### PR TITLE
SEO: split schema settings cards

### DIFF
--- a/projects/packages/seo/_inc/data/test/use-schema-settings.test.ts
+++ b/projects/packages/seo/_inc/data/test/use-schema-settings.test.ts
@@ -38,15 +38,20 @@ describe( 'useSchemaSettings', () => {
 		expect( result.current.localBusiness ).toEqual( RESPONSE.localBusiness );
 		expect( result.current.defaults ).toEqual( RESPONSE.defaults.organization );
 		expect( result.current.localBusinessDefaults ).toEqual( RESPONSE.defaults.localBusiness );
-		expect( result.current.isDirty ).toBe( false );
+		expect( result.current.isOrganizationDirty ).toBe( false );
+		expect( result.current.isLocalBusinessDirty ).toBe( false );
 	} );
 
-	it( 'tracks dirty state and saves through the schema-settings route', async () => {
+	it( 'saves only Organization and preserves pending LocalBusiness edits', async () => {
 		const onSave = jest.fn();
 		const { result } = renderHook( () => useSchemaSettings( RESPONSE, onSave ) );
 
-		act( () => result.current.setOrganizationField( { sameAs: [ 'https://twitter.com/acme' ] } ) );
-		expect( result.current.isDirty ).toBe( true );
+		act( () => {
+			result.current.setOrganizationField( { sameAs: [ 'https://twitter.com/acme' ] } );
+			result.current.setLocalBusinessField( { telephone: '+1 555 123 4567' } );
+		} );
+		expect( result.current.isOrganizationDirty ).toBe( true );
+		expect( result.current.isLocalBusinessDirty ).toBe( true );
 
 		const saved = {
 			breadcrumbList: RESPONSE.breadcrumbList,
@@ -56,22 +61,23 @@ describe( 'useSchemaSettings', () => {
 		};
 		mockApiFetch.mockResolvedValueOnce( saved );
 
-		act( () => result.current.save() );
+		act( () => result.current.saveOrganization() );
 
-		await waitFor( () => expect( result.current.isDirty ).toBe( false ) );
+		await waitFor( () => expect( result.current.isOrganizationDirty ).toBe( false ) );
 
 		const post = mockApiFetch.mock.calls.find(
 			( [ options ] ) => ( options as { method?: string } ).method === 'POST'
 		);
 		const options = post![ 0 ] as {
 			path: string;
-			data: Pick< SchemaSettings, 'breadcrumbList' | 'organization' | 'localBusiness' >;
+			data: Pick< SchemaSettings, 'organization' >;
 		};
 		expect( options.path ).toBe( '/jetpack/v4/seo/schema-settings' );
-		expect( options.data.organization.sameAs ).toEqual( [ 'https://twitter.com/acme' ] );
-		expect( options.data.breadcrumbList ).toEqual( RESPONSE.breadcrumbList );
-		expect( options.data.localBusiness ).toEqual( RESPONSE.localBusiness );
-		expect( result.current.localBusiness ).toEqual( saved.localBusiness );
+		expect( options.data ).toEqual( {
+			organization: { ...RESPONSE.organization, sameAs: [ 'https://twitter.com/acme' ] },
+		} );
+		expect( result.current.localBusiness.telephone ).toBe( '+1 555 123 4567' );
+		expect( result.current.isLocalBusinessDirty ).toBe( true );
 		expect( onSave ).toHaveBeenCalledWith( saved );
 		expect( createSuccessNotice ).toHaveBeenCalled();
 	} );
@@ -101,7 +107,8 @@ describe( 'useSchemaSettings', () => {
 		} );
 		expect( result.current.breadcrumbList ).toEqual( { enabled: false } );
 		expect( result.current.organization.name ).toBe( 'Pending edit' );
-		expect( result.current.isDirty ).toBe( true );
+		expect( result.current.isOrganizationDirty ).toBe( true );
+		expect( result.current.isLocalBusinessDirty ).toBe( false );
 		expect( onSave ).toHaveBeenCalledWith( saved );
 		expect( createSuccessNotice ).toHaveBeenCalled();
 	} );
@@ -117,16 +124,18 @@ describe( 'useSchemaSettings', () => {
 		expect( createErrorNotice ).toHaveBeenCalledWith( 'nope', expect.anything() );
 	} );
 
-	it( 'tracks dirty state and re-seeds localBusiness after saving', async () => {
+	it( 'saves only LocalBusiness and preserves pending Organization edits', async () => {
 		const { result } = renderHook( () => useSchemaSettings( RESPONSE ) );
 
-		act( () =>
+		act( () => {
+			result.current.setOrganizationField( { name: 'Pending organization' } );
 			result.current.setLocalBusinessField( {
 				enabled: true,
 				address: { ...RESPONSE.localBusiness.address, streetAddress: '123 Main St' },
-			} )
-		);
-		expect( result.current.isDirty ).toBe( true );
+			} );
+		} );
+		expect( result.current.isOrganizationDirty ).toBe( true );
+		expect( result.current.isLocalBusinessDirty ).toBe( true );
 
 		const saved: SchemaSettings = {
 			...RESPONSE,
@@ -138,8 +147,8 @@ describe( 'useSchemaSettings', () => {
 		};
 		mockApiFetch.mockResolvedValueOnce( saved );
 
-		act( () => result.current.save() );
-		await waitFor( () => expect( result.current.isDirty ).toBe( false ) );
+		act( () => result.current.saveLocalBusiness() );
+		await waitFor( () => expect( result.current.isLocalBusinessDirty ).toBe( false ) );
 
 		const post = mockApiFetch.mock.calls.find(
 			( [ options ] ) => ( options as { method?: string } ).method === 'POST'
@@ -149,7 +158,10 @@ describe( 'useSchemaSettings', () => {
 		};
 		expect( options.data.localBusiness.enabled ).toBe( true );
 		expect( options.data.localBusiness.address.streetAddress ).toBe( '123 Main St' );
+		expect( Object.keys( options.data ) ).toEqual( [ 'localBusiness' ] );
 		expect( result.current.localBusiness ).toEqual( saved.localBusiness );
+		expect( result.current.organization.name ).toBe( 'Pending organization' );
+		expect( result.current.isOrganizationDirty ).toBe( true );
 	} );
 
 	it( 'trims and uppercases the country code when saving LocalBusiness settings', async () => {
@@ -169,7 +181,7 @@ describe( 'useSchemaSettings', () => {
 			},
 		};
 		mockApiFetch.mockResolvedValueOnce( saved );
-		act( () => result.current.save() );
+		act( () => result.current.saveLocalBusiness() );
 		await waitFor( () => expect( createSuccessNotice ).toHaveBeenCalled() );
 
 		const post = mockApiFetch.mock.calls.find(
@@ -194,27 +206,26 @@ describe( 'useSchemaSettings', () => {
 
 		// An all-invalid set cleans to empty, matching the baseline — so not dirty.
 		act( () => result.current.setOrganizationField( { sameAs: [ '', '   ', 'not a url' ] } ) );
-		expect( result.current.isDirty ).toBe( false );
+		expect( result.current.isOrganizationDirty ).toBe( false );
 
 		act( () =>
 			result.current.setOrganizationField( {
 				sameAs: [ 'not a url', ' https://twitter.com/acme ', 'https://twitter.com/acme' ],
 			} )
 		);
-		expect( result.current.isDirty ).toBe( true );
+		expect( result.current.isOrganizationDirty ).toBe( true );
 
 		mockApiFetch.mockResolvedValueOnce( RESPONSE );
-		act( () => result.current.save() );
+		act( () => result.current.saveOrganization() );
 		await waitFor( () => expect( createSuccessNotice ).toHaveBeenCalled() );
 
 		const post = mockApiFetch.mock.calls.find(
 			( [ options ] ) => ( options as { method?: string } ).method === 'POST'
 		);
 		const options = post![ 0 ] as {
-			data: Pick< SchemaSettings, 'breadcrumbList' | 'organization' | 'localBusiness' >;
+			data: Pick< SchemaSettings, 'organization' >;
 		};
 		expect( options.data.organization.sameAs ).toEqual( [ 'https://twitter.com/acme' ] );
-		expect( options.data.breadcrumbList ).toEqual( RESPONSE.breadcrumbList );
-		expect( options.data.localBusiness ).toEqual( RESPONSE.localBusiness );
+		expect( Object.keys( options.data ) ).toEqual( [ 'organization' ] );
 	} );
 } );

--- a/projects/packages/seo/_inc/data/test/use-schema-settings.test.ts
+++ b/projects/packages/seo/_inc/data/test/use-schema-settings.test.ts
@@ -64,6 +64,7 @@ describe( 'useSchemaSettings', () => {
 		act( () => result.current.saveOrganization() );
 
 		await waitFor( () => expect( result.current.isOrganizationDirty ).toBe( false ) );
+		expect( createInfoNotice ).toHaveBeenCalledWith( 'Saving organization…', expect.anything() );
 
 		const post = mockApiFetch.mock.calls.find(
 			( [ options ] ) => ( options as { method?: string } ).method === 'POST'
@@ -97,6 +98,7 @@ describe( 'useSchemaSettings', () => {
 
 		act( () => result.current.commitBreadcrumbList( { enabled: false } ) );
 		expect( result.current.breadcrumbList ).toEqual( { enabled: false } );
+		expect( createInfoNotice ).toHaveBeenCalledWith( 'Saving breadcrumbs…', expect.anything() );
 
 		await waitFor( () => expect( result.current.isSaving ).toBe( false ) );
 
@@ -149,6 +151,7 @@ describe( 'useSchemaSettings', () => {
 
 		act( () => result.current.saveLocalBusiness() );
 		await waitFor( () => expect( result.current.isLocalBusinessDirty ).toBe( false ) );
+		expect( createInfoNotice ).toHaveBeenCalledWith( 'Saving local business…', expect.anything() );
 
 		const post = mockApiFetch.mock.calls.find(
 			( [ options ] ) => ( options as { method?: string } ).method === 'POST'

--- a/projects/packages/seo/_inc/data/use-schema-settings.ts
+++ b/projects/packages/seo/_inc/data/use-schema-settings.ts
@@ -92,7 +92,7 @@ export function useSchemaSettings(
 			const next = { ...sections.breadcrumbList, ...patch };
 			setSections( current => ( { ...current, breadcrumbList: next } ) );
 			setIsSaving( true );
-			createInfoNotice( __( 'Saving schema settings…', 'jetpack-seo' ), {
+			createInfoNotice( __( 'Saving breadcrumbs…', 'jetpack-seo' ), {
 				id: NOTICE_ID,
 				type: 'snackbar',
 				isDismissible: false,
@@ -146,11 +146,16 @@ export function useSchemaSettings(
 				return;
 			}
 			setIsSaving( true );
-			createInfoNotice( __( 'Saving schema settings…', 'jetpack-seo' ), {
-				id: NOTICE_ID,
-				type: 'snackbar',
-				isDismissible: false,
-			} );
+			createInfoNotice(
+				section === 'organization'
+					? __( 'Saving organization…', 'jetpack-seo' )
+					: __( 'Saving local business…', 'jetpack-seo' ),
+				{
+					id: NOTICE_ID,
+					type: 'snackbar',
+					isDismissible: false,
+				}
+			);
 			apiFetch< SchemaSettings >( {
 				path: ENDPOINT,
 				method: 'POST',

--- a/projects/packages/seo/_inc/data/use-schema-settings.ts
+++ b/projects/packages/seo/_inc/data/use-schema-settings.ts
@@ -22,12 +22,6 @@ type EditableSchemaSections = Pick<
 	'breadcrumbList' | 'organization' | 'localBusiness'
 >;
 
-const cleanSections = ( sections: EditableSchemaSections ): EditableSchemaSections => ( {
-	breadcrumbList: { ...sections.breadcrumbList },
-	organization: cleanOrganization( sections.organization ),
-	localBusiness: cleanLocalBusiness( sections.localBusiness ),
-} );
-
 export interface SchemaSettingsForm {
 	/** The editable BreadcrumbList setting. */
 	breadcrumbList: BreadcrumbListSettings;
@@ -40,16 +34,20 @@ export interface SchemaSettingsForm {
 	/** LocalBusiness defaults shown as field placeholders. */
 	localBusinessDefaults: LocalBusinessDefaults;
 	isSaving: boolean;
-	/** Whether the local schema values differ from the last-saved baseline. */
-	isDirty: boolean;
-	/** Patch one or more Organization fields locally (persisted by `save()`). */
+	/** Whether the local Organization values differ from their last-saved baseline. */
+	isOrganizationDirty: boolean;
+	/** Whether the local LocalBusiness values differ from their last-saved baseline. */
+	isLocalBusinessDirty: boolean;
+	/** Patch one or more Organization fields locally (persisted by `saveOrganization()`). */
 	setOrganizationField: ( patch: Partial< OrganizationSettings > ) => void;
 	/** Patch the BreadcrumbList setting and persist it immediately (toggles auto-save). */
 	commitBreadcrumbList: ( patch: Partial< BreadcrumbListSettings > ) => void;
-	/** Patch one or more LocalBusiness fields locally (persisted by `save()`). */
+	/** Patch one or more LocalBusiness fields locally (persisted by `saveLocalBusiness()`). */
 	setLocalBusinessField: ( patch: Partial< LocalBusinessSettings > ) => void;
-	/** Persist the current schema values through the schema-settings route. */
-	save: () => void;
+	/** Persist only the current Organization values through the schema-settings route. */
+	saveOrganization: () => void;
+	/** Persist only the current LocalBusiness values through the schema-settings route. */
+	saveLocalBusiness: () => void;
 }
 
 /**
@@ -70,18 +68,21 @@ export function useSchemaSettings(
 		localBusiness: initialSettings.localBusiness,
 	} );
 	const [ isSaving, setIsSaving ] = useState( false );
-	const [ isDirty, setIsDirty ] = useState( false );
 	const { createInfoNotice, createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
-	// The last-saved baseline, kept in a ref so save() compares against the freshest
-	// value without re-creating its callback.
-	const baselineRef = useRef< EditableSchemaSections >(
-		cleanSections( {
-			breadcrumbList: initialSettings.breadcrumbList,
-			organization: initialSettings.organization,
-			localBusiness: initialSettings.localBusiness,
-		} )
-	);
+	// The last-saved baseline, kept in a ref so each section can be saved without
+	// disturbing pending edits in the others.
+	const baselineRef = useRef< EditableSchemaSections >( {
+		breadcrumbList: { ...initialSettings.breadcrumbList },
+		organization: cleanOrganization( initialSettings.organization ),
+		localBusiness: cleanLocalBusiness( initialSettings.localBusiness ),
+	} );
+	const isOrganizationDirty =
+		JSON.stringify( cleanOrganization( sections.organization ) ) !==
+		JSON.stringify( baselineRef.current.organization );
+	const isLocalBusinessDirty =
+		JSON.stringify( cleanLocalBusiness( sections.localBusiness ) ) !==
+		JSON.stringify( baselineRef.current.localBusiness );
 
 	const commitBreadcrumbList = useCallback(
 		( patch: Partial< BreadcrumbListSettings > ) => {
@@ -106,13 +107,7 @@ export function useSchemaSettings(
 						...baselineRef.current,
 						breadcrumbList: { ...settings.breadcrumbList },
 					};
-					setSections( current => {
-						const merged = { ...current, breadcrumbList: settings.breadcrumbList };
-						setIsDirty(
-							JSON.stringify( cleanSections( merged ) ) !== JSON.stringify( baselineRef.current )
-						);
-						return merged;
-					} );
+					setSections( current => ( { ...current, breadcrumbList: settings.breadcrumbList } ) );
 					onSave?.( settings );
 					createSuccessNotice( __( 'Schema settings saved.', 'jetpack-seo' ), {
 						id: NOTICE_ID,
@@ -132,72 +127,73 @@ export function useSchemaSettings(
 	);
 
 	const setOrganizationField = useCallback( ( patch: Partial< OrganizationSettings > ) => {
-		setSections( current => {
-			const next = {
-				...current,
-				organization: { ...current.organization, ...patch },
-			};
-			setIsDirty(
-				JSON.stringify( cleanSections( next ) ) !== JSON.stringify( baselineRef.current )
-			);
-			return next;
-		} );
+		setSections( current => ( {
+			...current,
+			organization: { ...current.organization, ...patch },
+		} ) );
 	}, [] );
 
 	const setLocalBusinessField = useCallback( ( patch: Partial< LocalBusinessSettings > ) => {
-		setSections( current => {
-			const next = {
-				...current,
-				localBusiness: { ...current.localBusiness, ...patch },
-			};
-			setIsDirty(
-				JSON.stringify( cleanSections( next ) ) !== JSON.stringify( baselineRef.current )
-			);
-			return next;
-		} );
+		setSections( current => ( {
+			...current,
+			localBusiness: { ...current.localBusiness, ...patch },
+		} ) );
 	}, [] );
 
-	const save = useCallback( () => {
-		if ( isSaving ) {
-			return;
-		}
-		setIsSaving( true );
-		createInfoNotice( __( 'Saving schema settings…', 'jetpack-seo' ), {
-			id: NOTICE_ID,
-			type: 'snackbar',
-			isDismissible: false,
-		} );
-		apiFetch< SchemaSettings >( {
-			path: ENDPOINT,
-			method: 'POST',
-			data: cleanSections( sections ),
-		} )
-			.then( settings => {
-				// Re-seed from the server's response so the form reflects any sanitization
-				// (e.g. dropped/deduped URLs); a cleared field comes back empty and shows
-				// the placeholder again rather than re-freezing.
-				baselineRef.current = cleanSections( settings );
-				setSections( {
-					breadcrumbList: settings.breadcrumbList,
-					organization: settings.organization,
-					localBusiness: settings.localBusiness,
-				} );
-				onSave?.( settings );
-				setIsDirty( false );
-				createSuccessNotice( __( 'Schema settings saved.', 'jetpack-seo' ), {
-					id: NOTICE_ID,
-					type: 'snackbar',
-				} );
+	const saveSection = useCallback(
+		( section: 'organization' | 'localBusiness' ) => {
+			if ( isSaving ) {
+				return;
+			}
+			setIsSaving( true );
+			createInfoNotice( __( 'Saving schema settings…', 'jetpack-seo' ), {
+				id: NOTICE_ID,
+				type: 'snackbar',
+				isDismissible: false,
+			} );
+			apiFetch< SchemaSettings >( {
+				path: ENDPOINT,
+				method: 'POST',
+				data:
+					section === 'organization'
+						? { organization: cleanOrganization( sections.organization ) }
+						: { localBusiness: cleanLocalBusiness( sections.localBusiness ) },
 			} )
-			.catch( ( error: { message?: string } ) => {
-				createErrorNotice(
-					error?.message ??
-						__( 'Could not save schema settings. Please try again.', 'jetpack-seo' ),
-					{ id: NOTICE_ID, type: 'snackbar' }
-				);
-			} )
-			.finally( () => setIsSaving( false ) );
-	}, [ sections, isSaving, createInfoNotice, createSuccessNotice, createErrorNotice, onSave ] );
+				.then( settings => {
+					// Re-seed only the saved section from the server so sanitization is
+					// reflected without discarding pending edits in the sibling section.
+					if ( section === 'organization' ) {
+						baselineRef.current = {
+							...baselineRef.current,
+							organization: cleanOrganization( settings.organization ),
+						};
+						setSections( current => ( { ...current, organization: settings.organization } ) );
+					} else {
+						baselineRef.current = {
+							...baselineRef.current,
+							localBusiness: cleanLocalBusiness( settings.localBusiness ),
+						};
+						setSections( current => ( { ...current, localBusiness: settings.localBusiness } ) );
+					}
+					onSave?.( settings );
+					createSuccessNotice( __( 'Schema settings saved.', 'jetpack-seo' ), {
+						id: NOTICE_ID,
+						type: 'snackbar',
+					} );
+				} )
+				.catch( ( error: { message?: string } ) => {
+					createErrorNotice(
+						error?.message ??
+							__( 'Could not save schema settings. Please try again.', 'jetpack-seo' ),
+						{ id: NOTICE_ID, type: 'snackbar' }
+					);
+				} )
+				.finally( () => setIsSaving( false ) );
+		},
+		[ sections, isSaving, createInfoNotice, createSuccessNotice, createErrorNotice, onSave ]
+	);
+	const saveOrganization = useCallback( () => saveSection( 'organization' ), [ saveSection ] );
+	const saveLocalBusiness = useCallback( () => saveSection( 'localBusiness' ), [ saveSection ] );
 
 	return {
 		breadcrumbList: sections.breadcrumbList,
@@ -206,10 +202,12 @@ export function useSchemaSettings(
 		localBusiness: sections.localBusiness,
 		localBusinessDefaults: initialSettings.defaults.localBusiness,
 		isSaving,
-		isDirty,
+		isOrganizationDirty,
+		isLocalBusinessDirty,
 		commitBreadcrumbList,
 		setOrganizationField,
 		setLocalBusinessField,
-		save,
+		saveOrganization,
+		saveLocalBusiness,
 	};
 }

--- a/projects/packages/seo/_inc/screens/settings/schema-card.tsx
+++ b/projects/packages/seo/_inc/screens/settings/schema-card.tsx
@@ -2,7 +2,8 @@ import { ToggleControl } from '@wordpress/components';
 import { __, _x, sprintf } from '@wordpress/i18n';
 import { Badge, Card, CollapsibleCard, Stack } from '@wordpress/ui';
 import { useSchemaSettings } from '../../data/use-schema-settings';
-import OrganizationBusinessSection from './schema-settings/organization-business-section';
+import LocalBusinessSection from './schema-settings/local-business-section';
+import OrganizationSection from './schema-settings/organization-section';
 import type { SchemaSettings } from '../../data/schema-settings-types';
 import './style.scss';
 
@@ -13,9 +14,9 @@ const disabledLabel = __( 'Disabled', 'jetpack-seo' );
 /**
  * Site-level Schema settings section.
  *
- * Splits the site-level BreadcrumbList control from the combined Organization /
- * LocalBusiness form across two collapsible cards. The per-user Author profile
- * (Person / ProfilePage) lives in its own card.
+ * Renders the site-level BreadcrumbList, Organization, and LocalBusiness controls
+ * in separate collapsible cards. The per-user Author profile (Person /
+ * ProfilePage) lives in its own card.
  *
  * Collapsed by default and built from the shared `CollapsibleCard` compound,
  * matching the other Settings modules (Canonical URLs, Title structure, Site
@@ -38,29 +39,18 @@ interface Props {
  */
 function SchemaCard( { initialSettings, onSave }: Props ) {
 	const form = useSchemaSettings( initialSettings, onSave );
-	const {
-		breadcrumbList,
-		organization,
-		defaults,
-		localBusiness,
-		localBusinessDefaults,
-		isSaving,
-		commitBreadcrumbList,
-	} = form;
+	const { breadcrumbList, organization, defaults, localBusiness, isSaving, commitBreadcrumbList } =
+		form;
 
 	// Whether each Organization field counts as "set" for the header badge: `name` /
 	// `description` count when overridden here OR present in site identity (Site Title /
 	// Tagline); `sameAs` when it has a profile; `email` when filled. So a typical site
 	// reads "2 of 4 set" before the admin adds anything.
-	const localBusinessAddressSet =
-		Object.values( localBusiness.address ).some( Boolean ) ||
-		Object.values( localBusinessDefaults.address ).some( Boolean );
 	const fieldsSet = [
 		organization.name || defaults.name,
 		organization.description || defaults.description,
 		organization.sameAs.length > 0,
 		organization.email,
-		...( localBusiness.enabled ? [ localBusinessAddressSet ] : [] ),
 	];
 	const setCount = fieldsSet.filter( Boolean ).length;
 
@@ -94,7 +84,7 @@ function SchemaCard( { initialSettings, onSave }: Props ) {
 			<CollapsibleCard.Root defaultOpen={ false }>
 				<CollapsibleCard.Header>
 					<Stack direction="row" justify="space-between" align="center" gap="sm">
-						<Card.Title>{ __( 'Schema', 'jetpack-seo' ) }</Card.Title>
+						<Card.Title>{ __( 'Organization', 'jetpack-seo' ) }</Card.Title>
 						<Badge intent={ setCount === fieldsSet.length ? 'stable' : 'draft' }>
 							{ setCount > 0
 								? sprintf(
@@ -108,7 +98,21 @@ function SchemaCard( { initialSettings, onSave }: Props ) {
 					</Stack>
 				</CollapsibleCard.Header>
 				<CollapsibleCard.Content>
-					<OrganizationBusinessSection form={ form } />
+					<OrganizationSection form={ form } />
+				</CollapsibleCard.Content>
+			</CollapsibleCard.Root>
+
+			<CollapsibleCard.Root defaultOpen={ false }>
+				<CollapsibleCard.Header>
+					<Stack direction="row" justify="space-between" align="center" gap="sm">
+						<Card.Title>{ __( 'Local business', 'jetpack-seo' ) }</Card.Title>
+						<Badge intent={ localBusiness.enabled ? 'stable' : 'draft' }>
+							{ localBusiness.enabled ? enabledLabel : disabledLabel }
+						</Badge>
+					</Stack>
+				</CollapsibleCard.Header>
+				<CollapsibleCard.Content>
+					<LocalBusinessSection form={ form } />
 				</CollapsibleCard.Content>
 			</CollapsibleCard.Root>
 		</Stack>

--- a/projects/packages/seo/_inc/screens/settings/schema-settings/local-business-fields.tsx
+++ b/projects/packages/seo/_inc/screens/settings/schema-settings/local-business-fields.tsx
@@ -3,6 +3,7 @@
 import { TextControl } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Stack } from '@wordpress/ui';
+import clsx from 'clsx';
 import type {
 	LocalBusinessAddress,
 	LocalBusinessSettings,
@@ -187,16 +188,18 @@ const LocalBusinessFields: FC< Props > = ( { form } ) => {
 			{ ADDRESS_FIELD_ROWS.map( fields => (
 				<div
 					key={ fields[ 0 ].field }
-					className={ fields.length > 1 ? 'jetpack-seo-settings__schema-paired-fields' : undefined }
+					className={ clsx( {
+						'jetpack-seo-settings__schema-paired-fields': fields.length > 1,
+					} ) }
 				>
 					{ fields.map( ( { field, label, help } ) => {
 						const fieldError = field === 'addressCountry' && ! isCountryCode( address[ field ] );
 						return (
 							<div
 								key={ field }
-								className={ `jetpack-seo-settings__schema-paired-field${
-									fieldError ? ' jetpack-seo-settings__schema-field--error' : ''
-								}` }
+								className={ clsx( 'jetpack-seo-settings__schema-paired-field', {
+									'jetpack-seo-settings__schema-field--error': fieldError,
+								} ) }
 							>
 								<TextControl
 									label={ label }
@@ -219,11 +222,9 @@ const LocalBusinessFields: FC< Props > = ( { form } ) => {
 
 			<div className="jetpack-seo-settings__schema-paired-fields">
 				<div
-					className={ `jetpack-seo-settings__schema-paired-field${
-						! isPhoneNumber( localBusiness.telephone )
-							? ' jetpack-seo-settings__schema-field--error'
-							: ''
-					}` }
+					className={ clsx( 'jetpack-seo-settings__schema-paired-field', {
+						'jetpack-seo-settings__schema-field--error': ! isPhoneNumber( localBusiness.telephone ),
+					} ) }
 				>
 					<TextControl
 						label={ __( 'Phone', 'jetpack-seo' ) }
@@ -243,11 +244,9 @@ const LocalBusinessFields: FC< Props > = ( { form } ) => {
 				</div>
 
 				<div
-					className={ `jetpack-seo-settings__schema-paired-field${
-						! isPriceRange( localBusiness.priceRange )
-							? ' jetpack-seo-settings__schema-field--error'
-							: ''
-					}` }
+					className={ clsx( 'jetpack-seo-settings__schema-paired-field', {
+						'jetpack-seo-settings__schema-field--error': ! isPriceRange( localBusiness.priceRange ),
+					} ) }
 				>
 					<TextControl
 						label={ __( 'Price range', 'jetpack-seo' ) }

--- a/projects/packages/seo/_inc/screens/settings/schema-settings/local-business-fields.tsx
+++ b/projects/packages/seo/_inc/screens/settings/schema-settings/local-business-fields.tsx
@@ -21,18 +21,23 @@ const OPENING_DAYS: Array< { code: OpeningHoursDay; label: string } > = [
 	{ code: 'Su', label: __( 'Sunday', 'jetpack-seo' ) },
 ];
 
-const ADDRESS_FIELDS: Array< { field: keyof LocalBusinessAddress; label: string; help?: string } > =
+const ADDRESS_FIELD_ROWS: Array<
+	Array< { field: keyof LocalBusinessAddress; label: string; help?: string } >
+> = [
+	[ { field: 'streetAddress', label: __( 'Street address', 'jetpack-seo' ) } ],
 	[
-		{ field: 'streetAddress', label: __( 'Street address', 'jetpack-seo' ) },
 		{ field: 'addressLocality', label: __( 'City', 'jetpack-seo' ) },
 		{ field: 'addressRegion', label: __( 'State/Region', 'jetpack-seo' ) },
+	],
+	[
 		{ field: 'postalCode', label: __( 'Postal code', 'jetpack-seo' ) },
 		{
 			field: 'addressCountry',
 			label: __( 'Country', 'jetpack-seo' ),
 			help: __( 'Two-letter country code (for example US).', 'jetpack-seo' ),
 		},
-	];
+	],
+];
 
 const GEO_FIELDS: Array< {
 	field: keyof LocalBusinessSettings[ 'geo' ];
@@ -179,79 +184,90 @@ const LocalBusinessFields: FC< Props > = ( { form } ) => {
 				</span>
 			) }
 
-			{ ADDRESS_FIELDS.map( ( { field, label, help } ) => {
-				const fieldError = field === 'addressCountry' && ! isCountryCode( address[ field ] );
-				return (
-					<div
-						key={ field }
-						className={ fieldError ? 'jetpack-seo-settings__schema-field--error' : undefined }
-					>
-						<TextControl
-							label={ label }
-							help={ fieldError ? COUNTRY_CODE_ERROR : help }
-							placeholder={ localBusinessDefaults.address[ field ] }
-							value={ address[ field ] }
-							onChange={ next =>
-								setAddress( field, field === 'addressCountry' ? uppercaseAscii( next ) : next )
-							}
-							disabled={ isSaving }
-							aria-invalid={ Boolean( fieldError ) }
-							__next40pxDefaultSize
-							__nextHasNoMarginBottom
-						/>
-					</div>
-				);
-			} ) }
+			{ ADDRESS_FIELD_ROWS.map( fields => (
+				<div
+					key={ fields[ 0 ].field }
+					className={ fields.length > 1 ? 'jetpack-seo-settings__schema-paired-fields' : undefined }
+				>
+					{ fields.map( ( { field, label, help } ) => {
+						const fieldError = field === 'addressCountry' && ! isCountryCode( address[ field ] );
+						return (
+							<div
+								key={ field }
+								className={ `jetpack-seo-settings__schema-paired-field${
+									fieldError ? ' jetpack-seo-settings__schema-field--error' : ''
+								}` }
+							>
+								<TextControl
+									label={ label }
+									help={ fieldError ? COUNTRY_CODE_ERROR : help }
+									placeholder={ localBusinessDefaults.address[ field ] }
+									value={ address[ field ] }
+									onChange={ next =>
+										setAddress( field, field === 'addressCountry' ? uppercaseAscii( next ) : next )
+									}
+									disabled={ isSaving }
+									aria-invalid={ Boolean( fieldError ) }
+									__next40pxDefaultSize
+									__nextHasNoMarginBottom
+								/>
+							</div>
+						);
+					} ) }
+				</div>
+			) ) }
 
-			<div
-				className={
-					! isPhoneNumber( localBusiness.telephone )
-						? 'jetpack-seo-settings__schema-field--error'
-						: undefined
-				}
-			>
-				<TextControl
-					label={ __( 'Phone', 'jetpack-seo' ) }
-					type="tel"
-					help={
+			<div className="jetpack-seo-settings__schema-paired-fields">
+				<div
+					className={ `jetpack-seo-settings__schema-paired-field${
 						! isPhoneNumber( localBusiness.telephone )
-							? PHONE_ERROR
-							: __( 'Include the country and area codes when possible.', 'jetpack-seo' )
-					}
-					value={ localBusiness.telephone }
-					onChange={ next => setLocalBusinessField( { telephone: next } ) }
-					disabled={ isSaving }
-					aria-invalid={ ! isPhoneNumber( localBusiness.telephone ) }
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-				/>
-			</div>
+							? ' jetpack-seo-settings__schema-field--error'
+							: ''
+					}` }
+				>
+					<TextControl
+						label={ __( 'Phone', 'jetpack-seo' ) }
+						type="tel"
+						help={
+							! isPhoneNumber( localBusiness.telephone )
+								? PHONE_ERROR
+								: __( 'Include the country and area codes when possible.', 'jetpack-seo' )
+						}
+						value={ localBusiness.telephone }
+						onChange={ next => setLocalBusinessField( { telephone: next } ) }
+						disabled={ isSaving }
+						aria-invalid={ ! isPhoneNumber( localBusiness.telephone ) }
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+				</div>
 
-			<div
-				className={
-					! isPriceRange( localBusiness.priceRange )
-						? 'jetpack-seo-settings__schema-field--error'
-						: undefined
-				}
-			>
-				<TextControl
-					label={ __( 'Price range', 'jetpack-seo' ) }
-					placeholder="$$"
-					help={
+				<div
+					className={ `jetpack-seo-settings__schema-paired-field${
 						! isPriceRange( localBusiness.priceRange )
-							? PRICE_RANGE_ERROR
-							: __(
-									'Use a numerical range (for example $10–$20) or a relative price level (for example $$).',
-									'jetpack-seo'
-							  )
-					}
-					value={ localBusiness.priceRange }
-					onChange={ next => setLocalBusinessField( { priceRange: next } ) }
-					disabled={ isSaving }
-					aria-invalid={ ! isPriceRange( localBusiness.priceRange ) }
-					__next40pxDefaultSize
-					__nextHasNoMarginBottom
-				/>
+							? ' jetpack-seo-settings__schema-field--error'
+							: ''
+					}` }
+				>
+					<TextControl
+						label={ __( 'Price range', 'jetpack-seo' ) }
+						placeholder="$$"
+						help={
+							! isPriceRange( localBusiness.priceRange )
+								? PRICE_RANGE_ERROR
+								: __(
+										'Use a numerical range (for example $10–$20) or a relative price level (for example $$).',
+										'jetpack-seo'
+								  )
+						}
+						value={ localBusiness.priceRange }
+						onChange={ next => setLocalBusinessField( { priceRange: next } ) }
+						disabled={ isSaving }
+						aria-invalid={ ! isPriceRange( localBusiness.priceRange ) }
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+					/>
+				</div>
 			</div>
 
 			<div className="jetpack-seo-settings__schema-paired-fields">

--- a/projects/packages/seo/_inc/screens/settings/schema-settings/local-business-section.tsx
+++ b/projects/packages/seo/_inc/screens/settings/schema-settings/local-business-section.tsx
@@ -1,0 +1,66 @@
+/* eslint-disable react/jsx-no-bind */
+
+import { ToggleControl } from '@wordpress/components';
+import { __ } from '@wordpress/i18n';
+import { Button, Stack } from '@wordpress/ui';
+import LocalBusinessFields, { hasLocalBusinessErrors } from './local-business-fields';
+import type { SchemaSettingsForm } from '../../../data/use-schema-settings';
+import type { FC } from 'react';
+
+const saveLabel = __( 'Save', 'jetpack-seo' );
+
+interface Props {
+	/** The schema-settings form controller, owned by the Schema card group. */
+	form: SchemaSettingsForm;
+}
+
+/**
+ * The Local business settings form.
+ *
+ * @param props      - Component props.
+ * @param props.form - The shared schema-settings form controller.
+ * @return The Local business settings form.
+ */
+const LocalBusinessSection: FC< Props > = ( { form } ) => {
+	const {
+		localBusiness,
+		isSaving,
+		isLocalBusinessDirty,
+		setLocalBusinessField,
+		saveLocalBusiness,
+	} = form;
+
+	return (
+		<Stack direction="column" gap="lg">
+			<ToggleControl
+				label={ __( 'This site represents a local business', 'jetpack-seo' ) }
+				help={ __(
+					"Adds your business details (address, phone, hours) to the site's schema so search engines can show local info.",
+					'jetpack-seo'
+				) }
+				checked={ localBusiness.enabled }
+				onChange={ next => setLocalBusinessField( { enabled: next } ) }
+				disabled={ isSaving }
+				__nextHasNoMarginBottom
+			/>
+
+			{ localBusiness.enabled && <LocalBusinessFields form={ form } /> }
+
+			<div className="jetpack-seo-settings__save">
+				<Button
+					onClick={ saveLocalBusiness }
+					disabled={
+						isSaving ||
+						! isLocalBusinessDirty ||
+						( localBusiness.enabled && hasLocalBusinessErrors( form ) )
+					}
+					aria-label={ __( 'Save local business', 'jetpack-seo' ) }
+				>
+					{ saveLabel }
+				</Button>
+			</div>
+		</Stack>
+	);
+};
+
+export default LocalBusinessSection;

--- a/projects/packages/seo/_inc/screens/settings/schema-settings/organization-section.tsx
+++ b/projects/packages/seo/_inc/screens/settings/schema-settings/organization-section.tsx
@@ -1,9 +1,8 @@
 /* eslint-disable react/jsx-no-bind */
 
-import { TextControl, TextareaControl, ToggleControl } from '@wordpress/components';
+import { TextControl, TextareaControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Button, Stack } from '@wordpress/ui';
-import LocalBusinessFields, { hasLocalBusinessErrors } from './local-business-fields';
 import ProfileUrlList, { hasProfileUrlErrors } from './profile-url-list';
 import type { SchemaSettingsForm } from '../../../data/use-schema-settings';
 import type { FC } from 'react';
@@ -11,38 +10,34 @@ import type { FC } from 'react';
 const saveLabel = __( 'Save', 'jetpack-seo' );
 
 interface Props {
-	/** The schema-settings form controller, owned by the Schema card. */
+	/** The schema-settings form controller, owned by the Schema card group. */
 	form: SchemaSettingsForm;
 }
 
 /**
- * The shared site-level Schema form. Edits Organization and LocalBusiness
- * settings through the package's own REST route (never `/jetpack/v4/settings`).
- *
- * Presentational: the Schema card owns the {@link useSchemaSettings} controller
- * (so the header badge and this form share one state) and passes it in via `form`.
+ * The Organization settings form.
  *
  * @param props      - Component props.
- * @param props.form - The schema-settings form controller from the card.
+ * @param props.form - The shared schema-settings form controller.
  * @return The Organization settings form.
  */
-const OrganizationBusinessSection: FC< Props > = ( { form } ) => {
+const OrganizationSection: FC< Props > = ( { form } ) => {
 	const {
 		organization,
 		defaults,
-		localBusiness,
 		isSaving,
-		isDirty,
+		isOrganizationDirty,
 		setOrganizationField,
-		setLocalBusinessField,
-		save,
+		saveOrganization,
 	} = form;
 	const { name, description, sameAs, email } = organization;
-	const hasProfileErrors = hasProfileUrlErrors( sameAs );
-	const hasErrors = hasProfileErrors || ( localBusiness.enabled && hasLocalBusinessErrors( form ) );
 
 	return (
 		<Stack direction="column" gap="lg">
+			<span className="jetpack-seo-settings__title-tokens-label">
+				{ __( 'Help search engines understand the organization behind this site.', 'jetpack-seo' ) }
+			</span>
+
 			<TextControl
 				label={ __( 'Organization name', 'jetpack-seo' ) }
 				help={ __(
@@ -93,22 +88,12 @@ const OrganizationBusinessSection: FC< Props > = ( { form } ) => {
 				__nextHasNoMarginBottom
 			/>
 
-			<ToggleControl
-				label={ __( 'This site represents a local business', 'jetpack-seo' ) }
-				help={ __(
-					"Adds your business details (address, phone, hours) to the site's schema so search engines can show local info.",
-					'jetpack-seo'
-				) }
-				checked={ localBusiness.enabled }
-				onChange={ next => setLocalBusinessField( { enabled: next } ) }
-				disabled={ isSaving }
-				__nextHasNoMarginBottom
-			/>
-
-			{ localBusiness.enabled && <LocalBusinessFields form={ form } /> }
-
 			<div className="jetpack-seo-settings__save">
-				<Button onClick={ save } disabled={ isSaving || ! isDirty || hasErrors }>
+				<Button
+					onClick={ saveOrganization }
+					disabled={ isSaving || ! isOrganizationDirty || hasProfileUrlErrors( sameAs ) }
+					aria-label={ __( 'Save organization', 'jetpack-seo' ) }
+				>
 					{ saveLabel }
 				</Button>
 			</div>
@@ -116,4 +101,4 @@ const OrganizationBusinessSection: FC< Props > = ( { form } ) => {
 	);
 };
 
-export default OrganizationBusinessSection;
+export default OrganizationSection;

--- a/projects/packages/seo/_inc/screens/settings/test/schema-card.test.tsx
+++ b/projects/packages/seo/_inc/screens/settings/test/schema-card.test.tsx
@@ -108,9 +108,7 @@ describe( 'SchemaCard', () => {
 		mockForm = makeForm( { breadcrumbList: { enabled: false } } );
 		renderCard();
 
-		expect( screen.getByRole( 'button', { name: /Breadcrumbs/ } ) ).toHaveTextContent(
-			'Disabled'
-		);
+		expect( screen.getByRole( 'button', { name: /Breadcrumbs/ } ) ).toHaveTextContent( 'Disabled' );
 		expect( screen.getByText( '2 of 4 set' ) ).toBeInTheDocument();
 		expandBreadcrumbs();
 		expect(

--- a/projects/packages/seo/_inc/screens/settings/test/schema-card.test.tsx
+++ b/projects/packages/seo/_inc/screens/settings/test/schema-card.test.tsx
@@ -15,7 +15,8 @@ import type { SchemaSettingsForm } from '../../../data/use-schema-settings';
 const setOrganizationField = jest.fn();
 const commitBreadcrumbList = jest.fn();
 const setLocalBusinessField = jest.fn();
-const save = jest.fn();
+const saveOrganization = jest.fn();
+const saveLocalBusiness = jest.fn();
 
 // Resettable per test so each can vary the configured state the header badge reflects.
 let mockForm: SchemaSettingsForm;
@@ -28,11 +29,13 @@ const makeForm = ( overrides: Partial< SchemaSettingsForm > = {} ): SchemaSettin
 	localBusiness: EMPTY_LOCAL_BUSINESS,
 	localBusinessDefaults: EMPTY_LOCAL_BUSINESS_DEFAULTS,
 	isSaving: false,
-	isDirty: false,
+	isOrganizationDirty: false,
+	isLocalBusinessDirty: false,
 	commitBreadcrumbList,
 	setOrganizationField,
 	setLocalBusinessField,
-	save,
+	saveOrganization,
+	saveLocalBusiness,
 	...overrides,
 } );
 
@@ -47,9 +50,13 @@ const bootstrap: SchemaSettings = makeSchemaSettings();
 
 const renderCard = () => render( <SchemaCard initialSettings={ bootstrap } /> );
 
-const expandSchema = () =>
+const expandOrganization = () =>
 	// eslint-disable-next-line testing-library/prefer-user-event -- single click; fireEvent avoids the user-event devDep (lockfile churn).
-	fireEvent.click( screen.getByRole( 'button', { name: /Schema/ } ) );
+	fireEvent.click( screen.getByRole( 'button', { name: /Organization/ } ) );
+
+const expandLocalBusiness = () =>
+	// eslint-disable-next-line testing-library/prefer-user-event -- single click; see note above.
+	fireEvent.click( screen.getByRole( 'button', { name: /Local business/ } ) );
 
 const expandBreadcrumbs = () =>
 	// eslint-disable-next-line testing-library/prefer-user-event -- single click; see note above.
@@ -61,22 +68,17 @@ describe( 'SchemaCard', () => {
 		mockForm = makeForm();
 	} );
 
-	it( 'renders the Breadcrumbs and Schema sections collapsed by default', () => {
+	it( 'renders all three schema sections collapsed by default', () => {
 		renderCard();
 
-		expect( screen.getByRole( 'button', { name: /Breadcrumbs/ } ) ).toHaveAttribute(
-			'aria-expanded',
-			'false'
-		);
-		expect( screen.getByRole( 'button', { name: /Schema/ } ) ).toHaveAttribute(
-			'aria-expanded',
-			'false'
-		);
+		for ( const name of [ /Breadcrumbs/, /Organization/, /Local business/ ] ) {
+			expect( screen.getByRole( 'button', { name } ) ).toHaveAttribute( 'aria-expanded', 'false' );
+		}
 	} );
 
 	it( 'renders the Organization form with the Site Title as the name placeholder', () => {
 		renderCard();
-		expandSchema();
+		expandOrganization();
 
 		// With no stored override the field is empty and shows the Site Title as a
 		// placeholder, so an empty save keeps tracking the Site Title (no drift).
@@ -102,11 +104,13 @@ describe( 'SchemaCard', () => {
 		expect( commitBreadcrumbList ).toHaveBeenCalledWith( { enabled: false } );
 	} );
 
-	it( 'renders an explicitly disabled Breadcrumbs card without changing the Schema badge', () => {
+	it( 'renders an explicitly disabled Breadcrumbs card without changing the Organization badge', () => {
 		mockForm = makeForm( { breadcrumbList: { enabled: false } } );
 		renderCard();
 
-		expect( screen.getByText( 'Disabled' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: /Breadcrumbs/ } ) ).toHaveTextContent(
+			'Disabled'
+		);
 		expect( screen.getByText( '2 of 4 set' ) ).toBeInTheDocument();
 		expandBreadcrumbs();
 		expect(
@@ -116,7 +120,7 @@ describe( 'SchemaCard', () => {
 
 	it( 'adds a social-profile row through the hook', () => {
 		renderCard();
-		expandSchema();
+		expandOrganization();
 		// eslint-disable-next-line testing-library/prefer-user-event -- single click; see note above.
 		fireEvent.click( screen.getByRole( 'button', { name: /Add profile/ } ) );
 
@@ -125,7 +129,7 @@ describe( 'SchemaCard', () => {
 
 	it( 'hides LocalBusiness fields until the toggle is enabled', () => {
 		const view = renderCard();
-		expandSchema();
+		expandLocalBusiness();
 
 		expect( screen.queryByRole( 'textbox', { name: /Street address/ } ) ).not.toBeInTheDocument();
 
@@ -134,7 +138,7 @@ describe( 'SchemaCard', () => {
 			localBusiness: { ...mockForm.localBusiness, enabled: true },
 		} );
 		renderCard();
-		expandSchema();
+		expandLocalBusiness();
 
 		expect( screen.getByRole( 'textbox', { name: /Street address/ } ) ).toBeInTheDocument();
 		expect( screen.getByText( /Google requires it/ ) ).toBeInTheDocument();
@@ -142,7 +146,7 @@ describe( 'SchemaCard', () => {
 
 	it( 'updates the LocalBusiness toggle through the hook', () => {
 		renderCard();
-		expandSchema();
+		expandLocalBusiness();
 
 		// eslint-disable-next-line testing-library/prefer-user-event -- single click; see note above.
 		fireEvent.click( screen.getByRole( 'checkbox', { name: /local business/ } ) );
@@ -150,9 +154,62 @@ describe( 'SchemaCard', () => {
 		expect( setLocalBusinessField ).toHaveBeenCalledWith( { enabled: true } );
 	} );
 
+	it( 'saves Organization and Local business independently', () => {
+		mockForm = makeForm( {
+			isOrganizationDirty: true,
+			isLocalBusinessDirty: true,
+		} );
+		renderCard();
+		expandOrganization();
+		expandLocalBusiness();
+
+		// eslint-disable-next-line testing-library/prefer-user-event -- single click; fireEvent avoids lockfile churn.
+		fireEvent.click( screen.getByRole( 'button', { name: 'Save organization' } ) );
+		// eslint-disable-next-line testing-library/prefer-user-event -- single click; see note above.
+		fireEvent.click( screen.getByRole( 'button', { name: 'Save local business' } ) );
+
+		expect( saveOrganization ).toHaveBeenCalledTimes( 1 );
+		expect( saveLocalBusiness ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'pairs the compact Local business fields without pairing Street address', () => {
+		mockForm = makeForm( {
+			localBusiness: { ...mockForm.localBusiness, enabled: true },
+		} );
+		renderCard();
+		expandLocalBusiness();
+
+		const expectPair = ( first: HTMLElement, second: HTMLElement ) => {
+			// eslint-disable-next-line testing-library/no-node-access -- the wrapper is the layout contract under test.
+			const pair = first.closest( '.jetpack-seo-settings__schema-paired-fields' );
+			expect( pair ).not.toBeNull();
+			expect( pair ).toContainElement( second );
+		};
+		const streetAddress = screen.getByRole( 'textbox', { name: 'Street address' } );
+		// eslint-disable-next-line testing-library/no-node-access -- the absence of a paired wrapper is the layout contract.
+		expect( streetAddress.closest( '.jetpack-seo-settings__schema-paired-fields' ) ).toBeNull();
+		expectPair(
+			screen.getByRole( 'textbox', { name: 'City' } ),
+			screen.getByRole( 'textbox', { name: 'State/Region' } )
+		);
+		expectPair(
+			screen.getByRole( 'textbox', { name: 'Postal code' } ),
+			screen.getByRole( 'textbox', { name: 'Country' } )
+		);
+		expectPair(
+			screen.getByRole( 'textbox', { name: 'Phone' } ),
+			screen.getByRole( 'textbox', { name: 'Price range' } )
+		);
+		expectPair(
+			screen.getByRole( 'textbox', { name: 'Latitude' } ),
+			screen.getByRole( 'textbox', { name: 'Longitude' } )
+		);
+		expectPair( screen.getByLabelText( 'Monday opens' ), screen.getByLabelText( 'Monday closes' ) );
+	} );
+
 	it( 'disables saving when only one geo coordinate is filled', () => {
 		mockForm = makeForm( {
-			isDirty: true,
+			isLocalBusinessDirty: true,
 			localBusiness: {
 				...mockForm.localBusiness,
 				enabled: true,
@@ -160,7 +217,7 @@ describe( 'SchemaCard', () => {
 			},
 		} );
 		renderCard();
-		expandSchema();
+		expandLocalBusiness();
 
 		const error = screen.getByText( 'Enter both latitude and longitude, or leave both blank.' );
 		expect( error ).toHaveClass( 'jetpack-seo-settings__schema-pair-error' );
@@ -172,7 +229,7 @@ describe( 'SchemaCard', () => {
 			'aria-describedby',
 			error.id
 		);
-		expect( screen.getByRole( 'button', { name: /^Save$/ } ) ).toHaveAttribute(
+		expect( screen.getByRole( 'button', { name: 'Save local business' } ) ).toHaveAttribute(
 			'aria-disabled',
 			'true'
 		);
@@ -180,7 +237,7 @@ describe( 'SchemaCard', () => {
 
 	it( 'disables saving and marks invalid LocalBusiness text fields', () => {
 		mockForm = makeForm( {
-			isDirty: true,
+			isLocalBusinessDirty: true,
 			localBusiness: {
 				...mockForm.localBusiness,
 				enabled: true,
@@ -190,7 +247,7 @@ describe( 'SchemaCard', () => {
 			},
 		} );
 		renderCard();
-		expandSchema();
+		expandLocalBusiness();
 
 		expect( screen.getByRole( 'textbox', { name: 'Country' } ) ).toHaveAttribute(
 			'aria-invalid',
@@ -205,7 +262,7 @@ describe( 'SchemaCard', () => {
 			'true'
 		);
 		expect( screen.getByText( 'Enter fewer than 100 characters.' ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: /^Save$/ } ) ).toHaveAttribute(
+		expect( screen.getByRole( 'button', { name: 'Save local business' } ) ).toHaveAttribute(
 			'aria-disabled',
 			'true'
 		);
@@ -216,7 +273,7 @@ describe( 'SchemaCard', () => {
 			localBusiness: { ...mockForm.localBusiness, enabled: true },
 		} );
 		renderCard();
-		expandSchema();
+		expandLocalBusiness();
 
 		// eslint-disable-next-line testing-library/prefer-user-event -- single controlled change; see note above.
 		fireEvent.change( screen.getByRole( 'textbox', { name: 'Country' } ), {
@@ -240,7 +297,7 @@ describe( 'SchemaCard', () => {
 		[ { opens: '', closes: '17:00' }, 'Monday opens' ],
 	] )( 'disables saving when an opening-hours pair is incomplete', ( monday, missingField ) => {
 		mockForm = makeForm( {
-			isDirty: true,
+			isLocalBusinessDirty: true,
 			localBusiness: {
 				...mockForm.localBusiness,
 				enabled: true,
@@ -248,7 +305,7 @@ describe( 'SchemaCard', () => {
 			},
 		} );
 		renderCard();
-		expandSchema();
+		expandLocalBusiness();
 
 		expect( screen.getByLabelText( missingField ) ).toHaveAttribute( 'aria-invalid', 'true' );
 		const error = screen.getByText( 'Enter both opening and closing times, or leave both blank.' );
@@ -261,7 +318,7 @@ describe( 'SchemaCard', () => {
 			'aria-describedby',
 			error.id
 		);
-		expect( screen.getByRole( 'button', { name: /^Save$/ } ) ).toHaveAttribute(
+		expect( screen.getByRole( 'button', { name: 'Save local business' } ) ).toHaveAttribute(
 			'aria-disabled',
 			'true'
 		);
@@ -269,7 +326,7 @@ describe( 'SchemaCard', () => {
 
 	it( 'allows valid international details and overnight hours', () => {
 		mockForm = makeForm( {
-			isDirty: true,
+			isLocalBusinessDirty: true,
 			localBusiness: {
 				...mockForm.localBusiness,
 				enabled: true,
@@ -283,10 +340,10 @@ describe( 'SchemaCard', () => {
 			},
 		} );
 		renderCard();
-		expandSchema();
+		expandLocalBusiness();
 
 		expect( screen.getByText( /closing time earlier than opening/ ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: /^Save$/ } ) ).not.toHaveAttribute(
+		expect( screen.getByRole( 'button', { name: 'Save local business' } ) ).not.toHaveAttribute(
 			'aria-disabled',
 			'true'
 		);
@@ -297,7 +354,7 @@ describe( 'SchemaCard', () => {
 			localBusiness: { ...mockForm.localBusiness, enabled: true },
 		} );
 		renderCard();
-		expandSchema();
+		expandLocalBusiness();
 
 		const input = screen.getByLabelText( 'Monday opens' ) as HTMLInputElement;
 		input.value = '09:00';
@@ -318,16 +375,60 @@ describe( 'SchemaCard', () => {
 
 	it( 'disables saving when a social profile URL is invalid', () => {
 		mockForm = makeForm( {
-			isDirty: true,
+			isOrganizationDirty: true,
 			organization: { name: '', description: '', sameAs: [ 'not a url' ], email: '' },
 		} );
 		renderCard();
-		expandSchema();
+		expandOrganization();
 
 		expect(
 			screen.getByText( 'Enter a valid URL that starts with http:// or https://.' )
 		).toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: /^Save$/ } ) ).toHaveAttribute(
+		expect( screen.getByRole( 'button', { name: 'Save organization' } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+	} );
+
+	it( 'keeps Local business saving enabled when Organization URLs are invalid', () => {
+		mockForm = makeForm( {
+			isOrganizationDirty: true,
+			isLocalBusinessDirty: true,
+			organization: { name: '', description: '', sameAs: [ 'not a url' ], email: '' },
+		} );
+		renderCard();
+		expandOrganization();
+		expandLocalBusiness();
+
+		expect( screen.getByRole( 'button', { name: 'Save organization' } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+		expect( screen.getByRole( 'button', { name: 'Save local business' } ) ).not.toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+	} );
+
+	it( 'keeps Organization saving enabled when Local business values are invalid', () => {
+		mockForm = makeForm( {
+			isOrganizationDirty: true,
+			isLocalBusinessDirty: true,
+			localBusiness: {
+				...mockForm.localBusiness,
+				enabled: true,
+				geo: { latitude: '40.7128', longitude: '' },
+			},
+		} );
+		renderCard();
+		expandOrganization();
+		expandLocalBusiness();
+
+		expect( screen.getByRole( 'button', { name: 'Save organization' } ) ).not.toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+		expect( screen.getByRole( 'button', { name: 'Save local business' } ) ).toHaveAttribute(
 			'aria-disabled',
 			'true'
 		);
@@ -335,7 +436,7 @@ describe( 'SchemaCard', () => {
 
 	it( 'allows full social profile URLs', () => {
 		mockForm = makeForm( {
-			isDirty: true,
+			isOrganizationDirty: true,
 			organization: {
 				name: '',
 				description: '',
@@ -344,12 +445,12 @@ describe( 'SchemaCard', () => {
 			},
 		} );
 		renderCard();
-		expandSchema();
+		expandOrganization();
 
 		expect(
 			screen.queryByText( 'Enter a valid URL that starts with http:// or https://.' )
 		).not.toBeInTheDocument();
-		expect( screen.getByRole( 'button', { name: /^Save$/ } ) ).not.toHaveAttribute(
+		expect( screen.getByRole( 'button', { name: 'Save organization' } ) ).not.toHaveAttribute(
 			'aria-disabled',
 			'true'
 		);
@@ -357,7 +458,7 @@ describe( 'SchemaCard', () => {
 
 	it( 'disables saving when social profile URLs are duplicated', () => {
 		mockForm = makeForm( {
-			isDirty: true,
+			isOrganizationDirty: true,
 			organization: {
 				name: '',
 				description: '',
@@ -369,10 +470,10 @@ describe( 'SchemaCard', () => {
 			},
 		} );
 		renderCard();
-		expandSchema();
+		expandOrganization();
 
 		expect( screen.getAllByText( 'This profile URL is already listed.' ) ).toHaveLength( 1 );
-		expect( screen.getByRole( 'button', { name: /^Save$/ } ) ).toHaveAttribute(
+		expect( screen.getByRole( 'button', { name: 'Save organization' } ) ).toHaveAttribute(
 			'aria-disabled',
 			'true'
 		);
@@ -394,14 +495,11 @@ describe( 'SchemaCard', () => {
 		expect( screen.getByText( '3 of 4 set' ) ).toBeInTheDocument();
 	} );
 
-	it( 'counts LocalBusiness address as a fifth badge item only when enabled', () => {
-		mockForm = makeForm( {
-			localBusiness: {
-				...mockForm.localBusiness,
-				address: { ...mockForm.localBusiness.address, streetAddress: '123 Main St' },
-			},
-		} );
+	it( 'shows Local business status without changing the four-field Organization count', () => {
 		const view = renderCard();
+		expect( screen.getByRole( 'button', { name: /Local business/ } ) ).toHaveTextContent(
+			'Disabled'
+		);
 		expect( screen.getByText( '2 of 4 set' ) ).toBeInTheDocument();
 
 		view.unmount();
@@ -409,11 +507,13 @@ describe( 'SchemaCard', () => {
 			localBusiness: {
 				...mockForm.localBusiness,
 				enabled: true,
-				address: { ...mockForm.localBusiness.address, streetAddress: '123 Main St' },
 			},
 		} );
 		renderCard();
-		expect( screen.getByText( '3 of 5 set' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: /Local business/ } ) ).toHaveTextContent(
+			'Enabled'
+		);
+		expect( screen.getByText( '2 of 4 set' ) ).toBeInTheDocument();
 	} );
 
 	it( 'shows "Not set" when nothing is configured (no site identity either)', () => {

--- a/projects/packages/seo/changelog/refactor-schema-card
+++ b/projects/packages/seo/changelog/refactor-schema-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Improve the organization and local business schema settings layout.


### PR DESCRIPTION
Fixes #

## Proposed changes

* Split Schema settings into separate Organization and Local business cards.
* Save each section independently and pair compact Local business fields.

## Related product discussion/links

* None.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open Jetpack → SEO → Settings and confirm the card order: Breadcrumbs, Organization, Local business, Author profile.

<img width="1400" height="764" alt="CleanShot 2026-07-15 at 15 50 07@2x" src="https://github.com/user-attachments/assets/f820f501-6468-4809-8d57-2c1b1498ac73" />

* Confirm each card opens independently; enable Local business and check the paired field layout.

<img width="1374" height="2286" alt="CleanShot 2026-07-15 at 15 50 35@2x" src="https://github.com/user-attachments/assets/141a7089-1792-4017-94ac-0288dd913308" />

* Edit both Organization and Local business, save one, and confirm the other remains unsaved.
* Automated checks: `jp test js packages/seo`, `jp test php packages/seo`, and `jp phan packages/seo`.

## Screenshots

_To be added._
