### PR TITLE
Podcast: add soundbites and alternate files editor controls

### DIFF
--- a/projects/packages/podcast/changelog/add-podcast-episode-soundbites-ui
+++ b/projects/packages/podcast/changelog/add-podcast-episode-soundbites-ui
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Podcast Episode: add editor controls for soundbites and alternate audio/video files, so the front-end seek buttons and Podcasting 2.0 feed tags that already render can now be authored.

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -446,9 +446,10 @@ class Podcast_Episode_Block {
 								}
 								$start_label     = self::format_seconds_label( $soundbite['startTime'] );
 								$soundbite_title = isset( $soundbite['title'] ) ? trim( (string) $soundbite['title'] ) : '';
-								$start_seconds   = (int) floor( max( 0, (float) $soundbite['startTime'] ) );
+								// Keep fractional offsets so the seek button and Clip metadata match the feed.
+								$start_seconds   = max( 0, (float) $soundbite['startTime'] );
 								$end_seconds     = isset( $soundbite['duration'] )
-									? $start_seconds + (int) floor( max( 0, (float) $soundbite['duration'] ) )
+									? $start_seconds + max( 0, (float) $soundbite['duration'] )
 									: null;
 								?>
 								<li

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -447,8 +447,8 @@ class Podcast_Episode_Block {
 								$start_label     = self::format_seconds_label( $soundbite['startTime'] );
 								$soundbite_title = isset( $soundbite['title'] ) ? trim( (string) $soundbite['title'] ) : '';
 								// Keep fractional offsets so the seek button and Clip metadata match the feed.
-								$start_seconds   = max( 0, (float) $soundbite['startTime'] );
-								$end_seconds     = isset( $soundbite['duration'] )
+								$start_seconds = max( 0, (float) $soundbite['startTime'] );
+								$end_seconds   = isset( $soundbite['duration'] )
 									? $start_seconds + max( 0, (float) $soundbite['duration'] )
 									: null;
 								?>

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -249,6 +249,26 @@ class Podcast_Episode_Block {
 		$soundbites           = isset( $attributes['soundbites'] ) && is_array( $attributes['soundbites'] ) ? $attributes['soundbites'] : array();
 		$alternate_enclosures = isset( $attributes['alternateEnclosures'] ) && is_array( $attributes['alternateEnclosures'] ) ? $attributes['alternateEnclosures'] : array();
 
+		// Drop incomplete rows up front so an all-empty list doesn't enqueue the seek script or emit a bare <ul>.
+		$soundbites           = array_values(
+			array_filter(
+				$soundbites,
+				static function ( $soundbite ) {
+					return is_array( $soundbite ) && isset( $soundbite['startTime'] );
+				}
+			)
+		);
+		$alternate_enclosures = array_values(
+			array_filter(
+				$alternate_enclosures,
+				static function ( $alt ) {
+					return is_array( $alt )
+						&& ! empty( $alt['url'] )
+						&& wp_http_validate_url( esc_url_raw( (string) $alt['url'] ) );
+				}
+			)
+		);
+
 		// Only ship the click-to-seek script when there are soundbites to wire.
 		if ( ! empty( $soundbites ) ) {
 			self::enqueue_view_script();

--- a/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
+++ b/projects/packages/podcast/src/blocks/podcast-episode/class-podcast-episode-block.php
@@ -262,9 +262,14 @@ class Podcast_Episode_Block {
 			array_filter(
 				$alternate_enclosures,
 				static function ( $alt ) {
-					return is_array( $alt )
-						&& ! empty( $alt['url'] )
-						&& wp_http_validate_url( esc_url_raw( (string) $alt['url'] ) );
+					if ( ! is_array( $alt ) || empty( $alt['url'] ) ) {
+						return false;
+					}
+					if ( ! wp_http_validate_url( esc_url_raw( (string) $alt['url'] ) ) ) {
+						return false;
+					}
+					// `type` is required per spec — mirror the feed, which skips typeless entries.
+					return '' !== ( isset( $alt['type'] ) ? trim( (string) $alt['type'] ) : '' );
 				}
 			)
 		);

--- a/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
+++ b/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
@@ -271,9 +271,7 @@ function AlternateEnclosuresEditor( {
 		onChange( [ ...alternateEnclosures, { url: '', type: '', title: '', lang: '' } ] );
 	const toBitrate = ( value: string ) => {
 		const bitrate = Number( value );
-		return value === '' || ! Number.isFinite( bitrate ) || bitrate < 0
-			? undefined
-			: Math.floor( bitrate );
+		return value === '' || ! Number.isInteger( bitrate ) || bitrate < 0 ? undefined : bitrate;
 	};
 
 	return (

--- a/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
+++ b/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
@@ -45,6 +45,20 @@ interface CoverArt {
 	url?: string;
 }
 
+interface Soundbite {
+	startTime?: number;
+	duration?: number;
+	title?: string;
+}
+
+interface AlternateEnclosure {
+	url?: string;
+	type?: string;
+	title?: string;
+	lang?: string;
+	bitrate?: number;
+}
+
 interface PodcastEpisodeAttributes {
 	mediaId?: number;
 	mediaUrl?: string;
@@ -65,6 +79,8 @@ interface PodcastEpisodeAttributes {
 	people?: Person[];
 	showPoster?: boolean;
 	coverArt?: CoverArt;
+	soundbites?: Soundbite[];
+	alternateEnclosures?: AlternateEnclosure[];
 }
 
 interface MediaAttachment {
@@ -166,6 +182,149 @@ function PeopleEditor( { people, onChange }: PeopleEditorProps ) {
 	);
 }
 
+interface SoundbitesEditorProps {
+	soundbites: Soundbite[];
+	onChange: ( next: Soundbite[] ) => void;
+}
+
+function SoundbitesEditor( { soundbites, onChange }: SoundbitesEditorProps ) {
+	const updateSoundbite = ( index: number, patch: Partial< Soundbite > ) => {
+		onChange( soundbites.map( ( sb, i ) => ( i === index ? { ...sb, ...patch } : sb ) ) );
+	};
+	const removeSoundbite = ( index: number ) => onChange( soundbites.filter( ( _, i ) => i !== index ) );
+	const addSoundbite = () => onChange( [ ...soundbites, { startTime: 0, duration: 0, title: '' } ] );
+	// startTime/duration are seconds — parse empty as undefined so a cleared field
+	// doesn't coerce to 0 and emit a bogus feed entry.
+	const toSeconds = ( value: string ) => ( value === '' ? undefined : Number( value ) );
+
+	return (
+		<>
+			{ soundbites.map( ( soundbite, index ) => (
+				<div
+					className={ clsx( 'jetpack-podcast-episode__person-editor', {
+						'jetpack-podcast-episode__person-editor--alt': index % 2 === 1,
+					} ) }
+					key={ index }
+				>
+					<TextControl
+						label={ __( 'Start time (seconds)', 'jetpack-podcast' ) }
+						type="number"
+						min={ 0 }
+						step="any"
+						value={ soundbite.startTime ?? '' }
+						onChange={ value => updateSoundbite( index, { startTime: toSeconds( value ) } ) }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+					<TextControl
+						label={ __( 'Duration (seconds)', 'jetpack-podcast' ) }
+						help={ __( 'Required — soundbites with no duration are skipped.', 'jetpack-podcast' ) }
+						type="number"
+						min={ 0 }
+						step="any"
+						value={ soundbite.duration ?? '' }
+						onChange={ value => updateSoundbite( index, { duration: toSeconds( value ) } ) }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+					<TextControl
+						label={ __( 'Title', 'jetpack-podcast' ) }
+						value={ soundbite.title || '' }
+						onChange={ title => updateSoundbite( index, { title } ) }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+					<Button variant="link" isDestructive onClick={ () => removeSoundbite( index ) }>
+						{ __( 'Remove soundbite', 'jetpack-podcast' ) }
+					</Button>
+				</div>
+			) ) }
+			<Button variant="secondary" onClick={ addSoundbite }>
+				{ __( 'Add soundbite', 'jetpack-podcast' ) }
+			</Button>
+		</>
+	);
+}
+
+interface AlternateEnclosuresEditorProps {
+	alternateEnclosures: AlternateEnclosure[];
+	onChange: ( next: AlternateEnclosure[] ) => void;
+}
+
+function AlternateEnclosuresEditor( { alternateEnclosures, onChange }: AlternateEnclosuresEditorProps ) {
+	const updateEnclosure = ( index: number, patch: Partial< AlternateEnclosure > ) => {
+		onChange(
+			alternateEnclosures.map( ( alt, i ) => ( i === index ? { ...alt, ...patch } : alt ) )
+		);
+	};
+	const removeEnclosure = ( index: number ) =>
+		onChange( alternateEnclosures.filter( ( _, i ) => i !== index ) );
+	const addEnclosure = () =>
+		onChange( [ ...alternateEnclosures, { url: '', type: '', title: '', lang: '' } ] );
+
+	return (
+		<>
+			{ alternateEnclosures.map( ( alt, index ) => (
+				<div
+					className={ clsx( 'jetpack-podcast-episode__person-editor', {
+						'jetpack-podcast-episode__person-editor--alt': index % 2 === 1,
+					} ) }
+					key={ index }
+				>
+					<TextControl
+						label={ __( 'File URL', 'jetpack-podcast' ) }
+						type="url"
+						value={ alt.url || '' }
+						onChange={ url => updateEnclosure( index, { url } ) }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+					<TextControl
+						label={ __( 'MIME type', 'jetpack-podcast' ) }
+						help={ __( 'Required — e.g. audio/mpeg or video/mp4.', 'jetpack-podcast' ) }
+						value={ alt.type || '' }
+						onChange={ type => updateEnclosure( index, { type } ) }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+					<TextControl
+						label={ __( 'Title', 'jetpack-podcast' ) }
+						value={ alt.title || '' }
+						onChange={ title => updateEnclosure( index, { title } ) }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+					<TextControl
+						label={ __( 'Language', 'jetpack-podcast' ) }
+						help={ __( 'BCP 47 code, e.g. en or es-MX.', 'jetpack-podcast' ) }
+						value={ alt.lang || '' }
+						onChange={ lang => updateEnclosure( index, { lang } ) }
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+					<TextControl
+						label={ __( 'Bitrate (bits per second)', 'jetpack-podcast' ) }
+						type="number"
+						min={ 0 }
+						value={ alt.bitrate ?? '' }
+						onChange={ value =>
+							updateEnclosure( index, { bitrate: value === '' ? undefined : Number( value ) } )
+						}
+						__nextHasNoMarginBottom
+						__next40pxDefaultSize
+					/>
+					<Button variant="link" isDestructive onClick={ () => removeEnclosure( index ) }>
+						{ __( 'Remove alternate file', 'jetpack-podcast' ) }
+					</Button>
+				</div>
+			) ) }
+			<Button variant="secondary" onClick={ addEnclosure }>
+				{ __( 'Add alternate file', 'jetpack-podcast' ) }
+			</Button>
+		</>
+	);
+}
+
 export default function PodcastEpisodeEdit( { attributes, setAttributes, context }: EditProps ) {
 	const validated = useMemo(
 		() => getValidatedAttributes( metadata.attributes, attributes ) as PodcastEpisodeAttributes,
@@ -191,6 +350,8 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 		people = [],
 		showPoster,
 		coverArt,
+		soundbites = [],
+		alternateEnclosures = [],
 	} = validated;
 
 	const { postId, postType } = context || {};
@@ -614,6 +775,36 @@ export default function PodcastEpisodeEdit( { attributes, setAttributes, context
 						<PeopleEditor
 							people={ people }
 							onChange={ value => setAttributes( { people: value } ) }
+						/>
+					</BaseControl>
+					<BaseControl __nextHasNoMarginBottom>
+						<BaseControl.VisualLabel>
+							{ __( 'Soundbites', 'jetpack-podcast' ) }
+						</BaseControl.VisualLabel>
+						<p className="components-base-control__help">
+							{ __(
+								'Highlight clips by start time and length. Podcasting 2.0 apps surface them for sharing, and the post page shows click-to-seek buttons.',
+								'jetpack-podcast'
+							) }
+						</p>
+						<SoundbitesEditor
+							soundbites={ soundbites }
+							onChange={ value => setAttributes( { soundbites: value } ) }
+						/>
+					</BaseControl>
+					<BaseControl __nextHasNoMarginBottom>
+						<BaseControl.VisualLabel>
+							{ __( 'Alternate files', 'jetpack-podcast' ) }
+						</BaseControl.VisualLabel>
+						<p className="components-base-control__help">
+							{ __(
+								'Offer the episode in other formats, bitrates, or languages. Listed on the post page and in the feed as alternate enclosures.',
+								'jetpack-podcast'
+							) }
+						</p>
+						<AlternateEnclosuresEditor
+							alternateEnclosures={ alternateEnclosures }
+							onChange={ value => setAttributes( { alternateEnclosures: value } ) }
 						/>
 					</BaseControl>
 				</PanelBody>

--- a/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
+++ b/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
@@ -194,7 +194,13 @@ function SoundbitesEditor( { soundbites, onChange }: SoundbitesEditorProps ) {
 	const removeSoundbite = ( index: number ) =>
 		onChange( soundbites.filter( ( _, i ) => i !== index ) );
 	const addSoundbite = () => onChange( [ ...soundbites, { title: '' } ] );
-	const toSeconds = ( value: string ) => ( value === '' ? undefined : Number( value ) );
+	const toSeconds = ( value: string ) => {
+		if ( value === '' ) {
+			return undefined;
+		}
+		const seconds = Number( value );
+		return Number.isFinite( seconds ) ? Math.max( 0, seconds ) : undefined;
+	};
 
 	return (
 		<>
@@ -263,6 +269,12 @@ function AlternateEnclosuresEditor( {
 		onChange( alternateEnclosures.filter( ( _, i ) => i !== index ) );
 	const addEnclosure = () =>
 		onChange( [ ...alternateEnclosures, { url: '', type: '', title: '', lang: '' } ] );
+	const toBitrate = ( value: string ) => {
+		const bitrate = Number( value );
+		return value === '' || ! Number.isFinite( bitrate ) || bitrate < 0
+			? undefined
+			: Math.floor( bitrate );
+	};
 
 	return (
 		<>
@@ -309,9 +321,7 @@ function AlternateEnclosuresEditor( {
 						type="number"
 						min={ 0 }
 						value={ alt.bitrate ?? '' }
-						onChange={ value =>
-							updateEnclosure( index, { bitrate: value === '' ? undefined : Number( value ) } )
-						}
+						onChange={ value => updateEnclosure( index, { bitrate: toBitrate( value ) } ) }
 						__nextHasNoMarginBottom
 						__next40pxDefaultSize
 					/>

--- a/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
+++ b/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
@@ -191,7 +191,8 @@ function SoundbitesEditor( { soundbites, onChange }: SoundbitesEditorProps ) {
 	const updateSoundbite = ( index: number, patch: Partial< Soundbite > ) => {
 		onChange( soundbites.map( ( sb, i ) => ( i === index ? { ...sb, ...patch } : sb ) ) );
 	};
-	const removeSoundbite = ( index: number ) => onChange( soundbites.filter( ( _, i ) => i !== index ) );
+	const removeSoundbite = ( index: number ) =>
+		onChange( soundbites.filter( ( _, i ) => i !== index ) );
 	const addSoundbite = () => onChange( [ ...soundbites, { title: '' } ] );
 	const toSeconds = ( value: string ) => ( value === '' ? undefined : Number( value ) );
 
@@ -249,7 +250,10 @@ interface AlternateEnclosuresEditorProps {
 	onChange: ( next: AlternateEnclosure[] ) => void;
 }
 
-function AlternateEnclosuresEditor( { alternateEnclosures, onChange }: AlternateEnclosuresEditorProps ) {
+function AlternateEnclosuresEditor( {
+	alternateEnclosures,
+	onChange,
+}: AlternateEnclosuresEditorProps ) {
 	const updateEnclosure = ( index: number, patch: Partial< AlternateEnclosure > ) => {
 		onChange(
 			alternateEnclosures.map( ( alt, i ) => ( i === index ? { ...alt, ...patch } : alt ) )

--- a/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
+++ b/projects/packages/podcast/src/blocks/podcast-episode/edit.tsx
@@ -192,9 +192,7 @@ function SoundbitesEditor( { soundbites, onChange }: SoundbitesEditorProps ) {
 		onChange( soundbites.map( ( sb, i ) => ( i === index ? { ...sb, ...patch } : sb ) ) );
 	};
 	const removeSoundbite = ( index: number ) => onChange( soundbites.filter( ( _, i ) => i !== index ) );
-	const addSoundbite = () => onChange( [ ...soundbites, { startTime: 0, duration: 0, title: '' } ] );
-	// startTime/duration are seconds — parse empty as undefined so a cleared field
-	// doesn't coerce to 0 and emit a bogus feed entry.
+	const addSoundbite = () => onChange( [ ...soundbites, { title: '' } ] );
 	const toSeconds = ( value: string ) => ( value === '' ? undefined : Number( value ) );
 
 	return (

--- a/projects/packages/podcast/src/feed/class-episode-block-tags.php
+++ b/projects/packages/podcast/src/feed/class-episode-block-tags.php
@@ -301,6 +301,16 @@ class Episode_Block_Tags {
 			} elseif ( ! empty( $alt['url'] ) ) {
 				$sources[] = (string) $alt['url'];
 			}
+
+			// Drop unvalidated URIs so we never emit an empty or malformed <podcast:source>.
+			$sources = array_values(
+				array_filter(
+					$sources,
+					static function ( $uri ) {
+						return wp_http_validate_url( esc_url_raw( $uri ) );
+					}
+				)
+			);
 			if ( empty( $sources ) ) {
 				continue;
 			}

--- a/projects/packages/podcast/src/feed/class-episode-block-tags.php
+++ b/projects/packages/podcast/src/feed/class-episode-block-tags.php
@@ -302,12 +302,14 @@ class Episode_Block_Tags {
 				$sources[] = (string) $alt['url'];
 			}
 
-			// Drop unvalidated URIs so we never emit an empty or malformed <podcast:source>.
+			// Drop empty/malformed URIs so we never emit a blank <podcast:source>.
+			// Match the emit-side esc_url() rather than wp_http_validate_url(), which
+			// resolves DNS — we're printing a URI for clients, not fetching it.
 			$sources = array_values(
 				array_filter(
 					$sources,
 					static function ( $uri ) {
-						return wp_http_validate_url( esc_url_raw( $uri ) );
+						return '' !== esc_url_raw( (string) $uri );
 					}
 				)
 			);


### PR DESCRIPTION
## Proposed changes

The Podcast Episode block declared `soundbites` and `alternateEnclosures` attributes that were fully wired on the output side but had no way to be authored:

- **Front-end render** emitted schema.org `Clip` markup + click-to-seek soundbite buttons + an alternate-files list.
- **View script** (`view.ts`) enqueued the seek-on-click behavior whenever soundbites existed.
- **RSS feed** emitted real `<podcast:soundbite>` and `<podcast:alternateEnclosure>` Podcasting 2.0 tags (with existing test coverage).

…but `edit.tsx` exposed no controls for either, so all three paths were dead end-to-end. This adds the missing editor UI in the block's existing **Podcasting 2.0** inspector panel, modeled on the existing `PeopleEditor`:

- **Soundbites**: repeatable rows of start time / duration (seconds) / title. Cleared numeric fields parse to `undefined` rather than `0`, so an empty field can't emit a bogus feed entry.
- **Alternate files**: repeatable rows of file URL / MIME type / title / language / bitrate.

The data shapes produced match exactly what the render, feed, and existing PHP tests already expect, so no PHP or test changes were needed.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Create or edit a post with the **Podcast Episode** block and select an audio/video file.
* In the block sidebar, open the **Podcasting 2.0** panel.
* Under **Soundbites**, click *Add soundbite*, set a start time and duration (in seconds), and an optional title.
* Under **Alternate files**, click *Add alternate file*, set a file URL and MIME type (e.g. `audio/mpeg`), and optional title/language/bitrate.
* Save/publish, then view the post: soundbites render as click-to-seek buttons that jump the player; alternate files render as a list.
* View the podcast feed and confirm `<podcast:soundbite>` and `<podcast:alternateEnclosure>` tags appear for the episode.
