### PR TITLE
Premium Analytics: consolidate Stats data helpers

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1750-stats-data-helpers
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1750-stats-data-helpers
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Consolidate internal Stats list hook and comparison tree helpers. No user-facing change.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/use-stats-report.test.tsx
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/use-stats-report.test.tsx
@@ -6,7 +6,7 @@ import { renderHook } from '@testing-library/react';
 /**
  * Internal dependencies
  */
-import { createStatsListReportHook } from '../use-stats-report';
+import { createStatsListReportHook, splitStatsListOptions } from '../use-stats-report';
 import type { StatsReportParams } from '../../queries/stats-query';
 import type { UseStatsOptions } from '../use-stats-report';
 import type { ReactNode } from 'react';
@@ -17,26 +17,57 @@ type TestOptions = UseStatsOptions & {
 	group?: string;
 };
 
-function wrapper( { children }: { children: ReactNode } ) {
-	const queryClient = new QueryClient( {
-		defaultOptions: {
-			queries: {
-				retry: false,
-				queryFn: async () => ( { value: 0 } ),
-			},
+// Built once per file: a client rebuilt inside `wrapper` would be discarded on
+// every rerender, so any test that actually fetches would miss its own cache.
+const queryClient = new QueryClient( {
+	defaultOptions: {
+		queries: {
+			retry: false,
+			queryFn: async () => ( { value: 0 } ),
 		},
-	} );
+	},
+} );
 
+function wrapper( { children }: { children: ReactNode } ) {
 	return <QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>;
 }
 
+const params: StatsReportParams = {
+	from: '2026-07-01',
+	to: '2026-07-07',
+	interval: 'day',
+};
+
+const queryFactory = ( queryParams: StatsReportParams ): UseQueryOptions< TestReport > => ( {
+	queryKey: [ 'test-stats-list', queryParams.from, queryParams.to ],
+	queryFn: async () => ( { value: 1 } ),
+	enabled: false,
+} );
+
 describe( 'createStatsListReportHook', () => {
-	it( 'forwards list options and keeps the comparison mapper stable', () => {
-		const queryFactory = ( params: StatsReportParams ): UseQueryOptions< TestReport > => ( {
-			queryKey: [ 'test-stats-list', params.from, params.to ],
-			queryFn: async () => ( { value: 1 } ),
-			enabled: false,
+	it( 'forwards maxRows through splitStatsListOptions when a module has no merge option', () => {
+		const mergeComparisonRows = jest.fn( () => ( {
+			rows: [],
+			hasComparison: false,
+		} ) );
+		const useTestStatsList = createStatsListReportHook<
+			StatsReportParams,
+			TestReport,
+			unknown,
+			TestOptions
+		>( {
+			queryFactory,
+			reportSlug: 'test-default-list',
+			mergeComparisonRows,
+			getOptions: splitStatsListOptions,
 		} );
+
+		renderHook( () => useTestStatsList( params, { enabled: false, maxRows: 3 } ), { wrapper } );
+
+		expect( mergeComparisonRows ).toHaveBeenLastCalledWith( undefined, undefined, 3, undefined );
+	} );
+
+	it( 'forwards list options and keeps the comparison mapper stable', () => {
 		const mergeComparisonRows = jest.fn( () => ( {
 			rows: [],
 			hasComparison: false,
@@ -57,11 +88,6 @@ describe( 'createStatsListReportHook', () => {
 				return { queryOptions, maxRows, mergeOption: group };
 			},
 		} );
-		const params: StatsReportParams = {
-			from: '2026-07-01',
-			to: '2026-07-07',
-			interval: 'day',
-		};
 		const { rerender } = renderHook(
 			( { maxRows } ) =>
 				useTestStatsList( params, {

--- a/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/use-stats-report.test.tsx
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/__tests__/use-stats-report.test.tsx
@@ -1,0 +1,88 @@
+/**
+ * External dependencies
+ */
+import { QueryClient, QueryClientProvider, type UseQueryOptions } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import { createStatsListReportHook } from '../use-stats-report';
+import type { StatsReportParams } from '../../queries/stats-query';
+import type { UseStatsOptions } from '../use-stats-report';
+import type { ReactNode } from 'react';
+
+type TestReport = { value: number };
+type TestOptions = UseStatsOptions & {
+	maxRows?: number;
+	group?: string;
+};
+
+function wrapper( { children }: { children: ReactNode } ) {
+	const queryClient = new QueryClient( {
+		defaultOptions: {
+			queries: {
+				retry: false,
+				queryFn: async () => ( { value: 0 } ),
+			},
+		},
+	} );
+
+	return <QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>;
+}
+
+describe( 'createStatsListReportHook', () => {
+	it( 'forwards list options and keeps the comparison mapper stable', () => {
+		const queryFactory = ( params: StatsReportParams ): UseQueryOptions< TestReport > => ( {
+			queryKey: [ 'test-stats-list', params.from, params.to ],
+			queryFn: async () => ( { value: 1 } ),
+			enabled: false,
+		} );
+		const mergeComparisonRows = jest.fn( () => ( {
+			rows: [],
+			hasComparison: false,
+		} ) );
+		const useTestStatsList = createStatsListReportHook<
+			StatsReportParams,
+			TestReport,
+			unknown,
+			TestOptions,
+			string | undefined
+		>( {
+			queryFactory,
+			reportSlug: 'test-list',
+			mergeComparisonRows,
+			getOptions: options => {
+				const { maxRows, group, ...queryOptions } = options ?? {};
+
+				return { queryOptions, maxRows, mergeOption: group };
+			},
+		} );
+		const params: StatsReportParams = {
+			from: '2026-07-01',
+			to: '2026-07-07',
+			interval: 'day',
+		};
+		const { rerender } = renderHook(
+			( { maxRows } ) =>
+				useTestStatsList( params, {
+					enabled: false,
+					maxRows,
+					group: 'posts',
+				} ),
+			{
+				initialProps: { maxRows: 2 },
+				wrapper,
+			}
+		);
+
+		expect( mergeComparisonRows ).toHaveBeenLastCalledWith( undefined, undefined, 2, 'posts' );
+		expect( mergeComparisonRows ).toHaveBeenCalledTimes( 1 );
+
+		rerender( { maxRows: 2 } );
+		expect( mergeComparisonRows ).toHaveBeenCalledTimes( 1 );
+
+		rerender( { maxRows: 0 } );
+		expect( mergeComparisonRows ).toHaveBeenLastCalledWith( undefined, undefined, 0, 'posts' );
+		expect( mergeComparisonRows ).toHaveBeenCalledTimes( 2 );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-archives.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-archives.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { useCallback } from 'react';
-/**
  * Internal dependencies
  */
 import { mergeStatsArchivesComparisonRows } from '../processing/stats';
 import { statsArchivesQuery } from '../queries/stats-archives-query';
-import { useStatsReport } from './use-stats-report';
+import { createStatsListReportHook } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type {
 	StatsArchivesComparisonItem,
@@ -22,22 +18,13 @@ type StatsArchivesOptions = UseStatsOptions & {
 	maxRows?: number;
 };
 
-export function useStatsArchives( params: StatsReportParams, options?: StatsArchivesOptions ) {
-	const { maxRows, ...queryOptions } = options ?? {};
-	const mergeComparisonRows = useCallback(
-		(
-			primary?: StatsNormalizedReport< StatsArchivesItem >,
-			comparison?: StatsNormalizedReport< StatsArchivesItem >
-		) => mergeStatsArchivesComparisonRows( primary, comparison, maxRows ),
-		[ maxRows ]
-	);
-
-	return useStatsReport<
-		StatsReportParams,
-		StatsNormalizedReport< StatsArchivesItem >,
-		StatsArchivesComparisonItem
-	>( statsArchivesQuery, params, 'archives', {
-		...queryOptions,
-		mergeComparisonRows,
-	} );
-}
+export const useStatsArchives = createStatsListReportHook<
+	StatsReportParams,
+	StatsNormalizedReport< StatsArchivesItem >,
+	StatsArchivesComparisonItem,
+	StatsArchivesOptions
+>( {
+	queryFactory: statsArchivesQuery,
+	reportSlug: 'archives',
+	mergeComparisonRows: mergeStatsArchivesComparisonRows,
+} );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-archives.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-archives.ts
@@ -3,7 +3,7 @@
  */
 import { mergeStatsArchivesComparisonRows } from '../processing/stats';
 import { statsArchivesQuery } from '../queries/stats-archives-query';
-import { createStatsListReportHook } from './use-stats-report';
+import { createStatsListReportHook, splitStatsListOptions } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type {
 	StatsArchivesComparisonItem,
@@ -27,4 +27,5 @@ export const useStatsArchives = createStatsListReportHook<
 	queryFactory: statsArchivesQuery,
 	reportSlug: 'archives',
 	mergeComparisonRows: mergeStatsArchivesComparisonRows,
+	getOptions: splitStatsListOptions,
 } );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-clicks.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-clicks.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { useCallback } from 'react';
-/**
  * Internal dependencies
  */
 import { mergeStatsClicksComparisonRows } from '../processing/stats';
 import { statsClicksQuery } from '../queries/stats-clicks-query';
-import { useStatsReport } from './use-stats-report';
+import { createStatsListReportHook } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type {
 	StatsClicksComparisonItem,
@@ -20,22 +16,13 @@ type StatsClicksOptions = UseStatsOptions & {
 	maxRows?: number;
 };
 
-export function useStatsClicks( params: StatsReportParams, options?: StatsClicksOptions ) {
-	const { maxRows, ...queryOptions } = options ?? {};
-	const mergeComparisonRows = useCallback(
-		(
-			primary?: StatsNormalizedReport< StatsClicksItem >,
-			comparison?: StatsNormalizedReport< StatsClicksItem >
-		) => mergeStatsClicksComparisonRows( primary, comparison, maxRows ),
-		[ maxRows ]
-	);
-
-	return useStatsReport<
-		StatsReportParams,
-		StatsNormalizedReport< StatsClicksItem >,
-		StatsClicksComparisonItem
-	>( statsClicksQuery, params, 'clicks', {
-		...queryOptions,
-		mergeComparisonRows,
-	} );
-}
+export const useStatsClicks = createStatsListReportHook<
+	StatsReportParams,
+	StatsNormalizedReport< StatsClicksItem >,
+	StatsClicksComparisonItem,
+	StatsClicksOptions
+>( {
+	queryFactory: statsClicksQuery,
+	reportSlug: 'clicks',
+	mergeComparisonRows: mergeStatsClicksComparisonRows,
+} );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-clicks.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-clicks.ts
@@ -3,7 +3,7 @@
  */
 import { mergeStatsClicksComparisonRows } from '../processing/stats';
 import { statsClicksQuery } from '../queries/stats-clicks-query';
-import { createStatsListReportHook } from './use-stats-report';
+import { createStatsListReportHook, splitStatsListOptions } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type {
 	StatsClicksComparisonItem,
@@ -25,4 +25,5 @@ export const useStatsClicks = createStatsListReportHook<
 	queryFactory: statsClicksQuery,
 	reportSlug: 'clicks',
 	mergeComparisonRows: mergeStatsClicksComparisonRows,
+	getOptions: splitStatsListOptions,
 } );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-devices.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-devices.ts
@@ -3,7 +3,7 @@
  */
 import { mergeStatsDevicesComparisonRows } from '../processing/stats';
 import { statsDevicesQuery, type StatsDeviceProperty } from '../queries/stats-devices-query';
-import { createStatsListReportHook } from './use-stats-report';
+import { createStatsListReportHook, splitStatsListOptions } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type {
 	StatsDevicesComparisonItem,
@@ -28,6 +28,7 @@ const useStatsDevicesReport = createStatsListReportHook<
 	queryFactory: statsDevicesQuery,
 	reportSlug: 'devices',
 	mergeComparisonRows: mergeStatsDevicesComparisonRows,
+	getOptions: splitStatsListOptions,
 } );
 
 export function useStatsDevices( params: StatsDevicesParams, options?: StatsDevicesOptions ) {

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-devices.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-devices.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { useCallback } from 'react';
-/**
  * Internal dependencies
  */
 import { mergeStatsDevicesComparisonRows } from '../processing/stats';
 import { statsDevicesQuery, type StatsDeviceProperty } from '../queries/stats-devices-query';
-import { useStatsReport } from './use-stats-report';
+import { createStatsListReportHook } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type {
 	StatsDevicesComparisonItem,
@@ -23,27 +19,20 @@ type StatsDevicesOptions = UseStatsOptions & {
 	maxRows?: number;
 };
 
-export function useStatsDevices( params: StatsDevicesParams, options?: StatsDevicesOptions ) {
-	const { maxRows, ...queryOptions } = options ?? {};
-	const mergeComparisonRows = useCallback(
-		(
-			primary?: StatsNormalizedReport< StatsDevicesItem >,
-			comparison?: StatsNormalizedReport< StatsDevicesItem >
-		) => mergeStatsDevicesComparisonRows( primary, comparison, maxRows ),
-		[ maxRows ]
-	);
+const useStatsDevicesReport = createStatsListReportHook<
+	StatsReportParams & { deviceProperty?: StatsDeviceProperty },
+	StatsNormalizedReport< StatsDevicesItem >,
+	StatsDevicesComparisonItem,
+	StatsDevicesOptions
+>( {
+	queryFactory: statsDevicesQuery,
+	reportSlug: 'devices',
+	mergeComparisonRows: mergeStatsDevicesComparisonRows,
+} );
 
-	return useStatsReport<
-		StatsReportParams & { deviceProperty?: StatsDeviceProperty },
-		StatsNormalizedReport< StatsDevicesItem >,
-		StatsDevicesComparisonItem
-	>(
-		statsDevicesQuery,
+export function useStatsDevices( params: StatsDevicesParams, options?: StatsDevicesOptions ) {
+	return useStatsDevicesReport(
 		params as StatsReportParams & { deviceProperty?: StatsDeviceProperty },
-		'devices',
-		{
-			...queryOptions,
-			mergeComparisonRows,
-		}
+		options
 	);
 }

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-file-downloads.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-file-downloads.ts
@@ -3,7 +3,7 @@
  */
 import { mergeStatsFileDownloadsComparisonRows } from '../processing/stats';
 import { statsFileDownloadsQuery } from '../queries/stats-file-downloads-query';
-import { createStatsListReportHook } from './use-stats-report';
+import { createStatsListReportHook, splitStatsListOptions } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type {
 	StatsFileDownloadsComparisonItem,
@@ -25,4 +25,5 @@ export const useStatsFileDownloads = createStatsListReportHook<
 	queryFactory: statsFileDownloadsQuery,
 	reportSlug: 'file-downloads',
 	mergeComparisonRows: mergeStatsFileDownloadsComparisonRows,
+	getOptions: splitStatsListOptions,
 } );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-file-downloads.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-file-downloads.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { useCallback } from 'react';
-/**
  * Internal dependencies
  */
 import { mergeStatsFileDownloadsComparisonRows } from '../processing/stats';
 import { statsFileDownloadsQuery } from '../queries/stats-file-downloads-query';
-import { useStatsReport } from './use-stats-report';
+import { createStatsListReportHook } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type {
 	StatsFileDownloadsComparisonItem,
@@ -20,25 +16,13 @@ type StatsFileDownloadsOptions = UseStatsOptions & {
 	maxRows?: number;
 };
 
-export function useStatsFileDownloads(
-	params: StatsReportParams,
-	options?: StatsFileDownloadsOptions
-) {
-	const { maxRows, ...queryOptions } = options ?? {};
-	const mergeComparisonRows = useCallback(
-		(
-			primary?: StatsNormalizedReport< StatsFileDownloadsItem >,
-			comparison?: StatsNormalizedReport< StatsFileDownloadsItem >
-		) => mergeStatsFileDownloadsComparisonRows( primary, comparison, maxRows ),
-		[ maxRows ]
-	);
-
-	return useStatsReport<
-		StatsReportParams,
-		StatsNormalizedReport< StatsFileDownloadsItem >,
-		StatsFileDownloadsComparisonItem
-	>( statsFileDownloadsQuery, params, 'file-downloads', {
-		...queryOptions,
-		mergeComparisonRows,
-	} );
-}
+export const useStatsFileDownloads = createStatsListReportHook<
+	StatsReportParams,
+	StatsNormalizedReport< StatsFileDownloadsItem >,
+	StatsFileDownloadsComparisonItem,
+	StatsFileDownloadsOptions
+>( {
+	queryFactory: statsFileDownloadsQuery,
+	reportSlug: 'file-downloads',
+	mergeComparisonRows: mergeStatsFileDownloadsComparisonRows,
+} );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-locations.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-locations.ts
@@ -3,7 +3,7 @@
  */
 import { mergeStatsLocationsComparisonRows } from '../processing/stats';
 import { statsLocationsQuery } from '../queries/stats-locations-query';
-import { createStatsListReportHook } from './use-stats-report';
+import { createStatsListReportHook, splitStatsListOptions } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type {
 	StatsLocationsComparisonItem,
@@ -25,4 +25,5 @@ export const useStatsLocations = createStatsListReportHook<
 	queryFactory: statsLocationsQuery,
 	reportSlug: 'locations',
 	mergeComparisonRows: mergeStatsLocationsComparisonRows,
+	getOptions: splitStatsListOptions,
 } );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-locations.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-locations.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { useCallback } from 'react';
-/**
  * Internal dependencies
  */
 import { mergeStatsLocationsComparisonRows } from '../processing/stats';
 import { statsLocationsQuery } from '../queries/stats-locations-query';
-import { useStatsReport } from './use-stats-report';
+import { createStatsListReportHook } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type {
 	StatsLocationsComparisonItem,
@@ -20,25 +16,13 @@ type StatsLocationsOptions = UseStatsOptions & {
 	maxRows?: number;
 };
 
-export function useStatsLocations(
-	params: StatsReportParams & { geoMode?: 'country' | 'region' | 'city' },
-	options?: StatsLocationsOptions
-) {
-	const { maxRows, ...queryOptions } = options ?? {};
-	const mergeComparisonRows = useCallback(
-		(
-			primary?: StatsNormalizedReport< StatsLocationsItem >,
-			comparison?: StatsNormalizedReport< StatsLocationsItem >
-		) => mergeStatsLocationsComparisonRows( primary, comparison, maxRows ),
-		[ maxRows ]
-	);
-
-	return useStatsReport<
-		StatsReportParams & { geoMode?: 'country' | 'region' | 'city' },
-		StatsNormalizedReport< StatsLocationsItem >,
-		StatsLocationsComparisonItem
-	>( statsLocationsQuery, params, 'locations', {
-		...queryOptions,
-		mergeComparisonRows,
-	} );
-}
+export const useStatsLocations = createStatsListReportHook<
+	StatsReportParams & { geoMode?: 'country' | 'region' | 'city' },
+	StatsNormalizedReport< StatsLocationsItem >,
+	StatsLocationsComparisonItem,
+	StatsLocationsOptions
+>( {
+	queryFactory: statsLocationsQuery,
+	reportSlug: 'locations',
+	mergeComparisonRows: mergeStatsLocationsComparisonRows,
+} );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-referrers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-referrers.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { useCallback } from 'react';
-/**
  * Internal dependencies
  */
 import { mergeStatsReferrersComparisonRows } from '../processing/stats';
 import { statsReferrersQuery } from '../queries/stats-referrers-query';
-import { useStatsReport } from './use-stats-report';
+import { createStatsListReportHook } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type {
 	StatsNormalizedReport,
@@ -20,22 +16,13 @@ type StatsReferrersOptions = UseStatsOptions & {
 	maxRows?: number;
 };
 
-export function useStatsReferrers( params: StatsReportParams, options?: StatsReferrersOptions ) {
-	const { maxRows, ...queryOptions } = options ?? {};
-	const mergeComparisonRows = useCallback(
-		(
-			primary?: StatsNormalizedReport< StatsReferrersItem >,
-			comparison?: StatsNormalizedReport< StatsReferrersItem >
-		) => mergeStatsReferrersComparisonRows( primary, comparison, maxRows ),
-		[ maxRows ]
-	);
-
-	return useStatsReport<
-		StatsReportParams,
-		StatsNormalizedReport< StatsReferrersItem >,
-		StatsReferrersComparisonItem
-	>( statsReferrersQuery, params, 'referrers', {
-		...queryOptions,
-		mergeComparisonRows,
-	} );
-}
+export const useStatsReferrers = createStatsListReportHook<
+	StatsReportParams,
+	StatsNormalizedReport< StatsReferrersItem >,
+	StatsReferrersComparisonItem,
+	StatsReferrersOptions
+>( {
+	queryFactory: statsReferrersQuery,
+	reportSlug: 'referrers',
+	mergeComparisonRows: mergeStatsReferrersComparisonRows,
+} );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-referrers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-referrers.ts
@@ -3,7 +3,7 @@
  */
 import { mergeStatsReferrersComparisonRows } from '../processing/stats';
 import { statsReferrersQuery } from '../queries/stats-referrers-query';
-import { createStatsListReportHook } from './use-stats-report';
+import { createStatsListReportHook, splitStatsListOptions } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type {
 	StatsNormalizedReport,
@@ -25,4 +25,5 @@ export const useStatsReferrers = createStatsListReportHook<
 	queryFactory: statsReferrersQuery,
 	reportSlug: 'referrers',
 	mergeComparisonRows: mergeStatsReferrersComparisonRows,
+	getOptions: splitStatsListOptions,
 } );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-report.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-report.ts
@@ -31,7 +31,7 @@ type StatsReportQueryFactory< TParams extends StatsReportParams, TData > = (
 	params: TParams
 ) => UseQueryOptions< TData >;
 
-type StatsListReportOptions = UseStatsOptions & {
+export type StatsListReportOptions = UseStatsOptions & {
 	maxRows?: number;
 };
 
@@ -50,12 +50,32 @@ type StatsListReportHookConfig<
 		maxRows: number | undefined,
 		mergeOption: TMergeOption
 	) => StatsComparisonRowsResult< TComparisonRow >;
-	getOptions?: ( options: TOptions | undefined ) => {
+	// Required so that narrowing `TMergeOption` cannot leave the merge callback
+	// receiving an `undefined` the type says is impossible. Modules with no merge
+	// option pass `splitStatsListOptions`.
+	getOptions: ( options: TOptions | undefined ) => {
 		queryOptions: UseStatsOptions;
 		maxRows?: number;
 		mergeOption: TMergeOption;
 	};
 };
+
+/**
+ * The `getOptions` mapper for list reports whose merge helper takes no extra option:
+ * splits `maxRows` off the query options and leaves the merge option undefined.
+ *
+ * @param options - The hook's caller options.
+ * @return The split query options, row cap, and (absent) merge option.
+ */
+export function splitStatsListOptions( options: StatsListReportOptions | undefined ): {
+	queryOptions: UseStatsOptions;
+	maxRows?: number;
+	mergeOption: undefined;
+} {
+	const { maxRows, ...queryOptions } = options ?? {};
+
+	return { queryOptions, maxRows, mergeOption: undefined };
+}
 
 export function createStatsListReportHook<
 	TParams extends StatsReportParams,
@@ -70,18 +90,7 @@ export function createStatsListReportHook<
 	getOptions,
 }: StatsListReportHookConfig< TParams, TData, TComparisonRow, TOptions, TMergeOption > ) {
 	return function useStatsListReport( params: TParams, options?: TOptions ) {
-		const defaultOptions = () => {
-			const { maxRows, ...queryOptions } = options ?? {};
-
-			return {
-				queryOptions,
-				maxRows,
-				mergeOption: undefined as TMergeOption,
-			};
-		};
-		const { queryOptions, maxRows, mergeOption } = getOptions
-			? getOptions( options )
-			: defaultOptions();
+		const { queryOptions, maxRows, mergeOption } = getOptions( options );
 		const mergeComparisonRows = useCallback(
 			( primaryReport?: TData, comparisonReport?: TData ) =>
 				mergeRows( primaryReport, comparisonReport, maxRows, mergeOption ),

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-report.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-report.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 /**
  * Internal dependencies
  */
@@ -30,6 +30,70 @@ type UseStatsReportOptions< TData, TComparisonRow > = UseStatsOptions & {
 type StatsReportQueryFactory< TParams extends StatsReportParams, TData > = (
 	params: TParams
 ) => UseQueryOptions< TData >;
+
+type StatsListReportOptions = UseStatsOptions & {
+	maxRows?: number;
+};
+
+type StatsListReportHookConfig<
+	TParams extends StatsReportParams,
+	TData,
+	TComparisonRow,
+	TOptions extends StatsListReportOptions,
+	TMergeOption,
+> = {
+	queryFactory: StatsReportQueryFactory< TParams, TData >;
+	reportSlug: string;
+	mergeComparisonRows: (
+		primaryReport: TData | undefined,
+		comparisonReport: TData | undefined,
+		maxRows: number | undefined,
+		mergeOption: TMergeOption
+	) => StatsComparisonRowsResult< TComparisonRow >;
+	getOptions?: ( options: TOptions | undefined ) => {
+		queryOptions: UseStatsOptions;
+		maxRows?: number;
+		mergeOption: TMergeOption;
+	};
+};
+
+export function createStatsListReportHook<
+	TParams extends StatsReportParams,
+	TData,
+	TComparisonRow,
+	TOptions extends StatsListReportOptions = StatsListReportOptions,
+	TMergeOption = undefined,
+>( {
+	queryFactory,
+	reportSlug,
+	mergeComparisonRows: mergeRows,
+	getOptions,
+}: StatsListReportHookConfig< TParams, TData, TComparisonRow, TOptions, TMergeOption > ) {
+	return function useStatsListReport( params: TParams, options?: TOptions ) {
+		const defaultOptions = () => {
+			const { maxRows, ...queryOptions } = options ?? {};
+
+			return {
+				queryOptions,
+				maxRows,
+				mergeOption: undefined as TMergeOption,
+			};
+		};
+		const { queryOptions, maxRows, mergeOption } = getOptions
+			? getOptions( options )
+			: defaultOptions();
+		const mergeComparisonRows = useCallback(
+			( primaryReport?: TData, comparisonReport?: TData ) =>
+				mergeRows( primaryReport, comparisonReport, maxRows, mergeOption ),
+			[ maxRows, mergeOption ]
+		);
+
+		return useStatsReport< TParams, TData, TComparisonRow >( queryFactory, params, reportSlug, {
+			...queryOptions,
+			mergeComparisonRows,
+		} );
+	};
+}
 
 export function useStatsReport<
 	TParams extends StatsReportParams,

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-search-terms.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-search-terms.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { useCallback } from 'react';
-/**
  * Internal dependencies
  */
 import { mergeStatsSearchTermsComparisonRows } from '../processing/stats';
 import { statsSearchTermsQuery } from '../queries/stats-search-terms-query';
-import { useStatsReport } from './use-stats-report';
+import { createStatsListReportHook } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type {
 	StatsNormalizedReport,
@@ -20,25 +16,13 @@ type StatsSearchTermsOptions = UseStatsOptions & {
 	maxRows?: number;
 };
 
-export function useStatsSearchTerms(
-	params: StatsReportParams,
-	options?: StatsSearchTermsOptions
-) {
-	const { maxRows, ...queryOptions } = options ?? {};
-	const mergeComparisonRows = useCallback(
-		(
-			primary?: StatsNormalizedReport< StatsSearchTermsItem >,
-			comparison?: StatsNormalizedReport< StatsSearchTermsItem >
-		) => mergeStatsSearchTermsComparisonRows( primary, comparison, maxRows ),
-		[ maxRows ]
-	);
-
-	return useStatsReport<
-		StatsReportParams,
-		StatsNormalizedReport< StatsSearchTermsItem >,
-		StatsSearchTermsComparisonItem
-	>( statsSearchTermsQuery, params, 'search-terms', {
-		...queryOptions,
-		mergeComparisonRows,
-	} );
-}
+export const useStatsSearchTerms = createStatsListReportHook<
+	StatsReportParams,
+	StatsNormalizedReport< StatsSearchTermsItem >,
+	StatsSearchTermsComparisonItem,
+	StatsSearchTermsOptions
+>( {
+	queryFactory: statsSearchTermsQuery,
+	reportSlug: 'search-terms',
+	mergeComparisonRows: mergeStatsSearchTermsComparisonRows,
+} );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-search-terms.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-search-terms.ts
@@ -3,7 +3,7 @@
  */
 import { mergeStatsSearchTermsComparisonRows } from '../processing/stats';
 import { statsSearchTermsQuery } from '../queries/stats-search-terms-query';
-import { createStatsListReportHook } from './use-stats-report';
+import { createStatsListReportHook, splitStatsListOptions } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type {
 	StatsNormalizedReport,
@@ -25,4 +25,5 @@ export const useStatsSearchTerms = createStatsListReportHook<
 	queryFactory: statsSearchTermsQuery,
 	reportSlug: 'search-terms',
 	mergeComparisonRows: mergeStatsSearchTermsComparisonRows,
+	getOptions: splitStatsListOptions,
 } );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-top-authors.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-top-authors.ts
@@ -3,7 +3,7 @@
  */
 import { mergeStatsTopAuthorsComparisonRows } from '../processing/stats';
 import { statsTopAuthorsQuery } from '../queries/stats-top-authors-query';
-import { createStatsListReportHook } from './use-stats-report';
+import { createStatsListReportHook, splitStatsListOptions } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type {
 	StatsNormalizedReport,
@@ -25,4 +25,5 @@ export const useStatsTopAuthors = createStatsListReportHook<
 	queryFactory: statsTopAuthorsQuery,
 	reportSlug: 'top-authors',
 	mergeComparisonRows: mergeStatsTopAuthorsComparisonRows,
+	getOptions: splitStatsListOptions,
 } );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-top-authors.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-top-authors.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { useCallback } from 'react';
-/**
  * Internal dependencies
  */
 import { mergeStatsTopAuthorsComparisonRows } from '../processing/stats';
 import { statsTopAuthorsQuery } from '../queries/stats-top-authors-query';
-import { useStatsReport } from './use-stats-report';
+import { createStatsListReportHook } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type {
 	StatsNormalizedReport,
@@ -20,22 +16,13 @@ type StatsTopAuthorsOptions = UseStatsOptions & {
 	maxRows?: number;
 };
 
-export function useStatsTopAuthors( params: StatsReportParams, options?: StatsTopAuthorsOptions ) {
-	const { maxRows, ...queryOptions } = options ?? {};
-	const mergeComparisonRows = useCallback(
-		(
-			primary?: StatsNormalizedReport< StatsTopAuthorsItem >,
-			comparison?: StatsNormalizedReport< StatsTopAuthorsItem >
-		) => mergeStatsTopAuthorsComparisonRows( primary, comparison, maxRows ),
-		[ maxRows ]
-	);
-
-	return useStatsReport<
-		StatsReportParams,
-		StatsNormalizedReport< StatsTopAuthorsItem >,
-		StatsTopAuthorsComparisonItem
-	>( statsTopAuthorsQuery, params, 'top-authors', {
-		...queryOptions,
-		mergeComparisonRows,
-	} );
-}
+export const useStatsTopAuthors = createStatsListReportHook<
+	StatsReportParams,
+	StatsNormalizedReport< StatsTopAuthorsItem >,
+	StatsTopAuthorsComparisonItem,
+	StatsTopAuthorsOptions
+>( {
+	queryFactory: statsTopAuthorsQuery,
+	reportSlug: 'top-authors',
+	mergeComparisonRows: mergeStatsTopAuthorsComparisonRows,
+} );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-top-posts.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-top-posts.ts
@@ -1,13 +1,9 @@
 /**
- * External dependencies
- */
-import { useCallback } from 'react';
-/**
  * Internal dependencies
  */
 import { mergeStatsTopPostsComparisonRows } from '../processing/stats';
 import { statsTopPostsQuery } from '../queries/stats-top-posts-query';
-import { useStatsReport } from './use-stats-report';
+import { createStatsListReportHook } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type {
 	StatsNormalizedReport,
@@ -21,22 +17,20 @@ type StatsTopPostsOptions = UseStatsOptions & {
 	postTypes?: string[] | null;
 };
 
-export function useStatsTopPosts( params: StatsReportParams, options?: StatsTopPostsOptions ) {
-	const { maxRows, postTypes, ...queryOptions } = options ?? {};
-	const mergeComparisonRows = useCallback(
-		(
-			primary?: StatsNormalizedReport< StatsTopPostsItem >,
-			comparison?: StatsNormalizedReport< StatsTopPostsItem >
-		) => mergeStatsTopPostsComparisonRows( primary, comparison, { maxRows, postTypes } ),
-		[ maxRows, postTypes ]
-	);
+export const useStatsTopPosts = createStatsListReportHook<
+	StatsReportParams,
+	StatsNormalizedReport< StatsTopPostsItem >,
+	StatsTopPostsComparisonItem,
+	StatsTopPostsOptions,
+	string[] | null | undefined
+>( {
+	queryFactory: statsTopPostsQuery,
+	reportSlug: 'top-posts',
+	mergeComparisonRows: ( primary, comparison, maxRows, postTypes ) =>
+		mergeStatsTopPostsComparisonRows( primary, comparison, { maxRows, postTypes } ),
+	getOptions: options => {
+		const { maxRows, postTypes, ...queryOptions } = options ?? {};
 
-	return useStatsReport<
-		StatsReportParams,
-		StatsNormalizedReport< StatsTopPostsItem >,
-		StatsTopPostsComparisonItem
-	>( statsTopPostsQuery, params, 'top-posts', {
-		...queryOptions,
-		mergeComparisonRows,
-	} );
-}
+		return { queryOptions, maxRows, mergeOption: postTypes };
+	},
+} );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-video-plays.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-video-plays.ts
@@ -4,7 +4,7 @@
 import { mergeStatsVideoPlaysComparisonRows } from '../processing/stats';
 import { statsVideoPlaysQuery } from '../queries/stats-video-plays-query';
 import { statsVideoPlaysSummaryQuery } from '../queries/stats-video-plays-summary-query';
-import { createStatsListReportHook } from './use-stats-report';
+import { createStatsListReportHook, splitStatsListOptions } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type {
 	StatsNormalizedReport,
@@ -31,4 +31,5 @@ export const useStatsVideoPlays = createStatsListReportHook<
 			: statsVideoPlaysQuery( params ),
 	reportSlug: 'video-plays',
 	mergeComparisonRows: mergeStatsVideoPlaysComparisonRows,
+	getOptions: splitStatsListOptions,
 } );

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-video-plays.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-video-plays.ts
@@ -1,14 +1,10 @@
 /**
- * External dependencies
- */
-import { useCallback } from 'react';
-/**
  * Internal dependencies
  */
 import { mergeStatsVideoPlaysComparisonRows } from '../processing/stats';
 import { statsVideoPlaysQuery } from '../queries/stats-video-plays-query';
 import { statsVideoPlaysSummaryQuery } from '../queries/stats-video-plays-summary-query';
-import { useStatsReport } from './use-stats-report';
+import { createStatsListReportHook } from './use-stats-report';
 import type { UseStatsOptions } from './use-stats-report';
 import type {
 	StatsNormalizedReport,
@@ -21,29 +17,18 @@ type StatsVideoPlaysOptions = UseStatsOptions & {
 	maxRows?: number;
 };
 
-export function useStatsVideoPlays( params: StatsReportParams, options?: StatsVideoPlaysOptions ) {
-	const { maxRows, ...queryOptions } = options ?? {};
-	// The complete-stats range summary uses the same endpoint and normalized
-	// response as the standard report, but its API request must omit the
-	// `summarize` mode switch. Reuse the dedicated query factory that keeps
-	// `summarize` sanitizer-only while preserving this hook's comparison and
-	// row-merging contract for callers.
-	const queryFactory =
-		params.complete_stats && params.summarize ? statsVideoPlaysSummaryQuery : statsVideoPlaysQuery;
-	const mergeComparisonRows = useCallback(
-		(
-			primary?: StatsNormalizedReport< StatsVideoPlaysItem >,
-			comparison?: StatsNormalizedReport< StatsVideoPlaysItem >
-		) => mergeStatsVideoPlaysComparisonRows( primary, comparison, maxRows ),
-		[ maxRows ]
-	);
-
-	return useStatsReport<
-		StatsReportParams,
-		StatsNormalizedReport< StatsVideoPlaysItem >,
-		StatsVideoPlaysComparisonItem
-	>( queryFactory, params, 'video-plays', {
-		...queryOptions,
-		mergeComparisonRows,
-	} );
-}
+export const useStatsVideoPlays = createStatsListReportHook<
+	StatsReportParams,
+	StatsNormalizedReport< StatsVideoPlaysItem >,
+	StatsVideoPlaysComparisonItem,
+	StatsVideoPlaysOptions
+>( {
+	// Complete-stats summaries use the same endpoint and normalized response,
+	// but the API request must omit the sanitizer-only `summarize` switch.
+	queryFactory: params =>
+		params.complete_stats && params.summarize
+			? statsVideoPlaysSummaryQuery( params )
+			: statsVideoPlaysQuery( params ),
+	reportSlug: 'video-plays',
+	mergeComparisonRows: mergeStatsVideoPlaysComparisonRows,
+} );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/utils.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/utils.test.ts
@@ -5,6 +5,7 @@ import {
 	getStatsLabel,
 	getStatsSummaryIntervalFields,
 	mergeStatsComparisonRows,
+	mergeStatsTreeComparisonRows,
 	normalizeStatsSummary,
 } from '../utils';
 
@@ -148,5 +149,79 @@ describe( 'Stats report utilities', () => {
 				{ label: 'solo', path: [], indexPath: [ 0 ] },
 			] );
 		} );
+	} );
+
+	it( 'merges, sorts, and limits comparison trees with parent context', () => {
+		type TreeRow = {
+			key: string;
+			value: number;
+			children?: TreeRow[];
+		};
+		type MergedTreeRow = Omit< TreeRow, 'children' > & {
+			path: string;
+			previousValue?: number;
+			children: MergedTreeRow[] | null;
+			childrenHaveComparison: boolean;
+		};
+		const merge = ( maxRows?: number ) =>
+			mergeStatsTreeComparisonRows< TreeRow, TreeRow, MergedTreeRow, string >( {
+				primaryRows: [
+					{
+						key: 'matched',
+						value: 1,
+						children: [ { key: 'child', value: 2 } ],
+					},
+					{ key: 'visible', value: 3 },
+				],
+				comparisonRows: [
+					{
+						key: 'matched',
+						value: 0,
+						children: [ { key: 'child', value: 4 } ],
+					},
+				],
+				maxRows,
+				parentContext: 'root',
+				getPrimaryKey: row => row.key,
+				getComparisonKey: row => row.key,
+				getComparisonValue: row => row.value,
+				getPrimaryChildren: row => row.children,
+				getComparisonChildren: row => row.children,
+				mapRow: ( row, { previousValue }, parentPath ) => ( {
+					key: row.key,
+					value: row.value,
+					path: `${ parentPath }/${ row.key }`,
+					previousValue,
+					children: null,
+					childrenHaveComparison: false,
+				} ),
+				setChildren: ( row, children, childrenHaveComparison ) => ( {
+					...row,
+					children: children.length ? children : null,
+					childrenHaveComparison,
+				} ),
+				getChildContext: row => row.path,
+				sortRows: rows => [ ...rows ].sort( ( a, b ) => b.value - a.value ),
+			} );
+
+		const full = merge();
+		expect( full.hasComparison ).toBe( true );
+		expect( full.rows[ 1 ] ).toEqual(
+			expect.objectContaining( {
+				key: 'matched',
+				previousValue: 0,
+				childrenHaveComparison: true,
+			} )
+		);
+		expect( full.rows[ 1 ].children?.[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				path: 'root/matched/child',
+				previousValue: 4,
+			} )
+		);
+
+		const capped = merge( 1 );
+		expect( capped.rows.map( row => row.key ) ).toEqual( [ 'visible' ] );
+		expect( capped.hasComparison ).toBe( false );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/archives.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/archives.ts
@@ -10,8 +10,7 @@ import {
 	getStatsReportItems,
 	getStatsTopLevelDataDate,
 	getStatsTopLevelPeriod,
-	limitStatsRows,
-	mergeStatsComparisonRows,
+	mergeStatsTreeComparisonRows,
 } from './utils';
 import type { StatsNormalizedItemBase, StatsNormalizedReport, StatsRecord } from './types';
 import type { StatsQueryParams } from '../../utils/stats-params';
@@ -155,53 +154,29 @@ function sortStatsArchivesComparisonItems(
 	return [ ...items ].sort( ( a, b ) => b.value - a.value );
 }
 
-function mergeStatsArchivesComparisonItems(
-	items: StatsArchivesItem[],
-	comparisonItems: StatsArchivesItem[]
-): { rows: StatsArchivesComparisonItem[]; hasComparison: boolean } {
-	const { rows, hasComparison } = mergeStatsComparisonRows<
-		StatsArchivesItem,
-		StatsArchivesItem,
-		StatsArchivesComparisonItem
-	>( {
-		primaryRows: items,
-		comparisonRows: comparisonItems,
-		getPrimaryKey: getStatsArchiveKey,
-		getComparisonKey: getStatsArchiveKey,
-		getComparisonValue: item => item.value,
-		mapRow: ( item, { previousValue, comparisonItem } ) => {
-			const { rows: children } = mergeStatsArchivesComparisonItems(
-				item.children ?? [],
-				comparisonItem?.children ?? []
-			);
-
-			return {
-				...item,
-				previousValue,
-				children: children.length ? children : null,
-			};
-		},
-	} );
-
-	return { rows: sortStatsArchivesComparisonItems( rows ), hasComparison };
-}
-
 export function mergeStatsArchivesComparisonRows(
 	primaryReport: StatsNormalizedReport< StatsArchivesItem > | undefined,
 	comparisonReport: StatsNormalizedReport< StatsArchivesItem > | undefined,
 	maxRows?: number
 ): { rows: StatsArchivesComparisonItem[]; hasComparison: boolean } {
-	const { rows } = mergeStatsArchivesComparisonItems(
-		getStatsReportItems( primaryReport ),
-		getStatsReportItems( comparisonReport )
-	);
-
-	// The overlap gate is computed on the visible rows so an off-screen match
-	// cannot switch the comparison UI on (see AGENTS.md).
-	const visibleRows = limitStatsRows( rows, maxRows );
-
-	return {
-		rows: visibleRows,
-		hasComparison: visibleRows.some( row => row.previousValue !== undefined ),
-	};
+	return mergeStatsTreeComparisonRows<
+		StatsArchivesItem,
+		StatsArchivesItem,
+		StatsArchivesComparisonItem
+	>( {
+		primaryRows: getStatsReportItems( primaryReport ),
+		comparisonRows: getStatsReportItems( comparisonReport ),
+		maxRows,
+		getPrimaryKey: getStatsArchiveKey,
+		getComparisonKey: getStatsArchiveKey,
+		getComparisonValue: item => item.value,
+		getPrimaryChildren: item => item.children,
+		getComparisonChildren: item => item.children,
+		mapRow: ( item, { previousValue } ) => ( { ...item, previousValue, children: null } ),
+		setChildren: ( item, children ) => ( {
+			...item,
+			children: children.length ? children : null,
+		} ),
+		sortRows: sortStatsArchivesComparisonItems,
+	} );
 }

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/clicks.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/clicks.ts
@@ -2,10 +2,9 @@ import { safeParseFloat } from '../../utils/parsing';
 import {
 	coerceStatsArray,
 	getStatsReportItems,
-	limitStatsRows,
 	mapNestedItems,
 	mapStatsReportDataPoints,
-	mergeStatsComparisonRows,
+	mergeStatsTreeComparisonRows,
 	normalizeStatsReportSummary,
 } from './utils';
 import type { StatsNormalizedItemBase, StatsNormalizedReport, StatsRecord } from './types';
@@ -48,59 +47,42 @@ function sortStatsClicksComparisonItems(
 	return [ ...items ].sort( ( a, b ) => b.views - a.views );
 }
 
-function mergeStatsClicksComparisonItems(
-	items: StatsClicksItem[],
-	comparisonItems: StatsClicksItem[],
-	parent?: ClickParentContext
-): { rows: StatsClicksComparisonItem[]; hasComparison: boolean } {
-	const { rows, hasComparison } = mergeStatsComparisonRows<
-		StatsClicksItem,
-		StatsClicksItem,
-		StatsClicksComparisonItem
-	>( {
-		primaryRows: items,
-		comparisonRows: comparisonItems,
-		getPrimaryKey: item => getStatsClicksItemKey( item, parent?.label ),
-		getComparisonKey: item => getStatsClicksItemKey( item, parent?.label ),
-		getComparisonValue: item => item.views,
-		mapRow: ( item, { previousValue, comparisonItem } ) => {
-			const label = getStatsClicksItemLabel( item, parent?.label );
-			const { rows: children, hasComparison: childrenHaveComparison } =
-				mergeStatsClicksComparisonItems( item.children ?? [], comparisonItem?.children ?? [], {
-					label,
-					icon: item.icon ?? parent?.icon,
-				} );
-
-			return {
-				...item,
-				label,
-				icon: item.icon ?? parent?.icon ?? null,
-				previousValue,
-				children: children.length ? children : null,
-				childrenHaveComparison,
-			};
-		},
-	} );
-
-	return { rows: sortStatsClicksComparisonItems( rows ), hasComparison };
-}
-
 export function mergeStatsClicksComparisonRows(
 	primaryReport: StatsNormalizedReport< StatsClicksItem > | undefined,
 	comparisonReport: StatsNormalizedReport< StatsClicksItem > | undefined,
 	maxRows?: number
 ): { rows: StatsClicksComparisonItem[]; hasComparison: boolean } {
-	const { rows } = mergeStatsClicksComparisonItems(
-		getStatsReportItems( primaryReport ),
-		getStatsReportItems( comparisonReport )
-	);
-
-	const visibleRows = limitStatsRows( rows, maxRows );
-
-	return {
-		rows: visibleRows,
-		hasComparison: visibleRows.some( row => row.previousValue !== undefined ),
-	};
+	return mergeStatsTreeComparisonRows<
+		StatsClicksItem,
+		StatsClicksItem,
+		StatsClicksComparisonItem,
+		ClickParentContext
+	>( {
+		primaryRows: getStatsReportItems( primaryReport ),
+		comparisonRows: getStatsReportItems( comparisonReport ),
+		maxRows,
+		getPrimaryKey: ( item, parent ) => getStatsClicksItemKey( item, parent?.label ),
+		getComparisonKey: ( item, parent ) => getStatsClicksItemKey( item, parent?.label ),
+		getComparisonValue: item => item.views,
+		getPrimaryChildren: item => item.children,
+		getComparisonChildren: item => item.children,
+		mapRow: ( item, { previousValue }, parent ) => ( {
+			...item,
+			label: getStatsClicksItemLabel( item, parent?.label ),
+			icon: item.icon ?? parent?.icon ?? null,
+			previousValue,
+		} ),
+		setChildren: ( item, children, childrenHaveComparison ) => ( {
+			...item,
+			children: children.length ? children : null,
+			childrenHaveComparison,
+		} ),
+		getChildContext: item => ( {
+			label: typeof item.label === 'string' ? item.label : '',
+			icon: item.icon,
+		} ),
+		sortRows: sortStatsClicksComparisonItems,
+	} );
 }
 
 export function sanitizeStatsClicksResponse(

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/referrers.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/referrers.ts
@@ -2,10 +2,9 @@ import { safeParseFloat } from '../../utils/parsing';
 import {
 	coerceStatsArray,
 	getStatsReportItems,
-	limitStatsRows,
 	mapNestedItems,
 	mapStatsReportDataPoints,
-	mergeStatsComparisonRows,
+	mergeStatsTreeComparisonRows,
 	normalizeStatsReportSummary,
 } from './utils';
 import type {
@@ -59,62 +58,42 @@ function sortStatsReferrersComparisonItems(
 	return [ ...items ].sort( ( a, b ) => b.views - a.views );
 }
 
-function mergeStatsReferrersComparisonItems(
-	items: StatsReferrersItem[],
-	comparisonItems: StatsReferrersItem[],
-	parent?: ReferrerParentContext
-): { rows: StatsReferrersComparisonItem[]; hasComparison: boolean } {
-	const { rows, hasComparison } = mergeStatsComparisonRows<
-		StatsReferrersItem,
-		StatsReferrersItem,
-		StatsReferrersComparisonItem
-	>( {
-		primaryRows: items,
-		comparisonRows: comparisonItems,
-		getPrimaryKey: getStatsReferrersItemKey,
-		getComparisonKey: getStatsReferrersItemKey,
-		getComparisonValue: item => item.views,
-		mapRow: ( item, { previousValue, comparisonItem } ) => {
-			// Sources inherit their group's favicon so drill-down rows stay
-			// recognizable (e.g. Google Search → google.com keeps the Google icon).
-			const icon = item.icon ?? parent?.icon ?? null;
-			const { rows: children, hasComparison: childrenHaveComparison } =
-				mergeStatsReferrersComparisonItems( item.children ?? [], comparisonItem?.children ?? [], {
-					icon,
-				} );
-
-			return {
-				...item,
-				label: getStatsReferrersItemLabel( item ),
-				icon,
-				previousValue,
-				children: children.length ? children : null,
-				childrenHaveComparison,
-			};
-		},
-	} );
-
-	return { rows: sortStatsReferrersComparisonItems( rows ), hasComparison };
-}
-
 export function mergeStatsReferrersComparisonRows(
 	primaryReport: StatsNormalizedReport< StatsReferrersItem > | undefined,
 	comparisonReport: StatsNormalizedReport< StatsReferrersItem > | undefined,
 	maxRows?: number
 ): { rows: StatsReferrersComparisonItem[]; hasComparison: boolean } {
-	const { rows } = mergeStatsReferrersComparisonItems(
-		getStatsReportItems( primaryReport ),
-		getStatsReportItems( comparisonReport )
-	);
-
-	// The overlap gate is computed on the visible rows so an off-screen match
-	// cannot switch the comparison UI on (see AGENTS.md).
-	const visibleRows = limitStatsRows( rows, maxRows );
-
-	return {
-		rows: visibleRows,
-		hasComparison: visibleRows.some( row => row.previousValue !== undefined ),
-	};
+	return mergeStatsTreeComparisonRows<
+		StatsReferrersItem,
+		StatsReferrersItem,
+		StatsReferrersComparisonItem,
+		ReferrerParentContext
+	>( {
+		primaryRows: getStatsReportItems( primaryReport ),
+		comparisonRows: getStatsReportItems( comparisonReport ),
+		maxRows,
+		getPrimaryKey: getStatsReferrersItemKey,
+		getComparisonKey: getStatsReferrersItemKey,
+		getComparisonValue: item => item.views,
+		getPrimaryChildren: item => item.children,
+		getComparisonChildren: item => item.children,
+		mapRow: ( item, { previousValue }, parent ) => ( {
+			...item,
+			label: getStatsReferrersItemLabel( item ),
+			// Sources inherit their group's favicon so drill-down rows stay
+			// recognizable (e.g. Google Search → google.com keeps the Google icon).
+			icon: item.icon ?? parent?.icon ?? null,
+			previousValue,
+			children: null,
+		} ),
+		setChildren: ( item, children, childrenHaveComparison ) => ( {
+			...item,
+			children: children.length ? children : null,
+			childrenHaveComparison,
+		} ),
+		getChildContext: item => ( { icon: item.icon } ),
+		sortRows: sortStatsReferrersComparisonItems,
+	} );
 }
 
 export function sanitizeStatsReferrersResponse(

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/utils.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/utils.ts
@@ -35,6 +35,37 @@ export type MergeStatsComparisonRowsOptions< TPrimary, TComparison, TMapped > = 
 	mapRow: ( row: TPrimary, context: StatsComparisonRowContext< TComparison > ) => TMapped;
 };
 
+export type MergeStatsTreeComparisonRowsOptions<
+	TPrimary,
+	TComparison,
+	TMapped extends { previousValue?: number },
+	TParentContext,
+> = Omit<
+	MergeStatsComparisonRowsOptions< TPrimary, TComparison, TMapped >,
+	'mapRow' | 'getPrimaryKey' | 'getComparisonKey'
+> & {
+	maxRows?: number;
+	parentContext?: TParentContext;
+	getPrimaryKey: (
+		row: TPrimary,
+		parentContext: TParentContext | undefined
+	) => StatsComparisonKey | null | undefined;
+	getComparisonKey: (
+		row: TComparison,
+		parentContext: TParentContext | undefined
+	) => StatsComparisonKey | null | undefined;
+	getPrimaryChildren: ( row: TPrimary ) => TPrimary[] | null | undefined;
+	getComparisonChildren: ( row: TComparison ) => TComparison[] | null | undefined;
+	mapRow: (
+		row: TPrimary,
+		context: StatsComparisonRowContext< TComparison >,
+		parentContext: TParentContext | undefined
+	) => TMapped;
+	setChildren: ( row: TMapped, children: TMapped[], hasComparison: boolean ) => TMapped;
+	getChildContext?: ( row: TMapped, parentContext: TParentContext | undefined ) => TParentContext;
+	sortRows?: ( rows: TMapped[] ) => TMapped[];
+};
+
 export function isStatsRecord( value: unknown ): value is StatsRecord {
 	return typeof value === 'object' && value !== null && ! Array.isArray( value );
 }
@@ -178,6 +209,65 @@ export function flattenStatsLeaves< TItem, TRow >(
 	};
 
 	return items.flatMap( ( item, index ) => walk( item, [], [ index ] ) );
+}
+
+export function mergeStatsTreeComparisonRows<
+	TPrimary,
+	TComparison = TPrimary,
+	TMapped extends { previousValue?: number } = TPrimary & { previousValue?: number },
+	TParentContext = never,
+>( {
+	primaryRows,
+	comparisonRows = [],
+	maxRows,
+	parentContext,
+	getPrimaryKey,
+	getComparisonKey,
+	getComparisonValue,
+	getPrimaryChildren,
+	getComparisonChildren,
+	mapRow,
+	setChildren,
+	getChildContext,
+	sortRows,
+}: MergeStatsTreeComparisonRowsOptions< TPrimary, TComparison, TMapped, TParentContext > ): {
+	rows: TMapped[];
+	hasComparison: boolean;
+} {
+	const mergeLevel = (
+		levelPrimaryRows: TPrimary[],
+		levelComparisonRows: TComparison[],
+		levelParentContext: TParentContext | undefined
+	): { rows: TMapped[]; hasComparison: boolean } => {
+		const { rows, hasComparison } = mergeStatsComparisonRows< TPrimary, TComparison, TMapped >( {
+			primaryRows: levelPrimaryRows,
+			comparisonRows: levelComparisonRows,
+			getPrimaryKey: row => getPrimaryKey( row, levelParentContext ),
+			getComparisonKey: row => getComparisonKey( row, levelParentContext ),
+			getComparisonValue,
+			mapRow: ( row, context ) => {
+				const mappedRow = mapRow( row, context, levelParentContext );
+				const childContext = getChildContext?.( mappedRow, levelParentContext );
+				const children = mergeLevel(
+					getPrimaryChildren( row ) ?? [],
+					context.comparisonItem ? getComparisonChildren( context.comparisonItem ) ?? [] : [],
+					childContext
+				);
+
+				return setChildren( mappedRow, children.rows, children.hasComparison );
+			},
+		} );
+
+		return { rows: sortRows?.( rows ) ?? rows, hasComparison };
+	};
+
+	const { rows } = mergeLevel( primaryRows, comparisonRows, parentContext );
+	const visibleRows = limitStatsRows( rows, maxRows );
+
+	return {
+		rows: visibleRows,
+		hasComparison: visibleRows.some( row => row.previousValue !== undefined ),
+	};
 }
 
 function isStatsNumericSummaryValue( value: unknown ): boolean {

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/utils.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/utils.ts
@@ -262,6 +262,10 @@ export function mergeStatsTreeComparisonRows<
 	};
 
 	const { rows } = mergeLevel( primaryRows, comparisonRows, parentContext );
+
+	// The overlap gate is computed on the visible rows so an off-screen match
+	// cannot switch the comparison UI on (see AGENTS.md). Keep the limit ahead of
+	// the gate below — swapping the two silently changes that behavior.
 	const visibleRows = limitStatsRows( rows, maxRows );
 
 	return {


### PR DESCRIPTION
Fixes WOOA7S-1750

## Proposed changes

* Add a shared `createStatsListReportHook()` factory and migrate the ten Stats list hooks to it.
* Add `mergeStatsTreeComparisonRows()` and use it for clicks, referrers, and archives.
* Preserve module-specific row keys, sorting, nested context, `maxRows = 0`, and visible-row comparison gating while centralizing the shared contracts.
* Require `getOptions` on the factory (modules with no merge option pass the shared `splitStatsListOptions`), so narrowing `TMergeOption` can't compile into a merge callback that receives `undefined` at runtime.
* Add regression coverage for stable hook merge callbacks and generic tree merging.

This reduces the number of places that must be updated when the Stats comparison contract changes and helps prevent behavior such as `maxRows = 0` or overlap gating from drifting between reports.

## Related product discussion/links

* WOOA7S-1750

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This is a pure refactor — nothing should change on screen. The goal of testing is to confirm that.

### Storybook

```bash
pnpm --dir projects/js-packages/storybook run storybook:dev
```

Storybook serves the data package from TS source, so no build step is needed. For each story below, flip the `withComparison` control and confirm behavior is unchanged from trunk.

**Tree modules** (these use the new `mergeStatsTreeComparisonRows`):

* **Referrers → With Comparison** — top-level rows show deltas; a row with no comparison match shows `–`, not `0%`. Click **Search Engines** to drill down: child rows must also show deltas, and *Google Search* must inherit the parent group's Google icon (this is the parent-context path the refactor rewrote).
* **Clicks → With Comparison** — parent rows keep their blavatars; unmatched rows show `–`.
* **TopPosts → Archives** — renders the Taxonomies / Post types / Searches groups (archives has no widget of its own; this story is its only UI surface).

**Non-tree modules** (these exercise the `splitStatsListOptions` path shared by nine hooks):

* **SearchTerms → With Comparison**, **Locations → Widget Dashboard With Widget** (mounts the real `WidgetDashboard`), plus a spot-check of **Devices**, **FileDownloads**, **Authors**, or **VideoPress**.

**TopPosts → With Comparison** covers the one hook that narrows `TMergeOption` (it passes `postTypes` through its own `getOptions`).

### What a regression would look like

* Deltas disappearing, or `0%` / `100%` appearing where trunk shows `–` → comparison row matching broke.
* A capped widget showing a delta that trunk doesn't → the visible-row overlap gate moved ahead of `limitStatsRows`.
* A widget rendering every row despite a `max` setting → `maxRows` stopped being forwarded.
* Drill-down child rows losing their inherited icon → parent-context propagation broke.
