### PR TITLE
pnpmfile: remove stale overrides for @wordpress/* packages

### DIFF
--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -1,15 +1,11 @@
 // Packages we need to copy versions from for `@wordpress/dataviews/wp`.
 const wpPkgs = [
 	[ '@wordpress/components', 'change-case' ],
-	[ '@wordpress/components', 'colord' ],
-	[ '@wordpress/components', 'date-fns' ],
-	[ '@wordpress/components', 'deepmerge' ],
 	[ '@wordpress/components', '@emotion/cache' ],
 	[ '@wordpress/components', '@emotion/css' ],
 	[ '@wordpress/components', '@emotion/react' ],
 	[ '@wordpress/components', '@emotion/styled' ],
 	[ '@wordpress/components', '@emotion/utils' ],
-	[ '@wordpress/components', 'fast-deep-equal' ],
 	[ '@wordpress/components', '@floating-ui/react-dom' ],
 	[ '@wordpress/components', 'framer-motion' ],
 	[ '@wordpress/components', 'highlight-words-core' ],
@@ -17,7 +13,6 @@ const wpPkgs = [
 	[ '@wordpress/components', 'memize' ],
 	[ '@wordpress/components', '@use-gesture/react' ],
 	[ '@wordpress/components', 'uuid' ],
-	[ '@wordpress/components', '@wordpress/date' ],
 	[ '@wordpress/components', '@wordpress/hooks' ],
 	[ '@wordpress/components', 'react-colorful' ],
 	[ '@wordpress/components', 'react-day-picker' ],
@@ -138,29 +133,10 @@ async function fixDeps( pkg ) {
 				pkg.peerDependencies[ dep ] = ver.replace( /^\^?/, '>=' );
 			}
 		}
-
-		// Doesn't really need these at all with eslint 9 and our config.
-		pkg.peerDependenciesMeta ??= {};
-		pkg.peerDependenciesMeta[ '@typescript-eslint/eslint-plugin' ] = { optional: true };
-		pkg.peerDependenciesMeta[ '@typescript-eslint/parser' ] = { optional: true };
 	}
 
-	// Unnecessarily explicit deps. I don't think we really even need @wordpress/babel-preset-default at all.
-	if ( pkg.name === '@wordpress/babel-preset-default' ) {
-		for ( const [ dep, ver ] of Object.entries( pkg.dependencies ) ) {
-			if ( dep.startsWith( '@babel/' ) && ! ver.startsWith( '^' ) && ! ver.startsWith( '>' ) ) {
-				pkg.dependencies[ dep ] = '^' + ver;
-			}
-		}
-	}
-
-	// Outdated dependency and unnecessarily explicit deps.
+	// Outdated dependency
 	if ( pkg.name === '@wordpress/build' ) {
-		for ( const [ dep, ver ] of Object.entries( pkg.dependencies ) ) {
-			if ( ! ver.startsWith( '^' ) && ! ver.startsWith( '>' ) ) {
-				pkg.dependencies[ dep ] = '^' + ver;
-			}
-		}
 		if ( pkg.dependencies.cssnano === '^6.0.1' ) {
 			pkg.dependencies.cssnano = '^6 || ^7';
 		}

--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -403,7 +403,6 @@ function fixPeerDeps( pkg ) {
 	if (
 		( pkg.name === 'stylelint-config-recommended' ||
 			pkg.name === 'stylelint-config-recommended-scss' ||
-			pkg.name === '@stylistic/stylelint-plugin' ||
 			pkg.name === 'stylelint-scss' ) &&
 		pkg.peerDependencies?.stylelint?.startsWith( '^16.' )
 	) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
-pnpmfileChecksum: sha256-TsyVeBJhS5SLVvMrvXWG4HhpG6xBi+wPK6Zfe8eOYgs=
+pnpmfileChecksum: sha256-ZikcwXv2IUXUsJCxa0O8rTvJbiGdLkkyG2R9cf9QXWs=
 
 patchedDependencies:
   react-autosize-textarea: 5c09e1dee59caaaba3871f9d722f93e56b41169db486b059597e8f8c788aa464

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
-pnpmfileChecksum: sha256-bniQRcc4tTMY06AXyX9YsdiMmKUi9i/r4TFynjwrH1c=
+pnpmfileChecksum: sha256-TsyVeBJhS5SLVvMrvXWG4HhpG6xBi+wPK6Zfe8eOYgs=
 
 patchedDependencies:
   react-autosize-textarea: 5c09e1dee59caaaba3871f9d722f93e56b41169db486b059597e8f8c788aa464
@@ -11326,8 +11326,6 @@ packages:
     engines: {node: '>=18.12.0', npm: '>=8.19.2'}
     peerDependencies:
       '@babel/core': '>=7'
-      '@typescript-eslint/eslint-plugin': '*'
-      '@typescript-eslint/parser': '*'
       '@wordpress/theme': '*'
       eslint: ^9.0.0 || ^10.0.0
       eslint-config-prettier: '>=10.0.0'
@@ -11342,10 +11340,6 @@ packages:
       prettier: '>=3'
       typescript: '>=5'
     peerDependenciesMeta:
-      '@typescript-eslint/eslint-plugin':
-        optional: true
-      '@typescript-eslint/parser':
-        optional: true
       prettier:
         optional: true
       typescript:
@@ -25781,6 +25775,7 @@ snapshots:
       '@wordpress/components': 36.1.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(postcss@8.5.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/compose': 8.3.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/data': 10.50.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/date': 5.50.0
       '@wordpress/deprecated': 4.50.0
       '@wordpress/element': 8.2.0
       '@wordpress/i18n': 6.23.0
@@ -25791,6 +25786,10 @@ snapshots:
       '@wordpress/ui': 0.17.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/warning': 3.50.0
       clsx: 2.1.1
+      colord: 2.9.3
+      date-fns: 4.1.0
+      deepmerge: 4.3.1
+      fast-deep-equal: 3.1.3
       react: 18.3.1
       remove-accents: 0.5.0
     optionalDependencies:
@@ -25803,14 +25802,9 @@ snapshots:
       '@floating-ui/react-dom': 2.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react': 18.3.28
       '@use-gesture/react': 10.3.1(react@18.3.1)
-      '@wordpress/date': 5.50.0
       '@wordpress/hooks': 4.50.0
       change-case: 4.1.2
-      colord: 2.9.3
       colorjs.io: 0.6.1
-      date-fns: 4.1.0
-      deepmerge: 4.3.1
-      fast-deep-equal: 3.1.3
       framer-motion: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       highlight-words-core: 1.2.3
       is-plain-object: 5.0.0
@@ -25836,6 +25830,7 @@ snapshots:
       '@wordpress/components': 36.1.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/compose': 8.3.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/data': 10.50.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/date': 5.50.0
       '@wordpress/deprecated': 4.50.0
       '@wordpress/element': 8.2.0
       '@wordpress/i18n': 6.23.0
@@ -25846,6 +25841,10 @@ snapshots:
       '@wordpress/ui': 0.17.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/warning': 3.50.0
       clsx: 2.1.1
+      colord: 2.9.3
+      date-fns: 4.1.0
+      deepmerge: 4.3.1
+      fast-deep-equal: 3.1.3
       react: 18.3.1
       remove-accents: 0.5.0
     optionalDependencies:
@@ -25858,14 +25857,9 @@ snapshots:
       '@floating-ui/react-dom': 2.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react': 18.3.28
       '@use-gesture/react': 10.3.1(react@18.3.1)
-      '@wordpress/date': 5.50.0
       '@wordpress/hooks': 4.50.0
       change-case: 4.1.2
-      colord: 2.9.3
       colorjs.io: 0.6.1
-      date-fns: 4.1.0
-      deepmerge: 4.3.1
-      fast-deep-equal: 3.1.3
       framer-motion: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       highlight-words-core: 1.2.3
       is-plain-object: 5.0.0
@@ -25891,6 +25885,7 @@ snapshots:
       '@wordpress/components': 36.1.0(@types/react@18.3.28)(postcss@8.5.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/compose': 8.3.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/data': 10.50.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/date': 5.50.0
       '@wordpress/deprecated': 4.50.0
       '@wordpress/element': 8.2.0
       '@wordpress/i18n': 6.23.0
@@ -25901,6 +25896,10 @@ snapshots:
       '@wordpress/ui': 0.17.0(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/warning': 3.50.0
       clsx: 2.1.1
+      colord: 2.9.3
+      date-fns: 4.1.0
+      deepmerge: 4.3.1
+      fast-deep-equal: 3.1.3
       react: 18.3.1
       remove-accents: 0.5.0
     optionalDependencies:
@@ -25913,14 +25912,9 @@ snapshots:
       '@floating-ui/react-dom': 2.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react': 18.3.28
       '@use-gesture/react': 10.3.1(react@18.3.1)
-      '@wordpress/date': 5.50.0
       '@wordpress/hooks': 4.50.0
       change-case: 4.1.2
-      colord: 2.9.3
       colorjs.io: 0.6.1
-      date-fns: 4.1.0
-      deepmerge: 4.3.1
-      fast-deep-equal: 3.1.3
       framer-motion: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       highlight-words-core: 1.2.3
       is-plain-object: 5.0.0
@@ -25946,6 +25940,7 @@ snapshots:
       '@wordpress/components': 36.1.0(@types/react@18.3.28)(postcss@8.5.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@8.0.16(sass-embedded@1.97.3))
       '@wordpress/compose': 8.3.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/data': 10.50.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/date': 5.50.0
       '@wordpress/deprecated': 4.50.0
       '@wordpress/element': 8.2.0
       '@wordpress/i18n': 6.23.0
@@ -25956,6 +25951,10 @@ snapshots:
       '@wordpress/ui': 0.17.0(@types/react@18.3.28)(date-fns@4.1.0)(postcss@8.5.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@8.0.16(sass-embedded@1.97.3))
       '@wordpress/warning': 3.50.0
       clsx: 2.1.1
+      colord: 2.9.3
+      date-fns: 4.1.0
+      deepmerge: 4.3.1
+      fast-deep-equal: 3.1.3
       react: 18.3.1
       remove-accents: 0.5.0
     optionalDependencies:
@@ -25968,14 +25967,9 @@ snapshots:
       '@floating-ui/react-dom': 2.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react': 18.3.28
       '@use-gesture/react': 10.3.1(react@18.3.1)
-      '@wordpress/date': 5.50.0
       '@wordpress/hooks': 4.50.0
       change-case: 4.1.2
-      colord: 2.9.3
       colorjs.io: 0.6.1
-      date-fns: 4.1.0
-      deepmerge: 4.3.1
-      fast-deep-equal: 3.1.3
       framer-motion: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       highlight-words-core: 1.2.3
       is-plain-object: 5.0.0
@@ -26001,6 +25995,7 @@ snapshots:
       '@wordpress/components': 36.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/compose': 8.3.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/data': 10.50.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/date': 5.50.0
       '@wordpress/deprecated': 4.50.0
       '@wordpress/element': 8.2.0
       '@wordpress/i18n': 6.23.0
@@ -26011,6 +26006,10 @@ snapshots:
       '@wordpress/ui': 0.17.0(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/warning': 3.50.0
       clsx: 2.1.1
+      colord: 2.9.3
+      date-fns: 4.1.0
+      deepmerge: 4.3.1
+      fast-deep-equal: 3.1.3
       react: 18.3.1
       remove-accents: 0.5.0
     optionalDependencies:
@@ -26023,14 +26022,9 @@ snapshots:
       '@floating-ui/react-dom': 2.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react': 18.3.28
       '@use-gesture/react': 10.3.1(react@18.3.1)
-      '@wordpress/date': 5.50.0
       '@wordpress/hooks': 4.50.0
       change-case: 4.1.2
-      colord: 2.9.3
       colorjs.io: 0.6.1
-      date-fns: 4.1.0
-      deepmerge: 4.3.1
-      fast-deep-equal: 3.1.3
       framer-motion: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       highlight-words-core: 1.2.3
       is-plain-object: 5.0.0
@@ -26056,6 +26050,7 @@ snapshots:
       '@wordpress/components': 37.0.1-next.v.202607070741.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/compose': 8.3.1-next.v.202607070741.0(@types/react@18.3.28)(react@18.3.1)
       '@wordpress/data': 10.50.1-next.v.202607070741.0(@types/react@18.3.28)(react@18.3.1)
+      '@wordpress/date': 5.50.1-next.v.202607070741.0
       '@wordpress/deprecated': 4.50.1-next.v.202607070741.0
       '@wordpress/element': 8.2.1-next.v.202607070741.0
       '@wordpress/i18n': 6.23.1-next.v.202607070741.0
@@ -26066,6 +26061,10 @@ snapshots:
       '@wordpress/ui': 0.18.1-next.v.202607070741.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@wordpress/warning': 3.50.1-next.v.202607070741.0
       clsx: 2.1.1
+      colord: 2.9.3
+      date-fns: 4.1.0
+      deepmerge: 4.3.1
+      fast-deep-equal: 3.1.3
       react: 18.3.1
       remove-accents: 0.5.0
     optionalDependencies:
@@ -26078,14 +26077,9 @@ snapshots:
       '@floating-ui/react-dom': 2.1.9(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react': 18.3.28
       '@use-gesture/react': 10.3.1(react@18.3.1)
-      '@wordpress/date': 5.50.1-next.v.202607070741.0
       '@wordpress/hooks': 4.50.1-next.v.202607070741.0
       change-case: 4.1.2
-      colord: 2.9.3
       colorjs.io: 0.6.1
-      date-fns: 4.1.0
-      deepmerge: 4.3.1
-      fast-deep-equal: 3.1.3
       framer-motion: 11.18.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       highlight-words-core: 1.2.3
       is-plain-object: 5.0.0


### PR DESCRIPTION
Fixes #

## Proposed changes

With the recent dependency management improvements in Gutenberg, `@wordpress/*` packages are in a slightly better shape, thus some of our pnpmfile overrides no longer do anything. Each removal below was verified against the original npm manifests of the versions currently resolved in the lockfile:

* Remove the `wpPkgs` entries for `colord`, `date-fns`, `deepmerge`, `fast-deep-equal`, and `@wordpress/date` — `@wordpress/dataviews` (17.1.0) now declares these itself, at the same ranges `@wordpress/components` uses.
* Remove the `@typescript-eslint/*` `peerDependenciesMeta` entries for `@wordpress/eslint-plugin` — 25.6.0 depends on the combined `typescript-eslint` package instead, so the dep→peer loop never creates those peers anymore.
* Remove the `@wordpress/babel-preset-default` and `@wordpress/build` caret-adding loops — all their deps already use caret ranges. The still-needed `cssnano` fix for `@wordpress/build` is kept.
* Remove `@stylistic/stylelint-plugin` from the stylelint peer-bump group — 5.2.1 already declares `stylelint: ^17.6.0`, so the `^16.` condition can never match.

No resolved dependency versions change. The lockfile diff is the pnpmfile checksum plus the five dataviews deps moving from hook-injected `optionalDependencies` to its own `dependencies`.

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run `pnpm install` — it should complete without errors, lockfile changes, or `pnpmfile hack needs updating` warnings.
* Check `git diff trunk -- pnpm-lock.yaml` — no package version changes, only the checksum and the dataviews dependency re-categorization described above.
