### PR TITLE
Premium Analytics: add forced Loading/Error/Empty Storybook stories for migrated widgets

### DIFF
--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -218,7 +218,8 @@ not be merged.
    It mounts the real `WidgetDashboard` with this single widget and exposes the standard
    dashboard controls (size, edit mode, host environment, etc.), so it shows how the widget
    actually renders in product. The `Default` / `WithComparison` close-up stories use the
-   simpler canvas decorator from the template below — but never ship _only_ a bare-div story.
+   shared `withWidgetCanvas` decorator from the template below — but never ship _only_ a
+   close-up story.
 3. **Mocks**: Call `registerReportMocks()` at module-level for any widget that fetches
    report data. Without this the widget renders an error state in Storybook.
    - **Woo analytics widgets** (`/proxy/v2/analytics/reports/*`) are covered out of the box.
@@ -258,10 +259,11 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import MyWidgetRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -280,12 +282,9 @@ function renderMyWidget( { withComparison }: MyWidgetStoryControls ) {
 	);
 }
 
-// Close-up canvas so the chart fills the frame outside the dashboard grid.
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
+// Close-up canvas: `withWidgetCanvas` from `widgets/stories/with-widget-canvas` frames the
+// story in a white, widget-sized card so each state reads as a real dashboard widget. Import
+// the shared decorator — do not redefine a local bare-div canvas.
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/MyWidget',

--- a/projects/packages/premium-analytics/changelog/wooa7s-1675-forced-state-stories
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1675-forced-state-stories
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Update Storybook-only widget state stories. No user-facing change.

--- a/projects/packages/premium-analytics/changelog/wooa7s-1675-forced-state-stories
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1675-forced-state-stories
@@ -1,3 +1,4 @@
 Significance: patch
-Type: changed
-Comment: Update Storybook-only widget state stories. No user-facing change.
+Type: fixed
+
+Bookings by device: Use booking-specific empty and error messages.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sales-by-device/sales-by-device-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sales-by-device/sales-by-device-widget.tsx
@@ -21,6 +21,16 @@ type SalesByDeviceWidgetProps = {
 	 * When omitted, shows data for all product types.
 	 */
 	filter?: FilterCondition;
+
+	/**
+	 * Copy for the empty state.
+	 */
+	emptyStateText?: string;
+
+	/**
+	 * Copy for the error state.
+	 */
+	errorText?: string;
 };
 
 /**
@@ -34,8 +44,10 @@ type SalesByDeviceWidgetProps = {
  *
  * Must be used within a WidgetRoot which provides reportParams via context.
  *
- * @param props        - Component props
- * @param props.filter - Optional product type filter
+ * @param props                - Component props
+ * @param props.filter         - Optional product type filter
+ * @param props.emptyStateText - Copy for the empty state
+ * @param props.errorText      - Copy for the error state
  *
  * @example
  * // All product types
@@ -49,7 +61,11 @@ type SalesByDeviceWidgetProps = {
  *     <SalesByDeviceWidget filter={ BOOKINGS_FILTER } />
  * </WidgetRoot>
  */
