### PR TITLE
Forms: restore listView block support on the contact-form block

### DIFF
--- a/projects/packages/forms/changelog/fix-restore-contact-form-listview-support
+++ b/projects/packages/forms/changelog/fix-restore-contact-form-listview-support
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Contact Form: restore the listView block support so form fields can be managed from the editor List View (regressed when block attributes were ported to block.json metadata).

--- a/projects/packages/forms/src/blocks/contact-form/block.json
+++ b/projects/packages/forms/src/blocks/contact-form/block.json
@@ -46,7 +46,8 @@
 				"style": true,
 				"width": true
 			}
-		}
+		},
+		"listView": true
 	},
 	"attributes": {},
 	"editorScript": "file:./editor.js",

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -72,6 +72,7 @@ class Contact_Form_Block {
 							'width'  => true,
 						),
 					),
+					'listView'             => true,
 				),
 				'style_handles'         => array( 'jetpack-forms-layout' ),
 			)


### PR DESCRIPTION
## Proposed changes
* Restore the `listView` block support on the `jetpack/contact-form` block. This support was accidentally dropped when the block's attributes were ported to the `block.json` metadata file, and it stopped surfacing form fields in the editor List View — making it harder to reorder/manage fields and reducing compatibility with WordPress content-only editing mode.
* It is reinstated on both registration paths so they stay symmetric: the JS `block.json` (`supports.listView`) and the PHP `class-contact-form-block.php` supports array.

Originally added in [#46403](https://github.com/Automattic/jetpack/pull/46403); regressed around the metadata port in [#45272](https://github.com/Automattic/jetpack/pull/45272).

## Related product discussion/links
* Surfaced internally by mikael in the `#zap` Slack channel (Automattician-only discussion).

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Build the Forms package (or use a JN site with this branch).
* In the block editor, insert a **Form** block (or open a post that already contains one).
* Open the editor **List View** (the list icon in the top toolbar).
* Confirm the Form block is expandable and its inner field blocks (Name, Email, etc.) are listed and can be selected/reordered from the List View.
* Before this change the Form block did not expand to show its inner fields in List View; after it does.
