### PR TITLE
Stylelint: no WPDS token fallback values for WP Build routes

### DIFF
--- a/projects/packages/forms/changelog/update-stylelint-wp-build-no-token-fallback-values
+++ b/projects/packages/forms/changelog/update-stylelint-wp-build-no-token-fallback-values
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Comment: Remove manual WPDS token fallbacks from wp-build route styles so build-time PostCSS injects canonical design-token fallbacks.

--- a/projects/packages/forms/routes/response/style.scss
+++ b/projects/packages/forms/routes/response/style.scss
@@ -33,8 +33,8 @@
 	flex-wrap: wrap;
 
 	&__link {
-		font-size: var(--wpds-typography-font-size-lg, 15px);
-		line-height: var(--wpds-typography-line-height-md, 24px);
+		font-size: var(--wpds-typography-font-size-lg);
+		line-height: var(--wpds-typography-line-height-md);
 	}
 
 	&__sep {
@@ -45,12 +45,12 @@
 
 	&__current {
 		margin: 0;
-		font-family: var(--wpds-typography-font-family-heading, -apple-system, system-ui, "Segoe UI", "Roboto", sans-serif);
-		font-size: var(--wpds-typography-font-size-lg, 15px);
-		font-weight: var(--wpds-typography-font-weight-medium, 499);
-		line-height: var(--wpds-typography-line-height-sm, 20px);
+		font-family: var(--wpds-typography-font-family-heading);
+		font-size: var(--wpds-typography-font-size-lg);
+		font-weight: var(--wpds-typography-font-weight-medium);
+		line-height: var(--wpds-typography-line-height-sm);
 		// Match the page-title color used on the other dashboard headers.
-		color: var(--wpds-color-foreground-content-neutral, #1e1e1e);
+		color: var(--wpds-color-foreground-content-neutral);
 	}
 }
 

--- a/projects/packages/forms/routes/responses/response/style.scss
+++ b/projects/packages/forms/routes/responses/response/style.scss
@@ -6,7 +6,7 @@ $inspector-padding: 16px;
 
 .jp-forms-response-header {
 	padding: 8px;
-	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral, #e0e0e0);
+	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral);
 }
 
 .jp-forms-response-header-actions {
@@ -14,7 +14,7 @@ $inspector-padding: 16px;
 }
 
 .jp-forms__inbox__tip-container {
-	border-top: 1px solid var(--wpds-color-stroke-surface-neutral, #e0e0e0);
+	border-top: 1px solid var(--wpds-color-stroke-surface-neutral);
 	margin: auto 0 0 0;
 	padding: $inspector-padding;
 	text-wrap: pretty;

--- a/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/style.scss
+++ b/projects/packages/forms/src/dashboard/wp-build/components/dataviews-header-row/style.scss
@@ -1,7 +1,7 @@
 @use "@wordpress/base-styles/variables";
 
 .jp-forms-dataviews__view-actions {
-	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral, #e0e0e0);
+	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral);
 	padding-inline: 20px;
 	overflow-x: auto;
 	width: 100%;

--- a/projects/packages/newsletter/changelog/update-stylelint-wp-build-no-token-fallback-values
+++ b/projects/packages/newsletter/changelog/update-stylelint-wp-build-no-token-fallback-values
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Comment: Remove manual WPDS token fallbacks from wp-build route styles so build-time PostCSS injects canonical design-token fallbacks.

--- a/projects/packages/newsletter/routes/dashboard/route.scss
+++ b/projects/packages/newsletter/routes/dashboard/route.scss
@@ -5,7 +5,7 @@
 // TODO: drop the manual color override once a design-system "muted text" tone
 // lands on `Text` (see https://github.com/WordPress/gutenberg/issues/77391).
 .jetpack-newsletter__identity-email {
-	color: var(--wpds-color-foreground-content-neutral-weak, #50575e);
+	color: var(--wpds-color-foreground-content-neutral-weak);
 }
 
 // Inline avatar in the identity cell — keep it circular and prevent the
@@ -16,14 +16,14 @@
 
 // Inspector panel chrome.
 .jetpack-newsletter__panel-header {
-	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral, #f0f0f1);
-	padding: var(--wpds-dimension-padding-sm, 8px) var(--wpds-dimension-padding-lg, 16px);
+	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral);
+	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-lg);
 }
 
 .jetpack-newsletter__panel-body {
 	flex-grow: 1;
 	overflow-y: auto;
-	padding: var(--wpds-dimension-padding-2xl, 24px);
+	padding: var(--wpds-dimension-padding-2xl);
 }
 
 // Subscriber detail layout.
@@ -40,7 +40,7 @@
 // TODO: replace with `Text` "muted" tone once available
 // (see https://github.com/WordPress/gutenberg/issues/77391).
 .jetpack-newsletter__detail-email {
-	color: var(--wpds-color-foreground-content-neutral-weak, #50575e);
+	color: var(--wpds-color-foreground-content-neutral-weak);
 }
 
 // Stat row — Emails sent / Open rate / Click rate.
@@ -54,18 +54,18 @@
 // padding-lg (16px).
 .jetpack-newsletter__detail-stat,
 .jetpack-newsletter__detail-section {
-	--wp-ui-card-padding: var(--wpds-dimension-padding-lg, 16px);
+	--wp-ui-card-padding: var(--wpds-dimension-padding-lg);
 }
 
 .jetpack-newsletter__detail-stat-value {
 	display: block;
-	margin-top: var(--wpds-dimension-gap-sm, 8px);
+	margin-top: var(--wpds-dimension-gap-sm);
 }
 
 // Grouped sections — Card already provides the outer border, so rows just sit
 // in a column with the design-system gap.
 .jetpack-newsletter__detail-row-label {
-	color: var(--wpds-color-foreground-content-neutral-weak, #50575e);
+	color: var(--wpds-color-foreground-content-neutral-weak);
 }
 
 .jetpack-newsletter__detail-link {
@@ -77,5 +77,5 @@
 // checkbox — as it sits flush against the bottom edge. Reserve a little space
 // so the ring renders in full.
 .jetpack-newsletter__comp-modal-body {
-	padding-bottom: var(--wpds-dimension-padding-xs, 4px);
+	padding-bottom: var(--wpds-dimension-padding-xs);
 }

--- a/projects/packages/newsletter/routes/subscribers-announcement/route.scss
+++ b/projects/packages/newsletter/routes/subscribers-announcement/route.scss
@@ -29,12 +29,12 @@ body.admin_page_jetpack-subscribers {
 
 	&__inner {
 		align-items: flex-start;
-		padding: 48px var(--wpds-dimension-padding-2xl, 24px) 64px;
+		padding: 48px var(--wpds-dimension-padding-2xl) 64px;
 	}
 
 	&__subtitle {
 		margin-block: 12px 0;
-		color: var(--wpds-color-foreground-content-neutral-weak, #3c434a);
+		color: var(--wpds-color-foreground-content-neutral-weak);
 	}
 
 	&__cta {

--- a/projects/packages/premium-analytics/changelog/update-stylelint-wp-build-no-token-fallback-values
+++ b/projects/packages/premium-analytics/changelog/update-stylelint-wp-build-no-token-fallback-values
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Comment: Remove manual WPDS token fallbacks from wp-build route styles so build-time PostCSS injects canonical design-token fallbacks.

--- a/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.module.scss
+++ b/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.module.scss
@@ -10,5 +10,5 @@
 }
 
 .tabList {
-	padding-inline: var(--wpds-dimension-padding-2xl, 24px);
+	padding-inline: var(--wpds-dimension-padding-2xl);
 }

--- a/projects/packages/premium-analytics/routes/dashboard/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.module.scss
@@ -7,17 +7,17 @@
 	min-block-size: 0;
 	overflow-y: auto;
 	// Reserve paint space for the widget host's outer focus outline.
-	padding-block-start: calc(var(--wpds-border-width-focus, 2px) + 2px);
+	padding-block-start: calc(var(--wpds-border-width-focus) + 2px);
 	// Match the horizontal padding of the page header and the section tabs so the
 	// widget grid lines up with them instead of sitting flush to the edge.
 	padding-block-end: 24px;
-	padding-inline: var(--wpds-dimension-padding-2xl, 24px);
+	padding-inline: var(--wpds-dimension-padding-2xl);
 }
 
 .dateFilters {
 	// Sits below the section tabs and above the widgets. The tab list already
 	// adds a bottom margin, so only pad below here to keep the spacing even.
 	// Inline padding matches the tabs and widget grid so it lines up.
-	padding-block-end: var(--wpds-dimension-gap-lg, 16px);
-	padding-inline: var(--wpds-dimension-padding-2xl, 24px);
+	padding-block-end: var(--wpds-dimension-gap-lg);
+	padding-inline: var(--wpds-dimension-padding-2xl);
 }

--- a/projects/packages/premium-analytics/routes/post-detail/components/post-detail-tabs/post-detail-tabs.module.scss
+++ b/projects/packages/premium-analytics/routes/post-detail/components/post-detail-tabs/post-detail-tabs.module.scss
@@ -1,3 +1,3 @@
 .tabList {
-	padding-inline: var(--wpds-dimension-padding-2xl, 24px);
+	padding-inline: var(--wpds-dimension-padding-2xl);
 }

--- a/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.module.scss
+++ b/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.module.scss
@@ -2,18 +2,18 @@
 	display: flex;
 	align-items: flex-start;
 	justify-content: space-between;
-	gap: var(--wpds-dimension-gap-lg, 16px);
+	gap: var(--wpds-dimension-gap-lg);
 	border:
-		var(--wpds-border-width-xs, 1px) solid
-		var(--wpds-color-stroke-surface-neutral-weak, #f0f0f0);
-	border-radius: var(--wpds-border-radius-md, 8px);
-	padding: var(--wpds-dimension-padding-2xl, 24px);
+		var(--wpds-border-width-xs) solid
+		var(--wpds-color-stroke-surface-neutral-weak);
+	border-radius: var(--wpds-border-radius-md);
+	padding: var(--wpds-dimension-padding-2xl);
 }
 
 .details {
 	display: flex;
 	flex-direction: column;
-	gap: var(--wpds-dimension-gap-xs, 4px);
+	gap: var(--wpds-dimension-gap-xs);
 	min-inline-size: 0;
 }
 
@@ -21,12 +21,12 @@
 	display: flex;
 	flex-direction: row;
 	align-items: center;
-	gap: var(--wpds-dimension-gap-xs, 4px);
-	color: var(--wpds-color-foreground-content-neutral-weak, #757575);
+	gap: var(--wpds-dimension-gap-xs);
+	color: var(--wpds-color-foreground-content-neutral-weak);
 }
 
 .published {
-	color: var(--wpds-color-foreground-content-neutral-weak, #757575);
+	color: var(--wpds-color-foreground-content-neutral-weak);
 }
 
 .image {
@@ -34,5 +34,5 @@
 	inline-size: 72px;
 	block-size: 72px;
 	object-fit: cover;
-	border-radius: var(--wpds-border-radius-sm, 6px);
+	border-radius: var(--wpds-border-radius-sm);
 }

--- a/projects/packages/premium-analytics/routes/post-detail/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.module.scss
@@ -7,23 +7,23 @@
 	min-block-size: 0;
 	overflow-y: auto;
 	// Reserve paint space for the widget host's outer focus outline.
-	padding-block-start: calc(var(--wpds-border-width-focus, 2px) + 2px);
+	padding-block-start: calc(var(--wpds-border-width-focus) + 2px);
 	// Match the horizontal padding of the tab bar and header so the widget grid
 	// lines up with them instead of sitting flush to the edge.
 	padding-block-end: 24px;
-	padding-inline: var(--wpds-dimension-padding-2xl, 24px);
+	padding-inline: var(--wpds-dimension-padding-2xl);
 }
 
 .summary {
 	// Sits below the tab bar and above the date filters, aligned with the tabs
 	// and widget grid.
-	padding-block-end: var(--wpds-dimension-gap-lg, 16px);
-	padding-inline: var(--wpds-dimension-padding-2xl, 24px);
+	padding-block-end: var(--wpds-dimension-gap-lg);
+	padding-inline: var(--wpds-dimension-padding-2xl);
 }
 
 .dateFilters {
 	// Sits below the summary card and above the widgets. Only pad below to keep
 	// the spacing even; inline padding matches the tabs and widget grid.
-	padding-block-end: var(--wpds-dimension-gap-lg, 16px);
-	padding-inline: var(--wpds-dimension-padding-2xl, 24px);
+	padding-block-end: var(--wpds-dimension-gap-lg);
+	padding-inline: var(--wpds-dimension-padding-2xl);
 }

--- a/projects/packages/premium-analytics/routes/reports/posts/config/fields.module.css
+++ b/projects/packages/premium-analytics/routes/reports/posts/config/fields.module.css
@@ -1,7 +1,7 @@
 .homepageLink {
 	display: inline-flex;
 	align-items: center;
-	gap: var(--wpds-dimension-gap-xs, 4px);
+	gap: var(--wpds-dimension-gap-xs);
 }
 
 .externalIcon {

--- a/projects/packages/premium-analytics/routes/reports/posts/page.module.css
+++ b/projects/packages/premium-analytics/routes/reports/posts/page.module.css
@@ -12,7 +12,7 @@
 	 * with it instead of sitting flush to the edge.
 	 */
 	padding-block-end: 24px;
-	padding-inline: var(--wpds-dimension-padding-2xl, 24px);
+	padding-inline: var(--wpds-dimension-padding-2xl);
 }
 
 .dateFilters {

--- a/projects/packages/videopress/changelog/update-stylelint-wp-build-no-token-fallback-values
+++ b/projects/packages/videopress/changelog/update-stylelint-wp-build-no-token-fallback-values
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Comment: Remove manual WPDS token fallbacks from wp-build route styles so build-time PostCSS injects canonical design-token fallbacks.

--- a/projects/packages/videopress/routes/overview/style.scss
+++ b/projects/packages/videopress/routes/overview/style.scss
@@ -32,7 +32,7 @@
 				inset-inline: 0;
 				bottom: 0;
 				height: 3px;
-				background: var(--wpds-color-stroke-interactive-neutral-strong, #1d35b4);
+				background: var(--wpds-color-stroke-interactive-neutral-strong);
 				border-end-start-radius: inherit;
 				border-end-end-radius: inherit;
 				opacity: 0;
@@ -50,7 +50,7 @@
 			}
 
 			&:focus-visible {
-				outline: 2px solid var(--wpds-color-stroke-focus, #1d35b4);
+				outline: 2px solid var(--wpds-color-stroke-focus);
 				outline-offset: -2px;
 			}
 		}
@@ -210,26 +210,26 @@
 	// than the LineChart's default light card. The chart's visx-tooltip
 	// system handles positioning; we only style the inner content.
 	&__chart-tooltip {
-		padding: var(--wpds-dimension-padding-sm, 8px);
+		padding: var(--wpds-dimension-padding-sm);
 		background-color: rgba(0, 0, 0, 0.85);
 		color: #fff;
-		border-radius: var(--wpds-border-radius-md, 4px);
-		font-size: var(--wpds-typography-font-size-md, 13px);
+		border-radius: var(--wpds-border-radius-md);
+		font-size: var(--wpds-typography-font-size-md);
 		box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
 	}
 
 	&__chart-tooltip-date {
-		font-weight: var(--wpds-typography-font-weight-medium, 499);
-		padding-bottom: var(--wpds-dimension-padding-md, 12px);
+		font-weight: var(--wpds-typography-font-weight-medium);
+		padding-bottom: var(--wpds-dimension-padding-md);
 	}
 
 	&__chart-tooltip-row {
-		padding: var(--wpds-dimension-padding-xs, 4px) 0;
+		padding: var(--wpds-dimension-padding-xs) 0;
 	}
 
 	&__chart-tooltip-label {
-		font-weight: var(--wpds-typography-font-weight-medium, 499);
-		padding-right: var(--wpds-dimension-padding-lg, 16px);
+		font-weight: var(--wpds-typography-font-weight-medium);
+		padding-right: var(--wpds-dimension-padding-lg);
 	}
 
 	&__storage-meter {

--- a/tools/js-tools/stylelint.config.base.mjs
+++ b/tools/js-tools/stylelint.config.base.mjs
@@ -14,7 +14,9 @@ const baseConfig = {
 	rules: {
 		'plugin-wpds/no-unknown-ds-tokens': true,
 		'plugin-wpds/no-setting-wpds-custom-properties': true,
-		'plugin-wpds/no-token-fallback-values': null, // Disabled because `@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks` is not configured yet.
+		// Disabled globally: only wp-build dashboards configure `@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks`
+		// which adds fallbacks at build time.
+		'plugin-wpds/no-token-fallback-values': null,
 		// In addition to what `@wordpress/stylelint-config/scss-stylistic` does by default, also ignore comments containing /stylelint-disable/.
 		'@stylistic/max-line-length': [
 			80,
@@ -84,6 +86,27 @@ const baseConfig = {
 			},
 		],
 	},
+	overrides: [
+		{
+			// Packages with `build:wp-build` in package.json.
+			files: [
+				'projects/packages/backup/routes/**/*.{css,scss,sass}',
+				'projects/packages/forms/routes/**/*.{css,scss,sass}',
+				'projects/packages/forms/src/dashboard/wp-build/**/*.{css,scss,sass}',
+				'projects/packages/jetpack-mu-wpcom/routes/**/*.{css,scss,sass}',
+				'projects/packages/newsletter/routes/**/*.{css,scss,sass}',
+				'projects/packages/podcast/routes/**/*.{css,scss,sass}',
+				'projects/packages/premium-analytics/routes/**/*.{css,scss,sass}',
+				'projects/packages/publicize/routes/**/*.{css,scss,sass}',
+				'projects/packages/scan/routes/**/*.{css,scss,sass}',
+				'projects/packages/seo/routes/**/*.{css,scss,sass}',
+				'projects/packages/videopress/routes/**/*.{css,scss,sass}',
+			],
+			rules: {
+				'plugin-wpds/no-token-fallback-values': true,
+			},
+		},
+	],
 };
 
 export default baseConfig;


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/jetpack/pull/50110 which added linting for [WPDS tokens](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/docs/tokens.md) but didn't enforce the "no fallbacks" rule yet.


## Proposed changes
<!--- Explain what functional changes your PR includes -->
Enforces "no fallbacks" rule to paths which are built using `wp-Build` tooling: build pipeline in `wp-build` already adds fallbacks at build-time, so this is a safe change.

Manually maintaining fallbacks is error-prone and requires more work during `@wordpress/theme` updates.

List of paths is manually maintained list since it's meant to be temporary. I'm working through changes across codebase to add fallbacks in Webpack build bundles (https://github.com/Automattic/jetpack/pull/50108). Once that's finished, we can start linting the rest of the stylesheets as well.

On wp-build admin pages, WPDS tokens are always loaded and **manual fallbacks are ignored** — the browser always uses the token value from the theme.

However, there were some mismatches, and it's worth documenting just in case.

<details>
<summary>See list by severity</summary>

### High — wrong token semantics or large visual delta

| Token | Removed fallback | WPDS value | File(s) | Notes |
|---|---|---|---|---|
| `--wpds-color-stroke-interactive-neutral-strong` | `#1d35b4` (admin blue) | `#6e6e6e` (neutral gray) | `videopress/routes/overview/style.scss` | Tab underline indicator. Fallback implied brand color, but token is **neutral stroke**. With tokens loaded, tabs were already gray. If blue was intended, should use `--wpds-color-stroke-surface-brand-strong` or `--wpds-color-stroke-interactive-brand`. |
| `--wpds-border-radius-md` | `8px` | `4px` | `premium-analytics/.../post-summary-card.module.scss` | `8px` is `--wpds-border-radius-lg`, not `md`. Likely copy-paste error. |
| `--wpds-border-radius-sm` | `6px` | `2px` | same file (`.image`) | Image corners were much rounder in the fallback-only path. |

### Medium — noticeable color differences

| Token | Removed fallback(s) | WPDS value | File(s) |
|---|---|---|---|
| `--wpds-color-stroke-surface-neutral` | `#e0e0e0`, `#f0f0f1` | `#dbdbdb` | forms responses + dataviews header; newsletter panel header |
| `--wpds-color-foreground-content-neutral-weak` | `#50575e`, `#3c434a`, `#757575` | `#707070` | newsletter dashboard (×4), subscribers-announcement, post-summary-card (×2) |

The newsletter dashboard even has TODOs about wanting a “muted text” tone — the removed values were **WordPress admin grays** (`#50575e` ≈ `$gray-50`, `#3c434a` ≈ `$gray-60`), not WPDS `#707070`. With tokens loaded, muted text was already `#707070`.

### Low — minor or structural differences

| Token | Removed | WPDS | Impact |
|---|---|---|---|
| `--wpds-typography-font-family-heading` | truncated stack (no Oxygen-Sans, Ubuntu, etc.) | full system stack | `forms/routes/response/style.scss` — minor font fallback difference only when tokens missing |
| `--wpds-color-stroke-focus` | `#1d35b4` | `#3858e9` (runtime) / `var(--wp-admin-theme-color, #3858e9)` (PostCSS fallback) | `videopress/routes/overview/style.scss` — different blue; now theme-aware |
| `--wpds-border-width-focus` | `2px` | `var(--wp-admin-border-width-focus, 2px)` | premium-analytics stage files — equivalent when admin var is 2px; runtime CSS hardcodes `2px` |

</details>

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Smoke test affected routes:
- Forms
- Newsletter
- Premium Analytics 
- VideoPress
- SEO
- Scan
- Social
- Podcast

No differences in bundles, apart from corrected fallback values (they're now canonical rather than incorrect).