### PR TITLE
Premium Analytics: Surface external API errors in local CSV export endpoints

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-pa-csv-export-external-api-errors
+++ b/projects/packages/premium-analytics/changelog/fix-pa-csv-export-external-api-errors
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+CSV exports: Surface external API error details.

--- a/projects/packages/premium-analytics/src/Reports/Export/class-report-data-fetcher.php
+++ b/projects/packages/premium-analytics/src/Reports/Export/class-report-data-fetcher.php
@@ -20,6 +20,7 @@ use Automattic\Jetpack\PremiumAnalytics\Reports\Export\Support\Logger_Trait;
 use Automattic\Jetpack\PremiumAnalytics\Reports\Export\Support\Utilities;
 use WP_Error;
 use WP_REST_Request;
+use WP_REST_Response;
 
 /**
  * Data Fetcher class for retrieving report data.
@@ -469,13 +470,12 @@ class Report_Data_Fetcher {
 		}
 
 		// Check if the response has error status (API returned error).
-		if ( isset( $data['data']['status'] ) && $data['data']['status'] >= 400 ) {
-			$message = $data['message'] ?? 'Unknown error from API';
-			return new WP_Error(
-				'api_error',
-				$message,
-				array( 'status' => $data['data']['status'] )
-			);
+		if (
+			isset( $data['data']['status'] )
+			&& is_numeric( $data['data']['status'] )
+			&& (int) $data['data']['status'] >= 400
+		) {
+			return $this->build_external_api_error( $response );
 		}
 
 		return $data;
@@ -488,21 +488,31 @@ class Report_Data_Fetcher {
 	 * payloads represented as stdClass. Preserve the external details in data while
 	 * keeping a consistent local error message for the CSV export route.
 	 *
-	 * @param \WP_REST_Response $response Error response from the local proxy route.
+	 * @since $$next-version$$
+	 *
+	 * @param WP_REST_Response $response Response containing an external API error.
 	 * @return WP_Error Normalized external API error.
 	 */
