### PR TITLE
Admin bar: track command palette node clicks

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/track-wpcom-admin-bar-cmd-palette
+++ b/projects/packages/jetpack-mu-wpcom/changelog/track-wpcom-admin-bar-cmd-palette
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Track command palette trigger clicks in the wpcom admin bar.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-bar/wpcom-admin-bar.js
@@ -3,11 +3,17 @@ import { wpcomTrackEvent } from '../../common/tracks';
 import './wpcom-admin-bar.scss';
 
 document.addEventListener( 'DOMContentLoaded', () => {
-	const launchButton = document.querySelector( '#wp-admin-bar-site-plan-badge a' );
-	if ( ! launchButton ) {
-		return;
+	const planBadge = document.querySelector( '#wp-admin-bar-site-plan-badge a' );
+	if ( planBadge ) {
+		planBadge.addEventListener( 'click', () => {
+			wpcomTrackEvent( 'wpcom_adminbar_plan_clicked' );
+		} );
 	}
-	launchButton.addEventListener( 'click', () => {
-		wpcomTrackEvent( 'wpcom_adminbar_plan_clicked' );
-	} );
+
+	const commandPalette = document.querySelector( '#wp-admin-bar-command-palette a' );
+	if ( commandPalette ) {
+		commandPalette.addEventListener( 'click', () => {
+			wpcomTrackEvent( 'wpcom_adminbar_command_palette_clicked' );
+		} );
+	}
 } );


### PR DESCRIPTION
Part of DOTCOM-17884

## Proposed changes

Adds a click listener on the command palette node (`#wp-admin-bar-command-palette a`) in the wpcom admin bar that fires a `wpcom_adminbar_command_palette_clicked` Tracks event.

See previously similar PR which added similar tracking: https://github.com/Automattic/jetpack/pull/44165

## Does this pull request change what data or activity we track or use?

Yes. This adds a new Tracks event, `wpcom_adminbar_command_palette_clicked`, recorded when a user clicks the command palette in the wpcom admin bar.

## Testing instructions (Automatticians only)

1. Apply these changes to your sandbox, and sandbox a test site.
1. Visit the site's wp-admin.
1. Click the command palette (search icon).
2. Verify the event is fired.
3. Verify the event from https://github.com/Automattic/jetpack/pull/44165 can still be fired (regression testing).

<img width="298" height="190" alt="image" src="https://github.com/user-attachments/assets/5927ef65-7115-420d-b764-b5e38256311b" />
