### PR TITLE
JITM: center .jitm-card with margin 16px auto (9px auto on mobile)

### DIFF
--- a/projects/packages/jitm/changelog/update-jitm-card-margins
+++ b/projects/packages/jitm/changelog/update-jitm-card-margins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update .jitm-card margins to be horizontally centered (16px auto, 9px auto on mobile).

--- a/projects/packages/jitm/src/css/jetpack-admin-jitm.scss
+++ b/projects/packages/jitm/src/css/jetpack-admin-jitm.scss
@@ -151,7 +151,7 @@ $jp-gray-20:             #a7aaad;
 	display: block;
 	clear: both;
 	position: relative;
-	margin: rem.convert(48px) rem.convert(20px) 0 auto;
+	margin: rem.convert(16px) auto;
 	padding: rem.convert(16px);
 	padding-left: rem.convert(20px);
 	box-sizing: border-box;
@@ -174,6 +174,10 @@ $jp-gray-20:             #a7aaad;
 
 	&.is-card-link {
 		padding-right: rem.convert(48px);
+	}
+
+	@include breakpoints.breakpoint( "<480px" ) {
+		margin: rem.convert(9px) auto;
 	}
 }
 


### PR DESCRIPTION
## Proposed changes

Updates the `.jitm-card` margin so the card is horizontally centered:

* Base: `margin: 16px auto;` (was `48px 20px 0 auto`)
* Mobile (`<480px`): `margin: 9px auto;`

Values use the existing `rem.convert()` helper and the file's `<480px` breakpoint convention.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open any Jetpack/Woo admin screen (or a screen where a JITM renders) with a JITM visible.
* Confirm the `.jitm-card` is horizontally centered with a 16px top/bottom margin.
* Narrow the viewport below 480px and confirm the vertical margin tightens to 9px, still centered.


## Screenshots

Captured on a live Jurassic Ninja site on the Plugins screen (a generic admin page where the base `.jitm-card` rule applies with no per-context override). A test JITM was injected via filter. Computed margin: **before** `48px 20px 0 0` → **after** `16px auto` (desktop), `9px auto` (<480px).

### Desktop (1440px)

| Before | After |
|---|---|
| ![before desktop](https://github.com/Automattic/jetpack/raw/screenshots/update/jitm-card-margins/before-plugins-desktop.png) | ![after desktop](https://github.com/Automattic/jetpack/raw/screenshots/update/jitm-card-margins/after-plugins-desktop.png) |

### Mobile (390px)

| Before | After |
|---|---|
| ![before mobile](https://github.com/Automattic/jetpack/raw/screenshots/update/jitm-card-margins/before-plugins-mobile.png) | ![after mobile](https://github.com/Automattic/jetpack/raw/screenshots/update/jitm-card-margins/after-plugins-mobile.png) |
