### PR TITLE
AI Launchpad: AI-drafted About page content and gallery selection logging

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotobrd-529-ai-launchpad-add-logging-for-tailored-post-content
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotobrd-529-ai-launchpad-add-logging-for-tailored-post-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+AI Launchpad: write AI-drafted content on the About page instead of a library pattern, and log the gallery pattern selection to Logstash from the client.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -25,7 +25,7 @@
 		"clean": "rm -rf src/build/ src/build-module/ build/",
 		"e2e-tests": "playwright test --config src/features/verbum-comments/playwright.config.ts",
 		"sync:newspack-blocks": "./bin/sync-newspack-blocks.sh",
-		"test": "node --test --test-reporter spec src/features/write/test/undo-history.test.mjs",
+		"test": "node --test --test-reporter spec src/features/write/test/undo-history.test.mjs src/features/ai-launchpad/js/lib/*.test.mts src/features/ai-launchpad/js/wizard/*.test.mts src/features/ai-launchpad/js/tailored-list/*.test.mts",
 		"test-coverage": "c8 --report-dir=\"$COVERAGE_DIR\" --temp-directory=\"$ARTIFACTS_DIR/v8\" pnpm run test",
 		"typecheck": "tsgo --build",
 		"watch": "pnpm run build-production-js && pnpm webpack watch"

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -25,7 +25,7 @@
 		"clean": "rm -rf src/build/ src/build-module/ build/",
 		"e2e-tests": "playwright test --config src/features/verbum-comments/playwright.config.ts",
 		"sync:newspack-blocks": "./bin/sync-newspack-blocks.sh",
-		"test": "node --test --test-reporter spec src/features/write/test/undo-history.test.mjs src/features/ai-launchpad/js/lib/*.test.mts src/features/ai-launchpad/js/wizard/*.test.mts src/features/ai-launchpad/js/tailored-list/*.test.mts",
+		"test": "node --test --test-reporter spec src/features/write/test/undo-history.test.mjs",
 		"test-coverage": "c8 --report-dir=\"$COVERAGE_DIR\" --temp-directory=\"$ARTIFACTS_DIR/v8\" pnpm run test",
 		"typecheck": "tsgo --build",
 		"watch": "pnpm run build-production-js && pnpm webpack watch"

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/contracts/agent-output-schema.json
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/contracts/agent-output-schema.json
@@ -4,7 +4,7 @@
 	"title": "AI Launchpad Selector Agent Output",
 	"description": "Cross-stream contract for the AI Launchpad. Three consumers: (1) Stream F's `js/lib/tailor.ts` parses the `jetpack-ai-query` response and validates against this schema (Ajv); (2) Stream B's `PUT /tailored` validates incoming request bodies against this schema server-side; (3) the Node eval runner (`bin/eval-ai-launchpad.mjs`) validates fixture outputs against this schema during prompt iteration. Change this schema and three test paths fail in lockstep — that's the point.",
 	"type": "object",
