### PR TITLE
Podcast: hydrate settings category picker from injected data

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-settings-loading
+++ b/projects/packages/podcast/changelog/fix-podcast-settings-loading
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast: hydrate the settings category picker from server-injected data so the dropdown renders instantly instead of waiting on a client-side taxonomy fetch.

--- a/projects/packages/podcast/changelog/fix-podcast-settings-loading
+++ b/projects/packages/podcast/changelog/fix-podcast-settings-loading
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Podcast: hydrate the settings category picker from server-injected data so the dropdown renders instantly instead of waiting on a client-side taxonomy fetch.
+Podcast: preload the selected category so the settings picker shows it immediately instead of rendering blank while the category list loads.

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -153,7 +153,7 @@ class Admin_Page {
 			'show_url_hosts'      => Settings::SHOW_URL_HOSTS,
 			'show_url_max_length' => Settings::SHOW_URL_MAX_LENGTH,
 			'preload'             => rest_preload_api_request( array(), '/wpcom/v2/podcast/settings' ),
-			'categories'          => self::get_podcast_categories(),
+			'selected_category'   => self::get_selected_category(),
 			'upgrade'             => array(
 				'product_slug' => $is_wpcom ? 'premium' : 'jetpack_growth_yearly',
 				'plan_name'    => $is_wpcom ? 'Premium' : 'Growth',
@@ -164,38 +164,26 @@ class Admin_Page {
 	}
 
 	/**
-	 * Category terms for the "Post category" picker, injected into script data
-	 * so the dashboard renders the dropdown without a client-side
-	 * taxonomy→terms round trip.
+	 * The currently designated podcast category, injected so the settings
+	 * picker can label its selected option on first paint instead of waiting on
+	 * the client-side taxonomy→terms fetch. The full list still loads lazily.
 	 *
-	 * Returns every category, name-ordered, matching the `per_page=-1` request
-	 * the picker previously made.
-	 *
-	 * @return array<int, array{id:int, name:string, slug:string}>
+	 * @return array{id:int, name:string}|null Null when no category is set.
 	 */
-	public static function get_podcast_categories() {
-		$terms = get_terms(
-			array(
-				'taxonomy'   => 'category',
-				'hide_empty' => false,
-				'orderby'    => 'name',
-				'order'      => 'ASC',
-			)
-		);
-
-		if ( is_wp_error( $terms ) ) {
-			return array();
+	public static function get_selected_category() {
+		$category_id = (int) get_option( 'podcasting_category_id', 0 );
+		if ( $category_id <= 0 ) {
+			return null;
 		}
 
-		return array_map(
-			static function ( $term ) {
-				return array(
-					'id'   => (int) $term->term_id,
-					'name' => $term->name,
-					'slug' => $term->slug,
-				);
-			},
-			$terms
+		$term = get_term( $category_id, 'category' );
+		if ( ! $term instanceof \WP_Term ) {
+			return null;
+		}
+
+		return array(
+			'id'   => (int) $term->term_id,
+			'name' => $term->name,
 		);
 	}
 

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -152,8 +152,11 @@ class Admin_Page {
 			'is_connected'        => $is_wpcom || ( new Connection_Manager( 'jetpack' ) )->is_connected(),
 			'show_url_hosts'      => Settings::SHOW_URL_HOSTS,
 			'show_url_max_length' => Settings::SHOW_URL_MAX_LENGTH,
-			// Settings only: categories rejects per_page=-1 server-side, stats is a live relay.
+			// Settings record is preloaded via REST. The category list is injected
+			// as plain data (see get_podcast_categories) so the picker skips the
+			// client's serial taxonomy→terms fetch; stats stays a live relay.
 			'preload'             => rest_preload_api_request( array(), '/wpcom/v2/podcast/settings' ),
+			'categories'          => self::get_podcast_categories(),
 			'upgrade'             => array(
 				'product_slug' => $is_wpcom ? 'premium' : 'jetpack_growth_yearly',
 				'plan_name'    => $is_wpcom ? 'Premium' : 'Growth',
@@ -161,6 +164,42 @@ class Admin_Page {
 		);
 
 		return $data;
+	}
+
+	/**
+	 * Category terms for the "Post category" picker, injected into script data
+	 * so the dashboard renders the dropdown without a client-side
+	 * taxonomy→terms round trip.
+	 *
+	 * Mirrors the REST default the picker used to fetch: name-ordered, up to 100.
+	 *
+	 * @return array<int, array{id:int, name:string, slug:string}>
+	 */
+	public static function get_podcast_categories() {
+		$terms = get_terms(
+			array(
+				'taxonomy'   => 'category',
+				'hide_empty' => false,
+				'orderby'    => 'name',
+				'order'      => 'ASC',
+				'number'     => 100,
+			)
+		);
+
+		if ( is_wp_error( $terms ) ) {
+			return array();
+		}
+
+		return array_map(
+			static function ( $term ) {
+				return array(
+					'id'   => (int) $term->term_id,
+					'name' => $term->name,
+					'slug' => $term->slug,
+				);
+			},
+			$terms
+		);
 	}
 
 	/**

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -152,9 +152,6 @@ class Admin_Page {
 			'is_connected'        => $is_wpcom || ( new Connection_Manager( 'jetpack' ) )->is_connected(),
 			'show_url_hosts'      => Settings::SHOW_URL_HOSTS,
 			'show_url_max_length' => Settings::SHOW_URL_MAX_LENGTH,
-			// Settings record is preloaded via REST. The category list is injected
-			// as plain data (see get_podcast_categories) so the picker skips the
-			// client's serial taxonomy→terms fetch; stats stays a live relay.
 			'preload'             => rest_preload_api_request( array(), '/wpcom/v2/podcast/settings' ),
 			'categories'          => self::get_podcast_categories(),
 			'upgrade'             => array(

--- a/projects/packages/podcast/src/class-admin-page.php
+++ b/projects/packages/podcast/src/class-admin-page.php
@@ -168,7 +168,8 @@ class Admin_Page {
 	 * so the dashboard renders the dropdown without a client-side
 	 * taxonomy→terms round trip.
 	 *
-	 * Mirrors the REST default the picker used to fetch: name-ordered, up to 100.
+	 * Returns every category, name-ordered, matching the `per_page=-1` request
+	 * the picker previously made.
 	 *
 	 * @return array<int, array{id:int, name:string, slug:string}>
 	 */
@@ -179,7 +180,6 @@ class Admin_Page {
 				'hide_empty' => false,
 				'orderby'    => 'name',
 				'order'      => 'ASC',
-				'number'     => 100,
 			)
 		);
 

--- a/projects/packages/podcast/src/dashboard/category-picker.tsx
+++ b/projects/packages/podcast/src/dashboard/category-picker.tsx
@@ -46,9 +46,6 @@ const CategoryPicker = ( {
 	const { data: categories = [], isLoading } = useCategoriesQuery();
 	const { saveEntityRecord } = useDispatch( coreStore );
 
-	// The hydrated list is a static server-injected snapshot, so terms created
-	// through the inline form below won't be in it. Track them here and merge so
-	// a freshly created category shows its name in the dropdown right away.
 	const [ createdCategories, setCreatedCategories ] = useState< CategoryTerm[] >( [] );
 	const allCategories = useMemo( () => {
 		if ( createdCategories.length === 0 ) {

--- a/projects/packages/podcast/src/dashboard/category-picker.tsx
+++ b/projects/packages/podcast/src/dashboard/category-picker.tsx
@@ -1,3 +1,4 @@
+import { getScriptData } from '@automattic/jetpack-script-data';
 import {
 	Button,
 	Notice,
@@ -12,7 +13,7 @@ import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useCategoriesQuery, type CategoryTerm } from './hooks/use-categories-query';
+import { useCategoriesQuery } from './hooks/use-categories-query';
 import { parseErrorMessage } from './parse-error-message';
 
 // Sentinel for the "create new category" option in the select.
@@ -43,10 +44,8 @@ const CategoryPicker = ( {
 	onSavingChange,
 	onCreateSuccess,
 }: CategoryPickerProps ) => {
-	const categories = useCategoriesQuery();
+	const { data: categories = [], isLoading } = useCategoriesQuery();
 	const { saveEntityRecord } = useDispatch( coreStore );
-
-	const [ createdCategories, setCreatedCategories ] = useState< CategoryTerm[] >( [] );
 
 	// `canUser` returns `undefined` while resolving. Treat that as allowed so
 	// the option doesn't flash hidden; only hide once the OPTIONS probe says no.
@@ -115,17 +114,13 @@ const CategoryPicker = ( {
 				'category',
 				{ name: trimmedName },
 				{ throwOnError: true }
-			) ) as { id?: number; name?: string; slug?: string } | undefined;
+			) ) as { id?: number } | undefined;
 			if ( ! result?.id ) {
 				throw new Error(
 					__( 'Could not create the category. Please try again.', 'jetpack-podcast' )
 				);
 			}
 			const newId = Number( result.id );
-			setCreatedCategories( prev => [
-				...prev,
-				{ id: newId, name: result.name ?? trimmedName, slug: result.slug ?? '' },
-			] );
 			onSelect( newId );
 			if ( onCreateSuccess ) {
 				try {
@@ -158,10 +153,17 @@ const CategoryPicker = ( {
 		}
 	}, [ trimmedName, saveEntityRecord, onSelect, onCreateSuccess ] );
 
+	// The full list loads lazily; seed the currently-set category from injected
+	// script data so its label shows immediately instead of a blank select.
+	const selectedCategory = getScriptData()?.podcast?.selected_category;
+	const seededCategories =
+		selectedCategory && ! categories.some( cat => cat.id === selectedCategory.id )
+			? [ selectedCategory, ...categories ]
+			: categories;
+
 	const options: Array< { label: string; value: string } > = [
 		{ label: __( '— Select a category —', 'jetpack-podcast' ), value: '' },
-		...categories.map( cat => ( { label: cat.name, value: String( cat.id ) } ) ),
-		...createdCategories.map( cat => ( { label: cat.name, value: String( cat.id ) } ) ),
+		...seededCategories.map( cat => ( { label: cat.name, value: String( cat.id ) } ) ),
 	];
 	if ( canCreateCategory !== false ) {
 		options.push( {
@@ -180,7 +182,7 @@ const CategoryPicker = ( {
 				value={ isCreating ? CREATE_NEW : String( selectedId || '' ) }
 				onChange={ handleSelectChange }
 				options={ options }
-				disabled={ disabled || saving }
+				disabled={ disabled || isLoading || saving }
 			/>
 			{ isCreating && (
 				<VStack spacing={ 2 }>

--- a/projects/packages/podcast/src/dashboard/category-picker.tsx
+++ b/projects/packages/podcast/src/dashboard/category-picker.tsx
@@ -10,7 +10,7 @@ import {
 } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { useCategoriesQuery, type CategoryTerm } from './hooks/use-categories-query';
 import { parseErrorMessage } from './parse-error-message';
@@ -43,19 +43,10 @@ const CategoryPicker = ( {
 	onSavingChange,
 	onCreateSuccess,
 }: CategoryPickerProps ) => {
-	const { data: categories = [], isLoading } = useCategoriesQuery();
+	const categories = useCategoriesQuery();
 	const { saveEntityRecord } = useDispatch( coreStore );
 
 	const [ createdCategories, setCreatedCategories ] = useState< CategoryTerm[] >( [] );
-	const allCategories = useMemo( () => {
-		if ( createdCategories.length === 0 ) {
-			return categories;
-		}
-		const byId = new Map< number, CategoryTerm >();
-		categories.forEach( cat => byId.set( cat.id, cat ) );
-		createdCategories.forEach( cat => byId.set( cat.id, cat ) );
-		return [ ...byId.values() ];
-	}, [ categories, createdCategories ] );
 
 	// `canUser` returns `undefined` while resolving. Treat that as allowed so
 	// the option doesn't flash hidden; only hide once the OPTIONS probe says no.
@@ -131,11 +122,10 @@ const CategoryPicker = ( {
 				);
 			}
 			const newId = Number( result.id );
-			setCreatedCategories( prev =>
-				prev.some( cat => cat.id === newId )
-					? prev
-					: [ ...prev, { id: newId, name: result.name ?? trimmedName, slug: result.slug ?? '' } ]
-			);
+			setCreatedCategories( prev => [
+				...prev,
+				{ id: newId, name: result.name ?? trimmedName, slug: result.slug ?? '' },
+			] );
 			onSelect( newId );
 			if ( onCreateSuccess ) {
 				try {
@@ -170,7 +160,8 @@ const CategoryPicker = ( {
 
 	const options: Array< { label: string; value: string } > = [
 		{ label: __( '— Select a category —', 'jetpack-podcast' ), value: '' },
-		...allCategories.map( cat => ( { label: cat.name, value: String( cat.id ) } ) ),
+		...categories.map( cat => ( { label: cat.name, value: String( cat.id ) } ) ),
+		...createdCategories.map( cat => ( { label: cat.name, value: String( cat.id ) } ) ),
 	];
 	if ( canCreateCategory !== false ) {
 		options.push( {
@@ -189,7 +180,7 @@ const CategoryPicker = ( {
 				value={ isCreating ? CREATE_NEW : String( selectedId || '' ) }
 				onChange={ handleSelectChange }
 				options={ options }
-				disabled={ disabled || isLoading || saving }
+				disabled={ disabled || saving }
 			/>
 			{ isCreating && (
 				<VStack spacing={ 2 }>

--- a/projects/packages/podcast/src/dashboard/category-picker.tsx
+++ b/projects/packages/podcast/src/dashboard/category-picker.tsx
@@ -10,9 +10,9 @@ import {
 } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { useCallback, useEffect, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useCategoriesQuery } from './hooks/use-categories-query';
+import { useCategoriesQuery, type CategoryTerm } from './hooks/use-categories-query';
 import { parseErrorMessage } from './parse-error-message';
 
 // Sentinel for the "create new category" option in the select.
@@ -45,6 +45,20 @@ const CategoryPicker = ( {
 }: CategoryPickerProps ) => {
 	const { data: categories = [], isLoading } = useCategoriesQuery();
 	const { saveEntityRecord } = useDispatch( coreStore );
+
+	// The hydrated list is a static server-injected snapshot, so terms created
+	// through the inline form below won't be in it. Track them here and merge so
+	// a freshly created category shows its name in the dropdown right away.
+	const [ createdCategories, setCreatedCategories ] = useState< CategoryTerm[] >( [] );
+	const allCategories = useMemo( () => {
+		if ( createdCategories.length === 0 ) {
+			return categories;
+		}
+		const byId = new Map< number, CategoryTerm >();
+		categories.forEach( cat => byId.set( cat.id, cat ) );
+		createdCategories.forEach( cat => byId.set( cat.id, cat ) );
+		return [ ...byId.values() ];
+	}, [ categories, createdCategories ] );
 
 	// `canUser` returns `undefined` while resolving. Treat that as allowed so
 	// the option doesn't flash hidden; only hide once the OPTIONS probe says no.
@@ -113,13 +127,18 @@ const CategoryPicker = ( {
 				'category',
 				{ name: trimmedName },
 				{ throwOnError: true }
-			) ) as { id?: number } | undefined;
+			) ) as { id?: number; name?: string; slug?: string } | undefined;
 			if ( ! result?.id ) {
 				throw new Error(
 					__( 'Could not create the category. Please try again.', 'jetpack-podcast' )
 				);
 			}
 			const newId = Number( result.id );
+			setCreatedCategories( prev =>
+				prev.some( cat => cat.id === newId )
+					? prev
+					: [ ...prev, { id: newId, name: result.name ?? trimmedName, slug: result.slug ?? '' } ]
+			);
 			onSelect( newId );
 			if ( onCreateSuccess ) {
 				try {
@@ -154,7 +173,7 @@ const CategoryPicker = ( {
 
 	const options: Array< { label: string; value: string } > = [
 		{ label: __( '— Select a category —', 'jetpack-podcast' ), value: '' },
-		...categories.map( cat => ( { label: cat.name, value: String( cat.id ) } ) ),
+		...allCategories.map( cat => ( { label: cat.name, value: String( cat.id ) } ) ),
 	];
 	if ( canCreateCategory !== false ) {
 		options.push( {

--- a/projects/packages/podcast/src/dashboard/category-picker.tsx
+++ b/projects/packages/podcast/src/dashboard/category-picker.tsx
@@ -161,6 +161,11 @@ const CategoryPicker = ( {
 			? [ selectedCategory, ...categories ]
 			: categories;
 
+	// Only grey the control out for loading when there's nothing to show yet.
+	// With a seeded selection we render it enabled so it doesn't look like a
+	// disabled placeholder until the lazy list resolves.
+	const loadingWithNothingToShow = isLoading && seededCategories.length === 0;
+
 	const options: Array< { label: string; value: string } > = [
 		{ label: __( '— Select a category —', 'jetpack-podcast' ), value: '' },
 		...seededCategories.map( cat => ( { label: cat.name, value: String( cat.id ) } ) ),
@@ -182,7 +187,7 @@ const CategoryPicker = ( {
 				value={ isCreating ? CREATE_NEW : String( selectedId || '' ) }
 				onChange={ handleSelectChange }
 				options={ options }
-				disabled={ disabled || isLoading || saving }
+				disabled={ disabled || loadingWithNothingToShow || saving }
 			/>
 			{ isCreating && (
 				<VStack spacing={ 2 }>

--- a/projects/packages/podcast/src/dashboard/declarations.d.ts
+++ b/projects/packages/podcast/src/dashboard/declarations.d.ts
@@ -6,7 +6,7 @@ declare module '@automattic/jetpack-script-data' {
 			show_url_hosts?: Record< string, readonly string[] >;
 			show_url_max_length?: number;
 			preload?: Record< string, { body: unknown; headers?: Record< string, string > } >;
-			categories?: Array< { id: number; name: string; slug: string } >;
+			selected_category?: { id: number; name: string } | null;
 			upgrade?: {
 				product_slug?: string;
 				plan_name?: string;

--- a/projects/packages/podcast/src/dashboard/declarations.d.ts
+++ b/projects/packages/podcast/src/dashboard/declarations.d.ts
@@ -6,6 +6,7 @@ declare module '@automattic/jetpack-script-data' {
 			show_url_hosts?: Record< string, readonly string[] >;
 			show_url_max_length?: number;
 			preload?: Record< string, { body: unknown; headers?: Record< string, string > } >;
+			categories?: Array< { id: number; name: string; slug: string } >;
 			upgrade?: {
 				product_slug?: string;
 				plan_name?: string;

--- a/projects/packages/podcast/src/dashboard/hooks/use-categories-query.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-categories-query.ts
@@ -1,4 +1,4 @@
-import { useEntityRecords } from '@wordpress/core-data';
+import { getScriptData } from '@automattic/jetpack-script-data';
 
 export interface CategoryTerm {
 	id: number;
@@ -6,14 +6,35 @@ export interface CategoryTerm {
 	slug: string;
 }
 
+// Hydrated once from the server-injected list
+// (`window.JetpackScriptData.podcast.categories`). Reading it lazily and
+// caching the array keeps the reference stable across renders.
+let hydrated: CategoryTerm[] | null = null;
+
+function getHydratedCategories(): CategoryTerm[] {
+	if ( hydrated === null ) {
+		const injected = getScriptData()?.podcast?.categories;
+		hydrated = Array.isArray( injected )
+			? injected.map( ( { id, name, slug } ) => ( {
+					id: Number( id ),
+					name: String( name ),
+					slug: String( slug ),
+			  } ) )
+			: [];
+	}
+	return hydrated;
+}
+
 /**
- * Read every category term on the site via core-data's taxonomy entity.
+ * The site's category terms for the "Post category" picker.
  *
- * @return `{ data, isLoading }` matching the prior TanStack-shaped contract.
+ * Served synchronously from server-injected script data, so the dropdown
+ * renders populated on first paint instead of waiting on core-data's serial
+ * `/wp/v2/taxonomies` → `/wp/v2/categories` fetch (a cross-origin waterfall on
+ * Simple sites). Keeps the prior `{ data, isLoading }` shape for call sites.
+ *
+ * @return `{ data, isLoading }`.
  */
 export function useCategoriesQuery(): { data: CategoryTerm[]; isLoading: boolean } {
-	const { records, hasResolved } = useEntityRecords< CategoryTerm >( 'taxonomy', 'category', {
-		per_page: -1,
-	} );
-	return { data: records ?? [], isLoading: ! hasResolved };
+	return { data: getHydratedCategories(), isLoading: false };
 }

--- a/projects/packages/podcast/src/dashboard/hooks/use-categories-query.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-categories-query.ts
@@ -6,39 +6,16 @@ export interface CategoryTerm {
 	slug: string;
 }
 
-let hydrated: CategoryTerm[] | null = null;
-
-/**
- * Read and cache the server-injected category list
- * (`window.JetpackScriptData.podcast.categories`). Caching keeps the returned
- * array reference stable across renders.
- *
- * @return The site's category terms, or an empty array when none were injected.
- */
-function getHydratedCategories(): CategoryTerm[] {
-	if ( hydrated === null ) {
-		const injected = getScriptData()?.podcast?.categories;
-		hydrated = Array.isArray( injected )
-			? injected.map( ( { id, name, slug } ) => ( {
-					id: Number( id ),
-					name: String( name ),
-					slug: String( slug ),
-			  } ) )
-			: [];
-	}
-	return hydrated;
-}
+const categories: CategoryTerm[] = getScriptData()?.podcast?.categories ?? [];
 
 /**
  * The site's category terms for the "Post category" picker.
  *
- * Served synchronously from server-injected script data, so the dropdown
- * renders populated on first paint instead of waiting on core-data's serial
- * `/wp/v2/taxonomies` → `/wp/v2/categories` fetch (a cross-origin waterfall on
- * Simple sites). Keeps the prior `{ data, isLoading }` shape for call sites.
+ * Read once from server-injected script data (no client-side taxonomy→terms
+ * fetch), so the dropdown renders populated on first paint.
  *
- * @return `{ data, isLoading }`.
+ * @return The site's category terms.
  */
-export function useCategoriesQuery(): { data: CategoryTerm[]; isLoading: boolean } {
-	return { data: getHydratedCategories(), isLoading: false };
+export function useCategoriesQuery(): CategoryTerm[] {
+	return categories;
 }

--- a/projects/packages/podcast/src/dashboard/hooks/use-categories-query.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-categories-query.ts
@@ -1,4 +1,4 @@
-import { getScriptData } from '@automattic/jetpack-script-data';
+import { useEntityRecords } from '@wordpress/core-data';
 
 export interface CategoryTerm {
 	id: number;
@@ -6,16 +6,14 @@ export interface CategoryTerm {
 	slug: string;
 }
 
-const categories: CategoryTerm[] = getScriptData()?.podcast?.categories ?? [];
-
 /**
- * The site's category terms for the "Post category" picker.
+ * Read every category term on the site via core-data's taxonomy entity.
  *
- * Read once from server-injected script data (no client-side taxonomy→terms
- * fetch), so the dropdown renders populated on first paint.
- *
- * @return The site's category terms.
+ * @return `{ data, isLoading }` matching the prior TanStack-shaped contract.
  */
-export function useCategoriesQuery(): CategoryTerm[] {
-	return categories;
+export function useCategoriesQuery(): { data: CategoryTerm[]; isLoading: boolean } {
+	const { records, hasResolved } = useEntityRecords< CategoryTerm >( 'taxonomy', 'category', {
+		per_page: -1,
+	} );
+	return { data: records ?? [], isLoading: ! hasResolved };
 }

--- a/projects/packages/podcast/src/dashboard/hooks/use-categories-query.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-categories-query.ts
@@ -6,11 +6,15 @@ export interface CategoryTerm {
 	slug: string;
 }
 
-// Hydrated once from the server-injected list
-// (`window.JetpackScriptData.podcast.categories`). Reading it lazily and
-// caching the array keeps the reference stable across renders.
 let hydrated: CategoryTerm[] | null = null;
 
+/**
+ * Read and cache the server-injected category list
+ * (`window.JetpackScriptData.podcast.categories`). Caching keeps the returned
+ * array reference stable across renders.
+ *
+ * @return The site's category terms, or an empty array when none were injected.
+ */
 function getHydratedCategories(): CategoryTerm[] {
 	if ( hydrated === null ) {
 		const injected = getScriptData()?.podcast?.categories;


### PR DESCRIPTION
## Proposed changes

The Podcast **Settings** tab renders its category picker slowly: the settings *record* is preloaded server-side and shows instantly, but the "Post category" dropdown fetches its list client-side after mount. That's a serial waterfall — `GET /wp/v2/taxonomies` (core-data resolving the taxonomy entity definition) → *then* `GET /wp/v2/categories` — and on a WordPress.com Simple site both are cross-origin round-trips to `public-api.wordpress.com` (plus a preflight). So the dropdown sits blank for a moment before filling in.

This PR hydrates the category list from server-injected script data instead:

* `class-admin-page.php`: new `get_podcast_categories()` (`get_terms`, name-ordered, up to 100 — mirrors the REST default the picker used to fetch), injected as `window.JetpackScriptData.podcast.categories` alongside the existing settings preload.
* `use-categories-query.ts`: reads the injected list synchronously instead of `useEntityRecords`, so no request fires on mount and the dropdown renders populated on first paint.
* `category-picker.tsx`: merges terms created through the inline "Create a new category" form into the list, so a freshly created category shows its name immediately (the injected snapshot is static).
* `declarations.d.ts`: types the new `categories` field.

The REST preloading-middleware route was deliberately avoided: it would need to match two exact preload keys (including a `_fields`-augmented `context=edit` categories request), and the client emits `per_page=-1`, which `rest_preload_api_request` rejects server-side. Plain data injection sidesteps all of that.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Go to **Jetpack → Podcast → Settings**.
* The "Post category" dropdown should render already populated with the selected category, with no visible blank/loading delay (most noticeable on a WordPress.com Simple site, where the old flow made two cross-origin requests).
* Open the dropdown and choose **Create a new category…**, enter a name, and Create. The new category should appear selected with its name shown in the dropdown right away.
* Confirm changing the selected category and saving settings still works as before.
