### PR TITLE
WOOA7S-1501: Port Stats Comments widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-comments-widget
+++ b/projects/packages/premium-analytics/changelog/add-comments-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Comments: add the Comments widget ranking comment authors and most-commented posts and pages by comment count.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/comments.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/comments.ts
@@ -1,0 +1,104 @@
+/**
+ * Mock response for the Stats `comments` endpoint (`/proxy/v1.1/stats/comments`).
+ *
+ * The endpoint is all-time and returns two parallel lists — comment authors and
+ * commented posts — which the widget shows through its "By authors" / "By posts
+ * & pages" selector. This fixture populates both so the toggle is reviewable.
+ *
+ * Gravatar URLs are used for author avatars: the comments processor strips each
+ * URL's query string and re-appends `?d=mm`, so Storybook renders Gravatar's
+ * default avatar for these placeholder hashes.
+ */
+export const mockCommentsData = {
+	date: '2026-06-22',
+	authors: [
+		{
+			name: 'Alex Rivera',
+			comments: 128,
+			link: 'https://example.com/author/alex-rivera',
+			gravatar: 'https://www.gravatar.com/avatar/00000000000000000000000000000a01?s=96',
+		},
+		{
+			name: 'Priya Nair',
+			comments: 97,
+			link: 'https://example.com/author/priya-nair',
+			gravatar: 'https://www.gravatar.com/avatar/00000000000000000000000000000a02?s=96',
+		},
+		{
+			name: 'Marcus Chen',
+			comments: 74,
+			link: 'https://example.com/author/marcus-chen',
+			gravatar: 'https://www.gravatar.com/avatar/00000000000000000000000000000a03?s=96',
+		},
+		{
+			name: 'Sofia Almeida',
+			comments: 61,
+			link: 'https://example.com/author/sofia-almeida',
+			gravatar: 'https://www.gravatar.com/avatar/00000000000000000000000000000a04?s=96',
+		},
+		{
+			name: 'Daniel Okoro',
+			comments: 45,
+			link: 'https://example.com/author/daniel-okoro',
+			gravatar: 'https://www.gravatar.com/avatar/00000000000000000000000000000a05?s=96',
+		},
+		{
+			name: 'Hannah Weber',
+			comments: 33,
+			link: 'https://example.com/author/hannah-weber',
+			gravatar: 'https://www.gravatar.com/avatar/00000000000000000000000000000a06?s=96',
+		},
+		{
+			name: 'Leah Kim',
+			comments: 22,
+			link: 'https://example.com/author/leah-kim',
+			gravatar: 'https://www.gravatar.com/avatar/00000000000000000000000000000a07?s=96',
+		},
+	],
+	posts: [
+		{
+			id: 3201,
+			title: 'Launching our summer collection',
+			comments: 84,
+			link: 'https://example.com/summer-collection',
+		},
+		{
+			id: 3188,
+			title: 'A guide to sustainable packaging',
+			comments: 63,
+			link: 'https://example.com/sustainable-packaging',
+		},
+		{
+			id: 3150,
+			title: 'Behind the scenes at our studio',
+			comments: 51,
+			link: 'https://example.com/behind-the-scenes',
+		},
+		{
+			id: 3099,
+			title: 'How we source our materials',
+			comments: 38,
+			link: 'https://example.com/material-sourcing',
+		},
+		{
+			id: 3042,
+			title: 'Customer stories: made to last',
+			comments: 27,
+			link: 'https://example.com/customer-stories',
+		},
+		{
+			id: 2988,
+			title: 'Care tips for your new pieces',
+			comments: 19,
+			link: 'https://example.com/care-tips',
+		},
+		{
+			id: 2900,
+			title: 'Our roadmap for next year',
+			comments: 12,
+			link: 'https://example.com/roadmap',
+		},
+	],
+	monthly_comments: 260,
+	total_comments: 5810,
+};

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/index.ts
@@ -62,6 +62,7 @@ export {
 	mockCustomersByDateComparisonData,
 } from './customers';
 
