### PR TITLE
Content Guidelines: add Read more support link to page description

### DIFF
--- a/projects/plugins/jetpack/_inc/content-guidelines-ai/components/read-more-link.jsx
+++ b/projects/plugins/jetpack/_inc/content-guidelines-ai/components/read-more-link.jsx
@@ -1,0 +1,29 @@
+import { getRedirectUrl } from '@automattic/jetpack-components';
+import { isWpcomPlatformSite } from '@automattic/jetpack-script-data';
+import { ExternalLink } from '@wordpress/components';
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import {
+	GUIDELINES_SUPPORT_REDIRECT_JETPACK,
+	GUIDELINES_SUPPORT_REDIRECT_WPCOM,
+} from '../constants';
+import { recordGuidelinesEvent } from '../lib/tracks';
+
+export default function ReadMoreLink() {
+	const handleClick = useCallback( () => {
+		recordGuidelinesEvent( 'read_more_click' );
+	}, [] );
+
+	// Same platform split as the editor's Stripe nudge: wpcom platform sites
+	// (Simple and Atomic) read the wordpress.com support docs, self-hosted
+	// sites the jetpack.com ones.
+	const href = isWpcomPlatformSite()
+		? getRedirectUrl( GUIDELINES_SUPPORT_REDIRECT_WPCOM )
+		: getRedirectUrl( GUIDELINES_SUPPORT_REDIRECT_JETPACK );
+
+	return (
+		<ExternalLink href={ href } onClick={ handleClick }>
+			{ __( 'Read more', 'jetpack' ) }
+		</ExternalLink>
+	);
+}

--- a/projects/plugins/jetpack/_inc/content-guidelines-ai/constants.js
+++ b/projects/plugins/jetpack/_inc/content-guidelines-ai/constants.js
@@ -1,3 +1,9 @@
 export const STORE_NAME = 'core/guidelines';
 export const VALID_SECTIONS = [ 'site', 'copy', 'images', 'additional' ];
 export const API_PATH = '/wpcom/v2/jetpack-ai/suggest-guidelines';
+// jetpack.com/redirect source handlers for the "Read more" support link —
+// WordPress.com platform sites (Simple/Atomic) get the wordpress.com support
+// page, self-hosted sites the jetpack.com one. Point them at the final
+// support pages in the redirect tool once published — no code deploy needed.
+export const GUIDELINES_SUPPORT_REDIRECT_WPCOM = 'wpcom-support-content-guidelines';
+export const GUIDELINES_SUPPORT_REDIRECT_JETPACK = 'jetpack-support-content-guidelines';

--- a/projects/plugins/jetpack/_inc/content-guidelines-ai/lib/inject.js
+++ b/projects/plugins/jetpack/_inc/content-guidelines-ai/lib/inject.js
@@ -3,6 +3,7 @@ import { createRoot, createElement } from '@wordpress/element';
 import BlockSuggestionActions from '../components/block-suggestion-actions';
 import BlockSuggestionButtons from '../components/block-suggestion-buttons';
 import EmptyStateBanner from '../components/empty-state-banner';
+import ReadMoreLink from '../components/read-more-link';
 import SectionGenerateButton from '../components/section-generate-button';
 import SuggestAllButton from '../components/suggest-all-button';
 import SuggestionActions from '../components/suggestion-actions';
@@ -18,6 +19,7 @@ import { VALID_SECTIONS } from '../constants';
 
 const slots = {
 	header: { container: null, root: null },
+	'read-more': { container: null, root: null },
 	'upgrade-notice': { container: null, root: null },
 	banner: { container: null, root: null },
 };
@@ -125,14 +127,37 @@ function getBlockNameFromModal( modal ) {
 	return null;
 }
 
