### PR TITLE
My Jetpack: migrate to WPDS from Calypso color schemes

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/help/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/help/styles.module.scss
@@ -32,7 +32,7 @@
 }
 
 .footer {
-	background: var(--studio-white, #fff);
+	background: var(--wpds-color-background-surface-neutral-strong, #fff);
 
 	/* Center the content within the full-width background */
 	display: flex;

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/overview/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/overview/styles.module.scss
@@ -10,7 +10,7 @@
 }
 
 .footer {
-	background: var(--studio-white, #fff);
+	background: var(--wpds-color-background-surface-neutral-strong, #fff);
 
 	/* Center the content within the full-width background */
 	display: flex;

--- a/projects/packages/my-jetpack/_inc/components/stats-section/stats-chart-tooltip.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/stats-chart-tooltip.module.scss
@@ -4,8 +4,8 @@
 	box-shadow: none !important;
 
 	.stats-line-chart-tooltip {
-		color: var(--color-text-inverted, #fff);
-		background: var(--color-neutral-100, #101517);
+		color: var(--wpds-color-foreground-interactive-brand-strong, #fff);
+		background: var(--wpds-color-background-interactive-neutral-strong-active, #1e1e1e);
 		border-radius: 4px;
 		font-size: var(--font-body-small, 14px);
 		padding: 28px 24px 16px;
@@ -57,7 +57,7 @@
 					// vertical-align: middle;
 					width: 24px;
 					height: 24px;
-					fill: var(--color-text-inverted, #fff);
+					fill: var(--wpds-color-foreground-interactive-brand-strong, #fff);
 				}
 
 				// &:last-child {

--- a/projects/packages/my-jetpack/_inc/components/stats-section/stats-chart.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/stats-section/stats-chart.module.scss
@@ -34,7 +34,7 @@
 
 	.empty-state-card__icon {
 		align-self: center;
-		color: var(--color-neutral-80);
+		color: var(--wpds-color-foreground-content-neutral, #1e1e1e);
 		flex-shrink: 0;
 		margin-inline-end: 20px;
 	}
@@ -44,14 +44,14 @@
 	}
 
 	.empty-state-card-heading {
-		color: var(--color-neutral-80);
+		color: var(--wpds-color-foreground-content-neutral, #1e1e1e);
 
 		@include gb.heading-large;
 		margin-bottom: 8px;
 	}
 
 	.empty-state-card-info {
-		color: var(--color-neutral-40);
+		color: var(--wpds-color-foreground-content-neutral-weak, #707070);
 
 		@include gb.body-medium;
 	}

--- a/projects/packages/my-jetpack/changelog/update-wpds-color-tokens
+++ b/projects/packages/my-jetpack/changelog/update-wpds-color-tokens
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Replace Calypso --color-* and --studio-* CSS variables with WPDS design tokens in stats chart and tab panel styles.


### PR DESCRIPTION
Helps with migration to [WPDS tokens](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/docs/tokens.md) and build tooling more fully in the repo at https://github.com/Automattic/jetpack/pull/50108 when we don't need to worry about including Calypso Colours everywhere.


## Proposed changes
<!--- Explain what functional changes your PR includes -->
Migrates My Jetpack out from `@automattic/calypso-color-schemes` colors by switching a few tokens that there were into WPDS tokens.

<details>
<summary>Summary of colors before/after</summary>

| Location | Before (token) | Before (hex) | After (token) | After (hex) |
|----------|----------------|--------------|---------------|-------------|
| Tab panel footer bg (`overview`, `help`) | `--studio-white` | `#fff` | `--wpds-color-background-surface-neutral-strong` | `#fff` |
| Stats chart empty state icon & heading | `--color-neutral-80` | `#2c3338` | `--wpds-color-foreground-content-neutral` | `#1e1e1e` |
| Stats chart empty state info text | `--color-neutral-40` | `#787c82` | `--wpds-color-foreground-content-neutral-weak` | `#707070` |
| Stats chart tooltip background | `--color-neutral-100` | `#101517` | `--wpds-color-background-interactive-neutral-strong-active` | `#1e1e1e` |
| Stats chart tooltip text & icon fill | `--color-text-inverted` | `#fff` | `--wpds-color-foreground-interactive-brand-strong` | `#fff` |

- White tokens are unchanged (`#fff`).
- Neutral grays shift to the WPDS palette:
    - `#2c3338` → `#1e1e1e`
    - `#787c82` → `#707070`
    - `#101517` → `#1e1e1e`
</details>


## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Test charts area at My Jetpack.

### Before
<img width="981" height="463" alt="Screenshot 2026-07-14 at 00 46 57" src="https://github.com/user-attachments/assets/48233a87-fd6a-4734-b92e-32fa885a413c" />
<img width="1215" height="465" alt="Screenshot 2026-07-14 at 01 01 06" src="https://github.com/user-attachments/assets/35241c5f-9b68-4d2e-8a31-eedabdb17823" />



### After
<img width="988" height="473" alt="Screenshot 2026-07-14 at 00 42 30" src="https://github.com/user-attachments/assets/f47e74fe-ddbe-4e89-ba5e-75dbf9767432" />
<img width="1191" height="465" alt="Screenshot 2026-07-14 at 01 02 21" src="https://github.com/user-attachments/assets/befd7627-d65b-43ce-9f6e-ca183fe6f33c" />
