### PR TITLE
Premium Analytics: reveal the Top posts external-link icon on row hover

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-top-posts-link-hover-affordances
+++ b/projects/packages/premium-analytics/changelog/add-top-posts-link-hover-affordances
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Top posts: reveal the external-link icon on row hover/focus and hide the link primitive's duplicate new-tab arrow.

--- a/projects/packages/premium-analytics/widgets/top-posts/__tests__/top-posts.test.tsx
+++ b/projects/packages/premium-analytics/widgets/top-posts/__tests__/top-posts.test.tsx
@@ -123,6 +123,9 @@ describe( 'TopPostsWidget', () => {
 			name: /open hello world post in a new tab/i,
 		} );
 		expect( externalLink ).toHaveAttribute( 'href', 'https://example.com/hello-world/' );
+		expect( externalLink ).toHaveAttribute( 'target', '_blank' );
+		expect( externalLink ).toHaveAttribute( 'rel', 'noopener noreferrer' );
+		expect( screen.queryByLabelText( '(opens in a new tab)' ) ).not.toBeInTheDocument();
 
 		expect( screen.getByText( 'About Page' ) ).toBeInTheDocument();
 	} );

--- a/projects/packages/premium-analytics/widgets/top-posts/render.tsx
+++ b/projects/packages/premium-analytics/widgets/top-posts/render.tsx
@@ -143,11 +143,11 @@ function buildLeaderboardData(
 						</Text>
 					) }
 					{ externalLink && (
-						<a
+						<Link
 							className={ styles.externalLink }
 							href={ row.href }
-							target="_blank"
-							rel="noopener noreferrer"
+							variant="unstyled"
+							render={ <a target="_blank" rel="noopener noreferrer" /> }
 							aria-label={ sprintf(
 								/* translators: %s is a post, page, or archive page title. */
 								__( 'Open %s in a new tab', 'jetpack-premium-analytics' ),
@@ -155,7 +155,7 @@ function buildLeaderboardData(
 							) }
 						>
 							<Icon icon={ external } size={ 16 } />
-						</a>
+						</Link>
 					) }
 				</span>
 			),

--- a/projects/packages/premium-analytics/widgets/top-posts/render.tsx
+++ b/projects/packages/premium-analytics/widgets/top-posts/render.tsx
@@ -143,11 +143,11 @@ function buildLeaderboardData(
 						</Text>
 					) }
 					{ externalLink && (
-						<Link
+						<a
 							className={ styles.externalLink }
 							href={ row.href }
-							variant="unstyled"
-							openInNewTab
+							target="_blank"
+							rel="noopener noreferrer"
 							aria-label={ sprintf(
 								/* translators: %s is a post, page, or archive page title. */
 								__( 'Open %s in a new tab', 'jetpack-premium-analytics' ),
@@ -155,7 +155,7 @@ function buildLeaderboardData(
 							) }
 						>
 							<Icon icon={ external } size={ 16 } />
-						</Link>
+						</a>
 					) }
 				</span>
 			),

--- a/projects/packages/premium-analytics/widgets/top-posts/style.module.css
+++ b/projects/packages/premium-analytics/widgets/top-posts/style.module.css
@@ -65,6 +65,7 @@
 	flex: none;
 	color: var(--wpds-color-foreground-content-neutral-weak, currentColor);
 	opacity: 0;
+	transition: opacity 120ms ease-in-out;
 }
 
 .labelRow:hover .externalLink,
@@ -73,19 +74,12 @@
 }
 
 .externalLink:hover,
