### PR TITLE
Error Reporting: delegate all decisions to host-specific filters

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-error-reporting-filters
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-error-reporting-filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+WP.com Error Reporting: delegate all decisions to host-specific filters

--- a/projects/packages/jetpack-mu-wpcom/src/features/error-reporting/error-reporting.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/error-reporting/error-reporting.php
@@ -75,41 +75,15 @@ function wpcom_add_crossorigin_to_script_elements( $tag ) {
 }
 
 /**
- * Temporary function to feature flag Sentry by segment.
- *
- * We'll be testing it on production (simple sites) for a while to see if it's feasible to
- * activate it for all sites and perhaps get rid of our custom solution. If it works well,
- * we'll activate for all simple sites and look into activating it for WoA, too.
- *
- * @param int $user_id The user id.
- * @return bool
+ * Decide whether Sentry should be activated for a given user and blog.
  */
-function wpcom_user_in_sentry_test_segment( $user_id ) {
-	$current_segment = 10; // Segment of existing users that will get this feature in %.
-	$user_segment    = $user_id % 100;
-
-	/*
-	 * We get the last two digits of the user id and that will be used to decide in what
-	 * segment the user is. i.e if current_segment is 10, then only ids that end in < 10
-	 * will be considered part of the segment.
+function wpcom_should_activate_sentry() {
+	/**
+	 * Filter to enable Sentry error reporting.
+	 *
+	 * @param bool $enabled Whether Sentry should be activated.
 	 */
-	return $user_segment < $current_segment;
-}
-
-/**
- * Return whether Sentry should be activated for a given user.
- *
- * In this phase, a12s have the possibility of configuring what error reporter to use
- * through the sticker. a12s should not be covered by the segment logic.
- *
- * Regular users have the error reporter chosen based on the segmentation logic, only.
- *
- * @param int $user_id The user id. Used to check if the user is A8C or in the Sentry test segment.
- * @param int $blog_id The blog ID. Usually the value of `get_current_blog_id`. Used to check if the sticker is applied if user is A8C.
- */
-function wpcom_should_activate_sentry( $user_id, $blog_id ) {
-	return ( is_automattician( $user_id ) && has_blog_sticker( 'error-reporting-use-sentry', $blog_id ) )
-		|| ( ! is_automattician( $user_id ) && wpcom_user_in_sentry_test_segment( $user_id ) );
+	return apply_filters( 'a8c_enable_sentry_error_reporting', false );
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/error-reporting/error-reporting.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/error-reporting/error-reporting.php
@@ -8,22 +8,6 @@
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 
 /**
- * Whether the site is eligible for Error Reporting, which is a feature that's specific to WPCOM.
- *
- * By default, sites should not be eligible.
- *
- * @return bool True if current site is eligible for error reporting, false otherwise.
- */
-function wpcom_is_site_eligible_for_error_reporting() {
-	/**
-	 * Can be used to toggle the Error Reporting functionality.
-	 *
-	 * @param bool true if Error Reporting should be enabled, false otherwise.
-	 */
-	return apply_filters( 'a8c_enable_error_reporting', false );
-}
-
-/**
  * Inline  error handler that will capture errors before the main handler has a chance to.
  *
  * Errors are pushed to a global array called `_jsErr` which is then verified in the main handler.
@@ -75,18 +59,6 @@ function wpcom_add_crossorigin_to_script_elements( $tag ) {
 }
 
 /**
- * Decide whether Sentry should be activated for a given user and blog.
- */
-function wpcom_should_activate_sentry() {
-	/**
-	 * Filter to enable Sentry error reporting.
-	 *
-	 * @param bool $enabled Whether Sentry should be activated.
-	 */
-	return apply_filters( 'a8c_enable_sentry_error_reporting', false );
-}
-
-/**
  * Enqueue assets
  */
 function wpcom_enqueue_error_reporting_script() {
@@ -108,17 +80,29 @@ function wpcom_enqueue_error_reporting_script() {
 		true
 	);
 
+	/**
+	 * Filter to enable Sentry error reporting.
+	 *
+	 * @param bool $enabled Whether Sentry should be activated.
+	 */
+	$activate_sentry = apply_filters( 'a8c_enable_sentry_error_reporting', false );
+
 	wp_localize_script(
 		$script_id,
 		'WPcom_Error_Reporting_Config',
 		array(
-			'shouldActivateSentry' => wpcom_should_activate_sentry( get_current_user_id(), get_current_blog_id() ) ? 'true' : 'false',
+			'shouldActivateSentry' => $activate_sentry ? 'true' : 'false',
 			'releaseName'          => defined( 'WPCOM_DEPLOYED_GIT_HASH' ) ? 'WPCOM_' . WPCOM_DEPLOYED_GIT_HASH : 'WPCOM_NO_RELEASE',
 		)
 	);
 }
 
-if ( wpcom_is_site_eligible_for_error_reporting() ) {
+/**
+ * Can be used to toggle the Error Reporting functionality.
+ *
+ * @param bool true if Error Reporting should be enabled, false otherwise.
+ */
+if ( apply_filters( 'a8c_enable_error_reporting', false ) ) {
 	add_action( 'admin_print_scripts', 'wpcom_head_error_handler', 0 );
 	add_filter( 'script_loader_tag', 'wpcom_add_crossorigin_to_script_elements', 99, 2 );
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/error-reporting/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/error-reporting/index.js
@@ -35,9 +35,9 @@ function activateSentry() {
 }
 
 /**
- * Activate the home-brew error-reporting.
+ * Activate the WP.com Logstash error-reporting.
  */
-function activateHomebrewErrorReporting() {
+function activateLogstash() {
 	const reportError = ( { error } ) => {
 		// Sanitized error event objects do not include a nested error attribute. In
 		// that case, we return early to prevent a needless TypeError when defining
@@ -62,7 +62,7 @@ function activateHomebrewErrorReporting() {
 				data: { error: JSON.stringify( data ) },
 			} )
 				// eslint-disable-next-line no-console
-				.catch( () => console.error( 'Error: Unable to record the error in Logstash.' ) )
+				.catch( err => console.error( 'Error: Unable to record the error in Logstash.', err ) )
 		);
 	};
 
@@ -75,7 +75,7 @@ function activateHomebrewErrorReporting() {
 if ( shouldActivateSentry ) {
 	activateSentry();
 } else {
-	activateHomebrewErrorReporting();
+	activateLogstash();
 }
 
 // Remove the head handler as it's not needed anymore after we set the main one above (either Sentry or homebrew)

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-error-reporting-filters
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-error-reporting-filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+WP.com Error Reporting: delegate all decisions to host-specific filters

--- a/projects/plugins/wpcomsh/changelog/update-error-reporting-filters
+++ b/projects/plugins/wpcomsh/changelog/update-error-reporting-filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+WP.com Error Reporting: delegate all decisions to host-specific filters


### PR DESCRIPTION
This PR modifies the `error-reporting` activation logic. The `wpcom_is_site_eligible_for_error_reporting` and `wpcom_should_activate_sentry` functions now merely call `apply_filters` for respective filters, and nothing else. The actual logic for `wpcom_should_activate_sentry` has been moved to WP.com code in the 228018-ghe-Automattic/wpcom PR.

That PR will need to be deployed first, as it introduces a new filter handler. And only then we can deploy Jetpack with this PR, so that it can use the new filter. The net result is that the same code is still called, just differently organized.

This allows a host to completely specify the activation logic. When we activate error reporting on Atomic site, it will registers its own independent filters somewhere in `wpcomsh`.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

Apply both this PR and the wpcom one to your WP.com sandbox. Two files will be modified:
```
wp-content/mu-plugins/jetpack-mu-wpcom-plugin/{sun,moon}/jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/error-reporting/error-reporting.php
wp-content/mu-plugins/wpcom-error-reporting.php
```

Go to a Simple site's wp-admin and verify that it still loads the `error-reporting.js` script.

Also verify that the `window.WPcom_Error_Reporting_Config` object exists and that its `shouldActivateSentry` record is `'false'`. You're likely an a11n and the site doesn't have the `error-reporting-use-sentry` sticker, so Sentry is not enabled.

You can try to add the `error-reporting-use-sentry` sticker and verify that the `shouldActivateSentry` flag becomes `'true'`. But beware, stickers are cached independently on production and in your sandbox, you'll be getting stale cache entries unless you manually disable the cache using `has_blog_sticker`'s third parameter:
```php
has_blog_sticker( 'error-reporting-use-sentry', $blog_id, true );
```