### PR TITLE
Tests: fix parallel-run race in lazy block Gutenberg test fixtures

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-lazy-block-test-fixture-parallel-race
+++ b/projects/plugins/jetpack/changelog/fix-lazy-block-test-fixture-parallel-race
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Tests: use per-process lazy block fixture names to avoid a race between parallel PHPUnit runs in the coverage job.

--- a/projects/plugins/jetpack/changelog/fix-lazy-block-test-fixture-parallel-race
+++ b/projects/plugins/jetpack/changelog/fix-lazy-block-test-fixture-parallel-race
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
+Comment: Test-only change: use per-process lazy block fixture names to avoid a race between parallel PHPUnit runs in the coverage job.
 
-Tests: use per-process lazy block fixture names to avoid a race between parallel PHPUnit runs in the coverage job.

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Gutenberg_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Gutenberg_Test.php
@@ -556,12 +556,18 @@ class Jetpack_Gutenberg_Test extends WP_UnitTestCase {
 	/**
 	 * Create a throwaway lazy block fixture under extensions/blocks.
 	 *
-	 * @param string $feature       Block feature name.
+	 * The feature name is suffixed with the current PID: the coverage job runs
+	 * multiple PHPUnit processes (php-normal, php-multisite) concurrently in the
+	 * same checkout, so a fixed path would let one process delete the fixture out
+	 * from under the other.
+	 *
+	 * @param string $feature       Block feature name; the PID suffix is appended.
 	 * @param string $render_output Optional render output.
 	 *
-	 * @return array Fixture paths.
+	 * @return array Fixture data: the final `feature` name and the `dir`/`file` paths.
 	 */
 	private function create_lazy_fixture_block( $feature, $render_output = '' ) {
+		$feature .= '-' . getmypid();
 		$dir      = JETPACK__PLUGIN_DIR . 'extensions/blocks/' . $feature;
 		$file     = $dir . '/' . $feature . '.php';
 		$function = 'jetpack_test_render_' . str_replace( '-', '_', $feature );
@@ -580,8 +586,9 @@ class Jetpack_Gutenberg_Test extends WP_UnitTestCase {
 		);
 
 		return array(
-			'dir'  => $dir,
-			'file' => $file,
+			'feature' => $feature,
+			'dir'     => $dir,
+			'file'    => $file,
 		);
 	}
 
@@ -762,8 +769,8 @@ class Jetpack_Gutenberg_Test extends WP_UnitTestCase {
 	 * not re-run the include/registration logic.
 	 */
 	public function test_lazy_register_attempts_a_deferred_block_only_once() {
-		$feature = 'zz-lazy-once-fixture';
-		$fixture = $this->create_lazy_fixture_block( $feature );
+		$fixture = $this->create_lazy_fixture_block( 'zz-lazy-once-fixture' );
+		$feature = $fixture['feature'];
 
 		try {
 			$this->set_deferred_blocks( array( $feature => true ) );
@@ -781,8 +788,8 @@ class Jetpack_Gutenberg_Test extends WP_UnitTestCase {
 	 * top-level subtree walk, before the inner WP_Block would be constructed.
 	 */
 	public function test_lazy_register_walks_inner_blocks() {
-		$feature = 'zz-lazy-inner-fixture';
-		$fixture = $this->create_lazy_fixture_block( $feature );
+		$fixture = $this->create_lazy_fixture_block( 'zz-lazy-inner-fixture' );
+		$feature = $fixture['feature'];
 
 		try {
 			$this->set_deferred_blocks( array( $feature => true ) );
@@ -814,8 +821,8 @@ class Jetpack_Gutenberg_Test extends WP_UnitTestCase {
 	 * reusable-block reference, since core only parses that content at render time.
 	 */
 	public function test_lazy_register_resolves_synced_pattern_reference() {
-		$feature = 'zz-lazy-pattern-fixture';
-		$fixture = $this->create_lazy_fixture_block( $feature );
+		$fixture = $this->create_lazy_fixture_block( 'zz-lazy-pattern-fixture' );
+		$feature = $fixture['feature'];
 		$ref_id  = self::factory()->post->create(
 			array(
 				'post_type'    => 'wp_block',
@@ -860,27 +867,28 @@ class Jetpack_Gutenberg_Test extends WP_UnitTestCase {
 	 * include + $wp_filter['init'] capture/run path is exercised end-to-end.
 	 */
 	public function test_load_and_register_runs_deferred_block_init_callback() {
-		$feature = 'zz-lazy-fixture';
+		// PID suffix: parallel PHPUnit processes share this checkout, see create_lazy_fixture_block().
+		$feature = 'zz-lazy-fixture-' . getmypid();
 		$dir     = JETPACK__PLUGIN_DIR . 'extensions/blocks/' . $feature;
 		$file    = $dir . '/' . $feature . '.php';
 		wp_mkdir_p( $dir );
 		file_put_contents(
 			$file,
-			"<?php add_action( 'init', function () { register_block_type( 'jetpack/zz-lazy-fixture' ); } );\n"
+			"<?php add_action( 'init', function () { register_block_type( 'jetpack/{$feature}' ); } );\n"
 		);
 
 		try {
-			$this->assertFalse( Blocks::is_registered( 'jetpack/zz-lazy-fixture' ), 'Fixture block should start unregistered.' );
+			$this->assertFalse( Blocks::is_registered( 'jetpack/' . $feature ), 'Fixture block should start unregistered.' );
 
 			$this->invoke_load_and_register_deferred_block( $feature );
 
 			$this->assertTrue(
-				Blocks::is_registered( 'jetpack/zz-lazy-fixture' ),
+				Blocks::is_registered( 'jetpack/' . $feature ),
 				'The deferred block file should be included and its init callback run.'
 			);
 		} finally {
-			if ( Blocks::is_registered( 'jetpack/zz-lazy-fixture' ) ) {
-				unregister_block_type( 'jetpack/zz-lazy-fixture' );
+			if ( Blocks::is_registered( 'jetpack/' . $feature ) ) {
+				unregister_block_type( 'jetpack/' . $feature );
 			}
 			if ( file_exists( $file ) ) {
 				unlink( $file );
@@ -895,9 +903,9 @@ class Jetpack_Gutenberg_Test extends WP_UnitTestCase {
 	 * The do_blocks() function drives the real pre_render_block -> include -> init-replay path.
 	 */
 	public function test_do_blocks_lazy_registers_deferred_block_on_frontend() {
-		$feature       = 'zz-lazy-do-blocks-fixture';
 		$render_output = 'lazy fixture output';
-		$fixture       = $this->create_lazy_fixture_block( $feature, $render_output );
+		$fixture       = $this->create_lazy_fixture_block( 'zz-lazy-do-blocks-fixture', $render_output );
+		$feature       = $fixture['feature'];
 		$original_lazy = $this->get_lazy_blocks();
 		$saved_uri     = $_SERVER['REQUEST_URI'] ?? null;
 

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_Gutenberg_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_Gutenberg_Test.php
@@ -595,10 +595,10 @@ class Jetpack_Gutenberg_Test extends WP_UnitTestCase {
 	/**
 	 * Remove a throwaway lazy block fixture.
 	 *
-	 * @param string $feature Block feature name.
-	 * @param array  $fixture Fixture paths from create_lazy_fixture_block().
+	 * @param array $fixture Fixture data from create_lazy_fixture_block().
 	 */
-	private function remove_lazy_fixture_block( $feature, $fixture ) {
+	private function remove_lazy_fixture_block( $fixture ) {
+		$feature = $fixture['feature'];
 		if ( Blocks::is_registered( 'jetpack/' . $feature ) ) {
 			unregister_block_type( 'jetpack/' . $feature );
 		}
@@ -779,7 +779,7 @@ class Jetpack_Gutenberg_Test extends WP_UnitTestCase {
 			$this->assertArrayNotHasKey( $feature, $this->get_deferred_blocks(), 'Deferred block should be removed after a single attempt.' );
 			$this->assertTrue( Blocks::is_registered( 'jetpack/' . $feature ), 'Deferred block should be registered by the lazy loader.' );
 		} finally {
-			$this->remove_lazy_fixture_block( $feature, $fixture );
+			$this->remove_lazy_fixture_block( $fixture );
 		}
 	}
 
@@ -812,7 +812,7 @@ class Jetpack_Gutenberg_Test extends WP_UnitTestCase {
 			$this->assertArrayNotHasKey( $feature, $this->get_deferred_blocks(), 'Nested deferred block should be reached by the subtree walk.' );
 			$this->assertTrue( Blocks::is_registered( 'jetpack/' . $feature ), 'Nested deferred block should be registered by the lazy loader.' );
 		} finally {
-			$this->remove_lazy_fixture_block( $feature, $fixture );
+			$this->remove_lazy_fixture_block( $fixture );
 		}
 	}
 
@@ -844,7 +844,7 @@ class Jetpack_Gutenberg_Test extends WP_UnitTestCase {
 			$this->assertTrue( Blocks::is_registered( 'jetpack/' . $feature ), 'Deferred block inside a synced pattern should be registered by the lazy loader.' );
 		} finally {
 			wp_delete_post( $ref_id, true );
-			$this->remove_lazy_fixture_block( $feature, $fixture );
+			$this->remove_lazy_fixture_block( $fixture );
 		}
 	}
 
@@ -867,15 +867,8 @@ class Jetpack_Gutenberg_Test extends WP_UnitTestCase {
 	 * include + $wp_filter['init'] capture/run path is exercised end-to-end.
 	 */
 	public function test_load_and_register_runs_deferred_block_init_callback() {
-		// PID suffix: parallel PHPUnit processes share this checkout, see create_lazy_fixture_block().
-		$feature = 'zz-lazy-fixture-' . getmypid();
-		$dir     = JETPACK__PLUGIN_DIR . 'extensions/blocks/' . $feature;
-		$file    = $dir . '/' . $feature . '.php';
-		wp_mkdir_p( $dir );
-		file_put_contents(
-			$file,
-			"<?php add_action( 'init', function () { register_block_type( 'jetpack/{$feature}' ); } );\n"
-		);
+		$fixture = $this->create_lazy_fixture_block( 'zz-lazy-fixture' );
+		$feature = $fixture['feature'];
 
 		try {
 			$this->assertFalse( Blocks::is_registered( 'jetpack/' . $feature ), 'Fixture block should start unregistered.' );
@@ -887,15 +880,7 @@ class Jetpack_Gutenberg_Test extends WP_UnitTestCase {
 				'The deferred block file should be included and its init callback run.'
 			);
 		} finally {
-			if ( Blocks::is_registered( 'jetpack/' . $feature ) ) {
-				unregister_block_type( 'jetpack/' . $feature );
-			}
-			if ( file_exists( $file ) ) {
-				unlink( $file );
-			}
-			if ( is_dir( $dir ) ) {
-				rmdir( $dir );
-			}
+			$this->remove_lazy_fixture_block( $fixture );
 		}
 	}
 
@@ -940,7 +925,7 @@ class Jetpack_Gutenberg_Test extends WP_UnitTestCase {
 			} else {
 				unset( $_SERVER['REQUEST_URI'] );
 			}
-			$this->remove_lazy_fixture_block( $feature, $fixture );
+			$this->remove_lazy_fixture_block( $fixture );
 		}
 	}
 


### PR DESCRIPTION

## Proposed changes

The lazy-block tests from #49840 write fixtures to fixed paths under `extensions/blocks/`. The coverage job runs `php-normal` and `php-multisite` concurrently in the same checkout, and both run the `php/general` suite — so one process deletes the fixture while the other is mid-test. The victim hits the `file_exists()` guard in `load_and_register_deferred_block()`, nothing gets registered, and the test fails. That's the trunk failure in https://github.com/Automattic/jetpack/actions/runs/29093211026, and all five fixture-based tests can lose this lottery.

Tests that share mutable state with a concurrent copy of themselves are broken. Fix: stop sharing. `create_lazy_fixture_block()` now appends `getmypid()` to the feature name (and returns it), so each process gets its own fixture directory. The one inline fixture gets the same suffix. No production code touched, no locks — the tests were never in conflict, they were fighting over a filename.

## Related product discussion/links

* p1783687725085859-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Test-only change: green CI, including "Code coverage (PHP)", is the test.
* To reproduce the race: run two copies of the suite concurrently in one checkout (one with `WP_MULTISITE=1`) until one run's cleanup lands inside the other's test. With this change they use distinct `zz-lazy-*-<pid>` directories.