-.externalLink:focus {
+.externalLink:focus-visible {
 	color: inherit;
 }
 
-/* The widget draws its own external glyph (an svg); hide the Link
-   primitive's auto-appended new-tab arrow span so the icon doesn't double
-   up. */
-.externalLink span[role="img"] {
-	display: none;
-}
-
-/* No hover on touch: keep the icon visible so the affordance isn't lost. */
-@media (hover: none) {
+/* Touch-capable devices: keep the icon visible so the affordance isn't lost. */
+@media (hover: none), (any-pointer: coarse) {
 
 	.externalLink {
 		opacity: 1;

--- a/projects/packages/premium-analytics/widgets/top-posts/style.module.css
+++ b/projects/packages/premium-analytics/widgets/top-posts/style.module.css
@@ -56,16 +56,40 @@
 	text-decoration: underline;
 }
 
-/* Trailing external-link icon: opens the public page in a new tab. */
+/* Trailing external-link icon: opens the public page in a new tab. Hidden
+   until the row is hovered (or holds keyboard focus) so the resting rows read
+   as plain titles; opacity keeps the slot in the layout and the target
+   tappable, so nothing shifts on reveal. */
 .externalLink {
 	display: inline-flex;
 	flex: none;
 	color: var(--wpds-color-foreground-content-neutral-weak, currentColor);
+	opacity: 0;
+}
+
+.labelRow:hover .externalLink,
+.labelRow:focus-within .externalLink {
+	opacity: 1;
 }
 
 .externalLink:hover,
 .externalLink:focus {
 	color: inherit;
+}
+
+/* The widget draws its own external glyph (an svg); hide the Link
+   primitive's auto-appended new-tab arrow span so the icon doesn't double
+   up. */
+.externalLink span[role="img"] {
+	display: none;
+}
+
+/* No hover on touch: keep the icon visible so the affordance isn't lost. */
+@media (hover: none) {
+
+	.externalLink {
+		opacity: 1;
+	}
 }
 
 :global([inert]:not([inert="true"])) .root {


### PR DESCRIPTION
Related to [WOOA7S-1622](https://linear.app/a8c/issue/WOOA7S-1622/page-postpage-detail-traffic-view) (post detail polish).

## Why

Top posts rows carry two affordances: the title links internally to the post detail page, and a trailing icon opens the public page in a new tab. With the icon always visible, every row reads as "two links" at rest.

## Proposed changes

* The external-link icon now rests hidden and fades in when the row is hovered or holds keyboard focus (`:focus-within`), so resting rows read as plain titles. `opacity` keeps the slot in the layout — nothing shifts on reveal — and keeps the target tappable.
* Touch-capable devices keep the icon always visible via `@media (hover: none), (any-pointer: coarse)`: with no reliable hover trigger, hiding it would remove the affordance entirely.
* Render the trailing external icon link with the `@wordpress/ui` `Link` primitive and its `render` prop (`render={ <a target="_blank" rel="noopener noreferrer" /> }`). This keeps the primitive's wp-admin CSS defenses and focus styles while avoiding its auto-appended new-tab arrow.
* The internal title link's hover/focus underline is unchanged.

## Does this pull request change what data or activity we track or use?

No. CSS/rendering-only.

## Testing instructions

* Build: `pnpm jetpack build packages/premium-analytics --deps && pnpm jetpack build plugins/premium-analytics`.
* Open the dashboard's Top posts card: rows rest with plain titles; hovering a row fades in the trailing new-tab icon; tabbing through the row's links also reveals it.
* The icon shows a single external glyph (no doubled `↗`), muted at rest and darkening on its own hover/focus.
* In responsive/touch emulation (`hover: none`) or a coarse-pointer/hybrid touch setup, the icon is always visible.
* `pnpm run test widgets/top-posts` from `projects/packages/premium-analytics`.

|Before|After|
|-|-|
|<img width="606" height="648" alt="截圖 2026-07-16 上午9 55 39" src="https://github.com/user-attachments/assets/1729ab19-29d1-444d-8058-7f099014616f" />|<img width="615" height="650" alt="截圖 2026-07-16 上午10 06 40" src="https://github.com/user-attachments/assets/83ae48e9-f2e0-4275-b15f-92f61158a5c5" />|

🤖 Generated with [Claude Code](https://claude.com/claude-code)
