### PR TITLE
Premium Analytics: omit no-op comparison widget stories

### DIFF
--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -217,9 +217,9 @@ not be merged.
    shared `WidgetDashboardWithWidget` helper from `widgets/stories/widget-dashboard-with-widget.tsx`.
    It mounts the real `WidgetDashboard` with this single widget and exposes the standard
    dashboard controls (size, edit mode, host environment, etc.), so it shows how the widget
-   actually renders in product. The `Default` / `WithComparison` close-up stories use the
-   shared `withWidgetCanvas` decorator from the template below — but never ship _only_ a
-   close-up story.
+   actually renders in product. The `Default` and, when applicable, `WithComparison` close-up
+   stories use the shared `withWidgetCanvas` decorator from the template below — but never ship
+   _only_ a close-up story.
 3. **Mocks**: Call `registerReportMocks()` at module-level for any widget that fetches
    report data. Without this the widget renders an error state in Storybook.
    - **Woo analytics widgets** (`/proxy/v2/analytics/reports/*`) are covered out of the box.
@@ -236,18 +236,19 @@ not be merged.
 
 ### Story template
 
-Every widget ships three stories: a **Default** close-up, a **WithComparison** close-up, and a
-**WidgetDashboardWithWidget** story that mounts the real dashboard. This template is
-self-contained — copy it as the base rather than an existing widget's story file, which may
-have drifted. `meta.component` is the widget's render component; widget-specific args
-(comparison toggles, view selectors, …) are wired as Storybook controls.
+Every widget ships a **Default** close-up and a **WidgetDashboardWithWidget** story that mounts
+the real dashboard. Add a **WithComparison** close-up only when the widget's data hook returns
+`hasComparison` or `comparisonRows` and the render path consumes that value. This is the explicit
+criterion: accepting comparison query parameters or rendering unchanged when they are present
+does not by itself require the story. This template is self-contained — copy it as the base
+rather than an existing widget's story file, which may have drifted. `meta.component` is the
+widget's render component; widget-specific args (comparison toggles, view selectors, …) are wired
+as Storybook controls.
 
-`WithComparison` tests the date range picker's comparison parameters, not only visible delta
-UI. Some Stats endpoints accept `compare_*` params but return no comparison rows. Those widgets
-must still render gracefully when `reportParams` contains comparison dates; in that case the data
-hook should report that no comparable rows are available, and the chart's comparison UI should
-stay disabled or empty rather than inventing `previousValue`/`delta` values. Add a short story
-docs note when a module has no comparison data to display.
+`WithComparison` tests the date range picker's comparison parameters and the visible comparison
+UI. Widgets without mapped comparison rows omit the story and the `withComparison` control. Their
+`WidgetDashboardWithWidget` story should still pass comparison report params by default, so the
+widget is covered against crashing or inventing deltas when the host supplies comparison dates.
 
 The shared imports, helpers, and `meta`:
 
@@ -320,9 +321,9 @@ export const Default: Story = {
 };
 ```
 
-**2. `WithComparison`** — same close-up with comparison `reportParams` from the date range
-picker. Widgets with comparison data should show period-over-period values; widgets without
-comparison data should still render normally without fake deltas:
+**2. `WithComparison` (when the widget maps comparison rows)** — same close-up with comparison
+`reportParams` from the date range picker. It should show the period-over-period values consumed
+by the render path:
 
 ```tsx
 export const WithComparison: Story = {
@@ -366,6 +367,13 @@ export const WidgetDashboardWithWidget: StoryObj< MyWidgetDashboardStoryProps > 
 		withComparison: { control: 'boolean' },
 	},
 };
+```
+
+For a widget without mapped comparison rows, remove `withComparison` from the controls and omit
+the `WithComparison` export. Pass fixed comparison params in its dashboard story instead:
+
+```tsx
+attributes={ { reportParams: getDefaultQueryParams( true ) } }
 ```
 
 Expose additional widget-specific props (e.g. a `view: 'source' | 'channel' | 'campaign'`

--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -237,12 +237,14 @@ not be merged.
 ### Story template
 
 Every widget ships a **Default** close-up and a **WidgetDashboardWithWidget** story that mounts
-the real dashboard. Add a **WithComparison** close-up only when the widget's data hook returns
-`hasComparison` or `comparisonRows` and the render path consumes that value. This is the explicit
-criterion: accepting comparison query parameters or rendering unchanged when they are present
-does not by itself require the story. This template is self-contained — copy it as the base
-rather than an existing widget's story file, which may have drifted. `meta.component` is the
-widget's render component; widget-specific args (comparison toggles, view selectors, …) are wired
+the real dashboard. Add a **WithComparison** close-up only when the widget's data hook populates
+`comparisonRows` — in practice, when it passes `mergeComparisonRows` to `useStatsReport` (see
+`packages/data/src/hooks/use-stats-clicks.ts`). `rg -l mergeComparisonRows packages/data/src/hooks`
+lists the comparison-capable hooks; a widget whose hook is not in that list omits the story.
+`hasComparison` alone does not qualify — `useReport` returns it for any params carrying `compare_*`,
+whether or not the module has comparison data to show. This template is self-contained — copy it as
+the base rather than an existing widget's story file, which may have drifted. `meta.component` is
+the widget's render component; widget-specific args (view selectors, metric toggles, …) are wired
 as Storybook controls.
 
 `WithComparison` tests the date range picker's comparison parameters and the visible comparison
@@ -272,15 +274,8 @@ registerReportMocks();
 
 const MY_WIDGET_RENDER_MODULE = 'storybook/<widget-name>';
 
-// Widget-specific controls — add view selectors, metric toggles, etc. here.
-interface MyWidgetStoryControls {
-	withComparison: boolean;
-}
-
-function renderMyWidget( { withComparison }: MyWidgetStoryControls ) {
-	return (
-		<MyWidgetRender attributes={ { reportParams: getDefaultQueryParams( withComparison ) } } />
-	);
+function renderMyWidget() {
+	return <MyWidgetRender attributes={ { reportParams: getDefaultQueryParams() } } />;
 }
 
 // Close-up canvas: `withWidgetCanvas` from `widgets/stories/with-widget-canvas` frames the
@@ -291,9 +286,6 @@ const meta = {
 	title: 'Packages/Premium Analytics/Widgets/MyWidget',
 	component: MyWidgetRender,
 	tags: [ 'autodocs' ],
-	argTypes: {
-		withComparison: { control: 'boolean' },
-	},
 	parameters: {
 		docs: {
 			description: {
@@ -301,14 +293,13 @@ const meta = {
 			},
 		},
 	},
-	// The story args are the widget-specific controls, but `component` is the render
-	// component (host `WidgetRenderProps`). Intersect the two so `component` type-checks
-	// against the meta while the controls still drive `argTypes`/`args`.
-} satisfies Meta< ComponentProps< typeof MyWidgetRender > & MyWidgetStoryControls >;
+} satisfies Meta< typeof MyWidgetRender >;
 
 export default meta;
 
-type Story = StoryObj< MyWidgetStoryControls >;
+// Always parameterize the alias: bare `StoryObj` defaults to `Args = { [name: string]: any }`,
+// which silently accepts any `args` key and degrades `render`'s parameter to `{}`.
+type Story = StoryObj< typeof meta >;
 ```
 
 **1. `Default`** — the widget on its own, current period only:
@@ -316,16 +307,72 @@ type Story = StoryObj< MyWidgetStoryControls >;
 ```tsx
 export const Default: Story = {
 	render: renderMyWidget,
-	args: { withComparison: false },
 	decorators: [ withWidgetCanvas ],
 };
 ```
 
-**2. `WithComparison` (when the widget maps comparison rows)** — same close-up with comparison
-`reportParams` from the date range picker. It should show the period-over-period values consumed
-by the render path:
+**2. `WidgetDashboardWithWidget`** — mounts the real `WidgetDashboard` so the widget renders
+exactly as it does in product, inheriting the size / edit-mode / host-environment controls. It
+passes comparison params unconditionally, so the widget stays covered against crashing or
+inventing deltas when the host supplies comparison dates:
 
 ```tsx
+function MyWidgetDashboardStory( dashboardArgs: WidgetDashboardWithWidgetControls ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardArgs }
+			widgetType={ widgetDefinition }
+			renderModule={ MY_WIDGET_RENDER_MODULE }
+			renderComponent={ MyWidgetRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ { reportParams: getDefaultQueryParams( true ) } }
+		/>
+	);
+}
+
+export const WidgetDashboardWithWidget: StoryObj< WidgetDashboardWithWidgetControls > = {
+	render: args => <MyWidgetDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+	},
+};
+```
+
+**3. `WithComparison` — only when the widget's hook populates `comparisonRows`** (see the
+criterion above). Add a `withComparison` control, thread it through the render helper, and add
+the second close-up. It should show the period-over-period values the render path consumes:
+
+```tsx
+interface MyWidgetStoryControls {
+	withComparison: boolean;
+}
+
+function renderMyWidget( { withComparison }: MyWidgetStoryControls ) {
+	return (
+		<MyWidgetRender attributes={ { reportParams: getDefaultQueryParams( withComparison ) } } />
+	);
+}
+
+// The story args are the widget-specific controls, but `component` is the render component
+// (host `WidgetRenderProps`). Intersect the two so `component` type-checks against the meta
+// while the controls still drive `argTypes`/`args`.
+const meta = {
+	// …as above, plus:
+	argTypes: {
+		withComparison: { control: 'boolean' },
+	},
+} satisfies Meta< ComponentProps< typeof MyWidgetRender > & MyWidgetStoryControls >;
+
+type Story = StoryObj< MyWidgetStoryControls >;
+
+export const Default: Story = {
+	render: renderMyWidget,
+	args: { withComparison: false },
+	decorators: [ withWidgetCanvas ],
+};
+
 export const WithComparison: Story = {
 	render: renderMyWidget,
 	args: { withComparison: true },
@@ -333,53 +380,19 @@ export const WithComparison: Story = {
 };
 ```
 
-**3. `WidgetDashboardWithWidget`** — mounts the real `WidgetDashboard` so the widget renders
-exactly as it does in product, inheriting the size / edit-mode / host-environment controls:
-
-```tsx
-interface MyWidgetDashboardStoryProps
-	extends WidgetDashboardWithWidgetControls,
-		MyWidgetStoryControls {}
-
-function MyWidgetDashboardStory( {
-	withComparison,
-	...dashboardArgs
-}: MyWidgetDashboardStoryProps ) {
-	return (
-		<WidgetDashboardWithWidgetStory
-			{ ...dashboardArgs }
-			widgetType={ widgetDefinition }
-			renderModule={ MY_WIDGET_RENDER_MODULE }
-			renderComponent={ MyWidgetRender as ComponentType< WidgetRenderProps< unknown > > }
-			attributes={ { reportParams: getDefaultQueryParams( withComparison ) } }
-		/>
-	);
-}
-
-export const WidgetDashboardWithWidget: StoryObj< MyWidgetDashboardStoryProps > = {
-	render: args => <MyWidgetDashboardStory { ...args } />,
-	args: {
-		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
-		withComparison: true,
-	},
-	argTypes: {
-		...widgetDashboardWithWidgetArgTypes,
-		withComparison: { control: 'boolean' },
-	},
-};
-```
-
-For a widget without mapped comparison rows, remove `withComparison` from the controls and omit
-the `WithComparison` export. Pass fixed comparison params in its dashboard story instead:
-
-```tsx
-attributes={ { reportParams: getDefaultQueryParams( true ) } }
-```
-
 Expose additional widget-specific props (e.g. a `view: 'source' | 'channel' | 'campaign'`
-selector) as extra fields on the controls interface plus matching `args` and `argTypes`. The
-shared dashboard helper already provides container width / edit-mode / host-environment
-controls, so there's no need to add custom size decorators per widget.
+selector) as fields on a `MyWidgetStoryControls` interface plus matching `args` and `argTypes`,
+switching the alias to `StoryObj< MyWidgetStoryControls >` and the `meta` to the intersection
+form shown above. Where the dashboard story also needs those controls, have its props interface
+extend both: `interface MyWidgetDashboardStoryProps extends WidgetDashboardWithWidgetControls,
+MyWidgetStoryControls {}`. The shared dashboard helper already provides container width /
+edit-mode / host-environment controls, so there's no need to add custom size decorators per
+widget.
+
+Helpers that compose a story's `reportParams` (e.g. to add a `post_id` scope) should keep
+comparison as a parameter — `getMyWidgetAttributes( controls, withComparison = false )` — so the
+dashboard story can call them with `true` instead of rebuilding the params and duplicating the
+scoping rule.
 
 If a story exposes `withComparison`, both the close-up story and the dashboard story must pass
 `reportParams: getDefaultQueryParams( withComparison )` into the render component, and the render
@@ -390,9 +403,8 @@ Report mocks should exercise the shapes reviewers need to validate, not only the
 populated primary data for every widget; comparison data when the widget maps comparison rows;
 parent rows plus child rows for drill-down widgets; leaf rows with external links when a
 leaderboard can render non-drill-down links; and known unsupported/error responses when the
-module has a special failure mode. Prefer adding those shapes to the existing Default,
-WithComparison, or WidgetDashboardWithWidget stories over creating one-off state stories unless
-the state needs direct review.
+module has a special failure mode. Prefer adding those shapes to the widget's existing stories
+over creating one-off state stories unless the state needs direct review.
 
 To review a widget's loading / error / empty state directly, force it with
 `setReportMockState( '<endpoint>', 'loading' | 'error' | 'empty' )` in the story's `beforeEach`,

--- a/projects/packages/premium-analytics/changelog/wooa7s-1751
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1751
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Storybook: Omit comparison stories from widgets without comparison data.

