### PR TITLE
Charts: keep LeaderboardChart row spacing identical for interactive rows

### DIFF
--- a/projects/js-packages/charts/changelog/fix-charts-229-leaderboard-row-spacing
+++ b/projects/js-packages/charts/changelog/fix-charts-229-leaderboard-row-spacing
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Charts: keep LeaderboardChart row spacing and column alignment identical whether or not a row is interactive.
+LeaderboardChart: Keep row spacing and column alignment identical whether or not a row is interactive.

--- a/projects/js-packages/charts/changelog/fix-charts-229-leaderboard-row-spacing
+++ b/projects/js-packages/charts/changelog/fix-charts-229-leaderboard-row-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Charts: keep LeaderboardChart row spacing and column alignment identical whether or not a row is interactive.

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
@@ -107,9 +107,7 @@
 	grid-column: 1 / -1;
 	grid-template-columns: subgrid;
 	align-items: center;
-	box-sizing: border-box;
 	width: 100%;
-	margin: 0;
 	// Every row reserves the same space for the interactive focus ring. Keeping
 	// this on the shared wrapper ensures that adding or removing an action never
 	// changes the row height or subgrid column edges.

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
@@ -114,9 +114,13 @@
 	appearance: none;
 	width: 100%;
 	margin: 0;
-	// Reserve a ring's worth of space on every edge so the inset focus outline
-	// hugs the row without the bar painting over it (see :focus-visible below).
-	padding: var(--focus-ring-width);
+	// No padding: a row's layout metrics must not depend on whether it is
+	// interactive. Non-interactive rows render as bare grid cells, so any padding
+	// here would make interactive rows taller and inset their subgrid columns —
+	// visibly shifting the list when a drill-down swaps clickable parent rows for
+	// non-clickable child rows. The focus ring is drawn inside the row instead
+	// (see :focus-visible below).
+	padding: 0;
 	border: 0;
 	background: none;
 	color: inherit;
@@ -178,10 +182,9 @@
 		outline:
 			var(--focus-ring-width) solid
 			var(--wpds-color-stroke-focus, var(--wp-admin-theme-color, #3858e9));
-		// Inset by its own width so the outer edge hugs the row boundary: the
-		// outline then sits in the row's padding (also a ring width), clear of the
-		// bar, and stays inside the overflow:auto container that would clip an
-		// outset ring.
+		// Inset by its own width so the ring is painted inside the row: it hugs the
+		// row boundary without reserving layout space, and stays inside the
+		// overflow:auto container that would clip an outset ring.
 		outline-offset: calc(-1 * var(--focus-ring-width));
 	}
 }

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
@@ -100,27 +100,27 @@
 	font-style: italic;
 }
 
-.interactiveRow {
+.row {
 	--focus-ring-width: var(--wpds-border-width-focus, var(--wp-admin-border-width-focus, 2px));
 
 	display: grid;
 	grid-column: 1 / -1;
 	grid-template-columns: subgrid;
 	align-items: center;
+	box-sizing: border-box;
+	width: 100%;
+	margin: 0;
+	// Every row reserves the same space for the interactive focus ring. Keeping
+	// this on the shared wrapper ensures that adding or removing an action never
+	// changes the row height or subgrid column edges.
+	padding: var(--focus-ring-width);
+}
+
+.interactiveRow {
 	position: relative;
 
 	// Native button reset.
-	box-sizing: border-box;
 	appearance: none;
-	width: 100%;
-	margin: 0;
-	// No padding: a row's layout metrics must not depend on whether it is
-	// interactive. Non-interactive rows render as bare grid cells, so any padding
-	// here would make interactive rows taller and inset their subgrid columns —
-	// visibly shifting the list when a drill-down swaps clickable parent rows for
-	// non-clickable child rows. The focus ring is drawn inside the row instead
-	// (see :focus-visible below).
-	padding: 0;
 	border: 0;
 	background: none;
 	color: inherit;
@@ -182,9 +182,9 @@
 		outline:
 			var(--focus-ring-width) solid
 			var(--wpds-color-stroke-focus, var(--wp-admin-theme-color, #3858e9));
-		// Inset by its own width so the ring is painted inside the row: it hugs the
-		// row boundary without reserving layout space, and stays inside the
-		// overflow:auto container that would clip an outset ring.
+		// Inset by its own width so the outer edge hugs the row boundary: the
+		// outline then sits in the shared row padding, clear of the bar, and stays
+		// inside the overflow:auto container that would clip an outset ring.
 		outline-offset: calc(-1 * var(--focus-ring-width));
 	}
 }

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.module.scss
@@ -107,7 +107,6 @@
 	grid-column: 1 / -1;
 	grid-template-columns: subgrid;
 	align-items: center;
-	width: 100%;
 	// Every row reserves the same space for the interactive focus ring. Keeping
 	// this on the shared wrapper ensures that adding or removing an action never
 	// changes the row height or subgrid column edges.

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/leaderboard-chart.tsx
@@ -1,6 +1,5 @@
 /* eslint-disable @wordpress/no-unsafe-wp-apis */
 import { __experimentalGrid as Grid, VisuallyHidden } from '@wordpress/components';
-import { Fragment } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Icon, chevronRight } from '@wordpress/icons';
 import { Stack, Text } from '@wordpress/ui';
@@ -404,7 +403,7 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 										<button
 											key={ entry.id }
 											type="button"
-											className={ styles.interactiveRow }
+											className={ clsx( styles.row, styles.interactiveRow ) }
 											onClick={ entry.onClick }
 											aria-label={ entry.ariaLabel }
 										>
@@ -414,7 +413,11 @@ const LeaderboardChartInternal: FC< LeaderboardChartProps > = ( {
 									);
 								}
 
-								return <Fragment key={ entry.id }>{ rowCells }</Fragment>;
+								return (
+									<div key={ entry.id } className={ styles.row }>
+										{ rowCells }
+									</div>
+								);
 							} ) }
 						</Grid>
 					) }

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
@@ -1,5 +1,6 @@
 import { Stack } from '@wordpress/ui';
 import { action } from 'storybook/actions';
