### PR TITLE
Premium Analytics: fix DataViewsDrilldownNative stylesheet 404

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-drilldown-dataviews-css-404
+++ b/projects/packages/premium-analytics/changelog/fix-drilldown-dataviews-css-404
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+DataViewsDrilldownNative: inline the DataViews stylesheet through meta.load-css instead of a passthrough @import that 404'd at runtime.

--- a/projects/packages/premium-analytics/packages/ui/src/dataviews-drilldown-native/dataviews-drilldown-native.module.scss
+++ b/projects/packages/premium-analytics/packages/ui/src/dataviews-drilldown-native/dataviews-drilldown-native.module.scss
@@ -1,6 +1,14 @@
-@import "@wordpress/dataviews/build-style/style.css";
+@use "sass:meta";
 
 .root {
+
+	/* Load DataViews' stylesheet through Sass so it is inlined rather than
+	 * emitted as a relative @import that 404s at runtime. */
+	:global {
+
+		@include meta.load-css( "@wordpress/dataviews/build-style/style" );
+	}
+
 	width: 100%;
 }
 

--- a/projects/packages/premium-analytics/packages/ui/src/dataviews-drilldown-native/stories/dataviews-drilldown-native.stories.tsx
+++ b/projects/packages/premium-analytics/packages/ui/src/dataviews-drilldown-native/stories/dataviews-drilldown-native.stories.tsx
@@ -1,9 +1,3 @@
-/**
- * The DataViews base stylesheet. The component's scss imports it for product
- * builds, but Storybook's Vite/sass pipeline passes css-extension imports
- * through verbatim, so the story loads it as a side effect instead.
- */
-import '@wordpress/dataviews/build-style/style.css';
 import { DataViewsDrilldownNative } from '../dataviews-drilldown-native';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { DataViewRenderFieldProps, Field } from '@wordpress/dataviews';


### PR DESCRIPTION
## Proposed changes

Same fix as #50630, applied to the `DataViewsDrilldownNative` component (originally added in #50564).

`dataviews-drilldown-native.module.scss` did `@import "@wordpress/dataviews/build-style/style.css";`. Sass emits a `.css` `@import` **verbatim** into the compiled stylesheet, so at runtime on the Premium Analytics wp-admin page the browser resolves that relative URL against the page base and **404s** (visible on trunk at `admin.php?page=jetpack-premium-analytics-wp-admin`).

This inlines the stylesheet through `meta.load-css` inside `.root :global` — the same approach used for the report table in #50630 — so the CSS is bundled into the component's stylesheet rather than referenced by a relative `@import`:

* `dataviews-drilldown-native.module.scss`: replace the `@import` with `@include meta.load-css( "@wordpress/dataviews/build-style/style" )` inside `.root :global`.
* Story: drop the now-redundant side-effect import of the stylesheet — the component's SCSS loads it, so the story renders styled in isolation.

## Related product discussion/links

* Follow-up to #50630 (report table) and #50564 (component that introduced the import).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On trunk, open `admin.php?page=jetpack-premium-analytics-wp-admin` with the network tab open and note the **404** for `@wordpress/dataviews/build-style/style.css`.
* With this branch built, the 404 is gone — the stylesheet is inlined.
* Storybook: open **Packages/Premium Analytics/UI/DataViewsDrilldownNative** → the table renders fully styled (search box, column headers, bordered rows, hierarchy, pagination). Verified via screenshots of the `Default` and `MultipleColumns` stories after the change.