### PR TITLE
Premium Analytics: fix report table DataViews stylesheet 404

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-report-table-dataviews-css-404
+++ b/projects/packages/premium-analytics/changelog/fix-report-table-dataviews-css-404
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Report table: fix a 404 request for the DataViews stylesheet by inlining it through :global instead of a passthrough @import.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-records-table.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-records-table.module.scss
@@ -1,4 +1,13 @@
-@import "@wordpress/dataviews/build-style/style.css";
+@use "sass:meta";
+
+/* Inline DataViews' own stylesheet. It must load through :global so CSS Modules
+ * keeps DataViews' class names (.dataviews-wrapper, …) intact — a plain @import
+ * of the .css would instead be emitted verbatim and 404 at runtime against the
+ * page base. */
+:global {
+
+	@include meta.load-css( "@wordpress/dataviews/build-style/style" );
+}
 
 /* DataViews pads its own chrome — the toolbar, the table's first/last cells,
  * and the footer all carry the same 24px inline inset the section card would


### PR DESCRIPTION
## Proposed changes

Fixes a 404 for `…/wp-admin/@wordpress/dataviews/build-style/style.css` on the report table (e.g. Posts & Pages).

`report-records-table.module.scss` loaded the DataViews stylesheet with a plain `@import "…css"`. Sass passes a `.css` `@import` through verbatim instead of inlining it, and this package's CSS Module is injected into a runtime `<style>` tag — so the browser resolves the relative URL against `/wp-admin/` and 404s.

Fix: inline it with `meta.load-css`, wrapped in `:global { … }` so DataViews' class names stay unhashed. Same pattern the `publicize` package already uses (#39981).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build: `jetpack build packages/premium-analytics`.
* Open **wp-admin → Analytics**, go to a report with a table (e.g. Posts & Pages).
* In DevTools → Network, confirm there's no 404 for `@wordpress/dataviews/build-style/style.css`, and the table still renders styled.

Before:
<img width="2560" height="1328" alt="Screenshot 2026-07-17 at 11 04 28 AM" src="https://github.com/user-attachments/assets/32c3f0d7-4184-481d-a89e-20d69c5ab874" />

After:
<img width="2560" height="1321" alt="Screenshot 2026-07-17 at 11 08 14 AM" src="https://github.com/user-attachments/assets/3b695dfa-14c3-4616-b74d-4f5a4ac1d83a" />
