### PR TITLE
Podcast: fix malformed distribution feed URL on plain-permalink sites

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-feed-url
+++ b/projects/packages/podcast/changelog/fix-podcast-feed-url
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast: derive the distribution feed URL from WordPress's canonical category-feed API so it stays valid on plain-permalink and no-trailing-slash sites instead of producing a malformed URL.

--- a/projects/packages/podcast/src/class-settings.php
+++ b/projects/packages/podcast/src/class-settings.php
@@ -205,7 +205,37 @@ class Settings {
 			'podcasting_email'       => (string) get_option( 'podcasting_email', '' ),
 			'podcasting_show_urls'   => array_merge( $empty_map, array_intersect_key( $show_urls, $empty_map ) ),
 			'podcasting_show_states' => array_merge( $empty_map, array_intersect_key( $show_states, $empty_map ) ),
+			'podcasting_feed_url'    => self::feed_url(),
 		);
+	}
+
+	/**
+	 * Canonical RSS feed URL for the configured podcast category. Derived
+	 * read-only field on the settings payload — not a stored option.
+	 *
+	 * Built with WordPress's own {@see get_term_feed_link()} so it stays correct
+	 * across every permalink structure (pretty, plain `?cat=N`, no trailing
+	 * slash) and is identical on WPCOM and self-hosted. This is the URL the
+	 * category feed is actually served at — the SPA must not reconstruct it by
+	 * string-appending `feed/` to the archive link.
+	 *
+	 * @return string Feed URL, or '' when no valid category is configured.
+	 */
+	public static function feed_url(): string {
+		$category_id = (int) get_option( 'podcasting_category_id', 0 );
+		if ( $category_id <= 0 ) {
+			return '';
+		}
+		$link = get_term_feed_link( $category_id, 'category' );
+		if ( false === $link ) {
+			return '';
+		}
+		// get_term_feed_link() HTML-escapes the query separator (`&amp;`) in the
+		// plain-permalink form because core builds it for HTML attributes. The
+		// dashboard copies this straight into a directory submission field, so
+		// decode it back to a literal URL — otherwise `?feed=rss2&amp;cat=N` loses
+		// the `cat` filter and serves the whole-site feed instead of the category.
+		return html_entity_decode( $link, ENT_QUOTES );
 	}
 
 	/**

--- a/projects/packages/podcast/src/dashboard/distribution/index.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/index.tsx
@@ -13,7 +13,6 @@ import {
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
 import { useCopyToClipboard } from '@wordpress/compose';
-import { useEntityRecord } from '@wordpress/core-data';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { check, copy } from '@wordpress/icons';
@@ -99,15 +98,11 @@ const DistributionTab = ( { onEditSettings }: DistributionTabProps ) => {
 	const { data: settings } = usePodcastSettings();
 	const { issues, isReady, isLoading } = useValidationIssues();
 	const categoryId = settings?.podcasting_category_id ?? 0;
-	// Pull the configured category record so we can derive the feed URL
-	// (`{category-archive}feed/`) without needing PHP-side script data.
-	const { record: category } = useEntityRecord< { link?: string } >(
-		'taxonomy',
-		'category',
-		categoryId,
-		{ enabled: categoryId > 0 }
-	);
-	const feedUrl = category?.link ? `${ category.link }feed/` : '';
+	// Canonical category feed URL, derived server-side via get_term_feed_link()
+	// so it's correct across every permalink structure. Reconstructing it here by
+	// appending `feed/` to the archive link broke plain-permalink / no-trailing-
+	// slash sites (e.g. `?cat=5feed/`).
+	const feedUrl = settings?.podcasting_feed_url ?? '';
 	const isEnabled = categoryId > 0;
 	// Includes isLoading so the buttons don't flash enabled before issues resolve.
 	const isSubmitBlocked = ! isEnabled || ! isReady || isLoading;

--- a/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
@@ -52,6 +52,7 @@ const PODCAST_KEYS: Array< keyof PodcastSettings > = [
 	'podcasting_email',
 	'podcasting_show_urls',
 	'podcasting_show_states',
+	'podcasting_feed_url',
 ];
 
 // Ids from the injected map, plus the record's own keys, so a missing map never

--- a/projects/packages/podcast/src/dashboard/types.ts
+++ b/projects/packages/podcast/src/dashboard/types.ts
@@ -36,10 +36,7 @@ export interface PodcastSettings {
 // `podcasting_show_urls` is Partial because the server merges patches into the
 // stored map — callers can send `{ apple: 'url' }` without touching siblings.
 export type PodcastSettingsUpdate = Partial<
-	Omit<
-		PodcastSettings,
-		'podcasting_show_urls' | 'podcasting_show_states' | 'podcasting_feed_url'
-	>
+	Omit< PodcastSettings, 'podcasting_show_urls' | 'podcasting_show_states' | 'podcasting_feed_url' >
 > & {
 	podcasting_show_urls?: Partial< PodcastShowUrls >;
 	podcasting_show_states?: Partial< PodcastShowStates >;

--- a/projects/packages/podcast/src/dashboard/types.ts
+++ b/projects/packages/podcast/src/dashboard/types.ts
@@ -28,12 +28,18 @@ export interface PodcastSettings {
 	podcasting_email: string;
 	podcasting_show_urls: PodcastShowUrls;
 	podcasting_show_states: PodcastShowStates;
+	// Read-only: canonical category feed URL derived server-side via
+	// get_term_feed_link(). Never sent back in an update.
+	podcasting_feed_url: string;
 }
 
 // `podcasting_show_urls` is Partial because the server merges patches into the
 // stored map — callers can send `{ apple: 'url' }` without touching siblings.
 export type PodcastSettingsUpdate = Partial<
-	Omit< PodcastSettings, 'podcasting_show_urls' | 'podcasting_show_states' >
+	Omit<
+		PodcastSettings,
+		'podcasting_show_urls' | 'podcasting_show_states' | 'podcasting_feed_url'
+	>
 > & {
 	podcasting_show_urls?: Partial< PodcastShowUrls >;
 	podcasting_show_states?: Partial< PodcastShowStates >;

--- a/projects/packages/podcast/tests/php/Settings_Test.php
+++ b/projects/packages/podcast/tests/php/Settings_Test.php
@@ -259,8 +259,7 @@ class Settings_Test extends BaseTestCase {
 	}
 
 	public function test_feed_url_uses_canonical_category_feed_api() {
-		$term   = wp_insert_term( 'Podcast Cat', 'category' );
-		$cat_id = $term['term_id'];
+		$cat_id = $this->seed_category_term( 7 );
 		update_option( 'podcasting_category_id', $cat_id );
 
 		$feed_url = Settings::feed_url();
@@ -279,7 +278,7 @@ class Settings_Test extends BaseTestCase {
 		$this->assertStringNotContainsString( '&amp;', $feed_url );
 
 		delete_option( 'podcasting_category_id' );
-		wp_delete_term( $cat_id, 'category' );
+		wp_cache_flush();
 	}
 
 	public function test_feed_url_is_empty_without_a_category() {
@@ -294,16 +293,45 @@ class Settings_Test extends BaseTestCase {
 	}
 
 	public function test_get_all_includes_the_derived_feed_url() {
-		$term   = wp_insert_term( 'Feed Cat', 'category' );
-		$cat_id = $term['term_id'];
+		$cat_id = $this->seed_category_term( 8 );
 		update_option( 'podcasting_category_id', $cat_id );
 
 		$all = Settings::get_all();
 
 		$this->assertArrayHasKey( 'podcasting_feed_url', $all );
+		$this->assertNotEmpty( $all['podcasting_feed_url'] );
 		$this->assertSame( Settings::feed_url(), $all['podcasting_feed_url'] );
 
 		delete_option( 'podcasting_category_id' );
-		wp_delete_term( $cat_id, 'category' );
+		wp_cache_flush();
+	}
+
+	/**
+	 * WorDBless doesn't register core taxonomies or hydrate inserted terms
+	 * through get_term(), which get_term_feed_link() relies on. Register
+	 * `category` and seed the `terms` object cache with a fully-formed WP_Term so
+	 * get_term() resolves it — mirrors Customize_Feed_Test's approach.
+	 *
+	 * @param int $id Term ID to seed.
+	 * @return int The same term ID, for convenience.
+	 */
+	private function seed_category_term( int $id ): int {
+		if ( ! taxonomy_exists( 'category' ) ) {
+			register_taxonomy( 'category', 'post', array( 'hierarchical' => true ) );
+		}
+		wp_cache_set(
+			$id,
+			new \WP_Term(
+				(object) array(
+					'term_id'          => $id,
+					'name'             => 'Podcast Cat',
+					'slug'             => 'podcast-cat-' . $id,
+					'taxonomy'         => 'category',
+					'term_taxonomy_id' => $id,
+				)
+			),
+			'terms'
+		);
+		return $id;
 	}
 }