--- a/projects/packages/premium-analytics/widgets/all-time-stats/stories/all-time-stats-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/all-time-stats/stories/all-time-stats-widget.stories.tsx
@@ -121,7 +121,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'The "All-time stats" widget. Shows lifetime totals for the site — views, visitors, posts, and comments — as a responsive grid of metric tiles, sourced from the Jetpack Stats site-summary endpoint. Which tiles appear is controlled by the `metrics` attribute (`relevance: \'high\'`), exposed inline in the widget header and in the settings drawer.',
+					'The "All-time stats" widget. Shows lifetime totals for the site — views, visitors, posts, and comments — as a responsive grid of metric tiles, sourced from the Jetpack Stats site-summary endpoint. Which tiles appear is controlled by the `metrics` attribute (`relevance: \'high\'`), exposed inline in the widget header and in the settings drawer. This module has no comparison period, so the values render as bare numbers.',
 			},
 		},
 	},

--- a/projects/packages/premium-analytics/widgets/all-time-stats/stories/all-time-stats-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/all-time-stats/stories/all-time-stats-widget.stories.tsx
@@ -2,10 +2,6 @@
  * The stories drive the data-connected All-time stats widget through the shared
  * report-mock harness, which serves the Stats site-summary endpoint
  * (`/proxy/v1.1/stats`) via `routeStatsReport()`.
- *
- * This module has no comparison period, so `Default` and `WithComparison`
- * render identically; the toggle only exercises the date-range picker's
- * comparison params flowing through `reportParams` without breaking the widget.
  */
 /**
  * External dependencies
@@ -57,10 +53,6 @@ const storyWidgetType = {
 
 interface AllTimeStatsStoryControls {
 	/**
-	 * Whether to include comparison report params.
-	 */
-	withComparison: boolean;
-	/**
 	 * Lifetime totals to show in the widget body.
 	 */
 	metrics: AllTimeStatsMetricId[];
@@ -84,12 +76,8 @@ const ALL_METRICS_ARGS = {
  * @param {AllTimeStatsStoryControls} props - The story controls.
  * @return The rendered widget.
  */
-function renderAllTimeStats( { withComparison, metrics }: AllTimeStatsStoryControls ) {
-	return (
-		<AllTimeStatsRender
-			attributes={ { reportParams: getDefaultQueryParams( withComparison ), metrics } }
-		/>
-	);
+function renderAllTimeStats( { metrics }: AllTimeStatsStoryControls ) {
+	return <AllTimeStatsRender attributes={ { reportParams: getDefaultQueryParams(), metrics } } />;
 }
 
 // Distinct preset → own query-cache entry; see forceStatsMockState.
@@ -127,14 +115,13 @@ const meta = {
 	component: AllTimeStatsRender,
 	tags: [ 'autodocs' ],
 	argTypes: {
-		withComparison: { control: 'boolean' },
 		...METRIC_ARG_TYPES,
 	},
 	parameters: {
 		docs: {
 			description: {
 				component:
-					'The "All-time stats" widget. Shows lifetime totals for the site — views, visitors, posts, and comments — as a responsive grid of metric tiles, sourced from the Jetpack Stats site-summary endpoint. Which tiles appear is controlled by the `metrics` attribute (`relevance: \'high\'`), exposed inline in the widget header and in the settings drawer. This module has no comparison period, so the values render as bare numbers and the `WithComparison` story looks identical to `Default`.',
+					'The "All-time stats" widget. Shows lifetime totals for the site — views, visitors, posts, and comments — as a responsive grid of metric tiles, sourced from the Jetpack Stats site-summary endpoint. Which tiles appear is controlled by the `metrics` attribute (`relevance: \'high\'`), exposed inline in the widget header and in the settings drawer.',
 			},
 		},
 	},
@@ -149,18 +136,7 @@ type Story = StoryObj< AllTimeStatsStoryControls >;
  */
 export const Default: Story = {
 	render: renderAllTimeStats,
-	args: { withComparison: false, ...ALL_METRICS_ARGS },
-	decorators: [ withWidgetCanvas ],
-};
-
-/**
- * Comparison params flow through `reportParams`, but the site summary has no
- * comparison data, so the widget renders identically to `Default` — no fake
- * deltas.
- */
-export const WithComparison: Story = {
-	render: renderAllTimeStats,
-	args: { withComparison: true, ...ALL_METRICS_ARGS },
+	args: { ...ALL_METRICS_ARGS },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -210,7 +186,6 @@ interface AllTimeStatsDashboardStoryProps
  * @return The widget mounted inside the real `WidgetDashboard`.
  */
 function AllTimeStatsDashboardStory( {
-	withComparison,
 	metrics,
 	...dashboardArgs
 }: AllTimeStatsDashboardStoryProps ) {
@@ -220,7 +195,7 @@ function AllTimeStatsDashboardStory( {
 			widgetType={ storyWidgetType }
 			renderModule={ ALL_TIME_STATS_RENDER_MODULE }
 			renderComponent={ AllTimeStatsRender as ComponentType< WidgetRenderProps< unknown > > }
-			attributes={ { reportParams: getDefaultQueryParams( withComparison ), metrics } }
+			attributes={ { reportParams: getDefaultQueryParams( true ), metrics } }
 		/>
 	);
 }
@@ -229,12 +204,10 @@ export const WidgetDashboardWithWidget: StoryObj< AllTimeStatsDashboardStoryProp
 	render: args => <AllTimeStatsDashboardStory { ...args } />,
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
-		withComparison: true,
 		...ALL_METRICS_ARGS,
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
-		withComparison: { control: 'boolean' },
 		...METRIC_ARG_TYPES,
 	},
 };

--- a/projects/packages/premium-analytics/widgets/annual-highlights/stories/annual-highlights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/annual-highlights/stories/annual-highlights-widget.stories.tsx
@@ -127,7 +127,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					"The \"Annual highlights\" widget. Shows one year's totals — posts, words, likes, and comments — as a grid of metric tiles, with year arrows to step through the years the site has published in. Which tiles appear is controlled by the `metrics` attribute (`relevance: 'high'`), exposed inline in the widget header and in the settings drawer. Data comes from the designated `useStatsInsights` hook; in Storybook it is served by `registerReportMocks()` (the `stats/insights` handler in `routeStatsReport`).",
+					"The \"Annual highlights\" widget. Shows one year's totals — posts, words, likes, and comments — as a grid of metric tiles, with year arrows to step through the years the site has published in. Which tiles appear is controlled by the `metrics` attribute (`relevance: 'high'`), exposed inline in the widget header and in the settings drawer. Data comes from the designated `useStatsInsights` hook; in Storybook it is served by `registerReportMocks()` (the `stats/insights` handler in `routeStatsReport`). The insights module has no comparison period, so the tiles show bare counts.",
 			},
 		},
 	},

