### PR TITLE
Components: replace `VisuallyHidden` from components with UI version

### DIFF
--- a/projects/js-packages/charts/changelog/update-form-option-visuallyhidden-to-ui
+++ b/projects/js-packages/charts/changelog/update-form-option-visuallyhidden-to-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Comment: Charts: use aria-label for the leaderboard comparison placeholder instead of VisuallyHidden.

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @wordpress/no-unsafe-wp-apis */
-import { __experimentalGrid as Grid, VisuallyHidden } from '@wordpress/components';
+import { __experimentalGrid as Grid } from '@wordpress/components';
 import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, chevronRight } from '@wordpress/icons';
@@ -388,11 +388,9 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 												<Text
 													className={ clsx( styles.deltaValue, styles.deltaPlaceholder ) }
 													style={ { color: deltaColor } }
+													aria-label={ __( 'No comparison data', 'jetpack-charts' ) }
 												>
-													<span aria-hidden="true">-</span>
-													<VisuallyHidden as="span">
-														{ __( 'No comparison data', 'jetpack-charts' ) }
-													</VisuallyHidden>
+													-
 												</Text>
 											) }
 										</Stack>

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
@@ -97,8 +97,8 @@ describe( 'LeaderboardChart', () => {
 		expect( screen.getByText( '+25%' ) ).toBeInTheDocument();
 		expect( screen.getByText( '-8%' ) ).toBeInTheDocument();
 		expect( screen.getByText( 'New Source' ) ).toBeInTheDocument();
-		expect( screen.getByText( '-' ) ).toHaveAttribute( 'aria-hidden', 'true' );
-		expect( screen.getByText( 'No comparison data' ) ).toBeInTheDocument();
+		expect( screen.getByText( '-' ) ).toBeInTheDocument();
+		expect( screen.getByLabelText( 'No comparison data' ) ).toBeInTheDocument();
 		expect( screen.queryByText( '+100%' ) ).not.toBeInTheDocument();
 	} );
 

--- a/projects/js-packages/components/changelog/update-form-option-visuallyhidden-to-ui
+++ b/projects/js-packages/components/changelog/update-form-option-visuallyhidden-to-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Comment: Components: migrate VisuallyHidden from @wordpress/components to @wordpress/ui in Button.

--- a/projects/js-packages/components/components/button/index.tsx
+++ b/projects/js-packages/components/components/button/index.tsx
@@ -1,6 +1,7 @@
-import { Button as WPButton, Spinner, VisuallyHidden } from '@wordpress/components';
+import { Button as WPButton, Spinner } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, external } from '@wordpress/icons';
+import { VisuallyHidden } from '@wordpress/ui';
 import clsx from 'clsx';
 import { forwardRef } from 'react';
 import styles from './style.module.scss';
