### PR TITLE
Content Research: only load in the post editor 

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-content-research-hide-in-site-editor
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-content-research-hide-in-site-editor
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Content Research: only load in the post editor, not in the site editor, widgets editor, or customizer

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-content-research-hide-in-site-editor
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-content-research-hide-in-site-editor
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Content Research: only load in the post editor, not in the site editor, widgets editor, or customizer
+Content Research: Load only in the post editor, not in the site editor, widgets editor, or customizer.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-content-research/class-wpcom-content-research.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-content-research/class-wpcom-content-research.php
@@ -103,9 +103,16 @@ class WPCOM_Content_Research {
 	}
 
 	/**
-	 * Enqueue the Content Research sidebar script on editor screens.
+	 * Enqueue the Content Research sidebar script on post editor screens.
 	 */
 	public function enqueue_scripts() {
+		// Load in the post editor only — the `enqueue_block_editor_assets` action
+		// also fires in the site editor, widgets editor, and customizer.
+		$current_screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+		if ( ! $current_screen || 'post' !== $current_screen->base ) {
+			return;
+		}
+
 		if ( ! self::is_enabled() ) {
 			return;
 		}


### PR DESCRIPTION
## Proposed changes

* The Content Research beta feature (a11n-only) was appearing in the Site Edito:  its "Content Research" ⋮ menu item and the floating "Need inspiration?" button,  which shows after 5s whenever the root block list is empty (exactly the Site  Editor's browse/loading state).

## Related product discussion/links

Fixes https://linear.app/a8c/issue/DOTCOM-17851/content-research-beta-feature-appears-in-the-site-editor

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* As an Automattician, proxied, on a WPCOM Simple site.
* Open the Site Editor (Appearance → Editor): the "Content Research" item should
  no longer appear in the ⋮ options menu, and the floating "Need inspiration?"
  button should never pop up. Same for the widgets editor / customizer, if the
  active theme is a classic theme.
* Open the post editor on a fresh draft: Content Research should still be there
  (⋮ menu item, and the "Need inspiration?" float after ~5s on an empty draft;
  ⌘⌥G / Ctrl+Alt+G opens the window).