### PR TITLE
Premium Analytics: adaptive sizing for the Posting activity heatmap

### DIFF
--- a/projects/packages/premium-analytics/changelog/2026-07-14-14-02-46-599520
+++ b/projects/packages/premium-analytics/changelog/2026-07-14-14-02-46-599520
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Posting activity: heatmap now scales to its tile.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -113,6 +113,8 @@ export {
 export {
 	useAttributesWithSearchFallback,
 	useChartTheme,
+	useElementSize,
+	type ElementSize,
 	useSegmentStyles,
 	useSeriesStyles,
 	useWidgetDrillDown,

--- a/projects/packages/premium-analytics/widgets/posting-activity/__tests__/layout.test.ts
+++ b/projects/packages/premium-analytics/widgets/posting-activity/__tests__/layout.test.ts
@@ -1,40 +1,41 @@
 /**
  * Internal dependencies
  */
-import { computeCalendarHeatmapLayout, fitCalendarHeatmapColumns } from '../layout';
+import { computeCalendarHeatmapLayout, fitCompactCalendarHeatmapColumns } from '../layout';
 import type { CalendarHeatmapLayoutInput } from '../layout';
 
 const COMPACT_ASPECT = 1;
 const EXPANDED_ASPECT = 61 / 40;
 
-// A compact-mode base matching the widget's tuning; per-test overrides tweak the
-// tile size and mode.
+// Mirror the module-internal geometry constants so the total-dimension
+// assertions stay coherent with layout.ts.
+const ROW_LABEL_WIDTH = 32;
+const CELL_GAP = 4;
+const HEADER_HEIGHT = 16;
+const LEGEND_HEIGHT = 44;
+const ROWS = 7;
+
+// Only the fields the widget actually passes; rows and minColumns fall to their
+// defaults (7 and 6), matching how render.tsx calls this.
 const compactBase: CalendarHeatmapLayoutInput = {
 	availWidth: 400,
 	availHeight: 300,
 	dataColumns: 52,
-	rows: 7,
 	aspectRatio: COMPACT_ASPECT,
 	maxCellHeight: 35,
-	minColumns: 4,
-	gap: 2,
-	headerHeight: 16,
-	legendHeight: 24,
-	rowLabelWidth: 32,
 };
 
 const expandedBase: CalendarHeatmapLayoutInput = {
 	...compactBase,
 	aspectRatio: EXPANDED_ASPECT,
 	maxCellHeight: 48,
-	gap: 4,
 };
 
 describe( 'computeCalendarHeatmapLayout', () => {
-	it( 'a tall-narrow (2:1) tile hits the cell-height cap and preserves the 1:1 ratio', () => {
+	it( 'a tall-narrow tile hits the cell-height cap and preserves the 1:1 ratio', () => {
 		const layout = computeCalendarHeatmapLayout( {
 			...compactBase,
-			availWidth: 200,
+			availWidth: 280,
 			availHeight: 600,
 		} );
 
@@ -42,8 +43,8 @@ describe( 'computeCalendarHeatmapLayout', () => {
 		expect( layout.cellHeight ).toBe( 35 );
 		// Aspect ratio preserved: square cells.
 		expect( layout.cellWidth ).toBeCloseTo( layout.cellHeight * COMPACT_ASPECT );
-		// It is narrow, so it stays compact with only a few columns.
-		expect( layout.columns ).toBe( 4 );
+		// It is narrow, so it keeps only the minimum column count.
+		expect( layout.columns ).toBe( 6 );
 	} );
 
 	it( 'a wide-short (1:4) tile is height-limited yet fits many columns', () => {
@@ -60,7 +61,7 @@ describe( 'computeCalendarHeatmapLayout', () => {
 		expect( layout.columns ).toBe( 52 );
 	} );
 
-	it( 'a narrow-but-large tile triggers the 4-column shrink instead of scrolling', () => {
+	it( 'a narrow-but-large tile triggers the min-column shrink instead of scrolling', () => {
 		const layout = computeCalendarHeatmapLayout( {
 			...expandedBase,
 			availWidth: 250,
@@ -68,8 +69,8 @@ describe( 'computeCalendarHeatmapLayout', () => {
 		} );
 
 		// Falls back to the minimum column count.
-		expect( layout.columns ).toBe( 4 );
-		// The whole cell scaled down below the cap to make 4 columns fit.
+		expect( layout.columns ).toBe( 6 );
+		// The whole cell scaled down below the cap to make the minimum columns fit.
 		expect( layout.cellHeight ).toBeLessThan( expandedBase.maxCellHeight );
 		// Aspect ratio is still preserved (never distorted).
 		expect( layout.cellWidth / layout.cellHeight ).toBeCloseTo( EXPANDED_ASPECT );
@@ -98,8 +99,8 @@ describe( 'computeCalendarHeatmapLayout', () => {
 			dataColumns: 52,
 		} );
 
-		// The width fits 10 aspect-preserving columns; the rest are trimmed.
-		expect( layout.columns ).toBe( 10 );
+		// The width fits 11 aspect-preserving columns; the rest are trimmed.
+		expect( layout.columns ).toBe( 11 );
 		expect( layout.columns ).toBeLessThan( 52 );
 	} );
 
@@ -113,14 +114,9 @@ describe( 'computeCalendarHeatmapLayout', () => {
 		expect( layout.cellWidth / layout.cellHeight ).toBeCloseTo( EXPANDED_ASPECT );
 		// Totals follow the documented formulas exactly.
 		const expectedWidth =
-			expandedBase.rowLabelWidth +
-			layout.columns * layout.cellWidth +
-			( layout.columns - 1 ) * expandedBase.gap;
+			ROW_LABEL_WIDTH + layout.columns * layout.cellWidth + ( layout.columns - 1 ) * CELL_GAP;
 		const expectedHeight =
-			expandedBase.headerHeight +
-			expandedBase.legendHeight +
-			( expandedBase.rows ?? 7 ) * layout.cellHeight +
-			( ( expandedBase.rows ?? 7 ) - 1 ) * expandedBase.gap;
+			HEADER_HEIGHT + LEGEND_HEIGHT + ROWS * layout.cellHeight + ( ROWS - 1 ) * CELL_GAP;
 		expect( layout.heatmapWidth ).toBeCloseTo( expectedWidth );
 		expect( layout.heatmapHeight ).toBeCloseTo( expectedHeight );
 	} );
@@ -143,36 +139,43 @@ describe( 'computeCalendarHeatmapLayout', () => {
 		} );
 	} );
 
-	it( 'defaults rows to 7 and minColumns to 4 when omitted', () => {
+	it( 'defaults rows to 7 when omitted', () => {
+		const layout = computeCalendarHeatmapLayout( {
+			availWidth: 400,
+			availHeight: 600,
+			dataColumns: 52,
+			aspectRatio: COMPACT_ASPECT,
+			maxCellHeight: 35,
+		} );
+
+		// 7 rows at the 35px cap plus overhead and inter-row gaps.
+		expect( layout.heatmapHeight ).toBeCloseTo(
+			HEADER_HEIGHT + LEGEND_HEIGHT + ROWS * 35 + ( ROWS - 1 ) * CELL_GAP
+		);
+	} );
+
+	it( 'defaults minColumns to 6 when omitted', () => {
+		// At 200px only 4 aspect-preserving cells fit; a default minimum of 6 forces
+		// the shrink, so the column count lands on 6 rather than 4.
 		const layout = computeCalendarHeatmapLayout( {
 			availWidth: 200,
 			availHeight: 600,
 			dataColumns: 52,
 			aspectRatio: COMPACT_ASPECT,
 			maxCellHeight: 35,
-			gap: 2,
-			headerHeight: 16,
-			legendHeight: 24,
-			rowLabelWidth: 32,
 		} );
 
-		// 7 rows at the 35px cap plus overhead and inter-row gaps.
-		expect( layout.heatmapHeight ).toBeCloseTo( 16 + 24 + 7 * 35 + 6 * 2 );
-		expect( layout.columns ).toBe( 4 );
+		expect( layout.columns ).toBe( 6 );
 	} );
 } );
 
-describe( 'fitCalendarHeatmapColumns', () => {
+describe( 'fitCompactCalendarHeatmapColumns', () => {
 	const base = {
-		cellWidth: 11,
-		gap: 2,
-		rowLabelWidth: 32,
 		dataColumns: 52,
-		minColumns: 4,
 	};
 
 	it( 'fits as many fixed cells as the width allows, never overflowing', () => {
-		const columns = fitCalendarHeatmapColumns( { ...base, availWidth: 200 } );
+		const columns = fitCompactCalendarHeatmapColumns( { ...base, availWidth: 200 } );
 
 		// floor( (200 - 32) / (11 + 2) ) = floor( 12.9 ) = 12.
 		expect( columns ).toBe( 12 );
@@ -181,17 +184,19 @@ describe( 'fitCalendarHeatmapColumns', () => {
 	} );
 
 	it( 'never returns more columns than weeks in range', () => {
-		expect( fitCalendarHeatmapColumns( { ...base, availWidth: 2000, dataColumns: 20 } ) ).toBe(
-			20
-		);
+		expect(
+			fitCompactCalendarHeatmapColumns( { ...base, availWidth: 2000, dataColumns: 20 } )
+		).toBe( 20 );
 	} );
 
 	it( 'keeps the column minimum on a narrow tile', () => {
-		expect( fitCalendarHeatmapColumns( { ...base, availWidth: 60 } ) ).toBe( 4 );
+		expect( fitCompactCalendarHeatmapColumns( { ...base, availWidth: 60 } ) ).toBe( 6 );
 	} );
 
 	it( 'shows all available when the range has fewer than the minimum', () => {
-		expect( fitCalendarHeatmapColumns( { ...base, availWidth: 60, dataColumns: 2 } ) ).toBe( 2 );
+		expect( fitCompactCalendarHeatmapColumns( { ...base, availWidth: 60, dataColumns: 2 } ) ).toBe(
+			2
+		);
 	} );
 
 	it.each( [
@@ -199,6 +204,8 @@ describe( 'fitCalendarHeatmapColumns', () => {
 		[ 'zero data columns', { availWidth: 500, dataColumns: 0 } ],
 		[ 'NaN width', { availWidth: Number.NaN } ],
 	] )( 'returns 0 for %s', ( _label, override ) => {
-		expect( fitCalendarHeatmapColumns( { ...base, availWidth: 500, ...override } ) ).toBe( 0 );
+		expect( fitCompactCalendarHeatmapColumns( { ...base, availWidth: 500, ...override } ) ).toBe(
+			0
+		);
 	} );
 } );

--- a/projects/packages/premium-analytics/widgets/posting-activity/__tests__/layout.test.ts
+++ b/projects/packages/premium-analytics/widgets/posting-activity/__tests__/layout.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Internal dependencies
+ */
+import { computeCalendarHeatmapLayout, fitCalendarHeatmapColumns } from '../layout';
+import type { CalendarHeatmapLayoutInput } from '../layout';
+
+const COMPACT_ASPECT = 1;
+const EXPANDED_ASPECT = 61 / 40;
+
+// A compact-mode base matching the widget's tuning; per-test overrides tweak the
+// tile size and mode.
+const compactBase: CalendarHeatmapLayoutInput = {
+	availWidth: 400,
+	availHeight: 300,
+	dataColumns: 52,
+	rows: 7,
+	aspectRatio: COMPACT_ASPECT,
+	maxCellHeight: 35,
+	minColumns: 4,
+	gap: 2,
+	headerHeight: 16,
+	legendHeight: 24,
+	rowLabelWidth: 32,
+};
+
+const expandedBase: CalendarHeatmapLayoutInput = {
+	...compactBase,
+	aspectRatio: EXPANDED_ASPECT,
+	maxCellHeight: 48,
+	gap: 4,
+};
+
+describe( 'computeCalendarHeatmapLayout', () => {
+	it( 'a tall-narrow (2:1) tile hits the cell-height cap and preserves the 1:1 ratio', () => {
+		const layout = computeCalendarHeatmapLayout( {
+			...compactBase,
+			availWidth: 200,
+			availHeight: 600,
+		} );
+
+		// Height is ample, so the cell grows to the compact cap, not past it.
+		expect( layout.cellHeight ).toBe( 35 );
+		// Aspect ratio preserved: square cells.
+		expect( layout.cellWidth ).toBeCloseTo( layout.cellHeight * COMPACT_ASPECT );
+		// It is narrow, so it stays compact with only a few columns.
+		expect( layout.columns ).toBe( 4 );
+	} );
+
+	it( 'a wide-short (1:4) tile is height-limited yet fits many columns', () => {
+		const layout = computeCalendarHeatmapLayout( {
+			...compactBase,
+			availWidth: 1200,
+			availHeight: 120,
+		} );
+
+		// Short height keeps the cell well under the cap.
+		expect( layout.cellHeight ).toBeLessThan( compactBase.maxCellHeight );
+		expect( layout.cellHeight ).toBeGreaterThan( 0 );
+		// Wide enough to show every week column in range.
+		expect( layout.columns ).toBe( 52 );
+	} );
+
+	it( 'a narrow-but-large tile triggers the 4-column shrink instead of scrolling', () => {
+		const layout = computeCalendarHeatmapLayout( {
+			...expandedBase,
+			availWidth: 250,
+			availHeight: 600,
+		} );
+
+		// Falls back to the minimum column count.
+		expect( layout.columns ).toBe( 4 );
+		// The whole cell scaled down below the cap to make 4 columns fit.
+		expect( layout.cellHeight ).toBeLessThan( expandedBase.maxCellHeight );
+		// Aspect ratio is still preserved (never distorted).
+		expect( layout.cellWidth / layout.cellHeight ).toBeCloseTo( EXPANDED_ASPECT );
+		// The shrunk grid fills the available width rather than overflowing it.
+		expect( layout.heatmapWidth ).toBeLessThanOrEqual( 250 + 0.01 );
+		expect( layout.heatmapWidth ).toBeCloseTo( 250 );
+	} );
+
+	it( 'shows every column when the range has fewer than the minimum', () => {
+		const layout = computeCalendarHeatmapLayout( {
+			...compactBase,
+			availWidth: 800,
+			availHeight: 300,
+			dataColumns: 3,
+		} );
+
+		// min(minColumns, dataColumns) === 3, and the wide tile fits all of them.
+		expect( layout.columns ).toBe( 3 );
+	} );
+
+	it( 'trims to fewer columns when the weeks in range exceed the width', () => {
+		const layout = computeCalendarHeatmapLayout( {
+			...compactBase,
+			availWidth: 420,
+			availHeight: 300,
+			dataColumns: 52,
+		} );
+
+		// The width fits 10 aspect-preserving columns; the rest are trimmed.
+		expect( layout.columns ).toBe( 10 );
+		expect( layout.columns ).toBeLessThan( 52 );
+	} );
+
+	it( 'preserves the aspect ratio and reports coherent total dimensions', () => {
+		const layout = computeCalendarHeatmapLayout( {
+			...expandedBase,
+			availWidth: 900,
+			availHeight: 320,
+		} );
+
+		expect( layout.cellWidth / layout.cellHeight ).toBeCloseTo( EXPANDED_ASPECT );
+		// Totals follow the documented formulas exactly.
+		const expectedWidth =
+			expandedBase.rowLabelWidth +
+			layout.columns * layout.cellWidth +
+			( layout.columns - 1 ) * expandedBase.gap;
+		const expectedHeight =
+			expandedBase.headerHeight +
+			expandedBase.legendHeight +
+			( expandedBase.rows ?? 7 ) * layout.cellHeight +
+			( ( expandedBase.rows ?? 7 ) - 1 ) * expandedBase.gap;
+		expect( layout.heatmapWidth ).toBeCloseTo( expectedWidth );
+		expect( layout.heatmapHeight ).toBeCloseTo( expectedHeight );
+	} );
+
+	it.each( [
+		[ 'zero width', { availWidth: 0 } ],
+		[ 'zero height', { availHeight: 0 } ],
+		[ 'zero data columns', { dataColumns: 0 } ],
+		[ 'negative width', { availWidth: -100 } ],
+		[ 'NaN height', { availHeight: Number.NaN } ],
+		[ 'infinite width', { availWidth: Number.POSITIVE_INFINITY } ],
+	] )( 'returns a zero layout for %s', ( _label, override ) => {
+		const layout = computeCalendarHeatmapLayout( { ...compactBase, ...override } );
+		expect( layout ).toEqual( {
+			columns: 0,
+			cellWidth: 0,
+			cellHeight: 0,
+			heatmapWidth: 0,
+			heatmapHeight: 0,
+		} );
+	} );
+
+	it( 'defaults rows to 7 and minColumns to 4 when omitted', () => {
+		const layout = computeCalendarHeatmapLayout( {
+			availWidth: 200,
+			availHeight: 600,
+			dataColumns: 52,
+			aspectRatio: COMPACT_ASPECT,
+			maxCellHeight: 35,
+			gap: 2,
+			headerHeight: 16,
+			legendHeight: 24,
+			rowLabelWidth: 32,
+		} );
+
+		// 7 rows at the 35px cap plus overhead and inter-row gaps.
+		expect( layout.heatmapHeight ).toBeCloseTo( 16 + 24 + 7 * 35 + 6 * 2 );
+		expect( layout.columns ).toBe( 4 );
+	} );
+} );
+
+describe( 'fitCalendarHeatmapColumns', () => {
+	const base = {
+		cellWidth: 11,
+		gap: 2,
+		rowLabelWidth: 32,
+		dataColumns: 52,
+		minColumns: 4,
+	};
+
+	it( 'fits as many fixed cells as the width allows, never overflowing', () => {
+		const columns = fitCalendarHeatmapColumns( { ...base, availWidth: 200 } );
+
+		// floor( (200 - 32) / (11 + 2) ) = floor( 12.9 ) = 12.
+		expect( columns ).toBe( 12 );
+		// The trimmed row of cells stays within the available width.
+		expect( 32 + columns * 11 + columns * 2 ).toBeLessThanOrEqual( 200 );
+	} );
+
+	it( 'never returns more columns than weeks in range', () => {
+		expect( fitCalendarHeatmapColumns( { ...base, availWidth: 2000, dataColumns: 20 } ) ).toBe(
+			20
+		);
+	} );
+
+	it( 'keeps the column minimum on a narrow tile', () => {
+		expect( fitCalendarHeatmapColumns( { ...base, availWidth: 60 } ) ).toBe( 4 );
+	} );
+
+	it( 'shows all available when the range has fewer than the minimum', () => {
+		expect( fitCalendarHeatmapColumns( { ...base, availWidth: 60, dataColumns: 2 } ) ).toBe( 2 );
+	} );
+
+	it.each( [
+		[ 'zero width', { availWidth: 0 } ],
+		[ 'zero data columns', { availWidth: 500, dataColumns: 0 } ],
+		[ 'NaN width', { availWidth: Number.NaN } ],
+	] )( 'returns 0 for %s', ( _label, override ) => {
+		expect( fitCalendarHeatmapColumns( { ...base, availWidth: 500, ...override } ) ).toBe( 0 );
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/posting-activity/__tests__/streak-range.test.ts
+++ b/projects/packages/premium-analytics/widgets/posting-activity/__tests__/streak-range.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Internal dependencies
+ */
+import { resolveStreakRange } from '../streak-range';
+
+const TODAY = '2026-07-15';
+const MIN_DAYS = 365;
+
+describe( 'resolveStreakRange', () => {
+	it( 'floors a short picker range to a full year ending on its end date', () => {
+		const range = resolveStreakRange( { from: '2026-07-08', to: '2026-07-15' }, MIN_DAYS, TODAY );
+
+		expect( range.endDate ).toBe( '2026-07-15' );
+		// 365 days before the end date, not the picker's 7-day start.
+		expect( range.startDate ).toBe( '2025-07-15' );
+	} );
+
+	it( 'keeps a picker range that already spans more than the minimum', () => {
+		const range = resolveStreakRange( { from: '2024-01-01', to: '2026-07-15' }, MIN_DAYS, TODAY );
+
+		expect( range.endDate ).toBe( '2026-07-15' );
+		// The picker reaches further back than the floor, so it is preserved.
+		expect( range.startDate ).toBe( '2024-01-01' );
+	} );
+
+	it( 'ends on today and spans a year back when the report has no end date', () => {
+		const range = resolveStreakRange( {}, MIN_DAYS, TODAY );
+
+		expect( range.endDate ).toBe( '2026-07-15' );
+		expect( range.startDate ).toBe( '2025-07-15' );
+	} );
+
+	it( 'derives the date part from an ISO datetime end date', () => {
+		const range = resolveStreakRange(
+			{ from: '2026-07-14T00:00:00Z', to: '2026-07-15T23:59:59Z' },
+			MIN_DAYS,
+			TODAY
+		);
+
+		expect( range.endDate ).toBe( '2026-07-15' );
+		expect( range.startDate ).toBe( '2025-07-15' );
+	} );
+
+	it( 'floors from the end date even when only the start is missing', () => {
+		const range = resolveStreakRange( { to: '2026-03-01' }, MIN_DAYS, TODAY );
+
+		expect( range.endDate ).toBe( '2026-03-01' );
+		expect( range.startDate ).toBe( '2025-03-01' );
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/posting-activity/__tests__/streak-series.test.ts
+++ b/projects/packages/premium-analytics/widgets/posting-activity/__tests__/streak-series.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Internal dependencies
+ */
+import { buildStreakSeries } from '../streak-series';
+
+describe( 'buildStreakSeries', () => {
+	it( 'fills every day across the window, with null for days that have no posts', () => {
+		const series = buildStreakSeries(
+			{ '2026-01-01': 3, '2026-01-03': 1 },
+			'2026-01-01',
+			'2026-01-04'
+		);
+
+		expect( series ).toEqual( [
+			{ dateString: '2026-01-01', value: 3 },
+			{ dateString: '2026-01-02', value: null },
+			{ dateString: '2026-01-03', value: 1 },
+			{ dateString: '2026-01-04', value: null },
+		] );
+	} );
+
+	it( 'keeps a real 0 distinct from a missing day', () => {
+		const series = buildStreakSeries( { '2026-01-02': 0 }, '2026-01-01', '2026-01-02' );
+
+		expect( series ).toEqual( [
+			{ dateString: '2026-01-01', value: null },
+			{ dateString: '2026-01-02', value: 0 },
+		] );
+	} );
+
+	it( 'spans a full year (inclusive) of daily points', () => {
+		const series = buildStreakSeries( { '2026-07-15': 2 }, '2025-07-15', '2026-07-15' );
+
+		expect( series ).toHaveLength( 366 );
+		expect( series[ 0 ].dateString ).toBe( '2025-07-15' );
+		expect( series[ series.length - 1 ] ).toEqual( { dateString: '2026-07-15', value: 2 } );
+	} );
+
+	it( 'derives the date part from ISO datetime bounds', () => {
+		const series = buildStreakSeries(
+			{ '2026-01-01': 5 },
+			'2026-01-01T00:00:00Z',
+			'2026-01-02T23:59:59Z'
+		);
+
+		expect( series ).toEqual( [
+			{ dateString: '2026-01-01', value: 5 },
+			{ dateString: '2026-01-02', value: null },
+		] );
+	} );
+
+	it( 'falls back to the raw entries when the range is missing', () => {
+		const series = buildStreakSeries( { '2026-01-01': 3, '2026-01-05': 1 } );
+
+		expect( series ).toEqual( [
+			{ dateString: '2026-01-01', value: 3 },
+			{ dateString: '2026-01-05', value: 1 },
+		] );
+	} );
+
+	it( 'falls back to the raw entries when the range is inverted', () => {
+		const series = buildStreakSeries( { '2026-01-05': 1 }, '2026-01-05', '2026-01-01' );
+
+		expect( series ).toEqual( [ { dateString: '2026-01-05', value: 1 } ] );
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/posting-activity/layout.ts
+++ b/projects/packages/premium-analytics/widgets/posting-activity/layout.ts
@@ -1,0 +1,195 @@
+/**
+ * Pure geometry for the posting-activity calendar heatmap.
+ *
+ * Given the tile's available width and height, this decides the cell size, how
+ * many week columns to render, and the exact pixel rectangle the heatmap should
+ * occupy. It is intentionally dependency-free (no React, no charts imports) so it
+ * can be lifted into `@automattic/charts` later; the widget owns all policy (mode
+ * switching, trimming) around it.
+ */
+
+export type CalendarHeatmapLayoutInput = {
+	/** Width the tile offers the heatmap, in px. */
+	availWidth: number;
+	/** Height the tile offers the heatmap, in px. */
+	availHeight: number;
+	/** Week columns available in the selected range (variable, not a fixed 52). */
+	dataColumns: number;
+	/** Weekday rows. Defaults to 7. */
+	rows?: number;
+	/** Cell width / height: 1 (compact) or 61/40 (expanded). Always preserved. */
+	aspectRatio: number;
+	/** Per-mode cap on cell height, in px. */
+	maxCellHeight: number;
+	/** Minimum columns to keep before shrinking the cell. Defaults to 4. */
+	minColumns?: number;
+	/** Gap between cells, in px. */
+	gap: number;
+	/** Height reserved for the column-label header row, in px. */
+	headerHeight: number;
+	/** Height reserved for the legend below the grid, in px. */
+	legendHeight: number;
+	/** Width reserved for the weekday row labels, in px. */
+	rowLabelWidth: number;
+};
+
+export type CalendarHeatmapLayout = {
+	/** Week columns actually rendered (≤ dataColumns). */
+	columns: number;
+	/** Rendered cell width, in px. */
+	cellWidth: number;
+	/** Rendered cell height, in px. */
+	cellHeight: number;
+	/** Total heatmap width (row labels + cells + gaps), in px. */
+	heatmapWidth: number;
+	/** Total heatmap height (header + legend + cells + gaps), in px. */
+	heatmapHeight: number;
+};
+
+const ZERO_LAYOUT: CalendarHeatmapLayout = {
+	columns: 0,
+	cellWidth: 0,
+	cellHeight: 0,
+	heatmapWidth: 0,
+	heatmapHeight: 0,
+};
+
+const isPositiveFinite = ( value: number ): boolean => Number.isFinite( value ) && value > 0;
+
+const clamp = ( value: number, min: number, max: number ): number =>
+	Math.min( Math.max( value, min ), max );
+
+export type FitCalendarHeatmapColumnsInput = {
+	/** Width the tile offers the heatmap, in px. */
+	availWidth: number;
+	/** Fixed cell width, in px (compact cells do not scale). */
+	cellWidth: number;
+	/** Gap between cells, in px. */
+	gap: number;
+	/** Width reserved for the weekday row labels, in px. */
+	rowLabelWidth: number;
+	/** Week columns available in the selected range. */
+	dataColumns: number;
+	/** Minimum columns to keep. Defaults to 4. */
+	minColumns?: number;
+};
+
+/**
+ * How many fixed-size cells fit the width without overflowing, bounded by the
+ * weeks in range and the column minimum. For compact mode, where the chart draws
+ * its own fixed-size squares (grid is `max-content`) and would scroll if given
+ * more columns than fit — so unlike the scaling path this must never round up.
+ *
+ * @param input - The tile width and the fixed cell metrics.
+ * @return The column count to trim the data to (0 for a degenerate input).
+ */
+export function fitCalendarHeatmapColumns( input: FitCalendarHeatmapColumnsInput ): number {
+	const { availWidth, cellWidth, gap, rowLabelWidth, dataColumns, minColumns = 4 } = input;
+
+	if (
+		! isPositiveFinite( availWidth ) ||
+		! isPositiveFinite( cellWidth ) ||
+		! isPositiveFinite( dataColumns )
+	) {
+		return 0;
+	}
+
+	const safeGap = Number.isFinite( gap ) && gap > 0 ? gap : 0;
+	const safeRowLabelWidth =
+		Number.isFinite( rowLabelWidth ) && rowLabelWidth > 0 ? rowLabelWidth : 0;
+
+	// Each rendered column occupies a cell plus one grid gap; floor so the row of
+	// cells never exceeds the available width.
+	const fit = Math.floor( ( availWidth - safeRowLabelWidth ) / ( cellWidth + safeGap ) );
+
+	return clamp( fit, Math.min( minColumns, dataColumns ), dataColumns );
+}
+
+/**
+ * Computes the calendar-heatmap layout for a tile.
+ *
+ * Height drives the cell size (capped per mode); width trims the column count.
+ * The aspect ratio is always preserved — when even the minimum column count will
+ * not fit at the aspect-preserving cell width, the whole cell is scaled down
+ * instead of scrolling or distorting.
+ *
+ * @param input - The tile geometry and per-mode tuning.
+ * @return The chosen column count, cell size, and total heatmap rectangle.
+ */
+export function computeCalendarHeatmapLayout(
+	input: CalendarHeatmapLayoutInput
+): CalendarHeatmapLayout {
+	const {
+		availWidth,
+		availHeight,
+		dataColumns,
+		rows = 7,
+		aspectRatio,
+		maxCellHeight,
+		minColumns = 4,
+		gap,
+		headerHeight,
+		legendHeight,
+		rowLabelWidth,
+	} = input;
+
+	// Nothing to lay out (collapsed tile or empty range) → a coherent zero layout.
+	if (
+		! isPositiveFinite( availWidth ) ||
+		! isPositiveFinite( availHeight ) ||
+		! isPositiveFinite( dataColumns ) ||
+		! isPositiveFinite( aspectRatio ) ||
+		! isPositiveFinite( rows )
+	) {
+		return ZERO_LAYOUT;
+	}
+
+	const safeGap = Number.isFinite( gap ) && gap > 0 ? gap : 0;
+	const safeRowLabelWidth =
+		Number.isFinite( rowLabelWidth ) && rowLabelWidth > 0 ? rowLabelWidth : 0;
+	const safeHeaderHeight = Number.isFinite( headerHeight ) && headerHeight > 0 ? headerHeight : 0;
+	const safeLegendHeight = Number.isFinite( legendHeight ) && legendHeight > 0 ? legendHeight : 0;
+	const safeMaxCellHeight = isPositiveFinite( maxCellHeight ) ? maxCellHeight : Infinity;
+
+	// Height drives the cell size: fill the available height (minus overhead and
+	// inter-row gaps) up to the per-mode cap, floored at 0.
+	const heightForRows = availHeight - safeHeaderHeight - safeLegendHeight - ( rows - 1 ) * safeGap;
+	let cellHeight = Math.max( 0, Math.min( heightForRows / rows, safeMaxCellHeight ) );
+	let cellWidth = cellHeight * aspectRatio;
+
+	// Never fewer than this many columns unless the range has fewer weeks.
+	const requiredMinColumns = Math.min( minColumns, dataColumns );
+
+	// How many aspect-preserving cells fit the available width.
+	const widthForCells = availWidth - safeRowLabelWidth + safeGap;
+	const fitColumns =
+		cellWidth + safeGap > 0 ? Math.floor( widthForCells / ( cellWidth + safeGap ) ) : 0;
+
+	let columns: number;
+	if ( fitColumns < requiredMinColumns ) {
+		// 4-column-minimum shrink: the aspect-preserving cell is too wide for the
+		// minimum column count, so scale the whole cell down (ratio kept) until
+		// exactly that many columns fit the width — never scroll, never distort.
+		columns = requiredMinColumns;
+		const innerWidth = availWidth - safeRowLabelWidth - ( columns - 1 ) * safeGap;
+		cellWidth = columns > 0 ? Math.max( 0, innerWidth / columns ) : 0;
+		cellHeight = cellWidth / aspectRatio;
+	} else {
+		// Aspect-preserving cell fits: keep as many columns as the width allows,
+		// bounded by the weeks actually in range.
+		columns = clamp( fitColumns, requiredMinColumns, dataColumns );
+	}
+
+	const heatmapWidth =
+		columns > 0 ? safeRowLabelWidth + columns * cellWidth + ( columns - 1 ) * safeGap : 0;
+	const heatmapHeight =
+		safeHeaderHeight + safeLegendHeight + rows * cellHeight + ( rows - 1 ) * safeGap;
+
+	return {
+		columns,
+		cellWidth,
+		cellHeight,
+		heatmapWidth,
+		heatmapHeight,
+	};
+}

--- a/projects/packages/premium-analytics/widgets/posting-activity/layout.ts
+++ b/projects/packages/premium-analytics/widgets/posting-activity/layout.ts
@@ -23,14 +23,6 @@ export type CalendarHeatmapLayoutInput = {
 	maxCellHeight: number;
 	/** Minimum columns to keep before shrinking the cell. Defaults to 4. */
 	minColumns?: number;
-	/** Gap between cells, in px. */
-	gap: number;
-	/** Height reserved for the column-label header row, in px. */
-	headerHeight: number;
-	/** Height reserved for the legend below the grid, in px. */
-	legendHeight: number;
-	/** Width reserved for the weekday row labels, in px. */
-	rowLabelWidth: number;
 };
 
 export type CalendarHeatmapLayout = {
@@ -62,48 +54,41 @@ const clamp = ( value: number, min: number, max: number ): number =>
 export type FitCalendarHeatmapColumnsInput = {
 	/** Width the tile offers the heatmap, in px. */
 	availWidth: number;
-	/** Fixed cell width, in px (compact cells do not scale). */
-	cellWidth: number;
-	/** Gap between cells, in px. */
-	gap: number;
-	/** Width reserved for the weekday row labels, in px. */
-	rowLabelWidth: number;
 	/** Week columns available in the selected range. */
 	dataColumns: number;
 	/** Minimum columns to keep. Defaults to 4. */
 	minColumns?: number;
 };
 
+const ROW_LABEL_WIDTH = 32;
+const COMPACT_CELL_SIZE = 11;
+const COMPACT_CELL_GAP = 2;
 /**
- * How many fixed-size cells fit the width without overflowing, bounded by the
- * weeks in range and the column minimum. For compact mode, where the chart draws
- * its own fixed-size squares (grid is `max-content`) and would scroll if given
- * more columns than fit — so unlike the scaling path this must never round up.
+ * How many fixed-size cells fit the width without overflowing.
  *
  * @param input - The tile width and the fixed cell metrics.
  * @return The column count to trim the data to (0 for a degenerate input).
  */
-export function fitCalendarHeatmapColumns( input: FitCalendarHeatmapColumnsInput ): number {
-	const { availWidth, cellWidth, gap, rowLabelWidth, dataColumns, minColumns = 4 } = input;
+export function fitCompactCalendarHeatmapColumns( input: FitCalendarHeatmapColumnsInput ): number {
+	const { availWidth, dataColumns, minColumns = 6 } = input;
 
-	if (
-		! isPositiveFinite( availWidth ) ||
-		! isPositiveFinite( cellWidth ) ||
-		! isPositiveFinite( dataColumns )
-	) {
+	if ( ! isPositiveFinite( availWidth ) || ! isPositiveFinite( dataColumns ) ) {
 		return 0;
 	}
 
-	const safeGap = Number.isFinite( gap ) && gap > 0 ? gap : 0;
-	const safeRowLabelWidth =
-		Number.isFinite( rowLabelWidth ) && rowLabelWidth > 0 ? rowLabelWidth : 0;
+	const safeGap =
+		Number.isFinite( COMPACT_CELL_GAP ) && COMPACT_CELL_GAP > 0 ? COMPACT_CELL_GAP : 0;
 
 	// Each rendered column occupies a cell plus one grid gap; floor so the row of
 	// cells never exceeds the available width.
-	const fit = Math.floor( ( availWidth - safeRowLabelWidth ) / ( cellWidth + safeGap ) );
+	const fit = Math.floor( ( availWidth - ROW_LABEL_WIDTH ) / ( COMPACT_CELL_SIZE + safeGap ) );
 
 	return clamp( fit, Math.min( minColumns, dataColumns ), dataColumns );
 }
+
+const CELL_GAP = 4;
+const HEADER_HEIGHT = 16;
+const LEGEND_HEIGHT = 44;
 
 /**
  * Computes the calendar-heatmap layout for a tile.
@@ -126,11 +111,7 @@ export function computeCalendarHeatmapLayout(
 		rows = 7,
 		aspectRatio,
 		maxCellHeight,
-		minColumns = 4,
-		gap,
-		headerHeight,
-		legendHeight,
-		rowLabelWidth,
+		minColumns = 6,
 	} = input;
 
 	// Nothing to lay out (collapsed tile or empty range) → a coherent zero layout.
@@ -144,16 +125,11 @@ export function computeCalendarHeatmapLayout(
 		return ZERO_LAYOUT;
 	}
 
-	const safeGap = Number.isFinite( gap ) && gap > 0 ? gap : 0;
-	const safeRowLabelWidth =
-		Number.isFinite( rowLabelWidth ) && rowLabelWidth > 0 ? rowLabelWidth : 0;
-	const safeHeaderHeight = Number.isFinite( headerHeight ) && headerHeight > 0 ? headerHeight : 0;
-	const safeLegendHeight = Number.isFinite( legendHeight ) && legendHeight > 0 ? legendHeight : 0;
 	const safeMaxCellHeight = isPositiveFinite( maxCellHeight ) ? maxCellHeight : Infinity;
 
 	// Height drives the cell size: fill the available height (minus overhead and
 	// inter-row gaps) up to the per-mode cap, floored at 0.
-	const heightForRows = availHeight - safeHeaderHeight - safeLegendHeight - ( rows - 1 ) * safeGap;
+	const heightForRows = availHeight - HEADER_HEIGHT - LEGEND_HEIGHT - ( rows - 1 ) * CELL_GAP;
 	let cellHeight = Math.max( 0, Math.min( heightForRows / rows, safeMaxCellHeight ) );
 	let cellWidth = cellHeight * aspectRatio;
 
@@ -161,9 +137,9 @@ export function computeCalendarHeatmapLayout(
 	const requiredMinColumns = Math.min( minColumns, dataColumns );
 
 	// How many aspect-preserving cells fit the available width.
-	const widthForCells = availWidth - safeRowLabelWidth + safeGap;
+	const widthForCells = availWidth - ROW_LABEL_WIDTH + CELL_GAP;
 	const fitColumns =
-		cellWidth + safeGap > 0 ? Math.floor( widthForCells / ( cellWidth + safeGap ) ) : 0;
+		cellWidth + CELL_GAP > 0 ? Math.floor( widthForCells / ( cellWidth + CELL_GAP ) ) : 0;
 
 	let columns: number;
 	if ( fitColumns < requiredMinColumns ) {
@@ -171,19 +147,19 @@ export function computeCalendarHeatmapLayout(
 		// minimum column count, so scale the whole cell down (ratio kept) until
 		// exactly that many columns fit the width — never scroll, never distort.
 		columns = requiredMinColumns;
-		const innerWidth = availWidth - safeRowLabelWidth - ( columns - 1 ) * safeGap;
+		const innerWidth = availWidth - ROW_LABEL_WIDTH - ( columns - 1 ) * CELL_GAP;
 		cellWidth = columns > 0 ? Math.max( 0, innerWidth / columns ) : 0;
 		cellHeight = cellWidth / aspectRatio;
 	} else {
 		// Aspect-preserving cell fits: keep as many columns as the width allows,
-		// bounded by the weeks actually in range.
-		columns = clamp( fitColumns, requiredMinColumns, dataColumns );
+		// bounded by the weeks actually in range. This branch is only reached when
+		// `fitColumns >= requiredMinColumns`, so the minimum needs no re-clamping.
+		columns = Math.min( fitColumns, dataColumns );
 	}
 
 	const heatmapWidth =
-		columns > 0 ? safeRowLabelWidth + columns * cellWidth + ( columns - 1 ) * safeGap : 0;
-	const heatmapHeight =
-		safeHeaderHeight + safeLegendHeight + rows * cellHeight + ( rows - 1 ) * safeGap;
+		columns > 0 ? ROW_LABEL_WIDTH + columns * cellWidth + ( columns - 1 ) * CELL_GAP : 0;
+	const heatmapHeight = HEADER_HEIGHT + LEGEND_HEIGHT + rows * cellHeight + ( rows - 1 ) * CELL_GAP;
 
 	return {
 		columns,

--- a/projects/packages/premium-analytics/widgets/posting-activity/render.tsx
+++ b/projects/packages/premium-analytics/widgets/posting-activity/render.tsx
@@ -18,7 +18,7 @@ import { useMemo } from 'react';
 /**
  * Internal dependencies
  */
-import { computeCalendarHeatmapLayout, fitCalendarHeatmapColumns } from './layout';
+import { computeCalendarHeatmapLayout, fitCompactCalendarHeatmapColumns } from './layout';
 import { resolveStreakRange } from './streak-range';
 import { buildStreakSeries } from './streak-series';
 import styles from './style.module.css';
@@ -32,54 +32,12 @@ type PostingActivityRenderAttributes = PostingActivityAttributes &
 type PostingActivityWidgetProps = WidgetRenderProps< PostingActivityRenderAttributes >;
 
 // --- Heatmap sizing tuning ---------------------------------------------------
-// All layout policy lives here so the look can be tuned without touching the
-// pure geometry in `layout.ts`.
-
-/** Weekday rows in the calendar grid (the column-label header row is separate). */
-const ROWS = 7;
-/** Minimum week columns to keep before the cell is scaled down. */
-const MIN_COLUMNS = 4;
-
-/** Expanded cell width / height ratio. Always preserved — cells never stretch. */
 const EXPANDED_ASPECT_RATIO = 61 / 40;
-
-/** Per-mode cap on cell height, in px (height drives the expanded cell size). */
 const EXPANDED_MAX_CELL_HEIGHT = 48;
-
-/**
- * Compact mode renders the chart's own fixed-size squares (it does not scale), so
- * these mirror the chart theme's `heatmapChart.compactCellSize` / `compactCellGap`
- * and are used only to trim the data to the columns that fit the width.
- */
-const COMPACT_CELL_SIZE = 11;
-const COMPACT_CELL_GAP = 2;
-
-/**
- * Gap between expanded cells, in px. Matches the chart grid's own non-compact gap
- * (`--wpds-dimension-gap-xs`), so the computed rectangle agrees with what the
- * chart renders without overriding the chart's gap variable.
- */
-const GAP = 4;
-
-// Overhead reserved around the grid, in px. These budget the chart's own chrome
-// so the computed rectangle leaves room for it: the column-label header row, and
-// the legend plus the gap the chart lays out between the grid and the legend.
-const ROW_LABEL_WIDTH = 32;
-const HEADER_HEIGHT = 16;
-const LEGEND_HEIGHT = 44;
-
-/**
- * Available height (px) at or above which the heatmap switches to expanded 61:40
- * cells. Roughly where compact cells would already hit their cap and there is
- * vertical room to spare; below it the tile stays compact.
- */
+// If the tile is at least this tall, use expanded cells ( not compact ).
 const EXPANDED_MIN_HEIGHT = 220;
 
-/**
- * Minimum span, in days, the streak fetch always covers (ending on the report's
- * end date) so the heatmap has a full year of week columns to lay out even when
- * the dashboard date picker is on a short range.
- */
+// Minimum span, in days.
 const MIN_STREAK_DAYS = 365;
 
 /**
@@ -134,53 +92,40 @@ function PostingActivityInner() {
 	// avoid a scroll.
 	const isExpanded = size.height >= EXPANDED_MIN_HEIGHT;
 
-	const { columns, expandedLayout } = useMemo( () => {
-		if ( isExpanded ) {
-			const computed = computeCalendarHeatmapLayout( {
-				availWidth: size.width,
-				availHeight: size.height,
-				dataColumns,
-				rows: ROWS,
-				aspectRatio: EXPANDED_ASPECT_RATIO,
-				maxCellHeight: EXPANDED_MAX_CELL_HEIGHT,
-				minColumns: MIN_COLUMNS,
-				gap: GAP,
-				headerHeight: HEADER_HEIGHT,
-				legendHeight: LEGEND_HEIGHT,
-				rowLabelWidth: ROW_LABEL_WIDTH,
-			} );
-			return { columns: computed.columns, expandedLayout: computed };
-		}
-
-		const fitColumns = fitCalendarHeatmapColumns( {
-			availWidth: size.width,
-			cellWidth: COMPACT_CELL_SIZE,
-			gap: COMPACT_CELL_GAP,
-			rowLabelWidth: ROW_LABEL_WIDTH,
-			dataColumns,
-			minColumns: MIN_COLUMNS,
-		} );
-		return { columns: fitColumns, expandedLayout: null };
-	}, [ isExpanded, size.width, size.height, dataColumns ] );
-
-	// Keep the most-recent weeks: drop the oldest week columns from the left when
-	// the tile can't fit them all.
-	const trimmedData = useMemo(
-		() => ( columns > 0 ? heatmapData.slice( -columns ) : heatmapData ),
-		[ heatmapData, columns ]
-	);
-
 	// Expanded is sized to the computed rectangle so its `minmax(0, 1fr)` tracks
 	// fill it with 61:40 cells; compact renders the chart's own fixed squares and
 	// sizes itself. The measured parent centers whichever one, so a grid smaller
 	// than the tile sits in centered whitespace.
-	const sizingProps = isExpanded
-		? {
-				width: expandedLayout?.heatmapWidth,
-				height: expandedLayout?.heatmapHeight,
-				showValues: true,
-		  }
-		: { compact: true };
+	const { columns, sizingProps } = useMemo( () => {
+		if ( isExpanded ) {
+			const layout = computeCalendarHeatmapLayout( {
+				availWidth: size.width,
+				availHeight: size.height,
+				dataColumns,
+				aspectRatio: EXPANDED_ASPECT_RATIO,
+				maxCellHeight: EXPANDED_MAX_CELL_HEIGHT,
+			} );
+			return {
+				columns: layout.columns,
+				sizingProps: {
+					width: layout.heatmapWidth,
+					height: layout.heatmapHeight,
+					showValues: layout.cellWidth > 30,
+				},
+			};
+		}
+
+		const fitColumns = fitCompactCalendarHeatmapColumns( {
+			availWidth: size.width,
+			dataColumns,
+		} );
+		return { columns: fitColumns, sizingProps: { compact: true } };
+	}, [ isExpanded, size.width, size.height, dataColumns ] );
+
+	// Keep the most-recent weeks: drop the oldest week columns from the left when
+	// the tile can't fit them all. `slice( -0 )` returns the whole array, so a zero
+	// column count (degenerate tile) leaves the data untouched.
+	const trimmedData = useMemo( () => heatmapData.slice( -columns ), [ heatmapData, columns ] );
 
 	return (
 		<div className={ styles.content } ref={ setRef }>

--- a/projects/packages/premium-analytics/widgets/posting-activity/render.tsx
+++ b/projects/packages/premium-analytics/widgets/posting-activity/render.tsx
@@ -4,19 +4,23 @@
 import { useStatsStreak } from '@jetpack-premium-analytics/data';
 import { calendar } from '@jetpack-premium-analytics/icons';
 import {
-	HeatmapChart,
+	HeatmapChartUnresponsive,
 	WidgetRoot,
 	WidgetState,
 	buildCalendarHeatmapData,
+	useElementSize,
 	useWidgetRootContext,
-	type DataPointDate,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';
+import { format } from 'date-fns';
 import { useMemo } from 'react';
 /**
  * Internal dependencies
  */
+import { computeCalendarHeatmapLayout, fitCalendarHeatmapColumns } from './layout';
+import { resolveStreakRange } from './streak-range';
+import { buildStreakSeries } from './streak-series';
 import styles from './style.module.css';
 import type { PostingActivityAttributes } from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
@@ -27,35 +31,159 @@ type PostingActivityRenderAttributes = PostingActivityAttributes &
 	Partial< ReportParamsFieldAttributes >;
 type PostingActivityWidgetProps = WidgetRenderProps< PostingActivityRenderAttributes >;
 
+// --- Heatmap sizing tuning ---------------------------------------------------
+// All layout policy lives here so the look can be tuned without touching the
+// pure geometry in `layout.ts`.
+
+/** Weekday rows in the calendar grid (the column-label header row is separate). */
+const ROWS = 7;
+/** Minimum week columns to keep before the cell is scaled down. */
+const MIN_COLUMNS = 4;
+
+/** Expanded cell width / height ratio. Always preserved — cells never stretch. */
+const EXPANDED_ASPECT_RATIO = 61 / 40;
+
+/** Per-mode cap on cell height, in px (height drives the expanded cell size). */
+const EXPANDED_MAX_CELL_HEIGHT = 48;
+
+/**
+ * Compact mode renders the chart's own fixed-size squares (it does not scale), so
+ * these mirror the chart theme's `heatmapChart.compactCellSize` / `compactCellGap`
+ * and are used only to trim the data to the columns that fit the width.
+ */
+const COMPACT_CELL_SIZE = 11;
+const COMPACT_CELL_GAP = 2;
+
+/**
+ * Gap between expanded cells, in px. Matches the chart grid's own non-compact gap
+ * (`--wpds-dimension-gap-xs`), so the computed rectangle agrees with what the
+ * chart renders without overriding the chart's gap variable.
+ */
+const GAP = 4;
+
+// Overhead reserved around the grid, in px. These budget the chart's own chrome
+// so the computed rectangle leaves room for it: the column-label header row, and
+// the legend plus the gap the chart lays out between the grid and the legend.
+const ROW_LABEL_WIDTH = 32;
+const HEADER_HEIGHT = 16;
+const LEGEND_HEIGHT = 44;
+
+/**
+ * Available height (px) at or above which the heatmap switches to expanded 61:40
+ * cells. Roughly where compact cells would already hit their cap and there is
+ * vertical room to spare; below it the tile stays compact.
+ */
+const EXPANDED_MIN_HEIGHT = 220;
+
+/**
+ * Minimum span, in days, the streak fetch always covers (ending on the report's
+ * end date) so the heatmap has a full year of week columns to lay out even when
+ * the dashboard date picker is on a short range.
+ */
+const MIN_STREAK_DAYS = 365;
+
 /**
  * Fetches the posting-activity streak through the designated `useStatsStreak`
  * hook and renders it as a calendar heatmap. The `stats/streak` endpoint
  * returns a `{ 'yyyy-MM-dd': count }` map of posts per day (no comparison
  * period); `buildCalendarHeatmapData` lays that out into the week-column /
- * weekday-row grid the chart expects. The date range comes from the dashboard
- * picker via `reportParams`.
+ * weekday-row grid the chart expects.
+ *
+ * The date range comes from the dashboard picker via `reportParams`, but the
+ * fetch window is floored to at least a year (`MIN_STREAK_DAYS`) ending on the
+ * picker's end date — a calendar heatmap needs a span of weeks, not a 7-day slice.
+ *
+ * The heatmap adapts to the tile: it measures the available space and picks
+ * compact (fixed-size squares) or expanded (scaled 61:40 cells with numbers) from
+ * the available height, trimming the data to the columns that fit the width.
  *
  * @return The widget content.
  */
 function PostingActivityInner() {
 	const { reportParams } = useWidgetRootContext();
 
-	const { data, isLoading, isFetching, isError, refetch } = useStatsStreak( reportParams );
+	// Floor the fetch window to a full year ending on the picker's end date.
+	const streakRange = useMemo(
+		() => resolveStreakRange( reportParams, MIN_STREAK_DAYS, format( new Date(), 'yyyy-MM-dd' ) ),
+		[ reportParams ]
+	);
+	const streakParams = useMemo(
+		() => ( { ...reportParams, startDate: streakRange.startDate, endDate: streakRange.endDate } ),
+		[ reportParams, streakRange ]
+	);
+
+	const { data, isLoading, isFetching, isError, refetch } = useStatsStreak( streakParams );
 
 	const { data: heatmapData, rowLabels } = useMemo( () => {
-		const series: DataPointDate[] = Object.entries( data ?? {} ).map(
-			( [ dateString, value ] ) => ( {
-				dateString,
-				value,
-			} )
-		);
+		// The endpoint returns only days with posts; densify to the full window so
+		// the heatmap spans every week column, not just the weeks that have posts.
+		const series = buildStreakSeries( data ?? {}, streakRange.startDate, streakRange.endDate );
 		return buildCalendarHeatmapData( series );
-	}, [ data ] );
+	}, [ data, streakRange ] );
 
 	const hasData = heatmapData.length > 0;
+	const dataColumns = heatmapData.length;
+
+	// Measure the tile; the parent div fills the widget slot (with no padding of its
+	// own), so its size is the space the heatmap has to work with.
+	const [ setRef, size ] = useElementSize< HTMLDivElement >();
+
+	// Height drives the mode. Expanded: a scaled 61:40 grid sized to the computed
+	// rectangle (numbers shown). Compact: the chart's own fixed-size squares — we
+	// don't size it, only compute how many columns fit so the data is trimmed to
+	// avoid a scroll.
+	const isExpanded = size.height >= EXPANDED_MIN_HEIGHT;
+
+	const { columns, expandedLayout } = useMemo( () => {
+		if ( isExpanded ) {
+			const computed = computeCalendarHeatmapLayout( {
+				availWidth: size.width,
+				availHeight: size.height,
+				dataColumns,
+				rows: ROWS,
+				aspectRatio: EXPANDED_ASPECT_RATIO,
+				maxCellHeight: EXPANDED_MAX_CELL_HEIGHT,
+				minColumns: MIN_COLUMNS,
+				gap: GAP,
+				headerHeight: HEADER_HEIGHT,
+				legendHeight: LEGEND_HEIGHT,
+				rowLabelWidth: ROW_LABEL_WIDTH,
+			} );
+			return { columns: computed.columns, expandedLayout: computed };
+		}
+
+		const fitColumns = fitCalendarHeatmapColumns( {
+			availWidth: size.width,
+			cellWidth: COMPACT_CELL_SIZE,
+			gap: COMPACT_CELL_GAP,
+			rowLabelWidth: ROW_LABEL_WIDTH,
+			dataColumns,
+			minColumns: MIN_COLUMNS,
+		} );
+		return { columns: fitColumns, expandedLayout: null };
+	}, [ isExpanded, size.width, size.height, dataColumns ] );
+
+	// Keep the most-recent weeks: drop the oldest week columns from the left when
+	// the tile can't fit them all.
+	const trimmedData = useMemo(
+		() => ( columns > 0 ? heatmapData.slice( -columns ) : heatmapData ),
+		[ heatmapData, columns ]
+	);
+
+	// Expanded is sized to the computed rectangle so its `minmax(0, 1fr)` tracks
+	// fill it with 61:40 cells; compact renders the chart's own fixed squares and
+	// sizes itself. The measured parent centers whichever one, so a grid smaller
+	// than the tile sits in centered whitespace.
+	const sizingProps = isExpanded
+		? {
+				width: expandedLayout?.heatmapWidth,
+				height: expandedLayout?.heatmapHeight,
+				showValues: true,
+		  }
+		: { compact: true };
 
 	return (
-		<div className={ styles.content }>
+		<div className={ styles.content } ref={ setRef }>
 			<WidgetState
 				isLoading={ isLoading }
 				isFetching={ isFetching }
@@ -77,19 +205,19 @@ function PostingActivityInner() {
 					description: __( 'No posts published in this period.', 'jetpack-premium-analytics' ),
 				} }
 			>
-				<HeatmapChart
-					data={ heatmapData }
+				<HeatmapChartUnresponsive
+					data={ trimmedData }
 					rowLabels={ rowLabels }
-					compact
+					className={ styles.heatmap }
 					primaryColor="var(--wp-admin-theme-color, #3858e9)"
 					withTooltips
-					className={ styles.heatmap }
+					{ ...sizingProps }
 				>
-					<HeatmapChart.Legend
+					<HeatmapChartUnresponsive.Legend
 						lessLabel={ __( 'Fewer Posts', 'jetpack-premium-analytics' ) }
 						moreLabel={ __( 'More Posts', 'jetpack-premium-analytics' ) }
 					/>
-				</HeatmapChart>
+				</HeatmapChartUnresponsive>
 			</WidgetState>
 		</div>
 	);

--- a/projects/packages/premium-analytics/widgets/posting-activity/streak-range.ts
+++ b/projects/packages/premium-analytics/widgets/posting-activity/streak-range.ts
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { getDatePart } from '@jetpack-premium-analytics/datetime';
+import { format, parseISO, subDays } from 'date-fns';
+
+export type StreakRange = {
+	/** Inclusive first day to fetch, `yyyy-MM-dd`. */
+	startDate: string;
+	/** Inclusive last day to fetch, `yyyy-MM-dd`. */
+	endDate: string;
+};
+
+/**
+ * Floors the streak fetch window to at least `minDays` ending on the report's end
+ * date, so the calendar heatmap always has a full span of week columns to lay out
+ * — even when the dashboard date picker is on a short range (a 7-day range would
+ * otherwise yield a single week column). A longer picker range is kept as-is.
+ *
+ * Pure and date-injectable so it can be unit-tested without a clock: `todayIso`
+ * is only the fallback end date when the report has no `to`.
+ *
+ * @param params      - The report params (`yyyy-MM-dd` or ISO dates).
+ * @param params.from - Picker start date, when present.
+ * @param params.to   - Picker end date, when present.
+ * @param minDays     - Minimum number of days the window must span.
+ * @param todayIso    - Fallback end date (`yyyy-MM-dd`) when `params.to` is absent.
+ * @return The floored `{ startDate, endDate }` window.
+ */
+export function resolveStreakRange(
+	params: { from?: string; to?: string },
+	minDays: number,
+	todayIso: string
+): StreakRange {
+	const endDate = getDatePart( params.to ) ?? todayIso;
+	// Earliest start the window may have and still cover `minDays`.
+	const minStart = format( subDays( parseISO( endDate ), minDays ), 'yyyy-MM-dd' );
+	const from = getDatePart( params.from );
+	// Keep the picker's start only when it already reaches further back than the
+	// floor; `yyyy-MM-dd` strings compare chronologically.
+	const startDate = from && from < minStart ? from : minStart;
+
+	return { startDate, endDate };
+}

--- a/projects/packages/premium-analytics/widgets/posting-activity/streak-series.ts
+++ b/projects/packages/premium-analytics/widgets/posting-activity/streak-series.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { getDatePart } from '@jetpack-premium-analytics/datetime';
 import type { DataPointDate } from '@jetpack-premium-analytics/widgets-toolkit';
 
 /**
@@ -23,8 +24,8 @@ export function buildStreakSeries(
 	from?: string,
 	to?: string
 ): DataPointDate[] {
-	const fromPart = from?.split( 'T' )[ 0 ];
-	const toPart = to?.split( 'T' )[ 0 ];
+	const fromPart = getDatePart( from );
+	const toPart = getDatePart( to );
 
 	if ( ! fromPart || ! toPart || fromPart > toPart ) {
 		return Object.entries( counts ).map( ( [ dateString, value ] ) => ( {

--- a/projects/packages/premium-analytics/widgets/posting-activity/streak-series.ts
+++ b/projects/packages/premium-analytics/widgets/posting-activity/streak-series.ts
@@ -1,0 +1,51 @@
+/**
+ * External dependencies
+ */
+import type { DataPointDate } from '@jetpack-premium-analytics/widgets-toolkit';
+
+/**
+ * Densifies the sparse `stats/streak` response into a per-day series across the
+ * whole fetched window. The endpoint only returns days that have posts, so on its
+ * own `buildCalendarHeatmapData` would only see those clustered dates and lay out
+ * the weeks between them. Filling every day from `from` to `to` — missing days
+ * become `null`, an empty cell distinct from a real `0` — makes the heatmap span
+ * the full range of week columns regardless of where posts fall.
+ *
+ * Falls back to the raw entries when the range is missing or inverted.
+ *
+ * @param counts - Post counts keyed by `yyyy-MM-dd` (only days with posts).
+ * @param from   - Inclusive first day (`yyyy-MM-dd` or ISO), when present.
+ * @param to     - Inclusive last day (`yyyy-MM-dd` or ISO), when present.
+ * @return One data point per day across the window.
+ */
+export function buildStreakSeries(
+	counts: Record< string, number >,
+	from?: string,
+	to?: string
+): DataPointDate[] {
+	const fromPart = from?.split( 'T' )[ 0 ];
+	const toPart = to?.split( 'T' )[ 0 ];
+
+	if ( ! fromPart || ! toPart || fromPart > toPart ) {
+		return Object.entries( counts ).map( ( [ dateString, value ] ) => ( {
+			dateString,
+			value,
+		} ) );
+	}
+
+	const series: DataPointDate[] = [];
+	// Iterate in UTC so the day-by-day walk is DST-agnostic; the keys are plain
+	// calendar dates.
+	const end = new Date( `${ toPart }T00:00:00Z` );
+
+	for (
+		let day = new Date( `${ fromPart }T00:00:00Z` );
+		day <= end;
+		day.setUTCDate( day.getUTCDate() + 1 )
+	) {
+		const dateString = day.toISOString().slice( 0, 10 );
+		series.push( { dateString, value: counts[ dateString ] ?? null } );
+	}
+
+	return series;
+}

--- a/projects/packages/premium-analytics/widgets/posting-activity/style.module.css
+++ b/projects/packages/premium-analytics/widgets/posting-activity/style.module.css
@@ -6,21 +6,22 @@
 	overflow: hidden;
 }
 
+/* Measured tile area (the ref lives here): its size is the space the heatmap
+   works with, and it centers the heatmap so a grid smaller than the tile sits
+   in centered whitespace, not a corner. No scroll — columns trim to fit. */
 .content {
 	position: relative;
 	display: flex;
-	flex-direction: column;
 	flex: 1 1 0;
+	min-width: 0;
 	min-height: 0;
-	padding: var(--wpds-dimension-padding-lg);
-
-	/* The compact heatmap sizes to its content; let a wide 12-month grid scroll
-	   inside a narrow card instead of clipping months. */
-	overflow-x: auto;
+	align-items: center;
+	justify-content: center;
 }
 
-/* Center the fixed-size grid + legend group in a taller-than-content card so it
-   doesn't hug the top; horizontal start keeps overflow scrolling reachable. */
+/* Center the grid within the chart. Expanded is already sized to its rectangle;
+   compact fills the width with fixed squares, so this keeps that grid centered
+   rather than hugging the start edge. */
 .heatmap {
 	min-width: 0;
 	justify-content: center;

--- a/projects/packages/premium-analytics/widgets/posting-activity/style.module.css
+++ b/projects/packages/premium-analytics/widgets/posting-activity/style.module.css
@@ -16,7 +16,6 @@
 	min-width: 0;
 	min-height: 0;
 	align-items: center;
-	justify-content: center;
 }
 
 /* Center the grid within the chart. Expanded is already sized to its rectangle;


### PR DESCRIPTION
## Proposed changes

The Posting activity widget rendered its calendar heatmap in the chart's fixed-square `compact` mode at a fixed size, so it never adapted to the tile — tiny in tall tiles, and a full year overflowed into a horizontal scroll in narrow ones. It also only spanned the weeks that happened to contain posts. This makes the heatmap adapt to its tile and always show a full range.

**Sizing (pure geometry + widget policy)**
* New `layout.ts`: `computeCalendarHeatmapLayout` (expanded cell size, column count, exact rectangle) and `fitCalendarHeatmapColumns` (how many fixed cells fit a width). Dependency-free (no React/charts imports) so it can later be lifted into `@automattic/charts`.
* The widget measures the tile (`useElementSize` on the parent div) and picks the mode from its **height**:
  * **Expanded** (taller tiles): scaled **61:40** cells with in-cell numbers, sized to the computed rectangle via `HeatmapChartUnresponsive` `width`/`height` — so the chart's `minmax(0,1fr)` tracks produce the exact cells (no wrapper div, no double measurement). I borrowed the 61/40 from Eders demo, but we can adjust this.
  * **Compact** (shorter tiles): the chart's own **fixed-size squares** (`compact` prop) — the widget doesn't scale it, only trims the data to the columns that fit the width, so the `max-content` grid never scrolls.
* Both paths trim to the **most-recent** weeks when the tile can't fit them all. Width isn't part of the mode choice — a tall-narrow tile goes expanded and the 4-column-minimum shrink keeps cells fitting (`minColumns` is the knob to show more weeks there).

**Data**
* Floor the `stats/streak` fetch to at least a year ending on the picker's end date (`resolveStreakRange`) — a calendar heatmap needs a span of weeks, not a 7-day slice.
* Densify the sparse `{ 'yyyy-MM-dd': count }` response (only days with posts) to the full window, missing days → `null` (`buildStreakSeries`). Without this, `buildCalendarHeatmapData` derives its range from the returned data's min/max, so posts clustered in a narrow window would still collapse to a few columns even with the year-long fetch.

**Toolkit**
* Expose `HeatmapChartUnresponsive` and `useElementSize` through the widgets-toolkit passthrough (widgets must not import `@automattic/charts` directly). No charts-package change.

No changes to `@automattic/charts` are needed — expanded sizing reuses the existing `HeatmapChartUnresponsive` `width`/`height`, and compact reuses the existing `compact` prop.

Closes: WOOA7S-1693


https://github.com/user-attachments/assets/89825e7b-fd25-4999-9431-47be14acc2e2

## Related product discussion/links

* [WOOA7S-1693: Posting activity heat map only shows a single week](https://linear.app/a8c/issue/WOOA7S-1693/posting-activity-heat-map-only-shows-a-single-week)

## Does this pull request change what data or activity we track or use?

No — same `stats/streak` endpoint; only the requested date window is widened.

## Testing instructions

* `jetpack build --deps packages/premium-analytics` (or `pnpm run build`), then run Storybook for `js-packages/storybook`.
* Open **Packages / Premium Analytics / Widgets / PostingActivity → WidgetDashboardWithWidget** and drive the size controls (`widgetWidth`, `widgetHeight`, `rowHeight`, `dashboardWidth`):
  * **Short/narrow tiles** — compact fixed squares, columns trim to the most-recent weeks, **no horizontal scroll**.
  * **Tall tiles** — expanded 61:40 cells with per-day numbers, sized to the tile.
  * The heatmap always spans a full year of week columns regardless of the date-picker range.
* Open the Analytics dashboard and add the "posting activity" widget, increase/decrease the size, it should scale accordingly. 
* Unit tests: `pnpm --filter automattic/jetpack-premium-analytics test -- widgets/posting-activity` (31 tests across the layout geometry, column fit, the ≥365-day range floor, and the streak-series densification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
