### PR TITLE
Podcast: fix stats labels; stop relabeling stale stats mid-load

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-stats-window
+++ b/projects/packages/podcast/changelog/fix-podcast-stats-window
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Podcast stats: label each panel's time window where it differs from the selected period, and stop relabeling stale stats as the newly selected period while the request is still loading.
+Podcast stats: fix time-window labels and show a loading state instead of stale numbers when switching periods.

--- a/projects/packages/podcast/changelog/fix-podcast-stats-window
+++ b/projects/packages/podcast/changelog/fix-podcast-stats-window
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast stats: label each panel's time window in the All time view, and stop relabeling stale stats as the newly selected period while the request is still loading.

--- a/projects/packages/podcast/changelog/fix-podcast-stats-window
+++ b/projects/packages/podcast/changelog/fix-podcast-stats-window
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Podcast stats: label each panel's time window in the All time view, and stop relabeling stale stats as the newly selected period while the request is still loading.
+Podcast stats: label each panel's time window where it differs from the selected period, and stop relabeling stale stats as the newly selected period while the request is still loading.

--- a/projects/packages/podcast/src/dashboard/stats/components/episode-stats.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/components/episode-stats.tsx
@@ -42,7 +42,9 @@ const EpisodeStats = ( { postId, title, onBack, initialSelection }: EpisodeStats
 					>
 						{ title }
 					</h2>
-					<p className="podcast-stats__section-description">{ getPeriodHeading( selection ) }</p>
+					<p className="podcast-stats__section-description">
+						{ getPeriodHeading( selection, 'episode' ) }
+					</p>
 				</header>
 				<PeriodControl value={ selection } onChange={ setSelection } />
 			</div>

--- a/projects/packages/podcast/src/dashboard/stats/components/period-control.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/components/period-control.tsx
@@ -11,10 +11,18 @@ import '@automattic/ui/style.css';
  * Translated heading for a selection. Preset periods use a fixed label;
  * custom ranges render as "Apr 12 to May 12, 2026".
  *
+ * The 'all' preset differs by surface: the show view has a true lifetime total
+ * ("All time"), while the episode view tops out at the API's 365-day cap
+ * ("Last 12 months").
+ *
  * @param selection - Selection.
+ * @param scope     - 'show' has an all-time total; 'episode' maxes at 365 days.
  * @return          Heading.
  */
-export function getPeriodHeading( selection: PodcastStatsSelection ): string {
+export function getPeriodHeading(
+	selection: PodcastStatsSelection,
+	scope: 'show' | 'episode' = 'show'
+): string {
 	const { period, range } = selection;
 	if ( period === '7d' ) {
 		return __( 'Last 7 days', 'jetpack-podcast' );
@@ -25,11 +33,10 @@ export function getPeriodHeading( selection: PodcastStatsSelection ): string {
 	if ( period === '90d' ) {
 		return __( 'Last 90 days', 'jetpack-podcast' );
 	}
-	// The headline total for 'all' is lifetime, so name the view "All time".
-	// The sub-panels (365-day chart, 30-day breakdowns, 90-day top day) carry
-	// their own scope labels since the API can't report those over all time.
 	if ( period === 'all' ) {
-		return __( 'All time', 'jetpack-podcast' );
+		return scope === 'episode'
+			? __( 'Last 12 months', 'jetpack-podcast' )
+			: __( 'All time', 'jetpack-podcast' );
 	}
 	return formatLabel( localDateFromYmd( range.from ), localDateFromYmd( range.to ), getLocale() );
 }

--- a/projects/packages/podcast/src/dashboard/stats/components/period-control.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/components/period-control.tsx
@@ -25,10 +25,11 @@ export function getPeriodHeading( selection: PodcastStatsSelection ): string {
 	if ( period === '90d' ) {
 		return __( 'Last 90 days', 'jetpack-podcast' );
 	}
-	// 'all' is a 365-day window from the API's cap. Label matches the preset
-	// button the user clicks.
+	// The headline total for 'all' is lifetime, so name the view "All time".
+	// The sub-panels (365-day chart, 30-day breakdowns, 90-day top day) carry
+	// their own scope labels since the API can't report those over all time.
 	if ( period === 'all' ) {
-		return __( 'Last 12 months', 'jetpack-podcast' );
+		return __( 'All time', 'jetpack-podcast' );
 	}
 	return formatLabel( localDateFromYmd( range.from ), localDateFromYmd( range.to ), getLocale() );
 }

--- a/projects/packages/podcast/src/dashboard/stats/components/stats-by-app.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/components/stats-by-app.tsx
@@ -8,19 +8,21 @@ import type { PodcastStatsAppRow } from '../types';
 type StatsByAppProps = {
 	rows?: PodcastStatsAppRow[];
 	isLoading?: boolean;
+	scopeLabel?: string;
 };
 
-const StatsByApp = ( { rows = [], isLoading = false }: StatsByAppProps ) => {
+const StatsByApp = ( { rows = [], isLoading = false, scopeLabel }: StatsByAppProps ) => {
 	const title = __( 'By app', 'jetpack-podcast' );
 
 	if ( isLoading ) {
-		return <SectionCard title={ title } isLoading />;
+		return <SectionCard title={ title } metric={ scopeLabel } isLoading />;
 	}
 
 	if ( rows.length === 0 ) {
 		return (
 			<SectionCard
 				title={ title }
+				metric={ scopeLabel }
 				isEmpty
 				emptyMessage={ __( 'No app data in this period.', 'jetpack-podcast' ) }
 			>
@@ -48,7 +50,7 @@ const StatsByApp = ( { rows = [], isLoading = false }: StatsByAppProps ) => {
 	} );
 
 	return (
-		<SectionCard title={ title }>
+		<SectionCard title={ title } metric={ scopeLabel }>
 			<HorizontalBarList rows={ data } />
 		</SectionCard>
 	);

--- a/projects/packages/podcast/src/dashboard/stats/components/stats-locations.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/components/stats-locations.tsx
@@ -10,19 +10,21 @@ import type { GeoData } from '@automattic/charts';
 type StatsLocationsProps = {
 	rows?: PodcastStatsCountryRow[];
 	isLoading?: boolean;
+	scopeLabel?: string;
 };
 
-const StatsLocations = ( { rows = [], isLoading = false }: StatsLocationsProps ) => {
+const StatsLocations = ( { rows = [], isLoading = false, scopeLabel }: StatsLocationsProps ) => {
 	const title = __( 'By location', 'jetpack-podcast' );
 
 	if ( isLoading ) {
-		return <SectionCard title={ title } isLoading />;
+		return <SectionCard title={ title } metric={ scopeLabel } isLoading />;
 	}
 
 	if ( rows.length === 0 ) {
 		return (
 			<SectionCard
 				title={ title }
+				metric={ scopeLabel }
 				isEmpty
 				emptyMessage={ __( 'No country data in this period.', 'jetpack-podcast' ) }
 			>
@@ -59,7 +61,7 @@ const StatsLocations = ( { rows = [], isLoading = false }: StatsLocationsProps )
 	} );
 
 	return (
-		<SectionCard title={ title } className="podcast-stats-locations">
+		<SectionCard title={ title } metric={ scopeLabel } className="podcast-stats-locations">
 			<div className="podcast-stats-locations__grid">
 				<div className="podcast-stats-locations__map">
 					<GeoChart data={ mapData } region="world" height={ 480 } />

--- a/projects/packages/podcast/src/dashboard/stats/components/stats-top-episodes.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/components/stats-top-episodes.tsx
@@ -7,24 +7,27 @@ import type { PodcastStatsTopEpisode } from '../types';
 type StatsTopEpisodesProps = {
 	episodes?: PodcastStatsTopEpisode[];
 	isLoading?: boolean;
+	scopeLabel?: string;
 	onSelect?: ( episode: PodcastStatsTopEpisode ) => void;
 };
 
 const StatsTopEpisodes = ( {
 	episodes = [],
 	isLoading = false,
+	scopeLabel,
 	onSelect,
 }: StatsTopEpisodesProps ) => {
 	const title = __( 'Top episodes', 'jetpack-podcast' );
 
 	if ( isLoading ) {
-		return <SectionCard title={ title } isLoading />;
+		return <SectionCard title={ title } metric={ scopeLabel } isLoading />;
 	}
 
 	if ( episodes.length === 0 ) {
 		return (
 			<SectionCard
 				title={ title }
+				metric={ scopeLabel }
 				isEmpty
 				emptyMessage={ __( 'No episode downloads in this period.', 'jetpack-podcast' ) }
 			>
@@ -48,7 +51,7 @@ const StatsTopEpisodes = ( {
 	} );
 
 	return (
-		<SectionCard title={ title }>
+		<SectionCard title={ title } metric={ scopeLabel }>
 			<HorizontalBarList rows={ data } />
 		</SectionCard>
 	);

--- a/projects/packages/podcast/src/dashboard/stats/components/summary-tiles.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/components/summary-tiles.tsx
@@ -18,8 +18,10 @@ type SummaryTilesProps = {
 	byApp?: PodcastStatsAppRow[];
 	byCountry?: PodcastStatsCountryRow[];
 	topDay?: PodcastStatsTopDay | null;
-	// Scope note for the Top day tile when its window differs from the selected
-	// period (top_day always reflects the last 90 days).
+	// Scope note for the Top app / Top country tiles when their window differs
+	// from the selected period (the All time view sources them from a 30-day snapshot).
+	breakdownScope?: string;
+	// Scope note for the Top day tile; top_day always reflects the last 90 days.
 	topDayScope?: string;
 	isLoading?: boolean;
 };
@@ -36,6 +38,7 @@ const SummaryTiles = ( {
 	byApp = [],
 	byCountry = [],
 	topDay,
+	breakdownScope,
 	topDayScope,
 	isLoading = false,
 }: SummaryTilesProps ) => {
@@ -53,6 +56,7 @@ const SummaryTiles = ( {
 			heading: __( 'Top app', 'jetpack-podcast' ),
 			value: loadingValue ?? ( topApp ? formatAppName( topApp.app ) : EMPTY_VALUE ),
 			note: ! loadingValue && topApp ? formatPct( topApp.pct ) : undefined,
+			scope: ! loadingValue ? breakdownScope : undefined,
 		},
 		{
 			heading: __( 'Top country', 'jetpack-podcast' ),
@@ -60,6 +64,7 @@ const SummaryTiles = ( {
 				loadingValue ??
 				( topCountry ? getCountryName( topCountry.country, unknownCountry ) : EMPTY_VALUE ),
 			note: ! loadingValue && topCountry ? formatPct( topCountry.pct ) : undefined,
+			scope: ! loadingValue ? breakdownScope : undefined,
 		},
 		{
 			heading: __( 'Top day', 'jetpack-podcast' ),

--- a/projects/packages/podcast/src/dashboard/stats/components/summary-tiles.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/components/summary-tiles.tsx
@@ -18,6 +18,9 @@ type SummaryTilesProps = {
 	byApp?: PodcastStatsAppRow[];
 	byCountry?: PodcastStatsCountryRow[];
 	topDay?: PodcastStatsTopDay | null;
+	// Scope note for the Top day tile when its window differs from the selected
+	// period (top_day always reflects the last 90 days).
+	topDayScope?: string;
 	isLoading?: boolean;
 };
 
@@ -25,6 +28,7 @@ type Tile = {
 	heading: string;
 	value: string;
 	note?: string;
+	scope?: string;
 };
 
 const SummaryTiles = ( {
@@ -32,6 +36,7 @@ const SummaryTiles = ( {
 	byApp = [],
 	byCountry = [],
 	topDay,
+	topDayScope,
 	isLoading = false,
 }: SummaryTilesProps ) => {
 	const topApp = byApp[ 0 ];
@@ -67,6 +72,7 @@ const SummaryTiles = ( {
 							formatNumber( topDay.plays )
 					  )
 					: undefined,
+			scope: ! loadingValue ? topDayScope : undefined,
 		},
 	];
 
@@ -88,6 +94,11 @@ const SummaryTiles = ( {
 					{ tile.note && (
 						<Text size={ 12 } variant="muted">
 							{ tile.note }
+						</Text>
+					) }
+					{ tile.scope && (
+						<Text size={ 12 } variant="muted">
+							{ tile.scope }
 						</Text>
 					) }
 				</VStack>

--- a/projects/packages/podcast/src/dashboard/stats/index.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/index.tsx
@@ -126,6 +126,13 @@ const Stats = () => {
 	// Gate the full empty state on all-time plays so a quiet period doesn't masquerade as a new show.
 	const isEmpty = ! isLoading && ! isError && stats?.all_time_plays === 0;
 
+	// The "All time" view stitches together windows the API can't report over
+	// all time: 30-day breakdowns and a 90-day top day. Label those scopes so
+	// each panel is honest about its window rather than inheriting the heading.
+	const isAllTime = selection.period === 'all';
+	const breakdownScope = isAllTime ? __( 'Last 30 days', 'jetpack-podcast' ) : undefined;
+	const topDayScope = isAllTime ? __( 'Last 90 days', 'jetpack-podcast' ) : undefined;
+
 	return (
 		<div className="podcast-stats podcast-stats--stack">
 			<div className="podcast-stats__header">
@@ -179,6 +186,7 @@ const Stats = () => {
 								byApp={ stats?.by_app }
 								byCountry={ stats?.by_country }
 								topDay={ stats?.top_day }
+								topDayScope={ topDayScope }
 								isLoading={ isLoading }
 								layout="chart"
 							/>
@@ -188,11 +196,20 @@ const Stats = () => {
 						<StatsTopEpisodes
 							episodes={ stats?.top_episodes }
 							isLoading={ isLoading }
+							scopeLabel={ breakdownScope }
 							onSelect={ handleSelect }
 						/>
-						<StatsByApp rows={ stats?.by_app } isLoading={ isLoading } />
+						<StatsByApp
+							rows={ stats?.by_app }
+							isLoading={ isLoading }
+							scopeLabel={ breakdownScope }
+						/>
 					</div>
-					<StatsLocations rows={ stats?.by_country } isLoading={ isLoading } />
+					<StatsLocations
+						rows={ stats?.by_country }
+						isLoading={ isLoading }
+						scopeLabel={ breakdownScope }
+					/>
 				</>
 			) }
 		</div>

--- a/projects/packages/podcast/src/dashboard/stats/index.tsx
+++ b/projects/packages/podcast/src/dashboard/stats/index.tsx
@@ -126,12 +126,13 @@ const Stats = () => {
 	// Gate the full empty state on all-time plays so a quiet period doesn't masquerade as a new show.
 	const isEmpty = ! isLoading && ! isError && stats?.all_time_plays === 0;
 
-	// The "All time" view stitches together windows the API can't report over
-	// all time: 30-day breakdowns and a 90-day top day. Label those scopes so
-	// each panel is honest about its window rather than inheriting the heading.
+	// Some panels report over a window the API fixes regardless of the selection,
+	// so label those scopes when they differ from the heading. The All time view
+	// sources its breakdowns from a 30-day snapshot; top_day is always 90 days.
 	const isAllTime = selection.period === 'all';
 	const breakdownScope = isAllTime ? __( 'Last 30 days', 'jetpack-podcast' ) : undefined;
-	const topDayScope = isAllTime ? __( 'Last 90 days', 'jetpack-podcast' ) : undefined;
+	const topDayScope =
+		selection.period !== '90d' ? __( 'Last 90 days', 'jetpack-podcast' ) : undefined;
 
 	return (
 		<div className="podcast-stats podcast-stats--stack">
@@ -186,9 +187,9 @@ const Stats = () => {
 								byApp={ stats?.by_app }
 								byCountry={ stats?.by_country }
 								topDay={ stats?.top_day }
+								breakdownScope={ breakdownScope }
 								topDayScope={ topDayScope }
 								isLoading={ isLoading }
-								layout="chart"
 							/>
 						}
 					/>

--- a/projects/packages/podcast/src/dashboard/stats/use-show-stats-query.ts
+++ b/projects/packages/podcast/src/dashboard/stats/use-show-stats-query.ts
@@ -103,9 +103,14 @@ export function useShowStatsQuery(
 
 	const isError = overviewError || summaryError;
 
-	// Wait for both queries — keeps prior data on screen across period changes.
+	// The summary effect refetches on range change but leaves the previous
+	// response in state until the new one resolves. Compose only once the loaded
+	// summary actually covers the selected range; otherwise a period switch would
+	// relabel stale data as the new range and report isLoading:false mid-flight.
+	const summaryMatchesSelection = summary?.range?.from === from && summary?.range?.to === to;
+
 	let data: PodcastShowStats | undefined;
-	if ( summary && overview ) {
+	if ( summary && overview && summaryMatchesSelection ) {
 		const presetTotal = getOverviewTotal( overview, period );
 		data = {
 			...summary,

--- a/projects/packages/podcast/src/dashboard/stats/use-show-stats-query.ts
+++ b/projects/packages/podcast/src/dashboard/stats/use-show-stats-query.ts
@@ -107,7 +107,7 @@ export function useShowStatsQuery(
 	// response in state until the new one resolves. Compose only once the loaded
 	// summary actually covers the selected range; otherwise a period switch would
 	// relabel stale data as the new range and report isLoading:false mid-flight.
-	const summaryMatchesSelection = summary?.range?.from === from && summary?.range?.to === to;
+	const summaryMatchesSelection = summary?.range.from === from && summary?.range.to === to;
 
 	let data: PodcastShowStats | undefined;
 	if ( summary && overview && summaryMatchesSelection ) {


### PR DESCRIPTION
## What

Three fixes to the podcast Stats surface.

**1. Rename the "All time" heading and label mismatched windows.**
The API reports some panels over fixed windows regardless of the selected period: breakdowns and top episodes cover the last 30 days, and the top day covers the last 90 days. In the widest ("All time") view these were all shown under one heading with no note. Now the heading reads **All time** to match the all-time total, and the panels whose window differs carry a small scope label ("Last 30 days" / "Last 90 days").

**2. Don't show stale numbers while switching periods.**
Changing the period used to keep the previous data on screen, relabeled as the new range, until the new request finished. Now the panels show a loading state until the data for the selected range arrives.

**3. Keep the episode drilldown's heading accurate.**
The episode view's widest window is 365 days, not all-time, so it keeps the **Last 12 months** heading instead of inheriting the show's "All time" label.

## Does this pull request change what data or activity we track or use?

No

## Testing instructions:

* Open the podcast **Stats** tab on a WordPress.com-connected site.
* Select **All time** and confirm the heading reads "All time", with "Last 30 days" on By app / Top episodes / By location and "Last 90 days" on Top day.
* Switch between presets (e.g. 30 days ↔ All time) with the network throttled — panels should show a loading state, not the previous range's numbers.
* Open an episode from the Episodes tab and confirm its heading reads "Last 12 months", not "All time".
