### PR TITLE
Premium Analytics: add WordAds highlights widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1729-wordads-highlights
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1729-wordads-highlights
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Premium Analytics: add the WordAds highlights widget showing all-time earnings totals (Earnings, Paid, Outstanding amount).

--- a/projects/packages/premium-analytics/changelog/wooa7s-1729-wordads-highlights
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1729-wordads-highlights
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Premium Analytics: add the WordAds highlights widget showing all-time earnings totals (Earnings, Paid, Outstanding amount).
+Add the WordAds highlights widget showing all-time earnings, paid, and outstanding totals.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -87,6 +87,7 @@ const STATS_VIDEO_PLAYS_PATH = '/jetpack-premium-analytics/v1/proxy/v1.1/stats/v
 // own path branch rather than a `routeStatsReport()` case.
 const STATS_PLAN_USAGE_PATH = '/jetpack-premium-analytics/v1/proxy/v2/jetpack-stats/usage';
 const STATS_WORDADS_STATS_PATH = '/jetpack-premium-analytics/v1/proxy/v1.1/wordads/stats';
+const STATS_WORDADS_EARNINGS_PATH = '/jetpack-premium-analytics/v1/proxy/v1.1/wordads/earnings';
 // Post likes is a `posts/{id}/likes` proxy path (not under /stats), so it is
 // matched with its own pattern rather than through routeStatsReport().
 const POST_LIKES_PATH_PATTERN =
@@ -1149,6 +1150,32 @@ function buildWordAdsStatsResponse( query: URLSearchParams ) {
 	};
 }
 