-	"required": [ "tasks", "inferred", "first_post_draft" ],
+	"required": [ "tasks", "inferred", "first_post_draft", "about_page_draft" ],
 	"additionalProperties": false,
 	"properties": {
 		"tasks": {
@@ -93,6 +93,31 @@
 					"minItems": 2,
 					"maxItems": 2,
 					"description": "Two paragraphs; warm tone; no 'Welcome to my blog' clichés per the system prompt.",
+					"items": {
+						"type": "string",
+						"minLength": 1,
+						"maxLength": 1200
+					}
+				}
+			}
+		},
+		"about_page_draft": {
+			"type": "object",
+			"required": [ "title", "paragraphs" ],
+			"additionalProperties": false,
+			"description": "Starter About-page content, grounded in the user's own description. Persisted via POST /wp/v2/pages as status=draft when the user clicks the add_about_page task CTA. Outputs persisted before this field existed lack it; the client then creates an empty page shell.",
+			"properties": {
+				"title": {
+					"type": "string",
+					"minLength": 1,
+					"maxLength": 80,
+					"description": "The page title, ≤4 words per the system prompt (usually \"About\" or \"About {brand}\")."
+				},
+				"paragraphs": {
+					"type": "array",
+					"minItems": 2,
+					"maxItems": 3,
+					"description": "Two or three short paragraphs: who is behind the site, what visitors will find, an invitation.",
 					"items": {
 						"type": "string",
 						"minLength": 1,

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/about-page.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/about-page.test.mts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createAboutPage } from './about-page.ts';
+
+/**
+ * Stub fetcher that records the request and returns a created page.
+ *
+ * @return The stub and its recorded requests.
+ */
+function stubFetcher() {
+	const requests: object[] = [];
+	const fetcher = async ( options: object ) => {
+		requests.push( options );
+		return { id: 42 };
+	};
+	return { fetcher, requests };
+}
+
+describe( 'createAboutPage', () => {
+	it( 'creates a marked draft page from the AI draft, as escaped paragraph blocks', async () => {
+		const { fetcher, requests } = stubFetcher();
+		const result = await createAboutPage(
+			{ title: 'About Alpine Notes', paragraphs: [ 'Who we are.', 'Come <hike> with us.' ] },
+			fetcher
+		);
+
+		assert.deepEqual( result, { page_id: 42, edit_url: '/wp-admin/post.php?post=42&action=edit' } );
+		const request = requests[ 0 ] as {
+			path: string;
+			method: string;
+			data: { title: string; content: string; status: string; meta: object };
+		};
+		assert.equal( request.path, '/wp/v2/pages' );
+		assert.equal( request.method, 'POST' );
+		assert.equal( request.data.title, 'About Alpine Notes' );
+		assert.equal( request.data.status, 'draft' );
+		assert.deepEqual( request.data.meta, { _wpcom_ai_launchpad_about_page: true } );
+		assert.match( request.data.content, /<!-- wp:paragraph --><p>Who we are\.<\/p>/ );
+		// AI-drafted text must be escaped, never raw markup.
+		assert.match( request.data.content, /Come &lt;hike&gt; with us\./ );
+	} );
+
+	it( 'creates an empty "About" shell when the output predates the draft field', async () => {
+		const { fetcher, requests } = stubFetcher();
+		const result = await createAboutPage( undefined, fetcher );
+
+		assert.equal( result.page_id, 42 );
+		const request = requests[ 0 ] as { data: { title: string; content: string } };
+		assert.equal( request.data.title, 'About' );
+		assert.equal( request.data.content, '' );
+	} );
+} );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/about-page.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/about-page.ts
@@ -10,18 +10,20 @@ interface CreatedPage {
  * Create the About page as a draft from the AI-drafted content, emitted as Gutenberg
  * paragraph blocks.
  *
- * @param draft - The AI-drafted About page, or undefined for outputs persisted before the
- *              field existed — those get an empty shell the user fills in the editor.
+ * @param draft   - The AI-drafted About page, or undefined for outputs persisted before the
+ *                field existed — those get an empty shell the user fills in the editor.
+ * @param fetcher - Injectable request handler, so the node:test suite can stub the REST call.
  * @return The created page id and its editor URL.
  */
 export async function createAboutPage(
-	draft: AboutPageDraft | undefined
+	draft: AboutPageDraft | undefined,
+	fetcher: ( options: Parameters< typeof apiFetch >[ 0 ] ) => Promise< unknown > = apiFetch
 ): Promise< { page_id: number; edit_url: string } > {
 	// Untranslated placeholder title (like core's "Auto Draft"); the AI draft normally supplies it.
 	const title = draft?.title ?? 'About';
 	const content = draft ? paragraphsToBlocks( draft.paragraphs ) : '';
 
-	const page = ( await apiFetch( {
+	const page = ( await fetcher( {
 		path: '/wp/v2/pages',
 		method: 'POST',
 		data: {

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/about-page.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/about-page.ts
@@ -1,0 +1,40 @@
+import apiFetch from '@wordpress/api-fetch';
+import { paragraphsToBlocks } from './paragraph-blocks.ts';
+import type { AboutPageDraft } from './types.ts';
+
+interface CreatedPage {
+	id: number;
+}
+
+/**
+ * Create the About page as a draft from the AI-drafted content, emitted as Gutenberg
+ * paragraph blocks.
+ *
+ * @param draft - The AI-drafted About page, or undefined for outputs persisted before the
+ *              field existed — those get an empty shell the user fills in the editor.
+ * @return The created page id and its editor URL.
+ */
+export async function createAboutPage(
+	draft: AboutPageDraft | undefined
+): Promise< { page_id: number; edit_url: string } > {
+	// Untranslated placeholder title (like core's "Auto Draft"); the AI draft normally supplies it.
+	const title = draft?.title ?? 'About';
+	const content = draft ? paragraphsToBlocks( draft.paragraphs ) : '';
+
+	const page = ( await apiFetch( {
+		path: '/wp/v2/pages',
+		method: 'POST',
+		data: {
+			title,
+			content,
+			status: 'draft',
+			// Tag as the AI Launchpad page so the server-side listener can complete the task on publish.
+			meta: { _wpcom_ai_launchpad_about_page: true },
+		},
+	} ) ) as CreatedPage;
+
+	return {
+		page_id: page.id,
+		edit_url: '/wp-admin/post.php?post=' + page.id + '&action=edit',
+	};
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/content-log.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/content-log.test.mts
@@ -1,0 +1,17 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { buildLogstashParams } from './content-log.ts';
+
+describe( 'buildLogstashParams', () => {
+	it( 'encodes the logstash record with a JSON-string extra, matching the server dispatch shape', () => {
+		const params = JSON.parse(
+			buildLogstashParams( 'content_tailored', { page_id: 7, picked_score: 1 }, 123 )
+		);
+		assert.equal( params.blog_id, 123 );
+		assert.equal( params.feature, 'atomic_ai_launchpad' );
+		assert.equal( params.message, 'content_tailored' );
+		// `extra` must be a JSON string, not a nested object — log2logstash wp_json_encode()s it too.
+		assert.equal( typeof params.extra, 'string' );
+		assert.deepEqual( JSON.parse( params.extra ), { page_id: 7, picked_score: 1 } );
+	} );
+} );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/content-log.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/content-log.ts
@@ -1,0 +1,59 @@
+// Type-only: the runtime global is read directly so this module stays loadable by the node test
+// runner, which chokes on the package's non-erasable type imports.
+import type { JetpackScriptData } from '@automattic/jetpack-script-data';
+
+/**
+ * Logstash event for the gallery-page CTA — the one creation flow whose content is picked by
+ * client-side reasoning (pattern scoring) rather than taken from the persisted AI output. Posted
+ * from the browser, mirroring the HTTP dispatch of `Jetpack_Mu_Wpcom::log2logstash()`.
+ * Best-effort: logging must never fail the creation flow.
+ */
+
+const LOGSTASH_ENDPOINT = 'https://public-api.wordpress.com/rest/v1.1/logstash';
+
+/**
+ * Build the `params` form field of a logstash record. `extra` is JSON-encoded within the
+ * JSON-encoded record, matching the server dispatch shape.
+ *
+ * @param message - Event message slug.
+ * @param extra   - Event-specific properties.
+ * @param blogId  - The WP.com blog id, or 0 when unknown.
+ * @return The JSON-encoded record.
+ */
+export function buildLogstashParams( message: string, extra: object, blogId: number ): string {
+	return JSON.stringify( {
+		blog_id: blogId,
+		feature: 'atomic_ai_launchpad',
+		message,
+		extra: JSON.stringify( extra ),
+	} );
+}
+
+/**
+ * Send a `content_tailored` event, fire-and-forget. `sendBeacon` survives the navigation to the
+ * editor that follows content creation.
+ *
+ * @param buildExtra - Builds the event properties; called inside the guard so a throwing payload
+ *                   cannot fail the creation flow. No user free-text.
+ */
+export function logContentTailored( buildExtra: () => object ): void {
+	try {
+		const scriptData: JetpackScriptData | undefined = window.JetpackScriptData;
+		const blogId = scriptData?.site?.wpcom?.blog_id ?? 0;
+		const body = new URLSearchParams( {
+			params: buildLogstashParams( 'content_tailored', buildExtra(), blogId ),
+		} );
+
+		let sent = false;
+		try {
+			sent = navigator.sendBeacon( LOGSTASH_ENDPOINT, body );
+		} catch {
+			// Fall through to the fetch fallback.
+		}
+		if ( ! sent ) {
+			fetch( LOGSTASH_ENDPOINT, { method: 'POST', body, keepalive: true } ).catch( () => {} );
+		}
+	} catch {
+		// Best-effort.
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/fallback.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/fallback.ts
@@ -128,5 +128,14 @@ export function selectFallback( input: WizardInput ): TailoredOutput {
 				'Thanks for being here at the very beginning. Stay tuned for what comes next.',
 			],
 		},
+		about_page_draft: {
+			title: 'About',
+			paragraphs: [
+				'This is where the story of ' +
+					siteName +
+					' begins. Use this page to share who is behind the site and what it is all about.',
+				'Tell visitors how it started, what they can expect to find here, and where it is headed next.',
+			],
+		},
 	};
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/first-post.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/first-post.ts
@@ -1,31 +1,9 @@
 import apiFetch from '@wordpress/api-fetch';
+import { paragraphsToBlocks } from './paragraph-blocks.ts';
 import type { FirstPostDraft } from './types.ts';
 
 interface CreatedPost {
 	id: number;
-}
-
-/**
- * Escape HTML-significant characters in plain text to keep AI-drafted output
- * from injecting markup (stored XSS) or breaking block delimiters.
- *
- * @param text - The plain text to escape.
- * @return The escaped text, safe to embed in HTML.
- */
-function escapeHtml( text: string ): string {
-	return text.replace( /&/g, '&amp;' ).replace( /</g, '&lt;' ).replace( />/g, '&gt;' );
-}
-
-/**
- * Wrap each paragraph in a Gutenberg paragraph block.
- *
- * @param paragraphs - The paragraph strings.
- * @return The serialized block markup.
- */
-function toBlocks( paragraphs: string[] ): string {
-	return paragraphs
-		.map( text => '<!-- wp:paragraph --><p>' + escapeHtml( text ) + '</p><!-- /wp:paragraph -->' )
-		.join( '\n\n' );
 }
 
 /**
@@ -43,7 +21,7 @@ export async function createFirstPostDraft(
 		method: 'POST',
 		data: {
 			title: draft.title,
-			content: toBlocks( draft.paragraphs ),
+			content: paragraphsToBlocks( draft.paragraphs ),
 			status: 'draft',
 			// Tag as the AI Launchpad first post so the server can recognise this exact draft and show the
 			// in-progress "Continue" treatment, reopening it instead of drafting a second one.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/paragraph-blocks.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/paragraph-blocks.test.mts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { paragraphsToBlocks } from './paragraph-blocks.ts';
+
+describe( 'paragraphsToBlocks', () => {
+	it( 'wraps each paragraph in a paragraph block', () => {
+		const blocks = paragraphsToBlocks( [ 'First.', 'Second.' ] );
+		assert.equal(
+			blocks,
+			'<!-- wp:paragraph --><p>First.</p><!-- /wp:paragraph -->\n\n' +
+				'<!-- wp:paragraph --><p>Second.</p><!-- /wp:paragraph -->'
+		);
+	} );
+
+	it( 'escapes HTML-significant characters so drafted text cannot inject markup', () => {
+		const blocks = paragraphsToBlocks( [ 'a <script>alert(1)</script> & b' ] );
+		assert.ok( ! blocks.includes( '<script>' ), 'raw tags must not survive' );
+		assert.ok( blocks.includes( '&lt;script&gt;' ) );
+		assert.ok( blocks.includes( '&amp; b' ) );
+	} );
+} );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/paragraph-blocks.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/paragraph-blocks.ts
@@ -1,0 +1,22 @@
+/**
+ * Escape HTML-significant characters so AI-drafted text cannot inject markup (stored XSS)
+ * or break block delimiters.
+ *
+ * @param text - The plain text to escape.
+ * @return The escaped text.
+ */
+function escapeHtml( text: string ): string {
+	return text.replace( /&/g, '&amp;' ).replace( /</g, '&lt;' ).replace( />/g, '&gt;' );
+}
+
+/**
+ * Wrap each paragraph in a Gutenberg paragraph block.
+ *
+ * @param paragraphs - The paragraph strings.
+ * @return The serialized block markup.
+ */
+export function paragraphsToBlocks( paragraphs: string[] ): string {
+	return paragraphs
+		.map( text => '<!-- wp:paragraph --><p>' + escapeHtml( text ) + '</p><!-- /wp:paragraph -->' )
+		.join( '\n\n' );
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/pattern-page.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/pattern-page.test.mts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { pickPattern, selectPatternPage, type PtkPattern } from './pattern-page.ts';
+import { pickPattern, selectGalleryPage, type PtkPattern } from './pattern-page.ts';
 import type { TailoredInferred } from './types.ts';
 
 const inferred: TailoredInferred = {
@@ -9,6 +9,9 @@ const inferred: TailoredInferred = {
 	vibe: 'artisan',
 	audience: 'enthusiasts',
 };
+
+// The words nicheWords() derives from the inferred fixture above.
+const words = [ 'coffee', 'roastery', 'artisan', 'enthusiasts' ];
 
 describe( 'pickPattern', () => {
 	it( 'matches on category term titles, not slug keys', () => {
@@ -24,32 +27,36 @@ describe( 'pickPattern', () => {
 			categories: { cat_2: { slug: 'cat_2', title: 'Generic banner' } },
 		};
 		// `other` is first, so only correct title-based scoring promotes `match`.
-		assert.equal( pickPattern( [ other, match ], inferred ), match );
+		const result = pickPattern( [ other, match ], words );
+		assert.equal( result.pattern, match );
+		assert.equal( result.score, 1 );
 	} );
 
 	it( 'tolerates an empty-array taxonomy without throwing', () => {
 		const pattern: PtkPattern = { title: 'About', html: '<p>x</p>', categories: [], tags: [] };
-		assert.equal( pickPattern( [ pattern ], inferred ), pattern );
+		assert.equal( pickPattern( [ pattern ], words ).pattern, pattern );
 	} );
 
-	it( 'falls back to the first usable pattern when nothing scores', () => {
+	it( 'falls back to the first usable pattern, with score 0, when nothing scores', () => {
 		const first: PtkPattern = { title: 'Plain', html: '<p>a</p>', categories: {} };
 		const second: PtkPattern = { title: 'Also plain', html: '<p>b</p>', categories: {} };
-		assert.equal( pickPattern( [ first, second ], inferred ), first );
+		const result = pickPattern( [ first, second ], words );
+		assert.equal( result.pattern, first );
+		assert.equal( result.score, 0 );
 	} );
 
 	it( 'skips patterns without usable HTML', () => {
 		const noHtml: PtkPattern = { title: 'Coffee', categories: {} };
 		const usable: PtkPattern = { title: 'Tea', html: '<p>x</p>', categories: {} };
-		assert.equal( pickPattern( [ noHtml, usable ], inferred ), usable );
+		assert.equal( pickPattern( [ noHtml, usable ], words ).pattern, usable );
 	} );
 
-	it( 'returns null when no pattern has HTML', () => {
-		assert.equal( pickPattern( [ { title: 'x' }, { title: 'y' } ], inferred ), null );
+	it( 'returns a null pattern when no pattern has HTML', () => {
+		assert.equal( pickPattern( [ { title: 'x' }, { title: 'y' } ], words ).pattern, null );
 	} );
 } );
 
-describe( 'selectPatternPage', () => {
+describe( 'selectGalleryPage', () => {
 	const galleryPattern: PtkPattern = {
 		title: 'Gallery Page 1',
 		html: '<!-- wp:gallery --><figure></figure><!-- /wp:gallery -->',
@@ -61,46 +68,99 @@ describe( 'selectPatternPage', () => {
 		categories: { c2: { slug: 'about', title: 'About' } },
 	};
 
-	it( 'gallery variant filters to the gallery category and sets the gallery marker', () => {
-		const result = selectPatternPage( [ aboutPattern, galleryPattern ], inferred, 'gallery' );
+	it( 'filters to the gallery category and uses the fixed title', () => {
+		const result = selectGalleryPage( [ aboutPattern, galleryPattern ], inferred );
 		assert.equal( result.content, galleryPattern.html );
-		assert.equal( result.markerMeta, '_wpcom_ai_launchpad_gallery_page' );
 		// The title is fixed, not the matched pattern's name.
 		assert.equal( result.title, 'Gallery' );
 	} );
 
-	it( 'gallery variant falls back to a bare gallery block when no gallery pattern exists', () => {
-		const result = selectPatternPage( [ aboutPattern ], inferred, 'gallery' );
+	it( 'falls back to a bare gallery block when no gallery pattern exists', () => {
+		const result = selectGalleryPage( [ aboutPattern ], inferred );
 		assert.match( result.content, /wp:gallery/ );
-		assert.equal( result.markerMeta, '_wpcom_ai_launchpad_gallery_page' );
 		assert.equal( result.title, 'Gallery' );
+		assert.equal( result.log.fallback, 'empty' );
 	} );
 
-	it( 'gallery variant strips an in-pattern heading that repeats the title', () => {
+	it( 'strips an in-pattern heading that repeats the title', () => {
 		const withHeading: PtkPattern = {
 			title: 'Gallery Page 2',
 			html: '<!-- wp:heading --><h2 class="wp-block-heading">Gallery</h2><!-- /wp:heading -->\n<!-- wp:image --><figure></figure><!-- /wp:image -->',
 			categories: { c1: { slug: 'gallery', title: 'Gallery' } },
 		};
-		const result = selectPatternPage( [ withHeading ], inferred, 'gallery' );
+		const result = selectGalleryPage( [ withHeading ], inferred );
 		assert.equal( result.title, 'Gallery' );
 		assert.ok( ! /wp:heading/.test( result.content ), 'redundant heading removed' );
 		assert.ok( /wp:image/.test( result.content ), 'other blocks kept' );
 	} );
 
-	it( 'gallery variant keeps a heading whose text differs from the title', () => {
+	it( 'keeps a heading whose text differs from the title', () => {
 		const withHeading: PtkPattern = {
 			title: 'Gallery Page 3',
 			html: '<!-- wp:heading --><h2 class="wp-block-heading">Featured work</h2><!-- /wp:heading -->',
 			categories: { c1: { slug: 'gallery', title: 'Gallery' } },
 		};
-		const result = selectPatternPage( [ withHeading ], inferred, 'gallery' );
+		const result = selectGalleryPage( [ withHeading ], inferred );
 		assert.ok( /Featured work/.test( result.content ), 'non-matching heading kept' );
 	} );
 
-	it( 'about variant is unfiltered and sets the about marker', () => {
-		const result = selectPatternPage( [ aboutPattern, galleryPattern ], inferred, 'about' );
-		assert.equal( result.markerMeta, '_wpcom_ai_launchpad_about_page' );
-		assert.equal( result.content, aboutPattern.html );
+	it( 'reports a first_usable fallback when nothing matches the niche words', () => {
+		// The gallery pattern is in the pool but mentions no niche word, so the pick is arbitrary.
+		const result = selectGalleryPage( [ aboutPattern, galleryPattern ], inferred );
+		assert.deepEqual( result.log, {
+			pool_size: 1,
+			match_words: words,
+			picked_title: 'Gallery Page 1',
+			picked_score: 0,
+			fallback: 'first_usable',
+		} );
+	} );
+
+	it( 'reports a genuine match with its score and the filtered pool size', () => {
+		const coffeeGallery: PtkPattern = {
+			title: 'Coffee gallery',
+			html: '<!-- wp:gallery --><figure></figure><!-- /wp:gallery -->',
+			categories: { c1: { slug: 'gallery', title: 'Gallery' } },
+		};
+		const result = selectGalleryPage( [ aboutPattern, galleryPattern, coffeeGallery ], inferred );
+		// The about pattern is filtered out of the gallery pool before scoring.
+		assert.equal( result.log.pool_size, 2 );
+		assert.equal( result.log.picked_title, 'Coffee gallery' );
+		assert.equal( result.log.picked_score, 1 );
+		assert.equal( result.log.fallback, 'none' );
+	} );
+
+	it( 'reports an empty fallback when no usable pattern exists', () => {
+		const result = selectGalleryPage( [], inferred );
+		assert.equal( result.log.pool_size, 0 );
+		assert.equal( result.log.picked_title, null );
+		assert.equal( result.log.fallback, 'empty' );
+	} );
+
+	it( 'drops connective words and duplicates from the match words', () => {
+		const result = selectGalleryPage( [], {
+			goal: 'portfolio',
+			niche: 'wildlife photography from the Alps',
+			audience: 'photography enthusiasts',
+		} );
+		// "from"/"the" are stop words; "photography" appears in two fields but counts once.
+		assert.deepEqual( result.log.match_words, [
+			'wildlife',
+			'photography',
+			'alps',
+			'enthusiasts',
+		] );
+	} );
+
+	it( 'scores whole tokens only, so a niche word cannot match inside another word', () => {
+		const smart: PtkPattern = {
+			title: 'Smart marketing',
+			html: '<p>x</p>',
+			categories: { c1: { slug: 'gallery', title: 'Gallery' } },
+		};
+		const result = selectGalleryPage( [ smart ], { goal: 'portfolio', niche: 'art prints' } );
+		// "art" must not match "Smart": the pick falls back rather than reporting a match.
+		assert.equal( result.log.picked_score, 0 );
+		assert.equal( result.log.fallback, 'first_usable' );
 	} );
 } );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/pattern-page.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/pattern-page.ts
@@ -1,5 +1,11 @@
 import apiFetch from '@wordpress/api-fetch';
+import { logContentTailored } from './content-log.ts';
 import type { TailoredInferred } from './types.ts';
+
+/**
+ * Gallery-page creation from the PTK pattern library. Only the gallery task uses patterns —
+ * its content is images; the About page writes AI-drafted content instead (about-page.ts).
+ */
 
 const PTK_ENDPOINT = 'https://public-api.wordpress.com/rest/v1/ptk/patterns/en';
 
@@ -22,32 +28,29 @@ interface CreatedPage {
 	id: number;
 }
 
-export type PatternVariant = 'about' | 'gallery';
-
-const VARIANT_CONFIG: Record< PatternVariant, { category: string | null; markerMeta: string } > = {
-	about: { category: null, markerMeta: '_wpcom_ai_launchpad_about_page' },
-	gallery: { category: 'gallery', markerMeta: '_wpcom_ai_launchpad_gallery_page' },
-};
-
 // An empty core/gallery block, used when the pattern library yields no gallery pattern. The class list mirrors
 // what the gallery block serializes (including the default flex layout) so the editor doesn't flag invalid markup.
 const GALLERY_FALLBACK_HTML =
 	'<!-- wp:gallery {"linkTo":"none"} --><figure class="wp-block-gallery has-nested-images columns-default is-cropped is-layout-flex wp-block-gallery-is-layout-flex"></figure><!-- /wp:gallery -->';
 
+// Connective words that survive the length filter and would otherwise dominate scoring.
+const STOP_WORDS = new Set( [ 'and', 'the', 'for', 'with', 'from', 'your', 'our' ] );
+
 /**
- * Tokenize the inferred niche/vibe/audience into lowercase match words. Goal is
- * excluded: it describes intent, not topic, so it adds noise.
+ * Tokenize the inferred niche/vibe/audience into deduplicated lowercase match words.
+ * Goal is excluded: it describes intent, not topic.
  *
  * @param inferred - The AI-inferred site details.
  * @return The match words.
  */
 function nicheWords( inferred: TailoredInferred ): string[] {
-	return [ inferred.niche, inferred.vibe, inferred.audience ]
+	const words = [ inferred.niche, inferred.vibe, inferred.audience ]
 		.filter( ( value ): value is string => typeof value === 'string' && value.length > 0 )
 		.join( ' ' )
 		.toLowerCase()
 		.split( /[^a-z0-9]+/ )
-		.filter( word => word.length > 2 );
+		.filter( word => word.length > 2 && ! STOP_WORDS.has( word ) );
+	return [ ...new Set( words ) ];
 }
 
 /**
@@ -64,41 +67,39 @@ function termTitles( taxonomy: PtkTaxonomy | undefined ): string[] {
 }
 
 /**
- * Count how many match words appear in a pattern's title, category titles, or
- * tag titles.
+ * Count how many match words appear as whole tokens in a pattern's title, category titles,
+ * or tag titles (whole tokens, so "art" cannot match "Smart").
  *
  * @param pattern - The candidate pattern.
  * @param words   - The niche match words.
  * @return The match score.
  */
 function score( pattern: PtkPattern, words: string[] ): number {
-	const haystack = [
-		pattern.title ?? '',
-		...termTitles( pattern.categories ),
-		...termTitles( pattern.tags ),
-	]
-		.join( ' ' )
-		.toLowerCase();
-	return words.reduce( ( total, word ) => ( haystack.includes( word ) ? total + 1 : total ), 0 );
+	const haystack = new Set(
+		[ pattern.title ?? '', ...termTitles( pattern.categories ), ...termTitles( pattern.tags ) ]
+			.join( ' ' )
+			.toLowerCase()
+			.split( /[^a-z0-9]+/ )
+	);
+	return words.reduce( ( total, word ) => ( haystack.has( word ) ? total + 1 : total ), 0 );
 }
 
 /**
- * Pick the pattern best matching the inferred niche, falling back to the first
+ * Pick the pattern best matching the given niche words, falling back to the first
  * pattern with usable HTML when nothing scores.
  *
  * @param patterns - The fetched patterns.
- * @param inferred - The AI-inferred site details.
- * @return The chosen pattern, or null when none have HTML.
+ * @param words    - The niche match words.
+ * @return The chosen pattern (null when none have HTML) and its match score.
  */
 export function pickPattern(
 	patterns: PtkPattern[],
-	inferred: TailoredInferred
-): PtkPattern | null {
+	words: string[]
+): { pattern: PtkPattern | null; score: number } {
 	const usable = patterns.filter( pattern => typeof pattern.html === 'string' && pattern.html );
 	if ( usable.length === 0 ) {
-		return null;
+		return { pattern: null, score: 0 };
 	}
-	const words = nicheWords( inferred );
 	let best = usable[ 0 ];
 	let bestScore = score( best, words );
 	for ( const pattern of usable.slice( 1 ) ) {
@@ -108,7 +109,7 @@ export function pickPattern(
 			bestScore = current;
 		}
 	}
-	return best;
+	return { pattern: best, score: bestScore };
 }
 
 /**
@@ -131,43 +132,58 @@ function stripHeadingMatching( html: string, title: string ): string {
 }
 
 /**
- * Choose the page title, block content, and marker meta for a pattern-page variant.
- *
- * The gallery variant filters the library to the `gallery` category before niche scoring and falls back to a bare
- * gallery block so the page always contains a gallery. The about variant is unfiltered (current behaviour).
+ * How the pattern selection went, for the `content_tailored` event. `fallback`: `none` = a
+ * pattern matched the niche words, `first_usable` = nothing scored so the pick is arbitrary,
+ * `empty` = no usable pattern, so the bare gallery block was used.
+ */
+export interface GallerySelectionLog {
+	pool_size: number;
+	match_words: string[];
+	picked_title: string | null;
+	picked_score: number;
+	fallback: 'none' | 'first_usable' | 'empty';
+}
+
+/**
+ * Choose the gallery page's title and block content: the library is filtered to the `gallery`
+ * category before niche scoring, with a bare gallery block as the fallback.
  *
  * @param patterns - The fetched patterns.
  * @param inferred - The AI-inferred site details.
- * @param variant  - The pattern-page variant.
- * @return The title, content HTML, and marker meta key.
+ * @return The title, content HTML, and the selection log fields.
  */
-export function selectPatternPage(
+export function selectGalleryPage(
 	patterns: PtkPattern[],
-	inferred: TailoredInferred,
-	variant: PatternVariant
-): { title: string; content: string; markerMeta: string } {
-	const config = VARIANT_CONFIG[ variant ];
-	const pool =
-		config.category === null
-			? patterns
-			: patterns.filter( pattern =>
-					termTitles( pattern.categories ).some( title =>
-						title.toLowerCase().includes( config.category as string )
-					)
-			  );
-	const pattern = pickPattern( pool, inferred );
-	const fallback = variant === 'gallery' ? GALLERY_FALLBACK_HTML : '';
-	// The gallery page gets a fixed title; the pattern's own name ("Gallery: Two columns…") is not a useful title.
-	// Left untranslated on purpose: it's a placeholder on the created draft that the user renames before
-	// publishing (like WordPress core's English "Auto Draft"), not a piece of shipped UI copy.
-	const title =
-		variant === 'gallery' ? 'Gallery' : pattern?.title ?? inferred.brand_name ?? 'New page';
-	const rawContent = pattern?.html ?? fallback;
+	inferred: TailoredInferred
+): { title: string; content: string; log: GallerySelectionLog } {
+	const pool = patterns.filter( pattern =>
+		termTitles( pattern.categories ).some( title => title.toLowerCase().includes( 'gallery' ) )
+	);
+	const words = nicheWords( inferred );
+	const { pattern, score: pickedScore } = pickPattern( pool, words );
+
+	let fallback: GallerySelectionLog[ 'fallback' ] = 'none';
+	if ( pattern === null ) {
+		fallback = 'empty';
+	} else if ( pickedScore === 0 ) {
+		fallback = 'first_usable';
+	}
+
+	// Fixed, untranslated placeholder title (like core's "Auto Draft"); the pattern's own name
+	// ("Gallery: Two columns…") is not a useful title.
+	const title = 'Gallery';
+	const rawContent = pattern?.html ?? GALLERY_FALLBACK_HTML;
+
 	return {
 		title,
-		// Drop any in-pattern heading that just repeats the title, so the gallery page doesn't show "Gallery" twice.
-		content: variant === 'gallery' ? stripHeadingMatching( rawContent, title ) : rawContent,
-		markerMeta: config.markerMeta,
+		content: stripHeadingMatching( rawContent, title ),
+		log: {
+			pool_size: pool.length,
+			match_words: words,
+			picked_title: pattern?.title ?? null,
+			picked_score: pickedScore,
+			fallback,
+		},
 	};
 }
 
@@ -175,16 +191,14 @@ export function selectPatternPage(
 let cachedPatterns: PtkPattern[] | null = null;
 
 /**
- * Fetch the English pattern library, pick a pattern matching the inferred niche,
- * and create a draft page from it.
+ * Fetch the English pattern library, pick a gallery pattern matching the inferred
+ * niche, and create a draft page from it.
  *
  * @param inferred - The AI-inferred site details.
- * @param variant  - The pattern-page variant.
  * @return The created page id and its editor URL.
  */
-export async function createPatternPage(
-	inferred: TailoredInferred,
-	variant: PatternVariant = 'about'
+export async function createGalleryPage(
+	inferred: TailoredInferred
 ): Promise< { page_id: number; edit_url: string } > {
 	if ( cachedPatterns === null ) {
 		try {
@@ -196,15 +210,11 @@ export async function createPatternPage(
 				}
 			}
 		} catch {
-			// Network/parse failure: leave the cache unset so a later click retries; the page is still created below.
+			// Leave the cache unset so a later click retries; the page is still created below.
 		}
 	}
 
-	const { title, content, markerMeta } = selectPatternPage(
-		cachedPatterns ?? [],
-		inferred,
-		variant
-	);
+	const { title, content, log } = selectGalleryPage( cachedPatterns ?? [], inferred );
 
 	const page = ( await apiFetch( {
 		path: '/wp/v2/pages',
@@ -214,9 +224,16 @@ export async function createPatternPage(
 			content,
 			status: 'draft',
 			// Tag as the AI Launchpad page so the server-side listener can complete the task on publish.
-			meta: { [ markerMeta ]: true },
+			meta: { _wpcom_ai_launchpad_gallery_page: true },
 		},
 	} ) ) as CreatedPage;
+
+	logContentTailored( () => ( {
+		page_id: page.id,
+		// null = the library was unavailable.
+		library_size: cachedPatterns?.length ?? null,
+		...log,
+	} ) );
 
 	return {
 		page_id: page.id,

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
@@ -98,7 +98,7 @@ export function buildTailorPrompt(
 
 	return `You are helping a new WordPress.com user onboard. They have described their site in their own words. Your job is to make their onboarding checklist feel hand-picked for THIS site, not generic.
 
-Produce a single JSON object with THREE parts, in this order: an inferred-context blob, a tailored task list, and a starter blog post draft.
+Produce a single JSON object with FOUR parts, in this order: an inferred-context blob, a tailored task list, a starter blog post draft, and a starter About-page draft.
 
 Site name: ${ site_name }
 Goal: ${ goal }
@@ -141,6 +141,11 @@ Write a friendly starter blog post the user can edit and publish.
 - "subtitle": ONE line, verb-led, max 10 words, describing what publishing this post does for them. Optional.
 - "paragraphs": exactly 2 short paragraphs of opening body text. First introduces the topic in a warm, personal voice grounded in the user's niche; second invites the reader in. Plain English, no jargon. Avoid "Welcome to my blog" and "Hello world" cliches.
 
+============ STEP 4 - about_page_draft ============
+Write starter content for the site's About page, grounded in the user's own description - never generic filler.
+- "title": the page title, max 4 words. Usually just "About" or "About" plus the brand name.
+- "paragraphs": 2 or 3 short paragraphs in the same warm voice: who is behind the site, what visitors will find here (reference the niche and what the user actually does), and a closing invitation to look around or get in touch. Use first person where it reads naturally. Never use placeholders like "[your name]" - if a detail is unknown, write around it.
+
 ============ name resolution ============
 Treat the "Site name:" value above as THE ONLY brand/name to use anywhere - in the title, subtitle, paragraphs, and inferred.brand_name. It overrides any name mentioned inside the user description. If the description names a different brand, ignore it and use the "Site name:" value.
 
@@ -153,6 +158,7 @@ Return only a JSON object matching this schema. Do not include prose, code fence
 {
   "inferred": { "goal": "...", "brand_name": "...", "niche": "...", "theme_keyword": "...", "vibe": "...", "audience": "...", "tagline": "..." },
   "tasks": [ { "id": "...", "subtitle": "..." }, ... 6 total ],
-  "first_post_draft": { "title": "...", "subtitle": "...", "paragraphs": [ "...", "..." ] }
+  "first_post_draft": { "title": "...", "subtitle": "...", "paragraphs": [ "...", "..." ] },
+  "about_page_draft": { "title": "...", "paragraphs": [ "...", "..." ] }
 }`;
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/schema-validator.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/schema-validator.test.mts
@@ -36,6 +36,10 @@ function validOutput() {
 			title: 'Trails worth remembering',
 			paragraphs: [ 'First paragraph of the post.', 'Second paragraph of the post.' ],
 		},
+		about_page_draft: {
+			title: 'About',
+			paragraphs: [ 'Who is behind the site.', 'What visitors will find here.' ],
+		},
 	};
 }
 
@@ -113,6 +117,20 @@ describe( 'validateAgainstSchema', () => {
 	it( 'rejects a missing required field', () => {
 		const out = validOutput() as Record< string, unknown >;
 		delete out.first_post_draft;
+		assert.ok( validateAgainstSchema( out, fileSchema ).length > 0 );
+	} );
+
+	it( 'rejects a missing about_page_draft', () => {
+		const out = validOutput() as Record< string, unknown >;
+		delete out.about_page_draft;
+		assert.ok( validateAgainstSchema( out, fileSchema ).length > 0 );
+	} );
+
+	it( 'accepts a third About paragraph but rejects a fourth', () => {
+		const out = validOutput();
+		out.about_page_draft.paragraphs.push( 'A closing invitation.' );
+		assert.deepEqual( validateAgainstSchema( out, fileSchema ), [] );
+		out.about_page_draft.paragraphs.push( 'One too many.' );
 		assert.ok( validateAgainstSchema( out, fileSchema ).length > 0 );
 	} );
 } );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/schema-validator.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/schema-validator.ts
@@ -19,7 +19,7 @@ interface JsonSchema {
  */
 export const AGENT_OUTPUT_SCHEMA: JsonSchema = {
 	type: 'object',
-	required: [ 'tasks', 'inferred', 'first_post_draft' ],
+	required: [ 'tasks', 'inferred', 'first_post_draft', 'about_page_draft' ],
 	additionalProperties: false,
 	properties: {
 		tasks: {
@@ -64,6 +64,20 @@ export const AGENT_OUTPUT_SCHEMA: JsonSchema = {
 					type: 'array',
 					minItems: 2,
 					maxItems: 2,
+					items: { type: 'string', minLength: 1, maxLength: 1200 },
+				},
+			},
+		},
+		about_page_draft: {
+			type: 'object',
+			required: [ 'title', 'paragraphs' ],
+			additionalProperties: false,
+			properties: {
+				title: { type: 'string', minLength: 1, maxLength: 80 },
+				paragraphs: {
+					type: 'array',
+					minItems: 2,
+					maxItems: 3,
 					items: { type: 'string', minLength: 1, maxLength: 1200 },
 				},
 			},

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/types.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/types.ts
@@ -28,6 +28,11 @@ export interface FirstPostDraft {
 	paragraphs: string[];
 }
 
+export interface AboutPageDraft {
+	title: string;
+	paragraphs: string[];
+}
+
 /**
  * Mirrors contracts/agent-output-schema.json. Length and content constraints are
  * enforced by validation, not by the type system.
@@ -36,6 +41,8 @@ export interface TailoredOutput {
 	tasks: TailoredTask[];
 	inferred: TailoredInferred;
 	first_post_draft: FirstPostDraft;
+	// Schema-required for new outputs; optional here because older persisted outputs lack it.
+	about_page_draft?: AboutPageDraft;
 }
 
 export type TailorSource = 'ai' | 'fallback';

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
@@ -16,6 +16,8 @@ import {
 } from './model.ts';
 import type { EnrichedTask } from './model.ts';
 import type { TailoredOutput } from '../lib/types.ts';
+// Runtime import of the type-only module so V8 coverage sees it as covered.
+import '../lib/types.ts';
 
 const __dirname = dirname( fileURLToPath( import.meta.url ) );
 const CONTRACTS = resolve( __dirname, '../../contracts' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
@@ -16,8 +16,6 @@ import {
 } from './model.ts';
 import type { EnrichedTask } from './model.ts';
 import type { TailoredOutput } from '../lib/types.ts';
-// Runtime import of the type-only module so V8 coverage sees it as covered.
-import '../lib/types.ts';
 
 const __dirname = dirname( fileURLToPath( import.meta.url ) );
 const CONTRACTS = resolve( __dirname, '../../contracts' );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.test.mts
@@ -51,6 +51,13 @@ const fixture: TailoredOutput = {
 			'Browse the shop to find a piece that fits your table, or follow along here as we share new collections, studio notes, and the slow craft behind every glaze.',
 		],
 	},
+	about_page_draft: {
+		title: 'About Terra Ceramics',
+		paragraphs: [
+			'Terra Ceramics is a one-person pottery studio making small-batch homewares by hand.',
+			'Every glaze and curve is shaped at the wheel, meant to bring a little ritual to everyday tables.',
+		],
+	},
 };
 
 /**
@@ -84,8 +91,8 @@ describe( 'ctaKind', () => {
 		assert.equal( ctaKind( 'first_post_published_newsletter' ), 'first_post' );
 	} );
 
-	it( 'routes page-creating tasks to the pattern page handler', () => {
-		assert.equal( ctaKind( 'add_about_page' ), 'pattern_page' );
+	it( 'routes the About task to the AI-drafted page handler', () => {
+		assert.equal( ctaKind( 'add_about_page' ), 'about_page' );
 	} );
 
 	it( 'routes pathless launch tasks to the launch handler', () => {
@@ -106,8 +113,8 @@ describe( 'ctaKind', () => {
 } );
 
 describe( 'ctaKind gallery', () => {
-	it( 'routes add_gallery_page through the pattern-page flow', () => {
-		assert.equal( ctaKind( 'add_gallery_page' ), 'pattern_page' );
+	it( 'routes add_gallery_page through the gallery pattern-page flow', () => {
+		assert.equal( ctaKind( 'add_gallery_page' ), 'gallery_page' );
 	} );
 } );
 
@@ -233,7 +240,8 @@ describe( 'resolveCtaUrl', () => {
 			handlers: {
 				trackTaskClicked: ( props: { task_id: string } ) => clicked.push( props.task_id ),
 				createFirstPostDraft: async () => ( { post_id: 1, edit_url: '/wp-admin/post.php?post=1' } ),
-				createPatternPage: async () => ( { page_id: 2, edit_url: '/wp-admin/post.php?post=2' } ),
+				createAboutPage: async () => ( { page_id: 2, edit_url: '/wp-admin/post.php?post=2' } ),
+				createGalleryPage: async () => ( { page_id: 3, edit_url: '/wp-admin/post.php?post=3' } ),
 			},
 		};
 	}
@@ -282,7 +290,7 @@ describe( 'resolveCtaUrl', () => {
 		assert.deepEqual( clicked, [ 'first_post_published' ] );
 	} );
 
-	it( 'builds a pattern page and returns its editor URL for page tasks', async () => {
+	it( 'writes the AI-drafted About page and returns its editor URL', async () => {
 		const { clicked, handlers } = stubHandlers();
 		const url = await resolveCtaUrl(
 			task( { id: 'add_about_page', calypso_path: null } ),
@@ -293,25 +301,51 @@ describe( 'resolveCtaUrl', () => {
 		assert.deepEqual( clicked, [ 'add_about_page' ] );
 	} );
 
-	it( 'passes the pattern variant keyed by task id', async () => {
-		const variants: ( string | undefined )[] = [];
+	it( 'hands each page task its own input: the About draft and the inferred details', async () => {
+		const received: unknown[] = [];
 		const handlers = {
 			trackTaskClicked: () => {},
 			createFirstPostDraft: async () => ( { post_id: 1, edit_url: '/wp-admin/post.php?post=1' } ),
-			createPatternPage: async ( _inferred: TailoredOutput[ 'inferred' ], variant?: string ) => {
-				variants.push( variant );
+			createAboutPage: async ( draft: TailoredOutput[ 'about_page_draft' ] ) => {
+				received.push( draft );
 				return { page_id: 2, edit_url: '/wp-admin/post.php?post=2' };
+			},
+			createGalleryPage: async ( inferred: TailoredOutput[ 'inferred' ] ) => {
+				received.push( inferred );
+				return { page_id: 3, edit_url: '/wp-admin/post.php?post=3' };
 			},
 		};
 
-		await resolveCtaUrl(
+		const galleryUrl = await resolveCtaUrl(
 			task( { id: 'add_gallery_page', calypso_path: null } ),
 			fixture,
 			handlers
 		);
 		await resolveCtaUrl( task( { id: 'add_about_page', calypso_path: null } ), fixture, handlers );
 
-		assert.deepEqual( variants, [ 'gallery', 'about' ] );
+		assert.equal( galleryUrl, '/wp-admin/post.php?post=3' );
+		assert.deepEqual( received, [ fixture.inferred, fixture.about_page_draft ] );
+	} );
+
+	it( 'still creates the About page (as an empty shell) for an output without a draft', async () => {
+		// Outputs persisted before about_page_draft existed lack the field; the handler
+		// receives undefined and must still be called.
+		const drafts: unknown[] = [];
+		const { handlers } = stubHandlers();
+		handlers.createAboutPage = async ( draft?: TailoredOutput[ 'about_page_draft' ] ) => {
+			drafts.push( draft );
+			return { page_id: 2, edit_url: '/wp-admin/post.php?post=2' };
+		};
+		const legacy = { ...fixture };
+		delete ( legacy as Record< string, unknown > ).about_page_draft;
+
+		const url = await resolveCtaUrl(
+			task( { id: 'add_about_page', calypso_path: null } ),
+			legacy,
+			handlers
+		);
+		assert.equal( url, '/wp-admin/post.php?post=2' );
+		assert.deepEqual( drafts, [ undefined ] );
 	} );
 
 	it( 'reopens the existing draft for an in-progress task instead of creating a new one', async () => {

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
@@ -1,5 +1,9 @@
-import type { PatternVariant } from '../lib/pattern-page.ts';
-import type { TailoredInferred, TailoredOutput, FirstPostDraft } from '../lib/types.ts';
+import type {
+	AboutPageDraft,
+	TailoredInferred,
+	TailoredOutput,
+	FirstPostDraft,
+} from '../lib/types.ts';
 
 /**
  * A single enriched task: AI subtitle merged with the catalog's title,
@@ -49,10 +53,11 @@ export interface LaunchpadData {
 }
 
 /** How a task's "Get started" CTA behaves when clicked. */
-export type CtaKind = 'first_post' | 'pattern_page' | 'launch' | 'deeplink';
+export type CtaKind = 'first_post' | 'about_page' | 'gallery_page' | 'launch' | 'deeplink';
 
 const FIRST_POST_TASK_IDS = [ 'first_post_published', 'first_post_published_newsletter' ];
-const PATTERN_PAGE_TASK_IDS = [ 'add_about_page', 'add_gallery_page' ];
+// Create-content kinds are actionable only when the AI output is present.
+const CREATE_CONTENT_KINDS: CtaKind[] = [ 'first_post', 'about_page', 'gallery_page' ];
 // Launch tasks with no catalog deeplink: they open the wordpress.com launch flow.
 const LAUNCH_TASK_IDS = [
 	'site_launched',
@@ -63,8 +68,9 @@ const LAUNCH_TASK_IDS = [
 
 /**
  * Resolve how a task's "Get started" CTA behaves: first-creation tasks draft a
- * post, page-creating tasks build a pattern page, launch tasks open the launch
- * flow, everything else deeplinks to the catalog's `calypso_path`.
+ * post, the About task writes the AI-drafted page, the gallery task builds a
+ * pattern page, launch tasks open the launch flow, everything else deeplinks to
+ * the catalog's `calypso_path`.
  *
  * @param taskId - The catalog task ID.
  * @return The CTA kind.
@@ -73,8 +79,11 @@ export function ctaKind( taskId: string ): CtaKind {
 	if ( FIRST_POST_TASK_IDS.includes( taskId ) ) {
 		return 'first_post';
 	}
-	if ( PATTERN_PAGE_TASK_IDS.includes( taskId ) ) {
-		return 'pattern_page';
+	if ( 'add_about_page' === taskId ) {
+		return 'about_page';
+	}
+	if ( 'add_gallery_page' === taskId ) {
+		return 'gallery_page';
 	}
 	if ( LAUNCH_TASK_IDS.includes( taskId ) ) {
 		return 'launch';
@@ -139,9 +148,11 @@ export interface CtaHandlers {
 	createFirstPostDraft: (
 		draft: FirstPostDraft
 	) => Promise< { post_id: number; edit_url: string } >;
-	createPatternPage: (
-		inferred: TailoredInferred,
-		variant?: PatternVariant
+	createAboutPage: (
+		draft: AboutPageDraft | undefined
+	) => Promise< { page_id: number; edit_url: string } >;
+	createGalleryPage: (
+		inferred: TailoredInferred
 	) => Promise< { page_id: number; edit_url: string } >;
 }
 
@@ -192,9 +203,10 @@ export async function resolveCtaUrl(
 		url = task.calypso_path;
 	} else if ( kind === 'first_post' && output ) {
 		url = ( await handlers.createFirstPostDraft( output.first_post_draft ) ).edit_url;
-	} else if ( kind === 'pattern_page' && output ) {
-		const variant: PatternVariant = task.id === 'add_gallery_page' ? 'gallery' : 'about';
-		url = ( await handlers.createPatternPage( output.inferred, variant ) ).edit_url;
+	} else if ( kind === 'about_page' && output ) {
+		url = ( await handlers.createAboutPage( output.about_page_draft ) ).edit_url;
+	} else if ( kind === 'gallery_page' && output ) {
+		url = ( await handlers.createGalleryPage( output.inferred ) ).edit_url;
 	} else if ( kind === 'launch' ) {
 		url = siteUrl ? launchSiteUrl( siteUrl ) : null;
 	} else {
@@ -228,7 +240,7 @@ export function isTaskActionable(
 		return true;
 	}
 	const kind = ctaKind( task.id );
-	if ( ( kind === 'first_post' || kind === 'pattern_page' ) && output ) {
+	if ( CREATE_CONTENT_KINDS.includes( kind ) && output ) {
 		return true;
 	}
 	if ( kind === 'launch' ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
@@ -1,8 +1,9 @@
 import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { createAboutPage } from '../lib/about-page.ts';
 import { createFirstPostDraft } from '../lib/first-post.ts';
-import { createPatternPage } from '../lib/pattern-page.ts';
+import { createGalleryPage } from '../lib/pattern-page.ts';
 import { trackTaskClicked, trackTaskSkipped } from '../lib/tracks.ts';
 import { Layout } from './layout.tsx';
 import {
@@ -195,7 +196,8 @@ export function TailoredList( { pendingTailor, initialData, site, goal }: Props 
 				{
 					trackTaskClicked,
 					createFirstPostDraft,
-					createPatternPage,
+					createAboutPage,
+					createGalleryPage,
 				},
 				siteUrl
 			);

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
@@ -68,7 +68,7 @@ function getCtaLabel( taskId: string, inProgress: boolean ): string {
 	switch ( ctaKind( taskId ) ) {
 		case 'first_post':
 			return __( 'Write post', 'jetpack-mu-wpcom' );
-		case 'pattern_page':
+		case 'about_page':
 			return __( 'Add page', 'jetpack-mu-wpcom' );
 		case 'launch':
 			return __( 'Launch site', 'jetpack-mu-wpcom' );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -132,6 +132,10 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 				'title'      => 'First steps on the trail',
 				'paragraphs' => array( 'First paragraph.', 'Second paragraph.' ),
 			),
+			'about_page_draft' => array(
+				'title'      => 'About',
+				'paragraphs' => array( 'Who writes this journal.', 'What readers will find here.' ),
+			),
 		);
 	}
 


### PR DESCRIPTION
Fixes DOTOBRD-529

## Proposed changes

During user testing, the "Add your About page" task prefilled the page with a **footer template pattern** and no content related to the site. Root cause: the About flow scored the whole unfiltered PTK pattern library against the inferred niche words and, when nothing matched, silently fell back to the *first* pattern in the library — patterns only ever supply layout with generic filler copy anyway, so even a "good" match was never about the user's actual site.

This PR removes the cause rather than instrumenting it, and adds observability to the one place selection reasoning remains:

* **The About page is now AI-drafted, no patterns involved.** The tailoring output gains a required `about_page_draft` (title + 2–3 paragraphs, grounded in the user's own wizard description), generated in the same wizard-time AI call as the rest of the output — no extra latency or AI cost at CTA click. The CTA writes it as escaped paragraph blocks (shared helper with the first-post flow). Outputs persisted before the field existed create an empty "About" shell instead of arbitrary library content. This also drops a whole failure mode: the About CTA no longer depends on the PTK network fetch at all.
* **The gallery task keeps patterns** (its content is images, which an AI text draft can't supply) — which makes it the only creation flow whose content is picked by invisible client-side reasoning. A new `content_tailored` Logstash event (`feature: atomic_ai_launchpad`) records that reasoning: library/pool sizes, match words, picked pattern title, score, and which fallback branch produced the content. It's posted directly from the browser to the same public-api logstash endpoint the server-side `log2logstash()` HTTP dispatch already uses (form-encoded, `atomic_`-whitelisted feature), via `sendBeacon` so it survives the immediate navigation to the editor. Best-effort by construction: the payload is built inside the guard, so logging can never fail the creation flow.
* **Gallery scoring fixes the new event caught on its first live run:** the pick for a wildlife-photography portfolio was *"Heading and video on the right"*, scored 2 by matching the stop words "and" + "the". Scoring now drops connective stop words, deduplicates match words across inferred fields, and matches whole tokens only (so "art" can no longer match "Smart").

Known accepted limitation: the server-side `wpcom_ai_launchpad_tailoring_log_enabled` filter gates the existing `tailored` event but not this client-posted one.

## Related product discussion/links

* DOTOBRD-529

## Does this pull request change what data or activity we track or use?

It adds one Logstash event on gallery-page creation (`feature: atomic_ai_launchpad`, `message: content_tailored`). It carries no user free-text: pattern-library titles, AI-inferred niche match words (already logged by the existing `tailored` event), counts, and the created page id.

## Testing instructions

On an AI-Launchpad-eligible site (feature is OFF in production):

1. Reset with `…/wp-admin/admin.php?page=site-setup-wp-admin&reset-ai-launchpad=1` and run the wizard with a "Start a blog" goal and a descriptive brief.
2. Expand **Add your About page** → **Get started**: the created draft should contain 2–3 paragraphs actually about your brief (not a template pattern), and publishing it should still complete the task (marker meta unchanged).
3. Re-run the wizard with **Build a portfolio** and a photography brief; expand **Create your first gallery** → **Create gallery**: the created draft should contain a gallery-category pattern, and the browser should POST a `content_tailored` event to `public-api.wordpress.com/rest/v1.1/logstash` (visible in the Network tab; in Kibana under `feature: atomic_ai_launchpad AND message: content_tailored`).
4. Write your first post still drafts the AI post as before.
5. `?all_tasks=1` and the in-progress ("Continue working on…") treatments behave as before.
