### PR TITLE
Premium Analytics: lay the post detail header out as one row

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1622-post-detail-header-row
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1622-post-detail-header-row
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Premium Analytics: post detail header — summary and date filters share one row, with the featured-image thumbnail leading the title and a publish/performance-window subtitle.

--- a/projects/packages/premium-analytics/routes/post-detail/components/post-detail-tabs/post-detail-tabs.module.scss
+++ b/projects/packages/premium-analytics/routes/post-detail/components/post-detail-tabs/post-detail-tabs.module.scss
@@ -1,3 +1,10 @@
 .tabList {
 	padding-inline: var(--wpds-dimension-padding-2xl);
 }
+
+// The page header row below owns the spacing (its own 40px block padding),
+// so drop SectionTabs' default bottom margin. Doubled class to outrank the
+// shared `.tabList` rule regardless of bundle order.
+.tabList.tabList {
+	margin-block-end: 0;
+}

--- a/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.module.scss
+++ b/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.module.scss
@@ -1,13 +1,8 @@
 .card {
 	display: flex;
-	align-items: flex-start;
-	justify-content: space-between;
+	align-items: center;
 	gap: var(--wpds-dimension-gap-lg);
-	border:
-		var(--wpds-border-width-xs) solid
-		var(--wpds-color-stroke-surface-neutral-weak);
-	border-radius: var(--wpds-border-radius-md);
-	padding: var(--wpds-dimension-padding-2xl);
+	min-inline-size: 0;
 }
 
 .details {
@@ -17,22 +12,26 @@
 	min-inline-size: 0;
 }
 
