### PR TITLE
PayPal block: use WPDS tokens instead of Calypso color schemes

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23473,12 +23473,12 @@ snapshots:
 
   '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1)(webpack@5.107.2)':
     dependencies:
-      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
+      webpack: 5.107.2(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack@5.107.2)
 
   '@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.107.2)':
     dependencies:
-      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
+      webpack: 5.107.2(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack@5.107.2)
 
   '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.5)(webpack@5.107.2)':
@@ -23490,7 +23490,7 @@ snapshots:
 
   '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack@5.107.2)':
     dependencies:
-      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
+      webpack: 5.107.2(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack@5.107.2)
 
   '@wordpress/a11y@4.51.0':
@@ -26400,7 +26400,7 @@ snapshots:
   '@wordpress/dependency-extraction-webpack-plugin@6.51.0(webpack@5.107.2)':
     dependencies:
       json2php: 0.0.9
-      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
+      webpack: 5.107.2(webpack-cli@6.0.1)
 
   '@wordpress/deprecated@4.51.0':
     dependencies:
@@ -36546,7 +36546,7 @@ snapshots:
       neo-async: 2.6.2
     optionalDependencies:
       sass-embedded: 1.97.3
-      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
+      webpack: 5.107.2(webpack-cli@6.0.1)
 
   sax@1.6.0: {}
 
@@ -38000,7 +38000,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
+      webpack: 5.107.2(webpack-cli@6.0.1)
       webpack-merge: 6.0.1
 
   webpack-dev-middleware@7.4.5(webpack@5.107.2):
@@ -38210,7 +38210,7 @@ snapshots:
       watchpack: 2.5.2
       webpack-sources: 3.5.1
     optionalDependencies:
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.5)(webpack@5.107.2)
+      webpack-cli: 6.0.1(webpack@5.107.2)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3702,6 +3702,9 @@ importers:
       '@wordpress/block-serialization-default-parser':
         specifier: 5.51.0
         version: 5.51.0
+      '@wordpress/theme':
+        specifier: 0.17.0
+        version: 0.17.0(@types/react@18.3.28)(postcss@8.5.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       autoprefixer:
         specifier: 10.4.20
         version: 10.4.20(postcss@8.5.14)
@@ -23470,12 +23473,12 @@ snapshots:
 
   '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1)(webpack@5.107.2)':
     dependencies:
-      webpack: 5.107.2(webpack-cli@6.0.1)
+      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack@5.107.2)
 
   '@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.107.2)':
     dependencies:
-      webpack: 5.107.2(webpack-cli@6.0.1)
+      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack@5.107.2)
 
   '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.5)(webpack@5.107.2)':
@@ -23487,7 +23490,7 @@ snapshots:
 
   '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack@5.107.2)':
     dependencies:
-      webpack: 5.107.2(webpack-cli@6.0.1)
+      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack@5.107.2)
 
   '@wordpress/a11y@4.51.0':
@@ -26397,7 +26400,7 @@ snapshots:
   '@wordpress/dependency-extraction-webpack-plugin@6.51.0(webpack@5.107.2)':
     dependencies:
       json2php: 0.0.9
-      webpack: 5.107.2(webpack-cli@6.0.1)
+      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
 
   '@wordpress/deprecated@4.51.0':
     dependencies:
@@ -36543,7 +36546,7 @@ snapshots:
       neo-async: 2.6.2
     optionalDependencies:
       sass-embedded: 1.97.3
-      webpack: 5.107.2(webpack-cli@6.0.1)
+      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
 
   sax@1.6.0: {}
 
@@ -37997,7 +38000,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.107.2(webpack-cli@6.0.1)
+      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
       webpack-merge: 6.0.1
 
   webpack-dev-middleware@7.4.5(webpack@5.107.2):
@@ -38207,7 +38210,7 @@ snapshots:
       watchpack: 2.5.2
       webpack-sources: 3.5.1
     optionalDependencies:
-      webpack-cli: 6.0.1(webpack@5.107.2)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.5)(webpack@5.107.2)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'

--- a/projects/packages/paypal-payments/changelog/update-paypal-block-wpds-tokens
+++ b/projects/packages/paypal-payments/changelog/update-paypal-block-wpds-tokens
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Replace legacy --color-error tokens with WPDS design tokens in PayPal block editor styles, and emit DS token fallbacks via PostCSS.
 
-Comment: Replace legacy --color-error tokens with WPDS design tokens in PayPal block editor styles.

--- a/projects/packages/paypal-payments/changelog/update-paypal-block-wpds-tokens
+++ b/projects/packages/paypal-payments/changelog/update-paypal-block-wpds-tokens
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Comment: Replace legacy --color-error tokens with WPDS design tokens in PayPal block editor styles.

