### PR TITLE
VideoPress: decode HTML entities in dashboard video titles

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-admin-title-entities
+++ b/projects/packages/videopress/changelog/fix-videopress-admin-title-entities
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: Decode HTML entities in video titles so they no longer display as raw entities (e.g. `&#8217;`) in the dashboard library and video details header.

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-library.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-library.test.ts
@@ -105,4 +105,26 @@ describe( 'useLibrary', () => {
 		expect( result.current.paginationInfo.totalItems ).toBe( 1 );
 		expect( result.current.paginationInfo.totalPages ).toBe( 1 );
 	} );
+
+	it( 'decodes HTML entities in the rendered title', async () => {
+		const body = JSON.stringify( [
+			{ id: 7, title: { rendered: 'Molly&#8217;s &#8220;Best&#8221; Day' } },
+		] );
+		const responseHeaders: Record< string, string > = {
+			'X-WP-Total': '1',
+			'X-WP-TotalPages': '1',
+			'Content-Type': 'application/json',
+		};
+		mockApiFetch( async () => ( {
+			headers: { get: ( name: string ) => responseHeaders[ name ] ?? null },
+			json: async () => JSON.parse( body ),
+		} ) );
+
+		const { result } = renderHook( () => useLibrary( DEFAULT_VIEW ), {
+			wrapper: createTestWrapper(),
+		} );
+
+		await waitFor( () => expect( result.current.items.length ).toBeGreaterThan( 0 ) );
+		expect( result.current.items[ 0 ].title ).toBe( 'Molly’s “Best” Day' );
+	} );
 } );

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-video.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-video.test.ts
@@ -54,6 +54,20 @@ describe( 'useVideo', () => {
 		expect( result.current.video?.tracks ).toEqual( [] );
 	} );
 
+	it( 'decodes HTML entities in the rendered title', async () => {
+		mockApiFetch( async () => ( {
+			id: 42,
+			title: { rendered: 'Molly&#8217;s &#8220;Best&#8221; Day' },
+			jetpack_videopress: { guid: 'g' },
+			media_details: { videopress: { poster: 'https://example.com/p.jpg', finished: true } },
+		} ) );
+
+		const { result } = renderHook( () => useVideo( 42 ), { wrapper: createTestWrapper() } );
+
+		await waitFor( () => expect( result.current.video ).toBeDefined() );
+		expect( result.current.video?.title ).toBe( 'Molly’s “Best” Day' );
+	} );
+
 	it( 'maps an item without VideoPress data to a local item with defaults', async () => {
 		mockApiFetch( async () => ( {
 			id: 7,

--- a/projects/packages/videopress/src/dashboard/hooks/use-library.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-library.ts
@@ -1,5 +1,6 @@
 import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
+import { decodeEntities } from '@wordpress/html-entities';
 import { addQueryArgs } from '@wordpress/url';
 import { flattenVideoTracks } from '../../client/lib/video-tracks';
 import { buildShortcode } from '../utils/format';
@@ -175,7 +176,7 @@ function toLibraryItem( raw: ApiMediaItem ): LibraryItem {
 		id: String( raw.id ),
 		guid: vp?.guid ?? '',
 		type: isVideoPress ? 'videopress' : 'local',
-		title: raw.title?.rendered ?? raw.slug ?? '',
+		title: decodeEntities( raw.title?.rendered ?? raw.slug ?? '' ),
 		filename: raw.source_url?.split( '/' ).pop() ?? '',
 		thumbnailUrl: poster ?? null,
 		durationSeconds,

--- a/projects/packages/videopress/src/dashboard/hooks/use-video.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-video.ts
@@ -1,6 +1,7 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import { useCallback } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 import { flattenVideoTracks } from '../../client/lib/video-tracks';
 import { buildShortcode } from '../utils/format';
 import { LIBRARY_ITEM_QUERY_SEGMENT, LIBRARY_QUERY_KEY, privacyIntToString } from './use-library';
@@ -50,7 +51,7 @@ function toLibraryItem( raw: ApiMediaItem ): LibraryItem {
 		id: String( raw.id ),
 		guid: vp?.guid ?? '',
 		type: isVideoPress ? 'videopress' : 'local',
-		title: raw.title?.rendered ?? '',
+		title: decodeEntities( raw.title?.rendered ?? '' ),
 		filename: raw.source_url?.split( '/' ).pop() ?? '',
 		thumbnailUrl: poster ?? null,
 		durationSeconds,


### PR DESCRIPTION
Fixes #

## Proposed changes
* Fixes video titles rendering HTML entities literally (e.g. `Gotte&#8217;s Hand`, `Land&#8221;`) in the VideoPress dashboard.
* Root cause: the new routes-based dashboard hooks map WP core's `title.rendered` (which is HTML-encoded) straight into the UI without decoding. This affects the library grid cards, the video-details header/breadcrumb, and the TITLE input.
* Decode `title.rendered` with `@wordpress/html-entities` in `src/dashboard/hooks/use-video.ts` and `src/dashboard/hooks/use-library.ts`.
* Adds unit tests to both hooks covering entity decoding.

Note: an earlier revision of this PR patched the legacy `src/client/admin` store (`map-videos.ts`), but that path reads the already-decoded `jetpack_videopress.title` and is not what the shipped dashboard uses — that change has been reverted so the diff is scoped to the real fix.

## Testing instructions
* On a site running the VideoPress dashboard, have a video whose title contains a character WordPress texturizes/encodes — e.g. a curly apostrophe or quote: `Das schönste Land" in den Gau'n` (returned by the REST API as `Das schönste Land&#8221; in den Gau&#8217;n`).
* Go to **Jetpack → VideoPress → Library**.
  * **Before:** the card title shows literal entities (`…Land&#8221; in den Gau&#8217;n`).
  * **After:** it shows the decoded title (`…Land" in den Gau'n`).
* Open the video's details page.
  * Confirm the **breadcrumb** header and the **TITLE** input both show the decoded title, not `&#8221;`/`&#8217;`.
* Verified live on a Jurassic Ninja site (edit page breadcrumb + title input, and the library grid card).

## Does this pull request change what data or activity we track or use?
No.
