### PR TITLE
Podcast: remove the settings-saved analytics event

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-settings-tracks-pii
+++ b/projects/packages/podcast/changelog/fix-podcast-settings-tracks-pii
@@ -1,4 +1,4 @@
 Significance: patch
-Type: fixed
+Type: removed
 
-Podcast: keep raw settings values out of the settings-saved analytics event.
+Podcast: drop the settings-saved analytics event.

--- a/projects/packages/podcast/changelog/fix-podcast-settings-tracks-pii
+++ b/projects/packages/podcast/changelog/fix-podcast-settings-tracks-pii
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Podcast: report only aggregate/derived values in the settings-saved analytics event instead of copying raw user-authored option values (title, summary, copyright, image URL, directory maps) into Tracks.
+Podcast: keep raw settings values out of the settings-saved analytics event.

--- a/projects/packages/podcast/changelog/fix-podcast-settings-tracks-pii
+++ b/projects/packages/podcast/changelog/fix-podcast-settings-tracks-pii
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast: report only aggregate/derived values in the settings-saved analytics event instead of copying raw user-authored option values (title, summary, copyright, image URL, directory maps) into Tracks.

--- a/projects/packages/podcast/src/class-tracks.php
+++ b/projects/packages/podcast/src/class-tracks.php
@@ -40,8 +40,6 @@ class Tracks {
 
 		add_action( 'add_option_podcasting_show_urls', array( __CLASS__, 'record_show_url_added' ), 10, 2 );
 		add_action( 'update_option_podcasting_show_urls', array( __CLASS__, 'record_show_url_updated' ), 10, 3 );
-
-		add_action( 'jetpack_podcast_settings_saved', array( __CLASS__, 'record_settings_saved' ), 10, 2 );
 	}
 
 	/**
@@ -257,115 +255,6 @@ class Tracks {
 		} catch ( Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 			// Tracks is best-effort.
 		}
-	}
-
-	/**
-	 * Emit `wpcom_podcasting_settings_saved` after a podcast settings write.
-	 *
-	 * Fired off the `jetpack_podcast_settings_saved` action that
-	 * {@see Podcast_Settings_Endpoint::update_item()} triggers, so it's agnostic
-	 * to the REST transport — the endpoint already gates on a saved option.
-	 *
-	 * Reports an aggregate shape only — which keys were touched/changed plus
-	 * enabled/count derivations — never the raw option values. Title, summary,
-	 * copyright, image URL, and the directory maps are user-authored free text
-	 * that can carry PII or confidential material, so none of it is copied into
-	 * analytics. Mirrors the wpcom legacy handler's safe shape.
-	 *
-	 * @param array    $previous Pre-write settings snapshot from the action.
-	 * @param string[] $touched  Option names present in the write payload.
-	 */
-	public static function record_settings_saved( $previous = array(), $touched = array() ): void {
-		try {
-			$previous = is_array( $previous ) ? $previous : array();
-			$touched  = is_array( $touched ) ? $touched : array();
-			$current  = Settings::get_all();
-
-			$changed = array();
-			foreach ( $touched as $name ) {
-				if ( self::normalize_setting_value( $current[ $name ] ?? null ) !== self::normalize_setting_value( $previous[ $name ] ?? null ) ) {
-					$changed[] = $name;
-				}
-			}
-
-			self::record_event(
-				'wpcom_podcasting_settings_saved',
-				array(
-					'touched_settings'                   => implode( ',', $touched ),
-					'touched_settings_count'             => count( $touched ),
-					'changed_settings'                   => implode( ',', $changed ),
-					'changed_settings_count'             => count( $changed ),
-					'podcasting_enabled'                 => (int) ( $current['podcasting_category_id'] ?? 0 ) > 0,
-					'previous_podcasting_enabled'        => (int) ( $previous['podcasting_category_id'] ?? 0 ) > 0,
-					'show_urls_count'                    => self::count_non_empty_strings( $current['podcasting_show_urls'] ?? array() ),
-					'previous_show_urls_count'           => self::count_non_empty_strings( $previous['podcasting_show_urls'] ?? array() ),
-					'show_states_active_count'           => self::count_matching( $current['podcasting_show_states'] ?? array(), 'active' ),
-					'previous_show_states_active_count'  => self::count_matching( $previous['podcasting_show_states'] ?? array(), 'active' ),
-					'show_states_pending_count'          => self::count_matching( $current['podcasting_show_states'] ?? array(), 'pending' ),
-					'previous_show_states_pending_count' => self::count_matching( $previous['podcasting_show_states'] ?? array(), 'pending' ),
-				)
-			);
-		} catch ( Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
-			// Tracks is best-effort.
-		}
-	}
-
-	/**
-	 * Normalize a setting value for change detection: array maps drop empty
-	 * entries so padding differences don't read as a change; scalars pass through.
-	 *
-	 * @param mixed $value Raw option value.
-	 * @return mixed
-	 */
-	private static function normalize_setting_value( $value ) {
-		if ( ! is_array( $value ) ) {
-			return $value;
-		}
-		return array_filter(
-			$value,
-			static function ( $item ) {
-				return is_string( $item ) && '' !== $item;
-			}
-		);
-	}
-
-	/**
-	 * Count the non-empty string entries in a directory map.
-	 *
-	 * @param mixed $values Map of directory => value.
-	 */
-	private static function count_non_empty_strings( $values ): int {
-		if ( ! is_array( $values ) ) {
-			return 0;
-		}
-		return count(
-			array_filter(
-				$values,
-				static function ( $value ) {
-					return is_string( $value ) && '' !== $value;
-				}
-			)
-		);
-	}
-
-	/**
-	 * Count the entries in a show-states map matching a target state.
-	 *
-	 * @param mixed  $states Map of directory => state.
-	 * @param string $target State to count (`active` / `pending`).
-	 */
-	private static function count_matching( $states, string $target ): int {
-		if ( ! is_array( $states ) ) {
-			return 0;
-		}
-		return count(
-			array_filter(
-				$states,
-				static function ( $state ) use ( $target ) {
-					return $target === $state;
-				}
-			)
-		);
 	}
 
 	/**

--- a/projects/packages/podcast/src/class-tracks.php
+++ b/projects/packages/podcast/src/class-tracks.php
@@ -265,22 +265,107 @@ class Tracks {
 	 * Fired off the `jetpack_podcast_settings_saved` action that
 	 * {@see Podcast_Settings_Endpoint::update_item()} triggers, so it's agnostic
 	 * to the REST transport — the endpoint already gates on a saved option.
+	 *
+	 * Reports an aggregate shape only — which keys were touched/changed plus
+	 * enabled/count derivations — never the raw option values. Title, summary,
+	 * copyright, image URL, and the directory maps are user-authored free text
+	 * that can carry PII or confidential material, so none of it is copied into
+	 * analytics. Mirrors the wpcom legacy handler's safe shape.
+	 *
+	 * @param array    $previous Pre-write settings snapshot from the action.
+	 * @param string[] $touched  Option names present in the write payload.
 	 */
