### PR TITLE
Build: add browserslist config for autoprefixer PostCSS targets

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22194,7 +22194,7 @@ snapshots:
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@18.3.28)(react@18.3.1)
       unplugin: 2.3.11
     optionalDependencies:
-      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
+      webpack: 5.107.2(webpack-cli@6.0.1)
 
   '@storybook/global@5.0.0': {}
 
@@ -23419,24 +23419,24 @@ snapshots:
 
   '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1)(webpack@5.107.2)':
     dependencies:
-      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.5)(webpack@5.107.2)
+      webpack: 5.107.2(webpack-cli@6.0.1)
+      webpack-cli: 6.0.1(webpack@5.107.2)
 
   '@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.107.2)':
     dependencies:
-      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.5)(webpack@5.107.2)
+      webpack: 5.107.2(webpack-cli@6.0.1)
+      webpack-cli: 6.0.1(webpack@5.107.2)
 
   '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.5)(webpack@5.107.2)':
     dependencies:
-      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
+      webpack: 5.107.2(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.5)(webpack@5.107.2)
     optionalDependencies:
-      webpack-dev-server: 5.2.5(debug@4.4.3)(webpack-cli@6.0.1)(webpack@5.107.2)
+      webpack-dev-server: 5.2.5(webpack-cli@6.0.1)(webpack@5.107.2)
 
   '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack@5.107.2)':
     dependencies:
-      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
+      webpack: 5.107.2(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack@5.107.2)
 
   '@wordpress/a11y@4.51.0':
@@ -26346,7 +26346,7 @@ snapshots:
   '@wordpress/dependency-extraction-webpack-plugin@6.51.0(webpack@5.107.2)':
     dependencies:
       json2php: 0.0.9
-      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
+      webpack: 5.107.2(webpack-cli@6.0.1)
 
   '@wordpress/deprecated@4.51.0':
     dependencies:
@@ -37869,10 +37869,10 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
+      webpack: 5.107.2(webpack-cli@6.0.1)
       webpack-merge: 6.0.1
     optionalDependencies:
-      webpack-dev-server: 5.2.5(debug@4.4.3)(webpack-cli@6.0.1)(webpack@5.107.2)
+      webpack-dev-server: 5.2.5(webpack-cli@6.0.1)(webpack@5.107.2)
 
   webpack-cli@6.0.1(webpack@5.107.2):
     dependencies:
@@ -37888,7 +37888,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
+      webpack: 5.107.2(webpack-cli@6.0.1)
       webpack-merge: 6.0.1
 
   webpack-dev-middleware@7.4.5(webpack@5.107.2):
@@ -37900,7 +37900,7 @@ snapshots:
       range-parser: 1.3.0
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
+      webpack: 5.107.2(webpack-cli@6.0.1)
 
   webpack-dev-server@5.2.5(debug@4.4.3)(webpack-cli@6.0.1)(webpack@5.107.2):
     dependencies:
@@ -38057,7 +38057,7 @@ snapshots:
       watchpack: 2.5.2
       webpack-sources: 3.5.1
     optionalDependencies:
-      webpack-cli: 6.0.1(webpack-dev-server@5.2.5)(webpack@5.107.2)
+      webpack-cli: 6.0.1(webpack@5.107.2)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3086,6 +3086,9 @@ importers:
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260707.2
         version: 7.0.0-dev.20260707.2
+      '@wordpress/browserslist-config':
+        specifier: 6.51.0
+        version: 6.51.0
       '@wordpress/build':
         specifier: 0.18.0
         version: 0.18.0(@babel/core@7.29.7)(@wordpress/boot@0.18.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(postcss@8.5.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.51.0)(@wordpress/route@0.17.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@0.17.0(@types/react@18.3.28)(postcss@8.5.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
@@ -3349,6 +3352,9 @@ importers:
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260707.2
         version: 7.0.0-dev.20260707.2
+      '@wordpress/browserslist-config':
+        specifier: 6.51.0
+        version: 6.51.0
       autoprefixer:
         specifier: 10.4.20
         version: 10.4.20(postcss@8.5.14)
@@ -3673,6 +3679,9 @@ importers:
       '@wordpress/block-serialization-default-parser':
         specifier: 5.51.0
         version: 5.51.0
+      '@wordpress/browserslist-config':
+        specifier: 6.51.0
+        version: 6.51.0
       '@wordpress/theme':
         specifier: 0.17.0
         version: 0.17.0(@types/react@18.3.28)(postcss@8.5.14)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -22185,7 +22194,7 @@ snapshots:
       storybook: 10.4.6(@testing-library/dom@10.4.1)(@types/react@18.3.28)(react@18.3.1)
       unplugin: 2.3.11
     optionalDependencies:
-      webpack: 5.107.2(webpack-cli@6.0.1)
+      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
 
   '@storybook/global@5.0.0': {}
 
@@ -23410,24 +23419,24 @@ snapshots:
 
   '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1)(webpack@5.107.2)':
     dependencies:
-      webpack: 5.107.2(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack@5.107.2)
+      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.5)(webpack@5.107.2)
 
   '@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.107.2)':
     dependencies:
-      webpack: 5.107.2(webpack-cli@6.0.1)
-      webpack-cli: 6.0.1(webpack@5.107.2)
+      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.5)(webpack@5.107.2)
 
   '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack-dev-server@5.2.5)(webpack@5.107.2)':
     dependencies:
-      webpack: 5.107.2(webpack-cli@6.0.1)
+      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-dev-server@5.2.5)(webpack@5.107.2)
     optionalDependencies:
