### PR TITLE
Forms: update conversion modal to use UI components

### DIFF
--- a/projects/packages/forms/changelog/update-forms-migration-modal-ui-components
+++ b/projects/packages/forms/changelog/update-forms-migration-modal-ui-components
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Comment: Forms: migrate FormsHelpModal from @wordpress/components to @wordpress/ui Dialog, Button, Stack, and Text.

--- a/projects/packages/forms/src/dashboard/wp-build/components/forms-help-modal/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/forms-help-modal/index.tsx
@@ -2,17 +2,11 @@
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import {
-	Button,
-	CheckboxControl,
-	Modal,
-	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-} from '@wordpress/components';
+import { CheckboxControl } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { useState, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { Button, Dialog, Stack, Text } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
@@ -29,9 +23,9 @@ type Props = {
  * This is intended for the wp-build "Forms" screen, where the list shows managed forms only.
  *
  * @param props         - Component props.
- * @param props.isOpen  - Whether the modal is open.
+ * @param props.isOpen  - Whether the dialog is open.
  * @param props.onClose - Close handler.
- * @return The modal element, or null when closed.
+ * @return The dialog element.
  */
 export default function FormsHelpModal( { isOpen, onClose }: Props ) {
 	const [ dontShowAgain, setDontShowAgain ] = useState( false );
@@ -41,6 +35,15 @@ export default function FormsHelpModal( { isOpen, onClose }: Props ) {
 		setDontShowAgain( false );
 		onClose();
 	}, [ onClose ] );
+
+	const handleOpenChange = useCallback(
+		( open: boolean ) => {
+			if ( ! open ) {
+				handleClose();
+			}
+		},
+		[ handleClose ]
+	);
 
 	const handleSubmit = useCallback( () => {
 		if ( dontShowAgain ) {
@@ -58,41 +61,54 @@ export default function FormsHelpModal( { isOpen, onClose }: Props ) {
 	}
 
 	return (
-		<Modal
-			title={ __( 'Not seeing all your forms?', 'jetpack-forms' ) }
-			onRequestClose={ handleClose }
-		>
-			<VStack spacing="4">
-				<Text>
-					{ __( 'The Forms list shows reusable forms, not simple form blocks.', 'jetpack-forms' ) }
-				</Text>
-				<div>
-					<Text as="p" weight="500">
-						{ __( 'To convert a form block to a reusable form:', 'jetpack-forms' ) }
+		<Dialog.Root open onOpenChange={ handleOpenChange }>
+			<Dialog.Popup size="medium">
+				<Dialog.Header>
+					<Dialog.Title>{ __( 'Not seeing all your forms?', 'jetpack-forms' ) }</Dialog.Title>
+					<Dialog.CloseIcon label={ __( 'Close', 'jetpack-forms' ) } />
+				</Dialog.Header>
+				<Stack direction="column" gap="md">
+					<Text>
+						{ __(
+							'The Forms list shows reusable forms, not simple form blocks.',
+							'jetpack-forms'
+						) }
 					</Text>
-					<ol>
-						<li>
-							{ __( 'Open the page or post where your form block is embedded.', 'jetpack-forms' ) }
-						</li>
-						<li>{ __( 'Select the form block.', 'jetpack-forms' ) }</li>
-						<li>
-							{ __( 'Click "Edit Form" in the block toolbar to convert it.', 'jetpack-forms' ) }
-						</li>
-						<li>{ __( 'Save the page or post.', 'jetpack-forms' ) }</li>
-					</ol>
-				</div>
-				<HStack justify="space-between" alignment="center">
-					<CheckboxControl
-						__nextHasNoMarginBottom
-						label={ __( "Don't show this again", 'jetpack-forms' ) }
-						checked={ dontShowAgain }
-						onChange={ setDontShowAgain }
-					/>
-					<Button variant="primary" onClick={ handleSubmit }>
-						{ __( 'Got it', 'jetpack-forms' ) }
-					</Button>
-				</HStack>
-			</VStack>
-		</Modal>
+					<div>
+						<Text variant="body-md" render={ <p /> }>
+							<strong>
+								{ __( 'To convert a form block to a reusable form:', 'jetpack-forms' ) }
+							</strong>
+						</Text>
+						<ol>
+							<li>
+								{ __(
+									'Open the page or post where your form block is embedded.',
+									'jetpack-forms'
+								) }
+							</li>
+							<li>{ __( 'Select the form block.', 'jetpack-forms' ) }</li>
+							<li>
+								{ __( 'Click "Edit Form" in the block toolbar to convert it.', 'jetpack-forms' ) }
+							</li>
+							<li>{ __( 'Save the page or post.', 'jetpack-forms' ) }</li>
+						</ol>
+					</div>
+				</Stack>
+				<Dialog.Footer>
+					<Stack direction="row" justify="space-between" align="center" gap="md">
+						<CheckboxControl
+							__nextHasNoMarginBottom
+							label={ __( "Don't show this again", 'jetpack-forms' ) }
+							checked={ dontShowAgain }
+							onChange={ setDontShowAgain }
+						/>
+						<Button variant="solid" onClick={ handleSubmit }>
+							{ __( 'Got it', 'jetpack-forms' ) }
+						</Button>
+					</Stack>
+				</Dialog.Footer>
+			</Dialog.Popup>
+		</Dialog.Root>
 	);
 }

--- a/projects/packages/forms/src/dashboard/wp-build/components/forms-help-modal/index.tsx
+++ b/projects/packages/forms/src/dashboard/wp-build/components/forms-help-modal/index.tsx
@@ -67,47 +67,54 @@ export default function FormsHelpModal( { isOpen, onClose }: Props ) {
 					<Dialog.Title>{ __( 'Not seeing all your forms?', 'jetpack-forms' ) }</Dialog.Title>
 					<Dialog.CloseIcon label={ __( 'Close', 'jetpack-forms' ) } />
 				</Dialog.Header>
-				<Stack direction="column" gap="md">
-					<Text>
-						{ __(
-							'The Forms list shows reusable forms, not simple form blocks.',
-							'jetpack-forms'
-						) }
-					</Text>
-					<div>
-						<Text variant="body-md" render={ <p /> }>
-							<strong>
-								{ __( 'To convert a form block to a reusable form:', 'jetpack-forms' ) }
-							</strong>
+				<Dialog.Content>
+					<Stack direction="column" gap="md">
+						<Text>
+							{ __(
+								'The Forms list shows reusable forms, not simple form blocks.',
+								'jetpack-forms'
+							) }
 						</Text>
-						<ol>
-							<li>
-								{ __(
-									'Open the page or post where your form block is embedded.',
-									'jetpack-forms'
-								) }
-							</li>
-							<li>{ __( 'Select the form block.', 'jetpack-forms' ) }</li>
-							<li>
-								{ __( 'Click "Edit Form" in the block toolbar to convert it.', 'jetpack-forms' ) }
-							</li>
-							<li>{ __( 'Save the page or post.', 'jetpack-forms' ) }</li>
-						</ol>
-					</div>
-				</Stack>
-				<Dialog.Footer>
-					<Stack direction="row" justify="space-between" align="center" gap="md">
-						<CheckboxControl
-							__nextHasNoMarginBottom
-							label={ __( "Don't show this again", 'jetpack-forms' ) }
-							checked={ dontShowAgain }
-							onChange={ setDontShowAgain }
-						/>
-						<Button variant="solid" onClick={ handleSubmit }>
-							{ __( 'Got it', 'jetpack-forms' ) }
-						</Button>
+						<div>
+							<Text variant="body-md" render={ <p /> }>
+								<strong>
+									{ __( 'To convert a form block to a reusable form:', 'jetpack-forms' ) }
+								</strong>
+							</Text>
+							<ol>
+								<li>
+									{ __(
+										'Open the page or post where your form block is embedded.',
+										'jetpack-forms'
+									) }
+								</li>
+								<li>{ __( 'Select the form block.', 'jetpack-forms' ) }</li>
+								<li>
+									{ __( 'Click "Edit Form" in the block toolbar to convert it.', 'jetpack-forms' ) }
+								</li>
+								<li>{ __( 'Save the page or post.', 'jetpack-forms' ) }</li>
+							</ol>
+						</div>
 					</Stack>
-				</Dialog.Footer>
+				</Dialog.Content>
+				<Stack
+					render={ <Dialog.Footer /> }
+					direction="row"
+					justify="space-between"
+					align="center"
+					gap="md"
+					wrap="wrap"
+				>
+					<CheckboxControl
+						__nextHasNoMarginBottom
+						label={ __( "Don't show this again", 'jetpack-forms' ) }
+						checked={ dontShowAgain }
+						onChange={ setDontShowAgain }
+					/>
+					<Button variant="solid" onClick={ handleSubmit }>
+						{ __( 'Got it', 'jetpack-forms' ) }
+					</Button>
+				</Stack>
 			</Dialog.Popup>
 		</Dialog.Root>
 	);


### PR DESCRIPTION
Part of https://github.com/Automattic/jetpack/issues/48160

## Proposed changes
<!--- Explain what functional changes your PR includes -->
*  Replace components from `@wordpress/components` with `@wordpress/ui` variants.

<img width="635" height="404" alt="Screenshot 2026-07-10 at 17 30 08" src="https://github.com/user-attachments/assets/45b05291-18a5-4fef-a3ba-f970009d0e43" />


Later on, I'll enable a linter which will complain about using the old components (https://github.com/Automattic/jetpack/pull/48487)

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Test instructions from https://github.com/Automattic/jetpack/pull/47943:
    1. Make sure that the option "jetpack_forms_classic_state" is set to "classic". This will make the button that shows the modal appear. You can do this in `/wp-admin/options.php` 
    2. Have classic forms or short circuit [the check](https://github.com/Automattic/jetpack/blob/f6c75e3af4ce11b08fec3bcb057c9a964822d459/projects/packages/forms/routes/forms/stage.tsx#L92)
    3. Go to the Jetpack Forms dashboard on a site that has classic (non-managed) forms so the "Not seeing all your forms?" link appears.
    4. Click the "Not seeing all your forms?" link to open the help modal.
    5. Check the "Don't show this again" checkbox.
* Smoke test the forms modal; no drastic changes, but new components can look slightly different.