### PR TITLE
Premium Analytics: fix metric delta fallback dash rendering as an underscore

### DIFF
--- a/projects/packages/premium-analytics/changelog/2026-07-14-06-09-44-316047
+++ b/projects/packages/premium-analytics/changelog/2026-07-14-06-09-44-316047
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Traffic and Subscribers widgets: fix the metric delta so the fallback dash (shown when the previous period has no comparable value) no longer reads as an underscore next to the headline number.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-delta/metric-delta.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-delta/metric-delta.module.scss
@@ -1,4 +1,7 @@
 .delta {
+	// Centers the delta relative to the taller metric value beside it, instead of
+	// sitting on its baseline, where the fallback dash reads as an underscore.
+	align-self: center;
 	font-size: var(--wpds-typography-font-size-md);
 	font-weight: 400;
 	line-height: var(--wpds-typography-font-size-lg);


### PR DESCRIPTION
## Proposed changes

In the Traffic (and Subscribers) widget's metric tabs, the small delta indicator next to the headline number sometimes shows a mark that reads as a stray underscore (e.g. "44 _") instead of a dash.

That mark is the intentional "—" fallback `MetricDelta` renders when a period-over-period percentage can't be computed (previous period total is `0`, current isn't — division by zero). The dash itself is correct and should stay; the problem is purely visual: the delta sits bottom/baseline-aligned next to a much larger metric value, and a plain single-stroke dash lands right on the number's baseline, reading as an underscore. A real delta like "+47%" has enough glyph shapes to avoid the same illusion.

* Center the delta vertically relative to the metric value (`align-self: center` in `MetricDelta`) instead of bottom/baseline-aligning it, so the fallback dash reads as a dash. Real percentage deltas are unaffected.

Fixed at the shared `MetricDelta` component (`packages/widgets-toolkit`) rather than per-widget, since the Subscribers chart, metric-comparison widget, conversion-rate widget, all-time-stats widget, and the chart legend all render through the same component and can hit the same `previousValue === 0` fallback.

## Related product discussion/links

* Reported from a live dashboard screenshot showing "44 _", "9 _", "1 _" in the Traffic widget's tabs.

## Does this pull request change what data or activity we track or use?

No — CSS-only change, no data/tracking impact.

## Testing instructions

* In `projects/js-packages/storybook`, run `pnpm run storybook:dev` (port 50240).
* Open `Packages/Premium Analytics/Widgets Toolkit/Components/MetricWithComparison` → `RowLayout` story, set `previousValue` to `0` in the Controls panel. The dash next to the value should read as a centered dash, not an underscore sitting under the number.
* Set `previousValue` back to a real number (e.g. `30`) — the percentage delta ("+47%") should still look correctly placed, confirming no regression to the normal case.
* Open `Packages/Premium Analytics/Widgets/TrafficChart` → `WidgetDashboardWithWidget` story to see the fix in the actual widget layout.

| Before | After |
|-|-|
| <img width="670" height="200" alt="image" src="https://github.com/user-attachments/assets/d5270457-94e8-4228-8f23-e6886bbf284d" /> | <img width="674" height="295" alt="image" src="https://github.com/user-attachments/assets/bb066695-9c23-4a47-ad5b-272a1131d576" /> |