### PR TITLE
wpcomsh: enable error reporting for Atomic sites with gutenberg-react19-sticker

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-error-reporting-react-19
+++ b/projects/plugins/wpcomsh/changelog/add-error-reporting-react-19
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Enable wp-admin JS error reporting on sites participating in the `gutenberg-react-19` experiment.

--- a/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
+++ b/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
@@ -64,6 +64,18 @@ function wpcomsh_remove_gutenberg_experimental_menu() {
 }
 
 /**
+ * Enable wp-admin JS error reporting on sites participating in the `gutenberg-react-19`
+ * experiment, so that errors caused by the React 19 upgrade are captured.
+ *
+ * @param bool $is_enabled Whether error reporting is enabled.
+ * @return bool
+ */
+function wpcomsh_enable_error_reporting_for_react_19( $is_enabled ) {
+	return $is_enabled || ( function_exists( 'wpcomsh_is_site_sticker_active' ) && wpcomsh_is_site_sticker_active( 'gutenberg-react-19' ) );
+}
+add_filter( 'a8c_enable_error_reporting', 'wpcomsh_enable_error_reporting_for_react_19' );
+
+/**
  * Hotfix a Gutenberg bug that inadvertently loads wp-reset-editor-syles stylesheet in the
  * iframed site editor.
  *

--- a/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
+++ b/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
@@ -67,11 +67,22 @@ function wpcomsh_remove_gutenberg_experimental_menu() {
  * Enable wp-admin JS error reporting on sites participating in the `gutenberg-react-19`
  * experiment, so that errors caused by the React 19 upgrade are captured.
  *
+ * Reporting is enabled only for WP.com-connected users, who have accepted the WP.com
+ * terms of service and privacy policy. Local users have made no such agreement.
+ *
  * @param bool $is_enabled Whether error reporting is enabled.
  * @return bool
  */
 function wpcomsh_enable_error_reporting_for_react_19( $is_enabled ) {
-	return $is_enabled || ( function_exists( 'wpcomsh_is_site_sticker_active' ) && wpcomsh_is_site_sticker_active( 'gutenberg-react-19' ) );
+	if ( $is_enabled ) {
+		return true;
+	}
+
+	if ( ! function_exists( 'is_user_connected' ) || ! is_user_connected( get_current_user_id() ) ) {
+		return false;
+	}
+
+	return function_exists( 'wpcomsh_is_site_sticker_active' ) && wpcomsh_is_site_sticker_active( 'gutenberg-react-19' );
 }
 add_filter( 'a8c_enable_error_reporting', 'wpcomsh_enable_error_reporting_for_react_19' );
 


### PR DESCRIPTION
After preparation in #50483 and #50503, this PR enables Logstash error reporting for Atomic sites with the `gutenberg-react-19` sticker. This will help us track errors on sites that enable the React 19 experiment. The entire reporting is `wp-admin` only.

## Does this pull request change what data or activity we track or use?

Yes, it adds JS error tracking on `wp-admin` pages. Error data are sent to WordPress.com REST API and stored in Logstash.

## Testing instructions:
Install the version of `wpcomsh` from this branch to your testing WoA site (using the automated instructions from a PR comment).

In `wp-admin`, verify that the `error-reporting.js` script is being loaded.

Force the `wp-admin` to crash. I use a custom plugin with code similar to what is described in #50503 testing instructions.

Verify that the error has been captured and sent to `/js-error`.

Verify in Logstash that the error has been received and stored. I use a `feature: "wp-admin"` Kibana query to find recent error reports.