### PR TITLE
VideoPress: Fix legacy video block previews in the editor

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-videopress-legacy-preview-sandbox
+++ b/projects/plugins/jetpack/changelog/fix-videopress-legacy-preview-sandbox
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+VideoPress: Fix legacy video block previews in the editor.

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.jsx
@@ -34,7 +34,6 @@ import {
 	createRef,
 	Fragment,
 	useEffect,
-	useCallback,
 } from '@wordpress/element';
 import { escapeHTML } from '@wordpress/escape-html';
 import { __, _x, sprintf } from '@wordpress/i18n';
@@ -45,6 +44,7 @@ import { VideoPressBlockProvider } from './components';
 import { VIDEO_PRIVACY } from './constants';
 import Loading from './loading';
 import ResumableUpload from './resumable-upload';
+import { getVideoPressSandboxScripts } from './sandbox-scripts';
 import SeekbarColorSettings from './seekbar-color-settings';
 import TracksEditor from './tracks-editor';
 import { UploadingEditor } from './uploading-editor';
@@ -1063,26 +1063,7 @@ export const VpBlock = props => {
 		} ),
 	} );
 
-	const getSandboxScripts = useCallback( () => {
-		const sandboxScripts = Array.isArray( scripts ) ? scripts : [];
-
-		if ( window.videopressAjax ) {
-			const videopresAjaxURLBlob = new Blob(
-				[ `var videopressAjax = ${ JSON.stringify( window.videopressAjax ) };` ],
-				{
-					type: 'text/javascript',
-				}
-			);
-
-			return [
-				...sandboxScripts,
-				URL.createObjectURL( videopresAjaxURLBlob ),
-				window.videopressAjax.bridgeUrl,
-			];
-		}
-
-		return sandboxScripts;
-	}, [ scripts ] );
+	const sandboxScripts = getVideoPressSandboxScripts( scripts );
 
 	if ( shouldRenderLoadingBlock ) {
 		return (
@@ -1120,7 +1101,12 @@ export const VpBlock = props => {
 					style={ { margin: 'auto' } }
 					onResizeStop={ onBlockResize }
 				>
-					<SandBox html={ html } scripts={ getSandboxScripts() } type={ videoPressClassNames } />
+					<SandBox
+						html={ html }
+						scripts={ sandboxScripts }
+						type={ videoPressClassNames }
+						allowSameOrigin
+					/>
 				</ResizableBox>
 			</div>
 

--- a/projects/plugins/jetpack/extensions/blocks/videopress/edit.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/edit.jsx
@@ -34,6 +34,7 @@ import {
 	createRef,
 	Fragment,
 	useEffect,
+	useMemo,
 } from '@wordpress/element';
 import { escapeHTML } from '@wordpress/escape-html';
 import { __, _x, sprintf } from '@wordpress/i18n';
@@ -1063,7 +1064,9 @@ export const VpBlock = props => {
 		} ),
 	} );
 
