### PR TITLE
Fix malformed changelog entries

### DIFF
--- a/projects/js-packages/social-previews/changelog/update-social-previews-no-studio
+++ b/projects/js-packages/social-previews/changelog/update-social-previews-no-studio
@@ -1,4 +1,3 @@
 Significance: patch
 Type: changed
-
 Comment: Replace legacy `--studio-black` with `#000` in Threads and Twitter link preview card styles.

--- a/projects/packages/forms/changelog/remove-calypso-color-schemes
+++ b/projects/packages/forms/changelog/remove-calypso-color-schemes
@@ -1,4 +1,3 @@
 Significance: patch
 Type: changed
-
 Comment: Replace Calypso `--color-*` tokens with WPDS tokens in block editor styles and remove custom upsell nudge Calypso overrides.

--- a/projects/packages/forms/changelog/update-stylelint-wp-build-no-token-fallback-values
+++ b/projects/packages/forms/changelog/update-stylelint-wp-build-no-token-fallback-values
@@ -1,4 +1,3 @@
 Significance: patch
 Type: changed
-
 Comment: Remove manual WPDS token fallbacks from wp-build route and webpack dashboard styles so build-time PostCSS injects canonical design-token fallbacks.

--- a/projects/packages/newsletter/changelog/update-stylelint-wp-build-no-token-fallback-values
+++ b/projects/packages/newsletter/changelog/update-stylelint-wp-build-no-token-fallback-values
@@ -1,4 +1,3 @@
 Significance: patch
 Type: changed
-
 Comment: Remove manual WPDS token fallbacks from wp-build route styles so build-time PostCSS injects canonical design-token fallbacks.

--- a/projects/packages/newsletter/changelog/update-wpds-fallbacks-leftovers
+++ b/projects/packages/newsletter/changelog/update-wpds-fallbacks-leftovers
@@ -1,5 +1,4 @@
 Significance: patch
 Type: changed
-
 Comment: Drop hardcoded WPDS token fallbacks from shared _inc styles (injected by wp-build).
 

--- a/projects/packages/premium-analytics/changelog/update-premium-analytics-no-token-fallbacks
+++ b/projects/packages/premium-analytics/changelog/update-premium-analytics-no-token-fallbacks
@@ -1,4 +1,3 @@
 Significance: patch
 Type: changed
-
 Comment: Expand stylelint no-token-fallback-values to the whole package and remove manual WPDS token fallbacks from source so wp-build injects canonical theme fallbacks at build time.

--- a/projects/packages/premium-analytics/changelog/update-stylelint-wp-build-no-token-fallback-values
+++ b/projects/packages/premium-analytics/changelog/update-stylelint-wp-build-no-token-fallback-values
@@ -1,4 +1,3 @@
 Significance: patch
 Type: changed
-
 Comment: Remove manual WPDS token fallbacks from wp-build route styles so build-time PostCSS injects canonical design-token fallbacks.

--- a/projects/packages/publicize/changelog/update-stylelint-more-no-token-fallback-values
+++ b/projects/packages/publicize/changelog/update-stylelint-more-no-token-fallback-values
@@ -1,4 +1,3 @@
 Significance: patch
 Type: changed
-
 Comment: Remove manual WPDS token fallbacks from webpack admin styles so build-time PostCSS injects canonical design-token fallbacks.

--- a/projects/packages/scan/changelog/update-wpds-fallbacks-leftovers
+++ b/projects/packages/scan/changelog/update-wpds-fallbacks-leftovers
@@ -1,5 +1,4 @@
 Significance: patch
 Type: changed
-
 Comment: Drop hardcoded WPDS token fallbacks from shared _inc styles (injected by wp-build).
 

--- a/projects/packages/search/changelog/update-stylelint-more-no-token-fallback-values
+++ b/projects/packages/search/changelog/update-stylelint-more-no-token-fallback-values
@@ -1,4 +1,3 @@
 Significance: patch
 Type: changed
-
 Comment: Remove manual WPDS token fallbacks from dashboard styles so build-time PostCSS injects canonical design-token fallbacks.

--- a/projects/packages/seo/changelog/update-wpds-fallbacks-leftovers
+++ b/projects/packages/seo/changelog/update-wpds-fallbacks-leftovers
@@ -1,5 +1,4 @@
 Significance: patch
 Type: changed
-
 Comment: Drop hardcoded WPDS token fallbacks from _inc screen styles (injected by wp-build).
 

--- a/projects/packages/videopress/changelog/update-stylelint-wp-build-no-token-fallback-values
+++ b/projects/packages/videopress/changelog/update-stylelint-wp-build-no-token-fallback-values
@@ -1,4 +1,3 @@
 Significance: patch
 Type: changed
-
 Comment: Remove manual WPDS token fallbacks from wp-build route styles so build-time PostCSS injects canonical design-token fallbacks.


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
It seems these are intended to be internal-only changes which are not included in the changelog, but somehow they're including an unnecessary newline so the "Comment:" becomes part of the changelog.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Is the assumption accurate?