### PR TITLE
VideoPress: promote local videos to VideoPress in-process on WordPress.com Simple

### DIFF
--- a/projects/packages/videopress/changelog/add-videopress-simple-promote-local
+++ b/projects/packages/videopress/changelog/add-videopress-simple-promote-local
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+VideoPress: allow promoting existing local videos to VideoPress on WordPress.com Simple via an in-process wpcom/v2 endpoint

--- a/projects/packages/videopress/routes/library/promote-local.ts
+++ b/projects/packages/videopress/routes/library/promote-local.ts
@@ -1,0 +1,85 @@
+import { __, sprintf } from '@wordpress/i18n';
+
+export type PromoteLocalDeps = {
+	/**
+	 * Fires the promote mutation. Must be a promise that always settles
+	 * (mutateAsync) — TanStack detaches the observer from an in-flight
+	 * mutation when the same hook instance starts another one, silently
+	 * dropping that call's mutate-level callbacks (see useDeleteVideo), so
+	 * concurrent promotes can only be sequenced reliably via promises.
+	 */
+	promote: ( variables: {
+		id: string;
+		onProgress?: ( percent: number ) => void;
+	} ) => Promise< unknown >;
+	createSuccessNotice: ( content: string ) => void;
+	createErrorNotice: ( content: string ) => void;
+	/**
+	 * Receives a fresh snapshot of the in-flight id → upload-percent map
+	 * whenever it changes (a promote starting, a chunk progress report, or
+	 * a promote settling).
+	 */
+	onPromotingChange: ( progress: Map< string, number > ) => void;
+};
+
+/**
+ * Build the library's promote-local handler. The factory owns the in-flight
+ * progress map (the snapshots pushed through `onPromotingChange` drive the
+ * row overlays and their percentages) so a re-entrant call for an id already
+ * being promoted is a no-op — the promote endpoints aren't idempotent under
+ * concurrency, and without the guard a second same-id promote's `.finally()`
+ * would also tear the shared overlay down while the first is still in
+ * flight. Chunk progress from the off-Simple walker is folded into the same
+ * map; the Simple one-shot promote never reports progress, so its rows stay
+ * at 0 until the mutation settles.
+ *
+ * Extracted from the library stage (mirroring `upload-drop.ts`) so the
+ * notice/overlay sequencing is unit-testable without rendering the stage.
+ *
+ * @param deps - The mutation trigger, notice creators, and overlay sink.
+ * @return The `promoteLocal( id )` handler handed to actions and thumbnails.
+ */
+export function createPromoteLocal( deps: PromoteLocalDeps ): ( id: string ) => void {
+	const inFlight = new Map< string, number >();
+	const publish = () => deps.onPromotingChange( new Map( inFlight ) );
+
+	return ( id: string ) => {
+		if ( inFlight.has( id ) ) {
+			return;
+		}
+		inFlight.set( id, 0 );
+		publish();
+
+		deps
+			.promote( {
+				id,
+				onProgress: ( percent: number ) => {
+					// Ignore a straggler progress report after settle.
+					if ( ! inFlight.has( id ) ) {
+						return;
+					}
+					inFlight.set( id, percent );
+					publish();
+				},
+			} )
+			.then( () => {
+				deps.createSuccessNotice( __( 'Video uploaded to VideoPress.', 'jetpack-videopress-pkg' ) );
+			} )
+			.catch( ( error: Error ) => {
+				const reason = error?.message?.trim();
+				deps.createErrorNotice(
+					reason
+						? sprintf(
+								/* translators: %s: reason returned by the upload endpoint, e.g. "403: Invalid Mime". */
+								__( 'Failed to upload video to VideoPress: %s', 'jetpack-videopress-pkg' ),
+								reason
+						  )
+						: __( 'Failed to upload video to VideoPress.', 'jetpack-videopress-pkg' )
+				);
+			} )
+			.finally( () => {
+				inFlight.delete( id );
+				publish();
+			} );
+	};
+}

