### PR TITLE
Charts: contain aspectRatio charts within their parent (CHARTS-242)

### DIFF
--- a/projects/js-packages/charts/changelog/charts-242-heatmap-chart-does-not-shrink-vertically-with-aspect-ratio
+++ b/projects/js-packages/charts/changelog/charts-242-heatmap-chart-does-not-shrink-vertically-with-aspect-ratio
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Charts: keep aspectRatio charts within their parent on both axes so a height-constrained container no longer overflows vertically.

--- a/projects/js-packages/charts/src/charts/area-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/area-chart/stories/index.api.mdx
@@ -15,7 +15,7 @@ Stacked-by-default area chart component with responsive behaviour.
 | `data` | `SeriesData[]` | - | **Required.** Array of data series to display |
 | `width` | `number?` | responsive | Chart width in pixels |
 | `height` | `number?` | responsive | Chart height in pixels |
-| `aspectRatio` | `number` | - | Height as a fraction of width (e.g. `0.4`) for responsive charts. The chart fills the available width and derives its height, but if the parent is shorter it shrinks both axes to fit rather than overflowing (contained on both axes), and is centered horizontally when narrower than the parent. Used when `width`/`height` are omitted. |
+| `aspectRatio` | `number` | - | Height-to-width ratio (e.g. `0.4`) for responsive charts; the chart is contained within its parent on both axes. Used when `width`/`height` are omitted. |
 | `stacked` | `boolean` | `true` | Whether series should stack on top of each other |
 | `stackOffset` | `'none' \| 'expand' \| 'wiggle' \| 'silhouette'` | `'none'` | Stack offset strategy. `'expand'` produces a 100% stack, `'wiggle'` a streamgraph, `'silhouette'` a centred stack |
 | `smoothing` | `boolean` | `true` | Use Catmull-Rom curve smoothing. Ignored when `curveType` is set |

--- a/projects/js-packages/charts/src/charts/area-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/area-chart/stories/index.api.mdx
@@ -15,6 +15,7 @@ Stacked-by-default area chart component with responsive behaviour.
 | `data` | `SeriesData[]` | - | **Required.** Array of data series to display |
 | `width` | `number?` | responsive | Chart width in pixels |
 | `height` | `number?` | responsive | Chart height in pixels |
+| `aspectRatio` | `number` | - | Height as a fraction of width (e.g. `0.4`) for responsive charts. The chart fills the available width and derives its height, but if the parent is shorter it shrinks both axes to fit rather than overflowing (contained on both axes), and is centered horizontally when narrower than the parent. Used when `width`/`height` are omitted. |
 | `stacked` | `boolean` | `true` | Whether series should stack on top of each other |
 | `stackOffset` | `'none' \| 'expand' \| 'wiggle' \| 'silhouette'` | `'none'` | Stack offset strategy. `'expand'` produces a 100% stack, `'wiggle'` a streamgraph, `'silhouette'` a centred stack |
 | `smoothing` | `boolean` | `true` | Use Catmull-Rom curve smoothing. Ignored when `curveType` is set |

