### PR TITLE
Premium Analytics: fix post detail timeline comparisons and draw the email comparison overlay

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-post-detail-timeline-comparison
+++ b/projects/packages/premium-analytics/changelog/fix-post-detail-timeline-comparison
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Post detail: Align post view comparisons and avoid redundant email timeline requests.

--- a/projects/packages/premium-analytics/changelog/fix-post-detail-timeline-comparison
+++ b/projects/packages/premium-analytics/changelog/fix-post-detail-timeline-comparison
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Post detail: Align post view comparisons and avoid redundant email timeline requests.
+Post detail: align post view comparisons and draw the email timeline comparison overlay.

--- a/projects/packages/premium-analytics/changelog/fix-timeline-comparison-unequal-lengths
+++ b/projects/packages/premium-analytics/changelog/fix-timeline-comparison-unequal-lengths
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Post detail: keep the timeline comparison overlay correct when the compare window differs in length from the primary, and surface email compare-request failures.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-email-time-series.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-email-time-series.ts
@@ -10,19 +10,15 @@ import {
 	type StatsEmailTimeSeriesDataPoint,
 	type StatsEmailTimeSeriesSummary,
 } from '../queries/stats-email-time-series-query';
-import { useStatsReport, type UseStatsOptions } from './use-stats-report';
+import { useStatsQuery } from './use-stats-query';
+import type { UseStatsOptions } from './use-stats-report';
 
 export function useStatsEmailOpensTimeSeries(
 	postId: number,
 	params: StatsEmailTimeSeriesParams,
 	options?: UseStatsOptions
 ) {
-	return useStatsReport< StatsEmailTimeSeriesParams, StatsEmailTimeSeriesReport >(
-		p => statsEmailOpensTimeSeriesQuery( postId, p ),
-		params,
-		[ 'stats', 'email-opens-time-series', '__comparison__', 'disabled' ],
-		options
-	);
+	return useStatsQuery( statsEmailOpensTimeSeriesQuery( postId, params ), options );
 }
 
 export function useStatsEmailClicksTimeSeries(
@@ -30,12 +26,7 @@ export function useStatsEmailClicksTimeSeries(
 	params: StatsEmailTimeSeriesParams,
 	options?: UseStatsOptions
 ) {
-	return useStatsReport< StatsEmailTimeSeriesParams, StatsEmailTimeSeriesReport >(
-		p => statsEmailClicksTimeSeriesQuery( postId, p ),
-		params,
-		[ 'stats', 'email-clicks-time-series', '__comparison__', 'disabled' ],
-		options
-	);
+	return useStatsQuery( statsEmailClicksTimeSeriesQuery( postId, params ), options );
 }
 
 export type {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/email-timeline.test.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/email-timeline.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Internal dependencies
+ */
+import { buildEmailTimelineResponse } from './email-timeline';
+
+type EmailTimelineResponse = {
+	timeline: {
+		unit: string;
+		data: Array< [ string, number ] | [ string, number, number ] >;
+	};
+};
+
+describe( 'buildEmailTimelineResponse', () => {
+	it( 'generates daily buckets forward from the requested start date', () => {
+		const response = buildEmailTimelineResponse(
+			'opens',
+			'/stats/opens/emails/1234?period=day&quantity=3&date=2026-06-17&stats_fields=timeline'
+		) as EmailTimelineResponse;
+
+		expect( response.timeline.unit ).toBe( 'day' );
+		expect( response.timeline.data.map( row => row[ 0 ] ) ).toEqual( [
+			'2026-06-17',
+			'2026-06-18',
+			'2026-06-19',
+		] );
+	} );
+
+	it( 'generates hourly buckets forward from the requested start date', () => {
+		const response = buildEmailTimelineResponse(
+			'clicks',
+			'/stats/clicks/emails/1234?period=hour&quantity=3&date=2026-06-17&stats_fields=timeline'
+		) as EmailTimelineResponse;
+
+		expect( response.timeline.unit ).toBe( 'hour' );
+		expect( response.timeline.data ).toEqual(
+			expect.arrayContaining( [
+				expect.arrayContaining( [ '2026-06-17', 0 ] ),
+				expect.arrayContaining( [ '2026-06-17', 1 ] ),
+				expect.arrayContaining( [ '2026-06-17', 2 ] ),
+			] )
+		);
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/email-timeline.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/email-timeline.ts
@@ -56,10 +56,14 @@ export function buildEmailTimelineResponse(
 
 	const data: EmailTimelineRow[] = [];
 
+	// Nudge the curve by the window start so a comparison window draws a
+	// visibly different (but still deterministic) line than the primary.
+	const windowNudge = ( startDate.getUTCDate() % 7 ) * 2;
+
 	for ( let index = 0; index < quantity; index++ ) {
 		// Preserve the existing send-decay shape while emitting buckets from
 		// the requested start date forward.
-		const count = emailTimelineCount( metric, quantity - 1 - index );
+		const count = emailTimelineCount( metric, quantity - 1 - index ) + windowNudge;
 
 		if ( period === 'hour' ) {
 			const bucket = addHours( startDate, index );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/email-timeline.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/email-timeline.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { format, isValid, parseISO, subDays, subHours } from 'date-fns';
+import { addDays, addHours, format, isValid, parseISO } from 'date-fns';
 
 /**
  * The timeline matrix `stats/<opens|clicks>/emails/<postId>?stats_fields=timeline`
@@ -32,9 +32,9 @@ function emailTimelineCount( metric: 'opens' | 'clicks', index: number ): number
 
 /**
  * Builds a mock email timeline response for the "Email performance" widget. The
- * generated buckets end at the requested `date` and count back `quantity`
- * periods, mirroring how the real endpoint scopes its window, so the chart
- * always spans the dashboard date range the story requests.
+ * email timeline endpoint treats `date` as the first requested bucket and
+ * returns `quantity` periods going forward. Mirroring that behaviour keeps a
+ * story's chart aligned with its dashboard date range.
  *
  * @param metric      - Which timeline to return.
  * @param requestPath - The request path; `period`, `quantity`, and `date` are read off its query.
@@ -51,19 +51,21 @@ export function buildEmailTimelineResponse(
 		? Math.min( Math.max( parsedQuantity, 1 ), 24 * 90 )
 		: 30;
 	const parsedDate = parseISO( query.get( 'date' ) ?? '' );
-	const endDate = isValid( parsedDate ) ? parsedDate : new Date();
+	const startDate = isValid( parsedDate ) ? parsedDate : new Date();
 	const field = metric === 'opens' ? 'opens_count' : 'clicks_count';
 
 	const data: EmailTimelineRow[] = [];
 
-	for ( let index = quantity - 1; index >= 0; index-- ) {
-		const count = emailTimelineCount( metric, index );
+	for ( let index = 0; index < quantity; index++ ) {
+		// Preserve the existing send-decay shape while emitting buckets from
+		// the requested start date forward.
+		const count = emailTimelineCount( metric, quantity - 1 - index );
 
 		if ( period === 'hour' ) {
-			const bucket = subHours( endDate, index );
+			const bucket = addHours( startDate, index );
 			data.push( [ format( bucket, 'yyyy-MM-dd' ), bucket.getHours(), count ] );
 		} else {
-			data.push( [ format( subDays( endDate, index ), 'yyyy-MM-dd' ), count ] );
+			data.push( [ format( addDays( startDate, index ), 'yyyy-MM-dd' ), count ] );
 		}
 	}
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-stats-mocks.test.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-stats-mocks.test.ts
@@ -1,0 +1,18 @@
+/**
+ * Internal dependencies
+ */
+import { getStatsMock } from './register-stats-mocks';
+
+const STATS_BASE = '/jetpack-premium-analytics/v1/proxy/v1.1/stats';
+
+describe( 'getStatsMock', () => {
+	it( 'keeps the standalone clicks report mocked', () => {
+		expect( getStatsMock( `${ STATS_BASE }/clicks?period=day` ) ).not.toBeNull();
+	} );
+
+	it( 'lets email clicks timelines fall through to the report mocks', () => {
+		expect(
+			getStatsMock( `${ STATS_BASE }/clicks/emails/1234?period=day&stats_fields=timeline` )
+		).toBeNull();
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-stats-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-stats-mocks.ts
@@ -1134,14 +1134,14 @@ function buildStatsLocationViewsResponse(
 	};
 }
 
-function getStatsMock( path: string ): unknown | null {
+export function getStatsMock( path: string ): unknown | null {
 	const withoutBase = path.slice( STATS_BASE.length );
 	const queryIndex = withoutBase.indexOf( '?' );
 	const subPath = queryIndex === -1 ? withoutBase : withoutBase.slice( 0, queryIndex );
 	const query = new URLSearchParams( queryIndex === -1 ? '' : withoutBase.slice( queryIndex + 1 ) );
 	const isComparison = isComparisonRequest( path );
 
-	if ( subPath.startsWith( '/clicks' ) ) {
+	if ( subPath === '/clicks' ) {
 		return isComparison ? MOCK_CLICKS_COMPARISON : MOCK_CLICKS;
 	}
 

--- a/projects/packages/premium-analytics/widgets/email-time-series/__tests__/email-time-series.test.tsx
+++ b/projects/packages/premium-analytics/widgets/email-time-series/__tests__/email-time-series.test.tsx
@@ -105,6 +105,25 @@ describe( 'EmailTimeSeriesWidget', () => {
 		expect( requestedPath ).toContain( 'stats/clicks/emails/1234' );
 	} );
 
+	it( 'only requests the primary timeline when dashboard comparison params are present', async () => {
+		mockApiFetch.mockResolvedValue( OPENS_TIMELINE_RESPONSE );
+
+		render(
+			<EmailTimeSeriesWidget
+				attributes={ {
+					reportParams: { ...getDefaultQueryParams( true ), post_id: 1234 },
+					metric: 'opens',
+				} }
+			/>
+		);
+
+		await expect( screen.findByTestId( 'comparative-line-chart' ) ).resolves.toBeInTheDocument();
+
+		expect( mockApiFetch ).toHaveBeenCalledTimes( 1 );
+		const requestedPath = mockApiFetch.mock.calls[ 0 ][ 0 ].path as string;
+		expect( requestedPath ).toContain( 'stats/opens/emails/1234' );
+	} );
+
 	it( 'aggregates the daily buckets into ISO weeks for the weekly granularity', async () => {
 		mockApiFetch.mockResolvedValue( OPENS_TIMELINE_RESPONSE );
 

--- a/projects/packages/premium-analytics/widgets/email-time-series/__tests__/email-time-series.test.tsx
+++ b/projects/packages/premium-analytics/widgets/email-time-series/__tests__/email-time-series.test.tsx
@@ -3,6 +3,7 @@
  */
 import { getDefaultQueryParams, queryClient } from '@jetpack-premium-analytics/data';
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
@@ -211,6 +212,125 @@ describe( 'EmailTimeSeriesWidget', () => {
 		await waitFor( () => expect( chart ).toHaveAttribute( 'data-series-count', '2' ) );
 		expect( chart ).toHaveAttribute( 'data-values', '9' );
 		expect( chart ).toHaveAttribute( 'data-previous-values', '3' );
+	} );
+
+	it( 'folds a longer compare window into the last bucket instead of dropping days', async () => {
+		// previous-month can hand back more days than the primary (a 5-day
+		// compare window onto a 2-day primary). The overlay must keep the same
+		// two buckets as primary while summing all five compare days, not just
+		// the two that pair by index.
+		mockApiFetch.mockImplementation( ( { path }: { path: string } ) =>
+			Promise.resolve(
+				path.includes( 'date=2026-02-28' )
+					? {
+							timeline: {
+								unit: 'day',
+								fields: [ 'date', 'opens_count' ],
+								data: [
+									[ '2026-02-28', 10 ],
+									[ '2026-03-01', 20 ],
+								],
+							},
+					  }
+					: {
+							timeline: {
+								unit: 'day',
+								fields: [ 'date', 'opens_count' ],
+								data: [
+									[ '2026-01-28', 1 ],
+									[ '2026-01-29', 2 ],
+									[ '2026-01-30', 3 ],
+									[ '2026-01-31', 4 ],
+									[ '2026-02-01', 5 ],
+								],
+							},
+					  }
+			)
+		);
+
+		render(
+			<EmailTimeSeriesWidget
+				attributes={ {
+					reportParams: {
+						...getDefaultQueryParams( false ),
+						preset: undefined,
+						from: '2026-02-28T00:00:00.000+08:00',
+						to: '2026-03-01T23:59:59.999+08:00',
+						comp: '1',
+						compare_from: '2026-01-28T00:00:00.000+08:00',
+						compare_to: '2026-02-01T23:59:59.999+08:00',
+						post_id: 1234,
+					},
+					metric: 'opens',
+					granularity: 'month',
+				} }
+			/>
+		);
+
+		const chart = await screen.findByTestId( 'comparative-line-chart' );
+		await waitFor( () => expect( chart ).toHaveAttribute( 'data-series-count', '2' ) );
+		// Primary: Feb=10, Mar=20. Compare: Feb bucket = Jan 28 (1); Mar bucket =
+		// the four remaining days (2+3+4+5 = 14) folded in, so nothing is lost.
+		expect( chart ).toHaveAttribute( 'data-values', '10,20' );
+		expect( chart ).toHaveAttribute( 'data-previous-values', '1,14' );
+	} );
+
+	it( 'surfaces the error state and retries both windows when the compare request fails', async () => {
+		// Primary succeeds, comparison fails: the widget must not quietly show a
+		// lone solid line, so the error state appears and Retry re-runs both.
+		const compareStart = 'date=2026-06-24';
+		mockApiFetch.mockImplementation( ( { path }: { path: string } ) =>
+			path.includes( compareStart )
+				? Promise.reject( { status: 403, message: 'Forbidden' } )
+				: Promise.resolve( OPENS_TIMELINE_RESPONSE )
+		);
+
+		render(
+			<EmailTimeSeriesWidget
+				attributes={ {
+					reportParams: {
+						...getDefaultQueryParams( false ),
+						preset: undefined,
+						from: '2026-07-01T00:00:00.000+08:00',
+						to: '2026-07-07T23:59:59.999+08:00',
+						comp: '1',
+						compare_from: '2026-06-24T00:00:00.000+08:00',
+						compare_to: '2026-06-30T23:59:59.999+08:00',
+						post_id: 1234,
+					},
+					metric: 'opens',
+				} }
+			/>
+		);
+
+		await expect(
+			screen.findByText( /couldn't load this email's timeline/ )
+		).resolves.toBeInTheDocument();
+
+		// Retry re-runs both windows; once the compare window resolves, the
+		// dashed overlay renders.
+		mockApiFetch.mockImplementation( ( { path }: { path: string } ) =>
+			Promise.resolve(
+				path.includes( compareStart )
+					? {
+							timeline: {
+								unit: 'day',
+								fields: [ 'date', 'opens_count' ],
+								data: [
+									[ '2026-06-24', 2 ],
+									[ '2026-06-25', 3 ],
+									[ '2026-06-26', 4 ],
+								],
+							},
+					  }
+					: OPENS_TIMELINE_RESPONSE
+			)
+		);
+		await userEvent.click( screen.getByRole( 'button', { name: 'Retry' } ) );
+
+		const chart = await screen.findByTestId( 'comparative-line-chart' );
+		await waitFor( () => expect( chart ).toHaveAttribute( 'data-series-count', '2' ) );
+		expect( chart ).toHaveAttribute( 'data-previous-values', '2,3,4' );
 	} );
 
 	it( 'aggregates the daily buckets into ISO weeks for the weekly granularity', async () => {

--- a/projects/packages/premium-analytics/widgets/email-time-series/__tests__/email-time-series.test.tsx
+++ b/projects/packages/premium-analytics/widgets/email-time-series/__tests__/email-time-series.test.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { getDefaultQueryParams, queryClient } from '@jetpack-premium-analytics/data';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 /**
  * Internal dependencies
@@ -22,8 +22,10 @@ jest.mock( '@jetpack-premium-analytics/widgets-toolkit', () => ( {
 	} ) => (
 		<div
 			data-testid="comparative-line-chart"
+			data-series-count={ series.length }
 			data-series-label={ series[ 0 ]?.label }
 			data-values={ series[ 0 ]?.data.map( point => point.value ).join( ',' ) }
+			data-previous-values={ series[ 1 ]?.data.map( point => point.value ).join( ',' ) }
 		/>
 	),
 } ) );
@@ -105,23 +107,110 @@ describe( 'EmailTimeSeriesWidget', () => {
 		expect( requestedPath ).toContain( 'stats/clicks/emails/1234' );
 	} );
 
-	it( 'only requests the primary timeline when dashboard comparison params are present', async () => {
-		mockApiFetch.mockResolvedValue( OPENS_TIMELINE_RESPONSE );
+	it( 'fetches the compare window and draws it as a second series when comparison is on', async () => {
+		// Route by the window start: the primary window gets the real buckets,
+		// the compare window gets a distinct set.
+		mockApiFetch.mockImplementation( ( { path }: { path: string } ) =>
+			Promise.resolve(
+				path.includes( 'date=2026-07-01' )
+					? OPENS_TIMELINE_RESPONSE
+					: {
+							timeline: {
+								unit: 'day',
+								fields: [ 'date', 'opens_count' ],
+								data: [
+									[ '2026-06-24', 2 ],
+									[ '2026-06-25', 3 ],
+									[ '2026-06-26', 4 ],
+								],
+							},
+					  }
+			)
+		);
 
 		render(
 			<EmailTimeSeriesWidget
 				attributes={ {
-					reportParams: { ...getDefaultQueryParams( true ), post_id: 1234 },
+					reportParams: {
+						...getDefaultQueryParams( false ),
+						preset: undefined,
+						from: '2026-07-01T00:00:00.000+08:00',
+						to: '2026-07-07T23:59:59.999+08:00',
+						comp: '1',
+						compare_from: '2026-06-24T00:00:00.000+08:00',
+						compare_to: '2026-06-30T23:59:59.999+08:00',
+						post_id: 1234,
+					},
 					metric: 'opens',
 				} }
 			/>
 		);
 
-		await expect( screen.findByTestId( 'comparative-line-chart' ) ).resolves.toBeInTheDocument();
+		const chart = await screen.findByTestId( 'comparative-line-chart' );
+		await waitFor( () => expect( chart ).toHaveAttribute( 'data-series-count', '2' ) );
+		expect( chart ).toHaveAttribute( 'data-values', '10,5,7' );
+		expect( chart ).toHaveAttribute( 'data-previous-values', '2,3,4' );
 
-		expect( mockApiFetch ).toHaveBeenCalledTimes( 1 );
-		const requestedPath = mockApiFetch.mock.calls[ 0 ][ 0 ].path as string;
-		expect( requestedPath ).toContain( 'stats/opens/emails/1234' );
+		// One request per window, scoped by each window's start date.
+		const requestedDates = mockApiFetch.mock.calls.map( call =>
+			new URLSearchParams( String( call[ 0 ].path ).split( '?' )[ 1 ] ).get( 'date' )
+		);
+		expect( requestedDates ).toHaveLength( 2 );
+		expect( requestedDates ).toEqual( expect.arrayContaining( [ '2026-07-01', '2026-06-24' ] ) );
+	} );
+
+	it( 'buckets the compare window relative to the primary layout across month boundaries', async () => {
+		// Primary March window (one month bucket) vs a compare window crossing
+		// January into February: the overlay must still be a single bucket.
+		mockApiFetch.mockImplementation( ( { path }: { path: string } ) =>
+			Promise.resolve(
+				path.includes( 'date=2026-03-01' )
+					? {
+							timeline: {
+								unit: 'day',
+								fields: [ 'date', 'opens_count' ],
+								data: [
+									[ '2026-03-01', 4 ],
+									[ '2026-03-31', 5 ],
+								],
+							},
+					  }
+					: {
+							timeline: {
+								unit: 'day',
+								fields: [ 'date', 'opens_count' ],
+								data: [
+									[ '2026-01-29', 1 ],
+									[ '2026-02-28', 2 ],
+								],
+							},
+					  }
+			)
+		);
+
+		render(
+			<EmailTimeSeriesWidget
+				attributes={ {
+					reportParams: {
+						...getDefaultQueryParams( false ),
+						preset: undefined,
+						from: '2026-03-01T00:00:00.000+08:00',
+						to: '2026-03-31T23:59:59.999+08:00',
+						comp: '1',
+						compare_from: '2026-01-29T00:00:00.000+08:00',
+						compare_to: '2026-02-28T23:59:59.999+08:00',
+						post_id: 1234,
+					},
+					metric: 'opens',
+					granularity: 'month',
+				} }
+			/>
+		);
+
+		const chart = await screen.findByTestId( 'comparative-line-chart' );
+		await waitFor( () => expect( chart ).toHaveAttribute( 'data-series-count', '2' ) );
+		expect( chart ).toHaveAttribute( 'data-values', '9' );
+		expect( chart ).toHaveAttribute( 'data-previous-values', '3' );
 	} );
 
 	it( 'aggregates the daily buckets into ISO weeks for the weekly granularity', async () => {

--- a/projects/packages/premium-analytics/widgets/email-time-series/render.tsx
+++ b/projects/packages/premium-analytics/widgets/email-time-series/render.tsx
@@ -6,6 +6,7 @@ import {
 	getStatsChartBucketKey,
 	useStatsEmailClicksTimeSeries,
 	useStatsEmailOpensTimeSeries,
+	type StatsEmailTimeSeriesDataPoint,
 	type StatsEmailTimeSeriesReport,
 } from '@jetpack-premium-analytics/data';
 import { reports } from '@jetpack-premium-analytics/icons';
@@ -18,7 +19,7 @@ import {
 	useWidgetRootContext,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
-import { useMemo } from '@wordpress/element';
+import { useCallback, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -131,6 +132,17 @@ function EmailTimeSeriesReport( { metric, granularity }: EmailTimeSeriesReportPr
 	const active = metric === 'clicks' ? clicks : opens;
 	const activeComparison = metric === 'clicks' ? clicksComparison : opensComparison;
 
+	// A comparison failure must not silently drop the overlay while the solid
+	// line stays: surface the error and retry both windows together.
+	const isComparisonError =
+		hasComparison && activeComparison.isError && activeComparison.data === undefined;
+	const retry = useCallback( () => {
+		active.refetch();
+		if ( hasComparison ) {
+			activeComparison.refetch();
+		}
+	}, [ active, activeComparison, hasComparison ] );
+
 	const report = active.data as StatsEmailTimeSeriesReport | undefined;
 	const comparisonReport = hasComparison
 		? ( activeComparison.data as StatsEmailTimeSeriesReport | undefined )
@@ -154,11 +166,15 @@ function EmailTimeSeriesReport( { metric, granularity }: EmailTimeSeriesReportPr
 		} );
 	}, [ report, granularity, field ] );
 
-	// The comparison window is the same length as the primary but can sit
-	// differently against calendar boundaries, so calendar-bucketing it
-	// directly could yield a different bucket count and misalign the overlay.
-	// Instead each comparison day joins the bucket of its same-index primary
-	// day, which always mirrors the primary series' bucket layout.
+	// The comparison window is the same length as the primary for most presets,
+	// but previous-month/-year can differ (a 31-day month compared with a
+	// 28-day one), and either window can sit differently against calendar
+	// boundaries. So instead of calendar-bucketing the comparison directly —
+	// which could yield a different bucket count and misalign the overlay —
+	// each comparison day joins the bucket of the primary day at the same
+	// index. Comparison days past the primary window (a longer previous period)
+	// fold into the last bucket, so no comparison data is dropped and the
+	// overlay always mirrors the primary series' bucket layout.
 	const comparisonChartReport = useMemo( () => {
 		if ( ! report || ! comparisonReport ) {
 			return undefined;
@@ -168,18 +184,17 @@ function EmailTimeSeriesReport( { metric, granularity }: EmailTimeSeriesReportPr
 			return comparisonReport;
 		}
 
-		const totals = new Map<
-			string,
-			{ start: ( typeof comparisonReport.data )[ 0 ]; value: number }
-		>();
-		const order: string[] = [];
-		report.data.forEach( ( primaryPoint, index ) => {
-			const comparisonPoint = comparisonReport.data[ index ];
-			if ( ! comparisonPoint ) {
-				return;
-			}
+		const primaryBucketKeys = report.data.map( primaryPoint =>
+			getStatsChartBucketKey( primaryPoint.time_interval, granularity )
+		);
+		if ( ! primaryBucketKeys.length ) {
+			return undefined;
+		}
 
-			const key = getStatsChartBucketKey( primaryPoint.time_interval, granularity );
+		const totals = new Map< string, { start: StatsEmailTimeSeriesDataPoint; value: number } >();
+		const order: string[] = [];
+		comparisonReport.data.forEach( ( comparisonPoint: StatsEmailTimeSeriesDataPoint, index ) => {
+			const key = primaryBucketKeys[ Math.min( index, primaryBucketKeys.length - 1 ) ];
 			const value = Number( comparisonPoint[ field ] ?? 0 );
 			const bucket = totals.get( key );
 			if ( bucket ) {
@@ -219,16 +234,14 @@ function EmailTimeSeriesReport( { metric, granularity }: EmailTimeSeriesReportPr
 			<WidgetState
 				isLoading={ active.isLoading }
 				isFetching={ active.isFetching || ( hasComparison && activeComparison.isFetching ) }
-				isError={ active.isError }
+				isError={ active.isError || isComparisonError }
 				isEmpty={ ! hasSelection || ! hasPoints }
 				error={ {
 					description: __(
 						"We couldn't load this email's timeline. Please try again in a moment.",
 						'jetpack-premium-analytics'
 					),
-					actions: [
-						{ label: __( 'Retry', 'jetpack-premium-analytics' ), onClick: active.refetch },
-					],
+					actions: [ { label: __( 'Retry', 'jetpack-premium-analytics' ), onClick: retry } ],
 				} }
 				empty={ {
 					icon: reports,

--- a/projects/packages/premium-analytics/widgets/email-time-series/render.tsx
+++ b/projects/packages/premium-analytics/widgets/email-time-series/render.tsx
@@ -3,6 +3,7 @@
  */
 import {
 	bucketStatsTimeSeries,
+	getStatsChartBucketKey,
 	useStatsEmailClicksTimeSeries,
 	useStatsEmailOpensTimeSeries,
 	type StatsEmailTimeSeriesReport,
@@ -77,9 +78,12 @@ type EmailTimeSeriesReportProps = {
 
 /**
  * Fetches the selected email's opens or clicks timeline over the dashboard
- * date range and draws it as a line chart. The endpoint reports daily
- * buckets; the weekly granularity aggregates them client-side. Only the
- * active metric's query runs.
+ * date range and draws it as a line chart; with the date picker's comparison
+ * on, the compare window is fetched as a second request and drawn as a dashed
+ * overlay (legend switches to date-range labels). The endpoint reports daily
+ * buckets; weekly/monthly granularities aggregate them client-side, with the
+ * comparison bucketed relative to the primary layout. Only the active
+ * metric's queries run.
  *
  * @param {EmailTimeSeriesReportProps} props - The component props.
  * @return The widget content.
@@ -88,18 +92,49 @@ function EmailTimeSeriesReport( { metric, granularity }: EmailTimeSeriesReportPr
 	const { reportParams } = useWidgetRootContext();
 	const postId = toPostId( reportParams.post_id );
 	const hasSelection = postId > 0;
+	// Comparison dates only survive the report-param normalizer when the
+	// comparison toggle is on, so their presence is the comparison signal.
+	const hasComparison = !! ( reportParams.compare_from && reportParams.compare_to );
 
-	// Both hooks are called every render (hooks rule); only the active
-	// metric's query is enabled, so a single request runs.
+	// The endpoint has no comparison mode of its own, but it accepts any
+	// window (`date` is the window start), so the comparison period is just a
+	// second request scoped to the compare range.
+	const comparisonParams = useMemo(
+		() => ( {
+			...reportParams,
+			from: reportParams.compare_from ?? '',
+			to: reportParams.compare_to ?? '',
+			preset: undefined,
+			comp: undefined,
+			compare_from: undefined,
+			compare_to: undefined,
+			compare_preset: undefined,
+		} ),
+		[ reportParams ]
+	);
+
+	// All hooks are called every render (hooks rule); only the active
+	// metric's queries are enabled, and the comparison window only fetches
+	// while the date picker's comparison is on.
 	const opens = useStatsEmailOpensTimeSeries( postId, reportParams, {
 		enabled: hasSelection && metric === 'opens',
 	} );
 	const clicks = useStatsEmailClicksTimeSeries( postId, reportParams, {
 		enabled: hasSelection && metric === 'clicks',
 	} );
+	const opensComparison = useStatsEmailOpensTimeSeries( postId, comparisonParams, {
+		enabled: hasSelection && hasComparison && metric === 'opens',
+	} );
+	const clicksComparison = useStatsEmailClicksTimeSeries( postId, comparisonParams, {
+		enabled: hasSelection && hasComparison && metric === 'clicks',
+	} );
 	const active = metric === 'clicks' ? clicks : opens;
+	const activeComparison = metric === 'clicks' ? clicksComparison : opensComparison;
 
 	const report = active.data as StatsEmailTimeSeriesReport | undefined;
+	const comparisonReport = hasComparison
+		? ( activeComparison.data as StatsEmailTimeSeriesReport | undefined )
+		: undefined;
 	const field = METRIC_FIELDS[ metric ];
 
 	const chartReport = useMemo( () => {
@@ -119,15 +154,62 @@ function EmailTimeSeriesReport( { metric, granularity }: EmailTimeSeriesReportPr
 		} );
 	}, [ report, granularity, field ] );
 
+	// The comparison window is the same length as the primary but can sit
+	// differently against calendar boundaries, so calendar-bucketing it
+	// directly could yield a different bucket count and misalign the overlay.
+	// Instead each comparison day joins the bucket of its same-index primary
+	// day, which always mirrors the primary series' bucket layout.
+	const comparisonChartReport = useMemo( () => {
+		if ( ! report || ! comparisonReport ) {
+			return undefined;
+		}
+
+		if ( granularity === 'day' ) {
+			return comparisonReport;
+		}
+
+		const totals = new Map<
+			string,
+			{ start: ( typeof comparisonReport.data )[ 0 ]; value: number }
+		>();
+		const order: string[] = [];
+		report.data.forEach( ( primaryPoint, index ) => {
+			const comparisonPoint = comparisonReport.data[ index ];
+			if ( ! comparisonPoint ) {
+				return;
+			}
+
+			const key = getStatsChartBucketKey( primaryPoint.time_interval, granularity );
+			const value = Number( comparisonPoint[ field ] ?? 0 );
+			const bucket = totals.get( key );
+			if ( bucket ) {
+				bucket.value += value;
+			} else {
+				totals.set( key, { start: comparisonPoint, value } );
+				order.push( key );
+			}
+		} );
+
+		return {
+			...comparisonReport,
+			data: order.map( key => {
+				const bucket = totals.get( key )!;
+
+				return { ...bucket.start, value: bucket.value, [ field ]: bucket.value };
+			} ),
+		};
+	}, [ report, comparisonReport, granularity, field ] );
+
 	const series = useMemo(
 		() =>
 			chartReport
 				? buildReportMetricSeries( {
 						primary: chartReport,
+						comparison: comparisonChartReport,
 						metrics: [ { key: field, label: metricLabel( metric ) } ],
 				  } )
 				: [],
-		[ chartReport, field, metric ]
+		[ chartReport, comparisonChartReport, field, metric ]
 	);
 	const seriesStyles = useSeriesStyles( series );
 	const hasPoints = ( chartReport?.data?.length ?? 0 ) > 0;
@@ -136,7 +218,7 @@ function EmailTimeSeriesReport( { metric, granularity }: EmailTimeSeriesReportPr
 		<div className={ styles.root }>
 			<WidgetState
 				isLoading={ active.isLoading }
-				isFetching={ active.isFetching }
+				isFetching={ active.isFetching || ( hasComparison && activeComparison.isFetching ) }
 				isError={ active.isError }
 				isEmpty={ ! hasSelection || ! hasPoints }
 				error={ {

--- a/projects/packages/premium-analytics/widgets/email-time-series/render.tsx
+++ b/projects/packages/premium-analytics/widgets/email-time-series/render.tsx
@@ -99,7 +99,7 @@ function EmailTimeSeriesReport( { metric, granularity }: EmailTimeSeriesReportPr
 	} );
 	const active = metric === 'clicks' ? clicks : opens;
 
-	const report = active.primary.data as StatsEmailTimeSeriesReport | undefined;
+	const report = active.data as StatsEmailTimeSeriesReport | undefined;
 	const field = METRIC_FIELDS[ metric ];
 
 	const chartReport = useMemo( () => {

--- a/projects/packages/premium-analytics/widgets/email-time-series/stories/email-time-series-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-time-series/stories/email-time-series-widget.stories.tsx
@@ -6,8 +6,9 @@
  * as it does in product.
  *
  * The timeline is scoped to a single email via a mocked `reportParams.post_id`.
- * The endpoint has no comparison period, so it ignores comparison parameters
- * from the dashboard and always draws a single line.
+ * The endpoint has no comparison mode, but it accepts any window, so with the
+ * date picker's comparison on the widget fetches the compare window as a
+ * second request and draws it as a dashed overlay.
  */
 /**
  * External dependencies
@@ -63,19 +64,24 @@ const GRANULARITY_OPTIONS: EmailTimeSeriesGranularity[] =
 	attributeElementValues< EmailTimeSeriesGranularity >( 'granularity' );
 
 /**
- * Widget-specific controls for the opens/clicks metric and the day/week bucket
- * granularity.
+ * Widget-specific controls: the comparison toggle, the opens/clicks metric,
+ * and the bucket granularity.
  */
 interface EmailTimeSeriesStoryControls {
+	withComparison: boolean;
 	metric: EmailTimeSeriesMetric;
 	granularity: EmailTimeSeriesGranularity;
 }
 
-function renderEmailTimeSeries( { metric, granularity }: EmailTimeSeriesStoryControls ) {
+function renderEmailTimeSeries( {
+	withComparison,
+	metric,
+	granularity,
+}: EmailTimeSeriesStoryControls ) {
 	return (
 		<EmailTimeSeriesRender
 			attributes={ {
-				reportParams: { ...getDefaultQueryParams( false ), post_id: MOCK_EMAIL_ID },
+				reportParams: { ...getDefaultQueryParams( withComparison ), post_id: MOCK_EMAIL_ID },
 				metric,
 				granularity,
 			} }
@@ -103,6 +109,7 @@ const meta = {
 	component: EmailTimeSeriesRender,
 	tags: [ 'autodocs' ],
 	argTypes: {
+		withComparison: { control: 'boolean' },
 		metric: { control: 'select', options: METRIC_OPTIONS },
 		granularity: { control: 'select', options: GRANULARITY_OPTIONS },
 	},
@@ -110,7 +117,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					"The \"Email performance\" widget. Draws a single sent email's opens or clicks per day as a line chart, spanning the dashboard date range — the chart section of the legacy email detail page. The `granularity` attribute (`relevance: 'high'`) is exposed as a control by the widget host; weekly grouping aggregates the daily buckets client-side because the endpoint only reports hourly/daily. Scoped to one email via a mocked `reportParams.post_id`. The endpoint has no comparison period, so the chart stays a single line when the dashboard supplies comparison params.",
+					"The \"Email performance\" widget. Draws a single sent email's opens or clicks per day as a line chart, spanning the dashboard date range — the chart section of the legacy email detail page. The `granularity` attribute (`relevance: 'high'`) is exposed as a control by the widget host; weekly grouping aggregates the daily buckets client-side because the endpoint only reports hourly/daily. Scoped to one email via a mocked `reportParams.post_id`. With the date picker's comparison on, the compare window is fetched as a second request and drawn as a dashed overlay with date-range legend labels.",
 			},
 		},
 	},
@@ -126,7 +133,17 @@ type Story = StoryObj< EmailTimeSeriesStoryControls >;
  */
 export const Default: Story = {
 	render: renderEmailTimeSeries,
-	args: { metric: 'opens', granularity: 'day' },
+	args: { withComparison: false, metric: 'opens', granularity: 'day' },
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * Comparison from the date picker: the compare window fetches as a second
+ * request and draws as a dashed overlay, with date-range legend labels.
+ */
+export const WithComparison: Story = {
+	render: renderEmailTimeSeries,
+	args: { withComparison: true, metric: 'opens', granularity: 'day' },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -135,7 +152,7 @@ export const Default: Story = {
  */
 export const Clicks: Story = {
 	render: renderEmailTimeSeries,
-	args: { metric: 'clicks', granularity: 'day' },
+	args: { withComparison: false, metric: 'clicks', granularity: 'day' },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -144,7 +161,7 @@ export const Clicks: Story = {
  */
 export const ByWeeks: Story = {
 	render: renderEmailTimeSeries,
-	args: { metric: 'opens', granularity: 'week' },
+	args: { withComparison: false, metric: 'opens', granularity: 'week' },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -208,6 +225,7 @@ interface EmailTimeSeriesDashboardStoryProps
 		EmailTimeSeriesStoryControls {}
 
 function EmailTimeSeriesDashboardStory( {
+	withComparison,
 	metric,
 	granularity,
 	...dashboardArgs
@@ -219,9 +237,7 @@ function EmailTimeSeriesDashboardStory( {
 			renderModule={ EMAIL_TIME_SERIES_RENDER_MODULE }
 			renderComponent={ EmailTimeSeriesRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ {
-				// Keep the dashboard host's comparison params here to cover the
-				// no-comparison endpoint against the normal dashboard contract.
-				reportParams: { ...getDefaultQueryParams( true ), post_id: MOCK_EMAIL_ID },
+				reportParams: { ...getDefaultQueryParams( withComparison ), post_id: MOCK_EMAIL_ID },
 				metric,
 				granularity,
 			} }
@@ -233,11 +249,13 @@ export const WidgetDashboardWithWidget: StoryObj< EmailTimeSeriesDashboardStoryP
 	render: args => <EmailTimeSeriesDashboardStory { ...args } />,
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+		withComparison: true,
 		metric: 'opens',
 		granularity: 'day',
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
+		withComparison: { control: 'boolean' },
 		metric: { control: 'select', options: METRIC_OPTIONS },
 		granularity: { control: 'select', options: GRANULARITY_OPTIONS },
 	},

--- a/projects/packages/premium-analytics/widgets/email-time-series/stories/email-time-series-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-time-series/stories/email-time-series-widget.stories.tsx
@@ -6,8 +6,8 @@
  * as it does in product.
  *
  * The timeline is scoped to a single email via a mocked `reportParams.post_id`.
- * The endpoint has no comparison period, so the chart always draws a single
- * line even when the date picker injects comparison `reportParams`.
+ * The endpoint has no comparison period, so it ignores comparison parameters
+ * from the dashboard and always draws a single line.
  */
 /**
  * External dependencies
@@ -63,24 +63,19 @@ const GRANULARITY_OPTIONS: EmailTimeSeriesGranularity[] =
 	attributeElementValues< EmailTimeSeriesGranularity >( 'granularity' );
 
 /**
- * Widget-specific controls: the comparison toggle, the opens/clicks metric, and
- * the day/week bucket granularity.
+ * Widget-specific controls for the opens/clicks metric and the day/week bucket
+ * granularity.
  */
 interface EmailTimeSeriesStoryControls {
-	withComparison: boolean;
 	metric: EmailTimeSeriesMetric;
 	granularity: EmailTimeSeriesGranularity;
 }
 
-function renderEmailTimeSeries( {
-	withComparison,
-	metric,
-	granularity,
-}: EmailTimeSeriesStoryControls ) {
+function renderEmailTimeSeries( { metric, granularity }: EmailTimeSeriesStoryControls ) {
 	return (
 		<EmailTimeSeriesRender
 			attributes={ {
-				reportParams: { ...getDefaultQueryParams( withComparison ), post_id: MOCK_EMAIL_ID },
+				reportParams: { ...getDefaultQueryParams( false ), post_id: MOCK_EMAIL_ID },
 				metric,
 				granularity,
 			} }
@@ -108,7 +103,6 @@ const meta = {
 	component: EmailTimeSeriesRender,
 	tags: [ 'autodocs' ],
 	argTypes: {
-		withComparison: { control: 'boolean' },
 		metric: { control: 'select', options: METRIC_OPTIONS },
 		granularity: { control: 'select', options: GRANULARITY_OPTIONS },
 	},
@@ -116,7 +110,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					"The \"Email performance\" widget. Draws a single sent email's opens or clicks per day as a line chart, spanning the dashboard date range — the chart section of the legacy email detail page. The `granularity` attribute (`relevance: 'high'`) is exposed as a control by the widget host; weekly grouping aggregates the daily buckets client-side because the endpoint only reports hourly/daily. Scoped to one email via a mocked `reportParams.post_id`. The endpoint has no comparison period, so the chart stays a single line even when the date picker injects comparison params.",
+					"The \"Email performance\" widget. Draws a single sent email's opens or clicks per day as a line chart, spanning the dashboard date range — the chart section of the legacy email detail page. The `granularity` attribute (`relevance: 'high'`) is exposed as a control by the widget host; weekly grouping aggregates the daily buckets client-side because the endpoint only reports hourly/daily. Scoped to one email via a mocked `reportParams.post_id`. The endpoint has no comparison period, so the chart stays a single line when the dashboard supplies comparison params.",
 			},
 		},
 	},
@@ -132,7 +126,7 @@ type Story = StoryObj< EmailTimeSeriesStoryControls >;
  */
 export const Default: Story = {
 	render: renderEmailTimeSeries,
-	args: { withComparison: false, metric: 'opens', granularity: 'day' },
+	args: { metric: 'opens', granularity: 'day' },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -141,7 +135,7 @@ export const Default: Story = {
  */
 export const Clicks: Story = {
 	render: renderEmailTimeSeries,
-	args: { withComparison: false, metric: 'clicks', granularity: 'day' },
+	args: { metric: 'clicks', granularity: 'day' },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -150,17 +144,7 @@ export const Clicks: Story = {
  */
 export const ByWeeks: Story = {
 	render: renderEmailTimeSeries,
-	args: { withComparison: false, metric: 'opens', granularity: 'week' },
-	decorators: [ withWidgetCanvas ],
-};
-
-/**
- * Comparison `reportParams` from the date picker. The timeline endpoint returns
- * no comparison period, so the chart still draws a single line.
- */
-export const WithComparison: Story = {
-	render: renderEmailTimeSeries,
-	args: { withComparison: true, metric: 'opens', granularity: 'day' },
+	args: { metric: 'opens', granularity: 'week' },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -224,7 +208,6 @@ interface EmailTimeSeriesDashboardStoryProps
 		EmailTimeSeriesStoryControls {}
 
 function EmailTimeSeriesDashboardStory( {
-	withComparison,
 	metric,
 	granularity,
 	...dashboardArgs
@@ -236,7 +219,9 @@ function EmailTimeSeriesDashboardStory( {
 			renderModule={ EMAIL_TIME_SERIES_RENDER_MODULE }
 			renderComponent={ EmailTimeSeriesRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ {
-				reportParams: { ...getDefaultQueryParams( withComparison ), post_id: MOCK_EMAIL_ID },
+				// Keep the dashboard host's comparison params here to cover the
+				// no-comparison endpoint against the normal dashboard contract.
+				reportParams: { ...getDefaultQueryParams( true ), post_id: MOCK_EMAIL_ID },
 				metric,
 				granularity,
 			} }
@@ -248,13 +233,11 @@ export const WidgetDashboardWithWidget: StoryObj< EmailTimeSeriesDashboardStoryP
 	render: args => <EmailTimeSeriesDashboardStory { ...args } />,
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
-		withComparison: false,
 		metric: 'opens',
 		granularity: 'day',
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
-		withComparison: { control: 'boolean' },
 		metric: { control: 'select', options: METRIC_OPTIONS },
 		granularity: { control: 'select', options: GRANULARITY_OPTIONS },
 	},

--- a/projects/packages/premium-analytics/widgets/post-views/__tests__/post-views.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-views/__tests__/post-views.test.tsx
@@ -155,6 +155,79 @@ describe( 'PostViewsWidget', () => {
 		expect( chart ).toHaveAttribute( 'data-previous-values', '6' );
 	} );
 
+	it( 'clamps a shorter previous-month compare bucket to its own window', async () => {
+		// Primary March (31 days) vs previous-month February (28 days), monthly.
+		// The compare bucket must sum only February — a naive relative offset
+		// would run three days past the compare window and pull March 2 in.
+		mockApiFetch.mockResolvedValue( {
+			data: [
+				[ '2026-02-10', 5 ],
+				[ '2026-02-20', 7 ],
+				[ '2026-03-02', 50 ],
+				[ '2026-03-10', 100 ],
+				[ '2026-03-20', 200 ],
+			],
+		} );
+
+		render(
+			<PostViewsWidget
+				attributes={ {
+					reportParams: {
+						...DEFAULT_PARAMS,
+						from: '2026-03-01T00:00:00.000+08:00',
+						to: '2026-03-31T23:59:59.999+08:00',
+						post_id: 779,
+						comp: '1',
+						compare_from: '2026-02-01T00:00:00.000+08:00',
+						compare_to: '2026-02-28T23:59:59.999+08:00',
+					},
+					granularity: 'month',
+				} }
+			/>
+		);
+
+		const chart = await screen.findByTestId( 'comparative-line-chart' );
+		expect( chart ).toHaveAttribute( 'data-values', '350' );
+		// Only February's 5 + 7; March 2's 50 stays out of the compare bucket.
+		expect( chart ).toHaveAttribute( 'data-previous-values', '12' );
+	} );
+
+	it( 'keeps a longer previous-month compare window from truncating', async () => {
+		// Primary February (28 days) vs previous-month January (31 days),
+		// monthly. The compare bucket must sum all of January — the last bucket
+		// has to extend to the compare window end rather than stopping at the
+		// primary length.
+		mockApiFetch.mockResolvedValue( {
+			data: [
+				[ '2026-01-15', 10 ],
+				[ '2026-01-30', 20 ],
+				[ '2026-02-15', 100 ],
+			],
+		} );
+
+		render(
+			<PostViewsWidget
+				attributes={ {
+					reportParams: {
+						...DEFAULT_PARAMS,
+						from: '2026-02-01T00:00:00.000+08:00',
+						to: '2026-02-28T23:59:59.999+08:00',
+						post_id: 779,
+						comp: '1',
+						compare_from: '2026-01-01T00:00:00.000+08:00',
+						compare_to: '2026-01-31T23:59:59.999+08:00',
+					},
+					granularity: 'month',
+				} }
+			/>
+		);
+
+		const chart = await screen.findByTestId( 'comparative-line-chart' );
+		expect( chart ).toHaveAttribute( 'data-values', '100' );
+		// Both January days, including Jan 30 which the old offset would drop.
+		expect( chart ).toHaveAttribute( 'data-previous-values', '30' );
+	} );
+
 	it( 'renders the scopeless empty state and makes no request without a post scope', async () => {
 		render( <PostViewsWidget attributes={ {} } /> );
 

--- a/projects/packages/premium-analytics/widgets/post-views/__tests__/post-views.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-views/__tests__/post-views.test.tsx
@@ -228,6 +228,75 @@ describe( 'PostViewsWidget', () => {
 		expect( chart ).toHaveAttribute( 'data-previous-values', '30' );
 	} );
 
+	it( 'keeps one comparison point per calendar day when the compare window is longer', async () => {
+		mockApiFetch.mockResolvedValue( {
+			data: [
+				[ '2026-01-28', 1 ],
+				[ '2026-01-29', 2 ],
+				[ '2026-01-30', 3 ],
+				[ '2026-01-31', 4 ],
+				[ '2026-02-01', 5 ],
+				[ '2026-02-28', 10 ],
+				[ '2026-03-01', 20 ],
+			],
+		} );
+
+		render(
+			<PostViewsWidget
+				attributes={ {
+					reportParams: {
+						...DEFAULT_PARAMS,
+						from: '2026-02-28T00:00:00.000+08:00',
+						to: '2026-03-01T23:59:59.999+08:00',
+						post_id: 779,
+						comp: '1',
+						compare_from: '2026-01-28T00:00:00.000+08:00',
+						compare_to: '2026-02-01T23:59:59.999+08:00',
+					},
+					granularity: 'day',
+				} }
+			/>
+		);
+
+		const chart = await screen.findByTestId( 'comparative-line-chart' );
+		expect( chart ).toHaveAttribute( 'data-values', '10,20' );
+		// Day grouping must not fold Jan 29-Feb 1 into one point merely to
+		// mirror the shorter primary range.
+		expect( chart ).toHaveAttribute( 'data-previous-values', '1,2,3,4,5' );
+	} );
+
+	it( 'does not invent trailing comparison days when the compare window is shorter', async () => {
+		mockApiFetch.mockResolvedValue( {
+			data: [
+				[ '2026-02-28', 5 ],
+				[ '2026-03-29', 10 ],
+				[ '2026-03-30', 20 ],
+				[ '2026-03-31', 30 ],
+			],
+		} );
+
+		render(
+			<PostViewsWidget
+				attributes={ {
+					reportParams: {
+						...DEFAULT_PARAMS,
+						from: '2026-03-29T00:00:00.000+08:00',
+						to: '2026-03-31T23:59:59.999+08:00',
+						post_id: 779,
+						comp: '1',
+						compare_from: '2026-02-28T00:00:00.000+08:00',
+						compare_to: '2026-02-28T23:59:59.999+08:00',
+					},
+					granularity: 'day',
+				} }
+			/>
+		);
+
+		const chart = await screen.findByTestId( 'comparative-line-chart' );
+		expect( chart ).toHaveAttribute( 'data-values', '10,20,30' );
+		expect( chart ).toHaveAttribute( 'data-previous-values', '5' );
+	} );
+
 	it( 'renders the scopeless empty state and makes no request without a post scope', async () => {
 		render( <PostViewsWidget attributes={ {} } /> );
 

--- a/projects/packages/premium-analytics/widgets/post-views/__tests__/post-views.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-views/__tests__/post-views.test.tsx
@@ -120,6 +120,41 @@ describe( 'PostViewsWidget', () => {
 		expect( mockApiFetch ).toHaveBeenCalledTimes( 1 );
 	} );
 
+	it( 'uses primary month buckets for a previous period that crosses a month boundary', async () => {
+		mockApiFetch.mockResolvedValue( {
+			data: [
+				[ '2026-01-29', 1 ],
+				[ '2026-02-01', 2 ],
+				[ '2026-02-28', 3 ],
+				[ '2026-03-01', 4 ],
+				[ '2026-03-31', 5 ],
+			],
+		} );
+
+		render(
+			<PostViewsWidget
+				attributes={ {
+					reportParams: {
+						...DEFAULT_PARAMS,
+						from: '2026-03-01T00:00:00.000+08:00',
+						to: '2026-03-31T23:59:59.999+08:00',
+						post_id: 779,
+						comp: '1',
+						compare_from: '2026-01-29T00:00:00.000+08:00',
+						compare_to: '2026-02-28T23:59:59.999+08:00',
+					},
+					granularity: 'month',
+				} }
+			/>
+		);
+
+		const chart = await screen.findByTestId( 'comparative-line-chart' );
+		expect( chart ).toHaveAttribute( 'data-values', '9' );
+		// The previous period is one relative monthly bucket, not separate January
+		// and February points that the comparative chart would collapse onto March.
+		expect( chart ).toHaveAttribute( 'data-previous-values', '6' );
+	} );
+
 	it( 'renders the scopeless empty state and makes no request without a post scope', async () => {
 		render( <PostViewsWidget attributes={ {} } /> );
 

--- a/projects/packages/premium-analytics/widgets/post-views/use-post-views.ts
+++ b/projects/packages/premium-analytics/widgets/post-views/use-post-views.ts
@@ -9,13 +9,13 @@ import {
 } from '@jetpack-premium-analytics/data';
 import { useMemo } from '@wordpress/element';
 import {
+	addDays,
+	differenceInCalendarDays,
 	eachDayOfInterval,
 	eachMonthOfInterval,
 	eachWeekOfInterval,
 	format,
 	parseISO,
-	startOfISOWeek,
-	startOfMonth,
 } from 'date-fns';
 /**
  * Internal dependencies
@@ -49,6 +49,16 @@ export interface PostViewsState {
  * A date-only window sliced from the dashboard report params.
  */
 type DayWindow = {
+	from: string;
+	to: string;
+};
+
+/**
+ * One calendar bucket, including its visible label and the portion that falls
+ * inside the selected date window.
+ */
+type BucketWindow = {
+	date: string;
 	from: string;
 	to: string;
 };
@@ -93,42 +103,22 @@ function toDayWindow( from?: string, to?: string ): DayWindow | undefined {
 }
 
 /**
- * Bucket the post's daily view history into chart points for a window: day
- * buckets pass through, week/month buckets sum into their period start.
- * Every calendar bucket of the full requested window is zero-seeded before
- * summing — the endpoint may omit zero-view days and the history only starts
- * at publication, while the chart's comparison overlay aligns series by
- * index, so the primary and comparison windows must always yield the same
- * bucket count. Pre-publication days are genuinely zero views, so the
- * zero-fill is factual, not fabricated. The full history is bucketed
- * client-side because the endpoint's `weeks` field only covers a fixed
- * recent window.
+ * Build the primary range's calendar buckets. Each bucket keeps the calendar
+ * label used by the primary chart while clipping its data bounds to the
+ * selected range. The clipped bounds can then be applied to the comparison
+ * range as relative offsets, which preserves the primary series' bucket count
+ * across calendar boundaries.
  *
- * @param days   - The post's daily views, oldest first.
  * @param window - The date-only window to keep.
  * @param period - The bucket size.
- * @return One point per calendar bucket, oldest first.
+ * @return One bucket per calendar period, oldest first.
  */
-function bucketDays(
-	days: StatsPostDay[],
-	window: DayWindow,
-	period: PostViewsGranularity
-): PostViewsPoint[] {
+function calendarBucketWindows( window: DayWindow, period: PostViewsGranularity ): BucketWindow[] {
 	// The URL is user-editable, so an inverted range must not reach
 	// `eachDayOfInterval()` (it throws).
 	if ( window.from > window.to ) {
 		return [];
 	}
-
-	const bucketKey = ( date: string ): string => {
-		if ( period === 'day' ) {
-			return date;
-		}
-
-		const start =
-			period === 'week' ? startOfISOWeek( parseISO( date ) ) : startOfMonth( parseISO( date ) );
-		return format( start, 'yyyy-MM-dd' );
-	};
 
 	const interval = { start: parseISO( window.from ), end: parseISO( window.to ) };
 	let bucketStarts = eachDayOfInterval( interval );
@@ -138,22 +128,79 @@ function bucketDays(
 		bucketStarts = eachMonthOfInterval( interval );
 	}
 
-	const totals = new Map< string, number >(
-		bucketStarts.map( start => [ format( start, 'yyyy-MM-dd' ), 0 ] )
-	);
+	return bucketStarts.map( ( start, index ) => {
+		const date = format( start, 'yyyy-MM-dd' );
+		const nextDate = bucketStarts[ index + 1 ];
+		const end = nextDate ? format( addDays( nextDate, -1 ), 'yyyy-MM-dd' ) : window.to;
+
+		return {
+			date,
+			from: date < window.from ? window.from : date,
+			to: end > window.to ? window.to : end,
+		};
+	} );
+}
+
+/**
+ * Map primary bucket boundaries onto the comparison range. For example, a
+ * primary March 1–31 range has one monthly bucket; its equal-length January
+ * 29–February 28 comparison range must also have one bucket, even though it
+ * crosses two calendar months.
+ *
+ * @param primaryWindow    - The selected primary range.
+ * @param comparisonWindow - The previous-period range.
+ * @param buckets          - Calendar buckets clipped to the primary range.
+ * @return Comparison buckets with the primary range's relative boundaries.
+ */
+function relativeBucketWindows(
+	primaryWindow: DayWindow,
+	comparisonWindow: DayWindow,
+	buckets: BucketWindow[]
+): BucketWindow[] {
+	const primaryStart = parseISO( primaryWindow.from );
+	const comparisonStart = parseISO( comparisonWindow.from );
+
+	return buckets.map( bucket => {
+		const from = format(
+			addDays( comparisonStart, differenceInCalendarDays( parseISO( bucket.from ), primaryStart ) ),
+			'yyyy-MM-dd'
+		);
+		const to = format(
+			addDays( comparisonStart, differenceInCalendarDays( parseISO( bucket.to ), primaryStart ) ),
+			'yyyy-MM-dd'
+		);
+
+		return { date: from, from, to };
+	} );
+}
+
+/**
+ * Sum the post's daily view history into zero-filled buckets. The endpoint
+ * may omit zero-view days and the history only starts at publication, but
+ * those missing values are genuine zeroes. The full history is bucketed
+ * client-side because the endpoint's `weeks` field only covers a fixed recent
+ * window.
+ *
+ * @param days    - The post's daily views, oldest first.
+ * @param buckets - The bucket bounds to sum.
+ * @return One point per bucket, oldest first.
+ */
+function bucketDays( days: StatsPostDay[], buckets: BucketWindow[] ): PostViewsPoint[] {
+	const totals = new Map< string, number >( buckets.map( bucket => [ bucket.date, 0 ] ) );
 
 	for ( const day of days ) {
-		if ( day.date < window.from || day.date > window.to ) {
-			continue;
+		const bucket = buckets.find(
+			candidate => day.date >= candidate.from && day.date <= candidate.to
+		);
+		if ( bucket ) {
+			totals.set( bucket.date, ( totals.get( bucket.date ) ?? 0 ) + day.views );
 		}
-
-		const key = bucketKey( day.date );
-		totals.set( key, ( totals.get( key ) ?? 0 ) + day.views );
 	}
 
-	return Array.from( totals.entries() )
-		.sort( ( [ a ], [ b ] ) => a.localeCompare( b ) )
-		.map( ( [ date, value ] ) => ( { date: localTZDate( date ), value } ) );
+	return buckets.map( bucket => ( {
+		date: localTZDate( bucket.date ),
+		value: totals.get( bucket.date ) ?? 0,
+	} ) );
 }
 
 /**
@@ -181,9 +228,12 @@ export default function usePostViews(
 		const days = data?.data ?? [];
 		const window = toDayWindow( reportParams.from, reportParams.to );
 		const compareWindow = toDayWindow( reportParams.compare_from, reportParams.compare_to );
-
-		const currentPoints = window ? bucketDays( days, window, period ) : [];
-		const previousPoints = compareWindow ? bucketDays( days, compareWindow, period ) : undefined;
+		const buckets = window ? calendarBucketWindows( window, period ) : [];
+		const currentPoints = bucketDays( days, buckets );
+		const previousPoints =
+			window && compareWindow
+				? bucketDays( days, relativeBucketWindows( window, compareWindow, buckets ) )
+				: undefined;
 
 		return {
 			current: currentPoints,

--- a/projects/packages/premium-analytics/widgets/post-views/use-post-views.ts
+++ b/projects/packages/premium-analytics/widgets/post-views/use-post-views.ts
@@ -147,6 +147,16 @@ function calendarBucketWindows( window: DayWindow, period: PostViewsGranularity 
  * 29–February 28 comparison range must also have one bucket, even though it
  * crosses two calendar months.
  *
+ * Each comparison bucket starts at the same day offset from the comparison
+ * range's start as its primary bucket does from the primary start, so the
+ * bucket count always matches. The buckets fully partition the comparison
+ * range: every bucket's end is the next bucket's start minus a day, and the
+ * last bucket extends to `comparisonWindow.to`. That keeps the comparison a
+ * complete, non-overlapping cover of the selected range — a longer previous
+ * period (previous-month onto a shorter month) folds its tail into the last
+ * bucket instead of being truncated, and every bound is clamped to
+ * `comparisonWindow.to` so a shorter one never reaches past the selection.
+ *
  * @param primaryWindow    - The selected primary range.
  * @param comparisonWindow - The previous-period range.
  * @param buckets          - Calendar buckets clipped to the primary range.
@@ -160,15 +170,24 @@ function relativeBucketWindows(
 	const primaryStart = parseISO( primaryWindow.from );
 	const comparisonStart = parseISO( comparisonWindow.from );
 
-	return buckets.map( bucket => {
-		const from = format(
+	const froms = buckets.map( bucket =>
+		format(
 			addDays( comparisonStart, differenceInCalendarDays( parseISO( bucket.from ), primaryStart ) ),
 			'yyyy-MM-dd'
-		);
-		const to = format(
-			addDays( comparisonStart, differenceInCalendarDays( parseISO( bucket.to ), primaryStart ) ),
-			'yyyy-MM-dd'
-		);
+		)
+	);
+
+	return froms.map( ( from, index ) => {
+		// Each bucket runs up to the next bucket's start; the last one absorbs
+		// any remaining comparison days. Clamp the end to the selected window so
+		// a longer primary offset can't pull in out-of-range days. `from` is left
+		// unclamped so a shorter comparison keeps distinct (empty) trailing
+		// buckets rather than collapsing several onto the same key.
+		const rawTo =
+			index < froms.length - 1
+				? format( addDays( parseISO( froms[ index + 1 ] ), -1 ), 'yyyy-MM-dd' )
+				: comparisonWindow.to;
+		const to = rawTo > comparisonWindow.to ? comparisonWindow.to : rawTo;
 
 		return { date: from, from, to };
 	} );

--- a/projects/packages/premium-analytics/widgets/post-views/use-post-views.ts
+++ b/projects/packages/premium-analytics/widgets/post-views/use-post-views.ts
@@ -249,10 +249,18 @@ export default function usePostViews(
 		const compareWindow = toDayWindow( reportParams.compare_from, reportParams.compare_to );
 		const buckets = window ? calendarBucketWindows( window, period ) : [];
 		const currentPoints = bucketDays( days, buckets );
-		const previousPoints =
-			window && compareWindow
-				? bucketDays( days, relativeBucketWindows( window, compareWindow, buckets ) )
-				: undefined;
+		let comparisonBuckets: BucketWindow[] | undefined;
+		if ( window && compareWindow ) {
+			// Day grouping must remain one point per actual calendar day. Relative
+			// bucketing is only needed for coarser periods, where matching the
+			// primary layout prevents partial week/month boundaries from scrunching
+			// the comparison overlay.
+			comparisonBuckets =
+				period === 'day'
+					? calendarBucketWindows( compareWindow, period )
+					: relativeBucketWindows( window, compareWindow, buckets );
+		}
+		const previousPoints = comparisonBuckets ? bucketDays( days, comparisonBuckets ) : undefined;
 
 		return {
 			current: currentPoints,


### PR DESCRIPTION
Fixes #

## Proposed changes

* Make the Email performance Storybook timeline mock treat `date` as the first bucket, matching the endpoint (and nudge its curve by the window start so a comparison window draws a visibly distinct line).
* **Email performance chart: draw the date picker's comparison as a dashed overlay.** The endpoint has no comparison mode, but it accepts any window (`date` is the window start), so the compare range is fetched as a second request and overlaid dashed with date-range legend labels.
* **Handle comparison windows that differ in length from the primary.** `previous-month`/`previous-year` presets can hand back a compare window with a different day count than the primary (a 31-day month vs a 28-day one). Both widgets now keep the overlay correct:
  * Email weekly/monthly grouping assigns each **comparison** day to its same-index primary bucket and folds any tail (a longer previous period) into the last bucket, so the bucket count still mirrors primary and no compare days are dropped.
  * Post Views comparison buckets fully partition the compare window and clamp every bound to `compare_to`, so a longer previous period isn't truncated and a shorter one doesn't pull in out-of-range days. Day grouping keeps one point per actual calendar day (no invented trailing days); the relative-bucket alignment applies only to week/month grouping, where it prevents partial boundaries from scrunching the overlay.
* **Surface email compare-request failures.** If the primary loads but the compare request fails, the widget no longer quietly shows a lone solid line — the error state merges both queries and Retry refetches both windows.
* Keep the standalone Clicks report mock from swallowing email clicks timeline requests in Storybook (`/clicks` now matches exactly).

## Related product discussion/links

* Follow-up to #50612 and #50625.
* Endpoint `quantity`-clamp truncation for ranges > 30 days is tracked separately in WOOA7S-1765 (out of scope here).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run:
  `pnpm --dir projects/packages/premium-analytics test -- --runInBand packages/widgets-toolkit/src/stories/mocks/data/email-timeline.test.ts widgets/email-time-series/__tests__/email-time-series.test.tsx widgets/post-views/__tests__/post-views.test.tsx`
* On a post detail page's Email opens/clicks tab, enable a comparison range: the chart fetches the compare window (Network shows two timeline requests with different `date` starts) and draws it as a dashed line; the legend switches to date-range labels. Switch Group by to weeks/months — the overlay keeps one point per primary bucket.
* Pick a **Previous month** comparison with weekly/monthly grouping (primary and compare windows then differ in length): the dashed overlay stays aligned 1:1 with the primary and its totals cover the whole compare window.
* In `Packages/Premium Analytics/Widgets/EmailTimeSeries`, verify the timeline begins at the selected range start and the `WithComparison` story draws a dashed second line.
* In `Packages/Premium Analytics/Widgets/PostViews`, enable comparison and select Month grouping. The comparison series should contain one point per primary bucket.

## New tests

* Email: fetch + draw the compare window; relative bucketing across month boundaries; a **longer** compare window folds its tail instead of dropping days; a failed compare request shows the error and Retry refetches both.
* Post Views: shorter previous-month compare clamps to its window (no out-of-range days); longer previous-month compare isn't truncated; day grouping keeps one comparison point per calendar day (longer window isn't padded, shorter window doesn't invent trailing days).
