### PR TITLE
Podcast: release to self-hosted

### DIFF
--- a/projects/plugins/jetpack/changelog/remove-podcast-feature-filter
+++ b/projects/plugins/jetpack/changelog/remove-podcast-feature-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Podcast: release Podcast to self-hosted Jetpack sites. Removing the jetpack_podcast_for_the_world gate makes the module available and auto-activating everywhere, not just Simple and Atomic.

--- a/projects/plugins/jetpack/changelog/remove-podcast-feature-filter
+++ b/projects/plugins/jetpack/changelog/remove-podcast-feature-filter
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-Podcast: release Podcast to self-hosted Jetpack sites. Removing the jetpack_podcast_for_the_world gate makes the module available and auto-activating everywhere, not just Simple and Atomic.
+Podcast: Release Podcast to self-hosted sites, enabled by default on new installations and available but disabled on existing installations.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -693,8 +693,6 @@ class Jetpack {
 		add_filter( 'jetpack_get_default_modules', array( $this, 'filter_default_modules' ) );
 		add_filter( 'jetpack_get_default_modules', array( $this, 'handle_deprecated_modules' ), 99 );
 
-		add_filter( 'jetpack_get_available_modules', array( $this, 'filter_available_modules_podcast' ) );
-
 		add_action(
 			'plugins_loaded',
 			function () {
@@ -2342,34 +2340,6 @@ class Jetpack {
 			if ( $block_option ) {
 				unset( $modules[ $block_key ] );
 			}
-		}
-
-		return $modules;
-	}
-
-	/**
-	 * Hides the Podcast module unless it has been explicitly opted in for the
-	 * whole world via the `jetpack_podcast_for_the_world` filter.
-	 *
-	 * Keeps the module out of the available list (and therefore out of the
-	 * default/auto-activate list and My Jetpack) until it is ready to ship,
-	 * so there is no trace of it when the filter is false.
-	 *
-	 * @uses jetpack_get_available_modules filter
-	 * @param array $modules Array of available Jetpack modules, keyed by slug.
-	 * @return array
-	 */
-	public function filter_available_modules_podcast( $modules ) {
-		/**
-		 * Expose the Podcast module to self-hosted sites. While false the module
-		 * is hidden from the available list, so it can't be activated.
-		 *
-		 * @since 16.0
-		 *
-		 * @param bool $enabled Whether to expose the Podcast module. Default false.
-		 */
-		if ( ! apply_filters( 'jetpack_podcast_for_the_world', false ) ) {
-			unset( $modules['podcast'] );
 		}
 
 		return $modules;

--- a/projects/plugins/jetpack/modules/podcast.php
+++ b/projects/plugins/jetpack/modules/podcast.php
@@ -16,6 +16,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit( 0 );
 }
 
+// Podcast intentionally omits module-introduction metadata. This keeps it out
+// of version-ranged upgrade activation for existing sites, while Auto Activate
+// enables it when a new installation loads the complete default module list.
+
 // Core (feed, settings, block) is local WordPress — no connection needed.
 // Loading is wired in Jetpack::late_initialization() (not here) so it also
 // covers disconnected sites, which load_modules() skips.

--- a/projects/plugins/jetpack/tests/php/Get_Modules_Test.php
+++ b/projects/plugins/jetpack/tests/php/Get_Modules_Test.php
@@ -83,22 +83,6 @@ class Get_Modules_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Ensure Podcast follows the intended default activation rollout.
-	 */
-	public function test_podcast_default_activation_rollout() {
-		$this->assertContains(
-			'podcast',
-			Jetpack::get_default_modules(),
-			'Podcast should be enabled by default on new installations.'
-		);
-		$this->assertNotContains(
-			'podcast',
-			Jetpack::get_default_modules( '1.1', JETPACK__VERSION ),
-			'Podcast should not be enabled by a version-ranged upgrade on existing installations.'
-		);
-	}
-
-	/**
 	 * Test
 	 *
 	 * @dataProvider get_test_connection_filters_data

--- a/projects/plugins/jetpack/tests/php/Get_Modules_Test.php
+++ b/projects/plugins/jetpack/tests/php/Get_Modules_Test.php
@@ -55,6 +55,7 @@ class Get_Modules_Test extends WP_UnitTestCase {
 			'notes',
 			'photon-cdn',
 			'photon',
+			'podcast',
 			'post-by-email',
 			'protect',
 			'publicize',
@@ -79,6 +80,22 @@ class Get_Modules_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( asort( $expected_modules ), asort( self::$all_modules ) );
+	}
+
+	/**
+	 * Ensure Podcast follows the intended default activation rollout.
+	 */
+	public function test_podcast_default_activation_rollout() {
+		$this->assertContains(
+			'podcast',
+			Jetpack::get_default_modules(),
+			'Podcast should be enabled by default on new installations.'
+		);
+		$this->assertNotContains(
+			'podcast',
+			Jetpack::get_default_modules( '1.1', JETPACK__VERSION ),
+			'Podcast should not be enabled by a version-ranged upgrade on existing installations.'
+		);
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/changelog/remove-podcast-availability-filter
+++ b/projects/plugins/wpcomsh/changelog/remove-podcast-availability-filter
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Remove an obsolete Podcast availability filter while retaining the temporary Atomic activation-state migration.

--- a/projects/plugins/wpcomsh/changelog/remove-podcast-availability-filter
+++ b/projects/plugins/wpcomsh/changelog/remove-podcast-availability-filter
@@ -1,3 +1,4 @@
 Significance: patch
 Type: changed
-Comment: Remove an obsolete Podcast availability filter while retaining the temporary Atomic activation-state migration.
+
+Podcast: Remove the obsolete availability filter while retaining the temporary Atomic activation-state migration.

--- a/projects/plugins/wpcomsh/feature-plugins/podcast.php
+++ b/projects/plugins/wpcomsh/feature-plugins/podcast.php
@@ -2,22 +2,17 @@
 /**
  * Turn the Jetpack Podcast module on for Atomic sites.
  *
- * Podcast ships as a Jetpack module that Jetpack hides on self-hosted sites
- * until go-live. On Atomic we opt in early and force the module active so every
- * site hydrates its stored `jetpack_active_modules` setting — mirroring today's
- * always-on behavior. Removing this file at self-hosted go-live leaves the
- * hydrated setting in place, so sites stay on but the module becomes
- * user-toggleable.
+ * Podcast is available globally as a Jetpack module. Atomic temporarily forces
+ * the module active so sites persist it in their `jetpack_active_modules`
+ * setting as they receive requests, mirroring the previous always-on behavior.
+ * The force-activation hook can be removed after the hydration window; the
+ * stored setting will keep Podcast enabled while making it user-toggleable.
  *
  * @package wpcomsh
  */
 
-// Opt Atomic into the module: un-hides it, and new sites pick it up via its
-// `Auto Activate` header.
-add_filter( 'jetpack_podcast_for_the_world', '__return_true' );
-
 /**
- * Force Podcast active so every Atomic site hydrates its stored module setting.
+ * Force Podcast active while Atomic sites hydrate their stored module setting.
  *
  * @return void
  */

--- a/projects/plugins/wpcomsh/tests/WpcomshLoadedTest.php
+++ b/projects/plugins/wpcomsh/tests/WpcomshLoadedTest.php
@@ -26,11 +26,4 @@ class WpcomshLoadedTest extends WP_UnitTestCase {
 		$this->assertTrue( class_exists( 'Jetpack_Fonts_Typekit' ), 'vendor/automattic/custom-fonts-typekit not loaded' );
 		$this->assertTrue( function_exists( 'wpcom_media_video_styles' ), 'vendor/automattic/text-media-widget-styles not loaded' );
 	}
-
-	/**
-	 * Test that Atomic sites continue hydrating the Podcast module state.
-	 */
-	public function test_podcast_activation_hydration_hook_loaded() {
-		$this->assertSame( 0, has_action( 'init', 'wpcomsh_hydrate_podcast_module' ) );
-	}
 }

--- a/projects/plugins/wpcomsh/tests/WpcomshLoadedTest.php
+++ b/projects/plugins/wpcomsh/tests/WpcomshLoadedTest.php
@@ -26,4 +26,11 @@ class WpcomshLoadedTest extends WP_UnitTestCase {
 		$this->assertTrue( class_exists( 'Jetpack_Fonts_Typekit' ), 'vendor/automattic/custom-fonts-typekit not loaded' );
 		$this->assertTrue( function_exists( 'wpcom_media_video_styles' ), 'vendor/automattic/text-media-widget-styles not loaded' );
 	}
+
+	/**
+	 * Test that Atomic sites continue hydrating the Podcast module state.
+	 */
+	public function test_podcast_activation_hydration_hook_loaded() {
+		$this->assertSame( 0, has_action( 'init', 'wpcomsh_hydrate_podcast_module' ) );
+	}
 }


### PR DESCRIPTION
## Proposed changes

Makes the Podcast module available and auto-activating on all Jetpack sites (Simple, Atomic, and self-hosted) by removing the `jetpack_podcast_for_the_world` availability gate from the Jetpack plugin.

* `class.jetpack.php` — remove `filter_available_modules_podcast()` and its `jetpack_get_available_modules` registration. With the gate gone, the module's `Auto Activate: Yes` header handles activation everywhere.

**Deliberately NOT in this PR — deploy ordering.** The matching wpcomsh cleanup (removing the now-redundant `jetpack_podcast_for_the_world` opt-in from `feature-plugins/podcast.php`) is split into a follow-up that must ship **only after this Jetpack change is live on Atomic**.

Why: Jetpack computes active modules as `active ∩ available` (`Modules::get_active()`), and today's Jetpack still prunes `podcast` from *available* when the flag is false. If new wpcomsh — which would stop setting the flag — reaches an Atomic site *before* this Jetpack change, Podcast gets intersected out of the active set (an already-live product goes dark), and the force-activate hydration can't rescue it because `activate_module()` refuses an unavailable module. Shipping Jetpack first (this PR) is safe; the reverse is not. Leaving the wpcomsh opt-in in place during the transition is harmless once this lands — the filter it targets no longer exists, so it's a no-op.

## Related product discussion/links

* Final go-live step for the "Podcast — make it a proper Jetpack feature" project (PODS-183).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build Jetpack from this branch.
* On a **self-hosted** Jetpack site: confirm Podcast appears as a module, auto-activates, and its admin menu shows.
* On **Atomic** (current wpcomsh still setting the opt-in): confirm Podcast stays active with no regression and no duplicate admin submenu.
* On **Simple**: confirm no change.
* Confirm `filter_available_modules_podcast` and the `jetpack_podcast_for_the_world` gate are gone from the Jetpack plugin.
