### PR TITLE
Premium Analytics: preserve SelectField option value type on write

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-select-field-value-type
+++ b/projects/packages/premium-analytics/changelog/fix-select-field-value-type
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Fields: SelectField preserves the original option value type when writing a selection, avoiding string coercion of numeric-valued enums.

--- a/projects/packages/premium-analytics/packages/fields/src/field-select/__tests__/select-field.test.ts
+++ b/projects/packages/premium-analytics/packages/fields/src/field-select/__tests__/select-field.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Internal dependencies
+ */
+import { fromSelectValue, toSelectItems } from '../select-field';
+import type { Option } from '@wordpress/dataviews';
+
+const NUMERIC_ELEMENTS: Option[] = [
+	{ value: 10, label: 'Ten' },
+	{ value: 20, label: 'Twenty' },
+];
+
+const STRING_ELEMENTS: Option[] = [
+	{ value: 'posts', label: 'Posts' },
+	{ value: 'archives', label: 'Archives' },
+];
+
+describe( 'toSelectItems', () => {
+	it( 'stringifies numeric option values for the select control', () => {
+		expect( toSelectItems( NUMERIC_ELEMENTS ) ).toEqual( [
+			{ value: '10', label: 'Ten' },
+			{ value: '20', label: 'Twenty' },
+		] );
+	} );
+
+	it( 'leaves string option values unchanged', () => {
+		expect( toSelectItems( STRING_ELEMENTS ) ).toEqual( [
+			{ value: 'posts', label: 'Posts' },
+			{ value: 'archives', label: 'Archives' },
+		] );
+	} );
+} );
+
+describe( 'fromSelectValue', () => {
+	it( 'restores the original numeric type on write', () => {
+		const restored = fromSelectValue( NUMERIC_ELEMENTS, '20' );
+		expect( restored ).toBe( 20 );
+		expect( typeof restored ).toBe( 'number' );
+	} );
+
+	it( 'preserves string values', () => {
+		expect( fromSelectValue( STRING_ELEMENTS, 'archives' ) ).toBe( 'archives' );
+	} );
+
+	it( 'falls back to the raw string when no element matches', () => {
+		expect( fromSelectValue( NUMERIC_ELEMENTS, '99' ) ).toBe( '99' );
+	} );
+
+	it( 'round-trips every option through toSelectItems without coercion', () => {
+		toSelectItems( NUMERIC_ELEMENTS ).forEach( ( item, index ) => {
+			expect( fromSelectValue( NUMERIC_ELEMENTS, item.value ) ).toBe(
+				NUMERIC_ELEMENTS[ index ].value
+			);
+		} );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/fields/src/field-select/select-field.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/field-select/select-field.tsx
@@ -10,11 +10,16 @@ import { SelectControl } from '@wordpress/ui';
 import useElements from '../helpers/use-elements';
 import type { DataFormControlProps, Option } from '@wordpress/dataviews';
 
-function toSelectItems( elements: Option[] ) {
+export function toSelectItems( elements: Option[] ) {
 	return elements.map( element => ( {
 		label: element.label,
 		value: String( element.value ),
 	} ) );
+}
+
+export function fromSelectValue( elements: Option[], value: string ) {
+	const element = elements.find( candidate => String( candidate.value ) === value );
+	return element ? element.value : value;
 }
 
 /**
@@ -28,7 +33,7 @@ export default function SelectField< Item >( {
 }: DataFormControlProps< Item > ) {
 	const { label, description, getValue, setValue } = field;
 	const disabled = field.isDisabled( { item: data, field } );
-	const value = getValue( { item: data } ) ?? '';
+	const value = String( getValue( { item: data } ) ?? '' );
 
 	const { elements, isLoading } = useElements( {
 		elements: field.elements,
@@ -38,7 +43,7 @@ export default function SelectField< Item >( {
 	const items = useMemo( () => toSelectItems( elements ), [ elements ] );
 
 	const selectedItem = useMemo(
-		() => items.find( item => item.value === String( value ) ) ?? items[ 0 ] ?? null,
+		() => items.find( item => item.value === value ) ?? items[ 0 ] ?? null,
 		[ items, value ]
 	);
 
@@ -48,9 +53,9 @@ export default function SelectField< Item >( {
 				return;
 			}
 
-			onChange( setValue( { item: data, value: item.value } ) );
+			onChange( setValue( { item: data, value: fromSelectValue( elements, item.value ) } ) );
 		},
-		[ data, onChange, setValue ]
+		[ data, elements, onChange, setValue ]
 	);
 
 	if ( isLoading ) {


### PR DESCRIPTION
Follow-up to #50542. Addresses @dognose24's review note on `select-field.tsx`
about the stringify asymmetry between the read and write paths.

## Proposed changes

* `SelectField` now maps the selected option's stringified value back to the
  original element value before writing, so a field's declared value type is
  preserved (e.g. a numeric enum stays a number instead of being coerced to a
  string).
* The read and write boundaries are now symmetric: `toSelectItems()` stringifies
  element values for the control, and the new `fromSelectValue()` inverts that
  mapping on selection. The read path normalizes the current value once with
  `String()`.
* Adds unit tests covering the round-trip: numeric restore-on-write, string
  passthrough, and unknown-value fallback.

No behavior change for existing fields: every `SelectField` today is a
`type: 'text'` field with string enums, so the mapping is a no-op for them. This
removes a latent type coercion for any future numeric-valued select field.

## Related product discussion/links

* Follow-up to #50542.
* Review thread: @dognose24 on `select-field.tsx` (read side was stringified,
  write side was not).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* From `projects/packages/premium-analytics`, run `pnpm run test -- select-field`
  and confirm 6 passing tests.
* In the widget dashboard editor, open a widget with a `type: 'text'` field that
  has `elements` (e.g. Top Posts "View", or the locations granularity), change
  the select, and confirm the widget updates as before and the stored attribute
  keeps its declared type.
