### PR TITLE
Podcast: release version 1.4.0

### DIFF
--- a/projects/packages/podcast/CHANGELOG.md
+++ b/projects/packages/podcast/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-07-16
+### Added
+- Podcast Episode: add editor controls for soundbites and alternate audio/video files, so the front-end seek buttons and Podcasting 2.0 feed tags that already render can now be authored.
+
+### Changed
+- Podcast: remove the unused `Episode_Block_Tags::render()` seam; production and tests compose `get_block_attrs()` + `render_from_attrs()` directly. No behavior change.
+- Podcast Episode: the rich player is now a paid feature, gated in the editor for sites without a qualifying plan (an upgrade prompt on WordPress.com, hidden on self-hosted Jetpack like other paid blocks).
+- Update package dependencies.
+
+### Removed
+- Podcast: drop the settings-saved analytics event.
+
+### Fixed
+- Podcast: count episodes published with the Podcast Episode block in publish telemetry.
+- Podcast: derive the distribution feed URL from WordPress's canonical category-feed API so it stays valid on plain-permalink and no-trailing-slash sites instead of producing a malformed URL.
+- Podcast: fix hardcoded upsell fallback URL to use the injected upgrade product.
+- Podcast: preload the selected category so the settings picker shows it immediately instead of rendering blank while the category list loads.
+- Podcast: show a clear message when episode play counts can't load, instead of quietly showing zero plays.
+- Podcast feed: fixed missing episode details when the Podcast Episode block sits inside another block.
+- Podcast feed: stop podcast feed pages from showing up short or empty.
+- Podcast stats: fix time-window labels and show a loading state instead of stale numbers when switching periods.
+
 ## [1.3.2] - 2026-07-13
 ### Changed
 - Stop exposing the `podcasting_*` options through core `/wp/v2/settings`; the dashboard now reads and writes them via the dedicated `wpcom/v2/podcast/settings` endpoint. [#50458]
@@ -171,6 +193,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Dashboard: Replace the wp-build placeholder with page chrome and tab navigation. [#48559]
 - Dashboard: Slim down wp-build wiring to the Backup pattern. [#48600]
 
+[1.4.0]: https://github.com/Automattic/jetpack-podcast/compare/v1.3.2...v1.4.0
 [1.3.2]: https://github.com/Automattic/jetpack-podcast/compare/v1.3.1...v1.3.2
 [1.3.1]: https://github.com/Automattic/jetpack-podcast/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/Automattic/jetpack-podcast/compare/v1.2.0...v1.3.0

--- a/projects/packages/podcast/changelog/add-podcast-episode-plan-gating
+++ b/projects/packages/podcast/changelog/add-podcast-episode-plan-gating
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Podcast Episode: the rich player is now a paid feature, gated in the editor for sites without a qualifying plan (an upgrade prompt on WordPress.com, hidden on self-hosted Jetpack like other paid blocks).

--- a/projects/packages/podcast/changelog/add-podcast-episode-soundbites-ui
+++ b/projects/packages/podcast/changelog/add-podcast-episode-soundbites-ui
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Podcast Episode: add editor controls for soundbites and alternate audio/video files, so the front-end seek buttons and Podcasting 2.0 feed tags that already render can now be authored.

--- a/projects/packages/podcast/changelog/fix-podcast-episode-stats-error-handling
+++ b/projects/packages/podcast/changelog/fix-podcast-episode-stats-error-handling
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Podcast: show a clear message when episode play counts can't load, instead of quietly showing zero plays.

--- a/projects/packages/podcast/changelog/fix-podcast-feed-enclosure-pagination
+++ b/projects/packages/podcast/changelog/fix-podcast-feed-enclosure-pagination
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Podcast feed: stop podcast feed pages from showing up short or empty.

--- a/projects/packages/podcast/changelog/fix-podcast-feed-url
+++ b/projects/packages/podcast/changelog/fix-podcast-feed-url
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Podcast: derive the distribution feed URL from WordPress's canonical category-feed API so it stays valid on plain-permalink and no-trailing-slash sites instead of producing a malformed URL.

--- a/projects/packages/podcast/changelog/fix-podcast-hardcoded-upsell-urls
+++ b/projects/packages/podcast/changelog/fix-podcast-hardcoded-upsell-urls
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Podcast: fix hardcoded upsell fallback URL to use the injected upgrade product.

--- a/projects/packages/podcast/changelog/fix-podcast-nested-episode-tags
+++ b/projects/packages/podcast/changelog/fix-podcast-nested-episode-tags
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Podcast feed: fixed missing episode details when the Podcast Episode block sits inside another block.

--- a/projects/packages/podcast/changelog/fix-podcast-remove-dead-render
+++ b/projects/packages/podcast/changelog/fix-podcast-remove-dead-render
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Podcast: remove the unused `Episode_Block_Tags::render()` seam; production and tests compose `get_block_attrs()` + `render_from_attrs()` directly. No behavior change.

--- a/projects/packages/podcast/changelog/fix-podcast-settings-loading
+++ b/projects/packages/podcast/changelog/fix-podcast-settings-loading
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Podcast: preload the selected category so the settings picker shows it immediately instead of rendering blank while the category list loads.

--- a/projects/packages/podcast/changelog/fix-podcast-settings-tracks-pii
+++ b/projects/packages/podcast/changelog/fix-podcast-settings-tracks-pii
@@ -1,4 +1,0 @@
-Significance: patch
-Type: removed
-
-Podcast: drop the settings-saved analytics event.

--- a/projects/packages/podcast/changelog/fix-podcast-stats-window
+++ b/projects/packages/podcast/changelog/fix-podcast-stats-window
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Podcast stats: fix time-window labels and show a loading state instead of stale numbers when switching periods.

--- a/projects/packages/podcast/changelog/fix-podcast-telemetry-episode-block
+++ b/projects/packages/podcast/changelog/fix-podcast-telemetry-episode-block
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Podcast: count episodes published with the Podcast Episode block in publish telemetry.

--- a/projects/packages/podcast/changelog/renovate-wordpress-monorepo
+++ b/projects/packages/podcast/changelog/renovate-wordpress-monorepo
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/podcast/composer.json
+++ b/projects/packages/podcast/composer.json
@@ -59,7 +59,7 @@
 		"autotagger": true,
 		"mirror-repo": "Automattic/jetpack-podcast",
 		"branch-alias": {
-			"dev-trunk": "1.3.x-dev"
+			"dev-trunk": "1.4.x-dev"
 		},
 		"textdomain": "jetpack-podcast",
 		"version-constants": {

--- a/projects/packages/podcast/package.json
+++ b/projects/packages/podcast/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-podcast",
-	"version": "1.3.2",
+	"version": "1.4.0",
 	"private": true,
 	"description": "Jetpack Podcast functionality (Simple and Atomic only).",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/podcast/#readme",

--- a/projects/packages/podcast/src/class-podcast.php
+++ b/projects/packages/podcast/src/class-podcast.php
@@ -16,7 +16,7 @@ use Automattic\Jetpack\Status\Host;
  */
 class Podcast {
 
-	const PACKAGE_VERSION = '1.3.2';
+	const PACKAGE_VERSION = '1.4.0';
 
 	/**
 	 * Whether the class has been initialized.

--- a/projects/plugins/jetpack/changelog/podcast-version-bump
+++ b/projects/plugins/jetpack/changelog/podcast-version-bump
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2749,7 +2749,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/podcast",
-                "reference": "732b4c245ccd501c5f4bf1ce18fef9c9b1624e5a"
+                "reference": "cdeaa612312a11508d74183eae8f6374d87123ac"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -2775,7 +2775,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-podcast",
                 "branch-alias": {
-                    "dev-trunk": "1.3.x-dev"
+                    "dev-trunk": "1.4.x-dev"
                 },
                 "textdomain": "jetpack-podcast",
                 "version-constants": {

--- a/projects/plugins/mu-wpcom-plugin/changelog/podcast-version-bump
+++ b/projects/plugins/mu-wpcom-plugin/changelog/podcast-version-bump
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1522,7 +1522,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/podcast",
-                "reference": "732b4c245ccd501c5f4bf1ce18fef9c9b1624e5a"
+                "reference": "cdeaa612312a11508d74183eae8f6374d87123ac"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1548,7 +1548,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-podcast",
                 "branch-alias": {
-                    "dev-trunk": "1.3.x-dev"
+                    "dev-trunk": "1.4.x-dev"
                 },
                 "textdomain": "jetpack-podcast",
                 "version-constants": {

--- a/projects/plugins/wpcomsh/changelog/podcast-version-bump
+++ b/projects/plugins/wpcomsh/changelog/podcast-version-bump
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1709,7 +1709,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/podcast",
-                "reference": "732b4c245ccd501c5f4bf1ce18fef9c9b1624e5a"
+                "reference": "cdeaa612312a11508d74183eae8f6374d87123ac"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1735,7 +1735,7 @@
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-podcast",
                 "branch-alias": {
-                    "dev-trunk": "1.3.x-dev"
+                    "dev-trunk": "1.4.x-dev"
                 },
                 "textdomain": "jetpack-podcast",
                 "version-constants": {


### PR DESCRIPTION
## Proposed changes

Release version **1.4.0** of the Podcast package. Aggregates the pending changelog entries and bumps the version.

Highest significance is `minor`, so `1.3.2` → `1.4.0`. Bumped in `package.json`, `CHANGELOG.md`, and the `PACKAGE_VERSION` constant in `src/class-podcast.php`.

### Included changes (13 entries)

**Added**
* Podcast Episode: editor controls for soundbites and alternate audio/video files.

**Changed**
* Remove the unused `Episode_Block_Tags::render()` seam (no behavior change).
* Podcast Episode: the rich player is now a paid, plan-gated feature.
* Update package dependencies.

**Removed**
* Drop the settings-saved analytics event.

**Fixed**
* Count Podcast Episode block posts in publish telemetry.
* Derive the distribution feed URL from WordPress's canonical category-feed API.
* Fix hardcoded upsell fallback URL to use the injected upgrade product.
* Preload the selected category so the settings picker isn't blank while loading.
* Show a clear message when episode play counts can't load.
* Fix missing episode details when the Podcast Episode block is nested in another block.
* Stop podcast feed pages from showing up short or empty.
* Fix stats time-window labels and show a loading state when switching periods.

## Does this pull request change what data or activity we track or use?

No new tracking. This release removes the settings-saved analytics event.

## Testing instructions

* Confirm the package version reads `1.4.0` in `package.json`, `CHANGELOG.md`, and `Podcast::PACKAGE_VERSION`.
* Verify `CHANGELOG.md` has a single `## [1.4.0]` section covering all entries and the `changelog/` directory is empty (only `.gitkeep`).
* CI green (changelogger validation, lint).
