### PR TITLE
Paid Content: expire subscription access at end-of-day (NL-735)

### DIFF
--- a/projects/plugins/jetpack/changelog/add-paid-content-renewal-grace
+++ b/projects/plugins/jetpack/changelog/add-paid-content-renewal-grace
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Paid Content: expire subscription access at the end of the end_date day (UTC) rather than the exact purchase timestamp, so a same-day auto-renewal completes before access is cut and enforcement matches the platform's end-of-day expiration convention.

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
@@ -574,9 +574,8 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 		foreach ( $user_abbreviated_subscriptions as $subscription_plan_id => $details ) {
 			$details = (array) $details;
 
-			$end = is_int( $details['end_date'] ) ? $details['end_date'] : strtotime( $details['end_date'] );
-			if ( $end < time() ) {
-				// subscription not active anymore
+			if ( ! self::subscription_grants_access( $details ) ) {
+				// Subscription not active anymore (its end_date day has fully passed).
 				continue;
 			}
 
@@ -766,11 +765,51 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 	}
 
 	/**
+	 * Return true if an abbreviated subscription currently grants access.
+	 *
+	 * Access is granted through the end of the subscription's end_date day
+	 * (23:59:59 UTC), not the exact end_date timestamp. Memberships store
+	 * end_date as the precise purchase timestamp, while billing renews via a
+	 * deferred day-0 job that can run several hours after that timestamp. Since
+	 * the wider platform already treats end-of-day as the formal expiration
+	 * time for subscriptions, expiring at EOD here keeps a same-day auto-renewal
+	 * from cutting off access before its renewal completes, and aligns Paid
+	 * Content with the rest of WordPress.com / Jetpack.
+	 *
+	 * Cancelled and otherwise inactive subscriptions never reach this check —
+	 * they are dropped by the `'active' === status` filter in
+	 * abbreviate_subscriptions() — so this only ever extends an already-active
+	 * subscription to the end of its final day.
+	 *
+	 * @param object|array $subscription Abbreviated subscription (see abbreviate_subscriptions()).
+	 *
+	 * @return bool
+	 */
+	protected static function subscription_grants_access( $subscription ) {
+		$subscription = (array) $subscription;
+		if ( empty( $subscription['end_date'] ) ) {
+			return false;
+		}
+
+		$end = is_int( $subscription['end_date'] ) ? $subscription['end_date'] : strtotime( $subscription['end_date'] );
+		if ( false === $end ) {
+			return false;
+		}
+
+		// Expire at the end of the end_date's day (UTC), matching the platform's
+		// formal expiration convention rather than the exact purchase timestamp.
+		$end_of_day = strtotime( gmdate( 'Y-m-d 23:59:59', $end ) . ' UTC' );
+
+		return $end_of_day >= time();
+	}
+
+	/**
 	 * Return true if any ID/date pairs are valid. Otherwise false.
 	 *
 	 * @param int[]    $valid_plan_ids List of valid plan IDs.
 	 * @param object[] $token_subscriptions : ID must exist in the provided <code>$valid_subscriptions</code> parameter.
-	 *                                                            The provided end date needs to be greater than <code>now()</code>.
+	 *                                                            The provided end date needs to fall on or after today,
+	 *                                                            i.e. access lasts through the end of the end_date day (UTC).
 	 *
 	 * @return bool
 	 */
@@ -786,8 +825,7 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 
 		foreach ( $token_subscriptions as $product_id => $token_subscription ) {
 			if ( in_array( intval( $product_id ), $product_ids, true ) ) {
-				$end = is_int( $token_subscription->end_date ) ? $token_subscription->end_date : strtotime( $token_subscription->end_date );
-				if ( $end > time() ) {
+				if ( static::subscription_grants_access( $token_subscription ) ) {
 					return true;
 				}
 			}

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php
@@ -841,7 +841,7 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 
 		wp_set_current_user( $paid_subscriber_id );
 		// Stale token — end_date in the past.
-		$stale_payload = $this->get_payload( true, true, time() - HOUR_IN_SECONDS );
+		$stale_payload = $this->get_payload( true, true, time() - 2 * DAY_IN_SECONDS );
 		$this->set_returned_token( $stale_payload );
 
 		// Refresh endpoint returns a fresh token with a valid future end_date.
@@ -878,7 +878,7 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 		update_post_meta( $tier_plan_id, 'jetpack_memberships_type', 'tier' );
 
 		// Stale token — product_id matches the tier, but end_date is past.
-		$stale_payload = $this->get_payload( true, true, time() - HOUR_IN_SECONDS );
+		$stale_payload = $this->get_payload( true, true, time() - 2 * DAY_IN_SECONDS );
 		$this->set_returned_token( $stale_payload );
 
 		$this->refresh_response_override = $this->build_refresh_success_response();
@@ -943,7 +943,7 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 		$plan_id            = $users_plans[3];
 
 		wp_set_current_user( $paid_subscriber_id );
-		$stale_payload = $this->get_payload( true, true, time() - HOUR_IN_SECONDS );
+		$stale_payload = $this->get_payload( true, true, time() - 2 * DAY_IN_SECONDS );
 		$this->set_returned_token( $stale_payload );
 
 		// Refresh returns a token with no subscriptions (cancelled).
@@ -989,7 +989,7 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 		$plan_id            = $users_plans[3];
 
 		wp_set_current_user( $paid_subscriber_id );
-		$stale_payload                            = $this->get_payload( true, true, time() - HOUR_IN_SECONDS );
+		$stale_payload                            = $this->get_payload( true, true, time() - 2 * DAY_IN_SECONDS );
 		$service                                  = subscription_service();
 		$token_string                             = JWT::encode( $stale_payload, $service->get_key() );
 		$_COOKIE['wp-jp-premium-content-session'] = $token_string;
@@ -1025,7 +1025,7 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 		$plan_id            = $users_plans[3];
 
 		wp_set_current_user( $paid_subscriber_id );
-		$stale_payload                            = $this->get_payload( true, true, time() - HOUR_IN_SECONDS );
+		$stale_payload                            = $this->get_payload( true, true, time() - 2 * DAY_IN_SECONDS );
 		$service                                  = subscription_service();
 		$token_string                             = JWT::encode( $stale_payload, $service->get_key() );
 		$_COOKIE['wp-jp-premium-content-session'] = $token_string;
@@ -1060,7 +1060,7 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 		$plan_id            = $users_plans[3];
 
 		wp_set_current_user( $paid_subscriber_id );
-		$stale_payload                            = $this->get_payload( true, true, time() - HOUR_IN_SECONDS );
+		$stale_payload                            = $this->get_payload( true, true, time() - 2 * DAY_IN_SECONDS );
 		$service                                  = subscription_service();
 		$token_string                             = JWT::encode( $stale_payload, $service->get_key() );
 		$_COOKIE['wp-jp-premium-content-session'] = $token_string;
@@ -1099,7 +1099,7 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 		$plan_id            = $users_plans[3];
 
 		wp_set_current_user( $paid_subscriber_id );
-		$stale_payload                            = $this->get_payload( true, true, time() - HOUR_IN_SECONDS );
+		$stale_payload                            = $this->get_payload( true, true, time() - 2 * DAY_IN_SECONDS );
 		$service                                  = subscription_service();
 		$token_string                             = JWT::encode( $stale_payload, $service->get_key() );
 		$_COOKIE['wp-jp-premium-content-session'] = $token_string;
@@ -1152,5 +1152,154 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 
 		$this->assertTrue( current_visitor_can_access( array( 'selectedPlanIds' => array( $plan_id ) ), array() ) );
 		$this->assertSame( 0, $this->refresh_call_count, 'Refresh endpoint should not be called when the token is still active.' );
+	}
+
+	/**
+	 * Create a plan post mapped to the test product_id and return its ID.
+	 *
+	 * @return int
+	 */
+	private function create_plan_for_product() {
+		$plan_id = $this->factory->post->create(
+			array( 'post_type' => Jetpack_Memberships::$post_type_plan )
+		);
+		update_post_meta( $plan_id, 'jetpack_memberships_product_id', $this->product_id );
+		return $plan_id;
+	}
+
+	/**
+	 * Build a token payload for a single active subscription with the given end_date.
+	 *
+	 * @param int|string $subscription_end_date Unix timestamp or datetime string for the end_date.
+	 * @return array
+	 */
+	private function get_subscription_payload( $subscription_end_date ) {
+		return array(
+			'blog_sub'      => 'active',
+			'subscriptions' => array(
+				$this->product_id => array(
+					'status'     => 'active',
+					'end_date'   => $subscription_end_date,
+					'product_id' => $this->product_id,
+				),
+			),
+		);
+	}
+
+	/**
+	 * Core of the NL-735 fix: a subscription whose exact end_date timestamp has passed but whose
+	 * end_date DAY is still today keeps access through end-of-day (UTC). This is the incident —
+	 * a same-day auto-renewal that billing had not yet finished processing.
+	 *
+	 * @return void
+	 */
+	public function test_validate_subscriptions_grants_access_through_end_of_end_date_day() {
+		$plan_id = $this->create_plan_for_product();
+		// Start of today (UTC): the exact timestamp is in the past, but the day is not over.
+		$expired_earlier_today = strtotime( gmdate( 'Y-m-d 00:00:00' ) . ' UTC' );
+		$subs                  = array(
+			$this->product_id => (object) array( 'end_date' => $expired_earlier_today ),
+		);
+
+		$this->assertTrue(
+			Abstract_Token_Subscription_Service::validate_subscriptions( array( $plan_id ), $subs ),
+			'A subscription whose end_date is earlier today should keep access until end of day.'
+		);
+	}
+
+	/**
+	 * Once the end_date day is fully over, access is denied — end-of-day is the boundary, not a
+	 * multi-day grace.
+	 *
+	 * @return void
+	 */
+	public function test_validate_subscriptions_denies_access_after_end_of_end_date_day() {
+		$plan_id = $this->create_plan_for_product();
+		$subs    = array(
+			$this->product_id => (object) array( 'end_date' => time() - DAY_IN_SECONDS ),
+		);
+
+		$this->assertFalse(
+			Abstract_Token_Subscription_Service::validate_subscriptions( array( $plan_id ), $subs ),
+			'A subscription whose end_date day has fully passed should be denied.'
+		);
+	}
+
+	/**
+	 * Regression guard: a subscription with a future end_date still validates.
+	 *
+	 * @return void
+	 */
+	public function test_validate_subscriptions_grants_future_subscription() {
+		$plan_id = $this->create_plan_for_product();
+		$subs    = array(
+			$this->product_id => (object) array( 'end_date' => time() + DAY_IN_SECONDS ),
+		);
+
+		$this->assertTrue(
+			Abstract_Token_Subscription_Service::validate_subscriptions( array( $plan_id ), $subs )
+		);
+	}
+
+	/**
+	 * The end_date may be a datetime string (as memberships store it) rather than an int
+	 * timestamp; end-of-day handling must work either way.
+	 *
+	 * @return void
+	 */
+	public function test_validate_subscriptions_handles_string_end_date_through_end_of_day() {
+		$plan_id = $this->create_plan_for_product();
+		$subs    = array(
+			// A datetime string earlier today (UTC), the format memberships persist.
+			$this->product_id => (object) array( 'end_date' => gmdate( 'Y-m-d 00:00:00' ) ),
+		);
+
+		$this->assertTrue(
+			Abstract_Token_Subscription_Service::validate_subscriptions( array( $plan_id ), $subs ),
+			'A string end_date earlier today should still grant access through end of day.'
+		);
+	}
+
+	/**
+	 * End-to-end mirror of the NL-735 incident on the non-tier path: a paid subscriber whose
+	 * token end_date passed earlier today (a same-day auto-renewal still processing) keeps
+	 * access — and, because validation succeeds directly, no refresh HTTP call is made.
+	 *
+	 * @return void
+	 */
+	public function test_access_check_grants_access_through_end_of_day() {
+		$users_plans        = $this->set_up_users_and_plans();
+		$paid_subscriber_id = $users_plans[2];
+		$plan_id            = $users_plans[3];
+
+		wp_set_current_user( $paid_subscriber_id );
+		$expired_earlier_today = strtotime( gmdate( 'Y-m-d 00:00:00' ) . ' UTC' );
+		$this->set_returned_token( $this->get_subscription_payload( $expired_earlier_today ) );
+
+		$this->assertTrue(
+			current_visitor_can_access( array( 'selectedPlanIds' => array( $plan_id ) ), array() ),
+			'A subscriber whose end_date is earlier today should retain access through end of day.'
+		);
+		$this->assertSame( 0, $this->refresh_call_count, 'End-of-day access should be granted directly, without a refresh call.' );
+	}
+
+	/**
+	 * Counterpart: once the end_date day has fully passed the token no longer grants access, and
+	 * the refresh attempt (mocked to 500) cannot save it, so access is denied.
+	 *
+	 * @return void
+	 */
+	public function test_access_check_denies_after_end_of_day() {
+		$users_plans        = $this->set_up_users_and_plans();
+		$paid_subscriber_id = $users_plans[2];
+		$plan_id            = $users_plans[3];
+
+		wp_set_current_user( $paid_subscriber_id );
+		$this->set_returned_token( $this->get_subscription_payload( time() - 2 * DAY_IN_SECONDS ) );
+
+		$this->assertFalse(
+			current_visitor_can_access( array( 'selectedPlanIds' => array( $plan_id ) ), array() ),
+			'A subscription whose end_date day has passed should be denied.'
+		);
 	}
 }

--- a/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/subscriptions/Jetpack_Subscriptions_Test.php
@@ -321,7 +321,10 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 	}
 
 	public static function matrix_access() {
-		$time_outdated = time() - HOUR_IN_SECONDS;
+		// A prior-day timestamp. Paid Content grants access through the end of the
+		// end_date day (UTC), so an "expired" fixture must be before that day to
+		// actually read as expired.
+		$time_outdated = time() - 2 * DAY_IN_SECONDS;
 
 		return array(
 			// The follow use cases are mainly yot be thourough and probably duplicates some former use cases
@@ -841,9 +844,10 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 		);
 		$this->assertTrue( $subscription_service->visitor_can_view_content( Jetpack_Memberships::get_all_newsletter_plan_ids(), $post_access_level ) );
 
-		// Let's make sure date is taken into account
+		// Let's make sure date is taken into account (a fully-past day, since access
+		// lasts through the end of the end_date day).
 		$subscription_service = $this->set_returned_token(
-			$this->get_payload( true, true, time() - HOUR_IN_SECONDS, null, $gold_tier_annual_plan_id )
+			$this->get_payload( true, true, time() - 2 * DAY_IN_SECONDS, null, $gold_tier_annual_plan_id )
 		);
 		$this->assertFalse( $subscription_service->visitor_can_view_content( Jetpack_Memberships::get_all_newsletter_plan_ids(), $post_access_level ) );
 
@@ -899,9 +903,10 @@ class Jetpack_Subscriptions_Test extends WP_UnitTestCase {
 		);
 		$this->assertTrue( $subscription_service->visitor_can_view_content( Jetpack_Memberships::get_all_newsletter_plan_ids(), $post_access_level ) );
 
-		// Expired comp should NOT bypass the tier gate.
+		// Expired comp should NOT bypass the tier gate (a fully-past day, since access
+		// lasts through the end of the end_date day).
 		$subscription_service = $this->set_returned_token(
-			$this->get_payload( true, true, time() - HOUR_IN_SECONDS, null, $bronze_tier_plan_id, true )
+			$this->get_payload( true, true, time() - 2 * DAY_IN_SECONDS, null, $bronze_tier_plan_id, true )
 		);
 		$this->assertFalse( $subscription_service->visitor_can_view_content( Jetpack_Memberships::get_all_newsletter_plan_ids(), $post_access_level ) );
 


### PR DESCRIPTION
Fixes NL-735

## Proposed changes

Paid Content enforced access on a membership subscription's **exact `end_date` timestamp**. Memberships store `end_date` as the precise purchase timestamp (e.g. `2026-07-10 09:34:45`), and auto-renewals run via a deferred day-0 billing job that BDSE spreads across a **3–10 hour window**. So a subscriber could lose access the instant their timestamp passed, hours before that day's renewal completed — even though the renewal then succeeded.

Billing (Shilling) confirmed the ~6h renewal deferral is expected, and that the wider WordPress.com / Jetpack platform already treats **end-of-day as the formal expiration time** for subscriptions (which is why expiration messaging/scheduling holds until EOD). Paid Content was the outlier, enforcing on the exact timestamp.

This PR aligns Paid Content with that convention: a subscription grants access **through `23:59:59` UTC of its `end_date` day**, in the two enforcement points (`validate_subscriptions()` non-tier, and `maybe_gate_access_for_user_if_tier()` tier). That naturally covers a same-day auto-renewal regardless of how long BDSE defers it.

**Why no gating is needed:** cancelled/inactive subscriptions never reach this check — they're dropped upstream by the `'active' === status` filter in `abbreviate_subscriptions()`. So end-of-day only ever extends an already-active subscription to the end of its final day, matching the platform. No `auto_renew` flag or grace-period duration is involved.

## Related product discussion/links

* NL-735
* Root-cause confirmed with Billing/Shilling: the 3–10h renewal deferral is expected; EOD expiration is the platform convention Monetize should follow.
* Complements NL-546 (post-renewal stale-JWT refresh): EOD covers the same-day pre-renewal gap; refresh still handles genuinely-old stale tokens.

## Does this pull request change what data or activity we track or use?

No. It changes only how the existing `end_date` is compared against the current time (rounded up to end-of-day, UTC). No new data, tracking, or token-shape change.

## Testing instructions

Automated: `jetpack docker phpunit jetpack -- tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php` — 34 tests / 79 assertions pass, including:

* A subscription whose exact `end_date` is earlier **today** still grants access (the incident case), end-to-end through `current_visitor_can_access` with no refresh call.
* A subscription whose `end_date` day has fully passed is denied.
* Future `end_date` still grants; string (`Y-m-d H:i:s`) and integer `end_date` values both handled.
* NL-546 refresh-before-deny tests updated to use a prior-day stale `end_date` so they still exercise the refresh path under end-of-day expiry.

Manual (Simple/Atomic, or a Jetpack Beta JN site): with a Premium Content post gated to a plan and an active subscription, set the subscription's `end_date` to earlier today via the `earn_get_user_subscriptions_for_site_id` filter → content stays visible; set it to a prior day → paywall returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)