### PR TITLE
Content Guidelines AI: render the header button sooner

### DIFF
--- a/projects/plugins/jetpack/_inc/content-guidelines-ai.js
+++ b/projects/plugins/jetpack/_inc/content-guidelines-ai.js
@@ -5,9 +5,16 @@
  * Content Guidelines admin page (Gutenberg experimental feature).
  */
 import '@automattic/jetpack-shared-extension-utils/store/wordpress-com';
+import { select } from '@wordpress/data';
 import './content-guidelines-ai/store';
 import './content-guidelines-ai/style.scss';
 import { startInjection } from './content-guidelines-ai/lib/inject';
+
+// Warm the AI feature check now so it runs in parallel with the page's own
+// data loading. The resolver fires on the first select and its resolution is
+// cached, so components mounting later (only after Gutenberg renders the
+// guidelines list) attach to this request instead of starting it then.
+select( 'wordpress-com/plans' ).getAiAssistantFeature();
 
 if ( document.readyState === 'loading' ) {
 	document.addEventListener( 'DOMContentLoaded', startInjection );

--- a/projects/plugins/jetpack/_inc/content-guidelines-ai/components/suggest-all-button.jsx
+++ b/projects/plugins/jetpack/_inc/content-guidelines-ai/components/suggest-all-button.jsx
@@ -37,7 +37,14 @@ export default function SuggestAllButton() {
 	const hidden = ! bannerDismissed && hasFeature;
 	const hiddenProps = hidden ? { style: { display: 'none' }, 'aria-hidden': true } : {};
 
-	if ( ! featureResolved ) {
+	// Before the feature check resolves, only render when the banner was
+	// dismissed: in that state the button is visible on every plan and just
+	// morphs to the locked look if the check says no plan (the optimistic
+	// hasFeature default gives the unlocked presentation meanwhile, and
+	// useGenerateAll ignores clicks until the check answers). When the banner
+	// was not dismissed, button-vs-banner depends on the plan, so wait for
+	// the real answer to avoid rendering the wrong one.
+	if ( ! featureResolved && ! bannerDismissed ) {
 		return null;
 	}
 

--- a/projects/plugins/jetpack/_inc/content-guidelines-ai/hooks/use-generate-all.js
+++ b/projects/plugins/jetpack/_inc/content-guidelines-ai/hooks/use-generate-all.js
@@ -20,12 +20,25 @@ export default function useGenerateAll() {
 	const loading = useSelect( select => select( AI_STORE_NAME ).isLoading(), [] );
 	const { hasFeature } = useAiFeature();
 
+	const featureResolved = useSelect(
+		select => select( 'wordpress-com/plans' ).hasFinishedResolution( 'getAiAssistantFeature' ),
+		[]
+	);
+
 	const allGuidelines = useSelect( select => {
 		const store = select( STORE_NAME );
 		return Object.fromEntries( VALID_SECTIONS.map( slug => [ slug, store.getGuideline( slug ) ] ) );
 	}, [] );
 
 	const generate = useCallback( async () => {
+		// The header button can render before the feature check resolves (see
+		// SuggestAllButton). hasFeature is only an optimistic default until
+		// then — acting on it could fire a request destined to 403 on no-plan
+		// sites, surfacing a misleading error. Ignore clicks in that window.
+		if ( ! featureResolved ) {
+			return;
+		}
+
 		if ( ! hasFeature ) {
 			// No AI plan: surface the upgrade notice instead of generating. The
 			// click is a fresh intent signal, so the notice reappears even after
@@ -67,6 +80,7 @@ export default function useGenerateAll() {
 			stopLoading();
 		}
 	}, [
+		featureResolved,
 		hasFeature,
 		allGuidelines,
 		startLoading,

--- a/projects/plugins/jetpack/changelog/add-guidelines-early-header-button
+++ b/projects/plugins/jetpack/changelog/add-guidelines-early-header-button
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Content Guidelines AI: Start the AI feature check at script load instead of after the guidelines list renders, and render the header button immediately when the banner was already dismissed — removing most of the button's pop-in delay. Clicks are ignored during the brief window before the check resolves.


### PR DESCRIPTION
Fixes N/A — follow-up to #50224, addressing the header button's pop-in delay.

## Proposed changes

* Warm the `ai-assistant-feature` resolver at script load. The fetch previously started only when a component mounted — which happens after Gutenberg renders the guidelines list — so the two waits ran back-to-back. They now run in parallel, and the answer is usually in by the time the list exists.
* When the banner was already dismissed (known synchronously from the PHP preload), render the header button immediately instead of gating it on the feature check: in that state the button is visible on every plan, and it only swaps to the locked look (lock icon + tooltip) if the check answers no-plan. First-visit loads (banner not dismissed) keep the gate, since button-vs-banner genuinely depends on the plan.
* Guard `generate()` against the pre-resolution window, so an early click on a no-plan site can't fire a request destined to 403 and surface a misleading "Failed to generate guidelines" snackbar. Clicks in that sub-second window are ignored.

## Related product discussion/links
* Follow-up to the flow shipped in #50224; addresses the visible delay before the header button appears.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Site with an AI plan, banner previously dismissed:

* Go to Settings → Guidelines (`options-general.php?page=guidelines-wp-admin`).
* The header button should appear together with the page content — no separate pop-in a beat later. Clicking it immediately after load should either generate or do nothing (never error) — the no-op window is the sub-second before the feature check resolves.

Site without an AI plan, banner previously dismissed:

* The header button appears with the page content in the normal (Jetpack logo) look, then swaps to the lock icon + "Upgrade to unlock the AI assistant" tooltip when the feature check resolves (typically imperceptible; throttle the network to observe it).
* Clicking after the swap opens the upgrade notice as in #50224. Clicking during the pre-resolution window does nothing.

First visit (banner not dismissed) on either plan:

* Unchanged from #50224: the empty-state banner (paid) or upgrade notice + locked buttons (no plan) appear once the feature check resolves; the header button does not flash beforehand.
