### PR TITLE
Referrers: adopt the data-layer comparison merge helper and WidgetState

### DIFF
--- a/projects/packages/premium-analytics/changelog/referrers-comparison-widgetstate
+++ b/projects/packages/premium-analytics/changelog/referrers-comparison-widgetstate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Referrers: move comparison matching into the data layer's merge helper and render loading/error/empty through WidgetState.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-referrers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-referrers.ts
@@ -1,11 +1,41 @@
 /**
+ * External dependencies
+ */
+import { useCallback } from 'react';
+/**
  * Internal dependencies
  */
+import { mergeStatsReferrersComparisonRows } from '../processing/stats';
 import { statsReferrersQuery } from '../queries/stats-referrers-query';
 import { useStatsReport } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
+import type {
+	StatsNormalizedReport,
+	StatsReferrersComparisonItem,
+	StatsReferrersItem,
+} from '../processing/stats';
 import type { StatsReportParams } from '../queries/stats-query';
 
-export function useStatsReferrers( params: StatsReportParams, options?: UseStatsOptions ) {
-	return useStatsReport( statsReferrersQuery, params, 'referrers', options );
+type StatsReferrersOptions = UseStatsOptions & {
+	maxRows?: number;
+};
+
+export function useStatsReferrers( params: StatsReportParams, options?: StatsReferrersOptions ) {
+	const { maxRows, ...queryOptions } = options ?? {};
+	const mergeComparisonRows = useCallback(
+		(
+			primary?: StatsNormalizedReport< StatsReferrersItem >,
+			comparison?: StatsNormalizedReport< StatsReferrersItem >
+		) => mergeStatsReferrersComparisonRows( primary, comparison, maxRows ),
+		[ maxRows ]
+	);
+
+	return useStatsReport<
+		StatsReportParams,
+		StatsNormalizedReport< StatsReferrersItem >,
+		StatsReferrersComparisonItem
+	>( statsReferrersQuery, params, 'referrers', {
+		...queryOptions,
+		mergeComparisonRows,
+	} );
 }

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -273,6 +273,7 @@ export type {
 	StatsPublicizeApiResponse,
 	StatsPublicizeItem,
 	StatsPublicizeService,
+	StatsReferrersComparisonItem,
 	StatsReferrersItem,
 	StatsSearchTermsComparisonItem,
 	StatsSearchTermsItem,
@@ -314,6 +315,7 @@ export {
 export {
 	mergeStatsArchivesComparisonRows,
 	mergeStatsClicksComparisonRows,
+	mergeStatsReferrersComparisonRows,
 	mergeStatsComparisonRows,
 	mergeStatsDevicesComparisonRows,
 	mergeStatsFileDownloadsComparisonRows,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/referrers-merge.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/referrers-merge.test.ts
@@ -1,0 +1,203 @@
+import { mergeStatsReferrersComparisonRows } from '..';
+import type { StatsNormalizedReport, StatsReferrersItem } from '..';
+
+function makeItem( overrides: Partial< StatsReferrersItem > ): StatsReferrersItem {
+	return {
+		label: '',
+		views: 0,
+		link: null,
+		icon: null,
+		labelIcon: null,
+		children: null,
+		...overrides,
+	};
+}
+
+function makeReport( items: StatsReferrersItem[] ): StatsNormalizedReport< StatsReferrersItem > {
+	return {
+		summary: {},
+		data: [
+			{
+				time_interval: '2026-06-29',
+				date_start: '2026-06-29 00:00:00',
+				date_end: '2026-06-29 23:59:59',
+				items,
+			},
+		],
+	};
+}
+
+describe( 'mergeStatsReferrersComparisonRows', () => {
+	it( 'matches nested sources within the same group only', () => {
+		const primary = makeReport( [
+			makeItem( {
+				label: 'Search Engines',
+				views: 4801,
+				icon: 'https://example.com/search-engine.png',
+				children: [
+					makeItem( {
+						label: 'Google Search',
+						views: 3936,
+						icon: 'https://example.com/google.png',
+						children: [
+							makeItem( {
+								label: 'google.com',
+								views: 3920,
+								link: 'https://www.google.com/',
+								labelIcon: 'external',
+							} ),
+						],
+					} ),
+				],
+			} ),
+			makeItem( {
+				label: 'jetpack.com',
+				views: 18,
+				link: 'https://jetpack.com/',
+				labelIcon: 'external',
+			} ),
+		] );
+		// The same domain appears under a different group in the comparison
+		// period — it must not cross-match into Search Engines' subtree.
+		const comparison = makeReport( [
+			makeItem( {
+				label: 'Search Engines',
+				views: 4100,
+				children: [
+					makeItem( {
+						label: 'Google Search',
+						views: 3300,
+						children: [
+							makeItem( {
+								label: 'google.com',
+								views: 3290,
+								link: 'https://www.google.com/',
+								labelIcon: 'external',
+							} ),
+						],
+					} ),
+				],
+			} ),
+			makeItem( {
+				label: 'Recommendations',
+				views: 90,
+				children: [
+					makeItem( {
+						label: 'google.com',
+						views: 90,
+						link: 'https://www.google.com/',
+						labelIcon: 'external',
+					} ),
+				],
+			} ),
+		] );
+
+		const { rows, hasComparison } = mergeStatsReferrersComparisonRows( primary, comparison );
+
+		expect( hasComparison ).toBe( true );
+		expect( rows[ 0 ] ).toEqual(
+			expect.objectContaining( { label: 'Search Engines', previousValue: 4100 } )
+		);
+		expect( rows[ 0 ].children?.[ 0 ] ).toEqual(
+			expect.objectContaining( { label: 'Google Search', previousValue: 3300 } )
+		);
+		expect( rows[ 0 ].children?.[ 0 ].children?.[ 0 ] ).toEqual(
+			expect.objectContaining( { label: 'google.com', previousValue: 3290 } )
+		);
+		// Unmatched rows keep previousValue undefined rather than a fake zero.
+		expect( rows[ 1 ] ).toEqual(
+			expect.objectContaining( { label: 'jetpack.com', previousValue: undefined } )
+		);
+	} );
+
+	it( 'inherits the group favicon down to sources and domains', () => {
+		const primary = makeReport( [
+			makeItem( {
+				label: 'Search Engines',
+				views: 100,
+				icon: 'https://example.com/search-engine.png',
+				children: [
+					makeItem( {
+						label: 'Google Search',
+						views: 100,
+						icon: 'https://example.com/google.png',
+						children: [
+							makeItem( { label: 'google.com', views: 100, link: 'https://www.google.com/' } ),
+						],
+					} ),
+				],
+			} ),
+		] );
+
+		const { rows } = mergeStatsReferrersComparisonRows( primary, undefined );
+		const domain = rows[ 0 ].children?.[ 0 ].children?.[ 0 ];
+
+		expect( domain?.icon ).toBe( 'https://example.com/google.png' );
+	} );
+
+	it( 'gates the comparison flag on the visible rows only', () => {
+		const primary = makeReport( [
+			makeItem( { label: 'a.com', views: 5, link: 'https://a.com/' } ),
+			makeItem( { label: 'b.com', views: 2, link: 'https://b.com/' } ),
+		] );
+		// Only the second-ranked row overlaps the comparison period, so capping
+		// the list to one row must not switch the comparison UI on.
+		const comparison = makeReport( [
+			makeItem( { label: 'b.com', views: 4, link: 'https://b.com/' } ),
+		] );
+
+		const capped = mergeStatsReferrersComparisonRows( primary, comparison, 1 );
+		expect( capped.rows ).toHaveLength( 1 );
+		expect( capped.hasComparison ).toBe( false );
+
+		const full = mergeStatsReferrersComparisonRows( primary, comparison, 0 );
+		expect( full.rows ).toHaveLength( 2 );
+		expect( full.hasComparison ).toBe( true );
+	} );
+
+	it( 'flags subtrees whose children overlap the comparison period', () => {
+		const primary = makeReport( [
+			makeItem( {
+				label: 'Search Engines',
+				views: 10,
+				children: [ makeItem( { label: 'Google Search', views: 10 } ) ],
+			} ),
+			makeItem( {
+				label: 'Recommendations',
+				views: 5,
+				children: [ makeItem( { label: 'wordpress.com', views: 5 } ) ],
+			} ),
+		] );
+		const comparison = makeReport( [
+			makeItem( {
+				label: 'Search Engines',
+				views: 8,
+				children: [ makeItem( { label: 'Google Search', views: 8 } ) ],
+			} ),
+		] );
+
+		const { rows } = mergeStatsReferrersComparisonRows( primary, comparison );
+
+		expect( rows[ 0 ].childrenHaveComparison ).toBe( true );
+		expect( rows[ 1 ].childrenHaveComparison ).toBe( false );
+	} );
+
+	it( 'sorts every level by views descending', () => {
+		const primary = makeReport( [
+			makeItem( {
+				label: 'Group',
+				views: 10,
+				children: [
+					makeItem( { label: 'small', views: 1 } ),
+					makeItem( { label: 'big', views: 9 } ),
+				],
+			} ),
+			makeItem( { label: 'Top', views: 20 } ),
+		] );
+
+		const { rows } = mergeStatsReferrersComparisonRows( primary, undefined );
+
+		expect( rows.map( row => row.label ) ).toEqual( [ 'Top', 'Group' ] );
+		expect( rows[ 1 ].children?.map( row => row.label ) ).toEqual( [ 'big', 'small' ] );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -7,7 +7,7 @@ export {
 export type { StatsComparisonRowContext } from './utils';
 export { mergeStatsTopPostsComparisonRows, sanitizeStatsTopPostsResponse } from './top-posts';
 export { sanitizeStatsPostResponse } from './post';
-export { sanitizeStatsReferrersResponse } from './referrers';
+export { mergeStatsReferrersComparisonRows, sanitizeStatsReferrersResponse } from './referrers';
 export { mergeStatsClicksComparisonRows, sanitizeStatsClicksResponse } from './clicks';
 export {
 	mergeStatsSearchTermsComparisonRows,
@@ -61,7 +61,7 @@ export type {
 	StatsPostWeekDay,
 	StatsPostYear,
 } from './post';
-export type { StatsReferrersItem } from './referrers';
+export type { StatsReferrersComparisonItem, StatsReferrersItem } from './referrers';
 export type { StatsClicksComparisonItem, StatsClicksItem } from './clicks';
 export type { StatsSearchTermsComparisonItem, StatsSearchTermsItem } from './search-terms';
 export type { StatsFileDownloadsComparisonItem, StatsFileDownloadsItem } from './file-downloads';

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/referrers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/referrers.ts
@@ -1,8 +1,11 @@
 import { safeParseFloat } from '../../utils/parsing';
 import {
 	coerceStatsArray,
+	getStatsReportItems,
+	limitStatsRows,
 	mapNestedItems,
 	mapStatsReportDataPoints,
+	mergeStatsComparisonRows,
 	normalizeStatsReportSummary,
 } from './utils';
 import type {
@@ -20,6 +23,98 @@ export interface StatsReferrersItem extends StatsNormalizedItemBase< StatsReferr
 	labelIcon: string | null;
 	actions?: StatsItemAction[];
 	actionMenu?: number;
+}
+
+export interface StatsReferrersComparisonItem
+	extends Omit< StatsReferrersItem, 'children' | 'label' > {
+	/** Always resolved to a display string by the merge helper. */
+	label: string;
+	previousValue?: number;
+	children?: StatsReferrersComparisonItem[] | null;
+	childrenHaveComparison?: boolean;
+}
+
+type ReferrerParentContext = {
+	icon?: string | null;
+};
+
+function getStatsReferrersItemLabel( item: StatsReferrersItem ): string {
+	if ( typeof item.label === 'string' && item.label ) {
+		return item.label;
+	}
+
+	return item.link ?? '';
+}
+
+// Rows match by URL when present, else by label. Matching happens per level
+// (a group's children only match inside the comparison group's children), so
+// same-named rows at different drill levels cannot cross-match.
+function getStatsReferrersItemKey( item: StatsReferrersItem ): string {
+	return item.link ?? getStatsReferrersItemLabel( item );
+}
+
+function sortStatsReferrersComparisonItems(
+	items: StatsReferrersComparisonItem[]
+): StatsReferrersComparisonItem[] {
+	return [ ...items ].sort( ( a, b ) => b.views - a.views );
+}
+
+function mergeStatsReferrersComparisonItems(
+	items: StatsReferrersItem[],
+	comparisonItems: StatsReferrersItem[],
+	parent?: ReferrerParentContext
+): { rows: StatsReferrersComparisonItem[]; hasComparison: boolean } {
+	const { rows, hasComparison } = mergeStatsComparisonRows<
+		StatsReferrersItem,
+		StatsReferrersItem,
+		StatsReferrersComparisonItem
+	>( {
+		primaryRows: items,
+		comparisonRows: comparisonItems,
+		getPrimaryKey: getStatsReferrersItemKey,
+		getComparisonKey: getStatsReferrersItemKey,
+		getComparisonValue: item => item.views,
+		mapRow: ( item, { previousValue, comparisonItem } ) => {
+			// Sources inherit their group's favicon so drill-down rows stay
+			// recognizable (e.g. Google Search → google.com keeps the Google icon).
+			const icon = item.icon ?? parent?.icon ?? null;
+			const { rows: children, hasComparison: childrenHaveComparison } =
+				mergeStatsReferrersComparisonItems( item.children ?? [], comparisonItem?.children ?? [], {
+					icon,
+				} );
+
+			return {
+				...item,
+				label: getStatsReferrersItemLabel( item ),
+				icon,
+				previousValue,
+				children: children.length ? children : null,
+				childrenHaveComparison,
+			};
+		},
+	} );
+
+	return { rows: sortStatsReferrersComparisonItems( rows ), hasComparison };
+}
+
+export function mergeStatsReferrersComparisonRows(
+	primaryReport: StatsNormalizedReport< StatsReferrersItem > | undefined,
+	comparisonReport: StatsNormalizedReport< StatsReferrersItem > | undefined,
+	maxRows?: number
+): { rows: StatsReferrersComparisonItem[]; hasComparison: boolean } {
+	const { rows } = mergeStatsReferrersComparisonItems(
+		getStatsReportItems( primaryReport ),
+		getStatsReportItems( comparisonReport )
+	);
+
+	// The overlap gate is computed on the visible rows so an off-screen match
+	// cannot switch the comparison UI on (see AGENTS.md).
+	const visibleRows = limitStatsRows( rows, maxRows );
+
+	return {
+		rows: visibleRows,
+		hasComparison: visibleRows.some( row => row.previousValue !== undefined ),
+	};
 }
 
 export function sanitizeStatsReferrersResponse(

--- a/projects/packages/premium-analytics/widgets/referrers/__tests__/referrers.test.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/__tests__/referrers.test.tsx
@@ -7,8 +7,8 @@ import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
-import ReferrersWidget, { toReferrerRows } from '../render';
-import type { StatsNormalizedReport, StatsReferrersItem } from '@jetpack-premium-analytics/data';
+import ReferrersWidget, { toReferrerRow } from '../render';
+import type { StatsReferrersComparisonItem } from '@jetpack-premium-analytics/data';
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
@@ -162,154 +162,49 @@ describe( 'ReferrersWidget', () => {
 	} );
 } );
 
-describe( 'toReferrerRows', () => {
-	it( 'merges comparison values by scoped key before slicing primary rows', () => {
-		const primary = {
-			summary: {},
-			data: [
+describe( 'toReferrerRow', () => {
+	it( 'maps merged data-layer items onto leaderboard rows', () => {
+		const item: StatsReferrersComparisonItem = {
+			label: 'Search Engines',
+			views: 4801,
+			previousValue: 4100,
+			link: null,
+			icon: 'https://example.com/search-engine.png',
+			labelIcon: null,
+			childrenHaveComparison: true,
+			children: [
 				{
-					time_interval: '2026-06-29',
-					date_start: '2026-06-29 00:00:00',
-					date_end: '2026-06-29 23:59:59',
-					items: [
-						{
-							label: 'Search Engines',
-							views: 4801,
-							link: null,
-							icon: 'https://example.com/search-engine.png',
-							labelIcon: null,
-							children: [
-								{
-									label: 'Google Search',
-									views: 3936,
-									link: null,
-									icon: 'https://example.com/google.png',
-									labelIcon: null,
-									children: [
-										{
-											label: 'google.com',
-											views: 3920,
-											link: 'https://www.google.com/',
-											icon: null,
-											labelIcon: 'external',
-											children: null,
-										},
-									],
-								},
-							],
-						},
-						{
-							label: 'jetpack.com',
-							views: 18,
-							link: 'https://jetpack.com/',
-							icon: null,
-							labelIcon: 'external',
-							children: null,
-						},
-					] satisfies StatsReferrersItem[],
+					label: 'google.com',
+					views: 3920,
+					previousValue: undefined,
+					link: 'https://www.google.com/',
+					icon: 'https://example.com/google.png',
+					labelIcon: 'external',
+					children: null,
+					childrenHaveComparison: false,
 				},
 			],
-		} satisfies StatsNormalizedReport< StatsReferrersItem >;
+		};
 
-		const comparison = {
-			summary: {},
-			data: [
+		expect( toReferrerRow( item ) ).toEqual( {
+			label: 'Search Engines',
+			value: 4801,
+			previousValue: 4100,
+			href: undefined,
+			icon: 'https://example.com/search-engine.png',
+			childrenHaveComparison: true,
+			children: [
 				{
-					time_interval: '2026-06-22',
-					date_start: '2026-06-22 00:00:00',
-					date_end: '2026-06-22 23:59:59',
-					items: [
-						{
-							label: 'Search Engines',
-							views: 4100,
-							link: null,
-							icon: 'https://example.com/search-engine.png',
-							labelIcon: null,
-							children: [
-								{
-									label: 'Google Search',
-									views: 3300,
-									link: null,
-									icon: 'https://example.com/google.png',
-									labelIcon: null,
-									children: [
-										{
-											label: 'google.com',
-											views: 3290,
-											link: 'https://www.google.com/',
-											icon: null,
-											labelIcon: 'external',
-											children: null,
-										},
-									],
-								},
-							],
-						},
-					] satisfies StatsReferrersItem[],
+					label: 'google.com',
+					value: 3920,
+					// Missing comparison matches stay undefined so the chart
+					// suppresses the delta instead of showing a fake change.
+					previousValue: undefined,
+					href: 'https://www.google.com/',
+					icon: 'https://example.com/google.png',
+					children: undefined,
 				},
 			],
-		} satisfies StatsNormalizedReport< StatsReferrersItem >;
-
-		expect( toReferrerRows( primary, comparison, 1 ) ).toEqual( [
-			{
-				label: 'Search Engines',
-				value: 4801,
-				previousValue: 4100,
-				href: undefined,
-				icon: 'https://example.com/search-engine.png',
-				children: [
-					{
-						label: 'Google Search',
-						value: 3936,
-						previousValue: 3300,
-						href: undefined,
-						icon: 'https://example.com/google.png',
-						children: [
-							{
-								label: 'google.com',
-								value: 3920,
-								previousValue: 3290,
-								href: 'https://www.google.com/',
-								icon: 'https://example.com/google.png',
-								children: undefined,
-							},
-						],
-					},
-				],
-			},
-		] );
-	} );
-
-	it( 'keeps all rows when max is 0', () => {
-		const report = {
-			summary: {},
-			data: [
-				{
-					time_interval: '2026-06-29',
-					date_start: '2026-06-29 00:00:00',
-					date_end: '2026-06-29 23:59:59',
-					items: [
-						{
-							label: 'a.com',
-							views: 2,
-							link: 'https://a.com/',
-							icon: null,
-							labelIcon: 'external',
-							children: null,
-						},
-						{
-							label: 'b.com',
-							views: 1,
-							link: 'https://b.com/',
-							icon: null,
-							labelIcon: 'external',
-							children: null,
-						},
-					] satisfies StatsReferrersItem[],
-				},
-			],
-		} satisfies StatsNormalizedReport< StatsReferrersItem >;
-
-		expect( toReferrerRows( report, undefined, 0 ) ).toHaveLength( 2 );
+		} );
 	} );
 } );

--- a/projects/packages/premium-analytics/widgets/referrers/render.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/render.tsx
@@ -3,17 +3,17 @@
  */
 import {
 	useStatsReferrers,
-	type StatsNormalizedReport,
-	type StatsReferrersItem,
+	type StatsReferrersComparisonItem,
 	type StatsReportParams,
 } from '@jetpack-premium-analytics/data';
 import {
 	LeaderboardChart,
 	LeaderboardLabel,
 	WidgetBackLink,
-	WidgetLoadingOverlay,
 	WidgetRoot,
+	WidgetState,
 	calculateDelta,
+	sharePercentage,
 	useWidgetDrillDown,
 	useWidgetRootContext,
 	type LeaderboardChartData,
@@ -21,7 +21,8 @@ import {
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { useCallback, useEffect, useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { Link, Stack, Text } from '@wordpress/ui';
+import { globe } from '@wordpress/icons';
+import { Link } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
@@ -46,7 +47,9 @@ export type ReferrerRow = {
 	 */
 	value: number;
 	/**
-	 * View count for the comparison period.
+	 * View count for the comparison period. Undefined when the row has no
+	 * match in the comparison report, so charts suppress the delta instead of
+	 * rendering a fake change.
 	 */
 	previousValue?: number;
 	/**
@@ -63,115 +66,29 @@ export type ReferrerRow = {
 	 * (e.g. Search Engines → Google Search → google.com).
 	 */
 	children?: ReferrerRow[];
+	/**
+	 * Whether the child rows have any matching comparison-period rows.
+	 */
+	childrenHaveComparison?: boolean;
 };
-
-function getItemLabel( item: StatsReferrersItem ): string {
-	if ( typeof item.label === 'string' && item.label ) {
-		return item.label;
-	}
-
-	return item.link ?? '';
-}
-
-type NormalizedReferrerItem = {
-	key: string;
-	label: string;
-	value: number;
-	previousValue: number;
-	href?: string;
-	icon?: string | null;
-	children?: NormalizedReferrerItem[];
-};
-
-// Keys are scoped by the parent chain so same-named rows at different drill
-// levels (e.g. a "google.com" group and a "google.com" child of Google Search)
-// don't collide in the comparison lookup.
-function getItemKey( item: StatsReferrersItem, parentKey?: string ): string {
-	const ownKey = item.link ?? getItemLabel( item );
-
-	return parentKey ? `${ parentKey } > ${ ownKey }` : ownKey;
-}
-
-function buildReferrerItemLookup(
-	items: StatsReferrersItem[],
-	parentKey?: string
-): Map< string, StatsReferrersItem > {
-	const lookup = new Map< string, StatsReferrersItem >();
-
-	items.forEach( item => {
-		const key = getItemKey( item, parentKey );
-		lookup.set( key, item );
-		buildReferrerItemLookup( item.children ?? [], key ).forEach( ( value, childKey ) => {
-			lookup.set( childKey, value );
-		} );
-	} );
-
-	return lookup;
-}
-
-function normalizeReferrerItem(
-	item: StatsReferrersItem,
-	comparisonLookup: Map< string, StatsReferrersItem >,
-	parent?: { key: string; icon?: string | null }
-): NormalizedReferrerItem {
-	const key = getItemKey( item, parent?.key );
-	const children = ( item.children ?? [] ).map( child =>
-		normalizeReferrerItem( child, comparisonLookup, { key, icon: item.icon ?? parent?.icon } )
-	);
-
-	return {
-		key,
-		label: getItemLabel( item ),
-		value: item.views,
-		previousValue: comparisonLookup.get( key )?.views ?? 0,
-		href: item.link ?? undefined,
-		icon: item.icon ?? parent?.icon,
-		children: children.length ? sortReferrerItems( children ) : undefined,
-	};
-}
-
-function sortReferrerItems( items: NormalizedReferrerItem[] ): NormalizedReferrerItem[] {
-	return [ ...items ].sort( ( a, b ) => b.value - a.value );
-}
-
-function toReferrerRow( item: NormalizedReferrerItem ): ReferrerRow {
-	return {
-		label: item.label,
-		value: item.value,
-		previousValue: item.previousValue,
-		href: item.href,
-		icon: item.icon,
-		children: item.children?.map( toReferrerRow ),
-	};
-}
-
-function getItems(
-	report: StatsNormalizedReport< StatsReferrersItem > | undefined
-): StatsReferrersItem[] {
-	return report?.data.flatMap( point => point.items ) ?? [];
-}
 
 /**
- * Flattens a normalized referrers report into `ReferrerRow[]` and attaches
- * matching comparison values when a comparison report is present.
+ * Maps a merged data-layer row (comparison matching, sorting, and the row cap
+ * happen in `mergeStatsReferrersComparisonRows`) onto the widget's row shape.
  *
- * @param report           - Primary referrers report.
- * @param comparisonReport - Comparison referrers report.
- * @param max              - Maximum rows to keep. 0 keeps all rows.
- * @return Rows ready for the leaderboard.
+ * @param item - Merged referrers comparison item.
+ * @return Row ready for the leaderboard.
  */
-export function toReferrerRows(
-	report: StatsNormalizedReport< StatsReferrersItem > | undefined,
-	comparisonReport: StatsNormalizedReport< StatsReferrersItem > | undefined,
-	max: number
-): ReferrerRow[] {
-	const comparisonLookup = buildReferrerItemLookup( getItems( comparisonReport ) );
-	const sorted = sortReferrerItems(
-		getItems( report ).map( item => normalizeReferrerItem( item, comparisonLookup ) )
-	);
-	const sliced = max > 0 ? sorted.slice( 0, max ) : sorted;
-
-	return sliced.map( toReferrerRow );
+export function toReferrerRow( item: StatsReferrersComparisonItem ): ReferrerRow {
+	return {
+		label: item.label,
+		value: item.views,
+		previousValue: item.previousValue,
+		href: item.link ?? undefined,
+		icon: item.icon,
+		children: item.children?.map( toReferrerRow ),
+		...( item.childrenHaveComparison ? { childrenHaveComparison: true } : {} ),
+	};
 }
 
 /**
@@ -191,7 +108,8 @@ function buildLeaderboardData(
 	const maxPreviousViews = Math.max( ...rows.map( row => row.previousValue ?? 0 ), 1 );
 
 	return rows.map( ( row, index ) => {
-		const previousValue = row.previousValue ?? 0;
+		const previousValue = row.previousValue;
+		const hasPrevious = withComparison && previousValue !== undefined;
 		const hasChildren = !! row.children?.length;
 		const shouldRenderLink = !! row.href && ! hasChildren;
 		const label = (
@@ -224,9 +142,8 @@ function buildLeaderboardData(
 			currentValue: row.value,
 			currentShare: ( row.value / maxCurrentViews ) * 100,
 			previousValue,
-			previousShare:
-				withComparison && previousValue > 0 ? ( previousValue / maxPreviousViews ) * 100 : 0,
-			delta: withComparison ? calculateDelta( row.value, previousValue ) : 0,
+			previousShare: hasPrevious ? sharePercentage( previousValue, maxPreviousViews ) : undefined,
+			delta: hasPrevious ? calculateDelta( row.value, previousValue ) : undefined,
 			...( hasChildren &&
 				onDrillDown && {
 					onClick: () => onDrillDown( row ),
@@ -242,50 +159,31 @@ function buildLeaderboardData(
 
 export type ReferrersLeaderboardProps = {
 	rows?: ReferrerRow[];
-	isLoading?: boolean;
-	isError?: boolean;
 	withComparison?: boolean;
 	onDrillDown?: ( row: ReferrerRow ) => void;
 };
 
 /**
- * Presentational leaderboard for the Referrers widget.
+ * Presentational leaderboard for the Referrers widget. Loading, error, and
+ * empty states are owned by the inner component's `WidgetState`.
  *
  * @param props                - Component props.
  * @param props.rows           - Normalized referrer rows.
- * @param props.isLoading      - When true, show a loading overlay.
- * @param props.isError        - When true, show an error message.
  * @param props.withComparison - When true, render comparison deltas.
  * @param props.onDrillDown    - Callback fired when a row with child referrers is selected.
  * @return The rendered leaderboard.
  */
 export function ReferrersLeaderboard( {
 	rows = [],
-	isLoading = false,
-	isError = false,
 	withComparison = false,
 	onDrillDown,
 }: ReferrersLeaderboardProps ) {
-	if ( isError ) {
-		return (
-			<Stack align="center" justify="center" className={ styles.placeholder }>
-				<Text>{ __( 'Unable to load referrers.', 'jetpack-premium-analytics' ) }</Text>
-			</Stack>
-		);
-	}
-
-	if ( isLoading && rows.length === 0 ) {
-		return <WidgetLoadingOverlay />;
-	}
-
 	return (
 		<LeaderboardChart
 			data={ buildLeaderboardData( rows, withComparison, onDrillDown ) }
-			loading={ isLoading }
 			withComparison={ withComparison }
 			withOverlayLabel
 			showLegend={ false }
-			emptyStateText={ __( 'No referrers in this period.', 'jetpack-premium-analytics' ) }
 			dataFormat={ DATA_FORMAT }
 		/>
 	);
@@ -297,22 +195,16 @@ function ReferrersInner( { max }: { max: number } ) {
 		...reportParams,
 		max,
 	} as StatsReportParams;
-	const { primary, comparison, hasComparison, isLoading, isFetching, hasData, isError } =
-		useStatsReferrers( statsParams );
-	const showLoading = isLoading || ( isFetching && hasData );
 
-	const comparisonReport = comparison.data as
-		| StatsNormalizedReport< StatsReferrersItem >
-		| undefined;
+	// Row matching (per level, so same-named rows at different drill levels
+	// cannot cross-match), the visible-row cap, and the comparison-overlap
+	// gate all live in the data layer's merge helper (see AGENTS.md).
+	const { comparisonRows, hasComparison, isLoading, isFetching, isError, refetch } =
+		useStatsReferrers( statsParams, { maxRows: max } );
 
 	const rows = useMemo(
-		() =>
-			toReferrerRows(
-				primary.data as StatsNormalizedReport< StatsReferrersItem > | undefined,
-				comparisonReport,
-				max
-			),
-		[ primary.data, comparisonReport, max ]
+		() => ( comparisonRows?.rows ?? [] ).map( toReferrerRow ),
+		[ comparisonRows ]
 	);
 
 	// Referrer groups nest twice (group → source → domain), so the drill-down
@@ -352,7 +244,11 @@ function ReferrersInner( { max }: { max: number } ) {
 		return matched;
 	}, [ rows, drillPath ] );
 
-	const activeRows = trail.length ? trail[ trail.length - 1 ].children ?? [] : rows;
+	const currentRow = trail.length ? trail[ trail.length - 1 ] : null;
+	const activeRows = currentRow ? currentRow.children ?? [] : rows;
+	// Drilled levels gate the comparison UI on their own rows' overlap, so a
+	// subtree without comparison matches doesn't render placeholder deltas.
+	const withComparison = currentRow ? !! currentRow.childrenHaveComparison : hasComparison;
 
 	const drillInto = useCallback(
 		( row: ReferrerRow ) => {
@@ -391,13 +287,29 @@ function ReferrersInner( { max }: { max: number } ) {
 			{ trail.length > 0 && (
 				<WidgetBackLink label={ backLabel } ariaLabel={ backAriaLabel } onClick={ goBack } />
 			) }
-			<ReferrersLeaderboard
-				rows={ activeRows }
-				isLoading={ showLoading }
+			<WidgetState
+				isLoading={ isLoading }
+				isFetching={ isFetching }
 				isError={ isError }
-				withComparison={ hasComparison }
-				onDrillDown={ drillInto }
-			/>
+				isEmpty={ rows.length === 0 }
+				error={ {
+					description: __(
+						"We couldn't load referrers. Please try again in a moment.",
+						'jetpack-premium-analytics'
+					),
+					actions: [ { label: __( 'Retry', 'jetpack-premium-analytics' ), onClick: refetch } ],
+				} }
+				empty={ {
+					icon: globe,
+					description: __( 'No referrers in this period.', 'jetpack-premium-analytics' ),
+				} }
+			>
+				<ReferrersLeaderboard
+					rows={ activeRows }
+					withComparison={ withComparison }
+					onDrillDown={ drillInto }
+				/>
+			</WidgetState>
 		</div>
 	);
 }


### PR DESCRIPTION
Related to WOOA7S-1675 (WidgetState migration) — Referrers was the last Traffic-tab leaderboard still hand-rolling both its comparison matching and its loading/error/empty states.

## Why

Every other list widget on the Traffic tab (Top posts, Clicks, Locations, Devices, Top platforms, Search terms, UTM, File downloads, Authors, Videos) consumes the data layer's `mergeStats*ComparisonRows` helpers from #50193 and lets missing comparison matches stay `undefined`. Referrers still matched rows inside `render.tsx` with `previousValue ?? 0` placeholders — the fabricated-delta pattern the merge helpers were built to remove — and hand-rolled its error/loading branches instead of `WidgetState`.

## What

**Data layer**

- New `mergeStatsReferrersComparisonRows()` (modeled on the Clicks helper): per-level row matching by URL-then-label (same-named rows at different drill levels can't cross-match), group-favicon inheritance down the subtree, per-level sort by views, the visible-row cap, and the comparison-overlap gate computed on visible rows only. Missing matches stay `undefined`; `childrenHaveComparison` flags each subtree.
- `useStatsReferrers()` gains the `maxRows` option and wires the merge helper into `useStatsReport()`, matching the Clicks hook.

**Widget**

- `render.tsx` drops its local lookup/normalize/merge pipeline (~90 lines) and consumes `comparisonRows.rows` + hook-level `hasComparison`, keeping only presentation mapping.
- Drilled levels now gate their comparison UI on their own subtree's overlap (`childrenHaveComparison`) instead of the top-level flag, so a subtree with no comparison matches renders no placeholder deltas.
- Loading/error/empty render through `<WidgetState>` (Retry wired to the hooks' `refetch`, `globe` glyph for the empty state) per the search-terms reference; the drill-down back link stays outside as body chrome.

**Tests**

- Merge behavior moves to `processing/stats/__tests__/referrers-merge.test.ts`: per-level matching (no cross-group matches), favicon inheritance, visible-rows overlap gate, subtree comparison flags, per-level sorting.
- Widget tests keep the drill-down / reset / outbound-link interaction coverage and now assert the thin `toReferrerRow` mapping.

## Testing

- `pnpm test` — 637 tests pass (referrers suites: 15).
- `pnpm run typecheck`, eslint on the touched files.
- Storybook vitest for the referrers stories passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
