### PR TITLE
WOOA7S-1746: Premium Analytics: add the video highlights widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-video-detail-highlights-widget
+++ b/projects/packages/premium-analytics/changelog/add-video-detail-highlights-widget
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: added
 
-Add the video highlights widget: views, impressions, hours watched, and retention rate tiles for a selected video, with period-over-period comparison.
+Widgets: Add the video highlights widget: views, impressions, hours watched, and retention rate tiles for a selected video, with period-over-period comparison.

--- a/projects/packages/premium-analytics/changelog/add-video-detail-highlights-widget
+++ b/projects/packages/premium-analytics/changelog/add-video-detail-highlights-widget
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add the video highlights widget: views, impressions, hours watched, and retention rate tiles for a selected video, with period-over-period comparison.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-video-plays.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-video-plays.ts
@@ -7,6 +7,7 @@ import { useCallback } from 'react';
  */
 import { mergeStatsVideoPlaysComparisonRows } from '../processing/stats';
 import { statsVideoPlaysQuery } from '../queries/stats-video-plays-query';
+import { statsVideoPlaysSummaryQuery } from '../queries/stats-video-plays-summary-query';
 import { useStatsReport } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type {
@@ -22,6 +23,13 @@ type StatsVideoPlaysOptions = UseStatsOptions & {
 
 export function useStatsVideoPlays( params: StatsReportParams, options?: StatsVideoPlaysOptions ) {
 	const { maxRows, ...queryOptions } = options ?? {};
+	// The complete-stats range summary uses the same endpoint and normalized
+	// response as the standard report, but its API request must omit the
+	// `summarize` mode switch. Reuse the dedicated query factory that keeps
+	// `summarize` sanitizer-only while preserving this hook's comparison and
+	// row-merging contract for callers.
+	const queryFactory =
+		params.complete_stats && params.summarize ? statsVideoPlaysSummaryQuery : statsVideoPlaysQuery;
 	const mergeComparisonRows = useCallback(
 		(
 			primary?: StatsNormalizedReport< StatsVideoPlaysItem >,
@@ -34,7 +42,7 @@ export function useStatsVideoPlays( params: StatsReportParams, options?: StatsVi
 		StatsReportParams,
 		StatsNormalizedReport< StatsVideoPlaysItem >,
 		StatsVideoPlaysComparisonItem
-	>( statsVideoPlaysQuery, params, 'video-plays', {
+	>( queryFactory, params, 'video-plays', {
 		...queryOptions,
 		mergeComparisonRows,
 	} );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -1057,8 +1057,8 @@ function playsFactorForWindow( endDate: string | undefined ): number {
  * Builds a mock Stats "video-plays" response so the Videos widget renders a
  * populated leaderboard in Storybook. The shape matches what
  * `sanitizeStatsVideoPlaysResponse` reads (`days.<date>.plays[]`), and play
- * counts scale by how recent the requested window is so the comparison period
- * reads lower than the primary one.
+ * metrics scale by how recent the requested window is so the comparison period
+ * reads lower than the primary one, including complete-stats highlight rows.
  *
  * @param requestPath - The request path, used to read the window's end date.
  * @return Raw video-plays response.
@@ -1068,13 +1068,13 @@ function buildVideoPlaysResponse( requestPath: string ) {
 	const date = endDate ?? new Date().toISOString().slice( 0, 10 );
 	const factor = playsFactorForWindow( endDate );
 	const videos = [
-		{ post_id: 101, title: 'Getting Started Walkthrough', plays: 3820 },
-		{ post_id: 102, title: 'Product Launch Highlights', plays: 2640 },
-		{ post_id: 103, title: 'Customer Story: Acme Co.', plays: 1980 },
-		{ post_id: 104, title: 'How-To: Advanced Settings', plays: 1410 },
-		{ post_id: 105, title: 'Behind the Scenes', plays: 980 },
-		{ post_id: 106, title: 'Weekly Recap', plays: 540 },
-		{ post_id: 107, title: '', plays: 320 },
+		{ post_id: 101, title: 'Getting Started Walkthrough', plays: 3820, hours: 72.4 },
+		{ post_id: 102, title: 'Product Launch Highlights', plays: 2640, hours: 51.8 },
+		{ post_id: 103, title: 'Customer Story: Acme Co.', plays: 1980, hours: 38.2 },
+		{ post_id: 104, title: 'How-To: Advanced Settings', plays: 1410, hours: 27.6 },
+		{ post_id: 105, title: 'Behind the Scenes', plays: 980, hours: 18.9 },
+		{ post_id: 106, title: 'Weekly Recap', plays: 540, hours: 10.7 },
+		{ post_id: 107, title: '', plays: 320, hours: 6.1 },
 	];
 	const rows = videos.map( video => ( {
 		post_id: video.post_id,
@@ -1082,9 +1082,22 @@ function buildVideoPlaysResponse( requestPath: string ) {
 		url: `https://example.com/video/${ video.post_id }/`,
 		plays: Math.round( video.plays * factor ),
 		impressions: Math.round( video.plays * factor * 1.8 ),
-		watch_time: Math.round( video.plays * factor * 12 ),
-		retention_rate: 60,
+		watch_time: Number( ( video.hours * factor ).toFixed( 1 ) ),
+		retention_rate: Number( ( 67.6 * factor ).toFixed( 1 ) ),
 	} ) );
+	const completeStats = getQueryParam( requestPath, 'complete_stats' ) === '1';
+
+	if ( completeStats ) {
+		return {
+			date,
+			period: 'day',
+			days: {
+				summary: {
+					data: rows.map( ( { plays, ...row } ) => ( { ...row, views: plays } ) ),
+				},
+			},
+		};
+	}
 
 	// `summary.plays` feeds the summarized path (multi-day ranges set
 	// `summarize=1`); `days.<date>.plays` covers the single-day path.

--- a/projects/packages/premium-analytics/widgets/video-detail-highlights/__tests__/video-detail-highlights.test.tsx
+++ b/projects/packages/premium-analytics/widgets/video-detail-highlights/__tests__/video-detail-highlights.test.tsx
@@ -11,9 +11,7 @@ import VideoDetailHighlightsWidget from '../render';
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
-jest.mock( '@wordpress/route', () => ( {
-	useSearch: () => ( {} ),
-} ) );
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
 
 const mockApiFetch = apiFetch as unknown as jest.Mock;
 

--- a/projects/packages/premium-analytics/widgets/video-detail-highlights/__tests__/video-detail-highlights.test.tsx
+++ b/projects/packages/premium-analytics/widgets/video-detail-highlights/__tests__/video-detail-highlights.test.tsx
@@ -1,0 +1,211 @@
+/**
+ * External dependencies
+ */
+import { queryClient } from '@jetpack-premium-analytics/data';
+import { fireEvent, render, screen } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+/**
+ * Internal dependencies
+ */
+import VideoDetailHighlightsWidget from '../render';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => ( {} ),
+} ) );
+
+const mockApiFetch = apiFetch as unknown as jest.Mock;
+
+const COMPLETE_STATS_RESPONSE = {
+	date: '2026-07-14',
+	period: 'day',
+	days: {
+		summary: {
+			data: [
+				{
+					post_id: 104,
+					title: 'Another video',
+					views: '999',
+					impressions: '888',
+					watch_time: '77.7',
+					retention_rate: '55.5',
+				},
+				{
+					post_id: 105,
+					title: 'Selected video',
+					views: '128',
+					impressions: '456',
+					watch_time: '18.9',
+					retention_rate: '67.6',
+				},
+			],
+			total: {
+				views: '1127',
+				impressions: '1344',
+				watch_time: '96.6',
+			},
+		},
+	},
+};
+
+const COMPARISON_STATS_RESPONSE = {
+	date: '2026-06-30',
+	period: 'day',
+	days: {
+		summary: {
+			data: [
+				{
+					post_id: 105,
+					title: 'Selected video',
+					views: '64',
+					impressions: '228',
+					watch_time: '12.6',
+					retention_rate: '52',
+				},
+			],
+		},
+	},
+};
+
+const COMPARISON_WITHOUT_SELECTED_VIDEO_RESPONSE = {
+	date: '2026-06-30',
+	period: 'day',
+	days: {
+		summary: {
+			data: [
+				{
+					post_id: 104,
+					title: 'Another video',
+					views: '500',
+					impressions: '600',
+					watch_time: '40',
+					retention_rate: '50',
+				},
+			],
+		},
+	},
+};
+
+const MOCK_API_ERROR = {
+	code: 'stats_mock_error',
+	message: 'Mocked error response.',
+	data: { status: 403 },
+};
+
+function renderWidget( postId?: number, withComparison = false ) {
+	return render(
+		<VideoDetailHighlightsWidget
+			attributes={ {
+				reportParams: {
+					from: '2026-07-01',
+					to: '2026-07-07',
+					interval: 'day',
+					...( withComparison
+						? {
+								comp: '1',
+								compare_from: '2026-06-24',
+								compare_to: '2026-06-30',
+						  }
+						: {} ),
+					...( postId === undefined ? {} : { post_id: postId } ),
+				},
+			} }
+		/>
+	);
+}
+
+describe( 'VideoDetailHighlightsWidget', () => {
+	beforeEach( () => {
+		queryClient.clear();
+		mockApiFetch.mockReset();
+		mockApiFetch.mockResolvedValue( COMPLETE_STATS_RESPONSE );
+	} );
+
+	it( 'renders plain tiles when comparison is off', async () => {
+		renderWidget( 105 );
+
+		await expect( screen.findByText( '128' ) ).resolves.toBeInTheDocument();
+
+		const tiles = screen.getAllByRole( 'listitem' );
+		expect( tiles ).toHaveLength( 4 );
+		expect( tiles[ 0 ] ).toHaveTextContent( 'Views128' );
+		expect( tiles[ 1 ] ).toHaveTextContent( 'Impressions456' );
+		expect( tiles[ 2 ] ).toHaveTextContent( 'Hours watched18.9' );
+		expect( tiles[ 3 ] ).toHaveTextContent( 'Retention rate67.6%' );
+		expect( screen.queryByText( /^[+-]\d+%$/ ) ).not.toBeInTheDocument();
+
+		const requestedPath = mockApiFetch.mock.calls[ 0 ][ 0 ].path as string;
+		const videoRequests = mockApiFetch.mock.calls.filter( call =>
+			( call[ 0 ].path as string ).includes( 'stats/video-plays' )
+		);
+		expect( videoRequests ).toHaveLength( 1 );
+		expect( requestedPath ).toContain( 'stats/video-plays' );
+		expect( requestedPath ).toContain( 'complete_stats=1' );
+		expect( requestedPath ).toContain( 'max=0' );
+		expect( requestedPath ).toContain( 'period=day' );
+		expect( requestedPath ).toContain( 'start_date=' );
+		expect( requestedPath ).toContain( 'date=' );
+		expect( requestedPath ).not.toContain( 'summarize=' );
+	} );
+
+	it( 'renders per-tile deltas from the selected video comparison row', async () => {
+		mockApiFetch.mockImplementation( ( { path }: { path: string } ) =>
+			Promise.resolve(
+				path.includes( 'date=2026-06-30' ) ? COMPARISON_STATS_RESPONSE : COMPLETE_STATS_RESPONSE
+			)
+		);
+
+		renderWidget( 105, true );
+
+		await expect( screen.findAllByText( '+100%' ) ).resolves.toHaveLength( 2 );
+		expect( screen.getByText( '+50%' ) ).toBeInTheDocument();
+		expect( screen.getByText( '+30%' ) ).toBeInTheDocument();
+
+		const requestedPaths = mockApiFetch.mock.calls.map( call => call[ 0 ].path as string );
+		expect( requestedPaths.some( path => path.includes( 'date=2026-07-07' ) ) ).toBe( true );
+		expect( requestedPaths.some( path => path.includes( 'date=2026-06-30' ) ) ).toBe( true );
+	} );
+
+	it( 'uses the comparison layout without a delta when the selected video row is absent', async () => {
+		mockApiFetch.mockImplementation( ( { path }: { path: string } ) =>
+			Promise.resolve(
+				path.includes( 'date=2026-06-30' )
+					? COMPARISON_WITHOUT_SELECTED_VIDEO_RESPONSE
+					: COMPLETE_STATS_RESPONSE
+			)
+		);
+
+		renderWidget( 105, true );
+
+		await expect( screen.findByText( '128' ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( /^[+-]\d+%$/ ) ).not.toBeInTheDocument();
+		const videoRequests = mockApiFetch.mock.calls.filter( call =>
+			( call[ 0 ].path as string ).includes( 'stats/video-plays' )
+		);
+		expect( videoRequests ).toHaveLength( 2 );
+	} );
+
+	it( 'renders the scope-empty state and skips fetching without a post_id', () => {
+		renderWidget();
+
+		expect( screen.getByText( /open a video report/i ) ).toBeInTheDocument();
+		expect( mockApiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'renders an error state with a Retry action', async () => {
+		mockApiFetch.mockRejectedValue( MOCK_API_ERROR );
+		renderWidget( 105 );
+
+		await expect( screen.findByRole( 'alert' ) ).resolves.toHaveTextContent(
+			/couldn't load this video's highlights/i
+		);
+
+		const requestsBeforeRetry = mockApiFetch.mock.calls.length;
+		mockApiFetch.mockResolvedValue( COMPLETE_STATS_RESPONSE );
+		fireEvent.click( screen.getByRole( 'button', { name: /retry/i } ) ); // eslint-disable-line testing-library/prefer-user-event -- @testing-library/user-event is not a direct dep of this package.
+
+		await expect( screen.findByText( '128' ) ).resolves.toBeInTheDocument();
+		expect( mockApiFetch.mock.calls.length ).toBeGreaterThan( requestsBeforeRetry );
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/video-detail-highlights/package.json
+++ b/projects/packages/premium-analytics/widgets/video-detail-highlights/package.json
@@ -1,0 +1,18 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-video-detail-highlights",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/element": "8.2.0",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^15.0.0",
+		"@wordpress/widget-primitives": "0.2.0"
+	},
+	"devDependencies": {
+		"@testing-library/react": "16.3.2",
+		"@wordpress/api-fetch": "7.50.0"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/video-detail-highlights/package.json
+++ b/projects/packages/premium-analytics/widgets/video-detail-highlights/package.json
@@ -6,7 +6,7 @@
 	"dependencies": {
 		"@jetpack-premium-analytics/data": "link:../../packages/data",
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
-		"@wordpress/element": "8.2.0",
+		"@wordpress/element": "8.3.0",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^15.0.0",
 		"@wordpress/widget-primitives": "0.2.0"

--- a/projects/packages/premium-analytics/widgets/video-detail-highlights/package.json
+++ b/projects/packages/premium-analytics/widgets/video-detail-highlights/package.json
@@ -13,6 +13,6 @@
 	},
 	"devDependencies": {
 		"@testing-library/react": "16.3.2",
-		"@wordpress/api-fetch": "7.50.0"
+		"@wordpress/api-fetch": "7.51.0"
 	}
 }

--- a/projects/packages/premium-analytics/widgets/video-detail-highlights/render.tsx
+++ b/projects/packages/premium-analytics/widgets/video-detail-highlights/render.tsx
@@ -1,0 +1,220 @@
+/**
+ * External dependencies
+ */
+import {
+	useStatsVideoPlays,
+	type StatsNormalizedReport,
+	type StatsVideoPlaysItem,
+} from '@jetpack-premium-analytics/data';
+import {
+	MetricTileGrid,
+	WidgetRoot,
+	WidgetState,
+	useWidgetRootContext,
+	type DataFormat,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { percent, scheduled, seen, video } from '@wordpress/icons';
+/**
+ * Internal dependencies
+ */
+import styles from './style.module.css';
+import type { VideoDetailHighlightsAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+
+type VideoDetailHighlightsRenderAttributes = VideoDetailHighlightsAttributes &
+	Partial< ReportParamsFieldAttributes >;
+type VideoDetailHighlightsWidgetProps = WidgetRenderProps< VideoDetailHighlightsRenderAttributes >;
+
+const COUNT_FORMAT: DataFormat = {
+	type: 'number',
+	options: { useMultipliers: true, decimals: 0 },
+};
+
+const HOURS_FORMAT: DataFormat = {
+	type: 'number',
+	options: { decimals: 1 },
+};
+
+const RATE_FORMAT: DataFormat = {
+	type: 'percentage',
+	options: { decimals: 1, signDisplay: 'never' },
+};
+
+/**
+ * Resolve the routed VideoPress attachment ID. Invalid or missing values keep
+ * the data query disabled and show the widget's scope-empty descriptor.
+ *
+ * @param postId - The host-composed `reportParams.post_id` value.
+ * @return A positive video ID, or `NaN` when no valid video is selected.
+ */
+function toVideoId( postId: string | number | undefined ): number {
+	const parsed = typeof postId === 'number' ? postId : Number.parseInt( postId ?? '', 10 );
+
+	return Number.isInteger( parsed ) && parsed > 0 ? parsed : NaN;
+}
+
+/**
+ * Find the selected video in a normalized complete-stats range summary.
+ *
+ * @param report  - The normalized video-plays report.
+ * @param videoId - The selected VideoPress attachment ID.
+ * @return The selected video's metrics, when present.
+ */
+export function selectVideoHighlights(
+	report: StatsNormalizedReport< StatsVideoPlaysItem > | undefined,
+	videoId: number
+): StatsVideoPlaysItem | undefined {
+	for ( const point of report?.data ?? [] ) {
+		const row = point.items.find( item => Number( item.id ) === videoId );
+
+		if ( row ) {
+			return row;
+		}
+	}
+
+	return undefined;
+}
+
+/**
+ * Map a comparison metric to MetricTileGrid's three-state previous-value
+ * contract while preserving zero as a real value.
+ *
+ * @param hasComparison - Whether the user requested a comparison window.
+ * @param value         - The selected video's comparison metric.
+ * @return A number for a matched row, null for an unmatched row, or undefined
+ *         when comparison is off.
+ */
+function toPreviousValue( hasComparison: boolean, value?: number ): number | null | undefined {
+	if ( ! hasComparison ) {
+		return undefined;
+	}
+
+	return value ?? null;
+}
+
+/**
+ * Read the selected video scope from WidgetRoot, fetch the complete Stats range
+ * summary, and render its four metrics through the shared tile grid.
+ *
+ * @return The video highlights widget content.
+ */
+function VideoDetailHighlightsInner() {
+	const { reportParams } = useWidgetRootContext();
+	const videoId = toVideoId( reportParams.post_id );
+	const hasVideoScope = Number.isInteger( videoId );
+	const queryParams = useMemo(
+		() => ( {
+			...reportParams,
+			complete_stats: 1,
+			max: 0,
+			period: 'day',
+			summarize: 1,
+		} ),
+		[ reportParams ]
+	);
+	const { primary, comparison, isLoading, isFetching, isError, refetch } = useStatsVideoPlays(
+		queryParams,
+		{
+			enabled: hasVideoScope,
+		}
+	);
+	const row = useMemo(
+		() => selectVideoHighlights( primary.data, videoId ),
+		[ primary.data, videoId ]
+	);
+	const comparisonRow = useMemo(
+		() => selectVideoHighlights( comparison.data, videoId ),
+		[ comparison.data, videoId ]
+	);
+	// Mirror post-detail-highlights: `comp` is the report params contract's
+	// comparison toggle. The hook's `hasComparison` is intentionally not used
+	// because video row merging gates it on overlap across every returned video,
+	// not whether the user requested a comparison window for this selected one.
+	const hasComparison = reportParams.comp === '1';
+	const comparisonRetentionRate = comparisonRow ? comparisonRow.retention_rate / 100 : undefined;
+	const tiles = useMemo(
+		() => [
+			{
+				key: 'views',
+				label: __( 'Views', 'jetpack-premium-analytics' ),
+				icon: seen,
+				value: row?.plays ?? 0,
+				previousValue: toPreviousValue( hasComparison, comparisonRow?.plays ),
+			},
+			{
+				key: 'impressions',
+				label: __( 'Impressions', 'jetpack-premium-analytics' ),
+				icon: video,
+				value: row?.impressions ?? 0,
+				previousValue: toPreviousValue( hasComparison, comparisonRow?.impressions ),
+			},
+			{
+				key: 'watch-time',
+				label: __( 'Hours watched', 'jetpack-premium-analytics' ),
+				icon: scheduled,
+				value: row?.watch_time ?? 0,
+				previousValue: toPreviousValue( hasComparison, comparisonRow?.watch_time ),
+				dataFormat: HOURS_FORMAT,
+			},
+			{
+				key: 'retention-rate',
+				label: __( 'Retention rate', 'jetpack-premium-analytics' ),
+				icon: percent,
+				value: ( row?.retention_rate ?? 0 ) / 100,
+				previousValue: toPreviousValue( hasComparison, comparisonRetentionRate ),
+				dataFormat: RATE_FORMAT,
+			},
+		],
+		[ row, comparisonRow, comparisonRetentionRate, hasComparison ]
+	);
+
+	return (
+		<div className={ styles.root }>
+			<WidgetState
+				isLoading={ hasVideoScope && isLoading }
+				isFetching={ isFetching }
+				isError={ hasVideoScope && ! row && isError }
+				isEmpty={ ! hasVideoScope || ( ! isLoading && ! isError && ! row ) }
+				error={ {
+					description: __(
+						"We couldn't load this video's highlights. Please try again in a moment.",
+						'jetpack-premium-analytics'
+					),
+					actions: [
+						{
+							label: __( 'Retry', 'jetpack-premium-analytics' ),
+							onClick: () => void refetch(),
+						},
+					],
+				} }
+				empty={ {
+					icon: video,
+					description: hasVideoScope
+						? __( 'No highlights are available for this video.', 'jetpack-premium-analytics' )
+						: __( 'Open a video report to see its highlights here.', 'jetpack-premium-analytics' ),
+				} }
+			>
+				<MetricTileGrid tiles={ tiles } dataFormat={ COUNT_FORMAT } />
+			</WidgetState>
+		</div>
+	);
+}
+
+/**
+ * Video highlights widget render entry point.
+ *
+ * @param {VideoDetailHighlightsWidgetProps} props - Widget host props.
+ * @return The rendered widget.
+ */
+export default function VideoDetailHighlights( {
+	attributes = {},
+}: VideoDetailHighlightsWidgetProps ) {
+	return (
+		<WidgetRoot attributes={ attributes }>
+			<VideoDetailHighlightsInner />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/video-detail-highlights/stories/video-detail-highlights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/video-detail-highlights/stories/video-detail-highlights-widget.stories.tsx
@@ -1,0 +1,112 @@
+/**
+ * External dependencies
+ */
+import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
+/**
+ * Internal dependencies
+ */
+import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
+import VideoDetailHighlightsRender from '../render';
+import widgetDefinition from '../widget';
+import type { Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+const MOCK_VIDEO_ID = 105;
+const VIDEO_DETAIL_HIGHLIGHTS_RENDER_MODULE = 'storybook/video-detail-highlights';
+
+interface VideoDetailHighlightsStoryControls {
+	withComparison: boolean;
+}
+
+function getVideoReportParams( withComparison: boolean ) {
+	return {
+		...getDefaultQueryParams( withComparison ),
+		post_id: MOCK_VIDEO_ID,
+	};
+}
+
+function renderVideoDetailHighlights( { withComparison }: VideoDetailHighlightsStoryControls ) {
+	return (
+		<VideoDetailHighlightsRender
+			attributes={ { reportParams: getVideoReportParams( withComparison ) } }
+		/>
+	);
+}
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/VideoDetailHighlights',
+	component: VideoDetailHighlightsRender,
+	tags: [ 'autodocs' ],
+	argTypes: {
+		withComparison: { control: 'boolean' },
+	},
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The "Video highlights" widget shows views, impressions, hours watched, and retention rate for the video selected through `reportParams.post_id`. It uses the complete `stats/video-plays` range summary and shows period-over-period deltas when comparison is enabled. If the selected video has no comparison row, the tiles keep the comparison layout without inventing a vs-zero delta.',
+			},
+		},
+	},
+} satisfies Meta<
+	ComponentProps< typeof VideoDetailHighlightsRender > & VideoDetailHighlightsStoryControls
+>;
+
+export default meta;
+
+type Story = StoryObj< VideoDetailHighlightsStoryControls >;
+
+export const Default: Story = {
+	render: renderVideoDetailHighlights,
+	args: { withComparison: false },
+	decorators: [ withWidgetCanvas ],
+};
+
+export const WithComparison: Story = {
+	render: renderVideoDetailHighlights,
+	args: { withComparison: true },
+	decorators: [ withWidgetCanvas ],
+};
+
+interface VideoDetailHighlightsDashboardStoryProps
+	extends WidgetDashboardWithWidgetControls,
+		VideoDetailHighlightsStoryControls {}
+
+function VideoDetailHighlightsDashboardStory( {
+	withComparison,
+	...dashboardArgs
+}: VideoDetailHighlightsDashboardStoryProps ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ VIDEO_DETAIL_HIGHLIGHTS_RENDER_MODULE }
+			renderComponent={
+				VideoDetailHighlightsRender as ComponentType< WidgetRenderProps< unknown > >
+			}
+			attributes={ { reportParams: getVideoReportParams( withComparison ) } }
+		/>
+	);
+}
+
+export const WidgetDashboardWithWidget: StoryObj< VideoDetailHighlightsDashboardStoryProps > = {
+	render: args => <VideoDetailHighlightsDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		withComparison: true,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+		withComparison: { control: 'boolean' },
+	},
+};

--- a/projects/packages/premium-analytics/widgets/video-detail-highlights/stories/video-detail-highlights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/video-detail-highlights/stories/video-detail-highlights-widget.stories.tsx
@@ -1,4 +1,17 @@
 /**
+ * The Video highlights widget is the video detail page's highlights card: the
+ * selected video's views, impressions, hours watched, and retention rate as
+ * metric tiles. The video scope arrives through `reportParams.post_id` (seeded
+ * from the detail page URL in product); the `hasVideoScope` control toggles it
+ * to exercise the scopeless empty state. All four tiles are period-scoped and
+ * carry deltas when comparison is on; when the selected video has no
+ * comparison row, the tiles keep the comparison layout without inventing a
+ * vs-zero delta.
+ *
+ * Data comes from the proxied `stats/video-plays` complete-stats range
+ * summary, covered by the shared report mocks' video-plays fixture.
+ */
+/**
  * External dependencies
  */
 import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
@@ -21,25 +34,47 @@ import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
 
+// Matches a video row in the shared video-plays complete-stats fixture so the
+// scoped tiles resolve to real mock values.
 const MOCK_VIDEO_ID = 105;
+
 const VIDEO_DETAIL_HIGHLIGHTS_RENDER_MODULE = 'storybook/video-detail-highlights';
 
 interface VideoDetailHighlightsStoryControls {
 	withComparison: boolean;
+	hasVideoScope: boolean;
 }
 
-function getVideoReportParams( withComparison: boolean ) {
+/**
+ * Builds the widget attributes: report params with the video scope the detail
+ * page seeds from its URL when `hasVideoScope` is on.
+ *
+ * @param {VideoDetailHighlightsStoryControls} controls - The story controls.
+ * @return The widget attributes.
+ */
+function getVideoDetailHighlightsAttributes( {
+	withComparison,
+	hasVideoScope,
+}: VideoDetailHighlightsStoryControls ): ComponentProps<
+	typeof VideoDetailHighlightsRender
+>[ 'attributes' ] {
 	return {
-		...getDefaultQueryParams( withComparison ),
-		post_id: MOCK_VIDEO_ID,
+		reportParams: {
+			...getDefaultQueryParams( withComparison ),
+			...( hasVideoScope ? { post_id: MOCK_VIDEO_ID } : {} ),
+		},
 	};
 }
 
-function renderVideoDetailHighlights( { withComparison }: VideoDetailHighlightsStoryControls ) {
+/**
+ * Renders the data-connected widget with the composed attributes.
+ *
+ * @param {VideoDetailHighlightsStoryControls} controls - The story controls.
+ * @return The rendered widget.
+ */
+function renderVideoDetailHighlights( controls: VideoDetailHighlightsStoryControls ) {
 	return (
-		<VideoDetailHighlightsRender
-			attributes={ { reportParams: getVideoReportParams( withComparison ) } }
-		/>
+		<VideoDetailHighlightsRender attributes={ getVideoDetailHighlightsAttributes( controls ) } />
 	);
 }
 
@@ -48,13 +83,20 @@ const meta = {
 	component: VideoDetailHighlightsRender,
 	tags: [ 'autodocs' ],
 	argTypes: {
-		withComparison: { control: 'boolean' },
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+		hasVideoScope: {
+			control: 'boolean',
+			description: 'Include the `post_id` report param the video detail page seeds from its URL.',
+		},
 	},
 	parameters: {
 		docs: {
 			description: {
 				component:
-					'The "Video highlights" widget shows views, impressions, hours watched, and retention rate for the video selected through `reportParams.post_id`. It uses the complete `stats/video-plays` range summary and shows period-over-period deltas when comparison is enabled. If the selected video has no comparison row, the tiles keep the comparison layout without inventing a vs-zero delta.',
+					'The "Video highlights" widget: the selected video\'s views, impressions, hours watched, and retention rate as metric tiles — the video detail page\'s highlights card. It uses the complete `stats/video-plays` range summary and shows period-over-period deltas when comparison is enabled. If the selected video has no comparison row, the tiles keep the comparison layout without inventing a vs-zero delta. Without a video scope the widget renders a scopeless empty state.',
 			},
 		},
 	},
@@ -66,15 +108,34 @@ export default meta;
 
 type Story = StoryObj< VideoDetailHighlightsStoryControls >;
 
+/**
+ * Default — the selected video's highlights for the primary period only; the
+ * tiles show no deltas.
+ */
 export const Default: Story = {
 	render: renderVideoDetailHighlights,
-	args: { withComparison: false },
+	args: { withComparison: false, hasVideoScope: true },
 	decorators: [ withWidgetCanvas ],
 };
 
+/**
+ * WithComparison — the previous-period comparison from the date range picker;
+ * each tile carries a delta computed from the selected video's comparison row.
+ */
 export const WithComparison: Story = {
 	render: renderVideoDetailHighlights,
-	args: { withComparison: true },
+	args: { withComparison: true, hasVideoScope: true },
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * NoVideoScope — the widget without a `post_id` report param, as when no video
+ * is selected. Renders the scopeless empty state without firing a stats
+ * request.
+ */
+export const NoVideoScope: Story = {
+	render: renderVideoDetailHighlights,
+	args: { withComparison: false, hasVideoScope: false },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -82,19 +143,27 @@ interface VideoDetailHighlightsDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		VideoDetailHighlightsStoryControls {}
 
+/**
+ * Mounts the real `WidgetDashboard` with this single widget so it renders
+ * exactly as it does in product (framed card, sizing, host environment).
+ *
+ * @param {VideoDetailHighlightsDashboardStoryProps} props - The dashboard story controls.
+ * @return The widget mounted inside the real dashboard.
+ */
 function VideoDetailHighlightsDashboardStory( {
 	withComparison,
+	hasVideoScope,
 	...dashboardArgs
 }: VideoDetailHighlightsDashboardStoryProps ) {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ { ...widgetDefinition, presentation: 'framed' } }
 			renderModule={ VIDEO_DETAIL_HIGHLIGHTS_RENDER_MODULE }
 			renderComponent={
 				VideoDetailHighlightsRender as ComponentType< WidgetRenderProps< unknown > >
 			}
-			attributes={ { reportParams: getVideoReportParams( withComparison ) } }
+			attributes={ getVideoDetailHighlightsAttributes( { withComparison, hasVideoScope } ) }
 		/>
 	);
 }
@@ -103,10 +172,20 @@ export const WidgetDashboardWithWidget: StoryObj< VideoDetailHighlightsDashboard
 	render: args => <VideoDetailHighlightsDashboardStory { ...args } />,
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		widgetWidth: 4,
+		widgetHeight: 1,
 		withComparison: true,
+		hasVideoScope: true,
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
-		withComparison: { control: 'boolean' },
+		withComparison: {
+			control: 'boolean',
+			description: 'Include previous-period comparison report params.',
+		},
+		hasVideoScope: {
+			control: 'boolean',
+			description: 'Include the `post_id` report param the video detail page seeds from its URL.',
+		},
 	},
 };

--- a/projects/packages/premium-analytics/widgets/video-detail-highlights/style.module.css
+++ b/projects/packages/premium-analytics/widgets/video-detail-highlights/style.module.css
@@ -1,0 +1,6 @@
+.root {
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	overflow: hidden;
+}

--- a/projects/packages/premium-analytics/widgets/video-detail-highlights/widget.json
+++ b/projects/packages/premium-analytics/widgets/video-detail-highlights/widget.json
@@ -1,0 +1,7 @@
+{
+	"name": "jpa/video-detail-highlights",
+	"title": "Video highlights",
+	"description": "Views, impressions, hours watched, and retention rate for the video being viewed.",
+	"category": "stats",
+	"presentation": "framed"
+}

--- a/projects/packages/premium-analytics/widgets/video-detail-highlights/widget.ts
+++ b/projects/packages/premium-analytics/widgets/video-detail-highlights/widget.ts
@@ -1,0 +1,31 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { video } from '@wordpress/icons';
+import type { WidgetAttributeField } from '@wordpress/widget-primitives';
+
+/**
+ * Video highlights has no configurable attributes. The detail page scopes it
+ * to one video through `reportParams.post_id`.
+ */
+export type VideoDetailHighlightsAttributes = Record< never, never >;
+
+/**
+ * Widget type definition for the selected video's complete Stats metrics.
+ */
+export default {
+	name: 'jpa/video-detail-highlights',
+	title: __( 'Video highlights', 'jetpack-premium-analytics' ),
+	help: {
+		content: __(
+			'Views, impressions, hours watched, and retention rate for the video being viewed.',
+			'jetpack-premium-analytics'
+		),
+	},
+	icon: video,
+	attributes: [] as WidgetAttributeField< VideoDetailHighlightsAttributes >[],
+	example: {
+		attributes: {},
+	},
+};


### PR DESCRIPTION
Fixes WOOA7S-1746

## Proposed changes

New standalone `jpa/video-detail-highlights` widget — the video analog of post detail highlights — extracted from the video detail page work so it can merge independently.

* Renders Views, Impressions, Hours watched, and Retention rate tiles for the video selected via `reportParams.post_id` (empty descriptor when no video is selected), fed by the complete-stats video-plays range summary. `watch_time` is already in hours, matching Calypso's videopress module.
* When comparison is on (`comp === '1'`), all four tiles show period-over-period deltas, mirroring `post-detail-highlights`. Previous values are `null` when the video has no row in the comparison window, so no vs-zero delta is fabricated.
* `useStatsVideoPlays` routes `complete_stats` + `summarize` requests through the existing summary query factory; existing callers never send both flags, so their requests are unchanged.

<img width="2800" height="1100" alt="Google Chrome -2026-07-17 at 11 29 07@2x" src="https://github.com/user-attachments/assets/59ea83ee-0658-4994-92f9-ce6c9cd72b06" />


## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No — it reads existing video-plays stats.

## Testing instructions

The widget isn't placed in any report layout yet (the video detail page lands separately), so the easiest way to exercise it is Storybook and the unit tests:

* In `projects/packages/premium-analytics`, run `pnpm storybook` and open **Packages → Premium Analytics → Widgets → VideoDetailHighlights**.
* Check the **Default** story shows the four tiles with values and the **WithComparison** story shows period-over-period deltas; **WidgetDashboardWithWidget** renders it inside the dashboard frame.
* Optionally run the widget tests: `pnpm test widgets/video-detail-highlights`.