### PR TITLE
WOOA7S-1703: Premium Analytics: add the File downloads report at /reports/downloads

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-wooa7s-1703-downloads-report-page
+++ b/projects/packages/premium-analytics/changelog/add-wooa7s-1703-downloads-report-page
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Stats: Add the File downloads report at `/reports/downloads`.

--- a/projects/packages/premium-analytics/routes/reports/downloads/config/aggregate.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/downloads/config/aggregate.test.ts
@@ -62,6 +62,32 @@ describe( 'downloads report aggregate', () => {
 		expect( series.data.map( point => point.downloads ) ).toEqual( [ 4, 9 ] );
 	} );
 
+	it( 'groups daily totals into ISO weeks for the chart', () => {
+		const series = downloadsToTimeSeries( report, 'week' );
+
+		expect( series.data ).toEqual( [
+			expect.objectContaining( {
+				time_interval: '2026-06-01',
+				date_start: '2026-06-01T00:00:00+00:00',
+				date_end: '2026-06-02T23:59:59+00:00',
+				downloads: 13,
+			} ),
+		] );
+	} );
+
+	it( 'groups daily totals into calendar months for the chart', () => {
+		const series = downloadsToTimeSeries( report, 'month' );
+
+		expect( series.data ).toEqual( [
+			expect.objectContaining( {
+				time_interval: '2026-06-01',
+				date_start: '2026-06-01T00:00:00+00:00',
+				date_end: '2026-06-02T23:59:59+00:00',
+				downloads: 13,
+			} ),
+		] );
+	} );
+
 	it( 'aggregates matching files across buckets without mutating the report', () => {
 		const rows = aggregateDownloadRows( report );
 

--- a/projects/packages/premium-analytics/routes/reports/downloads/config/aggregate.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/downloads/config/aggregate.test.ts
@@ -1,0 +1,74 @@
+import { aggregateDownloadRows, downloadsToTimeSeries } from './aggregate';
+import type {
+	StatsFileDownloadsItem,
+	StatsNormalizedReport,
+} from '@jetpack-premium-analytics/data';
+
+const report: StatsNormalizedReport< StatsFileDownloadsItem > = {
+	summary: {},
+	data: [
+		{
+			time_interval: '2026-06-01',
+			date_start: '2026-06-01T00:00:00+00:00',
+			date_end: '2026-06-01T23:59:59+00:00',
+			items: [
+				{
+					label: '/files/report.pdf',
+					shortLabel: 'report.pdf',
+					link: 'https://example.com/files/report.pdf',
+					downloads: 4,
+					linkTitle: '/files/report.pdf',
+					labelIcon: 'external',
+					children: null,
+				},
+			],
+		},
+		{
+			time_interval: '2026-06-02',
+			date_start: '2026-06-02T00:00:00+00:00',
+			date_end: '2026-06-02T23:59:59+00:00',
+			items: [
+				{
+					label: '/files/report.pdf',
+					shortLabel: 'report.pdf',
+					link: 'https://example.com/files/report.pdf',
+					downloads: 6,
+					linkTitle: '/files/report.pdf',
+					labelIcon: 'external',
+					children: null,
+				},
+				{
+					label: '/files/guide.zip',
+					shortLabel: 'guide.zip',
+					link: 'https://example.com/files/guide.zip',
+					downloads: 3,
+					linkTitle: '/files/guide.zip',
+					labelIcon: 'external',
+					children: null,
+				},
+			],
+		},
+	],
+};
+
+describe( 'downloads report aggregate', () => {
+	it( 'builds the downloads time series from every bucket row', () => {
+		const series = downloadsToTimeSeries( report );
+
+		expect( series.summary ).toEqual( {
+			date_start: '2026-06-01T00:00:00+00:00',
+			date_end: '2026-06-02T23:59:59+00:00',
+		} );
+		expect( series.data.map( point => point.downloads ) ).toEqual( [ 4, 9 ] );
+	} );
+
+	it( 'aggregates matching files across buckets without mutating the report', () => {
+		const rows = aggregateDownloadRows( report );
+
+		expect( rows.map( row => ( { label: row.shortLabel, downloads: row.downloads } ) ) ).toEqual( [
+			{ label: 'report.pdf', downloads: 10 },
+			{ label: 'guide.zip', downloads: 3 },
+		] );
+		expect( report.data[ 0 ].items[ 0 ].downloads ).toBe( 4 );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/reports/downloads/config/aggregate.ts
+++ b/projects/packages/premium-analytics/routes/reports/downloads/config/aggregate.ts
@@ -1,0 +1,81 @@
+/**
+ * Internal dependencies
+ */
+import type {
+	StatsFileDownloadsItem,
+	StatsNormalizedReport,
+	StatsTimeSeriesReport,
+} from '@jetpack-premium-analytics/data';
+
+/**
+ * Stable identity for a file-download row across report buckets.
+ *
+ * @param item - A normalized file-download item.
+ * @return The row identity.
+ */
+function getFileKey( item: StatsFileDownloadsItem ): string {
+	return item.link ?? String( item.label ?? item.shortLabel ?? '' );
+}
+
+/**
+ * Convert a bucketed file-downloads report into downloads per interval.
+ *
+ * @param report - The bucketed file-downloads report.
+ * @return The chart-ready time series.
+ */
+export function downloadsToTimeSeries(
+	report: StatsNormalizedReport< StatsFileDownloadsItem > | undefined
+): StatsTimeSeriesReport {
+	const data = ( report?.data ?? [] ).map( point => {
+		const downloads = point.items.reduce( ( total, item ) => total + item.downloads, 0 );
+
+		return {
+			time_interval: point.time_interval,
+			date_start: point.date_start,
+			date_end: point.date_end,
+			label: point.time_interval,
+			items: [],
+			value: downloads,
+			downloads,
+		};
+	} );
+	const first = data[ 0 ];
+	const last = data[ data.length - 1 ];
+
+	return {
+		summary: {
+			...report?.summary,
+			...( first ? { date_start: first.date_start } : {} ),
+			...( last ? { date_end: last.date_end } : {} ),
+		},
+		data,
+	};
+}
+
+/**
+ * Aggregate a bucketed report into one row per file, summing downloads.
+ *
+ * @param report - The bucketed file-downloads report.
+ * @return Aggregated file rows.
+ */
+export function aggregateDownloadRows(
+	report: StatsNormalizedReport< StatsFileDownloadsItem > | undefined
+): StatsFileDownloadsItem[] {
+	const byFile = new Map< string, StatsFileDownloadsItem >();
+
+	for ( const point of report?.data ?? [] ) {
+		for ( const item of point.items ) {
+			const key = getFileKey( item );
+			const existing = byFile.get( key );
+
+			if ( existing ) {
+				existing.downloads += item.downloads;
+			} else {
+				// Do not mutate normalized report data held in the query cache.
+				byFile.set( key, { ...item } );
+			}
+		}
+	}
+
+	return [ ...byFile.values() ];
+}

--- a/projects/packages/premium-analytics/routes/reports/downloads/config/aggregate.ts
+++ b/projects/packages/premium-analytics/routes/reports/downloads/config/aggregate.ts
@@ -4,8 +4,35 @@
 import type {
 	StatsFileDownloadsItem,
 	StatsNormalizedReport,
+	StatsPeriod,
 	StatsTimeSeriesReport,
 } from '@jetpack-premium-analytics/data';
+
+type DownloadChartPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
+
+/**
+ * Map a daily bucket date to its chart bucket key.
+ *
+ * @param date   - The daily bucket date.
+ * @param period - The chart bucket period.
+ * @return The chart bucket key.
+ */
+export function getChartBucketKey( date: string, period: DownloadChartPeriod ): string {
+	if ( period === 'day' ) {
+		return date;
+	}
+
+	const bucketDate = new Date( `${ date.slice( 0, 10 ) }T00:00:00Z` );
+
+	if ( period === 'week' ) {
+		const daysSinceMonday = ( bucketDate.getUTCDay() + 6 ) % 7;
+		bucketDate.setUTCDate( bucketDate.getUTCDate() - daysSinceMonday );
+	} else {
+		bucketDate.setUTCDate( 1 );
+	}
+
+	return bucketDate.toISOString().slice( 0, 10 );
+}
 
 /**
  * Stable identity for a file-download row across report buckets.
@@ -18,27 +45,47 @@ function getFileKey( item: StatsFileDownloadsItem ): string {
 }
 
 /**
- * Convert a bucketed file-downloads report into downloads per interval.
+ * Convert a daily file-downloads report into downloads per chart interval.
  *
  * @param report - The bucketed file-downloads report.
+ * @param period - The chart bucket period.
  * @return The chart-ready time series.
  */
 export function downloadsToTimeSeries(
-	report: StatsNormalizedReport< StatsFileDownloadsItem > | undefined
+	report: StatsNormalizedReport< StatsFileDownloadsItem > | undefined,
+	period: DownloadChartPeriod = 'day'
 ): StatsTimeSeriesReport {
-	const data = ( report?.data ?? [] ).map( point => {
-		const downloads = point.items.reduce( ( total, item ) => total + item.downloads, 0 );
+	const buckets = new Map< string, StatsTimeSeriesReport[ 'data' ][ number ] >();
+	const points = [ ...( report?.data ?? [] ) ].sort( ( a, b ) =>
+		a.time_interval.localeCompare( b.time_interval )
+	);
 
-		return {
-			time_interval: point.time_interval,
+	for ( const point of points ) {
+		const downloads = point.items.reduce( ( total, item ) => total + item.downloads, 0 );
+		const key = getChartBucketKey( point.time_interval, period );
+		const existing = buckets.get( key );
+
+		if ( existing ) {
+			existing.date_end = point.date_end;
+			existing.value = Number( existing.value ) + downloads;
+			existing.downloads = Number( existing.downloads ) + downloads;
+			continue;
+		}
+
+		buckets.set( key, {
+			time_interval: key,
 			date_start: point.date_start,
 			date_end: point.date_end,
-			label: point.time_interval,
+			label: key,
 			items: [],
 			value: downloads,
 			downloads,
-		};
-	} );
+		} );
+	}
+
+	const data = [ ...buckets.values() ].sort( ( a, b ) =>
+		a.time_interval.localeCompare( b.time_interval )
+	);
 	const first = data[ 0 ];
 	const last = data[ data.length - 1 ];
 

--- a/projects/packages/premium-analytics/routes/reports/downloads/config/aggregate.ts
+++ b/projects/packages/premium-analytics/routes/reports/downloads/config/aggregate.ts
@@ -1,38 +1,13 @@
 /**
- * Internal dependencies
+ * External dependencies
  */
-import type {
-	StatsFileDownloadsItem,
-	StatsNormalizedReport,
-	StatsPeriod,
-	StatsTimeSeriesReport,
+import {
+	bucketStatsTimeSeries,
+	type StatsChartBucketPeriod,
+	type StatsFileDownloadsItem,
+	type StatsNormalizedReport,
+	type StatsTimeSeriesReport,
 } from '@jetpack-premium-analytics/data';
-
-type DownloadChartPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
-
-/**
- * Map a daily bucket date to its chart bucket key.
- *
- * @param date   - The daily bucket date.
- * @param period - The chart bucket period.
- * @return The chart bucket key.
- */
-export function getChartBucketKey( date: string, period: DownloadChartPeriod ): string {
-	if ( period === 'day' ) {
-		return date;
-	}
-
-	const bucketDate = new Date( `${ date.slice( 0, 10 ) }T00:00:00Z` );
-
-	if ( period === 'week' ) {
-		const daysSinceMonday = ( bucketDate.getUTCDay() + 6 ) % 7;
-		bucketDate.setUTCDate( bucketDate.getUTCDate() - daysSinceMonday );
-	} else {
-		bucketDate.setUTCDate( 1 );
-	}
-
-	return bucketDate.toISOString().slice( 0, 10 );
-}
 
 /**
  * Stable identity for a file-download row across report buckets.
@@ -53,50 +28,13 @@ function getFileKey( item: StatsFileDownloadsItem ): string {
  */
 export function downloadsToTimeSeries(
 	report: StatsNormalizedReport< StatsFileDownloadsItem > | undefined,
-	period: DownloadChartPeriod = 'day'
+	period: StatsChartBucketPeriod = 'day'
 ): StatsTimeSeriesReport {
-	const buckets = new Map< string, StatsTimeSeriesReport[ 'data' ][ number ] >();
-	const points = [ ...( report?.data ?? [] ) ].sort( ( a, b ) =>
-		a.time_interval.localeCompare( b.time_interval )
-	);
-
-	for ( const point of points ) {
+	return bucketStatsTimeSeries( report, period, point => {
 		const downloads = point.items.reduce( ( total, item ) => total + item.downloads, 0 );
-		const key = getChartBucketKey( point.time_interval, period );
-		const existing = buckets.get( key );
 
-		if ( existing ) {
-			existing.date_end = point.date_end;
-			existing.value = Number( existing.value ) + downloads;
-			existing.downloads = Number( existing.downloads ) + downloads;
-			continue;
-		}
-
-		buckets.set( key, {
-			time_interval: key,
-			date_start: point.date_start,
-			date_end: point.date_end,
-			label: key,
-			items: [],
-			value: downloads,
-			downloads,
-		} );
-	}
-
-	const data = [ ...buckets.values() ].sort( ( a, b ) =>
-		a.time_interval.localeCompare( b.time_interval )
-	);
-	const first = data[ 0 ];
-	const last = data[ data.length - 1 ];
-
-	return {
-		summary: {
-			...report?.summary,
-			...( first ? { date_start: first.date_start } : {} ),
-			...( last ? { date_end: last.date_end } : {} ),
-		},
-		data,
-	};
+		return { value: downloads, downloads };
+	} );
 }
 
 /**

--- a/projects/packages/premium-analytics/routes/reports/downloads/config/fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/downloads/config/fields.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import { getDownloadsFields } from './fields';
+import type { StatsFileDownloadsItem } from '@jetpack-premium-analytics/data';
+
+const download: StatsFileDownloadsItem = {
+	label: '/files/report.pdf',
+	shortLabel: 'report.pdf',
+	link: 'https://example.com/files/report.pdf',
+	downloads: 1234,
+	linkTitle: '/files/report.pdf',
+	labelIcon: 'external',
+	children: null,
+};
+
+/**
+ * Render one table field for a file-download row.
+ *
+ * @param id   - Field identifier.
+ * @param item - File-download row.
+ * @return The Testing Library render result.
+ */
+function renderField( id: string, item: StatsFileDownloadsItem ) {
+	const field = getDownloadsFields().find( candidate => candidate.id === id );
+	// eslint-disable-next-line testing-library/render-result-naming-convention -- `render` is the DataViews field component.
+	const FieldComponent = field?.render;
+
+	if ( ! field || ! FieldComponent ) {
+		throw new Error( `Downloads field ${ id } is unavailable` );
+	}
+
+	return render( <FieldComponent item={ item } field={ field as never } /> );
+}
+
+describe( 'downloads fields', () => {
+	it( 'renders the filename as an external asset link', () => {
+		renderField( 'file', download );
+
+		const link = screen.getByRole( 'link', { name: 'report.pdf' } );
+		expect( link ).toHaveAttribute( 'href', 'https://example.com/files/report.pdf' );
+		expect( link ).toHaveAttribute( 'target', '_blank' );
+		expect( link ).toHaveAttribute( 'rel', 'noopener noreferrer' );
+	} );
+
+	it( 'marks the file field searchable and formats the download count', () => {
+		const fileField = getDownloadsFields().find( field => field.id === 'file' );
+		expect( fileField?.enableGlobalSearch ).toBe( true );
+
+		renderField( 'downloads', download );
+		expect(
+			screen.getByText( content => content.replace( /\D/g, '' ) === '1234' )
+		).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/reports/downloads/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/downloads/config/fields.tsx
@@ -1,0 +1,52 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import type { StatsFileDownloadsItem } from '@jetpack-premium-analytics/data';
+import type { Field } from '@wordpress/dataviews';
+
+/**
+ * The visible file label, preferring the filename supplied by the endpoint.
+ *
+ * @param item - A normalized file-download row.
+ * @return The file label.
+ */
+function getFileLabel( item: StatsFileDownloadsItem ): string {
+	return item.shortLabel ?? String( item.label ?? '' );
+}
+
+/**
+ * DataViews fields for the File downloads records table.
+ *
+ * @return The field config.
+ */
+export function getDownloadsFields(): Field< StatsFileDownloadsItem >[] {
+	return [
+		{
+			id: 'file',
+			label: __( 'File', 'jetpack-premium-analytics' ),
+			enableGlobalSearch: true,
+			enableHiding: false,
+			getValue: ( { item } ) => getFileLabel( item ),
+			render: ( { item } ) => {
+				const label = getFileLabel( item );
+
+				if ( ! item.link ) {
+					return <>{ label }</>;
+				}
+
+				return (
+					<a href={ item.link } target="_blank" rel="noopener noreferrer">
+						{ label }
+					</a>
+				);
+			},
+		},
+		{
+			id: 'downloads',
+			label: __( 'Downloads', 'jetpack-premium-analytics' ),
+			getValue: ( { item } ) => item.downloads,
+			render: ( { item } ) => <>{ item.downloads.toLocaleString() }</>,
+		},
+	];
+}

--- a/projects/packages/premium-analytics/routes/reports/downloads/config/index.ts
+++ b/projects/packages/premium-analytics/routes/reports/downloads/config/index.ts
@@ -1,0 +1,3 @@
+export { aggregateDownloadRows, downloadsToTimeSeries } from './aggregate';
+export { getDownloadsFields } from './fields';
+export { useDownloadsReportRecords } from './use-report-records';

--- a/projects/packages/premium-analytics/routes/reports/downloads/config/use-report-records.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/downloads/config/use-report-records.test.ts
@@ -1,0 +1,106 @@
+import { useStatsFileDownloads } from '@jetpack-premium-analytics/data';
+import { renderHook } from '@testing-library/react';
+import { getChartBucketKey } from './aggregate';
+import { useDownloadsReportRecords } from './use-report-records';
+import type {
+	ReportParams,
+	StatsFileDownloadsItem,
+	StatsNormalizedReport,
+} from '@jetpack-premium-analytics/data';
+
+jest.mock( '@jetpack-premium-analytics/data', () => ( {
+	...jest.requireActual( '@jetpack-premium-analytics/data' ),
+	useStatsFileDownloads: jest.fn(),
+} ) );
+
+const mockUseStatsFileDownloads = useStatsFileDownloads as jest.MockedFunction<
+	typeof useStatsFileDownloads
+>;
+
+const report: StatsNormalizedReport< StatsFileDownloadsItem > = {
+	summary: {},
+	data: [
+		{
+			time_interval: '2026-07-09',
+			date_start: '2026-07-09T00:00:00+00:00',
+			date_end: '2026-07-09T23:59:59+00:00',
+			items: [
+				{
+					label: '/files/report.pdf',
+					shortLabel: 'report.pdf',
+					link: 'https://example.com/files/report.pdf',
+					downloads: 7,
+					linkTitle: '/files/report.pdf',
+					labelIcon: 'external',
+					children: null,
+				},
+			],
+		},
+		{
+			time_interval: '2026-07-10',
+			date_start: '2026-07-10T00:00:00+00:00',
+			date_end: '2026-07-10T23:59:59+00:00',
+			items: [
+				{
+					label: '/files/report.pdf',
+					shortLabel: 'report.pdf',
+					link: 'https://example.com/files/report.pdf',
+					downloads: 6,
+					linkTitle: '/files/report.pdf',
+					labelIcon: 'external',
+					children: null,
+				},
+			],
+		},
+	],
+};
+
+const params: ReportParams = {
+	from: '2026-07-09',
+	to: '2026-07-10',
+	interval: 'day',
+};
+
+describe( 'useDownloadsReportRecords', () => {
+	beforeEach( () => {
+		mockUseStatsFileDownloads.mockReturnValue( {
+			primary: { data: report },
+			comparison: { data: undefined },
+			hasComparison: false,
+			isLoading: false,
+		} as ReturnType< typeof useStatsFileDownloads > );
+	} );
+
+	it( 'derives table and chart data from a day-bucketed request', () => {
+		const { result } = renderHook( () => useDownloadsReportRecords( params, 'day' ) );
+
+		expect( mockUseStatsFileDownloads ).toHaveBeenCalledWith( {
+			...params,
+			max: 0,
+			summarize: 0,
+			period: 'day',
+		} );
+		expect( result.current.chart.primary.data.map( point => point.downloads ) ).toEqual( [ 7, 6 ] );
+		expect( result.current.rows ).toEqual( [
+			expect.objectContaining( { shortLabel: 'report.pdf', downloads: 13 } ),
+		] );
+	} );
+
+	it( 'keeps the request day-bucketed while grouping the chart by week', () => {
+		const dayResult = renderHook( () => useDownloadsReportRecords( params, 'day' ) ).result;
+		const weekResult = renderHook( () => useDownloadsReportRecords( params, 'week' ) ).result;
+		const weekKey = getChartBucketKey( report.data[ 0 ].time_interval, 'week' );
+
+		expect( mockUseStatsFileDownloads ).toHaveBeenLastCalledWith( {
+			...params,
+			max: 0,
+			summarize: 0,
+			period: 'day',
+		} );
+		expect( weekKey ).toBe( '2026-07-06' );
+		expect( weekResult.current.chart.primary.data ).toEqual( [
+			expect.objectContaining( { time_interval: weekKey, downloads: 13 } ),
+		] );
+		expect( weekResult.current.rows ).toEqual( dayResult.current.rows );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/reports/downloads/config/use-report-records.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/downloads/config/use-report-records.test.ts
@@ -1,6 +1,5 @@
 import { useStatsFileDownloads } from '@jetpack-premium-analytics/data';
 import { renderHook } from '@testing-library/react';
-import { getChartBucketKey } from './aggregate';
 import { useDownloadsReportRecords } from './use-report-records';
 import type {
 	ReportParams,
@@ -89,7 +88,6 @@ describe( 'useDownloadsReportRecords', () => {
 	it( 'keeps the request day-bucketed while grouping the chart by week', () => {
 		const dayResult = renderHook( () => useDownloadsReportRecords( params, 'day' ) ).result;
 		const weekResult = renderHook( () => useDownloadsReportRecords( params, 'week' ) ).result;
-		const weekKey = getChartBucketKey( report.data[ 0 ].time_interval, 'week' );
 
 		expect( mockUseStatsFileDownloads ).toHaveBeenLastCalledWith( {
 			...params,
@@ -97,9 +95,17 @@ describe( 'useDownloadsReportRecords', () => {
 			summarize: 0,
 			period: 'day',
 		} );
-		expect( weekKey ).toBe( '2026-07-06' );
+		expect( weekResult.current.chart.primary.summary ).toEqual( {
+			date_start: '2026-07-09T00:00:00+00:00',
+			date_end: '2026-07-10T23:59:59+00:00',
+		} );
 		expect( weekResult.current.chart.primary.data ).toEqual( [
-			expect.objectContaining( { time_interval: weekKey, downloads: 13 } ),
+			expect.objectContaining( {
+				time_interval: '2026-07-06',
+				date_start: '2026-07-06T00:00:00+00:00',
+				date_end: '2026-07-10T23:59:59+00:00',
+				downloads: 13,
+			} ),
 		] );
 		expect( weekResult.current.rows ).toEqual( dayResult.current.rows );
 	} );

--- a/projects/packages/premium-analytics/routes/reports/downloads/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/downloads/config/use-report-records.ts
@@ -14,6 +14,8 @@ import { useMemo } from '@wordpress/element';
  */
 import { aggregateDownloadRows, downloadsToTimeSeries } from './aggregate';
 
+type DownloadChartPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
+
 /**
  * Fetch and derive chart and table data for the File downloads report.
  *
@@ -21,7 +23,10 @@ import { aggregateDownloadRows, downloadsToTimeSeries } from './aggregate';
  * @param chartPeriod  - The chart bucket period.
  * @return Chart data and aggregated file records.
  */
-export function useDownloadsReportRecords( reportParams: ReportParams, chartPeriod: StatsPeriod ) {
+export function useDownloadsReportRecords(
+	reportParams: ReportParams,
+	chartPeriod: DownloadChartPeriod
+) {
 	// One unsummarized query supplies both the interval chart and the complete
 	// client-side table. `max: 0` requests every file row.
 	const recordsParams = useMemo(
@@ -29,18 +34,21 @@ export function useDownloadsReportRecords( reportParams: ReportParams, chartPeri
 			...reportParams,
 			max: 0,
 			summarize: 0,
-			period: chartPeriod,
+			period: 'day',
 		} ),
-		[ reportParams, chartPeriod ]
+		[ reportParams ]
 	);
 	const report = useStatsFileDownloads( recordsParams );
+	const primaryData = report.primary.data;
+	const comparisonData = report.comparison.data;
 
 	const chartPrimary = useMemo(
 		() =>
 			downloadsToTimeSeries(
-				report.primary.data as StatsNormalizedReport< StatsFileDownloadsItem > | undefined
+				primaryData as StatsNormalizedReport< StatsFileDownloadsItem > | undefined,
+				chartPeriod
 			),
-		[ report.primary.data ]
+		[ primaryData, chartPeriod ]
 	);
 	const chartComparison = useMemo( () => {
 		if ( ! reportParams.compare_from || ! reportParams.compare_to ) {
@@ -48,15 +56,16 @@ export function useDownloadsReportRecords( reportParams: ReportParams, chartPeri
 		}
 
 		return downloadsToTimeSeries(
-			report.comparison.data as StatsNormalizedReport< StatsFileDownloadsItem > | undefined
+			comparisonData as StatsNormalizedReport< StatsFileDownloadsItem > | undefined,
+			chartPeriod
 		);
-	}, [ reportParams, report.comparison.data ] );
+	}, [ reportParams, comparisonData, chartPeriod ] );
 	const rows = useMemo(
 		() =>
 			aggregateDownloadRows(
-				report.primary.data as StatsNormalizedReport< StatsFileDownloadsItem > | undefined
+				primaryData as StatsNormalizedReport< StatsFileDownloadsItem > | undefined
 			),
-		[ report.primary.data ]
+		[ primaryData ]
 	);
 
 	return {

--- a/projects/packages/premium-analytics/routes/reports/downloads/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/downloads/config/use-report-records.ts
@@ -4,17 +4,15 @@
 import {
 	useStatsFileDownloads,
 	type ReportParams,
+	type StatsChartBucketPeriod,
 	type StatsFileDownloadsItem,
 	type StatsNormalizedReport,
-	type StatsPeriod,
 } from '@jetpack-premium-analytics/data';
 import { useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
 import { aggregateDownloadRows, downloadsToTimeSeries } from './aggregate';
-
-type DownloadChartPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
 
 /**
  * Fetch and derive chart and table data for the File downloads report.
@@ -25,7 +23,7 @@ type DownloadChartPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
  */
 export function useDownloadsReportRecords(
 	reportParams: ReportParams,
-	chartPeriod: DownloadChartPeriod
+	chartPeriod: StatsChartBucketPeriod
 ) {
 	// One unsummarized query supplies both the interval chart and the complete
 	// client-side table. `max: 0` requests every file row.

--- a/projects/packages/premium-analytics/routes/reports/downloads/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/downloads/config/use-report-records.ts
@@ -1,0 +1,71 @@
+/**
+ * External dependencies
+ */
+import {
+	useStatsFileDownloads,
+	type ReportParams,
+	type StatsFileDownloadsItem,
+	type StatsNormalizedReport,
+	type StatsPeriod,
+} from '@jetpack-premium-analytics/data';
+import { useMemo } from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import { aggregateDownloadRows, downloadsToTimeSeries } from './aggregate';
+
+/**
+ * Fetch and derive chart and table data for the File downloads report.
+ *
+ * @param reportParams - The shared report-window parameters.
+ * @param chartPeriod  - The chart bucket period.
+ * @return Chart data and aggregated file records.
+ */
+export function useDownloadsReportRecords( reportParams: ReportParams, chartPeriod: StatsPeriod ) {
+	// One unsummarized query supplies both the interval chart and the complete
+	// client-side table. `max: 0` requests every file row.
+	const recordsParams = useMemo(
+		() => ( {
+			...reportParams,
+			max: 0,
+			summarize: 0,
+			period: chartPeriod,
+		} ),
+		[ reportParams, chartPeriod ]
+	);
+	const report = useStatsFileDownloads( recordsParams );
+
+	const chartPrimary = useMemo(
+		() =>
+			downloadsToTimeSeries(
+				report.primary.data as StatsNormalizedReport< StatsFileDownloadsItem > | undefined
+			),
+		[ report.primary.data ]
+	);
+	const chartComparison = useMemo( () => {
+		if ( ! reportParams.compare_from || ! reportParams.compare_to ) {
+			return undefined;
+		}
+
+		return downloadsToTimeSeries(
+			report.comparison.data as StatsNormalizedReport< StatsFileDownloadsItem > | undefined
+		);
+	}, [ reportParams, report.comparison.data ] );
+	const rows = useMemo(
+		() =>
+			aggregateDownloadRows(
+				report.primary.data as StatsNormalizedReport< StatsFileDownloadsItem > | undefined
+			),
+		[ report.primary.data ]
+	);
+
+	return {
+		chart: {
+			primary: chartPrimary,
+			comparison: report.hasComparison ? chartComparison : undefined,
+			isLoading: report.isLoading,
+		},
+		rows,
+		isLoading: report.isLoading,
+	};
+}

--- a/projects/packages/premium-analytics/routes/reports/downloads/page.module.css
+++ b/projects/packages/premium-analytics/routes/reports/downloads/page.module.css
@@ -1,0 +1,22 @@
+.page {
+	min-block-size: 0;
+}
+
+.content {
+	flex: 1 1 auto;
+	min-block-size: 0;
+	overflow-y: auto;
+	padding-block-end: 24px;
+
+	/*
+	 * Mirror the top padding of Page's own `hasPadding` content so the filters
+	 * row doesn't hug the header border — tabbed reports skip this because the
+	 * tab strip is designed to sit flush under the header.
+	 */
+	padding-block-start: var(--wpds-dimension-padding-lg);
+	padding-inline: var(--wpds-dimension-padding-2xl);
+}
+
+.dateFilters {
+	inline-size: 100%;
+}

--- a/projects/packages/premium-analytics/routes/reports/downloads/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/downloads/page.tsx
@@ -4,8 +4,8 @@
 import {
 	normalizeReportParams,
 	type IntervalType,
+	type StatsChartBucketPeriod,
 	type StatsFileDownloadsItem,
-	type StatsPeriod,
 } from '@jetpack-premium-analytics/data';
 import { useDashboardLink, useReportDateFilters } from '@jetpack-premium-analytics/routing';
 import { DateFiltersPanel } from '@jetpack-premium-analytics/ui';
@@ -28,7 +28,11 @@ import styles from './page.module.css';
 
 const ROUTE_FROM = route.path;
 const REPORT_PARAMS = { report: 'downloads' };
-const CHART_PERIODS = [ 'day', 'week', 'month' ] as const satisfies readonly StatsPeriod[];
+const CHART_PERIODS = [
+	'day',
+	'week',
+	'month',
+] as const satisfies readonly StatsChartBucketPeriod[];
 type ChartPeriod = ( typeof CHART_PERIODS )[ number ];
 
 /**

--- a/projects/packages/premium-analytics/routes/reports/downloads/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/downloads/page.tsx
@@ -1,0 +1,175 @@
+/**
+ * External dependencies
+ */
+import {
+	normalizeReportParams,
+	type IntervalType,
+	type StatsFileDownloadsItem,
+	type StatsPeriod,
+} from '@jetpack-premium-analytics/data';
+import { useDashboardLink, useReportDateFilters } from '@jetpack-premium-analytics/routing';
+import { DateFiltersPanel } from '@jetpack-premium-analytics/ui';
+import {
+	formatLegendLabels,
+	ReportPageLayout,
+	ReportPerformanceChart,
+	ReportRecordsTable,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { Breadcrumbs, Page } from '@wordpress/admin-ui';
+import { useCallback, useMemo, useState } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { useNavigate, useSearch } from '@wordpress/route';
+/**
+ * Internal dependencies
+ */
+import { route } from '../package.json';
+import { getDownloadsFields, useDownloadsReportRecords } from './config';
+import styles from './page.module.css';
+
+const ROUTE_FROM = route.path;
+const REPORT_PARAMS = { report: 'downloads' };
+const CHART_PERIODS = [ 'day', 'week', 'month' ] as const satisfies readonly StatsPeriod[];
+type ChartPeriod = ( typeof CHART_PERIODS )[ number ];
+
+/**
+ * Check whether a URL value is a supported chart period.
+ *
+ * @param value - URL search value.
+ * @return Whether the value is a chart period.
+ */
+function isChartPeriod( value: unknown ): value is ChartPeriod {
+	return CHART_PERIODS.includes( value as ChartPeriod );
+}
+
+/**
+ * Choose the chart bucket period for a report interval.
+ *
+ * @param interval - Report date interval.
+ * @return The default chart period.
+ */
+function getDefaultChartPeriod( interval?: IntervalType ): ChartPeriod {
+	if ( interval === 'week' ) {
+		return 'week';
+	}
+
+	if ( interval === 'month' || interval === 'quarter' || interval === 'year' ) {
+		return 'month';
+	}
+
+	return 'day';
+}
+
+/**
+ * Stable table row identity for a downloaded file.
+ *
+ * @param item - File-download row.
+ * @return The row identity.
+ */
+function getDownloadRowId( item: StatsFileDownloadsItem ): string {
+	return item.link ?? String( item.label ?? item.shortLabel ?? '' );
+}
+
+const RECORDS_VIEW = {
+	sort: { field: 'downloads', direction: 'desc' as const },
+	layout: {
+		styles: {
+			file: { width: '100%' },
+			downloads: { align: 'end' as const },
+		},
+	},
+};
+
+/**
+ * File downloads report page.
+ *
+ * @return The rendered report page.
+ */
+function DownloadsReport(): JSX.Element {
+	const search = useSearch( { from: ROUTE_FROM } ) as Record< string, string | undefined >;
+	const reportParams = useMemo(
+		() => normalizeReportParams( search as Parameters< typeof normalizeReportParams >[ 0 ] ),
+		[ search ]
+	);
+	const chartPeriod = isChartPeriod( search.period )
+		? search.period
+		: getDefaultChartPeriod( reportParams.interval );
+	const records = useDownloadsReportRecords( reportParams, chartPeriod );
+	const fields = useMemo( () => getDownloadsFields(), [] );
+	const chartMetrics = useMemo(
+		() => [ { key: 'downloads', label: __( 'Downloads', 'jetpack-premium-analytics' ) } ],
+		[]
+	);
+	const chartLegendLabels = useMemo( () => formatLegendLabels( reportParams ), [ reportParams ] );
+
+	const navigate = useNavigate();
+	const handleIntervalChange = useCallback(
+		( interval: IntervalType ) => {
+			const period = isChartPeriod( interval ) ? interval : getDefaultChartPeriod( interval );
+			navigate( {
+				to: ROUTE_FROM,
+				params: REPORT_PARAMS as unknown as never,
+				replace: true,
+				search: ( ( current: Record< string, unknown > ) => ( {
+					...current,
+					period,
+				} ) ) as unknown as never,
+			} );
+		},
+		[ navigate ]
+	);
+
+	const dateFilters = useReportDateFilters( ROUTE_FROM );
+	const dashboardLink = useDashboardLink();
+	const [ containerElement, setContainerElement ] = useState< HTMLDivElement | null >( null );
+
+	return (
+		<Page
+			breadcrumbs={
+				<Breadcrumbs
+					items={ [
+						{ label: __( 'Stats', 'jetpack-premium-analytics' ), to: dashboardLink },
+						{ label: __( 'File downloads', 'jetpack-premium-analytics' ) },
+					] }
+				/>
+			}
+			className={ styles.page }
+		>
+			<div className={ styles.content }>
+				<ReportPageLayout
+					filters={
+						<div ref={ setContainerElement } className={ styles.dateFilters }>
+							<DateFiltersPanel { ...dateFilters } containerElement={ containerElement } />
+						</div>
+					}
+				>
+					<ReportPerformanceChart
+						primary={ records.chart.primary }
+						comparison={ records.chart.comparison }
+						isLoading={ records.chart.isLoading }
+						metrics={ chartMetrics }
+						interval={ chartPeriod }
+						onIntervalChange={ handleIntervalChange }
+						legendLabels={ chartLegendLabels }
+					/>
+					<ReportRecordsTable< StatsFileDownloadsItem >
+						data={ records.rows }
+						fields={ fields }
+						getItemId={ getDownloadRowId }
+						isLoading={ records.isLoading }
+						initialView={ RECORDS_VIEW }
+						searchLabel={ __( 'Search files', 'jetpack-premium-analytics' ) }
+					/>
+				</ReportPageLayout>
+			</div>
+		</Page>
+	);
+}
+
+/**
+ * File downloads report page (default export for the report registry).
+ *
+ * @return The rendered report page.
+ */
+export default function DownloadsReportPage(): JSX.Element {
+	return <DownloadsReport />;
+}

--- a/projects/packages/premium-analytics/routes/reports/registry.ts
+++ b/projects/packages/premium-analytics/routes/reports/registry.ts
@@ -74,6 +74,11 @@ export const REPORTS: Record< string, ReportDefinition > = {
 		getTitle: () => __( 'Comments Subscribers', 'jetpack-premium-analytics' ),
 		load: () => import( './comment-followers/page' ),
 	},
+	downloads: {
+		id: 'downloads',
+		getTitle: () => __( 'File downloads', 'jetpack-premium-analytics' ),
+		load: () => import( './downloads/page' ),
+	},
 	posts: {
 		id: 'posts',
 		getTitle: () => __( 'Posts & Pages', 'jetpack-premium-analytics' ),

--- a/projects/packages/premium-analytics/widgets/file-downloads/__tests__/file-downloads.test.tsx
+++ b/projects/packages/premium-analytics/widgets/file-downloads/__tests__/file-downloads.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { queryClient } from '@jetpack-premium-analytics/data';
+import { render, screen } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import type { AnchorHTMLAttributes, ReactNode } from 'react';
+/**
+ * Internal dependencies
+ */
+import FileDownloadsWidget from '../render';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+type MockRouteLinkProps = {
+	to: string;
+	params?: Record< string, unknown >;
+	search?: Record< string, unknown >;
+	children: ReactNode;
+} & Omit< AnchorHTMLAttributes< HTMLAnchorElement >, 'href' >;
+
+jest.mock( '@wordpress/route', () => ( {
+	Link: ( { to, params, search, children, ...props }: MockRouteLinkProps ) => {
+		const path = Object.entries( params ?? {} ).reduce(
+			( result, [ key, value ] ) => result.replace( `$${ key }`, String( value ) ),
+			to
+		);
+		const query = new URLSearchParams();
+		Object.entries( search ?? {} ).forEach( ( [ key, value ] ) => {
+			if ( value !== undefined && value !== null ) {
+				query.set( key, String( value ) );
+			}
+		} );
+		const queryString = query.toString();
+
+		return (
+			<a href={ queryString ? `${ path }?${ queryString }` : path } { ...props }>
+				{ children }
+			</a>
+		);
+	},
+	useSearch: () => ( {} ),
+} ) );
+
+const mockApiFetch = apiFetch as unknown as jest.Mock;
+
+describe( 'FileDownloadsWidget', () => {
+	beforeEach( () => {
+		queryClient.clear();
+		mockApiFetch.mockReset();
+		mockApiFetch.mockResolvedValue( { date: '2026-06-22', days: {} } );
+	} );
+
+	it( 'links to the Downloads report', () => {
+		render( <FileDownloadsWidget attributes={ { max: 10 } } /> );
+
+		expect( screen.getByRole( 'link', { name: 'See report' } ) ).toHaveAttribute(
+			'href',
+			expect.stringContaining( '/reports/downloads' )
+		);
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/file-downloads/render.tsx
+++ b/projects/packages/premium-analytics/widgets/file-downloads/render.tsx
@@ -16,6 +16,8 @@ import { Link } from '@wordpress/ui';
 import {
 	calculateDelta,
 	LeaderboardChart,
+	ReportLink,
+	WidgetFooter,
 	WidgetRoot,
 	WidgetState,
 	useWidgetRootContext,
@@ -272,34 +274,39 @@ function FileDownloadsInner( { max }: FileDownloadsInnerProps ) {
 	const withComparison = hasComparison;
 
 	return (
-		<div className={ styles.content }>
-			<WidgetState
-				isLoading={ isLoading }
-				isFetching={ isFetching }
-				// The Stats queries carry `placeholderData`, so a failed range change
-				// keeps the prior period's rows visible; only surface the error when
-				// there is nothing to show.
-				isError={ rows.length === 0 && isError }
-				isEmpty={ rows.length === 0 }
-				error={ {
-					description:
-						unavailableMessage ??
-						__(
-							"We couldn't load file downloads. Please try again in a moment.",
-							'jetpack-premium-analytics'
-						),
-					actions: unavailableMessage
-						? []
-						: [ { label: __( 'Retry', 'jetpack-premium-analytics' ), onClick: refetch } ],
-				} }
-				empty={ {
-					icon: download,
-					description: __( 'No file downloads in this period.', 'jetpack-premium-analytics' ),
-				} }
-			>
-				<FileDownloadsLeaderboard rows={ rows } withComparison={ withComparison } />
-			</WidgetState>
-		</div>
+		<>
+			<div className={ styles.content }>
+				<WidgetState
+					isLoading={ isLoading }
+					isFetching={ isFetching }
+					// The Stats queries carry `placeholderData`, so a failed range change
+					// keeps the prior period's rows visible; only surface the error when
+					// there is nothing to show.
+					isError={ rows.length === 0 && isError }
+					isEmpty={ rows.length === 0 }
+					error={ {
+						description:
+							unavailableMessage ??
+							__(
+								"We couldn't load file downloads. Please try again in a moment.",
+								'jetpack-premium-analytics'
+							),
+						actions: unavailableMessage
+							? []
+							: [ { label: __( 'Retry', 'jetpack-premium-analytics' ), onClick: refetch } ],
+					} }
+					empty={ {
+						icon: download,
+						description: __( 'No file downloads in this period.', 'jetpack-premium-analytics' ),
+					} }
+				>
+					<FileDownloadsLeaderboard rows={ rows } withComparison={ withComparison } />
+				</WidgetState>
+			</div>
+			<WidgetFooter>
+				<ReportLink report="downloads" />
+			</WidgetFooter>
+		</>
 	);
 }
 

--- a/projects/packages/premium-analytics/widgets/file-downloads/stories/file-downloads-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/file-downloads/stories/file-downloads-widget.stories.tsx
@@ -14,6 +14,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withStoryRouter } from '../../stories/with-story-router';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import FileDownloadsRender from '../render';
 import widgetDefinition from '../widget';
@@ -101,13 +102,13 @@ type DashboardStory = StoryObj< FileDownloadsDashboardStoryProps >;
 export const Default: Story = {
 	render: renderFileDownloadsWidget,
 	args: { withComparison: false },
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 };
 
 export const WithComparison: Story = {
 	render: renderFileDownloadsWidget,
 	args: { withComparison: true },
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 };
 
 /**
@@ -118,7 +119,7 @@ export const Loading: Story = {
 	render: () => renderFileDownloadsOnPreset( 'last-90-days' ),
 	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 	beforeEach: () => {
 		forceStatsMockState( 'stats/file-downloads', 'loading' );
 		return () => forceStatsMockState( 'stats/file-downloads', null );
@@ -132,7 +133,7 @@ export const Loading: Story = {
 export const Error: Story = {
 	render: () => renderFileDownloadsOnPreset( 'last-7-days' ),
 	tags: [ '!autodocs' ],
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 	beforeEach: () => {
 		forceStatsMockState( 'stats/file-downloads', 'error' );
 		return () => forceStatsMockState( 'stats/file-downloads', null );
@@ -146,7 +147,7 @@ export const Error: Story = {
 export const Empty: Story = {
 	render: () => renderFileDownloadsOnPreset( 'last-365-days' ),
 	tags: [ '!autodocs' ],
-	decorators: [ withWidgetCanvas ],
+	decorators: [ withWidgetCanvas, withStoryRouter ],
 	beforeEach: () => {
 		forceStatsMockState( 'stats/file-downloads', 'empty' );
 		return () => forceStatsMockState( 'stats/file-downloads', null );


### PR DESCRIPTION
Part of [WOOA7S-1703](https://linear.app/a8c/issue/WOOA7S-1703)

## Proposed changes

* Adds the File downloads report at `/reports/downloads` on the reports framework from #50305: a `routes/reports/downloads/` page module (performance chart + records table, `config/aggregate.ts` with tests) and one `REPORTS` registry entry.
* The File downloads widget footer links to the report via the shared `WidgetFooter`/`ReportLink`, carrying the dashboard's current date range and comparison.

<!-- screenshot: add a capture of the /reports/downloads page -->

## Related product discussion/links

* [WOOA7S-1703](https://linear.app/a8c/issue/WOOA7S-1703)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `cd projects/packages/premium-analytics && pnpm run build`, open the Premium Analytics dashboard on a site with file-download stats.
* In the File downloads widget, click **View all** — you should land on `/reports/downloads` with the dashboard's date range and comparison intact.
* On the chart: change the time bucket (day/week/month) and collapse/expand it.
* On the table: search, sort, and page through — all client-side, no new requests.
* Change the date range from the page's date filter — chart and table should update together, and reloading the URL should restore the exact view.
