### PR TITLE
Premium Analytics: align drill-down reset behavior across Stats widgets

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1666-align-drilldown-reset
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1666-align-drilldown-reset
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Stats widgets: align drill-down reset behavior — selections survive refetches and range changes while they still resolve, and stored state is trimmed deterministically once settled data drops the selected row.

--- a/projects/packages/premium-analytics/widgets/authors/render.tsx
+++ b/projects/packages/premium-analytics/widgets/authors/render.tsx
@@ -114,11 +114,14 @@ export function AuthorsLeaderboard( {
 		[ rows, selectedAuthorId ]
 	);
 
+	// Clear the stored selection only once data has settled without the
+	// author — an in-flight load or refetch must not wipe a valid selection
+	// while rows are briefly empty or stale (see WOOA7S-1666).
 	useEffect( () => {
-		if ( selectedAuthorId && ! selectedAuthor ) {
+		if ( selectedAuthorId && ! selectedAuthor && ! isLoading && ! isRefetching ) {
 			clearSelectedAuthor();
 		}
-	}, [ selectedAuthorId, selectedAuthor, clearSelectedAuthor ] );
+	}, [ selectedAuthorId, selectedAuthor, isLoading, isRefetching, clearSelectedAuthor ] );
 
 	const chartData: LeaderboardChartData = useMemo( () => {
 		// Drilled-in: show the selected author's posts. Rows are not interactive;

--- a/projects/packages/premium-analytics/widgets/clicks/__tests__/clicks.test.tsx
+++ b/projects/packages/premium-analytics/widgets/clicks/__tests__/clicks.test.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { getDefaultQueryParams, queryClient } from '@jetpack-premium-analytics/data';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
@@ -89,6 +89,50 @@ describe( 'ClicksWidget', () => {
 
 		const link = await screen.findByRole( 'link', { name: /jetpack\.com/i } );
 		expect( link ).toHaveAttribute( 'href', 'https://jetpack.com/' );
+	} );
+
+	it( 'clears the stored drill-down when the selected link leaves the data', async () => {
+		const { rerender } = render(
+			<ClicksWidget
+				attributes={ { max: 10, reportParams: getDefaultQueryParams( false, 'last-7-days' ) } }
+			/>
+		);
+
+		const drillDownButton = await screen.findByRole( 'button', {
+			name: /view clicked links for wordpress\.org/i,
+		} );
+		fireEvent.click( drillDownButton ); // eslint-disable-line testing-library/prefer-user-event -- @testing-library/user-event is not a direct dep of this package.
+		await expect(
+			screen.findByRole( 'button', { name: /view all clicks/i } )
+		).resolves.toBeInTheDocument();
+
+		// The next range's report no longer contains the drilled domain, so the
+		// stale selection is dropped once the new data settles (WOOA7S-1666).
+		mockApiFetch.mockResolvedValue( {
+			date: '2026-06-29',
+			days: {},
+			summary: {
+				clicks: [
+					{
+						name: 'jetpack.com',
+						views: 18,
+						url: 'https://jetpack.com/',
+					},
+				],
+			},
+		} );
+		rerender(
+			<ClicksWidget
+				attributes={ { max: 10, reportParams: getDefaultQueryParams( false, 'last-30-days' ) } }
+			/>
+		);
+
+		await waitFor( () =>
+			expect( screen.queryByRole( 'button', { name: /view all clicks/i } ) ).not.toBeInTheDocument()
+		);
+		await expect(
+			screen.findByRole( 'link', { name: /jetpack\.com/i } )
+		).resolves.toBeInTheDocument();
 	} );
 } );
 

