### PR TITLE
WP Build Polyfills: bump @wordpress/theme to 0.17.0 to fix blank Forms/VideoPress dashboards on WP 6.9

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5157,7 +5157,7 @@ importers:
         version: 6.50.0
       '@wordpress/build':
         specifier: 0.16.1
-        version: 0.16.1(@babel/core@7.29.7)(@wordpress/boot@0.17.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.50.0)(@wordpress/route@0.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@0.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.2)
+        version: 0.16.1(@babel/core@7.29.7)(@wordpress/boot@0.17.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.50.0)(@wordpress/route@0.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@0.17.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.2)
       '@wordpress/icons':
         specifier: ^13.0.0
         version: 13.1.0(@types/react@18.3.28)(react@18.3.1)
@@ -5174,8 +5174,8 @@ importers:
         specifier: ^0.16.0
         version: 0.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/theme':
-        specifier: ^0.15.0
-        version: 0.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^0.17.0
+        version: 0.17.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/ui':
         specifier: ^0.13.0
         version: 0.13.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -25254,7 +25254,7 @@ snapshots:
       - browserslist
       - supports-color
 
-  '@wordpress/build@0.16.1(@babel/core@7.29.7)(@wordpress/boot@0.17.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.50.0)(@wordpress/route@0.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@0.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.2)':
+  '@wordpress/build@0.16.1(@babel/core@7.29.7)(@wordpress/boot@0.17.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.50.0)(@wordpress/route@0.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@0.17.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.2)':
     dependencies:
       '@emotion/babel-plugin': 11.13.5
       '@wordpress/style-runtime': 0.4.1
@@ -25276,7 +25276,7 @@ snapshots:
       '@wordpress/boot': 0.17.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/private-apis': 1.50.0
       '@wordpress/route': 0.16.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@wordpress/theme': 0.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@wordpress/theme': 0.17.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - '@babel/core'
       - browserslist

--- a/projects/packages/wp-build-polyfills/changelog/fix-wp-build-polyfills-theme-provider
+++ b/projects/packages/wp-build-polyfills/changelog/fix-wp-build-polyfills-theme-provider
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Update @wordpress/theme to 0.17.0 so wp.theme exposes ThemeProvider, which @wordpress/boot renders; fixes blank wp-build admin dashboards (Forms, VideoPress) on WordPress 6.9.

--- a/projects/packages/wp-build-polyfills/package.json
+++ b/projects/packages/wp-build-polyfills/package.json
@@ -36,7 +36,7 @@
 		"@wordpress/notices": "^5.40.0",
 		"@wordpress/private-apis": "1.50.0",
 		"@wordpress/route": "^0.16.0",
-		"@wordpress/theme": "^0.15.0",
+		"@wordpress/theme": "^0.17.0",
 		"@wordpress/ui": "^0.13.0",
 		"browserslist": "^4.24.0",
 		"c8": "^11.0.0",

--- a/projects/plugins/jetpack/changelog/fix-wp-build-polyfills-theme-provider
+++ b/projects/plugins/jetpack/changelog/fix-wp-build-polyfills-theme-provider
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Forms and VideoPress: fix the admin dashboards rendering a blank "Something went wrong!" error on WordPress 6.9.


### PR DESCRIPTION
## Proposed changes

Fixes the **blank "Something went wrong!" wp-build admin dashboards on Jetpack 16.0 / WordPress 6.9** — reported for **Forms**, and reproduced identically on **VideoPress**.

Bumps `@wordpress/theme` from `^0.15.0` to `^0.17.0` in `wp-build-polyfills`. That's the whole fix.

### Root cause: boot and theme are a mismatched pair on 16.0

`wp-build-polyfills` on `branch-16.0` resolves:

| Package | Version on 16.0 |
|---|---|
| `@wordpress/boot` | **0.17.0** |
| `@wordpress/theme` | **0.15.1** |

The polyfill's boot module renders `ThemeProvider` as a **public** export of `wp.theme`:

```js
(0, x.jsx)(h.ThemeProvider, { isRoot: true, ... })   // h = the wp-theme external
```

But `@wordpress/theme` 0.15.1 only exports `privateApis`. You can see it in the script 16.0 actually serves — `ThemeProvider` is compiled in, but never exported:

```js
t.d(a, { privateApis: () => n.j });   // no ThemeProvider
(window.wp = window.wp || {}).theme = a;
```

So boot reads `undefined`, React throws **#130** (`type is invalid ... got: undefined`), the error boundary catches it, and the page renders "Something went wrong!".

`@wordpress/theme` added the public export in 0.17.0:

```js
export { privateApis } from './private-apis';
export { ThemeProvider } from './theme-provider';   // ← new
```

Every wp-build (script-module) dashboard boots through that module, which is why **one dependency skew breaks multiple products at once**. This was never a Forms bug.

### Why this doesn't affect trunk

Trunk bumped theme to 0.17.0 as part of the `@wordpress/*` monorepo update (#49272), re-pairing boot and theme. That PR is ~281 files, so it isn't a sane cherry-pick for a point release — hence this minimal, targeted bump instead.

### Blast radius

Rebuilding the package with only this bump changes **exactly one built artifact** — `build/scripts/theme/index.js` (+ its `.asset.php`). Every other polyfill asset (boot, route, a11y, notices, private-apis, views) is byte-identical to what 16.0 ships. `@wordpress/ui` does **not** need to move; theme alone is sufficient.

## Testing instructions

Verified on a Jurassic Ninja site running **WordPress 6.9.4 + Jetpack 16.0** (Gutenberg not installed), driven with Playwright.

**Before** — `Jetpack → Forms` and `Jetpack → VideoPress` both render "Something went wrong!", console shows `Minified React error #130` originating in `jetpack-wp-build-polyfills/build/modules/boot/index.js`.

**After** (production build of this branch rsynced to the same site):

* **Forms** renders the forms list and Responses tabs.
* **VideoPress** renders Overview, views trends, and stats.
* **My Jetpack** and **Boost** continue to render (unaffected — they never depended on `wp-theme` on 16.0).
* `React error #130` is gone from the console.

To reproduce:

1. WordPress 6.9.x, Jetpack 16.0, Gutenberg plugin **inactive**.
2. Visit `admin.php?page=jetpack-forms-responses-wp-admin` → blank error page on stock 16.0.
3. Apply this branch, rebuild `wp-build-polyfills`, and reload → dashboard renders.

## Does this pull request change what data or activity we track or use?

No.