--- a/projects/packages/premium-analytics/widgets/annual-highlights/stories/annual-highlights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/annual-highlights/stories/annual-highlights-widget.stories.tsx
@@ -45,30 +45,22 @@ const storyWidgetType = {
 
 interface AnnualHighlightsStoryControls {
 	/**
-	 * Whether to inject comparison report params.
-	 */
-	withComparison: boolean;
-	/**
 	 * Metric tiles to show in the widget body.
 	 */
 	metrics: AnnualHighlightMetric[];
 }
 
 /**
- * Renders the data-connected widget with report params derived from the
- * comparison toggle and the selected metrics. The insights endpoint is not
- * period-scoped, so toggling comparison does not change what the widget shows
- * — it is wired through only to prove the widget renders unchanged when the
- * host injects comparison params.
+ * Renders the data-connected widget with the selected metrics.
  *
  * @param {AnnualHighlightsStoryControls} props - Story controls.
  * @return The rendered widget.
  */
-function renderAnnualHighlights( { withComparison, metrics }: AnnualHighlightsStoryControls ) {
+function renderAnnualHighlights( { metrics }: AnnualHighlightsStoryControls ) {
 	return (
 		<AnnualHighlightsRender
 			attributes={ {
-				reportParams: getDefaultQueryParams( withComparison ),
+				reportParams: getDefaultQueryParams(),
 				metrics,
 			} }
 		/>
@@ -129,14 +121,13 @@ const meta = {
 	component: AnnualHighlightsRender,
 	tags: [ 'autodocs' ],
 	argTypes: {
-		withComparison: { control: 'boolean' },
 		...METRIC_ARG_TYPES,
 	},
 	parameters: {
 		docs: {
 			description: {
 				component:
-					"The \"Annual highlights\" widget. Shows one year's totals — posts, words, likes, and comments — as a grid of metric tiles, with year arrows to step through the years the site has published in. Which tiles appear is controlled by the `metrics` attribute (`relevance: 'high'`), exposed inline in the widget header and in the settings drawer. Data comes from the designated `useStatsInsights` hook; in Storybook it is served by `registerReportMocks()` (the `stats/insights` handler in `routeStatsReport`). The insights module has no comparison period, so the tiles show bare counts and the `WithComparison` story renders identically to `Default`.",
+					"The \"Annual highlights\" widget. Shows one year's totals — posts, words, likes, and comments — as a grid of metric tiles, with year arrows to step through the years the site has published in. Which tiles appear is controlled by the `metrics` attribute (`relevance: 'high'`), exposed inline in the widget header and in the settings drawer. Data comes from the designated `useStatsInsights` hook; in Storybook it is served by `registerReportMocks()` (the `stats/insights` handler in `routeStatsReport`).",
 			},
 		},
 	},
@@ -151,18 +142,7 @@ type Story = StoryObj< AnnualHighlightsStoryControls >;
  */
 export const Default: Story = {
 	render: renderAnnualHighlights,
-	args: { withComparison: false, ...ALL_METRICS_ARGS },
-	decorators: [ withWidgetCanvas ],
-};
-
-/**
- * Same close-up with comparison report params injected. The insights module has
- * no comparison data, so this renders identically to `Default` — it only
- * verifies the widget stays stable when the host provides comparison params.
- */
-export const WithComparison: Story = {
-	render: renderAnnualHighlights,
-	args: { withComparison: true, ...ALL_METRICS_ARGS },
+	args: { ...ALL_METRICS_ARGS },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -211,7 +191,6 @@ interface AnnualHighlightsDashboardStoryProps
  * @return The rendered dashboard with the widget.
  */
 function AnnualHighlightsDashboardStory( {
-	withComparison,
 	metrics,
 	...dashboardArgs
 }: AnnualHighlightsDashboardStoryProps ) {
@@ -222,7 +201,7 @@ function AnnualHighlightsDashboardStory( {
 			renderModule={ ANNUAL_HIGHLIGHTS_RENDER_MODULE }
 			renderComponent={ AnnualHighlightsRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ {
-				reportParams: getDefaultQueryParams( withComparison ),
+				reportParams: getDefaultQueryParams( true ),
 				metrics,
 			} }
 		/>
@@ -235,12 +214,10 @@ export const WidgetDashboardWithWidget: StoryObj< AnnualHighlightsDashboardStory
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 		widgetWidth: 1,
 		widgetHeight: 1,
-		withComparison: true,
 		...ALL_METRICS_ARGS,
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
-		withComparison: { control: 'boolean' },
 		...METRIC_ARG_TYPES,
 	},
 };

--- a/projects/packages/premium-analytics/widgets/comments/stories/comments-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/comments/stories/comments-widget.stories.tsx
@@ -37,19 +37,14 @@ const VIEW_CONTROL = {
 };
 
 interface CommentsStoryControls {
-	withComparison: boolean;
 	view: CommentsView;
 }
 
-function renderComments( { withComparison, view }: CommentsStoryControls ) {
+function renderComments( { view }: CommentsStoryControls ) {
 	// The close-up story renders the bare widget without the host chrome, so the
 	// "View by" control isn't shown here; the `view` control drives the rendered
 	// view directly through the (host-owned) `view` attribute.
-	return (
-		<CommentsRender
-			attributes={ { view, reportParams: getDefaultQueryParams( withComparison ) } }
-		/>
-	);
+	return <CommentsRender attributes={ { view, reportParams: getDefaultQueryParams() } } />;
 }
 
 function CommentsDashboardRender( props: WidgetRenderProps< unknown > ) {
@@ -99,7 +94,6 @@ const meta = {
 	component: CommentsRender,
 	tags: [ 'autodocs' ],
 	argTypes: {
-		withComparison: { control: 'boolean' },
 		view: VIEW_CONTROL,
 	},
 	parameters: {
@@ -118,27 +112,8 @@ type Story = StoryObj< CommentsStoryControls >;
 
 export const Default: Story = {
 	render: renderComments,
-	args: { withComparison: false, view: 'authors' },
+	args: { view: 'authors' },
 	decorators: [ withWidgetCanvas ],
-};
-
-/**
- * The Comments endpoint is all-time and returns no comparison rows, so enabling
- * the date-range picker's comparison parameters renders the widget identically
- * to `Default` — no period-over-period deltas are shown.
- */
-export const WithComparison: Story = {
-	render: renderComments,
-	args: { withComparison: true, view: 'authors' },
-	decorators: [ withWidgetCanvas ],
-	parameters: {
-		docs: {
-			description: {
-				story:
-					'The Stats Comments module has no comparison data, so this renders the same as Default without fabricated deltas.',
-			},
-		},
-	},
 };
 
 /**
@@ -147,7 +122,7 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: renderComments,
-	args: { withComparison: false, view: 'authors' },
+	args: { view: 'authors' },
 	// Kept off the shared autodocs page: the mock override is keyed by path, so it
 	// would otherwise force the sibling stories on that page into the same state.
 	tags: [ '!autodocs' ],
@@ -161,7 +136,7 @@ export const Loading: Story = {
  */
 export const ErrorState: Story = {
 	render: renderComments,
-	args: { withComparison: false, view: 'authors' },
+	args: { view: 'authors' },
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: forceCommentsState( 'error' ),
@@ -173,7 +148,7 @@ export const ErrorState: Story = {
  */
 export const Empty: Story = {
 	render: renderComments,
-	args: { withComparison: false, view: 'authors' },
+	args: { view: 'authors' },
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: forceCommentsState( 'empty' ),
@@ -183,18 +158,14 @@ interface CommentsDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		CommentsStoryControls {}
 
-function CommentsDashboardStory( {
-	withComparison,
-	view,
-	...dashboardArgs
-}: CommentsDashboardStoryProps ) {
+function CommentsDashboardStory( { view, ...dashboardArgs }: CommentsDashboardStoryProps ) {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
 			widgetType={ storyWidgetType }
 			renderModule={ COMMENTS_RENDER_MODULE }
 			renderComponent={ CommentsDashboardRender as ComponentType< WidgetRenderProps< unknown > > }
-			attributes={ { view, reportParams: getDefaultQueryParams( withComparison ) } }
+			attributes={ { view, reportParams: getDefaultQueryParams( true ) } }
 		/>
 	);
 }
@@ -203,12 +174,10 @@ export const WidgetDashboardWithWidget: StoryObj< CommentsDashboardStoryProps > 
 	render: args => <CommentsDashboardStory { ...args } />,
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
-		withComparison: true,
 		view: 'authors',
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
-		withComparison: { control: 'boolean' },
 		view: VIEW_CONTROL,
 	},
 };

--- a/projects/packages/premium-analytics/widgets/email-breakdown/stories/email-breakdown-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/stories/email-breakdown-widget.stories.tsx
@@ -6,10 +6,7 @@
  * `WidgetDashboardWithWidget` mounts the real dashboard so it renders exactly
  * as it does in product.
  *
- * The breakdown is scoped to a single email via a mocked `reportParams.post_id`. These
- * endpoints report over the whole lifetime of the email and return no comparison period, so
- * the `WithComparison` story still renders without deltas — it only verifies the
- * widget stays graceful when the date picker injects comparison `reportParams`.
+ * The breakdown is scoped to a single email via a mocked `reportParams.post_id`.
  */
 /**
  * External dependencies
@@ -65,26 +62,20 @@ const METRIC_OPTIONS: EmailBreakdownMetric[] =
 	attributeElementValues< EmailBreakdownMetric >( 'metric' );
 
 /**
- * Widget-specific controls: the comparison toggle, the breakdown view, and the
- * opens/clicks metric for the dimension views.
+ * Widget-specific controls: the breakdown view and opens/clicks metric for the
+ * dimension views.
  */
 interface EmailBreakdownStoryControls {
-	withComparison: boolean;
 	view: EmailBreakdownView;
 	metric: EmailBreakdownMetric;
 	showMap: boolean;
 }
 
-function renderEmailBreakdown( {
-	withComparison,
-	view,
-	metric,
-	showMap,
-}: EmailBreakdownStoryControls ) {
+function renderEmailBreakdown( { view, metric, showMap }: EmailBreakdownStoryControls ) {
 	return (
 		<EmailBreakdownRender
 			attributes={ {
-				reportParams: { ...getDefaultQueryParams( withComparison ), post_id: MOCK_EMAIL_ID },
+				reportParams: { ...getDefaultQueryParams(), post_id: MOCK_EMAIL_ID },
 				view,
 				metric,
 				showMap,
@@ -115,7 +106,6 @@ const meta = {
 	component: EmailBreakdownRender,
 	tags: [ 'autodocs' ],
 	argTypes: {
-		withComparison: { control: 'boolean' },
 		view: { control: 'select', options: VIEW_OPTIONS },
 		metric: { control: 'select', options: METRIC_OPTIONS },
 		showMap: { control: 'boolean' },
@@ -124,7 +114,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'The "Email breakdown" widget. Breaks a single sent email down by countries, devices, email clients, or clicked links, rendered as a leaderboard. The `view` attribute (`relevance: \'high\'`) is exposed as a control by the widget host; the `metric` attribute picks the opens or clicks breakdown for the dimension views, while `links` always reads the clicks breakdown (merging internal link types with clicked user-content links, like the Calypso links module). Scoped to one email via a mocked `reportParams.post_id`. These endpoints have no comparison period, so the widget renders without deltas even when the date picker injects comparison params.',
+					'The "Email breakdown" widget. Breaks a single sent email down by countries, devices, email clients, or clicked links, rendered as a leaderboard. The `view` attribute (`relevance: \'high\'`) is exposed as a control by the widget host; the `metric` attribute picks the opens or clicks breakdown for the dimension views, while `links` always reads the clicks breakdown (merging internal link types with clicked user-content links, like the Calypso links module). Scoped to one email via a mocked `reportParams.post_id`.',
 			},
 		},
 	},
@@ -140,7 +130,7 @@ type Story = StoryObj< EmailBreakdownStoryControls >;
  */
 export const Default: Story = {
 	render: renderEmailBreakdown,
-	args: { withComparison: false, view: 'countries', metric: 'opens', showMap: false },
+	args: { view: 'countries', metric: 'opens', showMap: false },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -149,17 +139,7 @@ export const Default: Story = {
  */
 export const LocationClicksWithMap: Story = {
 	render: renderEmailBreakdown,
-	args: { withComparison: false, view: 'countries', metric: 'clicks', showMap: true },
-	decorators: [ withWidgetCanvas ],
-};
-
-/**
- * Comparison `reportParams` from the date picker. The breakdown endpoints return
- * no comparison rows, so the widget renders normally without deltas.
- */
-export const WithComparison: Story = {
-	render: renderEmailBreakdown,
-	args: { withComparison: true, view: 'countries', metric: 'opens', showMap: false },
+	args: { view: 'countries', metric: 'clicks', showMap: true },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -224,7 +204,6 @@ interface EmailBreakdownDashboardStoryProps
 		EmailBreakdownStoryControls {}
 
 function EmailBreakdownDashboardStory( {
-	withComparison,
 	view,
 	metric,
 	showMap,
@@ -237,7 +216,7 @@ function EmailBreakdownDashboardStory( {
 			renderModule={ EMAIL_BREAKDOWN_RENDER_MODULE }
 			renderComponent={ EmailBreakdownRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ {
-				reportParams: { ...getDefaultQueryParams( withComparison ), post_id: MOCK_EMAIL_ID },
+				reportParams: { ...getDefaultQueryParams( true ), post_id: MOCK_EMAIL_ID },
 				view,
 				metric,
 				showMap,
@@ -250,14 +229,12 @@ export const WidgetDashboardWithWidget: StoryObj< EmailBreakdownDashboardStoryPr
 	render: args => <EmailBreakdownDashboardStory { ...args } />,
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
-		withComparison: true,
 		view: 'countries',
 		metric: 'opens',
 		showMap: false,
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
-		withComparison: { control: 'boolean' },
 		view: { control: 'select', options: VIEW_OPTIONS },
 		metric: { control: 'select', options: METRIC_OPTIONS },
 		showMap: { control: 'boolean' },

--- a/projects/packages/premium-analytics/widgets/email-breakdown/stories/email-breakdown-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/stories/email-breakdown-widget.stories.tsx
@@ -114,7 +114,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'The "Email breakdown" widget. Breaks a single sent email down by countries, devices, email clients, or clicked links, rendered as a leaderboard. The `view` attribute (`relevance: \'high\'`) is exposed as a control by the widget host; the `metric` attribute picks the opens or clicks breakdown for the dimension views, while `links` always reads the clicks breakdown (merging internal link types with clicked user-content links, like the Calypso links module). Scoped to one email via a mocked `reportParams.post_id`.',
+					'The "Email breakdown" widget. Breaks a single sent email down by countries, devices, email clients, or clicked links, rendered as a leaderboard. The `view` attribute (`relevance: \'high\'`) is exposed as a control by the widget host; the `metric` attribute picks the opens or clicks breakdown for the dimension views, while `links` always reads the clicks breakdown (merging internal link types with clicked user-content links, like the Calypso links module). Scoped to one email via a mocked `reportParams.post_id`. The email breakdown endpoints have no comparison period, so the widget renders without deltas.',
 			},
 		},
 	},

--- a/projects/packages/premium-analytics/widgets/email-top-row/stories/email-top-row-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-top-row/stories/email-top-row-widget.stories.tsx
@@ -5,10 +5,7 @@
  * widget.
  *
  * The widget is scoped to a single email by the host through
- * `reportParams.post_id` and to one view by the `metric` attribute (Opens or
- * Clicks). The rate breakdown is all-time and returns no comparison rows, so the
- * `WithComparison` story renders identically to `Default` — there is no
- * period-over-period data and no deltas are shown.
+ * `reportParams.post_id` and to one view by the `metric` attribute (Opens or Clicks).
  *
  * The Loading / Error / Empty stories force the mock into that state with
  * `setReportMockState`; each uses a distinct `post_id` so its request has its own
@@ -48,18 +45,14 @@ const OPENS_MOCK_FRAGMENT = 'stats/opens/emails';
 
 interface EmailTopRowStoryControls {
 	metric: EmailMetric;
-	withComparison: boolean;
 }
 
-function renderEmailTopRow(
-	{ metric, withComparison }: EmailTopRowStoryControls,
-	postId: number = MOCK_POST_ID
-) {
+function renderEmailTopRow( { metric }: EmailTopRowStoryControls, postId: number = MOCK_POST_ID ) {
 	return (
 		<EmailTopRowRender
 			attributes={ {
 				metric,
-				reportParams: { ...getDefaultQueryParams( withComparison ), post_id: postId },
+				reportParams: { ...getDefaultQueryParams(), post_id: postId },
 			} }
 		/>
 	);
@@ -74,7 +67,6 @@ const meta = {
 			control: 'inline-radio',
 			options: [ 'opens', 'clicks' ],
 		},
-		withComparison: { control: 'boolean' },
 	},
 	parameters: {
 		docs: {
@@ -95,7 +87,7 @@ type Story = StoryObj< EmailTopRowStoryControls >;
  */
 export const Default: Story = {
 	render: args => renderEmailTopRow( args ),
-	args: { metric: 'opens', withComparison: false },
+	args: { metric: 'opens' },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -105,18 +97,7 @@ export const Default: Story = {
  */
 export const ClicksView: Story = {
 	render: args => renderEmailTopRow( args ),
-	args: { metric: 'clicks', withComparison: false },
-	decorators: [ withWidgetCanvas ],
-};
-
-/**
- * With comparison `reportParams` from the date range picker. The rate breakdown
- * has no comparison data, so the widget renders the same tiles with no deltas
- * rather than inventing period-over-period values.
- */
-export const WithComparison: Story = {
-	render: args => renderEmailTopRow( args ),
-	args: { metric: 'opens', withComparison: true },
+	args: { metric: 'clicks' },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -127,7 +108,7 @@ export const Loading: Story = {
 	render: args => renderEmailTopRow( args, 2001 ),
 	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
-	args: { metric: 'opens', withComparison: false },
+	args: { metric: 'opens' },
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {
 		setReportMockState( OPENS_MOCK_FRAGMENT, 'loading' );
@@ -142,7 +123,7 @@ export const Loading: Story = {
 export const Error: Story = {
 	render: args => renderEmailTopRow( args, 2002 ),
 	tags: [ '!autodocs' ],
-	args: { metric: 'opens', withComparison: false },
+	args: { metric: 'opens' },
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {
 		setReportMockState( OPENS_MOCK_FRAGMENT, 'error' );
@@ -157,7 +138,7 @@ export const Error: Story = {
 export const Empty: Story = {
 	render: args => renderEmailTopRow( args, 2003 ),
 	tags: [ '!autodocs' ],
-	args: { metric: 'opens', withComparison: false },
+	args: { metric: 'opens' },
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {
 		setReportMockState( OPENS_MOCK_FRAGMENT, 'empty' );
@@ -170,12 +151,10 @@ export const Empty: Story = {
  * fetching. This is how the widget renders on a report page before a row is chosen.
  */
 export const NoEmailSelected: Story = {
-	render: ( { metric, withComparison }: EmailTopRowStoryControls ) => (
-		<EmailTopRowRender
-			attributes={ { metric, reportParams: getDefaultQueryParams( withComparison ) } }
-		/>
+	render: ( { metric }: EmailTopRowStoryControls ) => (
+		<EmailTopRowRender attributes={ { metric, reportParams: getDefaultQueryParams() } } />
 	),
-	args: { metric: 'opens', withComparison: false },
+	args: { metric: 'opens' },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -183,11 +162,7 @@ interface EmailTopRowDashboardStoryProps
 	extends WidgetDashboardWithWidgetControls,
 		EmailTopRowStoryControls {}
 
-function EmailTopRowDashboardStory( {
-	metric,
-	withComparison,
-	...dashboardArgs
-}: EmailTopRowDashboardStoryProps ) {
+function EmailTopRowDashboardStory( { metric, ...dashboardArgs }: EmailTopRowDashboardStoryProps ) {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
@@ -196,7 +171,7 @@ function EmailTopRowDashboardStory( {
 			renderComponent={ EmailTopRowRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ {
 				metric,
-				reportParams: { ...getDefaultQueryParams( withComparison ), post_id: MOCK_POST_ID },
+				reportParams: { ...getDefaultQueryParams( true ), post_id: MOCK_POST_ID },
 			} }
 		/>
 	);
@@ -207,7 +182,6 @@ export const WidgetDashboardWithWidget: StoryObj< EmailTopRowDashboardStoryProps
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 		metric: 'opens',
-		withComparison: true,
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
@@ -215,6 +189,5 @@ export const WidgetDashboardWithWidget: StoryObj< EmailTopRowDashboardStoryProps
 			control: 'inline-radio',
 			options: [ 'opens', 'clicks' ],
 		},
-		withComparison: { control: 'boolean' },
 	},
 };

--- a/projects/packages/premium-analytics/widgets/latest-post/stories/latest-post-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/latest-post/stories/latest-post-widget.stories.tsx
@@ -31,7 +31,7 @@ import widgetDefinition from '../widget';
 import type { APIFetchMiddleware, APIFetchOptions } from '@wordpress/api-fetch';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
-import type { ComponentType } from 'react';
+import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
 
@@ -162,7 +162,7 @@ const meta = {
 
 export default meta;
 
-type Story = StoryObj;
+type Story = StoryObj< Partial< ComponentProps< typeof LatestPostRender > > >;
 
 /**
  * Default — the latest post with its lifetime views, likes, and comments.

--- a/projects/packages/premium-analytics/widgets/latest-post/stories/latest-post-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/latest-post/stories/latest-post-widget.stories.tsx
@@ -1,8 +1,4 @@
 /**
- * The Latest post widget reports lifetime totals, so it has no comparison
- * period: the `WithComparison` story passes comparison `reportParams` but
- * renders identically to `Default`.
- *
  * The widget reads its content locally from the core `/wp/v2/posts` endpoint and
  * its metrics (views, likes, comments) from the proxied `stats/post` endpoint,
  * both covered here by an `apiFetch` middleware that runs before the shared
@@ -35,7 +31,7 @@ import widgetDefinition from '../widget';
 import type { APIFetchMiddleware, APIFetchOptions } from '@wordpress/api-fetch';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
-import type { ComponentProps, ComponentType } from 'react';
+import type { ComponentType } from 'react';
 
 registerReportMocks();
 
@@ -97,21 +93,13 @@ registerLatestPostMocks();
 
 const LATEST_POST_RENDER_MODULE = 'storybook/latest-post';
 
-interface LatestPostStoryControls {
-	withComparison: boolean;
-}
-
 /**
  * Renders the data-connected widget with report params from the date range
  * picker.
- *
- * @param {LatestPostStoryControls} controls - The story controls.
  * @return The rendered widget.
  */
-function renderLatestPost( { withComparison }: LatestPostStoryControls ) {
-	return (
-		<LatestPostRender attributes={ { reportParams: getDefaultQueryParams( withComparison ) } } />
-	);
+function renderLatestPost() {
+	return <LatestPostRender attributes={ { reportParams: getDefaultQueryParams() } } />;
 }
 
 // Distinct preset → own query-cache entry; see forceStatsMockState.
@@ -162,40 +150,25 @@ const meta = {
 	title: 'Packages/Premium Analytics/Widgets/LatestPost',
 	component: LatestPostRender,
 	tags: [ 'autodocs' ],
-	argTypes: {
-		withComparison: { control: 'boolean' },
-	},
 	parameters: {
 		docs: {
 			description: {
 				component:
-					'The "Latest post" widget shows the site\'s most recently published post with its all-time views, likes, and comments. The metrics are lifetime totals, so there is no comparison period — the `WithComparison` story renders identically to `Default`.',
+					'The "Latest post" widget shows the site\'s most recently published post with its all-time views, likes, and comments.',
 			},
 		},
 	},
-} satisfies Meta< ComponentProps< typeof LatestPostRender > & LatestPostStoryControls >;
+} satisfies Meta< typeof LatestPostRender >;
 
 export default meta;
 
-type Story = StoryObj< LatestPostStoryControls >;
+type Story = StoryObj;
 
 /**
  * Default — the latest post with its lifetime views, likes, and comments.
  */
 export const Default: Story = {
 	render: renderLatestPost,
-	args: { withComparison: false },
-	decorators: [ withWidgetCanvas ],
-};
-
-/**
- * WithComparison — comparison `reportParams` are supplied by the date range
- * picker, but this module has no comparison data, so the widget renders
- * identically to `Default` (no deltas).
- */
-export const WithComparison: Story = {
-	render: renderLatestPost,
-	args: { withComparison: true },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -234,43 +207,34 @@ export const Empty: Story = {
 	beforeEach: () => forceLatestPostState( 'empty' ),
 };
 
-interface LatestPostDashboardStoryProps
-	extends WidgetDashboardWithWidgetControls,
-		LatestPostStoryControls {}
-
 /**
  * Mounts the real `WidgetDashboard` with this single widget so it renders
  * exactly as it does in product (framed card, sizing, edit mode).
  *
- * @param {LatestPostDashboardStoryProps} props - The dashboard story controls.
+ * @param {WidgetDashboardWithWidgetControls} dashboardArgs - The dashboard story controls.
  * @return The widget mounted inside the real dashboard.
  */
-function LatestPostDashboardStory( {
-	withComparison,
-	...dashboardArgs
-}: LatestPostDashboardStoryProps ) {
+function LatestPostDashboardStory( dashboardArgs: WidgetDashboardWithWidgetControls ) {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
 			widgetType={ { ...widgetDefinition, presentation: 'framed' } }
 			renderModule={ LATEST_POST_RENDER_MODULE }
 			renderComponent={ LatestPostRender as ComponentType< WidgetRenderProps< unknown > > }
-			attributes={ { reportParams: getDefaultQueryParams( withComparison ) } }
+			attributes={ { reportParams: getDefaultQueryParams( true ) } }
 		/>
 	);
 }
 
-export const WidgetDashboardWithWidget: StoryObj< LatestPostDashboardStoryProps > = {
+export const WidgetDashboardWithWidget: StoryObj< WidgetDashboardWithWidgetControls > = {
 	render: args => <LatestPostDashboardStory { ...args } />,
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 		// Latest post is a landscape widget: content left, featured image right.
 		widgetWidth: 2,
 		widgetHeight: 2,
-		withComparison: true,
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
-		withComparison: { control: 'boolean' },
 	},
 };

--- a/projects/packages/premium-analytics/widgets/most-popular-day/stories/most-popular-day-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/stories/most-popular-day-widget.stories.tsx
@@ -2,10 +2,7 @@
  * The stories render the data-connected widget fed by the shared
  * report-mock harness. `registerReportMocks` routes the `stats/` site summary
  * (`/proxy/v1.1/stats`) — including the `views_best_day*` fields this widget
- * reads — through `routeStatsReport()`, so no story-scoped middleware is
- * needed. The all-time "most popular day" highlight has no comparison period
- * and ignores the dashboard date range, so `WithComparison` renders identically
- * to `Default`.
+ * reads — through `routeStatsReport()`, so no story-scoped middleware is needed.
  */
 /**
  * External dependencies
@@ -29,7 +26,7 @@ import MostPopularDayRender from '../render';
 import widgetDefinition from '../widget';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
-import type { ComponentProps, ComponentType } from 'react';
+import type { ComponentType } from 'react';
 
 registerReportMocks();
 
@@ -62,61 +59,37 @@ function forceSiteSummaryState( state: 'loading' | 'error' | 'empty' ) {
 	};
 }
 
-interface MostPopularDayStoryControls {
-	withComparison: boolean;
-}
-
 /**
  * Renders the data-connected widget for the close-up stories.
- *
- * @param {MostPopularDayStoryControls} props - The story controls.
  * @return The rendered widget.
  */
-function renderMostPopularDay( { withComparison }: MostPopularDayStoryControls ) {
-	return (
-		<MostPopularDayRender
-			attributes={ { reportParams: getDefaultQueryParams( withComparison ) } }
-		/>
-	);
+function renderMostPopularDay() {
+	return <MostPopularDayRender attributes={ { reportParams: getDefaultQueryParams() } } />;
 }
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/MostPopularDay',
 	component: MostPopularDayRender,
 	tags: [ 'autodocs' ],
-	argTypes: {
-		withComparison: { control: 'boolean' },
-	},
 	parameters: {
 		docs: {
 			description: {
 				component:
-					'The "Most popular day" widget ports the Jetpack Stats all-time highlight: the single day your site drew the most views, with that day\'s view count and its share of all views. The value comes from a site-wide summary that has no comparison period and does not depend on the dashboard date range, so `WithComparison` renders identically to `Default`.',
+					'The "Most popular day" widget ports the Jetpack Stats all-time highlight: the single day your site drew the most views, with that day\'s view count and its share of all views. The value comes from a site-wide summary that does not depend on the dashboard date range.',
 			},
 		},
 	},
-} satisfies Meta< ComponentProps< typeof MostPopularDayRender > & MostPopularDayStoryControls >;
+} satisfies Meta< typeof MostPopularDayRender >;
 
 export default meta;
 
-type Story = StoryObj< MostPopularDayStoryControls >;
+type Story = StoryObj;
 
 /**
  * Default state — the best day for views and its share of all views.
  */
 export const Default: Story = {
 	render: renderMostPopularDay,
-	args: { withComparison: false },
-	decorators: [ withWidgetCanvas ],
-};
-
-/**
- * Comparison params from the date-range picker are passed through, but the
- * highlight has no comparison data, so the widget renders the same single value.
- */
-export const WithComparison: Story = {
-	render: renderMostPopularDay,
-	args: { withComparison: true },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -125,7 +98,7 @@ export const WithComparison: Story = {
  * mock is forced to never resolve for the duration of this story.
  */
 export const Loading: Story = {
-	render: () => renderMostPopularDay( { withComparison: false } ),
+	render: renderMostPopularDay,
 	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
@@ -137,7 +110,7 @@ export const Loading: Story = {
  * re-runs the query — still mocked as failing while this story is active).
  */
 export const Error: Story = {
-	render: () => renderMostPopularDay( { withComparison: false } ),
+	render: renderMostPopularDay,
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => forceSiteSummaryState( 'error' ),
@@ -148,46 +121,37 @@ export const Error: Story = {
  * (the neutral calendar glyph and the "not enough views" message).
  */
 export const Empty: Story = {
-	render: () => renderMostPopularDay( { withComparison: false } ),
+	render: renderMostPopularDay,
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => forceSiteSummaryState( 'empty' ),
 };
 
-interface MostPopularDayDashboardStoryProps
-	extends WidgetDashboardWithWidgetControls,
-		MostPopularDayStoryControls {}
-
 /**
  * Renders the data-connected widget through the shared dashboard harness, so it
  * appears exactly as it does in product (framed card, sizing, edit mode).
  *
- * @param {MostPopularDayDashboardStoryProps} props - The dashboard story controls.
+ * @param {WidgetDashboardWithWidgetControls} dashboardArgs - The dashboard story controls.
  * @return The widget mounted inside the real `WidgetDashboard`.
  */
-function MostPopularDayDashboardStory( {
-	withComparison,
-	...dashboardArgs
-}: MostPopularDayDashboardStoryProps ) {
+function MostPopularDayDashboardStory( dashboardArgs: WidgetDashboardWithWidgetControls ) {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
 			widgetType={ widgetDefinition }
 			renderModule={ MOST_POPULAR_DAY_RENDER_MODULE }
 			renderComponent={ MostPopularDayRender as ComponentType< WidgetRenderProps< unknown > > }
-			attributes={ { reportParams: getDefaultQueryParams( withComparison ) } }
+			attributes={ { reportParams: getDefaultQueryParams( true ) } }
 		/>
 	);
 }
 
-export const WidgetDashboardWithWidget: StoryObj< MostPopularDayDashboardStoryProps > = {
+export const WidgetDashboardWithWidget: StoryObj< WidgetDashboardWithWidgetControls > = {
 	render: args => <MostPopularDayDashboardStory { ...args } />,
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
-		withComparison: true,
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
-		withComparison: { control: 'boolean' },
 	},
 };

--- a/projects/packages/premium-analytics/widgets/most-popular-day/stories/most-popular-day-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/stories/most-popular-day-widget.stories.tsx
@@ -26,7 +26,7 @@ import MostPopularDayRender from '../render';
 import widgetDefinition from '../widget';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
-import type { ComponentType } from 'react';
+import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
 
@@ -83,7 +83,7 @@ const meta = {
 
 export default meta;
 
-type Story = StoryObj;
+type Story = StoryObj< Partial< ComponentProps< typeof MostPopularDayRender > > >;
 
 /**
  * Default state — the best day for views and its share of all views.

--- a/projects/packages/premium-analytics/widgets/most-popular-time/stories/most-popular-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-time/stories/most-popular-time-widget.stories.tsx
@@ -26,7 +26,7 @@ import MostPopularTimeRender from '../render';
 import widgetDefinition from '../widget';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
-import type { ComponentType } from 'react';
+import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
 
@@ -81,7 +81,7 @@ const meta = {
 
 export default meta;
 
-type Story = StoryObj;
+type Story = StoryObj< Partial< ComponentProps< typeof MostPopularTimeRender > > >;
 
 /**
  * Default state — the peak day and hour highlights.

--- a/projects/packages/premium-analytics/widgets/most-popular-time/stories/most-popular-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-time/stories/most-popular-time-widget.stories.tsx
@@ -2,9 +2,7 @@
  * The stories render the data-connected widget through `WidgetRoot`, so
  * they need report data to resolve against. `registerReportMocks` covers the
  * shared paths, including the `stats/insights` fixture wired into
- * `routeStatsReport()`. The insights endpoint has no comparison period, so
- * `WithComparison` renders identically to `Default` even though comparison
- * report params are supplied.
+ * `routeStatsReport()`.
  */
 /**
  * External dependencies
@@ -28,7 +26,7 @@ import MostPopularTimeRender from '../render';
 import widgetDefinition from '../widget';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
-import type { ComponentProps, ComponentType } from 'react';
+import type { ComponentType } from 'react';
 
 registerReportMocks();
 
@@ -59,35 +57,18 @@ function forceInsightsState( state: 'loading' | 'error' | 'empty' ) {
 }
 
 /**
- * Story controls. `withComparison` toggles the comparison report params to
- * confirm the widget renders identically — the insights endpoint has no
- * comparison period.
- */
-interface MostPopularTimeStoryControls {
-	withComparison: boolean;
-}
-
-/**
- * Renders the data-connected widget with the given comparison state.
+ * Renders the data-connected widget.
  *
- * @param {MostPopularTimeStoryControls} controls - The story controls.
  * @return The rendered widget.
  */
-function renderMostPopularTime( { withComparison }: MostPopularTimeStoryControls ) {
-	return (
-		<MostPopularTimeRender
-			attributes={ { reportParams: getDefaultQueryParams( withComparison ) } }
-		/>
-	);
+function renderMostPopularTime() {
+	return <MostPopularTimeRender attributes={ { reportParams: getDefaultQueryParams() } } />;
 }
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/MostPopularTime',
 	component: MostPopularTimeRender,
 	tags: [ 'autodocs' ],
-	argTypes: {
-		withComparison: { control: 'boolean' },
-	},
 	parameters: {
 		docs: {
 			description: {
@@ -96,37 +77,18 @@ const meta = {
 			},
 		},
 	},
-} satisfies Meta< ComponentProps< typeof MostPopularTimeRender > & MostPopularTimeStoryControls >;
+} satisfies Meta< typeof MostPopularTimeRender >;
 
 export default meta;
 
-type Story = StoryObj< MostPopularTimeStoryControls >;
+type Story = StoryObj;
 
 /**
  * Default state — the peak day and hour highlights.
  */
 export const Default: Story = {
 	render: renderMostPopularTime,
-	args: { withComparison: false },
 	decorators: [ withWidgetCanvas ],
-};
-
-/**
- * Comparison state — comparison report params are supplied, but the insights
- * endpoint has no comparison data, so this renders identically to Default.
- */
-export const WithComparison: Story = {
-	render: renderMostPopularTime,
-	args: { withComparison: true },
-	decorators: [ withWidgetCanvas ],
-	parameters: {
-		docs: {
-			description: {
-				story:
-					'The insights endpoint has no comparison period, so this renders identically to Default even when comparison report params are supplied.',
-			},
-		},
-	},
 };
 
 /**
@@ -134,7 +96,7 @@ export const WithComparison: Story = {
  * mock is forced to never resolve for the duration of this story.
  */
 export const Loading: Story = {
-	render: () => renderMostPopularTime( { withComparison: false } ),
+	render: renderMostPopularTime,
 	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
@@ -146,7 +108,7 @@ export const Loading: Story = {
  * re-runs the query — still mocked as failing while this story is active).
  */
 export const Error: Story = {
-	render: () => renderMostPopularTime( { withComparison: false } ),
+	render: renderMostPopularTime,
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => forceInsightsState( 'error' ),
@@ -158,27 +120,20 @@ export const Error: Story = {
  * analytics icon set).
  */
 export const Empty: Story = {
-	render: () => renderMostPopularTime( { withComparison: false } ),
+	render: renderMostPopularTime,
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => forceInsightsState( 'empty' ),
 };
 
-interface MostPopularTimeDashboardStoryProps
-	extends WidgetDashboardWithWidgetControls,
-		MostPopularTimeStoryControls {}
-
 /**
  * Renders the data-connected widget through the shared dashboard harness, so it
  * appears exactly as it does in product (framed card, sizing, edit mode).
  *
- * @param {MostPopularTimeDashboardStoryProps} props - The dashboard story controls.
+ * @param {WidgetDashboardWithWidgetControls} dashboardArgs - The dashboard story controls.
  * @return The widget mounted inside the real `WidgetDashboard`.
  */
-function MostPopularTimeDashboardStory( {
-	withComparison,
-	...dashboardArgs
-}: MostPopularTimeDashboardStoryProps ) {
+function MostPopularTimeDashboardStory( dashboardArgs: WidgetDashboardWithWidgetControls ) {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
@@ -190,19 +145,17 @@ function MostPopularTimeDashboardStory( {
 			} }
 			renderModule={ MOST_POPULAR_TIME_RENDER_MODULE }
 			renderComponent={ MostPopularTimeRender as ComponentType< WidgetRenderProps< unknown > > }
-			attributes={ { reportParams: getDefaultQueryParams( withComparison ) } }
+			attributes={ { reportParams: getDefaultQueryParams( true ) } }
 		/>
 	);
 }
 
-export const WidgetDashboardWithWidget: StoryObj< MostPopularTimeDashboardStoryProps > = {
+export const WidgetDashboardWithWidget: StoryObj< WidgetDashboardWithWidgetControls > = {
 	render: args => <MostPopularTimeDashboardStory { ...args } />,
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
-		withComparison: true,
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
-		withComparison: { control: 'boolean' },
 	},
 };

--- a/projects/packages/premium-analytics/widgets/plan-usage/stories/plan-usage-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/plan-usage/stories/plan-usage-widget.stories.tsx
@@ -28,7 +28,7 @@ import PlanUsageRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
-import type { ComponentType } from 'react';
+import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
 
@@ -129,7 +129,7 @@ const meta = {
 
 export default meta;
 
-type Story = StoryObj;
+type Story = StoryObj< Partial< ComponentProps< typeof PlanUsageRender > > >;
 
 /**
  * Default state — the current-cycle usage gauge.

--- a/projects/packages/premium-analytics/widgets/plan-usage/stories/plan-usage-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/plan-usage/stories/plan-usage-widget.stories.tsx
@@ -2,10 +2,7 @@
  * All stories render the data-connected widget through `WidgetRoot`, so they
  * need report data to resolve against. `registerReportMocks` covers the shared
  * paths, including the `jetpack-stats/usage` fixture wired into the
- * report-mocks middleware. The usage endpoint is a point-in-time reading with no
- * comparison period, so `WithComparison` renders identically to `Default` even
- * though comparison report params are supplied. The Loading / Error /
- * Unavailable stories force the request into each state via
+ * report-mocks middleware. The Loading / Error / Unavailable stories force the request into each state via
  * `setReportMockState`.
  */
 /**
@@ -31,7 +28,7 @@ import PlanUsageRender from '../render';
 import widgetDefinition from '../widget';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
-import type { ComponentProps, ComponentType } from 'react';
+import type { ComponentType } from 'react';
 
 registerReportMocks();
 
@@ -101,24 +98,12 @@ function forcePlanUsageOverLimit( { vip }: { vip: boolean } ) {
 }
 
 /**
- * Story controls. `withComparison` toggles the comparison report params to
- * confirm the widget renders identically — the usage endpoint has no comparison
- * period.
- */
-interface PlanUsageStoryControls {
-	withComparison: boolean;
-}
-
-/**
- * Renders the data-connected widget with the given comparison state.
+ * Renders the data-connected widget.
  *
- * @param {PlanUsageStoryControls} controls - The story controls.
  * @return The rendered widget.
  */
-function renderPlanUsage( { withComparison }: PlanUsageStoryControls ) {
-	return (
-		<PlanUsageRender attributes={ { reportParams: getDefaultQueryParams( withComparison ) } } />
-	);
+function renderPlanUsage() {
+	return <PlanUsageRender attributes={ { reportParams: getDefaultQueryParams() } } />;
 }
 
 // Close-up canvas so the gauge fills the frame outside the dashboard grid.
@@ -132,9 +117,6 @@ const meta = {
 	title: 'Packages/Premium Analytics/Widgets/PlanUsage',
 	component: PlanUsageRender,
 	tags: [ 'autodocs' ],
-	argTypes: {
-		withComparison: { control: 'boolean' },
-	},
 	parameters: {
 		docs: {
 			description: {
@@ -143,37 +125,18 @@ const meta = {
 			},
 		},
 	},
-} satisfies Meta< ComponentProps< typeof PlanUsageRender > & PlanUsageStoryControls >;
+} satisfies Meta< typeof PlanUsageRender >;
 
 export default meta;
 
-type Story = StoryObj< PlanUsageStoryControls >;
+type Story = StoryObj;
 
 /**
  * Default state — the current-cycle usage gauge.
  */
 export const Default: Story = {
 	render: renderPlanUsage,
-	args: { withComparison: false },
 	decorators: [ withWidgetCanvas ],
-};
-
-/**
- * Comparison state — comparison report params are supplied, but the usage
- * endpoint has no comparison data, so this renders identically to Default.
- */
-export const WithComparison: Story = {
-	render: renderPlanUsage,
-	args: { withComparison: true },
-	decorators: [ withWidgetCanvas ],
-	parameters: {
-		docs: {
-			description: {
-				story:
-					'The usage endpoint has no comparison period, so this renders identically to Default even when comparison report params are supplied.',
-			},
-		},
-	},
 };
 
 /**
@@ -182,7 +145,6 @@ export const WithComparison: Story = {
  */
 export const Loading: Story = {
 	render: renderPlanUsage,
-	args: { withComparison: false },
 	// Kept off the shared autodocs page: the mock override is keyed by path, so it
 	// would otherwise force the sibling stories on that page into the same state.
 	tags: [ '!autodocs' ],
@@ -196,7 +158,6 @@ export const Loading: Story = {
  */
 export const Error: Story = {
 	render: renderPlanUsage,
-	args: { withComparison: false },
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: forcePlanUsageState( 'error' ),
@@ -210,7 +171,6 @@ export const Error: Story = {
  */
 export const Unavailable: Story = {
 	render: renderPlanUsage,
-	args: { withComparison: false },
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: forcePlanUsageState( 'empty' ),
@@ -222,7 +182,6 @@ export const Unavailable: Story = {
  */
 export const OverLimit: Story = {
 	render: renderPlanUsage,
-	args: { withComparison: false },
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: forcePlanUsageOverLimit( { vip: false } ),
@@ -235,46 +194,36 @@ export const OverLimit: Story = {
  */
 export const OverLimitVip: Story = {
 	render: renderPlanUsage,
-	args: { withComparison: false },
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: forcePlanUsageOverLimit( { vip: true } ),
 };
 
-interface PlanUsageDashboardStoryProps
-	extends WidgetDashboardWithWidgetControls,
-		PlanUsageStoryControls {}
-
 /**
  * Renders the data-connected widget through the shared dashboard harness, so it
  * appears exactly as it does in product (framed card, sizing, edit mode).
  *
- * @param {PlanUsageDashboardStoryProps} props - The dashboard story controls.
+ * @param {WidgetDashboardWithWidgetControls} dashboardArgs - The dashboard story controls.
  * @return The widget mounted inside the real `WidgetDashboard`.
  */
-function PlanUsageDashboardStory( {
-	withComparison,
-	...dashboardArgs
-}: PlanUsageDashboardStoryProps ) {
+function PlanUsageDashboardStory( dashboardArgs: WidgetDashboardWithWidgetControls ) {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
 			widgetType={ { ...widgetDefinition, presentation: 'framed' } }
 			renderModule={ PLAN_USAGE_RENDER_MODULE }
 			renderComponent={ PlanUsageRender as ComponentType< WidgetRenderProps< unknown > > }
-			attributes={ { reportParams: getDefaultQueryParams( withComparison ) } }
+			attributes={ { reportParams: getDefaultQueryParams( true ) } }
 		/>
 	);
 }
 
-export const WidgetDashboardWithWidget: StoryObj< PlanUsageDashboardStoryProps > = {
+export const WidgetDashboardWithWidget: StoryObj< WidgetDashboardWithWidgetControls > = {
 	render: args => <PlanUsageDashboardStory { ...args } />,
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
-		withComparison: true,
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
-		withComparison: { control: 'boolean' },
 	},
 };

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/stories/post-traffic-activity-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/stories/post-traffic-activity-widget.stories.tsx
@@ -48,18 +48,17 @@ interface PostTrafficActivityStoryControls {
  * Builds the widget attributes: report params with the post scope the detail
  * page seeds from its URL when `hasPostScope` is on.
  *
- * @param {PostTrafficActivityStoryControls} controls - The story controls.
+ * @param {PostTrafficActivityStoryControls} controls       - The story controls.
+ * @param {boolean}                          withComparison - Include comparison report params.
  * @return The widget attributes.
  */
-function getPostTrafficActivityAttributes( {
-	hasPostScope,
-	preset,
-}: PostTrafficActivityStoryControls ): ComponentProps<
-	typeof PostTrafficActivityRender
->[ 'attributes' ] {
+function getPostTrafficActivityAttributes(
+	{ hasPostScope, preset }: PostTrafficActivityStoryControls,
+	withComparison = false
+): ComponentProps< typeof PostTrafficActivityRender >[ 'attributes' ] {
 	return {
 		reportParams: {
-			...getDefaultQueryParams( false, preset ),
+			...getDefaultQueryParams( withComparison, preset ),
 			...( hasPostScope ? { post_id: MOCK_POST_ID } : {} ),
 		},
 	};
@@ -165,13 +164,7 @@ function PostTrafficActivityDashboardStory( {
 			widgetType={ { ...widgetDefinition, presentation: 'framed' } }
 			renderModule={ POST_TRAFFIC_ACTIVITY_RENDER_MODULE }
 			renderComponent={ PostTrafficActivityRender as ComponentType< WidgetRenderProps< unknown > > }
-			attributes={ {
-				...getPostTrafficActivityAttributes( { hasPostScope, preset } ),
-				reportParams: {
-					...getDefaultQueryParams( true, preset ),
-					...( hasPostScope ? { post_id: MOCK_POST_ID } : {} ),
-				},
-			} }
+			attributes={ getPostTrafficActivityAttributes( { hasPostScope, preset }, true ) }
 		/>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/stories/post-traffic-activity-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/stories/post-traffic-activity-widget.stories.tsx
@@ -41,7 +41,6 @@ const POST_TRAFFIC_ACTIVITY_RENDER_MODULE = 'storybook/post-traffic-activity';
 
 interface PostTrafficActivityStoryControls {
 	hasPostScope: boolean;
-	withComparison: boolean;
 	preset: 'last-30-days' | 'last-365-days';
 }
 
@@ -54,14 +53,13 @@ interface PostTrafficActivityStoryControls {
  */
 function getPostTrafficActivityAttributes( {
 	hasPostScope,
-	withComparison,
 	preset,
 }: PostTrafficActivityStoryControls ): ComponentProps<
 	typeof PostTrafficActivityRender
 >[ 'attributes' ] {
 	return {
 		reportParams: {
-			...getDefaultQueryParams( withComparison, preset ),
+			...getDefaultQueryParams( false, preset ),
 			...( hasPostScope ? { post_id: MOCK_POST_ID } : {} ),
 		},
 	};
@@ -93,10 +91,6 @@ const meta = {
 			control: 'boolean',
 			description: 'Include the `post_id` report param the post detail page seeds from its URL.',
 		},
-		withComparison: {
-			control: 'boolean',
-			description: 'Include the date range picker comparison parameters.',
-		},
 		preset: {
 			control: 'select',
 			options: [ 'last-30-days', 'last-365-days' ],
@@ -124,27 +118,8 @@ type Story = StoryObj< PostTrafficActivityStoryControls >;
  */
 export const Default: Story = {
 	render: renderPostTrafficActivity,
-	args: { hasPostScope: true, withComparison: false, preset: 'last-30-days' },
+	args: { hasPostScope: true, preset: 'last-30-days' },
 	decorators: [ withWidgetCanvas ],
-};
-
-/**
- * WithComparison — verifies that comparison report params from the date range
- * picker pass through the widget host. The stats/post endpoint has no separate
- * comparison rows, so the activity grid intentionally remains primary-only.
- */
-export const WithComparison: Story = {
-	render: renderPostTrafficActivity,
-	args: { hasPostScope: true, withComparison: true, preset: 'last-30-days' },
-	decorators: [ withWidgetCanvas ],
-	parameters: {
-		docs: {
-			description: {
-				story:
-					'The stats/post endpoint does not return a comparison series. This story verifies that comparison report parameters are accepted without inventing comparison activity.',
-			},
-		},
-	},
 };
 
 /**
@@ -153,7 +128,7 @@ export const WithComparison: Story = {
  */
 export const Paged: Story = {
 	render: renderPostTrafficActivity,
-	args: { hasPostScope: true, withComparison: false, preset: 'last-365-days' },
+	args: { hasPostScope: true, preset: 'last-365-days' },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -164,7 +139,7 @@ export const Paged: Story = {
  */
 export const NoPostScope: Story = {
 	render: renderPostTrafficActivity,
-	args: { hasPostScope: false, withComparison: false, preset: 'last-30-days' },
+	args: { hasPostScope: false, preset: 'last-30-days' },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -181,7 +156,6 @@ interface PostTrafficActivityDashboardStoryProps
  */
 function PostTrafficActivityDashboardStory( {
 	hasPostScope,
-	withComparison,
 	preset,
 	...dashboardArgs
 }: PostTrafficActivityDashboardStoryProps ) {
@@ -191,7 +165,13 @@ function PostTrafficActivityDashboardStory( {
 			widgetType={ { ...widgetDefinition, presentation: 'framed' } }
 			renderModule={ POST_TRAFFIC_ACTIVITY_RENDER_MODULE }
 			renderComponent={ PostTrafficActivityRender as ComponentType< WidgetRenderProps< unknown > > }
-			attributes={ getPostTrafficActivityAttributes( { hasPostScope, withComparison, preset } ) }
+			attributes={ {
+				...getPostTrafficActivityAttributes( { hasPostScope, preset } ),
+				reportParams: {
+					...getDefaultQueryParams( true, preset ),
+					...( hasPostScope ? { post_id: MOCK_POST_ID } : {} ),
+				},
+			} }
 		/>
 	);
 }
@@ -206,7 +186,6 @@ export const WidgetDashboardWithWidget: StoryObj< PostTrafficActivityDashboardSt
 		widgetWidth: 4,
 		widgetHeight: 2,
 		hasPostScope: true,
-		withComparison: true,
 		preset: 'last-30-days',
 	},
 	argTypes: {
@@ -214,10 +193,6 @@ export const WidgetDashboardWithWidget: StoryObj< PostTrafficActivityDashboardSt
 		hasPostScope: {
 			control: 'boolean',
 			description: 'Include the `post_id` report param the post detail page seeds from its URL.',
-		},
-		withComparison: {
-			control: 'boolean',
-			description: 'Include the date range picker comparison parameters.',
 		},
 		preset: {
 			control: 'select',

--- a/projects/packages/premium-analytics/widgets/posting-activity/stories/posting-activity-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/posting-activity/stories/posting-activity-widget.stories.tsx
@@ -21,7 +21,7 @@ import widgetDefinition from '../widget';
 import type { APIFetchMiddleware, APIFetchOptions } from '@wordpress/api-fetch';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
-import type { ComponentType } from 'react';
+import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
 
@@ -128,7 +128,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'The "Posting activity" widget. Renders a calendar (contribution-style) heatmap of the number of posts published per day for the dashboard date range.',
+					'The "Posting activity" widget. Renders a calendar (contribution-style) heatmap of the number of posts published per day for the dashboard date range. The streak module has no comparison period, so the heatmap renders without deltas.',
 			},
 		},
 	},
@@ -136,7 +136,7 @@ const meta = {
 
 export default meta;
 
-type Story = StoryObj;
+type Story = StoryObj< Partial< ComponentProps< typeof PostingActivityRender > > >;
 
 /**
  * Default populated state — a year of posting activity for the current period.

--- a/projects/packages/premium-analytics/widgets/posting-activity/stories/posting-activity-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/posting-activity/stories/posting-activity-widget.stories.tsx
@@ -21,7 +21,7 @@ import widgetDefinition from '../widget';
 import type { APIFetchMiddleware, APIFetchOptions } from '@wordpress/api-fetch';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
-import type { ComponentProps, ComponentType } from 'react';
+import type { ComponentType } from 'react';
 
 registerReportMocks();
 
@@ -107,16 +107,8 @@ apiFetch.use( streakMocksMiddleware );
 
 const POSTING_ACTIVITY_RENDER_MODULE = 'storybook/posting-activity';
 
-interface PostingActivityStoryControls {
-	withComparison: boolean;
-}
-
-function renderPostingActivity( { withComparison }: PostingActivityStoryControls ) {
-	return (
-		<PostingActivityRender
-			attributes={ { reportParams: getDefaultQueryParams( withComparison ) } }
-		/>
-	);
+function renderPostingActivity() {
+	return <PostingActivityRender attributes={ { reportParams: getDefaultQueryParams() } } />;
 }
 
 // Distinct preset → own query-cache entry; see forceStatsMockState.
@@ -132,40 +124,25 @@ const meta = {
 	title: 'Packages/Premium Analytics/Widgets/PostingActivity',
 	component: PostingActivityRender,
 	tags: [ 'autodocs' ],
-	argTypes: {
-		withComparison: { control: 'boolean' },
-	},
 	parameters: {
 		docs: {
 			description: {
 				component:
-					'The "Posting activity" widget. Renders a calendar (contribution-style) heatmap of the number of posts published per day for the dashboard date range. The `stats/streak` endpoint has no comparison period, so the WithComparison story renders identically to Default — no deltas are shown.',
+					'The "Posting activity" widget. Renders a calendar (contribution-style) heatmap of the number of posts published per day for the dashboard date range.',
 			},
 		},
 	},
-} satisfies Meta< ComponentProps< typeof PostingActivityRender > & PostingActivityStoryControls >;
+} satisfies Meta< typeof PostingActivityRender >;
 
 export default meta;
 
-type Story = StoryObj< PostingActivityStoryControls >;
+type Story = StoryObj;
 
 /**
  * Default populated state — a year of posting activity for the current period.
  */
 export const Default: Story = {
 	render: renderPostingActivity,
-	args: { withComparison: false },
-	decorators: [ withWidgetCanvas ],
-};
-
-/**
- * Comparison state — the date range picker's comparison params are present, but
- * `stats/streak` has no comparison data, so the heatmap renders normally without
- * fabricated deltas.
- */
-export const WithComparison: Story = {
-	render: renderPostingActivity,
-	args: { withComparison: true },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -203,33 +180,24 @@ export const Empty: Story = {
 	beforeEach: () => forceStreakState( 'empty' ),
 };
 
-interface PostingActivityDashboardStoryProps
-	extends WidgetDashboardWithWidgetControls,
-		PostingActivityStoryControls {}
-
-function PostingActivityDashboardStory( {
-	withComparison,
-	...dashboardArgs
-}: PostingActivityDashboardStoryProps ) {
+function PostingActivityDashboardStory( dashboardArgs: WidgetDashboardWithWidgetControls ) {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
 			widgetType={ widgetDefinition }
 			renderModule={ POSTING_ACTIVITY_RENDER_MODULE }
 			renderComponent={ PostingActivityRender as ComponentType< WidgetRenderProps< unknown > > }
-			attributes={ { reportParams: getDefaultQueryParams( withComparison ) } }
+			attributes={ { reportParams: getDefaultQueryParams( true ) } }
 		/>
 	);
 }
 
-export const WidgetDashboardWithWidget: StoryObj< PostingActivityDashboardStoryProps > = {
+export const WidgetDashboardWithWidget: StoryObj< WidgetDashboardWithWidgetControls > = {
 	render: args => <PostingActivityDashboardStory { ...args } />,
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
-		withComparison: true,
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
-		withComparison: { control: 'boolean' },
 	},
 };

--- a/projects/packages/premium-analytics/widgets/shares/stories/shares-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/shares/stories/shares-widget.stories.tsx
@@ -62,16 +62,8 @@ const storyWidgetType = {
 	presentation: 'framed' as const,
 };
 
-interface SharesStoryControls {
-	withComparison: boolean;
-}
-
-function renderShares( { withComparison }: SharesStoryControls ) {
-	return (
-		<SharesRender
-			attributes={ { max: 10, reportParams: getDefaultQueryParams( withComparison ) } }
-		/>
-	);
+function renderShares() {
+	return <SharesRender attributes={ { max: 10, reportParams: getDefaultQueryParams() } } />;
 }
 
 function SharesDashboardRender( props: WidgetRenderProps< unknown > ) {
@@ -82,9 +74,6 @@ const meta = {
 	title: 'Packages/Premium Analytics/Widgets/Shares',
 	component: SharesRender,
 	tags: [ 'autodocs' ],
-	argTypes: {
-		withComparison: { control: 'boolean' },
-	},
 	parameters: {
 		docs: {
 			description: {
@@ -93,38 +82,18 @@ const meta = {
 			},
 		},
 	},
-} satisfies Meta< ComponentProps< typeof SharesRender > & SharesStoryControls >;
+} satisfies Meta< typeof SharesRender >;
 
 export default meta;
 
-type Story = StoryObj< SharesStoryControls >;
+type Story = StoryObj;
 
 /**
  * The widget on its own, populated from the mocked site summary.
  */
 export const Default: Story = {
 	render: renderShares,
-	args: { withComparison: false },
 	decorators: [ withWidgetCanvas ],
-};
-
-/**
- * Comparison state — the dashboard's comparison `reportParams` are present, but the
- * site summary has no comparison period, so the widget renders the same current
- * counts without period-over-period deltas.
- */
-export const WithComparison: Story = {
-	render: renderShares,
-	args: { withComparison: true },
-	decorators: [ withWidgetCanvas ],
-	parameters: {
-		docs: {
-			description: {
-				story:
-					'The Shares module has no comparison data, so no period-over-period deltas are shown.',
-			},
-		},
-	},
 };
 
 /**
@@ -132,7 +101,7 @@ export const WithComparison: Story = {
  * loading state. The mock never resolves for the duration of this story.
  */
 export const Loading: Story = {
-	render: () => renderShares( { withComparison: false } ),
+	render: renderShares,
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => forceSiteSummaryState( 'loading' ),
@@ -143,7 +112,7 @@ export const Loading: Story = {
  * state with a Retry action.
  */
 export const Error: Story = {
-	render: () => renderShares( { withComparison: false } ),
+	render: renderShares,
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => forceSiteSummaryState( 'error' ),
@@ -154,24 +123,20 @@ export const Error: Story = {
  * megaphone and guidance copy.
  */
 export const Empty: Story = {
-	render: () => renderShares( { withComparison: false } ),
+	render: renderShares,
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => forceSiteSummaryState( 'empty' ),
 };
 
-interface SharesDashboardStoryProps
-	extends WidgetDashboardWithWidgetControls,
-		SharesStoryControls {}
-
-function SharesDashboardStory( { withComparison, ...dashboardArgs }: SharesDashboardStoryProps ) {
+function SharesDashboardStory( dashboardArgs: WidgetDashboardWithWidgetControls ) {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
 			widgetType={ storyWidgetType }
 			renderModule={ SHARES_RENDER_MODULE }
 			renderComponent={ SharesDashboardRender as ComponentType< WidgetRenderProps< unknown > > }
-			attributes={ { max: 10, reportParams: getDefaultQueryParams( withComparison ) } }
+			attributes={ { max: 10, reportParams: getDefaultQueryParams( true ) } }
 		/>
 	);
 }
@@ -179,14 +144,12 @@ function SharesDashboardStory( { withComparison, ...dashboardArgs }: SharesDashb
 /**
  * Renders the real registered widget through the shared dashboard harness.
  */
-export const WidgetDashboardWithWidget: StoryObj< SharesDashboardStoryProps > = {
+export const WidgetDashboardWithWidget: StoryObj< WidgetDashboardWithWidgetControls > = {
 	render: args => <SharesDashboardStory { ...args } />,
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
-		withComparison: true,
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
-		withComparison: { control: 'boolean' },
 	},
 };

--- a/projects/packages/premium-analytics/widgets/shares/stories/shares-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/shares/stories/shares-widget.stories.tsx
@@ -86,7 +86,7 @@ const meta = {
 
 export default meta;
 
-type Story = StoryObj;
+type Story = StoryObj< Partial< ComponentProps< typeof SharesRender > > >;
 
 /**
  * The widget on its own, populated from the mocked site summary.

--- a/projects/packages/premium-analytics/widgets/subscriber-highlights/stories/subscriber-highlights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/subscriber-highlights/stories/subscriber-highlights-widget.stories.tsx
@@ -85,7 +85,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'The "Subscriber highlights" widget. Shows current subscriber totals — total, paid, free, and social followers — as a grid of metric tiles. Which tiles appear is controlled by the `metrics` attribute (`relevance: \'high\'`), exposed inline in the widget header and in the settings drawer. Data comes from the designated `useStatsSubscribersCounts` hook; in Storybook it is served by `registerReportMocks()` (the `subscribers/counts` handler).',
+					'The "Subscriber highlights" widget. Shows current subscriber totals — total, paid, free, and social followers — as a grid of metric tiles. Which tiles appear is controlled by the `metrics` attribute (`relevance: \'high\'`), exposed inline in the widget header and in the settings drawer. Data comes from the designated `useStatsSubscribersCounts` hook; in Storybook it is served by `registerReportMocks()` (the `subscribers/counts` handler). The counts module has no comparison period, so the tiles show bare counts.',
 			},
 		},
 	},

--- a/projects/packages/premium-analytics/widgets/subscriber-highlights/stories/subscriber-highlights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/subscriber-highlights/stories/subscriber-highlights-widget.stories.tsx
@@ -41,33 +41,22 @@ const storyWidgetType = {
 
 interface SubscriberHighlightsStoryControls {
 	/**
-	 * Whether to inject comparison report params.
-	 */
-	withComparison: boolean;
-	/**
 	 * Metric tiles to show in the widget body.
 	 */
 	metrics: SubscriberMetricId[];
 }
 
 /**
- * Renders the data-connected widget with report params derived from the
- * comparison toggle and the selected metrics. The counts endpoint is not
- * period-scoped, so toggling comparison does not change what the widget shows
- * — it is wired through only to prove the widget renders unchanged when the
- * host injects comparison params.
+ * Renders the data-connected widget with the selected metrics.
  *
  * @param {SubscriberHighlightsStoryControls} props - Story controls.
  * @return The rendered widget.
  */
-function renderSubscriberHighlights( {
-	withComparison,
-	metrics,
-}: SubscriberHighlightsStoryControls ) {
+function renderSubscriberHighlights( { metrics }: SubscriberHighlightsStoryControls ) {
 	return (
 		<SubscriberHighlightsRender
 			attributes={ {
-				reportParams: getDefaultQueryParams( withComparison ),
+				reportParams: getDefaultQueryParams(),
 				metrics,
 			} }
 		/>
@@ -90,14 +79,13 @@ const meta = {
 	component: SubscriberHighlightsRender,
 	tags: [ 'autodocs' ],
 	argTypes: {
-		withComparison: { control: 'boolean' },
 		...METRIC_ARG_TYPES,
 	},
 	parameters: {
 		docs: {
 			description: {
 				component:
-					'The "Subscriber highlights" widget. Shows current subscriber totals — total, paid, free, and social followers — as a grid of metric tiles. Which tiles appear is controlled by the `metrics` attribute (`relevance: \'high\'`), exposed inline in the widget header and in the settings drawer. Data comes from the designated `useStatsSubscribersCounts` hook; in Storybook it is served by `registerReportMocks()` (the `subscribers/counts` handler). The counts module has no comparison period, so the tiles show bare counts and the `WithComparison` story renders identically to `Default`.',
+					'The "Subscriber highlights" widget. Shows current subscriber totals — total, paid, free, and social followers — as a grid of metric tiles. Which tiles appear is controlled by the `metrics` attribute (`relevance: \'high\'`), exposed inline in the widget header and in the settings drawer. Data comes from the designated `useStatsSubscribersCounts` hook; in Storybook it is served by `registerReportMocks()` (the `subscribers/counts` handler).',
 			},
 		},
 	},
@@ -114,18 +102,7 @@ type Story = StoryObj< SubscriberHighlightsStoryControls >;
  */
 export const Default: Story = {
 	render: renderSubscriberHighlights,
-	args: { withComparison: false, ...ALL_METRICS_ARGS },
-	decorators: [ withWidgetCanvas ],
-};
-
-/**
- * Same close-up with comparison report params injected. The counts module has no
- * comparison data, so this renders identically to `Default` — it only verifies
- * the widget stays stable when the host provides comparison params.
- */
-export const WithComparison: Story = {
-	render: renderSubscriberHighlights,
-	args: { withComparison: true, ...ALL_METRICS_ARGS },
+	args: { ...ALL_METRICS_ARGS },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -144,7 +121,7 @@ function resetSubscribersCountsQuery() {
  */
 export const Loading: Story = {
 	render: renderSubscriberHighlights,
-	args: { withComparison: false, ...ALL_METRICS_ARGS },
+	args: { ...ALL_METRICS_ARGS },
 	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
@@ -164,7 +141,7 @@ export const Loading: Story = {
  */
 export const Error: Story = {
 	render: renderSubscriberHighlights,
-	args: { withComparison: false, ...ALL_METRICS_ARGS },
+	args: { ...ALL_METRICS_ARGS },
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {
@@ -183,7 +160,7 @@ export const Error: Story = {
  */
 export const Empty: Story = {
 	render: renderSubscriberHighlights,
-	args: { withComparison: false, ...ALL_METRICS_ARGS },
+	args: { ...ALL_METRICS_ARGS },
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {
@@ -207,7 +184,6 @@ interface SubscriberHighlightsDashboardStoryProps
  * @return The rendered dashboard with the widget.
  */
 function SubscriberHighlightsDashboardStory( {
-	withComparison,
 	metrics,
 	...dashboardArgs
 }: SubscriberHighlightsDashboardStoryProps ) {
@@ -220,7 +196,7 @@ function SubscriberHighlightsDashboardStory( {
 				SubscriberHighlightsRender as ComponentType< WidgetRenderProps< unknown > >
 			}
 			attributes={ {
-				reportParams: getDefaultQueryParams( withComparison ),
+				reportParams: getDefaultQueryParams( true ),
 				metrics,
 			} }
 		/>
@@ -233,12 +209,10 @@ export const WidgetDashboardWithWidget: StoryObj< SubscriberHighlightsDashboardS
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 		widgetWidth: 1,
 		widgetHeight: 1,
-		withComparison: true,
 		...ALL_METRICS_ARGS,
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
-		withComparison: { control: 'boolean' },
 		...METRIC_ARG_TYPES,
 	},
 };

--- a/projects/packages/premium-analytics/widgets/tags/stories/tags-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/stories/tags-widget.stories.tsx
@@ -28,14 +28,8 @@ const storyWidgetType = {
 	presentation: 'framed' as const,
 };
 
-interface TagsStoryControls {
-	withComparison: boolean;
-}
-
-function renderTags( { withComparison }: TagsStoryControls ) {
-	return (
-		<TagsRender attributes={ { max: 10, reportParams: getDefaultQueryParams( withComparison ) } } />
-	);
+function renderTags() {
+	return <TagsRender attributes={ { max: 10, reportParams: getDefaultQueryParams() } } />;
 }
 
 // Renders the widget with a distinct `max` so each forced-state story gets its
@@ -78,9 +72,6 @@ const meta = {
 	title: 'Packages/Premium Analytics/Widgets/Tags',
 	component: TagsRender,
 	tags: [ 'autodocs' ],
-	argTypes: {
-		withComparison: { control: 'boolean' },
-	},
 	parameters: {
 		docs: {
 			description: {
@@ -89,35 +80,15 @@ const meta = {
 			},
 		},
 	},
-} satisfies Meta< ComponentProps< typeof TagsRender > & TagsStoryControls >;
+} satisfies Meta< typeof TagsRender >;
 
 export default meta;
 
-type Story = StoryObj< TagsStoryControls >;
+type Story = StoryObj;
 
 export const Default: Story = {
 	render: renderTags,
-	args: { withComparison: false },
 	decorators: [ withWidgetCanvas ],
-};
-
-/**
- * The date range picker's comparison parameters are passed through, but the Stats
- * `tags` endpoint has no comparison period, so the widget renders single-period
- * values only — no period-over-period deltas are shown.
- */
-export const WithComparison: Story = {
-	render: renderTags,
-	args: { withComparison: true },
-	decorators: [ withWidgetCanvas ],
-	parameters: {
-		docs: {
-			description: {
-				story:
-					'The `tags` endpoint returns no comparison rows, so no deltas are shown even when the date range picker enables a comparison period.',
-			},
-		},
-	},
 };
 
 /**
@@ -164,28 +135,24 @@ export const Empty: Story = {
 	},
 };
 
-interface TagsDashboardStoryProps extends WidgetDashboardWithWidgetControls, TagsStoryControls {}
-
-function TagsDashboardStory( { withComparison, ...dashboardArgs }: TagsDashboardStoryProps ) {
+function TagsDashboardStory( dashboardArgs: WidgetDashboardWithWidgetControls ) {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
 			widgetType={ storyWidgetType }
 			renderModule={ TAGS_RENDER_MODULE }
 			renderComponent={ TagsDashboardRender as ComponentType< WidgetRenderProps< unknown > > }
-			attributes={ { max: 10, reportParams: getDefaultQueryParams( withComparison ) } }
+			attributes={ { max: 10, reportParams: getDefaultQueryParams( true ) } }
 		/>
 	);
 }
 
-export const WidgetDashboardWithWidget: StoryObj< TagsDashboardStoryProps > = {
+export const WidgetDashboardWithWidget: StoryObj< WidgetDashboardWithWidgetControls > = {
 	render: args => <TagsDashboardStory { ...args } />,
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
-		withComparison: true,
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
-		withComparison: { control: 'boolean' },
 	},
 };

--- a/projects/packages/premium-analytics/widgets/tags/stories/tags-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/stories/tags-widget.stories.tsx
@@ -84,7 +84,7 @@ const meta = {
 
 export default meta;
 
-type Story = StoryObj;
+type Story = StoryObj< Partial< ComponentProps< typeof TagsRender > > >;
 
 export const Default: Story = {
 	render: renderTags,

--- a/projects/packages/premium-analytics/widgets/video-detail-embeds/stories/video-detail-embeds-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/video-detail-embeds/stories/video-detail-embeds-widget.stories.tsx
@@ -39,7 +39,7 @@ const MOCK_VIDEO_ID = 105;
  * Builds the host-composed report params for the selected video, deriving the
  * requested date range.
  *
- * @param {PresetType} preset         - Optional date preset override.
+ * @param {PresetType} preset - Optional date preset override.
  * @return The report params with the single-video `post_id` scope.
  */
 function reportParamsForVideo( preset?: PresetType ) {

--- a/projects/packages/premium-analytics/widgets/video-detail-embeds/stories/video-detail-embeds-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/video-detail-embeds/stories/video-detail-embeds-widget.stories.tsx
@@ -20,7 +20,7 @@ import VideoDetailEmbedsRender from '../render';
 import widgetDefinition from '../widget';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
-import type { ComponentProps, ComponentType } from 'react';
+import type { ComponentType } from 'react';
 
 registerReportMocks();
 
@@ -35,48 +35,31 @@ const SINGLE_VIDEO_PATH_FRAGMENT = 'stats/video/';
 // `stats/video/{id}` endpoint returns the same fixture for any ID.
 const MOCK_VIDEO_ID = 105;
 
-// Widget-specific story control: toggles the previous-period comparison params.
-interface VideoDetailEmbedsStoryControls {
-	/**
-	 * Whether to request the previous-period comparison.
-	 */
-	withComparison: boolean;
-}
-
 /**
  * Builds the host-composed report params for the selected video, deriving the
- * date range / comparison from the `withComparison` control.
+ * requested date range.
  *
- * @param {boolean}    withComparison - Whether to include comparison params.
  * @param {PresetType} preset         - Optional date preset override.
  * @return The report params with the single-video `post_id` scope.
  */
-function reportParamsForVideo( withComparison: boolean, preset?: PresetType ) {
-	return { ...getDefaultQueryParams( withComparison, preset ), post_id: MOCK_VIDEO_ID };
+function reportParamsForVideo( preset?: PresetType ) {
+	return { ...getDefaultQueryParams( false, preset ), post_id: MOCK_VIDEO_ID };
 }
 
 /**
- * Render the data-connected widget with report params derived from the
- * `withComparison` control, so the close-up stories exercise the real data flow
- * (served by `registerReportMocks`).
+ * Render the data-connected widget with report params served by
+ * `registerReportMocks`.
  *
- * @param {VideoDetailEmbedsStoryControls} props - Story controls.
  * @return The rendered widget.
  */
-function renderVideoDetailEmbeds( { withComparison }: VideoDetailEmbedsStoryControls ) {
-	return (
-		<VideoDetailEmbedsRender
-			attributes={ { reportParams: reportParamsForVideo( withComparison ) } }
-		/>
-	);
+function renderVideoDetailEmbeds() {
+	return <VideoDetailEmbedsRender attributes={ { reportParams: reportParamsForVideo() } } />;
 }
 
 // Distinct preset → own query-cache entry; see forceStatsMockState.
 function renderVideoDetailEmbedsOnPreset( preset: PresetType ) {
 	return (
-		<VideoDetailEmbedsRender
-			attributes={ { reportParams: reportParamsForVideo( false, preset ) } }
-		/>
+		<VideoDetailEmbedsRender attributes={ { reportParams: reportParamsForVideo( preset ) } } />
 	);
 }
 
@@ -84,41 +67,25 @@ const meta = {
 	title: 'Packages/Premium Analytics/Widgets/VideoDetailEmbeds',
 	component: VideoDetailEmbedsRender,
 	tags: [ 'autodocs' ],
-	argTypes: {
-		withComparison: { control: 'boolean' },
-	},
 	parameters: {
 		docs: {
 			description: {
 				component:
-					'Dashboard widget listing the pages where a single video is embedded, sourced from the Jetpack Stats `stats/video/%d` module via `useStatsSingleVideo`. The widget is scoped to one video through the host-composed `reportParams.post_id`; without one it prompts to select a video. The single-video module has no comparison data, so the `WithComparison` control only exercises that the widget still renders normally when comparison params are present. In Storybook the data is served by `registerReportMocks`.',
+					'Dashboard widget listing the pages where a single video is embedded, sourced from the Jetpack Stats `stats/video/%d` module via `useStatsSingleVideo`. The widget is scoped to one video through the host-composed `reportParams.post_id`; without one it prompts to select a video. In Storybook the data is served by `registerReportMocks`.',
 			},
 		},
 	},
-} satisfies Meta<
-	ComponentProps< typeof VideoDetailEmbedsRender > & VideoDetailEmbedsStoryControls
->;
+} satisfies Meta< typeof VideoDetailEmbedsRender >;
 
 export default meta;
 
-type Story = StoryObj< VideoDetailEmbedsStoryControls >;
+type Story = StoryObj;
 
 /**
  * The widget on its own, current period only.
  */
 export const Default: Story = {
 	render: renderVideoDetailEmbeds,
-	args: { withComparison: false },
-	decorators: [ withWidgetCanvas ],
-};
-
-/**
- * Same close-up with comparison report params. The single-video module returns
- * no comparison rows, so the list renders normally without fabricated deltas.
- */
-export const WithComparison: Story = {
-	render: renderVideoDetailEmbeds,
-	args: { withComparison: true },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -176,41 +143,34 @@ export const Empty: Story = {
 	},
 };
 
-interface VideoDetailEmbedsDashboardStoryProps
-	extends WidgetDashboardWithWidgetControls,
-		VideoDetailEmbedsStoryControls {}
-
 /**
  * Renders the real registered widget through the shared dashboard harness, so
  * it appears exactly as it does in product, inheriting the size / edit-mode /
  * host-environment controls.
  *
- * @param {VideoDetailEmbedsDashboardStoryProps} props - Story controls.
+ * @param {WidgetDashboardWithWidgetControls} dashboardArgs - Story controls.
  * @return The widget mounted in the dashboard harness.
  */
-function VideoDetailEmbedsDashboardStory( {
-	withComparison,
-	...dashboardArgs
-}: VideoDetailEmbedsDashboardStoryProps ) {
+function VideoDetailEmbedsDashboardStory( dashboardArgs: WidgetDashboardWithWidgetControls ) {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
 			widgetType={ widgetDefinition }
 			renderModule={ VIDEO_DETAIL_EMBEDS_RENDER_MODULE }
 			renderComponent={ VideoDetailEmbedsRender as ComponentType< WidgetRenderProps< unknown > > }
-			attributes={ { reportParams: reportParamsForVideo( withComparison ) } }
+			attributes={ {
+				reportParams: { ...getDefaultQueryParams( true ), post_id: MOCK_VIDEO_ID },
+			} }
 		/>
 	);
 }
 
-export const WidgetDashboardWithWidget: StoryObj< VideoDetailEmbedsDashboardStoryProps > = {
+export const WidgetDashboardWithWidget: StoryObj< WidgetDashboardWithWidgetControls > = {
 	render: args => <VideoDetailEmbedsDashboardStory { ...args } />,
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
-		withComparison: true,
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
-		withComparison: { control: 'boolean' },
 	},
 };

--- a/projects/packages/premium-analytics/widgets/video-detail-embeds/stories/video-detail-embeds-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/video-detail-embeds/stories/video-detail-embeds-widget.stories.tsx
@@ -20,7 +20,7 @@ import VideoDetailEmbedsRender from '../render';
 import widgetDefinition from '../widget';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
-import type { ComponentType } from 'react';
+import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
 
@@ -39,11 +39,12 @@ const MOCK_VIDEO_ID = 105;
  * Builds the host-composed report params for the selected video, deriving the
  * requested date range.
  *
- * @param {PresetType} preset - Optional date preset override.
+ * @param {PresetType} preset         - Optional date preset override.
+ * @param {boolean}    withComparison - Include comparison report params.
  * @return The report params with the single-video `post_id` scope.
  */
-function reportParamsForVideo( preset?: PresetType ) {
-	return { ...getDefaultQueryParams( false, preset ), post_id: MOCK_VIDEO_ID };
+function reportParamsForVideo( preset?: PresetType, withComparison = false ) {
+	return { ...getDefaultQueryParams( withComparison, preset ), post_id: MOCK_VIDEO_ID };
 }
 
 /**
@@ -79,7 +80,7 @@ const meta = {
 
 export default meta;
 
-type Story = StoryObj;
+type Story = StoryObj< Partial< ComponentProps< typeof VideoDetailEmbedsRender > > >;
 
 /**
  * The widget on its own, current period only.
@@ -158,9 +159,7 @@ function VideoDetailEmbedsDashboardStory( dashboardArgs: WidgetDashboardWithWidg
 			widgetType={ widgetDefinition }
 			renderModule={ VIDEO_DETAIL_EMBEDS_RENDER_MODULE }
 			renderComponent={ VideoDetailEmbedsRender as ComponentType< WidgetRenderProps< unknown > > }
-			attributes={ {
-				reportParams: { ...getDefaultQueryParams( true ), post_id: MOCK_VIDEO_ID },
-			} }
+			attributes={ { reportParams: reportParamsForVideo( undefined, true ) } }
 		/>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/wordads-highlights/stories/wordads-highlights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-highlights/stories/wordads-highlights-widget.stories.tsx
@@ -88,7 +88,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'The "WordAds highlights" widget. Shows all-time WordAds payouts — total earnings, amount paid, and outstanding balance — as a grid of currency tiles (paid = earnings − outstanding). Ported from the Calypso WordAds "Totals" section. Which cards appear is controlled by the `metrics` attribute (`relevance: \'high\'`), exposed inline in the widget header and in the settings drawer. Data comes from the designated `useStatsWordAdsEarnings` hook; in Storybook it is served by `registerReportMocks()` (the `wordads/earnings` handler).',
+					'The "WordAds highlights" widget. Shows all-time WordAds payouts — total earnings, amount paid, and outstanding balance — as a grid of currency tiles (paid = earnings − outstanding). Ported from the Calypso WordAds "Totals" section. Which cards appear is controlled by the `metrics` attribute (`relevance: \'high\'`), exposed inline in the widget header and in the settings drawer. Data comes from the designated `useStatsWordAdsEarnings` hook; in Storybook it is served by `registerReportMocks()` (the `wordads/earnings` handler). The earnings module has no comparison period, so the tiles show bare amounts.',
 			},
 		},
 	},

--- a/projects/packages/premium-analytics/widgets/wordads-highlights/stories/wordads-highlights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-highlights/stories/wordads-highlights-widget.stories.tsx
@@ -44,30 +44,22 @@ const storyWidgetType = {
 
 interface WordAdsHighlightsStoryControls {
 	/**
-	 * Whether to inject comparison report params.
-	 */
-	withComparison: boolean;
-	/**
 	 * Earnings cards to show in the widget body.
 	 */
 	metrics: WordAdsEarningsMetricId[];
 }
 
 /**
- * Renders the data-connected widget with report params derived from the
- * comparison toggle and the selected metrics. The earnings endpoint is not
- * period-scoped, so toggling comparison does not change what the widget shows
- * — it is wired through only to prove the widget renders unchanged when the
- * host injects comparison params.
+ * Renders the data-connected widget with the selected metrics.
  *
  * @param {WordAdsHighlightsStoryControls} props - Story controls.
  * @return The rendered widget.
  */
-function renderWordAdsHighlights( { withComparison, metrics }: WordAdsHighlightsStoryControls ) {
+function renderWordAdsHighlights( { metrics }: WordAdsHighlightsStoryControls ) {
 	return (
 		<WordAdsHighlightsRender
 			attributes={ {
-				reportParams: getDefaultQueryParams( withComparison ),
+				reportParams: getDefaultQueryParams(),
 				metrics,
 			} }
 		/>
@@ -90,14 +82,13 @@ const meta = {
 	component: WordAdsHighlightsRender,
 	tags: [ 'autodocs' ],
 	argTypes: {
-		withComparison: { control: 'boolean' },
 		...METRIC_ARG_TYPES,
 	},
 	parameters: {
 		docs: {
 			description: {
 				component:
-					'The "WordAds highlights" widget. Shows all-time WordAds payouts — total earnings, amount paid, and outstanding balance — as a grid of currency tiles (paid = earnings − outstanding). Ported from the Calypso WordAds "Totals" section. Which cards appear is controlled by the `metrics` attribute (`relevance: \'high\'`), exposed inline in the widget header and in the settings drawer. Data comes from the designated `useStatsWordAdsEarnings` hook; in Storybook it is served by `registerReportMocks()` (the `wordads/earnings` handler). The earnings module has no comparison period, so the tiles show bare amounts and the `WithComparison` story renders identically to `Default`.',
+					'The "WordAds highlights" widget. Shows all-time WordAds payouts — total earnings, amount paid, and outstanding balance — as a grid of currency tiles (paid = earnings − outstanding). Ported from the Calypso WordAds "Totals" section. Which cards appear is controlled by the `metrics` attribute (`relevance: \'high\'`), exposed inline in the widget header and in the settings drawer. Data comes from the designated `useStatsWordAdsEarnings` hook; in Storybook it is served by `registerReportMocks()` (the `wordads/earnings` handler).',
 			},
 		},
 	},
@@ -114,18 +105,7 @@ type Story = StoryObj< WordAdsHighlightsStoryControls >;
  */
 export const Default: Story = {
 	render: renderWordAdsHighlights,
-	args: { withComparison: false, ...ALL_METRICS_ARGS },
-	decorators: [ withWidgetCanvas ],
-};
-
-/**
- * Same close-up with comparison report params injected. The earnings module has
- * no comparison data, so this renders identically to `Default` — it only
- * verifies the widget stays stable when the host provides comparison params.
- */
-export const WithComparison: Story = {
-	render: renderWordAdsHighlights,
-	args: { withComparison: true, ...ALL_METRICS_ARGS },
+	args: { ...ALL_METRICS_ARGS },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -144,7 +124,7 @@ function resetWordAdsEarningsQuery() {
  */
 export const Loading: Story = {
 	render: renderWordAdsHighlights,
-	args: { withComparison: false, ...ALL_METRICS_ARGS },
+	args: { ...ALL_METRICS_ARGS },
 	// Off the shared autodocs page — path-keyed override; see forceStatsMockState.
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
@@ -164,7 +144,7 @@ export const Loading: Story = {
  */
 export const Error: Story = {
 	render: renderWordAdsHighlights,
-	args: { withComparison: false, ...ALL_METRICS_ARGS },
+	args: { ...ALL_METRICS_ARGS },
 	tags: [ '!autodocs' ],
 	decorators: [ withWidgetCanvas ],
 	beforeEach: () => {
@@ -185,7 +165,7 @@ export const Error: Story = {
  */
 export const Empty: Story = {
 	render: renderWordAdsHighlights,
-	args: { withComparison: false, metrics: [] },
+	args: { metrics: [] },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -200,7 +180,6 @@ interface WordAdsHighlightsDashboardStoryProps
  * @return The rendered dashboard with the widget.
  */
 function WordAdsHighlightsDashboardStory( {
-	withComparison,
 	metrics,
 	...dashboardArgs
 }: WordAdsHighlightsDashboardStoryProps ) {
@@ -211,7 +190,7 @@ function WordAdsHighlightsDashboardStory( {
 			renderModule={ WORDADS_HIGHLIGHTS_RENDER_MODULE }
 			renderComponent={ WordAdsHighlightsRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ {
-				reportParams: getDefaultQueryParams( withComparison ),
+				reportParams: getDefaultQueryParams( true ),
 				metrics,
 			} }
 		/>
@@ -224,12 +203,10 @@ export const WidgetDashboardWithWidget: StoryObj< WordAdsHighlightsDashboardStor
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 		widgetWidth: 1,
 		widgetHeight: 1,
-		withComparison: true,
 		...ALL_METRICS_ARGS,
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
-		withComparison: { control: 'boolean' },
 		...METRIC_ARG_TYPES,
 	},
 };


### PR DESCRIPTION
Fixes WOOA7S-1751

## Proposed changes

* Make `WithComparison` optional for widgets whose data hooks do not return comparison data consumed by their render path.
* Remove 16 no-op comparison stories and their unused controls.
* Keep coverage for comparison report parameters by enabling them in each affected dashboard story.
* Retain the Site Overview comparison story because its render path consumes `hasComparison` and comparison summary data.

This reduces duplicate Storybook entries that appeared to test comparison UI but rendered identically to the default story, while preserving coverage for host-supplied comparison parameters.

## Related product discussion/links

* WOOA7S-1751

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Review the Premium Analytics Storybook widget list and confirm the affected widgets no longer expose a `WithComparison` story or `withComparison` control.
* Open an affected `WidgetDashboardWithWidget` story and confirm the widget still renders with comparison report parameters.
* Open the Site Overview stories and confirm `WithComparison` remains available and displays period-over-period values.