--- a/projects/packages/podcast/tests/php/Settings_Test.php
+++ b/projects/packages/podcast/tests/php/Settings_Test.php
@@ -257,4 +257,53 @@ class Settings_Test extends BaseTestCase {
 
 		$this->assertSame( '', Settings::raw_show_image_url() );
 	}
+
+	public function test_feed_url_uses_canonical_category_feed_api() {
+		$term   = wp_insert_term( 'Podcast Cat', 'category' );
+		$cat_id = $term['term_id'];
+		update_option( 'podcasting_category_id', $cat_id );
+
+		$feed_url = Settings::feed_url();
+
+		// Built from WordPress's own category-feed API, never the malformed
+		// `?cat=Nfeed/` a naive `feed/` concatenation produces on plain/no-
+		// trailing-slash permalinks.
+		$this->assertNotEmpty( $feed_url );
+		$this->assertStringNotContainsString( 'feed/', $feed_url );
+		$this->assertNotFalse( filter_var( $feed_url, FILTER_VALIDATE_URL ) );
+
+		// Entity-decoded so it's a usable copy-paste URL: the raw core value
+		// HTML-escapes the separator to `&amp;` (for HTML attributes), which would
+		// drop the `cat` filter and serve the whole-site feed if pasted as-is.
+		$this->assertSame( html_entity_decode( get_term_feed_link( $cat_id, 'category' ), ENT_QUOTES ), $feed_url );
+		$this->assertStringNotContainsString( '&amp;', $feed_url );
+
+		delete_option( 'podcasting_category_id' );
+		wp_delete_term( $cat_id, 'category' );
+	}
+
+	public function test_feed_url_is_empty_without_a_category() {
+		delete_option( 'podcasting_category_id' );
+
+		$this->assertSame( '', Settings::feed_url() );
+
+		update_option( 'podcasting_category_id', 0 );
+		$this->assertSame( '', Settings::feed_url() );
+
+		delete_option( 'podcasting_category_id' );
+	}
+
+	public function test_get_all_includes_the_derived_feed_url() {
+		$term   = wp_insert_term( 'Feed Cat', 'category' );
+		$cat_id = $term['term_id'];
+		update_option( 'podcasting_category_id', $cat_id );
+
+		$all = Settings::get_all();
+
+		$this->assertArrayHasKey( 'podcasting_feed_url', $all );
+		$this->assertSame( Settings::feed_url(), $all['podcasting_feed_url'] );
+
+		delete_option( 'podcasting_category_id' );
+		wp_delete_term( $cat_id, 'category' );
+	}
 }