+export { mockCommentsData } from './comments';
 export { mockSearchTermsData, mockSearchTermsComparisonData } from './search-terms';
 export { mockSingleVideoData } from './single-video';
 export { mockTopAuthorsData, mockTopAuthorsComparisonData } from './top-authors';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -45,6 +45,7 @@ import {
 	mockCustomersComparisonData,
 	mockCustomersByDateData,
 	mockCustomersByDateComparisonData,
+	mockCommentsData,
 	mockSearchTermsData,
 	mockSearchTermsComparisonData,
 	mockSingleVideoData,
@@ -898,6 +899,10 @@ function routeStatsReport( subPath: string ): unknown {
 			return nextIsComparison( 'stats/summary' )
 				? mockStatsSummaryComparisonData
 				: mockStatsSummaryData;
+		case '/comments':
+			// All-time report with no comparison period; the same body serves
+			// both the primary and comparison requests.
+			return mockCommentsData;
 		case '/search-terms':
 			return nextIsComparison( 'stats/search-terms' )
 				? mockSearchTermsComparisonData

--- a/projects/packages/premium-analytics/widgets/comments/package.json
+++ b/projects/packages/premium-analytics/widgets/comments/package.json
@@ -1,0 +1,16 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-comments",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/element": "8.2.0",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^15.0.0",
+		"@wordpress/ui": "0.17.0",
+		"@wordpress/widget-primitives": "0.2.0",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/comments/render.tsx
+++ b/projects/packages/premium-analytics/widgets/comments/render.tsx
@@ -17,8 +17,8 @@ import { Link, Stack } from '@wordpress/ui';
  * Internal dependencies
  */
 import styles from './style.module.css';
-import useCommentViews, { type CommentRow, type CommentView } from './use-comment-views';
-import { type CommentsAttributes } from './widget';
+import useCommentViews, { type CommentRow } from './use-comment-views';
+import { type CommentsAttributes, type CommentsView } from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ReactElement } from 'react';
 
@@ -27,10 +27,10 @@ type CommentsWidgetProps = WidgetRenderProps< CommentsRenderAttributes >;
 
 const DATA_FORMAT = { type: 'number' as const, options: { useMultipliers: true, decimals: 0 } };
 
-const COMMENT_VIEWS: CommentView[] = [ 'authors', 'posts' ];
+const COMMENT_VIEWS: CommentsView[] = [ 'authors', 'posts' ];
 
-function isCommentView( value: unknown ): value is CommentView {
-	return typeof value === 'string' && COMMENT_VIEWS.includes( value as CommentView );
+function isCommentView( value: unknown ): value is CommentsView {
+	return typeof value === 'string' && COMMENT_VIEWS.includes( value as CommentsView );
 }
 
 /**
@@ -39,11 +39,11 @@ function isCommentView( value: unknown ): value is CommentView {
  * permalink). Author rows carry no link in the normalized data, so they are
  * always static labels.
  *
- * @param {CommentRow}  row  - The row to label.
- * @param {CommentView} view - The active view.
+ * @param {CommentRow}   row  - The row to label.
+ * @param {CommentsView} view - The active view.
  * @return The label node.
  */
-function buildRowLabel( row: CommentRow, view: CommentView ): ReactElement {
+function buildRowLabel( row: CommentRow, view: CommentsView ): ReactElement {
 	if ( view === 'authors' ) {
 		return (
 			<LeaderboardLabel
@@ -89,7 +89,7 @@ interface CommentsInnerProps {
 	 * The active view. Owned by the widget host: the `view` attribute is
 	 * `relevance: 'high'`, so the host renders the "View by" header control.
 	 */
-	view: CommentView;
+	view: CommentsView;
 }
 
 /**

--- a/projects/packages/premium-analytics/widgets/comments/render.tsx
+++ b/projects/packages/premium-analytics/widgets/comments/render.tsx
@@ -9,7 +9,7 @@ import {
 	type LeaderboardChartData,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
-import { useCallback, useMemo, useState } from '@wordpress/element';
+import { useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { comment } from '@wordpress/icons';
 import { Link, Stack } from '@wordpress/ui';
@@ -31,10 +31,6 @@ const COMMENT_VIEWS: CommentView[] = [ 'authors', 'posts' ];
 
 function isCommentView( value: unknown ): value is CommentView {
 	return typeof value === 'string' && COMMENT_VIEWS.includes( value as CommentView );
-}
-
-function viewOptionClass( active: boolean ): string {
-	return active ? `${ styles.viewOption } ${ styles.viewOptionActive }` : styles.viewOption;
 }
 
 /**
@@ -90,27 +86,23 @@ interface CommentsInnerProps {
 	 */
 	max?: number;
 	/**
-	 * The view the widget opens on.
+	 * The active view. Owned by the widget host: the `view` attribute is
+	 * `relevance: 'high'`, so the host renders the "View by" header control.
 	 */
-	initialView: CommentView;
+	view: CommentView;
 }
 
 /**
  * Comments widget inner component. The comment counts come from the all-time
  * `stats/comments` report, so there is no date range or comparison period to
- * read from context; the view selector switches between the two groups the
- * report returns.
+ * read from context; the host-owned `view` selects which of the report's two
+ * groups is shown.
  *
  * @param {CommentsInnerProps} props - The component props.
  * @return The rendered widget content.
  */
-function CommentsInner( { max = 10, initialView }: CommentsInnerProps ) {
-	const [ view, setView ] = useState< CommentView >( initialView );
-
+function CommentsInner( { max = 10, view }: CommentsInnerProps ) {
 	const { data, isLoading, isFetching, isError, refetch } = useCommentViews( { view, max } );
-
-	const selectAuthors = useCallback( () => setView( 'authors' ), [] );
-	const selectPosts = useCallback( () => setView( 'posts' ), [] );
 
 	const leaderboardData = useMemo< LeaderboardChartData >( () => {
 		const maxValue = Math.max( ...data.map( row => row.value ), 0 );
@@ -125,28 +117,6 @@ function CommentsInner( { max = 10, initialView }: CommentsInnerProps ) {
 
 	return (
 		<Stack className={ styles.root }>
-			<div
-				className={ styles.viewControl }
-				role="group"
-				aria-label={ __( 'Comments view', 'jetpack-premium-analytics' ) }
-			>
-				<button
-					type="button"
-					className={ viewOptionClass( view === 'authors' ) }
-					aria-pressed={ view === 'authors' }
-					onClick={ selectAuthors }
-				>
-					{ __( 'By authors', 'jetpack-premium-analytics' ) }
-				</button>
-				<button
-					type="button"
-					className={ viewOptionClass( view === 'posts' ) }
-					aria-pressed={ view === 'posts' }
-					onClick={ selectPosts }
-				>
-					{ __( 'By posts & pages', 'jetpack-premium-analytics' ) }
-				</button>
-			</div>
 			<div className={ styles.content }>
 				<WidgetState
 					isLoading={ isLoading }
@@ -182,18 +152,19 @@ function CommentsInner( { max = 10, initialView }: CommentsInnerProps ) {
 
 /**
  * Comments widget: the site's comment authors and its most-commented posts and
- * pages, ranked by comment count and switchable through an in-widget view
- * selector. Ported from the Jetpack Stats "Comments" module.
+ * pages, ranked by comment count. The active view is the host-rendered "View by"
+ * header control (the `view` attribute). Ported from the Jetpack Stats
+ * "Comments" module.
  *
  * @param {CommentsWidgetProps} props - The widget render props.
  * @return The rendered Comments widget.
  */
 export default function Comments( { attributes = {} }: CommentsWidgetProps ) {
-	const initialView = isCommentView( attributes.view ) ? attributes.view : 'authors';
+	const view = isCommentView( attributes.view ) ? attributes.view : 'authors';
 
 	return (
 		<WidgetRoot attributes={ attributes }>
-			<CommentsInner max={ attributes.max } initialView={ initialView } />
+			<CommentsInner max={ attributes.max } view={ view } />
 		</WidgetRoot>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/comments/render.tsx
+++ b/projects/packages/premium-analytics/widgets/comments/render.tsx
@@ -1,0 +1,199 @@
+/**
+ * External dependencies
+ */
+import {
+	LeaderboardChart,
+	LeaderboardLabel,
+	WidgetRoot,
+	WidgetState,
+	type LeaderboardChartData,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { useCallback, useMemo, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { comment } from '@wordpress/icons';
+import { Link, Stack } from '@wordpress/ui';
+/**
+ * Internal dependencies
+ */
+import styles from './style.module.css';
+import useCommentViews, { type CommentRow, type CommentView } from './use-comment-views';
+import { type CommentsAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ReactElement } from 'react';
+
+type CommentsRenderAttributes = CommentsAttributes & Partial< ReportParamsFieldAttributes >;
+type CommentsWidgetProps = WidgetRenderProps< CommentsRenderAttributes >;
+
+const DATA_FORMAT = { type: 'number' as const, options: { useMultipliers: true, decimals: 0 } };
+
+const COMMENT_VIEWS: CommentView[] = [ 'authors', 'posts' ];
+
+function isCommentView( value: unknown ): value is CommentView {
+	return typeof value === 'string' && COMMENT_VIEWS.includes( value as CommentView );
+}
+
+function viewOptionClass( active: boolean ): string {
+	return active ? `${ styles.viewOption } ${ styles.viewOptionActive }` : styles.viewOption;
+}
+
+/**
+ * Builds a leaderboard row label. Authors render as a name + avatar; posts render
+ * as an external link to the published post (or plain text when a post has no
+ * permalink). Author rows carry no link in the normalized data, so they are
+ * always static labels.
+ *
+ * @param {CommentRow}  row  - The row to label.
+ * @param {CommentView} view - The active view.
+ * @return The label node.
+ */
+function buildRowLabel( row: CommentRow, view: CommentView ): ReactElement {
+	if ( view === 'authors' ) {
+		return (
+			<LeaderboardLabel
+				label={ row.label }
+				imageUrl={ row.avatarUrl }
+				imageAlt={ sprintf(
+					/* translators: %s is the comment author name */
+					__( 'Avatar of %s', 'jetpack-premium-analytics' ),
+					row.label
+				) }
+				imageClassName={ styles.avatar }
+			/>
+		);
+	}
+
+	if ( row.link ) {
+		return (
+			<Link
+				className={ styles.postLabel }
+				href={ row.link }
+				variant="unstyled"
+				openInNewTab
+				title={ row.label }
+			>
+				{ row.label }
+			</Link>
+		);
+	}
+
+	return (
+		<span className={ styles.postLabel } title={ row.label }>
+			{ row.label }
+		</span>
+	);
+}
+
+interface CommentsInnerProps {
+	/**
+	 * Maximum number of rows to display.
+	 */
+	max?: number;
+	/**
+	 * The view the widget opens on.
+	 */
+	initialView: CommentView;
+}
+
+/**
+ * Comments widget inner component. The comment counts come from the all-time
+ * `stats/comments` report, so there is no date range or comparison period to
+ * read from context; the view selector switches between the two groups the
+ * report returns.
+ *
+ * @param {CommentsInnerProps} props - The component props.
+ * @return The rendered widget content.
+ */
+function CommentsInner( { max = 10, initialView }: CommentsInnerProps ) {
+	const [ view, setView ] = useState< CommentView >( initialView );
+
+	const { data, isLoading, isFetching, isError, refetch } = useCommentViews( { view, max } );
+
+	const selectAuthors = useCallback( () => setView( 'authors' ), [] );
+	const selectPosts = useCallback( () => setView( 'posts' ), [] );
+
+	const leaderboardData = useMemo< LeaderboardChartData >( () => {
+		const maxValue = Math.max( ...data.map( row => row.value ), 0 );
+
+		return data.map( row => ( {
+			id: row.id,
+			label: buildRowLabel( row, view ),
+			currentValue: row.value,
+			currentShare: maxValue > 0 ? ( row.value / maxValue ) * 100 : 0,
+		} ) );
+	}, [ data, view ] );
+
+	return (
+		<Stack className={ styles.root }>
+			<div
+				className={ styles.viewControl }
+				role="group"
+				aria-label={ __( 'Comments view', 'jetpack-premium-analytics' ) }
+			>
+				<button
+					type="button"
+					className={ viewOptionClass( view === 'authors' ) }
+					aria-pressed={ view === 'authors' }
+					onClick={ selectAuthors }
+				>
+					{ __( 'By authors', 'jetpack-premium-analytics' ) }
+				</button>
+				<button
+					type="button"
+					className={ viewOptionClass( view === 'posts' ) }
+					aria-pressed={ view === 'posts' }
+					onClick={ selectPosts }
+				>
+					{ __( 'By posts & pages', 'jetpack-premium-analytics' ) }
+				</button>
+			</div>
+			<div className={ styles.content }>
+				<WidgetState
+					isLoading={ isLoading }
+					isFetching={ isFetching }
+					isError={ isError }
+					isEmpty={ data.length === 0 }
+					error={ {
+						description: __(
+							"We couldn't load comments. Please try again in a moment.",
+							'jetpack-premium-analytics'
+						),
+						actions: [ { label: __( 'Retry', 'jetpack-premium-analytics' ), onClick: refetch } ],
+					} }
+					empty={ {
+						icon: comment,
+						description: __(
+							'Learn about the comments your site receives by authors, posts, and pages.',
+							'jetpack-premium-analytics'
+						),
+					} }
+				>
+					<LeaderboardChart
+						data={ leaderboardData }
+						withOverlayLabel
+						showLegend={ false }
+						dataFormat={ DATA_FORMAT }
+					/>
+				</WidgetState>
+			</div>
+		</Stack>
+	);
+}
+
+/**
+ * Comments widget: the site's comment authors and its most-commented posts and
+ * pages, ranked by comment count and switchable through an in-widget view
+ * selector. Ported from the Jetpack Stats "Comments" module.
+ *
+ * @param {CommentsWidgetProps} props - The widget render props.
+ * @return The rendered Comments widget.
+ */
+export default function Comments( { attributes = {} }: CommentsWidgetProps ) {
+	const initialView = isCommentView( attributes.view ) ? attributes.view : 'authors';
+
+	return (
+		<WidgetRoot attributes={ attributes }>
+			<CommentsInner max={ attributes.max } initialView={ initialView } />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/comments/stories/comments-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/comments/stories/comments-widget.stories.tsx
@@ -1,28 +1,33 @@
-import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { getDefaultQueryParams, queryClient } from '@jetpack-premium-analytics/data';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import CommentsRender from '../render';
 import widgetDefinition from '../widget';
 import type { CommentsView } from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
-import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
 
 const COMMENTS_RENDER_MODULE = 'storybook/comments';
 
-// Pick only the fields that StoryWidgetMetadata accepts; the attribute schema
-// and example arrays are typed differently in WidgetType and cause a type error.
 const storyWidgetType = {
 	name: widgetDefinition.name,
 	title: widgetDefinition.title,
 	icon: widgetDefinition.icon,
+	// attributes/example let the dashboard host render the real "View by" header
+	// control for the `relevance: 'high'` attribute, as in Top Platforms.
+	attributes: widgetDefinition.attributes as WidgetType[ 'attributes' ],
+	example: widgetDefinition.example,
 	presentation: 'framed' as const,
 };
 
@@ -37,12 +42,11 @@ interface CommentsStoryControls {
 }
 
 function renderComments( { withComparison, view }: CommentsStoryControls ) {
-	// `view` seeds the widget's initial selection, held in local state. Keying the
-	// render on it remounts the widget when the control changes so the selector
-	// reflects the control rather than pinning the first-mount value.
+	// The close-up story renders the bare widget without the host chrome, so the
+	// "View by" control isn't shown here; the `view` control drives the rendered
+	// view directly through the (host-owned) `view` attribute.
 	return (
 		<CommentsRender
-			key={ view }
 			attributes={ { view, reportParams: getDefaultQueryParams( withComparison ) } }
 		/>
 	);
@@ -50,6 +54,24 @@ function renderComments( { withComparison, view }: CommentsStoryControls ) {
 
 function CommentsDashboardRender( props: WidgetRenderProps< unknown > ) {
 	return <CommentsRender { ...( props as ComponentProps< typeof CommentsRender > ) } />;
+}
+
+// The `stats/comments` endpoint is all-time, so its React Query key does not vary
+// by date. The shared query client would otherwise let a forced-state story read
+// a sibling story's cached success, so the cache is cleared around the story to
+// guarantee a fresh fetch that hits the forced mock.
+const COMMENTS_QUERY_KEY = [ 'stats', 'comments' ];
+
+function forceCommentsState( state: 'loading' | 'error' | 'empty' ) {
+	return () => {
+		queryClient.removeQueries( { queryKey: COMMENTS_QUERY_KEY } );
+		setReportMockState( 'stats/comments', state );
+
+		return () => {
+			setReportMockState( 'stats/comments', null );
+			queryClient.removeQueries( { queryKey: COMMENTS_QUERY_KEY } );
+		};
+	};
 }
 
 // Close-up frame: a white, widget-sized card so the widget reads the way it does
@@ -84,7 +106,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'The "Comments" widget. Ranks the site\'s comment authors and its most-commented posts and pages by comment count, switchable through an in-widget "By authors" / "By posts & pages" selector. Ported from the Jetpack Stats Comments module.',
+					'The "Comments" widget. Ranks the site\'s comment authors and its most-commented posts and pages by comment count. The active view is the host-rendered "View by" header control (Authors / Posts & pages). Ported from the Jetpack Stats Comments module.',
 			},
 		},
 	},
@@ -119,6 +141,44 @@ export const WithComparison: Story = {
 	},
 };
 
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: renderComments,
+	args: { withComparison: false, view: 'authors' },
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: forceCommentsState( 'loading' ),
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const ErrorState: Story = {
+	render: renderComments,
+	args: { withComparison: false, view: 'authors' },
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: forceCommentsState( 'error' ),
+};
+
+/**
+ * Resolved with no rows: the widget shows its empty state (the neutral comment
+ * glyph and "Learn about the comments your site receives…").
+ */
+export const Empty: Story = {
+	render: renderComments,
+	args: { withComparison: false, view: 'authors' },
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: forceCommentsState( 'empty' ),
+};
+
 interface CommentsDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		CommentsStoryControls {}
@@ -130,7 +190,6 @@ function CommentsDashboardStory( {
 }: CommentsDashboardStoryProps ) {
 	return (
 		<WidgetDashboardWithWidgetStory
-			key={ view }
 			{ ...dashboardArgs }
 			widgetType={ storyWidgetType }
 			renderModule={ COMMENTS_RENDER_MODULE }

--- a/projects/packages/premium-analytics/widgets/comments/stories/comments-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/comments/stories/comments-widget.stories.tsx
@@ -1,0 +1,155 @@
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import CommentsRender from '../render';
+import widgetDefinition from '../widget';
+import type { CommentsView } from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+const COMMENTS_RENDER_MODULE = 'storybook/comments';
+
+// Pick only the fields that StoryWidgetMetadata accepts; the attribute schema
+// and example arrays are typed differently in WidgetType and cause a type error.
+const storyWidgetType = {
+	name: widgetDefinition.name,
+	title: widgetDefinition.title,
+	icon: widgetDefinition.icon,
+	presentation: 'framed' as const,
+};
+
+const VIEW_CONTROL = {
+	control: 'inline-radio' as const,
+	options: [ 'authors', 'posts' ] as CommentsView[],
+};
+
+interface CommentsStoryControls {
+	withComparison: boolean;
+	view: CommentsView;
+}
+
+function renderComments( { withComparison, view }: CommentsStoryControls ) {
+	// `view` seeds the widget's initial selection, held in local state. Keying the
+	// render on it remounts the widget when the control changes so the selector
+	// reflects the control rather than pinning the first-mount value.
+	return (
+		<CommentsRender
+			key={ view }
+			attributes={ { view, reportParams: getDefaultQueryParams( withComparison ) } }
+		/>
+	);
+}
+
+function CommentsDashboardRender( props: WidgetRenderProps< unknown > ) {
+	return <CommentsRender { ...( props as ComponentProps< typeof CommentsRender > ) } />;
+}
+
+// Close-up frame: a white, widget-sized card so the widget reads the way it does
+// as a real dashboard widget (in product the host supplies this frame).
+const withWidgetCanvas: Decorator = Story => (
+	<div
+		style={ {
+			width: '380px',
+			height: '520px',
+			margin: '0 auto',
+			padding: '16px',
+			boxSizing: 'border-box',
+			background: '#fff',
+			border: '1px solid #e0e0e0',
+			borderRadius: '8px',
+			overflow: 'hidden',
+		} }
+	>
+		<Story />
+	</div>
+);
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/Comments',
+	component: CommentsRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		withComparison: { control: 'boolean' },
+		view: VIEW_CONTROL,
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The "Comments" widget. Ranks the site\'s comment authors and its most-commented posts and pages by comment count, switchable through an in-widget "By authors" / "By posts & pages" selector. Ported from the Jetpack Stats Comments module.',
+			},
+		},
+	},
+} satisfies Meta< ComponentProps< typeof CommentsRender > & CommentsStoryControls >;
+
+export default meta;
+
+type Story = StoryObj< CommentsStoryControls >;
+
+export const Default: Story = {
+	render: renderComments,
+	args: { withComparison: false, view: 'authors' },
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * The Comments endpoint is all-time and returns no comparison rows, so enabling
+ * the date-range picker's comparison parameters renders the widget identically
+ * to `Default` — no period-over-period deltas are shown.
+ */
+export const WithComparison: Story = {
+	render: renderComments,
+	args: { withComparison: true, view: 'authors' },
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'The Stats Comments module has no comparison data, so this renders the same as Default without fabricated deltas.',
+			},
+		},
+	},
+};
+
+interface CommentsDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		CommentsStoryControls {}
+
+function CommentsDashboardStory( {
+	withComparison,
+	view,
+	...dashboardArgs
+}: CommentsDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			key={ view }
+			{ ...dashboardArgs }
+			widgetType={ storyWidgetType }
+			renderModule={ COMMENTS_RENDER_MODULE }
+			renderComponent={ CommentsDashboardRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ { view, reportParams: getDefaultQueryParams( withComparison ) } }
+		/>
+	);
+}
+
+export const WidgetDashboardWithWidget: StoryObj< CommentsDashboardStoryProps > = {
+	render: args => <CommentsDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		withComparison: true,
+		view: 'authors',
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		withComparison: { control: 'boolean' },
+		view: VIEW_CONTROL,
+	},
+};

--- a/projects/packages/premium-analytics/widgets/comments/style.module.css
+++ b/projects/packages/premium-analytics/widgets/comments/style.module.css
@@ -16,13 +16,13 @@
 	min-height: 0;
 }
 
-/* Round the author avatar; a fixed size keeps the leaderboard row height
-   stable. */
+/* Round the author avatar; the shared image-size properties keep the
+   leaderboard row height stable and let LeaderboardLabel's centralized
+   picker-preview (`[inert]`) rule size the avatar correctly. */
 .avatar {
-	width: 20px;
-	height: 20px;
-	border-radius: 50%;
-	object-fit: cover;
+	--jpa-leaderboard-image-width: 20px;
+	--jpa-leaderboard-image-height: 20px;
+	--jpa-leaderboard-image-radius: 50%;
 }
 
 /* Post rows have no avatar, so the post label sizes the row: pad the block to
@@ -40,13 +40,4 @@
 a.postLabel:hover,
 a.postLabel:focus {
 	text-decoration: underline;
-}
-
-/* The picker grid applies img { width: 100%; height: 100%; object-fit: cover }
-   to all images inside the media cell, overriding our 20px avatar size.
-   Restore correct sizing for avatar images in any inert context. */
-:global([inert]) .root img {
-	width: 20px;
-	height: 20px;
-	object-fit: cover;
 }

--- a/projects/packages/premium-analytics/widgets/comments/style.module.css
+++ b/projects/packages/premium-analytics/widgets/comments/style.module.css
@@ -1,0 +1,96 @@
+.root {
+	container-type: inline-size;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	overflow: hidden;
+}
+
+/* Segmented view selector: a subtle track above the content, with the active
+   segment raised onto the base surface. Kept a sibling of the content so it
+   stays visible in every widget state. */
+.viewControl {
+	display: flex;
+	flex: 0 0 auto;
+	gap: var(--wpds-dimension-gap-xs);
+	padding: var(--wpds-dimension-padding-xs);
+	margin-block-end: var(--wpds-dimension-padding-sm);
+	background: var(--wpds-color-background-surface-neutral-weak);
+	border-radius: var(--wpds-border-radius-md);
+}
+
+.viewOption {
+	flex: 1 1 0;
+	min-width: 0;
+	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-sm);
+	border: 0;
+	border-radius: var(--wpds-border-radius-sm);
+	background: transparent;
+	color: var(--wpds-color-foreground-interactive-neutral);
+	font-size: var(--wpds-typography-font-size-sm);
+	font-weight: 500;
+	line-height: 1.4;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+	overflow: hidden;
+	cursor: pointer;
+}
+
+.viewOption:hover {
+	color: var(--wpds-color-foreground-interactive-neutral-strong);
+}
+
+.viewOption:focus-visible {
+	outline: 2px solid var(--wpds-color-foreground-interactive-brand);
+	outline-offset: -2px;
+}
+
+.viewOptionActive {
+	background: var(--wpds-color-background-surface-neutral);
+	color: var(--wpds-color-foreground-interactive-neutral-strong);
+}
+
+/* Positioned anchor so WidgetState's overlay (position: absolute; inset: 0)
+   resolves against the widget body, not the host frame. */
+.content {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	flex: 1 1 0;
+	min-height: 0;
+}
+
+/* Round the author avatar; a fixed size keeps the leaderboard row height
+   stable. */
+.avatar {
+	width: 20px;
+	height: 20px;
+	border-radius: 50%;
+	object-fit: cover;
+}
+
+/* Post rows have no avatar, so the post label sizes the row: pad the block to
+   set the overlay bar height and inset the text from the bar's rounded left
+   edge. */
+.postLabel {
+	display: block;
+	padding-block: var(--wpds-dimension-padding-md, 12px);
+	padding-inline-start: var(--wpds-dimension-padding-sm, 8px);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+a.postLabel:hover,
+a.postLabel:focus {
+	text-decoration: underline;
+}
+
+/* The picker grid applies img { width: 100%; height: 100%; object-fit: cover }
+   to all images inside the media cell, overriding our 20px avatar size.
+   Restore correct sizing for avatar images in any inert context. */
+:global([inert]) .root img {
+	width: 20px;
+	height: 20px;
+	object-fit: cover;
+}

--- a/projects/packages/premium-analytics/widgets/comments/style.module.css
+++ b/projects/packages/premium-analytics/widgets/comments/style.module.css
@@ -6,50 +6,6 @@
 	overflow: hidden;
 }
 
-/* Segmented view selector: a subtle track above the content, with the active
-   segment raised onto the base surface. Kept a sibling of the content so it
-   stays visible in every widget state. */
-.viewControl {
-	display: flex;
-	flex: 0 0 auto;
-	gap: var(--wpds-dimension-gap-xs);
-	padding: var(--wpds-dimension-padding-xs);
-	margin-block-end: var(--wpds-dimension-padding-sm);
-	background: var(--wpds-color-background-surface-neutral-weak);
-	border-radius: var(--wpds-border-radius-md);
-}
-
-.viewOption {
-	flex: 1 1 0;
-	min-width: 0;
-	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-sm);
-	border: 0;
-	border-radius: var(--wpds-border-radius-sm);
-	background: transparent;
-	color: var(--wpds-color-foreground-interactive-neutral);
-	font-size: var(--wpds-typography-font-size-sm);
-	font-weight: 500;
-	line-height: 1.4;
-	white-space: nowrap;
-	text-overflow: ellipsis;
-	overflow: hidden;
-	cursor: pointer;
-}
-
-.viewOption:hover {
-	color: var(--wpds-color-foreground-interactive-neutral-strong);
-}
-
-.viewOption:focus-visible {
-	outline: 2px solid var(--wpds-color-foreground-interactive-brand);
-	outline-offset: -2px;
-}
-
-.viewOptionActive {
-	background: var(--wpds-color-background-surface-neutral);
-	color: var(--wpds-color-foreground-interactive-neutral-strong);
-}
-
 /* Positioned anchor so WidgetState's overlay (position: absolute; inset: 0)
    resolves against the widget body, not the host frame. */
 .content {

--- a/projects/packages/premium-analytics/widgets/comments/use-comment-views.ts
+++ b/projects/packages/premium-analytics/widgets/comments/use-comment-views.ts
@@ -2,17 +2,13 @@
  * Internal dependencies
  */
 import { useStatsComments } from '@jetpack-premium-analytics/data';
+import type { CommentsView } from './widget';
 import type {
 	StatsCommentsAuthorItem,
 	StatsCommentsGroupItem,
 	StatsCommentsPostItem,
 	StatsCommentsResponse,
 } from '@jetpack-premium-analytics/data';
-
-/**
- * Which of the two Comments views is active.
- */
-export type CommentView = 'authors' | 'posts';
 
 export interface CommentRow {
 	/**
@@ -41,7 +37,7 @@ interface UseCommentViewsArgs {
 	/**
 	 * The active view: comment authors or commented posts.
 	 */
-	view: CommentView;
+	view: CommentsView;
 	/**
 	 * Maximum rows to display; `0` means all.
 	 */

--- a/projects/packages/premium-analytics/widgets/comments/use-comment-views.ts
+++ b/projects/packages/premium-analytics/widgets/comments/use-comment-views.ts
@@ -79,13 +79,17 @@ export default function useCommentViews( { view, max }: UseCommentViewsArgs ): C
 	const group = items.find( item => item.label === view ) as StatsCommentsGroupItem | undefined;
 	const children = group?.children ?? [];
 
+	// Derive the row key from the item's own identity, not its position, so it
+	// stays stable across refetches and can't collide on a repeated label (e.g.
+	// two "Anonymous" authors): posts key on their post id, authors on their
+	// gravatar hash, each falling back to the label when that is missing.
 	const rows: CommentRow[] = children
-		.map( ( child, index ) => {
+		.map( child => {
 			if ( view === 'authors' ) {
 				const author = child as StatsCommentsAuthorItem;
 				const label = toLabel( author.label );
 				return {
-					id: `${ index }-${ label }`,
+					id: author.icon ?? `author-${ label }`,
 					label,
 					value: author.value,
 					avatarUrl: author.icon ?? undefined,
@@ -95,7 +99,7 @@ export default function useCommentViews( { view, max }: UseCommentViewsArgs ): C
 			const post = child as StatsCommentsPostItem;
 			const label = toLabel( post.label );
 			return {
-				id: `${ index }-${ label }`,
+				id: post.id != null ? String( post.id ) : post.link ?? `post-${ label }`,
 				label,
 				value: post.value,
 				link: post.link ?? undefined,

--- a/projects/packages/premium-analytics/widgets/comments/use-comment-views.ts
+++ b/projects/packages/premium-analytics/widgets/comments/use-comment-views.ts
@@ -1,0 +1,120 @@
+/**
+ * Internal dependencies
+ */
+import { useStatsComments } from '@jetpack-premium-analytics/data';
+import type {
+	StatsCommentsAuthorItem,
+	StatsCommentsGroupItem,
+	StatsCommentsPostItem,
+	StatsCommentsResponse,
+} from '@jetpack-premium-analytics/data';
+
+/**
+ * Which of the two Comments views is active.
+ */
+export type CommentView = 'authors' | 'posts';
+
+export interface CommentRow {
+	/**
+	 * Stable React key for the row.
+	 */
+	id: string;
+	/**
+	 * Display label: author name (authors view) or post title (posts view).
+	 */
+	label: string;
+	/**
+	 * Number of comments attributed to this author or post.
+	 */
+	value: number;
+	/**
+	 * Author avatar URL. Set in the authors view only.
+	 */
+	avatarUrl?: string;
+	/**
+	 * External link to the published post. Set in the posts view only.
+	 */
+	link?: string;
+}
+
+interface UseCommentViewsArgs {
+	/**
+	 * The active view: comment authors or commented posts.
+	 */
+	view: CommentView;
+	/**
+	 * Maximum rows to display; `0` means all.
+	 */
+	max: number;
+}
+
+// The normalized item `label` is typed `unknown`; the comments endpoint always
+// yields strings, but coerce defensively so the row shape stays `string`.
+function toLabel( value: unknown ): string {
+	return typeof value === 'string' ? value : String( value );
+}
+
+interface CommentViewsState {
+	data: CommentRow[];
+	isLoading: boolean;
+	isFetching: boolean;
+	isError: boolean;
+	refetch: () => void;
+}
+
+/**
+ * Fetch the Comments report and expose the active view's rows.
+ *
+ * `useStatsComments` returns a single all-time report whose `data[0].items` are
+ * two group rows — one keyed `authors`, one keyed `posts`. This selects the
+ * group matching `view`, maps its children to a flat row shape (attaching the
+ * avatar for authors and the external link for posts), sorts by comment count,
+ * and trims to `max`. The endpoint has no comparison period, so no previous
+ * values are produced.
+ *
+ * @param {UseCommentViewsArgs} args - Hook arguments.
+ * @return The current data/loading/error state for the active view.
+ */
+export default function useCommentViews( { view, max }: UseCommentViewsArgs ): CommentViewsState {
+	const { data, isLoading, isFetching, isError, refetch } = useStatsComments();
+
+	const report = data as StatsCommentsResponse | undefined;
+	const items = report?.data?.[ 0 ]?.items ?? [];
+	const group = items.find( item => item.label === view ) as StatsCommentsGroupItem | undefined;
+	const children = group?.children ?? [];
+
+	const rows: CommentRow[] = children
+		.map( ( child, index ) => {
+			if ( view === 'authors' ) {
+				const author = child as StatsCommentsAuthorItem;
+				const label = toLabel( author.label );
+				return {
+					id: `${ index }-${ label }`,
+					label,
+					value: author.value,
+					avatarUrl: author.icon ?? undefined,
+				};
+			}
+
+			const post = child as StatsCommentsPostItem;
+			const label = toLabel( post.label );
+			return {
+				id: `${ index }-${ label }`,
+				label,
+				value: post.value,
+				link: post.link ?? undefined,
+			};
+		} )
+		.sort( ( a, b ) => b.value - a.value )
+		.slice( 0, max > 0 ? max : undefined );
+
+	return {
+		data: rows,
+		isLoading,
+		isFetching,
+		// Only surface the error state when there is nothing to show, so a
+		// transient refetch failure keeps the current rows visible.
+		isError: rows.length === 0 && isError,
+		refetch,
+	};
+}

--- a/projects/packages/premium-analytics/widgets/comments/use-comment-views.ts
+++ b/projects/packages/premium-analytics/widgets/comments/use-comment-views.ts
@@ -1,4 +1,8 @@
 /**
+ * External dependencies
+ */
+import { useMemo } from '@wordpress/element';
+/**
  * Internal dependencies
  */
 import { useStatsComments } from '@jetpack-premium-analytics/data';
@@ -74,39 +78,44 @@ interface CommentViewsState {
 export default function useCommentViews( { view, max }: UseCommentViewsArgs ): CommentViewsState {
 	const { data, isLoading, isFetching, isError, refetch } = useStatsComments();
 
-	const report = data as StatsCommentsResponse | undefined;
-	const items = report?.data?.[ 0 ]?.items ?? [];
-	const group = items.find( item => item.label === view ) as StatsCommentsGroupItem | undefined;
-	const children = group?.children ?? [];
+	// Memoize on the query's stable `data` reference so the row array keeps a
+	// stable identity across unrelated re-renders; otherwise every render hands
+	// a fresh array to render.tsx and defeats its downstream `useMemo`.
+	const rows: CommentRow[] = useMemo( () => {
+		const report = data as StatsCommentsResponse | undefined;
+		const items = report?.data?.[ 0 ]?.items ?? [];
+		const group = items.find( item => item.label === view ) as StatsCommentsGroupItem | undefined;
+		const children = group?.children ?? [];
 
-	// Derive the row key from the item's own identity, not its position, so it
-	// stays stable across refetches and can't collide on a repeated label (e.g.
-	// two "Anonymous" authors): posts key on their post id, authors on their
-	// gravatar hash, each falling back to the label when that is missing.
-	const rows: CommentRow[] = children
-		.map( child => {
-			if ( view === 'authors' ) {
-				const author = child as StatsCommentsAuthorItem;
-				const label = toLabel( author.label );
+		// Derive the row key from the item's own identity, not its position, so it
+		// stays stable across refetches and can't collide on a repeated label (e.g.
+		// two "Anonymous" authors): posts key on their post id, authors on their
+		// gravatar hash, each falling back to the label when that is missing.
+		return children
+			.map( child => {
+				if ( view === 'authors' ) {
+					const author = child as StatsCommentsAuthorItem;
+					const label = toLabel( author.label );
+					return {
+						id: author.icon ?? `author-${ label }`,
+						label,
+						value: author.value,
+						avatarUrl: author.icon ?? undefined,
+					};
+				}
+
+				const post = child as StatsCommentsPostItem;
+				const label = toLabel( post.label );
 				return {
-					id: author.icon ?? `author-${ label }`,
+					id: post.id != null ? String( post.id ) : post.link ?? `post-${ label }`,
 					label,
-					value: author.value,
-					avatarUrl: author.icon ?? undefined,
+					value: post.value,
+					link: post.link ?? undefined,
 				};
-			}
-
-			const post = child as StatsCommentsPostItem;
-			const label = toLabel( post.label );
-			return {
-				id: post.id != null ? String( post.id ) : post.link ?? `post-${ label }`,
-				label,
-				value: post.value,
-				link: post.link ?? undefined,
-			};
-		} )
-		.sort( ( a, b ) => b.value - a.value )
-		.slice( 0, max > 0 ? max : undefined );
+			} )
+			.sort( ( a, b ) => b.value - a.value )
+			.slice( 0, max > 0 ? max : undefined );
+	}, [ data, view, max ] );
 
 	return {
 		data: rows,

--- a/projects/packages/premium-analytics/widgets/comments/widget.json
+++ b/projects/packages/premium-analytics/widgets/comments/widget.json
@@ -1,0 +1,7 @@
+{
+	"name": "jpa/comments",
+	"title": "Comments",
+	"description": "The authors and posts that receive the most comments on your site.",
+	"category": "stats",
+	"presentation": "framed"
+}

--- a/projects/packages/premium-analytics/widgets/comments/widget.ts
+++ b/projects/packages/premium-analytics/widgets/comments/widget.ts
@@ -1,0 +1,63 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { comment } from '@wordpress/icons';
+import type { WidgetAttributeField } from '@wordpress/widget-primitives';
+
+/**
+ * Which of the two Comments views is shown: comment authors or commented posts.
+ */
+export type CommentsView = 'authors' | 'posts';
+
+export type CommentsAttributes = {
+	/**
+	 * Maximum number of rows to display.
+	 */
+	max?: number;
+	/**
+	 * The view the widget opens on: comment authors or commented posts. Both
+	 * views are always available through the in-widget selector; this is only
+	 * the initial selection.
+	 */
+	view?: CommentsView;
+};
+
+/**
+ * Widget type definition for the Comments widget.
+ *
+ * Ported from the Jetpack Stats "Comments" module. Ranks the site's comment
+ * authors and its most-commented posts and pages by comment count, switchable
+ * through an in-widget "By authors" / "By posts & pages" selector.
+ *
+ * Data: fetched via the PA proxy at `stats/comments` through `useStatsComments`.
+ * The endpoint is all-time and has no comparison period, so the widget ignores
+ * the dashboard date range.
+ */
+export default {
+	name: 'jpa/comments',
+	title: __( 'Comments', 'jetpack-premium-analytics' ),
+	icon: comment,
+	attributes: [
+		{
+			id: 'max',
+			label: __( 'Number of results', 'jetpack-premium-analytics' ),
+			type: 'integer',
+		},
+		{
+			id: 'view',
+			label: __( 'View by', 'jetpack-premium-analytics' ),
+			type: 'text',
+			elements: [
+				{ label: __( 'Authors', 'jetpack-premium-analytics' ), value: 'authors' },
+				{ label: __( 'Posts & pages', 'jetpack-premium-analytics' ), value: 'posts' },
+			],
+		},
+	] as WidgetAttributeField< CommentsAttributes >[],
+	example: {
+		attributes: {
+			max: 10,
+			view: 'authors',
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/comments/widget.ts
+++ b/projects/packages/premium-analytics/widgets/comments/widget.ts
@@ -27,8 +27,9 @@ export type CommentsAttributes = {
  * Widget type definition for the Comments widget.
  *
  * Ported from the Jetpack Stats "Comments" module. Ranks the site's comment
- * authors and its most-commented posts and pages by comment count, switchable
- * through an in-widget "By authors" / "By posts & pages" selector.
+ * authors and its most-commented posts and pages by comment count. The active
+ * view is the `view` attribute (`relevance: 'high'`), so the widget host renders
+ * the "View by" control in the widget header rather than the widget body.
  *
  * Data: fetched via the PA proxy at `stats/comments` through `useStatsComments`.
  * The endpoint is all-time and has no comparison period, so the widget ignores
@@ -52,6 +53,7 @@ export default {
 				{ label: __( 'Authors', 'jetpack-premium-analytics' ), value: 'authors' },
 				{ label: __( 'Posts & pages', 'jetpack-premium-analytics' ), value: 'posts' },
 			],
+			relevance: 'high',
 		},
 	] as WidgetAttributeField< CommentsAttributes >[],
 	example: {

--- a/projects/packages/premium-analytics/widgets/comments/widget.ts
+++ b/projects/packages/premium-analytics/widgets/comments/widget.ts
@@ -16,9 +16,9 @@ export type CommentsAttributes = {
 	 */
 	max?: number;
 	/**
-	 * The view the widget opens on: comment authors or commented posts. Both
-	 * views are always available through the in-widget selector; this is only
-	 * the initial selection.
+	 * The active view: comment authors or commented posts. The host renders
+	 * this as the "View by" header control (the attribute is `relevance:
+	 * 'high'`), so it is not shown in the widget body.
 	 */
 	view?: CommentsView;
 };


### PR DESCRIPTION
## Proposed changes

Ports the Jetpack Stats **Comments** module into a registered Premium Analytics dashboard widget (`jpa/comments`), a sibling of the recently added Shares widget.

**Why**
The dashboard is consolidating Jetpack Stats modules as native widgets. Comments is one of the remaining leaderboard-style modules: it surfaces who comments the most and which posts and pages draw the most discussion, in two switchable views.

**How**
- New self-contained widget under `widgets/comments/` (`package.json`, `widget.json`, `widget.ts`, `render.tsx`, `use-comment-views.ts`, `style.module.css`, story).
- Data comes from the existing `useStatsComments()` hook in `@jetpack-premium-analytics/data` (endpoint `stats/comments`). A widget-local view hook reads the two normalized groups the processor returns (`authors`, `posts`), exposes the active view's rows sorted by comment count, and trims to `max`. No new data-layer code.
- The endpoint is all-time with no comparison period, so the widget never emits `previousValue`/`delta` — comparison `reportParams` render the same as the primary period.
- The active view is the `view` attribute (`relevance: 'high'`), so the widget host renders a **View by** (Authors / Posts & pages) control in the widget header rather than the widget body. Author rows show a name + avatar (`LeaderboardLabel`); post rows are external links to the published post.
- Loading / error / empty states go through `<WidgetState>` (not `WidgetLoadingOverlay`); the empty state uses the `comment` glyph with copy adapted from upstream.

**What**
- Registered widget `jpa/comments`, category `stats`, `presentation: framed`, title "Comments".
- Storybook stories: `Default`, `WithComparison`, `WidgetDashboardWithWidget`, plus `Loading` / `Error` / `Empty` state stories, backed by a new `stats/comments` fixture that populates both authors and posts.

## Does this pull request change what data or activity we track or use?

No. It renders existing Jetpack Stats comments data already available through the Premium Analytics proxy.

## Testing instructions

- `jetpack build --deps packages/premium-analytics` — succeeds; `jpa/comments` appears in `build/widgets/registry.php`.
- In Storybook (`Packages / Premium Analytics / Widgets / Comments`):
  - `Default` / `WithComparison` / `WidgetDashboardWithWidget` render; in the dashboard story the host shows the **View by** header control, and switching Authors ⇄ Posts & pages swaps the avatar leaderboard for the linked-post leaderboard.
  - `Loading` / `Error` / `Empty` render the widget's loading spinner, error state with Retry, and empty state respectively, with no console errors.


https://github.com/user-attachments/assets/fcca3997-8c03-40d4-aca6-d4b9081f5f12

