### PR TITLE
Forms: surface common fields first in the block inserter

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-inserter-priority-order
+++ b/projects/packages/forms/changelog/fix-forms-inserter-priority-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Block editor: surface the most common fields (Name, Email, Text…) first in the form's block inserter instead of burying them past the quick-inserter cutoff.

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -124,17 +124,17 @@ const ALLOWED_FORM_BLOCKS = ALLOWED_BLOCKS.concat( CORE_BLOCKS ).filter(
 // "+" inside a form) shows only the first 6 prioritized blocks, and that
 // prioritized order fully overrides Gutenberg's usage-based "most used"
 // ranking. Deriving the order from child-blocks.js alone buried the most
-// commonly used fields (Name, Email, Text…) past the 6-item cutoff while
+// commonly used fields (Name, Email, Textarea…) past the 6-item cutoff while
 // surfacing incidental ones like Hidden. List the common fields explicitly
 // here; the remaining valid fields follow in their child-blocks.js order. See
 // DSGCOM-690.
 const FEATURED_INSERTER_FIELDS = [
 	'jetpack/field-name',
 	'jetpack/field-email',
-	'jetpack/field-text',
 	'jetpack/field-textarea',
+	'jetpack/field-text',
+	'jetpack/field-telephone',
 	'jetpack/field-select',
-	'jetpack/field-checkbox',
 ];
 
 const PRIORITIZED_INSERTER_BLOCKS = ( () => {

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -120,7 +120,30 @@ const ALLOWED_FORM_BLOCKS = ALLOWED_BLOCKS.concat( CORE_BLOCKS ).filter(
 	block => ! REMOVE_FIELDS_FROM_FORM.includes( block )
 );
 
-const PRIORITIZED_INSERTER_BLOCKS = [ ...validFields.map( block => `jetpack/${ block.name }` ) ];
+// Fields surfaced first in the block inserter. The quick inserter (the inline
+// "+" inside a form) shows only the first 6 prioritized blocks, and that
+// prioritized order fully overrides Gutenberg's usage-based "most used"
+// ranking. Deriving the order from child-blocks.js alone buried the most
+// commonly used fields (Name, Email, Text…) past the 6-item cutoff while
+// surfacing incidental ones like Hidden. List the common fields explicitly
+// here; the remaining valid fields follow in their child-blocks.js order. See
+// DSGCOM-690.
+const FEATURED_INSERTER_FIELDS = [
+	'jetpack/field-name',
+	'jetpack/field-email',
+	'jetpack/field-text',
+	'jetpack/field-textarea',
+	'jetpack/field-select',
+	'jetpack/field-checkbox',
+];
+
+const PRIORITIZED_INSERTER_BLOCKS = ( () => {
+	const validFieldNames = validFields.map( block => `jetpack/${ block.name }` );
+	return [
+		...FEATURED_INSERTER_FIELDS.filter( name => validFieldNames.includes( name ) ),
+		...validFieldNames.filter( name => ! FEATURED_INSERTER_FIELDS.includes( name ) ),
+	];
+} )();
 
 // Determine if a block has a required attribute. Exclude hidden fields.
 const isInputWithRequiredField = ( fullName?: string ): boolean => {


### PR DESCRIPTION
Fixes DSGCOM-690

## Proposed changes

When adding a field inside a Form block, the inline "quick inserter" (the `+` between fields) shows only **6** blocks. That set is driven by the Form block's `prioritizedInserterBlocks` setting, which **overrides** Gutenberg's usage-based ("most used"/frecency) ordering for those slots — so the visible fields are fully deterministic, not per-user.

Until now that list was derived from the raw array order in `child-blocks.js`, which happened to surface incidental fields (Checkbox, Consent, Date, Dropdown, **Hidden**, Email) and pushed the most commonly used fields — **Name** (~8th), **Text** (~11th) — past the 6-item cutoff. They never appeared by default no matter how often a user inserted them.

* Add an explicit `FEATURED_INSERTER_FIELDS` order — **Name, Email, Text, Textarea, Select (Dropdown), Checkbox** — used to build `PRIORITIZED_INSERTER_BLOCKS`.
* Remaining valid fields follow after the featured ones in their existing `child-blocks.js` order, so nothing is removed — only the top 6 change.
* No behavior change to `allowedBlocks` or anything else; the constant is only consumed by `useInnerBlocksProps` for inserter ordering.

## Related product discussion/links

* Linear: DSGCOM-690

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Create or edit a post/page and add a **Form** block.
* Click the inline `+` appender inside the form (the quick inserter) — do **not** type in the search box.
* **Before:** the 6 default blocks include *Hidden field* and omit *Name*/*Text*.
* **After:** the first 6 are **Name, Email, Text, Textarea, Dropdown (Select), Checkbox**, in that order.
* Confirm the order is identical on a brand-new site and on a heavily-used one (it is deterministic and not affected by usage history).
* Typing in the search box still surfaces every field (e.g. search "hidden" → Hidden field) — only the default ordering changed.
