### PR TITLE
Premium Analytics: move the post detail date filters below the tab bar

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-post-detail-filters-below-tabs
+++ b/projects/packages/premium-analytics/changelog/add-post-detail-filters-below-tabs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Post detail: move the date filters directly below the tab bar, mirroring the dashboard's placement.

--- a/projects/packages/premium-analytics/routes/post-detail/components/post-detail-tabs/post-detail-tabs.module.scss
+++ b/projects/packages/premium-analytics/routes/post-detail/components/post-detail-tabs/post-detail-tabs.module.scss
@@ -1,10 +1,3 @@
 .tabList {
 	padding-inline: var(--wpds-dimension-padding-2xl);
 }
-
-// The page header row below owns the spacing (its own 40px block padding),
-// so drop SectionTabs' default bottom margin. Doubled class to outrank the
-// shared `.tabList` rule regardless of bundle order.
-.tabList.tabList {
-	margin-block-end: 0;
-}

--- a/projects/packages/premium-analytics/routes/post-detail/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.module.scss
@@ -14,46 +14,19 @@
 	padding-inline: var(--wpds-dimension-padding-2xl);
 }
 
-.header {
-	// One row below the tab bar: summary left, date filters right. Wraps the
-	// filters onto their own line when the row gets narrow. Inline padding
-	// matches the tabs and widget grid; the 40px block spacing is the
-	// design's breathing room around the whole header row.
-	display: flex;
-	align-items: center;
-	justify-content: space-between;
-	flex-wrap: wrap;
-	gap: var(--wpds-dimension-gap-lg);
-	container-type: inline-size;
-	padding-block: 40px;
+.dateFilters {
+	// Sits directly below the tab bar, mirroring the main dashboard's
+	// placement. The tab list already adds a bottom margin, so only pad below
+	// here to keep the spacing even; inline padding matches the tabs and the
+	// widget grid so it lines up.
+	padding-block-end: var(--wpds-dimension-gap-lg);
 	padding-inline: var(--wpds-dimension-padding-2xl);
 }
 
-.summary {
-	flex: 1 1 360px;
-	min-inline-size: min(100%, 320px);
-}
-
-.dateFilters {
-	display: flex;
-	flex: 0 1 auto;
-	justify-content: flex-end;
-	min-inline-size: min(100%, 600px);
-}
-
-@container (max-width: 960px) {
-
-	.summary,
-	.dateFilters {
-		flex-basis: 100%;
-		min-inline-size: 0;
-	}
-
-	.dateFilters {
-		justify-content: flex-start;
-	}
-
-	.dateFilters :global(.date-filters-panel) {
-		inline-size: 100%;
-	}
+.header {
+	// The summary header below the filters. 16px on top stacks with the
+	// filters row's 16px bottom padding to 32px of space above the heading;
+	// 32px below mirrors it symmetrically.
+	padding-block: var(--wpds-dimension-gap-lg) 32px;
+	padding-inline: var(--wpds-dimension-padding-2xl);
 }

--- a/projects/packages/premium-analytics/routes/post-detail/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.module.scss
@@ -24,9 +24,9 @@
 }
 
 .header {
-	// The summary header below the filters. 16px on top stacks with the
-	// filters row's 16px bottom padding to 32px of space above the heading;
-	// 32px below mirrors it symmetrically.
-	padding-block: var(--wpds-dimension-gap-lg) 32px;
+	// The summary header below the filters. The top gap stacks with the
+	// filters row's bottom padding (gap-lg + gap-lg = gap-2xl of space above
+	// the heading); gap-2xl below mirrors it symmetrically.
+	padding-block: var(--wpds-dimension-gap-lg) var(--wpds-dimension-gap-2xl);
 	padding-inline: var(--wpds-dimension-padding-2xl);
 }

--- a/projects/packages/premium-analytics/routes/post-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.tsx
@@ -97,29 +97,21 @@ function PostDetail(): JSX.Element {
 				>
 					<PostDetailTabs tabs={ tabs } value={ activeTab } onChange={ setActiveTab }>
 						{ /*
-						 * The summary card and date filters are shared by every tab
+						 * The date filters and the summary card are shared by every tab
 						 * (same post, same date range), so they render once below the
-						 * tab bar and above the per-tab widget grid — one header row,
-						 * summary left, filters right (wrapping onto their own line
-						 * when the row gets narrow).
+						 * tab bar and above the per-tab widget grid. The filters sit
+						 * directly under the tabs, mirroring the main dashboard's
+						 * placement, with the summary header below them.
 						 *
-						 * The header row is also the responsive-measurement target:
-						 * DateFiltersPanel reads its width to pick mobile/wide layouts
-						 * instead of relying on the viewport. Measuring the row (not
-						 * the filters' own wrapper) keeps the measurement stable: the
-						 * panel only sits beside the summary when its intrinsic width
-						 * fits, and once wrapped it really has the row's full width.
+						 * The filters wrapper is also the responsive-measurement
+						 * target: DateFiltersPanel reads its width to pick mobile/wide
+						 * layouts instead of relying on the viewport.
 						 */ }
-						<div ref={ setContainerElement } className={ styles.header }>
-							<div className={ styles.summary }>
-								<PostSummaryCard
-									summary={ summary }
-									performanceRange={ dateFilters.appliedRange }
-								/>
-							</div>
-							<div className={ styles.dateFilters }>
-								<DateFiltersPanel { ...dateFilters } containerElement={ containerElement } />
-							</div>
+						<div ref={ setContainerElement } className={ styles.dateFilters }>
+							<DateFiltersPanel { ...dateFilters } containerElement={ containerElement } />
+						</div>
+						<div className={ styles.header }>
+							<PostSummaryCard summary={ summary } performanceRange={ dateFilters.appliedRange } />
 						</div>
 						{ tabs.map( tab => (
 							<SectionTabPanel key={ tab.id } value={ tab.id } className={ styles.content }>


### PR DESCRIPTION
Part of [WOOA7S-1622](https://linear.app/a8c/issue/WOOA7S-1622/page-postpage-detail-traffic-view). Split out of #50545 per review feedback — this changes the whole post detail page's header, not only the email tabs.

## Why

The post detail page currently lays the date filters out beside the summary title (one header row). The main dashboard places its filters directly below the section tabs; aligning the post detail page with that placement keeps the two surfaces consistent and frees the summary header from the side-by-side responsive juggling.

## Proposed changes

* Move the date filters directly below the tab bar, mirroring the main dashboard's placement (same spacing rhythm: the tab list's default bottom margin plus the filters row's bottom padding).
* The summary header (thumbnail + title + performance window subtitle) sits on its own row beneath them — 16px top padding stacks with the filters row's 16px bottom padding to 32px above the heading, mirrored by 32px below.
* Restore `SectionTabs`' default bottom margin on this page (the old header row owned that spacing) and drop the header's now-obsolete side-by-side responsive layout (flex split + 960px container query).

## Does this pull request change what data or activity we track or use?

No. Layout-only.

## Testing instructions

* Build premium-analytics and open a post detail page (`admin.php?page=jetpack-premium-analytics-wp-admin&p=%2Fpost%2F<post-id>`).
* The date filters sit directly under the tabs (left-aligned, like the dashboard's Traffic tab); the title block with thumbnail and performance subtitle renders below them.
* Narrow the window: the filters keep their own compact behavior; nothing overlaps the title.
* `pnpm run test routes/post-detail` and `pnpm run typecheck` from `projects/packages/premium-analytics`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
