### PR TITLE
Premium Analytics: format report counts with WordPress locale

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-report-table-count-formatting
+++ b/projects/packages/premium-analytics/changelog/fix-report-table-count-formatting
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Stats reports: format table counts using the WordPress user locale.
+Stats reports: format table counts and rates using the WordPress user locale.

--- a/projects/packages/premium-analytics/changelog/fix-report-table-count-formatting
+++ b/projects/packages/premium-analytics/changelog/fix-report-table-count-formatting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats reports: format table counts using the WordPress user locale.

--- a/projects/packages/premium-analytics/routes/reports/annual-insights/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/annual-insights/config/fields.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
 import { __ } from '@wordpress/i18n';
 import type { StatsInsightsYear } from '@jetpack-premium-analytics/data';
 import type { Field } from '@wordpress/dataviews';
@@ -12,7 +13,7 @@ import type { Field } from '@wordpress/dataviews';
  * @return The formatted number.
  */
 function formatNumber( value: number ): string {
-	return value.toLocaleString();
+	return formatMetricValue( value, 'number', { decimals: 0, useMultipliers: false } );
 }
 
 /**
@@ -23,10 +24,7 @@ function formatNumber( value: number ): string {
  * @return The formatted average.
  */
 function formatAverage( value: number ): string {
-	return value.toLocaleString( undefined, {
-		minimumFractionDigits: 1,
-		maximumFractionDigits: 1,
-	} );
+	return formatMetricValue( value, 'average', { decimals: 1 } );
 }
 
 /**

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/fields.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
 import { __ } from '@wordpress/i18n';
 import type { Field } from '@wordpress/dataviews';
 
@@ -66,7 +67,9 @@ export function getClicksFields(): Field< ClickRow >[] {
 			id: 'clicks',
 			label: __( 'Clicks', 'jetpack-premium-analytics' ),
 			getValue: ( { item } ) => item.clicks,
-			render: ( { item } ) => <>{ item.clicks.toLocaleString() }</>,
+			render: ( { item } ) => (
+				<>{ formatMetricValue( item.clicks, 'number', { decimals: 0, useMultipliers: false } ) }</>
+			),
 		},
 	];
 }

--- a/projects/packages/premium-analytics/routes/reports/comment-followers/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/comment-followers/config/fields.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { type StatsCommentFollowersItem } from '@jetpack-premium-analytics/data';
+import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
 import { type Field } from '@wordpress/dataviews';
 import { __ } from '@wordpress/i18n';
 import { Icon, external } from '@wordpress/icons';
@@ -62,7 +63,14 @@ export function getCommentFollowersFields(): Field< StatsCommentFollowersItem >[
 			id: 'subscribers',
 			label: __( 'Subscribers', 'jetpack-premium-analytics' ),
 			getValue: ( { item } ) => item.followers,
-			render: ( { item } ) => <>{ item.followers.toLocaleString() }</>,
+			render: ( { item } ) => (
+				<>
+					{ formatMetricValue( item.followers, 'number', {
+						decimals: 0,
+						useMultipliers: false,
+					} ) }
+				</>
+			),
 		},
 	];
 }

--- a/projects/packages/premium-analytics/routes/reports/comments/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/comments/config/fields.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
 import { __ } from '@wordpress/i18n';
 import { Link as RouteLink } from '@wordpress/route';
 import { Link as UiLink } from '@wordpress/ui';
@@ -77,7 +78,9 @@ export function getCommentsFields(): Field< CommentReportRow >[] {
 			id: 'comments',
 			label: __( 'Comments', 'jetpack-premium-analytics' ),
 			getValue: ( { item } ) => item.value,
-			render: ( { item } ) => <>{ item.value.toLocaleString() }</>,
+			render: ( { item } ) => (
+				<>{ formatMetricValue( item.value, 'number', { decimals: 0, useMultipliers: false } ) }</>
+			),
 		},
 	];
 }

--- a/projects/packages/premium-analytics/routes/reports/count-fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/count-fields.test.tsx
@@ -68,6 +68,32 @@ describe( 'report table count fields', () => {
 		expect( screen.getAllByText( '12,345' ) ).toHaveLength( 14 );
 	} );
 
+	it( 'formats Emails rates with the shared formatter', () => {
+		jest.spyOn( Number.prototype, 'toLocaleString' ).mockImplementation( () => {
+			throw new Error( 'Browser-locale formatting should not be used' );
+		} );
+
+		// The summary endpoint reports rates as 0–100, not 0–1.
+		renderCountField( getEmailsFields(), 'opens_rate', {
+			opens_rate: 66.666,
+			opens: 100,
+			unique_opens: 66,
+		} as never );
+
+		// Rounded to two decimals, unsigned — not `+66.67%`.
+		expect( screen.getByText( '66.67%' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders an em dash for a rate that is not attributable', () => {
+		renderCountField( getEmailsFields(), 'opens_rate', {
+			opens_rate: 0,
+			opens: 5,
+			unique_opens: 0,
+		} as never );
+
+		expect( screen.getByText( '—' ) ).toBeInTheDocument();
+	} );
+
 	it( 'formats Annual insights averages with the shared formatter', () => {
 		jest.spyOn( Number.prototype, 'toLocaleString' ).mockImplementation( () => {
 			throw new Error( 'Browser-locale formatting should not be used' );

--- a/projects/packages/premium-analytics/routes/reports/count-fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/count-fields.test.tsx
@@ -1,0 +1,54 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import { getClicksFields } from './clicks/config/fields';
+import { getCommentFollowersFields } from './comment-followers/config/fields';
+import { getDownloadsFields } from './downloads/config/fields';
+import { getArchivesFields, getPostsFields } from './posts/config/fields';
+import { getVideosFields } from './videos/config/fields';
+import type { Field } from '@wordpress/dataviews';
+
+/**
+ * Render a report table's numeric field for one row.
+ *
+ * @param fields - Report table fields.
+ * @param id     - Numeric field identifier.
+ * @param item   - Report table row.
+ */
+function renderCountField< Item >( fields: Field< Item >[], id: string, item: Item ) {
+	const field = fields.find( candidate => candidate.id === id );
+	// eslint-disable-next-line testing-library/render-result-naming-convention -- `render` is the DataViews field component.
+	const FieldComponent = field?.render;
+
+	if ( ! field || ! FieldComponent ) {
+		throw new Error( `Count field ${ id } is unavailable` );
+	}
+
+	render( <FieldComponent item={ item } field={ field as never } /> );
+}
+
+describe( 'report table count fields', () => {
+	afterEach( () => {
+		jest.restoreAllMocks();
+	} );
+
+	it( 'uses the shared formatter while preserving full counts', () => {
+		jest.spyOn( Number.prototype, 'toLocaleString' ).mockImplementation( () => {
+			throw new Error( 'Browser-locale formatting should not be used' );
+		} );
+
+		renderCountField( getPostsFields(), 'views', { views: 12345 } as never );
+		renderCountField( getArchivesFields(), 'views', { views: 12345 } as never );
+		renderCountField( getCommentFollowersFields(), 'subscribers', { followers: 12345 } as never );
+		renderCountField( getVideosFields(), 'plays', { plays: 12345 } as never );
+		renderCountField( getVideosFields(), 'impressions', { impressions: 12345 } as never );
+		renderCountField( getDownloadsFields(), 'downloads', { downloads: 12345 } as never );
+		renderCountField( getClicksFields(), 'clicks', { clicks: 12345 } as never );
+
+		expect( screen.getAllByText( '12,345' ) ).toHaveLength( 7 );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/reports/count-fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/count-fields.test.tsx
@@ -5,10 +5,17 @@ import { render, screen } from '@testing-library/react';
 /**
  * Internal dependencies
  */
+import { getAnnualInsightsFields } from './annual-insights/config/fields';
 import { getClicksFields } from './clicks/config/fields';
 import { getCommentFollowersFields } from './comment-followers/config/fields';
+import { getCommentsFields } from './comments/config/fields';
 import { getDownloadsFields } from './downloads/config/fields';
+import { getEmailsFields } from './emails/config/fields';
 import { getArchivesFields, getPostsFields } from './posts/config/fields';
+import { getReferrerFields } from './referrers/config/fields';
+import { getSearchTermsFields } from './search-terms/config/fields';
+import { getTagsFields } from './tags/config/fields';
+import { getUtmFields } from './utm/config/fields';
 import { getVideosFields } from './videos/config/fields';
 import type { Field } from '@wordpress/dataviews';
 
@@ -48,7 +55,27 @@ describe( 'report table count fields', () => {
 		renderCountField( getVideosFields(), 'impressions', { impressions: 12345 } as never );
 		renderCountField( getDownloadsFields(), 'downloads', { downloads: 12345 } as never );
 		renderCountField( getClicksFields(), 'clicks', { clicks: 12345 } as never );
+		renderCountField( getCommentsFields(), 'comments', { value: 12345 } as never );
+		renderCountField( getTagsFields(), 'views', { value: 12345 } as never );
+		renderCountField( getReferrerFields(), 'views', { views: 12345 } as never );
+		renderCountField( getSearchTermsFields(), 'views', { views: 12345 } as never );
+		renderCountField( getUtmFields( 'source-medium' ), 'views', { views: 12345 } as never );
+		renderCountField( getEmailsFields(), 'opens', { opens: 12345 } as never );
+		renderCountField( getAnnualInsightsFields(), 'total_posts', {
+			total_posts: 12345,
+		} as never );
 
-		expect( screen.getAllByText( '12,345' ) ).toHaveLength( 7 );
+		expect( screen.getAllByText( '12,345' ) ).toHaveLength( 14 );
+	} );
+
+	it( 'formats Annual insights averages with the shared formatter', () => {
+		jest.spyOn( Number.prototype, 'toLocaleString' ).mockImplementation( () => {
+			throw new Error( 'Browser-locale formatting should not be used' );
+		} );
+
+		// Legacy keeps a trailing `.0` on whole-number averages.
+		renderCountField( getAnnualInsightsFields(), 'avg_comments', { avg_comments: 4 } as never );
+
+		expect( screen.getByText( '4.0' ) ).toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/reports/downloads/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/downloads/config/fields.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
 import { __ } from '@wordpress/i18n';
 import type { StatsFileDownloadsItem } from '@jetpack-premium-analytics/data';
 import type { Field } from '@wordpress/dataviews';
@@ -46,7 +47,14 @@ export function getDownloadsFields(): Field< StatsFileDownloadsItem >[] {
 			id: 'downloads',
 			label: __( 'Downloads', 'jetpack-premium-analytics' ),
 			getValue: ( { item } ) => item.downloads,
-			render: ( { item } ) => <>{ item.downloads.toLocaleString() }</>,
+			render: ( { item } ) => (
+				<>
+					{ formatMetricValue( item.downloads, 'number', {
+						decimals: 0,
+						useMultipliers: false,
+					} ) }
+				</>
+			),
 		},
 	];
 }

--- a/projects/packages/premium-analytics/routes/reports/emails/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/emails/config/fields.tsx
@@ -23,9 +23,9 @@ function formatNumber( value: number ): string {
 
 /**
  * Format a rate for display. The summary endpoint reports rates as 0–100
- * percentages (unlike the per-post rate breakdown's 0–1 fractions) — Calypso's
- * Emails module renders `formatNumber( item.opens_rate )%` — so the value only
- * needs a `%` suffix.
+ * percentages (unlike the per-post rate breakdown's 0–1 fractions), so the
+ * value is scaled back to a fraction for `percentage` formatting, which
+ * supplies a locale-correct percent sign.
  *
  * Rates count *unique* recipients against sends. When events exist but none
  * could be attributed to a recipient (e.g. link-scanner or view-in-browser
@@ -43,7 +43,8 @@ function formatRate( rate: number, total: number, unique: number ): string {
 		return '—';
 	}
 
-	return `${ rate.toLocaleString( undefined, { maximumFractionDigits: 2 } ) }%`;
+	// `signDisplay` is forced to `auto` so a rate is not rendered as `+12%`.
+	return formatMetricValue( rate / 100, 'percentage', { decimals: 2, signDisplay: 'auto' } );
 }
 
 /**

--- a/projects/packages/premium-analytics/routes/reports/emails/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/emails/config/fields.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
 import { __ } from '@wordpress/i18n';
 import { Link } from '@wordpress/route';
 /**
@@ -17,7 +18,7 @@ import type { Field } from '@wordpress/dataviews';
  * @return The formatted number.
  */
 function formatNumber( value: number ): string {
-	return value.toLocaleString();
+	return formatMetricValue( value, 'number', { decimals: 0, useMultipliers: false } );
 }
 
 /**

--- a/projects/packages/premium-analytics/routes/reports/package.json
+++ b/projects/packages/premium-analytics/routes/reports/package.json
@@ -8,6 +8,7 @@
 	"dependencies": {
 		"@automattic/jetpack-script-data": "workspace:*",
 		"@jetpack-premium-analytics/data": "workspace:*",
+		"@jetpack-premium-analytics/formatters": "workspace:*",
 		"@jetpack-premium-analytics/routing": "workspace:*",
 		"@jetpack-premium-analytics/ui": "workspace:*",
 		"@jetpack-premium-analytics/widgets-toolkit": "workspace:*",

--- a/projects/packages/premium-analytics/routes/reports/posts/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/posts/config/fields.tsx
@@ -7,6 +7,7 @@ import {
 	type StatsArchivesItem,
 	type StatsTopPostsItem,
 } from '@jetpack-premium-analytics/data';
+import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
 import { __ } from '@wordpress/i18n';
 import { Icon, external } from '@wordpress/icons';
 import { Link } from '@wordpress/route';
@@ -80,7 +81,9 @@ export function getPostsFields(): Field< StatsTopPostsItem >[] {
 			id: 'views',
 			label: __( 'Views', 'jetpack-premium-analytics' ),
 			getValue: ( { item } ) => item.views,
-			render: ( { item } ) => <>{ item.views.toLocaleString() }</>,
+			render: ( { item } ) => (
+				<>{ formatMetricValue( item.views, 'number', { decimals: 0, useMultipliers: false } ) }</>
+			),
 		},
 	];
 }
@@ -182,7 +185,9 @@ export function getArchivesFields(): Field< ArchiveRow >[] {
 			id: 'views',
 			label: __( 'Views', 'jetpack-premium-analytics' ),
 			getValue: ( { item } ) => item.views,
-			render: ( { item } ) => <>{ item.views.toLocaleString() }</>,
+			render: ( { item } ) => (
+				<>{ formatMetricValue( item.views, 'number', { decimals: 0, useMultipliers: false } ) }</>
+			),
 		},
 	];
 }

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/fields.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
 import { LeaderboardLabel } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';
 /**
@@ -86,7 +87,9 @@ export function getReferrerFields(): Field< ReferrerRecord >[] {
 			id: 'views',
 			label: __( 'Views', 'jetpack-premium-analytics' ),
 			getValue: ( { item } ) => item.views,
-			render: ( { item } ) => <>{ item.views.toLocaleString() }</>,
+			render: ( { item } ) => (
+				<>{ formatMetricValue( item.views, 'number', { decimals: 0, useMultipliers: false } ) }</>
+			),
 		},
 	];
 }

--- a/projects/packages/premium-analytics/routes/reports/search-terms/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/search-terms/config/fields.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -30,7 +31,9 @@ export function getSearchTermsFields(): Field< SearchTermRow >[] {
 			type: 'integer',
 			enableSorting: true,
 			getValue: ( { item } ) => item.views,
-			render: ( { item } ) => <>{ item.views.toLocaleString() }</>,
+			render: ( { item } ) => (
+				<>{ formatMetricValue( item.views, 'number', { decimals: 0, useMultipliers: false } ) }</>
+			),
 		},
 	];
 }

--- a/projects/packages/premium-analytics/routes/reports/tags/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/tags/config/fields.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
 import { __ } from '@wordpress/i18n';
 import { category, tag as tagGlyph } from '@wordpress/icons';
 import { Icon, Link } from '@wordpress/ui';
@@ -64,7 +65,9 @@ export function getTagsFields(): Field< StatsTagsItem >[] {
 			id: 'views',
 			label: __( 'Views', 'jetpack-premium-analytics' ),
 			getValue: ( { item } ) => item.value,
-			render: ( { item } ) => <>{ item.value.toLocaleString() }</>,
+			render: ( { item } ) => (
+				<>{ formatMetricValue( item.value, 'number', { decimals: 0, useMultipliers: false } ) }</>
+			),
 		},
 	];
 }

--- a/projects/packages/premium-analytics/routes/reports/utm/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/utm/config/fields.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -29,7 +30,9 @@ export function getUtmFields( activeTab: UtmReportTabId ): Field< UtmReportRow >
 			id: 'views',
 			label: __( 'Views', 'jetpack-premium-analytics' ),
 			getValue: ( { item } ) => item.views,
-			render: ( { item } ) => <>{ item.views.toLocaleString() }</>,
+			render: ( { item } ) => (
+				<>{ formatMetricValue( item.views, 'number', { decimals: 0, useMultipliers: false } ) }</>
+			),
 		},
 	];
 }

--- a/projects/packages/premium-analytics/routes/reports/videos/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/videos/config/fields.tsx
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
 import { __ } from '@wordpress/i18n';
 import type { StatsVideoPlaysItem } from '@jetpack-premium-analytics/data';
 import type { Field } from '@wordpress/dataviews';
@@ -48,13 +49,22 @@ export function getVideosFields(): Field< StatsVideoPlaysItem >[] {
 			id: 'plays',
 			label: __( 'Plays', 'jetpack-premium-analytics' ),
 			getValue: ( { item } ) => item.plays,
-			render: ( { item } ) => <>{ item.plays.toLocaleString() }</>,
+			render: ( { item } ) => (
+				<>{ formatMetricValue( item.plays, 'number', { decimals: 0, useMultipliers: false } ) }</>
+			),
 		},
 		{
 			id: 'impressions',
 			label: __( 'Impressions', 'jetpack-premium-analytics' ),
 			getValue: ( { item } ) => item.impressions,
-			render: ( { item } ) => <>{ item.impressions.toLocaleString() }</>,
+			render: ( { item } ) => (
+				<>
+					{ formatMetricValue( item.impressions, 'number', {
+						decimals: 0,
+						useMultipliers: false,
+					} ) }
+				</>
+			),
 		},
 	];
 }


### PR DESCRIPTION
Fixes WOOA7S-1748

## Proposed changes

Report tables were formatting counts with `Number.prototype.toLocaleString()`, which uses the browser locale. This could make table counts use different separators or numbering systems from the rest of the dashboard when the browser and WordPress user locales differ.

* Format all seven report-table count fields with the shared `formatMetricValue` helper.
* Preserve full table precision by explicitly disabling compact K/M multipliers.
* Add regression coverage that prevents these fields from falling back to browser-locale formatting.

## Related product discussion/links

* WOOA7S-1748

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run `pnpm test -- --runInBand routes/reports/count-fields.test.tsx` from `projects/packages/premium-analytics`.
* Confirm the test covers the Posts, Archives, Comment Subscribers, Videos, File downloads, and Clicks report count fields.
* Build Premium Analytics with `pnpm run build` and confirm the reports route builds successfully.
* Optionally set the WordPress user locale and browser locale to different locales, then confirm report-table counts follow the WordPress locale and retain full values rather than K/M abbreviations.
