### PR TITLE
WOOA7S-1695: Premium Analytics: centralize the widget-picker preview image-size fix in shared label components

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-clicks-widget-preview-icon-picker-grid-size
+++ b/projects/packages/premium-analytics/changelog/fix-clicks-widget-preview-icon-picker-grid-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Clicks widget: fix favicons rendering oversized in the Add widget picker grid preview by rendering row labels through the shared LeaderboardLabel component.

--- a/projects/packages/premium-analytics/changelog/refactor-referrers-leaderboard-label
+++ b/projects/packages/premium-analytics/changelog/refactor-referrers-leaderboard-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Leaderboard widgets: centralize the widget-picker preview image-size fix in the shared LeaderboardLabel and render Referrers row labels through it.

--- a/projects/packages/premium-analytics/changelog/refactor-subscribers-list-picker-image-fix
+++ b/projects/packages/premium-analytics/changelog/refactor-subscribers-list-picker-image-fix
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Subscribers list: move the widget-picker preview avatar-size fix from the widget stylesheet into the shared SubscriberList component.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-label.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-label.module.scss
@@ -1,16 +1,29 @@
+/* min/max inline-size let the label shrink inside widget flex wrappers
+   (e.g. a link with a trailing external-arrow icon) so the text can
+   truncate instead of pushing the wrapper wider. */
 .container {
 	padding: var(--wpds-dimension-padding-sm);
+	min-inline-size: 0;
+	max-inline-size: 100%;
 }
 
+/* Leaderboard rows are a fixed 36px, so labels truncate rather than wrap. */
 .label {
+	min-inline-size: 0;
+	overflow: hidden;
 	font-size: var(--wpds-typography-font-size-sm);
+	white-space: nowrap;
+	text-overflow: ellipsis;
 }
 
