### PR TITLE
Write editor: recover UI on hung or failed save/publish

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-write-editor-save-recovery
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-write-editor-save-recovery
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Write editor: recover the UI when a save/publish request hangs or fails so Publish and Save no longer stay greyed out. A hung request is now aborted after a timeout, and prep-stage failures reset the saving flag and surface a retryable error.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -6205,8 +6205,12 @@ function describeSaveError( err ) {
 		const raw = err === undefined ? '' : String( err );
 		return { code: 'unknown', status: null, message: raw.slice( 0, MAX_ERROR_MESSAGE_LENGTH ) };
 	}
-	// Prefer the specific REST `code`; fall back to `name` ('AbortError', 'TypeError', …).
-	const code = err.code || err.name || 'unknown';
+	// Prefer the specific REST `code` (always a string, e.g. 'rest_cannot_edit');
+	// fall back to `name` ('AbortError', 'TypeError', …). Guard on a string code
+	// because a DOMException carries a numeric `.code` (AbortError is 20), which
+	// would otherwise shadow the 'AbortError' name and break the timeout message
+	// and telemetry error_code.
+	const code = ( typeof err.code === 'string' && err.code ) || err.name || 'unknown';
 	const status = err.data && typeof err.data.status === 'number' ? err.data.status : null;
 	const message = String( err.message || '' ).slice( 0, MAX_ERROR_MESSAGE_LENGTH );
 	return { code: String( code ), status, message };

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -6179,6 +6179,14 @@ function showPostPickerModal() {
 
 // Report a save that has neither resolved nor rejected within this window.
 const SAVE_STALL_THRESHOLD_MS = 30000;
+// Hard timeout for a save request. If it is still outstanding this long after
+// the stall threshold, abort it so the UI recovers — Publish/Save re-enable and
+// an error is shown — instead of staying greyed out forever (RSM-4323). Set
+// beyond the stall threshold so a genuinely slow-but-succeeding save still
+// completes, and so telemetry ordering stays readable: `save_stalled` fires
+// first as the diagnostic, then the abort surfaces as a recoverable
+// `save_failed` with error_code 'AbortError'.
+const SAVE_REQUEST_TIMEOUT_MS = SAVE_STALL_THRESHOLD_MS + 15000;
 // Cap free-text error strings so a pathological message can't bloat the payload.
 const MAX_ERROR_MESSAGE_LENGTH = 200;
 
@@ -6263,12 +6271,35 @@ function recordSaveStalled( { postStatus, isAutosave, isUpdate, isEditing, phase
 }
 
 /**
+ * Run window.wp.apiFetch with a hard timeout.
+ *
+ * If the request neither resolves nor rejects within `timeoutMs`, abort it so
+ * the caller's catch runs and the UI recovers, rather than hanging forever on a
+ * connection held open by a proxy, VPN, or ad blocker — the stall failure mode
+ * seen in RSM-4323. apiFetch passes `signal` through to window.fetch, so the
+ * aborted request rejects with an AbortError, which describeSaveError reports as
+ * error_code 'AbortError'.
+ *
+ * @param {object} options   - apiFetch options (path, method, data, …).
+ * @param {number} timeoutMs - Abort the request after this many milliseconds.
+ * @return {Promise<*>} Resolves with the apiFetch result, or rejects (including on abort).
+ */
+function apiFetchWithTimeout( options, timeoutMs ) {
+	const controller = new AbortController();
+	const timer = setTimeout( () => controller.abort(), timeoutMs );
+	return window.wp
+		.apiFetch( { ...options, signal: controller.signal } )
+		.finally( () => clearTimeout( timer ) );
+}
+
+/**
  * Save or publish the current post via the REST API.
  *
  * Thin wrapper around performSave() that reports any throw during content
  * preparation or tag resolution — code that runs before the save request's own
- * try/catch and today surfaces as a silent unhandled rejection. It re-throws to
- * preserve current behavior; this is an observability-only change (RSM-4323).
+ * try/catch and today surfaces as a silent unhandled rejection. On such a throw
+ * it now also recovers the UI (resets the saving flag, surfaces a retryable
+ * error) instead of leaving Publish/Save greyed out (RSM-4323).
  *
  * @param {string}  postStatus - The desired post status ('publish' or 'draft').
  * @param {boolean} isAutosave - Whether this is a periodic autosave (quieter UX).
@@ -6282,8 +6313,7 @@ async function savePost( postStatus, isAutosave = false ) {
 		await performSave( postStatus, isAutosave, saveCtx );
 	} catch ( err ) {
 		// Save-request failures are handled inside performSave; anything caught
-		// here threw during content prep / tag resolution. Report, then re-throw
-		// so behavior is unchanged.
+		// here threw during content prep / tag resolution.
 		clearTimeout( saveCtx.stallWatchdog );
 		recordSaveFailed( err, {
 			postStatus,
@@ -6292,7 +6322,21 @@ async function savePost( postStatus, isAutosave = false ) {
 			isEditing: state.editPostId > 0,
 			phase: 'prepare',
 		} );
-		throw err;
+		// Recover the UI. performSave sets state.isSaving = true before any of
+		// the prep work that can throw, so a prep-stage throw previously
+		// surfaced as a silent unhandled rejection with the saving flag stuck
+		// true — Publish/Save greyed out with no message (RSM-4323). Reset it,
+		// and for user-initiated saves surface a retryable error.
+		state.isSaving = false;
+		if ( ! isAutosave ) {
+			state.message = ( i18n.error || 'Error: %s' ).replace(
+				'%s',
+				i18n.couldNotSave || 'Could not save. Please try again.'
+			);
+			setTimeout( () => {
+				state.message = '';
+			}, 4000 );
+		}
 	}
 }
 
@@ -6451,9 +6495,13 @@ async function performSave( postStatus, isAutosave = false, saveCtx = {} ) {
 	if ( tagNames.length ) {
 		const newTagIds = await Promise.all(
 			tagNames.map( name =>
-				window.wp
-					.apiFetch( { path: '/wp/v2/tags', method: 'POST', data: { name } } )
+				apiFetchWithTimeout(
+					{ path: '/wp/v2/tags', method: 'POST', data: { name } },
+					SAVE_REQUEST_TIMEOUT_MS
+				)
 					.then( tag => tag.id )
+					// A duplicate returns term_id; a hung/aborted or failed tag
+					// request drops just that tag (null) so the save proceeds.
 					.catch( err => err?.data?.term_id ?? null )
 			)
 		).then( ids => ids.filter( Boolean ) );
@@ -6467,19 +6515,22 @@ async function performSave( postStatus, isAutosave = false, saveCtx = {} ) {
 	stallPhase = 'save_request';
 
 	try {
-		const post = await window.wp.apiFetch( {
-			path,
-			method: 'POST',
-			data: {
-				title: state.title,
-				content: blockMarkup,
-				status: postStatus,
-				categories: selectedCats,
-				...tagData,
-				featured_media: state.featuredMediaId || 0,
-				wpcom_write_editor_used: true,
+		const post = await apiFetchWithTimeout(
+			{
+				path,
+				method: 'POST',
+				data: {
+					title: state.title,
+					content: blockMarkup,
+					status: postStatus,
+					categories: selectedCats,
+					...tagData,
+					featured_media: state.featuredMediaId || 0,
+					wpcom_write_editor_used: true,
+				},
 			},
-		} );
+			SAVE_REQUEST_TIMEOUT_MS
+		);
 		clearTimeout( stallWatchdog );
 
 		// Store the post ID so subsequent saves update the same post.
@@ -6563,7 +6614,16 @@ async function performSave( postStatus, isAutosave = false, saveCtx = {} ) {
 		recordSaveFailed( err, { postStatus, isAutosave, isUpdate, isEditing, phase: 'save_request' } );
 		state.isSaving = false;
 		if ( ! isAutosave ) {
-			state.message = ( i18n.error || 'Error: %s' ).replace( '%s', err.message );
+			const { code } = describeSaveError( err );
+			// A timed-out/aborted request or a dropped connection carries no
+			// useful server message (the dominant failure in RSM-4323 was a
+			// network-layer reject with no HTTP status). Show a plain retry
+			// prompt instead of an empty or opaque "Error: ".
+			const detail =
+				code === 'AbortError' || ! err?.message
+					? i18n.saveTimedOut || 'Saving timed out. Please check your connection and try again.'
+					: err.message;
+			state.message = ( i18n.error || 'Error: %s' ).replace( '%s', detail );
 			setTimeout( () => {
 				state.message = '';
 			}, 4000 );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -6618,15 +6618,16 @@ async function performSave( postStatus, isAutosave = false, saveCtx = {} ) {
 		recordSaveFailed( err, { postStatus, isAutosave, isUpdate, isEditing, phase: 'save_request' } );
 		state.isSaving = false;
 		if ( ! isAutosave ) {
-			const { code } = describeSaveError( err );
+			const { code, message } = describeSaveError( err );
 			// A timed-out/aborted request or a dropped connection carries no
 			// useful server message (the dominant failure in RSM-4323 was a
 			// network-layer reject with no HTTP status). Show a plain retry
-			// prompt instead of an empty or opaque "Error: ".
+			// prompt instead of an empty or opaque "Error: ". `message` is
+			// already capped at MAX_ERROR_MESSAGE_LENGTH by describeSaveError.
 			const detail =
-				code === 'AbortError' || ! err?.message
+				code === 'AbortError' || ! message
 					? i18n.saveTimedOut || 'Saving timed out. Please check your connection and try again.'
-					: err.message;
+					: message;
 			state.message = ( i18n.error || 'Error: %s' ).replace( '%s', detail );
 			setTimeout( () => {
 				state.message = '';

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -1007,7 +1007,14 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 			<a class="bw-help-link" data-target="wpcom-help-center" href="https://wordpress.com/support/editors/write-editor/" target="_blank" rel="noopener noreferrer"><?php echo esc_html__( 'Read the Write editor guide', 'jetpack-mu-wpcom' ); ?> <span aria-hidden="true">&#8599;</span></a>
 		</div>
 		</div><!-- /.bw-help-wrap -->
-		<span class="bw-status" role="status" aria-live="polite" data-wp-text="state.displayStatus"></span>
+		<span class="bw-status" data-wp-text="state.displayStatus"></span>
+		<?php
+		// Screen-reader announcement for transient status (saving/publishing,
+		// "Please write something" validation, save/publish errors). Bound to
+		// state.message only — not state.displayStatus — so the title mirror the
+		// visible .bw-status also carries isn't re-announced on every keystroke.
+		?>
+		<span class="bw-visually-hidden" role="status" aria-live="polite" data-wp-text="state.message"></span>
 		<div class="bw-topbar-actions">
 			<button
 				class="bw-btn bw-btn-draft"

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -115,6 +115,8 @@ function wpcom_write_get_editor_strings() {
 		'draftAutosaved'       => __( 'Draft saved', 'jetpack-mu-wpcom' ),
 		// translators: %s is the error message.
 		'error'                => __( 'Error: %s', 'jetpack-mu-wpcom' ),
+		'couldNotSave'         => __( 'Could not save. Please try again.', 'jetpack-mu-wpcom' ),
+		'saveTimedOut'         => __( 'Saving timed out. Please check your connection and try again.', 'jetpack-mu-wpcom' ),
 		'normal'               => __( 'Normal', 'jetpack-mu-wpcom' ),
 		'heading2'             => __( 'Heading 2', 'jetpack-mu-wpcom' ),
 		'heading3'             => __( 'Heading 3', 'jetpack-mu-wpcom' ),

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -1011,8 +1011,8 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 		<?php
 		// Screen-reader announcement for transient status (saving/publishing,
 		// "Please write something" validation, save/publish errors). Bound to
-		// state.message only — not state.displayStatus — so the title mirror the
-		// visible .bw-status also carries isn't re-announced on every keystroke.
+		// state.message only — not state.displayStatus — so the title mirror that
+		// the visible .bw-status also carries isn't re-announced on every keystroke.
 		?>
 		<span class="bw-visually-hidden" role="status" aria-live="polite" data-wp-text="state.message"></span>
 		<div class="bw-topbar-actions">


### PR DESCRIPTION
## Proposed changes

Follow-up to the telemetry-only PR #50176 (RSM-4323). Failed or stalled saves in the Write editor leave **Publish** and **Save** greyed out with no recovery — the "unresponsive button, no message" report.

**This is safe recovery, not a root-cause cure.** The telemetry from #50176 (first ~11 days) shows:

* **Every** failure is in the network request (`phase: "save_request"`) — **zero** in content prep. The unprotected prep/tag code we'd worried about is not what throws in practice.
* The failures are **hangs and network-layer rejects, not hard server rejections**: 35 of 49 `save_failed` had **no HTTP status** (request leaves the browser, no reply), plus **24** saves that never settled at all within 30s. A hung request never resets the saving flag → stuck grey buttons.

Because these are intermittent hangs (not deterministic rejections — 478 publishes succeeded in the window, and the original reporter recovered), timing out a hung request and recovering the UI genuinely helps rather than looping the user through identical errors. The fix does **not** depend on the upstream trigger (ad blocker / VPN / flaky network — a fitting hypothesis, not proven).

### Changes

* Add `SAVE_REQUEST_TIMEOUT_MS` and an `apiFetchWithTimeout()` helper that aborts a save request still outstanding past the stall threshold (stall-threshold + 15s). The aborted request rejects with an `AbortError`, so the existing `catch` recovers the UI instead of hanging forever. Applied to the main save request and the tag-resolution requests.
* On a **prepare-stage** throw, reset `state.isSaving` and surface a retryable error (previously a silent unhandled rejection that left the buttons stuck). Data shows this path doesn't fire today, but it closes the latent hole.
* Give aborted/network failures a plain retry message (`saveTimedOut`) instead of an empty or opaque `Error:`.
* Two new i18n strings: `couldNotSave`, `saveTimedOut`.

The stall/failed **telemetry from #50176 stays in place** — if timeouts spike or retries keep failing after this ships, we'll see it and reassess.

## Related product discussion/links

* RSM-4323
* Follows #50176

## Does this pull request change what data or activity we track or use?

No new tracking. This is a behavioral change on top of the existing `wpcom_write_editor_save_failed` / `wpcom_write_editor_save_stalled` events from #50176. A timed-out request now surfaces as a `save_failed` with `error_code: "AbortError"`, using the existing event and props.

## Testing instructions

* Open the Write editor (`wp-admin/admin.php?page=write`), add a title and some body content.
* **Hung request auto-recovers:** in DevTools, hang the save with a stub that honors the abort signal — a request that never resolves *and never aborts* would leave the UI stuck, because recovery relies on `AbortController` rejecting the fetch (real `fetch` honors `signal`; a bare `new Promise(() => {})` does not): `const _o = window.wp.apiFetch; window.wp.apiFetch = o => o?.method === 'POST' ? new Promise( ( _, reject ) => o.signal?.addEventListener( 'abort', () => reject( new DOMException( 'The operation was aborted.', 'AbortError' ) ) ) ) : _o(o);` — click **Publish**. The button greys out; after the timeout it re-enables and shows a "Saving timed out…" message (instead of staying stuck forever). Restore with `window.wp.apiFetch = _o;`. (To avoid the 45s wait, temporarily lower `SAVE_REQUEST_TIMEOUT_MS`.)
* **Network reject recovers with a clear message:** `window.wp.apiFetch = () => Promise.reject( { name: 'TypeError', message: 'Failed to fetch' } );` then click **Publish** — buttons re-enable and a retry message shows.
* **Prepare-stage throw recovers:** add a `#tag` line and `window.wp.apiFetch = () => { throw new TypeError('boom'); };` — buttons re-enable and a "Could not save…" message shows (previously left them stuck).
* **Happy path unchanged:** a normal publish still redirects; a normal draft save still shows "Draft saved".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
