### PR TITLE
WOOA7S-1500: Port Stats Tags & categories widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1500-tags-categories-widget
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1500-tags-categories-widget
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Premium Analytics: add the Tags & categories Stats widget.

--- a/projects/packages/premium-analytics/packages/icons/src/index.ts
+++ b/projects/packages/premium-analytics/packages/icons/src/index.ts
@@ -11,3 +11,4 @@ export { customer } from './customer';
 export { paymentReturn } from './payment-return';
 export { search } from './search';
 export { payment } from './payment';
+export { tag } from './tag';

--- a/projects/packages/premium-analytics/packages/icons/src/tag/index.tsx
+++ b/projects/packages/premium-analytics/packages/icons/src/tag/index.tsx
@@ -1,0 +1,17 @@
+/**
+ * External dependencies
+ */
+import { SVG, Path } from '@wordpress/primitives';
+
+export const tag = (
+	<SVG width="48" height="48" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+		<Path
+			d="M21.41 11.58l-9-9C12.05 2.22 11.55 2 11 2H4c-1.1 0-2 .9-2 2v7c0 .55.22 1.05.59 1.42l9 9c.36.36.86.58 1.41.58.55 0 1.05-.22 1.41-.59l7-7c.37-.36.59-.86.59-1.41 0-.55-.23-1.06-.59-1.42z"
+			fill="var(--wpds-color-background-surface-neutral-weak, #F0F0F0)"
+		/>
+		<Path
+			d="M5.5 7C4.67 7 4 6.33 4 5.5S4.67 4 5.5 4 7 4.67 7 5.5 6.33 7 5.5 7z"
+			fill="var(--wpds-color-stroke-surface-neutral-weak, #E0E0E0)"
+		/>
+	</SVG>
+);

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/index.ts
@@ -64,6 +64,7 @@ export {
 
 export { mockSearchTermsData, mockSearchTermsComparisonData } from './search-terms';
 export { mockSingleVideoData } from './single-video';
+export { mockTagsData } from './tags';
 export { mockTopAuthorsData, mockTopAuthorsComparisonData } from './top-authors';
 
 export { mockSiteSummary } from './site-summary';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/tags.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/tags.ts
@@ -1,0 +1,74 @@
+/**
+ * Mock data for the Stats `tags` endpoint (drives the "Tags & categories" widget).
+ *
+ * Mirrors the WPCOM `stats/tags` response: a top-level `tags` list where each item
+ * groups one or more tags/categories that share posts, with the group's combined
+ * `views`. Single-member items link straight to their archive; multi-member items
+ * have no combined archive URL and drill down to their members in the widget.
+ *
+ * The fixture intentionally exercises every reviewable case: single categories
+ * (folder icon) and tags (tag icon) that link out, and grouped rows — one mixing
+ * a category with a tag, one combining two categories — that drill down.
+ */
+export const mockTagsData = {
+	date: '2026-06-22',
+	period: 'month',
+	tags: [
+		{
+			tags: [
+				{ type: 'category', name: 'Recipes', link: 'https://example.com/category/recipes/' },
+			],
+			views: 1240,
+		},
+		{
+			tags: [ { type: 'tag', name: 'vegan', link: 'https://example.com/tag/vegan/' } ],
+			views: 980,
+		},
+		{
+			tags: [
+				{ type: 'category', name: 'Desserts', link: 'https://example.com/category/desserts/' },
+				{ type: 'tag', name: 'chocolate', link: 'https://example.com/tag/chocolate/' },
+			],
+			views: 760,
+		},
+		{
+			tags: [ { type: 'tag', name: 'gluten-free', link: 'https://example.com/tag/gluten-free/' } ],
+			views: 645,
+		},
+		{
+			tags: [
+				{ type: 'category', name: 'Breakfast', link: 'https://example.com/category/breakfast/' },
+			],
+			views: 512,
+		},
+		{
+			tags: [
+				{ type: 'category', name: 'Dinner', link: 'https://example.com/category/dinner/' },
+				{
+					type: 'category',
+					name: 'Quick Meals',
+					link: 'https://example.com/category/quick-meals/',
+				},
+			],
+			views: 430,
+		},
+		{
+			tags: [
+				{ type: 'tag', name: 'high-protein', link: 'https://example.com/tag/high-protein/' },
+			],
+			views: 318,
+		},
+		{
+			tags: [ { type: 'tag', name: 'budget', link: 'https://example.com/tag/budget/' } ],
+			views: 254,
+		},
+		{
+			tags: [ { type: 'category', name: 'Snacks', link: 'https://example.com/category/snacks/' } ],
+			views: 187,
+		},
+		{
+			tags: [ { type: 'tag', name: 'meal-prep', link: 'https://example.com/tag/meal-prep/' } ],
+			views: 143,
+		},
+	],
+};

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -48,6 +48,7 @@ import {
 	mockSearchTermsData,
 	mockSearchTermsComparisonData,
 	mockSingleVideoData,
+	mockTagsData,
 	mockTopAuthorsData,
 	mockTopAuthorsComparisonData,
 	mockSiteSummary,
@@ -907,6 +908,10 @@ function routeStatsReport( subPath: string ): unknown {
 			return nextIsComparison( 'stats/top-authors' )
 				? mockTopAuthorsComparisonData
 				: mockTopAuthorsData;
+		case '/tags':
+			// The Stats `tags` endpoint has no comparison period, so the same
+			// primary fixture is returned for every request.
+			return mockTagsData;
 		case '/insights':
 			return mockStatsInsightsData;
 		default:

--- a/projects/packages/premium-analytics/widgets/tags/package.json
+++ b/projects/packages/premium-analytics/widgets/tags/package.json
@@ -1,0 +1,16 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-tags",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/icons": "link:../../packages/icons",
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/element": "8.2.0",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^15.0.0",
+		"@wordpress/ui": "0.17.0",
+		"@wordpress/widget-primitives": "0.2.0"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/tags/render.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/render.tsx
@@ -15,7 +15,7 @@ import { tag as tagIllustration } from '@jetpack-premium-analytics/icons';
 import { useEffect, useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { category, tag as tagGlyph } from '@wordpress/icons';
-import { Icon, Link, Stack, Text } from '@wordpress/ui';
+import { Icon, Link, Stack } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
@@ -65,9 +65,9 @@ function TagLabel( { labelIcon, label, link }: TagLabelProps ) {
 					{ label }
 				</Link>
 			) : (
-				<Text className={ styles.itemLabelText } title={ label }>
+				<span className={ styles.itemLabelText } title={ label }>
 					{ label }
-				</Text>
+				</span>
 			) }
 		</>
 	);
@@ -105,24 +105,25 @@ function TagsInner( { max = 10 }: TagsAttributes ) {
 	const { reportParams } = useWidgetRootContext();
 	const { data, isLoading, isFetching, isError, refetch } = useTagViews( { reportParams, max } );
 
-	// Store only the row id and resolve the row fresh from the current data, so a
-	// background refetch that drops the group cleanly falls back to the top view.
+	// Key the selection on the group's stable label and resolve the row fresh from
+	// the current data, so a background refetch that reorders rows keeps the user
+	// in the drilled-in view, and one that drops the group falls back to the top.
 	const {
-		drillDownItem: selectedId,
+		drillDownItem: selectedLabel,
 		drillDown: selectGroup,
 		resetDrillDown: clearSelection,
 	} = useWidgetDrillDown< string >();
 
 	const selectedGroup = useMemo(
-		() => ( selectedId ? data.find( row => row.id === selectedId ) ?? null : null ),
-		[ data, selectedId ]
+		() => ( selectedLabel ? data.find( row => row.label === selectedLabel ) ?? null : null ),
+		[ data, selectedLabel ]
 	);
 
 	useEffect( () => {
-		if ( selectedId && ! selectedGroup ) {
+		if ( selectedLabel && ! selectedGroup ) {
 			clearSelection();
 		}
-	}, [ selectedId, selectedGroup, clearSelection ] );
+	}, [ selectedLabel, selectedGroup, clearSelection ] );
 
 	const leaderboardData = useMemo< LeaderboardChartData >( () => {
 		const maxValue = Math.max( ...data.map( row => row.value ), 0 );
@@ -142,7 +143,7 @@ function TagsInner( { max = 10 }: TagsAttributes ) {
 				// Grouped rows have no single archive URL, so a click drills into
 				// their members instead. Single tag/category rows link out directly.
 				...( isGroup && {
-					onClick: () => selectGroup( row.id ),
+					onClick: () => selectGroup( row.label ),
 					ariaLabel: sprintf(
 						/* translators: %s is the grouped tags and categories label */
 						__( 'View the tags and categories in %s', 'jetpack-premium-analytics' ),

--- a/projects/packages/premium-analytics/widgets/tags/render.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/render.tsx
@@ -1,0 +1,219 @@
+/**
+ * External dependencies
+ */
+import {
+	LeaderboardChart,
+	WidgetBackLink,
+	WidgetRoot,
+	WidgetState,
+	useWidgetDrillDown,
+	useWidgetRootContext,
+	type LeaderboardChartData,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { tag as tagIllustration } from '@jetpack-premium-analytics/icons';
+import { useEffect, useMemo } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { category, tag as tagGlyph } from '@wordpress/icons';
+import { Icon, Link, Stack, Text } from '@wordpress/ui';
+/**
+ * Internal dependencies
+ */
+import styles from './style.module.css';
+import useTagViews, { type TagChildView } from './use-tag-views';
+import { type TagsAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+
+type TagsRenderAttributes = Partial< ReportParamsFieldAttributes > & TagsAttributes;
+type TagsWidgetProps = WidgetRenderProps< TagsRenderAttributes >;
+
+// The Stats sanitizer marks a category with the `folder` glyph key; every other
+// row is a tag.
+const rowGlyph = ( labelIcon: string ) => ( labelIcon === 'folder' ? category : tagGlyph );
+
+// Icon + label fields shared by the leaderboard rows and the drilled-in members;
+// documented on TagChildView.
+type TagLabelProps = Pick< TagChildView, 'labelIcon' | 'label' | 'link' >;
+
+interface TagGroupMembersProps {
+	/**
+	 * The selected group's individual tags/categories.
+	 */
+	members: TagChildView[];
+}
+
+/**
+ * Icon + label for a single tag/category, shared by the leaderboard rows and the
+ * drilled-in group members. A member with an archive URL renders an external
+ * link; one without renders plain text.
+ *
+ * @param {TagLabelProps} props - The component props.
+ * @return The rendered label.
+ */
+function TagLabel( { labelIcon, label, link }: TagLabelProps ) {
+	return (
+		<>
+			<Icon icon={ rowGlyph( labelIcon ) } size={ 20 } className={ styles.itemIcon } />
+			{ link ? (
+				<Link
+					className={ styles.itemLabelText }
+					href={ link }
+					variant="unstyled"
+					openInNewTab
+					title={ label }
+				>
+					{ label }
+				</Link>
+			) : (
+				<Text className={ styles.itemLabelText } title={ label }>
+					{ label }
+				</Text>
+			) }
+		</>
+	);
+}
+
+/**
+ * Drilled-in view for a grouped row: the individual tags and categories that
+ * share the selected group. The Stats endpoint reports only the group's
+ * combined views, so members are listed as links without their own values.
+ *
+ * @param {TagGroupMembersProps} props - The component props.
+ * @return The rendered member list.
+ */
+function TagGroupMembers( { members }: TagGroupMembersProps ) {
+	return (
+		<Stack direction="column" className={ styles.childList }>
+			{ members.map( member => (
+				<div key={ member.id } className={ styles.childRow }>
+					<TagLabel labelIcon={ member.labelIcon } label={ member.label } link={ member.link } />
+				</div>
+			) ) }
+		</Stack>
+	);
+}
+
+/**
+ * Tags & categories widget inner component. Reads report params from WidgetRoot
+ * context, fetches the ranked tags/categories, and drills grouped rows down to
+ * their members.
+ *
+ * @param {TagsAttributes} attributes - The widget attributes.
+ * @return The rendered widget content.
+ */
+function TagsInner( { max = 10 }: TagsAttributes ) {
+	const { reportParams } = useWidgetRootContext();
+	const { data, isLoading, isFetching, isError, refetch } = useTagViews( { reportParams, max } );
+
+	// Store only the row id and resolve the row fresh from the current data, so a
+	// background refetch that drops the group cleanly falls back to the top view.
+	const {
+		drillDownItem: selectedId,
+		drillDown: selectGroup,
+		resetDrillDown: clearSelection,
+	} = useWidgetDrillDown< string >();
+
+	const selectedGroup = useMemo(
+		() => ( selectedId ? data.find( row => row.id === selectedId ) ?? null : null ),
+		[ data, selectedId ]
+	);
+
+	useEffect( () => {
+		if ( selectedId && ! selectedGroup ) {
+			clearSelection();
+		}
+	}, [ selectedId, selectedGroup, clearSelection ] );
+
+	const leaderboardData = useMemo< LeaderboardChartData >( () => {
+		const maxValue = Math.max( ...data.map( row => row.value ), 0 );
+
+		return data.map( row => {
+			const isGroup = row.children.length > 0;
+
+			return {
+				id: row.id,
+				label: (
+					<Stack align="center" className={ styles.itemLabel }>
+						<TagLabel labelIcon={ row.labelIcon } label={ row.label } link={ row.link } />
+					</Stack>
+				),
+				currentValue: row.value,
+				currentShare: maxValue > 0 ? ( row.value / maxValue ) * 100 : 0,
+				// Grouped rows have no single archive URL, so a click drills into
+				// their members instead. Single tag/category rows link out directly.
+				...( isGroup && {
+					onClick: () => selectGroup( row.id ),
+					ariaLabel: sprintf(
+						/* translators: %s is the grouped tags and categories label */
+						__( 'View the tags and categories in %s', 'jetpack-premium-analytics' ),
+						row.label
+					),
+				} ),
+			};
+		} );
+	}, [ data, selectGroup ] );
+
+	return (
+		<Stack className={ styles.root }>
+			<div className={ styles.content }>
+				{ selectedGroup && (
+					<WidgetBackLink
+						label={ __( 'All tags & categories', 'jetpack-premium-analytics' ) }
+						onClick={ clearSelection }
+					/>
+				) }
+				<WidgetState
+					isLoading={ isLoading }
+					isFetching={ isFetching }
+					isError={ isError }
+					isEmpty={ data.length === 0 }
+					error={ {
+						description: __(
+							"We couldn't load tags & categories. Please try again in a moment.",
+							'jetpack-premium-analytics'
+						),
+						actions: [ { label: __( 'Retry', 'jetpack-premium-analytics' ), onClick: refetch } ],
+					} }
+					empty={ {
+						icon: tagIllustration,
+						description: __(
+							'Learn about your most visited tags & categories to track engaging topics.',
+							'jetpack-premium-analytics'
+						),
+					} }
+				>
+					{ selectedGroup ? (
+						<TagGroupMembers members={ selectedGroup.children } />
+					) : (
+						<LeaderboardChart
+							data={ leaderboardData }
+							withOverlayLabel
+							showLegend={ false }
+							dataFormat={ {
+								type: 'number',
+								options: { useMultipliers: true, decimals: 0 },
+							} }
+						/>
+					) }
+				</WidgetState>
+			</div>
+		</Stack>
+	);
+}
+
+/**
+ * Tags & categories widget: the site's most visited tags and categories for the
+ * selected period, ranked by views. Ported from the Jetpack Stats "Tags &
+ * categories" module. Grouped rows (several tags/categories sharing a post) drill
+ * down to their individual members.
+ *
+ * @param {TagsWidgetProps} props - The widget render props.
+ * @return The rendered Tags & categories widget.
+ */
+export default function Tags( { attributes = {} }: TagsWidgetProps ) {
+	return (
+		<WidgetRoot attributes={ attributes }>
+			<TagsInner max={ attributes.max } />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/tags/stories/tags-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/stories/tags-widget.stories.tsx
@@ -1,0 +1,132 @@
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import TagsRender from '../render';
+import widgetDefinition from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+const TAGS_RENDER_MODULE = 'storybook/tags';
+
+// Pick only the fields that StoryWidgetMetadata accepts; the attribute schema
+// and example arrays are typed differently in WidgetType and cause a type error.
+const storyWidgetType = {
+	name: widgetDefinition.name,
+	title: widgetDefinition.title,
+	icon: widgetDefinition.icon,
+	presentation: 'framed' as const,
+};
+
+interface TagsStoryControls {
+	withComparison: boolean;
+}
+
+function renderTags( { withComparison }: TagsStoryControls ) {
+	return (
+		<TagsRender attributes={ { max: 10, reportParams: getDefaultQueryParams( withComparison ) } } />
+	);
+}
+
+function TagsDashboardRender( props: WidgetRenderProps< unknown > ) {
+	return <TagsRender { ...( props as ComponentProps< typeof TagsRender > ) } />;
+}
+
+// Close-up frame: a white, widget-sized card so the widget reads the way it does
+// as a real dashboard widget (in product the host supplies this frame).
+const withWidgetCanvas: Decorator = Story => (
+	<div
+		style={ {
+			width: '380px',
+			height: '520px',
+			margin: '0 auto',
+			padding: '16px',
+			boxSizing: 'border-box',
+			background: '#fff',
+			border: '1px solid #e0e0e0',
+			borderRadius: '8px',
+			overflow: 'hidden',
+		} }
+	>
+		<Story />
+	</div>
+);
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/Tags',
+	component: TagsRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		withComparison: { control: 'boolean' },
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The "Tags & categories" widget. Displays the site\'s most visited tags and categories for the selected period, ranked by views. Single tags/categories link to their archive; grouped rows (several tags/categories sharing posts) drill down to their members. Ported from the Jetpack Stats Tags & categories module.',
+			},
+		},
+	},
+} satisfies Meta< ComponentProps< typeof TagsRender > & TagsStoryControls >;
+
+export default meta;
+
+type Story = StoryObj< TagsStoryControls >;
+
+export const Default: Story = {
+	render: renderTags,
+	args: { withComparison: false },
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * The date range picker's comparison parameters are passed through, but the Stats
+ * `tags` endpoint has no comparison period, so the widget renders single-period
+ * values only — no period-over-period deltas are shown.
+ */
+export const WithComparison: Story = {
+	render: renderTags,
+	args: { withComparison: true },
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'The `tags` endpoint returns no comparison rows, so no deltas are shown even when the date range picker enables a comparison period.',
+			},
+		},
+	},
+};
+
+interface TagsDashboardStoryProps extends WidgetDashboardWithWidgetControls, TagsStoryControls {}
+
+function TagsDashboardStory( { withComparison, ...dashboardArgs }: TagsDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardArgs }
+			widgetType={ storyWidgetType }
+			renderModule={ TAGS_RENDER_MODULE }
+			renderComponent={ TagsDashboardRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ { max: 10, reportParams: getDefaultQueryParams( withComparison ) } }
+		/>
+	);
+}
+
+export const WidgetDashboardWithWidget: StoryObj< TagsDashboardStoryProps > = {
+	render: args => <TagsDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		withComparison: { control: 'boolean' },
+	},
+};

--- a/projects/packages/premium-analytics/widgets/tags/stories/tags-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/stories/tags-widget.stories.tsx
@@ -1,11 +1,14 @@
-import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+import { getDefaultQueryParams, type PresetType } from '@jetpack-premium-analytics/data';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
-import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import TagsRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
@@ -32,6 +35,16 @@ interface TagsStoryControls {
 function renderTags( { withComparison }: TagsStoryControls ) {
 	return (
 		<TagsRender attributes={ { max: 10, reportParams: getDefaultQueryParams( withComparison ) } } />
+	);
+}
+
+// Renders the widget on a preset distinct from the other stories. The query key
+// derives from the date range, so a unique preset gives the forced-state stories
+// their own cache entry and they hit the mock fresh instead of reading another
+// story's cached success from the shared query client.
+function renderTagsOnPreset( preset: PresetType ) {
+	return (
+		<TagsRender attributes={ { max: 10, reportParams: getDefaultQueryParams( false, preset ) } } />
 	);
 }
 
@@ -102,6 +115,50 @@ export const WithComparison: Story = {
 					'The `tags` endpoint returns no comparison rows, so no deltas are shown even when the date range picker enables a comparison period.',
 			},
 		},
+	},
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderTagsOnPreset( 'last-90-days' ),
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'stats/tags', 'loading' );
+		return () => setReportMockState( 'stats/tags', null );
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: () => renderTagsOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'stats/tags', 'error' );
+		return () => setReportMockState( 'stats/tags', null );
+	},
+};
+
+/**
+ * Resolved with no rows: the widget shows its empty state (the neutral tag glyph
+ * and "Learn about your most visited tags & categories to track engaging topics.").
+ */
+export const Empty: Story = {
+	render: () => renderTagsOnPreset( 'last-365-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'stats/tags', 'empty' );
+		return () => setReportMockState( 'stats/tags', null );
 	},
 };
 