+/* Widgets customize the image through the custom properties (including
+   radius) rather than styling the <img> directly, so their rules never
+   compete with this one at equal specificity. */
 .labelImage {
 	width: var(--jpa-leaderboard-image-width, 28px);
 	height: var(--jpa-leaderboard-image-height, 28px);
 	vertical-align: middle;
-	border-radius: var(--wpds-border-radius-md);
+	border-radius: var(--jpa-leaderboard-image-radius, var(--wpds-border-radius-md));
 	object-fit: var(--jpa-leaderboard-image-fit, cover);
 }
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-label.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-label.module.scss
@@ -7,9 +7,18 @@
 }
 
 .labelImage {
-	width: 28px;
-	height: 28px;
+	width: var(--jpa-leaderboard-image-width, 28px);
+	height: var(--jpa-leaderboard-image-height, 28px);
 	vertical-align: middle;
 	border-radius: var(--wpds-border-radius-md);
-	object-fit: cover;
+	object-fit: var(--jpa-leaderboard-image-fit, cover);
+}
+
+/* The DataViews picker grid stretches media-cell images to 100%. Widget
+ * previews render inert, so restore the label image size there; custom
+ * properties preserve each widget's override. */
+:global([inert]) .container .labelImage {
+	width: var(--jpa-leaderboard-image-width, 28px);
+	height: var(--jpa-leaderboard-image-height, 28px);
+	object-fit: var(--jpa-leaderboard-image-fit, cover);
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-label.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-label.tsx
@@ -25,6 +25,10 @@ export type LeaderboardLabelProps = {
 	 * Class name for the image
 	 */
 	imageClassName?: string;
+	/**
+	 * How to render a missing image
+	 */
+	imageFallback?: 'placeholder' | 'hidden';
 };
 
 // Simple default image for when the image is not available.
@@ -47,26 +51,31 @@ const DEFAULT_IMAGE_URL =
  * @param props.imageUrl       - Optional image URL
  * @param props.imageAlt       - Alt text for the image
  * @param props.imageClassName - Class name for the image
+ * @param props.imageFallback  - How to render a missing image
  */
 export function LeaderboardLabel( {
 	label,
 	imageUrl,
 	imageAlt,
 	imageClassName,
+	imageFallback = 'placeholder',
 }: LeaderboardLabelProps ) {
 	// Use default if undefined OR empty string to prevent broken image flash
 	const finalImageUrl = imageUrl || DEFAULT_IMAGE_URL;
+	const shouldRenderImage = imageFallback === 'placeholder' || Boolean( imageUrl );
 
 	return (
 		<Stack direction="row" gap="sm" align="center" className={ styles.container }>
-			<img
-				src={ finalImageUrl }
-				onError={ ( e: React.SyntheticEvent< HTMLImageElement > ) => {
-					e.currentTarget.src = DEFAULT_IMAGE_URL;
-				} }
-				alt={ imageAlt || label }
-				className={ clsx( styles.labelImage, imageClassName ) }
-			/>
+			{ shouldRenderImage && (
+				<img
+					src={ finalImageUrl }
+					onError={ ( e: React.SyntheticEvent< HTMLImageElement > ) => {
+						e.currentTarget.src = DEFAULT_IMAGE_URL;
+					} }
+					alt={ imageAlt ?? label }
+					className={ clsx( styles.labelImage, imageClassName ) }
+				/>
+			) }
 			<span className={ styles.label }>{ label }</span>
 		</Stack>
 	);

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/subscriber-list/subscriber-list.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/subscriber-list/subscriber-list.module.scss
@@ -16,6 +16,14 @@
 	object-fit: cover;
 }
 
+/* The DataViews picker grids stretch media-cell images to 100%. Widget
+ * previews render inert, so restore the avatar size there. */
+:global([inert]) .row .avatar {
+	width: 32px;
+	height: 32px;
+	object-fit: cover;
+}
+
 .name {
 	overflow: hidden;
 	color: var(--wpds-color-foreground-content-neutral);

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/visitors-by-location/visitors-by-location-widget.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/visitors-by-location/visitors-by-location-widget.module.scss
@@ -46,12 +46,13 @@
 
 	// Width is the constraint that sizes flags: the boot layout shell forces
 	// img { height: auto } at higher specificity, so a height here never
-	// applies in the dashboard. `fill` (not `initial`, a CSS-wide keyword
-	// that would unset the custom property) keeps the flag uncropped.
+	// applies in the dashboard. `contain` (not `initial`, a CSS-wide keyword
+	// that would unset the custom property) keeps the flag uncropped and
+	// preserves its aspect ratio even if a height ever does apply.
 	.leaderboardImage {
 		--jpa-leaderboard-image-width: 28px;
 		--jpa-leaderboard-image-height: auto;
-		--jpa-leaderboard-image-fit: fill;
+		--jpa-leaderboard-image-fit: contain;
 		border-radius: var(--wpds-border-radius-sm, 2px);
 	}
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/visitors-by-location/visitors-by-location-widget.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/visitors-by-location/visitors-by-location-widget.module.scss
@@ -53,7 +53,7 @@
 		--jpa-leaderboard-image-width: 28px;
 		--jpa-leaderboard-image-height: auto;
 		--jpa-leaderboard-image-fit: contain;
-		border-radius: var(--wpds-border-radius-sm, 2px);
+		--jpa-leaderboard-image-radius: var(--wpds-border-radius-sm, 2px);
 	}
 }
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/visitors-by-location/visitors-by-location-widget.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/visitors-by-location/visitors-by-location-widget.module.scss
@@ -44,8 +44,14 @@
 	min-height: 0;
 	overflow: hidden;
 
+	// Width is the constraint that sizes flags: the boot layout shell forces
+	// img { height: auto } at higher specificity, so a height here never
+	// applies in the dashboard. `fill` (not `initial`, a CSS-wide keyword
+	// that would unset the custom property) keeps the flag uncropped.
 	.leaderboardImage {
-		height: 20px;
+		--jpa-leaderboard-image-width: 28px;
+		--jpa-leaderboard-image-height: auto;
+		--jpa-leaderboard-image-fit: fill;
 		border-radius: var(--wpds-border-radius-sm, 2px);
 	}
 }
