### PR TITLE
pnpm: exclude i18n-calypso from minimumReleaseAge check

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -35,6 +35,7 @@ minimumReleaseAgeExclude:
   - '@woocommerce/*'
   - '@wordpress/*'
   - 'gridicons'
+  - 'i18n-calypso'
 trustPolicy: no-downgrade
 trustPolicyExclude:
   # https://github.com/paulmillr/chokidar/issues/1440


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add `i18n-calypso` to `minimumReleaseAgeExclude` in `pnpm-workspace.yaml`.
* `i18n-calypso` is a first-party Automattic package but is published *unscoped*, so it wasn't covered by the existing `@automattic/*` exclusion.
* Fresh releases of it were being rejected by the 1-day `minimumReleaseAge` supply-chain policy (`ERR_PNPM_NO_MATURE_MATCHING_VERSION`), which blocked routine updates of `@automattic/*` packages that pull `i18n-calypso` in transitively (e.g. `@automattic/launchpad` → `@automattic/components`/`data-stores`/`calypso-analytics`).
* This aligns `i18n-calypso` with the other first-party scopes already on the exclude list.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Check out this branch.
* Run an update that pulls a recently-published `i18n-calypso` transitively, e.g.:
  `pnpm update -r @automattic/launchpad@latest`
* Confirm the update resolves without an `ERR_PNPM_NO_MATURE_MATCHING_VERSION` error for `i18n-calypso`.
* Confirm `pnpm install` still passes the supply-chain policy verification for all other entries (the `minimumReleaseAge` gate remains in effect for every package not on the exclude list).
