### PR TITLE
WOOA7S-1625: Premium Analytics: add the video detail page shell and links

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-wooa7s-1625-video-detail-page-shell
+++ b/projects/packages/premium-analytics/changelog/add-wooa7s-1625-video-detail-page-shell
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add the VideoPress video detail page shell and links.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/index.ts
@@ -166,6 +166,7 @@ export {
 	useStatsSingleVideo,
 	type StatsSingleVideoDataPoint,
 	type StatsSingleVideoPage,
+	type StatsSingleVideoPost,
 	type StatsSingleVideoParams,
 	type StatsSingleVideoResponse,
 } from './use-stats-single-video';

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-single-video.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-single-video.ts
@@ -7,7 +7,11 @@ import type { UseStatsOptions } from './use-stats-report';
 import type { StatsSingleVideoReport } from '../processing/stats';
 import type { StatsSingleVideoParams } from '../queries/stats-single-video-query';
 
-export type { StatsSingleVideoDataPoint, StatsSingleVideoPage } from '../processing/stats';
+export type {
+	StatsSingleVideoDataPoint,
+	StatsSingleVideoPage,
+	StatsSingleVideoPost,
+} from '../processing/stats';
 export type { StatsSingleVideoParams } from '../queries/stats-single-video-query';
 
 export type StatsSingleVideoResponse = StatsSingleVideoReport;

--- a/projects/packages/premium-analytics/packages/data/src/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/index.ts
@@ -186,6 +186,7 @@ export {
 	useStatsSingleVideo,
 	type StatsSingleVideoDataPoint,
 	type StatsSingleVideoPage,
+	type StatsSingleVideoPost,
 	type StatsSingleVideoParams,
 	type StatsSingleVideoResponse,
 } from './hooks/use-stats-single-video';

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/single-video.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/single-video.ts
@@ -9,6 +9,7 @@ export const singleVideoFixture = {
 		ID: 31533,
 		post_title: 'Launch recap',
 		post_date: '2026-06-12 14:30:00',
+		post_mime_type: 'video/mp4',
 	},
 };
 

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/single-video.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/single-video.ts
@@ -5,9 +5,15 @@ export const singleVideoFixture = {
 		[ '2026-06-14', 0 ],
 	],
 	pages: [ 'https://example.com/intro-video/', 'https://example.com/2026/06/launch-recap/' ],
+	post: {
+		ID: 31533,
+		post_title: 'Launch recap',
+		post_date: '2026-06-12 14:30:00',
+	},
 };
 
 export const singleVideoEmptyFixture = {
 	data: [],
 	pages: [],
+	post: null,
 };

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/single-video.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/single-video.test.ts
@@ -25,6 +25,7 @@ describe( 'Stats single video normalizer', () => {
 				id: 31533,
 				title: 'Launch recap',
 				date: '2026-06-12 14:30:00',
+				mimeType: 'video/mp4',
 			},
 		} );
 	} );
@@ -59,17 +60,23 @@ describe( 'Stats single video normalizer', () => {
 	it( 'keeps only well-formed attachment post fields', () => {
 		expect(
 			sanitizeStatsSingleVideoResponse( {
-				post: { ID: '42', post_title: 'Demo', post_date: '2026-06-15 09:00:00' },
+				post: {
+					ID: '42',
+					post_title: 'Demo',
+					post_date: '2026-06-15 09:00:00',
+					post_mime_type: 'video/webm',
+				},
 			} ).post
 		).toEqual( {
 			id: 42,
 			title: 'Demo',
 			date: '2026-06-15 09:00:00',
+			mimeType: 'video/webm',
 		} );
 
 		expect(
 			sanitizeStatsSingleVideoResponse( {
-				post: { ID: -1, post_title: 7, post_date: false },
+				post: { ID: -1, post_title: 7, post_date: false, post_mime_type: 12 },
 			} ).post
 		).toEqual( {} );
 	} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/single-video.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/single-video.test.ts
@@ -21,6 +21,11 @@ describe( 'Stats single video normalizer', () => {
 					link: 'https://example.com/2026/06/launch-recap/',
 				},
 			],
+			post: {
+				id: 31533,
+				title: 'Launch recap',
+				date: '2026-06-12 14:30:00',
+			},
 		} );
 	} );
 
