### PR TITLE
WPCOM JSON API: support path-parameter endpoints over the REST transport

### DIFF
--- a/projects/plugins/jetpack/changelog/add-json-api-rest-path-param-endpoints
+++ b/projects/plugins/jetpack/changelog/add-json-api-rest-path-param-endpoints
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+JSON API: support path-parameter endpoints over the REST transport, so single-item and action routes can migrate off XML-RPC.

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -2725,7 +2725,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 	public function create_rest_route_for_endpoint() {
 		register_rest_route(
 			static::REST_NAMESPACE,
-			$this->build_rest_route(),
+			$this->build_rest_route_regex(),
 			array(
 				'methods'             => $this->method,
 				'callback'            => array( $this, 'rest_callback' ),
@@ -2890,6 +2890,51 @@ abstract class WPCOM_JSON_API_Endpoint {
 	public function build_rest_route() {
 		$version_prefix = $this->max_version ? 'v' . $this->max_version : '';
 		return $version_prefix . $this->rest_route;
+	}
+
+	/**
+	 * REST route with %d/%s path tokens converted to named captures, for register_rest_route().
+	 * Static (token-less) routes are returned unchanged.
+	 *
+	 * @return string
+	 */
+	public function build_rest_route_regex() {
+		$route = $this->build_rest_route();
+		if ( ! str_contains( $route, '%' ) ) {
+			return $route;
+		}
+
+		$index = 0;
+		return preg_replace_callback(
+			'/%[sd]/',
+			function ( $matches ) use ( &$index ) {
+				$name = 'p' . ( ++$index );
+				return '%d' === $matches[0] ? "(?P<$name>\\d+)" : "(?P<$name>[^/]+)";
+			},
+			$route
+		);
+	}
+
+	/**
+	 * Concrete REST route for a single request: the real path-parameter values (from the request URL,
+	 * minus the leading site segment) substituted into the tokenized rest_route. Static routes are
+	 * returned unchanged. Used by the proxy transport.
+	 *
+	 * @param string $url Full request URL.
+	 * @return string
+	 */
+	public function build_concrete_rest_route( $url ) {
+		if ( ! str_contains( (string) $this->rest_route, '%' ) ) {
+			return $this->build_rest_route();
+		}
+
+		// The request path minus its "/rest/vX.Y/sites/<site>" prefix already IS the concrete route
+		// tail. The proxy matched this request to the endpoint's path template first, so the tail is
+		// guaranteed to fit the pattern build_rest_route_regex() registered on the remote.
+		$path = (string) wp_parse_url( $url, PHP_URL_PATH );
+		$path = preg_replace( '#^/rest/v[\d.]+/sites/[^/]+#', '', $path );
+
+		return 'v' . $this->max_version . $path;
 	}
 
 	/**

--- a/projects/plugins/jetpack/class.json-api-endpoints.php
+++ b/projects/plugins/jetpack/class.json-api-endpoints.php
@@ -2893,15 +2893,23 @@ abstract class WPCOM_JSON_API_Endpoint {
 	}
 
 	/**
+	 * Whether the endpoint's rest_route carries %d/%s path-parameter tokens.
+	 *
+	 * @return bool
+	 */
+	private function rest_route_has_tokens() {
+		return str_contains( (string) $this->rest_route, '%' );
+	}
+
+	/**
 	 * REST route with %d/%s path tokens converted to named captures, for register_rest_route().
 	 * Static (token-less) routes are returned unchanged.
 	 *
 	 * @return string
 	 */
 	public function build_rest_route_regex() {
-		$route = $this->build_rest_route();
-		if ( ! str_contains( $route, '%' ) ) {
-			return $route;
+		if ( ! $this->rest_route_has_tokens() ) {
+			return $this->build_rest_route();
 		}
 
 		$index = 0;
@@ -2911,7 +2919,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 				$name = 'p' . ( ++$index );
 				return '%d' === $matches[0] ? "(?P<$name>\\d+)" : "(?P<$name>[^/]+)";
 			},
-			$route
+			$this->build_rest_route()
 		);
 	}
 
@@ -2924,7 +2932,7 @@ abstract class WPCOM_JSON_API_Endpoint {
 	 * @return string
 	 */
 	public function build_concrete_rest_route( $url ) {
-		if ( ! str_contains( (string) $this->rest_route, '%' ) ) {
+		if ( ! $this->rest_route_has_tokens() ) {
 			return $this->build_rest_route();
 		}
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-post-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-post-v1-1-endpoint.php
@@ -20,7 +20,7 @@ new WPCOM_JSON_API_Get_Post_v1_1_Endpoint(
 
 		// The %d token is substituted with the real post ID by the transport (build_concrete_rest_route).
 		'rest_route'                           => '/posts/%d',
-		'rest_min_jp_version'                  => '16.0',
+		'rest_min_jp_version'                  => '17.0-a.1',
 
 		'allow_fallback_to_jetpack_blog_token' => true,
 
@@ -44,7 +44,7 @@ new WPCOM_JSON_API_Get_Post_v1_1_Endpoint(
 
 		// The slug:%s token is substituted with the real slug by the transport (build_concrete_rest_route).
 		'rest_route'                           => '/posts/slug:%s',
-		'rest_min_jp_version'                  => '16.0',
+		'rest_min_jp_version'                  => '17.0-a.1',
 
 		'allow_fallback_to_jetpack_blog_token' => true,
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-post-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-post-v1-1-endpoint.php
@@ -20,7 +20,7 @@ new WPCOM_JSON_API_Get_Post_v1_1_Endpoint(
 
 		// The %d token is substituted with the real post ID by the transport (build_concrete_rest_route).
 		'rest_route'                           => '/posts/%d',
-		'rest_min_jp_version'                  => '17.0-a.1',
+		'rest_min_jp_version'                  => '16.1-a.2',
 
 		'allow_fallback_to_jetpack_blog_token' => true,
 
@@ -44,7 +44,7 @@ new WPCOM_JSON_API_Get_Post_v1_1_Endpoint(
 
 		// The slug:%s token is substituted with the real slug by the transport (build_concrete_rest_route).
 		'rest_route'                           => '/posts/slug:%s',
-		'rest_min_jp_version'                  => '17.0-a.1',
+		'rest_min_jp_version'                  => '16.1-a.2',
 
 		'allow_fallback_to_jetpack_blog_token' => true,
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-post-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-post-v1-1-endpoint.php
@@ -20,7 +20,7 @@ new WPCOM_JSON_API_Get_Post_v1_1_Endpoint(
 
 		// The %d token is substituted with the real post ID by the transport (build_concrete_rest_route).
 		'rest_route'                           => '/posts/%d',
-		'rest_min_jp_version'                  => '16.1-a.2',
+		'rest_min_jp_version'                  => '16.1-a.3',
 
 		'allow_fallback_to_jetpack_blog_token' => true,
 
@@ -44,7 +44,7 @@ new WPCOM_JSON_API_Get_Post_v1_1_Endpoint(
 
 		// The slug:%s token is substituted with the real slug by the transport (build_concrete_rest_route).
 		'rest_route'                           => '/posts/slug:%s',
-		'rest_min_jp_version'                  => '16.1-a.2',
+		'rest_min_jp_version'                  => '16.1-a.3',
 
 		'allow_fallback_to_jetpack_blog_token' => true,
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-post-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-post-v1-1-endpoint.php
@@ -18,6 +18,10 @@ new WPCOM_JSON_API_Get_Post_v1_1_Endpoint(
 			'$post_ID' => '(int) The post ID',
 		),
 
+		// The %d token is substituted with the real post ID by the transport (build_concrete_rest_route).
+		'rest_route'                           => '/posts/%d',
+		'rest_min_jp_version'                  => '16.0',
+
 		'allow_fallback_to_jetpack_blog_token' => true,
 
 		'example_request'                      => 'https://public-api.wordpress.com/rest/v1.1/sites/en.blog.wordpress.com/posts/7',
@@ -38,6 +42,10 @@ new WPCOM_JSON_API_Get_Post_v1_1_Endpoint(
 			'$post_slug' => '(string) The post slug (a.k.a. sanitized name)',
 		),
 
+		// The slug:%s token is substituted with the real slug by the transport (build_concrete_rest_route).
+		'rest_route'                           => '/posts/slug:%s',
+		'rest_min_jp_version'                  => '16.0',
+
 		'allow_fallback_to_jetpack_blog_token' => true,
 
 		'example_request'                      => 'https://public-api.wordpress.com/rest/v1.1/sites/en.blog.wordpress.com/posts/slug:blogging-and-stuff',
@@ -57,9 +65,9 @@ class WPCOM_JSON_API_Get_Post_v1_1_Endpoint extends WPCOM_JSON_API_Post_v1_1_End
 	 * /sites/%s/posts/%d      -> $blog_id, $post_id
 	 * /sites/%s/posts/slug:%s -> $blog_id, $post_id
 	 *
-	 * @param string $path - the path.
-	 * @param int    $blog_id - the blog ID.
-	 * @param int    $post_id - the post ID.
+	 * @param string     $path - the path.
+	 * @param int        $blog_id - the blog ID.
+	 * @param int|string $post_id - the post ID, or the post slug for the `/posts/slug:` route.
 	 */
 	public function callback( $path = '', $blog_id = 0, $post_id = 0 ) {
 		$blog_id = $this->api->switch_to_blog_and_validate_user( $this->api->get_blog_id( $blog_id ) );

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Endpoint_Rest_Route_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Endpoint_Rest_Route_Test.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Unit tests for path-parameter REST route building on WPCOM_JSON_API_Endpoint.
+ *
+ * Run this test with command: jetpack docker phpunit jetpack -- --filter=WPCOM_JSON_API_Endpoint_Rest_Route_Test
+ *
+ * @package automattic/jetpack
+ *
+ * @phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
+ */
+
+use Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversMethod;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
+
+require_once JETPACK__PLUGIN_DIR . 'class.json-api-endpoints.php';
+
+/**
+ * Tests build_rest_route_regex() (route registration on the remote) and build_concrete_rest_route()
+ * (route the proxy sends per request). Together they let path-parameter endpoints ride the REST
+ * transport, which only ever carried a static route before.
+ *
+ * @covers \WPCOM_JSON_API_Endpoint
+ * @covers \WPCOM_JSON_API_Endpoint::build_concrete_rest_route
+ * @covers \WPCOM_JSON_API_Endpoint::build_rest_route_regex
+ */
+#[CoversClass( WPCOM_JSON_API_Endpoint::class )]
+#[CoversMethod( WPCOM_JSON_API_Endpoint::class, 'build_rest_route_regex' )]
+#[CoversMethod( WPCOM_JSON_API_Endpoint::class, 'build_concrete_rest_route' )]
+class WPCOM_JSON_API_Endpoint_Rest_Route_Test extends WP_UnitTestCase {
+	use WP_UnitTestCase_Fix;
+
+	/**
+	 * Build a minimal endpoint with the route-shaping properties set. rest_route is assigned after
+	 * construction so the constructor does not register the route as a side effect.
+	 *
+	 * @param string $rest_route  The endpoint rest_route (may contain %d/%s tokens).
+	 * @param string $path        The endpoint path template.
+	 * @param string $max_version The endpoint max version.
+	 * @return WPCOM_JSON_API_Endpoint
+	 */
+	private function make_endpoint( $rest_route, $path = '', $max_version = '1.1' ) {
+		$endpoint             = new WPCOM_JSON_API_Rest_Route_Test_Endpoint(
+			array(
+				'stat'        => 'test',
+				'path'        => $path,
+				'max_version' => $max_version,
+			)
+		);
+		$endpoint->rest_route = $rest_route;
+		return $endpoint;
+	}
+
+	/**
+	 * Path tokens (%d/%s) become ordered named captures via build_rest_route_regex(); static routes are unchanged.
+	 *
+	 * @dataProvider provide_regex_cases
+	 *
+	 * @param string $rest_route Endpoint rest_route.
+	 * @param string $expected   Expected registration route.
+	 * @group json-api
+	 */
+	#[DataProvider( 'provide_regex_cases' )]
+	#[Group( 'json-api' )]
+	public function test_build_rest_route_regex( $rest_route, $expected ) {
+		$this->assertSame( $expected, $this->make_endpoint( $rest_route )->build_rest_route_regex() );
+	}
+
+	/**
+	 * Data provider for build_rest_route_regex().
+	 *
+	 * @return array<string, array{string, string}>
+	 */
+	public static function provide_regex_cases() {
+		return array(
+			'static (no token)'  => array( '/posts', 'v1.1/posts' ),
+			'by id'              => array( '/posts/%d', 'v1.1/posts/(?P<p1>\d+)' ),
+			'by slug (prefix)'   => array( '/posts/slug:%s', 'v1.1/posts/slug:(?P<p1>[^/]+)' ),
+			'token then literal' => array( '/posts/%d/autosave', 'v1.1/posts/(?P<p1>\d+)/autosave' ),
+			'multiple tokens'    => array( '/taxonomies/%s/terms/slug:%s', 'v1.1/taxonomies/(?P<p1>[^/]+)/terms/slug:(?P<p2>[^/]+)' ),
+		);
+	}
+
+	/**
+	 * The real request path is reflowed into the route via build_concrete_rest_route(); static routes are unchanged.
+	 *
+	 * @dataProvider provide_concrete_cases
+	 *
+	 * @param string $rest_route  Endpoint rest_route.
+	 * @param string $path        Endpoint path template.
+	 * @param string $url         Full request URL.
+	 * @param string $max_version Endpoint max version.
+	 * @param string $expected    Expected concrete route.
+	 * @group json-api
+	 */
+	#[DataProvider( 'provide_concrete_cases' )]
+	#[Group( 'json-api' )]
+	public function test_build_concrete_rest_route( $rest_route, $path, $url, $max_version, $expected ) {
+		$this->assertSame( $expected, $this->make_endpoint( $rest_route, $path, $max_version )->build_concrete_rest_route( $url ) );
+	}
+
+	/**
+	 * Data provider for build_concrete_rest_route().
+	 *
+	 * @return array<string, array{string, string, string, string, string}>
+	 */
+	public static function provide_concrete_cases() {
+		return array(
+			'static (no token)'  => array( '/posts', '/sites/%s/posts', 'https://public-api.wordpress.com/rest/v1.1/sites/12/posts?number=10', '1.1', 'v1.1/posts' ),
+			'by id'              => array( '/posts/%d', '/sites/%s/posts/%d', 'https://public-api.wordpress.com/rest/v1.1/sites/en.blog.wordpress.com/posts/7?context=display', '1.1', 'v1.1/posts/7' ),
+			'by slug'            => array( '/posts/slug:%s', '/sites/%s/posts/slug:%s', 'https://public-api.wordpress.com/rest/v1.1/sites/12/posts/slug:hello-world', '1.1', 'v1.1/posts/slug:hello-world' ),
+			'token then literal' => array( '/posts/%d/autosave', '/sites/%s/posts/%d/autosave', 'https://public-api.wordpress.com/rest/v1.1/sites/12/posts/7/autosave', '1.1', 'v1.1/posts/7/autosave' ),
+			'multiple tokens'    => array( '/taxonomies/%s/terms/slug:%s', '/sites/%s/taxonomies/%s/terms/slug:%s', 'https://public-api.wordpress.com/rest/v1.1/sites/12/taxonomies/category/terms/slug:foo', '1.1', 'v1.1/taxonomies/category/terms/slug:foo' ),
+			'encoded slash'      => array( '/plugins/%s', '/sites/%s/plugins/%s', 'https://public-api.wordpress.com/rest/v1.2/sites/12/plugins/akismet%2Fakismet', '1.2', 'v1.2/plugins/akismet%2Fakismet' ),
+			'domain site'        => array( '/posts/%d', '/sites/%s/posts/%d', 'https://public-api.wordpress.com/rest/v1.1/sites/example.com/posts/42', '1.1', 'v1.1/posts/42' ),
+		);
+	}
+
+	/**
+	 * The end-to-end guarantee: for every tokenized shape the concrete route a request produces must
+	 * match the pattern the remote registered. This is what makes a request actually route.
+	 *
+	 * @dataProvider provide_roundtrip_cases
+	 *
+	 * @param string $rest_route Endpoint rest_route.
+	 * @param string $path       Endpoint path template.
+	 * @param string $url        Full request URL.
+	 * @group json-api
+	 */
+	#[DataProvider( 'provide_roundtrip_cases' )]
+	#[Group( 'json-api' )]
+	public function test_concrete_route_matches_registered_pattern( $rest_route, $path, $url ) {
+		$endpoint = $this->make_endpoint( $rest_route, $path );
+		$pattern  = $endpoint->build_rest_route_regex();
+		$concrete = $endpoint->build_concrete_rest_route( $url );
+
+		$this->assertSame( 1, preg_match( '#^' . $pattern . '$#', $concrete ), "Concrete route '$concrete' should match registered pattern '$pattern'." );
+	}
+
+	/**
+	 * Data provider for the round-trip test.
+	 *
+	 * @return array<string, array{string, string, string}>
+	 */
+	public static function provide_roundtrip_cases() {
+		return array(
+			'by id'              => array( '/posts/%d', '/sites/%s/posts/%d', 'https://public-api.wordpress.com/rest/v1.1/sites/12/posts/7' ),
+			'by slug'            => array( '/posts/slug:%s', '/sites/%s/posts/slug:%s', 'https://public-api.wordpress.com/rest/v1.1/sites/12/posts/slug:hello-world' ),
+			'token then literal' => array( '/posts/%d/autosave', '/sites/%s/posts/%d/autosave', 'https://public-api.wordpress.com/rest/v1.1/sites/12/posts/7/autosave' ),
+			'multiple tokens'    => array( '/taxonomies/%s/terms/slug:%s', '/sites/%s/taxonomies/%s/terms/slug:%s', 'https://public-api.wordpress.com/rest/v1.1/sites/12/taxonomies/category/terms/slug:foo' ),
+		);
+	}
+}
+
+/**
+ * Minimal concrete endpoint for exercising the route-building methods.
+ */
+class WPCOM_JSON_API_Rest_Route_Test_Endpoint extends WPCOM_JSON_API_Endpoint {
+
+	/**
+	 * Callback implementation (unused by these tests).
+	 *
+	 * @param string $path The request path.
+	 * @return mixed
+	 */
+	public function callback( $path = '' ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return array();
+	}
+}

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Get_Post_v1_1_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Get_Post_v1_1_Endpoint_Test.php
@@ -174,4 +174,68 @@ class WPCOM_JSON_API_Get_Post_v1_1_Endpoint_Test extends WP_UnitTestCase { // ph
 		$this->assertArrayHasKey( 'has_password', $response );
 		$this->assertFalse( $response['has_password'] );
 	}
+
+	/**
+	 * A post fetched by ID resolves to that post. The ID arrives as the positional callback
+	 * argument, which is how it is delivered over both the REST and XML-RPC transports.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_get_post_by_id_resolves_to_correct_post() {
+		$post_id = $this->create_post( array( 'post_title' => 'Fetched by ID' ) );
+
+		$response = $this->get_endpoint()->callback(
+			'/sites/' . self::$blog_id . '/posts/' . $post_id,
+			self::$blog_id,
+			$post_id
+		);
+
+		$this->assertIsArray( $response );
+		$this->assertSame( $post_id, $response['ID'] );
+	}
+
+	/**
+	 * A post fetched by slug resolves to the correct post. The slug arrives as the positional
+	 * callback argument (the `/posts/slug:` branch), matching how the tokenized REST route and
+	 * the XML-RPC path both deliver it.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_get_post_by_slug_resolves_to_correct_post() {
+		$post_id = $this->create_post(
+			array(
+				'post_title' => 'Fetched by slug',
+				'post_name'  => 'a-unique-slug',
+			)
+		);
+
+		$response = $this->get_endpoint()->callback(
+			'/sites/' . self::$blog_id . '/posts/slug:a-unique-slug',
+			self::$blog_id,
+			'a-unique-slug'
+		);
+
+		$this->assertIsArray( $response );
+		$this->assertSame( $post_id, $response['ID'] );
+		$this->assertSame( 'a-unique-slug', $response['slug'] );
+	}
+
+	/**
+	 * An unknown slug returns an unknown_post error instead of resolving to a post.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_get_post_by_unknown_slug_returns_error() {
+		$response = $this->get_endpoint()->callback(
+			'/sites/' . self::$blog_id . '/posts/slug:does-not-exist',
+			self::$blog_id,
+			'does-not-exist'
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $response );
+		$this->assertSame( 'unknown_post', $response->get_error_code() );
+	}
 }


### PR DESCRIPTION
## Proposed changes

* **Infrastructure; this is the main goal of the PR.** Today the Jetpack JSON API REST transport can only carry a *static* route: `build_rest_route()` returns `'v'.$max_version.$rest_route`, and that fixed string is what the proxy sends to the remote site. That is fine for *collection* endpoints (`/posts`, `/site`, `/users`, `/plugins`), but any endpoint whose path carries a value — a post ID, a slug, a plugin slug, a comment ID, a term — has no way to get that value to the remote. As a result every single-item and action endpoint is stuck on XML-RPC , and the REST migration can only ever cover the collection endpoints. This PR puts the missing infrastructure in place so path parameters can travel over the REST transport:
  * `build_rest_route_regex()` converts the `%d`/`%s` tokens in a `rest_route` into ordered named captures for `register_rest_route()` on the remote (e.g. `/posts/%d` → `v1.1/posts/(?P<p1>\d+)`).
  * `build_concrete_rest_route()` reflows the real request path into the route the proxy sends per request (e.g. `.../sites/X/posts/7` → `v1.1/posts/7`).
  * Both are strict no-ops for token-less routes, so the collection endpoints already rolling out are byte-for-byte unchanged.
* **A concrete endpoint to exercise it.** So there is something real to test on top of the new mechanism, the two single-post endpoints are enabled: `/posts/%d` (by ID) and `/posts/slug:%s` (by slug). Because the id/slug now arrive positionally on both transports, the endpoint callback needs no special-casing and reverts to its original form.
* **Unit tests** covering token → named-capture conversion, path reflow (single token, mid-path token, multiple tokens, encoded slash, domain site), and the end-to-end guarantee that the concrete route a request produces matches the pattern the remote registered.
* **Backwards compatible.** XML-RPC is untouched and remains the fallback; eligibility is gated by `rest_min_jp_version`. This is the Jetpack (remote) half; the wpcom part 227642-ghe-Automattic/wpcom needs to ship after this one.

## Related product discussion/links

* [CONNECT-359](https://linear.app/a8c/issue/CONNECT-359)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run the unit tests:
  * `jetpack docker phpunit jetpack -- --filter=WPCOM_JSON_API_Endpoint_Rest_Route_Test`
* End-to-end (requires the companion wpcom change 227642-ghe-Automattic/wpcom ): on a site in JSON API dev mode, `GET /rest/v1.1/sites/<blog_id>/posts/<post_id>` and `GET /rest/v1.1/sites/<blog_id>/posts/slug:<slug>` should return the post over REST, matching what XML-RPC returns.