### PR TITLE
Jetpack Footer: fix vertical stacking on WordPress.com Simple sites

### DIFF
--- a/projects/js-packages/components/changelog/fix-jetpack-footer-flex-simple-sites
+++ b/projects/js-packages/components/changelog/fix-jetpack-footer-flex-simple-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Jetpack Footer: add explicit `display: flex` so the footer lays out horizontally on WordPress.com Simple sites instead of stacking vertically.

--- a/projects/js-packages/components/components/jetpack-footer/style.scss
+++ b/projects/js-packages/components/components/jetpack-footer/style.scss
@@ -7,6 +7,7 @@
 	font-size: var(--wpds-typography-font-size-md, 13px);
 	padding: var(--wpds-dimension-padding-xl) var(--wpds-dimension-padding-2xl);
 	width: 100%;
+	display: flex;
 
 	.jetpack-footer__menu-item {
 


### PR DESCRIPTION
Fixes JETPACK-1866

## The issue 

* The `display:flex` was currently coming from the wp-ui Stack component, but since a different pat of the codebase was adding `footer { display: block; }` the display: flex that was coming from wp-ui component was having no effect. 

## Proposed changes
* Add an explicit `display: flex` to the `.jetpack-footer` container in the `js-components` package.
* The footer's children already depend on a flex layout — the a8c logo uses `margin-inline-start: auto` to push itself to the end, and `.jetpack-footer__logo` uses `flex-shrink: 0`. Without an explicit `display: flex` on the container, these rules have no effect.
* On WordPress.com Simple sites the footer inherited no ambient flex context, so items stacked vertically. Declaring `display: flex` on the container makes the footer lay out horizontally consistently across environments (Simple, Atomic, self-hosted).

## Related product discussion/links
* https://linear.app/a8c/issue/JETPACK-1866/jetpack-standard-footer-stacks-vertically-on-wpcom-simple-sites-and

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* On a WordPress.com Simple site (or any environment that renders the Jetpack Footer component), open a screen that displays the standard Jetpack footer (e.g. a Jetpack admin dashboard footer with the menu items and the "An Automattic Airline" a8c logo).
* Confirm the footer menu items and the a8c logo render on a single horizontal row, with the a8c logo pushed to the far end.
* Verify at viewport widths below and above 480px that the layout does not stack vertically.
* Before this change, the footer items stacked vertically on Simple sites; after, they lay out horizontally.
