### PR TITLE
Premium Analytics: keep the DataViews drill-down hierarchy on filter and sort

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-pa-drilldown-hierarchy
+++ b/projects/packages/premium-analytics/changelog/update-pa-drilldown-hierarchy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+UI: keep the DataViewsDrilldownNative hierarchy under search, filter, and sort.

--- a/projects/packages/premium-analytics/packages/ui/src/dataviews-drilldown-native/__tests__/process-hierarchy-levels.test.ts
+++ b/projects/packages/premium-analytics/packages/ui/src/dataviews-drilldown-native/__tests__/process-hierarchy-levels.test.ts
@@ -1,4 +1,4 @@
-import { processHierarchyLevels } from '../process-hierarchy-levels';
+import { processHierarchyLevels, withAncestors } from '../process-hierarchy-levels';
 
 type Row = {
 	id: string;
@@ -105,5 +105,72 @@ describe( 'processHierarchyLevels', () => {
 		expect( data ).toHaveLength( 2 );
 		expect( levelByItem.get( noIdRows[ 0 ] ) ).toBe( 0 );
 		expect( levelByItem.get( noIdRows[ 1 ] ) ).toBe( 0 );
+	} );
+} );
+
+describe( 'withAncestors', () => {
+	it( 'includes the ancestor chain of a matched row, in data order', () => {
+		const result = withAncestors(
+			rows,
+			new Set( [ 'google-search' ] ),
+			getItemId,
+			getItemParentId
+		);
+
+		expect( result.map( row => row.id ) ).toEqual( [ 'search', 'google', 'google-search' ] );
+	} );
+
+	it( 'returns a top-level match on its own', () => {
+		const result = withAncestors( rows, new Set( [ 'social' ] ), getItemId, getItemParentId );
+
+		expect( result.map( row => row.id ) ).toEqual( [ 'social' ] );
+	} );
+
+	it( 'collects a shared ancestor once for sibling matches', () => {
+		const result = withAncestors(
+			rows,
+			new Set( [ 'google', 'bing' ] ),
+			getItemId,
+			getItemParentId
+		);
+
+		expect( result.map( row => row.id ) ).toEqual( [ 'search', 'google', 'bing' ] );
+	} );
+
+	it( 'returns nothing when no row matched', () => {
+		expect( withAncestors( rows, new Set< string >(), getItemId, getItemParentId ) ).toEqual( [] );
+	} );
+
+	it( 'returns every row when all matched, preserving order', () => {
+		const result = withAncestors(
+			rows,
+			new Set( rows.map( getItemId ) ),
+			getItemId,
+			getItemParentId
+		);
+
+		expect( result ).toEqual( rows );
+	} );
+
+	it( 'stops at a parent absent from the data', () => {
+		const orphan: Row = { id: 'orphan', parentId: 'missing', referrer: 'Orphan', views: 1 };
+		const result = withAncestors(
+			[ ...rows, orphan ],
+			new Set( [ 'orphan' ] ),
+			getItemId,
+			getItemParentId
+		);
+
+		expect( result.map( row => row.id ) ).toEqual( [ 'orphan' ] );
+	} );
+
+	it( 'does not loop on a parent cycle', () => {
+		const cycle: Row[] = [
+			{ id: 'a', parentId: 'b', referrer: 'A', views: 1 },
+			{ id: 'b', parentId: 'a', referrer: 'B', views: 1 },
+		];
+		const result = withAncestors( cycle, new Set( [ 'a' ] ), getItemId, getItemParentId );
+
+		expect( result.map( row => row.id ).sort() ).toEqual( [ 'a', 'b' ] );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/ui/src/dataviews-drilldown-native/dataviews-drilldown-native.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/dataviews-drilldown-native/dataviews-drilldown-native.tsx
@@ -8,7 +8,7 @@ import { useCallback, useMemo, useState } from 'react';
  * Internal dependencies
  */
 import styles from './dataviews-drilldown-native.module.scss';
-import { processHierarchyLevels } from './process-hierarchy-levels';
+import { processHierarchyLevels, withAncestors } from './process-hierarchy-levels';
 import type { Field, SupportedLayouts, View, ViewBaseProps } from '@wordpress/dataviews';
 import type { ComponentProps, ReactNode } from 'react';
 
@@ -73,14 +73,12 @@ export interface DataViewsDrilldownNativeProps< Item > {
 }
 
 /**
- * Render flat parent/child rows through DataViews' own hierarchy support and
- * nothing else: the rows are re-emitted in depth-first order, `getItemLevel`
- * reports each row's depth, and `view.showLevels` renders the level marker on
- * the view's `titleField`. There is no expand/collapse — DataViews' native
- * level rendering is a static display — and search, filters, sorting, and
- * pagination are DataViews' flat `filterSortAndPaginate` semantics, so
- * sorting by a field re-orders rows flat and visually breaks the hierarchy
- * grouping.
+ * Render flat parent/child rows through DataViews' native hierarchy support
+ * (`view.showLevels` + `getItemLevel`), keeping the hierarchy legible across
+ * interactions: search and filter keep each match under its ancestors, sort
+ * orders within each level (not a flat global sort), and rows are emitted in
+ * depth-first order before pagination. There is no expand/collapse yet; the
+ * native level rendering is a static display.
  *
  * @param {DataViewsDrilldownNativeProps< Item >} props - The component props.
  * @return The DataViews drilldown.
@@ -113,15 +111,53 @@ export function DataViewsDrilldownNative< Item >( {
 		} as View;
 	} );
 
-	const { data: orderedData, levelByItem } = useMemo(
-		() => processHierarchyLevels( data, getItemId, getItemParentId ),
-		[ data, getItemId, getItemParentId ]
-	);
+	// Keep the hierarchy legible instead of the flat `filterSortAndPaginate`
+	// semantics: match, re-attach ancestors, re-emit in hierarchy order, then
+	// paginate. Runs over the in-memory rows, so the extra passes are cheap.
+	const { pageData, levelByItem, paginationInfo } = useMemo( () => {
+		// 1. Match: apply the view's search + filters only (no sort, one page).
+		const matches = filterSortAndPaginate(
+			data,
+			{ ...view, sort: undefined, page: 1, perPage: Math.max( data.length, 1 ) },
+			fields
+		).data;
 
-	const { data: pageData, paginationInfo } = useMemo(
-		() => filterSortAndPaginate( orderedData, view, fields ),
-		[ orderedData, view, fields ]
-	);
+		// 2. Re-attach ancestors so filtered children stay under their parents
+		//    instead of orphaned.
+		const subset = withAncestors(
+			data,
+			new Set( matches.map( getItemId ) ),
+			getItemId,
+			getItemParentId
+		);
+
+		// 3. Sort within levels: sort the subset flat, then re-emit in hierarchy
+		//    order; `processHierarchyLevels` keeps that order among siblings.
+		const sorted = filterSortAndPaginate(
+			subset,
+			{ ...view, search: '', filters: [], page: 1, perPage: Math.max( subset.length, 1 ) },
+			fields
+		).data;
+		const { data: orderedData, levelByItem: levels } = processHierarchyLevels(
+			sorted,
+			getItemId,
+			getItemParentId
+		);
+
+		// 4. Paginate the hierarchy-ordered rows ourselves.
+		const perPage = view.perPage ?? 10;
+		const page = view.page ?? 1;
+		const start = ( page - 1 ) * perPage;
+
+		return {
+			pageData: orderedData.slice( start, start + perPage ),
+			levelByItem: levels,
+			paginationInfo: {
+				totalItems: orderedData.length,
+				totalPages: Math.max( 1, Math.ceil( orderedData.length / perPage ) ),
+			},
+		};
+	}, [ data, view, fields, getItemId, getItemParentId ] );
 
 	const getItemLevel = useCallback(
 		( item: Item ) => levelByItem.get( item ) ?? 0,

--- a/projects/packages/premium-analytics/packages/ui/src/dataviews-drilldown-native/dataviews-drilldown-native.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/dataviews-drilldown-native/dataviews-drilldown-native.tsx
@@ -167,6 +167,8 @@ export function DataViewsDrilldownNative< Item >( {
 	// DataViews' appearance panel force-sets `showLevels: false` when you sort
 	// (native levels assume the default order). Our pipeline sorts within each
 	// level, so re-assert `showLevels: true` on every view change.
+	// TODO(upstream): DataViews shouldn't drop levels when the consumer's sort
+	// preserves the hierarchy; worth upstreaming so this workaround can go.
 	const handleChangeView = useCallback(
 		( nextView: View ) => setView( { ...nextView, showLevels: true } ),
 		[]

--- a/projects/packages/premium-analytics/packages/ui/src/dataviews-drilldown-native/dataviews-drilldown-native.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/dataviews-drilldown-native/dataviews-drilldown-native.tsx
@@ -164,11 +164,19 @@ export function DataViewsDrilldownNative< Item >( {
 		[ levelByItem ]
 	);
 
+	// DataViews' appearance panel force-sets `showLevels: false` when you sort
+	// (native levels assume the default order). Our pipeline sorts within each
+	// level, so re-assert `showLevels: true` on every view change.
+	const handleChangeView = useCallback(
+		( nextView: View ) => setView( { ...nextView, showLevels: true } ),
+		[]
+	);
+
 	return (
 		<div className={ clsx( styles.root, hideLevelMarkers && styles.hideLevelMarkers ) }>
 			<GenericDataViews< Item >
 				view={ view }
-				onChangeView={ setView }
+				onChangeView={ handleChangeView }
 				fields={ fields }
 				data={ pageData }
 				getItemId={ getItemId }

--- a/projects/packages/premium-analytics/packages/ui/src/dataviews-drilldown-native/index.ts
+++ b/projects/packages/premium-analytics/packages/ui/src/dataviews-drilldown-native/index.ts
@@ -1,3 +1,3 @@
 export { DataViewsDrilldownNative } from './dataviews-drilldown-native';
 export type { DataViewsDrilldownNativeProps } from './dataviews-drilldown-native';
-export { processHierarchyLevels } from './process-hierarchy-levels';
+export { processHierarchyLevels, withAncestors } from './process-hierarchy-levels';

--- a/projects/packages/premium-analytics/packages/ui/src/dataviews-drilldown-native/process-hierarchy-levels.ts
+++ b/projects/packages/premium-analytics/packages/ui/src/dataviews-drilldown-native/process-hierarchy-levels.ts
@@ -88,3 +88,53 @@ export function processHierarchyLevels< Item >(
 
 	return { data: orderedData, levelByItem };
 }
+
+/**
+ * Given the ids of the rows a search or filter matched, return those rows plus
+ * every ancestor up to a root, in the original `data` order (ready for
+ * {@link processHierarchyLevels}). This keeps a filtered view's matches under
+ * their parents instead of orphaning them. A missing, self-referential, or
+ * already-kept parent ends the walk, so cycles cannot loop.
+ *
+ * @param data            - The full flat rows.
+ * @param matchedIds      - Ids (from `getItemId`) of the rows that matched.
+ * @param getItemId       - Row id resolver.
+ * @param getItemParentId - Parent id resolver.
+ * @return The matched rows plus their ancestors, in `data` order.
+ */
+export function withAncestors< Item >(
+	data: Item[],
+	matchedIds: ReadonlySet< string >,
+	getItemId: ( item: Item ) => string,
+	getItemParentId: ( item: Item ) => string | number | null | undefined
+): Item[] {
+	const itemById = new Map( data.map( item => [ getItemId( item ), item ] ) );
+	const keep = new Set< string >( matchedIds );
+
+	for ( const id of matchedIds ) {
+		let current = itemById.get( id );
+
+		while ( current ) {
+			const rawParentId = getItemParentId( current );
+			const parentId =
+				rawParentId === null || rawParentId === undefined ? undefined : rawParentId.toString();
+
+			// Stop at a root, a self-referential parent, or one already kept
+			// (the last also breaks cycles, since a kept id's ancestors are
+			// guaranteed collected).
+			if ( ! parentId || parentId === getItemId( current ) || keep.has( parentId ) ) {
+				break;
+			}
+
+			const parent = itemById.get( parentId );
+			if ( ! parent ) {
+				break;
+			}
+
+			keep.add( parentId );
+			current = parent;
+		}
+	}
+
+	return data.filter( item => keep.has( getItemId( item ) ) );
+}

--- a/projects/packages/premium-analytics/packages/ui/src/dataviews-drilldown-native/stories/dataviews-drilldown-native.stories.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/dataviews-drilldown-native/stories/dataviews-drilldown-native.stories.tsx
@@ -482,7 +482,7 @@ export const Default: Story = {
 		docs: {
 			description: {
 				story:
-					"DataViews' native hierarchy rendering: `view.showLevels` plus `getItemLevel`, with levels drawn as em-dash markers on the title field. The hidden Medium field is filterable so the default DataViews filter control appears next to search.",
+					"DataViews' native hierarchy rendering: `view.showLevels` plus `getItemLevel`, with levels drawn as em-dash markers on the title field. Search and filter keep matches under their ancestors, and sort orders within each level. The hidden Medium field is filterable so the default DataViews filter control appears next to search.",
 			},
 		},
 	},
@@ -510,6 +510,21 @@ export const MultipleColumns: Story = {
 	},
 };
 
+export const Search: Story = {
+	args: {
+		...Default.args,
+		initialView: { ...initialView, search: 'Google' },
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Search keeps matches under their ancestors instead of orphaning them: searching "Google" surfaces Google, Google Search, and Google Images, still nested under Search Engines. Clear the search to see the full tree.',
+			},
+		},
+	},
+};
+
 export const Sorted: Story = {
 	args: {
 		...Default.args,
@@ -519,7 +534,7 @@ export const Sorted: Story = {
 		docs: {
 			description: {
 				story:
-					'Sorting keeps the flat `filterSortAndPaginate` semantics: rows re-order by the sorted field regardless of hierarchy, so level markers stay per-row but the visual grouping breaks. This is native DataViews behaviour, not a bug in the component.',
+					'Sorting orders within each level, not globally: top-level rows sort against each other and children sort within their parent, so the tree stays intact. Sorted by Views (desc) here.',
 			},
 		},
 	},
@@ -560,7 +575,7 @@ export const Paginated: Story = {
 		docs: {
 			description: {
 				story:
-					'Pagination is the flat DataViews semantics: every row counts as an item, and with no expand/collapse a deep subtree simply spans pages.',
+					'Pagination counts every row and slices the hierarchy-ordered list. Until the parent-on-page-boundary refinement lands, a deep subtree can still span pages (its child rows appear on the next page without their parent).',
 			},
 		},
 	},

--- a/projects/packages/premium-analytics/packages/ui/src/index.ts
+++ b/projects/packages/premium-analytics/packages/ui/src/index.ts
@@ -2,6 +2,7 @@ export {
 	DataViewsDrilldownNative,
 	type DataViewsDrilldownNativeProps,
 	processHierarchyLevels,
+	withAncestors,
 } from './dataviews-drilldown-native';
 export { DateFiltersPanel } from './date-filters-panel';
 export {


### PR DESCRIPTION
Follow-up to #50564 (`DataViewsDrilldownNative`), stacked on that branch. Implements WOOA7S-1743.

### What?

Makes `DataViewsDrilldownNative` keep its hierarchy legible across interactions instead of the flat `filterSortAndPaginate` semantics:

- **Search / filter** keep each match under its ancestors (no orphaned children).
- **Sort** orders within each level (top-level rows against each other, children within their parent) instead of a flat global sort that tears the tree apart.
- **Pagination** slices the hierarchy-ordered rows.

### Why?

The static component (#50564) renders native `showLevels` + `getItemLevel`, but ran search/filter/sort/pagination through the flat `filterSortAndPaginate`, so a search orphaned matched children (their ancestor rows dropped) and sorting flattened the tree. That diverges from the intended DataViews hierarchy behavior (WordPress/gutenberg#74072: "initial load, pagination, search, and filter maintain hierarchical order; sorting does not"). This aligns the component with that spec, client-side (PA report data is fully in memory).

### How?

New pure helper `withAncestors( data, matchedIds, getItemId, getItemParentId )` returns the matched rows plus their ancestor chain (missing, self-referential, or cyclic parents end the walk). The component's pipeline is reordered:

1. **Match** — `filterSortAndPaginate` for search + filters only (no sort, one page).
2. **Re-attach ancestors** — `withAncestors`.
3. **Sort within levels** — sort the subset flat, then `processHierarchyLevels` keeps that order among each parent's children.
4. **Paginate** the hierarchy-ordered rows.

### Testing

- `pnpm --filter @automattic/jetpack-premium-analytics-ui test process-hierarchy-levels` — 7 new `withAncestors` unit tests plus the existing `processHierarchyLevels` ones.
- Storybook (`cd projects/packages/premium-analytics && pnpm storybook`, find **DataViewsDrilldownNative**):
  - **Search** (new story): searching "Google" shows Google / Google Search / Google Images still nested under Search Engines.
  - **Sorted**: now orders within each level, tree intact.
  - **Default**: type "Google" in the search box to see it live.

https://github.com/user-attachments/assets/860e9570-8026-4fcf-b150-c4433cf55893


### Follow-ups

- [ ] Page > 1: prepend the first row's ancestor chain (remaining WOOA7S-1743 task).
- [ ] Expand/collapse (WOOA7S-1744).
