### PR TITLE
My Jetpack: add a Stats config to the pricing interstitial

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/config.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/config.ts
@@ -7,6 +7,7 @@ import { getJetpackAiConfig } from './products/jetpack-ai';
 import { getProtectConfig } from './products/protect';
 import { getSearchConfig } from './products/search';
 import { getSocialConfig } from './products/social';
+import { getStatsConfig } from './products/stats.tsx';
 import { getVideoPressConfig } from './products/videopress';
 import { ProductConfig } from './types';
 
@@ -23,6 +24,7 @@ export const getProductConfigs = (): ProductConfigs => ( {
 	protect: getProtectConfig(),
 	social: getSocialConfig(),
 	search: getSearchConfig(),
+	stats: getStatsConfig(),
 	videopress: getVideoPressConfig(),
 	'jetpack-ai': getJetpackAiConfig(),
 } );

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/products/shared-labels.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/products/shared-labels.ts
@@ -20,6 +20,7 @@ export const getTranslatableFeatureLabels = () => ( {
 	REAL_TIME_BACKUPS: __( 'Real-time backups and restores', 'jetpack-my-jetpack' ),
 	DETAILED_STATS: __( 'Detailed stats and insights', 'jetpack-my-jetpack' ),
 	MALWARE_SCANNING: __( 'Malware scanning and protection', 'jetpack-my-jetpack' ),
+	SPAM_FILTERING: __( 'Spam filtering for comments and forms', 'jetpack-my-jetpack' ),
 	VIDEO_HOSTING_1TB: __( 'Video hosting (1TB, ad-free)', 'jetpack-my-jetpack' ),
 	INSTANT_SITE_SEARCH: __( 'Instant site search', 'jetpack-my-jetpack' ),
 	SOCIAL_TOOLS: __( 'Social tools', 'jetpack-my-jetpack' ),

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/products/stats.tsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/products/stats.tsx
@@ -1,0 +1,91 @@
+import { StatsIcon } from '@automattic/jetpack-components';
+import { __ } from '@wordpress/i18n';
+import { ProductConfig } from '../types';
+import { getTranslatableFeatureLabels, COMPLETE, COMPLETE_SLUG } from './shared-labels';
+
+const StatsLogo = ( { height = 32 } ) => <StatsIcon size={ height } />;
+
+/**
+ * Get the configuration for the product.
+ *
+ * @return The configuration object for the product.
+ */
+export function getStatsConfig(): ProductConfig {
+	const {
+		INCLUDED,
+		NOT_INCLUDED,
+		FREE,
+		START_FOR_FREE,
+		GET_COMPLETE,
+		REAL_TIME_BACKUPS,
+		MALWARE_SCANNING,
+		SPAM_FILTERING,
+		INSTANT_SITE_SEARCH,
+		VIDEO_HOSTING_1TB,
+		PRIORITY_SUPPORT,
+	} = getTranslatableFeatureLabels();
+
+	return {
+		title: __( 'Simple, yet powerful stats to grow your site', 'jetpack-my-jetpack' ),
+		logo: StatsLogo,
+		bundle: COMPLETE_SLUG,
+		features: [
+			{
+				name: __( 'Real-time data on visitors', 'jetpack-my-jetpack' ),
+				free: { included: true, label: INCLUDED },
+				paid: { included: true, label: INCLUDED },
+				bundle: { included: true, label: __( 'All Stats features', 'jetpack-my-jetpack' ) },
+			},
+			{
+				name: __( 'Traffic stats and trends for post and pages', 'jetpack-my-jetpack' ),
+				free: { included: true, label: INCLUDED },
+				paid: { included: true, label: INCLUDED },
+				bundle: { included: true, label: REAL_TIME_BACKUPS },
+			},
+			{
+				name: __( 'Detailed statistics about links leading to your site', 'jetpack-my-jetpack' ),
+				free: { included: true, label: INCLUDED },
+				paid: { included: true, label: INCLUDED },
+				bundle: { included: true, label: MALWARE_SCANNING },
+			},
+			{
+				name: __( 'GDPR compliant', 'jetpack-my-jetpack' ),
+				free: { included: true, label: INCLUDED },
+				paid: { included: true, label: INCLUDED },
+				bundle: { included: true, label: SPAM_FILTERING },
+			},
+			{
+				name: __( 'Access to upcoming advanced features', 'jetpack-my-jetpack' ),
+				free: { included: false, label: NOT_INCLUDED },
+				paid: { included: true, label: INCLUDED },
+				bundle: { included: true, label: INSTANT_SITE_SEARCH },
+			},
+			{
+				name: __( 'Commercial use', 'jetpack-my-jetpack' ),
+				free: { included: false, label: NOT_INCLUDED },
+				paid: { included: true, label: INCLUDED },
+				bundle: { included: true, label: VIDEO_HOSTING_1TB },
+			},
+			{
+				name: PRIORITY_SUPPORT,
+				free: { included: false, label: NOT_INCLUDED },
+				paid: { included: true, label: INCLUDED },
+				bundle: { included: true, label: PRIORITY_SUPPORT },
+			},
+		],
+		tiers: {
+			free: {
+				name: FREE,
+				cta: START_FOR_FREE,
+			},
+			paid: {
+				name: 'Stats',
+				cta: __( 'Get Stats', 'jetpack-my-jetpack' ),
+			},
+			bundle: {
+				name: COMPLETE,
+				cta: GET_COMPLETE,
+			},
+		},
+	};
+}

--- a/projects/packages/my-jetpack/changelog/myjp-325-my-jetpack-stats-upsell-looks-broken
+++ b/projects/packages/my-jetpack/changelog/myjp-325-my-jetpack-stats-upsell-looks-broken
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-My Jetpack: register a Stats pricing-table config so the Stats interstitial no longer renders an empty column
+Register a pricing-table config for Stats so the interstitial no longer renders an empty column.

--- a/projects/packages/my-jetpack/changelog/myjp-325-my-jetpack-stats-upsell-looks-broken
+++ b/projects/packages/my-jetpack/changelog/myjp-325-my-jetpack-stats-upsell-looks-broken
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: register a Stats pricing-table config so the Stats interstitial no longer renders an empty column


### PR DESCRIPTION
Fixes MYJP-325

## Proposed changes

The Stats interstitial (`#/add-stats`) rendered with an empty right-hand column: `PricingInterstitial` had no `stats` entry in `getProductConfigs()`, so it fell back to the legacy `ProductInterstitial` with no children and no bundle — an empty `<Col lg={5}>`. A Stats config was never added when the pricing-table interstitials were introduced in #44801.

* Add `products/stats.tsx` with a `getStatsConfig()` pricing-table config (Free / Stats / Complete tiers), modeled on the Search config. Feature rows reuse the existing strings from `class-stats.php::get_features()`.
* Register the `stats` key in `config.ts` so the slug no longer takes the legacy fallback.
* Add a shared `SPAM_FILTERING` label to `shared-labels.ts` for the Complete column.
* Header logo: there's no Stats wordmark in the repo, so this wraps `StatsIcon` from `@automattic/jetpack-components` with the expected `height` prop.

A couple of judgment calls worth a second opinion:

* **Bundle column is Complete**, matching every other interstitial config (only security products pitch Security). `Stats::is_upgradable_by_bundle()` also lists `growth`; switching would mean rewriting the bundle-column feature copy too, since the current rows describe Complete-only features (backups, malware scanning, 1TB video, instant search).
* **Copy.** Row labels come from the existing Stats feature list and the title is new; happy to adjust if design/product want different wording.

Deliberately unchanged: `Stats::get_pricing_for_ui()` still doesn't expose `wpcom_free_product_slug`, so "Start for Free" activates the module without a WordPress.com checkout. PWYW also stays out of this table — it's only ever offered in the WordPress.com-powered stats purchase flow (reached from the product card's purchase URL), which this PR doesn't touch.

### Before / After

| Before | After |
| --- | --- |
| <img src="https://github.com/Automattic/jetpack/raw/screenshots/myjp-325-my-jetpack-stats-upsell-looks-broken/before.png" alt="Stats interstitial before: lone product card with an empty right-hand column" /> | <img src="https://github.com/Automattic/jetpack/raw/screenshots/myjp-325-my-jetpack-stats-upsell-looks-broken/after.png" alt="Stats interstitial after: full Free / Stats / Complete pricing table" /> |

## Related product discussion/links

* MYJP-325

## Does this pull request change what data or activity we track or use?

No. The interstitial fires the same existing `jetpack_myjetpack_product_interstitial_*` events as other configured products.

## Testing instructions

* On a connected test site running this branch, go to **Jetpack → My Jetpack** and open `#/add-stats` (or click "Learn more" on the Stats row of the Products tab — it routes here for any site without a paid Stats plan).
* Confirm the page shows the full three-column pricing table (Free / Stats / Complete) instead of a product card next to an empty column.
* "Start for Free" should activate Stats with no checkout and land you on the Stats admin page (`admin.php?page=stats`, its post-activation URL).
* "Get Stats" should go to checkout for `jetpack_stats_yearly`; "Get Complete" to the Complete checkout.
