### PR TITLE
Error Reporting: use direct fetch with no CORS preflight

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-error-reporting-fetch
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-error-reporting-fetch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+WP.com Error Reporting: use direct fetch with no CORS preflight

--- a/projects/packages/jetpack-mu-wpcom/src/features/error-reporting/index.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/error-reporting/index.js
@@ -1,5 +1,4 @@
 import * as Sentry from '@sentry/browser';
-import apiFetch from '@wordpress/api-fetch';
 import { addAction } from '@wordpress/hooks';
 
 const shouldActivateSentry = window.WPcom_Error_Reporting_Config?.shouldActivateSentry === 'true';
@@ -38,6 +37,8 @@ function activateSentry() {
  * Activate the WP.com Logstash error-reporting.
  */
 function activateLogstash() {
+	const JS_ERROR_ENDPOINT = 'https://public-api.wordpress.com/rest/v1.1/js-error';
+
 	const reportError = ( { error } ) => {
 		// Sanitized error event objects do not include a nested error attribute. In
 		// that case, we return early to prevent a needless TypeError when defining
@@ -54,13 +55,14 @@ function activateLogstash() {
 			feature: 'wp-admin',
 		};
 
+		// Send as direct `fetch` request with `x-www-form-urlencoded` content type and no extra
+		// headers like `X-WP-Nonce`. Prevents triggering a preflight request.
 		return (
-			apiFetch( {
-				global: true,
-				path: '/rest/v1.1/js-error',
-				method: 'POST',
-				data: { error: JSON.stringify( data ) },
-			} )
+			window
+				.fetch( JS_ERROR_ENDPOINT, {
+					method: 'POST',
+					body: new URLSearchParams( { error: JSON.stringify( data ) } ),
+				} )
 				// eslint-disable-next-line no-console
 				.catch( err => console.error( 'Error: Unable to record the error in Logstash.', err ) )
 		);

--- a/projects/plugins/mu-wpcom-plugin/changelog/update-error-reporting-fetch
+++ b/projects/plugins/mu-wpcom-plugin/changelog/update-error-reporting-fetch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+WP.com Error Reporting: use direct fetch with no CORS preflight

--- a/projects/plugins/wpcomsh/changelog/update-error-reporting-fetch
+++ b/projects/plugins/wpcomsh/changelog/update-error-reporting-fetch
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+WP.com Error Reporting: use direct fetch with no CORS preflight


### PR DESCRIPTION
Another improvement for `error-reporting` script, followup to #50483: send the POST request to `public-api/js-error` directly using `window.fetch` instead of relying on `apiFetch` and its middlewares.

`apiFetch` must be properly configured with middlewares and a custom fetch handler in order to detect the `global: true` flag and send the request to `public-api.wordpress.com` instead of the current site. This is set up on Simple sites, but not on Atomic ones. The functionality of the `error-reporting` script depends on subtle details of the surrounding JS environment. We'd like to make it more self-contained and independent.

Using `apiFetch` also means that the request will include non-standard headers that trigger a CORS preflight request. For example, `X-WP-Nonce`. We'd like to avoid that.

This PR converts the request to a direct fetch which uses `content-type: application/x-www-form-urlencoded` instead of `application/json`. Such a request is similar to a POST form submission and doesn't trigger any CORS preflight check. Because non-default `application/json` content type is another thing that triggers a preflight. The request is just the POST and nothing else.

## Testing instructions

Deploy the modified script to a WP.com sandbox.

On a sandboxed Simple site, cause an error. I do it with code snippets like this:
```php
wp_register_script( 'jarda-reporting-crash', false, array(), '1.0.0', true );
wp_enqueue_script( 'jarda-reporting-crash' );
wp_add_inline_script( 'jarda-reporting-crash', 'jarda_crash_me();' );
```

Verify in devtools that the `/js-error` request was sent and accepted (`ok:true` response).

## Does this pull request change what data or activity we track or use?
No