### PR TITLE
AI Launchpad: availability-aware tailoring

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotobrd-509-ai-launchpad-availability-aware-tailoring
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotobrd-509-ai-launchpad-availability-aware-tailoring
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Launchpad: generate fuller, better-tailored task lists — offer the tailoring AI only the tasks that will actually render on the site and goal (rescuing the About-page task the visibility gate wrongly hid during the REST request), and back-fill a short list toward six as a floor.

--- a/projects/packages/jetpack-mu-wpcom/changelog/dotobrd-509-ai-launchpad-availability-aware-tailoring
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotobrd-509-ai-launchpad-availability-aware-tailoring
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-AI Launchpad: generate fuller, better-tailored task lists — offer the tailoring AI only the tasks that will actually render on the site and goal (rescuing the About-page task the visibility gate wrongly hid during the REST request), and back-fill a short list toward six as a floor.
+AI Launchpad: generate fuller, better-tailored task lists — offer the tailoring AI only the tasks that will actually render on the site and goal (rescuing the About-page task the visibility gate wrongly hid during the REST request) and are not already complete, back-fill a short list toward six as a floor, and drop the "Personalize newsletter" task, which was born-completed and offered nothing to do.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -599,6 +599,9 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			);
 		}
 
+		// The AI's raw picks, captured before the unknown-id filter below so hallucinated ids stay observable.
+		$raw_task_ids = array_column( $payload['tasks'], 'id' );
+
 		$definitions = wpcom_launchpad_get_task_definitions();
 		$tasks       = array();
 
@@ -641,7 +644,71 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 		delete_option( self::OPTION_SKIPPED );
 		delete_option( self::OPTION_COMPLETED );
 
+		// After the writes, so the observed rendered list is the fresh one.
+		$this->log_tailoring( $ai_output, $raw_task_ids );
+
 		return array( 'ai_output' => $ai_output );