-      webpack-dev-server: 5.2.5(webpack-cli@6.0.1)(webpack@5.107.2)
+      webpack-dev-server: 5.2.5(debug@4.4.3)(webpack-cli@6.0.1)(webpack@5.107.2)
 
   '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack@5.107.2)':
     dependencies:
-      webpack: 5.107.2(webpack-cli@6.0.1)
+      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack@5.107.2)
 
   '@wordpress/a11y@4.51.0':
@@ -26337,7 +26346,7 @@ snapshots:
   '@wordpress/dependency-extraction-webpack-plugin@6.51.0(webpack@5.107.2)':
     dependencies:
       json2php: 0.0.9
-      webpack: 5.107.2(webpack-cli@6.0.1)
+      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
 
   '@wordpress/deprecated@4.51.0':
     dependencies:
@@ -37860,10 +37869,10 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.107.2(webpack-cli@6.0.1)
+      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
       webpack-merge: 6.0.1
     optionalDependencies:
-      webpack-dev-server: 5.2.5(webpack-cli@6.0.1)(webpack@5.107.2)
+      webpack-dev-server: 5.2.5(debug@4.4.3)(webpack-cli@6.0.1)(webpack@5.107.2)
 
   webpack-cli@6.0.1(webpack@5.107.2):
     dependencies:
@@ -37879,7 +37888,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.107.2(webpack-cli@6.0.1)
+      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
       webpack-merge: 6.0.1
 
   webpack-dev-middleware@7.4.5(webpack@5.107.2):
@@ -37891,7 +37900,7 @@ snapshots:
       range-parser: 1.3.0
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.107.2(webpack-cli@6.0.1)
+      webpack: 5.107.2(postcss@8.5.14)(webpack-cli@6.0.1)
 
   webpack-dev-server@5.2.5(debug@4.4.3)(webpack-cli@6.0.1)(webpack@5.107.2):
     dependencies:
@@ -38048,7 +38057,7 @@ snapshots:
       watchpack: 2.5.2
       webpack-sources: 3.5.1
     optionalDependencies:
-      webpack-cli: 6.0.1(webpack@5.107.2)
+      webpack-cli: 6.0.1(webpack-dev-server@5.2.5)(webpack@5.107.2)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'

--- a/projects/packages/classic-theme-helper/changelog/add-browserslist-for-autoprefixer
+++ b/projects/packages/classic-theme-helper/changelog/add-browserslist-for-autoprefixer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+Comment: Add browserslist config for autoprefixer PostCSS targets.
+

--- a/projects/packages/classic-theme-helper/package.json
+++ b/projects/packages/classic-theme-helper/package.json
@@ -23,6 +23,9 @@
 		"validate": "pnpm exec validate-es --no-error-on-unmatched-pattern dist/",
 		"watch": "pnpm run build && pnpm webpack watch"
 	},
+	"browserslist": [
+		"extends @wordpress/browserslist-config"
+	],
 	"devDependencies": {
 		"@automattic/jetpack-webpack-config": "workspace:*",
 		"@automattic/remove-asset-webpack-plugin": "workspace:*",

--- a/projects/packages/jetpack-mu-wpcom/changelog/add-browserslist-for-autoprefixer
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-browserslist-for-autoprefixer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+Comment: Add browserslist config for autoprefixer PostCSS targets.
+

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -30,6 +30,9 @@
 		"typecheck": "tsgo --build",
 		"watch": "pnpm run build-production-js && pnpm webpack watch"
 	},
