### PR TITLE
Premium Analytics: share Stats widget story and test helpers

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1755-story-test-helpers
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1755-story-test-helpers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Widgets: Keep Storybook rendering and test harnesses consistent across Stats widgets.

--- a/projects/packages/premium-analytics/widgets/clicks/__tests__/clicks.test.tsx
+++ b/projects/packages/premium-analytics/widgets/clicks/__tests__/clicks.test.tsx
@@ -4,7 +4,6 @@
 import { getDefaultQueryParams, queryClient } from '@jetpack-premium-analytics/data';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
-import type { AnchorHTMLAttributes, ReactNode } from 'react';
 /**
  * Internal dependencies
  */
@@ -13,35 +12,7 @@ import type { StatsClicksItem, StatsNormalizedReport } from '@jetpack-premium-an
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
-type MockRouteLinkProps = {
-	to: string;
-	params?: Record< string, unknown >;
-	search?: Record< string, unknown >;
-	children: ReactNode;
-} & Omit< AnchorHTMLAttributes< HTMLAnchorElement >, 'href' >;
-
-jest.mock( '@wordpress/route', () => ( {
-	Link: ( { to, params, search, children, ...props }: MockRouteLinkProps ) => {
-		const path = Object.entries( params ?? {} ).reduce(
-			( acc, [ key, value ] ) => acc.replace( `$${ key }`, String( value ) ),
-			to
-		);
-		const query = new URLSearchParams();
-		Object.entries( search ?? {} ).forEach( ( [ key, value ] ) => {
-			if ( value !== undefined && value !== null ) {
-				query.set( key, String( value ) );
-			}
-		} );
-		const queryString = query.toString();
-
-		return (
-			<a href={ queryString ? `${ path }?${ queryString }` : path } { ...props }>
-				{ children }
-			</a>
-		);
-	},
-	useSearch: () => ( {} ),
-} ) );
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
 
 const mockApiFetch = apiFetch as unknown as jest.Mock;
 

--- a/projects/packages/premium-analytics/widgets/comments/stories/comments-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/comments/stories/comments-widget.stories.tsx
@@ -5,6 +5,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
@@ -12,7 +13,7 @@ import {
 import CommentsRender from '../render';
 import widgetDefinition from '../widget';
 import type { CommentsView } from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -73,26 +74,6 @@ function forceCommentsState( state: 'loading' | 'error' | 'empty' ) {
 		};
 	};
 }
-
-// Close-up frame: a white, widget-sized card so the widget reads the way it does
-// as a real dashboard widget (in product the host supplies this frame).
-const withWidgetCanvas: Decorator = Story => (
-	<div
-		style={ {
-			width: '380px',
-			height: '520px',
-			margin: '0 auto',
-			padding: '16px',
-			boxSizing: 'border-box',
-			background: '#fff',
-			border: '1px solid #e0e0e0',
-			borderRadius: '8px',
-			overflow: 'hidden',
-		} }
-	>
-		<Story />
-	</div>
-);
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/Comments',

