### PR TITLE
ci: Build storybook if story-containing projects are touched

### DIFF
--- a/projects/js-packages/storybook/changelog/add-ci-build-storybook-if-projects-with-stories-touched
+++ b/projects/js-packages/storybook/changelog/add-ci-build-storybook-if-projects-with-stories-touched
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix an obsolete code comment.
+
+

--- a/projects/js-packages/storybook/storybook/projects.js
+++ b/projects/js-packages/storybook/storybook/projects.js
@@ -1,5 +1,4 @@
 // List of projects paths that contains stories
-// When adding something here, also add the project slug to .extra.dependencies.build in composer.json.
 import path from 'node:path';
 
 const basedir = path.join( import.meta.dirname, '../../../..' );

--- a/tools/cli/commands/dependencies.js
+++ b/tools/cli/commands/dependencies.js
@@ -1,4 +1,5 @@
-import { spawn } from 'child_process';
+import { spawn } from 'node:child_process';
+import path from 'node:path';
 import { chalkStderr } from 'chalk';
 import ignore from 'ignore';
 import {
@@ -124,6 +125,7 @@ export function builder( yargs ) {
  * @param {object} argv - the arguments passed.
  */
 export async function handler( argv ) {
+	const debug = argv.v ? m => console.error( chalkStderr.blue( m ) ) : () => {};
 	let deps = await getDependencies( process.cwd(), argv.extra, argv.dev === false );
 
 	if ( argv.ignoreRoot ) {
@@ -165,7 +167,6 @@ export async function handler( argv ) {
 		);
 		const projset = new Set( argv.projects );
 		const ig = ignore().add( ignoreFiles );
-		const debug = argv.v ? m => console.error( chalkStderr.blue( m ) ) : () => {};
 		for ( const file of stdout.split( '\n' ).filter( v => v.length ) ) {
 			if ( infrastructureFiles.has( file ) ) {
 				debug( `Diff touches infrastructure file ${ file }, considering all projects as changed.` );
@@ -192,6 +193,31 @@ export async function handler( argv ) {
 				}
 			}
 		}
+
+		// If this is for a build or tests, add js-packages/storybook if any project having stories is touched.
+		// This will help catch changes that work fine in the project but break the storybook build.
+		if (
+			argv.addDependents &&
+			( argv.extra === 'build' || argv.extra === 'test' ) &&
+			! projset.has( 'js-packages/storybook' )
+		) {
+			const tmpdeps = filterDeps( deps, [ ...projset ], { dependencies: false, dependents: true } );
+			const { projects: storybookProjects } = await import(
+				path.join( process.cwd(), 'projects/js-packages/storybook/storybook/projects.js' )
+			);
+			for ( const p of storybookProjects ) {
+				const m = p.match( /(?:^|\/)projects\/([^/]+\/[^/]+)(?:$|\/)/ );
+				if ( m && tmpdeps.has( m[ 1 ] ) ) {
+					const touched = projset.has( m[ 1 ] ) ? 'touched' : 'indirectly touched';
+					debug(
+						`Adding js-packages/storybook for ${ argv.extra } because ${ m[ 1 ] } is ${ touched }.`
+					);
+					projset.add( 'js-packages/storybook' );
+					break;
+				}
+			}
+		}
+
 		argv.projects = [ ...projset ];
 
 		// If the diff touched nothing, we output nothing.


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
We had a trunk break due to a PR that worked fine in the project but broke the storybook. We should build/test the storybook when any project containing stories gets touched to catch this sort of thing.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
p1784278382919189-slack-C034JEXD1RD

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI happy?
* Try something like `jetpack dependencies list --ignore-root --add-dependents --extra=build --verbose --git-changed=717dcfea741f0a3b1cd1c8fb6e51bbac8d2e3a7a...1b5b3f423375a250618878f1780e3eaf35a645f2` versus something like `jetpack dependencies list --ignore-root --add-dependents --extra=build --verbose --git-changed=fb126d85175a7c637ef8c2d17e3073a666aa6853^..fb126d85175a7c637ef8c2d17e3073a666aa6853`