### PR TITLE
Related Posts: enqueue block stylesheet on the block render path

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-related-posts-block-css-enqueue
+++ b/projects/plugins/jetpack/changelog/fix-related-posts-block-css-enqueue
@@ -1,3 +1,4 @@
 Significance: patch
 Type: bugfix
-Comment: Related Posts: enqueue the block stylesheet whenever the block renders, so it is styled on pages and classic themes where the module's front-end asset gate does not run (JETPACK-1876).
+
+Related Posts: enqueue the block stylesheet whenever the block renders, so it is styled on pages and classic themes where the module's front-end asset gate does not run.

--- a/projects/plugins/jetpack/changelog/fix-related-posts-block-css-enqueue
+++ b/projects/plugins/jetpack/changelog/fix-related-posts-block-css-enqueue
@@ -1,0 +1,3 @@
+Significance: patch
+Type: bugfix
+Comment: Related Posts: enqueue the block stylesheet whenever the block renders, so it is styled on pages and classic themes where the module's front-end asset gate does not run (JETPACK-1876).

--- a/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
+++ b/projects/plugins/jetpack/modules/related-posts/jetpack-related-posts.php
@@ -487,6 +487,19 @@ EOT;
 			return '';
 		}
 
+		/*
+		 * The block renders through its own block callback, independently of the
+		 * module's front-end asset gate (enabled_for_request()). That gate only
+		 * enqueues our assets on single posts in classic themes, so a block placed
+		 * on a page (or any view the gate skips) would render as unstyled HTML.
+		 * Enqueue the stylesheet here, whenever the block actually outputs markup,
+		 * to keep it styled everywhere it can be used. We intentionally do not widen
+		 * enabled_for_request() itself: that governs the automatic the_content
+		 * insertion and was deliberately scoped in #39784 to avoid showing related
+		 * posts on classic-theme pages.
+		 */
+		$this->enqueue_assets( false, true );
+
 		$list_markup = $this->render_post_list( $related_posts, $block_attributes );
 
 		if ( empty( $attributes['isServerRendered'] ) ) {

--- a/projects/plugins/jetpack/tests/php/modules/related-posts/Jetpack_RelatedPosts_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/related-posts/Jetpack_RelatedPosts_Test.php
@@ -23,7 +23,10 @@ class Jetpack_RelatedPosts_Test extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		$options = new ReflectionProperty( Jetpack_RelatedPosts::class, 'options' );
-		$options->setAccessible( true );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$options->setAccessible( true );
+		}
 		$options->setValue( Jetpack_RelatedPosts::init(), null );
 
 		parent::tear_down();