--- a/projects/js-packages/charts/src/charts/area-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/area-chart/stories/index.docs.mdx
@@ -100,11 +100,27 @@ For full legend configuration options, see the [Legend component docs](./?path=/
 
 ## Responsive Behavior
 
-By default, charts fill their parent container's dimensions. The parent must have an explicit height, or the chart must receive an `aspectRatio` prop:
+By default, charts **fill their parent container's dimensions**. The parent must have an explicit height, or the chart must receive an `aspectRatio`:
 
 <Canvas of={ AreaChartStories.AspectRatio } />
 
-For more details, see the [Responsive Design section](./?path=/docs/js-packages-charts-library-introduction--docs#responsive-design).
+<Source
+	language="jsx"
+	code={ `// Fill parent container (default) - parent needs explicit height
+	<div style={{ width: '100%', height: '400px' }}>
+		<AreaChart data={ data } />
+	</div>
+
+	// Use aspect ratio - height calculated from width
+	<div style={{ width: '100%' }}>
+		<AreaChart data={ data } aspectRatio={ 0.5 } />
+	</div>
+
+	// Fixed dimensions
+	<AreaChart data={ data } width={ 800 } height={ 400 } />` }
+/>
+
+For more details on responsive behavior, see the [Responsive Design section](./?path=/docs/js-packages-charts-library-introduction--docs#responsive-design) in the introduction.
 
 ## Animation
 

--- a/projects/js-packages/charts/src/charts/area-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/area-chart/stories/index.docs.mdx
@@ -111,7 +111,7 @@ By default, charts **fill their parent container's dimensions**. The parent must
 		<AreaChart data={ data } />
 	</div>
 
-	// Use aspect ratio - height calculated from width
+	// Use aspect ratio - height from width, contained if the parent is shorter
 	<div style={{ width: '100%' }}>
 		<AreaChart data={ data } aspectRatio={ 0.5 } />
 	</div>

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.api.mdx
@@ -16,6 +16,7 @@ Main chart component with responsive behavior by default.
 | `chartId` | `string` | auto-generated | Optional unique identifier for the chart |
 | `width` | `number` | responsive | Chart width in pixels |
 | `height` | `number` | `400` | Chart height in pixels |
+| `aspectRatio` | `number` | - | Height as a fraction of width (e.g. `0.4`) for responsive charts. The chart fills the available width and derives its height, but if the parent is shorter it shrinks both axes to fit rather than overflowing (contained on both axes), and is centered horizontally when narrower than the parent. Used when `width`/`height` are omitted. |
 | `orientation` | `'vertical' \| 'horizontal'` | `'vertical'` | Bar orientation |
 | `withTooltips` | `boolean` | `false` | Enable interactive tooltips |
 | `withPatterns` | `boolean` | `false` | Use pattern fills for accessibility |

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.api.mdx
@@ -16,7 +16,7 @@ Main chart component with responsive behavior by default.
 | `chartId` | `string` | auto-generated | Optional unique identifier for the chart |
 | `width` | `number` | responsive | Chart width in pixels |
 | `height` | `number` | `400` | Chart height in pixels |
-| `aspectRatio` | `number` | - | Height as a fraction of width (e.g. `0.4`) for responsive charts. The chart fills the available width and derives its height, but if the parent is shorter it shrinks both axes to fit rather than overflowing (contained on both axes), and is centered horizontally when narrower than the parent. Used when `width`/`height` are omitted. |
+| `aspectRatio` | `number` | - | Height-to-width ratio (e.g. `0.4`) for responsive charts; the chart is contained within its parent on both axes. Used when `width`/`height` are omitted. |
 | `orientation` | `'vertical' \| 'horizontal'` | `'vertical'` | Bar orientation |
 | `withTooltips` | `boolean` | `false` | Enable interactive tooltips |
 | `withPatterns` | `boolean` | `false` | Use pattern fills for accessibility |

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
@@ -65,7 +65,7 @@ The simplest bar chart requires only a `data` prop with categorical data:
 - **`width`**: Chart width in pixels. When omitted, fills parent container width
 - **`height`**: Chart height in pixels (defaults to 400). When omitted, fills parent container height
 - **`margin`**: Custom chart margins
-- **`aspectRatio`**: Height as a fraction of width (e.g., `0.5` = 50% height). When omitted, fills parent container height
+- **`aspectRatio`**: Height as a fraction of width (e.g., `0.5` = 50% height); if the parent is shorter than that height, the chart shrinks both axes to fit rather than overflowing (contained on both axes). When omitted, fills parent container height
 - **`maxWidth`**: Maximum width constraint for responsive charts (default: `1200`)
 - **`resizeDebounceTime`**: Debounce delay for resize events in ms (default: `300`)
 

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
@@ -65,7 +65,7 @@ The simplest bar chart requires only a `data` prop with categorical data:
 - **`width`**: Chart width in pixels. When omitted, fills parent container width
 - **`height`**: Chart height in pixels (defaults to 400). When omitted, fills parent container height
 - **`margin`**: Custom chart margins
-- **`aspectRatio`**: Height as a fraction of width (e.g., `0.5` = 50% height); if the parent is shorter than that height, the chart shrinks both axes to fit rather than overflowing (contained on both axes). When omitted, fills parent container height
+- **`aspectRatio`**: Height-to-width ratio (e.g. `0.5`) for responsive charts; the chart is contained within its parent on both axes. When omitted, fills the parent container's height
 - **`maxWidth`**: Maximum width constraint for responsive charts (default: `1200`)
 - **`resizeDebounceTime`**: Debounce delay for resize events in ms (default: `300`)
 

--- a/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/bar-chart/stories/index.docs.mdx
@@ -383,7 +383,7 @@ By default, charts **fill their parent container's dimensions**. The parent must
 		<BarChart data={data} />
 	</div>
 
-	// Use aspect ratio - height calculated from width
+	// Use aspect ratio - height from width, contained if the parent is shorter
 	<div style={{ width: '100%' }}>
 		<BarChart data={data} aspectRatio={0.5} />
 	</div>

--- a/projects/js-packages/charts/src/charts/bar-list-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/bar-list-chart/stories/index.api.mdx
@@ -15,6 +15,7 @@ A horizontal bar chart component optimized for list-style data presentation.
 | `data` | `SeriesData[]` | - | **Required.** Array of series data objects |
 | `width` | `number` | - | Chart width in pixels |
 | `height` | `number` | `400` | Chart height in pixels |
+| `aspectRatio` | `number` | - | Height as a fraction of width (e.g. `0.4`) for responsive charts. The chart fills the available width and derives its height, but if the parent is shorter it shrinks both axes to fit rather than overflowing (contained on both axes), and is centered horizontally when narrower than the parent. Used when `width`/`height` are omitted. |
 | `margin` | `ChartMargin` | `{ left: 0, right: 20, bottom: 0, top: 0 }` | Chart margins |
 | `withTooltips` | `boolean` | `false` | Enable interactive tooltips |
 | `animation` | `boolean` | `false` | Enable entry animation on initial render. Bars stretch from left to right. Automatically respects user's `prefers-reduced-motion` system setting |

--- a/projects/js-packages/charts/src/charts/bar-list-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/bar-list-chart/stories/index.api.mdx
@@ -15,7 +15,7 @@ A horizontal bar chart component optimized for list-style data presentation.
 | `data` | `SeriesData[]` | - | **Required.** Array of series data objects |
 | `width` | `number` | - | Chart width in pixels |
 | `height` | `number` | `400` | Chart height in pixels |
-| `aspectRatio` | `number` | - | Height as a fraction of width (e.g. `0.4`) for responsive charts. The chart fills the available width and derives its height, but if the parent is shorter it shrinks both axes to fit rather than overflowing (contained on both axes), and is centered horizontally when narrower than the parent. Used when `width`/`height` are omitted. |
+| `aspectRatio` | `number` | - | Height-to-width ratio (e.g. `0.4`) for responsive charts; the chart is contained within its parent on both axes. Used when `width`/`height` are omitted. |
 | `margin` | `ChartMargin` | `{ left: 0, right: 20, bottom: 0, top: 0 }` | Chart margins |
 | `withTooltips` | `boolean` | `false` | Enable interactive tooltips |
 | `animation` | `boolean` | `false` | Enable entry animation on initial render. Bars stretch from left to right. Automatically respects user's `prefers-reduced-motion` system setting |

--- a/projects/js-packages/charts/src/charts/bar-list-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/bar-list-chart/stories/index.docs.mdx
@@ -282,7 +282,7 @@ By default, BarListChart **fills its parent container's dimensions**. The parent
 		<BarListChart data={data} />
 	</div>
 
-	// Use aspect ratio - height calculated from width
+	// Use aspect ratio - height from width, contained if the parent is shorter
 	<div style={{ width: '100%' }}>
 		<BarListChart data={data} aspectRatio={0.4} />
 	</div>

--- a/projects/js-packages/charts/src/charts/geo-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/geo-chart/stories/index.api.mdx
@@ -15,7 +15,7 @@ Main component for rendering geographical data on an interactive world map using
 | `data` | `GeoData` | - | **Required.** Data in Google Charts format. First row contains column headers, subsequent rows contain data. Countries can be identified by full name (e.g., 'United States') or ISO codes (e.g., 'US'). Full names are recommended for better readability in tooltips. |
 | `width` | `number` | - | **Required.** Width of the chart in pixels |
 | `height` | `number` | - | **Required.** Height of the chart in pixels |
-| `aspectRatio` | `number` | - | Height as a fraction of width (e.g. `0.625`) for responsive charts. The chart fills the available width and derives its height, but if the parent is shorter it shrinks both axes to fit rather than overflowing (contained on both axes), and is centered horizontally when narrower than the parent. Used when `width`/`height` are omitted. |
+| `aspectRatio` | `number` | - | Height-to-width ratio (e.g. `0.625`) for responsive charts; the chart is contained within its parent on both axes. Used when `width`/`height` are omitted. |
 | `region` | `GeoRegion` | `'world'` | Region to display. Use `'world'` for a global view or any ISO 3166-1 alpha-2 country code (e.g., `'US'`) |
 | `resolution` | `GeoResolution` | `'countries'` | Map resolution: `'countries'`, `'provinces'` (state/province level, use with a specific region), or `'metros'` (US only) |
 | `onError` | `(error: GeoChartError) => void` | - | Callback fired when Google Charts emits a chart error, including draw errors Google renders into the chart container (e.g. a missing map file) |

--- a/projects/js-packages/charts/src/charts/geo-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/geo-chart/stories/index.api.mdx
@@ -15,6 +15,7 @@ Main component for rendering geographical data on an interactive world map using
 | `data` | `GeoData` | - | **Required.** Data in Google Charts format. First row contains column headers, subsequent rows contain data. Countries can be identified by full name (e.g., 'United States') or ISO codes (e.g., 'US'). Full names are recommended for better readability in tooltips. |
 | `width` | `number` | - | **Required.** Width of the chart in pixels |
 | `height` | `number` | - | **Required.** Height of the chart in pixels |
+| `aspectRatio` | `number` | - | Height as a fraction of width (e.g. `0.625`) for responsive charts. The chart fills the available width and derives its height, but if the parent is shorter it shrinks both axes to fit rather than overflowing (contained on both axes), and is centered horizontally when narrower than the parent. Used when `width`/`height` are omitted. |
 | `region` | `GeoRegion` | `'world'` | Region to display. Use `'world'` for a global view or any ISO 3166-1 alpha-2 country code (e.g., `'US'`) |
 | `resolution` | `GeoResolution` | `'countries'` | Map resolution: `'countries'`, `'provinces'` (state/province level, use with a specific region), or `'metros'` (US only) |
 | `onError` | `(error: GeoChartError) => void` | - | Callback fired when Google Charts emits a chart error, including draw errors Google renders into the chart container (e.g. a missing map file) |

--- a/projects/js-packages/charts/src/charts/geo-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/geo-chart/stories/index.docs.mdx
@@ -69,7 +69,7 @@ The simplest geo chart requires data, width, and height. The `data` prop uses Go
 **Layout & Dimensions:**
 - **`width`**: Width of the chart in pixels. When omitted, fills parent container width
 - **`height`**: Height of the chart in pixels. When omitted, fills parent container height (parent must have explicit height)
-- **`aspectRatio`**: Height as a fraction of width (e.g., `0.625` = 62.5% height). When provided, height is calculated from width
+- **`aspectRatio`**: Height as a fraction of width (e.g., `0.625` = 62.5% height). When provided, height is calculated from width; if the parent is shorter than that height, the chart shrinks both axes to fit rather than overflowing (contained on both axes)
 - **`maxWidth`**: Maximum width constraint for responsive charts (default: `1200`)
 - **`resizeDebounceTime`**: Debounce delay for resize events in ms (default: `300`)
 

--- a/projects/js-packages/charts/src/charts/geo-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/geo-chart/stories/index.docs.mdx
@@ -330,7 +330,7 @@ Like other charts in this library, GeoChart supports responsive sizing. By defau
 		<GeoChart data={ordersByCountry} />
 	</div>
 
-	// Use aspect ratio - height calculated from width
+	// Use aspect ratio - height from width, contained if the parent is shorter
 	<div style={{ width: '100%' }}>
 		<GeoChart data={ordersByCountry} aspectRatio={0.625} />
 	</div>

--- a/projects/js-packages/charts/src/charts/geo-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/geo-chart/stories/index.docs.mdx
@@ -69,7 +69,7 @@ The simplest geo chart requires data, width, and height. The `data` prop uses Go
 **Layout & Dimensions:**
 - **`width`**: Width of the chart in pixels. When omitted, fills parent container width
 - **`height`**: Height of the chart in pixels. When omitted, fills parent container height (parent must have explicit height)
-- **`aspectRatio`**: Height as a fraction of width (e.g., `0.625` = 62.5% height). When provided, height is calculated from width; if the parent is shorter than that height, the chart shrinks both axes to fit rather than overflowing (contained on both axes)
+- **`aspectRatio`**: Height-to-width ratio (e.g. `0.625`) for responsive charts; the chart is contained within its parent on both axes. When omitted, fills the parent container's height
 - **`maxWidth`**: Maximum width constraint for responsive charts (default: `1200`)
 - **`resizeDebounceTime`**: Debounce delay for resize events in ms (default: `300`)
 

--- a/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.api.mdx
@@ -22,7 +22,7 @@ and shaded with CSS `color-mix`, so the scale adapts to the chart background.
 | `renderTooltip` | `(data: HeatmapTooltipData) => ReactNode` | - | Custom tooltip render function. Receives `HeatmapTooltipData`. The default tooltip formats numeric values with `@automattic/number-formatters`. |
 | `width` | `number` | - | Fixed width in pixels. When omitted, the chart fills its parent's width. |
 | `height` | `number` | - | Fixed height in pixels. When omitted, the chart fills its parent's height. |
-| `aspectRatio` | `number` | - | Keeps the chart at this height-to-width ratio (e.g. `0.4`) in responsive mode. It fills the available width and derives its height, but if the parent is shorter it shrinks both axes to fit rather than overflowing. Used when `width`/`height` are omitted. |
+| `aspectRatio` | `number` | - | Keeps the chart at this height-to-width ratio (e.g. `0.4`) in responsive mode. It fills the available width and derives its height, but if the parent is shorter it shrinks both axes to fit rather than overflowing (and is centered horizontally when narrower than the parent). Used when `width`/`height` are omitted. |
 | `chartId` | `string` | - | Custom chart identifier used in accessibility attributes. |
 | `className` | `string` | - | Additional CSS class for the outermost element. |
 | `gap` | `GapSize` | `'md'` | Gap between chart layout regions (chart area, legend, children). Uses WordPress design system tokens. |

--- a/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.api.mdx
@@ -22,7 +22,7 @@ and shaded with CSS `color-mix`, so the scale adapts to the chart background.
 | `renderTooltip` | `(data: HeatmapTooltipData) => ReactNode` | - | Custom tooltip render function. Receives `HeatmapTooltipData`. The default tooltip formats numeric values with `@automattic/number-formatters`. |
 | `width` | `number` | - | Fixed width in pixels. When omitted, the chart fills its parent's width. |
 | `height` | `number` | - | Fixed height in pixels. When omitted, the chart fills its parent's height. |
-| `aspectRatio` | `number` | - | Keeps the chart at this height-to-width ratio (e.g. `0.4`) in responsive mode. It fills the available width and derives its height, but if the parent is shorter it shrinks both axes to fit rather than overflowing (and is centered horizontally when narrower than the parent). Used when `width`/`height` are omitted. |
+| `aspectRatio` | `number` | - | Height-to-width ratio (e.g. `0.4`) for responsive charts; the chart is contained within its parent on both axes. Used when `width`/`height` are omitted. |
 | `chartId` | `string` | - | Custom chart identifier used in accessibility attributes. |
 | `className` | `string` | - | Additional CSS class for the outermost element. |
 | `gap` | `GapSize` | `'md'` | Gap between chart layout regions (chart area, legend, children). Uses WordPress design system tokens. |

--- a/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.api.mdx
@@ -22,7 +22,7 @@ and shaded with CSS `color-mix`, so the scale adapts to the chart background.
 | `renderTooltip` | `(data: HeatmapTooltipData) => ReactNode` | - | Custom tooltip render function. Receives `HeatmapTooltipData`. The default tooltip formats numeric values with `@automattic/number-formatters`. |
 | `width` | `number` | - | Fixed width in pixels. When omitted, the chart fills its parent's width. |
 | `height` | `number` | - | Fixed height in pixels. When omitted, the chart fills its parent's height. |
-| `aspectRatio` | `number` | - | Height as a ratio of width in responsive mode (e.g. `0.4`). Used when `width`/`height` are omitted. |
+| `aspectRatio` | `number` | - | Keeps the chart at this height-to-width ratio (e.g. `0.4`) in responsive mode. It fills the available width and derives its height, but if the parent is shorter it shrinks both axes to fit rather than overflowing. Used when `width`/`height` are omitted. |
 | `chartId` | `string` | - | Custom chart identifier used in accessibility attributes. |
 | `className` | `string` | - | Additional CSS class for the outermost element. |
 | `gap` | `GapSize` | `'md'` | Gap between chart layout regions (chart area, legend, children). Uses WordPress design system tokens. |

--- a/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.docs.mdx
@@ -233,7 +233,7 @@ By default, the chart **fills its parent container's dimensions**, reflowing as 
 		<HeatmapChart data={ columns } rowLabels={ rowLabels } />
 	</div>
 
-	// Use aspect ratio - height calculated from width
+	// Use aspect ratio - height from width, contained if the parent is shorter
 	<div style={{ width: '100%' }}>
 		<HeatmapChart data={ columns } rowLabels={ rowLabels } aspectRatio={ 0.4 } />
 	</div>

--- a/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.docs.mdx
@@ -219,7 +219,7 @@ Everything else — the cell gap, corner radius, in-cell value size, the empty-c
 
 ## Responsive Behavior
 
-By default the chart fills its parent container's dimensions, reflowing fluidly as the container resizes. Give it a height in one of three ways: an explicit height on the parent, an `aspectRatio` to derive the height from the available width, or fixed `width`/`height` props. Without one of these the chart has no height to fill and collapses, so always constrain it:
+By default the chart fills its parent container's dimensions, reflowing fluidly as the container resizes. Give it a height in one of three ways: an explicit height on the parent, an `aspectRatio`, or fixed `width`/`height` props. Without one of these the chart has no height to fill and collapses, so always constrain it. With an `aspectRatio` the chart keeps that ratio and is contained within the parent: it fills the available width and derives its height, but if the parent is shorter than that derived height it shrinks both axes to fit rather than overflowing:
 
 <Source
 	language="jsx"

--- a/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.docs.mdx
@@ -75,6 +75,9 @@ The simplest heatmap requires `data` — an array of `HeatmapColumn` objects, ea
 - **`showValues`** (default: `!compact`): render the numeric value inside each cell (compact notation for large numbers; the tooltip keeps full precision)
 - **`primaryColor`**: color the scale interpolates toward at the highest value (prop > `heatmapChart.primaryColor` > palette `colors[0]`)
 - **`width`** / **`height`**: explicit dimensions in pixels. When omitted the chart fills its parent.
+- **`aspectRatio`**: Height-to-width ratio (e.g. `0.4`) for responsive charts; the chart is contained within its parent on both axes. When omitted, fills the parent container's height
+- **`maxWidth`**: Maximum width constraint for responsive charts (default: `1200`)
+- **`resizeDebounceTime`**: Debounce delay for resize events in ms (default: `300`)
 - **`gap`** (default: `'md'`): gap between chart layout regions (chart area, legend, children)
 - **`chartId`**: custom identifier for accessibility labelling
 - **`className`**: additional CSS class for the outer element
@@ -219,23 +222,25 @@ Everything else — the cell gap, corner radius, in-cell value size, the empty-c
 
 ## Responsive Behavior
 
-By default the chart fills its parent container's dimensions, reflowing fluidly as the container resizes. Give it a height in one of three ways: an explicit height on the parent, an `aspectRatio`, or fixed `width`/`height` props. Without one of these the chart has no height to fill and collapses, so always constrain it. With an `aspectRatio` the chart keeps that ratio and is contained within the parent: it fills the available width and derives its height, but if the parent is shorter than that derived height it shrinks both axes to fit rather than overflowing:
+By default, the chart **fills its parent container's dimensions**, reflowing as the container resizes. The parent must have an explicit height — or the chart must receive an `aspectRatio` or fixed `width`/`height`, otherwise it has no height to fill and collapses. With an `aspectRatio` the chart keeps that ratio, contained within its parent on both axes:
+
+<Canvas of={ HeatmapStories.AspectRatio } />
 
 <Source
 	language="jsx"
-	code={ `// Fill parent container — parent needs explicit height
-<div style={{ width: '100%', height: '200px' }}>
-	<HeatmapChart data={ columns } rowLabels={ rowLabels } />
-</div>
+	code={ `// Fill parent container (default) - parent needs explicit height
+	<div style={{ width: '100%', height: '200px' }}>
+		<HeatmapChart data={ columns } rowLabels={ rowLabels } />
+	</div>
 
-	// Derive height from width via aspectRatio (height = width × 0.4)
-	<HeatmapChart data={ columns } rowLabels={ rowLabels } aspectRatio={ 0.4 } />
+	// Use aspect ratio - height calculated from width
+	<div style={{ width: '100%' }}>
+		<HeatmapChart data={ columns } rowLabels={ rowLabels } aspectRatio={ 0.4 } />
+	</div>
 
 	// Fixed dimensions
 	<HeatmapChart data={ columns } rowLabels={ rowLabels } width={ 720 } height={ 200 } />` }
 />
-
-<Canvas of={ HeatmapStories.AspectRatio } />
 
 For more details on responsive behavior, see the [Responsive Design section](./?path=/docs/js-packages-charts-library-introduction--docs#responsive-design) in the introduction.
 

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.api.mdx
@@ -26,6 +26,7 @@ Main chart component for displaying ranked data with optional comparison values.
 | `legendLabels` | `{ primary?: string; comparison?: string }` | `undefined` | Custom labels for legend items |
 | `width` | `number` | `undefined` | Optional fixed width of the chart container in pixels |
 | `height` | `number` | `undefined` | Optional fixed height of the chart container in pixels |
+| `aspectRatio` | `number` | - | Height-to-width ratio (e.g. `0.4`) for responsive charts; the chart is contained within its parent on both axes. Used when `width`/`height` are omitted. |
 | `gap` | `GapSize` | `'md'` | Spacing between legend and chart content, using the WordPress `GapSize` scale |
 | `className` | `string` | `undefined` | Additional CSS class name for the chart container |
 | `style` | `React.CSSProperties & CustomProperties` | `undefined` | Custom styling for the chart container |

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.docs.mdx
@@ -85,6 +85,7 @@ The simplest leaderboard chart requires only a `data` prop with pre-processed le
 - **`className`**: Additional CSS class name for the chart container
 - **`style`**: Custom styling including CSS custom properties for border radius
 - **`width` / `height`**: Optional fixed chart container dimensions
+- **`aspectRatio`**: Height-to-width ratio (e.g. `0.4`) for responsive charts; the chart is contained within its parent on both axes. When omitted, fills the parent container's height
 - **`gap`**: Spacing between legend and chart content (Stack gap token/value)
 
 For detailed prop information, type definitions, and examples, see the [Leaderboard Chart API Reference](./?path=/docs/js-packages-charts-library-charts-leaderboard-chart-api-reference--docs).

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.docs.mdx
@@ -487,16 +487,21 @@ Leaderboard Charts integrate seamlessly with the chart theming system. The defau
 
 ## Responsive Behavior
 
-By default, leaderboard charts fill their parent container dimensions. The parent must provide an explicit height for constrained layouts:
+By default, leaderboard charts **fill their parent container's dimensions**. The parent must have an explicit height, or the chart must receive an `aspectRatio`:
 
 <Source
 	language="tsx"
-	code={ `// Responsive by default (fills parent container)
+	code={ `// Fill parent container (default) - parent needs explicit height
 		<div style={{ width: '100%', height: '320px' }}>
 			<LeaderboardChart data={ data } showLegend={ true } />
 		</div>
 
-		// Fixed-size exception
+		// Use aspect ratio - height from width, contained if the parent is shorter
+		<div style={{ width: '100%' }}>
+			<LeaderboardChart data={ data } aspectRatio={ 0.4 } showLegend={ true } />
+		</div>
+
+		// Fixed dimensions
 		<LeaderboardChart
 			data={ data }
 			width={ 300 }

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
@@ -372,10 +372,11 @@ describe( 'LeaderboardChart', () => {
 	} );
 
 	describe( 'Responsive wrapper', () => {
-		it( 'fills parent container (height:100%) by default', () => {
+		it( 'fills parent container by default (via CSS, no inline height)', () => {
 			render( <LeaderboardChart data={ mockData } /> );
 			const wrapper = screen.getByTestId( 'responsive-wrapper' );
-			expect( wrapper ).toHaveStyle( { height: '100%' } );
+			expect( wrapper ).toHaveClass( 'container' );
+			expect( wrapper ).not.toHaveAttribute( 'style' );
 		} );
 
 		it( 'applies explicit width and height to chart container', () => {

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
@@ -372,13 +372,6 @@ describe( 'LeaderboardChart', () => {
 	} );
 
 	describe( 'Responsive wrapper', () => {
-		it( 'fills parent container by default (via CSS, no inline height)', () => {
-			render( <LeaderboardChart data={ mockData } /> );
-			const wrapper = screen.getByTestId( 'responsive-wrapper' );
-			expect( wrapper ).toHaveClass( 'container' );
-			expect( wrapper ).not.toHaveAttribute( 'style' );
-		} );
-
 		it( 'applies explicit width and height to chart container', () => {
 			const { useParentSize } = jest.requireMock( '@visx/responsive' );
 			useParentSize.mockReturnValue( {

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.api.mdx
@@ -15,6 +15,7 @@ Main chart component with responsive behavior by default.
 | `data` | `SeriesData[]` | - | **Required.** Array of data series to display |
 | `width` | `number?` | responsive | Chart width in pixels |
 | `height` | `number?` | responsive | Chart height in pixels |
+| `aspectRatio` | `number` | - | Height as a fraction of width (e.g. `0.4`) for responsive charts. The chart fills the available width and derives its height, but if the parent is shorter it shrinks both axes to fit rather than overflowing (contained on both axes), and is centered horizontally when narrower than the parent. Used when `width`/`height` are omitted. |
 | `curveType` | `'smooth' \| 'linear' \| 'monotone'?` | `'smooth'` | Line curve interpolation type |
 | `withGradientFill` | `boolean` | `false` | Fill area under lines with gradient |
 | `withTooltips` | `boolean` | `true` | Enable interactive tooltips |

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.api.mdx
@@ -15,7 +15,7 @@ Main chart component with responsive behavior by default.
 | `data` | `SeriesData[]` | - | **Required.** Array of data series to display |
 | `width` | `number?` | responsive | Chart width in pixels |
 | `height` | `number?` | responsive | Chart height in pixels |
-| `aspectRatio` | `number` | - | Height as a fraction of width (e.g. `0.4`) for responsive charts. The chart fills the available width and derives its height, but if the parent is shorter it shrinks both axes to fit rather than overflowing (contained on both axes), and is centered horizontally when narrower than the parent. Used when `width`/`height` are omitted. |
+| `aspectRatio` | `number` | - | Height-to-width ratio (e.g. `0.4`) for responsive charts; the chart is contained within its parent on both axes. Used when `width`/`height` are omitted. |
 | `curveType` | `'smooth' \| 'linear' \| 'monotone'?` | `'smooth'` | Line curve interpolation type |
 | `withGradientFill` | `boolean` | `false` | Fill area under lines with gradient |
 | `withTooltips` | `boolean` | `true` | Enable interactive tooltips |

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
@@ -551,7 +551,7 @@ By default, charts **fill their parent container's dimensions**. The parent must
 		<LineChart data={data} />
 	</div>
 
-	// Use aspect ratio - height calculated from width
+	// Use aspect ratio - height from width, contained if the parent is shorter
 	<div style={{ width: '100%' }}>
 		<LineChart data={data} aspectRatio={0.5} />
 	</div>

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
@@ -71,7 +71,7 @@ The simplest line chart requires only a `data` prop with time-series data:
 - **`margin`**: Custom chart margins
 - **`className`**: Additional CSS class name for the chart container
 - **`chartId`**: Unique identifier for the chart (auto-generated if not provided)
-- **`aspectRatio`**: Height as a fraction of width (e.g., `0.5` = 50% height); if the parent is shorter than that height, the chart shrinks both axes to fit rather than overflowing (contained on both axes). When omitted, fills parent container height
+- **`aspectRatio`**: Height-to-width ratio (e.g. `0.5`) for responsive charts; the chart is contained within its parent on both axes. When omitted, fills the parent container's height
 - **`maxWidth`**: Maximum width constraint for responsive charts (default: `1200`)
 - **`resizeDebounceTime`**: Debounce delay for resize events in ms (default: `300`)
 

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
@@ -71,7 +71,7 @@ The simplest line chart requires only a `data` prop with time-series data:
 - **`margin`**: Custom chart margins
 - **`className`**: Additional CSS class name for the chart container
 - **`chartId`**: Unique identifier for the chart (auto-generated if not provided)
-- **`aspectRatio`**: Height as a fraction of width (e.g., `0.5` = 50% height). When omitted, fills parent container height
+- **`aspectRatio`**: Height as a fraction of width (e.g., `0.5` = 50% height); if the parent is shorter than that height, the chart shrinks both axes to fit rather than overflowing (contained on both axes). When omitted, fills parent container height
 - **`maxWidth`**: Maximum width constraint for responsive charts (default: `1200`)
 - **`resizeDebounceTime`**: Debounce delay for resize events in ms (default: `300`)
 

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/index.api.mdx
@@ -30,7 +30,7 @@ Main component for rendering pie and donut charts.
 | `className` | `string` | - | Additional CSS class names |
 | `chartId` | `string` | - | Custom chart identifier for accessibility |
 | `maxWidth` | `number` | - | Maximum width for responsive charts |
-| `aspectRatio` | `number` | `1` | Aspect ratio for responsive charts; the chart is contained within the parent on both axes (shrinks to fit if the parent is shorter than the derived height) |
+| `aspectRatio` | `number` | `1` | Height-to-width ratio for responsive charts; the chart is contained within its parent on both axes. |
 | `resizeDebounceTime` | `number` | `100` | Debounce time for resize events (ms) |
 
 ## Theme Properties

--- a/projects/js-packages/charts/src/charts/pie-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/pie-chart/stories/index.api.mdx
@@ -30,7 +30,7 @@ Main component for rendering pie and donut charts.
 | `className` | `string` | - | Additional CSS class names |
 | `chartId` | `string` | - | Custom chart identifier for accessibility |
 | `maxWidth` | `number` | - | Maximum width for responsive charts |
-| `aspectRatio` | `number` | `1` | Aspect ratio for responsive charts |
+| `aspectRatio` | `number` | `1` | Aspect ratio for responsive charts; the chart is contained within the parent on both axes (shrinks to fit if the parent is shorter than the derived height) |
 | `resizeDebounceTime` | `number` | `100` | Debounce time for resize events (ms) |
 
 ## Theme Properties

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/test/pie-semi-circle-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/test/pie-semi-circle-chart.test.tsx
@@ -226,13 +226,6 @@ describe( 'PieSemiCircleChart', () => {
 	} );
 
 	describe( 'Responsive wrapper', () => {
-		it( 'fills parent container by default (via CSS, no inline height)', () => {
-			render( <PieSemiCircleChart data={ mockData } /> );
-			const wrapper = screen.getByTestId( 'responsive-wrapper' );
-			expect( wrapper ).toHaveClass( 'container' );
-			expect( wrapper ).not.toHaveAttribute( 'style' );
-		} );
-
 		it( 'constrains chart to 2:1 ratio from measured dimensions', () => {
 			// Mock returns width:400, height:200, so chart renders at 400×200 (2:1 ratio)
 			render( <PieSemiCircleChart data={ mockData } /> );

--- a/projects/js-packages/charts/src/charts/pie-semi-circle-chart/test/pie-semi-circle-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/pie-semi-circle-chart/test/pie-semi-circle-chart.test.tsx
@@ -226,10 +226,11 @@ describe( 'PieSemiCircleChart', () => {
 	} );
 
 	describe( 'Responsive wrapper', () => {
-		it( 'fills parent container (height:100%) by default', () => {
+		it( 'fills parent container by default (via CSS, no inline height)', () => {
 			render( <PieSemiCircleChart data={ mockData } /> );
 			const wrapper = screen.getByTestId( 'responsive-wrapper' );
-			expect( wrapper ).toHaveStyle( { height: '100%' } );
+			expect( wrapper ).toHaveClass( 'container' );
+			expect( wrapper ).not.toHaveAttribute( 'style' );
 		} );
 
 		it( 'constrains chart to 2:1 ratio from measured dimensions', () => {

--- a/projects/js-packages/charts/src/charts/private/with-responsive/test/with-responsive.test.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/test/with-responsive.test.tsx
@@ -5,7 +5,7 @@ import type { BaseChartProps } from '../../../../types';
 // Mock the useParentSize hook
 jest.mock( '@visx/responsive', () => ( {
 	useParentSize: jest.fn( () => ( {
-		parentRef: { current: null },
+		parentRef: () => {},
 		width: 600, // Default width for tests
 		height: 300, // Default height for tests
 	} ) ),
@@ -21,11 +21,27 @@ describe( 'withResponsive', () => {
 	const ResponsiveComponent = withResponsive( MockComponent );
 
 	const { useParentSize } = jest.requireMock( '@visx/responsive' );
-	const DEFAULT_SIZE = { parentRef: { current: null }, width: 600, height: 300 };
+	const DEFAULT_SIZE = { parentRef: () => {}, width: 600, height: 300 };
+
+	// jsdom has no layout engine, so the wrapper's clientHeight (which the contain
+	// logic reads from real layout) is always 0. Mock it to simulate the height the
+	// parent makes available: 0 means unconstrained (the chart derives its height from
+	// width), a positive value simulates a parent that limits the height.
+	let mockClientHeight = 0;
+	beforeAll( () => {
+		Object.defineProperty( window.HTMLElement.prototype, 'clientHeight', {
+			configurable: true,
+			get() {
+				return mockClientHeight;
+			},
+		} );
+	} );
+
 	// Fully clear the mock (queued returns and implementation) after each test, then
 	// re-establish the default implementation, so a per-test override can't bleed
 	// into the next test.
 	afterEach( () => {
+		mockClientHeight = 0;
 		useParentSize.mockReset();
 		useParentSize.mockImplementation( () => DEFAULT_SIZE );
 	} );
@@ -45,16 +61,18 @@ describe( 'withResponsive', () => {
 		} );
 
 		test( 'derives height from width when the parent is taller than the derived height', () => {
-			// aspectRatio 0.4: derived height = 600 * 0.4 = 240, which fits the 300px
-			// parent, so the chart keeps the full measured width.
+			// Parent allows 300px of height; aspectRatio 0.4 derives 600 * 0.4 = 240,
+			// which fits, so the chart keeps the full measured width.
+			mockClientHeight = 300;
 			render( <ResponsiveComponent data={ [] } aspectRatio={ 0.4 } /> );
 			const component = screen.getByTestId( 'mock-component' );
 			expect( component ).toHaveStyle( { width: '600px', height: '240px' } );
 		} );
 
-		test( 'contains within the parent height when it is shorter than the derived height', () => {
-			// aspectRatio 0.75: derived height = 600 * 0.75 = 450 > 300, so both axes
-			// shrink to fit the 300px parent while preserving the ratio: 300 / 0.75 = 400.
+		test( 'contains within the parent height when the parent limits the available height', () => {
+			// Parent makes 300px of height available; aspectRatio 0.75 would derive
+			// 600 * 0.75 = 450, so both axes shrink to fit: 300 / 0.75 = 400.
+			mockClientHeight = 300;
 			render( <ResponsiveComponent data={ [] } aspectRatio={ 0.75 } /> );
 			const component = screen.getByTestId( 'mock-component' );
 			expect( component ).toHaveStyle( { width: '400px', height: '300px' } );
@@ -64,7 +82,7 @@ describe( 'withResponsive', () => {
 			// parentHeight 0 (unconstrained or not-yet-measured parent): the contain
 			// clamp must not run, so the height stays width-derived (600 * 0.4 = 240).
 			useParentSize.mockImplementation( () => ( {
-				parentRef: { current: null },
+				parentRef: () => {},
 				width: 600,
 				height: 0,
 			} ) );
@@ -117,11 +135,69 @@ describe( 'withResponsive', () => {
 			expect( content ).toHaveStyle( { width: '600px', height: '240px' } );
 		} );
 
-		test( 'content box contains to the parent height when it is shorter than the derived height', () => {
-			// aspectRatio 0.75: 600 * 0.75 = 450 > 300, so it shrinks to 400 × 300.
+		test( 'content box contains to the parent height when the parent limits the available height', () => {
+			// aspectRatio 0.75 derives 450 > the 300px the parent allows, so it shrinks
+			// to 400 × 300.
+			mockClientHeight = 300;
 			render( <ResponsiveComponent data={ [] } aspectRatio={ 0.75 } /> );
 			const content = screen.getByTestId( 'responsive-content' );
 			expect( content ).toHaveStyle( { width: '400px', height: '300px' } );
+		} );
+	} );
+
+	describe( 'resize behavior', () => {
+		test( 'grows on widen in a fluid (unconstrained-height) parent', () => {
+			// Unconstrained parent (mockClientHeight 0): the chart derives its height
+			// from width and must grow when the parent widens, not deadlock.
+			useParentSize.mockImplementation( () => ( {
+				parentRef: () => {},
+				width: 600,
+				height: 0,
+			} ) );
+			const { rerender } = render( <ResponsiveComponent data={ [] } aspectRatio={ 0.4 } /> );
+			expect( screen.getByTestId( 'mock-component' ) ).toHaveStyle( {
+				width: '600px',
+				height: '240px',
+			} );
+
+			useParentSize.mockImplementation( () => ( {
+				parentRef: () => {},
+				width: 900,
+				height: 0,
+			} ) );
+			rerender( <ResponsiveComponent data={ [] } aspectRatio={ 0.4 } /> );
+			expect( screen.getByTestId( 'mock-component' ) ).toHaveStyle( {
+				width: '900px',
+				height: '360px',
+			} );
+		} );
+
+		test( 'stays contained on widen when the parent limits the height', () => {
+			// Parent allows 150px of height. aspectRatio 0.4 derives 240 at width 600 and
+			// 360 at width 900 — both exceed 150 — so the chart stays contained at
+			// 375 × 150 (150 / 0.4 = 375) across the widen rather than overflowing.
+			mockClientHeight = 150;
+			useParentSize.mockImplementation( () => ( {
+				parentRef: () => {},
+				width: 600,
+				height: 150,
+			} ) );
+			const { rerender } = render( <ResponsiveComponent data={ [] } aspectRatio={ 0.4 } /> );
+			expect( screen.getByTestId( 'mock-component' ) ).toHaveStyle( {
+				width: '375px',
+				height: '150px',
+			} );
+
+			useParentSize.mockImplementation( () => ( {
+				parentRef: () => {},
+				width: 900,
+				height: 150,
+			} ) );
+			rerender( <ResponsiveComponent data={ [] } aspectRatio={ 0.4 } /> );
+			expect( screen.getByTestId( 'mock-component' ) ).toHaveStyle( {
+				width: '375px',
+				height: '150px',
+			} );
 		} );
 	} );
 

--- a/projects/js-packages/charts/src/charts/private/with-responsive/test/with-responsive.test.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/test/with-responsive.test.tsx
@@ -118,10 +118,12 @@ describe( 'withResponsive', () => {
 	} );
 
 	describe( 'wrapper dimensions', () => {
-		test( 'wrapper defaults to 100% width and height when no props', () => {
+		test( 'wrapper has no inline dimensions by default (fills the parent via CSS)', () => {
 			render( <ResponsiveComponent data={ [] } /> );
 			const wrapper = screen.getByTestId( 'responsive-wrapper' );
-			expect( wrapper ).toHaveStyle( { width: '100%', height: '100%' } );
+			expect( wrapper ).toHaveClass( 'container' );
+			expect( wrapper ).not.toHaveClass( 'isContained' );
+			expect( wrapper ).not.toHaveAttribute( 'style' );
 		} );
 
 		test( 'wrapper uses explicit width/height for dimensions when provided', () => {
@@ -130,10 +132,10 @@ describe( 'withResponsive', () => {
 			expect( wrapper ).toHaveStyle( { width: '200px', height: '200px' } );
 		} );
 
-		test( 'wrapper fills the parent (height 100%) with aspectRatio so it can measure both axes', () => {
+		test( 'wrapper gets the contained class with aspectRatio (centering lives in CSS)', () => {
 			render( <ResponsiveComponent data={ [] } aspectRatio={ 0.5 } /> );
 			const wrapper = screen.getByTestId( 'responsive-wrapper' );
-			expect( wrapper ).toHaveStyle( { width: '100%', height: '100%' } );
+			expect( wrapper ).toHaveClass( 'isContained' );
 		} );
 
 		test( 'no content box is rendered without an aspectRatio', () => {
@@ -141,20 +143,21 @@ describe( 'withResponsive', () => {
 			expect( screen.queryByTestId( 'responsive-content' ) ).not.toBeInTheDocument();
 		} );
 
-		test( 'renders the contained chart in an inner content box sized to the aspect ratio', () => {
-			// aspectRatio 0.4: 600 * 0.4 = 240 fits the 300px parent.
+		test( 'renders the contained chart in an inner content box sized by width + aspect-ratio', () => {
+			// aspectRatio 0.4: 600 * 0.4 = 240 fits the 300px parent. Only the width is set
+			// inline; the height comes from the CSS aspect-ratio.
 			render( <ResponsiveComponent data={ [] } aspectRatio={ 0.4 } /> );
 			const content = screen.getByTestId( 'responsive-content' );
-			expect( content ).toHaveStyle( { width: '600px', height: '240px' } );
+			expect( content ).toHaveStyle( { width: '600px', aspectRatio: '1 / 0.4' } );
 		} );
 
 		test( 'content box contains to the parent height when the parent limits the available height', () => {
-			// aspectRatio 0.75 derives 450 > the 300px the parent allows, so it shrinks
-			// to 400 × 300.
+			// aspectRatio 0.75 derives 450 > the 300px the parent allows, so the width
+			// shrinks to 400 (300 / 0.75) and the aspect-ratio keeps the height at 300.
 			mockClientHeight = 300;
 			render( <ResponsiveComponent data={ [] } aspectRatio={ 0.75 } /> );
 			const content = screen.getByTestId( 'responsive-content' );
-			expect( content ).toHaveStyle( { width: '400px', height: '300px' } );
+			expect( content ).toHaveStyle( { width: '400px', aspectRatio: '1 / 0.75' } );
 		} );
 	} );
 

--- a/projects/js-packages/charts/src/charts/private/with-responsive/test/with-responsive.test.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/test/with-responsive.test.tsx
@@ -34,11 +34,20 @@ describe( 'withResponsive', () => {
 			expect( component ).toHaveStyle( { height: '300px' } );
 		} );
 
-		test( 'calculates height from aspectRatio when provided', () => {
+		test( 'derives height from width when the parent is taller than the derived height', () => {
+			// aspectRatio 0.4: derived height = 600 * 0.4 = 240, which fits the 300px
+			// parent, so the chart keeps the full measured width.
+			render( <ResponsiveComponent data={ [] } aspectRatio={ 0.4 } /> );
+			const component = screen.getByTestId( 'mock-component' );
+			expect( component ).toHaveStyle( { width: '600px', height: '240px' } );
+		} );
+
+		test( 'contains within the parent height when it is shorter than the derived height', () => {
+			// aspectRatio 0.75: derived height = 600 * 0.75 = 450 > 300, so both axes
+			// shrink to fit the 300px parent while preserving the ratio: 300 / 0.75 = 400.
 			render( <ResponsiveComponent data={ [] } aspectRatio={ 0.75 } /> );
 			const component = screen.getByTestId( 'mock-component' );
-			// With aspectRatio, height = width * aspectRatio = 600 * 0.75 = 450
-			expect( component ).toHaveStyle( { height: '450px' } );
+			expect( component ).toHaveStyle( { width: '400px', height: '300px' } );
 		} );
 
 		test( 'respects maxWidth configuration', () => {
@@ -67,24 +76,29 @@ describe( 'withResponsive', () => {
 			expect( wrapper ).toHaveStyle( { width: '200px', height: '200px' } );
 		} );
 
-		test( 'wrapper uses auto height with aspectRatio', () => {
+		test( 'wrapper fills the parent (height 100%) with aspectRatio so it can measure both axes', () => {
 			render( <ResponsiveComponent data={ [] } aspectRatio={ 0.5 } /> );
 			const wrapper = screen.getByTestId( 'responsive-wrapper' );
-			expect( wrapper ).toHaveStyle( { width: '100%', height: 'auto' } );
+			expect( wrapper ).toHaveStyle( { width: '100%', height: '100%' } );
 		} );
 
-		test( 'wrapper expresses aspectRatio in CSS and caps at maxWidth', () => {
-			render( <ResponsiveComponent data={ [] } aspectRatio={ 0.5 } maxWidth={ 800 } /> );
-			const wrapper = screen.getByTestId( 'responsive-wrapper' );
-			// CSS aspect-ratio is width/height, so 1 / 0.5 = 2.
-			expect( wrapper ).toHaveStyle( { aspectRatio: '2', maxWidth: '800px' } );
+		test( 'no content box is rendered without an aspectRatio', () => {
+			render( <ResponsiveComponent data={ [] } /> );
+			expect( screen.queryByTestId( 'responsive-content' ) ).not.toBeInTheDocument();
 		} );
 
-		test( 'wrapper omits the maxWidth cap when an explicit width is set', () => {
-			render( <ResponsiveComponent data={ [] } aspectRatio={ 0.5 } width={ 300 } /> );
-			const wrapper = screen.getByTestId( 'responsive-wrapper' );
-			expect( wrapper ).toHaveStyle( { aspectRatio: '2', width: '300px' } );
-			expect( wrapper ).not.toHaveStyle( { maxWidth: '1200px' } );
+		test( 'renders the contained chart in an inner content box sized to the aspect ratio', () => {
+			// aspectRatio 0.4: 600 * 0.4 = 240 fits the 300px parent.
+			render( <ResponsiveComponent data={ [] } aspectRatio={ 0.4 } /> );
+			const content = screen.getByTestId( 'responsive-content' );
+			expect( content ).toHaveStyle( { width: '600px', height: '240px' } );
+		} );
+
+		test( 'content box contains to the parent height when it is shorter than the derived height', () => {
+			// aspectRatio 0.75: 600 * 0.75 = 450 > 300, so it shrinks to 400 × 300.
+			render( <ResponsiveComponent data={ [] } aspectRatio={ 0.75 } /> );
+			const content = screen.getByTestId( 'responsive-content' );
+			expect( content ).toHaveStyle( { width: '400px', height: '300px' } );
 		} );
 	} );
 

--- a/projects/js-packages/charts/src/charts/private/with-responsive/test/with-responsive.test.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/test/with-responsive.test.tsx
@@ -102,6 +102,19 @@ describe( 'withResponsive', () => {
 			const component = screen.getByTestId( 'mock-component' );
 			expect( component ).toHaveAttribute( 'data-size', '200' );
 		} );
+
+		test( 'assigns the wrapper to an object-shaped parentRef from useParentSize', () => {
+			// useParentSize hands back a callback ref in practice, but older versions
+			// return a RefObject; the wrapper must populate that shape too.
+			const objectRef: { current: HTMLElement | null } = { current: null };
+			useParentSize.mockImplementation( () => ( {
+				parentRef: objectRef,
+				width: 600,
+				height: 300,
+			} ) );
+			render( <ResponsiveComponent data={ [] } /> );
+			expect( objectRef.current ).toBe( screen.getByTestId( 'responsive-wrapper' ) );
+		} );
 	} );
 
 	describe( 'wrapper dimensions', () => {
@@ -197,6 +210,89 @@ describe( 'withResponsive', () => {
 			expect( screen.getByTestId( 'mock-component' ) ).toHaveStyle( {
 				width: '375px',
 				height: '150px',
+			} );
+		} );
+
+		test( 'releases containment when the parent grows tall enough', () => {
+			// Parent starts at 150px of height, so aspectRatio 0.4 (derives 240 at width
+			// 600) is contained to 375 × 150.
+			mockClientHeight = 150;
+			useParentSize.mockImplementation( () => ( {
+				parentRef: () => {},
+				width: 600,
+				height: 150,
+			} ) );
+			const { rerender } = render( <ResponsiveComponent data={ [] } aspectRatio={ 0.4 } /> );
+			expect( screen.getByTestId( 'mock-component' ) ).toHaveStyle( {
+				width: '375px',
+				height: '150px',
+			} );
+
+			// Parent grows to 300px — now taller than the 240px derived height — so
+			// containment releases and the chart returns to its full width-derived size.
+			mockClientHeight = 300;
+			useParentSize.mockImplementation( () => ( {
+				parentRef: () => {},
+				width: 600,
+				height: 300,
+			} ) );
+			rerender( <ResponsiveComponent data={ [] } aspectRatio={ 0.4 } /> );
+			expect( screen.getByTestId( 'mock-component' ) ).toHaveStyle( {
+				width: '600px',
+				height: '240px',
+			} );
+		} );
+
+		test( 'and re-contains to the new height when the parent shrinks further', () => {
+			// Parent allows 300px; aspectRatio 0.75 derives 450, so it contains to 400 × 300.
+			mockClientHeight = 300;
+			useParentSize.mockImplementation( () => ( {
+				parentRef: () => {},
+				width: 600,
+				height: 300,
+			} ) );
+			const { rerender } = render( <ResponsiveComponent data={ [] } aspectRatio={ 0.75 } /> );
+			expect( screen.getByTestId( 'mock-component' ) ).toHaveStyle( {
+				width: '400px',
+				height: '300px',
+			} );
+
+			// Parent shrinks to 150px — still shorter than the 450px derived height — so the
+			// chart re-contains to the new available height: 150 / 0.75 = 200 × 150.
+			mockClientHeight = 150;
+			useParentSize.mockImplementation( () => ( {
+				parentRef: () => {},
+				width: 600,
+				height: 150,
+			} ) );
+			rerender( <ResponsiveComponent data={ [] } aspectRatio={ 0.75 } /> );
+			expect( screen.getByTestId( 'mock-component' ) ).toHaveStyle( {
+				width: '200px',
+				height: '150px',
+			} );
+		} );
+
+		test( 'releases containment when aspectRatio is removed', () => {
+			// Contained first (derived 450 > the 300px parent → 400 × 300).
+			mockClientHeight = 300;
+			useParentSize.mockImplementation( () => ( {
+				parentRef: () => {},
+				width: 600,
+				height: 300,
+			} ) );
+			const { rerender } = render( <ResponsiveComponent data={ [] } aspectRatio={ 0.75 } /> );
+			expect( screen.getByTestId( 'mock-component' ) ).toHaveStyle( {
+				width: '400px',
+				height: '300px',
+			} );
+
+			// Dropping aspectRatio clears the containment and fills the parent again; the
+			// inner content box is gone.
+			rerender( <ResponsiveComponent data={ [] } /> );
+			expect( screen.queryByTestId( 'responsive-content' ) ).not.toBeInTheDocument();
+			expect( screen.getByTestId( 'mock-component' ) ).toHaveStyle( {
+				width: '600px',
+				height: '300px',
 			} );
 		} );
 	} );

--- a/projects/js-packages/charts/src/charts/private/with-responsive/test/with-responsive.test.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/test/with-responsive.test.tsx
@@ -20,6 +20,10 @@ describe( 'withResponsive', () => {
 
 	const ResponsiveComponent = withResponsive( MockComponent );
 
+	const { useParentSize } = jest.requireMock( '@visx/responsive' );
+	const DEFAULT_SIZE = { parentRef: { current: null }, width: 600, height: 300 };
+	afterEach( () => useParentSize.mockReturnValue( DEFAULT_SIZE ) );
+
 	describe( 'component dimensions', () => {
 		test( 'passes measured parent width to component', () => {
 			render( <ResponsiveComponent data={ [] } /> );
@@ -48,6 +52,15 @@ describe( 'withResponsive', () => {
 			render( <ResponsiveComponent data={ [] } aspectRatio={ 0.75 } /> );
 			const component = screen.getByTestId( 'mock-component' );
 			expect( component ).toHaveStyle( { width: '400px', height: '300px' } );
+		} );
+
+		test( 'derives height from width when the parent has no measured height', () => {
+			// parentHeight 0 (unconstrained or not-yet-measured parent): the contain
+			// clamp must not run, so the height stays width-derived (600 * 0.4 = 240).
+			useParentSize.mockReturnValue( { parentRef: { current: null }, width: 600, height: 0 } );
+			render( <ResponsiveComponent data={ [] } aspectRatio={ 0.4 } /> );
+			const component = screen.getByTestId( 'mock-component' );
+			expect( component ).toHaveStyle( { width: '600px', height: '240px' } );
 		} );
 
 		test( 'respects maxWidth configuration', () => {

--- a/projects/js-packages/charts/src/charts/private/with-responsive/test/with-responsive.test.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/test/with-responsive.test.tsx
@@ -22,7 +22,13 @@ describe( 'withResponsive', () => {
 
 	const { useParentSize } = jest.requireMock( '@visx/responsive' );
 	const DEFAULT_SIZE = { parentRef: { current: null }, width: 600, height: 300 };
-	afterEach( () => useParentSize.mockReturnValue( DEFAULT_SIZE ) );
+	// Fully clear the mock (queued returns and implementation) after each test, then
+	// re-establish the default implementation, so a per-test override can't bleed
+	// into the next test.
+	afterEach( () => {
+		useParentSize.mockReset();
+		useParentSize.mockImplementation( () => DEFAULT_SIZE );
+	} );
 
 	describe( 'component dimensions', () => {
 		test( 'passes measured parent width to component', () => {
@@ -57,7 +63,11 @@ describe( 'withResponsive', () => {
 		test( 'derives height from width when the parent has no measured height', () => {
 			// parentHeight 0 (unconstrained or not-yet-measured parent): the contain
 			// clamp must not run, so the height stays width-derived (600 * 0.4 = 240).
-			useParentSize.mockReturnValue( { parentRef: { current: null }, width: 600, height: 0 } );
+			useParentSize.mockImplementation( () => ( {
+				parentRef: { current: null },
+				width: 600,
+				height: 0,
+			} ) );
 			render( <ResponsiveComponent data={ [] } aspectRatio={ 0.4 } /> );
 			const component = screen.getByTestId( 'mock-component' );
 			expect( component ).toHaveStyle( { width: '600px', height: '240px' } );

--- a/projects/js-packages/charts/src/charts/private/with-responsive/test/with-responsive.test.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/test/with-responsive.test.tsx
@@ -143,21 +143,20 @@ describe( 'withResponsive', () => {
 			expect( screen.queryByTestId( 'responsive-content' ) ).not.toBeInTheDocument();
 		} );
 
-		test( 'renders the contained chart in an inner content box sized by width + aspect-ratio', () => {
-			// aspectRatio 0.4: 600 * 0.4 = 240 fits the 300px parent. Only the width is set
-			// inline; the height comes from the CSS aspect-ratio.
+		test( 'renders the contained chart in an inner content box sized to the aspect ratio', () => {
+			// aspectRatio 0.4: 600 * 0.4 = 240 fits the 300px parent.
 			render( <ResponsiveComponent data={ [] } aspectRatio={ 0.4 } /> );
 			const content = screen.getByTestId( 'responsive-content' );
-			expect( content ).toHaveStyle( { width: '600px', aspectRatio: '1 / 0.4' } );
+			expect( content ).toHaveStyle( { width: '600px', height: '240px' } );
 		} );
 
 		test( 'content box contains to the parent height when the parent limits the available height', () => {
-			// aspectRatio 0.75 derives 450 > the 300px the parent allows, so the width
-			// shrinks to 400 (300 / 0.75) and the aspect-ratio keeps the height at 300.
+			// aspectRatio 0.75 derives 450 > the 300px the parent allows, so both axes
+			// shrink to fit: width 400 (300 / 0.75) × height 300.
 			mockClientHeight = 300;
 			render( <ResponsiveComponent data={ [] } aspectRatio={ 0.75 } /> );
 			const content = screen.getByTestId( 'responsive-content' );
-			expect( content ).toHaveStyle( { width: '400px', aspectRatio: '1 / 0.75' } );
+			expect( content ).toHaveStyle( { width: '400px', height: '300px' } );
 		} );
 	} );
 

--- a/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.module.scss
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.module.scss
@@ -3,3 +3,11 @@
 	min-width: 0;
 	min-height: 0;
 }
+
+// The aspect-ratio contain box. Its explicit pixel width/height come from
+// JS, so keep it from being stretched or shrunk by the flex parent.
+.content {
+	flex: 0 0 auto;
+	min-width: 0;
+	min-height: 0;
+}

--- a/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.module.scss
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.module.scss
@@ -15,8 +15,8 @@
 	align-items: flex-start;
 }
 
-// The aspect-ratio contain box: JS sets its width, the height follows from the
-// aspect-ratio. Keep it from being stretched or shrunk by the flex parent.
+// The contain box. Its width/height come from JS; keep it from being stretched
+// or shrunk by the flex parent.
 .content {
 	flex: 0 0 auto;
 	min-width: 0;

--- a/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.module.scss
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.module.scss
@@ -1,11 +1,22 @@
 .container {
-	// Allow wrapper to shrink in flex layouts
+	// Fill the parent by default so the wrapper's live height reflects the
+	// real available space. JS sets width/height only when passed explicitly.
+	width: 100%;
+	height: 100%;
+	// Allow the wrapper to shrink in flex layouts
 	min-width: 0;
 	min-height: 0;
 }
 
-// The aspect-ratio contain box. Its explicit pixel width/height come from
-// JS, so keep it from being stretched or shrunk by the flex parent.
+// With an aspectRatio, center the contained box horizontally and top-align it.
+.isContained {
+	display: flex;
+	justify-content: center;
+	align-items: flex-start;
+}
+
+// The aspect-ratio contain box: JS sets its width, the height follows from the
+// aspect-ratio. Keep it from being stretched or shrunk by the flex parent.
 .content {
 	flex: 0 0 auto;
 	min-width: 0;

--- a/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
@@ -104,17 +104,15 @@ export function withResponsive< T extends Exclude< BaseChartProps< unknown >, 'o
 			boxHeight = parentHeight > 0 ? parentHeight : height ?? 0;
 		}
 
-		// Resolve containment from real layout, before paint. useParentSize measures
-		// this wrapper, whose height:100% resolves to `auto` (= our own content) when
-		// the parent has no definite height — so that measurement alone can't tell a
-		// genuine constraint from our content reflected back, and clamping against it
-		// deadlocks the chart at its current width on widen. Instead read the wrapper's
-		// live height AFTER layout: when the parent constrains us it is shorter than the
-		// height we drew (the content overflows) → contain to it; when it just reflects
-		// our content the two match → grow. Latch the constraint until the parent is
-		// tall enough for the full derived height again so a contained chart (which then
-		// no longer overflows) doesn't oscillate. parentHeight is a dependency only so a
-		// parent-height change re-runs this; the value used is the fresh clientHeight.
+		// Decide containment from the wrapper's real height, measured after layout.
+		// useParentSize's height is no good here: with height:100% and no definite
+		// parent height it just echoes our own content back, so clamping against it
+		// would freeze the chart at its current width when the container widens.
+		// Compare the post-layout clientHeight to the height we drew: shorter means the
+		// parent really constrains us → contain to it; equal means it is only our own
+		// content → let it grow. Once contained, stay contained until the parent is tall
+		// enough for the full derived height, so a now-fitting chart doesn't oscillate.
+		// (parentHeight is in the deps only to re-run this; the value used is clientHeight.)
 		useIsomorphicLayoutEffect( () => {
 			if ( ! hasAspectRatio ) {
 				if ( containedHeight !== null ) {

--- a/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
@@ -145,11 +145,11 @@ export function withResponsive< T extends Exclude< BaseChartProps< unknown >, 'o
 
 		// The outer element fills the parent (via CSS) so its live height reflects the
 		// real available space; JS sets width/height only when they are passed
-		// explicitly. With an aspectRatio the chart is placed in an inner box whose width
-		// is set here and whose height follows from the CSS aspect-ratio, so it keeps its
-		// proportions and fits within the parent on both axes (centered by CSS). Charts
-		// that fill their container via CSS (e.g. the heatmap grid) then track that box.
-		// Without an aspectRatio the chart fills the parent directly.
+		// explicitly. Static layout (fill, flex centering) lives in the stylesheet. With
+		// an aspectRatio the chart is placed in an inner box sized to the contained
+		// dimensions (centered by CSS) so it keeps its proportions and fits within the
+		// parent on both axes. Charts that fill their container via CSS (e.g. the heatmap
+		// grid) then track that box. Without an aspectRatio the chart fills the parent.
 		return (
 			<div
 				ref={ setWrapperRef }
@@ -164,7 +164,7 @@ export function withResponsive< T extends Exclude< BaseChartProps< unknown >, 'o
 					<div
 						data-testid="responsive-content"
 						className={ styles.content }
-						style={ { width: boxWidth, aspectRatio: `1 / ${ aspectRatio }` } }
+						style={ { width: boxWidth, height: boxHeight } }
 					>
 						{ wrappedComponent }
 					</div>

--- a/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
@@ -1,4 +1,5 @@
 import { useParentSize } from '@visx/responsive';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import styles from './with-responsive.module.scss';
 import type { BaseChartProps } from '../../../types';
 import type { ComponentType } from 'react';
@@ -30,50 +31,9 @@ export type ResponsiveConfig = {
 	resizeDebounceTime?: number;
 };
 
-const useResponsiveDimensions = ( {
-	resizeDebounceTime = 300,
-	maxWidth = 1200,
-	aspectRatio,
-	explicitWidth,
-	explicitHeight,
-}: ResponsiveConfig & { explicitWidth?: number; explicitHeight?: number } ) => {
-	const {
-		parentRef,
-		width: parentWidth,
-		height: parentHeight,
-	} = useParentSize( {
-		debounceTime: resizeDebounceTime,
-		enableDebounceLeadingCall: true,
-	} );
-
-	const hasAspectRatio = aspectRatio !== undefined && aspectRatio > 0;
-
-	// Cap the available width at maxWidth unless an explicit width pins it. Before
-	// measurement resolves, fall back to the explicit width.
-	const cap = explicitWidth === undefined ? maxWidth : Infinity;
-	const availableWidth = parentWidth > 0 ? Math.min( parentWidth, cap ) : explicitWidth ?? 0;
-
-	let width = availableWidth;
-	let height: number;
-
-	if ( hasAspectRatio ) {
-		height = availableWidth * aspectRatio;
-		// Contain: when the parent bounds the height and the width-derived height
-		// would overflow it, shrink both axes to fit, preserving the ratio. The 1px
-		// slack is not a workaround for a rare case — it covers the normal
-		// unconstrained-parent path (no explicit height on the parent), where this
-		// wrapper's own height comes from this box's content, so the measured height
-		// equals the derived height and a bare `>` would clamp it against itself.
-		if ( parentHeight > 0 && height > parentHeight + 1 ) {
-			height = parentHeight;
-			width = height / aspectRatio;
-		}
-	} else {
-		height = parentHeight > 0 ? parentHeight : explicitHeight ?? 0;
-	}
-
-	return { parentRef, width, height, hasAspectRatio };
-};
+// useLayoutEffect on the client (so containment is resolved before paint, no flash),
+// useEffect on the server to avoid React's SSR warning.
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
 /**
  * A higher-order component that provides responsive dimensions
@@ -96,16 +56,88 @@ export function withResponsive< T extends Exclude< BaseChartProps< unknown >, 'o
 	}: Omit< T, 'width' | 'height' | 'size' > & DimensionProps & ResponsiveConfig ) {
 		const {
 			parentRef,
-			width: boxWidth,
-			height: boxHeight,
-			hasAspectRatio,
-		} = useResponsiveDimensions( {
-			resizeDebounceTime,
-			maxWidth,
-			aspectRatio,
-			explicitWidth: width,
-			explicitHeight: height,
+			width: parentWidth,
+			height: parentHeight,
+		} = useParentSize( {
+			debounceTime: resizeDebounceTime,
+			enableDebounceLeadingCall: true,
 		} );
+
+		const hasAspectRatio = aspectRatio !== undefined && aspectRatio > 0;
+
+		// Keep our own handle on the wrapper so we can read its live height below, and
+		// still hand the node to useParentSize's ref (a callback ref in practice; guard
+		// the object-ref shape too).
+		const wrapperRef = useRef< HTMLDivElement | null >( null );
+		const setWrapperRef = useCallback(
+			( node: HTMLDivElement | null ) => {
+				wrapperRef.current = node;
+				if ( typeof parentRef === 'function' ) {
+					parentRef( node );
+				} else if ( parentRef ) {
+					( parentRef as { current: HTMLDivElement | null } ).current = node;
+				}
+			},
+			[ parentRef ]
+		);
+
+		// The parent's available height when it actually constrains the chart, else
+		// null (the chart derives its height from width and grows freely).
+		const [ containedHeight, setContainedHeight ] = useState< number | null >( null );
+
+		// Cap the available width at maxWidth unless an explicit width pins it. Before
+		// measurement resolves, fall back to the explicit width.
+		const cap = width === undefined ? maxWidth : Infinity;
+		const availableWidth = parentWidth > 0 ? Math.min( parentWidth, cap ) : width ?? 0;
+
+		let boxWidth = availableWidth;
+		let boxHeight: number;
+		if ( hasAspectRatio ) {
+			const derivedHeight = availableWidth * aspectRatio;
+			if ( containedHeight !== null && derivedHeight > containedHeight ) {
+				boxHeight = containedHeight;
+				boxWidth = boxHeight / aspectRatio;
+			} else {
+				boxHeight = derivedHeight;
+			}
+		} else {
+			boxHeight = parentHeight > 0 ? parentHeight : height ?? 0;
+		}
+
+		// Resolve containment from real layout, before paint. useParentSize measures
+		// this wrapper, whose height:100% resolves to `auto` (= our own content) when
+		// the parent has no definite height — so that measurement alone can't tell a
+		// genuine constraint from our content reflected back, and clamping against it
+		// deadlocks the chart at its current width on widen. Instead read the wrapper's
+		// live height AFTER layout: when the parent constrains us it is shorter than the
+		// height we drew (the content overflows) → contain to it; when it just reflects
+		// our content the two match → grow. Latch the constraint until the parent is
+		// tall enough for the full derived height again so a contained chart (which then
+		// no longer overflows) doesn't oscillate. parentHeight is a dependency only so a
+		// parent-height change re-runs this; the value used is the fresh clientHeight.
+		useIsomorphicLayoutEffect( () => {
+			if ( ! hasAspectRatio ) {
+				if ( containedHeight !== null ) {
+					setContainedHeight( null );
+				}
+				return;
+			}
+			const node = wrapperRef.current;
+			if ( ! node ) {
+				return;
+			}
+			const available = node.clientHeight;
+			const derivedHeight = availableWidth * aspectRatio;
+			if ( containedHeight === null ) {
+				if ( available > 0 && derivedHeight > available + 1 ) {
+					setContainedHeight( available );
+				}
+			} else if ( available >= derivedHeight - 1 ) {
+				setContainedHeight( null );
+			} else if ( Math.abs( available - containedHeight ) > 1 ) {
+				setContainedHeight( available );
+			}
+		}, [ hasAspectRatio, availableWidth, aspectRatio, containedHeight, parentHeight ] );
 
 		const wrappedComponent = (
 			<WrappedComponent
@@ -116,16 +148,15 @@ export function withResponsive< T extends Exclude< BaseChartProps< unknown >, 'o
 			/>
 		);
 
-		// The outer element fills the parent so useParentSize can measure the true
-		// available width AND height. With an aspectRatio the chart is placed in an
-		// inner box sized to the contained dimensions (centered horizontally, top-
-		// aligned) so it keeps its proportions and fits within the parent on both
-		// axes. Charts that fill their container via CSS (e.g. the heatmap grid) then
-		// track that contained box. Without an aspectRatio the chart fills the parent
-		// directly, exactly as before.
+		// The outer element fills the parent so its live height reflects the real
+		// available space. With an aspectRatio the chart is placed in an inner box sized
+		// to the contained dimensions (centered horizontally, top-aligned) so it keeps
+		// its proportions and fits within the parent on both axes. Charts that fill their
+		// container via CSS (e.g. the heatmap grid) then track that contained box. Without
+		// an aspectRatio the chart fills the parent directly, exactly as before.
 		return (
 			<div
-				ref={ parentRef }
+				ref={ setWrapperRef }
 				data-testid="responsive-wrapper"
 				className={ styles.container }
 				style={ {

--- a/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
@@ -16,7 +16,10 @@ export type ResponsiveConfig = {
 	maxWidth?: number;
 	/**
 	 * The aspect ratio of the chart (height = width * aspectRatio).
-	 * When provided, height is calculated from width.
+	 * When provided, the chart keeps this ratio and is contained within the
+	 * parent on both axes: it fills the available width and derives its height,
+	 * but if the parent is shorter than that derived height it shrinks both axes
+	 * to fit rather than overflowing.
 	 * When omitted, the chart fills the parent container's height.
 	 */
 	aspectRatio?: number;
@@ -30,7 +33,9 @@ const useResponsiveDimensions = ( {
 	resizeDebounceTime = 300,
 	maxWidth = 1200,
 	aspectRatio,
-}: ResponsiveConfig ) => {
+	explicitWidth,
+	explicitHeight,
+}: ResponsiveConfig & { explicitWidth?: number; explicitHeight?: number } ) => {
 	const {
 		parentRef,
 		width: parentWidth,
@@ -40,20 +45,32 @@ const useResponsiveDimensions = ( {
 		enableDebounceLeadingCall: true,
 	} );
 
-	const containerWidth = parentWidth > 0 ? Math.min( parentWidth, maxWidth ) : 0;
-	const containerHeight = aspectRatio !== undefined ? containerWidth * aspectRatio : parentHeight;
+	const hasAspectRatio = aspectRatio !== undefined && aspectRatio > 0;
 
-	return {
-		parentRef,
-		width: containerWidth,
-		height: containerHeight,
-		/**
-		 * Whether an aspectRatio was provided. Used to determine container
-		 * height styling: 'auto' when true (height derived from width),
-		 * '100%' when false (fill parent container).
-		 */
-		hasAspectRatio: aspectRatio !== undefined,
-	};
+	// Cap the available width at maxWidth unless an explicit width pins it. Before
+	// measurement resolves, fall back to the explicit width.
+	const cap = explicitWidth === undefined ? maxWidth : Infinity;
+	const availableWidth = parentWidth > 0 ? Math.min( parentWidth, cap ) : explicitWidth ?? 0;
+
+	let width = availableWidth;
+	let height: number;
+
+	if ( hasAspectRatio ) {
+		height = availableWidth * aspectRatio;
+		// Contain: when the parent bounds the height and the width-derived height
+		// would overflow it, shrink both axes to fit, preserving the ratio. The 1px
+		// slack keeps the self-referential auto-height case — a parent with no height
+		// of its own collapses onto this box, so measured height ≈ derived height —
+		// from clamping against itself.
+		if ( parentHeight > 0 && height > parentHeight + 1 ) {
+			height = parentHeight;
+			width = height / aspectRatio;
+		}
+	} else {
+		height = parentHeight > 0 ? parentHeight : explicitHeight ?? 0;
+	}
+
+	return { parentRef, width, height, hasAspectRatio };
 };
 
 /**
@@ -77,34 +94,33 @@ export function withResponsive< T extends Exclude< BaseChartProps< unknown >, 'o
 	}: Omit< T, 'width' | 'height' | 'size' > & DimensionProps & ResponsiveConfig ) {
 		const {
 			parentRef,
-			width: measuredWidth,
-			height: measuredHeight,
+			width: boxWidth,
+			height: boxHeight,
 			hasAspectRatio,
 		} = useResponsiveDimensions( {
 			resizeDebounceTime,
 			maxWidth,
 			aspectRatio,
+			explicitWidth: width,
+			explicitHeight: height,
 		} );
 
-		// Use measured dimensions, but fall back to explicit width/height props if measurement returns 0
-		// (e.g., during initial render or in test environments without DOM measurement).
-		// Do not use size here — size controls chart element dimensions (e.g. pie diameter), not container dimensions.
-		const effectiveWidth = measuredWidth || width || 0;
-		const effectiveHeight = measuredHeight || height || 0;
+		const wrappedComponent = (
+			<WrappedComponent
+				width={ boxWidth }
+				height={ boxHeight }
+				size={ size }
+				{ ...( chartProps as T ) }
+			/>
+		);
 
-		const defaultHeight = hasAspectRatio ? 'auto' : '100%';
-		// Express the aspect ratio in CSS so the container height tracks its width
-		// fluidly, rather than snapping to a debounced measured height. Cap the width
-		// at maxWidth so the CSS-derived height matches the maxWidth-capped content
-		// (the wrapped chart is sized from the capped `measuredWidth`).
-		const aspectRatioStyle =
-			hasAspectRatio && aspectRatio
-				? {
-						aspectRatio: `${ 1 / aspectRatio }`,
-						maxWidth: width === undefined ? maxWidth : undefined,
-				  }
-				: null;
-
+		// The outer element fills the parent so useParentSize can measure the true
+		// available width AND height. With an aspectRatio the chart is placed in an
+		// inner box sized to the contained dimensions (centered horizontally, top-
+		// aligned) so it keeps its proportions and fits within the parent on both
+		// axes. Charts that fill their container via CSS (e.g. the heatmap grid) then
+		// track that contained box. Without an aspectRatio the chart fills the parent
+		// directly, exactly as before.
 		return (
 			<div
 				ref={ parentRef }
@@ -112,16 +128,23 @@ export function withResponsive< T extends Exclude< BaseChartProps< unknown >, 'o
 				className={ styles.container }
 				style={ {
 					width: width ?? '100%',
-					height: height ?? defaultHeight,
-					...aspectRatioStyle,
+					height: height ?? '100%',
+					...( hasAspectRatio
+						? { display: 'flex', justifyContent: 'center', alignItems: 'flex-start' }
+						: null ),
 				} }
 			>
-				<WrappedComponent
-					width={ effectiveWidth }
-					height={ effectiveHeight }
-					size={ size }
-					{ ...( chartProps as T ) }
-				/>
+				{ hasAspectRatio ? (
+					<div
+						data-testid="responsive-content"
+						className={ styles.content }
+						style={ { width: boxWidth, height: boxHeight } }
+					>
+						{ wrappedComponent }
+					</div>
+				) : (
+					wrappedComponent
+				) }
 			</div>
 		);
 	};

--- a/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
@@ -19,7 +19,8 @@ export type ResponsiveConfig = {
 	 * When provided, the chart keeps this ratio and is contained within the
 	 * parent on both axes: it fills the available width and derives its height,
 	 * but if the parent is shorter than that derived height it shrinks both axes
-	 * to fit rather than overflowing.
+	 * to fit rather than overflowing. When it is narrower than the parent (the
+	 * height-constrained case) it is centered horizontally.
 	 * When omitted, the chart fills the parent container's height.
 	 */
 	aspectRatio?: number;

--- a/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
@@ -1,4 +1,5 @@
 import { useParentSize } from '@visx/responsive';
+import clsx from 'clsx';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import styles from './with-responsive.module.scss';
 import type { BaseChartProps } from '../../../types';
@@ -142,30 +143,28 @@ export function withResponsive< T extends Exclude< BaseChartProps< unknown >, 'o
 			/>
 		);
 
-		// The outer element fills the parent so its live height reflects the real
-		// available space. With an aspectRatio the chart is placed in an inner box sized
-		// to the contained dimensions (centered horizontally, top-aligned) so it keeps
-		// its proportions and fits within the parent on both axes. Charts that fill their
-		// container via CSS (e.g. the heatmap grid) then track that contained box. Without
-		// an aspectRatio the chart fills the parent directly, exactly as before.
+		// The outer element fills the parent (via CSS) so its live height reflects the
+		// real available space; JS sets width/height only when they are passed
+		// explicitly. With an aspectRatio the chart is placed in an inner box whose width
+		// is set here and whose height follows from the CSS aspect-ratio, so it keeps its
+		// proportions and fits within the parent on both axes (centered by CSS). Charts
+		// that fill their container via CSS (e.g. the heatmap grid) then track that box.
+		// Without an aspectRatio the chart fills the parent directly.
 		return (
 			<div
 				ref={ setWrapperRef }
 				data-testid="responsive-wrapper"
-				className={ styles.container }
+				className={ clsx( styles.container, hasAspectRatio && styles.isContained ) }
 				style={ {
-					width: width ?? '100%',
-					height: height ?? '100%',
-					...( hasAspectRatio
-						? { display: 'flex', justifyContent: 'center', alignItems: 'flex-start' }
-						: null ),
+					...( width !== undefined ? { width } : null ),
+					...( height !== undefined ? { height } : null ),
 				} }
 			>
 				{ hasAspectRatio ? (
 					<div
 						data-testid="responsive-content"
 						className={ styles.content }
-						style={ { width: boxWidth, height: boxHeight } }
+						style={ { width: boxWidth, aspectRatio: `1 / ${ aspectRatio }` } }
 					>
 						{ wrappedComponent }
 					</div>

--- a/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
@@ -122,11 +122,7 @@ export function withResponsive< T extends Exclude< BaseChartProps< unknown >, 'o
 				}
 				return;
 			}
-			const node = wrapperRef.current;
-			if ( ! node ) {
-				return;
-			}
-			const available = node.clientHeight;
+			const available = wrapperRef.current?.clientHeight ?? 0;
 			const derivedHeight = availableWidth * aspectRatio;
 			if ( containedHeight === null ) {
 				if ( available > 0 && derivedHeight > available + 1 ) {

--- a/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
+++ b/projects/js-packages/charts/src/charts/private/with-responsive/with-responsive.tsx
@@ -60,9 +60,10 @@ const useResponsiveDimensions = ( {
 		height = availableWidth * aspectRatio;
 		// Contain: when the parent bounds the height and the width-derived height
 		// would overflow it, shrink both axes to fit, preserving the ratio. The 1px
-		// slack keeps the self-referential auto-height case — a parent with no height
-		// of its own collapses onto this box, so measured height ≈ derived height —
-		// from clamping against itself.
+		// slack is not a workaround for a rare case — it covers the normal
+		// unconstrained-parent path (no explicit height on the parent), where this
+		// wrapper's own height comes from this box's content, so the measured height
+		// equals the derived height and a bare `>` would clamp it against itself.
 		if ( parentHeight > 0 && height > parentHeight + 1 ) {
 			height = parentHeight;
 			width = height / aspectRatio;

--- a/projects/js-packages/charts/src/charts/sparkline/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/sparkline/stories/index.api.mdx
@@ -28,7 +28,7 @@ Main component for rendering minimal trend visualizations.
 | `chartId` | `string` | - | Custom chart identifier for unique gradient/element identification |
 | `margin` | `object` | `{2,2,2,2}` | Margin around the chart |
 | `animation` | `boolean` | `false` | Enable entry animation on initial render. Creates a rising effect where the line scales up from the bottom. Automatically respects user's `prefers-reduced-motion` system setting |
-| `aspectRatio` | `number` | - | Aspect ratio for responsive charts. When omitted, fills parent height (responsive variant only) |
+| `aspectRatio` | `number` | - | Aspect ratio for responsive charts; if the parent is shorter than the derived height, the chart shrinks both axes to fit rather than overflowing (contained on both axes). When omitted, fills parent height (responsive variant only) |
 | `maxWidth` | `number` | `1200` | Maximum width for responsive charts (responsive variant only) |
 | `resizeDebounceTime` | `number` | `300` | Debounce time for resize events in ms (responsive variant only) |
 
@@ -153,7 +153,7 @@ The default `Sparkline` export includes responsive sizing. By default, it **fill
 ```
 
 **Responsive Props:**
-- `aspectRatio`: Height as a fraction of width (e.g., 0.3 = 30% height). When omitted, fills parent height.
+- `aspectRatio`: Height as a fraction of width (e.g., 0.3 = 30% height); if the parent is shorter than that height, the chart shrinks both axes to fit rather than overflowing (contained on both axes). When omitted, fills parent height.
 - `maxWidth`: Maximum width constraint (default: 1200)
 - `resizeDebounceTime`: Debounce delay for resize events (default: 300ms)
 

--- a/projects/js-packages/charts/src/charts/sparkline/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/sparkline/stories/index.api.mdx
@@ -28,7 +28,7 @@ Main component for rendering minimal trend visualizations.
 | `chartId` | `string` | - | Custom chart identifier for unique gradient/element identification |
 | `margin` | `object` | `{2,2,2,2}` | Margin around the chart |
 | `animation` | `boolean` | `false` | Enable entry animation on initial render. Creates a rising effect where the line scales up from the bottom. Automatically respects user's `prefers-reduced-motion` system setting |
-| `aspectRatio` | `number` | - | Aspect ratio for responsive charts; if the parent is shorter than the derived height, the chart shrinks both axes to fit rather than overflowing (contained on both axes). When omitted, fills parent height (responsive variant only) |
+| `aspectRatio` | `number` | - | Height-to-width ratio (e.g. `0.3`) for responsive charts; the chart is contained within its parent on both axes. Used when `width`/`height` are omitted (responsive variant only). |
 | `maxWidth` | `number` | `1200` | Maximum width for responsive charts (responsive variant only) |
 | `resizeDebounceTime` | `number` | `300` | Debounce time for resize events in ms (responsive variant only) |
 

--- a/projects/js-packages/charts/src/charts/sparkline/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/sparkline/stories/index.docs.mdx
@@ -66,7 +66,7 @@ The simplest sparkline requires only a `data` prop with an array of numeric valu
 - **`width`** (default: `100`): Width of the sparkline in pixels
 - **`height`** (default: `40`): Height of the sparkline in pixels
 - **`margin`** (default: `{2,2,2,2}`): Margin around the chart
-- **`aspectRatio`**: Height as a fraction of width. When omitted, fills parent container height
+- **`aspectRatio`**: Height as a fraction of width; if the parent is shorter than that height, the chart shrinks both axes to fit rather than overflowing (contained on both axes). When omitted, fills parent container height
 - **`maxWidth`** (default: `1200`): Maximum width constraint for responsive charts
 - **`resizeDebounceTime`** (default: `300`): Debounce delay for resize events in ms
 

--- a/projects/js-packages/charts/src/charts/sparkline/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/sparkline/stories/index.docs.mdx
@@ -215,7 +215,7 @@ The default `Sparkline` export includes responsive behavior. By default, it **fi
 		<Sparkline data={[10, 15, 12, 18, 22, 25]} color="#9C27B0" />
 	</div>
 
-	// Use aspect ratio - height calculated from width
+	// Use aspect ratio - height from width, contained if the parent is shorter
 	<div style={{ width: '100%', maxWidth: '200px' }}>
 		<Sparkline data={[10, 15, 12, 18, 22, 25]} color="#9C27B0" aspectRatio={0.3} />
 	</div>` }

--- a/projects/js-packages/charts/src/charts/sparkline/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/sparkline/stories/index.docs.mdx
@@ -66,7 +66,7 @@ The simplest sparkline requires only a `data` prop with an array of numeric valu
 - **`width`** (default: `100`): Width of the sparkline in pixels
 - **`height`** (default: `40`): Height of the sparkline in pixels
 - **`margin`** (default: `{2,2,2,2}`): Margin around the chart
-- **`aspectRatio`**: Height as a fraction of width; if the parent is shorter than that height, the chart shrinks both axes to fit rather than overflowing (contained on both axes). When omitted, fills parent container height
+- **`aspectRatio`**: Height-to-width ratio (e.g. `0.3`) for responsive charts; the chart is contained within its parent on both axes. When omitted, fills the parent container's height
 - **`maxWidth`** (default: `1200`): Maximum width constraint for responsive charts
 - **`resizeDebounceTime`** (default: `300`): Debounce delay for resize events in ms
 

--- a/projects/js-packages/charts/src/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/stories/index.docs.mdx
@@ -140,17 +140,17 @@ When you omit dimension props, the chart expands to fill its parent container:
 
 #### Aspect Ratio Mode
 
-For layouts where you want height calculated from width, pass the `aspectRatio` prop:
+For layouts where the container width varies but you want consistent proportions, pass the `aspectRatio` prop:
 
 <Source
 	language="jsx"
-	code={`// Height = width × aspectRatio (e.g., 2:1 ratio)
+	code={`// Height from width; contained if the parent is shorter
 	<div style={{ width: '100%' }}>
 		<LineChart data={data} aspectRatio={0.5} />
 	</div>`}
 />
 
-This is useful for responsive layouts where the container width varies but you want consistent proportions. The chart is contained within its parent on both axes: it fills the available width and derives its height, but if the parent is shorter than that derived height it shrinks both axes to fit rather than overflowing (and is centered horizontally when narrower than the parent). Because the chart keeps its aspect ratio, a parent that is taller than the derived height will show empty space below the chart rather than stretching it.
+The chart keeps this ratio, contained within its parent on both axes: it fills the available width and derives its height, but shrinks both axes to fit a shorter parent rather than overflowing. A taller parent leaves space below rather than stretching the chart.
 
 #### Fixed Dimensions
 

--- a/projects/js-packages/charts/src/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/stories/index.docs.mdx
@@ -150,7 +150,7 @@ For layouts where you want height calculated from width, pass the `aspectRatio` 
 	</div>`}
 />
 
-This is useful for responsive layouts where the container width varies but you want consistent proportions. The chart is contained within its parent on both axes: it fills the available width and derives its height, but if the parent is shorter than that derived height it shrinks both axes to fit rather than overflowing.
+This is useful for responsive layouts where the container width varies but you want consistent proportions. The chart is contained within its parent on both axes: it fills the available width and derives its height, but if the parent is shorter than that derived height it shrinks both axes to fit rather than overflowing (and is centered horizontally when narrower than the parent).
 
 #### Fixed Dimensions
 

--- a/projects/js-packages/charts/src/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/stories/index.docs.mdx
@@ -150,7 +150,7 @@ For layouts where you want height calculated from width, pass the `aspectRatio` 
 	</div>`}
 />
 
-This is useful for responsive layouts where the container width varies but you want consistent proportions.
+This is useful for responsive layouts where the container width varies but you want consistent proportions. The chart is contained within its parent on both axes: it fills the available width and derives its height, but if the parent is shorter than that derived height it shrinks both axes to fit rather than overflowing.
 
 #### Fixed Dimensions
 
@@ -167,7 +167,7 @@ For complete control, specify explicit `width` and `height` props:
 |------|------|---------|-------------|
 | `width` | `number` | - | Fixed width in pixels (omit for responsive) |
 | `height` | `number` | - | Fixed height in pixels (omit for responsive) |
-| `aspectRatio` | `number` | - | Height as ratio of width (e.g., `0.5` = half width) |
+| `aspectRatio` | `number` | - | Height as ratio of width (e.g., `0.5` = half width); contained within the parent on both axes |
 | `maxWidth` | `number` | `1200` | Maximum width constraint |
 | `resizeDebounceTime` | `number` | `300` | Debounce delay for resize events (ms) |
 

--- a/projects/js-packages/charts/src/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/stories/index.docs.mdx
@@ -150,7 +150,7 @@ For layouts where you want height calculated from width, pass the `aspectRatio` 
 	</div>`}
 />
 
-This is useful for responsive layouts where the container width varies but you want consistent proportions. The chart is contained within its parent on both axes: it fills the available width and derives its height, but if the parent is shorter than that derived height it shrinks both axes to fit rather than overflowing (and is centered horizontally when narrower than the parent).
+This is useful for responsive layouts where the container width varies but you want consistent proportions. The chart is contained within its parent on both axes: it fills the available width and derives its height, but if the parent is shorter than that derived height it shrinks both axes to fit rather than overflowing (and is centered horizontally when narrower than the parent). Because the chart keeps its aspect ratio, a parent that is taller than the derived height will show empty space below the chart rather than stretching it.
 
 #### Fixed Dimensions
 


### PR DESCRIPTION
Fixes CHARTS-242

### Why

When `aspectRatio` is set on a responsive chart, `withResponsive` derived the chart's height **purely from its width** and ignored the parent's available height. In a height-constrained parent the chart kept its full width-derived height and **overflowed (scrolled) vertically** instead of fitting — it shrank with the parent's width but not its height. The heatmap made this obvious: with `aspectRatio` set it filled the width but spilled out of a short container.

### Changes proposed in this Pull Request

`withResponsive` now fills the parent so it can measure **both** axes, then sizes the chart to a *contained* box:

- It still fills the available width and derives its height from `width × aspectRatio`.
- When the parent is **shorter** than that derived height, both axes shrink to fit while preserving the ratio (like `object-fit: contain`).
- Containment is resolved from the wrapper's **real height after layout** (via `useLayoutEffect` + `clientHeight`), driven through state, rather than from the debounced measurement — which for an unconstrained-height parent reflects the chart's own content back and would otherwise deadlock the chart at its current width on widen. So a fluid (width-only) parent still grows the chart correctly, while a genuinely short parent contains it.
- The chart renders inside an inner box sized to those contained dimensions, so charts that fill their container via CSS (the heatmap grid) track it too.

This is a shared change in `withResponsive`, so it applies to every responsive chart (area, bar, bar-list, geo, heatmap, leaderboard, line, pie, sparkline). Behavior only changes in the previously-broken height-constrained case; the tall-parent case still derives height from width exactly as before. `PieSemiCircleChart` keeps its own fixed 2:1 ratio and is unaffected.

**Docs consistency:** `aspectRatio` is now documented consistently across every chart that supports it — the API-reference prop tables, the "Optional Props" lists, and the "Responsive Behavior" examples — using the same concise "contained within its parent on both axes" wording. `PieSemiCircleChart` (fixed 2:1 ratio) and `ConversionFunnelChart` (non-responsive) intentionally omit it; `PieChart` documents `size` as its idiomatic sizing control.

### Screenshots

Heatmap `Aspect Ratio` story in a short (760×150) container.

**Before** — the chart keeps its full width-derived height and overflows the container vertically (only the top rows are visible; it scrolls):

<img width="1800" height="640" alt="heatmap-before" src="https://github.com/user-attachments/assets/f0adb376-0fa3-4526-834a-c4596d48331e" />

**After** — the chart shrinks on both axes, keeps its aspect ratio, and fits within the container (all rows visible, no scrollbar):

<img width="1800" height="640" alt="heatmap-after" src="https://github.com/user-attachments/assets/5e3de33f-a548-4cb2-93e4-5eef255a112e" />

### Testing instructions

This changes the shared `withResponsive` HOC, so it affects every chart that exposes an `aspectRatio`. In Storybook, each of these has an **Aspect Ratio** story under **JS Packages / Charts Library / Charts / …**:

- Heatmap Chart → Aspect Ratio
- Bar Chart → Aspect Ratio
- Bar List Chart → Aspect Ratio
- Area Chart → Aspect Ratio
- Line Chart → Aspect Ratio
- Sparkline → Aspect Ratio
- Leaderboard Chart → Aspect Ratio
- Geo Chart → Aspect Ratio

For each story:

1. In the story controls set **containerHeight** to a small value (e.g. `150px`) with a wide **containerWidth** (e.g. `760px`).
2. **Before this PR:** the chart keeps its full width-derived height and the container shows a vertical scrollbar (it overflows).
3. **After this PR:** the chart shrinks on both axes, keeps its aspect ratio, fits within the container with no scrollbar, and is centered horizontally.
4. Set a tall container (e.g. `400px`) and confirm the chart still fills the width and derives its height as before (unchanged behavior).
5. Widen a fluid (height-`auto`) container and confirm the chart **grows** with the width rather than sticking at its previous size.
6. Confirm nothing regresses for charts used **without** `aspectRatio` (they still fill the parent's height).

Verified in a real browser (Playwright): all 8 Aspect Ratio stories in a short (760×140) container. Seven fully contain — the box keeps its target ratio and the container no longer scrolls. Geo Chart is the one exception: it drops from a large overflow on `trunk` (scrollHeight ~382 vs 138) to a ~3px residual on this branch (the map `<svg>`'s inline descender), so it's hugely improved but not pixel-perfect; that residual is a geo-chart rendering detail, not the shared contain logic, and can be a follow-up. Also verified the widen case in a fluid parent (grows correctly, no deadlock), the tall-parent case (unchanged, derives height from width), and the unconstrained height-`auto` parent (wrapper grows to `width × aspectRatio` and participates in normal flow).

Unit tests: `pnpm --filter=@automattic/charts test` (993 passing), including added `withResponsive` tests covering the contain/grow/re-contain transitions and the aspectRatio-removed reset; coverage for `with-responsive.tsx` is back to 100% lines. Type-check is clean.

### Does this pull request change what data or activity we track or use?

No. This is a client-side layout/CSS change to how responsive charts size themselves; it does not add, remove, or change any tracked data or activity.
