### PR TITLE
Podcast: restore Atomic opt-in so the module stays available

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-podcast-dashboard-blank-atomic
+++ b/projects/plugins/wpcomsh/changelog/fix-podcast-dashboard-blank-atomic
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Podcast: Force the module active on plugins_loaded before Jetpack initializes it, so the dashboard renders instead of an empty container on Atomic sites.
+Podcast: Restore the Atomic opt-in so the module stays available on Jetpack builds that predate the self-hosted release, and force-activate it before Jetpack initializes so the dashboard renders instead of an empty container.

--- a/projects/plugins/wpcomsh/changelog/fix-podcast-dashboard-blank-atomic
+++ b/projects/plugins/wpcomsh/changelog/fix-podcast-dashboard-blank-atomic
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Podcast: Force the module active on plugins_loaded before Jetpack initializes it, so the dashboard renders instead of an empty container on Atomic sites.

--- a/projects/plugins/wpcomsh/feature-plugins/podcast.php
+++ b/projects/plugins/wpcomsh/feature-plugins/podcast.php
@@ -2,14 +2,21 @@
 /**
  * Turn the Jetpack Podcast module on for Atomic sites.
  *
- * Podcast is available globally as a Jetpack module. Atomic temporarily forces
- * the module active so sites persist it in their `jetpack_active_modules`
- * setting as they receive requests, mirroring the previous always-on behavior.
- * The force-activation hook can be removed after the hydration window; the
- * stored setting will keep Podcast enabled while making it user-toggleable.
+ * Podcast ships as a Jetpack module that older Jetpack builds still hide behind
+ * the `jetpack_podcast_for_the_world` filter. The Jetpack plugin currently
+ * pinned on Atomic predates the self-hosted release (#50447) that removes that
+ * gate, so wpcomsh keeps opting Atomic in — otherwise the module drops out of
+ * the available list entirely. We also force it active so existing sites, which
+ * do not auto-activate the module on upgrade, persist it in their stored
+ * `jetpack_active_modules` setting. Remove both once the Jetpack build on Atomic
+ * includes #50447; the stored setting keeps Podcast on and user-toggleable.
  *
  * @package wpcomsh
  */
+
+// Un-hide Podcast on Jetpack builds that still gate it. Registered at
+// mu-plugin load so it is in place before get_available_modules() first runs.
+add_filter( 'jetpack_podcast_for_the_world', '__return_true' );
 
 /**
  * Force Podcast active while Atomic sites hydrate their stored module setting.

--- a/projects/plugins/wpcomsh/feature-plugins/podcast.php
+++ b/projects/plugins/wpcomsh/feature-plugins/podcast.php
@@ -25,4 +25,8 @@ function wpcomsh_hydrate_podcast_module() {
 		Jetpack::activate_module( 'podcast', false, false );
 	}
 }
-add_action( 'init', 'wpcomsh_hydrate_podcast_module', 0, 0 );
+// Runs on plugins_loaded before Jetpack's late_initialization (priority 90),
+// which only calls Podcast::init() when the module already reads as active.
+// Activating on init (after plugins_loaded) lost that race: the menu still
+// rendered but the dashboard fell back to an empty container.
+add_action( 'plugins_loaded', 'wpcomsh_hydrate_podcast_module', 20 );


### PR DESCRIPTION
### Proposed changes

Released with this PR and the wpcomsh change was mistakenly included in the release. This removed the loader for wpcomsh before the latest version of Jetpack could operate on its own. This left Atomic sites in a broken state.

## Does this pull request change what data or activity we track or use?

No

### Testing instructions

On an Atomic site running Jetpack 16.1-a.1 (pre-#50447) with this wpcomsh change:

1. `wp jetpack module list` includes `podcast` (available again).
2. On a fresh request, wp-admin → Jetpack → Podcast renders the app container (`<div id="jetpack-podcast-dashboard-wp-admin-app" class="boot-layout-container">`), not a bare `Podcast` heading.
3. Media → Create AI Podcast is present.
