### PR TITLE
Search: fix "Start free" checkout dead-ending on unregistered sites

### DIFF
--- a/projects/packages/search/changelog/atlas-search-310-checkout-availability-handler-return
+++ b/projects/packages/search/changelog/atlas-search-310-checkout-availability-handler-return
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the Search upsell page's product-availability check not returning its promise, which caused checkout to always run even when the site already had the Search product.

--- a/projects/packages/search/changelog/atlas-search-310-start-free-checkout-link-flow
+++ b/projects/packages/search/changelog/atlas-search-310-start-free-checkout-link-flow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix checkout for unregistered sites getting stuck or redirected to the site selector instead of completing the purchase.

--- a/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/upsell-page/index.jsx
@@ -53,7 +53,7 @@ export default function UpsellPage( { isLoading = false } ) {
 	const { fetchSearchPlanInfo } = useDispatch( STORE_ID );
 	const checkSiteHasSearchProduct = useCallback( () => {
 		restApi.setApiNonce( APINonce );
-		fetchSearchPlanInfo().then( response => response?.supports_search );
+		return fetchSearchPlanInfo().then( response => response?.supports_search );
 	}, [ APINonce, fetchSearchPlanInfo ] );
 
 	const { run: sendToCartPaid, hasCheckoutStarted: hasCheckoutStartedPaid } =

--- a/projects/packages/search/src/dashboard/hooks/test/use-product-checkout-workflow.test.jsx
+++ b/projects/packages/search/src/dashboard/hooks/test/use-product-checkout-workflow.test.jsx
@@ -99,10 +99,13 @@ describe( 'useProductCheckoutWorkflow', () => {
 			useProductCheckoutWorkflow( { ...baseProps, isWpcom: true } )
 		);
 
-		// jsdom's `window.location.href` setter is locked (can't be
-		// spied/redefined), so `run()` triggering it surfaces as jsdom's
-		// "Not implemented: navigation" console error -- that's the evidence
-		// a redirect was actually attempted, alongside the URL it was built with.
+		// jsdom's `window.location.href` setter is locked (can't be spied/redefined),
+		// so `run()` still actually assigns it, which jsdom surfaces as a "Not
+		// implemented: navigation" console error. `@wordpress/jest-console`'s strict
+		// guard requires that be explicitly acknowledged (an unhandled console.error
+		// fails the test on its own) -- `toHaveErrored()` is that acknowledgement, not
+		// a check on the navigation itself; `getProductCheckoutUrl`'s asserted args
+		// below are the real signal for the built URL.
 		act( () => result.current.run() );
 
 		expect( mockConnectedRun ).not.toHaveBeenCalled();

--- a/projects/packages/search/src/dashboard/hooks/test/use-product-checkout-workflow.test.jsx
+++ b/projects/packages/search/src/dashboard/hooks/test/use-product-checkout-workflow.test.jsx
@@ -1,0 +1,135 @@
+let mockConnection;
+
+jest.mock( '@automattic/jetpack-analytics', () => ( {
+	__esModule: true,
+	default: { initialize: jest.fn(), tracks: { recordEvent: jest.fn() } },
+} ) );
+
+jest.mock( '@automattic/jetpack-components', () => ( {
+	getProductCheckoutUrl: jest.fn(
+		( productSlug, siteSuffix, _redirectUri, isConnected ) =>
+			`https://wordpress.com/checkout/${ siteSuffix }/${ productSlug }?connected=${ isConnected }`
+	),
+} ) );
+
+jest.mock( '@automattic/jetpack-connection', () => ( {
+	useConnection: jest.fn( () => mockConnection ),
+	useProductCheckoutWorkflow: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	select: () => ( {
+		getWpcomUser: jest.fn( () => null ),
+		getBlogId: jest.fn( () => 123 ),
+		getVersion: jest.fn( () => '1.0.0' ),
+	} ),
+} ) );
+
+jest.mock( 'store', () => ( { STORE_ID: 'jetpack-search-plugin' } ) );
+
+import analytics from '@automattic/jetpack-analytics';
+import { getProductCheckoutUrl } from '@automattic/jetpack-components';
+import {
+	useConnection,
+	useProductCheckoutWorkflow as useConnectionCheckoutWorkflow,
+} from '@automattic/jetpack-connection';
+import { act, renderHook } from '@testing-library/react';
+import useProductCheckoutWorkflow from '../use-product-checkout-workflow';
+
+const baseProps = {
+	productSlug: 'jetpack_search_free',
+	redirectUri: 'admin.php?page=jetpack-search',
+	siteSuffix: 'example.com',
+	blogID: 123,
+	adminUrl: 'https://example.com/wp-admin/',
+	from: 'jetpack-search',
+};
+
+describe( 'useProductCheckoutWorkflow', () => {
+	let mockConnectedRun;
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockConnectedRun = jest.fn();
+		useConnectionCheckoutWorkflow.mockReturnValue( { run: mockConnectedRun } );
+	} );
+
+	it( 'routes an unregistered site through the connect-after-checkout flow', () => {
+		mockConnection = { isRegistered: false, isUserConnected: false };
+
+		const { result } = renderHook( () => useProductCheckoutWorkflow( baseProps ) );
+
+		expect( useConnectionCheckoutWorkflow ).toHaveBeenCalledWith(
+			expect.objectContaining( { connectAfterCheckout: true } )
+		);
+
+		act( () => result.current.run() );
+
+		expect( mockConnectedRun ).toHaveBeenCalledTimes( 1 );
+		expect( getProductCheckoutUrl ).not.toHaveBeenCalled();
+		expect( result.current.isRegistered ).toBe( false );
+	} );
+
+	it( 'does not force connect-after-checkout for an already registered and connected site', () => {
+		mockConnection = { isRegistered: true, isUserConnected: true };
+
+		const { result } = renderHook( () => useProductCheckoutWorkflow( baseProps ) );
+
+		expect( useConnectionCheckoutWorkflow ).toHaveBeenCalledWith(
+			expect.objectContaining( { connectAfterCheckout: false } )
+		);
+
+		act( () => result.current.run() );
+
+		expect( mockConnectedRun ).toHaveBeenCalledTimes( 1 );
+		expect( result.current.isRegistered ).toBe( true );
+	} );
+
+	it( 'skips registration and the shared workflow entirely for WPCOM sites', () => {
+		mockConnection = { isRegistered: false, isUserConnected: false };
+
+		const { result } = renderHook( () =>
+			useProductCheckoutWorkflow( { ...baseProps, isWpcom: true } )
+		);
+
+		// jsdom's `window.location.href` setter is locked (can't be
+		// spied/redefined), so `run()` triggering it surfaces as jsdom's
+		// "Not implemented: navigation" console error -- that's the evidence
+		// a redirect was actually attempted, alongside the URL it was built with.
+		act( () => result.current.run() );
+
+		expect( mockConnectedRun ).not.toHaveBeenCalled();
+		expect( getProductCheckoutUrl ).toHaveBeenCalledWith(
+			'jetpack_search_free',
+			123,
+			'admin.php?page=jetpack-search',
+			true
+		);
+		expect( console ).toHaveErrored();
+		expect( result.current.isRegistered ).toBe( true );
+	} );
+
+	it( 'fires the purchase-button analytics event on run', () => {
+		mockConnection = { isRegistered: false, isUserConnected: false };
+
+		const { result } = renderHook( () => useProductCheckoutWorkflow( baseProps ) );
+
+		act( () => result.current.run() );
+
+		expect( analytics.tracks.recordEvent ).toHaveBeenCalledWith(
+			'jetpack_search_free_purchase_button_click',
+			expect.objectContaining( { isWpcom: false } )
+		);
+	} );
+
+	it( 'passes connection props through to useConnection', () => {
+		mockConnection = { isRegistered: false, isUserConnected: false };
+
+		renderHook( () => useProductCheckoutWorkflow( baseProps ) );
+
+		expect( useConnection ).toHaveBeenCalledWith( {
+			redirectUri: baseProps.redirectUri,
+			from: baseProps.from,
+		} );
+	} );
+} );