+/**
+ * Locate the wp-admin Page header title row — the space-between flex row
+ * containing the page <h1>. All header classes are hashed CSS-module names,
+ * so we walk up from the heading structurally.
+ *
+ * @return {HTMLElement|null} The row element, or null when not found.
+ */
+function findHeaderRow() {
+	const region = document.querySelector( '.admin-ui-navigable-region' );
+	const heading = region?.querySelector( 'h1' );
+	let row = heading?.parentElement;
+	while ( row && row !== region ) {
+		const style = window.getComputedStyle( row );
+		if (
+			style.display === 'flex' &&
+			style.flexDirection === 'row' &&
+			style.justifyContent.includes( 'between' )
+		) {
+			break;
+		}
+		row = row.parentElement;
+	}
+	return row && row !== region ? row : null;
+}
+
 function runAll() {
 	// Header button — right-aligned in the wp-admin Page header, where the
 	// native header actions would render. The gutenberg page passes no
-	// `actions` to <Page>, so that slot is never created; instead we target the
-	// header-content row (flex, justify: space-between) that holds the title and
-	// append the button as its second child so space-between pushes it to the
-	// right. All header classes are hashed CSS-module names, so we locate the
-	// row structurally: the space-between flex row containing the page <h1>.
+	// `actions` to <Page>, so that slot is never created; instead we append
+	// the button as the title row's second child so space-between pushes it
+	// to the right.
 	inject(
 		'header',
 		() => {
@@ -144,21 +169,8 @@ function runAll() {
 				return null;
 			}
 
-			const region = document.querySelector( '.admin-ui-navigable-region' );
-			const heading = region?.querySelector( 'h1' );
-			let row = heading?.parentElement;
-			while ( row && row !== region ) {
-				const style = window.getComputedStyle( row );
-				if (
-					style.display === 'flex' &&
-					style.flexDirection === 'row' &&
-					style.justifyContent.includes( 'between' )
-				) {
-					break;
-				}
-				row = row.parentElement;
-			}
-			return row && row !== region
+			const row = findHeaderRow();
+			return row
 				? {
 						parent: row,
 						className: 'jetpack-content-guidelines-ai__header-container',
@@ -166,6 +178,30 @@ function runAll() {
 				: null;
 		},
 		SuggestAllButton
+	);
+
+	// "Read more" support link — inline at the end of the header subtitle,
+	// the description <p> that follows the title row (its class is a hashed
+	// CSS-module name, so it's located structurally). Unlike the header
+	// button, there is no store data to wait for, so don't gate on
+	// `.guidelines__list` (which only exists after the async guidelines
+	// fetch) — inject as soon as the header renders so the link paints
+	// together with the description instead of popping in seconds later.
+	// The revision-history screen needs no explicit exclusion: it renders
+	// no Page header, so findHeaderRow() finds nothing there.
+	inject(
+		'read-more',
+		() => {
+			const subtitle = findHeaderRow()?.nextElementSibling;
+			return subtitle?.tagName === 'P'
+				? {
+						parent: subtitle,
+						className: 'jetpack-content-guidelines-ai__read-more-container',
+						tag: 'span',
+				  }
+				: null;
+		},
+		ReadMoreLink
 	);
 
 	// Upgrade notice — shown above the guideline list when AI is unavailable.

--- a/projects/plugins/jetpack/_inc/content-guidelines-ai/style.scss
+++ b/projects/plugins/jetpack/_inc/content-guidelines-ai/style.scss
@@ -242,7 +242,7 @@ $cg-diff-removed: #f8d7da;
 // "Read more" support link injected inline at the end of the
 // header description paragraph.
 .jetpack-content-guidelines-ai__read-more-container {
-	margin-left: 4px;
+	margin-inline-start: 4px;
 }
 
 // Upgrade notice.

--- a/projects/plugins/jetpack/_inc/content-guidelines-ai/style.scss
+++ b/projects/plugins/jetpack/_inc/content-guidelines-ai/style.scss
@@ -239,6 +239,12 @@ $cg-diff-removed: #f8d7da;
 	flex-wrap: wrap;
 }
 
+// "Read more" support link injected inline at the end of the
+// header description paragraph.
+.jetpack-content-guidelines-ai__read-more-container {
+	margin-left: 4px;
+}
+
 // Upgrade notice.
 .jetpack-content-guidelines-ai__upgrade-notice-container {
 	display: contents;

--- a/projects/plugins/jetpack/changelog/add-content-guidelines-read-more-link
+++ b/projects/plugins/jetpack/changelog/add-content-guidelines-read-more-link
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Content Guidelines: Add a Read more support link to the page description.


### PR DESCRIPTION
Fixes # N/A

## Proposed changes

* Adds a "Read more" external link at the end of the Content Guidelines page header description, injected by the existing `content-guidelines-ai` bundle (new `read-more` slot in `inject.js`).
* The link goes through the jetpack.com/redirect service with the usual platform split (same pattern as the editor's Stripe nudge): `isWpcomPlatformSite()` → `wpcom-support-content-guidelines`, self-hosted → `jetpack-support-content-guidelines`. Destinations get registered in the redirect tool once the support pages are published — no code deploy needed. No new dependencies (`@automattic/jetpack-components` and `@automattic/jetpack-script-data` are already bundle deps).
* Extracts the header slot's structural title-row walk into a shared `findHeaderRow()` helper used by both the header button and the new link.

## Related product discussion/links

* Internal: Content Guidelines AI rollout (feature currently gated to Automatticians).

## Does this pull request change what data or activity we track or use?

Adds one new Tracks event: `jetpack_ai_guidelines_read_more_click`, fired when the link is clicked. Anonymous UI interaction event, no new user data collected.

## Testing instructions

Requires an Automattician account (feature gate) and a WordPress.com Simple site, with your sandbox serving this branch's Jetpack build.

* Build this branch: `pnpm jetpack build plugins/jetpack --production` (or copy `_inc/build/content-guidelines-ai.{min.js,min.asset.php,css,rtl.css}` to your sandbox's `jetpack-plugin/sun/_inc/build/`).
* Visit wp-admin → Settings → Guidelines on the test site.
* Confirm a "Read more ↗" link renders inline at the end of the page description ("…voice and requirements."), styled like the surrounding text. It should appear together with the description — before the guidelines list finishes loading — not pop in afterwards.
* Click it: on a Simple site it should open `https://jetpack.com/redirect/?source=wpcom-support-content-guidelines` in a new tab (redirects to jetpack.com until the slug is registered), and queue a `jetpack_ai_guidelines_read_more_click` Tracks event (check `window._tkq` or the `t.gif` pixel request).
* On a self-hosted/JN site with the page available, the link should use `?source=jetpack-support-content-guidelines` instead.
* Open revision history and navigate back: the link should re-appear (re-injection), and it should NOT appear anywhere on the revision history screen itself.
* Non-Automattician users or sites without the AI feature state should see no change (whole bundle is gated).

Follow-up before un-gating: register both redirect sources in the redirect tool pointing at the final support pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016bCZZoziJ9cAbDwANFJnDG