--- a/projects/packages/premium-analytics/widgets/clicks/render.tsx
+++ b/projects/packages/premium-analytics/widgets/clicks/render.tsx
@@ -308,12 +308,13 @@ function ClicksInner( { max }: ClicksInnerProps ) {
 	// The view already falls back to the top list when the selected link is
 	// missing; clear the stored selection too once data has settled without
 	// it, so stale state can't resurface on a later refetch (WOOA7S-1666).
-	// In-flight fetches keep placeholder rows, so a valid selection survives.
+	// In-flight fetches keep placeholder rows and errors aren't settled data,
+	// so a valid selection survives refetches and transient failures.
 	useEffect( () => {
-		if ( selectedClickLabel && ! selectedClick && ! isLoading && ! isFetching ) {
+		if ( selectedClickLabel && ! selectedClick && ! isLoading && ! isFetching && ! isError ) {
 			clearSelectedClick();
 		}
-	}, [ selectedClickLabel, selectedClick, isLoading, isFetching, clearSelectedClick ] );
+	}, [ selectedClickLabel, selectedClick, isLoading, isFetching, isError, clearSelectedClick ] );
 
 	const handleDrillDown = useCallback(
 		( row: ClickRow ) => {

--- a/projects/packages/premium-analytics/widgets/clicks/render.tsx
+++ b/projects/packages/premium-analytics/widgets/clicks/render.tsx
@@ -306,15 +306,16 @@ function ClicksInner( { max }: ClicksInnerProps ) {
 	const withComparison = isDrillDown ? !! selectedClick?.childrenHaveComparison : hasComparison;
 
 	// The view already falls back to the top list when the selected link is
-	// missing; clear the stored selection too once data has settled without
-	// it, so stale state can't resurface on a later refetch (WOOA7S-1666).
-	// In-flight fetches keep placeholder rows and errors aren't settled data,
-	// so a valid selection survives refetches and transient failures.
+	// missing or no longer drillable (no children); clear the stored selection
+	// too once data has settled without a drillable match, so stale state
+	// can't resurface on a later refetch (WOOA7S-1666). In-flight fetches keep
+	// placeholder rows and errors aren't settled data, so a valid selection
+	// survives refetches and transient failures.
 	useEffect( () => {
-		if ( selectedClickLabel && ! selectedClick && ! isLoading && ! isFetching && ! isError ) {
+		if ( selectedClickLabel && ! isDrillDown && ! isLoading && ! isFetching && ! isError ) {
 			clearSelectedClick();
 		}
-	}, [ selectedClickLabel, selectedClick, isLoading, isFetching, isError, clearSelectedClick ] );
+	}, [ selectedClickLabel, isDrillDown, isLoading, isFetching, isError, clearSelectedClick ] );
 
 	const handleDrillDown = useCallback(
 		( row: ClickRow ) => {

--- a/projects/packages/premium-analytics/widgets/clicks/render.tsx
+++ b/projects/packages/premium-analytics/widgets/clicks/render.tsx
@@ -21,7 +21,7 @@ import {
 	type LeaderboardChartData,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
-import { useCallback, useMemo } from '@wordpress/element';
+import { useCallback, useEffect, useMemo } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Link, Stack, Text } from '@wordpress/ui';
 /**
@@ -304,6 +304,16 @@ function ClicksInner( { max }: ClicksInnerProps ) {
 	const isDrillDown = !! selectedClick?.children?.length;
 	const activeRows = isDrillDown ? selectedClick.children ?? [] : rows;
 	const withComparison = isDrillDown ? !! selectedClick?.childrenHaveComparison : hasComparison;
+
+	// The view already falls back to the top list when the selected link is
+	// missing; clear the stored selection too once data has settled without
+	// it, so stale state can't resurface on a later refetch (WOOA7S-1666).
+	// In-flight fetches keep placeholder rows, so a valid selection survives.
+	useEffect( () => {
+		if ( selectedClickLabel && ! selectedClick && ! isLoading && ! isFetching ) {
+			clearSelectedClick();
+		}
+	}, [ selectedClickLabel, selectedClick, isLoading, isFetching, clearSelectedClick ] );
 
 	const handleDrillDown = useCallback(
 		( row: ClickRow ) => {

--- a/projects/packages/premium-analytics/widgets/referrers/__tests__/referrers.test.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/__tests__/referrers.test.tsx
@@ -116,7 +116,7 @@ describe( 'ReferrersWidget', () => {
 		expect( screen.queryByRole( 'button', { name: /all referrers/i } ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'resets the drill-down to the top level when the date range changes', async () => {
+	it( 'keeps the drill-down across date range changes while the path still resolves', async () => {
 		const { rerender } = render(
 			<ReferrersWidget
 				attributes={ { max: 10, reportParams: getDefaultQueryParams( false, 'last-7-days' ) } }
@@ -132,7 +132,55 @@ describe( 'ReferrersWidget', () => {
 			screen.findByRole( 'button', { name: /view all referrers/i } )
 		).resolves.toBeInTheDocument();
 
-		// A new date range loads a different report; the stale drill path should clear.
+		// The new range still contains the drilled group, so the selection
+		// survives — matching how Locations keeps its country across ranges.
+		rerender(
+			<ReferrersWidget
+				attributes={ { max: 10, reportParams: getDefaultQueryParams( false, 'last-30-days' ) } }
+			/>
+		);
+
+		await expect(
+			screen.findByRole( 'button', { name: /view referrers for google search/i } )
+		).resolves.toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: /view all referrers/i } ) ).toBeInTheDocument();
+	} );
+
+	it( 'resets the drill-down when the drilled group disappears from the data', async () => {
+		const { rerender } = render(
+			<ReferrersWidget
+				attributes={ { max: 10, reportParams: getDefaultQueryParams( false, 'last-7-days' ) } }
+			/>
+		);
+
+		const groupButton = await screen.findByRole( 'button', {
+			name: /view referrers for search engines/i,
+		} );
+
+		fireEvent.click( groupButton ); // eslint-disable-line testing-library/prefer-user-event -- @testing-library/user-event is not a direct dep of this package.
+		await expect(
+			screen.findByRole( 'button', { name: /view all referrers/i } )
+		).resolves.toBeInTheDocument();
+
+		// The next range's report no longer contains the drilled group, so the
+		// stale path is dropped once the new data settles.
+		mockApiFetch.mockResolvedValue( {
+			date: '2026-06-29',
+			days: {},
+			summary: {
+				groups: [
+					{
+						group: 'jetpack.com',
+						name: 'jetpack.com',
+						url: 'https://jetpack.com/',
+						total: 18,
+						results: { views: 18 },
+					},
+				],
+				other_views: 0,
+				total_views: 18,
+			},
+		} );
 		rerender(
 			<ReferrersWidget
 				attributes={ { max: 10, reportParams: getDefaultQueryParams( false, 'last-30-days' ) } }
@@ -144,9 +192,7 @@ describe( 'ReferrersWidget', () => {
 				screen.queryByRole( 'button', { name: /view all referrers/i } )
 			).not.toBeInTheDocument()
 		);
-		await expect(
-			screen.findByRole( 'button', { name: /view referrers for search engines/i } )
-		).resolves.toBeInTheDocument();
+		await expect( screen.findByText( 'jetpack.com' ) ).resolves.toBeInTheDocument();
 	} );
 
 	it( 'renders childless referrers with a URL as outbound links that open in a new tab', async () => {

--- a/projects/packages/premium-analytics/widgets/referrers/render.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/render.tsx
@@ -240,10 +240,17 @@ function ReferrersInner( { max }: { max: number } ) {
 	// date range changed and the drilled group disappeared), trim it to the
 	// deepest level that still exists so stored state matches the view and
 	// stale levels can't resurface on a later refetch (WOOA7S-1666). A path
-	// that still resolves survives range changes, and in-flight fetches keep
-	// placeholder rows, so a valid selection survives refetches.
+	// that still resolves survives range changes; in-flight fetches keep
+	// placeholder rows and errors aren't settled data, so a valid selection
+	// survives refetches and transient failures.
 	useEffect( () => {
-		if ( ! drillPath?.length || isLoading || isFetching || trail.length === drillPath.length ) {
+		if (
+			! drillPath?.length ||
+			isLoading ||
+			isFetching ||
+			isError ||
+			trail.length === drillPath.length
+		) {
 			return;
 		}
 
@@ -252,7 +259,7 @@ function ReferrersInner( { max }: { max: number } ) {
 		} else {
 			resetDrillDown();
 		}
-	}, [ drillPath, trail, isLoading, isFetching, setDrillPath, resetDrillDown ] );
+	}, [ drillPath, trail, isLoading, isFetching, isError, setDrillPath, resetDrillDown ] );
 
 	const currentRow = trail.length ? trail[ trail.length - 1 ] : null;
 	const activeRows = currentRow ? currentRow.children ?? [] : rows;

--- a/projects/packages/premium-analytics/widgets/referrers/render.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/render.tsx
@@ -216,14 +216,6 @@ function ReferrersInner( { max }: { max: number } ) {
 		resetDrillDown,
 	} = useWidgetDrillDown< string[] >();
 
-	// Changing the dashboard date range loads a different set of referrers, so
-	// any drill-down path from the previous range no longer makes sense — return
-	// to the top-level list. Keyed on the range only, so background refetches and
-	// comparison toggles keep the current drill position.
-	useEffect( () => {
-		resetDrillDown();
-	}, [ reportParams.from, reportParams.to, resetDrillDown ] );
-
 	// Resolve the path against the current rows each render, so a refetch that
 	// drops a selected row falls back to the deepest level that still exists.
 	const trail = useMemo( () => {
@@ -243,6 +235,24 @@ function ReferrersInner( { max }: { max: number } ) {
 
 		return matched;
 	}, [ rows, drillPath ] );
+
+	// When settled data no longer resolves the whole stored path (e.g. the
+	// date range changed and the drilled group disappeared), trim it to the
+	// deepest level that still exists so stored state matches the view and
+	// stale levels can't resurface on a later refetch (WOOA7S-1666). A path
+	// that still resolves survives range changes, and in-flight fetches keep
+	// placeholder rows, so a valid selection survives refetches.
+	useEffect( () => {
+		if ( ! drillPath?.length || isLoading || isFetching || trail.length === drillPath.length ) {
+			return;
+		}
+
+		if ( trail.length ) {
+			setDrillPath( trail.map( row => row.label ) );
+		} else {
+			resetDrillDown();
+		}
+	}, [ drillPath, trail, isLoading, isFetching, setDrillPath, resetDrillDown ] );
 
 	const currentRow = trail.length ? trail[ trail.length - 1 ] : null;
 	const activeRows = currentRow ? currentRow.children ?? [] : rows;

--- a/projects/packages/premium-analytics/widgets/utm-insights/render.tsx
+++ b/projects/packages/premium-analytics/widgets/utm-insights/render.tsx
@@ -83,6 +83,16 @@ function UtmInsightsInner( { utmDimension, max }: UtmInsightsInnerProps ) {
 	);
 	const withComparison = isDrillDown ? !! selectedUtm?.childrenHaveComparison : hasComparison;
 
+	// The view already falls back to the top list when the selected row is
+	// missing; clear the stored selection too once data has settled without
+	// it, so stale state can't resurface on a later refetch (WOOA7S-1666).
+	// In-flight fetches keep placeholder rows, so a valid selection survives.
+	useEffect( () => {
+		if ( selectedUtmLabel && ! selectedUtm && ! isLoading && ! isFetching ) {
+			clearSelectedUtm();
+		}
+	}, [ selectedUtmLabel, selectedUtm, isLoading, isFetching, clearSelectedUtm ] );
+
 	const leaderboardData = useMemo< LeaderboardChartData >( () => {
 		const maxValue = Math.max( ...activeData.map( d => d.value ), 1 );
 		const maxPreviousValue = Math.max( ...activeData.map( d => d.previousValue ?? 0 ), 1 );

--- a/projects/packages/premium-analytics/widgets/utm-insights/render.tsx
+++ b/projects/packages/premium-analytics/widgets/utm-insights/render.tsx
@@ -86,12 +86,13 @@ function UtmInsightsInner( { utmDimension, max }: UtmInsightsInnerProps ) {
 	// The view already falls back to the top list when the selected row is
 	// missing; clear the stored selection too once data has settled without
 	// it, so stale state can't resurface on a later refetch (WOOA7S-1666).
-	// In-flight fetches keep placeholder rows, so a valid selection survives.
+	// In-flight fetches keep placeholder rows and errors aren't settled data,
+	// so a valid selection survives refetches and transient failures.
 	useEffect( () => {
-		if ( selectedUtmLabel && ! selectedUtm && ! isLoading && ! isFetching ) {
+		if ( selectedUtmLabel && ! selectedUtm && ! isLoading && ! isFetching && ! isError ) {
 			clearSelectedUtm();
 		}
-	}, [ selectedUtmLabel, selectedUtm, isLoading, isFetching, clearSelectedUtm ] );
+	}, [ selectedUtmLabel, selectedUtm, isLoading, isFetching, isError, clearSelectedUtm ] );
 
 	const leaderboardData = useMemo< LeaderboardChartData >( () => {
 		const maxValue = Math.max( ...activeData.map( d => d.value ), 1 );

--- a/projects/packages/premium-analytics/widgets/utm-insights/render.tsx
+++ b/projects/packages/premium-analytics/widgets/utm-insights/render.tsx
@@ -84,15 +84,16 @@ function UtmInsightsInner( { utmDimension, max }: UtmInsightsInnerProps ) {
 	const withComparison = isDrillDown ? !! selectedUtm?.childrenHaveComparison : hasComparison;
 
 	// The view already falls back to the top list when the selected row is
-	// missing; clear the stored selection too once data has settled without
-	// it, so stale state can't resurface on a later refetch (WOOA7S-1666).
-	// In-flight fetches keep placeholder rows and errors aren't settled data,
-	// so a valid selection survives refetches and transient failures.
+	// missing or no longer drillable (no children); clear the stored selection
+	// too once data has settled without a drillable match, so stale state
+	// can't resurface on a later refetch (WOOA7S-1666). In-flight fetches keep
+	// placeholder rows and errors aren't settled data, so a valid selection
+	// survives refetches and transient failures.
 	useEffect( () => {
-		if ( selectedUtmLabel && ! selectedUtm && ! isLoading && ! isFetching && ! isError ) {
+		if ( selectedUtmLabel && ! isDrillDown && ! isLoading && ! isFetching && ! isError ) {
 			clearSelectedUtm();
 		}
-	}, [ selectedUtmLabel, selectedUtm, isLoading, isFetching, isError, clearSelectedUtm ] );
+	}, [ selectedUtmLabel, isDrillDown, isLoading, isFetching, isError, clearSelectedUtm ] );
 
 	const leaderboardData = useMemo< LeaderboardChartData >( () => {
 		const maxValue = Math.max( ...activeData.map( d => d.value ), 1 );


### PR DESCRIPTION
Fixes WOOA7S-1666. Stacked on #50476 (Referrers merge-helper/WidgetState migration) — review the last commit only until that merges.

## Why

Stats widgets with drill-down reset their local state at different times (see the audit in WOOA7S-1666): Referrers wiped its path on every date-range change, UTM and Clicks kept stale stored selections behind a visual fallback, and Authors could clear a valid selection while a fetch was still in flight.

## The rule

Aligned on the semantics that landed for Most viewed in #50263 (data-driven, review-vetted there):

1. **Preserve** the selection during in-flight fetches, and across range changes while it still resolves against the fetched rows — matching how Locations keeps its country across ranges.
2. **Trim deterministically** once data settles without the selection: stored state is cut to the deepest level that still resolves (or cleared), so stale levels can't resurface on a later refetch.
3. **Explicit resets stay** for controls that redefine what the rows mean: UTM's dimension switch and Locations' view-by mode.

## Per widget

- **Referrers** — drops the unconditional date-range reset; the stored path is now trimmed to the resolved prefix once data settles. A drilled group that survives the new range keeps its drill-down.
- **Clicks** — clears the stored selection once settled data no longer contains the drilled domain (previously only the view fell back; the stale selection could resurface).
- **UTM Insights** — same stored-selection clearing; the dimension-change reset stays.
- **Authors** — the existing row-driven clear gains a fetch guard so loads/refetches can't wipe a valid selection while rows are briefly empty.
- **Locations** — unchanged by design: its selection drives the region query rather than resolving against fetched rows, so an empty drilled view with the back link is the correct behavior; the mode-change reset stays.

## Testing

- New regression tests: Referrers keeps its drill-down across a range change while the path resolves, and resets when the drilled group disappears; Clicks clears the stored drill-down when the selected domain leaves the data.
- `pnpm test` — 639 tests pass; `pnpm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
