### PR TITLE
WOOA7S-1759 - Premium Analytics: gate report comparison series on comparison data

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-pa-report-comparison-gating
+++ b/projects/packages/premium-analytics/changelog/update-pa-report-comparison-gating
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Reports: Show comparison chart series for Posts, Videos, and Downloads without requiring matching rows between periods.

--- a/projects/packages/premium-analytics/routes/reports/downloads/config/use-report-records.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/downloads/config/use-report-records.test.ts
@@ -54,6 +54,44 @@ const report: StatsNormalizedReport< StatsFileDownloadsItem > = {
 	],
 };
 
+const comparisonReport: StatsNormalizedReport< StatsFileDownloadsItem > = {
+	summary: {},
+	data: [
+		{
+			time_interval: '2026-07-07',
+			date_start: '2026-07-07T00:00:00+00:00',
+			date_end: '2026-07-07T23:59:59+00:00',
+			items: [
+				{
+					label: '/files/guide.pdf',
+					shortLabel: 'guide.pdf',
+					link: 'https://example.com/files/guide.pdf',
+					downloads: 4,
+					linkTitle: '/files/guide.pdf',
+					labelIcon: 'external',
+					children: null,
+				},
+			],
+		},
+		{
+			time_interval: '2026-07-08',
+			date_start: '2026-07-08T00:00:00+00:00',
+			date_end: '2026-07-08T23:59:59+00:00',
+			items: [
+				{
+					label: '/files/guide.pdf',
+					shortLabel: 'guide.pdf',
+					link: 'https://example.com/files/guide.pdf',
+					downloads: 5,
+					linkTitle: '/files/guide.pdf',
+					labelIcon: 'external',
+					children: null,
+				},
+			],
+		},
+	],
+};
+
 const params: ReportParams = {
 	from: '2026-07-09',
 	to: '2026-07-10',
@@ -108,5 +146,39 @@ describe( 'useDownloadsReportRecords', () => {
 			} ),
 		] );
 		expect( weekResult.current.rows ).toEqual( dayResult.current.rows );
