### PR TITLE
Newsletter: register the wp-theme polyfill on the legacy settings page

### DIFF
--- a/projects/packages/newsletter/changelog/fix-newsletter-legacy-wp-theme-polyfill
+++ b/projects/packages/newsletter/changelog/fix-newsletter-legacy-wp-theme-polyfill
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Register wp-build polyfills on the legacy settings page so the admin bundle loads when the wp-theme script handle isn't registered

--- a/projects/packages/newsletter/changelog/fix-newsletter-legacy-wp-theme-polyfill
+++ b/projects/packages/newsletter/changelog/fix-newsletter-legacy-wp-theme-polyfill
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Register wp-build polyfills on the legacy settings page so the admin bundle loads when the wp-theme script handle isn't registered
+Register wp-build polyfills on the legacy settings page so the admin bundle loads when the wp-theme script handle isn't registered.

--- a/projects/packages/newsletter/src/class-settings.php
+++ b/projects/packages/newsletter/src/class-settings.php
@@ -318,8 +318,10 @@ class Settings {
 		// Core does not register that handle, and `load_wp_build()` — the only
 		// other caller — runs on the modernized path alone. Without this,
 		// WordPress silently drops the script over the unregistered dependency
-		// and the page renders blank. Request only the handles this bundle needs,
-		// to keep the polyfill's `wp-private-apis` force-replacement off the rest.
+		// and the page renders blank. Request only the handles this bundle needs:
+		// `wp-theme` (Core never registers it) and `wp-private-apis` (so the
+		// polyfill can replace Core's incomplete allowlist on older WP). We leave
+		// out `wp-notices` so the polyfill's force-replacement never touches it.
 		if ( class_exists( \Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills::class ) ) {
 			\Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills::register(
 				'jetpack-newsletter',

--- a/projects/packages/newsletter/src/class-settings.php
+++ b/projects/packages/newsletter/src/class-settings.php
@@ -313,6 +313,20 @@ class Settings {
 			return;
 		}
 
+		// The legacy bundle imports `@wordpress/ui`, which reaches
+		// `@wordpress/theme` and so lists `wp-theme` in its generated asset file.
+		// Core does not register that handle, and `load_wp_build()` — the only
+		// other caller — runs on the modernized path alone. Without this,
+		// WordPress silently drops the script over the unregistered dependency
+		// and the page renders blank. Request only the handles this bundle needs,
+		// to keep the polyfill's `wp-private-apis` force-replacement off the rest.
+		if ( class_exists( \Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills::class ) ) {
+			\Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills::register(
+				'jetpack-newsletter',
+				array( 'wp-theme', 'wp-private-apis' )
+			);
+		}
+
 		Assets::register_script(
 			'jetpack-newsletter',
 			'../build/newsletter.js',

--- a/projects/packages/newsletter/tests/php/Settings_Test.php
+++ b/projects/packages/newsletter/tests/php/Settings_Test.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Newsletter\Tests;
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Newsletter\Settings;
+use Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills;
 use PHPUnit\Framework\Attributes\CoversClass;
 use WorDBless\BaseTestCase;
 
@@ -68,8 +69,42 @@ class Settings_Test extends BaseTestCase {
 		wp_dequeue_script( 'jetpack-newsletter' );
 		wp_deregister_script( 'jp-tracks' );
 		wp_deregister_script( 'jetpack-newsletter' );
+		wp_deregister_script( 'wp-theme' );
+
+		// The polyfill registrar keeps its request map, hook latch, and version
+		// threshold in process-global statics. Reset them so a legacy-surface
+		// test cannot leak state into — or read state from — another test.
+		$this->reset_wp_build_polyfills_statics();
 
 		parent::tear_down();
+	}
+
+	/**
+	 * Reset WP_Build_Polyfills' static state between tests.
+	 *
+	 * Mirrors WP_Build_Polyfills_Test's own tear_down: the registrar records
+	 * requested handles, whether it has hooked wp_default_scripts, and the
+	 * force-replacement version threshold in statics that otherwise persist
+	 * across tests in the same process.
+	 */
+	private function reset_wp_build_polyfills_statics() {
+		if ( ! class_exists( WP_Build_Polyfills::class ) ) {
+			return;
+		}
+
+		$statics = array(
+			'requested'            => array(),
+			'hooked'               => false,
+			'wp_version_threshold' => '7.0',
+		);
+
+		foreach ( $statics as $name => $value ) {
+			$property = new \ReflectionProperty( WP_Build_Polyfills::class, $name );
+			if ( PHP_VERSION_ID < 80100 ) {
+				$property->setAccessible( true );
+			}
+			$property->setValue( null, $value );
+		}
 	}
 
 	/**
@@ -298,23 +333,102 @@ class Settings_Test extends BaseTestCase {
 	 * here, `wp_enqueue_script` silently drops `jetpack-newsletter` over the
 	 * unregistered dependency and the page renders blank.
 	 */
-	public function test_load_admin_scripts_requests_wp_theme_polyfill_on_legacy_surface() {
+	public function test_load_admin_scripts_registers_wp_theme_polyfill_on_legacy_surface() {
 		add_filter( Settings::MODERNIZATION_FILTER, '__return_false' );
 
-		( new Settings() )->load_admin_scripts();
+		// The polyfill only registers wp-theme when its build asset exists on
+		// disk. That build directory is gitignored and absent in CI PHP runs, so
+		// borrow WP_Build_Polyfills_Test's fixture approach and lay down a stub
+		// asset file when the real build is missing.
+		$fixture = $this->ensure_wp_theme_polyfill_asset();
 
-		$consumers = \Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills::get_consumers();
+		// Core never registers wp-theme; start clean so the assertion reflects
+		// what our code registers rather than a leftover registration.
+		wp_deregister_script( 'wp-theme' );
 
-		$this->assertArrayHasKey(
-			'wp-theme',
-			$consumers,
-			'The legacy surface must request the wp-theme polyfill; the legacy bundle depends on that handle and Core never registers it.'
+		try {
+			( new Settings() )->load_admin_scripts();
+
+			$consumers = WP_Build_Polyfills::get_consumers();
+			$this->assertContains(
+				'jetpack-newsletter',
+				$consumers['wp-theme'] ?? array(),
+				'The legacy newsletter bundle must be recorded as a wp-theme polyfill consumer.'
+			);
+
+			// The behaviour the bug was about: wp-theme is actually registered, so
+			// WordPress no longer drops jetpack-newsletter over a missing dependency.
+			$this->assertTrue(
+				wp_script_is( 'wp-theme', 'registered' ),
+				'The legacy surface must register wp-theme; Core never does, and the bundle depends on it.'
+			);
+		} finally {
+			$this->remove_wp_theme_polyfill_asset( $fixture );
+		}
+	}
+
+	/**
+	 * Ensure the polyfill's built wp-theme asset file exists so register() can
+	 * register the handle.
+	 *
+	 * The wp-build-polyfills build directory is gitignored, so it may be missing
+	 * during PHP test runs. When it is, write a minimal stub at the exact path
+	 * register() reads (dirname of the class file, two levels up, + /build).
+	 *
+	 * @return array {file, dirs} describing what we created, for cleanup. Empty
+	 *               when the real asset already exists and nothing was created.
+	 */
+	private function ensure_wp_theme_polyfill_asset() {
+		$reflector = new \ReflectionClass( WP_Build_Polyfills::class );
+		$asset_dir = dirname( $reflector->getFileName(), 2 ) . '/build/scripts/theme';
+		$asset     = $asset_dir . '/index.asset.php';
+
+		if ( file_exists( $asset ) ) {
+			return array();
+		}
+
+		// Create the missing directory chain, tracking what we made so tear-down
+		// removes only our fixture and never a real build artifact.
+		$missing = array();
+		$dir     = $asset_dir;
+		while ( ! is_dir( $dir ) ) {
+			$missing[] = $dir;
+			$dir       = dirname( $dir );
+		}
+		$created_dirs = array();
+		foreach ( array_reverse( $missing ) as $dir ) {
+			mkdir( $dir );
+			$created_dirs[] = $dir;
+		}
+
+		file_put_contents( $asset, "<?php return array( 'dependencies' => array(), 'version' => 'test' );\n" );
+
+		return array(
+			'file' => $asset,
+			'dirs' => $created_dirs,
 		);
-		$this->assertContains(
-			'jetpack-newsletter',
-			$consumers['wp-theme'],
-			'The legacy newsletter bundle must be recorded as a wp-theme polyfill consumer.'
-		);
+	}
+
+	/**
+	 * Remove the stub wp-theme asset created by ensure_wp_theme_polyfill_asset().
+	 *
+	 * @param array $fixture The {file, dirs} descriptor it returned.
+	 */
+	private function remove_wp_theme_polyfill_asset( $fixture ) {
+		if ( empty( $fixture ) ) {
+			return;
+		}
+
+		if ( isset( $fixture['file'] ) && file_exists( $fixture['file'] ) ) {
+			unlink( $fixture['file'] );
+		}
+
+		// Remove deepest-first so each directory is empty when we drop it.
+		foreach ( array_reverse( $fixture['dirs'] ?? array() ) as $dir ) {
+			if ( is_dir( $dir ) ) {
+				rmdir( $dir );
+			}
+		}
 	}
 
 	/**

--- a/projects/packages/newsletter/tests/php/Settings_Test.php
+++ b/projects/packages/newsletter/tests/php/Settings_Test.php
@@ -291,6 +291,33 @@ class Settings_Test extends BaseTestCase {
 	}
 
 	/**
+	 * The legacy bundle depends on the `wp-theme` script handle — it imports
+	 * `@wordpress/ui`, which reaches `@wordpress/theme`, and WP Core does not
+	 * register that handle. Only `WP_Build_Polyfills` does, and its full
+	 * registration runs on the modernized path alone. Without an explicit request
+	 * here, `wp_enqueue_script` silently drops `jetpack-newsletter` over the
+	 * unregistered dependency and the page renders blank.
+	 */
+	public function test_load_admin_scripts_requests_wp_theme_polyfill_on_legacy_surface() {
+		add_filter( Settings::MODERNIZATION_FILTER, '__return_false' );
+
+		( new Settings() )->load_admin_scripts();
+
+		$consumers = \Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills::get_consumers();
+
+		$this->assertArrayHasKey(
+			'wp-theme',
+			$consumers,
+			'The legacy surface must request the wp-theme polyfill; the legacy bundle depends on that handle and Core never registers it.'
+		);
+		$this->assertContains(
+			'jetpack-newsletter',
+			$consumers['wp-theme'],
+			'The legacy newsletter bundle must be recorded as a wp-theme polyfill consumer.'
+		);
+	}
+
+	/**
 	 * `maybe_load_wp_build` is hooked at admin_menu priority 1 on every request,
 	 * but it must short-circuit unless the visitor is on `?page=jetpack-newsletter`.
 	 * It registers a `current_screen` listener as the easy-to-observe side effect.


### PR DESCRIPTION
Fixes #

## Proposed changes
* Register the `wp-theme` / `wp-private-apis` polyfills on the **legacy** Newsletter settings page, so the legacy admin bundle actually loads for sites that opt out of the modernized dashboard.
* Add a regression test asserting the legacy surface requests the `wp-theme` polyfill.

### The bug
Any site opting out via `add_filter( 'rsm_jetpack_ui_modernization_newsletter', '__return_false' )` gets a **blank Newsletter page** — styled chrome, empty body, and no console error.

### Root cause
The legacy `newsletter` webpack bundle imports `@wordpress/ui`, which reaches `@wordpress/theme`, so its generated `newsletter.asset.php` lists `wp-theme` as a dependency. WP Core never registers that handle — only `WP_Build_Polyfills` does, and its sole caller `load_wp_build()` is gated to the modernized path ("Keeps wp-build off every other request").

`wp_enqueue_script()` **silently drops** a script whose dependency handle is unregistered: no warning, no error. The stylesheet loads from a separate registry, which is why the page looks styled but renders empty. Verified server-side on a dev site — `wp-theme` is `NOT REGISTERED` while `wp-private-apis`, `wp-notices` and `wp-views` all are.

Interestingly, `@wordpress/ui` itself never becomes a handle (it's on DEWP's `BUNDLED_PACKAGES` allowlist, so it's compiled inline). But `@wordpress/theme` is *not* on that list, so once bundled `@wordpress/ui` code reaches `theme-provider.mjs`, DEWP externalizes it to `wp-theme`.

### The fix
Mirrors what Social already does in `Publicize_Assets::register_wp_build_polyfills()`. Only the two handles the legacy bundle needs are requested, to keep the polyfill's `wp-private-apis` force-replacement off handles we don't need. `packages/activity-log` recently fixed the identical bug (`fix-activity-log-blank`).

### Scope of the problem (other dashboards audited)
| Dashboard | Legacy bundle needs `wp-theme`? | Registers polyfills on legacy path? | Status |
|---|---|---|---|
| **Newsletter** | **Yes** | **No** | **Fixed here** |
| Social | Yes | Yes | Already fine |
| VideoPress | No | No | Fine — imports only `Notice`, tree-shakes away from `theme-provider` |
| Backup | No | No | Fine — imports only `Link` |
| Scan | n/a — no legacy bundle; package is dormant when the filter is off | n/a | Fine |

Worth flagging: VideoPress and Backup are safe only *incidentally*, via tree-shaking. If anyone imports a `@wordpress/ui` export that reaches `theme-provider.mjs` into either legacy tree, `wp-theme` silently appears in their asset file and those dashboards go blank the same way.

### Note on test coverage
The existing `test_load_admin_scripts_enqueues_legacy_bundle_when_modernization_disabled` asserts `wp_script_is( …, 'enqueued' )` — which passes even with the dependency missing, because enqueueing succeeds and the drop happens later at print time. That's why this slipped through. The new test asserts the polyfill is actually requested via the public `get_consumers()` API (rather than asserting registration, which depends on `WP_Build_Polyfills`' internal `$hooked` static and would be order-dependent).

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Add a snippet / mu-plugin to opt out of the modernized dashboard:
  ```php
  add_filter( 'rsm_jetpack_ui_modernization_newsletter', '__return_false' );
  ```
* **Before this PR:** go to **Jetpack → Newsletter** (`wp-admin/admin.php?page=jetpack-newsletter`). The page is blank — admin menu and chrome render, content area is empty, and there is **no** console error. Inspecting the DOM shows `#newsletter-settings-root` present with zero children, and no `newsletter` `<script>` tag at all.
* **After this PR:** the same page renders the full legacy settings UI — Newsletter / Subscriptions cards, toggles, and the DataForm sections.
* Confirm the modernized dashboard is unaffected: remove the filter (or set it to `__return_true`) and reload — the wp-build dashboard should behave exactly as before.
* Optional server-side check that the handle is now registered on the legacy page:
  ```
  wp eval 'do_action("wp_default_scripts", wp_scripts()); var_dump( isset( wp_scripts()->registered["wp-theme"] ) );'
  ```
* Run the tests: `cd projects/packages/newsletter && composer phpunit -- --filter Settings_Test`
