### PR TITLE
Premium Analytics: fix widgets resizing when a dropdown opens

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-metrics-dropdown-affects-other-widget-dimensions
+++ b/projects/packages/premium-analytics/changelog/fix-metrics-dropdown-affects-other-widget-dimensions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Widgets: fix the Most viewed and Referrers widgets changing size when a dropdown opens elsewhere on the dashboard.

--- a/projects/packages/premium-analytics/widgets/referrers/style.module.css
+++ b/projects/packages/premium-analytics/widgets/referrers/style.module.css
@@ -52,9 +52,3 @@
 	flex: 1 1 0;
 	min-height: 0;
 }
-
-:global([inert]:not([inert="true"])) .root {
-	height: auto;
-	aspect-ratio: 4 / 3;
-	overflow: hidden;
-}

--- a/projects/packages/premium-analytics/widgets/top-posts/style.module.css
+++ b/projects/packages/premium-analytics/widgets/top-posts/style.module.css
@@ -78,9 +78,3 @@
 		opacity: 1;
 	}
 }
-
-:global([inert]:not([inert="true"])) .root {
-	height: auto;
-	aspect-ratio: 4 / 3;
-	overflow: hidden;
-}


### PR DESCRIPTION
## Proposed changes

Opening the **Metrics** dropdown on the analytics dashboard resized *other* widgets: the Most viewed widget shifted down while the dropdown was open and snapped back on close.

Both the Most viewed (`top-posts`) and Referrers widgets carried a widget-picker workaround at the bottom of their CSS module:

```css
:global([inert]:not([inert="true"])) .root {
	height: auto;
	aspect-ratio: 4 / 3;
	overflow: hidden;
}
```

Those are exactly the three declarations seen appearing on click in the reported DevTools screenshot.

The flaw is that the rule keys "am I in the widget-picker preview?" off a **global `[inert]` ancestor selector**, but `inert` isn't owned by the picker. A modal popup — such as the Metrics `SelectControl` — inerts background content while it is open, so a sibling widget matches this selector and takes on a 4:3 aspect ratio for as long as the dropdown stays open.

This hack is already obsolete. #50294 removed it from the other 17 widgets and deleted the `AGENTS.md` guidance recommending it, because the picker host now sizes preview tiles itself. These two widgets merged *after* that cleanup (Jul 9 and Jul 14) from branches cut *before* it, quietly reintroducing the rule. This PR removes both, restoring parity with the rest of the package.

The `[inert]` image-sizing rules elsewhere (avatars, flags) are deliberately left alone — they only restore intended sizes, so they are no-ops outside the picker.

## Related product discussion/links

* https://linear.app/a8c/issue/WOOA7S-1763/metrics-dropdown-affects-other-widget-dimensions

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

**Reproducing the bug (on `trunk`)**

* Go to **Jetpack → Premium Analytics**.
* Make sure both the **Traffic** and **Most viewed** widgets are on the dashboard, with Traffic narrow enough that its metric picker renders as a dropdown rather than tabs (resize it small — the dropdown only appears below `metrics.length * MIN_TAB_WIDTH`).
* Open the Traffic widget's **Metrics** dropdown.
* 🐞 The Most viewed widget shifts downward / changes height while the dropdown is open, and returns when it closes.

**Verifying the fix (on this branch)**

* Repeat the steps above — opening the Metrics dropdown should leave every other widget's dimensions untouched.
* Repeat with the **Referrers** widget on the dashboard; it should also stay put.

**Checking for regressions in the widget picker** (this is what the removed rule was originally for)

* Enter dashboard **edit mode** and open the **widget picker**.
* Confirm the **Most viewed** and **Referrers** preview tiles render at a sensible size and do not collapse — they should look like the other widgets' previews, which have shipped without this rule since #50294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011oGxxfSNdnj1Pyf5FRnPQC
