### PR TITLE
Forms/AI: keep the AI guideline "Learn more" link on one line

### DIFF
--- a/projects/js-packages/ai-client/changelog/fix-ai-assistant-learn-more
+++ b/projects/js-packages/ai-client/changelog/fix-ai-assistant-learn-more
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI guideline message: keep the "Learn more" link on a single line on narrow/mobile widths

--- a/projects/js-packages/ai-client/src/components/message/style.scss
+++ b/projects/js-packages/ai-client/src/components/message/style.scss
@@ -38,9 +38,15 @@
 			padding: 0;
 		}
 
+		// The "Learn more" guideline link is a @wordpress/ui <Link>, which renders
+		// a plain <a> with hashed WPDS classes (not .components-external-link), so
+		// target it by element. Keep the link on a single line and stop it from
+		// shrinking so "Learn more" never wraps mid-phrase on narrow/mobile widths.
 		.components-button.is-link,
-		.components-external-link {
+		.components-external-link,
+		a {
 			flex-shrink: 0;
+			white-space: nowrap;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #

Fixes DSGCOM-689.

## Proposed changes
* Keeps the "Learn more" link in the AI generation guideline footer (`AI-generated content could be inaccurate or biased. Learn more`) on a single line, so it no longer wraps mid-phrase on narrow/mobile widths.
* Root cause: the footer is a `display: flex` row and the SCSS protected the link with `flex-shrink: 0` scoped to `.components-external-link`. PR #48529 swapped the `@wordpress/components` `ExternalLink` for a `@wordpress/ui` `<Link>`, which renders a plain `<a>` with hashed WPDS classes (no `.components-external-link`), so the guard silently stopped matching and the link was free to shrink and wrap.
* Fix targets the link **by element** (`a`) — the WPDS classes are hashed and unsafe to hook — and adds `white-space: nowrap` so it always stays on one line. The long disclaimer sibling absorbs the wrapping instead.
* Single change in the shared `@automattic/jetpack-ai-client` `Message` component, so it fixes every surface that renders the guideline: the Forms block AI generation, the AI Assistant block, and the AI Assistant paragraph extension.

## Related product discussion/links
* https://linear.app/a8c/issue/DSGCOM-689/jetpack-forms-fix-weird-line-breaks-on-mobile

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a site with a paid plan (Jetpack AI available), narrow the browser to a mobile width (or use responsive/device mode).
* In the block editor, add a **Form** block — the AI generation space shows the helper footer "AI-generated content could be inaccurate or biased. Learn more".
* Confirm the "Learn more" link stays on **one line** and does not break between "Learn" and "more".
* Repeat with the **AI Assistant** block and the **AI Assistant** paragraph extension (toolbar "Ask AI Assistant") — the guideline footer there should behave the same.
* Note: this CSS is bundled into the Jetpack plugin editor build (`_inc/blocks/editor-beta.css`); rebuild the **Jetpack plugin** (`pnpm --filter='jetpack' watch` or `pnpm run build-extensions` in `projects/plugins/jetpack`) and hard-reload the editor to see the change.

| Before | After |
| - | - |
| <img width="381" height="683" alt="Screenshot from 2026-07-10 17-03-31" src="https://github.com/user-attachments/assets/9ed34dea-6e87-4b8f-a678-fbd244b785c2" /> | <img width="381" height="683" alt="Screenshot from 2026-07-10 16-55-22" src="https://github.com/user-attachments/assets/708b770c-9908-425d-9699-0c967c873fd3" /> |
