### PR TITLE
WOOA7S-1696: Premium Analytics: add the Referrers report at /reports/referrers

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-wooa7s-1696-referrers-report-page
+++ b/projects/packages/premium-analytics/changelog/add-wooa7s-1696-referrers-report-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add the Referrers report at `/reports/referrers`.

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -111,9 +111,11 @@ export {
 } from './hooks/use-stats-visits';
 export {
 	bucketStatsTimeSeries,
+	flattenStatsLeaves,
 	getStatsChartBucketKey,
 	sliceWordAdsStatsReport,
 } from './processing/stats';
+export type { FlattenStatsLeavesContext, FlattenStatsLeavesOptions } from './processing/stats';
 export {
 	useStatsSummary,
 	type StatsSummaryParams,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/utils.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/utils.test.ts
@@ -1,6 +1,7 @@
 import { combineStatsNormalizedReports, sanitizeStatsTopPostsResponse } from '..';
 import { topPostsFixture, topPostsSummaryFixture } from '../__fixtures__/top-posts';
 import {
+	flattenStatsLeaves,
 	getStatsLabel,
 	getStatsSummaryIntervalFields,
 	mergeStatsComparisonRows,
@@ -111,5 +112,41 @@ describe( 'Stats report utilities', () => {
 
 		expect( result.hasComparison ).toBe( true );
 		expect( result.rows[ 0 ].previousValue ).toBe( 0 );
+	} );
+
+	describe( 'flattenStatsLeaves', () => {
+		type Node = { label: string; children?: Node[] | null };
+
+		const flatten = ( items: Node[] ) =>
+			flattenStatsLeaves( items, {
+				getChildren: item => item.children,
+				mapLeaf: ( item, { ancestors, indexPath } ) => ( {
+					label: item.label,
+					path: ancestors.map( ancestor => ancestor.label ),
+					indexPath,
+				} ),
+			} );
+
+		it( 'maps hierarchy leaves with their ancestor chain and index path', () => {
+			const rows = flatten( [
+				{
+					label: 'group',
+					children: [ { label: 'leaf-a' }, { label: 'branch', children: [ { label: 'leaf-b' } ] } ],
+				},
+				{ label: 'leaf-c', children: null },
+			] );
+
+			expect( rows ).toEqual( [
+				{ label: 'leaf-a', path: [ 'group' ], indexPath: [ 0, 0 ] },
+				{ label: 'leaf-b', path: [ 'group', 'branch' ], indexPath: [ 0, 1, 0 ] },
+				{ label: 'leaf-c', path: [], indexPath: [ 1 ] },
+			] );
+		} );
+
+		it( 'treats items with empty child lists as leaves', () => {
+			expect( flatten( [ { label: 'solo', children: [] } ] ) ).toEqual( [
+				{ label: 'solo', path: [], indexPath: [ 0 ] },
+			] );
+		} );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -1,10 +1,15 @@
 export {
 	combineStatsNormalizedReports,
+	flattenStatsLeaves,
 	mergeStatsComparisonRows,
 	sanitizeStatsPassthroughResponse,
 	sanitizeStatsSiteResponse,
 } from './utils';
-export type { StatsComparisonRowContext } from './utils';
+export type {
+	FlattenStatsLeavesContext,
+	FlattenStatsLeavesOptions,
+	StatsComparisonRowContext,
+} from './utils';
 export { bucketStatsTimeSeries, getStatsChartBucketKey } from './chart-buckets';
 export type { StatsChartBucketPeriod } from './chart-buckets';
 export { mergeStatsTopPostsComparisonRows, sanitizeStatsTopPostsResponse } from './top-posts';

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/utils.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/utils.ts
@@ -125,6 +125,61 @@ export function mergeStatsComparisonRows< TPrimary, TComparison = TPrimary, TMap
 	return { rows, hasComparison };
 }
 
+export type FlattenStatsLeavesContext< TItem > = {
+	/**
+	 * Ancestor items from the report root down to the leaf's parent.
+	 */
+	ancestors: TItem[];
+	/**
+	 * The item's index at each level, from the root list down to the leaf.
+	 */
+	indexPath: number[];
+};
+
+export type FlattenStatsLeavesOptions< TItem, TRow > = {
+	/**
+	 * Read an item's child items.
+	 */
+	getChildren: ( item: TItem ) => readonly TItem[] | null | undefined;
+	/**
+	 * Map a leaf item to a table row.
+	 */
+	mapLeaf: ( item: TItem, context: FlattenStatsLeavesContext< TItem > ) => TRow;
+};
+
+/**
+ * Flatten a nested report hierarchy into one row per leaf, depth-first.
+ *
+ * DataViews tables do not support nested rows yet, so report tables show only
+ * the hierarchy leaves. Each leaf's ancestor chain and index path are passed
+ * to `mapLeaf` so callers can derive group labels, inherited icons, or stable
+ * row ids.
+ *
+ * @param items               - The top-level report items.
+ * @param options             - The traversal callbacks.
+ * @param options.getChildren - Read an item's child items.
+ * @param options.mapLeaf     - Map a leaf item to a table row.
+ * @return One mapped row per hierarchy leaf.
+ */
+export function flattenStatsLeaves< TItem, TRow >(
+	items: readonly TItem[],
+	{ getChildren, mapLeaf }: FlattenStatsLeavesOptions< TItem, TRow >
+): TRow[] {
+	const walk = ( item: TItem, ancestors: TItem[], indexPath: number[] ): TRow[] => {
+		const children = getChildren( item ) ?? [];
+
+		if ( children.length ) {
+			return children.flatMap( ( child, index ) =>
+				walk( child, [ ...ancestors, item ], [ ...indexPath, index ] )
+			);
+		}
+
+		return [ mapLeaf( item, { ancestors, indexPath } ) ];
+	};
+
+	return items.flatMap( ( item, index ) => walk( item, [], [ index ] ) );
+}
+
 function isStatsNumericSummaryValue( value: unknown ): boolean {
 	return (
 		typeof value === 'number' ||

--- a/projects/packages/premium-analytics/routes/reports/posts/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/posts/config/fields.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import {
+	flattenStatsLeaves,
 	useSiteHomeUrl,
 	type StatsArchivesItem,
 	type StatsTopPostsItem,
@@ -124,39 +125,6 @@ function getArchiveFallbackLabel( parts: string[] ): string {
 }
 
 /**
- * Flatten one normalized archive item to leaf table rows.
- *
- * @param item - The normalized archive item.
- * @param path - Parent archive labels.
- * @param id   - Stable ID prefix for the item.
- * @return Leaf archive rows for the table.
- */
-function flattenArchiveEntry( item: StatsArchivesItem, path: string[], id: string ): ArchiveRow[] {
-	const label = String( item.label ?? '' );
-	const nextPath = label ? [ ...path, label ] : path;
-	const children = item.children ?? [];
-
-	if ( children.length ) {
-		return children.flatMap( ( child, index ) =>
-			flattenArchiveEntry( child, nextPath, `${ id }-${ index }` )
-		);
-	}
-
-	const link = typeof item.link === 'string' ? item.link : undefined;
-
-	return [
-		{
-			id,
-			label: link
-				? getArchiveLinkLabel( link ) ?? getArchiveFallbackLabel( nextPath )
-				: getArchiveFallbackLabel( nextPath ),
-			views: item.value,
-			link,
-		},
-	];
-}
-
-/**
  * Flatten the archives report groups into table rows. The backend groups
  * archive entries by type/taxonomy; DataViews does not show nested rows yet,
  * so the table shows only the leaf archive entries and labels them by URL
@@ -166,9 +134,23 @@ function flattenArchiveEntry( item: StatsArchivesItem, path: string[], id: strin
  * @return The flat rows.
  */
 export function flattenArchiveRows( items: StatsArchivesItem[] ): ArchiveRow[] {
-	return items.flatMap( ( group, groupIndex ) =>
-		flattenArchiveEntry( group, [], `${ String( group.label ) }-${ groupIndex }` )
-	);
+	return flattenStatsLeaves< StatsArchivesItem, ArchiveRow >( items, {
+		getChildren: item => item.children,
+		mapLeaf: ( item, { ancestors, indexPath } ) => {
+			const link = typeof item.link === 'string' ? item.link : undefined;
+			const pathLabels = [ ...ancestors, item ].map( entry => String( entry.label ?? '' ) );
+			const rootLabel = String( ( ancestors[ 0 ] ?? item ).label ?? '' );
+
+			return {
+				id: [ rootLabel, ...indexPath ].join( '-' ),
+				label: link
+					? getArchiveLinkLabel( link ) ?? getArchiveFallbackLabel( pathLabels )
+					: getArchiveFallbackLabel( pathLabels ),
+				views: item.value,
+				link,
+			};
+		},
+	} );
 }
 
 /**

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/aggregate.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/aggregate.test.ts
@@ -1,0 +1,115 @@
+import { aggregateReferrerRows, flattenReferrerRows, referrersToTimeSeries } from './aggregate';
+import type { StatsNormalizedReport, StatsReferrersItem } from '@jetpack-premium-analytics/data';
+
+const searchEngines: StatsReferrersItem = {
+	label: 'Search Engines',
+	views: 12,
+	link: null,
+	icon: null,
+	labelIcon: null,
+	children: [
+		{
+			label: 'Google Search',
+			views: 12,
+			link: null,
+			icon: null,
+			labelIcon: null,
+			children: [
+				{
+					label: 'google.com',
+					views: 12,
+					link: 'https://www.google.com/',
+					icon: null,
+					labelIcon: 'external',
+					children: null,
+				},
+			],
+		},
+	],
+};
+
+describe( 'report referrers aggregate', () => {
+	it( 'flattens hierarchy leaves and preserves the full parent path as the group', () => {
+		expect( flattenReferrerRows( [ searchEngines ] ) ).toEqual( [
+			{
+				id: '["Search Engines / Google Search","google.com","https://www.google.com/"]',
+				label: 'google.com',
+				group: 'Search Engines / Google Search',
+				views: 12,
+				link: 'https://www.google.com/',
+			},
+		] );
+	} );
+
+	it( 'keeps ungrouped leaf referrers as top-level rows', () => {
+		const direct: StatsReferrersItem = {
+			label: 'jetpack.com',
+			views: 4,
+			link: 'https://jetpack.com/',
+			icon: null,
+			labelIcon: 'external',
+			children: null,
+		};
+
+		expect( flattenReferrerRows( [ direct ] ) ).toEqual( [
+			{
+				id: '["","jetpack.com","https://jetpack.com/"]',
+				label: 'jetpack.com',
+				group: '',
+				views: 4,
+				link: 'https://jetpack.com/',
+			},
+		] );
+	} );
+
+	it( 'uses top-level totals for chart buckets and aggregates table leaves across buckets', () => {
+		const report: StatsNormalizedReport< StatsReferrersItem > = {
+			summary: {},
+			data: [
+				{
+					time_interval: '2026-06-01',
+					date_start: '2026-06-01T00:00:00+00:00',
+					date_end: '2026-06-01T23:59:59+00:00',
+					items: [ searchEngines ],
+				},
+				{
+					time_interval: '2026-06-02',
+					date_start: '2026-06-02T00:00:00+00:00',
+					date_end: '2026-06-02T23:59:59+00:00',
+					items: [
+						{
+							...searchEngines,
+							views: 8,
+							children: [
+								{
+									...searchEngines.children![ 0 ],
+									views: 8,
+									children: [
+										{
+											...searchEngines.children![ 0 ].children![ 0 ],
+											views: 8,
+										},
+									],
+								},
+							],
+						},
+					],
+				},
+			],
+		};
+
+		const series = referrersToTimeSeries( report );
+		expect( series.data.map( point => point.views ) ).toEqual( [ 12, 8 ] );
+		expect( series.summary ).toEqual( {
+			date_start: '2026-06-01T00:00:00+00:00',
+			date_end: '2026-06-02T23:59:59+00:00',
+		} );
+		expect( aggregateReferrerRows( report ) ).toEqual( [
+			expect.objectContaining( {
+				label: 'google.com',
+				group: 'Search Engines / Google Search',
+				views: 20,
+			} ),
+		] );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/aggregate.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/aggregate.test.ts
@@ -12,7 +12,7 @@ const searchEngines: StatsReferrersItem = {
 			label: 'Google Search',
 			views: 12,
 			link: null,
-			icon: null,
+			icon: 'https://icons.example/google.png',
 			labelIcon: null,
 			children: [
 				{
@@ -64,7 +64,7 @@ const bucketedReport: StatsNormalizedReport< StatsReferrersItem > = {
 };
 
 describe( 'report referrers aggregate', () => {
-	it( 'flattens hierarchy leaves and preserves the full parent path as the group', () => {
+	it( 'flattens hierarchy leaves, keeps the parent path as the group, and inherits ancestor icons', () => {
 		expect( flattenReferrerRows( [ searchEngines ] ) ).toEqual( [
 			{
 				id: '["Search Engines / Google Search","google.com","https://www.google.com/"]',
@@ -72,16 +72,17 @@ describe( 'report referrers aggregate', () => {
 				group: 'Search Engines / Google Search',
 				views: 12,
 				link: 'https://www.google.com/',
+				icon: 'https://icons.example/google.png',
 			},
 		] );
 	} );
 
-	it( 'keeps ungrouped leaf referrers as top-level rows', () => {
+	it( 'keeps ungrouped leaf referrers as top-level rows with their own icon', () => {
 		const direct: StatsReferrersItem = {
 			label: 'jetpack.com',
 			views: 4,
 			link: 'https://jetpack.com/',
-			icon: null,
+			icon: 'https://icons.example/jetpack.png',
 			labelIcon: 'external',
 			children: null,
 		};
@@ -93,6 +94,7 @@ describe( 'report referrers aggregate', () => {
 				group: '',
 				views: 4,
 				link: 'https://jetpack.com/',
+				icon: 'https://icons.example/jetpack.png',
 			},
 		] );
 	} );

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/aggregate.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/aggregate.test.ts
@@ -28,6 +28,41 @@ const searchEngines: StatsReferrersItem = {
 	],
 };
 
+const bucketedReport: StatsNormalizedReport< StatsReferrersItem > = {
+	summary: {},
+	data: [
+		{
+			time_interval: '2026-06-01',
+			date_start: '2026-06-01T00:00:00+00:00',
+			date_end: '2026-06-01T23:59:59+00:00',
+			items: [ searchEngines ],
+		},
+		{
+			time_interval: '2026-06-02',
+			date_start: '2026-06-02T00:00:00+00:00',
+			date_end: '2026-06-02T23:59:59+00:00',
+			items: [
+				{
+					...searchEngines,
+					views: 8,
+					children: [
+						{
+							...searchEngines.children![ 0 ],
+							views: 8,
+							children: [
+								{
+									...searchEngines.children![ 0 ].children![ 0 ],
+									views: 8,
+								},
+							],
+						},
+					],
+				},
+			],
+		},
+	],
+};
+
 describe( 'report referrers aggregate', () => {
 	it( 'flattens hierarchy leaves and preserves the full parent path as the group', () => {
 		expect( flattenReferrerRows( [ searchEngines ] ) ).toEqual( [
@@ -63,51 +98,42 @@ describe( 'report referrers aggregate', () => {
 	} );
 
 	it( 'uses top-level totals for chart buckets and aggregates table leaves across buckets', () => {
-		const report: StatsNormalizedReport< StatsReferrersItem > = {
-			summary: {},
-			data: [
-				{
-					time_interval: '2026-06-01',
-					date_start: '2026-06-01T00:00:00+00:00',
-					date_end: '2026-06-01T23:59:59+00:00',
-					items: [ searchEngines ],
-				},
-				{
-					time_interval: '2026-06-02',
-					date_start: '2026-06-02T00:00:00+00:00',
-					date_end: '2026-06-02T23:59:59+00:00',
-					items: [
-						{
-							...searchEngines,
-							views: 8,
-							children: [
-								{
-									...searchEngines.children![ 0 ],
-									views: 8,
-									children: [
-										{
-											...searchEngines.children![ 0 ].children![ 0 ],
-											views: 8,
-										},
-									],
-								},
-							],
-						},
-					],
-				},
-			],
-		};
-
-		const series = referrersToTimeSeries( report );
+		const series = referrersToTimeSeries( bucketedReport, 'day' );
 		expect( series.data.map( point => point.views ) ).toEqual( [ 12, 8 ] );
 		expect( series.summary ).toEqual( {
 			date_start: '2026-06-01T00:00:00+00:00',
 			date_end: '2026-06-02T23:59:59+00:00',
 		} );
-		expect( aggregateReferrerRows( report ) ).toEqual( [
+		expect( aggregateReferrerRows( bucketedReport ) ).toEqual( [
 			expect.objectContaining( {
 				label: 'google.com',
 				group: 'Search Engines / Google Search',
+				views: 20,
+			} ),
+		] );
+	} );
+
+	it( 'groups daily totals into ISO weeks for the chart', () => {
+		const series = referrersToTimeSeries( bucketedReport, 'week' );
+
+		expect( series.data ).toEqual( [
+			expect.objectContaining( {
+				time_interval: '2026-06-01',
+				date_start: '2026-06-01T00:00:00+00:00',
+				date_end: '2026-06-02T23:59:59+00:00',
+				views: 20,
+			} ),
+		] );
+	} );
+
+	it( 'groups daily totals into calendar months for the chart', () => {
+		const series = referrersToTimeSeries( bucketedReport, 'month' );
+
+		expect( series.data ).toEqual( [
+			expect.objectContaining( {
+				time_interval: '2026-06-01',
+				date_start: '2026-06-01T00:00:00+00:00',
+				date_end: '2026-06-02T23:59:59+00:00',
 				views: 20,
 			} ),
 		] );

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/aggregate.ts
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/aggregate.ts
@@ -1,0 +1,119 @@
+/**
+ * Internal dependencies
+ */
+import type { ReferrerRecord } from './fields';
+import type {
+	StatsNormalizedReport,
+	StatsReferrersItem,
+	StatsTimeSeriesReport,
+} from '@jetpack-premium-analytics/data';
+
+const GROUP_SEPARATOR = ' / ';
+
+/**
+ * Build one table row for every leaf in a referrer hierarchy. DataViews does
+ * not currently support nested table rows, so the parent path is retained in
+ * the Group field instead.
+ *
+ * @param item       - The current referrer item.
+ * @param parentPath - Parent labels from the report root to this item.
+ * @return Flattened leaf rows.
+ */
+function flattenReferrerItem( item: StatsReferrersItem, parentPath: string[] ): ReferrerRecord[] {
+	const label = String( item.label ?? '' );
+	const children = item.children ?? [];
+
+	if ( children.length ) {
+		const nextPath = label ? [ ...parentPath, label ] : parentPath;
+
+		return children.flatMap( child => flattenReferrerItem( child, nextPath ) );
+	}
+
+	const link = typeof item.link === 'string' ? item.link : undefined;
+	const group = parentPath.join( GROUP_SEPARATOR );
+	const id = JSON.stringify( [ group, label, link ?? null ] );
+
+	return [
+		{
+			id,
+			label,
+			group,
+			views: item.views,
+			link,
+		},
+	];
+}
+
+/**
+ * Flatten one bucket's referrer hierarchy into leaf table rows.
+ *
+ * @param items - Top-level referrer items.
+ * @return Flattened leaf rows.
+ */
+export function flattenReferrerRows( items: StatsReferrersItem[] ): ReferrerRecord[] {
+	return items.flatMap( item => flattenReferrerItem( item, [] ) );
+}
+
+/**
+ * Build the views-over-time chart from a bucketed referrers report.
+ *
+ * Top-level values already represent each group's complete total, so summing
+ * that level avoids counting the same hierarchy at every nested level.
+ *
+ * @param report - The bucketed referrers report.
+ * @return The chart-ready time series.
+ */
+export function referrersToTimeSeries(
+	report: StatsNormalizedReport< StatsReferrersItem > | undefined
+): StatsTimeSeriesReport {
+	const data = ( report?.data ?? [] ).map( point => {
+		const views = point.items.reduce( ( total, item ) => total + item.views, 0 );
+
+		return {
+			time_interval: point.time_interval,
+			date_start: point.date_start,
+			date_end: point.date_end,
+			label: point.time_interval,
+			items: [],
+			value: views,
+			views,
+		};
+	} );
+	const first = data[ 0 ];
+	const last = data[ data.length - 1 ];
+
+	return {
+		summary: {
+			...report?.summary,
+			...( first ? { date_start: first.date_start } : {} ),
+			...( last ? { date_end: last.date_end } : {} ),
+		},
+		data,
+	};
+}
+
+/**
+ * Aggregate bucketed referrers into one table row per hierarchy leaf.
+ *
+ * @param report - The bucketed referrers report.
+ * @return Aggregated table rows.
+ */
+export function aggregateReferrerRows(
+	report?: StatsNormalizedReport< StatsReferrersItem >
+): ReferrerRecord[] {
+	const byKey = new Map< string, ReferrerRecord >();
+
+	for ( const point of report?.data ?? [] ) {
+		for ( const row of flattenReferrerRows( point.items ) ) {
+			const existing = byKey.get( row.id );
+
+			if ( existing ) {
+				existing.views += row.views;
+			} else {
+				byKey.set( row.id, { ...row } );
+			}
+		}
+	}
+
+	return [ ...byKey.values() ];
+}

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/aggregate.ts
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/aggregate.ts
@@ -3,6 +3,7 @@
  */
 import {
 	bucketStatsTimeSeries,
+	flattenStatsLeaves,
 	type StatsChartBucketPeriod,
 	type StatsNormalizedReport,
 	type StatsReferrersItem,
@@ -16,47 +17,47 @@ import type { ReferrerRecord } from './fields';
 const GROUP_SEPARATOR = ' / ';
 
 /**
- * Build one table row for every leaf in a referrer hierarchy. DataViews does
- * not currently support nested table rows, so the parent path is retained in
- * the Group field instead.
+ * Read a referrer item's display label.
  *
- * @param item       - The current referrer item.
- * @param parentPath - Parent labels from the report root to this item.
- * @return Flattened leaf rows.
+ * @param item - The referrer item.
+ * @return The item label.
  */
-function flattenReferrerItem( item: StatsReferrersItem, parentPath: string[] ): ReferrerRecord[] {
-	const label = String( item.label ?? '' );
-	const children = item.children ?? [];
-
-	if ( children.length ) {
-		const nextPath = label ? [ ...parentPath, label ] : parentPath;
-
-		return children.flatMap( child => flattenReferrerItem( child, nextPath ) );
-	}
-
-	const link = typeof item.link === 'string' ? item.link : undefined;
-	const group = parentPath.join( GROUP_SEPARATOR );
-	const id = JSON.stringify( [ group, label, link ?? null ] );
-
-	return [
-		{
-			id,
-			label,
-			group,
-			views: item.views,
-			link,
-		},
-	];
+function getReferrerLabel( item: StatsReferrersItem ): string {
+	return String( item.label ?? '' );
 }
 
 /**
- * Flatten one bucket's referrer hierarchy into leaf table rows.
+ * Flatten one bucket's referrer hierarchy into leaf table rows. DataViews does
+ * not currently support nested table rows, so the parent path is retained in
+ * the Group field instead.
  *
  * @param items - Top-level referrer items.
  * @return Flattened leaf rows.
  */
 export function flattenReferrerRows( items: StatsReferrersItem[] ): ReferrerRecord[] {
-	return items.flatMap( item => flattenReferrerItem( item, [] ) );
+	return flattenStatsLeaves< StatsReferrersItem, ReferrerRecord >( items, {
+		getChildren: item => item.children,
+		mapLeaf: ( item, { ancestors } ) => {
+			const label = getReferrerLabel( item );
+			const link = typeof item.link === 'string' ? item.link : undefined;
+			const group = ancestors.map( getReferrerLabel ).filter( Boolean ).join( GROUP_SEPARATOR );
+			// Leaves inherit the closest ancestor favicon, like the dashboard
+			// widget (e.g. Google Search → google.com keeps the Google icon).
+			const icon =
+				item.icon ??
+				[ ...ancestors ].reverse().find( ancestor => ancestor.icon )?.icon ??
+				undefined;
+
+			return {
+				id: JSON.stringify( [ group, label, link ?? null ] ),
+				label,
+				group,
+				views: item.views,
+				link,
+				icon,
+			};
+		},
+	} );
 }
 
 /**

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/aggregate.ts
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/aggregate.ts
@@ -1,42 +1,19 @@
 /**
+ * External dependencies
+ */
+import {
+	bucketStatsTimeSeries,
+	type StatsChartBucketPeriod,
+	type StatsNormalizedReport,
+	type StatsReferrersItem,
+	type StatsTimeSeriesReport,
+} from '@jetpack-premium-analytics/data';
+/**
  * Internal dependencies
  */
 import type { ReferrerRecord } from './fields';
-import type {
-	StatsNormalizedReport,
-	StatsPeriod,
-	StatsReferrersItem,
-	StatsTimeSeriesReport,
-} from '@jetpack-premium-analytics/data';
 
 const GROUP_SEPARATOR = ' / ';
-type ReferrerChartPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
-
-/**
- * Map a daily bucket date onto its chart bucket key for the selected period —
- * the date itself for days, the start of the ISO week for weeks, and the
- * first-of-month date (`YYYY-MM-01`) for months.
- *
- * @param date   - The daily bucket date (`YYYY-MM-DD`).
- * @param period - The chart bucket period.
- * @return The bucket key the date aggregates into.
- */
-function getChartBucketKey( date: string, period: ReferrerChartPeriod ): string {
-	if ( period === 'day' ) {
-		return date;
-	}
-
-	const bucketDate = new Date( `${ date.slice( 0, 10 ) }T00:00:00Z` );
-
-	if ( period === 'week' ) {
-		const daysSinceMonday = ( bucketDate.getUTCDay() + 6 ) % 7;
-		bucketDate.setUTCDate( bucketDate.getUTCDate() - daysSinceMonday );
-	} else {
-		bucketDate.setUTCDate( 1 );
-	}
-
-	return bucketDate.toISOString().slice( 0, 10 );
-}
 
 /**
  * Build one table row for every leaf in a referrer hierarchy. DataViews does
@@ -96,48 +73,13 @@ export function flattenReferrerRows( items: StatsReferrersItem[] ): ReferrerReco
  */
 export function referrersToTimeSeries(
 	report: StatsNormalizedReport< StatsReferrersItem > | undefined,
-	period: ReferrerChartPeriod = 'day'
+	period: StatsChartBucketPeriod = 'day'
 ): StatsTimeSeriesReport {
-	const buckets = new Map< string, StatsTimeSeriesReport[ 'data' ][ number ] >();
-	const points = [ ...( report?.data ?? [] ) ].sort( ( a, b ) =>
-		a.time_interval.localeCompare( b.time_interval )
-	);
-
-	for ( const point of points ) {
+	return bucketStatsTimeSeries( report, period, point => {
 		const views = point.items.reduce( ( total, item ) => total + item.views, 0 );
-		const key = getChartBucketKey( point.time_interval, period );
-		const existing = buckets.get( key );
 
-		if ( existing ) {
-			existing.date_end = point.date_end;
-			existing.value = Number( existing.value ) + views;
-			existing.views = Number( existing.views ) + views;
-			continue;
-		}
-
-		buckets.set( key, {
-			time_interval: key,
-			date_start: point.date_start,
-			date_end: point.date_end,
-			label: key,
-			items: [],
-			value: views,
-			views,
-		} );
-	}
-
-	const data = [ ...buckets.values() ];
-	const first = data[ 0 ];
-	const last = data[ data.length - 1 ];
-
-	return {
-		summary: {
-			...report?.summary,
-			...( first ? { date_start: first.date_start } : {} ),
-			...( last ? { date_end: last.date_end } : {} ),
-		},
-		data,
-	};
+		return { value: views, views };
+	} );
 }
 
 /**

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/aggregate.ts
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/aggregate.ts
@@ -4,11 +4,39 @@
 import type { ReferrerRecord } from './fields';
 import type {
 	StatsNormalizedReport,
+	StatsPeriod,
 	StatsReferrersItem,
 	StatsTimeSeriesReport,
 } from '@jetpack-premium-analytics/data';
 
 const GROUP_SEPARATOR = ' / ';
+type ReferrerChartPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
+
+/**
+ * Map a daily bucket date onto its chart bucket key for the selected period —
+ * the date itself for days, the start of the ISO week for weeks, and the
+ * first-of-month date (`YYYY-MM-01`) for months.
+ *
+ * @param date   - The daily bucket date (`YYYY-MM-DD`).
+ * @param period - The chart bucket period.
+ * @return The bucket key the date aggregates into.
+ */
+function getChartBucketKey( date: string, period: ReferrerChartPeriod ): string {
+	if ( period === 'day' ) {
+		return date;
+	}
+
+	const bucketDate = new Date( `${ date.slice( 0, 10 ) }T00:00:00Z` );
+
+	if ( period === 'week' ) {
+		const daysSinceMonday = ( bucketDate.getUTCDay() + 6 ) % 7;
+		bucketDate.setUTCDate( bucketDate.getUTCDate() - daysSinceMonday );
+	} else {
+		bucketDate.setUTCDate( 1 );
+	}
+
+	return bucketDate.toISOString().slice( 0, 10 );
+}
 
 /**
  * Build one table row for every leaf in a referrer hierarchy. DataViews does
@@ -55,30 +83,50 @@ export function flattenReferrerRows( items: StatsReferrersItem[] ): ReferrerReco
 }
 
 /**
- * Build the views-over-time chart from a bucketed referrers report.
+ * Build the views-over-time chart from daily referrers data.
  *
  * Top-level values already represent each group's complete total, so summing
- * that level avoids counting the same hierarchy at every nested level.
+ * that level avoids counting the same hierarchy at every nested level. Week
+ * and month chart intervals are derived client-side so changing the chart does
+ * not change the exact report window or the table totals.
  *
  * @param report - The bucketed referrers report.
+ * @param period - The chart bucket period.
  * @return The chart-ready time series.
  */
 export function referrersToTimeSeries(
-	report: StatsNormalizedReport< StatsReferrersItem > | undefined
+	report: StatsNormalizedReport< StatsReferrersItem > | undefined,
+	period: ReferrerChartPeriod = 'day'
 ): StatsTimeSeriesReport {
-	const data = ( report?.data ?? [] ).map( point => {
-		const views = point.items.reduce( ( total, item ) => total + item.views, 0 );
+	const buckets = new Map< string, StatsTimeSeriesReport[ 'data' ][ number ] >();
+	const points = [ ...( report?.data ?? [] ) ].sort( ( a, b ) =>
+		a.time_interval.localeCompare( b.time_interval )
+	);
 
-		return {
-			time_interval: point.time_interval,
+	for ( const point of points ) {
+		const views = point.items.reduce( ( total, item ) => total + item.views, 0 );
+		const key = getChartBucketKey( point.time_interval, period );
+		const existing = buckets.get( key );
+
+		if ( existing ) {
+			existing.date_end = point.date_end;
+			existing.value = Number( existing.value ) + views;
+			existing.views = Number( existing.views ) + views;
+			continue;
+		}
+
+		buckets.set( key, {
+			time_interval: key,
 			date_start: point.date_start,
 			date_end: point.date_end,
-			label: point.time_interval,
+			label: key,
 			items: [],
 			value: views,
 			views,
-		};
-	} );
+		} );
+	}
+
+	const data = [ ...buckets.values() ];
 	const first = data[ 0 ];
 	const last = data[ data.length - 1 ];
 

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/fields.module.css
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/fields.module.css
@@ -1,0 +1,5 @@
+.referrerIcon {
+	--jpa-leaderboard-image-width: 16px;
+	--jpa-leaderboard-image-height: 16px;
+	--jpa-leaderboard-image-radius: var(--wpds-border-radius-sm);
+}

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/fields.test.tsx
@@ -1,0 +1,49 @@
+import { render, screen } from '@testing-library/react';
+import { getReferrerFields, type ReferrerRecord } from './fields';
+
+/**
+ * Mount the referrer field's render component for a table row.
+ *
+ * @param item - The referrer row to render.
+ * @return The Testing Library render result.
+ */
+function renderReferrerField( item: ReferrerRecord ) {
+	const field = getReferrerFields().find( candidate => candidate.id === 'referrer' );
+	// eslint-disable-next-line testing-library/render-result-naming-convention -- `render` is the DataViews field render component.
+	const ReferrerField = field?.render;
+
+	if ( ! field || ! ReferrerField ) {
+		throw new Error( 'Referrer field render callback is unavailable' );
+	}
+
+	return render( <ReferrerField item={ item } field={ field as never } /> );
+}
+
+describe( 'referrer field', () => {
+	it( 'renders URL-backed referrers as safe external links', () => {
+		renderReferrerField( {
+			id: 'search|google.com|https://www.google.com/',
+			label: 'google.com',
+			group: 'Search Engines',
+			views: 10,
+			link: 'https://www.google.com/',
+		} );
+
+		const link = screen.getByRole( 'link', { name: 'google.com' } );
+		expect( link ).toHaveAttribute( 'href', 'https://www.google.com/' );
+		expect( link ).toHaveAttribute( 'target', '_blank' );
+		expect( link ).toHaveAttribute( 'rel', 'noopener noreferrer' );
+	} );
+
+	it( 'renders referrers without a URL as plain text', () => {
+		renderReferrerField( {
+			id: '|Unknown|',
+			label: 'Unknown',
+			group: '',
+			views: 2,
+		} );
+
+		expect( screen.getByText( 'Unknown' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/fields.test.tsx
@@ -46,4 +46,46 @@ describe( 'referrer field', () => {
 		expect( screen.getByText( 'Unknown' ) ).toBeInTheDocument();
 		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
 	} );
+
+	it( 'renders referrers with unsafe URL schemes as plain text', () => {
+		renderReferrerField( {
+			id: '|Evil|javascript:alert(1)',
+			label: 'Evil',
+			group: '',
+			views: 1,
+
+			link: 'javascript:alert(1)',
+		} );
+
+		expect( screen.getByText( 'Evil' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the referrer favicon when the row has an icon', () => {
+		renderReferrerField( {
+			id: 'search|google.com|https://www.google.com/',
+			label: 'google.com',
+			group: 'Search Engines',
+			views: 10,
+			link: 'https://www.google.com/',
+			icon: 'https://icons.example/google.png',
+		} );
+
+		// The favicon is decorative (empty alt), so it maps to the presentation role.
+		expect( screen.getByRole( 'presentation' ) ).toHaveAttribute(
+			'src',
+			'https://icons.example/google.png'
+		);
+	} );
+
+	it( 'renders no favicon image when the row has no icon', () => {
+		renderReferrerField( {
+			id: '|Unknown|',
+			label: 'Unknown',
+			group: '',
+			views: 2,
+		} );
+
+		expect( screen.queryByRole( 'presentation' ) ).not.toBeInTheDocument();
+	} );
 } );

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/fields.tsx
@@ -1,7 +1,12 @@
 /**
  * External dependencies
  */
+import { LeaderboardLabel } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import styles from './fields.module.css';
 import type { Field } from '@wordpress/dataviews';
 
 /**
@@ -13,7 +18,27 @@ export type ReferrerRecord = {
 	group: string;
 	views: number;
 	link?: string;
+	icon?: string;
 };
+
+/**
+ * Return a URL only when it parses with an HTTP or HTTPS scheme.
+ *
+ * @param url - The candidate URL.
+ * @return The safe HTTP(S) URL, or null when it is missing, unparseable, or uses another scheme.
+ */
+function safeHttpUrl( url: string | undefined ): string | null {
+	if ( ! url ) {
+		return null;
+	}
+
+	try {
+		const { protocol } = new URL( url );
+		return protocol === 'http:' || protocol === 'https:' ? url : null;
+	} catch {
+		return null;
+	}
+}
 
 /**
  * DataViews field config for the Referrers records table.
@@ -29,13 +54,24 @@ export function getReferrerFields(): Field< ReferrerRecord >[] {
 			enableHiding: false,
 			getValue: ( { item } ) => item.label,
 			render: ( { item } ) => {
-				if ( ! item.link ) {
-					return <>{ item.label }</>;
+				const label = (
+					<LeaderboardLabel
+						label={ item.label }
+						imageUrl={ item.icon }
+						imageAlt=""
+						imageFallback="hidden"
+						imageClassName={ styles.referrerIcon }
+					/>
+				);
+				const safeUrl = safeHttpUrl( item.link );
+
+				if ( ! safeUrl ) {
+					return label;
 				}
 
 				return (
-					<a href={ item.link } target="_blank" rel="noopener noreferrer">
-						{ item.label }
+					<a href={ safeUrl } target="_blank" rel="noopener noreferrer">
+						{ label }
 					</a>
 				);
 			},

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/fields.tsx
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import type { Field } from '@wordpress/dataviews';
+
+/**
+ * A flattened referrer leaf shown in the records table.
+ */
+export type ReferrerRecord = {
+	id: string;
+	label: string;
+	group: string;
+	views: number;
+	link?: string;
+};
+
+/**
+ * DataViews field config for the Referrers records table.
+ *
+ * @return The field config.
+ */
+export function getReferrerFields(): Field< ReferrerRecord >[] {
+	return [
+		{
+			id: 'referrer',
+			label: __( 'Referrer', 'jetpack-premium-analytics' ),
+			enableGlobalSearch: true,
+			enableHiding: false,
+			getValue: ( { item } ) => item.label,
+			render: ( { item } ) => {
+				if ( ! item.link ) {
+					return <>{ item.label }</>;
+				}
+
+				return (
+					<a href={ item.link } target="_blank" rel="noopener noreferrer">
+						{ item.label }
+					</a>
+				);
+			},
+		},
+		{
+			id: 'group',
+			label: __( 'Group', 'jetpack-premium-analytics' ),
+			enableGlobalSearch: true,
+			getValue: ( { item } ) => item.group,
+		},
+		{
+			id: 'views',
+			label: __( 'Views', 'jetpack-premium-analytics' ),
+			getValue: ( { item } ) => item.views,
+			render: ( { item } ) => <>{ item.views.toLocaleString() }</>,
+		},
+	];
+}

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/index.ts
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/index.ts
@@ -1,0 +1,3 @@
+export { aggregateReferrerRows, flattenReferrerRows, referrersToTimeSeries } from './aggregate';
+export { getReferrerFields, type ReferrerRecord } from './fields';
+export { useReferrersReportRecords } from './use-report-records';

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/use-report-records.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/use-report-records.test.ts
@@ -50,6 +50,42 @@ const report: StatsNormalizedReport< StatsReferrersItem > = {
 	],
 };
 
+const comparisonReport: StatsNormalizedReport< StatsReferrersItem > = {
+	summary: {},
+	data: [
+		{
+			time_interval: '2026-07-07',
+			date_start: '2026-07-07T00:00:00+00:00',
+			date_end: '2026-07-07T23:59:59+00:00',
+			items: [
+				{
+					label: 'wordpress.com',
+					views: 4,
+					link: 'https://wordpress.com/',
+					icon: null,
+					labelIcon: 'external',
+					children: null,
+				},
+			],
+		},
+		{
+			time_interval: '2026-07-08',
+			date_start: '2026-07-08T00:00:00+00:00',
+			date_end: '2026-07-08T23:59:59+00:00',
+			items: [
+				{
+					label: 'wordpress.org',
+					views: 5,
+					link: 'https://wordpress.org/',
+					icon: null,
+					labelIcon: 'external',
+					children: null,
+				},
+			],
+		},
+	],
+};
+
 describe( 'useReferrersReportRecords', () => {
 	beforeEach( () => {
 		mockUseStatsReferrers.mockReturnValue( {
@@ -93,5 +129,44 @@ describe( 'useReferrersReportRecords', () => {
 			],
 		} );
 		expect( weekResult.current.rows ).toEqual( dayResult.current.rows );
+	} );
+
+	it( 'includes comparison chart buckets when referrers do not overlap the primary period', () => {
+		mockUseStatsReferrers.mockReturnValue( {
+			primary: { data: report },
+			comparison: { data: comparisonReport },
+			hasComparison: false,
+			isLoading: false,
+		} as ReturnType< typeof useStatsReferrers > );
+		const params: ReportParams = {
+			from: '2026-07-09',
+			to: '2026-07-10',
+			interval: 'day',
+			compare_from: '2026-07-07',
+			compare_to: '2026-07-08',
+		};
+
+		const { result } = renderHook( () => useReferrersReportRecords( params, 'day' ) );
+
+		expect( result.current.chart.comparison ).toBeDefined();
+		expect( result.current.chart.comparison?.data.map( point => point.views ) ).toEqual( [ 4, 5 ] );
+	} );
+
+	it( 'omits the comparison chart when comparison params are absent', () => {
+		mockUseStatsReferrers.mockReturnValue( {
+			primary: { data: report },
+			comparison: { data: comparisonReport },
+			hasComparison: false,
+			isLoading: false,
+		} as ReturnType< typeof useStatsReferrers > );
+		const params: ReportParams = {
+			from: '2026-07-09',
+			to: '2026-07-10',
+			interval: 'day',
+		};
+
+		const { result } = renderHook( () => useReferrersReportRecords( params, 'day' ) );
+
+		expect( result.current.chart.comparison ).toBeUndefined();
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/use-report-records.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/use-report-records.test.ts
@@ -1,0 +1,87 @@
+import { useStatsReferrers } from '@jetpack-premium-analytics/data';
+import { renderHook } from '@testing-library/react';
+import { useReferrersReportRecords } from './use-report-records';
+import type {
+	ReportParams,
+	StatsNormalizedReport,
+	StatsReferrersItem,
+} from '@jetpack-premium-analytics/data';
+
+jest.mock( '@jetpack-premium-analytics/data', () => ( {
+	...jest.requireActual( '@jetpack-premium-analytics/data' ),
+	useStatsReferrers: jest.fn(),
+} ) );
+
+const mockUseStatsReferrers = useStatsReferrers as jest.MockedFunction< typeof useStatsReferrers >;
+
+const report: StatsNormalizedReport< StatsReferrersItem > = {
+	summary: {},
+	data: [
+		{
+			time_interval: '2026-07-09',
+			date_start: '2026-07-09T00:00:00+00:00',
+			date_end: '2026-07-09T23:59:59+00:00',
+			items: [
+				{
+					label: 'example.com',
+					views: 7,
+					link: 'https://example.com/',
+					icon: null,
+					labelIcon: 'external',
+					children: null,
+				},
+			],
+		},
+		{
+			time_interval: '2026-07-10',
+			date_start: '2026-07-10T00:00:00+00:00',
+			date_end: '2026-07-10T23:59:59+00:00',
+			items: [
+				{
+					label: 'example.com',
+					views: 6,
+					link: 'https://example.com/',
+					icon: null,
+					labelIcon: 'external',
+					children: null,
+				},
+			],
+		},
+	],
+};
+
+describe( 'useReferrersReportRecords', () => {
+	beforeEach( () => {
+		mockUseStatsReferrers.mockReturnValue( {
+			primary: { data: report },
+			comparison: { data: undefined },
+			hasComparison: false,
+			isLoading: false,
+		} as ReturnType< typeof useStatsReferrers > );
+	} );
+
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'keeps the request day-bucketed while grouping only the chart by week', () => {
+		const params: ReportParams = {
+			from: '2026-07-09',
+			to: '2026-07-10',
+			interval: 'day',
+		};
+		const { result: dayResult } = renderHook( () => useReferrersReportRecords( params, 'day' ) );
+		const { result: weekResult } = renderHook( () => useReferrersReportRecords( params, 'week' ) );
+
+		expect( mockUseStatsReferrers ).toHaveBeenLastCalledWith( {
+			...params,
+			max: 0,
+			summarize: 0,
+			period: 'day',
+		} );
+		expect( weekResult.current.chart.primary.data ).toEqual( [
+			expect.objectContaining( { time_interval: '2026-07-06', views: 13 } ),
+		] );
+		expect( weekResult.current.rows ).toEqual( dayResult.current.rows );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/use-report-records.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/use-report-records.test.ts
@@ -79,9 +79,19 @@ describe( 'useReferrersReportRecords', () => {
 			summarize: 0,
 			period: 'day',
 		} );
-		expect( weekResult.current.chart.primary.data ).toEqual( [
-			expect.objectContaining( { time_interval: '2026-07-06', views: 13 } ),
-		] );
+		expect( weekResult.current.chart.primary ).toEqual( {
+			summary: {
+				date_start: '2026-07-09T00:00:00+00:00',
+				date_end: '2026-07-10T23:59:59+00:00',
+			},
+			data: [
+				expect.objectContaining( {
+					time_interval: '2026-07-06',
+					date_start: '2026-07-06T00:00:00+00:00',
+					views: 13,
+				} ),
+			],
+		} );
 		expect( weekResult.current.rows ).toEqual( dayResult.current.rows );
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/use-report-records.ts
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import {
+	useStatsReferrers,
+	type ReportParams,
+	type StatsPeriod,
+} from '@jetpack-premium-analytics/data';
+import { useMemo } from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import { aggregateReferrerRows, referrersToTimeSeries } from './aggregate';
+
+/**
+ * Fetch and derive the Referrers report chart and table records.
+ *
+ * @param reportParams - The shared report-window parameters.
+ * @param chartPeriod  - The chart's bucket period.
+ * @return Chart data and table records.
+ */
+export function useReferrersReportRecords( reportParams: ReportParams, chartPeriod: StatsPeriod ) {
+	// A single bucketed query feeds both report sections. `summarize: 0`
+	// preserves the time buckets for the chart, and `max: 0` requests every
+	// referrer so table search, sorting, and pagination remain client-side.
+	const recordsParams = useMemo(
+		() => ( {
+			...reportParams,
+			max: 0,
+			summarize: 0,
+			period: chartPeriod,
+		} ),
+		[ reportParams, chartPeriod ]
+	);
+	const report = useStatsReferrers( recordsParams );
+
+	const chartPrimary = useMemo(
+		() => referrersToTimeSeries( report.primary.data ),
+		[ report.primary.data ]
+	);
+	const chartComparison = useMemo( () => {
+		if ( ! reportParams.compare_from || ! reportParams.compare_to ) {
+			return undefined;
+		}
+
+		return referrersToTimeSeries( report.comparison.data );
+	}, [ reportParams, report.comparison.data ] );
+	const rows = useMemo(
+		() => aggregateReferrerRows( report.primary.data ),
+		[ report.primary.data ]
+	);
+
+	return {
+		chart: {
+			primary: chartPrimary,
+			comparison: report.hasComparison ? chartComparison : undefined,
+			isLoading: report.isLoading,
+		},
+		rows,
+		isLoading: report.isLoading,
+	};
+}

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/use-report-records.ts
@@ -12,6 +12,8 @@ import { useMemo } from '@wordpress/element';
  */
 import { aggregateReferrerRows, referrersToTimeSeries } from './aggregate';
 
+type ReferrerChartPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
+
 /**
  * Fetch and derive the Referrers report chart and table records.
  *
@@ -19,7 +21,10 @@ import { aggregateReferrerRows, referrersToTimeSeries } from './aggregate';
  * @param chartPeriod  - The chart's bucket period.
  * @return Chart data and table records.
  */
-export function useReferrersReportRecords( reportParams: ReportParams, chartPeriod: StatsPeriod ) {
+export function useReferrersReportRecords(
+	reportParams: ReportParams,
+	chartPeriod: ReferrerChartPeriod
+) {
 	// A single bucketed query feeds both report sections. `summarize: 0`
 	// preserves the time buckets for the chart, and `max: 0` requests every
 	// referrer so table search, sorting, and pagination remain client-side.
@@ -28,23 +33,23 @@ export function useReferrersReportRecords( reportParams: ReportParams, chartPeri
 			...reportParams,
 			max: 0,
 			summarize: 0,
-			period: chartPeriod,
+			period: 'day',
 		} ),
-		[ reportParams, chartPeriod ]
+		[ reportParams ]
 	);
 	const report = useStatsReferrers( recordsParams );
 
 	const chartPrimary = useMemo(
-		() => referrersToTimeSeries( report.primary.data ),
-		[ report.primary.data ]
+		() => referrersToTimeSeries( report.primary.data, chartPeriod ),
+		[ report.primary.data, chartPeriod ]
 	);
 	const chartComparison = useMemo( () => {
 		if ( ! reportParams.compare_from || ! reportParams.compare_to ) {
 			return undefined;
 		}
 
-		return referrersToTimeSeries( report.comparison.data );
-	}, [ reportParams, report.comparison.data ] );
+		return referrersToTimeSeries( report.comparison.data, chartPeriod );
+	}, [ reportParams, report.comparison.data, chartPeriod ] );
 	const rows = useMemo(
 		() => aggregateReferrerRows( report.primary.data ),
 		[ report.primary.data ]

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/use-report-records.ts
@@ -4,15 +4,13 @@
 import {
 	useStatsReferrers,
 	type ReportParams,
-	type StatsPeriod,
+	type StatsChartBucketPeriod,
 } from '@jetpack-premium-analytics/data';
 import { useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
 import { aggregateReferrerRows, referrersToTimeSeries } from './aggregate';
-
-type ReferrerChartPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
 
 /**
  * Fetch and derive the Referrers report chart and table records.
@@ -23,7 +21,7 @@ type ReferrerChartPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
  */
 export function useReferrersReportRecords(
 	reportParams: ReportParams,
-	chartPeriod: ReferrerChartPeriod
+	chartPeriod: StatsChartBucketPeriod
 ) {
 	// A single bucketed query feeds both report sections. `summarize: 0`
 	// preserves the time buckets for the chart, and `max: 0` requests every

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/use-report-records.ts
@@ -56,7 +56,7 @@ export function useReferrersReportRecords(
 	return {
 		chart: {
 			primary: chartPrimary,
-			comparison: report.hasComparison ? chartComparison : undefined,
+			comparison: report.comparison.data ? chartComparison : undefined,
 			isLoading: report.isLoading,
 		},
 		rows,

--- a/projects/packages/premium-analytics/routes/reports/referrers/page.module.css
+++ b/projects/packages/premium-analytics/routes/reports/referrers/page.module.css
@@ -13,7 +13,7 @@
 	 * tab strip is designed to sit flush under the header.
 	 */
 	padding-block-start: var(--wpds-dimension-padding-lg);
-	padding-block-end: 24px;
+	padding-block-end: var(--wpds-dimension-padding-2xl);
 	padding-inline: var(--wpds-dimension-padding-2xl);
 }
 

--- a/projects/packages/premium-analytics/routes/reports/referrers/page.module.css
+++ b/projects/packages/premium-analytics/routes/reports/referrers/page.module.css
@@ -1,0 +1,22 @@
+.page {
+	min-block-size: 0;
+}
+
+.content {
+	flex: 1 1 auto;
+	min-block-size: 0;
+	overflow-y: auto;
+
+	/*
+	 * Mirror the top padding of Page's own `hasPadding` content so the filters
+	 * row doesn't hug the header border — tabbed reports skip this because the
+	 * tab strip is designed to sit flush under the header.
+	 */
+	padding-block-start: var(--wpds-dimension-padding-lg);
+	padding-block-end: 24px;
+	padding-inline: var(--wpds-dimension-padding-2xl);
+}
+
+.dateFilters {
+	inline-size: 100%;
+}

--- a/projects/packages/premium-analytics/routes/reports/referrers/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/referrers/page.tsx
@@ -1,0 +1,178 @@
+/**
+ * External dependencies
+ */
+import {
+	normalizeReportParams,
+	type IntervalType,
+	type StatsPeriod,
+} from '@jetpack-premium-analytics/data';
+import { useDashboardLink, useReportDateFilters } from '@jetpack-premium-analytics/routing';
+import { DateFiltersPanel } from '@jetpack-premium-analytics/ui';
+import {
+	formatLegendLabels,
+	ReportPageLayout,
+	ReportPerformanceChart,
+	ReportRecordsTable,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { Breadcrumbs, Page } from '@wordpress/admin-ui';
+import { useCallback, useMemo, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useNavigate, useSearch } from '@wordpress/route';
+/**
+ * Internal dependencies
+ */
+import { route } from '../package.json';
+import { getReferrerFields, useReferrersReportRecords, type ReferrerRecord } from './config';
+import styles from './page.module.css';
+
+const ROUTE_FROM = route.path;
+const REPORT_PARAMS = { report: 'referrers' };
+const CHART_PERIODS = [ 'day', 'week', 'month' ] as const satisfies readonly StatsPeriod[];
+type ChartPeriod = ( typeof CHART_PERIODS )[ number ];
+
+/**
+ * Check whether a URL value is a supported chart period.
+ *
+ * @param value - The URL search value.
+ * @return Whether the value is a chart period.
+ */
+function isChartPeriod( value: unknown ): value is ChartPeriod {
+	return CHART_PERIODS.includes( value as ChartPeriod );
+}
+
+/**
+ * Choose the chart bucket period for a report interval.
+ *
+ * @param interval - The report date interval.
+ * @return The default chart bucket period.
+ */
+function getDefaultChartPeriod( interval?: IntervalType ): ChartPeriod {
+	if ( interval === 'week' ) {
+		return 'week';
+	}
+
+	if ( interval === 'month' || interval === 'quarter' || interval === 'year' ) {
+		return 'month';
+	}
+
+	return 'day';
+}
+
+/**
+ * Stable row id for the Referrers records table.
+ *
+ * @param item - The referrer row.
+ * @return The row id.
+ */
+function getReferrerRowId( item: ReferrerRecord ): string {
+	return item.id;
+}
+
+const RECORDS_VIEW = {
+	sort: { field: 'views', direction: 'desc' as const },
+	layout: {
+		styles: {
+			referrer: { width: '100%' },
+			views: { align: 'end' as const },
+		},
+	},
+};
+
+/**
+ * Premium Analytics Referrers report page component.
+ *
+ * @return {JSX.Element} The Referrers report page.
+ */
+function ReferrersReport(): JSX.Element {
+	const search = useSearch( { from: ROUTE_FROM } ) as Record< string, string | undefined >;
+	const reportParams = useMemo(
+		() => normalizeReportParams( search as Parameters< typeof normalizeReportParams >[ 0 ] ),
+		[ search ]
+	);
+
+	const chartPeriod = isChartPeriod( search.period )
+		? search.period
+		: getDefaultChartPeriod( reportParams.interval );
+	const records = useReferrersReportRecords( reportParams, chartPeriod );
+	const fields = useMemo( () => getReferrerFields(), [] );
+	const chartMetrics = useMemo(
+		() => [ { key: 'views', label: __( 'Views', 'jetpack-premium-analytics' ) } ],
+		[]
+	);
+	const chartLegendLabels = useMemo( () => formatLegendLabels( reportParams ), [ reportParams ] );
+
+	const navigate = useNavigate();
+	const handleIntervalChange = useCallback(
+		( interval: IntervalType ) => {
+			const period = isChartPeriod( interval ) ? interval : getDefaultChartPeriod( interval );
+			navigate( {
+				to: ROUTE_FROM,
+				params: REPORT_PARAMS as unknown as never,
+				replace: true,
+				search: ( ( current: Record< string, unknown > ) => ( {
+					...current,
+					period,
+				} ) ) as unknown as never,
+			} );
+		},
+		[ navigate ]
+	);
+
+	const dateFilters = useReportDateFilters( ROUTE_FROM );
+	const dashboardLink = useDashboardLink();
+	const [ containerElement, setContainerElement ] = useState< HTMLDivElement | null >( null );
+
+	return (
+		<Page
+			breadcrumbs={
+				<Breadcrumbs
+					items={ [
+						{
+							label: __( 'Stats', 'jetpack-premium-analytics' ),
+							to: dashboardLink,
+						},
+						{ label: __( 'Referrers', 'jetpack-premium-analytics' ) },
+					] }
+				/>
+			}
+			className={ styles.page }
+		>
+			<div className={ styles.content }>
+				<ReportPageLayout
+					filters={
+						<div ref={ setContainerElement } className={ styles.dateFilters }>
+							<DateFiltersPanel { ...dateFilters } containerElement={ containerElement } />
+						</div>
+					}
+				>
+					<ReportPerformanceChart
+						primary={ records.chart.primary }
+						comparison={ records.chart.comparison }
+						isLoading={ records.chart.isLoading }
+						metrics={ chartMetrics }
+						interval={ chartPeriod }
+						onIntervalChange={ handleIntervalChange }
+						legendLabels={ chartLegendLabels }
+					/>
+					<ReportRecordsTable
+						data={ records.rows }
+						fields={ fields }
+						getItemId={ getReferrerRowId }
+						isLoading={ records.isLoading }
+						initialView={ RECORDS_VIEW }
+						searchLabel={ __( 'Search referrers', 'jetpack-premium-analytics' ) }
+					/>
+				</ReportPageLayout>
+			</div>
+		</Page>
+	);
+}
+
+/**
+ * Referrers report page (default export for the report registry).
+ *
+ * @return {JSX.Element} The Referrers report page.
+ */
+export default function ReferrersReportPage(): JSX.Element {
+	return <ReferrersReport />;
+}

--- a/projects/packages/premium-analytics/routes/reports/referrers/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/referrers/page.tsx
@@ -4,7 +4,7 @@
 import {
 	normalizeReportParams,
 	type IntervalType,
-	type StatsPeriod,
+	type StatsChartBucketPeriod,
 } from '@jetpack-premium-analytics/data';
 import { useDashboardLink, useReportDateFilters } from '@jetpack-premium-analytics/routing';
 import { DateFiltersPanel } from '@jetpack-premium-analytics/ui';
@@ -27,8 +27,11 @@ import styles from './page.module.css';
 
 const ROUTE_FROM = route.path;
 const REPORT_PARAMS = { report: 'referrers' };
-const CHART_PERIODS = [ 'day', 'week', 'month' ] as const satisfies readonly StatsPeriod[];
-type ChartPeriod = ( typeof CHART_PERIODS )[ number ];
+const CHART_PERIODS = [
+	'day',
+	'week',
+	'month',
+] as const satisfies readonly StatsChartBucketPeriod[];
 
 /**
  * Check whether a URL value is a supported chart period.
@@ -36,8 +39,8 @@ type ChartPeriod = ( typeof CHART_PERIODS )[ number ];
  * @param value - The URL search value.
  * @return Whether the value is a chart period.
  */
-function isChartPeriod( value: unknown ): value is ChartPeriod {
-	return CHART_PERIODS.includes( value as ChartPeriod );
+function isChartPeriod( value: unknown ): value is StatsChartBucketPeriod {
+	return CHART_PERIODS.includes( value as StatsChartBucketPeriod );
 }
 
 /**
@@ -46,7 +49,7 @@ function isChartPeriod( value: unknown ): value is ChartPeriod {
  * @param interval - The report date interval.
  * @return The default chart bucket period.
  */
-function getDefaultChartPeriod( interval?: IntervalType ): ChartPeriod {
+function getDefaultChartPeriod( interval?: IntervalType ): StatsChartBucketPeriod {
 	if ( interval === 'week' ) {
 		return 'week';
 	}

--- a/projects/packages/premium-analytics/routes/reports/referrers/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/referrers/page.tsx
@@ -110,6 +110,12 @@ function ReferrersReport(): JSX.Element {
 			const period = isChartPeriod( interval ) ? interval : getDefaultChartPeriod( interval );
 			navigate( {
 				to: ROUTE_FROM,
+				/*
+				 * The router is built dynamically, so `/reports/$report` has no
+				 * statically-typed params/search schema (tanstack widens them to
+				 * `never`). Cast the same way the routing package does when it
+				 * writes the URL.
+				 */
 				params: REPORT_PARAMS as unknown as never,
 				replace: true,
 				search: ( ( current: Record< string, unknown > ) => ( {

--- a/projects/packages/premium-analytics/routes/reports/registry.ts
+++ b/projects/packages/premium-analytics/routes/reports/registry.ts
@@ -104,6 +104,11 @@ export const REPORTS: Record< string, ReportDefinition > = {
 		resolveSection: resolveUtmSection,
 		load: () => import( './utm/page' ),
 	},
+	referrers: {
+		id: 'referrers',
+		getTitle: () => __( 'Referrers', 'jetpack-premium-analytics' ),
+		load: () => import( './referrers/page' ),
+	},
 };
 
 /**

--- a/projects/packages/premium-analytics/widgets/referrers/__tests__/referrers.test.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/__tests__/referrers.test.tsx
@@ -4,6 +4,7 @@
 import { getDefaultQueryParams, queryClient } from '@jetpack-premium-analytics/data';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
+import type { AnchorHTMLAttributes, ReactNode } from 'react';
 /**
  * Internal dependencies
  */
@@ -12,7 +13,33 @@ import type { StatsReferrersComparisonItem } from '@jetpack-premium-analytics/da
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
+type MockRouteLinkProps = {
+	to: string;
+	params?: Record< string, unknown >;
+	search?: Record< string, unknown >;
+	children: ReactNode;
+} & Omit< AnchorHTMLAttributes< HTMLAnchorElement >, 'href' >;
+
 jest.mock( '@wordpress/route', () => ( {
+	Link: ( { to, params, search, children, ...props }: MockRouteLinkProps ) => {
+		const path = Object.entries( params ?? {} ).reduce(
+			( result, [ key, value ] ) => result.replace( `$${ key }`, String( value ) ),
+			to
+		);
+		const query = new URLSearchParams();
+		Object.entries( search ?? {} ).forEach( ( [ key, value ] ) => {
+			if ( value !== undefined && value !== null ) {
+				query.set( key, String( value ) );
+			}
+		} );
+		const queryString = query.toString();
+
+		return (
+			<a href={ queryString ? `${ path }?${ queryString }` : path } { ...props }>
+				{ children }
+			</a>
+		);
+	},
 	useSearch: () => ( {} ),
 } ) );
 
@@ -205,6 +232,17 @@ describe( 'ReferrersWidget', () => {
 		const link = await screen.findByRole( 'link', { name: /jetpack\.com/i } );
 		expect( link ).toHaveAttribute( 'href', 'https://jetpack.com/' );
 		expect( link ).toHaveAttribute( 'target', '_blank' );
+	} );
+
+	it( 'links to the full Referrers report', () => {
+		render(
+			<ReferrersWidget
+				attributes={ { max: 10, reportParams: getDefaultQueryParams( false, 'last-7-days' ) } }
+			/>
+		);
+
+		const link = screen.getByRole( 'link', { name: 'See report' } );
+		expect( link ).toHaveAttribute( 'href', expect.stringContaining( '/reports/referrers' ) );
 	} );
 } );
 

--- a/projects/packages/premium-analytics/widgets/referrers/render.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/render.tsx
@@ -9,7 +9,9 @@ import {
 import {
 	LeaderboardChart,
 	LeaderboardLabel,
+	ReportLink,
 	WidgetBackLink,
+	WidgetFooter,
 	WidgetRoot,
 	WidgetState,
 	calculateDelta,
@@ -355,6 +357,9 @@ export default function ReferrersWidget( {
 		<WidgetRoot attributes={ attributes }>
 			<div className={ styles.root }>
 				<ReferrersInner max={ max } />
+				<WidgetFooter>
+					<ReportLink report="referrers" />
+				</WidgetFooter>
 			</div>
 		</WidgetRoot>
 	);

--- a/projects/packages/premium-analytics/widgets/referrers/stories/referrers-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/stories/referrers-widget.stories.tsx
@@ -14,6 +14,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withStoryRouter } from '../../stories/with-story-router';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import ReferrersRender from '../render';
 import widgetDefinition from '../widget';
@@ -101,13 +102,13 @@ type DashboardStory = StoryObj< ReferrersDashboardStoryProps >;
 export const Default: Story = {
 	render: renderReferrersWidget,
 	args: { withComparison: false },
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 };
 
 export const WithComparison: Story = {
 	render: renderReferrersWidget,
 	args: { withComparison: true },
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 };
 
 /**
@@ -122,7 +123,7 @@ export const Loading: Story = {
 	render: () => renderReferrersOnPreset( 'last-90-days' ),
 	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 	beforeEach: () => {
 		forceStatsMockState( 'stats/referrers', 'loading' );
 		return () => forceStatsMockState( 'stats/referrers', null );
@@ -136,7 +137,7 @@ export const Loading: Story = {
 export const Error: Story = {
 	render: () => renderReferrersOnPreset( 'last-7-days' ),
 	tags: [ '!autodocs' ],
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 	beforeEach: () => {
 		forceStatsMockState( 'stats/referrers', 'error' );
 		return () => forceStatsMockState( 'stats/referrers', null );
@@ -150,7 +151,7 @@ export const Error: Story = {
 export const Empty: Story = {
 	render: () => renderReferrersOnPreset( 'last-365-days' ),
 	tags: [ '!autodocs' ],
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 	beforeEach: () => {
 		forceStatsMockState( 'stats/referrers', 'empty' );
 		return () => forceStatsMockState( 'stats/referrers', null );


### PR DESCRIPTION
Part of [WOOA7S-1696](https://linear.app/a8c/issue/WOOA7S-1696)

**Note: Grouped referrer rows (e.g. Search engines, Reddit) do not display their individual referrer URLs yet; this can be added later once we have confirmation on the drill-down DataViews UX**

<img width="1652" height="1640" alt="Google Chrome -2026-07-14 at 12 14 15@2x" src="https://github.com/user-attachments/assets/1b5bbb4f-2640-4e93-8e99-e461dbaebdff" />


## Proposed changes

* Adds the Referrers report at `/reports/referrers` on the reports framework from #50305: a `routes/reports/referrers/` page module (performance chart + records table, `config/aggregate.ts` with tests) and one `REPORTS` registry entry.
* The Referrers widget footer links to the report via the shared `WidgetFooter`/`ReportLink`, carrying the dashboard's current date range and comparison.

<!-- screenshot: add a capture of the /reports/referrers page -->

## Related product discussion/links

* [WOOA7S-1696](https://linear.app/a8c/issue/WOOA7S-1696)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `cd projects/packages/premium-analytics && pnpm run build`, open the Premium Analytics dashboard on a site with traffic data.
* In the Referrers widget, click **View all** — you should land on `/reports/referrers` with the dashboard's date range and comparison intact, and the breadcrumb linking back to the same dashboard view.
* On the chart: change the time bucket (day/week/month) and collapse/expand it.
* On the table: search, sort, and page through — all client-side, no new requests.
* Change the date range from the page's date filter — chart and table should update together, and reloading the URL should restore the exact view.

