### PR TITLE
Premium Analytics: keep the post detail tab bar in place while the page scrolls

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-post-detail-tab-scroll
+++ b/projects/packages/premium-analytics/changelog/fix-post-detail-tab-scroll
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Post detail: keep the tab bar in place while the page scrolls, matching the dashboard

--- a/projects/packages/premium-analytics/routes/post-detail/components/post-detail-tabs/post-detail-tabs.module.scss
+++ b/projects/packages/premium-analytics/routes/post-detail/components/post-detail-tabs/post-detail-tabs.module.scss
@@ -1,3 +1,14 @@
+// Flex column so the tab panel fills the remaining viewport height and
+// scrolls internally instead of growing with the widget grid — the tab bar,
+// date filters, and summary header stay put while the widgets scroll,
+// matching the dashboard's section tabs.
+.root {
+	display: flex;
+	flex-direction: column;
+	flex: 1 1 auto;
+	min-block-size: 0;
+}
+
 .tabList {
 	padding-inline: var(--wpds-dimension-padding-2xl);
 }

--- a/projects/packages/premium-analytics/routes/post-detail/components/post-detail-tabs/post-detail-tabs.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/components/post-detail-tabs/post-detail-tabs.tsx
@@ -41,7 +41,13 @@ type PostDetailTabsProps = {
  */
 export function PostDetailTabs( { tabs, value, onChange, children }: PostDetailTabsProps ) {
 	return (
-		<SectionTabs tabs={ tabs } value={ value } onChange={ onChange } className={ styles.tabList }>
+		<SectionTabs
+			tabs={ tabs }
+			value={ value }
+			onChange={ onChange }
+			rootClassName={ styles.root }
+			className={ styles.tabList }
+		>
 			{ children }
 		</SectionTabs>
 	);

--- a/projects/packages/premium-analytics/routes/post-detail/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.module.scss
@@ -2,10 +2,16 @@
 	min-block-size: 0;
 }
 
-.content {
+// One scroll container for everything below the tab bar: the summary header
+// scrolls away with the widgets while the sticky date filters pin to its top,
+// so only the tab bar and the filters stay in view.
+.scrollArea {
 	flex: 1 1 auto;
 	min-block-size: 0;
 	overflow-y: auto;
+}
+
+.content {
 	// Reserve paint space for the widget host's outer focus outline.
 	padding-block-start: calc(var(--wpds-border-width-focus) + 2px);
 	// Match the horizontal padding of the tab bar and header so the widget grid
@@ -15,10 +21,15 @@
 }
 
 .dateFilters {
-	// Sits directly below the tab bar, mirroring the main dashboard's
-	// placement. The tab list already adds a bottom margin, so only pad below
-	// here to keep the spacing even; inline padding matches the tabs and the
-	// widget grid so it lines up.
+	// First element of the scroll area, pinned to its top while the summary
+	// header and widgets scroll underneath; the opaque background matches the
+	// page so passing content disappears behind it. The tab list already adds
+	// a bottom margin, so only pad below here to keep the spacing even; inline
+	// padding matches the tabs and the widget grid so it lines up.
+	position: sticky;
+	inset-block-start: 0;
+	z-index: 2;
+	background: var(--wpds-color-background-surface-neutral);
 	padding-block-end: var(--wpds-dimension-gap-lg);
 	padding-inline: var(--wpds-dimension-padding-2xl);
 }

--- a/projects/packages/premium-analytics/routes/post-detail/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.module.scss
@@ -2,9 +2,9 @@
 	min-block-size: 0;
 }
 
-// One scroll container for everything below the tab bar: the summary header
-// scrolls away with the widgets while the sticky date filters pin to its top,
-// so only the tab bar and the filters stay in view.
+// The scroll container below the fixed tab bar and date filters: the summary
+// header scrolls away with the widgets instead of permanently occupying the
+// viewport.
 .scrollArea {
 	flex: 1 1 auto;
 	min-block-size: 0;
@@ -21,15 +21,10 @@
 }
 
 .dateFilters {
-	// First element of the scroll area, pinned to its top while the summary
-	// header and widgets scroll underneath; the opaque background matches the
-	// page so passing content disappears behind it. The tab list already adds
-	// a bottom margin, so only pad below here to keep the spacing even; inline
-	// padding matches the tabs and the widget grid so it lines up.
-	position: sticky;
-	inset-block-start: 0;
-	z-index: 2;
-	background: var(--wpds-color-background-surface-neutral);
+	// Sits directly below the tab bar, outside the scroll container, so it
+	// stays fixed exactly like the dashboard's filters. The tab list already
+	// adds a bottom margin, so only pad below here to keep the spacing even;
+	// inline padding matches the tabs and the widget grid so it lines up.
 	padding-block-end: var(--wpds-dimension-gap-lg);
 	padding-inline: var(--wpds-dimension-padding-2xl);
 }

--- a/projects/packages/premium-analytics/routes/post-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.tsx
@@ -121,25 +121,32 @@ function PostDetail(): JSX.Element {
 						{ /*
 						 * The date filters and the summary card are shared by every tab
 						 * (same post, same date range), so they render once below the
-						 * tab bar and above the per-tab widget grid. The filters sit
-						 * directly under the tabs, mirroring the main dashboard's
-						 * placement, with the summary header below them.
+						 * tab bar and above the per-tab widget grid. Everything below
+						 * the tab bar scrolls in one container: the summary header
+						 * scrolls away to give the widgets room, while the filters pin
+						 * to the top of the scroll area (position: sticky) so the date
+						 * range stays reachable — the tab bar itself never moves.
 						 *
 						 * The filters wrapper is also the responsive-measurement
 						 * target: DateFiltersPanel reads its width to pick mobile/wide
 						 * layouts instead of relying on the viewport.
 						 */ }
-						<div ref={ setContainerElement } className={ styles.dateFilters }>
-							<DateFiltersPanel { ...dateFilters } containerElement={ containerElement } />
+						<div className={ styles.scrollArea }>
+							<div ref={ setContainerElement } className={ styles.dateFilters }>
+								<DateFiltersPanel { ...dateFilters } containerElement={ containerElement } />
+							</div>
+							<div className={ styles.header }>
+								<PostSummaryCard
+									summary={ summary }
+									performanceRange={ dateFilters.appliedRange }
+								/>
+							</div>
+							{ tabs.map( tab => (
+								<SectionTabPanel key={ tab.id } value={ tab.id } className={ styles.content }>
+									{ activeTab === tab.id ? <WidgetDashboard.Widgets /> : null }
+								</SectionTabPanel>
+							) ) }
 						</div>
-						<div className={ styles.header }>
-							<PostSummaryCard summary={ summary } performanceRange={ dateFilters.appliedRange } />
-						</div>
-						{ tabs.map( tab => (
-							<SectionTabPanel key={ tab.id } value={ tab.id } className={ styles.content }>
-								{ activeTab === tab.id ? <WidgetDashboard.Widgets /> : null }
-							</SectionTabPanel>
-						) ) }
 					</PostDetailTabs>
 				</Page>
 			</WidgetDashboard>

--- a/projects/packages/premium-analytics/routes/post-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.tsx
@@ -121,20 +121,19 @@ function PostDetail(): JSX.Element {
 						{ /*
 						 * The date filters and the summary card are shared by every tab
 						 * (same post, same date range), so they render once below the
-						 * tab bar and above the per-tab widget grid. Everything below
-						 * the tab bar scrolls in one container: the summary header
-						 * scrolls away to give the widgets room, while the filters pin
-						 * to the top of the scroll area (position: sticky) so the date
-						 * range stays reachable — the tab bar itself never moves.
+						 * tab bar and above the per-tab widget grid. The tab bar and the
+						 * filters stay fixed outside the scroll container, exactly like
+						 * the dashboard's section tabs; the summary header scrolls away
+						 * inside it with the widgets, giving them the vertical room.
 						 *
 						 * The filters wrapper is also the responsive-measurement
 						 * target: DateFiltersPanel reads its width to pick mobile/wide
 						 * layouts instead of relying on the viewport.
 						 */ }
+						<div ref={ setContainerElement } className={ styles.dateFilters }>
+							<DateFiltersPanel { ...dateFilters } containerElement={ containerElement } />
+						</div>
 						<div className={ styles.scrollArea }>
-							<div ref={ setContainerElement } className={ styles.dateFilters }>
-								<DateFiltersPanel { ...dateFilters } containerElement={ containerElement } />
-							</div>
 							<div className={ styles.header }>
 								<PostSummaryCard
 									summary={ summary }


### PR DESCRIPTION
On the post detail page the tab bar (Post traffic / Email opens / Email clicks) scrolled away with the page, while the dashboard's section tabs stay put. The dashboard achieves that by passing a flex-column root class to `SectionTabs`, so the tab panel fills the remaining viewport height and scrolls internally; the post detail page never passed one, so its `Tabs.Root` grew with the widget grid and the whole page scrolled.

This aligns the post detail page with the dashboard's structure while keeping vertical space for content:

- The **tab bar and date filters** sit outside the scroll container and never move — exactly the dashboard's arrangement.
- The **post summary header scrolls away** inside the scroll container with the widgets, instead of permanently occupying the viewport.

## Other information

- [ ] Have you written new tests for your changes, if applicable?
  - Layout-only change (CSS + a class prop + a wrapper div); no behavior to unit-test.
- [ ] Have you checked the E2E test CI results, and verified that your changes do not break them?
- [ ] Have you tested your changes on WordPress.com, if applicable?

## Jetpack product discussion

WOOA7S-1622

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Apply the branch and build: `jetpack build packages/premium-analytics plugins/premium-analytics`.
2. Open Premium Analytics → click a post with enough widgets to overflow the viewport.
3. Scroll down: the summary header scrolls away while the tab bar and date filters never move — matching the dashboard's fixed section tabs while freeing the header's vertical space.

### Screenshots

|Before|After|
|-|-|
|<img width="1293" height="566" alt="截圖 2026-07-17 晚上11 23 45" src="https://github.com/user-attachments/assets/dceea020-e398-4853-8743-909e17b18748" />|<img width="1295" height="544" alt="截圖 2026-07-17 晚上11 21 38" src="https://github.com/user-attachments/assets/36b3360b-16b9-4070-8b78-fc4f4f6ebf16" />|

🤖 Generated with [Claude Code](https://claude.com/claude-code)
