### PR TITLE
Premium Analytics: Email top row rates are 0–1 fractions, not percentages

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-email-rate-fraction
+++ b/projects/packages/premium-analytics/changelog/fix-email-rate-fraction
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Email top row: rates from the per-post rate summary are 0-1 fractions; stop dividing by 100 so 2 sends / 2 opens reads 100 percent, not 1 percent.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/email-rate.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/email-rate.ts
@@ -10,8 +10,8 @@
  */
 export function buildEmailRateResponse( metric: 'opens' | 'clicks' ) {
 	if ( metric === 'clicks' ) {
-		return { total_sends: 1000, total_opens: 400, total_clicks: 40, clicks_rate: 3.81 };
+		return { total_sends: 1000, total_opens: 400, total_clicks: 40, clicks_rate: 0.0381 };
 	}
 
-	return { total_sends: 1000, total_opens: 400, unique_opens: 380, opens_rate: 38.1 };
+	return { total_sends: 1000, total_opens: 400, unique_opens: 380, opens_rate: 0.381 };
 }

--- a/projects/packages/premium-analytics/widgets/email-top-row/__tests__/email-top-row.test.tsx
+++ b/projects/packages/premium-analytics/widgets/email-top-row/__tests__/email-top-row.test.tsx
@@ -23,14 +23,14 @@ const OPENS_RATE_RESPONSE = {
 	total_sends: 1000,
 	total_opens: 400,
 	unique_opens: 380,
-	opens_rate: 38.1,
+	opens_rate: 0.381,
 };
 
 const CLICKS_RATE_RESPONSE = {
 	total_sends: 1000,
 	total_opens: 400,
 	total_clicks: 40,
-	clicks_rate: 3.81,
+	clicks_rate: 0.0381,
 };
 
 function routeRateResponse( options: unknown ) {
@@ -154,7 +154,7 @@ describe( 'EmailTopRowWidget', () => {
 describe( 'toEmailTopRowMetrics', () => {
 	it( 'builds the Opens view tiles in order and converts the 0–100 rate', () => {
 		const metrics = toEmailTopRowMetrics(
-			asSummary( { total_sends: 1000, total_opens: 400, unique_opens: 380, opens_rate: 38.1 } ),
+			asSummary( { total_sends: 1000, total_opens: 400, unique_opens: 380, opens_rate: 0.381 } ),
 			'opens'
 		);
 
@@ -170,7 +170,7 @@ describe( 'toEmailTopRowMetrics', () => {
 
 	it( 'builds the Clicks view tiles in order', () => {
 		const metrics = toEmailTopRowMetrics(
-			asSummary( { total_opens: 400, total_clicks: 40, clicks_rate: 3.81 } ),
+			asSummary( { total_opens: 400, total_clicks: 40, clicks_rate: 0.0381 } ),
 			'clicks'
 		);
 
@@ -184,7 +184,7 @@ describe( 'toEmailTopRowMetrics', () => {
 
 	it( 'hides the Unique opens tile when there are no unique opens', () => {
 		const metrics = toEmailTopRowMetrics(
-			asSummary( { total_sends: 1000, total_opens: 400, unique_opens: 0, opens_rate: 38.1 } ),
+			asSummary( { total_sends: 1000, total_opens: 400, unique_opens: 0, opens_rate: 0.381 } ),
 			'opens'
 		);
 

--- a/projects/packages/premium-analytics/widgets/email-top-row/render.tsx
+++ b/projects/packages/premium-analytics/widgets/email-top-row/render.tsx
@@ -177,13 +177,13 @@ function readCount( summary: EmailRateSummary, key: string ): number {
 }
 
 /**
- * Reads a rate field (0–100 percentage) off a rate summary and converts it to a
- * fraction for the percentage formatter. Returns `null` for a missing or zero
- * rate so the tile renders the grid's placeholder ("—") instead of "0%". Mirrors
- * the Jetpack Stats top row, which renders "-" for a missing or zero rate: in
- * wp-calypso, `client/my-sites/stats/stats-email-top-row/index.jsx` passes
- * `counts?.opens_rate ? … : null` (a truthy check, so 0 becomes null) and
- * `top-card.jsx` renders a null value as "-".
+ * Reads a rate field off a rate summary. The endpoint returns rates as 0–1
+ * fractions — wp-calypso's `stats-email-top-row/index.jsx` renders
+ * `Math.round( counts.opens_rate * 100 )}%` — which is exactly what the
+ * percentage formatter takes, so the value passes through. Returns `null` for
+ * a missing or zero rate so the tile renders the grid's placeholder ("—")
+ * instead of "0%", mirroring the Jetpack Stats top row (a truthy check there
+ * turns 0 into "-").
  *
  * @param summary - The email rate summary.
  * @param key     - The rate field to read.
@@ -192,7 +192,7 @@ function readCount( summary: EmailRateSummary, key: string ): number {
 function readRate( summary: EmailRateSummary, key: string ): number | null {
 	const value = Number( summary[ key ] );
 
-	return Number.isFinite( value ) && value !== 0 ? value / 100 : null;
+	return Number.isFinite( value ) && value !== 0 ? value : null;
 }
 
 /**


### PR DESCRIPTION
Related to [WOOA7S-1623](https://linear.app/a8c/issue/WOOA7S-1623/page-postpage-detail-emailnewsletter-view). Split out of #50545 per review feedback.

## Why

The per-post `stats/<opens|clicks>/emails/<postId>/rate` summary reports rates as **0–1 fractions** — wp-calypso's `stats-email-top-row/index.jsx` renders `Math.round( counts.opens_rate * 100 )}%`. The Email top row widget assumed 0–100 percentages and divided by 100 again, so an email opened by every recipient (2 sends / 2 opens) rendered as **1%** instead of **100%**.

## Proposed changes

* `readRate` passes the fraction straight to the percentage formatter instead of dividing by 100; the missing/zero → placeholder ("—") behavior is unchanged.
* Test fixtures and the Storybook rate mock now use the real payload shape (`opens_rate: 0.381`, `clicks_rate: 0.0381`), so they can't re-teach the wrong scale.

The widget is not yet placed in any shipped layout (its first placement lands with #50545), so this carries no user-visible change on trunk — it corrects the widget before it ships.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `pnpm run test widgets/email-top-row` from `projects/packages/premium-analytics`.
* Storybook: `Packages/Premium Analytics/Widgets/EmailTopRow` — Default shows a 38% open rate (fixture `0.381`), not 0.381%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
