### PR TITLE
VideoPress: Fix caption manager not loading on WordPress.com Simple sites

### DIFF
--- a/projects/packages/videopress/changelog/fix-caption-modal-wpcom-public-path
+++ b/projects/packages/videopress/changelog/fix-caption-modal-wpcom-public-path
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress: Fix the caption manager failing to load on WordPress.com Simple sites by setting Webpack's public path explicitly.

--- a/projects/packages/videopress/changelog/fix-caption-modal-wpcom-public-path
+++ b/projects/packages/videopress/changelog/fix-caption-modal-wpcom-public-path
@@ -1,4 +1,4 @@
 Significance: patch
-Type: bugfix
+Type: fixed
 
 Captions: Fix the caption manager failing to load on WordPress.com Simple sites by setting Webpack's public path explicitly.

--- a/projects/packages/videopress/changelog/fix-caption-modal-wpcom-public-path
+++ b/projects/packages/videopress/changelog/fix-caption-modal-wpcom-public-path
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-VideoPress: Fix the caption manager failing to load on WordPress.com Simple sites by setting Webpack's public path explicitly.
+Captions: Fix the caption manager failing to load on WordPress.com Simple sites by setting Webpack's public path explicitly.

--- a/projects/packages/videopress/src/class-block-editor-extensions.php
+++ b/projects/packages/videopress/src/class-block-editor-extensions.php
@@ -161,6 +161,7 @@ class Block_Editor_Extensions {
 			'isStandaloneActive'          => Status::is_standalone_plugin_active(),
 			'imagesURLBase'               => plugin_dir_url( __DIR__ ) . 'build/images/',
 			'playerBridgeUrl'             => plugins_url( '../build/lib/player-bridge.js', __FILE__ ),
+			'webpackPublicPath'           => plugins_url( '../build/', __FILE__ ),
 		);
 
 		// Expose initial state of site connection

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/index.ts
@@ -5,6 +5,8 @@ import { registerBlockType } from '@wordpress/blocks';
 /**
  * Internal dependencies
  */
+// Overrides Webpack's publicPath before any lazy chunk loads on wpcom.
+import '../../set-webpack-public-path';
 import editorImageURL from '../../utils/editor-image-url';
 import metadata from './block.json';
 import { VideoPressIcon as icon } from './components/icons';

--- a/projects/packages/videopress/src/client/block-editor/global.d.ts
+++ b/projects/packages/videopress/src/client/block-editor/global.d.ts
@@ -13,6 +13,7 @@ declare global {
 			jetpackVideoPressSettingUrl: string;
 			imagesURLBase: string;
 			playerBridgeUrl: string;
+			webpackPublicPath: string;
 		};
 	}
 }

--- a/projects/packages/videopress/src/client/block-editor/set-webpack-public-path.js
+++ b/projects/packages/videopress/src/client/block-editor/set-webpack-public-path.js
@@ -1,0 +1,17 @@
+/* exported __webpack_public_path__ */
+/* global __webpack_public_path__ */
+
+/**
+ * Dynamically set Webpack's publicPath so that lazily-loaded chunks (and their
+ * CSS) resolve against the package's build directory.
+ *
+ * We can't rely on `publicPath: 'auto'` because WordPress.com Simple's JS
+ * concatenation rewrites script URLs into `/_static/??…`, which breaks the
+ * `document.currentScript.src` auto-detection. Self-hosted sites keep working
+ * via auto-detection because the global is absent there.
+ * @see https://webpack.js.org/guides/public-path/#on-the-fly
+ */
+if ( typeof window === 'object' && window.videoPressEditorState?.webpackPublicPath ) {
+	// eslint-disable-next-line no-global-assign
+	__webpack_public_path__ = window.videoPressEditorState.webpackPublicPath;
+}