--- a/projects/packages/premium-analytics/widgets/email-breakdown/__tests__/email-breakdown.test.tsx
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/__tests__/email-breakdown.test.tsx
@@ -36,9 +36,7 @@ jest.mock( '@jetpack-premium-analytics/widgets-toolkit', () => ( {
 
 // WidgetRoot reads URL search params as a fallback for report params; outside
 // a matched route the real hook warns and throws.
-jest.mock( '@wordpress/route', () => ( {
-	useSearch: () => ( {} ),
-} ) );
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
 
 const mockApiFetch = apiFetch as unknown as jest.Mock;
 

--- a/projects/packages/premium-analytics/widgets/email-top-row/__tests__/email-top-row.test.tsx
+++ b/projects/packages/premium-analytics/widgets/email-top-row/__tests__/email-top-row.test.tsx
@@ -12,9 +12,7 @@ import type { StatsEmailBreakdown } from '@jetpack-premium-analytics/data';
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
-jest.mock( '@wordpress/route', () => ( {
-	useSearch: () => ( {} ),
-} ) );
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
 
 const mockApiFetch = apiFetch as unknown as jest.Mock;
 

--- a/projects/packages/premium-analytics/widgets/file-downloads/__tests__/file-downloads.test.tsx
+++ b/projects/packages/premium-analytics/widgets/file-downloads/__tests__/file-downloads.test.tsx
@@ -4,7 +4,6 @@
 import { queryClient } from '@jetpack-premium-analytics/data';
 import { render, screen } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
-import type { AnchorHTMLAttributes, ReactNode } from 'react';
 /**
  * Internal dependencies
  */
@@ -12,35 +11,7 @@ import FileDownloadsWidget from '../render';
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
-type MockRouteLinkProps = {
-	to: string;
-	params?: Record< string, unknown >;
-	search?: Record< string, unknown >;
-	children: ReactNode;
-} & Omit< AnchorHTMLAttributes< HTMLAnchorElement >, 'href' >;
-
-jest.mock( '@wordpress/route', () => ( {
-	Link: ( { to, params, search, children, ...props }: MockRouteLinkProps ) => {
-		const path = Object.entries( params ?? {} ).reduce(
-			( result, [ key, value ] ) => result.replace( `$${ key }`, String( value ) ),
-			to
-		);
-		const query = new URLSearchParams();
-		Object.entries( search ?? {} ).forEach( ( [ key, value ] ) => {
-			if ( value !== undefined && value !== null ) {
-				query.set( key, String( value ) );
-			}
-		} );
-		const queryString = query.toString();
-
-		return (
-			<a href={ queryString ? `${ path }?${ queryString }` : path } { ...props }>
-				{ children }
-			</a>
-		);
-	},
-	useSearch: () => ( {} ),
-} ) );
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
 
 const mockApiFetch = apiFetch as unknown as jest.Mock;
 

--- a/projects/packages/premium-analytics/widgets/latest-post/__tests__/use-latest-post.test.tsx
+++ b/projects/packages/premium-analytics/widgets/latest-post/__tests__/use-latest-post.test.tsx
@@ -1,29 +1,22 @@
 /**
  * External dependencies
  */
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { queryClient } from '@jetpack-premium-analytics/data';
 import { renderHook, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
+import { queryClientWrapper as wrapper } from '../../test-utils';
 import { useLatestPost } from '../use-latest-post';
-import type { ReactNode } from 'react';
 
 jest.mock( '@wordpress/api-fetch' );
 
 const mockApiFetch = apiFetch as jest.MockedFunction< typeof apiFetch >;
 
-function wrapper( { children }: { children: ReactNode } ) {
-	const queryClient = new QueryClient( {
-		defaultOptions: { queries: { retry: false } },
-	} );
-
-	return <QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>;
-}
-
 describe( 'useLatestPost', () => {
 	beforeEach( () => {
+		queryClient.clear();
 		mockApiFetch.mockReset();
 	} );
 

--- a/projects/packages/premium-analytics/widgets/plan-usage/__tests__/plan-usage.test.tsx
+++ b/projects/packages/premium-analytics/widgets/plan-usage/__tests__/plan-usage.test.tsx
@@ -13,9 +13,7 @@ jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
 // WidgetRoot reads URL search params as a fallback for report params; outside
 // a matched route the real hook warns and throws.
-jest.mock( '@wordpress/route', () => ( {
-	useSearch: () => ( {} ),
-} ) );
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
 
 const mockApiFetch = apiFetch as unknown as jest.Mock;
 

--- a/projects/packages/premium-analytics/widgets/plan-usage/stories/plan-usage-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/plan-usage/stories/plan-usage-widget.stories.tsx
@@ -27,9 +27,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import PlanUsageRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -120,13 +121,6 @@ function renderPlanUsage( { withComparison }: PlanUsageStoryControls ) {
 		<PlanUsageRender attributes={ { reportParams: getDefaultQueryParams( withComparison ) } } />
 	);
 }
-
-// Close-up canvas so the gauge fills the frame outside the dashboard grid.
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '360px' } }>
-		<Story />
-	</div>
-);
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/PlanUsage',

--- a/projects/packages/premium-analytics/widgets/post-comments/__tests__/post-comments.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-comments/__tests__/post-comments.test.tsx
@@ -11,9 +11,7 @@ import PostCommentsWidget from '../render';
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
-jest.mock( '@wordpress/route', () => ( {
-	useSearch: () => ( {} ),
-} ) );
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
 
 const mockApiFetch = apiFetch as unknown as jest.Mock;
 

--- a/projects/packages/premium-analytics/widgets/post-comments/stories/post-comments-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/post-comments/stories/post-comments-widget.stories.tsx
@@ -12,9 +12,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import PostCommentsRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -41,12 +42,6 @@ function getPostCommentsAttributes( {
 function renderPostComments( controls: PostCommentsStoryControls ) {
 	return <PostCommentsRender attributes={ getPostCommentsAttributes( controls ) } />;
 }
-
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '360px', height: '480px' } }>
-		<Story />
-	</div>
-);
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/PostComments',

--- a/projects/packages/premium-analytics/widgets/post-detail-highlights/__tests__/use-post-highlights.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-detail-highlights/__tests__/use-post-highlights.test.tsx
@@ -1,15 +1,15 @@
 /**
  * External dependencies
  */
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { queryClient } from '@jetpack-premium-analytics/data';
 import { renderHook, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
+import { queryClientWrapper as wrapper } from '../../test-utils';
 import usePostHighlights from '../use-post-highlights';
 import type { ReportParams } from '@jetpack-premium-analytics/data';
-import type { ReactNode } from 'react';
 
 jest.mock( '@wordpress/api-fetch' );
 
@@ -27,18 +27,11 @@ const STATS_POST_RESPONSE = {
 	post: { comment_count: '8' },
 };
 
-function wrapper( { children }: { children: ReactNode } ) {
-	const queryClient = new QueryClient( {
-		defaultOptions: { queries: { retry: false } },
-	} );
-
-	return <QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>;
-}
-
 const reportParams = ( params: Record< string, string > ) => params as unknown as ReportParams;
 
 describe( 'usePostHighlights', () => {
 	beforeEach( () => {
+		queryClient.clear();
 		mockApiFetch.mockReset();
 		mockApiFetch.mockResolvedValue( STATS_POST_RESPONSE );
 	} );

--- a/projects/packages/premium-analytics/widgets/post-detail-highlights/stories/post-detail-highlights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/post-detail-highlights/stories/post-detail-highlights-widget.stories.tsx
@@ -25,9 +25,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import PostDetailHighlightsRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -76,13 +77,6 @@ function renderPostDetailHighlights( controls: PostDetailHighlightsStoryControls
 		<PostDetailHighlightsRender attributes={ getPostDetailHighlightsAttributes( controls ) } />
 	);
 }
-
-// Close-up canvas sized to the tile row outside the dashboard grid.
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '160px' } }>
-		<Story />
-	</div>
-);
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/PostDetailHighlights',

