### PR TITLE
WOOA7S-1701: Premium Analytics: add the Search terms report at /reports/search-terms

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-wooa7s-1701-search-terms-report-page
+++ b/projects/packages/premium-analytics/changelog/add-wooa7s-1701-search-terms-report-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Search terms: Add the `/reports/search-terms` report page.

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/search-terms.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/search-terms.test.ts
@@ -36,6 +36,7 @@ describe( 'Stats search terms normalizer', () => {
 				time_interval: '2026-06-16',
 				date_start: '2026-06-16T00:00:00+00:00',
 				date_end: '2026-06-16T23:59:59+00:00',
+				encrypted_search_terms: 4,
 				items: [
 					expect.objectContaining( {
 						label: 'delete revisions for wordpress',

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/search-terms.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/search-terms.ts
@@ -1,12 +1,16 @@
 import { safeParseFloat } from '../../utils/parsing';
 import {
+	coerceStatsArray,
+	createStatsDataPoint,
+	getStatsBuckets,
 	getStatsReportItems,
+	getStatsResponsePeriod,
 	limitStatsRows,
-	mapStatsReportDataPoints,
+	mapStatsSummaryDataPoint,
 	mergeStatsComparisonRows,
 	normalizeStatsReportSummary,
 } from './utils';
-import type { StatsNormalizedItemBase, StatsNormalizedReport } from './types';
+import type { StatsNormalizedItemBase, StatsNormalizedReport, StatsRecord } from './types';
 import type { StatsQueryParams } from '../../utils/stats-params';
 
 export type StatsSearchTermsItem = StatsNormalizedItemBase & {
@@ -23,18 +27,38 @@ function getSearchTermKey( item: StatsSearchTermsItem ): string {
 	return typeof item.label === 'string' ? item.label : String( item.label );
 }
 
+function normalizeStatsSearchTerm( item: StatsRecord ): StatsSearchTermsItem {
+	return {
+		label: item.term,
+		views: safeParseFloat( item.views ),
+		className: 'user-selectable',
+		children: null,
+	};
+}
+
 export function sanitizeStatsSearchTermsResponse(
 	response: unknown,
 	query?: StatsQueryParams
 ): StatsNormalizedReport< StatsSearchTermsItem > {
+	const summaryData = mapStatsSummaryDataPoint(
+		response,
+		query,
+		[ 'search_terms' ],
+		normalizeStatsSearchTerm
+	);
+
 	return {
 		summary: normalizeStatsReportSummary( response, query, [ 'search_terms' ] ),
-		data: mapStatsReportDataPoints( response, query, [ 'search_terms' ], item => ( {
-			label: item.term,
-			views: safeParseFloat( item.views ),
-			className: 'user-selectable',
-			children: null,
-		} ) ),
+		data: summaryData.length
+			? summaryData
+			: getStatsBuckets( response, query ).map( ( [ date, bucket ] ) => ( {
+					...createStatsDataPoint(
+						date,
+						query?.period ?? getStatsResponsePeriod( response ),
+						coerceStatsArray< StatsRecord >( bucket.search_terms ).map( normalizeStatsSearchTerm )
+					),
+					encrypted_search_terms: bucket.encrypted_search_terms,
+			  } ) ),
 	};
 }
 

--- a/projects/packages/premium-analytics/routes/reports/registry.ts
+++ b/projects/packages/premium-analytics/routes/reports/registry.ts
@@ -92,6 +92,11 @@ export const REPORTS: Record< string, ReportDefinition > = {
 		resolveSection: resolveTabId,
 		load: () => import( './posts/page' ),
 	},
+	'search-terms': {
+		id: 'search-terms',
+		getTitle: () => __( 'Search terms', 'jetpack-premium-analytics' ),
+		load: () => import( './search-terms/page' ),
+	},
 	videos: {
 		id: 'videos',
 		getTitle: () => __( 'Videos', 'jetpack-premium-analytics' ),

--- a/projects/packages/premium-analytics/routes/reports/search-terms/config/aggregate.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/search-terms/config/aggregate.test.ts
@@ -6,9 +6,9 @@ describe( 'report search terms aggregate', () => {
 		summary: {},
 		data: [
 			{
-				time_interval: '2026-06-01',
-				date_start: '2026-06-01T00:00:00+00:00',
-				date_end: '2026-06-01T23:59:59+00:00',
+				time_interval: '2026-06-03',
+				date_start: '2026-06-03T00:00:00+00:00',
+				date_end: '2026-06-03T23:59:59+00:00',
 				items: [
 					{
 						label: 'wordpress analytics',
@@ -26,9 +26,9 @@ describe( 'report search terms aggregate', () => {
 				encrypted_search_terms: 4,
 			},
 			{
-				time_interval: '2026-06-02',
-				date_start: '2026-06-02T00:00:00+00:00',
-				date_end: '2026-06-02T23:59:59+00:00',
+				time_interval: '2026-06-04',
+				date_start: '2026-06-04T00:00:00+00:00',
+				date_end: '2026-06-04T23:59:59+00:00',
 				items: [
 					{
 						label: 'wordpress analytics',
@@ -51,13 +51,39 @@ describe( 'report search terms aggregate', () => {
 	} );
 
 	it( 'includes known and encrypted views in each chart bucket', () => {
-		const series = searchTermsToTimeSeries( report );
+		const series = searchTermsToTimeSeries( report, 'day' );
 
 		expect( series.summary ).toEqual( {
-			date_start: '2026-06-01T00:00:00+00:00',
-			date_end: '2026-06-02T23:59:59+00:00',
+			date_start: '2026-06-03T00:00:00+00:00',
+			date_end: '2026-06-04T23:59:59+00:00',
 		} );
 		expect( series.data.map( point => point.views ) ).toEqual( [ 9, 11 ] );
+	} );
+
+	it( 'groups daily totals into ISO weeks starting on Monday', () => {
+		const series = searchTermsToTimeSeries( report, 'week' );
+
+		expect( series.data ).toEqual( [
+			expect.objectContaining( {
+				time_interval: '2026-06-01',
+				date_start: '2026-06-03T00:00:00+00:00',
+				date_end: '2026-06-04T23:59:59+00:00',
+				views: 20,
+			} ),
+		] );
+	} );
+
+	it( 'groups daily totals into calendar months', () => {
+		const series = searchTermsToTimeSeries( report, 'month' );
+
+		expect( series.data ).toEqual( [
+			expect.objectContaining( {
+				time_interval: '2026-06-01',
+				date_start: '2026-06-03T00:00:00+00:00',
+				date_end: '2026-06-04T23:59:59+00:00',
+				views: 20,
+			} ),
+		] );
 	} );
 
 	it( 'omits the unknown row when the payload has no encrypted aggregate', () => {

--- a/projects/packages/premium-analytics/routes/reports/search-terms/config/aggregate.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/search-terms/config/aggregate.test.ts
@@ -1,0 +1,77 @@
+import { aggregateSearchTermRows, searchTermsToTimeSeries } from './aggregate';
+import type { StatsNormalizedReport, StatsSearchTermsItem } from '@jetpack-premium-analytics/data';
+
+describe( 'report search terms aggregate', () => {
+	const report: StatsNormalizedReport< StatsSearchTermsItem > = {
+		summary: {},
+		data: [
+			{
+				time_interval: '2026-06-01',
+				date_start: '2026-06-01T00:00:00+00:00',
+				date_end: '2026-06-01T23:59:59+00:00',
+				items: [
+					{
+						label: 'wordpress analytics',
+						views: 3,
+						className: 'user-selectable',
+						children: null,
+					},
+					{
+						label: 'jetpack stats',
+						views: 2,
+						className: 'user-selectable',
+						children: null,
+					},
+				],
+				encrypted_search_terms: 4,
+			},
+			{
+				time_interval: '2026-06-02',
+				date_start: '2026-06-02T00:00:00+00:00',
+				date_end: '2026-06-02T23:59:59+00:00',
+				items: [
+					{
+						label: 'wordpress analytics',
+						views: 5,
+						className: 'user-selectable',
+						children: null,
+					},
+				],
+				encrypted_search_terms: 6,
+			},
+		],
+	};
+
+	it( 'aggregates known terms and renders encrypted searches as a regular row', () => {
+		expect( aggregateSearchTermRows( report, 'Unknown search terms' ) ).toEqual( [
+			{ id: 'term:wordpress analytics', term: 'wordpress analytics', views: 8 },
+			{ id: 'term:jetpack stats', term: 'jetpack stats', views: 2 },
+			{ id: 'unknown-search-terms', term: 'Unknown search terms', views: 10 },
+		] );
+	} );
+
+	it( 'includes known and encrypted views in each chart bucket', () => {
+		const series = searchTermsToTimeSeries( report );
+
+		expect( series.summary ).toEqual( {
+			date_start: '2026-06-01T00:00:00+00:00',
+			date_end: '2026-06-02T23:59:59+00:00',
+		} );
+		expect( series.data.map( point => point.views ) ).toEqual( [ 9, 11 ] );
+	} );
+
+	it( 'omits the unknown row when the payload has no encrypted aggregate', () => {
+		const reportWithoutEncrypted = {
+			...report,
+			data: report.data.map( point => {
+				const { encrypted_search_terms, ...rest } = point;
+				void encrypted_search_terms;
+				return rest;
+			} ),
+		};
+
+		expect(
+			aggregateSearchTermRows( reportWithoutEncrypted, 'Unknown search terms' )
+		).toHaveLength( 2 );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/reports/search-terms/config/aggregate.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/search-terms/config/aggregate.test.ts
@@ -66,11 +66,15 @@ describe( 'report search terms aggregate', () => {
 		expect( series.data ).toEqual( [
 			expect.objectContaining( {
 				time_interval: '2026-06-01',
-				date_start: '2026-06-03T00:00:00+00:00',
+				date_start: '2026-06-01T00:00:00+00:00',
 				date_end: '2026-06-04T23:59:59+00:00',
 				views: 20,
 			} ),
 		] );
+		expect( series.summary ).toEqual( {
+			date_start: '2026-06-03T00:00:00+00:00',
+			date_end: '2026-06-04T23:59:59+00:00',
+		} );
 	} );
 
 	it( 'groups daily totals into calendar months', () => {
@@ -79,7 +83,7 @@ describe( 'report search terms aggregate', () => {
 		expect( series.data ).toEqual( [
 			expect.objectContaining( {
 				time_interval: '2026-06-01',
-				date_start: '2026-06-03T00:00:00+00:00',
+				date_start: '2026-06-01T00:00:00+00:00',
 				date_end: '2026-06-04T23:59:59+00:00',
 				views: 20,
 			} ),

--- a/projects/packages/premium-analytics/routes/reports/search-terms/config/aggregate.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/search-terms/config/aggregate.test.ts
@@ -50,6 +50,19 @@ describe( 'report search terms aggregate', () => {
 		] );
 	} );
 
+	it( 'omits the unknown row when encrypted search counts are all zero', () => {
+		const emptyReport = {
+			...report,
+			data: report.data.map( point => ( {
+				...point,
+				items: [],
+				encrypted_search_terms: 0,
+			} ) ),
+		};
+
+		expect( aggregateSearchTermRows( emptyReport, 'Unknown search terms' ) ).toEqual( [] );
+	} );
+
 	it( 'includes known and encrypted views in each chart bucket', () => {
 		const series = searchTermsToTimeSeries( report, 'day' );
 

--- a/projects/packages/premium-analytics/routes/reports/search-terms/config/aggregate.ts
+++ b/projects/packages/premium-analytics/routes/reports/search-terms/config/aggregate.ts
@@ -4,6 +4,7 @@
 import type {
 	StatsNormalizedDataPoint,
 	StatsNormalizedReport,
+	StatsPeriod,
 	StatsSearchTermsItem,
 	StatsTimeSeriesReport,
 } from '@jetpack-premium-analytics/data';
@@ -20,6 +21,32 @@ export type SearchTermRow = {
 type SearchTermsDataPoint = StatsNormalizedDataPoint< StatsSearchTermsItem > & {
 	encrypted_search_terms?: unknown;
 };
+
+type SearchTermsChartPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
+
+/**
+ * Map a daily bucket date onto its chart bucket key for the selected period.
+ *
+ * @param date   - The daily bucket date (`YYYY-MM-DD`).
+ * @param period - The chart bucket period.
+ * @return The bucket key the date aggregates into.
+ */
+function getChartBucketKey( date: string, period: SearchTermsChartPeriod ): string {
+	if ( period === 'day' ) {
+		return date;
+	}
+
+	const bucketDate = new Date( `${ date.slice( 0, 10 ) }T00:00:00Z` );
+
+	if ( period === 'week' ) {
+		const daysSinceMonday = ( bucketDate.getUTCDay() + 6 ) % 7;
+		bucketDate.setUTCDate( bucketDate.getUTCDate() - daysSinceMonday );
+	} else {
+		bucketDate.setUTCDate( 1 );
+	}
+
+	return bucketDate.toISOString().slice( 0, 10 );
+}
 
 /**
  * Read the aggregate encrypted-search count that the Stats payload stores
@@ -46,30 +73,49 @@ function getTermLabel( item: StatsSearchTermsItem ): string {
 }
 
 /**
- * Build a views-per-bucket series from a bucketed search-terms report.
+ * Build the chart's views-per-bucket series from daily search-terms data.
  * Known-term views and the encrypted aggregate are both included so the chart
- * represents the same records shown in the table.
+ * represents the same records shown in the table. Week and month intervals are
+ * derived client-side so changing the chart does not change the requested range.
  *
  * @param report - The bucketed search-terms report.
+ * @param period - The chart bucket period.
  * @return The chart-ready time series.
  */
 export function searchTermsToTimeSeries(
-	report: StatsNormalizedReport< StatsSearchTermsItem > | undefined
+	report: StatsNormalizedReport< StatsSearchTermsItem > | undefined,
+	period: SearchTermsChartPeriod = 'day'
 ): StatsTimeSeriesReport {
-	const data = ( report?.data ?? [] ).map( point => {
+	const buckets = new Map< string, StatsTimeSeriesReport[ 'data' ][ number ] >();
+	const points = [ ...( report?.data ?? [] ) ].sort( ( a, b ) =>
+		a.time_interval.localeCompare( b.time_interval )
+	);
+
+	for ( const point of points ) {
 		const knownViews = point.items.reduce( ( total, item ) => total + item.views, 0 );
 		const views = knownViews + ( getEncryptedSearchTerms( point ) ?? 0 );
+		const key = getChartBucketKey( point.time_interval, period );
+		const existing = buckets.get( key );
 
-		return {
-			time_interval: point.time_interval,
+		if ( existing ) {
+			existing.date_end = point.date_end;
+			existing.value = Number( existing.value ) + views;
+			existing.views = Number( existing.views ) + views;
+			continue;
+		}
+
+		buckets.set( key, {
+			time_interval: key,
 			date_start: point.date_start,
 			date_end: point.date_end,
-			label: point.time_interval,
+			label: key,
 			items: [],
 			value: views,
 			views,
-		};
-	} );
+		} );
+	}
+
+	const data = [ ...buckets.values() ];
 	const first = data[ 0 ];
 	const last = data[ data.length - 1 ];
 

--- a/projects/packages/premium-analytics/routes/reports/search-terms/config/aggregate.ts
+++ b/projects/packages/premium-analytics/routes/reports/search-terms/config/aggregate.ts
@@ -84,7 +84,6 @@ export function aggregateSearchTermRows(
 ): SearchTermRow[] {
 	const byTerm = new Map< string, SearchTermRow >();
 	let encryptedViews = 0;
-	let hasEncryptedViews = false;
 
 	for ( const point of report?.data ?? [] ) {
 		for ( const item of point.items ) {
@@ -100,14 +99,13 @@ export function aggregateSearchTermRows(
 
 		const bucketEncryptedViews = getEncryptedSearchTerms( point );
 		if ( bucketEncryptedViews !== undefined ) {
-			hasEncryptedViews = true;
 			encryptedViews += bucketEncryptedViews;
 		}
 	}
 
 	const rows = [ ...byTerm.values() ];
 
-	if ( hasEncryptedViews ) {
+	if ( encryptedViews > 0 ) {
 		rows.push( { id: 'unknown-search-terms', term: unknownLabel, views: encryptedViews } );
 	}
 

--- a/projects/packages/premium-analytics/routes/reports/search-terms/config/aggregate.ts
+++ b/projects/packages/premium-analytics/routes/reports/search-terms/config/aggregate.ts
@@ -1,0 +1,129 @@
+/**
+ * External dependencies
+ */
+import type {
+	StatsNormalizedDataPoint,
+	StatsNormalizedReport,
+	StatsSearchTermsItem,
+	StatsTimeSeriesReport,
+} from '@jetpack-premium-analytics/data';
+
+/**
+ * A row in the Search terms records table.
+ */
+export type SearchTermRow = {
+	id: string;
+	term: string;
+	views: number;
+};
+
+type SearchTermsDataPoint = StatsNormalizedDataPoint< StatsSearchTermsItem > & {
+	encrypted_search_terms?: unknown;
+};
+
+/**
+ * Read the aggregate encrypted-search count that the Stats payload stores
+ * beside a bucket's known `search_terms` array.
+ *
+ * @param point - A normalized search-terms bucket.
+ * @return The encrypted search count when present.
+ */
+function getEncryptedSearchTerms( point: SearchTermsDataPoint ): number | undefined {
+	const value = point.encrypted_search_terms;
+	const count = typeof value === 'number' ? value : Number( value );
+
+	return value !== undefined && Number.isFinite( count ) ? count : undefined;
+}
+
+/**
+ * Normalize an API term label to table text.
+ *
+ * @param item - A normalized search-term item.
+ * @return The term label.
+ */
+function getTermLabel( item: StatsSearchTermsItem ): string {
+	return typeof item.label === 'string' ? item.label : String( item.label );
+}
+
+/**
+ * Build a views-per-bucket series from a bucketed search-terms report.
+ * Known-term views and the encrypted aggregate are both included so the chart
+ * represents the same records shown in the table.
+ *
+ * @param report - The bucketed search-terms report.
+ * @return The chart-ready time series.
+ */
+export function searchTermsToTimeSeries(
+	report: StatsNormalizedReport< StatsSearchTermsItem > | undefined
+): StatsTimeSeriesReport {
+	const data = ( report?.data ?? [] ).map( point => {
+		const knownViews = point.items.reduce( ( total, item ) => total + item.views, 0 );
+		const views = knownViews + ( getEncryptedSearchTerms( point ) ?? 0 );
+
+		return {
+			time_interval: point.time_interval,
+			date_start: point.date_start,
+			date_end: point.date_end,
+			label: point.time_interval,
+			items: [],
+			value: views,
+			views,
+		};
+	} );
+	const first = data[ 0 ];
+	const last = data[ data.length - 1 ];
+
+	return {
+		summary: {
+			...report?.summary,
+			...( first ? { date_start: first.date_start } : {} ),
+			...( last ? { date_end: last.date_end } : {} ),
+		},
+		data,
+	};
+}
+
+/**
+ * Aggregate bucketed search terms into one row per known term plus one regular
+ * row for the encrypted aggregate. The caller supplies the translated label
+ * so this transform stays independent of i18n state.
+ *
+ * @param report       - The bucketed search-terms report.
+ * @param unknownLabel - Translated label for encrypted search terms.
+ * @return Search-term table rows.
+ */
+export function aggregateSearchTermRows(
+	report: StatsNormalizedReport< StatsSearchTermsItem > | undefined,
+	unknownLabel: string
+): SearchTermRow[] {
+	const byTerm = new Map< string, SearchTermRow >();
+	let encryptedViews = 0;
+	let hasEncryptedViews = false;
+
+	for ( const point of report?.data ?? [] ) {
+		for ( const item of point.items ) {
+			const term = getTermLabel( item );
+			const existing = byTerm.get( term );
+
+			if ( existing ) {
+				existing.views += item.views;
+			} else {
+				byTerm.set( term, { id: `term:${ term }`, term, views: item.views } );
+			}
+		}
+
+		const bucketEncryptedViews = getEncryptedSearchTerms( point );
+		if ( bucketEncryptedViews !== undefined ) {
+			hasEncryptedViews = true;
+			encryptedViews += bucketEncryptedViews;
+		}
+	}
+
+	const rows = [ ...byTerm.values() ];
+
+	if ( hasEncryptedViews ) {
+		rows.push( { id: 'unknown-search-terms', term: unknownLabel, views: encryptedViews } );
+	}
+
+	return rows;
+}

--- a/projects/packages/premium-analytics/routes/reports/search-terms/config/aggregate.ts
+++ b/projects/packages/premium-analytics/routes/reports/search-terms/config/aggregate.ts
@@ -1,12 +1,13 @@
 /**
  * External dependencies
  */
-import type {
-	StatsNormalizedDataPoint,
-	StatsNormalizedReport,
-	StatsPeriod,
-	StatsSearchTermsItem,
-	StatsTimeSeriesReport,
+import {
+	bucketStatsTimeSeries,
+	type StatsChartBucketPeriod,
+	type StatsNormalizedDataPoint,
+	type StatsNormalizedReport,
+	type StatsSearchTermsItem,
+	type StatsTimeSeriesReport,
 } from '@jetpack-premium-analytics/data';
 
 /**
@@ -21,32 +22,6 @@ export type SearchTermRow = {
 type SearchTermsDataPoint = StatsNormalizedDataPoint< StatsSearchTermsItem > & {
 	encrypted_search_terms?: unknown;
 };
-
-type SearchTermsChartPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
-
-/**
- * Map a daily bucket date onto its chart bucket key for the selected period.
- *
- * @param date   - The daily bucket date (`YYYY-MM-DD`).
- * @param period - The chart bucket period.
- * @return The bucket key the date aggregates into.
- */
-function getChartBucketKey( date: string, period: SearchTermsChartPeriod ): string {
-	if ( period === 'day' ) {
-		return date;
-	}
-
-	const bucketDate = new Date( `${ date.slice( 0, 10 ) }T00:00:00Z` );
-
-	if ( period === 'week' ) {
-		const daysSinceMonday = ( bucketDate.getUTCDay() + 6 ) % 7;
-		bucketDate.setUTCDate( bucketDate.getUTCDate() - daysSinceMonday );
-	} else {
-		bucketDate.setUTCDate( 1 );
-	}
-
-	return bucketDate.toISOString().slice( 0, 10 );
-}
 
 /**
  * Read the aggregate encrypted-search count that the Stats payload stores
@@ -84,49 +59,14 @@ function getTermLabel( item: StatsSearchTermsItem ): string {
  */
 export function searchTermsToTimeSeries(
 	report: StatsNormalizedReport< StatsSearchTermsItem > | undefined,
-	period: SearchTermsChartPeriod = 'day'
+	period: StatsChartBucketPeriod = 'day'
 ): StatsTimeSeriesReport {
-	const buckets = new Map< string, StatsTimeSeriesReport[ 'data' ][ number ] >();
-	const points = [ ...( report?.data ?? [] ) ].sort( ( a, b ) =>
-		a.time_interval.localeCompare( b.time_interval )
-	);
-
-	for ( const point of points ) {
+	return bucketStatsTimeSeries( report, period, point => {
 		const knownViews = point.items.reduce( ( total, item ) => total + item.views, 0 );
 		const views = knownViews + ( getEncryptedSearchTerms( point ) ?? 0 );
-		const key = getChartBucketKey( point.time_interval, period );
-		const existing = buckets.get( key );
 
-		if ( existing ) {
-			existing.date_end = point.date_end;
-			existing.value = Number( existing.value ) + views;
-			existing.views = Number( existing.views ) + views;
-			continue;
-		}
-
-		buckets.set( key, {
-			time_interval: key,
-			date_start: point.date_start,
-			date_end: point.date_end,
-			label: key,
-			items: [],
-			value: views,
-			views,
-		} );
-	}
-
-	const data = [ ...buckets.values() ];
-	const first = data[ 0 ];
-	const last = data[ data.length - 1 ];
-
-	return {
-		summary: {
-			...report?.summary,
-			...( first ? { date_start: first.date_start } : {} ),
-			...( last ? { date_end: last.date_end } : {} ),
-		},
-		data,
-	};
+		return { value: views, views };
+	} );
 }
 
 /**

--- a/projects/packages/premium-analytics/routes/reports/search-terms/config/fields.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/search-terms/config/fields.test.ts
@@ -1,0 +1,14 @@
+import { getSearchTermsFields } from './fields';
+
+describe( 'search terms fields', () => {
+	it( 'makes the search term searchable and both columns sortable', () => {
+		const fields = getSearchTermsFields();
+		const term = fields.find( field => field.id === 'term' );
+		const views = fields.find( field => field.id === 'views' );
+
+		expect( term ).toEqual(
+			expect.objectContaining( { enableGlobalSearch: true, enableSorting: true } )
+		);
+		expect( views ).toEqual( expect.objectContaining( { enableSorting: true } ) );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/reports/search-terms/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/search-terms/config/fields.tsx
@@ -1,0 +1,36 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import type { SearchTermRow } from './aggregate';
+import type { Field } from '@wordpress/dataviews';
+
+/**
+ * DataViews field config for the Search terms records table.
+ *
+ * @return The field config.
+ */
+export function getSearchTermsFields(): Field< SearchTermRow >[] {
+	return [
+		{
+			id: 'term',
+			label: __( 'Search term', 'jetpack-premium-analytics' ),
+			type: 'text',
+			enableGlobalSearch: true,
+			enableSorting: true,
+			enableHiding: false,
+			getValue: ( { item } ) => item.term,
+		},
+		{
+			id: 'views',
+			label: __( 'Views', 'jetpack-premium-analytics' ),
+			type: 'integer',
+			enableSorting: true,
+			getValue: ( { item } ) => item.views,
+			render: ( { item } ) => <>{ item.views.toLocaleString() }</>,
+		},
+	];
+}

--- a/projects/packages/premium-analytics/routes/reports/search-terms/config/index.ts
+++ b/projects/packages/premium-analytics/routes/reports/search-terms/config/index.ts
@@ -1,0 +1,3 @@
+export { aggregateSearchTermRows, searchTermsToTimeSeries, type SearchTermRow } from './aggregate';
+export { getSearchTermsFields } from './fields';
+export { useSearchTermsReportRecords } from './use-report-records';

--- a/projects/packages/premium-analytics/routes/reports/search-terms/config/use-report-records.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/search-terms/config/use-report-records.test.ts
@@ -3,8 +3,8 @@ import { renderHook } from '@testing-library/react';
 import { useSearchTermsReportRecords } from './use-report-records';
 import type {
 	ReportParams,
+	StatsChartBucketPeriod,
 	StatsNormalizedReport,
-	StatsPeriod,
 	StatsSearchTermsItem,
 } from '@jetpack-premium-analytics/data';
 
@@ -16,8 +16,6 @@ jest.mock( '@jetpack-premium-analytics/data', () => ( {
 const mockUseStatsSearchTerms = useStatsSearchTerms as jest.MockedFunction<
 	typeof useStatsSearchTerms
 >;
-
-type SearchTermsChartPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
 
 const report: StatsNormalizedReport< StatsSearchTermsItem > = {
 	summary: {},
@@ -100,7 +98,7 @@ describe( 'useSearchTermsReportRecords', () => {
 			compare_to: '2026-05-28',
 		};
 		const { result, rerender } = renderHook(
-			( { chartPeriod }: { chartPeriod: SearchTermsChartPeriod } ) =>
+			( { chartPeriod }: { chartPeriod: StatsChartBucketPeriod } ) =>
 				useSearchTermsReportRecords( params, chartPeriod ),
 			{ initialProps: { chartPeriod: 'day' } }
 		);

--- a/projects/packages/premium-analytics/routes/reports/search-terms/config/use-report-records.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/search-terms/config/use-report-records.test.ts
@@ -1,0 +1,125 @@
+import { useStatsSearchTerms } from '@jetpack-premium-analytics/data';
+import { renderHook } from '@testing-library/react';
+import { useSearchTermsReportRecords } from './use-report-records';
+import type {
+	ReportParams,
+	StatsNormalizedReport,
+	StatsPeriod,
+	StatsSearchTermsItem,
+} from '@jetpack-premium-analytics/data';
+
+jest.mock( '@jetpack-premium-analytics/data', () => ( {
+	...jest.requireActual( '@jetpack-premium-analytics/data' ),
+	useStatsSearchTerms: jest.fn(),
+} ) );
+
+const mockUseStatsSearchTerms = useStatsSearchTerms as jest.MockedFunction<
+	typeof useStatsSearchTerms
+>;
+
+type SearchTermsChartPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
+
+const report: StatsNormalizedReport< StatsSearchTermsItem > = {
+	summary: {},
+	data: [
+		{
+			time_interval: '2026-06-03',
+			date_start: '2026-06-03T00:00:00+00:00',
+			date_end: '2026-06-03T23:59:59+00:00',
+			items: [
+				{
+					label: 'jetpack stats',
+					views: 5,
+					className: 'user-selectable',
+					children: null,
+				},
+			],
+			encrypted_search_terms: 4,
+		},
+		{
+			time_interval: '2026-06-04',
+			date_start: '2026-06-04T00:00:00+00:00',
+			date_end: '2026-06-04T23:59:59+00:00',
+			items: [
+				{
+					label: 'jetpack stats',
+					views: 7,
+					className: 'user-selectable',
+					children: null,
+				},
+			],
+			encrypted_search_terms: 6,
+		},
+	],
+};
+
+/**
+ * Mock the shared Stats hook with the daily fixture.
+ *
+ * @param hasComparison - Whether comparison data is available.
+ */
+function mockSearchTermsReport( hasComparison = false ) {
+	mockUseStatsSearchTerms.mockReturnValue( {
+		primary: { data: report },
+		comparison: { data: hasComparison ? report : undefined },
+		hasComparison,
+		isLoading: false,
+	} as unknown as ReturnType< typeof useStatsSearchTerms > );
+}
+
+describe( 'useSearchTermsReportRecords', () => {
+	beforeEach( () => {
+		mockUseStatsSearchTerms.mockReset();
+	} );
+
+	it( 'requests daily buckets for the shared chart and table data', () => {
+		mockSearchTermsReport();
+		const params: ReportParams = {
+			from: '2026-06-03',
+			to: '2026-06-04',
+			interval: 'day',
+		};
+
+		renderHook( () => useSearchTermsReportRecords( params, 'day' ) );
+
+		expect( mockUseStatsSearchTerms ).toHaveBeenCalledWith( {
+			...params,
+			max: 0,
+			summarize: 0,
+			period: 'day',
+		} );
+	} );
+
+	it( 'keeps the request and table daily while grouping both chart series by week', () => {
+		mockSearchTermsReport( true );
+		const params: ReportParams = {
+			from: '2026-06-03',
+			to: '2026-06-04',
+			interval: 'day',
+			compare_from: '2026-05-27',
+			compare_to: '2026-05-28',
+		};
+		const { result, rerender } = renderHook(
+			( { chartPeriod }: { chartPeriod: SearchTermsChartPeriod } ) =>
+				useSearchTermsReportRecords( params, chartPeriod ),
+			{ initialProps: { chartPeriod: 'day' } }
+		);
+		const dayRows = result.current.table.rows;
+
+		rerender( { chartPeriod: 'week' } );
+
+		expect( mockUseStatsSearchTerms ).toHaveBeenLastCalledWith( {
+			...params,
+			max: 0,
+			summarize: 0,
+			period: 'day',
+		} );
+		expect( result.current.chart.primary.data ).toEqual( [
+			expect.objectContaining( { time_interval: '2026-06-01', views: 22 } ),
+		] );
+		expect( result.current.chart.comparison?.data ).toEqual( [
+			expect.objectContaining( { time_interval: '2026-06-01', views: 22 } ),
+		] );
+		expect( result.current.table.rows ).toEqual( dayRows );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/reports/search-terms/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/search-terms/config/use-report-records.ts
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import {
+	useStatsSearchTerms,
+	type ReportParams,
+	type StatsPeriod,
+} from '@jetpack-premium-analytics/data';
+import { useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import { aggregateSearchTermRows, searchTermsToTimeSeries } from './aggregate';
+
+/**
+ * Fetch and derive the chart and table records for the Search terms report.
+ *
+ * @param reportParams - The shared report-window parameters.
+ * @param chartPeriod  - The chart's bucket period.
+ * @return Chart data and table records.
+ */
+export function useSearchTermsReportRecords(
+	reportParams: ReportParams,
+	chartPeriod: StatsPeriod
+) {
+	/*
+	 * One bucketed report feeds both the chart and table. `summarize: 0` keeps
+	 * the per-period buckets, while `max: 0` requests all known terms for
+	 * client-side search, sorting, and pagination.
+	 */
+	const recordsParams = useMemo(
+		() => ( {
+			...reportParams,
+			max: 0,
+			summarize: 0,
+			period: chartPeriod,
+		} ),
+		[ reportParams, chartPeriod ]
+	);
+	const report = useStatsSearchTerms( recordsParams );
+	const unknownLabel = __( 'Unknown search terms', 'jetpack-premium-analytics' );
+
+	const chartPrimary = useMemo(
+		() => searchTermsToTimeSeries( report.primary.data ),
+		[ report.primary.data ]
+	);
+	const chartComparison = useMemo( () => {
+		if ( ! reportParams.compare_from || ! reportParams.compare_to ) {
+			return undefined;
+		}
+
+		return searchTermsToTimeSeries( report.comparison.data );
+	}, [ reportParams, report.comparison.data ] );
+	const rows = useMemo(
+		() => aggregateSearchTermRows( report.primary.data, unknownLabel ),
+		[ report.primary.data, unknownLabel ]
+	);
+
+	return {
+		chart: {
+			primary: chartPrimary,
+			comparison: report.hasComparison ? chartComparison : undefined,
+			isLoading: report.isLoading,
+		},
+		table: {
+			rows,
+			isLoading: report.isLoading,
+		},
+	};
+}

--- a/projects/packages/premium-analytics/routes/reports/search-terms/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/search-terms/config/use-report-records.ts
@@ -4,7 +4,7 @@
 import {
 	useStatsSearchTerms,
 	type ReportParams,
-	type StatsPeriod,
+	type StatsChartBucketPeriod,
 } from '@jetpack-premium-analytics/data';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -12,8 +12,6 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import { aggregateSearchTermRows, searchTermsToTimeSeries } from './aggregate';
-
-type SearchTermsChartPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
 
 /**
  * Fetch and derive the chart and table records for the Search terms report.
@@ -24,7 +22,7 @@ type SearchTermsChartPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
  */
 export function useSearchTermsReportRecords(
 	reportParams: ReportParams,
-	chartPeriod: SearchTermsChartPeriod
+	chartPeriod: StatsChartBucketPeriod
 ) {
 	/*
 	 * One bucketed report feeds both the chart and table. `summarize: 0` keeps

--- a/projects/packages/premium-analytics/routes/reports/search-terms/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/search-terms/config/use-report-records.ts
@@ -13,6 +13,8 @@ import { __ } from '@wordpress/i18n';
  */
 import { aggregateSearchTermRows, searchTermsToTimeSeries } from './aggregate';
 
+type SearchTermsChartPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
+
 /**
  * Fetch and derive the chart and table records for the Search terms report.
  *
@@ -22,7 +24,7 @@ import { aggregateSearchTermRows, searchTermsToTimeSeries } from './aggregate';
  */
 export function useSearchTermsReportRecords(
 	reportParams: ReportParams,
-	chartPeriod: StatsPeriod
+	chartPeriod: SearchTermsChartPeriod
 ) {
 	/*
 	 * One bucketed report feeds both the chart and table. `summarize: 0` keeps
@@ -34,24 +36,24 @@ export function useSearchTermsReportRecords(
 			...reportParams,
 			max: 0,
 			summarize: 0,
-			period: chartPeriod,
+			period: 'day',
 		} ),
-		[ reportParams, chartPeriod ]
+		[ reportParams ]
 	);
 	const report = useStatsSearchTerms( recordsParams );
 	const unknownLabel = __( 'Unknown search terms', 'jetpack-premium-analytics' );
 
 	const chartPrimary = useMemo(
-		() => searchTermsToTimeSeries( report.primary.data ),
-		[ report.primary.data ]
+		() => searchTermsToTimeSeries( report.primary.data, chartPeriod ),
+		[ report.primary.data, chartPeriod ]
 	);
 	const chartComparison = useMemo( () => {
 		if ( ! reportParams.compare_from || ! reportParams.compare_to ) {
 			return undefined;
 		}
 
-		return searchTermsToTimeSeries( report.comparison.data );
-	}, [ reportParams, report.comparison.data ] );
+		return searchTermsToTimeSeries( report.comparison.data, chartPeriod );
+	}, [ reportParams, report.comparison.data, chartPeriod ] );
 	const rows = useMemo(
 		() => aggregateSearchTermRows( report.primary.data, unknownLabel ),
 		[ report.primary.data, unknownLabel ]

--- a/projects/packages/premium-analytics/routes/reports/search-terms/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/search-terms/config/use-report-records.ts
@@ -60,7 +60,7 @@ export function useSearchTermsReportRecords(
 	return {
 		chart: {
 			primary: chartPrimary,
-			comparison: report.hasComparison ? chartComparison : undefined,
+			comparison: report.comparison.data ? chartComparison : undefined,
 			isLoading: report.isLoading,
 		},
 		table: {

--- a/projects/packages/premium-analytics/routes/reports/search-terms/page.module.css
+++ b/projects/packages/premium-analytics/routes/reports/search-terms/page.module.css
@@ -13,7 +13,7 @@
 	 * tab strip is designed to sit flush under the header.
 	 */
 	padding-block-start: var(--wpds-dimension-padding-lg);
-	padding-block-end: 24px;
+	padding-block-end: var(--wpds-dimension-padding-2xl);
 	padding-inline: var(--wpds-dimension-padding-2xl);
 }
 

--- a/projects/packages/premium-analytics/routes/reports/search-terms/page.module.css
+++ b/projects/packages/premium-analytics/routes/reports/search-terms/page.module.css
@@ -1,0 +1,22 @@
+.page {
+	min-block-size: 0;
+}
+
+.content {
+	flex: 1 1 auto;
+	min-block-size: 0;
+	overflow-y: auto;
+
+	/*
+	 * Mirror the top padding of Page's own `hasPadding` content so the filters
+	 * row doesn't hug the header border — tabbed reports skip this because the
+	 * tab strip is designed to sit flush under the header.
+	 */
+	padding-block-start: var(--wpds-dimension-padding-lg);
+	padding-block-end: 24px;
+	padding-inline: var(--wpds-dimension-padding-2xl);
+}
+
+.dateFilters {
+	inline-size: 100%;
+}

--- a/projects/packages/premium-analytics/routes/reports/search-terms/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/search-terms/page.tsx
@@ -1,0 +1,163 @@
+/**
+ * External dependencies
+ */
+import {
+	normalizeReportParams,
+	type IntervalType,
+	type StatsPeriod,
+} from '@jetpack-premium-analytics/data';
+import { useDashboardLink, useReportDateFilters } from '@jetpack-premium-analytics/routing';
+import { DateFiltersPanel } from '@jetpack-premium-analytics/ui';
+import {
+	formatLegendLabels,
+	ReportPageLayout,
+	ReportPerformanceChart,
+	ReportRecordsTable,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { Breadcrumbs, Page } from '@wordpress/admin-ui';
+import { useCallback, useMemo, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useNavigate, useSearch } from '@wordpress/route';
+/**
+ * Internal dependencies
+ */
+import { route } from '../package.json';
+import { getSearchTermsFields, useSearchTermsReportRecords, type SearchTermRow } from './config';
+import styles from './page.module.css';
+
+const ROUTE_FROM = route.path;
+const REPORT_PARAMS = { report: 'search-terms' };
+const CHART_PERIODS = [ 'day', 'week', 'month' ] as const satisfies readonly StatsPeriod[];
+type ChartPeriod = ( typeof CHART_PERIODS )[ number ];
+
+/**
+ * Check whether a URL value is a supported chart period.
+ *
+ * @param value - The URL search value.
+ * @return Whether the value is a chart period.
+ */
+function isChartPeriod( value: unknown ): value is ChartPeriod {
+	return CHART_PERIODS.includes( value as ChartPeriod );
+}
+
+/**
+ * Choose the chart bucket period for a report interval.
+ *
+ * @param interval - The report date interval.
+ * @return The default chart bucket period.
+ */
+function getDefaultChartPeriod( interval?: IntervalType ): ChartPeriod {
+	if ( interval === 'week' ) {
+		return 'week';
+	}
+
+	if ( interval === 'month' || interval === 'quarter' || interval === 'year' ) {
+		return 'month';
+	}
+
+	return 'day';
+}
+
+/**
+ * Stable row id for the records table.
+ *
+ * @param item - The search-term row.
+ * @return The row id.
+ */
+function getSearchTermRowId( item: SearchTermRow ): string {
+	return item.id;
+}
+
+const RECORDS_VIEW = {
+	sort: { field: 'views', direction: 'desc' as const },
+	layout: {
+		styles: {
+			term: { width: '100%' },
+			views: { align: 'end' as const },
+		},
+	},
+};
+
+/**
+ * Premium Analytics Search terms report page.
+ *
+ * @return The report page.
+ */
+export default function SearchTermsReportPage(): JSX.Element {
+	const search = useSearch( { from: ROUTE_FROM } ) as Record< string, string | undefined >;
+	const reportParams = useMemo(
+		() => normalizeReportParams( search as Parameters< typeof normalizeReportParams >[ 0 ] ),
+		[ search ]
+	);
+	const chartPeriod = isChartPeriod( search.period )
+		? search.period
+		: getDefaultChartPeriod( reportParams.interval );
+	const records = useSearchTermsReportRecords( reportParams, chartPeriod );
+	const fields = useMemo( () => getSearchTermsFields(), [] );
+	const chartMetrics = useMemo(
+		() => [ { key: 'views', label: __( 'Views', 'jetpack-premium-analytics' ) } ],
+		[]
+	);
+	const chartLegendLabels = useMemo( () => formatLegendLabels( reportParams ), [ reportParams ] );
+	const navigate = useNavigate();
+	const handleIntervalChange = useCallback(
+		( interval: IntervalType ) => {
+			const period = isChartPeriod( interval ) ? interval : getDefaultChartPeriod( interval );
+			navigate( {
+				to: ROUTE_FROM,
+				params: REPORT_PARAMS as unknown as never,
+				replace: true,
+				search: ( ( current: Record< string, unknown > ) => ( {
+					...current,
+					period,
+				} ) ) as unknown as never,
+			} );
+		},
+		[ navigate ]
+	);
+	const dateFilters = useReportDateFilters( ROUTE_FROM );
+	const dashboardLink = useDashboardLink();
+	const [ containerElement, setContainerElement ] = useState< HTMLDivElement | null >( null );
+
+	return (
+		<Page
+			breadcrumbs={
+				<Breadcrumbs
+					items={ [
+						{ label: __( 'Stats', 'jetpack-premium-analytics' ), to: dashboardLink },
+						{ label: __( 'Search terms', 'jetpack-premium-analytics' ) },
+					] }
+				/>
+			}
+			className={ styles.page }
+		>
+			<div className={ styles.content }>
+				<ReportPageLayout
+					filters={
+						<div ref={ setContainerElement } className={ styles.dateFilters }>
+							<DateFiltersPanel { ...dateFilters } containerElement={ containerElement } />
+						</div>
+					}
+				>
+					<ReportPerformanceChart
+						primary={ records.chart.primary }
+						comparison={ records.chart.comparison }
+						isLoading={ records.chart.isLoading }
+						metrics={ chartMetrics }
+						interval={ chartPeriod }
+						onIntervalChange={ handleIntervalChange }
+						legendLabels={ chartLegendLabels }
+					/>
+					<ReportRecordsTable< SearchTermRow >
+						data={ records.table.rows }
+						fields={ fields }
+						getItemId={ getSearchTermRowId }
+						isLoading={ records.table.isLoading }
+						initialView={ RECORDS_VIEW }
+						searchLabel={ __( 'Search terms', 'jetpack-premium-analytics' ) }
+					/>
+				</ReportPageLayout>
+			</div>
+		</Page>
+	);
+}

--- a/projects/packages/premium-analytics/routes/reports/search-terms/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/search-terms/page.tsx
@@ -4,7 +4,7 @@
 import {
 	normalizeReportParams,
 	type IntervalType,
-	type StatsPeriod,
+	type StatsChartBucketPeriod,
 } from '@jetpack-premium-analytics/data';
 import { useDashboardLink, useReportDateFilters } from '@jetpack-premium-analytics/routing';
 import { DateFiltersPanel } from '@jetpack-premium-analytics/ui';
@@ -27,7 +27,11 @@ import styles from './page.module.css';
 
 const ROUTE_FROM = route.path;
 const REPORT_PARAMS = { report: 'search-terms' };
-const CHART_PERIODS = [ 'day', 'week', 'month' ] as const satisfies readonly StatsPeriod[];
+const CHART_PERIODS = [
+	'day',
+	'week',
+	'month',
+] as const satisfies readonly StatsChartBucketPeriod[];
 type ChartPeriod = ( typeof CHART_PERIODS )[ number ];
 
 /**

--- a/projects/packages/premium-analytics/widgets/search-terms/__tests__/search-terms.test.tsx
+++ b/projects/packages/premium-analytics/widgets/search-terms/__tests__/search-terms.test.tsx
@@ -1,0 +1,66 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+import type { AnchorHTMLAttributes, ReactNode } from 'react';
+/**
+ * Internal dependencies
+ */
+import SearchTermsWidget from '../render';
+import useSearchTermViews from '../use-search-term-views';
+
+type MockRouteLinkProps = {
+	to: string;
+	params?: Record< string, unknown >;
+	search?: Record< string, unknown >;
+	children: ReactNode;
+} & Omit< AnchorHTMLAttributes< HTMLAnchorElement >, 'href' >;
+
+jest.mock( '@wordpress/route', () => ( {
+	Link: ( { to, params, search, children, ...props }: MockRouteLinkProps ) => {
+		const path = Object.entries( params ?? {} ).reduce(
+			( result, [ key, value ] ) => result.replace( `$${ key }`, String( value ) ),
+			to
+		);
+		const query = new URLSearchParams();
+		Object.entries( search ?? {} ).forEach( ( [ key, value ] ) => {
+			if ( value !== undefined && value !== null ) {
+				query.set( key, String( value ) );
+			}
+		} );
+		const queryString = query.toString();
+
+		return (
+			<a href={ queryString ? `${ path }?${ queryString }` : path } { ...props }>
+				{ children }
+			</a>
+		);
+	},
+	useSearch: () => ( {} ),
+} ) );
+
+jest.mock( '../use-search-term-views' );
+
+const mockUseSearchTermViews = jest.mocked( useSearchTermViews );
+
+describe( 'SearchTermsWidget', () => {
+	beforeEach( () => {
+		mockUseSearchTermViews.mockReturnValue( {
+			data: [],
+			isLoading: false,
+			isFetching: false,
+			isError: false,
+			hasComparison: false,
+			refetch: jest.fn(),
+		} );
+	} );
+
+	it( 'links to the Search Terms report', () => {
+		render( <SearchTermsWidget attributes={ {} } /> );
+
+		expect( screen.getByRole( 'link', { name: 'See report' } ) ).toHaveAttribute(
+			'href',
+			expect.stringContaining( '/reports/search-terms' )
+		);
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/search-terms/render.tsx
+++ b/projects/packages/premium-analytics/widgets/search-terms/render.tsx
@@ -4,6 +4,8 @@
 import {
 	calculateDelta,
 	LeaderboardChart,
+	ReportLink,
+	WidgetFooter,
 	WidgetRoot,
 	WidgetState,
 	sharePercentage,
@@ -101,6 +103,9 @@ function SearchTermsInner( { max = 10 }: SearchTermsAttributes ) {
 					/>
 				</WidgetState>
 			</div>
+			<WidgetFooter>
+				<ReportLink report="search-terms" />
+			</WidgetFooter>
 		</Stack>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/search-terms/stories/search-terms-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/search-terms/stories/search-terms-widget.stories.tsx
@@ -5,6 +5,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withStoryRouter } from '../../stories/with-story-router';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -78,13 +79,13 @@ type Story = StoryObj< SearchTermsStoryControls >;
 export const Default: Story = {
 	render: renderSearchTerms,
 	args: { withComparison: false },
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 };
 
 export const WithComparison: Story = {
 	render: renderSearchTerms,
 	args: { withComparison: true },
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 };
 
 /**
@@ -95,7 +96,7 @@ export const Loading: Story = {
 	render: () => renderSearchTermsOnPreset( 'last-90-days' ),
 	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 	beforeEach: () => {
 		setReportMockState( 'stats/search-terms', 'loading' );
 		return () => setReportMockState( 'stats/search-terms', null );
@@ -109,7 +110,7 @@ export const Loading: Story = {
 export const Error: Story = {
 	render: () => renderSearchTermsOnPreset( 'last-7-days' ),
 	tags: [ '!autodocs' ],
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 	beforeEach: () => {
 		setReportMockState( 'stats/search-terms', 'error' );
 		return () => setReportMockState( 'stats/search-terms', null );
@@ -123,7 +124,7 @@ export const Error: Story = {
 export const Empty: Story = {
 	render: () => renderSearchTermsOnPreset( 'last-365-days' ),
 	tags: [ '!autodocs' ],
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 	beforeEach: () => {
 		setReportMockState( 'stats/search-terms', 'empty' );
 		return () => setReportMockState( 'stats/search-terms', null );


### PR DESCRIPTION
Part of [WOOA7S-1701](https://linear.app/a8c/issue/WOOA7S-1701)

<img width="1482" height="1638" alt="Google Chrome -2026-07-14 at 12 09 52@2x" src="https://github.com/user-attachments/assets/9e8b5f8c-6f55-4e19-a1bc-a8719038de63" />

## Proposed changes

* Adds the Search terms report at `/reports/search-terms` on the reports framework from #50305: a `routes/reports/search-terms/` page module (performance chart + records table, `config/aggregate.ts` with tests) and one `REPORTS` registry entry.
* The Search terms widget footer links to the report via the shared `WidgetFooter`/`ReportLink`, carrying the dashboard's current date range and comparison.

<!-- screenshot: add a capture of the /reports/search-terms page -->

## Related product discussion/links

* [WOOA7S-1701](https://linear.app/a8c/issue/WOOA7S-1701)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `cd projects/packages/premium-analytics && pnpm run build`, open the Premium Analytics dashboard on a site with search traffic data.
* In the Search terms widget, click **View all** — you should land on `/reports/search-terms` with the dashboard's date range and comparison intact.
* On the chart: change the time bucket (day/week/month) and collapse/expand it.
* On the table: search, sort, and page through — all client-side, no new requests.
* Change the date range from the page's date filter — chart and table should update together, and reloading the URL should restore the exact view.
