### PR TITLE
Post-publish sharing panel: add missing space between sentence and link

### DIFF
--- a/projects/packages/publicize/_inc/components/manual-sharing/info.tsx
+++ b/projects/packages/publicize/_inc/components/manual-sharing/info.tsx
@@ -18,7 +18,7 @@ export function ManualSharingInfo( { ...textProps }: ManualSharingInfoProps ) {
 			{ __(
 				`Just tap the social network or "Copy to Clipboard" icon, and we'll format your content for sharing.`,
 				'jetpack-publicize-pkg'
-			) }
+			) }{ ' ' }
 			<Link openInNewTab href={ getRedirectUrl( 'jetpack-social-manual-sharing-help' ) }>
 				{ __( 'Learn more', 'jetpack-publicize-pkg' ) }
 			</Link>

--- a/projects/packages/publicize/changelog/fix-missing-space-post-publish-sharing-sentence
+++ b/projects/packages/publicize/changelog/fix-missing-space-post-publish-sharing-sentence
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Post-publish sharing panel: add missing space between sentence and link.


### PR DESCRIPTION
Fixes CM-842

## Proposed changes

The manual sharing info text in the post-publish panel rendered the closing sentence and the "Learn more" link with no space between them, so they displayed run together ("…for sharing.Learn more").

Add the missing space between the sentence and the `Link` component so the link reads as its own separate element.

| **Before** | **After** |
|--------|--------|
| <img width="349" height="250" alt="Screenshot 2026-07-10 at 13 25 37" src="https://github.com/user-attachments/assets/3d03aabc-917e-4454-b992-8f8c16d56c6d" /> | <img width="288" height="253" alt="image" src="https://github.com/user-attachments/assets/3583505d-f98a-4b9d-be32-f2be5bc7afc9" /> |

## Related product discussion/links

* CM-842

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Apply the branch and build the Publicize package (or the Social / Jetpack plugin).
* Publish a post and open the post-publish panel, then look at the manual sharing section.
* Confirm there is now a space between "…we'll format your content for sharing." and the "Learn more" link.