@@ -28,19 +33,44 @@ describe( 'Stats single video normalizer', () => {
 		expect( sanitizeStatsSingleVideoResponse( singleVideoEmptyFixture ) ).toEqual( {
 			data: [],
 			pages: [],
+			post: null,
 		} );
 	} );
 
 	it( 'drops malformed rows and keeps only well-formed [ date, views ] tuples', () => {
-		expect( sanitizeStatsSingleVideoResponse( undefined ) ).toEqual( { data: [], pages: [] } );
+		expect( sanitizeStatsSingleVideoResponse( undefined ) ).toEqual( {
+			data: [],
+			pages: [],
+			post: null,
+		} );
 		expect(
 			sanitizeStatsSingleVideoResponse( {
 				data: [ 'not-a-row', [], [ 1, 2 ], [ '2026-06-12', 2 ] ],
 				pages: [ 7 ],
+				post: 'not-a-post',
 			} )
 		).toEqual( {
 			data: [ { period: '2026-06-12', value: 2 } ],
 			pages: [],
+			post: null,
 		} );
+	} );
+
+	it( 'keeps only well-formed attachment post fields', () => {
+		expect(
+			sanitizeStatsSingleVideoResponse( {
+				post: { ID: '42', post_title: 'Demo', post_date: '2026-06-15 09:00:00' },
+			} ).post
+		).toEqual( {
+			id: 42,
+			title: 'Demo',
+			date: '2026-06-15 09:00:00',
+		} );
+
+		expect(
+			sanitizeStatsSingleVideoResponse( {
+				post: { ID: -1, post_title: 7, post_date: false },
+			} ).post
+		).toEqual( {} );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/index.ts
@@ -180,6 +180,7 @@ export type {
 export type {
 	StatsSingleVideoDataPoint,
 	StatsSingleVideoPage,
+	StatsSingleVideoPost,
 	StatsSingleVideoReport,
 } from './single-video';
 export type {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/single-video.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/single-video.ts
@@ -15,6 +15,7 @@ export type StatsSingleVideoPost = {
 	id?: number;
 	title?: string;
 	date?: string;
+	mimeType?: string;
 };
 
 export type StatsSingleVideoReport = {
@@ -38,6 +39,7 @@ function sanitizeSingleVideoPost( value: unknown ): StatsSingleVideoPost | null 
 			: {} ),
 		...( typeof value.post_title === 'string' ? { title: value.post_title } : {} ),
 		...( typeof value.post_date === 'string' ? { date: value.post_date } : {} ),
+		...( typeof value.post_mime_type === 'string' ? { mimeType: value.post_mime_type } : {} ),
 	};
 }
 

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/single-video.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/single-video.ts
@@ -1,5 +1,5 @@
 import { safeParseFloat } from '../../utils/parsing';
-import { coerceStatsArray, coerceStatsRecord } from './utils';
+import { coerceStatsArray, coerceStatsRecord, isStatsRecord } from './utils';
 
 export type StatsSingleVideoDataPoint = {
 	period: string;
@@ -11,10 +11,35 @@ export type StatsSingleVideoPage = {
 	link: string;
 };
 
+export type StatsSingleVideoPost = {
+	id?: number;
+	title?: string;
+	date?: string;
+};
+
 export type StatsSingleVideoReport = {
 	data: StatsSingleVideoDataPoint[];
 	pages: StatsSingleVideoPage[];
+	post: StatsSingleVideoPost | null;
 };
+
+function sanitizeSingleVideoPost( value: unknown ): StatsSingleVideoPost | null {
+	if ( ! isStatsRecord( value ) ) {
+		return null;
+	}
+
+	const id = Number( value.ID );
+
+	return {
+		...( ( typeof value.ID === 'number' || typeof value.ID === 'string' ) &&
+		Number.isInteger( id ) &&
+		id > 0
+			? { id }
+			: {} ),
+		...( typeof value.post_title === 'string' ? { title: value.post_title } : {} ),
+		...( typeof value.post_date === 'string' ? { date: value.post_date } : {} ),
+	};
+}
 
 export function sanitizeStatsSingleVideoResponse( response: unknown ): StatsSingleVideoReport {
 	const payload = coerceStatsRecord( response );
@@ -30,6 +55,7 @@ export function sanitizeStatsSingleVideoResponse( response: unknown ): StatsSing
 	const pages = coerceStatsArray< unknown >( payload.pages )
 		.filter( ( page ): page is string => typeof page === 'string' )
 		.map( page => ( { label: page, link: page } ) );
+	const post = sanitizeSingleVideoPost( payload.post );
 
-	return { data, pages };
+	return { data, pages, post };
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/index.ts
@@ -44,6 +44,7 @@ export {
 export { WidgetBackLink, type WidgetBackLinkProps } from './widget-back-link';
 export { WidgetFooter, type WidgetFooterProps } from './widget-footer';
 export { ReportLink, type ReportLinkProps } from './report-link';
+export { VideoTitleLink, type VideoTitleLinkProps } from './video-title-link';
 export {
 	SubscriberList,
 	type SubscriberListItem,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/video-title-link/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/video-title-link/index.ts
@@ -1,0 +1,1 @@
+export { VideoTitleLink, type VideoTitleLinkProps } from './video-title-link';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/video-title-link/video-title-link.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/video-title-link/video-title-link.tsx
@@ -1,0 +1,75 @@
+/**
+ * External dependencies
+ */
+import { Link } from '@wordpress/route';
+
+export type VideoTitleLinkProps = {
+	id?: number | string;
+	label: string;
+	link?: string | null;
+	search?: Record< string, unknown >;
+	classNames?: {
+		internal?: string;
+		external?: string;
+		plain?: string;
+	};
+	title?: string;
+};
+
+/**
+ * Render a video title as an internal detail link, an external fallback link,
+ * or plain text.
+ *
+ * @param props            - Component props.
+ * @param props.id         - Video attachment ID.
+ * @param props.label      - Visible video title.
+ * @param props.link       - External fallback URL.
+ * @param props.search     - Search parameters for the detail route.
+ * @param props.classNames - Optional classes for each rendering branch.
+ * @param props.title      - Optional native title attribute.
+ * @return The linked or plain video title.
+ */
+export function VideoTitleLink( {
+	id,
+	label,
+	link,
+	search,
+	classNames,
+	title,
+}: VideoTitleLinkProps ): JSX.Element {
+	const videoId = Number( id );
+
+	if ( Number.isInteger( videoId ) && videoId > 0 ) {
+		return (
+			<Link
+				className={ classNames?.internal }
+				to="/video/$videoId"
+				params={ { videoId: String( videoId ) } as unknown as never }
+				search={ search as unknown as never }
+				title={ title }
+			>
+				{ label }
+			</Link>
+		);
+	}
+
+	if ( link ) {
+		return (
+			<a
+				className={ classNames?.external }
+				href={ link }
+				target="_blank"
+				rel="noopener noreferrer"
+				title={ title }
+			>
+				{ label }
+			</a>
+		);
+	}
+
+	return (
+		<span className={ classNames?.plain } title={ title }>
+			{ label }
+		</span>
+	);
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -45,6 +45,8 @@ export {
 	type WidgetFooterProps,
 	ReportLink,
 	type ReportLinkProps,
+	VideoTitleLink,
+	type VideoTitleLinkProps,
 	SubscriberList,
 	type SubscriberListItem,
 	type SubscriberListProps,

--- a/projects/packages/premium-analytics/routes/reports/videos/config/fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/videos/config/fields.test.tsx
@@ -4,18 +4,31 @@ import type { StatsVideoPlaysItem } from '@jetpack-premium-analytics/data';
 import type { ReactNode } from 'react';
 
 // The router is built dynamically at runtime, so a field-level test has no
-// router to mount. Render `Link` as the anchor it becomes, keeping `to`/`params`
-// assertable, matching the other report field tests.
+// router to mount. Render `Link` as the anchor it becomes, keeping `to`/
+// `params`/`search` assertable, matching the other report field tests.
 jest.mock( '@wordpress/route', () => ( {
 	Link: ( {
 		to,
 		params,
+		search,
 		children,
 	}: {
 		to: string;
 		params: Record< string, string >;
+		search?: Record< string, string >;
 		children: ReactNode;
-	} ) => <a href={ to.replace( /\$(\w+)/g, ( _match, key ) => params[ key ] ) }>{ children }</a>,
+	} ) => {
+		const path = to.replace( /\$(\w+)/g, ( _match, key ) => params[ key ] );
+		const query = new URLSearchParams( search ?? {} ).toString();
+
+		return <a href={ query ? `${ path }?${ query }` : path }>{ children }</a>;
+	},
+	useSearch: () => ( {
+		from: '2026-06-01',
+		to: '2026-06-16',
+		// A page-owned param the detail link must not carry along.
+		chart_period: 'week',
+	} ),
 } ) );
 
 const video: StatsVideoPlaysItem = {
@@ -48,11 +61,13 @@ function renderTitleField( item: StatsVideoPlaysItem ) {
 }
 
 describe( 'videos fields', () => {
-	it( 'links a video title to its internal detail page', () => {
+	it( 'links a video title to its internal detail page, carrying the date window', () => {
 		renderTitleField( video );
 
 		const link = screen.getByRole( 'link', { name: 'Launch video' } );
-		expect( link ).toHaveAttribute( 'href', '/video/12' );
+		// Only the shared report-window params travel; page-owned params
+		// (`chart_period`) stay behind.
+		expect( link ).toHaveAttribute( 'href', '/video/12?from=2026-06-01&to=2026-06-16' );
 		expect( link ).not.toHaveAttribute( 'target' );
 	} );
 

--- a/projects/packages/premium-analytics/routes/reports/videos/config/fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/videos/config/fields.test.tsx
@@ -1,6 +1,22 @@
 import { render, screen } from '@testing-library/react';
 import { getVideosFields } from './fields';
 import type { StatsVideoPlaysItem } from '@jetpack-premium-analytics/data';
+import type { ReactNode } from 'react';
+
+// The router is built dynamically at runtime, so a field-level test has no
+// router to mount. Render `Link` as the anchor it becomes, keeping `to`/`params`
+// assertable, matching the other report field tests.
+jest.mock( '@wordpress/route', () => ( {
+	Link: ( {
+		to,
+		params,
+		children,
+	}: {
+		to: string;
+		params: Record< string, string >;
+		children: ReactNode;
+	} ) => <a href={ to.replace( /\$(\w+)/g, ( _match, key ) => params[ key ] ) }>{ children }</a>,
+} ) );
 
 const video: StatsVideoPlaysItem = {
 	id: 12,
@@ -32,8 +48,16 @@ function renderTitleField( item: StatsVideoPlaysItem ) {
 }
 
 describe( 'videos fields', () => {
-	it( 'links a video title to the payload URL', () => {
+	it( 'links a video title to its internal detail page', () => {
 		renderTitleField( video );
+
+		const link = screen.getByRole( 'link', { name: 'Launch video' } );
+		expect( link ).toHaveAttribute( 'href', '/video/12' );
+		expect( link ).not.toHaveAttribute( 'target' );
+	} );
+
+	it( 'keeps the external page link as the fallback for a row without an ID', () => {
+		renderTitleField( { ...video, id: undefined } );
 
 		const link = screen.getByRole( 'link', { name: 'Launch video' } );
 		expect( link ).toHaveAttribute( 'href', 'https://example.com/video/' );
@@ -41,8 +65,8 @@ describe( 'videos fields', () => {
 		expect( link ).toHaveAttribute( 'rel', 'noopener noreferrer' );
 	} );
 
-	it( 'renders plain text when the payload has no URL', () => {
-		renderTitleField( { ...video, link: null } );
+	it( 'renders plain text when a row has neither an ID nor a URL', () => {
+		renderTitleField( { ...video, id: undefined, link: null } );
 
 		expect( screen.getByText( 'Launch video' ) ).toBeInTheDocument();
 		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();

--- a/projects/packages/premium-analytics/routes/reports/videos/config/fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/videos/config/fields.test.tsx
@@ -80,11 +80,26 @@ describe( 'videos fields', () => {
 		expect( link ).toHaveAttribute( 'rel', 'noopener noreferrer' );
 	} );
 
+	it( 'does not create a detail link for a non-positive ID', () => {
+		renderTitleField( { ...video, id: 0 } );
+
+		expect( screen.getByRole( 'link', { name: 'Launch video' } ) ).toHaveAttribute(
+			'href',
+			'https://example.com/video/'
+		);
+	} );
+
 	it( 'renders plain text when a row has neither an ID nor a URL', () => {
 		renderTitleField( { ...video, id: undefined, link: null } );
 
 		expect( screen.getByText( 'Launch video' ) ).toBeInTheDocument();
 		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'keeps the report-owned untitled fallback', () => {
+		renderTitleField( { ...video, id: undefined, label: undefined, link: null } );
+
+		expect( screen.getByText( 'Untitled video' ) ).toBeInTheDocument();
 	} );
 
 	it( 'exposes searchable title and sortable metric fields', () => {

--- a/projects/packages/premium-analytics/routes/reports/videos/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/videos/config/fields.tsx
@@ -2,8 +2,10 @@
  * External dependencies
  */
 import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
+import { pickReportDateParams } from '@jetpack-premium-analytics/routing';
 import { __ } from '@wordpress/i18n';
-import { Link } from '@wordpress/route';
+import { Link, useSearch } from '@wordpress/route';
+import { useMemo } from 'react';
 import type { StatsVideoPlaysItem } from '@jetpack-premium-analytics/data';
 import type { Field } from '@wordpress/dataviews';
 
@@ -20,6 +22,45 @@ function getVideoTitle( video: StatsVideoPlaysItem ) {
 }
 
 /**
+ * Render a video row's title. Rows with an attachment ID link to the internal
+ * video detail page, carrying the report's current date window so the detail
+ * page and its "Stats" breadcrumb keep the range being inspected; the public
+ * URL remains the external fallback for rows without an ID.
+ *
+ * @param props      - Component props.
+ * @param props.item - The video report row.
+ * @return The linked or plain video title.
+ */
+function VideoTitle( { item }: { item: StatsVideoPlaysItem } ) {
+	const search = useSearch( { strict: false } ) as Record< string, unknown > | undefined;
+	const detailSearch = useMemo( () => pickReportDateParams( search ), [ search ] );
+	const title = getVideoTitle( item );
+	const videoId = Number( item.id );
+
+	if ( Number.isInteger( videoId ) && videoId > 0 ) {
+		return (
+			<Link
+				to="/video/$videoId"
+				params={ { videoId: String( item.id ) } as unknown as never }
+				search={ detailSearch as unknown as never }
+			>
+				{ title }
+			</Link>
+		);
+	}
+
+	if ( ! item.link ) {
+		return <>{ title }</>;
+	}
+
+	return (
+		<a href={ item.link } target="_blank" rel="noopener noreferrer">
+			{ title }
+		</a>
+	);
+}
+
+/**
  * DataViews field config for the Videos records table.
  *
  * @return The field config.
@@ -32,31 +73,7 @@ export function getVideosFields(): Field< StatsVideoPlaysItem >[] {
 			enableGlobalSearch: true,
 			enableHiding: false,
 			getValue: ( { item } ) => getVideoTitle( item ),
-			render: ( { item } ) => {
-				const title = getVideoTitle( item );
-				const videoId = Number( item.id );
-
-				if ( Number.isInteger( videoId ) && videoId > 0 ) {
-					return (
-						<Link
-							to="/video/$videoId"
-							params={ { videoId: String( item.id ) } as unknown as never }
-						>
-							{ title }
-						</Link>
-					);
-				}
-
-				if ( ! item.link ) {
-					return <>{ title }</>;
-				}
-
-				return (
-					<a href={ item.link } target="_blank" rel="noopener noreferrer">
-						{ title }
-					</a>
-				);
-			},
+			render: ( { item } ) => <VideoTitle item={ item } />,
 		},
 		{
 			id: 'plays',

--- a/projects/packages/premium-analytics/routes/reports/videos/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/videos/config/fields.tsx
@@ -3,8 +3,9 @@
  */
 import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
 import { pickReportDateParams } from '@jetpack-premium-analytics/routing';
+import { VideoTitleLink } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';
-import { Link, useSearch } from '@wordpress/route';
+import { useSearch } from '@wordpress/route';
 import { useMemo } from 'react';
 import type { StatsVideoPlaysItem } from '@jetpack-premium-analytics/data';
 import type { Field } from '@wordpress/dataviews';
@@ -35,28 +36,9 @@ function VideoTitle( { item }: { item: StatsVideoPlaysItem } ) {
 	const search = useSearch( { strict: false } ) as Record< string, unknown > | undefined;
 	const detailSearch = useMemo( () => pickReportDateParams( search ), [ search ] );
 	const title = getVideoTitle( item );
-	const videoId = Number( item.id );
-
-	if ( Number.isInteger( videoId ) && videoId > 0 ) {
-		return (
-			<Link
-				to="/video/$videoId"
-				params={ { videoId: String( item.id ) } as unknown as never }
-				search={ detailSearch as unknown as never }
-			>
-				{ title }
-			</Link>
-		);
-	}
-
-	if ( ! item.link ) {
-		return <>{ title }</>;
-	}
 
 	return (
-		<a href={ item.link } target="_blank" rel="noopener noreferrer">
-			{ title }
-		</a>
+		<VideoTitleLink id={ item.id } label={ title } link={ item.link } search={ detailSearch } />
 	);
 }
 

--- a/projects/packages/premium-analytics/routes/reports/videos/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/videos/config/fields.tsx
@@ -3,6 +3,7 @@
  */
 import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
 import { __ } from '@wordpress/i18n';
+import { Link } from '@wordpress/route';
 import type { StatsVideoPlaysItem } from '@jetpack-premium-analytics/data';
 import type { Field } from '@wordpress/dataviews';
 
@@ -33,6 +34,18 @@ export function getVideosFields(): Field< StatsVideoPlaysItem >[] {
 			getValue: ( { item } ) => getVideoTitle( item ),
 			render: ( { item } ) => {
 				const title = getVideoTitle( item );
+				const videoId = Number( item.id );
+
+				if ( Number.isInteger( videoId ) && videoId > 0 ) {
+					return (
+						<Link
+							to="/video/$videoId"
+							params={ { videoId: String( item.id ) } as unknown as never }
+						>
+							{ title }
+						</Link>
+					);
+				}
 
 				if ( ! item.link ) {
 					return <>{ title }</>;

--- a/projects/packages/premium-analytics/routes/video-detail/hooks/index.ts
+++ b/projects/packages/premium-analytics/routes/video-detail/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useVideoSummary, type VideoSummary } from './use-video-summary';

--- a/projects/packages/premium-analytics/routes/video-detail/hooks/use-video-summary.test.tsx
+++ b/projects/packages/premium-analytics/routes/video-detail/hooks/use-video-summary.test.tsx
@@ -1,0 +1,78 @@
+import { useStatsSingleVideo } from '@jetpack-premium-analytics/data';
+import { renderHook } from '@testing-library/react';
+import { useVideoSummary } from './use-video-summary';
+
+jest.mock( '@jetpack-premium-analytics/data', () => ( {
+	useStatsSingleVideo: jest.fn(),
+} ) );
+
+const mockUseStatsSingleVideo = useStatsSingleVideo as jest.Mock;
+const refetch = jest.fn();
+
+/**
+ * Stubs the single-video query result, defaulting to a resolved video.
+ *
+ * @param overrides - Fields to override on the default query result.
+ */
+function mockVideoQuery( overrides: Record< string, unknown > = {} ) {
+	mockUseStatsSingleVideo.mockReturnValue( {
+		data: { post: { id: 42, title: 'Demo', mimeType: 'video/mp4' } },
+		isLoading: false,
+		isError: false,
+		isSuccess: true,
+		refetch,
+		...overrides,
+	} );
+}
+
+describe( 'useVideoSummary', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it.each( [ null, {}, { id: 0 } ] )(
+		'treats a resolved post without a positive integer ID as not found',
+		post => {
+			mockVideoQuery( { data: { post } } );
+
+			const { result } = renderHook( () => useVideoSummary( 42 ) );
+
+			expect( result.current.isNotFound ).toBe( true );
+		}
+	);
+
+	// The endpoint always sends `post_mime_type`: `image/*` for images, empty for
+	// regular posts/pages, and a `video/` mime for videos. Only `video/` resolves.
+	it.each( [ 'image/jpeg', '', undefined ] )(
+		'treats a resolved non-video attachment (MIME type %p) as not found',
+		mimeType => {
+			mockVideoQuery( { data: { post: { id: 42, mimeType } } } );
+
+			const { result } = renderHook( () => useVideoSummary( 42 ) );
+
+			expect( result.current.isNotFound ).toBe( true );
+		}
+	);
+
+	it.each( [ 'video/videopress', 'video/quicktime', 'video/mp4' ] )(
+		'resolves a valid video attachment with MIME type %p',
+		mimeType => {
+			mockVideoQuery( { data: { post: { id: 42, mimeType } } } );
+
+			const { result } = renderHook( () => useVideoSummary( 42 ) );
+
+			expect( result.current.isNotFound ).toBe( false );
+		}
+	);
+
+	it.each( [
+		{ isLoading: true, isSuccess: false },
+		{ isError: true, isSuccess: false },
+	] )( 'does not report not found before a successful resolution', queryState => {
+		mockVideoQuery( { data: { post: null }, ...queryState } );
+
+		const { result } = renderHook( () => useVideoSummary( 42 ) );
+
+		expect( result.current.isNotFound ).toBe( false );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/video-detail/hooks/use-video-summary.ts
+++ b/projects/packages/premium-analytics/routes/video-detail/hooks/use-video-summary.ts
@@ -10,6 +10,8 @@ export type VideoSummary = {
 	isLoading: boolean;
 	/** Whether the single-video request failed — the page must not present a fallback title as real data. */
 	isError: boolean;
+	/** Whether the resolved attachment is missing or is known not to be a video. */
+	isNotFound: boolean;
 	/** Re-runs the failed request, for the error state's Retry action. */
 	refetch: () => void;
 };
@@ -21,7 +23,14 @@ export type VideoSummary = {
  * @return The resolved video summary.
  */
 export function useVideoSummary( videoId: number ): VideoSummary {
-	const { data, isLoading, isError, refetch } = useStatsSingleVideo( videoId );
+	const { data, isLoading, isError, isSuccess, refetch } = useStatsSingleVideo( videoId );
+	const post = data?.post;
+	const hasValidId = Number.isInteger( post?.id ) && Number( post?.id ) > 0;
+	// Require a `video/` prefix so non-video IDs (images, posts, pages) resolve to
+	// not-found. Videos are `video/videopress` on Jetpack/Atomic and their original
+	// mime (`video/mp4`, `video/quicktime`, …) on Simple, so match the prefix.
+	const mimeType = post?.mimeType?.trim();
+	const isVideoMimeType = Boolean( mimeType && mimeType.startsWith( 'video/' ) );
 
 	// The query's own refetch takes a react-query options object; expose a
 	// no-arg wrapper so callers can pass it straight to event handlers.
@@ -30,10 +39,11 @@ export function useVideoSummary( videoId: number ): VideoSummary {
 	}, [ refetch ] );
 
 	return {
-		title: data?.post?.title,
-		publishedDate: data?.post?.date,
+		title: post?.title,
+		publishedDate: post?.date,
 		isLoading,
 		isError,
+		isNotFound: isSuccess && ( ! hasValidId || ! isVideoMimeType ),
 		refetch: retry,
 	};
 }

--- a/projects/packages/premium-analytics/routes/video-detail/hooks/use-video-summary.ts
+++ b/projects/packages/premium-analytics/routes/video-detail/hooks/use-video-summary.ts
@@ -1,0 +1,26 @@
+/**
+ * External dependencies
+ */
+import { useStatsSingleVideo } from '@jetpack-premium-analytics/data';
+
+export type VideoSummary = {
+	title?: string;
+	publishedDate?: string;
+	isLoading: boolean;
+};
+
+/**
+ * Resolve the title and publication date for a single VideoPress attachment.
+ *
+ * @param videoId - The attachment post ID from the route.
+ * @return The resolved video summary.
+ */
+export function useVideoSummary( videoId: number ): VideoSummary {
+	const { data, isLoading } = useStatsSingleVideo( videoId );
+
+	return {
+		title: data?.post?.title,
+		publishedDate: data?.post?.date,
+		isLoading,
+	};
+}

--- a/projects/packages/premium-analytics/routes/video-detail/hooks/use-video-summary.ts
+++ b/projects/packages/premium-analytics/routes/video-detail/hooks/use-video-summary.ts
@@ -2,11 +2,16 @@
  * External dependencies
  */
 import { useStatsSingleVideo } from '@jetpack-premium-analytics/data';
+import { useCallback } from '@wordpress/element';
 
 export type VideoSummary = {
 	title?: string;
 	publishedDate?: string;
 	isLoading: boolean;
+	/** Whether the single-video request failed — the page must not present a fallback title as real data. */
+	isError: boolean;
+	/** Re-runs the failed request, for the error state's Retry action. */
+	refetch: () => void;
 };
 
 /**
@@ -16,11 +21,19 @@ export type VideoSummary = {
  * @return The resolved video summary.
  */
 export function useVideoSummary( videoId: number ): VideoSummary {
-	const { data, isLoading } = useStatsSingleVideo( videoId );
+	const { data, isLoading, isError, refetch } = useStatsSingleVideo( videoId );
+
+	// The query's own refetch takes a react-query options object; expose a
+	// no-arg wrapper so callers can pass it straight to event handlers.
+	const retry = useCallback( () => {
+		void refetch();
+	}, [ refetch ] );
 
 	return {
 		title: data?.post?.title,
 		publishedDate: data?.post?.date,
 		isLoading,
+		isError,
+		refetch: retry,
 	};
 }

--- a/projects/packages/premium-analytics/routes/video-detail/package.json
+++ b/projects/packages/premium-analytics/routes/video-detail/package.json
@@ -10,6 +10,7 @@
 		"@jetpack-premium-analytics/data": "workspace:*",
 		"@jetpack-premium-analytics/routing": "workspace:*",
 		"@wordpress/admin-ui": "2.5.0",
+		"@wordpress/element": "8.2.0",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/route": "0.16.0",
 		"@wordpress/ui": "0.17.0"

--- a/projects/packages/premium-analytics/routes/video-detail/package.json
+++ b/projects/packages/premium-analytics/routes/video-detail/package.json
@@ -1,0 +1,17 @@
+{
+	"private": true,
+	"name": "@automattic/jetpack-premium-analytics-video-detail-route",
+	"route": {
+		"path": "/video/$videoId",
+		"page": "jetpack-premium-analytics"
+	},
+	"dependencies": {
+		"@automattic/jetpack-script-data": "workspace:*",
+		"@jetpack-premium-analytics/data": "workspace:*",
+		"@jetpack-premium-analytics/routing": "workspace:*",
+		"@wordpress/admin-ui": "2.5.0",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/route": "0.16.0",
+		"@wordpress/ui": "0.17.0"
+	}
+}

--- a/projects/packages/premium-analytics/routes/video-detail/package.json
+++ b/projects/packages/premium-analytics/routes/video-detail/package.json
@@ -14,5 +14,8 @@
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/route": "0.16.0",
 		"@wordpress/ui": "0.17.0"
+	},
+	"devDependencies": {
+		"@testing-library/react": "16.3.2"
 	}
 }

--- a/projects/packages/premium-analytics/routes/video-detail/route.ts
+++ b/projects/packages/premium-analytics/routes/video-detail/route.ts
@@ -1,0 +1,42 @@
+/**
+ * External dependencies
+ */
+import { getScriptData } from '@automattic/jetpack-script-data';
+import { redirect } from '@wordpress/route';
+
+type VideoDetailParams = { videoId?: string };
+
+/**
+ * Whether a raw path parameter identifies a positive integer video attachment.
+ *
+ * @param value - The raw `videoId` path parameter.
+ * @return Whether the value is a valid video ID.
+ */
+function isValidVideoId( value: string | undefined ): value is string {
+	return !! value && /^\d+$/.test( value ) && Number( value ) > 0;
+}
+
+/**
+ * Route lifecycle for the video detail page.
+ *
+ * The page is available only to connected sites after the initial analytics
+ * sync, and only for positive integer attachment IDs.
+ */
+export const route = {
+	beforeLoad: ( { params }: { params?: VideoDetailParams } = {} ) => {
+		const connectionStatus = getScriptData()?.connection?.connectionStatus;
+
+		if ( ! connectionStatus?.isRegistered ) {
+			throw redirect( { to: '/connect' } );
+		}
+
+		const syncFinished = getScriptData()?.premium_analytics?.initial_full_sync_finished ?? 0;
+		if ( ! syncFinished ) {
+			throw redirect( { to: '/syncing' } );
+		}
+
+		if ( ! isValidVideoId( params?.videoId ) ) {
+			throw redirect( { to: '/' } );
+		}
+	},
+};

--- a/projects/packages/premium-analytics/routes/video-detail/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/video-detail/stage.module.scss
@@ -1,0 +1,8 @@
+.page {
+	min-block-size: 0;
+}
+
+.content {
+	padding-block: var(--wpds-dimension-padding-xl);
+	padding-inline: var(--wpds-dimension-padding-2xl);
+}

--- a/projects/packages/premium-analytics/routes/video-detail/stage.test.tsx
+++ b/projects/packages/premium-analytics/routes/video-detail/stage.test.tsx
@@ -1,0 +1,134 @@
+import { render, screen, within } from '@testing-library/react';
+import { useVideoSummary } from './hooks';
+import { stage } from './stage';
+import type { ReactNode } from 'react';
+
+jest.mock( '@jetpack-premium-analytics/data', () => ( {
+	AnalyticsQueryClientProvider: ( { children }: { children: ReactNode } ) => <>{ children }</>,
+	GlobalErrorProvider: ( { children }: { children: ReactNode } ) => <>{ children }</>,
+} ) );
+
+jest.mock( '@jetpack-premium-analytics/routing', () => ( {
+	pickReportDateParams: ( search: Record< string, unknown > ) => ( {
+		from: search.from,
+		to: search.to,
+	} ),
+	useDashboardLink: () => '/?from=2026-06-01&to=2026-06-16',
+} ) );
+
+jest.mock( '@wordpress/admin-ui', () => ( {
+	Breadcrumbs: ( { items }: { items: Array< { label: string } > } ) => (
+		<nav aria-label="Breadcrumbs">
+			{ items.map( item => (
+				<span key={ item.label } role="listitem">
+					{ item.label }
+				</span>
+			) ) }
+		</nav>
+	),
+	Page: ( { breadcrumbs, children }: { breadcrumbs: ReactNode; children: ReactNode } ) => (
+		<main>
+			{ breadcrumbs }
+			{ children }
+		</main>
+	),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	Link: ( {
+		to,
+		params,
+		search,
+		children,
+	}: {
+		to: string;
+		params?: Record< string, unknown >;
+		search?: Record< string, unknown >;
+		children: ReactNode;
+	} ) => {
+		const path = Object.entries( params ?? {} ).reduce(
+			( acc, [ key, value ] ) => acc.replace( `$${ key }`, String( value ) ),
+			to
+		);
+		const query = new URLSearchParams(
+			Object.entries( search ?? {} ).map( ( [ key, value ] ) => [ key, String( value ) ] )
+		).toString();
+
+		return <a href={ query ? `${ path }?${ query }` : path }>{ children }</a>;
+	},
+	useParams: () => ( { videoId: '42' } ),
+	useSearch: () => ( {
+		from: '2026-06-01',
+		to: '2026-06-16',
+		section: 'embeds',
+	} ),
+} ) );
+
+jest.mock( './hooks', () => ( {
+	useVideoSummary: jest.fn(),
+} ) );
+
+const mockUseVideoSummary = useVideoSummary as jest.Mock;
+const refetch = jest.fn();
+
+/**
+ * Stubs the video summary hook, defaulting to a resolved video with no title.
+ *
+ * @param overrides - Fields to override on the default summary.
+ */
+function mockSummary( overrides: Record< string, unknown > = {} ) {
+	mockUseVideoSummary.mockReturnValue( {
+		title: undefined,
+		publishedDate: undefined,
+		isLoading: false,
+		isError: false,
+		isNotFound: false,
+		refetch,
+		...overrides,
+	} );
+}
+
+describe( 'video detail stage', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'shows a not-found state with a date-preserving link back to Videos', () => {
+		mockSummary( { isNotFound: true } );
+
+		render( stage() );
+
+		expect( screen.getByText( "We couldn't find this video." ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: 'Back to Videos' } ) ).toHaveAttribute(
+			'href',
+			'/reports/videos?from=2026-06-01&to=2026-06-16'
+		);
+		expect( screen.queryByRole( 'heading', { level: 1 } ) ).not.toBeInTheDocument();
+	} );
+
+	it.each( [ { isLoading: true }, { isError: true }, { isNotFound: true } ] )(
+		'shows only the Stats crumb while no title is available',
+		summary => {
+			mockSummary( summary );
+
+			render( stage() );
+
+			const nav = screen.getByRole( 'navigation', { name: 'Breadcrumbs' } );
+			// Only the Stats crumb renders until a title resolves.
+			const crumbs = within( nav ).getAllByRole( 'listitem' );
+			expect( crumbs ).toHaveLength( 1 );
+			expect( crumbs[ 0 ] ).toHaveTextContent( 'Stats' );
+		}
+	);
+
+	it( 'adds the resolved title crumb', () => {
+		mockSummary( { title: 'Launch recap' } );
+
+		render( stage() );
+
+		const breadcrumbs = within( screen.getByRole( 'navigation', { name: 'Breadcrumbs' } ) );
+		expect( breadcrumbs.getByText( 'Stats' ) ).toBeInTheDocument();
+		expect( breadcrumbs.getByText( 'Launch recap' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'heading', { level: 1, name: 'Launch recap' } ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/video-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/video-detail/stage.tsx
@@ -1,0 +1,68 @@
+/**
+ * External dependencies
+ */
+import { AnalyticsQueryClientProvider, GlobalErrorProvider } from '@jetpack-premium-analytics/data';
+import { useDashboardLink } from '@jetpack-premium-analytics/routing';
+import { Breadcrumbs, Page } from '@wordpress/admin-ui';
+import { __ } from '@wordpress/i18n';
+import { useParams } from '@wordpress/route';
+import { Text } from '@wordpress/ui';
+/**
+ * Internal dependencies
+ */
+import { useVideoSummary } from './hooks';
+import { route } from './package.json';
+import styles from './stage.module.scss';
+
+const ROUTE_FROM = route.path;
+
+/**
+ * Premium Analytics video detail page shell.
+ *
+ * @return The video detail page.
+ */
+function VideoDetail(): JSX.Element {
+	const { videoId: videoIdParam } = useParams( { from: ROUTE_FROM } ) as { videoId?: string };
+	const summary = useVideoSummary( Number( videoIdParam ) );
+	const dashboardLink = useDashboardLink();
+	const title = summary.isLoading
+		? undefined
+		: summary.title?.trim() || __( 'Untitled video', 'jetpack-premium-analytics' );
+
+	return (
+		<Page
+			breadcrumbs={
+				<Breadcrumbs
+					items={ [
+						{ label: __( 'Stats', 'jetpack-premium-analytics' ), to: dashboardLink },
+						...( title ? [ { label: title } ] : [] ),
+					] }
+				/>
+			}
+			className={ styles.page }
+		>
+			<div className={ styles.content }>
+				{ title ? (
+					<Text variant="heading-xl" render={ <h1 /> }>
+						{ title }
+					</Text>
+				) : null }
+			</div>
+		</Page>
+	);
+}
+
+/**
+ * Route stage wrapper.
+ *
+ * @return The video detail page with its data and error providers.
+ */
+export function stage(): JSX.Element {
+	return (
+		<AnalyticsQueryClientProvider>
+			<GlobalErrorProvider>
+				<VideoDetail />
+			</GlobalErrorProvider>
+		</AnalyticsQueryClientProvider>
+	);
+}

--- a/projects/packages/premium-analytics/routes/video-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/video-detail/stage.tsx
@@ -6,7 +6,7 @@ import { useDashboardLink } from '@jetpack-premium-analytics/routing';
 import { Breadcrumbs, Page } from '@wordpress/admin-ui';
 import { __ } from '@wordpress/i18n';
 import { useParams } from '@wordpress/route';
-import { Text } from '@wordpress/ui';
+import { Button, Stack, Text } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
@@ -25,9 +25,13 @@ function VideoDetail(): JSX.Element {
 	const { videoId: videoIdParam } = useParams( { from: ROUTE_FROM } ) as { videoId?: string };
 	const summary = useVideoSummary( Number( videoIdParam ) );
 	const dashboardLink = useDashboardLink();
-	const title = summary.isLoading
-		? undefined
-		: summary.title?.trim() || __( 'Untitled video', 'jetpack-premium-analytics' );
+	// On error there is no trustworthy title: the fallback label must not be
+	// presented as real data, so the crumb and heading stay empty and the body
+	// shows the error state instead.
+	const title =
+		summary.isLoading || summary.isError
+			? undefined
+			: summary.title?.trim() || __( 'Untitled video', 'jetpack-premium-analytics' );
 
 	return (
 		<Page
@@ -42,6 +46,19 @@ function VideoDetail(): JSX.Element {
 			className={ styles.page }
 		>
 			<div className={ styles.content }>
+				{ summary.isError ? (
+					<Stack direction="column" align="flex-start" gap="sm">
+						<Text>
+							{ __(
+								"We couldn't load this video. Please try again in a moment.",
+								'jetpack-premium-analytics'
+							) }
+						</Text>
+						<Button variant="outline" onClick={ summary.refetch }>
+							{ __( 'Retry', 'jetpack-premium-analytics' ) }
+						</Button>
+					</Stack>
+				) : null }
 				{ title ? (
 					<Text variant="heading-xl" render={ <h1 /> }>
 						{ title }

--- a/projects/packages/premium-analytics/routes/video-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/video-detail/stage.tsx
@@ -2,10 +2,10 @@
  * External dependencies
  */
 import { AnalyticsQueryClientProvider, GlobalErrorProvider } from '@jetpack-premium-analytics/data';
-import { useDashboardLink } from '@jetpack-premium-analytics/routing';
+import { pickReportDateParams, useDashboardLink } from '@jetpack-premium-analytics/routing';
 import { Breadcrumbs, Page } from '@wordpress/admin-ui';
 import { __ } from '@wordpress/i18n';
-import { useParams } from '@wordpress/route';
+import { Link, useParams, useSearch } from '@wordpress/route';
 import { Button, Stack, Text } from '@wordpress/ui';
 /**
  * Internal dependencies
@@ -25,11 +25,12 @@ function VideoDetail(): JSX.Element {
 	const { videoId: videoIdParam } = useParams( { from: ROUTE_FROM } ) as { videoId?: string };
 	const summary = useVideoSummary( Number( videoIdParam ) );
 	const dashboardLink = useDashboardLink();
-	// On error there is no trustworthy title: the fallback label must not be
-	// presented as real data, so the crumb and heading stay empty and the body
-	// shows the error state instead.
+	const search = useSearch( { strict: false } ) as Record< string, unknown > | undefined;
+	const reportSearch = pickReportDateParams( search );
+	// Error and not-found responses have no trustworthy title, so only resolved
+	// videos add the title crumb or render the heading.
 	const title =
-		summary.isLoading || summary.isError
+		summary.isLoading || summary.isError || summary.isNotFound
 			? undefined
 			: summary.title?.trim() || __( 'Untitled video', 'jetpack-premium-analytics' );
 
@@ -46,7 +47,7 @@ function VideoDetail(): JSX.Element {
 			className={ styles.page }
 		>
 			<div className={ styles.content }>
-				{ summary.isError ? (
+				{ summary.isError && (
 					<Stack direction="column" align="flex-start" gap="sm">
 						<Text>
 							{ __(
@@ -58,7 +59,19 @@ function VideoDetail(): JSX.Element {
 							{ __( 'Retry', 'jetpack-premium-analytics' ) }
 						</Button>
 					</Stack>
-				) : null }
+				) }
+				{ summary.isNotFound && (
+					<Stack direction="column" align="flex-start" gap="sm">
+						<Text>{ __( "We couldn't find this video.", 'jetpack-premium-analytics' ) }</Text>
+						<Link
+							to="/reports/$report"
+							params={ { report: 'videos' } as unknown as never }
+							search={ reportSearch as unknown as never }
+						>
+							{ __( 'Back to Videos', 'jetpack-premium-analytics' ) }
+						</Link>
+					</Stack>
+				) }
 				{ title ? (
 					<Text variant="heading-xl" render={ <h1 /> }>
 						{ title }

--- a/projects/packages/premium-analytics/routes/video-detail/style-imports.d.ts
+++ b/projects/packages/premium-analytics/routes/video-detail/style-imports.d.ts
@@ -1,0 +1,12 @@
+declare module '*.module.css' {
+	const classes: { [ key: string ]: string };
+	export default classes;
+}
+
+declare module '*.module.scss' {
+	const classes: { [ key: string ]: string };
+	export default classes;
+}
+
+declare module '*.css';
+declare module '*.scss';

--- a/projects/packages/premium-analytics/widgets/videopress/__tests__/build-video-plays-data.test.ts
+++ b/projects/packages/premium-analytics/widgets/videopress/__tests__/build-video-plays-data.test.ts
@@ -63,6 +63,7 @@ describe( 'toVideoPlaysRows', () => {
 		);
 
 		expect( rows[ 0 ] ).toEqual( {
+			id: 107,
 			key: '107',
 			label: 'Untitled video',
 			link: 'https://example.com/video/107/',

--- a/projects/packages/premium-analytics/widgets/videopress/__tests__/videopress.test.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/__tests__/videopress.test.tsx
@@ -21,13 +21,13 @@ const mockApiFetch = apiFetch as unknown as jest.Mock;
 // Build a raw Stats "video-plays" response that satisfies both the summarized
 // (multi-day) and single-day read paths of `sanitizeStatsVideoPlaysResponse`.
 const buildResponse = (
-	videos: Array< { post_id?: number; title: string; plays: number; url?: string } >
+	videos: Array< { post_id?: number; title: string; plays: number; url?: string | null } >
 ) => {
 	const date = '2026-06-16';
 	const rows = videos.map( video => ( {
 		post_id: video.post_id,
 		title: video.title,
-		url: video.url ?? `https://example.com/video/${ video.post_id }/`,
+		url: video.url === undefined ? `https://example.com/video/${ video.post_id }/` : video.url,
 		plays: video.plays,
 		impressions: video.plays * 2,
 		watch_time: video.plays * 10,
@@ -78,6 +78,7 @@ describe( 'VideoPressWidget', () => {
 			'/video/101?from=2026-06-01&to=2026-06-16&interval=day&date_type=created'
 		);
 		expect( detailLink ).not.toHaveAttribute( 'target' );
+		expect( detailLink ).toHaveAttribute( 'title', 'Getting Started Walkthrough' );
 		expect(
 			screen.queryByRole( 'link', {
 				name: /Open Getting Started Walkthrough in a new tab/,
@@ -103,9 +104,25 @@ describe( 'VideoPressWidget', () => {
 		const link = await screen.findByRole( 'link', { name: /Legacy video/ } );
 		expect( link ).toHaveAttribute( 'href', 'https://example.com/video/legacy/' );
 		expect( link ).toHaveAttribute( 'target', '_blank' );
+		expect( link ).toHaveAttribute( 'rel', 'noopener noreferrer' );
+		expect( link ).toHaveAttribute( 'title', 'Legacy video' );
 		expect(
 			screen.queryByRole( 'link', { name: /Open Legacy video in a new tab/ } )
 		).not.toBeInTheDocument();
+	} );
+
+	it( 'keeps the title tooltip when a row has neither an ID nor a URL', async () => {
+		mockApiFetch.mockResolvedValue(
+			buildResponse( [ { title: 'Unlinked video', plays: 8, url: null } ] )
+		);
+
+		renderInDashboard(
+			<VideoPressWidget attributes={ { reportParams: { from: '2026-06-01', to: '2026-06-16' } } } />
+		);
+
+		const title = await screen.findByText( 'Unlinked video' );
+		expect( title ).not.toHaveRole( 'link' );
+		expect( title ).toHaveAttribute( 'title', 'Unlinked video' );
 	} );
 
 	it( 'requests the dashboard date range from report params', async () => {

--- a/projects/packages/premium-analytics/widgets/videopress/__tests__/videopress.test.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/__tests__/videopress.test.tsx
@@ -20,12 +20,14 @@ const mockApiFetch = apiFetch as unknown as jest.Mock;
 
 // Build a raw Stats "video-plays" response that satisfies both the summarized
 // (multi-day) and single-day read paths of `sanitizeStatsVideoPlaysResponse`.
-const buildResponse = ( videos: Array< { post_id: number; title: string; plays: number } > ) => {
+const buildResponse = (
+	videos: Array< { post_id?: number; title: string; plays: number; url?: string } >
+) => {
 	const date = '2026-06-16';
 	const rows = videos.map( video => ( {
 		post_id: video.post_id,
 		title: video.title,
-		url: `https://example.com/video/${ video.post_id }/`,
+		url: video.url ?? `https://example.com/video/${ video.post_id }/`,
 		plays: video.plays,
 		impressions: video.plays * 2,
 		watch_time: video.plays * 10,
@@ -63,15 +65,47 @@ describe( 'VideoPressWidget', () => {
 		expect( screen.getByText( 'Product Launch Highlights' ) ).toBeInTheDocument();
 	} );
 
-	it( 'links each row to the video page', async () => {
+	it( 'links each ID-backed title internally with the shared date window and no icon link', async () => {
 		renderInDashboard(
 			<VideoPressWidget attributes={ { reportParams: { from: '2026-06-01', to: '2026-06-16' } } } />
 		);
 
-		// The Link's new-tab icon appends "(opens in a new tab)" to the accessible name.
-		const link = await screen.findByRole( 'link', { name: /Getting Started Walkthrough/ } );
-		expect( link ).toHaveAttribute( 'href', 'https://example.com/video/101/' );
+		const detailLink = await screen.findByRole( 'link', {
+			name: 'Getting Started Walkthrough',
+		} );
+		expect( detailLink ).toHaveAttribute(
+			'href',
+			'/video/101?from=2026-06-01&to=2026-06-16&interval=day&date_type=created'
+		);
+		expect( detailLink ).not.toHaveAttribute( 'target' );
+		expect(
+			screen.queryByRole( 'link', {
+				name: /Open Getting Started Walkthrough in a new tab/,
+			} )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'keeps the external title link when a row has no numeric ID', async () => {
+		mockApiFetch.mockResolvedValue(
+			buildResponse( [
+				{
+					title: 'Legacy video',
+					plays: 12,
+					url: 'https://example.com/video/legacy/',
+				},
+			] )
+		);
+
+		renderInDashboard(
+			<VideoPressWidget attributes={ { reportParams: { from: '2026-06-01', to: '2026-06-16' } } } />
+		);
+
+		const link = await screen.findByRole( 'link', { name: /Legacy video/ } );
+		expect( link ).toHaveAttribute( 'href', 'https://example.com/video/legacy/' );
 		expect( link ).toHaveAttribute( 'target', '_blank' );
+		expect(
+			screen.queryByRole( 'link', { name: /Open Legacy video in a new tab/ } )
+		).not.toBeInTheDocument();
 	} );
 
 	it( 'requests the dashboard date range from report params', async () => {

--- a/projects/packages/premium-analytics/widgets/videopress/build-video-plays-data.ts
+++ b/projects/packages/premium-analytics/widgets/videopress/build-video-plays-data.ts
@@ -10,6 +10,10 @@ import type { StatsVideoPlaysComparisonItem } from '@jetpack-premium-analytics/d
  */
 export type VideoPlaysRow = {
 	/**
+	 * Attachment post ID used by the internal video-detail route.
+	 */
+	id?: number;
+	/**
 	 * Stable row key: the video's post ID, else its URL, else its label.
 	 */
 	key: string;
@@ -43,11 +47,16 @@ export type VideoPlaysRow = {
  * @return Normalized rows ready for the leaderboard.
  */
 export function toVideoPlaysRows( videos: StatsVideoPlaysComparisonItem[] = [] ): VideoPlaysRow[] {
-	return videos.map( video => ( {
-		key: getVideoKey( video ),
-		label: getVideoLabel( video ),
-		link: video.link,
-		plays: video.plays,
-		previousPlays: video.previousPlays,
-	} ) );
+	return videos.map( video => {
+		const id = Number( video.id );
+
+		return {
+			...( Number.isInteger( id ) && id > 0 ? { id } : {} ),
+			key: getVideoKey( video ),
+			label: getVideoLabel( video ),
+			link: video.link,
+			plays: video.plays,
+			previousPlays: video.previousPlays,
+		};
+	} );
 }

--- a/projects/packages/premium-analytics/widgets/videopress/package.json
+++ b/projects/packages/premium-analytics/widgets/videopress/package.json
@@ -5,9 +5,11 @@
 	"type": "module",
 	"dependencies": {
 		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/routing": "link:../../packages/routing",
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^15.0.0",
+		"@wordpress/route": "0.16.0",
 		"@wordpress/ui": "0.17.0",
 		"@wordpress/widget-primitives": "0.2.0",
 		"react": "18.3.1"

--- a/projects/packages/premium-analytics/widgets/videopress/render.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/render.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { useStatsVideoPlays } from '@jetpack-premium-analytics/data';
+import { pickReportDateParams } from '@jetpack-premium-analytics/routing';
 import {
 	LeaderboardChart,
 	ReportLink,
@@ -16,7 +17,8 @@ import {
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';
 import { video } from '@wordpress/icons';
-import { Link } from '@wordpress/ui';
+import { Link } from '@wordpress/route';
+import { Link as ExternalLink } from '@wordpress/ui';
 import { useMemo } from 'react';
 /**
  * Internal dependencies
@@ -39,24 +41,31 @@ type VideoPressWidgetProps = WidgetRenderProps< VideoPressRenderAttributes > & {
 };
 
 /**
- * Maps normalized video rows onto the shape `LeaderboardChart` expects. Each
- * row's label opens the video's page in a new tab when the report carries a
- * URL. Shares are computed against the largest value of either period so the
- * overlay bars stay proportional. Rows without a matching comparison-period
- * value keep `previousValue`/`previousShare`/`delta` as `undefined` so the
- * chart suppresses their delta instead of fabricating a vs-zero change.
+ * Build a video row's title. Attachment rows navigate to the internal detail
+ * route; rows without an ID retain the original external-link fallback.
  *
- * @param rows - The normalized video-plays rows.
- * @return The leaderboard chart data.
+ * @param row    - The normalized video row.
+ * @param search - Shared report-window parameters for the detail route.
+ * @return The linked or plain row title.
  */
-function buildLeaderboardData( rows: VideoPlaysRow[] ): LeaderboardChartData {
-	// `1` guards against division by zero when every value is 0.
-	const maxPlays = Math.max( ...rows.flatMap( row => [ row.plays, row.previousPlays ?? 0 ] ), 1 );
-
-	return rows.map( row => ( {
-		id: row.key,
-		label: row.link ? (
+function buildVideoTitle( row: VideoPlaysRow, search: Record< string, unknown > ): JSX.Element {
+	if ( row.id ) {
+		return (
 			<Link
+				className={ styles.internalLink }
+				to="/video/$videoId"
+				params={ { videoId: String( row.id ) } as unknown as never }
+				search={ search as unknown as never }
+				title={ row.label }
+			>
+				{ row.label }
+			</Link>
+		);
+	}
+
+	if ( row.link ) {
+		return (
+			<ExternalLink
 				className={ styles.labelLink }
 				href={ row.link }
 				variant="unstyled"
@@ -64,12 +73,37 @@ function buildLeaderboardData( rows: VideoPlaysRow[] ): LeaderboardChartData {
 				title={ row.label }
 			>
 				{ row.label }
-			</Link>
-		) : (
-			<span className={ styles.labelText } title={ row.label }>
-				{ row.label }
-			</span>
-		),
+			</ExternalLink>
+		);
+	}
+
+	return (
+		<span className={ styles.labelText } title={ row.label }>
+			{ row.label }
+		</span>
+	);
+}
+
+/**
+ * Maps normalized video rows onto the shape `LeaderboardChart` expects. Shares
+ * are computed against the largest value of either period so the overlay bars
+ * stay proportional. Rows without a matching comparison-period value keep
+ * comparison fields undefined so the chart suppresses fabricated deltas.
+ *
+ * @param rows   - The normalized video-plays rows.
+ * @param search - Shared report-window parameters for detail links.
+ * @return The leaderboard chart data.
+ */
+function buildLeaderboardData(
+	rows: VideoPlaysRow[],
+	search: Record< string, unknown >
+): LeaderboardChartData {
+	// `1` guards against division by zero when every value is 0.
+	const maxPlays = Math.max( ...rows.flatMap( row => [ row.plays, row.previousPlays ?? 0 ] ), 1 );
+
+	return rows.map( row => ( {
+		id: row.key,
+		label: buildVideoTitle( row, search ),
 		currentValue: row.plays,
 		currentShare: ( row.plays / maxPlays ) * 100,
 		previousValue: row.previousPlays,
@@ -117,8 +151,12 @@ function VideoPressReport( { max }: VideoPressReportProps ) {
 	const isInitialLoading = ( isLoading || primary.isPending ) && ! hasData;
 
 	const rows = useMemo( () => toVideoPlaysRows( comparisonRows?.rows ?? [] ), [ comparisonRows ] );
+	const detailSearch = useMemo( () => pickReportDateParams( reportParams ), [ reportParams ] );
 
-	const chartData = useMemo( () => buildLeaderboardData( rows ), [ rows ] );
+	const chartData = useMemo(
+		() => buildLeaderboardData( rows, detailSearch ),
+		[ rows, detailSearch ]
+	);
 
 	return (
 		<WidgetState

--- a/projects/packages/premium-analytics/widgets/videopress/render.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/render.tsx
@@ -6,6 +6,7 @@ import { pickReportDateParams } from '@jetpack-premium-analytics/routing';
 import {
 	LeaderboardChart,
 	ReportLink,
+	VideoTitleLink,
 	WidgetFooter,
 	WidgetRoot,
 	WidgetState,
@@ -17,8 +18,6 @@ import {
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';
 import { video } from '@wordpress/icons';
-import { Link } from '@wordpress/route';
-import { Link as ExternalLink } from '@wordpress/ui';
 import { useMemo } from 'react';
 /**
  * Internal dependencies
@@ -49,38 +48,19 @@ type VideoPressWidgetProps = WidgetRenderProps< VideoPressRenderAttributes > & {
  * @return The linked or plain row title.
  */
 function buildVideoTitle( row: VideoPlaysRow, search: Record< string, unknown > ): JSX.Element {
-	if ( row.id ) {
-		return (
-			<Link
-				className={ styles.internalLink }
-				to="/video/$videoId"
-				params={ { videoId: String( row.id ) } as unknown as never }
-				search={ search as unknown as never }
-				title={ row.label }
-			>
-				{ row.label }
-			</Link>
-		);
-	}
-
-	if ( row.link ) {
-		return (
-			<ExternalLink
-				className={ styles.labelLink }
-				href={ row.link }
-				variant="unstyled"
-				openInNewTab
-				title={ row.label }
-			>
-				{ row.label }
-			</ExternalLink>
-		);
-	}
-
 	return (
-		<span className={ styles.labelText } title={ row.label }>
-			{ row.label }
-		</span>
+		<VideoTitleLink
+			id={ row.id }
+			label={ row.label }
+			link={ row.link }
+			search={ search }
+			classNames={ {
+				internal: styles.internalLink,
+				external: styles.labelLink,
+				plain: styles.labelText,
+			} }
+			title={ row.label }
+		/>
 	);
 }
 

--- a/projects/packages/premium-analytics/widgets/videopress/stories/videopress-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/stories/videopress-widget.stories.tsx
@@ -71,7 +71,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					"Dashboard widget showing the site's most played VideoPress videos as a leaderboard, sourced from the Jetpack Stats `video-plays` module via `useStatsVideoPlays`, with optional period-over-period comparison. In Storybook the data is served by `registerReportMocks`.",
+					"Dashboard widget showing the site's most played VideoPress videos as a leaderboard, with internal video-detail links and optional period-over-period comparison. It is sourced from the Jetpack Stats `video-plays` module via `useStatsVideoPlays`; in Storybook the data is served by `registerReportMocks`.",
 			},
 		},
 	},

--- a/projects/packages/premium-analytics/widgets/videopress/style.module.css
+++ b/projects/packages/premium-analytics/widgets/videopress/style.module.css
@@ -1,5 +1,6 @@
 .labelLink,
-.labelText {
+.labelText,
+.internalLink {
 	display: block;
 
 	/* Vertical padding sets the overlay bar height — the bar fills the row,
@@ -18,7 +19,9 @@
 }
 
 .labelLink:hover,
-.labelLink:focus {
+.labelLink:focus,
+.internalLink:hover,
+.internalLink:focus {
 	text-decoration: underline;
 }
 


### PR DESCRIPTION
Fixes WOOA7S-1625

## Proposed changes

Adds the shell for the single-video detail page so upcoming video widgets have a route to land on, and wires the entry points that lead to it.

* New `/video/$videoId` route with the standard connection/sync guards; invalid (non positive-integer) IDs redirect back to the dashboard. The page renders a Stats breadcrumb and the video title (via a new `useVideoSummary` hook backed by `useStatsSingleVideo`).
* The single-video sanitizer now passes through the attachment `post` metadata (id, title, date) so the page can resolve its heading.
* Video titles in the Reports > Videos table and the VideoPress widget now link to the detail page (widget links carry the current report date params); rows without an attachment ID keep the previous external-link/plain-text fallback.

<img width="2768" height="1304" alt="Google Chrome -2026-07-17 at 17 37 58@2x" src="https://github.com/user-attachments/assets/bf22f66a-1252-47bc-9edb-b142d77fcd6e" />
_PR Adds an empty shell video-details page_

## Related product discussion/links

* WOOA7S-1625

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build Premium Analytics and open the dashboard on a site with VideoPress plays.
* In the VideoPress widget, click a video title — it should navigate to `/video/<id>` showing a Stats breadcrumb and the video's title, keeping the selected date range.
* Go to Premium Analytics ->  VideoPress widget, click on any video to go to the new video details page
* Go to Premium Analytics ->  VideoPress widget -> See report -> Click on any video to go to the new video details page
* Visit `/video/abc` or `/video/0` directly — you should be redirected to the dashboard.
