### PR TITLE
WPCOMSH: add optional bilmur site verification for WoA sites

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-bilmur-site-verification
+++ b/projects/plugins/wpcomsh/changelog/add-bilmur-site-verification
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Bilmur: add opt-in data-site-v attribute to the RUM meta tag via a new wpcomsh_bilmur_site_v filter

--- a/projects/plugins/wpcomsh/tests/WPCOMSH_RUM_Functions_Test.php
+++ b/projects/plugins/wpcomsh/tests/WPCOMSH_RUM_Functions_Test.php
@@ -44,4 +44,49 @@ class WPCOMSH_RUM_Functions_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'data-service="atomic"', $output );
 		$this->assertStringContainsString( 'bilmur.min.js', $output );
 	}
+
+	/**
+	 * Test that the site v is omitted by default
+	 */
+	public function test_wpcomsh_footer_rum_js_omits_site_v_by_default() {
+		ob_start();
+		wpcomsh_footer_rum_js();
+		$output = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'data-site-v', $output );
+	}
+
+	/**
+	 * Test that the site v is included when the filter is enabled
+	 */
+	public function test_wpcomsh_footer_rum_js_includes_site_v_when_enabled() {
+		add_filter( 'wpcomsh_bilmur_site_v', '__return_true' );
+
+		ob_start();
+		wpcomsh_footer_rum_js();
+		$output = ob_get_clean();
+
+		remove_filter( 'wpcomsh_bilmur_site_v', '__return_true' );
+
+		$expected = md5( (string) wp_parse_url( home_url(), PHP_URL_HOST ) );
+		$this->assertStringContainsString( 'data-site-v="' . $expected . '"', $output );
+	}
+
+	/**
+	 * Test that the site v is included when the filter is enabled
+	 */
+	public function test_wpcomsh_footer_rum_js_uses_custom_site_v_string() {
+		$callback = static function () {
+				return 'custom-value';
+		};
+		add_filter( 'wpcomsh_bilmur_site_v', $callback );
+
+		ob_start();
+		wpcomsh_footer_rum_js();
+		$output = ob_get_clean();
+
+		remove_filter( 'wpcomsh_bilmur_site_v', $callback );
+
+		$this->assertStringContainsString( 'data-site-v="custom-value"', $output );
+	}
 }

--- a/projects/plugins/wpcomsh/wpcomsh.php
+++ b/projects/plugins/wpcomsh/wpcomsh.php
@@ -609,14 +609,25 @@ function wpcomsh_footer_rum_js() {
 		$rum_kv = '';
 	}
 
+	$site_v = apply_filters( 'wpcomsh_bilmur_site_v', null );
+
+	if ( true === $site_v ) {
+		$site_v = md5( (string) wp_parse_url( home_url(), PHP_URL_HOST ) );
+	}
+
 	$data_site_tz = 'data-site-tz="' . esc_attr( wpcomsh_stats_timezone_string() ) . '"';
 
+	$data_site_v = ( is_string( $site_v ) && '' !== $site_v )
+			? 'data-site-v="' . esc_attr( $site_v ) . '"'
+			: '';
+
 	printf(
-		'<meta id="bilmur" property="bilmur:data" content="" %1$s data-provider="wordpress.com" data-service="%2$s" %3$s %4$s >' . "\n",
+		'<meta id="bilmur" property="bilmur:data" content="" %1$s data-provider="wordpress.com" data-service="%2$s" %3$s %4$s %5$s >' . "\n",
 		$rum_kv, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		esc_attr( $service ),
 		wp_kses_post( $allow_iframe ),
-		$data_site_tz // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		$data_site_tz, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		$data_site_v // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	);
 	printf(
 		'<script defer src="%s"></script>' . "\n", //phpcs:ignore WordPress.WP.EnqueuedResources.NonEnqueuedScript


### PR DESCRIPTION
## Proposed changes
Adds an opt-in data-site-v attribute to the bilmur RUM meta tag emitted by `wpcomsh_footer_rum_js()`, gated behind a new `wpcomsh_bilmur_site_v` filter. Off by default, only a small subset of sites will enable it (per discussion with the opers devs).

Resolution logic (in wpcomsh_footer_rum_js()):
- Filter returns true → attribute is added as an MD5 of the site host, no scheme or path, e.g. md5( "example.com" ), via wp_parse_url( home_url(), PHP_URL_HOST ).
- Filter returns a string → that value is used verbatim (escape hatch for a caller-supplied value).
- Filter returns null/empty (the default) → the attribute is omitted entirely.

```
// Enable with the computed hash:
add_filter( 'wpcomsh_bilmur_site_v', '__return_true' );

// Or supply a custom value:
add_filter( 'wpcomsh_bilmur_site_v', fn() => $my_hash );
```

The value is intentionally the bare host so it matches the destination's md5(site_host) comparison (verified: `md5("ulloi129.hu") === ad82588cc7e24ee0518e63700e16cfe8`).

### Cross-repo pairing
  
This is the WoA/Atomic half. The Simple-site equivalent lives in Automattic/wpcom (PR 228082-ghe-Automattic/wpcom), using a matching wpcom_bilmur_site_v filter and the same host-only hash. The two are independent (different platforms, different codebases) but should ship together for consistent behavior. 
  
### Does this pull request change what data or activity we track or use?
  
Yes. When a site opts in via the filter, the bilmur RUM meta tag gains a data-site-v attribute containing an MD5 hash of the site host. It is off by default and only added for the small set of sites that explicitly enable the filter. No new data is collected for sites that don't opt in.

## Testing instructions
1. Load any front-end page on a WoA site and view source. Confirm the `<meta id="bilmur" …>` tag does not include `data-site-v` (default/off).
2. Add `add_filter( 'wpcomsh_bilmur_site_v', '__return_true' );`, reload, and confirm the tag now includes `data-site-v="<md5 of the site host>"`.
3. Return a custom string from the filter and confirm the attribute uses that value verbatim.

Automated coverage added in WPCOMSH_RUM_Functions_Test.php:
  - attribute omitted by default
  - true → attribute contains md5( wp_parse_url( home_url(), PHP_URL_HOST ) )
  - custom string → attribute contains that value

Conversation References: p1781530965382899-slack-C4GAQ900P, p1781515448983089-slack-C4GAQ900P