### PR TITLE
Activity Log: register wp-build polyfills so the admin bundle loads

### DIFF
--- a/projects/packages/activity-log/changelog/fix-activity-log-blank
+++ b/projects/packages/activity-log/changelog/fix-activity-log-blank
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Register wp-build polyfills so the admin bundle loads on WordPress versions that don't provide the wp-theme script handle

--- a/projects/packages/activity-log/composer.json
+++ b/projects/packages/activity-log/composer.json
@@ -10,7 +10,8 @@
 		"automattic/jetpack-autoloader": "@dev",
 		"automattic/jetpack-composer-plugin": "@dev",
 		"automattic/jetpack-connection": "@dev",
-		"automattic/jetpack-status": "@dev"
+		"automattic/jetpack-status": "@dev",
+		"automattic/jetpack-wp-build-polyfills": "@dev"
 	},
 	"require-dev": {
 		"automattic/jetpack-changelogger": "@dev",

--- a/projects/packages/activity-log/src/class-jetpack-activity-log.php
+++ b/projects/packages/activity-log/src/class-jetpack-activity-log.php
@@ -16,6 +16,7 @@ use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills;
 use function add_action;
 use function add_filter;
 use function current_user_can;
@@ -145,6 +146,21 @@ class Jetpack_Activity_Log {
 				REST_Controller::clear_access_cache();
 			}
 		}
+
+		// The admin bundle depends on `@wordpress/*` handles (e.g. `wp-theme`,
+		// pulled in via `@wordpress/ui`) that Core does not register on older
+		// WordPress versions. Without them, WP_Scripts silently drops the
+		// bundle and the page renders as an empty root node. Register the
+		// polyfills here so this only runs on the Activity Log screen — the
+		// register() call can force-replace Core handles, so it must stay
+		// page-scoped rather than firing on every admin request.
+		WP_Build_Polyfills::register(
+			'jetpack-activity-log',
+			array_merge(
+				WP_Build_Polyfills::SCRIPT_HANDLES,
+				WP_Build_Polyfills::MODULE_IDS
+			)
+		);
 
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_admin_scripts' ) );
 	}

--- a/projects/plugins/jetpack/changelog/fix-activity-log-blank
+++ b/projects/plugins/jetpack/changelog/fix-activity-log-blank
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Composer lock update
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -196,7 +196,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/activity-log",
-                "reference": "78c58dc683e5907f6e355f0d394c833412351d26"
+                "reference": "3e2c129b691220b22eca31e6f1299d5b653c2420"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -205,6 +205,7 @@
                 "automattic/jetpack-composer-plugin": "@dev",
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-status": "@dev",
+                "automattic/jetpack-wp-build-polyfills": "@dev",
                 "php": ">=7.2"
             },
             "require-dev": {


### PR DESCRIPTION
Fixes #

## Proposed changes
* The Activity Log admin bundle depends on the `wp-theme` script handle (introduced when `@wordpress/ui` was bumped 0.13 → 0.17 [here](https://github.com/Automattic/jetpack/pull/49272), which now depends on `@wordpress/theme`). WordPress core does not register that handle, so `WP_Scripts::do_items()` silently dropped the entire bundle and the page rendered as an empty root node — no console error.
* Register the wp-build polyfills on the Activity Log screen via `WP_Build_Polyfills::register()`, mirroring the pattern already used by Forms, Backup, and My Jetpack. The call runs in `admin_init()` (hooked to `load-{page_suffix}`), so it stays page-scoped and never touches other admin requests.
* Added `automattic/jetpack-wp-build-polyfills` to the activity-log package's `composer.json`.

Note: this only affects trunk. The `@wordpress/ui` 0.17 bump is not part of the `jetpack/branch-16.0.1` release (which still pins 0.13), so shipped Activity Log builds are unaffected.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a site running WordPress without Gutenberg active (e.g. WP 6.9.x), connect Jetpack as a user and ensure the Activity Log menu item is available.
* Navigate to **Jetpack → Activity Log** (`wp-admin/admin.php?page=jetpack-activity-log`).
* Confirm the page renders the full Activity Log UI — the searchable DataViews timeline with events, filters, and pagination — rather than a blank content area.
* Optionally, view source / inspect the network panel and confirm both the activity-log `build/index.js` bundle and the `wp-theme` polyfill script are loaded.
