### PR TITLE
Daily Writing Prompt widget: refine hierarchy and fix self-hosted styling

### DIFF
--- a/projects/packages/newsletter/changelog/update-writing-prompt-widget-hierarchy
+++ b/projects/packages/newsletter/changelog/update-writing-prompt-widget-hierarchy
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Daily Writing Prompt widget: improve the prompt hierarchy — larger prompt text, icon-only previous/next arrow buttons, a refined primary call to action, a facepile (with a "+N" overflow count) alongside the "View responses" external link, and a footer divider. Also bundle the WPDS design tokens into the widget stylesheet so the styling renders on self-hosted Jetpack, where those tokens are not otherwise defined.
+Daily Writing Prompt widget: refresh the layout and fix its styling on self-hosted Jetpack.

--- a/projects/packages/newsletter/changelog/update-writing-prompt-widget-hierarchy
+++ b/projects/packages/newsletter/changelog/update-writing-prompt-widget-hierarchy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Daily Writing Prompt widget: improve the prompt hierarchy — larger prompt text, icon-only previous/next arrow buttons, a refined primary call to action, a facepile (with a "+N" overflow count) alongside the "View responses" external link, and a footer divider. Also bundle the WPDS design tokens into the widget stylesheet so the styling renders on self-hosted Jetpack, where those tokens are not otherwise defined.

--- a/projects/packages/newsletter/src/writing-prompt/style.scss
+++ b/projects/packages/newsletter/src/writing-prompt/style.scss
@@ -1,3 +1,9 @@
+// The widget's styles rely on WPDS design tokens (`--wpds-*`). On WordPress.com
+// these are globally available, but on self-hosted Jetpack wp-admin nothing
+// defines them, so the tokens resolve to nothing and the custom styling (footer
+// divider, prompt card, facepile chip) silently breaks. Bundle the token
+// definitions into this stylesheet, mirroring the Newsletter settings page.
+@import "@wordpress/theme/design-tokens.css";
 
 .wpcom-daily-writing-prompt--prompt {
 	background-color: var(--wpds-color-background-surface-neutral-weak);
@@ -5,20 +11,26 @@
 	border-radius: var(--wpds-border-radius-md);
 }
 
+.wpcom-daily-writing-prompt--prompt-text {
+	// Let the prompt grow so the navigation arrows stay pinned beside it, and
+	// drop the default wp-admin paragraph margins that would offset the row.
+	flex: 1;
+	margin: 0;
+}
+
+.wpcom-daily-writing-prompt--prompt-nav {
+	flex-shrink: 0;
+}
+
 .wpcom-daily-writing-prompt--branding {
 	padding-block-start: var(--wpds-dimension-padding-md);
-	border-block-start: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak);
+	// A clearly visible divider separating the footer from the prompt content,
+	// matching the dashboard's other widgets. The `-weak` stroke (#f0f0f0) reads
+	// as invisible against the white widget, so use the standard neutral stroke.
+	border-block-start: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral);
 }
 
 .wpcom-daily-writing-prompt--answered-users {
-
-	// The "View responses" secondary button renders as an anchor, so it
-	// inherits wp-admin's unlayered `a { color: #2271b1 }` rule, which would
-	// otherwise beat @wordpress/ui's layered button color. Re-apply the button's
-	// own foreground color. See settings/sections/paid-newsletter-section.tsx.
-	a {
-		color: var(--wp-ui-button-foreground-color);
-	}
 
 	img {
 		vertical-align: middle;
@@ -30,4 +42,22 @@
 	img:first-child {
 		margin-inline-start: 0;
 	}
+}
+
+.wpcom-daily-writing-prompt--answered-users-more {
+	// A count chip that closes the facepile ("+45"), overlapping the last avatar
+	// the same way the avatars overlap each other. Typography comes from the
+	// Text `body-sm` variant; this only shapes the neutral circle.
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	vertical-align: middle;
+	width: 22px;
+	height: 22px;
+	line-height: 1;
+	border-radius: 50%;
+	border: var(--wpds-border-width-sm) solid var(--wpds-color-background-surface-neutral);
+	margin-inline-start: calc(-1 * (var(--wpds-dimension-gap-sm) + var(--wpds-border-width-sm)));
+	background-color: var(--wpds-color-background-surface-neutral-weak);
+	color: var(--wpds-color-foreground-content-neutral-weak);
 }

--- a/projects/packages/newsletter/src/writing-prompt/style.scss
+++ b/projects/packages/newsletter/src/writing-prompt/style.scss
@@ -1,8 +1,3 @@
-// The widget's styles rely on WPDS design tokens (`--wpds-*`). On WordPress.com
-// these are globally available, but on self-hosted Jetpack wp-admin nothing
-// defines them, so the tokens resolve to nothing and the custom styling (footer
-// divider, prompt card, facepile chip) silently breaks. Bundle the token
-// definitions into this stylesheet, mirroring the Newsletter settings page.
 @import "@wordpress/theme/design-tokens.css";
 
 .wpcom-daily-writing-prompt--prompt {
@@ -12,8 +7,6 @@
 }
 
 .wpcom-daily-writing-prompt--prompt-text {
-	// Let the prompt grow so the navigation arrows stay pinned beside it, and
-	// drop the default wp-admin paragraph margins that would offset the row.
 	flex: 1;
 	margin: 0;
 }
@@ -24,9 +17,6 @@
 
 .wpcom-daily-writing-prompt--branding {
 	padding-block-start: var(--wpds-dimension-padding-md);
-	// A clearly visible divider separating the footer from the prompt content,
-	// matching the dashboard's other widgets. The `-weak` stroke (#f0f0f0) reads
-	// as invisible against the white widget, so use the standard neutral stroke.
 	border-block-start: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral);
 }
 