--- a/projects/packages/videopress/routes/library/promote-local.ts
+++ b/projects/packages/videopress/routes/library/promote-local.ts
@@ -35,6 +35,8 @@ export type PromoteLocalDeps = {
  *
  * Extracted from the library stage (mirroring `upload-drop.ts`) so the
  * notice/overlay sequencing is unit-testable without rendering the stage.
+ * Create it once per stage instance — the in-flight state lives in this
+ * closure, so a fresh factory would forget which rows are mid-promote.
  *
  * @param deps - The mutation trigger, notice creators, and overlay sink.
  * @return The `promoteLocal( id )` handler handed to actions and thumbnails.

--- a/projects/packages/videopress/routes/library/stage.tsx
+++ b/projects/packages/videopress/routes/library/stage.tsx
@@ -89,7 +89,7 @@ const StageInner = () => {
 	const { uploadQueue, startUpload, retryUpload } = useUpload();
 	const { mutateAsync: deleteVideo } = useDeleteVideo();
 	const { mutateAsync: setPrivacyAsync } = useSetPrivacy();
-	const { mutate: uploadFromLibrary } = useUploadFromLibrary();
+	const { mutateAsync: uploadFromLibrary } = useUploadFromLibrary();
 	const { isAtLimit, isFree, isUnlimited, videoCount, limit } = useFreeTier();
 	const runUpgrade = useVideoPressUpgrade();
 
@@ -192,47 +192,49 @@ const StageInner = () => {
 	const promoteLocal = useCallback(
 		( id: string ) => {
 			setPromotingProgress( prev => new Map( prev ).set( id, 0 ) );
-			uploadFromLibrary(
-				{
-					id,
-					onProgress: ( percent: number ) => {
-						setPromotingProgress( prev => {
-							// Ignore a straggler progress report after settle.
-							if ( ! prev.has( id ) ) {
-								return prev;
-							}
-							return new Map( prev ).set( id, percent );
-						} );
-					},
+			// React via the mutateAsync promise rather than mutate-level
+			// callbacks: TanStack detaches the observer from an in-flight
+			// mutation when the same hook instance starts another one,
+			// silently dropping that call's callbacks (see useDeleteVideo) —
+			// with promises, concurrent promotes each keep their own overlay
+			// teardown and notice.
+			uploadFromLibrary( {
+				id,
+				onProgress: ( percent: number ) => {
+					setPromotingProgress( prev => {
+						// Ignore a straggler progress report after settle.
+						if ( ! prev.has( id ) ) {
+							return prev;
+						}
+						return new Map( prev ).set( id, percent );
+					} );
 				},
-				{
-					onSuccess: () => {
-						createSuccessNotice( __( 'Video uploaded to VideoPress.', 'jetpack-videopress-pkg' ) );
-					},
-					onError: ( error: Error ) => {
-						const reason = error?.message?.trim();
-						createErrorNotice(
-							reason
-								? sprintf(
-										/* translators: %s: reason returned by the upload endpoint, e.g. "403: Invalid Mime". */
-										__( 'Failed to upload video to VideoPress: %s', 'jetpack-videopress-pkg' ),
-										reason
-								  )
-								: __( 'Failed to upload video to VideoPress.', 'jetpack-videopress-pkg' )
-						);
-					},
-					onSettled: () => {
-						setPromotingProgress( prev => {
-							if ( ! prev.has( id ) ) {
-								return prev;
-							}
-							const next = new Map( prev );
-							next.delete( id );
-							return next;
-						} );
-					},
-				}
-			);
+			} )
+				.then( () => {
+					createSuccessNotice( __( 'Video uploaded to VideoPress.', 'jetpack-videopress-pkg' ) );
+				} )
+				.catch( ( error: Error ) => {
+					const reason = error?.message?.trim();
+					createErrorNotice(
+						reason
+							? sprintf(
+									/* translators: %s: reason returned by the upload endpoint, e.g. "403: Invalid Mime". */
+									__( 'Failed to upload video to VideoPress: %s', 'jetpack-videopress-pkg' ),
+									reason
+							  )
+							: __( 'Failed to upload video to VideoPress.', 'jetpack-videopress-pkg' )
+					);
+				} )
+				.finally( () => {
+					setPromotingProgress( prev => {
+						if ( ! prev.has( id ) ) {
+							return prev;
+						}
+						const next = new Map( prev );
+						next.delete( id );
+						return next;
+					} );
+				} );
 		},
 		[ uploadFromLibrary, createSuccessNotice, createErrorNotice ]
 	);

--- a/projects/packages/videopress/routes/library/stage.tsx
+++ b/projects/packages/videopress/routes/library/stage.tsx
@@ -20,6 +20,7 @@ import { useSetPrivacy } from '../../src/dashboard/hooks/use-set-privacy';
 import { useUpload } from '../../src/dashboard/hooks/use-upload';
 import { useUploadFromLibrary } from '../../src/dashboard/hooks/use-upload-from-library';
 import { useVideoPressUpgrade } from '../../src/dashboard/hooks/use-videopress-upgrade';
+import { createPromoteLocal } from './promote-local';
 import { planVideoDrop } from './upload-drop';
 import './style.scss';
 import type { LibraryItem, LibraryItemPrivacy } from '../../src/dashboard/types/library';
@@ -189,53 +190,17 @@ const StageInner = () => {
 		[ isFree, isUnlimited, limit, videoCount, startUpload, createErrorNotice, runUpgrade ]
 	);
 
-	const promoteLocal = useCallback(
-		( id: string ) => {
-			setPromotingProgress( prev => new Map( prev ).set( id, 0 ) );
-			// React via the mutateAsync promise rather than mutate-level
-			// callbacks: TanStack detaches the observer from an in-flight
-			// mutation when the same hook instance starts another one,
-			// silently dropping that call's callbacks (see useDeleteVideo) —
-			// with promises, concurrent promotes each keep their own overlay
-			// teardown and notice.
-			uploadFromLibrary( {
-				id,
-				onProgress: ( percent: number ) => {
-					setPromotingProgress( prev => {
-						// Ignore a straggler progress report after settle.
-						if ( ! prev.has( id ) ) {
-							return prev;
-						}
-						return new Map( prev ).set( id, percent );
-					} );
-				},
-			} )
-				.then( () => {
-					createSuccessNotice( __( 'Video uploaded to VideoPress.', 'jetpack-videopress-pkg' ) );
-				} )
-				.catch( ( error: Error ) => {
-					const reason = error?.message?.trim();
-					createErrorNotice(
-						reason
-							? sprintf(
-									/* translators: %s: reason returned by the upload endpoint, e.g. "403: Invalid Mime". */
-									__( 'Failed to upload video to VideoPress: %s', 'jetpack-videopress-pkg' ),
-									reason
-							  )
-							: __( 'Failed to upload video to VideoPress.', 'jetpack-videopress-pkg' )
-					);
-				} )
-				.finally( () => {
-					setPromotingProgress( prev => {
-						if ( ! prev.has( id ) ) {
-							return prev;
-						}
-						const next = new Map( prev );
-						next.delete( id );
-						return next;
-					} );
-				} );
-		},
+	// The factory owns the in-flight progress map (re-entry guard + overlay
+	// snapshots, chunk progress folded in) and reacts via the mutateAsync
+	// promise; see promote-local.ts for why.
+	const promoteLocal = useMemo(
+		() =>
+			createPromoteLocal( {
+				promote: uploadFromLibrary,
+				createSuccessNotice,
+				createErrorNotice,
+				onPromotingChange: setPromotingProgress,
+			} ),
 		[ uploadFromLibrary, createSuccessNotice, createErrorNotice ]
 	);
 

--- a/projects/packages/videopress/routes/library/stage.tsx
+++ b/projects/packages/videopress/routes/library/stage.tsx
@@ -193,15 +193,19 @@ const StageInner = () => {
 	// The factory owns the in-flight progress map (re-entry guard + overlay
 	// snapshots, chunk progress folded in) and reacts via the mutateAsync
 	// promise; see promote-local.ts for why.
-	const promoteLocal = useMemo(
-		() =>
-			createPromoteLocal( {
-				promote: uploadFromLibrary,
-				createSuccessNotice,
-				createErrorNotice,
-				onPromotingChange: setPromotingProgress,
-			} ),
-		[ uploadFromLibrary, createSuccessNotice, createErrorNotice ]
+	// Deliberately created ONCE per stage instance: useGlobalNotices() returns
+	// fresh wrapper closures every render, so a dep-keyed useMemo would rebuild
+	// the factory (emptying its in-flight state) on each render — including the
+	// renders its own publishes trigger. All captured deps are stable: the
+	// notice wrappers forward to registry-bound dispatchers, mutateAsync is
+	// referentially stable in TanStack v5, and state setters never change.
+	const [ promoteLocal ] = useState( () =>
+		createPromoteLocal( {
+			promote: uploadFromLibrary,
+			createSuccessNotice,
+			createErrorNotice,
+			onPromotingChange: setPromotingProgress,
+		} )
 	);
 
 	const actions = useMemo(

--- a/projects/packages/videopress/routes/library/test/promote-local.test.ts
+++ b/projects/packages/videopress/routes/library/test/promote-local.test.ts
@@ -89,7 +89,9 @@ describe( 'createPromoteLocal', () => {
 		createPromoteLocal( deps )( '9' );
 		await flush();
 
-		expect( deps.createErrorNotice ).toHaveBeenCalledWith( 'Failed to upload video to VideoPress.' );
+		expect( deps.createErrorNotice ).toHaveBeenCalledWith(
+			'Failed to upload video to VideoPress.'
+		);
 		// The overlay still tears down on failure.
 		expect( snapshots ).toEqual( [ [ [ '9', 0 ] ], [] ] );
 	} );
@@ -128,7 +130,10 @@ describe( 'createPromoteLocal', () => {
 		expect( deps.createErrorNotice ).toHaveBeenCalledTimes( 1 );
 		expect( snapshots ).toEqual( [
 			[ [ 'a', 0 ] ],
-			[ [ 'a', 0 ], [ 'b', 0 ] ],
+			[
+				[ 'a', 0 ],
+				[ 'b', 0 ],
+			],
 			[ [ 'b', 0 ] ],
 		] );
 

--- a/projects/packages/videopress/routes/library/test/promote-local.test.ts
+++ b/projects/packages/videopress/routes/library/test/promote-local.test.ts
@@ -1,0 +1,141 @@
+import { createPromoteLocal, type PromoteLocalDeps } from '../promote-local';
+
+jest.mock( '@wordpress/i18n', () => ( {
+	__: ( text: string ) => text,
+	sprintf: ( format: string, value: string ) => format.replace( '%s', value ),
+} ) );
+
+type PromoteVariables = Parameters< PromoteLocalDeps[ 'promote' ] >[ 0 ];
+
+type Deferred = {
+	promise: Promise< unknown >;
+	resolve: ( value?: unknown ) => void;
+	reject: ( reason?: unknown ) => void;
+};
+
+const makeDeferred = (): Deferred => {
+	let resolve!: Deferred[ 'resolve' ];
+	let reject!: Deferred[ 'reject' ];
+	const promise = new Promise( ( res, rej ) => {
+		resolve = res;
+		reject = rej;
+	} );
+	return { promise, resolve, reject };
+};
+
+const flush = () => new Promise( resolve => setTimeout( resolve, 0 ) );
+
+const makeDeps = ( promote: ( variables: PromoteVariables ) => Promise< unknown > ) => {
+	const snapshots: [ string, number ][][] = [];
+	const started: PromoteVariables[] = [];
+	const deps = {
+		promote: jest.fn( ( variables: PromoteVariables ) => {
+			started.push( variables );
+			return promote( variables );
+		} ),
+		createSuccessNotice: jest.fn(),
+		createErrorNotice: jest.fn(),
+		onPromotingChange: jest.fn( ( progress: Map< string, number > ) => {
+			snapshots.push( [ ...progress.entries() ].sort() );
+		} ),
+	};
+	return { deps, snapshots, started };
+};
+
+describe( 'createPromoteLocal', () => {
+	it( 'promotes, notices success, and tears the overlay down', async () => {
+		const { deps, snapshots } = makeDeps( () => Promise.resolve() );
+		const promoteLocal = createPromoteLocal( deps );
+
+		promoteLocal( '9' );
+		await flush();
+
+		expect( deps.promote ).toHaveBeenCalledWith(
+			expect.objectContaining( { id: '9', onProgress: expect.any( Function ) } )
+		);
+		expect( deps.createSuccessNotice ).toHaveBeenCalledWith( 'Video uploaded to VideoPress.' );
+		expect( deps.createErrorNotice ).not.toHaveBeenCalled();
+		expect( snapshots ).toEqual( [ [ [ '9', 0 ] ], [] ] );
+	} );
+
+	it( 'folds chunk progress reports into the published map', async () => {
+		const gate = makeDeferred();
+		const { deps, snapshots, started } = makeDeps( () => gate.promise );
+		createPromoteLocal( deps )( '9' );
+
+		started[ 0 ].onProgress?.( 40 );
+		started[ 0 ].onProgress?.( 80 );
+		gate.resolve();
+		await flush();
+
+		// A straggler report after settle must not resurrect the overlay.
+		started[ 0 ].onProgress?.( 100 );
+
+		expect( snapshots ).toEqual( [ [ [ '9', 0 ] ], [ [ '9', 40 ] ], [ [ '9', 80 ] ], [] ] );
+	} );
+
+	it( 'formats the error notice with the rejection message', async () => {
+		const { deps } = makeDeps( () => Promise.reject( new Error( ' 403: Invalid Mime ' ) ) );
+		createPromoteLocal( deps )( '9' );
+		await flush();
+
+		expect( deps.createErrorNotice ).toHaveBeenCalledWith(
+			'Failed to upload video to VideoPress: 403: Invalid Mime'
+		);
+	} );
+
+	it( 'falls back to the generic error notice when the rejection has no message', async () => {
+		const { deps, snapshots } = makeDeps( () => Promise.reject( new Error( '' ) ) );
+		createPromoteLocal( deps )( '9' );
+		await flush();
+
+		expect( deps.createErrorNotice ).toHaveBeenCalledWith( 'Failed to upload video to VideoPress.' );
+		// The overlay still tears down on failure.
+		expect( snapshots ).toEqual( [ [ [ '9', 0 ] ], [] ] );
+	} );
+
+	it( 'ignores a re-entrant call for an id already in flight', async () => {
+		const gate = makeDeferred();
+		const { deps, snapshots } = makeDeps( () => gate.promise );
+		const promoteLocal = createPromoteLocal( deps );
+
+		promoteLocal( '9' );
+		promoteLocal( '9' ); // double-click while in flight — must be a no-op
+		gate.resolve();
+		await flush();
+
+		expect( deps.promote ).toHaveBeenCalledTimes( 1 );
+		expect( deps.createSuccessNotice ).toHaveBeenCalledTimes( 1 );
+		// One add, one teardown — the second click never touched the overlay.
+		expect( snapshots ).toEqual( [ [ [ '9', 0 ] ], [] ] );
+
+		// After settling, the same id may be promoted again.
+		promoteLocal( '9' );
+		expect( deps.promote ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'keeps concurrent promotes of different ids independent', async () => {
+		const gates: Record< string, Deferred > = { a: makeDeferred(), b: makeDeferred() };
+		const { deps, snapshots } = makeDeps( ( { id } ) => gates[ id ].promise );
+		const promoteLocal = createPromoteLocal( deps );
+
+		promoteLocal( 'a' );
+		promoteLocal( 'b' );
+		gates.a.reject( new Error( 'nope' ) );
+		await flush();
+
+		// a settled (error notice), b still overlaid.
+		expect( deps.createErrorNotice ).toHaveBeenCalledTimes( 1 );
+		expect( snapshots ).toEqual( [
+			[ [ 'a', 0 ] ],
+			[ [ 'a', 0 ], [ 'b', 0 ] ],
+			[ [ 'b', 0 ] ],
+		] );
+
+		gates.b.resolve();
+		await flush();
+
+		expect( deps.createSuccessNotice ).toHaveBeenCalledTimes( 1 );
+		expect( snapshots[ snapshots.length - 1 ] ).toEqual( [] );
+	} );
+} );

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
@@ -235,6 +235,33 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 				),
 			)
 		);
+
+		// Promote Route. WordPress.com Simple only: turn an existing local
+		// video attachment into a VideoPress video in-process. The file
+		// already lives on WordPress.com storage, so unlike the self-hosted
+		// flow (which walks videopress/v1/upload/{id} pushing tus chunks)
+		// promotion is a single call: create the global videos-table row and
+		// enqueue the transcode. Lives in wpcom/v2 because videopress/v1
+		// never reaches the REST dispatcher on Simple; the callback returns
+		// a clean error on every other host.
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/promote/(?P<attachment_id>\d+)',
+			array(
+				'args'                => array(
+					'attachment_id' => array(
+						'description' => __( 'The attachment id of the video to promote.', 'jetpack-videopress-pkg' ),
+						'type'        => 'integer',
+						'required'    => true,
+					),
+				),
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'videopress_promote_attachment' ),
+				'permission_callback' => function () {
+					return Data::can_perform_action() && current_user_can( 'upload_files' );
+				},
+			)
+		);
 	}
 
 	/**
@@ -301,6 +328,146 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 		}
 
 		return rest_ensure_response( $response );
+	}
+
+	/**
+	 * Promote an existing local video attachment to VideoPress. WordPress.com
+	 * Simple only.
+	 *
+	 * The population this serves: sites that uploaded videos on a plan
+	 * without VideoPress and later upgraded to one that includes it — their
+	 * pre-upgrade videos are plain attachments with no path onto VideoPress
+	 * (the dashboard's self-hosted promote flow can't run on Simple).
+	 *
+	 * Promotion is in-place: the same attachment id gains a row in the
+	 * global videos table — no sibling attachment is created and no
+	 * `_videopress_uploaded_id` marker is written (that is the self-hosted
+	 * sibling convention). The handler calls the exact primitive every
+	 * direct upload to a VideoPress-enabled Simple site flows through via
+	 * its `add_attachment` hook: `remote_transcode_one_video()`.
+	 *
+	 * @param WP_REST_Request $request The request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function videopress_promote_attachment( $request ) {
+		if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
+			return new WP_Error(
+				'videopress_promote_not_available',
+				__( 'Promoting local videos is only available on WordPress.com sites.', 'jetpack-videopress-pkg' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$attachment_id = (int) $request->get_param( 'attachment_id' );
+		$blog_id       = get_current_blog_id();
+
+		$post = get_post( $attachment_id );
+		if ( ! $post || 'attachment' !== $post->post_type || 'trash' === $post->post_status || ! wp_attachment_is( 'video', $post ) ) {
+			return new WP_Error(
+				'videopress_promote_invalid_attachment',
+				__( 'The attachment is not a video in this site’s media library.', 'jetpack-videopress-pkg' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		/*
+		 * Plan gate. The native path enforces VideoPress at upload/mime time
+		 * (wpcom_site_can_upload_videos()) and remote_transcode_one_video()
+		 * itself checks nothing — without this, a site whose plan allows
+		 * plain video uploads but not VideoPress could enqueue transcodes.
+		 */
+		if ( ! function_exists( 'wpcom_site_has_videopress' ) || ! wpcom_site_has_videopress( $blog_id ) ) {
+			return new WP_Error(
+				'videopress_promote_not_allowed',
+				__( 'This site’s plan does not include VideoPress.', 'jetpack-videopress-pkg' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		/*
+		 * public-api requests define ADMIN_PLUGINS, so the transcode
+		 * primitives are normally already loaded. This mirrors the wpcom TUS
+		 * uploader's ensure_wpcom_admin_includes_present() guard for any
+		 * context where they aren't, and degrades to the clean error below
+		 * (rather than a require fatal) if the files move mid-deploy.
+		 */
+		if ( ! function_exists( 'remote_transcode_one_video' ) && defined( 'ABSPATH' ) && file_exists( ABSPATH . 'wp-content/admin-plugins/videopress/transcode.php' ) ) {
+			require_once ABSPATH . 'wp-content/admin-plugins/videopress/class.videopress-job-base.php';
+			require_once ABSPATH . 'wp-content/admin-plugins/videopress/class.video-job-thumbnails.php';
+			require_once ABSPATH . 'wp-content/admin-plugins/videopress/class.video-thumbnailer.php';
+			require_once ABSPATH . 'wp-content/admin-plugins/videopress/video-transcoder.php';
+			require_once ABSPATH . 'wp-content/admin-plugins/videopress/transcode.php';
+		}
+
+		if ( ! function_exists( 'remote_transcode_one_video' ) || ! function_exists( 'video_get_info_by_blogpostid' ) ) {
+			return new WP_Error(
+				'videopress_promote_unavailable',
+				__( 'VideoPress is not available right now. Please try again later.', 'jetpack-videopress-pkg' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		/*
+		 * Already on VideoPress? Report success idempotently. Cache-busted
+		 * read: the wpcom delete path does clean this key, but a stale 12h
+		 * 'video-info' entry must not misreport here — and the fresh read
+		 * re-primes the cache the primitive's own (non-busted) lookup uses.
+		 */
+		$info = video_get_info_by_blogpostid( $blog_id, $attachment_id, true );
+		if ( $info && ! empty( $info->guid ) ) {
+			return rest_ensure_response(
+				array(
+					'guid'               => $info->guid,
+					'media_id'           => $attachment_id,
+					'already_videopress' => true,
+				)
+			);
+		}
+
+		/*
+		 * remote_transcode_one_video() derives the transcoder's fetch URL
+		 * from the attached file's blogs.dir path with an unguarded regex; a
+		 * non-matching path (some imports/migrations) would still create the
+		 * videos row and enqueue a malformed job that renders as
+		 * "Processing" forever. Validate with the same pattern first
+		 * (verbatim, unescaped dot included) and fail clean.
+		 */
+		$path = get_attached_file( $attachment_id );
+		if ( ! $path || ! preg_match( '|/wp-content/blogs.dir\S+?files(.+)$|i', $path ) ) {
+			return new WP_Error(
+				'videopress_promote_unsupported_file',
+				__( 'This video’s file cannot be promoted automatically. Please download it and upload it again.', 'jetpack-videopress-pkg' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		/*
+		 * Creates the videos-table row (video_create_info()) and enqueues
+		 * the async transcode job. The fresh-upload path sleep(3)s before
+		 * queueing (DB-write settling), so this request takes ~3s.
+		 */
+		remote_transcode_one_video( $attachment_id ); // @phan-suppress-current-line PhanUndeclaredFunction -- wpcom-only (admin-plugins/videopress/transcode.php), function_exists-guarded above; not in the generated wpcom stubs yet.
+
+		/*
+		 * The primitive returns bare false for every bail reason (missing
+		 * attachment, already transcoded, …), so verify by re-reading the
+		 * videos table instead of trusting the return value.
+		 */
+		$info = video_get_info_by_blogpostid( $blog_id, $attachment_id, true );
+		if ( ! $info || empty( $info->guid ) ) {
+			return new WP_Error(
+				'videopress_promote_failed',
+				__( 'The video could not be promoted to VideoPress. Please try again later.', 'jetpack-videopress-pkg' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		return rest_ensure_response(
+			array(
+				'guid'     => $info->guid,
+				'media_id' => $attachment_id,
+			)
+		);
 	}
 
 	/**

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
@@ -425,6 +425,28 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 		}
 
 		/*
+		 * A soft-deleted VideoPress row may still occupy this attachment's
+		 * slot: the videos table's primary key is (blog_id, post_id), so a
+		 * tombstoned row makes video_create_info()'s insert fail silently
+		 * and the fresh promote below would report an unexplained failure.
+		 * (The tombstoned attachment renders as an ordinary local video —
+		 * the REST fields only see live rows — so the UI can reach this.)
+		 * Detect it and answer honestly instead. Resurrecting the row via
+		 * the primitive's $redo path is a possible follow-up, but it needs
+		 * rollback semantics this endpoint doesn't want to own yet.
+		 */
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- wpcom global table; the live-row helper above can't see tombstoned rows, and this must not be cached.
+		$tombstoned_guid = $wpdb->get_var( $wpdb->prepare( 'SELECT guid FROM videos WHERE blog_id = %d AND post_id = %d', $blog_id, $attachment_id ) );
+		if ( $tombstoned_guid ) {
+			return new WP_Error(
+				'videopress_promote_previously_deleted',
+				__( 'This video was previously deleted from VideoPress, so it can’t be promoted automatically. Please upload it as a new video instead.', 'jetpack-videopress-pkg' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		/*
 		 * remote_transcode_one_video() derives the transcoder's fetch URL
 		 * from the attached file's blogs.dir path with an unguarded regex; a
 		 * non-matching path (some imports/migrations) would still create the

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
@@ -350,7 +350,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function videopress_promote_attachment( $request ) {
-		if ( ! defined( 'IS_WPCOM' ) || ! IS_WPCOM ) {
+		if ( ! $this->promote_is_available() ) {
 			return new WP_Error(
 				'videopress_promote_not_available',
 				__( 'Promoting local videos is only available on WordPress.com sites.', 'jetpack-videopress-pkg' ),
@@ -376,7 +376,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 		 * itself checks nothing — without this, a site whose plan allows
 		 * plain video uploads but not VideoPress could enqueue transcodes.
 		 */
-		if ( ! function_exists( 'wpcom_site_has_videopress' ) || ! wpcom_site_has_videopress( $blog_id ) ) {
+		if ( ! $this->promote_site_has_videopress( $blog_id ) ) {
 			return new WP_Error(
 				'videopress_promote_not_allowed',
 				__( 'This site’s plan does not include VideoPress.', 'jetpack-videopress-pkg' ),
@@ -384,31 +384,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 			);
 		}
 
-		/*
-		 * public-api requests define ADMIN_PLUGINS, so the transcode
-		 * primitives are normally already loaded. This mirrors the wpcom TUS
-		 * uploader's ensure_wpcom_admin_includes_present() guard for any
-		 * context where they aren't. Each file is existence-checked
-		 * individually so a partially-moved set mid-deploy degrades to the
-		 * clean error below rather than a require fatal.
-		 */
-		if ( ! function_exists( 'remote_transcode_one_video' ) && defined( 'ABSPATH' ) ) {
-			$transcode_includes = array(
-				'class.videopress-job-base.php',
-				'class.video-job-thumbnails.php',
-				'class.video-thumbnailer.php',
-				'video-transcoder.php',
-				'transcode.php',
-			);
-			foreach ( $transcode_includes as $transcode_include ) {
-				$transcode_include_path = ABSPATH . 'wp-content/admin-plugins/videopress/' . $transcode_include;
-				if ( file_exists( $transcode_include_path ) ) {
-					require_once $transcode_include_path;
-				}
-			}
-		}
-
-		if ( ! function_exists( 'remote_transcode_one_video' ) || ! function_exists( 'video_get_info_by_blogpostid' ) ) {
+		if ( ! $this->promote_load_primitives() ) {
 			return new WP_Error(
 				'videopress_promote_unavailable',
 				__( 'VideoPress is not available right now. Please try again later.', 'jetpack-videopress-pkg' ),
@@ -422,7 +398,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 		 * 'video-info' entry must not misreport here — and the fresh read
 		 * re-primes the cache the primitive's own (non-busted) lookup uses.
 		 */
-		$info = video_get_info_by_blogpostid( $blog_id, $attachment_id, true );
+		$info = $this->promote_video_info( $blog_id, $attachment_id );
 		if ( $info && ! empty( $info->guid ) ) {
 			return rest_ensure_response(
 				array(
@@ -444,10 +420,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 		 * the primitive's $redo path is a possible follow-up, but it needs
 		 * rollback semantics this endpoint doesn't want to own yet.
 		 */
-		global $wpdb;
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- wpcom global table; the live-row helper above can't see tombstoned rows, and this must not be cached.
-		$tombstoned_guid = $wpdb->get_var( $wpdb->prepare( 'SELECT guid FROM videos WHERE blog_id = %d AND post_id = %d', $blog_id, $attachment_id ) );
-		if ( $tombstoned_guid ) {
+		if ( $this->promote_find_any_guid( $blog_id, $attachment_id ) ) {
 			return new WP_Error(
 				'videopress_promote_previously_deleted',
 				__( 'This video was previously deleted from VideoPress, so it can’t be promoted automatically. Please upload it as a new video instead.', 'jetpack-videopress-pkg' ),
@@ -495,14 +468,14 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 		 * the async transcode job. The fresh-upload path sleep(3)s before
 		 * queueing (DB-write settling), so this request takes ~3s.
 		 */
-		remote_transcode_one_video( $attachment_id ); // @phan-suppress-current-line PhanUndeclaredFunction -- wpcom-only (admin-plugins/videopress/transcode.php), function_exists-guarded above; not in the generated wpcom stubs yet.
+		$this->promote_transcode( $attachment_id );
 
 		/*
 		 * The primitive returns bare false for every bail reason (missing
 		 * attachment, already transcoded, …), so verify by re-reading the
 		 * videos table instead of trusting the return value.
 		 */
-		$info = video_get_info_by_blogpostid( $blog_id, $attachment_id, true );
+		$info = $this->promote_video_info( $blog_id, $attachment_id );
 
 		wp_cache_delete( $promote_lock, 'video-info' );
 
@@ -520,6 +493,101 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 				'media_id' => $attachment_id,
 			)
 		);
+	}
+
+	/*
+	 * The five methods below are the promote flow's wpcom seams. They exist
+	 * so the orchestration above is unit-testable: monorepo CI can never
+	 * define IS_WPCOM, so without them every branch past the host guard
+	 * would be dead code under test. A WorDBless test double overrides
+	 * exactly these (and nothing else) to exercise the real ordering,
+	 * error contract, and mutex behavior.
+	 */
+
+	/**
+	 * Whether the in-process promote flow is available on this host.
+	 *
+	 * @return bool
+	 */
+	protected function promote_is_available() {
+		return defined( 'IS_WPCOM' ) && IS_WPCOM;
+	}
+
+	/**
+	 * Whether the site's plan includes VideoPress.
+	 *
+	 * @param int $blog_id The blog to check.
+	 * @return bool
+	 */
+	protected function promote_site_has_videopress( $blog_id ) {
+		return function_exists( 'wpcom_site_has_videopress' ) && wpcom_site_has_videopress( $blog_id );
+	}
+
+	/**
+	 * Ensure the wpcom transcode primitives are loaded.
+	 *
+	 * Public-api requests define ADMIN_PLUGINS, so they normally already
+	 * are; this mirrors the wpcom TUS uploader's
+	 * ensure_wpcom_admin_includes_present() guard for any context where
+	 * they aren't. Each file is existence-checked individually so a
+	 * partially-moved set mid-deploy degrades to the handler's clean error
+	 * rather than a require fatal.
+	 *
+	 * @return bool Whether the primitives are callable.
+	 */
+	protected function promote_load_primitives() {
+		if ( ! function_exists( 'remote_transcode_one_video' ) && defined( 'ABSPATH' ) ) {
+			$transcode_includes = array(
+				'class.videopress-job-base.php',
+				'class.video-job-thumbnails.php',
+				'class.video-thumbnailer.php',
+				'video-transcoder.php',
+				'transcode.php',
+			);
+			foreach ( $transcode_includes as $transcode_include ) {
+				$transcode_include_path = ABSPATH . 'wp-content/admin-plugins/videopress/' . $transcode_include;
+				if ( file_exists( $transcode_include_path ) ) {
+					require_once $transcode_include_path;
+				}
+			}
+		}
+
+		return function_exists( 'remote_transcode_one_video' ) && function_exists( 'video_get_info_by_blogpostid' );
+	}
+
+	/**
+	 * Cache-busted read of the live videos-table row for an attachment.
+	 *
+	 * @param int $blog_id       The blog id.
+	 * @param int $attachment_id The attachment id.
+	 * @return object|false The video info object, or false when no live row exists.
+	 */
+	protected function promote_video_info( $blog_id, $attachment_id ) {
+		return video_get_info_by_blogpostid( $blog_id, $attachment_id, true );
+	}
+
+	/**
+	 * Find any videos-table guid for the attachment, tombstoned included —
+	 * the live-row helper can't see soft-deleted rows.
+	 *
+	 * @param int $blog_id       The blog id.
+	 * @param int $attachment_id The attachment id.
+	 * @return string|null The guid, or null when no row exists at all.
+	 */
+	protected function promote_find_any_guid( $blog_id, $attachment_id ) {
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- wpcom global table; must see tombstoned rows and must not be cached.
+		return $wpdb->get_var( $wpdb->prepare( 'SELECT guid FROM videos WHERE blog_id = %d AND post_id = %d', $blog_id, $attachment_id ) );
+	}
+
+	/**
+	 * Run the wpcom promote primitive for an attachment.
+	 *
+	 * @param int $attachment_id The attachment id.
+	 * @return void
+	 */
+	protected function promote_transcode( $attachment_id ) {
+		remote_transcode_one_video( $attachment_id ); // @phan-suppress-current-line PhanUndeclaredFunction -- wpcom-only (admin-plugins/videopress/transcode.php), promote_load_primitives()-guarded; not in the generated wpcom stubs yet.
 	}
 
 	/**

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
@@ -454,7 +454,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 		 * atomic on the wpcom object cache; the TTL comfortably outlives the
 		 * primitive's sleep(3) and self-heals if the request dies mid-hold.
 		 */
-		$promote_lock = "videopress-promote-{$blog_id}-{$attachment_id}";
+		$promote_lock = $this->promote_lock_key( $blog_id, $attachment_id );
 		if ( ! wp_cache_add( $promote_lock, 1, 'video-info', 30 ) ) {
 			return new WP_Error(
 				'videopress_promote_in_progress',
@@ -503,6 +503,17 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 	 * exactly these (and nothing else) to exercise the real ordering,
 	 * error contract, and mutex behavior.
 	 */
+
+	/**
+	 * The object-cache key serializing promotes of one attachment.
+	 *
+	 * @param int $blog_id       The blog id.
+	 * @param int $attachment_id The attachment id.
+	 * @return string
+	 */
+	protected function promote_lock_key( $blog_id, $attachment_id ) {
+		return "videopress-promote-{$blog_id}-{$attachment_id}";
+	}
 
 	/**
 	 * Whether the in-process promote flow is available on this host.

--- a/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
+++ b/projects/packages/videopress/src/class-wpcom-rest-api-v2-endpoint-videopress.php
@@ -388,15 +388,24 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 		 * public-api requests define ADMIN_PLUGINS, so the transcode
 		 * primitives are normally already loaded. This mirrors the wpcom TUS
 		 * uploader's ensure_wpcom_admin_includes_present() guard for any
-		 * context where they aren't, and degrades to the clean error below
-		 * (rather than a require fatal) if the files move mid-deploy.
+		 * context where they aren't. Each file is existence-checked
+		 * individually so a partially-moved set mid-deploy degrades to the
+		 * clean error below rather than a require fatal.
 		 */
-		if ( ! function_exists( 'remote_transcode_one_video' ) && defined( 'ABSPATH' ) && file_exists( ABSPATH . 'wp-content/admin-plugins/videopress/transcode.php' ) ) {
-			require_once ABSPATH . 'wp-content/admin-plugins/videopress/class.videopress-job-base.php';
-			require_once ABSPATH . 'wp-content/admin-plugins/videopress/class.video-job-thumbnails.php';
-			require_once ABSPATH . 'wp-content/admin-plugins/videopress/class.video-thumbnailer.php';
-			require_once ABSPATH . 'wp-content/admin-plugins/videopress/video-transcoder.php';
-			require_once ABSPATH . 'wp-content/admin-plugins/videopress/transcode.php';
+		if ( ! function_exists( 'remote_transcode_one_video' ) && defined( 'ABSPATH' ) ) {
+			$transcode_includes = array(
+				'class.videopress-job-base.php',
+				'class.video-job-thumbnails.php',
+				'class.video-thumbnailer.php',
+				'video-transcoder.php',
+				'transcode.php',
+			);
+			foreach ( $transcode_includes as $transcode_include ) {
+				$transcode_include_path = ABSPATH . 'wp-content/admin-plugins/videopress/' . $transcode_include;
+				if ( file_exists( $transcode_include_path ) ) {
+					require_once $transcode_include_path;
+				}
+			}
 		}
 
 		if ( ! function_exists( 'remote_transcode_one_video' ) || ! function_exists( 'video_get_info_by_blogpostid' ) ) {
@@ -464,6 +473,24 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 		}
 
 		/*
+		 * Best-effort mutex around the primitive: the pre-checks above are
+		 * check-then-act, and remote_transcode_one_video() ignores
+		 * video_create_info()'s outcome and queues its transcode job
+		 * unconditionally — so two near-simultaneous promotes (double-click,
+		 * two tabs) would transcode the same video twice. wp_cache_add() is
+		 * atomic on the wpcom object cache; the TTL comfortably outlives the
+		 * primitive's sleep(3) and self-heals if the request dies mid-hold.
+		 */
+		$promote_lock = "videopress-promote-{$blog_id}-{$attachment_id}";
+		if ( ! wp_cache_add( $promote_lock, 1, 'video-info', 30 ) ) {
+			return new WP_Error(
+				'videopress_promote_in_progress',
+				__( 'This video is already being promoted to VideoPress.', 'jetpack-videopress-pkg' ),
+				array( 'status' => 409 )
+			);
+		}
+
+		/*
 		 * Creates the videos-table row (video_create_info()) and enqueues
 		 * the async transcode job. The fresh-upload path sleep(3)s before
 		 * queueing (DB-write settling), so this request takes ~3s.
@@ -476,6 +503,9 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress extends WP_REST_Controller {
 		 * videos table instead of trusting the return value.
 		 */
 		$info = video_get_info_by_blogpostid( $blog_id, $attachment_id, true );
+
+		wp_cache_delete( $promote_lock, 'video-info' );
+
 		if ( ! $info || empty( $info->guid ) ) {
 			return new WP_Error(
 				'videopress_promote_failed',

--- a/projects/packages/videopress/src/dashboard/components/library/actions.ts
+++ b/projects/packages/videopress/src/dashboard/components/library/actions.ts
@@ -115,10 +115,10 @@ export function buildLibraryActions( api: Api ): Action< LibraryItem >[] {
 			// On WordPress.com Simple the promote mutation routes through
 			// wpcom/v2/videopress/promote (in-process — the file is already on
 			// WordPress.com storage); elsewhere it walks /videopress/v1/upload/{id}.
-			isEligible: item =>
-				item.type === 'local' &&
-				item.upload.status !== 'uploading' &&
-				item.upload.status !== 'failed',
+			// Allowlist on 'idle' (matching the design note at the top of this
+			// file) so a row whose promote is already in flight — overlaid as
+			// 'promoting' — can't double-fire it.
+			isEligible: item => item.type === 'local' && item.upload.status === 'idle',
 			callback: items => {
 				const [ item ] = items;
 				if ( item ) {

--- a/projects/packages/videopress/src/dashboard/components/library/actions.ts
+++ b/projects/packages/videopress/src/dashboard/components/library/actions.ts
@@ -1,4 +1,3 @@
-import { isSimpleSite } from '@automattic/jetpack-script-data';
 import { __ } from '@wordpress/i18n';
 import type { LibraryItem, LibraryItemPrivacy } from '../../types/library';
 import type { Action } from '@wordpress/dataviews';
@@ -113,11 +112,10 @@ export function buildLibraryActions( api: Api ): Action< LibraryItem >[] {
 			label: __( 'Upload to VideoPress', 'jetpack-videopress-pkg' ),
 			isPrimary: true,
 			supportsBulk: false,
-			// Not offered on WordPress.com Simple: the promote flow walks
-			// /videopress/v1/upload/{id}, and the videopress/v1 namespace never
-			// reaches the REST dispatcher there — the action could only fail.
+			// On WordPress.com Simple the promote mutation routes through
+			// wpcom/v2/videopress/promote (in-process — the file is already on
+			// WordPress.com storage); elsewhere it walks /videopress/v1/upload/{id}.
 			isEligible: item =>
-				! isSimpleSite() &&
 				item.type === 'local' &&
 				item.upload.status !== 'uploading' &&
 				item.upload.status !== 'failed',

--- a/projects/packages/videopress/src/dashboard/components/library/test/actions.test.ts
+++ b/projects/packages/videopress/src/dashboard/components/library/test/actions.test.ts
@@ -73,4 +73,18 @@ describe( 'buildLibraryActions', () => {
 			unsetSimpleSite();
 		}
 	} );
+
+	it( 'makes a local row with any operation in flight ineligible for Upload to VideoPress', () => {
+		const action = buildLibraryActions( makeApi() ).find( a => a.id === 'upload-to-vp' );
+
+		// 'promoting' is the overlay the stage applies while a promote is in
+		// flight — the action must not double-fire it.
+		for ( const status of [ 'promoting', 'deleting', 'uploading', 'failed' ] as const ) {
+			const row = item( { type: 'local', upload: { status, progress: 0 } } );
+			expect( { status, eligible: action?.isEligible?.( row ) } ).toEqual( {
+				status,
+				eligible: false,
+			} );
+		}
+	} );
 } );

--- a/projects/packages/videopress/src/dashboard/components/library/test/actions.test.ts
+++ b/projects/packages/videopress/src/dashboard/components/library/test/actions.test.ts
@@ -55,18 +55,20 @@ describe( 'buildLibraryActions', () => {
 		expect( actions.find( a => a.id === 'manage-captions' )?.isEligible?.( idle ) ).toBe( true );
 	} );
 
-	it( 'offers Upload to VideoPress for idle local items — except on WordPress.com Simple', () => {
+	it( 'offers Upload to VideoPress for idle local items on every host', () => {
 		const local = item( { type: 'local' } );
 		const eligible = ( actions: ReturnType< typeof buildLibraryActions > ) =>
 			actions.find( a => a.id === 'upload-to-vp' )?.isEligible?.( local );
 
 		expect( eligible( buildLibraryActions( makeApi() ) ) ).toBe( true );
 
-		// The promote flow needs /videopress/v1/upload/{id}, which never reaches
-		// the REST dispatcher on Simple — the action must not be offered there.
+		// On WordPress.com Simple the promote mutation routes through the
+		// in-process wpcom/v2/videopress/promote endpoint, so the action is
+		// offered there too (it used to be hidden while only the unreachable
+		// videopress/v1 walker existed).
 		setSimpleSite();
 		try {
-			expect( eligible( buildLibraryActions( makeApi() ) ) ).toBe( false );
+			expect( eligible( buildLibraryActions( makeApi() ) ) ).toBe( true );
 		} finally {
 			unsetSimpleSite();
 		}

--- a/projects/packages/videopress/src/dashboard/components/library/test/thumbnail-field.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/library/test/thumbnail-field.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useProcessingProgress } from '../../../hooks/use-processing-progress';
 import { makeLibraryItem as item } from '../../../test-utils/library-item';
+import { setSimpleSite, unsetSimpleSite } from '../../../test-utils/simple-site';
 import { libraryFields } from '../fields';
 import ThumbnailField from '../thumbnail-field';
 import { UploadActionsProvider, type UploadActions } from '../upload-actions-context';
@@ -59,6 +60,21 @@ describe( 'ThumbnailField — grid Details access', () => {
 
 		await userEvent.click( screen.getByRole( 'button', { name: 'Upload to VideoPress' } ) );
 		expect( actions.promoteLocal ).toHaveBeenCalledWith( '9' );
+	} );
+
+	it( 'offers Upload to VideoPress on WordPress.com Simple too (VIDP-300)', async () => {
+		// The button used to be gated off on Simple while only the unreachable
+		// videopress/v1 walker existed; the wpcom/v2 promote route re-enabled it.
+		setSimpleSite();
+		try {
+			const actions = makeActions();
+			renderField( <ThumbnailField item={ item( { id: '9', type: 'local' } ) } />, actions );
+
+			await userEvent.click( screen.getByRole( 'button', { name: 'Upload to VideoPress' } ) );
+			expect( actions.promoteLocal ).toHaveBeenCalledWith( '9' );
+		} finally {
+			unsetSimpleSite();
+		}
 	} );
 
 	it( 'offers Retry for a failed upload', async () => {

--- a/projects/packages/videopress/src/dashboard/components/library/test/thumbnail-field.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/library/test/thumbnail-field.test.tsx
@@ -52,26 +52,26 @@ describe( 'ThumbnailField — grid Details access', () => {
 		expect( screen.getByText( '01:15' ) ).toBeInTheDocument();
 	} );
 
-	it( 'does not render the open-details button for a local video, and offers Upload instead', async () => {
+	it( 'does not render the open-details button for a local video, and offers Upload on every host', async () => {
 		const actions = makeActions();
-		renderField( <ThumbnailField item={ item( { id: '9', type: 'local' } ) } />, actions );
+		const { unmount } = renderField(
+			<ThumbnailField item={ item( { id: '9', type: 'local' } ) } />,
+			actions
+		);
 
 		expect( screen.queryByRole( 'button', { name: /Edit details/ } ) ).not.toBeInTheDocument();
 
 		await userEvent.click( screen.getByRole( 'button', { name: 'Upload to VideoPress' } ) );
 		expect( actions.promoteLocal ).toHaveBeenCalledWith( '9' );
-	} );
+		unmount();
 
-	it( 'offers Upload to VideoPress on WordPress.com Simple too (VIDP-300)', async () => {
-		// The button used to be gated off on Simple while only the unreachable
-		// videopress/v1 walker existed; the wpcom/v2 promote route re-enabled it.
+		// On WordPress.com Simple too: the button used to be gated off there
+		// while only the unreachable videopress/v1 walker existed (VIDP-300).
 		setSimpleSite();
 		try {
-			const actions = makeActions();
 			renderField( <ThumbnailField item={ item( { id: '9', type: 'local' } ) } />, actions );
-
 			await userEvent.click( screen.getByRole( 'button', { name: 'Upload to VideoPress' } ) );
-			expect( actions.promoteLocal ).toHaveBeenCalledWith( '9' );
+			expect( actions.promoteLocal ).toHaveBeenCalledTimes( 2 );
 		} finally {
 			unsetSimpleSite();
 		}

--- a/projects/packages/videopress/src/dashboard/components/library/thumbnail-field.tsx
+++ b/projects/packages/videopress/src/dashboard/components/library/thumbnail-field.tsx
@@ -1,4 +1,3 @@
-import { isSimpleSite } from '@automattic/jetpack-script-data';
 import { ProgressBar } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { Button, Stack, Text } from '@wordpress/ui';
@@ -107,21 +106,16 @@ export default function ThumbnailField( { item }: Props ) {
 					>
 						<Text>{ __( 'Local video', 'jetpack-videopress-pkg' ) }</Text>
 					</Stack>
-					{ /* The promote flow walks /videopress/v1/upload/{id}, which never
-					     reaches the REST dispatcher on WordPress.com Simple — don't
-					     offer a button that can only fail there. */ }
-					{ ! isSimpleSite() && (
-						<Stack
-							direction="row"
-							align="center"
-							justify="center"
-							className="vp-library__hover-action"
-						>
-							<Button variant="outline" size="compact" onClick={ () => promoteLocal( id ) }>
-								{ __( 'Upload to VideoPress', 'jetpack-videopress-pkg' ) }
-							</Button>
-						</Stack>
-					) }
+					<Stack
+						direction="row"
+						align="center"
+						justify="center"
+						className="vp-library__hover-action"
+					>
+						<Button variant="outline" size="compact" onClick={ () => promoteLocal( id ) }>
+							{ __( 'Upload to VideoPress', 'jetpack-videopress-pkg' ) }
+						</Button>
+					</Stack>
 				</>
 			) : null }
 

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-upload-from-library.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-upload-from-library.test.ts
@@ -208,7 +208,7 @@ describe( 'useUploadFromLibrary', () => {
 
 		let outcome;
 		await act( async () => {
-			outcome = await result.current.mutateAsync( 3 );
+			outcome = await result.current.mutateAsync( { id: 3 } );
 		} );
 
 		expect( outcome ).toEqual( { guid: 'g1234567', mediaId: 3 } );
@@ -229,7 +229,7 @@ describe( 'useUploadFromLibrary', () => {
 		const { result } = renderHook( () => useUploadFromLibrary(), { wrapper } );
 
 		await act( async () => {
-			await result.current.mutateAsync( 3 );
+			await result.current.mutateAsync( { id: 3 } );
 		} );
 
 		expect( paths ).toEqual( [ '/videopress/v1/upload/3' ] );

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-upload-from-library.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-upload-from-library.test.ts
@@ -1,5 +1,12 @@
+import { renderHook, act } from '@testing-library/react';
 import { mockApiFetch } from '../../test-utils/mock-api-fetch';
-import { uploadFromLibrary } from '../use-upload-from-library';
+import { createTestQueryClient, createTestWrapper } from '../../test-utils/query-client-wrapper';
+import { setSimpleSite, unsetSimpleSite } from '../../test-utils/simple-site';
+import {
+	promoteOnSimple,
+	uploadFromLibrary,
+	useUploadFromLibrary,
+} from '../use-upload-from-library';
 
 describe( 'uploadFromLibrary', () => {
 	it( 'returns guid + mediaId immediately when the first response is complete', async () => {
@@ -123,5 +130,82 @@ describe( 'uploadFromLibrary', () => {
 		} ) );
 
 		await expect( uploadFromLibrary( 1, { delayMs: 0 } ) ).rejects.toThrow( '403: Invalid Mime' );
+	} );
+} );
+
+describe( 'promoteOnSimple', () => {
+	it( 'POSTs the wpcom/v2 promote route once and maps the response', async () => {
+		const paths: ( string | undefined )[] = [];
+		mockApiFetch( async ( { path, method } ) => {
+			paths.push( path );
+			expect( method ).toBe( 'POST' );
+			return { guid: 'AbCd1234', media_id: 5 };
+		} );
+
+		await expect( promoteOnSimple( 5 ) ).resolves.toEqual( { guid: 'AbCd1234', mediaId: 5 } );
+		expect( paths ).toEqual( [ '/wpcom/v2/videopress/promote/5' ] );
+	} );
+
+	it( 'maps an idempotent already-on-VideoPress response like a fresh promote', async () => {
+		mockApiFetch( async () => ( {
+			guid: 'AbCd1234',
+			media_id: 9,
+			already_videopress: true,
+		} ) );
+
+		await expect( promoteOnSimple( 9 ) ).resolves.toEqual( { guid: 'AbCd1234', mediaId: 9 } );
+	} );
+
+	it( 'rejects with the REST error payload so callers can surface the message', async () => {
+		mockApiFetch( async () => {
+			throw { code: 'videopress_promote_not_allowed', message: 'No VideoPress here.' };
+		} );
+
+		await expect( promoteOnSimple( 5 ) ).rejects.toMatchObject( {
+			message: 'No VideoPress here.',
+		} );
+	} );
+} );
+
+describe( 'useUploadFromLibrary', () => {
+	afterEach( () => {
+		unsetSimpleSite();
+	} );
+
+	it( 'routes through the one-shot wpcom/v2 promote on Simple (no walker)', async () => {
+		setSimpleSite();
+		const paths: ( string | undefined )[] = [];
+		mockApiFetch( async ( { path } ) => {
+			paths.push( path );
+			return { guid: 'g1234567', media_id: 3 };
+		} );
+
+		const wrapper = createTestWrapper( createTestQueryClient() );
+		const { result } = renderHook( () => useUploadFromLibrary(), { wrapper } );
+
+		let outcome;
+		await act( async () => {
+			outcome = await result.current.mutateAsync( 3 );
+		} );
+
+		expect( outcome ).toEqual( { guid: 'g1234567', mediaId: 3 } );
+		expect( paths ).toEqual( [ '/wpcom/v2/videopress/promote/3' ] );
+	} );
+
+	it( 'keeps walking the videopress/v1 upload endpoint off Simple', async () => {
+		const paths: ( string | undefined )[] = [];
+		mockApiFetch( async ( { path } ) => {
+			paths.push( path );
+			return { status: 'complete', uploaded_details: { guid: 'g', media_id: 3 } };
+		} );
+
+		const wrapper = createTestWrapper( createTestQueryClient() );
+		const { result } = renderHook( () => useUploadFromLibrary(), { wrapper } );
+
+		await act( async () => {
+			await result.current.mutateAsync( 3 );
+		} );
+
+		expect( paths ).toEqual( [ '/videopress/v1/upload/3' ] );
 	} );
 } );

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-upload-from-library.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-upload-from-library.test.ts
@@ -2,6 +2,7 @@ import { renderHook, act } from '@testing-library/react';
 import { mockApiFetch } from '../../test-utils/mock-api-fetch';
 import { createTestQueryClient, createTestWrapper } from '../../test-utils/query-client-wrapper';
 import { setSimpleSite, unsetSimpleSite } from '../../test-utils/simple-site';
+import { LIBRARY_QUERY_KEY } from '../use-library';
 import {
 	promoteOnSimple,
 	uploadFromLibrary,
@@ -180,7 +181,9 @@ describe( 'useUploadFromLibrary', () => {
 			return { guid: 'g1234567', media_id: 3 };
 		} );
 
-		const wrapper = createTestWrapper( createTestQueryClient() );
+		const client = createTestQueryClient();
+		const invalidateSpy = jest.spyOn( client, 'invalidateQueries' );
+		const wrapper = createTestWrapper( client );
 		const { result } = renderHook( () => useUploadFromLibrary(), { wrapper } );
 
 		let outcome;
@@ -190,6 +193,23 @@ describe( 'useUploadFromLibrary', () => {
 
 		expect( outcome ).toEqual( { guid: 'g1234567', mediaId: 3 } );
 		expect( paths ).toEqual( [ '/wpcom/v2/videopress/promote/3' ] );
+		// The listing only learns about the in-place promotion through this
+		// invalidation — nothing else refetches while no item is processing.
+		expect( invalidateSpy ).toHaveBeenCalledWith( { queryKey: [ LIBRARY_QUERY_KEY ] } );
+	} );
+
+	it( 'normalizes a plain apiFetch rejection into an Error with its message', async () => {
+		setSimpleSite();
+		mockApiFetch( async () => {
+			// apiFetch rejects REST errors as plain objects, not Error instances.
+			throw { code: 'videopress_promote_not_allowed', message: 'No VideoPress here.' };
+		} );
+
+		await expect( promoteOnSimple( 5 ) ).rejects.toBeInstanceOf( Error );
+		mockApiFetch( async () => {
+			throw { code: 'videopress_promote_not_allowed', message: 'No VideoPress here.' };
+		} );
+		await expect( promoteOnSimple( 5 ) ).rejects.toThrow( 'No VideoPress here.' );
 	} );
 
 	it( 'keeps walking the videopress/v1 upload endpoint off Simple', async () => {

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-upload-from-library.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-upload-from-library.test.ts
@@ -47,7 +47,8 @@ describe( 'uploadFromLibrary', () => {
 		let i = 0;
 		mockApiFetch( async () => responses[ i++ ] );
 
-		await expect( uploadFromLibrary( 1, { delayMs: 0 } ) ).resolves.toEqual( {
+		// A real (1ms) delay so the between-poll sleep path runs too.
+		await expect( uploadFromLibrary( 1, { delayMs: 1 } ) ).resolves.toEqual( {
 			guid: 'g',
 			mediaId: 9,
 		} );
@@ -132,6 +133,14 @@ describe( 'uploadFromLibrary', () => {
 
 		await expect( uploadFromLibrary( 1, { delayMs: 0 } ) ).rejects.toThrow( '403: Invalid Mime' );
 	} );
+
+	it( 'falls back to a generic message when the error status has no detail', async () => {
+		mockApiFetch( async () => ( { status: 'error' } ) );
+
+		await expect( uploadFromLibrary( 1, { delayMs: 0 } ) ).rejects.toThrow(
+			'Unexpected upload status.'
+		);
+	} );
 } );
 
 describe( 'promoteOnSimple', () => {
@@ -165,6 +174,25 @@ describe( 'promoteOnSimple', () => {
 		await expect( promoteOnSimple( 5 ) ).rejects.toMatchObject( {
 			message: 'No VideoPress here.',
 		} );
+	} );
+
+	it( 'rethrows a rejection that is already an Error untouched', async () => {
+		const original = new Error( 'network down' );
+		mockApiFetch( async () => {
+			throw original;
+		} );
+
+		await expect( promoteOnSimple( 5 ) ).rejects.toBe( original );
+	} );
+
+	it( 'normalizes a messageless rejection into the generic Error', async () => {
+		mockApiFetch( async () => {
+			throw { code: 'mystery' };
+		} );
+
+		await expect( promoteOnSimple( 5 ) ).rejects.toThrow(
+			'Failed to promote video to VideoPress.'
+		);
 	} );
 } );
 

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-upload-from-library.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-upload-from-library.test.ts
@@ -149,31 +149,23 @@ describe( 'promoteOnSimple', () => {
 		mockApiFetch( async ( { path, method } ) => {
 			paths.push( path );
 			expect( method ).toBe( 'POST' );
-			return { guid: 'AbCd1234', media_id: 5 };
+			// `already_videopress` (the idempotent-replay marker) is unread
+			// by the mapper — same result shape either way.
+			return { guid: 'AbCd1234', media_id: 5, already_videopress: true };
 		} );
 
 		await expect( promoteOnSimple( 5 ) ).resolves.toEqual( { guid: 'AbCd1234', mediaId: 5 } );
 		expect( paths ).toEqual( [ '/wpcom/v2/videopress/promote/5' ] );
 	} );
 
-	it( 'maps an idempotent already-on-VideoPress response like a fresh promote', async () => {
-		mockApiFetch( async () => ( {
-			guid: 'AbCd1234',
-			media_id: 9,
-			already_videopress: true,
-		} ) );
-
-		await expect( promoteOnSimple( 9 ) ).resolves.toEqual( { guid: 'AbCd1234', mediaId: 9 } );
-	} );
-
-	it( 'rejects with the REST error payload so callers can surface the message', async () => {
+	it( 'rejects with an Error carrying the REST payload message', async () => {
 		mockApiFetch( async () => {
 			throw { code: 'videopress_promote_not_allowed', message: 'No VideoPress here.' };
 		} );
 
-		await expect( promoteOnSimple( 5 ) ).rejects.toMatchObject( {
-			message: 'No VideoPress here.',
-		} );
+		const rejection = promoteOnSimple( 5 );
+		await expect( rejection ).rejects.toBeInstanceOf( Error );
+		await expect( rejection ).rejects.toMatchObject( { message: 'No VideoPress here.' } );
 	} );
 
 	it( 'rethrows a rejection that is already an Error untouched', async () => {
@@ -224,20 +216,6 @@ describe( 'useUploadFromLibrary', () => {
 		// The listing only learns about the in-place promotion through this
 		// invalidation — nothing else refetches while no item is processing.
 		expect( invalidateSpy ).toHaveBeenCalledWith( { queryKey: [ LIBRARY_QUERY_KEY ] } );
-	} );
-
-	it( 'normalizes a plain apiFetch rejection into an Error with its message', async () => {
-		setSimpleSite();
-		mockApiFetch( async () => {
-			// apiFetch rejects REST errors as plain objects, not Error instances.
-			throw { code: 'videopress_promote_not_allowed', message: 'No VideoPress here.' };
-		} );
-
-		await expect( promoteOnSimple( 5 ) ).rejects.toBeInstanceOf( Error );
-		mockApiFetch( async () => {
-			throw { code: 'videopress_promote_not_allowed', message: 'No VideoPress here.' };
-		} );
-		await expect( promoteOnSimple( 5 ) ).rejects.toThrow( 'No VideoPress here.' );
 	} );
 
 	it( 'keeps walking the videopress/v1 upload endpoint off Simple', async () => {

--- a/projects/packages/videopress/src/dashboard/hooks/use-upload-from-library.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-upload-from-library.ts
@@ -1,3 +1,4 @@
+import { isSimpleSite } from '@automattic/jetpack-script-data';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
 import { LIBRARY_QUERY_KEY } from './use-library';
@@ -135,19 +136,53 @@ export type UploadFromLibraryVariables = {
 	onProgress?: ( percent: number ) => void;
 };
 
+type WpcomPromoteResponse = {
+	guid: string;
+	media_id: number;
+	// Present (true) when the attachment was already on VideoPress and the
+	// endpoint reported success idempotently instead of re-promoting.
+	already_videopress?: boolean;
+};
+
+/**
+ * Promote a local attachment in-process on WordPress.com Simple. The file
+ * already lives on WordPress.com storage, so there is no chunked upload to
+ * walk: a single POST creates the videos-table row and enqueues the
+ * transcode. Promotion is in-place — the attachment keeps its id (no
+ * sibling attachment is created), and the next library refetch shows the
+ * same row as a processing VideoPress video.
+ *
+ * @param attachmentId - The numeric or string WordPress attachment ID.
+ * @return The VideoPress GUID and (unchanged) media post ID.
+ */
+export async function promoteOnSimple(
+	attachmentId: string | number
+): Promise< UploadFromLibraryResult > {
+	const result = await apiFetch< WpcomPromoteResponse >( {
+		path: `/wpcom/v2/videopress/promote/${ attachmentId }`,
+		method: 'POST',
+	} );
+	return { guid: result.guid, mediaId: result.media_id };
+}
 /**
  * Promote an existing local WordPress media attachment to a
- * VideoPress-hosted video by walking the chunked upload endpoint.
- * On success the library query is invalidated so the new VideoPress
- * item appears (in processing state, which the library's existing
- * 2s polling then resolves once the backend finishes transcoding).
+ * VideoPress-hosted video. On WordPress.com Simple this is one in-process
+ * POST to wpcom/v2/videopress/promote (the file is already on WordPress.com
+ * storage); elsewhere it walks the chunked videopress/v1 upload endpoint.
+ * On success the library query is invalidated so the new VideoPress item
+ * appears (in processing state, which the library's existing 2s polling
+ * then resolves once the backend finishes transcoding).
  *
  * @return A react-query mutation.
  */
 export function useUploadFromLibrary() {
 	const client = useQueryClient();
 	return useMutation< UploadFromLibraryResult, Error, UploadFromLibraryVariables >( {
-		mutationFn: ( { id, onProgress } ) => uploadFromLibrary( id, { onProgress } ),
+		// On Simple the promote is a single in-process POST — there are no
+		// chunks, so onProgress never fires and the row's promoting overlay
+		// stays indeterminate until the mutation settles.
+		mutationFn: ( { id, onProgress } ) =>
+			isSimpleSite() ? promoteOnSimple( id ) : uploadFromLibrary( id, { onProgress } ),
 		onSuccess: () => {
 			client.invalidateQueries( { queryKey: [ LIBRARY_QUERY_KEY ] } );
 		},

--- a/projects/packages/videopress/src/dashboard/hooks/use-upload-from-library.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-upload-from-library.ts
@@ -158,10 +158,27 @@ type WpcomPromoteResponse = {
 export async function promoteOnSimple(
 	attachmentId: string | number
 ): Promise< UploadFromLibraryResult > {
-	const result = await apiFetch< WpcomPromoteResponse >( {
-		path: `/wpcom/v2/videopress/promote/${ attachmentId }`,
-		method: 'POST',
-	} );
+	let result: WpcomPromoteResponse;
+	try {
+		result = await apiFetch< WpcomPromoteResponse >( {
+			path: `/wpcom/v2/videopress/promote/${ attachmentId }`,
+			method: 'POST',
+		} );
+	} catch ( err ) {
+		// apiFetch rejects REST errors as plain { code, message } objects;
+		// normalize to Error so the mutation's declared error type stays
+		// truthful and stage-level notices can rely on `.message`.
+		if ( err instanceof Error ) {
+			throw err;
+		}
+		const message = ( err as { message?: string } )?.message;
+		throw new Error(
+			typeof message === 'string' && message !== ''
+				? message
+				: 'Failed to promote video to VideoPress.',
+			{ cause: err }
+		);
+	}
 	return { guid: result.guid, mediaId: result.media_id };
 }
 /**

--- a/projects/packages/videopress/src/utility-functions.php
+++ b/projects/packages/videopress/src/utility-functions.php
@@ -493,11 +493,15 @@ function videopress_make_resumable_upload_path( $blog_id ) {
  * This is a mock of the internal VideoPress method, which is meant to duplicate the functionality
  * of the WPCOM API, so that the Jetpack REST API returns the same data with no modifications.
  *
- * @param int $blog_id Blog ID.
- * @param int $post_id Post ID.
+ * @param int  $blog_id    Blog ID.
+ * @param int  $post_id    Post ID.
+ * @param bool $cache_bust Ignored. The real WPCOM function caches reads for 12 hours and this
+ *                         param forces a fresh read; the mock reads local postmeta directly.
+ *                         Mirrored here so IS_WPCOM call sites can pass it without the shared
+ *                         signature diverging from the real one.
  * @return stdClass
  */
-function video_get_info_by_blogpostid( $blog_id, $post_id ) {
+function video_get_info_by_blogpostid( $blog_id, $post_id, $cache_bust = false ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable -- see docblock.
 	$post = get_post( $post_id );
 
 	$video_info                  = new stdClass();

--- a/projects/packages/videopress/tests/php/WPCOM_REST_API_V2_Endpoint_VideoPress_Test.php
+++ b/projects/packages/videopress/tests/php/WPCOM_REST_API_V2_Endpoint_VideoPress_Test.php
@@ -505,6 +505,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 		$attachment_id = $this->make_attachment();
 		$lock          = 'videopress-promote-' . get_current_blog_id() . '-' . $attachment_id;
 
+		$result = null;
 		wp_cache_add( $lock, 1, 'video-info', 30 );
 		try {
 			$result = $endpoint->videopress_promote_attachment( $this->promote_request( $attachment_id ) );
@@ -568,9 +569,15 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 		$endpoint = new WPCOM_REST_API_V2_Endpoint_VideoPress();
 
 		$load_primitives = new \ReflectionMethod( $endpoint, 'promote_load_primitives' );
-		$this->assertFalse( $load_primitives->invoke( $endpoint ), 'Transcode primitives must not be loadable off-WPCOM.' );
+		$plan_gate       = new \ReflectionMethod( $endpoint, 'promote_site_has_videopress' );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			// Required to invoke protected methods before PHP 8.1; a
+			// deprecated no-op from PHP 8.5 on, so gate the call.
+			$load_primitives->setAccessible( true );
+			$plan_gate->setAccessible( true );
+		}
 
-		$plan_gate = new \ReflectionMethod( $endpoint, 'promote_site_has_videopress' );
+		$this->assertFalse( $load_primitives->invoke( $endpoint ), 'Transcode primitives must not be loadable off-WPCOM.' );
 		$this->assertFalse( $plan_gate->invoke( $endpoint, get_current_blog_id() ), 'The plan gate must fail closed off-WPCOM.' );
 	}
 

--- a/projects/packages/videopress/tests/php/WPCOM_REST_API_V2_Endpoint_VideoPress_Test.php
+++ b/projects/packages/videopress/tests/php/WPCOM_REST_API_V2_Endpoint_VideoPress_Test.php
@@ -325,6 +325,256 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Build a promote request for an attachment id.
+	 *
+	 * @param int $attachment_id The attachment id.
+	 * @return \WP_REST_Request
+	 */
+	private function promote_request( $attachment_id ) {
+		$request = new \WP_REST_Request( 'POST', '/wpcom/v2/videopress/promote/' . $attachment_id );
+		$request->set_param( 'attachment_id', $attachment_id );
+		return $request;
+	}
+
+	/**
+	 * Create an attachment whose attached file has the given path and mime.
+	 *
+	 * @param string $file The attached-file path (leading slash keeps it verbatim).
+	 * @param string $mime The attachment mime type.
+	 * @return int The attachment id.
+	 */
+	private function make_attachment( $file = '/wp-content/blogs.dir/9a1/12345/files/2026/07/test.mp4', $mime = 'video/mp4' ) {
+		$attachment_id = wp_insert_post(
+			array(
+				'post_type'      => 'attachment',
+				'post_status'    => 'inherit',
+				'post_mime_type' => $mime,
+				'post_title'     => 'Promote orchestration fixture',
+			)
+		);
+		update_post_meta( $attachment_id, '_wp_attached_file', $file );
+		return $attachment_id;
+	}
+
+	/**
+	 * Build the promote seam double.
+	 *
+	 * @return Mock_Promote_Endpoint
+	 */
+	private function make_promote_double() {
+		require_once __DIR__ . '/mocks/class-mock-promote-endpoint.php';
+		return new Mock_Promote_Endpoint();
+	}
+
+	/**
+	 * Test that the promote orchestration reports not-available when the
+	 * host seam says so (the production seam's IS_WPCOM path is covered by
+	 * the dispatch test above).
+	 */
+	public function test_promote_orchestration_reports_not_available() {
+		$endpoint            = $this->make_promote_double();
+		$endpoint->available = false;
+
+		$result = $endpoint->videopress_promote_attachment( $this->promote_request( 123 ) );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'videopress_promote_not_available', $result->get_error_code() );
+		$this->assertSame( 404, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * Test that missing, non-attachment, trashed, and non-video targets are
+	 * all rejected as invalid attachments before any wpcom seam is touched.
+	 */
+	public function test_promote_orchestration_rejects_invalid_attachments() {
+		$endpoint = $this->make_promote_double();
+
+		$page_id    = wp_insert_post(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+				'post_title'  => 'Not an attachment',
+			)
+		);
+		$trashed_id = $this->make_attachment();
+		wp_update_post(
+			array(
+				'ID'          => $trashed_id,
+				'post_status' => 'trash',
+			)
+		);
+		$text_id = $this->make_attachment( '/wp-content/blogs.dir/9a1/12345/files/2026/07/notes.txt', 'text/plain' );
+
+		foreach ( array( 999999, $page_id, $trashed_id, $text_id ) as $target ) {
+			$result = $endpoint->videopress_promote_attachment( $this->promote_request( $target ) );
+			$this->assertInstanceOf( \WP_Error::class, $result, "Target {$target} should be rejected." );
+			$this->assertSame( 'videopress_promote_invalid_attachment', $result->get_error_code(), "Target {$target} should be an invalid attachment." );
+		}
+		$this->assertSame( array(), $endpoint->transcoded );
+	}
+
+	/**
+	 * Test that a site without VideoPress gets a 403 from the plan gate.
+	 */
+	public function test_promote_orchestration_requires_videopress_plan() {
+		$endpoint                 = $this->make_promote_double();
+		$endpoint->has_videopress = false;
+		$attachment_id            = $this->make_attachment();
+
+		$result = $endpoint->videopress_promote_attachment( $this->promote_request( $attachment_id ) );
+
+		$this->assertSame( 'videopress_promote_not_allowed', $result->get_error_code() );
+		$this->assertSame( 403, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * Test that unavailable transcode primitives produce a clean 500.
+	 */
+	public function test_promote_orchestration_reports_unavailable_primitives() {
+		$endpoint                    = $this->make_promote_double();
+		$endpoint->primitives_loaded = false;
+		$attachment_id               = $this->make_attachment();
+
+		$result = $endpoint->videopress_promote_attachment( $this->promote_request( $attachment_id ) );
+
+		$this->assertSame( 'videopress_promote_unavailable', $result->get_error_code() );
+		$this->assertSame( 500, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * Test that an attachment already on VideoPress reports success
+	 * idempotently without invoking the primitive.
+	 */
+	public function test_promote_orchestration_is_idempotent_for_live_videos() {
+		$endpoint              = $this->make_promote_double();
+		$endpoint->video_infos = array( (object) array( 'guid' => 'AbCd1234' ) );
+		$attachment_id         = $this->make_attachment();
+
+		$result = $endpoint->videopress_promote_attachment( $this->promote_request( $attachment_id ) );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $result );
+		$this->assertSame(
+			array(
+				'guid'               => 'AbCd1234',
+				'media_id'           => $attachment_id,
+				'already_videopress' => true,
+			),
+			$result->get_data()
+		);
+		$this->assertSame( array(), $endpoint->transcoded );
+	}
+
+	/**
+	 * Test that a tombstoned videos row produces the specific 409 instead of
+	 * an unexplained failure, without invoking the primitive.
+	 */
+	public function test_promote_orchestration_rejects_previously_deleted_videos() {
+		$endpoint           = $this->make_promote_double();
+		$endpoint->any_guid = 'DeAd1234';
+		$attachment_id      = $this->make_attachment();
+
+		$result = $endpoint->videopress_promote_attachment( $this->promote_request( $attachment_id ) );
+
+		$this->assertSame( 'videopress_promote_previously_deleted', $result->get_error_code() );
+		$this->assertSame( 409, $result->get_error_data()['status'] );
+		$this->assertSame( array(), $endpoint->transcoded );
+	}
+
+	/**
+	 * Test that a file outside the blogs.dir shape fails clean with a 400 —
+	 * the primitive would otherwise create a broken row plus a malformed
+	 * transcode job stuck at "Processing" forever.
+	 */
+	public function test_promote_orchestration_rejects_non_blogsdir_files() {
+		$endpoint      = $this->make_promote_double();
+		$attachment_id = $this->make_attachment( '/var/imported/2026/07/migrated.mp4' );
+
+		$result = $endpoint->videopress_promote_attachment( $this->promote_request( $attachment_id ) );
+
+		$this->assertSame( 'videopress_promote_unsupported_file', $result->get_error_code() );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+		$this->assertSame( array(), $endpoint->transcoded );
+	}
+
+	/**
+	 * Test that a concurrent promote holding the lock turns into a 409 and
+	 * the primitive is not invoked.
+	 */
+	public function test_promote_orchestration_respects_the_promote_lock() {
+		$endpoint      = $this->make_promote_double();
+		$attachment_id = $this->make_attachment();
+		$lock          = 'videopress-promote-' . get_current_blog_id() . '-' . $attachment_id;
+
+		wp_cache_add( $lock, 1, 'video-info', 30 );
+		try {
+			$result = $endpoint->videopress_promote_attachment( $this->promote_request( $attachment_id ) );
+		} finally {
+			wp_cache_delete( $lock, 'video-info' );
+		}
+
+		$this->assertSame( 'videopress_promote_in_progress', $result->get_error_code() );
+		$this->assertSame( 409, $result->get_error_data()['status'] );
+		$this->assertSame( array(), $endpoint->transcoded );
+	}
+
+	/**
+	 * Test the fresh-promote happy path: the primitive runs once, the
+	 * verification read supplies the new guid, and the lock is released.
+	 */
+	public function test_promote_orchestration_promotes_and_releases_the_lock() {
+		$endpoint              = $this->make_promote_double();
+		$endpoint->video_infos = array( false, (object) array( 'guid' => 'Ne3w1234' ) );
+		$attachment_id         = $this->make_attachment();
+		$lock                  = 'videopress-promote-' . get_current_blog_id() . '-' . $attachment_id;
+
+		$result = $endpoint->videopress_promote_attachment( $this->promote_request( $attachment_id ) );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $result );
+		$this->assertSame(
+			array(
+				'guid'     => 'Ne3w1234',
+				'media_id' => $attachment_id,
+			),
+			$result->get_data()
+		);
+		$this->assertSame( array( $attachment_id ), $endpoint->transcoded );
+		$this->assertFalse( wp_cache_get( $lock, 'video-info' ), 'The promote lock should be released after success.' );
+	}
+
+	/**
+	 * Test that a promote whose verification read finds no row reports a 500
+	 * — the primitive returns bare false for every bail reason — and still
+	 * releases the lock.
+	 */
+	public function test_promote_orchestration_reports_failure_and_releases_the_lock() {
+		$endpoint      = $this->make_promote_double();
+		$attachment_id = $this->make_attachment();
+		$lock          = 'videopress-promote-' . get_current_blog_id() . '-' . $attachment_id;
+
+		$result = $endpoint->videopress_promote_attachment( $this->promote_request( $attachment_id ) );
+
+		$this->assertSame( 'videopress_promote_failed', $result->get_error_code() );
+		$this->assertSame( 500, $result->get_error_data()['status'] );
+		$this->assertSame( array( $attachment_id ), $endpoint->transcoded );
+		$this->assertFalse( wp_cache_get( $lock, 'video-info' ), 'The promote lock should be released after failure.' );
+	}
+
+	/**
+	 * Test that the real (non-double) wpcom seams fail closed off-WPCOM:
+	 * the transcode primitives can't be loaded (the admin-plugins files
+	 * don't exist here) and the plan gate reports no VideoPress.
+	 */
+	public function test_promote_real_seams_fail_closed_off_wpcom() {
+		$endpoint = new WPCOM_REST_API_V2_Endpoint_VideoPress();
+
+		$load_primitives = new \ReflectionMethod( $endpoint, 'promote_load_primitives' );
+		$this->assertFalse( $load_primitives->invoke( $endpoint ), 'Transcode primitives must not be loadable off-WPCOM.' );
+
+		$plan_gate = new \ReflectionMethod( $endpoint, 'promote_site_has_videopress' );
+		$this->assertFalse( $plan_gate->invoke( $endpoint, get_current_blog_id() ), 'The plan gate must fail closed off-WPCOM.' );
+	}
+
+	/**
 	 * Data provider for valid privacy_setting values.
 	 *
 	 * @return array[] Test cases.

--- a/projects/packages/videopress/tests/php/WPCOM_REST_API_V2_Endpoint_VideoPress_Test.php
+++ b/projects/packages/videopress/tests/php/WPCOM_REST_API_V2_Endpoint_VideoPress_Test.php
@@ -28,6 +28,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 	private const ROUTE_UPLOAD_JWT      = '/wpcom/v2/videopress/upload-jwt';
 	private const ROUTE_PLAYBACK_JWT    = '/wpcom/v2/videopress/playback-jwt/(?P<video_guid>[A-Za-z0-9]{8})';
 	private const ROUTE_SETTINGS        = '/wpcom/v2/videopress/settings';
+	private const ROUTE_PROMOTE         = '/wpcom/v2/videopress/promote/(?P<attachment_id>\d+)';
 
 	/**
 	 * Set up the test environment.
@@ -107,6 +108,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 		$this->assertArrayHasKey( self::ROUTE_UPLOAD_JWT, $routes );
 		$this->assertArrayHasKey( self::ROUTE_PLAYBACK_JWT, $routes );
 		$this->assertArrayHasKey( self::ROUTE_SETTINGS, $routes );
+		$this->assertArrayHasKey( self::ROUTE_PROMOTE, $routes );
 	}
 
 	/**
@@ -246,6 +248,80 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( 'success', $response->get_data()['code'] );
 		$this->assertTrue( (bool) get_option( 'videopress_auto_subtitles_disabled' ) );
+	}
+
+	/**
+	 * Test that the promote route's attachment_id path param carries an
+	 * integer schema and the route regex rejects non-numeric ids outright.
+	 */
+	public function test_promote_route_has_attachment_id_schema() {
+		$routes = rest_get_server()->get_routes();
+		$args   = $routes[ self::ROUTE_PROMOTE ][0]['args'];
+
+		$this->assertArrayHasKey( 'attachment_id', $args );
+		$this->assertSame( 'integer', $args['attachment_id']['type'] );
+		$this->assertTrue( $args['attachment_id']['required'] );
+
+		$request  = new \WP_REST_Request( 'POST', '/wpcom/v2/videopress/promote/not-a-number' );
+		$response = rest_get_server()->dispatch( $request );
+		$this->assertSame( 404, $response->get_status() );
+	}
+
+	/**
+	 * Test that a logged-out promote POST is rejected with a 401.
+	 */
+	public function test_promote_dispatch_requires_authentication() {
+		wp_set_current_user( 0 );
+
+		$request  = new \WP_REST_Request( 'POST', '/wpcom/v2/videopress/promote/123' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test that a user without upload_files can't promote, even when the
+	 * connection term of the permission callback would pass.
+	 */
+	public function test_promote_dispatch_rejects_users_without_upload_files() {
+		$user_id = $this->login_as( 'subscriber' );
+		$this->mock_connection( $user_id );
+
+		$request  = new \WP_REST_Request( 'POST', '/wpcom/v2/videopress/promote/123' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * Test that even an author-level user can't promote without a Jetpack
+	 * connection off-WPCOM (Data::can_perform_action() requires one).
+	 */
+	public function test_promote_dispatch_rejects_unconnected_uploader() {
+		$this->login_as( 'author' );
+
+		$request  = new \WP_REST_Request( 'POST', '/wpcom/v2/videopress/promote/123' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * Test that a connected uploader clears the permission callback and the
+	 * handler then reports the endpoint unavailable off-WPCOM: promotion is
+	 * in-process on WordPress.com Simple only (self-hosted promotes walk
+	 * videopress/v1/upload/{id} instead), and IS_WPCOM can't be simulated
+	 * in this environment.
+	 */
+	public function test_promote_dispatch_reports_not_available_off_wpcom() {
+		$user_id = $this->login_as( 'author' );
+		$this->mock_connection( $user_id );
+
+		$request  = new \WP_REST_Request( 'POST', '/wpcom/v2/videopress/promote/123' );
+		$response = rest_get_server()->dispatch( $request );
+
+		$this->assertSame( 404, $response->get_status() );
+		$this->assertSame( 'videopress_promote_not_available', $response->get_data()['code'] );
 	}
 
 	/**

--- a/projects/packages/videopress/tests/php/WPCOM_REST_API_V2_Endpoint_VideoPress_Test.php
+++ b/projects/packages/videopress/tests/php/WPCOM_REST_API_V2_Endpoint_VideoPress_Test.php
@@ -566,6 +566,12 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 	 * don't exist here) and the plan gate reports no VideoPress.
 	 */
 	public function test_promote_real_seams_fail_closed_off_wpcom() {
+		if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
+			// The wpcom test harness (wpcut) runs this suite inside the real
+			// platform, where the primitives load and the plan gate is live.
+			$this->markTestSkipped( 'On WordPress.com the real seams are open by design.' );
+		}
+
 		$endpoint = new WPCOM_REST_API_V2_Endpoint_VideoPress();
 
 		$load_primitives = new \ReflectionMethod( $endpoint, 'promote_load_primitives' );

--- a/projects/packages/videopress/tests/php/WPCOM_REST_API_V2_Endpoint_VideoPress_Test.php
+++ b/projects/packages/videopress/tests/php/WPCOM_REST_API_V2_Endpoint_VideoPress_Test.php
@@ -503,7 +503,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 	public function test_promote_orchestration_respects_the_promote_lock() {
 		$endpoint      = $this->make_promote_double();
 		$attachment_id = $this->make_attachment();
-		$lock          = 'videopress-promote-' . get_current_blog_id() . '-' . $attachment_id;
+		$lock          = $endpoint->lock_key( get_current_blog_id(), $attachment_id );
 
 		$result = null;
 		wp_cache_add( $lock, 1, 'video-info', 30 );
@@ -526,7 +526,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 		$endpoint              = $this->make_promote_double();
 		$endpoint->video_infos = array( false, (object) array( 'guid' => 'Ne3w1234' ) );
 		$attachment_id         = $this->make_attachment();
-		$lock                  = 'videopress-promote-' . get_current_blog_id() . '-' . $attachment_id;
+		$lock                  = $endpoint->lock_key( get_current_blog_id(), $attachment_id );
 
 		$result = $endpoint->videopress_promote_attachment( $this->promote_request( $attachment_id ) );
 
@@ -550,7 +550,7 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 	public function test_promote_orchestration_reports_failure_and_releases_the_lock() {
 		$endpoint      = $this->make_promote_double();
 		$attachment_id = $this->make_attachment();
-		$lock          = 'videopress-promote-' . get_current_blog_id() . '-' . $attachment_id;
+		$lock          = $endpoint->lock_key( get_current_blog_id(), $attachment_id );
 
 		$result = $endpoint->videopress_promote_attachment( $this->promote_request( $attachment_id ) );
 
@@ -572,19 +572,29 @@ class WPCOM_REST_API_V2_Endpoint_VideoPress_Test extends BaseTestCase {
 			$this->markTestSkipped( 'On WordPress.com the real seams are open by design.' );
 		}
 
-		$endpoint = new WPCOM_REST_API_V2_Endpoint_VideoPress();
+		$endpoint = new class() extends WPCOM_REST_API_V2_Endpoint_VideoPress {
+			/**
+			 * Expose the protected primitives-loading seam.
+			 *
+			 * @return bool
+			 */
+			public function load_primitives() {
+				return $this->promote_load_primitives();
+			}
 
-		$load_primitives = new \ReflectionMethod( $endpoint, 'promote_load_primitives' );
-		$plan_gate       = new \ReflectionMethod( $endpoint, 'promote_site_has_videopress' );
-		if ( \PHP_VERSION_ID < 80100 ) {
-			// Required to invoke protected methods before PHP 8.1; a
-			// deprecated no-op from PHP 8.5 on, so gate the call.
-			$load_primitives->setAccessible( true );
-			$plan_gate->setAccessible( true );
-		}
+			/**
+			 * Expose the protected plan-gate seam.
+			 *
+			 * @param int $blog_id The blog id.
+			 * @return bool
+			 */
+			public function plan_gate( $blog_id ) {
+				return $this->promote_site_has_videopress( $blog_id );
+			}
+		};
 
-		$this->assertFalse( $load_primitives->invoke( $endpoint ), 'Transcode primitives must not be loadable off-WPCOM.' );
-		$this->assertFalse( $plan_gate->invoke( $endpoint, get_current_blog_id() ), 'The plan gate must fail closed off-WPCOM.' );
+		$this->assertFalse( $endpoint->load_primitives(), 'Transcode primitives must not be loadable off-WPCOM.' );
+		$this->assertFalse( $endpoint->plan_gate( get_current_blog_id() ), 'The plan gate must fail closed off-WPCOM.' );
 	}
 
 	/**

--- a/projects/packages/videopress/tests/php/mocks/class-mock-promote-endpoint.php
+++ b/projects/packages/videopress/tests/php/mocks/class-mock-promote-endpoint.php
@@ -68,6 +68,19 @@ class Mock_Promote_Endpoint extends WPCOM_REST_API_V2_Endpoint_VideoPress {
 	}
 
 	/**
+	 * Public passthrough so tests assert against the production lock-key
+	 * format instead of hand-rebuilding it (a stale copy would make the
+	 * lock-release assertions pass vacuously).
+	 *
+	 * @param int $blog_id       The blog id.
+	 * @param int $attachment_id The attachment id.
+	 * @return string
+	 */
+	public function lock_key( $blog_id, $attachment_id ) {
+		return $this->promote_lock_key( $blog_id, $attachment_id );
+	}
+
+	/**
 	 * Scripted host availability.
 	 *
 	 * @return bool

--- a/projects/packages/videopress/tests/php/mocks/class-mock-promote-endpoint.php
+++ b/projects/packages/videopress/tests/php/mocks/class-mock-promote-endpoint.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Seam double for the promote flow of WPCOM_REST_API_V2_Endpoint_VideoPress.
+ *
+ * @package automattic/jetpack-videopress
+ */
+
+namespace Automattic\Jetpack\VideoPress;
+
+/**
+ * Overrides exactly the wpcom-touching promote seams so WorDBless tests can
+ * drive the real orchestration in videopress_promote_attachment() — the
+ * ordering, error contract, and mutex behavior — none of which is otherwise
+ * reachable in CI (IS_WPCOM can't be defined there). Everything not listed
+ * here (attachment validation, path check, wp_cache mutex, responses) runs
+ * the production code.
+ */
+class Mock_Promote_Endpoint extends WPCOM_REST_API_V2_Endpoint_VideoPress {
+
+	/**
+	 * Scripted promote_is_available() result.
+	 *
+	 * @var bool
+	 */
+	public $available = true;
+
+	/**
+	 * Scripted promote_site_has_videopress() result.
+	 *
+	 * @var bool
+	 */
+	public $has_videopress = true;
+
+	/**
+	 * Scripted promote_load_primitives() result.
+	 *
+	 * @var bool
+	 */
+	public $primitives_loaded = true;
+
+	/**
+	 * Scripted results for successive promote_video_info() calls: the
+	 * pre-check read first, then the post-transcode verification read.
+	 * Exhausting the list yields false (no live row).
+	 *
+	 * @var array
+	 */
+	public $video_infos = array();
+
+	/**
+	 * Scripted promote_find_any_guid() result (tombstone detection).
+	 *
+	 * @var string|null
+	 */
+	public $any_guid = null;
+
+	/**
+	 * Attachment ids promote_transcode() was invoked for.
+	 *
+	 * @var array
+	 */
+	public $transcoded = array();
+
+	/**
+	 * Skip the parent constructor: no route-registration side effects.
+	 */
+	public function __construct() {
+	}
+
+	/**
+	 * Scripted host availability.
+	 *
+	 * @return bool
+	 */
+	protected function promote_is_available() {
+		return $this->available;
+	}
+
+	/**
+	 * Scripted plan gate.
+	 *
+	 * @param int $blog_id The blog id (unused by the double).
+	 * @return bool
+	 */
+	protected function promote_site_has_videopress( $blog_id ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return $this->has_videopress;
+	}
+
+	/**
+	 * Scripted primitives availability.
+	 *
+	 * @return bool
+	 */
+	protected function promote_load_primitives() {
+		return $this->primitives_loaded;
+	}
+
+	/**
+	 * Scripted live-row reads, consumed in call order.
+	 *
+	 * @param int $blog_id       The blog id (unused by the double).
+	 * @param int $attachment_id The attachment id (unused by the double).
+	 * @return object|false
+	 */
+	protected function promote_video_info( $blog_id, $attachment_id ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return count( $this->video_infos ) > 0 ? array_shift( $this->video_infos ) : false;
+	}
+
+	/**
+	 * Scripted tombstone lookup.
+	 *
+	 * @param int $blog_id       The blog id (unused by the double).
+	 * @param int $attachment_id The attachment id (unused by the double).
+	 * @return string|null
+	 */
+	protected function promote_find_any_guid( $blog_id, $attachment_id ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return $this->any_guid;
+	}
+
+	/**
+	 * Record the primitive invocation instead of running wpcom code.
+	 *
+	 * @param int $attachment_id The attachment id.
+	 * @return void
+	 */
+	protected function promote_transcode( $attachment_id ) {
+		$this->transcoded[] = $attachment_id;
+	}
+}


### PR DESCRIPTION
## Proposed changes

On WordPress.com Simple, the dashboard's "Upload to VideoPress" (promote-local) action was hidden by #50410 because its transport could not work there: the flow walks `POST /videopress/v1/upload/{id}`, and the `videopress/v1` namespace never reaches the REST dispatcher on Simple — every click produced ~120 failing requests, then a generic error. Hiding it was the right triage, but it left no path to promote local videos on Simple, and that population is real: new Personal/Premium plans don't include VideoPress, so a customer can upload plain video attachments and later upgrade to a plan that does include it (site stays on Simple), stranding their pre-upgrade videos as "Local video" tiles.

Promotion is actually *easier* on Simple than self-hosted — the file already lives on WordPress.com storage, so no chunked client upload is needed:

* **New route `POST wpcom/v2/videopress/promote/{attachment_id}`** (same monorepo escape hatch as the settings routes — wpcom `require`s this class verbatim, so the route ships with the next jetpack-plugin deploy, no wpcom-side change needed). The `IS_WPCOM` handler promotes **in-place** by calling `remote_transcode_one_video()` — the exact primitive every direct upload to a VideoPress-enabled Simple site flows through via its `add_attachment` hook (and what wpcom's own `bin/videopress/reprocess-video.php` calls). The same attachment id gains a `videos`-table row; no sibling attachment, no `_videopress_uploaded_id` marker.
* **The handler pre-validates what the primitive doesn't** (it returns bare `false` for every bail reason):
  * attachment exists, is a video, isn't trashed (404);
  * plan gate via `wpcom_site_has_videopress()` — the native path only enforces VideoPress at upload/mime time, so without this a site with plain-video-upload rights could enqueue transcodes (403);
  * already-on-VideoPress → idempotent success with the existing guid;
  * **previously-deleted video → honest 409.** Live testing surfaced a structural constraint: the `videos` table's primary key is `(blog_id, post_id)`, so a soft-deleted row permanently occupies the slot and `video_create_info()`'s insert fails silently. Since tombstoned attachments render as ordinary "Local video" tiles (the REST fields only see live rows), the UI can reach this dead end — it now gets a specific message instead of an unexplained failure. (Resurrecting the row via the primitive's `$redo` path is a possible follow-up; it needs rollback semantics this endpoint shouldn't own yet.)
  * blogs.dir path regex (verbatim from the primitive) — a non-matching path would create a broken row plus a malformed transcode job stuck at "Processing" forever (400).
* **Client side**, `useUploadFromLibrary()` branches on `isSimpleSite()`: one POST to the new route instead of the 120-attempt walker, mapped to the same `{ guid, mediaId }` result, so the stage-level orchestration is unchanged. The two UI gates (DataViews row action in `actions.ts`, thumbnail hover button in `thumbnail-field.tsx`) are removed.
* **Drive-by fix**: the stage's `promoteLocal` now reacts via the `mutateAsync` promise instead of mutate-level callbacks — TanStack detaches the observer from an in-flight mutation when the same hook instance starts another one, so a second concurrent promote used to strand the first row's "promoting" overlay and eat its notice (the pitfall already documented in `useDeleteVideo`).
* The `video_get_info_by_blogpostid()` mock gains the real WPCOM function's `$cache_bust` param (ignored locally) so `IS_WPCOM` call sites can pass it without the shared signature diverging.

**Rollout**: ships behind the modernized-dashboard flag from VIDP-285 (`rsm_jetpack_ui_modernization_videopress`) — the only UI that can reach the endpoint is itself gated. The REST route registers ungated (same decision as the rest of the wpcom/v2 surface on this project: UI-flagged, REST registered), and returns a clean 404 on non-wpcom hosts.

## Related product discussion/links

* VIDP-300 (the follow-up filed from #50410)
* VIDP-285 (the rollout flag this lands behind)
* Automattic/jetpack#50410 — the Simple dashboard PR that hid the action (`8799da27ea`)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Self-hosted / Atomic (regression — behavior should be unchanged):

* `jetpack build packages/videopress` and load the dashboard on a connected site with a local (non-VideoPress) video in the media library.
* The "Upload to VideoPress" row action and thumbnail hover button behave exactly as before (walker flow, progress overlay, success notice).
* `composer -d projects/packages/videopress phpunit` and `pnpm test` in the package: green (26 endpoint tests incl. 5 new promote tests; 594 JS tests).

WordPress.com Simple (needs a sandbox; live-verified on `willstestdotblog.wordpress.com`):

1. Deploy the branch to a sandbox slot and open the modernized dashboard (VIDP-285 flag on: `videopress-modernized-dashboard` sticker or log in as an Automattician).
2. With a local video in the library (a video attachment with no `videos`-table row — e.g. uploaded before the plan included VideoPress): hover its tile → "Upload to VideoPress" appears (used to be hidden on Simple); same for the row action in list view.
3. Click it → single `POST /wpcom/v2/sites/{id}/videopress/promote/{id}` (no request storm), "Video uploaded to VideoPress." notice, tile flips to **Processing**, and the library's existing 2s poll resolves it once the transcoder writes the poster. Verified server-side: `videos` row created with a fresh guid, `fmt_std=initiated`, transcode job queued; `privacy_setting` defaults to site-default.
4. Promote the same video again (e.g. replay the request) → 200 with the existing guid and `already_videopress: true` (idempotent).
5. Tombstoned attachment (video soft-deleted from VideoPress while the attachment survives): promote → error notice "…previously deleted from VideoPress, so it can't be promoted automatically…" (409, no broken row created).
