### PR TITLE
VideoPress: show live transcoding and promote-to-VideoPress progress in the library

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5013,6 +5013,9 @@ importers:
       react-router:
         specifier: 7.15.1
         version: 7.15.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      socket.io-client:
+        specifier: 4.8.3
+        version: 4.8.3
       tus-js-client:
         specifier: 4.2.3
         version: 4.2.3
@@ -9904,6 +9907,9 @@ packages:
   '@so-ric/colorspace@1.1.6':
     resolution: {integrity: sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==}
 
+  '@socket.io/component-emitter@3.1.2':
+    resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -13220,6 +13226,13 @@ packages:
 
   encoding@0.1.13:
     resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
+
+  engine.io-client@6.6.6:
+    resolution: {integrity: sha512-iY6QdftLQ9pyiPoX082bpf/u1UewnOaJrtJIF9T0++QB34lZrj0uP+Q/bj8AlUsAxqhnkTV2BS8SBZSxOmoV5Q==}
+
+  engine.io-parser@5.2.3:
+    resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
+    engines: {node: '>=10.0.0'}
 
   enhanced-resolve@5.24.2:
     resolution: {integrity: sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==}
@@ -17173,6 +17186,14 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
+  socket.io-client@4.8.3:
+    resolution: {integrity: sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==}
+    engines: {node: '>=10.0.0'}
+
+  socket.io-parser@4.2.7:
+    resolution: {integrity: sha512-IH/iSeO9T6gz1KkFleGDWkG9N3dl4jXVYUtMhIqH10Md0ttMer8nUNWiP1DKuNrybD2xBrixLJdCC9J6ECoYkg==}
+    engines: {node: '>=10.0.0'}
+
   sockjs@0.3.24:
     resolution: {integrity: sha512-GJgLTZ7vYb/JtPSSZ10hsOYIvEYsjbNU+zPdIHcUaWVNUEPivzxku31865sSSud0Da0W4lEeOPlmw93zLQchuQ==}
 
@@ -18464,6 +18485,10 @@ packages:
 
   xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
+  xmlhttprequest-ssl@2.1.2:
+    resolution: {integrity: sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==}
+    engines: {node: '>=0.4.0'}
 
   y-protocols@1.0.7:
     resolution: {integrity: sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==}
@@ -22051,6 +22076,8 @@ snapshots:
     dependencies:
       color: 5.0.3
       text-hex: 1.0.0
+
+  '@socket.io/component-emitter@3.1.2': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -32034,6 +32061,20 @@ snapshots:
     dependencies:
       iconv-lite: 0.6.3
 
+  engine.io-client@6.6.6:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-parser: 5.2.3
+      ws: 8.21.0
+      xmlhttprequest-ssl: 2.1.2
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  engine.io-parser@5.2.3: {}
+
   enhanced-resolve@5.24.2:
     dependencies:
       graceful-fs: 4.2.11
@@ -36682,6 +36723,24 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  socket.io-client@4.8.3:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+      engine.io-client: 6.6.6
+      socket.io-parser: 4.2.7
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  socket.io-parser@4.2.7:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   sockjs@0.3.24:
     dependencies:
       faye-websocket: 0.11.4
@@ -38286,6 +38345,8 @@ snapshots:
   xmlbuilder@11.0.1: {}
 
   xmlchars@2.2.0: {}
+
+  xmlhttprequest-ssl@2.1.2: {}
 
   y-protocols@1.0.7(yjs@13.6.29):
     dependencies:

--- a/projects/packages/videopress/changelog/jetpack-1882-videopress-library-display-processing-progress
+++ b/projects/packages/videopress/changelog/jetpack-1882-videopress-library-display-processing-progress
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Library: Show live transcoding progress on processing videos after upload.

--- a/projects/packages/videopress/changelog/videopress-library-promote-local-upload-progress
+++ b/projects/packages/videopress/changelog/videopress-library-promote-local-upload-progress
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Library: Show live upload progress when uploading a video from the media library to VideoPress.

--- a/projects/packages/videopress/changelog/videopress-video-details-processing-progress
+++ b/projects/packages/videopress/changelog/videopress-video-details-processing-progress
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Video details: Show live transcoding progress while a video is processing.

--- a/projects/packages/videopress/changelog/videopress-video-details-processing-progress
+++ b/projects/packages/videopress/changelog/videopress-video-details-processing-progress
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Video details: Show live transcoding progress while a video is processing.
+Video details: Show the video player while a video is processing, reporting live transcoding progress, instead of a static placeholder.

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -73,6 +73,7 @@
 		"react": "18.3.1",
 		"react-dom": "18.3.1",
 		"react-router": "7.15.1",
