### PR TITLE
Write editor: fix anon mobile topbar crowding and block empty publish

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-write-editor-anon-mobile-topbar-and-empty-publish
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-write-editor-anon-mobile-topbar-and-empty-publish
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write editor: fix logged-out topbar title crowding on mobile and block publishing an empty post

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -2412,6 +2412,34 @@ body.bw-modal-open {
 		padding: 0 16px;
 	}
 
+	/*
+	 * The topbar status mirrors the post title ("Untitled" when
+	 * empty), which on a narrow topbar collides with the anon
+	 * "WordPress.com · Write" / "Not signed in" labels + Publish.
+	 * When idle, hide the title mirror and pin the actions right. The
+	 * has-topbar-message class (data-wp-class, driven by
+	 * state.hasMessage) marks when a transient message is showing
+	 * (Saving/Saved, "Please write something").
+	 */
+	.bw-topbar:not(.has-topbar-message) .bw-status {
+		display: none;
+	}
+
+	.bw-topbar-actions {
+		margin-left: auto;
+	}
+
+	/*
+	 * While a message is showing, let it take over the bar: hide the
+	 * brand wordmark and "Not signed in" so the centered message uses
+	 * the full width instead of being squished between them. Both
+	 * reappear once the message clears.
+	 */
+	.bw-topbar.has-topbar-message .bw-anon-brand,
+	.bw-topbar.has-topbar-message .bw-anon-status {
+		display: none;
+	}
+
 	.bw-editor {
 		padding: 0 16px;
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -3558,6 +3558,12 @@ const { state } = store( 'wpcom-write', {
 		get displayStatus() {
 			return state.message || state.headerLabel;
 		},
+		get hasMessage() {
+			// Drives the has-topbar-message class on the topbar (data-wp-class) so the
+			// mobile layout can hide the idle title mirror and let a transient message
+			// take over the bar. See style.css.
+			return !! ( state.message && state.message.trim() );
+		},
 		get isClassicWarning() {
 			return state.unsupportedWarning === 'classic-editor';
 		},
@@ -5932,6 +5938,17 @@ const { state } = store( 'wpcom-write', {
 
 		async publish() {
 			if ( isAnon() ) {
+				// Nothing to hand off to signup yet — block the empty publish the
+				// same way the authenticated path does in performSave(), so an anon
+				// visitor can't wall themselves into signup with a blank draft.
+				if ( ! hasWritableContent() ) {
+					state.message = i18n.pleaseWriteSomething || 'Please write something';
+					setTimeout( () => {
+						state.message = '';
+					}, 2500 );
+					return;
+				}
+
 				// The publish-intent event — the moment an anon visitor hits the
 				// signup wall. Captured before navigating away so it isn't lost to
 				// the handoff. word_count / draft_size_bytes size the draft; the

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -1005,7 +1005,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 			<a class="bw-help-link" data-target="wpcom-help-center" href="https://wordpress.com/support/editors/write-editor/" target="_blank" rel="noopener noreferrer"><?php echo esc_html__( 'Read the Write editor guide', 'jetpack-mu-wpcom' ); ?> <span aria-hidden="true">&#8599;</span></a>
 		</div>
 		</div><!-- /.bw-help-wrap -->
-		<span class="bw-status" data-wp-text="state.displayStatus"></span>
+		<span class="bw-status" role="status" aria-live="polite" data-wp-text="state.displayStatus"></span>
 		<div class="bw-topbar-actions">
 			<button
 				class="bw-btn bw-btn-draft"

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -988,7 +988,7 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 <div data-wp-interactive="wpcom-write" class="bw-app">
 
 	<!-- Top bar -->
-	<header class="bw-topbar">
+	<header class="bw-topbar" data-wp-class--has-topbar-message="state.hasMessage">
 		<a href="<?php echo esc_url( $back_url ); ?>" class="bw-back" title="<?php echo esc_attr__( 'Back', 'jetpack-mu-wpcom' ); ?>" aria-label="<?php echo esc_attr__( 'Back', 'jetpack-mu-wpcom' ); ?>" data-wp-on--click="actions.handleBack">&larr;</a>
 		<div class="bw-help-wrap" data-wp-on--keydown="actions.handleHelpKeyDown" data-wp-on--focusout="actions.handleHelpFocusOut">
 		<button class="bw-help-toggle" data-wp-on--click="actions.toggleHelp" title="<?php echo esc_attr__( 'Tips', 'jetpack-mu-wpcom' ); ?>" aria-label="<?php echo esc_attr__( 'Tips', 'jetpack-mu-wpcom' ); ?>"><span class="bw-help-i" aria-hidden="true">i</span></button>


### PR DESCRIPTION
## Proposed changes

Two fixes to the logged-out (anonymous) Write editor in `jetpack-mu-wpcom`:

1. **Mobile topbar crowding.** The topbar status mirrors the post title (`Untitled` when empty). On a narrow topbar it collided with the injected `WordPress.com · Write` / `Not signed in` labels, rendering as `U.Not signed in`. On mobile we now hide the idle title mirror and pin the actions to the right. When a transient message is showing, a `has-topbar-message` class (driven by `state.hasMessage` via `data-wp-class`) lets the message take over the full width instead of being squished between the labels; the labels reappear once it clears. Desktop is unchanged (all rules live in the existing `@media (max-width: 768px)` block).

2. **Empty publish.** The anonymous `publish()` path skipped the content check, so a visitor could click Publish on an empty editor and get handed off to signup with a blank draft. It now runs the same `hasWritableContent()` guard the authenticated path already uses in `performSave()`, showing "Please write something" and staying put.

Before | After
--- | ---
<img width="563" height="1218" alt="IMG_0793" src="https://github.com/user-attachments/assets/e849abfe-10cf-4aaf-a5ba-3f561067c02f" /> | <img width="364" height="330" alt="Screenshot 2026-07-15 at 4 21 50 PM" src="https://github.com/user-attachments/assets/434d68b6-fa55-4779-a10f-842ebd0d6a75" />


## Related product discussion/links

* pe7F0s-3R3-p2

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

In the logged-out Write editor on a mobile viewport (≤768px):

* **Topbar:** confirm the bar reads `WordPress.com · Write   Not signed in   Publish` with no `Untitled` mirror crowding/overlapping the labels.
* **Empty publish:** with the title and body empty, tap **Publish**. It should *not* redirect to signup — instead the message "Please write something" briefly takes over the bar (the wordmark + "Not signed in" hide while it shows, then return).
* **Non-empty publish:** type a title/body and tap **Publish** — the normal anon handoff to signup still happens.
* **Desktop:** confirm the topbar status/title behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)