### PR TITLE
Site launch celebration modal: left-align the domain upsell on mobile

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-dsgcom-635-celebrate-launch-upsell-alignment
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-dsgcom-635-celebrate-launch-upsell-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Site launch modal: left-align the domain upsell to match the rest of the modal.

--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-dsgcom-635-celebrate-launch-upsell-alignment
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-dsgcom-635-celebrate-launch-upsell-alignment
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Site launch modal: left-align the domain upsell to match the rest of the modal.
+Site launch modal: left-align the domain upsell on mobile to match the rest of the modal.

--- a/projects/packages/jetpack-mu-wpcom/src/common/celebrate-launch/celebrate-launch-modal.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/common/celebrate-launch/celebrate-launch-modal.scss
@@ -88,11 +88,18 @@
 	background-color: $gray-100;
 	display: flex;
 	flex-direction: column;
-	gap: $grid-unit-20;
+	gap: $grid-unit-15;
+	justify-content: center;
 	margin: $grid-unit-30 -#{$grid-unit-30} -#{$grid-unit-30} -#{$grid-unit-30};
 	padding: $grid-unit-30;
 
 	p {
 		margin: 0;
+	}
+
+	@media (min-width: $break-small) {
+		align-items: center;
+		flex-direction: row;
+		gap: $grid-unit-30;
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/src/common/celebrate-launch/celebrate-launch-modal.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/common/celebrate-launch/celebrate-launch-modal.scss
@@ -84,21 +84,15 @@
 }
 
 .launched__modal-upsell {
-	align-items: center;
+	align-items: flex-start;
 	background-color: $gray-100;
 	display: flex;
 	flex-direction: column;
-	gap: $grid-unit-15;
-	justify-content: center;
+	gap: $grid-unit-20;
 	margin: $grid-unit-30 -#{$grid-unit-30} -#{$grid-unit-30} -#{$grid-unit-30};
 	padding: $grid-unit-30;
 
 	p {
 		margin: 0;
-	}
-
-	@media (min-width: $break-small) {
-		flex-direction: row;
-		gap: $grid-unit-30;
 	}
 }


### PR DESCRIPTION
## Proposed changes

- Update the mobile layout of the wp-admin "Congrats, your site is live!" site launch modal by left-aligning the domain upsell button to the left

This is the wp-admin counterpart to this [Calypso PR](https://github.com/Automattic/wp-calypso/pull/112647), which applies the same layout to the MSD site launch modal.

### Screenshots

| Before | After |
| --- | --- |
| <img width="612" height="882" alt="Screenshot 2026-07-15 at 13 44 21" src="https://github.com/user-attachments/assets/b599494d-628d-4be0-921f-5061f5005f06" /> | <img width="612" height="882" alt="Screenshot 2026-07-15 at 13 44 17" src="https://github.com/user-attachments/assets/419bb1ed-2ad2-44c8-a82f-3523f35ad72a" /> |

## Related product discussion/links

* [DSGCOM-635](https://linear.app/a8c/issue/DSGCOM-635)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Test this both in Simple and WoW. Note that the site must either be a free site or not have a custom domain attached to it.

- Check out this branch into a test site
  * **Simple:** on your sandbox, run `bin/jetpack-downloader test jetpack-mu-wpcom-plugin fix/dsgcom-635-left-align-domain-upsell`
  * **WoA:** enable the `fix/dsgcom-635-left-align-domain-upsell` branch of "WordPress.com Site Helper" via the Jetpack Beta plugin (see the auto-generated comment below).
- Force-show the modal: append `?celebrate-launch` to the wp-admin URL
- Narrow the browser to mobile view and ensure the layout is correct (upsell button is left-aligned)
- Ensure the desktop view is unchanged