+		"socket.io-client": "4.8.3",
 		"tus-js-client": "4.2.3"
 	},
 	"devDependencies": {

--- a/projects/packages/videopress/routes/library/stage.tsx
+++ b/projects/packages/videopress/routes/library/stage.tsx
@@ -66,11 +66,14 @@ const StageInner = () => {
 	const [ view, setView ] = useState< View >( initialView );
 	const [ selection, setSelection ] = useState< string[] >( [] );
 	const [ captionVideo, setCaptionVideo ] = useState< LibraryItem | null >( null );
-	// Local IDs currently being promoted from local-storage to VideoPress.
-	// The upload-from-library endpoint doesn't report progress, so we just
-	// need to know which rows to overlay with an "Uploading…" state.
-	const [ promotingIds, setPromotingIds ] = useState< Set< string > >( () => new Set() );
-	// IDs currently being deleted. Same overlay technique as promotingIds:
+	// Local IDs currently being promoted from local-storage to VideoPress,
+	// mapped to the last upload percentage (0–100) reported by the chunked
+	// upload-from-library endpoint, so their rows can show the same live
+	// progress as a regular upload.
+	const [ promotingProgress, setPromotingProgress ] = useState< Map< string, number > >(
+		() => new Map()
+	);
+	// IDs currently being deleted. Same overlay technique as promotingProgress:
 	// rows get a "Deleting…" state (thumbnail overlay in grid, title pill in
 	// table) until the post-delete refetch removes them from the listing.
 	const [ deletingIds, setDeletingIds ] = useState< Set< string > >( () => new Set() );
@@ -188,38 +191,48 @@ const StageInner = () => {
 
 	const promoteLocal = useCallback(
 		( id: string ) => {
-			setPromotingIds( prev => {
-				const next = new Set( prev );
-				next.add( id );
-				return next;
-			} );
-			uploadFromLibrary( id, {
-				onSuccess: () => {
-					createSuccessNotice( __( 'Video uploaded to VideoPress.', 'jetpack-videopress-pkg' ) );
+			setPromotingProgress( prev => new Map( prev ).set( id, 0 ) );
+			uploadFromLibrary(
+				{
+					id,
+					onProgress: ( percent: number ) => {
+						setPromotingProgress( prev => {
+							// Ignore a straggler progress report after settle.
+							if ( ! prev.has( id ) ) {
+								return prev;
+							}
+							return new Map( prev ).set( id, percent );
+						} );
+					},
 				},
-				onError: ( error: Error ) => {
-					const reason = error?.message?.trim();
-					createErrorNotice(
-						reason
-							? sprintf(
-									/* translators: %s: reason returned by the upload endpoint, e.g. "403: Invalid Mime". */
-									__( 'Failed to upload video to VideoPress: %s', 'jetpack-videopress-pkg' ),
-									reason
-							  )
-							: __( 'Failed to upload video to VideoPress.', 'jetpack-videopress-pkg' )
-					);
-				},
-				onSettled: () => {
-					setPromotingIds( prev => {
-						if ( ! prev.has( id ) ) {
-							return prev;
-						}
-						const next = new Set( prev );
-						next.delete( id );
-						return next;
-					} );
-				},
-			} );
+				{
+					onSuccess: () => {
+						createSuccessNotice( __( 'Video uploaded to VideoPress.', 'jetpack-videopress-pkg' ) );
+					},
+					onError: ( error: Error ) => {
+						const reason = error?.message?.trim();
+						createErrorNotice(
+							reason
+								? sprintf(
+										/* translators: %s: reason returned by the upload endpoint, e.g. "403: Invalid Mime". */
+										__( 'Failed to upload video to VideoPress: %s', 'jetpack-videopress-pkg' ),
+										reason
+								  )
+								: __( 'Failed to upload video to VideoPress.', 'jetpack-videopress-pkg' )
+						);
+					},
+					onSettled: () => {
+						setPromotingProgress( prev => {
+							if ( ! prev.has( id ) ) {
+								return prev;
+							}
+							const next = new Map( prev );
+							next.delete( id );
+							return next;
+						} );
+					},
+				}
+			);
 		},
 		[ uploadFromLibrary, createSuccessNotice, createErrorNotice ]
 	);
@@ -406,8 +419,9 @@ const StageInner = () => {
 		// pill and the thumbnail overlay reflect the operation without
 		// needing a parallel signal at every render site.
 		const overlaid = items.map( item => {
-			if ( promotingIds.has( item.id ) ) {
-				return { ...item, upload: { status: 'promoting' as const, progress: 0 } };
+			const promoting = promotingProgress.get( item.id );
+			if ( promoting !== undefined ) {
+				return { ...item, upload: { status: 'promoting' as const, progress: promoting } };
 			}
 			if ( deletingIds.has( item.id ) ) {
 				return { ...item, upload: { status: 'deleting' as const, progress: 0 } };
@@ -415,7 +429,7 @@ const StageInner = () => {
 			return item;
 		} );
 		return [ ...inFlight, ...overlaid ];
-	}, [ uploadQueue, items, promotingIds, deletingIds ] );
+	}, [ uploadQueue, items, promotingProgress, deletingIds ] );
 
 	const getItemId = useCallback( ( item: LibraryItem ) => item.id, [] );
 

--- a/projects/packages/videopress/routes/video/style.scss
+++ b/projects/packages/videopress/routes/video/style.scss
@@ -92,19 +92,6 @@
 // "Processing" panel shown in place of the player while the VideoPress
 // backend is still transcoding the upload; keeps the player's 16:9 slot so
 // the page doesn't jump when playback becomes available.
-.vp-video-details__player-processing {
-	display: flex;
-	flex-direction: column;
-	gap: 8px;
-	align-items: center;
-	justify-content: center;
-	background: #f0f0f0;
-	color: #1e1e1e;
-}
-
-.vp-video-details__player-progress-bar {
-	width: 40%;
-}
 
 // The action buttons row should size to its content, not stretch across
 // the column flex parent.

--- a/projects/packages/videopress/routes/video/style.scss
+++ b/projects/packages/videopress/routes/video/style.scss
@@ -94,10 +94,16 @@
 // the page doesn't jump when playback becomes available.
 .vp-video-details__player-processing {
 	display: flex;
+	flex-direction: column;
+	gap: 8px;
 	align-items: center;
 	justify-content: center;
 	background: #f0f0f0;
 	color: #1e1e1e;
+}
+
+.vp-video-details__player-progress-bar {
+	width: 40%;
 }
 
 // The action buttons row should size to its content, not stretch across

--- a/projects/packages/videopress/src/dashboard/components/library/fields.tsx
+++ b/projects/packages/videopress/src/dashboard/components/library/fields.tsx
@@ -1,6 +1,7 @@
 import { getSettings as getDateSettings } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
 import { Badge, Stack, Text } from '@wordpress/ui';
+import { useProcessingProgress } from '../../hooks/use-processing-progress';
 import { formatBytes, formatDuration } from '../../utils/format';
 import ThumbnailField from './thumbnail-field';
 import { useUploadActions } from './upload-actions-context';
@@ -59,7 +60,12 @@ const privacyLabel = ( privacy: LibraryItem[ 'privacy' ] ): string => {
 };
 
 const TitleCell = ( { item }: { item: LibraryItem } ) => {
-	const { upload, type, isProcessing } = item;
+	const { upload, type, isProcessing, guid, isPrivate } = item;
+	const processingProgress = useProcessingProgress(
+		guid,
+		isPrivate,
+		type === 'videopress' && upload.status === 'idle' && isProcessing
+	);
 	let pill: { intent: BadgeIntent; label: string } | null = null;
 	if ( upload.status === 'uploading' ) {
 		pill = {
@@ -88,7 +94,14 @@ const TitleCell = ( { item }: { item: LibraryItem } ) => {
 	} else if ( isProcessing ) {
 		pill = {
 			intent: 'informational',
-			label: __( 'Processing', 'jetpack-videopress-pkg' ),
+			label:
+				processingProgress !== null
+					? sprintf(
+							/* translators: %d: transcoding progress percentage */
+							__( 'Processing %d%%', 'jetpack-videopress-pkg' ),
+							processingProgress
+					  )
+					: __( 'Processing', 'jetpack-videopress-pkg' ),
 		};
 	} else if ( type === 'local' ) {
 		pill = {

--- a/projects/packages/videopress/src/dashboard/components/library/fields.tsx
+++ b/projects/packages/videopress/src/dashboard/components/library/fields.tsx
@@ -67,7 +67,7 @@ const TitleCell = ( { item }: { item: LibraryItem } ) => {
 		type === 'videopress' && upload.status === 'idle' && isProcessing
 	);
 	let pill: { intent: BadgeIntent; label: string } | null = null;
-	if ( upload.status === 'uploading' ) {
+	if ( upload.status === 'uploading' || upload.status === 'promoting' ) {
 		pill = {
 			intent: 'informational',
 			label: sprintf(
@@ -75,11 +75,6 @@ const TitleCell = ( { item }: { item: LibraryItem } ) => {
 				__( 'Uploading %d%%', 'jetpack-videopress-pkg' ),
 				Math.round( upload.progress )
 			),
-		};
-	} else if ( upload.status === 'promoting' ) {
-		pill = {
-			intent: 'informational',
-			label: __( 'Uploading…', 'jetpack-videopress-pkg' ),
 		};
 	} else if ( upload.status === 'deleting' ) {
 		pill = {

--- a/projects/packages/videopress/src/dashboard/components/library/test/thumbnail-field.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/library/test/thumbnail-field.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { useProcessingProgress } from '../../../hooks/use-processing-progress';
 import { makeLibraryItem as item } from '../../../test-utils/library-item';
 import { libraryFields } from '../fields';
 import ThumbnailField from '../thumbnail-field';
@@ -10,6 +11,11 @@ import type { Field } from '@wordpress/dataviews';
 // Avoid the react-query/apiFetch poster request; the poster URL is irrelevant here.
 jest.mock( '../../../hooks/use-poster-url', () => ( {
 	usePosterUrl: jest.fn( () => null ),
+} ) );
+
+// Avoid the socket.io connection; tests drive the returned value directly.
+jest.mock( '../../../hooks/use-processing-progress', () => ( {
+	useProcessingProgress: jest.fn( () => null ),
 } ) );
 
 const makeActions = ( overrides: Partial< UploadActions > = {} ): UploadActions => ( {
@@ -84,6 +90,58 @@ describe( 'ThumbnailField — grid Details access', () => {
 		);
 		expect( screen.getByText( 'Deleting…' ) ).toBeInTheDocument();
 		expect( screen.queryByRole( 'button', { name: /Edit details/ } ) ).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'ThumbnailField — processing overlay', () => {
+	const mockedUseProcessingProgress = useProcessingProgress as jest.Mock;
+
+	afterEach( () => {
+		mockedUseProcessingProgress.mockReturnValue( null );
+	} );
+
+	it( 'subscribes to progress for a processing VideoPress video', () => {
+		renderField(
+			<ThumbnailField item={ item( { guid: 'abc123', isProcessing: true } ) } />,
+			makeActions()
+		);
+		expect( mockedUseProcessingProgress ).toHaveBeenCalledWith( 'abc123', false, true );
+	} );
+
+	it( 'shows the plain Processing label before the first progress event', () => {
+		renderField( <ThumbnailField item={ item( { isProcessing: true } ) } />, makeActions() );
+		expect( screen.getByText( 'Processing' ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows the live transcoding percentage once progress is known', () => {
+		mockedUseProcessingProgress.mockReturnValue( 42 );
+		renderField( <ThumbnailField item={ item( { isProcessing: true } ) } />, makeActions() );
+		expect( screen.getByText( 'Processing 42%' ) ).toBeInTheDocument();
+	} );
+} );
+
+describe( 'TitleCell — processing pill', () => {
+	const mockedUseProcessingProgress = useProcessingProgress as jest.Mock;
+
+	afterEach( () => {
+		mockedUseProcessingProgress.mockReturnValue( null );
+	} );
+
+	it( 'shows the live transcoding percentage in the status pill', () => {
+		mockedUseProcessingProgress.mockReturnValue( 87 );
+		renderField(
+			<TitleCellRender item={ item( { title: 'Fresh upload', isProcessing: true } ) } />,
+			makeActions()
+		);
+		expect( screen.getByText( 'Processing 87%' ) ).toBeInTheDocument();
+	} );
+
+	it( 'falls back to the plain Processing pill before the first progress event', () => {
+		renderField(
+			<TitleCellRender item={ item( { title: 'Fresh upload', isProcessing: true } ) } />,
+			makeActions()
+		);
+		expect( screen.getByText( 'Processing' ) ).toBeInTheDocument();
 	} );
 } );
 

--- a/projects/packages/videopress/src/dashboard/components/library/test/thumbnail-field.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/library/test/thumbnail-field.test.tsx
@@ -83,6 +83,19 @@ describe( 'ThumbnailField — grid Details access', () => {
 		expect( screen.getByText( '40%' ) ).toBeInTheDocument();
 	} );
 
+	it( 'shows live upload progress while promoting a local video to VideoPress', () => {
+		renderField(
+			<ThumbnailField
+				item={ item( { type: 'local', upload: { status: 'promoting', progress: 60 } } ) }
+			/>,
+			makeActions()
+		);
+		expect( screen.getByText( '60%' ) ).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'button', { name: 'Upload to VideoPress' } )
+		).not.toBeInTheDocument();
+	} );
+
 	it( 'shows a Deleting… overlay and removes the open-details button while deleting', () => {
 		renderField(
 			<ThumbnailField item={ item( { upload: { status: 'deleting', progress: 0 } } ) } />,
@@ -117,6 +130,22 @@ describe( 'ThumbnailField — processing overlay', () => {
 		mockedUseProcessingProgress.mockReturnValue( 42 );
 		renderField( <ThumbnailField item={ item( { isProcessing: true } ) } />, makeActions() );
 		expect( screen.getByText( 'Processing 42%' ) ).toBeInTheDocument();
+	} );
+} );
+
+describe( 'TitleCell — promoting pill', () => {
+	it( 'shows the live upload percentage while promoting a local video', () => {
+		renderField(
+			<TitleCellRender
+				item={ item( {
+					type: 'local',
+					title: 'Raw Footage',
+					upload: { status: 'promoting', progress: 33 },
+				} ) }
+			/>,
+			makeActions()
+		);
+		expect( screen.getByText( 'Uploading 33%' ) ).toBeInTheDocument();
 	} );
 } );
 

--- a/projects/packages/videopress/src/dashboard/components/library/thumbnail-field.tsx
+++ b/projects/packages/videopress/src/dashboard/components/library/thumbnail-field.tsx
@@ -3,6 +3,7 @@ import { ProgressBar } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Button, Stack, Text } from '@wordpress/ui';
 import { usePosterUrl } from '../../hooks/use-poster-url';
+import { useProcessingProgress } from '../../hooks/use-processing-progress';
 import { formatDuration } from '../../utils/format';
 import { useUploadActions } from './upload-actions-context';
 import type { LibraryItem } from '../../types/library';
@@ -27,10 +28,15 @@ type Props = { item: LibraryItem };
  */
 export default function ThumbnailField( { item }: Props ) {
 	const { promoteLocal, retryUpload, openVideoDetails } = useUploadActions();
-	const { type, upload, durationSeconds, id, title, isProcessing } = item;
+	const { type, upload, durationSeconds, id, guid, title, isPrivate, isProcessing } = item;
 	const posterUrl = usePosterUrl( item );
 
 	const isVideoPressIdle = type === 'videopress' && upload.status === 'idle';
+	const processingProgress = useProcessingProgress(
+		guid,
+		isPrivate,
+		isVideoPressIdle && isProcessing
+	);
 
 	return (
 		<div className="vp-library__thumbnail">
@@ -41,11 +47,24 @@ export default function ThumbnailField( { item }: Props ) {
 			{ isVideoPressIdle && isProcessing ? (
 				<Stack
 					direction="column"
+					gap="sm"
 					align="center"
 					justify="center"
 					className="vp-library__processing"
 				>
-					<Text>{ __( 'Processing', 'jetpack-videopress-pkg' ) }</Text>
+					<Text>
+						{ processingProgress !== null
+							? sprintf(
+									/* translators: %d: transcoding progress percentage */
+									__( 'Processing %d%%', 'jetpack-videopress-pkg' ),
+									processingProgress
+							  )
+							: __( 'Processing', 'jetpack-videopress-pkg' ) }
+					</Text>
+					<ProgressBar
+						className="vp-library__progress-bar"
+						value={ processingProgress ?? undefined }
+					/>
 				</Stack>
 			) : null }
 

--- a/projects/packages/videopress/src/dashboard/components/library/thumbnail-field.tsx
+++ b/projects/packages/videopress/src/dashboard/components/library/thumbnail-field.tsx
@@ -125,7 +125,7 @@ export default function ThumbnailField( { item }: Props ) {
 				</>
 			) : null }
 
-			{ upload.status === 'uploading' ? (
+			{ upload.status === 'uploading' || upload.status === 'promoting' ? (
 				<Stack
 					direction="column"
 					gap="sm"
@@ -138,7 +138,7 @@ export default function ThumbnailField( { item }: Props ) {
 				</Stack>
 			) : null }
 
-			{ upload.status === 'promoting' || upload.status === 'deleting' ? (
+			{ upload.status === 'deleting' ? (
 				<Stack
 					direction="column"
 					gap="sm"
@@ -146,11 +146,7 @@ export default function ThumbnailField( { item }: Props ) {
 					justify="center"
 					className="vp-library__progress"
 				>
-					<Text>
-						{ upload.status === 'deleting'
-							? __( 'Deleting…', 'jetpack-videopress-pkg' )
-							: __( 'Uploading…', 'jetpack-videopress-pkg' ) }
-					</Text>
+					<Text>{ __( 'Deleting…', 'jetpack-videopress-pkg' ) }</Text>
 					<ProgressBar className="vp-library__progress-bar" />
 				</Stack>
 			) : null }

--- a/projects/packages/videopress/src/dashboard/components/video-details/preview-player.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/preview-player.tsx
@@ -1,10 +1,7 @@
-import { ProgressBar } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
-import { Text } from '@wordpress/ui';
+import { __ } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 import { useEffect, useState } from 'react';
 import getMediaToken from '../../../client/lib/get-media-token';
-import { useProcessingProgress } from '../../hooks/use-processing-progress';
 import type { LibraryItem } from '../../types/library';
 import type { ReactElement } from 'react';
 
@@ -34,9 +31,12 @@ const getVideoPressEmbedUrl = ( guid: string, isPrivate: boolean, playbackToken?
  * Playable preview at the top of the Video details screen. Embeds the same
  * VideoPress player the block renders in post content (an iframe from
  * videopress.com), so playback, captions, quality and fullscreen all behave
- * exactly as they do for site visitors. Private videos get a playback token
- * minted before the embed loads; local items without a VideoPress GUID fall
- * back to a native `<video>` on their direct source.
+ * exactly as they do for site visitors. Videos still being transcoded render
+ * the embed too: the player's own converting screen reports the live
+ * processing percentage and starts playback when it completes. Private
+ * videos get a playback token minted before the embed loads; local items
+ * without a VideoPress GUID fall back to a native `<video>` on their direct
+ * source.
  *
  * @param props       - Component props.
  * @param props.video - The current video record.
@@ -45,8 +45,8 @@ const getVideoPressEmbedUrl = ( guid: string, isPrivate: boolean, playbackToken?
 export default function PreviewPlayer( { video }: Props ): ReactElement | null {
 	const { guid, isPrivate } = video;
 	// null = token fetch pending, '' = failed or not needed, string = minted token.
+	// eslint-disable-next-line @wordpress/no-unused-vars-before-return -- Hook must run unconditionally (Rules of Hooks); its value is only read after the early return below.
 	const [ playbackToken, setPlaybackToken ] = useState< string | null >( null );
-	const processingProgress = useProcessingProgress( guid, isPrivate, video.isProcessing );
 
 	/*
 	 * Private videos require a playback token on the embed URL. Mint one when
@@ -74,26 +74,6 @@ export default function PreviewPlayer( { video }: Props ): ReactElement | null {
 			isCurrent = false;
 		};
 	}, [ guid, isPrivate ] );
-
-	if ( video.isProcessing ) {
-		return (
-			<div className="vp-video-details__player vp-video-details__player-processing">
-				<Text>
-					{ processingProgress !== null
-						? sprintf(
-								/* translators: %d: transcoding progress percentage */
-								__( 'Processing %d%%', 'jetpack-videopress-pkg' ),
-								processingProgress
-						  )
-						: __( 'Processing', 'jetpack-videopress-pkg' ) }
-				</Text>
-				<ProgressBar
-					className="vp-video-details__player-progress-bar"
-					value={ processingProgress ?? undefined }
-				/>
-			</div>
-		);
-	}
 
 	if ( ! guid ) {
 		if ( ! video.sourceUrl ) {

--- a/projects/packages/videopress/src/dashboard/components/video-details/preview-player.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/preview-player.tsx
@@ -1,8 +1,10 @@
-import { __ } from '@wordpress/i18n';
+import { ProgressBar } from '@wordpress/components';
+import { __, sprintf } from '@wordpress/i18n';
 import { Text } from '@wordpress/ui';
 import { addQueryArgs } from '@wordpress/url';
 import { useEffect, useState } from 'react';
 import getMediaToken from '../../../client/lib/get-media-token';
+import { useProcessingProgress } from '../../hooks/use-processing-progress';
 import type { LibraryItem } from '../../types/library';
 import type { ReactElement } from 'react';
 
@@ -44,6 +46,7 @@ export default function PreviewPlayer( { video }: Props ): ReactElement | null {
 	const { guid, isPrivate } = video;
 	// null = token fetch pending, '' = failed or not needed, string = minted token.
 	const [ playbackToken, setPlaybackToken ] = useState< string | null >( null );
+	const processingProgress = useProcessingProgress( guid, isPrivate, video.isProcessing );
 
 	/*
 	 * Private videos require a playback token on the embed URL. Mint one when
@@ -75,7 +78,19 @@ export default function PreviewPlayer( { video }: Props ): ReactElement | null {
 	if ( video.isProcessing ) {
 		return (
 			<div className="vp-video-details__player vp-video-details__player-processing">
-				<Text>{ __( 'Processing', 'jetpack-videopress-pkg' ) }</Text>
+				<Text>
+					{ processingProgress !== null
+						? sprintf(
+								/* translators: %d: transcoding progress percentage */
+								__( 'Processing %d%%', 'jetpack-videopress-pkg' ),
+								processingProgress
+						  )
+						: __( 'Processing', 'jetpack-videopress-pkg' ) }
+				</Text>
+				<ProgressBar
+					className="vp-video-details__player-progress-bar"
+					value={ processingProgress ?? undefined }
+				/>
 			</div>
 		);
 	}

--- a/projects/packages/videopress/src/dashboard/components/video-details/test/preview-player.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/test/preview-player.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import getMediaToken from '../../../../client/lib/get-media-token';
+import { useProcessingProgress } from '../../../hooks/use-processing-progress';
 import PreviewPlayer from '../preview-player';
 import type { LibraryItem } from '../../../types/library';
 
@@ -8,6 +9,12 @@ jest.mock( '../../../../client/lib/get-media-token', () => ( {
 	default: jest.fn(),
 } ) );
 const mockedGetMediaToken = getMediaToken as unknown as jest.Mock;
+
+// Avoid the socket.io connection; tests drive the returned value directly.
+jest.mock( '../../../hooks/use-processing-progress', () => ( {
+	useProcessingProgress: jest.fn( () => null ),
+} ) );
+const mockedUseProcessingProgress = useProcessingProgress as jest.Mock;
 
 const baseVideo: LibraryItem = {
 	id: '42',
@@ -76,6 +83,14 @@ describe( 'PreviewPlayer', () => {
 
 		expect( screen.getByText( 'Processing' ) ).toBeInTheDocument();
 		expect( screen.queryByTitle( 'Video preview' ) ).not.toBeInTheDocument();
+		expect( mockedUseProcessingProgress ).toHaveBeenCalledWith( 'abc123', false, true );
+	} );
+
+	it( 'shows the live transcoding percentage on the processing panel once known', () => {
+		mockedUseProcessingProgress.mockReturnValueOnce( 42 );
+		render( <PreviewPlayer video={ { ...baseVideo, isProcessing: true } } /> );
+
+		expect( screen.getByText( 'Processing 42%' ) ).toBeInTheDocument();
 	} );
 
 	it( 'plays local items without a GUID through a native video element', () => {

--- a/projects/packages/videopress/src/dashboard/components/video-details/test/preview-player.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/test/preview-player.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import getMediaToken from '../../../../client/lib/get-media-token';
-import { useProcessingProgress } from '../../../hooks/use-processing-progress';
 import PreviewPlayer from '../preview-player';
 import type { LibraryItem } from '../../../types/library';
 
@@ -9,12 +8,6 @@ jest.mock( '../../../../client/lib/get-media-token', () => ( {
 	default: jest.fn(),
 } ) );
 const mockedGetMediaToken = getMediaToken as unknown as jest.Mock;
-
-// Avoid the socket.io connection; tests drive the returned value directly.
-jest.mock( '../../../hooks/use-processing-progress', () => ( {
-	useProcessingProgress: jest.fn( () => null ),
-} ) );
-const mockedUseProcessingProgress = useProcessingProgress as jest.Mock;
 
 const baseVideo: LibraryItem = {
 	id: '42',
@@ -78,19 +71,14 @@ describe( 'PreviewPlayer', () => {
 		);
 	} );
 
-	it( 'shows the processing panel instead of a player while transcoding', () => {
+	it( 'embeds the player while transcoding, whose converting screen reports progress', () => {
 		render( <PreviewPlayer video={ { ...baseVideo, isProcessing: true } } /> );
 
-		expect( screen.getByText( 'Processing' ) ).toBeInTheDocument();
-		expect( screen.queryByTitle( 'Video preview' ) ).not.toBeInTheDocument();
-		expect( mockedUseProcessingProgress ).toHaveBeenCalledWith( 'abc123', false, true );
-	} );
-
-	it( 'shows the live transcoding percentage on the processing panel once known', () => {
-		mockedUseProcessingProgress.mockReturnValueOnce( 42 );
-		render( <PreviewPlayer video={ { ...baseVideo, isProcessing: true } } /> );
-
-		expect( screen.getByText( 'Processing 42%' ) ).toBeInTheDocument();
+		expect( screen.getByTitle( 'Video preview' ) ).toHaveAttribute(
+			'src',
+			expect.stringContaining( 'https://videopress.com/embed/abc123' )
+		);
+		expect( screen.queryByText( 'Processing' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'plays local items without a GUID through a native video element', () => {

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-processing-progress.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-processing-progress.test.ts
@@ -1,0 +1,191 @@
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { io } from 'socket.io-client';
+import { fetchVideoItem } from '../../../client/lib/fetch-video-item';
+import {
+	useProcessingProgress,
+	__resetProcessingProgressForTests,
+} from '../use-processing-progress';
+
+jest.mock( 'socket.io-client', () => ( {
+	io: jest.fn(),
+} ) );
+
+jest.mock( '../../../client/lib/fetch-video-item', () => ( {
+	fetchVideoItem: jest.fn(),
+} ) );
+
+const mockedIo = io as unknown as jest.Mock;
+const mockedFetchVideoItem = fetchVideoItem as unknown as jest.Mock;
+
+type ConversionStatusEvent = { type: string; progress: number };
+type Handler = ( data: ConversionStatusEvent ) => void;
+
+type FakeSocket = {
+	on: jest.Mock;
+	off: jest.Mock;
+	disconnect: jest.Mock;
+	emit: ( event: string, data: ConversionStatusEvent ) => void;
+};
+
+/**
+ * Build a fake socket.io socket capturing `on`/`off` handlers so tests can
+ * emit server events.
+ *
+ * @return The fake socket.
+ */
+function makeFakeSocket(): FakeSocket {
+	const handlers = new Map< string, Set< Handler > >();
+	return {
+		on: jest.fn( ( event: string, handler: Handler ) => {
+			const set = handlers.get( event ) ?? new Set< Handler >();
+			set.add( handler );
+			handlers.set( event, set );
+		} ),
+		off: jest.fn( ( event: string, handler: Handler ) => {
+			handlers.get( event )?.delete( handler );
+		} ),
+		disconnect: jest.fn(),
+		emit: ( event, data ) => {
+			handlers.get( event )?.forEach( handler => handler( data ) );
+		},
+	};
+}
+
+let sockets: FakeSocket[];
+
+beforeEach( () => {
+	sockets = [];
+	mockedIo.mockImplementation( () => {
+		const socket = makeFakeSocket();
+		sockets.push( socket );
+		return socket;
+	} );
+	// Default: a standard video with no dvd rendition.
+	mockedFetchVideoItem.mockResolvedValue( { files_status: { std: { mp4: 'PROCESSING' } } } );
+} );
+
+afterEach( () => {
+	__resetProcessingProgressForTests();
+	jest.clearAllMocks();
+} );
+
+/**
+ * Wait for the shared store to finish the video-info fetch and open its
+ * socket connection.
+ *
+ * @return The connected fake socket.
+ */
+async function waitForSocket(): Promise< FakeSocket > {
+	await waitFor( () => expect( mockedIo ).toHaveBeenCalled() );
+	return sockets[ sockets.length - 1 ];
+}
+
+describe( 'useProcessingProgress', () => {
+	it( 'stays inert while disabled', () => {
+		const { result } = renderHook( () => useProcessingProgress( 'abc123', false, false ) );
+
+		expect( result.current ).toBeNull();
+		expect( mockedFetchVideoItem ).not.toHaveBeenCalled();
+		expect( mockedIo ).not.toHaveBeenCalled();
+	} );
+
+	it( 'connects to the progress socket for the video guid', async () => {
+		renderHook( () => useProcessingProgress( 'abc123', false, true ) );
+
+		await waitForSocket();
+
+		expect( mockedFetchVideoItem ).toHaveBeenCalledWith( { guid: 'abc123', isPrivate: false } );
+		expect( mockedIo ).toHaveBeenCalledWith( 'https://io.videopress.com', {
+			upgrade: false,
+			query: { guid: 'abc123' },
+		} );
+	} );
+
+	it( 'reports floored std_mp4 progress and ignores untracked filetypes', async () => {
+		const { result } = renderHook( () => useProcessingProgress( 'abc123', false, true ) );
+		const socket = await waitForSocket();
+
+		expect( result.current ).toBeNull();
+
+		act( () => socket.emit( 'conversion status', { type: 'std_mp4', progress: 33.7 } ) );
+		expect( result.current ).toBe( 33 );
+
+		// dvd_mp4 is not tracked for a standard video.
+		act( () => socket.emit( 'conversion status', { type: 'dvd_mp4', progress: 90 } ) );
+		expect( result.current ).toBe( 33 );
+	} );
+
+	it( 'tracks dvd_mp4 when the video has a dvd rendition', async () => {
+		mockedFetchVideoItem.mockResolvedValue( { files_status: { dvd: { mp4: 'PROCESSING' } } } );
+
+		const { result } = renderHook( () => useProcessingProgress( 'dvd456', false, true ) );
+		const socket = await waitForSocket();
+
+		act( () => socket.emit( 'conversion status', { type: 'std_mp4', progress: 90 } ) );
+		expect( result.current ).toBeNull();
+
+		act( () => socket.emit( 'conversion status', { type: 'dvd_mp4', progress: 60 } ) );
+		expect( result.current ).toBe( 60 );
+	} );
+
+	it( 'clamps negative progress reports to zero', async () => {
+		const { result } = renderHook( () => useProcessingProgress( 'abc123', false, true ) );
+		const socket = await waitForSocket();
+
+		act( () => socket.emit( 'conversion status', { type: 'std_mp4', progress: -1 } ) );
+		expect( result.current ).toBe( 0 );
+	} );
+
+	it( 'disconnects the socket once conversion reaches 100', async () => {
+		const { result } = renderHook( () => useProcessingProgress( 'abc123', false, true ) );
+		const socket = await waitForSocket();
+
+		act( () => socket.emit( 'conversion status', { type: 'std_mp4', progress: 100 } ) );
+
+		expect( result.current ).toBe( 100 );
+		expect( socket.off ).toHaveBeenCalledWith( 'conversion status', expect.any( Function ) );
+		expect( socket.disconnect ).toHaveBeenCalled();
+	} );
+
+	it( 'falls back to std_mp4 when the video info request fails', async () => {
+		mockedFetchVideoItem.mockRejectedValue( new Error( 'not ready' ) );
+
+		const { result } = renderHook( () => useProcessingProgress( 'abc123', false, true ) );
+		const socket = await waitForSocket();
+
+		act( () => socket.emit( 'conversion status', { type: 'std_mp4', progress: 50 } ) );
+		expect( result.current ).toBe( 50 );
+	} );
+
+	it( 'shares one socket between subscribers of the same guid', async () => {
+		const { result: firstResult } = renderHook( () =>
+			useProcessingProgress( 'abc123', false, true )
+		);
+		const { result: secondResult } = renderHook( () =>
+			useProcessingProgress( 'abc123', false, true )
+		);
+		const socket = await waitForSocket();
+
+		expect( mockedIo ).toHaveBeenCalledTimes( 1 );
+
+		act( () => socket.emit( 'conversion status', { type: 'std_mp4', progress: 25 } ) );
+		expect( firstResult.current ).toBe( 25 );
+		expect( secondResult.current ).toBe( 25 );
+	} );
+
+	it( 'disconnects when the last subscriber unmounts', async () => {
+		const { unmount: unmountFirst } = renderHook( () =>
+			useProcessingProgress( 'abc123', false, true )
+		);
+		const { unmount: unmountSecond } = renderHook( () =>
+			useProcessingProgress( 'abc123', false, true )
+		);
+		const socket = await waitForSocket();
+
+		unmountFirst();
+		expect( socket.disconnect ).not.toHaveBeenCalled();
+
+		unmountSecond();
+		expect( socket.disconnect ).toHaveBeenCalled();
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-upload-from-library.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-upload-from-library.test.ts
@@ -46,6 +46,40 @@ describe( 'uploadFromLibrary', () => {
 		expect( i ).toBe( 3 );
 	} );
 
+	it( 'reports the upload percentage after each chunk response', async () => {
+		const responses = [
+			{ status: 'new' as const, bytes_uploaded: 0, file_size: 200 },
+			{ status: 'uploading' as const, bytes_uploaded: 100, file_size: 200 },
+			{
+				status: 'complete' as const,
+				bytes_uploaded: 200,
+				file_size: 200,
+				uploaded_details: { guid: 'g', media_id: 9 },
+			},
+		];
+		let i = 0;
+		mockApiFetch( async () => responses[ i++ ] );
+		const onProgress = jest.fn();
+
+		await uploadFromLibrary( 1, { delayMs: 0, onProgress } );
+
+		expect( onProgress.mock.calls.map( ( [ percent ] ) => percent ) ).toEqual( [ 0, 50, 100 ] );
+	} );
+
+	it( 'skips progress reporting when the response lacks byte counts', async () => {
+		const responses = [
+			{ status: 'uploading' as const },
+			{ status: 'complete' as const, uploaded_details: { guid: 'g', media_id: 9 } },
+		];
+		let i = 0;
+		mockApiFetch( async () => responses[ i++ ] );
+		const onProgress = jest.fn();
+
+		await uploadFromLibrary( 1, { delayMs: 0, onProgress } );
+
+		expect( onProgress ).not.toHaveBeenCalled();
+	} );
+
 	it( 'throws after exceeding the max poll attempts', async () => {
 		mockApiFetch( async () => ( { status: 'uploading' } ) );
 

--- a/projects/packages/videopress/src/dashboard/hooks/use-processing-progress.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-processing-progress.ts
@@ -1,0 +1,174 @@
+// Live transcoding progress for VideoPress videos that are still being
+// processed after upload, ported from the VideoPress player's converting
+// plugin. The player opens a socket.io connection to io.videopress.com and
+// averages the per-filetype `conversion status` events it receives for the
+// video's GUID; this module speaks the same protocol so the library shows
+// the same percentage the embedded player reports.
+//
+// A module-level store keeps one socket per GUID no matter how many cells
+// subscribe (the thumbnail overlay and the title-cell pill both render per
+// item), and tears the socket down when the last subscriber unmounts.
+
+import { useCallback, useSyncExternalStore } from '@wordpress/element';
+import { io } from 'socket.io-client';
+import { fetchVideoItem } from '../../client/lib/fetch-video-item';
+import type { Socket } from 'socket.io-client';
+
+const PROGRESS_SOCKET_ORIGIN = 'https://io.videopress.com';
+
+type ConversionStatusEvent = {
+	type: string;
+	progress: number;
+};
+
+type ProgressEntry = {
+	progress: number | null;
+	subscribers: Set< () => void >;
+	socket: Socket | null;
+	disposed: boolean;
+};
+
+const entries = new Map< string, ProgressEntry >();
+
+/**
+ * Fetch the video's `files_status` and connect the entry's socket.
+ *
+ * The set of output formats VideoPress transcodes for a video decides which
+ * per-filetype progress events count towards the average — the same
+ * selection the player makes before showing its converting modal: videos
+ * large enough to get a DVD rendition are tracked via `dvd_mp4`, everything
+ * else via `std_mp4`.
+ *
+ * @param guid      - The video GUID.
+ * @param isPrivate - Whether the video is private (the info request then
+ *                  needs a playback token).
+ * @param entry     - The store entry to connect.
+ */
+async function connect( guid: string, isPrivate: boolean, entry: ProgressEntry ): Promise< void > {
+	let supportedTypes = [ 'std_mp4' ];
+	try {
+		const info = await fetchVideoItem( { guid, isPrivate } );
+		if ( info?.files_status?.dvd ) {
+			supportedTypes = [ 'dvd_mp4' ];
+		}
+	} catch {
+		// No video info yet; std_mp4 is produced for every upload.
+	}
+
+	if ( entry.disposed ) {
+		return;
+	}
+
+	const progressByType: Record< string, number > = {};
+	supportedTypes.forEach( type => {
+		progressByType[ type ] = 0;
+	} );
+
+	const socket = io( PROGRESS_SOCKET_ORIGIN, { upgrade: false, query: { guid } } );
+	entry.socket = socket;
+
+	const onStatus = ( data: ConversionStatusEvent ) => {
+		// Ignore events for filetypes this video's average doesn't track.
+		if ( ! ( data.type in progressByType ) ) {
+			return;
+		}
+		progressByType[ data.type ] = data.progress;
+
+		let sum = 0;
+		for ( const type in progressByType ) {
+			// The backend reports negative values before a filetype starts.
+			sum += Math.max( 0, progressByType[ type ] );
+		}
+		entry.progress = Math.floor( sum / supportedTypes.length );
+		entry.subscribers.forEach( notify => notify() );
+
+		if ( entry.progress >= 100 ) {
+			socket.off( 'conversion status', onStatus );
+			socket.disconnect();
+		}
+	};
+
+	socket.on( 'conversion status', onStatus );
+}
+
+/**
+ * Subscribe to conversion progress for a GUID, creating the shared socket on
+ * first subscription and disposing it when the last subscriber leaves.
+ *
+ * @param guid      - The video GUID.
+ * @param isPrivate - Whether the video is private.
+ * @param notify    - Called whenever the progress value changes.
+ * @return Unsubscribe callback.
+ */
+function subscribeToProgress( guid: string, isPrivate: boolean, notify: () => void ): () => void {
+	let entry = entries.get( guid );
+	if ( ! entry ) {
+		entry = { progress: null, subscribers: new Set(), socket: null, disposed: false };
+		entries.set( guid, entry );
+		void connect( guid, isPrivate, entry );
+	}
+	entry.subscribers.add( notify );
+
+	return () => {
+		entry.subscribers.delete( notify );
+		if ( entry.subscribers.size === 0 ) {
+			entry.disposed = true;
+			entry.socket?.disconnect();
+			entries.delete( guid );
+		}
+	};
+}
+
+/**
+ * Read the last known progress for a GUID.
+ *
+ * @param guid - The video GUID.
+ * @return Percentage 0–100, or null before the first event arrives.
+ */
+function readProgress( guid: string ): number | null {
+	return entries.get( guid )?.progress ?? null;
+}
+
+/**
+ * Reset the shared progress store. Intended for tests; production code
+ * should not call this.
+ */
+export function __resetProcessingProgressForTests(): void {
+	entries.forEach( entry => {
+		entry.disposed = true;
+		entry.socket?.disconnect();
+	} );
+	entries.clear();
+}
+
+/**
+ * Track the live transcoding progress of a processing VideoPress video.
+ *
+ * @param guid      - The video GUID.
+ * @param isPrivate - Whether the video is private.
+ * @param enabled   - Only subscribe while true (e.g. while the item is
+ *                  processing); pass false to keep the hook inert.
+ * @return Percentage 0–100, or null while no progress is known.
+ */
+export function useProcessingProgress(
+	guid: string,
+	isPrivate: boolean,
+	enabled: boolean
+): number | null {
+	const subscribe = useCallback(
+		( notify: () => void ) => {
+			if ( ! enabled || ! guid ) {
+				return () => {};
+			}
+			return subscribeToProgress( guid, isPrivate, notify );
+		},
+		[ guid, isPrivate, enabled ]
+	);
+
+	const getSnapshot = useCallback(
+		() => ( enabled && guid ? readProgress( guid ) : null ),
+		[ guid, enabled ]
+	);
+
+	return useSyncExternalStore( subscribe, getSnapshot, getSnapshot );
+}

--- a/projects/packages/videopress/src/dashboard/hooks/use-upload-from-library.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-upload-from-library.ts
@@ -13,6 +13,10 @@ type UploadStatusResponse = {
 	// Returned for the `uploaded` (already-on-VideoPress) terminal status.
 	uploaded_post_id?: number | string;
 	uploaded_video_guid?: string;
+	// Chunk-progress fields present on `new` / `resume` / `uploading` /
+	// `complete` responses (`bytes_uploaded` is -1 on `error`).
+	bytes_uploaded?: number;
+	file_size?: number;
 };
 
 export type UploadFromLibraryResult = {
@@ -25,6 +29,8 @@ export type UploadFromLibraryOptions = {
 	delayMs?: number;
 	/** Maximum total attempts before giving up. */
 	maxAttempts?: number;
+	/** Called with the upload percentage (0–100) after each chunk response. */
+	onProgress?: ( percent: number ) => void;
 };
 
 const DEFAULT_DELAY_MS = 500;
@@ -77,6 +83,21 @@ export async function uploadFromLibrary(
 			continue;
 		}
 
+		// Each POST pushes one chunk server-side and reports the running
+		// offset; surface it so callers can render real upload progress.
+		// `bytes_uploaded` is -1 on `error` responses, hence the >= 0 guard.
+		if (
+			options.onProgress &&
+			typeof result.bytes_uploaded === 'number' &&
+			typeof result.file_size === 'number' &&
+			result.bytes_uploaded >= 0 &&
+			result.file_size > 0
+		) {
+			options.onProgress(
+				Math.min( 100, Math.round( ( result.bytes_uploaded / result.file_size ) * 100 ) )
+			);
+		}
+
 		if ( result.status === 'complete' && result.uploaded_details ) {
 			return {
 				guid: result.uploaded_details.guid,
@@ -107,6 +128,13 @@ export async function uploadFromLibrary(
 	throw new Error( 'Upload from library timed out.' );
 }
 
+export type UploadFromLibraryVariables = {
+	/** The numeric or string WordPress attachment ID. */
+	id: string | number;
+	/** Called with the upload percentage (0–100) after each chunk response. */
+	onProgress?: ( percent: number ) => void;
+};
+
 /**
  * Promote an existing local WordPress media attachment to a
  * VideoPress-hosted video by walking the chunked upload endpoint.
@@ -118,8 +146,8 @@ export async function uploadFromLibrary(
  */
 export function useUploadFromLibrary() {
 	const client = useQueryClient();
-	return useMutation< UploadFromLibraryResult, Error, string | number >( {
-		mutationFn: id => uploadFromLibrary( id ),
+	return useMutation< UploadFromLibraryResult, Error, UploadFromLibraryVariables >( {
+		mutationFn: ( { id, onProgress } ) => uploadFromLibrary( id, { onProgress } ),
 		onSuccess: () => {
 			client.invalidateQueries( { queryKey: [ LIBRARY_QUERY_KEY ] } );
 		},


### PR DESCRIPTION
Fixes JETPACK-1882

## Proposed changes

After an upload finishes, the modernized VideoPress library only showed a static "Processing" overlay until the poster poll flipped the item — there was no indication of how far along transcoding was. This PR ports the progress mechanism from the VideoPress player's converting plugin into the dashboard library:

* New `useProcessingProgress` hook (`src/dashboard/hooks/use-processing-progress.ts`): opens a socket.io connection to `io.videopress.com` keyed by the video GUID and averages the per-filetype `conversion status` events, exactly like the player — tracking `dvd_mp4` when the video's `files_status` includes a DVD rendition and `std_mp4` otherwise (fetched via the existing `fetchVideoItem`, falling back to `std_mp4` when the info isn't available yet).
* A module-level store shares one socket per GUID no matter how many cells subscribe, and disconnects when the last subscriber unmounts or progress reaches 100.
* The grid thumbnail overlay now shows "Processing N%" with a determinate progress bar once the first event arrives (plain "Processing" with an indeterminate bar before that), and the table view's status pill shows the same live percentage.
* The video details page drops its "Processing" placeholder branch entirely and renders the embedded player for processing videos too — the player's own converting screen reports the live percentage and starts playback when conversion completes.
* `socket.io-client` is bundled as an npm dependency rather than the player's CDN loader, since wp.org-distributed plugins cannot load remote executable code.

The library's existing 2s refetch-while-processing behavior is unchanged and still swaps the tile to the real thumbnail when transcoding completes.

Additionally, uploads **from the blog media library to VideoPress** ("Upload to VideoPress" on local videos) now report live progress too:

* Every poll of the chunked `/videopress/v1/upload/{id}` endpoint already returns `bytes_uploaded` and `file_size`; `uploadFromLibrary()` now surfaces that via an `onProgress` callback and the library stage tracks the percentage per attachment.
* Promoting rows render exactly like regular uploads — a percentage with a determinate progress bar on the thumbnail overlay, and an "Uploading N%" pill in the table view — instead of the previous indeterminate "Uploading…" overlay. Deleting keeps its indeterminate treatment.

## Related product discussion/links

* JETPACK-1882

## Does this pull request change what data or activity we track or use?

No tracking changes. wp-admin now opens the same socket.io connection to the VideoPress conversion-progress service (`io.videopress.com`) that the embedded player already opens on the front end; the only datum sent is the video GUID, and only while a video on the current library page is processing.

## Screenshots

Processing/transcoding progress:
<img width="1684" height="1142" alt="image" src="https://github.com/user-attachments/assets/e831243d-40a3-4901-af3e-a469d1ecbecb" />


## Testing instructions

### For testing local video upload and processing progress

* On a fresh site, upload a video to your library
* Install Jetpack and Activate VideoPress
* On the VideoPress Dashboard > Library the uploaded video will show as "Local video"
* Clicking to "Upload to VideoPress" will now show a progress status when the video starts uploading
* Testing with larger videos is better as a small video might not show progress if the upload finishes too quickly

### For the processing only
* Enable the modernized VideoPress dashboard: `add_filter( 'rsm_jetpack_ui_modernization_videopress', '__return_true' );`
* Go to Jetpack → VideoPress → Library.
* Upload a reasonably large video (a few hundred MB helps — transcoding needs to run long enough to observe).
* After the upload bar completes, the tile should show "Processing N%" with a progress bar that advances as the backend transcodes (compare with the same video's embedded player, which reports the same percentage).
* Switch the library to table view: the "Processing" pill next to the title should show the same live percentage.
* Open the processing video's details page (click the tile/title): the preview panel should show the embedded player's converting screen ("We are converting this video for optimal playback…" with a percentage), which starts playback once conversion completes.
* When processing finishes, the tile should swap to the real thumbnail as before.
* Upload-from-library progress: upload a large video to the WordPress media library directly (Media → Add New), then in the VideoPress library hover its "Local video" tile and click "Upload to VideoPress". The tile should show a live percentage and progress bar while the server pushes chunks (the table pill shows "Uploading N%"), then flip to a processing VideoPress row.
* Regression: local-video tiles, uploading/failed overlays, and the Edit details hover action should behave as before.
* CI equivalent: `pnpm jest src/dashboard`, `pnpm typecheck`, and `pnpm build` in `projects/packages/videopress` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
