### PR TITLE
VideoPress: add playable preview to the video details page

### DIFF
--- a/projects/packages/videopress/changelog/jetpack-1883-videopress-library-no-way-to-preview-or-play-a-video
+++ b/projects/packages/videopress/changelog/jetpack-1883-videopress-library-no-way-to-preview-or-play-a-video
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+VideoPress: play videos directly on the library's video details page via an embedded VideoPress player, replacing the static thumbnail

--- a/projects/packages/videopress/routes/video/stage.tsx
+++ b/projects/packages/videopress/routes/video/stage.tsx
@@ -12,6 +12,7 @@ import { getVideoInfoQueryKeyPrefix } from '../../src/client/components/caption-
 import QueryClientWrapper from '../../src/dashboard/components/query-client-wrapper';
 import ChaptersHelpModal from '../../src/dashboard/components/video-details/chapters-help-modal';
 import HeaderActions from '../../src/dashboard/components/video-details/header-actions';
+import PreviewPlayer from '../../src/dashboard/components/video-details/preview-player';
 import PrivacySharingCard from '../../src/dashboard/components/video-details/privacy-sharing-card';
 import RatingCard from '../../src/dashboard/components/video-details/rating-card';
 import ThumbnailCard from '../../src/dashboard/components/video-details/thumbnail-card';
@@ -149,6 +150,7 @@ const Editor = ( {
 			}
 		>
 			<div className="vp-video-details">
+				<PreviewPlayer video={ video } />
 				<ThumbnailCard
 					video={ video }
 					onAddToNewPost={ onAddToNewPost }

--- a/projects/packages/videopress/routes/video/style.scss
+++ b/projects/packages/videopress/routes/video/style.scss
@@ -110,9 +110,10 @@
 // The "Update thumbnail" trigger is a @wordpress/components Button (36px
 // tall) sitting next to a @wordpress/ui Button, which sizes off the WPDS
 // size-lg token (40px). Pin the trigger to the same token so the two
-// actions read as one row; the fallback matches the token's built value.
+// actions read as one row. (No fallback — the build injects token
+// fallbacks automatically.)
 .vp-thumbnail-update__trigger .components-button {
-	height: var(--wpds-dimension-size-lg, 40px);
+	height: var(--wpds-dimension-size-lg);
 }
 
 // "FILE NAME" / "UPLOADED ON" caption labels (Figma uses uppercase

--- a/projects/packages/videopress/routes/video/style.scss
+++ b/projects/packages/videopress/routes/video/style.scss
@@ -107,6 +107,14 @@
 	flex-wrap: wrap;
 }
 
