### PR TITLE
WOOA7S-1502: Port Stats Shares widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-shares-widget
+++ b/projects/packages/premium-analytics/changelog/add-shares-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Shares: add the Shares widget listing the number of times content was shared to each social network.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/site-summary.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/site-summary.ts
@@ -1,7 +1,9 @@
 /**
  * Mock response for the Jetpack Stats site-summary endpoint
  * (`/proxy/v1.1/stats`, no sub-path), which returns all-time lifetime totals.
- * Consumed by the All-time stats and Most popular day widgets via `useStatsSite`.
+ * Consumed by the All-time stats, Most popular day, and Shares widgets via
+ * `useStatsSite`. The `shares` total plus `shares_<service>` per-network counts
+ * back the Shares widget.
  */
 export const mockSiteSummary = {
 	stats: {
@@ -11,5 +13,10 @@ export const mockSiteSummary = {
 		comments: 4_123,
 		views_best_day: '2020-08-18',
 		views_best_day_total: 197_500,
+		shares: 21_640,
+		shares_facebook: 12_840,
+		shares_twitter: 5_320,
+		shares_linkedin: 2_180,
+		shares_tumblr: 1_300,
 	},
 };

--- a/projects/packages/premium-analytics/src/dashboard-layout.php
+++ b/projects/packages/premium-analytics/src/dashboard-layout.php
@@ -414,16 +414,26 @@ function get_dashboard_default_section_layouts() {
 				)
 			),
 			get_dashboard_default_widget_instance(
+				'default-shares-widget-instance',
+				'jpa/shares',
+				7,
+				1,
+				2,
+				array(
+					'max' => 10,
+				)
+			),
+			get_dashboard_default_widget_instance(
 				'default-most-popular-day-widget-instance',
 				'jpa/most-popular-day',
-				7,
+				8,
 				1,
 				1
 			),
 			get_dashboard_default_widget_instance(
 				'default-most-popular-time-widget-instance',
 				'jpa/most-popular-time',
-				8,
+				9,
 				1,
 				1
 			),

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
@@ -112,8 +112,9 @@ class Dashboard_Layout_Test extends TestCase {
 	 * The insights tab receives its bundled stats widgets.
 	 */
 	public function test_seed_default_dashboard_layout_adds_insights_widgets() {
-		$layout       = seed_default_dashboard_layout( array(), DASHBOARD_INSIGHTS_SECTION_ID );
-		$layout_types = array_column( $layout, 'type' );
+		$layout         = seed_default_dashboard_layout( array(), DASHBOARD_INSIGHTS_SECTION_ID );
+		$layout_by_uuid = array_column( $layout, null, 'uuid' );
+		$layout_types   = array_column( $layout, 'type' );
 
 		$this->assertContains( 'jpa/annual-highlights', $layout_types );
 		$this->assertContains( 'jpa/all-time-stats', $layout_types );
@@ -121,6 +122,22 @@ class Dashboard_Layout_Test extends TestCase {
 		$this->assertContains( 'jpa/posting-activity', $layout_types );
 		$this->assertContains( 'jpa/authors', $layout_types );
 		$this->assertContains( 'jpa/stats-emails', $layout_types );
+		$this->assertContains( 'jpa/shares', $layout_types );
+		$this->assertSame(
+			array(
+				'uuid'       => 'default-shares-widget-instance',
+				'type'       => 'jpa/shares',
+				'attributes' => array(
+					'max' => 10,
+				),
+				'placement'  => array(
+					'width'  => 1,
+					'height' => 2,
+					'order'  => 7,
+				),
+			),
+			$layout_by_uuid['default-shares-widget-instance']
+		);
 		$this->assertSame(
 			get_dashboard_default_layout_for( DASHBOARD_INSIGHTS_SECTION_ID ),
 			get_dashboard_default_layout_for( 'analytics/insights' )

--- a/projects/packages/premium-analytics/widgets/shares/__tests__/use-share-views.test.ts
+++ b/projects/packages/premium-analytics/widgets/shares/__tests__/use-share-views.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Internal dependencies
+ */
+import { buildShareViews } from '../use-share-views';
+
+describe( 'buildShareViews', () => {
+	it( 'sorts positive share counts and applies the max row limit', () => {
+		expect(
+			buildShareViews(
+				{
+					shares: 16,
+					shares_facebook: 10,
+					shares_twitter: 5,
+					shares_linkedin: 1,
+					shares_tumblr: 0,
+				},
+				2
+			)
+		).toEqual( [
+			{ service: 'facebook', label: 'Facebook', value: 10 },
+			{ service: 'twitter', label: 'Twitter', value: 5 },
+		] );
+	} );
+
+	it( 'normalizes legacy Google+ share keys', () => {
+		expect( buildShareViews( { 'shares_google-plus-1': 7 }, 10 ) ).toEqual( [
+			{ service: 'google_plus', label: 'Google+', value: 7 },
+		] );
+	} );
+
+	it( 'aggregates custom share button keys into one row', () => {
+		expect(
+			buildShareViews(
+				{
+					'shares_custom-1513105119': 3,
+					'shares_custom-1513105120': 4,
+					shares_facebook: 1,
+				},
+				10
+			)
+		).toEqual( [
+			{ service: 'custom', label: 'Custom share buttons', value: 7 },
+			{ service: 'facebook', label: 'Facebook', value: 1 },
+		] );
+	} );
+
+	it( 'treats max 0 as all rows', () => {
+		expect(
+			buildShareViews(
+				{
+					shares_facebook: 2,
+					shares_twitter: 1,
+				},
+				0
+			)
+		).toHaveLength( 2 );
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/shares/package.json
+++ b/projects/packages/premium-analytics/widgets/shares/package.json
@@ -1,0 +1,16 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-shares",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/icons": "link:../../packages/icons",
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/element": "8.2.0",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^15.0.0",
+		"@wordpress/ui": "0.17.0",
+		"@wordpress/widget-primitives": "0.2.0"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/shares/render.tsx
+++ b/projects/packages/premium-analytics/widgets/shares/render.tsx
@@ -1,0 +1,102 @@
+/**
+ * External dependencies
+ */
+import {
+	LeaderboardChart,
+	WidgetRoot,
+	WidgetState,
+	type LeaderboardChartData,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { megaphone } from '@jetpack-premium-analytics/icons';
+import { useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { Stack, Text } from '@wordpress/ui';
+/**
+ * Internal dependencies
+ */
+import styles from './style.module.css';
+import useShareViews from './use-share-views';
+import { type SharesAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+
+type SharesRenderAttributes = Partial< ReportParamsFieldAttributes > & SharesAttributes;
+type SharesWidgetProps = WidgetRenderProps< SharesRenderAttributes >;
+
+/**
+ * Shares widget inner component. The share counts come from the all-time site
+ * summary, so there is no date range or comparison period to read from context.
+ *
+ * @param {SharesAttributes} attributes - The widget attributes.
+ * @return The rendered widget content.
+ */
+function SharesInner( { max = 10 }: SharesAttributes ) {
+	const { data, isLoading, isFetching, isError, refetch } = useShareViews( { max } );
+
+	const leaderboardData = useMemo< LeaderboardChartData >( () => {
+		const maxValue = Math.max( ...data.map( s => s.value ), 0 );
+
+		return data.map( ( service, index ) => ( {
+			id: `${ index }-${ service.service }`,
+			label: (
+				<Stack align="center" className={ styles.itemLabel }>
+					<Text className={ styles.itemLabelText }>{ service.label }</Text>
+				</Stack>
+			),
+			currentValue: service.value,
+			currentShare: maxValue > 0 ? ( service.value / maxValue ) * 100 : 0,
+		} ) );
+	}, [ data ] );
+
+	return (
+		<Stack className={ styles.root }>
+			<div className={ styles.content }>
+				<WidgetState
+					isLoading={ isLoading }
+					isFetching={ isFetching }
+					isError={ isError }
+					isEmpty={ data.length === 0 }
+					error={ {
+						description: __(
+							"We couldn't load shares. Please try again in a moment.",
+							'jetpack-premium-analytics'
+						),
+						actions: [ { label: __( 'Retry', 'jetpack-premium-analytics' ), onClick: refetch } ],
+					} }
+					empty={ {
+						icon: megaphone,
+						description: __(
+							'Learn where your content has been shared the most.',
+							'jetpack-premium-analytics'
+						),
+					} }
+				>
+					<LeaderboardChart
+						data={ leaderboardData }
+						withOverlayLabel
+						showLegend={ false }
+						dataFormat={ {
+							type: 'number',
+							options: { useMultipliers: true, decimals: 0 },
+						} }
+					/>
+				</WidgetState>
+			</div>
+		</Stack>
+	);
+}
+
+/**
+ * Shares widget: the number of times the site's content was shared to each social
+ * network, ranked by share count. Ported from the Jetpack Stats "Shares" module.
+ *
+ * @param {SharesWidgetProps} props - The widget render props.
+ * @return The rendered Shares widget.
+ */
+export default function Shares( { attributes = {} }: SharesWidgetProps ) {
+	return (
+		<WidgetRoot attributes={ attributes }>
+			<SharesInner max={ attributes.max } />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/shares/stories/shares-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/shares/stories/shares-widget.stories.tsx
@@ -1,0 +1,154 @@
+/**
+ * The Shares widget lists each social network the site's content was shared to,
+ * ranked by share count. Data comes from the all-time site summary via
+ * `useStatsSite`; the summary has no date range or comparison period, so the
+ * widget shows the same counts regardless of the dashboard's comparison state.
+ */
+/**
+ * External dependencies
+ */
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+/**
+ * Internal dependencies
+ */
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import SharesRender from '../render';
+import widgetDefinition from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+const SHARES_RENDER_MODULE = 'storybook/shares';
+
+// Pick only the fields that StoryWidgetMetadata accepts; the attribute schema and
+// example arrays are typed differently in WidgetType and cause a type error.
+const storyWidgetType = {
+	name: widgetDefinition.name,
+	title: widgetDefinition.title,
+	icon: widgetDefinition.icon,
+	presentation: 'framed' as const,
+};
+
+interface SharesStoryControls {
+	withComparison: boolean;
+}
+
+function renderShares( { withComparison }: SharesStoryControls ) {
+	return (
+		<SharesRender
+			attributes={ { max: 10, reportParams: getDefaultQueryParams( withComparison ) } }
+		/>
+	);
+}
+
+function SharesDashboardRender( props: WidgetRenderProps< unknown > ) {
+	return <SharesRender { ...( props as ComponentProps< typeof SharesRender > ) } />;
+}
+
+// Close-up frame: a white, widget-sized card so the leaderboard reads the way it
+// does as a real dashboard widget (in product the host supplies this frame).
+const withWidgetCanvas: Decorator = Story => (
+	<div
+		style={ {
+			width: '380px',
+			height: '520px',
+			margin: '0 auto',
+			padding: '16px',
+			boxSizing: 'border-box',
+			background: '#fff',
+			border: '1px solid #e0e0e0',
+			borderRadius: '8px',
+			overflow: 'hidden',
+		} }
+	>
+		<Story />
+	</div>
+);
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/Shares',
+	component: SharesRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		withComparison: { control: 'boolean' },
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The "Shares" widget. Lists each social network the site\'s content was shared to, ranked by share count. Ported from the Jetpack Stats Shares module.',
+			},
+		},
+	},
+} satisfies Meta< ComponentProps< typeof SharesRender > & SharesStoryControls >;
+
+export default meta;
+
+type Story = StoryObj< SharesStoryControls >;
+
+/**
+ * The widget on its own, populated from the mocked site summary.
+ */
+export const Default: Story = {
+	render: renderShares,
+	args: { withComparison: false },
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * Comparison state — the dashboard's comparison `reportParams` are present, but the
+ * site summary has no comparison period, so the widget renders the same current
+ * counts without period-over-period deltas.
+ */
+export const WithComparison: Story = {
+	render: renderShares,
+	args: { withComparison: true },
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'The Shares module has no comparison data, so no period-over-period deltas are shown.',
+			},
+		},
+	},
+};
+
+interface SharesDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		SharesStoryControls {}
+
+function SharesDashboardStory( { withComparison, ...dashboardArgs }: SharesDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardArgs }
+			widgetType={ storyWidgetType }
+			renderModule={ SHARES_RENDER_MODULE }
+			renderComponent={ SharesDashboardRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ { max: 10, reportParams: getDefaultQueryParams( withComparison ) } }
+		/>
+	);
+}
+
+/**
+ * Renders the real registered widget through the shared dashboard harness.
+ */
+export const WidgetDashboardWithWidget: StoryObj< SharesDashboardStoryProps > = {
+	render: args => <SharesDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		withComparison: { control: 'boolean' },
+	},
+};

--- a/projects/packages/premium-analytics/widgets/shares/style.module.css
+++ b/projects/packages/premium-analytics/widgets/shares/style.module.css
@@ -1,0 +1,27 @@
+.root {
+	container-type: inline-size;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	overflow: hidden;
+}
+
+.content {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	flex: 1 1 0;
+	min-height: 0;
+}
+
+.itemLabel {
+	padding: var(--wpds-dimension-padding-sm);
+	min-width: 0;
+	overflow: hidden;
+}
+
+.itemLabelText {
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}

--- a/projects/packages/premium-analytics/widgets/shares/use-share-views.ts
+++ b/projects/packages/premium-analytics/widgets/shares/use-share-views.ts
@@ -1,0 +1,104 @@
+/**
+ * Internal dependencies
+ */
+import { useStatsSite } from '@jetpack-premium-analytics/data';
+
+export interface ShareView {
+	/**
+	 * Service slug (e.g. `facebook`), taken from the `shares_<service>` key.
+	 */
+	service: string;
+	/**
+	 * Human-readable network name.
+	 */
+	label: string;
+	/**
+	 * Number of times content was shared to this network.
+	 */
+	value: number;
+}
+
+interface UseShareViewsArgs {
+	/**
+	 * Maximum rows to display; `0` means all.
+	 */
+	max: number;
+}
+
+interface ShareViewsState {
+	data: ShareView[];
+	isLoading: boolean;
+	isFetching: boolean;
+	isError: boolean;
+	refetch: () => void;
+}
+
+const SHARES_PREFIX = 'shares_';
+
+// Display names for the known sharing services. Unlisted services fall back to a
+// humanized slug, so a new network still renders a sensible label.
+const SERVICE_LABELS: Record< string, string > = {
+	facebook: 'Facebook',
+	twitter: 'Twitter',
+	linkedin: 'LinkedIn',
+	tumblr: 'Tumblr',
+	pinterest: 'Pinterest',
+	reddit: 'Reddit',
+	pocket: 'Pocket',
+	telegram: 'Telegram',
+	whatsapp: 'WhatsApp',
+	skype: 'Skype',
+	google_plus: 'Google+',
+	print: 'Print',
+	email: 'Email',
+	press_this: 'Press This',
+	jetpack_whatsapp: 'WhatsApp',
+};
+
+function serviceLabel( service: string ): string {
+	return (
+		SERVICE_LABELS[ service ] ??
+		service
+			.split( '_' )
+			.filter( Boolean )
+			.map( part => part.charAt( 0 ).toUpperCase() + part.slice( 1 ) )
+			.join( ' ' )
+	);
+}
+
+/**
+ * Fetch per-network share counts for the Shares widget via the shared Stats data layer.
+ *
+ * The counts live on the site summary (`stats` endpoint) as `shares_<service>`
+ * fields, so this delegates to `useStatsSite`. The summary is all-time and has no
+ * comparison period; rows are sorted by share count and trimmed to `max`.
+ *
+ * @param {UseShareViewsArgs} args - Hook arguments.
+ * @return The current data/loading/error state.
+ */
+export default function useShareViews( { max }: UseShareViewsArgs ): ShareViewsState {
+	const { data, isLoading, isFetching, isError, refetch } = useStatsSite();
+
+	const summary = ( data as { stats?: Record< string, unknown > } | undefined )?.stats ?? {};
+
+	const items = Object.entries( summary )
+		.filter( ( [ key ] ) => key.startsWith( SHARES_PREFIX ) )
+		.map( ( [ key, value ] ) => {
+			const service = key.slice( SHARES_PREFIX.length );
+			return { service, label: serviceLabel( service ), value: Number( value ) || 0 };
+		} )
+		.filter( item => item.value > 0 )
+		.sort( ( a, b ) => b.value - a.value )
+		.slice( 0, max > 0 ? max : undefined );
+
+	return {
+		data: items,
+		isLoading,
+		isFetching,
+		// The summary query carries `placeholderData: previousData => previousData`, so
+		// keep showing prior rows on a transient refetch failure and only surface the
+		// error when there's nothing to show.
+		isError: items.length === 0 && isError,
+		refetch,
+	};
+}

--- a/projects/packages/premium-analytics/widgets/shares/use-share-views.ts
+++ b/projects/packages/premium-analytics/widgets/shares/use-share-views.ts
@@ -1,4 +1,8 @@
 /**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+/**
  * Internal dependencies
  */
 import { useStatsSite } from '@jetpack-premium-analytics/data';
@@ -52,8 +56,26 @@ const SERVICE_LABELS: Record< string, string > = {
 	print: 'Print',
 	email: 'Email',
 	press_this: 'Press This',
-	jetpack_whatsapp: 'WhatsApp',
+	custom: __( 'Custom share buttons', 'jetpack-premium-analytics' ),
 };
+
+function canonicalService( service: string ): string {
+	const normalized = service.replace( /-/g, '_' );
+
+	if ( normalized.startsWith( 'custom_' ) ) {
+		return 'custom';
+	}
+
+	if ( normalized.startsWith( 'google_plus' ) ) {
+		return 'google_plus';
+	}
+
+	if ( normalized === 'jetpack_whatsapp' ) {
+		return 'whatsapp';
+	}
+
+	return normalized;
+}
 
 function serviceLabel( service: string ): string {
 	return (
@@ -64,6 +86,34 @@ function serviceLabel( service: string ): string {
 			.map( part => part.charAt( 0 ).toUpperCase() + part.slice( 1 ) )
 			.join( ' ' )
 	);
+}
+
+export function buildShareViews( summary: Record< string, unknown >, max: number ): ShareView[] {
+	const byService = new Map< string, ShareView >();
+
+	Object.entries( summary ).forEach( ( [ key, value ] ) => {
+		if ( ! key.startsWith( SHARES_PREFIX ) ) {
+			return;
+		}
+
+		const count = Number( value ) || 0;
+		if ( count <= 0 ) {
+			return;
+		}
+
+		const service = canonicalService( key.slice( SHARES_PREFIX.length ) );
+		const previous = byService.get( service );
+
+		byService.set( service, {
+			service,
+			label: serviceLabel( service ),
+			value: ( previous?.value ?? 0 ) + count,
+		} );
+	} );
+
+	return [ ...byService.values() ]
+		.sort( ( a, b ) => b.value - a.value )
+		.slice( 0, max > 0 ? max : undefined );
 }
 
 /**
@@ -81,15 +131,7 @@ export default function useShareViews( { max }: UseShareViewsArgs ): ShareViewsS
 
 	const summary = ( data as { stats?: Record< string, unknown > } | undefined )?.stats ?? {};
 
-	const items = Object.entries( summary )
-		.filter( ( [ key ] ) => key.startsWith( SHARES_PREFIX ) )
-		.map( ( [ key, value ] ) => {
-			const service = key.slice( SHARES_PREFIX.length );
-			return { service, label: serviceLabel( service ), value: Number( value ) || 0 };
-		} )
-		.filter( item => item.value > 0 )
-		.sort( ( a, b ) => b.value - a.value )
-		.slice( 0, max > 0 ? max : undefined );
+	const items = buildShareViews( summary, max );
 
 	return {
 		data: items,

--- a/projects/packages/premium-analytics/widgets/shares/widget.json
+++ b/projects/packages/premium-analytics/widgets/shares/widget.json
@@ -1,0 +1,7 @@
+{
+	"name": "jpa/shares",
+	"title": "Shares",
+	"description": "The number of times your content was shared to social networks.",
+	"category": "stats",
+	"presentation": "framed"
+}

--- a/projects/packages/premium-analytics/widgets/shares/widget.ts
+++ b/projects/packages/premium-analytics/widgets/shares/widget.ts
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { share } from '@wordpress/icons';
+import type { WidgetAttributeField } from '@wordpress/widget-primitives';
+
+export type SharesAttributes = {
+	/**
+	 * Maximum number of rows to display.
+	 */
+	max?: number;
+};
+
+/**
+ * Widget type definition for the Shares widget.
+ *
+ * Ported from the Jetpack Stats "Shares" module. Lists each social network your
+ * content was shared to, ranked by the number of shares.
+ *
+ * Data: read from the site summary (`stats` endpoint) via `useStatsSite`; the
+ * `shares_<service>` fields hold the per-network counts. The summary is all-time
+ * and has no comparison period, so the widget ignores the dashboard date range.
+ */
+export default {
+	name: 'jpa/shares',
+	title: __( 'Shares', 'jetpack-premium-analytics' ),
+	icon: share,
+	attributes: [
+		{
+			id: 'max',
+			label: __( 'Number of results', 'jetpack-premium-analytics' ),
+			type: 'integer',
+		},
+	] as WidgetAttributeField< SharesAttributes >[],
+	example: {
+		attributes: {
+			max: 10,
+		},
+	},
+};


### PR DESCRIPTION
Fixes WOOA7S-1502

## Proposed changes

Ports the Jetpack Stats **Shares** module into a registered Premium Analytics widget (`jpa/shares`).

**Why.** This is a re-do of #50148, which is being closed. That PR rendered Publicize **follower counts** (via `useStatsPublicize`) — the data behind the upstream `stats-reach` module — rather than the **Shares** module this issue is scoped to. The upstream source ([`stats-shares.tsx`](https://github.com/Automattic/wp-calypso/blob/trunk/client/my-sites/stats/features/modules/stats-shares/stats-shares.tsx)) is the "Number of Shares" card: how many times content was shared to each social network, not follower counts.

**How.** The share counts already live on the site summary (`stats` endpoint) as `shares_<service>` fields, so the widget reads them through the existing `useStatsSite` hook — no new data-package hook or query. A widget-local view hook (`use-share-views.ts`) scans the `shares_<service>` summary keys, labels known services, sorts by count, and trims to `max`. The summary is all-time with no comparison period, so the widget renders current counts with no period-over-period deltas.

**Design note — data-driven service list (intentional divergence from upstream).** Upstream `stats-shares.tsx` intersects the counts with `useSharingButtonsQuery` — the site's _currently enabled_ sharing buttons. Because share counts are all-time historical, that approach hides historical shares for any network whose share button was later turned off (e.g. years of Facebook shares vanish the moment the Facebook button is disabled). This widget instead derives the service list from the summary's own `shares_<service>` keys, so historical counts stay visible regardless of the current button config, and a network Jetpack adds server-side shows up automatically — no extra sharing-buttons query. The single assumption, that every `shares_<service>` key is a per-network count, is pinned with a comment in the hook.

**What.**

- New `widgets/shares/` workspace package: `package.json`, `widget.json`, `widget.ts`, `use-share-views.ts`, `render.tsx`, `style.module.css`, and a Storybook story.
- Follows the current Stats-widget contract: two-component structure, `<WidgetRoot>` seeded with host `attributes`, and `<WidgetState>` (not the legacy `WidgetLoadingOverlay`) for loading/error/empty. Empty state uses a neutral glyph and the upstream "Learn where your content has been shared the most." copy.
- Storybook mocks reuse the shared harness: the bare `/stats` summary is already routed by `registerReportMocks()`, so this only adds `shares_*` fields to the existing `site-summary` fixture — no story-scoped `apiFetch` middleware.
- Changelog entry added.

No changes to `packages/data`, `packages/widgets-toolkit` source, or `@automattic/charts`.

**Follow-up.** WOOA7S-1706 tracks unifying this widget-local service-label map with the data package's `publicizeServices` registry into one shared source (and giving Shares the service icons the Reach widget already renders), so the two social widgets stay visually consistent. Kept out of this PR to leave the data source untouched.

## Does this pull request change what data or activity we track or use?

No. It surfaces existing Jetpack Stats share-count data through a new dashboard widget.

## Testing instructions

- `pnpm --dir projects/js-packages/storybook run storybook:dev` → open **Packages / Premium Analytics / Widgets / Shares** and confirm the `Default`, `WithComparison`, and `WidgetDashboardWithWidget` stories render a populated leaderboard (Facebook / Twitter / LinkedIn / Tumblr). `WithComparison` shows the same counts with no deltas, as documented.
- Verified locally: `/widget-audit shares` clean, `eslint` clean, `tsgo` typecheck clean, and `jetpack build --deps packages/premium-analytics` succeeds (`jpa/shares` appears in the generated widget registry).
- Live-dashboard verification pending — handled centrally.


https://github.com/user-attachments/assets/643fe7b8-effe-41d2-833f-fff92a41e8a6