--- a/projects/packages/search/src/dashboard/hooks/test/use-product-checkout-workflow.test.jsx
+++ b/projects/packages/search/src/dashboard/hooks/test/use-product-checkout-workflow.test.jsx
@@ -59,9 +59,16 @@ describe( 'useProductCheckoutWorkflow', () => {
 
 		const { result } = renderHook( () => useProductCheckoutWorkflow( baseProps ) );
 
-		expect( useConnectionCheckoutWorkflow ).toHaveBeenCalledWith(
-			expect.objectContaining( { connectAfterCheckout: true } )
-		);
+		expect( useConnectionCheckoutWorkflow ).toHaveBeenCalledWith( {
+			productSlug: baseProps.productSlug,
+			redirectUrl: baseProps.redirectUri,
+			siteSuffix: baseProps.siteSuffix,
+			adminUrl: baseProps.adminUrl,
+			from: baseProps.from,
+			siteProductAvailabilityHandler: null,
+			connectAfterCheckout: true,
+			useBlogIdSuffix: true,
+		} );
 
 		act( () => result.current.run() );
 

--- a/projects/packages/search/src/dashboard/hooks/use-product-checkout-workflow.jsx
+++ b/projects/packages/search/src/dashboard/hooks/use-product-checkout-workflow.jsx
@@ -1,27 +1,35 @@
 import analytics from '@automattic/jetpack-analytics';
-import restApi from '@automattic/jetpack-api';
 import { getProductCheckoutUrl } from '@automattic/jetpack-components';
-import { useConnection, CONNECTION_STORE_ID } from '@automattic/jetpack-connection';
-import { useDispatch, select as syncSelect } from '@wordpress/data';
-import { useEffect, useState } from 'react';
+import {
+	useConnection,
+	useProductCheckoutWorkflow as useConnectionCheckoutWorkflow,
+} from '@automattic/jetpack-connection';
+import { select as syncSelect } from '@wordpress/data';
+import { useState } from 'react';
 import { STORE_ID } from 'store';
 
-const {
-	registrationNonce,
-	apiRoot,
-	apiNonce,
-	siteSuffix: defaultSiteSuffix,
-} = window?.JP_CONNECTION_INITIAL_STATE ? window.JP_CONNECTION_INITIAL_STATE : {};
+const { siteSuffix: defaultSiteSuffix } = window?.JP_CONNECTION_INITIAL_STATE
+	? window.JP_CONNECTION_INITIAL_STATE
+	: {};
 
 /**
- * Custom hook that performs the needed steps
- * to concrete the checkout workflow.
+ * Custom hook that performs the needed steps to complete the checkout workflow.
+ *
+ * Delegates registration, the connect-after-checkout siteless flow, and checkout-URL
+ * construction to `@automattic/jetpack-connection`'s `useProductCheckoutWorkflow`, so an
+ * unregistered/unlinked site is routed through Calypso's `checkout/jetpack/` route
+ * instead of a site-scoped URL Calypso can't resolve (which falls back to the site
+ * selector). Two things stay local, since neither belongs in the shared hook: WPCOM
+ * (Simple) sites, which have no "connection" concept in that package's PHP layer and so
+ * must skip registration/connect entirely; and Search's own purchase-button analytics
+ * event.
  *
  * @param {object}   props                                - The props passed to the hook.
  * @param {string}   props.productSlug                    - The WordPress product slug.
  * @param {string}   props.redirectUri                    - The URI to redirect to after checkout.
  * @param {string}   [props.siteSuffix]                   - The site suffix.
  * @param {string}   [props.blogID]                       - The blog ID.
+ * @param {string}   [props.adminUrl]                     - The site wp-admin URL.
  * @param {Function} props.siteProductAvailabilityHandler - The function used to check whether the site already has the requested product. This will be checked after registration and the checkout page will be skipped if the promise returned resloves true.
  * @param {Function} props.from                           - The plugin slug initiated the flow.
  * @param {Function} props.isWpcom                        - Whether it's WPCOM site.
@@ -32,47 +40,25 @@ export default function useProductCheckoutWorkflow( {
 	redirectUri,
 	siteSuffix = defaultSiteSuffix,
 	blogID = null,
+	adminUrl,
 	siteProductAvailabilityHandler = null,
 	from,
 	isWpcom = false,
 } = {} ) {
 	const [ hasCheckoutStarted, setCheckoutStarted ] = useState( false );
-	const { registerSite } = useDispatch( CONNECTION_STORE_ID );
 
-	const { isUserConnected, isRegistered, handleConnectUser } = useConnection( {
-		redirectUri,
-		from,
-	} );
+	const { isUserConnected, isRegistered } = useConnection( { redirectUri, from } );
 
-	const initializeAnalytics = () => {
-		const tracksUser = syncSelect( STORE_ID ).getWpcomUser();
-		const blogId = syncSelect( STORE_ID ).getBlogId();
-
-		if ( tracksUser ) {
-			analytics.initialize( tracksUser.ID, tracksUser.login, {
-				blog_id: blogId,
-			} );
-		}
-	};
-
-	// Build the checkout URL.
-	const checkoutProductUrl = getProductCheckoutUrl(
+	const { run: runConnectedCheckout } = useConnectionCheckoutWorkflow( {
 		productSlug,
-		blogID || siteSuffix,
-		redirectUri,
-		isUserConnected || isWpcom
-	);
-
-	const handleAfterRegistration = () => {
-		return Promise.resolve(
-			siteProductAvailabilityHandler && siteProductAvailabilityHandler()
-		).then( siteHasWpcomProduct => {
-			if ( siteHasWpcomProduct ) {
-				return handleConnectUser();
-			}
-			window.location.href = checkoutProductUrl;
-		} );
-	};
+		redirectUrl: redirectUri,
+		siteSuffix,
+		adminUrl,
+		from,
+		siteProductAvailabilityHandler,
+		connectAfterCheckout: ! isRegistered || ! isUserConnected,
+		useBlogIdSuffix: !! blogID,
+	} );
 
 	/**
 	 * Handler to run the checkout workflow.
@@ -83,24 +69,31 @@ export default function useProductCheckoutWorkflow( {
 	const run = event => {
 		event && event.preventDefault();
 		setCheckoutStarted( true );
-		initializeAnalytics();
+
+		const tracksUser = syncSelect( STORE_ID ).getWpcomUser();
+		if ( tracksUser ) {
+			analytics.initialize( tracksUser.ID, tracksUser.login, {
+				blog_id: syncSelect( STORE_ID ).getBlogId(),
+			} );
+		}
 		analytics.tracks.recordEvent( productSlug + '_purchase_button_click', {
-			isWpcom: isWpcom,
+			isWpcom,
 			current_version: syncSelect( STORE_ID ).getVersion(),
 		} );
 
-		if ( isRegistered || isWpcom ) {
-			return handleAfterRegistration();
+		if ( isWpcom ) {
+			// WPCOM sites are already fully connected -- skip registration/connect entirely.
+			window.location.href = getProductCheckoutUrl(
+				productSlug,
+				blogID || siteSuffix,
+				redirectUri,
+				true
+			);
+			return;
 		}
 
-		registerSite( { registrationNonce, redirectUri } ).then( handleAfterRegistration );
+		runConnectedCheckout();
 	};
-
-	// Initialize/Setup the REST API.
-	useEffect( () => {
-		restApi.setApiRoot( apiRoot );
-		restApi.setApiNonce( apiNonce );
-	}, [] );
 
 	return {
 		run,

--- a/projects/packages/search/src/dashboard/hooks/use-product-checkout-workflow.jsx
+++ b/projects/packages/search/src/dashboard/hooks/use-product-checkout-workflow.jsx
@@ -33,7 +33,7 @@ const { siteSuffix: defaultSiteSuffix } = window?.JP_CONNECTION_INITIAL_STATE
  * @param {Function} props.siteProductAvailabilityHandler - The function used to check whether the site already has the requested product. This will be checked after registration and the checkout page will be skipped if the promise returned resloves true.
  * @param {Function} props.from                           - The plugin slug initiated the flow.
  * @param {Function} props.isWpcom                        - Whether it's WPCOM site.
- * @return {Function} - The useEffect hook.
+ * @return {{run: Function, isRegistered: boolean, hasCheckoutStarted: boolean}} The checkout workflow handle.
  */
 export default function useProductCheckoutWorkflow( {
 	productSlug,
@@ -49,6 +49,10 @@ export default function useProductCheckoutWorkflow( {
 
 	const { isUserConnected, isRegistered } = useConnection( { redirectUri, from } );
 
+	// `useBlogIdSuffix` re-checks truthiness against the connection package's own
+	// `getBlogId()` selector, not this `blogID` prop -- both ultimately read the same
+	// `Jetpack_Options::get_option( 'id' )` PHP option within the same request, via two
+	// separate `window` initial-state globals, so they agree in practice.
 	const { run: runConnectedCheckout } = useConnectionCheckoutWorkflow( {
 		productSlug,
 		redirectUrl: redirectUri,


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SEARCH-310/search-fix-start-free-checkout-dead-ending-on-calypso-site-selector

## Why

Someone trying Jetpack Search for the first time on a site that isn't yet connected to WordPress.com clicks "Start free" (or "Get Search") on the pricing screen and expects to land in checkout. Instead the purchase flow dead-ends — either stuck on a spinner forever, or dropped on Calypso's "pick a site" screen — with no way to actually get the product. This PR fixes that so the purchase always reaches checkout, and the site gets linked to the user's account automatically as part of that flow.

## Proposed changes

* Route Search's checkout hook through the shared `@automattic/jetpack-connection` `useProductCheckoutWorkflow` hook (with `connectAfterCheckout` enabled for non-WPCOM sites) instead of Search's own stale, forked copy of the same logic.
* This sends unregistered/unlinked sites to Calypso's siteless `checkout/jetpack/{product}` route (`connect_after_checkout=true`, `from_site_slug`, `admin_url`), which links the site to the user's account as part of checkout — the same flow VideoPress and My Jetpack already use — instead of the old register-then-checkout flow that required the site to already be linked before Calypso would show it.
* WPCOM (Simple) sites and Search's own purchase-button analytics event stay local to Search, since neither belongs in the shared hook.

## Screenshots

Pricing grid (identical before/after — only the click destination changes):

![pricing grid](https://github.com/user-attachments/assets/0c202028-d8df-4307-94c5-0eb7f0dbb247)

Clicking "Start for free" on an unregistered site:

| Before | After |
|---|---|
| ![before: stuck spinner, never navigates](https://github.com/user-attachments/assets/958a5dbe-41f3-4642-9ec0-97e8664b8d37) | ![after: lands on Calypso checkout](https://github.com/user-attachments/assets/48cf1a7d-5e38-4d46-b284-43344c748f29) |

## Related product discussion/links

* https://linear.app/a8c/issue/SEARCH-310/search-fix-start-free-checkout-dead-ending-on-calypso-site-selector

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site that is **not yet connected** to WordPress.com, go to the Jetpack Search dashboard (`wp-admin/admin.php?page=jetpack-search`) — it should show the pricing grid.
* Click **"Start for free"**.
  * Expected: redirects to Calypso checkout at `checkout/jetpack/jetpack_search_free?connect_after_checkout=true&...` and shows a $0 order ready to complete.
  * Before this fix: the button spins indefinitely, or (on a site where the registration call succeeds) Calypso shows its site-selector screen instead of checkout.
* Click **"Get Search"** (paid tier) and confirm it likewise reaches checkout (`checkout/jetpack/jetpack_search?connect_after_checkout=true&...`) rather than stalling or hitting the site selector.
* Repeat both on an **already-connected** site and confirm checkout behavior is unchanged (goes straight to the site-scoped checkout URL, no `connect_after_checkout`).
* **Simple sites need testing too**, even though this PR doesn't touch that code path — it's worth confirming the `isWpcom` branch (`use-product-checkout-workflow.jsx:84-93`) still behaves exactly as it did before this PR:
  * On a WordPress.com **Simple** site (not Atomic/WoA, not self-hosted) — sandbox to this branch, or verify after it lands in trunk and reaches the `moon` snapshot — open the Jetpack Search dashboard (`/wp-admin/admin.php?page=jetpack-search` inside Calypso's admin, or the equivalent `wordpress.com/wp-admin/...` path for the site).
  * Click **"Start for free"** / **"Get Search"** and confirm it goes straight to a plain `checkout/{site}/{product}?redirect_to=...&site={site}` URL — **no** `connect_after_checkout`, `from_site_slug`, or `unlinked` params, since Simple sites skip the connect/register step entirely (they're already owned by the account, unlike a self-hosted site).
  * Confirm checkout completes normally, same as on trunk today — this path is unchanged by this PR, so it's a regression check, not new behavior.

