### PR TITLE
AI settings: report SEO enhancer availability

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai-feature-settings.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai-feature-settings.php
@@ -19,6 +19,7 @@
 
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Current_Plan;
+use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Search\Plan as Search_Plan;
 use Automattic\Jetpack\Status\Host;
 
@@ -203,13 +204,38 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings extends WP_REST_Controller 
 					),
 				),
 				'feature_clip'      => array( 'enabled' => $stored['feature_clip'] ),
-				'seo_enhancer'      => array( 'enabled' => $stored['seo_enhancer'] ),
+				'seo_enhancer'      => array(
+					'enabled'   => $stored['seo_enhancer'],
+					'available' => $this->is_seo_enhancer_available(),
+				),
 				'ai_search'         => array(
 					'enabled'          => $stored['ai_search'],
 					'requires_upgrade' => ! $supports_search,
 				),
 			),
 		);
+	}
+
+	/**
+	 * Whether the AI SEO enhancer is available on this site, so the settings
+	 * page can hide its row where the feature can't run.
+	 *
+	 * Mirrors the legacy Traffic page's gate: the feature filter, the
+	 * seo-tools module (always active on WordPress.com Simple, where
+	 * Modules::is_active() short-circuits), and the plan feature.
+	 *
+	 * @return bool
+	 */
+	private function is_seo_enhancer_available() {
+		$filter_on = (bool) apply_filters( 'ai_seo_enhancer_enabled', true );
+
+		$module_active = class_exists( Modules::class )
+			&& ( new Modules() )->is_active( 'seo-tools' );
+
+		$plan_supports = class_exists( Current_Plan::class )
+			&& Current_Plan::supports( 'ai-seo-enhancer' );
+
+		return $filter_on && $module_active && $plan_supports;
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-seo-enhancer-availability
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-seo-enhancer-availability
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI settings: report SEO enhancer availability in the feature-settings endpoint.


### PR DESCRIPTION
Addresses backend for https://github.com/Automattic/jetpack/pull/50386#discussion_r3557433876

## Proposed changes
* The `feature-settings` endpoint reports `seo_enhancer.available`, so the settings page can hide the AI SEO row where the enhancer can't run.
* The gate mirrors the legacy Traffic page: the `ai_seo_enhancer_enabled` filter, the `seo-tools` module (`Modules::is_active()` — always true on Simple), and the `ai-seo-enhancer` plan feature. Happy to drop the module term if you'd rather match the newer `packages/seo` formula (filter + plan only).

## Does this pull request change what data or activity we track or use?
No

## Testing instructions
* `GET wpcom/v2/jetpack-ai/feature-settings` as admin → `features.seo_enhancer.available` is `true` on a plan with the feature and the seo-tools module active.
* Deactivate the SEO Tools module (or test on a plan without `ai-seo-enhancer`) → `available` flips to `false`
