### PR TITLE
Search: keep the Collapsible Filters panel in sync with the sidebar Filters block

### DIFF
--- a/projects/packages/search/changelog/echo-search-307-sync-filters-popover
+++ b/projects/packages/search/changelog/echo-search-307-sync-filters-popover
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search overlay/embedded templates: keep the Collapsible Filters panel in sync with the sidebar Filters block, so editing filter labels or adding/removing filters in the sidebar always shows up in the panel too. When both blocks coexist, the panel is locked read-only in the editor since it now mirrors the sidebar; it stays fully editable when used standalone.

--- a/projects/packages/search/src/search-blocks/AGENTS.md
+++ b/projects/packages/search/src/search-blocks/AGENTS.md
@@ -157,6 +157,15 @@ Block edit components mirror the server `render.php` so the canvas preview match
 - **Snap empty selections to the full set.** Persisting `availableSortOptions: []` would make the renderer fall back to "all options" while every inspector checkbox stays unchecked — invisible mismatch. The setter writes the canonical full set back instead.
 - **Per-instance IDs.** Edit components that emit `<label htmlFor=…>` use `useId()` — the editor canvas may render the same block twice, and a shared static id breaks the label→control association on the second instance.
 
+## Editor preview gotchas
+
+Rendering a read-only preview of *another* block's current children (not your own `InnerBlocks`) inside an edit component — `filters-popover` does this to mirror `filters`/`filters-product` — has two traps:
+
+- **`<BlockPreview>` silently renders at zero height when nested inside the Site Editor's own iframed canvas.** It renders its content into its own internal iframe and sizes itself via a `ResizeObserver` on that iframe's content; the observer never reports a nonzero height when the whole thing is nested one level inside the canvas iframe the Site Editor already uses, so the preview loads real content but stays invisible. Confirmed by inspecting the live DOM in a browser (real content, `0` measured height) — not a timing/mount-order issue, waiting longer doesn't fix it.
+- **The non-iframed alternative, `useBlockPreview()`, is only published under the experimental name `__experimentalUseBlockPreview`** in `@wordpress/block-editor` as of the versions this package installs — there's no stable `useBlockPreview` export despite the un-prefixed name existing in Gutenberg's own source. Importing the plain name resolves to `undefined` and throws at call time. Depending on the `__experimental` name ties a shipped block to an unstable API that WordPress core can rename or remove without notice.
+
+Given both, prefer locking the block's own (already-synced) `InnerBlocks` read-only with `<Disabled>` (a long-stable public component) over live-mirroring another block's content. It loses "reflects edits before you save," but every reload/save picks up the source's current state regardless — self-healing, no unstable dependency.
+
 ## Comments
 
 Code is the source of truth — well-named identifiers should make most code easier to read than any prose attached to it. Default to **no comment**.

--- a/projects/packages/search/src/search-blocks/blocks/filters-popover/edit.jsx
+++ b/projects/packages/search/src/search-blocks/blocks/filters-popover/edit.jsx
@@ -6,9 +6,17 @@
  * edit the panel contents when expanded or the surrounding template parts when collapsed. The
  * trigger itself stays inert because clicking it would select the block (and pop the settings
  * sidebar) without giving the author a way to collapse the panel afterwards.
+ *
+ * When a jetpack-search/filters(-product) block exists elsewhere in the document, this block's
+ * own inner blocks are server-synced to mirror it (Search_Blocks::sync_filters_popover_content())
+ * on every save/reload, so direct edits here would silently vanish — the panel locks its own
+ * InnerBlocks read-only via Disabled in that case. See AGENTS.md's "Editor preview gotchas" for
+ * why this doesn't render a live mirror instead. Standalone (no sidebar sibling), the panel is
+ * fully editable as normal.
  */
 import { BlockControls, InnerBlocks, useBlockProps } from '@wordpress/block-editor';
-import { ToolbarButton, ToolbarGroup } from '@wordpress/components';
+import { Disabled, Notice, ToolbarButton, ToolbarGroup } from '@wordpress/components';
+import { useSelect } from '@wordpress/data';
 import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { filter } from '@wordpress/icons';
