### PR TITLE
Premium Analytics: use native help for widget descriptions

### DIFF
--- a/projects/packages/premium-analytics/changelog/remove-redundant-widget-descriptions
+++ b/projects/packages/premium-analytics/changelog/remove-redundant-widget-descriptions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Show widget descriptions in the native header info popover.

--- a/projects/packages/premium-analytics/widgets/all-time-stats/widget.ts
+++ b/projects/packages/premium-analytics/widgets/all-time-stats/widget.ts
@@ -60,6 +60,12 @@ export const DEFAULT_ALL_TIME_STATS_METRICS: AllTimeStatsMetricId[] = ALL_TIME_S
 export default {
 	name: 'jpa/all-time-stats',
 	title: __( 'All-time stats', 'jetpack-premium-analytics' ),
+	help: {
+		content: __(
+			'Lifetime totals for your site — views, visitors, posts, and comments.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: trendingUp,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/annual-highlights/widget.ts
+++ b/projects/packages/premium-analytics/widgets/annual-highlights/widget.ts
@@ -42,6 +42,12 @@ export const DEFAULT_HIGHLIGHT_METRICS: AnnualHighlightMetric[] = [
 export default {
 	name: 'jpa/annual-highlights',
 	title: __( 'Annual highlights', 'jetpack-premium-analytics' ),
+	help: {
+		content: __(
+			'Your totals for the year at a glance — posts, words, likes, and comments.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: calendar,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/authors/widget.ts
+++ b/projects/packages/premium-analytics/widgets/authors/widget.ts
@@ -23,6 +23,12 @@ export type AuthorsAttributes = {
 export default {
 	name: 'jpa/authors',
 	title: __( 'Authors', 'jetpack-premium-analytics' ),
+	help: {
+		content: __(
+			'Learn about your most popular authors to better understand how they contribute to grow your site.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: postAuthor,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/average-items-per-order/widget.ts
+++ b/projects/packages/premium-analytics/widgets/average-items-per-order/widget.ts
@@ -25,9 +25,11 @@ export type AverageItemsPerOrderAttributes = Record< never, never >;
 export default {
 	name: 'jpa/average-items-per-order',
 	title: __( 'Average items per order', 'jetpack-premium-analytics' ),
-	description: __(
-		'Show the average number of products per order over a set period of time.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'Show the average number of products per order over a set period of time.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/average-order-value/widget.ts
+++ b/projects/packages/premium-analytics/widgets/average-order-value/widget.ts
@@ -25,9 +25,11 @@ export type AverageOrderValueAttributes = Record< never, never >;
 export default {
 	name: 'jpa/average-order-value',
 	title: __( 'Average order value', 'jetpack-premium-analytics' ),
-	description: __(
-		'Track the average value of each order over a set period of time.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'Track the average value of each order over a set period of time.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/bookings-by-device/widget.ts
+++ b/projects/packages/premium-analytics/widgets/bookings-by-device/widget.ts
@@ -25,9 +25,11 @@ export type BookingsByDeviceAttributes = Record< never, never >;
 export default {
 	name: 'jpa/bookings-by-device',
 	title: __( 'Bookings by device', 'jetpack-premium-analytics' ),
-	description: __(
-		'See which devices your customers are using to make bookings in your store.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'See which devices your customers are using to make bookings in your store.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/bookings-by-status/widget.ts
+++ b/projects/packages/premium-analytics/widgets/bookings-by-status/widget.ts
@@ -25,9 +25,11 @@ export type BookingsByStatusAttributes = Record< never, never >;
 export default {
 	name: 'jpa/bookings-by-status',
 	title: __( 'Bookings by status', 'jetpack-premium-analytics' ),
-	description: __(
-		'Number of bookings by status over the selected time period.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'Number of bookings by status over the selected time period.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/bookings-over-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/bookings-over-time/widget.ts
@@ -25,9 +25,11 @@ export type BookingsOverTimeAttributes = Record< never, never >;
 export default {
 	name: 'jpa/bookings-over-time',
 	title: __( 'Bookings over time', 'jetpack-premium-analytics' ),
-	description: __(
-		'See a breakdown of when bookings are placed to identify peak selling periods.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'See a breakdown of when bookings are placed to identify peak selling periods.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/widget.ts
+++ b/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/widget.ts
@@ -25,9 +25,11 @@ export type BookingsRevenueByCustomerTypeAttributes = Record< never, never >;
 export default {
 	name: 'jpa/bookings-revenue-by-customer-type',
 	title: __( 'Bookings revenue by customer type', 'jetpack-premium-analytics' ),
-	description: __(
-		'Revenue breakdown from new customers vs returning customers for bookings over the selected time period.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'Revenue breakdown from new customers vs returning customers for bookings over the selected time period.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/clicks/widget.ts
+++ b/projects/packages/premium-analytics/widgets/clicks/widget.ts
@@ -24,6 +24,12 @@ export type ClicksAttributes = {
 export default {
 	name: 'jpa/clicks',
 	title: __( 'Clicks', 'jetpack-premium-analytics' ),
+	help: {
+		content: __(
+			'Most clicked external links to track engaging content.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/comments/widget.ts
+++ b/projects/packages/premium-analytics/widgets/comments/widget.ts
@@ -38,6 +38,12 @@ export type CommentsAttributes = {
 export default {
 	name: 'jpa/comments',
 	title: __( 'Comments', 'jetpack-premium-analytics' ),
+	help: {
+		content: __(
+			'Learn about the comments your site receives by authors, posts, and pages.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: comment,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/conversion-rate/widget.ts
+++ b/projects/packages/premium-analytics/widgets/conversion-rate/widget.ts
@@ -24,9 +24,11 @@ export type ConversionRateAttributes = Record< never, never >;
 export default {
 	name: 'jpa/conversion-rate',
 	title: __( 'Store conversion rate', 'jetpack-premium-analytics' ),
-	description: __(
-		'Store conversion rate over the selected time period.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'Conversion funnel from visitors to completed purchases over the selected time period.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/coupon-usage-over-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/coupon-usage-over-time/widget.ts
@@ -24,6 +24,11 @@ export type CouponUsageOverTimeAttributes = Record< never, never >;
 export default {
 	name: 'jpa/coupon-usage-over-time',
 	title: __( 'Coupon usage over time', 'jetpack-premium-analytics' ),
-	description: __( 'Coupon usage over the selected time period.', 'jetpack-premium-analytics' ),
+	help: {
+		content: __(
+			'Track how effective your discounts and promotions have been over a set period of time.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/devices/widget.ts
+++ b/projects/packages/premium-analytics/widgets/devices/widget.ts
@@ -25,6 +25,12 @@ export type DevicesAttributes = {
 export default {
 	name: 'jpa/devices',
 	title: __( 'Devices', 'jetpack-premium-analytics' ),
+	help: {
+		content: __(
+			'The devices and browsers your visitors use to access your website.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: desktop,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/email-breakdown/widget.ts
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/widget.ts
@@ -56,6 +56,12 @@ export type EmailBreakdownAttributes = {
 export default {
 	name: 'jpa/email-breakdown',
 	title: __( 'Email breakdown', 'jetpack-premium-analytics' ),
+	help: {
+		content: __(
+			'Breaks a sent email down by countries, devices, email clients, or clicked links.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: envelope,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/emails/widget.ts
+++ b/projects/packages/premium-analytics/widgets/emails/widget.ts
@@ -39,6 +39,9 @@ export type EmailsAttributes = {
 export default {
 	name: 'jpa/stats-emails',
 	title: __( 'Emails', 'jetpack-premium-analytics' ),
+	help: {
+		content: __( 'Latest emails sent and their performance.', 'jetpack-premium-analytics' ),
+	},
 	icon: envelope,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/file-downloads/widget.ts
+++ b/projects/packages/premium-analytics/widgets/file-downloads/widget.ts
@@ -25,6 +25,9 @@ export type FileDownloadsAttributes = {
 export default {
 	name: 'jpa/file-downloads',
 	title: __( 'File downloads', 'jetpack-premium-analytics' ),
+	help: {
+		content: __( 'Most downloaded files from your site.', 'jetpack-premium-analytics' ),
+	},
 	icon: download,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/gross-sales-over-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/gross-sales-over-time/widget.ts
@@ -25,6 +25,11 @@ export type GrossSalesOverTimeAttributes = Record< never, never >;
 export default {
 	name: 'jpa/gross-sales-over-time',
 	title: __( 'Gross sales over time', 'jetpack-premium-analytics' ),
-	description: __( 'Gross sales over the selected time period.', 'jetpack-premium-analytics' ),
+	help: {
+		content: __(
+			'Monitor your total revenue — before any discounts, returns, or adjustments — over a set period of time.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/latest-post/widget.ts
+++ b/projects/packages/premium-analytics/widgets/latest-post/widget.ts
@@ -24,6 +24,12 @@ export type LatestPostAttributes = Record< never, never >;
 export default {
 	name: 'jpa/latest-post',
 	title: __( 'Latest post', 'jetpack-premium-analytics' ),
+	help: {
+		content: __(
+			'Your most recently published post with its views, likes, and comments.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: postList,
 	attributes: [] as WidgetAttributeField< LatestPostAttributes >[],
 	example: {

--- a/projects/packages/premium-analytics/widgets/locations/widget.ts
+++ b/projects/packages/premium-analytics/widgets/locations/widget.ts
@@ -29,6 +29,12 @@ export type LocationsAttributes = {
 export default {
 	name: 'jpa/locations',
 	title: __( 'Locations', 'jetpack-premium-analytics' ),
+	help: {
+		content: __(
+			'Visitors’ viewing location by countries, regions and cities.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: mapMarker,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/most-popular-day/widget.ts
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/widget.ts
@@ -20,6 +20,8 @@ export type MostPopularDayAttributes = Record< never, never >;
 export default {
 	name: 'jpa/most-popular-day',
 	title: __( 'Most popular day', 'jetpack-premium-analytics' ),
-	description: __( 'The day your site received the most views.', 'jetpack-premium-analytics' ),
+	help: {
+		content: __( 'The day your site received the most views.', 'jetpack-premium-analytics' ),
+	},
 	icon: calendar,
 };

--- a/projects/packages/premium-analytics/widgets/most-popular-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/most-popular-time/widget.ts
@@ -22,5 +22,11 @@ export type MostPopularTimeAttributes = Record< never, never >;
 export default {
 	name: 'jpa/most-popular-time',
 	title: __( 'Most popular time', 'jetpack-premium-analytics' ),
+	help: {
+		content: __(
+			'The day of week and hour of day when your site gets the most views.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: scheduled,
 };

--- a/projects/packages/premium-analytics/widgets/net-sales-over-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/net-sales-over-time/widget.ts
@@ -25,9 +25,11 @@ export type NetSalesOverTimeAttributes = Record< never, never >;
 export default {
 	name: 'jpa/net-sales-over-time',
 	title: __( 'Net sales over time', 'jetpack-premium-analytics' ),
-	description: __(
-		'Monitor your total revenue after discounts, returns, or adjustments over a set period of time.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'Monitor your total revenue — after any discounts, returns, or adjustments — over a set period of time.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/new-vs-returning-customer/widget.ts
+++ b/projects/packages/premium-analytics/widgets/new-vs-returning-customer/widget.ts
@@ -25,9 +25,11 @@ export type NewVsReturningCustomerAttributes = Record< never, never >;
 export default {
 	name: 'jpa/new-vs-returning-customer',
 	title: __( 'New vs returning customer', 'jetpack-premium-analytics' ),
-	description: __(
-		'Unique customer counts broken down by new vs returning customers over the selected time period.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'Unique customer counts broken down by new vs returning customers over the selected time period.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/orders-fulfillment/widget.ts
+++ b/projects/packages/premium-analytics/widgets/orders-fulfillment/widget.ts
@@ -25,9 +25,11 @@ export type OrdersFulfillmentAttributes = Record< never, never >;
 export default {
 	name: 'jpa/orders-fulfillment',
 	title: __( 'Orders fulfillment', 'jetpack-premium-analytics' ),
-	description: __(
-		'Shows the breakdown of fulfilled vs unfulfilled order counts over the selected time period.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'Shows the breakdown of fulfilled vs unfulfilled order counts over the selected time period.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/orders-over-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/orders-over-time/widget.ts
@@ -25,9 +25,11 @@ export type OrdersOverTimeAttributes = Record< never, never >;
 export default {
 	name: 'jpa/orders-over-time',
 	title: __( 'Orders over time', 'jetpack-premium-analytics' ),
-	description: __(
-		'See a breakdown of when orders are placed to identify peak selling periods.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'See a breakdown of when orders are placed to identify peak selling periods.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/payment-status/widget.ts
+++ b/projects/packages/premium-analytics/widgets/payment-status/widget.ts
@@ -25,9 +25,11 @@ export type PaymentStatusAttributes = Record< never, never >;
 export default {
 	name: 'jpa/payment-status',
 	title: __( 'Payment status', 'jetpack-premium-analytics' ),
-	description: __(
-		'Shows the breakdown of paid vs unpaid order revenue over the selected time period.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'Shows the breakdown of paid vs unpaid order revenue over the selected time period.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/posting-activity/widget.ts
+++ b/projects/packages/premium-analytics/widgets/posting-activity/widget.ts
@@ -21,5 +21,11 @@ export type PostingActivityAttributes = Record< never, never >;
 export default {
 	name: 'jpa/posting-activity',
 	title: __( 'Posting activity', 'jetpack-premium-analytics' ),
+	help: {
+		content: __(
+			'How often you publish — a calendar heatmap of posts per day.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: calendar,
 };

--- a/projects/packages/premium-analytics/widgets/referrers/widget.ts
+++ b/projects/packages/premium-analytics/widgets/referrers/widget.ts
@@ -23,6 +23,12 @@ export type ReferrersAttributes = {
 export default {
 	name: 'jpa/referrers',
 	title: __( 'Referrers', 'jetpack-premium-analytics' ),
+	help: {
+		content: __(
+			'Websites referring visitors sorted by most clicked. Learn about where your audience comes from.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: globe,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/revenue-by-customer-type/widget.ts
+++ b/projects/packages/premium-analytics/widgets/revenue-by-customer-type/widget.ts
@@ -25,9 +25,11 @@ export type RevenueByCustomerTypeAttributes = Record< never, never >;
 export default {
 	name: 'jpa/revenue-by-customer-type',
 	title: __( 'Revenue by customer type', 'jetpack-premium-analytics' ),
-	description: __(
-		'Shows the breakdown of order revenue from new and returning customers over the selected time period.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'Revenue breakdown from new customers vs returning customers over the selected time period.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/widget.ts
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/widget.ts
@@ -25,9 +25,8 @@ export type SalesByCouponUsageAttributes = Record< never, never >;
 export default {
 	name: 'jpa/sales-by-coupon-usage',
 	title: __( 'Sales by coupon usage', 'jetpack-premium-analytics' ),
-	description: __(
-		'Sales by coupon usage over the selected time period.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __( 'Compare sales with and without coupons.', 'jetpack-premium-analytics' ),
+	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon/widget.ts
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon/widget.ts
@@ -25,9 +25,11 @@ export type SalesByCouponAttributes = Record< never, never >;
 export default {
 	name: 'jpa/sales-by-coupon',
 	title: __( 'Sales by coupon', 'jetpack-premium-analytics' ),
-	description: __(
-		'Shows the top coupon codes by order revenue over the selected time period.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'Revenue from physical product sales using coupons over the selected time period.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/sales-by-device/widget.ts
+++ b/projects/packages/premium-analytics/widgets/sales-by-device/widget.ts
@@ -25,9 +25,11 @@ export type SalesByDeviceAttributes = Record< never, never >;
 export default {
 	name: 'jpa/sales-by-device',
 	title: __( 'Sales by device', 'jetpack-premium-analytics' ),
-	description: __(
-		'Shows the sales breakdown by device type over the selected time period.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'See which devices your customers are using to make purchases in your store.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-campaign/widget.ts
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-campaign/widget.ts
@@ -25,9 +25,11 @@ export type SalesByUtmCampaignAttributes = Record< never, never >;
 export default {
 	name: 'jpa/sales-by-utm-campaign',
 	title: __( 'Sales by UTM campaign', 'jetpack-premium-analytics' ),
-	description: __(
-		'Shows the top UTM campaigns by order revenue over the selected time period.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'See which marketing campaigns are driving sales in your store.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-channel/widget.ts
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-channel/widget.ts
@@ -25,9 +25,11 @@ export type SalesByUtmChannelAttributes = Record< never, never >;
 export default {
 	name: 'jpa/sales-by-utm-channel',
 	title: __( 'Sales by UTM channel', 'jetpack-premium-analytics' ),
-	description: __(
-		'Shows the top UTM channels by order revenue over the selected time period.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'See which marketing channels are driving sales in your store.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-source/widget.ts
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-source/widget.ts
@@ -25,9 +25,11 @@ export type SalesByUtmSourceAttributes = Record< never, never >;
 export default {
 	name: 'jpa/sales-by-utm-source',
 	title: __( 'Sales by UTM source', 'jetpack-premium-analytics' ),
-	description: __(
-		'Shows the top UTM sources by order revenue over the selected time period.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'See which referral sources are driving sales in your store.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/search-terms/widget.ts
+++ b/projects/packages/premium-analytics/widgets/search-terms/widget.ts
@@ -24,6 +24,12 @@ export type SearchTermsAttributes = {
 export default {
 	name: 'jpa/search-terms',
 	title: __( 'Search Terms', 'jetpack-premium-analytics' ),
+	help: {
+		content: __(
+			'Learn about popular terms visitors use to find your site content on search engines.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: search,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/sessions-by-device/widget.ts
+++ b/projects/packages/premium-analytics/widgets/sessions-by-device/widget.ts
@@ -25,9 +25,11 @@ export type SessionsByDeviceAttributes = Record< never, never >;
 export default {
 	name: 'jpa/sessions-by-device',
 	title: __( 'Sessions by device', 'jetpack-premium-analytics' ),
-	description: __(
-		'Shows the sessions breakdown by device type over the selected time period.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'See which devices visitors are using to browse your store.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/shares/widget.ts
+++ b/projects/packages/premium-analytics/widgets/shares/widget.ts
@@ -25,6 +25,12 @@ export type SharesAttributes = {
 export default {
 	name: 'jpa/shares',
 	title: __( 'Shares', 'jetpack-premium-analytics' ),
+	help: {
+		content: __(
+			'Learn where your content has been shared the most.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: share,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/site-overview/widget.ts
+++ b/projects/packages/premium-analytics/widgets/site-overview/widget.ts
@@ -59,6 +59,12 @@ export const DEFAULT_SITE_OVERVIEW_METRICS: SiteOverviewMetricId[] = SITE_OVERVI
 export default {
 	name: 'jpa/site-overview',
 	title: __( 'Site overview', 'jetpack-premium-analytics' ),
+	help: {
+		content: __(
+			'Views, visitors, likes, and comments for the selected period, with period-over-period change.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: globe,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/widget.ts
+++ b/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/widget.ts
@@ -24,9 +24,11 @@ export type StoreConversionRateBookingsAttributes = Record< never, never >;
 export default {
 	name: 'jpa/store-conversion-rate-bookings',
 	title: __( 'Store conversion rate - Bookings', 'jetpack-premium-analytics' ),
-	description: __(
-		'Store conversion rate for booking products over the selected time period.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'Track your booking conversion funnel from sessions to completed bookings over the selected time period.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/store-performance/stories/store-performance-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/store-performance/stories/store-performance-widget.stories.tsx
@@ -31,7 +31,7 @@ const ensureLineChartComposition = () => LineChart.Legend;
 const storyWidgetType = {
 	name: widgetDefinition.name,
 	title: widgetDefinition.title,
-	description: widgetDefinition.description,
+	help: widgetDefinition.help,
 	icon: widgetDefinition.icon,
 	attributes: widgetDefinition.attributes as WidgetType[ 'attributes' ],
 	example: widgetDefinition.example,

--- a/projects/packages/premium-analytics/widgets/store-performance/widget.ts
+++ b/projects/packages/premium-analytics/widgets/store-performance/widget.ts
@@ -41,10 +41,9 @@ export type StorePerformanceAttributes = {
 export default {
 	name: 'jpa/store-performance',
 	title: __( 'Store performance', 'jetpack-premium-analytics' ),
-	description: __(
-		'Shows key store performance metrics at a glance.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __( 'Shows key store performance metrics at a glance.', 'jetpack-premium-analytics' ),
+	},
 	icon: store,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/subscriber-highlights/widget.ts
+++ b/projects/packages/premium-analytics/widgets/subscriber-highlights/widget.ts
@@ -56,6 +56,12 @@ export const DEFAULT_SUBSCRIBER_METRICS: SubscriberMetricId[] = SUBSCRIBER_METRI
 export default {
 	name: 'jpa/subscriber-highlights',
 	title: __( 'Subscriber highlights', 'jetpack-premium-analytics' ),
+	help: {
+		content: __(
+			'Your subscriber totals at a glance — total, paid, free, and social followers.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: people,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/widget.ts
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/widget.ts
@@ -36,10 +36,12 @@ export type SubscribersChartAttributes = {
 export default {
 	name: 'jpa/subscribers-chart',
 	title: __( 'Subscribers', 'jetpack-premium-analytics' ),
-	description: __(
-		'Track subscriber growth over time, with paid subscribers and the previous period overlaid for comparison.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'Track subscriber growth over time, with paid subscribers and the previous period overlaid for comparison.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: trendingUp,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/subscribers-list/widget.ts
+++ b/projects/packages/premium-analytics/widgets/subscribers-list/widget.ts
@@ -26,6 +26,9 @@ export type SubscribersListAttributes = {
 export default {
 	name: 'jpa/subscribers-list',
 	title: __( 'Latest Subscribers', 'jetpack-premium-analytics' ),
+	help: {
+		content: __( 'Your most recent subscribers.', 'jetpack-premium-analytics' ),
+	},
 	icon: people,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/tags/widget.ts
+++ b/projects/packages/premium-analytics/widgets/tags/widget.ts
@@ -25,6 +25,12 @@ export type TagsAttributes = {
 export default {
 	name: 'jpa/tags',
 	title: __( 'Tags & categories', 'jetpack-premium-analytics' ),
+	help: {
+		content: __(
+			'Most visited tags & categories. Learn about the most engaging topics.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: tag,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/top-performing-bookings/widget.ts
+++ b/projects/packages/premium-analytics/widgets/top-performing-bookings/widget.ts
@@ -25,9 +25,11 @@ export type TopPerformingBookingsAttributes = Record< never, never >;
 export default {
 	name: 'jpa/top-performing-bookings',
 	title: __( 'Top performing bookings', 'jetpack-premium-analytics' ),
-	description: __(
-		'Shows the top booking products by net revenue over the selected time period.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'Your best-selling bookings by revenue over the selected time period.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/top-performing-products/widget.ts
+++ b/projects/packages/premium-analytics/widgets/top-performing-products/widget.ts
@@ -25,9 +25,11 @@ export type TopPerformingProductsAttributes = Record< never, never >;
 export default {
 	name: 'jpa/top-performing-products',
 	title: __( 'Top performing products', 'jetpack-premium-analytics' ),
-	description: __(
-		'Shows the top products by net revenue over the selected time period.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'Your best-selling products by revenue over the selected time period.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/top-platforms/widget.ts
+++ b/projects/packages/premium-analytics/widgets/top-platforms/widget.ts
@@ -26,6 +26,12 @@ export type TopPlatformsAttributes = {
 export default {
 	name: 'jpa/top-platforms',
 	title: __( 'Top Platforms', 'jetpack-premium-analytics' ),
+	help: {
+		content: __(
+			'Top browsers and operating systems your visitors use.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/top-posts/widget.ts
+++ b/projects/packages/premium-analytics/widgets/top-posts/widget.ts
@@ -38,6 +38,12 @@ export type TopPostsAttributes = {
 export default {
 	name: 'jpa/stats-top-posts',
 	title: __( 'Most viewed', 'jetpack-premium-analytics' ),
+	help: {
+		content: __(
+			'Most viewed posts, pages and archive. Learn about what content resonates the most.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/total-returns/widget.ts
+++ b/projects/packages/premium-analytics/widgets/total-returns/widget.ts
@@ -25,9 +25,11 @@ export type TotalReturnsAttributes = Record< never, never >;
 export default {
 	name: 'jpa/total-returns',
 	title: __( 'Total returns', 'jetpack-premium-analytics' ),
-	description: __(
-		'Shows refunds and net sales over the selected time period.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'Total value of returns issued for physical products over the selected time period.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/total-sales-over-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/total-sales-over-time/widget.ts
@@ -25,9 +25,11 @@ export type TotalSalesOverTimeAttributes = Record< never, never >;
 export default {
 	name: 'jpa/total-sales-over-time',
 	title: __( 'Total sales over time', 'jetpack-premium-analytics' ),
-	description: __(
-		'Track total sales including all orders and transactions.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'Track total sales including all orders and transactions.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/traffic-chart/widget.ts
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/widget.ts
@@ -37,10 +37,12 @@ export type TrafficChartAttributes = {
 export default {
 	name: 'jpa/traffic-chart',
 	title: __( 'Traffic', 'jetpack-premium-analytics' ),
-	description: __(
-		'Compare views, visitors, likes, and comments over the selected period, with the previous period overlaid for comparison.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'Compare views, visitors, likes, and comments over the selected period, with the previous period overlaid for comparison.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/utm-insights/widget.ts
+++ b/projects/packages/premium-analytics/widgets/utm-insights/widget.ts
@@ -32,6 +32,12 @@ export type UtmInsightsAttributes = {
 export default {
 	name: 'jpa/utm-insights',
 	title: __( 'UTM Insights', 'jetpack-premium-analytics' ),
+	help: {
+		content: __(
+			'Track your campaign UTM performance data. Generate URL codes with our builder.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: trendingUp,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/video-detail-embeds/widget.ts
+++ b/projects/packages/premium-analytics/widgets/video-detail-embeds/widget.ts
@@ -26,10 +26,6 @@ export type VideoDetailEmbedsAttributes = Record< never, never >;
 export default {
 	name: 'jpa/video-detail-embeds',
 	title: __( 'Video embeds', 'jetpack-premium-analytics' ),
-	description: __(
-		'Pages where the selected video is embedded, sourced from Jetpack Stats.',
-		'jetpack-premium-analytics'
-	),
 	help: {
 		content: __(
 			'Lists every page on your site where the selected video is embedded, so you can see where it is being watched.',

--- a/projects/packages/premium-analytics/widgets/videopress/widget.ts
+++ b/projects/packages/premium-analytics/widgets/videopress/widget.ts
@@ -30,6 +30,12 @@ export type VideoPressAttributes = {
 export default {
 	name: 'jpa/videopress',
 	title: __( 'VideoPress', 'jetpack-premium-analytics' ),
+	help: {
+		content: __(
+			'Most popular videos uploaded to your site. Learn more about their performance.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: video,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/visitors-by-location/widget.ts
+++ b/projects/packages/premium-analytics/widgets/visitors-by-location/widget.ts
@@ -25,9 +25,11 @@ export type VisitorsByLocationAttributes = Record< never, never >;
 export default {
 	name: 'jpa/visitors-by-location',
 	title: __( 'Visitors by location', 'jetpack-premium-analytics' ),
-	description: __(
-		'See where your store visitors are located geographically.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'See where your store visitors are located geographically.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: mapMarker,
 };

--- a/projects/packages/premium-analytics/widgets/visitors-over-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/visitors-over-time/widget.ts
@@ -25,9 +25,11 @@ export type VisitorsOverTimeAttributes = Record< never, never >;
 export default {
 	name: 'jpa/visitors-over-time',
 	title: __( 'Visitors over time', 'jetpack-premium-analytics' ),
-	description: __(
-		'Track website visitor trends and monitor traffic patterns over time.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'Track website visitor trends and monitor traffic patterns over time.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: seen,
 };

--- a/projects/packages/premium-analytics/widgets/wordads-chart-tabs/widget.ts
+++ b/projects/packages/premium-analytics/widgets/wordads-chart-tabs/widget.ts
@@ -53,10 +53,12 @@ export type WordAdsChartTabsAttributes = {
 export default {
 	name: 'jpa/wordads-chart-tabs',
 	title: __( 'WordAds', 'jetpack-premium-analytics' ),
-	description: __(
-		'Compare ads served, average CPM, and revenue over the selected period, with the previous period overlaid for comparison.',
-		'jetpack-premium-analytics'
-	),
+	help: {
+		content: __(
+			'Compare ads served, average CPM, and revenue over the selected period, with the previous period overlaid for comparison.',
+			'jetpack-premium-analytics'
+		),
+	},
 	icon: chartBar,
 	attributes: [
 		{


### PR DESCRIPTION
Fixes WOOA7S-1688

## Proposed changes

* Remove redundant runtime widget `description` fields and use the dashboard's native header `help` metadata instead.
* Add header help to every production widget; only the Hello World example and React Query devtool intentionally omit it.
* Reuse Woo Analytics info copy and Calypso Stats infotip copy where direct upstream equivalents exist.
* Keep `widget.json` descriptions as discovery metadata for the widget picker, following the WordPress widget contract.
* Keep this change in frontend widget registrations, following the pattern currently supported by Premium Analytics without expanding its PHP registry adapter.

## Related product discussion/links

* WOOA7S-1688

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run `pnpm --filter @automattic/jetpack-premium-analytics typecheck`.
* Run `pnpm lint-changed`.
* Open the Premium Analytics dashboard and add widgets from both Stats and store analytics, such as **Authors**, **Average order value**, and **Store performance**.
* Confirm each production widget header shows an info icon and that its popover contains the widget's explanatory text.


https://github.com/user-attachments/assets/aa16eb94-101b-472b-97b2-0d7768f16c79

