### PR TITLE
Podcast: read episode block metadata when nested in Group/Columns

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-nested-episode-tags
+++ b/projects/packages/podcast/changelog/fix-podcast-nested-episode-tags
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast feed: read episode block attrs when the Podcast Episode block is nested inside Group/Columns, so item-level RSS tags aren't dropped.

--- a/projects/packages/podcast/changelog/fix-podcast-nested-episode-tags
+++ b/projects/packages/podcast/changelog/fix-podcast-nested-episode-tags
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Podcast feed: read episode block attrs when the Podcast Episode block is nested inside Group/Columns, so item-level RSS tags aren't dropped.
+Podcast feed: fixed missing episode details when the Podcast Episode block sits inside another block.

--- a/projects/packages/podcast/src/feed/class-episode-block-tags.php
+++ b/projects/packages/podcast/src/feed/class-episode-block-tags.php
@@ -61,6 +61,9 @@ class Episode_Block_Tags {
 	 * First-wins: a post containing multiple `jetpack/podcast-episode` blocks
 	 * is semantically odd (one item = one episode) so we don't try to merge.
 	 *
+	 * The block can be nested inside layout blocks (Group, Columns, …), so we
+	 * search the full tree depth-first rather than only top-level results.
+	 *
 	 * @param WP_Post $post Episode post.
 	 * @return array<string, mixed>
 	 */
@@ -71,12 +74,33 @@ class Episode_Block_Tags {
 		if ( false === strpos( $post->post_content, '<!-- wp:jetpack/podcast-episode' ) ) {
 			return array();
 		}
-		foreach ( parse_blocks( $post->post_content ) as $block ) {
+		$block = self::find_episode_block( parse_blocks( $post->post_content ) );
+		if ( null === $block ) {
+			return array();
+		}
+		return isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : array();
+	}
+
+	/**
+	 * Depth-first search for the first `jetpack/podcast-episode` block, descending
+	 * into `innerBlocks` so nesting inside Group/Columns/etc. doesn't hide it.
+	 *
+	 * @param array $blocks Parsed blocks (from parse_blocks() or an innerBlocks array).
+	 * @return array<string, mixed>|null The matching block, or null if none found.
+	 */
+	private static function find_episode_block( array $blocks ): ?array {
+		foreach ( $blocks as $block ) {
 			if ( isset( $block['blockName'] ) && 'jetpack/podcast-episode' === $block['blockName'] ) {
-				return isset( $block['attrs'] ) && is_array( $block['attrs'] ) ? $block['attrs'] : array();
+				return $block;
+			}
+			if ( ! empty( $block['innerBlocks'] ) && is_array( $block['innerBlocks'] ) ) {
+				$found = self::find_episode_block( $block['innerBlocks'] );
+				if ( null !== $found ) {
+					return $found;
+				}
 			}
 		}
-		return array();
+		return null;
 	}
 
 	/**

--- a/projects/packages/podcast/tests/php/Feed/Episode_Block_Tags_Test.php
+++ b/projects/packages/podcast/tests/php/Feed/Episode_Block_Tags_Test.php
@@ -56,6 +56,41 @@ class Episode_Block_Tags_Test extends BaseTestCase {
 		$this->assertStringNotContainsString( '<itunes:episode>99</itunes:episode>', $xml );
 	}
 
+	public function test_render_finds_block_nested_in_group() {
+		$xml = $this->render_post(
+			'<!-- wp:group --><div class="wp-block-group">'
+			. '<!-- wp:jetpack/podcast-episode {"episodeNumber":7} /-->'
+			. '</div><!-- /wp:group -->'
+		);
+
+		$this->assertStringContainsString( '<itunes:episode>7</itunes:episode>', $xml );
+	}
+
+	public function test_render_finds_deeply_nested_block() {
+		$xml = $this->render_post(
+			'<!-- wp:columns --><div class="wp-block-columns">'
+			. '<!-- wp:column --><div class="wp-block-column">'
+			. '<!-- wp:jetpack/podcast-episode {"seasonNumber":3} /-->'
+			. '</div><!-- /wp:column -->'
+			. '</div><!-- /wp:columns -->'
+		);
+
+		$this->assertStringContainsString( '<itunes:season>3</itunes:season>', $xml );
+	}
+
+	public function test_render_first_block_wins_across_nesting() {
+		// Depth-first order: the nested block appears first in reading order and wins.
+		$xml = $this->render_post(
+			'<!-- wp:group --><div class="wp-block-group">'
+			. '<!-- wp:jetpack/podcast-episode {"episodeNumber":1} /-->'
+			. '</div><!-- /wp:group -->'
+			. '<!-- wp:jetpack/podcast-episode {"episodeNumber":99} /-->'
+		);
+
+		$this->assertStringContainsString( '<itunes:episode>1</itunes:episode>', $xml );
+		$this->assertStringNotContainsString( '<itunes:episode>99</itunes:episode>', $xml );
+	}
+
 	public function test_episode_number_emits_both_namespaces() {
 		$xml = $this->render_from_attrs( array( 'episodeNumber' => 12 ) );
 


### PR DESCRIPTION
## Proposed changes
The podcast feed reads item-level RSS metadata (episode/season number, transcript, chapters, people, soundbites, cover art, etc.) from the first `jetpack/podcast-episode` block in a post. `Episode_Block_Tags::get_block_attrs()` only walked the **top-level** results of `parse_blocks()`, so when the Podcast Episode block was nested inside a layout block (Group, Columns → Column, …) it lived in the parent's `innerBlocks` and was never found. Result: the player still rendered, but podcast directories silently received an episode item stripped of all its `<itunes:*>` / `<podcast:*>` tags.

* Replace the flat top-level loop with a depth-first `find_episode_block()` helper that descends into `innerBlocks`.
* Preserve the existing "first-wins" semantics — first match in document reading order (pre-order traversal), so a nested block earlier in the post beats a later top-level one.
* Add regression tests for a block nested in Group, deeply nested in Columns→Column, and first-wins across nesting.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Create/edit a podcast episode post and place a **Podcast Episode** block **inside a Group or Columns block**. Set some episode metadata (e.g. episode number, transcript URL).
* View the episode's feed item (or run the podcast package PHPUnit suite).
* Confirm the item-level `<itunes:*>` / `<podcast:*>` tags are present. Before this fix they were dropped for nested blocks.
* Automated: `cd projects/packages/podcast && composer phpunit -- --filter Episode_Block_Tags` — all green, including the new nested-block tests.