@@ -84,13 +90,4 @@
 	.geoChart {
 		display: none;
 	}
-}
-
-// The picker grid applies img { width: 100%; height: 100%; object-fit: cover }
-// to all images inside the media cell, overriding our 20px flag height.
-// Restore correct sizing for flag images in any inert context.
-:global([inert]) .leaderboardChart .leaderboardImage {
-	width: auto;
-	height: 20px;
-	object-fit: initial;
 }

--- a/projects/packages/premium-analytics/widgets/authors/style.module.css
+++ b/projects/packages/premium-analytics/widgets/authors/style.module.css
@@ -16,13 +16,12 @@
 	min-height: 0;
 }
 
-/* Round the author avatar; a fixed size keeps the leaderboard row height
-   stable. */
+/* Round the author avatar; the shared image-size properties keep the
+   leaderboard row height stable. */
 .avatar {
-	width: 20px;
-	height: 20px;
+	--jpa-leaderboard-image-width: 20px;
+	--jpa-leaderboard-image-height: 20px;
 	border-radius: 50%;
-	object-fit: cover;
 }
 
 /* Drilled-in post rows have no avatar, so the post label sizes the row.
@@ -40,13 +39,4 @@
 a.postLabel:hover,
 a.postLabel:focus {
 	text-decoration: underline;
-}
-
-/* The picker grid applies img { width: 100%; height: 100%; object-fit: cover }
- * to all images inside the media cell, overriding our 20px avatar size.
- * Restore correct sizing for avatar images in any inert context. */
-:global([inert]) .root img {
-	width: 20px;
-	height: 20px;
-	object-fit: cover;
 }

--- a/projects/packages/premium-analytics/widgets/authors/style.module.css
+++ b/projects/packages/premium-analytics/widgets/authors/style.module.css
@@ -21,7 +21,7 @@
 .avatar {
 	--jpa-leaderboard-image-width: 20px;
 	--jpa-leaderboard-image-height: 20px;
-	border-radius: 50%;
+	--jpa-leaderboard-image-radius: 50%;
 }
 
 /* Drilled-in post rows have no avatar, so the post label sizes the row.

--- a/projects/packages/premium-analytics/widgets/clicks/render.tsx
+++ b/projects/packages/premium-analytics/widgets/clicks/render.tsx
@@ -9,6 +9,7 @@ import {
 } from '@jetpack-premium-analytics/data';
 import {
 	LeaderboardChart,
+	LeaderboardLabel,
 	WidgetBackLink,
 	WidgetLoadingOverlay,
 	WidgetRoot,
@@ -176,28 +177,6 @@ export function toClickRows(
 	return sliced.map( toClickRow );
 }
 
-type ClickLabelProps = {
-	/**
-	 * The normalized click row whose favicon and label to render.
-	 */
-	row: ClickRow;
-};
-
-/**
- * Renders a click row's favicon and label.
- *
- * @param {ClickLabelProps} props - The component props.
- * @return The rendered label content.
- */
-function ClickLabel( { row }: ClickLabelProps ) {
-	return (
-		<span className={ styles.labelContent }>
-			{ row.icon && <img src={ row.icon } alt="" className={ styles.labelIcon } /> }
-			<span className={ styles.labelTitle }>{ row.label }</span>
-		</span>
-	);
-}
-
 /**
  * Maps normalized click rows onto the shape `LeaderboardChart` expects.
  *
@@ -218,6 +197,15 @@ function buildLeaderboardData(
 		const previousValue = row.previousValue ?? 0;
 		const hasChildren = !! row.children?.length;
 		const shouldRenderLink = !! row.href && ! hasChildren;
+		const label = (
+			<LeaderboardLabel
+				label={ row.label }
+				imageUrl={ row.icon ?? undefined }
+				imageAlt=""
+				imageFallback="hidden"
+				imageClassName={ styles.labelIcon }
+			/>
+		);
 
 		return {
 			id: `${ index }-${ row.href ?? row.label }`,
@@ -229,11 +217,11 @@ function buildLeaderboardData(
 					openInNewTab
 					title={ row.label }
 				>
-					<ClickLabel row={ row } />
+					{ label }
 				</Link>
 			) : (
 				<span className={ styles.labelText } title={ row.label }>
-					<ClickLabel row={ row } />
+					{ label }
 				</span>
 			),
 			currentValue: row.value,

--- a/projects/packages/premium-analytics/widgets/clicks/style.module.css
+++ b/projects/packages/premium-analytics/widgets/clicks/style.module.css
@@ -1,7 +1,7 @@
 .labelIcon {
 	--jpa-leaderboard-image-width: 16px;
 	--jpa-leaderboard-image-height: 16px;
-	border-radius: var(--wpds-border-radius-sm);
+	--jpa-leaderboard-image-radius: var(--wpds-border-radius-sm);
 }
 
 /* Flex keeps the Link's external-arrow icon on the same line as the label;
@@ -21,22 +21,6 @@
 
 .labelLink {
 	gap: var(--wpds-dimension-gap-xs, 4px);
-}
-
-/* Let the label Stack shrink inside the flex wrapper so the text can
-   truncate. */
-.labelLink > div,
-.labelText > div {
-	min-inline-size: 0;
-	max-inline-size: 100%;
-}
-
-.labelLink > div > span,
-.labelText > div > span {
-	min-inline-size: 0;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
 }
 
 .labelLink:hover,

