### PR TITLE
Charts: add hidden heatmap cells for ragged calendar edges

### DIFF
--- a/projects/js-packages/charts/changelog/add-heatmap-hidden-cells
+++ b/projects/js-packages/charts/changelog/add-heatmap-hidden-cells
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Charts: add hidden heatmap cells for ragged calendar edges — buildCalendarHeatmapData's hideOutOfRangeDays option renders week-completion days outside the series' span as empty grid slots skipped by hover and keyboard navigation.

--- a/projects/js-packages/charts/changelog/add-heatmap-hidden-cells
+++ b/projects/js-packages/charts/changelog/add-heatmap-hidden-cells
@@ -1,4 +1,4 @@
 Significance: patch
-Type: added
+Type: changed
 
-Charts: add hidden heatmap cells for ragged calendar edges — buildCalendarHeatmapData's hideOutOfRangeDays option renders week-completion days outside the series' span as empty grid slots skipped by hover and keyboard navigation.
+Charts: make calendar heatmaps render ragged edges by default, with out-of-range days skipped by hover and keyboard navigation.

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
@@ -87,6 +87,13 @@
 	background: var(--wpds-color-background-track-neutral-weak, #f0f0f0);
 }
 
+// An empty grid slot (calendar ragged edges): keeps its track but paints and
+// captures nothing. `visibility` (not `display`) so the slot still sizes.
+.heatmap-chart__cell--hidden {
+	visibility: hidden;
+	pointer-events: none;
+}
+
 // Floor the mix at 15% so the lowest value stays visibly tinted, distinct from
 // an empty cell.
 .heatmap-chart__cell--filled {

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
@@ -129,6 +129,11 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 		hideTooltip();
 	}, [ hideTooltip ] );
 
