### PR TITLE
Verbum Comments: enable social login inside the iframe via Storage Access API

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/cm-841-surface-login-requirement
+++ b/projects/packages/jetpack-mu-wpcom/changelog/cm-841-surface-login-requirement
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Verbum Comments: surface the login requirement up front when registration is required but in-frame social login is unavailable, instead of showing a guest form that is rejected on submit.

--- a/projects/packages/jetpack-mu-wpcom/changelog/verbum-iframe-social-login-storage-access
+++ b/projects/packages/jetpack-mu-wpcom/changelog/verbum-iframe-social-login-storage-access
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Verbum Comments: allow social login (WordPress.com / Facebook) inside the cross-origin comment iframe on Atomic/Jetpack sites by requesting first-party cookie access via the Storage Access API.

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
@@ -237,6 +237,7 @@ class Verbum_Comments {
 					/* translators: %s is the name of the provider (WordPress, Facebook, Twitter) */
 					'Logged in via %s'                   => __( 'Logged in via %s', 'jetpack-mu-wpcom' ),
 					'Log out'                            => __( 'Log out', 'jetpack-mu-wpcom' ),
+					'Log in'                             => __( 'Log in', 'jetpack-mu-wpcom' ),
 					'Email'                              => __( 'Email', 'jetpack-mu-wpcom' ),
 					'(Address never made public)'        => __( '(Address never made public)', 'jetpack-mu-wpcom'), // phpcs:ignore PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket
 					'Instantly'                          => __( 'Instantly', 'jetpack-mu-wpcom' ),

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/logged-out.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/logged-out.tsx
@@ -40,6 +40,29 @@ const getLoginCommentText = ( commentParent: Signal ) => {
 	return <span>{ defaultText }</span>;
 };
 
+/**
+ * Build a top-level login URL for the site the comment form belongs to.
+ *
+ * On Atomic/Jetpack the comment form runs inside a cross-origin iframe, so the parent post URL
+ * is passed in via the location hash (`#parent=…`). We log in against that site so the visitor
+ * returns authenticated (via Jetpack SSO) and can comment.
+ */
+const getSiteLoginUrl = () => {
+	const parentUrl = decodeURIComponent(
+		window.location.hash.match( /[#&]parent=([^&]*)/ )?.[ 1 ] ?? ''
+	);
+
+	const target = parentUrl || VerbumComments.homeURL || '';
+
+	try {
+		return `${ new URL( target ).origin }/wp-login.php?redirect_to=${ encodeURIComponent(
+			target
+		) }`;
+	} catch {
+		return target;
+	}
+};
+
 export const LoggedOut = ( { login, canWeAccessCookies, loginWindow }: LoggedOutProps ) => {
 	const [ activeService, setActiveService ] = useState( '' );
 	const closeLoginPopupService = requireNameEmail && ! mustLogIn ? 'mail' : '';
@@ -83,6 +106,34 @@ export const LoggedOut = ( { login, canWeAccessCookies, loginWindow }: LoggedOut
 	};
 
 	const { commentParent } = useContext( VerbumSignals );
+
+	// Login is required but we can't render the in-frame login options (e.g. cross-origin
+	// iframe on Atomic where cookies are blocked). Showing the guest form here is a dead end:
+	// the comment is rejected on submit with "you must be logged in". Surface the requirement
+	// up front with a link to log in instead.
+	const loginRequiredWithoutInFrameAuth = mustLogIn && ! canWeAccessCookies;
+
+	if ( loginRequiredWithoutInFrameAuth ) {
+		return (
+			<div className="verbum-subscriptions logged-out">
+				<div className="verbum-subscriptions__wrapper">
+					<div className="verbum-subscriptions__login verbum-subscriptions__login-required">
+						<div className="verbum-subscriptions__login-header">
+							{ getLoginCommentText( commentParent ) }
+						</div>
+						<a
+							className="components-button is-primary"
+							href={ getSiteLoginUrl() }
+							target="_top"
+							rel="noopener noreferrer"
+						>
+							{ translate( 'Log in' ) }
+						</a>
+					</div>
+				</div>
+			</div>
+		);
+	}
 
 	return (
 		<div className="verbum-subscriptions logged-out">

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/logged-out.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/logged-out.tsx
@@ -107,11 +107,15 @@ export const LoggedOut = ( { login, canWeAccessCookies, loginWindow }: LoggedOut
 
 	const { commentParent } = useContext( VerbumSignals );
 
-	// Login is required but we can't render the in-frame login options (e.g. cross-origin
-	// iframe on Atomic where cookies are blocked). Showing the guest form here is a dead end:
-	// the comment is rejected on submit with "you must be logged in". Surface the requirement
-	// up front with a link to log in instead.
-	const loginRequiredWithoutInFrameAuth = mustLogIn && ! canWeAccessCookies;
+	// In the iframe (Atomic/Jetpack) we offer social login and request cookie access on click,
+	// so the buttons render even when the cookie test currently fails.
+	const showSocialButtons = canWeAccessCookies || !! VerbumComments.isJetpackComments;
+
+	// Login is required but there's no way to log in here (cookies blocked and not in the iframe
+	// where social login is offered). Showing the guest form would be a dead end: the comment is
+	// rejected on submit with "you must be logged in". Surface the requirement with a login link.
+	const loginRequiredWithoutInFrameAuth =
+		mustLogIn && ! canWeAccessCookies && ! VerbumComments.isJetpackComments;
 
 	if ( loginRequiredWithoutInFrameAuth ) {
 		return (
@@ -139,7 +143,7 @@ export const LoggedOut = ( { login, canWeAccessCookies, loginWindow }: LoggedOut
 		<div className="verbum-subscriptions logged-out">
 			<div className="verbum-subscriptions__wrapper">
 				<div className="verbum-subscriptions__login">
-					{ canWeAccessCookies && (
+					{ showSocialButtons && (
 						<>
 							<div className="verbum-subscriptions__login-header">
 								{ getLoginCommentText( commentParent ) }
@@ -198,7 +202,12 @@ export const LoggedOut = ( { login, canWeAccessCookies, loginWindow }: LoggedOut
 							</div>
 						</>
 					) }
-					<EmailForm shouldShowEmailForm={ activeService === 'mail' || ! canWeAccessCookies } />
+					<EmailForm
+						shouldShowEmailForm={
+							activeService === 'mail' ||
+							( ! canWeAccessCookies && ! VerbumComments.isJetpackComments )
+						}
+					/>
 				</div>
 			</div>
 		</div>

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/logged-out.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/components/logged-out.tsx
@@ -46,6 +46,8 @@ const getLoginCommentText = ( commentParent: Signal ) => {
  * On Atomic/Jetpack the comment form runs inside a cross-origin iframe, so the parent post URL
  * is passed in via the location hash (`#parent=…`). We log in against that site so the visitor
  * returns authenticated (via Jetpack SSO) and can comment.
+ *
+ * @return {string} - The site's login URL, or the bare target if it can't be parsed.
  */
 const getSiteLoginUrl = () => {
 	const parentUrl = decodeURIComponent(
@@ -111,13 +113,11 @@ export const LoggedOut = ( { login, canWeAccessCookies, loginWindow }: LoggedOut
 	// so the buttons render even when the cookie test currently fails.
 	const showSocialButtons = canWeAccessCookies || !! VerbumComments.isJetpackComments;
 
-	// Login is required but there's no way to log in here (cookies blocked and not in the iframe
-	// where social login is offered). Showing the guest form would be a dead end: the comment is
-	// rejected on submit with "you must be logged in". Surface the requirement with a login link.
-	const loginRequiredWithoutInFrameAuth =
-		mustLogIn && ! canWeAccessCookies && ! VerbumComments.isJetpackComments;
+	// Login is required but cookies are blocked, so an in-frame login may not stick. Keep the
+	// top-level login link on offer — without it, a denied cookie prompt is a dead end again.
+	const showSiteLogin = mustLogIn && ! canWeAccessCookies;
 
-	if ( loginRequiredWithoutInFrameAuth ) {
+	if ( showSiteLogin && ! showSocialButtons ) {
 		return (
 			<div className="verbum-subscriptions logged-out">
 				<div className="verbum-subscriptions__wrapper">
@@ -202,10 +202,19 @@ export const LoggedOut = ( { login, canWeAccessCookies, loginWindow }: LoggedOut
 							</div>
 						</>
 					) }
+					{ showSiteLogin && showSocialButtons && (
+						<a
+							className="components-button is-link verbum-subscriptions__login-link"
+							href={ getSiteLoginUrl() }
+							target="_top"
+							rel="noopener noreferrer"
+						>
+							{ translate( 'Log in' ) }
+						</a>
+					) }
 					<EmailForm
 						shouldShowEmailForm={
-							activeService === 'mail' ||
-							( ! canWeAccessCookies && ! VerbumComments.isJetpackComments )
+							activeService === 'mail' || ( ! canWeAccessCookies && ! mustLogIn )
 						}
 					/>
 				</div>

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/hooks/useSocialLogin.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/hooks/useSocialLogin.tsx
@@ -26,6 +26,29 @@ const addWordPressDomain = window.location.hostname.endsWith( '.wordpress.com' )
 	: '';
 
 /**
+ * Ask the browser to grant this (cross-origin) frame access to its first-party cookies.
+ *
+ * On Atomic/Jetpack, Verbum runs inside a third-party iframe where the `.wordpress.com` auth
+ * cookies can't be read/written, so the social login state can't be established. The Storage
+ * Access API restores first-party cookie access, but only from a user gesture — so this must be
+ * called synchronously off the login click. If it's denied or unsupported we fall through: the
+ * popup + postMessage flow still authenticates for the current session, only persistence is lost.
+ */
+const ensureCookieAccess = async () => {
+	try {
+		if (
+			typeof document.hasStorageAccess === 'function' &&
+			typeof document.requestStorageAccess === 'function' &&
+			! ( await document.hasStorageAccess() )
+		) {
+			await document.requestStorageAccess();
+		}
+	} catch {
+		// Access denied or unsupported — social login still works in-session via postMessage.
+	}
+};
+
+/**
  * Hook to retrieve user info from server, handle social login, and logout functionality.
  *
  * @return {object} login, loginWindowRef, logout - login is a function to open the social login popup, loginWindowRef is a reference to the login popup window, and logout is a function to logout the user.
@@ -74,6 +97,13 @@ export default function useSocialLogin() {
 
 	const login = async ( service: SocialServiceName ) => {
 		const { connectURL } = VerbumComments;
+
+		// Restore first-party cookie access before logging in, so the login state can persist
+		// inside the iframe. Runs off the login-button gesture, which the Storage Access API requires.
+		if ( VerbumComments.isJetpackComments ) {
+			await ensureCookieAccess();
+		}
+
 		const broadcastChannel = new BroadcastChannel( 'verbum_post_message' );
 
 		const loginWindow = window.open(

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/hooks/useSocialLogin.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/hooks/useSocialLogin.tsx
@@ -29,22 +29,18 @@ const addWordPressDomain = window.location.hostname.endsWith( '.wordpress.com' )
  * Ask the browser to grant this (cross-origin) frame access to its first-party cookies.
  *
  * On Atomic/Jetpack, Verbum runs inside a third-party iframe where the `.wordpress.com` auth
- * cookies can't be read/written, so the social login state can't be established. The Storage
- * Access API restores first-party cookie access, but only from a user gesture — so this must be
- * called synchronously off the login click. If it's denied or unsupported we fall through: the
- * popup + postMessage flow still authenticates for the current session, only persistence is lost.
+ * cookies can't be read or written, so a social login never sticks — and the comment POST back to
+ * jetpack.wordpress.com arrives without a session, which WP.com downgrades to a guest comment.
+ *
+ * Best-effort: not awaited, so the login popup still opens on the same click. `window.open()` and
+ * this both want the user gesture, and the popup is the one that breaks visibly without it. If
+ * access is denied the visitor stays logged out and the top-level login link remains available.
  */
-const ensureCookieAccess = async () => {
+const requestCookieAccess = () => {
 	try {
-		if (
-			typeof document.hasStorageAccess === 'function' &&
-			typeof document.requestStorageAccess === 'function' &&
-			! ( await document.hasStorageAccess() )
-		) {
-			await document.requestStorageAccess();
-		}
+		document.requestStorageAccess?.().catch( () => {} );
 	} catch {
-		// Access denied or unsupported — social login still works in-session via postMessage.
+		// Unsupported — the caller handles the still-logged-out case.
 	}
 };
 
@@ -95,15 +91,8 @@ export default function useSocialLogin() {
 		document.cookie = `${ cookieName }=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/; SameSite=None; Secure=True;${ addWordPressDomain }`;
 	};
 
-	const login = async ( service: SocialServiceName ) => {
+	const login = ( service: SocialServiceName ) => {
 		const { connectURL } = VerbumComments;
-
-		// Restore first-party cookie access before logging in, so the login state can persist
-		// inside the iframe. Runs off the login-button gesture, which the Storage Access API requires.
-		if ( VerbumComments.isJetpackComments ) {
-			await ensureCookieAccess();
-		}
-
 		const broadcastChannel = new BroadcastChannel( 'verbum_post_message' );
 
 		const loginWindow = window.open(
@@ -111,6 +100,11 @@ export default function useSocialLogin() {
 			'VerbumCommentsLogin',
 			`status=0,toolbar=0,location=1,menubar=0,directories=0,resizable=1,scrollbars=0${ serviceData[ service ].popup }`
 		);
+
+		// Requested once the popup is open, so it resolves while the visitor is still logging in.
+		if ( VerbumComments.isJetpackComments ) {
+			requestCookieAccess();
+		}
 
 		const waitForLogin = ( event: MessageEvent ) => {
 			if (

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/hooks/useSocialLogin.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/hooks/useSocialLogin.tsx
@@ -93,7 +93,16 @@ export default function useSocialLogin() {
 
 	const login = ( service: SocialServiceName ) => {
 		const { connectURL } = VerbumComments;
-		const broadcastChannel = new BroadcastChannel( 'verbum_post_message' );
+
+		// BroadcastChannel needs storage access, which a cookie-blocked iframe doesn't have — Firefox
+		// throws SecurityError. It's a secondary channel: the popup also posts back via
+		// window.postMessage, picked up by the listener below, so carry on without it.
+		let broadcastChannel: BroadcastChannel | null = null;
+		try {
+			broadcastChannel = new BroadcastChannel( 'verbum_post_message' );
+		} catch {
+			// No channel available.
+		}
 
 		const loginWindow = window.open(
 			`${ connectURL }&blog_id=${ VerbumComments.siteId }&post_id=${ VerbumComments.postId }&service=${ service }`,
@@ -136,7 +145,7 @@ export default function useSocialLogin() {
 
 		// Listen for login data
 		window.addEventListener( 'message', waitForLogin );
-		broadcastChannel.addEventListener( 'message', waitForLogin );
+		broadcastChannel?.addEventListener( 'message', waitForLogin );
 
 		// Clean up loginWindow to reset activeService
 		const loginClosed = setInterval( () => {
@@ -144,8 +153,8 @@ export default function useSocialLogin() {
 				clearInterval( loginClosed );
 				setLoginWindowRef( undefined );
 				window.removeEventListener( 'message', waitForLogin );
-				broadcastChannel.removeEventListener( 'message', waitForLogin );
-				broadcastChannel.close();
+				broadcastChannel?.removeEventListener( 'message', waitForLogin );
+				broadcastChannel?.close();
 			}
 		}, 100 );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/state.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/state.tsx
@@ -20,12 +20,15 @@ export function createSignals() {
 	 * Here we also check if cookies are accessible, userInfo is set and the service is different from 'guest' or 'jetpack'.
 	 */
 	const userLoggedIn = computed( () => {
+		const info = userInfo.value;
+		const isExternalService =
+			!! info && info.service !== 'guest' && info.service !== 'jetpack';
+
+		// A fresh social login (via postMessage) carries an access_token even when cookies are
+		// blocked in the iframe, so treat that as logged in too — not just readable-cookie logins.
 		return (
 			VerbumComments.isJetpackCommentsLoggedIn ||
-			( canWeAccessCookies() &&
-				userInfo.value &&
-				userInfo.value?.service !== 'guest' &&
-				userInfo.value?.service !== 'jetpack' )
+			( isExternalService && ( canWeAccessCookies() || !! info.access_token ) )
 		);
 	} );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/state.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/state.tsx
@@ -20,15 +20,12 @@ export function createSignals() {
 	 * Here we also check if cookies are accessible, userInfo is set and the service is different from 'guest' or 'jetpack'.
 	 */
 	const userLoggedIn = computed( () => {
-		const info = userInfo.value;
-		const isExternalService =
-			!! info && info.service !== 'guest' && info.service !== 'jetpack';
-
-		// A fresh social login (via postMessage) carries an access_token even when cookies are
-		// blocked in the iframe, so treat that as logged in too — not just readable-cookie logins.
 		return (
 			VerbumComments.isJetpackCommentsLoggedIn ||
-			( isExternalService && ( canWeAccessCookies() || !! info.access_token ) )
+			( canWeAccessCookies() &&
+				userInfo.value &&
+				userInfo.value?.service !== 'guest' &&
+				userInfo.value?.service !== 'jetpack' )
 		);
 	} );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/style.scss
@@ -332,6 +332,13 @@
 							padding-bottom: 16px;
 						}
 
+						.verbum-subscriptions__login-required {
+
+							.components-button.is-primary {
+								text-decoration: none;
+							}
+						}
+
 						.verbum-logins {
 							display: flex;
 							align-items: center;

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/style.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/style.scss
@@ -339,6 +339,11 @@
 							}
 						}
 
+						.verbum-subscriptions__login-link {
+							display: inline-block;
+							margin-block-start: 8px;
+						}
+
 						.verbum-logins {
 							display: flex;
 							align-items: center;

--- a/projects/plugins/jetpack/changelog/verbum-iframe-social-login-storage-access
+++ b/projects/plugins/jetpack/changelog/verbum-iframe-social-login-storage-access
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Comments: allow the comment form iframe to request first-party cookie access, so social login can work inside it.

--- a/projects/plugins/jetpack/modules/comments/comments.php
+++ b/projects/plugins/jetpack/modules/comments/comments.php
@@ -518,7 +518,8 @@ HTML;
 					<?php endif; ?>
 					class="jetpack_remote_comment"
 					id="jetpack_remote_comment"
-					sandbox="allow-same-origin allow-top-navigation allow-scripts allow-forms allow-popups"
+					<?php // `allow-storage-access-by-user-activation` lets the form request first-party cookie access; without it the browser refuses the request outright. ?>
+					sandbox="allow-same-origin allow-top-navigation allow-scripts allow-forms allow-popups allow-storage-access-by-user-activation"
 				>
 					<?php if ( $is_amp ) : ?>
 						<button overflow><?php esc_html_e( 'Show more', 'jetpack' ); ?></button>


### PR DESCRIPTION
## Proposed changes

Follow-up to #50396. Verbum runs in a third-party iframe (`jetpack.wordpress.com`) embedded in the site's own domain, so it can't read or write the `.wordpress.com` auth cookies — which is why social login is suppressed there. This uses the **Storage Access API** to try to restore first-party cookie access, so WordPress.com / Facebook login can work inside the comment iframe on Atomic/Jetpack sites.

* `useSocialLogin`: on the login click, open the popup first and then call `document.requestStorageAccess()` without awaiting it. Both want the user gesture, and the popup is the one that breaks visibly without it.
* `logged-out`: render the social buttons in the iframe even when the cookie test currently fails, so there is something to click. #50396's top-level login link stays on offer alongside them, and the guest form is suppressed whenever login is required (it would be rejected on submit).

Nothing here weakens `comment_registration` — when it works, the visitor gets a real WordPress.com session and WP.com signs the identity server-side.

### Why cookie access has to actually be granted

If the session isn't readable on `jetpack.wordpress.com` when the form POSTs, WP.com's `process_remote_comment_form_hc_post_as()` falls through from `case 'wordpress'` to the `default` branch and rewrites `hc_post_as` to `guest`. The site then rejects the comment with "you must be logged in". So a denied prompt is not a soft degradation — the login silently does not count.

That's why this PR no longer flips `userLoggedIn` on a bare `access_token`: showing someone as logged in when the POST will be downgraded just moves the dead end to after they've logged in. If access is denied the visitor stays logged out and still has the login link.

## Related product discussion/links

* CM-841

## Does this pull request change what data or activity we track or use?

No. It requests browser storage access to read existing first-party auth cookies; no new data is collected.

## Testing instructions

> Stacked on #50396 — review/merge that first.

1. On an Atomic (WoA) site, enable Settings → Discussion → "Users must be registered and logged in to comment".
2. Open a post as a logged-out visitor.
3. **Before:** no WordPress.com/Facebook options render — just a guest form that fails on submit.
4. **After:** the WordPress.com and Facebook buttons render, with a "Log in" link as a fallback.
5. Click WordPress.com. Confirm **the popup is not blocked** — this is the main thing this revision changes. Allow the cookie prompt if one appears, complete the login, then post a comment and confirm it saves.
6. Repeat with the cookie prompt **denied**. Confirm you are not shown as logged in, and that the "Log in" link is still there and works.
7. Repeat with `comment_registration` **off**: the guest form should still be available as it is today.
8. Confirm Simple sites (first-party, non-iframe) are unchanged.

### Still needs verifying before this is trusted

* **Does the grant cover the form POST?** Submitting navigates the iframe to `jetpack.wordpress.com`, a cross-site navigation. If the storage-access grant doesn't cause the session cookie to be attached to that request, `is_user_logged_in()` is false on WP.com and step 5 fails even though the prompt was allowed. This needs checking in Chrome, Safari and Firefox — it is the assumption the whole approach rests on.
* **How often is the prompt even offered?** Browsers generally require recent first-party interaction with wordpress.com before prompting, and otherwise deny outright. If that is rare for a typical blog visitor, most people land on the fallback path.
* Popup and prompt ordering across those same three browsers, with cold profiles.
