### PR TITLE
Premium Analytics: trim dashboard sections API to the server contract

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-premium-analytics-sections-server-contract
+++ b/projects/packages/premium-analytics/changelog/update-premium-analytics-sections-server-contract
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Dashboard Sections API: expose a derived section slug and trim GET /sections to definitions only ({ id, slug, label, order }), retire the per-user section layout write routes in favor of core preferences persistence, and relabel the WooCommerce section to Store.

--- a/projects/packages/premium-analytics/src/class-dashboard-section.php
+++ b/projects/packages/premium-analytics/src/class-dashboard-section.php
@@ -31,6 +31,13 @@ final class Dashboard_Section {
 	public $id;
 
 	/**
+	 * URL-facing section slug, derived from the identifier.
+	 *
+	 * @var string
+	 */
+	public $slug;
+
+	/**
 	 * Display label.
 	 *
 	 * @var string
@@ -68,9 +75,22 @@ final class Dashboard_Section {
 	public function __construct( $dashboard_name, $id, $args = array() ) {
 		$this->dashboard_name = $dashboard_name;
 		$this->id             = $id;
+		$this->slug           = self::derive_slug( $id );
 		$this->label          = $id;
 
 		$this->set_props( $args );
+	}
+
+	/**
+	 * Derives the URL-facing slug from a namespaced section identifier.
+	 *
+	 * @param string $id Section identifier, e.g. `analytics/traffic`.
+	 * @return string The segment after the namespace, e.g. `traffic`.
+	 */
+	private static function derive_slug( $id ) {
+		$separator = strpos( (string) $id, '/' );
+
+		return false === $separator ? (string) $id : substr( $id, $separator + 1 );
 	}
 
 	/**
@@ -107,6 +127,7 @@ final class Dashboard_Section {
 	public function to_array() {
 		return array(
 			'id'    => $this->id,
+			'slug'  => $this->slug,
 			'label' => $this->label,
 			'order' => (int) $this->order,
 		);

--- a/projects/packages/premium-analytics/src/dashboard-sections.php
+++ b/projects/packages/premium-analytics/src/dashboard-sections.php
@@ -106,7 +106,7 @@ function register_default_dashboard_sections() {
 			},
 		),
 		'woocommerce/store'     => array(
-			'label'          => __( 'WooCommerce', 'jetpack-premium-analytics' ),
+			'label'          => __( 'Store', 'jetpack-premium-analytics' ),
 			'order'          => 40,
 			'is_available'   => __NAMESPACE__ . '\\is_woocommerce_dashboard_section_available',
 			'default_layout' => __NAMESPACE__ . '\\get_woocommerce_dashboard_section_default_layout',
@@ -143,247 +143,6 @@ function check_dashboard_sections_permission() {
 }
 
 /**
- * Gets the user meta key used by the WordPress preferences store.
- *
- * @global \wpdb $wpdb WordPress database abstraction object.
- *
- * @return string Persisted preferences user meta key.
- */
-function get_persisted_preferences_meta_key() {
-	global $wpdb;
-
-	return $wpdb->get_blog_prefix() . 'persisted_preferences';
-}
-
-/**
- * Reads the raw stored preferences for a user.
- *
- * The dashboard default layout is injected through the same user meta key at
- * read time. Section layout writes need the committed value only, otherwise a
- * section-only update can accidentally persist that synthetic default layout.
- *
- * @param int $user_id User ID.
- * @return array Preferences array.
- */
-function get_stored_persisted_preferences_for_user( $user_id ) {
-	$default_layout_filter = __NAMESPACE__ . '\\inject_dashboard_default_layout';
-	$removed_filter        = remove_filter( 'get_user_metadata', $default_layout_filter, 99 );
-
-	$preferences = get_user_meta( $user_id, get_persisted_preferences_meta_key(), true );
-
-	if ( $removed_filter ) {
-		add_filter( 'get_user_metadata', $default_layout_filter, 99, 3 );
-	}
-
-	return is_array( $preferences ) ? $preferences : array();
-}
-
-/**
- * Reads stored dashboard section layouts for a user.
- *
- * Invalid or stale section layout entries are ignored while preserving the
- * missing-key semantics used by the section API.
- *
- * @param int $user_id User ID.
- * @return array<string,array> Map of section IDs to custom layouts.
- */
-function get_dashboard_section_layouts_for_user( $user_id ) {
-	$preferences = get_stored_persisted_preferences_for_user( $user_id );
-	$scope       = $preferences[ DASHBOARD_LAYOUT_SCOPE ] ?? array();
-
-	if ( ! is_array( $scope ) ) {
-		return array();
-	}
-
-	$layouts = $scope[ DASHBOARD_SECTION_LAYOUTS_KEY ] ?? array();
-
-	if ( ! is_array( $layouts ) ) {
-		return array();
-	}
-
-	$normalized = array();
-
-	foreach ( $layouts as $section_id => $layout ) {
-		if (
-			is_string( $section_id )
-			&& 1 === preg_match( '/^' . get_dashboard_section_id_pattern() . '$/', $section_id )
-			&& is_dashboard_section_layout( $layout )
-		) {
-			$normalized[ $section_id ] = array_values( $layout );
-		}
-	}
-
-	return $normalized;
-}
-
-/**
- * Persists a custom dashboard section layout for a user.
- *
- * @param int    $user_id    User ID.
- * @param string $section_id Section identifier.
- * @param array  $layout     Widget layout.
- * @return bool True when the write completed or the stored value was unchanged.
- */
-function update_dashboard_section_layout_for_user( $user_id, $section_id, $layout ) {
-	$preferences = get_stored_persisted_preferences_for_user( $user_id );
-	$original    = $preferences;
-
-	if ( ! isset( $preferences[ DASHBOARD_LAYOUT_SCOPE ] ) || ! is_array( $preferences[ DASHBOARD_LAYOUT_SCOPE ] ) ) {
-		$preferences[ DASHBOARD_LAYOUT_SCOPE ] = array();
-	}
-
-	if (
-		! isset( $preferences[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ] )
-		|| ! is_array( $preferences[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ] )
-	) {
-		$preferences[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ] = array();
-	}
-
-	$preferences[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ][ $section_id ] = array_values( $layout );
-
-	if ( $preferences === $original ) {
-		return true;
-	}
-
-	$updated = update_user_meta( $user_id, get_persisted_preferences_meta_key(), $preferences );
-
-	return false !== $updated;
-}
-
-/**
- * Removes a custom dashboard section layout for a user.
- *
- * @param int    $user_id    User ID.
- * @param string $section_id Section identifier.
- * @return bool True when the reset completed or there was nothing to reset.
- */
-function delete_dashboard_section_layout_for_user( $user_id, $section_id ) {
-	$preferences = get_stored_persisted_preferences_for_user( $user_id );
-
-	if (
-		! isset( $preferences[ DASHBOARD_LAYOUT_SCOPE ] )
-		|| ! is_array( $preferences[ DASHBOARD_LAYOUT_SCOPE ] )
-		|| ! isset( $preferences[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ] )
-		|| ! is_array( $preferences[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ] )
-	) {
-		return true;
-	}
-
-	if ( ! array_key_exists( $section_id, $preferences[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ] ) ) {
-		return true;
-	}
-
-	unset( $preferences[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ][ $section_id ] );
-
-	if ( empty( $preferences[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ] ) ) {
-		unset( $preferences[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ] );
-	}
-
-	$updated = update_user_meta( $user_id, get_persisted_preferences_meta_key(), $preferences );
-
-	return false !== $updated;
-}
-
-/**
- * Removes all custom dashboard section layouts for a user.
- *
- * @param int $user_id User ID.
- * @return bool True when the reset completed or there was nothing to reset.
- */
-function delete_dashboard_section_layouts_for_user( $user_id ) {
-	$preferences = get_stored_persisted_preferences_for_user( $user_id );
-
-	if (
-		! isset( $preferences[ DASHBOARD_LAYOUT_SCOPE ] )
-		|| ! is_array( $preferences[ DASHBOARD_LAYOUT_SCOPE ] )
-		|| ! isset( $preferences[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ] )
-	) {
-		return true;
-	}
-
-	unset( $preferences[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ] );
-
-	if ( empty( $preferences[ DASHBOARD_LAYOUT_SCOPE ] ) ) {
-		unset( $preferences[ DASHBOARD_LAYOUT_SCOPE ] );
-	}
-
-	$updated = update_user_meta( $user_id, get_persisted_preferences_meta_key(), $preferences );
-
-	return false !== $updated;
-}
-
-/**
- * Checks whether a value is a valid dashboard section layout.
- *
- * @param mixed $layout Candidate layout.
- * @return bool True when the value is a list of widget instances.
- */
-function is_dashboard_section_layout( $layout ) {
-	if ( ! is_array( $layout ) ) {
-		return false;
-	}
-
-	$expected_key = 0;
-
-	foreach ( $layout as $key => $widget ) {
-		if ( $key !== $expected_key ) {
-			return false;
-		}
-
-		++$expected_key;
-
-		if ( ! is_array( $widget ) ) {
-			return false;
-		}
-
-		if ( ! isset( $widget['uuid'] ) || ! is_string( $widget['uuid'] ) || '' === $widget['uuid'] ) {
-			return false;
-		}
-
-		if ( ! isset( $widget['type'] ) || ! is_string( $widget['type'] ) || '' === $widget['type'] ) {
-			return false;
-		}
-
-		if ( isset( $widget['placement'] ) && ! is_array( $widget['placement'] ) ) {
-			return false;
-		}
-
-		if ( isset( $widget['attributes'] ) && ! is_array( $widget['attributes'] ) ) {
-			return false;
-		}
-	}
-
-	return true;
-}
-
-/**
- * Validates a dashboard section layout REST argument.
- *
- * @param mixed $value Candidate layout.
- * @return true|\WP_Error True when valid, otherwise an error.
- */
-function validate_dashboard_section_layout( $value ) {
-	if ( is_dashboard_section_layout( $value ) ) {
-		return true;
-	}
-
-	return new \WP_Error(
-		'invalid_dashboard_section_layout',
-		__( 'Dashboard section layout must be an array of widget instances.', 'jetpack-premium-analytics' )
-	);
-}
-
-/**
- * Sanitizes a dashboard section layout REST argument.
- *
- * @param mixed $value Candidate layout.
- * @return array Layout array.
- */
-function sanitize_dashboard_section_layout( $value ) {
-	return is_array( $value ) ? array_values( $value ) : array();
-}
-
-/**
  * Resolves a route section, including availability checks.
  *
  * @param string $dashboard_name Dashboard identifier.
@@ -413,33 +172,15 @@ function get_available_dashboard_section_for_route( $dashboard_name, $section_id
 }
 
 /**
- * Builds the public REST representation for a dashboard section.
- *
- * @param Dashboard_Section $section         Dashboard section.
- * @param array             $section_layouts Map of section IDs to custom layouts.
- * @return array REST response data.
- */
-function get_dashboard_section_response_data( Dashboard_Section $section, $section_layouts ) {
-	$has_custom_layout = array_key_exists( $section->id, $section_layouts );
-	$data              = $section->to_array();
-
-	$data['layout']          = $has_custom_layout ? $section_layouts[ $section->id ] : $section->get_default_layout();
-	$data['hasCustomLayout'] = $has_custom_layout;
-
-	return $data;
-}
-
-/**
  * REST callback returning available dashboard sections.
  *
  * @param \WP_REST_Request $request REST request carrying the dashboard name.
  * @return \WP_REST_Response
  */
 function get_dashboard_sections_response( $request ) {
-	$section_layouts = get_dashboard_section_layouts_for_user( get_current_user_id() );
-	$sections        = array_map(
-		static function ( Dashboard_Section $section ) use ( $section_layouts ) {
-			return get_dashboard_section_response_data( $section, $section_layouts );
+	$sections = array_map(
+		static function ( Dashboard_Section $section ) {
+			return $section->to_array();
 		},
 		get_available_dashboard_sections( $request['name'] )
 	);
@@ -461,87 +202,6 @@ function get_dashboard_section_default_layout_response( $request ) {
 	}
 
 	return rest_ensure_response( $section->get_default_layout() );
-}
-
-/**
- * REST callback persisting a dashboard section layout for the current user.
- *
- * @param \WP_REST_Request $request REST request carrying dashboard, section, and layout.
- * @return \WP_REST_Response|\WP_Error
- */
-function update_dashboard_section_layout_response( $request ) {
-	$section = get_available_dashboard_section_for_route( $request['name'], $request['section'] );
-
-	if ( is_wp_error( $section ) ) {
-		return $section;
-	}
-
-	$layout = sanitize_dashboard_section_layout( $request['layout'] );
-	$user   = get_current_user_id();
-
-	if ( ! update_dashboard_section_layout_for_user( $user, $section->id, $layout ) ) {
-		return new \WP_Error(
-			'dashboard_section_layout_update_failed',
-			__( 'Could not update dashboard section layout.', 'jetpack-premium-analytics' ),
-			array( 'status' => 500 )
-		);
-	}
-
-	return rest_ensure_response(
-		get_dashboard_section_response_data(
-			$section,
-			array( $section->id => $layout )
-		)
-	);
-}
-
-/**
- * REST callback removing a dashboard section layout customization for the current user.
- *
- * @param \WP_REST_Request $request REST request carrying dashboard and section identifiers.
- * @return \WP_REST_Response|\WP_Error
- */
-function delete_dashboard_section_layout_response( $request ) {
-	$section = get_available_dashboard_section_for_route( $request['name'], $request['section'] );
-
-	if ( is_wp_error( $section ) ) {
-		return $section;
-	}
-
-	$user = get_current_user_id();
-
-	if ( ! delete_dashboard_section_layout_for_user( $user, $section->id ) ) {
-		return new \WP_Error(
-			'dashboard_section_layout_delete_failed',
-			__( 'Could not reset dashboard section layout.', 'jetpack-premium-analytics' ),
-			array( 'status' => 500 )
-		);
-	}
-
-	return rest_ensure_response(
-		get_dashboard_section_response_data(
-			$section,
-			get_dashboard_section_layouts_for_user( $user )
-		)
-	);
-}
-
-/**
- * REST callback removing all dashboard section layout customizations for the current user.
- *
- * @param \WP_REST_Request $request REST request carrying the dashboard identifier.
- * @return \WP_REST_Response|\WP_Error
- */
-function delete_dashboard_sections_layouts_response( $request ) {
-	if ( ! delete_dashboard_section_layouts_for_user( get_current_user_id() ) ) {
-		return new \WP_Error(
-			'dashboard_section_layout_delete_failed',
-			__( 'Could not reset dashboard section layouts.', 'jetpack-premium-analytics' ),
-			array( 'status' => 500 )
-		);
-	}
-
-	return get_dashboard_sections_response( $request );
 }
 
 /**
@@ -568,73 +228,10 @@ function register_dashboard_sections_rest_routes() {
 
 	register_rest_route(
 		DASHBOARD_REST_NAMESPACE,
-		'/dashboards/(?P<name>' . get_dashboard_name_pattern() . ')/sections',
-		array(
-			'methods'             => \WP_REST_Server::DELETABLE,
-			'callback'            => __NAMESPACE__ . '\\delete_dashboard_sections_layouts_response',
-			'permission_callback' => __NAMESPACE__ . '\\check_dashboard_sections_permission',
-			'args'                => array(
-				'name' => array(
-					'description' => __( 'Dashboard identifier as produced by the build pipeline.', 'jetpack-premium-analytics' ),
-					'type'        => 'string',
-				),
-			),
-		)
-	);
-
-	register_rest_route(
-		DASHBOARD_REST_NAMESPACE,
 		'/dashboards/(?P<name>' . get_dashboard_name_pattern() . ')/sections/(?P<section>' . get_dashboard_section_id_pattern() . ')/default-layout',
 		array(
 			'methods'             => \WP_REST_Server::READABLE,
 			'callback'            => __NAMESPACE__ . '\\get_dashboard_section_default_layout_response',
-			'permission_callback' => __NAMESPACE__ . '\\check_dashboard_sections_permission',
-			'args'                => array(
-				'name'    => array(
-					'description' => __( 'Dashboard identifier as produced by the build pipeline.', 'jetpack-premium-analytics' ),
-					'type'        => 'string',
-				),
-				'section' => array(
-					'description' => __( 'Dashboard section identifier.', 'jetpack-premium-analytics' ),
-					'type'        => 'string',
-				),
-			),
-		)
-	);
-
-	register_rest_route(
-		DASHBOARD_REST_NAMESPACE,
-		'/dashboards/(?P<name>' . get_dashboard_name_pattern() . ')/sections/(?P<section>' . get_dashboard_section_id_pattern() . ')/layout',
-		array(
-			'methods'             => 'PUT',
-			'callback'            => __NAMESPACE__ . '\\update_dashboard_section_layout_response',
-			'permission_callback' => __NAMESPACE__ . '\\check_dashboard_sections_permission',
-			'args'                => array(
-				'name'    => array(
-					'description' => __( 'Dashboard identifier as produced by the build pipeline.', 'jetpack-premium-analytics' ),
-					'type'        => 'string',
-				),
-				'section' => array(
-					'description' => __( 'Dashboard section identifier.', 'jetpack-premium-analytics' ),
-					'type'        => 'string',
-				),
-				'layout'  => array(
-					'description'       => __( 'Widget layout to persist for the dashboard section.', 'jetpack-premium-analytics' ),
-					'type'              => 'array',
-					'required'          => true,
-					'validate_callback' => __NAMESPACE__ . '\\validate_dashboard_section_layout',
-					'sanitize_callback' => __NAMESPACE__ . '\\sanitize_dashboard_section_layout',
-				),
-			),
-		)
-	);
-
-	register_rest_route(
-		DASHBOARD_REST_NAMESPACE,
-		'/dashboards/(?P<name>' . get_dashboard_name_pattern() . ')/sections/(?P<section>' . get_dashboard_section_id_pattern() . ')/layout',
-		array(
-			'methods'             => \WP_REST_Server::DELETABLE,
-			'callback'            => __NAMESPACE__ . '\\delete_dashboard_section_layout_response',
 			'permission_callback' => __NAMESPACE__ . '\\check_dashboard_sections_permission',
 			'args'                => array(
 				'name'    => array(

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
@@ -57,6 +57,8 @@ class Dashboard_Section_Test extends BaseTestCase {
 		remove_all_actions( 'doing_it_wrong_run' );
 		remove_all_filters( WOOCOMMERCE_DASHBOARD_SECTION_AVAILABLE_FILTER );
 
+		wp_set_current_user( 0 );
+
 		parent::tear_down();
 	}
 
@@ -102,6 +104,7 @@ class Dashboard_Section_Test extends BaseTestCase {
 		$this->assertSame( $section, $registry->get_registered( 'example_dashboard', 'example/traffic' ) );
 		$this->assertSame( 'example_dashboard', $section->dashboard_name );
 		$this->assertSame( 'example/traffic', $section->id );
+		$this->assertSame( 'traffic', $section->slug );
 		$this->assertSame( 'Traffic', $section->label );
 		$this->assertSame( 15, $section->order );
 		$this->assertSame( $layout, $section->get_default_layout() );
@@ -160,6 +163,27 @@ class Dashboard_Section_Test extends BaseTestCase {
 		$this->assertSame( 10, $section->order );
 		$this->assertTrue( $section->is_available() );
 		$this->assertSame( array(), $section->get_default_layout() );
+	}
+
+	/**
+	 * Slugs are derived from the section ID segment after the namespace.
+	 */
+	public function test_section_slug_is_derived_from_id() {
+		register_default_dashboard_sections();
+
+		$expected = array(
+			'analytics/traffic'     => 'traffic',
+			'analytics/insights'    => 'insights',
+			'analytics/subscribers' => 'subscribers',
+			'woocommerce/store'     => 'store',
+		);
+
+		foreach ( $expected as $id => $slug ) {
+			$section = get_registered_dashboard_section( DASHBOARD_NAME, $id );
+
+			$this->assertInstanceOf( Dashboard_Section::class, $section );
+			$this->assertSame( $slug, $section->slug );
+		}
 	}
 
 	/**
@@ -227,11 +251,10 @@ class Dashboard_Section_Test extends BaseTestCase {
 		$this->assertSame(
 			array(
 				array(
-					'id'              => 'analytics/traffic',
-					'label'           => 'Traffic',
-					'order'           => 10,
-					'layout'          => array(),
-					'hasCustomLayout' => false,
+					'id'    => 'analytics/traffic',
+					'slug'  => 'traffic',
+					'label' => 'Traffic',
+					'order' => 10,
 				),
 			),
 			$response->get_data()
@@ -343,16 +366,19 @@ class Dashboard_Section_Test extends BaseTestCase {
 			array(
 				array(
 					'id'    => 'analytics/traffic',
+					'slug'  => 'traffic',
 					'label' => 'Traffic',
 					'order' => 10,
 				),
 				array(
 					'id'    => 'analytics/insights',
+					'slug'  => 'insights',
 					'label' => 'Insights',
 					'order' => 20,
 				),
 				array(
 					'id'    => 'analytics/subscribers',
+					'slug'  => 'subscribers',
 					'label' => 'Subscribers',
 					'order' => 30,
 				),
@@ -378,7 +404,7 @@ class Dashboard_Section_Test extends BaseTestCase {
 
 		$this->assertInstanceOf( Dashboard_Section::class, $woocommerce );
 		$this->assertTrue( $woocommerce->is_available() );
-		$this->assertSame( 'WooCommerce', $woocommerce->label );
+		$this->assertSame( 'Store', $woocommerce->label );
 		$this->assertSame( 40, $woocommerce->order );
 		$this->assertSame(
 			array(
@@ -481,18 +507,16 @@ class Dashboard_Section_Test extends BaseTestCase {
 		$this->assertSame(
 			array(
 				array(
-					'id'              => 'example/first',
-					'label'           => 'First',
-					'order'           => 10,
-					'layout'          => array(),
-					'hasCustomLayout' => false,
+					'id'    => 'example/first',
+					'slug'  => 'first',
+					'label' => 'First',
+					'order' => 10,
 				),
 				array(
-					'id'              => 'example/later',
-					'label'           => 'Later',
-					'order'           => 20,
-					'layout'          => array(),
-					'hasCustomLayout' => false,
+					'id'    => 'example/later',
+					'slug'  => 'later',
+					'label' => 'Later',
+					'order' => 20,
 				),
 			),
 			$response->get_data()
@@ -500,23 +524,55 @@ class Dashboard_Section_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Sections route includes resolved default layouts.
+	 * Sections route includes the store section only when WooCommerce is detected.
 	 */
-	public function test_sections_route_resolves_default_layouts() {
-		$default_layout = array(
-			array(
-				'uuid' => 'default-route-widget',
-				'type' => 'example/widget',
-			),
+	public function test_sections_route_reflects_woocommerce_availability() {
+		register_default_dashboard_sections();
+
+		$this->set_admin_user();
+
+		add_filter( WOOCOMMERCE_DASHBOARD_SECTION_AVAILABLE_FILTER, '__return_false' );
+
+		$response = rest_get_server()->dispatch(
+			new WP_REST_Request( 'GET', '/wpcom/v2/dashboards/' . DASHBOARD_NAME . '/sections' )
 		);
 
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			array( 'traffic', 'insights', 'subscribers' ),
+			array_column( $response->get_data(), 'slug' )
+		);
+
+		remove_all_filters( WOOCOMMERCE_DASHBOARD_SECTION_AVAILABLE_FILTER );
+		add_filter( WOOCOMMERCE_DASHBOARD_SECTION_AVAILABLE_FILTER, '__return_true' );
+
+		$response = rest_get_server()->dispatch(
+			new WP_REST_Request( 'GET', '/wpcom/v2/dashboards/' . DASHBOARD_NAME . '/sections' )
+		);
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			array( 'traffic', 'insights', 'subscribers', 'store' ),
+			array_column( $response->get_data(), 'slug' )
+		);
+	}
+
+	/**
+	 * Sections route responses carry definition fields only.
+	 */
+	public function test_sections_route_returns_lean_section_shape() {
 		register_dashboard_section(
 			'route_sections_dashboard',
 			'analytics/traffic',
 			array(
 				'label'          => 'Traffic',
 				'order'          => 10,
-				'default_layout' => $default_layout,
+				'default_layout' => array(
+					array(
+						'uuid' => 'default-route-widget',
+						'type' => 'example/widget',
+					),
+				),
 			)
 		);
 
@@ -530,59 +586,10 @@ class Dashboard_Section_Test extends BaseTestCase {
 		$this->assertSame(
 			array(
 				array(
-					'id'              => 'analytics/traffic',
-					'label'           => 'Traffic',
-					'order'           => 10,
-					'layout'          => $default_layout,
-					'hasCustomLayout' => false,
-				),
-			),
-			$response->get_data()
-		);
-	}
-
-	/**
-	 * Sections route treats an empty stored layout as a deliberate customization.
-	 */
-	public function test_sections_route_resolves_customized_empty_layouts() {
-		$default_layout = array(
-			array(
-				'uuid' => 'default-route-widget',
-				'type' => 'example/widget',
-			),
-		);
-
-		register_dashboard_section(
-			'route_sections_dashboard',
-			'analytics/traffic',
-			array(
-				'label'          => 'Traffic',
-				'order'          => 10,
-				'default_layout' => $default_layout,
-			)
-		);
-
-		$user_id = $this->set_admin_user();
-		$this->set_section_layouts_preference(
-			$user_id,
-			array(
-				'analytics/traffic' => array(),
-			)
-		);
-
-		$response = rest_get_server()->dispatch(
-			new WP_REST_Request( 'GET', '/wpcom/v2/dashboards/route_sections_dashboard/sections' )
-		);
-
-		$this->assertSame( 200, $response->get_status() );
-		$this->assertSame(
-			array(
-				array(
-					'id'              => 'analytics/traffic',
-					'label'           => 'Traffic',
-					'order'           => 10,
-					'layout'          => array(),
-					'hasCustomLayout' => true,
+					'id'    => 'analytics/traffic',
+					'slug'  => 'traffic',
+					'label' => 'Traffic',
+					'order' => 10,
 				),
 			),
 			$response->get_data()
@@ -674,144 +681,9 @@ class Dashboard_Section_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Layout route persists a custom layout for the current user.
+	 * Retired section-layout write routes are no longer registered.
 	 */
-	public function test_update_layout_route_persists_current_user_layout() {
-		$custom_layout = array(
-			array(
-				'uuid'       => 'custom-route-widget',
-				'type'       => 'example/widget',
-				'attributes' => array(
-					'example' => true,
-				),
-				'placement'  => array(
-					'width'  => 2,
-					'height' => 1,
-					'order'  => 0,
-				),
-			),
-		);
-
-		register_dashboard_section(
-			'route_layout_dashboard',
-			'analytics/traffic',
-			array(
-				'label' => 'Traffic',
-				'order' => 10,
-			)
-		);
-
-		$user_id = $this->set_admin_user();
-
-		$request = new WP_REST_Request( 'PUT', '/wpcom/v2/dashboards/route_layout_dashboard/sections/analytics/traffic/layout' );
-		$request->set_param( 'layout', $custom_layout );
-
-		$response = rest_get_server()->dispatch( $request );
-
-		$this->assertSame( 200, $response->get_status() );
-		$this->assertSame(
-			array(
-				'id'              => 'analytics/traffic',
-				'label'           => 'Traffic',
-				'order'           => 10,
-				'layout'          => $custom_layout,
-				'hasCustomLayout' => true,
-			),
-			$response->get_data()
-		);
-
-		$stored = get_stored_persisted_preferences_for_user( $user_id );
-
-		$this->assertSame(
-			$custom_layout,
-			$stored[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ]['analytics/traffic']
-		);
-	}
-
-	/**
-	 * Layout route does not persist the injected dashboard default layout.
-	 */
-	public function test_update_layout_route_does_not_persist_injected_dashboard_layout() {
-		$custom_layout = array(
-			array(
-				'uuid' => 'custom-route-widget',
-				'type' => 'example/widget',
-			),
-		);
-
-		register_dashboard_section(
-			'route_layout_dashboard',
-			'analytics/traffic',
-			array(
-				'label' => 'Traffic',
-				'order' => 10,
-			)
-		);
-
-		$user_id = $this->set_admin_user();
-
-		$request = new WP_REST_Request( 'PUT', '/wpcom/v2/dashboards/route_layout_dashboard/sections/analytics/traffic/layout' );
-		$request->set_param( 'layout', $custom_layout );
-
-		$response = rest_get_server()->dispatch( $request );
-
-		$this->assertSame( 200, $response->get_status() );
-
-		$stored = get_stored_persisted_preferences_for_user( $user_id );
-
-		$this->assertArrayHasKey( DASHBOARD_SECTION_LAYOUTS_KEY, $stored[ DASHBOARD_LAYOUT_SCOPE ] );
-		$this->assertSame(
-			$custom_layout,
-			$stored[ DASHBOARD_LAYOUT_SCOPE ][ DASHBOARD_SECTION_LAYOUTS_KEY ]['analytics/traffic']
-		);
-		$this->assertArrayNotHasKey( DASHBOARD_LAYOUT_KEY, $stored[ DASHBOARD_LAYOUT_SCOPE ] );
-	}
-
-	/**
-	 * Layout route accepts an empty custom layout.
-	 */
-	public function test_update_layout_route_persists_empty_layout_as_custom() {
-		$default_layout = array(
-			array(
-				'uuid' => 'default-route-widget',
-				'type' => 'example/widget',
-			),
-		);
-
-		register_dashboard_section(
-			'route_layout_dashboard',
-			'analytics/traffic',
-			array(
-				'label'          => 'Traffic',
-				'order'          => 10,
-				'default_layout' => $default_layout,
-			)
-		);
-
-		$this->set_admin_user();
-
-		$request = new WP_REST_Request( 'PUT', '/wpcom/v2/dashboards/route_layout_dashboard/sections/analytics/traffic/layout' );
-		$request->set_param( 'layout', array() );
-
-		$response = rest_get_server()->dispatch( $request );
-
-		$this->assertSame( 200, $response->get_status() );
-		$this->assertSame(
-			array(
-				'id'              => 'analytics/traffic',
-				'label'           => 'Traffic',
-				'order'           => 10,
-				'layout'          => array(),
-				'hasCustomLayout' => true,
-			),
-			$response->get_data()
-		);
-	}
-
-	/**
-	 * Layout route rejects invalid widget layout entries.
-	 */
-	public function test_update_layout_route_rejects_invalid_layout() {
+	public function test_retired_layout_write_routes_are_not_registered() {
 		register_dashboard_section(
 			'route_layout_dashboard',
 			'analytics/traffic',
@@ -823,352 +695,25 @@ class Dashboard_Section_Test extends BaseTestCase {
 
 		$this->set_admin_user();
 
-		$request = new WP_REST_Request( 'PUT', '/wpcom/v2/dashboards/route_layout_dashboard/sections/analytics/traffic/layout' );
-		$request->set_param(
-			'layout',
-			array(
-				array(
-					'uuid' => 'missing-type-widget',
-				),
-			)
+		$retired_requests = array(
+			'PUT section layout'    => array( 'PUT', '/wpcom/v2/dashboards/route_layout_dashboard/sections/analytics/traffic/layout' ),
+			'DELETE section layout' => array( 'DELETE', '/wpcom/v2/dashboards/route_layout_dashboard/sections/analytics/traffic/layout' ),
+			'DELETE all sections'   => array( 'DELETE', '/wpcom/v2/dashboards/route_layout_dashboard/sections' ),
 		);
 
-		$response = rest_get_server()->dispatch( $request );
+		foreach ( $retired_requests as $case => $retired_request ) {
+			list( $method, $route ) = $retired_request;
 
-		$this->assertSame( 400, $response->get_status() );
-	}
+			$request = new WP_REST_Request( $method, $route );
+			if ( 'PUT' === $method ) {
+				$request->set_param( 'layout', array() );
+			}
 
-	/**
-	 * Layout route rejects non-array widget attributes.
-	 */
-	public function test_update_layout_route_rejects_invalid_attributes() {
-		register_dashboard_section(
-			'route_layout_dashboard',
-			'analytics/traffic',
-			array(
-				'label' => 'Traffic',
-				'order' => 10,
-			)
-		);
+			$response = rest_get_server()->dispatch( $request );
 
-		$this->set_admin_user();
-
-		$request = new WP_REST_Request( 'PUT', '/wpcom/v2/dashboards/route_layout_dashboard/sections/analytics/traffic/layout' );
-		$request->set_param(
-			'layout',
-			array(
-				array(
-					'uuid'       => 'invalid-attributes-widget',
-					'type'       => 'example/widget',
-					'attributes' => 'oops',
-				),
-			)
-		);
-
-		$response = rest_get_server()->dispatch( $request );
-
-		$this->assertSame( 400, $response->get_status() );
-	}
-
-	/**
-	 * Layout route requires manage_options.
-	 */
-	public function test_update_layout_route_requires_manage_options() {
-		register_dashboard_section(
-			'route_layout_dashboard',
-			'analytics/traffic',
-			array(
-				'label' => 'Traffic',
-				'order' => 10,
-			)
-		);
-
-		wp_set_current_user( 0 );
-
-		$request = new WP_REST_Request( 'PUT', '/wpcom/v2/dashboards/route_layout_dashboard/sections/analytics/traffic/layout' );
-		$request->set_param( 'layout', array() );
-
-		$response = rest_get_server()->dispatch( $request );
-
-		$this->assertSame( 401, $response->get_status() );
-	}
-
-	/**
-	 * Layout route returns 404 for unknown sections.
-	 */
-	public function test_update_layout_route_returns_404_for_unknown_section() {
-		$this->set_admin_user();
-
-		$request = new WP_REST_Request( 'PUT', '/wpcom/v2/dashboards/route_layout_dashboard/sections/analytics/missing/layout' );
-		$request->set_param( 'layout', array() );
-
-		$response = rest_get_server()->dispatch( $request );
-
-		$this->assertSame( 404, $response->get_status() );
-		$this->assertSame( 'dashboard_section_not_found', $response->as_error()->get_error_code() );
-	}
-
-	/**
-	 * Layout route returns 404 for unavailable sections.
-	 */
-	public function test_update_layout_route_returns_404_for_unavailable_section() {
-		register_dashboard_section(
-			'route_unavailable_dashboard',
-			'analytics/insights',
-			array(
-				'label'        => 'Insights',
-				'order'        => 10,
-				'is_available' => '__return_false',
-			)
-		);
-
-		$this->set_admin_user();
-
-		$request = new WP_REST_Request( 'PUT', '/wpcom/v2/dashboards/route_unavailable_dashboard/sections/analytics/insights/layout' );
-		$request->set_param( 'layout', array() );
-
-		$response = rest_get_server()->dispatch( $request );
-
-		$this->assertSame( 404, $response->get_status() );
-		$this->assertSame( 'dashboard_section_unavailable', $response->as_error()->get_error_code() );
-	}
-
-	/**
-	 * Delete layout route resets a section to its default layout.
-	 */
-	public function test_delete_layout_route_resets_to_default_layout() {
-		$default_layout = array(
-			array(
-				'uuid' => 'default-route-widget',
-				'type' => 'example/widget',
-			),
-		);
-		$custom_layout  = array(
-			array(
-				'uuid' => 'custom-route-widget',
-				'type' => 'example/widget',
-			),
-		);
-
-		register_dashboard_section(
-			'route_layout_dashboard',
-			'analytics/traffic',
-			array(
-				'label'          => 'Traffic',
-				'order'          => 10,
-				'default_layout' => $default_layout,
-			)
-		);
-
-		$user_id = $this->set_admin_user();
-		$this->set_section_layouts_preference(
-			$user_id,
-			array(
-				'analytics/traffic' => $custom_layout,
-			)
-		);
-
-		$response = rest_get_server()->dispatch(
-			new WP_REST_Request( 'DELETE', '/wpcom/v2/dashboards/route_layout_dashboard/sections/analytics/traffic/layout' )
-		);
-
-		$this->assertSame( 200, $response->get_status() );
-		$this->assertSame(
-			array(
-				'id'              => 'analytics/traffic',
-				'label'           => 'Traffic',
-				'order'           => 10,
-				'layout'          => $default_layout,
-				'hasCustomLayout' => false,
-			),
-			$response->get_data()
-		);
-
-		$stored = get_stored_persisted_preferences_for_user( $user_id );
-
-		$this->assertArrayNotHasKey( DASHBOARD_SECTION_LAYOUTS_KEY, $stored[ DASHBOARD_LAYOUT_SCOPE ] );
-		$this->assertSame( 'keep-me', $stored[ DASHBOARD_LAYOUT_SCOPE ]['unrelatedPreference'] );
-	}
-
-	/**
-	 * Delete layout route returns 404 for unknown sections.
-	 */
-	public function test_delete_layout_route_returns_404_for_unknown_section() {
-		$this->set_admin_user();
-
-		$response = rest_get_server()->dispatch(
-			new WP_REST_Request( 'DELETE', '/wpcom/v2/dashboards/route_layout_dashboard/sections/analytics/missing/layout' )
-		);
-
-		$this->assertSame( 404, $response->get_status() );
-		$this->assertSame( 'dashboard_section_not_found', $response->as_error()->get_error_code() );
-	}
-
-	/**
-	 * Delete layout route returns 404 for unavailable sections.
-	 */
-	public function test_delete_layout_route_returns_404_for_unavailable_section() {
-		register_dashboard_section(
-			'route_unavailable_dashboard',
-			'analytics/insights',
-			array(
-				'label'        => 'Insights',
-				'order'        => 10,
-				'is_available' => '__return_false',
-			)
-		);
-
-		$this->set_admin_user();
-
-		$response = rest_get_server()->dispatch(
-			new WP_REST_Request( 'DELETE', '/wpcom/v2/dashboards/route_unavailable_dashboard/sections/analytics/insights/layout' )
-		);
-
-		$this->assertSame( 404, $response->get_status() );
-		$this->assertSame( 'dashboard_section_unavailable', $response->as_error()->get_error_code() );
-	}
-
-	/**
-	 * Delete sections route resets every custom section layout.
-	 */
-	public function test_delete_sections_route_resets_all_section_layouts() {
-		$traffic_default  = array(
-			array(
-				'uuid' => 'default-traffic-widget',
-				'type' => 'example/widget',
-			),
-		);
-		$insights_default = array(
-			array(
-				'uuid' => 'default-insights-widget',
-				'type' => 'example/widget',
-			),
-		);
-		$traffic_custom   = array(
-			array(
-				'uuid' => 'custom-traffic-widget',
-				'type' => 'example/widget',
-			),
-		);
-		$insights_custom  = array(
-			array(
-				'uuid' => 'custom-insights-widget',
-				'type' => 'example/widget',
-			),
-		);
-
-		register_dashboard_section(
-			'route_layout_dashboard',
-			'analytics/traffic',
-			array(
-				'label'          => 'Traffic',
-				'order'          => 10,
-				'default_layout' => $traffic_default,
-			)
-		);
-		register_dashboard_section(
-			'route_layout_dashboard',
-			'analytics/insights',
-			array(
-				'label'          => 'Insights',
-				'order'          => 20,
-				'default_layout' => $insights_default,
-			)
-		);
-
-		$user_id = $this->set_admin_user();
-		$this->set_section_layouts_preference(
-			$user_id,
-			array(
-				'analytics/traffic'  => $traffic_custom,
-				'analytics/insights' => $insights_custom,
-			)
-		);
-
-		$response = rest_get_server()->dispatch(
-			new WP_REST_Request( 'DELETE', '/wpcom/v2/dashboards/route_layout_dashboard/sections' )
-		);
-
-		$this->assertSame( 200, $response->get_status() );
-		$this->assertSame(
-			array(
-				array(
-					'id'              => 'analytics/traffic',
-					'label'           => 'Traffic',
-					'order'           => 10,
-					'layout'          => $traffic_default,
-					'hasCustomLayout' => false,
-				),
-				array(
-					'id'              => 'analytics/insights',
-					'label'           => 'Insights',
-					'order'           => 20,
-					'layout'          => $insights_default,
-					'hasCustomLayout' => false,
-				),
-			),
-			$response->get_data()
-		);
-
-		$stored = get_stored_persisted_preferences_for_user( $user_id );
-
-		$this->assertArrayNotHasKey( DASHBOARD_SECTION_LAYOUTS_KEY, $stored[ DASHBOARD_LAYOUT_SCOPE ] );
-		$this->assertSame( 'keep-me', $stored[ DASHBOARD_LAYOUT_SCOPE ]['unrelatedPreference'] );
-	}
-
-	/**
-	 * Delete sections route removes the empty dashboard scope.
-	 */
-	public function test_delete_sections_route_removes_empty_dashboard_scope() {
-		register_dashboard_section(
-			'route_layout_dashboard',
-			'analytics/traffic',
-			array(
-				'label' => 'Traffic',
-				'order' => 10,
-			)
-		);
-
-		$user_id = $this->set_admin_user();
-		update_user_meta(
-			$user_id,
-			get_persisted_preferences_meta_key(),
-			array(
-				DASHBOARD_LAYOUT_SCOPE => array(
-					DASHBOARD_SECTION_LAYOUTS_KEY => array(
-						'analytics/traffic' => array(
-							array(
-								'uuid' => 'custom-traffic-widget',
-								'type' => 'example/widget',
-							),
-						),
-					),
-				),
-			)
-		);
-
-		$response = rest_get_server()->dispatch(
-			new WP_REST_Request( 'DELETE', '/wpcom/v2/dashboards/route_layout_dashboard/sections' )
-		);
-
-		$this->assertSame( 200, $response->get_status() );
-
-		$stored = get_stored_persisted_preferences_for_user( $user_id );
-
-		$this->assertArrayNotHasKey( DASHBOARD_LAYOUT_SCOPE, $stored );
-	}
-
-	/**
-	 * Delete sections route requires manage_options.
-	 */
-	public function test_delete_sections_route_requires_manage_options() {
-		wp_set_current_user( 0 );
-
-		$response = rest_get_server()->dispatch(
-			new WP_REST_Request( 'DELETE', '/wpcom/v2/dashboards/route_layout_dashboard/sections' )
-		);
-
-		$this->assertSame( 401, $response->get_status() );
+			$this->assertSame( 404, $response->get_status(), $case );
+			$this->assertSame( 'rest_no_route', $response->as_error()->get_error_code(), $case );
+		}
 	}
 
 	/**
@@ -1190,25 +735,5 @@ class Dashboard_Section_Test extends BaseTestCase {
 		wp_set_current_user( $admin_id );
 
 		return $admin_id;
-	}
-
-	/**
-	 * Store section layout preferences for a user.
-	 *
-	 * @param int   $user_id         User ID.
-	 * @param array $section_layouts Section layout map.
-	 * @return void
-	 */
-	private function set_section_layouts_preference( $user_id, $section_layouts ) {
-		update_user_meta(
-			$user_id,
-			get_persisted_preferences_meta_key(),
-			array(
-				DASHBOARD_LAYOUT_SCOPE => array(
-					'unrelatedPreference'         => 'keep-me',
-					DASHBOARD_SECTION_LAYOUTS_KEY => $section_layouts,
-				),
-			)
-		);
 	}
 }


### PR DESCRIPTION
Fixes #

## Proposed changes

First of two PRs wiring the dashboard tab bar to the server-side section registry (see the linked plan discussion). This one lands the server contract only — there is no live JS consumer of these routes yet, so it is safe to reshape them. A follow-up PR will make the frontend consume `GET /sections`.

* Add a `slug` to `Dashboard_Section`, derived from the section ID segment after the namespace (`analytics/traffic` → `traffic`, `woocommerce/store` → `store`), and expose it in the REST representation. The frontend will use the slug for `?section=` URLs and preference keys, so existing bookmarks and stored layouts keep working with zero migration.
* Trim `GET /wpcom/v2/dashboards/{name}/sections` to return section definitions only — `{ id, slug, label, order }` per section. The resolved `layout` and `hasCustomLayout` fields are gone: layout persistence stays entirely on core `@wordpress/preferences` (`dashboardSectionLayouts` key), which already covers reads and writes.
* Retire the unused section-layout write surface and the per-user helpers that only served it:
  * `PUT /dashboards/{name}/sections/{ns}/{slug}/layout`
  * `DELETE /dashboards/{name}/sections/{ns}/{slug}/layout`
  * `DELETE /dashboards/{name}/sections` (reset-all)
  * `get_dashboard_section_layouts_for_user()`, `update/delete_dashboard_section_layout_for_user()`, `delete_dashboard_section_layouts_for_user()`, `get_stored_persisted_preferences_for_user()`, and the section-layout validators.
* Keep `GET /sections` and `GET .../default-layout` (the reset path) unchanged, along with the inject-on-read default seeding in `dashboard-layout.php`.
* Relabel the `woocommerce/store` section from "WooCommerce" to "Store", matching the label the static frontend tab uses today, so switching to server-driven labels causes no visible change.

## Related product discussion/links

* Successor to the approach in #49924 (closed); the registry itself landed via #50167, #50205, #50364, and #50372. This series connects the frontend to it instead of building a parallel layout-persistence layer.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `cd projects/packages/premium-analytics && composer phpunit` — the suite covers the new `slug` field, the lean `GET /sections` response shape, WooCommerce availability filtering via the `jetpack_premium_analytics_woocommerce_dashboard_section_available` filter, the retired routes returning `404 rest_no_route`, ordering, and the `manage_options` permission check.

### In the browser with `wp.apiFetch`

On a Jetpack-connected test site with this branch built, log in as an admin, open the Premium Analytics dashboard (or the block editor — any admin screen that loads `wp-api-fetch`), and run in the browser console:

1. The sections read returns definitions only:
   ```js
   await wp.apiFetch( { path: '/wpcom/v2/dashboards/jetpack-premium-analytics_dashboard/sections' } );
   ```
   Expect an ordered array of `{ id, slug, label, order }` objects only — no `layout` or `hasCustomLayout` keys. With WooCommerce active it ends with `{ id: 'woocommerce/store', slug: 'store', label: 'Store', order: 40 }`; with WooCommerce deactivated that entry disappears.
2. The default-layout read (reset path) still works:
   ```js
   await wp.apiFetch( { path: '/wpcom/v2/dashboards/jetpack-premium-analytics_dashboard/sections/analytics/traffic/default-layout' } );
   ```
   Expect an array of widget instances.
3. The retired write routes are gone — each of these must reject with `rest_no_route` (404):
   ```js
   await wp.apiFetch( { path: '/wpcom/v2/dashboards/jetpack-premium-analytics_dashboard/sections/analytics/traffic/layout', method: 'PUT', data: { layout: [] } } );
   await wp.apiFetch( { path: '/wpcom/v2/dashboards/jetpack-premium-analytics_dashboard/sections/analytics/traffic/layout', method: 'DELETE' } );
   await wp.apiFetch( { path: '/wpcom/v2/dashboards/jetpack-premium-analytics_dashboard/sections', method: 'DELETE' } );
   ```

### No user-facing change

The dashboard UI is unaffected: the tab bar still renders from the static frontend config (no JS consumer of these routes exists yet), and layout customization/reset still works through core preferences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KKXV17Z2FVzrtTt8zK5RaF
