### PR TITLE
Launchpad: clear the site intent for the deprecated start-writing flow

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-start-writing-flow
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-start-writing-flow
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Clear the site intent for the deprecated start-writing flow, and stop suppressing the recommended tags modal for it.

--- a/projects/packages/jetpack-mu-wpcom/src/common/tour-kit/constants.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/common/tour-kit/constants.ts
@@ -1,3 +1,2 @@
-// Copied from https://github.com/Automattic/wp-calypso/blob/ce1a376af4bcc8987855ced4c961efacda6e1d32/packages/onboarding/src/utils/flows.ts#L32-L33
-export const START_WRITING_FLOW = 'start-writing';
+// Copied from https://github.com/Automattic/wp-calypso/blob/ce1a376af4bcc8987855ced4c961efacda6e1d32/packages/onboarding/src/utils/flows.ts#L33
 export const DESIGN_FIRST_FLOW = 'design-first';

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -441,6 +441,49 @@ function wpcom_register_default_launchpad_checklists() {
 add_action( 'init', 'wpcom_register_default_launchpad_checklists', 11 );
 
 /**
+ * Clears the site intent for a retired onboarding flow.
+ *
+ * A retired flow no longer accepts new sites, so the sites left on one sit in
+ * an onboarding they can never be guided through. Clearing the intent returns
+ * them to the same state as a site that never picked one: no Launchpad, and no
+ * onboarding email campaign.
+ *
+ * Writes once per site, since the intent stops matching afterwards. Delete this
+ * once no site carries one of these values.
+ */
+function wpcom_launchpad_clear_retired_site_intents() {
+	$retired_site_intents = array( 'start-writing' );
+
+	if ( ! in_array( get_option( 'site_intent' ), $retired_site_intents, true ) ) {
+		return;
+	}
+
+	update_option( 'site_intent', '' );
+	update_option( 'launchpad_screen', 'off' );
+}
+
+/**
+ * Clears the retired site intent once the target site's options are readable.
+ *
+ * On `public-api.wordpress.com`, `init` fires before the request switches to
+ * the blog, so reading `site_intent` there would read the wrong site.
+ *
+ * Runs ahead of the checklist registration, on both paths, so that the active
+ * task listeners are never registered for an intent that is about to be gone.
+ *
+ * @return void
+ */
+function wpcom_launchpad_clear_retired_site_intents_on_correct_action() {
+	if ( wp_parse_url( home_url(), PHP_URL_HOST ) === 'public-api.wordpress.com' ) {
+		add_action( 'rest_api_switched_to_blog', 'wpcom_launchpad_clear_retired_site_intents' );
+		return;
+	}
+
+	wpcom_launchpad_clear_retired_site_intents();
+}
+add_action( 'init', 'wpcom_launchpad_clear_retired_site_intents_on_correct_action', 10 );
+
+/**
  * Adds hooks to the correct action to add active task listeners.
  * Handles REST API requests vs non-REST API requests.
  *

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/recommended-tags-modal/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-editor-nux/src/recommended-tags-modal/index.tsx
@@ -2,7 +2,6 @@ import { Modal } from '@wordpress/components';
 import { useSelect } from '@wordpress/data';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import {
-	START_WRITING_FLOW,
 	DESIGN_FIRST_FLOW,
 	useSiteIntent,
 	useShouldShowSellerCelebrationModal,
@@ -108,7 +107,7 @@ const RecommendedTagsModalInner: FC = () => {
 
 const RecommendedTagsModal = () => {
 	const { siteIntent: intent } = useSiteIntent();
-	if ( intent === START_WRITING_FLOW || intent === DESIGN_FIRST_FLOW ) {
+	if ( intent === DESIGN_FIRST_FLOW ) {
 		return null;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/Launchpad_Retired_Site_Intents_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/Launchpad_Retired_Site_Intents_Test.php
@@ -1,0 +1,211 @@
+<?php
+/**
+ * Test class for wpcom_launchpad_clear_retired_site_intents.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Test class for wpcom_launchpad_clear_retired_site_intents.
+ */
+class Launchpad_Retired_Site_Intents_Test extends \WorDBless\BaseTestCase {
+	/**
+	 * The `home_url` filter a test installed, if any.
+	 *
+	 * @var callable|null
+	 */
+	private $home_url_filter;
+
+	/**
+	 * Undo only what this test hooked, even when it fails partway. Other callbacks
+	 * on these hooks belong to the rest of the suite.
+	 */
+	public function tear_down() {
+		if ( null !== $this->home_url_filter ) {
+			remove_filter( 'home_url', $this->home_url_filter );
+			$this->home_url_filter = null;
+		}
+		remove_action( 'rest_api_switched_to_blog', 'wpcom_launchpad_clear_retired_site_intents' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Pretends the request is being served from the REST API host.
+	 */
+	private function serve_from_rest_api_host() {
+		$this->home_url_filter = function () {
+			return 'https://public-api.wordpress.com';
+		};
+		add_filter( 'home_url', $this->home_url_filter );
+	}
+
+	/**
+	 * A site left on a retired flow has its intent cleared and its Launchpad turned off.
+	 */
+	public function test_retired_intent_is_cleared() {
+		update_option( 'site_intent', 'start-writing' );
+		update_option( 'launchpad_screen', 'full' );
+
+		wpcom_launchpad_clear_retired_site_intents();
+
+		$this->assertSame( '', get_option( 'site_intent' ) );
+		$this->assertSame( 'off', get_option( 'launchpad_screen' ) );
+	}
+
+	/**
+	 * The intent is its own guard, so a later run leaves the site alone.
+	 */
+	public function test_clearing_is_idempotent() {
+		update_option( 'site_intent', 'start-writing' );
+		update_option( 'launchpad_screen', 'full' );
+
+		wpcom_launchpad_clear_retired_site_intents();
+
+		$this->assertSame( '', get_option( 'site_intent' ) );
+		$this->assertSame( 'off', get_option( 'launchpad_screen' ) );
+
+		// No intent matches now, so a second pass must not write, even to a site
+		// that turned its Launchpad back on in the meantime.
+		update_option( 'launchpad_screen', 'full' );
+
+		wpcom_launchpad_clear_retired_site_intents();
+
+		$this->assertSame( '', get_option( 'site_intent' ) );
+		$this->assertSame( 'full', get_option( 'launchpad_screen' ) );
+	}
+
+	/**
+	 * A live site intent is never disturbed.
+	 *
+	 * @param string $site_intent A site intent that is still in use.
+	 * @dataProvider provide_live_site_intents
+	 */
+	#[DataProvider( 'provide_live_site_intents' )]
+	public function test_live_site_intents_are_untouched( $site_intent ) {
+		update_option( 'site_intent', $site_intent );
+		update_option( 'launchpad_screen', 'full' );
+
+		wpcom_launchpad_clear_retired_site_intents();
+
+		$this->assertSame( $site_intent, get_option( 'site_intent' ) );
+		$this->assertSame( 'full', get_option( 'launchpad_screen' ) );
+	}
+
+	/**
+	 * Site intents that must survive the cleanup.
+	 *
+	 * @return array
+	 */
+	public static function provide_live_site_intents() {
+		return array(
+			'design-first' => array( 'design-first' ),
+			'write'        => array( 'write' ),
+			'build'        => array( 'build' ),
+			'sell'         => array( 'sell' ),
+			'newsletter'   => array( 'newsletter' ),
+			'videopress'   => array( 'videopress' ),
+		);
+	}
+
+	/**
+	 * A site with no intent is left alone, and gains no Launchpad option.
+	 */
+	public function test_site_without_an_intent_is_untouched() {
+		delete_option( 'site_intent' );
+		delete_option( 'launchpad_screen' );
+
+		wpcom_launchpad_clear_retired_site_intents();
+
+		$this->assertFalse( get_option( 'site_intent' ) );
+		$this->assertFalse( get_option( 'launchpad_screen' ) );
+	}
+
+	/**
+	 * The cleanup runs before the checklists register their task listeners, so no
+	 * listener is ever set up for an intent that is about to be cleared.
+	 */
+	public function test_cleanup_is_dispatched_before_checklist_registration() {
+		$cleanup      = has_action( 'init', 'wpcom_launchpad_clear_retired_site_intents_on_correct_action' );
+		$registration = has_action( 'init', 'wpcom_register_default_launchpad_checklists' );
+
+		$this->assertNotFalse( $cleanup );
+		$this->assertNotFalse( $registration );
+		$this->assertLessThan( $registration, $cleanup, 'cleanup must run before checklist registration' );
+	}
+
+	/**
+	 * Off the REST API host, the cleanup runs straight away.
+	 */
+	public function test_cleanup_runs_immediately_off_the_rest_api_host() {
+		update_option( 'site_intent', 'start-writing' );
+
+		wpcom_launchpad_clear_retired_site_intents_on_correct_action();
+
+		$this->assertSame( '', get_option( 'site_intent' ) );
+		$this->assertFalse( has_action( 'rest_api_switched_to_blog', 'wpcom_launchpad_clear_retired_site_intents' ) );
+	}
+
+	/**
+	 * On the REST API host the cleanup writes nothing when init runs, and waits for
+	 * the blog switch instead.
+	 *
+	 * The suite is single site, so `switch_to_blog()` does not exist here. A switch
+	 * is stood in for by changing the options between the two moments: whatever is
+	 * readable when the action fires stands for the target site, and whatever was
+	 * readable at init stands for the site the request started on.
+	 */
+	public function test_cleanup_writes_nothing_before_the_blog_switch() {
+		$this->serve_from_rest_api_host();
+		update_option( 'site_intent', 'start-writing' );
+		update_option( 'launchpad_screen', 'full' );
+
+		wpcom_launchpad_clear_retired_site_intents_on_correct_action();
+
+		$this->assertSame( 'start-writing', get_option( 'site_intent' ) );
+		$this->assertSame( 'full', get_option( 'launchpad_screen' ) );
+		$this->assertNotFalse( has_action( 'rest_api_switched_to_blog', 'wpcom_launchpad_clear_retired_site_intents' ) );
+	}
+
+	/**
+	 * The options the cleanup acts on are the ones readable when the blog switch
+	 * fires, not the ones readable at init.
+	 */
+	public function test_cleanup_reads_the_options_of_the_switched_to_blog() {
+		$this->serve_from_rest_api_host();
+		update_option( 'site_intent', 'design-first' );
+		update_option( 'launchpad_screen', 'full' );
+
+		wpcom_launchpad_clear_retired_site_intents_on_correct_action();
+
+		// Stand in for switching to a blog that is on the retired flow.
+		update_option( 'site_intent', 'start-writing' );
+
+		do_action( 'rest_api_switched_to_blog' );
+
+		$this->assertSame( '', get_option( 'site_intent' ) );
+		$this->assertSame( 'off', get_option( 'launchpad_screen' ) );
+	}
+
+	/**
+	 * A retired intent seen at init does not get cleared on whatever blog the
+	 * request has switched to. This is the regression the dispatcher prevents.
+	 */
+	public function test_cleanup_ignores_the_intent_seen_before_the_blog_switch() {
+		$this->serve_from_rest_api_host();
+		update_option( 'site_intent', 'start-writing' );
+		update_option( 'launchpad_screen', 'full' );
+
+		wpcom_launchpad_clear_retired_site_intents_on_correct_action();
+
+		// Stand in for switching to a blog that is on a live flow.
+		update_option( 'site_intent', 'design-first' );
+
+		do_action( 'rest_api_switched_to_blog' );
+
+		$this->assertSame( 'design-first', get_option( 'site_intent' ), 'the switched-to blog must survive' );
+		$this->assertSame( 'full', get_option( 'launchpad_screen' ), 'the switched-to blog must survive' );
+	}
+}


### PR DESCRIPTION
Fixes # N/A

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Clear the `site_intent` for the deprecated start-writing flow, and turn the Launchpad off. The flow accepts no new sites, so the sites left on it sit in an onboarding they can never be guided through. Clearing the intent returns them to the same state as a site that never picked one.
* Stop suppressing the block editor's recommended tags modal for the flow, and drop the constant that only that check used.

The cleanup runs on `init`. On `public-api.wordpress.com` that action fires before the request switches to the target blog, so there it defers to `rest_api_switched_to_blog`, mirroring how the active task listeners are registered. It writes at most once per site, and the tests cover every live intent to confirm none of them are disturbed.

**What this PR deliberately does not do.** The `start-writing` checklist, the `blog_launched` gating, and the tailored onboarding email campaign all stay. wpcom's Guides observer still drives a six step email campaign for this intent, and it records task completion through the registered checklist, so removing either one breaks it. Keeping the checklist also keeps the slug in the launchpad endpoint's `checklist_slug` enum, so no client that passes the stored intent gets a 400.

Those pieces come out in a later change, once the Guides campaign is retired and Calypso no longer routes anyone into the flow.

**Worth a reviewer's attention.** Clearing the intent already ends the Guides email campaign for a site, because the observer skips every step for an intent it does not recognise. That is the intended outcome for a retired flow, but it is a product behaviour change rather than a mechanical cleanup, and the wpcom test suite will not catch it: those tests set `site_intent` after `init` has already run, so the cleanup never fires there.

## Related product discussion/links
* N/A

## Does this pull request change what data or activity we track or use?
No new data is collected. Sites still on the retired flow stop receiving its onboarding email campaign, since clearing the intent takes them out of it.

## Testing instructions
* Check out this branch and run the package's PHP tests. All should pass, including the new `Launchpad_Retired_Site_Intents_Test`:
  ```
  cd projects/packages/jetpack-mu-wpcom && composer test-php
  ```
* On a site with `site_intent` set to `start-writing` and `launchpad_screen` set to `full`, load any page, then confirm:
  * `site_intent` is now empty and `launchpad_screen` is `off`.
  * The Launchpad is no longer shown, and the sites dashboard renders normally with no failing launchpad request.
  * The block editor's recommended tags modal now appears, where it was previously suppressed.
* On a site with `site_intent` set to `design-first`, confirm nothing changed:
  * The intent is untouched and the Launchpad still shows the design-first checklist.
  * The blog launch task stays disabled until the plan, domain, and blog setup tasks are complete.
  * The recommended tags modal stays hidden.
  * Launching the site clears `site_intent` and turns the Launchpad screen off, and the tailored onboarding email still triggers.
* On a site with any other intent, such as `write`, `sell`, or `videopress`, confirm the intent survives untouched.
