### PR TITLE
Premium Analytics: respect zero max in Authors widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1747-authors-max-zero
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1747-authors-max-zero
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Authors: Respect a maximum value of zero when requesting all rows.

--- a/projects/packages/premium-analytics/widgets/authors/__tests__/authors.test.tsx
+++ b/projects/packages/premium-analytics/widgets/authors/__tests__/authors.test.tsx
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { getDefaultQueryParams, queryClient } from '@jetpack-premium-analytics/data';
+import { render, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+/**
+ * Internal dependencies
+ */
+import AuthorsWidget from '../render';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => ( {} ),
+} ) );
+
+const mockApiFetch = apiFetch as unknown as jest.Mock;
+
+describe( 'AuthorsWidget', () => {
+	beforeEach( () => {
+		queryClient.clear();
+		mockApiFetch.mockReset();
+		mockApiFetch.mockResolvedValue( {
+			date: '2026-07-17',
+			period: 'day',
+			summary: { authors: [] },
+		} );
+	} );
+
+	it( 'passes max zero through to request all authors', async () => {
+		render(
+			<AuthorsWidget
+				attributes={ { max: 0, reportParams: getDefaultQueryParams( false, 'last-7-days' ) } }
+			/>
+		);
+
+		await waitFor( () =>
+			expect( mockApiFetch ).toHaveBeenCalledWith(
+				expect.objectContaining( {
+					path: expect.stringMatching( /[?&]max=0(?:&|$)/ ),
+				} )
+			)
+		);
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/authors/render.tsx
+++ b/projects/packages/premium-analytics/widgets/authors/render.tsx
@@ -9,6 +9,7 @@ import {
 	WidgetRoot,
 	WidgetState,
 	formatLegendLabels,
+	toMaxRows,
 	useWidgetDrillDown,
 	useWidgetRootContext,
 	type LeaderboardChartData,
@@ -34,12 +35,6 @@ const DEFAULT_MAX = 7;
 type AuthorsRenderAttributes = AuthorsAttributes & Partial< ReportParamsFieldAttributes >;
 
 type AuthorsWidgetProps = WidgetRenderProps< AuthorsRenderAttributes >;
-
-const toPositiveInt = ( value: string | number | undefined, fallback: number ) => {
-	const parsed = typeof value === 'number' ? value : Number.parseInt( value ?? '', 10 );
-
-	return Number.isFinite( parsed ) && parsed > 0 ? parsed : fallback;
-};
 
 export type AuthorsLeaderboardProps = {
 	/**
@@ -322,7 +317,7 @@ export default function Authors( { attributes = {} }: AuthorsWidgetProps ) {
 	return (
 		<WidgetRoot attributes={ attributes }>
 			<div className={ styles.root }>
-				<AuthorsReport max={ toPositiveInt( attributes.max, DEFAULT_MAX ) } />
+				<AuthorsReport max={ toMaxRows( attributes.max, DEFAULT_MAX ) } />
 			</div>
 		</WidgetRoot>
 	);


### PR DESCRIPTION
## Proposed changes

* Replace the Authors widget's local positive-integer parser with the shared `toMaxRows` helper.
* Preserve `max = 0`, which is the Stats widget contract for displaying all rows returned by the API, instead of silently falling back to seven rows.
* Add a regression test that verifies `max=0` reaches the top-authors Stats request.

The wpcom top-authors endpoint does not treat `max=0` as literally unlimited. For memory safety, it converts `0` to its hard limit of 20 authors per day. In summary mode, the response can contain more than 20 authors because it combines each day's results, but it cannot include authors who never appeared in a day's top 20. This PR therefore displays all rows available in the API response, subject to that intentional server-side cap.

## Related product discussion/links

* WOOA7S-1747

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run `pnpm exec jest --config=projects/packages/premium-analytics/tests/jest.config.cjs projects/packages/premium-analytics/widgets/authors/__tests__ --runInBand`.
* Run `pnpm --dir projects/packages/premium-analytics typecheck`.
* Configure the Authors widget with a maximum value of `0` and confirm the request includes `max=0` and renders all authors returned by the API.
