### PR TITLE
Account Protection: default the password param in the login form detection callback

### DIFF
--- a/projects/packages/account-protection/changelog/fix-password-detection-default-password
+++ b/projects/packages/account-protection/changelog/fix-password-detection-default-password
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Account Protection: Default the login form password detection callback's password argument to null so other plugins hooking into the authenticate filter without a password do not trigger a fatal error.

--- a/projects/packages/account-protection/src/class-password-detection.php
+++ b/projects/packages/account-protection/src/class-password-detection.php
@@ -46,7 +46,7 @@ class Password_Detection {
 	 *
 	 * @return \WP_User|\WP_Error|null The user object, error object, or null.
 	 */
-	public function login_form_password_detection( $user, ?string $password ) {
+	public function login_form_password_detection( $user, ?string $password = null ) {
 		// First check if the user object and password are valid. Third-party plugins might pass
 		// incompatible types to authentication hooks, so we need this extra check.
 		if ( is_wp_error( $user ) || ! ( $user instanceof \WP_User ) || $password === null ) {

--- a/projects/packages/account-protection/tests/php/Password_Detection_Test.php
+++ b/projects/packages/account-protection/tests/php/Password_Detection_Test.php
@@ -549,4 +549,21 @@ class Password_Detection_Test extends BaseTestCase {
 		// Assert that that \WP_User is returned.
 		$this->assertSame( $some_user, $return, 'User should be returned when a NULL password is provided.' );
 	}
+
+	/**
+	 * Tests that login_form_password_detection handles a missing password argument gracefully.
+	 *
+	 * Other plugins hooking into the `authenticate` filter may call the callback without
+	 * supplying the password argument. The parameter defaults to null so this must not fatal.
+	 */
+	public function test_login_form_password_detection_handles_missing_password_argument_gracefully(): void {
+		$sut       = new Password_Detection();
+		$some_user = new \WP_User();
+
+		// Intentionally omit the password argument to exercise the default value.
+		$return = $sut->login_form_password_detection( $some_user );
+
+		// Assert that the \WP_User is returned unchanged.
+		$this->assertSame( $some_user, $return, 'User should be returned when the password argument is omitted.' );
+	}
 }


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/PROTECT-178

## Proposed changes
* Give `Password_Detection::login_form_password_detection()` a default value of `null` for its `?string $password` parameter. Previously the parameter had no default, so any plugin hooking into the `authenticate` filter and invoking the callback without a password argument would trigger an `ArgumentCountError` fatal.
* The method body already returns the `$user` untouched when `$password === null`, so the default value simply completes that existing safety net.
* Extend the unit tests with `test_login_form_password_detection_handles_missing_password_argument_gracefully`, which calls the method with the password argument omitted entirely (distinct from the existing explicit-`null` test).

## Related product discussion/links
* p1784041285765649-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Added unit test covers it

🤖 Generated with [Claude Code](https://claude.com/claude-code) and edited