### PR TITLE
VideoPress: Add WPDS token fallbacks to PostCSS config.

### DIFF
--- a/projects/packages/videopress/changelog/add-webpack-postcss-wpds-fallbacks
+++ b/projects/packages/videopress/changelog/add-webpack-postcss-wpds-fallbacks
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Inject WPDS design-token fallbacks during webpack CSS builds.

--- a/projects/packages/videopress/postcss.config.js
+++ b/projects/packages/videopress/postcss.config.js
@@ -1,3 +1,6 @@
 module.exports = () => ( {
-	plugins: [ require( 'autoprefixer' ) ],
+	plugins: [
+		require( '@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks' ).default,
+		require( 'autoprefixer' ),
+	],
 } );


### PR DESCRIPTION
Wire postcss-ds-token-fallbacks into the existing VideoPress webpack PostCSS pipeline, so nobody needs to add and maintain fallbacks in code. `var( --wpds-token )` converts to `var( --wpds-token, #000 )` at build time.

Older VideoPress UIs, apart from the WP Build dashboard, are _not_ using WPDS tokens yet, so this is more about just consolidating build pipelines across Jetpack so that one can use WPDS tokens anywhere in the repo. Split out from bigger https://github.com/Automattic/jetpack/pull/50108

The new WP Build VideoPress dashboard does use WPDS tokens, but that dashboard has its own build pipeline taking care of these fallbacks already.

## Proposed changes
<!--- Explain what functional changes your PR includes -->
Update block & legacy dashboard webpack config to include WPDS design token fallbacks:

- Video block (`block-editor/blocks/video/*`)
- **Legacy dashboard** — `admin/index` → `src/client/admin/index.jsx`
- **Dashboard shell CSS** — `dashboard-shell/index` → `src/dashboard/admin-shell.scss` (layout for wp-build routes)
- Block editor / Divi extensions

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Smoke test VideoPress, but there should not be an observable difference in bundles before/after.