-export function SalesByDeviceWidget( { filter }: SalesByDeviceWidgetProps ) {
+export function SalesByDeviceWidget( {
+	filter,
+	emptyStateText,
+	errorText,
+}: SalesByDeviceWidgetProps ) {
 	const { reportParams } = useWidgetRootContext();
 
 	// Add the device view to params
@@ -82,15 +98,18 @@ export function SalesByDeviceWidget( { filter }: SalesByDeviceWidgetProps ) {
 			isError={ isError && ! hasData }
 			isEmpty={ isEmptyChartData( chartData ) }
 			error={ {
-				description: __(
-					"We couldn't load sales by device data. Please try again in a moment.",
-					'jetpack-premium-analytics'
-				),
+				description:
+					errorText ??
+					__(
+						"We couldn't load sales by device data. Please try again in a moment.",
+						'jetpack-premium-analytics'
+					),
 				actions: [ { label: __( 'Retry', 'jetpack-premium-analytics' ), onClick: refetch } ],
 			} }
 			empty={ {
 				icon: device,
-				description: __( 'No sales data in this period.', 'jetpack-premium-analytics' ),
+				description:
+					emptyStateText ?? __( 'No sales data in this period.', 'jetpack-premium-analytics' ),
 			} }
 		>
 			<BarChart

--- a/projects/packages/premium-analytics/widgets/all-time-stats/stories/all-time-stats-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/all-time-stats/stories/all-time-stats-widget.stories.tsx
@@ -10,11 +10,18 @@
 /**
  * External dependencies
  */
-import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import {
+	getDefaultQueryParams,
+	queryClient,
+	type PresetType,
+} from '@jetpack-premium-analytics/data';
 /**
  * Internal dependencies
  */
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
@@ -84,6 +91,41 @@ function renderAllTimeStats( { withComparison, metrics }: AllTimeStatsStoryContr
 	);
 }
 
+/**
+ * Renders the widget on a preset distinct from the other stories.
+ *
+ * @param preset - The date range preset.
+ * @return The rendered widget.
+ */
+function renderAllTimeStatsOnPreset( preset: PresetType ) {
+	return (
+		<AllTimeStatsRender attributes={ { reportParams: getDefaultQueryParams( false, preset ) } } />
+	);
+}
+
+/**
+ * Forces the site-summary request into a loading/error/empty state for a story.
+ *
+ * The summary is all-time, so its query key carries no date params and a
+ * distinct date preset alone would not give the story a fresh cache entry.
+ * Evict the query from the shared client on enter and on cleanup so each
+ * forced-state story hits the mock fresh (and no forced result leaks into the
+ * sibling stories).
+ *
+ * @param state - The forced state.
+ * @return The story cleanup callback.
+ */
+function forceSiteSummaryState( state: 'loading' | 'error' | 'empty' ) {
+	// The bare `/proxy/v1.1/stats` site-summary endpoint — the only stats
+	// request this widget makes.
+	setReportMockState( 'proxy/v1.1/stats', state );
+	queryClient.removeQueries( { queryKey: [ 'stats', 'site' ] } );
+	return () => {
+		setReportMockState( 'proxy/v1.1/stats', null );
+		queryClient.removeQueries( { queryKey: [ 'stats', 'site' ] } );
+	};
+}
+
 // Close-up canvas so the stat list fills the frame outside the dashboard grid.
 const withWidgetCanvas: Decorator = Story => (
 	<div style={ { width: '100%', maxWidth: '480px' } }>
@@ -131,6 +173,41 @@ export const WithComparison: Story = {
 	render: renderAllTimeStats,
 	args: { withComparison: true, ...ALL_METRICS_ARGS },
 	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderAllTimeStatsOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => forceSiteSummaryState( 'loading' ),
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderAllTimeStatsOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => forceSiteSummaryState( 'error' ),
+};
+
+/**
+ * Resolved with no summary fields: the widget shows its empty state (the neutral
+ * trending glyph and "No stats recorded yet.").
+ */
+export const Empty: Story = {
+	render: () => renderAllTimeStatsOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => forceSiteSummaryState( 'empty' ),
 };
 
 interface AllTimeStatsDashboardStoryProps

--- a/projects/packages/premium-analytics/widgets/all-time-stats/stories/all-time-stats-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/all-time-stats/stories/all-time-stats-widget.stories.tsx
@@ -92,12 +92,7 @@ function renderAllTimeStats( { withComparison, metrics }: AllTimeStatsStoryContr
 	);
 }
 
-/**
- * Renders the widget on a preset distinct from the other stories.
- *
- * @param preset - The date range preset.
- * @return The rendered widget.
- */
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderAllTimeStatsOnPreset( preset: PresetType ) {
 	return (
 		<AllTimeStatsRender attributes={ { reportParams: getDefaultQueryParams( false, preset ) } } />
@@ -175,8 +170,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderAllTimeStatsOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => forceSiteSummaryState( 'loading' ),

--- a/projects/packages/premium-analytics/widgets/all-time-stats/stories/all-time-stats-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/all-time-stats/stories/all-time-stats-widget.stories.tsx
@@ -28,12 +28,13 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import AllTimeStatsRender from '../render';
 import widgetDefinition, {
 	DEFAULT_ALL_TIME_STATS_METRICS,
 	type AllTimeStatsMetricId,
 } from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -125,13 +126,6 @@ function forceSiteSummaryState( state: 'loading' | 'error' | 'empty' ) {
 		queryClient.removeQueries( { queryKey: [ 'stats', 'site' ] } );
 	};
 }
-
-// Close-up canvas so the stat list fills the frame outside the dashboard grid.
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', maxWidth: '480px' } }>
-		<Story />
-	</div>
-);
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/AllTimeStats',

--- a/projects/packages/premium-analytics/widgets/annual-highlights/stories/annual-highlights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/annual-highlights/stories/annual-highlights-widget.stories.tsx
@@ -15,13 +15,14 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import AnnualHighlightsRender from '../render';
 import widgetDefinition, { DEFAULT_HIGHLIGHT_METRICS, type AnnualHighlightMetric } from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -128,13 +129,6 @@ const METRIC_ARG_TYPES = {
 const ALL_METRICS_ARGS = {
 	metrics: DEFAULT_HIGHLIGHT_METRICS,
 } as const;
-
-// Close-up canvas so the grid fills the frame outside the dashboard grid.
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/AnnualHighlights',

--- a/projects/packages/premium-analytics/widgets/annual-highlights/stories/annual-highlights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/annual-highlights/stories/annual-highlights-widget.stories.tsx
@@ -80,13 +80,7 @@ const METRIC_OPTIONS = DEFAULT_HIGHLIGHT_METRICS.map( metric => ( {
 	label: metric.charAt( 0 ).toUpperCase() + metric.slice( 1 ),
 } ) );
 
-/**
- * Renders the widget on a preset distinct from the other stories, with every
- * metric tile enabled.
- *
- * @param preset - The date range preset.
- * @return The rendered widget.
- */
+// Distinct preset → own query-cache entry; see forceStatsMockState. Every metric tile enabled.
 function renderAnnualHighlightsOnPreset( preset: PresetType ) {
 	return (
 		<AnnualHighlightsRender
@@ -178,8 +172,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderAnnualHighlightsOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => forceInsightsState( 'loading' ),

--- a/projects/packages/premium-analytics/widgets/annual-highlights/stories/annual-highlights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/annual-highlights/stories/annual-highlights-widget.stories.tsx
@@ -1,7 +1,11 @@
 /**
  * External dependencies
  */
-import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import {
+	getDefaultQueryParams,
+	queryClient,
+	type PresetType,
+} from '@jetpack-premium-analytics/data';
 /**
  * Internal dependencies
  */
@@ -11,7 +15,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import AnnualHighlightsRender from '../render';
 import widgetDefinition, { DEFAULT_HIGHLIGHT_METRICS, type AnnualHighlightMetric } from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -72,6 +79,45 @@ const METRIC_OPTIONS = DEFAULT_HIGHLIGHT_METRICS.map( metric => ( {
 	label: metric.charAt( 0 ).toUpperCase() + metric.slice( 1 ),
 } ) );
 
+/**
+ * Renders the widget on a preset distinct from the other stories, with every
+ * metric tile enabled.
+ *
+ * @param preset - The date range preset.
+ * @return The rendered widget.
+ */
+function renderAnnualHighlightsOnPreset( preset: PresetType ) {
+	return (
+		<AnnualHighlightsRender
+			attributes={ {
+				reportParams: getDefaultQueryParams( false, preset ),
+				metrics: DEFAULT_HIGHLIGHT_METRICS,
+			} }
+		/>
+	);
+}
+
+/**
+ * Forces the insights request into a loading/error/empty state for a story.
+ *
+ * The insights endpoint is not period-scoped, so its query key carries no date
+ * params and a distinct date preset alone would not give the story a fresh
+ * cache entry. Evict the query from the shared client on enter and on cleanup
+ * so each forced-state story hits the mock fresh (and no forced result leaks
+ * into the sibling stories).
+ *
+ * @param state - The forced state.
+ * @return The story cleanup callback.
+ */
+function forceInsightsState( state: 'loading' | 'error' | 'empty' ) {
+	setReportMockState( 'stats/insights', state );
+	queryClient.removeQueries( { queryKey: [ 'stats', 'insights' ] } );
+	return () => {
+		setReportMockState( 'stats/insights', null );
+		queryClient.removeQueries( { queryKey: [ 'stats', 'insights' ] } );
+	};
+}
+
 const METRIC_ARG_TYPES = {
 	metrics: {
 		control: 'check',
@@ -130,6 +176,41 @@ export const WithComparison: Story = {
 	render: renderAnnualHighlights,
 	args: { withComparison: true, ...ALL_METRICS_ARGS },
 	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderAnnualHighlightsOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => forceInsightsState( 'loading' ),
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderAnnualHighlightsOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => forceInsightsState( 'error' ),
+};
+
+/**
+ * Resolved with no years: the widget shows its empty state (the neutral calendar
+ * glyph and "No highlights to show yet.").
+ */
+export const Empty: Story = {
+	render: () => renderAnnualHighlightsOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => forceInsightsState( 'empty' ),
 };
 
 interface AnnualHighlightsDashboardStoryProps

--- a/projects/packages/premium-analytics/widgets/authors/stories/authors-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/authors/stories/authors-widget.stories.tsx
@@ -39,10 +39,7 @@ function renderAuthors( { withComparison }: AuthorsStoryControls ) {
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderAuthorsOnPreset( preset: PresetType ) {
 	return (
 		<AuthorsRender
@@ -97,8 +94,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderAuthorsOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/authors/stories/authors-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/authors/stories/authors-widget.stories.tsx
@@ -5,13 +5,14 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import AuthorsRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -53,12 +54,6 @@ function renderAuthorsOnPreset( preset: PresetType ) {
 function AuthorsDashboardRender( props: WidgetRenderProps< unknown > ) {
 	return <AuthorsRender { ...( props as ComponentProps< typeof AuthorsRender > ) } />;
 }
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '360px' } }>
-		<Story />
-	</div>
-);
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/Authors',

--- a/projects/packages/premium-analytics/widgets/authors/stories/authors-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/authors/stories/authors-widget.stories.tsx
@@ -1,11 +1,14 @@
-import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { getDefaultQueryParams, type PresetType } from '@jetpack-premium-analytics/data';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import AuthorsRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -31,6 +34,18 @@ function renderAuthors( { withComparison }: AuthorsStoryControls ) {
 	return (
 		<AuthorsRender
 			attributes={ { max: 7, reportParams: getDefaultQueryParams( withComparison ) } }
+		/>
+	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderAuthorsOnPreset( preset: PresetType ) {
+	return (
+		<AuthorsRender
+			attributes={ { max: 7, reportParams: getDefaultQueryParams( false, preset ) } }
 		/>
 	);
 }
@@ -79,6 +94,50 @@ export const WithComparison: Story = {
 	render: renderAuthors,
 	args: { withComparison: true },
 	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderAuthorsOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'stats/top-authors', 'loading' );
+		return () => setReportMockState( 'stats/top-authors', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderAuthorsOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'stats/top-authors', 'error' );
+		return () => setReportMockState( 'stats/top-authors', null );
+	},
+};
+
+/**
+ * Resolved with no rows: the widget shows its empty state (the neutral author
+ * glyph and the introductory description).
+ */
+export const Empty: Story = {
+	render: () => renderAuthorsOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'stats/top-authors', 'empty' );
+		return () => setReportMockState( 'stats/top-authors', null );
+	},
 };
 
 interface AuthorsDashboardStoryProps

--- a/projects/packages/premium-analytics/widgets/average-items-per-order/stories/average-items-per-order-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/average-items-per-order/stories/average-items-per-order-widget.stories.tsx
@@ -85,10 +85,7 @@ function renderAverageItemsPerOrder( {
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderAverageItemsPerOrderOnPreset( preset: SelectablePresetId ) {
 	return (
 		<AverageItemsPerOrderRender attributes={ getAverageItemsPerOrderAttributes( false, preset ) } />
@@ -193,8 +190,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderAverageItemsPerOrderOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/average-items-per-order/stories/average-items-per-order-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/average-items-per-order/stories/average-items-per-order-widget.stories.tsx
@@ -6,13 +6,14 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import AverageItemsPerOrderRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -35,12 +36,6 @@ type AverageItemsPerOrderStoryProps = AverageItemsPerOrderRenderProps &
 interface AverageItemsPerOrderDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		AverageItemsPerOrderStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getAverageItemsPerOrderAttributes(
 	withComparison = false,

--- a/projects/packages/premium-analytics/widgets/average-items-per-order/stories/average-items-per-order-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/average-items-per-order/stories/average-items-per-order-widget.stories.tsx
@@ -214,8 +214,8 @@ export const Error: Story = {
 };
 
 /**
- * Resolved with no order data: the widget shows its empty state ("No data found
- * for this date range.").
+ * Resolved with no order data: the widget shows its empty state ("No orders in
+ * this period.").
  */
 export const Empty: Story = {
 	render: () => renderAverageItemsPerOrderOnPreset( 'last-365-days' ),

--- a/projects/packages/premium-analytics/widgets/average-items-per-order/stories/average-items-per-order-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/average-items-per-order/stories/average-items-per-order-widget.stories.tsx
@@ -6,7 +6,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import AverageItemsPerOrderRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -84,6 +87,16 @@ function renderAverageItemsPerOrder( {
 		<AverageItemsPerOrderRender
 			attributes={ getAverageItemsPerOrderAttributes( withComparison, preset ) }
 		/>
+	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderAverageItemsPerOrderOnPreset( preset: SelectablePresetId ) {
+	return (
+		<AverageItemsPerOrderRender attributes={ getAverageItemsPerOrderAttributes( false, preset ) } />
 	);
 }
 
@@ -176,6 +189,50 @@ export const WithComparison: Story = {
 				) => getAverageItemsPerOrderSource( storyContext.args ),
 			},
 		},
+	},
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderAverageItemsPerOrderOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders/by-date', 'loading' );
+		return () => setReportMockState( 'orders/by-date', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderAverageItemsPerOrderOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders/by-date', 'error' );
+		return () => setReportMockState( 'orders/by-date', null );
+	},
+};
+
+/**
+ * Resolved with no order data: the widget shows its empty state ("No data found
+ * for this date range.").
+ */
+export const Empty: Story = {
+	render: () => renderAverageItemsPerOrderOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders/by-date', 'empty' );
+		return () => setReportMockState( 'orders/by-date', null );
 	},
 };
 

--- a/projects/packages/premium-analytics/widgets/average-order-value/stories/average-order-value-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/average-order-value/stories/average-order-value-widget.stories.tsx
@@ -6,7 +6,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import AverageOrderValueRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -81,6 +84,14 @@ function renderAverageOrderValue( { withComparison, preset }: AverageOrderValueS
 			attributes={ getAverageOrderValueAttributes( withComparison, preset ) }
 		/>
 	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderAverageOrderValueOnPreset( preset: SelectablePresetId ) {
+	return <AverageOrderValueRender attributes={ getAverageOrderValueAttributes( false, preset ) } />;
 }
 
 function AverageOrderValueDashboardStory( {
@@ -170,6 +181,50 @@ export const WithComparison: Story = {
 				) => getAverageOrderValueSource( storyContext.args ),
 			},
 		},
+	},
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderAverageOrderValueOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders/by-date', 'loading' );
+		return () => setReportMockState( 'orders/by-date', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderAverageOrderValueOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders/by-date', 'error' );
+		return () => setReportMockState( 'orders/by-date', null );
+	},
+};
+
+/**
+ * Resolved with no order data: the widget shows its empty state ("No data found
+ * for this date range.").
+ */
+export const Empty: Story = {
+	render: () => renderAverageOrderValueOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders/by-date', 'empty' );
+		return () => setReportMockState( 'orders/by-date', null );
 	},
 };
 

--- a/projects/packages/premium-analytics/widgets/average-order-value/stories/average-order-value-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/average-order-value/stories/average-order-value-widget.stories.tsx
@@ -81,10 +81,7 @@ function renderAverageOrderValue( { withComparison, preset }: AverageOrderValueS
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderAverageOrderValueOnPreset( preset: SelectablePresetId ) {
 	return <AverageOrderValueRender attributes={ getAverageOrderValueAttributes( false, preset ) } />;
 }
@@ -185,8 +182,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderAverageOrderValueOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/average-order-value/stories/average-order-value-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/average-order-value/stories/average-order-value-widget.stories.tsx
@@ -206,8 +206,8 @@ export const Error: Story = {
 };
 
 /**
- * Resolved with no order data: the widget shows its empty state ("No data found
- * for this date range.").
+ * Resolved with no order data: the widget shows its empty state ("No orders in
+ * this period.").
  */
 export const Empty: Story = {
 	render: () => renderAverageOrderValueOnPreset( 'last-365-days' ),

--- a/projects/packages/premium-analytics/widgets/average-order-value/stories/average-order-value-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/average-order-value/stories/average-order-value-widget.stories.tsx
@@ -6,13 +6,14 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import AverageOrderValueRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -34,12 +35,6 @@ type AverageOrderValueStoryProps = AverageOrderValueRenderProps & AverageOrderVa
 interface AverageOrderValueDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		AverageOrderValueStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getAverageOrderValueAttributes(
 	withComparison = false,

--- a/projects/packages/premium-analytics/widgets/bookings-by-device/render.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-by-device/render.tsx
@@ -7,6 +7,7 @@ import {
 	WidgetRoot,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
+import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
@@ -27,7 +28,16 @@ type BookingsByDeviceWidgetProps = WidgetRenderProps< BookingsByDeviceRenderAttr
 };
 
 function BookingsByDeviceWidget() {
-	return <SalesByDeviceWidget filter={ BOOKINGS_FILTER } />;
+	return (
+		<SalesByDeviceWidget
+			filter={ BOOKINGS_FILTER }
+			emptyStateText={ __( 'No booking data in this period.', 'jetpack-premium-analytics' ) }
+			errorText={ __(
+				"We couldn't load booking data by device. Please try again in a moment.",
+				'jetpack-premium-analytics'
+			) }
+		/>
+	);
 }
 
 /**

--- a/projects/packages/premium-analytics/widgets/bookings-by-device/stories/bookings-by-device-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-by-device/stories/bookings-by-device-widget.stories.tsx
@@ -208,7 +208,7 @@ export const Error: Story = {
 
 /**
  * Resolved with no order-attribution rows: the widget shows its empty state (the
- * neutral device glyph and "No sales data in this period.").
+ * neutral device glyph and "No booking data in this period.").
  */
 export const Empty: Story = {
 	render: () => renderBookingsByDeviceOnPreset( 'last-365-days' ),

--- a/projects/packages/premium-analytics/widgets/bookings-by-device/stories/bookings-by-device-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-by-device/stories/bookings-by-device-widget.stories.tsx
@@ -81,10 +81,7 @@ function renderBookingsByDevice( { withComparison, preset }: BookingsByDeviceSto
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderBookingsByDeviceOnPreset( preset: SelectablePresetId ) {
 	return <BookingsByDeviceRender attributes={ getBookingsByDeviceAttributes( false, preset ) } />;
 }
@@ -185,8 +182,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderBookingsByDeviceOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/bookings-by-device/stories/bookings-by-device-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-by-device/stories/bookings-by-device-widget.stories.tsx
@@ -6,7 +6,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import BookingsByDeviceRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -81,6 +84,14 @@ function renderBookingsByDevice( { withComparison, preset }: BookingsByDeviceSto
 			attributes={ getBookingsByDeviceAttributes( withComparison, preset ) }
 		/>
 	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderBookingsByDeviceOnPreset( preset: SelectablePresetId ) {
+	return <BookingsByDeviceRender attributes={ getBookingsByDeviceAttributes( false, preset ) } />;
 }
 
 function BookingsByDeviceDashboardStory( {
@@ -169,6 +180,52 @@ export const WithComparison: Story = {
 				) => getBookingsByDeviceSource( storyContext.args ),
 			},
 		},
+	},
+};
+
+/**
+ * First load: the filtered order-attribution report is in flight, so the widget
+ * shows its loading state. The mock is forced to never resolve for the duration
+ * of this story.
+ */
+export const Loading: Story = {
+	render: () => renderBookingsByDeviceOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'order-attribution-by-product/device/summary', 'loading' );
+		return () => setReportMockState( 'order-attribution-by-product/device/summary', null );
+	},
+};
+
+/**
+ * The filtered order-attribution report failed: the widget shows its error state
+ * with a Retry action (which re-runs the query — still mocked as failing while
+ * this story is active).
+ */
+export const Error: Story = {
+	render: () => renderBookingsByDeviceOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'order-attribution-by-product/device/summary', 'error' );
+		return () => setReportMockState( 'order-attribution-by-product/device/summary', null );
+	},
+};
+
+/**
+ * Resolved with no order-attribution rows: the widget shows its empty state (the
+ * neutral device glyph and "No sales data in this period.").
+ */
+export const Empty: Story = {
+	render: () => renderBookingsByDeviceOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'order-attribution-by-product/device/summary', 'empty' );
+		return () => setReportMockState( 'order-attribution-by-product/device/summary', null );
 	},
 };
 

--- a/projects/packages/premium-analytics/widgets/bookings-by-device/stories/bookings-by-device-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-by-device/stories/bookings-by-device-widget.stories.tsx
@@ -6,13 +6,14 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import BookingsByDeviceRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -34,12 +35,6 @@ type BookingsByDeviceStoryProps = BookingsByDeviceRenderProps & BookingsByDevice
 interface BookingsByDeviceDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		BookingsByDeviceStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getBookingsByDeviceAttributes(
 	withComparison = false,

--- a/projects/packages/premium-analytics/widgets/bookings-by-status/stories/bookings-by-status-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-by-status/stories/bookings-by-status-widget.stories.tsx
@@ -6,7 +6,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import BookingsByStatusRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -81,6 +84,14 @@ function renderBookingsByStatus( { withComparison, preset }: BookingsByStatusSto
 			attributes={ getBookingsByStatusAttributes( withComparison, preset ) }
 		/>
 	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderBookingsByStatusOnPreset( preset: SelectablePresetId ) {
+	return <BookingsByStatusRender attributes={ getBookingsByStatusAttributes( false, preset ) } />;
 }
 
 function BookingsByStatusDashboardStory( {
@@ -166,6 +177,52 @@ export const WithComparison: Story = {
 				code: getBookingsByStatusSource( { withComparison: true, preset: DEFAULT_PRESET } ),
 			},
 		},
+	},
+};
+
+/**
+ * First load: the bookings report is in flight, so the widget shows its
+ * loading state. The mock is forced to never resolve for the duration of this
+ * story.
+ */
+export const Loading: Story = {
+	render: () => renderBookingsByStatusOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'bookings/by-date', 'loading' );
+		return () => setReportMockState( 'bookings/by-date', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action
+ * (which re-runs the query — still mocked as failing while this story is
+ * active).
+ */
+export const Error: Story = {
+	render: () => renderBookingsByStatusOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'bookings/by-date', 'error' );
+		return () => setReportMockState( 'bookings/by-date', null );
+	},
+};
+
+/**
+ * Resolved with no bookings: the widget shows its empty state ("No bookings in
+ * this period.").
+ */
+export const Empty: Story = {
+	render: () => renderBookingsByStatusOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'bookings/by-date', 'empty' );
+		return () => setReportMockState( 'bookings/by-date', null );
 	},
 };
 

--- a/projects/packages/premium-analytics/widgets/bookings-by-status/stories/bookings-by-status-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-by-status/stories/bookings-by-status-widget.stories.tsx
@@ -81,10 +81,7 @@ function renderBookingsByStatus( { withComparison, preset }: BookingsByStatusSto
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderBookingsByStatusOnPreset( preset: SelectablePresetId ) {
 	return <BookingsByStatusRender attributes={ getBookingsByStatusAttributes( false, preset ) } />;
 }
@@ -182,8 +179,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderBookingsByStatusOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/bookings-by-status/stories/bookings-by-status-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-by-status/stories/bookings-by-status-widget.stories.tsx
@@ -6,13 +6,14 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import BookingsByStatusRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -34,12 +35,6 @@ type BookingsByStatusStoryProps = BookingsByStatusRenderProps & BookingsByStatus
 interface BookingsByStatusDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		BookingsByStatusStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getBookingsByStatusAttributes(
 	withComparison = false,

--- a/projects/packages/premium-analytics/widgets/bookings-over-time/stories/bookings-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-over-time/stories/bookings-over-time-widget.stories.tsx
@@ -87,10 +87,7 @@ function renderBookingsOverTime( { withComparison, preset }: BookingsOverTimeSto
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderBookingsOverTimeOnPreset( preset: SelectablePresetId ) {
 	ensureLineChartComposition();
 
@@ -198,8 +195,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderBookingsOverTimeOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/bookings-over-time/stories/bookings-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-over-time/stories/bookings-over-time-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import LineChart from '../../../../../js-packages/charts/src/charts/line-chart/line-chart';
 import {
 	registerReportMocks,
@@ -13,7 +14,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import BookingsOverTimeRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -38,12 +39,6 @@ type BookingsOverTimeStoryProps = BookingsOverTimeRenderProps & BookingsOverTime
 interface BookingsOverTimeDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		BookingsOverTimeStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getBookingsOverTimeAttributes(
 	withComparison = false,

--- a/projects/packages/premium-analytics/widgets/bookings-over-time/stories/bookings-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-over-time/stories/bookings-over-time-widget.stories.tsx
@@ -7,7 +7,10 @@ import {
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
 import LineChart from '../../../../../js-packages/charts/src/charts/line-chart/line-chart';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import BookingsOverTimeRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -87,6 +90,16 @@ function renderBookingsOverTime( { withComparison, preset }: BookingsOverTimeSto
 			attributes={ getBookingsOverTimeAttributes( withComparison, preset ) }
 		/>
 	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderBookingsOverTimeOnPreset( preset: SelectablePresetId ) {
+	ensureLineChartComposition();
+
+	return <BookingsOverTimeRender attributes={ getBookingsOverTimeAttributes( false, preset ) } />;
 }
 
 function BookingsOverTimeDashboardStory( {
@@ -177,6 +190,54 @@ export const WithComparison: Story = {
 				) => getBookingsOverTimeSource( storyContext.args ),
 			},
 		},
+	},
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ *
+ * Bookings are order data filtered to booking product types, so this widget's
+ * report goes through the `orders-by-product-type/by-date` endpoint rather than
+ * the plain `orders/by-date` endpoint the other order-metric widgets use.
+ */
+export const Loading: Story = {
+	render: () => renderBookingsOverTimeOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders-by-product-type/by-date', 'loading' );
+		return () => setReportMockState( 'orders-by-product-type/by-date', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderBookingsOverTimeOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders-by-product-type/by-date', 'error' );
+		return () => setReportMockState( 'orders-by-product-type/by-date', null );
+	},
+};
+
+/**
+ * Resolved with no booking data: the widget shows its empty state ("No data
+ * found for this date range.").
+ */
+export const Empty: Story = {
+	render: () => renderBookingsOverTimeOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders-by-product-type/by-date', 'empty' );
+		return () => setReportMockState( 'orders-by-product-type/by-date', null );
 	},
 };
 

--- a/projects/packages/premium-analytics/widgets/bookings-over-time/stories/bookings-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-over-time/stories/bookings-over-time-widget.stories.tsx
@@ -219,8 +219,8 @@ export const Error: Story = {
 };
 
 /**
- * Resolved with no booking data: the widget shows its empty state ("No data
- * found for this date range.").
+ * Resolved with no booking data: the widget shows its empty state ("No bookings
+ * in this period.").
  */
 export const Empty: Story = {
 	render: () => renderBookingsOverTimeOnPreset( 'last-365-days' ),

--- a/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/stories/bookings-revenue-by-customer-type-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/stories/bookings-revenue-by-customer-type-widget.stories.tsx
@@ -6,13 +6,14 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import BookingsRevenueByCustomerTypeRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -38,12 +39,6 @@ type BookingsRevenueByCustomerTypeStoryProps = BookingsRevenueByCustomerTypeRend
 interface BookingsRevenueByCustomerTypeDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		BookingsRevenueByCustomerTypeStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getBookingsRevenueByCustomerTypeAttributes(
 	withComparison = false,

--- a/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/stories/bookings-revenue-by-customer-type-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/stories/bookings-revenue-by-customer-type-widget.stories.tsx
@@ -90,10 +90,7 @@ function renderBookingsRevenueByCustomerType( {
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderBookingsRevenueByCustomerTypeOnPreset( preset: SelectablePresetId ) {
 	return (
 		<BookingsRevenueByCustomerTypeRender
@@ -201,8 +198,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderBookingsRevenueByCustomerTypeOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/stories/bookings-revenue-by-customer-type-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/stories/bookings-revenue-by-customer-type-widget.stories.tsx
@@ -6,7 +6,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import BookingsRevenueByCustomerTypeRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -88,6 +91,18 @@ function renderBookingsRevenueByCustomerType( {
 	return (
 		<BookingsRevenueByCustomerTypeRender
 			attributes={ getBookingsRevenueByCustomerTypeAttributes( withComparison, preset ) }
+		/>
+	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderBookingsRevenueByCustomerTypeOnPreset( preset: SelectablePresetId ) {
+	return (
+		<BookingsRevenueByCustomerTypeRender
+			attributes={ getBookingsRevenueByCustomerTypeAttributes( false, preset ) }
 		/>
 	);
 }
@@ -181,6 +196,52 @@ export const WithComparison: Story = {
 				) => getBookingsRevenueByCustomerTypeSource( storyContext.args ),
 			},
 		},
+	},
+};
+
+/**
+ * First load: the filtered customers report is in flight, so the widget shows
+ * its loading state. The mock is forced to never resolve for the duration of
+ * this story.
+ */
+export const Loading: Story = {
+	render: () => renderBookingsRevenueByCustomerTypeOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'customers/new-returning', 'loading' );
+		return () => setReportMockState( 'customers/new-returning', null );
+	},
+};
+
+/**
+ * The filtered customers report failed: the widget shows its error state with a
+ * Retry action (which re-runs the query — still mocked as failing while this
+ * story is active).
+ */
+export const Error: Story = {
+	render: () => renderBookingsRevenueByCustomerTypeOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'customers/new-returning', 'error' );
+		return () => setReportMockState( 'customers/new-returning', null );
+	},
+};
+
+/**
+ * The filtered customers report resolved with no booking revenue in the period:
+ * the widget shows its empty state.
+ */
+export const Empty: Story = {
+	render: () => renderBookingsRevenueByCustomerTypeOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'customers/new-returning', 'empty' );
+		return () => setReportMockState( 'customers/new-returning', null );
 	},
 };
 

--- a/projects/packages/premium-analytics/widgets/clicks/stories/clicks-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/clicks/stories/clicks-widget.stories.tsx
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
-import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { getDefaultQueryParams, type PresetType } from '@jetpack-premium-analytics/data';
 /**
  * Internal dependencies
  */
 import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import { registerStatsMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-stats-mocks';
+import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
@@ -49,6 +50,18 @@ function renderClicksWidget( { withComparison }: ClicksStoryControls ) {
 	return (
 		<ClicksRender
 			attributes={ { max: 10, reportParams: getDefaultQueryParams( withComparison ) } }
+		/>
+	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderClicksOnPreset( preset: PresetType ) {
+	return (
+		<ClicksRender
+			attributes={ { max: 10, reportParams: getDefaultQueryParams( false, preset ) } }
 		/>
 	);
 }
@@ -100,6 +113,53 @@ export const WithComparison: Story = {
 	render: renderClicksWidget,
 	args: { withComparison: true },
 	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ *
+ * Forced through `forceStatsMockState`: `stats/clicks` is answered by the legacy
+ * stats mocks before the shared `setReportMockState` override can intercept it.
+ */
+export const Loading: Story = {
+	render: () => renderClicksOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'stats/clicks', 'loading' );
+		return () => forceStatsMockState( 'stats/clicks', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderClicksOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'stats/clicks', 'error' );
+		return () => forceStatsMockState( 'stats/clicks', null );
+	},
+};
+
+/**
+ * Resolved with no rows: the widget shows its empty state (the neutral chart
+ * glyph and "No clicks in this period.").
+ */
+export const Empty: Story = {
+	render: () => renderClicksOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'stats/clicks', 'empty' );
+		return () => forceStatsMockState( 'stats/clicks', null );
+	},
 };
 
 export const WidgetDashboardWithWidget: DashboardStory = {

--- a/projects/packages/premium-analytics/widgets/clicks/stories/clicks-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/clicks/stories/clicks-widget.stories.tsx
@@ -49,10 +49,7 @@ function renderClicksWidget( { withComparison }: ClicksStoryControls ) {
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderClicksOnPreset( preset: PresetType ) {
 	return (
 		<ClicksRender
@@ -119,8 +116,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderClicksOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/clicks/stories/clicks-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/clicks/stories/clicks-widget.stories.tsx
@@ -14,9 +14,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import ClicksRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -39,12 +40,6 @@ interface ClicksStoryControls {
 interface ClicksDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		ClicksStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '340px' } }>
-		<Story />
-	</div>
-);
 
 function renderClicksWidget( { withComparison }: ClicksStoryControls ) {
 	return (

--- a/projects/packages/premium-analytics/widgets/conversion-rate/stories/conversion-rate-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/conversion-rate/stories/conversion-rate-widget.stories.tsx
@@ -7,12 +7,13 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import ConversionRateRender from '../render';
 import widgetDefinition from '../widget';
 import type { APIFetchMiddleware } from '@wordpress/api-fetch';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -89,12 +90,6 @@ type ConversionRateStoryProps = ConversionRateWidgetProps & ConversionRateStoryC
 interface ConversionRateDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		ConversionRateStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getConversionRateAttributes(
 	withComparison = false,

--- a/projects/packages/premium-analytics/widgets/conversion-rate/stories/conversion-rate-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/conversion-rate/stories/conversion-rate-widget.stories.tsx
@@ -242,9 +242,9 @@ export const WithComparison: Story = {
  * The story's own conversion-rate mock middleware (registered above) would
  * otherwise shadow `setReportMockState` — it always answers
  * `sessions/by-conversion-rate` with canned data and never falls through.
- * `forceStatsMockState` registers its override middleware lazily, on first
- * call, so it is guaranteed to be the last-registered (and therefore first-run)
- * middleware here.
+ * `forceStatsMockState` re-registers its shared override when this story sets a
+ * forced state, keeping it ahead of story-local middleware even if Storybook
+ * lazy-loads another story module later.
  */
 export const Loading: Story = {
 	render: () => renderConversionRateOnPreset( 'last-90-days' ),

--- a/projects/packages/premium-analytics/widgets/conversion-rate/stories/conversion-rate-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/conversion-rate/stories/conversion-rate-widget.stories.tsx
@@ -137,10 +137,7 @@ function renderConversionRate( { withComparison, preset }: ConversionRateStoryCo
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderConversionRateOnPreset( preset: SelectablePresetId ) {
 	return <ConversionRateRender attributes={ getConversionRateAttributes( false, preset ) } />;
 }
@@ -248,8 +245,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderConversionRateOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/conversion-rate/stories/conversion-rate-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/conversion-rate/stories/conversion-rate-widget.stories.tsx
@@ -8,6 +8,7 @@ import {
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
 import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import ConversionRateRender from '../render';
 import widgetDefinition from '../widget';
 import type { APIFetchMiddleware } from '@wordpress/api-fetch';
@@ -141,6 +142,14 @@ function renderConversionRate( { withComparison, preset }: ConversionRateStoryCo
 	);
 }
 
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderConversionRateOnPreset( preset: SelectablePresetId ) {
+	return <ConversionRateRender attributes={ getConversionRateAttributes( false, preset ) } />;
+}
+
 function ConversionRateDashboardStory( {
 	withComparison,
 	preset,
@@ -228,6 +237,57 @@ export const WithComparison: Story = {
 				) => getConversionRateSource( storyContext.args ),
 			},
 		},
+	},
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ *
+ * The story's own conversion-rate mock middleware (registered above) would
+ * otherwise shadow `setReportMockState` — it always answers
+ * `sessions/by-conversion-rate` with canned data and never falls through.
+ * `forceStatsMockState` registers its override middleware lazily, on first
+ * call, so it is guaranteed to be the last-registered (and therefore first-run)
+ * middleware here.
+ */
+export const Loading: Story = {
+	render: () => renderConversionRateOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'sessions/by-conversion-rate', 'loading' );
+		return () => forceStatsMockState( 'sessions/by-conversion-rate', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderConversionRateOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'sessions/by-conversion-rate', 'error' );
+		return () => forceStatsMockState( 'sessions/by-conversion-rate', null );
+	},
+};
+
+/**
+ * Resolved with no active sessions: the widget shows its empty state ("No
+ * conversion data in this period.").
+ */
+export const Empty: Story = {
+	render: () => renderConversionRateOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'sessions/by-conversion-rate', 'empty' );
+		return () => forceStatsMockState( 'sessions/by-conversion-rate', null );
 	},
 };
 

--- a/projects/packages/premium-analytics/widgets/coupon-usage-over-time/stories/coupon-usage-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/coupon-usage-over-time/stories/coupon-usage-over-time-widget.stories.tsx
@@ -6,7 +6,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import CouponUsageOverTimeRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -81,6 +84,16 @@ function renderCouponUsageOverTime( { withComparison, preset }: CouponUsageOverT
 		<CouponUsageOverTimeRender
 			attributes={ getCouponUsageOverTimeAttributes( withComparison, preset ) }
 		/>
+	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderCouponUsageOverTimeOnPreset( preset: SelectablePresetId ) {
+	return (
+		<CouponUsageOverTimeRender attributes={ getCouponUsageOverTimeAttributes( false, preset ) } />
 	);
 }
 
@@ -165,6 +178,52 @@ export const WithComparison: Story = {
 				) => getCouponUsageOverTimeSource( storyContext.args ),
 			},
 		},
+	},
+};
+
+/**
+ * First load: the coupons-by-date report is in flight, so the widget shows its
+ * loading state. The mock is forced to never resolve for the duration of this
+ * story.
+ */
+export const Loading: Story = {
+	render: () => renderCouponUsageOverTimeOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'coupons/by-date', 'loading' );
+		return () => setReportMockState( 'coupons/by-date', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action
+ * (which re-runs the query — still mocked as failing while this story is
+ * active).
+ */
+export const Error: Story = {
+	render: () => renderCouponUsageOverTimeOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'coupons/by-date', 'error' );
+		return () => setReportMockState( 'coupons/by-date', null );
+	},
+};
+
+/**
+ * Resolved with no coupon usage: the widget shows its empty state ("No coupon
+ * usage in this period.").
+ */
+export const Empty: Story = {
+	render: () => renderCouponUsageOverTimeOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'coupons/by-date', 'empty' );
+		return () => setReportMockState( 'coupons/by-date', null );
 	},
 };
 

--- a/projects/packages/premium-analytics/widgets/coupon-usage-over-time/stories/coupon-usage-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/coupon-usage-over-time/stories/coupon-usage-over-time-widget.stories.tsx
@@ -82,10 +82,7 @@ function renderCouponUsageOverTime( { withComparison, preset }: CouponUsageOverT
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderCouponUsageOverTimeOnPreset( preset: SelectablePresetId ) {
 	return (
 		<CouponUsageOverTimeRender attributes={ getCouponUsageOverTimeAttributes( false, preset ) } />
@@ -183,8 +180,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderCouponUsageOverTimeOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/coupon-usage-over-time/stories/coupon-usage-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/coupon-usage-over-time/stories/coupon-usage-over-time-widget.stories.tsx
@@ -6,13 +6,14 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import CouponUsageOverTimeRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -35,12 +36,6 @@ type CouponUsageOverTimeStoryProps = CouponUsageOverTimeWidgetProps &
 interface CouponUsageOverTimeDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		CouponUsageOverTimeStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getCouponUsageOverTimeAttributes(
 	withComparison = false,

--- a/projects/packages/premium-analytics/widgets/devices/stories/devices-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/devices/stories/devices-widget.stories.tsx
@@ -5,12 +5,13 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import { registerStatsMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-stats-mocks';
 import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import DevicesRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -35,12 +36,6 @@ interface DevicesStoryControls {
 interface DevicesDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		DevicesStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '380px' } }>
-		<Story />
-	</div>
-);
 
 function renderDevicesWidget( { withComparison }: DevicesStoryControls ) {
 	return (

--- a/projects/packages/premium-analytics/widgets/devices/stories/devices-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/devices/stories/devices-widget.stories.tsx
@@ -45,10 +45,7 @@ function renderDevicesWidget( { withComparison }: DevicesStoryControls ) {
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderDevicesOnPreset( preset: PresetType ) {
 	return (
 		<DevicesRender
@@ -115,8 +112,7 @@ export const WithComparison: StoryObj< DevicesStoryControls > = {
  */
 export const Loading: StoryObj< DevicesStoryControls > = {
 	render: () => renderDevicesOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/devices/stories/devices-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/devices/stories/devices-widget.stories.tsx
@@ -1,4 +1,4 @@
-import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { getDefaultQueryParams, type PresetType } from '@jetpack-premium-analytics/data';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
@@ -7,6 +7,7 @@ import {
 } from '../../stories/widget-dashboard-with-widget';
 import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import { registerStatsMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-stats-mocks';
+import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import DevicesRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -45,6 +46,18 @@ function renderDevicesWidget( { withComparison }: DevicesStoryControls ) {
 	return (
 		<DevicesRender
 			attributes={ { max: 5, reportParams: getDefaultQueryParams( withComparison ) } }
+		/>
+	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderDevicesOnPreset( preset: PresetType ) {
+	return (
+		<DevicesRender
+			attributes={ { max: 5, reportParams: getDefaultQueryParams( false, preset ) } }
 		/>
 	);
 }
@@ -99,6 +112,50 @@ export const WithComparison: StoryObj< DevicesStoryControls > = {
 	render: renderDevicesWidget,
 	args: { withComparison: true },
 	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: StoryObj< DevicesStoryControls > = {
+	render: () => renderDevicesOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'stats/devices/screensize', 'loading' );
+		return () => forceStatsMockState( 'stats/devices/screensize', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: StoryObj< DevicesStoryControls > = {
+	render: () => renderDevicesOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'stats/devices/screensize', 'error' );
+		return () => forceStatsMockState( 'stats/devices/screensize', null );
+	},
+};
+
+/**
+ * Resolved with no rows: the widget shows its empty state (the neutral device
+ * glyph and "No device data in this period.").
+ */
+export const Empty: StoryObj< DevicesStoryControls > = {
+	render: () => renderDevicesOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'stats/devices/screensize', 'empty' );
+		return () => forceStatsMockState( 'stats/devices/screensize', null );
+	},
 };
 
 export const WidgetDashboardWithWidget: DashboardStory = {

--- a/projects/packages/premium-analytics/widgets/email-breakdown/stories/email-breakdown-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/stories/email-breakdown-widget.stories.tsx
@@ -29,10 +29,11 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import EmailBreakdownRender from '../render';
 import widgetDefinition from '../widget';
 import type { EmailBreakdownMetric, EmailBreakdownView } from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -101,13 +102,6 @@ function renderEmailBreakdownForState( postId: number ) {
 		/>
 	);
 }
-
-// Close-up canvas so the chart fills the frame outside the dashboard grid.
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '320px' } }>
-		<Story />
-	</div>
-);
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/EmailBreakdown',

--- a/projects/packages/premium-analytics/widgets/email-breakdown/stories/email-breakdown-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/stories/email-breakdown-widget.stories.tsx
@@ -152,8 +152,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderEmailBreakdownForState( 5601 ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/email-top-row/stories/email-top-row-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-top-row/stories/email-top-row-widget.stories.tsx
@@ -28,10 +28,11 @@ import {
 	registerReportMocks,
 	setReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import EmailTopRowRender from '../render';
 import widgetDefinition from '../widget';
 import type { EmailMetric } from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -63,13 +64,6 @@ function renderEmailTopRow(
 		/>
 	);
 }
-
-// Close-up canvas so the tiles fill the frame outside the dashboard grid.
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/EmailTopRow',

--- a/projects/packages/premium-analytics/widgets/email-top-row/stories/email-top-row-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-top-row/stories/email-top-row-widget.stories.tsx
@@ -124,8 +124,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: args => renderEmailTopRow( args, 2001 ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	args: { metric: 'opens', withComparison: false },
 	decorators: [ withWidgetCanvas ],

--- a/projects/packages/premium-analytics/widgets/emails/stories/emails-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/emails/stories/emails-widget.stories.tsx
@@ -142,8 +142,7 @@ function renderEmailsWithMax( max: number ) {
  */
 export const Loading: Story = {
 	render: () => renderEmailsWithMax( 7 ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/emails/stories/emails-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/emails/stories/emails-widget.stories.tsx
@@ -21,6 +21,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import EmailsRender, { EmailsLeaderboard, type EmailRow } from '../render';
 import widgetDefinition from '../widget';
 import type { Meta, StoryObj, Decorator } from '@storybook/react';
@@ -104,16 +105,6 @@ const mockLongLabelRows: EmailRow[] = [
 		clicksRate: 6.7,
 	},
 ];
-
-/**
- * Close-up canvas so the widget fills a real body area outside the dashboard
- * grid — the loading overlay and empty state need a sized container to render in.
- */
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '320px' } }>
-		<Story />
-	</div>
-);
 
 /**
  * Default populated state — latest emails (newest first) with their open rate.

--- a/projects/packages/premium-analytics/widgets/file-downloads/stories/file-downloads-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/file-downloads/stories/file-downloads-widget.stories.tsx
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
-import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { getDefaultQueryParams, type PresetType } from '@jetpack-premium-analytics/data';
 /**
  * Internal dependencies
  */
 import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import { registerStatsMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-stats-mocks';
+import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
@@ -49,6 +50,18 @@ function renderFileDownloadsWidget( { withComparison }: FileDownloadsStoryContro
 	return (
 		<FileDownloadsRender
 			attributes={ { max: 10, reportParams: getDefaultQueryParams( withComparison ) } }
+		/>
+	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderFileDownloadsOnPreset( preset: PresetType ) {
+	return (
+		<FileDownloadsRender
+			attributes={ { max: 10, reportParams: getDefaultQueryParams( false, preset ) } }
 		/>
 	);
 }
@@ -103,6 +116,50 @@ export const WithComparison: Story = {
 	render: renderFileDownloadsWidget,
 	args: { withComparison: true },
 	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderFileDownloadsOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'stats/file-downloads', 'loading' );
+		return () => forceStatsMockState( 'stats/file-downloads', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderFileDownloadsOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'stats/file-downloads', 'error' );
+		return () => forceStatsMockState( 'stats/file-downloads', null );
+	},
+};
+
+/**
+ * Resolved with no rows: the widget shows its empty state (the download glyph
+ * and "No file downloads in this period.").
+ */
+export const Empty: Story = {
+	render: () => renderFileDownloadsOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'stats/file-downloads', 'empty' );
+		return () => forceStatsMockState( 'stats/file-downloads', null );
+	},
 };
 
 export const WidgetDashboardWithWidget: DashboardStory = {

--- a/projects/packages/premium-analytics/widgets/file-downloads/stories/file-downloads-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/file-downloads/stories/file-downloads-widget.stories.tsx
@@ -49,10 +49,7 @@ function renderFileDownloadsWidget( { withComparison }: FileDownloadsStoryContro
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderFileDownloadsOnPreset( preset: PresetType ) {
 	return (
 		<FileDownloadsRender
@@ -119,8 +116,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderFileDownloadsOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/file-downloads/stories/file-downloads-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/file-downloads/stories/file-downloads-widget.stories.tsx
@@ -14,9 +14,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import FileDownloadsRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -39,12 +40,6 @@ interface FileDownloadsStoryControls {
 interface FileDownloadsDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		FileDownloadsStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '340px' } }>
-		<Story />
-	</div>
-);
 
 function renderFileDownloadsWidget( { withComparison }: FileDownloadsStoryControls ) {
 	return (

--- a/projects/packages/premium-analytics/widgets/gross-sales-over-time/stories/gross-sales-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/gross-sales-over-time/stories/gross-sales-over-time-widget.stories.tsx
@@ -7,7 +7,10 @@ import {
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
 import LineChart from '../../../../../js-packages/charts/src/charts/line-chart/line-chart';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import GrossSalesOverTimeRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -85,6 +88,18 @@ function renderGrossSalesOverTime( { withComparison, preset }: GrossSalesOverTim
 		<GrossSalesOverTimeRender
 			attributes={ getGrossSalesOverTimeAttributes( withComparison, preset ) }
 		/>
+	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderGrossSalesOverTimeOnPreset( preset: SelectablePresetId ) {
+	ensureLineChartComposition();
+
+	return (
+		<GrossSalesOverTimeRender attributes={ getGrossSalesOverTimeAttributes( false, preset ) } />
 	);
 }
 
@@ -176,6 +191,50 @@ export const WithComparison: Story = {
 				) => getGrossSalesOverTimeSource( storyContext.args ),
 			},
 		},
+	},
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderGrossSalesOverTimeOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders/by-date', 'loading' );
+		return () => setReportMockState( 'orders/by-date', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderGrossSalesOverTimeOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders/by-date', 'error' );
+		return () => setReportMockState( 'orders/by-date', null );
+	},
+};
+
+/**
+ * Resolved with no gross sales data: the widget shows its empty state ("No data
+ * found for this date range.").
+ */
+export const Empty: Story = {
+	render: () => renderGrossSalesOverTimeOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders/by-date', 'empty' );
+		return () => setReportMockState( 'orders/by-date', null );
 	},
 };
 

--- a/projects/packages/premium-analytics/widgets/gross-sales-over-time/stories/gross-sales-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/gross-sales-over-time/stories/gross-sales-over-time-widget.stories.tsx
@@ -86,10 +86,7 @@ function renderGrossSalesOverTime( { withComparison, preset }: GrossSalesOverTim
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderGrossSalesOverTimeOnPreset( preset: SelectablePresetId ) {
 	ensureLineChartComposition();
 
@@ -195,8 +192,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderGrossSalesOverTimeOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/gross-sales-over-time/stories/gross-sales-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/gross-sales-over-time/stories/gross-sales-over-time-widget.stories.tsx
@@ -216,8 +216,8 @@ export const Error: Story = {
 };
 
 /**
- * Resolved with no gross sales data: the widget shows its empty state ("No data
- * found for this date range.").
+ * Resolved with no gross sales data: the widget shows its empty state ("No sales
+ * in this period.").
  */
 export const Empty: Story = {
 	render: () => renderGrossSalesOverTimeOnPreset( 'last-365-days' ),

--- a/projects/packages/premium-analytics/widgets/gross-sales-over-time/stories/gross-sales-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/gross-sales-over-time/stories/gross-sales-over-time-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import LineChart from '../../../../../js-packages/charts/src/charts/line-chart/line-chart';
 import {
 	registerReportMocks,
@@ -13,7 +14,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import GrossSalesOverTimeRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -37,12 +38,6 @@ type GrossSalesOverTimeStoryProps = GrossSalesOverTimeWidgetProps & GrossSalesOv
 interface GrossSalesOverTimeDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		GrossSalesOverTimeStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getGrossSalesOverTimeAttributes(
 	withComparison = false,

--- a/projects/packages/premium-analytics/widgets/latest-post/stories/latest-post-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/latest-post/stories/latest-post-widget.stories.tsx
@@ -12,12 +12,17 @@
 /**
  * External dependencies
  */
-import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import {
+	getDefaultQueryParams,
+	queryClient,
+	type PresetType,
+} from '@jetpack-premium-analytics/data';
 import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
 import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
@@ -108,6 +113,54 @@ function renderLatestPost( { withComparison }: LatestPostStoryControls ) {
 	);
 }
 
+/**
+ * Renders the widget on a preset distinct from the other stories.
+ *
+ * @param preset - The date range preset.
+ * @return The rendered widget.
+ */
+function renderLatestPostOnPreset( preset: PresetType ) {
+	return (
+		<LatestPostRender attributes={ { reportParams: getDefaultQueryParams( false, preset ) } } />
+	);
+}
+
+/**
+ * Forces the widget's requests into a loading/error/empty state for a story.
+ *
+ * This widget's endpoints are served by this file's own fixture middleware, so
+ * the shared `setReportMockState` override never sees them; the story-side
+ * `forceStatsMockState` helper registers ahead of the fixtures instead. An
+ * `empty` override resolves to the generic no-rows shape, which the latest-post
+ * sanitizer reduces to "no published post".
+ *
+ * The latest-post and stats/post query keys also carry no date params, so a
+ * distinct date preset alone would not give the story a fresh cache entry.
+ * Evict both queries from the shared client on enter and on cleanup so each
+ * forced-state story hits the mock fresh (and no forced result leaks into the
+ * sibling stories).
+ *
+ * @param state - The forced state.
+ * @return The story cleanup callback.
+ */
+function forceLatestPostState( state: 'loading' | 'error' | 'empty' ) {
+	const setState = ( value: typeof state | null ) => {
+		forceStatsMockState( LATEST_POST_PATH, value );
+		forceStatsMockState( STATS_POST_PATH, value );
+	};
+	const evict = () => {
+		queryClient.removeQueries( { queryKey: [ 'latest-post' ] } );
+		queryClient.removeQueries( { queryKey: [ 'stats', 'post' ] } );
+	};
+
+	setState( state );
+	evict();
+	return () => {
+		setState( null );
+		evict();
+	};
+}
+
 // Close-up canvas so the card fills the frame outside the dashboard grid.
 const withWidgetCanvas: Decorator = Story => (
 	<div style={ { width: '100%', height: '300px' } }>
@@ -154,6 +207,43 @@ export const WithComparison: Story = {
 	render: renderLatestPost,
 	args: { withComparison: true },
 	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderLatestPostOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override applies to every
+	// mounted copy of this widget, so it would otherwise force the sibling
+	// stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => forceLatestPostState( 'loading' ),
+};
+
+/**
+ * The content fetch failed: the widget shows its error state with a Retry
+ * action (which re-runs the query — still mocked as failing while this story is
+ * active).
+ */
+export const Error: Story = {
+	render: () => renderLatestPostOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => forceLatestPostState( 'error' ),
+};
+
+/**
+ * Resolved with no published posts: the widget shows its empty state (the
+ * neutral post-list glyph and "Publish a post to see its stats here.").
+ */
+export const Empty: Story = {
+	render: () => renderLatestPostOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => forceLatestPostState( 'empty' ),
 };
 
 interface LatestPostDashboardStoryProps

--- a/projects/packages/premium-analytics/widgets/latest-post/stories/latest-post-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/latest-post/stories/latest-post-widget.stories.tsx
@@ -29,10 +29,11 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import LatestPostRender from '../render';
 import widgetDefinition from '../widget';
 import type { APIFetchMiddleware, APIFetchOptions } from '@wordpress/api-fetch';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -160,13 +161,6 @@ function forceLatestPostState( state: 'loading' | 'error' | 'empty' ) {
 		evict();
 	};
 }
-
-// Close-up canvas so the card fills the frame outside the dashboard grid.
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/LatestPost',

--- a/projects/packages/premium-analytics/widgets/latest-post/stories/latest-post-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/latest-post/stories/latest-post-widget.stories.tsx
@@ -114,12 +114,7 @@ function renderLatestPost( { withComparison }: LatestPostStoryControls ) {
 	);
 }
 
-/**
- * Renders the widget on a preset distinct from the other stories.
- *
- * @param preset - The date range preset.
- * @return The rendered widget.
- */
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderLatestPostOnPreset( preset: PresetType ) {
 	return (
 		<LatestPostRender attributes={ { reportParams: getDefaultQueryParams( false, preset ) } } />
@@ -210,9 +205,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderLatestPostOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override applies to every
-	// mounted copy of this widget, so it would otherwise force the sibling
-	// stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => forceLatestPostState( 'loading' ),

--- a/projects/packages/premium-analytics/widgets/latest-post/stories/latest-post-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/latest-post/stories/latest-post-widget.stories.tsx
@@ -131,9 +131,10 @@ function renderLatestPostOnPreset( preset: PresetType ) {
  *
  * This widget's endpoints are served by this file's own fixture middleware, so
  * the shared `setReportMockState` override never sees them; the story-side
- * `forceStatsMockState` helper registers ahead of the fixtures instead. An
- * `empty` override resolves to the generic no-rows shape, which the latest-post
- * sanitizer reduces to "no published post".
+ * `forceStatsMockState` helper re-registers its shared middleware whenever a
+ * forced state is set, keeping it ahead of these fixtures. An `empty` override
+ * resolves to the generic no-rows shape, which the latest-post sanitizer
+ * reduces to "no published post".
  *
  * The latest-post and stats/post query keys also carry no date params, so a
  * distinct date preset alone would not give the story a fresh cache entry.

--- a/projects/packages/premium-analytics/widgets/locations/stories/locations-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/stories/locations-widget.stories.tsx
@@ -5,12 +5,13 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import { registerStatsMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-stats-mocks';
 import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import LocationsRender from '../render';
 import widgetDefinition, { type LocationsAttributes } from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -36,12 +37,6 @@ interface LocationsStoryControls {
 interface LocationsDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		LocationsStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getLocationsAttributes( {
 	withComparison,

--- a/projects/packages/premium-analytics/widgets/locations/stories/locations-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/stories/locations-widget.stories.tsx
@@ -1,4 +1,4 @@
-import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { getDefaultQueryParams, type PresetType } from '@jetpack-premium-analytics/data';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
@@ -7,6 +7,7 @@ import {
 } from '../../stories/widget-dashboard-with-widget';
 import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import { registerStatsMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-stats-mocks';
+import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import LocationsRender from '../render';
 import widgetDefinition, { type LocationsAttributes } from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -55,6 +56,22 @@ function getLocationsAttributes( {
 
 function renderLocationsWidget( controls: LocationsStoryControls ) {
 	return <LocationsRender attributes={ getLocationsAttributes( controls ) } />;
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderLocationsOnPreset( preset: PresetType ) {
+	return (
+		<LocationsRender
+			attributes={ {
+				geoGranularity: 'country',
+				max: 10,
+				reportParams: getDefaultQueryParams( false, preset ),
+			} }
+		/>
+	);
 }
 
 function LocationsDashboardRender( props: WidgetRenderProps< unknown > ) {
@@ -123,6 +140,50 @@ export const CitiesMode: StoryObj< LocationsStoryControls > = {
 	render: renderLocationsWidget,
 	args: { withComparison: false, geoGranularity: 'city' },
 	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: StoryObj< LocationsStoryControls > = {
+	render: () => renderLocationsOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'stats/location-views', 'loading' );
+		return () => forceStatsMockState( 'stats/location-views', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: StoryObj< LocationsStoryControls > = {
+	render: () => renderLocationsOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'stats/location-views', 'error' );
+		return () => forceStatsMockState( 'stats/location-views', null );
+	},
+};
+
+/**
+ * Resolved with no rows: the widget shows its empty state (the neutral location
+ * glyph and the "stats will appear here" copy).
+ */
+export const Empty: StoryObj< LocationsStoryControls > = {
+	render: () => renderLocationsOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'stats/location-views', 'empty' );
+		return () => forceStatsMockState( 'stats/location-views', null );
+	},
 };
 
 export const WidgetDashboardWithWidget: DashboardStory = {

--- a/projects/packages/premium-analytics/widgets/locations/stories/locations-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/stories/locations-widget.stories.tsx
@@ -53,10 +53,7 @@ function renderLocationsWidget( controls: LocationsStoryControls ) {
 	return <LocationsRender attributes={ getLocationsAttributes( controls ) } />;
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderLocationsOnPreset( preset: PresetType ) {
 	return (
 		<LocationsRender
@@ -143,8 +140,7 @@ export const CitiesMode: StoryObj< LocationsStoryControls > = {
  */
 export const Loading: StoryObj< LocationsStoryControls > = {
 	render: () => renderLocationsOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/most-popular-day/stories/most-popular-day-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/stories/most-popular-day-widget.stories.tsx
@@ -20,13 +20,14 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import MostPopularDayRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -78,13 +79,6 @@ function renderMostPopularDay( { withComparison }: MostPopularDayStoryControls )
 		/>
 	);
 }
-
-// Close-up canvas so the highlight fills the frame outside the dashboard grid.
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/MostPopularDay',

--- a/projects/packages/premium-analytics/widgets/most-popular-day/stories/most-popular-day-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/stories/most-popular-day-widget.stories.tsx
@@ -126,8 +126,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderMostPopularDay( { withComparison: false } ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => forceSiteSummaryState( 'loading' ),

--- a/projects/packages/premium-analytics/widgets/most-popular-day/stories/most-popular-day-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/stories/most-popular-day-widget.stories.tsx
@@ -1,5 +1,5 @@
 /**
- * The three stories render the data-connected widget fed by the shared
+ * The stories render the data-connected widget fed by the shared
  * report-mock harness. `registerReportMocks` routes the `stats/` site summary
  * (`/proxy/v1.1/stats`) — including the `views_best_day*` fields this widget
  * reads — through `routeStatsReport()`, so no story-scoped middleware is
@@ -10,7 +10,7 @@
 /**
  * External dependencies
  */
-import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { getDefaultQueryParams, queryClient } from '@jetpack-premium-analytics/data';
 /**
  * Internal dependencies
  */
@@ -20,7 +20,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import MostPopularDayRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -30,6 +33,33 @@ import type { ComponentProps, ComponentType } from 'react';
 registerReportMocks();
 
 const MOST_POPULAR_DAY_RENDER_MODULE = 'storybook/most-popular-day';
+
+// Path fragment of the site-summary request (`useStatsSite` hits the bare
+// `/proxy/v1.1/stats` endpoint). It is a prefix of every Stats proxy path, but
+// the forced-state stories render only this widget, so nothing else matches.
+const SITE_SUMMARY_PATH_FRAGMENT = 'proxy/v1.1/stats';
+
+/**
+ * Forces the site-summary request into the given state for a story's lifetime.
+ *
+ * `useStatsSite()` has a constant query key — the all-time summary ignores the
+ * dashboard date range — so distinct date presets cannot give the forced-state
+ * stories their own cache entries. Instead, drop the cached summary from the
+ * shared query client so the widget re-fetches and hits the forced mock, and
+ * drop it again on cleanup so a forced empty/error result doesn't leak into the
+ * other stories' shared cache entry.
+ *
+ * @param state - The forced report-mock state.
+ * @return The `beforeEach` cleanup callback.
+ */
+function forceSiteSummaryState( state: 'loading' | 'error' | 'empty' ) {
+	queryClient.removeQueries( { queryKey: [ 'stats', 'site' ] } );
+	setReportMockState( SITE_SUMMARY_PATH_FRAGMENT, state );
+	return () => {
+		setReportMockState( SITE_SUMMARY_PATH_FRAGMENT, null );
+		queryClient.removeQueries( { queryKey: [ 'stats', 'site' ] } );
+	};
+}
 
 interface MostPopularDayStoryControls {
 	withComparison: boolean;
@@ -94,6 +124,41 @@ export const WithComparison: Story = {
 	render: renderMostPopularDay,
 	args: { withComparison: true },
 	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderMostPopularDay( { withComparison: false } ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => forceSiteSummaryState( 'loading' ),
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderMostPopularDay( { withComparison: false } ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => forceSiteSummaryState( 'error' ),
+};
+
+/**
+ * Resolved without a usable `views_best_day`: the widget shows its empty state
+ * (the neutral calendar glyph and the "not enough views" message).
+ */
+export const Empty: Story = {
+	render: () => renderMostPopularDay( { withComparison: false } ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => forceSiteSummaryState( 'empty' ),
 };
 
 interface MostPopularDayDashboardStoryProps

--- a/projects/packages/premium-analytics/widgets/most-popular-time/stories/most-popular-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-time/stories/most-popular-time-widget.stories.tsx
@@ -23,9 +23,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import MostPopularTimeRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -79,13 +80,6 @@ function renderMostPopularTime( { withComparison }: MostPopularTimeStoryControls
 		/>
 	);
 }
-
-// Close-up canvas so the highlights fill the frame outside the grid.
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '360px' } }>
-		<Story />
-	</div>
-);
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/MostPopularTime',

--- a/projects/packages/premium-analytics/widgets/most-popular-time/stories/most-popular-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-time/stories/most-popular-time-widget.stories.tsx
@@ -1,5 +1,5 @@
 /**
- * All three stories render the data-connected widget through `WidgetRoot`, so
+ * The stories render the data-connected widget through `WidgetRoot`, so
  * they need report data to resolve against. `registerReportMocks` covers the
  * shared paths, including the `stats/insights` fixture wired into
  * `routeStatsReport()`. The insights endpoint has no comparison period, so
@@ -9,11 +9,14 @@
 /**
  * External dependencies
  */
-import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { getDefaultQueryParams, queryClient } from '@jetpack-premium-analytics/data';
 /**
  * Internal dependencies
  */
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
@@ -29,6 +32,30 @@ import type { ComponentProps, ComponentType } from 'react';
 registerReportMocks();
 
 const MOST_POPULAR_TIME_RENDER_MODULE = 'storybook/most-popular-time';
+
+const INSIGHTS_PATH_FRAGMENT = 'stats/insights';
+
+/**
+ * Forces the insights request into the given state for a story's lifetime.
+ *
+ * `useStatsInsights()` has a constant query key — the lifetime insights report
+ * ignores the dashboard date range — so distinct date presets cannot give the
+ * forced-state stories their own cache entries. Instead, drop the cached report
+ * from the shared query client so the widget re-fetches and hits the forced
+ * mock, and drop it again on cleanup so a forced empty/error result doesn't
+ * leak into the other stories' shared cache entry.
+ *
+ * @param state - The forced report-mock state.
+ * @return The `beforeEach` cleanup callback.
+ */
+function forceInsightsState( state: 'loading' | 'error' | 'empty' ) {
+	queryClient.removeQueries( { queryKey: [ 'stats', 'insights' ] } );
+	setReportMockState( INSIGHTS_PATH_FRAGMENT, state );
+	return () => {
+		setReportMockState( INSIGHTS_PATH_FRAGMENT, null );
+		queryClient.removeQueries( { queryKey: [ 'stats', 'insights' ] } );
+	};
+}
 
 /**
  * Story controls. `withComparison` toggles the comparison report params to
@@ -106,6 +133,42 @@ export const WithComparison: Story = {
 			},
 		},
 	},
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderMostPopularTime( { withComparison: false } ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => forceInsightsState( 'loading' ),
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderMostPopularTime( { withComparison: false } ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => forceInsightsState( 'error' ),
+};
+
+/**
+ * Resolved without peak day/hour data: the widget shows its empty state (no
+ * icon — the widget's `scheduled` glyph has no neutral counterpart in the
+ * analytics icon set).
+ */
+export const Empty: Story = {
+	render: () => renderMostPopularTime( { withComparison: false } ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => forceInsightsState( 'empty' ),
 };
 
 interface MostPopularTimeDashboardStoryProps

--- a/projects/packages/premium-analytics/widgets/most-popular-time/stories/most-popular-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-time/stories/most-popular-time-widget.stories.tsx
@@ -135,8 +135,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderMostPopularTime( { withComparison: false } ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => forceInsightsState( 'loading' ),

--- a/projects/packages/premium-analytics/widgets/net-sales-over-time/stories/net-sales-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/net-sales-over-time/stories/net-sales-over-time-widget.stories.tsx
@@ -86,10 +86,7 @@ function renderNetSalesOverTime( { withComparison, preset }: NetSalesOverTimeSto
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderNetSalesOverTimeOnPreset( preset: SelectablePresetId ) {
 	ensureLineChartComposition();
 
@@ -194,8 +191,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderNetSalesOverTimeOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/net-sales-over-time/stories/net-sales-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/net-sales-over-time/stories/net-sales-over-time-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import LineChart from '../../../../../js-packages/charts/src/charts/line-chart/line-chart';
 import {
 	registerReportMocks,
@@ -13,7 +14,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import NetSalesOverTimeRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -37,12 +38,6 @@ type NetSalesOverTimeStoryProps = NetSalesOverTimeWidgetProps & NetSalesOverTime
 interface NetSalesOverTimeDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		NetSalesOverTimeStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getNetSalesOverTimeAttributes(
 	withComparison = false,

--- a/projects/packages/premium-analytics/widgets/net-sales-over-time/stories/net-sales-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/net-sales-over-time/stories/net-sales-over-time-widget.stories.tsx
@@ -215,8 +215,8 @@ export const Error: Story = {
 };
 
 /**
- * Resolved with no net sales data: the widget shows its empty state ("No data
- * found for this date range.").
+ * Resolved with no net sales data: the widget shows its empty state ("No sales
+ * in this period.").
  */
 export const Empty: Story = {
 	render: () => renderNetSalesOverTimeOnPreset( 'last-365-days' ),

--- a/projects/packages/premium-analytics/widgets/net-sales-over-time/stories/net-sales-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/net-sales-over-time/stories/net-sales-over-time-widget.stories.tsx
@@ -7,7 +7,10 @@ import {
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
 import LineChart from '../../../../../js-packages/charts/src/charts/line-chart/line-chart';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import NetSalesOverTimeRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -86,6 +89,16 @@ function renderNetSalesOverTime( { withComparison, preset }: NetSalesOverTimeSto
 			attributes={ getNetSalesOverTimeAttributes( withComparison, preset ) }
 		/>
 	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderNetSalesOverTimeOnPreset( preset: SelectablePresetId ) {
+	ensureLineChartComposition();
+
+	return <NetSalesOverTimeRender attributes={ getNetSalesOverTimeAttributes( false, preset ) } />;
 }
 
 function NetSalesOverTimeDashboardStory( {
@@ -177,6 +190,50 @@ export const WithComparison: Story = {
 				) => getNetSalesOverTimeSource( storyContext.args ),
 			},
 		},
+	},
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderNetSalesOverTimeOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders/by-date', 'loading' );
+		return () => setReportMockState( 'orders/by-date', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderNetSalesOverTimeOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders/by-date', 'error' );
+		return () => setReportMockState( 'orders/by-date', null );
+	},
+};
+
+/**
+ * Resolved with no net sales data: the widget shows its empty state ("No data
+ * found for this date range.").
+ */
+export const Empty: Story = {
+	render: () => renderNetSalesOverTimeOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders/by-date', 'empty' );
+		return () => setReportMockState( 'orders/by-date', null );
 	},
 };
 

--- a/projects/packages/premium-analytics/widgets/new-vs-returning-customer/stories/new-vs-returning-customer-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/new-vs-returning-customer/stories/new-vs-returning-customer-widget.stories.tsx
@@ -85,10 +85,7 @@ function renderNewVsReturningCustomer( {
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderNewVsReturningCustomerOnPreset( preset: SelectablePresetId ) {
 	return (
 		<NewVsReturningCustomerRender
@@ -196,8 +193,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderNewVsReturningCustomerOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/new-vs-returning-customer/stories/new-vs-returning-customer-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/new-vs-returning-customer/stories/new-vs-returning-customer-widget.stories.tsx
@@ -6,7 +6,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import NewVsReturningCustomerRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -83,6 +86,18 @@ function renderNewVsReturningCustomer( {
 	return (
 		<NewVsReturningCustomerRender
 			attributes={ getNewVsReturningCustomerAttributes( withComparison, preset ) }
+		/>
+	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderNewVsReturningCustomerOnPreset( preset: SelectablePresetId ) {
+	return (
+		<NewVsReturningCustomerRender
+			attributes={ getNewVsReturningCustomerAttributes( false, preset ) }
 		/>
 	);
 }
@@ -176,6 +191,52 @@ export const WithComparison: Story = {
 				) => getNewVsReturningCustomerSource( storyContext.args ),
 			},
 		},
+	},
+};
+
+/**
+ * First load: the customers-by-date report is in flight, so the widget shows
+ * its loading state. The mock is forced to never resolve for the duration of
+ * this story.
+ */
+export const Loading: Story = {
+	render: () => renderNewVsReturningCustomerOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'customers/by-date', 'loading' );
+		return () => setReportMockState( 'customers/by-date', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action
+ * (which re-runs the query — still mocked as failing while this story is
+ * active).
+ */
+export const Error: Story = {
+	render: () => renderNewVsReturningCustomerOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'customers/by-date', 'error' );
+		return () => setReportMockState( 'customers/by-date', null );
+	},
+};
+
+/**
+ * Resolved with no customers: the widget shows its empty state ("No customer
+ * data in this period.").
+ */
+export const Empty: Story = {
+	render: () => renderNewVsReturningCustomerOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'customers/by-date', 'empty' );
+		return () => setReportMockState( 'customers/by-date', null );
 	},
 };
 

--- a/projects/packages/premium-analytics/widgets/new-vs-returning-customer/stories/new-vs-returning-customer-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/new-vs-returning-customer/stories/new-vs-returning-customer-widget.stories.tsx
@@ -6,13 +6,14 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import NewVsReturningCustomerRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -35,12 +36,6 @@ type NewVsReturningCustomerStoryProps = NewVsReturningCustomerWidgetProps &
 interface NewVsReturningCustomerDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		NewVsReturningCustomerStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getNewVsReturningCustomerAttributes(
 	withComparison = false,

--- a/projects/packages/premium-analytics/widgets/orders-fulfillment/stories/orders-fulfillment-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/orders-fulfillment/stories/orders-fulfillment-widget.stories.tsx
@@ -6,7 +6,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import OrdersFulfillmentRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -81,6 +84,14 @@ function renderOrdersFulfillment( { withComparison, preset }: OrdersFulfillmentS
 			attributes={ getOrdersFulfillmentAttributes( withComparison, preset ) }
 		/>
 	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderOrdersFulfillmentOnPreset( preset: SelectablePresetId ) {
+	return <OrdersFulfillmentRender attributes={ getOrdersFulfillmentAttributes( false, preset ) } />;
 }
 
 function OrdersFulfillmentDashboardStory( {
@@ -170,6 +181,52 @@ export const WithComparison: Story = {
 				) => getOrdersFulfillmentSource( storyContext.args ),
 			},
 		},
+	},
+};
+
+/**
+ * First load: both fulfillment reports (fulfilled and unfulfilled) are in
+ * flight, so the widget shows its loading state. The mock is forced to never
+ * resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderOrdersFulfillmentOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders/by-date', 'loading' );
+		return () => setReportMockState( 'orders/by-date', null );
+	},
+};
+
+/**
+ * Both fulfillment reports failed: the widget shows its error state with a
+ * Retry action (which re-runs both queries — still mocked as failing while
+ * this story is active).
+ */
+export const Error: Story = {
+	render: () => renderOrdersFulfillmentOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders/by-date', 'error' );
+		return () => setReportMockState( 'orders/by-date', null );
+	},
+};
+
+/**
+ * Resolved with no fulfilled or unfulfilled orders: the widget shows its empty
+ * state ("No orders in this period.").
+ */
+export const Empty: Story = {
+	render: () => renderOrdersFulfillmentOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders/by-date', 'empty' );
+		return () => setReportMockState( 'orders/by-date', null );
 	},
 };
 

--- a/projects/packages/premium-analytics/widgets/orders-fulfillment/stories/orders-fulfillment-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/orders-fulfillment/stories/orders-fulfillment-widget.stories.tsx
@@ -6,13 +6,14 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import OrdersFulfillmentRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -34,12 +35,6 @@ type OrdersFulfillmentStoryProps = OrdersFulfillmentWidgetProps & OrdersFulfillm
 interface OrdersFulfillmentDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		OrdersFulfillmentStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getOrdersFulfillmentAttributes(
 	withComparison = false,

--- a/projects/packages/premium-analytics/widgets/orders-fulfillment/stories/orders-fulfillment-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/orders-fulfillment/stories/orders-fulfillment-widget.stories.tsx
@@ -81,10 +81,7 @@ function renderOrdersFulfillment( { withComparison, preset }: OrdersFulfillmentS
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderOrdersFulfillmentOnPreset( preset: SelectablePresetId ) {
 	return <OrdersFulfillmentRender attributes={ getOrdersFulfillmentAttributes( false, preset ) } />;
 }
@@ -186,8 +183,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderOrdersFulfillmentOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/orders-over-time/stories/orders-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/orders-over-time/stories/orders-over-time-widget.stories.tsx
@@ -7,7 +7,10 @@ import {
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
 import LineChart from '../../../../../js-packages/charts/src/charts/line-chart/line-chart';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import OrdersOverTimeRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -85,6 +88,16 @@ function renderOrdersOverTime( { withComparison, preset }: OrdersOverTimeStoryCo
 	return (
 		<OrdersOverTimeRender attributes={ getOrdersOverTimeAttributes( withComparison, preset ) } />
 	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderOrdersOverTimeOnPreset( preset: SelectablePresetId ) {
+	ensureLineChartComposition();
+
+	return <OrdersOverTimeRender attributes={ getOrdersOverTimeAttributes( false, preset ) } />;
 }
 
 function OrdersOverTimeDashboardStory( {
@@ -175,6 +188,50 @@ export const WithComparison: Story = {
 				) => getOrdersOverTimeSource( storyContext.args ),
 			},
 		},
+	},
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderOrdersOverTimeOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders/by-date', 'loading' );
+		return () => setReportMockState( 'orders/by-date', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderOrdersOverTimeOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders/by-date', 'error' );
+		return () => setReportMockState( 'orders/by-date', null );
+	},
+};
+
+/**
+ * Resolved with no order data: the widget shows its empty state ("No data found
+ * for this date range.").
+ */
+export const Empty: Story = {
+	render: () => renderOrdersOverTimeOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders/by-date', 'empty' );
+		return () => setReportMockState( 'orders/by-date', null );
 	},
 };
 

--- a/projects/packages/premium-analytics/widgets/orders-over-time/stories/orders-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/orders-over-time/stories/orders-over-time-widget.stories.tsx
@@ -85,10 +85,7 @@ function renderOrdersOverTime( { withComparison, preset }: OrdersOverTimeStoryCo
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderOrdersOverTimeOnPreset( preset: SelectablePresetId ) {
 	ensureLineChartComposition();
 
@@ -192,8 +189,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderOrdersOverTimeOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/orders-over-time/stories/orders-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/orders-over-time/stories/orders-over-time-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import LineChart from '../../../../../js-packages/charts/src/charts/line-chart/line-chart';
 import {
 	registerReportMocks,
@@ -13,7 +14,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import OrdersOverTimeRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -38,12 +39,6 @@ type OrdersOverTimeStoryProps = OrdersOverTimeWidgetProps & OrdersOverTimeStoryC
 interface OrdersOverTimeDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		OrdersOverTimeStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getOrdersOverTimeAttributes(
 	withComparison = false,

--- a/projects/packages/premium-analytics/widgets/orders-over-time/stories/orders-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/orders-over-time/stories/orders-over-time-widget.stories.tsx
@@ -213,8 +213,8 @@ export const Error: Story = {
 };
 
 /**
- * Resolved with no order data: the widget shows its empty state ("No data found
- * for this date range.").
+ * Resolved with no order data: the widget shows its empty state ("No orders in
+ * this period.").
  */
 export const Empty: Story = {
 	render: () => renderOrdersOverTimeOnPreset( 'last-365-days' ),

--- a/projects/packages/premium-analytics/widgets/payment-status/stories/payment-status-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/payment-status/stories/payment-status-widget.stories.tsx
@@ -6,7 +6,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import PaymentStatusRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -79,6 +82,14 @@ function renderPaymentStatus( { withComparison, preset }: PaymentStatusStoryCont
 	return (
 		<PaymentStatusRender attributes={ getPaymentStatusAttributes( withComparison, preset ) } />
 	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderPaymentStatusOnPreset( preset: SelectablePresetId ) {
+	return <PaymentStatusRender attributes={ getPaymentStatusAttributes( false, preset ) } />;
 }
 
 function PaymentStatusDashboardStory( {
@@ -169,6 +180,50 @@ export const WithComparison: Story = {
 				) => getPaymentStatusSource( storyContext.args ),
 			},
 		},
+	},
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderPaymentStatusOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders/by-date', 'loading' );
+		return () => setReportMockState( 'orders/by-date', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderPaymentStatusOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders/by-date', 'error' );
+		return () => setReportMockState( 'orders/by-date', null );
+	},
+};
+
+/**
+ * Resolved with no order revenue: the widget shows its empty state (the neutral
+ * payment glyph and "No order revenue in this period.").
+ */
+export const Empty: Story = {
+	render: () => renderPaymentStatusOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders/by-date', 'empty' );
+		return () => setReportMockState( 'orders/by-date', null );
 	},
 };
 

--- a/projects/packages/premium-analytics/widgets/payment-status/stories/payment-status-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/payment-status/stories/payment-status-widget.stories.tsx
@@ -6,13 +6,14 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import PaymentStatusRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -34,12 +35,6 @@ type PaymentStatusStoryProps = PaymentStatusWidgetProps & PaymentStatusStoryCont
 interface PaymentStatusDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		PaymentStatusStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getPaymentStatusAttributes(
 	withComparison = false,

--- a/projects/packages/premium-analytics/widgets/payment-status/stories/payment-status-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/payment-status/stories/payment-status-widget.stories.tsx
@@ -79,10 +79,7 @@ function renderPaymentStatus( { withComparison, preset }: PaymentStatusStoryCont
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderPaymentStatusOnPreset( preset: SelectablePresetId ) {
 	return <PaymentStatusRender attributes={ getPaymentStatusAttributes( false, preset ) } />;
 }
@@ -184,8 +181,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderPaymentStatusOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/posting-activity/stories/posting-activity-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/posting-activity/stories/posting-activity-widget.stories.tsx
@@ -17,10 +17,11 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import PostingActivityRender from '../render';
 import widgetDefinition from '../widget';
 import type { APIFetchMiddleware, APIFetchOptions } from '@wordpress/api-fetch';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -137,13 +138,6 @@ function renderPostingActivityOnPreset( preset: PresetType ) {
 		/>
 	);
 }
-
-// Close-up canvas so the heatmap fills the frame outside the dashboard grid.
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/PostingActivity',

--- a/projects/packages/premium-analytics/widgets/posting-activity/stories/posting-activity-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/posting-activity/stories/posting-activity-widget.stories.tsx
@@ -1,13 +1,16 @@
 /**
  * External dependencies
  */
-import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { getDefaultQueryParams, type PresetType } from '@jetpack-premium-analytics/data';
 import apiFetch from '@wordpress/api-fetch';
 import { getUnixTime, startOfDay, subDays } from 'date-fns';
 /**
  * Internal dependencies
  */
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
@@ -24,7 +27,30 @@ import type { ComponentProps, ComponentType } from 'react';
 registerReportMocks();
 
 const STATS_STREAK_PATH = '/jetpack-premium-analytics/v1/proxy/v1.1/stats/streak';
+const STATS_STREAK_PATH_FRAGMENT = 'stats/streak';
 const STREAK_DAYS = 365;
+
+// The story-local streak middleware below runs ahead of the shared report
+// middleware (it is registered after it, so apiFetch unshifts it in front) and
+// would swallow streak requests before a `setReportMockState` override can
+// apply. The forced-state stories raise this flag so streak requests fall
+// through to the shared middleware while an override is active.
+let deferToForcedStreakState = false;
+
+/**
+ * Forces the streak request into the given state for a story's lifetime.
+ *
+ * @param state - The forced report-mock state.
+ * @return The `beforeEach` cleanup callback.
+ */
+function forceStreakState( state: 'loading' | 'error' | 'empty' ) {
+	deferToForcedStreakState = true;
+	setReportMockState( STATS_STREAK_PATH_FRAGMENT, state );
+	return () => {
+		setReportMockState( STATS_STREAK_PATH_FRAGMENT, null );
+		deferToForcedStreakState = false;
+	};
+}
 
 /**
  * A year of deterministic posts-per-day counts keyed by unix-second timestamps,
@@ -64,7 +90,7 @@ function buildStreakResponse() {
 const streakMocksMiddleware: APIFetchMiddleware = async ( options: APIFetchOptions, next ) => {
 	const requestPath = options.path ?? options.url ?? '';
 
-	if ( ! requestPath.startsWith( STATS_STREAK_PATH ) ) {
+	if ( deferToForcedStreakState || ! requestPath.startsWith( STATS_STREAK_PATH ) ) {
 		return next( options );
 	}
 
@@ -95,6 +121,19 @@ function renderPostingActivity( { withComparison }: PostingActivityStoryControls
 	return (
 		<PostingActivityRender
 			attributes={ { reportParams: getDefaultQueryParams( withComparison ) } }
+		/>
+	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The streak
+// query key derives from the date range, so a unique preset gives the
+// forced-state stories their own cache entry and they hit the mock fresh
+// instead of reading another story's cached success from the shared query
+// client.
+function renderPostingActivityOnPreset( preset: PresetType ) {
+	return (
+		<PostingActivityRender
+			attributes={ { reportParams: getDefaultQueryParams( false, preset ) } }
 		/>
 	);
 }
@@ -145,6 +184,41 @@ export const WithComparison: Story = {
 	render: renderPostingActivity,
 	args: { withComparison: true },
 	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderPostingActivityOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => forceStreakState( 'loading' ),
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderPostingActivityOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => forceStreakState( 'error' ),
+};
+
+/**
+ * Resolved with no posts in the range: the widget shows its empty state (the
+ * neutral calendar glyph and the "posts will appear here" message).
+ */
+export const Empty: Story = {
+	render: () => renderPostingActivityOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => forceStreakState( 'empty' ),
 };
 
 interface PostingActivityDashboardStoryProps

--- a/projects/packages/premium-analytics/widgets/posting-activity/stories/posting-activity-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/posting-activity/stories/posting-activity-widget.stories.tsx
@@ -119,11 +119,7 @@ function renderPostingActivity( { withComparison }: PostingActivityStoryControls
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The streak
-// query key derives from the date range, so a unique preset gives the
-// forced-state stories their own cache entry and they hit the mock fresh
-// instead of reading another story's cached success from the shared query
-// client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderPostingActivityOnPreset( preset: PresetType ) {
 	return (
 		<PostingActivityRender
@@ -179,8 +175,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderPostingActivityOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => forceStreakState( 'loading' ),

--- a/projects/packages/premium-analytics/widgets/posting-activity/stories/posting-activity-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/posting-activity/stories/posting-activity-widget.stories.tsx
@@ -7,10 +7,8 @@ import { getUnixTime, startOfDay, subDays } from 'date-fns';
 /**
  * Internal dependencies
  */
-import {
-	registerReportMocks,
-	setReportMockState,
-} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
@@ -31,25 +29,20 @@ const STATS_STREAK_PATH = '/jetpack-premium-analytics/v1/proxy/v1.1/stats/streak
 const STATS_STREAK_PATH_FRAGMENT = 'stats/streak';
 const STREAK_DAYS = 365;
 
-// The story-local streak middleware below runs ahead of the shared report
-// middleware (it is registered after it, so apiFetch unshifts it in front) and
-// would swallow streak requests before a `setReportMockState` override can
-// apply. The forced-state stories raise this flag so streak requests fall
-// through to the shared middleware while an override is active.
-let deferToForcedStreakState = false;
-
 /**
  * Forces the streak request into the given state for a story's lifetime.
+ *
+ * The story-local streak middleware below would otherwise shadow
+ * `setReportMockState`, so use the shared story-side override helper that
+ * re-registers ahead of story-local middleware when a forced state is set.
  *
  * @param state - The forced report-mock state.
  * @return The `beforeEach` cleanup callback.
  */
 function forceStreakState( state: 'loading' | 'error' | 'empty' ) {
-	deferToForcedStreakState = true;
-	setReportMockState( STATS_STREAK_PATH_FRAGMENT, state );
+	forceStatsMockState( STATS_STREAK_PATH_FRAGMENT, state );
 	return () => {
-		setReportMockState( STATS_STREAK_PATH_FRAGMENT, null );
-		deferToForcedStreakState = false;
+		forceStatsMockState( STATS_STREAK_PATH_FRAGMENT, null );
 	};
 }
 
@@ -91,7 +84,7 @@ function buildStreakResponse() {
 const streakMocksMiddleware: APIFetchMiddleware = async ( options: APIFetchOptions, next ) => {
 	const requestPath = options.path ?? options.url ?? '';
 
-	if ( deferToForcedStreakState || ! requestPath.startsWith( STATS_STREAK_PATH ) ) {
+	if ( ! requestPath.startsWith( STATS_STREAK_PATH ) ) {
 		return next( options );
 	}
 

--- a/projects/packages/premium-analytics/widgets/referrers/stories/referrers-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/stories/referrers-widget.stories.tsx
@@ -49,10 +49,7 @@ function renderReferrersWidget( { withComparison }: ReferrersStoryControls ) {
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderReferrersOnPreset( preset: PresetType ) {
 	return (
 		<ReferrersRender
@@ -123,8 +120,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderReferrersOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/referrers/stories/referrers-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/stories/referrers-widget.stories.tsx
@@ -14,9 +14,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import ReferrersRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -39,12 +40,6 @@ interface ReferrersStoryControls {
 interface ReferrersDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		ReferrersStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '340px' } }>
-		<Story />
-	</div>
-);
 
 function renderReferrersWidget( { withComparison }: ReferrersStoryControls ) {
 	return (

--- a/projects/packages/premium-analytics/widgets/referrers/stories/referrers-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/stories/referrers-widget.stories.tsx
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
-import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { getDefaultQueryParams, type PresetType } from '@jetpack-premium-analytics/data';
 /**
  * Internal dependencies
  */
 import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import { registerStatsMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-stats-mocks';
+import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
@@ -49,6 +50,18 @@ function renderReferrersWidget( { withComparison }: ReferrersStoryControls ) {
 	return (
 		<ReferrersRender
 			attributes={ { max: 10, reportParams: getDefaultQueryParams( withComparison ) } }
+		/>
+	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderReferrersOnPreset( preset: PresetType ) {
+	return (
+		<ReferrersRender
+			attributes={ { max: 10, reportParams: getDefaultQueryParams( false, preset ) } }
 		/>
 	);
 }
@@ -103,6 +116,54 @@ export const WithComparison: Story = {
 	render: renderReferrersWidget,
 	args: { withComparison: true },
 	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ *
+ * Forced through `forceStatsMockState`: `stats/referrers` is answered by the
+ * legacy stats mocks before the shared `setReportMockState` override can
+ * intercept it.
+ */
+export const Loading: Story = {
+	render: () => renderReferrersOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'stats/referrers', 'loading' );
+		return () => forceStatsMockState( 'stats/referrers', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderReferrersOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'stats/referrers', 'error' );
+		return () => forceStatsMockState( 'stats/referrers', null );
+	},
+};
+
+/**
+ * Resolved with no rows: the widget shows its empty state (the neutral globe
+ * glyph and "No referrers in this period.").
+ */
+export const Empty: Story = {
+	render: () => renderReferrersOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'stats/referrers', 'empty' );
+		return () => forceStatsMockState( 'stats/referrers', null );
+	},
 };
 
 export const WidgetDashboardWithWidget: DashboardStory = {

--- a/projects/packages/premium-analytics/widgets/revenue-by-customer-type/stories/revenue-by-customer-type-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/revenue-by-customer-type/stories/revenue-by-customer-type-widget.stories.tsx
@@ -6,13 +6,14 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import RevenueByCustomerTypeRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -35,12 +36,6 @@ type RevenueByCustomerTypeStoryProps = RevenueByCustomerTypeRenderProps &
 interface RevenueByCustomerTypeDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		RevenueByCustomerTypeStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getRevenueByCustomerTypeAttributes(
 	withComparison = false,

--- a/projects/packages/premium-analytics/widgets/revenue-by-customer-type/stories/revenue-by-customer-type-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/revenue-by-customer-type/stories/revenue-by-customer-type-widget.stories.tsx
@@ -85,10 +85,7 @@ function renderRevenueByCustomerType( {
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderRevenueByCustomerTypeOnPreset( preset: SelectablePresetId ) {
 	return (
 		<RevenueByCustomerTypeRender
@@ -196,8 +193,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderRevenueByCustomerTypeOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/revenue-by-customer-type/stories/revenue-by-customer-type-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/revenue-by-customer-type/stories/revenue-by-customer-type-widget.stories.tsx
@@ -6,7 +6,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import RevenueByCustomerTypeRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -83,6 +86,18 @@ function renderRevenueByCustomerType( {
 	return (
 		<RevenueByCustomerTypeRender
 			attributes={ getRevenueByCustomerTypeAttributes( withComparison, preset ) }
+		/>
+	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderRevenueByCustomerTypeOnPreset( preset: SelectablePresetId ) {
+	return (
+		<RevenueByCustomerTypeRender
+			attributes={ getRevenueByCustomerTypeAttributes( false, preset ) }
 		/>
 	);
 }
@@ -176,6 +191,52 @@ export const WithComparison: Story = {
 				) => getRevenueByCustomerTypeSource( storyContext.args ),
 			},
 		},
+	},
+};
+
+/**
+ * First load: the customers report is in flight, so the widget shows its
+ * loading state. The mock is forced to never resolve for the duration of this
+ * story.
+ */
+export const Loading: Story = {
+	render: () => renderRevenueByCustomerTypeOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'customers/new-returning', 'loading' );
+		return () => setReportMockState( 'customers/new-returning', null );
+	},
+};
+
+/**
+ * The customers report failed: the widget shows its error state with a Retry
+ * action (which re-runs the query — still mocked as failing while this story is
+ * active).
+ */
+export const Error: Story = {
+	render: () => renderRevenueByCustomerTypeOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'customers/new-returning', 'error' );
+		return () => setReportMockState( 'customers/new-returning', null );
+	},
+};
+
+/**
+ * The customers report resolved with no revenue in the period: the widget shows
+ * its empty state.
+ */
+export const Empty: Story = {
+	render: () => renderRevenueByCustomerTypeOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'customers/new-returning', 'empty' );
+		return () => setReportMockState( 'customers/new-returning', null );
 	},
 };
 

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/stories/sales-by-coupon-usage-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/stories/sales-by-coupon-usage-widget.stories.tsx
@@ -81,10 +81,7 @@ function renderSalesByCouponUsage( { withComparison, preset }: SalesByCouponUsag
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderSalesByCouponUsageOnPreset( preset: SelectablePresetId ) {
 	return (
 		<SalesByCouponUsageRender attributes={ getSalesByCouponUsageAttributes( false, preset ) } />
@@ -187,8 +184,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderSalesByCouponUsageOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/stories/sales-by-coupon-usage-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/stories/sales-by-coupon-usage-widget.stories.tsx
@@ -6,13 +6,14 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SalesByCouponUsageRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -34,12 +35,6 @@ type SalesByCouponUsageStoryProps = SalesByCouponUsageWidgetProps & SalesByCoupo
 interface SalesByCouponUsageDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		SalesByCouponUsageStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getSalesByCouponUsageAttributes(
 	withComparison = false,

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/stories/sales-by-coupon-usage-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/stories/sales-by-coupon-usage-widget.stories.tsx
@@ -6,7 +6,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SalesByCouponUsageRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -80,6 +83,16 @@ function renderSalesByCouponUsage( { withComparison, preset }: SalesByCouponUsag
 		<SalesByCouponUsageRender
 			attributes={ getSalesByCouponUsageAttributes( withComparison, preset ) }
 		/>
+	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderSalesByCouponUsageOnPreset( preset: SelectablePresetId ) {
+	return (
+		<SalesByCouponUsageRender attributes={ getSalesByCouponUsageAttributes( false, preset ) } />
 	);
 }
 
@@ -170,6 +183,51 @@ export const WithComparison: Story = {
 				) => getSalesByCouponUsageSource( storyContext.args ),
 			},
 		},
+	},
+};
+
+/**
+ * First load: the coupons report is in flight, so the widget shows its loading
+ * state. The mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderSalesByCouponUsageOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'coupons/', 'loading' );
+		return () => setReportMockState( 'coupons/', null );
+	},
+};
+
+/**
+ * The coupons report failed: the widget shows its error state with a Retry
+ * action (which re-runs the query — still mocked as failing while this story is
+ * active).
+ */
+export const Error: Story = {
+	render: () => renderSalesByCouponUsageOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'coupons/', 'error' );
+		return () => setReportMockState( 'coupons/', null );
+	},
+};
+
+/**
+ * Resolved with no coupon rows: the widget shows its empty state (the neutral
+ * coupon glyph and "No coupon sales in this period.").
+ */
+export const Empty: Story = {
+	render: () => renderSalesByCouponUsageOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'coupons/', 'empty' );
+		return () => setReportMockState( 'coupons/', null );
 	},
 };
 

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon/stories/sales-by-coupon-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon/stories/sales-by-coupon-widget.stories.tsx
@@ -61,10 +61,7 @@ function renderSalesByCoupon( { withComparison, preset }: SalesByCouponStoryCont
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderSalesByCouponOnPreset( preset: SelectablePresetId ) {
 	return (
 		<SalesByCouponRender
@@ -156,8 +153,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderSalesByCouponOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon/stories/sales-by-coupon-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon/stories/sales-by-coupon-widget.stories.tsx
@@ -6,13 +6,14 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SalesByCouponRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -41,12 +42,6 @@ type SalesByCouponStoryProps = SalesByCouponWidgetProps & SalesByCouponStoryCont
 interface SalesByCouponDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		SalesByCouponStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getSalesByCouponAttributes(
 	withComparison = false,

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon/stories/sales-by-coupon-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon/stories/sales-by-coupon-widget.stories.tsx
@@ -6,7 +6,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SalesByCouponRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -58,6 +61,19 @@ function renderSalesByCoupon( { withComparison, preset }: SalesByCouponStoryCont
 	return (
 		<SalesByCouponRender
 			attributes={ getSalesByCouponAttributes( withComparison, preset ) }
+			setError={ setStoryError }
+		/>
+	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderSalesByCouponOnPreset( preset: SelectablePresetId ) {
+	return (
+		<SalesByCouponRender
+			attributes={ getSalesByCouponAttributes( false, preset ) }
 			setError={ setStoryError }
 		/>
 	);
@@ -137,6 +153,51 @@ export const WithComparison: Story = {
 		withComparison: true,
 	},
 	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * First load: the coupons report is in flight, so the widget shows its loading
+ * state. The mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderSalesByCouponOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'coupons/', 'loading' );
+		return () => setReportMockState( 'coupons/', null );
+	},
+};
+
+/**
+ * The coupons report failed: the widget shows its error state with a Retry
+ * action (which re-runs the query — still mocked as failing while this story is
+ * active).
+ */
+export const Error: Story = {
+	render: () => renderSalesByCouponOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'coupons/', 'error' );
+		return () => setReportMockState( 'coupons/', null );
+	},
+};
+
+/**
+ * Resolved with no coupon rows: the widget shows its empty state (the neutral
+ * coupon glyph and "No coupon sales in this period.").
+ */
+export const Empty: Story = {
+	render: () => renderSalesByCouponOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'coupons/', 'empty' );
+		return () => setReportMockState( 'coupons/', null );
+	},
 };
 
 /**

--- a/projects/packages/premium-analytics/widgets/sales-by-device/stories/sales-by-device-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-device/stories/sales-by-device-widget.stories.tsx
@@ -1,6 +1,9 @@
 import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
 import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
@@ -85,6 +88,14 @@ function renderSalesByDevice( { withComparison, preset }: SalesByDeviceStoryCont
 	return (
 		<SalesByDeviceRender attributes={ getSalesByDeviceAttributes( withComparison, preset ) } />
 	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderSalesByDeviceOnPreset( preset: SelectablePresetId ) {
+	return <SalesByDeviceRender attributes={ getSalesByDeviceAttributes( false, preset ) } />;
 }
 
 /**
@@ -180,6 +191,52 @@ export const WithComparison: Story = {
 				) => getSalesByDeviceSource( storyContext.args ),
 			},
 		},
+	},
+};
+
+/**
+ * First load: the order-attribution report is in flight, so the widget shows its
+ * loading state. The mock is forced to never resolve for the duration of this
+ * story.
+ */
+export const Loading: Story = {
+	render: () => renderSalesByDeviceOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'order-attribution/device/summary', 'loading' );
+		return () => setReportMockState( 'order-attribution/device/summary', null );
+	},
+};
+
+/**
+ * The order-attribution report failed: the widget shows its error state with a
+ * Retry action (which re-runs the query — still mocked as failing while this
+ * story is active).
+ */
+export const Error: Story = {
+	render: () => renderSalesByDeviceOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'order-attribution/device/summary', 'error' );
+		return () => setReportMockState( 'order-attribution/device/summary', null );
+	},
+};
+
+/**
+ * Resolved with no order-attribution rows: the widget shows its empty state (the
+ * neutral device glyph and "No sales data in this period.").
+ */
+export const Empty: Story = {
+	render: () => renderSalesByDeviceOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'order-attribution/device/summary', 'empty' );
+		return () => setReportMockState( 'order-attribution/device/summary', null );
 	},
 };
 

--- a/projects/packages/premium-analytics/widgets/sales-by-device/stories/sales-by-device-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-device/stories/sales-by-device-widget.stories.tsx
@@ -10,9 +10,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import SalesByDeviceRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -40,12 +41,6 @@ type SalesByDeviceStoryProps = SalesByDeviceWidgetProps & SalesByDeviceStoryCont
 interface SalesByDeviceDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		SalesByDeviceStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getSalesByDeviceAttributes(
 	withComparison = false,

--- a/projects/packages/premium-analytics/widgets/sales-by-device/stories/sales-by-device-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-device/stories/sales-by-device-widget.stories.tsx
@@ -85,10 +85,7 @@ function renderSalesByDevice( { withComparison, preset }: SalesByDeviceStoryCont
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderSalesByDeviceOnPreset( preset: SelectablePresetId ) {
 	return <SalesByDeviceRender attributes={ getSalesByDeviceAttributes( false, preset ) } />;
 }
@@ -196,8 +193,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderSalesByDeviceOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-campaign/stories/sales-by-utm-campaign-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-campaign/stories/sales-by-utm-campaign-widget.stories.tsx
@@ -10,9 +10,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import SalesByUtmCampaignRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -40,12 +41,6 @@ type SalesByUtmCampaignStoryProps = SalesByUtmCampaignWidgetProps & SalesByUtmCa
 interface SalesByUtmCampaignDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		SalesByUtmCampaignStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getSalesByUtmCampaignAttributes(
 	withComparison = false,

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-campaign/stories/sales-by-utm-campaign-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-campaign/stories/sales-by-utm-campaign-widget.stories.tsx
@@ -87,10 +87,7 @@ function renderSalesByUtmCampaign( { withComparison, preset }: SalesByUtmCampaig
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderSalesByUtmCampaignOnPreset( preset: SelectablePresetId ) {
 	return (
 		<SalesByUtmCampaignRender attributes={ getSalesByUtmCampaignAttributes( false, preset ) } />
@@ -199,8 +196,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderSalesByUtmCampaignOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-campaign/stories/sales-by-utm-campaign-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-campaign/stories/sales-by-utm-campaign-widget.stories.tsx
@@ -1,6 +1,9 @@
 import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
 import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
@@ -86,6 +89,16 @@ function renderSalesByUtmCampaign( { withComparison, preset }: SalesByUtmCampaig
 		<SalesByUtmCampaignRender
 			attributes={ getSalesByUtmCampaignAttributes( withComparison, preset ) }
 		/>
+	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderSalesByUtmCampaignOnPreset( preset: SelectablePresetId ) {
+	return (
+		<SalesByUtmCampaignRender attributes={ getSalesByUtmCampaignAttributes( false, preset ) } />
 	);
 }
 
@@ -182,6 +195,50 @@ export const WithComparison: Story = {
 				) => getSalesByUtmCampaignSource( storyContext.args ),
 			},
 		},
+	},
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderSalesByUtmCampaignOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'order-attribution/campaign/summary', 'loading' );
+		return () => setReportMockState( 'order-attribution/campaign/summary', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderSalesByUtmCampaignOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'order-attribution/campaign/summary', 'error' );
+		return () => setReportMockState( 'order-attribution/campaign/summary', null );
+	},
+};
+
+/**
+ * Resolved with no rows: the widget shows its empty state ("No attribution data
+ * in this period.").
+ */
+export const Empty: Story = {
+	render: () => renderSalesByUtmCampaignOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'order-attribution/campaign/summary', 'empty' );
+		return () => setReportMockState( 'order-attribution/campaign/summary', null );
 	},
 };
 

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-channel/stories/sales-by-utm-channel-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-channel/stories/sales-by-utm-channel-widget.stories.tsx
@@ -53,10 +53,7 @@ function renderSalesByUtmChannel( { withComparison, preset }: SalesByUtmChannelS
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderSalesByUtmChannelOnPreset( preset: SelectablePresetId ) {
 	return <SalesByUtmChannelRender attributes={ getSalesByUtmChannelAttributes( false, preset ) } />;
 }
@@ -137,8 +134,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderSalesByUtmChannelOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-channel/stories/sales-by-utm-channel-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-channel/stories/sales-by-utm-channel-widget.stories.tsx
@@ -6,7 +6,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SalesByUtmChannelRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -53,6 +56,14 @@ function renderSalesByUtmChannel( { withComparison, preset }: SalesByUtmChannelS
 			attributes={ getSalesByUtmChannelAttributes( withComparison, preset ) }
 		/>
 	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderSalesByUtmChannelOnPreset( preset: SelectablePresetId ) {
+	return <SalesByUtmChannelRender attributes={ getSalesByUtmChannelAttributes( false, preset ) } />;
 }
 
 function SalesByUtmChannelDashboardStory( {
@@ -123,6 +134,50 @@ export const WithComparison: Story = {
 		withComparison: true,
 	},
 	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderSalesByUtmChannelOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'order-attribution/channel/summary', 'loading' );
+		return () => setReportMockState( 'order-attribution/channel/summary', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderSalesByUtmChannelOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'order-attribution/channel/summary', 'error' );
+		return () => setReportMockState( 'order-attribution/channel/summary', null );
+	},
+};
+
+/**
+ * Resolved with no rows: the widget shows its empty state ("No attribution data
+ * in this period.").
+ */
+export const Empty: Story = {
+	render: () => renderSalesByUtmChannelOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'order-attribution/channel/summary', 'empty' );
+		return () => setReportMockState( 'order-attribution/channel/summary', null );
+	},
 };
 
 /**

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-channel/stories/sales-by-utm-channel-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-channel/stories/sales-by-utm-channel-widget.stories.tsx
@@ -6,13 +6,14 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SalesByUtmChannelRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -34,12 +35,6 @@ type SalesByUtmChannelStoryProps = SalesByUtmChannelWidgetProps & SalesByUtmChan
 interface SalesByUtmChannelDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		SalesByUtmChannelStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getSalesByUtmChannelAttributes(
 	withComparison = false,

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-source/stories/sales-by-utm-source-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-source/stories/sales-by-utm-source-widget.stories.tsx
@@ -6,13 +6,14 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SalesByUtmSourceRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -34,12 +35,6 @@ type SalesByUtmSourceStoryProps = SalesByUtmSourceWidgetProps & SalesByUtmSource
 interface SalesByUtmSourceDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		SalesByUtmSourceStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getSalesByUtmSourceAttributes(
 	withComparison = false,

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-source/stories/sales-by-utm-source-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-source/stories/sales-by-utm-source-widget.stories.tsx
@@ -81,10 +81,7 @@ function renderSalesByUtmSource( { withComparison, preset }: SalesByUtmSourceSto
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderSalesByUtmSourceOnPreset( preset: SelectablePresetId ) {
 	return <SalesByUtmSourceRender attributes={ getSalesByUtmSourceAttributes( false, preset ) } />;
 }
@@ -185,8 +182,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderSalesByUtmSourceOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-source/stories/sales-by-utm-source-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-source/stories/sales-by-utm-source-widget.stories.tsx
@@ -6,7 +6,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SalesByUtmSourceRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -81,6 +84,14 @@ function renderSalesByUtmSource( { withComparison, preset }: SalesByUtmSourceSto
 			attributes={ getSalesByUtmSourceAttributes( withComparison, preset ) }
 		/>
 	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderSalesByUtmSourceOnPreset( preset: SelectablePresetId ) {
+	return <SalesByUtmSourceRender attributes={ getSalesByUtmSourceAttributes( false, preset ) } />;
 }
 
 function SalesByUtmSourceDashboardStory( {
@@ -170,6 +181,50 @@ export const WithComparison: Story = {
 				) => getSalesByUtmSourceSource( storyContext.args ),
 			},
 		},
+	},
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderSalesByUtmSourceOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'order-attribution/source/summary', 'loading' );
+		return () => setReportMockState( 'order-attribution/source/summary', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderSalesByUtmSourceOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'order-attribution/source/summary', 'error' );
+		return () => setReportMockState( 'order-attribution/source/summary', null );
+	},
+};
+
+/**
+ * Resolved with no rows: the widget shows its empty state ("No attribution data
+ * in this period.").
+ */
+export const Empty: Story = {
+	render: () => renderSalesByUtmSourceOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'order-attribution/source/summary', 'empty' );
+		return () => setReportMockState( 'order-attribution/source/summary', null );
 	},
 };
 

--- a/projects/packages/premium-analytics/widgets/search-terms/stories/search-terms-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/search-terms/stories/search-terms-widget.stories.tsx
@@ -41,10 +41,7 @@ function renderSearchTerms( { withComparison }: SearchTermsStoryControls ) {
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderSearchTermsOnPreset( preset: PresetType ) {
 	return (
 		<SearchTermsRender
@@ -96,8 +93,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderSearchTermsOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/search-terms/stories/search-terms-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/search-terms/stories/search-terms-widget.stories.tsx
@@ -5,13 +5,14 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SearchTermsRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -55,26 +56,6 @@ function renderSearchTermsOnPreset( preset: PresetType ) {
 function SearchTermsDashboardRender( props: WidgetRenderProps< unknown > ) {
 	return <SearchTermsRender { ...( props as ComponentProps< typeof SearchTermsRender > ) } />;
 }
-
-// Close-up frame: a white, widget-sized card so each state reads the way it does
-// as a real dashboard widget (in product the host supplies this frame).
-const withWidgetCanvas: Decorator = Story => (
-	<div
-		style={ {
-			width: '380px',
-			height: '520px',
-			margin: '0 auto',
-			padding: '16px',
-			boxSizing: 'border-box',
-			background: '#fff',
-			border: '1px solid #e0e0e0',
-			borderRadius: '8px',
-			overflow: 'hidden',
-		} }
-	>
-		<Story />
-	</div>
-);
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/SearchTerms',

--- a/projects/packages/premium-analytics/widgets/sessions-by-device/stories/sessions-by-device-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sessions-by-device/stories/sessions-by-device-widget.stories.tsx
@@ -81,10 +81,7 @@ function renderSessionsByDevice( { withComparison, preset }: SessionsByDeviceSto
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderSessionsByDeviceOnPreset( preset: SelectablePresetId ) {
 	return <SessionsByDeviceRender attributes={ getSessionsByDeviceAttributes( false, preset ) } />;
 }
@@ -186,8 +183,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderSessionsByDeviceOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/sessions-by-device/stories/sessions-by-device-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sessions-by-device/stories/sessions-by-device-widget.stories.tsx
@@ -6,13 +6,14 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SessionsByDeviceRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -34,12 +35,6 @@ type SessionsByDeviceStoryProps = SessionsByDeviceWidgetProps & SessionsByDevice
 interface SessionsByDeviceDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		SessionsByDeviceStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getSessionsByDeviceAttributes(
 	withComparison = false,

--- a/projects/packages/premium-analytics/widgets/sessions-by-device/stories/sessions-by-device-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sessions-by-device/stories/sessions-by-device-widget.stories.tsx
@@ -6,7 +6,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SessionsByDeviceRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -81,6 +84,14 @@ function renderSessionsByDevice( { withComparison, preset }: SessionsByDeviceSto
 			attributes={ getSessionsByDeviceAttributes( withComparison, preset ) }
 		/>
 	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderSessionsByDeviceOnPreset( preset: SelectablePresetId ) {
+	return <SessionsByDeviceRender attributes={ getSessionsByDeviceAttributes( false, preset ) } />;
 }
 
 function SessionsByDeviceDashboardStory( {
@@ -170,6 +181,52 @@ export const WithComparison: Story = {
 				) => getSessionsByDeviceSource( storyContext.args ),
 			},
 		},
+	},
+};
+
+/**
+ * First load: the sessions-by-device report is in flight, so the widget shows
+ * its loading state. The mock is forced to never resolve for the duration of
+ * this story.
+ */
+export const Loading: Story = {
+	render: () => renderSessionsByDeviceOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'sessions/by-device', 'loading' );
+		return () => setReportMockState( 'sessions/by-device', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action
+ * (which re-runs the query — still mocked as failing while this story is
+ * active).
+ */
+export const Error: Story = {
+	render: () => renderSessionsByDeviceOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'sessions/by-device', 'error' );
+		return () => setReportMockState( 'sessions/by-device', null );
+	},
+};
+
+/**
+ * Resolved with no sessions: the widget shows its empty state ("No session
+ * data in this period.").
+ */
+export const Empty: Story = {
+	render: () => renderSessionsByDeviceOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'sessions/by-device', 'empty' );
+		return () => setReportMockState( 'sessions/by-device', null );
 	},
 };
 

--- a/projects/packages/premium-analytics/widgets/shares/stories/shares-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/shares/stories/shares-widget.stories.tsx
@@ -7,7 +7,7 @@
 /**
  * External dependencies
  */
-import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { getDefaultQueryParams, queryClient } from '@jetpack-premium-analytics/data';
 /**
  * Internal dependencies
  */
@@ -17,16 +17,41 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SharesRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
 
 const SHARES_RENDER_MODULE = 'storybook/shares';
+const SITE_SUMMARY_PATH_FRAGMENT = 'proxy/v1.1/stats';
+
+/**
+ * Forces the all-time site summary into a state for a story's lifetime.
+ *
+ * `useStatsSite()` has a constant query key because its summary ignores the
+ * dashboard date range. Remove that shared entry before and after each forced
+ * story so it reaches the mock and cannot leak its result into another story.
+ *
+ * @param state - The forced report-mock state.
+ * @return The `beforeEach` cleanup callback.
+ */
+function forceSiteSummaryState( state: 'loading' | 'error' | 'empty' ) {
+	queryClient.removeQueries( { queryKey: [ 'stats', 'site' ] } );
+	setReportMockState( SITE_SUMMARY_PATH_FRAGMENT, state );
+
+	return () => {
+		setReportMockState( SITE_SUMMARY_PATH_FRAGMENT, null );
+		queryClient.removeQueries( { queryKey: [ 'stats', 'site' ] } );
+	};
+}
 
 // Pick only the fields that StoryWidgetMetadata accepts; the attribute schema and
 // example arrays are typed differently in WidgetType and cause a type error.
@@ -52,26 +77,6 @@ function renderShares( { withComparison }: SharesStoryControls ) {
 function SharesDashboardRender( props: WidgetRenderProps< unknown > ) {
 	return <SharesRender { ...( props as ComponentProps< typeof SharesRender > ) } />;
 }
-
-// Close-up frame: a white, widget-sized card so the leaderboard reads the way it
-// does as a real dashboard widget (in product the host supplies this frame).
-const withWidgetCanvas: Decorator = Story => (
-	<div
-		style={ {
-			width: '380px',
-			height: '520px',
-			margin: '0 auto',
-			padding: '16px',
-			boxSizing: 'border-box',
-			background: '#fff',
-			border: '1px solid #e0e0e0',
-			borderRadius: '8px',
-			overflow: 'hidden',
-		} }
-	>
-		<Story />
-	</div>
-);
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/Shares',
@@ -120,6 +125,39 @@ export const WithComparison: Story = {
 			},
 		},
 	},
+};
+
+/**
+ * First load: the all-time site summary is in flight, so the widget shows its
+ * loading state. The mock never resolves for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderShares( { withComparison: false } ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => forceSiteSummaryState( 'loading' ),
+};
+
+/**
+ * The site-summary request failed: the widget shows its shares-specific error
+ * state with a Retry action.
+ */
+export const Error: Story = {
+	render: () => renderShares( { withComparison: false } ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => forceSiteSummaryState( 'error' ),
+};
+
+/**
+ * Resolved without positive share counts: the widget shows its empty-state
+ * megaphone and guidance copy.
+ */
+export const Empty: Story = {
+	render: () => renderShares( { withComparison: false } ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => forceSiteSummaryState( 'empty' ),
 };
 
 interface SharesDashboardStoryProps

--- a/projects/packages/premium-analytics/widgets/site-overview/stories/site-overview-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/stories/site-overview-widget.stories.tsx
@@ -24,12 +24,13 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import SiteOverviewRender from '../render';
 import widgetDefinition, {
 	DEFAULT_SITE_OVERVIEW_METRICS,
 	type SiteOverviewMetricId,
 } from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -106,13 +107,6 @@ const METRIC_ARG_TYPES = {
 const ALL_METRICS_ARGS = {
 	metrics: DEFAULT_SITE_OVERVIEW_METRICS,
 } as const;
-
-// Close-up canvas so the metric grid fills the frame outside the dashboard grid.
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', maxWidth: '560px' } }>
-		<Story />
-	</div>
-);
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/SiteOverview',

--- a/projects/packages/premium-analytics/widgets/site-overview/stories/site-overview-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/stories/site-overview-widget.stories.tsx
@@ -79,15 +79,7 @@ function renderSiteOverview( { withComparison, metrics }: SiteOverviewStoryContr
 	);
 }
 
-/**
- * Renders the widget on a preset distinct from the other stories. The query key
- * derives from the date range, so a unique preset gives the forced-state stories
- * their own cache entry and they hit the mock fresh instead of reading another
- * story's cached success from the shared query client.
- *
- * @param preset - The date-range preset for this story.
- * @return The rendered widget.
- */
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderSiteOverviewOnPreset( preset: PresetType ) {
 	return (
 		<SiteOverviewRender
@@ -155,8 +147,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderSiteOverviewOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/stories/store-conversion-rate-bookings-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/stories/store-conversion-rate-bookings-widget.stories.tsx
@@ -8,6 +8,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import StoreConversionRateBookingsRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -163,6 +164,18 @@ function renderStoreConversionRateBookings( {
 	);
 }
 
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderStoreConversionRateBookingsOnPreset( preset: SelectablePresetId ) {
+	return (
+		<StoreConversionRateBookingsRender
+			attributes={ getStoreConversionRateBookingsAttributes( false, preset ) }
+		/>
+	);
+}
+
 /**
  * Renders the store conversion rate bookings widget inside the dashboard story shell.
  *
@@ -261,6 +274,57 @@ export const WithComparison: Story = {
 				) => getStoreConversionRateBookingsSource( storyContext.args ),
 			},
 		},
+	},
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ *
+ * The story's own conversion-rate mock middleware (registered above) would
+ * otherwise shadow `setReportMockState` — it always answers
+ * `sessions/by-conversion-rate` with canned data and never falls through.
+ * `forceStatsMockState` registers its override middleware lazily, on first
+ * call, so it is guaranteed to be the last-registered (and therefore first-run)
+ * middleware here.
+ */
+export const Loading: Story = {
+	render: () => renderStoreConversionRateBookingsOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'sessions/by-conversion-rate', 'loading' );
+		return () => forceStatsMockState( 'sessions/by-conversion-rate', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderStoreConversionRateBookingsOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'sessions/by-conversion-rate', 'error' );
+		return () => forceStatsMockState( 'sessions/by-conversion-rate', null );
+	},
+};
+
+/**
+ * Resolved with no active sessions: the widget shows its empty state ("No
+ * conversion data in this period.").
+ */
+export const Empty: Story = {
+	render: () => renderStoreConversionRateBookingsOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'sessions/by-conversion-rate', 'empty' );
+		return () => forceStatsMockState( 'sessions/by-conversion-rate', null );
 	},
 };
 

--- a/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/stories/store-conversion-rate-bookings-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/stories/store-conversion-rate-bookings-widget.stories.tsx
@@ -159,10 +159,7 @@ function renderStoreConversionRateBookings( {
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderStoreConversionRateBookingsOnPreset( preset: SelectablePresetId ) {
 	return (
 		<StoreConversionRateBookingsRender
@@ -285,8 +282,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderStoreConversionRateBookingsOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/stories/store-conversion-rate-bookings-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/stories/store-conversion-rate-bookings-widget.stories.tsx
@@ -279,9 +279,9 @@ export const WithComparison: Story = {
  * The story's own conversion-rate mock middleware (registered above) would
  * otherwise shadow `setReportMockState` — it always answers
  * `sessions/by-conversion-rate` with canned data and never falls through.
- * `forceStatsMockState` registers its override middleware lazily, on first
- * call, so it is guaranteed to be the last-registered (and therefore first-run)
- * middleware here.
+ * `forceStatsMockState` re-registers its shared override when this story sets a
+ * forced state, keeping it ahead of story-local middleware even if Storybook
+ * lazy-loads another story module later.
  */
 export const Loading: Story = {
 	render: () => renderStoreConversionRateBookingsOnPreset( 'last-90-days' ),

--- a/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/stories/store-conversion-rate-bookings-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/stories/store-conversion-rate-bookings-widget.stories.tsx
@@ -8,10 +8,11 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import StoreConversionRateBookingsRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { APIFetchMiddleware } from '@wordpress/api-fetch';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -46,12 +47,6 @@ type StoreConversionRateBookingsStoryProps = StoreConversionRateBookingsWidgetPr
 interface StoreConversionRateBookingsDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		StoreConversionRateBookingsStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 /**
  * Builds a mock conversion-rate report response.

--- a/projects/packages/premium-analytics/widgets/store-performance/stories/store-performance-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/store-performance/stories/store-performance-widget.stories.tsx
@@ -127,12 +127,15 @@ function renderStorePerformance( {
 // derives from the date range, so a unique preset gives the forced-state stories
 // their own cache entry and they hit the mock fresh instead of reading another
 // story's cached success from the shared query client.
-function renderStorePerformanceOnPreset( preset: SelectablePresetId ) {
+function renderStorePerformanceOnPreset(
+	preset: SelectablePresetId,
+	metrics: StorePerformanceMetricId[] = DEFAULT_STORE_PERFORMANCE_METRICS
+) {
 	ensureLineChartComposition();
 
 	return (
 		<StorePerformanceRender
-			attributes={ getStorePerformanceAttributes( { withComparison: false, preset } ) }
+			attributes={ getStorePerformanceAttributes( { withComparison: false, preset, metrics } ) }
 		/>
 	);
 }
@@ -277,6 +280,16 @@ export const Error: Story = {
 		setAllReportMockStates( 'error' );
 		return () => setAllReportMockStates( null );
 	},
+};
+
+/**
+ * No metrics selected: the widget has no tabs to show, so it renders its empty
+ * state before fetching reports.
+ */
+export const Empty: Story = {
+	render: () => renderStorePerformanceOnPreset( 'last-365-days', [] ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
 };
 
 /**

--- a/projects/packages/premium-analytics/widgets/store-performance/stories/store-performance-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/store-performance/stories/store-performance-widget.stories.tsx
@@ -1,7 +1,10 @@
 import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
 import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
 import LineChart from '../../../../../js-packages/charts/src/charts/line-chart/line-chart';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
@@ -125,6 +128,35 @@ function renderStorePerformance( {
 	);
 }
 
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderStorePerformanceOnPreset( preset: SelectablePresetId ) {
+	ensureLineChartComposition();
+
+	return (
+		<StorePerformanceRender
+			attributes={ getStorePerformanceAttributes( { withComparison: false, preset } ) }
+		/>
+	);
+}
+
+// Every report endpoint behind the widget's default metrics (net sales/orders,
+// bookings, visitors, conversion rate, customers). State stories force all of
+// them so no metric report resolves with data.
+const STORE_PERFORMANCE_ENDPOINTS = [
+	'orders/by-date',
+	'orders-by-product-type/by-date',
+	'sessions/by-date',
+	'sessions/by-conversion-rate',
+	'customers/by-date',
+] as const;
+
+function setAllReportMockStates( state: 'loading' | 'error' | null ) {
+	STORE_PERFORMANCE_ENDPOINTS.forEach( endpoint => setReportMockState( endpoint, state ) );
+}
+
 function StorePerformanceDashboardStory( {
 	withComparison,
 	preset,
@@ -218,6 +250,37 @@ export const WithComparison: Story = {
 				) => getStorePerformanceSource( storyContext.args ),
 			},
 		},
+	},
+};
+
+/**
+ * First load: every metric report is in flight, so the widget shows its loading
+ * state. The mocks are forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderStorePerformanceOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setAllReportMockStates( 'loading' );
+		return () => setAllReportMockStates( null );
+	},
+};
+
+/**
+ * Every metric report failed: the widget shows its error state with a Retry
+ * action (which re-runs all queries — still mocked as failing while this story
+ * is active).
+ */
+export const Error: Story = {
+	render: () => renderStorePerformanceOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setAllReportMockStates( 'error' );
+		return () => setAllReportMockStates( null );
 	},
 };
 

--- a/projects/packages/premium-analytics/widgets/store-performance/stories/store-performance-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/store-performance/stories/store-performance-widget.stories.tsx
@@ -123,10 +123,7 @@ function renderStorePerformance( {
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderStorePerformanceOnPreset(
 	preset: SelectablePresetId,
 	metrics: StorePerformanceMetricId[] = DEFAULT_STORE_PERFORMANCE_METRICS
@@ -257,8 +254,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderStorePerformanceOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/store-performance/stories/store-performance-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/store-performance/stories/store-performance-widget.stories.tsx
@@ -11,10 +11,11 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import { DEFAULT_STORE_PERFORMANCE_METRICS, type StorePerformanceMetricId } from '../metrics';
 import StorePerformanceRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -61,12 +62,6 @@ type StorePerformanceStoryProps = StorePerformanceRenderProps & StorePerformance
 interface StorePerformanceDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		StorePerformanceStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '420px' } }>
-		<Story />
-	</div>
-);
 
 function getStorePerformanceAttributes( {
 	withComparison = false,

--- a/projects/packages/premium-analytics/widgets/stories/force-stats-mock-state.ts
+++ b/projects/packages/premium-analytics/widgets/stories/force-stats-mock-state.ts
@@ -1,0 +1,70 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+import type { APIFetchMiddleware, APIFetchOptions } from '@wordpress/api-fetch';
+
+type ForcedMockState = 'error' | 'loading' | 'empty';
+
+const stateOverrides = new Map< string, ForcedMockState >();
+
+const forcedStateMiddleware: APIFetchMiddleware = async ( options: APIFetchOptions, next ) => {
+	const requestPath = options.path ?? options.url ?? '';
+
+	for ( const [ fragment, state ] of stateOverrides ) {
+		if ( ! requestPath.includes( fragment ) ) {
+			continue;
+		}
+		if ( state === 'loading' ) {
+			// Never settles: the query stays in its loading state.
+			return new Promise< never >( () => {} );
+		}
+		if ( state === 'empty' ) {
+			// A valid response with no rows across the shapes report sanitizers read
+			// (`summary` / `days` / `data`), so the widget resolves to its empty state.
+			return { date: '2026-01-01', period: 'day', summary: {}, days: {}, data: [] };
+		}
+		// A 403 is not retried by `shouldRetryApiError`, so the error UI shows at
+		// once instead of after the query's retry backoff.
+		return Promise.reject( {
+			code: 'stats_mock_error',
+			message: 'Mocked error response for Storybook.',
+			data: { status: 403 },
+		} );
+	}
+
+	return next( options );
+};
+
+let registered = false;
+
+/**
+ * Story-side counterpart of `setReportMockState` for Stats endpoints owned by
+ * the legacy stats mocks (`register-stats-mocks.ts`), e.g. `stats/clicks` and
+ * `stats/referrers`.
+ *
+ * The shared override in `register-report-mocks.ts` never sees those requests:
+ * the last-registered `apiFetch` middleware runs first, and `registerStatsMocks()`
+ * always registers after `registerReportMocks()` in the story modules, so the
+ * legacy middleware answers the endpoints it knows before the override loop can
+ * intercept them. This helper registers its own middleware lazily on first use —
+ * i.e. after every mock registration — so it is guaranteed to run first.
+ *
+ * Same contract as `setReportMockState`: call it in a story's `beforeEach` and
+ * clear the override with `null` in the returned cleanup.
+ *
+ * @param pathFragment - Substring matched against the request path (e.g. `stats/clicks`).
+ * @param state        - The forced state, or `null` to clear.
+ */
+export function forceStatsMockState( pathFragment: string, state: ForcedMockState | null ): void {
+	if ( ! registered ) {
+		registered = true;
+		apiFetch.use( forcedStateMiddleware );
+	}
+
+	if ( state === null ) {
+		stateOverrides.delete( pathFragment );
+	} else {
+		stateOverrides.set( pathFragment, state );
+	}
+}

--- a/projects/packages/premium-analytics/widgets/stories/force-stats-mock-state.ts
+++ b/projects/packages/premium-analytics/widgets/stories/force-stats-mock-state.ts
@@ -53,6 +53,18 @@ const forcedStateMiddleware: APIFetchMiddleware = async ( options: APIFetchOptio
  * Same contract as `setReportMockState`: call it in a story's `beforeEach` and
  * clear the override with `null` in the returned cleanup.
  *
+ * Conventions for the forced-state stories that drive this helper (the per-story
+ * comments point here rather than repeating the rationale in every widget file):
+ * - Tag them `!autodocs`. The override is keyed by path, so on the shared
+ *   autodocs page it would force every sibling story into the same state.
+ * - Render each on a date preset distinct from the widget's other stories. The
+ *   query key derives from the date range, so a unique preset gives the story
+ *   its own cache entry and it hits the mock fresh instead of reading another
+ *   story's cached success from the shared query client. When a widget's query
+ *   key carries no date params, a distinct preset can't isolate it — evict the
+ *   query from the shared client on enter and cleanup instead (see the
+ *   `latest-post` stories).
+ *
  * @param pathFragment - Substring matched against the request path (e.g. `stats/clicks`).
  * @param state        - The forced state, or `null` to clear.
  */

--- a/projects/packages/premium-analytics/widgets/stories/force-stats-mock-state.ts
+++ b/projects/packages/premium-analytics/widgets/stories/force-stats-mock-state.ts
@@ -36,19 +36,19 @@ const forcedStateMiddleware: APIFetchMiddleware = async ( options: APIFetchOptio
 	return next( options );
 };
 
-let registered = false;
-
 /**
- * Story-side counterpart of `setReportMockState` for Stats endpoints owned by
- * the legacy stats mocks (`register-stats-mocks.ts`), e.g. `stats/clicks` and
- * `stats/referrers`.
+ * Story-side counterpart of `setReportMockState` for endpoints owned by
+ * story-local or legacy stats mocks, e.g. `stats/clicks`, `stats/referrers`,
+ * `reports/products`, or `latest-post`.
  *
- * The shared override in `register-report-mocks.ts` never sees those requests:
- * the last-registered `apiFetch` middleware runs first, and `registerStatsMocks()`
- * always registers after `registerReportMocks()` in the story modules, so the
- * legacy middleware answers the endpoints it knows before the override loop can
- * intercept them. This helper registers its own middleware lazily on first use —
- * i.e. after every mock registration — so it is guaranteed to run first.
+ * The shared override in `register-report-mocks.ts` can miss those requests:
+ * the last-registered `apiFetch` middleware runs first, so legacy stats mocks or
+ * story-local endpoint mocks can answer before the shared override loop sees
+ * the request. Storybook can lazy-load more story modules later, so this helper
+ * re-registers its shared middleware whenever a forced state is set. The
+ * duplicate registrations are intentional: they share the same override map and
+ * keep the forced-state middleware ahead of any later endpoint-specific
+ * middleware.
  *
  * Same contract as `setReportMockState`: call it in a story's `beforeEach` and
  * clear the override with `null` in the returned cleanup.
@@ -57,14 +57,10 @@ let registered = false;
  * @param state        - The forced state, or `null` to clear.
  */
 export function forceStatsMockState( pathFragment: string, state: ForcedMockState | null ): void {
-	if ( ! registered ) {
-		registered = true;
-		apiFetch.use( forcedStateMiddleware );
-	}
-
 	if ( state === null ) {
 		stateOverrides.delete( pathFragment );
 	} else {
+		apiFetch.use( forcedStateMiddleware );
 		stateOverrides.set( pathFragment, state );
 	}
 }

--- a/projects/packages/premium-analytics/widgets/stories/with-widget-canvas.tsx
+++ b/projects/packages/premium-analytics/widgets/stories/with-widget-canvas.tsx
@@ -1,0 +1,67 @@
+import { useLayoutEffect, useRef } from 'react';
+import type { Decorator } from '@storybook/react';
+import type { ReactNode } from 'react';
+
+// Frame the widget root the way the dashboard host cell does at runtime, so the
+// loading / error / empty states render correctly in the close-up card:
+// - `position: relative` gives the absolute `WidgetLoadingOverlay` a frame to
+//   fill instead of escaping to the Storybook page and centering off-card.
+// - `justify-content: safe center` vertically centers a state shorter than the
+//   frame (the `height: 100%` error/empty boxes otherwise cling to the top);
+//   `safe` falls back to top alignment when content is taller, so a full
+//   leaderboard is never clipped at the top.
+//
+// The styles are applied to the widget's own root (the element WidgetRoot marks
+// with `container-name: widget`) rather than via a CSS descendant selector,
+// because Storybook inserts a `display: contents` wrapper of varying depth
+// between the card and the widget that makes positional selectors unreliable.
+function frameWidgetRoot( host: HTMLElement | null ) {
+	if ( ! host ) {
+		return;
+	}
+	const widgetRoot = Array.from( host.querySelectorAll< HTMLElement >( '*' ) ).find(
+		el => getComputedStyle( el ).containerName === 'widget'
+	);
+	if ( ! widgetRoot ) {
+		return;
+	}
+	widgetRoot.style.position = 'relative';
+	widgetRoot.style.display = 'flex';
+	widgetRoot.style.flexDirection = 'column';
+	widgetRoot.style.justifyContent = 'safe center';
+}
+
+// A white, widget-sized card that frames a story the way the dashboard host frames a
+// widget in product, so each state (ready / loading / error / empty) reads as a real
+// dashboard widget rather than a bare fragment on the Storybook canvas.
+export function WidgetCanvas( { children }: { children: ReactNode } ) {
+	const hostRef = useRef< HTMLDivElement >( null );
+	useLayoutEffect( () => {
+		frameWidgetRoot( hostRef.current );
+	} );
+	return (
+		<div
+			ref={ hostRef }
+			style={ {
+				width: '380px',
+				height: '440px',
+				margin: '0 auto',
+				padding: '16px',
+				boxSizing: 'border-box',
+				background: '#fff',
+				border: '1px solid #e0e0e0',
+				borderRadius: '8px',
+				overflow: 'hidden',
+			} }
+		>
+			{ children }
+		</div>
+	);
+}
+
+// Decorator form of WidgetCanvas for the close-up widget stories.
+export const withWidgetCanvas: Decorator = Story => (
+	<WidgetCanvas>
+		<Story />
+	</WidgetCanvas>
+);

--- a/projects/packages/premium-analytics/widgets/subscriber-highlights/stories/subscriber-highlights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/subscriber-highlights/stories/subscriber-highlights-widget.stories.tsx
@@ -145,8 +145,7 @@ function resetSubscribersCountsQuery() {
 export const Loading: Story = {
 	render: renderSubscriberHighlights,
 	args: { withComparison: false, ...ALL_METRICS_ARGS },
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/subscriber-highlights/stories/subscriber-highlights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/subscriber-highlights/stories/subscriber-highlights-widget.stories.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { getDefaultQueryParams, queryClient } from '@jetpack-premium-analytics/data';
 /**
  * Internal dependencies
  */
@@ -11,7 +11,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SubscriberHighlightsRender from '../render';
 import widgetDefinition, { DEFAULT_SUBSCRIBER_METRICS, type SubscriberMetricId } from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -130,6 +133,74 @@ export const WithComparison: Story = {
 	render: renderSubscriberHighlights,
 	args: { withComparison: true, ...ALL_METRICS_ARGS },
 	decorators: [ withWidgetCanvas ],
+};
+
+// The counts endpoint takes no params, so its query key is static and every
+// story in this file shares one cache entry (a distinct date preset can't
+// separate them — the query does not key on report params). Dropping the query
+// on story enter and exit gives each forced-state story a fresh fetch, and
+// clears a never-settling `loading` fetch before the other stories reuse the key.
+function resetSubscribersCountsQuery() {
+	queryClient.removeQueries( { queryKey: [ 'stats', 'subscribers-counts' ] } );
+}
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: renderSubscriberHighlights,
+	args: { withComparison: false, ...ALL_METRICS_ARGS },
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		resetSubscribersCountsQuery();
+		setReportMockState( 'subscribers/counts', 'loading' );
+		return () => {
+			setReportMockState( 'subscribers/counts', null );
+			resetSubscribersCountsQuery();
+		};
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: renderSubscriberHighlights,
+	args: { withComparison: false, ...ALL_METRICS_ARGS },
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		resetSubscribersCountsQuery();
+		setReportMockState( 'subscribers/counts', 'error' );
+		return () => {
+			setReportMockState( 'subscribers/counts', null );
+			resetSubscribersCountsQuery();
+		};
+	},
+};
+
+/**
+ * Resolved without counts: the widget shows its empty state (the neutral
+ * customer glyph and "No subscriber counts available yet.").
+ */
+export const Empty: Story = {
+	render: renderSubscriberHighlights,
+	args: { withComparison: false, ...ALL_METRICS_ARGS },
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		resetSubscribersCountsQuery();
+		setReportMockState( 'subscribers/counts', 'empty' );
+		return () => {
+			setReportMockState( 'subscribers/counts', null );
+			resetSubscribersCountsQuery();
+		};
+	},
 };
 
 interface SubscriberHighlightsDashboardStoryProps

--- a/projects/packages/premium-analytics/widgets/subscriber-highlights/stories/subscriber-highlights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/subscriber-highlights/stories/subscriber-highlights-widget.stories.tsx
@@ -11,13 +11,14 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SubscriberHighlightsRender from '../render';
 import widgetDefinition, { DEFAULT_SUBSCRIBER_METRICS, type SubscriberMetricId } from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -83,13 +84,6 @@ const METRIC_ARG_TYPES = {
 const ALL_METRICS_ARGS = {
 	metrics: DEFAULT_SUBSCRIBER_METRICS,
 } as const;
-
-// Close-up canvas so the grid fills the frame outside the dashboard grid.
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/SubscriberHighlights',

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/stories/subscribers-chart-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/stories/subscribers-chart-widget.stories.tsx
@@ -21,7 +21,7 @@ import widgetDefinition, {
 	DEFAULT_SUBSCRIBERS_CHART_METRICS,
 	type SubscribersChartMetricId,
 } from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -65,10 +65,7 @@ function renderSubscribersChart( { withComparison, metrics }: SubscribersChartSt
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderSubscribersChartOnPreset( preset: PresetType ) {
 	return (
 		<SubscribersChartRender
@@ -125,8 +122,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderSubscribersChartOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/stories/subscribers-chart-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/stories/subscribers-chart-widget.stories.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { getDefaultQueryParams, type PresetType } from '@jetpack-premium-analytics/data';
 /**
  * Internal dependencies
  */
@@ -11,7 +11,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SubscribersChartRender from '../render';
 import widgetDefinition, {
 	DEFAULT_SUBSCRIBERS_CHART_METRICS,
@@ -57,6 +60,18 @@ function renderSubscribersChart( { withComparison, metrics }: SubscribersChartSt
 	return (
 		<SubscribersChartRender
 			attributes={ { reportParams: getDefaultQueryParams( withComparison ), metrics } }
+		/>
+	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderSubscribersChartOnPreset( preset: PresetType ) {
+	return (
+		<SubscribersChartRender
+			attributes={ { reportParams: getDefaultQueryParams( false, preset ) } }
 		/>
 	);
 }
@@ -107,6 +122,51 @@ export const WithComparison: Story = {
 	render: renderSubscribersChart,
 	args: { withComparison: true, ...ALL_METRICS_ARGS },
 	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state (the
+ * metric tabs over the chart's loading overlay). The mock is forced to never
+ * resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderSubscribersChartOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'stats/subscribers', 'loading' );
+		return () => setReportMockState( 'stats/subscribers', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderSubscribersChartOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'stats/subscribers', 'error' );
+		return () => setReportMockState( 'stats/subscribers', null );
+	},
+};
+
+/**
+ * Resolved with no points: the widget shows its empty state (the neutral
+ * customer glyph and "No subscriber data in this period.").
+ */
+export const Empty: Story = {
+	render: () => renderSubscribersChartOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'stats/subscribers', 'empty' );
+		return () => setReportMockState( 'stats/subscribers', null );
+	},
 };
 
 interface SubscribersChartDashboardStoryProps

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/stories/subscribers-chart-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/stories/subscribers-chart-widget.stories.tsx
@@ -11,6 +11,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
@@ -75,13 +76,6 @@ function renderSubscribersChartOnPreset( preset: PresetType ) {
 		/>
 	);
 }
-
-// Close-up canvas so the chart fills the frame outside the dashboard grid.
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '360px' } }>
-		<Story />
-	</div>
-);
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/SubscribersChart',

--- a/projects/packages/premium-analytics/widgets/subscribers-list/stories/subscribers-list-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-list/stories/subscribers-list-widget.stories.tsx
@@ -64,8 +64,7 @@ function renderSubscribersListWithNum( num: number ) {
  */
 export const Loading: Story = {
 	render: () => renderSubscribersListWithNum( 5 ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/subscribers-list/stories/subscribers-list-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-list/stories/subscribers-list-widget.stories.tsx
@@ -7,26 +7,20 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SubscribersListRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentType } from 'react';
 
 registerReportMocks();
 
 const SUBSCRIBERS_LIST_RENDER_MODULE = 'storybook/subscribers-list';
-
-// Close-up canvas so the roster fills the frame outside the dashboard grid.
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '360px' } }>
-		<Story />
-	</div>
-);
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/SubscribersList',

--- a/projects/packages/premium-analytics/widgets/subscribers-list/stories/subscribers-list-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-list/stories/subscribers-list-widget.stories.tsx
@@ -7,7 +7,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SubscribersListRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -50,6 +53,59 @@ type DashboardStory = StoryObj< WidgetDashboardWithWidgetControls >;
 export const Default: Story = {
 	render: () => <SubscribersListRender attributes={ { num: 6 } } />,
 	decorators: [ withWidgetCanvas ],
+};
+
+// Renders the widget with a `num` distinct from the other stories. The
+// followers query has no date range — its key carries the row count (`max`) —
+// so a unique `num` gives each forced-state story its own cache entry and it
+// hits the mock fresh instead of reading another story's cached success from
+// the shared query client.
+function renderSubscribersListWithNum( num: number ) {
+	return <SubscribersListRender attributes={ { num } } />;
+}
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderSubscribersListWithNum( 5 ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'stats/followers', 'loading' );
+		return () => setReportMockState( 'stats/followers', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderSubscribersListWithNum( 7 ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'stats/followers', 'error' );
+		return () => setReportMockState( 'stats/followers', null );
+	},
+};
+
+/**
+ * Resolved with no rows: the widget shows its empty state (the neutral customer
+ * glyph and "No subscribers yet.").
+ */
+export const Empty: Story = {
+	render: () => renderSubscribersListWithNum( 8 ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'stats/followers', 'empty' );
+		return () => setReportMockState( 'stats/followers', null );
+	},
 };
 
 /**

--- a/projects/packages/premium-analytics/widgets/top-performing-bookings/stories/top-performing-bookings-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-performing-bookings/stories/top-performing-bookings-widget.stories.tsx
@@ -8,11 +8,12 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import TopPerformingBookingsRender from '../render';
 import widgetDefinition from '../widget';
 import type { APIFetchMiddleware } from '@wordpress/api-fetch';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -156,12 +157,6 @@ type TopPerformingBookingsStoryProps = TopPerformingBookingsWidgetProps &
 interface TopPerformingBookingsDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		TopPerformingBookingsStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getTopPerformingBookingsAttributes(
 	withComparison = false,

--- a/projects/packages/premium-analytics/widgets/top-performing-bookings/stories/top-performing-bookings-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-performing-bookings/stories/top-performing-bookings-widget.stories.tsx
@@ -324,9 +324,10 @@ export const WithComparison: Story = {
  *
  * The story's own product/image mock middleware (registered above) would
  * otherwise shadow `setReportMockState` — it always answers `reports/products`
- * with canned data and never falls through. `forceStatsMockState` registers its
- * override middleware lazily, on first call, so it is guaranteed to be the
- * last-registered (and therefore first-run) middleware here.
+ * with canned data and never falls through. `forceStatsMockState` re-registers
+ * its shared override when this story sets a forced state, keeping it ahead of
+ * story-local middleware even if Storybook lazy-loads another story module
+ * later.
  */
 export const Loading: Story = {
 	render: () => renderTopPerformingBookingsOnPreset( 'last-90-days' ),

--- a/projects/packages/premium-analytics/widgets/top-performing-bookings/stories/top-performing-bookings-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-performing-bookings/stories/top-performing-bookings-widget.stories.tsx
@@ -206,10 +206,7 @@ function renderTopPerformingBookings( {
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderTopPerformingBookingsOnPreset( preset: SelectablePresetId ) {
 	return (
 		<TopPerformingBookingsRender
@@ -331,8 +328,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderTopPerformingBookingsOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/top-performing-bookings/stories/top-performing-bookings-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-performing-bookings/stories/top-performing-bookings-widget.stories.tsx
@@ -8,6 +8,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import TopPerformingBookingsRender from '../render';
 import widgetDefinition from '../widget';
 import type { APIFetchMiddleware } from '@wordpress/api-fetch';
@@ -210,6 +211,18 @@ function renderTopPerformingBookings( {
 	);
 }
 
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderTopPerformingBookingsOnPreset( preset: SelectablePresetId ) {
+	return (
+		<TopPerformingBookingsRender
+			attributes={ getTopPerformingBookingsAttributes( false, preset ) }
+		/>
+	);
+}
+
 /**
  * Story wrapper for rendering the top performing bookings widget in dashboard chrome.
  *
@@ -307,6 +320,56 @@ export const WithComparison: Story = {
 				) => getTopPerformingBookingsSource( storyContext.args ),
 			},
 		},
+	},
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ *
+ * The story's own product/image mock middleware (registered above) would
+ * otherwise shadow `setReportMockState` — it always answers `reports/products`
+ * with canned data and never falls through. `forceStatsMockState` registers its
+ * override middleware lazily, on first call, so it is guaranteed to be the
+ * last-registered (and therefore first-run) middleware here.
+ */
+export const Loading: Story = {
+	render: () => renderTopPerformingBookingsOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'reports/products', 'loading' );
+		return () => forceStatsMockState( 'reports/products', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderTopPerformingBookingsOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'reports/products', 'error' );
+		return () => forceStatsMockState( 'reports/products', null );
+	},
+};
+
+/**
+ * Resolved with no rows: the widget shows its empty state ("No booking sales in
+ * this period.").
+ */
+export const Empty: Story = {
+	render: () => renderTopPerformingBookingsOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'reports/products', 'empty' );
+		return () => forceStatsMockState( 'reports/products', null );
 	},
 };
 

--- a/projects/packages/premium-analytics/widgets/top-performing-products/stories/top-performing-products-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-performing-products/stories/top-performing-products-widget.stories.tsx
@@ -8,11 +8,12 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import TopPerformingProductsRender from '../render';
 import widgetDefinition from '../widget';
 import type { APIFetchMiddleware } from '@wordpress/api-fetch';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -151,12 +152,6 @@ type TopPerformingProductsStoryProps = TopPerformingProductsWidgetProps &
 interface TopPerformingProductsDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		TopPerformingProductsStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getTopPerformingProductsAttributes(
 	withComparison = false,

--- a/projects/packages/premium-analytics/widgets/top-performing-products/stories/top-performing-products-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-performing-products/stories/top-performing-products-widget.stories.tsx
@@ -203,10 +203,7 @@ function renderTopPerformingProducts( {
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderTopPerformingProductsOnPreset( preset: SelectablePresetId ) {
 	return (
 		<TopPerformingProductsRender
@@ -321,8 +318,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderTopPerformingProductsOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/top-performing-products/stories/top-performing-products-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-performing-products/stories/top-performing-products-widget.stories.tsx
@@ -8,6 +8,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import TopPerformingProductsRender from '../render';
 import widgetDefinition from '../widget';
 import type { APIFetchMiddleware } from '@wordpress/api-fetch';
@@ -207,6 +208,19 @@ function renderTopPerformingProducts( {
 	);
 }
 
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderTopPerformingProductsOnPreset( preset: SelectablePresetId ) {
+	return (
+		<TopPerformingProductsRender
+			attributes={ getTopPerformingProductsAttributes( false, preset ) }
+			setError={ noopSetError }
+		/>
+	);
+}
+
 function TopPerformingProductsDashboardStory( {
 	withComparison,
 	preset,
@@ -296,6 +310,56 @@ export const WithComparison: Story = {
 				) => getTopPerformingProductsSource( storyContext.args ),
 			},
 		},
+	},
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ *
+ * The story's own product/image mock middleware (registered above) would
+ * otherwise shadow `setReportMockState` — it always answers `reports/products`
+ * with canned data and never falls through. `forceStatsMockState` registers its
+ * override middleware lazily, on first call, so it is guaranteed to be the
+ * last-registered (and therefore first-run) middleware here.
+ */
+export const Loading: Story = {
+	render: () => renderTopPerformingProductsOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'reports/products', 'loading' );
+		return () => forceStatsMockState( 'reports/products', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderTopPerformingProductsOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'reports/products', 'error' );
+		return () => forceStatsMockState( 'reports/products', null );
+	},
+};
+
+/**
+ * Resolved with no rows: the widget shows its empty state ("No product sales in
+ * this period.").
+ */
+export const Empty: Story = {
+	render: () => renderTopPerformingProductsOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'reports/products', 'empty' );
+		return () => forceStatsMockState( 'reports/products', null );
 	},
 };
 

--- a/projects/packages/premium-analytics/widgets/top-performing-products/stories/top-performing-products-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-performing-products/stories/top-performing-products-widget.stories.tsx
@@ -314,9 +314,10 @@ export const WithComparison: Story = {
  *
  * The story's own product/image mock middleware (registered above) would
  * otherwise shadow `setReportMockState` — it always answers `reports/products`
- * with canned data and never falls through. `forceStatsMockState` registers its
- * override middleware lazily, on first call, so it is guaranteed to be the
- * last-registered (and therefore first-run) middleware here.
+ * with canned data and never falls through. `forceStatsMockState` re-registers
+ * its shared override when this story sets a forced state, keeping it ahead of
+ * story-local middleware even if Storybook lazy-loads another story module
+ * later.
  */
 export const Loading: Story = {
 	render: () => renderTopPerformingProductsOnPreset( 'last-90-days' ),

--- a/projects/packages/premium-analytics/widgets/top-platforms/stories/top-platforms-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-platforms/stories/top-platforms-widget.stories.tsx
@@ -1,4 +1,4 @@
-import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { getDefaultQueryParams, type PresetType } from '@jetpack-premium-analytics/data';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
@@ -7,6 +7,7 @@ import {
 } from '../../stories/widget-dashboard-with-widget';
 import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import { registerStatsMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-stats-mocks';
+import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import TopPlatformsRender from '../render';
 import widgetDefinition, { type TopPlatformsAttributes } from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -57,6 +58,22 @@ function getTopPlatformsAttributes( {
 
 function renderTopPlatformsWidget( controls: TopPlatformsStoryControls ) {
 	return <TopPlatformsRender attributes={ getTopPlatformsAttributes( controls ) } />;
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderTopPlatformsOnPreset( preset: PresetType ) {
+	return (
+		<TopPlatformsRender
+			attributes={ {
+				max: 10,
+				platformDimension: 'browser',
+				reportParams: getDefaultQueryParams( false, preset ),
+			} }
+		/>
+	);
 }
 
 function TopPlatformsDashboardRender( props: WidgetRenderProps< unknown > ) {
@@ -127,6 +144,50 @@ export const ByOS: StoryObj< TopPlatformsStoryControls > = {
 	render: renderTopPlatformsWidget,
 	args: { withComparison: false, platformDimension: 'platform' },
 	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: StoryObj< TopPlatformsStoryControls > = {
+	render: () => renderTopPlatformsOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'stats/devices', 'loading' );
+		return () => forceStatsMockState( 'stats/devices', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: StoryObj< TopPlatformsStoryControls > = {
+	render: () => renderTopPlatformsOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'stats/devices', 'error' );
+		return () => forceStatsMockState( 'stats/devices', null );
+	},
+};
+
+/**
+ * Resolved with no rows: the widget shows its empty state (the neutral device
+ * glyph and "No platform data in this period.").
+ */
+export const Empty: StoryObj< TopPlatformsStoryControls > = {
+	render: () => renderTopPlatformsOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'stats/devices', 'empty' );
+		return () => forceStatsMockState( 'stats/devices', null );
+	},
 };
 
 export const WidgetDashboardWithWidget: DashboardStory = {

--- a/projects/packages/premium-analytics/widgets/top-platforms/stories/top-platforms-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-platforms/stories/top-platforms-widget.stories.tsx
@@ -55,10 +55,7 @@ function renderTopPlatformsWidget( controls: TopPlatformsStoryControls ) {
 	return <TopPlatformsRender attributes={ getTopPlatformsAttributes( controls ) } />;
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderTopPlatformsOnPreset( preset: PresetType ) {
 	return (
 		<TopPlatformsRender
@@ -147,8 +144,7 @@ export const ByOS: StoryObj< TopPlatformsStoryControls > = {
  */
 export const Loading: StoryObj< TopPlatformsStoryControls > = {
 	render: () => renderTopPlatformsOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/top-platforms/stories/top-platforms-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-platforms/stories/top-platforms-widget.stories.tsx
@@ -5,12 +5,13 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import { registerStatsMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-stats-mocks';
 import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import TopPlatformsRender from '../render';
 import widgetDefinition, { type TopPlatformsAttributes } from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -38,12 +39,6 @@ interface TopPlatformsStoryControls {
 interface TopPlatformsDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		TopPlatformsStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getTopPlatformsAttributes( {
 	withComparison,

--- a/projects/packages/premium-analytics/widgets/top-posts/stories/top-posts.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-posts/stories/top-posts.stories.tsx
@@ -1,11 +1,14 @@
 /**
  * External dependencies
  */
-import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { getDefaultQueryParams, type PresetType } from '@jetpack-premium-analytics/data';
 /**
  * Internal dependencies
  */
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import { registerStatsMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-stats-mocks';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
@@ -14,6 +17,7 @@ import {
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
 import { withStoryRouter } from '../../stories/with-story-router';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import TopPostsRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -45,7 +49,7 @@ interface TopPostsDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		TopPostsStoryControls {}
 
-const withWidgetCanvas: Decorator = Story => (
+const withTopPostsCanvas: Decorator = Story => (
 	<div style={ { width: '100%', height: '340px' } }>
 		<Story />
 	</div>
@@ -117,19 +121,19 @@ type DashboardStory = StoryObj< TopPostsDashboardStoryProps >;
 export const Default: Story = {
 	render: renderTopPostsWidget,
 	args: { withComparison: false, contentView: 'posts' },
-	decorators: [ withWidgetCanvas, withStoryRouter ],
+	decorators: [ withTopPostsCanvas, withStoryRouter ],
 };
 
 export const WithComparison: Story = {
 	render: renderTopPostsWidget,
 	args: { withComparison: true, contentView: 'posts' },
-	decorators: [ withWidgetCanvas, withStoryRouter ],
+	decorators: [ withTopPostsCanvas, withStoryRouter ],
 };
 
 export const Archives: Story = {
 	render: renderTopPostsWidget,
 	args: { withComparison: true, contentView: 'archives' },
-	decorators: [ withWidgetCanvas, withStoryRouter ],
+	decorators: [ withTopPostsCanvas, withStoryRouter ],
 	parameters: {
 		docs: {
 			description: {
@@ -153,5 +157,62 @@ export const WidgetDashboardWithWidget: DashboardStory = {
 			control: 'boolean',
 			description: 'Include previous-period comparison report params and deltas.',
 		},
+	},
+};
+
+// Use distinct presets so each forced-state story has its own query-cache entry.
+function renderTopPostsOnPreset( preset: PresetType ) {
+	return (
+		<TopPostsRender
+			attributes={ {
+				num: 10,
+				contentView: 'posts',
+				reportParams: getDefaultQueryParams( false, preset ),
+			} }
+		/>
+	);
+}
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderTopPostsOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
+	beforeEach: () => {
+		setReportMockState( 'stats/top-posts', 'loading' );
+		return () => setReportMockState( 'stats/top-posts', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderTopPostsOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
+	beforeEach: () => {
+		setReportMockState( 'stats/top-posts', 'error' );
+		return () => setReportMockState( 'stats/top-posts', null );
+	},
+};
+
+/**
+ * Resolved with no rows: the widget shows its empty state (the neutral chart
+ * glyph and "No views in this period.").
+ */
+export const Empty: Story = {
+	render: () => renderTopPostsOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
+	beforeEach: () => {
+		setReportMockState( 'stats/top-posts', 'empty' );
+		return () => setReportMockState( 'stats/top-posts', null );
 	},
 };

--- a/projects/packages/premium-analytics/widgets/top-posts/stories/top-posts.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-posts/stories/top-posts.stories.tsx
@@ -160,7 +160,7 @@ export const WidgetDashboardWithWidget: DashboardStory = {
 	},
 };
 
-// Use distinct presets so each forced-state story has its own query-cache entry.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderTopPostsOnPreset( preset: PresetType ) {
 	return (
 		<TopPostsRender
@@ -179,8 +179,7 @@ function renderTopPostsOnPreset( preset: PresetType ) {
  */
 export const Loading: Story = {
 	render: () => renderTopPostsOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas, withStoryRouter ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/top-posts/stories/top-posts.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-posts/stories/top-posts.stories.tsx
@@ -5,10 +5,7 @@ import { getDefaultQueryParams, type PresetType } from '@jetpack-premium-analyti
 /**
  * Internal dependencies
  */
-import {
-	registerReportMocks,
-	setReportMockState,
-} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import { registerStatsMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-stats-mocks';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
@@ -16,6 +13,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import { withStoryRouter } from '../../stories/with-story-router';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import TopPostsRender from '../render';
@@ -183,8 +181,8 @@ export const Loading: Story = {
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas, withStoryRouter ],
 	beforeEach: () => {
-		setReportMockState( 'stats/top-posts', 'loading' );
-		return () => setReportMockState( 'stats/top-posts', null );
+		forceStatsMockState( 'stats/top-posts', 'loading' );
+		return () => forceStatsMockState( 'stats/top-posts', null );
 	},
 };
 
@@ -197,8 +195,8 @@ export const Error: Story = {
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas, withStoryRouter ],
 	beforeEach: () => {
-		setReportMockState( 'stats/top-posts', 'error' );
-		return () => setReportMockState( 'stats/top-posts', null );
+		forceStatsMockState( 'stats/top-posts', 'error' );
+		return () => forceStatsMockState( 'stats/top-posts', null );
 	},
 };
 
@@ -211,7 +209,7 @@ export const Empty: Story = {
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas, withStoryRouter ],
 	beforeEach: () => {
-		setReportMockState( 'stats/top-posts', 'empty' );
-		return () => setReportMockState( 'stats/top-posts', null );
+		forceStatsMockState( 'stats/top-posts', 'empty' );
+		return () => forceStatsMockState( 'stats/top-posts', null );
 	},
 };

--- a/projects/packages/premium-analytics/widgets/total-returns/stories/total-returns-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/total-returns/stories/total-returns-widget.stories.tsx
@@ -1,6 +1,9 @@
 import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
 import { SELECTABLE_PRESETS, type SelectablePresetId } from '@jetpack-premium-analytics/datetime';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
@@ -52,6 +55,19 @@ function renderTotalReturns( { withComparison, preset }: TotalReturnsStoryContro
 	return (
 		<TotalReturnsRender
 			attributes={ getTotalReturnsAttributes( withComparison, preset ) }
+			setError={ noopSetError }
+		/>
+	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderTotalReturnsOnPreset( preset: SelectablePresetId ) {
+	return (
+		<TotalReturnsRender
+			attributes={ getTotalReturnsAttributes( false, preset ) }
 			setError={ noopSetError }
 		/>
 	);
@@ -124,6 +140,51 @@ export const WithComparison: Story = {
 		withComparison: true,
 	},
 	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * First load: the orders report is in flight, so the widget shows its loading
+ * state. The mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderTotalReturnsOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders/by-date', 'loading' );
+		return () => setReportMockState( 'orders/by-date', null );
+	},
+};
+
+/**
+ * The orders report failed: the widget shows its error state with a Retry action
+ * (which re-runs the query — still mocked as failing while this story is
+ * active).
+ */
+export const Error: Story = {
+	render: () => renderTotalReturnsOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders/by-date', 'error' );
+		return () => setReportMockState( 'orders/by-date', null );
+	},
+};
+
+/**
+ * Resolved with no refunds in the period: the widget shows its empty state (the
+ * neutral payment-return glyph and "No returns in this period.").
+ */
+export const Empty: Story = {
+	render: () => renderTotalReturnsOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders/by-date', 'empty' );
+		return () => setReportMockState( 'orders/by-date', null );
+	},
 };
 
 /**

--- a/projects/packages/premium-analytics/widgets/total-returns/stories/total-returns-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/total-returns/stories/total-returns-widget.stories.tsx
@@ -55,10 +55,7 @@ function renderTotalReturns( { withComparison, preset }: TotalReturnsStoryContro
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderTotalReturnsOnPreset( preset: SelectablePresetId ) {
 	return (
 		<TotalReturnsRender
@@ -143,8 +140,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderTotalReturnsOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/total-returns/stories/total-returns-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/total-returns/stories/total-returns-widget.stories.tsx
@@ -10,9 +10,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import TotalReturnsRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -35,12 +36,6 @@ type TotalReturnsStoryProps = TotalReturnsWidgetProps & TotalReturnsStoryControl
 interface TotalReturnsDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		TotalReturnsStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getTotalReturnsAttributes(
 	withComparison = false,

--- a/projects/packages/premium-analytics/widgets/total-sales-over-time/stories/total-sales-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/total-sales-over-time/stories/total-sales-over-time-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
@@ -13,7 +14,7 @@ import {
 import LineChart from '../../../../../js-packages/charts/src/charts/line-chart/line-chart';
 import TotalSalesOverTimeRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -37,12 +38,6 @@ type TotalSalesOverTimeStoryProps = TotalSalesOverTimeWidgetProps & TotalSalesOv
 interface TotalSalesOverTimeDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		TotalSalesOverTimeStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getTotalSalesOverTimeAttributes(
 	withComparison = false,

--- a/projects/packages/premium-analytics/widgets/total-sales-over-time/stories/total-sales-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/total-sales-over-time/stories/total-sales-over-time-widget.stories.tsx
@@ -6,7 +6,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import LineChart from '../../../../../js-packages/charts/src/charts/line-chart/line-chart';
 import TotalSalesOverTimeRender from '../render';
 import widgetDefinition from '../widget';
@@ -85,6 +88,18 @@ function renderTotalSalesOverTime( { withComparison, preset }: TotalSalesOverTim
 		<TotalSalesOverTimeRender
 			attributes={ getTotalSalesOverTimeAttributes( withComparison, preset ) }
 		/>
+	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderTotalSalesOverTimeOnPreset( preset: SelectablePresetId ) {
+	ensureLineChartComposition();
+
+	return (
+		<TotalSalesOverTimeRender attributes={ getTotalSalesOverTimeAttributes( false, preset ) } />
 	);
 }
 
@@ -178,6 +193,50 @@ export const WithComparison: Story = {
 				) => getTotalSalesOverTimeSource( storyContext.args ),
 			},
 		},
+	},
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderTotalSalesOverTimeOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders/by-date', 'loading' );
+		return () => setReportMockState( 'orders/by-date', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderTotalSalesOverTimeOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders/by-date', 'error' );
+		return () => setReportMockState( 'orders/by-date', null );
+	},
+};
+
+/**
+ * Resolved with no sales data: the widget shows its empty state ("No data found
+ * for this date range.").
+ */
+export const Empty: Story = {
+	render: () => renderTotalSalesOverTimeOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'orders/by-date', 'empty' );
+		return () => setReportMockState( 'orders/by-date', null );
 	},
 };
 

--- a/projects/packages/premium-analytics/widgets/total-sales-over-time/stories/total-sales-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/total-sales-over-time/stories/total-sales-over-time-widget.stories.tsx
@@ -86,10 +86,7 @@ function renderTotalSalesOverTime( { withComparison, preset }: TotalSalesOverTim
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderTotalSalesOverTimeOnPreset( preset: SelectablePresetId ) {
 	ensureLineChartComposition();
 
@@ -197,8 +194,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderTotalSalesOverTimeOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/total-sales-over-time/stories/total-sales-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/total-sales-over-time/stories/total-sales-over-time-widget.stories.tsx
@@ -218,8 +218,8 @@ export const Error: Story = {
 };
 
 /**
- * Resolved with no sales data: the widget shows its empty state ("No data found
- * for this date range.").
+ * Resolved with no sales data: the widget shows its empty state ("No sales in
+ * this period.").
  */
 export const Empty: Story = {
 	render: () => renderTotalSalesOverTimeOnPreset( 'last-365-days' ),

--- a/projects/packages/premium-analytics/widgets/traffic-chart/stories/traffic-chart-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/stories/traffic-chart-widget.stories.tsx
@@ -1,14 +1,17 @@
 /**
  * Internal dependencies
  */
-import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { getDefaultQueryParams, type PresetType } from '@jetpack-premium-analytics/data';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import TrafficChartRender from '../render';
 import widgetDefinition, {
 	DEFAULT_TRAFFIC_CHART_METRICS,
@@ -58,6 +61,16 @@ function renderTrafficChart( { withComparison, metrics }: TrafficChartStoryContr
 	);
 }
 
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderTrafficChartOnPreset( preset: PresetType ) {
+	return (
+		<TrafficChartRender attributes={ { reportParams: getDefaultQueryParams( false, preset ) } } />
+	);
+}
+
 // Close-up canvas so the chart fills the frame outside the dashboard grid.
 const withWidgetCanvas: Decorator = Story => (
 	<div style={ { width: '100%', height: '360px' } }>
@@ -103,6 +116,52 @@ export const WithComparison: Story = {
 	render: renderTrafficChart,
 	args: { withComparison: true, ...ALL_METRICS_ARGS },
 	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * First load: both visits fetches are in flight, so the widget shows its loading
+ * state (the metric tabs over the chart's loading overlay). The mock is forced
+ * to never resolve for the duration of this story. Both of the widget's requests
+ * hit the same `stats/visits` path, so one override covers them.
+ */
+export const Loading: Story = {
+	render: () => renderTrafficChartOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'stats/visits', 'loading' );
+		return () => setReportMockState( 'stats/visits', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the queries — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderTrafficChartOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'stats/visits', 'error' );
+		return () => setReportMockState( 'stats/visits', null );
+	},
+};
+
+/**
+ * Resolved with no points: the widget shows its empty state (the neutral
+ * reports glyph and "No traffic data in this period.").
+ */
+export const Empty: Story = {
+	render: () => renderTrafficChartOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'stats/visits', 'empty' );
+		return () => setReportMockState( 'stats/visits', null );
+	},
 };
 
 interface TrafficChartDashboardStoryProps

--- a/projects/packages/premium-analytics/widgets/traffic-chart/stories/traffic-chart-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/stories/traffic-chart-widget.stories.tsx
@@ -8,6 +8,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
@@ -70,13 +71,6 @@ function renderTrafficChartOnPreset( preset: PresetType ) {
 		<TrafficChartRender attributes={ { reportParams: getDefaultQueryParams( false, preset ) } } />
 	);
 }
-
-// Close-up canvas so the chart fills the frame outside the dashboard grid.
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '360px' } }>
-		<Story />
-	</div>
-);
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/TrafficChart',

--- a/projects/packages/premium-analytics/widgets/traffic-chart/stories/traffic-chart-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/stories/traffic-chart-widget.stories.tsx
@@ -18,7 +18,7 @@ import widgetDefinition, {
 	DEFAULT_TRAFFIC_CHART_METRICS,
 	type TrafficChartMetricId,
 } from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -62,10 +62,7 @@ function renderTrafficChart( { withComparison, metrics }: TrafficChartStoryContr
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderTrafficChartOnPreset( preset: PresetType ) {
 	return (
 		<TrafficChartRender attributes={ { reportParams: getDefaultQueryParams( false, preset ) } } />
@@ -120,8 +117,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderTrafficChartOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/utm-insights/stories/utm-insights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/utm-insights/stories/utm-insights-widget.stories.tsx
@@ -5,12 +5,13 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import { registerStatsMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-stats-mocks';
 import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import UtmInsightsRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -33,13 +34,6 @@ interface UtmInsightsStoryControls {
 interface UtmInsightsDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		UtmInsightsStoryControls {}
-
-// Close-up canvas so the leaderboard fills the frame outside the dashboard grid.
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/UtmInsights',

--- a/projects/packages/premium-analytics/widgets/utm-insights/stories/utm-insights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/utm-insights/stories/utm-insights-widget.stories.tsx
@@ -89,10 +89,7 @@ export const WithComparison: Story = {
 	decorators: [ withWidgetCanvas ],
 };
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderUtmInsightsOnPreset( preset: PresetType ) {
 	return (
 		<UtmInsightsRender
@@ -111,8 +108,7 @@ function renderUtmInsightsOnPreset( preset: PresetType ) {
  */
 export const Loading: Story = {
 	render: () => renderUtmInsightsOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/utm-insights/stories/utm-insights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/utm-insights/stories/utm-insights-widget.stories.tsx
@@ -1,17 +1,20 @@
-import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { getDefaultQueryParams, type PresetType } from '@jetpack-premium-analytics/data';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import { registerStatsMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-stats-mocks';
+import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import UtmInsightsRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
+registerReportMocks();
 registerStatsMocks();
 
 const UTM_INSIGHTS_RENDER_MODULE = 'storybook/utm-insights';
@@ -90,6 +93,66 @@ export const WithComparison: Story = {
 	),
 	args: { withComparison: true },
 	decorators: [ withWidgetCanvas ],
+};
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderUtmInsightsOnPreset( preset: PresetType ) {
+	return (
+		<UtmInsightsRender
+			attributes={ {
+				utmDimension: 'utm_source,utm_medium',
+				max: 10,
+				reportParams: getDefaultQueryParams( false, preset ),
+			} }
+		/>
+	);
+}
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderUtmInsightsOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'stats/utm', 'loading' );
+		return () => forceStatsMockState( 'stats/utm', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderUtmInsightsOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'stats/utm', 'error' );
+		return () => forceStatsMockState( 'stats/utm', null );
+	},
+};
+
+/**
+ * Resolved with no rows: the widget shows its empty state (the neutral megaphone
+ * glyph and "No UTM data in this period.").
+ */
+export const Empty: Story = {
+	render: () => renderUtmInsightsOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		forceStatsMockState( 'stats/utm', 'empty' );
+		return () => forceStatsMockState( 'stats/utm', null );
+	},
 };
 
 // Alternative close-up showing the Campaign dimension.

--- a/projects/packages/premium-analytics/widgets/video-detail-embeds/stories/video-detail-embeds-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/video-detail-embeds/stories/video-detail-embeds-widget.stories.tsx
@@ -71,10 +71,7 @@ function renderVideoDetailEmbeds( { withComparison }: VideoDetailEmbedsStoryCont
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderVideoDetailEmbedsOnPreset( preset: PresetType ) {
 	return (
 		<VideoDetailEmbedsRender
@@ -142,8 +139,7 @@ export const NoVideoSelected: Story = {
  */
 export const Loading: Story = {
 	render: () => renderVideoDetailEmbedsOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/video-detail-embeds/stories/video-detail-embeds-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/video-detail-embeds/stories/video-detail-embeds-widget.stories.tsx
@@ -15,9 +15,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import VideoDetailEmbedsRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -81,26 +82,6 @@ function renderVideoDetailEmbedsOnPreset( preset: PresetType ) {
 		/>
 	);
 }
-
-// Close-up frame: a white, widget-sized card so each state reads the way it does
-// as a real dashboard widget (in product the host supplies this frame).
-const withWidgetCanvas: Decorator = Story => (
-	<div
-		style={ {
-			width: '380px',
-			height: '520px',
-			margin: '0 auto',
-			padding: '16px',
-			boxSizing: 'border-box',
-			background: '#fff',
-			border: '1px solid #e0e0e0',
-			borderRadius: '8px',
-			overflow: 'hidden',
-		} }
-	>
-		<Story />
-	</div>
-);
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/VideoDetailEmbeds',

--- a/projects/packages/premium-analytics/widgets/videopress/stories/videopress-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/stories/videopress-widget.stories.tsx
@@ -15,9 +15,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import VideoPressRender from '../render';
 import widgetDefinition, { DEFAULT_MAX } from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -60,13 +61,6 @@ function renderVideoPressOnPreset( preset: PresetType ) {
 		/>
 	);
 }
-
-// Close-up canvas so the leaderboard fills the frame outside the dashboard grid.
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '360px' } }>
-		<Story />
-	</div>
-);
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/VideoPress',

--- a/projects/packages/premium-analytics/widgets/videopress/stories/videopress-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/stories/videopress-widget.stories.tsx
@@ -50,10 +50,7 @@ function renderVideoPress( { withComparison }: VideoPressStoryControls ) {
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderVideoPressOnPreset( preset: PresetType ) {
 	return (
 		<VideoPressRender
@@ -108,8 +105,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderVideoPressOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/visitors-by-location/stories/visitors-by-location-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/visitors-by-location/stories/visitors-by-location-widget.stories.tsx
@@ -6,7 +6,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import VisitorsByLocationRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -82,6 +85,18 @@ function renderVisitorsByLocation( { withComparison, preset }: VisitorsByLocatio
 		<VisitorsByLocationRender
 			attributes={ getVisitorsByLocationAttributes( withComparison, preset ) }
 		/>
+	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client. The US/Worldwide toggle
+// stays visible and interactive in every state — it is a sibling of `WidgetState`,
+// not gated by it, per the widget's contract.
+function renderVisitorsByLocationOnPreset( preset: SelectablePresetId ) {
+	return (
+		<VisitorsByLocationRender attributes={ getVisitorsByLocationAttributes( false, preset ) } />
 	);
 }
 
@@ -176,6 +191,51 @@ export const WithComparison: Story = {
 				) => getVisitorsByLocationSource( storyContext.args ),
 			},
 		},
+	},
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state
+ * below the (still interactive) US/Worldwide toggle. The mock is forced to
+ * never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderVisitorsByLocationOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'sessions/by-location', 'loading' );
+		return () => setReportMockState( 'sessions/by-location', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderVisitorsByLocationOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'sessions/by-location', 'error' );
+		return () => setReportMockState( 'sessions/by-location', null );
+	},
+};
+
+/**
+ * Resolved with no rows: the widget shows its empty state ("No location data in
+ * this period.").
+ */
+export const Empty: Story = {
+	render: () => renderVisitorsByLocationOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'sessions/by-location', 'empty' );
+		return () => setReportMockState( 'sessions/by-location', null );
 	},
 };
 

--- a/projects/packages/premium-analytics/widgets/visitors-by-location/stories/visitors-by-location-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/visitors-by-location/stories/visitors-by-location-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { WidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
@@ -37,9 +38,9 @@ interface VisitorsByLocationDashboardStoryProps
 
 const withWidgetCanvas: Decorator = Story => (
 	<GlobalErrorProvider>
-		<div style={ { width: '100%', height: '300px' } }>
+		<WidgetCanvas>
 			<Story />
-		</div>
+		</WidgetCanvas>
 	</GlobalErrorProvider>
 );
 

--- a/projects/packages/premium-analytics/widgets/visitors-by-location/stories/visitors-by-location-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/visitors-by-location/stories/visitors-by-location-widget.stories.tsx
@@ -89,10 +89,7 @@ function renderVisitorsByLocation( { withComparison, preset }: VisitorsByLocatio
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client. The US/Worldwide toggle
+// Distinct preset → own query-cache entry; see forceStatsMockState. The US/Worldwide toggle
 // stays visible and interactive in every state — it is a sibling of `WidgetState`,
 // not gated by it, per the widget's contract.
 function renderVisitorsByLocationOnPreset( preset: SelectablePresetId ) {
@@ -202,8 +199,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderVisitorsByLocationOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/visitors-over-time/stories/visitors-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/visitors-over-time/stories/visitors-over-time-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
@@ -13,7 +14,7 @@ import {
 import LineChart from '../../../../../js-packages/charts/src/charts/line-chart/line-chart';
 import VisitorsOverTimeRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -38,12 +39,6 @@ type VisitorsOverTimeStoryProps = VisitorsOverTimeWidgetProps & VisitorsOverTime
 interface VisitorsOverTimeDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		VisitorsOverTimeStoryControls {}
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
 
 function getVisitorsOverTimeAttributes(
 	withComparison = false,

--- a/projects/packages/premium-analytics/widgets/visitors-over-time/stories/visitors-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/visitors-over-time/stories/visitors-over-time-widget.stories.tsx
@@ -88,10 +88,7 @@ function renderVisitorsOverTime( { withComparison, preset }: VisitorsOverTimeSto
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderVisitorsOverTimeOnPreset( preset: SelectablePresetId ) {
 	ensureLineChartComposition();
 
@@ -200,8 +197,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderVisitorsOverTimeOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/visitors-over-time/stories/visitors-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/visitors-over-time/stories/visitors-over-time-widget.stories.tsx
@@ -6,7 +6,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import LineChart from '../../../../../js-packages/charts/src/charts/line-chart/line-chart';
 import VisitorsOverTimeRender from '../render';
 import widgetDefinition from '../widget';
@@ -85,6 +88,21 @@ function renderVisitorsOverTime( { withComparison, preset }: VisitorsOverTimeSto
 	return (
 		<VisitorsOverTimeRender
 			attributes={ getVisitorsOverTimeAttributes( withComparison, preset ) }
+			setError={ noopSetError }
+		/>
+	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderVisitorsOverTimeOnPreset( preset: SelectablePresetId ) {
+	ensureLineChartComposition();
+
+	return (
+		<VisitorsOverTimeRender
+			attributes={ getVisitorsOverTimeAttributes( false, preset ) }
 			setError={ noopSetError }
 		/>
 	);
@@ -178,6 +196,50 @@ export const WithComparison: Story = {
 				) => getVisitorsOverTimeSource( storyContext.args ),
 			},
 		},
+	},
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderVisitorsOverTimeOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'sessions/by-date', 'loading' );
+		return () => setReportMockState( 'sessions/by-date', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderVisitorsOverTimeOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'sessions/by-date', 'error' );
+		return () => setReportMockState( 'sessions/by-date', null );
+	},
+};
+
+/**
+ * Resolved with no visitor data: the widget shows its empty state ("No data
+ * found for this date range.").
+ */
+export const Empty: Story = {
+	render: () => renderVisitorsOverTimeOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'sessions/by-date', 'empty' );
+		return () => setReportMockState( 'sessions/by-date', null );
 	},
 };
 

--- a/projects/packages/premium-analytics/widgets/visitors-over-time/stories/visitors-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/visitors-over-time/stories/visitors-over-time-widget.stories.tsx
@@ -221,8 +221,8 @@ export const Error: Story = {
 };
 
 /**
- * Resolved with no visitor data: the widget shows its empty state ("No data
- * found for this date range.").
+ * Resolved with no visitor data: the widget shows its empty state ("No visitors
+ * in this period.").
  */
 export const Empty: Story = {
 	render: () => renderVisitorsOverTimeOnPreset( 'last-365-days' ),

--- a/projects/packages/premium-analytics/widgets/wordads-chart-tabs/stories/wordads-chart-tabs-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-chart-tabs/stories/wordads-chart-tabs-widget.stories.tsx
@@ -12,10 +12,11 @@ import {
 	registerReportMocks,
 	setReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import { DEFAULT_WORDADS_CHART_METRICS, type WordAdsChartMetricId } from '../metrics';
 import WordAdsChartTabsRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -61,13 +62,6 @@ function renderWordAdsChartTabsOnPreset( preset: PresetType ) {
 		/>
 	);
 }
-
-// Close-up canvas so the chart fills the frame outside the dashboard grid.
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '360px' } }>
-		<Story />
-	</div>
-);
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/WordAdsChartTabs',

--- a/projects/packages/premium-analytics/widgets/wordads-chart-tabs/stories/wordads-chart-tabs-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-chart-tabs/stories/wordads-chart-tabs-widget.stories.tsx
@@ -51,10 +51,7 @@ function renderWordAdsChartTabs( { withComparison, metrics }: WordAdsChartTabsSt
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
+// Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderWordAdsChartTabsOnPreset( preset: PresetType ) {
 	return (
 		<WordAdsChartTabsRender
@@ -109,8 +106,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: () => renderWordAdsChartTabsOnPreset( 'last-90-days' ),
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {


### PR DESCRIPTION

## Proposed changes

* Add forced Loading/Error/Empty Storybook stories for the WidgetState migration in #50383.
* Use the shared widget canvas so forced states render like dashboard cards.

## Related product discussion/links

* WOOA7S-1675

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build Storybook and open `Packages > Premium Analytics > Widgets`.
* Check a few `Loading`, `Error`, and `Empty` stories, e.g. WordAdsChartTabs, Search terms, and Store performance.
* Confirm `Default` / `WithComparison` stories still render populated.


https://github.com/user-attachments/assets/4857e645-1c47-4761-ac2a-cfcab16fe01e