--- a/projects/plugins/jetpack/tests/php/modules/related-posts/Jetpack_RelatedPosts_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/related-posts/Jetpack_RelatedPosts_Test.php
@@ -52,7 +52,12 @@ class Jetpack_RelatedPosts_Test extends WP_UnitTestCase {
 		remove_filter( 'jetpack_relatedposts_filter_options', '__return_null' );
 
 		// Never hit the WordPress.com API during the test...
-		add_filter( 'pre_http_request', static fn () => new WP_Error( 'no_http_in_tests', 'HTTP disabled in tests' ) );
+		add_filter(
+			'pre_http_request',
+			static function () {
+				return new WP_Error( 'no_http_in_tests', 'HTTP disabled in tests' );
+			}
+		);
 
 		// ...and inject a related post so the block produces markup.
 		add_filter(

--- a/projects/plugins/jetpack/tests/php/modules/related-posts/Jetpack_RelatedPosts_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/related-posts/Jetpack_RelatedPosts_Test.php
@@ -81,8 +81,14 @@ class Jetpack_RelatedPosts_Test extends WP_UnitTestCase {
 		wp_dequeue_style( 'jetpack_related-posts' );
 		$this->assertFalse( wp_style_is( 'jetpack_related-posts', 'enqueued' ) );
 
+		// isServerRendered mirrors the get_server_rendered_html() path: calling
+		// render_block() directly never registers a block, so block supports must
+		// be skipped (otherwise WP_Block_Supports::apply_block_supports() reads an
+		// offset on a null block_to_render and warns). The enqueue under test runs
+		// before that branch, so this does not affect what we are asserting.
 		$output = $related_posts->render_block(
 			array(
+				'isServerRendered'  => true,
 				'displayThumbnails' => false,
 				'displayDate'       => false,
 			),

--- a/projects/plugins/jetpack/tests/php/modules/related-posts/Jetpack_RelatedPosts_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/related-posts/Jetpack_RelatedPosts_Test.php
@@ -16,6 +16,82 @@ class Jetpack_RelatedPosts_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Tear down.
+	 *
+	 * Reset the singleton's cached options so option state does not leak between
+	 * tests (get_options() caches the first computed value on the instance).
+	 */
+	public function tear_down() {
+		$options = new ReflectionProperty( Jetpack_RelatedPosts::class, 'options' );
+		$options->setAccessible( true );
+		$options->setValue( Jetpack_RelatedPosts::init(), null );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * The Related Posts block renders through its own block callback, independently
+	 * of the module's front-end asset gate (enabled_for_request()). Rendering the
+	 * block must therefore enqueue its own stylesheet, otherwise the block appears
+	 * as unstyled HTML in any context the gate skips — most notably a Related Posts
+	 * block placed on a page while using a classic theme.
+	 *
+	 * Regression test for the "block CSS not enqueued on the frontend" bug. The fix
+	 * must live on the block render path and must NOT widen enabled_for_request(),
+	 * which would re-introduce #39783 (related posts auto-appended to classic-theme
+	 * pages).
+	 */
+	public function test_render_block_enqueues_frontend_style() {
+		$related_posts = Jetpack_RelatedPosts::init();
+
+		// render_block() bails unless it is handling a front-end request.
+		add_filter( 'jetpack_is_frontend', '__return_true' );
+
+		// Use the module's real default options (enabled, size 3) instead of the
+		// null options the shared set_up injects.
+		remove_filter( 'jetpack_relatedposts_filter_options', '__return_null' );
+
+		// Never hit the WordPress.com API during the test...
+		add_filter( 'pre_http_request', static fn () => new WP_Error( 'no_http_in_tests', 'HTTP disabled in tests' ) );
+
+		// ...and inject a related post so the block produces markup.
+		add_filter(
+			'jetpack_relatedposts_returned_results',
+			static function () {
+				return array(
+					array(
+						'title' => 'A related post',
+						'url'   => 'https://example.org/related-post/',
+						'rel'   => '',
+					),
+				);
+			}
+		);
+
+		// A singular post for render_block() to build against (it uses get_the_ID()).
+		$post_id         = self::factory()->post->create();
+		$GLOBALS['post'] = get_post( $post_id );
+
+		// Sanity check: the stylesheet is not already enqueued.
+		wp_dequeue_style( 'jetpack_related-posts' );
+		$this->assertFalse( wp_style_is( 'jetpack_related-posts', 'enqueued' ) );
+
+		$output = $related_posts->render_block(
+			array(
+				'displayThumbnails' => false,
+				'displayDate'       => false,
+			),
+			''
+		);
+
+		$this->assertStringContainsString( 'jp-relatedposts-i2', $output, 'The block should render its markup.' );
+		$this->assertTrue(
+			wp_style_is( 'jetpack_related-posts', 'enqueued' ),
+			'Rendering the Related Posts block should enqueue its stylesheet.'
+		);
+	}
+
+	/**
 	 * Verify that 'enabled' remains the same if it's true.
 	 *
 	 * @since  4.7.0

--- a/projects/plugins/jetpack/tests/php/modules/related-posts/Jetpack_RelatedPosts_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/related-posts/Jetpack_RelatedPosts_Test.php
@@ -94,6 +94,63 @@ class Jetpack_RelatedPosts_Test extends WP_UnitTestCase {
 			wp_style_is( 'jetpack_related-posts', 'enqueued' ),
 			'Rendering the Related Posts block should enqueue its stylesheet.'
 		);
+
+		// The block path only needs the stylesheet; the async script is intentionally
+		// not enqueued here (enqueue_assets( false, true )).
+		$this->assertFalse(
+			wp_script_is( 'jetpack_related-posts', 'enqueued' ),
+			'Rendering the Related Posts block should not enqueue the async script.'
+		);
+	}
+
+	/**
+	 * The stylesheet must only be enqueued when the block actually outputs markup.
+	 * render_block() returns an empty string before the enqueue when there are no
+	 * related posts, so rendering an empty block must not leave the stylesheet on
+	 * the page.
+	 */
+	public function test_render_block_without_results_does_not_enqueue_style() {
+		$related_posts = Jetpack_RelatedPosts::init();
+
+		// render_block() bails unless it is handling a front-end request.
+		add_filter( 'jetpack_is_frontend', '__return_true' );
+
+		// Use the module's real default options (enabled, size 3) instead of the
+		// null options the shared set_up injects.
+		remove_filter( 'jetpack_relatedposts_filter_options', '__return_null' );
+
+		// Never hit the WordPress.com API during the test...
+		add_filter(
+			'pre_http_request',
+			static function () {
+				return new WP_Error( 'no_http_in_tests', 'HTTP disabled in tests' );
+			}
+		);
+
+		// ...and force an empty result set so the block renders nothing.
+		add_filter( 'jetpack_relatedposts_returned_results', '__return_empty_array' );
+
+		// A singular post for render_block() to build against (it uses get_the_ID()).
+		$post_id         = self::factory()->post->create();
+		$GLOBALS['post'] = get_post( $post_id );
+
+		// Ensure a clean baseline: the stylesheet is not already enqueued.
+		wp_dequeue_style( 'jetpack_related-posts' );
+		$this->assertFalse( wp_style_is( 'jetpack_related-posts', 'enqueued' ) );
+
+		$output = $related_posts->render_block(
+			array(
+				'displayThumbnails' => false,
+				'displayDate'       => false,
+			),
+			''
+		);
+
+		$this->assertSame( '', $output, 'The block should render nothing when there are no related posts.' );
+		$this->assertFalse(
+			wp_style_is( 'jetpack_related-posts', 'enqueued' ),
+			'The Related Posts block should not enqueue its stylesheet when it renders nothing.'
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes JETPACK-1876

## Proposed changes

The Related Posts block renders through its own block callback, but its frontend stylesheet was never enqueued by the block itself. The CSS (`modules/related-posts/related-posts.css`) is only enqueued as a side effect of the module's front-end asset gate, `enabled_for_request()` — which on **classic themes** only fires on **single posts** (`is_single()`). So a Related Posts block placed on a **page** (or any view the gate skips) rendered its `jp-relatedposts-i2` markup with no matching CSS: an unstyled bullet list with full-size images and visible `dt`/`dd` labels.

This enqueues the stylesheet inside `render_block()`, right after we know the block will output markup, reusing the module's existing `enqueue_assets( false, true )` helper (handle `jetpack_related-posts`, including RTL + AMP handling). The block is now styled everywhere it can be placed, independent of theme type or the page/post distinction.

* Enqueue the block's stylesheet on the block render path, whenever the block actually renders related posts.
* Add a regression test asserting the style is enqueued when the block renders without the module's gate having run.

**Deliberately not changed:** `enabled_for_request()` is left untouched. That gate governs the automatic `the_content` insertion of related posts and was intentionally scoped in #39784 to avoid auto-appending related posts to classic-theme pages (#39783). Widening it would re-introduce that bug. The fix is confined to the block render path — it only adds CSS to markup the user explicitly placed — so the auto-insertion behavior is unchanged. The enqueue is idempotent on single posts, where the module already enqueues the same handle.

## Related product discussion/links

* Guards against regressing #39783 / #39784

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Related Posts can render three ways (block, `[jetpack-related-posts]` shortcode, automatic `the_content` insertion) and behaves differently on classic vs. block themes, so please cover the matrix below. This fix only changes the **block** render path; the shortcode and automatic-insertion paths are intentionally unchanged.

**Setup**

* Start with a site connected to WordPress.com, with the Related Posts module active (Settings → Reading) and several published posts *and* pages that will match as related content.

### 1. The fix — classic theme, block on a page

* Activate a **classic** theme (e.g. Twenty Twenty-One).
* Edit a **Page** (not a post), add a **Related Posts** block, and publish.
* View the Page on the frontend.
  * **Before this PR:** related posts render as an unstyled vertical list — full-width images, visible "Date"/"Author" labels, no grid.
  * **After this PR:** related posts render with their normal grid styling, and a `jetpack_related-posts` stylesheet is present on the page.

### 2. Block inserted via a Site Editor template (block theme)

This is a different insertion path than "block inside post content", and it's the path #39784 was tested against.

* Switch to a **block** theme (e.g. Twenty Twenty-Five).
* Go to Appearance → Editor → Templates → **Single Posts**, add a Related Posts block at the bottom, and save.
* Go to Appearance → Editor → Templates → **Pages**, add a Related Posts block at the bottom, and save.
* View the frontend of both a post and a page → related posts should render **styled** in both.

### 3. AMP

The AMP path is the only other caller of the changed method.

* With the AMP plugin active (or `?amp` on a supported setup), view a post that shows related posts.
* Confirm the related posts are **styled** (CSS is inlined for AMP) and the page still validates.

### 4. Regression checks (behavior should be unchanged)

* **Classic theme + block on a single _post_:** still styled, and there is exactly **one** `jetpack_related-posts` stylesheet on the page (no double-enqueue).
* **Block theme + block in post and page content:** still styled.
* **Automatic insertion** (Related Posts enabled in Settings → Reading, **no** block, classic theme, single post): related posts still appear at the bottom of the post, styled.
* **Classic theme, pages _without_ the block:** still show **no** auto-inserted related posts (guards #39783).
* **Shortcode** `[jetpack-related-posts]` on a single post: still renders as before.

### 5. Nice-to-have

* **RTL locale** (e.g. Hebrew): the RTL stylesheet loads for the block.
* **Page Optimize active** (the plugin present on the reported site): the block's CSS still applies after style concatenation.
* **Block on a page with no available related posts** (fresh site): the block renders nothing and no stray `jetpack_related-posts` stylesheet is loaded.

**Automated:** `jetpack docker phpunit jetpack -- --filter=Jetpack_RelatedPosts_Test` → `OK (5 tests, 8 assertions)`.
