### PR TITLE
Premium Analytics: scope DataViews styles

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-storybook-dataviews-style-build
+++ b/projects/packages/premium-analytics/changelog/fix-storybook-dataviews-style-build
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Report table: Scope the inlined DataViews stylesheet to keep Storybook builds working.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-records-table.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-records-table.module.scss
@@ -1,20 +1,19 @@
 @use "sass:meta";
 
-/* Inline DataViews' own stylesheet. It must load through :global so CSS Modules
- * keeps DataViews' class names (.dataviews-wrapper, …) intact — a plain @import
- * of the .css would instead be emitted verbatim and 404 at runtime against the
- * page base. */
-:global {
-
-	@include meta.load-css( "@wordpress/dataviews/build-style/style" );
-}
-
 /* DataViews pads its own chrome — the toolbar, the table's first/last cells,
  * and the footer all carry the same 24px inline inset the section card would
  * add — so the card contributes no padding of its own; otherwise the two
  * stack and the whole table sits doubly inset. Clip children so DataViews'
  * square row and footer edges follow the card's rounded corners. */
 .root {
+
+	/* Keep DataViews' selectors global within this component while loading the
+	 * stylesheet through Sass so Storybook does not emit a relative @import. */
+	:global {
+
+		@include meta.load-css( "@wordpress/dataviews/build-style/style" );
+	}
+
 	padding: 0;
 	overflow: hidden;
 }


### PR DESCRIPTION
## Proposed changes

* Keep the DataViews stylesheet inside the report table CSS Module.
* Scope its global selectors beneath the report table root, following the pattern established in #39991.
* Continue loading the stylesheet through Sass so Storybook does not emit a broken relative import.

This fixes the Storybook build regression introduced by #50589 without restoring globally applied DataViews styles.

## Related product discussion/links

* #50589
* #39991

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run `pnpm jetpack build js-packages/storybook` and confirm it succeeds.
* Run `pnpm jetpack build plugins/premium-analytics --deps` and confirm it succeeds.
* Run `pnpm stylelint packages/widgets-toolkit/src/components/report-page/report-records-table.module.scss` from `projects/packages/premium-analytics`.
* Confirm the generated Premium Analytics CSS prefixes imported DataViews selectors with the report table's hashed root class.
