### PR TITLE
Search Blocks: add basic HTML support to no-results messages

### DIFF
--- a/projects/packages/search/changelog/add-search-blocks-no-results-html-support
+++ b/projects/packages/search/changelog/add-search-blocks-no-results-html-support
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add support for basic inline HTML (links, emphasis, line breaks) in the Results List no-results messages.

--- a/projects/packages/search/src/search-blocks/blocks/results-list/edit.jsx
+++ b/projects/packages/search/src/search-blocks/blocks/results-list/edit.jsx
@@ -15,7 +15,13 @@
  * names.
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
-import { Button, PanelBody, RadioControl, TextControl } from '@wordpress/components';
+import {
+	Button,
+	PanelBody,
+	RadioControl,
+	TextControl,
+	TextareaControl,
+} from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { __, _n, sprintf } from '@wordpress/i18n';
 
@@ -217,27 +223,25 @@ export default function ResultsListEdit( { attributes, setAttributes, clientId }
 						options={ LAYOUT_OPTIONS() }
 						onChange={ value => setAttributes( { layout: value } ) }
 					/>
-					<TextControl
-						__next40pxDefaultSize
+					<TextareaControl
 						__nextHasNoMarginBottom
 						label={ __( 'No-results message', 'jetpack-search-pkg' ) }
 						value={ attributes?.noResultsMessage || '' }
 						placeholder={ noResultsDefault }
 						onChange={ value => setAttributes( { noResultsMessage: value } ) }
 						help={ __(
-							'Shown when a search returns nothing. Leave empty for the default.',
+							'Shown when a search returns nothing. Basic HTML is supported: <a>, <strong>, <em>, <b>, <i>, and <br>. Leave empty for the default.',
 							'jetpack-search-pkg'
 						) }
 					/>
-					<TextControl
-						__next40pxDefaultSize
+					<TextareaControl
 						__nextHasNoMarginBottom
 						label={ __( 'No-results message (when filters are active)', 'jetpack-search-pkg' ) }
 						value={ attributes?.noResultsWithFiltersMessage || '' }
 						placeholder={ noResultsWithFiltersDefault }
 						onChange={ value => setAttributes( { noResultsWithFiltersMessage: value } ) }
 						help={ __(
-							'Shown when active filters return zero results. Leave empty for the default.',
+							'Shown when active filters return zero results. Basic HTML is supported: <a>, <strong>, <em>, <b>, <i>, and <br>. Leave empty for the default.',
 							'jetpack-search-pkg'
 						) }
 					/>

--- a/projects/packages/search/src/search-blocks/blocks/results-list/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/results-list/render.php
@@ -102,9 +102,29 @@ if ( function_exists( 'wp_interactivity_state' ) ) {
 $is_initial_loading = Search_Blocks::is_initial_loading();
 $skeleton_count     = 'compact' === $layout ? 6 : 4;
 
-// `trim()` so a whitespace-only attribute (e.g. an author who saved spaces)
-// still falls back to the default copy instead of rendering a blank message.
-$no_results_message = trim( (string) ( $attrs['noResultsMessage'] ?? '' ) );
+/*
+ * Basic inline HTML authors may use in the no-results messages (SEARCH-308).
+ * Anything outside this list is stripped by `wp_kses()`.
+ */
+$no_results_allowed_html = array(
+	'a'      => array(
+		'href'   => true,
+		'target' => true,
+		'rel'    => true,
+	),
+	'b'      => array(),
+	'br'     => array(),
+	'em'     => array(),
+	'i'      => array(),
+	'strong' => array(),
+);
+
+/*
+ * Sanitize before the trim check so a message that kses strips to nothing
+ * (or a whitespace-only attribute an author saved) still falls back to the
+ * default copy instead of rendering a blank message.
+ */
+$no_results_message = trim( wp_kses( (string) ( $attrs['noResultsMessage'] ?? '' ), $no_results_allowed_html ) );
 if ( '' === $no_results_message ) {
 	$no_results_message = __( 'No results found. Try a different search.', 'jetpack-search-pkg' );
 }
@@ -112,7 +132,7 @@ if ( '' === $no_results_message ) {
 // Filter-aware variant — shown when `state.hasActiveFilters` is true. Both
 // variants live in the markup so the store's existing reactive getter picks
 // which `<p>` is visible without a store-side message-resolution branch.
-$no_results_with_filters_message = trim( (string) ( $attrs['noResultsWithFiltersMessage'] ?? '' ) );
+$no_results_with_filters_message = trim( wp_kses( (string) ( $attrs['noResultsWithFiltersMessage'] ?? '' ), $no_results_allowed_html ) );
 if ( '' === $no_results_with_filters_message ) {
 	$no_results_with_filters_message = __( 'No results match these filters. Try clearing some, or searching for something else.', 'jetpack-search-pkg' );
 }
@@ -344,8 +364,8 @@ if ( '' === $error_message ) {
 		// adding initial `hidden` to one of the variants, or both messages
 		// will flash briefly on hydration.
 		?>
-		<p data-wp-bind--hidden="state.hasActiveFilters"><?php echo esc_html( $no_results_message ); ?></p>
-		<p data-wp-bind--hidden="!state.hasActiveFilters"><?php echo esc_html( $no_results_with_filters_message ); ?></p>
+		<p data-wp-bind--hidden="state.hasActiveFilters"><?php echo wp_kses( $no_results_message, $no_results_allowed_html ); ?></p>
+		<p data-wp-bind--hidden="!state.hasActiveFilters"><?php echo wp_kses( $no_results_with_filters_message, $no_results_allowed_html ); ?></p>
 	</div>
 	<div
 		class="jetpack-search-results__error"

--- a/projects/packages/search/tests/js/search-blocks/results-list-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/results-list-edit.test.jsx
@@ -66,6 +66,20 @@ jest.mock( '@wordpress/components', () => ( {
 			</>
 		);
 	},
+	TextareaControl: ( { label, value, onChange, placeholder } ) => {
+		const id = `textarea-${ String( label ).toLowerCase().replace( /\s+/g, '-' ) }`;
+		return (
+			<>
+				<label htmlFor={ id }>{ label }</label>
+				<textarea
+					id={ id }
+					value={ value || '' }
+					placeholder={ placeholder }
+					onChange={ event => onChange( event.target.value ) }
+				/>
+			</>
+		);
+	},
 } ) );
 
 jest.mock( '@wordpress/i18n', () => ( {
@@ -282,11 +296,21 @@ describe( 'ResultsListEdit', () => {
 		);
 
 		// The success-state preview is the only thing rendered on the canvas;
-		// the empty and error copy live in the Inspector controls only.
+		// the empty and error copy live in the Inspector controls only. The
+		// no-results fields are textareas, whose values surface as text
+		// content, so assert any match sits inside the Inspector rather than
+		// expecting zero matches document-wide.
 		expect( screen.getByText( 'First sample result' ) ).toBeInTheDocument();
-		expect( screen.queryByText( 'Try a broader query.' ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( 'Clear a filter to see results.' ) ).not.toBeInTheDocument();
-		expect( screen.queryByText( 'Search is offline right now.' ) ).not.toBeInTheDocument();
+		const inspector = screen.getByTestId( 'inspector' );
+		for ( const copy of [
+			'Try a broader query.',
+			'Clear a filter to see results.',
+			'Search is offline right now.',
+		] ) {
+			for ( const element of screen.queryAllByText( copy ) ) {
+				expect( inspector ).toContainElement( element );
+			}
+		}
 	} );
 } );
 

--- a/projects/packages/search/tests/php/Results_List_Render_Test.php
+++ b/projects/packages/search/tests/php/Results_List_Render_Test.php
@@ -313,8 +313,14 @@ class Results_List_Render_Test extends TestCase {
 			)
 		);
 		$this->assertStringNotContainsString( '<script>', $markup );
-		$this->assertStringNotContainsString( '<img', $markup );
-		$this->assertStringContainsString( 'Nothing found.', $markup );
+		$this->assertStringNotContainsString( 'onerror', $markup );
+		// Scoped to the message `<p>` — the results template legitimately
+		// contains an `<img>` (the result thumbnail), so assert the tags were
+		// stripped from the message itself rather than the whole markup.
+		$this->assertStringContainsString(
+			'<p data-wp-bind--hidden="state.hasActiveFilters">alert(1)Nothing found.</p>',
+			$markup
+		);
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Results_List_Render_Test.php
+++ b/projects/packages/search/tests/php/Results_List_Render_Test.php
@@ -24,15 +24,19 @@ class Results_List_Render_Test extends TestCase {
 			'jetpack-search/results-list',
 			array(
 				'attributes'      => array(
-					'layout'           => array(
+					'layout'                      => array(
 						'type'    => 'string',
 						'default' => 'expanded',
 					),
-					'noResultsMessage' => array(
+					'noResultsMessage'            => array(
 						'type'    => 'string',
 						'default' => '',
 					),
-					'errorMessage'     => array(
+					'noResultsWithFiltersMessage' => array(
+						'type'    => 'string',
+						'default' => '',
+					),
+					'errorMessage'                => array(
 						'type'    => 'string',
 						'default' => '',
 					),
@@ -271,13 +275,67 @@ class Results_List_Render_Test extends TestCase {
 	}
 
 	/**
-	 * Both message attributes are user-controlled, so the template must
-	 * escape HTML to prevent stored XSS through a crafted attribute value.
+	 * The no-results messages support a small allowlist of inline HTML
+	 * (SEARCH-308) — links, emphasis, and line breaks survive rendering.
 	 */
-	public function test_no_results_message_is_html_escaped() {
-		$markup = $this->render( array( 'noResultsMessage' => '<script>alert(1)</script>' ) );
-		$this->assertStringNotContainsString( '<script>alert(1)</script>', $markup );
-		$this->assertStringContainsString( '&lt;script&gt;alert(1)&lt;/script&gt;', $markup );
+	public function test_no_results_message_keeps_allowed_inline_html() {
+		$markup = $this->render(
+			array(
+				'noResultsMessage' => 'Try <a href="/archive" target="_blank" rel="noopener">the archive</a> or <strong>browse</strong>.',
+			)
+		);
+		$this->assertStringContainsString( '<a href="/archive" target="_blank" rel="noopener">the archive</a>', $markup );
+		$this->assertStringContainsString( '<strong>browse</strong>', $markup );
+	}
+
+	/**
+	 * The filter-aware variant runs through the same kses allowlist.
+	 */
+	public function test_no_results_with_filters_message_keeps_allowed_inline_html() {
+		$markup = $this->render(
+			array(
+				'noResultsWithFiltersMessage' => 'Clear filters or <a href="/help">get help</a>.',
+			)
+		);
+		$this->assertStringContainsString( '<a href="/help">get help</a>.', $markup );
+		$this->assertStringNotContainsString( 'No results match these filters.', $markup );
+	}
+
+	/**
+	 * The message attributes are user-controlled, so anything outside the
+	 * allowlist must be stripped to prevent stored XSS through a crafted
+	 * attribute value.
+	 */
+	public function test_no_results_message_strips_disallowed_html() {
+		$markup = $this->render(
+			array(
+				'noResultsMessage' => '<script>alert(1)</script><img src="x" onerror="alert(1)">Nothing found.',
+			)
+		);
+		$this->assertStringNotContainsString( '<script>', $markup );
+		$this->assertStringNotContainsString( '<img', $markup );
+		$this->assertStringContainsString( 'Nothing found.', $markup );
+	}
+
+	/**
+	 * Disallowed attributes on allowed tags are stripped while the tag
+	 * itself survives.
+	 */
+	public function test_no_results_message_strips_disallowed_attributes() {
+		$markup = $this->render(
+			array( 'noResultsMessage' => '<a href="/x" onclick="alert(1)">link</a>' )
+		);
+		$this->assertStringContainsString( '<a href="/x">link</a>', $markup );
+		$this->assertStringNotContainsString( 'onclick', $markup );
+	}
+
+	/**
+	 * A message kses strips to nothing (e.g. a lone disallowed tag) falls
+	 * back to the default copy instead of rendering a blank message.
+	 */
+	public function test_no_results_message_that_sanitizes_to_nothing_falls_back_to_default() {
+		$markup = $this->render( array( 'noResultsMessage' => '<img src="x">' ) );
+		$this->assertStringContainsString( 'No results found. Try a different search.', $markup );
 	}
 
 	/**


### PR DESCRIPTION
Fixes SEARCH-308

## Proposed changes

* Search Blocks: the Results List block's "No-results message" and "No-results message (when filters are active)" settings now support basic inline HTML — `a` (`href`, `target`, `rel`), `strong`, `em`, `b`, `i`, and `br`. Anything outside that allowlist is stripped with `wp_kses()` (previously the whole message was flattened to plain text with `esc_html()`).
* A message that sanitizes to nothing (e.g. a lone disallowed tag) falls back to the default copy instead of rendering blank.
* The two inspector fields are now `TextareaControl`s (HTML messages tend to be a full paragraph with links) and their help text lists the supported tags.
* The error message is unchanged (plain text) — it's a `role="alert"` region and out of scope for this request.

## Related product discussion/links

* Linear: SEARCH-308

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site with the Search blocks experience enabled (`wp option update jetpack_search_experience embedded`), open the Site Editor and edit the Jetpack Search template.
* Select the **Results List** block and, in the inspector, set the **No-results message** to something like:
  `Nothing found. Try <a href="/archive"><strong>browsing the archive</strong></a>.`
* On the front end, search for gibberish that returns no results — the message should render with a working link and bold text.
* Repeat for the **No-results message (when filters are active)** field with a filter applied.
* Verify disallowed markup is stripped: set the message to `<script>alert(1)</script><img src=x onerror=alert(1)>hello` and confirm only `hello` renders (no script execution, no image).
* PHP tests: `cd projects/packages/search && composer phpunit -- --filter Results_List_Render_Test`

| Before | After |
| ------ | ----- |
|<img width="516" height="358" alt="Screenshot 2026-07-14 at 12 54 07 PM" src="https://github.com/user-attachments/assets/8b5d878c-6ace-4081-b623-4ae37fe84791" />|<img width="515" height="350" alt="Screenshot 2026-07-14 at 12 53 52 PM" src="https://github.com/user-attachments/assets/1ecf8c6a-c29a-4e0b-9dd8-7d2328b9c3d3" />|
|<img width="285" height="542" alt="Screenshot 2026-07-14 at 12 58 15 PM" src="https://github.com/user-attachments/assets/52a119d5-768b-4f02-826e-8d92ca3604c1" />|<img width="273" height="643" alt="Screenshot 2026-07-14 at 12 57 39 PM" src="https://github.com/user-attachments/assets/393114bc-c2f8-458a-846e-5db35a64dc56" />|
