### PR TITLE
AI settings: add a Feature Clip toggle

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-settings.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-settings.php
@@ -54,6 +54,7 @@ class Jetpack_AI_Settings {
 		'writing_assistant' => 'jetpack_ai_writing_assistant_enabled',
 		'image_editor'      => 'jetpack_ai_image_editor_enabled',
 		'image_label'       => 'jetpack_ai_image_label_enabled',
+		'feature_clip'      => 'jetpack_ai_feature_clip_enabled',
 		'seo_enhancer'      => 'ai_seo_enhancer_enabled',
 		'ai_search'         => 'jetpack_search_ai_answers_enabled',
 	);
@@ -68,6 +69,7 @@ class Jetpack_AI_Settings {
 		'writing_assistant' => true,
 		'image_editor'      => true,
 		'image_label'       => true,
+		'feature_clip'      => true,
 		'seo_enhancer'      => false,
 		'ai_search'         => false,
 	);
@@ -78,7 +80,7 @@ class Jetpack_AI_Settings {
 	 *
 	 * @var array
 	 */
-	const OWNED_FEATURES = array( 'writing_assistant', 'image_editor', 'image_label' );
+	const OWNED_FEATURES = array( 'writing_assistant', 'image_editor', 'image_label', 'feature_clip' );
 
 	/**
 	 * Whether init() has already run.
@@ -124,6 +126,7 @@ class Jetpack_AI_Settings {
 			self::FEATURE_OPTIONS['writing_assistant'] => __( 'Whether the Jetpack AI writing assistant is enabled.', 'jetpack' ),
 			self::FEATURE_OPTIONS['image_editor']      => __( 'Whether the Jetpack AI image editor is enabled.', 'jetpack' ),
 			self::FEATURE_OPTIONS['image_label']       => __( 'Whether images generated with Jetpack AI are marked as AI-generated.', 'jetpack' ),
+			self::FEATURE_OPTIONS['feature_clip']      => __( 'Whether Jetpack AI video clip generation is enabled.', 'jetpack' ),
 		);
 
 		foreach ( $options as $option => $description ) {

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai-feature-settings.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai-feature-settings.php
@@ -54,7 +54,7 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings extends WP_REST_Controller 
 	 *
 	 * @var string[]
 	 */
-	const FEATURE_KEYS = array( 'writing_assistant', 'image_editor', 'image_label', 'seo_enhancer', 'ai_search' );
+	const FEATURE_KEYS = array( 'writing_assistant', 'image_editor', 'image_label', 'feature_clip', 'seo_enhancer', 'ai_search' );
 
 	/**
 	 * Constructor.
@@ -202,6 +202,7 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings extends WP_REST_Controller 
 						),
 					),
 				),
+				'feature_clip'      => array( 'enabled' => $stored['feature_clip'] ),
 				'seo_enhancer'      => array( 'enabled' => $stored['seo_enhancer'] ),
 				'ai_search'         => array(
 					'enabled'          => $stored['ai_search'],

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-feature-clip-toggle
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-feature-clip-toggle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Assistant: add a Feature Clip toggle to the AI feature settings.

--- a/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
+++ b/projects/plugins/jetpack/extensions/plugins/image-studio/image-studio.php
@@ -163,6 +163,13 @@ function image_studio_can_generate_video_clips() {
 		return false;
 	}
 
+	// The Feature Clip toggle on the AI settings page wins over every
+	// environment-based enable below: off must mean no clip generation,
+	// even where Image Studio itself stays available.
+	if ( ! \Jetpack_AI_Settings::is_feature_enabled( 'feature_clip' ) ) {
+		return false;
+	}
+
 	if ( function_exists( 'wpcom_site_can_upload_videos' ) && ! wpcom_site_can_upload_videos() ) {
 		return false;
 	}

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Options_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Options_Test.php
@@ -278,6 +278,7 @@ class Jetpack_Sync_Options_Test extends Jetpack_Sync_TestBase {
 			'jetpack_ai_writing_assistant_enabled'         => false,
 			'jetpack_ai_image_editor_enabled'              => false,
 			'jetpack_ai_image_label_enabled'               => false,
+			'jetpack_ai_feature_clip_enabled'              => false,
 			'jetpack_ai_agents_enabled'                    => false,
 			'wpcom_classic_early_release'                  => true,
 			'jetpack_newsletters_publishing_default_frequency' => 'weekly',


### PR DESCRIPTION
Fixes # adds feature clips to #50287

## Proposed changes

* Adds a `feature_clip` toggle to the AI feature settings: new `jetpack_ai_feature_clip_enabled` option (default on), exposed through the `feature-settings` endpoint.
* Enforces it in `image_studio_can_generate_video_clips()`, so toggling it off stops clip generation everywhere — the client already reads that via `canGenerateVideoClips`, no JS changes needed.
* Also adds the sync-test fixture entries the new whitelisted options need (including the five from the base branch — drop that hunk if you've fixed it already).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `wp option update jetpack_ai_feature_clip_enabled 0` -> in the editor, Image Studio should stop offering clip generation (`window.imageStudioData.canGenerateVideoClips` -> `false`); Image Studio itself stays available
* `GET wpcom/v2/jetpack-ai/feature-settings` -> response includes `features.feature_clip` - POST toggles it
