### PR TITLE
Charts: CSS var naming consistency + --a8c-charts-* token catalog [CHARTS-201]

### DIFF
--- a/projects/js-packages/charts/AGENTS.md
+++ b/projects/js-packages/charts/AGENTS.md
@@ -28,6 +28,11 @@ The package is migrating to WordPress UI and Theme as its defaults. When adding 
 - **UI primitives.** Prefer `Stack` and the stable `Text` from `@wordpress/ui` over ad-hoc flexbox or raw `<span>`/`<div>` for layout and text. Do not use `__experimental*` exports from `@wordpress/components` (e.g. `__experimentalText`, `__experimentalHStack`) — use the stable `@wordpress/ui` equivalents. Exception: `__experimentalGrid` has no stable alternative yet and is acceptable to use for now.
 - **Theming.** Theming flows through `@wordpress/theme`'s `ThemeProvider` (unlocked via private APIs in Storybook; see `src/stories/chart-decorator.tsx`). Do not manually override DS tokens in stories or components to achieve theming — pass a color through `ThemeProvider` instead.
 - **Chart element styles.** Read chart element styles via `getElementStyles` from `GlobalChartsProvider`, not directly from `theme`. This is the supported path for color/style resolution across themes.
+- **Package CSS variables.** Package-owned custom properties follow
+  `--a8c-charts-{category}-{name}` (see `TOKENS.md` for the catalog and its
+  `--wpds-*` mappings). Charts reference `--a8c-charts-*` roles with the mapped
+  `var(--wpds-*, <spec-fallback>)` as the inline fallback; there is no runtime
+  emission yet (that is CHARTS-203).
 
 ## Documentation Workflow
 

--- a/projects/js-packages/charts/TOKENS.md
+++ b/projects/js-packages/charts/TOKENS.md
@@ -2,7 +2,7 @@
 
 `@automattic/charts` exposes its themeable values as CSS custom properties under a
 single convention: `--a8c-charts-{category}-{name}`. `{category}` mirrors the WPDS
-token type (`color`, `dimension`, `border-radius`, `border-width`).
+token type (`color`, `dimension`, `border-radius`).
 
 ## How it resolves today
 

--- a/projects/js-packages/charts/TOKENS.md
+++ b/projects/js-packages/charts/TOKENS.md
@@ -48,8 +48,8 @@ maps directly to its own `--wpds-*` token rather than chaining through `grid`.
 Instance styling knobs, on the same convention but not shared semantic roles:
 `--a8c-charts-border-radius-leaderboard-bar`,
 `--a8c-charts-dimension-leaderboard-bar-hover-inset`,
-`--a8c-charts-color-zoom-*`, `--a8c-charts-color-heatmap-*`,
-`--a8c-charts-dimension-heatmap-*`, `--a8c-charts-heatmap-cell-intensity`.
+`--a8c-charts-color-heatmap-*`, `--a8c-charts-dimension-heatmap-*`,
+`--a8c-charts-heatmap-cell-intensity`.
 
 `--a8c-charts-heatmap-cell-intensity` is the one variable without a `{category}`
 segment: it holds a unitless 0–1 scalar consumed inside `color-mix()`, not a colour.

--- a/projects/js-packages/charts/TOKENS.md
+++ b/projects/js-packages/charts/TOKENS.md
@@ -22,16 +22,26 @@ mapped `--wpds-*` token wins; otherwise the spec-value hex wins. Setting any
 | Role | Maps to `--wpds-*` | Fallback |
 |---|---|---|
 | `--a8c-charts-color-grid` | `--wpds-color-stroke-surface-neutral` | `#dbdbdb` |
+| `--a8c-charts-color-axis` | `--wpds-color-stroke-surface-neutral` | `#dbdbdb` |
+| `--a8c-charts-color-tick` | `--wpds-color-stroke-surface-neutral` | `#dbdbdb` |
 | `--a8c-charts-color-label` | `--wpds-color-foreground-content-neutral` | `#1e1e1e` |
 | `--a8c-charts-color-label-secondary` | `--wpds-color-foreground-content-neutral-weak` | `#707070` |
 | `--a8c-charts-color-label-inverse` | `--wpds-color-foreground-interactive-neutral-strong` | `#f0f0f0` |
+| `--a8c-charts-color-label-on-fill` | _(none — white-on-series-fill, no WPDS fit)_ | `#FFFFFF` |
+| `--a8c-charts-color-annotation` | `--wpds-color-foreground-content-neutral` | `#1e1e1e` |
 | `--a8c-charts-color-trend-up` | `--wpds-color-foreground-content-success-weak` | `#008030` |
 | `--a8c-charts-color-trend-down` | `--wpds-color-foreground-content-error-weak` | `#cc1818` |
 | `--a8c-charts-color-trend-neutral` | `--wpds-color-foreground-content-neutral-weak` | `#707070` |
 | `--a8c-charts-color-background` | `--wpds-color-background-surface-neutral-strong` | `#fff` |
 | `--a8c-charts-color-surface-secondary` | `--wpds-color-background-surface-neutral-weak` | `#f4f4f4` |
 | `--a8c-charts-color-track` | `--wpds-color-background-track-neutral-weak` | `#f0f0f0` |
+| `--a8c-charts-color-tooltip-surface` | _(none — translucent dark surface, no WPDS fit)_ | `rgba(0,0,0,0.85)` |
 | `--a8c-charts-color-focus` | `--wpds-color-stroke-focus` | `#3858e9` |
+
+`--a8c-charts-color-axis` (axis line) and `--a8c-charts-color-tick` (tick marks)
+resolve to the same value as `--a8c-charts-color-grid` by default. They are kept as
+distinct roles so axis, tick marks, and gridlines can be themed independently; each
+maps directly to its own `--wpds-*` token rather than chaining through `grid`.
 
 ## Tier 2 — component-specific variables
 

--- a/projects/js-packages/charts/TOKENS.md
+++ b/projects/js-packages/charts/TOKENS.md
@@ -45,6 +45,12 @@ Instance styling knobs, on the same convention but not shared semantic roles:
 `--a8c-charts-heatmap-cell-intensity` is the one variable without a `{category}`
 segment: it holds a unitless 0–1 scalar consumed inside `color-mix()`, not a colour.
 
+The heatmap Tier-2 variables (`--a8c-charts-color-heatmap-*`,
+`--a8c-charts-dimension-heatmap-*`, `--a8c-charts-heatmap-cell-intensity`) are
+**component-emitted** — the chart sets them from JS per render — not consumer
+override points. `--a8c-charts-border-width-focus` is a genuine override point,
+honoured by both the leaderboard and heatmap focus rings.
+
 ## Public override variables
 
 These are documented, supported override points. Deprecated names still work — they

--- a/projects/js-packages/charts/TOKENS.md
+++ b/projects/js-packages/charts/TOKENS.md
@@ -49,8 +49,7 @@ Instance styling knobs, on the same convention but not shared semantic roles:
 `--a8c-charts-border-radius-leaderboard-bar`,
 `--a8c-charts-dimension-leaderboard-bar-hover-inset`,
 `--a8c-charts-color-zoom-*`, `--a8c-charts-color-heatmap-*`,
-`--a8c-charts-dimension-heatmap-*`, `--a8c-charts-heatmap-cell-intensity`,
-`--a8c-charts-border-width-focus`.
+`--a8c-charts-dimension-heatmap-*`, `--a8c-charts-heatmap-cell-intensity`.
 
 `--a8c-charts-heatmap-cell-intensity` is the one variable without a `{category}`
 segment: it holds a unitless 0–1 scalar consumed inside `color-mix()`, not a colour.
@@ -58,8 +57,7 @@ segment: it holds a unitless 0–1 scalar consumed inside `color-mix()`, not a c
 The heatmap Tier-2 variables (`--a8c-charts-color-heatmap-*`,
 `--a8c-charts-dimension-heatmap-*`, `--a8c-charts-heatmap-cell-intensity`) are
 **component-emitted** — the chart sets them from JS per render — not consumer
-override points. `--a8c-charts-border-width-focus` is a genuine override point,
-honoured by both the leaderboard and heatmap focus rings.
+override points.
 
 ## Public override variables
 