-	public static function record_settings_saved(): void {
+	public static function record_settings_saved( $previous = array(), $touched = array() ): void {
 		try {
-			// Skip user-supplied free-text fields — keep PII out of tracks.
-			$pii   = array( 'podcasting_email', 'podcasting_talent_name' );
-			$state = array();
-			foreach ( Settings::OPTION_NAMES as $name ) {
-				if ( in_array( $name, $pii, true ) ) {
-					continue;
+			$previous = is_array( $previous ) ? $previous : array();
+			$touched  = is_array( $touched ) ? $touched : array();
+			$current  = Settings::get_all();
+
+			$changed = array();
+			foreach ( $touched as $name ) {
+				if ( self::normalize_setting_value( $current[ $name ] ?? null ) !== self::normalize_setting_value( $previous[ $name ] ?? null ) ) {
+					$changed[] = $name;
 				}
-				$state[ $name ] = get_option( $name, '' );
 			}
-			self::record_event( 'wpcom_podcasting_settings_saved', $state );
+
+			self::record_event(
+				'wpcom_podcasting_settings_saved',
+				array(
+					'touched_settings'                   => implode( ',', $touched ),
+					'touched_settings_count'             => count( $touched ),
+					'changed_settings'                   => implode( ',', $changed ),
+					'changed_settings_count'             => count( $changed ),
+					'podcasting_enabled'                 => (int) ( $current['podcasting_category_id'] ?? 0 ) > 0,
+					'previous_podcasting_enabled'        => (int) ( $previous['podcasting_category_id'] ?? 0 ) > 0,
+					'show_urls_count'                    => self::count_non_empty_strings( $current['podcasting_show_urls'] ?? array() ),
+					'previous_show_urls_count'           => self::count_non_empty_strings( $previous['podcasting_show_urls'] ?? array() ),
+					'show_states_active_count'           => self::count_matching( $current['podcasting_show_states'] ?? array(), 'active' ),
+					'previous_show_states_active_count'  => self::count_matching( $previous['podcasting_show_states'] ?? array(), 'active' ),
+					'show_states_pending_count'          => self::count_matching( $current['podcasting_show_states'] ?? array(), 'pending' ),
+					'previous_show_states_pending_count' => self::count_matching( $previous['podcasting_show_states'] ?? array(), 'pending' ),
+				)
+			);
 		} catch ( Throwable $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
 			// Tracks is best-effort.
 		}
+	}
+
+	/**
+	 * Normalize a setting value for change detection: array maps drop empty
+	 * entries so padding differences don't read as a change; scalars pass through.
+	 *
+	 * @param mixed $value Raw option value.
+	 * @return mixed
+	 */
+	private static function normalize_setting_value( $value ) {
+		if ( ! is_array( $value ) ) {
+			return $value;
+		}
+		return array_filter(
+			$value,
+			static function ( $item ) {
+				return is_string( $item ) && '' !== $item;
+			}
+		);
+	}
+
+	/**
+	 * Count the non-empty string entries in a directory map.
+	 *
+	 * @param mixed $values Map of directory => value.
+	 */
+	private static function count_non_empty_strings( $values ): int {
+		if ( ! is_array( $values ) ) {
+			return 0;
+		}
+		return count(
+			array_filter(
+				$values,
+				static function ( $value ) {
+					return is_string( $value ) && '' !== $value;
+				}
+			)
+		);
+	}
+
+	/**
+	 * Count the entries in a show-states map matching a target state.
+	 *
+	 * @param mixed  $states Map of directory => state.
+	 * @param string $target State to count (`active` / `pending`).
+	 */
+	private static function count_matching( $states, string $target ): int {
+		if ( ! is_array( $states ) ) {
+			return 0;
+		}
+		return count(
+			array_filter(
+				$states,
+				static function ( $state ) use ( $target ) {
+					return $target === $state;
+				}
+			)
+		);
 	}
 
 	/**

--- a/projects/packages/podcast/src/class-tracks.php
+++ b/projects/packages/podcast/src/class-tracks.php
@@ -41,7 +41,7 @@ class Tracks {
 		add_action( 'add_option_podcasting_show_urls', array( __CLASS__, 'record_show_url_added' ), 10, 2 );
 		add_action( 'update_option_podcasting_show_urls', array( __CLASS__, 'record_show_url_updated' ), 10, 3 );
 
-		add_action( 'jetpack_podcast_settings_saved', array( __CLASS__, 'record_settings_saved' ) );
+		add_action( 'jetpack_podcast_settings_saved', array( __CLASS__, 'record_settings_saved' ), 10, 2 );
 	}
 
 	/**

--- a/projects/packages/podcast/src/endpoints/class-podcast-settings-endpoint.php
+++ b/projects/packages/podcast/src/endpoints/class-podcast-settings-endpoint.php
@@ -107,16 +107,13 @@ class Podcast_Settings_Endpoint extends WP_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function update_item( $request ) {
-		$previous = Settings::get_all();
-		$touched  = array();
-		$saved    = false;
+		$saved = false;
 
 		foreach ( Settings::OPTION_NAMES as $name ) {
 			$value = $request->get_param( $name );
 			if ( null === $value ) {
 				continue;
 			}
-			$touched[] = $name;
 			if ( update_option( $name, $value ) ) {
 				$saved = true;
 			}
@@ -126,16 +123,9 @@ class Podcast_Settings_Endpoint extends WP_REST_Controller {
 			/**
 			 * Fires after a podcast settings write changes at least one option.
 			 *
-			 * Passes only the pre-write snapshot and the touched option names so
-			 * listeners can derive aggregates without re-reading state — never a
-			 * vehicle for the raw values themselves.
-			 *
 			 * @since 1.1.1
-			 *
-			 * @param array    $previous Full settings record captured before the write.
-			 * @param string[] $touched  Option names present in the request payload.
 			 */
-			do_action( 'jetpack_podcast_settings_saved', $previous, $touched );
+			do_action( 'jetpack_podcast_settings_saved' );
 		}
 
 		return rest_ensure_response( Settings::get_all() );

--- a/projects/packages/podcast/src/endpoints/class-podcast-settings-endpoint.php
+++ b/projects/packages/podcast/src/endpoints/class-podcast-settings-endpoint.php
@@ -107,13 +107,16 @@ class Podcast_Settings_Endpoint extends WP_REST_Controller {
 	 * @return WP_REST_Response
 	 */
 	public function update_item( $request ) {
-		$saved = false;
+		$previous = Settings::get_all();
+		$touched  = array();
+		$saved    = false;
 
 		foreach ( Settings::OPTION_NAMES as $name ) {
 			$value = $request->get_param( $name );
 			if ( null === $value ) {
 				continue;
 			}
+			$touched[] = $name;
 			if ( update_option( $name, $value ) ) {
 				$saved = true;
 			}
@@ -123,9 +126,16 @@ class Podcast_Settings_Endpoint extends WP_REST_Controller {
 			/**
 			 * Fires after a podcast settings write changes at least one option.
 			 *
+			 * Passes only the pre-write snapshot and the touched option names so
+			 * listeners can derive aggregates without re-reading state — never a
+			 * vehicle for the raw values themselves.
+			 *
 			 * @since 1.1.1
+			 *
+			 * @param array    $previous Full settings record captured before the write.
+			 * @param string[] $touched  Option names present in the request payload.
 			 */
-			do_action( 'jetpack_podcast_settings_saved' );
+			do_action( 'jetpack_podcast_settings_saved', $previous, $touched );
 		}
 
 		return rest_ensure_response( Settings::get_all() );

--- a/projects/packages/podcast/tests/php/Tracks_Test.php
+++ b/projects/packages/podcast/tests/php/Tracks_Test.php
@@ -292,19 +292,23 @@ class Tracks_Test extends BaseTestCase {
 		$this->assertCount( 1, $this->events_named( 'wpcom_podcasting_show_url_saved' ) );
 	}
 
-	public function test_settings_saved_emits_snapshot_with_pii_redacted() {
-		update_option( 'podcasting_title', 'New Title' );
-		update_option( 'podcasting_email', 'host@example.com' );
-		update_option( 'podcasting_talent_name', 'Jane Host' );
+	public function test_settings_saved_reports_aggregates_not_raw_values() {
+		update_option( 'podcasting_category_id', 42 );
+		update_option( 'podcasting_title', 'My Secret Show Name' );
 
-		Tracks::record_settings_saved();
+		Tracks::record_settings_saved(
+			array( 'podcasting_category_id' => 0 ),
+			array( 'podcasting_category_id', 'podcasting_title' )
+		);
 
 		$events = $this->events_named( 'wpcom_podcasting_settings_saved' );
 		$this->assertCount( 1, $events );
-		$this->assertSame( 'New Title', $events[0]['properties']['podcasting_title'] );
-		// PII is redacted from the payload.
-		$this->assertArrayNotHasKey( 'podcasting_email', $events[0]['properties'] );
-		$this->assertArrayNotHasKey( 'podcasting_talent_name', $events[0]['properties'] );
+		$props = $events[0]['properties'];
+
+		// Derived fields are emitted; raw user-authored content is not.
+		$this->assertTrue( $props['podcasting_enabled'] );
+		$this->assertArrayNotHasKey( 'podcasting_title', $props );
+		$this->assertNotContains( 'My Secret Show Name', $props );
 	}
 
 	public function test_init_wires_settings_saved_recorder() {

--- a/projects/packages/podcast/tests/php/Tracks_Test.php
+++ b/projects/packages/podcast/tests/php/Tracks_Test.php
@@ -38,9 +38,6 @@ class Tracks_Test extends BaseTestCase {
 		delete_option( 'podcasting_archive' );
 		delete_option( 'podcasting_show_urls' );
 		delete_option( 'podcasting_show_states' );
-		delete_option( 'podcasting_title' );
-		delete_option( 'podcasting_email' );
-		delete_option( 'podcasting_talent_name' );
 		delete_option( 'podcast_show_launched_tracked' );
 		wp_cache_flush();
 		WorDBless_Posts::init()->clear_all_posts();
@@ -290,31 +287,5 @@ class Tracks_Test extends BaseTestCase {
 		);
 
 		$this->assertCount( 1, $this->events_named( 'wpcom_podcasting_show_url_saved' ) );
-	}
-
-	public function test_settings_saved_reports_aggregates_not_raw_values() {
-		update_option( 'podcasting_category_id', 42 );
-		update_option( 'podcasting_title', 'My Secret Show Name' );
-
-		Tracks::record_settings_saved(
-			array( 'podcasting_category_id' => 0 ),
-			array( 'podcasting_category_id', 'podcasting_title' )
-		);
-
-		$events = $this->events_named( 'wpcom_podcasting_settings_saved' );
-		$this->assertCount( 1, $events );
-		$props = $events[0]['properties'];
-
-		// Derived fields are emitted; raw user-authored content is not.
-		$this->assertTrue( $props['podcasting_enabled'] );
-		$this->assertArrayNotHasKey( 'podcasting_title', $props );
-	}
-
-	public function test_init_wires_settings_saved_recorder() {
-		Tracks::init();
-
-		$this->assertNotFalse(
-			has_action( 'jetpack_podcast_settings_saved', array( Tracks::class, 'record_settings_saved' ) )
-		);
 	}
 }

--- a/projects/packages/podcast/tests/php/Tracks_Test.php
+++ b/projects/packages/podcast/tests/php/Tracks_Test.php
@@ -308,7 +308,6 @@ class Tracks_Test extends BaseTestCase {
 		// Derived fields are emitted; raw user-authored content is not.
 		$this->assertTrue( $props['podcasting_enabled'] );
 		$this->assertArrayNotHasKey( 'podcasting_title', $props );
-		$this->assertNotContains( 'My Secret Show Name', $props );
 	}
 
 	public function test_init_wires_settings_saved_recorder() {


### PR DESCRIPTION
## Proposed changes

Removes the `wpcom_podcasting_settings_saved` Tracks event. It was sending raw settings values into analytics, and the useful signals (enable/disable, directory submits, launches, publishes) are already covered by the dedicated podcast events — so it added little beyond noise and privacy risk.

## Does this pull request change what data or activity we track or use?

Yes — it removes an analytics event. No new data collected.

## Testing instructions

* `cd projects/packages/podcast && composer phpunit`
