### PR TITLE
Premium Analytics: drive dashboard tabs from the section registry

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-premium-analytics-frontend-sections
+++ b/projects/packages/premium-analytics/changelog/update-premium-analytics-frontend-sections
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Dashboard: drive the section tab bar from the server-side section registry — the GET /sections response is preloaded into the page render, ?section= is validated against the available slugs with URL rewrite on fallback, and the Store tab renders only when WooCommerce is active.

--- a/projects/packages/premium-analytics/packages/init/src/index.ts
+++ b/projects/packages/premium-analytics/packages/init/src/index.ts
@@ -13,9 +13,11 @@ import { chartBar } from '@wordpress/icons';
 let authConfigured = false;
 
 /**
- * Configure the bundled apiFetch instance with the WordPress REST API root URL
- * and authentication nonce from Jetpack script data. Runs once before routes
- * render so shared packages (e.g. site-sync) can call the REST API.
+ * Configure the bundled apiFetch instance with the WordPress REST API root URL,
+ * authentication nonce, and server-printed response preloads from Jetpack
+ * script data. Runs once before routes render so shared packages (e.g.
+ * site-sync) can call the REST API and preloaded requests resolve without a
+ * network round trip.
  */
 function setupApiFetch(): void {
 	if ( authConfigured ) {
@@ -28,9 +30,16 @@ function setupApiFetch(): void {
 	if ( site?.rest_nonce ) {
 		apiFetch.use( apiFetch.createNonceMiddleware( site.rest_nonce ) );
 	}
+	// The dashboard page render prints the `GET /sections` response keyed by
+	// its REST path; the preloading middleware serves it to the first matching
+	// apiFetch call instead of hitting the network.
+	const sectionsPreload = getScriptData()?.premium_analytics?.dashboard_sections_preload;
+	if ( sectionsPreload ) {
+		apiFetch.use( apiFetch.createPreloadingMiddleware( sectionsPreload ) );
+	}
 	// Only latch once we actually registered, so an early call before
 	// script-data is ready doesn't permanently skip configuration.
-	if ( site?.rest_root || site?.rest_nonce ) {
+	if ( site?.rest_root || site?.rest_nonce || sectionsPreload ) {
 		authConfigured = true;
 	}
 }

--- a/projects/packages/premium-analytics/packages/site-sync/src/jetpack-script-data.d.ts
+++ b/projects/packages/premium-analytics/packages/site-sync/src/jetpack-script-data.d.ts
@@ -15,6 +15,10 @@ declare module '@automattic/jetpack-script-data' {
 			has_store_data: boolean;
 			// Whether experimental CSV export controls should render.
 			csv_exports_enabled?: boolean;
+			// Preloaded `GET /sections` responses keyed by REST path, printed by
+			// the dashboard page render. Consumed by apiFetch's preloading
+			// middleware and the dashboard's section hooks.
+			dashboard_sections_preload?: Record< string, { body?: unknown } >;
 		};
 	}
 }

--- a/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.tsx
@@ -32,6 +32,9 @@ type DashboardSectionsProps = {
  * changes upward. Panel children are rendered inside the same Tabs.Root so the
  * tablist and section content share a complete tab/panel relationship.
  *
+ * Tabs are keyed by the section `slug` — the URL-facing identifier the active
+ * section state uses — not the namespaced `id`.
+ *
  * @param props          - Component props.
  * @param props.sections - The sections to render, in order.
  * @param props.value    - The currently active section ID.
@@ -47,7 +50,7 @@ export function DashboardSections( {
 }: DashboardSectionsProps ) {
 	return (
 		<SectionTabs
-			tabs={ sections }
+			tabs={ sections.map( ( { slug, label } ) => ( { id: slug, label } ) ) }
 			value={ value }
 			onChange={ onChange }
 			rootClassName={ styles.root }

--- a/projects/packages/premium-analytics/routes/dashboard/config/index.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/index.ts
@@ -1,8 +1,7 @@
 export {
-	DASHBOARD_SECTION_IDS,
-	DEFAULT_SECTION_ID,
-	getSectionLabel,
-	getDashboardSections,
+	getDashboardSectionsPath,
+	getPreloadedDashboardSections,
+	normalizeDashboardSections,
 	resolveSectionId,
 	type DashboardSection,
 	type DashboardSectionId,

--- a/projects/packages/premium-analytics/routes/dashboard/config/section-layouts.test.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/section-layouts.test.ts
@@ -13,12 +13,15 @@ describe( 'section layouts config', () => {
 		).toBe( true );
 	} );
 
-	it( 'rejects unknown section keys', () => {
+	it( 'accepts keys for sections not currently available', () => {
+		// Slugs are server-driven, so the map must keep layouts for sections
+		// that are temporarily unavailable (e.g. store with WooCommerce off).
 		expect(
 			isDashboardSectionLayouts( {
-				unknown: [],
+				store: [],
+				conversions: [],
 			} )
-		).toBe( false );
+		).toBe( true );
 	} );
 
 	it( 'rejects non-array layouts', () => {
@@ -27,5 +30,10 @@ describe( 'section layouts config', () => {
 				traffic: {},
 			} )
 		).toBe( false );
+	} );
+
+	it( 'rejects non-object values', () => {
+		expect( isDashboardSectionLayouts( [ [] ] ) ).toBe( false );
+		expect( isDashboardSectionLayouts( null ) ).toBe( false );
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/dashboard/config/section-layouts.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/section-layouts.ts
@@ -1,13 +1,15 @@
-import { DASHBOARD_SECTION_IDS } from './sections';
 import type { DashboardSectionId } from './sections';
 import type { DashboardWidget } from '@wordpress/widget-dashboard';
 
 export type DashboardSectionLayouts = Partial< Record< DashboardSectionId, DashboardWidget[] > >;
 
-const SECTION_IDS = new Set< string >( DASHBOARD_SECTION_IDS );
-
 /**
  * Check whether a value can be used as the persisted section layout map.
+ *
+ * Keys are section slugs, which are server-driven, so any string key is
+ * accepted: a stored layout must survive its section becoming unavailable
+ * (e.g. the store section after WooCommerce is deactivated) so it is still
+ * there when the section comes back.
  *
  * @param value - Candidate preference value.
  * @return Whether the value is a valid section layout map.
@@ -17,7 +19,5 @@ export function isDashboardSectionLayouts( value: unknown ): value is DashboardS
 		return false;
 	}
 
-	return Object.entries( value ).every(
-		( [ sectionId, layout ] ) => SECTION_IDS.has( sectionId ) && Array.isArray( layout )
-	);
+	return Object.values( value ).every( layout => Array.isArray( layout ) );
 }

--- a/projects/packages/premium-analytics/routes/dashboard/config/sections.test.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/sections.test.ts
@@ -1,35 +1,143 @@
-import { __ } from '@wordpress/i18n';
+/**
+ * External dependencies
+ */
+import { getScriptData } from '@automattic/jetpack-script-data';
+/**
+ * Internal dependencies
+ */
 import {
-	DASHBOARD_SECTION_IDS,
-	DEFAULT_SECTION_ID,
-	getDashboardSections,
+	getDashboardSectionsPath,
+	getPreloadedDashboardSections,
+	normalizeDashboardSections,
 	resolveSectionId,
+	type DashboardSection,
 } from './sections';
 
-jest.mock( '@wordpress/i18n', () => ( {
-	__: jest.fn( ( text: string ) => text ),
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	getScriptData: jest.fn(),
 } ) );
 
-describe( 'dashboard sections', () => {
-	it( 'builds the ordered section definitions', () => {
-		expect( getDashboardSections() ).toEqual( [
-			{ id: 'traffic', label: 'Traffic' },
-			{ id: 'insights', label: 'Insights' },
-			{ id: 'subscribers', label: 'Subscribers' },
-			{ id: 'store', label: 'Store' },
+const mockGetScriptData = getScriptData as jest.Mock;
+
+const DASHBOARD_NAME = 'jetpack-premium-analytics_dashboard';
+const SECTIONS_PATH = `/wpcom/v2/dashboards/${ DASHBOARD_NAME }/sections`;
+
+const SERVER_SECTIONS: DashboardSection[] = [
+	{ id: 'analytics/traffic', slug: 'traffic', label: 'Traffic', order: 10 },
+	{ id: 'analytics/insights', slug: 'insights', label: 'Insights', order: 20 },
+	{ id: 'analytics/subscribers', slug: 'subscribers', label: 'Subscribers', order: 30 },
+	{ id: 'woocommerce/store', slug: 'store', label: 'Store', order: 40 },
+];
+
+/**
+ * Point the mocked script data at a sections preload entry.
+ *
+ * @param body - Preloaded response body.
+ * @param path - REST path the preload is keyed by.
+ */
+function mockPreload( body: unknown, path: string = SECTIONS_PATH ) {
+	mockGetScriptData.mockReturnValue( {
+		premium_analytics: {
+			dashboard_sections_preload: { [ path ]: { body } },
+		},
+	} );
+}
+
+beforeEach( () => {
+	mockGetScriptData.mockReset();
+} );
+
+describe( 'getDashboardSectionsPath', () => {
+	it( 'builds the sections REST path for a dashboard', () => {
+		expect( getDashboardSectionsPath( DASHBOARD_NAME ) ).toBe( SECTIONS_PATH );
+	} );
+} );
+
+describe( 'normalizeDashboardSections', () => {
+	it( 'keeps entries carrying the server section shape', () => {
+		expect( normalizeDashboardSections( SERVER_SECTIONS ) ).toEqual( SERVER_SECTIONS );
+	} );
+
+	it( 'drops entries missing the section shape', () => {
+		expect(
+			normalizeDashboardSections( [
+				SERVER_SECTIONS[ 0 ],
+				{ id: 'analytics/broken', label: 'No slug', order: 20 },
+				{ id: 'analytics/empty', slug: '', label: 'Empty slug', order: 30 },
+				'not-a-section',
+				null,
+			] )
+		).toEqual( [ SERVER_SECTIONS[ 0 ] ] );
+	} );
+
+	it( 'returns an empty list for non-array payloads', () => {
+		expect( normalizeDashboardSections( undefined ) ).toEqual( [] );
+		expect( normalizeDashboardSections( { sections: SERVER_SECTIONS } ) ).toEqual( [] );
+	} );
+} );
+
+describe( 'getPreloadedDashboardSections', () => {
+	it( 'reads the preload entry keyed by the dashboard sections path', () => {
+		mockPreload( SERVER_SECTIONS );
+
+		expect( getPreloadedDashboardSections( DASHBOARD_NAME ) ).toEqual( SERVER_SECTIONS );
+	} );
+
+	it( 'omits the store section when the server filtered it out', () => {
+		// With WooCommerce inactive the registry's availability gate drops the
+		// section server-side, so the preload simply does not carry it.
+		mockPreload( SERVER_SECTIONS.slice( 0, 3 ) );
+
+		expect( getPreloadedDashboardSections( DASHBOARD_NAME ).map( s => s.slug ) ).toEqual( [
+			'traffic',
+			'insights',
+			'subscribers',
+		] );
+	} );
+
+	it( 'surfaces a synthetic registered section', () => {
+		// Any available section registered against the server registry renders,
+		// proving the extension path works without frontend changes.
+		mockPreload( [
+			...SERVER_SECTIONS,
+			{ id: 'acme/conversions', slug: 'conversions', label: 'Conversions', order: 50 },
 		] );
 
-		expect( __ ).toHaveBeenCalledWith( 'Traffic', 'jetpack-premium-analytics' );
+		expect( getPreloadedDashboardSections( DASHBOARD_NAME ).map( s => s.slug ) ).toContain(
+			'conversions'
+		);
 	} );
 
-	it( 'keeps the default section first', () => {
-		expect( DEFAULT_SECTION_ID ).toBe( 'traffic' );
-		expect( DASHBOARD_SECTION_IDS[ 0 ] ).toBe( DEFAULT_SECTION_ID );
+	it( 'returns an empty list when no preload is present', () => {
+		mockGetScriptData.mockReturnValue( {} );
+
+		expect( getPreloadedDashboardSections( DASHBOARD_NAME ) ).toEqual( [] );
 	} );
 
-	it( 'resolves unknown section search values to the default section', () => {
-		expect( resolveSectionId( 'insights' ) ).toBe( 'insights' );
-		expect( resolveSectionId( 'missing' ) ).toBe( DEFAULT_SECTION_ID );
-		expect( resolveSectionId( undefined ) ).toBe( DEFAULT_SECTION_ID );
+	it( 'returns an empty list for a different dashboard name', () => {
+		mockPreload( SERVER_SECTIONS );
+
+		expect( getPreloadedDashboardSections( 'other_dashboard' ) ).toEqual( [] );
+	} );
+} );
+
+describe( 'resolveSectionId', () => {
+	it( 'keeps a slug matching an available section', () => {
+		expect( resolveSectionId( 'insights', SERVER_SECTIONS ) ).toBe( 'insights' );
+	} );
+
+	it( 'falls back to the first section by order for stale or unavailable slugs', () => {
+		const withoutStore = SERVER_SECTIONS.slice( 0, 3 );
+
+		expect( resolveSectionId( 'store', withoutStore ) ).toBe( 'traffic' );
+		expect( resolveSectionId( 'missing', SERVER_SECTIONS ) ).toBe( 'traffic' );
+	} );
+
+	it( 'falls back to the first section when no value is given', () => {
+		expect( resolveSectionId( undefined, SERVER_SECTIONS ) ).toBe( 'traffic' );
+	} );
+
+	it( 'returns an empty slug when no sections are available yet', () => {
+		expect( resolveSectionId( 'traffic', [] ) ).toBe( '' );
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/dashboard/config/sections.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/sections.ts
@@ -1,87 +1,131 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import { getScriptData } from '@automattic/jetpack-script-data';
+/**
+ * Internal dependencies
+ */
+import { DASHBOARD_REST_NAMESPACE } from '../hooks/constants';
 
 /**
- * Ordered list of the dashboard section IDs.
+ * A dashboard section definition, as served by
+ * `GET /dashboards/{name}/sections` (see `getDashboardSectionsPath`).
  *
- * This is the single source of truth for which sections exist and in what order.
- * Each section is surfaced as a tab and renders the customizable widget grid,
- * so the IDs are kept stable and URL-friendly (they are persisted in the
- * `?section=` search param).
- */
-export const DASHBOARD_SECTION_IDS = [ 'traffic', 'insights', 'subscribers', 'store' ] as const;
-
-/**
- * Dashboard section identifier.
- * Derived from DASHBOARD_SECTION_IDS to keep the union in sync with the source list.
- */
-export type DashboardSectionId = ( typeof DASHBOARD_SECTION_IDS )[ number ];
-
-/**
- * Default section shown when the URL has no (or an unknown) `section` param.
- */
-export const DEFAULT_SECTION_ID: DashboardSectionId = 'traffic';
-
-/**
- * A dashboard section definition.
- *
- * For now a section is just an ID and a display label. This is the natural place
- * to attach per-section metadata such as the default widget layout.
+ * The server-side section registry is the single source of truth for which
+ * sections exist, in what order, and with which labels — the WooCommerce
+ * section, for example, is only present when WooCommerce is active.
  */
 export type DashboardSection = {
-	id: DashboardSectionId;
+	/**
+	 * Canonical namespaced identifier, e.g. `analytics/traffic`.
+	 */
+	id: string;
+
+	/**
+	 * URL-facing slug (the segment after the namespace), e.g. `traffic`.
+	 * Persisted in the `?section=` search param and as the section-layout
+	 * preference key, so it stays short and stable.
+	 */
+	slug: string;
+
+	/**
+	 * Translated display label.
+	 */
 	label: string;
+
+	/**
+	 * Sort order (ascending).
+	 */
+	order: number;
 };
 
 /**
- * Canonical section definitions with lazy label getters, in display order.
- *
- * Labels are defined once here, as getters resolved at call time, so translations
- * are applied after the i18n locale data has loaded. Mirrors the datetime
- * package's `PRESET_DEFINITIONS`.
+ * Dashboard section identifier as used by the frontend: the URL-facing `slug`
+ * of a `DashboardSection`. Server-driven, so no longer a static union.
  */
-const SECTION_DEFINITIONS: ReadonlyArray< {
-	id: DashboardSectionId;
-	getLabel: () => string;
-} > = [
-	{ id: 'traffic', getLabel: () => __( 'Traffic', 'jetpack-premium-analytics' ) },
-	{ id: 'insights', getLabel: () => __( 'Insights', 'jetpack-premium-analytics' ) },
-	{ id: 'subscribers', getLabel: () => __( 'Subscribers', 'jetpack-premium-analytics' ) },
-	{ id: 'store', getLabel: () => __( 'Store', 'jetpack-premium-analytics' ) },
-];
+export type DashboardSectionId = string;
 
 /**
- * Get the translated display label for a section.
+ * Build the REST path serving a dashboard's section definitions.
  *
- * @param id - The section identifier.
- * @return Translated label for the section.
+ * @param dashboardName - Dashboard registration name.
+ * @return The `GET /sections` REST path.
  */
-export function getSectionLabel( id: DashboardSectionId ): string {
-	return SECTION_DEFINITIONS.find( section => section.id === id )?.getLabel() ?? id;
+export function getDashboardSectionsPath( dashboardName: string ): string {
+	return `/${ DASHBOARD_REST_NAMESPACE }/dashboards/${ dashboardName }/sections`;
 }
 
 /**
- * Build the ordered list of section definitions ({ id, label }).
+ * Narrow an arbitrary value to a dashboard section definition.
  *
- * Labels are resolved lazily (at call time) so translations are applied after
- * the i18n locale data has loaded.
- *
- * @return Ordered list of section definitions.
+ * @param value - Candidate section.
+ * @return Whether the value carries the server section shape.
  */
-export function getDashboardSections(): DashboardSection[] {
-	return SECTION_DEFINITIONS.map( ( { id, getLabel } ) => ( { id, label: getLabel() } ) );
+function isDashboardSection( value: unknown ): value is DashboardSection {
+	if ( ! value || typeof value !== 'object' ) {
+		return false;
+	}
+
+	const { id, slug, label, order } = value as Record< string, unknown >;
+
+	return (
+		typeof id === 'string' &&
+		typeof slug === 'string' &&
+		slug !== '' &&
+		typeof label === 'string' &&
+		typeof order === 'number'
+	);
 }
 
 /**
- * Narrow an arbitrary string to a known section ID, falling back to the default.
+ * Narrow a `GET /sections` response to a list of section definitions.
  *
- * @param value - The candidate section ID (e.g. from the URL).
- * @return A valid section ID.
+ * The payload crosses a serialization boundary (REST response or script-data
+ * preload), so entries that don't carry the section shape are dropped rather
+ * than propagated into the tab bar.
+ *
+ * @param value - Candidate response body.
+ * @return The section definitions, in server order.
  */
-export function resolveSectionId( value: string | undefined ): DashboardSectionId {
-	return value && ( DASHBOARD_SECTION_IDS as readonly string[] ).includes( value )
-		? ( value as DashboardSectionId )
-		: DEFAULT_SECTION_ID;
+export function normalizeDashboardSections( value: unknown ): DashboardSection[] {
+	return Array.isArray( value ) ? value.filter( isDashboardSection ) : [];
+}
+
+/**
+ * Read the server-printed `GET /sections` preload for a dashboard.
+ *
+ * The dashboard page render injects the response into JetpackScriptData keyed
+ * by REST path, so the section list is available synchronously on first paint
+ * — before any request resolves — and `?section=` resolution sees the full
+ * slug set.
+ *
+ * @param dashboardName - Dashboard registration name.
+ * @return The preloaded sections, or an empty list when no preload is present.
+ */
+export function getPreloadedDashboardSections( dashboardName: string ): DashboardSection[] {
+	const preload = getScriptData()?.premium_analytics?.dashboard_sections_preload;
+
+	return normalizeDashboardSections( preload?.[ getDashboardSectionsPath( dashboardName ) ]?.body );
+}
+
+/**
+ * Narrow an arbitrary string to an available section slug, falling back to the
+ * first section by order.
+ *
+ * A miss covers both stale slugs (an old bookmark) and currently unavailable
+ * sections (`?section=store` with WooCommerce off).
+ *
+ * @param value    - The candidate section slug (e.g. from the URL).
+ * @param sections - The available sections, in order.
+ * @return The resolved section slug, or an empty string when no sections exist.
+ */
+export function resolveSectionId(
+	value: string | undefined,
+	sections: DashboardSection[]
+): DashboardSectionId {
+	if ( value && sections.some( section => section.slug === value ) ) {
+		return value;
+	}
+
+	return sections[ 0 ]?.slug ?? '';
 }

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/use-active-section.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/use-active-section.test.tsx
@@ -1,0 +1,94 @@
+/**
+ * External dependencies
+ */
+import { useStagedSearch } from '@jetpack-premium-analytics/routing';
+import { act, renderHook } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import { useActiveSection } from './use-active-section';
+import type { DashboardSection } from '../config';
+
+jest.mock( '@jetpack-premium-analytics/routing', () => ( {
+	useStagedSearch: jest.fn(),
+} ) );
+
+const mockUseStagedSearch = useStagedSearch as jest.Mock;
+
+const SECTIONS: DashboardSection[] = [
+	{ id: 'analytics/traffic', slug: 'traffic', label: 'Traffic', order: 10 },
+	{ id: 'analytics/insights', slug: 'insights', label: 'Insights', order: 20 },
+];
+
+/**
+ * Mock the staged-search state with a given `?section=` value.
+ *
+ * @param section - The effective section search param.
+ * @return The stage and commit spies.
+ */
+function mockSearch( section: string | undefined ) {
+	const stage = jest.fn();
+	const commit = jest.fn();
+	mockUseStagedSearch.mockReturnValue( { effective: { section }, stage, commit } );
+
+	return { stage, commit };
+}
+
+beforeEach( () => {
+	mockUseStagedSearch.mockReset();
+} );
+
+describe( 'useActiveSection', () => {
+	it( 'keeps a valid section slug and leaves the URL alone', () => {
+		const { stage, commit } = mockSearch( 'insights' );
+
+		const { result } = renderHook( () => useActiveSection( SECTIONS ) );
+
+		expect( result.current[ 0 ] ).toBe( 'insights' );
+		expect( stage ).not.toHaveBeenCalled();
+		expect( commit ).not.toHaveBeenCalled();
+	} );
+
+	it( 'falls back to the first section and rewrites the URL for a stale slug', () => {
+		const { stage, commit } = mockSearch( 'store' );
+
+		const { result } = renderHook( () => useActiveSection( SECTIONS ) );
+
+		expect( result.current[ 0 ] ).toBe( 'traffic' );
+		expect( stage ).toHaveBeenCalledWith( { section: 'traffic' } );
+		expect( commit ).toHaveBeenCalledWith( { replace: true } );
+	} );
+
+	it( 'defaults to the first section without rewriting a clean URL', () => {
+		const { stage, commit } = mockSearch( undefined );
+
+		const { result } = renderHook( () => useActiveSection( SECTIONS ) );
+
+		expect( result.current[ 0 ] ).toBe( 'traffic' );
+		expect( stage ).not.toHaveBeenCalled();
+		expect( commit ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not rewrite while the section list is still empty', () => {
+		const { stage, commit } = mockSearch( 'traffic' );
+
+		const { result } = renderHook( () => useActiveSection( [] ) );
+
+		expect( result.current[ 0 ] ).toBe( '' );
+		expect( stage ).not.toHaveBeenCalled();
+		expect( commit ).not.toHaveBeenCalled();
+	} );
+
+	it( 'pushes one history entry per explicit section switch', () => {
+		const { stage, commit } = mockSearch( 'traffic' );
+
+		const { result } = renderHook( () => useActiveSection( SECTIONS ) );
+
+		act( () => {
+			result.current[ 1 ]( 'insights' );
+		} );
+
+		expect( stage ).toHaveBeenCalledWith( { section: 'insights' } );
+		expect( commit ).toHaveBeenCalledWith( { replace: false } );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/use-active-section.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/use-active-section.ts
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import { useStagedSearch } from '@jetpack-premium-analytics/routing';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 /**
  * Internal dependencies
  */
-import { resolveSectionId, type DashboardSectionId } from '../config';
+import { resolveSectionId, type DashboardSection, type DashboardSectionId } from '../config';
 import { route } from '../package.json';
 
 /**
@@ -28,14 +28,36 @@ type SectionSearch = {
  * shares the same search-param model as the date filters; switching a section is an
  * immediate stage + commit (one history entry per change).
  *
- * @return A tuple of the active section ID and a setter to change it.
+ * The raw `?section=` value is validated against the available sections — a
+ * miss (a stale slug, or a currently unavailable section like `store` with
+ * WooCommerce off) resolves to the first section by order and the URL is
+ * rewritten in place to the resolved slug.
+ *
+ * @param sections - The available sections, in order.
+ * @return A tuple of the active section slug and a setter to change it.
  */
-export function useActiveSection(): [ DashboardSectionId, ( id: DashboardSectionId ) => void ] {
+export function useActiveSection(
+	sections: DashboardSection[]
+): [ DashboardSectionId, ( id: DashboardSectionId ) => void ] {
 	const { effective, stage, commit } = useStagedSearch< SectionSearch, typeof ROUTE_FROM >( {
 		from: ROUTE_FROM,
 	} );
 
-	const activeSection = resolveSectionId( effective.section );
+	const activeSection = resolveSectionId( effective.section, sections );
+
+	// Rewrite an unresolvable `?section=` to the slug actually rendered, so the
+	// URL never advertises a section that isn't shown. Replace instead of push:
+	// the invalid URL should not survive as a history entry.
+	useEffect( () => {
+		if ( sections.length === 0 || effective.section === undefined ) {
+			return;
+		}
+
+		if ( effective.section !== activeSection ) {
+			stage( { section: activeSection } );
+			commit( { replace: true } );
+		}
+	}, [ sections.length, effective.section, activeSection, stage, commit ] );
 
 	const setActiveSection = useCallback(
 		( id: DashboardSectionId ) => {

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-section-layout.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-section-layout.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * External dependencies
+ */
+import { act, renderHook } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import { useDispatch, useSelect } from '@wordpress/data';
+/**
+ * Internal dependencies
+ */
+import { DASHBOARD_NAME, DASHBOARD_PREFERENCES_SCOPE } from './constants';
+import { useDashboardSectionLayout } from './use-dashboard-section-layout';
+import type { DashboardWidget } from '@wordpress/widget-dashboard';
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useSelect: jest.fn(),
+	useDispatch: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/preferences', () => ( {
+	store: 'core/preferences',
+} ) );
+
+const mockApiFetch = apiFetch as unknown as jest.Mock;
+const mockUseSelect = useSelect as jest.Mock;
+const mockUseDispatch = useDispatch as jest.Mock;
+
+const PREFERENCES_KEY = 'dashboardSectionLayouts';
+
+const widget = ( uuid: string ): DashboardWidget => ( { uuid, type: 'jpa/story-widget' } );
+
+/**
+ * Mock the preferences store with stored values keyed by preference name.
+ *
+ * @param stored - Stored preference values.
+ * @return The preferences `set` spy.
+ */
+function mockPreferences( stored: Record< string, unknown > ) {
+	const set = jest.fn();
+
+	mockUseSelect.mockImplementation( selector =>
+		selector( () => ( {
+			get: ( _scope: string, key: string ) => stored[ key ],
+		} ) )
+	);
+	mockUseDispatch.mockReturnValue( { set } );
+
+	return set;
+}
+
+beforeEach( () => {
+	mockApiFetch.mockReset();
+	mockUseSelect.mockReset();
+	mockUseDispatch.mockReset();
+} );
+
+describe( 'useDashboardSectionLayout', () => {
+	it( 'reads the active section layout from the preferences map keyed by slug', () => {
+		mockPreferences( {
+			[ PREFERENCES_KEY ]: { store: [ widget( 'store-widget' ) ] },
+		} );
+
+		const { result } = renderHook( () => useDashboardSectionLayout( DASHBOARD_NAME, 'store' ) );
+
+		expect( result.current[ 0 ] ).toEqual( [ widget( 'store-widget' ) ] );
+	} );
+
+	it( 'writes the section layout through the preferences store', () => {
+		const set = mockPreferences( {
+			[ PREFERENCES_KEY ]: { traffic: [ widget( 'traffic-widget' ) ] },
+		} );
+
+		const { result } = renderHook( () => useDashboardSectionLayout( DASHBOARD_NAME, 'store' ) );
+
+		act( () => {
+			result.current[ 1 ]( [ widget( 'store-widget' ) ] );
+		} );
+
+		expect( set ).toHaveBeenCalledWith( DASHBOARD_PREFERENCES_SCOPE, PREFERENCES_KEY, {
+			traffic: [ widget( 'traffic-widget' ) ],
+			store: [ widget( 'store-widget' ) ],
+		} );
+	} );
+
+	it( 'resets by fetching the section default and persisting it as a preference', async () => {
+		const set = mockPreferences( { [ PREFERENCES_KEY ]: {} } );
+		mockApiFetch.mockResolvedValue( [ widget( 'default-widget' ) ] );
+
+		const { result } = renderHook( () => useDashboardSectionLayout( DASHBOARD_NAME, 'traffic' ) );
+
+		await act( async () => {
+			await result.current[ 2 ]();
+		} );
+
+		expect( mockApiFetch ).toHaveBeenCalledWith( {
+			path: '/wpcom/v2/dashboards/traffic/default-layout',
+		} );
+		expect( set ).toHaveBeenCalledWith( DASHBOARD_PREFERENCES_SCOPE, PREFERENCES_KEY, {
+			traffic: [ widget( 'default-widget' ) ],
+		} );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-sections.test.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-sections.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * External dependencies
+ */
+import { getScriptData } from '@automattic/jetpack-script-data';
+import { renderHook, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+/**
+ * Internal dependencies
+ */
+import { useDashboardSections } from './use-dashboard-sections';
+import type { DashboardSection } from '../config';
+
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	getScriptData: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+const mockGetScriptData = getScriptData as jest.Mock;
+const mockApiFetch = apiFetch as unknown as jest.Mock;
+
+const DASHBOARD_NAME = 'jetpack-premium-analytics_dashboard';
+const SECTIONS_PATH = `/wpcom/v2/dashboards/${ DASHBOARD_NAME }/sections`;
+
+const SERVER_SECTIONS: DashboardSection[] = [
+	{ id: 'analytics/traffic', slug: 'traffic', label: 'Traffic', order: 10 },
+	{ id: 'analytics/insights', slug: 'insights', label: 'Insights', order: 20 },
+	{ id: 'woocommerce/store', slug: 'store', label: 'Store', order: 40 },
+];
+
+beforeEach( () => {
+	mockGetScriptData.mockReset();
+	mockApiFetch.mockReset();
+} );
+
+describe( 'useDashboardSections', () => {
+	it( 'resolves the section list synchronously from the preload', () => {
+		mockGetScriptData.mockReturnValue( {
+			premium_analytics: {
+				dashboard_sections_preload: { [ SECTIONS_PATH ]: { body: SERVER_SECTIONS } },
+			},
+		} );
+
+		const { result } = renderHook( () => useDashboardSections( DASHBOARD_NAME ) );
+
+		// First render already carries the full list — no async gap, no tab-bar flash.
+		expect( result.current ).toEqual( SERVER_SECTIONS );
+		expect( mockApiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'fetches the section list when no preload is present', async () => {
+		mockGetScriptData.mockReturnValue( {} );
+		mockApiFetch.mockResolvedValue( SERVER_SECTIONS );
+
+		const { result } = renderHook( () => useDashboardSections( DASHBOARD_NAME ) );
+
+		expect( result.current ).toEqual( [] );
+
+		await waitFor( () => expect( result.current ).toEqual( SERVER_SECTIONS ) );
+		expect( mockApiFetch ).toHaveBeenCalledWith( { path: SECTIONS_PATH } );
+	} );
+
+	it( 'leaves the section list empty when the fetch fails', async () => {
+		mockGetScriptData.mockReturnValue( {} );
+		mockApiFetch.mockRejectedValue( new Error( 'nope' ) );
+
+		const { result } = renderHook( () => useDashboardSections( DASHBOARD_NAME ) );
+
+		await waitFor( () => expect( mockApiFetch ).toHaveBeenCalled() );
+		expect( result.current ).toEqual( [] );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-sections.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-sections.ts
@@ -1,21 +1,60 @@
 /**
  * External dependencies
  */
-import { useMemo } from 'react';
+import apiFetch from '@wordpress/api-fetch';
+import { useEffect, useState } from 'react';
 /**
  * Internal dependencies
  */
-import { getDashboardSections, type DashboardSection } from '../config';
+import {
+	getDashboardSectionsPath,
+	getPreloadedDashboardSections,
+	normalizeDashboardSections,
+	type DashboardSection,
+} from '../config';
 
 /**
- * Get the ordered list of dashboard sections.
+ * Get the ordered list of dashboard sections from the server-side registry.
  *
- * Wraps the pure `getDashboardSections()` builder in `useMemo` so the section
- * list (and its translated labels) is built once per mount instead of on every
- * render. The section set is static, so an empty dependency array is correct.
+ * The section list — which tabs exist, in what order, labelled how — is
+ * server-driven via `GET /sections`, so conditional sections (e.g. the store
+ * section, present only when WooCommerce is active) never render a dead tab.
  *
- * @return The ordered, memoized list of dashboard sections.
+ * The dashboard page render preloads the response into script data, so the
+ * list is resolved synchronously on first render — no tab-bar flash. The
+ * REST request only runs when the preload is absent (e.g. a stale page
+ * render); it resolves from the same registry.
+ *
+ * @param dashboardName - Dashboard registration name.
+ * @return The ordered list of dashboard sections.
  */
-export function useDashboardSections(): DashboardSection[] {
-	return useMemo( () => getDashboardSections(), [] );
+export function useDashboardSections( dashboardName: string ): DashboardSection[] {
+	const [ sections, setSections ] = useState< DashboardSection[] >( () =>
+		getPreloadedDashboardSections( dashboardName )
+	);
+
+	useEffect( () => {
+		if ( getPreloadedDashboardSections( dashboardName ).length > 0 ) {
+			return;
+		}
+
+		let cancelled = false;
+
+		apiFetch( { path: getDashboardSectionsPath( dashboardName ) } )
+			.then( response => {
+				if ( ! cancelled ) {
+					setSections( normalizeDashboardSections( response ) );
+				}
+			} )
+			.catch( () => {
+				// Leave the section list empty; the dashboard renders no tabs
+				// rather than inventing a stale static list.
+			} );
+
+		return () => {
+			cancelled = true;
+		};
+	}, [ dashboardName ] );
+
+	return sections;
 }

--- a/projects/packages/premium-analytics/routes/dashboard/package.json
+++ b/projects/packages/premium-analytics/routes/dashboard/package.json
@@ -25,5 +25,8 @@
 		"date-fns": "4.1.0",
 		"fast-deep-equal": "^3.1.3",
 		"react": "18.3.1"
+	},
+	"devDependencies": {
+		"@testing-library/react": "16.3.2"
 	}
 }

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -24,8 +24,8 @@ import styles from './stage.module.scss';
  * @return {JSX.Element} The Premium Analytics dashboard.
  */
 function Dashboard(): JSX.Element {
-	const sections = useDashboardSections();
-	const [ activeSection, setActiveSection ] = useActiveSection();
+	const sections = useDashboardSections( DASHBOARD_NAME );
+	const [ activeSection, setActiveSection ] = useActiveSection( sections );
 	const [ layout, setLayout, resetLayout ] = useDashboardSectionLayout(
 		DASHBOARD_NAME,
 		activeSection
@@ -105,8 +105,12 @@ function Dashboard(): JSX.Element {
 							<DateFiltersPanel { ...dateFilters } containerElement={ containerElement } />
 						</div>
 						{ sections.map( section => (
-							<SectionTabPanel key={ section.id } value={ section.id } className={ styles.content }>
-								{ activeSection === section.id ? (
+							<SectionTabPanel
+								key={ section.slug }
+								value={ section.slug }
+								className={ styles.content }
+							>
+								{ activeSection === section.slug ? (
 									<>
 										<WidgetDashboard.NoWidgetsState />
 										<WidgetDashboard.Widgets />

--- a/projects/packages/premium-analytics/src/dashboard-sections.php
+++ b/projects/packages/premium-analytics/src/dashboard-sections.php
@@ -131,6 +131,46 @@ function bootstrap_dashboard_sections() {
 	} else {
 		add_action( 'init', __NAMESPACE__ . '\\register_default_dashboard_sections' );
 	}
+
+	add_filter( 'jetpack_admin_js_script_data', __NAMESPACE__ . '\\inject_dashboard_sections_script_data', 20 );
+}
+
+/**
+ * Injects the `GET /sections` response into JetpackScriptData as an apiFetch
+ * preload, keyed by the REST path the frontend requests.
+ *
+ * The dashboard tab bar is built from this response, so it is preloaded into
+ * the page render: the frontend resolves the section list synchronously on
+ * first paint instead of flashing an empty tab bar while a request is in
+ * flight. Scoped to the dashboard pages so other admin script-data consumers
+ * don't carry the payload.
+ *
+ * @param array $data The script data passed by the assets package.
+ * @return array
+ */
+function inject_dashboard_sections_script_data( array $data ): array {
+	if ( ! Analytics::is_dashboard_request() ) {
+		return $data;
+	}
+
+	if ( ! isset( $data['premium_analytics'] ) || ! is_array( $data['premium_analytics'] ) ) {
+		$data['premium_analytics'] = array();
+	}
+
+	$sections_path = '/' . DASHBOARD_REST_NAMESPACE . '/dashboards/' . DASHBOARD_NAME . '/sections';
+
+	$data['premium_analytics']['dashboard_sections_preload'] = array(
+		$sections_path => array(
+			'body' => array_map(
+				static function ( Dashboard_Section $section ) {
+					return $section->to_array();
+				},
+				get_available_dashboard_sections( DASHBOARD_NAME )
+			),
+		),
+	);
+
+	return $data;
 }
 
 /**

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
@@ -58,6 +58,7 @@ class Dashboard_Section_Test extends BaseTestCase {
 		remove_all_filters( WOOCOMMERCE_DASHBOARD_SECTION_AVAILABLE_FILTER );
 
 		wp_set_current_user( 0 );
+		unset( $_GET['page'] );
 
 		parent::tear_down();
 	}
@@ -714,6 +715,86 @@ class Dashboard_Section_Test extends BaseTestCase {
 			$this->assertSame( 404, $response->get_status(), $case );
 			$this->assertSame( 'rest_no_route', $response->as_error()->get_error_code(), $case );
 		}
+	}
+
+	/**
+	 * Script data carries the sections preload, keyed by the REST path, on dashboard pages.
+	 */
+	public function test_script_data_injects_sections_preload_on_dashboard_page() {
+		register_default_dashboard_sections();
+		add_filter( WOOCOMMERCE_DASHBOARD_SECTION_AVAILABLE_FILTER, '__return_true' );
+
+		set_current_screen( 'toplevel_page_jetpack-premium-analytics' );
+		$_GET['page'] = 'jetpack-premium-analytics';
+
+		$data    = inject_dashboard_sections_script_data( array() );
+		$path    = '/' . DASHBOARD_REST_NAMESPACE . '/dashboards/' . DASHBOARD_NAME . '/sections';
+		$preload = $data['premium_analytics']['dashboard_sections_preload'];
+
+		$this->assertArrayHasKey( $path, $preload );
+		$this->assertSame(
+			array( 'traffic', 'insights', 'subscribers', 'store' ),
+			array_column( $preload[ $path ]['body'], 'slug' )
+		);
+		$this->assertSame(
+			array(
+				'id'    => 'analytics/traffic',
+				'slug'  => 'traffic',
+				'label' => 'Traffic',
+				'order' => 10,
+			),
+			$preload[ $path ]['body'][0]
+		);
+	}
+
+	/**
+	 * The preload reflects section availability, mirroring the REST response.
+	 */
+	public function test_script_data_preload_omits_unavailable_sections() {
+		register_default_dashboard_sections();
+		add_filter( WOOCOMMERCE_DASHBOARD_SECTION_AVAILABLE_FILTER, '__return_false' );
+
+		set_current_screen( 'toplevel_page_jetpack-premium-analytics' );
+		$_GET['page'] = 'jetpack-premium-analytics-wp-admin';
+
+		$data    = inject_dashboard_sections_script_data( array() );
+		$preload = $data['premium_analytics']['dashboard_sections_preload'];
+
+		$this->assertSame(
+			array( 'traffic', 'insights', 'subscribers' ),
+			array_column( $preload[ '/' . DASHBOARD_REST_NAMESPACE . '/dashboards/' . DASHBOARD_NAME . '/sections' ]['body'], 'slug' )
+		);
+	}
+
+	/**
+	 * The preload stays off script data rendered for other admin pages.
+	 */
+	public function test_script_data_preload_skips_other_admin_pages() {
+		register_default_dashboard_sections();
+
+		set_current_screen( 'edit-post' );
+		$_GET['page'] = 'some-other-plugin';
+
+		$data = inject_dashboard_sections_script_data( array( 'existing' => true ) );
+
+		$this->assertSame( array( 'existing' => true ), $data );
+	}
+
+	/**
+	 * Bootstrapping registers the script data preload filter.
+	 *
+	 * Re-runs the bootstrap rather than relying on the require-time call:
+	 * other test classes (e.g. Analytics_Test) clear all script data filters
+	 * in their teardown.
+	 */
+	public function test_bootstrap_registers_script_data_preload_filter() {
+		remove_filter( 'jetpack_admin_js_script_data', __NAMESPACE__ . '\\inject_dashboard_sections_script_data', 20 );
+
+		bootstrap_dashboard_sections();
+
+		$this->assertNotFalse(
+			has_filter( 'jetpack_admin_js_script_data', __NAMESPACE__ . '\\inject_dashboard_sections_script_data' )
+		);
 	}
 
 	/**

--- a/projects/packages/premium-analytics/widgets/hello-world/stories/dashboard-sections-grid.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/hello-world/stories/dashboard-sections-grid.stories.tsx
@@ -2,7 +2,6 @@ import { useState } from '@wordpress/element';
 import { Tabs } from '@wordpress/ui';
 import { WidgetDashboard, type DashboardWidget } from '@wordpress/widget-dashboard';
 import { DashboardSections } from '../../../routes/dashboard/components';
-import { DEFAULT_SECTION_ID, getDashboardSections } from '../../../routes/dashboard/config';
 import styles from '../../../routes/dashboard/stage.module.scss';
 import type { Meta, StoryObj } from '@storybook/react';
 import type {
@@ -14,6 +13,15 @@ import type {
 type StoryWidgetAttributes = {
 	title: string;
 };
+
+// In product the section list is server-driven (GET /sections); the story pins
+// a static list mirroring that response shape.
+const storySections = [
+	{ id: 'analytics/traffic', slug: 'traffic', label: 'Traffic', order: 10 },
+	{ id: 'analytics/insights', slug: 'insights', label: 'Insights', order: 20 },
+	{ id: 'analytics/subscribers', slug: 'subscribers', label: 'Subscribers', order: 30 },
+	{ id: 'woocommerce/store', slug: 'store', label: 'Store', order: 40 },
+];
 
 type StoryWidgetProps = WidgetRenderProps< StoryWidgetAttributes >;
 
@@ -98,8 +106,8 @@ const resolveWidgetModule: ResolveWidgetModule = moduleId =>
  * @return Story component.
  */
 function DashboardSectionsGridStory() {
-	const sections = getDashboardSections();
-	const [ activeSection, setActiveSection ] = useState( DEFAULT_SECTION_ID );
+	const sections = storySections;
+	const [ activeSection, setActiveSection ] = useState( sections[ 0 ].slug );
 	const [ layout, setLayout ] = useState< DashboardWidget[] >( initialLayout );
 
 	return (
@@ -131,8 +139,8 @@ function DashboardSectionsGridStory() {
 				onChange={ setActiveSection }
 			>
 				{ sections.map( section => (
-					<Tabs.Panel key={ section.id } value={ section.id } className={ styles.content }>
-						{ activeSection === section.id ? (
+					<Tabs.Panel key={ section.slug } value={ section.slug } className={ styles.content }>
+						{ activeSection === section.slug ? (
 							<WidgetDashboard
 								widgetTypes={ widgetTypes }
 								layout={ layout }


### PR DESCRIPTION
Fixes #

## Proposed changes

Second of two PRs wiring the dashboard tab bar to the server-side section registry, on top of #50661 (the server contract, now merged — this branch is rebased onto trunk). The frontend now consumes `GET /sections`, so tab **availability, order, and labels** are server-driven and the store tab renders only when WooCommerce is active.

* **Preload.** Dashboard page renders inject the `GET /wpcom/v2/dashboards/{name}/sections` response into `JetpackScriptData`, keyed by REST path, and the init package registers `apiFetch.createPreloadingMiddleware()` alongside the existing root-URL + nonce middleware.
* **Consume.** `useDashboardSections( DASHBOARD_NAME )` resolves the section list synchronously from the preload — no tab-bar flash, and the valid slug set is known before `?section=` resolution. When the preload is absent it falls back to fetching the same route.
* **Delete the static config.** `DASHBOARD_SECTION_IDS`, `SECTION_DEFINITIONS`, and the static label getters are gone; the `DashboardSection` type now mirrors the server shape (`{ id, slug, label, order }`). The frontend uses the bare `slug` (`traffic`, `store`, …) for the `?section=` URL and preference keys, so existing bookmarks and stored layouts keep working with zero migration.
* **Resolution.** `useActiveSection()` validates `?section=` against the available slugs; on a miss (a stale slug, or `?section=store` with WooCommerce off) it falls back to the first section by order and rewrites the URL in place (`replace`, not push). A clean URL without `?section=` is left untouched.
* **Layout untouched.** `useDashboardSectionLayout` keeps reading/writing the `dashboardSectionLayouts` preference map keyed by slug, and reset keeps calling `GET .../default-layout`. The preference-map validator no longer checks keys against a static list, so a stored layout survives its section becoming temporarily unavailable.

## Related product discussion/links

* Builds on #50661 (server contract, merged).
* Successor to the approach in #49924 (closed); the registry itself landed via #50167, #50205, #50364, and #50372.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `cd projects/packages/premium-analytics && pnpm run test` — covers synchronous preload consumption, the no-preload fetch fallback, `?section=` resolution incl. fallback + URL rewrite, the store tab disappearing when the preload lacks it, a synthetic registered section rendering (the extension path), and section-layout read/write still going through core preferences keyed by slug.
* `composer phpunit` — covers the script-data preload injection: keyed by the sections REST path, availability-filtered (no `store` when WooCommerce is off), and scoped to the dashboard admin pages only.
* On a test site with the package built, as an admin:
  * With WooCommerce active, the dashboard shows Traffic / Insights / Subscribers / Store; deactivate WooCommerce and the Store tab disappears.
  * With WooCommerce off, load `?section=store` (or any unknown slug like `?section=bogus`): the dashboard falls back to Traffic and the URL is rewritten in place to `?section=traffic` without adding a history entry.
  * View source of the dashboard page: `window.JetpackScriptData.premium_analytics.dashboard_sections_preload` carries the sections response, and the tab bar renders on first paint with no flash and no `GET /sections` network request.
  * Widget layout customization and "Reset layout" still work per section, persisted via core preferences (`dashboardSectionLayouts`), unchanged from trunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DF6jSHNV6JRfEn99ThUTv3
