### PR TITLE
Newsletter: fix intermittent dashboard FOUC on Firefox

### DIFF
--- a/projects/packages/newsletter/changelog/fix-newsletter-dashboard-firefox-fouc
+++ b/projects/packages/newsletter/changelog/fix-newsletter-dashboard-firefox-fouc
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix an intermittent flash of unstyled content on the Newsletter dashboard in Firefox.

--- a/projects/packages/newsletter/routes/dashboard/route.scss
+++ b/projects/packages/newsletter/routes/dashboard/route.scss
@@ -1,5 +1,5 @@
-@use "sass:meta";
-@include meta.load-css("@wordpress/dataviews/build-style/style.css");
+// The DataViews CSS this route needs arrives via `src/settings/style.scss`,
+// which `stage.tsx` also imports — loading it here too would double-ship it.
 
 // Subscriber identity cell.
 // TODO: drop the manual color override once a design-system "muted text" tone

--- a/projects/packages/newsletter/src/settings/style.scss
+++ b/projects/packages/newsletter/src/settings/style.scss
@@ -1,9 +1,19 @@
 @use "@automattic/jetpack-base-styles/admin-page-layout" as *;
 @use "sass:meta";
 
-// Import dataviews styles for DataForm component
-@import "@wordpress/theme/design-tokens.css";
-@import "@wordpress/dataviews/build-style/style.css";
+// NB: do NOT `@import "@wordpress/…css"` here. Sass passes `.css` `@import`s
+// through as literal CSS `@import` at-rules, and — because this stylesheet is
+// JS-injected as a single `<style>` at runtime — any `@import` lands at the top
+// of the same tag that carries the `jetpack-admin-page-layout` mixin below.
+// Firefox refuses to apply ANY rule from a stylesheet with pending imports, so
+// the whole layout stays inert until the imports resolve, producing an
+// intermittent FOUC where the page paints unstyled (content under the admin
+// menu, tabs mis-inset) and then snaps into place. The two imports that used to
+// live here also resolved to 404s (bare specifiers against `/wp-admin/…`) and
+// were redundant: DataViews CSS is inlined via `routes/dashboard/route.scss`'s
+// `meta.load-css`, and the theme design tokens come from `wp-components` et al.
+// Every other wp-build dashboard (Social, Forms, VideoPress) keeps its mixin
+// SCSS import-free for exactly this reason.
 @include meta.load-css("./sections/placement-card");
 
 body.jetpack_page_jetpack-newsletter {

--- a/projects/packages/newsletter/src/settings/style.scss
+++ b/projects/packages/newsletter/src/settings/style.scss
@@ -1,19 +1,22 @@
 @use "@automattic/jetpack-base-styles/admin-page-layout" as *;
 @use "sass:meta";
 
-// NB: do NOT `@import "@wordpress/…css"` here. Sass passes `.css` `@import`s
-// through as literal CSS `@import` at-rules, and — because this stylesheet is
-// JS-injected as a single `<style>` at runtime — any `@import` lands at the top
-// of the same tag that carries the `jetpack-admin-page-layout` mixin below.
-// Firefox refuses to apply ANY rule from a stylesheet with pending imports, so
-// the whole layout stays inert until the imports resolve, producing an
-// intermittent FOUC where the page paints unstyled (content under the admin
-// menu, tabs mis-inset) and then snaps into place. The two imports that used to
-// live here also resolved to 404s (bare specifiers against `/wp-admin/…`) and
-// were redundant: DataViews CSS is inlined via `routes/dashboard/route.scss`'s
-// `meta.load-css`, and the theme design tokens come from `wp-components` et al.
-// Every other wp-build dashboard (Social, Forms, VideoPress) keeps its mixin
-// SCSS import-free for exactly this reason.
+// This stylesheet feeds two bundles: the wp-build dashboard
+// (`routes/dashboard/stage.tsx`) and the legacy settings page
+// (`src/settings/index.tsx`, the `newsletter` webpack entry, still served when
+// a site opts out via `rsm_jetpack_ui_modernization_newsletter`). Load shared
+// CSS with `meta.load-css`, never a literal `@import "….css"`:
+// - Sass passes `.css` `@import`s through as literal CSS at-rules. On the
+//   wp-build path they survive to runtime, where the bare specifiers resolve
+//   against `/wp-admin/…` and 404. Firefox applies NO rule from a stylesheet
+//   with pending imports, so the `jetpack-admin-page-layout` mixin below stays
+//   inert until they settle — an intermittent FOUC where the page paints
+//   unstyled (content under the admin menu, tabs mis-inset), then snaps in.
+// - `meta.load-css` inlines at Sass compile time, so both bundles get the rules
+//   and no runtime `@import` ever reaches the browser.
+// The DataViews CSS is required, not decorative: the sections below render
+// `DataForm`, which needs it for layout and spacing on both pages.
+@include meta.load-css("@wordpress/dataviews/build-style/style.css");
 @include meta.load-css("./sections/placement-card");
 
 body.jetpack_page_jetpack-newsletter {


### PR DESCRIPTION
Fixes JETPACK-1922

## Proposed changes
* Removes two broken `@import` at-rules from the modernized Newsletter dashboard's layout stylesheet (`projects/packages/newsletter/src/settings/style.scss`) that were causing an intermittent flash of unstyled content (FOUC) on Firefox.

### Root cause
The modernized dashboard's layout stylesheet is JS-injected as a single `<style>` tag at runtime. `src/settings/style.scss` — the file carrying the shared `jetpack-admin-page-layout` mixin — began with:

```scss
@import "@wordpress/theme/design-tokens.css";
@import "@wordpress/dataviews/build-style/style.css";
```

Sass passes `.css` `@import`s through as literal CSS `@import` at-rules, so they landed at the top of the same injected tag as the mixin. As bare specifiers they resolved to **404s** (`/wp-admin/@wordpress/…`). **Firefox refuses to apply any rule from a stylesheet while it has pending `@import`s**, so the entire layout (fixed `#wpbody-content` offset, `.jp-admin-page` margin, tab-strip inset) stayed inert until the two failed network fetches settled — painting the page unstyled (content tucked under the admin menu, tabs mis-inset) and then snapping into place. The race made it intermittent; Chrome applies eagerly and rarely showed it.

Both imports were also **redundant**: DataViews CSS is already inlined via `routes/dashboard/route.scss`'s `meta.load-css`, and the `@wordpress/theme` design tokens are provided by `wp-components` and other render-blocking handles. Every other wp-build dashboard (Social, Forms, VideoPress) keeps its mixin SCSS import-free for exactly this reason — which is why none of them exhibit the flash.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* This affects the modernized Newsletter dashboard, which is on by default.
* Open **Firefox** (the bug is Firefox-specific; Chrome coalesces the flash away).
* Navigate to **Jetpack → Newsletter** (`wp-admin/admin.php?page=jetpack-newsletter`).
* Hard-reload the page (`Ctrl/Cmd+Shift+R`) several times in a row.
* **Before this change:** on many loads the page content briefly renders shifted left under the admin menu / with the tab strip mis-positioned, then snaps into place.
* **After this change:** the header, tabs, and content render correctly on every load — no flash.
* Also confirm no regression: the DataViews subscribers table and the Settings tab (which uses DataForm) still render fully styled, and the layout (fixed column, pinned footer) is unchanged in both Firefox and Chrome.