+	"browserslist": [
+		"extends @wordpress/browserslist-config"
+	],
 	"dependencies": {
 		"@automattic/calypso-color-schemes": "4.0.0",
 		"@automattic/color-studio": "4.1.0",
@@ -122,6 +125,7 @@
 		"@types/react": "^18.3.28",
 		"@types/react-dom": "18.3.7",
 		"@typescript/native-preview": "7.0.0-dev.20260707.2",
+		"@wordpress/browserslist-config": "6.51.0",
 		"@wordpress/build": "0.18.0",
 		"autoprefixer": "10.4.20",
 		"babel-plugin-transform-rename-properties": "0.1.0",

--- a/projects/packages/masterbar/changelog/add-browserslist-for-autoprefixer
+++ b/projects/packages/masterbar/changelog/add-browserslist-for-autoprefixer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+Comment: Add browserslist config for autoprefixer PostCSS targets.
+

--- a/projects/packages/masterbar/package.json
+++ b/projects/packages/masterbar/package.json
@@ -23,6 +23,9 @@
 		"validate": "pnpm exec validate-es --no-error-on-unmatched-pattern dist/",
 		"watch": "pnpm run build && pnpm webpack watch --config tools/webpack.config.js"
 	},
+	"browserslist": [
+		"extends @wordpress/browserslist-config"
+	],
 	"dependencies": {
 		"@automattic/calypso-color-schemes": "4.0.0",
 		"@automattic/color-studio": "4.1.0",

--- a/projects/packages/my-jetpack/changelog/add-browserslist-for-autoprefixer
+++ b/projects/packages/my-jetpack/changelog/add-browserslist-for-autoprefixer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+Comment: Add browserslist config for autoprefixer PostCSS targets.
+

--- a/projects/packages/my-jetpack/package.json
+++ b/projects/packages/my-jetpack/package.json
@@ -31,6 +31,9 @@
 		"watch": "pnpm run build && pnpm webpack watch",
 		"watch:hot": "pnpm run clean && webpack serve"
 	},
+	"browserslist": [
+		"extends @wordpress/browserslist-config"
+	],
 	"dependencies": {
 		"@automattic/babel-plugin-replace-textdomain": "workspace:*",
 		"@automattic/charts": "workspace:*",
@@ -78,6 +81,7 @@
 		"@types/node": "^24.12.0",
 		"@types/react": "18.3.28",
 		"@typescript/native-preview": "7.0.0-dev.20260707.2",
+		"@wordpress/browserslist-config": "6.51.0",
 		"autoprefixer": "10.4.20",
 		"concurrently": "10.0.3",
 		"jest": "30.4.2",

--- a/projects/packages/paypal-payments/changelog/add-browserslist-for-autoprefixer
+++ b/projects/packages/paypal-payments/changelog/add-browserslist-for-autoprefixer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+Comment: Add browserslist config for autoprefixer PostCSS targets.
+

--- a/projects/packages/paypal-payments/package.json
+++ b/projects/packages/paypal-payments/package.json
@@ -21,6 +21,9 @@
 		"test:js": "jest --config=jest.config.js",
 		"watch": "webpack --watch --config ./webpack.config.blocks.js"
 	},
+	"browserslist": [
+		"extends @wordpress/browserslist-config"
+	],
 	"dependencies": {
 		"@automattic/babel-plugin-replace-textdomain": "workspace:*",
 		"@automattic/format-currency": "1.0.1",
@@ -61,6 +64,7 @@
 		"@types/react": "18.3.28",
 		"@wordpress/babel-plugin-import-jsx-pragma": "5.51.0",
 		"@wordpress/block-serialization-default-parser": "5.51.0",
+		"@wordpress/browserslist-config": "6.51.0",
 		"@wordpress/theme": "0.17.0",
 		"autoprefixer": "10.4.20",
 		"babel-jest": "30.4.1",

--- a/projects/packages/videopress/changelog/add-browserslist-for-autoprefixer
+++ b/projects/packages/videopress/changelog/add-browserslist-for-autoprefixer
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+Comment: Add browserslist config for autoprefixer PostCSS targets.
+

--- a/projects/packages/videopress/package.json
+++ b/projects/packages/videopress/package.json
@@ -29,6 +29,9 @@
 		"watch": "concurrently 'pnpm:build-client --watch' 'pnpm:watch:wp-build'",
 		"watch:wp-build": "wp-build --watch"
 	},
+	"browserslist": [
+		"extends @wordpress/browserslist-config"
+	],
 	"dependencies": {
 		"@automattic/charts": "workspace:*",
 		"@automattic/jetpack-analytics": "workspace:*",


### PR DESCRIPTION
Follow-up to feedback at https://github.com/Automattic/jetpack/pull/50577#discussion_r3605688811

## Proposed changes
<!--- Explain what functional changes your PR includes -->
*  Adds Browserlist to various packages where we now include `autoprefixer` as part of PostCSS workflow.

Will tidy up bundles produced by Autoprefixed to match our targetted browsers rather than Autoprefixer defaults.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* You can observe bundles change slightly but otherwise not much to test.