--- a/projects/packages/premium-analytics/widgets/clicks/style.module.css
+++ b/projects/packages/premium-analytics/widgets/clicks/style.module.css
@@ -1,49 +1,47 @@
-.labelContent {
-	display: inline-flex;
-	align-items: center;
-	min-inline-size: 0;
-	max-inline-size: 100%;
-	gap: var(--wpds-dimension-gap-xs, 4px);
-}
-
 .labelIcon {
-	flex: 0 0 auto;
-	inline-size: 16px;
-	block-size: 16px;
+	--jpa-leaderboard-image-width: 16px;
+	--jpa-leaderboard-image-height: 16px;
 	border-radius: var(--wpds-border-radius-sm);
 }
 
+/* Flex keeps the Link's external-arrow icon on the same line as the label;
+   the min height keeps the standard 36px leaderboard row. */
 .labelLink,
 .labelText {
-	padding-block: var(--wpds-dimension-padding-md, 12px);
-	padding-inline-start: var(--wpds-dimension-padding-sm, 8px);
+	display: flex;
+	align-items: center;
+	min-block-size: 36px;
+	min-inline-size: 0;
+	max-inline-size: 100%;
 	overflow: hidden;
 	color: inherit;
 	text-decoration: none;
-	text-overflow: ellipsis;
 	white-space: nowrap;
 }
 
 .labelLink {
-	display: flex;
-	align-items: center;
 	gap: var(--wpds-dimension-gap-xs, 4px);
 }
 
