### PR TITLE
AI Launchpad: update wizard and launchpad copy per design feedback

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dsgcom-758-ai-launchpad-update-copy-for-wizard-and-launchpad-based-on
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dsgcom-758-ai-launchpad-update-copy-for-wizard-and-launchpad-based-on
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Launchpad: refresh wizard and launchpad copy, with a goal-specific launchpad heading.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/app.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/app.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from '@wordpress/element';
 import { decideInitialView, isAllTasksMode, type View } from './lib/orchestration.ts';
 import { TailoredList } from './tailored-list/tailored-list.tsx';
 import { Wizard } from './wizard/wizard.tsx';
-import type { TailorResult } from './lib/types.ts';
+import type { GoalSlug, TailorResult } from './lib/types.ts';
 import type { LaunchpadData } from './tailored-list/model.ts';
 
 /**
@@ -16,6 +16,8 @@ export function App() {
 	// null while the initial read is in flight.
 	const [ view, setView ] = useState< View | null >( null );
 	const [ pendingTailor, setPendingTailor ] = useState< Promise< TailorResult > | undefined >();
+	// The goal picked in the wizard, forwarded to the list for its heading.
+	const [ goal, setGoal ] = useState< GoalSlug | undefined >();
 	// Handed to the list so returning users don't refetch the same endpoint.
 	const [ initialData, setInitialData ] = useState< LaunchpadData | undefined >();
 
@@ -48,6 +50,7 @@ export function App() {
 				siteUrl={ initialData?.site?.url }
 				onComplete={ ( input, tailoring ) => {
 					setPendingTailor( () => tailoring );
+					setGoal( input.goal );
 					// The wizard wrote the entered Name to blogname; keep the preview
 					// card's title in sync without refetching. Mirrors the server's
 					// guard: an empty/whitespace Name never overwrites the title.
@@ -70,6 +73,7 @@ export function App() {
 			pendingTailor={ pendingTailor }
 			initialData={ pendingTailor ? undefined : initialData }
 			site={ initialData?.site }
+			goal={ goal }
 		/>
 	);
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/layout.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/layout.tsx
@@ -1,11 +1,37 @@
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
 import { SitePreview } from './site-preview.tsx';
+import type { GoalSlug } from '../lib/types.ts';
 import type { ReactNode } from 'react';
+
+/**
+ * The launchpad heading, keyed to the wizard goal. Full sentences per goal so
+ * translators get natural phrasing; `build`, `educate`, and an unknown goal all
+ * read as a generic "site".
+ *
+ * @param goal - The wizard goal, or null when unknown.
+ * @return The heading text.
+ */
+function headingForGoal( goal: GoalSlug | null ): string {
+	switch ( goal ) {
+		case 'write':
+			return __( "Let's get your blog ready to launch", 'jetpack-mu-wpcom' );
+		case 'sell':
+			return __( "Let's get your store ready to launch", 'jetpack-mu-wpcom' );
+		case 'newsletter':
+			return __( "Let's get your newsletter ready to launch", 'jetpack-mu-wpcom' );
+		case 'portfolio':
+			return __( "Let's get your portfolio ready to launch", 'jetpack-mu-wpcom' );
+		default:
+			return __( "Let's get your site ready to launch", 'jetpack-mu-wpcom' );
+	}
+}
 
 interface Props {
 	// The status line under the heading.
 	progressLabel: string;
+	// The wizard goal, used to pick the heading; null when unknown.
+	goal: GoalSlug | null;
 	// Site context for the preview card; omitted when unknown (dev fixtures).
 	siteUrl: string | null;
 	siteTitle?: string | null;
@@ -21,13 +47,21 @@ interface Props {
  *
  * @param props               - Component props.
  * @param props.progressLabel - The status line under the heading.
+ * @param props.goal          - The wizard goal, used to pick the heading.
  * @param props.siteUrl       - The site's front-end URL (for the preview).
  * @param props.siteTitle     - The site name (for the preview).
  * @param props.siteEditUrl   - The Site Editor URL (preview quick link).
  * @param props.children      - The left column content.
  * @return The layout element.
  */
-export function Layout( { progressLabel, siteUrl, siteTitle, siteEditUrl, children }: Props ) {
+export function Layout( {
+	progressLabel,
+	goal,
+	siteUrl,
+	siteTitle,
+	siteEditUrl,
+	children,
+}: Props ) {
 	// Without a site URL, collapse to a single column so the grid doesn't reserve
 	// an empty preview track that squeezes the tasks.
 	const hasPreview = !! siteUrl;
@@ -35,9 +69,7 @@ export function Layout( { progressLabel, siteUrl, siteTitle, siteEditUrl, childr
 	return (
 		<div className="ai-launchpad-tailored-list__layout">
 			<header className="ai-launchpad-tailored-list__heading">
-				<h1 className="ai-launchpad-tailored-list__title-heading">
-					{ __( 'Get the most out of WordPress', 'jetpack-mu-wpcom' ) }
-				</h1>
+				<h1 className="ai-launchpad-tailored-list__title-heading">{ headingForGoal( goal ) }</h1>
 				<p className="ai-launchpad-tailored-list__progress">{ progressLabel }</p>
 			</header>
 			<div

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
@@ -17,7 +17,7 @@ import {
 } from './model.ts';
 import { TailoredListSkeleton } from './skeleton.tsx';
 import { TaskCard } from './task-card.tsx';
-import type { TailoredOutput, TailorResult } from '../lib/types.ts';
+import type { GoalSlug, TailoredOutput, TailorResult } from '../lib/types.ts';
 
 import './style.scss';
 
@@ -44,6 +44,9 @@ interface Props {
 	// Site context for the preview card, passed on the wizard→list path too so the
 	// skeleton can show the preview. The fetched site takes precedence.
 	site?: SiteData;
+
+	// The wizard goal, used for the heading until the AI output supplies its own.
+	goal?: GoalSlug;
 }
 
 /**
@@ -56,9 +59,10 @@ interface Props {
  * @param props.pendingTailor - In-flight tailor call to await before fetching.
  * @param props.initialData   - Composite read supplied by the host (returning users).
  * @param props.site          - Site context for the preview (always supplied by the host).
+ * @param props.goal          - The wizard goal (wizard→list path), for the heading.
  * @return The tailored-list element.
  */
-export function TailoredList( { pendingTailor, initialData, site }: Props = {} ) {
+export function TailoredList( { pendingTailor, initialData, site, goal }: Props = {} ) {
 	// Returning users seed straight from initialData so the first frame isn't the
 	// loading copy. The wizard→list path has no initialData and starts as loading.
 	const [ tasks, setTasks ] = useState< EnrichedTask[] | null >( () => initialData?.tasks ?? null );
@@ -157,10 +161,14 @@ export function TailoredList( { pendingTailor, initialData, site }: Props = {} )
 		[ tasks, skippedIds ]
 	);
 
+	// Prefer the goal from the loaded AI output; fall back to the wizard's.
+	const effectiveGoal = output?.inferred?.goal ?? goal ?? null;
+
 	if ( ! tasks ) {
 		return (
 			<Layout
 				progressLabel={ __( 'Tailoring your checklist…', 'jetpack-mu-wpcom' ) }
+				goal={ effectiveGoal }
 				siteUrl={ siteUrl }
 				siteTitle={ siteTitle }
 				siteEditUrl={ siteEditUrl }
@@ -264,6 +272,7 @@ export function TailoredList( { pendingTailor, initialData, site }: Props = {} )
 	return (
 		<Layout
 			progressLabel={ progressLabel }
+			goal={ effectiveGoal }
 			siteUrl={ siteUrl }
 			siteTitle={ siteTitle }
 			siteEditUrl={ siteEditUrl }

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/details-step.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/details-step.tsx
@@ -111,7 +111,7 @@ export default function DetailsStep( {
 			<TextControl
 				__nextHasNoMarginBottom
 				__next40pxDefaultSize
-				label={ __( 'Name', 'jetpack-mu-wpcom' ) }
+				label={ __( 'Site name', 'jetpack-mu-wpcom' ) }
 				value={ siteName }
 				onChange={ onSiteNameChange }
 			/>

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/goals-step.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/goals-step.tsx
@@ -19,7 +19,7 @@ function goalOptions(): GoalOption[] {
 	return [
 		{
 			key: 'write',
-			title: __( 'Write', 'jetpack-mu-wpcom' ),
+			title: __( 'Start a blog', 'jetpack-mu-wpcom' ),
 			description: __( 'Share your ideas, stories, or expertise.', 'jetpack-mu-wpcom' ),
 			icon: pencil,
 		},
@@ -40,19 +40,19 @@ function goalOptions(): GoalOption[] {
 		},
 		{
 			key: 'newsletter',
-			title: __( 'Newsletter', 'jetpack-mu-wpcom' ),
+			title: __( 'Start a newsletter', 'jetpack-mu-wpcom' ),
 			description: __( 'Reach subscribers directly in their inbox.', 'jetpack-mu-wpcom' ),
 			icon: envelope,
 		},
 		{
 			key: 'educate',
 			title: __( 'Educate', 'jetpack-mu-wpcom' ),
-			description: __( 'For schools, nonprofits, courses, or communities.', 'jetpack-mu-wpcom' ),
+			description: __( 'Teach students, run courses, or grow a community.', 'jetpack-mu-wpcom' ),
 			icon: people,
 		},
 		{
 			key: 'portfolio',
-			title: __( 'Portfolio', 'jetpack-mu-wpcom' ),
+			title: __( 'Build a portfolio', 'jetpack-mu-wpcom' ),
 			description: __( 'Showcase your work, projects, or creative side.', 'jetpack-mu-wpcom' ),
 			icon: gallery,
 		},
@@ -80,7 +80,7 @@ export default function GoalsStep( { value, onChange }: Props ) {
 					{ __( "What's your main goal?", 'jetpack-mu-wpcom' ) }
 				</h2>
 				<p className="ai-launchpad-wizard__step-subtitle">
-					{ __( 'This helps us tailor your setup checklist.', 'jetpack-mu-wpcom' ) }
+					{ __( "We'll tailor your next steps to help you launch.", 'jetpack-mu-wpcom' ) }
 				</p>
 			</div>
 			<div className="ai-launchpad-wizard__cards" role="radiogroup">


### PR DESCRIPTION
Fixes DSGCOM-758

Design review of the AI Launchpad flagged several copy issues: the wizard goal labels didn't read as actions, one subtitle was a bare list of audiences, the step-2 field was ambiguously labelled "Name", and the launchpad heading ("Get the most out of WordPress") was generic and didn't reflect what the user set out to build. This PR applies the reviewed copy and makes the heading speak to each goal.

The heading is built as one full sentence per goal (rather than interpolating a noun into a shared string) so each variant translates as natural language.

## Proposed changes
* Wizard step 1: subtitle → "We'll tailor your next steps to help you launch."; Write → "Start a blog"; Newsletter → "Start a newsletter"; Portfolio → "Build a portfolio"; Educate subtitle → "Teach students, run courses, or grow a community."
* Wizard step 2: field label "Name" → "Site name".
* Launchpad heading is now goal-specific — "Let's get your {blog|store|newsletter|portfolio|site} ready to launch" — mapped per the issue's correlation table (write→blog, sell→store, newsletter→newsletter, portfolio→portfolio, build & educate→site).
* The goal is threaded from the wizard through to the list so the heading is correct even during the loading frame; once the tailored AI output arrives it supplies the authoritative goal.

## Related product discussion/links
* DSGCOM-758 (and design feedback in DSGCOM-757)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On an Atomic site with the AI Launchpad enabled, open the launchpad and start the wizard.
* Step 1: confirm the subtitle reads "We'll tailor your next steps to help you launch.", and the cards read "Start a blog", "Start a newsletter", "Build a portfolio", and the Educate card's subtitle reads "Teach students, run courses, or grow a community."
* Step 2: confirm the first field is labelled "Site name".
* Complete the wizard for each goal and confirm the launchpad heading matches: Write → "Let's get your blog ready to launch", Sell → "…store…", Newsletter → "…newsletter…", Portfolio → "…portfolio…", Build & Educate → "…site…".
* As a returning user (reload the launchpad), confirm the heading still matches the goal chosen earlier.
