### PR TITLE
Forms/Newsletter: deterministic Color Studio background colors for initials Gravatars

### DIFF
--- a/projects/js-packages/components/changelog/add-gravatar-identity-bg-color
+++ b/projects/js-packages/components/changelog/add-gravatar-identity-bg-color
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Gravatar: pick a stable Color Studio background color per email for initials identity avatars via bg_color

--- a/projects/js-packages/components/components/gravatar/index.tsx
+++ b/projects/js-packages/components/components/gravatar/index.tsx
@@ -23,6 +23,39 @@ type DefaultImage =
 	| 'robohash'
 	| 'wavatar';
 
+/**
+ * Background colors for the "initials" identity avatars, drawn from the
+ * Color Studio palette's 50 shades (https://color-studio.blog/).
+ *
+ * Hex values without the leading `#`, as Gravatar's `bg_color` param expects.
+ */
+const IDENTITY_BG_COLORS = [
+	'3858e9', // Blue 50
+	'984a9c', // Purple 50
+	'c9356e', // Pink 50
+	'd63638', // Red 50
+	'b26200', // Orange 50
+	'9d6e00', // Yellow 50
+	'008a20', // Green 50
+	'008763', // Celadon 50
+];
+
+/**
+ * Picks a stable background color for an email's identity avatar, so the same
+ * address always renders on the same Color Studio color.
+ *
+ * Uses the first 8 hex chars of the normalized email's SHA-256, matching
+ * `Feedback_Author::get_avatar_url()` in the Forms package.
+ *
+ * @param email - Email address the avatar is rendered for.
+ * @return A hex color (without the leading `#`) from IDENTITY_BG_COLORS.
+ */
+export function getIdentityBackgroundColor( email: string ): string {
+	const hash = sha256( email.trim().toLowerCase() );
+	const index = parseInt( hash.slice( 0, 8 ), 16 ) % IDENTITY_BG_COLORS.length;
+	return IDENTITY_BG_COLORS[ index ];
+}
+
 export type GravatarProps = {
 	/**
 	 * Style of the placeholder image when the email has no Gravatar profile.
@@ -123,13 +156,15 @@ export default function Gravatar( {
 
 	const hashedEmail = sha256( email );
 	const hovercardName = displayName ? `&name=${ encodeURIComponent( displayName ) }` : '';
+	const backgroundColor =
+		defaultImage === 'initials' ? `&bg_color=${ getIdentityBackgroundColor( email ) }` : '';
 
 	return (
 		<img
 			ref={ profileImageRef }
 			className={ clsx( 'jetpack-components-gravatar', className ) }
 			alt={ displayName || '' }
-			src={ `https://secure.gravatar.com/avatar/${ hashedEmail }?d=${ defaultImage }${ hovercardName }` }
+			src={ `https://secure.gravatar.com/avatar/${ hashedEmail }?d=${ defaultImage }${ hovercardName }${ backgroundColor }` }
 			width={ size }
 			height={ size }
 			loading="lazy"

--- a/projects/js-packages/components/components/gravatar/index.tsx
+++ b/projects/js-packages/components/components/gravatar/index.tsx
@@ -31,6 +31,13 @@ type DefaultImage =
  * against them, and the warmer ones (orange, yellow, green, celadon) sit right
  * on the 4.5:1 line. Swapping in a lighter tint would quietly drop below AA.
  *
+ * Keep in sync with `Feedback_Author::IDENTITY_BG_COLORS` in
+ * projects/packages/forms/src/contact-form/class-feedback-author.php, which
+ * colors the same authors in the response notification emails. The hexes are
+ * spelled out rather than imported from `@automattic/color-studio` on purpose:
+ * PHP can't read node_modules at runtime, so importing here would let the two
+ * halves drift apart invisibly instead of visibly.
+ *
  * Hex values without the leading `#`, as Gravatar's `bg_color` param expects.
  */
 const IDENTITY_BG_COLORS = [
@@ -49,12 +56,15 @@ const IDENTITY_BG_COLORS = [
  * address always renders on the same Color Studio color.
  *
  * Uses the first 8 hex chars of the normalized email's SHA-256, matching
- * `Feedback_Author::get_avatar_url()` in the Forms package.
+ * `Feedback_Author::get_identity_background_color()` in the Forms package.
+ *
+ * Any stable string works: the Forms dashboard falls back to the visitor's IP
+ * address for responses submitted without an email.
  *
  * @param email - Email address the avatar is rendered for.
- * @return A hex color (without the leading `#`) from IDENTITY_BG_COLORS.
+ * @return A hex color from IDENTITY_BG_COLORS.
  */
-export function getIdentityBackgroundColor( email: string ): string {
+function getIdentityBackgroundColor( email: string ): string {
 	const hash = sha256( email.trim().toLowerCase() );
 	const index = parseInt( hash.slice( 0, 8 ), 16 ) % IDENTITY_BG_COLORS.length;
 	return IDENTITY_BG_COLORS[ index ];
@@ -160,7 +170,7 @@ export default function Gravatar( {
 
 	const hashedEmail = sha256( email );
 	const hovercardName = displayName ? `&name=${ encodeURIComponent( displayName ) }` : '';
-	const backgroundColor =
+	const bgColorParam =
 		defaultImage === 'initials' ? `&bg_color=${ getIdentityBackgroundColor( email ) }` : '';
 
 	return (
@@ -168,7 +178,7 @@ export default function Gravatar( {
 			ref={ profileImageRef }
 			className={ clsx( 'jetpack-components-gravatar', className ) }
 			alt={ displayName || '' }
-			src={ `https://secure.gravatar.com/avatar/${ hashedEmail }?d=${ defaultImage }${ hovercardName }${ backgroundColor }` }
+			src={ `https://secure.gravatar.com/avatar/${ hashedEmail }?d=${ defaultImage }${ hovercardName }${ bgColorParam }` }
 			width={ size }
 			height={ size }
 			loading="lazy"

--- a/projects/js-packages/components/components/gravatar/index.tsx
+++ b/projects/js-packages/components/components/gravatar/index.tsx
@@ -27,6 +27,10 @@ type DefaultImage =
  * Background colors for the "initials" identity avatars, drawn from the
  * Color Studio palette's 50 shades (https://color-studio.blog/).
  *
+ * Only the 50-level shades are safe here: the white initials clear WCAG AA
+ * against them, and the warmer ones (orange, yellow, green, celadon) sit right
+ * on the 4.5:1 line. Swapping in a lighter tint would quietly drop below AA.
+ *
  * Hex values without the leading `#`, as Gravatar's `bg_color` param expects.
  */
 const IDENTITY_BG_COLORS = [

--- a/projects/packages/forms/changelog/add-gravatar-identity-bg-color
+++ b/projects/packages/forms/changelog/add-gravatar-identity-bg-color
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Feedback author avatars: pick a stable Color Studio background color per email for initials identity avatars via bg_color

--- a/projects/packages/forms/src/contact-form/class-feedback-author.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-author.php
@@ -132,6 +132,42 @@ class Feedback_Author {
 	}
 
 	/**
+	 * Background colors for the "initials" identity avatars, drawn from the
+	 * Color Studio palette's 50 shades (https://color-studio.blog/).
+	 *
+	 * Hex values without the leading `#`, as Gravatar's `bg_color` param expects.
+	 *
+	 * @var string[]
+	 */
+	const IDENTITY_BG_COLORS = array(
+		'3858e9', // Blue 50.
+		'984a9c', // Purple 50.
+		'c9356e', // Pink 50.
+		'd63638', // Red 50.
+		'b26200', // Orange 50.
+		'9d6e00', // Yellow 50.
+		'008a20', // Green 50.
+		'008763', // Celadon 50.
+	);
+
+	/**
+	 * Pick a stable background color for an email's identity avatar, so the
+	 * same address always renders on the same Color Studio color.
+	 *
+	 * Uses the first 8 hex chars of the normalized email's SHA-256, matching
+	 * the shared Gravatar component in js-packages/components.
+	 *
+	 * @param string $email Email address the avatar is rendered for.
+	 * @return string A hex color (without the leading `#`) from IDENTITY_BG_COLORS.
+	 */
+	public static function get_identity_background_color( string $email ): string {
+		$hash  = hash( 'sha256', strtolower( trim( $email ) ) );
+		$index = hexdec( substr( $hash, 0, 8 ) ) % count( self::IDENTITY_BG_COLORS );
+
+		return self::IDENTITY_BG_COLORS[ $index ];
+	}
+
+	/**
 	 * Get the avatar URL of the author.
 	 *
 	 * Uses Gravatar's "initials" default so that users without a Gravatar
@@ -154,7 +190,7 @@ class Feedback_Author {
 			$name = strstr( $this->email, '@', true );
 		}
 
-		return "https://gravatar.com/avatar/{$hash}?d=initials&name=" . rawurlencode( $name ) . '&s=96';
+		return "https://gravatar.com/avatar/{$hash}?d=initials&name=" . rawurlencode( $name ) . '&s=96&bg_color=' . self::get_identity_background_color( $this->email );
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-feedback-author.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-author.php
@@ -135,6 +135,10 @@ class Feedback_Author {
 	 * Background colors for the "initials" identity avatars, drawn from the
 	 * Color Studio palette's 50 shades (https://color-studio.blog/).
 	 *
+	 * Only the 50-level shades are safe here: the white initials clear WCAG AA
+	 * against them, and the warmer ones (orange, yellow, green, celadon) sit right
+	 * on the 4.5:1 line. Swapping in a lighter tint would quietly drop below AA.
+	 *
 	 * Hex values without the leading `#`, as Gravatar's `bg_color` param expects.
 	 *
 	 * @var string[]

--- a/projects/packages/forms/src/contact-form/class-feedback-author.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-author.php
@@ -15,6 +15,33 @@ namespace Automattic\Jetpack\Forms\ContactForm;
 class Feedback_Author {
 
 	/**
+	 * Background colors for the "initials" identity avatars, drawn from the
+	 * Color Studio palette's 50 shades (https://color-studio.blog/).
+	 *
+	 * Only the 50-level shades are safe here: the white initials clear WCAG AA
+	 * against them, and the warmer ones (orange, yellow, green, celadon) sit right
+	 * on the 4.5:1 line. Swapping in a lighter tint would quietly drop below AA.
+	 *
+	 * Keep in sync with IDENTITY_BG_COLORS in
+	 * projects/js-packages/components/components/gravatar/index.tsx, which colors
+	 * the same authors in the Forms dashboard.
+	 *
+	 * Hex values without the leading `#`, as Gravatar's `bg_color` param expects.
+	 *
+	 * @var string[]
+	 */
+	const IDENTITY_BG_COLORS = array(
+		'3858e9', // Blue 50.
+		'984a9c', // Purple 50.
+		'c9356e', // Pink 50.
+		'd63638', // Red 50.
+		'b26200', // Orange 50.
+		'9d6e00', // Yellow 50.
+		'008a20', // Green 50.
+		'008763', // Celadon 50.
+	);
+
+	/**
 	 * The name of the author.
 	 *
 	 * @var string
@@ -132,39 +159,17 @@ class Feedback_Author {
 	}
 
 	/**
-	 * Background colors for the "initials" identity avatars, drawn from the
-	 * Color Studio palette's 50 shades (https://color-studio.blog/).
-	 *
-	 * Only the 50-level shades are safe here: the white initials clear WCAG AA
-	 * against them, and the warmer ones (orange, yellow, green, celadon) sit right
-	 * on the 4.5:1 line. Swapping in a lighter tint would quietly drop below AA.
-	 *
-	 * Hex values without the leading `#`, as Gravatar's `bg_color` param expects.
-	 *
-	 * @var string[]
-	 */
-	const IDENTITY_BG_COLORS = array(
-		'3858e9', // Blue 50.
-		'984a9c', // Purple 50.
-		'c9356e', // Pink 50.
-		'd63638', // Red 50.
-		'b26200', // Orange 50.
-		'9d6e00', // Yellow 50.
-		'008a20', // Green 50.
-		'008763', // Celadon 50.
-	);
-
-	/**
 	 * Pick a stable background color for an email's identity avatar, so the
 	 * same address always renders on the same Color Studio color.
 	 *
 	 * Uses the first 8 hex chars of the normalized email's SHA-256, matching
-	 * the shared Gravatar component in js-packages/components.
+	 * `getIdentityBackgroundColor()` in the shared Gravatar component
+	 * (projects/js-packages/components/components/gravatar/index.tsx).
 	 *
 	 * @param string $email Email address the avatar is rendered for.
-	 * @return string A hex color (without the leading `#`) from IDENTITY_BG_COLORS.
+	 * @return string A hex color from IDENTITY_BG_COLORS.
 	 */
-	public static function get_identity_background_color( string $email ): string {
+	private static function get_identity_background_color( string $email ): string {
 		$hash  = hash( 'sha256', strtolower( trim( $email ) ) );
 		$index = hexdec( substr( $hash, 0, 8 ) ) % count( self::IDENTITY_BG_COLORS );
 
@@ -194,7 +199,9 @@ class Feedback_Author {
 			$name = strstr( $this->email, '@', true );
 		}
 
-		return "https://gravatar.com/avatar/{$hash}?d=initials&name=" . rawurlencode( $name ) . '&s=96&bg_color=' . self::get_identity_background_color( $this->email );
+		$bg_color = self::get_identity_background_color( $this->email );
+
+		return "https://gravatar.com/avatar/{$hash}?d=initials&s=96&bg_color={$bg_color}&name=" . rawurlencode( $name );
 	}
 
 	/**


### PR DESCRIPTION
Example colours
<img width="1080" height="719" alt="Screenshot 2026-07-16 at 11 33 47 AM" src="https://github.com/user-attachments/assets/f1c1fe79-735a-46aa-9548-1ad3fe852d94" />

## Proposed changes

* The shared `Gravatar` component (`js-packages/components`) now appends a `bg_color` query parameter when the `initials` identity variation is used, so avatars for users without a Gravatar profile render on a consistent, deterministic background color.
* The color is picked from a subset of the [Color Studio](https://color-studio.blog/) palette's `50` shades (Blue, Purple, Pink, Red, Orange, Yellow, Green, Celadon) by hashing the normalized email (`sha256` of the lowercased/trimmed address → first 8 hex chars → palette index), so the same email always gets the same color across page refreshes and surfaces.
* `Feedback_Author::get_avatar_url()` in the Forms package applies the same palette and identical hash math server-side, so the `author_avatar` REST field and form-response emails match the dashboard color for a given email.
* Affected surfaces: Forms responses inbox + response inspector (both dashboard implementations) and the Newsletter Subscribers list + subscriber detail views.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build and install this branch (`jetpack build --deps plugins/jetpack`) on a test site, or use a Jurassic Ninja site.
* Create a page with a Form block and submit responses using emails that have no Gravatar profile. These cover all 8 palette colors:
  * `mallory@example.com` → Blue `#3858e9`
  * `alice@example.com` → Purple `#984a9c`
  * `frank@example.com` → Pink `#c9356e`
  * `dave@example.com` → Red `#d63638`
  * `grace@example.com` → Orange `#b26200`
  * `erin@example.com` → Yellow `#9d6e00`
  * `gia@example.com` → Green `#008a20`
  * `bob@example.com` → Celadon `#008763`
* Go to wp-admin → Jetpack → Forms → Responses and confirm each response's initials avatar uses the expected background color, and that the colors are stable across page refreshes.
* Open a response in the inspector panel and confirm the avatar color matches the list.
* In the wp-admin Subscribers UI (Newsletter), add subscribers with the emails above and confirm the same colors appear in the list and detail views.
* Confirm an email address **with** a real Gravatar profile still shows its actual profile image (the `bg_color` param only affects the `initials` fallback).
* Check a form response notification email: the avatar in the email should use the same background color as the dashboard for the same sender email.
