### PR TITLE
My Jetpack: hide Modules footer links on WordPress.com Simple sites

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/build-optional-menu-items.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/build-optional-menu-items.ts
@@ -14,6 +14,7 @@ type BuildOptionalMenuItemsArgs = {
 	userIsAdmin: boolean;
 	isSiteConnected: boolean;
 	isJetpackPluginActive: boolean;
+	isSimpleSite: boolean;
 	onModulesClick: () => void;
 	onResetClick: () => void;
 	onResetKeyDown: ( event: KeyboardEvent ) => void;
@@ -25,13 +26,16 @@ const buildOptionalMenuItems = ( {
 	userIsAdmin,
 	isSiteConnected,
 	isJetpackPluginActive,
+	isSimpleSite,
 	onModulesClick,
 	onResetClick,
 	onResetKeyDown,
 }: BuildOptionalMenuItemsArgs ): FooterMenuItem[] => {
 	const items: FooterMenuItem[] = [];
 
-	if ( userIsAdmin && isSiteConnected && isJetpackPluginActive ) {
+	// The jetpack_modules admin page is not registered on WordPress.com Simple sites,
+	// so the link would 404 there.
+	if ( userIsAdmin && isSiteConnected && isJetpackPluginActive && ! isSimpleSite ) {
 		items.push( {
 			label: _x(
 				'Modules',

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -9,6 +9,7 @@ import {
 	GlobalNotices,
 	Notice,
 } from '@automattic/jetpack-components';
+import { isSimpleSite } from '@automattic/jetpack-script-data';
 import { useViewportMatch } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
 import clsx from 'clsx';
@@ -172,6 +173,7 @@ export default function MyJetpackScreen() {
 		userIsAdmin,
 		isSiteConnected,
 		isJetpackPluginActive,
+		isSimpleSite: isSimpleSite(),
 		onModulesClick: () => recordEvent( 'jetpack_myjetpack_footer_link_click', { link: 'modules' } ),
 		onResetClick: () => resetJetpackOptions(),
 		onResetKeyDown: e => onKeyDownCallback( e, () => resetJetpackOptions() ),

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/test/build-optional-menu-items.test.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/test/build-optional-menu-items.test.ts
@@ -9,6 +9,7 @@ const baseArgs = {
 	userIsAdmin: true,
 	isSiteConnected: true,
 	isJetpackPluginActive: true,
+	isSimpleSite: false,
 	onModulesClick: jest.fn(),
 	onResetClick: jest.fn(),
 	onResetKeyDown: jest.fn(),
@@ -40,6 +41,12 @@ describe( 'buildOptionalMenuItems', () => {
 
 		it( 'omits the Modules link when the main Jetpack plugin is not active', () => {
 			const items = buildOptionalMenuItems( { ...baseArgs, isJetpackPluginActive: false } );
+
+			expect( items.find( item => item.label === 'Modules' ) ).toBeUndefined();
+		} );
+
+		it( 'omits the Modules link on WordPress.com Simple sites', () => {
+			const items = buildOptionalMenuItems( { ...baseArgs, isSimpleSite: true } );
 
 			expect( items.find( item => item.label === 'Modules' ) ).toBeUndefined();
 		} );

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/help/footer.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/help/footer.tsx
@@ -1,4 +1,4 @@
-import { currentUserCan, getAdminUrl } from '@automattic/jetpack-script-data';
+import { currentUserCan, getAdminUrl, isSimpleSite } from '@automattic/jetpack-script-data';
 import { __ } from '@wordpress/i18n';
 import { Link, Text } from '@wordpress/ui';
 import { useCallback } from 'react';
@@ -31,9 +31,11 @@ export function HelpFooter() {
 	// the Jetpack plugin is active (My Jetpack also runs inside other standalone
 	// plugins where these pages aren't registered), and the current user can
 	// manage options (both pages require it, but the Help tab is also shown to
-	// non-admins like editors). Guard on both to avoid links that dead-end on a
-	// "you are not allowed to access this page" screen.
-	const showUsefulLinks = isJetpackPluginActive() && currentUserCan( 'manage_options' );
+	// non-admins like editors). Neither page is registered on WordPress.com
+	// Simple sites. Guard on all of these to avoid links that dead-end on a
+	// 404 or a "you are not allowed to access this page" screen.
+	const showUsefulLinks =
+		isJetpackPluginActive() && currentUserCan( 'manage_options' ) && ! isSimpleSite();
 
 	return (
 		<div className={ styles.footer }>

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/help/test/footer.test.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/help/test/footer.test.tsx
@@ -1,0 +1,46 @@
+import '@testing-library/jest-dom';
+import { currentUserCan, getAdminUrl, isSimpleSite } from '@automattic/jetpack-script-data';
+import { render, screen } from '@testing-library/react';
+import { isJetpackPluginActive } from '../../../../utils/is-jetpack-plugin-active';
+import { HelpFooter } from '../footer';
+
+jest.mock( '@automattic/jetpack-script-data' );
+jest.mock( '../../../../utils/is-jetpack-plugin-active' );
+jest.mock( '../use-help-tracking', () => ( {
+	useHelpTracking: () => ( { trackHelpRequest: jest.fn() } ),
+} ) );
+
+const mockCurrentUserCan = currentUserCan as jest.MockedFunction< typeof currentUserCan >;
+const mockGetAdminUrl = getAdminUrl as jest.MockedFunction< typeof getAdminUrl >;
+const mockIsSimpleSite = isSimpleSite as jest.MockedFunction< typeof isSimpleSite >;
+const mockIsJetpackPluginActive = isJetpackPluginActive as jest.MockedFunction<
+	typeof isJetpackPluginActive
+>;
+
+describe( 'HelpFooter', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockCurrentUserCan.mockReturnValue( true );
+		mockGetAdminUrl.mockImplementation( path => `https://example.com/wp-admin/${ path }` );
+		mockIsJetpackPluginActive.mockReturnValue( true );
+		mockIsSimpleSite.mockReturnValue( false );
+	} );
+
+	it( 'shows the Useful links section for an admin with the Jetpack plugin active', () => {
+		render( <HelpFooter /> );
+
+		expect( screen.getByRole( 'navigation', { name: 'Useful links' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: 'All Jetpack modules' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'link', { name: 'Debug information' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'hides the Useful links section on WordPress.com Simple sites', () => {
+		mockIsSimpleSite.mockReturnValue( true );
+
+		render( <HelpFooter /> );
+
+		expect( screen.queryByRole( 'navigation', { name: 'Useful links' } ) ).not.toBeInTheDocument();
+		// The rest of the footer still renders.
+		expect( screen.getByText( 'Real humans. Real support.' ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-modules-link-simple-sites
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-modules-link-simple-sites
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Hide the Modules footer links on WordPress.com Simple sites, where the Jetpack modules admin page does not exist.

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-modules-link-simple-sites
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-modules-link-simple-sites
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Hide the Modules footer links on WordPress.com Simple sites, where the Jetpack modules admin page does not exist.
+Hide the Modules footer link and the Help tab's Useful links section (All Jetpack modules, Debug information) on WordPress.com Simple sites, where the target admin pages do not exist.


### PR DESCRIPTION
Fixes JETPACK-1961

## Proposed changes

* Hide the "Modules" link in the My Jetpack page footer on WordPress.com Simple sites.
* Hide the "Useful links" section (All Jetpack modules, Debug information) in the Help tab footer on the same sites.

Both links target wp-admin pages that only the Jetpack plugin registers: `admin.php?page=jetpack_modules` and `admin.php?page=jetpack-debugger`. Neither page exists on Simple sites, so the links land on a 404. This didn't matter until we started enabling My Jetpack on Simple sites behind the `my-jetpack` blog sticker (part of the "Display My Jetpack on WordPress.com" project); now users there can click straight into a dead end.

## Related product discussion/links

* Linear: [JETPACK-1961](https://linear.app/a8c/issue/JETPACK-1961/make-sure-that-there-are-no-modules-link-in-the-footer-since-it-doesnt)
* Project: [Display "My Jetpack" on WordPress.com](https://linear.app/a8c/project/display-my-jetpack-on-wordpresscom-a0b92161a95c)

## Does this pull request change what data or activity we track or use?

No.

## Before / after

Captured on a live Jurassic Ninja site at 1440×900 with a simulated Simple site: `JetpackScriptData.site.host` was forced to `wpcom` before the app rendered, since a real Simple site can't run unreleased package code yet. "Before" is a trunk build (merge base `7e03e4b`), "after" is this branch. Both passes used the same forced host, so the only variable is the code change.

**Page footer** (`admin.php?page=my-jetpack`):

| Before | After |
|---|---|
| ![Modules link visible in the page footer](https://github.com/Automattic/jetpack/raw/screenshots/fix/my-jetpack-modules-link-simple-sites/before-footer.png) | ![Modules link removed from the page footer](https://github.com/Automattic/jetpack/raw/screenshots/fix/my-jetpack-modules-link-simple-sites/after-footer.png) |

**Help tab footer** ("Useful links" section):

| Before | After |
|---|---|
| ![Useful links section with All Jetpack modules and Debug information](https://github.com/Automattic/jetpack/raw/screenshots/fix/my-jetpack-modules-link-simple-sites/before-help-section.png) | ![Useful links section removed](https://github.com/Automattic/jetpack/raw/screenshots/fix/my-jetpack-modules-link-simple-sites/after-help-section.png) |

## Testing instructions

* On a WordPress.com Simple site with the `my-jetpack` blog sticker (or with `WPCOM_MY_JETPACK` defined), open `wp-admin/admin.php?page=my-jetpack`:
  * The page footer no longer shows a "Modules" link.
  * The Help tab no longer shows the "Useful links" section.
* On a self-hosted site with the Jetpack plugin active and connected, check that both links still appear as before.
* `pnpm test` in `projects/packages/my-jetpack` passes and includes a new case for the Simple-site gate.