--- a/projects/packages/paypal-payments/changelog/update-wpds-fallback-values-paypal-payments
+++ b/projects/packages/paypal-payments/changelog/update-wpds-fallback-values-paypal-payments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Build: Emit DS token fallbacks via PostCSS and drop hardcoded fallbacks from styles.

--- a/projects/packages/paypal-payments/changelog/update-wpds-fallback-values-paypal-payments
+++ b/projects/packages/paypal-payments/changelog/update-wpds-fallback-values-paypal-payments
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Build: Emit DS token fallbacks via PostCSS and drop hardcoded fallbacks from styles.

--- a/projects/packages/paypal-payments/package.json
+++ b/projects/packages/paypal-payments/package.json
@@ -61,6 +61,7 @@
 		"@types/react": "18.3.28",
 		"@wordpress/babel-plugin-import-jsx-pragma": "5.51.0",
 		"@wordpress/block-serialization-default-parser": "5.51.0",
+		"@wordpress/theme": "0.17.0",
 		"autoprefixer": "10.4.20",
 		"babel-jest": "30.4.1",
 		"jest": "30.4.2",

--- a/projects/packages/paypal-payments/src/block/editor.scss
+++ b/projects/packages/paypal-payments/src/block/editor.scss
@@ -50,7 +50,7 @@
 
 		.components-text-control__input,
 		.components-textarea-control__input {
-			border-color: var(--color-error);
+			border-color: var(--wpds-color-stroke-interactive-error, #cc1818);
 		}
 	}
 

--- a/projects/packages/paypal-payments/src/block/editor.scss
+++ b/projects/packages/paypal-payments/src/block/editor.scss
@@ -50,7 +50,7 @@
 
 		.components-text-control__input,
 		.components-textarea-control__input {
-			border-color: var(--wpds-color-stroke-interactive-error, #cc1818);
+			border-color: var(--wpds-color-stroke-interactive-error);
 		}
 	}
 

--- a/projects/packages/paypal-payments/src/block/help-message.scss
+++ b/projects/packages/paypal-payments/src/block/help-message.scss
@@ -17,10 +17,10 @@
 	}
 
 	&.help-message-is-error {
-		color: var(--color-error);
+		color: var(--wpds-color-foreground-content-error, #d63638);
 
 		svg {
-			fill: var(--color-error);
+			fill: var(--wpds-color-foreground-content-error, #d63638);
 		}
 	}
 }

--- a/projects/packages/paypal-payments/src/block/help-message.scss
+++ b/projects/packages/paypal-payments/src/block/help-message.scss
@@ -17,10 +17,10 @@
 	}
 
 	&.help-message-is-error {
-		color: var(--wpds-color-foreground-content-error, #d63638);
+		color: var(--wpds-color-foreground-content-error);
 
 		svg {
-			fill: var(--wpds-color-foreground-content-error, #d63638);
+			fill: var(--wpds-color-foreground-content-error);
 		}
 	}
 }

--- a/projects/packages/paypal-payments/webpack.config.blocks.js
+++ b/projects/packages/paypal-payments/webpack.config.blocks.js
@@ -66,7 +66,12 @@ const sharedWebpackConfig = {
 					{
 						loader: 'postcss-loader',
 						options: {
-							postcssOptions: { plugins: [ require( 'autoprefixer' ) ] },
+							postcssOptions: {
+								plugins: [
+									require( '@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks' ).default,
+									require( 'autoprefixer' ),
+								],
+							},
 						},
 					},
 					{ loader: 'sass-loader', options: { api: 'modern-compiler' } },

--- a/tools/js-tools/stylelint.config.base.mjs
+++ b/tools/js-tools/stylelint.config.base.mjs
@@ -105,6 +105,7 @@ const baseConfig = {
 				// Webpack packages with `@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks`
 				'projects/packages/forms/src/**/*.{css,scss,sass}',
 				'projects/packages/my-jetpack/_inc/**/*.{css,scss,sass}',
+				'projects/packages/paypal-payments/src/**/*.{css,scss,sass}',
 				'projects/packages/publicize/_inc/**/*.{css,scss,sass}',
 				'projects/packages/search/**/*.{css,scss,sass}',
 				'projects/packages/videopress/src/**/*.{css,scss,sass}',


### PR DESCRIPTION
Helps with migration to [WPDS tokens](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/docs/tokens.md) and builds tooling more fully in the repo at https://github.com/Automattic/jetpack/pull/50108 when we don't need to worry about including Calypso Colours everywhere.

## Proposed changes
<!--- Explain what functional changes your PR includes -->
- Migrates PayPal block out from `@automattic/calypso-color-schemes` colors by switching a few tokens that there were into WPDS tokens.
- Adds build step to add WPDS color fallbacks
- Includes files in linter which checks for WPDS token "no fallbacks"


Super simple since it was just error color. 

Note that previous color for text was `#d63638` and new one is `#470000` but it's now aligned with design system and is more readable. Border is now `#cc1818`.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Add Paypal block
* No visual changes