### PR TITLE
Premium Analytics: report table links rest neutral, color on hover

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-report-table-link-hover
+++ b/projects/packages/premium-analytics/changelog/add-report-table-link-hover
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Reports: table row links rest as neutral text and take the interactive color and underline on hover/focus, per the report-table design.

--- a/projects/packages/premium-analytics/changelog/add-report-table-link-hover
+++ b/projects/packages/premium-analytics/changelog/add-report-table-link-hover
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Reports: table row links rest as neutral text and take the interactive color and underline on hover/focus, per the report-table design.
+Reports: Display table row links as neutral text, applying the interactive color and underline on hover or focus.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-records-table.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-records-table.module.scss
@@ -20,3 +20,19 @@
 .root :global(.dataviews-layout__container) {
 	flex: 1 1 auto;
 }
+
+/* Per the report-table design, row links rest as neutral text and only take
+ * the interactive color and underline on hover/keyboard focus. Scoped to the
+ * records table so it styles every report's links (internal and external)
+ * in one place, overriding both wp-admin's default blue anchors and the
+ * unstyled-Link hover-underline recipes individual cells may carry. */
+.root :global(a) {
+	color: var(--wpds-color-foreground-content-neutral);
+	text-decoration: none;
+}
+
+.root :global(a:hover),
+.root :global(a:focus-visible) {
+	color: var(--wpds-color-foreground-interactive-brand);
+	text-decoration: underline;
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-records-table.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-records-table.module.scss
@@ -23,16 +23,15 @@
 
 /* Per the report-table design, row links rest as neutral text and only take
  * the interactive color and underline on hover/keyboard focus. Scoped to the
- * records table so it styles every report's links (internal and external)
- * in one place, overriding both wp-admin's default blue anchors and the
- * unstyled-Link hover-underline recipes individual cells may carry. */
-.root :global(a) {
+ * DataViews table body so custom empty states or other table chrome can keep
+ * their own link treatment. */
+.root :global(.dataviews-view-table tbody a:any-link) {
 	color: var(--wpds-color-foreground-content-neutral);
 	text-decoration: none;
 }
 
-.root :global(a:hover),
-.root :global(a:focus-visible) {
+.root :global(.dataviews-view-table tbody a:any-link:hover),
+.root :global(.dataviews-view-table tbody a:any-link:focus-visible) {
 	color: var(--wpds-color-foreground-interactive-brand);
 	text-decoration: underline;
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-records-table.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-records-table.tsx
@@ -9,7 +9,7 @@ import { useMemo, useState } from 'react';
 import { ReportPageSection } from './report-page-layout';
 import styles from './report-records-table.module.scss';
 import type { Action, Field, SupportedLayouts, View } from '@wordpress/dataviews';
-import type { ReactNode } from 'react';
+import type { ComponentProps, ReactElement, ReactNode } from 'react';
 
 const DEFAULT_PER_PAGE_SIZES = [ 10, 25, 50, 100 ];
 
@@ -32,6 +32,12 @@ const GenericDataViews = DataViews as unknown as < Item >( props: {
 	empty?: ReactNode;
 	searchLabel?: string;
 	config?: { perPageSizes: number[] };
+	isItemClickable?: ( item: Item ) => boolean;
+	renderItemLink?: (
+		props: {
+			item: Item;
+		} & ComponentProps< 'a' >
+	) => ReactElement;
 } ) => ReturnType< typeof DataViews >;
 
 export interface ReportRecordsTableProps< Item > {
@@ -53,6 +59,14 @@ export interface ReportRecordsTableProps< Item > {
 	empty?: ReactNode;
 	/** Page size choices (defaults to 10/25/50/100). */
 	perPageSizes?: number[];
+	/** Whether a record's primary field should render as an interactive link. */
+	isItemClickable?: ( item: Item ) => boolean;
+	/** Render the primary-field link while preserving DataViews table styling. */
+	renderItemLink?: (
+		props: {
+			item: Item;
+		} & ComponentProps< 'a' >
+	) => ReactElement;
 }
 
 /**
@@ -78,6 +92,8 @@ export function ReportRecordsTable< Item >( {
 	actions,
 	empty,
 	perPageSizes = DEFAULT_PER_PAGE_SIZES,
+	isItemClickable,
+	renderItemLink,
 }: ReportRecordsTableProps< Item > ) {
 	const [ view, setView ] = useState< View >(
 		() =>
@@ -114,6 +130,8 @@ export function ReportRecordsTable< Item >( {
 				empty={ empty }
 				searchLabel={ searchLabel }
 				config={ { perPageSizes } }
+				isItemClickable={ isItemClickable }
+				renderItemLink={ renderItemLink }
 			/>
 		</ReportPageSection>
 	);

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/stories/report-page.stories.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/stories/report-page.stories.module.scss
@@ -1,17 +1,5 @@
-.titleLink,
 .externalLink {
-	display: inline-flex;
-	align-items: center;
 	gap: var(--wpds-dimension-gap-xs);
-	max-width: 100%;
-	vertical-align: top;
-}
-
-.linkText {
-	min-width: 0;
-	overflow: hidden;
-	text-overflow: ellipsis;
-	white-space: nowrap;
 }
 
 .externalIcon {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/stories/report-page.stories.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/stories/report-page.stories.module.scss
@@ -1,0 +1,19 @@
+.titleLink,
+.externalLink {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--wpds-dimension-gap-xs);
+	max-width: 100%;
+	vertical-align: top;
+}
+
+.linkText {
+	min-width: 0;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.externalIcon {
+	flex-shrink: 0;
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/stories/report-page.stories.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/stories/report-page.stories.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { GlobalChartsProvider } from '@automattic/charts';
+import '@wordpress/dataviews/build-style/style.css';
 import { Button } from '@wordpress/components';
 import { Icon, external } from '@wordpress/icons';
 import { Text } from '@wordpress/ui';
@@ -108,33 +109,6 @@ const POST_FIELDS: Field< PostRow >[] = [
 		enableGlobalSearch: true,
 		enableHiding: false,
 		getValue: ( { item } ) => item.title,
-		render: ( { item } ) => {
-			if ( ! item.link ) {
-				return <>{ item.title }</>;
-			}
-
-			const title = <span className={ styles.linkText }>{ item.title }</span>;
-
-			if ( item.isExternal ) {
-				return (
-					<a
-						className={ styles.externalLink }
-						href={ item.link }
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						{ title }
-						<Icon className={ styles.externalIcon } icon={ external } size={ 16 } />
-					</a>
-				);
-			}
-
-			return (
-				<a className={ styles.titleLink } href={ item.link }>
-					{ title }
-				</a>
-			);
-		},
 	},
 	{
 		id: 'views',
@@ -220,8 +194,29 @@ function ComposedReportPage( { withComparison, isLoading }: ReportPageStoryContr
 				fields={ POST_FIELDS }
 				getItemId={ ( item: PostRow ) => item.id }
 				isLoading={ isLoading }
-				initialView={ { sort: { field: 'views', direction: 'desc' } } }
+				initialView={ {
+					sort: { field: 'views', direction: 'desc' },
+					titleField: 'title',
+					fields: [ 'views' ],
+				} }
 				searchLabel="Search posts"
+				isItemClickable={ ( item: PostRow ) => Boolean( item.link ) }
+				renderItemLink={ ( { item, className, children, ...linkProps } ) => (
+					<a
+						{ ...linkProps }
+						className={ [ className, item.isExternal ? styles.externalLink : '' ]
+							.filter( Boolean )
+							.join( ' ' ) }
+						href={ item.link }
+						target={ item.isExternal ? '_blank' : undefined }
+						rel={ item.isExternal ? 'noopener noreferrer' : undefined }
+					>
+						{ children }
+						{ item.isExternal ? (
+							<Icon className={ styles.externalIcon } icon={ external } size={ 16 } />
+						) : null }
+					</a>
+				) }
 			/>
 		</ReportPageLayout>
 	);

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/stories/report-page.stories.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/stories/report-page.stories.tsx
@@ -13,6 +13,7 @@ import { useChartTheme } from '../../../hooks';
 import { ReportPageLayout } from '../report-page-layout';
 import { ReportPerformanceChart } from '../report-performance-chart';
 import { ReportRecordsTable } from '../report-records-table';
+import styles from './report-page.stories.module.scss';
 import type { IntervalType, StatsTimeSeriesReport } from '@jetpack-premium-analytics/data';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
 import type { Field } from '@wordpress/dataviews';
@@ -112,16 +113,27 @@ const POST_FIELDS: Field< PostRow >[] = [
 				return <>{ item.title }</>;
 			}
 
+			const title = <span className={ styles.linkText }>{ item.title }</span>;
+
 			if ( item.isExternal ) {
 				return (
-					<a href={ item.link } target="_blank" rel="noopener noreferrer">
-						{ item.title }
-						<Icon icon={ external } size={ 16 } />
+					<a
+						className={ styles.externalLink }
+						href={ item.link }
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						{ title }
+						<Icon className={ styles.externalIcon } icon={ external } size={ 16 } />
 					</a>
 				);
 			}
 
-			return <a href={ item.link }>{ item.title }</a>;
+			return (
+				<a className={ styles.titleLink } href={ item.link }>
+					{ title }
+				</a>
+			);
 		},
 	},
 	{

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/stories/report-page.stories.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/stories/report-page.stories.tsx
@@ -3,6 +3,7 @@
  */
 import { GlobalChartsProvider } from '@automattic/charts';
 import { Button } from '@wordpress/components';
+import { Icon, external } from '@wordpress/icons';
 import { Text } from '@wordpress/ui';
 import { useState } from 'react';
 /**
@@ -73,12 +74,20 @@ const COMPARISON_REPORT = buildVisitsReport( 30, 0.8 );
 type PostRow = {
 	id: string;
 	title: string;
+	link?: string;
+	isExternal?: boolean;
 	views: number;
 };
 
 const POSTS: PostRow[] = [
-	{ id: '1', title: 'Hello world!', views: 172 },
-	{ id: '2', title: 'The Ultimate Guide to SEO in 2025', views: 127 },
+	{ id: '1', title: 'Hello world!', link: '#/post/1', views: 172 },
+	{
+		id: '2',
+		title: 'The Ultimate Guide to SEO in 2025',
+		link: 'https://example.com/seo-guide',
+		isExternal: true,
+		views: 127,
+	},
 	{ id: '3', title: '10 Tips for Better Product Photography', views: 97 },
 	{ id: '4', title: 'Why Remote Work Is Here to Stay', views: 74 },
 	{ id: '5', title: "A Beginner's Guide to Email Marketing", views: 55 },
@@ -98,6 +107,22 @@ const POST_FIELDS: Field< PostRow >[] = [
 		enableGlobalSearch: true,
 		enableHiding: false,
 		getValue: ( { item } ) => item.title,
+		render: ( { item } ) => {
+			if ( ! item.link ) {
+				return <>{ item.title }</>;
+			}
+
+			if ( item.isExternal ) {
+				return (
+					<a href={ item.link } target="_blank" rel="noopener noreferrer">
+						{ item.title }
+						<Icon icon={ external } size={ 16 } />
+					</a>
+				);
+			}
+
+			return <a href={ item.link }>{ item.title }</a>;
+		},
 	},
 	{
 		id: 'views',


### PR DESCRIPTION
Related to [WOOA7S-1621](https://linear.app/a8c/issue/WOOA7S-1621/page-insights-module-report-pages-dataviews) / the report-page framework (WOOA7S-1614).

## Why

Report tables currently mix two link treatments: internal titles (`@wordpress/route` `Link`) pick up wp-admin's default blue underlined anchors, while external cells built on the unstyled `@wordpress/ui` `Link` rest neutral with a hover underline. The report-table design specifies one treatment: rows rest as neutral text, and links take the interactive color and underline only on hover or keyboard focus.

## Proposed changes

Add a shared link treatment in `ReportRecordsTable`, scoped to DataViews table body anchors:

* At rest: neutral foreground, no underline.
* On `:hover` / `:focus-visible`: interactive brand color + underline.

The `ReportRecordsTable` wrapper now also passes through DataViews' primary-field link props so Storybook can exercise internal and external row links through DataViews' native `renderItemLink` path. This keeps the table's native title-field spacing, typography, row height, and borders intact while still covering the link states.

Because the visual treatment lives in the shared table component, every report — Posts & Pages, Videos, File downloads, Clicks, Comments Subscribers, and the in-flight Insights/Emails reports — gets the design treatment at once, and future reports inherit it for free.

## Does this pull request change what data or activity we track or use?

No. This only changes report table presentation and Storybook coverage.

## Testing instructions

* Build premium-analytics and open `/reports/posts` (or any report).
* Row title links rest as neutral text, indistinguishable from non-link rows at a glance; hovering (or tabbing to) a link turns it the admin theme color with an underline.
* External-link cells (e.g. the Posts report's homepage row) behave the same.
* In Storybook, open `Packages / Premium Analytics / Widgets Toolkit / Components / ReportPage / Default`.
* Confirm the first row renders as an internal link, the second row renders as an external link with an aligned external icon, and non-link rows keep the normal DataViews table styling.

### Screenshots
|Before|After|
|-|-|
|<img width="748" height="696" alt="截圖 2026-07-17 晚上9 32 53" src="https://github.com/user-attachments/assets/3c24290f-ba57-4bd0-9717-b40f2cfd820a" />|<img width="671" height="573" alt="截圖 2026-07-17 晚上9 37 28" src="https://github.com/user-attachments/assets/c5c31867-c3df-4b25-bfe6-4aa0b3db3ddf" />|