### PR TITLE
WOOA7S-1702: Premium Analytics: add the Videos report at /reports/videos

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-wooa7s-1702-videos-report-page
+++ b/projects/packages/premium-analytics/changelog/add-wooa7s-1702-videos-report-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add the Videos report at `/reports/videos`.

--- a/projects/packages/premium-analytics/routes/reports/registry.ts
+++ b/projects/packages/premium-analytics/routes/reports/registry.ts
@@ -76,6 +76,12 @@ export const REPORTS: Record< string, ReportDefinition > = {
 		resolveSection: resolveTabId,
 		load: () => import( './posts/page' ),
 	},
+	videos: {
+		id: 'videos',
+		getTitle: () => __( 'Videos', 'jetpack-premium-analytics' ),
+		getDescription: () => __( 'See how your videos perform.', 'jetpack-premium-analytics' ),
+		load: () => import( './videos/page' ),
+	},
 };
 
 /**

--- a/projects/packages/premium-analytics/routes/reports/videos/config/aggregate.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/videos/config/aggregate.test.ts
@@ -114,9 +114,9 @@ const report: StatsNormalizedReport< StatsVideoPlaysItem > = {
 	summary: {},
 	data: [
 		{
-			time_interval: '2026-06-01',
-			date_start: '2026-06-01T00:00:00+00:00',
-			date_end: '2026-06-01T23:59:59+00:00',
+			time_interval: '2026-06-04',
+			date_start: '2026-06-04T00:00:00+00:00',
+			date_end: '2026-06-04T23:59:59+00:00',
 			items: [
 				makeVideo( { plays: 10, impressions: 30 } ),
 				makeVideo( {
@@ -129,9 +129,9 @@ const report: StatsNormalizedReport< StatsVideoPlaysItem > = {
 			],
 		},
 		{
-			time_interval: '2026-06-02',
-			date_start: '2026-06-02T00:00:00+00:00',
-			date_end: '2026-06-02T23:59:59+00:00',
+			time_interval: '2026-06-05',
+			date_start: '2026-06-05T00:00:00+00:00',
+			date_end: '2026-06-05T23:59:59+00:00',
 			items: [ makeVideo( { plays: 7, impressions: 20 } ) ],
 		},
 	],
@@ -142,8 +142,8 @@ describe( 'report videos aggregate', () => {
 		const series = videosToTimeSeries( report );
 
 		expect( series.summary ).toEqual( {
-			date_start: '2026-06-01T00:00:00+00:00',
-			date_end: '2026-06-02T23:59:59+00:00',
+			date_start: '2026-06-04T00:00:00+00:00',
+			date_end: '2026-06-05T23:59:59+00:00',
 		} );
 		expect( series.data.map( point => point.plays ) ).toEqual( [ 15, 7 ] );
 	} );
@@ -155,10 +155,14 @@ describe( 'report videos aggregate', () => {
 			expect.objectContaining( {
 				time_interval: '2026-06-01',
 				date_start: '2026-06-01T00:00:00+00:00',
-				date_end: '2026-06-02T23:59:59+00:00',
+				date_end: '2026-06-05T23:59:59+00:00',
 				plays: 22,
 			} ),
 		] );
+		expect( series.summary ).toEqual( {
+			date_start: '2026-06-04T00:00:00+00:00',
+			date_end: '2026-06-05T23:59:59+00:00',
+		} );
 	} );
 
 	it( 'aggregates plays and impressions without mutating the report', () => {

--- a/projects/packages/premium-analytics/routes/reports/videos/config/aggregate.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/videos/config/aggregate.test.ts
@@ -1,0 +1,216 @@
+import { aggregateVideoRows, getVideoRowId, videosToTimeSeries } from './aggregate';
+import type { StatsNormalizedReport, StatsVideoPlaysItem } from '@jetpack-premium-analytics/data';
+
+const liveBucketedResponse = {
+	date: '2026-07-10',
+	period: 'day',
+	days: {
+		'2026-07-08': {
+			data: [
+				{
+					post_id: 441,
+					title: 'demo-video-mp4',
+					views: 34,
+					impressions: 40,
+					watch_time: 0.02,
+					retention_rate: 67.1,
+				},
+				{
+					post_id: 461,
+					title: 'feature-walkthrough-mp4',
+					views: 23,
+					impressions: 30,
+					watch_time: 0.01,
+					retention_rate: 61.5,
+				},
+				{
+					post_id: 454,
+					title: 'product-tour-mp4',
+					views: 22,
+					impressions: 30,
+					watch_time: 0.01,
+					retention_rate: 70.1,
+				},
+				{
+					post_id: 456,
+					title: 'webinar-recording-mp4',
+					views: 10,
+					impressions: 10,
+					watch_time: 0.005,
+					retention_rate: 75.4,
+				},
+			],
+		},
+		'2026-07-09': {
+			data: [
+				{ post_id: 441, title: 'demo-video-mp4', views: 33, impressions: 30 },
+				{ post_id: 461, title: 'feature-walkthrough-mp4', views: 23, impressions: 25 },
+				{ post_id: 454, title: 'product-tour-mp4', views: 22, impressions: 28 },
+				{ post_id: 456, title: 'webinar-recording-mp4', views: 9, impressions: 15 },
+			],
+		},
+		'2026-07-10': {
+			data: [
+				{ post_id: 441, title: 'demo-video-mp4', views: 6, impressions: 40 },
+				{ post_id: 461, title: 'feature-walkthrough-mp4', views: 6, impressions: 28 },
+				{ post_id: 454, title: 'product-tour-mp4', views: 5, impressions: 30 },
+				{ post_id: 456, title: 'webinar-recording-mp4', views: 4, impressions: 21 },
+			],
+		},
+	},
+};
+
+/**
+ * Build the normalized report the buckets hook would produce from the live
+ * fixture response, so aggregation tests run on realistic data.
+ *
+ * @return The normalized bucketed report.
+ */
+function normalizeFixtureBuckets(): StatsNormalizedReport< StatsVideoPlaysItem > {
+	return {
+		summary: {
+			date_start: '2026-07-08T00:00:00+00:00',
+			date_end: '2026-07-10T23:59:59+00:00',
+		},
+		data: Object.entries( liveBucketedResponse.days ).map( ( [ date, bucket ] ) => ( {
+			time_interval: date,
+			date_start: `${ date }T00:00:00+00:00`,
+			date_end: `${ date }T23:59:59+00:00`,
+			items: bucket.data.map( item => ( {
+				id: item.post_id,
+				label: item.title,
+				plays: item.views,
+				impressions: item.impressions,
+				watch_time: item.watch_time ?? 0,
+				retention_rate: item.retention_rate ?? 0,
+				link: null,
+				children: null,
+			} ) ),
+		} ) ),
+	};
+}
+
+/**
+ * Build a video row fixture.
+ *
+ * @param overrides - Fields to override on the default row.
+ * @return The video row.
+ */
+function makeVideo( overrides: Partial< StatsVideoPlaysItem > = {} ): StatsVideoPlaysItem {
+	return {
+		id: 1,
+		label: 'Launch video',
+		plays: 0,
+		impressions: 0,
+		watch_time: 0,
+		retention_rate: 0,
+		link: 'https://example.com/video/',
+		children: null,
+		...overrides,
+	};
+}
+
+const report: StatsNormalizedReport< StatsVideoPlaysItem > = {
+	summary: {},
+	data: [
+		{
+			time_interval: '2026-06-01',
+			date_start: '2026-06-01T00:00:00+00:00',
+			date_end: '2026-06-01T23:59:59+00:00',
+			items: [
+				makeVideo( { plays: 10, impressions: 30 } ),
+				makeVideo( {
+					id: 2,
+					label: 'Demo',
+					link: 'https://example.com/demo/',
+					plays: 5,
+					impressions: 12,
+				} ),
+			],
+		},
+		{
+			time_interval: '2026-06-02',
+			date_start: '2026-06-02T00:00:00+00:00',
+			date_end: '2026-06-02T23:59:59+00:00',
+			items: [ makeVideo( { plays: 7, impressions: 20 } ) ],
+		},
+	],
+};
+
+describe( 'report videos aggregate', () => {
+	it( 'builds plays totals for each chart bucket', () => {
+		const series = videosToTimeSeries( report );
+
+		expect( series.summary ).toEqual( {
+			date_start: '2026-06-01T00:00:00+00:00',
+			date_end: '2026-06-02T23:59:59+00:00',
+		} );
+		expect( series.data.map( point => point.plays ) ).toEqual( [ 15, 7 ] );
+	} );
+
+	it( 'groups real daily totals into calendar weeks for the chart', () => {
+		const series = videosToTimeSeries( report, 'week' );
+
+		expect( series.data ).toEqual( [
+			expect.objectContaining( {
+				time_interval: '2026-06-01',
+				date_start: '2026-06-01T00:00:00+00:00',
+				date_end: '2026-06-02T23:59:59+00:00',
+				plays: 22,
+			} ),
+		] );
+	} );
+
+	it( 'aggregates plays and impressions without mutating the report', () => {
+		const rows = aggregateVideoRows( report );
+
+		expect( rows ).toEqual( [
+			expect.objectContaining( { id: 1, plays: 17, impressions: 50 } ),
+			expect.objectContaining( { id: 2, plays: 5, impressions: 12 } ),
+		] );
+		expect( report.data[ 0 ].items[ 0 ].plays ).toBe( 10 );
+	} );
+
+	it( 'aggregates every live date bucket into full-range table totals', () => {
+		const normalized = normalizeFixtureBuckets();
+
+		expect( aggregateVideoRows( normalized ) ).toEqual( [
+			expect.objectContaining( {
+				id: 441,
+				label: 'demo-video-mp4',
+				plays: 73,
+				impressions: 110,
+			} ),
+			expect.objectContaining( {
+				id: 461,
+				label: 'feature-walkthrough-mp4',
+				plays: 52,
+				impressions: 83,
+			} ),
+			expect.objectContaining( { id: 454, plays: 49, impressions: 88 } ),
+			expect.objectContaining( { id: 456, plays: 23, impressions: 46 } ),
+		] );
+	} );
+
+	it( 'builds one correctly dated chart point from every live date bucket', () => {
+		const normalized = normalizeFixtureBuckets();
+		const series = videosToTimeSeries( normalized );
+
+		expect(
+			series.data.map( point => ( {
+				date: point.time_interval,
+				dateStart: point.date_start,
+				plays: point.plays,
+			} ) )
+		).toEqual( [
+			{ date: '2026-07-08', dateStart: '2026-07-08T00:00:00+00:00', plays: 89 },
+			{ date: '2026-07-09', dateStart: '2026-07-09T00:00:00+00:00', plays: 87 },
+			{ date: '2026-07-10', dateStart: '2026-07-10T00:00:00+00:00', plays: 21 },
+		] );
+	} );
+
+	it( 'falls back from id to URL and then title for row identity', () => {
+		expect( getVideoRowId( makeVideo( { id: undefined } ) ) ).toBe( 'https://example.com/video/' );
+		expect( getVideoRowId( makeVideo( { id: undefined, link: null } ) ) ).toBe( 'Launch video' );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/reports/videos/config/aggregate.ts
+++ b/projects/packages/premium-analytics/routes/reports/videos/config/aggregate.ts
@@ -1,40 +1,13 @@
 /**
  * External dependencies
  */
-import type {
-	StatsNormalizedReport,
-	StatsPeriod,
-	StatsTimeSeriesReport,
-	StatsVideoPlaysItem,
+import {
+	bucketStatsTimeSeries,
+	type StatsChartBucketPeriod,
+	type StatsNormalizedReport,
+	type StatsTimeSeriesReport,
+	type StatsVideoPlaysItem,
 } from '@jetpack-premium-analytics/data';
-
-type VideoChartPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
-
-/**
- * Map a daily bucket date onto its chart bucket key for the selected period —
- * the date itself for days, the start of the ISO week for weeks, and the
- * first-of-month date (`YYYY-MM-01`) for months.
- *
- * @param date   - The daily bucket date (`YYYY-MM-DD`).
- * @param period - The chart bucket period.
- * @return The bucket key the date aggregates into.
- */
-function getChartBucketKey( date: string, period: VideoChartPeriod ): string {
-	if ( period === 'day' ) {
-		return date;
-	}
-
-	const bucketDate = new Date( `${ date.slice( 0, 10 ) }T00:00:00Z` );
-
-	if ( period === 'week' ) {
-		const daysSinceMonday = ( bucketDate.getUTCDay() + 6 ) % 7;
-		bucketDate.setUTCDate( bucketDate.getUTCDate() - daysSinceMonday );
-	} else {
-		bucketDate.setUTCDate( 1 );
-	}
-
-	return bucketDate.toISOString().slice( 0, 10 );
-}
 
 /**
  * Resolve the stable identity shared by a video across report buckets.
@@ -64,45 +37,13 @@ export function getVideoRowId( video: StatsVideoPlaysItem ): string {
  */
 export function videosToTimeSeries(
 	report: StatsNormalizedReport< StatsVideoPlaysItem > | undefined,
-	period: VideoChartPeriod = 'day'
+	period: StatsChartBucketPeriod = 'day'
 ): StatsTimeSeriesReport {
-	const buckets = new Map< string, StatsTimeSeriesReport[ 'data' ][ number ] >();
-
-	for ( const point of report?.data ?? [] ) {
+	return bucketStatsTimeSeries( report, period, point => {
 		const plays = point.items.reduce( ( total, item ) => total + item.plays, 0 );
-		const key = getChartBucketKey( point.time_interval, period );
-		const existing = buckets.get( key );
 
-		if ( existing ) {
-			existing.date_end = point.date_end;
-			existing.value = Number( existing.value ) + plays;
-			existing.plays = Number( existing.plays ) + plays;
-			continue;
-		}
-
-		buckets.set( key, {
-			time_interval: key,
-			date_start: point.date_start,
-			date_end: point.date_end,
-			label: key,
-			items: [],
-			value: plays,
-			plays,
-		} );
-	}
-
-	const data = [ ...buckets.values() ];
-	const first = data[ 0 ];
-	const last = data[ data.length - 1 ];
-
-	return {
-		summary: {
-			...report?.summary,
-			...( first ? { date_start: first.date_start } : {} ),
-			...( last ? { date_end: last.date_end } : {} ),
-		},
-		data,
-	};
+		return { value: plays, plays };
+	} );
 }
 
 /**

--- a/projects/packages/premium-analytics/routes/reports/videos/config/aggregate.ts
+++ b/projects/packages/premium-analytics/routes/reports/videos/config/aggregate.ts
@@ -13,7 +13,7 @@ type VideoChartPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
 /**
  * Map a daily bucket date onto its chart bucket key for the selected period —
  * the date itself for days, the start of the ISO week for weeks, and the
- * `YYYY-MM` month prefix for months.
+ * first-of-month date (`YYYY-MM-01`) for months.
  *
  * @param date   - The daily bucket date (`YYYY-MM-DD`).
  * @param period - The chart bucket period.

--- a/projects/packages/premium-analytics/routes/reports/videos/config/aggregate.ts
+++ b/projects/packages/premium-analytics/routes/reports/videos/config/aggregate.ts
@@ -1,0 +1,135 @@
+/**
+ * External dependencies
+ */
+import type {
+	StatsNormalizedReport,
+	StatsPeriod,
+	StatsTimeSeriesReport,
+	StatsVideoPlaysItem,
+} from '@jetpack-premium-analytics/data';
+
+type VideoChartPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
+
+/**
+ * Map a daily bucket date onto its chart bucket key for the selected period —
+ * the date itself for days, the start of the ISO week for weeks, and the
+ * `YYYY-MM` month prefix for months.
+ *
+ * @param date   - The daily bucket date (`YYYY-MM-DD`).
+ * @param period - The chart bucket period.
+ * @return The bucket key the date aggregates into.
+ */
+function getChartBucketKey( date: string, period: VideoChartPeriod ): string {
+	if ( period === 'day' ) {
+		return date;
+	}
+
+	const bucketDate = new Date( `${ date.slice( 0, 10 ) }T00:00:00Z` );
+
+	if ( period === 'week' ) {
+		const daysSinceMonday = ( bucketDate.getUTCDay() + 6 ) % 7;
+		bucketDate.setUTCDate( bucketDate.getUTCDate() - daysSinceMonday );
+	} else {
+		bucketDate.setUTCDate( 1 );
+	}
+
+	return bucketDate.toISOString().slice( 0, 10 );
+}
+
+/**
+ * Resolve the stable identity shared by a video across report buckets.
+ *
+ * @param video - The normalized video row.
+ * @return The video's stable row key.
+ */
+export function getVideoRowId( video: StatsVideoPlaysItem ): string {
+	if ( video.id != null ) {
+		return String( video.id );
+	}
+
+	return video.link || String( video.label ?? '' );
+}
+
+/**
+ * Build the chart's plays-per-bucket time series from daily video data.
+ *
+ * The endpoint's documented `num` query form returns genuine daily buckets.
+ * Keeping that request fixed at `period=day` preserves the exact selected
+ * range; week and month chart intervals are derived from those daily points
+ * without changing the records that feed the table.
+ *
+ * @param report - The bucketed video-plays report.
+ * @param period - The chart bucket period.
+ * @return The chart-ready time series.
+ */
+export function videosToTimeSeries(
+	report: StatsNormalizedReport< StatsVideoPlaysItem > | undefined,
+	period: VideoChartPeriod = 'day'
+): StatsTimeSeriesReport {
+	const buckets = new Map< string, StatsTimeSeriesReport[ 'data' ][ number ] >();
+
+	for ( const point of report?.data ?? [] ) {
+		const plays = point.items.reduce( ( total, item ) => total + item.plays, 0 );
+		const key = getChartBucketKey( point.time_interval, period );
+		const existing = buckets.get( key );
+
+		if ( existing ) {
+			existing.date_end = point.date_end;
+			existing.value = Number( existing.value ) + plays;
+			existing.plays = Number( existing.plays ) + plays;
+			continue;
+		}
+
+		buckets.set( key, {
+			time_interval: key,
+			date_start: point.date_start,
+			date_end: point.date_end,
+			label: key,
+			items: [],
+			value: plays,
+			plays,
+		} );
+	}
+
+	const data = [ ...buckets.values() ];
+	const first = data[ 0 ];
+	const last = data[ data.length - 1 ];
+
+	return {
+		summary: {
+			...report?.summary,
+			...( first ? { date_start: first.date_start } : {} ),
+			...( last ? { date_end: last.date_end } : {} ),
+		},
+		data,
+	};
+}
+
+/**
+ * Aggregate one bucketed report into one table row per video, summing the
+ * metrics returned by the video-plays payload without mutating query data.
+ *
+ * @param report - The bucketed video-plays report.
+ * @return The aggregated video rows.
+ */
+export function aggregateVideoRows(
+	report: StatsNormalizedReport< StatsVideoPlaysItem > | undefined
+): StatsVideoPlaysItem[] {
+	const byKey = new Map< string, StatsVideoPlaysItem >();
+
+	for ( const point of report?.data ?? [] ) {
+		for ( const item of point.items ) {
+			const key = getVideoRowId( item );
+			const existing = byKey.get( key );
+
+			if ( existing ) {
+				existing.plays += item.plays;
+				existing.impressions += item.impressions;
+			} else {
+				byKey.set( key, { ...item } );
+			}
+		}
+	}
+
+	return [ ...byKey.values() ];
+}

--- a/projects/packages/premium-analytics/routes/reports/videos/config/fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/videos/config/fields.test.tsx
@@ -1,0 +1,63 @@
+import { render, screen } from '@testing-library/react';
+import { getVideosFields } from './fields';
+import type { StatsVideoPlaysItem } from '@jetpack-premium-analytics/data';
+
+const video: StatsVideoPlaysItem = {
+	id: 12,
+	label: 'Launch video',
+	plays: 11,
+	impressions: 42,
+	watch_time: 128.5,
+	retention_rate: 61.25,
+	link: 'https://example.com/video/',
+	children: null,
+};
+
+/**
+ * Render the videos table's title field for one row.
+ *
+ * @param item - The video row to render.
+ * @return The RTL render result.
+ */
+function renderTitleField( item: StatsVideoPlaysItem ) {
+	const field = getVideosFields().find( candidate => candidate.id === 'title' );
+	// eslint-disable-next-line testing-library/render-result-naming-convention -- `render` here is the DataViews field render component, not RTL's render result.
+	const TitleField = field?.render;
+
+	if ( ! field || ! TitleField ) {
+		throw new Error( 'Videos title field render callback is unavailable' );
+	}
+
+	return render( <TitleField item={ item } field={ field as never } /> );
+}
+
+describe( 'videos fields', () => {
+	it( 'links a video title to the payload URL', () => {
+		renderTitleField( video );
+
+		const link = screen.getByRole( 'link', { name: 'Launch video' } );
+		expect( link ).toHaveAttribute( 'href', 'https://example.com/video/' );
+		expect( link ).toHaveAttribute( 'target', '_blank' );
+		expect( link ).toHaveAttribute( 'rel', 'noopener noreferrer' );
+	} );
+
+	it( 'renders plain text when the payload has no URL', () => {
+		renderTitleField( { ...video, link: null } );
+
+		expect( screen.getByText( 'Launch video' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'exposes searchable title and sortable metric fields', () => {
+		const fields = getVideosFields();
+
+		expect( fields.map( field => field.id ) ).toEqual( [ 'title', 'plays', 'impressions' ] );
+		expect( fields.find( field => field.id === 'title' )?.enableGlobalSearch ).toBe( true );
+		expect( fields.find( field => field.id === 'plays' )?.getValue?.( { item: video } ) ).toBe(
+			11
+		);
+		expect(
+			fields.find( field => field.id === 'impressions' )?.getValue?.( { item: video } )
+		).toBe( 42 );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/reports/videos/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/videos/config/fields.tsx
@@ -1,0 +1,49 @@
+/**
+ * External dependencies
+ */
+import { getVideoLabel } from '@jetpack-premium-analytics/widgets-toolkit';
+import { __ } from '@wordpress/i18n';
+import type { StatsVideoPlaysItem } from '@jetpack-premium-analytics/data';
+import type { Field } from '@wordpress/dataviews';
+
+/**
+ * DataViews field config for the Videos records table.
+ *
+ * @return The field config.
+ */
+export function getVideosFields(): Field< StatsVideoPlaysItem >[] {
+	return [
+		{
+			id: 'title',
+			label: __( 'Video', 'jetpack-premium-analytics' ),
+			enableGlobalSearch: true,
+			enableHiding: false,
+			getValue: ( { item } ) => getVideoLabel( item ),
+			render: ( { item } ) => {
+				const title = getVideoLabel( item );
+
+				if ( ! item.link ) {
+					return <>{ title }</>;
+				}
+
+				return (
+					<a href={ item.link } target="_blank" rel="noopener noreferrer">
+						{ title }
+					</a>
+				);
+			},
+		},
+		{
+			id: 'plays',
+			label: __( 'Plays', 'jetpack-premium-analytics' ),
+			getValue: ( { item } ) => item.plays,
+			render: ( { item } ) => <>{ item.plays.toLocaleString() }</>,
+		},
+		{
+			id: 'impressions',
+			label: __( 'Impressions', 'jetpack-premium-analytics' ),
+			getValue: ( { item } ) => item.impressions,
+			render: ( { item } ) => <>{ item.impressions.toLocaleString() }</>,
+		},
+	];
+}

--- a/projects/packages/premium-analytics/routes/reports/videos/config/index.ts
+++ b/projects/packages/premium-analytics/routes/reports/videos/config/index.ts
@@ -1,0 +1,3 @@
+export { aggregateVideoRows, getVideoRowId, videosToTimeSeries } from './aggregate';
+export { getVideosFields } from './fields';
+export { useVideosReportRecords } from './use-report-records';

--- a/projects/packages/premium-analytics/routes/reports/videos/config/use-report-records.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/videos/config/use-report-records.test.ts
@@ -108,7 +108,11 @@ describe( 'useVideosReportRecords', () => {
 			complete_stats: 1,
 		} );
 		expect( result.current.chart.primary.data ).toEqual( [
-			expect.objectContaining( { time_interval: '2026-07-06', plays: 13 } ),
+			expect.objectContaining( {
+				time_interval: '2026-07-06',
+				date_start: '2026-07-06T00:00:00+00:00',
+				plays: 13,
+			} ),
 		] );
 		expect( result.current.rows ).toEqual( [
 			expect.objectContaining( { id: 441, plays: 13, impressions: 22 } ),

--- a/projects/packages/premium-analytics/routes/reports/videos/config/use-report-records.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/videos/config/use-report-records.test.ts
@@ -77,10 +77,41 @@ describe( 'useVideosReportRecords', () => {
 			max: 0,
 			summarize: 0,
 			period: 'day',
+			complete_stats: 1,
 		} );
 		expect( result.current.rows ).toEqual( [
 			expect.objectContaining( { id: 441, plays: 13, impressions: 22 } ),
 		] );
 		expect( result.current.chart.primary.data.map( point => point.plays ) ).toEqual( [ 7, 6 ] );
+	} );
+
+	it( 'keeps the request day-bucketed while grouping the chart by week', () => {
+		mockUseStatsVideoPlays.mockReturnValue( {
+			primary: { data: report },
+			comparison: { data: undefined },
+			hasComparison: false,
+			isLoading: false,
+		} as ReturnType< typeof useStatsVideoPlays > );
+		const params: ReportParams = {
+			from: '2026-07-09',
+			to: '2026-07-10',
+			interval: 'day',
+		};
+
+		const { result } = renderHook( () => useVideosReportRecords( params, 'week' ) );
+
+		expect( mockUseStatsVideoPlays ).toHaveBeenCalledWith( {
+			...params,
+			max: 0,
+			summarize: 0,
+			period: 'day',
+			complete_stats: 1,
+		} );
+		expect( result.current.chart.primary.data ).toEqual( [
+			expect.objectContaining( { time_interval: '2026-07-06', plays: 13 } ),
+		] );
+		expect( result.current.rows ).toEqual( [
+			expect.objectContaining( { id: 441, plays: 13, impressions: 22 } ),
+		] );
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/reports/videos/config/use-report-records.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/videos/config/use-report-records.test.ts
@@ -1,0 +1,84 @@
+import { useStatsVideoPlays } from '@jetpack-premium-analytics/data';
+import { renderHook } from '@testing-library/react';
+import { useVideosReportRecords } from './use-report-records';
+import type {
+	ReportParams,
+	StatsNormalizedReport,
+	StatsVideoPlaysItem,
+} from '@jetpack-premium-analytics/data';
+
+jest.mock( '@jetpack-premium-analytics/data', () => ( {
+	...jest.requireActual( '@jetpack-premium-analytics/data' ),
+	useStatsVideoPlays: jest.fn(),
+} ) );
+
+const mockUseStatsVideoPlays = useStatsVideoPlays as jest.MockedFunction< typeof useStatsVideoPlays >;
+
+const report: StatsNormalizedReport< StatsVideoPlaysItem > = {
+	summary: {},
+	data: [
+		{
+			time_interval: '2026-07-09',
+			date_start: '2026-07-09T00:00:00+00:00',
+			date_end: '2026-07-09T23:59:59+00:00',
+			items: [
+				{
+					id: 441,
+					label: 'Demo',
+					plays: 7,
+					impressions: 10,
+					watch_time: 0,
+					retention_rate: 0,
+					link: null,
+					children: null,
+				},
+			],
+		},
+		{
+			time_interval: '2026-07-10',
+			date_start: '2026-07-10T00:00:00+00:00',
+			date_end: '2026-07-10T23:59:59+00:00',
+			items: [
+				{
+					id: 441,
+					label: 'Demo',
+					plays: 6,
+					impressions: 12,
+					watch_time: 0,
+					retention_rate: 0,
+					link: null,
+					children: null,
+				},
+			],
+		},
+	],
+};
+
+describe( 'useVideosReportRecords', () => {
+	it( 'derives table and chart data from the shared bucketed video hook', () => {
+		mockUseStatsVideoPlays.mockReturnValue( {
+			primary: { data: report },
+			comparison: { data: undefined },
+			hasComparison: false,
+			isLoading: false,
+		} as ReturnType< typeof useStatsVideoPlays > );
+		const params: ReportParams = {
+			from: '2026-07-09',
+			to: '2026-07-10',
+			interval: 'day',
+		};
+
+		const { result } = renderHook( () => useVideosReportRecords( params, 'day' ) );
+
+		expect( mockUseStatsVideoPlays ).toHaveBeenCalledWith( {
+			...params,
+			max: 0,
+			summarize: 0,
+			period: 'day',
+		} );
+		expect( result.current.rows ).toEqual( [
+			expect.objectContaining( { id: 441, plays: 13, impressions: 22 } ),
+		] );
+		expect( result.current.chart.primary.data.map( point => point.plays ) ).toEqual( [ 7, 6 ] );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/reports/videos/config/use-report-records.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/videos/config/use-report-records.test.ts
@@ -12,7 +12,9 @@ jest.mock( '@jetpack-premium-analytics/data', () => ( {
 	useStatsVideoPlays: jest.fn(),
 } ) );
 
-const mockUseStatsVideoPlays = useStatsVideoPlays as jest.MockedFunction< typeof useStatsVideoPlays >;
+const mockUseStatsVideoPlays = useStatsVideoPlays as jest.MockedFunction<
+	typeof useStatsVideoPlays
+>;
 
 const report: StatsNormalizedReport< StatsVideoPlaysItem > = {
 	summary: {},

--- a/projects/packages/premium-analytics/routes/reports/videos/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/videos/config/use-report-records.ts
@@ -30,9 +30,10 @@ export function useVideosReportRecords(
 			...reportParams,
 			max: 0,
 			summarize: 0,
-			period: chartPeriod,
+			period: 'day',
+			complete_stats: 1,
 		} ),
-		[ reportParams, chartPeriod ]
+		[ reportParams ]
 	);
 	const videos = useStatsVideoPlays( recordsParams );
 	const primaryData = videos.primary.data;

--- a/projects/packages/premium-analytics/routes/reports/videos/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/videos/config/use-report-records.ts
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import {
+	useStatsVideoPlays,
+	type ReportParams,
+	type StatsPeriod,
+} from '@jetpack-premium-analytics/data';
+import { useMemo } from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import { aggregateVideoRows, videosToTimeSeries } from './aggregate';
+
+type VideoChartPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
+
+/**
+ * Fetch and derive the Videos report chart and table from one bucketed query.
+ *
+ * @param reportParams - The shared report-window parameters.
+ * @param chartPeriod  - The chart's bucket period.
+ * @return Chart data and table records.
+ */
+export function useVideosReportRecords(
+	reportParams: ReportParams,
+	chartPeriod: VideoChartPeriod
+) {
+	const recordsParams = useMemo(
+		() => ( {
+			...reportParams,
+			max: 0,
+			summarize: 0,
+			period: chartPeriod,
+		} ),
+		[ reportParams, chartPeriod ]
+	);
+	const videos = useStatsVideoPlays( recordsParams );
+	const primaryData = videos.primary.data;
+	const comparisonData = videos.comparison.data;
+
+	const chartPrimary = useMemo(
+		() => videosToTimeSeries( primaryData, chartPeriod ),
+		[ primaryData, chartPeriod ]
+	);
+	const chartComparison = useMemo( () => {
+		if ( ! videos.hasComparison ) {
+			return undefined;
+		}
+
+		return videosToTimeSeries( comparisonData, chartPeriod );
+	}, [ videos.hasComparison, comparisonData, chartPeriod ] );
+	const rows = useMemo( () => aggregateVideoRows( primaryData ), [ primaryData ] );
+
+	return {
+		chart: {
+			primary: chartPrimary,
+			comparison: chartComparison,
+			isLoading: videos.isLoading,
+		},
+		rows,
+		isLoading: videos.isLoading,
+	};
+}

--- a/projects/packages/premium-analytics/routes/reports/videos/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/videos/config/use-report-records.ts
@@ -4,15 +4,13 @@
 import {
 	useStatsVideoPlays,
 	type ReportParams,
-	type StatsPeriod,
+	type StatsChartBucketPeriod,
 } from '@jetpack-premium-analytics/data';
 import { useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
 import { aggregateVideoRows, videosToTimeSeries } from './aggregate';
-
-type VideoChartPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
 
 /**
  * Fetch and derive the Videos report chart and table from one bucketed query.
@@ -23,7 +21,7 @@ type VideoChartPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
  */
 export function useVideosReportRecords(
 	reportParams: ReportParams,
-	chartPeriod: VideoChartPeriod
+	chartPeriod: StatsChartBucketPeriod
 ) {
 	const recordsParams = useMemo(
 		() => ( {

--- a/projects/packages/premium-analytics/routes/reports/videos/page.module.css
+++ b/projects/packages/premium-analytics/routes/reports/videos/page.module.css
@@ -1,0 +1,22 @@
+.page {
+	min-block-size: 0;
+}
+
+.content {
+	flex: 1 1 auto;
+	min-block-size: 0;
+	overflow-y: auto;
+
+	/*
+	 * Mirror the top padding of Page's own `hasPadding` content so the filters
+	 * row doesn't hug the header border — tabbed reports skip this because the
+	 * tab strip is designed to sit flush under the header.
+	 */
+	padding-block-start: var(--wpds-dimension-padding-lg, 16px);
+	padding-block-end: 24px;
+	padding-inline: var(--wpds-dimension-padding-2xl, 24px);
+}
+
+.dateFilters {
+	inline-size: 100%;
+}

--- a/projects/packages/premium-analytics/routes/reports/videos/page.module.css
+++ b/projects/packages/premium-analytics/routes/reports/videos/page.module.css
@@ -12,9 +12,9 @@
 	 * row doesn't hug the header border — tabbed reports skip this because the
 	 * tab strip is designed to sit flush under the header.
 	 */
-	padding-block-start: var(--wpds-dimension-padding-lg, 16px);
+	padding-block-start: var(--wpds-dimension-padding-lg);
 	padding-block-end: 24px;
-	padding-inline: var(--wpds-dimension-padding-2xl, 24px);
+	padding-inline: var(--wpds-dimension-padding-2xl);
 }
 
 .dateFilters {

--- a/projects/packages/premium-analytics/routes/reports/videos/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/videos/page.tsx
@@ -4,7 +4,7 @@
 import {
 	normalizeReportParams,
 	type IntervalType,
-	type StatsPeriod,
+	type StatsChartBucketPeriod,
 	type StatsVideoPlaysItem,
 } from '@jetpack-premium-analytics/data';
 import { useDashboardLink, useReportDateFilters } from '@jetpack-premium-analytics/routing';
@@ -28,7 +28,11 @@ import styles from './page.module.css';
 
 const ROUTE_FROM = route.path;
 const REPORT_PARAMS = { report: 'videos' };
-const CHART_PERIODS = [ 'day', 'week', 'month' ] as const satisfies readonly StatsPeriod[];
+const CHART_PERIODS = [
+	'day',
+	'week',
+	'month',
+] as const satisfies readonly StatsChartBucketPeriod[];
 type ChartPeriod = ( typeof CHART_PERIODS )[ number ];
 
 /**

--- a/projects/packages/premium-analytics/routes/reports/videos/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/videos/page.tsx
@@ -1,0 +1,170 @@
+/**
+ * External dependencies
+ */
+import {
+	normalizeReportParams,
+	type IntervalType,
+	type StatsPeriod,
+	type StatsVideoPlaysItem,
+} from '@jetpack-premium-analytics/data';
+import { useDashboardLink, useReportDateFilters } from '@jetpack-premium-analytics/routing';
+import { DateFiltersPanel } from '@jetpack-premium-analytics/ui';
+import {
+	formatLegendLabels,
+	ReportPageLayout,
+	ReportPerformanceChart,
+	ReportRecordsTable,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { Breadcrumbs, Page } from '@wordpress/admin-ui';
+import { useCallback, useMemo, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useNavigate, useSearch } from '@wordpress/route';
+/**
+ * Internal dependencies
+ */
+import { route } from '../package.json';
+import { getVideoRowId, getVideosFields, useVideosReportRecords } from './config';
+import styles from './page.module.css';
+
+const ROUTE_FROM = route.path;
+const REPORT_PARAMS = { report: 'videos' };
+const CHART_PERIODS = [ 'day', 'week', 'month' ] as const satisfies readonly StatsPeriod[];
+type ChartPeriod = ( typeof CHART_PERIODS )[ number ];
+
+/**
+ * Whether a value is one of the chart bucket periods this report offers.
+ *
+ * @param value - The candidate value (e.g. from the URL search).
+ * @return Whether the value is a chart period.
+ */
+function isChartPeriod( value: unknown ): value is ChartPeriod {
+	return CHART_PERIODS.includes( value as ChartPeriod );
+}
+
+/**
+ * Choose the chart bucket period for a report interval.
+ *
+ * @param interval - The report date interval.
+ * @return The default chart bucket period.
+ */
+function getDefaultChartPeriod( interval?: IntervalType ): ChartPeriod {
+	if ( interval === 'week' ) {
+		return 'week';
+	}
+
+	if ( interval === 'month' || interval === 'quarter' || interval === 'year' ) {
+		return 'month';
+	}
+
+	return 'day';
+}
+
+const RECORDS_VIEW = {
+	sort: { field: 'plays', direction: 'desc' as const },
+	layout: {
+		styles: {
+			title: { width: '100%' },
+			plays: { align: 'end' as const },
+			impressions: { align: 'end' as const },
+		},
+	},
+};
+
+/**
+ * Premium Analytics Videos report page.
+ *
+ * @return The Videos report page.
+ */
+function VideosReport(): JSX.Element {
+	const search = useSearch( { from: ROUTE_FROM } ) as Record< string, string | undefined >;
+	const reportParams = useMemo(
+		() => normalizeReportParams( search as Parameters< typeof normalizeReportParams >[ 0 ] ),
+		[ search ]
+	);
+	const chartPeriod = isChartPeriod( search.period )
+		? search.period
+		: getDefaultChartPeriod( reportParams.interval );
+	const records = useVideosReportRecords( reportParams, chartPeriod );
+	const fields = useMemo( () => getVideosFields(), [] );
+	const chartMetrics = useMemo(
+		() => [ { key: 'plays', label: __( 'Plays', 'jetpack-premium-analytics' ) } ],
+		[]
+	);
+	const chartLegendLabels = useMemo( () => formatLegendLabels( reportParams ), [ reportParams ] );
+
+	const navigate = useNavigate();
+	const handleIntervalChange = useCallback(
+		( interval: IntervalType ) => {
+			const period = isChartPeriod( interval ) ? interval : getDefaultChartPeriod( interval );
+			navigate( {
+				to: ROUTE_FROM,
+				params: REPORT_PARAMS as unknown as never,
+				replace: true,
+				search: ( ( current: Record< string, unknown > ) => ( {
+					...current,
+					period,
+				} ) ) as unknown as never,
+			} );
+		},
+		[ navigate ]
+	);
+
+	const dateFilters = useReportDateFilters( ROUTE_FROM );
+	const dashboardLink = useDashboardLink();
+	const [ containerElement, setContainerElement ] = useState< HTMLDivElement | null >( null );
+
+	return (
+		<Page
+			breadcrumbs={
+				<Breadcrumbs
+					items={ [
+						{
+							label: __( 'Stats', 'jetpack-premium-analytics' ),
+							to: dashboardLink,
+						},
+						{ label: __( 'Videos', 'jetpack-premium-analytics' ) },
+					] }
+				/>
+			}
+			subTitle={ __( 'See how your videos perform.', 'jetpack-premium-analytics' ) }
+			className={ styles.page }
+		>
+			<div className={ styles.content }>
+				<ReportPageLayout
+					filters={
+						<div ref={ setContainerElement } className={ styles.dateFilters }>
+							<DateFiltersPanel { ...dateFilters } containerElement={ containerElement } />
+						</div>
+					}
+				>
+					<ReportPerformanceChart
+						primary={ records.chart.primary }
+						comparison={ records.chart.comparison }
+						isLoading={ records.chart.isLoading }
+						metrics={ chartMetrics }
+						interval={ chartPeriod }
+						onIntervalChange={ handleIntervalChange }
+						legendLabels={ chartLegendLabels }
+					/>
+					<ReportRecordsTable< StatsVideoPlaysItem >
+						data={ records.rows }
+						fields={ fields }
+						getItemId={ getVideoRowId }
+						isLoading={ records.isLoading }
+						initialView={ RECORDS_VIEW }
+						searchLabel={ __( 'Search videos', 'jetpack-premium-analytics' ) }
+					/>
+				</ReportPageLayout>
+			</div>
+		</Page>
+	);
+}
+
+/**
+ * Videos report page (default export for the report registry).
+ *
+ * @return The Videos report page.
+ */
+export default function VideosReportPage(): JSX.Element {
+	return <VideosReport />;
+}

--- a/projects/packages/premium-analytics/widgets/videopress/__tests__/videopress.test.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/__tests__/videopress.test.tsx
@@ -4,17 +4,43 @@
 import { GlobalErrorProvider, queryClient } from '@jetpack-premium-analytics/data';
 import { render, screen } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
+import type { AnchorHTMLAttributes, ReactElement, ReactNode } from 'react';
 /**
  * Internal dependencies
  */
 import VideoPressWidget from '../render';
-import type { ReactElement } from 'react';
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+type MockRouteLinkProps = {
+	to: string;
+	params?: Record< string, unknown >;
+	search?: Record< string, unknown >;
+	children: ReactNode;
+} & Omit< AnchorHTMLAttributes< HTMLAnchorElement >, 'href' >;
 
 // WidgetRoot reads URL search params as a fallback for report params; outside
 // a matched route the real hook warns and throws.
 jest.mock( '@wordpress/route', () => ( {
+	Link: ( { to, params, search, children, ...props }: MockRouteLinkProps ) => {
+		const path = Object.entries( params ?? {} ).reduce(
+			( acc, [ key, value ] ) => acc.replace( `$${ key }`, String( value ) ),
+			to
+		);
+		const query = new URLSearchParams();
+		Object.entries( search ?? {} ).forEach( ( [ key, value ] ) => {
+			if ( value !== undefined && value !== null ) {
+				query.set( key, String( value ) );
+			}
+		} );
+		const queryString = query.toString();
+
+		return (
+			<a href={ queryString ? `${ path }?${ queryString }` : path } { ...props }>
+				{ children }
+			</a>
+		);
+	},
 	useSearch: () => ( {} ),
 } ) );
 
@@ -90,6 +116,17 @@ describe( 'VideoPressWidget', () => {
 		expect( requestedPath ).toContain( 'start_date=2026-03-01' );
 		expect( requestedPath ).toContain( 'date=2026-03-10' );
 		expect( requestedPath ).toContain( 'days=10' );
+	} );
+
+	it( 'links to the Videos report', () => {
+		renderInDashboard(
+			<VideoPressWidget attributes={ { reportParams: { from: '2026-03-01', to: '2026-03-10' } } } />
+		);
+
+		expect( screen.getByRole( 'link', { name: 'See report' } ) ).toHaveAttribute(
+			'href',
+			expect.stringContaining( '/reports/videos' )
+		);
 	} );
 
 	it( 'shows the empty state when the period has no video plays', async () => {

--- a/projects/packages/premium-analytics/widgets/videopress/render.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/render.tsx
@@ -4,6 +4,8 @@
 import { useStatsVideoPlays } from '@jetpack-premium-analytics/data';
 import {
 	LeaderboardChart,
+	ReportLink,
+	WidgetFooter,
 	WidgetRoot,
 	WidgetState,
 	calculateDelta,
@@ -167,6 +169,9 @@ export default function VideoPress( { attributes = {}, setError }: VideoPressWid
 	return (
 		<WidgetRoot attributes={ attributes } setError={ setError }>
 			<VideoPressReport max={ toMaxRows( attributes.max, DEFAULT_MAX ) } />
+			<WidgetFooter>
+				<ReportLink report="videos" />
+			</WidgetFooter>
 		</WidgetRoot>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/videopress/stories/videopress-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/stories/videopress-widget.stories.tsx
@@ -15,6 +15,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withStoryRouter } from '../../stories/with-story-router';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import VideoPressRender from '../render';
 import widgetDefinition, { DEFAULT_MAX } from '../widget';
@@ -86,7 +87,7 @@ type Story = StoryObj< VideoPressStoryControls >;
 export const Default: Story = {
 	render: renderVideoPress,
 	args: { withComparison: false },
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 };
 
 /**
@@ -96,7 +97,7 @@ export const Default: Story = {
 export const WithComparison: Story = {
 	render: renderVideoPress,
 	args: { withComparison: true },
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 };
 
 /**
@@ -107,7 +108,7 @@ export const Loading: Story = {
 	render: () => renderVideoPressOnPreset( 'last-90-days' ),
 	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 	beforeEach: () => {
 		setReportMockState( 'stats/video-plays', 'loading' );
 		return () => setReportMockState( 'stats/video-plays', null );
@@ -121,7 +122,7 @@ export const Loading: Story = {
 export const Error: Story = {
 	render: () => renderVideoPressOnPreset( 'last-7-days' ),
 	tags: [ '!autodocs' ],
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 	beforeEach: () => {
 		setReportMockState( 'stats/video-plays', 'error' );
 		return () => setReportMockState( 'stats/video-plays', null );
@@ -135,7 +136,7 @@ export const Error: Story = {
 export const Empty: Story = {
 	render: () => renderVideoPressOnPreset( 'last-365-days' ),
 	tags: [ '!autodocs' ],
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 	beforeEach: () => {
 		setReportMockState( 'stats/video-plays', 'empty' );
 		return () => setReportMockState( 'stats/video-plays', null );


### PR DESCRIPTION
Part of [WOOA7S-1702](https://linear.app/a8c/issue/WOOA7S-1702)

<img width="1836" height="1976" alt="Google Chrome -2026-07-14 at 12 08 51@2x" src="https://github.com/user-attachments/assets/2049e217-e0d7-4035-bfdd-829fdfa0ee30" />


## Proposed changes

* Adds the Videos report at `/reports/videos` on the reports framework from #50305: a `routes/reports/videos/` page module (performance chart + records table, `config/aggregate.ts` with tests) and one `REPORTS` registry entry.
* Adds a bucketed video-plays data path to the data package — `useStatsVideoPlaysBuckets` hook, `stats-video-plays-buckets-query`, and a bucketed `video-plays` normalizer — so the chart can plot plays per day/week/month.
* The VideoPress widget footer links to the report via the shared `WidgetFooter`/`ReportLink`, carrying the dashboard's current date range and comparison.

<!-- screenshot: add a capture of the /reports/videos page -->

## Related product discussion/links

* [WOOA7S-1702](https://linear.app/a8c/issue/WOOA7S-1702)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `cd projects/packages/premium-analytics && pnpm run build`, open the Premium Analytics dashboard on a site with VideoPress videos that have plays.
* In the VideoPress widget, click **View all** — you should land on `/reports/videos` with the dashboard's date range and comparison intact.
* On the chart: change the time bucket (day/week/month) and collapse/expand it — plays should re-bucket accordingly.
* On the table: search, sort, and page through — all client-side, no new requests.
* Change the date range from the page's date filter — chart and table should update together, and reloading the URL should restore the exact view.
