### PR TITLE
renovate: Add polyfilled packages to the "Bundled WP" group

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -129,8 +129,12 @@
 				'@wordpress/ui',
 				'@wordpress/undo-manager',
 				'@wordpress/views',
-				// @wordpress/theme is grouped here because many bundled packages (notably @wordpress/ui)
-				// rely on its design tokens (--wpds-*).
+				// Additional packages polyfilled by wp-build-polyfills, which need to be kept in sync with each other.
+				'@wordpress/a11y',
+				'@wordpress/boot',
+				'@wordpress/notices',
+				'@wordpress/private-apis',
+				'@wordpress/route',
 				'@wordpress/theme',
 				// @wordpress/build is still heavily developed; its dashboards share the same bundled
 				// packages and test surface, so exercising build alongside the rest is practical.

--- a/projects/packages/wp-build-polyfills/changelog/update-renovate-bundled-wp-group
+++ b/projects/packages/wp-build-polyfills/changelog/update-renovate-bundled-wp-group
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Add a comment that new polyfills should probably also adjust the renovate config.
+
+

--- a/projects/packages/wp-build-polyfills/webpack.config.js
+++ b/projects/packages/wp-build-polyfills/webpack.config.js
@@ -169,6 +169,9 @@ const disabledPlugins = {
 };
 
 // ── Polyfill definitions ────────────────────────────────────────────────────
+//
+// If adding or removing something here, you'll probably also want to add or remove it
+// from the "Bundled @wordpress/* monorepo" group in `.github/renovate.json5`.
 
 const classicPolyfills = [
 	{


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
The polyfill packages should all be updated together. Add the missing ones to the group.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
https://github.com/Automattic/jetpack/pull/50509#issuecomment-4989274485

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* 🤷 I guess you could cherry-pick this into a fork from before 161416c54f0b3c735d4035ab1d5675b8f72a5cd9, then run Renovate and see how the packages divide out.