### PR TITLE
pnpm: Exclude 'gridicons' in minimum relase age limit

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,6 +34,7 @@ minimumReleaseAgeExclude:
   - '@automattic/*'
   - '@woocommerce/*'
   - '@wordpress/*'
+  - 'gridicons'
 trustPolicy: no-downgrade
 trustPolicyExclude:
   # https://github.com/paulmillr/chokidar/issues/1440


### PR DESCRIPTION
Gridicons is our own package so we can update it right away without limits:

- https://github.com/Automattic/gridicons
- https://www.npmjs.com/package/gridicons

Follow-up to https://github.com/Automattic/jetpack/pull/50407#issuecomment-4936082194