### PR TITLE
Premium Analytics: Add post detail Traffic activity widget

### DIFF
--- a/projects/js-packages/charts/changelog/add-heatmap-max-cell-size
+++ b/projects/js-packages/charts/changelog/add-heatmap-max-cell-size
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Charts: add HeatmapChart maxCellWidth/maxCellHeight caps so sparse non-compact grids keep sensible cell sizes.

--- a/projects/js-packages/charts/changelog/add-heatmap-max-cell-size
+++ b/projects/js-packages/charts/changelog/add-heatmap-max-cell-size
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Charts: add HeatmapChart min/max cell size bounds (sparse grids keep sensible cells, long grids overflow for scrolling), hidden cells for ragged calendar edges (buildCalendarHeatmapData's hideOutOfRangeDays), and floor an all-zero heatmap at the scale bottom instead of full intensity.
+Charts: add HeatmapChart min/max cell size bounds (sparse grids keep sensible cells, long grids overflow for scrolling) and floor an all-zero heatmap at the scale bottom instead of full intensity.

--- a/projects/js-packages/charts/changelog/add-heatmap-max-cell-size
+++ b/projects/js-packages/charts/changelog/add-heatmap-max-cell-size
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Charts: add HeatmapChart min/max cell size bounds (sparse grids keep sensible cells, long grids overflow for scrolling) and floor an all-zero heatmap at the scale bottom instead of full intensity.
+Charts: add HeatmapChart min/max cell size bounds (sparse grids keep sensible cells, long grids overflow for scrolling), hidden cells for ragged calendar edges (buildCalendarHeatmapData's hideOutOfRangeDays), and floor an all-zero heatmap at the scale bottom instead of full intensity.

--- a/projects/js-packages/charts/changelog/add-heatmap-max-cell-size
+++ b/projects/js-packages/charts/changelog/add-heatmap-max-cell-size
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Charts: add HeatmapChart maxCellWidth/maxCellHeight caps so sparse non-compact grids keep sensible cell sizes.
+Charts: add HeatmapChart min/max cell size bounds (sparse grids keep sensible cells, long grids overflow for scrolling) and floor an all-zero heatmap at the scale bottom instead of full intensity.

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
@@ -5,9 +5,10 @@
 	font-size: var(--wpds-typography-font-size-sm, 12px);
 }
 
-// Capped grids are content-sized, so the wrapper hugs them instead of
-// stretching — the consumer decides how to place it in leftover space.
-.heatmap-chart--capped {
+// Height-capped grids are content-sized vertically, so the wrapper hugs them
+// instead of stretching — the consumer decides how to place it in leftover
+// space. Width-only caps keep the normal full-height layout.
+.heatmap-chart--height-capped {
 	height: max-content;
 }
 
@@ -42,9 +43,10 @@
 	min-height: 0;
 }
 
-// Cell-size caps make the tracks content-bound, so the grid must not stretch:
-// leftover container height would otherwise be absorbed by the auto label row.
-.heatmap-chart__grid--capped {
+// A cell-height cap makes the row tracks content-bound, so the grid must not
+// stretch: leftover container height would otherwise be absorbed by the auto
+// label row. A width-only cap does not change vertical flex sizing.
+.heatmap-chart__grid--height-capped {
 	flex: 0 0 auto;
 	height: max-content;
 	min-height: 0;

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
@@ -36,6 +36,14 @@
 	min-height: 0;
 }
 
+// Cell-size caps make the tracks content-bound, so the grid must not stretch:
+// leftover container height would otherwise be absorbed by the auto label row.
+.heatmap-chart__grid--capped {
+	flex: 0 0 auto;
+	height: max-content;
+	min-height: 0;
+}
+
 .heatmap-chart__row {
 	display: contents;
 }

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
@@ -85,6 +85,13 @@
 	background: var(--wpds-color-background-track-neutral-weak, #f0f0f0);
 }
 
+// An empty grid slot (calendar ragged edges): keeps its track but paints and
+// captures nothing. `visibility` (not `display`) so the slot still sizes.
+.heatmap-chart__cell--hidden {
+	visibility: hidden;
+	pointer-events: none;
+}
+
 // Floor the mix at 15% so the lowest value stays visibly tinted, distinct from
 // an empty cell.
 .heatmap-chart__cell--filled {

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
@@ -5,6 +5,12 @@
 	font-size: var(--wpds-typography-font-size-sm, 12px);
 }
 
+// Capped grids are content-sized, so the wrapper hugs them instead of
+// stretching — the consumer decides how to place it in leftover space.
+.heatmap-chart--capped {
+	height: max-content;
+}
+
 .heatmap-chart__empty {
 	padding: var(--wpds-dimension-padding-lg, 16px);
 	color: var(--wpds-color-foreground-content-neutral-weak, #707070);

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
@@ -85,13 +85,6 @@
 	background: var(--wpds-color-background-track-neutral-weak, #f0f0f0);
 }
 
-// An empty grid slot (calendar ragged edges): keeps its track but paints and
-// captures nothing. `visibility` (not `display`) so the slot still sizes.
-.heatmap-chart__cell--hidden {
-	visibility: hidden;
-	pointer-events: none;
-}
-
 // Floor the mix at 15% so the lowest value stays visibly tinted, distinct from
 // an empty cell.
 .heatmap-chart__cell--filled {

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
@@ -129,6 +129,11 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 		hideTooltip();
 	}, [ hideTooltip ] );
 
+	const isCellHidden = useCallback(
+		( col: number, row: number ) => data[ col ]?.data[ row ]?.hidden === true,
+		[ data ]
+	);
+
 	const onChartKeyDown = useCallback(
 		( event: React.KeyboardEvent< HTMLDivElement > ) => {
 			if (
@@ -148,26 +153,46 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 			event.preventDefault();
 
 			if ( selectedIndex === undefined ) {
-				setSelectedIndex( 0 );
+				// Start at the first navigable cell (a calendar's leading edge
+				// slots may be hidden).
+				for ( let index = 0; index < columns * rows; index++ ) {
+					if ( ! isCellHidden( Math.floor( index / rows ), index % rows ) ) {
+						setSelectedIndex( index );
+						return;
+					}
+				}
 				return;
 			}
 
+			let stepCol = 0;
+			let stepRow = 0;
+			if ( event.key === 'ArrowRight' ) {
+				stepCol = 1;
+			} else if ( event.key === 'ArrowLeft' ) {
+				stepCol = -1;
+			} else if ( event.key === 'ArrowDown' ) {
+				stepRow = 1;
+			} else if ( event.key === 'ArrowUp' ) {
+				stepRow = -1;
+			}
+
+			// Step past hidden slots to the next navigable cell in the pressed
+			// direction; when only hidden slots (or the edge) remain that way,
+			// the selection stays put.
 			let col = Math.floor( selectedIndex / rows );
 			let row = selectedIndex % rows;
+			do {
+				col += stepCol;
+				row += stepRow;
+			} while ( col >= 0 && col < columns && row >= 0 && row < rows && isCellHidden( col, row ) );
 
-			if ( event.key === 'ArrowRight' ) {
-				col = Math.min( col + 1, columns - 1 );
-			} else if ( event.key === 'ArrowLeft' ) {
-				col = Math.max( col - 1, 0 );
-			} else if ( event.key === 'ArrowDown' ) {
-				row = Math.min( row + 1, rows - 1 );
-			} else if ( event.key === 'ArrowUp' ) {
-				row = Math.max( row - 1, 0 );
+			if ( col < 0 || col >= columns || row < 0 || row >= rows ) {
+				return;
 			}
 
 			setSelectedIndex( col * rows + row );
 		},
-		[ rows, columns, selectedIndex, hideTooltip ]
+		[ rows, columns, selectedIndex, hideTooltip, isCellHidden ]
 	);
 
 	const handleCellMouseMove = useCallback(
@@ -340,6 +365,24 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 									</span>
 									{ data.map( ( column, columnIndex ) => {
 										const cell = column.data[ rowIndex ];
+
+										// A hidden cell keeps its grid slot (so the rest of the
+										// column doesn't shift) but paints nothing and takes no
+										// interaction — a calendar's ragged edges.
+										if ( cell?.hidden ) {
+											return (
+												<div
+													key={ `cell-${ columnIndex }-${ rowIndex }` }
+													data-testid="heatmap-cell-hidden"
+													aria-hidden="true"
+													className={ clsx(
+														styles[ 'heatmap-chart__cell' ],
+														styles[ 'heatmap-chart__cell--hidden' ]
+													) }
+												/>
+											);
+										}
+
 										const value = cell?.value ?? null;
 										const present = isPresent( value );
 										const normalized = present ? getNormalizedValue( value, extent ) : 0;

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
@@ -48,6 +48,8 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 	showValues,
 	maxCellWidth,
 	maxCellHeight,
+	minCellWidth,
+	minCellHeight,
 	rowLabels = [],
 	primaryColor,
 	gap = 'md',
@@ -246,14 +248,15 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 	}
 
 	// Non-compact tracks split the container by default; a max cap makes them
-	// stop growing there instead, so sparse ranges keep sensible cell sizes
-	// while narrow containers still shrink them.
+	// stop growing there instead, so sparse ranges keep sensible cell sizes,
+	// and a min floor makes the grid overflow (for a scrollable wrapper)
+	// rather than crushing cells on long ranges.
 	const columnTrack = compact
 		? 'var(--heatmap-cell-size)'
-		: `minmax(0, ${ maxCellWidth ? `${ maxCellWidth }px` : '1fr' })`;
+		: `minmax(${ minCellWidth ?? 0 }px, ${ maxCellWidth ? `${ maxCellWidth }px` : '1fr' })`;
 	const rowTrack = compact
 		? 'var(--heatmap-cell-size)'
-		: `minmax(0, ${ maxCellHeight ? `${ maxCellHeight }px` : '1fr' })`;
+		: `minmax(${ minCellHeight ?? 0 }px, ${ maxCellHeight ? `${ maxCellHeight }px` : '1fr' })`;
 	const gridStyle: Record< string, string | number > = {
 		'--heatmap-primary': primaryColorHex,
 		'--heatmap-bg': theme.backgroundColor,

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
@@ -273,10 +273,11 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 			? `${ chartId }-cell-${ Math.floor( selectedIndex / rows ) }-${ selectedIndex % rows }`
 			: undefined;
 
-	// Capped tracks make the chart content-sized: neither the wrapper nor the
-	// grid stretches, or the leftover container height would land in the auto
-	// label row.
-	const capped = ! compact && Boolean( maxCellWidth || maxCellHeight );
+	// A capped row track makes the chart content-sized vertically: neither the
+	// wrapper nor the grid stretches, or the leftover container height would
+	// land in the auto label row. A width-only cap must keep the normal vertical
+	// flex sizing, so it does not opt into this class.
+	const heightCapped = ! compact && Boolean( maxCellHeight );
 
 	return (
 		<HeatmapContext.Provider value={ heatmapContext }>
@@ -288,7 +289,7 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 					trailingContent={ nonLegendChildren }
 					gap={ gap }
 					className={ clsx( 'heatmap-chart', styles[ 'heatmap-chart' ], className, {
-						[ styles[ 'heatmap-chart--capped' ] ]: capped,
+						[ styles[ 'heatmap-chart--height-capped' ] ]: heightCapped,
 					} ) }
 					// Explicit dimensions (the unresponsive export) pin the size; otherwise
 					// width/height are unset and the grid fills its container via CSS. The
@@ -309,7 +310,7 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 						onKeyDown={ onChartKeyDown }
 						className={ clsx( styles[ 'heatmap-chart__grid' ], {
 							[ styles[ 'heatmap-chart__grid--compact' ] ]: compact,
-							[ styles[ 'heatmap-chart__grid--capped' ] ]: capped,
+							[ styles[ 'heatmap-chart__grid--height-capped' ] ]: heightCapped,
 						} ) }
 						style={ gridStyle as CSSProperties }
 					>

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
@@ -302,6 +302,10 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 						onKeyDown={ onChartKeyDown }
 						className={ clsx( styles[ 'heatmap-chart__grid' ], {
 							[ styles[ 'heatmap-chart__grid--compact' ] ]: compact,
+							// Capped tracks make the grid content-sized; without this the
+							// leftover container height would land in the auto label row.
+							[ styles[ 'heatmap-chart__grid--capped' ] ]:
+								! compact && Boolean( maxCellWidth || maxCellHeight ),
 						} ) }
 						style={ gridStyle as CSSProperties }
 					>

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
@@ -129,11 +129,6 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 		hideTooltip();
 	}, [ hideTooltip ] );
 
-	const isCellHidden = useCallback(
-		( col: number, row: number ) => data[ col ]?.data[ row ]?.hidden === true,
-		[ data ]
-	);
-
 	const onChartKeyDown = useCallback(
 		( event: React.KeyboardEvent< HTMLDivElement > ) => {
 			if (
@@ -153,46 +148,26 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 			event.preventDefault();
 
 			if ( selectedIndex === undefined ) {
-				// Start at the first navigable cell (a calendar's leading edge
-				// slots may be hidden).
-				for ( let index = 0; index < columns * rows; index++ ) {
-					if ( ! isCellHidden( Math.floor( index / rows ), index % rows ) ) {
-						setSelectedIndex( index );
-						return;
-					}
-				}
+				setSelectedIndex( 0 );
 				return;
 			}
 
-			let stepCol = 0;
-			let stepRow = 0;
-			if ( event.key === 'ArrowRight' ) {
-				stepCol = 1;
-			} else if ( event.key === 'ArrowLeft' ) {
-				stepCol = -1;
-			} else if ( event.key === 'ArrowDown' ) {
-				stepRow = 1;
-			} else if ( event.key === 'ArrowUp' ) {
-				stepRow = -1;
-			}
-
-			// Step past hidden slots to the next navigable cell in the pressed
-			// direction; when only hidden slots (or the edge) remain that way,
-			// the selection stays put.
 			let col = Math.floor( selectedIndex / rows );
 			let row = selectedIndex % rows;
-			do {
-				col += stepCol;
-				row += stepRow;
-			} while ( col >= 0 && col < columns && row >= 0 && row < rows && isCellHidden( col, row ) );
 
-			if ( col < 0 || col >= columns || row < 0 || row >= rows ) {
-				return;
+			if ( event.key === 'ArrowRight' ) {
+				col = Math.min( col + 1, columns - 1 );
+			} else if ( event.key === 'ArrowLeft' ) {
+				col = Math.max( col - 1, 0 );
+			} else if ( event.key === 'ArrowDown' ) {
+				row = Math.min( row + 1, rows - 1 );
+			} else if ( event.key === 'ArrowUp' ) {
+				row = Math.max( row - 1, 0 );
 			}
 
 			setSelectedIndex( col * rows + row );
 		},
-		[ rows, columns, selectedIndex, hideTooltip, isCellHidden ]
+		[ rows, columns, selectedIndex, hideTooltip ]
 	);
 
 	const handleCellMouseMove = useCallback(
@@ -365,24 +340,6 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 									</span>
 									{ data.map( ( column, columnIndex ) => {
 										const cell = column.data[ rowIndex ];
-
-										// A hidden cell keeps its grid slot (so the rest of the
-										// column doesn't shift) but paints nothing and takes no
-										// interaction — a calendar's ragged edges.
-										if ( cell?.hidden ) {
-											return (
-												<div
-													key={ `cell-${ columnIndex }-${ rowIndex }` }
-													data-testid="heatmap-cell-hidden"
-													aria-hidden="true"
-													className={ clsx(
-														styles[ 'heatmap-chart__cell' ],
-														styles[ 'heatmap-chart__cell--hidden' ]
-													) }
-												/>
-											);
-										}
-
 										const value = cell?.value ?? null;
 										const present = isPresent( value );
 										const normalized = present ? getNormalizedValue( value, extent ) : 0;

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
@@ -46,6 +46,8 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 	className,
 	compact = false,
 	showValues,
+	maxCellWidth,
+	maxCellHeight,
 	rowLabels = [],
 	primaryColor,
 	gap = 'md',
@@ -243,12 +245,20 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 		);
 	}
 
-	const trackSize = compact ? 'var(--heatmap-cell-size)' : 'minmax(0, 1fr)';
+	// Non-compact tracks split the container by default; a max cap makes them
+	// stop growing there instead, so sparse ranges keep sensible cell sizes
+	// while narrow containers still shrink them.
+	const columnTrack = compact
+		? 'var(--heatmap-cell-size)'
+		: `minmax(0, ${ maxCellWidth ? `${ maxCellWidth }px` : '1fr' })`;
+	const rowTrack = compact
+		? 'var(--heatmap-cell-size)'
+		: `minmax(0, ${ maxCellHeight ? `${ maxCellHeight }px` : '1fr' })`;
 	const gridStyle: Record< string, string | number > = {
 		'--heatmap-primary': primaryColorHex,
 		'--heatmap-bg': theme.backgroundColor,
-		gridTemplateColumns: `auto repeat(${ columns }, ${ trackSize })`,
-		gridTemplateRows: `auto repeat(${ rows }, ${ trackSize })`,
+		gridTemplateColumns: `auto repeat(${ columns }, ${ columnTrack })`,
+		gridTemplateRows: `auto repeat(${ rows }, ${ rowTrack })`,
 	};
 	if ( compact ) {
 		gridStyle[ '--heatmap-cell-gap' ] = `${ compactCellGap }px`;

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
@@ -273,6 +273,11 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 			? `${ chartId }-cell-${ Math.floor( selectedIndex / rows ) }-${ selectedIndex % rows }`
 			: undefined;
 
+	// Capped tracks make the chart content-sized: neither the wrapper nor the
+	// grid stretches, or the leftover container height would land in the auto
+	// label row.
+	const capped = ! compact && Boolean( maxCellWidth || maxCellHeight );
+
 	return (
 		<HeatmapContext.Provider value={ heatmapContext }>
 			<SingleChartContext.Provider value={ { chartId } }>
@@ -282,7 +287,9 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 					legendChildren={ [] }
 					trailingContent={ nonLegendChildren }
 					gap={ gap }
-					className={ clsx( 'heatmap-chart', styles[ 'heatmap-chart' ], className ) }
+					className={ clsx( 'heatmap-chart', styles[ 'heatmap-chart' ], className, {
+						[ styles[ 'heatmap-chart--capped' ] ]: capped,
+					} ) }
 					// Explicit dimensions (the unresponsive export) pin the size; otherwise
 					// width/height are unset and the grid fills its container via CSS. The
 					// responsive export drops the measured pixels so reflow stays fluid.
@@ -302,10 +309,7 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 						onKeyDown={ onChartKeyDown }
 						className={ clsx( styles[ 'heatmap-chart__grid' ], {
 							[ styles[ 'heatmap-chart__grid--compact' ] ]: compact,
-							// Capped tracks make the grid content-sized; without this the
-							// leftover container height would land in the auto label row.
-							[ styles[ 'heatmap-chart__grid--capped' ] ]:
-								! compact && Boolean( maxCellWidth || maxCellHeight ),
+							[ styles[ 'heatmap-chart__grid--capped' ] ]: capped,
 						} ) }
 						style={ gridStyle as CSSProperties }
 					>

--- a/projects/js-packages/charts/src/charts/heatmap-chart/private/build-calendar-data.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/private/build-calendar-data.ts
@@ -25,19 +25,9 @@ const toDate = ( point: DataPointDate ): Date | null => {
 
 export const buildCalendarHeatmapData = (
 	series: DataPointDate[],
-	options: {
-		weekStartsOn?: 0 | 1;
-		/**
-		 * Mark the days completing the first/last week outside the series'
-		 * date span as hidden cells (empty grid slots) instead of blank
-		 * cells, giving the calendar ragged edges. Days inside the span stay
-		 * blank cells even when the series has no entry for them.
-		 */
-		hideOutOfRangeDays?: boolean;
-	} = {}
+	options: { weekStartsOn?: 0 | 1 } = {}
 ): CalendarHeatmapResult => {
 	const weekStartsOn = options.weekStartsOn ?? 1;
-	const hideOutOfRangeDays = options.hideOutOfRangeDays ?? false;
 
 	const entries = series
 		.map( point => ( { date: toDate( point ), value: point.value } ) )
@@ -62,11 +52,6 @@ export const buildCalendarHeatmapData = (
 
 	const gridStart = startOfWeek( minDate, { weekStartsOn } );
 	const weekCount = differenceInCalendarWeeks( maxDate, gridStart, { weekStartsOn } ) + 1;
-
-	// Day-key bounds for the ragged-edge option: calendar-day comparison, so
-	// entries carrying a time of day can't shift the span.
-	const minDayKey = format( minDate, 'yyyy-MM-dd' );
-	const maxDayKey = format( maxDate, 'yyyy-MM-dd' );
 
 	const rowLabels = Array.from( { length: 7 }, ( _, row ) =>
 		LABELLED_ROWS.includes( row ) ? format( addDays( gridStart, row ), 'EEE' ) : ''
@@ -100,14 +85,10 @@ export const buildCalendarHeatmapData = (
 		for ( let row = 0; row < 7; row++ ) {
 			const day = addDays( gridStart, week * 7 + row );
 			const key = format( day, 'yyyy-MM-dd' );
-			const cell: HeatmapCell = {
+			cells.push( {
 				label: format( day, 'EEE, MMM d, yyyy' ),
 				value: valueByDay.has( key ) ? ( valueByDay.get( key ) as number | null ) : null,
-			};
-			if ( hideOutOfRangeDays && ( key < minDayKey || key > maxDayKey ) ) {
-				cell.hidden = true;
-			}
-			cells.push( cell );
+			} );
 		}
 		data.push( { label, data: cells } );
 	}

--- a/projects/js-packages/charts/src/charts/heatmap-chart/private/build-calendar-data.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/private/build-calendar-data.ts
@@ -25,9 +25,19 @@ const toDate = ( point: DataPointDate ): Date | null => {
 
 export const buildCalendarHeatmapData = (
 	series: DataPointDate[],
-	options: { weekStartsOn?: 0 | 1 } = {}
+	options: {
+		weekStartsOn?: 0 | 1;
+		/**
+		 * Mark the days completing the first/last week outside the series'
+		 * date span as hidden cells (empty grid slots) instead of blank
+		 * cells, giving the calendar ragged edges. Days inside the span stay
+		 * blank cells even when the series has no entry for them.
+		 */
+		hideOutOfRangeDays?: boolean;
+	} = {}
 ): CalendarHeatmapResult => {
 	const weekStartsOn = options.weekStartsOn ?? 1;
+	const hideOutOfRangeDays = options.hideOutOfRangeDays ?? false;
 
 	const entries = series
 		.map( point => ( { date: toDate( point ), value: point.value } ) )
@@ -52,6 +62,11 @@ export const buildCalendarHeatmapData = (
 
 	const gridStart = startOfWeek( minDate, { weekStartsOn } );
 	const weekCount = differenceInCalendarWeeks( maxDate, gridStart, { weekStartsOn } ) + 1;
+
+	// Day-key bounds for the ragged-edge option: calendar-day comparison, so
+	// entries carrying a time of day can't shift the span.
+	const minDayKey = format( minDate, 'yyyy-MM-dd' );
+	const maxDayKey = format( maxDate, 'yyyy-MM-dd' );
 
 	const rowLabels = Array.from( { length: 7 }, ( _, row ) =>
 		LABELLED_ROWS.includes( row ) ? format( addDays( gridStart, row ), 'EEE' ) : ''
@@ -85,10 +100,14 @@ export const buildCalendarHeatmapData = (
 		for ( let row = 0; row < 7; row++ ) {
 			const day = addDays( gridStart, week * 7 + row );
 			const key = format( day, 'yyyy-MM-dd' );
-			cells.push( {
+			const cell: HeatmapCell = {
 				label: format( day, 'EEE, MMM d, yyyy' ),
 				value: valueByDay.has( key ) ? ( valueByDay.get( key ) as number | null ) : null,
-			} );
+			};
+			if ( hideOutOfRangeDays && ( key < minDayKey || key > maxDayKey ) ) {
+				cell.hidden = true;
+			}
+			cells.push( cell );
 		}
 		data.push( { label, data: cells } );
 	}

--- a/projects/js-packages/charts/src/charts/heatmap-chart/private/use-heatmap-colors.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/private/use-heatmap-colors.ts
@@ -31,7 +31,11 @@ export const getValueExtent = ( data: HeatmapColumn[] ): [ number, number ] => {
 };
 
 /**
- * Normalize a value to 0–1 within the extent. A flat extent (min === max) maps to 1.
+ * Normalize a value to 0–1 within the extent. A flat extent (min === max)
+ * maps to 1 — every cell is equally the "highest" — except an all-zero
+ * extent, which maps to 0 so a no-activity grid renders at the scale's
+ * bottom instead of full intensity.
+ *
  * @param value  - The value to normalize
  * @param extent - Tuple of [min, max] values for the normalization range
  * @return Normalized value between 0 and 1
@@ -39,7 +43,7 @@ export const getValueExtent = ( data: HeatmapColumn[] ): [ number, number ] => {
 export const getNormalizedValue = ( value: number, extent: [ number, number ] ): number => {
 	const [ min, max ] = extent;
 	if ( min === max ) {
-		return 1;
+		return max === 0 ? 0 : 1;
 	}
 	return Math.min( 1, Math.max( 0, ( value - min ) / ( max - min ) ) );
 };

--- a/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.api.mdx
@@ -17,6 +17,10 @@ and shaded with CSS `color-mix`, so the scale adapts to the chart background.
 | `rowLabels` | `string[]` | `[]` | y-axis labels by row index. Empty entries render blank. |
 | `compact` | `boolean` | `false` | Compact mode: tighten cell gaps, suppress in-cell values, and thin axis labels. |
 | `showValues` | `boolean` | `!compact` | Render the numeric value inside each cell (compact notation for large numbers; the tooltip and aria-label keep full precision). |
+| `maxCellWidth` | `number` | - | Maximum cell width in pixels in non-compact mode. Cells stop growing at this width while narrower containers may still shrink them. |
+| `maxCellHeight` | `number` | - | Maximum cell height in pixels in non-compact mode. Applying it content-sizes the chart vertically so unused container height does not stretch the rows. |
+| `minCellWidth` | `number` | `0` | Minimum cell width in pixels in non-compact mode. The grid overflows horizontally instead of shrinking cells below this width. |
+| `minCellHeight` | `number` | `0` | Minimum cell height in pixels in non-compact mode. The grid overflows vertically instead of shrinking cells below this height. |
 | `primaryColor` | `string` | theme / palette | Color the scale interpolates toward at the highest value. Resolution order: this prop > `heatmapChart.primaryColor` > palette `colors[0]`. |
 | `withTooltips` | `boolean` | `false` | Show a tooltip on cell hover or keyboard navigation. |
 | `renderTooltip` | `(data: HeatmapTooltipData) => ReactNode` | - | Custom tooltip render function. Receives `HeatmapTooltipData`. The default tooltip formats numeric values with `@automattic/number-formatters`. |

--- a/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.docs.mdx
@@ -73,6 +73,8 @@ The simplest heatmap requires `data` — an array of `HeatmapColumn` objects, ea
 - **`withTooltips`** (default: `false`): show a tooltip on cell hover
 - **`compact`** (default: `false`): tighten spacing and suppress in-cell values for compact widgets
 - **`showValues`** (default: `!compact`): render the numeric value inside each cell (compact notation for large numbers; the tooltip keeps full precision)
+- **`maxCellWidth`** / **`maxCellHeight`**: cap how large cells may grow in non-compact mode
+- **`minCellWidth`** / **`minCellHeight`** (default: `0`): keep cells from shrinking below a readable size and let the grid overflow instead
 - **`primaryColor`**: color the scale interpolates toward at the highest value (prop > `heatmapChart.primaryColor` > palette `colors[0]`)
 - **`width`** / **`height`**: explicit dimensions in pixels. When omitted the chart fills its parent.
 - **`gap`** (default: `'md'`): gap between chart layout regions (chart area, legend, children)
@@ -100,6 +102,40 @@ Use `compact` for narrow widgets or dashboards where vertical space is limited. 
 In-cell values use compact notation (e.g. `748.5K`, `1.2M`) so large numbers fit the cell. The tooltip and each cell's accessible label keep the full, precise value.
 
 <Canvas of={ HeatmapStories.LargeValues } />
+
+## Cell Size Bounds
+
+Non-compact heatmaps normally divide the available width and height evenly across all cells. Use maximum bounds to keep sparse grids from producing oversized cells. Width and height caps are independent: setting only `maxCellWidth` keeps the normal full-height row layout, while setting `maxCellHeight` content-sizes the chart vertically.
+
+<Canvas of={ HeatmapStories.MaximumCellSize } />
+
+<Source
+	language="tsx"
+	code={ `<HeatmapChart
+		data={ columns }
+		rowLabels={ rowLabels }
+		maxCellWidth={ 64 }
+		maxCellHeight={ 42 }
+	/>` }
+/>
+
+Minimum bounds preserve readable cell dimensions in dense grids. When the container becomes smaller than the resulting grid, place the chart inside a scrollable container so users can reach the overflowed cells.
+
+<Canvas of={ HeatmapStories.MinimumCellSize } />
+
+<Source
+	language="tsx"
+	code={ `<div style={ { width: '480px', height: '280px', overflow: 'auto' } }>
+		<HeatmapChart
+			data={ columns }
+			rowLabels={ rowLabels }
+			minCellWidth={ 44 }
+			minCellHeight={ 32 }
+		/>
+	</div>` }
+/>
+
+Cell size bounds are ignored in compact mode, which uses the theme's fixed `compactCellSize` instead.
 
 ## Calendar Layout
 

--- a/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.stories.tsx
@@ -26,6 +26,26 @@ const meta: Meta< StoryArgs > = {
 		...themeArgTypes,
 		compact: { control: 'boolean', table: { category: 'Visual Style' } },
 		showValues: { control: 'boolean', table: { category: 'Visual Style' } },
+		maxCellWidth: {
+			control: { type: 'number', min: 1 },
+			description: 'Maximum cell width in pixels in non-compact mode',
+			table: { category: 'Cell Size' },
+		},
+		maxCellHeight: {
+			control: { type: 'number', min: 1 },
+			description: 'Maximum cell height in pixels in non-compact mode',
+			table: { category: 'Cell Size' },
+		},
+		minCellWidth: {
+			control: { type: 'number', min: 0 },
+			description: 'Minimum cell width in pixels in non-compact mode',
+			table: { category: 'Cell Size' },
+		},
+		minCellHeight: {
+			control: { type: 'number', min: 0 },
+			description: 'Minimum cell height in pixels in non-compact mode',
+			table: { category: 'Cell Size' },
+		},
 	},
 } satisfies Meta< StoryArgs >;
 
@@ -49,6 +69,26 @@ export const LargeValues: Story = {
 	args: {
 		...Default.args,
 		data: heatmapLargeValueMatrix,
+	},
+};
+
+export const MaximumCellSize: Story = {
+	args: {
+		...Default.args,
+		containerWidth: '1000px',
+		containerHeight: '420px',
+		maxCellWidth: 64,
+		maxCellHeight: 42,
+	},
+};
+
+export const MinimumCellSize: Story = {
+	args: {
+		...Default.args,
+		containerWidth: '480px',
+		containerHeight: '280px',
+		minCellWidth: 44,
+		minCellHeight: 32,
 	},
 };
 

--- a/projects/js-packages/charts/src/charts/heatmap-chart/test/build-calendar-data.test.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/test/build-calendar-data.test.ts
@@ -33,6 +33,38 @@ describe( 'buildCalendarHeatmapData', () => {
 		expect( data[ 0 ].data[ 1 ].value ).toBeNull(); // Tue Jan 2 has no datum
 	} );
 
+	test( 'hideOutOfRangeDays hides the week-completion days outside the span', () => {
+		const midWeek: DataPointDate[] = [
+			{ dateString: '2024-01-03', value: 5 }, // Wed
+			{ dateString: '2024-01-09', value: 2 }, // Tue (2nd week)
+		];
+		const { data } = buildCalendarHeatmapData( midWeek, {
+			weekStartsOn: 1,
+			hideOutOfRangeDays: true,
+		} );
+
+		// Mon Jan 1 and Tue Jan 2 precede the span — hidden; Wed Jan 3 opens it.
+		expect( data[ 0 ].data[ 0 ].hidden ).toBe( true );
+		expect( data[ 0 ].data[ 1 ].hidden ).toBe( true );
+		expect( data[ 0 ].data[ 2 ].hidden ).toBeUndefined();
+
+		// Thu Jan 4 is inside the span with no entry — a blank cell, not hidden.
+		expect( data[ 0 ].data[ 3 ].hidden ).toBeUndefined();
+		expect( data[ 0 ].data[ 3 ].value ).toBeNull();
+
+		// Tue Jan 9 closes the span; Wed Jan 10 onward is hidden.
+		expect( data[ 1 ].data[ 1 ].hidden ).toBeUndefined();
+		expect( data[ 1 ].data[ 2 ].hidden ).toBe( true );
+		expect( data[ 1 ].data[ 6 ].hidden ).toBe( true );
+	} );
+
+	test( 'out-of-span days stay blank cells without hideOutOfRangeDays', () => {
+		const midWeek: DataPointDate[] = [ { dateString: '2024-01-03', value: 5 } ]; // Wed
+		const { data } = buildCalendarHeatmapData( midWeek, { weekStartsOn: 1 } );
+		expect( data[ 0 ].data[ 0 ].hidden ).toBeUndefined();
+		expect( data[ 0 ].data[ 0 ].value ).toBeNull();
+	} );
+
 	test( 'labels only the first column of each month', () => {
 		const multiMonth: DataPointDate[] = [
 			{ dateString: '2024-01-01', value: 1 },

--- a/projects/js-packages/charts/src/charts/heatmap-chart/test/build-calendar-data.test.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/test/build-calendar-data.test.ts
@@ -33,38 +33,6 @@ describe( 'buildCalendarHeatmapData', () => {
 		expect( data[ 0 ].data[ 1 ].value ).toBeNull(); // Tue Jan 2 has no datum
 	} );
 
-	test( 'hideOutOfRangeDays hides the week-completion days outside the span', () => {
-		const midWeek: DataPointDate[] = [
-			{ dateString: '2024-01-03', value: 5 }, // Wed
-			{ dateString: '2024-01-09', value: 2 }, // Tue (2nd week)
-		];
-		const { data } = buildCalendarHeatmapData( midWeek, {
-			weekStartsOn: 1,
-			hideOutOfRangeDays: true,
-		} );
-
-		// Mon Jan 1 and Tue Jan 2 precede the span — hidden; Wed Jan 3 opens it.
-		expect( data[ 0 ].data[ 0 ].hidden ).toBe( true );
-		expect( data[ 0 ].data[ 1 ].hidden ).toBe( true );
-		expect( data[ 0 ].data[ 2 ].hidden ).toBeUndefined();
-
-		// Thu Jan 4 is inside the span with no entry — a blank cell, not hidden.
-		expect( data[ 0 ].data[ 3 ].hidden ).toBeUndefined();
-		expect( data[ 0 ].data[ 3 ].value ).toBeNull();
-
-		// Tue Jan 9 closes the span; Wed Jan 10 onward is hidden.
-		expect( data[ 1 ].data[ 1 ].hidden ).toBeUndefined();
-		expect( data[ 1 ].data[ 2 ].hidden ).toBe( true );
-		expect( data[ 1 ].data[ 6 ].hidden ).toBe( true );
-	} );
-
-	test( 'out-of-span days stay blank cells without hideOutOfRangeDays', () => {
-		const midWeek: DataPointDate[] = [ { dateString: '2024-01-03', value: 5 } ]; // Wed
-		const { data } = buildCalendarHeatmapData( midWeek, { weekStartsOn: 1 } );
-		expect( data[ 0 ].data[ 0 ].hidden ).toBeUndefined();
-		expect( data[ 0 ].data[ 0 ].value ).toBeNull();
-	} );
-
 	test( 'labels only the first column of each month', () => {
 		const multiMonth: DataPointDate[] = [
 			{ dateString: '2024-01-01', value: 1 },

--- a/projects/js-packages/charts/src/charts/heatmap-chart/test/heatmap-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/test/heatmap-chart.test.tsx
@@ -213,6 +213,57 @@ describe( 'HeatmapChart', () => {
 		expect( grid ).not.toHaveAttribute( 'aria-activedescendant' );
 	} );
 
+	// Calendar ragged edges: hidden cells keep their grid slot but paint
+	// nothing and take no interaction.
+	const raggedData: HeatmapColumn[] = [
+		{ label: 'W1', data: [ { value: null, hidden: true }, { value: 1 }, { value: 2 } ] },
+		{ label: 'W2', data: [ { value: 3 }, { value: null, hidden: true }, { value: 4 } ] },
+		{ label: 'W3', data: [ { value: 5 }, { value: 6 }, { value: null, hidden: true } ] },
+	];
+
+	test( 'hidden cells render as empty slots outside the accessibility tree', () => {
+		renderChart( { data: raggedData } );
+		expect( screen.getAllByTestId( 'heatmap-cell' ) ).toHaveLength( 6 );
+		expect( screen.getAllByTestId( 'heatmap-cell-hidden' ) ).toHaveLength( 3 );
+		expect( screen.getAllByRole( 'gridcell' ) ).toHaveLength( 6 );
+	} );
+
+	test( 'keyboard navigation skips hidden cells and never lands on them', async () => {
+		renderChart( { data: raggedData, rowLabels: [ 'Mon', 'Tue', 'Wed' ] } );
+		const grid = screen.getByRole( 'grid', { name: /heatmap/i } );
+		const user = userEvent.setup();
+
+		// The initial selection starts past the hidden leading slot (0,0).
+		grid.focus();
+		await user.keyboard( '{ArrowDown}' );
+		expect( grid ).toHaveAttribute(
+			'aria-activedescendant',
+			expect.stringMatching( /-cell-0-1$/ )
+		);
+
+		// ArrowRight steps over the hidden (1,1) to (2,1).
+		await user.keyboard( '{ArrowRight}' );
+		expect( grid ).toHaveAttribute(
+			'aria-activedescendant',
+			expect.stringMatching( /-cell-2-1$/ )
+		);
+
+		// Only a hidden slot (2,2) lies below — the selection stays put.
+		await user.keyboard( '{ArrowDown}' );
+		expect( grid ).toHaveAttribute(
+			'aria-activedescendant',
+			expect.stringMatching( /-cell-2-1$/ )
+		);
+
+		// ArrowLeft steps back over the hidden (1,1) to (0,1); ArrowUp has
+		// only the hidden (0,0) above, so the selection stays again.
+		await user.keyboard( '{ArrowLeft}{ArrowUp}' );
+		expect( grid ).toHaveAttribute(
+			'aria-activedescendant',
+			expect.stringMatching( /-cell-0-1$/ )
+		);
+	} );
+
 	test( 'rows contain gridcell children in the ARIA hierarchy', () => {
 		renderChart();
 		const rows = screen.getAllByRole( 'row' );

--- a/projects/js-packages/charts/src/charts/heatmap-chart/test/heatmap-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/test/heatmap-chart.test.tsx
@@ -213,57 +213,6 @@ describe( 'HeatmapChart', () => {
 		expect( grid ).not.toHaveAttribute( 'aria-activedescendant' );
 	} );
 
-	// Calendar ragged edges: hidden cells keep their grid slot but paint
-	// nothing and take no interaction.
-	const raggedData: HeatmapColumn[] = [
-		{ label: 'W1', data: [ { value: null, hidden: true }, { value: 1 }, { value: 2 } ] },
-		{ label: 'W2', data: [ { value: 3 }, { value: null, hidden: true }, { value: 4 } ] },
-		{ label: 'W3', data: [ { value: 5 }, { value: 6 }, { value: null, hidden: true } ] },
-	];
-
-	test( 'hidden cells render as empty slots outside the accessibility tree', () => {
-		renderChart( { data: raggedData } );
-		expect( screen.getAllByTestId( 'heatmap-cell' ) ).toHaveLength( 6 );
-		expect( screen.getAllByTestId( 'heatmap-cell-hidden' ) ).toHaveLength( 3 );
-		expect( screen.getAllByRole( 'gridcell' ) ).toHaveLength( 6 );
-	} );
-
-	test( 'keyboard navigation skips hidden cells and never lands on them', async () => {
-		renderChart( { data: raggedData, rowLabels: [ 'Mon', 'Tue', 'Wed' ] } );
-		const grid = screen.getByRole( 'grid', { name: /heatmap/i } );
-		const user = userEvent.setup();
-
-		// The initial selection starts past the hidden leading slot (0,0).
-		grid.focus();
-		await user.keyboard( '{ArrowDown}' );
-		expect( grid ).toHaveAttribute(
-			'aria-activedescendant',
-			expect.stringMatching( /-cell-0-1$/ )
-		);
-
-		// ArrowRight steps over the hidden (1,1) to (2,1).
-		await user.keyboard( '{ArrowRight}' );
-		expect( grid ).toHaveAttribute(
-			'aria-activedescendant',
-			expect.stringMatching( /-cell-2-1$/ )
-		);
-
-		// Only a hidden slot (2,2) lies below — the selection stays put.
-		await user.keyboard( '{ArrowDown}' );
-		expect( grid ).toHaveAttribute(
-			'aria-activedescendant',
-			expect.stringMatching( /-cell-2-1$/ )
-		);
-
-		// ArrowLeft steps back over the hidden (1,1) to (0,1); ArrowUp has
-		// only the hidden (0,0) above, so the selection stays again.
-		await user.keyboard( '{ArrowLeft}{ArrowUp}' );
-		expect( grid ).toHaveAttribute(
-			'aria-activedescendant',
-			expect.stringMatching( /-cell-0-1$/ )
-		);
-	} );
-
 	test( 'rows contain gridcell children in the ARIA hierarchy', () => {
 		renderChart();
 		const rows = screen.getAllByRole( 'row' );

--- a/projects/js-packages/charts/src/charts/heatmap-chart/test/heatmap-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/test/heatmap-chart.test.tsx
@@ -259,6 +259,36 @@ describe( 'HeatmapChart', () => {
 		expect( grid.style.gridTemplateColumns ).toContain( 'var(--heatmap-cell-size)' );
 	} );
 
+	test( 'caps cell width without changing the normal vertical layout', () => {
+		renderChart( { maxCellWidth: 64 } );
+		const chart = screen.getByTestId( 'heatmap-chart' );
+		const grid = screen.getByRole( 'grid', { name: /heatmap/i } );
+
+		expect( grid.style.gridTemplateColumns ).toContain( 'minmax(0px, 64px)' );
+		expect( grid.style.gridTemplateRows ).toContain( 'minmax(0px, 1fr)' );
+		expect( chart ).not.toHaveClass( 'heatmap-chart--height-capped' );
+		expect( grid ).not.toHaveClass( 'heatmap-chart__grid--height-capped' );
+	} );
+
+	test( 'content-sizes the vertical layout when cell height is capped', () => {
+		renderChart( { maxCellHeight: 42 } );
+		const chart = screen.getByTestId( 'heatmap-chart' );
+		const grid = screen.getByRole( 'grid', { name: /heatmap/i } );
+
+		expect( grid.style.gridTemplateColumns ).toContain( 'minmax(0px, 1fr)' );
+		expect( grid.style.gridTemplateRows ).toContain( 'minmax(0px, 42px)' );
+		expect( chart ).toHaveClass( 'heatmap-chart--height-capped' );
+		expect( grid ).toHaveClass( 'heatmap-chart__grid--height-capped' );
+	} );
+
+	test( 'applies independent minimum cell width and height floors', () => {
+		renderChart( { minCellWidth: 44, minCellHeight: 32 } );
+		const grid = screen.getByRole( 'grid', { name: /heatmap/i } );
+
+		expect( grid.style.gridTemplateColumns ).toContain( 'minmax(44px, 1fr)' );
+		expect( grid.style.gridTemplateRows ).toContain( 'minmax(32px, 1fr)' );
+	} );
+
 	test( 'applies the primaryColor prop as the cell-scale color', () => {
 		renderChart( { primaryColor: '#abcdef' } );
 		const grid = screen.getByRole( 'grid', { name: /heatmap/i } );

--- a/projects/js-packages/charts/src/charts/heatmap-chart/test/use-heatmap-colors.test.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/test/use-heatmap-colors.test.ts
@@ -31,4 +31,8 @@ describe( 'getNormalizedValue', () => {
 	test( 'returns 1 when min === max', () => {
 		expect( getNormalizedValue( 7, [ 7, 7 ] ) ).toBe( 1 );
 	} );
+
+	test( 'returns 0 for an all-zero extent so a no-activity grid stays at the scale bottom', () => {
+		expect( getNormalizedValue( 0, [ 0, 0 ] ) ).toBe( 0 );
+	} );
 } );

--- a/projects/js-packages/charts/src/charts/heatmap-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/types.ts
@@ -42,6 +42,14 @@ export interface HeatmapChartProps
 	/** Cap a cell's height (px) in non-compact mode; see `maxCellWidth`. */
 	maxCellHeight?: number;
 	/**
+	 * Floor a cell's width (px) in non-compact mode. Below it the grid stops
+	 * shrinking and overflows its container instead, so a scrollable wrapper
+	 * can take over for long ranges. Default 0 (cells shrink freely).
+	 */
+	minCellWidth?: number;
+	/** Floor a cell's height (px) in non-compact mode; see `minCellWidth`. */
+	minCellHeight?: number;
+	/**
 	 * Color the cell scale interpolates toward at the highest value
 	 * (this prop > theme `heatmapChart.primaryColor` > palette `colors[0]`).
 	 */

--- a/projects/js-packages/charts/src/charts/heatmap-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/types.ts
@@ -6,13 +6,6 @@ export type HeatmapCell = {
 	/** Per-cell label used in the tooltip / accessible name. */
 	label?: string;
 	value: number | null;
-	/**
-	 * Leave the cell's grid slot empty: nothing is painted and the cell is
-	 * skipped by hover and keyboard navigation, while the slot keeps its
-	 * place so the rest of the grid doesn't shift. For calendar edges, where
-	 * days completing the first/last week fall outside the covered range.
-	 */
-	hidden?: boolean;
 };
 
 /** A heatmap column (rendered left→right); its cells render top→bottom. */

--- a/projects/js-packages/charts/src/charts/heatmap-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/types.ts
@@ -33,6 +33,15 @@ export interface HeatmapChartProps
 	/** Render the numeric value inside each cell. Default `! compact`. */
 	showValues?: boolean;
 	/**
+	 * Cap a cell's width (px) in non-compact mode. Cells grow up to the cap
+	 * and stop instead of splitting the whole container width, so sparse
+	 * ranges don't produce oversized cells; narrow containers still shrink
+	 * them. Ignored in compact mode, which uses a fixed cell size.
+	 */
+	maxCellWidth?: number;
+	/** Cap a cell's height (px) in non-compact mode; see `maxCellWidth`. */
+	maxCellHeight?: number;
+	/**
 	 * Color the cell scale interpolates toward at the highest value
 	 * (this prop > theme `heatmapChart.primaryColor` > palette `colors[0]`).
 	 */

--- a/projects/js-packages/charts/src/charts/heatmap-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/types.ts
@@ -6,6 +6,13 @@ export type HeatmapCell = {
 	/** Per-cell label used in the tooltip / accessible name. */
 	label?: string;
 	value: number | null;
+	/**
+	 * Leave the cell's grid slot empty: nothing is painted and the cell is
+	 * skipped by hover and keyboard navigation, while the slot keeps its
+	 * place so the rest of the grid doesn't shift. For calendar edges, where
+	 * days completing the first/last week fall outside the covered range.
+	 */
+	hidden?: boolean;
 };
 
 /** A heatmap column (rendered left→right); its cells render top→bottom. */

--- a/projects/js-packages/charts/src/charts/heatmap-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/types.ts
@@ -39,7 +39,11 @@ export interface HeatmapChartProps
 	 * them. Ignored in compact mode, which uses a fixed cell size.
 	 */
 	maxCellWidth?: number;
-	/** Cap a cell's height (px) in non-compact mode; see `maxCellWidth`. */
+	/**
+	 * Cap a cell's height (px) in non-compact mode. Applying this cap
+	 * content-sizes the chart vertically so rows do not absorb unused height.
+	 * Ignored in compact mode, which uses a fixed cell size.
+	 */
 	maxCellHeight?: number;
 	/**
 	 * Floor a cell's width (px) in non-compact mode. Below it the grid stops

--- a/projects/packages/premium-analytics/changelog/add-post-traffic-activity-widget
+++ b/projects/packages/premium-analytics/changelog/add-post-traffic-activity-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add the post detail Traffic activity widget: the scoped post's daily views as a calendar heatmap.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -165,6 +165,7 @@ export {
 	GeoChart,
 	GlobalChartsProvider,
 	HeatmapChart,
+	HeatmapChartUnresponsive,
 	buildCalendarHeatmapData,
 	type DataPointDate,
 	type GeoChartError,

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
@@ -18,14 +18,16 @@ export const POST_DETAIL_TAB_LAYOUTS: Record< PostDetailTabId, DashboardWidget[]
 			placement: { width: WIDGET_DASHBOARD_COLUMN_COUNT, height: 1, order: 1 },
 		},
 		{
-			uuid: 'post-traffic-activity',
-			type: 'jpa/post-traffic-activity',
-			placement: { width: 3, height: 2, order: 2 },
-		},
-		{
+			// The rest of this row is reserved for the upcoming comments and
+			// UTM cards.
 			uuid: 'post-likes',
 			type: 'jpa/post-likes',
-			placement: { width: 1, height: 2, order: 3 },
+			placement: { width: 1, height: 2, order: 2 },
+		},
+		{
+			uuid: 'post-traffic-activity',
+			type: 'jpa/post-traffic-activity',
+			placement: { width: WIDGET_DASHBOARD_COLUMN_COUNT, height: 2, order: 3 },
 		},
 	],
 	'email-opens': [],

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
@@ -18,9 +18,14 @@ export const POST_DETAIL_TAB_LAYOUTS: Record< PostDetailTabId, DashboardWidget[]
 			placement: { width: WIDGET_DASHBOARD_COLUMN_COUNT, height: 1, order: 1 },
 		},
 		{
+			uuid: 'post-traffic-activity',
+			type: 'jpa/post-traffic-activity',
+			placement: { width: 3, height: 2, order: 2 },
+		},
+		{
 			uuid: 'post-likes',
 			type: 'jpa/post-likes',
-			placement: { width: 1, height: 2, order: 2 },
+			placement: { width: 1, height: 2, order: 3 },
 		},
 	],
 	'email-opens': [],

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test.tsx
@@ -59,24 +59,24 @@ describe( 'usePostTrafficActivity', () => {
 
 		const { days } = result.current;
 
-		// The 4-day range pads backward to the grid span (168 days), with the
-		// page snapped to week boundaries (Monday 2026-01-19 → Sunday
-		// 2026-07-05) so it lays out exactly 24 columns.
-		expect( days ).toHaveLength( 168 );
+		// The 4-day range pads backward to the grid span, with the page
+		// snapped to week boundaries (Monday 2026-01-19 → Sunday 2026-07-05,
+		// 24 columns) — but the emitted days stop at the range end, so the
+		// trailing week-completion day (2026-07-05) renders as a ragged
+		// edge, not a blank cell.
+		expect( days ).toHaveLength( 167 );
 		expect( days[ 0 ].dateString ).toBe( '2026-01-19' );
 
-		// Values render only inside the selected range; the in-range gap and
-		// the trailing week-completion day are blank.
-		expect( days.slice( -5 ) ).toEqual( [
+		// Values render only inside the selected range; the in-range gap is blank.
+		expect( days.slice( -4 ) ).toEqual( [
 			{ dateString: '2026-07-01', value: 2 },
 			{ dateString: '2026-07-02', value: null },
 			{ dateString: '2026-07-03', value: 5 },
 			{ dateString: '2026-07-04', value: null },
-			{ dateString: '2026-07-05', value: null },
 		] );
 
 		// Filler days stay blank even where the history has views (2026-06-30).
-		expect( days.slice( 0, -5 ).every( day => day.value === null ) ).toBe( true );
+		expect( days.slice( 0, -4 ).every( day => day.value === null ) ).toBe( true );
 
 		// One page covers the range, so no pager.
 		expect( result.current.isPaged ).toBe( false );
@@ -99,23 +99,26 @@ describe( 'usePostTrafficActivity', () => {
 
 		await waitFor( () => expect( result.current.hasData ).toBe( true ) );
 
-		// Newest page first: ends at the end of the range's last week
-		// (Sunday 2026-07-05), no newer page.
+		// Newest page first: the page window ends at the end of the range's
+		// last week (Sunday 2026-07-05), but the emitted days stop at the
+		// range end so the extra day renders as a ragged edge.
 		expect( result.current.isPaged ).toBe( true );
 		expect( result.current.canShowNewer ).toBe( false );
 		expect( result.current.canShowOlder ).toBe( true );
-		expect( result.current.days ).toHaveLength( 168 );
-		expect( result.current.days.at( -1 )?.dateString ).toBe( '2026-07-05' );
+		expect( result.current.days ).toHaveLength( 167 );
+		expect( result.current.days.at( -1 )?.dateString ).toBe( '2026-07-04' );
 
 		act( () => result.current.showOlder() );
 
 		// The oldest page clamps to the range's first week (Monday
-		// 2025-12-29) and fills forward as a full grid (overlapping the
-		// previous page) — no months of out-of-range padding before it.
+		// 2025-12-29) and fills forward (overlapping the previous page) — and
+		// while paging, days before the range start are omitted too, so the
+		// emitted days open at the range start (2026-01-01) and the three
+		// leading week-completion days render as a ragged edge.
 		expect( result.current.canShowNewer ).toBe( true );
 		expect( result.current.canShowOlder ).toBe( false );
-		expect( result.current.days ).toHaveLength( 168 );
-		expect( result.current.days[ 0 ].dateString ).toBe( '2025-12-29' );
+		expect( result.current.days ).toHaveLength( 165 );
+		expect( result.current.days[ 0 ].dateString ).toBe( '2026-01-01' );
 		expect( result.current.days.at( -1 )?.dateString ).toBe( '2026-06-14' );
 		expect( result.current.days[ 0 ].value ).toBeNull();
 	} );

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test.tsx
@@ -15,9 +15,11 @@ jest.mock( '@wordpress/api-fetch' );
 
 const mockApiFetch = apiFetch as jest.MockedFunction< typeof apiFetch >;
 
-// Daily history with a gap on 2026-07-02 (the endpoint omits zero-view days).
+// Daily history with a gap on 2026-07-02 (the endpoint omits zero-view days)
+// and a day before the selected range (must stay blank in the padded grid).
 const STATS_POST_RESPONSE = {
 	data: [
+		[ '2026-06-30', 9 ],
 		[ '2026-07-01', 2 ],
 		[ '2026-07-03', 5 ],
 	],
@@ -39,7 +41,7 @@ describe( 'usePostTrafficActivity', () => {
 		mockApiFetch.mockResolvedValue( STATS_POST_RESPONSE );
 	} );
 
-	it( 'fills every calendar day of the window, blanking no-traffic days', async () => {
+	it( 'pads short ranges to the minimum grid span, blanking filler and no-traffic days', async () => {
 		const { result } = renderHook(
 			() =>
 				usePostTrafficActivity(
@@ -54,12 +56,21 @@ describe( 'usePostTrafficActivity', () => {
 
 		await waitFor( () => expect( result.current.hasData ).toBe( true ) );
 
-		expect( result.current.days ).toEqual( [
+		const { days } = result.current;
+
+		// The 4-day range pads backward to the minimum grid span (112 days).
+		expect( days ).toHaveLength( 112 );
+
+		// Values render only inside the selected range; the in-range gap is blank.
+		expect( days.slice( -4 ) ).toEqual( [
 			{ dateString: '2026-07-01', value: 2 },
 			{ dateString: '2026-07-02', value: null },
 			{ dateString: '2026-07-03', value: 5 },
 			{ dateString: '2026-07-04', value: null },
 		] );
+
+		// Filler days stay blank even where the history has views (2026-06-30).
+		expect( days.slice( 0, -4 ).every( day => day.value === null ) ).toBe( true );
 	} );
 
 	it( 'returns no days when a window bound is missing or malformed', async () => {

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
@@ -71,6 +71,43 @@ describe( 'usePostTrafficActivity', () => {
 
 		// Filler days stay blank even where the history has views (2026-06-30).
 		expect( days.slice( 0, -4 ).every( day => day.value === null ) ).toBe( true );
+
+		// One page covers the range, so no pager.
+		expect( result.current.isPaged ).toBe( false );
+	} );
+
+	it( 'pages a long range from the newest page backward', async () => {
+		const { result } = renderHook(
+			() =>
+				usePostTrafficActivity(
+					779,
+					reportParams( {
+						// 185 days — one page (168) plus a partial older page.
+						from: '2026-01-01T00:00:00.000+08:00',
+						to: '2026-07-04T23:59:59.999+08:00',
+					} )
+				),
+			{ wrapper }
+		);
+
+		await waitFor( () => expect( result.current.hasData ).toBe( true ) );
+
+		// Newest page first: ends at the range end, no newer page.
+		expect( result.current.isPaged ).toBe( true );
+		expect( result.current.canShowNewer ).toBe( false );
+		expect( result.current.canShowOlder ).toBe( true );
+		expect( result.current.days ).toHaveLength( 168 );
+		expect( result.current.days.at( -1 )?.dateString ).toBe( '2026-07-04' );
+
+		act( () => result.current.showOlder() );
+
+		// The older (last) page: still a full grid, padded past the range
+		// start with blanks.
+		expect( result.current.canShowNewer ).toBe( true );
+		expect( result.current.canShowOlder ).toBe( false );
+		expect( result.current.days ).toHaveLength( 168 );
+		expect( result.current.days.at( -1 )?.dateString ).toBe( '2026-01-17' );
+		expect( result.current.days[ 0 ].value ).toBeNull();
 	} );
 
 	it( 'returns no days when a window bound is missing or malformed', async () => {

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * External dependencies
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+/**
+ * Internal dependencies
+ */
+import usePostTrafficActivity from '../use-post-traffic-activity';
+import type { ReportParams } from '@jetpack-premium-analytics/data';
+import type { ReactNode } from 'react';
+
+jest.mock( '@wordpress/api-fetch' );
+
+const mockApiFetch = apiFetch as jest.MockedFunction< typeof apiFetch >;
+
+// Daily history with a gap on 2026-07-02 (the endpoint omits zero-view days).
+const STATS_POST_RESPONSE = {
+	data: [
+		[ '2026-07-01', 2 ],
+		[ '2026-07-03', 5 ],
+	],
+};
+
+function wrapper( { children }: { children: ReactNode } ) {
+	const queryClient = new QueryClient( {
+		defaultOptions: { queries: { retry: false } },
+	} );
+
+	return <QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>;
+}
+
+const reportParams = ( params: Record< string, string > ) => params as unknown as ReportParams;
+
+describe( 'usePostTrafficActivity', () => {
+	beforeEach( () => {
+		mockApiFetch.mockReset();
+		mockApiFetch.mockResolvedValue( STATS_POST_RESPONSE );
+	} );
+
+	it( 'zero-fills every calendar day of the window', async () => {
+		const { result } = renderHook(
+			() =>
+				usePostTrafficActivity(
+					779,
+					reportParams( {
+						from: '2026-07-01T00:00:00.000+08:00',
+						to: '2026-07-04T23:59:59.999+08:00',
+					} )
+				),
+			{ wrapper }
+		);
+
+		await waitFor( () => expect( result.current.hasData ).toBe( true ) );
+
+		expect( result.current.days ).toEqual( [
+			{ dateString: '2026-07-01', value: 2 },
+			{ dateString: '2026-07-02', value: 0 },
+			{ dateString: '2026-07-03', value: 5 },
+			{ dateString: '2026-07-04', value: 0 },
+		] );
+	} );
+
+	it( 'returns no days when a window bound is missing or malformed', async () => {
+		const { result } = renderHook(
+			() =>
+				usePostTrafficActivity(
+					779,
+					reportParams( { from: 'not-a-date', to: '2026-07-04T23:59:59.999+08:00' } )
+				),
+			{ wrapper }
+		);
+
+		await waitFor( () => expect( result.current.hasData ).toBe( true ) );
+
+		expect( result.current.days ).toEqual( [] );
+	} );
+
+	it( 'never fires a request without a post scope', () => {
+		const { result } = renderHook( () => usePostTrafficActivity( 0, reportParams( {} ) ), {
+			wrapper,
+		} );
+
+		expect( result.current.hasData ).toBe( false );
+		expect( result.current.days ).toEqual( [] );
+		expect( mockApiFetch ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test.tsx
@@ -59,19 +59,24 @@ describe( 'usePostTrafficActivity', () => {
 
 		const { days } = result.current;
 
-		// The 4-day range pads backward to the grid span (168 days).
+		// The 4-day range pads backward to the grid span (168 days), with the
+		// page snapped to week boundaries (Monday 2026-01-19 → Sunday
+		// 2026-07-05) so it lays out exactly 24 columns.
 		expect( days ).toHaveLength( 168 );
+		expect( days[ 0 ].dateString ).toBe( '2026-01-19' );
 
-		// Values render only inside the selected range; the in-range gap is blank.
-		expect( days.slice( -4 ) ).toEqual( [
+		// Values render only inside the selected range; the in-range gap and
+		// the trailing week-completion day are blank.
+		expect( days.slice( -5 ) ).toEqual( [
 			{ dateString: '2026-07-01', value: 2 },
 			{ dateString: '2026-07-02', value: null },
 			{ dateString: '2026-07-03', value: 5 },
 			{ dateString: '2026-07-04', value: null },
+			{ dateString: '2026-07-05', value: null },
 		] );
 
 		// Filler days stay blank even where the history has views (2026-06-30).
-		expect( days.slice( 0, -4 ).every( day => day.value === null ) ).toBe( true );
+		expect( days.slice( 0, -5 ).every( day => day.value === null ) ).toBe( true );
 
 		// One page covers the range, so no pager.
 		expect( result.current.isPaged ).toBe( false );
@@ -94,23 +99,24 @@ describe( 'usePostTrafficActivity', () => {
 
 		await waitFor( () => expect( result.current.hasData ).toBe( true ) );
 
-		// Newest page first: ends at the range end, no newer page.
+		// Newest page first: ends at the end of the range's last week
+		// (Sunday 2026-07-05), no newer page.
 		expect( result.current.isPaged ).toBe( true );
 		expect( result.current.canShowNewer ).toBe( false );
 		expect( result.current.canShowOlder ).toBe( true );
 		expect( result.current.days ).toHaveLength( 168 );
-		expect( result.current.days.at( -1 )?.dateString ).toBe( '2026-07-04' );
+		expect( result.current.days.at( -1 )?.dateString ).toBe( '2026-07-05' );
 
 		act( () => result.current.showOlder() );
 
-		// The oldest page clamps to the range start and fills forward as a
-		// full grid (overlapping the previous page) — no out-of-range padding
-		// before the range.
+		// The oldest page clamps to the range's first week (Monday
+		// 2025-12-29) and fills forward as a full grid (overlapping the
+		// previous page) — no months of out-of-range padding before it.
 		expect( result.current.canShowNewer ).toBe( true );
 		expect( result.current.canShowOlder ).toBe( false );
 		expect( result.current.days ).toHaveLength( 168 );
-		expect( result.current.days[ 0 ].dateString ).toBe( '2026-01-01' );
-		expect( result.current.days.at( -1 )?.dateString ).toBe( '2026-06-17' );
+		expect( result.current.days[ 0 ].dateString ).toBe( '2025-12-29' );
+		expect( result.current.days.at( -1 )?.dateString ).toBe( '2026-06-14' );
 		expect( result.current.days[ 0 ].value ).toBeNull();
 	} );
 

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test.tsx
@@ -41,7 +41,7 @@ describe( 'usePostTrafficActivity', () => {
 		mockApiFetch.mockResolvedValue( STATS_POST_RESPONSE );
 	} );
 
-	it( 'pads short ranges to the minimum grid span, blanking filler and no-traffic days', async () => {
+	it( 'pads short ranges to the grid span, blanking filler and no-traffic days', async () => {
 		const { result } = renderHook(
 			() =>
 				usePostTrafficActivity(
@@ -58,8 +58,8 @@ describe( 'usePostTrafficActivity', () => {
 
 		const { days } = result.current;
 
-		// The 4-day range pads backward to the minimum grid span (112 days).
-		expect( days ).toHaveLength( 112 );
+		// The 4-day range pads backward to the grid span (168 days).
+		expect( days ).toHaveLength( 168 );
 
 		// Values render only inside the selected range; the in-range gap is blank.
 		expect( days.slice( -4 ) ).toEqual( [

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test.tsx
@@ -39,7 +39,7 @@ describe( 'usePostTrafficActivity', () => {
 		mockApiFetch.mockResolvedValue( STATS_POST_RESPONSE );
 	} );
 
-	it( 'zero-fills every calendar day of the window', async () => {
+	it( 'fills every calendar day of the window, blanking no-traffic days', async () => {
 		const { result } = renderHook(
 			() =>
 				usePostTrafficActivity(
@@ -56,9 +56,9 @@ describe( 'usePostTrafficActivity', () => {
 
 		expect( result.current.days ).toEqual( [
 			{ dateString: '2026-07-01', value: 2 },
-			{ dateString: '2026-07-02', value: 0 },
+			{ dateString: '2026-07-02', value: null },
 			{ dateString: '2026-07-03', value: 5 },
-			{ dateString: '2026-07-04', value: 0 },
+			{ dateString: '2026-07-04', value: null },
 		] );
 	} );
 

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test.tsx
@@ -59,24 +59,24 @@ describe( 'usePostTrafficActivity', () => {
 
 		const { days } = result.current;
 
-		// The 4-day range pads backward to the grid span, with the page
-		// snapped to week boundaries (Monday 2026-01-19 → Sunday 2026-07-05,
-		// 24 columns) — but the emitted days stop at the range end, so the
-		// trailing week-completion day (2026-07-05) renders as a ragged
-		// edge, not a blank cell.
-		expect( days ).toHaveLength( 167 );
+		// The 4-day range pads backward to the grid span (168 days), with the
+		// page snapped to week boundaries (Monday 2026-01-19 → Sunday
+		// 2026-07-05) so it lays out exactly 24 columns.
+		expect( days ).toHaveLength( 168 );
 		expect( days[ 0 ].dateString ).toBe( '2026-01-19' );
 
-		// Values render only inside the selected range; the in-range gap is blank.
-		expect( days.slice( -4 ) ).toEqual( [
+		// Values render only inside the selected range; the in-range gap and
+		// the trailing week-completion day are blank.
+		expect( days.slice( -5 ) ).toEqual( [
 			{ dateString: '2026-07-01', value: 2 },
 			{ dateString: '2026-07-02', value: null },
 			{ dateString: '2026-07-03', value: 5 },
 			{ dateString: '2026-07-04', value: null },
+			{ dateString: '2026-07-05', value: null },
 		] );
 
 		// Filler days stay blank even where the history has views (2026-06-30).
-		expect( days.slice( 0, -4 ).every( day => day.value === null ) ).toBe( true );
+		expect( days.slice( 0, -5 ).every( day => day.value === null ) ).toBe( true );
 
 		// One page covers the range, so no pager.
 		expect( result.current.isPaged ).toBe( false );
@@ -99,26 +99,23 @@ describe( 'usePostTrafficActivity', () => {
 
 		await waitFor( () => expect( result.current.hasData ).toBe( true ) );
 
-		// Newest page first: the page window ends at the end of the range's
-		// last week (Sunday 2026-07-05), but the emitted days stop at the
-		// range end so the extra day renders as a ragged edge.
+		// Newest page first: ends at the end of the range's last week
+		// (Sunday 2026-07-05), no newer page.
 		expect( result.current.isPaged ).toBe( true );
 		expect( result.current.canShowNewer ).toBe( false );
 		expect( result.current.canShowOlder ).toBe( true );
-		expect( result.current.days ).toHaveLength( 167 );
-		expect( result.current.days.at( -1 )?.dateString ).toBe( '2026-07-04' );
+		expect( result.current.days ).toHaveLength( 168 );
+		expect( result.current.days.at( -1 )?.dateString ).toBe( '2026-07-05' );
 
 		act( () => result.current.showOlder() );
 
 		// The oldest page clamps to the range's first week (Monday
-		// 2025-12-29) and fills forward (overlapping the previous page) — and
-		// while paging, days before the range start are omitted too, so the
-		// emitted days open at the range start (2026-01-01) and the three
-		// leading week-completion days render as a ragged edge.
+		// 2025-12-29) and fills forward as a full grid (overlapping the
+		// previous page) — no months of out-of-range padding before it.
 		expect( result.current.canShowNewer ).toBe( true );
 		expect( result.current.canShowOlder ).toBe( false );
-		expect( result.current.days ).toHaveLength( 165 );
-		expect( result.current.days[ 0 ].dateString ).toBe( '2026-01-01' );
+		expect( result.current.days ).toHaveLength( 168 );
+		expect( result.current.days[ 0 ].dateString ).toBe( '2025-12-29' );
 		expect( result.current.days.at( -1 )?.dateString ).toBe( '2026-06-14' );
 		expect( result.current.days[ 0 ].value ).toBeNull();
 	} );

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test.tsx
@@ -115,7 +115,8 @@ describe( 'usePostTrafficActivity', () => {
 			() =>
 				usePostTrafficActivity(
 					779,
-					reportParams( { from: 'not-a-date', to: '2026-07-04T23:59:59.999+08:00' } )
+					reportParams( { from: 'not-a-date', to: '2026-07-04T23:59:59.999+08:00' } ),
+					168
 				),
 			{ wrapper }
 		);
@@ -126,7 +127,7 @@ describe( 'usePostTrafficActivity', () => {
 	} );
 
 	it( 'never fires a request without a post scope', () => {
-		const { result } = renderHook( () => usePostTrafficActivity( 0, reportParams( {} ) ), {
+		const { result } = renderHook( () => usePostTrafficActivity( 0, reportParams( {} ), 168 ), {
 			wrapper,
 		} );
 

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test.tsx
@@ -103,12 +103,14 @@ describe( 'usePostTrafficActivity', () => {
 
 		act( () => result.current.showOlder() );
 
-		// The older (last) page: still a full grid, padded past the range
-		// start with blanks.
+		// The oldest page clamps to the range start and fills forward as a
+		// full grid (overlapping the previous page) — no out-of-range padding
+		// before the range.
 		expect( result.current.canShowNewer ).toBe( true );
 		expect( result.current.canShowOlder ).toBe( false );
 		expect( result.current.days ).toHaveLength( 168 );
-		expect( result.current.days.at( -1 )?.dateString ).toBe( '2026-01-17' );
+		expect( result.current.days[ 0 ].dateString ).toBe( '2026-01-01' );
+		expect( result.current.days.at( -1 )?.dateString ).toBe( '2026-06-17' );
 		expect( result.current.days[ 0 ].value ).toBeNull();
 	} );
 

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test.tsx
@@ -49,7 +49,8 @@ describe( 'usePostTrafficActivity', () => {
 					reportParams( {
 						from: '2026-07-01T00:00:00.000+08:00',
 						to: '2026-07-04T23:59:59.999+08:00',
-					} )
+					} ),
+					168
 				),
 			{ wrapper }
 		);
@@ -85,7 +86,8 @@ describe( 'usePostTrafficActivity', () => {
 						// 185 days — one page (168) plus a partial older page.
 						from: '2026-01-01T00:00:00.000+08:00',
 						to: '2026-07-04T23:59:59.999+08:00',
-					} )
+					} ),
+					168
 				),
 			{ wrapper }
 		);

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/package.json
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/package.json
@@ -7,9 +7,11 @@
 		"@jetpack-premium-analytics/data": "link:../../packages/data",
 		"@jetpack-premium-analytics/icons": "link:../../packages/icons",
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/compose": "8.3.0",
 		"@wordpress/element": "8.2.0",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^15.0.0",
+		"@wordpress/ui": "0.17.0",
 		"@wordpress/widget-primitives": "0.2.0",
 		"date-fns": "4.1.0"
 	}

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/package.json
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/package.json
@@ -1,0 +1,16 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-post-traffic-activity",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/icons": "link:../../packages/icons",
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/element": "8.2.0",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^15.0.0",
+		"@wordpress/widget-primitives": "0.2.0",
+		"date-fns": "4.1.0"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/render.tsx
@@ -78,7 +78,9 @@ function PostTrafficActivityInner() {
 	const measureRef = useResizeObserver< HTMLDivElement >( entries => {
 		const rect = entries[ 0 ]?.contentRect;
 		if ( rect ) {
-			setWidth( rect.width );
+			// Round and dedupe so subpixel resize reports don't churn renders.
+			const next = Math.round( rect.width );
+			setWidth( previous => ( previous === next ? previous : next ) );
 		}
 	} );
 
@@ -116,15 +118,14 @@ function PostTrafficActivityInner() {
 						),
 						actions: [ { label: __( 'Retry', 'jetpack-premium-analytics' ), onClick: refetch } ],
 					} }
+					// A post with no traffic renders the all-blank grid (the sparse
+					// treatment), so the empty state only covers the missing scope.
 					empty={ {
 						icon: reports,
-						description:
-							postId <= 0
-								? __(
-										'Open a post or page report to see its traffic activity here.',
-										'jetpack-premium-analytics'
-								  )
-								: __( 'No traffic activity in this period yet.', 'jetpack-premium-analytics' ),
+						description: __(
+							'Open a post or page report to see its traffic activity here.',
+							'jetpack-premium-analytics'
+						),
 					} }
 				>
 					<div className={ styles.content }>

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/render.tsx
@@ -98,10 +98,8 @@ function PostTrafficActivityInner() {
 		refetch,
 	} = usePostTrafficActivity( postId, reportParams, weeksForWidth( width ) * 7 );
 
-	// Ragged edges: the hook already trims days outside the visible span, so
-	// the slots completing those first/last weeks render empty, not blank.
 	const { data: heatmapData, rowLabels } = useMemo(
-		() => buildCalendarHeatmapData( days, { hideOutOfRangeDays: true } ),
+		() => buildCalendarHeatmapData( days ),
 		[ days ]
 	);
 

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/render.tsx
@@ -10,7 +10,8 @@ import {
 	useWidgetRootContext,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
-import { useMemo } from '@wordpress/element';
+import { useResizeObserver } from '@wordpress/compose';
+import { useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { Button, Stack } from '@wordpress/ui';
@@ -25,6 +26,35 @@ import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 type PostTrafficActivityRenderAttributes = PostTrafficActivityAttributes &
 	Partial< ReportParamsFieldAttributes >;
 type PostTrafficActivityWidgetProps = WidgetRenderProps< PostTrafficActivityRenderAttributes >;
+
+/**
+ * Sizing the page to the card: one page shows as many whole week columns as
+ * fit at the design's cell width. The constants mirror the chart's
+ * non-compact metrics — 64px design cells, the 4px cell gap, and an
+ * allowance for the weekday-label gutter.
+ */
+const CELL_WIDTH = 64;
+const CELL_GAP = 4;
+const LABEL_GUTTER = 48;
+const MIN_PAGE_WEEKS = 4;
+const DEFAULT_PAGE_WEEKS = 16;
+
+/**
+ * Whole week columns that fit the measured card width.
+ *
+ * @param width - The measured content width, if known yet.
+ * @return The page width in week columns.
+ */
+function weeksForWidth( width?: number ): number {
+	if ( ! width ) {
+		return DEFAULT_PAGE_WEEKS;
+	}
+
+	return Math.max(
+		MIN_PAGE_WEEKS,
+		Math.floor( ( width - LABEL_GUTTER ) / ( CELL_WIDTH + CELL_GAP ) )
+	);
+}
 
 /**
  * Traffic activity inner component. Reads the post scope and date range from
@@ -42,6 +72,16 @@ function PostTrafficActivityInner() {
 	const parsedPostId = Number( reportParams.post_id );
 	const postId = Number.isInteger( parsedPostId ) && parsedPostId > 0 ? parsedPostId : 0;
 
+	// One page spans the whole week columns that fit the measured card width,
+	// so the grid fills the card without horizontal scrolling.
+	const [ width, setWidth ] = useState< number >();
+	const measureRef = useResizeObserver< HTMLDivElement >( entries => {
+		const rect = entries[ 0 ]?.contentRect;
+		if ( rect ) {
+			setWidth( rect.width );
+		}
+	} );
+
 	const {
 		days,
 		isPaged,
@@ -54,7 +94,7 @@ function PostTrafficActivityInner() {
 		isError,
 		hasData,
 		refetch,
-	} = usePostTrafficActivity( postId, reportParams );
+	} = usePostTrafficActivity( postId, reportParams, weeksForWidth( width ) * 7 );
 
 	const { data: heatmapData, rowLabels } = useMemo(
 		() => buildCalendarHeatmapData( days ),
@@ -62,7 +102,7 @@ function PostTrafficActivityInner() {
 	);
 
 	return (
-		<div className={ styles.root }>
+		<div ref={ measureRef } className={ styles.root }>
 			{ /* Pager chrome stays a sibling of WidgetState so it is available in
 			     every state; it only renders when the range exceeds one page. */ }
 			{ isPaged && (
@@ -121,13 +161,10 @@ function PostTrafficActivityInner() {
 							rowLabels={ rowLabels }
 							primaryColor="var(--wp-admin-theme-color, #3858e9)"
 							withTooltips
-							// Cap cells at the design's 64x42 so a short range doesn't
-							// blow the few columns up to the card width, and floor the
-							// width so narrow cards scroll a page instead of crushing
-							// cells.
+							// Cap cells at the design's 64x42; the page span is already
+							// sized to the card, so tracks never need to shrink below it.
 							maxCellWidth={ 64 }
 							maxCellHeight={ 42 }
-							minCellWidth={ 44 }
 							className={ styles.heatmap }
 						/>
 					</div>

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/render.tsx
@@ -3,7 +3,7 @@
  */
 import { reports } from '@jetpack-premium-analytics/icons';
 import {
-	HeatmapChart,
+	HeatmapChartUnresponsive,
 	WidgetRoot,
 	WidgetState,
 	buildCalendarHeatmapData,
@@ -103,34 +103,6 @@ function PostTrafficActivityInner() {
 
 	return (
 		<div ref={ measureRef } className={ styles.root }>
-			{ /* Pager chrome stays a sibling of WidgetState so it is available in
-			     every state; it only renders when the range exceeds one page. */ }
-			{ isPaged && (
-				<Stack align="center" justify="flex-end" gap="sm" className={ styles.pager }>
-					<Button
-						type="button"
-						variant="minimal"
-						tone="neutral"
-						size="small"
-						onClick={ showOlder }
-						disabled={ ! canShowOlder }
-						aria-label={ __( 'Older activity', 'jetpack-premium-analytics' ) }
-					>
-						<Button.Icon icon={ chevronLeft } size={ 16 } />
-					</Button>
-					<Button
-						type="button"
-						variant="minimal"
-						tone="neutral"
-						size="small"
-						onClick={ showNewer }
-						disabled={ ! canShowNewer }
-						aria-label={ __( 'Newer activity', 'jetpack-premium-analytics' ) }
-					>
-						<Button.Icon icon={ chevronRight } size={ 16 } />
-					</Button>
-				</Stack>
-			) }
 			<div className={ styles.body }>
 				<WidgetState
 					isLoading={ isLoading && ! hasData }
@@ -156,7 +128,40 @@ function PostTrafficActivityInner() {
 					} }
 				>
 					<div className={ styles.content }>
-						<HeatmapChart
+						{ /* The pager centers with the grid as one block; it only exists
+						     when the range exceeds one page (and only in the ready state,
+						     where the grid it steps is visible). */ }
+						{ isPaged && (
+							<Stack align="center" justify="flex-end" gap="sm" className={ styles.pager }>
+								<Button
+									type="button"
+									variant="minimal"
+									tone="neutral"
+									size="small"
+									onClick={ showOlder }
+									disabled={ ! canShowOlder }
+									aria-label={ __( 'Older activity', 'jetpack-premium-analytics' ) }
+								>
+									<Button.Icon icon={ chevronLeft } size={ 16 } />
+								</Button>
+								<Button
+									type="button"
+									variant="minimal"
+									tone="neutral"
+									size="small"
+									onClick={ showNewer }
+									disabled={ ! canShowNewer }
+									aria-label={ __( 'Newer activity', 'jetpack-premium-analytics' ) }
+								>
+									<Button.Icon icon={ chevronRight } size={ 16 } />
+								</Button>
+							</Stack>
+						) }
+						{ /* The unresponsive chart export: the capped grid is
+						     content-sized and the page span is derived from the widget's
+						     own measurement, so the responsive wrapper's full-height
+						     measuring container would only break the centered block. */ }
+						<HeatmapChartUnresponsive
 							data={ heatmapData }
 							rowLabels={ rowLabels }
 							primaryColor="var(--wp-admin-theme-color, #3858e9)"

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/render.tsx
@@ -81,9 +81,12 @@ function PostTrafficActivityInner() {
 						primaryColor="var(--wp-admin-theme-color, #3858e9)"
 						withTooltips
 						// Cap the cell size so a short range doesn't blow the few
-						// columns up to the card width (the design's ~88x56 cells).
+						// columns up to the card width (the design's ~88x56 cells),
+						// and floor the width so long ranges overflow into the
+						// wrapper's horizontal scroll instead of crushing cells.
 						maxCellWidth={ 88 }
 						maxCellHeight={ 56 }
+						minCellWidth={ 44 }
 						className={ styles.heatmap }
 					/>
 				</div>

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/render.tsx
@@ -12,6 +12,8 @@ import {
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
+import { Button, Stack } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
@@ -26,11 +28,12 @@ type PostTrafficActivityWidgetProps = WidgetRenderProps< PostTrafficActivityRend
 
 /**
  * Traffic activity inner component. Reads the post scope and date range from
- * WidgetRoot context and renders the post's daily views as a calendar
- * heatmap through `<WidgetState>` — week columns, weekday rows, and view
- * counts inside the cells; without a post scope (e.g. the widget added
- * outside a post detail page) the query never enables and the empty state
- * shows.
+ * WidgetRoot context and renders one page of the post's daily views as a
+ * calendar heatmap through `<WidgetState>` — week columns, weekday rows, and
+ * view counts inside the cells. Ranges longer than one page grow a header
+ * pager stepping through the range; without a post scope (e.g. the widget
+ * added outside a post detail page) the query never enables and the empty
+ * state shows.
  *
  * @return The rendered widget content.
  */
@@ -39,10 +42,19 @@ function PostTrafficActivityInner() {
 	const parsedPostId = Number( reportParams.post_id );
 	const postId = Number.isInteger( parsedPostId ) && parsedPostId > 0 ? parsedPostId : 0;
 
-	const { days, isLoading, isFetching, isError, hasData, refetch } = usePostTrafficActivity(
-		postId,
-		reportParams
-	);
+	const {
+		days,
+		isPaged,
+		canShowOlder,
+		canShowNewer,
+		showOlder,
+		showNewer,
+		isLoading,
+		isFetching,
+		isError,
+		hasData,
+		refetch,
+	} = usePostTrafficActivity( postId, reportParams );
 
 	const { data: heatmapData, rowLabels } = useMemo(
 		() => buildCalendarHeatmapData( days ),
@@ -51,46 +63,76 @@ function PostTrafficActivityInner() {
 
 	return (
 		<div className={ styles.root }>
-			<WidgetState
-				isLoading={ isLoading && ! hasData }
-				isFetching={ isFetching }
-				isError={ isError }
-				isEmpty={ postId <= 0 || heatmapData.length === 0 }
-				error={ {
-					description: __(
-						"We couldn't load this traffic activity. Please try again in a moment.",
-						'jetpack-premium-analytics'
-					),
-					actions: [ { label: __( 'Retry', 'jetpack-premium-analytics' ), onClick: refetch } ],
-				} }
-				empty={ {
-					icon: reports,
-					description:
-						postId <= 0
-							? __(
-									'Open a post or page report to see its traffic activity here.',
-									'jetpack-premium-analytics'
-							  )
-							: __( 'No traffic activity in this period yet.', 'jetpack-premium-analytics' ),
-				} }
-			>
-				<div className={ styles.content }>
-					<HeatmapChart
-						data={ heatmapData }
-						rowLabels={ rowLabels }
-						primaryColor="var(--wp-admin-theme-color, #3858e9)"
-						withTooltips
-						// Cap the cell size so a short range doesn't blow the few
-						// columns up to the card width (the design's ~88x56 cells),
-						// and floor the width so long ranges overflow into the
-						// wrapper's horizontal scroll instead of crushing cells.
-						maxCellWidth={ 88 }
-						maxCellHeight={ 56 }
-						minCellWidth={ 44 }
-						className={ styles.heatmap }
-					/>
-				</div>
-			</WidgetState>
+			{ /* Pager chrome stays a sibling of WidgetState so it is available in
+			     every state; it only renders when the range exceeds one page. */ }
+			{ isPaged && (
+				<Stack align="center" justify="flex-end" gap="sm" className={ styles.pager }>
+					<Button
+						type="button"
+						variant="minimal"
+						tone="neutral"
+						size="small"
+						onClick={ showOlder }
+						disabled={ ! canShowOlder }
+						aria-label={ __( 'Older activity', 'jetpack-premium-analytics' ) }
+					>
+						<Button.Icon icon={ chevronLeft } size={ 16 } />
+					</Button>
+					<Button
+						type="button"
+						variant="minimal"
+						tone="neutral"
+						size="small"
+						onClick={ showNewer }
+						disabled={ ! canShowNewer }
+						aria-label={ __( 'Newer activity', 'jetpack-premium-analytics' ) }
+					>
+						<Button.Icon icon={ chevronRight } size={ 16 } />
+					</Button>
+				</Stack>
+			) }
+			<div className={ styles.body }>
+				<WidgetState
+					isLoading={ isLoading && ! hasData }
+					isFetching={ isFetching }
+					isError={ isError }
+					isEmpty={ postId <= 0 || heatmapData.length === 0 }
+					error={ {
+						description: __(
+							"We couldn't load this traffic activity. Please try again in a moment.",
+							'jetpack-premium-analytics'
+						),
+						actions: [ { label: __( 'Retry', 'jetpack-premium-analytics' ), onClick: refetch } ],
+					} }
+					empty={ {
+						icon: reports,
+						description:
+							postId <= 0
+								? __(
+										'Open a post or page report to see its traffic activity here.',
+										'jetpack-premium-analytics'
+								  )
+								: __( 'No traffic activity in this period yet.', 'jetpack-premium-analytics' ),
+					} }
+				>
+					<div className={ styles.content }>
+						<HeatmapChart
+							data={ heatmapData }
+							rowLabels={ rowLabels }
+							primaryColor="var(--wp-admin-theme-color, #3858e9)"
+							withTooltips
+							// Cap cells at the design's 64x42 so a short range doesn't
+							// blow the few columns up to the card width, and floor the
+							// width so narrow cards scroll a page instead of crushing
+							// cells.
+							maxCellWidth={ 64 }
+							maxCellHeight={ 42 }
+							minCellWidth={ 44 }
+							className={ styles.heatmap }
+						/>
+					</div>
+				</WidgetState>
+			</div>
 		</div>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/render.tsx
@@ -80,6 +80,10 @@ function PostTrafficActivityInner() {
 						rowLabels={ rowLabels }
 						primaryColor="var(--wp-admin-theme-color, #3858e9)"
 						withTooltips
+						// Cap the cell size so a short range doesn't blow the few
+						// columns up to the card width (the design's ~88x56 cells).
+						maxCellWidth={ 88 }
+						maxCellHeight={ 56 }
 						className={ styles.heatmap }
 					/>
 				</div>

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/render.tsx
@@ -98,8 +98,10 @@ function PostTrafficActivityInner() {
 		refetch,
 	} = usePostTrafficActivity( postId, reportParams, weeksForWidth( width ) * 7 );
 
+	// Ragged edges: the hook already trims days outside the visible span, so
+	// the slots completing those first/last weeks render empty, not blank.
 	const { data: heatmapData, rowLabels } = useMemo(
-		() => buildCalendarHeatmapData( days ),
+		() => buildCalendarHeatmapData( days, { hideOutOfRangeDays: true } ),
 		[ days ]
 	);
 

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/render.tsx
@@ -1,0 +1,105 @@
+/**
+ * External dependencies
+ */
+import { reports } from '@jetpack-premium-analytics/icons';
+import {
+	HeatmapChart,
+	WidgetRoot,
+	WidgetState,
+	buildCalendarHeatmapData,
+	useWidgetRootContext,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import styles from './style.module.css';
+import usePostTrafficActivity from './use-post-traffic-activity';
+import type { PostTrafficActivityAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+
+type PostTrafficActivityRenderAttributes = PostTrafficActivityAttributes &
+	Partial< ReportParamsFieldAttributes >;
+type PostTrafficActivityWidgetProps = WidgetRenderProps< PostTrafficActivityRenderAttributes >;
+
+/**
+ * Traffic activity inner component. Reads the post scope and date range from
+ * WidgetRoot context and renders the post's daily views as a calendar
+ * heatmap through `<WidgetState>` — week columns, weekday rows, and view
+ * counts inside the cells; without a post scope (e.g. the widget added
+ * outside a post detail page) the query never enables and the empty state
+ * shows.
+ *
+ * @return The rendered widget content.
+ */
+function PostTrafficActivityInner() {
+	const { reportParams } = useWidgetRootContext();
+	const parsedPostId = Number( reportParams.post_id );
+	const postId = Number.isInteger( parsedPostId ) && parsedPostId > 0 ? parsedPostId : 0;
+
+	const { days, isLoading, isFetching, isError, hasData, refetch } = usePostTrafficActivity(
+		postId,
+		reportParams
+	);
+
+	const { data: heatmapData, rowLabels } = useMemo(
+		() => buildCalendarHeatmapData( days ),
+		[ days ]
+	);
+
+	return (
+		<div className={ styles.root }>
+			<WidgetState
+				isLoading={ isLoading && ! hasData }
+				isFetching={ isFetching }
+				isError={ isError }
+				isEmpty={ postId <= 0 || heatmapData.length === 0 }
+				error={ {
+					description: __(
+						"We couldn't load this traffic activity. Please try again in a moment.",
+						'jetpack-premium-analytics'
+					),
+					actions: [ { label: __( 'Retry', 'jetpack-premium-analytics' ), onClick: refetch } ],
+				} }
+				empty={ {
+					icon: reports,
+					description:
+						postId <= 0
+							? __(
+									'Open a post or page report to see its traffic activity here.',
+									'jetpack-premium-analytics'
+							  )
+							: __( 'No traffic activity in this period yet.', 'jetpack-premium-analytics' ),
+				} }
+			>
+				<div className={ styles.content }>
+					<HeatmapChart
+						data={ heatmapData }
+						rowLabels={ rowLabels }
+						primaryColor="var(--wp-admin-theme-color, #3858e9)"
+						withTooltips
+						className={ styles.heatmap }
+					/>
+				</div>
+			</WidgetState>
+		</div>
+	);
+}
+
+/**
+ * Traffic activity widget: the scoped post's daily views as a calendar
+ * heatmap — the post detail Traffic view's activity card, replacing the
+ * legacy months table.
+ *
+ * @param {PostTrafficActivityWidgetProps} props - The widget render props.
+ * @return The rendered widget.
+ */
+export default function PostTrafficActivity( { attributes = {} }: PostTrafficActivityWidgetProps ) {
+	return (
+		<WidgetRoot attributes={ attributes }>
+			<PostTrafficActivityInner />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/stories/post-traffic-activity-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/stories/post-traffic-activity-widget.stories.tsx
@@ -1,0 +1,173 @@
+/**
+ * The Traffic activity widget is the post detail Traffic view's activity
+ * card: the scoped post's daily views over the dashboard date range as a
+ * calendar heatmap (week columns, weekday rows, view counts in the cells).
+ * The post scope arrives through `reportParams.post_id` (seeded from the
+ * detail page URL in product); the `hasPostScope` control toggles it to
+ * exercise the scopeless empty state. Days the endpoint omits are
+ * zero-filled so the grid stays complete.
+ *
+ * Data comes from the proxied `stats/post/{id}` endpoint, covered by the
+ * shared report mocks' `stats-post` fixture (a deterministic daily series
+ * ending today, so relative date presets always intersect it).
+ */
+/**
+ * External dependencies
+ */
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+/**
+ * Internal dependencies
+ */
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import PostTrafficActivityRender from '../render';
+import widgetDefinition from '../widget';
+import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+// Any post ID resolves to the shared `stats-post` fixture; this one matches
+// the fixture's own post row for coherence.
+const MOCK_POST_ID = 779;
+
+const POST_TRAFFIC_ACTIVITY_RENDER_MODULE = 'storybook/post-traffic-activity';
+
+interface PostTrafficActivityStoryControls {
+	hasPostScope: boolean;
+}
+
+/**
+ * Builds the widget attributes: report params with the post scope the detail
+ * page seeds from its URL when `hasPostScope` is on.
+ *
+ * @param {PostTrafficActivityStoryControls} controls - The story controls.
+ * @return The widget attributes.
+ */
+function getPostTrafficActivityAttributes( {
+	hasPostScope,
+}: PostTrafficActivityStoryControls ): ComponentProps<
+	typeof PostTrafficActivityRender
+>[ 'attributes' ] {
+	return {
+		reportParams: {
+			...getDefaultQueryParams( false ),
+			...( hasPostScope ? { post_id: MOCK_POST_ID } : {} ),
+		},
+	};
+}
+
+/**
+ * Renders the data-connected widget with the composed attributes.
+ *
+ * @param {PostTrafficActivityStoryControls} controls - The story controls.
+ * @return The rendered widget.
+ */
+function renderPostTrafficActivity( controls: PostTrafficActivityStoryControls ) {
+	return <PostTrafficActivityRender attributes={ getPostTrafficActivityAttributes( controls ) } />;
+}
+
+// Close-up canvas sized to the heatmap outside the dashboard grid.
+const withWidgetCanvas: Decorator = Story => (
+	<div style={ { width: '100%', height: '360px' } }>
+		<Story />
+	</div>
+);
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/PostTrafficActivity',
+	component: PostTrafficActivityRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		hasPostScope: {
+			control: 'boolean',
+			description: 'Include the `post_id` report param the post detail page seeds from its URL.',
+		},
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The "Traffic activity" widget: the scoped post\'s daily views over the dashboard date range as a calendar heatmap — the post detail Traffic view\'s activity card, replacing the legacy months table. Days the endpoint omits are zero-filled so the grid stays complete. Without a post scope the widget renders a scopeless empty state.',
+			},
+		},
+	},
+} satisfies Meta<
+	ComponentProps< typeof PostTrafficActivityRender > & PostTrafficActivityStoryControls
+>;
+
+export default meta;
+
+type Story = StoryObj< PostTrafficActivityStoryControls >;
+
+/**
+ * Default — the scoped post's daily view heatmap for the dashboard range.
+ */
+export const Default: Story = {
+	render: renderPostTrafficActivity,
+	args: { hasPostScope: true },
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * NoPostScope — the widget without a `post_id` report param, as when added
+ * outside a post detail page. Renders the scopeless empty state without
+ * firing a stats request.
+ */
+export const NoPostScope: Story = {
+	render: renderPostTrafficActivity,
+	args: { hasPostScope: false },
+	decorators: [ withWidgetCanvas ],
+};
+
+interface PostTrafficActivityDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		PostTrafficActivityStoryControls {}
+
+/**
+ * Mounts the real `WidgetDashboard` with this single widget so it renders
+ * exactly as it does in product (framed card, sizing, host environment).
+ *
+ * @param {PostTrafficActivityDashboardStoryProps} props - The dashboard story controls.
+ * @return The widget mounted inside the real dashboard.
+ */
+function PostTrafficActivityDashboardStory( {
+	hasPostScope,
+	...dashboardArgs
+}: PostTrafficActivityDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardArgs }
+			widgetType={ { ...widgetDefinition, presentation: 'framed' } }
+			renderModule={ POST_TRAFFIC_ACTIVITY_RENDER_MODULE }
+			renderComponent={ PostTrafficActivityRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ getPostTrafficActivityAttributes( { hasPostScope } ) }
+		/>
+	);
+}
+
+/**
+ * Mirrors the production placement (3 columns × 2 rows, beside the likes card).
+ */
+export const WidgetDashboardWithWidget: StoryObj< PostTrafficActivityDashboardStoryProps > = {
+	render: args => <PostTrafficActivityDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		widgetWidth: 3,
+		widgetHeight: 2,
+		hasPostScope: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		hasPostScope: {
+			control: 'boolean',
+			description: 'Include the `post_id` report param the post detail page seeds from its URL.',
+		},
+	},
+};

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/stories/post-traffic-activity-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/stories/post-traffic-activity-widget.stories.tsx
@@ -4,8 +4,8 @@
  * calendar heatmap (week columns, weekday rows, view counts in the cells).
  * The post scope arrives through `reportParams.post_id` (seeded from the
  * detail page URL in product); the `hasPostScope` control toggles it to
- * exercise the scopeless empty state. Days the endpoint omits are
- * zero-filled so the grid stays complete.
+ * exercise the scopeless empty state. Days without traffic stay blank
+ * cells, per the design, while the grid stays complete.
  *
  * Data comes from the proxied `stats/post/{id}` endpoint, covered by the
  * shared report mocks' `stats-post` fixture (a deterministic daily series
@@ -94,7 +94,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'The "Traffic activity" widget: the scoped post\'s daily views over the dashboard date range as a calendar heatmap — the post detail Traffic view\'s activity card, replacing the legacy months table. Days the endpoint omits are zero-filled so the grid stays complete. Without a post scope the widget renders a scopeless empty state.',
+					'The "Traffic activity" widget: the scoped post\'s daily views over the dashboard date range as a calendar heatmap — the post detail Traffic view\'s activity card, replacing the legacy months table. Days without traffic stay blank cells, per the design, while the grid stays complete. Without a post scope the widget renders a scopeless empty state.',
 			},
 		},
 	},

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/stories/post-traffic-activity-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/stories/post-traffic-activity-widget.stories.tsx
@@ -41,6 +41,8 @@ const POST_TRAFFIC_ACTIVITY_RENDER_MODULE = 'storybook/post-traffic-activity';
 
 interface PostTrafficActivityStoryControls {
 	hasPostScope: boolean;
+	withComparison: boolean;
+	preset: 'last-30-days' | 'last-365-days';
 }
 
 /**
@@ -52,12 +54,14 @@ interface PostTrafficActivityStoryControls {
  */
 function getPostTrafficActivityAttributes( {
 	hasPostScope,
+	withComparison,
+	preset,
 }: PostTrafficActivityStoryControls ): ComponentProps<
 	typeof PostTrafficActivityRender
 >[ 'attributes' ] {
 	return {
 		reportParams: {
-			...getDefaultQueryParams( false ),
+			...getDefaultQueryParams( withComparison, preset ),
 			...( hasPostScope ? { post_id: MOCK_POST_ID } : {} ),
 		},
 	};
@@ -75,7 +79,7 @@ function renderPostTrafficActivity( controls: PostTrafficActivityStoryControls )
 
 // Close-up canvas sized to the heatmap outside the dashboard grid.
 const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '360px' } }>
+	<div style={ { width: '100%', height: '400px' } }>
 		<Story />
 	</div>
 );
@@ -88,6 +92,15 @@ const meta = {
 		hasPostScope: {
 			control: 'boolean',
 			description: 'Include the `post_id` report param the post detail page seeds from its URL.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include the date range picker comparison parameters.',
+		},
+		preset: {
+			control: 'select',
+			options: [ 'last-30-days', 'last-365-days' ],
+			description: 'Dashboard date range used to exercise single-page and paged layouts.',
 		},
 	},
 	parameters: {
@@ -111,7 +124,36 @@ type Story = StoryObj< PostTrafficActivityStoryControls >;
  */
 export const Default: Story = {
 	render: renderPostTrafficActivity,
-	args: { hasPostScope: true },
+	args: { hasPostScope: true, withComparison: false, preset: 'last-30-days' },
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * WithComparison — verifies that comparison report params from the date range
+ * picker pass through the widget host. The stats/post endpoint has no separate
+ * comparison rows, so the activity grid intentionally remains primary-only.
+ */
+export const WithComparison: Story = {
+	render: renderPostTrafficActivity,
+	args: { hasPostScope: true, withComparison: true, preset: 'last-30-days' },
+	decorators: [ withWidgetCanvas ],
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'The stats/post endpoint does not return a comparison series. This story verifies that comparison report parameters are accepted without inventing comparison activity.',
+			},
+		},
+	},
+};
+
+/**
+ * Paged — a deterministic year-long range that always exceeds one page at
+ * the default story width, exposing both pager controls for direct review.
+ */
+export const Paged: Story = {
+	render: renderPostTrafficActivity,
+	args: { hasPostScope: true, withComparison: false, preset: 'last-365-days' },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -122,7 +164,7 @@ export const Default: Story = {
  */
 export const NoPostScope: Story = {
 	render: renderPostTrafficActivity,
-	args: { hasPostScope: false },
+	args: { hasPostScope: false, withComparison: false, preset: 'last-30-days' },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -139,6 +181,8 @@ interface PostTrafficActivityDashboardStoryProps
  */
 function PostTrafficActivityDashboardStory( {
 	hasPostScope,
+	withComparison,
+	preset,
 	...dashboardArgs
 }: PostTrafficActivityDashboardStoryProps ) {
 	return (
@@ -147,7 +191,7 @@ function PostTrafficActivityDashboardStory( {
 			widgetType={ { ...widgetDefinition, presentation: 'framed' } }
 			renderModule={ POST_TRAFFIC_ACTIVITY_RENDER_MODULE }
 			renderComponent={ PostTrafficActivityRender as ComponentType< WidgetRenderProps< unknown > > }
-			attributes={ getPostTrafficActivityAttributes( { hasPostScope } ) }
+			attributes={ getPostTrafficActivityAttributes( { hasPostScope, withComparison, preset } ) }
 		/>
 	);
 }
@@ -162,12 +206,23 @@ export const WidgetDashboardWithWidget: StoryObj< PostTrafficActivityDashboardSt
 		widgetWidth: 4,
 		widgetHeight: 2,
 		hasPostScope: true,
+		withComparison: true,
+		preset: 'last-30-days',
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
 		hasPostScope: {
 			control: 'boolean',
 			description: 'Include the `post_id` report param the post detail page seeds from its URL.',
+		},
+		withComparison: {
+			control: 'boolean',
+			description: 'Include the date range picker comparison parameters.',
+		},
+		preset: {
+			control: 'select',
+			options: [ 'last-30-days', 'last-365-days' ],
+			description: 'Dashboard date range used to exercise single-page and paged layouts.',
 		},
 	},
 };

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/stories/post-traffic-activity-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/stories/post-traffic-activity-widget.stories.tsx
@@ -153,13 +153,13 @@ function PostTrafficActivityDashboardStory( {
 }
 
 /**
- * Mirrors the production placement (3 columns × 2 rows, beside the likes card).
+ * Mirrors the production placement (full width × 2 rows).
  */
 export const WidgetDashboardWithWidget: StoryObj< PostTrafficActivityDashboardStoryProps > = {
 	render: args => <PostTrafficActivityDashboardStory { ...args } />,
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
-		widgetWidth: 3,
+		widgetWidth: 4,
 		widgetHeight: 2,
 		hasPostScope: true,
 	},

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/style.module.css
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/style.module.css
@@ -1,0 +1,26 @@
+/* Fill the tile so empty/error states center; the framed widget host's
+ * content area is the scroll viewport for anything taller. */
+.root {
+	display: flex;
+	flex-direction: column;
+	min-height: 100%;
+}
+
+.content {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	flex: 1 1 0;
+	min-height: 0;
+
+	/* A wide date range produces more week columns than a narrow card fits;
+	   scroll horizontally instead of clipping months. */
+	overflow-x: auto;
+}
+
+/* Center the grid vertically in a taller-than-content card; horizontal start
+   keeps overflow scrolling reachable. */
+.heatmap {
+	min-width: 0;
+	justify-content: center;
+}

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/style.module.css
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/style.module.css
@@ -33,6 +33,15 @@
 	overflow-x: auto;
 }
 
+/* The chart's responsive measuring container fills the tile height (its
+   sizing is structural — it is what gets measured), so center the
+   content-sized capped chart inside it rather than around it. */
+.content > * {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+}
+
 .heatmap {
 	flex: 0 0 auto;
 	min-width: 0;

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/style.module.css
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/style.module.css
@@ -25,13 +25,16 @@
 	height: 100%;
 	min-height: 0;
 
-	/* A wide date range produces more week columns than a narrow card fits;
-	   scroll horizontally instead of clipping months. */
+	/* The page is sized to the card, so the content-sized grid centers in the
+	   leftover tile height. */
+	justify-content: center;
+
+	/* Safety net for sub-minimum widths (the page floor is 4 week columns). */
 	overflow-x: auto;
 }
 
 .heatmap {
-	flex: 1 1 0;
+	flex: 0 0 auto;
 	min-width: 0;
 	min-height: 0;
 }

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/style.module.css
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/style.module.css
@@ -12,6 +12,13 @@
 	flex-shrink: 0;
 }
 
+/* Draw the focus ring inside the buttons; the default outset ring gets
+   clipped by the content area's overflow (same treatment as the metric
+   tabs). */
+.pager button {
+	outline-offset: calc(-1 * var(--wpds-border-width-focus, 1.5px));
+}
+
 /* Remaining tile height for WidgetState's block-level ready wrapper. */
 .body {
 	flex: 1 1 0;

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/style.module.css
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/style.module.css
@@ -25,21 +25,13 @@
 	height: 100%;
 	min-height: 0;
 
-	/* The page is sized to the card, so the content-sized grid centers in the
-	   leftover tile height. */
+	/* The pager + content-sized grid center as one block in the leftover
+	   tile height. */
 	justify-content: center;
+	gap: var(--wpds-dimension-gap-sm, 8px);
 
 	/* Safety net for sub-minimum widths (the page floor is 4 week columns). */
 	overflow-x: auto;
-}
-
-/* The chart's responsive measuring container fills the tile height (its
-   sizing is structural — it is what gets measured), so center the
-   content-sized capped chart inside it rather than around it. */
-.content > * {
-	display: flex;
-	flex-direction: column;
-	justify-content: center;
 }
 
 .heatmap {

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/style.module.css
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/style.module.css
@@ -1,16 +1,18 @@
-/* Fill the tile so empty/error states center; the framed widget host's
- * content area is the scroll viewport for anything taller. */
+/* The non-compact heatmap grid fills its container (1fr tracks), so the
+ * height chain must stay bounded from the widget frame's viewport down:
+ * root → WidgetState's block-level `.ready` (block-size 100%) → content. */
 .root {
 	display: flex;
 	flex-direction: column;
-	min-height: 100%;
+	height: 100%;
+	min-height: 0;
 }
 
 .content {
 	position: relative;
 	display: flex;
 	flex-direction: column;
-	flex: 1 1 0;
+	height: 100%;
 	min-height: 0;
 
 	/* A wide date range produces more week columns than a narrow card fits;
@@ -18,9 +20,8 @@
 	overflow-x: auto;
 }
 
-/* Center the grid vertically in a taller-than-content card; horizontal start
-   keeps overflow scrolling reachable. */
 .heatmap {
+	flex: 1 1 0;
 	min-width: 0;
-	justify-content: center;
+	min-height: 0;
 }

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/style.module.css
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/style.module.css
@@ -8,6 +8,16 @@
 	min-height: 0;
 }
 
+.pager {
+	flex-shrink: 0;
+}
+
+/* Remaining tile height for WidgetState's block-level ready wrapper. */
+.body {
+	flex: 1 1 0;
+	min-height: 0;
+}
+
 .content {
 	position: relative;
 	display: flex;

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/use-post-traffic-activity.ts
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/use-post-traffic-activity.ts
@@ -1,0 +1,84 @@
+/**
+ * External dependencies
+ */
+import { useStatsPost, type ReportParams } from '@jetpack-premium-analytics/data';
+import { useMemo } from '@wordpress/element';
+import { eachDayOfInterval, format, parseISO } from 'date-fns';
+import type { DataPointDate } from '@jetpack-premium-analytics/widgets-toolkit';
+
+/**
+ * Normalized activity state: one point per calendar day in the window plus
+ * the request's load/error flags. `hasData` distinguishes the first load from
+ * refetches.
+ */
+export interface PostTrafficActivityState {
+	days: DataPointDate[];
+	isLoading: boolean;
+	isFetching: boolean;
+	isError: boolean;
+	hasData: boolean;
+	refetch: () => void;
+}
+
+/**
+ * Extract a shape-validated `YYYY-MM-DD` day from an ISO report param. The
+ * params originate from URL search params; a malformed bound disables the
+ * window rather than reaching `parseISO`/`eachDayOfInterval` (which throw).
+ *
+ * @param value - The ISO date-time string.
+ * @return The date-only day, or undefined when missing/malformed.
+ */
+function toDay( value?: string ): string | undefined {
+	const day = value?.slice( 0, 10 );
+	return day && /^\d{4}-\d{2}-\d{2}$/.test( day ) && ! Number.isNaN( parseISO( day ).getTime() )
+		? day
+		: undefined;
+}
+
+/**
+ * Fetch the scoped post's daily view activity for the dashboard's report
+ * params. The `stats/post` daily history covers every day since publication
+ * but omits zero-view days, so every calendar day of the window is
+ * zero-seeded — the heatmap renders a complete grid, and pre-publication
+ * days are genuinely zero views.
+ *
+ * @param postId       - The scoped post ID (0 disables the request).
+ * @param reportParams - The dashboard date range.
+ * @return The daily activity points and load/error state.
+ */
+export default function usePostTrafficActivity(
+	postId: number,
+	reportParams: ReportParams
+): PostTrafficActivityState {
+	const { data, isLoading, isFetching, isError, refetch } = useStatsPost( {
+		postId,
+		fields: [ 'data' ],
+	} );
+
+	const days = useMemo< DataPointDate[] >( () => {
+		const history = data?.data ?? [];
+		const from = toDay( reportParams.from );
+		const to = toDay( reportParams.to );
+
+		if ( ! from || ! to || from > to ) {
+			return [];
+		}
+
+		const viewsByDay = new Map( history.map( day => [ day.date, day.views ] ) );
+
+		return eachDayOfInterval( { start: parseISO( from ), end: parseISO( to ) } ).map( date => {
+			const dateString = format( date, 'yyyy-MM-dd' );
+
+			return { dateString, value: viewsByDay.get( dateString ) ?? 0 };
+		} );
+	}, [ data, reportParams.from, reportParams.to ] );
+
+	return {
+		days,
+		isLoading,
+		isFetching,
+		isError,
+		hasData: !! data,
+		refetch,
+	};
+}

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/use-post-traffic-activity.ts
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/use-post-traffic-activity.ts
@@ -2,17 +2,25 @@
  * External dependencies
  */
 import { useStatsPost, type ReportParams } from '@jetpack-premium-analytics/data';
-import { useMemo } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { eachDayOfInterval, format, parseISO, subDays } from 'date-fns';
 import type { DataPointDate } from '@jetpack-premium-analytics/widgets-toolkit';
 
 /**
- * Normalized activity state: one point per calendar day in the window plus
- * the request's load/error flags. `hasData` distinguishes the first load from
- * refetches.
+ * Normalized activity state: one point per calendar day of the visible page
+ * plus paging controls and the request's load/error flags. `hasData`
+ * distinguishes the first load from refetches.
  */
 export interface PostTrafficActivityState {
 	days: DataPointDate[];
+	/** Whether the selected range exceeds one page (shows the pager). */
+	isPaged: boolean;
+	/** Whether an older page exists inside the selected range. */
+	canShowOlder: boolean;
+	/** Whether a newer page exists (the newest page is shown first). */
+	canShowNewer: boolean;
+	showOlder: () => void;
+	showNewer: () => void;
 	isLoading: boolean;
 	isFetching: boolean;
 	isError: boolean;
@@ -36,27 +44,27 @@ function toDay( value?: string ): string | undefined {
 }
 
 /**
- * Days the grid spans for short ranges (24 week columns). The design fills
- * the card with blank cells even when the selected range is short, so the
- * grid's first day is anchored at `range end − (GRID_SPAN_DAYS − 1)` and the
- * gap back to it is padded with blank filler weeks; values still render only
- * inside the selected range. Selections longer than the span use their own
- * length instead (the cell-width floor turns that into horizontal scroll).
- * At the chart's 44–88px cell-width bounds, 24 columns cover roughly
- * 1050–2100px of card width.
+ * Days one heatmap page spans (24 week columns). The design fills the card
+ * with blank cells even when the selected range is short, so a range at or
+ * under one page pads backward to `range end − (PAGE_SPAN_DAYS − 1)` with
+ * blank filler weeks. A longer range is paged: the newest page shows first
+ * and the header arrows step through the range one page at a time, the
+ * oldest page padding backward the same way. Values always render only
+ * inside the selected range. At the chart's 44–64px cell-width bounds, 24
+ * columns cover roughly 1050–1550px of card width.
  */
-const GRID_SPAN_DAYS = 168;
+const PAGE_SPAN_DAYS = 168;
 
 /**
  * Fetch the scoped post's daily view activity for the dashboard's report
- * params. Every calendar day of the grid gets a point so the heatmap stays
- * complete, but days without traffic — and the backfilled padding before a
- * short range — carry `null`: the design renders them as blank cells rather
- * than zero labels.
+ * params and expose one page of it. Every calendar day of the page gets a
+ * point so the heatmap grid stays complete, but days without traffic — and
+ * filler days outside the selected range — carry `null`: the design renders
+ * them as blank cells rather than zero labels.
  *
  * @param postId       - The scoped post ID (0 disables the request).
  * @param reportParams - The dashboard date range.
- * @return The daily activity points and load/error state.
+ * @return The visible page's daily points, paging controls, and load/error state.
  */
 export default function usePostTrafficActivity(
 	postId: number,
@@ -67,25 +75,28 @@ export default function usePostTrafficActivity(
 		fields: [ 'data' ],
 	} );
 
-	const days = useMemo< DataPointDate[] >( () => {
-		const history = data?.data ?? [];
-		const from = toDay( reportParams.from );
-		const to = toDay( reportParams.to );
+	// Pages step back from the range end; a new range starts at the newest page.
+	const [ pageOffset, setPageOffset ] = useState( 0 );
+	useEffect( () => {
+		setPageOffset( 0 );
+	}, [ reportParams.from, reportParams.to ] );
 
+	const from = toDay( reportParams.from );
+	const to = toDay( reportParams.to );
+
+	const { days, isPaged, canShowOlder } = useMemo( () => {
 		if ( ! from || ! to || from > to ) {
-			return [];
+			return { days: [] as DataPointDate[], isPaged: false, canShowOlder: false };
 		}
 
+		const history = data?.data ?? [];
 		const viewsByDay = new Map( history.map( day => [ day.date, day.views ] ) );
 
-		// Pad short ranges backward to the span's first day so the grid fills
-		// the card; the filler days stay blank regardless of history.
-		const end = parseISO( to );
 		const rangeStart = parseISO( from );
-		const paddedStart = subDays( end, GRID_SPAN_DAYS - 1 );
-		const gridStart = rangeStart < paddedStart ? rangeStart : paddedStart;
+		const pageEnd = subDays( parseISO( to ), pageOffset * PAGE_SPAN_DAYS );
+		const pageStart = subDays( pageEnd, PAGE_SPAN_DAYS - 1 );
 
-		return eachDayOfInterval( { start: gridStart, end } ).map( date => {
+		const points = eachDayOfInterval( { start: pageStart, end: pageEnd } ).map( date => {
 			const dateString = format( date, 'yyyy-MM-dd' );
 			const inRange = dateString >= from && dateString <= to;
 			const views = inRange ? viewsByDay.get( dateString ) : undefined;
@@ -94,10 +105,29 @@ export default function usePostTrafficActivity(
 			// not a `0` label.
 			return { dateString, value: views ? views : null };
 		} );
-	}, [ data, reportParams.from, reportParams.to ] );
+
+		return {
+			days: points,
+			isPaged: rangeStart < subDays( parseISO( to ), PAGE_SPAN_DAYS - 1 ),
+			canShowOlder: rangeStart < pageStart,
+		};
+	}, [ data, from, to, pageOffset ] );
+
+	const showOlder = useCallback( () => {
+		setPageOffset( offset => ( canShowOlder ? offset + 1 : offset ) );
+	}, [ canShowOlder ] );
+
+	const showNewer = useCallback( () => {
+		setPageOffset( offset => Math.max( 0, offset - 1 ) );
+	}, [] );
 
 	return {
 		days,
+		isPaged,
+		canShowOlder,
+		canShowNewer: pageOffset > 0,
+		showOlder,
+		showNewer,
 		isLoading,
 		isFetching,
 		isError,

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/use-post-traffic-activity.ts
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/use-post-traffic-activity.ts
@@ -36,12 +36,16 @@ function toDay( value?: string ): string | undefined {
 }
 
 /**
- * Minimum days the grid spans (~16 week columns). The design fills the card
- * with blank cells even when the selected range is short, so ranges below
- * this pad backward with blank filler weeks; the values still render only
- * inside the selected range.
+ * Days the grid spans for short ranges (24 week columns). The design fills
+ * the card with blank cells even when the selected range is short, so the
+ * grid's first day is anchored at `range end − (GRID_SPAN_DAYS − 1)` and the
+ * gap back to it is padded with blank filler weeks; values still render only
+ * inside the selected range. Selections longer than the span use their own
+ * length instead (the cell-width floor turns that into horizontal scroll).
+ * At the chart's 44–88px cell-width bounds, 24 columns cover roughly
+ * 1050–2100px of card width.
  */
-const MIN_GRID_DAYS = 112;
+const GRID_SPAN_DAYS = 168;
 
 /**
  * Fetch the scoped post's daily view activity for the dashboard's report
@@ -74,11 +78,11 @@ export default function usePostTrafficActivity(
 
 		const viewsByDay = new Map( history.map( day => [ day.date, day.views ] ) );
 
-		// Pad short ranges backward to the minimum span so the grid fills the
-		// card; the filler days stay blank regardless of history.
+		// Pad short ranges backward to the span's first day so the grid fills
+		// the card; the filler days stay blank regardless of history.
 		const end = parseISO( to );
 		const rangeStart = parseISO( from );
-		const paddedStart = subDays( end, MIN_GRID_DAYS - 1 );
+		const paddedStart = subDays( end, GRID_SPAN_DAYS - 1 );
 		const gridStart = rangeStart < paddedStart ? rangeStart : paddedStart;
 
 		return eachDayOfInterval( { start: gridStart, end } ).map( date => {

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/use-post-traffic-activity.ts
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/use-post-traffic-activity.ts
@@ -37,10 +37,9 @@ function toDay( value?: string ): string | undefined {
 
 /**
  * Fetch the scoped post's daily view activity for the dashboard's report
- * params. The `stats/post` daily history covers every day since publication
- * but omits zero-view days, so every calendar day of the window is
- * zero-seeded — the heatmap renders a complete grid, and pre-publication
- * days are genuinely zero views.
+ * params. Every calendar day of the window gets a point so the heatmap grid
+ * stays complete, but days without traffic carry `null` — the design leaves
+ * them as blank cells rather than zero labels.
  *
  * @param postId       - The scoped post ID (0 disables the request).
  * @param reportParams - The dashboard date range.
@@ -68,8 +67,10 @@ export default function usePostTrafficActivity(
 
 		return eachDayOfInterval( { start: parseISO( from ), end: parseISO( to ) } ).map( date => {
 			const dateString = format( date, 'yyyy-MM-dd' );
+			const views = viewsByDay.get( dateString );
 
-			return { dateString, value: viewsByDay.get( dateString ) ?? 0 };
+			// Blank (null) for no-traffic days, per the design — not a `0` label.
+			return { dateString, value: views ? views : null };
 		} );
 	}, [ data, reportParams.from, reportParams.to ] );
 

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/use-post-traffic-activity.ts
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/use-post-traffic-activity.ts
@@ -3,7 +3,7 @@
  */
 import { useStatsPost, type ReportParams } from '@jetpack-premium-analytics/data';
 import { useMemo } from '@wordpress/element';
-import { eachDayOfInterval, format, parseISO } from 'date-fns';
+import { eachDayOfInterval, format, parseISO, subDays } from 'date-fns';
 import type { DataPointDate } from '@jetpack-premium-analytics/widgets-toolkit';
 
 /**
@@ -36,10 +36,19 @@ function toDay( value?: string ): string | undefined {
 }
 
 /**
+ * Minimum days the grid spans (~16 week columns). The design fills the card
+ * with blank cells even when the selected range is short, so ranges below
+ * this pad backward with blank filler weeks; the values still render only
+ * inside the selected range.
+ */
+const MIN_GRID_DAYS = 112;
+
+/**
  * Fetch the scoped post's daily view activity for the dashboard's report
- * params. Every calendar day of the window gets a point so the heatmap grid
- * stays complete, but days without traffic carry `null` — the design leaves
- * them as blank cells rather than zero labels.
+ * params. Every calendar day of the grid gets a point so the heatmap stays
+ * complete, but days without traffic — and the backfilled padding before a
+ * short range — carry `null`: the design renders them as blank cells rather
+ * than zero labels.
  *
  * @param postId       - The scoped post ID (0 disables the request).
  * @param reportParams - The dashboard date range.
@@ -65,11 +74,20 @@ export default function usePostTrafficActivity(
 
 		const viewsByDay = new Map( history.map( day => [ day.date, day.views ] ) );
 
-		return eachDayOfInterval( { start: parseISO( from ), end: parseISO( to ) } ).map( date => {
-			const dateString = format( date, 'yyyy-MM-dd' );
-			const views = viewsByDay.get( dateString );
+		// Pad short ranges backward to the minimum span so the grid fills the
+		// card; the filler days stay blank regardless of history.
+		const end = parseISO( to );
+		const rangeStart = parseISO( from );
+		const paddedStart = subDays( end, MIN_GRID_DAYS - 1 );
+		const gridStart = rangeStart < paddedStart ? rangeStart : paddedStart;
 
-			// Blank (null) for no-traffic days, per the design — not a `0` label.
+		return eachDayOfInterval( { start: gridStart, end } ).map( date => {
+			const dateString = format( date, 'yyyy-MM-dd' );
+			const inRange = dateString >= from && dateString <= to;
+			const views = inRange ? viewsByDay.get( dateString ) : undefined;
+
+			// Blank (null) for no-traffic and filler days, per the design —
+			// not a `0` label.
 			return { dateString, value: views ? views : null };
 		} );
 	}, [ data, reportParams.from, reportParams.to ] );

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/use-post-traffic-activity.ts
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/use-post-traffic-activity.ts
@@ -44,42 +44,39 @@ function toDay( value?: string ): string | undefined {
 }
 
 /**
- * Days one heatmap page spans (24 week columns). The design fills the card
- * with blank cells even when the selected range is short, so a range at or
- * under one page pads backward to `range end − (PAGE_SPAN_DAYS − 1)` with
- * blank filler weeks. A longer range is paged: the newest page shows first
- * and the header arrows step through the range one page at a time, the
- * oldest page padding backward the same way. Values always render only
- * inside the selected range. At the chart's 44–64px cell-width bounds, 24
- * columns cover roughly 1050–1550px of card width.
- */
-const PAGE_SPAN_DAYS = 168;
-
-/**
  * Fetch the scoped post's daily view activity for the dashboard's report
- * params and expose one page of it. Every calendar day of the page gets a
- * point so the heatmap grid stays complete, but days without traffic — and
- * filler days outside the selected range — carry `null`: the design renders
- * them as blank cells rather than zero labels.
+ * params and expose one page of it. The caller derives `pageSpanDays` from
+ * the card width (whole week columns that fit), so one page always fills the
+ * card exactly: a range at or under one page pads backward to
+ * `range end − (pageSpanDays − 1)` with blank filler weeks, and a longer
+ * range is paged — the newest page shows first and the header arrows step
+ * through the range one page at a time, the oldest page padding backward the
+ * same way. Every calendar day of the page gets a point so the heatmap grid
+ * stays complete, but days without traffic — and filler days outside the
+ * selected range — carry `null`: the design renders them as blank cells
+ * rather than zero labels.
  *
  * @param postId       - The scoped post ID (0 disables the request).
  * @param reportParams - The dashboard date range.
+ * @param pageSpanDays - Days one page spans (a whole number of weeks).
  * @return The visible page's daily points, paging controls, and load/error state.
  */
 export default function usePostTrafficActivity(
 	postId: number,
-	reportParams: ReportParams
+	reportParams: ReportParams,
+	pageSpanDays: number
 ): PostTrafficActivityState {
 	const { data, isLoading, isFetching, isError, refetch } = useStatsPost( {
 		postId,
 		fields: [ 'data' ],
 	} );
 
-	// Pages step back from the range end; a new range starts at the newest page.
+	// Pages step back from the range end; a new range (or a resize that
+	// changes the page span) starts back at the newest page.
 	const [ pageOffset, setPageOffset ] = useState( 0 );
 	useEffect( () => {
 		setPageOffset( 0 );
-	}, [ reportParams.from, reportParams.to ] );
+	}, [ reportParams.from, reportParams.to, pageSpanDays ] );
 
 	const from = toDay( reportParams.from );
 	const to = toDay( reportParams.to );
@@ -93,8 +90,8 @@ export default function usePostTrafficActivity(
 		const viewsByDay = new Map( history.map( day => [ day.date, day.views ] ) );
 
 		const rangeStart = parseISO( from );
-		const pageEnd = subDays( parseISO( to ), pageOffset * PAGE_SPAN_DAYS );
-		const pageStart = subDays( pageEnd, PAGE_SPAN_DAYS - 1 );
+		const pageEnd = subDays( parseISO( to ), pageOffset * pageSpanDays );
+		const pageStart = subDays( pageEnd, pageSpanDays - 1 );
 
 		const points = eachDayOfInterval( { start: pageStart, end: pageEnd } ).map( date => {
 			const dateString = format( date, 'yyyy-MM-dd' );
@@ -108,10 +105,10 @@ export default function usePostTrafficActivity(
 
 		return {
 			days: points,
-			isPaged: rangeStart < subDays( parseISO( to ), PAGE_SPAN_DAYS - 1 ),
+			isPaged: rangeStart < subDays( parseISO( to ), pageSpanDays - 1 ),
 			canShowOlder: rangeStart < pageStart,
 		};
-	}, [ data, from, to, pageOffset ] );
+	}, [ data, from, to, pageOffset, pageSpanDays ] );
 
 	const showOlder = useCallback( () => {
 		setPageOffset( offset => ( canShowOlder ? offset + 1 : offset ) );

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/use-post-traffic-activity.ts
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/use-post-traffic-activity.ts
@@ -58,11 +58,12 @@ function toDay( value?: string ): string | undefined {
  * card exactly: a range at or under one page pads backward to
  * `range end − (pageSpanDays − 1)` with blank filler weeks, and a longer
  * range is paged — the newest page shows first and the header arrows step
- * through the range one page at a time, the oldest page padding backward the
- * same way. Every calendar day of the page gets a point so the heatmap grid
- * stays complete, but days without traffic — and filler days outside the
- * selected range — carry `null`: the design renders them as blank cells
- * rather than zero labels.
+ * through the range one page at a time. Days without traffic — and, on a
+ * short range, the backward-padding filler before the range — carry `null`:
+ * the design renders them as blank cells rather than zero labels. Days past
+ * the range end (and, when paging, before the range start) are omitted
+ * entirely, so the chart renders their week-completion slots as ragged
+ * edges instead of blanks.
  *
  * @param postId       - The scoped post ID (0 disables the request).
  * @param reportParams - The dashboard date range.
@@ -120,7 +121,17 @@ export default function usePostTrafficActivity(
 			pageEnd = clampedEnd < newestPageEnd ? clampedEnd : newestPageEnd;
 		}
 
-		const points = eachDayOfInterval( { start: pageStart, end: pageEnd } ).map( date => {
+		// Trim the emitted days to what should render as cells; the chart
+		// hides the week-completion slots outside them (ragged edges). Days
+		// past the range end always drop. Days before the range start drop
+		// only when paging — a short range keeps its backward padding, since
+		// those blanks are what fill the card.
+		const rangeStart = parseISO( from );
+		const rangeEnd = parseISO( to );
+		const visibleStart = paged && rangeStart > pageStart ? rangeStart : pageStart;
+		const visibleEnd = rangeEnd < pageEnd ? rangeEnd : pageEnd;
+
+		const points = eachDayOfInterval( { start: visibleStart, end: visibleEnd } ).map( date => {
 			const dateString = format( date, 'yyyy-MM-dd' );
 			const inRange = dateString >= from && dateString <= to;
 			const views = inRange ? viewsByDay.get( dateString ) : undefined;

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/use-post-traffic-activity.ts
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/use-post-traffic-activity.ts
@@ -3,7 +3,7 @@
  */
 import { useStatsPost, type ReportParams } from '@jetpack-premium-analytics/data';
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
-import { eachDayOfInterval, format, parseISO, subDays } from 'date-fns';
+import { addDays, eachDayOfInterval, format, parseISO, subDays } from 'date-fns';
 import type { DataPointDate } from '@jetpack-premium-analytics/widgets-toolkit';
 
 /**
@@ -90,8 +90,21 @@ export default function usePostTrafficActivity(
 		const viewsByDay = new Map( history.map( day => [ day.date, day.views ] ) );
 
 		const rangeStart = parseISO( from );
-		const pageEnd = subDays( parseISO( to ), pageOffset * pageSpanDays );
-		const pageStart = subDays( pageEnd, pageSpanDays - 1 );
+		const rangeEnd = parseISO( to );
+		const paged = rangeStart < subDays( rangeEnd, pageSpanDays - 1 );
+
+		let pageEnd = subDays( rangeEnd, pageOffset * pageSpanDays );
+		let pageStart = subDays( pageEnd, pageSpanDays - 1 );
+
+		// The oldest page of a paged range clamps to the range start and fills
+		// forward (overlapping the previous page), instead of padding months of
+		// out-of-range blanks before it. Short ranges keep padding backward
+		// from the range end so the grid still fills the card.
+		if ( paged && pageStart < rangeStart ) {
+			pageStart = rangeStart;
+			const clampedEnd = addDays( rangeStart, pageSpanDays - 1 );
+			pageEnd = clampedEnd < rangeEnd ? clampedEnd : rangeEnd;
+		}
 
 		const points = eachDayOfInterval( { start: pageStart, end: pageEnd } ).map( date => {
 			const dateString = format( date, 'yyyy-MM-dd' );
@@ -105,7 +118,7 @@ export default function usePostTrafficActivity(
 
 		return {
 			days: points,
-			isPaged: rangeStart < subDays( parseISO( to ), pageSpanDays - 1 ),
+			isPaged: paged,
 			canShowOlder: rangeStart < pageStart,
 		};
 	}, [ data, from, to, pageOffset, pageSpanDays ] );

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/use-post-traffic-activity.ts
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/use-post-traffic-activity.ts
@@ -3,7 +3,15 @@
  */
 import { useStatsPost, type ReportParams } from '@jetpack-premium-analytics/data';
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
-import { addDays, eachDayOfInterval, format, parseISO, subDays } from 'date-fns';
+import {
+	addDays,
+	eachDayOfInterval,
+	endOfWeek,
+	format,
+	parseISO,
+	startOfWeek,
+	subDays,
+} from 'date-fns';
 import type { DataPointDate } from '@jetpack-premium-analytics/widgets-toolkit';
 
 /**
@@ -89,21 +97,27 @@ export default function usePostTrafficActivity(
 		const history = data?.data ?? [];
 		const viewsByDay = new Map( history.map( day => [ day.date, day.views ] ) );
 
-		const rangeStart = parseISO( from );
-		const rangeEnd = parseISO( to );
-		const paged = rangeStart < subDays( rangeEnd, pageSpanDays - 1 );
+		// Pages snap to week boundaries: the chart grids Monday-start week
+		// columns from the window's first week, so an unaligned window would
+		// span one more column than the width measurement sized the card for.
+		// With both bounds aligned, a page is exactly `pageSpanDays / 7`
+		// columns; the days past the range edges inside those weeks stay
+		// blank filler.
+		const firstWeekStart = startOfWeek( parseISO( from ), { weekStartsOn: 1 } );
+		const newestPageEnd = endOfWeek( parseISO( to ), { weekStartsOn: 1 } );
+		const paged = firstWeekStart < subDays( newestPageEnd, pageSpanDays - 1 );
 
-		let pageEnd = subDays( rangeEnd, pageOffset * pageSpanDays );
+		let pageEnd = subDays( newestPageEnd, pageOffset * pageSpanDays );
 		let pageStart = subDays( pageEnd, pageSpanDays - 1 );
 
-		// The oldest page of a paged range clamps to the range start and fills
-		// forward (overlapping the previous page), instead of padding months of
-		// out-of-range blanks before it. Short ranges keep padding backward
-		// from the range end so the grid still fills the card.
-		if ( paged && pageStart < rangeStart ) {
-			pageStart = rangeStart;
-			const clampedEnd = addDays( rangeStart, pageSpanDays - 1 );
-			pageEnd = clampedEnd < rangeEnd ? clampedEnd : rangeEnd;
+		// The oldest page of a paged range clamps to the range's first week
+		// and fills forward (overlapping the previous page), instead of
+		// padding months of out-of-range blanks before it. Short ranges keep
+		// padding backward from the range end so the grid still fills the card.
+		if ( paged && pageStart < firstWeekStart ) {
+			pageStart = firstWeekStart;
+			const clampedEnd = addDays( firstWeekStart, pageSpanDays - 1 );
+			pageEnd = clampedEnd < newestPageEnd ? clampedEnd : newestPageEnd;
 		}
 
 		const points = eachDayOfInterval( { start: pageStart, end: pageEnd } ).map( date => {
@@ -119,7 +133,7 @@ export default function usePostTrafficActivity(
 		return {
 			days: points,
 			isPaged: paged,
-			canShowOlder: rangeStart < pageStart,
+			canShowOlder: firstWeekStart < pageStart,
 		};
 	}, [ data, from, to, pageOffset, pageSpanDays ] );
 

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/use-post-traffic-activity.ts
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/use-post-traffic-activity.ts
@@ -58,12 +58,11 @@ function toDay( value?: string ): string | undefined {
  * card exactly: a range at or under one page pads backward to
  * `range end − (pageSpanDays − 1)` with blank filler weeks, and a longer
  * range is paged — the newest page shows first and the header arrows step
- * through the range one page at a time. Days without traffic — and, on a
- * short range, the backward-padding filler before the range — carry `null`:
- * the design renders them as blank cells rather than zero labels. Days past
- * the range end (and, when paging, before the range start) are omitted
- * entirely, so the chart renders their week-completion slots as ragged
- * edges instead of blanks.
+ * through the range one page at a time, the oldest page padding backward the
+ * same way. Every calendar day of the page gets a point so the heatmap grid
+ * stays complete, but days without traffic — and filler days outside the
+ * selected range — carry `null`: the design renders them as blank cells
+ * rather than zero labels.
  *
  * @param postId       - The scoped post ID (0 disables the request).
  * @param reportParams - The dashboard date range.
@@ -121,17 +120,7 @@ export default function usePostTrafficActivity(
 			pageEnd = clampedEnd < newestPageEnd ? clampedEnd : newestPageEnd;
 		}
 
-		// Trim the emitted days to what should render as cells; the chart
-		// hides the week-completion slots outside them (ragged edges). Days
-		// past the range end always drop. Days before the range start drop
-		// only when paging — a short range keeps its backward padding, since
-		// those blanks are what fill the card.
-		const rangeStart = parseISO( from );
-		const rangeEnd = parseISO( to );
-		const visibleStart = paged && rangeStart > pageStart ? rangeStart : pageStart;
-		const visibleEnd = rangeEnd < pageEnd ? rangeEnd : pageEnd;
-
-		const points = eachDayOfInterval( { start: visibleStart, end: visibleEnd } ).map( date => {
+		const points = eachDayOfInterval( { start: pageStart, end: pageEnd } ).map( date => {
 			const dateString = format( date, 'yyyy-MM-dd' );
 			const inRange = dateString >= from && dateString <= to;
 			const views = inRange ? viewsByDay.get( dateString ) : undefined;

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/widget.json
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/widget.json
@@ -1,0 +1,7 @@
+{
+	"name": "jpa/post-traffic-activity",
+	"title": "Traffic activity",
+	"description": "Daily views for the post or page being viewed, as a calendar heatmap.",
+	"category": "stats",
+	"presentation": "framed"
+}

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/widget.ts
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/widget.ts
@@ -20,8 +20,8 @@ export type PostTrafficActivityAttributes = Record< never, never >;
  * The post detail Traffic view's activity card, replacing the legacy Calypso
  * post detail months table (`post-detail-table-section`) per the new design:
  * the scoped post's daily views over the dashboard date range as a calendar
- * heatmap — week columns, weekday rows, view counts in the cells. Days the
- * endpoint omits are zero-filled so the grid stays complete.
+ * heatmap — week columns, weekday rows, view counts in the cells. Days without
+ * traffic stay blank cells, per the design, while the grid stays complete.
  */
 export default {
 	name: 'jpa/post-traffic-activity',

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/widget.ts
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/widget.ts
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { calendar } from '@wordpress/icons';
+import type { WidgetAttributeField } from '@wordpress/widget-primitives';
+
+/**
+ * The Traffic activity widget has no configurable attributes: it always shows
+ * the daily view heatmap of the post the page is scoped to (via
+ * `reportParams.post_id`). `Record< never, never >` (not
+ * `Record< string, never >`) so the render-only type can compose host fields
+ * such as `reportParams` without collapsing them to `never`.
+ */
+export type PostTrafficActivityAttributes = Record< never, never >;
+
+/**
+ * Widget type definition.
+ *
+ * The post detail Traffic view's activity card, replacing the legacy Calypso
+ * post detail months table (`post-detail-table-section`) per the new design:
+ * the scoped post's daily views over the dashboard date range as a calendar
+ * heatmap — week columns, weekday rows, view counts in the cells. Days the
+ * endpoint omits are zero-filled so the grid stays complete.
+ */
+export default {
+	name: 'jpa/post-traffic-activity',
+	title: __( 'Traffic activity', 'jetpack-premium-analytics' ),
+	help: {
+		content: __(
+			'Daily views for the post or page being viewed, as a calendar heatmap.',
+			'jetpack-premium-analytics'
+		),
+	},
+	icon: calendar,
+	attributes: [] as WidgetAttributeField< PostTrafficActivityAttributes >[],
+	example: {
+		attributes: {},
+	},
+};


### PR DESCRIPTION
Part of [WOOA7S-1527](https://linear.app/a8c/issue/WOOA7S-1527/port-jetpack-stats-card-post-detail-table). Based on trunk, on top of the merged #50457 / #50488 / #50487.

## Why

The post detail Traffic view is missing the legacy months table's job — showing when a post gets its traffic. The new design reimagines that card as a **Traffic activity calendar heatmap** (week columns, weekday rows, daily view counts in the cells), so this ports the data onto that shape instead of reproducing the months × years table.

## Proposed changes

* New `jpa/post-traffic-activity` widget: the scoped post's daily views over the dashboard date range as a calendar heatmap, through the shared `HeatmapChart` + `buildCalendarHeatmapData` (the same stack as the posting-activity widget), with view counts rendered in the cells and an admin-theme `primaryColor` scale.
* Data rides the `stats/post` daily history already in the data layer (no new endpoints). Every calendar day of the window gets a cell so the grid stays complete, but days without traffic render as blank cells (no zero labels), per the design's sparse-data treatment.
* The fixed Traffic layout places the card full width × 2 rows on its own row, below the likes row (the rest of which is reserved for the upcoming comments and UTM cards).
* Paging per the design: one page spans the whole week columns that fit the measured card width at the design's 64×42 cells (ResizeObserver on the widget root). A range at or under one page pads backward with blank filler weeks so the grid always fills the card; a longer range shows its newest page first with chevrons stepping through it (rendered only when there is more than one page), and the oldest page clamps to the range's first week. Pages snap to Monday-start week boundaries so a page lays out exactly its measured column count; values render only inside the selected range. The pager + grid center as one block in the tile, via the unresponsive chart export (the capped grid is content-sized; `HeatmapChart` gains min/max cell-size bounds and content-sized capped layout in `@automattic/charts`).
* Storybook: `Default` / `NoPostScope` / `WidgetDashboardWithWidget` (production 4×2) stories over the shared `stats-post` fixture; hook tests cover the week-aligned page padding, long-range paging with the oldest-page clamp, malformed bounds, and the scopeless no-fetch guard.

## Does this pull request change what data or activity we track or use?

No. The widget reads the existing `stats/post` endpoint through the established proxy; the daily history field is already served.

## Verification

`pnpm run typecheck`, eslint, and the hook tests pass; post-detail route tests still pass with the layout change. Exercised against a live post-detail page on a local docker env.

## Testing instructions

* From `projects/packages/premium-analytics`: `pnpm run typecheck`, `pnpm run test widgets/post-traffic-activity routes/post-detail`.
* Storybook: `Packages/Premium Analytics/Widgets/PostTrafficActivity` — `Default` shows the heatmap over the fixture's daily series; `NoPostScope` shows the scopeless empty state.
* On a Jetpack-connected site: open a post detail page (`admin.php?page=jetpack-premium-analytics-wp-admin&p=%2Fpost%2F<post-id>`) — the Traffic activity card renders full width on its own row below Latest likes, every day of the selected range has a cell, with no-traffic days blank, and the counts match the same post's daily views on the legacy Stats post detail page.
* Select a long range (e.g. a year): chevrons appear above the grid and step through it page by page — the oldest page starts at the range's first week; on a short range the pager is absent and the grid pads back to a full page of blank cells. Resize the browser: the page re-fits to the card and returns to the newest page.

### Screenshots

#### Data of period from `2025/07/13` to `2026/07/15`
|First table|Last table|
|-|-|
|<img width="1316" height="650" alt="截圖 2026-07-15 中午12 24 05" src="https://github.com/user-attachments/assets/27e08576-f2ac-4267-ae7b-95fcb203c830" />|<img width="1317" height="652" alt="截圖 2026-07-15 中午12 23 41" src="https://github.com/user-attachments/assets/810db07d-fcd8-4648-8451-f94d468bdd7d" />|

#### Data less than one table
<img width="1316" height="653" alt="截圖 2026-07-15 中午12 29 24" src="https://github.com/user-attachments/assets/d21448e7-5fd4-4960-beb3-fe8538acd432" />

