### PR TITLE
Jetpack AI Sidebar: enable block toolbar button for internal test users

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-sidebar-block-toolbar-button-flag
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-sidebar-block-toolbar-button-flag
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Gate the AI sidebar block toolbar button feature flag (blockToolbarButton) on internal testing environments instead of hardcoding it off. Exposed in internal testing environments only; no user-facing change, so the changelog entry is intentionally empty.
+
+

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -363,6 +363,17 @@ class Jetpack_AI_Sidebar {
 	}
 
 	/**
+	 * UI feature flag for the block toolbar button that replaces the legacy AI toolbar.
+	 *
+	 * Exposed only in internal testing environments while the feature is in development.
+	 *
+	 * @return bool
+	 */
+	private static function is_block_toolbar_button_enabled(): bool {
+		return jetpack_is_internal_testing_environment();
+	}
+
+	/**
 	 * Whether the site's plan includes the Jetpack SEO feature.
 	 *
 	 * Same predicate the SEO editor panel uses to decide between the SEO fields and
@@ -455,7 +466,7 @@ class Jetpack_AI_Sidebar {
 			'generateFeedback'        => self::is_generate_feedback_enabled(),
 			'proofreadContent'        => self::is_proofread_content_enabled(),
 			'blockTransformations'    => true,
-			'blockToolbarButton'      => false,
+			'blockToolbarButton'      => self::is_block_toolbar_button_enabled(),
 			'optimizeTitleSuggestion' => self::is_optimize_title_suggestion_enabled(),
 			'seoSuggestions'          => self::is_seo_suggestions_enabled(),
 			'excerptSuggestion'       => self::is_excerpt_suggestion_enabled(),
@@ -476,6 +487,7 @@ class Jetpack_AI_Sidebar {
 		$features['generateFeedback']        = self::is_generate_feedback_enabled();
 		$features['proofreadContent']        = self::is_proofread_content_enabled();
 		$features['optimizeTitleSuggestion'] = (bool) $features['optimizeTitleSuggestion'] && self::is_optimize_title_suggestion_enabled();
+		$features['blockToolbarButton']      = (bool) $features['blockToolbarButton'] && self::is_block_toolbar_button_enabled();
 		$features['seoSuggestions']          = (bool) $features['seoSuggestions'] && self::is_seo_suggestions_enabled();
 		$features['excerptSuggestion']       = (bool) $features['excerptSuggestion'] && self::is_excerpt_suggestion_enabled();
 

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -541,6 +541,34 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the toolbar button is exposed by default in internal testing environments,
+	 * without needing the preview feature filter.
+	 */
+	public function test_toolbar_button_enabled_by_default_in_internal_testing() {
+		$this->set_block_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+
+		$this->assertTrue( Jetpack_AI_Sidebar::is_toolbar_button_enabled() );
+	}
+
+	/**
+	 * Test that a host filter can still force the toolbar button off inside internal testing.
+	 */
+	public function test_toolbar_button_filter_can_force_off_in_internal_testing() {
+		$this->set_block_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		add_filter(
+			'jetpack_ai_sidebar_preview_features',
+			static function ( $features ) {
+				$features['blockToolbarButton'] = false;
+				return $features;
+			}
+		);
+
+		$this->assertFalse( Jetpack_AI_Sidebar::is_toolbar_button_enabled() );
+	}
+
+	/**
 	 * Test that the preview feature flag activates the toolbar button.
 	 */
 	public function test_toolbar_button_enabled_by_preview_feature_flag() {
@@ -776,11 +804,11 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertSame( true, $data['jetpackAiSidebar']['enabled'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['aiEditorialReview'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['blockTransformations'] );
-		$this->assertSame( false, $data['jetpackAiSidebar']['features']['blockToolbarButton'] );
+		$this->assertSame( true, $data['jetpackAiSidebar']['features']['blockToolbarButton'] );
 		// A8C_PROXIED_REQUEST marks an internal testing environment, which is the same gate that
 		// emits this payload at all, so the in-development Generate Feedback, Optimize Title,
-		// and Excerpt suggestions are exposed here. SEO suggestions stay off because the
-		// seo-tools module and plan gate are not satisfied in this test.
+		// Excerpt, and block toolbar button features are exposed here. SEO suggestions stay off
+		// because the seo-tools module and plan gate are not satisfied in this test.
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['generateFeedback'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['optimizeTitleSuggestion'] );
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['seoSuggestions'] );
@@ -997,7 +1025,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertSame( true, $data['jetpackAiSidebar']['enabled'] );
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['aiEditorialReview'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['blockTransformations'] );
-		$this->assertSame( false, $data['jetpackAiSidebar']['features']['blockToolbarButton'] );
+		// A8C_PROXIED_REQUEST marks an internal testing environment, so the in-development block
+		// toolbar button feature is exposed here even though AI Editorial Review is filtered off.
+		$this->assertSame( true, $data['jetpackAiSidebar']['features']['blockToolbarButton'] );
 	}
 
 	/**


### PR DESCRIPTION
Relates to FORNO-335

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* For internal a8c users, this PR replaces the existing Jetpack AI block toolbar button with a new one which launches the Jetpack AI sidebar.



Before
<img width="448" height="82" alt="Screenshot 2026-07-15 at 17 14 28" src="https://github.com/user-attachments/assets/b2ac9e21-fb2b-42d6-b748-6edc12dcc44d" />


After
<img width="477" height="64" alt="Screenshot 2026-07-15 at 17 13 39" src="https://github.com/user-attachments/assets/9f78783a-7271-42a6-8a76-9d10d0892813" />


## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* p1783953541571429-slack-CLKJLBFB8

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* `bin/jetpack-downloader test jetpack add/jetpack-ai-sidebar-block-toolbar-button-internal` on your sandbox
* Sandbox your test site
* Open a post and select a block in the editor
* Verify the Jetpack sparkle icon is hidden and the Big Sky sparkle icon is displayed instead in the block toolbar
* Click the button and verify it opens the sitebar chat