+/**
+ * Builds the wordads/earnings response for the WordAds earnings widget.
+ *
+ * The earnings module reports all-time totals (not period-scoped), so this
+ * returns a fixed raw WPCOM payload: `total_earnings` and `total_amount_owed`
+ * feed the widget's Earnings / Paid / Outstanding cards (paid = earnings −
+ * owed). The per-period breakdowns are included for shape fidelity even though
+ * the highlights widget does not read them.
+ *
+ * @return Raw wordads/earnings response in the WPCOM shape.
+ */
+function buildWordAdsEarningsResponse() {
+	return {
+		earnings: {
+			total_earnings: 1284.57,
+			total_amount_owed: 342.19,
+			wordads: {
+				'2026-06': { amount: 212.34, pageviews: 84210, status: 1 },
+				'2026-05': { amount: 198.72, pageviews: 79880, status: 2 },
+			},
+			sponsored: {},
+			adjustment: {},
+		},
+	};
+}
+
 const reportMocksMiddleware: APIFetchMiddleware = async ( options: APIFetchOptions, next ) => {
 	const requestPath = options.path ?? options.url ?? '';
 
@@ -1227,6 +1254,10 @@ const reportMocksMiddleware: APIFetchMiddleware = async ( options: APIFetchOptio
 		return buildWordAdsStatsResponse(
 			new URLSearchParams( queryIndex === -1 ? '' : requestPath.slice( queryIndex + 1 ) )
 		);
+	}
+
+	if ( requestPath.startsWith( STATS_WORDADS_EARNINGS_PATH ) ) {
+		return buildWordAdsEarningsResponse();
 	}
 
 	if ( requestPath.startsWith( STATS_API_BASE ) ) {

--- a/projects/packages/premium-analytics/widgets/wordads-highlights/__tests__/wordads-highlights.test.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-highlights/__tests__/wordads-highlights.test.tsx
@@ -95,11 +95,10 @@ describe( 'WordAdsHighlightsWidget', () => {
 		expect( screen.queryByText( 'Outstanding amount' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'prompts to select a metric when the metrics attribute is empty', async () => {
+	it( 'prompts to select a metric without requesting earnings when metrics are empty', () => {
 		render( <WordAdsHighlightsWidget attributes={ { metrics: [] } } /> );
 
-		await expect(
-			screen.findByText( 'Select at least one metric to display.' )
-		).resolves.toBeInTheDocument();
+		expect( screen.getByText( 'Select at least one metric to display.' ) ).toBeInTheDocument();
+		expect( mockApiFetch ).not.toHaveBeenCalled();
 	} );
 } );

--- a/projects/packages/premium-analytics/widgets/wordads-highlights/__tests__/wordads-highlights.test.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-highlights/__tests__/wordads-highlights.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * External dependencies
+ */
+import { queryClient } from '@jetpack-premium-analytics/data';
+import { render, screen } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+/**
+ * Internal dependencies
+ */
+import WordAdsHighlightsWidget from '../render';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+// WidgetRoot reads URL search params as a fallback for report params; outside
+// a matched route the real hook warns and throws.
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => ( {} ),
+} ) );
+
+const mockApiFetch = apiFetch as unknown as jest.Mock;
+
+// total_earnings − total_amount_owed = paid, so Earnings/$1,200.00,
+// Paid/$900.00, Outstanding/$300.00 pin both the field wiring and the
+// subtraction.
+const EARNINGS_RESPONSE = {
+	earnings: {
+		total_earnings: 1200,
+		total_amount_owed: 300,
+	},
+};
+
+describe( 'WordAdsHighlightsWidget', () => {
+	beforeEach( () => {
+		// The data package's query client is a module-level singleton; drop its
+		// cache so each test starts from a fresh fetch.
+		queryClient.clear();
+		mockApiFetch.mockReset();
+		mockApiFetch.mockResolvedValue( EARNINGS_RESPONSE );
+	} );
+
+	it( 'requests the wordads/earnings endpoint and renders every earnings card', async () => {
+		render( <WordAdsHighlightsWidget attributes={ {} } /> );
+
+		await expect( screen.findByText( 'Earnings' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( 'Paid' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Outstanding amount' ) ).toBeInTheDocument();
+
+		const requestedPath = mockApiFetch.mock.calls[ 0 ][ 0 ].path as string;
+		expect( requestedPath ).toContain( 'proxy/v1.1/wordads/earnings' );
+	} );
+
+	it( 'maps earnings to Earnings, derives Paid as earnings − outstanding, and shows Outstanding', async () => {
+		render( <WordAdsHighlightsWidget attributes={ {} } /> );
+
+		await expect( screen.findByText( 'Earnings' ) ).resolves.toBeInTheDocument();
+
+		// Tiles render in a fixed order: Earnings, Paid, Outstanding. Reading the
+		// currency values in document order pins the field-to-tile wiring and the
+		// paid subtraction (1200 − 300 = 900).
+		const values = screen.getAllByText( /^\$[\d,]+\.\d{2}$/ ).map( el => el.textContent );
+		expect( values ).toEqual( [ '$1,200.00', '$900.00', '$300.00' ] );
+	} );
+
+	it( 'shows the error state when the earnings request fails', async () => {
+		// Reject with a non-retryable (403) error so React Query surfaces the
+		// error state immediately instead of retrying with backoff.
+		mockApiFetch.mockRejectedValue( { status: 403, message: 'Forbidden' } );
+
+		render( <WordAdsHighlightsWidget attributes={ {} } /> );
+
+		await expect(
+			screen.findByText( "We couldn't load WordAds earnings. Please try again in a moment." )
+		).resolves.toBeInTheDocument();
+		expect( screen.queryByText( 'Earnings' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the loading overlay while the earnings request is pending', () => {
+		// A promise that never settles keeps the query in its loading state.
+		mockApiFetch.mockReturnValue( new Promise( () => {} ) );
+
+		const { container } = render( <WordAdsHighlightsWidget attributes={ {} } /> );
+
+		// WidgetLoadingOverlay renders a WP Spinner (role="presentation", no
+		// accessible name), so the class is the only stable handle for it.
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- No accessible role/text on the spinner to query.
+		expect( container.querySelector( '.components-spinner' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Earnings' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'hides a card when it is not in the metrics attribute', async () => {
+		render( <WordAdsHighlightsWidget attributes={ { metrics: [ 'earnings' ] } } /> );
+
+		await expect( screen.findByText( 'Earnings' ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( 'Paid' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Outstanding amount' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'prompts to select a metric when the metrics attribute is empty', async () => {
+		render( <WordAdsHighlightsWidget attributes={ { metrics: [] } } /> );
+
+		await expect(
+			screen.findByText( 'Select at least one metric to display.' )
+		).resolves.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/wordads-highlights/__tests__/wordads-highlights.test.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-highlights/__tests__/wordads-highlights.test.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { queryClient } from '@jetpack-premium-analytics/data';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
@@ -72,6 +72,36 @@ describe( 'WordAdsHighlightsWidget', () => {
 			screen.findByText( "We couldn't load WordAds earnings. Please try again in a moment." )
 		).resolves.toBeInTheDocument();
 		expect( screen.queryByText( 'Earnings' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'recovers via Retry after a failed earnings request', async () => {
+		// Only the first request fails, so the tiles below can only come from the
+		// Retry action's refetch.
+		mockApiFetch.mockRejectedValueOnce( { status: 403, message: 'Forbidden' } );
+
+		render( <WordAdsHighlightsWidget attributes={ {} } /> );
+
+		await expect(
+			screen.findByText( "We couldn't load WordAds earnings. Please try again in a moment." )
+		).resolves.toBeInTheDocument();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Retry' } ) ); // eslint-disable-line testing-library/prefer-user-event -- @testing-library/user-event is not a direct dep of this package.
+
+		await expect( screen.findByText( '$1,200.00' ) ).resolves.toBeInTheDocument();
+	} );
+
+	it( 'renders a zero balance as $0.00 rather than an empty state', async () => {
+		// A site that just enabled WordAds: the endpoint reports no totals, which
+		// the sanitizer resolves to real zeros. That is data — a zero balance is a
+		// valid amount, not an absence of earnings.
+		mockApiFetch.mockResolvedValue( { earnings: {} } );
+
+		render( <WordAdsHighlightsWidget attributes={ {} } /> );
+
+		await expect( screen.findByText( 'Earnings' ) ).resolves.toBeInTheDocument();
+
+		const values = screen.getAllByText( /^\$[\d,]+\.\d{2}$/ ).map( el => el.textContent );
+		expect( values ).toEqual( [ '$0.00', '$0.00', '$0.00' ] );
 	} );
 
 	it( 'shows the loading overlay while the earnings request is pending', () => {

--- a/projects/packages/premium-analytics/widgets/wordads-highlights/package.json
+++ b/projects/packages/premium-analytics/widgets/wordads-highlights/package.json
@@ -1,0 +1,17 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-wordads-highlights",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/fields": "link:../../packages/fields",
+		"@jetpack-premium-analytics/icons": "link:../../packages/icons",
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^15.0.0",
+		"@wordpress/ui": "0.17.0",
+		"@wordpress/widget-primitives": "0.2.0",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/wordads-highlights/package.json
+++ b/projects/packages/premium-analytics/widgets/wordads-highlights/package.json
@@ -10,7 +10,6 @@
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^15.0.0",
-		"@wordpress/ui": "0.17.0",
 		"@wordpress/widget-primitives": "0.2.0",
 		"react": "18.3.1"
 	}

--- a/projects/packages/premium-analytics/widgets/wordads-highlights/render.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-highlights/render.tsx
@@ -1,0 +1,135 @@
+/**
+ * External dependencies
+ */
+import {
+	useStatsWordAdsEarnings,
+	type StatsWordAdsEarningsResponse,
+} from '@jetpack-premium-analytics/data';
+import { megaphone } from '@jetpack-premium-analytics/icons';
+import {
+	MetricTileGrid,
+	WidgetRoot,
+	WidgetState,
+	type DataFormat,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { __ } from '@wordpress/i18n';
+import { payment, receipt, tip } from '@wordpress/icons';
+/**
+ * Internal dependencies
+ */
+import styles from './style.module.css';
+import {
+	DEFAULT_WORDADS_EARNINGS_METRICS,
+	WORDADS_EARNINGS_METRICS,
+	type WordAdsEarningsMetricId,
+	type WordAdsHighlightsAttributes,
+} from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+
+// The wordads/earnings endpoint reports all-time totals and is not
+// period-scoped, so the widget ignores the dashboard date range. Report params
+// are still accepted at the WidgetRoot boundary (and Storybook may inject them)
+// so the host contract holds.
+type WordAdsHighlightsRenderAttributes = WordAdsHighlightsAttributes &
+	Partial< ReportParamsFieldAttributes >;
+type WordAdsHighlightsWidgetProps = WidgetRenderProps< WordAdsHighlightsRenderAttributes >;
+
+// Earnings are currency; formatCurrency renders the connected site's WordAds
+// payouts, which are always denominated in USD.
+const CURRENCY_FORMAT: DataFormat = { type: 'currency', options: { decimals: 2 } };
+
+/**
+ * Render-only config per card: the tile icon and the earnings value it shows.
+ * Ids and labels are shared with the settings checkboxes via
+ * `WORDADS_EARNINGS_METRICS` in `widget.ts`. "Paid" is derived — the payload
+ * carries total earnings and the outstanding balance, and paid is their
+ * difference — matching the Calypso WordAds Totals section.
+ */
+const TILE_CONFIG: Record<
+	WordAdsEarningsMetricId,
+	{ icon: typeof payment; value: ( data?: StatsWordAdsEarningsResponse ) => number }
+> = {
+	earnings: { icon: payment, value: data => data?.total_earnings ?? 0 },
+	paid: {
+		icon: receipt,
+		value: data => ( data ? data.total_earnings - data.total_amount_owed : 0 ),
+	},
+	outstanding: { icon: tip, value: data => data?.total_amount_owed ?? 0 },
+};
+
+/**
+ * Fetches WordAds earnings through the designated `useStatsWordAdsEarnings` hook
+ * and renders the totals as a currency `MetricTileGrid`. The earnings module has
+ * no comparison period, so each tile shows a bare formatted amount. Which cards
+ * appear is controlled by the `metrics` attribute.
+ *
+ * @param {WordAdsEarningsMetricId[]} metrics - Enabled earnings card ids.
+ * @return The widget content.
+ */
+function WordAdsHighlightsReport( {
+	metrics = DEFAULT_WORDADS_EARNINGS_METRICS,
+}: {
+	metrics?: WordAdsEarningsMetricId[];
+} ) {
+	const { data, isLoading, isFetching, isError, refetch } = useStatsWordAdsEarnings();
+	const enabledMetrics = new Set( metrics );
+
+	const tiles = WORDADS_EARNINGS_METRICS.filter( ( { id } ) => enabledMetrics.has( id ) ).map(
+		( { id, label } ) => ( {
+			key: id,
+			label,
+			icon: TILE_CONFIG[ id ].icon,
+			value: TILE_CONFIG[ id ].value( data ),
+		} )
+	);
+
+	return (
+		<div className={ styles.root }>
+			<WidgetState
+				isLoading={ isLoading }
+				isFetching={ isFetching }
+				isError={ isError }
+				isEmpty={ tiles.length === 0 }
+				error={ {
+					description: __(
+						"We couldn't load WordAds earnings. Please try again in a moment.",
+						'jetpack-premium-analytics'
+					),
+					actions: [
+						{
+							label: __( 'Retry', 'jetpack-premium-analytics' ),
+							onClick: () => {
+								refetch();
+							},
+						},
+					],
+				} }
+				empty={ {
+					icon: megaphone,
+					description: __( 'Select at least one metric to display.', 'jetpack-premium-analytics' ),
+				} }
+			>
+				<MetricTileGrid tiles={ tiles } dataFormat={ CURRENCY_FORMAT } currencyCode="USD" />
+			</WidgetState>
+		</div>
+	);
+}
+
+/**
+ * Widget render entry point.
+ *
+ * WidgetRoot provides the analytics query client and chart theme consumed by the
+ * inner report. Host attributes are forwarded so any injected report params are
+ * preserved even though the earnings endpoint is not period-scoped.
+ *
+ * @param {WordAdsHighlightsWidgetProps} props - The widget render props.
+ * @return The rendered widget.
+ */
+export default function WordAdsHighlights( { attributes = {} }: WordAdsHighlightsWidgetProps ) {
+	return (
+		<WidgetRoot attributes={ attributes }>
+			<WordAdsHighlightsReport metrics={ attributes.metrics } />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/wordads-highlights/render.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-highlights/render.tsx
@@ -72,8 +72,11 @@ function WordAdsHighlightsReport( {
 }: {
 	metrics?: WordAdsEarningsMetricId[];
 } ) {
-	const { data, isLoading, isFetching, isError, refetch } = useStatsWordAdsEarnings();
 	const enabledMetrics = new Set( metrics );
+	const hasEnabledMetrics = WORDADS_EARNINGS_METRICS.some( ( { id } ) => enabledMetrics.has( id ) );
+	const { data, isLoading, isFetching, isError, refetch } = useStatsWordAdsEarnings( undefined, {
+		enabled: hasEnabledMetrics,
+	} );
 
 	const tiles = WORDADS_EARNINGS_METRICS.filter( ( { id } ) => enabledMetrics.has( id ) ).map(
 		( { id, label } ) => ( {
@@ -90,7 +93,7 @@ function WordAdsHighlightsReport( {
 				isLoading={ isLoading }
 				isFetching={ isFetching }
 				isError={ isError }
-				isEmpty={ tiles.length === 0 }
+				isEmpty={ ! hasEnabledMetrics }
 				error={ {
 					description: __(
 						"We couldn't load WordAds earnings. Please try again in a moment.",

--- a/projects/packages/premium-analytics/widgets/wordads-highlights/stories/wordads-highlights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-highlights/stories/wordads-highlights-widget.stories.tsx
@@ -1,0 +1,242 @@
+/**
+ * External dependencies
+ */
+import { getDefaultQueryParams, queryClient } from '@jetpack-premium-analytics/data';
+/**
+ * Internal dependencies
+ */
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import WordAdsHighlightsRender from '../render';
+import widgetDefinition, {
+	DEFAULT_WORDADS_EARNINGS_METRICS,
+	type WordAdsEarningsMetricId,
+} from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+const WORDADS_HIGHLIGHTS_RENDER_MODULE = 'storybook/wordads-highlights';
+
+// Endpoint fragment the forced-state stories toggle. The earnings query takes no
+// date params, so every story shares one query key — the forced-state stories
+// clear the query cache (below) rather than isolating via distinct date presets
+// the way period-scoped widgets (e.g. Search Terms) do.
+const EARNINGS_ENDPOINT = 'wordads/earnings';
+
+// Carry the widget's metadata, including the metric-visibility attribute schema
+// so the dashboard story's settings drawer renders the real checkboxes.
+// Presentation is left unset so the host frames the widget and renders its
+// identity (title + icon), matching widget.json.
+const storyWidgetType = {
+	name: widgetDefinition.name,
+	title: widgetDefinition.title,
+	icon: widgetDefinition.icon,
+	help: widgetDefinition.help,
+	attributes: widgetDefinition.attributes as WidgetType[ 'attributes' ],
+	example: widgetDefinition.example,
+};
+
+interface WordAdsHighlightsStoryControls {
+	/**
+	 * Whether to inject comparison report params.
+	 */
+	withComparison: boolean;
+	/**
+	 * Earnings cards to show in the widget body.
+	 */
+	metrics: WordAdsEarningsMetricId[];
+}
+
+/**
+ * Renders the data-connected widget with report params derived from the
+ * comparison toggle and the selected metrics. The earnings endpoint is not
+ * period-scoped, so toggling comparison does not change what the widget shows
+ * — it is wired through only to prove the widget renders unchanged when the
+ * host injects comparison params.
+ *
+ * @param {WordAdsHighlightsStoryControls} props - Story controls.
+ * @return The rendered widget.
+ */
+function renderWordAdsHighlights( { withComparison, metrics }: WordAdsHighlightsStoryControls ) {
+	return (
+		<WordAdsHighlightsRender
+			attributes={ {
+				reportParams: getDefaultQueryParams( withComparison ),
+				metrics,
+			} }
+		/>
+	);
+}
+
+const METRIC_ARG_TYPES = {
+	metrics: {
+		control: 'check',
+		options: DEFAULT_WORDADS_EARNINGS_METRICS,
+	},
+} as const;
+
+const ALL_METRICS_ARGS = {
+	metrics: DEFAULT_WORDADS_EARNINGS_METRICS,
+} as const;
+
+// Close-up canvas so the grid fills the frame outside the dashboard grid.
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '300px' } }>
+		<Story />
+	</div>
+);
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/WordAdsHighlights',
+	component: WordAdsHighlightsRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		withComparison: { control: 'boolean' },
+		...METRIC_ARG_TYPES,
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The "WordAds highlights" widget. Shows all-time WordAds payouts — total earnings, amount paid, and outstanding balance — as a grid of currency tiles (paid = earnings − outstanding). Ported from the Calypso WordAds "Totals" section. Which cards appear is controlled by the `metrics` attribute (`relevance: \'high\'`), exposed inline in the widget header and in the settings drawer. Data comes from the designated `useStatsWordAdsEarnings` hook; in Storybook it is served by `registerReportMocks()` (the `wordads/earnings` handler). The earnings module has no comparison period, so the tiles show bare amounts and the `WithComparison` story renders identically to `Default`.',
+			},
+		},
+	},
+} satisfies Meta<
+	ComponentProps< typeof WordAdsHighlightsRender > & WordAdsHighlightsStoryControls
+>;
+
+export default meta;
+
+type Story = StoryObj< WordAdsHighlightsStoryControls >;
+
+/**
+ * The widget on its own, populated from the mocked wordads/earnings payload.
+ */
+export const Default: Story = {
+	render: renderWordAdsHighlights,
+	args: { withComparison: false, ...ALL_METRICS_ARGS },
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * Same close-up with comparison report params injected. The earnings module has
+ * no comparison data, so this renders identically to `Default` — it only
+ * verifies the widget stays stable when the host provides comparison params.
+ */
+export const WithComparison: Story = {
+	render: renderWordAdsHighlights,
+	args: { withComparison: true, ...ALL_METRICS_ARGS },
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story. The query
+ * cache is cleared on enter/exit because the earnings query key has no date
+ * params to vary — without clearing it, a sibling story's cached success would
+ * be shown instead of the loading state.
+ */
+export const Loading: Story = {
+	render: renderWordAdsHighlights,
+	args: { withComparison: false, ...ALL_METRICS_ARGS },
+	// Kept off the shared autodocs page: the mock override is keyed by path, so it
+	// would otherwise force the sibling stories on that page into the same state.
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		queryClient.clear();
+		setReportMockState( EARNINGS_ENDPOINT, 'loading' );
+		return () => {
+			setReportMockState( EARNINGS_ENDPOINT, null );
+			queryClient.clear();
+		};
+	},
+};
+
+/**
+ * The fetch failed: the widget shows its error state with a Retry action (which
+ * re-runs the query — still mocked as failing while this story is active).
+ */
+export const Error: Story = {
+	render: renderWordAdsHighlights,
+	args: { withComparison: false, ...ALL_METRICS_ARGS },
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		queryClient.clear();
+		setReportMockState( EARNINGS_ENDPOINT, 'error' );
+		return () => {
+			setReportMockState( EARNINGS_ENDPOINT, null );
+			queryClient.clear();
+		};
+	},
+};
+
+/**
+ * No card selected: the widget shows its empty state ("Select at least one
+ * metric to display."). Unlike period-scoped widgets, WordAds earnings has no
+ * data-driven empty — a zero balance is a valid `$0.00`, not an empty state — so
+ * the empty state is reached by clearing the `metrics` attribute.
+ */
+export const Empty: Story = {
+	render: renderWordAdsHighlights,
+	args: { withComparison: false, metrics: [] },
+	decorators: [ withWidgetCanvas ],
+};
+
+interface WordAdsHighlightsDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		WordAdsHighlightsStoryControls {}
+
+/**
+ * Renders the real registered widget through the shared dashboard harness.
+ *
+ * @param {WordAdsHighlightsDashboardStoryProps} props - Dashboard and widget controls.
+ * @return The rendered dashboard with the widget.
+ */
+function WordAdsHighlightsDashboardStory( {
+	withComparison,
+	metrics,
+	...dashboardArgs
+}: WordAdsHighlightsDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardArgs }
+			widgetType={ storyWidgetType }
+			renderModule={ WORDADS_HIGHLIGHTS_RENDER_MODULE }
+			renderComponent={ WordAdsHighlightsRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ {
+				reportParams: getDefaultQueryParams( withComparison ),
+				metrics,
+			} }
+		/>
+	);
+}
+
+export const WidgetDashboardWithWidget: StoryObj< WordAdsHighlightsDashboardStoryProps > = {
+	render: args => <WordAdsHighlightsDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		widgetWidth: 1,
+		widgetHeight: 1,
+		withComparison: true,
+		...ALL_METRICS_ARGS,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		withComparison: { control: 'boolean' },
+		...METRIC_ARG_TYPES,
+	},
+};

--- a/projects/packages/premium-analytics/widgets/wordads-highlights/stories/wordads-highlights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-highlights/stories/wordads-highlights-widget.stories.tsx
@@ -11,6 +11,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
@@ -20,19 +21,13 @@ import widgetDefinition, {
 	DEFAULT_WORDADS_EARNINGS_METRICS,
 	type WordAdsEarningsMetricId,
 } from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
 
 const WORDADS_HIGHLIGHTS_RENDER_MODULE = 'storybook/wordads-highlights';
-
-// Endpoint fragment the forced-state stories toggle. The earnings query takes no
-// date params, so every story shares one query key — the forced-state stories
-// clear the query cache (below) rather than isolating via distinct date presets
-// the way period-scoped widgets (e.g. Search Terms) do.
-const EARNINGS_ENDPOINT = 'wordads/earnings';
 
 // Carry the widget's metadata, including the metric-visibility attribute schema
 // so the dashboard story's settings drawer renders the real checkboxes.
@@ -90,13 +85,6 @@ const ALL_METRICS_ARGS = {
 	metrics: DEFAULT_WORDADS_EARNINGS_METRICS,
 } as const;
 
-// Close-up canvas so the grid fills the frame outside the dashboard grid.
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '300px' } }>
-		<Story />
-	</div>
-);
-
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/WordAdsHighlights',
 	component: WordAdsHighlightsRender,
@@ -141,26 +129,31 @@ export const WithComparison: Story = {
 	decorators: [ withWidgetCanvas ],
 };
 
+// The earnings endpoint takes no params, so its query key is static and every
+// story in this file shares one cache entry (a distinct date preset can't
+// separate them — the query does not key on report params). Dropping the query
+// on story enter and exit gives each forced-state story a fresh fetch, and
+// clears a never-settling `loading` fetch before the other stories reuse the key.
+function resetWordAdsEarningsQuery() {
+	queryClient.removeQueries( { queryKey: [ 'stats', 'wordads-earnings' ] } );
+}
+
 /**
  * First load: the fetch is in flight, so the widget shows its loading state. The
- * mock is forced to never resolve for the duration of this story. The query
- * cache is cleared on enter/exit because the earnings query key has no date
- * params to vary — without clearing it, a sibling story's cached success would
- * be shown instead of the loading state.
+ * mock is forced to never resolve for the duration of this story.
  */
 export const Loading: Story = {
 	render: renderWordAdsHighlights,
 	args: { withComparison: false, ...ALL_METRICS_ARGS },
-	// Kept off the shared autodocs page: the mock override is keyed by path, so it
-	// would otherwise force the sibling stories on that page into the same state.
+	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {
-		queryClient.clear();
-		setReportMockState( EARNINGS_ENDPOINT, 'loading' );
+		resetWordAdsEarningsQuery();
+		setReportMockState( 'wordads/earnings', 'loading' );
 		return () => {
-			setReportMockState( EARNINGS_ENDPOINT, null );
-			queryClient.clear();
+			setReportMockState( 'wordads/earnings', null );
+			resetWordAdsEarningsQuery();
 		};
 	},
 };
@@ -175,11 +168,11 @@ export const Error: Story = {
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {
-		queryClient.clear();
-		setReportMockState( EARNINGS_ENDPOINT, 'error' );
+		resetWordAdsEarningsQuery();
+		setReportMockState( 'wordads/earnings', 'error' );
 		return () => {
-			setReportMockState( EARNINGS_ENDPOINT, null );
-			queryClient.clear();
+			setReportMockState( 'wordads/earnings', null );
+			resetWordAdsEarningsQuery();
 		};
 	},
 };

--- a/projects/packages/premium-analytics/widgets/wordads-highlights/style.module.css
+++ b/projects/packages/premium-analytics/widgets/wordads-highlights/style.module.css
@@ -1,0 +1,8 @@
+/* No outer padding: the host frames the widget and owns the padding. */
+.root {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	overflow-x: hidden;
+	overflow-y: auto;
+}

--- a/projects/packages/premium-analytics/widgets/wordads-highlights/widget.json
+++ b/projects/packages/premium-analytics/widgets/wordads-highlights/widget.json
@@ -2,6 +2,6 @@
 	"name": "jpa/wordads-highlights",
 	"title": "WordAds highlights",
 	"description": "Your WordAds earnings at a glance — total earnings, amount paid, and outstanding balance.",
-	"category": "traffic",
+	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/wordads-highlights/widget.json
+++ b/projects/packages/premium-analytics/widgets/wordads-highlights/widget.json
@@ -1,0 +1,7 @@
+{
+	"name": "jpa/wordads-highlights",
+	"title": "WordAds highlights",
+	"description": "Your WordAds earnings at a glance — total earnings, amount paid, and outstanding balance.",
+	"category": "traffic",
+	"presentation": "framed"
+}

--- a/projects/packages/premium-analytics/widgets/wordads-highlights/widget.ts
+++ b/projects/packages/premium-analytics/widgets/wordads-highlights/widget.ts
@@ -1,0 +1,80 @@
+/**
+ * External dependencies
+ */
+import { ArrayCheckboxField } from '@jetpack-premium-analytics/fields';
+import { megaphone } from '@jetpack-premium-analytics/icons';
+import { __ } from '@wordpress/i18n';
+import type { WidgetAttributeField } from '@wordpress/widget-primitives';
+
+/**
+ * The earnings cards the widget can show, in display order: the persisted id and
+ * label of each metric. Single source for the settings checkboxes and the
+ * rendered tiles so the two cannot drift apart; `render.tsx` maps the ids to
+ * icons and earnings fields.
+ */
+export const WORDADS_EARNINGS_METRICS = [
+	{ id: 'earnings', label: __( 'Earnings', 'jetpack-premium-analytics' ) },
+	{ id: 'paid', label: __( 'Paid', 'jetpack-premium-analytics' ) },
+	{ id: 'outstanding', label: __( 'Outstanding amount', 'jetpack-premium-analytics' ) },
+] as const satisfies readonly { id: string; label: string }[];
+
+/**
+ * Identifier persisted in the widget's `metrics` attribute for one earnings card.
+ */
+export type WordAdsEarningsMetricId = ( typeof WORDADS_EARNINGS_METRICS )[ number ][ 'id' ];
+
+/**
+ * Configurable attributes for the WordAds earnings widget. The widget has no
+ * date range — the `wordads/earnings` endpoint reports all-time totals and is
+ * not period-scoped.
+ */
+export type WordAdsHighlightsAttributes = {
+	/**
+	 * Earnings cards to show in the widget body.
+	 */
+	metrics?: WordAdsEarningsMetricId[];
+};
+
+/**
+ * Default selection for new widget instances: every card enabled.
+ */
+export const DEFAULT_WORDADS_EARNINGS_METRICS: WordAdsEarningsMetricId[] =
+	WORDADS_EARNINGS_METRICS.map( metric => metric.id );
+
+/**
+ * Widget type definition.
+ *
+ * `help` surfaces as an info popover in the widget header; its copy mirrors the
+ * Calypso WordAds payout notice explaining the payout threshold and timing.
+ * `example.attributes` doubles as the defaults applied to new instances: every
+ * card enabled.
+ */
+export default {
+	name: 'jpa/wordads-highlights',
+	title: __( 'WordAds highlights', 'jetpack-premium-analytics' ),
+	icon: megaphone,
+	help: {
+		content: __(
+			'Payment is made once your outstanding balance reaches $100, approximately 45 days after the end of the month in which it was earned.',
+			'jetpack-premium-analytics'
+		),
+	},
+	attributes: [
+		{
+			id: 'metrics',
+			label: __( 'Metrics', 'jetpack-premium-analytics' ),
+			type: 'array',
+			relevance: 'high',
+			Edit: ArrayCheckboxField,
+			elements: WORDADS_EARNINGS_METRICS.map( metric => ( {
+				value: metric.id,
+				label: metric.label,
+			} ) ),
+		},
+	] as WidgetAttributeField< WordAdsHighlightsAttributes >[],
+	example: {
+		attributes: {
+			metrics: DEFAULT_WORDADS_EARNINGS_METRICS,
+		},
+	},
+};


### PR DESCRIPTION
## Proposed changes

Adds a `jpa/wordads-highlights` widget to the Premium Analytics dashboard, porting the "Totals" section from the Calypso WordAds Stats page.

- Three USD cards: **Earnings**, **Paid** (`earnings − outstanding`), **Outstanding amount** — configurable via a `metrics` checkbox attribute.
- Reuses the existing `useStatsWordAdsEarnings()` hook (`wordads/earnings` proxy) — no new data-layer or proxy work. All-time totals, so it ignores the dashboard date range.
- Loading/error/empty via `WidgetState`; the Calypso payout notice is carried by the `help` field (plain text, matching upstream).
- Adds a `wordads/earnings` Storybook mock so stories render real data and forced states.

Out of scope: the WordAds earnings table, and wiring the widget into any default dashboard list.

## Related product discussion/links

- WOOA7S-1729

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Run Storybook and open **Packages / Premium Analytics / Widgets / WordAdsHighlights**; confirm Default, Loading, Error, and Empty render, and the dashboard story shows the "WordAds highlights" 


https://github.com/user-attachments/assets/4f664c4a-2dcd-445f-a268-85f60b922eef
