### PR TITLE
Premium Analytics: update widget helper copy and link Learn more to Stats support

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-widget-helper-content
+++ b/projects/packages/premium-analytics/changelog/update-widget-helper-content
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Update widget helper copy and link Learn more to Stats support.
+Widgets: update helper copy across the Traffic, Insights, and Subscribers widgets, and link "Learn more" out to Stats support.

--- a/projects/packages/premium-analytics/changelog/update-widget-helper-content
+++ b/projects/packages/premium-analytics/changelog/update-widget-helper-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update widget helper copy and link Learn more to Stats support.

--- a/projects/packages/premium-analytics/widgets/authors/widget.ts
+++ b/projects/packages/premium-analytics/widgets/authors/widget.ts
@@ -25,9 +25,15 @@ export default {
 	title: __( 'Authors', 'jetpack-premium-analytics' ),
 	help: {
 		content: __(
-			'Learn about your most popular authors to better understand how they contribute to grow your site.',
+			'The authors whose content received the most views.',
 			'jetpack-premium-analytics'
 		),
+		links: [
+			{
+				label: __( 'Learn more', 'jetpack-premium-analytics' ),
+				href: 'https://jetpack.com/support/jetpack-stats/',
+			},
+		],
 	},
 	icon: postAuthor,
 	attributes: [

--- a/projects/packages/premium-analytics/widgets/clicks/widget.ts
+++ b/projects/packages/premium-analytics/widgets/clicks/widget.ts
@@ -26,9 +26,15 @@ export default {
 	title: __( 'Clicks', 'jetpack-premium-analytics' ),
 	help: {
 		content: __(
-			'Most clicked external links to track engaging content.',
+			'The external links your visitors clicked most often, sorted by clicks.',
 			'jetpack-premium-analytics'
 		),
+		links: [
+			{
+				label: __( 'Learn more', 'jetpack-premium-analytics' ),
+				href: 'https://jetpack.com/support/jetpack-stats/',
+			},
+		],
 	},
 	icon: link,
 	attributes: [

--- a/projects/packages/premium-analytics/widgets/comments/widget.ts
+++ b/projects/packages/premium-analytics/widgets/comments/widget.ts
@@ -45,9 +45,15 @@ export default {
 	title: __( 'Comments', 'jetpack-premium-analytics' ),
 	help: {
 		content: __(
-			'Learn about the comments your site receives by authors, posts, and pages.',
+			'A breakdown of comments, grouped by author and by post or page.',
 			'jetpack-premium-analytics'
 		),
+		links: [
+			{
+				label: __( 'Learn more', 'jetpack-premium-analytics' ),
+				href: 'https://jetpack.com/support/jetpack-stats/',
+			},
+		],
 	},
 	icon: comment,
 	attributes: [

--- a/projects/packages/premium-analytics/widgets/devices/widget.ts
+++ b/projects/packages/premium-analytics/widgets/devices/widget.ts
@@ -27,9 +27,15 @@ export default {
 	title: __( 'Devices', 'jetpack-premium-analytics' ),
 	help: {
 		content: __(
-			'The devices and browsers your visitors use to access your website.',
+			'A breakdown of the device types your visitors used, sorted by views.',
 			'jetpack-premium-analytics'
 		),
+		links: [
+			{
+				label: __( 'Learn more', 'jetpack-premium-analytics' ),
+				href: 'https://jetpack.com/support/jetpack-stats/',
+			},
+		],
 	},
 	icon: desktop,
 	attributes: [

--- a/projects/packages/premium-analytics/widgets/emails/widget.ts
+++ b/projects/packages/premium-analytics/widgets/emails/widget.ts
@@ -45,7 +45,10 @@ export default {
 	name: 'jpa/stats-emails',
 	title: __( 'Emails', 'jetpack-premium-analytics' ),
 	help: {
-		content: __( 'Latest emails sent and their performance.', 'jetpack-premium-analytics' ),
+		content: __(
+			'Your most recently sent emails, including their open and click rates.',
+			'jetpack-premium-analytics'
+		),
 	},
 	icon: envelope,
 	attributes: [

--- a/projects/packages/premium-analytics/widgets/file-downloads/widget.ts
+++ b/projects/packages/premium-analytics/widgets/file-downloads/widget.ts
@@ -26,7 +26,16 @@ export default {
 	name: 'jpa/file-downloads',
 	title: __( 'File downloads', 'jetpack-premium-analytics' ),
 	help: {
-		content: __( 'Most downloaded files from your site.', 'jetpack-premium-analytics' ),
+		content: __(
+			'The files your visitors downloaded most often, sorted by number of downloads.',
+			'jetpack-premium-analytics'
+		),
+		links: [
+			{
+				label: __( 'Learn more', 'jetpack-premium-analytics' ),
+				href: 'https://jetpack.com/support/jetpack-stats/',
+			},
+		],
 	},
 	icon: download,
 	attributes: [

--- a/projects/packages/premium-analytics/widgets/locations/widget.ts
+++ b/projects/packages/premium-analytics/widgets/locations/widget.ts
@@ -36,9 +36,15 @@ export default {
 	title: __( 'Locations', 'jetpack-premium-analytics' ),
 	help: {
 		content: __(
-			'Visitors’ viewing location by countries, regions and cities.',
+			'The countries, regions, and cities where your visitors came from, sorted by views.',
 			'jetpack-premium-analytics'
 		),
+		links: [
+			{
+				label: __( 'Learn more', 'jetpack-premium-analytics' ),
+				href: 'https://jetpack.com/support/jetpack-stats/',
+			},
+		],
 	},
 	icon: mapMarker,
 	attributes: [

--- a/projects/packages/premium-analytics/widgets/posting-activity/widget.ts
+++ b/projects/packages/premium-analytics/widgets/posting-activity/widget.ts
@@ -23,7 +23,7 @@ export default {
 	title: __( 'Posting activity', 'jetpack-premium-analytics' ),
 	help: {
 		content: __(
-			'How often you publish — a calendar heatmap of posts per day.',
+			'Your posting activity, shown as a heatmap to help you spot your most and least active days.',
 			'jetpack-premium-analytics'
 		),
 	},

--- a/projects/packages/premium-analytics/widgets/referrers/widget.ts
+++ b/projects/packages/premium-analytics/widgets/referrers/widget.ts
@@ -25,9 +25,15 @@ export default {
 	title: __( 'Referrers', 'jetpack-premium-analytics' ),
 	help: {
 		content: __(
-			'Websites referring visitors sorted by most clicked. Learn about where your audience comes from.',
+			'The sources that sent the most visitors to your site, sorted by clicks.',
 			'jetpack-premium-analytics'
 		),
+		links: [
+			{
+				label: __( 'Learn more', 'jetpack-premium-analytics' ),
+				href: 'https://jetpack.com/support/jetpack-stats/',
+			},
+		],
 	},
 	icon: globe,
 	attributes: [

--- a/projects/packages/premium-analytics/widgets/search-terms/widget.ts
+++ b/projects/packages/premium-analytics/widgets/search-terms/widget.ts
@@ -26,9 +26,15 @@ export default {
 	title: __( 'Search Terms', 'jetpack-premium-analytics' ),
 	help: {
 		content: __(
-			'Learn about popular terms visitors use to find your site content on search engines.',
+			'The most popular search terms visitors used to find your site.',
 			'jetpack-premium-analytics'
 		),
+		links: [
+			{
+				label: __( 'Learn more', 'jetpack-premium-analytics' ),
+				href: 'https://jetpack.com/support/jetpack-stats/',
+			},
+		],
 	},
 	icon: search,
 	attributes: [

--- a/projects/packages/premium-analytics/widgets/shares/widget.ts
+++ b/projects/packages/premium-analytics/widgets/shares/widget.ts
@@ -27,7 +27,7 @@ export default {
 	title: __( 'Shares', 'jetpack-premium-analytics' ),
 	help: {
 		content: __(
-			'Learn where your content has been shared the most.',
+			'The platforms where your content was shared most often, sorted by number of shares.',
 			'jetpack-premium-analytics'
 		),
 	},

--- a/projects/packages/premium-analytics/widgets/site-overview/widget.ts
+++ b/projects/packages/premium-analytics/widgets/site-overview/widget.ts
@@ -61,7 +61,7 @@ export default {
 	title: __( 'Site overview', 'jetpack-premium-analytics' ),
 	help: {
 		content: __(
-			'Views, visitors, likes, and comments for the selected period, with period-over-period change.',
+			"A summary of your site's views, visitors, likes, and comments, with period-over-period change.",
 			'jetpack-premium-analytics'
 		),
 	},

--- a/projects/packages/premium-analytics/widgets/subscriber-highlights/widget.ts
+++ b/projects/packages/premium-analytics/widgets/subscriber-highlights/widget.ts
@@ -58,7 +58,7 @@ export default {
 	title: __( 'Subscriber highlights', 'jetpack-premium-analytics' ),
 	help: {
 		content: __(
-			'Your subscriber totals at a glance — total, paid, free, and social followers.',
+			'A summary of your subscribers — total, paid, free, and social followers.',
 			'jetpack-premium-analytics'
 		),
 	},

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/widget.ts
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/widget.ts
@@ -69,7 +69,7 @@ export default {
 	title: __( 'Subscribers', 'jetpack-premium-analytics' ),
 	help: {
 		content: __(
-			'Track subscriber growth over time, with paid subscribers and the previous period overlaid for comparison.',
+			'A summary of the new subscribers you gained over time, with paid subscribers overlaid.',
 			'jetpack-premium-analytics'
 		),
 	},

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/widget.ts
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/widget.ts
@@ -69,7 +69,7 @@ export default {
 	title: __( 'Subscribers', 'jetpack-premium-analytics' ),
 	help: {
 		content: __(
-			'A summary of the new subscribers you gained over time, with paid subscribers overlaid.',
+			'A summary of your subscriber growth over time, with paid subscribers and the previous period overlaid for comparison.',
 			'jetpack-premium-analytics'
 		),
 	},

--- a/projects/packages/premium-analytics/widgets/tags/widget.ts
+++ b/projects/packages/premium-analytics/widgets/tags/widget.ts
@@ -27,9 +27,15 @@ export default {
 	title: __( 'Tags & categories', 'jetpack-premium-analytics' ),
 	help: {
 		content: __(
-			'Most visited tags & categories. Learn about the most engaging topics.',
+			'The tags and categories associated with your most-viewed content, sorted by views.',
 			'jetpack-premium-analytics'
 		),
+		links: [
+			{
+				label: __( 'Learn more', 'jetpack-premium-analytics' ),
+				href: 'https://jetpack.com/support/jetpack-stats/',
+			},
+		],
 	},
 	icon: tag,
 	attributes: [

--- a/projects/packages/premium-analytics/widgets/top-platforms/widget.ts
+++ b/projects/packages/premium-analytics/widgets/top-platforms/widget.ts
@@ -33,9 +33,15 @@ export default {
 	title: __( 'Top Platforms', 'jetpack-premium-analytics' ),
 	help: {
 		content: __(
-			'Top browsers and operating systems your visitors use.',
+			'A breakdown of the operating systems and browsers your visitors used, sorted by views.',
 			'jetpack-premium-analytics'
 		),
+		links: [
+			{
+				label: __( 'Learn more', 'jetpack-premium-analytics' ),
+				href: 'https://jetpack.com/support/jetpack-stats/',
+			},
+		],
 	},
 	icon: chartBar,
 	attributes: [

--- a/projects/packages/premium-analytics/widgets/top-posts/widget.ts
+++ b/projects/packages/premium-analytics/widgets/top-posts/widget.ts
@@ -45,9 +45,15 @@ export default {
 	title: __( 'Most viewed', 'jetpack-premium-analytics' ),
 	help: {
 		content: __(
-			'Most viewed posts, pages and archive. Learn about what content resonates the most.',
+			'Your most popular posts and pages, sorted by views.',
 			'jetpack-premium-analytics'
 		),
+		links: [
+			{
+				label: __( 'Learn more', 'jetpack-premium-analytics' ),
+				href: 'https://jetpack.com/support/jetpack-stats/',
+			},
+		],
 	},
 	icon: postList,
 	attributes: [

--- a/projects/packages/premium-analytics/widgets/traffic-chart/widget.ts
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/widget.ts
@@ -72,7 +72,7 @@ export default {
 	title: __( 'Traffic', 'jetpack-premium-analytics' ),
 	help: {
 		content: __(
-			'Compare views, visitors, likes, and comments over the selected period, with the previous period overlaid for comparison.',
+			"A summary of your site's views, visitors, likes, and comments, with the previous period overlaid for comparison.",
 			'jetpack-premium-analytics'
 		),
 	},

--- a/projects/packages/premium-analytics/widgets/utm-insights/widget.ts
+++ b/projects/packages/premium-analytics/widgets/utm-insights/widget.ts
@@ -34,10 +34,13 @@ export default {
 	name: 'jpa/utm-insights',
 	title: __( 'UTM Insights', 'jetpack-premium-analytics' ),
 	help: {
-		content: __(
-			'Track your campaign UTM performance data. Generate URL codes with our builder.',
-			'jetpack-premium-analytics'
-		),
+		content: __( 'Your top UTM campaigns, sorted by views.', 'jetpack-premium-analytics' ),
+		links: [
+			{
+				label: __( 'Learn more', 'jetpack-premium-analytics' ),
+				href: 'https://jetpack.com/support/jetpack-stats/',
+			},
+		],
 	},
 	icon: trendingUp,
 	attributes: [

--- a/projects/packages/premium-analytics/widgets/videopress/widget.ts
+++ b/projects/packages/premium-analytics/widgets/videopress/widget.ts
@@ -32,9 +32,15 @@ export default {
 	title: __( 'VideoPress', 'jetpack-premium-analytics' ),
 	help: {
 		content: __(
-			'Most popular videos uploaded to your site. Learn more about their performance.',
+			'The published videos your visitors watched most often, sorted by views.',
 			'jetpack-premium-analytics'
 		),
+		links: [
+			{
+				label: __( 'Learn more', 'jetpack-premium-analytics' ),
+				href: 'https://jetpack.com/support/jetpack-stats/',
+			},
+		],
 	},
 	icon: video,
 	attributes: [


### PR DESCRIPTION
Fixes WOOA7S-1752

## Proposed changes

Updates the helper tooltip copy on 20 Premium Analytics widgets 

* **13 widgets get new copy plus a "Learn more" link** — `top-posts`, `referrers`, `locations`, `utm-insights`, `clicks`, `authors`, `search-terms`, `videopress`, `file-downloads`, `devices`, `top-platforms`, `tags`, `comments`.
* **7 get new copy only** — `posting-activity`, `shares`, `emails`, `site-overview`, `traffic-chart`, `subscribers-chart`, `subscriber-highlights`.
* **No WooCommerce changes** — all 22 spreadsheet rows already matched the shipped copy verbatim, as did `subscribers-list`.

**Where this deviates from the spreadsheet:**

* **Both "Summary" rows fit two widgets each**, so both were updated, keeping each one's distinguishing clause rather than showing two identical tooltips on one tab.
* **`subscribers-chart` deviates from the sheet on purpose.** The sheet says subscribers *gained*, but the widget plots a *cumulative* series (`render.tsx`: "each point is the cumulative count as of that period, so the headline value is the last point, not a sum"). Taken literally it would misreport growth by orders of magnitude, so it reads "growth".
* **UTM ships the "Learn more" link only.** The sheet asks for "Learn more or generate a new URL", but the URL builder is an in-app affordance and `help.links` only takes an `href`. Follow-up.

**Rows not implemented.** The spreadsheet was compiled against the design demo site, whose widget set differs from the current package, so these have nothing to map onto: **Total views**, **Total visitors**, **Total words** (no such widgets), **Traffic views activity** (no site-level daily-views heatmap), and **Popular days** (`most-popular-day` measures the single all-time top day, not weekday averages — a different metric). 

## Related product discussion/links

* WOOA7S-1752

## Does this pull request change what data or activity we track or use?

No. Copy-only, plus outbound links to the public Jetpack Stats support page.

## Testing instructions

Strings-only change, no runtime logic.


* `pnpm storybook`, open any changed widget under **Packages/Premium Analytics/Widgets/** using the `WidgetDashboardWithWidget` story (it mounts the real dashboard, so the real header and infotip render), and click the ⓘ beside the title.
  * Copy should match the spreadsheet's Adjusted column.
  * On a linked widget (e.g. **TopPosts**), "Learn more" should be an actual link to `https://jetpack.com/support/jetpack-stats/` — not plain text.
  * Each Summary pair should read differently: `site-overview` vs `traffic-chart`, `subscribers-chart` vs `subscriber-highlights`.