--- a/projects/packages/premium-analytics/widgets/tags/stories/tags-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/stories/tags-widget.stories.tsx
@@ -1,4 +1,4 @@
-import { getDefaultQueryParams, type PresetType } from '@jetpack-premium-analytics/data';
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
 import {
 	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
@@ -38,14 +38,16 @@ function renderTags( { withComparison }: TagsStoryControls ) {
 	);
 }
 
-// Renders the widget on a preset distinct from the other stories. The query key
-// derives from the date range, so a unique preset gives the forced-state stories
-// their own cache entry and they hit the mock fresh instead of reading another
-// story's cached success from the shared query client.
-function renderTagsOnPreset( preset: PresetType ) {
-	return (
-		<TagsRender attributes={ { max: 10, reportParams: getDefaultQueryParams( false, preset ) } } />
-	);
+// Renders the widget with a distinct `max` so each forced-state story gets its
+// own cache entry. The `stats/tags` query key collapses the date range to just
+// `{ date, max }` (the range's end date), so every "last N days" preset ending
+// today resolves to the SAME key — a distinct preset would NOT isolate these
+// stories (unlike date-range-keyed widgets). `max` IS in the key, and it doesn't
+// change what a loading/error/empty state renders, so it is the reliable
+// isolator: without it the Loading story's never-resolving query would poison
+// Default (and Empty/Error would leave cached rows) on same-tab story switches.
+function renderTagsWithMax( max: number ) {
+	return <TagsRender attributes={ { max, reportParams: getDefaultQueryParams( false ) } } />;
 }
 
 function TagsDashboardRender( props: WidgetRenderProps< unknown > ) {
@@ -123,7 +125,7 @@ export const WithComparison: Story = {
  * mock is forced to never resolve for the duration of this story.
  */
 export const Loading: Story = {
-	render: () => renderTagsOnPreset( 'last-90-days' ),
+	render: () => renderTagsWithMax( 9 ),
 	// Kept off the shared autodocs page: the mock override is keyed by path, so it
 	// would otherwise force the sibling stories on that page into the same state.
 	tags: [ '!autodocs' ],
@@ -139,7 +141,7 @@ export const Loading: Story = {
  * re-runs the query — still mocked as failing while this story is active).
  */
 export const Error: Story = {
-	render: () => renderTagsOnPreset( 'last-7-days' ),
+	render: () => renderTagsWithMax( 8 ),
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {
@@ -153,7 +155,7 @@ export const Error: Story = {
  * and "Learn about your most visited tags & categories to track engaging topics.").
  */
 export const Empty: Story = {
-	render: () => renderTagsOnPreset( 'last-365-days' ),
+	render: () => renderTagsWithMax( 7 ),
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {

--- a/projects/packages/premium-analytics/widgets/tags/style.module.css
+++ b/projects/packages/premium-analytics/widgets/tags/style.module.css
@@ -1,0 +1,61 @@
+.root {
+	container-type: inline-size;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	overflow: hidden;
+}
+
+/* Positioned anchor so the WidgetState busy overlay (position: absolute;
+   inset: 0) resolves against the widget body, not the host frame. */
+.content {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	flex: 1 1 0;
+	min-height: 0;
+}
+
+/* Icon + label row for the leaderboard. min-height keeps a stable 36px row for
+   both single tag/category rows and grouped (drill-down) rows. */
+.itemLabel {
+	gap: var(--wpds-dimension-padding-sm, 8px);
+	min-height: 36px;
+	min-width: 0;
+	padding-inline: var(--wpds-dimension-padding-sm, 8px);
+	overflow: hidden;
+}
+
+/* Keep the category/tag glyph from shrinking when the label is long. */
+.itemIcon {
+	flex-shrink: 0;
+}
+
+.itemLabelText {
+	overflow: hidden;
+	white-space: nowrap;
+	text-overflow: ellipsis;
+}
+
+a.itemLabelText:hover,
+a.itemLabelText:focus {
+	text-decoration: underline;
+}
+
+/* Drilled-in group members: a scrollable list of the individual
+   tags/categories. The Stats endpoint reports no per-member views, so these
+   rows are links only, without leaderboard bars. */
+.childList {
+	flex: 1 1 0;
+	min-height: 0;
+	overflow-y: auto;
+}
+
+.childRow {
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-padding-sm, 8px);
+	min-height: 36px;
+	padding-inline: var(--wpds-dimension-padding-sm, 8px);
+	overflow: hidden;
+}

--- a/projects/packages/premium-analytics/widgets/tags/use-tag-views.ts
+++ b/projects/packages/premium-analytics/widgets/tags/use-tag-views.ts
@@ -1,0 +1,138 @@
+/**
+ * Internal dependencies
+ */
+import { useStatsTags } from '@jetpack-premium-analytics/data';
+import type {
+	ReportParams,
+	StatsNormalizedReport,
+	StatsTagsItem,
+} from '@jetpack-premium-analytics/data';
+
+/**
+ * A single tag or category grouped under a parent row. Grouped rows have no
+ * combined archive URL, so their members are surfaced here as individual
+ * links the user can drill into. The Stats endpoint reports only the group's
+ * combined views, so children carry no per-member value.
+ */
+export interface TagChildView {
+	/**
+	 * Stable row id.
+	 */
+	id: string;
+	/**
+	 * Member name (tag or category).
+	 */
+	label: string;
+	/**
+	 * `folder` for a category, otherwise the tag glyph key.
+	 */
+	labelIcon: string;
+	/**
+	 * Archive URL for this member, or `null` when unavailable.
+	 */
+	link: string | null;
+}
+
+/**
+ * A leaderboard row for the Tags & categories widget. A row is either a single
+ * tag/category (with an archive `link` and no `children`) or a group of several
+ * tags/categories sharing a post (`link: null`, with `children` to drill into).
+ */
+export interface TagView {
+	/**
+	 * Stable row id.
+	 */
+	id: string;
+	/**
+	 * Joined display label (e.g. `Recipes, Vegan`).
+	 */
+	label: string;
+	/**
+	 * Icon for the row: the first member's glyph (`folder` for a category).
+	 */
+	labelIcon: string;
+	/**
+	 * Views for this row (the group's combined views when grouped).
+	 */
+	value: number;
+	/**
+	 * Archive URL for a single tag/category, or `null` for a grouped row.
+	 */
+	link: string | null;
+	/**
+	 * Grouped members to drill into; empty for a single tag/category row.
+	 */
+	children: TagChildView[];
+}
+
+interface UseTagViewsArgs {
+	/**
+	 * PA ReportParams from WidgetRoot context.
+	 */
+	reportParams: ReportParams;
+	/**
+	 * Maximum rows to display; `0` means all.
+	 */
+	max: number;
+}
+
+interface TagViewsState {
+	data: TagView[];
+	isLoading: boolean;
+	isFetching: boolean;
+	isError: boolean;
+	refetch: () => void;
+}
+
+/**
+ * Fetch the most visited tags and categories for the Tags & categories widget
+ * via the shared Stats data layer.
+ *
+ * Delegates fetching, caching, and normalization to `useStatsTags` from
+ * `@jetpack-premium-analytics/data`, then maps the normalized rows onto the
+ * leaderboard shape and trims to `max`. The `stats/tags` endpoint is a single
+ * period query with no comparison, so rows carry current-period views only.
+ *
+ * @param {UseTagViewsArgs} args - Hook arguments.
+ * @return The current data/loading/error state.
+ */
+export default function useTagViews( { reportParams, max }: UseTagViewsArgs ): TagViewsState {
+	const { data, isLoading, isFetching, isError, refetch } = useStatsTags( {
+		...reportParams,
+		max,
+	} );
+
+	const report = data as StatsNormalizedReport< StatsTagsItem > | undefined;
+	const items = ( report?.data?.[ 0 ]?.items ?? [] )
+		.slice( 0, max > 0 ? max : undefined )
+		.map( ( item, index ): TagView => {
+			const children = ( item.children ?? [] ).map(
+				( child, childIndex ): TagChildView => ( {
+					id: `${ index }-${ childIndex }-${ child.label }`,
+					label: child.label,
+					labelIcon: child.labelIcon,
+					link: child.link,
+				} )
+			);
+
+			return {
+				id: `${ index }-${ item.labelText }`,
+				label: item.labelText,
+				labelIcon: item.label[ 0 ]?.labelIcon ?? '',
+				value: item.value,
+				link: item.link,
+				children,
+			};
+		} );
+
+	return {
+		data: items,
+		isLoading,
+		isFetching,
+		// The Stats query carries `placeholderData: previousData => previousData`, so
+		// keep showing prior rows on a transient refetch failure and only surface the
+		// error when there's nothing to show.
+		isError: items.length === 0 && isError,
+		refetch,
+	};
+}

--- a/projects/packages/premium-analytics/widgets/tags/use-tag-views.ts
+++ b/projects/packages/premium-analytics/widgets/tags/use-tag-views.ts
@@ -1,4 +1,8 @@
 /**
+ * External dependencies
+ */
+import { useMemo } from '@wordpress/element';
+/**
  * Internal dependencies
  */
 import { useStatsTags } from '@jetpack-premium-analytics/data';
@@ -102,28 +106,40 @@ export default function useTagViews( { reportParams, max }: UseTagViewsArgs ): T
 		max,
 	} );
 
-	const report = data as StatsNormalizedReport< StatsTagsItem > | undefined;
-	const items = ( report?.data?.[ 0 ]?.items ?? [] )
-		.slice( 0, max > 0 ? max : undefined )
-		.map( ( item, index ): TagView => {
-			const children = ( item.children ?? [] ).map(
-				( child, childIndex ): TagChildView => ( {
-					id: `${ index }-${ childIndex }-${ child.label }`,
-					label: child.label,
-					labelIcon: child.labelIcon,
-					link: child.link,
-				} )
-			);
+	// Memoize on the query's stable `data` reference so the row array keeps a
+	// stable identity across unrelated re-renders; otherwise every render hands a
+	// fresh array to render.tsx and defeats its downstream memos and drill-down
+	// effect.
+	const items = useMemo< TagView[] >( () => {
+		const report = data as StatsNormalizedReport< StatsTagsItem > | undefined;
 
-			return {
-				id: `${ index }-${ item.labelText }`,
-				label: item.labelText,
-				labelIcon: item.label[ 0 ]?.labelIcon ?? '',
-				value: item.value,
-				link: item.link,
-				children,
-			};
-		} );
+		return ( report?.data?.[ 0 ]?.items ?? [] )
+			.slice( 0, max > 0 ? max : undefined )
+			.map( ( item ): TagView => {
+				// Key on the row's own identity, not its position, so keys stay stable
+				// across refetches that reorder or drop rows: a single tag/category
+				// keys on its archive URL, a grouped row on its combined label (which
+				// the drill-down already treats as the row's unique id).
+				const parentId = item.link ?? item.labelText;
+				const children = ( item.children ?? [] ).map(
+					( child ): TagChildView => ( {
+						id: child.link ?? `${ parentId }-${ child.label }`,
+						label: child.label,
+						labelIcon: child.labelIcon,
+						link: child.link,
+					} )
+				);
+
+				return {
+					id: parentId,
+					label: item.labelText,
+					labelIcon: item.label[ 0 ]?.labelIcon ?? '',
+					value: item.value,
+					link: item.link,
+					children,
+				};
+			} );
+	}, [ data, max ] );
 
 	return {
 		data: items,

--- a/projects/packages/premium-analytics/widgets/tags/widget.json
+++ b/projects/packages/premium-analytics/widgets/tags/widget.json
@@ -1,0 +1,7 @@
+{
+	"name": "jpa/tags",
+	"title": "Tags & categories",
+	"description": "Your most visited tags and categories, ranked by views.",
+	"category": "stats",
+	"presentation": "framed"
+}

--- a/projects/packages/premium-analytics/widgets/tags/widget.ts
+++ b/projects/packages/premium-analytics/widgets/tags/widget.ts
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { tag } from '@wordpress/icons';
+import type { WidgetAttributeField } from '@wordpress/widget-primitives';
+
+export type TagsAttributes = {
+	/**
+	 * Maximum number of rows to display.
+	 */
+	max?: number;
+};
+
+/**
+ * Widget type definition for the Tags & categories widget.
+ *
+ * Ported from the Jetpack Stats "Tags & categories" module. Lists the site's
+ * most visited tags and categories for the selected period, ranked by views.
+ *
+ * Data: read from the `stats/tags` endpoint via `useStatsTags`. A row can group
+ * several tags/categories that share a post; those grouped rows have no single
+ * archive URL and drill down to their individual members instead.
+ */
+export default {
+	name: 'jpa/tags',
+	title: __( 'Tags & categories', 'jetpack-premium-analytics' ),
+	icon: tag,
+	attributes: [
+		{
+			id: 'max',
+			label: __( 'Number of results', 'jetpack-premium-analytics' ),
+			type: 'integer',
+		},
+	] as WidgetAttributeField< TagsAttributes >[],
+	example: {
+		attributes: {
+			max: 10,
+		},
+	},
+};


### PR DESCRIPTION
Fixes WOOA7S-1500

## Proposed changes

**Why**

Premium Analytics is porting the Jetpack Stats modules into first-class dashboard widgets. The "Tags & categories" module — the site's most visited tags and categories for the selected period — was still missing from the dashboard.

**How**

- New registered widget at `widgets/tags/` (`jpa/tags`), composed from the widgets-toolkit primitives following the current `<WidgetState>` + view-hook contract (mirrors `widgets/search-terms/`).
- Data comes from the existing `useStatsTags()` hook (`stats/tags` endpoint) via a widget-local `use-tag-views` hook that maps the normalized report onto leaderboard rows and trims to `max`. The endpoint is period-scoped, so the inner component reads `reportParams` from `useWidgetRootContext()`. It is a single-period query with no comparison, so no period-over-period deltas are fabricated.
- Rows are ranked by views in a `<LeaderboardChart>`. Categories and tags are distinguished by icon (folder vs tag). A single tag/category links out to its archive; a grouped row (several tags/categories sharing posts, which has no combined archive URL) drills down via `useWidgetDrillDown` + `WidgetBackLink` to a list of its members as individual links.
- Loading / error / empty states render through `<WidgetState>`. The empty state uses a new `tag` glyph added to `@jetpack-premium-analytics/icons`, with copy adapted from the upstream Stats module.
- Storybook: `Default`, `WithComparison` (documents that the endpoint returns no comparison rows, so no deltas show), and `WidgetDashboardWithWidget`. Adds a `stats/tags` fixture wired into `routeStatsReport()`; the fixture includes single category/tag rows plus grouped rows so the drill-down path is reviewable.

**What**

- Adds `widgets/tags/` (`widget.json`, `widget.ts`, `render.tsx`, `use-tag-views.ts`, `style.module.css`, stories).
- Adds a `tag` icon to `packages/icons`.
- Adds a `stats/tags` Storybook mock fixture and wires it into the report-mock middleware.
- Adds a changelog entry.

## Related product discussion/links

- WOOA7S-1500

## Does this pull request change what data or activity we track or use?

No. It reuses the existing Stats `tags` proxy endpoint through the shared data hook; no new tracking or data collection.

## Testing instructions

- Build the package: `jetpack build --deps packages/premium-analytics`, and confirm `jpa/tags` appears in `build/widgets/registry.php`.
- Run Storybook for the Premium Analytics package and open **Packages/Premium Analytics/Widgets/Tags**.
- Confirm the `Default` story renders the leaderboard ranked by views, with category (folder) vs tag icons and external-link rows.
- Click a grouped row (e.g. "Dinner, Quick Meals") and confirm it drills down to its members with a "← All tags & categories" back link; click the back link to return.
- Confirm `WithComparison` renders the same single-period values with no fabricated deltas.
- Confirm `WidgetDashboardWithWidget` renders the widget framed by the dashboard host (title + tag icon in the header).


https://github.com/user-attachments/assets/99c1c82f-0408-4f0a-a5e2-230d15df0f26

