### PR TITLE
Update/my jetpack pricing interstitial width

### DIFF
--- a/projects/js-packages/components/changelog/update-my-jetpack-pricing-interstitial-width
+++ b/projects/js-packages/components/changelog/update-my-jetpack-pricing-interstitial-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+PricingTable: add optional `breakpoint` prop to control the viewport width at which offers switch from columns to stacked blocks (defaults to 'large').

--- a/projects/js-packages/components/components/pricing-table/index.tsx
+++ b/projects/js-packages/components/components/pricing-table/index.tsx
@@ -59,8 +59,8 @@ export const PricingTableItem: FC< PricingTableItemProps > = ( {
 	tooltipTitle,
 	tooltipClassName = '',
 } ) => {
-	const isLg = useViewportMatch( 'large' );
-	const item = useContext( PricingTableContext )[ index ];
+	const { items, isLg } = useContext( PricingTableContext );
+	const item = items[ index ];
 	const isExplicitlyEmpty = label === '';
 	const showTick = isComingSoon || isIncluded;
 
@@ -157,11 +157,12 @@ const PricingTable: FC< PricingTableProps > = ( {
 	items,
 	children,
 	showIntroOfferDisclaimer = false,
+	breakpoint = 'large',
 } ) => {
-	const isLg = useViewportMatch( 'large' );
+	const isLg = useViewportMatch( breakpoint );
 
 	return (
-		<PricingTableContext.Provider value={ items }>
+		<PricingTableContext.Provider value={ { items, isLg } }>
 			<div
 				className={ clsx( styles.container, { [ styles[ 'is-viewport-large' ] ]: isLg } ) }
 				style={

--- a/projects/js-packages/components/components/pricing-table/types.ts
+++ b/projects/js-packages/components/components/pricing-table/types.ts
@@ -31,6 +31,15 @@ export type PricingTableProps = {
 	 * Whether to show the intro offer disclaimer text with the ToS.
 	 */
 	showIntroOfferDisclaimer?: boolean;
+
+	/**
+	 * Viewport breakpoint at or above which the table renders as columns
+	 * (below it, offers stack into blocks). Defaults to 'large' (960px).
+	 * Interstitials hosting 3 offers can pass 'xlarge' (1080px) to stack
+	 * earlier and avoid cramped columns. Accepts any `@wordpress/compose`
+	 * viewport-match breakpoint name.
+	 */
+	breakpoint?: 'mobile' | 'small' | 'medium' | 'large' | 'xlarge' | 'wide' | 'huge' | 'xhuge';
 };
 
 export type PricingTableColumnProps = {

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/pricing-interstitial.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/pricing-interstitial.jsx
@@ -410,6 +410,7 @@ export default function PricingInterstitial( { slug } ) {
 						items={ config.features }
 						showIntroOfferDisclaimer={ false }
 						headerLogo={ config.logo ? <config.logo height={ 32 } /> : null }
+						breakpoint="xlarge"
 					>
 						{ config.tiers.free && (
 							<PricingTableColumn className={ styles[ 'pricing-column' ] }>

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/style.module.scss
@@ -59,7 +59,6 @@
 }
 
 .interstitialContainer {
-	--max-container-width: 100%;
 	padding: 48px;
 	background: #fcfcfc;
 }

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/style.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/style.module.scss
@@ -59,6 +59,10 @@
 }
 
 .interstitialContainer {
+	// Product pricing interstitials are the intentional exception to the shared
+	// 1040px container cap: most hold 3 pricing offers, which 1040px cramps.
+	// 1280px matches the content width of the Figma onboarding mockups (MYJP-326).
+	--max-container-width: 1280px;
 	padding: 48px;
 	background: #fcfcfc;
 }

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-pricing-interstitial-width
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-pricing-interstitial-width
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Allow pricing interstitials to limit container width


### PR DESCRIPTION
Part of MYJP-326

## Proposed changes
Product pricing interstitials in My Jetpack were rendering full-bleed (via a `--max-container-width: 100%` override), while every other upsell/admin page is width-restrained. This aligns them without flattening them into the shared 1040px cap, since these interstitials are the intentional exception (most host 3 pricing offers, which 1040px cramps).

- Cap the pricing interstitials at **1280px**, matching the content width of the Figma onboarding mockups, instead of running edge-to-edge.
- Stack offers into blocks **earlier**: add an optional `breakpoint` prop to the shared `PricingTable` component (defaults to `large` / 960px, so all other consumers are unchanged) and have the interstitials opt into `xlarge` (1080px). This removes the cramped-column / horizontal-scroll band that appeared between ~960–1080px.

## Related product discussion/links
MYJP-326

## Does this pull request change what data or activity we track or use?
No

## Testing instructions
1. Open **My Jetpack → Products** and click **Learn more** on a product with a pricing interstitial (e.g. Search → `#/add-search`).
2. On a wide viewport, confirm the content is capped at **1280px and centered** (no longer full-bleed edge-to-edge).
3. Slowly narrow the browser window:
   - Offers stay as **columns** down to ~1080px.
   - Below ~1080px they **stack into blocks** — with no cramped columns and no horizontal scrollbar in the ~960–1080px range.
4. Regression check — confirm other `PricingTable` consumers are **unchanged** (still switch to blocks at 960px):
   - Jetpack → **Search** sidebar upsell (when Search is not active).
   - **Social** pricing screen.