+	const isCellHidden = useCallback(
+		( col: number, row: number ) => data[ col ]?.data[ row ]?.hidden === true,
+		[ data ]
+	);
+
 	const onChartKeyDown = useCallback(
 		( event: React.KeyboardEvent< HTMLDivElement > ) => {
 			if (
@@ -148,26 +153,46 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 			event.preventDefault();
 
 			if ( selectedIndex === undefined ) {
-				setSelectedIndex( 0 );
+				// Start at the first navigable cell (a calendar's leading edge
+				// slots may be hidden).
+				for ( let index = 0; index < columns * rows; index++ ) {
+					if ( ! isCellHidden( Math.floor( index / rows ), index % rows ) ) {
+						setSelectedIndex( index );
+						return;
+					}
+				}
 				return;
 			}
 
+			let stepCol = 0;
+			let stepRow = 0;
+			if ( event.key === 'ArrowRight' ) {
+				stepCol = 1;
+			} else if ( event.key === 'ArrowLeft' ) {
+				stepCol = -1;
+			} else if ( event.key === 'ArrowDown' ) {
+				stepRow = 1;
+			} else if ( event.key === 'ArrowUp' ) {
+				stepRow = -1;
+			}
+
+			// Step past hidden slots to the next navigable cell in the pressed
+			// direction; when only hidden slots (or the edge) remain that way,
+			// the selection stays put.
 			let col = Math.floor( selectedIndex / rows );
 			let row = selectedIndex % rows;
+			do {
+				col += stepCol;
+				row += stepRow;
+			} while ( col >= 0 && col < columns && row >= 0 && row < rows && isCellHidden( col, row ) );
 
-			if ( event.key === 'ArrowRight' ) {
-				col = Math.min( col + 1, columns - 1 );
-			} else if ( event.key === 'ArrowLeft' ) {
-				col = Math.max( col - 1, 0 );
-			} else if ( event.key === 'ArrowDown' ) {
-				row = Math.min( row + 1, rows - 1 );
-			} else if ( event.key === 'ArrowUp' ) {
-				row = Math.max( row - 1, 0 );
+			if ( col < 0 || col >= columns || row < 0 || row >= rows ) {
+				return;
 			}
 
 			setSelectedIndex( col * rows + row );
 		},
-		[ rows, columns, selectedIndex, hideTooltip ]
+		[ rows, columns, selectedIndex, hideTooltip, isCellHidden ]
 	);
 
 	const handleCellMouseMove = useCallback(
@@ -341,6 +366,24 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 									</span>
 									{ data.map( ( column, columnIndex ) => {
 										const cell = column.data[ rowIndex ];
+
+										// A hidden cell keeps its grid slot (so the rest of the
+										// column doesn't shift) but paints nothing and takes no
+										// interaction — a calendar's ragged edges.
+										if ( cell?.hidden ) {
+											return (
+												<div
+													key={ `cell-${ columnIndex }-${ rowIndex }` }
+													data-testid="heatmap-cell-hidden"
+													aria-hidden="true"
+													className={ clsx(
+														styles[ 'heatmap-chart__cell' ],
+														styles[ 'heatmap-chart__cell--hidden' ]
+													) }
+												/>
+											);
+										}
+
 										const value = cell?.value ?? null;
 										const present = isPresent( value );
 										const normalized = present ? getNormalizedValue( value, extent ) : 0;

--- a/projects/js-packages/charts/src/charts/heatmap-chart/private/build-calendar-data.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/private/build-calendar-data.ts
@@ -37,7 +37,7 @@ export const buildCalendarHeatmapData = (
 	} = {}
 ): CalendarHeatmapResult => {
 	const weekStartsOn = options.weekStartsOn ?? 1;
-	const hideOutOfRangeDays = options.hideOutOfRangeDays ?? false;
+	const hideOutOfRangeDays = options.hideOutOfRangeDays ?? true;
 
 	const entries = series
 		.map( point => ( { date: toDate( point ), value: point.value } ) )

--- a/projects/js-packages/charts/src/charts/heatmap-chart/private/build-calendar-data.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/private/build-calendar-data.ts
@@ -25,9 +25,19 @@ const toDate = ( point: DataPointDate ): Date | null => {
 
 export const buildCalendarHeatmapData = (
 	series: DataPointDate[],
-	options: { weekStartsOn?: 0 | 1 } = {}
+	options: {
+		weekStartsOn?: 0 | 1;
+		/**
+		 * Mark the days completing the first/last week outside the series'
+		 * date span as hidden cells (empty grid slots) instead of blank
+		 * cells, giving the calendar ragged edges. Days inside the span stay
+		 * blank cells even when the series has no entry for them.
+		 */
+		hideOutOfRangeDays?: boolean;
+	} = {}
 ): CalendarHeatmapResult => {
 	const weekStartsOn = options.weekStartsOn ?? 1;
+	const hideOutOfRangeDays = options.hideOutOfRangeDays ?? false;
 
 	const entries = series
 		.map( point => ( { date: toDate( point ), value: point.value } ) )
@@ -52,6 +62,11 @@ export const buildCalendarHeatmapData = (
 
 	const gridStart = startOfWeek( minDate, { weekStartsOn } );
 	const weekCount = differenceInCalendarWeeks( maxDate, gridStart, { weekStartsOn } ) + 1;
+
+	// Day-key bounds for the ragged-edge option: calendar-day comparison, so
+	// entries carrying a time of day can't shift the span.
+	const minDayKey = format( minDate, 'yyyy-MM-dd' );
+	const maxDayKey = format( maxDate, 'yyyy-MM-dd' );
 
 	const rowLabels = Array.from( { length: 7 }, ( _, row ) =>
 		LABELLED_ROWS.includes( row ) ? format( addDays( gridStart, row ), 'EEE' ) : ''
@@ -85,10 +100,14 @@ export const buildCalendarHeatmapData = (
 		for ( let row = 0; row < 7; row++ ) {
 			const day = addDays( gridStart, week * 7 + row );
 			const key = format( day, 'yyyy-MM-dd' );
-			cells.push( {
+			const cell: HeatmapCell = {
 				label: format( day, 'EEE, MMM d, yyyy' ),
 				value: valueByDay.has( key ) ? ( valueByDay.get( key ) as number | null ) : null,
-			} );
+			};
+			if ( hideOutOfRangeDays && ( key < minDayKey || key > maxDayKey ) ) {
+				cell.hidden = true;
+			}
+			cells.push( cell );
 		}
 		data.push( { label, data: cells } );
 	}

--- a/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.api.mdx
@@ -122,7 +122,7 @@ function buildCalendarHeatmapData(
 | --------- | ---- | ------- | ----------- |
 | `series` | `DataPointDate[]` | - | **Required.** Array of data points with a `date` (or `dateString`) and a numeric `value`. |
 | `options.weekStartsOn` | `0 \| 1` | `1` | Day the week starts on: `0` = Sunday, `1` = Monday. |
-| `options.hideOutOfRangeDays` | `boolean` | `false` | Mark the week-completion days outside the series' date span as hidden cells (empty grid slots) instead of blank cells, giving the calendar ragged edges. |
+| `options.hideOutOfRangeDays` | `boolean` | `true` | Mark the week-completion days outside the series' date span as hidden cells (empty grid slots) instead of blank cells, giving the calendar ragged edges. Pass `false` to keep them as blank cells. |
 
 **Returns:** `CalendarHeatmapResult`
 

--- a/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.api.mdx
@@ -73,6 +73,12 @@ type HeatmapCell = {
 	label?: string;
 	/** Numeric value. Use null to mark an empty / missing cell. */
 	value: number | null;
+	/**
+	 * Leave the cell's grid slot empty: nothing is painted and the cell is
+	 * skipped by hover and keyboard navigation, while the slot keeps its
+	 * place so the rest of the grid doesn't shift.
+	 */
+	hidden?: boolean;
 };
 ```
 
@@ -106,7 +112,7 @@ Utility function that converts a flat time-series into the `HeatmapColumn[]` / `
 ```typescript
 function buildCalendarHeatmapData(
 	series: DataPointDate[],
-	options?: { weekStartsOn?: 0 | 1 }
+	options?: { weekStartsOn?: 0 | 1; hideOutOfRangeDays?: boolean }
 ): CalendarHeatmapResult
 ```
 
@@ -116,6 +122,7 @@ function buildCalendarHeatmapData(
 | --------- | ---- | ------- | ----------- |
 | `series` | `DataPointDate[]` | - | **Required.** Array of data points with a `date` (or `dateString`) and a numeric `value`. |
 | `options.weekStartsOn` | `0 \| 1` | `1` | Day the week starts on: `0` = Sunday, `1` = Monday. |
+| `options.hideOutOfRangeDays` | `boolean` | `false` | Mark the week-completion days outside the series' date span as hidden cells (empty grid slots) instead of blank cells, giving the calendar ragged edges. |
 
 **Returns:** `CalendarHeatmapResult`
 

--- a/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.docs.mdx
@@ -171,9 +171,7 @@ Use `buildCalendarHeatmapData` to convert a flat `DataPointDate[]` series into t
 `buildCalendarHeatmapData` accepts an optional `options` object:
 
 - **`weekStartsOn`** (`0 | 1`, default `1`): `0` = Sunday, `1` = Monday
-- **`hideOutOfRangeDays`** (`boolean`, default `false`): render the week-completion days outside the series' date span as empty grid slots instead of blank cells, giving the calendar ragged edges. Days inside the span stay blank cells even when the series has no entry for them. Hidden slots keep their grid position but paint nothing, and hover and keyboard navigation skip them.
-
-<Canvas of={ HeatmapStories.CalendarRaggedEdges } />
+- **`hideOutOfRangeDays`** (`boolean`, default `true`): render the week-completion days outside the series' date span as empty grid slots instead of blank cells, giving the calendar ragged edges. Days inside the span stay blank cells even when the series has no entry for them. Hidden slots keep their grid position but paint nothing, and hover and keyboard navigation skip them. Pass `false` to keep out-of-range days as blank cells.
 
 ## Fixed Dimensions
 

--- a/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.docs.mdx
@@ -171,6 +171,9 @@ Use `buildCalendarHeatmapData` to convert a flat `DataPointDate[]` series into t
 `buildCalendarHeatmapData` accepts an optional `options` object:
 
 - **`weekStartsOn`** (`0 | 1`, default `1`): `0` = Sunday, `1` = Monday
+- **`hideOutOfRangeDays`** (`boolean`, default `false`): render the week-completion days outside the series' date span as empty grid slots instead of blank cells, giving the calendar ragged edges. Days inside the span stay blank cells even when the series has no entry for them. Hidden slots keep their grid position but paint nothing, and hover and keyboard navigation skip them.
+
+<Canvas of={ HeatmapStories.CalendarRaggedEdges } />
 
 ## Fixed Dimensions
 

--- a/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.stories.tsx
@@ -109,6 +109,35 @@ export const Calendar: StoryObj< StoryArgs & { weekStartsOn: 0 | 1 } > = {
 	},
 };
 
+// The ragged-edge option: week-completion days outside the series' span
+// render as empty slots instead of blank cells.
+export const CalendarRaggedEdges: StoryObj<
+	StoryArgs & { weekStartsOn: 0 | 1; hideOutOfRangeDays: boolean }
+> = {
+	render: ( { weekStartsOn, hideOutOfRangeDays, ...args } ) => {
+		// A mid-week span (Wed → Wed) so both calendar edges are ragged.
+		const { data, rowLabels } = buildCalendarHeatmapData( heatmapCalendarSeries.slice( 2, 115 ), {
+			weekStartsOn,
+			hideOutOfRangeDays,
+		} );
+		return <HeatmapChart { ...args } data={ data } rowLabels={ rowLabels } />;
+	},
+	args: {
+		...sharedThemeArgs,
+		withTooltips: true,
+		weekStartsOn: 1,
+		hideOutOfRangeDays: true,
+	},
+	argTypes: {
+		weekStartsOn: {
+			control: { type: 'inline-radio', labels: { 0: 'Sunday', 1: 'Monday' } },
+			options: [ 1, 0 ],
+			table: { category: 'Calendar' },
+		},
+		hideOutOfRangeDays: { control: 'boolean', table: { category: 'Calendar' } },
+	},
+};
+
 // Regression story for a one-column first month label in compact mode.
 export const CompactCalendarPartialMonth: StoryObj< StoryArgs & { weekStartsOn: 0 | 1 } > = {
 	render: ( { weekStartsOn, ...args } ) => {

--- a/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/stories/index.stories.tsx
@@ -92,30 +92,11 @@ export const MinimumCellSize: Story = {
 	},
 };
 
-export const Calendar: StoryObj< StoryArgs & { weekStartsOn: 0 | 1 } > = {
-	render: ( { weekStartsOn, ...args } ) => {
-		const { data, rowLabels } = buildCalendarHeatmapData( heatmapCalendarSeries, {
-			weekStartsOn,
-		} );
-		return <HeatmapChart { ...args } data={ data } rowLabels={ rowLabels } />;
-	},
-	args: { ...sharedThemeArgs, withTooltips: true, weekStartsOn: 1 },
-	argTypes: {
-		weekStartsOn: {
-			control: { type: 'inline-radio', labels: { 0: 'Sunday', 1: 'Monday' } },
-			options: [ 1, 0 ],
-			table: { category: 'Calendar' },
-		},
-	},
-};
-
-// The ragged-edge option: week-completion days outside the series' span
-// render as empty slots instead of blank cells.
-export const CalendarRaggedEdges: StoryObj<
+export const Calendar: StoryObj<
 	StoryArgs & { weekStartsOn: 0 | 1; hideOutOfRangeDays: boolean }
 > = {
 	render: ( { weekStartsOn, hideOutOfRangeDays, ...args } ) => {
-		// A mid-week span (Wed → Wed) so both calendar edges are ragged.
+		// A mid-week span (Wed to Wed) so both calendar edges are ragged.
 		const { data, rowLabels } = buildCalendarHeatmapData( heatmapCalendarSeries.slice( 2, 115 ), {
 			weekStartsOn,
 			hideOutOfRangeDays,

--- a/projects/js-packages/charts/src/charts/heatmap-chart/test/build-calendar-data.test.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/test/build-calendar-data.test.ts
@@ -33,6 +33,38 @@ describe( 'buildCalendarHeatmapData', () => {
 		expect( data[ 0 ].data[ 1 ].value ).toBeNull(); // Tue Jan 2 has no datum
 	} );
 
+	test( 'hideOutOfRangeDays hides the week-completion days outside the span', () => {
+		const midWeek: DataPointDate[] = [
+			{ dateString: '2024-01-03', value: 5 }, // Wed
+			{ dateString: '2024-01-09', value: 2 }, // Tue (2nd week)
+		];
+		const { data } = buildCalendarHeatmapData( midWeek, {
+			weekStartsOn: 1,
+			hideOutOfRangeDays: true,
+		} );
+
+		// Mon Jan 1 and Tue Jan 2 precede the span — hidden; Wed Jan 3 opens it.
+		expect( data[ 0 ].data[ 0 ].hidden ).toBe( true );
+		expect( data[ 0 ].data[ 1 ].hidden ).toBe( true );
+		expect( data[ 0 ].data[ 2 ].hidden ).toBeUndefined();
+
+		// Thu Jan 4 is inside the span with no entry — a blank cell, not hidden.
+		expect( data[ 0 ].data[ 3 ].hidden ).toBeUndefined();
+		expect( data[ 0 ].data[ 3 ].value ).toBeNull();
+
+		// Tue Jan 9 closes the span; Wed Jan 10 onward is hidden.
+		expect( data[ 1 ].data[ 1 ].hidden ).toBeUndefined();
+		expect( data[ 1 ].data[ 2 ].hidden ).toBe( true );
+		expect( data[ 1 ].data[ 6 ].hidden ).toBe( true );
+	} );
+
+	test( 'out-of-span days stay blank cells without hideOutOfRangeDays', () => {
+		const midWeek: DataPointDate[] = [ { dateString: '2024-01-03', value: 5 } ]; // Wed
+		const { data } = buildCalendarHeatmapData( midWeek, { weekStartsOn: 1 } );
+		expect( data[ 0 ].data[ 0 ].hidden ).toBeUndefined();
+		expect( data[ 0 ].data[ 0 ].value ).toBeNull();
+	} );
+
 	test( 'labels only the first column of each month', () => {
 		const multiMonth: DataPointDate[] = [
 			{ dateString: '2024-01-01', value: 1 },

--- a/projects/js-packages/charts/src/charts/heatmap-chart/test/build-calendar-data.test.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/test/build-calendar-data.test.ts
@@ -33,14 +33,13 @@ describe( 'buildCalendarHeatmapData', () => {
 		expect( data[ 0 ].data[ 1 ].value ).toBeNull(); // Tue Jan 2 has no datum
 	} );
 
-	test( 'hideOutOfRangeDays hides the week-completion days outside the span', () => {
+	test( 'hides the week-completion days outside the span by default', () => {
 		const midWeek: DataPointDate[] = [
 			{ dateString: '2024-01-03', value: 5 }, // Wed
 			{ dateString: '2024-01-09', value: 2 }, // Tue (2nd week)
 		];
 		const { data } = buildCalendarHeatmapData( midWeek, {
 			weekStartsOn: 1,
-			hideOutOfRangeDays: true,
 		} );
 
 		// Mon Jan 1 and Tue Jan 2 precede the span — hidden; Wed Jan 3 opens it.
@@ -58,9 +57,12 @@ describe( 'buildCalendarHeatmapData', () => {
 		expect( data[ 1 ].data[ 6 ].hidden ).toBe( true );
 	} );
 
-	test( 'out-of-span days stay blank cells without hideOutOfRangeDays', () => {
+	test( 'out-of-span days stay blank cells when hideOutOfRangeDays is false', () => {
 		const midWeek: DataPointDate[] = [ { dateString: '2024-01-03', value: 5 } ]; // Wed
-		const { data } = buildCalendarHeatmapData( midWeek, { weekStartsOn: 1 } );
+		const { data } = buildCalendarHeatmapData( midWeek, {
+			weekStartsOn: 1,
+			hideOutOfRangeDays: false,
+		} );
 		expect( data[ 0 ].data[ 0 ].hidden ).toBeUndefined();
 		expect( data[ 0 ].data[ 0 ].value ).toBeNull();
 	} );

--- a/projects/js-packages/charts/src/charts/heatmap-chart/test/heatmap-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/test/heatmap-chart.test.tsx
@@ -213,6 +213,57 @@ describe( 'HeatmapChart', () => {
 		expect( grid ).not.toHaveAttribute( 'aria-activedescendant' );
 	} );
 
+	// Calendar ragged edges: hidden cells keep their grid slot but paint
+	// nothing and take no interaction.
+	const raggedData: HeatmapColumn[] = [
+		{ label: 'W1', data: [ { value: null, hidden: true }, { value: 1 }, { value: 2 } ] },
+		{ label: 'W2', data: [ { value: 3 }, { value: null, hidden: true }, { value: 4 } ] },
+		{ label: 'W3', data: [ { value: 5 }, { value: 6 }, { value: null, hidden: true } ] },
+	];
+
+	test( 'hidden cells render as empty slots outside the accessibility tree', () => {
+		renderChart( { data: raggedData } );
+		expect( screen.getAllByTestId( 'heatmap-cell' ) ).toHaveLength( 6 );
+		expect( screen.getAllByTestId( 'heatmap-cell-hidden' ) ).toHaveLength( 3 );
+		expect( screen.getAllByRole( 'gridcell' ) ).toHaveLength( 6 );
+	} );
+
+	test( 'keyboard navigation skips hidden cells and never lands on them', async () => {
+		renderChart( { data: raggedData, rowLabels: [ 'Mon', 'Tue', 'Wed' ] } );
+		const grid = screen.getByRole( 'grid', { name: /heatmap/i } );
+		const user = userEvent.setup();
+
+		// The initial selection starts past the hidden leading slot (0,0).
+		grid.focus();
+		await user.keyboard( '{ArrowDown}' );
+		expect( grid ).toHaveAttribute(
+			'aria-activedescendant',
+			expect.stringMatching( /-cell-0-1$/ )
+		);
+
+		// ArrowRight steps over the hidden (1,1) to (2,1).
+		await user.keyboard( '{ArrowRight}' );
+		expect( grid ).toHaveAttribute(
+			'aria-activedescendant',
+			expect.stringMatching( /-cell-2-1$/ )
+		);
+
+		// Only a hidden slot (2,2) lies below — the selection stays put.
+		await user.keyboard( '{ArrowDown}' );
+		expect( grid ).toHaveAttribute(
+			'aria-activedescendant',
+			expect.stringMatching( /-cell-2-1$/ )
+		);
+
+		// ArrowLeft steps back over the hidden (1,1) to (0,1); ArrowUp has
+		// only the hidden (0,0) above, so the selection stays again.
+		await user.keyboard( '{ArrowLeft}{ArrowUp}' );
+		expect( grid ).toHaveAttribute(
+			'aria-activedescendant',
+			expect.stringMatching( /-cell-0-1$/ )
+		);
+	} );
+
 	test( 'rows contain gridcell children in the ARIA hierarchy', () => {
 		renderChart();
 		const rows = screen.getAllByRole( 'row' );

--- a/projects/js-packages/charts/src/charts/heatmap-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/types.ts
@@ -6,6 +6,13 @@ export type HeatmapCell = {
 	/** Per-cell label used in the tooltip / accessible name. */
 	label?: string;
 	value: number | null;
+	/**
+	 * Leave the cell's grid slot empty: nothing is painted and the cell is
+	 * skipped by hover and keyboard navigation, while the slot keeps its
+	 * place so the rest of the grid doesn't shift. For calendar edges, where
+	 * days completing the first/last week fall outside the covered range.
+	 */
+	hidden?: boolean;
 };
 
 /** A heatmap column (rendered left→right); its cells render top→bottom. */


### PR DESCRIPTION
Part of [WOOA7S-1732](https://linear.app/a8c/issue/WOOA7S-1732/traffic-activity-heatmap-ragged-calendar-edges-trim-out-of-range-cells). Split out of #50517 so the chart capability can land and be reviewed on its own.

## Why

`buildCalendarHeatmapData` grids whole weeks, so a series that starts or ends mid-week gets week-completion filler days rendered as blank no-data cells. Those fillers are indistinguishable from real in-range days that simply have no data. Calendar heatmap designs, such as the Premium Analytics post Traffic activity card and GitHub's contribution graph, render those edges ragged instead: the out-of-range slots are empty.

## Proposed changes

* `HeatmapCell` gains an optional `hidden` flag: the cell keeps its grid slot so the rest of the column does not shift, but paints nothing, takes no pointer interaction, and stays out of the accessibility tree.
* `buildCalendarHeatmapData` now marks the week-completion days outside the series' date span as hidden by default. Days inside the span stay blank cells even when the series has no entry for them. Consumers can pass `{ hideOutOfRangeDays: false }` to keep the previous blank-cell edge behavior.
* Keyboard navigation skips hidden cells: the initial selection starts at the first visible cell, arrow keys step over hidden slots to the next visible cell in the pressed direction, and the selection stays put when only hidden slots or the grid edge remain that way.
* Storybook: the default `Calendar` story now demonstrates ragged edges with a mid-week span and an `hideOutOfRangeDays` control, plus the option documented in `index.docs.mdx` and `index.api.mdx`.
* Tests: builder coverage for the default hidden-edge behavior, the explicit `hideOutOfRangeDays: false` opt-out, in-span gaps staying blank, and renderer coverage for the empty slots and skip-over/stay-put keyboard behavior.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* From `projects/js-packages/charts`: `pnpm run test heatmap-chart`.
* Call `buildCalendarHeatmapData( series )` with a series starting/ending mid-week and render the result. The first/last week columns show empty slots for the out-of-range days, hovering them shows no tooltip, and arrow-key navigation never lands on them.
* Pass `{ hideOutOfRangeDays: false }` to verify the previous blank-cell edge behavior is still available.

### Screenshots

| `hideOutOfRangeDays: false` (opt out) | `hideOutOfRangeDays: true` (default) |
|-|-|
|<img width="1328" height="816" alt="Calendar heatmap with blank edge cells" src="https://github.com/user-attachments/assets/de82fbff-4bdd-4086-a5ab-0cae608e5adb" />|<img width="1330" height="794" alt="Calendar heatmap with ragged hidden edge cells" src="https://github.com/user-attachments/assets/f542fbb1-e5ea-4eb8-8755-f741ba6f6c48" />|