@@ -45,9 +35,6 @@
 }
 
 .wpcom-daily-writing-prompt--answered-users-more {
-	// A count chip that closes the facepile ("+45"), overlapping the last avatar
-	// the same way the avatars overlap each other. Typography comes from the
-	// Text `body-sm` variant; this only shapes the neutral circle.
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;

--- a/projects/packages/newsletter/src/writing-prompt/style.scss
+++ b/projects/packages/newsletter/src/writing-prompt/style.scss
@@ -1,14 +1,9 @@
 @import "@wordpress/theme/design-tokens.css";
 
-.wpcom-daily-writing-prompt--prompt {
-	background-color: var(--wpds-color-background-surface-neutral-weak);
-	padding: var(--wpds-dimension-padding-md);
-	border-radius: var(--wpds-border-radius-md);
-}
-
 .wpcom-daily-writing-prompt--prompt-text {
 	flex: 1;
 	margin: 0;
+	text-wrap: pretty;
 }
 
 .wpcom-daily-writing-prompt--prompt-nav {
@@ -39,8 +34,10 @@
 	align-items: center;
 	justify-content: center;
 	vertical-align: middle;
-	width: 22px;
-	height: 22px;
+	width: 24px;
+	height: 24px;
+	font-size: 0.625rem;
+	font-variant-numeric: tabular-nums;
 	line-height: 1;
 	border-radius: 50%;
 	border: var(--wpds-border-width-sm) solid var(--wpds-color-background-surface-neutral);

--- a/projects/packages/newsletter/src/writing-prompt/style.scss
+++ b/projects/packages/newsletter/src/writing-prompt/style.scss
@@ -36,7 +36,7 @@
 	vertical-align: middle;
 	width: 24px;
 	height: 24px;
-	font-size: 0.625rem;
+	font-size: 0.5625rem;
 	font-variant-numeric: tabular-nums;
 	line-height: 1;
 	border-radius: 50%;

--- a/projects/packages/newsletter/src/writing-prompt/writing-prompt.jsx
+++ b/projects/packages/newsletter/src/writing-prompt/writing-prompt.jsx
@@ -15,7 +15,7 @@ import {
 	useState,
 } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { arrowLeft, arrowRight } from '@wordpress/icons';
 import { Button, IconButton, Link, Stack, Text } from '@wordpress/ui';
 import { addQueryArgs } from '@wordpress/url';
@@ -165,11 +165,7 @@ export default () => {
 											className="wpcom-daily-writing-prompt--answered-users-more"
 											variant="body-sm"
 										>
-											{ sprintf(
-												/* translators: %d is how many more people answered the prompt beyond the avatars shown. */
-												__( '+%d', 'jetpack-newsletter' ),
-												prompt.answered_users_count - prompt.answered_users_sample.length
-											) }
+											{ `+${ prompt.answered_users_count - prompt.answered_users_sample.length }` }
 										</Text>
 									) }
 								</span>

--- a/projects/packages/newsletter/src/writing-prompt/writing-prompt.jsx
+++ b/projects/packages/newsletter/src/writing-prompt/writing-prompt.jsx
@@ -99,12 +99,12 @@ export default () => {
 					<Stack
 						className="wpcom-daily-writing-prompt--prompt"
 						direction="row"
-						align="center"
+						align="flex-start"
 						gap="sm"
 					>
 						<Text
 							className="wpcom-daily-writing-prompt--prompt-text"
-							variant="body-xl"
+							variant="body-lg"
 							render={ <p /> }
 						>
 							{ decodeEntities( prompt.text ) }
@@ -152,10 +152,10 @@ export default () => {
 											<img
 												alt={ __( 'User avatar', 'jetpack-newsletter' ) }
 												src={ addQueryArgs( sample.avatar, {
-													s: 22 * 2,
+													s: 24 * 2,
 												} ) }
-												width={ 22 }
-												height={ 22 }
+												width={ 24 }
+												height={ 24 }
 												key={ sample.avatar }
 											/>
 										);

--- a/projects/packages/newsletter/src/writing-prompt/writing-prompt.jsx
+++ b/projects/packages/newsletter/src/writing-prompt/writing-prompt.jsx
@@ -15,8 +15,9 @@ import {
 	useState,
 } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
-import { __ } from '@wordpress/i18n';
-import { Button, Link, Stack, Text } from '@wordpress/ui';
+import { __, sprintf } from '@wordpress/i18n';
+import { arrowLeft, arrowRight } from '@wordpress/icons';
+import { Button, IconButton, Link, Stack, Text } from '@wordpress/ui';
 import { addQueryArgs } from '@wordpress/url';
 
 export default () => {
@@ -95,59 +96,56 @@ export default () => {
 		<Stack direction="column" gap="md">
 			{ hasPrompt ? (
 				<>
-					<Stack className="wpcom-daily-writing-prompt--prompt" direction="column" gap="md">
-						<Text variant="body-md" render={ <p /> }>
+					<Stack
+						className="wpcom-daily-writing-prompt--prompt"
+						direction="row"
+						align="center"
+						gap="sm"
+					>
+						<Text
+							className="wpcom-daily-writing-prompt--prompt-text"
+							variant="body-xl"
+							render={ <p /> }
+						>
 							{ decodeEntities( prompt.text ) }
 						</Text>
-						<Stack direction="row" justify="flex-end">
-							<Button
-								variant="minimal"
-								size="small"
+						<Stack
+							className="wpcom-daily-writing-prompt--prompt-nav"
+							direction="row"
+							gap="xs"
+							align="center"
+						>
+							<IconButton
+								icon={ arrowLeft }
+								label={ __( 'Previous prompt', 'jetpack-newsletter' ) }
+								variant="outline"
+								tone="neutral"
+								size="compact"
 								onClick={ goToPrevious }
 								disabled={ index === 0 }
-							>
-								{ __( '← Previous', 'jetpack-newsletter' ) }
-							</Button>
-							<Button
-								variant="minimal"
-								size="small"
+							/>
+							<IconButton
+								icon={ arrowRight }
+								label={ __( 'Next prompt', 'jetpack-newsletter' ) }
+								variant="outline"
+								tone="neutral"
+								size="compact"
 								onClick={ goToNext }
 								disabled={ index === prompts.length - 1 }
-							>
-								{ __( 'Next →', 'jetpack-newsletter' ) }
-							</Button>
+							/>
 						</Stack>
 					</Stack>
 					<Stack direction="row" justify="space-between" align="center" gap="sm" wrap="wrap">
-						{ /* Replace with LinkButton once available: https://github.com/WordPress/gutenberg/issues/77098 */ }
 						<Button variant="outline" size="compact" onClick={ postAnswer }>
-							{ __( 'Post Answer', 'jetpack-newsletter' ) }
+							{ __( 'Post your answer', 'jetpack-newsletter' ) }
 						</Button>
 						{ prompt.answered_users_sample.length > 0 && (
 							<Stack
 								className="wpcom-daily-writing-prompt--answered-users"
 								direction="row"
 								align="center"
-								gap="xs"
+								gap="sm"
 							>
-								{ prompt.answered_users_count > 0 && (
-									<Button
-										variant="outline"
-										size="compact"
-										tone="neutral"
-										nativeButton={ false }
-										onClick={ recordViewResponsesClick }
-										render={
-											<a
-												href={ new URL( prompt.answered_link ).toString() }
-												target="_blank"
-												rel="noreferrer noopener"
-											/>
-										}
-									>
-										{ __( 'View responses', 'jetpack-newsletter' ) }
-									</Button>
-								) }
 								<span>
 									{ prompt.answered_users_sample.map( sample => {
 										return (
@@ -162,7 +160,29 @@ export default () => {
 											/>
 										);
 									} ) }
+									{ prompt.answered_users_count > prompt.answered_users_sample.length && (
+										<Text
+											className="wpcom-daily-writing-prompt--answered-users-more"
+											variant="body-sm"
+										>
+											{ sprintf(
+												/* translators: %d is how many more people answered the prompt beyond the avatars shown. */
+												__( '+%d', 'jetpack-newsletter' ),
+												prompt.answered_users_count - prompt.answered_users_sample.length
+											) }
+										</Text>
+									) }
 								</span>
+								{ prompt.answered_users_count > 0 && (
+									<Link
+										href={ new URL( prompt.answered_link ).toString() }
+										openInNewTab
+										rel="noreferrer noopener"
+										onClick={ recordViewResponsesClick }
+									>
+										{ __( 'View responses', 'jetpack-newsletter' ) }
+									</Link>
+								) }
 							</Stack>
 						) }
 					</Stack>

--- a/projects/packages/newsletter/tests/writing-prompt.test.tsx
+++ b/projects/packages/newsletter/tests/writing-prompt.test.tsx
@@ -44,7 +44,7 @@ jest.mock( '@automattic/jetpack-analytics', () => ( {
 	},
 } ) );
 
-import { render, screen, within } from '@testing-library/react';
+import { act, render, screen, within } from '@testing-library/react';
 import WritingPrompt from '../src/writing-prompt/writing-prompt';
 
 const PROMPT = {
@@ -110,7 +110,7 @@ describe( 'WritingPrompt widget empty state', () => {
 		).toHaveAttribute( 'href', 'https://wordpress.com/reader?origin_site_id=12345' );
 
 		// None of the prompt-only controls should render without a prompt.
-		expect( screen.queryByRole( 'button', { name: 'Post Answer' } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Post your answer' } ) ).not.toBeInTheDocument();
 		expect( screen.queryByRole( 'button', { name: /Next/ } ) ).not.toBeInTheDocument();
 	} );
 
@@ -152,33 +152,51 @@ describe( 'WritingPrompt widget Reader link and responses', () => {
 		mockIsWpcomPlatformSite.mockReturnValue( true );
 	} );
 
-	it( 'renders the View responses button and avatar faces outside the footer', async () => {
+	it( 'renders the View responses link and avatar faces outside the footer', async () => {
 		mockApiFetch.mockResolvedValue( [ PROMPT_WITH_RESPONSES ] );
 
 		const { container } = render( <WritingPrompt /> );
 
-		// The responses control is a secondary button rendered as an anchor, so it
-		// carries the button role while still navigating via its href.
-		const responsesButton = await screen.findByRole( 'button', { name: /View responses/ } );
-		expect( responsesButton ).toHaveAttribute( 'href', 'https://example.com/tag/dailyprompt-1' );
-		expect( responsesButton ).toHaveAttribute( 'target', '_blank' );
+		// The responses control is an external link that opens the Reader tag
+		// archive in a new tab.
+		const responsesLink = await screen.findByRole( 'link', { name: /View responses/ } );
+		expect( responsesLink ).toHaveAttribute( 'href', 'https://example.com/tag/dailyprompt-1' );
+		expect( responsesLink ).toHaveAttribute( 'target', '_blank' );
 		expect( screen.getAllByRole( 'img', { name: 'User avatar' } ) ).toHaveLength( 2 );
 
-		// The responses button now lives in the answered-users group, next to the avatars.
+		// The facepile closes with a "+N" chip for the answerers beyond the two
+		// sampled avatars (3 total answerers - 2 shown = 1 more).
+		expect( screen.getByText( '+1' ) ).toBeInTheDocument();
+
+		// The responses link now lives in the answered-users group, next to the avatars.
 		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- The answered-users group has no ARIA role, so a class selector is the most direct way to scope this assertion.
 		const answeredUsers = container.querySelector( '.wpcom-daily-writing-prompt--answered-users' );
 		expect( answeredUsers ).not.toBeNull();
 		expect(
-			within( answeredUsers as HTMLElement ).getByRole( 'button', { name: /View responses/ } )
+			within( answeredUsers as HTMLElement ).getByRole( 'link', { name: /View responses/ } )
 		).toBeInTheDocument();
 
-		// The branding footer must NOT contain the responses button.
+		// The branding footer must NOT contain the responses link.
 		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- The branding footer has no ARIA role, so a class selector is the most direct way to scope this assertion.
 		const footer = container.querySelector( '.wpcom-daily-writing-prompt--branding' );
 		expect( footer ).not.toBeNull();
 		expect(
-			within( footer as HTMLElement ).queryByRole( 'button', { name: /View responses/ } )
+			within( footer as HTMLElement ).queryByRole( 'link', { name: /View responses/ } )
 		).not.toBeInTheDocument();
+	} );
+
+	it( 'omits the "+N" facepile chip when every answerer is already shown', async () => {
+		// answered_users_count matches the number of sampled avatars, so there are
+		// no additional answerers to summarise.
+		mockApiFetch.mockResolvedValue( [ { ...PROMPT_WITH_RESPONSES, answered_users_count: 2 } ] );
+
+		render( <WritingPrompt /> );
+
+		await expect(
+			screen.findByRole( 'link', { name: /View responses/ } )
+		).resolves.toBeInTheDocument();
+		expect( screen.getAllByRole( 'img', { name: 'User avatar' } ) ).toHaveLength( 2 );
+		expect( screen.queryByText( /^\+\d/ ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'renders the Reader link in the footer with the origin_site_id', async () => {
@@ -304,6 +322,64 @@ const PROMPTS = [
 	},
 ];
 
+describe( 'WritingPrompt widget prompt navigation', () => {
+	beforeEach( () => {
+		mockApiFetch.mockReset();
+		mockGetSiteData.mockReset();
+		mockIsWpcomPlatformSite.mockReset();
+		mockGetSiteData.mockReturnValue( { wpcom: { blog_id: 12345 } } );
+		mockIsWpcomPlatformSite.mockReturnValue( true );
+	} );
+
+	it( 'renders icon-only Previous/Next controls and disables Previous on the first prompt', async () => {
+		mockApiFetch.mockResolvedValue( PROMPTS );
+
+		render( <WritingPrompt /> );
+
+		// The navigation controls are icon-only buttons whose accessible name comes
+		// from their label (rendered as a tooltip), replacing the old text buttons.
+		const previous = await screen.findByRole( 'button', { name: 'Previous prompt' } );
+		const next = screen.getByRole( 'button', { name: 'Next prompt' } );
+
+		// On the first prompt there is nothing before it, so Previous is disabled
+		// while Next stays available to advance through the remaining prompts.
+		// @wordpress/ui buttons express their disabled state via `aria-disabled`
+		// (the element stays focusable), so assert on that rather than the native
+		// `disabled` attribute.
+		expect( previous ).toHaveAttribute( 'aria-disabled', 'true' );
+		expect( next ).not.toHaveAttribute( 'aria-disabled', 'true' );
+	} );
+
+	it( 'advances to the next prompt and disables Next on the last prompt', async () => {
+		mockApiFetch.mockResolvedValue( PROMPTS );
+
+		render( <WritingPrompt /> );
+
+		const next = await screen.findByRole( 'button', { name: 'Next prompt' } );
+		expect( screen.getByText( 'What is your favorite way to relax?' ) ).toBeInTheDocument();
+
+		// The package favours the native `.click()` pattern over fireEvent; wrap it
+		// in act() so the resulting index state update flushes cleanly.
+		act( () => {
+			next.click();
+		} );
+
+		// The second (and last) prompt is now shown, so Next is disabled and
+		// Previous becomes available again.
+		await expect(
+			screen.findByText( 'What did you eat for breakfast?' )
+		).resolves.toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Next prompt' } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+		expect( screen.getByRole( 'button', { name: 'Previous prompt' } ) ).not.toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+	} );
+} );
+
 describe( 'WritingPrompt widget analytics', () => {
 	beforeEach( () => {
 		mockApiFetch.mockReset();
@@ -344,10 +420,10 @@ describe( 'WritingPrompt widget analytics', () => {
 		expect( mockInitialize ).not.toHaveBeenCalled();
 	} );
 
-	it( 'records a post-answer event with the prompt id when Post Answer is clicked', async () => {
+	it( 'records a post-answer event with the prompt id when Post your answer is clicked', async () => {
 		render( <WritingPrompt /> );
 
-		const postAnswerButton = await screen.findByRole( 'button', { name: 'Post Answer' } );
+		const postAnswerButton = await screen.findByRole( 'button', { name: 'Post your answer' } );
 		postAnswerButton.click();
 
 		expect( mockRecordEvent ).toHaveBeenCalledWith(
@@ -364,8 +440,8 @@ describe( 'WritingPrompt widget analytics', () => {
 	it( 'records a view-responses event with the prompt id when View responses is clicked', async () => {
 		render( <WritingPrompt /> );
 
-		const responsesButton = await screen.findByRole( 'button', { name: /View responses/ } );
-		responsesButton.click();
+		const responsesLink = await screen.findByRole( 'link', { name: /View responses/ } );
+		responsesLink.click();
 
 		expect( mockRecordEvent ).toHaveBeenCalledWith(
 			'jetpack_newsletter_writing_prompt_view_responses_click',


### PR DESCRIPTION
Fixes CM-845

## Proposed changes

This reworks the Daily Writing Prompt dashboard widget, and fixes a styling bug that only showed up on self-hosted Jetpack.

* The prompt is now the visual lead, in a larger typeface.
* Previous/next are icon-only arrow buttons sitting beside the prompt, replacing the old "← Previous" / "Next →" text buttons.
* The primary call to action reads "Post your answer".
* The answered-users avatars form a facepile capped with a "+N" overflow count.
* "View responses" is now an external link (opens the Reader tag archive in a new tab) instead of a secondary button.
* A divider separates the footer from the prompt content, matching the dashboard's other widgets.

| **Before** | **After** |
|--------|--------|
| <img width="467" height="277" alt="image" src="https://github.com/user-attachments/assets/3c7801ac-54fd-4f5e-b370-e9350203b9d8" /> | <img width="460" height="237" alt="Screenshot 2026-07-14 at 15 05 57" src="https://github.com/user-attachments/assets/93577138-ed6a-4efb-88f4-95a37f8fdc61" /> | 

## Related product discussion/links

* p8oabR-1Ql-p2#comment-9170

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The widget renders on the wp-admin Dashboard of a Jetpack-connected site (Simple, Atomic, or self-hosted). Self-hosted is the case worth checking, since that's where the token bug lived.

* Spin up a Jetpack-connected site (a Jurassic Ninja site with Jetpack works).
* Go to **wp-admin → Dashboard**.
* Confirm the **Daily Writing Prompt** widget shows: a large prompt in a grey card, icon-only ←/→ arrows beside it, a **Post your answer** button, a facepile of avatars with a **+N** count, a **View responses ↗** external link, and a visible horizontal divider above the Jetpack footer.
* Click ←/→ to cycle prompts; **Post your answer** opens the editor with the prompt; **View responses** opens the Reader tag archive in a new tab.