+	} );
+
+	it( 'includes comparison chart buckets when downloads do not overlap the primary period', () => {
+		mockUseStatsFileDownloads.mockReturnValue( {
+			primary: { data: report },
+			comparison: { data: comparisonReport },
+			hasComparison: false,
+			isLoading: false,
+		} as ReturnType< typeof useStatsFileDownloads > );
+		const comparisonParams: ReportParams = {
+			...params,
+			compare_from: '2026-07-07',
+			compare_to: '2026-07-08',
+		};
+
+		const { result } = renderHook( () => useDownloadsReportRecords( comparisonParams, 'day' ) );
+
+		expect( result.current.chart.comparison ).toBeDefined();
+		expect( result.current.chart.comparison?.data.map( point => point.downloads ) ).toEqual( [
+			4, 5,
+		] );
+	} );
+
+	it( 'omits the comparison chart when comparison params are absent', () => {
+		mockUseStatsFileDownloads.mockReturnValue( {
+			primary: { data: report },
+			comparison: { data: comparisonReport },
+			hasComparison: false,
+			isLoading: false,
+		} as ReturnType< typeof useStatsFileDownloads > );
+
+		const { result } = renderHook( () => useDownloadsReportRecords( params, 'day' ) );
+
+		expect( result.current.chart.comparison ).toBeUndefined();
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/reports/downloads/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/downloads/config/use-report-records.ts
@@ -69,7 +69,7 @@ export function useDownloadsReportRecords(
 	return {
 		chart: {
 			primary: chartPrimary,
-			comparison: report.hasComparison ? chartComparison : undefined,
+			comparison: report.comparison.data ? chartComparison : undefined,
 			isLoading: report.isLoading,
 		},
 		rows,

--- a/projects/packages/premium-analytics/routes/reports/posts/config/use-report-records.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/posts/config/use-report-records.test.ts
@@ -50,6 +50,40 @@ const report: StatsNormalizedReport< StatsTopPostsItem > = {
 	],
 };
 
+const comparisonReport: StatsNormalizedReport< StatsTopPostsItem > = {
+	summary: {},
+	data: [
+		{
+			time_interval: '2026-07-07',
+			date_start: '2026-07-07T00:00:00+00:00',
+			date_end: '2026-07-07T23:59:59+00:00',
+			items: [
+				{
+					id: 99,
+					label: 'Post B',
+					views: 4,
+					link: 'https://example.com/post-b/',
+					type: 'post',
+				},
+			],
+		},
+		{
+			time_interval: '2026-07-08',
+			date_start: '2026-07-08T00:00:00+00:00',
+			date_end: '2026-07-08T23:59:59+00:00',
+			items: [
+				{
+					id: 99,
+					label: 'Post B',
+					views: 5,
+					link: 'https://example.com/post-b/',
+					type: 'post',
+				},
+			],
+		},
+	],
+};
+
 const params: ReportParams = {
 	from: '2026-07-09',
 	to: '2026-07-10',
@@ -99,5 +133,39 @@ describe( 'usePostsReportRecords', () => {
 			} ),
 		] );
 		expect( weekResult.current.posts.rows ).toEqual( dayResult.current.posts.rows );
+	} );
+
+	it( 'includes comparison chart buckets when posts do not overlap the primary period', () => {
+		mockUseStatsTopPosts.mockReturnValue( {
+			primary: { data: report },
+			comparison: { data: comparisonReport },
+			hasComparison: false,
+			isLoading: false,
+		} as ReturnType< typeof useStatsTopPosts > );
+		const comparisonParams: ReportParams = {
+			...params,
+			compare_from: '2026-07-07',
+			compare_to: '2026-07-08',
+		};
+
+		const { result } = renderHook( () =>
+			usePostsReportRecords( 'posts-pages', comparisonParams, 'day' )
+		);
+
+		expect( result.current.chart.comparison ).toBeDefined();
+		expect( result.current.chart.comparison?.data.map( point => point.views ) ).toEqual( [ 4, 5 ] );
+	} );
+
+	it( 'omits the comparison chart when comparison params are absent', () => {
+		mockUseStatsTopPosts.mockReturnValue( {
+			primary: { data: report },
+			comparison: { data: comparisonReport },
+			hasComparison: false,
+			isLoading: false,
+		} as ReturnType< typeof useStatsTopPosts > );
+
+		const { result } = renderHook( () => usePostsReportRecords( 'posts-pages', params, 'day' ) );
+
+		expect( result.current.chart.comparison ).toBeUndefined();
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/reports/posts/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/posts/config/use-report-records.ts
@@ -89,7 +89,7 @@ export function usePostsReportRecords(
 	return {
 		chart: {
 			primary: chartPrimary,
-			comparison: activeReport.hasComparison ? chartComparison : undefined,
+			comparison: activeReport.comparison.data ? chartComparison : undefined,
 			isLoading: activeReport.isLoading,
 		},
 		posts: {

--- a/projects/packages/premium-analytics/routes/reports/videos/config/use-report-records.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/videos/config/use-report-records.test.ts
@@ -60,6 +60,46 @@ const report: StatsNormalizedReport< StatsVideoPlaysItem > = {
 	],
 };
 
+const comparisonReport: StatsNormalizedReport< StatsVideoPlaysItem > = {
+	summary: {},
+	data: [
+		{
+			time_interval: '2026-07-07',
+			date_start: '2026-07-07T00:00:00+00:00',
+			date_end: '2026-07-07T23:59:59+00:00',
+			items: [
+				{
+					id: 777,
+					label: 'Comparison video',
+					plays: 4,
+					impressions: 0,
+					watch_time: 0,
+					retention_rate: 0,
+					link: null,
+					children: null,
+				},
+			],
+		},
+		{
+			time_interval: '2026-07-08',
+			date_start: '2026-07-08T00:00:00+00:00',
+			date_end: '2026-07-08T23:59:59+00:00',
+			items: [
+				{
+					id: 777,
+					label: 'Comparison video',
+					plays: 5,
+					impressions: 0,
+					watch_time: 0,
+					retention_rate: 0,
+					link: null,
+					children: null,
+				},
+			],
+		},
+	],
+};
+
 const summaryRows: StatsVideoPlaysItem[] = [
 	{
 		id: 441,
@@ -194,5 +234,39 @@ describe( 'useVideosReportRecords', () => {
 
 		expect( result.current.chart.isLoading ).toBe( false );
 		expect( result.current.isLoading ).toBe( true );
+	} );
+
+	it( 'includes comparison chart buckets when videos do not overlap the primary period', () => {
+		mockQueries();
+		mockUseStatsVideoPlays.mockReturnValue( {
+			primary: { data: report },
+			comparison: { data: comparisonReport },
+			hasComparison: false,
+			isLoading: false,
+		} as ReturnType< typeof useStatsVideoPlays > );
+		const comparisonParams: ReportParams = {
+			...params,
+			compare_from: '2026-07-07',
+			compare_to: '2026-07-08',
+		};
+
+		const { result } = renderHook( () => useVideosReportRecords( comparisonParams, 'day' ) );
+
+		expect( result.current.chart.comparison ).toBeDefined();
+		expect( result.current.chart.comparison?.data.map( point => point.plays ) ).toEqual( [ 4, 5 ] );
+	} );
+
+	it( 'omits the comparison chart when comparison params are absent', () => {
+		mockQueries();
+		mockUseStatsVideoPlays.mockReturnValue( {
+			primary: { data: report },
+			comparison: { data: comparisonReport },
+			hasComparison: false,
+			isLoading: false,
+		} as ReturnType< typeof useStatsVideoPlays > );
+
+		const { result } = renderHook( () => useVideosReportRecords( params, 'day' ) );
+
+		expect( result.current.chart.comparison ).toBeUndefined();
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/reports/videos/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/videos/config/use-report-records.ts
@@ -75,12 +75,12 @@ export function useVideosReportRecords(
 		[ primaryData, chartPeriod ]
 	);
 	const chartComparison = useMemo( () => {
-		if ( ! videos.hasComparison ) {
+		if ( ! reportParams.compare_from || ! reportParams.compare_to || ! comparisonData ) {
 			return undefined;
 		}
 
 		return videosToTimeSeries( comparisonData, chartPeriod );
-	}, [ videos.hasComparison, comparisonData, chartPeriod ] );
+	}, [ reportParams.compare_from, reportParams.compare_to, comparisonData, chartPeriod ] );
 
 	return {
 		chart: {


### PR DESCRIPTION
## Proposed changes

* The Posts, Videos, and Downloads report charts gated their comparison series on `hasComparison`, which only becomes true when the two periods share matching rows. When the row sets differ between periods, the comparison series never rendered even though the API returned comparison data.
* Gate the series on the presence of comparison data (and the compare params for Videos) instead, so it renders whenever comparison data is available.
* Adds tests for the three report record hooks.

## Related product discussion/links

* WOOA7S-1759

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open a Premium Analytics report page (Posts, Videos, or Downloads) and enable a comparison period.
* Pick a date range where the items differ between the two periods (e.g. posts that only received views in the current period).
* Verify the comparison series now renders on the chart; previously it was omitted unless both periods had matching rows.