### PR TITLE
Publicize: remove calypso color schemes

### DIFF
--- a/projects/js-packages/social-previews/changelog/update-google-search-preview-wpds-token
+++ b/projects/js-packages/social-previews/changelog/update-google-search-preview-wpds-token
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Comment: Replace Calypso `--color-neutral-0` with WPDS `--wpds-color-stroke-surface-neutral` in Google search preview styles.

--- a/projects/js-packages/social-previews/src/google-search-preview/style.scss
+++ b/projects/js-packages/social-previews/src/google-search-preview/style.scss
@@ -10,7 +10,7 @@
 */
 
 .search-preview__display {
-	border: 1px solid var(--color-neutral-0);
+	border: 1px solid var(--wpds-color-stroke-surface-neutral, #dbdbdb);
 	font-family: arial, sans-serif;
 	padding: 10px 20px;
 	overflow-wrap: break-word;

--- a/projects/packages/publicize/_inc/components/social-page.tsx
+++ b/projects/packages/publicize/_inc/components/social-page.tsx
@@ -7,12 +7,9 @@ import { Tabs, Tooltip } from '@wordpress/ui';
 import { ModernizationProvider } from '../hooks/use-is-modernized';
 import SocialGate from './social-gate';
 import useSocialGate from './social-gate/use-social-gate';
-// Define the `--color-facebook`, `--color-twitter`, ... custom properties
-// that `SocialServiceIcon` (and friends) consume to paint per-service
-// brand colours. The legacy `social-admin-page` webpack bundle inlines
-// these via `postcss-custom-properties { preserve: false }`; the chassis
-// esbuild pipeline doesn't run postcss, so the variables would otherwise
-// be undefined and the icons render black on a white surface.
+// Define the `--jetpack-social-color-facebook`, `--jetpack-social-color-twitter`, ...
+// custom properties that `SocialServiceIcon` (and friends) consume to paint
+// per-service brand colours.
 import 'social-logos/colors.css';
 import './social-page.scss';
 import type { ReactNode } from 'react';

--- a/projects/packages/publicize/_inc/components/social-page.tsx
+++ b/projects/packages/publicize/_inc/components/social-page.tsx
@@ -7,9 +7,9 @@ import { Tabs, Tooltip } from '@wordpress/ui';
 import { ModernizationProvider } from '../hooks/use-is-modernized';
 import SocialGate from './social-gate';
 import useSocialGate from './social-gate/use-social-gate';
-// Define the `--jetpack-social-color-facebook`, `--jetpack-social-color-twitter`, ...
-// custom properties that `SocialServiceIcon` (and friends) consume to paint
-// per-service brand colours.
+// Define the `--color-facebook`, `--color-twitter`, ... custom properties from
+// `social-logos/colors.css` that `SocialServiceIcon` (and friends) consume to
+// paint per-service brand colours.
 import 'social-logos/colors.css';
 import './social-page.scss';
 import type { ReactNode } from 'react';

--- a/projects/packages/publicize/_inc/components/social-page.tsx
+++ b/projects/packages/publicize/_inc/components/social-page.tsx
@@ -7,9 +7,9 @@ import { Tabs, Tooltip } from '@wordpress/ui';
 import { ModernizationProvider } from '../hooks/use-is-modernized';
 import SocialGate from './social-gate';
 import useSocialGate from './social-gate/use-social-gate';
-// Define the `--color-facebook`, `--color-twitter`, ... custom properties from
-// `social-logos/colors.css` that `SocialServiceIcon` (and friends) consume to
-// paint per-service brand colours.
+// Define the `--jetpack-social-logo-color-facebook`, `--jetpack-social-logo-color-twitter`,
+// etc. custom properties from `social-logos/colors.css` that `SocialServiceIcon` (and friends)
+// consume to paint per-service brand colours.
 import 'social-logos/colors.css';
 import './social-page.scss';
 import type { ReactNode } from 'react';

--- a/projects/packages/publicize/changelog/update-social-page-token-comment
+++ b/projects/packages/publicize/changelog/update-social-page-token-comment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Comment: Remove Calypso color schemes dependency.

--- a/projects/packages/publicize/postcss.config.js
+++ b/projects/packages/publicize/postcss.config.js
@@ -1,21 +1,6 @@
 module.exports = () => ( {
 	plugins: [
-		require( '@csstools/postcss-global-data' )( {
-			// Provide the properties that postcss-custom-properties is going to work with.
-			files: [ require.resolve( '@automattic/calypso-color-schemes/root-only/index.css' ) ],
-		} ),
-		require( 'postcss-custom-properties' )( {
-			// Use of `preserve: false` dates back to when we still used @automattic/calypso-build.
-			// Ideally we'd get rid of it to properly make use of CSS vars, but first we have to
-			// figure out how to ensure the vars actually get defined in the browser without
-			// including them in every bundle. Some base stylesheet (wp_register_style) the other
-			// stylesheets depend on maybe? And also deal with extremely generic vars like "--color-text".
-			//
-			// See also https://github.com/Automattic/jetpack/pull/13854#issuecomment-550898168,
-			// where people were confused about what was going on when calypso-build stopped
-			// including a postcss.config.js like this by default.
-			preserve: false,
-		} ),
+		require( '@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks' ).default,
 		require( 'autoprefixer' ),
 	],
 } );


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/jetpack/pull/50413 and split out from bigger PR https://github.com/Automattic/jetpack/pull/50108 to focus on Social/Publicize only.


## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Remove Calypso color scheme dependency from Publicize now that nothing uses it anymore. 
    * Usage was removed in https://github.com/Automattic/jetpack/pull/50413, and one last variable in the Publicise dependency `@automattic/social-previews` was removed in this PR.

* Remove `postcss-custom-properties` which was used to inline tokens; `var( --token )` becomes `#000` as old browser fallback.

* Adds `@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks` which ensures WPDS tokens used now have fallback `var( --wpds-token )` now becomes `var( --wpds-token, #000 )`.

Calypso token definitions in the bundle were removed and inlined previously by `postcss-custom-properties`, which also inlined other used token variables; bundle size intentionally grows a bit as a result.

<details>
<summary>See AI bundle size analysis...</summary>

## Summary

| Scope | Trunk (gzip) | Branch (gzip) | Delta |
|---|---:|---:|---:|
| **publicize `build/` (all files)** | 2,140.6 KiB | 2,162.1 KiB | **+21.5 KiB** |
| **social-previews `style.css`** | 7.9 KiB | 8.0 KiB | **+0.1 KiB** |

**JS is unchanged.** All size movement is in CSS.

## Entrypoints affected

| Entrypoint | Trunk gzip | Branch gzip | Delta |
|---|---:|---:|---:|
| `classic-editor` | 5.2 KiB | 5.2 KiB | 0 |
| `social-admin-page` (js+css+rtl) | 190.5 KiB | 195.4 KiB | **+4.9 KiB** |
| `block-editor-jetpack` (js+css+rtl) | 425.8 KiB | 434.1 KiB | **+8.3 KiB** |
| `block-editor-social` (js+css+rtl) | 426.1 KiB | 434.4 KiB | **+8.3 KiB** |
| `routes/dashboard/content.min.js` | 338.9 KiB | 338.9 KiB | 0 |

## CSS-only breakdown (raw → gzip impact)

| File | Raw Δ | Gzip Δ |
|---|---:|---:|
| `block-editor-jetpack.css` / `.rtl.css` | +49.0 KiB each | +4.2 KiB each |
| `block-editor-social.css` / `.rtl.css` | +49.0 KiB each | +4.2 KiB each |
| `social-admin-page.css` / `.rtl.css` | +13.3 KiB each | +2.4–2.5 KiB each |

## Why CSS grew

Trunk PostCSS (`postcss-custom-properties` + Calypso `root-only`, `preserve: false`) **inlines** custom properties to hex values at build time.

Branch PostCSS (`postcss-ds-token-fallbacks` + `autoprefixer`) **keeps** `var(--wpds-*, fallback)` in output:

- `block-editor-jetpack.css`: **1** `var(--wpds-*)` on trunk → **903** on branch
- `social-admin-page.css`: **4** → **70**

So the branch trades smaller inlined CSS for runtime CSS variables (with fallbacks). Gzip impact is much smaller than raw (+21.5 KiB total vs +222.7 KiB raw across changed CSS files).

## Unchanged

- All `.js` bundles (including wp-build dashboard route)
- Copied image/assets
- `social-previews` token rename (`#f6f7f7` → `#dbdbdb` border) is negligible (+30 B raw)

**Net:** branch adds ~**22 KiB gzip** to publicize production output, almost entirely from preserving WPDS CSS variables instead of inlining Calypso colors.
</details>


## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Smoke test Social