### PR TITLE
docs: document re-running the WordPress.com Tests CI check via context-a8c

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,6 +230,16 @@ PR descriptions MUST follow the template in `.github/PULL_REQUEST_TEMPLATE.md` â
 gh pr create --title "Title" --body-file pr-body.md --label "[Status] Needs Review" --label "Enhancement" --assignee @me
 ```
 
+### Re-running CI Checks
+
+Most CI checks can be re-run with the usual `gh` commands (e.g. `gh run rerun <run-id> --failed`, or `gh pr checks`).
+
+The exception is the **WordPress.com Tests** check (the TeamCity `JetpackPreFlightChecks_BasicChecks` build). It cannot be restarted via the GitHub UI or the `gh` CLI. When that check fails on something unrelated to your change, re-trigger it with the context-a8c command:
+
+```
+/context-a8c:rerun-jetpack-preflight <PR-number>
+```
+
 ## Code Review Guidelines
 
 When reviewing code, check for:


### PR DESCRIPTION
## Proposed changes
* Adds a "Re-running CI Checks" subsection to `AGENTS.md` so coding agents are aware of the newly announced ability to re-run the **WordPress.com Tests** check (the TeamCity `JetpackPreFlightChecks_BasicChecks` build) — which can't be restarted via the GitHub UI or the `gh` CLI. Agents now know to use `/context-a8c:rerun-jetpack-preflight <PR-number>` for that one check and keep using the usual `gh` commands for everything else.

## Related product discussion/links
* pdWQjU-1Ch-p2

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Read the new "Re-running CI Checks" subsection under "Pull Requests" in `AGENTS.md` and confirm it accurately describes the command.
