### PR TITLE
Stylelint: no token fallback values (VideoPress, Search, Forms, Publicize, & Boost)

### DIFF
--- a/projects/packages/forms/changelog/update-stylelint-wp-build-no-token-fallback-values
+++ b/projects/packages/forms/changelog/update-stylelint-wp-build-no-token-fallback-values
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Comment: Remove manual WPDS token fallbacks from wp-build route styles so build-time PostCSS injects canonical design-token fallbacks.
+Comment: Remove manual WPDS token fallbacks from wp-build route and webpack dashboard styles so build-time PostCSS injects canonical design-token fallbacks.

--- a/projects/packages/forms/src/blocks/input-range/editor.scss
+++ b/projects/packages/forms/src/blocks/input-range/editor.scss
@@ -25,7 +25,7 @@ div.jetpack-input-range {
 			vertical-align: baseline;
 
 			&.has-error {
-				outline-color: var(--wpds-color-foreground-content-error, #470000);
+				outline-color: var(--wpds-color-foreground-content-error);
 				box-shadow: none;
 			}
 

--- a/projects/packages/forms/src/dashboard/components/dataviews-header-row/style.scss
+++ b/projects/packages/forms/src/dashboard/components/dataviews-header-row/style.scss
@@ -25,7 +25,7 @@
 	// Jetpack Forms specific additions (match Inbox).
 	position: sticky;
 	left: 0;
-	background: var(--wpds-color-background-surface-neutral-strong, #fff);
+	background: var(--wpds-color-background-surface-neutral-strong);
 	justify-content: space-between;
 	gap: 8px;
 	flex-direction: column;

--- a/projects/packages/forms/src/dashboard/components/feedback-comments/style.scss
+++ b/projects/packages/forms/src/dashboard/components/feedback-comments/style.scss
@@ -50,7 +50,7 @@
 
 // Individual comment (item)
 .jp-forms__feedback-comments-comment {
-	background-color: var(--jp-forms-white-off, var(--wpds-color-background-surface-neutral-weak, #e7e7e7));
+	background-color: var(--jp-forms-white-off, var(--wpds-color-background-surface-neutral-weak));
 	border-radius: var(--jp-forms-border-radius, 4px);
 	padding: 12px;
 
@@ -75,7 +75,7 @@
 	.jp-forms__feedback-comments-comment-author {
 		font-size: 14px;
 		font-weight: 600;
-		color: var(--jp-forms-color-darker-20, var(--wpds-color-foreground-content-neutral, #1e1e1e));
+		color: var(--jp-forms-color-darker-20, var(--wpds-color-foreground-content-neutral));
 	}
 
 	.jp-forms__feedback-comments-comment-date {

--- a/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-fields/field-preview/style.scss
@@ -8,7 +8,7 @@
 			padding-top: 24px;
 			padding-bottom: 24px;
 			// Multiple variables as fallback until style tokens are fully available.
-			border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral, var(--jp-forms-border-color, #e0e0e0));
+			border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral);
 		}
 
 		.jp-forms__field-preview-icon {
@@ -18,14 +18,14 @@
 		.jp-forms__field-preview-content {
 			min-width: 0; // Prevents flex item from overflowing
 			overflow-wrap: break-word;
-			line-height: var(--wpds-typography-line-height-sm, 20px);
+			line-height: var(--wpds-typography-line-height-sm);
 		}
 
 		// Value needed for positioning with the icon in case label is missing.
 		.jp-forms__field-preview-label,
 		.jp-forms__field-preview-value {
 			// Align first line centrally with the 24px icon.
-			margin-top: calc((24px - var(--wpds-typography-line-height-sm, 20px)) / 2);
+			margin-top: calc((24px - var(--wpds-typography-line-height-sm)) / 2);
 		}
 	}
 
@@ -40,7 +40,7 @@
 }
 
 .jp-forms__field-preview-label {
-	color: var(--wpds-color-foreground-content-neutral-weak, #707070);
+	color: var(--wpds-color-foreground-content-neutral-weak);
 	font-weight: 300;
 }
 

--- a/projects/packages/forms/src/dashboard/components/inspector/response-meta/style.scss
+++ b/projects/packages/forms/src/dashboard/components/inspector/response-meta/style.scss
@@ -6,7 +6,7 @@
 	padding: variables.$grid-unit-30 variables.$grid-unit-20;
 
 	// Multiple variables as fallback until style tokens are available everywhere.
-	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral, var(--jp-forms-border-color, #e0e0e0));
+	border-bottom: 1px solid var(--wpds-color-stroke-surface-neutral);
 }
 
 .jp-forms__inbox-response-meta-from {

--- a/projects/packages/forms/src/dashboard/inbox/style.scss
+++ b/projects/packages/forms/src/dashboard/inbox/style.scss
@@ -10,7 +10,7 @@
 	flex-grow: 1;
 	display: flex;
 	flex-direction: column;
-	background-color: var(--wpds-color-background-surface-neutral-strong, #fff);
+	background-color: var(--wpds-color-background-surface-neutral-strong);
 }
 
 /*

--- a/projects/packages/publicize/_inc/components/connection-icon/styles.module.scss
+++ b/projects/packages/publicize/_inc/components/connection-icon/styles.module.scss
@@ -12,17 +12,17 @@
 
 	img,
 	.avatar {
-		background-color: var(--wpds-color-background-surface-neutral-strong, #fff);
+		background-color: var(--wpds-color-background-surface-neutral-strong);
 		block-size: 24px;
-		border: 2px solid var(--wpds-color-background-surface-neutral-strong, #fff);
+		border: 2px solid var(--wpds-color-background-surface-neutral-strong);
 		border-radius: 50%;
 		inline-size: 24px;
 	}
 
 	.social-icon {
-		background-color: var(--wpds-color-background-surface-neutral-strong, #fff);
+		background-color: var(--wpds-color-background-surface-neutral-strong);
 		block-size: 14px;
-		border-radius: var(--wpds-border-radius-sm, 2px);
+		border-radius: var(--wpds-border-radius-sm);
 		inline-size: 14px;
 		inset-block-end: 0;
 		inset-inline-end: 0;

--- a/projects/packages/publicize/_inc/components/connection-management/style-modern.module.scss
+++ b/projects/packages/publicize/_inc/components/connection-management/style-modern.module.scss
@@ -2,8 +2,8 @@
 	align-items: start;
 	display: flex;
 	flex-direction: column;
-	gap: var(--wpds-dimension-gap-xl, 24px);
-	padding-top: var(--wpds-dimension-padding-lg, 16px);
+	gap: var(--wpds-dimension-gap-xl);
+	padding-top: var(--wpds-dimension-padding-lg);
 	width: 100%;
 
 	> h3 {
@@ -12,7 +12,7 @@
 }
 
 .description {
-	color: var(--wpds-color-foreground-content-neutral-weak, #757575);
+	color: var(--wpds-color-foreground-content-neutral-weak);
 }
 
 .connection-list {
@@ -31,7 +31,7 @@
 	// divider line that separates it from the surrounding Card.Header
 	// (or whatever chrome wraps the list).
 	.connection-list-item {
-		border-top: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #e4e4e4);
+		border-top: 1px solid var(--wpds-color-stroke-surface-neutral-weak);
 		margin: 0;
 	}
 }
@@ -42,8 +42,8 @@
 .connection-row {
 	align-items: center;
 	display: flex;
-	gap: var(--wpds-dimension-gap-lg, 16px);
-	padding: var(--wpds-dimension-padding-lg, 16px) var(--wpds-dimension-padding-2xl, 24px);
+	gap: var(--wpds-dimension-gap-lg);
+	padding: var(--wpds-dimension-padding-lg) var(--wpds-dimension-padding-2xl);
 	width: 100%;
 }
 
@@ -55,16 +55,16 @@
 	appearance: none;
 	background: none;
 	border: 0;
-	border-radius: var(--wpds-border-radius-sm, 2px);
+	border-radius: var(--wpds-border-radius-sm);
 	color: inherit;
-	cursor: var(--wpds-cursor-control, pointer);
+	cursor: var(--wpds-cursor-control);
 	display: inline-flex;
 	flex-shrink: 0;
 	margin: 0;
-	padding: var(--wpds-dimension-padding-xs, 4px);
+	padding: var(--wpds-dimension-padding-xs);
 
 	&:focus-visible {
-		outline: var(--wpds-border-width-focus, 2px) solid var(--wpds-color-stroke-focus, #3858e9);
+		outline: var(--wpds-border-width-focus) solid var(--wpds-color-stroke-focus);
 		outline-offset: 0;
 	}
 }
@@ -79,20 +79,20 @@
 // Size comes from the `body-lg` Text variant; keep the neutral colour and the
 // medium weight that the variant doesn't set.
 .connection-item-name {
-	color: var(--wpds-color-foreground-content-neutral, #1e1e1e);
-	font-weight: var(--wpds-typography-font-weight-medium, 499);
+	color: var(--wpds-color-foreground-content-neutral);
+	font-weight: var(--wpds-typography-font-weight-medium);
 }
 
 .connection-network {
-	color: var(--wpds-color-foreground-content-neutral-weak, #757575);
+	color: var(--wpds-color-foreground-content-neutral-weak);
 }
 
 .chevron {
-	color: var(--wpds-color-foreground-content-neutral, #1e1e1e);
+	color: var(--wpds-color-foreground-content-neutral);
 	flex-shrink: 0;
 
 	@media not (prefers-reduced-motion) {
-		transition: rotate var(--wpds-motion-duration-md, 0.15s) var(--wpds-motion-easing-balanced, ease-out);
+		transition: rotate var(--wpds-motion-duration-md) var(--wpds-motion-easing-balanced);
 	}
 }
 
@@ -120,7 +120,7 @@
 	}
 
 	@media not (prefers-reduced-motion) {
-		transition: all var(--wpds-motion-duration-md, 0.15s) var(--wpds-motion-easing-balanced, ease-out);
+		transition: all var(--wpds-motion-duration-md) var(--wpds-motion-easing-balanced);
 	}
 }
 
@@ -129,17 +129,17 @@
 	// padding doubles as clearance for the focus ring of the first focusable
 	// child (e.g. the mark-as-shared info button) — without it the ring's top
 	// edge is clipped by the panel.
-	padding: var(--wpds-dimension-padding-xs, 4px) var(--wpds-dimension-padding-2xl, 24px) var(--wpds-dimension-padding-xl, 20px);
+	padding: var(--wpds-dimension-padding-xs) var(--wpds-dimension-padding-2xl) var(--wpds-dimension-padding-xl);
 }
 
 // Stack supplies the row layout (align + gap); only the trailing spacing
 // below the toggle is left here.
 .mark-shared-wrap {
-	padding-bottom: var(--wpds-dimension-padding-lg, 16px);
+	padding-bottom: var(--wpds-dimension-padding-lg);
 }
 
 .connection-template-wrap {
-	margin-bottom: var(--wpds-dimension-gap-xl, 24px);
+	margin-bottom: var(--wpds-dimension-gap-xl);
 
 	&:empty {
 		margin-bottom: 0;

--- a/projects/packages/publicize/_inc/components/manage-connections-modal/style-modern.module.scss
+++ b/projects/packages/publicize/_inc/components/manage-connections-modal/style-modern.module.scss
@@ -13,8 +13,8 @@
 //      causes.
 // `translateX(-50%)` keeps the frame horizontally centered against `left: 50%`.
 .services-list {
-	top: calc(var(--wp-admin--admin-bar--height, 0px) + var(--wpds-dimension-padding-2xl, 24px));
-	max-height: calc(100dvh - var(--wp-admin--admin-bar--height, 0px) - 2 * var(--wpds-dimension-padding-2xl, 24px));
+	top: calc(var(--wp-admin--admin-bar--height, 0px) + var(--wpds-dimension-padding-2xl));
+	max-height: calc(100dvh - var(--wp-admin--admin-bar--height, 0px) - 2 * var(--wpds-dimension-padding-2xl));
 	transform: translateX(-50%);
 }
 
@@ -48,7 +48,7 @@
 	--jetpack-social-admin-menu-width: 160px;
 
 	left: calc(50% + var(--jetpack-social-admin-menu-width) / 2);
-	max-width: min(960px, calc(100dvw - var(--jetpack-social-admin-menu-width) - 2 * var(--wpds-dimension-padding-2xl, 24px)));
+	max-width: min(960px, calc(100dvw - var(--jetpack-social-admin-menu-width) - 2 * var(--wpds-dimension-padding-2xl)));
 }
 
 // The sidebar width varies by environment and menu state; mirror the chassis

--- a/projects/packages/publicize/_inc/components/overview-tab/style.scss
+++ b/projects/packages/publicize/_inc/components/overview-tab/style.scss
@@ -7,7 +7,7 @@
 .jetpack-social-overview {
 	display: flex;
 	flex-direction: column;
-	gap: var(--wpds-dimension-gap-lg, 16px);
+	gap: var(--wpds-dimension-gap-lg);
 	margin-inline: auto;
 	max-inline-size: 720px;
 	inline-size: 100%;
@@ -22,7 +22,7 @@
 	align-items: center;
 	display: flex;
 	flex-direction: column;
-	padding-block: var(--wpds-dimension-padding-2xl, 24px);
+	padding-block: var(--wpds-dimension-padding-2xl);
 	text-align: center;
 }
 
@@ -40,7 +40,7 @@
 // The top padding stays at Card.Header's default 24px so the title still
 // has comfortable headroom from the card edge.
 .jetpack-social-overview__accounts-card-header {
-	padding-block-end: var(--wpds-dimension-padding-xl, 20px);
+	padding-block-end: var(--wpds-dimension-padding-xl);
 }
 
 // Strip the Card.Content padding when the body is the flat connections

--- a/projects/packages/publicize/_inc/components/overview-tab/traffic-chart-card.scss
+++ b/projects/packages/publicize/_inc/components/overview-tab/traffic-chart-card.scss
@@ -8,7 +8,7 @@
 	align-items: center;
 	display: flex;
 	flex-wrap: wrap;
-	gap: var(--wpds-dimension-gap-md, 12px);
+	gap: var(--wpds-dimension-gap-md);
 	justify-content: space-between;
 }
 
@@ -29,7 +29,7 @@
 }
 
 .jetpack-social-overview__chart-content {
-	padding-block-start: var(--wpds-dimension-padding-md, 12px);
+	padding-block-start: var(--wpds-dimension-padding-md);
 }
 
 .jetpack-social-overview__chart-loading,
@@ -39,7 +39,7 @@
 	display: flex;
 	justify-content: center;
 	min-block-size: 240px;
-	padding-block: var(--wpds-dimension-padding-xl, 20px);
+	padding-block: var(--wpds-dimension-padding-xl);
 	text-align: center;
 }
 
@@ -76,7 +76,7 @@
 	display: flex;
 	inset: 0;
 	justify-content: center;
-	padding: var(--wpds-dimension-padding-md, 12px);
+	padding: var(--wpds-dimension-padding-md);
 	pointer-events: none;
 	position: absolute;
 }

--- a/projects/packages/publicize/_inc/components/services/style-modern.module.scss
+++ b/projects/packages/publicize/_inc/components/services/style-modern.module.scss
@@ -15,7 +15,7 @@
 		margin: 0;
 
 		&:not(:first-child) {
-			border-top: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #e4e4e4);
+			border-top: 1px solid var(--wpds-color-stroke-surface-neutral-weak);
 		}
 	}
 
@@ -23,31 +23,31 @@
 		display: flex;
 		flex: 1;
 		flex-direction: column;
-		gap: var(--wpds-dimension-gap-xs, 4px);
+		gap: var(--wpds-dimension-gap-xs);
 		min-width: 0;
 	}
 
 	.heading {
 		align-items: center;
 		display: flex;
-		gap: var(--wpds-dimension-gap-lg, 16px);
+		gap: var(--wpds-dimension-gap-lg);
 	}
 
 	// Size comes from the `body-lg` Text variant; keep the colour + medium weight.
 	.title {
-		color: var(--wpds-color-foreground-content-neutral, var(--jp-gray-80));
-		font-weight: var(--wpds-typography-font-weight-medium, 499);
+		color: var(--wpds-color-foreground-content-neutral);
+		font-weight: var(--wpds-typography-font-weight-medium);
 		line-height: 1.4;
 	}
 
 	.description {
-		color: var(--wpds-color-foreground-content-neutral-weak, #757575);
-		font-size: var(--wpds-typography-font-size-md, 13px);
+		color: var(--wpds-color-foreground-content-neutral-weak);
+		font-size: var(--wpds-typography-font-size-md);
 	}
 
 	.actions {
 		display: flex;
-		gap: var(--wpds-dimension-gap-sm, 8px);
+		gap: var(--wpds-dimension-gap-sm);
 	}
 
 	.active-connection {
@@ -61,7 +61,7 @@
 	}
 
 	.service-connection-list {
-		border-top: 1px solid var(--wpds-color-stroke-surface-neutral-weak, #e4e4e4);
+		border-top: 1px solid var(--wpds-color-stroke-surface-neutral-weak);
 		padding-top: 1rem;
 
 		li:not(:last-child) {
@@ -79,15 +79,15 @@
 // and the chassis Overview share the same visual language.
 .service-row {
 	align-items: center;
-	cursor: var(--wpds-cursor-control, pointer);
+	cursor: var(--wpds-cursor-control);
 	display: flex;
-	gap: var(--wpds-dimension-gap-lg, 16px);
-	padding: var(--wpds-dimension-padding-lg, 16px) var(--wpds-dimension-padding-2xl, 24px);
+	gap: var(--wpds-dimension-gap-lg);
+	padding: var(--wpds-dimension-padding-lg) var(--wpds-dimension-padding-2xl);
 	width: 100%;
 
 	&:focus-visible {
-		outline: var(--wpds-border-width-focus, 2px) solid var(--wpds-color-stroke-focus, #3858e9);
-		outline-offset: calc(var(--wpds-border-width-focus, 2px) * -1);
+		outline: var(--wpds-border-width-focus) solid var(--wpds-color-stroke-focus);
+		outline-offset: calc(var(--wpds-border-width-focus) * -1);
 	}
 
 	&[data-panel-open] {
@@ -103,11 +103,11 @@
 }
 
 .chevron {
-	color: var(--wpds-color-foreground-content-neutral, #1e1e1e);
+	color: var(--wpds-color-foreground-content-neutral);
 	flex-shrink: 0;
 
 	@media not (prefers-reduced-motion) {
-		transition: rotate var(--wpds-motion-duration-md, 0.15s) var(--wpds-motion-easing-balanced, ease-out);
+		transition: rotate var(--wpds-motion-duration-md) var(--wpds-motion-easing-balanced);
 	}
 }
 
@@ -128,12 +128,12 @@
 	}
 
 	@media not (prefers-reduced-motion) {
-		transition: all var(--wpds-motion-duration-md, 0.15s) var(--wpds-motion-easing-balanced, ease-out);
+		transition: all var(--wpds-motion-duration-md) var(--wpds-motion-easing-balanced);
 	}
 }
 
 .service-panel-inner {
-	padding: 0 var(--wpds-dimension-padding-2xl, 24px) var(--wpds-dimension-padding-xl, 20px);
+	padding: 0 var(--wpds-dimension-padding-2xl) var(--wpds-dimension-padding-xl);
 }
 
 .example-wrapper {

--- a/projects/packages/publicize/_inc/components/settings-tab/style.scss
+++ b/projects/packages/publicize/_inc/components/settings-tab/style.scss
@@ -17,7 +17,7 @@
 	align-items: center;
 	display: flex;
 	flex-direction: column;
-	padding-block: var(--wpds-dimension-padding-2xl, 24px);
+	padding-block: var(--wpds-dimension-padding-2xl);
 	text-align: center;
 }
 
@@ -29,5 +29,5 @@
 // theme density.
 .jetpack-social-settings__card-nested,
 .jetpack-social-settings__card-actions {
-	padding-inline-start: var(--wpds-dimension-gap-3xl, 40px);
+	padding-inline-start: var(--wpds-dimension-gap-3xl);
 }

--- a/projects/packages/publicize/_inc/components/social-gate/style.scss
+++ b/projects/packages/publicize/_inc/components/social-gate/style.scss
@@ -20,18 +20,18 @@
 
 	&__subtitle {
 		margin: 0 0 24px;
-		color: var(--wpds-color-foreground-content-neutral, #50575e);
+		color: var(--wpds-color-foreground-content-neutral);
 	}
 
 	&__error {
-		color: var(--wpds-color-foreground-content-error, #d63638);
+		color: var(--wpds-color-foreground-content-error);
 		margin-bottom: 16px;
 	}
 
 	&__tos {
 		margin-top: 16px;
 		font-size: 12px;
-		color: var(--wpds-color-foreground-content-neutral, #50575e);
+		color: var(--wpds-color-foreground-content-neutral);
 	}
 
 	&__price {
@@ -40,13 +40,13 @@
 
 	&__price-was {
 		text-decoration: line-through;
-		color: var(--wpds-color-foreground-content-neutral, #50575e);
+		color: var(--wpds-color-foreground-content-neutral);
 	}
 
 	&__price-legend {
 		display: block;
 		font-size: 12px;
-		color: var(--wpds-color-foreground-content-neutral, #50575e);
+		color: var(--wpds-color-foreground-content-neutral);
 	}
 
 	&__features {

--- a/projects/packages/publicize/_inc/components/social-page.scss
+++ b/projects/packages/publicize/_inc/components/social-page.scss
@@ -7,7 +7,7 @@
 // the sticky `.jp-admin-page-tabs` strip. This file adds only the page-specific
 // pieces: the off-white canvas and the tab content padding.
 
-$jetpack-social-inset: var(--wpds-dimension-padding-2xl, 24px);
+$jetpack-social-inset: var(--wpds-dimension-padding-2xl);
 
 // Both body classes: `jetpack_page_*` when Social is a submenu under the
 // Jetpack menu (Jetpack plugin), `toplevel_page_*` when it's a top-level menu

--- a/projects/packages/publicize/changelog/update-stylelint-more-no-token-fallback-values
+++ b/projects/packages/publicize/changelog/update-stylelint-more-no-token-fallback-values
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Comment: Remove manual WPDS token fallbacks from webpack admin styles so build-time PostCSS injects canonical design-token fallbacks.

--- a/projects/packages/search/changelog/update-stylelint-more-no-token-fallback-values
+++ b/projects/packages/search/changelog/update-stylelint-more-no-token-fallback-values
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Comment: Remove manual WPDS token fallbacks from dashboard styles so build-time PostCSS injects canonical design-token fallbacks.

--- a/projects/packages/search/src/dashboard/components/module-control/style.scss
+++ b/projects/packages/search/src/dashboard/components/module-control/style.scss
@@ -64,7 +64,7 @@
 	display: inline-flex;
 	align-items: center;
 	flex-wrap: wrap;
-	gap: var(--wpds-dimension-gap-sm, 8px);
+	gap: var(--wpds-dimension-gap-sm);
 }
 
 .jp-form-search-settings-group__toggle-description {

--- a/tools/js-tools/stylelint.config.base.mjs
+++ b/tools/js-tools/stylelint.config.base.mjs
@@ -105,6 +105,7 @@ const baseConfig = {
 				// Webpack packages with `@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks`
 				'projects/packages/publicize/_inc/**/*.{css,scss,sass}',
 				'projects/packages/search/**/*.{css,scss,sass}',
+				'projects/packages/videopress/src/**/*.{css,scss,sass}',
 			],
 			rules: {
 				'plugin-wpds/no-token-fallback-values': true,

--- a/tools/js-tools/stylelint.config.base.mjs
+++ b/tools/js-tools/stylelint.config.base.mjs
@@ -107,6 +107,7 @@ const baseConfig = {
 				'projects/packages/publicize/_inc/**/*.{css,scss,sass}',
 				'projects/packages/search/**/*.{css,scss,sass}',
 				'projects/packages/videopress/src/**/*.{css,scss,sass}',
+				'projects/plugins/boost/app/assets/src/**/*.{css,scss,sass}',
 			],
 			rules: {
 				'plugin-wpds/no-token-fallback-values': true,

--- a/tools/js-tools/stylelint.config.base.mjs
+++ b/tools/js-tools/stylelint.config.base.mjs
@@ -103,6 +103,7 @@ const baseConfig = {
 				'projects/packages/seo/routes/**/*.{css,scss,sass}',
 				'projects/packages/videopress/routes/**/*.{css,scss,sass}',
 				// Webpack packages with `@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks`
+				'projects/packages/forms/src/**/*.{css,scss,sass}',
 				'projects/packages/publicize/_inc/**/*.{css,scss,sass}',
 				'projects/packages/search/**/*.{css,scss,sass}',
 				'projects/packages/videopress/src/**/*.{css,scss,sass}',

--- a/tools/js-tools/stylelint.config.base.mjs
+++ b/tools/js-tools/stylelint.config.base.mjs
@@ -14,8 +14,9 @@ const baseConfig = {
 	rules: {
 		'plugin-wpds/no-unknown-ds-tokens': true,
 		'plugin-wpds/no-setting-wpds-custom-properties': true,
-		// Disabled globally: only wp-build dashboards configure `@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks`
-		// which adds fallbacks at build time.
+		// Disabled globally: only wp-build dashboards and webpack packages with
+		// `@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks`
+		// add fallbacks at build time.
 		'plugin-wpds/no-token-fallback-values': null,
 		// In addition to what `@wordpress/stylelint-config/scss-stylistic` does by default, also ignore comments containing /stylelint-disable/.
 		'@stylistic/max-line-length': [
@@ -88,8 +89,8 @@ const baseConfig = {
 	},
 	overrides: [
 		{
-			// Packages with `build:wp-build` in package.json.
 			files: [
+				// wp-build dashboards (`build:wp-build` in package.json; fallbacks via @wordpress/build).
 				'projects/packages/backup/routes/**/*.{css,scss,sass}',
 				'projects/packages/forms/routes/**/*.{css,scss,sass}',
 				'projects/packages/forms/src/dashboard/wp-build/**/*.{css,scss,sass}',
@@ -101,6 +102,9 @@ const baseConfig = {
 				'projects/packages/scan/routes/**/*.{css,scss,sass}',
 				'projects/packages/seo/routes/**/*.{css,scss,sass}',
 				'projects/packages/videopress/routes/**/*.{css,scss,sass}',
+				// Webpack packages with `@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks`
+				'projects/packages/publicize/_inc/**/*.{css,scss,sass}',
+				'projects/packages/search/**/*.{css,scss,sass}',
 			],
 			rules: {
 				'plugin-wpds/no-token-fallback-values': true,


### PR DESCRIPTION
Follow-up to https://github.com/Automattic/jetpack/pull/50110 which added linting for [WPDS tokens](https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/docs/tokens.md) but didn't enforce the "no fallbacks" rule yet.

At https://github.com/Automattic/jetpack/pull/50502 we started enforcing WP Build routes; this PR starts enforcing some of the bundles now using `@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks` to inject fallbacks automatically at build time.
 
## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Lint "no token fallbacks" for bundles using `@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks`
* Remove `var(--wpds-*, …)` fallbacks: all of them matched with canonical `@wordpress/theme` values
* Remove redundant legacy Jetpack token fallbacks in Forms if they were as fallback (2nd var), not if they are primary (1st var). Forms sometimes just uses WPDS tokens as fallbacks which would be good to clean up but not in this PR.


<details>
<summary>Bundles mostly stay the same</summary>
**Confirmed.** Before (`85920e3b10`) vs after (`8cbbea829d`) builds of search, publicize, videopress, forms, and boost are the same aside from WPDS fallback corrections (and the style content-hashes those change).

### Bundle identity
| Package | Files | Byte-identical | Diff cause |
|---|---|---|---|
| **search** | 78 | 78 | none |
| **videopress** | 42 | 42 | none |
| **boost** | 4 | 4 | none |
| **forms** (dist+build) | 101 | 95 | fallback corrections only |
| **publicize** | 15 | 7 | fallback corrections only |

After normalizing `var(--wpds-*, …)` fallbacks (and the `data-wp-hash` / `registerStyle` hashes driven by that CSS), **all 240 comparable CSS/JS files match**. Token sequences and counts are unchanged.

### Fallback corrections (manual → theme)
Only **forms** and **publicize** changed. Search/VideoPress/Boost had no mismatched manual fallbacks in these builds.

| Token | Before (manual) | After (theme) |
|---|---|---|
| `--wpds-color-background-surface-neutral-weak` | `#e7e7e7` | `#f4f4f4` |
| `--wpds-color-stroke-surface-neutral` | `var(--jp-forms-border-color, #e0e0e0)` | `#dbdbdb` |
| `--wpds-color-stroke-surface-neutral-weak` | `#e4e4e4` | `#f0f0f0` |
| `--wpds-color-foreground-content-neutral` | `var(--jp-gray-80)` / `#50575e` | `#1e1e1e` |
| `--wpds-color-foreground-content-neutral-weak` | `#757575` | `#707070` |
| `--wpds-color-foreground-content-error` | `#d63638` | `#470000` |
| `--wpds-color-stroke-focus` | `#3858e9` | `var(--wp-admin-theme-color, #3858e9)` |
| `--wpds-border-width-focus` | `2px` | `var(--wp-admin-border-width-focus, 2px)` |
| `--wpds-motion-duration-md` | `0.15s` | `200ms` |
| `--wpds-motion-easing-balanced` | `ease-out` | `cubic-bezier(0.4, 0, 0.2, 1)` |

</details>


## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Compare bundles; everything should now have fallback values
* Smoke test affected UIs