### PR TITLE
Remove sidebar height gate

### DIFF
--- a/projects/packages/agents-manager/changelog/update-agents-manager-remove-sidebar-height-gate
+++ b/projects/packages/agents-manager/changelog/update-agents-manager-remove-sidebar-height-gate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sidebar docking gate: stop undocking when the viewport is shorter than the admin menu; the docked layout now keeps the admin menu scrollable at any height.

--- a/projects/packages/agents-manager/src/class-sidebar-open-preservation.php
+++ b/projects/packages/agents-manager/src/class-sidebar-open-preservation.php
@@ -18,13 +18,10 @@ namespace Automattic\Jetpack\Agents_Manager;
  * never left orphaned.
  *
  * The server can know the persisted "open && docked" preference, but not the
- * live viewport — and the docked layout only fits above a width breakpoint and
- * when the admin menu fits vertically. Width is handled in CSS (a static media
- * query). Height cannot be: the threshold is the *measured* #adminmenu height,
- * which varies per page. So a tiny synchronous viewport-height gate is printed on
- * `in_admin_header` (which fires after #adminmenu is in the DOM, before the
- * content paints) to re-evaluate the real dock gate and strip the pre-rendered
- * classes when the chat will actually float — pre-paint, so there is no flash.
+ * live viewport — the docked layout only fits above a width breakpoint. So a
+ * tiny synchronous gate is printed on `in_admin_header` (before the content
+ * paints) to re-evaluate the real dock gate and strip the pre-rendered classes
+ * when the chat will actually float — pre-paint, so there is no flash.
  */
 class Sidebar_Open_Preservation {
 	/**
@@ -69,8 +66,7 @@ class Sidebar_Open_Preservation {
 		add_filter( 'admin_body_class', array( $this, 'add_preopen_body_classes' ), PHP_INT_MAX );
 
 		// Reconcile the pre-rendered shell against the live viewport before the
-		// page content paints. `in_admin_header` fires after #adminmenu is in the
-		// DOM, so the script can measure it the same way the React app does.
+		// page content paints.
 		add_action( 'in_admin_header', array( $this, 'print_sidebar_docking_gate_script' ) );
 	}
 

--- a/projects/packages/agents-manager/src/js/sidebar-docking-gate.ts
+++ b/projects/packages/agents-manager/src/js/sidebar-docking-gate.ts
@@ -63,19 +63,9 @@ function runSidebarDockingGate() {
 		return;
 	}
 
-	const adminMenu = document.getElementById( 'adminmenu' );
-	if ( ! adminMenu ) {
-		return;
-	}
-
-	// The docked layout pins the admin menu to the viewport; if the menu is taller
-	// than the room below the admin bar it would be clipped, so the chat floats instead.
-	const adminBar = document.getElementById( 'wpadminbar' );
-	const adminBarHeight = adminBar ? adminBar.offsetHeight : 32;
-	const tooShort = window.innerHeight < adminMenu.offsetHeight + adminBarHeight + 20;
 	const tooNarrow = window.innerWidth < DESKTOP_MIN_WIDTH;
 
-	if ( tooShort || tooNarrow || ! isFullscreenGateOpen() ) {
+	if ( tooNarrow || ! isFullscreenGateOpen() ) {
 		removeDockedShell();
 	}
 }

--- a/projects/packages/agents-manager/tests/js/sidebar-docking-gate.test.ts
+++ b/projects/packages/agents-manager/tests/js/sidebar-docking-gate.test.ts
@@ -15,33 +15,6 @@ const DOCKED_SIDEBAR_BODY_CLASSES = [
 ];
 
 /**
- * jsdom does not lay elements out, so offsetHeight is always 0. Stub it so the
- * gate's height math has something to measure.
- *
- * @param {HTMLElement} element - Element to stub.
- * @param {number}      value   - Pixel height to report.
- */
-function stubOffsetHeight( element: HTMLElement, value: number ): void {
-	Object.defineProperty( element, 'offsetHeight', {
-		configurable: true,
-		value,
-	} );
-}
-
-/**
- * Set the viewport height the gate reads.
- *
- * @param {number} value - Pixel height for window.innerHeight.
- */
-function setViewportHeight( value: number ): void {
-	Object.defineProperty( window, 'innerHeight', {
-		configurable: true,
-		writable: true,
-		value,
-	} );
-}
-
-/**
  * Set the viewport width the gate reads.
  *
  * @param {number} value - Pixel width for window.innerWidth.
@@ -89,34 +62,8 @@ describe( 'sidebar-docking-gate', () => {
 		jest.resetModules();
 	} );
 
-	it( 'removes the docked classes when the menu does not fit the viewport', async () => {
+	it( 'keeps the docked classes on a wide, non-gated screen', async () => {
 		addDockedClasses();
-
-		const adminMenu = document.createElement( 'div' );
-		adminMenu.id = 'adminmenu';
-		stubOffsetHeight( adminMenu, 800 );
-		document.body.appendChild( adminMenu );
-
-		// 600 < 800 + 32 (default bar) + 20 => too short.
-		setViewportHeight( 600 );
-
-		await runGate();
-
-		DOCKED_SIDEBAR_BODY_CLASSES.forEach( cls => {
-			expect( document.body ).not.toHaveClass( cls );
-		} );
-	} );
-
-	it( 'keeps the docked classes when the menu fits the viewport', async () => {
-		addDockedClasses();
-
-		const adminMenu = document.createElement( 'div' );
-		adminMenu.id = 'adminmenu';
-		stubOffsetHeight( adminMenu, 400 );
-		document.body.appendChild( adminMenu );
-
-		// 1000 >= 400 + 32 + 20 => fits.
-		setViewportHeight( 1000 );
 
 		await runGate();
 
@@ -127,14 +74,6 @@ describe( 'sidebar-docking-gate', () => {
 
 	it( 'removes the docked classes when the viewport is too narrow', async () => {
 		addDockedClasses();
-
-		const adminMenu = document.createElement( 'div' );
-		adminMenu.id = 'adminmenu';
-		stubOffsetHeight( adminMenu, 400 );
-		document.body.appendChild( adminMenu );
-
-		// Tall enough to fit, but narrower than the 1200px threshold.
-		setViewportHeight( 1000 );
 		setViewportWidth( 1100 );
 
 		await runGate();
@@ -148,14 +87,6 @@ describe( 'sidebar-docking-gate', () => {
 		addDockedClasses();
 		document.body.classList.add( 'post-php' );
 
-		const adminMenu = document.createElement( 'div' );
-		adminMenu.id = 'adminmenu';
-		stubOffsetHeight( adminMenu, 400 );
-		document.body.appendChild( adminMenu );
-
-		// Fits and wide enough; only the fullscreen gate trips.
-		setViewportHeight( 1000 );
-
 		await runGate();
 
 		DOCKED_SIDEBAR_BODY_CLASSES.forEach( cls => {
@@ -167,90 +98,15 @@ describe( 'sidebar-docking-gate', () => {
 		addDockedClasses();
 		document.body.classList.add( 'post-php', 'is-fullscreen-mode' );
 
-		const adminMenu = document.createElement( 'div' );
-		adminMenu.id = 'adminmenu';
-		stubOffsetHeight( adminMenu, 400 );
-		document.body.appendChild( adminMenu );
-
-		setViewportHeight( 1000 );
-
 		await runGate();
 
 		DOCKED_SIDEBAR_BODY_CLASSES.forEach( cls => {
 			expect( document.body ).toHaveClass( cls );
-		} );
-	} );
-
-	it( 'does nothing when the admin menu is absent', async () => {
-		addDockedClasses();
-		setViewportHeight( 100 );
-
-		await runGate();
-
-		// The classes are left untouched because the gate bails out early.
-		DOCKED_SIDEBAR_BODY_CLASSES.forEach( cls => {
-			expect( document.body ).toHaveClass( cls );
-		} );
-	} );
-
-	it( 'falls back to a 32px admin bar height when #wpadminbar is missing', async () => {
-		addDockedClasses();
-
-		const adminMenu = document.createElement( 'div' );
-		adminMenu.id = 'adminmenu';
-		stubOffsetHeight( adminMenu, 700 );
-		document.body.appendChild( adminMenu );
-
-		// Boundary with the 32px fallback: 760 >= 700 + 32 + 20 (752) => fits.
-		setViewportHeight( 760 );
-		await runGate();
-		DOCKED_SIDEBAR_BODY_CLASSES.forEach( cls => {
-			expect( document.body ).toHaveClass( cls );
-		} );
-
-		// One pixel under the fallback threshold => too short.
-		document.body.className = '';
-		addDockedClasses();
-		jest.resetModules();
-		setViewportHeight( 751 );
-		await runGate();
-		DOCKED_SIDEBAR_BODY_CLASSES.forEach( cls => {
-			expect( document.body ).not.toHaveClass( cls );
-		} );
-	} );
-
-	it( 'uses the real admin bar offsetHeight when #wpadminbar is present', async () => {
-		addDockedClasses();
-
-		const adminBar = document.createElement( 'div' );
-		adminBar.id = 'wpadminbar';
-		stubOffsetHeight( adminBar, 100 );
-		document.body.appendChild( adminBar );
-
-		const adminMenu = document.createElement( 'div' );
-		adminMenu.id = 'adminmenu';
-		stubOffsetHeight( adminMenu, 700 );
-		document.body.appendChild( adminMenu );
-
-		// With the taller real bar: 800 < 700 + 100 + 20 (820) => too short,
-		// even though it would have fit with the 32px fallback.
-		setViewportHeight( 800 );
-
-		await runGate();
-
-		DOCKED_SIDEBAR_BODY_CLASSES.forEach( cls => {
-			expect( document.body ).not.toHaveClass( cls );
 		} );
 	} );
 
 	it( 'strips the shell when a fullscreen-gated class is added after the first run', async () => {
 		addDockedClasses();
-
-		const adminMenu = document.createElement( 'div' );
-		adminMenu.id = 'adminmenu';
-		stubOffsetHeight( adminMenu, 400 );
-		document.body.appendChild( adminMenu );
-		setViewportHeight( 1000 );
 
 		await runGate();
 
@@ -271,12 +127,6 @@ describe( 'sidebar-docking-gate', () => {
 	it( 'keeps the shell when a gated class is added while in fullscreen mode', async () => {
 		addDockedClasses();
 
-		const adminMenu = document.createElement( 'div' );
-		adminMenu.id = 'adminmenu';
-		stubOffsetHeight( adminMenu, 400 );
-		document.body.appendChild( adminMenu );
-		setViewportHeight( 1000 );
-
 		await runGate();
 
 		document.body.classList.add( 'post-php', 'is-fullscreen-mode' );
@@ -289,12 +139,6 @@ describe( 'sidebar-docking-gate', () => {
 
 	it( 'stops observing once the chat app mounts', async () => {
 		addDockedClasses();
-
-		const adminMenu = document.createElement( 'div' );
-		adminMenu.id = 'adminmenu';
-		stubOffsetHeight( adminMenu, 400 );
-		document.body.appendChild( adminMenu );
-		setViewportHeight( 1000 );
 
 		await runGate();
 
@@ -315,12 +159,6 @@ describe( 'sidebar-docking-gate', () => {
 
 	it( 'disconnects after one strip and never loops or re-strips', async () => {
 		addDockedClasses();
-
-		const adminMenu = document.createElement( 'div' );
-		adminMenu.id = 'adminmenu';
-		stubOffsetHeight( adminMenu, 400 );
-		document.body.appendChild( adminMenu );
-		setViewportHeight( 1000 );
 
 		await runGate();
 


### PR DESCRIPTION
Part of AI-1059

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Remove the viewport-height check (`tooShort`) from the pre-paint sidebar-docking gate: the gate no longer strips the pre-rendered docked shell when the viewport is shorter than the admin menu. It still strips for too-narrow viewports (<1200px) and non-fullscreen Gutenberg screens.
* Drop the `#adminmenu` / `#wpadminbar` measurement scaffolding and the height-specific unit tests that only existed to feed that check.
* Update the comments in `Sidebar_Open_Preservation` that justified the inline script via the measured admin menu height.

This mirrors Automattic/wp-calypso#112706, which removed the same height gate from the `useCanDock` hook the two files are cross-referenced with ("keep in sync" notes): docked mode now keeps the wp-admin menu scrollable at any viewport height, with flyout submenus repositioned so the scroll container doesn't clip them. With only one side deployed, short viewports briefly paint an unframed wp-admin before the app mounts and docks — no breakage, just the same layout pop a cold load already has.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* AI-1059
* Automattic/wp-calypso#112706 — the Calypso-side change this mirrors
* #49439 — background on the pre-render + gate mechanism

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Unit tests: `pnpm run test` within `projects/packages/agents-manager`.
* Sync this branch with you sandbox 
  * On your sandbox inside of wpcom/public_html run: `bin/jetpack-downloader test jetpack-mu-wpcom-plugin update/agents-manager-remove-sidebar-height-gate`
* Refer to Automattic/wp-calypso#112706 for the testing instructions
