### PR TITLE
pnpm: enable enableGlobalVirtualStore to share deps across worktrees

### DIFF
--- a/.agents/skills/widget-audit.md
+++ b/.agents/skills/widget-audit.md
@@ -23,7 +23,7 @@ assume: namespace, text domain, and the dependency versions the package resolves
    argument used in `__()` across the package (e.g. `jetpack-premium-analytics`).
 2. **Resolved versions**: check tokens and props against what the package actually
    resolves, not against trunk or memory:
-   - Tokens → `@wordpress/theme`'s `design-tokens.css` in `node_modules/.pnpm`.
+   - Tokens → `@wordpress/theme`'s `design-tokens.css` (resolve the package, see below).
    - UI props → the resolved `@wordpress/ui` `build-types`.
    - Contract types → `@wordpress/widget-primitives` `build-types`.
 
@@ -97,7 +97,7 @@ assume: namespace, text domain, and the dependency versions the package resolves
 ## How to verify tokens
 
 ```bash
-TOK=$(find node_modules/.pnpm -path '*@wordpress+theme*/css/design-tokens.css' | head -1)
+TOK=$(find "$(node -e 'console.log(require("path").dirname(require.resolve("@wordpress/theme/package.json")))')" -name design-tokens.css | head -1)
 grep -rhoE '\-\-wpds-[a-z0-9-]+' widgets/<slug>/*.css | sort -u | while read -r t; do
   grep -qE -- "$t\b" "$TOK" || echo "MISSING from resolved theme: $t"
 done

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,11 +24,6 @@ strictPeerDependencies: true
 # No hoisting by default.
 hoistPattern: []
 
-# Symlink node_modules from a store-wide virtual store instead of node_modules/.pnpm, so
-# checkouts (notably git worktrees) share one copy. https://pnpm.io/git-worktrees
-# The docs' NODE_PATH/ESM caveat only affects hoisted deps, and we hoist nothing.
-enableGlobalVirtualStore: true
-
 # Silence this warning. Our `jetpack dependencies build-order` (also used by `jetpack build --all`) checks for cycles itself, plus it has a way to indicate that a dep is only for testing.
 ignoreWorkspaceCycles: true
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,6 +24,11 @@ strictPeerDependencies: true
 # No hoisting by default.
 hoistPattern: []
 
+# Symlink node_modules from a store-wide virtual store instead of node_modules/.pnpm, so
+# checkouts (notably git worktrees) share one copy. https://pnpm.io/git-worktrees
+# The docs' NODE_PATH/ESM caveat only affects hoisted deps, and we hoist nothing.
+enableGlobalVirtualStore: true
+
 # Silence this warning. Our `jetpack dependencies build-order` (also used by `jetpack build --all`) checks for cycles itself, plus it has a way to indicate that a dep is only for testing.
 ignoreWorkspaceCycles: true
 

--- a/projects/js-packages/charts/changelog/update-pnpm-enable-global-virtual-store
+++ b/projects/js-packages/charts/changelog/update-pnpm-enable-global-virtual-store
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update test config to use the global virtual store.
+
+

--- a/projects/js-packages/charts/tests/jest.config.cjs
+++ b/projects/js-packages/charts/tests/jest.config.cjs
@@ -14,8 +14,8 @@ module.exports = {
 			require.resolve
 		),
 	},
-	// Transform d3-* ESM packages (pattern accounts for pnpm .pnpm directory structure)
-	transformIgnorePatterns: [ '/node_modules/(?!\\.pnpm/|d3-|internmap/|uuid/)' ],
+	// Transform d3-* ESM packages. See config.base.js for the `(?!.*/node_modules/)` anchor.
+	transformIgnorePatterns: [ '/node_modules/(?!.*/node_modules/)(?!d3-|internmap/|uuid/)' ],
 	setupFilesAfterEnv: [
 		...( baseConfig.setupFilesAfterEnv || [] ),
 		path.join( __dirname, 'setup-element-size-mock.js' ),

--- a/projects/js-packages/storybook/changelog/update-pnpm-enable-global-virtual-store
+++ b/projects/js-packages/storybook/changelog/update-pnpm-enable-global-virtual-store
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update test config to use the global virtual store.
+
+

--- a/projects/js-packages/storybook/vitest.config.ts
+++ b/projects/js-packages/storybook/vitest.config.ts
@@ -1,8 +1,17 @@
+import { execSync } from 'child_process';
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
 import { playwright } from '@vitest/browser-playwright';
+import { searchForWorkspaceRoot } from 'vite';
 import { configDefaults, defineConfig } from 'vitest/config';
 
 const __dirname = import.meta.dirname;
+
+/*
+ * Under `enableGlobalVirtualStore`, packages resolve into the pnpm store rather than the monorepo,
+ * and Vite refuses to serve files outside its allow list. Setting `allow` replaces the default, so
+ * the workspace root has to be listed too.
+ */
+const pnpmStorePath = execSync( 'pnpm store path', { encoding: 'utf8' } ).trim();
 
 export default defineConfig( {
 	server: {
@@ -14,6 +23,11 @@ export default defineConfig( {
 	test: {
 		projects: [
 			{
+				server: {
+					fs: {
+						allow: [ searchForWorkspaceRoot( __dirname ), pnpmStorePath ],
+					},
+				},
 				plugins: [
 					await storybookTest( {
 						configDir: `${ __dirname }/storybook`,

--- a/projects/js-packages/webpack-config/changelog/update-pnpm-enable-global-virtual-store
+++ b/projects/js-packages/webpack-config/changelog/update-pnpm-enable-global-virtual-store
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update config to use global virtual store.
+
+

--- a/projects/js-packages/webpack-config/src/webpack/pnpm-deterministic-ids.js
+++ b/projects/js-packages/webpack-config/src/webpack/pnpm-deterministic-ids.js
@@ -17,11 +17,12 @@ const PNPM_PATH_REGEXP =
 
 /*
  * With `enableGlobalVirtualStore`, packages live in the pnpm store instead of `node_modules/.pnpm`,
- * as `<store>/links/<@scope|@>/<name>/<version>/<hash>/node_modules/<path>`. The store is outside
- * the monorepo, so its absolute path would otherwise leak into the identifier.
+ * as `<store>/v<N>/links/<@scope|@>/<name>/<version>/<hash>/node_modules/<path>`. The store is
+ * outside the monorepo, so its absolute path would otherwise leak into the identifier. The `v<N>`
+ * store-version directory keeps this from matching a project path that merely contains `links/`.
  */
 const PNPM_GLOBAL_STORE_PATH_REGEXP =
-	/(?<=^|[|!])[^|!]*?\/links\/[^/]+\/[^/]+\/[^/]+\/[0-9a-f]{32,}\/node_modules\/([^|!]+)/g;
+	/(?<=^|[|!])[^|!]*?\/v[0-9]+\/links\/[^/]+\/[^/]+\/[^/]+\/[0-9a-f]{32,}\/node_modules\/([^|!]+)/g;
 
 /**
  * Replace pnpm store paths in an identifier.

--- a/projects/js-packages/webpack-config/src/webpack/pnpm-deterministic-ids.js
+++ b/projects/js-packages/webpack-config/src/webpack/pnpm-deterministic-ids.js
@@ -13,7 +13,7 @@ const {
 const { compareModulesByPreOrderIndexOrIdentifier } = require( 'webpack/lib/util/comparators' );
 
 const PNPM_PATH_REGEXP =
-	/(?<=^|[|!])(?:\.\.\/)*node_modules\/\.pnpm\/[^/]*\/node_modules\/([^|!]+)/g;
+	/(?<=^|[|!])(?:\.\.\/)*node_modules\/\.pnpm\/[^/!|]*\/node_modules\/([^|!]+)/g;
 
 /*
  * With `enableGlobalVirtualStore`, packages live in the pnpm store instead of `node_modules/.pnpm`,
@@ -22,7 +22,7 @@ const PNPM_PATH_REGEXP =
  * store-version directory keeps this from matching a project path that merely contains `links/`.
  */
 const PNPM_GLOBAL_STORE_PATH_REGEXP =
-	/(?<=^|[|!])[^|!]*?\/v[0-9]+\/links\/[^/]+\/[^/]+\/[^/]+\/[0-9a-f]{32,}\/node_modules\/([^|!]+)/g;
+	/(?<=^|[|!])[^|!]*?\/v[0-9]+\/links\/@[^/!|]*\/[^/!|]+\/[^/!|]+\/[0-9a-f]{32,}\/node_modules\/([^|!]+)/g;
 
 /**
  * Replace pnpm store paths in an identifier.

--- a/projects/js-packages/webpack-config/src/webpack/pnpm-deterministic-ids.js
+++ b/projects/js-packages/webpack-config/src/webpack/pnpm-deterministic-ids.js
@@ -16,10 +16,8 @@ const PNPM_PATH_REGEXP =
 	/(?<=^|[|!])(?:\.\.\/)*node_modules\/\.pnpm\/[^/!|]*\/node_modules\/([^|!]+)/g;
 
 /*
- * With `enableGlobalVirtualStore`, packages live in the pnpm store instead of `node_modules/.pnpm`,
- * as `<store>/v<N>/links/<@scope|@>/<name>/<version>/<hash>/node_modules/<path>`. The store is
- * outside the monorepo, so its absolute path would otherwise leak into the identifier. The `v<N>`
- * store-version directory keeps this from matching a project path that merely contains `links/`.
+ * With `enableGlobalVirtualStore`, packages live at
+ * `<store>/v<N>/links/<@scope|@>/<name>/<version>/<hash>/node_modules/<path>`.
  */
 const PNPM_GLOBAL_STORE_PATH_REGEXP =
 	/(?<=^|[|!])[^|!]*?\/v[0-9]+\/links\/@[^/!|]*\/[^/!|]+\/[^/!|]+\/[0-9a-f]{32,}\/node_modules\/([^|!]+)/g;

--- a/projects/js-packages/webpack-config/src/webpack/pnpm-deterministic-ids.js
+++ b/projects/js-packages/webpack-config/src/webpack/pnpm-deterministic-ids.js
@@ -15,6 +15,14 @@ const { compareModulesByPreOrderIndexOrIdentifier } = require( 'webpack/lib/util
 const PNPM_PATH_REGEXP =
 	/(?<=^|[|!])(?:\.\.\/)*node_modules\/\.pnpm\/[^/]*\/node_modules\/([^|!]+)/g;
 
+/*
+ * With `enableGlobalVirtualStore`, packages live in the pnpm store instead of `node_modules/.pnpm`,
+ * as `<store>/links/<@scope|@>/<name>/<version>/<hash>/node_modules/<path>`. The store is outside
+ * the monorepo, so its absolute path would otherwise leak into the identifier.
+ */
+const PNPM_GLOBAL_STORE_PATH_REGEXP =
+	/(?<=^|[|!])[^|!]*?\/links\/[^/]+\/[^/]+\/[^/]+\/[0-9a-f]{32,}\/node_modules\/([^|!]+)/g;
+
 /**
  * Replace pnpm store paths in an identifier.
  *
@@ -29,7 +37,9 @@ const PNPM_PATH_REGEXP =
  * @return {string} Transformed identifier.
  */
 function fixPnpmPaths( identifier ) {
-	return identifier.replace( PNPM_PATH_REGEXP, '.pnpm/$1' );
+	return identifier
+		.replace( PNPM_PATH_REGEXP, '.pnpm/$1' )
+		.replace( PNPM_GLOBAL_STORE_PATH_REGEXP, '.pnpm/$1' );
 }
 
 /** @typedef {import("../Compiler")} Compiler */

--- a/projects/plugins/jetpack/changelog/update-pnpm-enable-global-virtual-store
+++ b/projects/plugins/jetpack/changelog/update-pnpm-enable-global-virtual-store
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update test config to use the global virtual store.
+
+

--- a/projects/plugins/jetpack/tests/jest.config.gui.js
+++ b/projects/plugins/jetpack/tests/jest.config.gui.js
@@ -13,7 +13,7 @@ module.exports = {
 	// This is necessary to allow css from uplot, @wordpress/admin-ui, and @gravatar-com (the
 	// latter for the lifted Gravatar component's hovercard styles) to be imported.
 	transformIgnorePatterns: [
-		'/node_modules/(?!(.pnpm|@automattic)/|uuid/|uplot/.*\\.css|@wordpress/admin-ui/.*\\.css|@gravatar-com/.*\\.css)',
+		'/node_modules/(?!.*/node_modules/)(?!@automattic/|uuid/|uplot/.*\\.css|@wordpress/admin-ui/.*\\.css|@gravatar-com/.*\\.css)',
 		...baseConfig.transformIgnorePatterns,
 	],
 	collectCoverageFrom: [

--- a/tools/cli/commands/rsync.js
+++ b/tools/cli/commands/rsync.js
@@ -3,6 +3,7 @@ import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import process from 'process';
+import { fileURLToPath } from 'url';
 import util from 'util';
 import chalk from 'chalk';
 import chokidar from 'chokidar';
@@ -605,7 +606,10 @@ async function rsyncToDest( source, dest, password = null ) {
 		// When RSYNC_PROXY_SOCKET is set, use the rsh-proxy script to route SSH through the host
 		// This enables support for Secure Enclave SSH keys that can't be forwarded into Docker
 		if ( process.env.RSYNC_PROXY_SOCKET ) {
-			rsyncArgs.push( '--rsh=/workspace/tools/docker/bin/rsync-rsh-proxy.sh' );
+			const rshProxy = fileURLToPath(
+				new URL( '../../docker/bin/rsync-rsh-proxy.sh', import.meta.url )
+			);
+			rsyncArgs.push( `--rsh=${ rshProxy }` );
 		}
 
 		rsyncArgs.push( source, dest );

--- a/tools/docker/Dockerfile.monorepo
+++ b/tools/docker/Dockerfile.monorepo
@@ -80,16 +80,10 @@ RUN mkdir -p "${PNPM_HOME}" \
 RUN npm install --global pnpm@$PNPM_VERSION \
     && SHELL=bash pnpm setup
 
-WORKDIR /workspace
-
 # Set up locale
 RUN locale-gen en_US.UTF-8 \
     && update-locale LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 \
     && find /var/ -name '*-old' -delete \
     && rm -rf /var/log/dpkg.log /var/log/alternatives.log /var/log/apt/ ~/.launchpadlib
-
-# Mark /workspace as a safe directory for git to avoid "dubious ownership" warnings
-# when the monorepo is mounted from the host with different ownership.
-RUN git config --system --add safe.directory /workspace
 
 CMD ["bash"]

--- a/tools/docker/bin/monorepo
+++ b/tools/docker/bin/monorepo
@@ -156,7 +156,11 @@ fi
   fi
 
   if [[ "${DEBUG:-}" = "1" ]]; then
-      echo "[pnpm] store path (host and container): ${PNPM_STORE_PATH:-<container default>}"
+      if [[ -n "$PNPM_STORE_PATH" ]]; then
+          echo "[pnpm] store path (host and container): $PNPM_STORE_PATH"
+      else
+          echo "[pnpm] no host pnpm; using the container's default store"
+      fi
   fi
 
   mkdir -p "$DOCKER_DATA_DIR"

--- a/tools/docker/bin/monorepo
+++ b/tools/docker/bin/monorepo
@@ -139,7 +139,7 @@ fi
   # Mirror the host pnpm store into the container at the same path, so node_modules' symlinks into it
   # resolve on both sides. With no host pnpm there's no host store to share; fall back to the
   # container's own store, as before.
-  PNPM_STORE_PATH="$( cd "$MONOREPO_ROOT" && command -v pnpm >/dev/null 2>&1 && pnpm store path 2>/dev/null )"
+  PNPM_STORE_PATH="$( cd "$MONOREPO_ROOT" && command -v pnpm &>/dev/null && pnpm store path 2>/dev/null )"
 
   PNPM_STORE_DOCKER_ARGS=()
   if [[ -n "$PNPM_STORE_PATH" ]]; then

--- a/tools/docker/bin/monorepo
+++ b/tools/docker/bin/monorepo
@@ -141,27 +141,38 @@ fi
   # `links/` dir, so the store has to sit at the same absolute path inside the container as it does
   # on the host. Together with mounting the repo at its host path (below), that keeps one set of
   # symlinks valid on both sides.
-  PNPM_STORE_PATH="$( cd "$MONOREPO_ROOT" && pnpm store path 2>/dev/null )"
-  if [[ -z "$PNPM_STORE_PATH" ]]; then
-      echo "Could not determine the pnpm store path. Is pnpm installed on the host?" >&2
-      exit 1
-  fi
-  # `pnpm store path` includes the store version (e.g. .../store/v11), which pnpm re-appends to
-  # storeDir, so hand it the parent.
-  PNPM_STORE_BASE="$( dirname "$PNPM_STORE_PATH" )"
-  mkdir -p "$PNPM_STORE_PATH"
+  # Without pnpm on the host there's no host store to share, and no host node_modules pointing into
+  # one. Let the container fall back to its own store, as it did before.
+  PNPM_STORE_PATH="$( cd "$MONOREPO_ROOT" && command -v pnpm >/dev/null 2>&1 && pnpm store path 2>/dev/null )"
 
-  # A store inside the repo is already covered by the repo mount.
   PNPM_STORE_DOCKER_ARGS=()
-  if [[ "$PNPM_STORE_BASE" != "$MONOREPO_ROOT" && "$PNPM_STORE_BASE" != "$MONOREPO_ROOT"/* ]]; then
-      PNPM_STORE_DOCKER_ARGS+=( -v "$PNPM_STORE_BASE:$PNPM_STORE_BASE" )
+  if [[ -n "$PNPM_STORE_PATH" ]]; then
+      # `pnpm store path` includes the store version (e.g. .../store/v11), which pnpm re-appends to
+      # storeDir, so hand it the parent.
+      PNPM_STORE_BASE="$( dirname "$PNPM_STORE_PATH" )"
+      mkdir -p "$PNPM_STORE_PATH"
+
+      # A store inside the repo is already covered by the repo mount.
+      if [[ "$PNPM_STORE_BASE" != "$MONOREPO_ROOT" && "$PNPM_STORE_BASE" != "$MONOREPO_ROOT"/* ]]; then
+          PNPM_STORE_DOCKER_ARGS+=( -v "$PNPM_STORE_BASE:$PNPM_STORE_BASE" )
+      fi
+      PNPM_STORE_DOCKER_ARGS+=( -e pnpm_config_store_dir="$PNPM_STORE_BASE" )
   fi
 
   if [[ "${DEBUG:-}" = "1" ]]; then
-      echo "[pnpm] store path (host and container): $PNPM_STORE_PATH"
+      echo "[pnpm] store path (host and container): ${PNPM_STORE_PATH:-<container default>}"
   fi
 
   mkdir -p "$DOCKER_DATA_DIR"
+
+  # Mark the repo as a safe directory for git, which otherwise refuses to operate on a checkout owned
+  # by another user. `$DOCKER_DATA_DIR` is the container's HOME, so this lands in git's global config;
+  # passing it via `GIT_CONFIG_*` instead would clobber, and be clobbered by, a caller's own entries.
+  GITCONFIG="$DOCKER_DATA_DIR/.gitconfig"
+  for SAFE_DIR in "$MONOREPO_ROOT" ${MAIN_GIT_DIR:+"$MAIN_GIT_DIR"}; do
+      git config --file "$GITCONFIG" --get-all safe.directory 2>/dev/null | grep -qxF "$SAFE_DIR" \
+          || git config --file "$GITCONFIG" --add safe.directory "$SAFE_DIR"
+  done
 
   docker run --rm $TTY_FLAG \
     -v "$MONOREPO_ROOT:$MONOREPO_ROOT" \
@@ -170,9 +181,6 @@ fi
     "${PNPM_STORE_DOCKER_ARGS[@]}" \
     "${WORKTREE_DOCKER_ARGS[@]}" \
     -w "$MONOREPO_ROOT" \
-    -e GIT_CONFIG_COUNT=1 \
-    -e GIT_CONFIG_KEY_0=safe.directory \
-    -e GIT_CONFIG_VALUE_0="$MONOREPO_ROOT" \
     -e TERM=$TERM \
     -e COLORTERM=$COLORTERM \
     -e JETPACK_MONOREPO_ENV=1 \
@@ -184,7 +192,6 @@ fi
     -e NPM_CONFIG_USERCONFIG=/root/.npmrc \
     -e NPM_CONFIG_CACHE=/root/.npm \
     -e PNPM_HOME=/root/.local/share/pnpm \
-    -e pnpm_config_store_dir="$PNPM_STORE_BASE" \
     -e GIT_AUTHOR_NAME="${GIT_USER_NAME}" \
     -e GIT_AUTHOR_EMAIL="${GIT_USER_EMAIL}" \
     -e GIT_COMMITTER_NAME="${GIT_USER_NAME}" \

--- a/tools/docker/bin/monorepo
+++ b/tools/docker/bin/monorepo
@@ -166,8 +166,7 @@ fi
   mkdir -p "$DOCKER_DATA_DIR"
 
   # Mark the repo as a safe directory for git, which otherwise refuses to operate on a checkout owned
-  # by another user. `$DOCKER_DATA_DIR` is the container's HOME, so this lands in git's global config;
-  # passing it via `GIT_CONFIG_*` instead would clobber, and be clobbered by, a caller's own entries.
+  # by another user. `$DOCKER_DATA_DIR` is the container's HOME, so this lands in git's global config.
   GITCONFIG="$DOCKER_DATA_DIR/.gitconfig"
   for SAFE_DIR in "$MONOREPO_ROOT" ${MAIN_GIT_DIR:+"$MAIN_GIT_DIR"}; do
       git config --file "$GITCONFIG" --get-all safe.directory 2>/dev/null | grep -qxF "$SAFE_DIR" \

--- a/tools/docker/bin/monorepo
+++ b/tools/docker/bin/monorepo
@@ -124,42 +124,55 @@ fi
   if [[ "$IS_WORKTREE" = "1" ]]; then
       # Share the main repo's Docker data dir (ssh keys, composer/npm/pnpm caches)
       DOCKER_DATA_DIR="$MAIN_REPO_ROOT/tools/docker/data/monorepo"
-      # Mount main .git/ so git operations work inside the container
+      # Mount main .git/ at its host path, so the worktree's `.git` file resolves inside the container.
       WORKTREE_DOCKER_ARGS+=(
-          -v "$MAIN_GIT_DIR:/repo-git:ro"
-          -v "$MAIN_GIT_DIR/objects:/repo-git/objects"
-          -v "$MAIN_GIT_DIR/worktrees/$WORKTREE_NAME:/repo-git/worktrees/$WORKTREE_NAME"
-          -e "GIT_DIR=/repo-git/worktrees/$WORKTREE_NAME"
-          -e "GIT_WORK_TREE=/workspace"
+          -v "$MAIN_GIT_DIR:$MAIN_GIT_DIR:ro"
+          -v "$MAIN_GIT_DIR/objects:$MAIN_GIT_DIR/objects"
+          -v "$MAIN_GIT_DIR/worktrees/$WORKTREE_NAME:$MAIN_GIT_DIR/worktrees/$WORKTREE_NAME"
+          -e "GIT_DIR=$MAIN_GIT_DIR/worktrees/$WORKTREE_NAME"
+          -e "GIT_WORK_TREE=$MONOREPO_ROOT"
       )
   else
       DOCKER_DATA_DIR="$MONOREPO_ROOT/tools/docker/data/monorepo"
   fi
 
   # Set pnpm store directory.
-  # For worktrees: use /root/.pnpm-store (shared across all worktrees via DOCKER_DATA_DIR).
-  # For non-worktrees: use /workspace/.pnpm-store (same mount as node_modules, preserves hardlinks).
-  if [[ "$IS_WORKTREE" = "1" ]]; then
-      PNPM_STORE_DIR_CONTAINER="/root/.pnpm-store"
-  else
-      PNPM_STORE_DIR_CONTAINER="/workspace/.pnpm-store"
+  # `enableGlobalVirtualStore` makes node_modules a tree of relative symlinks into the store's
+  # `links/` dir, so the store has to sit at the same absolute path inside the container as it does
+  # on the host. Together with mounting the repo at its host path (below), that keeps one set of
+  # symlinks valid on both sides.
+  PNPM_STORE_PATH="$( cd "$MONOREPO_ROOT" && pnpm store path 2>/dev/null )"
+  if [[ -z "$PNPM_STORE_PATH" ]]; then
+      echo "Could not determine the pnpm store path. Is pnpm installed on the host?" >&2
+      exit 1
+  fi
+  # `pnpm store path` includes the store version (e.g. .../store/v11), which pnpm re-appends to
+  # storeDir, so hand it the parent.
+  PNPM_STORE_BASE="$( dirname "$PNPM_STORE_PATH" )"
+  mkdir -p "$PNPM_STORE_PATH"
+
+  # A store inside the repo is already covered by the repo mount.
+  PNPM_STORE_DOCKER_ARGS=()
+  if [[ "$PNPM_STORE_BASE" != "$MONOREPO_ROOT" && "$PNPM_STORE_BASE" != "$MONOREPO_ROOT"/* ]]; then
+      PNPM_STORE_DOCKER_ARGS+=( -v "$PNPM_STORE_BASE:$PNPM_STORE_BASE" )
   fi
 
   if [[ "${DEBUG:-}" = "1" ]]; then
-      echo "[pnpm] store dir (container): $PNPM_STORE_DIR_CONTAINER"
-      if [[ "$IS_WORKTREE" = "1" ]]; then
-          echo "[pnpm] store dir (host): $DOCKER_DATA_DIR/.pnpm-store"
-      fi
+      echo "[pnpm] store path (host and container): $PNPM_STORE_PATH"
   fi
 
   mkdir -p "$DOCKER_DATA_DIR"
 
   docker run --rm $TTY_FLAG \
-    -v "$MONOREPO_ROOT:/workspace" \
+    -v "$MONOREPO_ROOT:$MONOREPO_ROOT" \
     -v "$DOCKER_DATA_DIR:/root" \
     -v /var/run/docker.sock:/var/run/docker.sock \
+    "${PNPM_STORE_DOCKER_ARGS[@]}" \
     "${WORKTREE_DOCKER_ARGS[@]}" \
-    -w /workspace \
+    -w "$MONOREPO_ROOT" \
+    -e GIT_CONFIG_COUNT=1 \
+    -e GIT_CONFIG_KEY_0=safe.directory \
+    -e GIT_CONFIG_VALUE_0="$MONOREPO_ROOT" \
     -e TERM=$TERM \
     -e COLORTERM=$COLORTERM \
     -e JETPACK_MONOREPO_ENV=1 \
@@ -171,7 +184,7 @@ fi
     -e NPM_CONFIG_USERCONFIG=/root/.npmrc \
     -e NPM_CONFIG_CACHE=/root/.npm \
     -e PNPM_HOME=/root/.local/share/pnpm \
-    -e pnpm_config_store_dir="$PNPM_STORE_DIR_CONTAINER" \
+    -e pnpm_config_store_dir="$PNPM_STORE_BASE" \
     -e GIT_AUTHOR_NAME="${GIT_USER_NAME}" \
     -e GIT_AUTHOR_EMAIL="${GIT_USER_EMAIL}" \
     -e GIT_COMMITTER_NAME="${GIT_USER_NAME}" \

--- a/tools/docker/bin/monorepo
+++ b/tools/docker/bin/monorepo
@@ -136,13 +136,9 @@ fi
       DOCKER_DATA_DIR="$MONOREPO_ROOT/tools/docker/data/monorepo"
   fi
 
-  # Set pnpm store directory.
-  # `enableGlobalVirtualStore` makes node_modules a tree of relative symlinks into the store's
-  # `links/` dir, so the store has to sit at the same absolute path inside the container as it does
-  # on the host. Together with mounting the repo at its host path (below), that keeps one set of
-  # symlinks valid on both sides.
-  # Without pnpm on the host there's no host store to share, and no host node_modules pointing into
-  # one. Let the container fall back to its own store, as it did before.
+  # Mirror the host pnpm store into the container at the same path, so node_modules' symlinks into it
+  # resolve on both sides. With no host pnpm there's no host store to share; fall back to the
+  # container's own store, as before.
   PNPM_STORE_PATH="$( cd "$MONOREPO_ROOT" && command -v pnpm >/dev/null 2>&1 && pnpm store path 2>/dev/null )"
 
   PNPM_STORE_DOCKER_ARGS=()

--- a/tools/js-tools/jest/config.base.js
+++ b/tools/js-tools/jest/config.base.js
@@ -35,8 +35,9 @@ module.exports = {
 	// - @gravatar-com: for the lifted Gravatar component's hovercard styles
 	// - marked: esm-only
 	// - uuid: v14 went esm-only, so it needs transforming
+	// `(?!.*/node_modules/)` anchors to the last `node_modules`, the one before the package name. The pnpm store's own path may contain one too.
 	transformIgnorePatterns: [
-		'/node_modules/(?!\\.pnpm|marked/|uuid/|uplot/.*\\.css|@wordpress/admin-ui/.*\\.css|@gravatar-com/.*\\.css)',
+		'/node_modules/(?!.*/node_modules/)(?!marked/|uuid/|uplot/.*\\.css|@wordpress/admin-ui/.*\\.css|@gravatar-com/.*\\.css)',
 	],
 	moduleNameMapper: {
 		jetpackConfig: path.join( __dirname, 'jest-jetpack-config.js' ),

--- a/tools/js-tools/jest/config.base.js
+++ b/tools/js-tools/jest/config.base.js
@@ -35,7 +35,7 @@ module.exports = {
 	// - @gravatar-com: for the lifted Gravatar component's hovercard styles
 	// - marked: esm-only
 	// - uuid: v14 went esm-only, so it needs transforming
-	// `(?!.*/node_modules/)` anchors to the last `node_modules`, the one before the package name. The pnpm store's own path may contain one too.
+	// `(?!.*/node_modules/)` handles pnpm's store with nested `node_modules` dirs.
 	transformIgnorePatterns: [
 		'/node_modules/(?!.*/node_modules/)(?!marked/|uuid/|uplot/.*\\.css|@wordpress/admin-ui/.*\\.css|@gravatar-com/.*\\.css)',
 	],


### PR DESCRIPTION
Another attempt for #48093

## Proposed changes

Turns on pnpm's [global virtual store](https://pnpm.io/git-worktrees) so multiple checkouts (mainly git worktrees) share one copy of the dependencies instead of each having their own `node_modules/.pnpm`.

|                                    | Before | After |
| ---------------------------------- | ------ | ----- |
| `du -sh node_modules`              | 2.5G   | 1.4M  |
| `pnpm install` in a fresh worktree | 74s    | 2s    |

The catch is that dependencies now live in the pnpm store, outside the repo, so a few things that assumed they were inside it needed fixing:

- **Docker container** (`tools/docker/bin/monorepo`) — mounts the repo, the store, and `.git/` at their host paths so the store symlinks resolve inside the container.
- **Jest** — `transformIgnorePatterns` matched the first `node_modules` in a path; on CI the store path has its own, so nothing got transformed. Anchored it to the last one.
- **Storybook** — Vite won't serve files outside the repo, so the store is now on its allow list.
- **Webpack** — the plugin that strips pnpm paths out of module IDs didn't know the new store layout, so build output wasn't reproducible. Taught it the new shape.

Plus a couple of small follow-ons (`jetpack rsync`, the widget-audit skill, and some dead `/workspace` bits in the Dockerfile).

Heads up: the first `pnpm install` after this lands will wipe and rebuild `node_modules`. That's normal, just once.

## Related product discussion/links

* https://pnpm.io/git-worktrees

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `pnpm install` (say yes when it asks to remove `node_modules`). `readlink node_modules/husky` should now point into your pnpm store.
* `git worktree add --detach /tmp/wt HEAD && cd /tmp/wt && time pnpm install` — should take a couple of seconds. Clean up with `git worktree remove --force /tmp/wt`.
* `tools/docker/bin/monorepo bash -c 'node -e "require.resolve(\"husky\")" && git status'` — resolves and git works, no "dubious ownership". (Needs an image with pnpm 11.5.2 — `docker pull automattic/jetpack-monorepo:latest`.)
* Tests: `pnpm exec jest` in `js-packages/components`, and `pnpm run storybook:test` in `js-packages/storybook`.

If you're on Linux, also check `tools/docker/bin/monorepo git status` there — on macOS Docker hides the file-ownership mismatch that the runtime `safe.directory` fixes.
