### PR TITLE
Premium Analytics: add shared chart-bucketing helper; keep Posts report requests day-bucketed

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-pa-shared-chart-bucketing
+++ b/projects/packages/premium-analytics/changelog/add-pa-shared-chart-bucketing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats reports: keep data requests day-bucketed and group chart intervals client-side via a shared helper; fixes the Posts report table totals changing with the chart interval.

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -99,7 +99,11 @@ export {
 	type StatsVisitsStatField,
 	type StatsVisitsStatFields,
 } from './hooks/use-stats-visits';
-export { sliceWordAdsStatsReport } from './processing/stats';
+export {
+	bucketStatsTimeSeries,
+	getStatsChartBucketKey,
+	sliceWordAdsStatsReport,
+} from './processing/stats';
 export {
 	useStatsSummary,
 	type StatsSummaryParams,
@@ -238,6 +242,7 @@ export type {
 export type {
 	StatsArchivesComparisonItem,
 	StatsArchivesItem,
+	StatsChartBucketPeriod,
 	StatsClicksComparisonItem,
 	StatsClicksItem,
 	StatsCommentFollowersItem,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/chart-buckets.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/chart-buckets.test.ts
@@ -27,6 +27,15 @@ function getViews( point: StatsNormalizedReport< StatsTopPostsItem >[ 'data' ][ 
 describe( 'Stats chart buckets', () => {
 	it( 'uses daily dates as identity keys', () => {
 		expect( getStatsChartBucketKey( '2026-07-09', 'day' ) ).toBe( '2026-07-09' );
+
+		const report: StatsNormalizedReport< StatsTopPostsItem > = {
+			summary: {},
+			data: [ createPoint( '2026-07-09', 7 ) ],
+		};
+
+		expect( bucketStatsTimeSeries( report, 'day', getViews ).data[ 0 ].date_start ).toBe(
+			'2026-07-09T00:00:00+00:00'
+		);
 	} );
 
 	it( 'groups daily points by ISO week and sums their metrics', () => {
@@ -54,7 +63,7 @@ describe( 'Stats chart buckets', () => {
 			data: [
 				{
 					time_interval: '2026-07-06',
-					date_start: '2026-07-09T00:00:00+00:00',
+					date_start: '2026-07-06T00:00:00+00:00',
 					date_end: '2026-07-10T23:59:59+00:00',
 					label: '2026-07-06',
 					items: [],
@@ -82,9 +91,32 @@ describe( 'Stats chart buckets', () => {
 
 		expect( getStatsChartBucketKey( '2026-06-30', 'month' ) ).toBe( '2026-06-01' );
 		expect( getStatsChartBucketKey( '2026-07-01', 'month' ) ).toBe( '2026-07-01' );
-		expect(
-			bucketStatsTimeSeries( report, 'month', getViews ).data.map( point => point.time_interval )
-		).toEqual( [ '2026-06-01', '2026-07-01' ] );
+		expect( bucketStatsTimeSeries( report, 'month', getViews ) ).toEqual( {
+			summary: {
+				date_start: '2026-06-30T00:00:00+00:00',
+				date_end: '2026-07-01T23:59:59+00:00',
+			},
+			data: [
+				{
+					time_interval: '2026-06-01',
+					date_start: '2026-06-01T00:00:00+00:00',
+					date_end: '2026-06-30T23:59:59+00:00',
+					label: '2026-06-01',
+					items: [],
+					value: 4,
+					views: 4,
+				},
+				{
+					time_interval: '2026-07-01',
+					date_start: '2026-07-01T00:00:00+00:00',
+					date_end: '2026-07-01T23:59:59+00:00',
+					label: '2026-07-01',
+					items: [],
+					value: 8,
+					views: 8,
+				},
+			],
+		} );
 	} );
 
 	it( 'returns empty data while passing through an empty report summary', () => {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/chart-buckets.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/chart-buckets.test.ts
@@ -1,0 +1,105 @@
+import { bucketStatsTimeSeries, getStatsChartBucketKey } from '..';
+import type { StatsNormalizedReport, StatsTopPostsItem } from '..';
+
+function createPoint( date: string, views: number ) {
+	return {
+		time_interval: date,
+		date_start: `${ date }T00:00:00+00:00`,
+		date_end: `${ date }T23:59:59+00:00`,
+		items: [
+			{
+				id: 1,
+				label: 'Post',
+				views,
+				link: 'https://example.com/post/',
+				type: 'post',
+			},
+		],
+	};
+}
+
+function getViews( point: StatsNormalizedReport< StatsTopPostsItem >[ 'data' ][ number ] ) {
+	const views = point.items.reduce( ( total, item ) => total + item.views, 0 );
+
+	return { value: views, views };
+}
+
+describe( 'Stats chart buckets', () => {
+	it( 'uses daily dates as identity keys', () => {
+		expect( getStatsChartBucketKey( '2026-07-09', 'day' ) ).toBe( '2026-07-09' );
+	} );
+
+	it( 'groups daily points by ISO week and sums their metrics', () => {
+		const report: StatsNormalizedReport< StatsTopPostsItem > = {
+			summary: {
+				date_start: '2000-01-01T00:00:00+00:00',
+				date_end: '2000-01-01T23:59:59+00:00',
+				views: 18,
+			},
+			data: [
+				createPoint( '2026-07-09', 7 ),
+				createPoint( '2026-07-10', 6 ),
+				createPoint( '2026-07-13', 5 ),
+			],
+		};
+
+		expect( getStatsChartBucketKey( '2026-07-09', 'week' ) ).toBe( '2026-07-06' );
+		expect( getStatsChartBucketKey( '2026-07-10', 'week' ) ).toBe( '2026-07-06' );
+		expect( bucketStatsTimeSeries( report, 'week', getViews ) ).toEqual( {
+			summary: {
+				date_start: '2026-07-09T00:00:00+00:00',
+				date_end: '2026-07-13T23:59:59+00:00',
+				views: 18,
+			},
+			data: [
+				{
+					time_interval: '2026-07-06',
+					date_start: '2026-07-09T00:00:00+00:00',
+					date_end: '2026-07-10T23:59:59+00:00',
+					label: '2026-07-06',
+					items: [],
+					value: 13,
+					views: 13,
+				},
+				{
+					time_interval: '2026-07-13',
+					date_start: '2026-07-13T00:00:00+00:00',
+					date_end: '2026-07-13T23:59:59+00:00',
+					label: '2026-07-13',
+					items: [],
+					value: 5,
+					views: 5,
+				},
+			],
+		} );
+	} );
+
+	it( 'uses full first-of-month dates across a month boundary', () => {
+		const report: StatsNormalizedReport< StatsTopPostsItem > = {
+			summary: {},
+			data: [ createPoint( '2026-06-30', 4 ), createPoint( '2026-07-01', 8 ) ],
+		};
+
+		expect( getStatsChartBucketKey( '2026-06-30', 'month' ) ).toBe( '2026-06-01' );
+		expect( getStatsChartBucketKey( '2026-07-01', 'month' ) ).toBe( '2026-07-01' );
+		expect(
+			bucketStatsTimeSeries( report, 'month', getViews ).data.map( point => point.time_interval )
+		).toEqual( [ '2026-06-01', '2026-07-01' ] );
+	} );
+
+	it( 'returns empty data while passing through an empty report summary', () => {
+		const report: StatsNormalizedReport< StatsTopPostsItem > = {
+			summary: { views: 0 },
+			data: [],
+		};
+
+		expect( bucketStatsTimeSeries( report, 'day', getViews ) ).toEqual( {
+			summary: { views: 0 },
+			data: [],
+		} );
+		expect( bucketStatsTimeSeries( undefined, 'day', getViews ) ).toEqual( {
+			summary: {},
+			data: [],
+		} );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/chart-buckets.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/chart-buckets.ts
@@ -1,0 +1,90 @@
+import type { StatsTimeSeriesReport } from './time-series';
+import type { StatsNormalizedDataPoint, StatsNormalizedItem, StatsNormalizedReport } from './types';
+import type { StatsPeriod } from '../../utils/stats-params';
+
+export type StatsChartBucketPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
+
+type StatsChartBucketValues = Record< string, number > & { value: number };
+
+/**
+ * Map a daily bucket date onto its chart bucket key for the selected period —
+ * the date itself for days, the Monday start date of the ISO week for weeks,
+ * and the first-of-month date (`YYYY-MM-01`) for months.
+ *
+ * @param date   - The daily bucket date (`YYYY-MM-DD`).
+ * @param period - The chart bucket period.
+ * @return The bucket key the date aggregates into.
+ */
+export function getStatsChartBucketKey( date: string, period: StatsChartBucketPeriod ): string {
+	if ( period === 'day' ) {
+		return date;
+	}
+
+	const bucketDate = new Date( `${ date.slice( 0, 10 ) }T00:00:00Z` );
+
+	if ( period === 'week' ) {
+		const daysSinceMonday = ( bucketDate.getUTCDay() + 6 ) % 7;
+		bucketDate.setUTCDate( bucketDate.getUTCDate() - daysSinceMonday );
+	} else {
+		bucketDate.setUTCDate( 1 );
+	}
+
+	return bucketDate.toISOString().slice( 0, 10 );
+}
+
+/**
+ * Collapse a normalized daily Stats report into chart buckets.
+ *
+ * The caller maps each data point to its chart metrics, including the required
+ * headline `value`. Metrics are summed when daily points share a chart bucket.
+ *
+ * @param report          - The normalized daily Stats report.
+ * @param period          - The chart bucket period.
+ * @param getBucketValues - Extract the numeric chart metrics from a data point.
+ * @return The chart-ready time series.
+ */
+export function bucketStatsTimeSeries< TItem extends StatsNormalizedItem >(
+	report: StatsNormalizedReport< TItem > | undefined,
+	period: StatsChartBucketPeriod,
+	getBucketValues: ( point: StatsNormalizedDataPoint< TItem > ) => StatsChartBucketValues
+): StatsTimeSeriesReport {
+	const buckets = new Map< string, StatsTimeSeriesReport[ 'data' ][ number ] >();
+
+	for ( const point of report?.data ?? [] ) {
+		const key = getStatsChartBucketKey( point.time_interval, period );
+		const values = getBucketValues( point );
+		const existing = buckets.get( key );
+
+		if ( existing ) {
+			existing.date_end = point.date_end;
+
+			for ( const [ metric, value ] of Object.entries( values ) ) {
+				existing[ metric ] = Number( existing[ metric ] ?? 0 ) + value;
+			}
+
+			continue;
+		}
+
+		buckets.set( key, {
+			time_interval: key,
+			date_start: point.date_start,
+			date_end: point.date_end,
+			label: key,
+			items: [],
+			...values,
+		} );
+	}
+
+	const data = [ ...buckets.values() ];
+	const first = data[ 0 ];
+	const last = data[ data.length - 1 ];
+
+	return {
+		summary: {
+			...report?.summary,
+			...( first ? { date_start: first.date_start } : {} ),
+			...( last ? { date_end: last.date_end } : {} ),
+		},
+		data,
+	};
+}

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/chart-buckets.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/chart-buckets.ts
@@ -37,6 +37,9 @@ export function getStatsChartBucketKey( date: string, period: StatsChartBucketPe
  *
  * The caller maps each data point to its chart metrics, including the required
  * headline `value`. Metrics are summed when daily points share a chart bucket.
+ * Each bucket's `date_start` combines the bucket-key date with the first daily
+ * point's time and offset. This keeps `localTZDate()` anchored to the bucket-key
+ * calendar date; a bare `YYYY-MM-DD` would instead be parsed as a UTC instant.
  *
  * @param report          - The normalized daily Stats report.
  * @param period          - The chart bucket period.
@@ -49,8 +52,9 @@ export function bucketStatsTimeSeries< TItem extends StatsNormalizedItem >(
 	getBucketValues: ( point: StatsNormalizedDataPoint< TItem > ) => StatsChartBucketValues
 ): StatsTimeSeriesReport {
 	const buckets = new Map< string, StatsTimeSeriesReport[ 'data' ][ number ] >();
+	const points = report?.data ?? [];
 
-	for ( const point of report?.data ?? [] ) {
+	for ( const point of points ) {
 		const key = getStatsChartBucketKey( point.time_interval, period );
 		const values = getBucketValues( point );
 		const existing = buckets.get( key );
@@ -67,7 +71,7 @@ export function bucketStatsTimeSeries< TItem extends StatsNormalizedItem >(
 
 		buckets.set( key, {
 			time_interval: key,
-			date_start: point.date_start,
+			date_start: `${ key }${ point.date_start.slice( 10 ) }`,
 			date_end: point.date_end,
 			label: key,
 			items: [],
@@ -76,8 +80,8 @@ export function bucketStatsTimeSeries< TItem extends StatsNormalizedItem >(
 	}
 
 	const data = [ ...buckets.values() ];
-	const first = data[ 0 ];
-	const last = data[ data.length - 1 ];
+	const first = points[ 0 ];
+	const last = points[ points.length - 1 ];
 
 	return {
 		summary: {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -5,6 +5,8 @@ export {
 	sanitizeStatsSiteResponse,
 } from './utils';
 export type { StatsComparisonRowContext } from './utils';
+export { bucketStatsTimeSeries, getStatsChartBucketKey } from './chart-buckets';
+export type { StatsChartBucketPeriod } from './chart-buckets';
 export { mergeStatsTopPostsComparisonRows, sanitizeStatsTopPostsResponse } from './top-posts';
 export { sanitizeStatsPostResponse } from './post';
 export { sanitizeStatsPostLikesResponse } from './post-likes';

--- a/projects/packages/premium-analytics/routes/reports/posts/config/aggregate.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/posts/config/aggregate.test.ts
@@ -1,4 +1,9 @@
-import { aggregateArchiveRows, aggregatePostRows, postsToTimeSeries } from './aggregate';
+import {
+	aggregateArchiveRows,
+	aggregatePostRows,
+	archivesToTimeSeries,
+	postsToTimeSeries,
+} from './aggregate';
 import type {
 	StatsArchivesItem,
 	StatsNormalizedReport,
@@ -11,9 +16,9 @@ describe( 'report posts aggregate', () => {
 			summary: {},
 			data: [
 				{
-					time_interval: '2026-W23',
-					date_start: '2026-06-01T00:00:00+00:00',
-					date_end: '2026-06-07T23:59:59+00:00',
+					time_interval: '2026-07-09',
+					date_start: '2026-07-09T00:00:00+00:00',
+					date_end: '2026-07-09T23:59:59+00:00',
 					items: [
 						{
 							id: 1,
@@ -32,9 +37,9 @@ describe( 'report posts aggregate', () => {
 					],
 				},
 				{
-					time_interval: '2026-W24',
-					date_start: '2026-06-08T00:00:00+00:00',
-					date_end: '2026-06-14T23:59:59+00:00',
+					time_interval: '2026-07-10',
+					date_start: '2026-07-10T00:00:00+00:00',
+					date_end: '2026-07-10T23:59:59+00:00',
 					items: [
 						{
 							id: 1,
@@ -55,14 +60,19 @@ describe( 'report posts aggregate', () => {
 			],
 		};
 
-		const series = postsToTimeSeries( report );
+		const series = postsToTimeSeries( report, 'week' );
 
 		expect( series.summary ).toEqual( {
-			date_start: '2026-06-01T00:00:00+00:00',
-			date_end: '2026-06-14T23:59:59+00:00',
+			date_start: '2026-07-09T00:00:00+00:00',
+			date_end: '2026-07-10T23:59:59+00:00',
 		} );
-		expect( series.data.map( point => point.time_interval ) ).toEqual( [ '2026-W23', '2026-W24' ] );
-		expect( series.data.map( point => point.views ) ).toEqual( [ 15, 19 ] );
+		expect( series.data ).toEqual( [
+			expect.objectContaining( {
+				time_interval: '2026-07-06',
+				value: 34,
+				views: 34,
+			} ),
+		] );
 		expect( aggregatePostRows( report ) ).toEqual( [
 			expect.objectContaining( {
 				id: 1,
@@ -76,6 +86,42 @@ describe( 'report posts aggregate', () => {
 				link: null,
 				type: 'homepage',
 			} ),
+		] );
+	} );
+
+	it( 'groups daily archive chart points by month', () => {
+		const report: StatsNormalizedReport< StatsArchivesItem > = {
+			summary: {},
+			data: [
+				{
+					time_interval: '2026-06-30',
+					date_start: '2026-06-30T00:00:00+00:00',
+					date_end: '2026-06-30T23:59:59+00:00',
+					items: [ { label: 'home', value: 3, children: null } ],
+				},
+				{
+					time_interval: '2026-07-01',
+					date_start: '2026-07-01T00:00:00+00:00',
+					date_end: '2026-07-01T23:59:59+00:00',
+					items: [ { label: 'home', value: 5, children: null } ],
+				},
+				{
+					time_interval: '2026-07-02',
+					date_start: '2026-07-02T00:00:00+00:00',
+					date_end: '2026-07-02T23:59:59+00:00',
+					items: [ { label: 'home', value: 7, children: null } ],
+				},
+			],
+		};
+
+		expect(
+			archivesToTimeSeries( report, 'month' ).data.map( point => ( {
+				time_interval: point.time_interval,
+				views: point.views,
+			} ) )
+		).toEqual( [
+			{ time_interval: '2026-06-01', views: 3 },
+			{ time_interval: '2026-07-01', views: 12 },
 		] );
 	} );
 

--- a/projects/packages/premium-analytics/routes/reports/posts/config/aggregate.ts
+++ b/projects/packages/premium-analytics/routes/reports/posts/config/aggregate.ts
@@ -1,21 +1,24 @@
 /**
+ * External dependencies
+ */
+import {
+	bucketStatsTimeSeries,
+	type StatsChartBucketPeriod,
+	type StatsArchivesItem,
+	type StatsNormalizedReport,
+	type StatsTimeSeriesReport,
+	type StatsTopPostsItem,
+} from '@jetpack-premium-analytics/data';
+/**
  * Internal dependencies
  */
 import { flattenArchiveRows, type ArchiveRow } from './fields';
-import type {
-	StatsArchivesItem,
-	StatsNormalizedItem,
-	StatsNormalizedReport,
-	StatsTimeSeriesReport,
-	StatsTopPostsItem,
-} from '@jetpack-premium-analytics/data';
 
 /**
  * The report pages fetch each tab's module report without `summarize`, so the
- * response arrives as per-interval buckets (one data point per day/week/month
- * with that bucket's rows). One query then feeds both page sections:
+ * response arrives as daily buckets. One query then feeds both page sections:
  *
- * - the performance chart, by summing each bucket's rows into a time series;
+ * - the performance chart, by grouping daily buckets client-side;
  * - the records table, by aggregating the rows across buckets.
  *
  * Deriving both from the same report keeps the chart scoped to exactly the
@@ -27,70 +30,44 @@ import type {
  */
 
 /**
- * Build a chart time series from a bucketed report.
+ * Build the chart's views-per-bucket time series for the Posts & Pages tab
+ * from daily top-posts data.
  *
- * The query owns the bucket size (`period=day|week|month`), and the normalizer
- * resolves each bucket's `date_start` / `date_end`. The report page only sums
- * each bucket's rows for the chart metric.
- *
- * @param report - The bucketed module report.
- * @param sum    - Sums one bucket's rows into the bucket's value.
- * @return The chart-ready time series.
- */
-function toTimeSeries< TItem extends StatsNormalizedItem >(
-	report: StatsNormalizedReport< TItem > | undefined,
-	sum: ( items: TItem[] ) => number
-): StatsTimeSeriesReport {
-	const data = ( report?.data ?? [] ).map( point => {
-		const views = sum( point.items );
-
-		return {
-			time_interval: point.time_interval,
-			date_start: point.date_start,
-			date_end: point.date_end,
-			label: point.time_interval,
-			items: [],
-			value: views,
-			views,
-		};
-	} );
-	const first = data[ 0 ];
-	const last = data[ data.length - 1 ];
-
-	return {
-		summary: {
-			...report?.summary,
-			...( first ? { date_start: first.date_start } : {} ),
-			...( last ? { date_end: last.date_end } : {} ),
-		},
-		data,
-	};
-}
-
-/**
- * Views-per-bucket time series for the Posts & Pages tab.
- *
- * @param report - The bucketed top-posts report.
+ * @param report - The daily top-posts report.
+ * @param period - The chart bucket period.
  * @return The chart-ready time series.
  */
 export function postsToTimeSeries(
-	report: StatsNormalizedReport< StatsTopPostsItem > | undefined
+	report: StatsNormalizedReport< StatsTopPostsItem > | undefined,
+	period: StatsChartBucketPeriod = 'day'
 ): StatsTimeSeriesReport {
-	return toTimeSeries( report, items => items.reduce( ( total, item ) => total + item.views, 0 ) );
+	return bucketStatsTimeSeries( report, period, point => {
+		const views = point.items.reduce( ( total, item ) => total + item.views, 0 );
+
+		return { value: views, views };
+	} );
 }
 
 /**
- * Views-per-bucket time series for the Archives tab.
+ * Build the chart's views-per-bucket time series for the Archives tab from
+ * daily archives data.
  *
- * @param report - The bucketed archives report.
+ * @param report - The daily archives report.
+ * @param period - The chart bucket period.
  * @return The chart-ready time series.
  */
 export function archivesToTimeSeries(
-	report: StatsNormalizedReport< StatsArchivesItem > | undefined
+	report: StatsNormalizedReport< StatsArchivesItem > | undefined,
+	period: StatsChartBucketPeriod = 'day'
 ): StatsTimeSeriesReport {
-	return toTimeSeries( report, items =>
-		flattenArchiveRows( items ).reduce( ( total, row ) => total + row.views, 0 )
-	);
+	return bucketStatsTimeSeries( report, period, point => {
+		const views = flattenArchiveRows( point.items ).reduce(
+			( total, row ) => total + row.views,
+			0
+		);
+
+		return { value: views, views };
+	} );
 }
 
 /**

--- a/projects/packages/premium-analytics/routes/reports/posts/config/use-report-records.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/posts/config/use-report-records.test.ts
@@ -1,0 +1,103 @@
+import { useStatsArchives, useStatsTopPosts } from '@jetpack-premium-analytics/data';
+import { renderHook } from '@testing-library/react';
+import { usePostsReportRecords } from './use-report-records';
+import type {
+	ReportParams,
+	StatsNormalizedReport,
+	StatsTopPostsItem,
+} from '@jetpack-premium-analytics/data';
+
+jest.mock( '@jetpack-premium-analytics/data', () => ( {
+	...jest.requireActual( '@jetpack-premium-analytics/data' ),
+	useStatsArchives: jest.fn(),
+	useStatsTopPosts: jest.fn(),
+} ) );
+
+const mockUseStatsArchives = useStatsArchives as jest.MockedFunction< typeof useStatsArchives >;
+const mockUseStatsTopPosts = useStatsTopPosts as jest.MockedFunction< typeof useStatsTopPosts >;
+
+const report: StatsNormalizedReport< StatsTopPostsItem > = {
+	summary: {},
+	data: [
+		{
+			time_interval: '2026-07-09',
+			date_start: '2026-07-09T00:00:00+00:00',
+			date_end: '2026-07-09T23:59:59+00:00',
+			items: [
+				{
+					id: 42,
+					label: 'Post A',
+					views: 7,
+					link: 'https://example.com/post-a/',
+					type: 'post',
+				},
+			],
+		},
+		{
+			time_interval: '2026-07-10',
+			date_start: '2026-07-10T00:00:00+00:00',
+			date_end: '2026-07-10T23:59:59+00:00',
+			items: [
+				{
+					id: 42,
+					label: 'Post A',
+					views: 6,
+					link: 'https://example.com/post-a/',
+					type: 'post',
+				},
+			],
+		},
+	],
+};
+
+const params: ReportParams = {
+	from: '2026-07-09',
+	to: '2026-07-10',
+	interval: 'day',
+};
+
+describe( 'usePostsReportRecords', () => {
+	beforeEach( () => {
+		mockUseStatsArchives.mockReset();
+		mockUseStatsTopPosts.mockReset();
+		mockUseStatsTopPosts.mockReturnValue( {
+			primary: { data: report },
+			comparison: { data: undefined },
+			hasComparison: false,
+			isLoading: false,
+		} as ReturnType< typeof useStatsTopPosts > );
+		mockUseStatsArchives.mockReturnValue( {
+			primary: { data: undefined },
+			comparison: { data: undefined },
+			hasComparison: false,
+			isLoading: false,
+		} as ReturnType< typeof useStatsArchives > );
+	} );
+
+	it( 'keeps both requests day-bucketed while grouping only the chart by week', () => {
+		const dayResult = renderHook( () =>
+			usePostsReportRecords( 'posts-pages', params, 'day' )
+		).result;
+		const weekResult = renderHook( () =>
+			usePostsReportRecords( 'posts-pages', params, 'week' )
+		).result;
+		const expectedParams = {
+			...params,
+			max: 0,
+			summarize: 0,
+			period: 'day',
+			skip_archives: 1,
+		};
+
+		expect( mockUseStatsTopPosts ).toHaveBeenLastCalledWith( expectedParams, { enabled: true } );
+		expect( mockUseStatsArchives ).toHaveBeenLastCalledWith( expectedParams, { enabled: false } );
+		expect( weekResult.current.chart.primary.data ).toEqual( [
+			expect.objectContaining( {
+				time_interval: '2026-07-06',
+				value: 13,
+				views: 13,
+			} ),
+		] );
+		expect( weekResult.current.posts.rows ).toEqual( dayResult.current.posts.rows );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/reports/posts/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/posts/config/use-report-records.ts
@@ -5,7 +5,7 @@ import {
 	useStatsArchives,
 	useStatsTopPosts,
 	type ReportParams,
-	type StatsPeriod,
+	type StatsChartBucketPeriod,
 	type StatsTopPostsItem,
 } from '@jetpack-premium-analytics/data';
 import { useMemo } from '@wordpress/element';
@@ -31,7 +31,7 @@ import type { ReportPostsTabId } from './tabs';
 export function usePostsReportRecords(
 	activeTab: ReportPostsTabId,
 	reportParams: ReportParams,
-	chartPeriod: StatsPeriod
+	chartPeriod: StatsChartBucketPeriod
 ) {
 	const isPostsTab = activeTab === 'posts-pages';
 
@@ -39,8 +39,8 @@ export function usePostsReportRecords(
 	 * One bucketed report per tab feeds both the chart and the table (see
 	 * `config/aggregate.ts`), so the chart is scoped to exactly the records
 	 * shown below it. `summarize: 0` opts out of the data layer's automatic
-	 * summarization to get the buckets; `period` comes from the chart control
-	 * and is written to the URL. `max: 0` asks for every row so
+	 * summarization to get daily buckets. The chart control is applied only to
+	 * client-side chart derivation. `max: 0` asks for every row so
 	 * search/sort/pagination run client-side. Each tab's report only fetches
 	 * while its tab is active. `skip_archives=1` mirrors the Stats "Most
 	 * viewed" card: the homepage is returned inside `stats/top-posts` as
@@ -52,10 +52,10 @@ export function usePostsReportRecords(
 			...reportParams,
 			max: 0,
 			summarize: 0,
-			period: chartPeriod,
+			period: 'day',
 			skip_archives: 1,
 		} ),
-		[ reportParams, chartPeriod ]
+		[ reportParams ]
 	);
 	const posts = useStatsTopPosts( recordsParams, { enabled: isPostsTab } );
 	const archives = useStatsArchives( recordsParams, { enabled: ! isPostsTab } );
@@ -64,18 +64,18 @@ export function usePostsReportRecords(
 
 	const chartPrimary = useMemo( () => {
 		return isPostsTab
-			? postsToTimeSeries( posts.primary.data )
-			: archivesToTimeSeries( archives.primary.data );
-	}, [ isPostsTab, posts.primary.data, archives.primary.data ] );
+			? postsToTimeSeries( posts.primary.data, chartPeriod )
+			: archivesToTimeSeries( archives.primary.data, chartPeriod );
+	}, [ isPostsTab, posts.primary.data, archives.primary.data, chartPeriod ] );
 	const chartComparison = useMemo( () => {
 		if ( ! reportParams.compare_from || ! reportParams.compare_to ) {
 			return undefined;
 		}
 
 		return isPostsTab
-			? postsToTimeSeries( posts.comparison.data )
-			: archivesToTimeSeries( archives.comparison.data );
-	}, [ isPostsTab, reportParams, posts.comparison.data, archives.comparison.data ] );
+			? postsToTimeSeries( posts.comparison.data, chartPeriod )
+			: archivesToTimeSeries( archives.comparison.data, chartPeriod );
+	}, [ isPostsTab, reportParams, posts.comparison.data, archives.comparison.data, chartPeriod ] );
 
 	const postRows = useMemo< StatsTopPostsItem[] >(
 		() => aggregatePostRows( posts.primary.data ),

--- a/projects/packages/premium-analytics/routes/reports/posts/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/posts/page.tsx
@@ -151,8 +151,8 @@ function PostsReport(): JSX.Element {
 	);
 	const chartLegendLabels = useMemo( () => formatLegendLabels( reportParams ), [ reportParams ] );
 
-	// The chart period is part of the report query, so changing it writes the
-	// URL (and re-fetches) rather than living in component state.
+	// The chart period is written to the URL and applied to the daily report
+	// data client-side rather than living in component state.
 	const navigate = useNavigate();
 	const handleIntervalChange = useCallback(
 		( interval: IntervalType ) => {


### PR DESCRIPTION
Fixes N/A — follow-up to the reviewer feedback in #50443 (also see WOOA7S-1692 report pages).

## Proposed changes

* Add a shared client-side chart-bucketing helper to the data package (`packages/data/src/processing/stats/chart-buckets.ts`):
  * `getStatsChartBucketKey( date, period )` — maps a daily bucket date onto its chart bucket key: the date itself for days, the ISO-week Monday for weeks, the first-of-month date (`YYYY-MM-01`) for months.
  * `bucketStatsTimeSeries( report, period, getBucketValues )` — collapses a normalized daily Stats report into chart buckets, summing the caller-mapped metrics, so report pages can re-bucket day-level data client-side.
  * Both exported from `@jetpack-premium-analytics/data`, with dedicated unit tests (ISO-week/month boundaries, metric summing, date-range carry, empty input).
* Fix the Posts report's data request: `/reports/posts` previously sent the chart interval (day/week/month) as the Stats API `period`. The Stats query factory derives the request window from `period/date/num`, so week/month rounded the window to whole weeks/months — switching the chart interval changed the table totals. The request is now always `period: 'day'` (both Posts and Pages/Archives tabs) and the chart interval is applied client-side via the shared helper, so table totals are stable across chart granularities.
* Migrate `postsToTimeSeries` / `archivesToTimeSeries` to thin wrappers over the shared helper (removes the report-local bucketing logic).

This is the same fix already applied to the in-flight report PRs (#50437, #50438, #50439, #50441, #50442, #50443, #50444); once this lands, those branches will be rebased to drop their local copies of the bucketing logic and use the shared helper.

## Related product discussion/links

* Reviewer feedback: https://github.com/Automattic/jetpack/pull/50443#discussion_r3584568161
* Linear: WOOA7S-1692 (Reports: add a report page for each Stats widget)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build Premium Analytics (`jetpack build --deps packages/premium-analytics`) on a Jetpack-connected site with Stats data.
* Go to the Premium Analytics dashboard → open the **Posts** report (`/reports/posts`).
* Note the totals in the records table, then switch the chart interval between **Day / Week / Month**:
  * The chart re-buckets (weekly buckets start on Monday; monthly buckets on the 1st).
  * The table rows and totals stay identical across all three intervals (previously they changed).
  * The network request to the Stats proxy keeps `period=day` regardless of the selected interval, and no re-fetch fires when switching intervals.
* Repeat on the **Pages** tab of the same report.
* Unit tests: from `projects/packages/premium-analytics` run:
  * `pnpm jest --config tests/jest.config.cjs packages/data/src/processing/stats`
  * `pnpm jest --config tests/jest.config.cjs routes/reports/posts`