@@ -44,12 +45,16 @@ const Button = forwardRef< HTMLElement, ButtonProps >( ( props, ref ) => {
 	const externalIcon = isExternalLink && (
 		<>
 			<Icon size={ externalIconSize } icon={ external } className={ styles[ 'external-icon' ] } />
-			<VisuallyHidden as="span">
-				{
-					/* translators: accessibility text */
-					__( '(opens in a new tab)', 'jetpack-components' )
+			<VisuallyHidden
+				render={
+					<span>
+						{
+							/* translators: accessibility text */
+							__( '(opens in a new tab)', 'jetpack-components' )
+						}
+					</span>
 				}
-			</VisuallyHidden>
+			/>
 		</>
 	);
 	const externalTarget = isExternalLink ? '_blank' : undefined;

--- a/projects/packages/activity-log/changelog/update-form-option-visuallyhidden-to-ui
+++ b/projects/packages/activity-log/changelog/update-form-option-visuallyhidden-to-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Comment: Activity Log: migrate VisuallyHidden from @wordpress/components to @wordpress/ui in date range presets.

--- a/projects/packages/activity-log/src/js/components/DateRangePicker/presets-listbox.tsx
+++ b/projects/packages/activity-log/src/js/components/DateRangePicker/presets-listbox.tsx
@@ -7,9 +7,9 @@ import {
 	Button,
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	Composite,
-	VisuallyHidden,
 } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { VisuallyHidden } from '@wordpress/ui';
 import { presetDefs } from './utils';
 import type { PresetId } from './utils';
 

--- a/projects/packages/forms/changelog/update-form-option-visuallyhidden-to-ui
+++ b/projects/packages/forms/changelog/update-form-option-visuallyhidden-to-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Comment: Forms: migrate VisuallyHidden from @wordpress/components to @wordpress/ui in block editor and dashboard components.

--- a/projects/packages/forms/src/blocks/input-range/edit.js
+++ b/projects/packages/forms/src/blocks/input-range/edit.js
@@ -1,6 +1,6 @@
 import { useBlockProps } from '@wordpress/block-editor';
-import { VisuallyHidden } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
+import { VisuallyHidden } from '@wordpress/ui';
 import { useState, useEffect, useRef } from 'react';
 import useInsertAfterOnEnterKeyDown from '../shared/hooks/use-insert-after-on-enter-key-down.js';
 import { computeSliderValuePosition } from './utils.js';
@@ -86,9 +86,13 @@ export default function SliderInputEdit( props ) {
 	return (
 		<div { ...blockProps }>
 			<div className="jetpack-field-slider__input-row">
-				<VisuallyHidden as="label" htmlFor={ `${ clientId }-slider-min` }>
-					{ __( 'Slider minimum value', 'jetpack-forms' ) }
-				</VisuallyHidden>
+				<VisuallyHidden
+					render={
+						<label htmlFor={ `${ clientId }-slider-min` }>
+							{ __( 'Slider minimum value', 'jetpack-forms' ) }
+						</label>
+					}
+				/>
 				<input
 					id={ `${ clientId }-slider-min` }
 					type="number"
@@ -108,9 +112,13 @@ export default function SliderInputEdit( props ) {
 					onKeyDown={ onKeyDown }
 				/>
 				<div className="jetpack-field-slider__input-container">
-					<VisuallyHidden as="label" htmlFor={ `${ clientId }-slider-default` }>
-						{ __( 'Slider default value', 'jetpack-forms' ) }
-					</VisuallyHidden>
+					<VisuallyHidden
+						render={
+							<label htmlFor={ `${ clientId }-slider-default` }>
+								{ __( 'Slider default value', 'jetpack-forms' ) }
+							</label>
+						}
+					/>
 					<input
 						id={ `${ clientId }-slider-default` }
 						type="range"
@@ -129,9 +137,13 @@ export default function SliderInputEdit( props ) {
 						{ defaultFromContext }
 					</div>
 				</div>
-				<VisuallyHidden as="label" htmlFor={ `${ clientId }-slider-max` }>
-					{ __( 'Slider maximum value', 'jetpack-forms' ) }
-				</VisuallyHidden>
+				<VisuallyHidden
+					render={
+						<label htmlFor={ `${ clientId }-slider-max` }>
+							{ __( 'Slider maximum value', 'jetpack-forms' ) }
+						</label>
+					}
+				/>
 				<input
 					id={ `${ clientId }-slider-max` }
 					type="number"

--- a/projects/packages/forms/src/blocks/option/edit.js
+++ b/projects/packages/forms/src/blocks/option/edit.js
@@ -4,10 +4,11 @@ import {
 	store as blockEditorStore,
 	useBlockProps,
 } from '@wordpress/block-editor';
-import { ToggleControl, PanelBody, VisuallyHidden } from '@wordpress/components';
+import { ToggleControl, PanelBody } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { VisuallyHidden } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useSyncedAttributes } from '../shared/hooks/use-synced-attributes.js';
 import { ALLOWED_FORMATS } from '../shared/util/constants.js';
@@ -183,9 +184,13 @@ const OptionEdit = ( {
 			</li>
 			{ type === 'radio' && isOther && ( isSelected || isParentSelected ) && (
 				<li className="jetpack-other-text-input-wrapper is-visible">
-					<VisuallyHidden as="label" htmlFor={ `${ clientId }-other-text` }>
-						{ otherPlaceholder || __( 'Please specify…', 'jetpack-forms' ) }
-					</VisuallyHidden>
+					<VisuallyHidden
+						render={
+							<label htmlFor={ `${ clientId }-other-text` }>
+								{ otherPlaceholder || __( 'Please specify…', 'jetpack-forms' ) }
+							</label>
+						}
+					/>
 					<input
 						id={ `${ clientId }-other-text` }
 						className="grunion-field jetpack-field__input"

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-rating/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-rating/index.tsx
@@ -3,9 +3,9 @@
  */
 import {
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-	VisuallyHidden,
 } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
+import { VisuallyHidden } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
@@ -61,7 +61,7 @@ const FieldRating = ( { value }: FieldRatingProps ) => {
 
 	return (
 		<>
-			<VisuallyHidden as="span">{ ratingLabel }</VisuallyHidden>
+			<VisuallyHidden render={ <span>{ ratingLabel }</span> } />
 			<HStack spacing="1" alignment="topLeft">
 				{ Array.from( { length: clampedMax }, ( _, index ) => (
 					<span style={ { flex: '0 0 24px' } } key={ index }>

--- a/projects/packages/my-jetpack/_inc/components/connection-screen/body.tsx
+++ b/projects/packages/my-jetpack/_inc/components/connection-screen/body.tsx
@@ -1,8 +1,8 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { ConnectScreen } from '@automattic/jetpack-connection';
-import { VisuallyHidden } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Icon, external } from '@wordpress/icons';
+import { VisuallyHidden } from '@wordpress/ui';
 import connectImage from './connect.webp';
 import styles from './styles.module.scss';
 import type { FC, ReactNode } from 'react';
@@ -83,12 +83,16 @@ const ConnectionScreenBody: FC< ConnectScreenProps > = props => {
 					>
 						{ __( 'See all Jetpack features', 'jetpack-my-jetpack' ) }
 						<Icon icon={ external } />
-						<VisuallyHidden as="span">
-							{
-								/* translators: accessibility text */
-								__( '(opens in a new tab)', 'jetpack-my-jetpack' )
+						<VisuallyHidden
+							render={
+								<span>
+									{
+										/* translators: accessibility text */
+										__( '(opens in a new tab)', 'jetpack-my-jetpack' )
+									}
+								</span>
 							}
-						</VisuallyHidden>
+						/>
 					</a>
 				</li>
 			</ul>

--- a/projects/packages/my-jetpack/changelog/update-form-option-visuallyhidden-to-ui
+++ b/projects/packages/my-jetpack/changelog/update-form-option-visuallyhidden-to-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Comment: My Jetpack: migrate VisuallyHidden from @wordpress/components to @wordpress/ui in connection screen.

--- a/projects/packages/podcast/changelog/update-form-option-visuallyhidden-to-ui
+++ b/projects/packages/podcast/changelog/update-form-option-visuallyhidden-to-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Comment: Podcast: migrate VisuallyHidden from @wordpress/components to @wordpress/ui in distribution UI.

--- a/projects/packages/podcast/src/dashboard/distribution/index.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/index.tsx
@@ -4,7 +4,6 @@ import {
 	Card,
 	CardBody,
 	Notice,
-	VisuallyHidden,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalHStack as HStack,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
@@ -17,6 +16,7 @@ import { useEntityRecord } from '@wordpress/core-data';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { check, copy } from '@wordpress/icons';
+import { VisuallyHidden } from '@wordpress/ui';
 import { usePodcastSettings } from '../hooks/use-podcast-settings';
 import { useValidationIssues } from '../hooks/use-validation-issues';
 import ConfettiAnimation from './confetti';
@@ -50,7 +50,7 @@ const StateBadge = ( { state }: { state: PodcastShowState } ) => {
 	const label = state === 'active' ? SUBMITTED_LABEL : PENDING_LABEL;
 	return (
 		<span className={ `podcast__state-badge podcast__state-badge--${ state }` }>
-			<VisuallyHidden as="span">{ __( 'Status:', 'jetpack-podcast' ) } </VisuallyHidden>
+			<VisuallyHidden render={ <span>{ __( 'Status:', 'jetpack-podcast' ) } </span> } />
 			{ label }
 		</span>
 	);

--- a/projects/packages/podcast/src/dashboard/distribution/submit-modal.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/submit-modal.tsx
@@ -9,7 +9,6 @@ import {
 	Modal,
 	Notice,
 	TextControl,
-	VisuallyHidden,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalHStack as HStack,
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
@@ -21,6 +20,7 @@ import { useCopyToClipboard } from '@wordpress/compose';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { check, external, link } from '@wordpress/icons';
+import { VisuallyHidden } from '@wordpress/ui';
 import { prependHTTPS } from '@wordpress/url';
 import { usePodcastSettings, useUpdatePodcastSettings } from '../hooks/use-podcast-settings';
 import { getShowHostsFor, getShowUrlMaxLength } from '../podcatchers';

--- a/projects/packages/publicize/_inc/components/customize-and-preview/customization-section/index.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/customization-section/index.tsx
@@ -1,6 +1,6 @@
-import { VisuallyHidden } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { VisuallyHidden } from '@wordpress/ui';
 import { Connection } from '../../../social-store/types';
 import { hasSocialPaidFeatures } from '../../../utils';
 import { MediaValidationNotices } from '../../form/media-validation-notices';

--- a/projects/packages/publicize/_inc/components/customize-and-preview/preview-section/index.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/preview-section/index.tsx
@@ -1,6 +1,7 @@
-import { Icon, VisuallyHidden } from '@wordpress/components';
+import { Icon } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
 import { info } from '@wordpress/icons';
+import { VisuallyHidden } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useConnectionPreviewData } from '../../../hooks/use-connection-preview-data';
 import { PostPreview } from './post-preview';
@@ -63,9 +64,13 @@ function EnabledPreview( { connection }: PreviewSectionProps ) {
 
 	return (
 		<>
-			<VisuallyHidden as="h2">
-				{ _x( 'Preview', 'Noun: Post preview section heading', 'jetpack-publicize-pkg' ) }
-			</VisuallyHidden>
+			<VisuallyHidden
+				render={
+					<h2>
+						{ _x( 'Preview', 'Noun: Post preview section heading', 'jetpack-publicize-pkg' ) }
+					</h2>
+				}
+			/>
 			<div className={ styles[ 'preview-wrapper' ] } aria-busy={ previewData.isLoading }>
 				{ previewData.isLoading ? (
 					<PreviewSkeleton />

--- a/projects/packages/publicize/_inc/components/media-picker/index.tsx
+++ b/projects/packages/publicize/_inc/components/media-picker/index.tsx
@@ -1,10 +1,10 @@
 import { ThemeProvider } from '@automattic/jetpack-components';
 import { MediaUpload, MediaUploadCheck } from '@wordpress/block-editor';
-import { ResponsiveWrapper, Spinner, VisuallyHidden } from '@wordpress/components';
+import { ResponsiveWrapper, Spinner } from '@wordpress/components';
 import { Fragment, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, closeSmall } from '@wordpress/icons';
-import { Button } from '@wordpress/ui';
+import { Button, VisuallyHidden } from '@wordpress/ui';
 import clsx from 'clsx';
 import { isVideo } from '../../hooks/use-media-restrictions';
 import { SELECTABLE_MEDIA_TYPES } from '../../hooks/use-media-restrictions/restrictions';

--- a/projects/packages/publicize/changelog/update-form-option-visuallyhidden-to-ui
+++ b/projects/packages/publicize/changelog/update-form-option-visuallyhidden-to-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Comment: Publicize: migrate VisuallyHidden from @wordpress/components to @wordpress/ui in customize-and-preview and media picker components.

--- a/projects/plugins/jetpack/changelog/update-form-option-visuallyhidden-to-ui
+++ b/projects/plugins/jetpack/changelog/update-form-option-visuallyhidden-to-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Comment: Newsletter: migrate VisuallyHidden from @wordpress/components to @wordpress/ui in memberships settings.

--- a/projects/plugins/jetpack/extensions/shared/memberships/settings.js
+++ b/projects/plugins/jetpack/extensions/shared/memberships/settings.js
@@ -6,7 +6,6 @@ import {
 	FlexBlock,
 	RadioControl,
 	Spinner,
-	VisuallyHidden,
 	__experimentalToggleGroupControl as ToggleGroupControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
@@ -17,6 +16,7 @@ import { PostVisibilityCheck, store as editorStore } from '@wordpress/editor';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon } from '@wordpress/icons';
+import { VisuallyHidden } from '@wordpress/ui';
 import paywallBlockMetadata from '../../blocks/paywall/block.json';
 import { store as membershipProductsStore } from '../../store/membership-products';
 import './settings.scss';
@@ -153,7 +153,7 @@ export function NewsletterAccessRadioButtons( {
 
 	return (
 		<fieldset className="jetpack-newsletter-access-radio-buttons">
-			<VisuallyHidden as="legend">{ __( 'Access', 'jetpack' ) } </VisuallyHidden>
+			<VisuallyHidden render={ <legend>{ __( 'Access', 'jetpack' ) } </legend> } />
 			<RadioControl
 				onChange={ value => {
 					if (


### PR DESCRIPTION
Part of https://github.com/Automattic/jetpack/issues/48160

## Proposed changes
<!--- Explain what functional changes your PR includes -->
*  Replaces `VisuallyHidden` component from `@wordpress/components` ([storybook](https://wordpress.github.io/gutenberg/?path=/docs/components-visuallyhidden--docs))  with `@wordpress/ui` version ([storybook](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-visuallyhidden--docs)).

Later on, I'll enable a linter which will complain about using the old component (https://github.com/Automattic/jetpack/pull/48487)

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Smoke test touched UIs; no changes visible.