+	}
+
+	/**
+	 * Emits the tailoring observation event to Logstash, keyed `feature: atomic_ai_launchpad`, `message: tailored`
+	 * (the public-api logstash endpoint whitelists features by their `atomic_` prefix — a bare feature name is
+	 * rejected with a 400 on the Atomic HTTP dispatch path). Best-effort: logging must never fail the tailoring write.
+	 *
+	 * @param array    $ai_output    The persisted AI output envelope.
+	 * @param string[] $raw_task_ids The AI's selected ids before the unknown-id filter.
+	 * @return void
+	 */
+	private function log_tailoring( $ai_output, $raw_task_ids ) {
+		try {
+			$extra = $this->tailoring_log_extra( $ai_output, $raw_task_ids );
+
+			/**
+			 * Gates the tailoring observation event sent to Logstash.
+			 *
+			 * @param bool  $enabled Whether to send the event. Default true.
+			 * @param array $extra   The event payload about to be sent.
+			 */
+			if ( ! apply_filters( 'wpcom_ai_launchpad_tailoring_log_enabled', true, $extra ) ) {
+				return;
+			}
+
+			\Automattic\Jetpack\Jetpack_Mu_Wpcom::log2logstash( 'atomic_ai_launchpad', 'tailored', $extra );
+		} catch ( \Throwable $e ) {
+			unset( $e );
+		}
+	}
+
+	/**
+	 * The tailoring observation event: how the AI's output relates to what the site will actually render.
+	 *
+	 * Carries the inferred details, the AI's raw selected ids (pre-filter, so hallucinated ids are observable), the
+	 * rendered ids, and their delta — `dropped` is what the unknown-id filter and the visibility gate removed, `added`
+	 * is what synthetics and the backfill floor put in. The delta is diffed post-remap so a selected id that renders
+	 * under its working equivalent does not read as a drop plus an addition. The raw wizard title/description are
+	 * never included, and the inferred fields that can echo the user's own words near-verbatim are stripped:
+	 * `brand_name` restates the title and `tagline` is drafted from the description.
+	 *
+	 * @param array    $ai_output    The persisted AI output envelope.
+	 * @param string[] $raw_task_ids The AI's selected ids before the unknown-id filter.
+	 * @return array
+	 */
+	private function tailoring_log_extra( $ai_output, $raw_task_ids ) {
+		// Schema-validated on the write path, so `inferred` is always present here.
+		$inferred = $ai_output['payload']['inferred'];
+		unset( $inferred['brand_name'], $inferred['tagline'] );
+
+		$rendered = array_column( $this->get_current_tasks(), 'id' );
+		$remapped = array_unique( array_map( 'wpcom_ai_launchpad_remap_task_id', $raw_task_ids ) );
+
+		return array(
+			'source'   => $ai_output['source'],
+			'inferred' => $inferred,
+			'selected' => $raw_task_ids,
+			'rendered' => $rendered,
+			'dropped'  => array_values( array_diff( $remapped, $rendered ) ),
+			'added'    => array_values( array_diff( $rendered, $remapped ) ),
+		);
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -661,19 +661,21 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	 */
 	private function log_tailoring( $ai_output, $raw_task_ids ) {
 		try {
-			$extra = $this->tailoring_log_extra( $ai_output, $raw_task_ids );
-
 			/**
-			 * Gates the tailoring observation event sent to Logstash.
+			 * Gates the tailoring observation event sent to Logstash. Checked before the event
+			 * is built, so disabling it also skips the extra task-list rebuild the event needs.
 			 *
-			 * @param bool  $enabled Whether to send the event. Default true.
-			 * @param array $extra   The event payload about to be sent.
+			 * @param bool $enabled Whether to send the event. Default true.
 			 */
-			if ( ! apply_filters( 'wpcom_ai_launchpad_tailoring_log_enabled', true, $extra ) ) {
+			if ( ! apply_filters( 'wpcom_ai_launchpad_tailoring_log_enabled', true ) ) {
 				return;
 			}
 
-			\Automattic\Jetpack\Jetpack_Mu_Wpcom::log2logstash( 'atomic_ai_launchpad', 'tailored', $extra );
+			\Automattic\Jetpack\Jetpack_Mu_Wpcom::log2logstash(
+				'atomic_ai_launchpad',
+				'tailored',
+				$this->tailoring_log_extra( $ai_output, $raw_task_ids )
+			);
 		} catch ( \Throwable $e ) {
 			unset( $e );
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -475,6 +475,10 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			if ( count( $tasks ) >= $target ) {
 				break;
 			}
+			// A filler card that is already complete offers nothing to do; better a shorter list.
+			if ( ! empty( $task['completed'] ) ) {
+				continue;
+			}
 			$tasks = $this->insert_before_launch_task( $tasks, $task );
 		}
 
@@ -814,18 +818,25 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	 * @return array
 	 */
 	public function get_available_tasks( $request ) {
-		return array( 'available_task_ids' => $this->available_task_ids( (string) $request['goal'] ) );
+		$ids = $this->available_task_ids( (string) $request['goal'] );
+		return array(
+			'available_task_ids'  => $ids['actionable'],
+			'renderable_task_ids' => $ids['renderable'],
+		);
 	}
 
 	/**
 	 * The task ids that will actually render on this site for the given goal — the menu tailoring should choose from.
 	 *
 	 * Built by running the whole catalog through the real gate (visibility + force-visible overrides, and the sell
-	 * goal's woo-preview mode), so a task the AI could pick but the site would drop is never offered. The client
-	 * intersects this with its own TASK_MENU. Computed once per wizard submit.
+	 * goal's woo-preview mode), so a task the AI could pick but the site would drop is never offered. `actionable`
+	 * additionally excludes tasks that are already complete — they leave nothing to do — except the launch tasks,
+	 * which the output contract requires last even on a site that already launched. `renderable` keeps the completed
+	 * ones: the client falls back to it when completion leaves too few actionable tasks to fill a valid list. The
+	 * client intersects these with its own TASK_MENU. Computed once per wizard submit.
 	 *
 	 * @param string $goal The inferred/selected goal.
-	 * @return string[]
+	 * @return array{renderable: string[], actionable: string[]}
 	 */
 	private function available_task_ids( $goal ) {
 		if ( ! function_exists( 'is_plugin_active' ) ) {
@@ -834,7 +845,19 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 		// Sell keeps the commerce tasks as a disabled preview until WooCommerce is active, so they count as available.
 		$disable_hidden_woo = 'sell' === $goal && ! is_plugin_active( 'woocommerce/woocommerce.php' );
 
-		return array_column( $this->build_all_catalog_tasks( false, $disable_hidden_woo ), 'id' );
+		$tasks = $this->build_all_catalog_tasks( false, $disable_hidden_woo );
+
+		$actionable = array_filter(
+			$tasks,
+			static function ( $task ) {
+				return ! $task['completed'] || in_array( $task['id'], self::LAUNCH_TASK_IDS, true );
+			}
+		);
+
+		return array(
+			'renderable' => array_column( $tasks, 'id' ),
+			'actionable' => array_column( $actionable, 'id' ),
+		);
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -55,13 +55,16 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	);
 
 	/**
-	 * Tasks whose catalog visibility gate encodes an `IS_WPCOM`-only assumption the AI Launchpad overrides.
+	 * Tasks whose catalog visibility gate is a false negative in this read path, so the AI Launchpad overrides it.
 	 *
 	 * `add_10_email_subscribers` is gated off WordPress.com, but AI_Launchpad_Subscribers_Listener reads the count on
-	 * Atomic, so the task must still render and its visibility gate is skipped here.
+	 * Atomic, so the task must still render. `add_about_page` is gated on the `_wpcom_template_layout_category`
+	 * page-meta key being registered, which does not happen during a REST request, so the task is wrongly hidden even
+	 * though its "add a page" CTA works — force it visible so tailoring can offer this genuinely useful task.
 	 */
 	const FORCE_VISIBLE_TASK_IDS = array(
 		'add_10_email_subscribers',
+		'add_about_page',
 	);
 
 	/**
@@ -187,6 +190,26 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 							'type'              => 'string',
 							'default'           => 'en',
 							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/available-tasks',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_available_tasks' ),
+					'permission_callback' => array( $this, 'can_read' ),
+					'args'                => array(
+						'goal' => array(
+							'description'       => 'The selected goal; sell keeps commerce tasks as available previews.',
+							'type'              => 'string',
+							'default'           => '',
+							'sanitize_callback' => 'sanitize_key',
 						),
 					),
 				),
@@ -784,13 +807,47 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	}
 
 	/**
-	 * Builds the enriched task list for every catalog task, bypassing the visibility gate (backs `?all_tasks=1`).
+	 * Read endpoint backing the client's availability-aware tailoring: the task ids that will render for the given
+	 * goal. Fetched before the AI call (which the wizard prewarms), so the prompt offers only renderable tasks.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return array
+	 */
+	public function get_available_tasks( $request ) {
+		return array( 'available_task_ids' => $this->available_task_ids( (string) $request['goal'] ) );
+	}
+
+	/**
+	 * The task ids that will actually render on this site for the given goal — the menu tailoring should choose from.
+	 *
+	 * Built by running the whole catalog through the real gate (visibility + force-visible overrides, and the sell
+	 * goal's woo-preview mode), so a task the AI could pick but the site would drop is never offered. The client
+	 * intersects this with its own TASK_MENU. Computed once per wizard submit.
+	 *
+	 * @param string $goal The inferred/selected goal.
+	 * @return string[]
+	 */
+	private function available_task_ids( $goal ) {
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+		// Sell keeps the commerce tasks as a disabled preview until WooCommerce is active, so they count as available.
+		$disable_hidden_woo = 'sell' === $goal && ! is_plugin_active( 'woocommerce/woocommerce.php' );
+
+		return array_column( $this->build_all_catalog_tasks( false, $disable_hidden_woo ), 'id' );
+	}
+
+	/**
+	 * Builds the enriched task list for every catalog task (backs `?all_tasks=1` when the gate is bypassed, and
+	 * available_task_ids() when it is not).
 	 *
 	 * Each task is enriched in isolation so one that can't be built is skipped rather than breaking the whole view.
 	 *
+	 * @param bool $bypass_visibility  Whether to skip the catalog visibility gate (the testing view does).
+	 * @param bool $disable_hidden_woo Whether hidden commerce tasks render as a disabled preview instead of dropping.
 	 * @return array
 	 */
-	private function build_all_catalog_tasks() {
+	private function build_all_catalog_tasks( $bypass_visibility = true, $disable_hidden_woo = false ) {
 		$built    = array();
 		$seen_ids = array();
 		foreach ( array_keys( wpcom_launchpad_get_task_definitions() ) as $task_id ) {
@@ -802,7 +859,9 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 							'subtitle' => $task_id,
 						),
 					),
-					true
+					$bypass_visibility,
+					null,
+					$disable_hidden_woo
 				);
 			} catch ( \Throwable $e ) {
 				continue;

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -407,7 +407,73 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			}
 		}
 
+		// Restore the list toward six after the visibility gate has dropped tasks (before skips, which are the
+		// user's own removals). No-op on an empty list so the wizard still runs when there is no AI output.
+		$tasks = $this->backfill_to_minimum( $tasks, $theme_cta, $disable_hidden_woo );
+
 		return $this->apply_skipped_tasks( $tasks );
+	}
+
+	/**
+	 * Tops a short rendered list back up toward the six tasks the AI is asked to return.
+	 *
+	 * The catalog visibility gate in build_tasks() drops any task it hides on this site (e.g. add_about_page needs a
+	 * page-template meta key that is absent during a REST request) with no replacement, so a gate-heavy AI pick can
+	 * collapse the list to two or three cards. This backfills from a small pool of broadly-useful tasks and keeps the
+	 * launch task last. The pool is run through build_tasks() in one pass, which gates and dedups it, so a pool task
+	 * the site hides simply does not appear. Backfilled cards are skippable (see skip_task); a fuller, AI-ranked
+	 * overflow pool is the eventual replacement.
+	 *
+	 * @param array  $tasks              The rendered task list, already gated, launch task last.
+	 * @param string $theme_cta          Pre-resolved themes-showcase CTA passed through to build_tasks().
+	 * @param bool   $disable_hidden_woo Whether hidden commerce tasks render as a disabled preview.
+	 * @return array
+	 */
+	private function backfill_to_minimum( $tasks, $theme_cta, $disable_hidden_woo ) {
+		$target = 6;
+		if ( count( $tasks ) >= $target || empty( $tasks ) ) {
+			return $tasks;
+		}
+
+		$present    = array_column( $tasks, 'id' );
+		$candidates = array();
+		foreach ( $this->backfill_pool() as $id => $subtitle ) {
+			if ( ! in_array( $id, $present, true ) ) {
+				$candidates[] = array(
+					'id'       => $id,
+					'subtitle' => $subtitle,
+				);
+			}
+		}
+
+		// One build over every candidate: build_tasks() drops the gated ones and dedups, preserving pool order.
+		$built = $this->build_tasks( $candidates, false, $theme_cta, $disable_hidden_woo );
+		foreach ( $built as $task ) {
+			if ( count( $tasks ) >= $target ) {
+				break;
+			}
+			$tasks = $this->insert_before_launch_task( $tasks, $task );
+		}
+
+		return $tasks;
+	}
+
+	/**
+	 * The ordered id => subtitle pool the short-list backfill draws from: broadly-useful tasks that render on most
+	 * sites and are skippable, most-broadly-applicable first. Each has a distinct card title, and none duplicate work
+	 * the wizard already did (e.g. no site-title task — the wizard captured the name). Excludes tasks whose completion
+	 * depends on the AI-task list (the theme/social listeners, the complete-on-click route), since a backfilled card is
+	 * not on that list. skip_task() reads the ids here to keep every backfilled card skippable, so the set lives here.
+	 *
+	 * @return array<string, string>
+	 */
+	private function backfill_pool() {
+		return array(
+			'design_edited'        => __( 'Make the design your own.', 'jetpack-mu-wpcom' ),
+			'add_new_page'         => __( 'Add a page your visitors will want, like About or Contact.', 'jetpack-mu-wpcom' ),
+			'connect_social_media' => __( 'Connect your social accounts to reach more people.', 'jetpack-mu-wpcom' ),
+			'drive_traffic'        => __( 'Help people discover your site.', 'jetpack-mu-wpcom' ),
+		);
 	}
 
 	/**
@@ -593,9 +659,10 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	/**
 	 * Marks a task as skipped: it renders (and counts) as completed without its real completion signal ever firing.
 	 *
-	 * Restricted to tasks on the site's AI-selected list plus the synthetic ids the list adds itself. Persisted
-	 * separately from `launchpad_checklist_tasks_statuses` because several catalog tasks recompute completion live
-	 * (memberships, woo, domains) and would ignore a status write; the skip set is overlaid on read instead.
+	 * Restricted to tasks on the site's AI-selected list, the synthetic ids the list adds itself, and the short-list
+	 * backfill pool — so every rendered card (AI, synthetic, or filler) is skippable. Persisted separately from
+	 * `launchpad_checklist_tasks_statuses` because several catalog tasks recompute completion live (memberships, woo,
+	 * domains) and would ignore a status write; the skip set is overlaid on read instead.
 	 *
 	 * @param WP_REST_Request $request Request object.
 	 * @return array|WP_Error
@@ -603,7 +670,7 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	public function skip_task( $request ) {
 		$task_id = $request['task_id'];
 
-		$skippable = array_merge( wpcom_ai_launchpad_get_ai_task_ids(), self::SYNTHETIC_TASK_IDS );
+		$skippable = array_merge( wpcom_ai_launchpad_get_ai_task_ids(), self::SYNTHETIC_TASK_IDS, array_keys( $this->backfill_pool() ) );
 		if ( ! in_array( $task_id, $skippable, true ) ) {
 			return new WP_Error(
 				'ai_launchpad_task_not_skippable',

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.test.mts
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
-import { buildTailorPrompt, TASK_MENU } from './prompts.ts';
+import { buildTailorPrompt, chooseTailoringMenu, TASK_MENU } from './prompts.ts';
 import type { WizardInput } from './types.ts';
 
 const __dirname = dirname( fileURLToPath( import.meta.url ) );
@@ -57,6 +57,19 @@ describe( 'buildTailorPrompt', () => {
 		for ( const id of TASK_MENU ) {
 			assert.ok( prompt.includes( '- ' + id ), `menu ID "${ id }" missing from prompt` );
 		}
+	} );
+
+	it( 'offers the actionable ids while enough of them remain on the menu', () => {
+		const actionable = TASK_MENU.slice( 0, 12 );
+		const renderable = [ ...actionable, 'first_post_published_extra' ];
+		assert.equal( chooseTailoringMenu( actionable, renderable ), actionable );
+	} );
+
+	it( 'relaxes to the renderable ids when completion leaves too few actionable menu tasks', () => {
+		// Ids off the menu do not count toward the threshold: the prompt's menu is the intersection.
+		const actionable = [ ...TASK_MENU.slice( 0, 4 ), 'off_menu_task_a', 'off_menu_task_b' ];
+		const renderable = TASK_MENU.slice( 0, 20 );
+		assert.equal( chooseTailoringMenu( actionable, renderable ), renderable );
 	} );
 
 	it( 'instructs the model to return only JSON', () => {

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.test.mts
@@ -37,6 +37,28 @@ describe( 'buildTailorPrompt', () => {
 		assert.ok( ! TASK_MENU.includes( 'design_completed' ) );
 	} );
 
+	it( 'restricts the offered menu to the available tasks when given', () => {
+		const available = [ 'first_post_published', 'site_theme_selected', 'site_launched' ];
+		const prompt = buildTailorPrompt( fixtures[ 0 ].input, available );
+		// A menu section lists only the available ids...
+		for ( const id of available ) {
+			assert.ok( prompt.includes( '- ' + id ), `available ID "${ id }" missing from menu` );
+		}
+		// ...and a menu-only task that is not available is dropped from the list.
+		const dropped = TASK_MENU.find( id => ! available.includes( id ) ) as string;
+		assert.ok(
+			! prompt.includes( '- ' + dropped ),
+			`unavailable ID "${ dropped }" should be dropped`
+		);
+	} );
+
+	it( 'falls back to the full menu when the available list is empty', () => {
+		const prompt = buildTailorPrompt( fixtures[ 0 ].input, [] );
+		for ( const id of TASK_MENU ) {
+			assert.ok( prompt.includes( '- ' + id ), `menu ID "${ id }" missing from prompt` );
+		}
+	} );
+
 	it( 'instructs the model to return only JSON', () => {
 		const prompt = buildTailorPrompt( fixtures[ 0 ].input );
 		assert.ok( /return only a json object/i.test( prompt ) );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
@@ -54,6 +54,26 @@ export const TASK_MENU: readonly string[] = [
 	'start_building_your_audience',
 ];
 
+// The AI must return exactly six tasks, so the offered menu needs comfortable headroom beyond six.
+const MIN_TAILORING_MENU = 10;
+
+/**
+ * Pick the task ids the prompt's menu is filtered to: the actionable ids (renderable and not already complete),
+ * unless completion leaves too few of them on the menu to fill a valid six-task list — then relax to every
+ * renderable id, since a completed card still renders fine and beats making valid AI output impossible.
+ *
+ * @param actionableTaskIds - Renderable-and-not-completed ids from the available-tasks endpoint.
+ * @param renderableTaskIds - All renderable ids, regardless of completion.
+ * @return The ids to filter the menu to.
+ */
+export function chooseTailoringMenu(
+	actionableTaskIds: readonly string[],
+	renderableTaskIds: readonly string[]
+): readonly string[] {
+	const menuCount = TASK_MENU.filter( id => actionableTaskIds.includes( id ) ).length;
+	return menuCount >= MIN_TAILORING_MENU ? actionableTaskIds : renderableTaskIds;
+}
+
 /**
  * Build the single combined prompt sent to jetpack-ai-query, producing the
  * inferred blob, task list, and first-post draft in one JSON response. Hard rules

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
@@ -36,7 +36,6 @@ export const TASK_MENU: readonly string[] = [
 	'subscribers_added',
 	'import_subscribers',
 	'newsletter_plan_created',
-	'setup_newsletter',
 	'customize_welcome_message',
 	'enable_subscribers_modal',
 	'manage_subscribers',

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
@@ -60,11 +60,22 @@ export const TASK_MENU: readonly string[] = [
  * inferred blob, task list, and first-post draft in one JSON response. Hard rules
  * mirror the server-side validation so valid output is not rejected.
  *
- * @param input - The collected wizard input.
+ * @param input            - The collected wizard input.
+ * @param availableTaskIds - Task ids that will render on this site+goal; the menu is filtered to these. Optional; the full menu is used when omitted or empty.
  * @return The prompt string.
  */
-export function buildTailorPrompt( input: WizardInput ): string {
+export function buildTailorPrompt(
+	input: WizardInput,
+	availableTaskIds?: readonly string[]
+): string {
 	const { goal, site_name, description } = input;
+
+	// Offer only tasks that will actually render on this site+goal, so the model never spends a pick on a task the
+	// server would drop. Falls back to the full menu when availability is unknown (e.g. the lookup failed).
+	const menu =
+		availableTaskIds && availableTaskIds.length
+			? TASK_MENU.filter( id => availableTaskIds.includes( id ) )
+			: TASK_MENU;
 
 	return `You are helping a new WordPress.com user onboard. They have described their site in their own words. Your job is to make their onboarding checklist feel hand-picked for THIS site, not generic.
 
@@ -115,7 +126,7 @@ Write a friendly starter blog post the user can edit and publish.
 Treat the "Site name:" value above as THE ONLY brand/name to use anywhere - in the title, subtitle, paragraphs, and inferred.brand_name. It overrides any name mentioned inside the user description. If the description names a different brand, ignore it and use the "Site name:" value.
 
 ============ available task menu ============
-${ TASK_MENU.map( id => '- ' + id ).join( '\n' ) }
+${ menu.map( id => '- ' + id ).join( '\n' ) }
 
 ============ format ============
 Return only a JSON object matching this schema. Do not include prose, code fences, or commentary. The first character MUST be "{".

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/tailor.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/tailor.ts
@@ -2,7 +2,7 @@ import apiFetch from '@wordpress/api-fetch';
 import { addQueryArgs } from '@wordpress/url';
 import { selectFallback } from './fallback.ts';
 import { requestJwt } from './jwt.ts';
-import { buildTailorPrompt } from './prompts.ts';
+import { buildTailorPrompt, chooseTailoringMenu } from './prompts.ts';
 import { parseAgentResponse } from './schema-validator.ts';
 import { trackAiResponseReceived } from './tracks.ts';
 import type { TailoredOutput, TailorResult, TailorSource, WizardInput } from './types.ts';
@@ -101,19 +101,25 @@ async function fetchAiOutputWithRetry(
 }
 
 /**
- * Fetch the task ids that will actually render for this goal, so the prompt offers
- * only renderable tasks. Returns an empty list on failure, which leaves the prompt
- * using the full menu.
+ * Fetch the task ids the prompt's menu may offer for this goal: the actionable ids, relaxed to all renderable
+ * ids when completion leaves too few to fill a valid list (see chooseTailoringMenu). Returns an empty list on
+ * failure, which leaves the prompt using the full menu.
  *
  * @param goal - The selected goal.
- * @return The available task ids, or an empty array.
+ * @return The task ids to offer, or an empty array.
  */
-async function fetchAvailableTaskIds( goal: string ): Promise< string[] > {
+async function fetchAvailableTaskIds( goal: string ): Promise< readonly string[] > {
 	try {
 		const response = ( await apiFetch( {
 			path: addQueryArgs( '/wpcom/v2/ai-launchpad/available-tasks', { goal } ),
-		} ) ) as { available_task_ids?: string[] };
-		return Array.isArray( response.available_task_ids ) ? response.available_task_ids : [];
+		} ) ) as { available_task_ids?: string[]; renderable_task_ids?: string[] };
+		const actionable = Array.isArray( response.available_task_ids )
+			? response.available_task_ids
+			: [];
+		const renderable = Array.isArray( response.renderable_task_ids )
+			? response.renderable_task_ids
+			: [];
+		return chooseTailoringMenu( actionable, renderable );
 	} catch {
 		return [];
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/tailor.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/tailor.ts
@@ -24,10 +24,14 @@ type FetchOutcome = { ok: true; output: TailoredOutput } | { ok: false; retryabl
  * Call jetpack-ai-query once with the combined prompt and return the validated
  * output, or a failure outcome tagging whether the failure is worth retrying.
  *
- * @param input - The collected wizard input.
+ * @param input            - The collected wizard input.
+ * @param availableTaskIds - Task ids the prompt may offer (filters the menu).
  * @return The attempt outcome.
  */
-async function fetchAiOutput( input: WizardInput ): Promise< FetchOutcome > {
+async function fetchAiOutput(
+	input: WizardInput,
+	availableTaskIds: readonly string[]
+): Promise< FetchOutcome > {
 	const controller = new AbortController();
 	// eslint-disable-next-line @wordpress/no-unused-vars-before-return -- the timeout must arm before the awaited request and is cleared in finally.
 	const timeout = setTimeout( () => controller.abort(), AI_QUERY_TIMEOUT_MS );
@@ -41,7 +45,7 @@ async function fetchAiOutput( input: WizardInput ): Promise< FetchOutcome > {
 				Authorization: 'Bearer ' + token,
 			},
 			body: JSON.stringify( {
-				messages: [ { role: 'user', content: buildTailorPrompt( input ) } ],
+				messages: [ { role: 'user', content: buildTailorPrompt( input, availableTaskIds ) } ],
 				feature: 'ai-launchpad',
 				model: 'gpt-4o',
 				max_tokens: 1800,
@@ -81,15 +85,38 @@ async function fetchAiOutput( input: WizardInput ): Promise< FetchOutcome > {
  * Call jetpack-ai-query, retrying once on a transient/validation failure, and
  * return the validated output or null.
  *
- * @param input - The collected wizard input.
+ * @param input            - The collected wizard input.
+ * @param availableTaskIds - Task ids the prompt may offer (filters the menu).
  * @return The validated output, or null.
  */
-async function fetchAiOutputWithRetry( input: WizardInput ): Promise< TailoredOutput | null > {
-	let outcome = await fetchAiOutput( input );
+async function fetchAiOutputWithRetry(
+	input: WizardInput,
+	availableTaskIds: readonly string[]
+): Promise< TailoredOutput | null > {
+	let outcome = await fetchAiOutput( input, availableTaskIds );
 	if ( ! outcome.ok && outcome.retryable ) {
-		outcome = await fetchAiOutput( input );
+		outcome = await fetchAiOutput( input, availableTaskIds );
 	}
 	return outcome.ok ? outcome.output : null;
+}
+
+/**
+ * Fetch the task ids that will actually render for this goal, so the prompt offers
+ * only renderable tasks. Returns an empty list on failure, which leaves the prompt
+ * using the full menu.
+ *
+ * @param goal - The selected goal.
+ * @return The available task ids, or an empty array.
+ */
+async function fetchAvailableTaskIds( goal: string ): Promise< string[] > {
+	try {
+		const response = ( await apiFetch( {
+			path: addQueryArgs( '/wpcom/v2/ai-launchpad/available-tasks', { goal } ),
+		} ) ) as { available_task_ids?: string[] };
+		return Array.isArray( response.available_task_ids ) ? response.available_task_ids : [];
+	} catch {
+		return [];
+	}
 }
 
 /**
@@ -115,7 +142,8 @@ async function persist( output: TailoredOutput, source: TailorSource ): Promise<
  */
 export async function tailor( input: WizardInput ): Promise< TailorResult > {
 	const start = performance.now();
-	const aiOutput = await fetchAiOutputWithRetry( input );
+	const availableTaskIds = await fetchAvailableTaskIds( input.goal );
+	const aiOutput = await fetchAiOutputWithRetry( input, availableTaskIds );
 
 	if ( aiOutput ) {
 		try {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -427,6 +427,55 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * A task that is already complete offers nothing to do, so it is excluded from the actionable ids offered to the
+	 * tailoring AI — but stays in the renderable ids, the client's relaxation set for heavily-completed sites.
+	 */
+	public function test_available_tasks_exclude_already_completed_tasks() {
+		wp_set_current_user( $this->admin_id );
+
+		$before = $this->call_api( Requests::GET, '/available-tasks', null, array( 'goal' => 'write' ) )->get_data();
+		$this->assertContains( 'first_post_published', $before['available_task_ids'] );
+
+		update_option( 'launchpad_checklist_tasks_statuses', array( 'first_post_published' => true ) );
+
+		$after = $this->call_api( Requests::GET, '/available-tasks', null, array( 'goal' => 'write' ) )->get_data();
+		$this->assertNotContains( 'first_post_published', $after['available_task_ids'] );
+		$this->assertContains( 'first_post_published', $after['renderable_task_ids'] );
+	}
+
+	/**
+	 * The launch tasks are exempt from the already-completed filter: the output contract requires the tailored list
+	 * to end on one, so a site that already launched must still be able to produce a valid list.
+	 */
+	public function test_available_tasks_keep_completed_launch_tasks() {
+		wp_set_current_user( $this->admin_id );
+
+		update_option( 'launch-status', 'launched' );
+
+		$data = $this->call_api( Requests::GET, '/available-tasks', null, array( 'goal' => 'write' ) )->get_data();
+
+		// Guard against the premise going stale: the launch task really is complete on this site, so its presence
+		// below proves the exemption rather than mere incompleteness.
+		$this->assertTrue( wpcom_launchpad_checklists()->is_task_id_complete( 'site_launched' ) );
+		$this->assertContains( 'site_launched', $data['available_task_ids'] );
+	}
+
+	/**
+	 * The short-list backfill must not top the list up with already-completed filler: a pre-checked card the user
+	 * never chose offers nothing to do. A shorter list is preferable.
+	 */
+	public function test_backfill_skips_already_completed_pool_tasks() {
+		wp_set_current_user( $this->admin_id );
+		update_option( 'launchpad_checklist_tasks_statuses', array( 'drive_traffic' => true ) );
+		$this->seed_ai_output_with_tasks( array( 'first_post_published', 'site_launched' ), 'write' );
+
+		$ids = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], 'id' );
+
+		$this->assertNotContains( 'drive_traffic', $ids, 'a completed pool task is not backfilled' );
+		$this->assertContains( 'add_new_page', $ids, 'incomplete pool tasks still backfill' );
+	}
+
+	/**
 	 * Test that GET keeps add_10_email_subscribers even though its catalog
 	 * visibility callback (wpcom_launchpad_are_newsletter_subscriber_counts_available)
 	 * is false off WordPress.com: the AI Launchpad retrieves the subscriber count

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -398,6 +398,35 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * The available-tasks endpoint advertises the tasks that will actually render on this site+goal, so tailoring can
+	 * pick only from renderable tasks. Woo tasks are gated off without WooCommerce, so a write list excludes them,
+	 * while a sell list keeps them (as previews) and so lists them as available.
+	 */
+	public function test_available_tasks_endpoint_is_goal_aware() {
+		wp_set_current_user( $this->admin_id );
+
+		$write = $this->call_api( Requests::GET, '/available-tasks', null, array( 'goal' => 'write' ) )->get_data();
+		$this->assertArrayHasKey( 'available_task_ids', $write );
+		$this->assertContains( 'first_post_published', $write['available_task_ids'] );
+		$this->assertNotContains( 'woo_products', $write['available_task_ids'], 'woo tasks are not available without a store on a write site' );
+
+		$sell = $this->call_api( Requests::GET, '/available-tasks', null, array( 'goal' => 'sell' ) )->get_data();
+		$this->assertContains( 'woo_products', $sell['available_task_ids'], 'sell keeps woo tasks as previews, so they are available' );
+	}
+
+	/**
+	 * The add_about_page task is hidden only by a REST-context quirk (its gate needs a page-template meta key that is
+	 * not registered during the request). It is force-visible, so it is offered as available.
+	 */
+	public function test_available_tasks_include_rescued_add_about_page() {
+		wp_set_current_user( $this->admin_id );
+
+		$data = $this->call_api( Requests::GET, '/available-tasks', null, array( 'goal' => 'write' ) )->get_data();
+
+		$this->assertContains( 'add_about_page', $data['available_task_ids'] );
+	}
+
+	/**
 	 * Test that GET keeps add_10_email_subscribers even though its catalog
 	 * visibility callback (wpcom_launchpad_are_newsletter_subscriber_counts_available)
 	 * is false off WordPress.com: the AI Launchpad retrieves the subscriber count

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -357,6 +357,47 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * The catalog visibility gate can hide several AI-picked tasks on a given site (e.g. add_about_page needs a
+	 * page-template meta key that is not registered during a REST request), which collapses the rendered list.
+	 * A short list is topped back up toward six from a pool of broadly-useful tasks, keeping the launch task last.
+	 */
+	public function test_get_backfills_a_short_list_to_six_with_launch_last() {
+		wp_set_current_user( $this->admin_id );
+		$this->seed_ai_output_with_tasks( array( 'first_post_published', 'site_launched' ), 'write' );
+
+		$tasks = $this->call_api( Requests::GET )->get_data()['tasks'];
+		$ids   = array_column( $tasks, 'id' );
+
+		$this->assertCount( 6, $tasks, 'a two-task list is backfilled to six' );
+		$this->assertSame( 'first_post_published', $ids[0], 'the AI tasks keep their lead position' );
+		$this->assertSame( 'site_launched', end( $ids ), 'the launch task stays last' );
+		$this->assertSame( array_values( array_unique( $ids ) ), $ids, 'no duplicate task cards' );
+	}
+
+	/**
+	 * A backfilled filler card must be skippable so it can never strand the launchpad, and GET must stay a read: it
+	 * must not rewrite the persisted AI output. The skip route accepts a backfilled id (via the pool allowlist), and
+	 * the persisted payload is untouched by the read.
+	 */
+	public function test_backfilled_task_is_skippable_and_get_does_not_mutate_ai_output() {
+		wp_set_current_user( $this->admin_id );
+		$this->seed_ai_output_with_tasks( array( 'first_post_published', 'site_launched' ), 'write' );
+		$before = get_option( 'wpcom_ai_launchpad_ai_output' );
+
+		$rendered = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], 'id' );
+		$this->assertCount( 6, $rendered, 'the short list is backfilled to six' );
+
+		// GET is a pure read: the persisted AI output is unchanged.
+		$this->assertSame( $before, get_option( 'wpcom_ai_launchpad_ai_output' ) );
+
+		// A backfilled filler card (one not in the seeded AI list) can be skipped.
+		$backfilled = array_values( array_diff( $rendered, array( 'first_post_published', 'site_launched' ) ) );
+		$this->assertNotEmpty( $backfilled );
+		$result = $this->call_api( 'POST', '/skip-task', array( 'task_id' => $backfilled[0] ) );
+		$this->assertSame( 200, $result->get_status(), $backfilled[0] . ' is skippable' );
+	}
+
+	/**
 	 * Test that GET keeps add_10_email_subscribers even though its catalog
 	 * visibility callback (wpcom_launchpad_are_newsletter_subscriber_counts_available)
 	 * is false off WordPress.com: the AI Launchpad retrieves the subscriber count
@@ -645,8 +686,9 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 		$ids = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], 'id' );
 
 		$this->assertContains( 'add_gallery_page', $ids );
-		// Injected immediately before the launch task.
-		$this->assertSame( array( 'site_title', 'add_gallery_page', 'site_launched' ), $ids );
+		// Injected immediately after the AI task and before the launch task; any backfill filler follows it.
+		$this->assertSame( array( 'site_title', 'add_gallery_page' ), array_slice( $ids, 0, 2 ), 'gallery follows the AI task' );
+		$this->assertSame( 'site_launched', end( $ids ), 'launch stays last' );
 
 		$gallery = null;
 		foreach ( $this->call_api( Requests::GET )->get_data()['tasks'] as $task ) {
@@ -1681,6 +1723,8 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_get_does_not_inject_theme_task_for_non_sell() {
 		wp_set_current_user( $this->admin_id );
+		// The theme task is sell-only (ensure_theme_task) and is not in the short-list backfill pool, so even a short
+		// non-sell list never gains one.
 		$this->seed_ai_output_with_tasks( array( 'first_post_published', 'site_launched' ), 'write' );
 
 		$ids = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], 'id' );
@@ -1833,9 +1877,11 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_get_sets_completed_flag_when_all_done() {
 		wp_set_current_user( $this->admin_id );
-		$this->seed_ai_output_with_tasks( array( 'first_post_published', 'site_launched' ) );
+		// A full six-task list so the short-list backfill does not add tasks that would keep it incomplete.
+		$ids = array( 'first_post_published', 'design_edited', 'site_title', 'setup_general', 'site_theme_selected', 'site_launched' );
+		$this->seed_ai_output_with_tasks( $ids );
 		// Skipping every task coerces each to completed, so the list reads as done.
-		update_option( 'wpcom_ai_launchpad_skipped_tasks', array( 'first_post_published', 'site_launched' ), false );
+		update_option( 'wpcom_ai_launchpad_skipped_tasks', $ids, false );
 
 		$this->call_api( Requests::GET );
 
@@ -1862,10 +1908,14 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_skip_final_task_sets_completed_flag() {
 		wp_set_current_user( $this->admin_id );
-		$this->seed_ai_output_with_tasks( array( 'first_post_published', 'site_launched' ) );
+		// A full six-task list so the short-list backfill does not add tasks beyond the ones skipped below.
+		$non_launch = array( 'first_post_published', 'design_edited', 'site_title', 'setup_general', 'site_theme_selected' );
+		$this->seed_ai_output_with_tasks( array_merge( $non_launch, array( 'site_launched' ) ) );
 
-		$this->call_api( 'POST', '/skip-task', array( 'task_id' => 'first_post_published' ) );
-		$this->assertFalse( get_option( 'wpcom_ai_launchpad_completed' ), 'still incomplete after one skip' );
+		foreach ( $non_launch as $id ) {
+			$this->call_api( 'POST', '/skip-task', array( 'task_id' => $id ) );
+		}
+		$this->assertFalse( get_option( 'wpcom_ai_launchpad_completed' ), 'still incomplete while the launch task remains' );
 
 		$this->call_api( 'POST', '/skip-task', array( 'task_id' => 'site_launched' ) );
 		$this->assertTrue( (bool) get_option( 'wpcom_ai_launchpad_completed' ), 'complete after skipping the last task' );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -22,8 +22,8 @@ require_once \Automattic\Jetpack\Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/ai-la
 require_once \Automattic\Jetpack\Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/ai-launchpad/class-ai-launchpad-rest.php';
 
 // Block real Logstash dispatch of the tailoring observation event for the entire phpunit
-// process (its HTTP fallback fires from a shutdown function, i.e. after teardown). A spy
-// test hooks the same filter at priority 11 to assert the event payload.
+// process (its HTTP fallback fires from a shutdown function, i.e. after teardown). The
+// event payload itself is asserted by invoking the builder directly.
 add_filter( 'wpcom_ai_launchpad_tailoring_log_enabled', '__return_false' );
 
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -481,20 +481,14 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * `PUT /tailored` emits an observation event: the AI-inferred details (minus brand_name, which echoes the
-	 * user-typed site title), the ids the AI selected, the ids the site will actually render, and the delta between
-	 * them. The event is captured through the gate filter's extra argument; real dispatch stays blocked by the
-	 * file-level `__return_false`.
+	 * The tailoring observation event reports the AI-inferred details (minus brand_name, which echoes the
+	 * user-typed site title), the ids the AI selected, the ids the site will actually render, and the delta
+	 * between them. The event is built (via reflection) against the state `PUT /tailored` just persisted —
+	 * the same envelope and timing the gated logger uses; real dispatch stays blocked by the file-level
+	 * `__return_false`, which short-circuits before the event is built.
 	 */
 	public function test_update_tailored_logs_observation_event() {
 		wp_set_current_user( $this->admin_id );
-
-		$captured = null;
-		$spy      = static function ( $enabled, $extra ) use ( &$captured ) {
-			$captured = $extra;
-			return $enabled;
-		};
-		add_filter( 'wpcom_ai_launchpad_tailoring_log_enabled', $spy, 11, 2 );
 
 		$payload             = self::valid_payload();
 		$payload['inferred'] = array(
@@ -520,9 +514,15 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 		);
 
 		$result = $this->call_api( 'PUT', '/tailored', $payload );
-		remove_filter( 'wpcom_ai_launchpad_tailoring_log_enabled', $spy, 11 );
-
 		$this->assertSame( 200, $result->get_status() );
+
+		// Build the event exactly as log_tailoring would: from the persisted envelope and the raw pre-filter ids.
+		$builder  = new \ReflectionMethod( AI_Launchpad_REST::class, 'tailoring_log_extra' );
+		$captured = $builder->invoke(
+			new AI_Launchpad_REST(),
+			get_option( 'wpcom_ai_launchpad_ai_output' ),
+			array_column( $payload['tasks'], 'id' )
+		);
 		$this->assertIsArray( $captured );
 
 		// Only the intended fields, and never the user's own words: brand_name (echoes the title) and tagline

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -21,6 +21,11 @@ require_once \Automattic\Jetpack\Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/ai-la
 //phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
 require_once \Automattic\Jetpack\Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/ai-launchpad/class-ai-launchpad-rest.php';
 
+// Block real Logstash dispatch of the tailoring observation event for the entire phpunit
+// process (its HTTP fallback fires from a shutdown function, i.e. after teardown). A spy
+// test hooks the same filter at priority 11 to assert the event payload.
+add_filter( 'wpcom_ai_launchpad_tailoring_log_enabled', '__return_false' );
+
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
@@ -473,6 +478,79 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 
 		$this->assertNotContains( 'drive_traffic', $ids, 'a completed pool task is not backfilled' );
 		$this->assertContains( 'add_new_page', $ids, 'incomplete pool tasks still backfill' );
+	}
+
+	/**
+	 * `PUT /tailored` emits an observation event: the AI-inferred details (minus brand_name, which echoes the
+	 * user-typed site title), the ids the AI selected, the ids the site will actually render, and the delta between
+	 * them. The event is captured through the gate filter's extra argument; real dispatch stays blocked by the
+	 * file-level `__return_false`.
+	 */
+	public function test_update_tailored_logs_observation_event() {
+		wp_set_current_user( $this->admin_id );
+
+		$captured = null;
+		$spy      = static function ( $enabled, $extra ) use ( &$captured ) {
+			$captured = $extra;
+			return $enabled;
+		};
+		add_filter( 'wpcom_ai_launchpad_tailoring_log_enabled', $spy, 11, 2 );
+
+		$payload             = self::valid_payload();
+		$payload['inferred'] = array(
+			'goal'       => 'write',
+			'brand_name' => 'Alpine Notes',
+			'tagline'    => 'Hiking stories from Jane Doe of 12 Elm Street.',
+			'niche'      => 'hiking',
+		);
+		// A gate-hidden pick (woo without WooCommerce), a remapped pick, and a hallucinated id the write path
+		// silently filters, to exercise the delta reporting. Swapped in mid-list: the schema requires exactly six
+		// tasks, launch task last.
+		$payload['tasks'][2] = array(
+			'id'       => 'imaginary_task',
+			'subtitle' => 'A task the catalog does not know.',
+		);
+		$payload['tasks'][3] = array(
+			'id'       => 'woo_products',
+			'subtitle' => 'Add your first products.',
+		);
+		$payload['tasks'][4] = array(
+			'id'       => 'post_sharing_enabled',
+			'subtitle' => 'Share posts automatically.',
+		);
+
+		$result = $this->call_api( 'PUT', '/tailored', $payload );
+		remove_filter( 'wpcom_ai_launchpad_tailoring_log_enabled', $spy, 11 );
+
+		$this->assertSame( 200, $result->get_status() );
+		$this->assertIsArray( $captured );
+
+		// Only the intended fields, and never the user's own words: brand_name (echoes the title) and tagline
+		// (drafted from the description) are stripped from inferred.
+		$this->assertSame( array( 'source', 'inferred', 'selected', 'rendered', 'dropped', 'added' ), array_keys( $captured ) );
+		$this->assertSame( 'ai', $captured['source'] );
+		$this->assertArrayNotHasKey( 'brand_name', $captured['inferred'] );
+		$this->assertArrayNotHasKey( 'tagline', $captured['inferred'] );
+		$this->assertSame( 'write', $captured['inferred']['goal'] );
+		$this->assertSame( 'hiking', $captured['inferred']['niche'] );
+
+		// Selected reports the AI's raw picks — including the hallucinated id the write path filtered out.
+		$this->assertContains( 'woo_products', $captured['selected'] );
+		$this->assertContains( 'post_sharing_enabled', $captured['selected'] );
+		$this->assertContains( 'imaginary_task', $captured['selected'] );
+		$this->assertContains( 'first_post_published', $captured['rendered'] );
+		$this->assertNotContains( 'woo_products', $captured['rendered'] );
+
+		// The gate-hidden and hallucinated picks are drops; the remapped pick is not (it renders as its working
+		// equivalent).
+		$this->assertContains( 'woo_products', $captured['dropped'] );
+		$this->assertContains( 'imaginary_task', $captured['dropped'] );
+		$this->assertNotContains( 'post_sharing_enabled', $captured['dropped'] );
+		$this->assertContains( 'connect_social_media', $captured['rendered'] );
+
+		// Additions (synthetics/backfill) are reported so list inflation is observable: dropping two of six picks
+		// leaves a short list, and the backfill tops it up from the pool.
+		$this->assertContains( 'add_new_page', $captured['added'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes DOTOBRD-509

## Proposed changes

**Why:** freshly tailored task lists kept coming out wrong — sometimes two cards instead of six, sometimes padded with generic filler, sometimes carrying cards that were born pre-checked. The root cause is that the tailoring AI picked from the full 48-task menu *blind*: it had no idea which tasks the catalog visibility gate would drop on this particular site (~1/3 of the menu on a typical site), which were already complete, or which could never be completed at all. Every bad list was the model faithfully choosing from a menu full of options the server would then silently throw away. On top of that, we had zero visibility into how often this happened — every tuning decision so far has been guesswork from manual reset-and-rerun testing.

This PR makes the offered menu match reality, and makes the gap measurable:

* **Offer the AI only tasks that will actually render** — a new `available-tasks` read endpoint runs the whole catalog through the same gate the rendered list uses (visibility, force-visible overrides, the sell goal's woo-preview mode), and the client filters the prompt's menu to the result. The endpoint is separate from the wizard write because the AI call is prewarmed while the user is still typing, so availability has to reach the prompt before Finish.
* **…and that are not already complete** — a pre-checked card offers nothing to do. Launch tasks stay exempt (the output contract requires the list to end on one, even on an already-launched site), and on heavily-completed sites the client relaxes back to the full renderable set — otherwise the exactly-six output contract would become impossible to satisfy and every AI attempt would fail into the generic fallback.
* **Rescue `add_about_page`** — its visibility gate is a false negative during REST requests (it checks for a page-meta key that is only registered in the editor), which was hiding a genuinely useful task the AI recommends often.
* **Back-fill short lists toward six as a floor** — now a rare last resort rather than the main defense; the filler pool also skips completed tasks.
* **Drop "Personalize newsletter" (`setup_newsletter`) from the menu** — the only task whose completion is hardcoded `true`, so it always rendered born-completed. The menu already carries the real alternative (`customize_welcome_message`, which points at Newsletter settings and completes on an actual welcome-message save).
* **Log a tailoring observation event** — each persisted tailoring emits a Logstash event with the inferred context and the selected/rendered id delta, so gate-drop rate, hallucinated picks, backfill frequency, and per-goal selection quality become measurable before any further prompt or menu tuning.

## Related product discussion/links

* DOTOBRD-509

## Does this pull request change what data or activity we track or use?

Yes — the new Logstash observation event (`feature: atomic_ai_launchpad`, `message: tailored`) records, per tailoring run: the output source (ai/fallback), the AI-inferred site context, the task ids the AI selected, and the ids actually rendered. The user's own words deliberately stay out: the wizard title and description are never logged, and the inferred fields that echo them near-verbatim (`brand_name`, `tagline`) are stripped before dispatch. A default-true filter (`wpcom_ai_launchpad_tailoring_log_enabled`) acts as the kill-switch. The feature slug uses the `atomic_` prefix because the public-api logstash endpoint rejects non-whitelisted features — a bare slug would be silently dropped on Atomic.

## Testing instructions

On a site with the AI Launchpad enabled (`wpcom_ai_launchpad_enabled`, feature is dark in production):

* Reset the launchpad state (`wp-admin/?reset-ai-launchpad=1`) and run the wizard with the **Newsletter** goal.
* The tailored list should hold six actionable cards: no "Personalize newsletter", no pre-checked cards you never acted on.
* `GET /wpcom/v2/ai-launchpad/available-tasks?goal=write` should return `available_task_ids` (excluding tasks the site already completed, but always including a launch task) plus a `renderable_task_ids` superset.
* Complete a task (e.g. set the site title), reset, re-run the wizard: the completed task should not appear in the new list.
* In Kibana, filter `feature: atomic_ai_launchpad AND message: tailored`: each wizard run should produce one event whose `extra` shows `selected` vs `rendered` with `dropped`/`added` deltas, and whose `inferred` contains no `brand_name`/`tagline`.
* PHP: `composer phpunit` in `projects/packages/jetpack-mu-wpcom` (643 tests). JS: `node --test --experimental-strip-types src/features/ai-launchpad/js/lib/prompts.test.mts src/features/ai-launchpad/js/lib/fallback.test.mts`.