### PR DESCRIPTION
## Proposed changes

The Podcast distribution dashboard built the RSS feed URL by string-appending `feed/` to the category archive link (`${category.link}feed/`). That only produces a valid URL when the archive link ends in a trailing slash — i.e. pretty permalinks. On plain-permalink or no-trailing-slash sites the archive link is a query URL, so the result is malformed (e.g. `?cat=5feed/`), and users could copy or submit an invalid feed to podcast directories.

This derives the feed URL server-side from WordPress's own category-feed API instead:

* Add `Settings::feed_url()`, which uses `get_term_feed_link( $category_id, 'category' )` — the same URL the podcast category feed is actually served at — so it's correct across every permalink structure (pretty, plain `?cat=N`, no trailing slash) and identical on WordPress.com and self-hosted.
* Expose it as a read-only `podcasting_feed_url` field on the existing `wpcom/v2/podcast/settings` payload; the SPA reads it instead of reconstructing the URL client-side. Removes the now-unnecessary `useEntityRecord` category fetch.
* Entity-decode the value: `get_term_feed_link()` HTML-escapes the query separator to `&amp;` (it's built for HTML attributes). Pasted verbatim into a directory, `?feed=rss2&amp;cat=N` drops the `cat` filter and serves the whole-site feed instead of the category — so we decode it back to a literal, copy-paste-safe URL.
* Add PHP tests covering the canonical output, the entity-decode, empty-when-no-category, and the field's presence in `get_all()`.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

On a self-hosted / Atomic site with the Podcast dashboard:

1. Settings → Permalinks → set **Plain** (`?p=123`).
2. In the Podcast dashboard, set a podcast category, then open the **Distribution** tab.
3. Confirm the **RSS feed** field shows a valid URL of the form `https://example.com/?feed=rss2&cat=<ID>` — not `?cat=<ID>feed/` and not containing `&amp;`.
4. Open that URL: it should return `application/rss+xml` scoped to the podcast category (only episodes in that category, channel title = category name).
5. Repeat with **Post name** permalinks and confirm the field shows `https://example.com/category/<slug>/feed/` and serves the same category feed.

Verified end-to-end on a Jurassic Ninja site with plain permalinks: the corrected URL returns the correct single-category feed, while the old `?cat=Nfeed/` form returned an HTML page.
