### PR TITLE
Forms: Clarify notifications sidebar section

### DIFF
--- a/projects/packages/forms/changelog/update-forms-notifications-text
+++ b/projects/packages/forms/changelog/update-forms-notifications-text
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Just updated some text
+
+

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-email-connection-settings.jsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-email-connection-settings.jsx
@@ -88,7 +88,7 @@ const JetpackEmailConnectionSettings = ( {
 	return (
 		<>
 			<ToggleControl
-				label={ __( 'Send responses to email', 'jetpack-forms' ) }
+				label={ __( 'Email me new responses', 'jetpack-forms' ) }
 				checked={ emailNotifications }
 				help={ __( 'Get incoming form responses sent to your email inbox.', 'jetpack-forms' ) }
 				onChange={ value => setAttributes( { emailNotifications: value } ) }
@@ -100,7 +100,7 @@ const JetpackEmailConnectionSettings = ( {
 						aria-describedby={ `contact-form-${ instanceId }-email-${
 							hasEmailErrors() ? 'error' : 'help'
 						}` }
-						label={ __( 'Email address to send to', 'jetpack-forms' ) }
+						label={ __( 'Send email notifications to', 'jetpack-forms' ) }
 						placeholder={ __( 'name@example.com', 'jetpack-forms' ) }
 						onKeyDown={ e => {
 							if ( event.key === 'Enter' ) {

--- a/projects/packages/forms/src/blocks/contact-form/components/notifications-settings.jsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/notifications-settings.jsx
@@ -75,7 +75,7 @@ const NotificationsSettings = ( {
 			/>
 			<>
 				<ToggleControl
-					label={ __( 'Enable notifications for responses', 'jetpack-forms' ) }
+					label={ __( 'Send me push notifications', 'jetpack-forms' ) }
 					help={ createInterpolateElement(
 						__(
 							'Receive push notifications when someone fills out your form. <pushNotificationsLink>Learn more.</pushNotificationsLink>',

--- a/projects/packages/forms/tests/js/contact-form/components/notifications-settings.test.jsx
+++ b/projects/packages/forms/tests/js/contact-form/components/notifications-settings.test.jsx
@@ -228,7 +228,7 @@ describe( 'NotificationsSettings', () => {
 			/>
 		);
 
-		expect( screen.getByText( 'Enable notifications for responses' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Send me push notifications' ) ).toBeInTheDocument();
 	} );
 
 	it( 'does not show user selector when toggle is disabled', () => {


### PR DESCRIPTION
Fixes DSGCOM-592

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Updates the text to clarify the intention: The notifications are for you, not the responder.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Create a new post
* Add a Form block
* Check the sidebar's "Form notifications" section for the updated text

| Before | After |
| - | - |
| <img width="321" height="524" alt="Screenshot from 2026-07-10 14-02-18" src="https://github.com/user-attachments/assets/72884539-2b9a-4323-a8a7-4361c4478d71" /> | <img width="321" height="524" alt="Screenshot from 2026-07-10 13-47-43" src="https://github.com/user-attachments/assets/49aeecc6-a3a5-4783-9222-891fd2a0b01d" /> |