+import { expect } from 'storybook/test';
 import { defaultTheme, useGlobalChartsContext } from '../../../providers';
 import {
 	chartDecorator,
@@ -269,6 +270,49 @@ export const Interactive: Story = {
 					'Rows with an `onClick` become interactive: the whole row is clickable and keyboard-focusable (Enter/Space), with a chevron revealed on hover/focus. The consumer supplies the action (e.g. drill-down).',
 			},
 		},
+	},
+};
+
+export const MixedInteractivity: Story = {
+	args: {
+		...sharedThemeArgs,
+		data: sampleData.map( ( entry, index ) =>
+			index % 2 === 0 ? { ...entry, onClick: () => onLeaderboardItemClick( entry.id ) } : entry
+		),
+		withComparison: true,
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					'Interactive and non-interactive rows in one chart. Being clickable is a visual affordance only — it must not change a row height or column alignment, otherwise a drill-down that swaps clickable parent rows for non-clickable child rows visibly shifts the list.',
+			},
+		},
+	},
+	play: async ( { canvasElement } ) => {
+		const grid = canvasElement.querySelector( '[class*="leaderboardChart__content"] > *' );
+
+		// The story must actually mix both row shapes for the rest to mean anything.
+		const interactiveRows = grid.querySelectorAll( '[class*="interactiveRow"]' ).length;
+		expect( interactiveRows ).toBeGreaterThan( 0 );
+		expect( interactiveRows ).toBeLessThan( sampleData.length );
+
+		// An interactive row is one subgrid button wrapping both cells; a
+		// non-interactive row is those cells as bare grid children. Either way every
+		// grid child fills its row, so one distinct height means one row height.
+		const heights = new Set(
+			[ ...grid.children ].map( child => child.getBoundingClientRect().height )
+		);
+		expect( heights.size ).toBe( 1 );
+
+		// Column edges are read off the cells themselves — the button wrapper spans
+		// the full row even when its padding insets the cells inside it.
+		const edge = ( selector: string, side: 'left' | 'right' ) =>
+			new Set(
+				[ ...grid.querySelectorAll( selector ) ].map( cell => cell.getBoundingClientRect()[ side ] )
+			);
+		expect( edge( '[class*="barWithLabelContainer"]', 'left' ).size ).toBe( 1 );
+		expect( edge( '[class*="valueContainer"]', 'right' ).size ).toBe( 1 );
 	},
 };
 

--- a/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/leaderboard-chart/stories/index.stories.tsx
@@ -280,29 +280,30 @@ export const MixedInteractivity: Story = {
 			index % 2 === 0 ? { ...entry, onClick: () => onLeaderboardItemClick( entry.id ) } : entry
 		),
 		withComparison: true,
