### PR TITLE
chore(premium-analytics): Disable cookie consent 

### DIFF
--- a/projects/plugins/premium-analytics/changelog/update-disable-cookie-consent
+++ b/projects/plugins/premium-analytics/changelog/update-disable-cookie-consent
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Ship with the cookie consent banner disabled; it is planned for a later release.

--- a/projects/plugins/premium-analytics/src/class-jetpack-premium-analytics.php
+++ b/projects/plugins/premium-analytics/src/class-jetpack-premium-analytics.php
@@ -26,6 +26,9 @@ class Jetpack_Premium_Analytics {
 	 */
 	public function __construct() {
 		Analytics::init( array( 'menu_title' => 'Analytics' ) );
-		Cookie_Consent::init();
+
+		// Ships disabled: the banner is planned for a later release. The package stays wired up
+		// so the `jetpack_cookie_consent_config` filter can switch it back on for development.
+		Cookie_Consent::init( array( 'enabled' => false ) );
 	}
 }


### PR DESCRIPTION
## Proposed changes

**Why:** v1 stays in the "helper/processor" role — we honour whatever consent tool a merchant already runs, but we don't ship our own banner yet. That's gated on product/legal sign-off (WOOA7S-1543) and is planned for a later release.

**How:** Pass `enabled => false` to `Cookie_Consent::init()`. It early-returns before registering a single hook, so nothing ships: no banner, no CCPA page, no footer links, no consent-log routes or cron, no frontend assets.

Kept wired up rather than unwired because Premium Analytics is the package's only consumer, and the `jetpack_cookie_consent_config` filter is applied _after_ our config resolves — so dev/QA can switch it back on without editing plugin source.

**What:** One line in `class-jetpack-premium-analytics.php`. The Composer dependency, `composer.lock`, and the `cookie-consent` package are untouched.

## Related product discussion/links

- WOOA7S-1543 — the product/legal sign-off gating the banner.

## Does this pull request change what data or activity we track or use?

No

## Testing instructions

On a test site with the WP Consent API plugin active, visit the frontend from a GDPR region (or append `?preview_cookie_consent=1`):

- No consent banner appears.
- No `/your-privacy-choices` page is created, no footer privacy links injected.
- `GET /wp-json/jetpack/v4/cookie-consent/consent-log` 404s.

Then confirm the dev escape hatch, via an mu-plugin:

```php
add_filter(
	'jetpack_cookie_consent_config',
	function ( $config ) {
		$config['enabled'] = true;
		return $config;
	}
);
```

Reload — the banner returns and behaves as before this PR.

