### PR TITLE
Content Guidelines AI: preload the AI feature state from PHP

### DIFF
--- a/projects/js-packages/jetpack-shared-stores/changelog/add-guidelines-ai-feature-preload
+++ b/projects/js-packages/jetpack-shared-stores/changelog/add-guidelines-ai-feature-preload
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Export mapAiFeatureResponseToAiFeatureProps from the package barrel so consumers can hydrate the wordpress-com/plans store from a server-side preload of the ai-assistant-feature payload.

--- a/projects/js-packages/jetpack-shared-stores/src/store/wordpress-com/index.ts
+++ b/projects/js-packages/jetpack-shared-stores/src/store/wordpress-com/index.ts
@@ -16,6 +16,11 @@ import type { AiFeatureProps, PlanStateProps } from './types.ts';
 // barrel (the only entry point this package exposes).
 export type * from './types.ts';
 
+// Re-export the response mapper so consumers that receive the
+// ai-assistant-feature endpoint payload server-side (e.g. as a page preload)
+// can hydrate the store with it.
+export { mapAiFeatureResponseToAiFeatureProps } from './actions.ts';
+
 const store = 'wordpress-com/plans';
 
 export const selectors = {

--- a/projects/plugins/jetpack/_inc/content-guidelines-ai.js
+++ b/projects/plugins/jetpack/_inc/content-guidelines-ai.js
@@ -4,13 +4,31 @@
  * Injects Jetpack AI-powered generate/improve buttons into the
  * Content Guidelines admin page (Gutenberg experimental feature).
  */
+import { mapAiFeatureResponseToAiFeatureProps } from '@automattic/jetpack-shared-stores';
 import '@automattic/jetpack-shared-extension-utils/store/wordpress-com';
+import { dispatch } from '@wordpress/data';
 import './content-guidelines-ai/store';
 import './content-guidelines-ai/style.scss';
 import { startInjection } from './content-guidelines-ai/lib/inject';
 
-if ( document.readyState === 'loading' ) {
-	document.addEventListener( 'DOMContentLoaded', startInjection );
-} else {
-	startInjection();
+// The AI feature state is resolved server-side and preloaded into the page
+// (see _inc/content-guidelines-ai.php), so components render the correct
+// locked/unlocked state on first paint with no client-side plan fetch.
+// Without the preload (server-side lookup failed) render no AI UI at all —
+// the store's optimistic hasFeature default would show unlocked buttons
+// whose requests are destined to fail.
+const aiFeature = window.jetpackContentGuidelinesAi?.aiFeature;
+
+if ( aiFeature ) {
+	const plansDispatch = dispatch( 'wordpress-com/plans' );
+	plansDispatch.storeAiAssistantFeature( mapAiFeatureResponseToAiFeatureProps( aiFeature ) );
+	// Mark the selector resolved so its resolver never fires a redundant
+	// fetch when components select getAiAssistantFeature.
+	plansDispatch.finishResolution( 'getAiAssistantFeature', [] );
+
+	if ( document.readyState === 'loading' ) {
+		document.addEventListener( 'DOMContentLoaded', startInjection );
+	} else {
+		startInjection();
+	}
 }

--- a/projects/plugins/jetpack/_inc/content-guidelines-ai.php
+++ b/projects/plugins/jetpack/_inc/content-guidelines-ai.php
@@ -89,10 +89,30 @@ function jetpack_content_guidelines_ai_enqueue_scripts( $hook_suffix ) {
 	$banner_dismissed = class_exists( 'WPCOM_REST_API_V2_Endpoint_Guidelines_Banner_Dismissed' )
 		? WPCOM_REST_API_V2_Endpoint_Guidelines_Banner_Dismissed::is_dismissed()
 		: true;
+
+	$initial_state = array( 'bannerDismissed' => $banner_dismissed );
+
+	// Resolve the AI feature state server-side so the bundle can hydrate the
+	// wordpress-com/plans store at boot and render the correct locked/unlocked
+	// buttons on first paint, with no client-side plan fetch. On WordPress.com
+	// Simple this is a synchronous local lookup; on Atomic/self-hosted it is
+	// transient-cached with a blocking remote refresh when cold. On failure
+	// the key is omitted and the bundle renders no AI UI for this load (fail
+	// closed) rather than guessing.
+	if ( ! class_exists( 'Jetpack_AI_Helper' ) && is_readable( JETPACK__PLUGIN_DIR . '_inc/lib/class-jetpack-ai-helper.php' ) ) {
+		require_once JETPACK__PLUGIN_DIR . '_inc/lib/class-jetpack-ai-helper.php';
+	}
+	if ( class_exists( 'Jetpack_AI_Helper' ) ) {
+		$ai_feature = Jetpack_AI_Helper::get_ai_assistance_feature();
+		if ( ! is_wp_error( $ai_feature ) ) {
+			$initial_state['aiFeature'] = $ai_feature;
+		}
+	}
+
 	wp_add_inline_script(
 		'jetpack-content-guidelines-ai',
 		'window.jetpackContentGuidelinesAi = ' . wp_json_encode(
-			array( 'bannerDismissed' => $banner_dismissed ),
+			$initial_state,
 			JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
 		) . ';',
 		'before'

--- a/projects/plugins/jetpack/_inc/content-guidelines-ai/components/block-suggestion-buttons.jsx
+++ b/projects/plugins/jetpack/_inc/content-guidelines-ai/components/block-suggestion-buttons.jsx
@@ -17,14 +17,6 @@ export default function BlockSuggestionButtons( { blockName, blockModal } ) {
 		useDispatch( AI_STORE_NAME );
 	const { hasFeature } = useAiFeature();
 
-	// The plans store defaults hasFeature to true until its fetch resolves, so
-	// rendering before resolution would flash the button and then remove it on
-	// no-plan sites. Wait for the real answer instead.
-	const featureResolved = useSelect(
-		select => select( 'wordpress-com/plans' ).hasFinishedResolution( 'getAiAssistantFeature' ),
-		[]
-	);
-
 	const blockLoading = useSelect(
 		select => select( AI_STORE_NAME ).isSectionLoading( blockName ),
 		[ blockName ]
@@ -82,10 +74,6 @@ export default function BlockSuggestionButtons( { blockName, blockModal } ) {
 		recordGuidelinesEvent( 'dismiss', { type: 'block', slug: blockName } );
 		clearSuggestion( blockName );
 	}, [ blockName, clearSuggestion ] );
-
-	if ( ! featureResolved ) {
-		return null;
-	}
 
 	if ( suggestion ) {
 		return (

--- a/projects/plugins/jetpack/_inc/content-guidelines-ai/components/empty-state-banner.jsx
+++ b/projects/plugins/jetpack/_inc/content-guidelines-ai/components/empty-state-banner.jsx
@@ -14,14 +14,6 @@ export default function EmptyStateBanner() {
 
 	const dismissed = useSelect( select => select( AI_STORE_NAME ).isBannerDismissed(), [] );
 
-	// The plans store defaults hasFeature to true until its fetch resolves, so
-	// rendering before resolution would flash the banner on no-plan sites and
-	// then swap it for the upgrade notice. Wait for the real answer instead.
-	const featureResolved = useSelect(
-		select => select( 'wordpress-com/plans' ).hasFinishedResolution( 'getAiAssistantFeature' ),
-		[]
-	);
-
 	const handleDismiss = useCallback( () => {
 		dismissBanner();
 	}, [ dismissBanner ] );
@@ -31,7 +23,7 @@ export default function EmptyStateBanner() {
 		generate();
 	}, [ dismissBanner, generate ] );
 
-	if ( ! featureResolved || dismissed || ! hasFeature ) {
+	if ( dismissed || ! hasFeature ) {
 		return null;
 	}
 

--- a/projects/plugins/jetpack/_inc/content-guidelines-ai/components/section-generate-button.jsx
+++ b/projects/plugins/jetpack/_inc/content-guidelines-ai/components/section-generate-button.jsx
@@ -16,14 +16,6 @@ export default function SectionGenerateButton( { slug } ) {
 		useDispatch( AI_STORE_NAME );
 	const { hasFeature } = useAiFeature();
 
-	// The plans store defaults hasFeature to true until its fetch resolves, so
-	// rendering before resolution would flash the unlocked state on no-plan
-	// sites. Wait for the real answer instead.
-	const featureResolved = useSelect(
-		select => select( 'wordpress-com/plans' ).hasFinishedResolution( 'getAiAssistantFeature' ),
-		[]
-	);
-
 	const sectionLoading = useSelect(
 		select => select( AI_STORE_NAME ).isSectionLoading( slug ),
 		[ slug ]
@@ -75,10 +67,6 @@ export default function SectionGenerateButton( { slug } ) {
 		showUpgradeNotice,
 		createErrorNotice,
 	] );
-
-	if ( ! featureResolved ) {
-		return null;
-	}
 
 	const button = (
 		<Button

--- a/projects/plugins/jetpack/_inc/content-guidelines-ai/components/suggest-all-button.jsx
+++ b/projects/plugins/jetpack/_inc/content-guidelines-ai/components/suggest-all-button.jsx
@@ -12,14 +12,6 @@ export default function SuggestAllButton() {
 
 	const bannerDismissed = useSelect( select => select( AI_STORE_NAME ).isBannerDismissed(), [] );
 
-	// The plans store defaults hasFeature to true until its fetch resolves —
-	// waiting for the real answer avoids the button flashing into the wrong
-	// state (it briefly rendered as functional on no-plan sites).
-	const featureResolved = useSelect(
-		select => select( 'wordpress-com/plans' ).hasFinishedResolution( 'getAiAssistantFeature' ),
-		[]
-	);
-
 	const allGuidelines = useSelect( select => {
 		const store = select( STORE_NAME );
 		return Object.fromEntries( VALID_SECTIONS.map( slug => [ slug, store.getGuideline( slug ) ] ) );
@@ -36,10 +28,6 @@ export default function SuggestAllButton() {
 	// clicking it opens the upgrade notice (see useGenerateAll).
 	const hidden = ! bannerDismissed && hasFeature;
 	const hiddenProps = hidden ? { style: { display: 'none' }, 'aria-hidden': true } : {};
-
-	if ( ! featureResolved ) {
-		return null;
-	}
 
 	const button = (
 		<Button

--- a/projects/plugins/jetpack/changelog/add-guidelines-ai-feature-preload
+++ b/projects/plugins/jetpack/changelog/add-guidelines-ai-feature-preload
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Content Guidelines AI: Resolve the AI plan state in PHP and preload it into the page, hydrating the plans store at boot so buttons render in the correct locked/unlocked state on first paint with no client-side plan fetch. When the server-side lookup fails, the AI UI is omitted for that load instead of guessing.


### PR DESCRIPTION
Fixes N/A — supersedes #50491; follow-up to #50224.

## Proposed changes

* Resolve the AI plan state **server-side** and preload it into the page, instead of fetching it client-side after components mount. PHP computes the `ai-assistant-feature` payload at enqueue time — a synchronous local lookup (`wpcom_site_has_feature`) on WordPress.com Simple; on Atomic/self-hosted the existing transient-cached helper, with a blocking remote refresh when the cache is cold — and inlines it alongside the existing `bannerDismissed` preload in `window.jetpackContentGuidelinesAi`.
* At boot the bundle hydrates the `wordpress-com/plans` store with the payload and marks the selector resolved, so the resolver never fires. This mirrors how the sibling `jetpack-modules` store in `jetpack-shared-stores` hydrates from window state. Components read the store unchanged via `useAiFeature()`/`useAICheckout()` — one source of truth — and render the correct locked/unlocked state on first paint: **no client-side plan fetch, no pop-in delay, no gate, no morph**.
* **Fail closed:** if the server-side lookup errors, the payload is omitted and the bundle renders no AI UI for that load — the store's optimistic `hasFeature: true` default would otherwise show unlocked buttons whose requests are destined to 403 (surfacing a misleading "Failed to generate" error).
* Delete the `hasFinishedResolution` gates from all four components; with the store authoritative at boot they no longer have a job.
* `jetpack-shared-stores`: export the existing `mapAiFeatureResponseToAiFeatureProps` from the package barrel so the preload payload can be mapped without duplicating the shape.

## Related product discussion/links
* Follow-up to the locked-buttons flow in #50224; replaces the client-side timing optimizations of #50491 (closed unmerged).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

WordPress.com Simple (needs this fused; free-plan site):

* Go to Settings → Guidelines (`options-general.php?page=guidelines-wp-admin`).
* `window.jetpackContentGuidelinesAi.aiFeature` is present with `has-feature: false`, and the locked buttons (lock icon + tooltip) render together with the page content — no delay, no flash, and **no request** to `/wpcom/v2/jetpack-ai/ai-assistant-feature` in the Network tab.
* Clicking a locked button opens the upgrade notice as in #50224.

Atomic / JN with a Jetpack AI plan:

* Same page: buttons render unlocked with the content; no client-side feature request. First load after the transient expires (~cold cache) pays the lookup server-side — the page arrives slightly later but already correct.

Failure path (any platform):

* Simulate the helper failing (e.g. define a short-circuit or break connectivity on a JN site): the page renders with no AI buttons and no banner/notice at all, and no JS errors in the console.
