### PR TITLE
Premium Analytics: seed Emails widget and full-width layout in Subscribers tab

### DIFF
--- a/projects/packages/premium-analytics/changelog/subscribers-tab-emails-layout
+++ b/projects/packages/premium-analytics/changelog/subscribers-tab-emails-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Dashboard: seed the Emails widget in the Subscribers tab and make the subscriber highlights and chart full width, matching the Subscribers page composition.

--- a/projects/packages/premium-analytics/src/dashboard-layout.php
+++ b/projects/packages/premium-analytics/src/dashboard-layout.php
@@ -450,7 +450,7 @@ function get_dashboard_default_section_layouts() {
 				'default-subscriber-highlights-widget-instance',
 				'jpa/subscriber-highlights',
 				0,
-				2,
+				4,
 				1,
 				array(
 					'showTotal'  => true,
@@ -463,8 +463,8 @@ function get_dashboard_default_section_layouts() {
 				'default-subscribers-chart-widget-instance',
 				'jpa/subscribers-chart',
 				1,
-				2,
-				2,
+				4,
+				1,
 				array(
 					'granularity' => 'auto',
 				)
@@ -473,10 +473,21 @@ function get_dashboard_default_section_layouts() {
 				'default-subscribers-list-widget-instance',
 				'jpa/subscribers-list',
 				2,
-				1,
+				2,
 				2,
 				array(
 					'num' => 6,
+				)
+			),
+			get_dashboard_default_widget_instance(
+				'default-subscribers-emails-widget-instance',
+				'jpa/stats-emails',
+				3,
+				2,
+				2,
+				array(
+					'max'    => 10,
+					'metric' => 'opens',
 				)
 			),
 		),

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
@@ -159,6 +159,7 @@ class Dashboard_Layout_Test extends TestCase {
 		$this->assertContains( 'jpa/subscriber-highlights', $layout_types );
 		$this->assertContains( 'jpa/subscribers-chart', $layout_types );
 		$this->assertContains( 'jpa/subscribers-list', $layout_types );
+		$this->assertContains( 'jpa/stats-emails', $layout_types );
 		$this->assertSame(
 			array(
 				'uuid'       => 'default-subscribers-list-widget-instance',
@@ -167,12 +168,28 @@ class Dashboard_Layout_Test extends TestCase {
 					'num' => 6,
 				),
 				'placement'  => array(
-					'width'  => 1,
+					'width'  => 2,
 					'height' => 2,
 					'order'  => 2,
 				),
 			),
 			$layout_by_uuid['default-subscribers-list-widget-instance']
+		);
+		$this->assertSame(
+			array(
+				'uuid'       => 'default-subscribers-emails-widget-instance',
+				'type'       => 'jpa/stats-emails',
+				'attributes' => array(
+					'max'    => 10,
+					'metric' => 'opens',
+				),
+				'placement'  => array(
+					'width'  => 2,
+					'height' => 2,
+					'order'  => 3,
+				),
+			),
+			$layout_by_uuid['default-subscribers-emails-widget-instance']
 		);
 		$this->assertSame(
 			get_dashboard_default_layout_for( DASHBOARD_SUBSCRIBERS_SECTION_ID ),


### PR DESCRIPTION
Part of WOOA7S-1617

## Proposed changes

* Seed the Emails widget (`jpa/stats-emails`) in the Subscribers tab's default layout, beside the subscribers list, matching the Subscribers page composition.
* Make the Subscriber highlights and Subscribers chart full width so they span the grid at every breakpoint.
* Render the subscribers list and Emails as side-by-side half-width widgets.



## Related product discussion/links

* WOOA7S-1617
* WOOA7S-1728

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open the Premium Analytics dashboard and switch to the **Subscribers** tab (reset the layout if you've already customized it).
* Confirm Subscriber highlights and the Subscribers chart render full width.
* Confirm the subscribers list and the Emails widget appear side by side below the chart.

Stats:
<img width="2391" height="1280" alt="Screenshot 2026-07-14 at 3 25 28 PM" src="https://github.com/user-attachments/assets/21fd9d28-4693-449e-a2b2-311cf69bb527" />

Premium Analytics:
<img width="2546" height="1288" alt="Screenshot 2026-07-14 at 3 17 57 PM" src="https://github.com/user-attachments/assets/3b8f8167-e5bd-49a7-ab38-fb5560652536" />


## Follow-up

* WOOA7S-1728 — the ported Subscriber highlights widget diverges from upstream's "All-time stats" section in content (missing the 30/60/90-day growth cards, adds a Social card); tracked separately.