### PR TITLE
VideoPress: reuse attachment title, description & caption when promoting a Media Library video

### DIFF
--- a/projects/packages/videopress/changelog/add-videopress-library-upload-title
+++ b/projects/packages/videopress/changelog/add-videopress-library-upload-title
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Reuse the attachment title, description and caption for the VideoPress video when promoting an existing Media Library video with the "Upload to VideoPress" action, instead of only the file name.
+Media Library: reuse the attachment title, description and caption for the VideoPress video when promoting a video with the "Upload to VideoPress" action, instead of only the file name.

--- a/projects/packages/videopress/changelog/add-videopress-library-upload-title
+++ b/projects/packages/videopress/changelog/add-videopress-library-upload-title
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Reuse the attachment title as the VideoPress video title when promoting an existing Media Library video with the "Upload to VideoPress" action, instead of the file name.
+Reuse the attachment title, description and caption for the VideoPress video when promoting an existing Media Library video with the "Upload to VideoPress" action, instead of only the file name.

--- a/projects/packages/videopress/changelog/add-videopress-library-upload-title
+++ b/projects/packages/videopress/changelog/add-videopress-library-upload-title
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Reuse the attachment title as the VideoPress video title when promoting an existing Media Library video with the "Upload to VideoPress" action, instead of the file name.