+// The "Update thumbnail" trigger is a @wordpress/components Button (36px
+// tall) sitting next to a @wordpress/ui Button, which sizes off the WPDS
+// size-lg token (40px). Pin the trigger to the same token so the two
+// actions read as one row; the fallback matches the token's built value.
+.vp-thumbnail-update__trigger .components-button {
+	height: var(--wpds-dimension-size-lg, 40px);
+}
+
 // "FILE NAME" / "UPLOADED ON" caption labels (Figma uses uppercase
 // with subdued color so they read as field labels, not body text).
 .vp-video-details__meta-label {

--- a/projects/packages/videopress/routes/video/style.scss
+++ b/projects/packages/videopress/routes/video/style.scss
@@ -21,7 +21,7 @@
 // non-mobile so the mobile breakpoint keeps cards content-sized with
 // natural breathing room instead of stretching edge-to-edge of the
 // viewport.
-@media (min-width: 600px) {
+@media ( min-width: 600px ) {
 
 	.vp-video-details {
 		width: 100%;
@@ -67,36 +67,44 @@
 	min-height: 320px;
 }
 
-.vp-video-details__thumbnail {
-	display: block;
-	max-width: 240px;
+// Playable preview at the top of the details screen. The frame is pinned
+// to 16:9 — the canonical player shape — and the embed letterboxes any
+// other aspect ratio inside it against the black background, so the page
+// doesn't reflow based on the video's own dimensions (which the media
+// record doesn't expose anyway).
+.vp-video-details__player {
+	position: relative;
+	width: 100%;
+	aspect-ratio: 16 / 9;
+	background: #000;
 	border-radius: 4px;
-	flex-shrink: 0;
+	overflow: hidden;
+
+	iframe,
+	video {
+		display: block;
+		width: 100%;
+		height: 100%;
+		border: 0;
+	}
 }
 
-// "Processing" badge shown in place of the poster <img> while the
-// VideoPress backend is still transcoding the upload. With no poster to
-// size it, the box hugs its label, so it needs its own padding to read as
-// a tidy pill instead of text pressed against the neutral background.
-// (Inherits the 4px border-radius from .vp-video-details__thumbnail.)
-.vp-video-details__thumbnail-processing {
+// "Processing" panel shown in place of the player while the VideoPress
+// backend is still transcoding the upload; keeps the player's 16:9 slot so
+// the page doesn't jump when playback becomes available.
+.vp-video-details__player-processing {
 	display: flex;
 	align-items: center;
 	justify-content: center;
-	padding: 4px 12px;
 	background: #f0f0f0;
 	color: #1e1e1e;
 }
 
-.vp-video-details__thumbnail-meta {
-	flex: 1;
-	min-width: 0;
-}
-
-// Outlined "Add video to new post" should size to its content,
-// not stretch across the column flex parent.
-.vp-video-details__primary-action {
+// The action buttons row should size to its content, not stretch across
+// the column flex parent.
+.vp-video-details__actions {
 	align-self: flex-start;
+	flex-wrap: wrap;
 }
 
 // "FILE NAME" / "UPLOADED ON" caption labels (Figma uses uppercase
@@ -118,54 +126,6 @@
 // breathing room without growing the row height.
 .vp-video-details__manage-subtitles {
 	padding-inline: 8px;
-}
-
-// Mobile: stack the Thumbnail card's two columns vertically. With the
-// meta column hosting full-width copy fields + the primary action,
-// anything narrower than ~600px squashes the meta into a barely-readable
-// strip. The thumbnail keeps its natural, width-capped size from the base
-// rule so it renders correctly for any aspect ratio.
-@media (max-width: 600px) {
-
-	.vp-video-details__thumbnail-row {
-		flex-direction: column !important;
-	}
-}
-
-.vp-video-details__thumbnail-wrapper {
-	position: relative;
-	flex-shrink: 0;
-}
-
-// The trigger is the @wordpress/components DropdownMenu wrapper; position it
-// over the thumbnail's top-right corner. Give the toggle button an opaque
-// surface so the pencil icon stays legible over any poster image (light or
-// dark), matching the solid affordance it had as a @wordpress/ui IconButton.
-.vp-thumbnail-update__trigger {
-	position: absolute;
-	top: 8px;
-	right: 8px;
-
-	.components-button {
-		background: rgba(255, 255, 255, 0.9);
-		box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.1);
-
-		&:hover:not(:disabled) {
-			background: #fff;
-		}
-	}
-}
-
-.vp-video-details__thumbnail-updating {
-	position: absolute;
-	inset: 0;
-	z-index: 1;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	background: rgba(0, 0, 0, 0.55);
-	color: #fff;
-	border-radius: 4px;
 }
 
 .vp-frame-scrubber {

--- a/projects/packages/videopress/src/dashboard/components/video-details/preview-player.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/preview-player.tsx
@@ -1,0 +1,114 @@
+import { __ } from '@wordpress/i18n';
+import { Text } from '@wordpress/ui';
+import { addQueryArgs } from '@wordpress/url';
+import { useEffect, useState } from 'react';
+import getMediaToken from '../../../client/lib/get-media-token';
+import type { LibraryItem } from '../../types/library';
+import type { ReactElement } from 'react';
+
+type Props = {
+	video: LibraryItem;
+};
+
+/*
+ * Private videos are embedded from video.wordpress.com; public ones from
+ * videopress.com — same split the caption manager's preview player uses.
+ */
+const getVideoPressEmbedOrigin = ( isPrivate: boolean ): string =>
+	isPrivate ? 'https://video.wordpress.com' : 'https://videopress.com';
+
+/*
+ * `resizeToParent` keeps the player sized to the iframe, which the stylesheet
+ * pins to a 16:9 frame; non-16:9 videos letterbox inside it rather than crop
+ * (the block's `cover` mode). Controls are on by default, matching the block.
+ */
+const getVideoPressEmbedUrl = ( guid: string, isPrivate: boolean, playbackToken?: string ) =>
+	addQueryArgs( `${ getVideoPressEmbedOrigin( isPrivate ) }/embed/${ guid }`, {
+		resizeToParent: true,
+		...( playbackToken ? { metadata_token: playbackToken } : {} ),
+	} );
+
+/**
+ * Playable preview at the top of the Video details screen. Embeds the same
+ * VideoPress player the block renders in post content (an iframe from
+ * videopress.com), so playback, captions, quality and fullscreen all behave
+ * exactly as they do for site visitors. Private videos get a playback token
+ * minted before the embed loads; local items without a VideoPress GUID fall
+ * back to a native `<video>` on their direct source.
+ *
+ * @param props       - Component props.
+ * @param props.video - The current video record.
+ * @return The player element, or null when there is nothing playable yet.
+ */
+export default function PreviewPlayer( { video }: Props ): ReactElement | null {
+	const { guid, isPrivate } = video;
+	// null = token fetch pending, '' = failed or not needed, string = minted token.
+	const [ playbackToken, setPlaybackToken ] = useState< string | null >( null );
+
+	/*
+	 * Private videos require a playback token on the embed URL. Mint one when
+	 * needed; if minting fails, fall back to the tokenless embed.
+	 */
+	useEffect( () => {
+		if ( ! isPrivate || ! guid ) {
+			return;
+		}
+
+		let isCurrent = true;
+		getMediaToken( 'playback', { guid } )
+			.then( tokenData => {
+				if ( isCurrent ) {
+					setPlaybackToken( tokenData?.token || '' );
+				}
+			} )
+			.catch( () => {
+				if ( isCurrent ) {
+					setPlaybackToken( '' );
+				}
+			} );
+
+		return () => {
+			isCurrent = false;
+		};
+	}, [ guid, isPrivate ] );
+
+	if ( video.isProcessing ) {
+		return (
+			<div className="vp-video-details__player vp-video-details__player-processing">
+				<Text>{ __( 'Processing', 'jetpack-videopress-pkg' ) }</Text>
+			</div>
+		);
+	}
+
+	if ( ! guid ) {
+		if ( ! video.sourceUrl ) {
+			return null;
+		}
+		return (
+			<div className="vp-video-details__player">
+				<video
+					aria-label={ __( 'Video preview', 'jetpack-videopress-pkg' ) }
+					src={ video.sourceUrl }
+					poster={ video.thumbnailUrl ?? undefined }
+					controls
+				/>
+			</div>
+		);
+	}
+
+	// Hold the embed back until the playback-token fetch for a private video settles.
+	if ( isPrivate && playbackToken === null ) {
+		return <div className="vp-video-details__player" aria-busy="true" />;
+	}
+
+	return (
+		<div className="vp-video-details__player">
+			<iframe
+				title={ __( 'Video preview', 'jetpack-videopress-pkg' ) }
+				src={ getVideoPressEmbedUrl( guid, isPrivate, playbackToken || undefined ) }
+				allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+				allowFullScreen
+			/>
+		</div>
+	);
+}

--- a/projects/packages/videopress/src/dashboard/components/video-details/test/preview-player.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/test/preview-player.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import getMediaToken from '../../../../client/lib/get-media-token';
+import PreviewPlayer from '../preview-player';
+import type { LibraryItem } from '../../../types/library';
+
+jest.mock( '../../../../client/lib/get-media-token', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+const mockedGetMediaToken = getMediaToken as unknown as jest.Mock;
+
+const baseVideo: LibraryItem = {
+	id: '42',
+	guid: 'abc123',
+	type: 'videopress',
+	title: 'My video',
+	filename: 'movie.mp4',
+	thumbnailUrl: 'https://example.test/poster.jpg',
+	durationSeconds: 60,
+	uploadDate: '2026-01-01T00:00:00',
+	privacy: 'public',
+	isPrivate: false,
+	fileSizeBytes: 0,
+	upload: { status: 'idle', progress: 0 },
+	description: '',
+	rating: 'G',
+	displayEmbed: true,
+	allowDownloads: false,
+	shortcode: '[videopress abc123]',
+	sourceUrl: 'https://example.test/movie.mp4',
+	isProcessing: false,
+	tracks: [],
+};
+
+beforeEach( () => {
+	mockedGetMediaToken.mockReset();
+} );
+
+describe( 'PreviewPlayer', () => {
+	it( 'embeds the public VideoPress player without minting a token', () => {
+		render( <PreviewPlayer video={ baseVideo } /> );
+
+		const iframe = screen.getByTitle( 'Video preview' );
+		expect( iframe ).toHaveAttribute(
+			'src',
+			expect.stringContaining( 'https://videopress.com/embed/abc123' )
+		);
+		expect( mockedGetMediaToken ).not.toHaveBeenCalled();
+	} );
+
+	it( 'private video: embeds from video.wordpress.com with the minted playback token', async () => {
+		mockedGetMediaToken.mockResolvedValueOnce( { token: 'tok-1' } );
+		render( <PreviewPlayer video={ { ...baseVideo, isPrivate: true } } /> );
+
+		const iframe = await screen.findByTitle( 'Video preview' );
+		expect( mockedGetMediaToken ).toHaveBeenCalledWith( 'playback', { guid: 'abc123' } );
+		expect( iframe ).toHaveAttribute(
+			'src',
+			expect.stringContaining( 'https://video.wordpress.com/embed/abc123' )
+		);
+		expect( iframe ).toHaveAttribute( 'src', expect.stringContaining( 'metadata_token=tok-1' ) );
+	} );
+
+	it( 'private video: falls back to the tokenless embed when minting fails', async () => {
+		mockedGetMediaToken.mockRejectedValueOnce( new Error( 'nope' ) );
+		render( <PreviewPlayer video={ { ...baseVideo, isPrivate: true } } /> );
+
+		const iframe = await screen.findByTitle( 'Video preview' );
+		await waitFor( () =>
+			expect( iframe ).not.toHaveAttribute( 'src', expect.stringContaining( 'metadata_token' ) )
+		);
+	} );
+
+	it( 'shows the processing panel instead of a player while transcoding', () => {
+		render( <PreviewPlayer video={ { ...baseVideo, isProcessing: true } } /> );
+
+		expect( screen.getByText( 'Processing' ) ).toBeInTheDocument();
+		expect( screen.queryByTitle( 'Video preview' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'plays local items without a GUID through a native video element', () => {
+		render( <PreviewPlayer video={ { ...baseVideo, type: 'local', guid: '' } } /> );
+
+		const video = screen.getByLabelText( 'Video preview' );
+		expect( video.tagName ).toBe( 'VIDEO' );
+		expect( video ).toHaveAttribute( 'src', 'https://example.test/movie.mp4' );
+	} );
+
+	it( 'renders nothing when there is no GUID and no direct source', () => {
+		const { container } = render(
+			<PreviewPlayer video={ { ...baseVideo, guid: '', sourceUrl: undefined } } />
+		);
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/components/video-details/thumbnail-card.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/thumbnail-card.tsx
@@ -4,13 +4,12 @@ import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { copy } from '@wordpress/icons';
 import { Button, Card, IconButton, InputControl, Stack, Text } from '@wordpress/ui';
-import { useCallback, useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useVideoTracks } from '../../../client/components/caption-manager-modal/use-video-tracks';
 import {
 	getLanguageDisplayName,
 	getManualLanguageTagFromTrackKey,
 } from '../../../client/lib/video-tracks/language';
-import { usePosterUrl } from '../../hooks/use-poster-url';
 import { useUpdateVideoPoster } from '../../hooks/use-update-video-poster';
 import { selectImageFromMediaLibrary } from '../../utils/select-image-from-media-library';
 import SelectFrameDialog from './select-frame-dialog';
@@ -25,12 +24,6 @@ type Props = {
 };
 
 const dateSettings = getDateSettings();
-
-// Upper bound on how long we keep showing "Updating…" while waiting for the
-// freshly generated poster <img> to load. The onLoad handler normally clears
-// it sooner; this just guarantees the overlay can't get stuck if onLoad never
-// fires (identical URL, cache hit, or a load error).
-const POSTER_CONFIRM_TIMEOUT_MS = 5000;
 
 // The Subtitles row lists this many languages before collapsing into "and N more".
 const MAX_SUBTITLE_LANGUAGES_SHOWN = 2;
@@ -85,10 +78,11 @@ const canEditThumbnail = ( video: LibraryItem ): boolean =>
 	video.type === 'videopress' && ! video.isProcessing && Boolean( video.sourceUrl || video.guid );
 
 /**
- * Top-of-page card on the Video details screen. Renders the thumbnail,
- * the "Add video to new post" outlined action, two read-only copy fields
- * (Link to video, Shortcode) using InputControl + IconButton suffix, and
- * metadata rows (File name, Uploaded on, Subtitles with a Manage action).
+ * Top-of-page card on the Video details screen (below the preview player).
+ * Renders the "Update thumbnail" and "Add video to new post" actions, two
+ * read-only copy fields (Link to video, Shortcode) using InputControl +
+ * IconButton suffix, and metadata rows (File name, Uploaded on, Subtitles
+ * with a Manage action).
  *
  * @param props                   - Component props.
  * @param props.video             - The current video record.
@@ -102,7 +96,6 @@ export default function ThumbnailCard( {
 	onManageSubtitles,
 }: Props ): ReactElement {
 	const link = linkForVideo( video );
-	const posterUrl = usePosterUrl( video );
 
 	/*
 	 * The media REST item omits `tracks`, so the languages come from the same
@@ -147,47 +140,11 @@ export default function ThumbnailCard( {
 	const { createSuccessNotice, createErrorNotice } = useGlobalNotices();
 	const updatePoster = useUpdateVideoPoster();
 	const [ dialogOpen, setDialogOpen ] = useState( false );
-	// True between a poster mutation resolving and the new thumbnail <img>
-	// actually loading. Keeps the "Updating…" overlay up and the success
-	// notice held back so the toast lines up with the visible change rather
-	// than firing a beat early (while the browser is still fetching the image).
-	const [ confirmingPoster, setConfirmingPoster ] = useState( false );
-
-	const finishUpdate = useCallback( () => {
-		setConfirmingPoster( false );
-		createSuccessNotice( __( 'Thumbnail updated.', 'jetpack-videopress-pkg' ) );
-	}, [ createSuccessNotice ] );
-
-	// Safety net: if onLoad never reports back (identical URL, cache hit with no
-	// event, or a load error) don't strand the UI in "Updating…".
-	useEffect( () => {
-		if ( ! confirmingPoster ) {
-			return;
-		}
-		const timer = setTimeout( finishUpdate, POSTER_CONFIRM_TIMEOUT_MS );
-		return () => clearTimeout( timer );
-	}, [ confirmingPoster, finishUpdate ] );
 
 	const notifyResult = {
-		onSuccess: ( { poster }: { poster?: string } ) => {
-			// The mutation already wrote the new poster into the cache, so the
-			// <img> below is now pointing at it. Wait for that image to load
-			// before clearing the overlay and notifying. With no poster (e.g.
-			// generation polling exhausted) there's nothing to wait for.
-			if ( poster ) {
-				setConfirmingPoster( true );
-			} else {
-				finishUpdate();
-			}
-		},
+		onSuccess: () => createSuccessNotice( __( 'Thumbnail updated.', 'jetpack-videopress-pkg' ) ),
 		onError: () =>
 			createErrorNotice( __( 'Failed to update thumbnail.', 'jetpack-videopress-pkg' ) ),
-	};
-
-	const confirmPosterLoad = () => {
-		if ( confirmingPoster ) {
-			finishUpdate();
-		}
 	};
 
 	const handleConfirmFrame = ( atTimeMs: number ) => {
@@ -209,36 +166,14 @@ export default function ThumbnailCard( {
 		);
 	};
 
-	let thumbnail: ReactElement | null = null;
-	if ( posterUrl ) {
-		thumbnail = (
-			<img
-				src={ posterUrl }
-				alt=""
-				width={ 240 }
-				height={ 135 }
-				className="vp-video-details__thumbnail"
-				onLoad={ confirmPosterLoad }
-				onError={ confirmPosterLoad }
-			/>
-		);
-	} else if ( video.isProcessing ) {
-		thumbnail = (
-			<div className="vp-video-details__thumbnail vp-video-details__thumbnail-processing">
-				<Text>{ __( 'Processing', 'jetpack-videopress-pkg' ) }</Text>
-			</div>
-		);
-	}
-
 	const showUpdateButton = canEditThumbnail( video );
-	const isUpdating = updatePoster.isPending || confirmingPoster;
+	const isUpdating = updatePoster.isPending;
 
 	return (
 		<Card.Root>
 			<Card.Content>
-				<Stack direction="row" gap="md" align="start" className="vp-video-details__thumbnail-row">
-					<div className="vp-video-details__thumbnail-wrapper">
-						{ thumbnail }
+				<Stack direction="column" gap="md">
+					<Stack direction="row" gap="sm" className="vp-video-details__actions">
 						{ showUpdateButton && (
 							<ThumbnailUpdateButton
 								canSelectFromVideo={ Boolean( video.sourceUrl ) }
@@ -248,13 +183,6 @@ export default function ThumbnailCard( {
 								onUploadImage={ handleUploadImage }
 							/>
 						) }
-						{ isUpdating && (
-							<div className="vp-video-details__thumbnail-updating">
-								<Text>{ __( 'Updating…', 'jetpack-videopress-pkg' ) }</Text>
-							</div>
-						) }
-					</div>
-					<Stack direction="column" gap="md" className="vp-video-details__thumbnail-meta">
 						<Button
 							variant="outline"
 							onClick={ onAddToNewPost }
@@ -262,69 +190,67 @@ export default function ThumbnailCard( {
 						>
 							{ __( 'Add video to new post', 'jetpack-videopress-pkg' ) }
 						</Button>
-
-						<InputControl
-							label={ __( 'Link to video', 'jetpack-videopress-pkg' ) }
-							value={ link }
-							readOnly
-							suffix={
-								<CopyIconButton
-									text={ link }
-									fieldLabel={ __( 'Link to video', 'jetpack-videopress-pkg' ) }
-								/>
-							}
-						/>
-
-						<InputControl
-							label={ __( 'Shortcode', 'jetpack-videopress-pkg' ) }
-							value={ video.shortcode }
-							readOnly
-							suffix={
-								<CopyIconButton
-									text={ video.shortcode }
-									fieldLabel={ __( 'Shortcode', 'jetpack-videopress-pkg' ) }
-								/>
-							}
-						/>
-
-						<Stack direction="column" gap="xs">
-							<Text variant="body-sm" className="vp-video-details__meta-label">
-								{ __( 'File name', 'jetpack-videopress-pkg' ) }
-							</Text>
-							<Text>{ video.filename }</Text>
-						</Stack>
-
-						<Stack direction="column" gap="xs">
-							<Text variant="body-sm" className="vp-video-details__meta-label">
-								{ __( 'Uploaded on', 'jetpack-videopress-pkg' ) }
-							</Text>
-							<Text>{ dateI18n( dateSettings.formats.date, video.uploadDate ) }</Text>
-						</Stack>
-
-						{ video.guid && (
-							<Stack direction="column" gap="xs">
-								<Text variant="body-sm" className="vp-video-details__meta-label">
-									{ __( 'Subtitles', 'jetpack-videopress-pkg' ) }
-								</Text>
-								<Stack direction="row" gap="sm" align="center">
-									<Text>
-										{ isLoadingTracks
-											? __( 'Loading…', 'jetpack-videopress-pkg' )
-											: subtitleSummary }
-									</Text>
-									<Button
-										variant="minimal"
-										size="small"
-										className="vp-video-details__manage-subtitles"
-										aria-label={ __( 'Manage subtitles', 'jetpack-videopress-pkg' ) }
-										onClick={ onManageSubtitles }
-									>
-										{ __( 'Manage', 'jetpack-videopress-pkg' ) }
-									</Button>
-								</Stack>
-							</Stack>
-						) }
 					</Stack>
+
+					<InputControl
+						label={ __( 'Link to video', 'jetpack-videopress-pkg' ) }
+						value={ link }
+						readOnly
+						suffix={
+							<CopyIconButton
+								text={ link }
+								fieldLabel={ __( 'Link to video', 'jetpack-videopress-pkg' ) }
+							/>
+						}
+					/>
+
+					<InputControl
+						label={ __( 'Shortcode', 'jetpack-videopress-pkg' ) }
+						value={ video.shortcode }
+						readOnly
+						suffix={
+							<CopyIconButton
+								text={ video.shortcode }
+								fieldLabel={ __( 'Shortcode', 'jetpack-videopress-pkg' ) }
+							/>
+						}
+					/>
+
+					<Stack direction="column" gap="xs">
+						<Text variant="body-sm" className="vp-video-details__meta-label">
+							{ __( 'File name', 'jetpack-videopress-pkg' ) }
+						</Text>
+						<Text>{ video.filename }</Text>
+					</Stack>
+
+					<Stack direction="column" gap="xs">
+						<Text variant="body-sm" className="vp-video-details__meta-label">
+							{ __( 'Uploaded on', 'jetpack-videopress-pkg' ) }
+						</Text>
+						<Text>{ dateI18n( dateSettings.formats.date, video.uploadDate ) }</Text>
+					</Stack>
+
+					{ video.guid && (
+						<Stack direction="column" gap="xs">
+							<Text variant="body-sm" className="vp-video-details__meta-label">
+								{ __( 'Subtitles', 'jetpack-videopress-pkg' ) }
+							</Text>
+							<Stack direction="row" gap="sm" align="center">
+								<Text>
+									{ isLoadingTracks ? __( 'Loading…', 'jetpack-videopress-pkg' ) : subtitleSummary }
+								</Text>
+								<Button
+									variant="minimal"
+									size="small"
+									className="vp-video-details__manage-subtitles"
+									aria-label={ __( 'Manage subtitles', 'jetpack-videopress-pkg' ) }
+									onClick={ onManageSubtitles }
+								>
+									{ __( 'Manage', 'jetpack-videopress-pkg' ) }
+								</Button>
+							</Stack>
+						</Stack>
+					) }
 				</Stack>
 			</Card.Content>
 			<SelectFrameDialog

--- a/projects/packages/videopress/src/dashboard/components/video-details/thumbnail-update-button.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/thumbnail-update-button.tsx
@@ -12,12 +12,11 @@ type Props = {
 };
 
 /**
- * Overlay button that opens the thumbnail-update menu with two actions:
+ * Button that opens the thumbnail-update menu with two actions:
  * "Select from video" and "Upload image". Uses the same `@wordpress/components`
  * DropdownMenu as the page header's ⋯ menu so both menus share the design
- * system's look — including MenuItem's default right-aligned icons. Sits on
- * top of the video thumbnail inside ThumbnailCard via the
- * `vp-thumbnail-update__trigger` class.
+ * system's look — including MenuItem's default right-aligned icons. Rendered
+ * inline next to the "Add video to new post" action inside ThumbnailCard.
  *
  * @param props                    - Component props.
  * @param props.canSelectFromVideo - Whether the frame-picker action is available.
@@ -25,7 +24,7 @@ type Props = {
  * @param props.isBusy             - When true, the trigger button is disabled.
  * @param props.onSelectFromVideo  - Called when the user chooses "Select from video".
  * @param props.onUploadImage      - Called when the user chooses "Upload image".
- * @return The overlay button element.
+ * @return The dropdown button element.
  */
 export default function ThumbnailUpdateButton( {
 	canSelectFromVideo,
@@ -38,8 +37,13 @@ export default function ThumbnailUpdateButton( {
 		<DropdownMenu
 			icon={ pencil }
 			label={ __( 'Update thumbnail', 'jetpack-videopress-pkg' ) }
+			text={
+				isBusy
+					? __( 'Updating…', 'jetpack-videopress-pkg' )
+					: __( 'Update thumbnail', 'jetpack-videopress-pkg' )
+			}
 			className="vp-thumbnail-update__trigger"
-			toggleProps={ { size: 'compact', disabled: isBusy } }
+			toggleProps={ { variant: 'secondary', disabled: isBusy, isBusy } }
 		>
 			{ ( { onClose } ) => (
 				<MenuGroup>

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-poster-url.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-poster-url.test.ts
@@ -1,0 +1,127 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import { createElement, type ReactNode } from 'react';
+import { usePosterUrl, usePlaybackToken } from '../use-poster-url';
+import type { LibraryItem } from '../../types/library';
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+const mockedApiFetch = apiFetch as unknown as jest.Mock;
+
+const baseVideo: LibraryItem = {
+	id: '42',
+	guid: 'abc123',
+	type: 'videopress',
+	title: 'My video',
+	filename: 'movie.mp4',
+	thumbnailUrl: 'https://example.test/poster.jpg',
+	durationSeconds: 60,
+	uploadDate: '2026-01-01T00:00:00',
+	privacy: 'public',
+	isPrivate: false,
+	fileSizeBytes: 0,
+	upload: { status: 'idle', progress: 0 },
+	description: '',
+	rating: 'G',
+	displayEmbed: true,
+	allowDownloads: false,
+	shortcode: '[videopress abc123]',
+	sourceUrl: 'https://example.test/movie.mp4',
+	isProcessing: false,
+	tracks: [],
+};
+
+/**
+ * Create an isolated QueryClient and a React wrapper component for renderHook.
+ *
+ * @return An object containing the client and wrapper component.
+ */
+function makeWrapper() {
+	const client = new QueryClient( {
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	} );
+	const wrapper = ( { children }: { children: ReactNode } ) =>
+		createElement( QueryClientProvider, { client }, children );
+	return { client, wrapper };
+}
+
+afterEach( () => {
+	mockedApiFetch.mockReset();
+} );
+
+describe( 'usePosterUrl', () => {
+	it( 'public video: returns the thumbnail URL as-is without minting a token', () => {
+		const { wrapper } = makeWrapper();
+		const { result } = renderHook( () => usePosterUrl( baseVideo ), { wrapper } );
+
+		expect( result.current ).toBe( 'https://example.test/poster.jpg' );
+		expect( mockedApiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'returns null when the video has no thumbnail', () => {
+		const { wrapper } = makeWrapper();
+		const { result } = renderHook( () => usePosterUrl( { ...baseVideo, thumbnailUrl: null } ), {
+			wrapper,
+		} );
+
+		expect( result.current ).toBeNull();
+	} );
+
+	it( 'private video: returns null while the token is in flight, then the signed URL', async () => {
+		mockedApiFetch.mockResolvedValueOnce( { playback_token: 'tok-1' } );
+		const { wrapper } = makeWrapper();
+		const { result } = renderHook( () => usePosterUrl( { ...baseVideo, isPrivate: true } ), {
+			wrapper,
+		} );
+
+		expect( result.current ).toBeNull();
+
+		await waitFor( () =>
+			expect( result.current ).toBe( 'https://example.test/poster.jpg?metadata_token=tok-1' )
+		);
+		expect( mockedApiFetch ).toHaveBeenCalledWith( {
+			path: '/wpcom/v2/videopress/playback-jwt/abc123',
+			method: 'POST',
+		} );
+	} );
+
+	it( 'private video: stays null when the response carries no playback token', async () => {
+		mockedApiFetch.mockResolvedValueOnce( {} );
+		const { wrapper } = makeWrapper();
+		const { result } = renderHook( () => usePosterUrl( { ...baseVideo, isPrivate: true } ), {
+			wrapper,
+		} );
+
+		await waitFor( () => expect( mockedApiFetch ).toHaveBeenCalledTimes( 1 ) );
+		expect( result.current ).toBeNull();
+	} );
+} );
+
+describe( 'usePlaybackToken', () => {
+	it( 'skips the request when disabled or without a guid', () => {
+		const { wrapper } = makeWrapper();
+		const { result: disabled } = renderHook( () => usePlaybackToken( 'abc123', false ), {
+			wrapper,
+		} );
+		const { result: noGuid } = renderHook( () => usePlaybackToken( '', true ), { wrapper } );
+
+		expect( disabled.current ).toBeUndefined();
+		expect( noGuid.current ).toBeUndefined();
+		expect( mockedApiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'shares one request per guid across concurrent renders', async () => {
+		mockedApiFetch.mockResolvedValue( { playback_token: 'tok-1' } );
+		const { wrapper } = makeWrapper();
+		const { result: first } = renderHook( () => usePlaybackToken( 'abc123', true ), { wrapper } );
+		const { result: second } = renderHook( () => usePlaybackToken( 'abc123', true ), { wrapper } );
+
+		await waitFor( () => expect( first.current ).toBe( 'tok-1' ) );
+		await waitFor( () => expect( second.current ).toBe( 'tok-1' ) );
+		expect( mockedApiFetch ).toHaveBeenCalledTimes( 1 );
+	} );
+} );


### PR DESCRIPTION
Fixes JETPACK-1883

## Proposed changes

* Adds a playable preview at the top of the VideoPress library's video details page (`/wp-admin/admin.php?page=jetpack-videopress&p=/video/{id}`). The new `PreviewPlayer` component embeds the same VideoPress player iframe that post content renders, so playback, captions, playback speed, quality selection, and fullscreen all behave exactly as they do for site visitors.
* Private videos are embedded from `video.wordpress.com` with a playback token minted via `getMediaToken( 'playback' )` (same pattern the caption manager's preview player uses), falling back to a tokenless embed if minting fails. Public videos embed from `videopress.com`.
* Videos still transcoding show a "Processing" panel in the player's 16:9 slot; local items without a VideoPress GUID fall back to a native `<video>` element on their direct source.
* Removes the static thumbnail (`vp-video-details__thumbnail-wrapper`) from the top card, along with the poster-load confirmation machinery that existed only to sync the success toast with the `<img>` refresh.
* Moves the "Update thumbnail" action inline, before the "Add video to new post" button, as a secondary button with the same dropdown menu as before ("Select from video" / "Upload image"). It shows "Updating…" and is disabled while a poster mutation is in flight.
* Adds a jest suite for `PreviewPlayer` covering public/private embeds, token-mint failure, processing, local fallback, and empty states.
* Adds a jest suite for the `use-poster-url` hook, which was previously only covered indirectly through the thumbnail card it no longer renders in.

## Related product discussion/links

* Linear: JETPACK-1883

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Ensure you have a site with VideoPress active and at least one uploaded video.
* Go to **Jetpack → VideoPress → Library** and open a video's details page.
* Verify the page now starts with an embedded player instead of a static thumbnail, and that you can play the video with full controls (seek, volume, captions if available, speed, quality, fullscreen) — matching playback of the same video inserted in a post.
* Set the video's privacy to **Private**, save, reload the details page, and confirm playback still works (the embed should load from `video.wordpress.com` with a `metadata_token` query param).
* Verify the **Update thumbnail** button now sits before **Add video to new post**, and that both of its menu actions work: "Select from video" opens the frame picker and "Upload image" opens the media library; a success snackbar appears after updating.
* Upload a new video and open its details while it is still processing: the player area should show a "Processing" panel.
* Check the layout on a narrow viewport (<600px): the action buttons should wrap and the player should stay 16:9, full width.

## Screenshots
<img width="2924" height="1734" alt="image" src="https://github.com/user-attachments/assets/a832ce85-74b4-4795-8411-a7d2c7ce53b8" />