+		withOverlayLabel: true,
 	},
 	parameters: {
 		docs: {
 			description: {
 				story:
-					'Interactive and non-interactive rows in one chart. Being clickable is a visual affordance only — it must not change a row height or column alignment, otherwise a drill-down that swaps clickable parent rows for non-clickable child rows visibly shifts the list.',
+					'Interactive and non-interactive rows with the overlay-label presentation used by Jetpack Stats. Being clickable is a visual affordance only — it must not change a row height or column alignment, otherwise a drill-down that swaps clickable parent rows for non-clickable child rows visibly shifts the list.',
 			},
 		},
 	},
 	play: async ( { canvasElement } ) => {
 		const grid = canvasElement.querySelector( '[class*="leaderboardChart__content"] > *' );
 
-		// The story must actually mix both row shapes for the rest to mean anything.
-		const interactiveRows = grid.querySelectorAll( '[class*="interactiveRow"]' ).length;
+		// Every entry uses the same row wrapper; only the interactive rows are buttons.
+		const rows = grid.querySelectorAll( ':scope > [class*="row"]' );
+		expect( rows ).toHaveLength( sampleData.length );
+
+		// The story must actually mix both row types for the rest to mean anything.
+		const interactiveRows = grid.querySelectorAll( ':scope > button[class*="row"]' ).length;
 		expect( interactiveRows ).toBeGreaterThan( 0 );
 		expect( interactiveRows ).toBeLessThan( sampleData.length );
 
-		// An interactive row is one subgrid button wrapping both cells; a
-		// non-interactive row is those cells as bare grid children. Either way every
-		// grid child fills its row, so one distinct height means one row height.
-		const heights = new Set(
-			[ ...grid.children ].map( child => child.getBoundingClientRect().height )
-		);
+		// Both wrapper types must have the same height.
+		const heights = new Set( [ ...rows ].map( row => row.getBoundingClientRect().height ) );
 		expect( heights.size ).toBe( 1 );
 
 		// Column edges are read off the cells themselves — the button wrapper spans


### PR DESCRIPTION
Fixes Automattic/jetpack#50129

## Proposed changes

**Why:** `LeaderboardChart` rows previously rendered as two DOM shapes: entries with `onClick` used a `<button className={interactiveRow}>`, while entries without it rendered their cells through a bare `<Fragment>`. Only the button reserved `padding: var(--focus-ring-width)`, so making a row clickable changed its height and inset its subgrid columns. Premium Analytics drill-down widgets swap clickable parent rows for non-clickable child rows, which made the list visibly shift during drill-down.

**How:** Give every entry a consistent row wrapper. Interactive entries render as a `<button>` and non-interactive entries render as a `<div>`; both use the shared `.row` class for the subgrid layout, sizing, and focus-ring padding. `.interactiveRow` now contains only button-specific reset and interaction styles.

The shared padding is intentional. It keeps the inset focus outline clear of the bar without making interactivity affect layout. The existing `isolation: isolate` is also retained: it confines the bar's negative `z-index` to its local stacking context, keeping overlay bars behind labels without allowing them to fall behind an ancestor background (Automattic/jetpack#45043).

**What:**

* Render every leaderboard entry through a shared row wrapper: `<button>` when interactive, `<div>` otherwise.
* Apply identical padding, height, and subgrid column metrics to both row types.
* Update the `MixedInteractivity` story to use the overlay-label presentation used by Jetpack Stats.
* Assert in the story play test that every entry has a wrapper and that mixed row types have equal heights and aligned columns.

Trade-off: fully non-interactive charts now reserve the same focus-ring space as interactive charts, so their rows are slightly taller. This keeps the component stable when consumers add or remove row actions.

## Related product discussion/links

* Automattic/jetpack#50129

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Automated Storybook test:

```bash
cd projects/js-packages/storybook && pnpm exec vitest run -t "Mixed Interactivity"
```

Visual, in **Charts Library → Leaderboard Chart → Mixed Interactivity**:

* Confirm the story uses overlay labels and alternates interactive and non-interactive rows.
* Confirm every row has identical height and that labels and values remain aligned.
* Tab through the interactive rows and confirm the focus ring is visible on all four edges, is not covered by the bar, and is not clipped.
* Hover interactive rows and confirm the value, bar, and chevron affordance still behave correctly.

Additional checks run locally:

```bash
pnpm --filter @automattic/charts test -- --runInBand src/charts/leaderboard-chart/test/leaderboard-chart.test.tsx
pnpm --filter @automattic/charts typecheck
```

<img src="https://github.com/user-attachments/assets/903e58ad-e6ef-45a0-8779-eafdc9780bee " alt="Screenshot 2026-07-21 at 10 50 45 AM" width="1875" data-linear-height="944" />