### PR TITLE
i18n: fix launch site translations

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-launch-site-translations
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-launch-site-translations
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Load JS translations for the Launch site admin-bar button to avoid it being rendered in English.

--- a/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launch-button/index.php
@@ -156,6 +156,11 @@ function wpcom_enqueue_launch_button_assets() {
 		true
 	);
 
+	// Load the translations to avoid wp.i18n overwriting server-side translations
+	// with English strings, and in general make it possible to use translations
+	// in JS.
+	wp_set_script_translations( 'adminbar-launch-button', 'jetpack-mu-wpcom' );
+
 	$bundles      = function_exists( 'wpcom_get_site_purchases' ) ? wp_list_filter( wpcom_get_site_purchases(), array( 'product_type' => 'bundle' ) ) : array();
 	$current_plan = array_pop( $bundles );
 


### PR DESCRIPTION
Fixes I18N-373

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Load JS translations for launch-button to prevent them being displayed in English.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->


## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Set your user language to a popular non-English locale.
* Select an unlaunched Simple site.
* Go to https:/<yoursite>.wordpress.com/wp-admin/index.php and confirm that the "Launch site" button in the adminbar flips from translated to untranslated.
* Sandbox the site and confirm that the issue is fixed with the PR.
