### PR TITLE
Podcast: count Podcast Episode block in publish telemetry

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-telemetry-episode-block
+++ b/projects/packages/podcast/changelog/fix-podcast-telemetry-episode-block
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Podcast telemetry: count episodes published with the Podcast Episode block so published-episode and show-launch stats are no longer undercounted.
+Podcast: count episodes published with the Podcast Episode block in publish telemetry.

--- a/projects/packages/podcast/changelog/fix-podcast-telemetry-episode-block
+++ b/projects/packages/podcast/changelog/fix-podcast-telemetry-episode-block
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast telemetry: count episodes published with the Podcast Episode block so published-episode and show-launch stats are no longer undercounted.

--- a/projects/packages/podcast/src/class-tracks.php
+++ b/projects/packages/podcast/src/class-tracks.php
@@ -11,6 +11,7 @@ namespace Automattic\Jetpack\Podcast;
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Podcast\Feed\Customize_Feed;
+use Automattic\Jetpack\Podcast\Feed\Episode_Block_Tags;
 use Throwable;
 use WP_Post;
 use WP_Query;
@@ -343,12 +344,19 @@ class Tracks {
 
 	/**
 	 * Filters out posts in the podcast category that aren't actually episodes.
-	 * `core/audio` block + classic-editor attached audio cover the supported
-	 * authoring paths.
+	 * Covers all three authoring paths: the `jetpack/podcast-episode` block
+	 * (the paid path — media lives in its `mediaUrl` attr, often an external or
+	 * unattached URL that the two checks below miss), the `core/audio` block,
+	 * and classic-editor attached audio.
 	 *
 	 * @param WP_Post $post Post being checked.
 	 */
 	private static function has_podcast_media( WP_Post $post ): bool {
+		$attrs = Episode_Block_Tags::get_block_attrs( $post );
+		if ( ! empty( $attrs['mediaUrl'] ) ) {
+			return true;
+		}
+
 		return has_block( 'core/audio', $post )
 			|| ! empty( get_attached_media( 'audio', $post->ID ) );
 	}

--- a/projects/packages/podcast/tests/php/Tracks_Test.php
+++ b/projects/packages/podcast/tests/php/Tracks_Test.php
@@ -181,6 +181,28 @@ class Tracks_Test extends BaseTestCase {
 		$this->assertEmpty( $this->events_named( 'wpcom_podcast_episode_published' ) );
 	}
 
+	public function test_episode_published_emits_for_podcast_episode_block_with_external_media() {
+		$cat_id = $this->configure_podcast_category();
+		$post   = $this->insert_post_in_category( $cat_id );
+		// External media in the block's `mediaUrl` — no core/audio block, nothing
+		// attached to the post, so the pre-block checks would miss it.
+		$post->post_content = '<!-- wp:jetpack/podcast-episode {"mediaUrl":"https://cdn.example.com/ep1.mp3"} /-->';
+
+		Tracks::record_episode_published( $post->ID, $post, false, null );
+
+		$this->assertCount( 1, $this->events_named( 'wpcom_podcast_episode_published' ) );
+	}
+
+	public function test_episode_published_skips_podcast_episode_block_without_media() {
+		$cat_id             = $this->configure_podcast_category();
+		$post               = $this->insert_post_in_category( $cat_id );
+		$post->post_content = '<!-- wp:jetpack/podcast-episode {"episodeNumber":1} /-->';
+
+		Tracks::record_episode_published( $post->ID, $post, false, null );
+
+		$this->assertEmpty( $this->events_named( 'wpcom_podcast_episode_published' ) );
+	}
+
 	public function test_media_uploaded_emits_for_audio_when_podcasting_enabled() {
 		$this->configure_podcast_category();
 


### PR DESCRIPTION
## Proposed changes

Publish telemetry didn't recognize the **Podcast Episode block** (`jetpack/podcast-episode`), so episodes published with it weren't counted. The gate (`has_podcast_media()`) only looked for a `core/audio` block or audio attached to the post — but this block stores its media in a `mediaUrl` attr that's usually an external URL, matching neither.

This adds a check for a `jetpack/podcast-episode` block with a non-empty `mediaUrl`, reusing the feed's existing `Episode_Block_Tags::get_block_attrs()` helper.

## Does this pull request change what data or activity we track or use?

No. Same two events (`wpcom_podcast_episode_published`, `wpcom_podcast_show_launched`), same properties — this just fixes their coverage so they fire for Podcast Episode block posts too.

## Testing instructions

* On a site with a podcast category set, publish a post in that category using the **Podcast Episode** block with an external `mediaUrl`.
* Confirm `wpcom_podcast_episode_published` fires (and `wpcom_podcast_show_launched` for the first episode). On `trunk` neither fires.
* Publish one with no media selected and confirm nothing fires.
* Unit tests: `cd projects/packages/podcast && composer phpunit -- --filter Tracks_Test`.