-.type {
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	gap: var(--wpds-dimension-gap-xs);
+.subtitle {
 	color: var(--wpds-color-foreground-content-neutral-weak);
 }
 
-.published {
-	color: var(--wpds-color-foreground-content-neutral-weak);
+.image,
+.imagePlaceholder {
+	flex: 0 0 auto;
+	inline-size: 96px;
+	block-size: 96px;
+	border-radius: var(--wpds-border-radius-md);
 }
 
 .image {
-	flex: 0 0 auto;
-	inline-size: 72px;
-	block-size: 72px;
 	object-fit: cover;
-	border-radius: var(--wpds-border-radius-sm);
+}
+
+.imagePlaceholder {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: var(--wpds-color-background-surface-neutral-weak);
+	color: var(--wpds-color-foreground-content-neutral-weak);
 }

--- a/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.module.scss
+++ b/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.module.scss
@@ -15,7 +15,9 @@
 	min-inline-size: 0;
 }
 
-.title {
+// Outranks the Text heading variant's `:is(h1,…).__heading` font-size rule
+// ((0,1,1)) without touching its private custom properties.
+.details h1.title {
 	font-size: 32px;
 	font-weight: 500;
 	line-height: 1.2;

--- a/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.module.scss
+++ b/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.module.scss
@@ -1,27 +1,37 @@
 .card {
 	display: flex;
 	align-items: center;
-	gap: var(--wpds-dimension-gap-lg);
+	gap: 20px;
 	min-inline-size: 0;
 }
 
 .details {
 	display: flex;
 	flex-direction: column;
-	gap: var(--wpds-dimension-gap-xs);
+	// The text block matches the thumbnail height: title against its top,
+	// subtitle against its bottom.
+	justify-content: space-between;
+	block-size: 72px;
 	min-inline-size: 0;
+}
+
+.title {
+	font-size: 32px;
+	font-weight: 500;
+	line-height: 1.2;
 }
 
 .subtitle {
 	color: var(--wpds-color-foreground-content-neutral-weak);
+	font-size: 13px;
 }
 
 .image,
 .imagePlaceholder {
 	flex: 0 0 auto;
-	inline-size: 96px;
-	block-size: 96px;
-	border-radius: var(--wpds-border-radius-md);
+	inline-size: 72px;
+	block-size: 72px;
+	border-radius: 8px;
 }
 
 .image {

--- a/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.module.scss
+++ b/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.module.scss
@@ -12,6 +12,7 @@
 	// subtitle against its bottom.
 	justify-content: space-between;
 	block-size: 72px;
+	flex: 1 1 auto;
 	min-inline-size: 0;
 }
 
@@ -21,11 +22,17 @@
 	font-size: 32px;
 	font-weight: 500;
 	line-height: 1.2;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .subtitle {
 	color: var(--wpds-color-foreground-content-neutral-weak);
 	font-size: 13px;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .image,

--- a/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.tsx
@@ -83,7 +83,9 @@ export function PostSummaryCard( { summary, performanceRange }: PostSummaryCardP
 				</div>
 			) }
 			<div className={ styles.details }>
-				<Text variant="heading-xl" render={ <h1 /> } className={ styles.title }>
+				{ /* The heading ellipsizes to one line; `title` keeps the full text
+				     reachable on hover. */ }
+				<Text variant="heading-xl" render={ <h1 title={ title } /> } className={ styles.title }>
 					{ title }
 				</Text>
 				{ subtitle ? (

--- a/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.tsx
@@ -83,7 +83,7 @@ export function PostSummaryCard( { summary, performanceRange }: PostSummaryCardP
 				</div>
 			) }
 			<div className={ styles.details }>
-				<Text variant="heading-xl" render={ <h1 /> }>
+				<Text variant="heading-xl" render={ <h1 /> } className={ styles.title }>
 					{ title }
 				</Text>
 				{ subtitle ? (

--- a/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/components/post-summary-card/post-summary-card.tsx
@@ -13,7 +13,15 @@ import type { PostSummary } from '../../hooks';
 
 type PostSummaryCardProps = {
 	summary: PostSummary;
+	/**
+	 * The committed report date range, rendered as the performance window
+	 * ("Performance from … to …") so the header states what period every
+	 * widget below reflects.
+	 */
+	performanceRange?: { from: Date | undefined; to: Date | undefined };
 };
+
+const DATE_FORMAT = 'MMM d, yyyy';
 
 /**
  * Get the display label for a post type slug.
@@ -28,43 +36,62 @@ function getTypeLabel( type?: string ): string {
 }
 
 /**
- * The header card summarizing the post/page being viewed: type badge, title,
- * published date, and featured image.
+ * The page-header summary of the post/page being viewed: featured-image
+ * thumbnail (or a type-icon placeholder), title, and one line stating the
+ * publish date and the applied performance window.
  *
- * @param props         - Component props.
- * @param props.summary - The resolved post summary.
- * @return The summary card element.
+ * @param props                  - Component props.
+ * @param props.summary          - The resolved post summary.
+ * @param props.performanceRange - The committed report date range.
+ * @return The summary header element.
  */
-export function PostSummaryCard( { summary }: PostSummaryCardProps ) {
+export function PostSummaryCard( { summary, performanceRange }: PostSummaryCardProps ) {
 	const { title, type, publishedDate, imageUrl } = summary;
 
 	const publishedDateObject = publishedDate ? new Date( publishedDate ) : undefined;
-	const publishedLabel =
+	const publishedSentence =
 		publishedDateObject && isValid( publishedDateObject )
 			? sprintf(
-					/* translators: %s: the date a post was published, e.g. "Aug 19, 2025". */
-					__( 'Published %s', 'jetpack-premium-analytics' ),
-					format( publishedDateObject, 'MMM d, yyyy' )
+					/* translators: %1$s: "Post" or "Page". %2$s: the publish date, e.g. "Aug 19, 2025". */
+					__( '%1$s published on %2$s.', 'jetpack-premium-analytics' ),
+					getTypeLabel( type ),
+					format( publishedDateObject, DATE_FORMAT )
 			  )
 			: undefined;
 
+	const { from, to } = performanceRange ?? {};
+	const performanceSentence =
+		from && to && isValid( from ) && isValid( to )
+			? sprintf(
+					/* translators: %1$s and %2$s: the report range bounds, e.g. "Jul 9, 2026". */
+					__( 'Performance from %1$s to %2$s', 'jetpack-premium-analytics' ),
+					format( from, DATE_FORMAT ),
+					format( to, DATE_FORMAT )
+			  )
+			: undefined;
+	const subtitle = [ publishedSentence, performanceSentence ].filter( Boolean ).join( ' ' );
+
 	return (
 		<div className={ styles.card }>
-			<div className={ styles.details }>
-				<div className={ styles.type }>
-					<Icon icon={ type === 'page' ? pageIcon : postIcon } size={ 20 } />
-					<Text variant="body-sm">{ getTypeLabel( type ) }</Text>
+			{ imageUrl ? (
+				<img className={ styles.image } src={ imageUrl } alt="" />
+			) : (
+				// The placeholder carries the type glyph, so the type still
+				// reads at a glance without its own badge row.
+				<div className={ styles.imagePlaceholder } aria-hidden="true">
+					<Icon icon={ type === 'page' ? pageIcon : postIcon } size={ 28 } />
 				</div>
+			) }
+			<div className={ styles.details }>
 				<Text variant="heading-xl" render={ <h1 /> }>
 					{ title }
 				</Text>
-				{ publishedLabel ? (
-					<Text variant="body-sm" className={ styles.published }>
-						{ publishedLabel }
+				{ subtitle ? (
+					<Text variant="body-sm" className={ styles.subtitle }>
+						{ subtitle }
 					</Text>
 				) : null }
 			</div>
-			{ imageUrl ? <img className={ styles.image } src={ imageUrl } alt="" /> : null }
 		</div>
 	);
 }

--- a/projects/packages/premium-analytics/routes/post-detail/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.module.scss
@@ -24,15 +24,36 @@
 	justify-content: space-between;
 	flex-wrap: wrap;
 	gap: var(--wpds-dimension-gap-lg);
+	container-type: inline-size;
 	padding-block: 40px;
 	padding-inline: var(--wpds-dimension-padding-2xl);
 }
 
 .summary {
-	flex: 1 1 auto;
-	min-inline-size: 0;
+	flex: 1 1 360px;
+	min-inline-size: min(100%, 320px);
 }
 
 .dateFilters {
-	flex: 0 0 auto;
+	display: flex;
+	flex: 0 1 auto;
+	justify-content: flex-end;
+	min-inline-size: min(100%, 600px);
+}
+
+@container (max-width: 960px) {
+
+	.summary,
+	.dateFilters {
+		flex-basis: 100%;
+		min-inline-size: 0;
+	}
+
+	.dateFilters {
+		justify-content: flex-start;
+	}
+
+	.dateFilters :global(.date-filters-panel) {
+		inline-size: 100%;
+	}
 }

--- a/projects/packages/premium-analytics/routes/post-detail/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.module.scss
@@ -17,13 +17,14 @@
 .header {
 	// One row below the tab bar: summary left, date filters right. Wraps the
 	// filters onto their own line when the row gets narrow. Inline padding
-	// matches the tabs and widget grid.
+	// matches the tabs and widget grid; the 40px block spacing is the
+	// design's breathing room around the whole header row.
 	display: flex;
 	align-items: center;
 	justify-content: space-between;
 	flex-wrap: wrap;
 	gap: var(--wpds-dimension-gap-lg);
-	padding-block-end: var(--wpds-dimension-gap-lg);
+	padding-block: 40px;
 	padding-inline: var(--wpds-dimension-padding-2xl);
 }
 

--- a/projects/packages/premium-analytics/routes/post-detail/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.module.scss
@@ -14,16 +14,24 @@
 	padding-inline: var(--wpds-dimension-padding-2xl);
 }
 
-.summary {
-	// Sits below the tab bar and above the date filters, aligned with the tabs
-	// and widget grid.
+.header {
+	// One row below the tab bar: summary left, date filters right. Wraps the
+	// filters onto their own line when the row gets narrow. Inline padding
+	// matches the tabs and widget grid.
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	flex-wrap: wrap;
+	gap: var(--wpds-dimension-gap-lg);
 	padding-block-end: var(--wpds-dimension-gap-lg);
 	padding-inline: var(--wpds-dimension-padding-2xl);
 }
 
+.summary {
+	flex: 1 1 auto;
+	min-inline-size: 0;
+}
+
 .dateFilters {
-	// Sits below the summary card and above the widgets. Only pad below to keep
-	// the spacing even; inline padding matches the tabs and widget grid.
-	padding-block-end: var(--wpds-dimension-gap-lg);
-	padding-inline: var(--wpds-dimension-padding-2xl);
+	flex: 0 0 auto;
 }

--- a/projects/packages/premium-analytics/routes/post-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.tsx
@@ -99,17 +99,27 @@ function PostDetail(): JSX.Element {
 						{ /*
 						 * The summary card and date filters are shared by every tab
 						 * (same post, same date range), so they render once below the
-						 * tab bar and above the per-tab widget grid.
+						 * tab bar and above the per-tab widget grid — one header row,
+						 * summary left, filters right (wrapping onto their own line
+						 * when the row gets narrow).
 						 *
-						 * The date-filters wrapper is also the responsive-measurement
-						 * target: DateFiltersPanel reads its width to pick mobile/wide
-						 * layouts instead of relying on the viewport.
+						 * The header row is also the responsive-measurement target:
+						 * DateFiltersPanel reads its width to pick mobile/wide layouts
+						 * instead of relying on the viewport. Measuring the row (not
+						 * the filters' own wrapper) keeps the measurement stable: the
+						 * panel only sits beside the summary when its intrinsic width
+						 * fits, and once wrapped it really has the row's full width.
 						 */ }
-						<div className={ styles.summary }>
-							<PostSummaryCard summary={ summary } />
-						</div>
-						<div ref={ setContainerElement } className={ styles.dateFilters }>
-							<DateFiltersPanel { ...dateFilters } containerElement={ containerElement } />
+						<div ref={ setContainerElement } className={ styles.header }>
+							<div className={ styles.summary }>
+								<PostSummaryCard
+									summary={ summary }
+									performanceRange={ dateFilters.appliedRange }
+								/>
+							</div>
+							<div className={ styles.dateFilters }>
+								<DateFiltersPanel { ...dateFilters } containerElement={ containerElement } />
+							</div>
 						</div>
 						{ tabs.map( tab => (
 							<SectionTabPanel key={ tab.id } value={ tab.id } className={ styles.content }>


### PR DESCRIPTION
Part of [WOOA7S-1622](https://linear.app/a8c/issue/WOOA7S-1622/page-postpage-detail-traffic-view).

## Why

The post detail header currently stacks two full-width rows — a bordered summary card (type badge, title, published date, image on the right) and the date filters below it. The design mock lays them out as one header row: featured-image thumbnail leading the title on the left, the date filters right-aligned on the same line, and a single subtitle stating both the publish date and the applied performance window.

## Proposed changes

* One header row in the post detail stage: summary left (`flex: 1`), date filters right (`flex: none`), wrapping the filters onto their own line when the row gets narrow. The row is the `DateFiltersPanel` responsive-measurement target — the panel only sits beside the summary when its intrinsic width fits, and once wrapped it really has the row's full width, so the measurement stays honest in both positions.
* `PostSummaryCard` redesigned per the mock and its spec: card border/padding dropped (it's a page header now), the featured image moves to the left as a 72×72 / 8px-radius thumbnail — with a type-icon placeholder when the post has none — 20px from the text block, whose height matches the thumbnail (32px/1.2 medium title at the top, 13px muted subtitle at the bottom). The type badge row folds into the subtitle sentence ("Post published on Oct 21, 2024. Performance from Jul 9, 2026 to Jul 15, 2026").
* The performance window renders from the committed report range (`useReportDateFilters`' `appliedRange`), so the header always states the period the widgets below reflect.
* Spacing per spec: the header row carries 40px block padding and owns that spacing alone — `SectionTabs`' default 16px bottom margin is zeroed on this page (doubled-class override so bundle order can't flip it). The 32px title outranks the `Text` heading variant's `:is(h1,…)` font-size rule via selector specificity instead of touching its private custom properties.

Out of scope: the mock's `‹` step-back-one-period control belongs to the date picker itself and is left for a picker-level follow-up.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* From `projects/packages/premium-analytics`: `pnpm run typecheck`, `pnpm run test routes/post-detail`.
* On a Jetpack-connected site, open a post detail page (`admin.php?page=jetpack-premium-analytics-wp-admin&p=%2Fpost%2F<post-id>`): the title block and the date filters share one row; the subtitle reads "Post published on …. Performance from … to …" and the range updates when a new range is applied.
* Posts without a featured image show a neutral placeholder tile with the post/page glyph.
* Narrow the window: the filters wrap below the title before switching to their compact layout.

### Screenshots

| Before (stacked header) | After (one row, per design) |
|-|-|
|<img width="1320" height="575" alt="截圖 2026-07-15 晚上10 24 43" src="https://github.com/user-attachments/assets/5d1d65f9-c2c4-490c-9cc6-a740dee65e1e" />|<img width="1315" height="546" alt="截圖 2026-07-15 晚上10 19 29" src="https://github.com/user-attachments/assets/0ec63acc-43d1-4f22-83b8-cfa9b27591e8" />|

🤖 Generated with [Claude Code](https://claude.com/claude-code)