--- a/projects/packages/premium-analytics/widgets/post-likes/__tests__/post-likes.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-likes/__tests__/post-likes.test.tsx
@@ -13,9 +13,7 @@ jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
 // WidgetRoot reads URL search params as a fallback for report params; outside
 // a matched route the real hook warns and throws.
-jest.mock( '@wordpress/route', () => ( {
-	useSearch: () => ( {} ),
-} ) );
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
 
 const mockApiFetch = apiFetch as unknown as jest.Mock;
 

--- a/projects/packages/premium-analytics/widgets/post-likes/stories/post-likes-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/post-likes/stories/post-likes-widget.stories.tsx
@@ -23,9 +23,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import PostLikesRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -68,13 +69,6 @@ function getPostLikesAttributes( {
 function renderPostLikes( controls: PostLikesStoryControls ) {
 	return <PostLikesRender attributes={ getPostLikesAttributes( controls ) } />;
 }
-
-// Close-up canvas sized to the roster outside the dashboard grid.
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '360px', height: '480px' } }>
-		<Story />
-	</div>
-);
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/PostLikes',

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test.tsx
@@ -1,15 +1,15 @@
 /**
  * External dependencies
  */
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { queryClient } from '@jetpack-premium-analytics/data';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
  */
+import { queryClientWrapper as wrapper } from '../../test-utils';
 import usePostTrafficActivity from '../use-post-traffic-activity';
 import type { ReportParams } from '@jetpack-premium-analytics/data';
