### PR TITLE
Forms: keep Form Responses admin bar link visible on mobile

### DIFF
--- a/projects/packages/forms/changelog/fix-dsgcom-595-form-responses-masterbar-mobile
+++ b/projects/packages/forms/changelog/fix-dsgcom-595-form-responses-masterbar-mobile
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the Form Responses quick link disappearing from the admin bar on mobile viewports, and align its icon with the native items.

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1310,6 +1310,16 @@ class Contact_Form extends Contact_Form_Shortcode {
 				),
 			)
 		);
+
+		// On viewports <=782px, WordPress core hides every top-level admin bar item except a hardcoded
+		// allowlist of core nodes, so our custom node disappears. Re-show it and size the icon to match the
+		// native items (52px-wide box, centered ~28px glyph). The `.ab-icon` overrides use !important because
+		// the SVG carries its desktop sizing in an inline style attribute, which otherwise wins the cascade.
+		echo '<style>@media screen and (max-width: 782px){' .
+			'#wpadminbar li#wp-admin-bar-jetpack-forms{display:block;}' .
+			'#wpadminbar li#wp-admin-bar-jetpack-forms>.ab-item{display:flex;align-items:center;justify-content:center;width:52px;padding:0;}' .
+			'#wpadminbar li#wp-admin-bar-jetpack-forms .ab-icon{width:28px!important;height:28px!important;top:0!important;margin:0!important;}' .
+			'}</style>';
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1311,14 +1311,21 @@ class Contact_Form extends Contact_Form_Shortcode {
 			)
 		);
 
-		// On viewports <=782px, WordPress core hides every top-level admin bar item except a hardcoded
-		// allowlist of core nodes, so our custom node disappears. Re-show it and size the icon to match the
-		// native items (52px-wide box, centered ~28px glyph). The `.ab-icon` overrides use !important because
-		// the SVG carries its desktop sizing in an inline style attribute, which otherwise wins the cascade.
-		// Match the dimmed icon color core applies to its own mobile items; the SVG fills with currentColor.
-		echo '<style>@media screen and (max-width: 782px){' .
+		// The SVG fills with currentColor, which inherits the item's full-brightness text color, so the icon
+		// renders brighter than the native admin bar icons -- core dims those to rgba(240,246,252,0.6) at every
+		// width. Fade it to 0.6 opacity to match, and restore full opacity on hover/focus like core does; using
+		// opacity (rather than a hardcoded color) keeps the hover state tracking the user's admin color scheme.
+		//
+		// The <=782px block handles core hiding every non-allowlisted top-level item on mobile: re-show ours and
+		// size the icon to the native touch target (52px box, centered 28px glyph). The `.ab-icon` sizing uses
+		// !important because the SVG carries its desktop sizing in an inline style attribute that otherwise wins.
+		echo '<style>' .
+			'#wpadminbar #wp-admin-bar-jetpack-forms .ab-icon{opacity:0.6;}' .
+			'#wpadminbar #wp-admin-bar-jetpack-forms:hover .ab-icon,' .
+			'#wpadminbar #wp-admin-bar-jetpack-forms .ab-item:focus .ab-icon{opacity:1;}' .
+			'@media screen and (max-width: 782px){' .
 			'#wpadminbar li#wp-admin-bar-jetpack-forms{display:block;}' .
-			'#wpadminbar li#wp-admin-bar-jetpack-forms>.ab-item{display:flex;align-items:center;justify-content:center;width:52px;padding:0;color:rgba(240,246,252,0.6);}' .
+			'#wpadminbar li#wp-admin-bar-jetpack-forms>.ab-item{display:flex;align-items:center;justify-content:center;width:52px;padding:0;}' .
 			'#wpadminbar li#wp-admin-bar-jetpack-forms .ab-icon{width:28px!important;height:28px!important;top:0!important;margin:0!important;}' .
 			'}</style>';
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1315,9 +1315,10 @@ class Contact_Form extends Contact_Form_Shortcode {
 		// allowlist of core nodes, so our custom node disappears. Re-show it and size the icon to match the
 		// native items (52px-wide box, centered ~28px glyph). The `.ab-icon` overrides use !important because
 		// the SVG carries its desktop sizing in an inline style attribute, which otherwise wins the cascade.
+		// Match the dimmed icon color core applies to its own mobile items; the SVG fills with currentColor.
 		echo '<style>@media screen and (max-width: 782px){' .
 			'#wpadminbar li#wp-admin-bar-jetpack-forms{display:block;}' .
-			'#wpadminbar li#wp-admin-bar-jetpack-forms>.ab-item{display:flex;align-items:center;justify-content:center;width:52px;padding:0;}' .
+			'#wpadminbar li#wp-admin-bar-jetpack-forms>.ab-item{display:flex;align-items:center;justify-content:center;width:52px;padding:0;color:rgba(240,246,252,0.6);}' .
 			'#wpadminbar li#wp-admin-bar-jetpack-forms .ab-icon{width:28px!important;height:28px!important;top:0!important;margin:0!important;}' .
 			'}</style>';
 	}

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1311,13 +1311,15 @@ class Contact_Form extends Contact_Form_Shortcode {
 			)
 		);
 
