### PR TITLE
REST API: add type coverage for v1.1 post response scalar fields

### DIFF
--- a/projects/plugins/jetpack/changelog/add-post-v1-1-response-field-type-tests
+++ b/projects/plugins/jetpack/changelog/add-post-v1-1-response-field-type-tests
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Comment: Add regression tests asserting the scalar field types in the WP.com v1.1 get-post REST response.

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Get_Post_v1_1_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Get_Post_v1_1_Endpoint_Test.php
@@ -9,6 +9,7 @@
 
 use Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
 
 require_once JETPACK__PLUGIN_DIR . 'class.json-api-endpoints.php';
@@ -173,5 +174,95 @@ class WPCOM_JSON_API_Get_Post_v1_1_Endpoint_Test extends WP_UnitTestCase { // ph
 		$this->assertIsArray( $response );
 		$this->assertArrayHasKey( 'has_password', $response );
 		$this->assertFalse( $response['has_password'] );
+	}
+
+	/**
+	 * Fetches the default v1.1 response for a freshly created published post.
+	 *
+	 * @return array The rendered post response.
+	 */
+	private function get_default_post_response() {
+		$post_id = $this->create_post();
+
+		$response = $this->get_endpoint()->callback(
+			'/sites/' . self::$blog_id . '/posts/' . $post_id,
+			self::$blog_id,
+			$post_id
+		);
+
+		$this->assertIsArray( $response );
+
+		return $response;
+	}
+
+	/**
+	 * Turns a flat list of field names into named single-argument data sets, so each
+	 * field is written once but still labels its own case in the test output.
+	 *
+	 * @param string[] $fields Response field names.
+	 * @return array
+	 */
+	private static function field_cases( array $fields ) {
+		$cases = array();
+		foreach ( $fields as $field ) {
+			$cases[ $field ] = array( $field );
+		}
+		return $cases;
+	}
+
+	/**
+	 * Fields documented '(int)' in WPCOM_JSON_API_Post_v1_1_Endpoint::$post_object_format.
+	 *
+	 * @return array
+	 */
+	public static function int_response_field_provider() {
+		return self::field_cases( array( 'ID', 'site_ID', 'like_count', 'menu_order', 'attachment_count' ) );
+	}
+
+	/**
+	 * Fields documented '(bool)' in WPCOM_JSON_API_Post_v1_1_Endpoint::$post_object_format.
+	 *
+	 * @return array
+	 */
+	public static function bool_response_field_provider() {
+		return self::field_cases( array( 'sticky', 'has_password', 'likes_enabled', 'sharing_enabled', 'i_like', 'is_reblogged', 'is_following' ) );
+	}
+
+	/**
+	 * Each '(int)'-documented field must be serialized as a JSON number, never a string.
+	 *
+	 * The render_response_keys() serializer casts only ID and site_ID itself and trusts
+	 * each SAL getter for the rest, so this locks the contract and guards against a type
+	 * leak like the site_ID one recurring elsewhere.
+	 *
+	 * @dataProvider int_response_field_provider
+	 * @group json-api
+	 *
+	 * @param string $field The response field name.
+	 */
+	#[DataProvider( 'int_response_field_provider' )]
+	#[Group( 'json-api' )]
+	public function test_int_response_field_is_serialized_as_an_integer( string $field ) {
+		$response = $this->get_default_post_response();
+
+		$this->assertArrayHasKey( $field, $response, $field . ' should be present in the response' );
+		$this->assertIsInt( $response[ $field ], $field . ' should be serialized as an integer' );
+	}
+
+	/**
+	 * Each '(bool)'-documented field must be serialized as a JSON boolean, never a string.
+	 *
+	 * @dataProvider bool_response_field_provider
+	 * @group json-api
+	 *
+	 * @param string $field The response field name.
+	 */
+	#[DataProvider( 'bool_response_field_provider' )]
+	#[Group( 'json-api' )]
+	public function test_bool_response_field_is_serialized_as_a_boolean( string $field ) {
+		$response = $this->get_default_post_response();
+
+		$this->assertArrayHasKey( $field, $response, $field . ' should be present in the response' );
+		$this->assertIsBool( $response[ $field ], $field . ' should be serialized as a boolean' );
 	}
 }


### PR DESCRIPTION
## Proposed changes

* Follow-up to #50467 (the `site_ID` integer-cast fix). Adds `test_scalar_response_fields_have_documented_types` to `WPCOM_JSON_API_Get_Post_v1_1_Endpoint_Test`, asserting every `(int)`- and `(bool)`-documented field in the v1.1 get-post response is serialized as the matching JSON type (a number / a boolean, never a string).
* **Why:** `render_response_keys()` casts only `ID` and `site_ID` itself and trusts each SAL getter for the rest. The getters are currently disciplined — I audited them; each either casts internally (`get_menu_order()`, `get_attachments_and_count()`, `is_sticky()`, …) or returns a native-typed constant — so there's no active bug. But nothing locked that contract, which is exactly how the `site_ID` leak slipped through. This test closes that gap for the whole scalar-field set in one place.
* **Fields covered:** `(int)` — `ID`, `site_ID`, `like_count`, `menu_order`, `attachment_count`; `(bool)` — `sticky`, `has_password`, `likes_enabled`, `sharing_enabled`, `i_like`, `is_reblogged`, `is_following`.
* Test-only; no production code changes. Independent of #50467 (a default-response `site_ID` is already an integer without that fix).

## Related product discussion/links

* Follow-up to the `site_ID` type fix in #50467.

## Does this pull request change what data or activity we track or use?

No. Test-only.

## Testing instructions

* `jetpack docker phpunit jetpack -- --filter=test_scalar_response_fields_have_documented_types` — passes.
* To confirm it actually catches regressions: temporarily change a trusted SAL getter to return the wrong type (e.g. `SAL_Post::get_menu_order()` → `(string)`) and re-run — the test fails with `menu_order should be serialized as an integer / Failed asserting that '0' is of type int`.