-.labelText {
-	display: block;
+/* Let the label Stack shrink inside the flex wrapper so the text can
+   truncate. */
+.labelLink > div,
+.labelText > div {
+	min-inline-size: 0;
+	max-inline-size: 100%;
+}
+
+.labelLink > div > span,
+.labelText > div > span {
+	min-inline-size: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .labelLink:hover,
 .labelLink:focus {
 	text-decoration: underline;
-}
-
-.labelTitle {
-	min-inline-size: 0;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
 }
 
 .placeholder {

--- a/projects/packages/premium-analytics/widgets/locations/style.module.css
+++ b/projects/packages/premium-analytics/widgets/locations/style.module.css
@@ -120,11 +120,12 @@
 
 /* Width is the constraint that sizes flags: the boot layout shell forces
    img { height: auto } at higher specificity, so a height here never applies
-   in the dashboard. `fill` (not `initial`, a CSS-wide keyword that would
-   unset the custom property) keeps the flag's aspect ratio uncropped. */
+   in the dashboard. `contain` (not `initial`, a CSS-wide keyword that would
+   unset the custom property) keeps the flag's aspect ratio uncropped even if
+   a height ever does apply. */
 .leaderboardImage {
 	--jpa-leaderboard-image-width: 28px;
 	--jpa-leaderboard-image-height: auto;
-	--jpa-leaderboard-image-fit: fill;
+	--jpa-leaderboard-image-fit: contain;
 	border-radius: var(--wpds-border-radius-sm, 2px);
 }

--- a/projects/packages/premium-analytics/widgets/locations/style.module.css
+++ b/projects/packages/premium-analytics/widgets/locations/style.module.css
@@ -127,5 +127,5 @@
 	--jpa-leaderboard-image-width: 28px;
 	--jpa-leaderboard-image-height: auto;
 	--jpa-leaderboard-image-fit: contain;
-	border-radius: var(--wpds-border-radius-sm, 2px);
+	--jpa-leaderboard-image-radius: var(--wpds-border-radius-sm, 2px);
 }

--- a/projects/packages/premium-analytics/widgets/locations/style.module.css
+++ b/projects/packages/premium-analytics/widgets/locations/style.module.css
@@ -118,16 +118,13 @@
 	}
 }
 
+/* Width is the constraint that sizes flags: the boot layout shell forces
+   img { height: auto } at higher specificity, so a height here never applies
+   in the dashboard. `fill` (not `initial`, a CSS-wide keyword that would
+   unset the custom property) keeps the flag's aspect ratio uncropped. */
 .leaderboardImage {
-	height: 20px;
+	--jpa-leaderboard-image-width: 28px;
+	--jpa-leaderboard-image-height: auto;
+	--jpa-leaderboard-image-fit: fill;
 	border-radius: var(--wpds-border-radius-sm, 2px);
-}
-
-/* The picker grid applies img { width: 100%; height: 100%; object-fit: cover }
- * to all images inside the media cell, overriding our 20px flag height.
- * Restore correct sizing for flag images in any inert context. */
-:global([inert]) .leaderboard .leaderboardImage {
-	width: auto;
-	height: 20px;
-	object-fit: initial;
 }

