### PR TITLE
Admin bar: hide the house dashicon / default favicon when site icon is set

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-wpcom-admin-bar-site-icon
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-wpcom-admin-bar-site-icon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin bar: hide the house dashicon when site icon is set

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.scss
@@ -103,7 +103,7 @@
 
 #wpadminbar #wp-admin-bar-site-name {
 
-	> .ab-item::before {
+	&:not(.has-site-icon) > .ab-item::before {
 
 		/**
 		 * Always show the House icon by the site name.

--- a/projects/plugins/wpcomsh/changelog/fix-wpcom-admin-bar-site-icon
+++ b/projects/plugins/wpcomsh/changelog/fix-wpcom-admin-bar-site-icon
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Admin bar: don't treat the default favicon fallback as a site icon

--- a/projects/plugins/wpcomsh/feature-plugins/managed-themes.php
+++ b/projects/plugins/wpcomsh/feature-plugins/managed-themes.php
@@ -234,6 +234,11 @@ function wpcomsh_load_theme_compat_file() {
 add_action( 'after_setup_theme', 'wpcomsh_load_theme_compat_file', 0 ); // Hook early so that after_setup_theme can still be used at default priority.
 
 /**
+ * The default site icon served when a site doesn't have a custom one.
+ */
+const WPCOMSH_DEFAULT_SITE_ICON_URL = 'https://s0.wp.com/i/webclip.png';
+
+/**
  * Provides a favicon fallback in case it's undefined.
  *
  * @param string $url Site Icon URL.
@@ -241,9 +246,26 @@ add_action( 'after_setup_theme', 'wpcomsh_load_theme_compat_file', 0 ); // Hook 
  */
 function wpcomsh_site_icon_url( $url ) {
 	if ( empty( $url ) ) {
-		$url = 'https://s0.wp.com/i/webclip.png';
+		$url = WPCOMSH_DEFAULT_SITE_ICON_URL;
 	}
 
 	return $url;
 }
 add_filter( 'get_site_icon_url', 'wpcomsh_site_icon_url' );
+
+/**
+ * Hides the site icon in the admin bar when the site has no custom site icon.
+ *
+ * This effectively ignores the favicon fallback provided by the
+ * `wpcomsh_site_icon_url()` function above.
+ *
+ * @param bool $show Whether to show site icons in the admin bar.
+ * @return bool Whether to show site icons in the admin bar.
+ */
+function wpcomsh_admin_bar_hide_default_site_icon( $show ) {
+	if ( $show && WPCOMSH_DEFAULT_SITE_ICON_URL === get_site_icon_url() ) {
+		return false;
+	}
+	return $show;
+}
+add_filter( 'wp_admin_bar_show_site_icons', 'wpcomsh_admin_bar_hide_default_site_icon' );


### PR DESCRIPTION
Fixes DOTCOM-17787

## Proposed changes

Starting from WP 7.1, we replace the house dashicons with the site icon if set. See:

- https://github.com/WordPress/wordpress-develop/pull/11781

In `jetpack-mu-wpcom`, there's a logic to always replace the odometer icon (in frontend) to house dashicon with `!important`. It conflicts with the new logic, so we prepend `:not(.has-site-icon)` to fix this. 

Additionally, in Atomic sites, we fix the logic so that the default site icon is not shown in the admin bar (as then there will be duplicate W icons next to each other).

## Does this pull request change what data or activity we track or use?

No

## Testing instructions

1. Prepare a WoW dev site.
1. Apply this patch (via Beta Tester).
1. Regression test:
   1. Go to wp-admin and site frontend and verify there's only the house dashicon.
   2. Go to Settings -> General, upload a site icon, save, then verify the same thing above.
1. Remove the site icon again.
1. Now Install Gutenberg 23.6 (RC).
   1. Go to wp-admin and site frontend and verify there's only the house dashicon.
   2. Go to Settings -> General, upload a site icon, save:
       1. Go to wp-admin and site frontend and verify there's only site icon and not the house dashicon.

## Screenshots

### Without site icon

Before

<img width="300" height="32" alt="image" src="https://github.com/user-attachments/assets/1fc4584d-7907-4f05-8234-f91fae51a87b" />

After

<img width="300" height="32" alt="image" src="https://github.com/user-attachments/assets/e987149a-405b-49a9-95ab-fd3c3e0edc37" />


### With site icon

Before

<img width="300" height="32" alt="image" src="https://github.com/user-attachments/assets/a4920306-087e-4955-84d9-680928809793" />

After

<img width="300" height="32" alt="image" src="https://github.com/user-attachments/assets/8904a903-3819-49fb-a9bc-4983849085a0" />

