### PR TITLE
Fix My Jetpack route crash in Chrome (And Protect)

### DIFF
--- a/projects/packages/my-jetpack/_inc/admin.jsx
+++ b/projects/packages/my-jetpack/_inc/admin.jsx
@@ -43,7 +43,9 @@ import Providers from './providers';
  */
 function ScrollToTop() {
 	const location = useLocation();
-	useEffect( () => window.scrollTo( 0, 0 ), [ location ] );
+	useEffect( () => {
+		window.scrollTo( 0, 0 );
+	}, [ location ] );
 
 	return null;
 }

--- a/projects/packages/my-jetpack/changelog/fix-scrollto-route-crash
+++ b/projects/packages/my-jetpack/changelog/fix-scrollto-route-crash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: fix route changes in Chrome when scroll APIs return promises.

--- a/projects/plugins/protect/changelog/fix-scrollto-route-crash
+++ b/projects/plugins/protect/changelog/fix-scrollto-route-crash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Protect: fix route changes in Chrome when scroll APIs return promises.

--- a/projects/plugins/protect/src/js/index.tsx
+++ b/projects/plugins/protect/src/js/index.tsx
@@ -32,7 +32,9 @@ const queryClient = new QueryClient( {
  */
 function ScrollToTop() {
 	const location = useLocation();
-	useEffect( () => window.scrollTo( 0, 0 ), [ location ] );
+	useEffect( () => {
+		window.scrollTo( 0, 0 );
+	}, [ location ] );
 
 	return null;
 }


### PR DESCRIPTION
Fixes: p1783960683602709-slack-C0299DMPG

## Summary
- Prevent the My Jetpack and Protect plugin `ScrollToTop` effect from returning the result of `window.scrollTo()`.
- Avoid React treating Chromium scroll API promises as effect cleanup callbacks on route changes.

Causes a blank page. 

## Why this happens in Chrome
`ScrollToTop` used a concise arrow effect: `useEffect( () => window.scrollTo( 0, 0 ), [ location ] )`. React treats any value returned from an effect callback as that effect cleanup. In Firefox, `window.scrollTo( 0, 0 )` returns `undefined`, so there is no cleanup. In Chrome/Chromium, the same call can return a `Promise`; React stores that promise as the cleanup value and then tries to call it during the next route change/unmount. Because the promise is not a function, React throws from its effect cleanup path, which leaves the My Jetpack admin page blank.

The fix keeps the scroll behavior but uses a block body so the effect callback returns `undefined` consistently across browsers.

## Testing instructions:
- In Chrome
- Click on top-level jetpack admin menu item
- Click on all of these tabs: 

<img width="718" height="393" alt="image" src="https://github.com/user-attachments/assets/22bad6ab-fe7f-4391-ae8c-cd583531f7bf" />

## Does this pull request change what data or activity we track or use?
No