### PR TITLE
Stylelint: enable no-token-fallback-values (almost) everywhere

### DIFF
--- a/tools/js-tools/stylelint.config.base.mjs
+++ b/tools/js-tools/stylelint.config.base.mjs
@@ -14,10 +14,7 @@ const baseConfig = {
 	rules: {
 		'plugin-wpds/no-unknown-ds-tokens': true,
 		'plugin-wpds/no-setting-wpds-custom-properties': true,
-		// Disabled globally: only wp-build dashboards and webpack packages with
-		// `@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks`
-		// add fallbacks at build time.
-		'plugin-wpds/no-token-fallback-values': null,
+		'plugin-wpds/no-token-fallback-values': true,
 		// In addition to what `@wordpress/stylelint-config/scss-stylistic` does by default, also ignore comments containing /stylelint-disable/.
 		'@stylistic/max-line-length': [
 			80,
@@ -89,39 +86,16 @@ const baseConfig = {
 	},
 	overrides: [
 		{
+			// Packages that still ship hardcoded WPDS fallbacks (no build-time inject yet).
 			files: [
-				// wp-build dashboards (`build:wp-build` in package.json; fallbacks via @wordpress/build).
-				'projects/packages/backup/routes/**/*.{css,scss,sass}',
-				'projects/packages/forms/routes/**/*.{css,scss,sass}',
-				'projects/packages/forms/src/dashboard/wp-build/**/*.{css,scss,sass}',
-				'projects/packages/jetpack-mu-wpcom/routes/**/*.{css,scss,sass}',
-				'projects/packages/newsletter/routes/**/*.{css,scss,sass}',
-				'projects/packages/newsletter/_inc/**/*.{css,scss,sass}',
-				'projects/packages/podcast/routes/**/*.{css,scss,sass}',
-				'projects/packages/premium-analytics/**/*.{css,scss,sass}',
-				'projects/packages/publicize/routes/**/*.{css,scss,sass}',
-				'projects/packages/scan/routes/**/*.{css,scss,sass}',
-				'projects/packages/scan/_inc/**/*.{css,scss,sass}',
-				'projects/packages/seo/routes/**/*.{css,scss,sass}',
-				'projects/packages/seo/_inc/**/*.{css,scss,sass}',
-				'projects/packages/videopress/routes/**/*.{css,scss,sass}',
-				// Webpack packages with `@wordpress/theme/postcss-plugins/postcss-ds-token-fallbacks`
-				'projects/js-packages/licensing/**/*.{css,scss,sass}',
-				'projects/packages/activity-log/src/**/*.{css,scss,sass}',
-				'projects/packages/backup/src/**/*.{css,scss,sass}',
-				'projects/packages/forms/src/**/*.{css,scss,sass}',
-				'projects/packages/jetpack-mu-wpcom/src/**/*.{css,scss,sass}',
-				'projects/packages/my-jetpack/_inc/**/*.{css,scss,sass}',
-				'projects/packages/paypal-payments/src/**/*.{css,scss,sass}',
-				'projects/packages/newsletter/src/**/*.{css,scss,sass}',
-				'projects/packages/publicize/_inc/**/*.{css,scss,sass}',
-				'projects/packages/search/**/*.{css,scss,sass}',
-				'projects/packages/videopress/src/**/*.{css,scss,sass}',
-				'projects/plugins/boost/app/assets/src/**/*.{css,scss,sass}',
-				'projects/plugins/protect/src/**/*.{css,scss,sass}',
+				'projects/js-packages/base-styles/**/*.{css,scss,sass}',
+				'projects/js-packages/charts/**/*.{css,scss,sass}',
+				'projects/js-packages/components/**/*.{css,scss,sass}',
+				'projects/js-packages/social-previews/**/*.{css,scss,sass}',
+				'projects/plugins/jetpack/**/*.{css,scss,sass}',
 			],
 			rules: {
-				'plugin-wpds/no-token-fallback-values': true,
+				'plugin-wpds/no-token-fallback-values': null,
 			},
 		},
 	],


### PR DESCRIPTION
Follow-up to linter config started at:
- https://github.com/Automattic/jetpack/pull/50110
- https://github.com/Automattic/jetpack/pull/50502

...and numerous PRs meanwhile to add fallback token handling and linting to big chunk of the repo.

Among files with `--wpds-*` the linter + build time fallbacks now cover:

| | Covered | Total | **%** |
|---|---|---|---|
| **Files** | 147 | 173 | **85.0%** |
| **Packages** | 16 | 21 | **76.2%** |

**Not on the rule:** `charts`, `components`, `base-styles`, `social-previews`, `plugins/jetpack`

Those others are pretty complicated:
- use LightningCSS, not PostCSS:
  - charts (https://github.com/Automattic/jetpack/pull/50614)
  - social-previews (https://github.com/Automattic/jetpack/pull/50646) 
- Jetpack plugin still relies on old Calypso colour schemes a little too much
- components and base-styles are just unique cases otherwise


## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Enable `no-token-fallback-values` by default, except on folders still not going through build pipeline that adds the tokens at build-time.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Lint is passing.