### PR TITLE
Podcast: derive upsell fallback URL from injected product

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-hardcoded-upsell-urls
+++ b/projects/packages/podcast/changelog/fix-podcast-hardcoded-upsell-urls
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Podcast: derive the no-site-slug upsell checkout fallback from the injected upgrade product instead of hardcoding wpcom URLs, so the fallback points at the right product (e.g. `jetpack_growth`) on self-hosted rather than a generic pricing page.
+Podcast: fix hardcoded upsell fallback URL to use the injected upgrade product.

--- a/projects/packages/podcast/changelog/fix-podcast-hardcoded-upsell-urls
+++ b/projects/packages/podcast/changelog/fix-podcast-hardcoded-upsell-urls
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast: derive the no-site-slug upsell checkout fallback from the injected upgrade product instead of hardcoding wpcom URLs, so the fallback points at the right product (e.g. `jetpack_growth`) on self-hosted rather than a generic pricing page.

--- a/projects/packages/podcast/src/dashboard/locked-preview/index.tsx
+++ b/projects/packages/podcast/src/dashboard/locked-preview/index.tsx
@@ -23,7 +23,6 @@ const LockedPreview = ( { variant }: LockedPreviewProps ) => {
 		siteSlug: getSiteData()?.suffix ?? '',
 		returnUrl,
 		params: { cancel_to: returnUrl },
-		noSiteSlugUrl: 'https://wordpress.com/pricing',
 	} );
 
 	const titleId = useId();

--- a/projects/packages/podcast/src/dashboard/upgrade.ts
+++ b/projects/packages/podcast/src/dashboard/upgrade.ts
@@ -17,6 +17,12 @@ export const getUpgradeProductSlug = (): string =>
 export const getUpgradePlanName = (): string =>
 	getScriptData()?.podcast?.upgrade?.plan_name ?? 'Premium';
 
+// Generic, site-agnostic checkout for the injected upgrade product (e.g.
+// `jetpack_growth` on self-hosted, `premium` on wpcom). Used as the fallback
+// when there's no site slug to build a per-site checkout from.
+export const getUpgradeProductCheckoutUrl = (): string =>
+	`https://wordpress.com/checkout/${ getUpgradeProductSlug() }`;
+
 interface UpgradeCheckoutUrlArgs {
 	/** Calypso site fragment (`site.suffix`); empty falls back to `noSiteSlugUrl`. */
 	siteSlug: string;
@@ -24,25 +30,25 @@ interface UpgradeCheckoutUrlArgs {
 	returnUrl: string;
 	/** Extra query params to set on the checkout URL (e.g. `source`, `cancel_to`). */
 	params?: Record< string, string >;
-	/** URL to use when there's no site slug to build a per-site checkout from. */
-	noSiteSlugUrl: string;
+	/** URL to use when there's no site slug; defaults to the generic product checkout. */
+	noSiteSlugUrl?: string;
 }
 
 /**
  * Build the podcast upsell checkout URL for the injected upgrade product.
  *
- * @param {UpgradeCheckoutUrlArgs} args               - Checkout URL arguments.
- * @param {string}                 args.siteSlug      - Calypso site fragment; empty falls back to `noSiteSlugUrl`.
- * @param {string}                 args.returnUrl     - Where checkout returns after purchase (`redirect_to`).
- * @param {object}                 [args.params]      - Extra query params to set on the checkout URL.
- * @param {string}                 args.noSiteSlugUrl - URL to use when there's no site slug.
+ * @param {UpgradeCheckoutUrlArgs} args                 - Checkout URL arguments.
+ * @param {string}                 args.siteSlug        - Calypso site fragment; empty falls back to `noSiteSlugUrl`.
+ * @param {string}                 args.returnUrl       - Where checkout returns after purchase (`redirect_to`).
+ * @param {object}                 [args.params]        - Extra query params to set on the checkout URL.
+ * @param {string}                 [args.noSiteSlugUrl] - URL to use when there's no site slug; defaults to the generic product checkout.
  * @return {string} The checkout URL for the injected upgrade product.
  */
 export const buildUpgradeCheckoutUrl = ( {
 	siteSlug,
 	returnUrl,
 	params,
-	noSiteSlugUrl,
+	noSiteSlugUrl = getUpgradeProductCheckoutUrl(),
 }: UpgradeCheckoutUrlArgs ): string => {
 	if ( ! siteSlug ) {
 		return noSiteSlugUrl;

--- a/projects/packages/podcast/src/dashboard/welcome/index.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/index.tsx
@@ -14,7 +14,7 @@ import {
 import { useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Icon, check, globe, layout, megaphone } from '@wordpress/icons';
-import { buildUpgradeCheckoutUrl, getUpgradeProductSlug, getUpgradePlanName } from '../upgrade';
+import { buildUpgradeCheckoutUrl, getUpgradePlanName } from '../upgrade';
 import './style.scss';
 
 interface WelcomeProps {
@@ -50,7 +50,6 @@ const getUpgradeCheckoutUrl = (): string => {
 		returnUrl: returnTo,
 		// Calypso threads `source` through its downstream Tracks events.
 		params: { source: CHECKOUT_SOURCE },
-		noSiteSlugUrl: `https://wordpress.com/checkout/${ getUpgradeProductSlug() }`,
 	} );
 };
 


### PR DESCRIPTION
## Proposed changes

A final migration audit flagged two hardcoded `wordpress.com` upsell URLs in the podcast dashboard that should be dynamic now that the module runs on self-hosted Jetpack. These were the `noSiteSlugUrl` fallbacks — the rarely-hit path used only when a site slug is unavailable (the normal path already builds a per-site Calypso checkout via `getProductCheckoutUrl`).

* `locked-preview` fell back to a generic `https://wordpress.com/pricing` — a weak, non-product landing for a self-hosted Growth upsell.
* `welcome` hand-built `https://wordpress.com/checkout/${slug}`, duplicating the base URL that already lives in `getProductCheckoutUrl`.

Both are replaced by a single `getUpgradeProductCheckoutUrl()` helper in `upgrade.ts` that derives the fallback from the server-injected upgrade product slug (`jetpack_growth`/`jetpack_complete` on self-hosted, `premium`/etc. on wpcom). `buildUpgradeCheckoutUrl` now defaults `noSiteSlugUrl` to it, so the components carry no hardcoded URLs and both fallbacks land on the correct product checkout.

Note: `wordpress.com/checkout/` itself is the canonical, cross-Jetpack checkout base (Jetpack plans genuinely sell through Calypso checkout there), so the one remaining literal is intentional and co-located with `getProductCheckoutUrl`'s own base.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a **self-hosted** Jetpack site, open the Podcast dashboard on a free plan and click an upgrade CTA (Welcome plan card, or the Episodes/Stats locked preview). Confirm the checkout URL targets the injected product (e.g. `.../checkout/<site>/jetpack_growth`).
* To exercise the fallback specifically: with no site slug available, confirm the CTA now points at `https://wordpress.com/checkout/jetpack_growth` (self-hosted) / the injected product, rather than `/pricing`.
* Repeat on a Simple/Atomic site and confirm the wpcom product checkout is unchanged.
