### PR TITLE
Premium Analytics: fix post-detail timeline comparison behaviors

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-post-detail-timeline-comparison
+++ b/projects/packages/premium-analytics/changelog/fix-post-detail-timeline-comparison
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Post detail: Align post view comparisons and avoid redundant email timeline requests.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-email-time-series.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-stats-email-time-series.ts
@@ -10,19 +10,15 @@ import {
 	type StatsEmailTimeSeriesDataPoint,
 	type StatsEmailTimeSeriesSummary,
 } from '../queries/stats-email-time-series-query';
-import { useStatsReport, type UseStatsOptions } from './use-stats-report';
+import { useStatsQuery } from './use-stats-query';
+import type { UseStatsOptions } from './use-stats-report';
 
 export function useStatsEmailOpensTimeSeries(
 	postId: number,
 	params: StatsEmailTimeSeriesParams,
 	options?: UseStatsOptions
 ) {
-	return useStatsReport< StatsEmailTimeSeriesParams, StatsEmailTimeSeriesReport >(
-		p => statsEmailOpensTimeSeriesQuery( postId, p ),
-		params,
-		[ 'stats', 'email-opens-time-series', '__comparison__', 'disabled' ],
-		options
-	);
+	return useStatsQuery( statsEmailOpensTimeSeriesQuery( postId, params ), options );
 }
 
 export function useStatsEmailClicksTimeSeries(
@@ -30,12 +26,7 @@ export function useStatsEmailClicksTimeSeries(
 	params: StatsEmailTimeSeriesParams,
 	options?: UseStatsOptions
 ) {
-	return useStatsReport< StatsEmailTimeSeriesParams, StatsEmailTimeSeriesReport >(
-		p => statsEmailClicksTimeSeriesQuery( postId, p ),
-		params,
-		[ 'stats', 'email-clicks-time-series', '__comparison__', 'disabled' ],
-		options
-	);
+	return useStatsQuery( statsEmailClicksTimeSeriesQuery( postId, params ), options );
 }
 
 export type {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/email-timeline.test.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/email-timeline.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Internal dependencies
+ */
+import { buildEmailTimelineResponse } from './email-timeline';
+
+type EmailTimelineResponse = {
+	timeline: {
+		unit: string;
+		data: Array< [ string, number ] | [ string, number, number ] >;
+	};
+};
+
+describe( 'buildEmailTimelineResponse', () => {
+	it( 'generates daily buckets forward from the requested start date', () => {
+		const response = buildEmailTimelineResponse(
+			'opens',
+			'/stats/opens/emails/1234?period=day&quantity=3&date=2026-06-17&stats_fields=timeline'
+		) as EmailTimelineResponse;
+
+		expect( response.timeline.unit ).toBe( 'day' );
+		expect( response.timeline.data.map( row => row[ 0 ] ) ).toEqual( [
+			'2026-06-17',
+			'2026-06-18',
+			'2026-06-19',
+		] );
+	} );
+
+	it( 'generates hourly buckets forward from the requested start date', () => {
+		const response = buildEmailTimelineResponse(
+			'clicks',
+			'/stats/clicks/emails/1234?period=hour&quantity=3&date=2026-06-17&stats_fields=timeline'
+		) as EmailTimelineResponse;
+
+		expect( response.timeline.unit ).toBe( 'hour' );
+		expect( response.timeline.data ).toEqual(
+			expect.arrayContaining( [
+				expect.arrayContaining( [ '2026-06-17', 0 ] ),
+				expect.arrayContaining( [ '2026-06-17', 1 ] ),
+				expect.arrayContaining( [ '2026-06-17', 2 ] ),
+			] )
+		);
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/email-timeline.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/data/email-timeline.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { format, isValid, parseISO, subDays, subHours } from 'date-fns';
+import { addDays, addHours, format, isValid, parseISO } from 'date-fns';
 
 /**
  * The timeline matrix `stats/<opens|clicks>/emails/<postId>?stats_fields=timeline`
@@ -32,9 +32,9 @@ function emailTimelineCount( metric: 'opens' | 'clicks', index: number ): number
 
 /**
  * Builds a mock email timeline response for the "Email performance" widget. The
- * generated buckets end at the requested `date` and count back `quantity`
- * periods, mirroring how the real endpoint scopes its window, so the chart
- * always spans the dashboard date range the story requests.
+ * email timeline endpoint treats `date` as the first requested bucket and
+ * returns `quantity` periods going forward. Mirroring that behaviour keeps a
+ * story's chart aligned with its dashboard date range.
  *
  * @param metric      - Which timeline to return.
  * @param requestPath - The request path; `period`, `quantity`, and `date` are read off its query.
@@ -51,19 +51,21 @@ export function buildEmailTimelineResponse(
 		? Math.min( Math.max( parsedQuantity, 1 ), 24 * 90 )
 		: 30;
 	const parsedDate = parseISO( query.get( 'date' ) ?? '' );
-	const endDate = isValid( parsedDate ) ? parsedDate : new Date();
+	const startDate = isValid( parsedDate ) ? parsedDate : new Date();
 	const field = metric === 'opens' ? 'opens_count' : 'clicks_count';
 
 	const data: EmailTimelineRow[] = [];
 
-	for ( let index = quantity - 1; index >= 0; index-- ) {
-		const count = emailTimelineCount( metric, index );
+	for ( let index = 0; index < quantity; index++ ) {
+		// Preserve the existing send-decay shape while emitting buckets from
+		// the requested start date forward.
+		const count = emailTimelineCount( metric, quantity - 1 - index );
 
 		if ( period === 'hour' ) {
-			const bucket = subHours( endDate, index );
+			const bucket = addHours( startDate, index );
 			data.push( [ format( bucket, 'yyyy-MM-dd' ), bucket.getHours(), count ] );
 		} else {
-			data.push( [ format( subDays( endDate, index ), 'yyyy-MM-dd' ), count ] );
+			data.push( [ format( addDays( startDate, index ), 'yyyy-MM-dd' ), count ] );
 		}
 	}
 

--- a/projects/packages/premium-analytics/widgets/email-time-series/__tests__/email-time-series.test.tsx
+++ b/projects/packages/premium-analytics/widgets/email-time-series/__tests__/email-time-series.test.tsx
@@ -105,6 +105,25 @@ describe( 'EmailTimeSeriesWidget', () => {
 		expect( requestedPath ).toContain( 'stats/clicks/emails/1234' );
 	} );
 
+	it( 'only requests the primary timeline when dashboard comparison params are present', async () => {
+		mockApiFetch.mockResolvedValue( OPENS_TIMELINE_RESPONSE );
+
+		render(
+			<EmailTimeSeriesWidget
+				attributes={ {
+					reportParams: { ...getDefaultQueryParams( true ), post_id: 1234 },
+					metric: 'opens',
+				} }
+			/>
+		);
+
+		await expect( screen.findByTestId( 'comparative-line-chart' ) ).resolves.toBeInTheDocument();
+
+		expect( mockApiFetch ).toHaveBeenCalledTimes( 1 );
+		const requestedPath = mockApiFetch.mock.calls[ 0 ][ 0 ].path as string;
+		expect( requestedPath ).toContain( 'stats/opens/emails/1234' );
+	} );
+
 	it( 'aggregates the daily buckets into ISO weeks for the weekly granularity', async () => {
 		mockApiFetch.mockResolvedValue( OPENS_TIMELINE_RESPONSE );
 

--- a/projects/packages/premium-analytics/widgets/email-time-series/render.tsx
+++ b/projects/packages/premium-analytics/widgets/email-time-series/render.tsx
@@ -99,7 +99,7 @@ function EmailTimeSeriesReport( { metric, granularity }: EmailTimeSeriesReportPr
 	} );
 	const active = metric === 'clicks' ? clicks : opens;
 
-	const report = active.primary.data as StatsEmailTimeSeriesReport | undefined;
+	const report = active.data as StatsEmailTimeSeriesReport | undefined;
 	const field = METRIC_FIELDS[ metric ];
 
 	const chartReport = useMemo( () => {

--- a/projects/packages/premium-analytics/widgets/email-time-series/stories/email-time-series-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-time-series/stories/email-time-series-widget.stories.tsx
@@ -6,8 +6,8 @@
  * as it does in product.
  *
  * The timeline is scoped to a single email via a mocked `reportParams.post_id`.
- * The endpoint has no comparison period, so the chart always draws a single
- * line even when the date picker injects comparison `reportParams`.
+ * The endpoint has no comparison period, so it ignores comparison parameters
+ * from the dashboard and always draws a single line.
  */
 /**
  * External dependencies
@@ -63,24 +63,19 @@ const GRANULARITY_OPTIONS: EmailTimeSeriesGranularity[] =
 	attributeElementValues< EmailTimeSeriesGranularity >( 'granularity' );
 
 /**
- * Widget-specific controls: the comparison toggle, the opens/clicks metric, and
- * the day/week bucket granularity.
+ * Widget-specific controls for the opens/clicks metric and the day/week bucket
+ * granularity.
  */
 interface EmailTimeSeriesStoryControls {
-	withComparison: boolean;
 	metric: EmailTimeSeriesMetric;
 	granularity: EmailTimeSeriesGranularity;
 }
 
-function renderEmailTimeSeries( {
-	withComparison,
-	metric,
-	granularity,
-}: EmailTimeSeriesStoryControls ) {
+function renderEmailTimeSeries( { metric, granularity }: EmailTimeSeriesStoryControls ) {
 	return (
 		<EmailTimeSeriesRender
 			attributes={ {
-				reportParams: { ...getDefaultQueryParams( withComparison ), post_id: MOCK_EMAIL_ID },
+				reportParams: { ...getDefaultQueryParams( false ), post_id: MOCK_EMAIL_ID },
 				metric,
 				granularity,
 			} }
@@ -108,7 +103,6 @@ const meta = {
 	component: EmailTimeSeriesRender,
 	tags: [ 'autodocs' ],
 	argTypes: {
-		withComparison: { control: 'boolean' },
 		metric: { control: 'select', options: METRIC_OPTIONS },
 		granularity: { control: 'select', options: GRANULARITY_OPTIONS },
 	},
@@ -116,7 +110,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					"The \"Email performance\" widget. Draws a single sent email's opens or clicks per day as a line chart, spanning the dashboard date range — the chart section of the legacy email detail page. The `granularity` attribute (`relevance: 'high'`) is exposed as a control by the widget host; weekly grouping aggregates the daily buckets client-side because the endpoint only reports hourly/daily. Scoped to one email via a mocked `reportParams.post_id`. The endpoint has no comparison period, so the chart stays a single line even when the date picker injects comparison params.",
+					"The \"Email performance\" widget. Draws a single sent email's opens or clicks per day as a line chart, spanning the dashboard date range — the chart section of the legacy email detail page. The `granularity` attribute (`relevance: 'high'`) is exposed as a control by the widget host; weekly grouping aggregates the daily buckets client-side because the endpoint only reports hourly/daily. Scoped to one email via a mocked `reportParams.post_id`. The endpoint has no comparison period, so the chart stays a single line when the dashboard supplies comparison params.",
 			},
 		},
 	},
@@ -132,7 +126,7 @@ type Story = StoryObj< EmailTimeSeriesStoryControls >;
  */
 export const Default: Story = {
 	render: renderEmailTimeSeries,
-	args: { withComparison: false, metric: 'opens', granularity: 'day' },
+	args: { metric: 'opens', granularity: 'day' },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -141,7 +135,7 @@ export const Default: Story = {
  */
 export const Clicks: Story = {
 	render: renderEmailTimeSeries,
-	args: { withComparison: false, metric: 'clicks', granularity: 'day' },
+	args: { metric: 'clicks', granularity: 'day' },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -150,17 +144,7 @@ export const Clicks: Story = {
  */
 export const ByWeeks: Story = {
 	render: renderEmailTimeSeries,
-	args: { withComparison: false, metric: 'opens', granularity: 'week' },
-	decorators: [ withWidgetCanvas ],
-};
-
-/**
- * Comparison `reportParams` from the date picker. The timeline endpoint returns
- * no comparison period, so the chart still draws a single line.
- */
-export const WithComparison: Story = {
-	render: renderEmailTimeSeries,
-	args: { withComparison: true, metric: 'opens', granularity: 'day' },
+	args: { metric: 'opens', granularity: 'week' },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -224,7 +208,6 @@ interface EmailTimeSeriesDashboardStoryProps
 		EmailTimeSeriesStoryControls {}
 
 function EmailTimeSeriesDashboardStory( {
-	withComparison,
 	metric,
 	granularity,
 	...dashboardArgs
@@ -236,7 +219,9 @@ function EmailTimeSeriesDashboardStory( {
 			renderModule={ EMAIL_TIME_SERIES_RENDER_MODULE }
 			renderComponent={ EmailTimeSeriesRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ {
-				reportParams: { ...getDefaultQueryParams( withComparison ), post_id: MOCK_EMAIL_ID },
+				// Keep the dashboard host's comparison params here to cover the
+				// no-comparison endpoint against the normal dashboard contract.
+				reportParams: { ...getDefaultQueryParams( true ), post_id: MOCK_EMAIL_ID },
 				metric,
 				granularity,
 			} }
@@ -248,13 +233,11 @@ export const WidgetDashboardWithWidget: StoryObj< EmailTimeSeriesDashboardStoryP
 	render: args => <EmailTimeSeriesDashboardStory { ...args } />,
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
-		withComparison: false,
 		metric: 'opens',
 		granularity: 'day',
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
-		withComparison: { control: 'boolean' },
 		metric: { control: 'select', options: METRIC_OPTIONS },
 		granularity: { control: 'select', options: GRANULARITY_OPTIONS },
 	},

--- a/projects/packages/premium-analytics/widgets/post-views/__tests__/post-views.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-views/__tests__/post-views.test.tsx
@@ -120,6 +120,41 @@ describe( 'PostViewsWidget', () => {
 		expect( mockApiFetch ).toHaveBeenCalledTimes( 1 );
 	} );
 
+	it( 'uses primary month buckets for a previous period that crosses a month boundary', async () => {
+		mockApiFetch.mockResolvedValue( {
+			data: [
+				[ '2026-01-29', 1 ],
+				[ '2026-02-01', 2 ],
+				[ '2026-02-28', 3 ],
+				[ '2026-03-01', 4 ],
+				[ '2026-03-31', 5 ],
+			],
+		} );
+
+		render(
+			<PostViewsWidget
+				attributes={ {
+					reportParams: {
+						...DEFAULT_PARAMS,
+						from: '2026-03-01T00:00:00.000+08:00',
+						to: '2026-03-31T23:59:59.999+08:00',
+						post_id: 779,
+						comp: '1',
+						compare_from: '2026-01-29T00:00:00.000+08:00',
+						compare_to: '2026-02-28T23:59:59.999+08:00',
+					},
+					granularity: 'month',
+				} }
+			/>
+		);
+
+		const chart = await screen.findByTestId( 'comparative-line-chart' );
+		expect( chart ).toHaveAttribute( 'data-values', '9' );
+		// The previous period is one relative monthly bucket, not separate January
+		// and February points that the comparative chart would collapse onto March.
+		expect( chart ).toHaveAttribute( 'data-previous-values', '6' );
+	} );
+
 	it( 'renders the scopeless empty state and makes no request without a post scope', async () => {
 		render( <PostViewsWidget attributes={ {} } /> );
 

--- a/projects/packages/premium-analytics/widgets/post-views/use-post-views.ts
+++ b/projects/packages/premium-analytics/widgets/post-views/use-post-views.ts
@@ -9,13 +9,13 @@ import {
 } from '@jetpack-premium-analytics/data';
 import { useMemo } from '@wordpress/element';
 import {
+	addDays,
+	differenceInCalendarDays,
 	eachDayOfInterval,
 	eachMonthOfInterval,
 	eachWeekOfInterval,
 	format,
 	parseISO,
-	startOfISOWeek,
-	startOfMonth,
 } from 'date-fns';
 /**
  * Internal dependencies
@@ -49,6 +49,16 @@ export interface PostViewsState {
  * A date-only window sliced from the dashboard report params.
  */
 type DayWindow = {
+	from: string;
+	to: string;
+};
+
+/**
+ * One calendar bucket, including its visible label and the portion that falls
+ * inside the selected date window.
+ */
+type BucketWindow = {
+	date: string;
 	from: string;
 	to: string;
 };
@@ -93,42 +103,22 @@ function toDayWindow( from?: string, to?: string ): DayWindow | undefined {
 }
 
 /**
- * Bucket the post's daily view history into chart points for a window: day
- * buckets pass through, week/month buckets sum into their period start.
- * Every calendar bucket of the full requested window is zero-seeded before
- * summing — the endpoint may omit zero-view days and the history only starts
- * at publication, while the chart's comparison overlay aligns series by
- * index, so the primary and comparison windows must always yield the same
- * bucket count. Pre-publication days are genuinely zero views, so the
- * zero-fill is factual, not fabricated. The full history is bucketed
- * client-side because the endpoint's `weeks` field only covers a fixed
- * recent window.
+ * Build the primary range's calendar buckets. Each bucket keeps the calendar
+ * label used by the primary chart while clipping its data bounds to the
+ * selected range. The clipped bounds can then be applied to the comparison
+ * range as relative offsets, which preserves the primary series' bucket count
+ * across calendar boundaries.
  *
- * @param days   - The post's daily views, oldest first.
  * @param window - The date-only window to keep.
  * @param period - The bucket size.
- * @return One point per calendar bucket, oldest first.
+ * @return One bucket per calendar period, oldest first.
  */
-function bucketDays(
-	days: StatsPostDay[],
-	window: DayWindow,
-	period: PostViewsGranularity
-): PostViewsPoint[] {
+function calendarBucketWindows( window: DayWindow, period: PostViewsGranularity ): BucketWindow[] {
 	// The URL is user-editable, so an inverted range must not reach
 	// `eachDayOfInterval()` (it throws).
 	if ( window.from > window.to ) {
 		return [];
 	}
-
-	const bucketKey = ( date: string ): string => {
-		if ( period === 'day' ) {
-			return date;
-		}
-
-		const start =
-			period === 'week' ? startOfISOWeek( parseISO( date ) ) : startOfMonth( parseISO( date ) );
-		return format( start, 'yyyy-MM-dd' );
-	};
 
 	const interval = { start: parseISO( window.from ), end: parseISO( window.to ) };
 	let bucketStarts = eachDayOfInterval( interval );
@@ -138,22 +128,79 @@ function bucketDays(
 		bucketStarts = eachMonthOfInterval( interval );
 	}
 
-	const totals = new Map< string, number >(
-		bucketStarts.map( start => [ format( start, 'yyyy-MM-dd' ), 0 ] )
-	);
+	return bucketStarts.map( ( start, index ) => {
+		const date = format( start, 'yyyy-MM-dd' );
+		const nextDate = bucketStarts[ index + 1 ];
+		const end = nextDate ? format( addDays( nextDate, -1 ), 'yyyy-MM-dd' ) : window.to;
+
+		return {
+			date,
+			from: date < window.from ? window.from : date,
+			to: end > window.to ? window.to : end,
+		};
+	} );
+}
+
+/**
+ * Map primary bucket boundaries onto the comparison range. For example, a
+ * primary March 1–31 range has one monthly bucket; its equal-length January
+ * 29–February 28 comparison range must also have one bucket, even though it
+ * crosses two calendar months.
+ *
+ * @param primaryWindow    - The selected primary range.
+ * @param comparisonWindow - The previous-period range.
+ * @param buckets          - Calendar buckets clipped to the primary range.
+ * @return Comparison buckets with the primary range's relative boundaries.
+ */
+function relativeBucketWindows(
+	primaryWindow: DayWindow,
+	comparisonWindow: DayWindow,
+	buckets: BucketWindow[]
+): BucketWindow[] {
+	const primaryStart = parseISO( primaryWindow.from );
+	const comparisonStart = parseISO( comparisonWindow.from );
+
+	return buckets.map( bucket => {
+		const from = format(
+			addDays( comparisonStart, differenceInCalendarDays( parseISO( bucket.from ), primaryStart ) ),
+			'yyyy-MM-dd'
+		);
+		const to = format(
+			addDays( comparisonStart, differenceInCalendarDays( parseISO( bucket.to ), primaryStart ) ),
+			'yyyy-MM-dd'
+		);
+
+		return { date: from, from, to };
+	} );
+}
+
+/**
+ * Sum the post's daily view history into zero-filled buckets. The endpoint
+ * may omit zero-view days and the history only starts at publication, but
+ * those missing values are genuine zeroes. The full history is bucketed
+ * client-side because the endpoint's `weeks` field only covers a fixed recent
+ * window.
+ *
+ * @param days    - The post's daily views, oldest first.
+ * @param buckets - The bucket bounds to sum.
+ * @return One point per bucket, oldest first.
+ */
+function bucketDays( days: StatsPostDay[], buckets: BucketWindow[] ): PostViewsPoint[] {
+	const totals = new Map< string, number >( buckets.map( bucket => [ bucket.date, 0 ] ) );
 
 	for ( const day of days ) {
-		if ( day.date < window.from || day.date > window.to ) {
-			continue;
+		const bucket = buckets.find(
+			candidate => day.date >= candidate.from && day.date <= candidate.to
+		);
+		if ( bucket ) {
+			totals.set( bucket.date, ( totals.get( bucket.date ) ?? 0 ) + day.views );
 		}
-
-		const key = bucketKey( day.date );
-		totals.set( key, ( totals.get( key ) ?? 0 ) + day.views );
 	}
 
-	return Array.from( totals.entries() )
-		.sort( ( [ a ], [ b ] ) => a.localeCompare( b ) )
-		.map( ( [ date, value ] ) => ( { date: localTZDate( date ), value } ) );
+	return buckets.map( bucket => ( {
+		date: localTZDate( bucket.date ),
+		value: totals.get( bucket.date ) ?? 0,
+	} ) );
 }
 
 /**
@@ -181,9 +228,12 @@ export default function usePostViews(
 		const days = data?.data ?? [];
 		const window = toDayWindow( reportParams.from, reportParams.to );
 		const compareWindow = toDayWindow( reportParams.compare_from, reportParams.compare_to );
-
-		const currentPoints = window ? bucketDays( days, window, period ) : [];
-		const previousPoints = compareWindow ? bucketDays( days, compareWindow, period ) : undefined;
+		const buckets = window ? calendarBucketWindows( window, period ) : [];
+		const currentPoints = bucketDays( days, buckets );
+		const previousPoints =
+			window && compareWindow
+				? bucketDays( days, relativeBucketWindows( window, compareWindow, buckets ) )
+				: undefined;
 
 		return {
 			current: currentPoints,


### PR DESCRIPTION
Lands the post-detail chart data fixes that were in-flight on the closed #50636, re-based onto trunk. A post-merge review of #50561 / #50612 / #50625 flagged three issues; each was verified against the WPCOM handler source before acting:

## What this fixes

**1. Email timeline fires an unused comparison request (flagged as P2 — confirmed)**

`useStatsEmail*TimeSeries` was built on `useStatsReport`, which enables a comparison query whenever the dashboard picker sets `comp=1` — but the Email performance widget only draws the primary series, and `isLoading` / `isFetching` / `isError` are OR-ed across both queries, so a slow or failing comparison request degraded the whole card for nothing. The hooks now use the primary-only `useStatsQuery`.

**2. Post views monthly comparison can produce overlapping x-axis points (flagged as P2 — confirmed)**

`use-post-views` bucketed the primary and comparison windows by calendar independently; equal-length windows don't always contain the same number of calendar months (Mar 1–31 → one bucket; its Jan 29–Feb 28 comparison → two), and the chart's alignment collapsed the extra comparison point onto the last primary date. Comparison buckets now reuse the primary buckets' boundaries as relative offsets from the comparison start, preserving the bucket count across calendar boundaries. Includes the cross-month regression test.

## What was checked and deliberately NOT changed

The review also claimed (P1) that the timeline range is reversed — that `date` should be the range **end** per the endpoint docs ("The most recent day to include in results"). The wpcom handler source says otherwise: `Email_Stats::get_interval_dates()` constructs the window as `[date, date + (quantity − 1) × period]` — **`date` is the start and buckets extend forward**, exactly what the client sends since #50612. The endpoint's registration docblock is stale, not the client. Verified empirically on a live email detail page as well.

The same investigation surfaced a real adjacent limitation: the endpoint clamps `quantity` to ≤ 30, so ranges longer than 30 days silently truncate to their first 30 days. That needs a period-selection design (day → week → month by range length) and is tracked in WOOA7S-1765 rather than jammed in here.

## Testing

- `pnpm test` — 988 tests pass (includes the new cross-month post-views regression test and the email mock timeline tests).
- `pnpm run typecheck` clean.
- Storybook vitest for the email-time-series and post-views stories — 12 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
