### PR TITLE
Premium Analytics: share common Stats widget CSS modules

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1755-shared-widget-css
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1755-shared-widget-css
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Widgets: Share common layout styles across Stats widgets.

--- a/projects/packages/premium-analytics/widgets/authors/style.module.css
+++ b/projects/packages/premium-analytics/widgets/authors/style.module.css
@@ -1,19 +1,11 @@
 .root {
-	container-type: inline-size;
-	display: flex;
-	flex-direction: column;
-	height: 100%;
-	overflow: hidden;
+	composes: root from '../widget-layout.module.css';
 }
 
 /* Positioned anchor so WidgetLoadingOverlay (position: absolute; inset: 0)
    resolves against the widget body, not the host frame. */
 .content {
-	position: relative;
-	display: flex;
-	flex-direction: column;
-	flex: 1 1 0;
-	min-height: 0;
+	composes: content from '../widget-layout.module.css';
 }
 
 /* Round the author avatar; the shared image-size properties keep the
@@ -29,8 +21,8 @@
    text from the bar's rounded left edge. */
 .postLabel {
 	display: block;
-	padding-block: var(--wpds-dimension-padding-md);
-	padding-inline-start: var(--wpds-dimension-padding-sm);
+	padding-block: var( --wpds-dimension-padding-md );
+	padding-inline-start: var( --wpds-dimension-padding-sm );
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;

--- a/projects/packages/premium-analytics/widgets/clicks/style.module.css
+++ b/projects/packages/premium-analytics/widgets/clicks/style.module.css
@@ -1,7 +1,7 @@
 .labelIcon {
 	--jpa-leaderboard-image-width: 16px;
 	--jpa-leaderboard-image-height: 16px;
-	--jpa-leaderboard-image-radius: var(--wpds-border-radius-sm);
+	--jpa-leaderboard-image-radius: var( --wpds-border-radius-sm );
 }
 
 /* Flex keeps the Link's external-arrow icon on the same line as the label;
@@ -20,7 +20,7 @@
 }
 
 .labelLink {
-	gap: var(--wpds-dimension-gap-xs);
+	gap: var( --wpds-dimension-gap-xs );
 }
 
 .labelLink:hover,
@@ -32,23 +32,15 @@
 	flex: 1 1 0;
 	inline-size: 100%;
 	min-block-size: 200px;
-	color: var(--wpds-color-foreground-content-neutral-weak);
+	color: var( --wpds-color-foreground-content-neutral-weak );
 	text-align: center;
 }
 
 .root {
-	container-type: inline-size;
-	display: flex;
-	flex-direction: column;
-	height: 100%;
+	composes: root from '../widget-layout.module.css';
 	min-height: 0;
-	overflow: hidden;
 }
 
 .content {
-	position: relative;
-	display: flex;
-	flex-direction: column;
-	flex: 1 1 0;
-	min-height: 0;
+	composes: content from '../widget-layout.module.css';
 }

--- a/projects/packages/premium-analytics/widgets/comments/style.module.css
+++ b/projects/packages/premium-analytics/widgets/comments/style.module.css
@@ -1,19 +1,11 @@
 .root {
-	container-type: inline-size;
-	display: flex;
-	flex-direction: column;
-	height: 100%;
-	overflow: hidden;
+	composes: root from '../widget-layout.module.css';
 }
 
 /* Positioned anchor so WidgetState's overlay (position: absolute; inset: 0)
    resolves against the widget body, not the host frame. */
 .content {
-	position: relative;
-	display: flex;
-	flex-direction: column;
-	flex: 1 1 0;
-	min-height: 0;
+	composes: content from '../widget-layout.module.css';
 }
 
 /* Round the author avatar; the shared image-size properties keep the
@@ -30,8 +22,8 @@
    edge. */
 .postLabel {
 	display: block;
-	padding-block: var(--wpds-dimension-padding-md);
-	padding-inline-start: var(--wpds-dimension-padding-sm);
+	padding-block: var( --wpds-dimension-padding-md );
+	padding-inline-start: var( --wpds-dimension-padding-sm );
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;

--- a/projects/packages/premium-analytics/widgets/devices/style.module.css
+++ b/projects/packages/premium-analytics/widgets/devices/style.module.css
@@ -1,17 +1,9 @@
 .root {
-	container-type: inline-size;
-	display: flex;
-	flex-direction: column;
-	height: 100%;
-	overflow: hidden;
+	composes: root from '../widget-layout.module.css';
 }
 
 .content {
-	position: relative;
-	display: flex;
-	flex-direction: column;
-	flex: 1 1 0;
-	min-height: 0;
+	composes: content from '../widget-layout.module.css';
 }
 
 .chartWrap {
@@ -23,16 +15,15 @@
 }
 
 .chartShell {
-	inline-size: min(100%, 320px);
+	inline-size: min( 100%, 320px );
 	display: flex;
 	flex-direction: column;
-	gap: var(--wpds-dimension-gap-xl);
+	gap: var( --wpds-dimension-gap-xl );
 }
 
 @container (max-width: 420px) {
-
 	.chartShell {
-		inline-size: min(100%, 220px);
-		gap: var(--wpds-dimension-gap-sm);
+		inline-size: min( 100%, 220px );
+		gap: var( --wpds-dimension-gap-sm );
 	}
 }

--- a/projects/packages/premium-analytics/widgets/file-downloads/style.module.css
+++ b/projects/packages/premium-analytics/widgets/file-downloads/style.module.css
@@ -1,8 +1,8 @@
 .labelLink {
 	display: block;
 
-	padding-block: var(--wpds-dimension-padding-md);
-	padding-inline-start: var(--wpds-dimension-padding-sm);
+	padding-block: var( --wpds-dimension-padding-md );
+	padding-inline-start: var( --wpds-dimension-padding-sm );
 	overflow: hidden;
 	color: inherit;
 	text-decoration: none;
@@ -17,25 +17,17 @@
 
 .labelText {
 	display: block;
-	padding-block: var(--wpds-dimension-padding-md);
-	padding-inline-start: var(--wpds-dimension-padding-sm);
+	padding-block: var( --wpds-dimension-padding-md );
+	padding-inline-start: var( --wpds-dimension-padding-sm );
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
 
 .root {
-	container-type: inline-size;
-	display: flex;
-	flex-direction: column;
-	height: 100%;
-	overflow: hidden;
+	composes: root from '../widget-layout.module.css';
 }
 
 .content {
-	position: relative;
-	display: flex;
-	flex-direction: column;
-	flex: 1 1 0;
-	min-height: 0;
+	composes: content from '../widget-layout.module.css';
 }

--- a/projects/packages/premium-analytics/widgets/most-popular-day/style.module.css
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/style.module.css
@@ -5,11 +5,7 @@
 }
 
 .content {
-	position: relative;
-	display: flex;
-	flex-direction: column;
-	flex: 1 1 0;
-	min-height: 0;
+	composes: content from '../widget-layout.module.css';
 }
 
 /* Fill the WidgetState ready area so the highlight stays centered. */
@@ -18,5 +14,5 @@
 }
 
 .caption {
-	color: var(--wpds-color-foreground-content-neutral-weak);
+	color: var( --wpds-color-foreground-content-neutral-weak );
 }

--- a/projects/packages/premium-analytics/widgets/referrers/style.module.css
+++ b/projects/packages/premium-analytics/widgets/referrers/style.module.css
@@ -1,7 +1,7 @@
 .labelIcon {
 	--jpa-leaderboard-image-width: 16px;
 	--jpa-leaderboard-image-height: 16px;
-	--jpa-leaderboard-image-radius: var(--wpds-border-radius-sm);
+	--jpa-leaderboard-image-radius: var( --wpds-border-radius-sm );
 }
 
 /* Flex keeps the Link's external-arrow icon on the same line as the label;
@@ -20,7 +20,7 @@
 }
 
 .labelLink {
-	gap: var(--wpds-dimension-gap-xs);
+	gap: var( --wpds-dimension-gap-xs );
 }
 
 .labelLink:hover,
@@ -32,23 +32,15 @@
 	flex: 1 1 0;
 	inline-size: 100%;
 	min-block-size: 200px;
-	color: var(--wpds-color-foreground-content-neutral-weak);
+	color: var( --wpds-color-foreground-content-neutral-weak );
 	text-align: center;
 }
 
 .root {
-	container-type: inline-size;
-	display: flex;
-	flex-direction: column;
-	height: 100%;
+	composes: root from '../widget-layout.module.css';
 	min-height: 0;
-	overflow: hidden;
 }
 
 .content {
-	position: relative;
-	display: flex;
-	flex-direction: column;
-	flex: 1 1 0;
-	min-height: 0;
+	composes: content from '../widget-layout.module.css';
 }

--- a/projects/packages/premium-analytics/widgets/search-terms/style.module.css
+++ b/projects/packages/premium-analytics/widgets/search-terms/style.module.css
@@ -1,21 +1,13 @@
 .root {
-	container-type: inline-size;
-	display: flex;
-	flex-direction: column;
-	height: 100%;
-	overflow: hidden;
+	composes: root from '../widget-layout.module.css';
 }
 
 .content {
-	position: relative;
-	display: flex;
-	flex-direction: column;
-	flex: 1 1 0;
-	min-height: 0;
+	composes: content from '../widget-layout.module.css';
 }
 
 .itemLabel {
-	padding: var(--wpds-dimension-padding-sm);
+	padding: var( --wpds-dimension-padding-sm );
 	min-width: 0;
 	overflow: hidden;
 }

--- a/projects/packages/premium-analytics/widgets/shares/style.module.css
+++ b/projects/packages/premium-analytics/widgets/shares/style.module.css
@@ -1,21 +1,13 @@
 .root {
-	container-type: inline-size;
-	display: flex;
-	flex-direction: column;
-	height: 100%;
-	overflow: hidden;
+	composes: root from '../widget-layout.module.css';
 }
 
 .content {
-	position: relative;
-	display: flex;
-	flex-direction: column;
-	flex: 1 1 0;
-	min-height: 0;
+	composes: content from '../widget-layout.module.css';
 }
 
 .itemLabel {
-	padding: var(--wpds-dimension-padding-sm);
+	padding: var( --wpds-dimension-padding-sm );
 	min-width: 0;
 	overflow: hidden;
 }

--- a/projects/packages/premium-analytics/widgets/tags/style.module.css
+++ b/projects/packages/premium-analytics/widgets/tags/style.module.css
@@ -1,28 +1,20 @@
 .root {
-	container-type: inline-size;
-	display: flex;
-	flex-direction: column;
-	height: 100%;
-	overflow: hidden;
+	composes: root from '../widget-layout.module.css';
 }
 
 /* Positioned anchor so the WidgetState busy overlay (position: absolute;
    inset: 0) resolves against the widget body, not the host frame. */
 .content {
-	position: relative;
-	display: flex;
-	flex-direction: column;
-	flex: 1 1 0;
-	min-height: 0;
+	composes: content from '../widget-layout.module.css';
 }
 
 /* Icon + label row for the leaderboard. min-height keeps a stable 36px row for
    both single tag/category rows and grouped (drill-down) rows. */
 .itemLabel {
-	gap: var(--wpds-dimension-padding-sm);
+	gap: var( --wpds-dimension-padding-sm );
 	min-height: 36px;
 	min-width: 0;
-	padding-inline: var(--wpds-dimension-padding-sm);
+	padding-inline: var( --wpds-dimension-padding-sm );
 	overflow: hidden;
 }
 
@@ -54,8 +46,8 @@ a.itemLabelText:focus {
 .childRow {
 	display: flex;
 	align-items: center;
-	gap: var(--wpds-dimension-padding-sm);
+	gap: var( --wpds-dimension-padding-sm );
 	min-height: 36px;
-	padding-inline: var(--wpds-dimension-padding-sm);
+	padding-inline: var( --wpds-dimension-padding-sm );
 	overflow: hidden;
 }

--- a/projects/packages/premium-analytics/widgets/top-platforms/style.module.css
+++ b/projects/packages/premium-analytics/widgets/top-platforms/style.module.css
@@ -1,19 +1,11 @@
 .root {
-	container-type: inline-size;
-	display: flex;
-	flex-direction: column;
-	height: 100%;
-	overflow: hidden;
+	composes: root from '../widget-layout.module.css';
 }
 
 .content {
-	position: relative;
-	display: flex;
-	flex-direction: column;
-	flex: 1 1 0;
-	min-height: 0;
+	composes: content from '../widget-layout.module.css';
 }
 
 .itemLabel {
-	padding: var(--wpds-dimension-padding-sm);
+	padding: var( --wpds-dimension-padding-sm );
 }

--- a/projects/packages/premium-analytics/widgets/top-posts/style.module.css
+++ b/projects/packages/premium-analytics/widgets/top-posts/style.module.css
@@ -1,18 +1,10 @@
 .root {
-	container-type: inline-size;
-	display: flex;
-	flex-direction: column;
-	height: 100%;
+	composes: root from '../widget-layout.module.css';
 	min-height: 0;
-	overflow: hidden;
 }
 
 .content {
-	position: relative;
-	display: flex;
-	flex-direction: column;
-	flex: 1 1 0;
-	min-height: 0;
+	composes: content from '../widget-layout.module.css';
 }
 
 /* Vertical padding sets the overlay bar height — the bar fills the row,
@@ -23,10 +15,10 @@
 .labelRow {
 	display: flex;
 	align-items: center;
-	gap: var(--wpds-dimension-gap-xs);
+	gap: var( --wpds-dimension-gap-xs );
 	min-width: 0;
-	padding-block: var(--wpds-dimension-padding-md);
-	padding-inline-start: var(--wpds-dimension-padding-sm);
+	padding-block: var( --wpds-dimension-padding-md );
+	padding-inline-start: var( --wpds-dimension-padding-sm );
 }
 
 /* `min-width: 0` lets the flex item shrink below its content width so the
@@ -56,7 +48,7 @@
 .externalLink {
 	display: inline-flex;
 	flex: none;
-	color: var(--wpds-color-foreground-content-neutral-weak);
+	color: var( --wpds-color-foreground-content-neutral-weak );
 	opacity: 0;
 	transition: opacity 120ms ease-in-out;
 }
@@ -72,8 +64,7 @@
 }
 
 /* Touch-capable devices: keep the icon visible so the affordance isn't lost. */
-@media (hover: none), (any-pointer: coarse) {
-
+@media ( hover: none ), ( any-pointer: coarse ) {
 	.externalLink {
 		opacity: 1;
 	}

--- a/projects/packages/premium-analytics/widgets/videopress/style.module.css
+++ b/projects/packages/premium-analytics/widgets/videopress/style.module.css
@@ -4,12 +4,12 @@
 
 	/* Vertical padding sets the overlay bar height — the bar fills the row,
 	   whose height is driven by this label (there is no image to size it). */
-	padding-block: var(--wpds-dimension-padding-md);
+	padding-block: var( --wpds-dimension-padding-md );
 
 	/* Inset the text from the bar's rounded left edge. The chart applies this to
 	   its default `.label` in overlay mode (`.is-overlay .label`), but a custom
 	   label element bypasses that rule, so we mirror it here. */
-	padding-inline-start: var(--wpds-dimension-padding-sm);
+	padding-inline-start: var( --wpds-dimension-padding-sm );
 	overflow: hidden;
 	color: inherit;
 	text-decoration: none;
@@ -23,17 +23,9 @@
 }
 
 .root {
-	container-type: inline-size;
-	display: flex;
-	flex-direction: column;
-	height: 100%;
-	overflow: hidden;
+	composes: root from '../widget-layout.module.css';
 }
 
 .content {
-	position: relative;
-	display: flex;
-	flex-direction: column;
-	flex: 1 1 0;
-	min-height: 0;
+	composes: content from '../widget-layout.module.css';
 }

--- a/projects/packages/premium-analytics/widgets/widget-layout.module.css
+++ b/projects/packages/premium-analytics/widgets/widget-layout.module.css
@@ -1,0 +1,15 @@
+.root {
+	container-type: inline-size;
+	display: flex;
+	flex-direction: column;
+	block-size: 100%;
+	overflow: hidden;
+}
+
+.content {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	flex: 1 1 0;
+	min-block-size: 0;
+}


### PR DESCRIPTION
Fixes WOOA7S-1755

## Proposed changes

* Extract the repeated widget root/content height chain into one shared CSS Module.
* Compose the shared layout classes from 13 Stats widgets while preserving all widget-specific rules locally.
* Keep the shared module at the `widgets/` root so widget auto-discovery does not register a helper directory as a widget.

This reduces drift between widgets that depend on the same flex and overflow behavior. Keeping this layout chain centralized is particularly important for loading, empty, and error overlays. Pair-specific leaderboard and label styles remain in their widget modules rather than introducing small abstractions with only two consumers.

## Related product discussion/links

* WOOA7S-1755

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run `projects/packages/premium-analytics/node_modules/.bin/tsgo --noEmit -p projects/packages/premium-analytics/tsconfig.json`.
* Run `pnpm --dir projects/packages/premium-analytics run build:wp-build` and confirm all widgets build successfully.
* In Storybook, compare Authors/Comments, Search terms/Shares, Clicks/Referrers, and the other changed widgets at narrow and wide sizes.
* Confirm ready, loading, empty, and error content remains contained within each widget frame.