-	private function build_external_api_error( \WP_REST_Response $response ): WP_Error {
+	private function build_external_api_error( WP_REST_Response $response ): WP_Error {
 		$data = $this->normalize_response_data( $response->get_data() );
 		if ( is_wp_error( $data ) ) {
 			return $data;
 		}
 
-		$status           = (int) $response->get_status();
+		$response_status  = (int) $response->get_status();
+		$status           = $response_status >= 400 ? $response_status : 500;
 		$external_code    = null;
 		$external_message = null;
 
 		if ( is_array( $data ) ) {
-			if ( isset( $data['data']['status'] ) ) {
+			// A real HTTP error status is authoritative. Only use an embedded status when the
+			// transport succeeded but the response body represents an API failure.
+			if (
+				$response_status < 400
+				&& isset( $data['data']['status'] )
+				&& is_numeric( $data['data']['status'] )
+				&& (int) $data['data']['status'] >= 400
+			) {
 				$status = (int) $data['data']['status'];
 			}
 
@@ -519,11 +529,11 @@ class Report_Data_Fetcher {
 			'status' => $status > 0 ? $status : 500,
 		);
 
-		if ( null !== $external_message && '' !== $external_message ) {
+		if ( null !== $external_message ) {
 			$error_data['message'] = $external_message;
 		}
 
-		if ( null !== $external_code && '' !== $external_code ) {
+		if ( null !== $external_code ) {
 			$error_data['external_code'] = $external_code;
 		}
 

--- a/projects/packages/premium-analytics/src/Reports/Export/class-report-data-fetcher.php
+++ b/projects/packages/premium-analytics/src/Reports/Export/class-report-data-fetcher.php
@@ -516,7 +516,7 @@ class Report_Data_Fetcher {
 		}
 
 		$error_data = array(
-			'status' => $status ?: 500,
+			'status' => $status > 0 ? $status : 500,
 		);
 
 		if ( null !== $external_message && '' !== $external_message ) {

--- a/projects/packages/premium-analytics/src/Reports/Export/class-report-data-fetcher.php
+++ b/projects/packages/premium-analytics/src/Reports/Export/class-report-data-fetcher.php
@@ -291,11 +291,20 @@ class Report_Data_Fetcher {
 	 * @return bool True when the API rejected the fields parameter.
 	 */
 	private function is_invalid_fields_error( WP_Error $error ): bool {
-		if ( 'rest_invalid_param' !== $error->get_error_code() ) {
-			return false;
+		$error_code = $error->get_error_code();
+		$data       = $error->get_error_data();
+
+		if (
+			'external_api_error' === $error_code
+			&& is_array( $data )
+			&& isset( $data['external_code'] )
+		) {
+			$error_code = $data['external_code'];
 		}
 
-		$data = $error->get_error_data();
+		if ( 'rest_invalid_param' !== $error_code ) {
+			return false;
+		}
 
 		return is_array( $data ) && isset( $data['params']['fields'] );
 	}
@@ -503,17 +512,22 @@ class Report_Data_Fetcher {
 		$status           = $response_status >= 400 ? $response_status : 500;
 		$external_code    = null;
 		$external_message = null;
+		$external_params  = null;
 
 		if ( is_array( $data ) ) {
+			$external_data = isset( $data['data'] ) && is_array( $data['data'] )
+				? $data['data']
+				: array();
+
 			// A real HTTP error status is authoritative. Only use an embedded status when the
 			// transport succeeded but the response body represents an API failure.
 			if (
 				$response_status < 400
-				&& isset( $data['data']['status'] )
-				&& is_numeric( $data['data']['status'] )
-				&& (int) $data['data']['status'] >= 400
+				&& isset( $external_data['status'] )
+				&& is_numeric( $external_data['status'] )
+				&& (int) $external_data['status'] >= 400
 			) {
-				$status = (int) $data['data']['status'];
+				$status = (int) $external_data['status'];
 			}
 
 			if ( isset( $data['code'] ) && is_scalar( $data['code'] ) ) {
@@ -522,6 +536,10 @@ class Report_Data_Fetcher {
 
 			if ( isset( $data['message'] ) && is_scalar( $data['message'] ) ) {
 				$external_message = (string) $data['message'];
+			}
+
+			if ( isset( $external_data['params'] ) && is_array( $external_data['params'] ) ) {
+				$external_params = $external_data['params'];
 			}
 		}
 
@@ -535,6 +553,10 @@ class Report_Data_Fetcher {
 
 		if ( null !== $external_code ) {
 			$error_data['external_code'] = $external_code;
+		}
+
+		if ( null !== $external_params ) {
+			$error_data['params'] = $external_params;
 		}
 
 		return new WP_Error(

--- a/projects/packages/premium-analytics/src/Reports/Export/class-report-data-fetcher.php
+++ b/projects/packages/premium-analytics/src/Reports/Export/class-report-data-fetcher.php
@@ -441,9 +441,14 @@ class Report_Data_Fetcher {
 
 		// Check for errors.
 		if ( $response->is_error() ) {
-			$error_data = $response->as_error();
+			$error_data = $this->build_external_api_error( $response );
+			$error_meta = $error_data->get_error_data();
+			$message    = is_array( $error_meta ) && ! empty( $error_meta['message'] )
+				? $error_meta['message']
+				: $error_data->get_error_message();
+
 			$this->logger->log_error(
-				'Proxy request failed: ' . $error_data->get_error_message(),
+				'Proxy request failed: ' . $message,
 				__METHOD__
 			);
 			return $error_data;
@@ -474,6 +479,59 @@ class Report_Data_Fetcher {
 		}
 
 		return $data;
+	}
+
+	/**
+	 * Build a stable local error from an external API error response.
+	 *
+	 * WP_REST_Response::as_error() can lose the upstream message for proxied error
+	 * payloads represented as stdClass. Preserve the external details in data while
+	 * keeping a consistent local error message for the CSV export route.
+	 *
+	 * @param \WP_REST_Response $response Error response from the local proxy route.
+	 * @return WP_Error Normalized external API error.
+	 */
+	private function build_external_api_error( \WP_REST_Response $response ): WP_Error {
+		$data = $this->normalize_response_data( $response->get_data() );
+		if ( is_wp_error( $data ) ) {
+			return $data;
+		}
+
+		$status           = (int) $response->get_status();
+		$external_code    = null;
+		$external_message = null;
+
+		if ( is_array( $data ) ) {
+			if ( isset( $data['data']['status'] ) ) {
+				$status = (int) $data['data']['status'];
+			}
+
+			if ( isset( $data['code'] ) && is_scalar( $data['code'] ) ) {
+				$external_code = (string) $data['code'];
+			}
+
+			if ( isset( $data['message'] ) && is_scalar( $data['message'] ) ) {
+				$external_message = (string) $data['message'];
+			}
+		}
+
+		$error_data = array(
+			'status' => $status ?: 500,
+		);
+
+		if ( null !== $external_message && '' !== $external_message ) {
+			$error_data['message'] = $external_message;
+		}
+
+		if ( null !== $external_code && '' !== $external_code ) {
+			$error_data['external_code'] = $external_code;
+		}
+
+		return new WP_Error(
+			'external_api_error',
+			__( 'External API error', 'jetpack-premium-analytics' ),
+			$error_data
+		);
 	}
 
 	/**

--- a/projects/packages/premium-analytics/tests/php/Reports/Export/ReportDataFetcher_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Reports/Export/ReportDataFetcher_Test.php
@@ -1,20 +1,21 @@
 <?php
 /**
- * Tests for the CSV export Report_Data_Fetcher pure helpers (merge/normalize logic).
+ * Tests for the CSV export Report_Data_Fetcher helpers.
  *
- * The network methods fetch()/make_proxy_request() are exercised against the live site
- * (they call the WPCom proxy); these tests cover the data-shaping methods that need no network.
+ * The proxy error path is intercepted at the local REST layer, so it needs no external request.
  *
  * @package automattic/jetpack-premium-analytics
  */
 
 namespace Automattic\Jetpack\PremiumAnalytics\Reports\Export;
 
+use Automattic\Jetpack\PremiumAnalytics\REST\Api_Proxy_Controller;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use WP_Error;
 use WP_REST_Response;
+use WP_REST_Server;
 
 require_once __DIR__ . '/fixtures/class-spy-logger.php';
 
@@ -150,6 +151,60 @@ class ReportDataFetcher_Test extends TestCase {
 		$this->assertSame(
 			array(
 				'status' => 500,
+			),
+			$result->get_error_data()
+		);
+	}
+
+	/**
+	 * External proxy failures retain their upstream details when the export fetcher makes the
+	 * internal REST request.
+	 */
+	public function test_make_proxy_request_normalizes_external_api_errors() {
+		global $wp_rest_server;
+
+		$previous_server  = $wp_rest_server;
+		$wp_rest_server   = new WP_REST_Server();
+		$proxy_controller = new Api_Proxy_Controller();
+		$register_routes  = array( $proxy_controller, 'register_routes' );
+		$route            = '/jetpack-premium-analytics/v1/proxy/v2/analytics/reports/coverage-test-error';
+		$pre_dispatch     = static function ( $result, $server, $request ) use ( $route ) {
+			if ( $route === $request->get_route() ) {
+				return new WP_REST_Response(
+					(object) array(
+						'code'    => 'woocommerce_analytics_bookings_error',
+						'message' => 'Failed to retrieve bookings data. Please try again later.',
+						'data'    => (object) array(
+							'status' => 500,
+						),
+					),
+					500
+				);
+			}
+
+			return $result;
+		};
+
+		add_action( 'rest_api_init', $register_routes );
+		add_filter( 'rest_pre_dispatch', $pre_dispatch, 10, 3 );
+
+		try {
+			// Routes must be registered on the `rest_api_init` action.
+			do_action( 'rest_api_init' );
+			$result = $this->invoke( 'make_proxy_request', array( 'reports/coverage-test-error', array() ) );
+		} finally {
+			remove_action( 'rest_api_init', $register_routes );
+			remove_filter( 'rest_pre_dispatch', $pre_dispatch, 10 );
+			$wp_rest_server = $previous_server;
+		}
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'external_api_error', $result->get_error_code() );
+		$this->assertSame(
+			array(
+				'status'        => 500,
+				'message'       => 'Failed to retrieve bookings data. Please try again later.',
+				'external_code' => 'woocommerce_analytics_bookings_error',
 			),
 			$result->get_error_data()
 		);

--- a/projects/packages/premium-analytics/tests/php/Reports/Export/ReportDataFetcher_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Reports/Export/ReportDataFetcher_Test.php
@@ -141,6 +141,39 @@ class ReportDataFetcher_Test extends TestCase {
 		);
 	}
 
+	public function test_build_external_api_error_preserves_invalid_fields_metadata_for_retry() {
+		$response = new WP_REST_Response(
+			(object) array(
+				'code'    => 'rest_invalid_param',
+				'message' => 'Invalid parameter(s): fields',
+				'data'    => (object) array(
+					'status' => 400,
+					'params' => (object) array(
+						'fields' => 'fields is not one of the allowed values.',
+					),
+				),
+			),
+			400
+		);
+
+		$result = $this->invoke( 'build_external_api_error', array( $response ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'external_api_error', $result->get_error_code() );
+		$this->assertSame(
+			array(
+				'status'        => 400,
+				'message'       => 'Invalid parameter(s): fields',
+				'external_code' => 'rest_invalid_param',
+				'params'        => array(
+					'fields' => 'fields is not one of the allowed values.',
+				),
+			),
+			$result->get_error_data()
+		);
+		$this->assertTrue( $this->invoke( 'is_invalid_fields_error', array( $result ) ) );
+	}
+
 	public function test_build_external_api_error_uses_fallback_status_without_external_details() {
 		$response = new WP_REST_Response( array(), 0 );
 

--- a/projects/packages/premium-analytics/tests/php/Reports/Export/ReportDataFetcher_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Reports/Export/ReportDataFetcher_Test.php
@@ -156,6 +156,32 @@ class ReportDataFetcher_Test extends TestCase {
 		);
 	}
 
+	public function test_build_external_api_error_keeps_http_status_and_empty_external_message() {
+		$response = new WP_REST_Response(
+			(object) array(
+				'code'    => 500,
+				'message' => '',
+				'data'    => (object) array(
+					'status' => 502,
+				),
+			),
+			500
+		);
+
+		$result = $this->invoke( 'build_external_api_error', array( $response ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'external_api_error', $result->get_error_code() );
+		$this->assertSame(
+			array(
+				'status'        => 500,
+				'message'       => '',
+				'external_code' => '500',
+			),
+			$result->get_error_data()
+		);
+	}
+
 	/**
 	 * External proxy failures retain their upstream details when the export fetcher makes the
 	 * internal REST request.
@@ -167,9 +193,10 @@ class ReportDataFetcher_Test extends TestCase {
 		$wp_rest_server   = new WP_REST_Server();
 		$proxy_controller = new Api_Proxy_Controller();
 		$register_routes  = array( $proxy_controller, 'register_routes' );
-		$route            = '/jetpack-premium-analytics/v1/proxy/v2/analytics/reports/coverage-test-error';
-		$pre_dispatch     = static function ( $result, $server, $request ) use ( $route ) {
-			if ( $route === $request->get_route() ) {
+		$error_route      = '/jetpack-premium-analytics/v1/proxy/v2/analytics/reports/coverage-test-error';
+		$embedded_route   = '/jetpack-premium-analytics/v1/proxy/v2/analytics/reports/coverage-test-embedded-error';
+		$pre_dispatch     = static function ( $result, $server, $request ) use ( $error_route, $embedded_route ) {
+			if ( $error_route === $request->get_route() ) {
 				return new WP_REST_Response(
 					(object) array(
 						'code'    => 'woocommerce_analytics_bookings_error',
@@ -182,6 +209,19 @@ class ReportDataFetcher_Test extends TestCase {
 				);
 			}
 
+			if ( $embedded_route === $request->get_route() ) {
+				return new WP_REST_Response(
+					(object) array(
+						'code'    => 'embedded_analytics_error',
+						'message' => 'The API embedded an error in a successful response.',
+						'data'    => (object) array(
+							'status' => 502,
+						),
+					),
+					200
+				);
+			}
+
 			return $result;
 		};
 
@@ -191,7 +231,8 @@ class ReportDataFetcher_Test extends TestCase {
 		try {
 			// Routes must be registered on the `rest_api_init` action.
 			do_action( 'rest_api_init' );
-			$result = $this->invoke( 'make_proxy_request', array( 'reports/coverage-test-error', array() ) );
+			$result          = $this->invoke( 'make_proxy_request', array( 'reports/coverage-test-error', array() ) );
+			$embedded_result = $this->invoke( 'make_proxy_request', array( 'reports/coverage-test-embedded-error', array() ) );
 		} finally {
 			remove_action( 'rest_api_init', $register_routes );
 			remove_filter( 'rest_pre_dispatch', $pre_dispatch, 10 );
@@ -207,6 +248,17 @@ class ReportDataFetcher_Test extends TestCase {
 				'external_code' => 'woocommerce_analytics_bookings_error',
 			),
 			$result->get_error_data()
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $embedded_result );
+		$this->assertSame( 'external_api_error', $embedded_result->get_error_code() );
+		$this->assertSame(
+			array(
+				'status'        => 502,
+				'message'       => 'The API embedded an error in a successful response.',
+				'external_code' => 'embedded_analytics_error',
+			),
+			$embedded_result->get_error_data()
 		);
 	}
 }

--- a/projects/packages/premium-analytics/tests/php/Reports/Export/ReportDataFetcher_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Reports/Export/ReportDataFetcher_Test.php
@@ -139,4 +139,19 @@ class ReportDataFetcher_Test extends TestCase {
 			$result->get_error_data()
 		);
 	}
+
+	public function test_build_external_api_error_uses_fallback_status_without_external_details() {
+		$response = new WP_REST_Response( array(), 0 );
+
+		$result = $this->invoke( 'build_external_api_error', array( $response ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'external_api_error', $result->get_error_code() );
+		$this->assertSame(
+			array(
+				'status' => 500,
+			),
+			$result->get_error_data()
+		);
+	}
 }

--- a/projects/packages/premium-analytics/tests/php/Reports/Export/ReportDataFetcher_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Reports/Export/ReportDataFetcher_Test.php
@@ -14,6 +14,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use ReflectionMethod;
 use WP_Error;
+use WP_REST_Response;
 
 require_once __DIR__ . '/fixtures/class-spy-logger.php';
 
@@ -110,5 +111,32 @@ class ReportDataFetcher_Test extends TestCase {
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertSame( 'proxy_response_encode_failed', $result->get_error_code() );
+	}
+
+	public function test_build_external_api_error_preserves_external_message() {
+		$response = new WP_REST_Response(
+			(object) array(
+				'code'    => 'woocommerce_analytics_bookings_error',
+				'message' => 'Failed to retrieve bookings data. Please try again later.',
+				'data'    => (object) array(
+					'status' => 500,
+				),
+			),
+			500
+		);
+
+		$result = $this->invoke( 'build_external_api_error', array( $response ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'external_api_error', $result->get_error_code() );
+		$this->assertSame( 'External API error', $result->get_error_message() );
+		$this->assertSame(
+			array(
+				'status'        => 500,
+				'message'       => 'Failed to retrieve bookings data. Please try again later.',
+				'external_code' => 'woocommerce_analytics_bookings_error',
+			),
+			$result->get_error_data()
+		);
 	}
 }


### PR DESCRIPTION
The local report export API can sometimes return cryptic error responses if the response from the external, proxied request errors:

```json
{
    "code": 500,
    "message": "",
    "data": {
        "status": 500
    }
}
```

The remote error code comes through, but nothing else

## Proposed changes
* Normalize both HTTP-level proxy failures and HTTP-200 responses containing an embedded API error into a stable `external_api_error` response.
* Preserve upstream error details, including empty values. Treat the HTTP status as authoritative for transport failures and use `data.status` only for embedded errors.
* Add regression coverage for proxied external API errors and a Premium Analytics changelog entry.

```json
{
    "code": "external_api_error",
    "message": "External API error",
    "data": {
        "status": 500,
        "message": "…upstream message…",
        "external_code": "…upstream_code…"
    }
}
```

## Does this pull request change what data or activity we track or use?
No. This only changes how existing CSV export errors are surfaced in local API responses.

## Testing instructions
* On a local or staging site with Premium Analytics and WooCommerce active, temporarily load this local-only fixture. It intercepts only the internal analytics proxy request and must be removed after testing:

```php
add_filter(
	'rest_pre_dispatch',
	static function ( $result, $server, $request ) {
		if ( '/jetpack-premium-analytics/v1/proxy/v2/analytics/reports/orders/by-date' !== $request->get_route() ) {
			return $result;
		}

		return new WP_REST_Response(
			(object) array(
				'code'    => 'woocommerce_analytics_error',
				'message' => 'Upstream analytics request failed.',
				'data'    => (object) array( 'status' => 500 ),
			),
			500
		);
	},
	10,
	3
);
```

* Trigger a Gross Sales Over Time CSV export through the dashboard:
  `POST /wp-json/jetpack-premium-analytics/v1/reports/csv-export`
  ```json
  {
    "report_type": "grosssalesovertime",
    "from": "2026-01-01T00:00:00",
    "to": "2026-02-04T23:59:59",
    "delivery_method": "download"
  }
  ```
* Confirm the response keeps HTTP `500` and returns `code: "external_api_error"`, `message: "External API error"`, `data.message: "Upstream analytics request failed."`, and `data.external_code: "woocommerce_analytics_error"`.
* Repeat with the fixture returning HTTP `200` and `data.status: 502`. Confirm the CSV endpoint returns HTTP `502` with `code: "external_api_error"` and preserves the upstream message and code.
* Remove the temporary fixture.