--- a/projects/packages/videopress/src/class-uploader.php
+++ b/projects/packages/videopress/src/class-uploader.php
@@ -210,6 +210,7 @@ class Uploader {
 		}
 		try {
 			$this->get_client()->file( $this->get_file_path(), $this->get_file_name() );
+			$this->get_client()->add_metadata( 'title', get_the_title( $this->attachment_id ) );
 
 			$bytes_uploaded = $this->get_client()->upload( self::CHUNK_SIZE );
 

--- a/projects/packages/videopress/src/class-uploader.php
+++ b/projects/packages/videopress/src/class-uploader.php
@@ -209,10 +209,18 @@ class Uploader {
 			return $this->check_status();
 		}
 		try {
-			$this->get_client()->file( $this->get_file_path(), $this->get_file_name() );
-			$this->get_client()->add_metadata( 'title', get_the_title( $this->attachment_id ) );
+			$attachment = get_post( $this->attachment_id );
+			$client     = $this->get_client();
+			$client->file( $this->get_file_path(), $this->get_file_name() );
+			$client->add_metadata( 'title', get_the_title( $this->attachment_id ) );
+			if ( '' !== $attachment->post_content ) {
+				$client->add_metadata( 'description', $attachment->post_content );
+			}
+			if ( '' !== $attachment->post_excerpt ) {
+				$client->add_metadata( 'caption', $attachment->post_excerpt );
+			}
 
-			$bytes_uploaded = $this->get_client()->upload( self::CHUNK_SIZE );
+			$bytes_uploaded = $client->upload( self::CHUNK_SIZE );
 
 			if ( $bytes_uploaded === $this->get_file_size() ) {
 				$this->mark_as_uploaded( $this->get_client()->get_uploaded_video_details()['media_id'] );

--- a/projects/packages/videopress/src/class-uploader.php
+++ b/projects/packages/videopress/src/class-uploader.php
@@ -212,7 +212,7 @@ class Uploader {
 			$attachment = get_post( $this->attachment_id );
 			$client     = $this->get_client();
 			$client->file( $this->get_file_path(), $this->get_file_name() );
-			$client->add_metadata( 'title', get_the_title( $this->attachment_id ) );
+			$client->add_metadata( 'title', $attachment->post_title );
 			if ( '' !== $attachment->post_content ) {
 				$client->add_metadata( 'description', $attachment->post_content );
 			}

--- a/projects/packages/videopress/src/class-xmlrpc.php
+++ b/projects/packages/videopress/src/class-xmlrpc.php
@@ -89,7 +89,7 @@ class XMLRPC {
 
 		foreach ( $media as & $media_item ) {
 			$url   = is_string( $media_item['url'] ?? null ) ? $media_item['url'] : '';
-			$title = ! empty( $media_item['title'] )
+			$title = isset( $media_item['title'] ) && '' !== $media_item['title']
 				? sanitize_text_field( $media_item['title'] )
 				: sanitize_title( basename( $url ) );
 			$guid  = $media['guid'] ?? null;
@@ -97,10 +97,10 @@ class XMLRPC {
 			$media_id = videopress_create_new_media_item( $title, $guid );
 
 			$post_update = array();
-			if ( ! empty( $media_item['description'] ) ) {
+			if ( isset( $media_item['description'] ) && '' !== $media_item['description'] ) {
 				$post_update['post_content'] = sanitize_textarea_field( $media_item['description'] );
 			}
-			if ( ! empty( $media_item['caption'] ) ) {
+			if ( isset( $media_item['caption'] ) && '' !== $media_item['caption'] ) {
 				$post_update['post_excerpt'] = sanitize_textarea_field( $media_item['caption'] );
 			}
 			if ( $post_update ) {

--- a/projects/packages/videopress/src/class-xmlrpc.php
+++ b/projects/packages/videopress/src/class-xmlrpc.php
@@ -95,6 +95,18 @@ class XMLRPC {
 
 			$media_id = videopress_create_new_media_item( $title, $guid );
 
+			$post_update = array();
+			if ( ! empty( $media_item['description'] ) ) {
+				$post_update['post_content'] = sanitize_textarea_field( $media_item['description'] );
+			}
+			if ( ! empty( $media_item['caption'] ) ) {
+				$post_update['post_excerpt'] = sanitize_textarea_field( $media_item['caption'] );
+			}
+			if ( $post_update ) {
+				$post_update['ID'] = $media_id;
+				wp_update_post( $post_update );
+			}
+
 			wp_update_attachment_metadata(
 				$media_id,
 				array(

--- a/projects/packages/videopress/src/class-xmlrpc.php
+++ b/projects/packages/videopress/src/class-xmlrpc.php
@@ -88,9 +88,10 @@ class XMLRPC {
 		$this->authenticate_user();
 
 		foreach ( $media as & $media_item ) {
+			$url   = is_string( $media_item['url'] ?? null ) ? $media_item['url'] : '';
 			$title = ! empty( $media_item['title'] )
 				? sanitize_text_field( $media_item['title'] )
-				: sanitize_title( basename( $media_item['url'] ) );
+				: sanitize_title( basename( $url ) );
 			$guid  = $media['guid'] ?? null;
 
 			$media_id = videopress_create_new_media_item( $title, $guid );

--- a/projects/packages/videopress/src/class-xmlrpc.php
+++ b/projects/packages/videopress/src/class-xmlrpc.php
@@ -88,7 +88,9 @@ class XMLRPC {
 		$this->authenticate_user();
 
 		foreach ( $media as & $media_item ) {
-			$title = sanitize_title( basename( $media_item['url'] ) );
+			$title = ! empty( $media_item['title'] )
+				? sanitize_text_field( $media_item['title'] )
+				: sanitize_title( basename( $media_item['url'] ) );
 			$guid  = $media['guid'] ?? null;
 
 			$media_id = videopress_create_new_media_item( $title, $guid );

--- a/projects/packages/videopress/tests/php/VideoPress_Uploader_Test.php
+++ b/projects/packages/videopress/tests/php/VideoPress_Uploader_Test.php
@@ -197,7 +197,7 @@ class VideoPress_Uploader_Test extends BaseTestCase {
 		wp_update_post(
 			array(
 				'ID'           => $this->valid_attachment_id,
-				'post_title'   => 'My Edited Video Title',
+				'post_title'   => 'She said "hello"',
 				'post_content' => 'My video description',
 				'post_excerpt' => 'My video caption',
 			)
@@ -216,7 +216,15 @@ class VideoPress_Uploader_Test extends BaseTestCase {
 
 		$uploader->upload();
 
-		$this->assertSame( 'My Edited Video Title', $mock_client->metadata['title'] ?? null );
+		$title = $mock_client->metadata['title'] ?? '';
+
+		/*
+		 * The raw stored title is sent verbatim. Reading it through get_the_title() would apply the
+		 * the_title display filters (wptexturize, convert_chars), turning the quote into an HTML
+		 * entity such as &#8221; that then leaks into the VideoPress video title.
+		 */
+		$this->assertStringContainsString( '"', $title );
+		$this->assertStringNotContainsString( '&#', $title );
 		$this->assertSame( 'My video description', $mock_client->metadata['description'] ?? null );
 		$this->assertSame( 'My video caption', $mock_client->metadata['caption'] ?? null );
 	}

--- a/projects/packages/videopress/tests/php/VideoPress_Uploader_Test.php
+++ b/projects/packages/videopress/tests/php/VideoPress_Uploader_Test.php
@@ -208,6 +208,7 @@ class VideoPress_Uploader_Test extends BaseTestCase {
 		// Swap in a client double so the upload does not touch the network.
 		$mock_client = new Mock_Tus_Client();
 		$client_prop = new \ReflectionProperty( Uploader::class, 'client' );
+		$client_prop->setAccessible( true );
 		$client_prop->setValue( $uploader, $mock_client );
 
 		$uploader->upload();
@@ -236,6 +237,7 @@ class VideoPress_Uploader_Test extends BaseTestCase {
 
 		$mock_client = new Mock_Tus_Client();
 		$client_prop = new \ReflectionProperty( Uploader::class, 'client' );
+		$client_prop->setAccessible( true );
 		$client_prop->setValue( $uploader, $mock_client );
 
 		$uploader->upload();

--- a/projects/packages/videopress/tests/php/VideoPress_Uploader_Test.php
+++ b/projects/packages/videopress/tests/php/VideoPress_Uploader_Test.php
@@ -188,16 +188,18 @@ class VideoPress_Uploader_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Tests that the upload attaches the attachment title as tus metadata, so VideoPress
-	 * can reuse the Media Library title instead of the file name.
+	 * Tests that the upload attaches the attachment title, description and caption as tus
+	 * metadata, so VideoPress can reuse the Media Library values instead of the file name.
 	 */
-	public function test_upload_sends_attachment_title_as_metadata() {
+	public function test_upload_sends_attachment_meta_as_metadata() {
 		require_once __DIR__ . '/mocks/class-mock-tus-client.php';
 
 		wp_update_post(
 			array(
-				'ID'         => $this->valid_attachment_id,
-				'post_title' => 'My Edited Video Title',
+				'ID'           => $this->valid_attachment_id,
+				'post_title'   => 'My Edited Video Title',
+				'post_content' => 'My video description',
+				'post_excerpt' => 'My video caption',
 			)
 		);
 
@@ -210,8 +212,37 @@ class VideoPress_Uploader_Test extends BaseTestCase {
 
 		$uploader->upload();
 
+		$this->assertSame( 'My Edited Video Title', $mock_client->metadata['title'] ?? null );
+		$this->assertSame( 'My video description', $mock_client->metadata['description'] ?? null );
+		$this->assertSame( 'My video caption', $mock_client->metadata['caption'] ?? null );
+	}
+
+	/**
+	 * Tests that empty description and caption are not sent as tus metadata.
+	 */
+	public function test_upload_omits_empty_description_and_caption() {
+		require_once __DIR__ . '/mocks/class-mock-tus-client.php';
+
+		wp_update_post(
+			array(
+				'ID'           => $this->valid_attachment_id,
+				'post_title'   => 'My Edited Video Title',
+				'post_content' => '',
+				'post_excerpt' => '',
+			)
+		);
+
+		$uploader = new Uploader( $this->valid_attachment_id );
+
+		$mock_client = new Mock_Tus_Client();
+		$client_prop = new \ReflectionProperty( Uploader::class, 'client' );
+		$client_prop->setValue( $uploader, $mock_client );
+
+		$uploader->upload();
+
 		$this->assertArrayHasKey( 'title', $mock_client->metadata );
-		$this->assertSame( 'My Edited Video Title', $mock_client->metadata['title'] );
+		$this->assertArrayNotHasKey( 'description', $mock_client->metadata );
+		$this->assertArrayNotHasKey( 'caption', $mock_client->metadata );
 	}
 
 	/**

--- a/projects/packages/videopress/tests/php/VideoPress_Uploader_Test.php
+++ b/projects/packages/videopress/tests/php/VideoPress_Uploader_Test.php
@@ -188,6 +188,33 @@ class VideoPress_Uploader_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Tests that the upload attaches the attachment title as tus metadata, so VideoPress
+	 * can reuse the Media Library title instead of the file name.
+	 */
+	public function test_upload_sends_attachment_title_as_metadata() {
+		require_once __DIR__ . '/mocks/class-mock-tus-client.php';
+
+		wp_update_post(
+			array(
+				'ID'         => $this->valid_attachment_id,
+				'post_title' => 'My Edited Video Title',
+			)
+		);
+
+		$uploader = new Uploader( $this->valid_attachment_id );
+
+		// Swap in a client double so the upload does not touch the network.
+		$mock_client = new Mock_Tus_Client();
+		$client_prop = new \ReflectionProperty( Uploader::class, 'client' );
+		$client_prop->setValue( $uploader, $mock_client );
+
+		$uploader->upload();
+
+		$this->assertArrayHasKey( 'title', $mock_client->metadata );
+		$this->assertSame( 'My Edited Video Title', $mock_client->metadata['title'] );
+	}
+
+	/**
 	 * Tests the get_upload_token method
 	 */
 	public function test_get_upload_token_disconnected() {

--- a/projects/packages/videopress/tests/php/VideoPress_Uploader_Test.php
+++ b/projects/packages/videopress/tests/php/VideoPress_Uploader_Test.php
@@ -208,7 +208,10 @@ class VideoPress_Uploader_Test extends BaseTestCase {
 		// Swap in a client double so the upload does not touch the network.
 		$mock_client = new Mock_Tus_Client();
 		$client_prop = new \ReflectionProperty( Uploader::class, 'client' );
-		$client_prop->setAccessible( true );
+		// setAccessible() is required before PHP 8.1 and deprecated as a no-op from PHP 8.5.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$client_prop->setAccessible( true );
+		}
 		$client_prop->setValue( $uploader, $mock_client );
 
 		$uploader->upload();
@@ -237,7 +240,10 @@ class VideoPress_Uploader_Test extends BaseTestCase {
 
 		$mock_client = new Mock_Tus_Client();
 		$client_prop = new \ReflectionProperty( Uploader::class, 'client' );
-		$client_prop->setAccessible( true );
+		// setAccessible() is required before PHP 8.1 and deprecated as a no-op from PHP 8.5.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$client_prop->setAccessible( true );
+		}
 		$client_prop->setValue( $uploader, $mock_client );
 
 		$uploader->upload();

--- a/projects/packages/videopress/tests/php/XMLRPC_Test.php
+++ b/projects/packages/videopress/tests/php/XMLRPC_Test.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Tests for the VideoPress XMLRPC class.
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+use PHPUnit\Framework\Attributes\BeforeClass;
+use WorDBless\BaseTestCase;
+use WorDBless\Posts;
+
+/**
+ * Class to test the VideoPress XMLRPC class.
+ */
+class XMLRPC_Test extends BaseTestCase {
+
+	/**
+	 * Sets up the test environment before the class tests begin.
+	 *
+	 * @beforeClass
+	 */
+	#[BeforeClass]
+	public static function set_up_class() {
+		require_once __DIR__ . '/../../src/utility-functions.php';
+		Posts::init();
+	}
+
+	/**
+	 * The media item title supplied by the uploader is used as the attachment post_title.
+	 */
+	public function test_create_media_item_uses_supplied_title() {
+		$media = array(
+			array(
+				'url'   => 'https://videopress.com/v/original-file-name.mp4',
+				'title' => 'Edited Library Title',
+			),
+		);
+
+		$result = XMLRPC::init()->create_media_item( $media );
+
+		$this->assertSame( 'Edited Library Title', $result['media'][0]['post']->post_title );
+	}
+
+	/**
+	 * When no title is supplied, the attachment falls back to a title derived from the file name.
+	 */
+	public function test_create_media_item_falls_back_to_file_name() {
+		$media = array(
+			array(
+				'url' => 'https://videopress.com/v/original-file-name.mp4',
+			),
+		);
+
+		$result = XMLRPC::init()->create_media_item( $media );
+
+		$this->assertSame( sanitize_title( 'original-file-name.mp4' ), $result['media'][0]['post']->post_title );
+	}
+}

--- a/projects/packages/videopress/tests/php/XMLRPC_Test.php
+++ b/projects/packages/videopress/tests/php/XMLRPC_Test.php
@@ -28,19 +28,24 @@ class XMLRPC_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The media item title supplied by the uploader is used as the attachment post_title.
+	 * The media item title, description and caption supplied by the uploader are applied to the
+	 * created attachment.
 	 */
-	public function test_create_media_item_uses_supplied_title() {
+	public function test_create_media_item_uses_supplied_meta() {
 		$media = array(
 			array(
-				'url'   => 'https://videopress.com/v/original-file-name.mp4',
-				'title' => 'Edited Library Title',
+				'url'         => 'https://videopress.com/v/original-file-name.mp4',
+				'title'       => 'Edited Library Title',
+				'description' => 'Edited library description',
+				'caption'     => 'Edited library caption',
 			),
 		);
 
-		$result = XMLRPC::init()->create_media_item( $media );
+		$post = XMLRPC::init()->create_media_item( $media )['media'][0]['post'];
 
-		$this->assertSame( 'Edited Library Title', $result['media'][0]['post']->post_title );
+		$this->assertSame( 'Edited Library Title', $post->post_title );
+		$this->assertSame( 'Edited library description', $post->post_content );
+		$this->assertSame( 'Edited library caption', $post->post_excerpt );
 	}
 
 	/**

--- a/projects/packages/videopress/tests/php/XMLRPC_Test.php
+++ b/projects/packages/videopress/tests/php/XMLRPC_Test.php
@@ -49,6 +49,20 @@ class XMLRPC_Test extends BaseTestCase {
 	}
 
 	/**
+	 * A supplied title of "0" is treated as a real title, not as a missing value.
+	 */
+	public function test_create_media_item_keeps_zero_string_title() {
+		$media = array(
+			array(
+				'url'   => 'https://videopress.com/v/original-file-name.mp4',
+				'title' => '0',
+			),
+		);
+
+		$this->assertSame( '0', XMLRPC::init()->create_media_item( $media )['media'][0]['post']->post_title );
+	}
+
+	/**
 	 * When no title is supplied, the attachment falls back to a title derived from the file name.
 	 */
 	public function test_create_media_item_falls_back_to_file_name() {

--- a/projects/packages/videopress/tests/php/mocks/class-mock-tus-client.php
+++ b/projects/packages/videopress/tests/php/mocks/class-mock-tus-client.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Mock Tus client for testing the VideoPress Uploader without network access.
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+/**
+ * Records the metadata attached by the Uploader and skips the real upload.
+ */
+class Mock_Tus_Client {
+
+	/**
+	 * The metadata attached to the upload, keyed by metadata name.
+	 *
+	 * @var array
+	 */
+	public $metadata = array();
+
+	/**
+	 * Records the file, mirroring Tus_Client::file().
+	 *
+	 * @param string      $file File path.
+	 * @param string|null $name File name.
+	 * @return Mock_Tus_Client
+	 */
+	public function file( $file, $name = null ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return $this;
+	}
+
+	/**
+	 * Records a metadata value, mirroring Tus_Client::add_metadata().
+	 *
+	 * @param string $key   The metadata name.
+	 * @param string $value The metadata value.
+	 * @return Mock_Tus_Client
+	 */
+	public function add_metadata( $key, $value ) {
+		$this->metadata[ $key ] = $value;
+		return $this;
+	}
+
+	/**
+	 * Pretends to upload, returning a partial byte count so the Uploader reports "uploading".
+	 *
+	 * @param int $bytes The chunk size.
+	 * @return int
+	 */
+	public function upload( $bytes = -1 ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return 0;
+	}
+}


### PR DESCRIPTION
Fixes JETPACK-1881

## Proposed changes

When a video already in the Media Library is promoted to VideoPress via the **"Upload to VideoPress"** action (dashboard row action / block editor "use existing attachment" branch — the server-side `Uploader` path, *not* the direct browser upload of a local file), the resulting VideoPress video's title was always derived from the file name, ignoring any title/description/caption the user had set on the attachment.

* Attach the attachment's title, description (`post_content`) and caption (`post_excerpt`) as tus upload metadata in `Uploader::upload()`. Description and caption are only sent when non-empty.
* Read those values back in the `jetpack.createMediaItem` XML-RPC callback (`XMLRPC::create_media_item()`) and apply them to the created VideoPress attachment, falling back to the file-name-derived title when no title is supplied.
* Add PHP test coverage for both the send side (metadata attached, empty fields omitted) and the receive side (supplied meta applied, file-name fallback).

**Note:** This is the Jetpack half of the change. The wpcom VideoPress upload/transcoding backend must (a) read the new `title`/`description`/`caption` keys out of the tus `Upload-Metadata` header and (b) echo them back in the `createMediaItem` payload for the values to reach the video end-to-end. Until that lands, this is a no-op fallback (behavior unchanged).

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This exercises the "promote an existing Media Library video to VideoPress" flow, which requires the paired wpcom backend change to observe the end result. The Jetpack-side behavior is covered by unit tests:

* From `projects/packages/videopress`, run `composer phpunit -- --filter 'XMLRPC_Test|VideoPress_Uploader_Test'` and confirm all tests pass.
* Manual (with the wpcom backend change in place):
  * Upload a plain video to the Media Library, then edit its Title, Caption and Description.
  * Trigger **Upload to VideoPress** on that attachment (VideoPress dashboard row action, or select it in a VideoPress block).
  * Confirm the resulting VideoPress video uses the edited title/description/caption rather than the file name.
  * Repeat with the title/description/caption left at defaults and confirm the title falls back to the file name and no empty description/caption are sent.
