### PR TITLE
WOOA7S-1699: Premium Analytics: add the UTM report at /reports/utm

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-wooa7s-1699-utm-report-page
+++ b/projects/packages/premium-analytics/changelog/add-wooa7s-1699-utm-report-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add the UTM report at `/reports/utm`.

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/utm.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/utm.test.ts
@@ -58,6 +58,7 @@ describe( 'Stats UTM normalizer', () => {
 			{
 				label: 'spring-sale / newsletter / email',
 				value: 18,
+				paramValues: '["spring-sale","newsletter","email"]',
 				children: [
 					{
 						id: 41,
@@ -84,6 +85,7 @@ describe( 'Stats UTM normalizer', () => {
 			{
 				label: 'direct',
 				value: 7,
+				paramValues: 'direct',
 				children: null,
 			},
 		] );
@@ -96,7 +98,7 @@ describe( 'Stats UTM normalizer', () => {
 		} );
 	} );
 
-	it( 'treats an empty top posts object as already resolved', () => {
+	it( 'returns no children for an empty top posts object', () => {
 		const result = sanitizeStatsUtmResponse(
 			{
 				top_utm_values: {
@@ -111,6 +113,7 @@ describe( 'Stats UTM normalizer', () => {
 			{
 				label: 'direct',
 				value: 7,
+				paramValues: 'direct',
 				children: null,
 			},
 		] );
@@ -137,7 +140,7 @@ describe( 'Stats UTM normalizer', () => {
 		] );
 	} );
 
-	it( 'treats disabled top post queries as already resolved', () => {
+	it( 'keeps param values when top post queries are disabled', () => {
 		const result = sanitizeStatsUtmResponse(
 			{
 				top_utm_values: {
@@ -155,6 +158,7 @@ describe( 'Stats UTM normalizer', () => {
 			{
 				label: 'newsletter / email',
 				value: 24,
+				paramValues: '["newsletter","email"]',
 				children: null,
 			},
 		] );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/utm.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/utm.ts
@@ -143,9 +143,6 @@ export function sanitizeStatsUtmResponse(
 	const payload = coerceStatsRecord( response );
 	const topUtmValues = coerceStatsRecord( payload.top_utm_values );
 	const topPosts = coerceStatsRecord( payload.top_posts );
-	// Calypso treats the presence of top_posts, even an empty object, or an explicit
-	// top-post opt-out as the signal that top-post fetching has already been resolved.
-	const hasResolvedTopPosts = payload.top_posts != null || query?.query_top_posts === false;
 	const utmParam = query?.utm_param;
 	const items = Object.entries( topUtmValues )
 		.sort( ( [ , valueA ], [ , valueB ] ) => safeParseFloat( valueB ) - safeParseFloat( valueA ) )
@@ -158,7 +155,7 @@ export function sanitizeStatsUtmResponse(
 			return {
 				label: labelParts.join( ' / ' ),
 				value: safeParseFloat( value ),
-				...( hasResolvedTopPosts ? {} : { paramValues } ),
+				paramValues,
 				children: children.length ? children : null,
 			};
 		} );

--- a/projects/packages/premium-analytics/routes/reports/registry.ts
+++ b/projects/packages/premium-analytics/routes/reports/registry.ts
@@ -13,7 +13,6 @@ import { __ } from '@wordpress/i18n';
 // depends on the routing helper and i18n, so it's safe to import here.
 import { resolveTabId } from './posts/config/tabs';
 import { resolveSection as resolveUtmSection } from './utm/config/tabs';
-import { resolveSection as resolveUtmSection } from './utm/config/tabs';
 import type { ComponentType } from 'react';
 
 /**

--- a/projects/packages/premium-analytics/routes/reports/registry.ts
+++ b/projects/packages/premium-analytics/routes/reports/registry.ts
@@ -12,6 +12,8 @@ import { __ } from '@wordpress/i18n';
 // pull the UI into the route guard's import chain. `config/tabs.ts` only
 // depends on the routing helper and i18n, so it's safe to import here.
 import { resolveTabId } from './posts/config/tabs';
+import { resolveSection as resolveUtmSection } from './utm/config/tabs';
+import { resolveSection as resolveUtmSection } from './utm/config/tabs';
 import type { ComponentType } from 'react';
 
 /**
@@ -96,6 +98,12 @@ export const REPORTS: Record< string, ReportDefinition > = {
 		getTitle: () => __( 'Videos', 'jetpack-premium-analytics' ),
 		getDescription: () => __( 'See how your videos perform.', 'jetpack-premium-analytics' ),
 		load: () => import( './videos/page' ),
+	},
+	utm: {
+		id: 'utm',
+		getTitle: () => __( 'UTM', 'jetpack-premium-analytics' ),
+		resolveSection: resolveUtmSection,
+		load: () => import( './utm/page' ),
 	},
 };
 

--- a/projects/packages/premium-analytics/routes/reports/utm/config/aggregate.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/utm/config/aggregate.test.ts
@@ -11,8 +11,8 @@ describe( 'UTM report aggregate', () => {
 					date_start: '2026-06-01T00:00:00+00:00',
 					date_end: '2026-06-07T23:59:59+00:00',
 					items: [
-						{ label: 'newsletter', value: 10, children: null },
-						{ label: 'social', value: 5, children: null },
+						{ label: 'newsletter', value: 10, paramValues: 'newsletter', children: null },
+						{ label: 'social', value: 5, paramValues: 'social', children: null },
 					],
 				},
 			],
@@ -25,7 +25,12 @@ describe( 'UTM report aggregate', () => {
 	} );
 
 	it( 'sums matching values without mutating the report', () => {
-		const item = { label: 'newsletter', value: 7, children: null } satisfies StatsUtmItem;
+		const item = {
+			label: 'newsletter',
+			value: 7,
+			paramValues: 'newsletter',
+			children: null,
+		} satisfies StatsUtmItem;
 		const report: StatsNormalizedReport< StatsUtmItem > = {
 			summary: {},
 			data: [
@@ -39,7 +44,7 @@ describe( 'UTM report aggregate', () => {
 					time_interval: '2026-06-02',
 					date_start: '2026-06-02T00:00:00+00:00',
 					date_end: '2026-06-02T23:59:59+00:00',
-					items: [ { label: 'newsletter', value: 8, children: null } ],
+					items: [ { label: 'newsletter', value: 8, paramValues: 'newsletter', children: null } ],
 				},
 			],
 		};
@@ -58,13 +63,53 @@ describe( 'UTM report aggregate', () => {
 					time_interval: '2026-06-01',
 					date_start: '2026-06-01T00:00:00+00:00',
 					date_end: '2026-06-01T23:59:59+00:00',
-					items: [ { label: 'google / cpc', value: 10, children: null } ],
+					items: [
+						{ label: 'google / cpc', value: 10, paramValues: '["google","cpc"]', children: null },
+					],
 				},
 			],
 		};
 
 		expect( aggregateUtmRows( report ) ).toEqual( [
-			{ id: 'google / cpc', label: 'google / cpc', views: 10 },
+			{ id: '["google","cpc"]', label: 'google / cpc', views: 10 },
 		] );
+	} );
+
+	it( 'keeps distinct UTM tuples separate even when their labels collide', () => {
+		const report: StatsNormalizedReport< StatsUtmItem > = {
+			summary: { total: 9 },
+			data: [
+				{
+					time_interval: '2026-06-01',
+					date_start: '2026-06-01T00:00:00+00:00',
+					date_end: '2026-06-01T23:59:59+00:00',
+					items: [
+						{ label: 'a / b / c', value: 6, paramValues: '["a / b","c"]', children: null },
+						{ label: 'a / b / c', value: 3, paramValues: '["a","b / c"]', children: null },
+					],
+				},
+			],
+		};
+
+		expect( aggregateUtmRows( report ) ).toEqual( [
+			{ id: '["a / b","c"]', label: 'a / b / c', views: 6 },
+			{ id: '["a","b / c"]', label: 'a / b / c', views: 3 },
+		] );
+	} );
+
+	it( 'falls back to the label when param values are missing', () => {
+		const report: StatsNormalizedReport< StatsUtmItem > = {
+			summary: { total: 4 },
+			data: [
+				{
+					time_interval: '2026-06-01',
+					date_start: '2026-06-01T00:00:00+00:00',
+					date_end: '2026-06-01T23:59:59+00:00',
+					items: [ { label: 'direct', value: 4, children: null } ],
+				},
+			],
+		};
+
+		expect( aggregateUtmRows( report ) ).toEqual( [ { id: 'direct', label: 'direct', views: 4 } ] );
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/reports/utm/config/aggregate.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/utm/config/aggregate.test.ts
@@ -1,0 +1,70 @@
+import { aggregateUtmRows } from './aggregate';
+import type { StatsNormalizedReport, StatsUtmItem } from '@jetpack-premium-analytics/data';
+
+describe( 'UTM report aggregate', () => {
+	it( 'maps UTM values to report rows', () => {
+		const report: StatsNormalizedReport< StatsUtmItem > = {
+			summary: { total: 15 },
+			data: [
+				{
+					time_interval: '2026-06-01:2026-06-07',
+					date_start: '2026-06-01T00:00:00+00:00',
+					date_end: '2026-06-07T23:59:59+00:00',
+					items: [
+						{ label: 'newsletter', value: 10, children: null },
+						{ label: 'social', value: 5, children: null },
+					],
+				},
+			],
+		};
+
+		expect( aggregateUtmRows( report ) ).toEqual( [
+			{ id: 'newsletter', label: 'newsletter', views: 10 },
+			{ id: 'social', label: 'social', views: 5 },
+		] );
+	} );
+
+	it( 'sums matching values without mutating the report', () => {
+		const item = { label: 'newsletter', value: 7, children: null } satisfies StatsUtmItem;
+		const report: StatsNormalizedReport< StatsUtmItem > = {
+			summary: {},
+			data: [
+				{
+					time_interval: '2026-06-01',
+					date_start: '2026-06-01T00:00:00+00:00',
+					date_end: '2026-06-01T23:59:59+00:00',
+					items: [ item ],
+				},
+				{
+					time_interval: '2026-06-02',
+					date_start: '2026-06-02T00:00:00+00:00',
+					date_end: '2026-06-02T23:59:59+00:00',
+					items: [ { label: 'newsletter', value: 8, children: null } ],
+				},
+			],
+		};
+
+		expect( aggregateUtmRows( report ) ).toEqual( [
+			{ id: 'newsletter', label: 'newsletter', views: 15 },
+		] );
+		expect( item.value ).toBe( 7 );
+	} );
+
+	it( 'preserves normalized combined-dimension labels', () => {
+		const report: StatsNormalizedReport< StatsUtmItem > = {
+			summary: { total: 10 },
+			data: [
+				{
+					time_interval: '2026-06-01',
+					date_start: '2026-06-01T00:00:00+00:00',
+					date_end: '2026-06-01T23:59:59+00:00',
+					items: [ { label: 'google / cpc', value: 10, children: null } ],
+				},
+			],
+		};
+
+		expect( aggregateUtmRows( report ) ).toEqual( [
+			{ id: 'google / cpc', label: 'google / cpc', views: 10 },
+		] );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/reports/utm/config/aggregate.ts
+++ b/projects/packages/premium-analytics/routes/reports/utm/config/aggregate.ts
@@ -18,20 +18,23 @@ export type UtmReportRow = {
  * @return Aggregated UTM value rows.
  */
 export function aggregateUtmRows( report?: StatsNormalizedReport< StatsUtmItem > ): UtmReportRow[] {
-	const byLabel = new Map< string, UtmReportRow >();
+	// Key rows by the raw UTM tuple, not the display label: distinct tuples such as
+	// `["a / b","c"]` and `["a","b / c"]` format to the same label but are separate rows.
+	const byParamValues = new Map< string, UtmReportRow >();
 
 	for ( const point of report?.data ?? [] ) {
 		for ( const item of point.items ) {
 			const label = String( item.label ?? '' );
-			const existing = byLabel.get( label );
+			const key = item.paramValues ?? label;
+			const existing = byParamValues.get( key );
 
 			if ( existing ) {
 				existing.views += item.value;
 			} else {
-				byLabel.set( label, { id: label, label, views: item.value } );
+				byParamValues.set( key, { id: key, label, views: item.value } );
 			}
 		}
 	}
 
-	return [ ...byLabel.values() ];
+	return [ ...byParamValues.values() ];
 }

--- a/projects/packages/premium-analytics/routes/reports/utm/config/aggregate.ts
+++ b/projects/packages/premium-analytics/routes/reports/utm/config/aggregate.ts
@@ -1,0 +1,37 @@
+import type { StatsNormalizedReport, StatsUtmItem } from '@jetpack-premium-analytics/data';
+
+/** A single UTM value aggregated across the selected report range. */
+export type UtmReportRow = {
+	id: string;
+	label: string;
+	views: number;
+};
+
+/**
+ * Flatten a normalized UTM report into one row per UTM value.
+ *
+ * The current endpoint returns one range-level data point. Aggregating across
+ * every point keeps this transform correct if the normalizer later exposes
+ * bucketed responses, without mutating data held in the query cache.
+ *
+ * @param report - The normalized UTM report.
+ * @return Aggregated UTM value rows.
+ */
+export function aggregateUtmRows( report?: StatsNormalizedReport< StatsUtmItem > ): UtmReportRow[] {
+	const byLabel = new Map< string, UtmReportRow >();
+
+	for ( const point of report?.data ?? [] ) {
+		for ( const item of point.items ) {
+			const label = String( item.label ?? '' );
+			const existing = byLabel.get( label );
+
+			if ( existing ) {
+				existing.views += item.value;
+			} else {
+				byLabel.set( label, { id: label, label, views: item.value } );
+			}
+		}
+	}
+
+	return [ ...byLabel.values() ];
+}

--- a/projects/packages/premium-analytics/routes/reports/utm/config/fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/utm/config/fields.test.tsx
@@ -1,0 +1,40 @@
+import { render, screen } from '@testing-library/react';
+import { getUtmFields } from './fields';
+import type { UtmReportRow } from './aggregate';
+
+const row: UtmReportRow = { id: 'newsletter', label: 'newsletter', views: 1234 };
+
+describe( 'UTM report fields', () => {
+	it( 'makes the UTM value searchable', () => {
+		const field = getUtmFields( 'source-medium' ).find( candidate => candidate.id === 'utmValue' );
+
+		expect( field?.enableGlobalSearch ).toBe( true );
+		expect( field?.getValue?.( { item: row } as never ) ).toBe( 'newsletter' );
+	} );
+
+	it.each( [
+		[ 'source-medium', 'Source / Medium' ],
+		[ 'campaign-source-medium', 'Campaign / Source / Medium' ],
+		[ 'source', 'Source' ],
+		[ 'medium', 'Medium' ],
+		[ 'campaign', 'Campaign' ],
+	] as const )( 'labels the %s dimension column', ( tab, label ) => {
+		const field = getUtmFields( tab ).find( candidate => candidate.id === 'utmValue' );
+
+		expect( field?.label ).toBe( label );
+	} );
+
+	it( 'renders a localized views value', () => {
+		const field = getUtmFields( 'source-medium' ).find( candidate => candidate.id === 'views' );
+		// eslint-disable-next-line testing-library/render-result-naming-convention -- `render` here is the DataViews field render component, not RTL's render result.
+		const ViewsField = field?.render;
+
+		if ( ! field || ! ViewsField ) {
+			throw new Error( 'Views field render callback is unavailable' );
+		}
+
+		render( <ViewsField item={ row } field={ field as never } /> );
+
+		expect( screen.getByText( row.views.toLocaleString() ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/reports/utm/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/utm/config/fields.tsx
@@ -1,0 +1,35 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import { getUtmTabLabel, type UtmReportTabId } from './tabs';
+import type { UtmReportRow } from './aggregate';
+import type { Field } from '@wordpress/dataviews';
+
+/**
+ * DataViews fields for the UTM report records table.
+ *
+ * @param activeTab - The active UTM dimension tab.
+ * @return The field config.
+ */
+export function getUtmFields( activeTab: UtmReportTabId ): Field< UtmReportRow >[] {
+	return [
+		{
+			id: 'utmValue',
+			label: getUtmTabLabel( activeTab ),
+			enableGlobalSearch: true,
+			enableHiding: false,
+			getValue: ( { item } ) => item.label,
+			render: ( { item } ) => <>{ item.label }</>,
+		},
+		{
+			id: 'views',
+			label: __( 'Views', 'jetpack-premium-analytics' ),
+			getValue: ( { item } ) => item.views,
+			render: ( { item } ) => <>{ item.views.toLocaleString() }</>,
+		},
+	];
+}

--- a/projects/packages/premium-analytics/routes/reports/utm/config/index.ts
+++ b/projects/packages/premium-analytics/routes/reports/utm/config/index.ts
@@ -1,0 +1,10 @@
+export { aggregateUtmRows, type UtmReportRow } from './aggregate';
+export { getUtmFields } from './fields';
+export {
+	getReportUtmTabs,
+	getUtmParam,
+	getUtmTabLabel,
+	resolveSection,
+	type UtmReportTabId,
+} from './tabs';
+export { useUtmReportRecords } from './use-report-records';

--- a/projects/packages/premium-analytics/routes/reports/utm/config/tabs.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/utm/config/tabs.test.ts
@@ -1,0 +1,26 @@
+import { getReportUtmTabs, getUtmParam, resolveSection } from './tabs';
+
+describe( 'UTM report tabs', () => {
+	it( 'matches the widget dimension order and defaults to Source / Medium', () => {
+		expect( getReportUtmTabs() ).toEqual( [
+			{ id: 'source-medium', label: 'Source / Medium' },
+			{ id: 'campaign-source-medium', label: 'Campaign / Source / Medium' },
+			{ id: 'source', label: 'Source' },
+			{ id: 'medium', label: 'Medium' },
+			{ id: 'campaign', label: 'Campaign' },
+		] );
+		expect( resolveSection( undefined ) ).toBe( 'source-medium' );
+		expect( resolveSection( 'missing' ) ).toBe( 'source-medium' );
+	} );
+
+	it.each( [
+		[ 'source-medium', 'utm_source,utm_medium' ],
+		[ 'campaign-source-medium', 'utm_campaign,utm_source,utm_medium' ],
+		[ 'source', 'utm_source' ],
+		[ 'medium', 'utm_medium' ],
+		[ 'campaign', 'utm_campaign' ],
+	] as const )( 'resolves %s to %s', ( tab, utmParam ) => {
+		expect( resolveSection( tab ) ).toBe( tab );
+		expect( getUtmParam( tab ) ).toBe( utmParam );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/reports/utm/config/tabs.ts
+++ b/projects/packages/premium-analytics/routes/reports/utm/config/tabs.ts
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { defineReportTabs } from '@jetpack-premium-analytics/routing';
+import { __ } from '@wordpress/i18n';
+import type { StatsUtmParam } from '@jetpack-premium-analytics/data';
+
+/**
+ * Stable URL section identifiers for the UTM report's parameter selector.
+ */
+export type UtmReportTabId =
+	| 'source-medium'
+	| 'campaign-source-medium'
+	| 'source'
+	| 'medium'
+	| 'campaign';
+
+const DEFAULT_TAB_ID: UtmReportTabId = 'source-medium';
+
+const reportUtmTabs = defineReportTabs< UtmReportTabId >(
+	[
+		{
+			id: 'source-medium',
+			getLabel: () => __( 'Source / Medium', 'jetpack-premium-analytics' ),
+		},
+		{
+			id: 'campaign-source-medium',
+			getLabel: () => __( 'Campaign / Source / Medium', 'jetpack-premium-analytics' ),
+		},
+		{ id: 'source', getLabel: () => __( 'Source', 'jetpack-premium-analytics' ) },
+		{ id: 'medium', getLabel: () => __( 'Medium', 'jetpack-premium-analytics' ) },
+		{ id: 'campaign', getLabel: () => __( 'Campaign', 'jetpack-premium-analytics' ) },
+	],
+	DEFAULT_TAB_ID
+);
+
+const UTM_PARAMS: Record< UtmReportTabId, StatsUtmParam > = {
+	'source-medium': 'utm_source,utm_medium',
+	'campaign-source-medium': 'utm_campaign,utm_source,utm_medium',
+	source: 'utm_source',
+	medium: 'utm_medium',
+	campaign: 'utm_campaign',
+};
+
+/** Build the ordered, translated report tabs. */
+export const getReportUtmTabs = reportUtmTabs.getTabs;
+
+/** Get the translated dimension label for a report tab. */
+export const getUtmTabLabel = reportUtmTabs.getTabLabel;
+
+/** Resolve an arbitrary URL section to a supported UTM report tab. */
+export const resolveSection = reportUtmTabs.resolve;
+
+/**
+ * Map a report tab to the UTM endpoint's parameter dimension.
+ *
+ * @param tab - The active report tab.
+ * @return The matching UTM endpoint parameter.
+ */
+export function getUtmParam( tab: UtmReportTabId ): StatsUtmParam {
+	return UTM_PARAMS[ tab ];
+}

--- a/projects/packages/premium-analytics/routes/reports/utm/config/use-report-records.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/utm/config/use-report-records.test.tsx
@@ -1,0 +1,55 @@
+import {
+	useStatsUtm,
+	type ReportParams,
+	type StatsUtmParam,
+} from '@jetpack-premium-analytics/data';
+import { renderHook } from '@testing-library/react';
+import { useUtmReportRecords } from './use-report-records';
+import type { UtmReportTabId } from './tabs';
+
+jest.mock( '@jetpack-premium-analytics/data', () => ( {
+	useStatsUtm: jest.fn(),
+} ) );
+
+const mockUseStatsUtm = useStatsUtm as jest.MockedFunction< typeof useStatsUtm >;
+
+const REPORT_PARAMS = {
+	from: '2026-06-01',
+	to: '2026-06-07',
+	interval: 'day',
+} as ReportParams;
+
+const TABS = [
+	[ 'source-medium', 'utm_source,utm_medium' ],
+	[ 'campaign-source-medium', 'utm_campaign,utm_source,utm_medium' ],
+	[ 'source', 'utm_source' ],
+	[ 'medium', 'utm_medium' ],
+	[ 'campaign', 'utm_campaign' ],
+] as const satisfies ReadonlyArray< readonly [ UtmReportTabId, StatsUtmParam ] >;
+
+describe( 'useUtmReportRecords', () => {
+	beforeEach( () => {
+		mockUseStatsUtm.mockReset();
+		mockUseStatsUtm.mockReturnValue( {
+			primary: { data: undefined },
+			isLoading: false,
+		} as never );
+	} );
+
+	it.each( TABS )( 'only enables the %s request', ( activeTab, activeUtmParam ) => {
+		renderHook( () => useUtmReportRecords( activeTab, REPORT_PARAMS ) );
+
+		expect( mockUseStatsUtm ).toHaveBeenCalledTimes( TABS.length );
+		TABS.forEach( ( [ , utmParam ], index ) => {
+			const [ params, options ] = mockUseStatsUtm.mock.calls[ index ];
+
+			expect( params ).toMatchObject( {
+				utmParam,
+				max: 0,
+				summarize: 0,
+				query_top_posts: false,
+			} );
+			expect( options ).toEqual( { enabled: utmParam === activeUtmParam } );
+		} );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/reports/utm/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/utm/config/use-report-records.ts
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import { useStatsUtm, type ReportParams } from '@jetpack-premium-analytics/data';
+import { useMemo } from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import { aggregateUtmRows } from './aggregate';
+import { getUtmParam, type UtmReportTabId } from './tabs';
+
+/**
+ * Fetch and derive the table records for the active UTM dimension.
+ *
+ * @param activeTab    - The active UTM dimension tab.
+ * @param reportParams - The shared report-window parameters.
+ * @return The active dimension's table rows and loading state.
+ */
+export function useUtmReportRecords( activeTab: UtmReportTabId, reportParams: ReportParams ) {
+	const baseParams = useMemo(
+		() => ( {
+			...reportParams,
+			max: 0,
+			summarize: 0,
+			query_top_posts: false,
+		} ),
+		[ reportParams ]
+	);
+
+	const sourceMedium = useStatsUtm(
+		{ ...baseParams, utmParam: getUtmParam( 'source-medium' ) } as Parameters<
+			typeof useStatsUtm
+		>[ 0 ],
+		{ enabled: activeTab === 'source-medium' }
+	);
+	const campaignSourceMedium = useStatsUtm(
+		{ ...baseParams, utmParam: getUtmParam( 'campaign-source-medium' ) } as Parameters<
+			typeof useStatsUtm
+		>[ 0 ],
+		{ enabled: activeTab === 'campaign-source-medium' }
+	);
+	const source = useStatsUtm(
+		{ ...baseParams, utmParam: getUtmParam( 'source' ) } as Parameters< typeof useStatsUtm >[ 0 ],
+		{ enabled: activeTab === 'source' }
+	);
+	const medium = useStatsUtm(
+		{ ...baseParams, utmParam: getUtmParam( 'medium' ) } as Parameters< typeof useStatsUtm >[ 0 ],
+		{ enabled: activeTab === 'medium' }
+	);
+	const campaign = useStatsUtm(
+		{ ...baseParams, utmParam: getUtmParam( 'campaign' ) } as Parameters< typeof useStatsUtm >[ 0 ],
+		{ enabled: activeTab === 'campaign' }
+	);
+
+	const activeReport = {
+		'source-medium': sourceMedium,
+		'campaign-source-medium': campaignSourceMedium,
+		source,
+		medium,
+		campaign,
+	}[ activeTab ];
+	const rows = useMemo(
+		() => aggregateUtmRows( activeReport.primary.data ),
+		[ activeReport.primary.data ]
+	);
+
+	return { rows, isLoading: activeReport.isLoading };
+}

--- a/projects/packages/premium-analytics/routes/reports/utm/page.module.css
+++ b/projects/packages/premium-analytics/routes/reports/utm/page.module.css
@@ -1,0 +1,15 @@
+.page {
+	min-block-size: 0;
+}
+
+.content {
+	flex: 1 1 auto;
+	min-block-size: 0;
+	overflow-y: auto;
+	padding-block-end: 24px;
+	padding-inline: var(--wpds-dimension-padding-2xl);
+}
+
+.dateFilters {
+	inline-size: 100%;
+}

--- a/projects/packages/premium-analytics/routes/reports/utm/page.module.css
+++ b/projects/packages/premium-analytics/routes/reports/utm/page.module.css
@@ -6,7 +6,7 @@
 	flex: 1 1 auto;
 	min-block-size: 0;
 	overflow-y: auto;
-	padding-block-end: 24px;
+	padding-block-end: var(--wpds-dimension-padding-2xl);
 	padding-inline: var(--wpds-dimension-padding-2xl);
 }
 

--- a/projects/packages/premium-analytics/routes/reports/utm/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/utm/page.tsx
@@ -1,0 +1,117 @@
+/**
+ * External dependencies
+ */
+import { normalizeReportParams } from '@jetpack-premium-analytics/data';
+import {
+	useDashboardLink,
+	useReportDateFilters,
+	useSectionTab,
+} from '@jetpack-premium-analytics/routing';
+import { DateFiltersPanel } from '@jetpack-premium-analytics/ui';
+import {
+	ReportPageLayout,
+	ReportPageTabs,
+	ReportRecordsTable,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { Breadcrumbs, Page } from '@wordpress/admin-ui';
+import { useMemo, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useSearch } from '@wordpress/route';
+/**
+ * Internal dependencies
+ */
+import { route } from '../package.json';
+import {
+	getReportUtmTabs,
+	getUtmFields,
+	resolveSection,
+	useUtmReportRecords,
+	type UtmReportRow,
+} from './config';
+import styles from './page.module.css';
+
+const ROUTE_FROM = route.path;
+
+const RECORDS_VIEW = {
+	sort: { field: 'views', direction: 'desc' as const },
+	layout: {
+		styles: {
+			utmValue: { width: '100%' },
+			views: { align: 'end' as const },
+		},
+	},
+};
+
+/**
+ * Stable row id for the UTM records table.
+ *
+ * @param item - The UTM row.
+ * @return The row id.
+ */
+function getUtmRowId( item: UtmReportRow ): string {
+	return item.id;
+}
+
+/**
+ * Premium Analytics UTM report page.
+ *
+ * @return The UTM report page.
+ */
+function UtmReport(): JSX.Element {
+	const search = useSearch( { from: ROUTE_FROM } ) as Record< string, string | undefined >;
+	const reportParams = useMemo(
+		() => normalizeReportParams( search as Parameters< typeof normalizeReportParams >[ 0 ] ),
+		[ search ]
+	);
+	const tabs = useMemo( () => getReportUtmTabs(), [] );
+	const [ activeTab, setActiveTab ] = useSectionTab( ROUTE_FROM, resolveSection );
+	const records = useUtmReportRecords( activeTab, reportParams );
+	const fields = useMemo( () => getUtmFields( activeTab ), [ activeTab ] );
+	const dateFilters = useReportDateFilters( ROUTE_FROM );
+	const dashboardLink = useDashboardLink();
+	const [ containerElement, setContainerElement ] = useState< HTMLDivElement | null >( null );
+
+	return (
+		<Page
+			breadcrumbs={
+				<Breadcrumbs
+					items={ [
+						{ label: __( 'Stats', 'jetpack-premium-analytics' ), to: dashboardLink },
+						{ label: __( 'UTM', 'jetpack-premium-analytics' ) },
+					] }
+				/>
+			}
+			className={ styles.page }
+		>
+			<div className={ styles.content }>
+				<ReportPageLayout
+					tabs={ <ReportPageTabs tabs={ tabs } value={ activeTab } onChange={ setActiveTab } /> }
+					filters={
+						<div ref={ setContainerElement } className={ styles.dateFilters }>
+							<DateFiltersPanel { ...dateFilters } containerElement={ containerElement } />
+						</div>
+					}
+				>
+					<ReportRecordsTable< UtmReportRow >
+						key={ activeTab }
+						data={ records.rows }
+						fields={ fields }
+						getItemId={ getUtmRowId }
+						isLoading={ records.isLoading }
+						initialView={ RECORDS_VIEW }
+						searchLabel={ __( 'Search UTM values', 'jetpack-premium-analytics' ) }
+					/>
+				</ReportPageLayout>
+			</div>
+		</Page>
+	);
+}
+
+/**
+ * Default export for the dynamic report registry.
+ *
+ * @return The UTM report page.
+ */
+export default function UtmReportPage(): JSX.Element {
+	return <UtmReport />;
+}

--- a/projects/packages/premium-analytics/widgets/utm-insights/__tests__/utm-insights.test.tsx
+++ b/projects/packages/premium-analytics/widgets/utm-insights/__tests__/utm-insights.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import type { AnchorHTMLAttributes, ReactNode } from 'react';
+/**
+ * Internal dependencies
+ */
+import UtmInsightsWidget from '../render';
+
+type MockRouteLinkProps = {
+	to: string;
+	params?: Record< string, unknown >;
+	search?: Record< string, unknown >;
+	children: ReactNode;
+} & Omit< AnchorHTMLAttributes< HTMLAnchorElement >, 'href' >;
+
+jest.mock( '@wordpress/route', () => ( {
+	Link: ( { to, params, search, children, ...props }: MockRouteLinkProps ) => {
+		const path = Object.entries( params ?? {} ).reduce(
+			( result, [ key, value ] ) => result.replace( `$${ key }`, String( value ) ),
+			to
+		);
+		const query = new URLSearchParams();
+		Object.entries( search ?? {} ).forEach( ( [ key, value ] ) => {
+			if ( value !== undefined && value !== null ) {
+				query.set( key, String( value ) );
+			}
+		} );
+		const queryString = query.toString();
+
+		return (
+			<a href={ queryString ? `${ path }?${ queryString }` : path } { ...props }>
+				{ children }
+			</a>
+		);
+	},
+	useSearch: () => ( {} ),
+} ) );
+
+jest.mock( '../use-utm-insights', () => ( {
+	__esModule: true,
+	default: () => ( {
+		data: [],
+		hasComparison: false,
+		isLoading: false,
+		isFetching: false,
+		hasData: false,
+		isError: false,
+	} ),
+} ) );
+
+describe( 'UtmInsightsWidget', () => {
+	it( 'links to the UTM report', () => {
+		render( <UtmInsightsWidget attributes={ {} } /> );
+
+		expect( screen.getByRole( 'link', { name: 'See report' } ) ).toHaveAttribute(
+			'href',
+			expect.stringContaining( '/reports/utm' )
+		);
+		expect( screen.getByRole( 'link', { name: 'See report' } ) ).toHaveAttribute(
+			'href',
+			expect.stringContaining( 'section=source-medium' )
+		);
+	} );
+
+	it( 'links the combined campaign dimension to its matching report tab', () => {
+		render(
+			<UtmInsightsWidget attributes={ { utmDimension: 'utm_campaign,utm_source,utm_medium' } } />
+		);
+
+		expect( screen.getByRole( 'link', { name: 'See report' } ) ).toHaveAttribute(
+			'href',
+			expect.stringContaining( 'section=campaign-source-medium' )
+		);
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/utm-insights/render.tsx
+++ b/projects/packages/premium-analytics/widgets/utm-insights/render.tsx
@@ -7,7 +7,9 @@ import { Stack, Text } from '@wordpress/ui';
 import {
 	calculateDelta,
 	LeaderboardChart,
+	ReportLink,
 	WidgetBackLink,
+	WidgetFooter,
 	WidgetRoot,
 	WidgetState,
 	useWidgetDrillDown,
@@ -31,6 +33,13 @@ import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 type UtmInsightsRenderAttributes = UtmInsightsAttributes & Partial< ReportParamsFieldAttributes >;
 type UtmInsightsWidgetProps = WidgetRenderProps< UtmInsightsRenderAttributes >;
 
+type UtmReportSection =
+	| 'source-medium'
+	| 'campaign-source-medium'
+	| 'source'
+	| 'medium'
+	| 'campaign';
+
 const DATA_FORMAT = { type: 'number' as const, options: { useMultipliers: true, decimals: 0 } };
 
 const DEFAULT_UTM_DIMENSION: StatsUtmParam = 'utm_source,utm_medium';
@@ -45,6 +54,22 @@ type UtmInsightsInnerProps = {
 	 */
 	max: number;
 };
+
+/** Map a widget dimension to a section supported by the UTM report. */
+function getUtmReportSection( utmDimension: StatsUtmParam ): UtmReportSection {
+	switch ( utmDimension ) {
+		case 'utm_source,utm_medium':
+			return 'source-medium';
+		case 'utm_campaign,utm_source,utm_medium':
+			return 'campaign-source-medium';
+		case 'utm_source':
+			return 'source';
+		case 'utm_medium':
+			return 'medium';
+		case 'utm_campaign':
+			return 'campaign';
+	}
+}
 
 /**
  * Inner component — rendered inside WidgetRoot.
@@ -142,6 +167,11 @@ function UtmInsightsInner( { utmDimension, max }: UtmInsightsInnerProps ) {
 			className={ styles.backLink }
 		/>
 	) : null;
+	const footer = (
+		<WidgetFooter>
+			<ReportLink report="utm" section={ getUtmReportSection( utmDimension ) } />
+		</WidgetFooter>
+	);
 
 	return (
 		<>
@@ -173,6 +203,7 @@ function UtmInsightsInner( { utmDimension, max }: UtmInsightsInnerProps ) {
 					/>
 				</WidgetState>
 			</div>
+			{ footer }
 		</>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/utm-insights/render.tsx
+++ b/projects/packages/premium-analytics/widgets/utm-insights/render.tsx
@@ -167,12 +167,6 @@ function UtmInsightsInner( { utmDimension, max }: UtmInsightsInnerProps ) {
 			className={ styles.backLink }
 		/>
 	) : null;
-	const footer = (
-		<WidgetFooter>
-			<ReportLink report="utm" section={ getUtmReportSection( utmDimension ) } />
-		</WidgetFooter>
-	);
-
 	return (
 		<>
 			{ backLink }
@@ -203,7 +197,9 @@ function UtmInsightsInner( { utmDimension, max }: UtmInsightsInnerProps ) {
 					/>
 				</WidgetState>
 			</div>
-			{ footer }
+			<WidgetFooter>
+				<ReportLink report="utm" section={ getUtmReportSection( utmDimension ) } />
+			</WidgetFooter>
 		</>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/utm-insights/stories/utm-insights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/utm-insights/stories/utm-insights-widget.stories.tsx
@@ -5,6 +5,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withStoryRouter } from '../../stories/with-story-router';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import { registerStatsMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-stats-mocks';
@@ -72,7 +73,7 @@ export const Default: Story = {
 		/>
 	),
 	args: { withComparison: false },
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 };
 
 export const WithComparison: Story = {
@@ -86,7 +87,7 @@ export const WithComparison: Story = {
 		/>
 	),
 	args: { withComparison: true },
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 };
 
 // Distinct preset → own query-cache entry; see forceStatsMockState.
@@ -110,7 +111,7 @@ export const Loading: Story = {
 	render: () => renderUtmInsightsOnPreset( 'last-90-days' ),
 	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 	beforeEach: () => {
 		forceStatsMockState( 'stats/utm', 'loading' );
 		return () => forceStatsMockState( 'stats/utm', null );
@@ -124,7 +125,7 @@ export const Loading: Story = {
 export const Error: Story = {
 	render: () => renderUtmInsightsOnPreset( 'last-7-days' ),
 	tags: [ '!autodocs' ],
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 	beforeEach: () => {
 		forceStatsMockState( 'stats/utm', 'error' );
 		return () => forceStatsMockState( 'stats/utm', null );
@@ -138,7 +139,7 @@ export const Error: Story = {
 export const Empty: Story = {
 	render: () => renderUtmInsightsOnPreset( 'last-365-days' ),
 	tags: [ '!autodocs' ],
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 	beforeEach: () => {
 		forceStatsMockState( 'stats/utm', 'empty' );
 		return () => forceStatsMockState( 'stats/utm', null );
@@ -157,7 +158,7 @@ export const ByCampaign: Story = {
 		/>
 	),
 	args: { withComparison: false },
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 };
 
 // Full dashboard story — mounts the real WidgetDashboard so the widget renders


### PR DESCRIPTION
Part of [WOOA7S-1699](https://linear.app/a8c/issue/WOOA7S-1699)

**Note: UTM rows do not display their top posts yet; this can be added later once we have confirmation on the drill-down DataViews UX**

<img width="1500" height="1454" alt="Google Chrome -2026-07-14 at 12 11 08@2x" src="https://github.com/user-attachments/assets/9e992142-3da4-4106-a301-8da22867b31d" />


## Proposed changes

* Adds the UTM report at `/reports/utm` on the reports framework from #50305: a `routes/reports/utm/` page module (records table, `config/aggregate.ts` with tests) and one `REPORTS` registry entry. The UTM endpoint returns range-level totals rather than bucketed series, so this report is table-only — no performance chart.
* Five grouping tabs (Source / Medium, Campaign / Source / Medium, Source, Medium, Campaign) bound to `?section=` via the shared report-tabs machinery.
* Table rows are keyed by the raw UTM tuple (`paramValues`) rather than the formatted label, so distinct combinations that format to the same label (e.g. `["a / b","c"]` and `["a","b / c"]`) stay separate rows, matching Calypso.
* The UTM insights widget footer links to the report via the shared `WidgetFooter`/`ReportLink`, carrying the dashboard's current date range and comparison.

## Related product discussion/links

* [WOOA7S-1699](https://linear.app/a8c/issue/WOOA7S-1699)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `cd projects/packages/premium-analytics && pnpm run build`, open the Premium Analytics dashboard on a site with UTM traffic data.
* In the UTM insights widget, click **See report** — you should land on `/reports/utm` with the dashboard's date range and comparison intact.
* Switch between the grouping tabs — the `?section=` URL param should update, the table columns should follow the selected grouping, and reloading the URL should restore the selected tab.
* On the table: search, sort, and page through — all client-side, no new requests.
* Change the date range from the page's date filter — the table should update, and reloading the URL should restore the exact view.
