### PR TITLE
Forms: remove helper copy from Form block sidebar toggles

### DIFF
--- a/projects/packages/forms/changelog/update-forms-helper-text
+++ b/projects/packages/forms/changelog/update-forms-helper-text
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Removed some helper text from the Form block sidebar
+
+

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-email-connection-settings.jsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-email-connection-settings.jsx
@@ -90,7 +90,6 @@ const JetpackEmailConnectionSettings = ( {
 			<ToggleControl
 				label={ __( 'Email me new responses', 'jetpack-forms' ) }
 				checked={ emailNotifications }
-				help={ __( 'Get incoming form responses sent to your email inbox.', 'jetpack-forms' ) }
 				onChange={ value => setAttributes( { emailNotifications: value } ) }
 				__nextHasNoMarginBottom={ true }
 			/>

--- a/projects/packages/forms/src/blocks/contact-form/components/notifications-settings.jsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/notifications-settings.jsx
@@ -1,12 +1,9 @@
-import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
-import { WpcomSupportLink } from '@automattic/jetpack-shared-extension-utils/components';
 import { FormTokenField, ToggleControl } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
-import { useState, createInterpolateElement } from '@wordpress/element';
+import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Link } from '@wordpress/ui';
 import JetpackEmailConnectionSettings from './jetpack-email-connection-settings.jsx';
 
 const NotificationsSettings = ( {
@@ -58,11 +55,6 @@ const NotificationsSettings = ( {
 	// All available user names for suggestions
 	const allUserNames = eligibleUsers.map( user => user.name || user.slug );
 
-	const isWpcom = isWpcomPlatformSite();
-	const wpcomSupportLink =
-		'https://wordpress.com/support/wordpress-editor/blocks/form-block/view-contact-form-messages/#receive-push-notifications';
-	const jetpackSupportLink = 'https://jetpack.com/support/notifications/';
-
 	return (
 		<>
 			<JetpackEmailConnectionSettings
@@ -76,19 +68,6 @@ const NotificationsSettings = ( {
 			<>
 				<ToggleControl
 					label={ __( 'Send me push notifications', 'jetpack-forms' ) }
-					help={ createInterpolateElement(
-						__(
-							'Receive push notifications when someone fills out your form. <pushNotificationsLink>Learn more.</pushNotificationsLink>',
-							'jetpack-forms'
-						),
-						{
-							pushNotificationsLink: isWpcom ? (
-								<WpcomSupportLink supportLink={ wpcomSupportLink } />
-							) : (
-								<Link openInNewTab href={ jetpackSupportLink } />
-							),
-						}
-					) }
 					checked={ localFormNotifications }
 					onChange={ value => {
 						if ( value ) {

--- a/projects/packages/forms/src/blocks/shared/components/jetpack-manage-responses-settings.jsx
+++ b/projects/packages/forms/src/blocks/shared/components/jetpack-manage-responses-settings.jsx
@@ -12,10 +12,6 @@ const JetpackManageResponsesSettings = ( { attributes, setAttributes } ) => {
 		<>
 			<ToggleControl
 				label={ __( 'Save responses', 'jetpack-forms' ) }
-				help={ __(
-					'Keep responses saved, or set up email/integration to avoid losing them.',
-					'jetpack-forms'
-				) }
 				checked={ saveResponses }
 				onChange={ value => setAttributes( { saveResponses: value } ) }
 				__nextHasNoMarginBottom={ true }


### PR DESCRIPTION
Fixes DSGCOM-691

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Removes the descriptive helper text under three toggles in the Form block's sidebar to reduce visual clutter in the Form notification and Response storage sections:
  * "Email me new responses" — removed _"Get incoming form responses sent to your email inbox."_
  * "Send me push notifications" — removed _"Receive push notifications when someone fills out your form. Learn more."_
  * "Save responses" — removed _"Keep responses saved, or set up email/integration to avoid losing them."_
* Cleans up now-unused imports (`isWpcomPlatformSite`, `WpcomSupportLink`, `createInterpolateElement`, `Link`) in `notifications-settings.jsx`.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* https://linear.app/a8c/issue/DSGCOM-691/jetpack-forms-remove-helper-copy

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
* Create or edit a post/page and add a **Form** block.
* Select the form block and open the block settings sidebar.
* Under the **Form notification** section, confirm the "Email me new responses" and "Send me push notifications" toggles no longer show helper text below them.
* Under the **Response storage** section, confirm the "Save responses" toggle no longer shows helper text below it.
* Verify the toggles still function correctly (enabling/disabling still updates the block attributes).
