### PR TITLE
Backport 16.0.1 changelog and poll shortcode fix to trunk

### DIFF
--- a/projects/plugins/jetpack/CHANGELOG.md
+++ b/projects/plugins/jetpack/CHANGELOG.md
@@ -32,6 +32,12 @@
 - Update the @react-spring/web dependency to v10 for React 19 compatibility. [#50288]
 - Update WPDS design tokens to the @wordpress/theme 0.16/0.17 names (see https://github.com/WordPress/gutenberg/blob/trunk/packages/theme/CHANGELOG.md#0160-2026-06-24 ). [#49272]
 
+## 16.0.1 - 2026-07-15
+### Bug fixes
+- Fix the Forms and VideoPress admin dashboards rendering a blank "Something went wrong!" error on WordPress 6.9. [#50515]
+- My Jetpack: Fix route changes in Chrome when scroll APIs return promises. [#50465]
+- Poll shortcode: Require HTTPS and an exact script path when loading the poll script.
+
 ## 16.0 - 2026-07-07
 ### Enhancements
 - Add AI-powered "Generate/Improve with Jetpack" buttons to the Content Guidelines admin page. [#47959]

--- a/projects/plugins/jetpack/_inc/polldaddy-shortcode.js
+++ b/projects/plugins/jetpack/_inc/polldaddy-shortcode.js
@@ -27,6 +27,9 @@
 					} catch {
 						return false;
 					}
+					if ( poll_url.protocol !== 'https:' ) {
+						return false;
+					}
 					if (
 						poll_url.hostname !== 'secure.polldaddy.com' &&
 						poll_url.hostname !== 'static.polldaddy.com'
@@ -34,7 +37,7 @@
 						return false;
 					}
 					const pathname = poll_url.pathname;
-					if ( ! /\/?p\/\d+\.js/.test( pathname ) ) {
+					if ( ! /^\/p\/\d+\.js$/.test( pathname ) ) {
 						return false;
 					}
 					const wp_pd_js = d.createElement( 'script' );

--- a/projects/plugins/jetpack/changelog/backport-16-0-1-poll-shortcode
+++ b/projects/plugins/jetpack/changelog/backport-16-0-1-poll-shortcode
@@ -1,0 +1,5 @@
+Significance: patch
+Type: bugfix
+Comment: Poll shortcode script-loading fix shipped in 16.0.1 and recorded in that release's changelog block; no separate 16.1 entry needed.
+
+


### PR DESCRIPTION
Backports the Jetpack 16.0.1 point release to trunk, per the standard point-release cleanup.

## What's included
- **CHANGELOG.md** — adds the shipped `## 16.0.1` release block above `## 16.0`.
- **`_inc/polldaddy-shortcode.js`** — require an HTTPS scheme and an exact script path when loading the poll script.
- **changelog fragment** — a `Comment:`-only fragment (the change is already recorded in the 16.0.1 block and shipped in that release, so no separate 16.1 entry is needed).

## What's NOT included
Per point-release convention, the four-point package releases (wp-build-polyfills 0.2.0.1, my-jetpack 5.40.5.1) are not backported — those changes already exist in the packages' newer trunk versions.

## Definition of done
- [x] `## 16.0.1` block present in `CHANGELOG.md` above `## 16.0`, matching what shipped.
- [x] `polldaddy-shortcode.js` matches the change on `jetpack/branch-16.0.1`.
- [x] `changelogger-validate-all.sh` passes; `git diff --check` clean.
- [x] Reviewed and merged to trunk.

## Does this pull request change what data or activity we track or use?
No

## Testing instructions:
None