### PR TITLE
SEO: fix FAQPage schema for editor-saved Details blocks

### DIFF
--- a/projects/packages/seo/changelog/fix-faq-schema-details-summary
+++ b/projects/packages/seo/changelog/fix-faq-schema-details-summary
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the FAQ schema so FAQPage JSON-LD emits from editor-saved Details blocks.

--- a/projects/packages/seo/src/class-post-schema-node.php
+++ b/projects/packages/seo/src/class-post-schema-node.php
@@ -124,7 +124,7 @@ class Post_Schema_Node {
 			if ( 'core/details' !== ( $block['blockName'] ?? '' ) ) {
 				continue;
 			}
-			$question = trim( (string) ( $block['attrs']['summary'] ?? '' ) );
+			$question = trim( html_entity_decode( wp_strip_all_tags( (string) ( $block['innerHTML'] ?? '' ) ), ENT_QUOTES, 'UTF-8' ) );
 
 			// Render only the inner blocks for the answer. Rendering the whole
 			// core/details block would re-include the <summary> (the question).
@@ -132,7 +132,7 @@ class Post_Schema_Node {
 			foreach ( $block['innerBlocks'] ?? array() as $inner_block ) {
 				$answer_html .= render_block( $inner_block );
 			}
-			$answer = trim( wp_strip_all_tags( $answer_html ) );
+			$answer = trim( html_entity_decode( wp_strip_all_tags( $answer_html ), ENT_QUOTES, 'UTF-8' ) );
 			if ( '' === $question || '' === $answer ) {
 				continue;
 			}

--- a/projects/packages/seo/tests/php/PostSchemaNodeTest.php
+++ b/projects/packages/seo/tests/php/PostSchemaNodeTest.php
@@ -137,9 +137,9 @@ class PostSchemaNodeTest extends TestCase {
 	public function test_faq_answer_excludes_the_question() {
 		\Jetpack_SEO_Posts::$schema_type = 'faq';
 
-		$content  = '<!-- wp:details {"summary":"What is SEO?"} -->';
-		$content .= '<details class="wp-block-details"><summary>What is SEO?</summary>';
-		$content .= '<!-- wp:paragraph --><p>Search engine optimization.</p><!-- /wp:paragraph -->';
+		$content  = '<!-- wp:details -->';
+		$content .= '<details class="wp-block-details"><summary>What is <strong>SEO</strong> &amp; AEO?</summary>';
+		$content .= '<!-- wp:paragraph --><p>Search engine optimization &amp; answer engine optimization.</p><!-- /wp:paragraph -->';
 		$content .= '</details><!-- /wp:details -->';
 
 		$node = Post_Schema_Node::build( $this->make_post( array( 'post_content' => $content ) ) );
@@ -150,9 +150,9 @@ class PostSchemaNodeTest extends TestCase {
 
 		$item = $node['mainEntity'][0];
 		$this->assertSame( 'Question', $item['@type'] );
-		$this->assertSame( 'What is SEO?', $item['name'] );
-		$this->assertSame( 'Search engine optimization.', $item['acceptedAnswer']['text'] );
-		$this->assertStringNotContainsString( 'What is SEO?', $item['acceptedAnswer']['text'] );
+		$this->assertSame( 'What is SEO & AEO?', $item['name'] );
+		$this->assertSame( 'Search engine optimization & answer engine optimization.', $item['acceptedAnswer']['text'] );
+		$this->assertStringNotContainsString( 'What is SEO & AEO?', $item['acceptedAnswer']['text'] );
 	}
 
 	/**

--- a/projects/packages/seo/tests/php/SchemaBuilderTest.php
+++ b/projects/packages/seo/tests/php/SchemaBuilderTest.php
@@ -408,7 +408,7 @@ class SchemaBuilderTest extends TestCase {
 	public function test_emits_graph_with_faqpage_for_faq_override() {
 		\Jetpack_SEO_Posts::$schema_type = 'faq';
 
-		$content  = '<!-- wp:details {"summary":"What is SEO?"} -->';
+		$content  = '<!-- wp:details -->';
 		$content .= '<details class="wp-block-details"><summary>What is SEO?</summary>';
 		$content .= '<!-- wp:paragraph --><p>Search engine optimization.</p><!-- /wp:paragraph -->';
 		$content .= '</details><!-- /wp:details -->';
@@ -750,7 +750,7 @@ class SchemaBuilderTest extends TestCase {
 		$this->set_site_name( 'Acme Co' );
 		\Jetpack_SEO_Posts::$schema_type = 'faq';
 
-		$content  = '<!-- wp:details {"summary":"What is SEO?"} -->';
+		$content  = '<!-- wp:details -->';
 		$content .= '<details class="wp-block-details"><summary>What is SEO?</summary>';
 		$content .= '<!-- wp:paragraph --><p>Search engine optimization.</p><!-- /wp:paragraph -->';
 		$content .= '</details><!-- /wp:details -->';


### PR DESCRIPTION
Fixes JETPACK-1793.

## Proposed changes

`core/details` stores its summary in the saved `<summary>` markup rather than the block comment. `parse_blocks()` therefore leaves `attrs.summary` empty for real editor content, causing FAQ items to be skipped and preventing `FAQPage` JSON-LD from emitting.

* Read the question from the parsed block's `innerHTML`.
* Convert question and answer markup to decoded plain text.
* Replace synthetic test fixtures with editor-saved Details markup.
* Add a patch changelog entry.

This is the minimal replacement for #50093.

## Related product discussion/links

* [JETPACK-1793](https://linear.app/a8c/issue/JETPACK-1793/faq-schema-faqpage-never-emits-from-real-editor-saved-details-blocks)
* Replaces #50093.

## Does this pull request change what data or activity we track or use?

No. It only fixes structured-data output for content authors have already configured as FAQ schema.

## Testing instructions

Automated validation:

* `git diff --check`
* `vendor/bin/phpcs -p -s --standard=.github/files/php-linting-phpcs.xml projects/packages/seo/src/class-post-schema-node.php projects/packages/seo/tests/php/PostSchemaNodeTest.php projects/packages/seo/tests/php/SchemaBuilderTest.php`
* `jp test php packages/seo`
* `jp test js packages/seo`
* `jp phan packages/seo`

Manual verification:

1. On a site with the new SEO experience and SEO Tools active, create and publish both a post and a page containing a Details block.
2. Put a question in the Details summary and an answer in its inner content.
3. Set the Schema type to FAQ. (post tab in the editor -> Schema type)
4. View the front-end source and confirm the JSON-LD `@graph` contains a `FAQPage` node whose `mainEntity[].name` is the summary text and whose `acceptedAnswer.text` is the answer.
5. Confirm rich text and HTML entities are emitted as decoded plain text and the question is not duplicated in the answer.

```json
{
  "@context": "https://schema.org",
  "@graph": [
    {
      "@type": "FAQPage",
      "mainEntity": [
        {
          "@type": "Question",
          "name": "This is a question",
          "acceptedAnswer": {
            "@type": "Answer",
            "text": "This is the answer"
          }
        }
      ]
    },
    {
      "@type": "BreadcrumbList",
      "itemListElement": [
        {
          "@type": "ListItem",
          "position": 1,
          "name": "Home",
          "item": "[site URL redacted]"
        },
        {
          "@type": "ListItem",
          "position": 2,
          "name": "Post with details block"
        }
      ]
    }
  ]
}
```