### PR TITLE
Pages homepage connection banner: make notice dismissible and persist per user

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/2026-07-13-12-54-34-527878
+++ b/projects/packages/jetpack-mu-wpcom/changelog/2026-07-13-12-54-34-527878
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Pages homepage connection banner: make the notice dismissible and persist the dismissal per user.

--- a/projects/packages/jetpack-mu-wpcom/src/features/pages/js/pages-homepage-connection-banner.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/pages/js/pages-homepage-connection-banner.js
@@ -24,5 +24,32 @@ import { wpcomTrackEvent } from '../../../common/tracks';
 		bannerBtn?.addEventListener( 'click', function () {
 			wpcomTrackEvent( 'wpcom_pages_edit_homepage_banner_clicked' );
 		} );
+
+		const attachDismissHandler = function ( btn ) {
+			btn.addEventListener( 'click', function () {
+				wpcomTrackEvent( 'wpcom_pages_edit_homepage_banner_dismissed' );
+
+				const body = new FormData();
+				body.append( 'action', 'dismiss_homepage_connection_banner' );
+				body.append( 'nonce', banner.dataset.nonce );
+				fetch( window.ajaxurl, { method: 'POST', body } );
+			} );
+		};
+
+		const dismissBtn = banner.querySelector( '.notice-dismiss' );
+		if ( dismissBtn ) {
+			attachDismissHandler( dismissBtn );
+		} else {
+			// WP core injects the dismiss button dynamically via common.js;
+			// watch for it if it hasn't appeared yet.
+			const observer = new MutationObserver( function () {
+				const btn = banner.querySelector( '.notice-dismiss' );
+				if ( btn ) {
+					observer.disconnect();
+					attachDismissHandler( btn );
+				}
+			} );
+			observer.observe( banner, { childList: true, subtree: true } );
+		}
 	} );
 } )( jQuery );

--- a/projects/packages/jetpack-mu-wpcom/src/features/pages/pages-homepage-connection-banner.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/pages/pages-homepage-connection-banner.php
@@ -15,25 +15,18 @@ const WPCOM_HOMEPAGE_CONNECTION_BANNER_DISMISSED_META = 'wpcom_pages_homepage_co
 
 /**
  * Displays the homepage connection banner in the admin notices.
+ *
+ * The markup is rendered directly (rather than via wp_admin_notice()) because
+ * wp_admin_notice() passes its output through wp_kses_post(), which strips the
+ * data-nonce attribute the dismissal AJAX request relies on.
  */
 function homepage_connection_banner() {
-	$message = sprintf(
-		'<p>%s</p><a href="%s" class="button-primary">%s</a>',
-		esc_html( __( 'Looking to customize your homepage?', 'jetpack-mu-wpcom' ) ),
+	printf(
+		'<div id="edit-homepage-banner" class="notice notice-info is-dismissible" data-nonce="%s"><p>%s</p><a href="%s" class="button-primary">%s</a></div>',
+		esc_attr( wp_create_nonce( 'dismiss_homepage_connection_banner' ) ),
+		esc_html__( 'Looking to customize your homepage?', 'jetpack-mu-wpcom' ),
 		esc_url( admin_url( 'site-editor.php' ) ),
 		esc_html__( 'Edit homepage', 'jetpack-mu-wpcom' )
-	);
-
-	wp_admin_notice(
-		$message,
-		array(
-			'type'        => 'info',
-			'id'          => 'edit-homepage-banner',
-			'dismissible' => true,
-			'attributes'  => array(
-				'data-nonce' => wp_create_nonce( 'dismiss_homepage_connection_banner' ),
-			),
-		)
 	);
 }
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/pages/pages-homepage-connection-banner.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/pages/pages-homepage-connection-banner.php
@@ -9,6 +9,11 @@
  */
 
 /**
+ * User meta key storing whether the current user has dismissed the homepage connection banner.
+ */
+const WPCOM_HOMEPAGE_CONNECTION_BANNER_DISMISSED_META = 'wpcom_pages_homepage_connection_banner_dismissed';
+
+/**
  * Displays the homepage connection banner in the admin notices.
  */
 function homepage_connection_banner() {
@@ -22,8 +27,12 @@ function homepage_connection_banner() {
 	wp_admin_notice(
 		$message,
 		array(
-			'type' => 'info',
-			'id'   => 'edit-homepage-banner',
+			'type'        => 'info',
+			'id'          => 'edit-homepage-banner',
+			'dismissible' => true,
+			'attributes'  => array(
+				'data-nonce' => wp_create_nonce( 'dismiss_homepage_connection_banner' ),
+			),
 		)
 	);
 }
@@ -40,6 +49,11 @@ function wpcom_add_pages_homepage_connection_banner() {
 	$is_edit_page_screen = 'edit-page' === $screen->id;
 
 	if ( ! $is_edit_page_screen ) {
+		return;
+	}
+
+	// Don't show the banner if the current user has already dismissed it.
+	if ( get_user_meta( get_current_user_id(), WPCOM_HOMEPAGE_CONNECTION_BANNER_DISMISSED_META, true ) ) {
 		return;
 	}
 
@@ -70,3 +84,13 @@ function wpcom_add_pages_homepage_connection_banner() {
 }
 
 add_action( 'current_screen', 'wpcom_add_pages_homepage_connection_banner' );
+
+/**
+ * AJAX handler to persist the dismissal of the homepage connection banner in user meta.
+ */
+function wpcom_dismiss_pages_homepage_connection_banner() {
+	check_ajax_referer( 'dismiss_homepage_connection_banner', 'nonce' );
+	update_user_meta( get_current_user_id(), WPCOM_HOMEPAGE_CONNECTION_BANNER_DISMISSED_META, '1' );
+	wp_send_json_success( null, 200, JSON_UNESCAPED_SLASHES );
+}
+add_action( 'wp_ajax_dismiss_homepage_connection_banner', 'wpcom_dismiss_pages_homepage_connection_banner' );


### PR DESCRIPTION
Fixes DSGCOM-688

## Proposed changes
* Make the Pages → homepage connection banner dismissible by rendering it with WordPress's `is-dismissible` notice control.
* Persist the dismissal in per-user meta (`wpcom_pages_homepage_connection_banner_dismissed`) via a nonce-protected AJAX handler (`wp_ajax_dismiss_homepage_connection_banner`), so the banner stays hidden for that user across page loads.
* Bail out of rendering the banner early when the current user has already dismissed it.
* Wire up the dismiss button in the banner JS (matching the existing AI assistant banner pattern), including a `MutationObserver` fallback since WP core injects the dismiss button dynamically, and add a `wpcom_pages_edit_homepage_banner_dismissed` track event.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
Yes — adds a `wpcom_pages_edit_homepage_banner_dismissed` Tracks event fired when a user dismisses the banner, alongside the existing shown/clicked events. Dismissal state is stored in per-user meta.

## Testing instructions

* On a site using a **block theme** with the homepage set to display **latest posts** (Settings → Reading → "Your latest posts"), as a user who can `edit_theme_options`, go to **Pages** (`wp-admin/edit.php?post_type=page`).
* Confirm the "Looking to customize your homepage?" banner appears, now with a dismiss (×) button in the top-right.
* Click the dismiss button and confirm the banner disappears.
* Reload the Pages screen and confirm the banner does **not** reappear.
* Optionally, check the browser Network tab to confirm the `admin-ajax.php` request with `action=dismiss_homepage_connection_banner` returns success, and verify the `wpcom_pages_homepage_connection_banner_dismissed` user meta is set to `1`.
* Deleting that user meta value should make the banner show again.