@@ -26,6 +34,8 @@ const ALLOWED = [
 	'jetpack-search/clear-filters',
 ];
 
+const SOURCE_BLOCK_NAMES = [ 'jetpack-search/filters', 'jetpack-search/filters-product' ];
+
 /**
  * Edit component for the filters-popover block.
  *
@@ -33,12 +43,30 @@ const ALLOWED = [
  */
 export default function FiltersPopoverEdit() {
 	const [ isPopoverOpen, setIsPopoverOpen ] = useState( false );
+
+	const hasSidebarFilters = useSelect( select => {
+		const { getBlockName, getClientIdsWithDescendants } = select( 'core/block-editor' );
+		return getClientIdsWithDescendants().some( clientId =>
+			SOURCE_BLOCK_NAMES.includes( getBlockName( clientId ) )
+		);
+	}, [] );
+
 	// Split into a top-level if/else so Terser doesn't collapse two __() calls
 	// into `__( cond ? 'a' : 'b' )` — the post-build i18n validator requires a
 	// string literal as the first argument.
 	let togglePanelLabel = __( 'Show filter panel', 'jetpack-search-pkg' );
 	if ( isPopoverOpen ) {
 		togglePanelLabel = __( 'Hide filter panel', 'jetpack-search-pkg' );
+	}
+	let noticeText = __(
+		'Configure the filters to show when this panel is collapsed to a button.',
+		'jetpack-search-pkg'
+	);
+	if ( hasSidebarFilters ) {
+		noticeText = __(
+			'This panel mirrors the Filters block on wider screens — add, remove, or edit filters there and they will carry over here on the next save or reload.',
+			'jetpack-search-pkg'
+		);
 	}
 	const blockProps = useBlockProps( {
 		className: [
@@ -88,7 +116,16 @@ export default function FiltersPopoverEdit() {
 					role="region"
 					aria-label={ __( 'Search filters', 'jetpack-search-pkg' ) }
 				>
-					<InnerBlocks template={ TEMPLATE } allowedBlocks={ ALLOWED } />
+					<Notice status="info" isDismissible={ false }>
+						{ noticeText }
+					</Notice>
+					{ hasSidebarFilters ? (
+						<Disabled>
+							<InnerBlocks template={ TEMPLATE } allowedBlocks={ ALLOWED } />
+						</Disabled>
+					) : (
+						<InnerBlocks template={ TEMPLATE } allowedBlocks={ ALLOWED } />
+					) }
 				</div>
 			</div>
 		</>

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1013,7 +1013,7 @@ class Search_Blocks {
 		$template_path = __DIR__ . '/templates/jetpack-search.html';
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- local, bundled template file.
 		$raw = is_readable( $template_path ) ? (string) file_get_contents( $template_path ) : '';
-		return static::substitute_template_placeholders( $raw );
+		return static::sync_filters_popover_content( static::substitute_template_placeholders( $raw ) );
 	}
 
 	/**
@@ -1088,7 +1088,8 @@ class Search_Blocks {
 		$file          = $is_product ? 'jetpack-search-overlay-product.html' : 'jetpack-search-overlay.html';
 		$template_path = __DIR__ . '/templates/' . $file;
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- local, bundled template file; wp_remote_get() is for remote URLs.
-		self::$overlay_template_content_cache[ $key ] = is_readable( $template_path ) ? (string) file_get_contents( $template_path ) : '';
+		$raw = is_readable( $template_path ) ? (string) file_get_contents( $template_path ) : '';
+		self::$overlay_template_content_cache[ $key ] = static::sync_filters_popover_content( $raw );
 		return self::$overlay_template_content_cache[ $key ];
 	}
 
@@ -1659,7 +1660,7 @@ CSS;
 		$template_path = __DIR__ . '/templates/jetpack-search-product-results.html';
 		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- local, bundled template file.
 		$raw = is_readable( $template_path ) ? (string) file_get_contents( $template_path ) : '';
-		return static::substitute_template_placeholders( $raw );
+		return static::sync_filters_popover_content( static::substitute_template_placeholders( $raw ) );
 	}
 
 	/**
@@ -1693,6 +1694,93 @@ CSS;
 	 */
 	protected static function resolve_chrome_slugs(): array {
 		return Theme_Chrome_Slug_Resolver::resolve();
+	}
+
+	/**
+	 * Names of the "source of truth" filter-composition blocks — whichever is
+	 * present in a template supplies the canonical filter config that
+	 * `jetpack-search/filters-popover` mirrors. See {@see sync_filters_popover_content()}.
+	 */
+	const FILTERS_SOURCE_BLOCK_NAMES = array( 'jetpack-search/filters', 'jetpack-search/filters-product' );
+
+	/**
+	 * `jetpack-search/filters-popover` (the collapsible/mobile filter panel) and
+	 * `jetpack-search/filters` / `jetpack-search/filters-product` (the wide-viewport
+	 * sidebar) are two independently-serialized copies of the same filter
+	 * configuration, shown one-or-the-other via a CSS breakpoint. Nothing keeps
+	 * them in sync, so editing one silently leaves the other stale (SEARCH-307).
+	 *
+	 * Rather than a two-way sync, the sidebar block is treated as the single
+	 * source of truth: every time template content is read — for rendering or
+	 * for editing — the popover's inner blocks are recomputed to mirror
+	 * whatever the sidebar currently contains. A direct edit to the popover's
+	 * own inner blocks still saves, but is overwritten back to match the
+	 * sidebar on the next read; self-healing, no migration needed for content
+	 * that already diverged before this existed.
+	 *
+	 * @param string $content Block markup, e.g. a full template or singleton-CPT post_content.
+	 * @return string Block markup with the popover's inner blocks synced to the sidebar's, unchanged if either block is absent.
+	 */
+	public static function sync_filters_popover_content( string $content ): string {
+		if ( '' === $content || false === strpos( $content, 'jetpack-search/filters-popover' ) ) {
+			return $content;
+		}
+		$blocks = parse_blocks( $content );
+		$source = static::find_block_by_name( $blocks, self::FILTERS_SOURCE_BLOCK_NAMES );
+		if ( null === $source ) {
+			return $content;
+		}
+		$replaced = static::replace_block_inner_content( $blocks, 'jetpack-search/filters-popover', $source );
+		return $replaced ? serialize_blocks( $blocks ) : $content;
+	}
+
+	/**
+	 * Depth-first search for the first block matching one of `$names`.
+	 *
+	 * @param array<int,array<string,mixed>> $blocks Parsed blocks (`parse_blocks()` shape).
+	 * @param string[]                       $names  Block names to match.
+	 * @return array<string,mixed>|null
+	 */
+	protected static function find_block_by_name( array $blocks, array $names ): ?array {
+		foreach ( $blocks as $block ) {
+			if ( in_array( $block['blockName'], $names, true ) ) {
+				return $block;
+			}
+			if ( ! empty( $block['innerBlocks'] ) ) {
+				$found = static::find_block_by_name( $block['innerBlocks'], $names );
+				if ( null !== $found ) {
+					return $found;
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * Depth-first search that overwrites the first block named `$name` with
+	 * `$source`'s inner blocks. `innerBlocks`/`innerContent`/`innerHTML` are
+	 * copied together from `$source` so the null-placeholder bookkeeping in
+	 * `innerContent` stays internally consistent regardless of how many
+	 * filters `$source` has.
+	 *
+	 * @param array<int,array<string,mixed>> $blocks Parsed blocks, modified in place.
+	 * @param string                         $name   Block name to replace.
+	 * @param array<string,mixed>            $source Block whose inner content is cloned onto the match.
+	 * @return bool Whether a match was found and replaced.
+	 */
+	protected static function replace_block_inner_content( array &$blocks, string $name, array $source ): bool {
+		foreach ( $blocks as &$block ) {
+			if ( $block['blockName'] === $name ) {
+				$block['innerBlocks']  = $source['innerBlocks'];
+				$block['innerContent'] = $source['innerContent'];
+				$block['innerHTML']    = $source['innerHTML'];
+				return true;
+			}
+			if ( ! empty( $block['innerBlocks'] ) && static::replace_block_inner_content( $block['innerBlocks'], $name, $source ) ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/class-singleton-template-cpt.php
+++ b/projects/packages/search/src/search-blocks/class-singleton-template-cpt.php
@@ -139,7 +139,10 @@ abstract class Singleton_Template_Cpt {
 	 * Mirror `Search_Blocks::sync_filters_popover_content()` onto this
 	 * singleton's REST response so the Site Editor opens with the popover
 	 * already matching the sidebar Filters block, instead of showing stale
-	 * content until the next save/reload.
+	 * content until the next save/reload. Only `content.raw` (what the editor
+	 * hydrates from) needs this — `content.rendered` is post-`the_content`
+	 * HTML with block comments already replaced by their output, so the
+	 * block-name guard in `sync_filters_popover_content()` never matches it.
 	 *
 	 * @param \WP_REST_Response $response REST response for the singleton post.
 	 * @return \WP_REST_Response
@@ -147,9 +150,6 @@ abstract class Singleton_Template_Cpt {
 	public static function sync_filters_popover_in_rest_response( $response ) {
 		if ( isset( $response->data['content']['raw'] ) ) {
 			$response->data['content']['raw'] = Search_Blocks::sync_filters_popover_content( $response->data['content']['raw'] );
-		}
-		if ( isset( $response->data['content']['rendered'] ) ) {
-			$response->data['content']['rendered'] = Search_Blocks::sync_filters_popover_content( $response->data['content']['rendered'] );
 		}
 		return $response;
 	}

--- a/projects/packages/search/src/search-blocks/class-singleton-template-cpt.php
+++ b/projects/packages/search/src/search-blocks/class-singleton-template-cpt.php
@@ -128,6 +128,30 @@ abstract class Singleton_Template_Cpt {
 		// `before_delete_post` fires for force-delete too, so it catches every
 		// delete path: AJAX reset, REST DELETE, post.php trash-then-delete.
 		add_action( 'before_delete_post', array( static::class, 'maybe_cleanup_on_singleton_delete' ) );
+		// The block editor loads this singleton via core's post REST route
+		// directly, bypassing get_customized_content() entirely, so the
+		// filters-popover sync there wouldn't reach the editor canvas without
+		// this — see sync_filters_popover_in_rest_response().
+		add_filter( 'rest_prepare_' . static::POST_TYPE, array( static::class, 'sync_filters_popover_in_rest_response' ) );
+	}
+
+	/**
+	 * Mirror `Search_Blocks::sync_filters_popover_content()` onto this
+	 * singleton's REST response so the Site Editor opens with the popover
+	 * already matching the sidebar Filters block, instead of showing stale
+	 * content until the next save/reload.
+	 *
+	 * @param \WP_REST_Response $response REST response for the singleton post.
+	 * @return \WP_REST_Response
+	 */
+	public static function sync_filters_popover_in_rest_response( $response ) {
+		if ( isset( $response->data['content']['raw'] ) ) {
+			$response->data['content']['raw'] = Search_Blocks::sync_filters_popover_content( $response->data['content']['raw'] );
+		}
+		if ( isset( $response->data['content']['rendered'] ) ) {
+			$response->data['content']['rendered'] = Search_Blocks::sync_filters_popover_content( $response->data['content']['rendered'] );
+		}
+		return $response;
 	}
 
 	/**
@@ -218,7 +242,7 @@ abstract class Singleton_Template_Cpt {
 		}
 		// Empty content = admin saved a blank canvas. Honor it explicitly so
 		// the editor doesn't loop with the bundled content on every save.
-		self::$caches[ static::class ] = (string) $post->post_content;
+		self::$caches[ static::class ] = Search_Blocks::sync_filters_popover_content( (string) $post->post_content );
 		return self::$caches[ static::class ];
 	}
 

--- a/projects/packages/search/tests/js/search-blocks/filters-popover-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/filters-popover-edit.test.jsx
@@ -17,6 +17,8 @@ jest.mock( '@wordpress/components', () => ( {
 			{ label }
 		</button>
 	),
+	Notice: ( { children } ) => <div role="status">{ children }</div>,
+	Disabled: ( { children } ) => <div data-testid="filters-popover-disabled">{ children }</div>,
 } ) );
 
 jest.mock( '@wordpress/icons', () => ( {
@@ -27,7 +29,26 @@ jest.mock( '@wordpress/i18n', () => ( {
 	__: text => text,
 } ) );
 
+// Simulates the `core/block-editor` store: `mockBlockEditorStore` controls
+// whether a `jetpack-search/filters(-product)` block exists elsewhere in the
+// document, which decides whether the popover mirrors it (read-only preview)
+// or is directly editable (standalone).
+let mockBlockEditorStore;
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: callback => callback( () => mockBlockEditorStore ),
+} ) );
+
 describe( 'FiltersPopoverEdit', () => {
+	beforeEach( () => {
+		// Default: no sidebar Filters block anywhere in the document — standalone, editable.
+		mockBlockEditorStore = {
+			getClientIdsWithDescendants: () => [],
+			getBlockName: () => undefined,
+			getBlocks: () => [],
+		};
+	} );
+
 	// The trigger button is a non-interactive preview of the front-end control.
 	// A block-toolbar button is the actual toggle in the editor — clicking the
 	// inline trigger would select the block and open the settings sidebar without
@@ -60,4 +81,30 @@ describe( 'FiltersPopoverEdit', () => {
 		const closed = screen.getByRole( 'button', { name: 'Show filter panel' } );
 		expect( closed ).toHaveAttribute( 'aria-pressed', 'false' );
 	} );
+
+	it( 'is directly editable when standalone (no sidebar Filters block in the document)', () => {
+		render( <FiltersPopoverEdit /> );
+
+		expect( screen.getByTestId( 'filters-popover-inner-blocks' ) ).toBeInTheDocument();
+		expect( screen.queryByTestId( 'filters-popover-disabled' ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( 'status' ) ).toHaveTextContent( /collapsed to a button/ );
+	} );
+
+	it.each( [ 'jetpack-search/filters', 'jetpack-search/filters-product' ] )(
+		'locks the panel read-only when a sidebar %s block exists elsewhere in the document',
+		sourceBlockName => {
+			mockBlockEditorStore = {
+				getClientIdsWithDescendants: () => [ 'sidebar-filters-client-id' ],
+				getBlockName: clientId =>
+					clientId === 'sidebar-filters-client-id' ? sourceBlockName : undefined,
+				getBlocks: () => [],
+			};
+
+			render( <FiltersPopoverEdit /> );
+
+			const disabled = screen.getByTestId( 'filters-popover-disabled' );
+			expect( disabled ).toContainElement( screen.getByTestId( 'filters-popover-inner-blocks' ) );
+			expect( screen.getByRole( 'status' ) ).toHaveTextContent( /mirrors the Filters block/ );
+		}
+	);
 } );

--- a/projects/packages/search/tests/php/Filters_Popover_Sync_Test.php
+++ b/projects/packages/search/tests/php/Filters_Popover_Sync_Test.php
@@ -130,6 +130,8 @@ class Filters_Popover_Sync_Test extends Search_TestCase {
 		Overlay_Template::reset_customized_content_cache();
 
 		$synced = Overlay_Template::get_customized_content();
+		$this->assertNotNull( $synced );
+		$synced = (string) $synced;
 
 		$this->assertStringContainsString( '"label":"Limit results to"', $synced );
 		$this->assertStringNotContainsString( '"taxonomy":"post_tag"', $synced );

--- a/projects/packages/search/tests/php/Filters_Popover_Sync_Test.php
+++ b/projects/packages/search/tests/php/Filters_Popover_Sync_Test.php
@@ -138,6 +138,21 @@ class Filters_Popover_Sync_Test extends Search_TestCase {
 	}
 
 	/**
+	 * The REST filter is what the Site Editor's load actually goes through
+	 * (bypassing get_customized_content() entirely) — covers that path
+	 * directly rather than only through the singleton-CPT read path above.
+	 */
+	public function test_rest_response_sync_normalizes_content_raw() {
+		$content  = static::wrap_columns( static::SIDEBAR_FILTERS, static::STALE_POPOVER );
+		$response = new \WP_REST_Response( array( 'content' => array( 'raw' => $content ) ) );
+
+		$synced = Overlay_Template::sync_filters_popover_in_rest_response( $response );
+
+		$this->assertStringContainsString( '"label":"Limit results to"', $synced->data['content']['raw'] );
+		$this->assertStringNotContainsString( '"taxonomy":"post_tag"', $synced->data['content']['raw'] );
+	}
+
+	/**
 	 * Guards the no-op path at the Singleton_Template_Cpt layer too: a
 	 * customization with no filters-popover block round-trips byte-for-byte,
 	 * matching Search_Template_Test::test_customized_state_returns_post_content().

--- a/projects/packages/search/tests/php/Filters_Popover_Sync_Test.php
+++ b/projects/packages/search/tests/php/Filters_Popover_Sync_Test.php
@@ -131,7 +131,6 @@ class Filters_Popover_Sync_Test extends Search_TestCase {
 
 		$synced = Overlay_Template::get_customized_content();
 		$this->assertNotNull( $synced );
-		$synced = (string) $synced;
 
 		$this->assertStringContainsString( '"label":"Limit results to"', $synced );
 		$this->assertStringNotContainsString( '"taxonomy":"post_tag"', $synced );

--- a/projects/packages/search/tests/php/Filters_Popover_Sync_Test.php
+++ b/projects/packages/search/tests/php/Filters_Popover_Sync_Test.php
@@ -1,0 +1,167 @@
+<?php
+
+namespace Automattic\Jetpack\Search;
+
+use Automattic\Jetpack\Search\TestCase as Search_TestCase;
+
+/**
+ * Unit tests for Search_Blocks::sync_filters_popover_content() and its
+ * integration through Overlay_Template::get_customized_content() —
+ * SEARCH-307's "keep the two blocks in sync" fix.
+ *
+ * @package automattic/jetpack-search
+ */
+class Filters_Popover_Sync_Test extends Search_TestCase {
+
+	const SIDEBAR_FILTERS = '<!-- wp:jetpack-search/filters -->' .
+		'<!-- wp:jetpack-search/active-filters /-->' .
+		'<!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"category","label":"Limit results to"} /-->' .
+		'<!-- /wp:jetpack-search/filters -->';
+
+	const STALE_POPOVER = '<!-- wp:jetpack-search/filters-popover -->' .
+		'<!-- wp:jetpack-search/active-filters /-->' .
+		'<!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->' .
+		'<!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"post_tag"} /-->' .
+		'<!-- wp:jetpack-search/filter-checkbox {"filterType":"post_type"} /-->' .
+		'<!-- /wp:jetpack-search/filters-popover -->';
+
+	public function setUp(): void {
+		parent::setUp();
+		Overlay_Template::register_post_type();
+		Overlay_Template::reset_customized_content_cache();
+		delete_option( Overlay_Template::OPTION_POST_ID );
+		Search_Blocks::reset_overlay_template_content_cache();
+	}
+
+	public function tearDown(): void {
+		$post_id = (int) get_option( Overlay_Template::OPTION_POST_ID, 0 );
+		if ( $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+		delete_option( Overlay_Template::OPTION_POST_ID );
+		Overlay_Template::reset_customized_content_cache();
+		Search_Blocks::reset_overlay_template_content_cache();
+		parent::tearDown();
+	}
+
+	/**
+	 * The popover's stale/diverged filters (missing the label override,
+	 * carrying filters the sidebar no longer has) normalize to exactly what
+	 * the sidebar block currently contains.
+	 */
+	public function test_popover_normalizes_to_sidebar_filters() {
+		$content = static::wrap_columns( static::SIDEBAR_FILTERS, static::STALE_POPOVER );
+
+		$synced = Search_Blocks::sync_filters_popover_content( $content );
+
+		$this->assertStringContainsString(
+			'"label":"Limit results to"',
+			$synced,
+			'Custom label from the sidebar block must carry over to the popover.'
+		);
+		$this->assertStringNotContainsString(
+			'"taxonomy":"post_tag"',
+			$synced,
+			'A filter removed from the sidebar must no longer appear in the popover.'
+		);
+		$this->assertStringNotContainsString(
+			'"filterType":"post_type"',
+			$synced,
+			'A filter removed from the sidebar must no longer appear in the popover.'
+		);
+	}
+
+	/**
+	 * `jetpack-search/filters-product` (the WooCommerce sidebar variant) is
+	 * recognized as a source of truth too.
+	 */
+	public function test_recognizes_filters_product_as_source() {
+		$product_filters = '<!-- wp:jetpack-search/filters-product -->' .
+			'<!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"product_cat","label":"Product category"} /-->' .
+			'<!-- /wp:jetpack-search/filters-product -->';
+		$content         = static::wrap_columns( $product_filters, static::STALE_POPOVER );
+
+		$synced = Search_Blocks::sync_filters_popover_content( $content );
+
+		$this->assertStringContainsString( '"label":"Product category"', $synced );
+	}
+
+	/**
+	 * Content with no source block (sidebar filters absent) is returned
+	 * unchanged — nothing to mirror.
+	 */
+	public function test_no_op_when_source_block_absent() {
+		$content = '<!-- wp:group -->' . static::STALE_POPOVER . '<!-- /wp:group -->';
+
+		$this->assertSame( $content, Search_Blocks::sync_filters_popover_content( $content ) );
+	}
+
+	/**
+	 * Content with no popover block at all is returned unchanged — the
+	 * cheap `strpos()` guard should skip the parse/serialize round trip
+	 * entirely, so unrelated content is never touched.
+	 */
+	public function test_no_op_when_popover_block_absent() {
+		$content = '<!-- wp:paragraph --><p>SENTINEL_CONTENT</p><!-- /wp:paragraph -->';
+
+		$this->assertSame( $content, Search_Blocks::sync_filters_popover_content( $content ) );
+	}
+
+	/**
+	 * A saved Overlay_Template customization with diverged filters-popover
+	 * content comes back synced through get_customized_content() — the
+	 * frontend-render + classic-theme-body path.
+	 */
+	public function test_overlay_template_customization_is_synced_on_read() {
+		// Block-comment JSON attrs need `unfiltered_html` to survive
+		// wp_insert_post()'s KSES pass — matches the real editing flow,
+		// which is admin-only (see Singleton_Template_Cpt's capabilities map).
+		wp_set_current_user( $this->admin_id );
+		$content = static::wrap_columns( static::SIDEBAR_FILTERS, static::STALE_POPOVER );
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => Overlay_Template::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_title'   => 'Overlay Template Test',
+				'post_content' => $content,
+			)
+		);
+		update_option( Overlay_Template::OPTION_POST_ID, $post_id );
+		Overlay_Template::reset_customized_content_cache();
+
+		$synced = Overlay_Template::get_customized_content();
+
+		$this->assertStringContainsString( '"label":"Limit results to"', $synced );
+		$this->assertStringNotContainsString( '"taxonomy":"post_tag"', $synced );
+	}
+
+	/**
+	 * Guards the no-op path at the Singleton_Template_Cpt layer too: a
+	 * customization with no filters-popover block round-trips byte-for-byte,
+	 * matching Search_Template_Test::test_customized_state_returns_post_content().
+	 */
+	public function test_unrelated_customization_round_trips_unchanged() {
+		$content = '<!-- wp:paragraph --><p>SENTINEL_CONTENT</p><!-- /wp:paragraph -->';
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => Overlay_Template::POST_TYPE,
+				'post_status'  => 'publish',
+				'post_title'   => 'Overlay Template Test',
+				'post_content' => $content,
+			)
+		);
+		update_option( Overlay_Template::OPTION_POST_ID, $post_id );
+		Overlay_Template::reset_customized_content_cache();
+
+		$this->assertSame( $content, Overlay_Template::get_customized_content() );
+	}
+
+	/**
+	 * @param string $sidebar Sidebar filters block markup.
+	 * @param string $popover Popover block markup.
+	 * @return string Minimal columns wrapper placing both side by side, matching the bundled templates' shape.
+	 */
+	protected static function wrap_columns( string $sidebar, string $popover ): string {
+		return '<!-- wp:columns -->' . $popover . $sidebar . '<!-- /wp:columns -->';
+	}
+}


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/SEARCH-307/jetpack-search-blocks-overlay-template-collapsible-filters-dont

## Why
The search overlay/embedded templates show filters two different ways depending on screen width: a sidebar on wide screens, a collapsible panel on narrow screens. These are two separate blocks with their own independent copies of the filter configuration, so editing one (renaming a filter's label, removing a filter) never showed up in the other — and on a later editor visit, the stale copy could even overwrite an intentional change. Now the sidebar is the source of truth and the collapsible panel always mirrors it, on both the front end and in the editor.

## Proposed changes
* Add `Search_Blocks::sync_filters_popover_content()` — parses template content, finds the sidebar `jetpack-search/filters`/`filters-product` block, and overwrites the collapsible `jetpack-search/filters-popover` block's inner blocks to match it.
* Wire the sync into every place template content is read: `Singleton_Template_Cpt::get_customized_content()` (covers all four singleton-CPT customization classes), a new `rest_prepare_{post_type}` filter (so the Site Editor loads with synced content, not just the front end), and the three bundled-template readers in `Search_Blocks`.
* Self-healing: sites that already have diverged content correct on the next read — no migration needed.
* Editor UX: when a sidebar `Filters` block exists elsewhere in the document, the Collapsible Filters block locks its own inner-blocks region read-only (`Disabled`) with a `Notice` pointing at the sidebar block, since direct edits there would otherwise silently vanish on the next save/reload. Used standalone (no sidebar sibling), it stays fully editable.
* Document a Gutenberg gotcha in `AGENTS.md` hit while building the editor-side preview: `<BlockPreview>` renders at zero height when nested inside the Site Editor's own iframed canvas, and the non-iframed alternative (`useBlockPreview`) is only published under an experimental name in the installed WP version — hence locking the existing `InnerBlocks` read-only instead of live-mirroring.

## Related product discussion/links
* https://linear.app/a8c/issue/SEARCH-307/jetpack-search-blocks-overlay-template-collapsible-filters-dont

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

Acceptance criteria from the issue:
- [ ] Renaming a filter's label in the sidebar Filters block shows the new label in the Collapsible Filters panel too (not the stale default).
- [ ] Removing a filter (e.g. Post Type or Tag) from the sidebar Filters block removes it from the Collapsible Filters panel too, instead of it reappearing later.
- [ ] Reopening the Overlay template editor after a previous edit session shows the two blocks still in sync (no stale content resurfacing).

Steps:
1. In a site with Jetpack Search's "Overlay search (blocks)" experience active, go to **Jetpack → Search → Settings** and click **Edit the Search overlay**.
2. In the sidebar `Filters` block, rename the Category filter's label (e.g. to "Limit results to") and remove the Post Type filter. Save.
3. Reload the template editor, select the **Collapsible Filters** block, and expand its panel via the block toolbar's filter icon — it should show the same label and filter set as the sidebar, and should be locked read-only (clicking a checkbox inside it does nothing) with a notice pointing at the sidebar block.
4. On the front end, trigger the search overlay at a viewport ≥992px — the sidebar shows the updated label/filters. Shrink the viewport below 992px and open the collapsible filter trigger — it shows the same updated label/filters.
5. Drop a standalone Collapsible Filters block into an unrelated post (no sidebar Filters block nearby) — it should be fully editable as before.

## Verification
Reproduced the bug's exact scenario (custom Category label + removed Tag/Post Type filters in the sidebar) against a local Jetpack Search overlay template, then verified end-to-end: the popover's inner blocks in the Site Editor (via List View) matched the sidebar exactly after a reload; the live front end matched at both ≥992px (sidebar) and <992px (collapsible panel, verified via a mobile-viewport emulated browser session); and clicking a checkbox inside the locked panel had no effect, confirming the read-only lock. Full search-package PHPUnit suite (621 tests) and the search-blocks Jest suite (603 tests) pass; phpcs and eslint clean on all touched files.