--- a/projects/packages/videopress/src/client/block-editor/set-webpack-public-path.js
+++ b/projects/packages/videopress/src/client/block-editor/set-webpack-public-path.js
@@ -2,13 +2,10 @@
 /* global __webpack_public_path__ */
 
 /**
- * Dynamically set Webpack's publicPath so that lazily-loaded chunks (and their
- * CSS) resolve against the package's build directory.
- *
- * We can't rely on `publicPath: 'auto'` because WordPress.com Simple's JS
- * concatenation rewrites script URLs into `/_static/??…`, which breaks the
- * `document.currentScript.src` auto-detection. Self-hosted sites keep working
- * via auto-detection because the global is absent there.
+ * Set Webpack's publicPath from the localized global so lazy chunks (and their
+ * CSS) resolve against the package build dir. The `'auto'` fallback is
+ * unreliable on WordPress.com Simple, where JS concatenation rewrites the
+ * script URL that auto-detection reads.
  * @see https://webpack.js.org/guides/public-path/#on-the-fly
  */
 if ( typeof window === 'object' && window.videoPressEditorState?.webpackPublicPath ) {

--- a/projects/packages/videopress/src/client/block-editor/test/set-webpack-public-path.test.js
+++ b/projects/packages/videopress/src/client/block-editor/test/set-webpack-public-path.test.js
@@ -1,0 +1,49 @@
+/**
+ * Tests for the block-editor Webpack public-path override.
+ *
+ * The module runs a side effect at import time, so each case arranges globals
+ * first and then re-requires it in isolation via `jest.resetModules()`.
+ */
+
+describe( 'set-webpack-public-path', () => {
+	const originalEditorState = window.videoPressEditorState;
+
+	beforeEach( () => {
+		/*
+		 * Provide a resolvable global so the module's assignment to Webpack's
+		 * `__webpack_public_path__` free variable doesn't throw under strict
+		 * mode. In the real build Webpack supplies this variable.
+		 */
+		global.__webpack_public_path__ = 'initial/';
+		jest.resetModules();
+	} );
+
+	afterEach( () => {
+		window.videoPressEditorState = originalEditorState;
+		delete global.__webpack_public_path__;
+	} );
+
+	test( 'sets the public path from the localized global when present', () => {
+		window.videoPressEditorState = { webpackPublicPath: 'https://example.com/build/' };
+
+		require( '../set-webpack-public-path' );
+
+		expect( global.__webpack_public_path__ ).toBe( 'https://example.com/build/' );
+	} );
+
+	test( 'leaves the public path unchanged when the localized global is absent', () => {
+		delete window.videoPressEditorState;
+
+		require( '../set-webpack-public-path' );
+
+		expect( global.__webpack_public_path__ ).toBe( 'initial/' );
+	} );
+
+	test( 'leaves the public path unchanged when webpackPublicPath is empty', () => {
+		window.videoPressEditorState = { webpackPublicPath: '' };
+
+		require( '../set-webpack-public-path' );
+
+		expect( global.__webpack_public_path__ ).toBe( 'initial/' );
+	} );
+} );

--- a/projects/packages/videopress/src/client/block-editor/test/set-webpack-public-path.test.js
+++ b/projects/packages/videopress/src/client/block-editor/test/set-webpack-public-path.test.js
@@ -1,8 +1,6 @@
 /**
- * Tests for the block-editor Webpack public-path override.
- *
- * The module runs a side effect at import time, so each case arranges globals
- * first and then re-requires it in isolation via `jest.resetModules()`.
+ * Tests for the block-editor Webpack public-path override, which runs as an
+ * import-time side effect — each case arranges globals then re-requires it.
  */
 
 describe( 'set-webpack-public-path', () => {
@@ -10,9 +8,8 @@ describe( 'set-webpack-public-path', () => {
 
 	beforeEach( () => {
 		/*
-		 * Provide a resolvable global so the module's assignment to Webpack's
-		 * `__webpack_public_path__` free variable doesn't throw under strict
-		 * mode. In the real build Webpack supplies this variable.
+		 * Webpack supplies this free variable in real builds; define it here so
+		 * the module's strict-mode assignment resolves instead of throwing.
 		 */
 		global.__webpack_public_path__ = 'initial/';
 		jest.resetModules();

--- a/projects/packages/videopress/src/client/block-editor/test/set-webpack-public-path.test.js
+++ b/projects/packages/videopress/src/client/block-editor/test/set-webpack-public-path.test.js
@@ -4,8 +4,6 @@
  */
 
 describe( 'set-webpack-public-path', () => {
-	const originalEditorState = window.videoPressEditorState;
-
 	beforeEach( () => {
 		/*
 		 * Webpack supplies this free variable in real builds; define it here so
@@ -16,7 +14,7 @@ describe( 'set-webpack-public-path', () => {
 	} );
 
 	afterEach( () => {
-		window.videoPressEditorState = originalEditorState;
+		delete window.videoPressEditorState;
 		delete global.__webpack_public_path__;
 	} );
 


### PR DESCRIPTION
Fixes #

## Proposed changes
* Fix the VideoPress caption manager failing to load on WordPress.com Simple sites. On Simple sites, jsconcat rewrites editor script URLs into `/_static/??…`, which breaks webpack's `currentScript.src`-based `publicPath` auto-detection — so the caption manager's lazy-loaded JS chunks and modal CSS were requested from the site root instead of the videopress package's `build/` directory, and the modal never loaded.
* Localize a `webpackPublicPath` onto the block editor state (`plugins_url( '../build/', __FILE__ )`), which resolves correctly under the vendored mu-plugins path on Simple sites and survives JS concatenation.
* Add a guarded `set-webpack-public-path.js` module (imported first in the block-editor entry) that assigns `__webpack_public_path__` from that global. Self-hosted sites have no global and keep working via auto-detection.
* This mirrors the established pattern already used by the Jetpack plugin blocks (`Jetpack_Block_Assets_Base_Url`) and Instant Search (`webpackPublicPath`) for the same wpcom-concat reason. The caption manager is the first lazy-loaded editor chunk this package has shipped, which is why it's the first feature to hit this.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a **WordPress.com Simple site** (or a Jurassic Ninja site to confirm no regression on self-hosted / Atomic), edit a post and add a VideoPress block with an uploaded video.
* Open the block toolbar / settings and launch the **caption manager** ("Manage captions"/subtitles) modal.
* Confirm the modal opens and its styles render — before this fix, the lazy chunk (e.g. `caption-manager-modal`) and its CSS 404'd from the site root (`https://<site>.wordpress.com/457.js`) and the modal failed to load.
* In the browser Network tab, confirm the chunk and CSS requests resolve against the package build directory (`…/jetpack_vendor/automattic/jetpack-videopress/build/`) rather than the site root.
* On self-hosted, confirm the caption manager still opens normally (auto-detection path, unchanged).
