### PR TITLE
Podcast: stop exposing podcasting_* through core /wp/v2/settings

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-settings-core-rest-exposure
+++ b/projects/packages/podcast/changelog/fix-podcast-settings-core-rest-exposure
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Podcast: stop exposing the `podcasting_*` options through core `/wp/v2/settings`. The dashboard reads and writes them via the dedicated `wpcom/v2/podcast/settings` endpoint; the registered `sanitize_callback`s are kept so writes stay validated.

--- a/projects/packages/podcast/src/class-settings.php
+++ b/projects/packages/podcast/src/class-settings.php
@@ -8,11 +8,10 @@
 namespace Automattic\Jetpack\Podcast;
 
 /**
- * Registers the `podcasting_*` options with their `sanitize_callback`s and
- * `show_in_rest` so they keep appearing in core `/wp/v2/settings`. The dashboard
- * now reads and writes them through the dedicated {@see Podcast_Settings_Endpoint}
- * (`wpcom/v2/podcast/settings`); the core exposure stays for now and is removed
- * in a follow-up once WPCOM's settings-controller test is decoupled.
+ * Registers the `podcasting_*` options with their `sanitize_callback`s so writes
+ * through any path stay validated. The dashboard reads and writes them through the
+ * dedicated {@see Podcast_Settings_Endpoint} (`wpcom/v2/podcast/settings`); they
+ * are intentionally not exposed through core `/wp/v2/settings`.
  *
  * Array-shaped options merge against stored values on sanitize, not replace —
  * the SPA can PATCH partial entries without losing the rest.
@@ -112,7 +111,6 @@ class Settings {
 					'type'              => $type,
 					'default'           => $default,
 					'sanitize_callback' => $sanitize,
-					'show_in_rest'      => true,
 				)
 			);
 		}
@@ -124,13 +122,6 @@ class Settings {
 				'type'              => 'string',
 				'default'           => '',
 				'sanitize_callback' => 'esc_url_raw',
-				'show_in_rest'      => array(
-					'schema' => array(
-						'type'    => 'string',
-						'default' => '',
-						'format'  => 'uri',
-					),
-				),
 			)
 		);
 
@@ -141,12 +132,11 @@ class Settings {
 				'type'              => 'boolean',
 				'default'           => false,
 				'sanitize_callback' => array( __CLASS__, 'sanitize_explicit' ),
-				'show_in_rest'      => true,
 			)
 		);
 
-		// Registered under WP core's `options` group: REST-only settings that
-		// WPCOM never wired into the Settings API.
+		// Registered under WP core's `options` group: settings WPCOM never wired
+		// into a Settings API form.
 		register_setting(
 			'options',
 			'podcasting_email',
@@ -154,7 +144,6 @@ class Settings {
 				'type'              => 'string',
 				'default'           => '',
 				'sanitize_callback' => 'sanitize_email',
-				'show_in_rest'      => true,
 			)
 		);
 
@@ -165,12 +154,8 @@ class Settings {
 				'type'              => 'integer',
 				'default'           => 0,
 				'sanitize_callback' => 'absint',
-				'show_in_rest'      => true,
 			)
 		);
-
-		$podcatcher_keys = array_keys( self::SHOW_URL_HOSTS );
-		$empty_map       = array_fill_keys( $podcatcher_keys, '' );
 
 		register_setting(
 			'options',
@@ -179,20 +164,6 @@ class Settings {
 				'type'              => 'object',
 				'default'           => array(),
 				'sanitize_callback' => array( __CLASS__, 'sanitize_show_urls' ),
-				'show_in_rest'      => array(
-					'schema' => array(
-						'type'       => 'object',
-						'default'    => $empty_map,
-						'properties' => array_fill_keys(
-							$podcatcher_keys,
-							array(
-								'type'      => 'string',
-								'format'    => 'uri',
-								'maxLength' => self::SHOW_URL_MAX_LENGTH,
-							)
-						),
-					),
-				),
 			)
 		);
 
@@ -203,19 +174,6 @@ class Settings {
 				'type'              => 'object',
 				'default'           => array(),
 				'sanitize_callback' => array( __CLASS__, 'sanitize_show_states' ),
-				'show_in_rest'      => array(
-					'schema' => array(
-						'type'       => 'object',
-						'default'    => $empty_map,
-						'properties' => array_fill_keys(
-							$podcatcher_keys,
-							array(
-								'type' => 'string',
-								'enum' => array( '', 'pending', 'active' ),
-							)
-						),
-					),
-				),
 			)
 		);
 	}

--- a/projects/packages/podcast/tests/php/Settings_Test.php
+++ b/projects/packages/podcast/tests/php/Settings_Test.php
@@ -15,14 +15,15 @@ use WorDBless\BaseTestCase;
 #[CoversClass( Settings::class )]
 class Settings_Test extends BaseTestCase {
 
-	public function test_register_settings_exposes_every_option_to_rest() {
+	public function test_register_settings_keeps_sanitizers_but_not_core_rest_exposure() {
 		Settings::register_settings();
 
 		$registered = get_registered_settings();
 
 		foreach ( Settings::OPTION_NAMES as $name ) {
 			$this->assertArrayHasKey( $name, $registered, "$name should be registered" );
-			$this->assertNotEmpty( $registered[ $name ]['show_in_rest'], "$name should declare show_in_rest" );
+			$this->assertNotEmpty( $registered[ $name ]['sanitize_callback'], "$name should keep its sanitize_callback" );
+			$this->assertEmpty( $registered[ $name ]['show_in_rest'], "$name should not be exposed through core /wp/v2/settings" );
 		}
 	}
 


### PR DESCRIPTION
## Proposed changes

Completes the deferred teardown of the Podcast options' core `/wp/v2/settings` exposure, now that the dashboard and block editor read/write exclusively through the dedicated `wpcom/v2/podcast/settings` endpoint.

* Drop `show_in_rest` from all 14 `podcasting_*` `register_setting()` calls, so the options no longer surface through core `/wp/v2/settings` or the `root/site` entity.
* **Keep every `sanitize_callback` and the `media`/`options` groups intact** — the endpoint writers (`Podcast_Settings_Endpoint`, `Podcast_Distribution_Endpoint::save_show_state`) rely on these to validate and merge partial array patches. Sanitization is unchanged.
* Remove the now-dead `$podcatcher_keys` / `$empty_map` locals that only fed the removed REST schemas (`get_all()` keeps its own copy).
* Refresh the class docblock to drop the "removed in a follow-up" deferral language.
* Flip `Settings_Test::test_register_settings_*` to assert the new intent: sanitizers survive, core REST exposure is gone.

A pre-flight confirmed no live consumer reads `podcasting_*` through core `/wp/v2/settings` — the dashboard and block editor use the dedicated `wpcom/v2/podcast/settings` core-data entity, and everything else (Calypso, SAL endpoints, sync defaults) reads via `get_option()`/SAL.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `cd projects/packages/podcast && composer install && composer phpunit` — the full suite (181 tests) passes, including the endpoint tests that exercise the retained sanitizers.
* Confirm the Podcast settings dashboard still loads, reads, and saves correctly on Simple, Atomic, and self-hosted — it routes through `wpcom/v2/podcast/settings`, not core `/wp/v2/settings`.
* Verify partial saves of `podcasting_show_urls` / `podcasting_show_states` still merge and validate against the per-podcatcher hostname allowlist.