### PR TITLE
SEO: compute the Overview content-coverage counts in a single query and cache them

### DIFF
--- a/projects/packages/seo/changelog/fix-jetpack-1848-cache-content-coverage
+++ b/projects/packages/seo/changelog/fix-jetpack-1848-cache-content-coverage
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Overview: cache the content-coverage counts and compute them in a single query.

--- a/projects/packages/seo/src/class-initializer.php
+++ b/projects/packages/seo/src/class-initializer.php
@@ -570,6 +570,29 @@ class Initializer {
 	}
 
 	/**
+	 * Post types the content-coverage counts span.
+	 *
+	 * @return string[]
+	 */
+	private static function coverage_post_types() {
+		return array( 'post', 'page' );
+	}
+
+	/**
+	 * The SEO post-meta keys the content-coverage counts read.
+	 *
+	 * @return string[]
+	 */
+	private static function coverage_meta_keys() {
+		return array(
+			self::META_SCHEMA_TYPE,
+			self::META_TITLE,
+			self::META_DESCRIPTION,
+			self::META_NOINDEX,
+		);
+	}
+
+	/**
 	 * Factual content-coverage counts for the Overview card: how many published
 	 * posts/pages have each SEO field set. State, not a score — the card shows
 	 * proportions + raw counts and lets the admin decide what matters.
@@ -577,63 +600,79 @@ class Initializer {
 	 * @return array{total:int,with_schema:int,with_title:int,with_description:int,with_search_visible:int}
 	 */
 	private static function get_content_coverage() {
-		$post_types = array( 'post', 'page' );
+		global $wpdb;
 
-		$total = 0;
-		foreach ( $post_types as $post_type ) {
-			$counts = wp_count_posts( $post_type );
-			$total += isset( $counts->publish ) ? (int) $counts->publish : 0;
+		$post_types = self::coverage_post_types();
+		$meta_keys  = self::coverage_meta_keys();
+
+		$meta_key_placeholders  = implode( ', ', array_fill( 0, count( $meta_keys ), '%s' ) );
+		$post_type_placeholders = implode( ', ', array_fill( 0, count( $post_types ), '%s' ) );
+
+		/*
+		 * Driven from `wp_postmeta`, not `wp_posts`: most sites have far more published
+		 * posts than SEO fields set, so the join starts from the small side, where the
+		 * `meta_key` index serves `meta_key IN (…)` directly.
+		 *
+		 * The aggregate has no GROUP BY, so it still returns its single row — counts at
+		 * zero, `total` intact — on a site with no SEO meta at all.
+		 *
+		 * COUNT( DISTINCT p.ID ) because a post can carry more than one row for the same
+		 * meta key. `<> ''` counts a field as set; noindex alone is an exact `= '1'`.
+		 */
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		$sql = $wpdb->prepare(
+			"SELECT
+				(
+					SELECT COUNT(*)
+					FROM {$wpdb->posts}
+					WHERE post_status = 'publish' AND post_type IN ( {$post_type_placeholders} )
+				) AS total,
+				COUNT( DISTINCT CASE WHEN pm.meta_key = %s AND pm.meta_value <> '' THEN p.ID END ) AS with_schema,
+				COUNT( DISTINCT CASE WHEN pm.meta_key = %s AND pm.meta_value <> '' THEN p.ID END ) AS with_title,
+				COUNT( DISTINCT CASE WHEN pm.meta_key = %s AND pm.meta_value <> '' THEN p.ID END ) AS with_description,
+				COUNT( DISTINCT CASE WHEN pm.meta_key = %s AND pm.meta_value = '1' THEN p.ID END ) AS noindexed
+			FROM {$wpdb->postmeta} pm
+			INNER JOIN {$wpdb->posts} p
+				ON p.ID = pm.post_id
+				AND p.post_status = 'publish'
+				AND p.post_type IN ( {$post_type_placeholders} )
+			WHERE pm.meta_key IN ( {$meta_key_placeholders} )",
+			array_merge(
+				$post_types,
+				// The CASE arms above, in the order they appear.
+				array( self::META_SCHEMA_TYPE, self::META_TITLE, self::META_DESCRIPTION, self::META_NOINDEX ),
+				$post_types,
+				$meta_keys
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Aggregate count with no core API equivalent; $sql is the prepared statement built directly above.
+		$row = $wpdb->get_row( $sql );
+
+		if ( ! $row ) {
+			return array(
+				'total'               => 0,
+				'with_schema'         => 0,
+				'with_title'          => 0,
+				'with_description'    => 0,
+				'with_search_visible' => 0,
+			);
 		}
 
-		// Search-engine visibility is the inverse of the per-post noindex meta: a
-		// post is visible unless it's explicitly set to noindex (stored as '1'), so
-		// most posts (no meta row) count as visible.
-		$noindexed = self::count_published_with_meta( $post_types, self::META_NOINDEX, '1' );
+		$total     = (int) $row->total;
+		$noindexed = (int) $row->noindexed;
 
 		return array(
 			'total'               => $total,
-			'with_schema'         => self::count_published_with_meta( $post_types, self::META_SCHEMA_TYPE ),
-			'with_title'          => self::count_published_with_meta( $post_types, self::META_TITLE ),
-			'with_description'    => self::count_published_with_meta( $post_types, self::META_DESCRIPTION ),
+			'with_schema'         => (int) $row->with_schema,
+			'with_title'          => (int) $row->with_title,
+			'with_description'    => (int) $row->with_description,
+			// Search-engine visibility is the inverse of the per-post noindex meta: a
+			// post is visible unless it's explicitly set to noindex (stored as '1'), so
+			// most posts (no meta row) count as visible.
 			'with_search_visible' => max( 0, $total - $noindexed ),
 		);
-	}
-
-	/**
-	 * Count published posts/pages whose meta is set. With no `$value`, counts a
-	 * non-empty string meta; with a `$value`, counts an exact match.
-	 *
-	 * @param string[]    $post_types Post types to count across.
-	 * @param string      $meta_key   Meta key to test.
-	 * @param string|null $value      Exact value to match, or null for "non-empty".
-	 * @return int
-	 */
-	private static function count_published_with_meta( $post_types, $meta_key, $value = null ) {
-		$clause = null === $value
-			? array(
-				'key'     => $meta_key,
-				'value'   => '',
-				'compare' => '!=',
-			)
-			: array(
-				'key'   => $meta_key,
-				'value' => $value,
-			);
-
-		$query = new \WP_Query(
-			array(
-				'post_type'              => $post_types,
-				'post_status'            => 'publish',
-				'posts_per_page'         => 1,
-				'fields'                 => 'ids',
-				'update_post_meta_cache' => false,
-				'update_post_term_cache' => false,
-				// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query -- Overview snapshot; one count query per metric on the SEO page only.
-				'meta_query'             => array( $clause ),
-			)
-		);
-
-		return (int) $query->found_posts;
 	}
 
 	/**

--- a/projects/packages/seo/src/class-initializer.php
+++ b/projects/packages/seo/src/class-initializer.php
@@ -127,11 +127,35 @@ class Initializer {
 	const VISIBILITY_OPTION = 'jetpack_seo_surface_visible';
 
 	/**
+	 * Transient holding the Overview's content-coverage counts.
+	 *
+	 * Versioned, so a future change to the payload's shape can't read a stale array
+	 * written by an older version of this code.
+	 *
+	 * @var string
+	 */
+	const COVERAGE_COUNTS_TRANSIENT = 'jetpack_seo_content_coverage_counts_v1';
+
+	/**
+	 * How long the content-coverage counts survive without being invalidated.
+	 *
+	 * @var int
+	 */
+	const COVERAGE_COUNTS_TTL = HOUR_IN_SECONDS;
+
+	/**
 	 * Whether the package has been initialized.
 	 *
 	 * @var bool
 	 */
 	private static $initialized = false;
+
+	/**
+	 * Whether the coverage transient has already been dropped during this request.
+	 *
+	 * @var bool
+	 */
+	private static $coverage_invalidated = false;
 
 	/**
 	 * Initialize the package.
@@ -185,6 +209,12 @@ class Initializer {
 		// dashboard recovers its data instead of dead-ending. Registered whenever the
 		// surface is visible (independent of the seo-tools module, like the Overview).
 		add_action( 'rest_api_init', array( __CLASS__, 'register_rest_reads' ) );
+
+		// Keep the Overview's cached content-coverage counts honest. Hooked here rather than
+		// alongside the admin surface above because posts are written from everywhere — the
+		// block editor (REST), the classic editor, wp-cli, cron, other plugins — and the
+		// cache has to be dropped wherever that happens, not just where it's read.
+		self::register_coverage_invalidation();
 
 		// The settings surface only comes online once SEO tools are active — there's
 		// nothing to configure while the module is off, so we don't register its REST
@@ -597,9 +627,56 @@ class Initializer {
 	 * posts/pages have each SEO field set. State, not a score — the card shows
 	 * proportions + raw counts and lets the admin decide what matters.
 	 *
+	 * Served from {@see self::COVERAGE_COUNTS_TRANSIENT} when it's warm. The counts are read on
+	 * every load of the SEO page — and by every tab of it, since the dashboard preloads
+	 * all of its REST reads at once — so without a cache a plain reload pays for the
+	 * query again having changed nothing.
+	 *
 	 * @return array{total:int,with_schema:int,with_title:int,with_description:int,with_search_visible:int}
 	 */
 	private static function get_content_coverage() {
+		$cached = get_transient( self::COVERAGE_COUNTS_TRANSIENT );
+
+		if ( self::is_content_coverage( $cached ) ) {
+			return $cached;
+		}
+
+		$coverage = self::compute_content_coverage();
+
+		set_transient( self::COVERAGE_COUNTS_TRANSIENT, $coverage, self::COVERAGE_COUNTS_TTL );
+		// The cache is warm again, so a later write in this same request has something
+		// to invalidate and must not be swallowed by the once-per-request guard.
+		self::$coverage_invalidated = false;
+
+		return $coverage;
+	}
+
+	/**
+	 * Whether a value read back from the cache is a coverage payload this code can use.
+	 *
+	 * @param mixed $value Value read from the transient.
+	 * @return bool
+	 */
+	private static function is_content_coverage( $value ) {
+		if ( ! is_array( $value ) ) {
+			return false;
+		}
+
+		foreach ( array( 'total', 'with_schema', 'with_title', 'with_description', 'with_search_visible' ) as $key ) {
+			if ( ! isset( $value[ $key ] ) || ! is_int( $value[ $key ] ) ) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Count the coverage metrics straight from the database.
+	 *
+	 * @return array{total:int,with_schema:int,with_title:int,with_description:int,with_search_visible:int}
+	 */
+	private static function compute_content_coverage() {
 		global $wpdb;
 
 		$post_types = self::coverage_post_types();
@@ -647,7 +724,7 @@ class Initializer {
 		);
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Aggregate count with no core API equivalent; $sql is the prepared statement built directly above.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Aggregate count with no core API equivalent; $sql is the prepared statement built directly above. The result is cached in self::COVERAGE_COUNTS_TRANSIENT by the get_content_coverage() wrapper, which is the only caller — the sniff just can't see across the two methods.
 		$row = $wpdb->get_row( $sql );
 
 		if ( ! $row ) {
@@ -673,6 +750,91 @@ class Initializer {
 			// most posts (no meta row) count as visible.
 			'with_search_visible' => max( 0, $total - $noindexed ),
 		);
+	}
+
+	/**
+	 * Hook the writes that can move the content-coverage counts.
+	 *
+	 * @return void
+	 */
+	public static function register_coverage_invalidation() {
+		// Covers publish, unpublish, trash, untrash and scheduled posts going live — every
+		// route by which a post enters or leaves the published set.
+		add_action( 'transition_post_status', array( __CLASS__, 'invalidate_content_coverage_on_status_change' ), 10, 3 );
+		add_action( 'deleted_post', array( __CLASS__, 'invalidate_content_coverage_on_delete' ), 10, 2 );
+
+		foreach ( array( 'added_post_meta', 'updated_post_meta', 'deleted_post_meta' ) as $hook ) {
+			add_action( $hook, array( __CLASS__, 'invalidate_content_coverage_on_meta_change' ), 10, 3 );
+		}
+	}
+
+	/**
+	 * Drop the cached counts when a post enters or leaves the published set.
+	 *
+	 * @param string        $new_status Status the post is moving to.
+	 * @param string        $old_status Status the post is moving from.
+	 * @param \WP_Post|null $post       The post being transitioned.
+	 * @return void
+	 */
+	public static function invalidate_content_coverage_on_status_change( $new_status, $old_status, $post ) {
+		if ( ! $post instanceof \WP_Post || ! in_array( $post->post_type, self::coverage_post_types(), true ) ) {
+			return;
+		}
+
+		// Draft to draft, pending to draft, and the like never touch the counts.
+		if ( 'publish' !== $new_status && 'publish' !== $old_status ) {
+			return;
+		}
+
+		self::invalidate_content_coverage();
+	}
+
+	/**
+	 * Drop the cached counts when a post is deleted outright.
+	 *
+	 * Trashing already goes through `transition_post_status`; this catches a hard delete,
+	 * which for an already-trashed post transitions nothing.
+	 *
+	 * @param int           $post_id Deleted post ID.
+	 * @param \WP_Post|null $post    The post that was deleted.
+	 * @return void
+	 */
+	public static function invalidate_content_coverage_on_delete( $post_id, $post = null ) {
+		if ( ! $post instanceof \WP_Post || ! in_array( $post->post_type, self::coverage_post_types(), true ) ) {
+			return;
+		}
+
+		self::invalidate_content_coverage();
+	}
+
+	/**
+	 * Drop the cached counts when one of the SEO fields they count is written.
+	 *
+	 * @param int|int[] $meta_id   Meta row ID, or IDs on delete. Unused.
+	 * @param int       $object_id Post the meta belongs to. Unused.
+	 * @param string    $meta_key  Meta key written.
+	 * @return void
+	 */
+	public static function invalidate_content_coverage_on_meta_change( $meta_id, $object_id, $meta_key ) {
+		if ( ! in_array( $meta_key, self::coverage_meta_keys(), true ) ) {
+			return;
+		}
+
+		self::invalidate_content_coverage();
+	}
+
+	/**
+	 * Drop the cached counts, at most once per request.
+	 *
+	 * @return void
+	 */
+	private static function invalidate_content_coverage() {
+		if ( self::$coverage_invalidated ) {
+			return;
+		}
+
+		self::$coverage_invalidated = true;
+		delete_transient( self::COVERAGE_COUNTS_TRANSIENT );
 	}
 
 	/**

--- a/projects/packages/seo/src/class-initializer.php
+++ b/projects/packages/seo/src/class-initializer.php
@@ -151,13 +151,6 @@ class Initializer {
 	private static $initialized = false;
 
 	/**
-	 * Whether the coverage transient has already been dropped during this request.
-	 *
-	 * @var bool
-	 */
-	private static $coverage_invalidated = false;
-
-	/**
 	 * Initialize the package.
 	 *
 	 * Called from the Jetpack plugin's `late_initialization()` hook.
@@ -644,9 +637,6 @@ class Initializer {
 		$coverage = self::compute_content_coverage();
 
 		set_transient( self::COVERAGE_COUNTS_TRANSIENT, $coverage, self::COVERAGE_COUNTS_TTL );
-		// The cache is warm again, so a later write in this same request has something
-		// to invalidate and must not be swallowed by the once-per-request guard.
-		self::$coverage_invalidated = false;
 
 		return $coverage;
 	}
@@ -774,6 +764,12 @@ class Initializer {
 	/**
 	 * Drop the cached counts when a post enters or leaves the published set.
 	 *
+	 * Known limitation: this hook only ever sees the post's new type, so converting a
+	 * published post to an uncounted post type (or the reverse) isn't caught here and
+	 * leaves `total` stale until the next tracked write or the transient's TTL expiry.
+	 * A direct `set_post_type()` bypasses every hook anyway, so the TTL backstop is what
+	 * ultimately bounds that staleness.
+	 *
 	 * @param string        $new_status Status the post is moving to.
 	 * @param string        $old_status Status the post is moving from.
 	 * @param \WP_Post|null $post       The post being transitioned.
@@ -827,16 +823,11 @@ class Initializer {
 	}
 
 	/**
-	 * Drop the cached counts, at most once per request.
+	 * Drop the cached counts.
 	 *
 	 * @return void
 	 */
 	private static function invalidate_content_coverage() {
-		if ( self::$coverage_invalidated ) {
-			return;
-		}
-
-		self::$coverage_invalidated = true;
 		delete_transient( self::COVERAGE_COUNTS_TRANSIENT );
 	}
 

--- a/projects/packages/seo/src/class-initializer.php
+++ b/projects/packages/seo/src/class-initializer.php
@@ -725,30 +725,33 @@ class Initializer {
 		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
 
 		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.NotPrepared -- Aggregate count with no core API equivalent; $sql is the prepared statement built directly above. The result is cached in self::COVERAGE_COUNTS_TRANSIENT by the get_content_coverage() wrapper, which is the only caller — the sniff just can't see across the two methods.
-		$row = $wpdb->get_row( $sql );
+		$row = $wpdb->get_row( $sql, ARRAY_A );
 
-		if ( ! $row ) {
-			return array(
-				'total'               => 0,
-				'with_schema'         => 0,
-				'with_title'          => 0,
-				'with_description'    => 0,
-				'with_search_visible' => 0,
-			);
-		}
-
-		$total     = (int) $row->total;
-		$noindexed = (int) $row->noindexed;
+		// Defaults, so a query that returns nothing at all reads as an empty site rather
+		// than fataling on a missing key.
+		$counts = array_map(
+			'intval',
+			array_merge(
+				array(
+					'total'            => 0,
+					'with_schema'      => 0,
+					'with_title'       => 0,
+					'with_description' => 0,
+					'noindexed'        => 0,
+				),
+				is_array( $row ) ? $row : array()
+			)
+		);
 
 		return array(
-			'total'               => $total,
-			'with_schema'         => (int) $row->with_schema,
-			'with_title'          => (int) $row->with_title,
-			'with_description'    => (int) $row->with_description,
+			'total'               => $counts['total'],
+			'with_schema'         => $counts['with_schema'],
+			'with_title'          => $counts['with_title'],
+			'with_description'    => $counts['with_description'],
 			// Search-engine visibility is the inverse of the per-post noindex meta: a
 			// post is visible unless it's explicitly set to noindex (stored as '1'), so
 			// most posts (no meta row) count as visible.
-			'with_search_visible' => max( 0, $total - $noindexed ),
+			'with_search_visible' => max( 0, $counts['total'] - $counts['noindexed'] ),
 		);
 	}
 

--- a/projects/packages/seo/tests/php/InitializerTest.php
+++ b/projects/packages/seo/tests/php/InitializerTest.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\SEO;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -15,6 +16,66 @@ use PHPUnit\Framework\TestCase;
  */
 #[CoversClass( Initializer::class )]
 class InitializerTest extends TestCase {
+
+	/**
+	 * The coverage cache and its once-per-request guard are process state, so they leak
+	 * between tests unless both are cleared.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->reset_coverage_cache();
+	}
+
+	protected function tearDown(): void {
+		$this->reset_coverage_cache();
+		parent::tearDown();
+	}
+
+	/**
+	 * Drop the cached counts and re-arm the once-per-request invalidation guard.
+	 */
+	private function reset_coverage_cache() {
+		delete_transient( Initializer::COVERAGE_COUNTS_TRANSIENT );
+
+		$guard = new \ReflectionProperty( Initializer::class, 'coverage_invalidated' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$guard->setAccessible( true );
+		}
+		$guard->setValue( null, false );
+	}
+
+	/**
+	 * Invoke one of the class's private statics.
+	 *
+	 * @param string $name Method name.
+	 * @param mixed  ...$args Arguments.
+	 * @return mixed
+	 */
+	private function invoke_private( $name, ...$args ) {
+		$method = new \ReflectionMethod( Initializer::class, $name );
+		// Required to invoke a private method on PHP < 8.1 (a no-op from 8.1 on).
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		return $method->invoke( null, ...$args );
+	}
+
+	/**
+	 * A coverage payload with distinctive numbers, so a cached read is unmistakable:
+	 * recomputing in this database-less suite can only ever produce zeros.
+	 *
+	 * @return array
+	 */
+	private function seeded_coverage() {
+		return array(
+			'total'               => 41,
+			'with_schema'         => 7,
+			'with_title'          => 13,
+			'with_description'    => 11,
+			'with_search_visible' => 39,
+		);
+	}
 
 	/**
 	 * The Initializer class exists and exposes the expected menu slug.
@@ -115,6 +176,172 @@ class InitializerTest extends TestCase {
 	}
 
 	/**
+	 * A warm cache is returned as-is. The seeded numbers can't have been recomputed —
+	 * there's no database here, so a recompute yields zeros — which is what makes this
+	 * prove the query was skipped rather than merely that the shape survived.
+	 */
+	public function test_content_coverage_is_served_from_the_cache() {
+		set_transient( Initializer::COVERAGE_COUNTS_TRANSIENT, $this->seeded_coverage(), HOUR_IN_SECONDS );
+
+		$this->assertSame( $this->seeded_coverage(), $this->invoke_private( 'get_content_coverage' ) );
+	}
+
+	/**
+	 * A miss computes and then writes the counts back, so the next read is a hit.
+	 */
+	public function test_content_coverage_populates_the_cache_on_a_miss() {
+		$this->assertFalse( get_transient( Initializer::COVERAGE_COUNTS_TRANSIENT ) );
+
+		$coverage = $this->invoke_private( 'get_content_coverage' );
+
+		$this->assertSame( $coverage, get_transient( Initializer::COVERAGE_COUNTS_TRANSIENT ) );
+	}
+
+	/**
+	 * Anything in the transient that isn't a well-formed payload — a truncated write, a
+	 * value left by an older version of this code, someone else's data under the key — is
+	 * treated as a miss. The Overview card destructures all five counts unconditionally,
+	 * so handing it a partial array would be worse than recomputing.
+	 *
+	 * @param mixed $garbage Value found in the transient.
+	 * @dataProvider provide_malformed_cache_values
+	 */
+	#[DataProvider( 'provide_malformed_cache_values' )]
+	public function test_malformed_cache_value_is_recomputed( $garbage ) {
+		set_transient( Initializer::COVERAGE_COUNTS_TRANSIENT, $garbage, HOUR_IN_SECONDS );
+
+		$coverage = $this->invoke_private( 'get_content_coverage' );
+
+		$this->assertSame(
+			array(
+				'total'               => 0,
+				'with_schema'         => 0,
+				'with_title'          => 0,
+				'with_description'    => 0,
+				'with_search_visible' => 0,
+			),
+			$coverage
+		);
+	}
+
+	/**
+	 * @return array<string, array{mixed}>
+	 */
+	public static function provide_malformed_cache_values() {
+		return array(
+			'a string'           => array( 'nonsense' ),
+			'a partial payload'  => array( array( 'total' => 5 ) ),
+			'non-integer counts' => array(
+				array(
+					'total'               => '5',
+					'with_schema'         => '1',
+					'with_title'          => '1',
+					'with_description'    => '1',
+					'with_search_visible' => '5',
+				),
+			),
+		);
+	}
+
+	/**
+	 * Writing one of the four SEO fields the Overview counts drops the cache; writing any
+	 * other post meta leaves it alone. Without that second half, every meta write on the
+	 * site — and plugins write a lot of it — would throw the counts away.
+	 */
+	public function test_meta_change_invalidates_only_for_the_counted_keys() {
+		set_transient( Initializer::COVERAGE_COUNTS_TRANSIENT, $this->seeded_coverage(), HOUR_IN_SECONDS );
+
+		Initializer::invalidate_content_coverage_on_meta_change( 1, 123, '_edit_lock' );
+		$this->assertSame(
+			$this->seeded_coverage(),
+			get_transient( Initializer::COVERAGE_COUNTS_TRANSIENT ),
+			'An unrelated meta key must not invalidate the counts.'
+		);
+
+		Initializer::invalidate_content_coverage_on_meta_change( 1, 123, Initializer::META_DESCRIPTION );
+		$this->assertFalse( get_transient( Initializer::COVERAGE_COUNTS_TRANSIENT ) );
+	}
+
+	/**
+	 * Publishing and unpublishing move the counts; a transition between two unpublished
+	 * states doesn't, and neither does one on a post type the Overview never counts.
+	 *
+	 * @param string $new_status  Status transitioned to.
+	 * @param string $old_status  Status transitioned from.
+	 * @param string $post_type   Post type transitioning.
+	 * @param bool   $invalidates Whether the cache should be dropped.
+	 * @dataProvider provide_status_transitions
+	 */
+	#[DataProvider( 'provide_status_transitions' )]
+	public function test_status_change_invalidates_only_when_the_published_set_changes( $new_status, $old_status, $post_type, $invalidates ) {
+		set_transient( Initializer::COVERAGE_COUNTS_TRANSIENT, $this->seeded_coverage(), HOUR_IN_SECONDS );
+
+		$post = new \WP_Post( (object) array( 'post_type' => $post_type ) );
+		Initializer::invalidate_content_coverage_on_status_change( $new_status, $old_status, $post );
+
+		if ( $invalidates ) {
+			$this->assertFalse( get_transient( Initializer::COVERAGE_COUNTS_TRANSIENT ) );
+		} else {
+			$this->assertSame( $this->seeded_coverage(), get_transient( Initializer::COVERAGE_COUNTS_TRANSIENT ) );
+		}
+	}
+
+	/**
+	 * @return array<string, array{string, string, string, bool}>
+	 */
+	public static function provide_status_transitions() {
+		return array(
+			'post published'         => array( 'publish', 'draft', 'post', true ),
+			'page published'         => array( 'publish', 'auto-draft', 'page', true ),
+			'post unpublished'       => array( 'draft', 'publish', 'post', true ),
+			'post trashed'           => array( 'trash', 'publish', 'post', true ),
+			'draft to pending'       => array( 'pending', 'draft', 'post', false ),
+			'uncounted post type'    => array( 'publish', 'draft', 'attachment', false ),
+			'uncounted type trashed' => array( 'trash', 'publish', 'product', false ),
+		);
+	}
+
+	/**
+	 * A hard delete drops the cache for the counted post types only. Trashing already went
+	 * through the status transition; this is the path where an already-trashed post is
+	 * deleted for good and transitions nothing.
+	 */
+	public function test_delete_invalidates_only_for_the_counted_post_types() {
+		set_transient( Initializer::COVERAGE_COUNTS_TRANSIENT, $this->seeded_coverage(), HOUR_IN_SECONDS );
+
+		Initializer::invalidate_content_coverage_on_delete( 123, new \WP_Post( (object) array( 'post_type' => 'attachment' ) ) );
+		$this->assertSame( $this->seeded_coverage(), get_transient( Initializer::COVERAGE_COUNTS_TRANSIENT ) );
+
+		Initializer::invalidate_content_coverage_on_delete( 123, new \WP_Post( (object) array( 'post_type' => 'page' ) ) );
+		$this->assertFalse( get_transient( Initializer::COVERAGE_COUNTS_TRANSIENT ) );
+	}
+
+	/**
+	 * A bulk write fires the invalidation hooks once per post; the cache only needs
+	 * clearing once, so the second call is a no-op. But reading the counts warms the cache
+	 * again, and a write after that must invalidate for real — otherwise a long-running
+	 * process that reads then keeps writing would leave stale numbers behind.
+	 */
+	public function test_invalidation_runs_once_per_request_until_the_cache_is_warm_again() {
+		set_transient( Initializer::COVERAGE_COUNTS_TRANSIENT, $this->seeded_coverage(), HOUR_IN_SECONDS );
+
+		Initializer::invalidate_content_coverage_on_meta_change( 1, 123, Initializer::META_TITLE );
+		$this->assertFalse( get_transient( Initializer::COVERAGE_COUNTS_TRANSIENT ) );
+
+		// Nothing has re-read the counts, so a second write has nothing to drop and must
+		// not issue another delete.
+		set_transient( Initializer::COVERAGE_COUNTS_TRANSIENT, $this->seeded_coverage(), HOUR_IN_SECONDS );
+		Initializer::invalidate_content_coverage_on_meta_change( 2, 124, Initializer::META_TITLE );
+		$this->assertSame( $this->seeded_coverage(), get_transient( Initializer::COVERAGE_COUNTS_TRANSIENT ) );
+
+		// Reading re-warms the cache and re-arms the guard, so the next write invalidates.
+		$this->reset_coverage_cache();
+		$this->invoke_private( 'get_content_coverage' );
+		Initializer::invalidate_content_coverage_on_meta_change( 3, 125, Initializer::META_TITLE );
+		$this->assertFalse( get_transient( Initializer::COVERAGE_COUNTS_TRANSIENT ) );
+	}
+
+	/**
 	 * `get_overview_data()` assembles the full Overview bootstrap (site
 	 * visibility, verification booleans, content coverage, and plan state) the
 	 * dashboard reads. With no host-plugin options present it degrades to
@@ -174,6 +401,22 @@ class InitializerTest extends TestCase {
 			$this->assertNotFalse(
 				has_action( 'rest_api_init', array( Initializer::class, 'register_rest_settings' ) )
 			);
+
+			// The coverage cache is invalidated from writes that happen anywhere — the block
+			// editor posts through REST, where is_admin() is false — so these have to be
+			// registered by init() itself, not by the admin-only branch above.
+			$this->assertNotFalse(
+				has_action( 'transition_post_status', array( Initializer::class, 'invalidate_content_coverage_on_status_change' ) )
+			);
+			$this->assertNotFalse(
+				has_action( 'deleted_post', array( Initializer::class, 'invalidate_content_coverage_on_delete' ) )
+			);
+			foreach ( array( 'added_post_meta', 'updated_post_meta', 'deleted_post_meta' ) as $hook ) {
+				$this->assertNotFalse(
+					has_action( $hook, array( Initializer::class, 'invalidate_content_coverage_on_meta_change' ) ),
+					"init() must hook {$hook} to keep the coverage counts fresh."
+				);
+			}
 		} finally {
 			remove_filter( 'rsm_jetpack_seo', '__return_true' );
 			remove_filter( 'jetpack_active_modules', $enable_module );

--- a/projects/packages/seo/tests/php/InitializerTest.php
+++ b/projects/packages/seo/tests/php/InitializerTest.php
@@ -60,23 +60,58 @@ class InitializerTest extends TestCase {
 	}
 
 	/**
-	 * `count_published_with_meta()` supports an exact-value match (used for the
-	 * schema-type metric) in addition to the default "non-empty" mode. Exercised
-	 * directly because the Overview only ever calls the non-empty mode, so the
-	 * value-match branch would otherwise go uncovered. Returns an integer count
-	 * (zero in the empty test environment).
+	 * The coverage query joins `wp_postmeta` on the key list `coverage_meta_keys()`
+	 * returns, but counts each metric with its own CASE arm naming a `META_*`
+	 * constant directly. Those two have to name the same keys: a key dropped from
+	 * the join list (or a CASE arm pointing at a key the join never selected) makes
+	 * the affected metric silently count zero rather than fail. Pin both lists.
 	 */
-	public function test_count_published_with_meta_supports_exact_value() {
-		$method = new \ReflectionMethod( Initializer::class, 'count_published_with_meta' );
+	public function test_coverage_targets_the_seo_meta_keys_and_post_types() {
+		$meta_keys  = new \ReflectionMethod( Initializer::class, 'coverage_meta_keys' );
+		$post_types = new \ReflectionMethod( Initializer::class, 'coverage_post_types' );
+		// Required to invoke a private method on PHP < 8.1 (a no-op from 8.1 on).
+		if ( PHP_VERSION_ID < 80100 ) {
+			$meta_keys->setAccessible( true );
+			$post_types->setAccessible( true );
+		}
+
+		$this->assertEqualsCanonicalizing(
+			array(
+				Initializer::META_SCHEMA_TYPE,
+				Initializer::META_TITLE,
+				Initializer::META_DESCRIPTION,
+				Initializer::META_NOINDEX,
+			),
+			$meta_keys->invoke( null ),
+			'Every meta key a CASE arm counts must also be selected by the join.'
+		);
+
+		$this->assertSame( array( 'post', 'page' ), $post_types->invoke( null ) );
+	}
+
+	/**
+	 * With no database behind it (this suite runs WorDBless dbless), the coverage
+	 * query returns nothing. It has to degrade to a well-formed all-zero payload —
+	 * the Overview card destructures all five counts unconditionally — and do it
+	 * without emitting a notice, which PHPUnit is configured to fail on.
+	 */
+	public function test_content_coverage_degrades_to_zeros_without_a_database() {
+		$method = new \ReflectionMethod( Initializer::class, 'get_content_coverage' );
 		// Required to invoke a private method on PHP < 8.1 (a no-op from 8.1 on).
 		if ( PHP_VERSION_ID < 80100 ) {
 			$method->setAccessible( true );
 		}
 
-		$count = $method->invoke( null, array( 'post', 'page' ), 'jetpack_seo_schema_type', 'article' );
-
-		$this->assertIsInt( $count );
-		$this->assertSame( 0, $count );
+		$this->assertSame(
+			array(
+				'total'               => 0,
+				'with_schema'         => 0,
+				'with_title'          => 0,
+				'with_description'    => 0,
+				'with_search_visible' => 0,
+			),
+			$method->invoke( null )
+		);
 	}
 
 	/**

--- a/projects/packages/seo/tests/php/InitializerTest.php
+++ b/projects/packages/seo/tests/php/InitializerTest.php
@@ -18,17 +18,32 @@ use PHPUnit\Framework\TestCase;
 class InitializerTest extends TestCase {
 
 	/**
-	 * The coverage cache and its once-per-request guard are process state, so they leak
-	 * between tests unless both are cleared.
+	 * The cache, its once-per-request guard and the database all persist between tests
+	 * here, so every one of them has to start from a known-empty state.
 	 */
 	protected function setUp(): void {
 		parent::setUp();
 		$this->reset_coverage_cache();
+		$this->reset_content();
 	}
 
 	protected function tearDown(): void {
+		$this->reset_content();
 		$this->reset_coverage_cache();
 		parent::tearDown();
+	}
+
+	/**
+	 * Empty the posts tables. WorDBless keeps the SQLite database between tests, so
+	 * content created by one test would otherwise be counted by the next.
+	 */
+	private function reset_content() {
+		global $wpdb;
+
+		$wpdb->query( "DELETE FROM {$wpdb->postmeta}" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		$wpdb->query( "DELETE FROM {$wpdb->posts}" ); // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+
+		wp_cache_flush();
 	}
 
 	/**
@@ -151,18 +166,11 @@ class InitializerTest extends TestCase {
 	}
 
 	/**
-	 * With no database behind it (this suite runs WorDBless dbless), the coverage
-	 * query returns nothing. It has to degrade to a well-formed all-zero payload —
-	 * the Overview card destructures all five counts unconditionally — and do it
-	 * without emitting a notice, which PHPUnit is configured to fail on.
+	 * An empty site still gets a well-formed payload. The aggregate has no GROUP BY, so
+	 * it returns its row even with nothing to count, and the Overview card destructures
+	 * all five counts unconditionally.
 	 */
-	public function test_content_coverage_degrades_to_zeros_without_a_database() {
-		$method = new \ReflectionMethod( Initializer::class, 'get_content_coverage' );
-		// Required to invoke a private method on PHP < 8.1 (a no-op from 8.1 on).
-		if ( PHP_VERSION_ID < 80100 ) {
-			$method->setAccessible( true );
-		}
-
+	public function test_content_coverage_is_all_zeros_on_an_empty_site() {
 		$this->assertSame(
 			array(
 				'total'               => 0,
@@ -171,7 +179,110 @@ class InitializerTest extends TestCase {
 				'with_description'    => 0,
 				'with_search_visible' => 0,
 			),
-			$method->invoke( null )
+			$this->invoke_private( 'get_content_coverage' )
+		);
+	}
+
+	/**
+	 * The counts against real content. Every fixture here is one the query could plausibly
+	 * get wrong: a post with two rows for the same meta key must be counted once, not
+	 * twice; an empty-string value means "not set"; noindex only counts on an exact '1',
+	 * so '0' leaves the post search-visible; and drafts, trashed posts and other post types
+	 * are not part of the published set at all.
+	 */
+	public function test_content_coverage_counts_published_posts_and_pages() {
+		// Published, everything set, and hidden from search.
+		$this->publish(
+			array(
+				Initializer::META_SCHEMA_TYPE => 'Article',
+				Initializer::META_TITLE       => 'A title',
+				Initializer::META_DESCRIPTION => 'A description',
+				Initializer::META_NOINDEX     => '1',
+			)
+		);
+
+		// Published, nothing set.
+		$this->publish();
+
+		// Empty strings are not "set".
+		$this->publish(
+			array(
+				Initializer::META_TITLE       => '',
+				Initializer::META_DESCRIPTION => '',
+			)
+		);
+
+		// noindex '0' is not noindexed — the post stays search-visible.
+		$this->publish( array( Initializer::META_NOINDEX => '0' ) );
+
+		// Two rows for one key: the post has a title, and counts once.
+		$duplicated = $this->publish();
+		$this->add_meta_row( $duplicated, Initializer::META_TITLE, 'first' );
+		$this->add_meta_row( $duplicated, Initializer::META_TITLE, 'second' );
+
+		// A page counts alongside posts.
+		$this->publish( array( Initializer::META_DESCRIPTION => 'Page description' ), 'page' );
+
+		// None of these are part of the published set.
+		$this->publish( array( Initializer::META_TITLE => 'Draft title' ), 'post', 'draft' );
+		$this->publish( array( Initializer::META_TITLE => 'Trashed title' ), 'post', 'trash' );
+		$this->publish( array( Initializer::META_TITLE => 'Attachment title' ), 'attachment' );
+
+		$this->assertSame(
+			array(
+				'total'               => 6,
+				'with_schema'         => 1,
+				'with_title'          => 2,
+				'with_description'    => 2,
+				'with_search_visible' => 5,
+			),
+			$this->invoke_private( 'get_content_coverage' )
+		);
+	}
+
+	/**
+	 * Publish a post with the given SEO meta.
+	 *
+	 * @param array  $meta      Meta keys to set.
+	 * @param string $post_type Post type.
+	 * @param string $status    Post status.
+	 * @return int Post ID.
+	 */
+	private function publish( $meta = array(), $post_type = 'post', $status = 'publish' ) {
+		$post_id = wp_insert_post(
+			array(
+				'post_title'  => 'Test post',
+				'post_status' => $status,
+				'post_type'   => $post_type,
+			)
+		);
+
+		foreach ( $meta as $key => $value ) {
+			update_post_meta( $post_id, $key, $value );
+		}
+
+		return $post_id;
+	}
+
+	/**
+	 * Add a postmeta row directly, so a post can end up with two rows for one key —
+	 * which `update_post_meta()` would never produce, and which the counts must dedupe.
+	 *
+	 * @param int    $post_id Post to attach the row to.
+	 * @param string $key     Meta key.
+	 * @param string $value   Meta value.
+	 * @return void
+	 */
+	private function add_meta_row( $post_id, $key, $value ) {
+		global $wpdb;
+
+		$wpdb->insert(
+			$wpdb->postmeta,
+			array(
+				'post_id'    => $post_id,
+				'meta_key'   => $key,
+				'meta_value' => $value,
+			)
 		);
 	}
 

--- a/projects/packages/seo/tests/php/InitializerTest.php
+++ b/projects/packages/seo/tests/php/InitializerTest.php
@@ -18,8 +18,8 @@ use PHPUnit\Framework\TestCase;
 class InitializerTest extends TestCase {
 
 	/**
-	 * The cache, its once-per-request guard and the database all persist between tests
-	 * here, so every one of them has to start from a known-empty state.
+	 * The cache and the database both persist between tests here, so every one of them
+	 * has to start from a known-empty state.
 	 */
 	protected function setUp(): void {
 		parent::setUp();
@@ -47,16 +47,10 @@ class InitializerTest extends TestCase {
 	}
 
 	/**
-	 * Drop the cached counts and re-arm the once-per-request invalidation guard.
+	 * Drop the cached counts.
 	 */
 	private function reset_coverage_cache() {
 		delete_transient( Initializer::COVERAGE_COUNTS_TRANSIENT );
-
-		$guard = new \ReflectionProperty( Initializer::class, 'coverage_invalidated' );
-		if ( PHP_VERSION_ID < 80100 ) {
-			$guard->setAccessible( true );
-		}
-		$guard->setValue( null, false );
 	}
 
 	/**
@@ -428,27 +422,19 @@ class InitializerTest extends TestCase {
 	}
 
 	/**
-	 * A bulk write fires the invalidation hooks once per post; the cache only needs
-	 * clearing once, so the second call is a no-op. But reading the counts warms the cache
-	 * again, and a write after that must invalidate for real — otherwise a long-running
-	 * process that reads then keeps writing would leave stale numbers behind.
+	 * Every tracked write drops the transient, with no once-per-request guard: a later
+	 * write in the same request must clear a cache a concurrent read re-warmed in between,
+	 * so an intermediate count can't survive to the end of a bulk update.
 	 */
-	public function test_invalidation_runs_once_per_request_until_the_cache_is_warm_again() {
+	public function test_every_tracked_write_invalidates_the_cache() {
 		set_transient( Initializer::COVERAGE_COUNTS_TRANSIENT, $this->seeded_coverage(), HOUR_IN_SECONDS );
 
 		Initializer::invalidate_content_coverage_on_meta_change( 1, 123, Initializer::META_TITLE );
 		$this->assertFalse( get_transient( Initializer::COVERAGE_COUNTS_TRANSIENT ) );
 
-		// Nothing has re-read the counts, so a second write has nothing to drop and must
-		// not issue another delete.
+		// A concurrent read re-warms the cache mid-write; the next write must still clear it.
 		set_transient( Initializer::COVERAGE_COUNTS_TRANSIENT, $this->seeded_coverage(), HOUR_IN_SECONDS );
 		Initializer::invalidate_content_coverage_on_meta_change( 2, 124, Initializer::META_TITLE );
-		$this->assertSame( $this->seeded_coverage(), get_transient( Initializer::COVERAGE_COUNTS_TRANSIENT ) );
-
-		// Reading re-warms the cache and re-arms the guard, so the next write invalidates.
-		$this->reset_coverage_cache();
-		$this->invoke_private( 'get_content_coverage' );
-		Initializer::invalidate_content_coverage_on_meta_change( 3, 125, Initializer::META_TITLE );
 		$this->assertFalse( get_transient( Initializer::COVERAGE_COUNTS_TRANSIENT ) );
 	}
 

--- a/projects/packages/seo/tests/php/bootstrap.php
+++ b/projects/packages/seo/tests/php/bootstrap.php
@@ -9,7 +9,17 @@ require_once __DIR__ . '/../../vendor/autoload.php';
 
 define( 'WP_DEBUG', true );
 
-\Automattic\Jetpack\Test_Environment::init();
+// SQLite rather than the default dbless engine: the Overview's content-coverage counts
+// are a single SQL aggregate over wp_posts/wp_postmeta, and dbless has no database for it
+// to run against — every count would be zero no matter what the query said.
+\Automattic\Jetpack\Test_Environment::init( null, 'sqlite' );
+
+// A real database starts without the default roles, so every capability check fails.
+// Seed them, so tests that act as an administrator have the capabilities of one.
+if ( ! function_exists( 'populate_roles' ) ) {
+	require_once ABSPATH . 'wp-admin/includes/schema.php';
+}
+populate_roles();
 
 // Controllable stand-ins for the host-plugin classes the SEO package guards on
 // with class_exists(). The real implementations live in projects/plugins/jetpack


### PR DESCRIPTION
Fixes JETPACK-1848

## Proposed changes

The SEO dashboard's Overview "content coverage" card recomputed its five counts on **every** load of the page — and on every *tab* of it, since `inject_script_data()` preloads all three REST reads at once, so opening Settings or AI also paid for the Overview's counts.

The PR addresses that by:

* **Collapsing the counts into one aggregate query.** It's driven from `wp_postmeta`, not `wp_posts`: most sites have far more published posts than SEO fields set, so the join starts from the small side, where the `meta_key` index serves it directly. `total` comes from a scalar subquery the `type_status_date` index answers on its own.
* **Caching the result in a transient**, invalidated on the writes that can actually move the numbers: a post entering or leaving the published set (`transition_post_status`), hard deletes (`deleted_post`), and add/update/delete of the four SEO meta keys the card counts.

No client-side changes: the `content_coverage` payload shape is unchanged.

## Related product discussion/links

* https://linear.app/a8c/issue/JETPACK-1848/
* Sub-issue of JETPACK-1843 (SEO package audit findings)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The SEO surface is behind a feature flag — add `add_filter( 'rsm_jetpack_seo', '__return_true' );` in a mu-plugin (it must run before `plugins_loaded`). On a fresh install `jetpack_seo_surface_visible` is already seeded true.

**The counts must not change.** This PR is a pure performance change, so the important check is that the numbers are identical to before:

* Create a mix of published posts and pages, some with SEO fields set (Title, Description, Schema type, "Hide from search engines") and some without. Include a few drafts and trashed posts, which must *not* be counted.
* Go to **Jetpack → SEO → Overview** and confirm the content-coverage card's five numbers match what you'd expect (total published posts+pages, and how many have each field set).
* Check out `trunk`, reload, and confirm the numbers are the same.