-import type { ReactNode } from 'react';
 
 jest.mock( '@wordpress/api-fetch' );
 
@@ -25,18 +25,11 @@ const STATS_POST_RESPONSE = {
 	],
 };
 
-function wrapper( { children }: { children: ReactNode } ) {
-	const queryClient = new QueryClient( {
-		defaultOptions: { queries: { retry: false } },
-	} );
-
-	return <QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>;
-}
-
 const reportParams = ( params: Record< string, string > ) => params as unknown as ReportParams;
 
 describe( 'usePostTrafficActivity', () => {
 	beforeEach( () => {
+		queryClient.clear();
 		mockApiFetch.mockReset();
 		mockApiFetch.mockResolvedValue( STATS_POST_RESPONSE );
 	} );

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/stories/post-traffic-activity-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/stories/post-traffic-activity-widget.stories.tsx
@@ -25,9 +25,10 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import PostTrafficActivityRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -76,13 +77,6 @@ function getPostTrafficActivityAttributes( {
 function renderPostTrafficActivity( controls: PostTrafficActivityStoryControls ) {
 	return <PostTrafficActivityRender attributes={ getPostTrafficActivityAttributes( controls ) } />;
 }
-
-// Close-up canvas sized to the heatmap outside the dashboard grid.
-const withWidgetCanvas: Decorator = Story => (
-	<div style={ { width: '100%', height: '400px' } }>
-		<Story />
-	</div>
-);
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/PostTrafficActivity',

--- a/projects/packages/premium-analytics/widgets/referrers/__tests__/referrers.test.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/__tests__/referrers.test.tsx
@@ -4,7 +4,6 @@
 import { getDefaultQueryParams, queryClient } from '@jetpack-premium-analytics/data';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
-import type { AnchorHTMLAttributes, ReactNode } from 'react';
 /**
  * Internal dependencies
  */
@@ -13,35 +12,7 @@ import type { StatsReferrersComparisonItem } from '@jetpack-premium-analytics/da
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
-type MockRouteLinkProps = {
-	to: string;
-	params?: Record< string, unknown >;
-	search?: Record< string, unknown >;
-	children: ReactNode;
-} & Omit< AnchorHTMLAttributes< HTMLAnchorElement >, 'href' >;
-
-jest.mock( '@wordpress/route', () => ( {
-	Link: ( { to, params, search, children, ...props }: MockRouteLinkProps ) => {
-		const path = Object.entries( params ?? {} ).reduce(
-			( result, [ key, value ] ) => result.replace( `$${ key }`, String( value ) ),
-			to
-		);
-		const query = new URLSearchParams();
-		Object.entries( search ?? {} ).forEach( ( [ key, value ] ) => {
-			if ( value !== undefined && value !== null ) {
-				query.set( key, String( value ) );
-			}
-		} );
-		const queryString = query.toString();
-
-		return (
-			<a href={ queryString ? `${ path }?${ queryString }` : path } { ...props }>
-				{ children }
-			</a>
-		);
-	},
-	useSearch: () => ( {} ),
-} ) );
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
 
 const mockApiFetch = apiFetch as unknown as jest.Mock;
 

--- a/projects/packages/premium-analytics/widgets/search-terms/__tests__/search-terms.test.tsx
+++ b/projects/packages/premium-analytics/widgets/search-terms/__tests__/search-terms.test.tsx
@@ -2,42 +2,13 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
-import type { AnchorHTMLAttributes, ReactNode } from 'react';
 /**
  * Internal dependencies
  */
 import SearchTermsWidget from '../render';
 import useSearchTermViews from '../use-search-term-views';
 
-type MockRouteLinkProps = {
-	to: string;
-	params?: Record< string, unknown >;
-	search?: Record< string, unknown >;
-	children: ReactNode;
-} & Omit< AnchorHTMLAttributes< HTMLAnchorElement >, 'href' >;
-
-jest.mock( '@wordpress/route', () => ( {
-	Link: ( { to, params, search, children, ...props }: MockRouteLinkProps ) => {
-		const path = Object.entries( params ?? {} ).reduce(
-			( result, [ key, value ] ) => result.replace( `$${ key }`, String( value ) ),
-			to
-		);
-		const query = new URLSearchParams();
-		Object.entries( search ?? {} ).forEach( ( [ key, value ] ) => {
-			if ( value !== undefined && value !== null ) {
-				query.set( key, String( value ) );
-			}
-		} );
-		const queryString = query.toString();
-
-		return (
-			<a href={ queryString ? `${ path }?${ queryString }` : path } { ...props }>
-				{ children }
-			</a>
-		);
-	},
-	useSearch: () => ( {} ),
-} ) );
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
 
 jest.mock( '../use-search-term-views' );
 

--- a/projects/packages/premium-analytics/widgets/site-overview/__tests__/site-overview.test.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/__tests__/site-overview.test.tsx
@@ -13,9 +13,7 @@ jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
 // WidgetRoot reads URL search params as a fallback for report params; outside
 // a matched route the real hook warns and throws.
-jest.mock( '@wordpress/route', () => ( {
-	useSearch: () => ( {} ),
-} ) );
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
 
 const mockApiFetch = apiFetch as unknown as jest.Mock;
 

--- a/projects/packages/premium-analytics/widgets/subscriber-highlights/__tests__/subscriber-highlights.test.tsx
+++ b/projects/packages/premium-analytics/widgets/subscriber-highlights/__tests__/subscriber-highlights.test.tsx
@@ -13,9 +13,7 @@ jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
 // WidgetRoot reads URL search params as a fallback for report params; outside
 // a matched route the real hook warns and throws.
-jest.mock( '@wordpress/route', () => ( {
-	useSearch: () => ( {} ),
-} ) );
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
 
 const mockApiFetch = apiFetch as unknown as jest.Mock;
 

--- a/projects/packages/premium-analytics/widgets/tags/stories/tags-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/stories/tags-widget.stories.tsx
@@ -5,13 +5,14 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
 	setReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import TagsRender from '../render';
 import widgetDefinition from '../widget';
-import type { Decorator, Meta, StoryObj } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
@@ -53,26 +54,6 @@ function renderTagsWithMax( max: number ) {
 function TagsDashboardRender( props: WidgetRenderProps< unknown > ) {
 	return <TagsRender { ...( props as ComponentProps< typeof TagsRender > ) } />;
 }
-
-// Close-up frame: a white, widget-sized card so the widget reads the way it does
-// as a real dashboard widget (in product the host supplies this frame).
-const withWidgetCanvas: Decorator = Story => (
-	<div
-		style={ {
-			width: '380px',
-			height: '520px',
-			margin: '0 auto',
-			padding: '16px',
-			boxSizing: 'border-box',
-			background: '#fff',
-			border: '1px solid #e0e0e0',
-			borderRadius: '8px',
-			overflow: 'hidden',
-		} }
-	>
-		<Story />
-	</div>
-);
 
 const meta = {
 	title: 'Packages/Premium Analytics/Widgets/Tags',

--- a/projects/packages/premium-analytics/widgets/test-utils.tsx
+++ b/projects/packages/premium-analytics/widgets/test-utils.tsx
@@ -1,0 +1,44 @@
+/**
+ * External dependencies
+ */
+import { queryClient } from '@jetpack-premium-analytics/data';
+import { QueryClientProvider } from '@tanstack/react-query';
+import type { AnchorHTMLAttributes, ReactNode } from 'react';
+
+type MockRouteLinkProps = {
+	to: string;
+	params?: Record< string, unknown >;
+	search?: Record< string, unknown >;
+	children: ReactNode;
+} & Omit< AnchorHTMLAttributes< HTMLAnchorElement >, 'href' >;
+
+function MockRouteLink( { to, params, search, children, ...props }: MockRouteLinkProps ) {
+	const path = Object.entries( params ?? {} ).reduce(
+		( currentPath, [ key, value ] ) => currentPath.replace( `$${ key }`, String( value ) ),
+		to
+	);
+	const query = new URLSearchParams();
+	Object.entries( search ?? {} ).forEach( ( [ key, value ] ) => {
+		if ( value !== undefined && value !== null ) {
+			query.set( key, String( value ) );
+		}
+	} );
+	const queryString = query.toString();
+
+	return (
+		<a href={ queryString ? `${ path }?${ queryString }` : path } { ...props }>
+			{ children }
+		</a>
+	);
+}
+
+/** Shared Jest replacement for the WordPress route module. */
+export const mockWordPressRoute = {
+	Link: MockRouteLink,
+	useSearch: () => ( {} ),
+};
+
+/** Shared renderHook wrapper using the application's query client. */
+export function queryClientWrapper( { children }: { children: ReactNode } ) {
+	return <QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>;
+}

--- a/projects/packages/premium-analytics/widgets/top-posts/__tests__/top-posts.test.tsx
+++ b/projects/packages/premium-analytics/widgets/top-posts/__tests__/top-posts.test.tsx
@@ -5,7 +5,7 @@ import { getScriptData } from '@automattic/jetpack-script-data';
 import { queryClient } from '@jetpack-premium-analytics/data';
 import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
-import type { AnchorHTMLAttributes, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 /**
  * Internal dependencies
  */
@@ -16,39 +16,9 @@ jest.mock( '@automattic/jetpack-script-data', () => ( {
 } ) );
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
-type MockRouteLinkProps = {
-	to: string;
-	params?: Record< string, unknown >;
-	search?: Record< string, unknown >;
-	children: ReactNode;
-} & Omit< AnchorHTMLAttributes< HTMLAnchorElement >, 'href' >;
-
 // WidgetRoot reads URL search params as a fallback for report params; outside
 // a matched route the real hook warns and throws.
-jest.mock( '@wordpress/route', () => ( {
-	Link: ( { to, params, search, children, ...props }: MockRouteLinkProps ) => {
-		// Interpolate `$name` path segments from `params`, mirroring the router,
-		// so a param route like `/reports/$report` resolves to `/reports/posts`.
-		const path = Object.entries( params ?? {} ).reduce(
-			( acc, [ key, value ] ) => acc.replace( `$${ key }`, String( value ) ),
-			to
-		);
-		const query = new URLSearchParams();
-		Object.entries( search ?? {} ).forEach( ( [ key, value ] ) => {
-			if ( value !== undefined && value !== null ) {
-				query.set( key, String( value ) );
-			}
-		} );
-		const queryString = query.toString();
-
-		return (
-			<a href={ queryString ? `${ path }?${ queryString }` : path } { ...props }>
-				{ children }
-			</a>
-		);
-	},
-	useSearch: () => ( {} ),
-} ) );
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
 
 const mockGetScriptData = getScriptData as jest.Mock;
 const mockApiFetch = apiFetch as unknown as jest.Mock;

--- a/projects/packages/premium-analytics/widgets/utm-insights/__tests__/utm-insights.test.tsx
+++ b/projects/packages/premium-analytics/widgets/utm-insights/__tests__/utm-insights.test.tsx
@@ -2,41 +2,12 @@
  * External dependencies
  */
 import { render, screen } from '@testing-library/react';
-import type { AnchorHTMLAttributes, ReactNode } from 'react';
 /**
  * Internal dependencies
  */
 import UtmInsightsWidget from '../render';
 
-type MockRouteLinkProps = {
-	to: string;
-	params?: Record< string, unknown >;
-	search?: Record< string, unknown >;
-	children: ReactNode;
-} & Omit< AnchorHTMLAttributes< HTMLAnchorElement >, 'href' >;
-
-jest.mock( '@wordpress/route', () => ( {
-	Link: ( { to, params, search, children, ...props }: MockRouteLinkProps ) => {
-		const path = Object.entries( params ?? {} ).reduce(
-			( result, [ key, value ] ) => result.replace( `$${ key }`, String( value ) ),
-			to
-		);
-		const query = new URLSearchParams();
-		Object.entries( search ?? {} ).forEach( ( [ key, value ] ) => {
-			if ( value !== undefined && value !== null ) {
-				query.set( key, String( value ) );
-			}
-		} );
-		const queryString = query.toString();
-
-		return (
-			<a href={ queryString ? `${ path }?${ queryString }` : path } { ...props }>
-				{ children }
-			</a>
-		);
-	},
-	useSearch: () => ( {} ),
-} ) );
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
 
 jest.mock( '../use-utm-insights', () => ( {
 	__esModule: true,

--- a/projects/packages/premium-analytics/widgets/video-detail-embeds/__tests__/video-detail-embeds.test.tsx
+++ b/projects/packages/premium-analytics/widgets/video-detail-embeds/__tests__/video-detail-embeds.test.tsx
@@ -11,9 +11,7 @@ import VideoDetailEmbedsWidget from '../render';
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
-jest.mock( '@wordpress/route', () => ( {
-	useSearch: () => ( {} ),
-} ) );
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
 
 const mockApiFetch = apiFetch as unknown as jest.Mock;
 

--- a/projects/packages/premium-analytics/widgets/videopress/__tests__/videopress.test.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/__tests__/videopress.test.tsx
@@ -4,7 +4,7 @@
 import { GlobalErrorProvider, queryClient } from '@jetpack-premium-analytics/data';
 import { render, screen } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
-import type { AnchorHTMLAttributes, ReactElement, ReactNode } from 'react';
+import type { ReactElement } from 'react';
 /**
  * Internal dependencies
  */
@@ -12,37 +12,9 @@ import VideoPressWidget from '../render';
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
-type MockRouteLinkProps = {
-	to: string;
-	params?: Record< string, unknown >;
-	search?: Record< string, unknown >;
-	children: ReactNode;
-} & Omit< AnchorHTMLAttributes< HTMLAnchorElement >, 'href' >;
-
 // WidgetRoot reads URL search params as a fallback for report params; outside
 // a matched route the real hook warns and throws.
-jest.mock( '@wordpress/route', () => ( {
-	Link: ( { to, params, search, children, ...props }: MockRouteLinkProps ) => {
-		const path = Object.entries( params ?? {} ).reduce(
-			( acc, [ key, value ] ) => acc.replace( `$${ key }`, String( value ) ),
-			to
-		);
-		const query = new URLSearchParams();
-		Object.entries( search ?? {} ).forEach( ( [ key, value ] ) => {
-			if ( value !== undefined && value !== null ) {
-				query.set( key, String( value ) );
-			}
-		} );
-		const queryString = query.toString();
-
-		return (
-			<a href={ queryString ? `${ path }?${ queryString }` : path } { ...props }>
-				{ children }
-			</a>
-		);
-	},
-	useSearch: () => ( {} ),
-} ) );
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
 
 const mockApiFetch = apiFetch as unknown as jest.Mock;
 

--- a/projects/packages/premium-analytics/widgets/wordads-highlights/__tests__/wordads-highlights.test.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-highlights/__tests__/wordads-highlights.test.tsx
@@ -13,9 +13,7 @@ jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
 // WidgetRoot reads URL search params as a fallback for report params; outside
 // a matched route the real hook warns and throws.
-jest.mock( '@wordpress/route', () => ( {
-	useSearch: () => ( {} ),
-} ) );
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
 
 const mockApiFetch = apiFetch as unknown as jest.Mock;
 


### PR DESCRIPTION
Part of WOOA7S-1755

## Proposed changes

* Replace seven locally defined Storybook canvases with the shared `withWidgetCanvas` decorator.
* Ensure close-up stories apply the same widget-root framing used for loading, error, and empty states.
* Add a shared widget test utility for the WordPress route mock and React Query wrapper.
* Reuse the application query client in hook tests and clear it between tests.

The local story decorators only rendered a sized `div`, so they omitted the shared canvas behavior that measures and frames the real widget root. This made several stories render differently from the dashboard. The shared test helpers remove repeated setup while keeping the same test behavior.

## Related product discussion/links

* WOOA7S-1755

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run `projects/packages/premium-analytics/node_modules/.bin/tsgo --noEmit -p projects/packages/premium-analytics/tsconfig.json`.
* Run the changed widget test suites with the Premium Analytics Jest configuration.
* Confirm all 19 changed test suites pass (124 tests).
* In Storybook, open Comments, Tags, Post Likes, Plan Usage, Post Detail Highlights, Post Comments, and Post Traffic Activity.
* Confirm their close-up stories remain contained in the shared widget canvas and loading/error states are centered within the widget frame.