-	const sandboxScripts = getVideoPressSandboxScripts( scripts );
+	// Memoized so loading-state re-renders don't mint a new (never-revoked)
+	// blob URL each time — getVideoPressSandboxScripts calls URL.createObjectURL.
+	const sandboxScripts = useMemo( () => getVideoPressSandboxScripts( scripts ), [ scripts ] );
 
 	if ( shouldRenderLoadingBlock ) {
 		return (

--- a/projects/plugins/jetpack/extensions/blocks/videopress/sandbox-scripts.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/sandbox-scripts.js
@@ -1,0 +1,29 @@
+export const getVideoPressSandboxScripts = scripts => {
+	const sandboxScripts = Array.isArray( scripts ) ? [ ...scripts ] : [];
+
+	if ( window.videopressAjax ) {
+		const videopressAjaxURLBlob = new Blob(
+			[
+				`var videopressAjax = ${ JSON.stringify( {
+					...window.videopressAjax,
+					context: 'sandbox',
+				} ) };`,
+			],
+			{
+				type: 'text/javascript',
+			}
+		);
+
+		sandboxScripts.push( URL.createObjectURL( videopressAjaxURLBlob ) );
+
+		if ( window.videopressAjax.bridgeUrl ) {
+			sandboxScripts.push( window.videopressAjax.bridgeUrl );
+		}
+	}
+
+	if ( window?.videoPressEditorState?.playerBridgeUrl ) {
+		sandboxScripts.push( window.videoPressEditorState.playerBridgeUrl );
+	}
+
+	return sandboxScripts;
+};

--- a/projects/plugins/jetpack/extensions/blocks/videopress/test/sandbox-scripts.test.js
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/test/sandbox-scripts.test.js
@@ -1,0 +1,80 @@
+import { getVideoPressSandboxScripts } from '../sandbox-scripts';
+
+describe( 'getVideoPressSandboxScripts', () => {
+	let createObjectURLDescriptor;
+
+	beforeEach( () => {
+		delete window.videopressAjax;
+		delete window.videoPressEditorState;
+
+		createObjectURLDescriptor = Object.getOwnPropertyDescriptor( URL, 'createObjectURL' );
+		Object.defineProperty( URL, 'createObjectURL', {
+			configurable: true,
+			value: jest.fn().mockReturnValue( 'blob:videopress-ajax' ),
+		} );
+
+		jest.spyOn( global, 'Blob' ).mockImplementation( ( parts, options ) => ( { parts, options } ) );
+	} );
+
+	afterEach( () => {
+		jest.restoreAllMocks();
+
+		if ( createObjectURLDescriptor ) {
+			Object.defineProperty( URL, 'createObjectURL', createObjectURLDescriptor );
+		} else {
+			delete URL.createObjectURL;
+		}
+	} );
+
+	it( 'returns no extra scripts when VideoPress globals are absent', () => {
+		expect( getVideoPressSandboxScripts() ).toEqual( [] );
+		expect( global.Blob ).not.toHaveBeenCalled();
+		expect( URL.createObjectURL ).not.toHaveBeenCalled();
+	} );
+
+	it( 'preserves existing preview scripts', () => {
+		expect( getVideoPressSandboxScripts( [ 'https://example.com/preview.js' ] ) ).toEqual( [
+			'https://example.com/preview.js',
+		] );
+	} );
+
+	it( 'does not mutate the existing preview scripts', () => {
+		const scripts = [ 'https://example.com/preview.js' ];
+		const sandboxScripts = getVideoPressSandboxScripts( scripts );
+
+		sandboxScripts.push( 'https://example.com/another.js' );
+
+		expect( scripts ).toEqual( [ 'https://example.com/preview.js' ] );
+	} );
+
+	it( 'injects videopressAjax with sandbox context', () => {
+		window.videopressAjax = {
+			ajaxUrl: 'https://example.com/ajax',
+			bridgeUrl: 'https://example.com/ajax-bridge.js',
+		};
+
+		expect( getVideoPressSandboxScripts( [ 'https://example.com/preview.js' ] ) ).toEqual( [
+			'https://example.com/preview.js',
+			'blob:videopress-ajax',
+			'https://example.com/ajax-bridge.js',
+		] );
+
+		expect( global.Blob ).toHaveBeenCalledWith(
+			[
+				'var videopressAjax = {"ajaxUrl":"https://example.com/ajax","bridgeUrl":"https://example.com/ajax-bridge.js","context":"sandbox"};',
+			],
+			{ type: 'text/javascript' }
+		);
+	} );
+
+	it( 'includes the editor player bridge script when available', () => {
+		window.videoPressEditorState = {
+			playerBridgeUrl: 'https://example.com/player-bridge.js',
+		};
+
+		expect( getVideoPressSandboxScripts( [ 'https://example.com/preview.js' ] ) ).toEqual( [
+			'https://example.com/preview.js',
+			'https://example.com/player-bridge.js',
+		] );
+	} );
+} );

--- a/projects/plugins/jetpack/extensions/blocks/videopress/test/vp-block.test.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/videopress/test/vp-block.test.jsx
@@ -1,0 +1,111 @@
+import { render, screen } from '@testing-library/react';
+import { VpBlock } from '../edit';
+
+const mockSandBoxProps = jest.fn();
+
+jest.mock( '@automattic/jetpack-shared-extension-utils/icons', () => ( {
+	VideoPressIcon: () => null,
+} ) );
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+jest.mock( '@wordpress/blob', () => ( { isBlobURL: jest.fn() } ) );
+jest.mock( '@wordpress/block-editor', () => {
+	const React = jest.requireActual( 'react' );
+	const RichText = () => null;
+	RichText.isEmpty = value => ! value;
+
+	return {
+		BlockControls: ( { children } ) => React.createElement( React.Fragment, null, children ),
+		InspectorControls: ( { children } ) => React.createElement( React.Fragment, null, children ),
+		MediaUpload: () => null,
+		MediaUploadCheck: ( { children } ) => React.createElement( React.Fragment, null, children ),
+		RichText,
+		useBlockProps: props => props,
+	};
+} );
+jest.mock( '@wordpress/components', () => {
+	const React = jest.requireActual( 'react' );
+	const EmptyComponent = () => null;
+
+	return {
+		BaseControl: EmptyComponent,
+		Button: EmptyComponent,
+		PanelBody: EmptyComponent,
+		ResizableBox: ( { children } ) => React.createElement( 'div', null, children ),
+		SandBox: props => {
+			mockSandBoxProps( props );
+			return React.createElement( 'div', { 'data-testid': 'sandbox' } );
+		},
+		SelectControl: EmptyComponent,
+		ToggleControl: EmptyComponent,
+		ToolbarButton: EmptyComponent,
+		ToolbarGroup: EmptyComponent,
+		Tooltip: EmptyComponent,
+	};
+} );
+jest.mock( '@wordpress/compose', () => ( {
+	compose: () => component => component,
+	createHigherOrderComponent: transform => transform,
+	usePrevious: jest.fn(),
+	withInstanceId: component => component,
+} ) );
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+	withDispatch: () => component => component,
+	withSelect: () => component => component,
+} ) );
+jest.mock( '@wordpress/i18n', () => ( {
+	__: text => text,
+	_x: text => text,
+	sprintf: text => text,
+} ) );
+jest.mock( '@wordpress/icons', () => ( { Icon: () => null } ) );
+jest.mock( '@wordpress/ui', () => ( { Link: () => null } ) );
+jest.mock( '../components', () => ( { VideoPressBlockProvider: ( { children } ) => children } ) );
+jest.mock( '../loading', () => () => null );
+jest.mock( '../resumable-upload', () => () => null );
+jest.mock( '../seekbar-color-settings', () => () => null );
+jest.mock( '../tracks-editor', () => () => null );
+jest.mock( '../uploading-editor', () => ( { UploadingEditor: () => null } ) );
+jest.mock( '../url', () => ( { getVideoPressUrl: jest.fn() } ) );
+jest.mock( '../utils', () => ( {
+	getClassNames: jest.fn(),
+	removeFileNameExtension: jest.fn(),
+} ) );
+
+describe( 'VpBlock', () => {
+	beforeEach( () => {
+		mockSandBoxProps.mockClear();
+		delete window.videopressAjax;
+		delete window.videoPressEditorState;
+	} );
+
+	it( 'renders the legacy preview in a same-origin sandbox', () => {
+		render(
+			<VpBlock
+				attributes={ {
+					align: undefined,
+					className: '',
+					maxWidth: '100%',
+					videoPressClassNames: 'wp-video-shortcode',
+				} }
+				caption=""
+				hideOverlay={ jest.fn() }
+				html="<iframe src='https://videopress.com/e/example' />"
+				interactive
+				isSelected={ false }
+				scripts={ [ 'https://example.com/preview.js' ] }
+				setAttributes={ jest.fn() }
+				shouldRenderLoadingBlock={ false }
+			/>
+		);
+
+		expect( screen.getByTestId( 'sandbox' ) ).toBeInTheDocument();
+		expect( mockSandBoxProps ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				allowSameOrigin: true,
+				scripts: [ 'https://example.com/preview.js' ],
+			} )
+		);
+	} );
+} );


