### PR TITLE
Help Center: add jetpack-connection-health REST proxy for Atomic sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-help-center-jetpack-connection-health-endpoint
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-help-center-jetpack-connection-health-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Help Center: add a jetpack-connection-health REST proxy so Atomic sites can detect an unreachable site and route affected users to a human.

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/AGENTS.md
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/AGENTS.md
@@ -47,6 +47,7 @@ All routes are registered under the `help-center` namespace (`/wp-json/help-cent
 | `/fetch-post`                                         | GET    | `Fetch_Post`            | `GET /help/article/{blog_id}/{post_id}`       | Fetch a single support article       |
 | `/articles`                                           | GET    | `Fetch_Post`            | `GET /help/articles?blog_id=...&post_ids=...` | Fetch multiple support articles      |
 | `/forum/new`                                          | POST   | `Forum`                 | `POST /help/forum/new`                        | Create a forum topic                 |
+| `/jetpack-connection-health`                          | GET    | `Jetpack_Connection_Health` | `GET /sites/{site}/jetpack-connection-health` | Site connection health (reachability) |
 | `/jetpack-search/ai/search`                           | GET    | `Jetpack_Search_AI`     | `GET /sites/{site}/jetpack-search/ai/search`  | AI-powered article search            |
 | `/odie/chat/{bot_id}`                                 | POST   | `Odie`                  | `POST /odie/chat/{bot_id}/`                   | Start a new Odie chat                |
 | `/odie/chat/{bot_id}/{chat_id}`                       | GET    | `Odie`                  | `GET /odie/chat/{bot_id}/{chat_id}`           | Get an Odie chat conversation        |

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/AGENTS.md
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/AGENTS.md
@@ -40,35 +40,35 @@ For connected variants, it injects `helpCenterData` as inline JS containing user
 
 All routes are registered under the `help-center` namespace (`/wp-json/help-center/...`). Every endpoint proxies to a WPcom REST API.
 
-| Route                                                 | Method | Controller              | Proxies to                                    | Description                          |
-| ----------------------------------------------------- | ------ | ----------------------- | --------------------------------------------- | ------------------------------------ |
-| `/authenticate/chat`                                  | POST   | `Authenticate`          | `POST /help/authenticate/chat`                | Zendesk/messaging chat auth          |
-| `/support-availability/email`                         | GET    | `Email_Support_Enabled` | `GET /help/eligibility/email/mine`            | Check email support eligibility      |
-| `/fetch-post`                                         | GET    | `Fetch_Post`            | `GET /help/article/{blog_id}/{post_id}`       | Fetch a single support article       |
-| `/articles`                                           | GET    | `Fetch_Post`            | `GET /help/articles?blog_id=...&post_ids=...` | Fetch multiple support articles      |
-| `/forum/new`                                          | POST   | `Forum`                 | `POST /help/forum/new`                        | Create a forum topic                 |
+| Route                                                 | Method | Controller                  | Proxies to                                    | Description                           |
+| ----------------------------------------------------- | ------ | --------------------------- | --------------------------------------------- | ------------------------------------- |
+| `/authenticate/chat`                                  | POST   | `Authenticate`              | `POST /help/authenticate/chat`                | Zendesk/messaging chat auth           |
+| `/support-availability/email`                         | GET    | `Email_Support_Enabled`     | `GET /help/eligibility/email/mine`            | Check email support eligibility       |
+| `/fetch-post`                                         | GET    | `Fetch_Post`                | `GET /help/article/{blog_id}/{post_id}`       | Fetch a single support article        |
+| `/articles`                                           | GET    | `Fetch_Post`                | `GET /help/articles?blog_id=...&post_ids=...` | Fetch multiple support articles       |
+| `/forum/new`                                          | POST   | `Forum`                     | `POST /help/forum/new`                        | Create a forum topic                  |
 | `/jetpack-connection-health`                          | GET    | `Jetpack_Connection_Health` | `GET /sites/{site}/jetpack-connection-health` | Site connection health (reachability) |
-| `/jetpack-search/ai/search`                           | GET    | `Jetpack_Search_AI`     | `GET /sites/{site}/jetpack-search/ai/search`  | AI-powered article search            |
-| `/odie/chat/{bot_id}`                                 | POST   | `Odie`                  | `POST /odie/chat/{bot_id}/`                   | Start a new Odie chat                |
-| `/odie/chat/{bot_id}/{chat_id}`                       | GET    | `Odie`                  | `GET /odie/chat/{bot_id}/{chat_id}`           | Get an Odie chat conversation        |
-| `/odie/chat/{bot_id}/{chat_id}`                       | POST   | `Odie`                  | `POST /odie/chat/{bot_id}/{chat_id}`          | Send a message to an Odie chat       |
-| `/odie/chat/{bot_id}/{chat_id}/{message_id}/feedback` | POST   | `Odie`                  | `POST /odie/chat/.../feedback`                | Rate an Odie message                 |
-| `/odie/conversations/{bot_ids}`                       | GET    | `Odie`                  | `GET /odie/conversations/{bot_ids}`           | List recent Odie conversations       |
-| `/open-state`                                         | GET    | `Persisted_Open_State`  | `GET /me/preferences`                         | Get Help Center open/minimized state |
-| `/open-state`                                         | PUT    | `Persisted_Open_State`  | `POST /me/preferences`                        | Set Help Center open/minimized state |
-| `/search`                                             | GET    | `Search`                | `GET /help/search`                            | Search help articles                 |
-| `/sibyl`                                              | GET    | `Sibyl`                 | `GET /help/sibyl`                             | AI-suggested support articles        |
-| `/support-activity`                                   | GET    | `Support_Activity`      | `GET /support-activity`                       | Active support tickets               |
-| `/support-interactions`                               | GET    | `Support_Interactions`  | `GET /support-interactions/`                  | List support interactions            |
-| `/support-interactions/{id}`                          | GET    | `Support_Interactions`  | `GET /support-interactions/{id}`              | Get a single interaction             |
-| `/support-interactions`                               | POST   | `Support_Interactions`  | `POST /support-interactions`                  | Create a support interaction         |
-| `/support-interactions/{id}/events`                   | POST   | `Support_Interactions`  | `POST /support-interactions/{id}/events`      | Add event to interaction             |
-| `/support-interactions/{id}/status`                   | PUT    | `Support_Interactions`  | `PUT /support-interactions/{id}/status`       | Update interaction status            |
-| `/support-status`                                     | GET    | `Support_Status`        | `GET /help/support-status`                    | Support eligibility/tier             |
-| `/support-status/messaging`                           | GET    | `Support_Status`        | `GET /help/support-status/messaging`          | Messaging support availability       |
-| `/csat`                                               | POST   | `Ticket_CSAT`           | `POST /help/csat`                             | Submit ticket CSAT rating            |
-| `/ticket/new`                                         | POST   | `Ticket`                | `POST /help/ticket/new`                       | Create a support ticket              |
-| `/zendesk/user-fields`                                | POST   | `User_Fields`           | `POST /help/zendesk/update-user-fields`       | Update Zendesk user fields           |
+| `/jetpack-search/ai/search`                           | GET    | `Jetpack_Search_AI`         | `GET /sites/{site}/jetpack-search/ai/search`  | AI-powered article search             |
+| `/odie/chat/{bot_id}`                                 | POST   | `Odie`                      | `POST /odie/chat/{bot_id}/`                   | Start a new Odie chat                 |
+| `/odie/chat/{bot_id}/{chat_id}`                       | GET    | `Odie`                      | `GET /odie/chat/{bot_id}/{chat_id}`           | Get an Odie chat conversation         |
+| `/odie/chat/{bot_id}/{chat_id}`                       | POST   | `Odie`                      | `POST /odie/chat/{bot_id}/{chat_id}`          | Send a message to an Odie chat        |
+| `/odie/chat/{bot_id}/{chat_id}/{message_id}/feedback` | POST   | `Odie`                      | `POST /odie/chat/.../feedback`                | Rate an Odie message                  |
+| `/odie/conversations/{bot_ids}`                       | GET    | `Odie`                      | `GET /odie/conversations/{bot_ids}`           | List recent Odie conversations        |
+| `/open-state`                                         | GET    | `Persisted_Open_State`      | `GET /me/preferences`                         | Get Help Center open/minimized state  |
+| `/open-state`                                         | PUT    | `Persisted_Open_State`      | `POST /me/preferences`                        | Set Help Center open/minimized state  |
+| `/search`                                             | GET    | `Search`                    | `GET /help/search`                            | Search help articles                  |
+| `/sibyl`                                              | GET    | `Sibyl`                     | `GET /help/sibyl`                             | AI-suggested support articles         |
+| `/support-activity`                                   | GET    | `Support_Activity`          | `GET /support-activity`                       | Active support tickets                |
+| `/support-interactions`                               | GET    | `Support_Interactions`      | `GET /support-interactions/`                  | List support interactions             |
+| `/support-interactions/{id}`                          | GET    | `Support_Interactions`      | `GET /support-interactions/{id}`              | Get a single interaction              |
+| `/support-interactions`                               | POST   | `Support_Interactions`      | `POST /support-interactions`                  | Create a support interaction          |
+| `/support-interactions/{id}/events`                   | POST   | `Support_Interactions`      | `POST /support-interactions/{id}/events`      | Add event to interaction              |
+| `/support-interactions/{id}/status`                   | PUT    | `Support_Interactions`      | `PUT /support-interactions/{id}/status`       | Update interaction status             |
+| `/support-status`                                     | GET    | `Support_Status`            | `GET /help/support-status`                    | Support eligibility/tier              |
+| `/support-status/messaging`                           | GET    | `Support_Status`            | `GET /help/support-status/messaging`          | Messaging support availability        |
+| `/csat`                                               | POST   | `Ticket_CSAT`               | `POST /help/csat`                             | Submit ticket CSAT rating             |
+| `/ticket/new`                                         | POST   | `Ticket`                    | `POST /help/ticket/new`                       | Create a support ticket               |
+| `/zendesk/user-fields`                                | POST   | `User_Fields`               | `POST /help/zendesk/update-user-fields`       | Update Zendesk user fields            |
 
 ## Other Behaviors
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-help-center.php
@@ -482,6 +482,10 @@ class Help_Center {
 		$controller = new WP_REST_Help_Center_Jetpack_Search_AI();
 		$controller->register_rest_route();
 
+		require_once __DIR__ . '/class-wp-rest-help-center-jetpack-connection-health.php';
+		$controller = new WP_REST_Help_Center_Jetpack_Connection_Health();
+		$controller->register_rest_route();
+
 		require_once __DIR__ . '/class-wp-rest-help-center-fetch-post.php';
 		$controller = new WP_REST_Help_Center_Fetch_Post();
 		$controller->register_rest_route();

--- a/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-jetpack-connection-health.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/help-center/class-wp-rest-help-center-jetpack-connection-health.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * WP_REST_Help_Center_Jetpack_Connection_Health file.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace A8C\FSE;
+
+use Automattic\Jetpack\Connection\Client;
+
+/**
+ * Class WP_REST_Help_Center_Jetpack_Connection_Health.
+ */
+class WP_REST_Help_Center_Jetpack_Connection_Health extends \WP_REST_Controller {
+	/**
+	 * WP_REST_Help_Center_Jetpack_Connection_Health constructor.
+	 */
+	public function __construct() {
+		$this->namespace = 'help-center';
+		$this->rest_base = '/jetpack-connection-health';
+	}
+
+	/**
+	 * Register available routes.
+	 */
+	public function register_rest_route() {
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base,
+			array(
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => array( $this, 'get_connection_health' ),
+				'permission_callback' => 'is_user_logged_in',
+			)
+		);
+	}
+
+	/**
+	 * Return the Jetpack connection health for the current site.
+	 */
+	public function get_connection_health() {
+		/*
+		 * Atomic sites have the WP.com blog ID stored as a Jetpack option. This code deliberately
+		 * doesn't use `Jetpack_Options::get_option` so it works even when Jetpack has not been loaded.
+		 */
+		$jetpack_options = get_option( 'jetpack_options' );
+		if ( is_array( $jetpack_options ) && isset( $jetpack_options['id'] ) ) {
+			$site = (int) $jetpack_options['id'];
+		} else {
+			$site = get_current_blog_id();
+		}
+
+		$body = Client::wpcom_json_api_request_as_user(
+			'sites/' . $site . '/jetpack-connection-health',
+			'2'
+		);
+
+		if ( is_wp_error( $body ) ) {
+			return $body;
+		}
+
+		$response = json_decode( wp_remote_retrieve_body( $body ) );
+
+		return rest_ensure_response( $response );
+	}
+}


### PR DESCRIPTION
## Proposed changes

* Add a `help-center/jetpack-connection-health` REST route (controller `WP_REST_Help_Center_Jetpack_Connection_Health`) that proxies to the WPcom `sites/{id}/jetpack-connection-health` endpoint.
* Registers it in `class-help-center.php` alongside the other Help Center endpoints, and documents it in the feature `AGENTS.md` endpoint table.
* The blog ID is derived server-side (`jetpack_options['id']`, falling back to `get_current_blog_id()`) — no spoofable request parameter.

This is the **backend prerequisite** for the Calypso change: the Help Center frontend calls this endpoint via `apiFetch` on Atomic sites (wp-admin/Gutenberg) where the WPcom APIs aren't directly accessible (`canAccessWpcomApis()` is `false`). Without it, an unreachable Atomic site can't be detected there and affected users never get routed to a human.

## Related product discussion/links

* Calypso PR (depends on this): Automattic/wp-calypso#112577
* DSGCOM-746

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Sandbox `widgets.wp.com` and deploy/sync this `jetpack-mu-wpcom` change to a sandbox.
* On an Atomic site, hit `GET /wp-json/help-center/jetpack-connection-health` while logged in — it should return the WPcom connection-health payload (`{ is_healthy, error }`) for that site.
* With the Calypso PR bundle in place, open the Help Center on an unreachable Atomic site as a chat-eligible user and confirm the footer shows **Contact a Happiness Engineer** instead of **Get help**.