### PR TITLE
Premium Analytics: metric tile values and borders per the detail-page mocks

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-metric-tile-value-and-border-per-mocks
+++ b/projects/packages/premium-analytics/changelog/update-metric-tile-value-and-border-per-mocks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Metric tiles: pin wide-layout values at 32px regular and use the neutral stroke for tile borders, per the post/email detail mocks

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid.module.scss
@@ -3,7 +3,8 @@ $metric-tile-grid-wide-min-inline-size: 640px;
 // single row of tiles. Tunable — below this, wide cells stay one row.
 $metric-tile-grid-grid-min-block-size: 360px;
 $metric-tile-grid-row-value-font-size-max: 40px;
-$metric-tile-grid-tile-value-font-size-max: 40px;
+// The design spec pins highlight-tile values at 32px.
+$metric-tile-grid-tile-value-font-size: 32px;
 $metric-tile-grid-prominent-value-font-size-max: 44px;
 $metric-tile-grid-large-row-min-block-size: calc(var(--wpds-typography-line-height-2xl) + var(--wpds-dimension-padding-2xl) + var(--wpds-dimension-padding-2xl) + var(--wpds-dimension-gap-lg));
 
@@ -35,7 +36,7 @@ $metric-tile-grid-large-row-min-block-size: calc(var(--wpds-typography-line-heig
 	min-block-size: 0;
 	padding-block: var(--wpds-dimension-padding-sm);
 	padding-inline: var(--wpds-dimension-padding-lg);
-	border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral-weak);
+	border: var(--wpds-border-width-xs) solid var(--wpds-color-stroke-surface-neutral);
 	border-radius: var(--wpds-border-radius-lg);
 }
 
@@ -67,6 +68,7 @@ $metric-tile-grid-large-row-min-block-size: calc(var(--wpds-typography-line-heig
 	overflow: hidden;
 	color: var(--wpds-color-foreground-content-neutral);
 	font-size: clamp(var(--wpds-typography-font-size-xl), 10cqh, $metric-tile-grid-row-value-font-size-max);
+	font-weight: var(--wpds-typography-font-weight-regular);
 	line-height: 1.2;
 	text-overflow: ellipsis;
 	white-space: nowrap;
@@ -135,7 +137,7 @@ $metric-tile-grid-large-row-min-block-size: calc(var(--wpds-typography-line-heig
 
 	.tile .value,
 	.tile .placeholder {
-		font-size: clamp(var(--wpds-typography-font-size-xl), 11cqh, $metric-tile-grid-tile-value-font-size-max);
+		font-size: $metric-tile-grid-tile-value-font-size;
 	}
 }
 


### PR DESCRIPTION
Aligns the shared `MetricTileGrid` (widgets-toolkit) with the latest post/email detail design mocks:

- **Value typography**: the wide single-row tile layout pins values at **32px, regular weight**. Previously the container-query clamp (`clamp(20px, 11cqh, 40px)`, #50384) bottomed out at 20px on one-row cards, and `MetricValue`'s inherited 500 weight (from the original Woo analytics port) read heavier than the spec. The narrow row layout keeps its responsive clamp — its label-left/value-right rows are density-oriented and the mocks don't cover them.
- **Tile border**: `--wpds-color-stroke-surface-neutral` instead of `--wpds-color-stroke-surface-neutral-weak` (#f0f0f0), which was near invisible. The mocks draw tile borders at #e0e0e0; the neutral stroke resolves to #dfdfdf with the runtime WPDS stylesheet (#dbdbdb in the bundled fallback), the closest token either way.

Split out of #50612 so the shared-component change is reviewable on its own: `MetricTileGrid` backs the highlight rows on the post/email detail tabs and the dashboard tile widgets (Site overview, All-time stats, Subscriber/Annual/WordAds highlights), so the border change is visible on all of them; the font-size change only affects the wide single-row layout used by the detail-tab highlight rows.

## Other information

- [ ] Have you written new tests for your changes, if applicable?
  - Style-only change; existing MetricTileGrid tests cover the markup.
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable?

## Jetpack product discussion

WOOA7S-1738 (the design-mock set this aligns to)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Apply the branch and build: `jetpack build packages/premium-analytics plugins/premium-analytics`.
2. Open a post detail page (Premium Analytics → click a post): the Post highlights tiles show 32px regular-weight values and a visible border (the neutral stroke, #dfdfdf at runtime).
3. Check a narrow tile widget on the dashboard (e.g. All-time stats at 2×1): rows keep their compact responsive value size; only the border darkens.

### Screenshots

|Before|After|
|-|-|
|<img width="980" height="339" alt="截圖 2026-07-17 晚上9 58 45" src="https://github.com/user-attachments/assets/ac87a754-0763-47bd-a7f3-ccb491dadc32" />|<img width="978" height="329" alt="截圖 2026-07-17 晚上10 16 57" src="https://github.com/user-attachments/assets/85226815-c23a-47a2-898e-8439abb6cde1" />|

🤖 Generated with [Claude Code](https://claude.com/claude-code)
