### PR TITLE
Premium Analytics: LeaderboardLabel owns the shared row height + hugTrailing prop

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1767-leaderboardlabel-row-height
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1767-leaderboardlabel-row-height
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-LeaderboardLabel: own the shared 36px row height and expose a `hugTrailing` prop, so avatar-less leaderboard consumers stop re-patching row rhythm and the Comments widget no longer reaches into the component's structure to hug the new-tab arrow.
+Keep leaderboard row heights consistent when images are unavailable and improve spacing for linked comment authors.

--- a/projects/packages/premium-analytics/changelog/wooa7s-1767-leaderboardlabel-row-height
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1767-leaderboardlabel-row-height
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+LeaderboardLabel: own the shared 36px row height and expose a `hugTrailing` prop, so avatar-less leaderboard consumers stop re-patching row rhythm and the Comments widget no longer reaches into the component's structure to hug the new-tab arrow.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/__tests__/leaderboard-label.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/__tests__/leaderboard-label.test.tsx
@@ -1,0 +1,39 @@
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import { LeaderboardLabel } from '../leaderboard-label';
+
+// The shared CSS stub (tests/style-stub.cjs) returns an empty object, so the
+// component's `styles.*` lookups would all be undefined and no class name would
+// reach the DOM. Provide identity class names here so the `hugTrailing`
+// modifier is observable.
+jest.mock( '../leaderboard-label.module.scss', () => ( {
+	container: 'container',
+	hugTrailing: 'hugTrailing',
+	label: 'label',
+	labelImage: 'labelImage',
+} ) );
+
+describe( 'LeaderboardLabel', () => {
+	it( 'drops the trailing inline padding when hugTrailing is set', () => {
+		const { container } = render( <LeaderboardLabel label="Alex Rivera" hugTrailing /> );
+
+		// eslint-disable-next-line testing-library/no-node-access -- the modifier lands on the rendered root; there is no role/text handle for it.
+		const root = container.firstChild;
+		expect( root ).toHaveClass( 'container' );
+		expect( root ).toHaveClass( 'hugTrailing' );
+	} );
+
+	it( 'preserves the trailing inline padding by default', () => {
+		const { container } = render( <LeaderboardLabel label="Alex Rivera" /> );
+
+		// eslint-disable-next-line testing-library/no-node-access -- the modifier lands on the rendered root; there is no role/text handle for it.
+		const root = container.firstChild;
+		expect( root ).toHaveClass( 'container' );
+		expect( root ).not.toHaveClass( 'hugTrailing' );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-label.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-label.module.scss
@@ -5,6 +5,23 @@
 	padding: var(--wpds-dimension-padding-sm);
 	min-inline-size: 0;
 	max-inline-size: 100%;
+
+	/* Own the shared 36px leaderboard row height here so avatar-less consumers
+	   (e.g. Referrers/Clicks with imageFallback="hidden") don't each re-patch it
+	   with per-widget min-block-size or line-height rules. Avatar rows already
+	   reach 36px (20px image + 2x padding-sm); this floors the height for rows
+	   with no image. Font-size is intentionally left to `.label` so this rule
+	   can't regress a consumer whose text inherits a different size. */
+	min-block-size: var(--jpa-leaderboard-row-min-height, 36px);
+	align-items: center;
+}
+
+/* Opt-in for consumers that append inline content after the label (e.g. a
+   Link's new-tab arrow): drop the container's trailing inline padding so the
+   following node hugs the label. Replaces widgets reaching into this
+   component's structure with `.someLabel > :first-child`. */
+.hugTrailing {
+	padding-inline-end: 0;
 }
 
 /* Leaderboard rows are a fixed 36px, so labels truncate rather than wrap. */

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-label.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-label.tsx
@@ -29,6 +29,13 @@ export type LeaderboardLabelProps = {
 	 * How to render a missing image
 	 */
 	imageFallback?: 'placeholder' | 'hidden';
+	/**
+	 * Drop the label's trailing inline padding so following inline content
+	 * (e.g. a Link's new-tab arrow) hugs the label instead of sitting a
+	 * padding-sm gap away. Prefer this over targeting the container's
+	 * internal structure from the consuming widget.
+	 */
+	hugTrailing?: boolean;
 };
 
 // Simple default image for when the image is not available.
@@ -52,6 +59,7 @@ const DEFAULT_IMAGE_URL =
  * @param props.imageAlt       - Alt text for the image
  * @param props.imageClassName - Class name for the image
  * @param props.imageFallback  - How to render a missing image
+ * @param props.hugTrailing    - Drop trailing inline padding so following inline content hugs the label
  */
 export function LeaderboardLabel( {
 	label,
@@ -59,13 +67,19 @@ export function LeaderboardLabel( {
 	imageAlt,
 	imageClassName,
 	imageFallback = 'placeholder',
+	hugTrailing = false,
 }: LeaderboardLabelProps ) {
 	// Use default if undefined OR empty string to prevent broken image flash
 	const finalImageUrl = imageUrl || DEFAULT_IMAGE_URL;
 	const shouldRenderImage = imageFallback === 'placeholder' || Boolean( imageUrl );
 
 	return (
-		<Stack direction="row" gap="sm" align="center" className={ styles.container }>
+		<Stack
+			direction="row"
+			gap="sm"
+			align="center"
+			className={ clsx( styles.container, hugTrailing && styles.hugTrailing ) }
+		>
 			{ shouldRenderImage && (
 				<img
 					src={ finalImageUrl }

--- a/projects/packages/premium-analytics/widgets/comments/__tests__/comments.test.tsx
+++ b/projects/packages/premium-analytics/widgets/comments/__tests__/comments.test.tsx
@@ -13,6 +13,20 @@ jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
 jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
 
+// The shared CSS stub returns an empty object, so LeaderboardLabel's `styles.*`
+// lookups would all be undefined and the `hugTrailing` modifier could not be
+// observed. Provide identity class names for the leaderboard label so the
+// linked/unlinked padding wiring is assertable.
+jest.mock(
+	'../../../packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-label.module.scss',
+	() => ( {
+		container: 'container',
+		hugTrailing: 'hugTrailing',
+		label: 'label',
+		labelImage: 'labelImage',
+	} )
+);
+
 const mockApiFetch = apiFetch as unknown as jest.Mock;
 
 describe( 'CommentsWidget', () => {
@@ -68,5 +82,29 @@ describe( 'CommentsWidget', () => {
 		await expect( screen.findByText( 'Member Author' ) ).resolves.toBeInTheDocument();
 		expect( screen.queryByRole( 'link', { name: /Member Author/ } ) ).not.toBeInTheDocument();
 		expect( screen.getByAltText( 'Avatar of Member Author' ) ).toBeInTheDocument();
+	} );
+
+	it( 'hugs the new-tab arrow for linked authors but keeps trailing padding for unlinked ones', async () => {
+		render(
+			<CommentsWidget
+				attributes={ {
+					view: 'authors',
+					reportParams: getDefaultQueryParams( false ),
+				} }
+			/>
+		);
+
+		// Linked author: the label sits inside the out-linking anchor, whose
+		// appended new-tab arrow should hug the name, so trailing padding is dropped.
+		const link = await screen.findByRole( 'link', { name: /Guest Author/ } );
+		// eslint-disable-next-line testing-library/no-node-access -- the hug modifier lands on the label element inside the anchor.
+		expect( link.firstChild ).toHaveClass( 'container', 'hugTrailing' );
+
+		// Unlinked author: a bare label with no following arrow, so the trailing
+		// padding is preserved (no hug-trailing modifier).
+		// eslint-disable-next-line testing-library/no-node-access -- reach the bare label wrapping the unlinked author name.
+		const unlinkedLabel = screen.getByText( 'Member Author' ).parentElement;
+		expect( unlinkedLabel ).toHaveClass( 'container' );
+		expect( unlinkedLabel ).not.toHaveClass( 'hugTrailing' );
 	} );
 } );

--- a/projects/packages/premium-analytics/widgets/comments/render.tsx
+++ b/projects/packages/premium-analytics/widgets/comments/render.tsx
@@ -65,6 +65,9 @@ function buildRowLabel( row: CommentRow, view: CommentsView ): ReactElement {
 						  )
 				}
 				imageClassName={ styles.avatar }
+				// Drop the label's trailing inline padding so the linking Link's
+				// appended new-tab arrow hugs the author name.
+				hugTrailing
 			/>
 		);
 

--- a/projects/packages/premium-analytics/widgets/comments/render.tsx
+++ b/projects/packages/premium-analytics/widgets/comments/render.tsx
@@ -65,9 +65,9 @@ function buildRowLabel( row: CommentRow, view: CommentsView ): ReactElement {
 						  )
 				}
 				imageClassName={ styles.avatar }
-				// Drop the label's trailing inline padding so the linking Link's
-				// appended new-tab arrow hugs the author name.
-				hugTrailing
+				// Drop the label's trailing inline padding only when the linking
+				// Link appends a new-tab arrow after the author name.
+				hugTrailing={ Boolean( row.link ) }
 			/>
 		);
 

--- a/projects/packages/premium-analytics/widgets/comments/style.module.css
+++ b/projects/packages/premium-analytics/widgets/comments/style.module.css
@@ -28,7 +28,12 @@
 /* Post rows have no avatar, so the post label sizes the row: pad the block to
    set the overlay bar height and inset the text from the bar's rounded left
    edge. `padding-sm` + a 20px line box lands on the same 36px row the Authors
-   view gets from LeaderboardLabel, so toggling views keeps the row rhythm. */
+   view gets from LeaderboardLabel, so toggling views keeps the row rhythm.
+
+   Not yet routed through LeaderboardLabel (which now owns the 36px row): the
+   post label inherits its font-size while LeaderboardLabel's `.label` pins
+   font-size-sm, so converging would change the post text size. Deferred until
+   the two views' font sizes are reconciled (WOOA7S-1767). */
 .postLabel {
 	display: block;
 	padding-block: var(--wpds-dimension-padding-sm);
@@ -53,14 +58,6 @@ a.postLabel:focus {
 	display: inline-flex;
 	align-items: center;
 	min-width: 0;
-}
-
-/* Drop the trailing inline padding so the new-tab arrow hugs the name. This
-   targets LeaderboardLabel's outer container (the anchor's only child), so it
-   is coupled to that component rendering a single wrapping element — revisit if
-   LeaderboardLabel's structure changes. */
-.authorLabel > :first-child {
-	padding-inline-end: 0;
 }
 
 /* Underline the label container (avatar + name) on hover, not the inline-flex


### PR DESCRIPTION
## What

Follow-up from @chihsuan's review of #50595 (WOOA7S-1767).

`LeaderboardLabel` now **owns the shared 36px leaderboard row height** and exposes a **`hugTrailing`** prop, so consumers stop re-implementing row rhythm and stop reaching into the component's internal structure.

- **Row height ownership** — a `min-block-size` floor (token-overridable via `--jpa-leaderboard-row-min-height`) on the label container. Avatar rows already reached 36px (20px image + 2× `padding-sm`); this floors the height for **avatar-less** rows so consumers using `imageFallback="hidden"` (Referrers, Clicks, and the Comments Posts view) no longer each patch it with their own `min-block-size` / `line-height`.
- **`hugTrailing` prop** — drops the container's trailing inline padding so following inline content (a `Link`'s new-tab arrow) hugs the label. Replaces the Comments widget's `.authorLabel > :first-child { padding-inline-end: 0 }` override, which was coupled to `LeaderboardLabel` rendering a single wrapping element.
  - **Enable it only when inline content actually follows the label.** In Comments, that means linked authors only — `hugTrailing={ Boolean( row.link ) }`. This matches the old CSS, which scoped the override to `.authorLabel` (present only on the linked branch), so unlinked authors keep their trailing padding. Turning it on unconditionally strips padding from rows that have no arrow to hug.

## The precondition @chihsuan flagged — resolved

The review asked to **compare the two views' font sizes before centralizing**, because a shared rule would otherwise regress one of them. Measured (DevTools, Storybook):

- Authors' `.label` pins `font-size-sm` = **12px** (explicit opt-in, shared by every `LeaderboardLabel` consumer).
- Posts' `.postLabel` sets no font-size and **inherits the default body size** = **13px** (`--wpds-typography-font-size-md` / the wp-admin base).

They differ, so this PR **deliberately does not converge the Posts view onto `LeaderboardLabel`** — doing so would shrink the post text 13px → 12px. `.postLabel` is kept (with a comment explaining the deferral). Font-size is intentionally left to `.label`, so the new `min-block-size` rule **cannot** regress any consumer on the font-size axis.

Note for the follow-up: 12px is the value every other leaderboard row already uses, so converging Posts to 12px would make Comments consistent with the rest of the dashboard — but that is a visible 1px change and needs a design/product call, out of scope here.

## Scope

- `packages/widgets-toolkit/src/components/chart-leaderboard/` — `leaderboard-label.tsx` (prop) + `leaderboard-label.module.scss` (row height + `.hugTrailing`).
- `widgets/comments/` — authors label passes `hugTrailing={ Boolean( row.link ) }`; removed the `> :first-child` padding override.

## Commits

- `LeaderboardLabel owns the shared row height + hugTrailing prop` — the centralization above.
- `Preserve padding for unlinked comment authors` — gates `hugTrailing` on `row.link` so only linked authors (which render a new-tab arrow) drop the trailing padding, restoring the pre-refactor behavior for unlinked rows.

## Testing

- [x] eslint + stylelint clean on touched files
- [x] `pnpm run typecheck` clean
- [x] Full CI green
- [x] **Precondition measured** — Authors 12px vs Posts 13px (see above); confirms Posts is correctly left un-converged
- [x] Storybook (Comments / Referrers / Clicks): 36px rows unchanged; linked authors' new-tab arrow hugs the name; the unlinked author row (Leah Kim in the mock — a `?user_id=` link the normalizer rejects) keeps its trailing padding
- [ ] Optional: wp-admin before/after screenshot (not a blocker; Storybook resolves `@jetpack-premium-analytics/*` to the same source the dashboard ships)

## Follow-ups (not in this PR)

- Converge the Comments Posts view (and de-duplicate Referrers/Clicks `min-block-size:36px`) onto the component once the font-size question is settled.
- The Authors hover/focus underline still uses `.authorLabel:hover > :first-child` — a smaller remaining bit of structural coupling that could move behind the component API too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

