### PR TITLE
Stylelint: enable no-token-fallback-values lint for licensing package

### DIFF
--- a/tools/js-tools/stylelint.config.base.mjs
+++ b/tools/js-tools/stylelint.config.base.mjs
@@ -103,6 +103,7 @@ const baseConfig = {
 				'projects/packages/seo/routes/**/*.{css,scss,sass}',
 				'projects/packages/videopress/routes/**/*.{css,scss,sass}',
 				// Webpack packages with `@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks`
+				'projects/js-packages/licensing/**/*.{css,scss,sass}',
 				'projects/packages/activity-log/src/**/*.{css,scss,sass}',
 				'projects/packages/forms/src/**/*.{css,scss,sass}',
 				'projects/packages/my-jetpack/_inc/**/*.{css,scss,sass}',


### PR DESCRIPTION

## Proposed changes
<!--- Explain what functional changes your PR includes -->
*  Just enforces what we're already doing in this package; no fallbacks for WPDS token fallbacks.
The package doesn't have its own css/js build pipeline (webpack or otherwise) and it's instead imported in places like My Jetpack (which already adds fallbacks) and the Jetpack plugin (which currently doesn't do much about wpds tokens, see pr https://github.com/Automattic/jetpack/pull/50108).

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->


* lint passing if you try to add fallbacks :-)
