### PR TITLE
Stats: add a single media item route to the stats-app proxy

### DIFF
--- a/projects/packages/stats-admin/changelog/add-stats-admin-media-item-route
+++ b/projects/packages/stats-admin/changelog/add-stats-admin-media-item-route
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: expose a single media item route on the stats-app proxy, so the Odyssey video details page can show the video's title, date, thumbnail, and duration.

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -111,6 +111,17 @@ class REST_Controller {
 			)
 		);
 
+		// Single media item info (e.g. the video shown on the video details page).
+		register_rest_route(
+			static::$namespace,
+			sprintf( '/sites/%d/media/(?P<resource_id>[\d]+)', Jetpack_Options::get_option( 'id' ) ),
+			array(
+				'methods'             => WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_single_media_item' ),
+				'permission_callback' => array( $this, 'can_user_view_general_stats_callback' ),
+			)
+		);
+
 		// General stats for the site.
 		register_rest_route(
 			static::$namespace,
@@ -655,6 +666,57 @@ class REST_Controller {
 			'discussion'     => array( 'comment_count' => intval( $post->comment_count ) ),
 			'date'           => $post->post_date,
 			'post_thumbnail' => array( 'URL' => get_the_post_thumbnail_url( $post->ID ) ),
+		);
+	}
+
+	/**
+	 * Get brief information for a single media item.
+	 *
+	 * @param WP_REST_Request $req The request object.
+	 * @return array|WP_Error
+	 */
+	public function get_single_media_item( $req ) {
+		$media_id = intval( $req->get_param( 'resource_id' ) );
+		$post     = get_post( $media_id, OBJECT, 'display' );
+		if ( empty( $post ) || 'attachment' !== $post->post_type ) {
+			return new WP_Error(
+				'unknown_media',
+				'Unknown media',
+				array( 'status' => 404 )
+			);
+		}
+
+		// The response should be as compatible as possible with `/sites/$site_id/media/$media_id`.
+		// Like `get_single_post`, the request is not forwarded to WordPress.com because that
+		// might require user tokens, which is not possible for users without a WordPress.com account.
+		$metadata   = wp_get_attachment_metadata( $media_id );
+		$length     = null;
+		$thumbnails = array();
+
+		if ( ! empty( $metadata['length'] ) ) {
+			$length = intval( $metadata['length'] );
+		} elseif ( ! empty( $metadata['videopress']['duration'] ) ) {
+			// VideoPress stores the duration in milliseconds.
+			$length = intval( round( $metadata['videopress']['duration'] / 1000 ) );
+		}
+
+		if ( ! empty( $metadata['videopress']['poster'] ) ) {
+			// VideoPress format thumbnails (fmt_*) are only generated on WordPress.com;
+			// map the poster to the largest format so consumers find a thumbnail where expected.
+			$thumbnails['fmt_hd'] = $metadata['videopress']['poster'];
+		} elseif ( get_the_post_thumbnail_url( $post->ID ) ) {
+			$thumbnails['fmt_std'] = get_the_post_thumbnail_url( $post->ID );
+		}
+
+		return array(
+			'ID'         => $post->ID,
+			'site_ID'    => Jetpack_Options::get_option( 'id' ),
+			'title'      => $post->post_title,
+			'date'       => $post->post_date,
+			'URL'        => wp_get_attachment_url( $post->ID ),
+			'mime_type'  => $post->post_mime_type,
+			'length'     => $length,
+			'thumbnails' => (object) $thumbnails,
 		);
 	}
 

--- a/projects/packages/stats-admin/tests/php/REST_Controller_Test.php
+++ b/projects/packages/stats-admin/tests/php/REST_Controller_Test.php
@@ -164,6 +164,41 @@ class REST_Controller_Test extends Stats_TestCase {
 	}
 
 	/**
+	 * Test '/jetpack/v4/stats-app/sites/999/media/{media_id}'
+	 */
+	public function test_get_single_media_item() {
+		wp_set_current_user( $this->admin_id );
+
+		$attachment_id = wp_insert_attachment(
+			array(
+				'post_title'     => 'Test video',
+				'post_mime_type' => 'video/mp4',
+				'post_status'    => 'inherit',
+			)
+		);
+		wp_update_attachment_metadata( $attachment_id, array( 'length' => 95 ) );
+
+		$request = new WP_REST_Request(
+			'GET',
+			sprintf( '/jetpack/v4/stats-app/sites/999/media/%d', $attachment_id )
+		);
+		$request->set_header( 'content-type', 'application/json' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( 'Test video', $data['title'] );
+		$this->assertEquals( 95, $data['length'] );
+
+		// Unknown media items return 404.
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/stats-app/sites/999/media/987654' );
+		$request->set_header( 'content-type', 'application/json' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
 	 * Test '/jetpack/v4/stats-app/sites/999/site-has-never-published-post'
 	 */
 	public function test_site_has_never_published_post() {


### PR DESCRIPTION
Related to Automattic/wp-calypso#112499 (STATS-299 — modernized video details page in Odyssey Stats).

## Proposed changes

* Register `GET /jetpack/v4/stats-app/sites/{blog_id}/media/{media_id}` on the stats-admin REST controller, gated by the same `can_user_view_general_stats_callback` permission as the single-post route.
* Serve the response from the local attachment (like `get_single_post` does, rather than forwarding to WordPress.com, so it works for users without a WordPress.com account). The response mirrors the fields of `/sites/{site}/media/{id}` that the Calypso video details page consumes: `ID`, `title`, `date`, `URL`, `mime_type`, `length` (seconds, from core video metadata or the VideoPress `duration`), and `thumbnails` (VideoPress `poster` mapped to `fmt_hd`, falling back to the featured image as `fmt_std`).
* Add a REST controller test covering the 200 response shape and the 404 for unknown media IDs.

## Related product discussion/links

* STATS-299 / STATS-312 (Linear)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Set up a Jetpack site with a VideoPress video that has some plays.
* Build the stats-admin package into the Jetpack plugin and open Odyssey Stats (Jetpack → Stats) in wp-admin.
* Navigate to Videos → click a video to open the video details page.
* Without this change, `wp-json/jetpack/v4/stats-app/sites/{id}/media/{id}` returns 404, the header card is hidden, and Retention rate shows “-”.
* With this change, the header card shows the video title, upload date, and thumbnail, and the Retention rate card shows a percentage (it needs the video duration from this endpoint).
* Also verify `GET /wp-json/jetpack/v4/stats-app/sites/{id}/media/{id}` directly: a video attachment ID returns the fields above; a nonexistent ID returns 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)