### PR TITLE
WOOA7S-1698: Premium Analytics: add the Clicks report at /reports/clicks

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-wooa7s-1698-clicks-report-page
+++ b/projects/packages/premium-analytics/changelog/add-wooa7s-1698-clicks-report-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add the Clicks report at `/reports/clicks`.

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/aggregate.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/aggregate.test.ts
@@ -80,10 +80,14 @@ describe( 'report clicks aggregate', () => {
 	it( 'groups daily totals into ISO calendar weeks for the chart', () => {
 		const series = clicksToTimeSeries( dailyReport, 'week' );
 
+		expect( series.summary ).toEqual( {
+			date_start: '2026-07-09T00:00:00+00:00',
+			date_end: '2026-07-10T23:59:59+00:00',
+		} );
 		expect( series.data ).toEqual( [
 			expect.objectContaining( {
 				time_interval: '2026-07-06',
-				date_start: '2026-07-09T00:00:00+00:00',
+				date_start: '2026-07-06T00:00:00+00:00',
 				date_end: '2026-07-10T23:59:59+00:00',
 				clicks: 13,
 				value: 13,
@@ -95,28 +99,32 @@ describe( 'report clicks aggregate', () => {
 		const reportWithNextMonth = {
 			...dailyReport,
 			data: [
+				...dailyReport.data,
 				{
 					time_interval: '2026-08-02',
 					date_start: '2026-08-02T00:00:00+00:00',
 					date_end: '2026-08-02T23:59:59+00:00',
 					items: [ makeClickItem( 3 ) ],
 				},
-				...dailyReport.data,
 			],
 		};
 		const series = clicksToTimeSeries( reportWithNextMonth, 'month' );
 
+		expect( series.summary ).toEqual( {
+			date_start: '2026-07-09T00:00:00+00:00',
+			date_end: '2026-08-02T23:59:59+00:00',
+		} );
 		expect( series.data ).toEqual( [
 			expect.objectContaining( {
 				time_interval: '2026-07-01',
-				date_start: '2026-07-09T00:00:00+00:00',
+				date_start: '2026-07-01T00:00:00+00:00',
 				date_end: '2026-07-10T23:59:59+00:00',
 				clicks: 13,
 				value: 13,
 			} ),
 			expect.objectContaining( {
 				time_interval: '2026-08-01',
-				date_start: '2026-08-02T00:00:00+00:00',
+				date_start: '2026-08-01T00:00:00+00:00',
 				date_end: '2026-08-02T23:59:59+00:00',
 				clicks: 3,
 				value: 3,

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/aggregate.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/aggregate.test.ts
@@ -1,6 +1,41 @@
 import { aggregateClickRows, clicksToTimeSeries } from './aggregate';
 import type { StatsClicksItem, StatsNormalizedReport } from '@jetpack-premium-analytics/data';
 
+/**
+ * Build a top-level click item with the requested total.
+ *
+ * @param views - The item's click count.
+ * @return The click item.
+ */
+function makeClickItem( views: number ): StatsClicksItem {
+	return {
+		label: 'jetpack.com',
+		views,
+		link: 'https://jetpack.com/',
+		icon: null,
+		labelIcon: 'external',
+		children: null,
+	};
+}
+
+const dailyReport: StatsNormalizedReport< StatsClicksItem > = {
+	summary: {},
+	data: [
+		{
+			time_interval: '2026-07-09',
+			date_start: '2026-07-09T00:00:00+00:00',
+			date_end: '2026-07-09T23:59:59+00:00',
+			items: [ makeClickItem( 8 ) ],
+		},
+		{
+			time_interval: '2026-07-10',
+			date_start: '2026-07-10T00:00:00+00:00',
+			date_end: '2026-07-10T23:59:59+00:00',
+			items: [ makeClickItem( 5 ) ],
+		},
+	],
+};
+
 describe( 'report clicks aggregate', () => {
 	it( 'builds the chart from top-level totals without double-counting children', () => {
 		const report: StatsNormalizedReport< StatsClicksItem > = {
@@ -40,6 +75,53 @@ describe( 'report clicks aggregate', () => {
 			date_start: '2026-06-01T00:00:00+00:00',
 			date_end: '2026-06-01T23:59:59+00:00',
 		} );
+	} );
+
+	it( 'groups daily totals into ISO calendar weeks for the chart', () => {
+		const series = clicksToTimeSeries( dailyReport, 'week' );
+
+		expect( series.data ).toEqual( [
+			expect.objectContaining( {
+				time_interval: '2026-07-06',
+				date_start: '2026-07-09T00:00:00+00:00',
+				date_end: '2026-07-10T23:59:59+00:00',
+				clicks: 13,
+				value: 13,
+			} ),
+		] );
+	} );
+
+	it( 'groups daily totals into calendar months for the chart', () => {
+		const reportWithNextMonth = {
+			...dailyReport,
+			data: [
+				{
+					time_interval: '2026-08-02',
+					date_start: '2026-08-02T00:00:00+00:00',
+					date_end: '2026-08-02T23:59:59+00:00',
+					items: [ makeClickItem( 3 ) ],
+				},
+				...dailyReport.data,
+			],
+		};
+		const series = clicksToTimeSeries( reportWithNextMonth, 'month' );
+
+		expect( series.data ).toEqual( [
+			expect.objectContaining( {
+				time_interval: '2026-07-01',
+				date_start: '2026-07-09T00:00:00+00:00',
+				date_end: '2026-07-10T23:59:59+00:00',
+				clicks: 13,
+				value: 13,
+			} ),
+			expect.objectContaining( {
+				time_interval: '2026-08-01',
+				date_start: '2026-08-02T00:00:00+00:00',
+				date_end: '2026-08-02T23:59:59+00:00',
+				clicks: 3,
+				value: 3,
+			} ),
+		] );
 	} );
 
 	it( 'flattens grouped child URLs and aggregates them across buckets', () => {

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/aggregate.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/aggregate.test.ts
@@ -1,0 +1,122 @@
+import { aggregateClickRows, clicksToTimeSeries } from './aggregate';
+import type { StatsClicksItem, StatsNormalizedReport } from '@jetpack-premium-analytics/data';
+
+describe( 'report clicks aggregate', () => {
+	it( 'builds the chart from top-level totals without double-counting children', () => {
+		const report: StatsNormalizedReport< StatsClicksItem > = {
+			summary: {},
+			data: [
+				{
+					time_interval: '2026-06-01',
+					date_start: '2026-06-01T00:00:00+00:00',
+					date_end: '2026-06-01T23:59:59+00:00',
+					items: [
+						{
+							label: 'wordpress.org',
+							views: 12,
+							link: null,
+							icon: null,
+							labelIcon: null,
+							children: [
+								{
+									label: '/plugins/jetpack-search',
+									views: 8,
+									link: 'https://wordpress.org/plugins/jetpack-search',
+									icon: null,
+									labelIcon: 'external',
+									children: null,
+								},
+							],
+						},
+					],
+				},
+			],
+		};
+
+		const series = clicksToTimeSeries( report );
+
+		expect( series.data[ 0 ] ).toEqual( expect.objectContaining( { clicks: 12, value: 12 } ) );
+		expect( series.summary ).toEqual( {
+			date_start: '2026-06-01T00:00:00+00:00',
+			date_end: '2026-06-01T23:59:59+00:00',
+		} );
+	} );
+
+	it( 'flattens grouped child URLs and aggregates them across buckets', () => {
+		const item = ( views: number ): StatsClicksItem => ( {
+			label: 'wordpress.org',
+			views,
+			link: null,
+			icon: null,
+			labelIcon: null,
+			children: [
+				{
+					label: '/plugins/jetpack-search',
+					views,
+					link: 'https://wordpress.org/plugins/jetpack-search',
+					icon: null,
+					labelIcon: 'external',
+					children: null,
+				},
+			],
+		} );
+		const report: StatsNormalizedReport< StatsClicksItem > = {
+			summary: {},
+			data: [
+				{
+					time_interval: '2026-06-01',
+					date_start: '2026-06-01T00:00:00+00:00',
+					date_end: '2026-06-01T23:59:59+00:00',
+					items: [ item( 8 ) ],
+				},
+				{
+					time_interval: '2026-06-02',
+					date_start: '2026-06-02T00:00:00+00:00',
+					date_end: '2026-06-02T23:59:59+00:00',
+					items: [ item( 5 ) ],
+				},
+			],
+		};
+
+		expect( aggregateClickRows( report ) ).toEqual( [
+			{
+				id: 'wordpress.org|https://wordpress.org/plugins/jetpack-search',
+				clickedUrl: 'https://wordpress.org/plugins/jetpack-search',
+				href: 'https://wordpress.org/plugins/jetpack-search',
+				group: 'wordpress.org',
+				clicks: 13,
+			},
+		] );
+	} );
+
+	it( 'keeps a directly linked top-level URL as a row', () => {
+		const report: StatsNormalizedReport< StatsClicksItem > = {
+			summary: {},
+			data: [
+				{
+					time_interval: '2026-06-01',
+					date_start: '2026-06-01T00:00:00+00:00',
+					date_end: '2026-06-01T23:59:59+00:00',
+					items: [
+						{
+							label: 'jetpack.com',
+							views: 4,
+							link: 'https://jetpack.com/',
+							icon: null,
+							labelIcon: 'external',
+							children: null,
+						},
+					],
+				},
+			],
+		};
+
+		expect( aggregateClickRows( report ) ).toEqual( [
+			expect.objectContaining( {
+				clickedUrl: 'https://jetpack.com/',
+				group: 'jetpack.com',
+				clicks: 4,
+			} ),
+		] );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/aggregate.ts
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/aggregate.ts
@@ -1,38 +1,80 @@
-/**
- * Internal dependencies
- */
 import type { ClickRow } from './fields';
 import type {
 	StatsClicksItem,
 	StatsNormalizedReport,
+	StatsPeriod,
 	StatsTimeSeriesReport,
 } from '@jetpack-premium-analytics/data';
 
+type ClicksChartPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
+
 /**
- * Convert a bucketed clicks report to a clicks-per-bucket time series.
+ * Map a daily bucket date onto its chart bucket key for the selected period.
+ *
+ * @param date   - The daily bucket date (`YYYY-MM-DD`).
+ * @param period - The chart bucket period.
+ * @return The bucket key the date aggregates into.
+ */
+function getChartBucketKey( date: string, period: ClicksChartPeriod ): string {
+	if ( period === 'day' ) {
+		return date;
+	}
+
+	const bucketDate = new Date( `${ date.slice( 0, 10 ) }T00:00:00Z` );
+
+	if ( period === 'week' ) {
+		const daysSinceMonday = ( bucketDate.getUTCDay() + 6 ) % 7;
+		bucketDate.setUTCDate( bucketDate.getUTCDate() - daysSinceMonday );
+	} else {
+		bucketDate.setUTCDate( 1 );
+	}
+
+	return bucketDate.toISOString().slice( 0, 10 );
+}
+
+/**
+ * Convert a daily clicks report to a clicks-per-bucket time series.
  *
  * Top-level click groups already contain their children's totals, so only
  * top-level values are summed to avoid double-counting flattened child URLs.
  *
- * @param report - The bucketed clicks report.
+ * @param report - The daily clicks report.
+ * @param period - The chart bucket period.
  * @return The chart-ready time series.
  */
 export function clicksToTimeSeries(
-	report: StatsNormalizedReport< StatsClicksItem > | undefined
+	report: StatsNormalizedReport< StatsClicksItem > | undefined,
+	period: ClicksChartPeriod = 'day'
 ): StatsTimeSeriesReport {
-	const data = ( report?.data ?? [] ).map( point => {
-		const clicks = point.items.reduce( ( total, item ) => total + item.views, 0 );
+	const buckets = new Map< string, StatsTimeSeriesReport[ 'data' ][ number ] >();
+	const points = [ ...( report?.data ?? [] ) ].sort( ( first, second ) =>
+		first.time_interval.localeCompare( second.time_interval )
+	);
 
-		return {
-			time_interval: point.time_interval,
+	for ( const point of points ) {
+		const clicks = point.items.reduce( ( total, item ) => total + item.views, 0 );
+		const key = getChartBucketKey( point.time_interval, period );
+		const existing = buckets.get( key );
+
+		if ( existing ) {
+			existing.date_end = point.date_end;
+			existing.value = Number( existing.value ) + clicks;
+			existing.clicks = Number( existing.clicks ) + clicks;
+			continue;
+		}
+
+		buckets.set( key, {
+			time_interval: key,
 			date_start: point.date_start,
 			date_end: point.date_end,
-			label: point.time_interval,
+			label: key,
 			items: [],
 			value: clicks,
 			clicks,
-		};
-	} );
+		} );
+	}
+
+	const data = [ ...buckets.values() ];
 	const first = data[ 0 ];
 	const last = data[ data.length - 1 ];
 

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/aggregate.ts
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/aggregate.ts
@@ -1,0 +1,105 @@
+/**
+ * Internal dependencies
+ */
+import type { ClickRow } from './fields';
+import type {
+	StatsClicksItem,
+	StatsNormalizedReport,
+	StatsTimeSeriesReport,
+} from '@jetpack-premium-analytics/data';
+
+/**
+ * Convert a bucketed clicks report to a clicks-per-bucket time series.
+ *
+ * Top-level click groups already contain their children's totals, so only
+ * top-level values are summed to avoid double-counting flattened child URLs.
+ *
+ * @param report - The bucketed clicks report.
+ * @return The chart-ready time series.
+ */
+export function clicksToTimeSeries(
+	report: StatsNormalizedReport< StatsClicksItem > | undefined
+): StatsTimeSeriesReport {
+	const data = ( report?.data ?? [] ).map( point => {
+		const clicks = point.items.reduce( ( total, item ) => total + item.views, 0 );
+
+		return {
+			time_interval: point.time_interval,
+			date_start: point.date_start,
+			date_end: point.date_end,
+			label: point.time_interval,
+			items: [],
+			value: clicks,
+			clicks,
+		};
+	} );
+	const first = data[ 0 ];
+	const last = data[ data.length - 1 ];
+
+	return {
+		summary: {
+			...report?.summary,
+			...( first ? { date_start: first.date_start } : {} ),
+			...( last ? { date_end: last.date_end } : {} ),
+		},
+		data,
+	};
+}
+
+/**
+ * Flatten a click group to linked leaf rows.
+ *
+ * @param item  - The current click item.
+ * @param group - The root click group label.
+ * @return Linked leaf rows.
+ */
+function flattenClickItem( item: StatsClicksItem, group: string ): ClickRow[] {
+	const children = item.children ?? [];
+
+	if ( children.length ) {
+		return children.flatMap( child => flattenClickItem( child, group ) );
+	}
+
+	if ( ! item.link ) {
+		return [];
+	}
+
+	return [
+		{
+			id: `${ group }|${ item.link }`,
+			clickedUrl: item.link,
+			href: item.link,
+			group,
+			clicks: item.views,
+		},
+	];
+}
+
+/**
+ * Aggregate bucketed click groups into one flat row per clicked URL.
+ *
+ * @param report - The bucketed clicks report.
+ * @return Flat URL rows with their root click group.
+ */
+export function aggregateClickRows(
+	report?: StatsNormalizedReport< StatsClicksItem >
+): ClickRow[] {
+	const byKey = new Map< string, ClickRow >();
+
+	for ( const point of report?.data ?? [] ) {
+		for ( const item of point.items ) {
+			const group = String( item.label ?? '' );
+			for ( const row of flattenClickItem( item, group ) ) {
+				const existing = byKey.get( row.id );
+
+				if ( existing ) {
+					existing.clicks += row.clicks;
+				} else {
+					byKey.set( row.id, { ...row } );
+				}
+			}
+		}
+	}
+
+	return [ ...byKey.values() ];
+}

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/aggregate.ts
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/aggregate.ts
@@ -1,36 +1,17 @@
-import type { ClickRow } from './fields';
-import type {
-	StatsClicksItem,
-	StatsNormalizedReport,
-	StatsPeriod,
-	StatsTimeSeriesReport,
-} from '@jetpack-premium-analytics/data';
-
-type ClicksChartPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
-
 /**
- * Map a daily bucket date onto its chart bucket key for the selected period.
- *
- * @param date   - The daily bucket date (`YYYY-MM-DD`).
- * @param period - The chart bucket period.
- * @return The bucket key the date aggregates into.
+ * External dependencies
  */
-function getChartBucketKey( date: string, period: ClicksChartPeriod ): string {
-	if ( period === 'day' ) {
-		return date;
-	}
-
-	const bucketDate = new Date( `${ date.slice( 0, 10 ) }T00:00:00Z` );
-
-	if ( period === 'week' ) {
-		const daysSinceMonday = ( bucketDate.getUTCDay() + 6 ) % 7;
-		bucketDate.setUTCDate( bucketDate.getUTCDate() - daysSinceMonday );
-	} else {
-		bucketDate.setUTCDate( 1 );
-	}
-
-	return bucketDate.toISOString().slice( 0, 10 );
-}
+import {
+	bucketStatsTimeSeries,
+	type StatsChartBucketPeriod,
+	type StatsClicksItem,
+	type StatsNormalizedReport,
+	type StatsTimeSeriesReport,
+} from '@jetpack-premium-analytics/data';
+/**
+ * Internal dependencies
+ */
+import type { ClickRow } from './fields';
 
 /**
  * Convert a daily clicks report to a clicks-per-bucket time series.
@@ -44,48 +25,13 @@ function getChartBucketKey( date: string, period: ClicksChartPeriod ): string {
  */
 export function clicksToTimeSeries(
 	report: StatsNormalizedReport< StatsClicksItem > | undefined,
-	period: ClicksChartPeriod = 'day'
+	period: StatsChartBucketPeriod = 'day'
 ): StatsTimeSeriesReport {
-	const buckets = new Map< string, StatsTimeSeriesReport[ 'data' ][ number ] >();
-	const points = [ ...( report?.data ?? [] ) ].sort( ( first, second ) =>
-		first.time_interval.localeCompare( second.time_interval )
-	);
-
-	for ( const point of points ) {
+	return bucketStatsTimeSeries( report, period, point => {
 		const clicks = point.items.reduce( ( total, item ) => total + item.views, 0 );
-		const key = getChartBucketKey( point.time_interval, period );
-		const existing = buckets.get( key );
 
-		if ( existing ) {
-			existing.date_end = point.date_end;
-			existing.value = Number( existing.value ) + clicks;
-			existing.clicks = Number( existing.clicks ) + clicks;
-			continue;
-		}
-
-		buckets.set( key, {
-			time_interval: key,
-			date_start: point.date_start,
-			date_end: point.date_end,
-			label: key,
-			items: [],
-			value: clicks,
-			clicks,
-		} );
-	}
-
-	const data = [ ...buckets.values() ];
-	const first = data[ 0 ];
-	const last = data[ data.length - 1 ];
-
-	return {
-		summary: {
-			...report?.summary,
-			...( first ? { date_start: first.date_start } : {} ),
-			...( last ? { date_end: last.date_end } : {} ),
-		},
-		data,
-	};
+		return { value: clicks, clicks };
+	} );
 }
 
 /**

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/fields.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from '@testing-library/react';
+import { getClicksFields, type ClickRow } from './fields';
+
+const row: ClickRow = {
+	id: 'wordpress.org|https://wordpress.org/plugins/jetpack-search',
+	clickedUrl: 'https://wordpress.org/plugins/jetpack-search',
+	href: 'https://wordpress.org/plugins/jetpack-search',
+	group: 'wordpress.org',
+	clicks: 42,
+};
+
+describe( 'clicks fields', () => {
+	it( 'renders clicked URLs as safe external links', () => {
+		const field = getClicksFields().find( candidate => candidate.id === 'clickedUrl' );
+		const { render: UrlField } = field ?? {};
+
+		if ( ! field || ! UrlField ) {
+			throw new Error( 'Clicked URL field render callback is unavailable' );
+		}
+
+		render( <UrlField item={ row } field={ field as never } /> );
+
+		const link = screen.getByRole( 'link', { name: row.clickedUrl } );
+		expect( link ).toHaveAttribute( 'href', row.href );
+		expect( link ).toHaveAttribute( 'target', '_blank' );
+		expect( link ).toHaveAttribute( 'rel', 'noopener noreferrer' );
+	} );
+
+	it( 'renders clicked URLs with unsafe schemes as plain text', () => {
+		const field = getClicksFields().find( candidate => candidate.id === 'clickedUrl' );
+		const { render: UrlField } = field ?? {};
+		const unsafeRow = { ...row, href: 'javascript:alert(1)' };
+
+		if ( ! field || ! UrlField ) {
+			throw new Error( 'Clicked URL field render callback is unavailable' );
+		}
+
+		render( <UrlField item={ unsafeRow } field={ field as never } /> );
+
+		expect( screen.getByText( unsafeRow.clickedUrl ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'link', { name: unsafeRow.clickedUrl } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'makes URL and group values globally searchable', () => {
+		const fields = getClicksFields();
+
+		expect( fields.find( field => field.id === 'clickedUrl' )?.enableGlobalSearch ).toBe( true );
+		expect( fields.find( field => field.id === 'group' )?.enableGlobalSearch ).toBe( true );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/fields.tsx
@@ -1,0 +1,72 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import type { Field } from '@wordpress/dataviews';
+
+export type ClickRow = {
+	id: string;
+	clickedUrl: string;
+	href: string;
+	group: string;
+	clicks: number;
+};
+
+/**
+ * Return a URL only when it parses with an HTTP or HTTPS scheme.
+ *
+ * @param url - The candidate URL.
+ * @return The safe HTTP(S) URL, or null when it is missing, unparseable, or uses another scheme.
+ */
+function safeHttpUrl( url: string | undefined ): string | null {
+	if ( ! url ) {
+		return null;
+	}
+
+	try {
+		const { protocol } = new URL( url );
+		return protocol === 'http:' || protocol === 'https:' ? url : null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * DataViews field config for the Clicks records table.
+ *
+ * @return The field config.
+ */
+export function getClicksFields(): Field< ClickRow >[] {
+	return [
+		{
+			id: 'clickedUrl',
+			label: __( 'Clicked URL', 'jetpack-premium-analytics' ),
+			enableGlobalSearch: true,
+			enableHiding: false,
+			getValue: ( { item } ) => item.clickedUrl,
+			render: ( { item } ) => {
+				const safeUrl = safeHttpUrl( item.href );
+
+				return safeUrl ? (
+					<a href={ safeUrl } target="_blank" rel="noopener noreferrer">
+						{ item.clickedUrl }
+					</a>
+				) : (
+					<>{ item.clickedUrl }</>
+				);
+			},
+		},
+		{
+			id: 'group',
+			label: __( 'Group', 'jetpack-premium-analytics' ),
+			enableGlobalSearch: true,
+			getValue: ( { item } ) => item.group,
+		},
+		{
+			id: 'clicks',
+			label: __( 'Clicks', 'jetpack-premium-analytics' ),
+			getValue: ( { item } ) => item.clicks,
+			render: ( { item } ) => <>{ item.clicks.toLocaleString() }</>,
+		},
+	];
+}

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/index.ts
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/index.ts
@@ -1,0 +1,3 @@
+export { aggregateClickRows, clicksToTimeSeries } from './aggregate';
+export { getClicksFields, type ClickRow } from './fields';
+export { useClicksReportRecords } from './use-report-records';

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/use-report-records.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/use-report-records.test.ts
@@ -50,6 +50,42 @@ const report: StatsNormalizedReport< StatsClicksItem > = {
 	],
 };
 
+const comparisonReport: StatsNormalizedReport< StatsClicksItem > = {
+	summary: {},
+	data: [
+		{
+			time_interval: '2026-07-07',
+			date_start: '2026-07-07T00:00:00+00:00',
+			date_end: '2026-07-07T23:59:59+00:00',
+			items: [
+				{
+					label: 'wordpress.com',
+					views: 4,
+					link: 'https://wordpress.com/',
+					icon: null,
+					labelIcon: 'external',
+					children: null,
+				},
+			],
+		},
+		{
+			time_interval: '2026-07-08',
+			date_start: '2026-07-08T00:00:00+00:00',
+			date_end: '2026-07-08T23:59:59+00:00',
+			items: [
+				{
+					label: 'wordpress.org',
+					views: 5,
+					link: 'https://wordpress.org/',
+					icon: null,
+					labelIcon: 'external',
+					children: null,
+				},
+			],
+		},
+	],
+};
+
 const params: ReportParams = {
 	from: '2026-07-09',
 	to: '2026-07-10',
@@ -113,5 +149,57 @@ describe( 'useClicksReportRecords', () => {
 			} ),
 		] );
 		expect( result.current.rows ).toEqual( dayRows );
+	} );
+
+	it( 'includes comparison chart buckets when clicked URLs do not overlap the primary period', () => {
+		mockUseStatsClicks.mockReturnValue( {
+			primary: { data: report },
+			comparison: { data: comparisonReport },
+			hasComparison: false,
+			isLoading: false,
+		} as ReturnType< typeof useStatsClicks > );
+		const comparisonParams: ReportParams = {
+			...params,
+			compare_from: '2026-07-07',
+			compare_to: '2026-07-08',
+		};
+
+		const { result } = renderHook( () => useClicksReportRecords( comparisonParams, 'day' ) );
+
+		expect( result.current.chart.comparison ).toBeDefined();
+		expect( result.current.chart.comparison?.data.map( point => point.clicks ) ).toEqual( [
+			4, 5,
+		] );
+	} );
+
+	it( 'omits the comparison chart when comparison params are absent', () => {
+		mockUseStatsClicks.mockReturnValue( {
+			primary: { data: report },
+			comparison: { data: comparisonReport },
+			hasComparison: false,
+			isLoading: false,
+		} as ReturnType< typeof useStatsClicks > );
+
+		const { result } = renderHook( () => useClicksReportRecords( params, 'day' ) );
+
+		expect( result.current.chart.comparison ).toBeUndefined();
+	} );
+
+	it( 'omits the comparison chart while the comparison query is loading', () => {
+		mockUseStatsClicks.mockReturnValue( {
+			primary: { data: report },
+			comparison: { data: undefined },
+			hasComparison: false,
+			isLoading: true,
+		} as ReturnType< typeof useStatsClicks > );
+		const comparisonParams: ReportParams = {
+			...params,
+			compare_from: '2026-07-07',
+			compare_to: '2026-07-08',
+		};
+
+		const { result } = renderHook( () => useClicksReportRecords( comparisonParams, 'day' ) );
+
+		expect( result.current.chart.comparison ).toBeUndefined();
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/use-report-records.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/use-report-records.test.ts
@@ -1,0 +1,117 @@
+import { useStatsClicks } from '@jetpack-premium-analytics/data';
+import { renderHook } from '@testing-library/react';
+import { useClicksReportRecords } from './use-report-records';
+import type {
+	ReportParams,
+	StatsClicksItem,
+	StatsNormalizedReport,
+} from '@jetpack-premium-analytics/data';
+
+jest.mock( '@jetpack-premium-analytics/data', () => ( {
+	...jest.requireActual( '@jetpack-premium-analytics/data' ),
+	useStatsClicks: jest.fn(),
+} ) );
+
+const mockUseStatsClicks = useStatsClicks as jest.MockedFunction< typeof useStatsClicks >;
+
+const report: StatsNormalizedReport< StatsClicksItem > = {
+	summary: {},
+	data: [
+		{
+			time_interval: '2026-07-09',
+			date_start: '2026-07-09T00:00:00+00:00',
+			date_end: '2026-07-09T23:59:59+00:00',
+			items: [
+				{
+					label: 'jetpack.com',
+					views: 7,
+					link: 'https://jetpack.com/',
+					icon: null,
+					labelIcon: 'external',
+					children: null,
+				},
+			],
+		},
+		{
+			time_interval: '2026-07-10',
+			date_start: '2026-07-10T00:00:00+00:00',
+			date_end: '2026-07-10T23:59:59+00:00',
+			items: [
+				{
+					label: 'jetpack.com',
+					views: 6,
+					link: 'https://jetpack.com/',
+					icon: null,
+					labelIcon: 'external',
+					children: null,
+				},
+			],
+		},
+	],
+};
+
+const params: ReportParams = {
+	from: '2026-07-09',
+	to: '2026-07-10',
+	interval: 'day',
+};
+
+/**
+ * Configure the mocked Stats hook with the daily report fixture.
+ */
+function mockClicksReport() {
+	mockUseStatsClicks.mockReturnValue( {
+		primary: { data: report },
+		comparison: { data: undefined },
+		hasComparison: false,
+		isLoading: false,
+	} as ReturnType< typeof useStatsClicks > );
+}
+
+describe( 'useClicksReportRecords', () => {
+	beforeEach( () => {
+		mockUseStatsClicks.mockReset();
+		mockClicksReport();
+	} );
+
+	it( 'derives table and daily chart data from a day-bucketed request', () => {
+		const { result } = renderHook( () => useClicksReportRecords( params, 'day' ) );
+
+		expect( mockUseStatsClicks ).toHaveBeenCalledWith( {
+			...params,
+			max: 0,
+			summarize: 0,
+			period: 'day',
+		} );
+		expect( result.current.chart.primary.data.map( point => point.clicks ) ).toEqual( [ 7, 6 ] );
+		expect( result.current.rows ).toEqual( [
+			expect.objectContaining( { clickedUrl: 'https://jetpack.com/', clicks: 13 } ),
+		] );
+	} );
+
+	it( 'keeps the request day-bucketed while grouping only the chart by week', () => {
+		const { result: dayResult, unmount } = renderHook( () =>
+			useClicksReportRecords( params, 'day' )
+		);
+		const dayRows = dayResult.current.rows;
+		unmount();
+		mockUseStatsClicks.mockClear();
+
+		const { result } = renderHook( () => useClicksReportRecords( params, 'week' ) );
+
+		expect( mockUseStatsClicks ).toHaveBeenCalledWith( {
+			...params,
+			max: 0,
+			summarize: 0,
+			period: 'day',
+		} );
+		expect( result.current.chart.primary.data ).toEqual( [
+			expect.objectContaining( {
+				time_interval: '2026-07-06',
+				clicks: 13,
+				value: 13,
+			} ),
+		] );
+		expect( result.current.rows ).toEqual( dayRows );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/use-report-records.ts
@@ -12,6 +12,8 @@ import { useMemo } from '@wordpress/element';
  */
 import { aggregateClickRows, clicksToTimeSeries } from './aggregate';
 
+type ClicksChartPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
+
 /**
  * Fetch and derive the Clicks chart and table from one bucketed query.
  *
@@ -19,29 +21,32 @@ import { aggregateClickRows, clicksToTimeSeries } from './aggregate';
  * @param chartPeriod  - The chart's bucket period.
  * @return Chart data and flat clicked-URL rows.
  */
-export function useClicksReportRecords( reportParams: ReportParams, chartPeriod: StatsPeriod ) {
+export function useClicksReportRecords(
+	reportParams: ReportParams,
+	chartPeriod: ClicksChartPeriod
+) {
 	const recordsParams = useMemo(
 		() => ( {
 			...reportParams,
 			max: 0,
 			summarize: 0,
-			period: chartPeriod,
+			period: 'day',
 		} ),
-		[ reportParams, chartPeriod ]
+		[ reportParams ]
 	);
 	const report = useStatsClicks( recordsParams );
 
 	const chartPrimary = useMemo(
-		() => clicksToTimeSeries( report.primary.data ),
-		[ report.primary.data ]
+		() => clicksToTimeSeries( report.primary.data, chartPeriod ),
+		[ report.primary.data, chartPeriod ]
 	);
 	const chartComparison = useMemo( () => {
 		if ( ! reportParams.compare_from || ! reportParams.compare_to ) {
 			return undefined;
 		}
 
-		return clicksToTimeSeries( report.comparison.data );
-	}, [ reportParams, report.comparison.data ] );
+		return clicksToTimeSeries( report.comparison.data, chartPeriod );
+	}, [ reportParams, report.comparison.data, chartPeriod ] );
 	const rows = useMemo( () => aggregateClickRows( report.primary.data ), [ report.primary.data ] );
 
 	return {

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/use-report-records.ts
@@ -4,15 +4,13 @@
 import {
 	useStatsClicks,
 	type ReportParams,
-	type StatsPeriod,
+	type StatsChartBucketPeriod,
 } from '@jetpack-premium-analytics/data';
 import { useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
 import { aggregateClickRows, clicksToTimeSeries } from './aggregate';
-
-type ClicksChartPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
 
 /**
  * Fetch and derive the Clicks chart and table from one bucketed query.
@@ -23,7 +21,7 @@ type ClicksChartPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
  */
 export function useClicksReportRecords(
 	reportParams: ReportParams,
-	chartPeriod: ClicksChartPeriod
+	chartPeriod: StatsChartBucketPeriod
 ) {
 	const recordsParams = useMemo(
 		() => ( {

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/use-report-records.ts
@@ -50,7 +50,7 @@ export function useClicksReportRecords(
 	return {
 		chart: {
 			primary: chartPrimary,
-			comparison: report.hasComparison ? chartComparison : undefined,
+			comparison: report.comparison.data ? chartComparison : undefined,
 			isLoading: report.isLoading,
 		},
 		rows,

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/use-report-records.ts
@@ -1,0 +1,56 @@
+/**
+ * External dependencies
+ */
+import {
+	useStatsClicks,
+	type ReportParams,
+	type StatsPeriod,
+} from '@jetpack-premium-analytics/data';
+import { useMemo } from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import { aggregateClickRows, clicksToTimeSeries } from './aggregate';
+
+/**
+ * Fetch and derive the Clicks chart and table from one bucketed query.
+ *
+ * @param reportParams - The shared report-window parameters.
+ * @param chartPeriod  - The chart's bucket period.
+ * @return Chart data and flat clicked-URL rows.
+ */
+export function useClicksReportRecords( reportParams: ReportParams, chartPeriod: StatsPeriod ) {
+	const recordsParams = useMemo(
+		() => ( {
+			...reportParams,
+			max: 0,
+			summarize: 0,
+			period: chartPeriod,
+		} ),
+		[ reportParams, chartPeriod ]
+	);
+	const report = useStatsClicks( recordsParams );
+
+	const chartPrimary = useMemo(
+		() => clicksToTimeSeries( report.primary.data ),
+		[ report.primary.data ]
+	);
+	const chartComparison = useMemo( () => {
+		if ( ! reportParams.compare_from || ! reportParams.compare_to ) {
+			return undefined;
+		}
+
+		return clicksToTimeSeries( report.comparison.data );
+	}, [ reportParams, report.comparison.data ] );
+	const rows = useMemo( () => aggregateClickRows( report.primary.data ), [ report.primary.data ] );
+
+	return {
+		chart: {
+			primary: chartPrimary,
+			comparison: report.hasComparison ? chartComparison : undefined,
+			isLoading: report.isLoading,
+		},
+		rows,
+		isLoading: report.isLoading,
+	};
+}

--- a/projects/packages/premium-analytics/routes/reports/clicks/page.module.css
+++ b/projects/packages/premium-analytics/routes/reports/clicks/page.module.css
@@ -13,7 +13,7 @@
 	 * tab strip is designed to sit flush under the header.
 	 */
 	padding-block-start: var(--wpds-dimension-padding-lg);
-	padding-block-end: 24px;
+	padding-block-end: var(--wpds-dimension-padding-2xl);
 	padding-inline: var(--wpds-dimension-padding-2xl);
 }
 

--- a/projects/packages/premium-analytics/routes/reports/clicks/page.module.css
+++ b/projects/packages/premium-analytics/routes/reports/clicks/page.module.css
@@ -1,0 +1,22 @@
+.page {
+	min-block-size: 0;
+}
+
+.content {
+	flex: 1 1 auto;
+	min-block-size: 0;
+	overflow-y: auto;
+
+	/*
+	 * Mirror the top padding of Page's own `hasPadding` content so the filters
+	 * row doesn't hug the header border — tabbed reports skip this because the
+	 * tab strip is designed to sit flush under the header.
+	 */
+	padding-block-start: var(--wpds-dimension-padding-lg);
+	padding-block-end: 24px;
+	padding-inline: var(--wpds-dimension-padding-2xl);
+}
+
+.dateFilters {
+	inline-size: 100%;
+}

--- a/projects/packages/premium-analytics/routes/reports/clicks/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/clicks/page.tsx
@@ -4,7 +4,7 @@
 import {
 	normalizeReportParams,
 	type IntervalType,
-	type StatsPeriod,
+	type StatsChartBucketPeriod,
 } from '@jetpack-premium-analytics/data';
 import { useDashboardLink, useReportDateFilters } from '@jetpack-premium-analytics/routing';
 import { DateFiltersPanel } from '@jetpack-premium-analytics/ui';
@@ -27,8 +27,11 @@ import styles from './page.module.css';
 
 const ROUTE_FROM = route.path;
 const REPORT_PARAMS = { report: 'clicks' };
-const CHART_PERIODS = [ 'day', 'week', 'month' ] as const satisfies readonly StatsPeriod[];
-type ChartPeriod = ( typeof CHART_PERIODS )[ number ];
+const CHART_PERIODS = [
+	'day',
+	'week',
+	'month',
+] as const satisfies readonly StatsChartBucketPeriod[];
 
 /**
  * Check whether a URL value is a supported chart period.
@@ -36,8 +39,8 @@ type ChartPeriod = ( typeof CHART_PERIODS )[ number ];
  * @param value - The URL search value.
  * @return Whether the value is a chart period.
  */
-function isChartPeriod( value: unknown ): value is ChartPeriod {
-	return CHART_PERIODS.includes( value as ChartPeriod );
+function isChartPeriod( value: unknown ): value is StatsChartBucketPeriod {
+	return CHART_PERIODS.includes( value as StatsChartBucketPeriod );
 }
 
 /**
@@ -46,7 +49,7 @@ function isChartPeriod( value: unknown ): value is ChartPeriod {
  * @param interval - The report date interval.
  * @return The default chart bucket period.
  */
-function getDefaultChartPeriod( interval?: IntervalType ): ChartPeriod {
+function getDefaultChartPeriod( interval?: IntervalType ): StatsChartBucketPeriod {
 	if ( interval === 'week' ) {
 		return 'week';
 	}

--- a/projects/packages/premium-analytics/routes/reports/clicks/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/clicks/page.tsx
@@ -1,0 +1,184 @@
+/**
+ * External dependencies
+ */
+import {
+	normalizeReportParams,
+	type IntervalType,
+	type StatsPeriod,
+} from '@jetpack-premium-analytics/data';
+import { useDashboardLink, useReportDateFilters } from '@jetpack-premium-analytics/routing';
+import { DateFiltersPanel } from '@jetpack-premium-analytics/ui';
+import {
+	formatLegendLabels,
+	ReportPageLayout,
+	ReportPerformanceChart,
+	ReportRecordsTable,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { Breadcrumbs, Page } from '@wordpress/admin-ui';
+import { useCallback, useMemo, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useNavigate, useSearch } from '@wordpress/route';
+/**
+ * Internal dependencies
+ */
+import { route } from '../package.json';
+import { getClicksFields, useClicksReportRecords, type ClickRow } from './config';
+import styles from './page.module.css';
+
+const ROUTE_FROM = route.path;
+const REPORT_PARAMS = { report: 'clicks' };
+const CHART_PERIODS = [ 'day', 'week', 'month' ] as const satisfies readonly StatsPeriod[];
+type ChartPeriod = ( typeof CHART_PERIODS )[ number ];
+
+/**
+ * Check whether a URL value is a supported chart period.
+ *
+ * @param value - The URL search value.
+ * @return Whether the value is a chart period.
+ */
+function isChartPeriod( value: unknown ): value is ChartPeriod {
+	return CHART_PERIODS.includes( value as ChartPeriod );
+}
+
+/**
+ * Choose the chart bucket period for a report interval.
+ *
+ * @param interval - The report date interval.
+ * @return The default chart bucket period.
+ */
+function getDefaultChartPeriod( interval?: IntervalType ): ChartPeriod {
+	if ( interval === 'week' ) {
+		return 'week';
+	}
+
+	if ( interval === 'month' || interval === 'quarter' || interval === 'year' ) {
+		return 'month';
+	}
+
+	return 'day';
+}
+
+/**
+ * Stable row id for the Clicks records table.
+ *
+ * @param item - The clicked URL row.
+ * @return The row id.
+ */
+function getClickRowId( item: ClickRow ): string {
+	return item.id;
+}
+
+const RECORDS_VIEW = {
+	sort: { field: 'clicks', direction: 'desc' as const },
+	layout: {
+		styles: {
+			clickedUrl: { width: '100%' },
+			clicks: { align: 'end' as const },
+		},
+	},
+};
+
+/**
+ * Premium Analytics Clicks report page component.
+ *
+ * @return The Clicks report page.
+ */
+function ClicksReport(): JSX.Element {
+	const search = useSearch( { from: ROUTE_FROM } ) as Record< string, string | undefined >;
+	const reportParams = useMemo(
+		() => normalizeReportParams( search as Parameters< typeof normalizeReportParams >[ 0 ] ),
+		[ search ]
+	);
+
+	const chartPeriod = isChartPeriod( search.period )
+		? search.period
+		: getDefaultChartPeriod( reportParams.interval );
+	const records = useClicksReportRecords( reportParams, chartPeriod );
+	const fields = useMemo( () => getClicksFields(), [] );
+	const chartMetrics = useMemo(
+		() => [ { key: 'clicks', label: __( 'Clicks', 'jetpack-premium-analytics' ) } ],
+		[]
+	);
+	const chartLegendLabels = useMemo( () => formatLegendLabels( reportParams ), [ reportParams ] );
+
+	const navigate = useNavigate();
+	const handleIntervalChange = useCallback(
+		( interval: IntervalType ) => {
+			const period = isChartPeriod( interval ) ? interval : getDefaultChartPeriod( interval );
+			navigate( {
+				to: ROUTE_FROM,
+				/*
+				 * The router is built dynamically, so `/reports/$report` has no
+				 * statically-typed params/search schema (tanstack widens them to
+				 * `never`). Cast the same way the routing package does when it
+				 * writes the URL.
+				 */
+				params: REPORT_PARAMS as unknown as never,
+				replace: true,
+				search: ( ( current: Record< string, unknown > ) => ( {
+					...current,
+					period,
+				} ) ) as unknown as never,
+			} );
+		},
+		[ navigate ]
+	);
+
+	const dateFilters = useReportDateFilters( ROUTE_FROM );
+	const dashboardLink = useDashboardLink();
+	const [ containerElement, setContainerElement ] = useState< HTMLDivElement | null >( null );
+
+	return (
+		<Page
+			breadcrumbs={
+				<Breadcrumbs
+					items={ [
+						{
+							label: __( 'Stats', 'jetpack-premium-analytics' ),
+							to: dashboardLink,
+						},
+						{ label: __( 'Clicks', 'jetpack-premium-analytics' ) },
+					] }
+				/>
+			}
+			className={ styles.page }
+		>
+			<div className={ styles.content }>
+				<ReportPageLayout
+					filters={
+						<div ref={ setContainerElement } className={ styles.dateFilters }>
+							<DateFiltersPanel { ...dateFilters } containerElement={ containerElement } />
+						</div>
+					}
+				>
+					<ReportPerformanceChart
+						primary={ records.chart.primary }
+						comparison={ records.chart.comparison }
+						isLoading={ records.chart.isLoading }
+						metrics={ chartMetrics }
+						interval={ chartPeriod }
+						onIntervalChange={ handleIntervalChange }
+						legendLabels={ chartLegendLabels }
+					/>
+					<ReportRecordsTable< ClickRow >
+						data={ records.rows }
+						fields={ fields }
+						getItemId={ getClickRowId }
+						isLoading={ records.isLoading }
+						initialView={ RECORDS_VIEW }
+						searchLabel={ __( 'Search clicked URLs', 'jetpack-premium-analytics' ) }
+					/>
+				</ReportPageLayout>
+			</div>
+		</Page>
+	);
+}
+
+/**
+ * Clicks report page (default export for the report registry).
+ *
+ * @return The Clicks report page.
+ */
+export default function ClicksReportPage(): JSX.Element {
+	return <ClicksReport />;
+}

--- a/projects/packages/premium-analytics/routes/reports/registry.ts
+++ b/projects/packages/premium-analytics/routes/reports/registry.ts
@@ -74,6 +74,11 @@ export const REPORTS: Record< string, ReportDefinition > = {
 		getTitle: () => __( 'Comments Subscribers', 'jetpack-premium-analytics' ),
 		load: () => import( './comment-followers/page' ),
 	},
+	clicks: {
+		id: 'clicks',
+		getTitle: () => __( 'Clicks', 'jetpack-premium-analytics' ),
+		load: () => import( './clicks/page' ),
+	},
 	downloads: {
 		id: 'downloads',
 		getTitle: () => __( 'File downloads', 'jetpack-premium-analytics' ),

--- a/projects/packages/premium-analytics/widgets/clicks/__tests__/clicks.test.tsx
+++ b/projects/packages/premium-analytics/widgets/clicks/__tests__/clicks.test.tsx
@@ -4,6 +4,7 @@
 import { getDefaultQueryParams, queryClient } from '@jetpack-premium-analytics/data';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
+import type { AnchorHTMLAttributes, ReactNode } from 'react';
 /**
  * Internal dependencies
  */
@@ -12,7 +13,33 @@ import type { StatsClicksItem, StatsNormalizedReport } from '@jetpack-premium-an
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
+type MockRouteLinkProps = {
+	to: string;
+	params?: Record< string, unknown >;
+	search?: Record< string, unknown >;
+	children: ReactNode;
+} & Omit< AnchorHTMLAttributes< HTMLAnchorElement >, 'href' >;
+
 jest.mock( '@wordpress/route', () => ( {
+	Link: ( { to, params, search, children, ...props }: MockRouteLinkProps ) => {
+		const path = Object.entries( params ?? {} ).reduce(
+			( acc, [ key, value ] ) => acc.replace( `$${ key }`, String( value ) ),
+			to
+		);
+		const query = new URLSearchParams();
+		Object.entries( search ?? {} ).forEach( ( [ key, value ] ) => {
+			if ( value !== undefined && value !== null ) {
+				query.set( key, String( value ) );
+			}
+		} );
+		const queryString = query.toString();
+
+		return (
+			<a href={ queryString ? `${ path }?${ queryString }` : path } { ...props }>
+				{ children }
+			</a>
+		);
+	},
 	useSearch: () => ( {} ),
 } ) );
 
@@ -89,6 +116,15 @@ describe( 'ClicksWidget', () => {
 
 		const link = await screen.findByRole( 'link', { name: /jetpack\.com/i } );
 		expect( link ).toHaveAttribute( 'href', 'https://jetpack.com/' );
+	} );
+
+	it( 'links to the Clicks report', () => {
+		render( <ClicksWidget attributes={ { max: 10 } } /> );
+
+		expect( screen.getByRole( 'link', { name: 'See report' } ) ).toHaveAttribute(
+			'href',
+			expect.stringContaining( '/reports/clicks' )
+		);
 	} );
 
 	it( 'clears the stored drill-down when the selected link leaves the data', async () => {

--- a/projects/packages/premium-analytics/widgets/clicks/render.tsx
+++ b/projects/packages/premium-analytics/widgets/clicks/render.tsx
@@ -12,7 +12,9 @@ import {
 import {
 	LeaderboardChart,
 	LeaderboardLabel,
+	ReportLink,
 	WidgetBackLink,
+	WidgetFooter,
 	WidgetRoot,
 	WidgetState,
 	calculateDelta,
@@ -358,6 +360,9 @@ export default function ClicksWidget( { attributes = {} }: ClicksWidgetProps ) {
 		<WidgetRoot attributes={ attributes }>
 			<div className={ styles.root }>
 				<ClicksInner max={ max } />
+				<WidgetFooter>
+					<ReportLink report="clicks" />
+				</WidgetFooter>
 			</div>
 		</WidgetRoot>
 	);

--- a/projects/packages/premium-analytics/widgets/clicks/stories/clicks-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/clicks/stories/clicks-widget.stories.tsx
@@ -14,6 +14,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withStoryRouter } from '../../stories/with-story-router';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import ClicksRender from '../render';
 import widgetDefinition from '../widget';
@@ -98,13 +99,13 @@ type DashboardStory = StoryObj< ClicksDashboardStoryProps >;
 export const Default: Story = {
 	render: renderClicksWidget,
 	args: { withComparison: false },
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 };
 
 export const WithComparison: Story = {
 	render: renderClicksWidget,
 	args: { withComparison: true },
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 };
 
 /**
@@ -118,7 +119,7 @@ export const Loading: Story = {
 	render: () => renderClicksOnPreset( 'last-90-days' ),
 	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 	beforeEach: () => {
 		forceStatsMockState( 'stats/clicks', 'loading' );
 		return () => forceStatsMockState( 'stats/clicks', null );
@@ -132,7 +133,7 @@ export const Loading: Story = {
 export const Error: Story = {
 	render: () => renderClicksOnPreset( 'last-7-days' ),
 	tags: [ '!autodocs' ],
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 	beforeEach: () => {
 		forceStatsMockState( 'stats/clicks', 'error' );
 		return () => forceStatsMockState( 'stats/clicks', null );
@@ -146,7 +147,7 @@ export const Error: Story = {
 export const Empty: Story = {
 	render: () => renderClicksOnPreset( 'last-365-days' ),
 	tags: [ '!autodocs' ],
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 	beforeEach: () => {
 		forceStatsMockState( 'stats/clicks', 'empty' );
 		return () => forceStatsMockState( 'stats/clicks', null );


### PR DESCRIPTION
Part of [WOOA7S-1698](https://linear.app/a8c/issue/WOOA7S-1698)

**Note: Grouped click rows do not display their child URLs yet; this can be added later once we have confirmation on the drill-down DataViews UX**

<img width="1940" height="1772" alt="Google Chrome -2026-07-14 at 12 07 05@2x" src="https://github.com/user-attachments/assets/3fdcaee9-d44f-4c66-aaf3-1951a669e46c" />

## Proposed changes

* Adds the Clicks report at `/reports/clicks` on the reports framework from #50305: a `routes/reports/clicks/` page module (performance chart + records table, `config/aggregate.ts` with tests) and one `REPORTS` registry entry.
* The Clicks widget footer links to the report via the shared `WidgetFooter`/`ReportLink`, carrying the dashboard's current date range and comparison.


## Related product discussion/links

* [WOOA7S-1698](https://linear.app/a8c/issue/WOOA7S-1698)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `cd projects/packages/premium-analytics && pnpm run build`, open the Premium Analytics dashboard on a site with traffic data.
* In the Clicks widget, click **View all** — you should land on `/reports/clicks` with the dashboard's date range and comparison intact.
* On the chart: change the time bucket (day/week/month) and collapse/expand it.
* On the table: search, sort, and page through — all client-side, no new requests.
* Change the date range from the page's date filter — chart and table should update together, and reloading the URL should restore the exact view.
