### PR TITLE
Social previews: remove usage of studio colors

### DIFF
--- a/projects/js-packages/social-previews/changelog/update-social-previews-no-studio
+++ b/projects/js-packages/social-previews/changelog/update-social-previews-no-studio
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Comment: Replace legacy `--studio-black` with `#000` in Threads and Twitter link preview card styles.

--- a/projects/js-packages/social-previews/src/threads-preview/style.scss
+++ b/projects/js-packages/social-previews/src/threads-preview/style.scss
@@ -152,7 +152,7 @@
 				padding: 0.75em;
 				text-decoration: none;
 				font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-				color: var(--studio-black);
+				color: vars.$threads-text-primary-color;
 				text-align: left;
 				overflow: hidden;
 				display: flex;

--- a/projects/js-packages/social-previews/src/twitter-preview/style.scss
+++ b/projects/js-packages/social-previews/src/twitter-preview/style.scss
@@ -201,7 +201,7 @@
 				padding: 0.75em;
 				text-decoration: none;
 				font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-				color: var(--studio-black);
+				color: #000;
 				text-align: left;
 				overflow: hidden;
 				display: flex;


### PR DESCRIPTION
Helps with migration to [WPDS tokens](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/docs/tokens.md) and build tooling more fully in the repo at https://github.com/Automattic/jetpack/pull/50108 when we don't need to worry about including Studio colors anywhere.


## Proposed changes

Just swaps black -token with black and another black sass token; nothing in final CSS changes (black is still black).

<!--- Explain what functional changes your PR includes -->
* Replaces two instances of `--studio-black` (#000) usages and anyway aligns how these previews handle colors:
   * Threads section has its own color variables already, just use those like the rest of the section:
       https://github.com/Automattic/jetpack/blob/dbdb40d4a477ab42f15fceda6ea11bbd6e971b7f/projects/js-packages/social-previews/src/threads-preview/variables.scss#L3
   * X/Twitter section uses straight HEX values; use that for the text just like for everything else.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Social previews continue look normal; text continues to render #000/black just like before.
