### PR TITLE
Podcast: remove dead Episode_Block_Tags::render() seam

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-remove-dead-render
+++ b/projects/packages/podcast/changelog/fix-podcast-remove-dead-render
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Podcast: remove the unused `Episode_Block_Tags::render()` seam; production and tests compose `get_block_attrs()` + `render_from_attrs()` directly. No behavior change.

--- a/projects/packages/podcast/src/feed/class-episode-block-tags.php
+++ b/projects/packages/podcast/src/feed/class-episode-block-tags.php
@@ -20,21 +20,6 @@ use WP_Post;
 class Episode_Block_Tags {
 
 	/**
-	 * Emit item-level tags for a post if it contains a podcast-episode block.
-	 * Posts without the block contribute nothing — legacy audio items keep
-	 * their pre-block behavior intact.
-	 *
-	 * @param WP_Post $post Episode post.
-	 */
-	public static function render( WP_Post $post ): void {
-		$attrs = self::get_block_attrs( $post );
-		if ( empty( $attrs ) ) {
-			return;
-		}
-		self::render_from_attrs( $attrs );
-	}
-
-	/**
 	 * Testable seam — emit tags for a literal attrs array, skipping the block
 	 * parse. Each emit is independent and no-ops on missing/blank values.
 	 *

--- a/projects/packages/podcast/tests/php/Feed/Episode_Block_Tags_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Episode_Block_Tags_Test.php
@@ -28,7 +28,7 @@ class Episode_Block_Tags_Test extends BaseTestCase {
 	}
 
 	private function render_post( string $content ): string {
-		$post = new WP_Post(
+		$post  = new WP_Post(
 			(object) array(
 				'ID'           => 1,
 				'post_content' => $content,

--- a/projects/packages/podcast/tests/php/Feed/Episode_Block_Tags_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Episode_Block_Tags_Test.php
@@ -34,8 +34,11 @@ class Episode_Block_Tags_Test extends BaseTestCase {
 				'post_content' => $content,
 			)
 		);
+		$attrs = Episode_Block_Tags::get_block_attrs( $post );
 		ob_start();
-		Episode_Block_Tags::render( $post );
+		if ( ! empty( $attrs ) ) {
+			Episode_Block_Tags::render_from_attrs( $attrs );
+		}
 		return (string) ob_get_clean();
 	}
 


### PR DESCRIPTION
### What

`Episode_Block_Tags::render()` had no production caller — the feed (`class-customize-feed.php`) already calls `get_block_attrs()` + `render_from_attrs()` directly so it can reuse the attrs for cover art. The method was only reachable from one test helper.

- Removed the dead method.
- Repointed the test helper to compose the same two methods, so it now exercises the real production path (same assertions).

No behavior change.

### Testing

- `php -l` clean on both files; no dangling `::render()` references.
- Couldn't run PHPUnit locally (needs the monorepo `phpunit-select-config` helper) — CI covers it.
