### PR TITLE
REST API: cast site_ID to an integer in v1.1 post responses

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-post-site-id-integer-type
+++ b/projects/plugins/jetpack/changelog/fix-post-site-id-integer-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Fix site_ID being returned as a string instead of an integer from the v1.1 posts create and update REST API endpoints

--- a/projects/plugins/jetpack/changelog/fix-post-site-id-integer-type
+++ b/projects/plugins/jetpack/changelog/fix-post-site-id-integer-type
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Fix site_ID being returned as a string instead of an integer from the v1.1 posts create and update REST API endpoints
+REST API: Fix site_ID being returned as a string instead of an integer in v1.1 post responses.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-post-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-post-v1-1-endpoint.php
@@ -179,7 +179,7 @@ abstract class WPCOM_JSON_API_Post_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint
 					$response[ $key ] = (int) $post->ID;
 					break;
 				case 'site_ID':
-					$response[ $key ] = $post->site->get_id();
+					$response[ $key ] = (int) $post->site->get_id();
 					break;
 				case 'author':
 					$response[ $key ] = $post->get_author();

--- a/projects/plugins/jetpack/tests/php/json-api/Json_Api_Update_Post_Endpoints_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/Json_Api_Update_Post_Endpoints_Test.php
@@ -33,6 +33,13 @@ class Json_Api_Update_Post_Endpoints_Test extends WP_UnitTestCase {
 	private static $admin_user_id;
 
 	/**
+	 * Saved $_SERVER superglobal.
+	 *
+	 * @var array
+	 */
+	private $pre_globals;
+
+	/**
 	 * Create fixtures once, before any tests in the class have run.
 	 *
 	 * @param WP_UnitTest_Factory $factory A factory object.
@@ -62,6 +69,7 @@ class Json_Api_Update_Post_Endpoints_Test extends WP_UnitTestCase {
 
 		parent::set_up();
 
+		$this->pre_globals = $_SERVER;
 		$this->set_globals();
 
 		WPCOM_JSON_API::init()->token_details = array( 'blog_id' => $blog_id );
@@ -76,6 +84,8 @@ class Json_Api_Update_Post_Endpoints_Test extends WP_UnitTestCase {
 		$api->post_body     = null;
 		$api->content_type  = null;
 		wp_set_current_user( 0 );
+
+		$_SERVER = $this->pre_globals;
 
 		parent::tear_down();
 	}
@@ -117,8 +127,9 @@ class Json_Api_Update_Post_Endpoints_Test extends WP_UnitTestCase {
 	 * as an integer, matching its documented `(int) The site ID.` contract.
 	 *
 	 * `site_ID` is emitted from `$post->site->get_id()`, which returns the
-	 * request token's `blog_id` verbatim. On create/update requests that value
-	 * is a string, so without the `(int)` cast in
+	 * request token's `blog_id` verbatim. That `blog_id` comes from
+	 * `Jetpack_Options::get_option( 'id' )` and is commonly a string, so without
+	 * the `(int)` cast in
 	 * `WPCOM_JSON_API_Post_v1_1_Endpoint::render_response_keys()` the response
 	 * leaks a quoted string. We reproduce that by giving the token a string
 	 * `blog_id`; this assertion fails on the unfixed serializer.
@@ -183,8 +194,9 @@ class Json_Api_Update_Post_Endpoints_Test extends WP_UnitTestCase {
 		$api = WPCOM_JSON_API::init();
 
 		// Jetpack_Site::get_id() returns $this->platform->token->blog_id verbatim.
-		// A string value mirrors the create/update request condition, and it is the
-		// WP.com site ID, distinct from the local $GLOBALS['blog_id'] used for routing.
+		// The token blog_id comes from Jetpack_Options::get_option( 'id' ) and is
+		// commonly a string; using one here (the WP.com site ID, distinct from the
+		// local $GLOBALS['blog_id'] used for routing) exercises the (int) cast.
 		$api->token_details = array( 'blog_id' => (string) self::WPCOM_SITE_ID );
 		$api->content_type  = 'application/json';
 		$api->post_body     = (string) wp_json_encode( $input, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );

--- a/projects/plugins/jetpack/tests/php/json-api/Json_Api_Update_Post_Endpoints_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/Json_Api_Update_Post_Endpoints_Test.php
@@ -5,6 +5,8 @@
  * @package automattic/jetpack
  */
 
+use PHPUnit\Framework\Attributes\Group;
+
 require_once JETPACK__PLUGIN_DIR . 'class.json-api-endpoints.php';
 
 /**
@@ -12,6 +14,32 @@ require_once JETPACK__PLUGIN_DIR . 'class.json-api-endpoints.php';
  */
 class Json_Api_Update_Post_Endpoints_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * A WP.com site ID carried by the request token, deliberately distinct from
+	 * the local `$GLOBALS['blog_id']`. `site_ID` is serialized from this token
+	 * value (not the local blog), so a distinct number proves the field follows
+	 * the token rather than coincidentally matching the local blog ID.
+	 *
+	 * @var int
+	 */
+	private const WPCOM_SITE_ID = 1234567;
+
+	/**
+	 * An admin user ID, used to authorize write requests.
+	 *
+	 * @var int
+	 */
+	private static $admin_user_id;
+
+	/**
+	 * Create fixtures once, before any tests in the class have run.
+	 *
+	 * @param WP_UnitTest_Factory $factory A factory object.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_user_id = $factory->user->create( array( 'role' => 'administrator' ) );
+	}
 
 	/**
 	 * Inserts globals needed to initialize the endpoint.
@@ -37,6 +65,19 @@ class Json_Api_Update_Post_Endpoints_Test extends WP_UnitTestCase {
 		$this->set_globals();
 
 		WPCOM_JSON_API::init()->token_details = array( 'blog_id' => $blog_id );
+	}
+
+	/**
+	 * Reset shared API singleton state after each test.
+	 */
+	public function tear_down() {
+		$api                = WPCOM_JSON_API::init();
+		$api->token_details = array();
+		$api->post_body     = null;
+		$api->content_type  = null;
+		wp_set_current_user( 0 );
+
+		parent::tear_down();
 	}
 
 	/**
@@ -69,6 +110,86 @@ class Json_Api_Update_Post_Endpoints_Test extends WP_UnitTestCase {
 		$updated_input = $this->invoke_method( $endpoint, 'untrash_post', array( $post, $input ) );
 		// Tests that we remove the slug id it contains the '__trashed' suffix.
 		$this->assertEmpty( $updated_input );
+	}
+
+	/**
+	 * The create endpoint (`POST /sites/%s/posts/new`) must serialize `site_ID`
+	 * as an integer, matching its documented `(int) The site ID.` contract.
+	 *
+	 * `site_ID` is emitted from `$post->site->get_id()`, which returns the
+	 * request token's `blog_id` verbatim. On create/update requests that value
+	 * is a string, so without the `(int)` cast in
+	 * `WPCOM_JSON_API_Post_v1_1_Endpoint::render_response_keys()` the response
+	 * leaks a quoted string. We reproduce that by giving the token a string
+	 * `blog_id`; this assertion fails on the unfixed serializer.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_create_post_returns_site_id_as_an_integer() {
+		wp_set_current_user( self::$admin_user_id );
+
+		$response = $this->write_via_endpoint(
+			'/sites/' . self::WPCOM_SITE_ID . '/posts/new',
+			0,
+			array(
+				'title'  => 'Created in test',
+				'status' => 'draft',
+			)
+		);
+
+		$this->assertIsArray( $response );
+		$this->assertArrayHasKey( 'site_ID', $response );
+		$this->assertIsInt( $response['site_ID'] );
+		$this->assertSame( self::WPCOM_SITE_ID, $response['site_ID'] );
+	}
+
+	/**
+	 * The update endpoint (`POST /sites/%s/posts/%d`) must serialize `site_ID`
+	 * as an integer, for the same reason and via the same inherited
+	 * `get_post_by()` -> `render_response_keys()` path as create.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_update_post_returns_site_id_as_an_integer() {
+		wp_set_current_user( self::$admin_user_id );
+
+		$post_id = $this->get_post();
+
+		$response = $this->write_via_endpoint(
+			'/sites/' . self::WPCOM_SITE_ID . '/posts/' . $post_id,
+			$post_id,
+			array( 'title' => 'Updated in test' )
+		);
+
+		$this->assertIsArray( $response );
+		$this->assertArrayHasKey( 'site_ID', $response );
+		$this->assertIsInt( $response['site_ID'] );
+		$this->assertSame( self::WPCOM_SITE_ID, $response['site_ID'] );
+	}
+
+	/**
+	 * Drive the update endpoint's `callback()` for a create or update request,
+	 * forcing the string `blog_id` token condition that makes `site_ID` leak as
+	 * a string on the unfixed serializer.
+	 *
+	 * @param string $path    The request path (ending in `/new` to create).
+	 * @param int    $post_id The post ID (0 when creating).
+	 * @param array  $input   The request body fields.
+	 * @return array|WP_Error The endpoint response.
+	 */
+	private function write_via_endpoint( $path, $post_id, array $input ) {
+		$api = WPCOM_JSON_API::init();
+
+		// Jetpack_Site::get_id() returns $this->platform->token->blog_id verbatim.
+		// A string value mirrors the create/update request condition, and it is the
+		// WP.com site ID, distinct from the local $GLOBALS['blog_id'] used for routing.
+		$api->token_details = array( 'blog_id' => (string) self::WPCOM_SITE_ID );
+		$api->content_type  = 'application/json';
+		$api->post_body     = (string) wp_json_encode( $input, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+
+		return $this->get_endpoint()->callback( $path, self::WPCOM_SITE_ID, $post_id );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Get_Post_v1_1_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Get_Post_v1_1_Endpoint_Test.php
@@ -238,4 +238,37 @@ class WPCOM_JSON_API_Get_Post_v1_1_Endpoint_Test extends WP_UnitTestCase { // ph
 		$this->assertInstanceOf( WP_Error::class, $response );
 		$this->assertSame( 'unknown_post', $response->get_error_code() );
 	}
+
+	/**
+	 * The site_ID field must always be serialized as an integer, matching its
+	 * documented '(int) The site ID.' contract.
+	 *
+	 * The render_response_keys() serializer emits site_ID from
+	 * $post->site->get_id(). For a Jetpack_Site that returns the request token's
+	 * blog_id verbatim, and on create/update requests that value is a string —
+	 * so without an explicit (int) cast those endpoints leaked a quoted string
+	 * while reads returned a number. We reproduce that condition by giving the
+	 * token a string blog_id.
+	 *
+	 * @group json-api
+	 */
+	#[Group( 'json-api' )]
+	public function test_site_id_is_returned_as_an_integer() {
+		$post_id = $this->create_post();
+
+		// Jetpack_Site::get_id() returns $this->platform->token->blog_id; a string
+		// value here mirrors the create/update request condition.
+		WPCOM_JSON_API::init()->token_details = array( 'blog_id' => (string) self::$blog_id );
+
+		$response = $this->get_endpoint()->callback(
+			'/sites/' . self::$blog_id . '/posts/' . $post_id,
+			self::$blog_id,
+			$post_id
+		);
+
+		$this->assertIsArray( $response );
+		$this->assertArrayHasKey( 'site_ID', $response );
+		$this->assertIsInt( $response['site_ID'] );
+		$this->assertSame( (int) self::$blog_id, $response['site_ID'] );
+	}
 }

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Get_Post_v1_1_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Get_Post_v1_1_Endpoint_Test.php
@@ -244,11 +244,11 @@ class WPCOM_JSON_API_Get_Post_v1_1_Endpoint_Test extends WP_UnitTestCase { // ph
 	 * documented '(int) The site ID.' contract.
 	 *
 	 * The render_response_keys() serializer emits site_ID from
-	 * $post->site->get_id(). For a Jetpack_Site that returns the request token's
-	 * blog_id verbatim, and on create/update requests that value is a string —
-	 * so without an explicit (int) cast those endpoints leaked a quoted string
-	 * while reads returned a number. We reproduce that condition by giving the
-	 * token a string blog_id.
+	 * $post->site->get_id(), which returns the request token's blog_id verbatim.
+	 * That blog_id originates from Jetpack_Options::get_option( 'id' ) and is
+	 * commonly a string, so without an explicit (int) cast the serializer leaked a
+	 * quoted string. We reproduce that condition by giving the token a string
+	 * blog_id.
 	 *
 	 * @group json-api
 	 */


### PR DESCRIPTION
## Proposed changes

* The v1.1 post serializer emitted `site_ID` without the `(int)` cast that every sibling ID field uses. The value comes from `$post->site->get_id()`, which returns an `int` on reads but a `string` on writes — so `GET /rest/v1.1/sites/$site/posts/$ID` returned `site_ID` as a JSON number while `POST …/posts/new` and `POST …/posts/$ID` returned it as a quoted string, violating the documented `(int)` contract.
* Added the missing `(int)` cast in `WPCOM_JSON_API_Post_v1_1_Endpoint::render_response_keys()`, matching the adjacent `case 'ID'`. **One line covers read, create, and update** — the create/update endpoint (`WPCOM_JSON_API_Update_Post_v1_1_Endpoint`) extends this class and returns via the same inherited `get_post_by()`.
* The v1 sibling (`WPCOM_JSON_API_Post_Endpoint`) already casts `site_ID` to `(int)`, so no change was needed there. `case 'ID'` was already cast and is left untouched.

This fixes [a crash in the iOS Share Extension](https://github.com/wordpress-mobile/WordPress-iOS/pull/25773), which reads `site_ID` as an `NSNumber`.

## Related product discussion/links

* iOS Share Extension crash caused by `site_ID` arriving as a string from the create/update endpoints.
* This bug is a regression – https://github.com/Automattic/jetpack/pull/3639 broke a prior cast that had normalized the value to an int.

## Does this pull request change what data or activity we track or use?

No. This only normalizes the JSON type of an existing field (`site_ID`) to match the documented `(int)` contract; no new data is collected.

## Testing instructions

On a WP.com sandbox:

* `POST /rest/v1.1/sites/$site/posts/new` (create) and `POST /rest/v1.1/sites/$site/posts/$ID` (update) — confirm the response now returns `"site_ID": 123` as an **unquoted number**, matching the `GET /rest/v1.1/sites/$site/posts/$ID` response.
* Confirm no other field's type changed.