--- a/projects/js-packages/charts/TOKENS.md
+++ b/projects/js-packages/charts/TOKENS.md
@@ -1,0 +1,58 @@
+# Charts CSS custom-property catalog
+
+`@automattic/charts` exposes its themeable values as CSS custom properties under a
+single convention: `--a8c-charts-{category}-{name}`. `{category}` mirrors the WPDS
+token type (`color`, `dimension`, `border-radius`, `border-width`).
+
+## How it resolves today
+
+Nothing emits these variables at runtime yet (that is CHARTS-203). Each reference in
+the library carries its default inline as a fallback:
+
+```scss
+stroke: var(--a8c-charts-color-grid, var(--wpds-color-stroke-surface-neutral, #dbdbdb));
+```
+
+So an `--a8c-charts-*` variable you set on a chart container wins; otherwise the
+mapped `--wpds-*` token wins; otherwise the spec-value hex wins. Setting any
+`--a8c-charts-*` variable on a chart ancestor overrides that role.
+
+## Tier 1 — semantic catalog (shared, themeable roles)
+
+| Role | Maps to `--wpds-*` | Fallback |
+|---|---|---|
+| `--a8c-charts-color-grid` | `--wpds-color-stroke-surface-neutral` | `#dbdbdb` |
+| `--a8c-charts-color-label` | `--wpds-color-foreground-content-neutral` | `#1e1e1e` |
+| `--a8c-charts-color-label-secondary` | `--wpds-color-foreground-content-neutral-weak` | `#707070` |
+| `--a8c-charts-color-label-inverse` | `--wpds-color-foreground-interactive-neutral-strong` | `#f0f0f0` |
+| `--a8c-charts-color-trend-up` | `--wpds-color-foreground-content-success-weak` | `#008030` |
+| `--a8c-charts-color-trend-down` | `--wpds-color-foreground-content-error-weak` | `#cc1818` |
+| `--a8c-charts-color-trend-neutral` | `--wpds-color-foreground-content-neutral-weak` | `#707070` |
+| `--a8c-charts-color-background` | `--wpds-color-background-surface-neutral-strong` | `#fff` |
+| `--a8c-charts-color-surface-secondary` | `--wpds-color-background-surface-neutral-weak` | `#f4f4f4` |
+| `--a8c-charts-color-track` | `--wpds-color-background-track-neutral-weak` | `#f0f0f0` |
+| `--a8c-charts-color-focus` | `--wpds-color-stroke-focus` | `#3858e9` |
+
+## Tier 2 — component-specific variables
+
+Instance styling knobs, on the same convention but not shared semantic roles:
+`--a8c-charts-border-radius-leaderboard-bar`,
+`--a8c-charts-dimension-leaderboard-bar-hover-inset`,
+`--a8c-charts-color-zoom-*`, `--a8c-charts-color-heatmap-*`,
+`--a8c-charts-dimension-heatmap-*`, `--a8c-charts-heatmap-cell-intensity`,
+`--a8c-charts-border-width-focus`.
+
+`--a8c-charts-heatmap-cell-intensity` is the one variable without a `{category}`
+segment: it holds a unitless 0–1 scalar consumed inside `color-mix()`, not a colour.
+
+## Public override variables
+
+These are documented, supported override points. Deprecated names still work — they
+are read as an inner fallback behind the new name:
+
+| New | Deprecated alias |
+|---|---|
+| `--a8c-charts-color-trend-up` | `--charts-trend-up-color` |
+| `--a8c-charts-color-trend-down` | `--charts-trend-down-color` |
+| `--a8c-charts-color-trend-neutral` | `--charts-trend-neutral-color` |
+| `--a8c-charts-border-radius-leaderboard-bar` | `--a8c--charts--leaderboard--bar--border-radius` |

--- a/projects/js-packages/charts/changelog/charts-201-css-var-naming-consistency
+++ b/projects/js-packages/charts/changelog/charts-201-css-var-naming-consistency
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Charts: standardise package CSS custom properties on the --a8c-charts-{category}-{name} naming convention and document the token catalog; existing public override variables keep working via deprecated aliases.