### PR DESCRIPTION
Fixes [VIDP-303](https://linear.app/a8c/issue/VIDP-303/video-shows-private-despite-public-privacy-setting)

## Proposed changes

* Update the legacy VideoPress-enhanced `core/video` editor preview to use the same sandbox configuration as the current VideoPress player.
* Pass `allowSameOrigin` to the editor sandbox.
* Provide `videopressAjax` with the sandbox context and load the available player bridge scripts.
* Add focused coverage for the sandbox scripts and legacy `VpBlock` configuration.

This only changes the legacy block's editor preview. It does not modify WordPress core, migrate saved blocks, change serialized content, or alter frontend video privacy.

## Related product discussion/links

* [VIDP-303: Video shows private despite public privacy setting](https://linear.app/a8c/issue/VIDP-303/video-shows-private-despite-public-privacy-setting)
* [VIDP-240: Core Video block shows "This video is private" for VideoPress videos](https://linear.app/a8c/issue/VIDP-240/corevideo-block-shows-this-video-is-private-for-videopress-videos)

Note: This is a Dotcom Bug Blitz contribution pending VideoPress team review, not an indication that the owning team has started implementation.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

### Automated testing

```bash
pnpm --dir projects/plugins/jetpack test-extensions --runInBand \
  extensions/blocks/videopress/test/sandbox-scripts.test.js \
  extensions/blocks/videopress/test/vp-block.test.jsx

pnpm exec eslint \
  projects/plugins/jetpack/extensions/blocks/videopress/edit.jsx \
  projects/plugins/jetpack/extensions/blocks/videopress/sandbox-scripts.js \
  projects/plugins/jetpack/extensions/blocks/videopress/test
```

### Manual testing

1. On a WordPress.com Simple site, open a public VideoPress video serialized as a legacy `core/video` block.
2. Without the patch, confirm the frontend plays the video while the editor incorrectly reports that it is private.
3. Build Jetpack from this branch and load it through a WordPress.com sandbox.
4. Hard-refresh the editor and confirm the legacy Video block displays its preview.
5. Save and reopen the post, then verify Code Editor still shows `<!-- wp:video` rather than `<!-- wp:videopress/video`.
6. Confirm an existing modern VideoPress block continues to preview correctly.
7. Confirm an ordinary `core/video` block without a VideoPress GUID is unaffected.
8. Set the test video to Private and confirm it remains unavailable to logged-out frontend visitors.
9. Restore the video to Public and confirm the patched legacy editor preview works again.
10. Check that no VideoPress iframe, player-bridge, or `SecurityError` errors appear in the browser console.

### Before

The public VideoPress video is incorrectly shown as private in the legacy Video block.

<img width="1199" height="735" alt="Before: a public VideoPress video shown as private in the legacy Video block" src="https://github.com/user-attachments/assets/4a86e991-e381-4af1-9e0a-70c296e8e13e" />

### After

The same legacy Video block displays the public video preview with the patch applied.

<img width="1199" height="735" alt="After: the public VideoPress preview working in the legacy Video block" src="https://github.com/user-attachments/assets/fe24c533-d577-4a23-b6a3-8ab1259a2c6c" />
