### PR TITLE
Likes: fix missing per-post Likes toggle in the block editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-likes-editor-toggle-register-plugin
+++ b/projects/plugins/jetpack/changelog/fix-likes-editor-toggle-register-plugin
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Likes: Restore the per-post Likes toggle in the block editor, which failed to register when withSelect returned a memo object.

--- a/projects/plugins/jetpack/extensions/plugins/likes/likes-checkbox.jsx
+++ b/projects/plugins/jetpack/extensions/plugins/likes/likes-checkbox.jsx
@@ -1,16 +1,25 @@
 import { useModuleStatus } from '@automattic/jetpack-shared-extension-utils';
 import { ToggleControl } from '@wordpress/components';
-import { compose } from '@wordpress/compose';
-import { withDispatch, withSelect } from '@wordpress/data';
-import { PostTypeSupportCheck } from '@wordpress/editor';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { store as editorStore, PostTypeSupportCheck } from '@wordpress/editor';
 import { __ } from '@wordpress/i18n';
 import JetpackLikesAndSharingPanel from '../../shared/jetpack-likes-and-sharing-panel';
 import { LikesPlaceholder } from './components/placeholder';
 import { LikesSkeletonLoader } from './components/skeleton-loader';
 
-const LikesCheckbox = ( { areLikesEnabled, editPost } ) => {
+/*
+ * This has to stay a plain function component: registerPlugin() requires `render` to be
+ * a function, and withSelect() returns a React.memo object, which it silently rejects.
+ */
+const LikesCheckbox = () => {
 	const { isLoadingModules, isChangingStatus, isModuleActive, changeStatus } =
 		useModuleStatus( 'likes' );
+
+	const areLikesEnabled = useSelect(
+		select => select( editorStore ).getEditedPostAttribute( 'jetpack_likes_enabled' ),
+		[]
+	);
+	const { editPost } = useDispatch( editorStore );
 
 	if ( ! isModuleActive ) {
 		return (
@@ -46,20 +55,4 @@ const LikesCheckbox = ( { areLikesEnabled, editPost } ) => {
 	);
 };
 
-// Fetch the post meta.
-const applyWithSelect = withSelect( select => {
-	const { getEditedPostAttribute } = select( 'core/editor' );
-	const areLikesEnabled = getEditedPostAttribute( 'jetpack_likes_enabled' );
-
-	return { areLikesEnabled };
-} );
-
-// Provide method to update post meta.
-const applyWithDispatch = withDispatch( dispatch => {
-	const { editPost } = dispatch( 'core/editor' );
-
-	return { editPost };
-} );
-
-// Combine the higher-order components.
-export default compose( [ applyWithSelect, applyWithDispatch ] )( LikesCheckbox );
+export default LikesCheckbox;


### PR DESCRIPTION
Fixes JETPACK-1863

## Proposed changes

The per-post Likes toggle is missing from the **Likes and Sharing** panel in the block editor.

`likes-checkbox.jsx` exported `compose( [ applyWithSelect, applyWithDispatch ] )( LikesCheckbox )`, with `withSelect` outermost. `withSelect` wraps its component in `memo( forwardRef( … ) )`, so the export is a **React.memo object**, not a function:

```js
withSelect( … )( C )    // typeof "object"  → Symbol(react.memo)
withDispatch( … )( C )  // typeof "function"
```

Older `@wordpress/plugins` validates `render` with `typeof render !== 'function'`, so it rejected the memo object, logged `The "render" property must be specified and must be a valid function.`, and returned `null`. `jetpack-likes` was therefore never registered and the Likes fill never reached the panel. The sibling Sharing control already uses hooks, which is why it kept rendering and only Likes disappeared.

* Convert `LikesCheckbox` to `useSelect`/`useDispatch` so the export stays a plain function component, matching `show-sharing-control`.

### Which environments are affected

This needs `@wordpress/data` to memo-wrap `withSelect` **and** `@wordpress/plugins` to still require a literal function. Upstream has since relaxed that check to `isValidElementType()`, which accepts memo objects:

| Gutenberg | `registerPlugin` check | Result on `trunk` |
| --- | --- | --- |
| 23.4.0 (the reported WoA site) | `typeof render !== 'function'` | **Toggle missing** |
| 23.5.2 (local) | `isValidElementType( render )` | Works |

So the affected window is environments whose `@wordpress/plugins` predates the `isValidElementType` change. The reported Simple/WoA sites sit in it today; sites on newer Gutenberg do not. I did not pin down the exact Gutenberg release that flipped it — the `@wordpress/plugins` changelog has no entry for it.

Landing this regardless: relying on `registerPlugin` accepting an exotic component type is fragile, a plain function component is correct under both the old and new checks, and it makes Likes consistent with Sharing.

Note that the theme is a red herring: the issue reports classic themes, but nothing in this code path branches on classic vs block themes.

## Related product discussion/links

* https://linear.app/a8c/issue/JETPACK-1863/missing-per-post-like-toggle-on-classic-themes

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The bug only reproduces where `@wordpress/plugins` still requires `render` to be a literal function — see the table above. Any site works, self-hosted included; you just need **Gutenberg 23.4** active. On newer Gutenberg the toggle renders on `trunk` too, so there is nothing to see there beyond a no-regression check.

Set up an affected environment:

* Make sure Jetpack is connected and the **Likes** module is enabled.
* Install and activate **Gutenberg 23.4**: `wp plugin install https://downloads.wordpress.org/plugin/gutenberg.23.4.0.zip --force --activate`

Confirm the bug on `trunk`:

* Open any post in the block editor.
* Open the **Jetpack** sidebar (Jetpack icon, top right) and expand **Likes and Sharing**.
* Only **Show sharing buttons** is present — **Show likes** is missing.
* Confirm the plugin never registered: `wp.plugins.getPlugins().some( p => p.name === 'jetpack-likes' )` → `false`.
* `registerPlugin` logs `The "render" property must be specified and must be a valid function.`, though the DevTools console panel may not surface it. To see it, reload with this in place:
  ```js
  const orig = console.error;
  console.error = ( ...args ) => { window.__errs = ( window.__errs || [] ).concat( args.join( ' ' ) ); orig( ...args ); };
  ```

Verify the fix on this branch:

* **Show likes** renders alongside **Show sharing buttons**, and `wp.plugins.getPlugins()` now includes `jetpack-likes`.
* Toggle **Show likes** off, save, reload — the setting persists (`jetpack_likes_enabled` / the `switch_like_status` post meta round-trips).
* Check the front end: the Like button is gone. Toggle it back on and confirm it returns.
* Disable the **Likes** module and confirm the panel still shows the "Activate Likes" placeholder (that path was refactored too).

No-regression check on current Gutenberg:

* Update Gutenberg to the latest (or deactivate it) and confirm **Show likes** still renders and still persists.

| Before | After |
| --- | --- |
|<img width="268" height="95" alt="Screenshot 2026-07-14 at 5 08 27 PM" src="https://github.com/user-attachments/assets/0862a532-6807-4845-bf95-c6833e7d9dde" />|<img width="272" height="124" alt="Screenshot 2026-07-14 at 5 07 16 PM" src="https://github.com/user-attachments/assets/71bc1814-bcb8-499f-9617-0533da675162" />|

