### PR TITLE
Prod build: exclude postcss config files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -36,6 +36,8 @@ jsconfig.json          production-exclude
 phpunit.*.xml.dist     production-exclude
 phpunit.xml.dist       production-exclude
 tsconfig.json          production-exclude
+postcss.config.js      production-exclude
+postcss.config.[cm]js  production-exclude
 webpack.config.js      production-exclude
 webpack.config.[cm]js  production-exclude
 **/changelog/**        production-exclude

--- a/projects/packages/publicize/.gitattributes
+++ b/projects/packages/publicize/.gitattributes
@@ -7,5 +7,4 @@ build/**          production-include
 # Remember to end all directories with `/**` to properly tag every file.
 /_inc/**           production-exclude
 /jest-globals.js   production-exclude
-/postcss.config.js production-exclude
 routes/**          production-exclude

--- a/projects/packages/publicize/changelog/update-exclude-postcss-configs-from-production-builds
+++ b/projects/packages/publicize/changelog/update-exclude-postcss-configs-from-production-builds
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
-
 Comment: Exclude postcss.config.js from production builds via root .gitattributes; remove redundant package-level entry.
+

--- a/projects/packages/publicize/changelog/update-exclude-postcss-configs-from-production-builds
+++ b/projects/packages/publicize/changelog/update-exclude-postcss-configs-from-production-builds
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Comment: Exclude postcss.config.js from production builds via root .gitattributes; remove redundant package-level entry.

--- a/projects/packages/search/.gitattributes
+++ b/projects/packages/search/.gitattributes
@@ -7,7 +7,6 @@
 # (see also entries in the monorepo root .gitattributes)
 /.size-limit.js                                          production-exclude
 /jest.url-tests.config.js                                production-exclude
-/postcss.config.js                                       production-exclude
 /docs/**                                                 production-exclude
 /tools/**                                                production-exclude
 /src/**/test/**                                          production-exclude

--- a/projects/packages/search/changelog/update-exclude-postcss-configs-from-production-builds
+++ b/projects/packages/search/changelog/update-exclude-postcss-configs-from-production-builds
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
-
 Comment: Exclude postcss.config.js from production builds via root .gitattributes; remove redundant package-level entry.
+

--- a/projects/packages/search/changelog/update-exclude-postcss-configs-from-production-builds
+++ b/projects/packages/search/changelog/update-exclude-postcss-configs-from-production-builds
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Comment: Exclude postcss.config.js from production builds via root .gitattributes; remove redundant package-level entry.

--- a/projects/packages/videopress/.gitattributes
+++ b/projects/packages/videopress/.gitattributes
@@ -15,5 +15,4 @@ src/**/*.jsx      production-exclude
 src/**/*.scss     production-exclude
 declarations.d.ts production-exclude
 global.d.ts       production-exclude
-postcss.config.js production-exclude
 routes/**         production-exclude

--- a/projects/packages/videopress/changelog/update-exclude-postcss-configs-from-production-builds
+++ b/projects/packages/videopress/changelog/update-exclude-postcss-configs-from-production-builds
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
-
 Comment: Exclude postcss.config.js from production builds via root .gitattributes; remove redundant package-level entry.
+

--- a/projects/packages/videopress/changelog/update-exclude-postcss-configs-from-production-builds
+++ b/projects/packages/videopress/changelog/update-exclude-postcss-configs-from-production-builds
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Comment: Exclude postcss.config.js from production builds via root .gitattributes; remove redundant package-level entry.


### PR DESCRIPTION
Follow-up to feedback in https://github.com/Automattic/jetpack/pull/50577#discussion_r3605703887
## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Exclude all PostCSS config files from production builds at root level of monorepo.
* Removed the redundant `postcss.config.js` lines from publicize, search, and videopress `.gitattributes`. They’re covered by the root entries now.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* N/A