--- a/projects/packages/premium-analytics/widgets/referrers/render.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/render.tsx
@@ -9,6 +9,7 @@ import {
 } from '@jetpack-premium-analytics/data';
 import {
 	LeaderboardChart,
+	LeaderboardLabel,
 	WidgetBackLink,
 	WidgetLoadingOverlay,
 	WidgetRoot,
@@ -173,22 +174,6 @@ export function toReferrerRows(
 	return sliced.map( toReferrerRow );
 }
 
-function ReferrerLabel( { row }: { row: ReferrerRow } ) {
-	return (
-		<span className={ styles.labelContent }>
-			{ /* The fixed-size box (not the img) owns the favicon dimensions: the
-			     widget-picker preview grid stretches raw `img` elements to 100%,
-			     so sizing the parent keeps the icon 16px in both contexts. */ }
-			{ row.icon && (
-				<span className={ styles.labelIconBox }>
-					<img src={ row.icon } alt="" className={ styles.labelIcon } />
-				</span>
-			) }
-			<span className={ styles.labelTitle }>{ row.label }</span>
-		</span>
-	);
-}
-
 /**
  * Maps normalized referrer rows onto the shape `LeaderboardChart` expects.
  *
@@ -209,6 +194,15 @@ function buildLeaderboardData(
 		const previousValue = row.previousValue ?? 0;
 		const hasChildren = !! row.children?.length;
 		const shouldRenderLink = !! row.href && ! hasChildren;
+		const label = (
+			<LeaderboardLabel
+				label={ row.label }
+				imageUrl={ row.icon ?? undefined }
+				imageAlt=""
+				imageFallback="hidden"
+				imageClassName={ styles.labelIcon }
+			/>
+		);
 
 		return {
 			id: `${ index }-${ row.href ?? row.label }`,
@@ -220,11 +214,11 @@ function buildLeaderboardData(
 					openInNewTab
 					title={ row.label }
 				>
-					<ReferrerLabel row={ row } />
+					{ label }
 				</Link>
 			) : (
 				<span className={ styles.labelText } title={ row.label }>
-					<ReferrerLabel row={ row } />
+					{ label }
 				</span>
 			),
 			currentValue: row.value,

--- a/projects/packages/premium-analytics/widgets/referrers/style.module.css
+++ b/projects/packages/premium-analytics/widgets/referrers/style.module.css
@@ -1,55 +1,46 @@
-.labelContent {
-	display: inline-flex;
-	align-items: center;
-	min-inline-size: 0;
-	max-inline-size: 100%;
-	gap: var(--wpds-dimension-gap-xs, 4px);
-}
-
-.labelIconBox {
-	flex: 0 0 auto;
-	inline-size: 16px;
-	block-size: 16px;
-}
-
 .labelIcon {
-	inline-size: 16px;
-	block-size: 16px;
+	--jpa-leaderboard-image-width: 16px;
+	--jpa-leaderboard-image-height: 16px;
 	border-radius: var(--wpds-border-radius-sm);
-	object-fit: cover;
 }
 
+/* Flex keeps the Link's external-arrow icon on the same line as the label;
+   the min height keeps the standard 36px leaderboard row. */
 .labelLink,
 .labelText {
-	padding-block: var(--wpds-dimension-padding-md, 12px);
-	padding-inline-start: var(--wpds-dimension-padding-sm, 8px);
+	display: flex;
+	align-items: center;
+	min-block-size: 36px;
+	min-inline-size: 0;
+	max-inline-size: 100%;
 	overflow: hidden;
 	color: inherit;
 	text-decoration: none;
-	text-overflow: ellipsis;
 	white-space: nowrap;
 }
 
 .labelLink {
-	display: flex;
-	align-items: center;
 	gap: var(--wpds-dimension-gap-xs, 4px);
 }
 
-.labelText {
-	display: block;
+/* Let the label Stack shrink inside the flex link so the text can truncate. */
+.labelLink > div,
+.labelText > div {
+	min-inline-size: 0;
+	max-inline-size: 100%;
 }
 
-.labelLink:hover .labelTitle,
-.labelLink:focus .labelTitle {
-	text-decoration: underline;
-}
-
-.labelTitle {
+.labelLink > div > span,
+.labelText > div > span {
 	min-inline-size: 0;
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+}
+
+.labelLink:hover,
+.labelLink:focus {
+	text-decoration: underline;
 }
 
 .placeholder {
@@ -82,4 +73,3 @@
 	aspect-ratio: 4 / 3;
 	overflow: hidden;
 }
-

--- a/projects/packages/premium-analytics/widgets/referrers/style.module.css
+++ b/projects/packages/premium-analytics/widgets/referrers/style.module.css
@@ -1,7 +1,7 @@
 .labelIcon {
 	--jpa-leaderboard-image-width: 16px;
 	--jpa-leaderboard-image-height: 16px;
-	border-radius: var(--wpds-border-radius-sm);
+	--jpa-leaderboard-image-radius: var(--wpds-border-radius-sm);
 }
 
 /* Flex keeps the Link's external-arrow icon on the same line as the label;
@@ -21,21 +21,6 @@
 
 .labelLink {
 	gap: var(--wpds-dimension-gap-xs, 4px);
-}
-
-/* Let the label Stack shrink inside the flex link so the text can truncate. */
-.labelLink > div,
-.labelText > div {
-	min-inline-size: 0;
-	max-inline-size: 100%;
-}
-
-.labelLink > div > span,
-.labelText > div > span {
-	min-inline-size: 0;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
 }
 
 .labelLink:hover,

--- a/projects/packages/premium-analytics/widgets/subscribers-list/render.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-list/render.tsx
@@ -19,7 +19,6 @@ import { useMemo } from 'react';
 /**
  * Internal dependencies
  */
-import styles from './style.module.css';
 import type { SubscribersListAttributes } from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 
@@ -84,7 +83,7 @@ export const SubscribersRoster = ( {
 	moreCount = 0,
 }: SubscribersRosterProps ) => {
 	return (
-		<div className={ styles.root }>
+		<div>
 			{ isError ? (
 				<Text>{ __( 'Unable to load subscribers.', 'jetpack-premium-analytics' ) }</Text>
 			) : (

--- a/projects/packages/premium-analytics/widgets/subscribers-list/style.module.css
+++ b/projects/packages/premium-analytics/widgets/subscribers-list/style.module.css
@@ -1,7 +1,0 @@
-/* The picker grid applies img { width: 100%; height: 100%; object-fit: cover }
-   to every image in its media cell, blowing the 32px avatars up to fill the
-   tile. Restore their size in any inert (picker) context. */
-:global([inert]) .root img {
-	width: 32px;
-	height: 32px;
-}


### PR DESCRIPTION
## Proposed changes
The widget picker renders live widget previews in an inert context where the preview grid stretches raw `img` elements to fill their container (`.dataviews-view-picker-grid__media img { width: 100%; height: 100% }`). Every widget that shows images was affected: Clicks favicons rendered enormous (WOOA7S-1695), and Authors, Locations, Visitors by location, and Subscribers list each carried their own near-identical per-widget workaround (e.g. #50393). Instead of patching each widget's stylesheet individually, this centralizes the picker-preview image-size fix in the shared components:

* `LeaderboardLabel` now owns the inert-context image sizing via `--jpa-leaderboard-image-*` custom properties, and gains an `imageFallback="hidden"` prop for rows without an icon.
* The Clicks and Referrers widgets render their row labels through the shared component, dropping their local label markup and per-widget fixes.
* Authors, Locations, and Visitors-by-location migrate their existing overrides to the new custom properties, and their duplicated `[inert]` rules are removed.
* The Subscribers-list avatar-size fix moves into the shared `SubscriberList` styles.

Net result: no per-widget picker fixes remain — the two shared components (`LeaderboardLabel`, `SubscriberList`) own the counter-rule, and any future widget using them is covered automatically. The durable upstream fix is still for `@wordpress/widget-dashboard`/`@wordpress/dataviews` to not apply media-thumbnail styling to widget previews; until then this keeps the workaround in one place per component instead of one per widget.

## Related product discussion/links
* WOOA7S-1695
* Follows the per-widget approach from #50393 (Authors), now centralized.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* On a site with Premium Analytics, open the dashboard widget picker (customize / add widget).
* Check the **Clicks** widget preview card: favicons should render small (16px) next to labels, not stretched to fill the row.
* Check the **Referrers**, **Authors**, **Locations**, **Visitors by location**, and **Subscribers list** previews still render their images/avatars at the correct size (16px favicons, 20px avatars, 28px-wide flags, 32px subscriber avatars).
* Add the Clicks and Referrers widgets to the dashboard and confirm rows render as before: favicon + label on one line with the external-link arrow, 36px rows, rows without a favicon show no placeholder.
* Check Locations/Visitors by location flags and Authors avatars render unchanged on the dashboard.

Before/after screenshots of the Clicks widget preview: _to be added_.
