### PR TITLE
WOOA7S-1745: Apply grid styles to All-time stats

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1745-all-time-stats-grid
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1745-all-time-stats-grid
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+All-time stats: Display lifetime metrics in responsive cards.

--- a/projects/packages/premium-analytics/widgets/all-time-stats/package.json
+++ b/projects/packages/premium-analytics/widgets/all-time-stats/package.json
@@ -9,7 +9,6 @@
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^15.0.0",
-		"@wordpress/ui": "0.17.0",
 		"@wordpress/widget-primitives": "0.2.0",
 		"react": "18.3.1"
 	},

--- a/projects/packages/premium-analytics/widgets/all-time-stats/render.tsx
+++ b/projects/packages/premium-analytics/widgets/all-time-stats/render.tsx
@@ -3,14 +3,14 @@
  */
 import { useStatsSite } from '@jetpack-premium-analytics/data';
 import {
-	MetricWithComparison,
+	MetricTileGrid,
 	WidgetRoot,
 	WidgetState,
+	type DataFormat,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';
-import { Icon, comment, people, postContent, seen, trendingUp } from '@wordpress/icons';
-import { Text } from '@wordpress/ui';
+import { comment, people, postContent, seen, trendingUp } from '@wordpress/icons';
 import { useMemo } from 'react';
 /**
  * Internal dependencies
@@ -37,24 +37,24 @@ type AllTimeStatsWidgetProps = WidgetRenderProps< AllTimeStatsRenderAttributes >
  */
 type StatsSummary = Record< string, unknown >;
 
-const COUNT_FORMAT = {
-	type: 'number' as const,
+const COUNT_FORMAT: DataFormat = {
+	type: 'number',
 	options: { decimals: 0 },
 };
 
 /**
- * Render-only config per metric: the row icon. Ids and labels are shared with
+ * Render-only config per metric: the tile icon. Ids and labels are shared with
  * the settings checkboxes via `ALL_TIME_STATS_METRICS` in `widget.ts`; the id
- * doubles as the summary field the row reads.
+ * doubles as the summary field the tile reads.
  */
-const ROW_CONFIG: Record< AllTimeStatsMetricId, { icon: typeof seen } > = {
+const TILE_CONFIG: Record< AllTimeStatsMetricId, { icon: typeof seen } > = {
 	views: { icon: seen },
 	visitors: { icon: people },
 	posts: { icon: postContent },
 	comments: { icon: comment },
 };
 
-type AllTimeStatsRow = {
+type AllTimeStatsTile = {
 	key: AllTimeStatsMetricId;
 	label: string;
 	icon: typeof seen;
@@ -63,7 +63,7 @@ type AllTimeStatsRow = {
 
 /**
  * Reads a numeric summary field, returning `undefined` when the key is absent
- * or not a finite number, so rows for missing fields can be skipped.
+ * or not a finite number, so tiles for missing fields can be skipped.
  *
  * @param summary - The normalized all-time summary.
  * @param key     - The summary field to read.
@@ -78,7 +78,7 @@ function readCount( summary: StatsSummary | undefined, key: string ): number | u
 
 /**
  * Fetches the all-time site summary through the designated `useStatsSite` hook
- * and renders the lifetime totals as a labelled list of icon rows. Which rows
+ * and renders the lifetime totals as a grid of metric tiles. Which tiles
  * appear is controlled by the `metrics` attribute; fields absent from the
  * response are skipped. There is no comparison period for this module, so each
  * value renders as a bare number.
@@ -97,20 +97,20 @@ function AllTimeStatsReport( {
 
 	const summary = ( data as { stats?: StatsSummary } | undefined )?.stats;
 
-	// Resolve selected ids against the canonical definitions so the row order
+	// Resolve selected ids against the canonical definitions so the tile order
 	// stays stable regardless of the order the ids were toggled in.
 	const enabledMetrics = useMemo( () => {
 		const selected = new Set( metrics );
 		return ALL_TIME_STATS_METRICS.filter( metric => selected.has( metric.id ) );
 	}, [ metrics ] );
 
-	const rows = useMemo(
+	const tiles = useMemo(
 		() =>
-			enabledMetrics.flatMap( ( { id, label } ): AllTimeStatsRow[] => {
+			enabledMetrics.flatMap( ( { id, label } ): AllTimeStatsTile[] => {
 				const value = readCount( summary, id );
 				return value === undefined
 					? []
-					: [ { key: id, label, icon: ROW_CONFIG[ id ].icon, value } ];
+					: [ { key: id, label, icon: TILE_CONFIG[ id ].icon, value } ];
 			} ),
 		[ enabledMetrics, summary ]
 	);
@@ -125,8 +125,8 @@ function AllTimeStatsReport( {
 				// The query keeps prior data via `placeholderData`, so a transient
 				// refetch failure keeps the totals visible; only surface the error
 				// when there is nothing to show.
-				isError={ rows.length === 0 && isError }
-				isEmpty={ rows.length === 0 }
+				isError={ tiles.length === 0 && isError }
+				isEmpty={ tiles.length === 0 }
 				error={ {
 					description: __(
 						"We couldn't load all-time stats. Please try again in a moment.",
@@ -144,20 +144,7 @@ function AllTimeStatsReport( {
 							: __( 'No stats recorded yet.', 'jetpack-premium-analytics' ),
 				} }
 			>
-				<div className={ styles.list }>
-					{ rows.map( row => (
-						<div key={ row.key } className={ styles.row }>
-							<Icon className={ styles.icon } icon={ row.icon } />
-							<Text className={ styles.label }>{ row.label }</Text>
-							<MetricWithComparison
-								className={ styles.value }
-								value={ row.value }
-								dataFormat={ COUNT_FORMAT }
-								fontSize="md"
-							/>
-						</div>
-					) ) }
-				</div>
+				<MetricTileGrid tiles={ tiles } dataFormat={ COUNT_FORMAT } />
 			</WidgetState>
 		</div>
 	);

--- a/projects/packages/premium-analytics/widgets/all-time-stats/stories/all-time-stats-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/all-time-stats/stories/all-time-stats-widget.stories.tsx
@@ -134,7 +134,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'The "All-time stats" widget. Shows lifetime totals for the site — views, visitors, posts, and comments — as a labelled list of icon rows, sourced from the Jetpack Stats site-summary endpoint. Which rows appear is controlled by the `metrics` attribute (`relevance: \'high\'`), exposed inline in the widget header and in the settings drawer. This module has no comparison period, so the values render as bare numbers and the `WithComparison` story looks identical to `Default`.',
+					'The "All-time stats" widget. Shows lifetime totals for the site — views, visitors, posts, and comments — as a responsive grid of metric tiles, sourced from the Jetpack Stats site-summary endpoint. Which tiles appear is controlled by the `metrics` attribute (`relevance: \'high\'`), exposed inline in the widget header and in the settings drawer. This module has no comparison period, so the values render as bare numbers and the `WithComparison` story looks identical to `Default`.',
 			},
 		},
 	},

--- a/projects/packages/premium-analytics/widgets/all-time-stats/style.module.css
+++ b/projects/packages/premium-analytics/widgets/all-time-stats/style.module.css
@@ -1,29 +1,8 @@
+/* No outer padding: the host frames the widget and owns the padding. */
 .root {
-	position: relative;
-	min-height: 120px;
-}
-
-.list {
 	display: flex;
 	flex-direction: column;
-	gap: var(--wpds-dimension-gap-lg);
-}
-
-.row {
-	display: flex;
-	align-items: center;
-	gap: var(--wpds-dimension-gap-md);
-}
-
-.icon {
-	flex-shrink: 0;
-	fill: var(--wpds-color-foreground-content-neutral);
-}
-
-.label {
-	flex: 1;
-}
-
-.value {
-	margin-inline-start: auto;
+	height: 100%;
+	overflow-x: hidden;
+	overflow-y: auto;
 }

--- a/projects/packages/premium-analytics/widgets/all-time-stats/widget.ts
+++ b/projects/packages/premium-analytics/widgets/all-time-stats/widget.ts
@@ -13,7 +13,7 @@ import { ArrayCheckboxField } from '@jetpack-premium-analytics/fields';
 /**
  * The lifetime totals the widget can show, in display order: the persisted id
  * and label of each metric. Single source for the settings checkboxes and the
- * rendered rows so the two cannot drift apart; `render.tsx` maps the ids to
+ * rendered tiles so the two cannot drift apart; `render.tsx` maps the ids to
  * icons and summary fields.
  */
 export const ALL_TIME_STATS_METRICS = [
@@ -24,8 +24,8 @@ export const ALL_TIME_STATS_METRICS = [
 ] as const satisfies readonly { id: string; label: string }[];
 
 /**
- * Identifier persisted in the widget's `metrics` attribute for one total row.
- * Each id doubles as the summary field the row reads.
+ * Identifier persisted in the widget's `metrics` attribute for one total tile.
+ * Each id doubles as the summary field the tile reads.
  */
 export type AllTimeStatsMetricId = ( typeof ALL_TIME_STATS_METRICS )[ number ][ 'id' ];
 
@@ -53,8 +53,8 @@ export const DEFAULT_ALL_TIME_STATS_METRICS: AllTimeStatsMetricId[] = ALL_TIME_S
 /**
  * Widget type definition.
  *
- * Ported from the Jetpack Stats "All-time stats" card: a labelled list of
- * lifetime totals — views, visitors, posts, and comments. `example.attributes`
+ * Ported from the Jetpack Stats "All-time stats" card: a grid of metric tiles
+ * for lifetime totals — views, visitors, posts, and comments. `example.attributes`
  * doubles as the defaults applied to new instances: every metric enabled.
  */
 export default {


### PR DESCRIPTION
Fixes WOOA7S-1745

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Render All-time stats with the shared `MetricTileGrid` used by Annual highlights.
* Remove the widget's list-only styles and unused `@wordpress/ui` dependency.
* Update the widget documentation and changelog entry to describe the responsive metric cards.

All-time stats currently renders as a plain list while the related highlights widgets use responsive cards. Reusing the shared grid keeps these dashboard modules visually consistent and gives All-time stats the same narrow, wide, and tall layouts without duplicating responsive styling.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* WOOA7S-1745

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Run `pnpm --filter @automattic/jetpack-premium-analytics storybook`.
* Open the All-time stats `Widget Dashboard With Widget` story.
* Change the widget size and confirm the metrics use compact rows when narrow, centered cards when wide and short, and a two-column card grid when wide and tall.
* Confirm the Default, With Comparison, Loading, Error, and Empty stories still render correctly.


https://github.com/user-attachments/assets/40d6eca8-f521-416b-92ff-c5d89d6527f5