--- a/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/conversion-funnel-chart/conversion-funnel-chart.module.scss
@@ -12,7 +12,7 @@
 
 .main-rate {
 	overflow: hidden;
-	color: var(--wpds-color-foreground-content-neutral, #1e1e1e);
+	color: var(--a8c-charts-color-label, var(--wpds-color-foreground-content-neutral, #1e1e1e));
 	text-overflow: ellipsis;
 	font-size: var(--wpds-typography-font-size-xl, 18px);
 	font-style: normal;
@@ -54,7 +54,7 @@
 }
 
 .step-label {
-	color: var(--wpds-color-foreground-content-neutral-weak, #707070);
+	color: var(--a8c-charts-color-label-secondary, var(--wpds-color-foreground-content-neutral-weak, #707070));
 	font-size: var(--wpds-typography-font-size-sm, 12px);
 	font-weight: var(--wpds-typography-font-weight-regular, 400);
 	line-height: var(--wpds-typography-line-height-xs, 16px);
@@ -64,7 +64,7 @@
 }
 
 .step-rate {
-	color: var(--wpds-color-foreground-content-neutral, #1e1e1e);
+	color: var(--a8c-charts-color-label, var(--wpds-color-foreground-content-neutral, #1e1e1e));
 	font-size: var(--wpds-typography-font-size-md, 13px);
 	font-weight: var(--wpds-typography-font-weight-medium, 499);
 	line-height: var(--wpds-typography-line-height-xs, 16px);
@@ -100,7 +100,7 @@
 }
 
 .tooltip-wrapper {
-	background: var(--wpds-color-background-surface-neutral-strong, #fff);
+	background: var(--a8c-charts-color-background, var(--wpds-color-background-surface-neutral-strong, #fff));
 
 	// Override .visx-tooltip inline styles.
 	border-radius: var(--wpds-border-radius-md, 4px) !important;
@@ -110,7 +110,7 @@
 }
 
 .tooltip-title {
-	color: var(--wpds-color-foreground-content-neutral, #1e1e1e);
+	color: var(--a8c-charts-color-label, var(--wpds-color-foreground-content-neutral, #1e1e1e));
 	font-size: var(--wpds-typography-font-size-sm, 12px);
 	font-style: normal;
 	font-weight: var(--wpds-typography-font-weight-regular, 400);
@@ -118,7 +118,7 @@
 }
 
 .tooltip-content {
-	color: var(--wpds-color-foreground-content-neutral, #1e1e1e);
+	color: var(--a8c-charts-color-label, var(--wpds-color-foreground-content-neutral, #1e1e1e));
 	font-size: var(--wpds-typography-font-size-md, 13px);
 	font-style: normal;
 	font-weight: var(--wpds-typography-font-weight-medium, 499);
@@ -127,6 +127,6 @@
 
 .empty-state {
 	text-align: center;
-	color: var(--wpds-color-foreground-content-neutral-weak, #707070);
+	color: var(--a8c-charts-color-label-secondary, var(--wpds-color-foreground-content-neutral-weak, #707070));
 	font-size: var(--wpds-typography-font-size-lg, 16px);
 }

--- a/projects/js-packages/charts/src/charts/geo-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/geo-chart/stories/index.api.mdx
@@ -89,8 +89,8 @@ The following properties can be customized via the theme system:
 | Property | Type | Default | Description |
 | -------- | ---- | ------- | ----------- |
 | `colors[0]` | `string` | `'#98C8DF'` | Primary color used for data visualization (color axis range) |
-| `backgroundColor` | `string` | `'var(--wpds-color-background-surface-neutral-strong, #fff)'` | Background color of the map |
-| `geoChart.featureFillColor` | `string` | `'var(--wpds-color-background-surface-neutral-weak, #f4f4f4)'` | Fill color for countries without data values |
+| `backgroundColor` | `string` | `'var(--a8c-charts-color-background, var(--wpds-color-background-surface-neutral-strong, #fff))'` | Background color of the map |
+| `geoChart.featureFillColor` | `string` | `'var(--a8c-charts-color-surface-secondary, var(--wpds-color-background-surface-neutral-weak, #f4f4f4))'` | Fill color for countries without data values |
 
 ## Country Identification
 

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
@@ -1,3 +1,8 @@
+// Focus-ring width shared across the grid and cell-selected focus outlines. A
+// Sass var, not a custom property: a compile-time constant scoped to this
+// module, so it needs no runtime cascade and never lands on the DOM.
+$focus-ring-width: var(--wpds-border-width-focus, var(--wp-admin-border-width-focus, 2px));
+
 .heatmap-chart {
 	width: 100%;
 	height: 100%;
@@ -29,7 +34,7 @@
 
 	&:focus-visible {
 		outline:
-			var(--a8c-charts-border-width-focus, var(--wpds-border-width-focus, var(--wp-admin-border-width-focus, 2px))) solid
+			$focus-ring-width solid
 			var(--a8c-charts-color-focus, var(--wpds-color-stroke-focus, var(--wp-admin-theme-color, #3858e9)));
 		outline-offset: 2px;
 		border-radius: var(--wpds-border-radius-sm, 2px);
@@ -102,9 +107,9 @@
 
 .heatmap-chart__cell--selected {
 	outline:
-		var(--a8c-charts-border-width-focus, var(--wpds-border-width-focus, var(--wp-admin-border-width-focus, 2px))) solid
+		$focus-ring-width solid
 		var(--a8c-charts-color-focus, var(--wpds-color-stroke-focus, var(--wp-admin-theme-color, #3858e9)));
-	outline-offset: calc(-1 * var(--a8c-charts-border-width-focus, var(--wpds-border-width-focus, var(--wp-admin-border-width-focus, 2px))));
+	outline-offset: calc(-1 * #{$focus-ring-width});
 }
 
 .heatmap-chart__cell-value {

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
@@ -14,14 +14,14 @@
 
 .heatmap-chart__empty {
 	padding: var(--wpds-dimension-padding-lg, 16px);
-	color: var(--wpds-color-foreground-content-neutral-weak, #707070);
+	color: var(--a8c-charts-color-label-secondary, var(--wpds-color-foreground-content-neutral-weak, #707070));
 }
 
 // Track template is set inline because CSS `repeat()` won't take a `var()`
 // count. ARIA rows are `display: contents` so their cells join this grid.
 .heatmap-chart__grid {
 	display: grid;
-	gap: var(--heatmap-cell-gap, var(--wpds-dimension-gap-xs, 4px));
+	gap: var(--a8c-charts-dimension-heatmap-cell-gap, var(--wpds-dimension-gap-xs, 4px));
 	flex: 1 1 0;
 	width: 100%;
 	// Override flex's auto minimum so short widgets do not scroll.
@@ -30,7 +30,7 @@
 	&:focus-visible {
 		outline:
 			var(--wpds-border-width-focus, var(--wp-admin-border-width-focus, 2px)) solid
-			var(--wpds-color-stroke-focus, var(--wp-admin-theme-color, #3858e9));
+			var(--a8c-charts-color-focus, var(--wpds-color-stroke-focus, var(--wp-admin-theme-color, #3858e9)));
 		outline-offset: 2px;
 		border-radius: var(--wpds-border-radius-sm, 2px);
 	}
@@ -58,7 +58,7 @@
 
 .heatmap-chart__col-label,
 .heatmap-chart__row-label {
-	color: var(--wpds-color-foreground-content-neutral-weak, #707070);
+	color: var(--a8c-charts-color-label-secondary, var(--wpds-color-foreground-content-neutral-weak, #707070));
 	font-size: var(--wpds-typography-font-size-xs, 11px);
 	white-space: nowrap;
 	overflow: visible;
@@ -84,7 +84,7 @@
 	min-height: 0;
 	border-radius: var(--wpds-border-radius-sm, 2px);
 	// Empty (no-data) default; cells with a value override it below.
-	background: var(--wpds-color-background-track-neutral-weak, #f0f0f0);
+	background: var(--a8c-charts-color-track, var(--wpds-color-background-track-neutral-weak, #f0f0f0));
 }
 
 // An empty grid slot (calendar ragged edges): keeps its track but paints and
@@ -97,30 +97,30 @@
 // Floor the mix at 15% so the lowest value stays visibly tinted, distinct from
 // an empty cell.
 .heatmap-chart__cell--filled {
-	background: color-mix(in sRGB, var(--heatmap-primary) calc((0.15 + 0.85 * var(--intensity)) * 100%), var(--heatmap-bg, #fff));
+	background: color-mix(in sRGB, var(--a8c-charts-color-heatmap-primary) calc((0.15 + 0.85 * var(--a8c-charts-heatmap-cell-intensity)) * 100%), var(--a8c-charts-color-heatmap-background, #fff));
 }
 
 .heatmap-chart__cell--selected {
 	outline:
 		var(--wpds-border-width-focus, var(--wp-admin-border-width-focus, 2px)) solid
-		var(--wpds-color-stroke-focus, var(--wp-admin-theme-color, #3858e9));
+		var(--a8c-charts-color-focus, var(--wpds-color-stroke-focus, var(--wp-admin-theme-color, #3858e9)));
 	outline-offset: calc(-1 * var(--wpds-border-width-focus, var(--wp-admin-border-width-focus, 2px)));
 }
 
 .heatmap-chart__cell-value {
-	color: var(--wpds-color-foreground-content-neutral, #1e1e1e);
+	color: var(--a8c-charts-color-label, var(--wpds-color-foreground-content-neutral, #1e1e1e));
 	font-size: var(--wpds-typography-font-size-md, 13px);
 }
 
 // Light text on fills dark enough to out-contrast dark text (decided in JS from
 // the blended fill luminance).
 .heatmap-chart__cell--strong .heatmap-chart__cell-value {
-	color: var(--wpds-color-foreground-interactive-neutral-strong, #f0f0f0);
+	color: var(--a8c-charts-color-label-inverse, var(--wpds-color-foreground-interactive-neutral-strong, #f0f0f0));
 }
 
 .heatmap-chart__legend-swatch {
 	width: var(--wpds-dimension-size-3xs, 12px);
 	height: var(--wpds-dimension-size-3xs, 12px);
 	border-radius: var(--wpds-border-radius-sm, 2px);
-	background: color-mix(in sRGB, var(--heatmap-primary) calc((0.15 + 0.85 * var(--intensity)) * 100%), var(--heatmap-bg, #fff));
+	background: color-mix(in sRGB, var(--a8c-charts-color-heatmap-primary) calc((0.15 + 0.85 * var(--a8c-charts-heatmap-cell-intensity)) * 100%), var(--a8c-charts-color-heatmap-background, #fff));
 }

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.module.scss
@@ -29,7 +29,7 @@
 
 	&:focus-visible {
 		outline:
-			var(--wpds-border-width-focus, var(--wp-admin-border-width-focus, 2px)) solid
+			var(--a8c-charts-border-width-focus, var(--wpds-border-width-focus, var(--wp-admin-border-width-focus, 2px))) solid
 			var(--a8c-charts-color-focus, var(--wpds-color-stroke-focus, var(--wp-admin-theme-color, #3858e9)));
 		outline-offset: 2px;
 		border-radius: var(--wpds-border-radius-sm, 2px);
@@ -102,9 +102,9 @@
 
 .heatmap-chart__cell--selected {
 	outline:
-		var(--wpds-border-width-focus, var(--wp-admin-border-width-focus, 2px)) solid
+		var(--a8c-charts-border-width-focus, var(--wpds-border-width-focus, var(--wp-admin-border-width-focus, 2px))) solid
 		var(--a8c-charts-color-focus, var(--wpds-color-stroke-focus, var(--wp-admin-theme-color, #3858e9)));
-	outline-offset: calc(-1 * var(--wpds-border-width-focus, var(--wp-admin-border-width-focus, 2px)));
+	outline-offset: calc(-1 * var(--a8c-charts-border-width-focus, var(--wpds-border-width-focus, var(--wp-admin-border-width-focus, 2px))));
 }
 
 .heatmap-chart__cell-value {

--- a/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/heatmap-chart.tsx
@@ -277,20 +277,20 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 	// and a min floor makes the grid overflow (for a scrollable wrapper)
 	// rather than crushing cells on long ranges.
 	const columnTrack = compact
-		? 'var(--heatmap-cell-size)'
+		? 'var(--a8c-charts-dimension-heatmap-cell-size)'
 		: `minmax(${ minCellWidth ?? 0 }px, ${ maxCellWidth ? `${ maxCellWidth }px` : '1fr' })`;
 	const rowTrack = compact
-		? 'var(--heatmap-cell-size)'
+		? 'var(--a8c-charts-dimension-heatmap-cell-size)'
 		: `minmax(${ minCellHeight ?? 0 }px, ${ maxCellHeight ? `${ maxCellHeight }px` : '1fr' })`;
 	const gridStyle: Record< string, string | number > = {
-		'--heatmap-primary': primaryColorHex,
-		'--heatmap-bg': theme.backgroundColor,
+		'--a8c-charts-color-heatmap-primary': primaryColorHex,
+		'--a8c-charts-color-heatmap-background': theme.backgroundColor,
 		gridTemplateColumns: `auto repeat(${ columns }, ${ columnTrack })`,
 		gridTemplateRows: `auto repeat(${ rows }, ${ rowTrack })`,
 	};
 	if ( compact ) {
-		gridStyle[ '--heatmap-cell-gap' ] = `${ compactCellGap }px`;
-		gridStyle[ '--heatmap-cell-size' ] = `${ compactCellSize }px`;
+		gridStyle[ '--a8c-charts-dimension-heatmap-cell-gap' ] = `${ compactCellGap }px`;
+		gridStyle[ '--a8c-charts-dimension-heatmap-cell-size' ] = `${ compactCellSize }px`;
 	}
 
 	const activeDescendant =
@@ -419,7 +419,11 @@ const HeatmapChartInternal: FC< HeatmapChartProps > = ( {
 														selectedIndex === flatIndex,
 												} ) }
 												style={
-													present ? ( { '--intensity': normalized } as CSSProperties ) : undefined
+													present
+														? ( {
+																'--a8c-charts-heatmap-cell-intensity': normalized,
+														  } as CSSProperties )
+														: undefined
 												}
 												onMouseMove={ handleCellMouseMove }
 												onMouseLeave={ handleCellMouseLeave }

--- a/projects/js-packages/charts/src/charts/heatmap-chart/private/heatmap-legend.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/private/heatmap-legend.tsx
@@ -37,9 +37,9 @@ export const HeatmapLegend: FC< HeatmapLegendProps > = ( { steps = 5, lessLabel,
 							className={ styles[ 'heatmap-chart__legend-swatch' ] }
 							style={
 								{
-									'--heatmap-primary': primaryColorHex,
-									'--heatmap-bg': backgroundColor,
-									'--intensity': intensity,
+									'--a8c-charts-color-heatmap-primary': primaryColorHex,
+									'--a8c-charts-color-heatmap-background': backgroundColor,
+									'--a8c-charts-heatmap-cell-intensity': intensity,
 								} as CSSProperties
 							}
 						/>

--- a/projects/js-packages/charts/src/charts/heatmap-chart/test/heatmap-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/heatmap-chart/test/heatmap-chart.test.tsx
@@ -285,7 +285,7 @@ describe( 'HeatmapChart', () => {
 		renderChart();
 		const grid = screen.getByRole( 'grid', { name: /heatmap/i } );
 		// Non-compact sets no inline gap — the SCSS falls back to the WPDS token.
-		expect( grid.style.getPropertyValue( '--heatmap-cell-gap' ) ).toBe( '' );
+		expect( grid.style.getPropertyValue( '--a8c-charts-dimension-heatmap-cell-gap' ) ).toBe( '' );
 	} );
 
 	test( 'applies the compact gap inline from the theme compactCellGap', () => {
@@ -295,7 +295,9 @@ describe( 'HeatmapChart', () => {
 			</GlobalChartsProvider>
 		);
 		const grid = screen.getByRole( 'grid', { name: /heatmap/i } );
-		expect( grid.style.getPropertyValue( '--heatmap-cell-gap' ) ).toBe( '3px' );
+		expect( grid.style.getPropertyValue( '--a8c-charts-dimension-heatmap-cell-gap' ) ).toBe(
+			'3px'
+		);
 	} );
 
 	test( 'sizes compact cells to the theme compactCellSize', () => {
@@ -305,9 +307,13 @@ describe( 'HeatmapChart', () => {
 			</GlobalChartsProvider>
 		);
 		const grid = screen.getByRole( 'grid', { name: /heatmap/i } );
-		expect( grid.style.getPropertyValue( '--heatmap-cell-size' ) ).toBe( '20px' );
+		expect( grid.style.getPropertyValue( '--a8c-charts-dimension-heatmap-cell-size' ) ).toBe(
+			'20px'
+		);
 		// Compact track template is built from the fixed cell size.
-		expect( grid.style.gridTemplateColumns ).toContain( 'var(--heatmap-cell-size)' );
+		expect( grid.style.gridTemplateColumns ).toContain(
+			'var(--a8c-charts-dimension-heatmap-cell-size)'
+		);
 	} );
 
 	test( 'caps cell width without changing the normal vertical layout', () => {
@@ -343,7 +349,7 @@ describe( 'HeatmapChart', () => {
 	test( 'applies the primaryColor prop as the cell-scale color', () => {
 		renderChart( { primaryColor: '#abcdef' } );
 		const grid = screen.getByRole( 'grid', { name: /heatmap/i } );
-		expect( grid.style.getPropertyValue( '--heatmap-primary' ) ).toBe( '#abcdef' );
+		expect( grid.style.getPropertyValue( '--a8c-charts-color-heatmap-primary' ) ).toBe( '#abcdef' );
 	} );
 
 	test( 'resolves primaryColor from the chart theme', () => {
@@ -353,7 +359,7 @@ describe( 'HeatmapChart', () => {
 			</GlobalChartsProvider>
 		);
 		const grid = screen.getByRole( 'grid', { name: /heatmap/i } );
-		expect( grid.style.getPropertyValue( '--heatmap-primary' ) ).toBe( '#0a0b0c' );
+		expect( grid.style.getPropertyValue( '--a8c-charts-color-heatmap-primary' ) ).toBe( '#0a0b0c' );
 	} );
 
 	test( 'falls back to the palette colors[0] when no prop or theme primaryColor is set', () => {
@@ -363,7 +369,7 @@ describe( 'HeatmapChart', () => {
 			</GlobalChartsProvider>
 		);
 		const grid = screen.getByRole( 'grid', { name: /heatmap/i } );
-		expect( grid.style.getPropertyValue( '--heatmap-primary' ) ).toBe( '#0a0b0c' );
+		expect( grid.style.getPropertyValue( '--a8c-charts-color-heatmap-primary' ) ).toBe( '#0a0b0c' );
 	} );
 
 	test( 'the unresponsive export pins explicit width and height', () => {

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
@@ -123,12 +123,13 @@
 	padding-block: 0;
 }
 
-.row {
-	// Sourced from the catalog token so an ancestor override of
-	// `--a8c-charts-border-width-focus` is honoured (the same point the
-	// heatmap uses); then WPDS, then the wp-admin fallback.
-	--focus-ring-width: var(--a8c-charts-border-width-focus, var(--wpds-border-width-focus, var(--wp-admin-border-width-focus, 2px)));
+// Focus-ring width shared so a standard row's reserved padding and an
+// interactive row's outline (and its inset offset) stay equal. A Sass var,
+// not a custom property: a compile-time constant scoped to this module, so it
+// needs no runtime cascade and never lands on the DOM as an unprefixed var.
+$focus-ring-width: var(--wpds-border-width-focus, var(--wp-admin-border-width-focus, 2px));
 
+.row {
 	display: grid;
 	grid-column: 1 / -1;
 	grid-template-columns: subgrid;
@@ -136,7 +137,7 @@
 	// Every row reserves the same space for the interactive focus ring. Keeping
 	// this on the shared wrapper ensures that adding or removing an action never
 	// changes the row height or subgrid column edges.
-	padding: var(--focus-ring-width);
+	padding: $focus-ring-width;
 }
 
 .interactiveRow {
@@ -203,12 +204,12 @@
 	&:focus-visible {
 		border-radius: var(--wpds-border-radius-sm, 2px);
 		outline:
-			var(--focus-ring-width) solid
+			$focus-ring-width solid
 			var(--a8c-charts-color-focus, var(--wpds-color-stroke-focus, var(--wp-admin-theme-color, #3858e9)));
 		// Inset by its own width so the outer edge hugs the row boundary: the
 		// outline then sits in the shared row padding, clear of the bar, and stays
 		// inside the overflow:auto container that would clip an outset ring.
-		outline-offset: calc(-1 * var(--focus-ring-width));
+		outline-offset: calc(-1 * #{$focus-ring-width});
 	}
 }
 

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
@@ -60,7 +60,7 @@
 		// row's fixed-pixel hover inset from collapsing a narrow bar to nothing.
 		min-width: var(--wpds-dimension-size-5xs, 4px);
 
-		border-radius: var(--a8c--charts--leaderboard--bar--border-radius, 9999px);
+		border-radius: var(--a8c-charts-border-radius-leaderboard-bar, var(--a8c--charts--leaderboard--bar--border-radius, 9999px));
 		z-index: -1; /* places it behind the label */
 
 		&--animated {
@@ -104,7 +104,7 @@
 .emptyState {
 	padding: var(--wpds-dimension-padding-3xl, 32px) var(--wpds-dimension-padding-lg, 16px);
 	text-align: center;
-	color: var(--wpds-color-foreground-content-neutral-weak, #707070);
+	color: var(--a8c-charts-color-label-secondary, var(--wpds-color-foreground-content-neutral-weak, #707070));
 	font-size: var(--wpds-typography-font-size-md, 13px);
 	font-style: italic;
 }
@@ -124,7 +124,10 @@
 }
 
 .row {
-	--focus-ring-width: var(--wpds-border-width-focus, var(--wp-admin-border-width-focus, 2px));
+	// Sourced from the catalog token so an ancestor override of
+	// `--a8c-charts-border-width-focus` is honoured (the same point the
+	// heatmap uses); then WPDS, then the wp-admin fallback.
+	--focus-ring-width: var(--a8c-charts-border-width-focus, var(--wpds-border-width-focus, var(--wp-admin-border-width-focus, 2px)));
 
 	display: grid;
 	grid-column: 1 / -1;
@@ -176,14 +179,14 @@
 
 		// Fixed reserve for the chevron — the value slides by it in full, and the
 		// bar width inset (see leaderboard-chart.tsx) scales it by the bar's share.
-		--a8c--charts--leaderboard--bar--hover-inset: var(--wpds-dimension-gap-2xl, 32px);
+		--a8c-charts-dimension-leaderboard-bar-hover-inset: var(--wpds-dimension-gap-2xl, 32px);
 
 		.bar {
 			opacity: 0.5;
 		}
 
 		.valueContainer {
-			transform: translateX(calc(var(--a8c--charts--leaderboard--bar--hover-inset) * -1));
+			transform: translateX(calc(var(--a8c-charts-dimension-leaderboard-bar-hover-inset) * -1));
 		}
 
 		.chevron {
@@ -194,14 +197,14 @@
 	// In RTL the value slides toward the inline start the other way (rightward).
 	[dir="rtl"] &:hover .valueContainer,
 	[dir="rtl"] &:focus-visible .valueContainer {
-		transform: translateX(var(--a8c--charts--leaderboard--bar--hover-inset));
+		transform: translateX(var(--a8c-charts-dimension-leaderboard-bar-hover-inset));
 	}
 
 	&:focus-visible {
 		border-radius: var(--wpds-border-radius-sm, 2px);
 		outline:
 			var(--focus-ring-width) solid
-			var(--wpds-color-stroke-focus, var(--wp-admin-theme-color, #3858e9));
+			var(--a8c-charts-color-focus, var(--wpds-color-stroke-focus, var(--wp-admin-theme-color, #3858e9)));
 		// Inset by its own width so the outer edge hugs the row boundary: the
 		// outline then sits in the shared row padding, clear of the bar, and stays
 		// inside the overflow:auto container that would clip an outset ring.
@@ -216,7 +219,7 @@
 	bottom: 0;
 	margin-block: auto;
 	opacity: 0;
-	color: var(--wpds-color-foreground-content-neutral-weak, #707070);
+	color: var(--a8c-charts-color-label-secondary, var(--wpds-color-foreground-content-neutral-weak, #707070));
 	transition:
 		opacity var(--wpds-motion-duration-sm, 100ms)
 		var(--wpds-motion-easing-subtle, cubic-bezier(0.15, 0, 0.15, 1));

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
@@ -62,7 +62,7 @@ const defaultDeltaFormatter = ( value: number ): string => {
  * @return A CSS width value.
  */
 const getBarWidth = ( share: number ): string =>
-	`calc(${ share }% - var(--a8c--charts--leaderboard--bar--hover-inset, 0px) * ${ share } / 100)`;
+	`calc(${ share }% - var(--a8c-charts-dimension-leaderboard-bar-hover-inset, 0px) * ${ share } / 100)`;
 
 const hasComparisonValue = (
 	entry: LeaderboardEntry

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.api.mdx
@@ -56,7 +56,7 @@ interface LeaderboardEntry {
 
 ```typescript
 type CustomProperties = {
-	'--a8c--charts--leaderboard--bar--border-radius'?: string;
+	'--a8c-charts-border-radius-leaderboard-bar'?: string;
 };
 ```
 

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.docs.mdx
@@ -442,7 +442,7 @@ Combine overlay labels with custom styling and transparent colors:
 		withOverlayLabel={true}
 		primaryColor="rgba(56, 88, 233, 0.08)" // Semi-transparent
 		style={{
-			'--a8c--charts--leaderboard--bar--border-radius': '4px',
+			'--a8c-charts-border-radius-leaderboard-bar': '4px',
 		}}
 	/>` }
 />
@@ -456,7 +456,7 @@ The component supports CSS custom properties for advanced styling:
 	code={ `<LeaderboardChart
 		data={data}
 		style={{
-			'--a8c--charts--leaderboard--bar--border-radius': '8px',
+			'--a8c-charts-border-radius-leaderboard-bar': '8px',
 		}}
 		className="myCustomChart"
 	/>` }
@@ -465,7 +465,7 @@ The component supports CSS custom properties for advanced styling:
 <Source
 	language="css"
 	code={ `.myCustomChart {
-		--a8c--charts--leaderboard--bar--border-radius: 8px;
+		--a8c-charts-border-radius-leaderboard-bar: 8px;
 	}` }
 />
 

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
@@ -215,7 +215,7 @@ export const MissingComparisonRowsWithOverlayLabel: Story = {
 		withOverlayLabel: true,
 		loading: false,
 		style: {
-			'--a8c--charts--leaderboard--bar--border-radius': '4px',
+			'--a8c-charts-border-radius-leaderboard-bar': '4px',
 		},
 	},
 	parameters: {
@@ -260,7 +260,7 @@ export const Interactive: Story = {
 		withComparison: true,
 		withOverlayLabel: true,
 		style: {
-			'--a8c--charts--leaderboard--bar--border-radius': '4px',
+			'--a8c-charts-border-radius-leaderboard-bar': '4px',
 		},
 	},
 	render: args => <LeaderboardChartWithOverlayLabelImage { ...args } />,
@@ -508,7 +508,7 @@ export const OverlayLabelWithImage: Story = {
 		withOverlayLabel: true,
 		loading: false,
 		style: {
-			'--a8c--charts--leaderboard--bar--border-radius': '4px',
+			'--a8c-charts-border-radius-leaderboard-bar': '4px',
 		},
 	},
 	render: args => <LeaderboardChartWithOverlayLabelImage { ...args } />,

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/types.ts
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/types.ts
@@ -64,6 +64,8 @@ export interface LeaderboardChartProps
 	 * Custom styling for the chart container
 	 */
 	style?: React.CSSProperties & {
+		'--a8c-charts-border-radius-leaderboard-bar'?: string;
+		/** @deprecated Use `--a8c-charts-border-radius-leaderboard-bar`. */
 		'--a8c--charts--leaderboard--bar--border-radius'?: string;
 	};
 

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.module.scss
@@ -18,8 +18,8 @@
 
 	&__tooltip,
 	&__annotation-label-popover {
-		background: var(--wpds-color-background-surface-neutral-strong, #fff);
-		color: var(--wpds-color-foreground-content-neutral, #1e1e1e);
+		background: var(--a8c-charts-color-background, var(--wpds-color-background-surface-neutral-strong, #fff));
+		color: var(--a8c-charts-color-label, var(--wpds-color-foreground-content-neutral, #1e1e1e));
 		padding: var(--wpds-dimension-padding-sm, 8px);
 	}
 

--- a/projects/js-packages/charts/src/charts/private/grid-control/grid-control.module.scss
+++ b/projects/js-packages/charts/src/charts/private/grid-control/grid-control.module.scss
@@ -1,7 +1,7 @@
 .grid-control {
 
 	:global(.visx-line) {
-		stroke: var(--wpds-color-stroke-surface-neutral, #dbdbdb);
+		stroke: var(--a8c-charts-color-grid, var(--wpds-color-stroke-surface-neutral, #dbdbdb));
 		stroke-width: 1px;
 		shape-rendering: crispEdges;
 	}

--- a/projects/js-packages/charts/src/charts/private/svg-empty-state/svg-empty-state.module.scss
+++ b/projects/js-packages/charts/src/charts/private/svg-empty-state/svg-empty-state.module.scss
@@ -1,5 +1,5 @@
 .svg-empty-state {
 	text-align: center;
 	font-size: var(--wpds-typography-font-size-md, 13px);
-	color: var(--wpds-color-foreground-content-neutral-weak, #707070);
+	color: var(--a8c-charts-color-label-secondary, var(--wpds-color-foreground-content-neutral-weak, #707070));
 }

--- a/projects/js-packages/charts/src/charts/private/x-zoom.module.scss
+++ b/projects/js-packages/charts/src/charts/private/x-zoom.module.scss
@@ -1,12 +1,13 @@
 .x-zoom {
 
-	// All zoom controls read --a8c-charts-color-zoom-* names. The translucent
-	// rgba overlays (selection fill/stroke, reset background/border) have no WPDS
-	// equivalent, so they fall back to their rgba literals; the opaque foreground
-	// and focus colors fall back to WPDS tokens.
+	// The zoom control's bespoke colours are inlined, not exposed as
+	// --a8c-charts-color-zoom-* override vars. The control is slated for rework
+	// (reset button -> @wordpress/ui Button), so it is deliberately not a public
+	// theming surface. Focus tracks the shared --a8c-charts-color-focus role; the
+	// button text uses the WPDS content-foreground token.
 	&__selection {
-		fill: var(--a8c-charts-color-zoom-selection-fill, rgba(56, 88, 233, 0.16));
-		stroke: var(--a8c-charts-color-zoom-selection-stroke, rgba(56, 88, 233, 0.65));
+		fill: rgba(56, 88, 233, 0.16);
+		stroke: rgba(56, 88, 233, 0.65);
 		stroke-width: var(--wpds-border-width-xs, 1px);
 		pointer-events: none;
 	}
@@ -22,21 +23,21 @@
 		width: 28px;
 		height: 28px;
 		padding: 0;
-		background: var(--a8c-charts-color-zoom-reset-background, rgba(255, 255, 255, 0.92));
-		color: var(--a8c-charts-color-zoom-reset-foreground, var(--wpds-color-foreground-content-neutral, #1e1e1e));
+		background: rgba(255, 255, 255, 0.92);
+		color: var(--wpds-color-foreground-content-neutral, #1e1e1e);
 		border:
 			var(--wpds-border-width-xs, 1px) solid
-			var(--a8c-charts-color-zoom-reset-border, rgba(0, 0, 0, 0.16));
+			rgba(0, 0, 0, 0.16);
 		border-radius: var(--wpds-border-radius-md, 4px);
 		cursor: pointer;
 		box-shadow: var(--wpds-elevation-xs, 0 1px 1px 0 #00000008, 0 1px 2px 0 #00000005, 0 3px 3px 0 #00000005, 0 4px 4px 0 #00000003);
 
 		&:hover {
-			background: var(--a8c-charts-color-zoom-reset-background-hover, rgba(255, 255, 255, 1));
+			background: rgba(255, 255, 255, 1);
 		}
 
 		&:focus-visible {
-			outline: 2px solid var(--a8c-charts-color-zoom-reset-focus, var(--a8c-charts-color-focus, var(--wpds-color-stroke-focus, #3858e9)));
+			outline: 2px solid var(--a8c-charts-color-focus, var(--wpds-color-stroke-focus, #3858e9));
 			outline-offset: 1px;
 		}
 	}

--- a/projects/js-packages/charts/src/charts/private/x-zoom.module.scss
+++ b/projects/js-packages/charts/src/charts/private/x-zoom.module.scss
@@ -4,8 +4,8 @@
 	// background/border) have no WPDS equivalent and stay as-is; only the
 	// opaque foreground and focus colors are tokenized.
 	&__selection {
-		fill: var(--charts-zoom-selection-fill, rgba(56, 88, 233, 0.16));
-		stroke: var(--charts-zoom-selection-stroke, rgba(56, 88, 233, 0.65));
+		fill: var(--a8c-charts-color-zoom-selection-fill, rgba(56, 88, 233, 0.16));
+		stroke: var(--a8c-charts-color-zoom-selection-stroke, rgba(56, 88, 233, 0.65));
 		stroke-width: var(--wpds-border-width-xs, 1px);
 		pointer-events: none;
 	}
@@ -21,21 +21,21 @@
 		width: 28px;
 		height: 28px;
 		padding: 0;
-		background: var(--charts-zoom-reset-bg, rgba(255, 255, 255, 0.92));
-		color: var(--charts-zoom-reset-fg, var(--wpds-color-foreground-content-neutral, #1e1e1e));
+		background: var(--a8c-charts-color-zoom-reset-background, rgba(255, 255, 255, 0.92));
+		color: var(--a8c-charts-color-zoom-reset-foreground, var(--wpds-color-foreground-content-neutral, #1e1e1e));
 		border:
 			var(--wpds-border-width-xs, 1px) solid
-			var(--charts-zoom-reset-border, rgba(0, 0, 0, 0.16));
+			var(--a8c-charts-color-zoom-reset-border, rgba(0, 0, 0, 0.16));
 		border-radius: var(--wpds-border-radius-md, 4px);
 		cursor: pointer;
 		box-shadow: var(--wpds-elevation-xs, 0 1px 1px 0 #00000008, 0 1px 2px 0 #00000005, 0 3px 3px 0 #00000005, 0 4px 4px 0 #00000003);
 
 		&:hover {
-			background: var(--charts-zoom-reset-bg-hover, rgba(255, 255, 255, 1));
+			background: var(--a8c-charts-color-zoom-reset-background-hover, rgba(255, 255, 255, 1));
 		}
 
 		&:focus-visible {
-			outline: 2px solid var(--charts-zoom-reset-focus, var(--wpds-color-stroke-focus, #3858e9));
+			outline: 2px solid var(--a8c-charts-color-zoom-reset-focus, var(--wpds-color-stroke-focus, #3858e9));
 			outline-offset: 1px;
 		}
 	}

--- a/projects/js-packages/charts/src/charts/private/x-zoom.module.scss
+++ b/projects/js-packages/charts/src/charts/private/x-zoom.module.scss
@@ -36,7 +36,7 @@
 		}
 
 		&:focus-visible {
-			outline: 2px solid var(--a8c-charts-color-zoom-reset-focus, var(--wpds-color-stroke-focus, #3858e9));
+			outline: 2px solid var(--a8c-charts-color-zoom-reset-focus, var(--a8c-charts-color-focus, var(--wpds-color-stroke-focus, #3858e9)));
 			outline-offset: 1px;
 		}
 	}

--- a/projects/js-packages/charts/src/charts/private/x-zoom.module.scss
+++ b/projects/js-packages/charts/src/charts/private/x-zoom.module.scss
@@ -1,8 +1,9 @@
 .x-zoom {
 
-	// The translucent rgba overlay colors (selection fill/stroke, reset
-	// background/border) have no WPDS equivalent and stay as-is; only the
-	// opaque foreground and focus colors are tokenized.
+	// All zoom controls read --a8c-charts-color-zoom-* names. The translucent
+	// rgba overlays (selection fill/stroke, reset background/border) have no WPDS
+	// equivalent, so they fall back to their rgba literals; the opaque foreground
+	// and focus colors fall back to WPDS tokens.
 	&__selection {
 		fill: var(--a8c-charts-color-zoom-selection-fill, rgba(56, 88, 233, 0.16));
 		stroke: var(--a8c-charts-color-zoom-selection-stroke, rgba(56, 88, 233, 0.65));

--- a/projects/js-packages/charts/src/components/tooltip/base-tooltip.module.scss
+++ b/projects/js-packages/charts/src/components/tooltip/base-tooltip.module.scss
@@ -2,8 +2,9 @@
 	padding: var(--wpds-dimension-padding-sm, 8px);
 	// No WPDS token fits a translucent dark tooltip surface:
 	// bg-interactive-neutral-strong is opaque, and there is no
-	// white-on-dark content foreground token.
-	background-color: rgba(0, 0, 0, 0.85);
+	// white-on-dark content foreground token. The role carries the
+	// hardcoded translucent value as its fallback.
+	background-color: var(--a8c-charts-color-tooltip-surface, rgba(0, 0, 0, 0.85));
 	color: #fff;
 	border-radius: var(--wpds-border-radius-md, 4px);
 	font-size: var(--wpds-typography-font-size-md, 13px);

--- a/projects/js-packages/charts/src/components/trend-indicator/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/components/trend-indicator/stories/index.api.mdx
@@ -78,9 +78,9 @@ resolves to the accessible WPDS semantic token shown below:
 
 | Property | Default (WPDS token) | Description |
 |----------|----------------------|-------------|
-| `--charts-trend-up-color` | `--wpds-color-foreground-content-success-weak` (`#008030`) | Color for upward trends (green) |
-| `--charts-trend-down-color` | `--wpds-color-foreground-content-error-weak` (`#cc1818`) | Color for downward trends (red) |
-| `--charts-trend-neutral-color` | `--wpds-color-foreground-content-neutral-weak` (`#707070`) | Color for neutral trends (gray) |
+| `--a8c-charts-color-trend-up` | `--wpds-color-foreground-content-success-weak` (`#008030`) | Colour for upward trends. Deprecated alias: `--charts-trend-up-color`. |
+| `--a8c-charts-color-trend-down` | `--wpds-color-foreground-content-error-weak` (`#cc1818`) | Colour for downward trends. Deprecated alias: `--charts-trend-down-color`. |
+| `--a8c-charts-color-trend-neutral` | `--wpds-color-foreground-content-neutral-weak` (`#707070`) | Colour for neutral trends. Deprecated alias: `--charts-trend-neutral-color`. |
 
 ## Accessibility Attributes
 

--- a/projects/js-packages/charts/src/components/trend-indicator/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/components/trend-indicator/stories/index.docs.mdx
@@ -131,9 +131,9 @@ them:
 	language="css"
 	code={`:root {
 	/* Defaults shown — these resolve to the WPDS tokens below: */
-	--charts-trend-up-color: var(--wpds-color-foreground-content-success-weak, #008030);
-	--charts-trend-down-color: var(--wpds-color-foreground-content-error-weak, #cc1818);
-	--charts-trend-neutral-color: var(--wpds-color-foreground-content-neutral-weak, #707070);
+	--a8c-charts-color-trend-up: var(--wpds-color-foreground-content-success-weak, #008030);
+	--a8c-charts-color-trend-down: var(--wpds-color-foreground-content-error-weak, #cc1818);
+	--a8c-charts-color-trend-neutral: var(--wpds-color-foreground-content-neutral-weak, #707070);
 }`}
 />
 

--- a/projects/js-packages/charts/src/components/trend-indicator/trend-indicator.module.scss
+++ b/projects/js-packages/charts/src/components/trend-indicator/trend-indicator.module.scss
@@ -6,18 +6,19 @@
 	font-weight: var(--wpds-typography-font-weight-medium, 499);
 	line-height: 1;
 
-	// Trend colors use the documented --charts-trend-* override API, falling
-	// back to the accessible WPDS semantic tokens.
+	// Trend colours use the --a8c-charts-color-trend-* catalog roles, falling back
+	// to the deprecated --charts-trend-*-color override API and then to the
+	// accessible WPDS semantic tokens.
 	&--up {
-		color: var(--charts-trend-up-color, var(--wpds-color-foreground-content-success-weak, #008030));
+		color: var(--a8c-charts-color-trend-up, var(--charts-trend-up-color, var(--wpds-color-foreground-content-success-weak, #008030)));
 	}
 
 	&--down {
-		color: var(--charts-trend-down-color, var(--wpds-color-foreground-content-error-weak, #cc1818));
+		color: var(--a8c-charts-color-trend-down, var(--charts-trend-down-color, var(--wpds-color-foreground-content-error-weak, #cc1818)));
 	}
 
 	&--neutral {
-		color: var(--charts-trend-neutral-color, var(--wpds-color-foreground-content-neutral-weak, #707070));
+		color: var(--a8c-charts-color-trend-neutral, var(--charts-trend-neutral-color, var(--wpds-color-foreground-content-neutral-weak, #707070)));
 	}
 
 	&__icon {

--- a/projects/js-packages/charts/src/providers/chart-context/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/providers/chart-context/stories/index.docs.mdx
@@ -113,21 +113,21 @@ The Global Charts Context uses a comprehensive theme system that controls all vi
 		colors: [ '#98C8DF', '#006DAB', '#A6DC80', '#1F9828', '#FF8C8F' ],
 
     	// Chart background and labels
-		backgroundColor: 'var(--wpds-color-background-surface-neutral-strong, #fff)',
+		backgroundColor: 'var(--a8c-charts-color-background, var(--wpds-color-background-surface-neutral-strong, #fff))',
 		labelBackgroundColor: 'transparent',
 		labelTextColor: '#FFFFFF',
 
 		// Grid and axis styling
 		gridStyles: {
-			stroke: 'var(--wpds-color-stroke-surface-neutral, #dbdbdb)',
+			stroke: 'var(--a8c-charts-color-grid, var(--wpds-color-stroke-surface-neutral, #dbdbdb))',
 			strokeWidth: 1,
 		},
-		xAxisLineStyles: { stroke: 'var(--wpds-color-stroke-surface-neutral, #dbdbdb)', strokeWidth: 1 },
+		xAxisLineStyles: { stroke: 'var(--a8c-charts-color-grid, var(--wpds-color-stroke-surface-neutral, #dbdbdb))', strokeWidth: 1 },
 
 		// Legend appearance
 		legend: {
 			labelStyles: {
-				color: 'var(--wpds-color-foreground-content-neutral, #1e1e1e)',
+				color: 'var(--a8c-charts-color-label, var(--wpds-color-foreground-content-neutral, #1e1e1e))',
 			},
 		},
 
@@ -137,15 +137,15 @@ The Global Charts Context uses a comprehensive theme system that controls all vi
 			secondaryColor: '#98C8DF',
 			// [negative, neutral, positive]
 			deltaColors: [
-				'var(--wpds-color-foreground-content-error-weak, #cc1818)',
-				'var(--wpds-color-foreground-content-neutral-weak, #707070)',
-				'var(--wpds-color-foreground-content-success-weak, #008030)',
+				'var(--a8c-charts-color-trend-down, var(--wpds-color-foreground-content-error-weak, #cc1818))',
+				'var(--a8c-charts-color-trend-neutral, var(--wpds-color-foreground-content-neutral-weak, #707070))',
+				'var(--a8c-charts-color-trend-up, var(--wpds-color-foreground-content-success-weak, #008030))',
 			],
 		},
 
 		conversionFunnelChart: {
 			primaryColor: '#006DAB',
-			backgroundColor: 'var(--wpds-color-background-surface-neutral-weak, #f4f4f4)',
+			backgroundColor: 'var(--a8c-charts-color-surface-secondary, var(--wpds-color-background-surface-neutral-weak, #f4f4f4))',
 		}
 	};
 

--- a/projects/js-packages/charts/src/providers/chart-context/themes.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/themes.ts
@@ -8,8 +8,8 @@ const defaultTheme: CompleteChartTheme = {
 		'var(--a8c-charts-color-background, var(--wpds-color-background-surface-neutral-strong, #fff))',
 	labelBackgroundColor: 'transparent', // label background color (transparent by default)
 	// White label text sits on top of arbitrary series colors, so it has no WPDS
-	// content-foreground equivalent and stays hardcoded (tokenization outlier).
-	labelTextColor: '#FFFFFF',
+	// content-foreground equivalent; the role carries the hardcoded value as its fallback.
+	labelTextColor: 'var(--a8c-charts-color-label-on-fill, #FFFFFF)',
 	colors: [ '#98C8DF', '#006DAB', '#A6DC80', '#1F9828', '#FF8C8F' ],
 	gridStyles: {
 		stroke: 'var(--a8c-charts-color-grid, var(--wpds-color-stroke-surface-neutral, #dbdbdb))',
@@ -19,11 +19,11 @@ const defaultTheme: CompleteChartTheme = {
 	gridColor: '',
 	gridColorDark: '',
 	xTickLineStyles: {
-		stroke: 'var(--a8c-charts-color-grid, var(--wpds-color-stroke-surface-neutral, #dbdbdb))',
+		stroke: 'var(--a8c-charts-color-tick, var(--wpds-color-stroke-surface-neutral, #dbdbdb))',
 		strokeWidth: 1,
 	},
 	xAxisLineStyles: {
-		stroke: 'var(--a8c-charts-color-grid, var(--wpds-color-stroke-surface-neutral, #dbdbdb))',
+		stroke: 'var(--a8c-charts-color-axis, var(--wpds-color-stroke-surface-neutral, #dbdbdb))',
 		strokeWidth: 1,
 	},
 	legend: {
@@ -48,17 +48,17 @@ const defaultTheme: CompleteChartTheme = {
 	annotationStyles: {
 		label: {
 			anchorLineStroke:
-				'var(--a8c-charts-color-label, var(--wpds-color-foreground-content-neutral, #1e1e1e))',
+				'var(--a8c-charts-color-annotation, var(--wpds-color-foreground-content-neutral, #1e1e1e))',
 			backgroundFill:
 				'var(--a8c-charts-color-background, var(--wpds-color-background-surface-neutral-strong, #fff))',
 		},
 		connector: {
 			stroke:
-				'var(--a8c-charts-color-label, var(--wpds-color-foreground-content-neutral, #1e1e1e))',
+				'var(--a8c-charts-color-annotation, var(--wpds-color-foreground-content-neutral, #1e1e1e))',
 		},
 		circleSubject: {
 			stroke: 'transparent',
-			fill: 'var(--a8c-charts-color-label, var(--wpds-color-foreground-content-neutral, #1e1e1e))',
+			fill: 'var(--a8c-charts-color-annotation, var(--wpds-color-foreground-content-neutral, #1e1e1e))',
 			radius: 5,
 		},
 	},

--- a/projects/js-packages/charts/src/providers/chart-context/themes.ts
+++ b/projects/js-packages/charts/src/providers/chart-context/themes.ts
@@ -4,24 +4,31 @@ import type { CompleteChartTheme } from '../../types';
  * Default theme configuration
  */
 const defaultTheme: CompleteChartTheme = {
-	backgroundColor: 'var(--wpds-color-background-surface-neutral-strong, #fff)',
+	backgroundColor:
+		'var(--a8c-charts-color-background, var(--wpds-color-background-surface-neutral-strong, #fff))',
 	labelBackgroundColor: 'transparent', // label background color (transparent by default)
 	// White label text sits on top of arbitrary series colors, so it has no WPDS
 	// content-foreground equivalent and stays hardcoded (tokenization outlier).
 	labelTextColor: '#FFFFFF',
 	colors: [ '#98C8DF', '#006DAB', '#A6DC80', '#1F9828', '#FF8C8F' ],
 	gridStyles: {
-		stroke: 'var(--wpds-color-stroke-surface-neutral, #dbdbdb)',
+		stroke: 'var(--a8c-charts-color-grid, var(--wpds-color-stroke-surface-neutral, #dbdbdb))',
 		strokeWidth: 1,
 	},
 	tickLength: 4,
 	gridColor: '',
 	gridColorDark: '',
-	xTickLineStyles: { stroke: 'var(--wpds-color-stroke-surface-neutral, #dbdbdb)', strokeWidth: 1 },
-	xAxisLineStyles: { stroke: 'var(--wpds-color-stroke-surface-neutral, #dbdbdb)', strokeWidth: 1 },
+	xTickLineStyles: {
+		stroke: 'var(--a8c-charts-color-grid, var(--wpds-color-stroke-surface-neutral, #dbdbdb))',
+		strokeWidth: 1,
+	},
+	xAxisLineStyles: {
+		stroke: 'var(--a8c-charts-color-grid, var(--wpds-color-stroke-surface-neutral, #dbdbdb))',
+		strokeWidth: 1,
+	},
 	legend: {
 		labelStyles: {
-			color: 'var(--wpds-color-foreground-content-neutral, #1e1e1e)',
+			color: 'var(--a8c-charts-color-label, var(--wpds-color-foreground-content-neutral, #1e1e1e))',
 		},
 		containerStyles: {},
 		shapeStyles: [],
@@ -34,26 +41,30 @@ const defaultTheme: CompleteChartTheme = {
 	// elements for axis labels and ticks. Setting `inherit` lets SVG text
 	// pick up the host application's font-family via normal CSS inheritance.
 	svgLabelSmall: {
-		fill: 'var(--wpds-color-foreground-content-neutral, #1e1e1e)',
+		fill: 'var(--a8c-charts-color-label, var(--wpds-color-foreground-content-neutral, #1e1e1e))',
 		fontFamily: 'inherit',
 	},
 	svgLabelBig: { fontFamily: 'inherit' },
 	annotationStyles: {
 		label: {
-			anchorLineStroke: 'var(--wpds-color-foreground-content-neutral, #1e1e1e)',
-			backgroundFill: 'var(--wpds-color-background-surface-neutral-strong, #fff)',
+			anchorLineStroke:
+				'var(--a8c-charts-color-label, var(--wpds-color-foreground-content-neutral, #1e1e1e))',
+			backgroundFill:
+				'var(--a8c-charts-color-background, var(--wpds-color-background-surface-neutral-strong, #fff))',
 		},
 		connector: {
-			stroke: 'var(--wpds-color-foreground-content-neutral, #1e1e1e)',
+			stroke:
+				'var(--a8c-charts-color-label, var(--wpds-color-foreground-content-neutral, #1e1e1e))',
 		},
 		circleSubject: {
 			stroke: 'transparent',
-			fill: 'var(--wpds-color-foreground-content-neutral, #1e1e1e)',
+			fill: 'var(--a8c-charts-color-label, var(--wpds-color-foreground-content-neutral, #1e1e1e))',
 			radius: 5,
 		},
 	},
 	geoChart: {
-		featureFillColor: 'var(--wpds-color-background-surface-neutral-weak, #f4f4f4)',
+		featureFillColor:
+			'var(--a8c-charts-color-surface-secondary, var(--wpds-color-background-surface-neutral-weak, #f4f4f4))',
 	},
 	leaderboardChart: {
 		rowGap: 12,
@@ -61,15 +72,18 @@ const defaultTheme: CompleteChartTheme = {
 		labelSpacing: 'xs',
 		// [negative, neutral, positive]
 		deltaColors: [
-			'var(--wpds-color-foreground-content-error-weak, #cc1818)',
-			'var(--wpds-color-foreground-content-neutral-weak, #707070)',
-			'var(--wpds-color-foreground-content-success-weak, #008030)',
+			'var(--a8c-charts-color-trend-down, var(--wpds-color-foreground-content-error-weak, #cc1818))',
+			'var(--a8c-charts-color-trend-neutral, var(--wpds-color-foreground-content-neutral-weak, #707070))',
+			'var(--a8c-charts-color-trend-up, var(--wpds-color-foreground-content-success-weak, #008030))',
 		],
 	},
 	conversionFunnelChart: {
-		backgroundColor: 'var(--wpds-color-background-surface-neutral-weak, #f4f4f4)',
-		positiveChangeColor: 'var(--wpds-color-foreground-content-success-weak, #008030)',
-		negativeChangeColor: 'var(--wpds-color-foreground-content-error-weak, #cc1818)',
+		backgroundColor:
+			'var(--a8c-charts-color-surface-secondary, var(--wpds-color-background-surface-neutral-weak, #f4f4f4))',
+		positiveChangeColor:
+			'var(--a8c-charts-color-trend-up, var(--wpds-color-foreground-content-success-weak, #008030))',
+		negativeChangeColor:
+			'var(--a8c-charts-color-trend-down, var(--wpds-color-foreground-content-error-weak, #cc1818))',
 	},
 	lineChart: {
 		lineStyles: {


### PR DESCRIPTION
Fixes CHARTS-201 (https://linear.app/a8c/issue/CHARTS-201/css-var-naming-consistency)

### Why

The charts package had **four** different CSS-custom-property naming conventions in use (`--jp-*`, `--charts-*`, `--a8c--charts--*`, raw Gutenberg-style), which the design analysis rated "Poor" for consistency. Two of those conventions were already retired by the earlier tokenization work (CHARTS-198/199/200/205); this PR settles the remaining inconsistency by defining a single `--a8c-charts-*` semantic token catalog and migrating everything onto the convention `--a8c-charts-{category}-{name}`.

This is the **foundational** step that gates the theming architecture (CHARTS-203), the palette work (CHARTS-202), and the colour migration (CHARTS-227): it fixes the names those issues build on, so they don't have to.

### What this is (and isn't)

- **Is:** a naming migration. It defines the catalog (16 Tier-1 semantic roles + their `--wpds-*` mappings, documented in a new `TOKENS.md`) and repoints every package-owned CSS var and inline semantic `--wpds-*` colour reference onto it.
- **Isn't:** a runtime change. Nothing emits the catalog yet — that's CHARTS-203. Every migrated reference keeps its existing fallback chain (`var(--a8c-charts-*, var(--wpds-*, #hex))`), so it resolves to the **exact same value** as before. **Output is pixel-identical.**

### Changes proposed in this Pull Request

- **New `TOKENS.md`** documenting the `--a8c-charts-*` catalog (16 Tier-1 roles), the Tier-2 component vars, and the public override vars; `AGENTS.md` gains a one-line convention note.
- **Tier-1 catalog wiring** — the inline semantic `--wpds-*` colour refs in `themes.ts` and the SCSS modules now reference `--a8c-charts-color-*` roles: grid, axis, tick, label, label-secondary, label-inverse, label-on-fill, annotation, trend up/down/neutral, background, surface-secondary, track, tooltip-surface, focus. (`axis`/`tick` split from `grid`, `annotation` from `label`; `label-on-fill` and `tooltip-surface` give previously-hardcoded values a named role.)
- **Tier-2 renames** — the leaderboard, trend-indicator, and heatmap component vars adopt the `--a8c-charts-{category}-{name}` convention.
- **Backward compatibility** — the 4 public override vars (the 3 `--charts-trend-*-color` and the leaderboard `--a8c--charts--leaderboard--bar--border-radius`) keep their old names as an inner fallback and are documented as `@deprecated`, so existing consumer overrides keep working untouched.
- One deliberate naming exception: `--a8c-charts-heatmap-cell-intensity` omits the `{category}` segment because it holds a unitless scalar, not a colour.

### Refinements during review

Two would-be override points were reconsidered and **removed** rather than migrated. Both are value-preserving — each var was never set, so it already resolved to the inlined value:

- **Dropped `--a8c-charts-border-width-focus`.** It was never assigned a value — a chart-scoped override *hook* for a WPDS-owned dimension, inconsistent with referencing `--wpds-*` dimensions directly (the way gaps and font sizes are handled) and applied inconsistently (the zoom reset button never used it). The leaderboard and heatmap now reference `--wpds-border-width-focus` directly, keeping the row-padding/outline coupling via a module-scoped Sass `$focus-ring-width` — a compile-time constant, so nothing new lands on the DOM.
- **Inlined the `--a8c-charts-color-zoom-*` namespace.** These were a de-facto public override surface (never a supported or back-compat'd API) for a control slated for rework — the reset button becomes a `@wordpress/ui` Button. Rather than commit to maintaining the vars, the bespoke colours are inlined; the reset focus ring now uses the shared `--a8c-charts-color-focus` role and the button text the WPDS content-foreground token.

### Out of scope (deliberately)

No runtime emission of the catalog (CHARTS-203); no palette (`theme.colors`) tokenization (CHARTS-202); no `--wpds-elevation-*` changes (handled by the `@wordpress/*` bump PR #50509).

### Testing instructions

- `pnpm test` in `projects/js-packages/charts` — 999 tests pass (the heatmap suite asserts the JS-side var names directly and was updated TDD-style).
- `pnpm typecheck` — passes (the leaderboard `style` prop types both the new and deprecated `border-radius` keys).
- Because SCSS is invisible to Jest, correctness of the SCSS repoints rests on: (a) every migrated ref preserving its exact `--wpds-*` token + hex fallback (verified — zero value drift), and (b) Storybook rendering being identical before/after. Verify visually in Storybook: trend indicator, leaderboard (radius/hover/focus), zoom controls, heatmap cells/legend, funnel, line-chart tooltip, grid lines, geo fill.
- Back-compat check: setting an **old** var name (e.g. `--charts-trend-up-color`, or `--a8c--charts--leaderboard--bar--border-radius` via `style`) on a consumer still applies.

### Does this pull request change what data or activity we track or use?

No. This is a CSS custom-property naming migration — it renames existing CSS variables to one convention and adds documentation. It changes no data collection, tracking, activity, telemetry, or user-facing behaviour; rendered output is pixel-identical.