-		// The SVG fills with currentColor, which inherits the item's full-brightness text color, so the icon
-		// renders brighter than the native admin bar icons -- core dims those to rgba(240,246,252,0.6) at every
-		// width. Fade it to 0.6 opacity to match, and restore full opacity on hover/focus like core does; using
-		// opacity (rather than a hardcoded color) keeps the hover state tracking the user's admin color scheme.
+		// The icon SVG fills with currentColor. On desktop it inherits the item's full-brightness text color, so
+		// it renders brighter than the native admin bar icons -- core dims those to rgba(240,246,252,0.6) via
+		// `.ab-icon::before` rules our SVG can't match. Fade it to 0.6 opacity to match, and restore full opacity
+		// on hover/focus; using opacity (not a hardcoded color) keeps the hover state tracking the user's admin
+		// color scheme accent, like the native icons. On mobile (<=782px) core instead dims the item's own text
+		// color, which the SVG already inherits, so reset opacity to 1 there to avoid dimming the icon twice.
 		//
-		// The <=782px block handles core hiding every non-allowlisted top-level item on mobile: re-show ours and
-		// size the icon to the native touch target (52px box, centered 28px glyph). The `.ab-icon` sizing uses
+		// The <=782px block also handles core hiding every non-allowlisted top-level item on mobile: re-show ours
+		// and size the icon to the native touch target (52px box, centered 28px glyph). The `.ab-icon` sizing uses
 		// !important because the SVG carries its desktop sizing in an inline style attribute that otherwise wins.
 		echo '<style>' .
 			'#wpadminbar #wp-admin-bar-jetpack-forms .ab-icon{opacity:0.6;}' .
@@ -1326,7 +1328,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'@media screen and (max-width: 782px){' .
 			'#wpadminbar li#wp-admin-bar-jetpack-forms{display:block;}' .
 			'#wpadminbar li#wp-admin-bar-jetpack-forms>.ab-item{display:flex;align-items:center;justify-content:center;width:52px;padding:0;}' .
-			'#wpadminbar li#wp-admin-bar-jetpack-forms .ab-icon{width:28px!important;height:28px!important;top:0!important;margin:0!important;}' .
+			'#wpadminbar li#wp-admin-bar-jetpack-forms .ab-icon{width:28px!important;height:28px!important;top:0!important;margin:0!important;opacity:1;}' .
 			'}</style>';
 	}
 


### PR DESCRIPTION
Fixes DSGCOM-595

## Proposed changes
* The "Form Responses" quick link that Jetpack Forms adds to the admin bar on singular pages containing a form was disappearing on mobile viewports (≤782px). WordPress core's `admin-bar.css` hides every top-level admin bar item below 782px and only re-shows a hardcoded allowlist of core node IDs; the custom `jetpack-forms` node was never on that list.
* Emit a small, scoped `<style>` alongside the node that re-shows `#wp-admin-bar-jetpack-forms` on mobile. The selector carries two IDs, so it beats core's single-ID hiding rule on specificity (no `!important` needed for the un-hide).
* Size the icon to match the native mobile items: the anchor becomes a 52px-wide flex box centering a 28px SVG glyph, mirroring core's 52×46 icon boxes. The `.ab-icon` overrides use `!important` because the SVG carries its desktop sizing in an inline `style` attribute, which otherwise wins the cascade.
* Desktop rendering (icon + "Form Responses" label) is unchanged — everything lives inside `@media (max-width: 782px)`.

## Related product discussion/links
* https://linear.app/a8c/issue/DSGCOM-595

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a site with Jetpack (or the standalone Jetpack Forms plugin) active, publish a page/post that contains a Jetpack Form and includes a form block, and make sure you're logged in as a user who can `edit_pages`.
* View that page on the front end at a **desktop** width (>782px). Confirm the admin bar shows the "Form Responses" item with its icon and text label, as before.
* Narrow the browser to a **mobile** width (≤782px), e.g. 430px, and reload.
  * **Before:** the Form Responses item is absent from the admin bar.
  * **After:** the Form Responses icon appears in the admin bar, the same size and vertical alignment as the native icons (Edit, New, Comments, etc.), with the text label hidden like the native items.
* Tapping the icon still opens the Form Responses (Feedback) dashboard.
