### PR TITLE
wp-build-polyfills: add export-contract build check to catch version-skew

### DIFF
--- a/projects/packages/wp-build-polyfills/README.md
+++ b/projects/packages/wp-build-polyfills/README.md
@@ -86,7 +86,7 @@ set fails the build instead of silently blanking a dashboard at runtime (as in J
 - **`validate-boot-asset.js`** — every dependency handle in the boot module's `.asset.php` is a known
   Core or polyfill handle (catches a script silently dropped for an unregistered dependency).
 - **`validate-export-contract.js`** — every symbol a consumer (`@wordpress/boot`, …) imports from a
-  polyfilled classic-script provider (`@wordpress/theme`, `notices`, `private-apis`, `views`) exists
+  polyfilled classic-script provider (`@wordpress/theme`, `@wordpress/notices`, `@wordpress/private-apis`, `@wordpress/views`) exists
   in that provider's shipped public API (catches the 16.0 `wp.theme.ThemeProvider is undefined`
   case). Run standalone with `pnpm run check-contracts`. The ESM module providers (`route`, `a11y`)
   are a follow-up. Regression-tested in `tests/js/validate-export-contract.test.js`.

--- a/projects/packages/wp-build-polyfills/README.md
+++ b/projects/packages/wp-build-polyfills/README.md
@@ -80,69 +80,16 @@ Consuming packages should add `@automattic/jetpack-wp-build-polyfills` as a devD
 
 ## Safety checks
 
-This package ships a **matched set** of `@wordpress/*` packages that call each other's exports at
-runtime (e.g. `@wordpress/boot` imports `ThemeProvider` from `@wordpress/theme`). If the versions
-drift out of sync, an imported symbol can resolve to `undefined` at runtime — a blank dashboard with
-**no build error and no obvious console message**. That is what shipped in Jetpack 16.0.
+Two checks run after `webpack` (see the `build` script) so version skew in the bundled `@wordpress/*`
+set fails the build instead of silently blanking a dashboard at runtime (as in Jetpack 16.0):
 
-Two build-time checks run automatically after `webpack` (see the `build` script) to catch that class
-of failure before it ships:
-
-### 1. Boot asset handle check (`validate-boot-asset.js`)
-
-Verifies every dependency **handle** in the boot module's `.asset.php` is a known WordPress Core or
-polyfill handle. Catches the *missing/unknown-handle* failure (WordPress silently drops a script
-whose dependency isn't registered).
-
-### 2. Export-contract check (`validate-export-contract.js`)
-
-Verifies that every symbol a consumer package (`@wordpress/boot`, …) **imports** from a polyfilled
-provider (`@wordpress/theme`, `@wordpress/notices`, `@wordpress/private-apis`, `@wordpress/views`)
-actually exists in that provider's shipped public API. This is the direct detector of the 16.0
-`ThemeProvider is undefined` failure — it compares the `import { … }` statements in the consumer's
-published ESM against the `export { … }` surface of the provider version this package ships.
-
-> Scope: v1 checks the **classic-script** providers (the `window.wp.<pkg>` globals), which is where a
-> missing export silently becomes `undefined`. The ESM module providers (`@wordpress/route`,
-> `@wordpress/a11y`) resolve via the browser import map and are a documented follow-up.
-
-Run it on its own:
-
-```bash
-pnpm run check-contracts
-```
-
-### Simulating a violation
-
-To confirm the guard actually stops a broken build (locally, and — in a PR — as a red CI check),
-you can reproduce a skew two ways:
-
-**A. Env-var simulation (fast, no reinstall).** Drop a symbol from a provider's exports without
-touching the lockfile:
-
-```bash
-# Reproduces the 16.0 skew: boot needs ThemeProvider, pretend theme no longer exports it.
-pnpm run simulate:skew
-# → exits non-zero with the export-contract error (this is what CI would see).
-
-# Any package:symbol pair works, comma-separated:
-WP_BUILD_POLYFILLS_SIMULATE_MISSING="@wordpress/notices:SnackbarNotices" pnpm run check-contracts
-```
-
-**B. Real version pin (authentic end-to-end).** Pin a provider to a version that genuinely lacks the
-export, install, and build:
-
-```bash
-# @wordpress/theme < 0.16 only exposed ThemeProvider privately (the real 16.0 cause).
-# Edit package.json:  "@wordpress/theme": "0.15.1"
-pnpm install
-pnpm run build   # → fails at validate-export-contract.js
-# Revert the pin + `pnpm install` when done.
-```
-
-Both are also encoded as automated tests in `tests/js/validate-export-contract.test.js` (see the
-`FAILS on the 16.0 shape …` and `detects a simulated skew …` cases), so the guard itself is
-regression-tested.
+- **`validate-boot-asset.js`** — every dependency handle in the boot module's `.asset.php` is a known
+  Core or polyfill handle (catches a script silently dropped for an unregistered dependency).
+- **`validate-export-contract.js`** — every symbol a consumer (`@wordpress/boot`, …) imports from a
+  polyfilled classic-script provider (`@wordpress/theme`, `notices`, `private-apis`, `views`) exists
+  in that provider's shipped public API (catches the 16.0 `wp.theme.ThemeProvider is undefined`
+  case). Run standalone with `pnpm run check-contracts`. The ESM module providers (`route`, `a11y`)
+  are a follow-up. Regression-tested in `tests/js/validate-export-contract.test.js`.
 
 ## Development
 

--- a/projects/packages/wp-build-polyfills/README.md
+++ b/projects/packages/wp-build-polyfills/README.md
@@ -78,6 +78,72 @@ Consuming packages should add `@automattic/jetpack-wp-build-polyfills` as a devD
 "build:boot-proxy": "provide-boot-asset-file"
 ```
 
+## Safety checks
+
+This package ships a **matched set** of `@wordpress/*` packages that call each other's exports at
+runtime (e.g. `@wordpress/boot` imports `ThemeProvider` from `@wordpress/theme`). If the versions
+drift out of sync, an imported symbol can resolve to `undefined` at runtime — a blank dashboard with
+**no build error and no obvious console message**. That is what shipped in Jetpack 16.0.
+
+Two build-time checks run automatically after `webpack` (see the `build` script) to catch that class
+of failure before it ships:
+
+### 1. Boot asset handle check (`validate-boot-asset.js`)
+
+Verifies every dependency **handle** in the boot module's `.asset.php` is a known WordPress Core or
+polyfill handle. Catches the *missing/unknown-handle* failure (WordPress silently drops a script
+whose dependency isn't registered).
+
+### 2. Export-contract check (`validate-export-contract.js`)
+
+Verifies that every symbol a consumer package (`@wordpress/boot`, …) **imports** from a polyfilled
+provider (`@wordpress/theme`, `@wordpress/notices`, `@wordpress/private-apis`, `@wordpress/views`)
+actually exists in that provider's shipped public API. This is the direct detector of the 16.0
+`ThemeProvider is undefined` failure — it compares the `import { … }` statements in the consumer's
+published ESM against the `export { … }` surface of the provider version this package ships.
+
+> Scope: v1 checks the **classic-script** providers (the `window.wp.<pkg>` globals), which is where a
+> missing export silently becomes `undefined`. The ESM module providers (`@wordpress/route`,
+> `@wordpress/a11y`) resolve via the browser import map and are a documented follow-up.
+
+Run it on its own:
+
+```bash
+pnpm run check-contracts
+```
+
+### Simulating a violation
+
+To confirm the guard actually stops a broken build (locally, and — in a PR — as a red CI check),
+you can reproduce a skew two ways:
+
+**A. Env-var simulation (fast, no reinstall).** Drop a symbol from a provider's exports without
+touching the lockfile:
+
+```bash
+# Reproduces the 16.0 skew: boot needs ThemeProvider, pretend theme no longer exports it.
+pnpm run simulate:skew
+# → exits non-zero with the export-contract error (this is what CI would see).
+
+# Any package:symbol pair works, comma-separated:
+WP_BUILD_POLYFILLS_SIMULATE_MISSING="@wordpress/notices:SnackbarNotices" pnpm run check-contracts
+```
+
+**B. Real version pin (authentic end-to-end).** Pin a provider to a version that genuinely lacks the
+export, install, and build:
+
+```bash
+# @wordpress/theme < 0.16 only exposed ThemeProvider privately (the real 16.0 cause).
+# Edit package.json:  "@wordpress/theme": "0.15.1"
+pnpm install
+pnpm run build   # → fails at validate-export-contract.js
+# Revert the pin + `pnpm install` when done.
+```
+
+Both are also encoded as automated tests in `tests/js/validate-export-contract.test.js` (see the
+`FAILS on the 16.0 shape …` and `detects a simulated skew …` cases), so the guard itself is
+regression-tested.
+
 ## Development
 
 ```bash

--- a/projects/packages/wp-build-polyfills/bin/validate-export-contract-lib.js
+++ b/projects/packages/wp-build-polyfills/bin/validate-export-contract-lib.js
@@ -33,27 +33,66 @@
 const { readFileSync, readdirSync, existsSync } = require( 'fs' );
 const path = require( 'path' );
 
-// Provider packages whose public exports we verify. Scoped to the CLASSIC
-// SCRIPT polyfills (the `window.wp.<pkg>` globals) — this is the surface where
-// a missing export silently resolves to `undefined` at runtime (the 16.0
-// failure mode). Keep in sync with `classicPolyfills` in webpack.config.js and
-// SCRIPT_HANDLES in src/class-wp-build-polyfills.php (asserted by a test).
+// The shipped package set has a single source of truth: the class constants in
+// src/class-wp-build-polyfills.php (SCRIPT_HANDLES + MODULE_IDS), which is also
+// what registers them at runtime. We derive the validator's provider/consumer
+// lists from there rather than maintaining a second copy (see getShippedPackages).
 //
-// NOTE: the ESM module polyfills (@wordpress/route, @wordpress/a11y) are
-// resolved via the browser import map rather than a window global, so they
-// have a different (import-map) failure mode. Verifying them is a documented
-// follow-up; see README "Export-contract validation".
-const PROVIDER_PACKAGES = [
-	'@wordpress/theme',
-	'@wordpress/notices',
-	'@wordpress/private-apis',
-	'@wordpress/views',
-];
+// - Providers (whose exports we verify) = SCRIPT_HANDLES, the CLASSIC-SCRIPT
+//   polyfills (`window.wp.<pkg>` globals) — the surface where a missing export
+//   silently resolves to `undefined` at runtime (the 16.0 failure mode).
+// - Consumers (whose imports we scan) = MODULE_IDS, the ESM module polyfills
+//   that compose the providers.
+//
+// NOTE: the ESM module polyfills are only scanned as consumers, not verified as
+// providers — they resolve via the browser import map rather than a window
+// global, a different failure mode. Verifying them is a documented follow-up
+// (see README "Safety checks").
 
-// Consumer packages whose imports we scan. These are the ESM polyfills that
-// compose the provider packages above. Keep in sync with `modulePolyfills` in
-// webpack.config.js (asserted by a test).
-const CONSUMER_PACKAGES = [ '@wordpress/boot', '@wordpress/route', '@wordpress/a11y' ];
+/**
+ * Map a classic-script handle to its npm package name (e.g. `wp-theme` → `@wordpress/theme`).
+ *
+ * @param {string} handle - A `wp-*` script handle.
+ * @return {string} The `@wordpress/*` package name.
+ */
+function handleToPackage( handle ) {
+	return '@wordpress/' + handle.replace( /^wp-/, '' );
+}
+
+/**
+ * Extract a `const NAME = array( 'a', 'b' );` PHP class-constant array's string values.
+ *
+ * @param {string} phpSource - PHP file contents.
+ * @param {string} constName - Constant name (e.g. 'SCRIPT_HANDLES').
+ * @return {string[]} The array's string literal values, or [] if not found.
+ */
+function parsePhpConstArray( phpSource, constName ) {
+	const match = phpSource.match(
+		new RegExp( `const\\s+${ constName }\\s*=\\s*array\\(([^)]*)\\)` )
+	);
+	if ( ! match ) {
+		return [];
+	}
+	return match[ 1 ].match( /'([^']+)'/g )?.map( s => s.replace( /'/g, '' ) ) ?? [];
+}
+
+/**
+ * Derive the shipped provider/consumer package lists from the PHP class constants
+ * (the single source of truth).
+ *
+ * @param {string} packageRoot - Polyfill package root.
+ * @return {{ providers: string[], consumers: string[] }} Classic-script providers and module consumers.
+ */
+function getShippedPackages( packageRoot ) {
+	const php = readFileSync(
+		path.join( packageRoot, 'src', 'class-wp-build-polyfills.php' ),
+		'utf8'
+	);
+	return {
+		providers: parsePhpConstArray( php, 'SCRIPT_HANDLES' ).map( handleToPackage ),
+		consumers: parsePhpConstArray( php, 'MODULE_IDS' ), // Already `@wordpress/*` names.
+	};
+}
 
 /**
  * Extract the ORIGINAL names of the symbols named-imported from a specific
@@ -222,8 +261,9 @@ function readPackageExports( pkgDir ) {
  */
 function validateExportContracts( options = {} ) {
 	const packageRoot = options.packageRoot || path.join( __dirname, '..' );
-	const providers = options.providers || PROVIDER_PACKAGES;
-	const consumers = options.consumers || CONSUMER_PACKAGES;
+	const shipped = getShippedPackages( packageRoot );
+	const providers = options.providers || shipped.providers;
+	const consumers = options.consumers || shipped.consumers;
 	const simulateMissing =
 		options.simulateMissing || parseSimulateEnv( process.env.WP_BUILD_POLYFILLS_SIMULATE_MISSING );
 
@@ -359,6 +399,7 @@ module.exports = {
 	validateExportContracts,
 	parseSimulateEnv,
 	formatError,
-	PROVIDER_PACKAGES,
-	CONSUMER_PACKAGES,
+	handleToPackage,
+	parsePhpConstArray,
+	getShippedPackages,
 };

--- a/projects/packages/wp-build-polyfills/bin/validate-export-contract-lib.js
+++ b/projects/packages/wp-build-polyfills/bin/validate-export-contract-lib.js
@@ -1,4 +1,4 @@
-/* global __dirname */
+/* global __dirname, process */
 /**
  * Export-contract validation: assert every symbol a consumer package imports from
  * a polyfilled provider actually exists in the shipped provider's public exports.
@@ -55,8 +55,10 @@ function getShippedPackages( packageRoot ) {
 
 /**
  * Original names of the symbols named-imported from a provider in ESM source.
- * Handles `import { A, B as C } from '@wordpress/x'` (imported name is before `as`);
- * ignores namespace/default imports, which can't be a missing named export.
+ * Handles `import { A, B as C } from '@wordpress/x'` and the mixed default form
+ * `import Def, { A } from '@wordpress/x'` (imported name is before `as`); a pure
+ * default or namespace import has no `{ … }` and is ignored (can't be a missing
+ * named export).
  *
  * @param {string} source      - ESM source text.
  * @param {string} providerPkg - e.g. '@wordpress/theme'.
@@ -65,7 +67,11 @@ function getShippedPackages( packageRoot ) {
 function parseNamedImports( source, providerPkg ) {
 	const found = new Set();
 	const escaped = providerPkg.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
-	const re = new RegExp( `import\\s*\\{([^}]*)\\}\\s*from\\s*['"]${ escaped }['"]`, 'g' );
+	// Optional `Default,` before the named block covers `import Def, { A } from …`.
+	const re = new RegExp(
+		`import\\s*(?:[\\w$]+\\s*,\\s*)?\\{([^}]*)\\}\\s*from\\s*['"]${ escaped }['"]`,
+		'g'
+	);
 	let match;
 	while ( ( match = re.exec( source ) ) !== null ) {
 		for ( const specifier of match[ 1 ].split( ',' ) ) {
@@ -220,6 +226,28 @@ function formatError( failures, errors ) {
 }
 
 /**
+ * Parse WP_BUILD_POLYFILLS_SIMULATE_MISSING (`pkg:Symbol,pkg:Symbol`) into a
+ * `{ pkg: [ symbol ] }` drop-map. This is a TEST-ONLY hook that lets the CLI's
+ * failure path be exercised end-to-end (see the CLI test); it is not a
+ * user-facing feature.
+ *
+ * @param {string|undefined} raw - Raw env value.
+ * @return {object} Map of provider package → symbol[] to drop.
+ */
+function parseSimulateEnv( raw ) {
+	const map = {};
+	for ( const pair of ( raw || '' ).split( ',' ) ) {
+		const idx = pair.lastIndexOf( ':' );
+		const pkg = idx === -1 ? '' : pair.slice( 0, idx ).trim();
+		const symbol = idx === -1 ? '' : pair.slice( idx + 1 ).trim();
+		if ( pkg && symbol ) {
+			( map[ pkg ] = map[ pkg ] || [] ).push( symbol );
+		}
+	}
+	return map;
+}
+
+/**
  * Validate the export contracts across the shipped package set. Reads the shipped
  * versions from the polyfill's own resolution context (same as the build).
  *
@@ -235,7 +263,8 @@ function validateExportContracts( options = {} ) {
 	const shipped = getShippedPackages( packageRoot );
 	const providers = options.providers || shipped.providers;
 	const consumers = options.consumers || shipped.consumers;
-	const simulateMissing = options.simulateMissing || {};
+	const simulateMissing =
+		options.simulateMissing || parseSimulateEnv( process.env.WP_BUILD_POLYFILLS_SIMULATE_MISSING );
 
 	const errors = [];
 	const providerExports = {};
@@ -248,6 +277,16 @@ function validateExportContracts( options = {} ) {
 		if ( ! exp ) {
 			errors.push( `Could not read exports for ${ provider }.` );
 			continue;
+		}
+		if ( exp.opaque ) {
+			// A barrel (`export *`) can't be statically enumerated, so we can't verify
+			// this provider — warn loudly rather than skip it silently, which would be
+			// a hole in exactly the protection this check exists for.
+			// eslint-disable-next-line no-console
+			console.warn(
+				`[export-contract] Not verifying ${ provider }: its index uses \`export *\`, ` +
+					'so its public exports can’t be enumerated statically.'
+			);
 		}
 		const dropped = simulateMissing[ provider ] || [];
 		providerExports[ provider ] = {

--- a/projects/packages/wp-build-polyfills/bin/validate-export-contract-lib.js
+++ b/projects/packages/wp-build-polyfills/bin/validate-export-contract-lib.js
@@ -1,56 +1,16 @@
-/* global __dirname, process */
+/* global __dirname */
 /**
- * Shared logic for the export-contract validator.
- *
- * Used by both the post-build CLI script and the test suite.
- *
- * WHY THIS EXISTS
- * ---------------
- * This package ships a *matched set* of `@wordpress/*` packages. Some of them
- * import symbols from others at runtime — most importantly `@wordpress/boot`
- * imports `ThemeProvider` from `@wordpress/theme`, `SnackbarNotices` from
- * `@wordpress/notices`, and so on. Those imported packages are shipped as
- * classic scripts that expose a `window.wp.<pkg>` global.
- *
- * If the versions get out of sync (e.g. boot expects a public `ThemeProvider`
- * export but the shipped `@wordpress/theme` only exposes it privately), the
- * symbol resolves to `undefined` at runtime → React error #130 → blank
- * dashboard, with NO build error and NO obvious console message. That is
- * exactly what shipped in Jetpack 16.0.
- *
- * The existing `validate-boot-asset` check verifies that dependency *handle
- * names* are known. It does NOT verify that the *symbols* one package imports
- * from another actually exist in the shipped version. This check closes that
- * gap: for every symbol a consumer package imports from a polyfilled provider
- * package, assert the provider's shipped public API actually exports it.
- *
- * Both sides are read from the packages' published ESM source
- * (`build-module/*.mjs`) — NOT from the webpack-built bundle — because the
- * built bundle mangles import identifiers under minification, while the source
- * `import { X } from '@wordpress/y'` / `export { X }` statements are stable.
+ * Export-contract validation: assert every symbol a consumer package imports from
+ * a polyfilled provider actually exists in the shipped provider's public exports.
+ * A missing symbol resolves to `undefined` at runtime (blank dashboard, no build
+ * error) — the Jetpack 16.0 failure mode. Shared by the post-build CLI and tests.
  */
 
 const { readFileSync, readdirSync, existsSync } = require( 'fs' );
 const path = require( 'path' );
 
-// The shipped package set has a single source of truth: the class constants in
-// src/class-wp-build-polyfills.php (SCRIPT_HANDLES + MODULE_IDS), which is also
-// what registers them at runtime. We derive the validator's provider/consumer
-// lists from there rather than maintaining a second copy (see getShippedPackages).
-//
-// - Providers (whose exports we verify) = SCRIPT_HANDLES, the CLASSIC-SCRIPT
-//   polyfills (`window.wp.<pkg>` globals) — the surface where a missing export
-//   silently resolves to `undefined` at runtime (the 16.0 failure mode).
-// - Consumers (whose imports we scan) = MODULE_IDS, the ESM module polyfills
-//   that compose the providers.
-//
-// NOTE: the ESM module polyfills are only scanned as consumers, not verified as
-// providers — they resolve via the browser import map rather than a window
-// global, a different failure mode. Verifying them is a documented follow-up
-// (see README "Safety checks").
-
 /**
- * Map a classic-script handle to its npm package name (e.g. `wp-theme` → `@wordpress/theme`).
+ * Map a classic-script handle to its npm package name (`wp-theme` → `@wordpress/theme`).
  *
  * @param {string} handle - A `wp-*` script handle.
  * @return {string} The `@wordpress/*` package name.
@@ -60,28 +20,27 @@ function handleToPackage( handle ) {
 }
 
 /**
- * Extract a `const NAME = array( 'a', 'b' );` PHP class-constant array's string values.
+ * Extract the string values of a `const NAME = array( 'a', 'b' );` PHP class constant.
  *
  * @param {string} phpSource - PHP file contents.
- * @param {string} constName - Constant name (e.g. 'SCRIPT_HANDLES').
- * @return {string[]} The array's string literal values, or [] if not found.
+ * @param {string} constName - Constant name.
+ * @return {string[]} The array's string values, or [] if not found.
  */
 function parsePhpConstArray( phpSource, constName ) {
 	const match = phpSource.match(
 		new RegExp( `const\\s+${ constName }\\s*=\\s*array\\(([^)]*)\\)` )
 	);
-	if ( ! match ) {
-		return [];
-	}
-	return match[ 1 ].match( /'([^']+)'/g )?.map( s => s.replace( /'/g, '' ) ) ?? [];
+	return match ? match[ 1 ].match( /'([^']+)'/g )?.map( s => s.replace( /'/g, '' ) ) ?? [] : [];
 }
 
 /**
- * Derive the shipped provider/consumer package lists from the PHP class constants
- * (the single source of truth).
+ * Derive the shipped provider/consumer lists from the class constants in
+ * class-wp-build-polyfills.php (SCRIPT_HANDLES + MODULE_IDS) — the single source of
+ * truth that also registers them at runtime. Providers are the classic-script globals
+ * whose exports we verify; consumers are the ESM modules that import them.
  *
  * @param {string} packageRoot - Polyfill package root.
- * @return {{ providers: string[], consumers: string[] }} Classic-script providers and module consumers.
+ * @return {{ providers: string[], consumers: string[] }} Providers and consumers.
  */
 function getShippedPackages( packageRoot ) {
 	const php = readFileSync(
@@ -90,26 +49,21 @@ function getShippedPackages( packageRoot ) {
 	);
 	return {
 		providers: parsePhpConstArray( php, 'SCRIPT_HANDLES' ).map( handleToPackage ),
-		consumers: parsePhpConstArray( php, 'MODULE_IDS' ), // Already `@wordpress/*` names.
+		consumers: parsePhpConstArray( php, 'MODULE_IDS' ),
 	};
 }
 
 /**
- * Extract the ORIGINAL names of the symbols named-imported from a specific
- * provider package in a chunk of ESM source.
- *
- * Handles `import { A, B as C } from '@wordpress/x'` (the imported name is the
- * token BEFORE `as`), across single- and multi-line import statements, single
- * or double quotes. Namespace (`import * as ns`) and default imports are
- * intentionally ignored: they cannot fail as a "missing named export".
+ * Original names of the symbols named-imported from a provider in ESM source.
+ * Handles `import { A, B as C } from '@wordpress/x'` (imported name is before `as`);
+ * ignores namespace/default imports, which can't be a missing named export.
  *
  * @param {string} source      - ESM source text.
  * @param {string} providerPkg - e.g. '@wordpress/theme'.
- * @return {string[]} Sorted, de-duplicated original imported symbol names.
+ * @return {string[]} Sorted, de-duplicated imported symbol names.
  */
 function parseNamedImports( source, providerPkg ) {
 	const found = new Set();
-	// Match `import { ... } from '<providerPkg>'` — the `{ ... }` may span lines.
 	const escaped = providerPkg.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
 	const re = new RegExp( `import\\s*\\{([^}]*)\\}\\s*from\\s*['"]${ escaped }['"]`, 'g' );
 	let match;
@@ -128,13 +82,9 @@ function parseNamedImports( source, providerPkg ) {
 }
 
 /**
- * Extract the PUBLIC export names from a provider package's built ESM index.
- *
- * Handles consolidated `export { A, default2 as B, store }` blocks and
- * re-export `export { A as B } from './x'` forms (the public name is the token
- * AFTER `as`). If the index uses a wildcard `export *`, the public surface
- * cannot be statically enumerated — the result is flagged `opaque` so callers
- * can skip (warn) rather than emit a false "missing export".
+ * Public export names from a provider's built ESM index. Handles `export { A, B as C }`
+ * (public name is after `as`); flags wildcard `export *` as opaque so callers skip it
+ * rather than emit a false "missing export".
  *
  * @param {string} indexSource - Contents of the package's `module`/`main` entry.
  * @return {{ names: string[], opaque: boolean }} Public export names + opacity flag.
@@ -142,7 +92,6 @@ function parseNamedImports( source, providerPkg ) {
 function parsePublicExports( indexSource ) {
 	const names = new Set();
 	const opaque = /export\s*\*/.test( indexSource );
-
 	const re = /export\s*\{([^}]*)\}/g;
 	let match;
 	while ( ( match = re.exec( indexSource ) ) !== null ) {
@@ -151,7 +100,6 @@ function parsePublicExports( indexSource ) {
 			if ( ! trimmed ) {
 				continue;
 			}
-			// `A as B` → public name is `B`; plain `A` → `A`.
 			const parts = trimmed.split( /\s+as\s+/ );
 			const name = parts[ parts.length - 1 ].trim();
 			if ( name ) {
@@ -163,15 +111,15 @@ function parsePublicExports( indexSource ) {
 }
 
 /**
- * Pure contract check for one (consumer → provider) pair.
+ * Contract check for one (consumer → provider) pair.
  *
- * @param {object}   args          - The (consumer, provider) pair and its symbols.
- * @param {string}   args.consumer - Consumer package name (for messages).
- * @param {string}   args.provider - Provider package name (for messages).
- * @param {string[]} args.imported - Symbols the consumer imports from the provider.
- * @param {string[]} args.exported - Public export names of the provider.
+ * @param {object}   args          - The pair and its symbols.
+ * @param {string}   args.consumer - Consumer package name.
+ * @param {string}   args.provider - Provider package name.
+ * @param {string[]} args.imported - Symbols the consumer imports.
+ * @param {string[]} args.exported - Provider's public export names.
  * @param {boolean}  [args.opaque] - True when the provider's exports can't be enumerated.
- * @return {{ ok: boolean, consumer: string, provider: string, missing: string[], skipped?: boolean }} The contract result.
+ * @return {{ ok: boolean, consumer: string, provider: string, missing: string[], skipped?: boolean }} Result.
  */
 function checkContract( { consumer, provider, imported, exported, opaque = false } ) {
 	if ( opaque ) {
@@ -183,25 +131,22 @@ function checkContract( { consumer, provider, imported, exported, opaque = false
 }
 
 /**
- * Resolve a package's directory from a given base directory, honouring the
- * pnpm/monorepo resolution the webpack build itself uses.
+ * Resolve a package's directory from a base dir (same resolution the build uses).
  *
  * @param {string} pkgName - e.g. '@wordpress/theme'.
- * @param {string} fromDir - Directory to resolve from (the polyfill package root).
+ * @param {string} fromDir - Directory to resolve from.
  * @return {string|null} Absolute package directory, or null if unresolvable.
  */
 function resolvePackageDir( pkgName, fromDir ) {
 	try {
-		const pkgJson = require.resolve( `${ pkgName }/package.json`, { paths: [ fromDir ] } );
-		return path.dirname( pkgJson );
+		return path.dirname( require.resolve( `${ pkgName }/package.json`, { paths: [ fromDir ] } ) );
 	} catch {
 		return null;
 	}
 }
 
 /**
- * Read the concatenated ESM source of every `*.mjs` file under a package's
- * `build-module` directory (used to scan a consumer's imports).
+ * Concatenated ESM source of every `*.mjs` under a package's `build-module` dir.
  *
  * @param {string} pkgDir - Absolute package directory.
  * @return {string} Concatenated source, or '' if no build-module dir.
@@ -227,7 +172,7 @@ function readBuildModuleSource( pkgDir ) {
 }
 
 /**
- * Read a provider package's public export names from its ESM entry point.
+ * Read a provider's public export names from its ESM entry point.
  *
  * @param {string} pkgDir - Absolute package directory.
  * @return {{ names: string[], opaque: boolean } | null} Exports, or null if unreadable.
@@ -239,47 +184,69 @@ function readPackageExports( pkgDir ) {
 		return null;
 	}
 	const entryPath = path.join( pkgDir, entry );
-	if ( ! existsSync( entryPath ) ) {
-		return null;
-	}
-	return parsePublicExports( readFileSync( entryPath, 'utf8' ) );
+	return existsSync( entryPath ) ? parsePublicExports( readFileSync( entryPath, 'utf8' ) ) : null;
 }
 
 /**
- * Run the export-contract validation across the shipped package set.
+ * Format an actionable error message for failed contracts.
  *
- * Reads the shipped versions from the polyfill package's own resolution
- * context (same as the webpack build), so the check reflects exactly what the
- * package ships.
+ * @param {object[]} failures - Failed contract results.
+ * @param {string[]} errors   - Non-contract errors (unreadable packages).
+ * @return {string} Formatted message.
+ */
+function formatError( failures, errors ) {
+	const lines = [];
+	if ( failures.length ) {
+		lines.push(
+			'Export-contract violation: a polyfilled package imports symbols the shipped',
+			'version of another polyfilled package does not export — this resolves to',
+			'`undefined` at runtime (blank dashboard, no build error; the Jetpack 16.0',
+			'failure mode). Bump the provider so its public API matches, keeping the',
+			'`@wordpress/*` set version-aligned.',
+			''
+		);
+		for ( const f of failures ) {
+			lines.push(
+				`   ${ f.consumer } imports from ${ f.provider }: [ ${ f.missing.join(
+					', '
+				) } ] — not exported.`
+			);
+		}
+	}
+	if ( errors.length ) {
+		lines.push( '', ...errors );
+	}
+	return lines.join( '\n' );
+}
+
+/**
+ * Validate the export contracts across the shipped package set. Reads the shipped
+ * versions from the polyfill's own resolution context (same as the build).
  *
- * @param {object}   [options]                 - Validation options.
+ * @param {object}   [options]                 - Options.
  * @param {string}   [options.packageRoot]     - Polyfill package root. Defaults to this package.
  * @param {string[]} [options.providers]       - Override provider list (tests).
  * @param {string[]} [options.consumers]       - Override consumer list (tests).
- * @param {object}   [options.simulateMissing] - Map of providerPkg → symbol[] to drop from its exports, to simulate a skew (see WP_BUILD_POLYFILLS_SIMULATE_MISSING).
- * @return {{ ok: boolean, results: object[], errors: string[], error?: string }} The aggregate validation result.
+ * @param {object}   [options.simulateMissing] - Map of providerPkg → symbol[] to drop, to simulate a skew (tests).
+ * @return {{ ok: boolean, results: object[], errors: string[], error?: string }} Aggregate result.
  */
 function validateExportContracts( options = {} ) {
 	const packageRoot = options.packageRoot || path.join( __dirname, '..' );
 	const shipped = getShippedPackages( packageRoot );
 	const providers = options.providers || shipped.providers;
 	const consumers = options.consumers || shipped.consumers;
-	const simulateMissing =
-		options.simulateMissing || parseSimulateEnv( process.env.WP_BUILD_POLYFILLS_SIMULATE_MISSING );
+	const simulateMissing = options.simulateMissing || {};
 
 	const errors = [];
-
-	// Resolve each provider's shipped public exports once.
 	const providerExports = {};
 	for ( const provider of providers ) {
 		const dir = resolvePackageDir( provider, packageRoot );
 		if ( ! dir ) {
-			// A provider that isn't installed simply isn't shipped — skip it.
-			continue;
+			continue; // Not installed → not shipped.
 		}
 		const exp = readPackageExports( dir );
 		if ( ! exp ) {
-			errors.push( `Could not read exports for ${ provider } (no readable module entry).` );
+			errors.push( `Could not read exports for ${ provider }.` );
 			continue;
 		}
 		const dropped = simulateMissing[ provider ] || [];
@@ -301,105 +268,31 @@ function validateExportContracts( options = {} ) {
 		}
 		for ( const provider of Object.keys( providerExports ) ) {
 			const imported = parseNamedImports( source, provider );
-			if ( imported.length === 0 ) {
-				continue;
+			if ( imported.length ) {
+				results.push(
+					checkContract( {
+						consumer,
+						provider,
+						imported,
+						exported: providerExports[ provider ].names,
+						opaque: providerExports[ provider ].opaque,
+					} )
+				);
 			}
-			results.push(
-				checkContract( {
-					consumer,
-					provider,
-					imported,
-					exported: providerExports[ provider ].names,
-					opaque: providerExports[ provider ].opaque,
-				} )
-			);
 		}
 	}
 
 	const failures = results.filter( r => ! r.ok );
 	const ok = failures.length === 0 && errors.length === 0;
-
-	let error;
-	if ( ! ok ) {
-		error = formatError( failures, errors );
-	}
-	return { ok, results, errors, error };
-}
-
-/**
- * Parse the WP_BUILD_POLYFILLS_SIMULATE_MISSING env var into a drop-map.
- *
- * Format: comma-separated `@wordpress/pkg:Symbol` pairs, e.g. `@wordpress/theme:ThemeProvider`.
- *
- * @param {string|undefined} raw - Raw env value.
- * @return {object} Map of provider package → symbol[] to drop.
- */
-function parseSimulateEnv( raw ) {
-	const map = {};
-	if ( ! raw ) {
-		return map;
-	}
-	for ( const pair of raw.split( ',' ) ) {
-		const idx = pair.lastIndexOf( ':' );
-		if ( idx === -1 ) {
-			continue;
-		}
-		const pkg = pair.slice( 0, idx ).trim();
-		const symbol = pair.slice( idx + 1 ).trim();
-		if ( ! pkg || ! symbol ) {
-			continue;
-		}
-		( map[ pkg ] = map[ pkg ] || [] ).push( symbol );
-	}
-	return map;
-}
-
-/**
- * Build a human-readable, actionable error message.
- *
- * @param {object[]} failures - Failed contract results.
- * @param {string[]} errors   - Non-contract errors (unreadable packages, etc.).
- * @return {string} Formatted message.
- */
-function formatError( failures, errors ) {
-	const lines = [];
-	if ( failures.length > 0 ) {
-		lines.push(
-			'Export-contract violation: a polyfilled package imports symbols that the',
-			'shipped version of another polyfilled package does NOT export.',
-			'',
-			'This resolves to `undefined` at runtime → blank dashboard, no build error',
-			'(this is the Jetpack 16.0 failure mode).',
-			''
-		);
-		for ( const f of failures ) {
-			lines.push(
-				`   ${ f.consumer } imports from ${ f.provider }: [ ${ f.missing.join(
-					', '
-				) } ] — NOT exported.`
-			);
-		}
-		lines.push(
-			'',
-			'Fix: bump the provider package so its shipped public API matches what the',
-			'consumer expects, and keep the whole `@wordpress/*` set version-aligned',
-			'(they are a co-released matched set). See package.json devDependencies.'
-		);
-	}
-	if ( errors.length > 0 ) {
-		lines.push( '', 'Additional problems:', ...errors.map( e => `   - ${ e }` ) );
-	}
-	return lines.join( '\n' );
+	return { ok, results, errors, error: ok ? undefined : formatError( failures, errors ) };
 }
 
 module.exports = {
+	handleToPackage,
+	parsePhpConstArray,
+	getShippedPackages,
 	parseNamedImports,
 	parsePublicExports,
 	checkContract,
 	validateExportContracts,
-	parseSimulateEnv,
-	formatError,
-	handleToPackage,
-	parsePhpConstArray,
-	getShippedPackages,
 };

--- a/projects/packages/wp-build-polyfills/bin/validate-export-contract-lib.js
+++ b/projects/packages/wp-build-polyfills/bin/validate-export-contract-lib.js
@@ -358,6 +358,7 @@ module.exports = {
 	checkContract,
 	validateExportContracts,
 	parseSimulateEnv,
+	formatError,
 	PROVIDER_PACKAGES,
 	CONSUMER_PACKAGES,
 };

--- a/projects/packages/wp-build-polyfills/bin/validate-export-contract-lib.js
+++ b/projects/packages/wp-build-polyfills/bin/validate-export-contract-lib.js
@@ -1,0 +1,363 @@
+/* global __dirname, process */
+/**
+ * Shared logic for the export-contract validator.
+ *
+ * Used by both the post-build CLI script and the test suite.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * This package ships a *matched set* of `@wordpress/*` packages. Some of them
+ * import symbols from others at runtime — most importantly `@wordpress/boot`
+ * imports `ThemeProvider` from `@wordpress/theme`, `SnackbarNotices` from
+ * `@wordpress/notices`, and so on. Those imported packages are shipped as
+ * classic scripts that expose a `window.wp.<pkg>` global.
+ *
+ * If the versions get out of sync (e.g. boot expects a public `ThemeProvider`
+ * export but the shipped `@wordpress/theme` only exposes it privately), the
+ * symbol resolves to `undefined` at runtime → React error #130 → blank
+ * dashboard, with NO build error and NO obvious console message. That is
+ * exactly what shipped in Jetpack 16.0.
+ *
+ * The existing `validate-boot-asset` check verifies that dependency *handle
+ * names* are known. It does NOT verify that the *symbols* one package imports
+ * from another actually exist in the shipped version. This check closes that
+ * gap: for every symbol a consumer package imports from a polyfilled provider
+ * package, assert the provider's shipped public API actually exports it.
+ *
+ * Both sides are read from the packages' published ESM source
+ * (`build-module/*.mjs`) — NOT from the webpack-built bundle — because the
+ * built bundle mangles import identifiers under minification, while the source
+ * `import { X } from '@wordpress/y'` / `export { X }` statements are stable.
+ */
+
+const { readFileSync, readdirSync, existsSync } = require( 'fs' );
+const path = require( 'path' );
+
+// Provider packages whose public exports we verify. Scoped to the CLASSIC
+// SCRIPT polyfills (the `window.wp.<pkg>` globals) — this is the surface where
+// a missing export silently resolves to `undefined` at runtime (the 16.0
+// failure mode). Keep in sync with `classicPolyfills` in webpack.config.js and
+// SCRIPT_HANDLES in src/class-wp-build-polyfills.php (asserted by a test).
+//
+// NOTE: the ESM module polyfills (@wordpress/route, @wordpress/a11y) are
+// resolved via the browser import map rather than a window global, so they
+// have a different (import-map) failure mode. Verifying them is a documented
+// follow-up; see README "Export-contract validation".
+const PROVIDER_PACKAGES = [
+	'@wordpress/theme',
+	'@wordpress/notices',
+	'@wordpress/private-apis',
+	'@wordpress/views',
+];
+
+// Consumer packages whose imports we scan. These are the ESM polyfills that
+// compose the provider packages above. Keep in sync with `modulePolyfills` in
+// webpack.config.js (asserted by a test).
+const CONSUMER_PACKAGES = [ '@wordpress/boot', '@wordpress/route', '@wordpress/a11y' ];
+
+/**
+ * Extract the ORIGINAL names of the symbols named-imported from a specific
+ * provider package in a chunk of ESM source.
+ *
+ * Handles `import { A, B as C } from '@wordpress/x'` (the imported name is the
+ * token BEFORE `as`), across single- and multi-line import statements, single
+ * or double quotes. Namespace (`import * as ns`) and default imports are
+ * intentionally ignored: they cannot fail as a "missing named export".
+ *
+ * @param {string} source      - ESM source text.
+ * @param {string} providerPkg - e.g. '@wordpress/theme'.
+ * @return {string[]} Sorted, de-duplicated original imported symbol names.
+ */
+function parseNamedImports( source, providerPkg ) {
+	const found = new Set();
+	// Match `import { ... } from '<providerPkg>'` — the `{ ... }` may span lines.
+	const escaped = providerPkg.replace( /[.*+?^${}()|[\]\\]/g, '\\$&' );
+	const re = new RegExp( `import\\s*\\{([^}]*)\\}\\s*from\\s*['"]${ escaped }['"]`, 'g' );
+	let match;
+	while ( ( match = re.exec( source ) ) !== null ) {
+		for ( const specifier of match[ 1 ].split( ',' ) ) {
+			const name = specifier
+				.trim()
+				.split( /\s+as\s+/ )[ 0 ]
+				.trim();
+			if ( name ) {
+				found.add( name );
+			}
+		}
+	}
+	return [ ...found ].sort();
+}
+
+/**
+ * Extract the PUBLIC export names from a provider package's built ESM index.
+ *
+ * Handles consolidated `export { A, default2 as B, store }` blocks and
+ * re-export `export { A as B } from './x'` forms (the public name is the token
+ * AFTER `as`). If the index uses a wildcard `export *`, the public surface
+ * cannot be statically enumerated — the result is flagged `opaque` so callers
+ * can skip (warn) rather than emit a false "missing export".
+ *
+ * @param {string} indexSource - Contents of the package's `module`/`main` entry.
+ * @return {{ names: string[], opaque: boolean }} Public export names + opacity flag.
+ */
+function parsePublicExports( indexSource ) {
+	const names = new Set();
+	const opaque = /export\s*\*/.test( indexSource );
+
+	const re = /export\s*\{([^}]*)\}/g;
+	let match;
+	while ( ( match = re.exec( indexSource ) ) !== null ) {
+		for ( const specifier of match[ 1 ].split( ',' ) ) {
+			const trimmed = specifier.trim();
+			if ( ! trimmed ) {
+				continue;
+			}
+			// `A as B` → public name is `B`; plain `A` → `A`.
+			const parts = trimmed.split( /\s+as\s+/ );
+			const name = parts[ parts.length - 1 ].trim();
+			if ( name ) {
+				names.add( name );
+			}
+		}
+	}
+	return { names: [ ...names ].sort(), opaque };
+}
+
+/**
+ * Pure contract check for one (consumer → provider) pair.
+ *
+ * @param {object}   args          - The (consumer, provider) pair and its symbols.
+ * @param {string}   args.consumer - Consumer package name (for messages).
+ * @param {string}   args.provider - Provider package name (for messages).
+ * @param {string[]} args.imported - Symbols the consumer imports from the provider.
+ * @param {string[]} args.exported - Public export names of the provider.
+ * @param {boolean}  [args.opaque] - True when the provider's exports can't be enumerated.
+ * @return {{ ok: boolean, consumer: string, provider: string, missing: string[], skipped?: boolean }} The contract result.
+ */
+function checkContract( { consumer, provider, imported, exported, opaque = false } ) {
+	if ( opaque ) {
+		return { ok: true, consumer, provider, missing: [], skipped: true };
+	}
+	const exportedSet = new Set( exported );
+	const missing = imported.filter( name => ! exportedSet.has( name ) );
+	return { ok: missing.length === 0, consumer, provider, missing };
+}
+
+/**
+ * Resolve a package's directory from a given base directory, honouring the
+ * pnpm/monorepo resolution the webpack build itself uses.
+ *
+ * @param {string} pkgName - e.g. '@wordpress/theme'.
+ * @param {string} fromDir - Directory to resolve from (the polyfill package root).
+ * @return {string|null} Absolute package directory, or null if unresolvable.
+ */
+function resolvePackageDir( pkgName, fromDir ) {
+	try {
+		const pkgJson = require.resolve( `${ pkgName }/package.json`, { paths: [ fromDir ] } );
+		return path.dirname( pkgJson );
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Read the concatenated ESM source of every `*.mjs` file under a package's
+ * `build-module` directory (used to scan a consumer's imports).
+ *
+ * @param {string} pkgDir - Absolute package directory.
+ * @return {string} Concatenated source, or '' if no build-module dir.
+ */
+function readBuildModuleSource( pkgDir ) {
+	const dir = path.join( pkgDir, 'build-module' );
+	if ( ! existsSync( dir ) ) {
+		return '';
+	}
+	const chunks = [];
+	const walk = current => {
+		for ( const entry of readdirSync( current, { withFileTypes: true } ) ) {
+			const full = path.join( current, entry.name );
+			if ( entry.isDirectory() ) {
+				walk( full );
+			} else if ( entry.name.endsWith( '.mjs' ) ) {
+				chunks.push( readFileSync( full, 'utf8' ) );
+			}
+		}
+	};
+	walk( dir );
+	return chunks.join( '\n' );
+}
+
+/**
+ * Read a provider package's public export names from its ESM entry point.
+ *
+ * @param {string} pkgDir - Absolute package directory.
+ * @return {{ names: string[], opaque: boolean } | null} Exports, or null if unreadable.
+ */
+function readPackageExports( pkgDir ) {
+	const pkg = JSON.parse( readFileSync( path.join( pkgDir, 'package.json' ), 'utf8' ) );
+	const entry = pkg.module || pkg.main;
+	if ( ! entry ) {
+		return null;
+	}
+	const entryPath = path.join( pkgDir, entry );
+	if ( ! existsSync( entryPath ) ) {
+		return null;
+	}
+	return parsePublicExports( readFileSync( entryPath, 'utf8' ) );
+}
+
+/**
+ * Run the export-contract validation across the shipped package set.
+ *
+ * Reads the shipped versions from the polyfill package's own resolution
+ * context (same as the webpack build), so the check reflects exactly what the
+ * package ships.
+ *
+ * @param {object}   [options]                 - Validation options.
+ * @param {string}   [options.packageRoot]     - Polyfill package root. Defaults to this package.
+ * @param {string[]} [options.providers]       - Override provider list (tests).
+ * @param {string[]} [options.consumers]       - Override consumer list (tests).
+ * @param {object}   [options.simulateMissing] - Map of providerPkg → symbol[] to drop from its exports, to simulate a skew (see WP_BUILD_POLYFILLS_SIMULATE_MISSING).
+ * @return {{ ok: boolean, results: object[], errors: string[], error?: string }} The aggregate validation result.
+ */
+function validateExportContracts( options = {} ) {
+	const packageRoot = options.packageRoot || path.join( __dirname, '..' );
+	const providers = options.providers || PROVIDER_PACKAGES;
+	const consumers = options.consumers || CONSUMER_PACKAGES;
+	const simulateMissing =
+		options.simulateMissing || parseSimulateEnv( process.env.WP_BUILD_POLYFILLS_SIMULATE_MISSING );
+
+	const errors = [];
+
+	// Resolve each provider's shipped public exports once.
+	const providerExports = {};
+	for ( const provider of providers ) {
+		const dir = resolvePackageDir( provider, packageRoot );
+		if ( ! dir ) {
+			// A provider that isn't installed simply isn't shipped — skip it.
+			continue;
+		}
+		const exp = readPackageExports( dir );
+		if ( ! exp ) {
+			errors.push( `Could not read exports for ${ provider } (no readable module entry).` );
+			continue;
+		}
+		const dropped = simulateMissing[ provider ] || [];
+		providerExports[ provider ] = {
+			names: exp.names.filter( n => ! dropped.includes( n ) ),
+			opaque: exp.opaque,
+		};
+	}
+
+	const results = [];
+	for ( const consumer of consumers ) {
+		const dir = resolvePackageDir( consumer, packageRoot );
+		if ( ! dir ) {
+			continue;
+		}
+		const source = readBuildModuleSource( dir );
+		if ( ! source ) {
+			continue;
+		}
+		for ( const provider of Object.keys( providerExports ) ) {
+			const imported = parseNamedImports( source, provider );
+			if ( imported.length === 0 ) {
+				continue;
+			}
+			results.push(
+				checkContract( {
+					consumer,
+					provider,
+					imported,
+					exported: providerExports[ provider ].names,
+					opaque: providerExports[ provider ].opaque,
+				} )
+			);
+		}
+	}
+
+	const failures = results.filter( r => ! r.ok );
+	const ok = failures.length === 0 && errors.length === 0;
+
+	let error;
+	if ( ! ok ) {
+		error = formatError( failures, errors );
+	}
+	return { ok, results, errors, error };
+}
+
+/**
+ * Parse the WP_BUILD_POLYFILLS_SIMULATE_MISSING env var into a drop-map.
+ *
+ * Format: comma-separated `@wordpress/pkg:Symbol` pairs, e.g. `@wordpress/theme:ThemeProvider`.
+ *
+ * @param {string|undefined} raw - Raw env value.
+ * @return {object} Map of provider package → symbol[] to drop.
+ */
+function parseSimulateEnv( raw ) {
+	const map = {};
+	if ( ! raw ) {
+		return map;
+	}
+	for ( const pair of raw.split( ',' ) ) {
+		const idx = pair.lastIndexOf( ':' );
+		if ( idx === -1 ) {
+			continue;
+		}
+		const pkg = pair.slice( 0, idx ).trim();
+		const symbol = pair.slice( idx + 1 ).trim();
+		if ( ! pkg || ! symbol ) {
+			continue;
+		}
+		( map[ pkg ] = map[ pkg ] || [] ).push( symbol );
+	}
+	return map;
+}
+
+/**
+ * Build a human-readable, actionable error message.
+ *
+ * @param {object[]} failures - Failed contract results.
+ * @param {string[]} errors   - Non-contract errors (unreadable packages, etc.).
+ * @return {string} Formatted message.
+ */
+function formatError( failures, errors ) {
+	const lines = [];
+	if ( failures.length > 0 ) {
+		lines.push(
+			'Export-contract violation: a polyfilled package imports symbols that the',
+			'shipped version of another polyfilled package does NOT export.',
+			'',
+			'This resolves to `undefined` at runtime → blank dashboard, no build error',
+			'(this is the Jetpack 16.0 failure mode).',
+			''
+		);
+		for ( const f of failures ) {
+			lines.push(
+				`   ${ f.consumer } imports from ${ f.provider }: [ ${ f.missing.join(
+					', '
+				) } ] — NOT exported.`
+			);
+		}
+		lines.push(
+			'',
+			'Fix: bump the provider package so its shipped public API matches what the',
+			'consumer expects, and keep the whole `@wordpress/*` set version-aligned',
+			'(they are a co-released matched set). See package.json devDependencies.'
+		);
+	}
+	if ( errors.length > 0 ) {
+		lines.push( '', 'Additional problems:', ...errors.map( e => `   - ${ e }` ) );
+	}
+	return lines.join( '\n' );
+}
+
+module.exports = {
+	parseNamedImports,
+	parsePublicExports,
+	checkContract,
+	validateExportContracts,
+	parseSimulateEnv,
+	PROVIDER_PACKAGES,
+	CONSUMER_PACKAGES,
+};

--- a/projects/packages/wp-build-polyfills/bin/validate-export-contract-lib.js
+++ b/projects/packages/wp-build-polyfills/bin/validate-export-contract-lib.js
@@ -58,7 +58,8 @@ function getShippedPackages( packageRoot ) {
  * Handles `import { A, B as C } from '@wordpress/x'` and the mixed default form
  * `import Def, { A } from '@wordpress/x'` (imported name is before `as`); a pure
  * default or namespace import has no `{ … }` and is ignored (can't be a missing
- * named export).
+ * named export). Matches `import` statements only — an `export { … } from
+ * '@wordpress/x'` re-export is not a consumer import and yields nothing.
  *
  * @param {string} source      - ESM source text.
  * @param {string} providerPkg - e.g. '@wordpress/theme'.
@@ -88,19 +89,23 @@ function parseNamedImports( source, providerPkg ) {
 }
 
 /**
- * Public export names from a provider's built ESM index. Handles `export { A, B as C }`
- * (public name is after `as`); flags wildcard `export *` as opaque so callers skip it
- * rather than emit a false "missing export".
+ * Public export names from a provider's built ESM index. Handles consolidated
+ * `export { A, B as C }` blocks (public name is after `as`) and inline
+ * declarations `export const/function/class/let/var X`; flags wildcard
+ * `export *` as opaque so callers skip it rather than emit a false "missing
+ * export". (`@wordpress/*` ship esbuild-consolidated indexes today, but an
+ * inline-export bump must not make the check report every symbol missing.)
  *
- * @param {string} indexSource - Contents of the package's `module`/`main` entry.
+ * @param {string} indexSource - Contents of the package's entry point.
  * @return {{ names: string[], opaque: boolean }} Public export names + opacity flag.
  */
 function parsePublicExports( indexSource ) {
 	const names = new Set();
 	const opaque = /export\s*\*/.test( indexSource );
-	const re = /export\s*\{([^}]*)\}/g;
+
+	const blockRe = /export\s*\{([^}]*)\}/g;
 	let match;
-	while ( ( match = re.exec( indexSource ) ) !== null ) {
+	while ( ( match = blockRe.exec( indexSource ) ) !== null ) {
 		for ( const specifier of match[ 1 ].split( ',' ) ) {
 			const trimmed = specifier.trim();
 			if ( ! trimmed ) {
@@ -113,6 +118,14 @@ function parsePublicExports( indexSource ) {
 			}
 		}
 	}
+
+	// Inline declarations, e.g. `export const ThemeProvider = …`.
+	for ( const m of indexSource.matchAll(
+		/export\s+(?:async\s+)?(?:function|class|const|let|var)\s+([\w$]+)/g
+	) ) {
+		names.add( m[ 1 ] );
+	}
+
 	return { names: [ ...names ].sort(), opaque };
 }
 
@@ -185,7 +198,10 @@ function readBuildModuleSource( pkgDir ) {
  */
 function readPackageExports( pkgDir ) {
 	const pkg = JSON.parse( readFileSync( path.join( pkgDir, 'package.json' ), 'utf8' ) );
-	const entry = pkg.module || pkg.main;
+	// Prefer the `exports` map's ESM entry (how resolution actually works), then
+	// fall back to `module`/`main`. `@wordpress/boot` already ships no `main`.
+	const dot = pkg.exports?.[ '.' ];
+	const entry = ( typeof dot === 'string' ? dot : dot?.import ) ?? pkg.module ?? pkg.main;
 	if ( ! entry ) {
 		return null;
 	}
@@ -266,12 +282,20 @@ function validateExportContracts( options = {} ) {
 	const simulateMissing =
 		options.simulateMissing || parseSimulateEnv( process.env.WP_BUILD_POLYFILLS_SIMULATE_MISSING );
 
+	// Never drop a package from coverage silently — a check that verifies nothing
+	// but stays green is the failure mode this exists to prevent.
+	const warn = message => {
+		// eslint-disable-next-line no-console
+		console.warn( `[export-contract] ${ message }` );
+	};
+
 	const errors = [];
 	const providerExports = {};
 	for ( const provider of providers ) {
 		const dir = resolvePackageDir( provider, packageRoot );
 		if ( ! dir ) {
-			continue; // Not installed → not shipped.
+			warn( `Provider ${ provider } is not resolvable — not verifying it.` );
+			continue;
 		}
 		const exp = readPackageExports( dir );
 		if ( ! exp ) {
@@ -279,13 +303,9 @@ function validateExportContracts( options = {} ) {
 			continue;
 		}
 		if ( exp.opaque ) {
-			// A barrel (`export *`) can't be statically enumerated, so we can't verify
-			// this provider — warn loudly rather than skip it silently, which would be
-			// a hole in exactly the protection this check exists for.
-			// eslint-disable-next-line no-console
-			console.warn(
-				`[export-contract] Not verifying ${ provider }: its index uses \`export *\`, ` +
-					'so its public exports can’t be enumerated statically.'
+			warn(
+				`Not verifying ${ provider }: its index uses \`export *\`, so its public ` +
+					'exports can’t be enumerated statically.'
 			);
 		}
 		const dropped = simulateMissing[ provider ] || [];
@@ -299,10 +319,12 @@ function validateExportContracts( options = {} ) {
 	for ( const consumer of consumers ) {
 		const dir = resolvePackageDir( consumer, packageRoot );
 		if ( ! dir ) {
+			warn( `Consumer ${ consumer } is not resolvable — its imports were not checked.` );
 			continue;
 		}
 		const source = readBuildModuleSource( dir );
 		if ( ! source ) {
+			warn( `Consumer ${ consumer } has no build-module/ — its imports were not checked.` );
 			continue;
 		}
 		for ( const provider of Object.keys( providerExports ) ) {

--- a/projects/packages/wp-build-polyfills/bin/validate-export-contract.js
+++ b/projects/packages/wp-build-polyfills/bin/validate-export-contract.js
@@ -1,22 +1,9 @@
 #!/usr/bin/env node
 
 /**
- * Validate that symbols one polyfilled package imports from another actually
- * exist in the shipped version's public API.
- *
- * This package ships a matched set of `@wordpress/*` packages. When they get
- * out of version sync, a symbol one imports from another (e.g.
- * `ThemeProvider` from `@wordpress/theme`) can resolve to `undefined` at
- * runtime — a blank dashboard with NO build error. That is the Jetpack 16.0
- * failure mode. The handle-name check in `validate-boot-asset.js` does not
- * catch it; this one does.
- *
- * Runs after the build (see package.json `build`), and is also exercised by
- * `tests/js/validate-export-contract.test.js`.
- *
- * Manual trigger (simulate a skew without touching the lockfile): set
- * `WP_BUILD_POLYFILLS_SIMULATE_MISSING="@wordpress/theme:ThemeProvider"` and run this script,
- * or use the `pnpm run simulate:skew` shortcut.
+ * Post-build check: fail the build when a polyfilled package imports a symbol the
+ * shipped version of another polyfilled package does not export (the Jetpack 16.0
+ * blank-dashboard failure mode). See validate-export-contract-lib.js.
  */
 
 const { validateExportContracts } = require( './validate-export-contract-lib.js' );

--- a/projects/packages/wp-build-polyfills/bin/validate-export-contract.js
+++ b/projects/packages/wp-build-polyfills/bin/validate-export-contract.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+
+/**
+ * Validate that symbols one polyfilled package imports from another actually
+ * exist in the shipped version's public API.
+ *
+ * This package ships a matched set of `@wordpress/*` packages. When they get
+ * out of version sync, a symbol one imports from another (e.g.
+ * `ThemeProvider` from `@wordpress/theme`) can resolve to `undefined` at
+ * runtime — a blank dashboard with NO build error. That is the Jetpack 16.0
+ * failure mode. The handle-name check in `validate-boot-asset.js` does not
+ * catch it; this one does.
+ *
+ * Runs after the build (see package.json `build`), and is also exercised by
+ * `tests/js/validate-export-contract.test.js`.
+ *
+ * Manual trigger (simulate a skew without touching the lockfile): set
+ * `WP_BUILD_POLYFILLS_SIMULATE_MISSING="@wordpress/theme:ThemeProvider"` and run this script,
+ * or use the `pnpm run simulate:skew` shortcut.
+ */
+
+const { validateExportContracts } = require( './validate-export-contract-lib.js' );
+
+const result = validateExportContracts();
+
+if ( ! result.ok ) {
+	throw new Error( result.error );
+}

--- a/projects/packages/wp-build-polyfills/changelog/add-export-contract-validation
+++ b/projects/packages/wp-build-polyfills/changelog/add-export-contract-validation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add a build-time export-contract check that fails the build when a polyfilled package imports a symbol the shipped version of another polyfilled package does not export — the Jetpack 16.0 blank-dashboard failure mode.

--- a/projects/packages/wp-build-polyfills/package.json
+++ b/projects/packages/wp-build-polyfills/package.json
@@ -20,7 +20,6 @@
 		"build-production": "NODE_ENV=production BABEL_ENV=production pnpm run build",
 		"check-contracts": "node bin/validate-export-contract.js",
 		"clean": "rm -rf build/",
-		"simulate:skew": "WP_BUILD_POLYFILLS_SIMULATE_MISSING='@wordpress/theme:ThemeProvider' node bin/validate-export-contract.js",
 		"test": "node --test 'tests/js/**/*.test.js'",
 		"test-coverage": "c8 --report-dir=\"$COVERAGE_DIR\" --temp-directory=\"$ARTIFACTS_DIR/v8\" pnpm run test"
 	},

--- a/projects/packages/wp-build-polyfills/package.json
+++ b/projects/packages/wp-build-polyfills/package.json
@@ -16,9 +16,11 @@
 		"strip-unminified-prod": "bin/strip-unminified-prod.js"
 	},
 	"scripts": {
-		"build": "pnpm run clean && webpack && node bin/validate-boot-asset.js",
+		"build": "pnpm run clean && webpack && node bin/validate-boot-asset.js && node bin/validate-export-contract.js",
 		"build-production": "NODE_ENV=production BABEL_ENV=production pnpm run build",
 		"clean": "rm -rf build/",
+		"check-contracts": "node bin/validate-export-contract.js",
+		"simulate:skew": "WP_BUILD_POLYFILLS_SIMULATE_MISSING='@wordpress/theme:ThemeProvider' node bin/validate-export-contract.js",
 		"test": "node --test 'tests/js/**/*.test.js'",
 		"test-coverage": "c8 --report-dir=\"$COVERAGE_DIR\" --temp-directory=\"$ARTIFACTS_DIR/v8\" pnpm run test"
 	},

--- a/projects/packages/wp-build-polyfills/package.json
+++ b/projects/packages/wp-build-polyfills/package.json
@@ -18,8 +18,8 @@
 	"scripts": {
 		"build": "pnpm run clean && webpack && node bin/validate-boot-asset.js && node bin/validate-export-contract.js",
 		"build-production": "NODE_ENV=production BABEL_ENV=production pnpm run build",
-		"clean": "rm -rf build/",
 		"check-contracts": "node bin/validate-export-contract.js",
+		"clean": "rm -rf build/",
 		"simulate:skew": "WP_BUILD_POLYFILLS_SIMULATE_MISSING='@wordpress/theme:ThemeProvider' node bin/validate-export-contract.js",
 		"test": "node --test 'tests/js/**/*.test.js'",
 		"test-coverage": "c8 --report-dir=\"$COVERAGE_DIR\" --temp-directory=\"$ARTIFACTS_DIR/v8\" pnpm run test"

--- a/projects/packages/wp-build-polyfills/tests/js/validate-export-contract.test.js
+++ b/projects/packages/wp-build-polyfills/tests/js/validate-export-contract.test.js
@@ -1,0 +1,184 @@
+const assert = require( 'node:assert/strict' );
+const { describe, it } = require( 'node:test' );
+const path = require( 'path' );
+const {
+	parseNamedImports,
+	parsePublicExports,
+	checkContract,
+	parseSimulateEnv,
+	validateExportContracts,
+	PROVIDER_PACKAGES,
+	CONSUMER_PACKAGES,
+} = require( '../../bin/validate-export-contract-lib.js' );
+
+describe( 'validate-export-contract', () => {
+	describe( 'parseNamedImports', () => {
+		it( 'extracts a single named import', () => {
+			const src = "import { ThemeProvider } from '@wordpress/theme';";
+			assert.deepEqual( parseNamedImports( src, '@wordpress/theme' ), [ 'ThemeProvider' ] );
+		} );
+
+		it( 'uses the ORIGINAL name for aliased imports (`x as y`)', () => {
+			const src = "import { privateApis as routePrivateApis } from '@wordpress/route';";
+			assert.deepEqual( parseNamedImports( src, '@wordpress/route' ), [ 'privateApis' ] );
+		} );
+
+		it( 'handles multiple, multi-line, double-quoted imports', () => {
+			const src = `
+				import {
+					privateApis as routePrivateApis,
+					useNavigate
+				} from "@wordpress/route";
+			`;
+			assert.deepEqual( parseNamedImports( src, '@wordpress/route' ), [
+				'privateApis',
+				'useNavigate',
+			] );
+		} );
+
+		it( 'only matches the requested provider, not lookalikes', () => {
+			const src =
+				"import { A } from '@wordpress/theme';\nimport { B } from '@wordpress/theme-extra';";
+			assert.deepEqual( parseNamedImports( src, '@wordpress/theme' ), [ 'A' ] );
+		} );
+
+		it( 'ignores namespace and default imports (cannot be a missing named export)', () => {
+			const src = "import * as ns from '@wordpress/theme';\nimport def from '@wordpress/theme';";
+			assert.deepEqual( parseNamedImports( src, '@wordpress/theme' ), [] );
+		} );
+
+		it( 'returns empty when the provider is not imported', () => {
+			assert.deepEqual( parseNamedImports( "import { x } from 'clsx';", '@wordpress/theme' ), [] );
+		} );
+	} );
+
+	describe( 'parsePublicExports', () => {
+		it( 'parses a consolidated export block', () => {
+			const { names, opaque } = parsePublicExports(
+				'export {\n  ThemeProvider,\n  privateApis\n};'
+			);
+			assert.deepEqual( names, [ 'ThemeProvider', 'privateApis' ] );
+			assert.equal( opaque, false );
+		} );
+
+		it( 'uses the PUBLIC name for aliased exports (`x as y`)', () => {
+			// This is the real shape of @wordpress/notices' built index.
+			const { names } = parsePublicExports(
+				'export { default2 as InlineNotices, default3 as SnackbarNotices, store };'
+			);
+			assert.deepEqual( names, [ 'InlineNotices', 'SnackbarNotices', 'store' ] );
+		} );
+
+		it( 'flags wildcard re-exports as opaque', () => {
+			const { opaque } = parsePublicExports( "export * from './lib';\nexport { a };" );
+			assert.equal( opaque, true );
+		} );
+	} );
+
+	describe( 'checkContract', () => {
+		it( 'passes when every imported symbol is exported', () => {
+			const r = checkContract( {
+				consumer: '@wordpress/boot',
+				provider: '@wordpress/theme',
+				imported: [ 'ThemeProvider' ],
+				exported: [ 'ThemeProvider', 'privateApis' ],
+			} );
+			assert.equal( r.ok, true );
+			assert.deepEqual( r.missing, [] );
+		} );
+
+		// ── THE JETPACK 16.0 REGRESSION ──────────────────────────────────────
+		// boot imports `ThemeProvider`, but the shipped @wordpress/theme (0.15.1)
+		// only exposed it privately → public exports were `[ privateApis ]`.
+		// At runtime `wp.theme.ThemeProvider` was `undefined` → React #130 →
+		// blank dashboard. This check must catch it at build time.
+		it( 'FAILS on the 16.0 shape: boot imports ThemeProvider, theme 0.15.1 does not export it', () => {
+			const r = checkContract( {
+				consumer: '@wordpress/boot',
+				provider: '@wordpress/theme',
+				imported: [ 'ThemeProvider' ],
+				exported: [ 'privateApis' ], // theme 0.15.1 public surface
+			} );
+			assert.equal( r.ok, false );
+			assert.deepEqual( r.missing, [ 'ThemeProvider' ] );
+		} );
+
+		it( 'skips (passes) when the provider exports are opaque', () => {
+			const r = checkContract( {
+				consumer: '@wordpress/boot',
+				provider: '@wordpress/theme',
+				imported: [ 'ThemeProvider' ],
+				exported: [],
+				opaque: true,
+			} );
+			assert.equal( r.ok, true );
+			assert.equal( r.skipped, true );
+		} );
+	} );
+
+	describe( 'parseSimulateEnv', () => {
+		it( 'parses pkg:symbol pairs', () => {
+			assert.deepEqual( parseSimulateEnv( '@wordpress/theme:ThemeProvider' ), {
+				'@wordpress/theme': [ 'ThemeProvider' ],
+			} );
+		} );
+
+		it( 'parses multiple comma-separated pairs (scoped names keep their colon)', () => {
+			assert.deepEqual(
+				parseSimulateEnv( '@wordpress/theme:ThemeProvider,@wordpress/notices:SnackbarNotices' ),
+				{
+					'@wordpress/theme': [ 'ThemeProvider' ],
+					'@wordpress/notices': [ 'SnackbarNotices' ],
+				}
+			);
+		} );
+
+		it( 'returns empty for undefined/blank', () => {
+			assert.deepEqual( parseSimulateEnv( undefined ), {} );
+			assert.deepEqual( parseSimulateEnv( '' ), {} );
+		} );
+	} );
+
+	describe( 'package lists stay in sync with the build config', () => {
+		it( 'PROVIDER_PACKAGES matches webpack classicPolyfills', () => {
+			const webpack = require( '../../webpack.config.js' );
+			const scriptNames = webpack
+				.filter( c => c.name && c.name.startsWith( 'script-' ) )
+				.map( c => '@wordpress/' + c.name.replace( 'script-', '' ) )
+				.sort();
+			assert.deepEqual( [ ...PROVIDER_PACKAGES ].sort(), scriptNames );
+		} );
+
+		it( 'CONSUMER_PACKAGES matches webpack modulePolyfills', () => {
+			const webpack = require( '../../webpack.config.js' );
+			const moduleNames = webpack
+				.filter( c => c.name && c.name.startsWith( 'module-' ) )
+				.map( c => '@wordpress/' + c.name.replace( 'module-', '' ) )
+				.sort();
+			assert.deepEqual( [ ...CONSUMER_PACKAGES ].sort(), moduleNames );
+		} );
+	} );
+
+	describe( 'validateExportContracts (real installed tree)', () => {
+		const packageRoot = path.join( __dirname, '..', '..' );
+
+		it( 'passes against the actually-shipped @wordpress/* versions', () => {
+			const result = validateExportContracts( { packageRoot } );
+			// If a provider isn't installed the check simply skips it, so a
+			// clean tree should always be ok. A failure here means a real skew.
+			assert.equal( result.ok, true, result.error || 'unexpected contract failure' );
+		} );
+
+		it( 'detects a simulated skew (drops ThemeProvider from @wordpress/theme)', () => {
+			const result = validateExportContracts( {
+				packageRoot,
+				simulateMissing: { '@wordpress/theme': [ 'ThemeProvider' ] },
+			} );
+			assert.equal( result.ok, false );
+			const themeFailure = result.results.find( r => r.provider === '@wordpress/theme' && ! r.ok );
+			assert.ok( themeFailure, 'expected a @wordpress/theme contract failure' );
+			assert.ok( themeFailure.missing.includes( 'ThemeProvider' ) );
+			assert.match( result.error, /16\.0 failure mode|ThemeProvider/ );
+		} );
+	} );
+} );

--- a/projects/packages/wp-build-polyfills/tests/js/validate-export-contract.test.js
+++ b/projects/packages/wp-build-polyfills/tests/js/validate-export-contract.test.js
@@ -27,11 +27,15 @@ describe( 'validate-export-contract', () => {
 		);
 	} );
 
-	it( 'parsePublicExports reads export names, honouring `as` aliases and `export *`', () => {
+	it( 'parsePublicExports reads block, inline and aliased exports, and flags `export *`', () => {
 		assert.deepEqual(
 			parsePublicExports( 'export { default2 as SnackbarNotices, store };' ).names,
 			[ 'SnackbarNotices', 'store' ]
 		);
+		// Inline declarations (not just consolidated `export { … }` blocks).
+		assert.deepEqual( parsePublicExports( 'export const ThemeProvider = () => {};' ).names, [
+			'ThemeProvider',
+		] );
 		assert.equal( parsePublicExports( "export * from './x';" ).opaque, true );
 	} );
 
@@ -75,6 +79,12 @@ describe( 'validate-export-contract', () => {
 		it( 'passes for the actually-shipped @wordpress/* versions', () => {
 			const result = validateExportContracts( { packageRoot } );
 			assert.equal( result.ok, true, result.error || 'unexpected contract failure' );
+			// Guard against a vacuous green: the boot↔theme/notices/private-apis and
+			// route↔private-apis pairs must actually be scanned.
+			assert.ok(
+				result.results.length > 0,
+				'no contracts were scanned — the check may be silently verifying nothing'
+			);
 		} );
 
 		it( 'fails on a simulated skew (theme missing ThemeProvider)', () => {

--- a/projects/packages/wp-build-polyfills/tests/js/validate-export-contract.test.js
+++ b/projects/packages/wp-build-polyfills/tests/js/validate-export-contract.test.js
@@ -1,3 +1,4 @@
+const { execFileSync } = require( 'child_process' );
 const assert = require( 'node:assert/strict' );
 const { describe, it } = require( 'node:test' );
 const path = require( 'path' );
@@ -7,6 +8,7 @@ const {
 	checkContract,
 	parseSimulateEnv,
 	validateExportContracts,
+	formatError,
 	PROVIDER_PACKAGES,
 	CONSUMER_PACKAGES,
 } = require( '../../bin/validate-export-contract-lib.js' );
@@ -136,6 +138,78 @@ describe( 'validate-export-contract', () => {
 		it( 'returns empty for undefined/blank', () => {
 			assert.deepEqual( parseSimulateEnv( undefined ), {} );
 			assert.deepEqual( parseSimulateEnv( '' ), {} );
+		} );
+
+		it( 'skips malformed entries (no colon) and blank pkg/symbol', () => {
+			assert.deepEqual(
+				parseSimulateEnv( 'nocolon,:onlysymbol,@wordpress/theme:,@wordpress/theme:ThemeProvider' ),
+				{ '@wordpress/theme': [ 'ThemeProvider' ] }
+			);
+		} );
+	} );
+
+	describe( 'formatError', () => {
+		it( 'renders a failures-only message with the 16.0 reference', () => {
+			const msg = formatError(
+				[
+					{
+						consumer: '@wordpress/boot',
+						provider: '@wordpress/theme',
+						missing: [ 'ThemeProvider' ],
+					},
+				],
+				[]
+			);
+			assert.match( msg, /16\.0 failure mode/ );
+			assert.match( msg, /ThemeProvider/ );
+			assert.doesNotMatch( msg, /Additional problems/ );
+		} );
+
+		it( 'renders an errors-only message (unreadable packages, etc.)', () => {
+			const msg = formatError( [], [ 'Could not read exports for @wordpress/theme.' ] );
+			assert.match( msg, /Additional problems/ );
+			assert.match( msg, /Could not read exports/ );
+		} );
+	} );
+
+	describe( 'validateExportContracts — resolution branches', () => {
+		it( 'skips providers/consumers that are not installed (no false failure)', () => {
+			const result = validateExportContracts( {
+				packageRoot: path.join( __dirname, '..', '..' ),
+				providers: [ '@wordpress/definitely-not-a-real-package' ],
+				consumers: [ '@wordpress/definitely-not-a-real-package' ],
+			} );
+			assert.equal( result.ok, true );
+			assert.deepEqual( result.results, [] );
+		} );
+	} );
+
+	describe( 'CLI (bin/validate-export-contract.js)', () => {
+		const cli = path.join( __dirname, '..', '..', 'bin', 'validate-export-contract.js' );
+		const cwd = path.join( __dirname, '..', '..' );
+
+		it( 'exits 0 when contracts are satisfied', () => {
+			// Throws if the process exits non-zero.
+			execFileSync( process.execPath, [ cli ], { cwd, stdio: 'pipe' } );
+		} );
+
+		it( 'exits non-zero and reports the violation when a symbol is simulated missing', () => {
+			assert.throws(
+				() =>
+					execFileSync( process.execPath, [ cli ], {
+						cwd,
+						stdio: 'pipe',
+						env: {
+							...process.env,
+							WP_BUILD_POLYFILLS_SIMULATE_MISSING: '@wordpress/theme:ThemeProvider',
+						},
+					} ),
+				err => {
+					assert.notEqual( err.status, 0 );
+					assert.match( String( err.stderr ), /ThemeProvider|16\.0 failure mode/ );
+					return true;
+				}
+			);
 		} );
 	} );
 

--- a/projects/packages/wp-build-polyfills/tests/js/validate-export-contract.test.js
+++ b/projects/packages/wp-build-polyfills/tests/js/validate-export-contract.test.js
@@ -9,8 +9,9 @@ const {
 	parseSimulateEnv,
 	validateExportContracts,
 	formatError,
-	PROVIDER_PACKAGES,
-	CONSUMER_PACKAGES,
+	handleToPackage,
+	parsePhpConstArray,
+	getShippedPackages,
 } = require( '../../bin/validate-export-contract-lib.js' );
 
 describe( 'validate-export-contract', () => {
@@ -213,23 +214,37 @@ describe( 'validate-export-contract', () => {
 		} );
 	} );
 
-	describe( 'package lists stay in sync with the build config', () => {
-		it( 'PROVIDER_PACKAGES matches webpack classicPolyfills', () => {
-			const webpack = require( '../../webpack.config.js' );
-			const scriptNames = webpack
-				.filter( c => c.name && c.name.startsWith( 'script-' ) )
-				.map( c => '@wordpress/' + c.name.replace( 'script-', '' ) )
-				.sort();
-			assert.deepEqual( [ ...PROVIDER_PACKAGES ].sort(), scriptNames );
+	describe( 'shipped-package derivation (single source of truth)', () => {
+		const packageRoot = path.join( __dirname, '..', '..' );
+
+		it( 'handleToPackage maps `wp-*` handles to `@wordpress/*` names', () => {
+			assert.equal( handleToPackage( 'wp-theme' ), '@wordpress/theme' );
+			assert.equal( handleToPackage( 'wp-private-apis' ), '@wordpress/private-apis' );
 		} );
 
-		it( 'CONSUMER_PACKAGES matches webpack modulePolyfills', () => {
+		it( 'parsePhpConstArray extracts a class-constant array', () => {
+			const php = "const SCRIPT_HANDLES = array( 'wp-notices', 'wp-theme' );";
+			assert.deepEqual( parsePhpConstArray( php, 'SCRIPT_HANDLES' ), [ 'wp-notices', 'wp-theme' ] );
+		} );
+
+		it( 'parsePhpConstArray returns [] when the constant is absent', () => {
+			assert.deepEqual( parsePhpConstArray( '<?php // nothing', 'SCRIPT_HANDLES' ), [] );
+		} );
+
+		// The provider/consumer lists are derived from SCRIPT_HANDLES + MODULE_IDS
+		// in class-wp-build-polyfills.php (the single source of truth). This test
+		// guards that the PHP registration and the webpack build cannot silently
+		// diverge — if a polyfill is added to one but not the other, it fails.
+		it( 'PHP-derived packages match what webpack actually builds', () => {
+			const { providers, consumers } = getShippedPackages( packageRoot );
 			const webpack = require( '../../webpack.config.js' );
-			const moduleNames = webpack
-				.filter( c => c.name && c.name.startsWith( 'module-' ) )
-				.map( c => '@wordpress/' + c.name.replace( 'module-', '' ) )
-				.sort();
-			assert.deepEqual( [ ...CONSUMER_PACKAGES ].sort(), moduleNames );
+			const built = prefix =>
+				webpack
+					.filter( c => c.name && c.name.startsWith( prefix ) )
+					.map( c => '@wordpress/' + c.name.replace( prefix, '' ) )
+					.sort();
+			assert.deepEqual( [ ...providers ].sort(), built( 'script-' ) );
+			assert.deepEqual( [ ...consumers ].sort(), built( 'module-' ) );
 		} );
 	} );
 

--- a/projects/packages/wp-build-polyfills/tests/js/validate-export-contract.test.js
+++ b/projects/packages/wp-build-polyfills/tests/js/validate-export-contract.test.js
@@ -3,271 +3,93 @@ const assert = require( 'node:assert/strict' );
 const { describe, it } = require( 'node:test' );
 const path = require( 'path' );
 const {
-	parseNamedImports,
-	parsePublicExports,
-	checkContract,
-	parseSimulateEnv,
-	validateExportContracts,
-	formatError,
 	handleToPackage,
 	parsePhpConstArray,
 	getShippedPackages,
+	parseNamedImports,
+	parsePublicExports,
+	checkContract,
+	validateExportContracts,
 } = require( '../../bin/validate-export-contract-lib.js' );
 
+const packageRoot = path.join( __dirname, '..', '..' );
+
 describe( 'validate-export-contract', () => {
-	describe( 'parseNamedImports', () => {
-		it( 'extracts a single named import', () => {
-			const src = "import { ThemeProvider } from '@wordpress/theme';";
-			assert.deepEqual( parseNamedImports( src, '@wordpress/theme' ), [ 'ThemeProvider' ] );
-		} );
-
-		it( 'uses the ORIGINAL name for aliased imports (`x as y`)', () => {
-			const src = "import { privateApis as routePrivateApis } from '@wordpress/route';";
-			assert.deepEqual( parseNamedImports( src, '@wordpress/route' ), [ 'privateApis' ] );
-		} );
-
-		it( 'handles multiple, multi-line, double-quoted imports', () => {
-			const src = `
-				import {
-					privateApis as routePrivateApis,
-					useNavigate
-				} from "@wordpress/route";
-			`;
-			assert.deepEqual( parseNamedImports( src, '@wordpress/route' ), [
-				'privateApis',
-				'useNavigate',
-			] );
-		} );
-
-		it( 'only matches the requested provider, not lookalikes', () => {
-			const src =
-				"import { A } from '@wordpress/theme';\nimport { B } from '@wordpress/theme-extra';";
-			assert.deepEqual( parseNamedImports( src, '@wordpress/theme' ), [ 'A' ] );
-		} );
-
-		it( 'ignores namespace and default imports (cannot be a missing named export)', () => {
-			const src = "import * as ns from '@wordpress/theme';\nimport def from '@wordpress/theme';";
-			assert.deepEqual( parseNamedImports( src, '@wordpress/theme' ), [] );
-		} );
-
-		it( 'returns empty when the provider is not imported', () => {
-			assert.deepEqual( parseNamedImports( "import { x } from 'clsx';", '@wordpress/theme' ), [] );
-		} );
+	it( 'parseNamedImports extracts imported names, honouring `as` aliases', () => {
+		const src =
+			"import { ThemeProvider } from '@wordpress/theme';\nimport { privateApis as p } from '@wordpress/route';";
+		assert.deepEqual( parseNamedImports( src, '@wordpress/theme' ), [ 'ThemeProvider' ] );
+		assert.deepEqual( parseNamedImports( src, '@wordpress/route' ), [ 'privateApis' ] );
 	} );
 
-	describe( 'parsePublicExports', () => {
-		it( 'parses a consolidated export block', () => {
-			const { names, opaque } = parsePublicExports(
-				'export {\n  ThemeProvider,\n  privateApis\n};'
-			);
-			assert.deepEqual( names, [ 'ThemeProvider', 'privateApis' ] );
-			assert.equal( opaque, false );
-		} );
-
-		it( 'uses the PUBLIC name for aliased exports (`x as y`)', () => {
-			// This is the real shape of @wordpress/notices' built index.
-			const { names } = parsePublicExports(
-				'export { default2 as InlineNotices, default3 as SnackbarNotices, store };'
-			);
-			assert.deepEqual( names, [ 'InlineNotices', 'SnackbarNotices', 'store' ] );
-		} );
-
-		it( 'flags wildcard re-exports as opaque', () => {
-			const { opaque } = parsePublicExports( "export * from './lib';\nexport { a };" );
-			assert.equal( opaque, true );
-		} );
+	it( 'parsePublicExports reads export names, honouring `as` aliases and `export *`', () => {
+		assert.deepEqual(
+			parsePublicExports( 'export { default2 as SnackbarNotices, store };' ).names,
+			[ 'SnackbarNotices', 'store' ]
+		);
+		assert.equal( parsePublicExports( "export * from './x';" ).opaque, true );
 	} );
 
-	describe( 'checkContract', () => {
-		it( 'passes when every imported symbol is exported', () => {
-			const r = checkContract( {
-				consumer: '@wordpress/boot',
-				provider: '@wordpress/theme',
-				imported: [ 'ThemeProvider' ],
-				exported: [ 'ThemeProvider', 'privateApis' ],
-			} );
-			assert.equal( r.ok, true );
-			assert.deepEqual( r.missing, [] );
+	// The Jetpack 16.0 regression: boot imports ThemeProvider, but theme 0.15.1 only
+	// exported it privately, so at runtime `wp.theme.ThemeProvider` was undefined.
+	it( 'checkContract fails when an imported symbol is not exported (the 16.0 shape)', () => {
+		const bad = checkContract( {
+			consumer: '@wordpress/boot',
+			provider: '@wordpress/theme',
+			imported: [ 'ThemeProvider' ],
+			exported: [ 'privateApis' ],
 		} );
+		assert.equal( bad.ok, false );
+		assert.deepEqual( bad.missing, [ 'ThemeProvider' ] );
 
-		// ── THE JETPACK 16.0 REGRESSION ──────────────────────────────────────
-		// boot imports `ThemeProvider`, but the shipped @wordpress/theme (0.15.1)
-		// only exposed it privately → public exports were `[ privateApis ]`.
-		// At runtime `wp.theme.ThemeProvider` was `undefined` → React #130 →
-		// blank dashboard. This check must catch it at build time.
-		it( 'FAILS on the 16.0 shape: boot imports ThemeProvider, theme 0.15.1 does not export it', () => {
-			const r = checkContract( {
-				consumer: '@wordpress/boot',
-				provider: '@wordpress/theme',
-				imported: [ 'ThemeProvider' ],
-				exported: [ 'privateApis' ], // theme 0.15.1 public surface
-			} );
-			assert.equal( r.ok, false );
-			assert.deepEqual( r.missing, [ 'ThemeProvider' ] );
+		const good = checkContract( {
+			consumer: '@wordpress/boot',
+			provider: '@wordpress/theme',
+			imported: [ 'ThemeProvider' ],
+			exported: [ 'ThemeProvider' ],
 		} );
-
-		it( 'skips (passes) when the provider exports are opaque', () => {
-			const r = checkContract( {
-				consumer: '@wordpress/boot',
-				provider: '@wordpress/theme',
-				imported: [ 'ThemeProvider' ],
-				exported: [],
-				opaque: true,
-			} );
-			assert.equal( r.ok, true );
-			assert.equal( r.skipped, true );
-		} );
+		assert.equal( good.ok, true );
 	} );
 
-	describe( 'parseSimulateEnv', () => {
-		it( 'parses pkg:symbol pairs', () => {
-			assert.deepEqual( parseSimulateEnv( '@wordpress/theme:ThemeProvider' ), {
-				'@wordpress/theme': [ 'ThemeProvider' ],
-			} );
-		} );
+	it( 'derives providers/consumers from the PHP source of truth, matching webpack', () => {
+		assert.equal( handleToPackage( 'wp-private-apis' ), '@wordpress/private-apis' );
+		assert.deepEqual( parsePhpConstArray( "const X = array( 'wp-theme' );", 'X' ), [ 'wp-theme' ] );
 
-		it( 'parses multiple comma-separated pairs (scoped names keep their colon)', () => {
-			assert.deepEqual(
-				parseSimulateEnv( '@wordpress/theme:ThemeProvider,@wordpress/notices:SnackbarNotices' ),
-				{
-					'@wordpress/theme': [ 'ThemeProvider' ],
-					'@wordpress/notices': [ 'SnackbarNotices' ],
-				}
-			);
-		} );
-
-		it( 'returns empty for undefined/blank', () => {
-			assert.deepEqual( parseSimulateEnv( undefined ), {} );
-			assert.deepEqual( parseSimulateEnv( '' ), {} );
-		} );
-
-		it( 'skips malformed entries (no colon) and blank pkg/symbol', () => {
-			assert.deepEqual(
-				parseSimulateEnv( 'nocolon,:onlysymbol,@wordpress/theme:,@wordpress/theme:ThemeProvider' ),
-				{ '@wordpress/theme': [ 'ThemeProvider' ] }
-			);
-		} );
+		const { providers, consumers } = getShippedPackages( packageRoot );
+		const webpack = require( '../../webpack.config.js' );
+		const built = prefix =>
+			webpack
+				.filter( c => c.name && c.name.startsWith( prefix ) )
+				.map( c => '@wordpress/' + c.name.replace( prefix, '' ) )
+				.sort();
+		assert.deepEqual( [ ...providers ].sort(), built( 'script-' ) );
+		assert.deepEqual( [ ...consumers ].sort(), built( 'module-' ) );
 	} );
 
-	describe( 'formatError', () => {
-		it( 'renders a failures-only message with the 16.0 reference', () => {
-			const msg = formatError(
-				[
-					{
-						consumer: '@wordpress/boot',
-						provider: '@wordpress/theme',
-						missing: [ 'ThemeProvider' ],
-					},
-				],
-				[]
-			);
-			assert.match( msg, /16\.0 failure mode/ );
-			assert.match( msg, /ThemeProvider/ );
-			assert.doesNotMatch( msg, /Additional problems/ );
-		} );
-
-		it( 'renders an errors-only message (unreadable packages, etc.)', () => {
-			const msg = formatError( [], [ 'Could not read exports for @wordpress/theme.' ] );
-			assert.match( msg, /Additional problems/ );
-			assert.match( msg, /Could not read exports/ );
-		} );
-	} );
-
-	describe( 'validateExportContracts — resolution branches', () => {
-		it( 'skips providers/consumers that are not installed (no false failure)', () => {
-			const result = validateExportContracts( {
-				packageRoot: path.join( __dirname, '..', '..' ),
-				providers: [ '@wordpress/definitely-not-a-real-package' ],
-				consumers: [ '@wordpress/definitely-not-a-real-package' ],
-			} );
-			assert.equal( result.ok, true );
-			assert.deepEqual( result.results, [] );
-		} );
-	} );
-
-	describe( 'CLI (bin/validate-export-contract.js)', () => {
-		const cli = path.join( __dirname, '..', '..', 'bin', 'validate-export-contract.js' );
-		const cwd = path.join( __dirname, '..', '..' );
-
-		it( 'exits 0 when contracts are satisfied', () => {
-			// Throws if the process exits non-zero.
-			execFileSync( process.execPath, [ cli ], { cwd, stdio: 'pipe' } );
-		} );
-
-		it( 'exits non-zero and reports the violation when a symbol is simulated missing', () => {
-			assert.throws(
-				() =>
-					execFileSync( process.execPath, [ cli ], {
-						cwd,
-						stdio: 'pipe',
-						env: {
-							...process.env,
-							WP_BUILD_POLYFILLS_SIMULATE_MISSING: '@wordpress/theme:ThemeProvider',
-						},
-					} ),
-				err => {
-					assert.notEqual( err.status, 0 );
-					assert.match( String( err.stderr ), /ThemeProvider|16\.0 failure mode/ );
-					return true;
-				}
-			);
-		} );
-	} );
-
-	describe( 'shipped-package derivation (single source of truth)', () => {
-		const packageRoot = path.join( __dirname, '..', '..' );
-
-		it( 'handleToPackage maps `wp-*` handles to `@wordpress/*` names', () => {
-			assert.equal( handleToPackage( 'wp-theme' ), '@wordpress/theme' );
-			assert.equal( handleToPackage( 'wp-private-apis' ), '@wordpress/private-apis' );
-		} );
-
-		it( 'parsePhpConstArray extracts a class-constant array', () => {
-			const php = "const SCRIPT_HANDLES = array( 'wp-notices', 'wp-theme' );";
-			assert.deepEqual( parsePhpConstArray( php, 'SCRIPT_HANDLES' ), [ 'wp-notices', 'wp-theme' ] );
-		} );
-
-		it( 'parsePhpConstArray returns [] when the constant is absent', () => {
-			assert.deepEqual( parsePhpConstArray( '<?php // nothing', 'SCRIPT_HANDLES' ), [] );
-		} );
-
-		// The provider/consumer lists are derived from SCRIPT_HANDLES + MODULE_IDS
-		// in class-wp-build-polyfills.php (the single source of truth). This test
-		// guards that the PHP registration and the webpack build cannot silently
-		// diverge — if a polyfill is added to one but not the other, it fails.
-		it( 'PHP-derived packages match what webpack actually builds', () => {
-			const { providers, consumers } = getShippedPackages( packageRoot );
-			const webpack = require( '../../webpack.config.js' );
-			const built = prefix =>
-				webpack
-					.filter( c => c.name && c.name.startsWith( prefix ) )
-					.map( c => '@wordpress/' + c.name.replace( prefix, '' ) )
-					.sort();
-			assert.deepEqual( [ ...providers ].sort(), built( 'script-' ) );
-			assert.deepEqual( [ ...consumers ].sort(), built( 'module-' ) );
-		} );
-	} );
-
-	describe( 'validateExportContracts (real installed tree)', () => {
-		const packageRoot = path.join( __dirname, '..', '..' );
-
-		it( 'passes against the actually-shipped @wordpress/* versions', () => {
+	describe( 'against the installed tree', () => {
+		it( 'passes for the actually-shipped @wordpress/* versions', () => {
 			const result = validateExportContracts( { packageRoot } );
-			// If a provider isn't installed the check simply skips it, so a
-			// clean tree should always be ok. A failure here means a real skew.
 			assert.equal( result.ok, true, result.error || 'unexpected contract failure' );
 		} );
 
-		it( 'detects a simulated skew (drops ThemeProvider from @wordpress/theme)', () => {
+		it( 'fails on a simulated skew (theme missing ThemeProvider)', () => {
 			const result = validateExportContracts( {
 				packageRoot,
 				simulateMissing: { '@wordpress/theme': [ 'ThemeProvider' ] },
 			} );
 			assert.equal( result.ok, false );
-			const themeFailure = result.results.find( r => r.provider === '@wordpress/theme' && ! r.ok );
-			assert.ok( themeFailure, 'expected a @wordpress/theme contract failure' );
-			assert.ok( themeFailure.missing.includes( 'ThemeProvider' ) );
-			assert.match( result.error, /16\.0 failure mode|ThemeProvider/ );
+			assert.match( result.error, /ThemeProvider/ );
 		} );
+	} );
+
+	it( 'the CLI exits 0 when contracts hold', () => {
+		execFileSync(
+			process.execPath,
+			[ path.join( packageRoot, 'bin', 'validate-export-contract.js' ) ],
+			{
+				cwd: packageRoot,
+				stdio: 'pipe',
+			}
+		);
 	} );
 } );

--- a/projects/packages/wp-build-polyfills/tests/js/validate-export-contract.test.js
+++ b/projects/packages/wp-build-polyfills/tests/js/validate-export-contract.test.js
@@ -15,11 +15,16 @@ const {
 const packageRoot = path.join( __dirname, '..', '..' );
 
 describe( 'validate-export-contract', () => {
-	it( 'parseNamedImports extracts imported names, honouring `as` aliases', () => {
+	it( 'parseNamedImports extracts imported names, honouring `as` aliases and mixed default imports', () => {
 		const src =
 			"import { ThemeProvider } from '@wordpress/theme';\nimport { privateApis as p } from '@wordpress/route';";
 		assert.deepEqual( parseNamedImports( src, '@wordpress/theme' ), [ 'ThemeProvider' ] );
 		assert.deepEqual( parseNamedImports( src, '@wordpress/route' ), [ 'privateApis' ] );
+		// `import Def, { Bar } from …` must still yield the named symbol.
+		assert.deepEqual(
+			parseNamedImports( "import Def, { Bar } from '@wordpress/theme';", '@wordpress/theme' ),
+			[ 'Bar' ]
+		);
 	} );
 
 	it( 'parsePublicExports reads export names, honouring `as` aliases and `export *`', () => {
@@ -82,13 +87,29 @@ describe( 'validate-export-contract', () => {
 		} );
 	} );
 
+	const cli = path.join( packageRoot, 'bin', 'validate-export-contract.js' );
+
 	it( 'the CLI exits 0 when contracts hold', () => {
-		execFileSync(
-			process.execPath,
-			[ path.join( packageRoot, 'bin', 'validate-export-contract.js' ) ],
-			{
-				cwd: packageRoot,
-				stdio: 'pipe',
+		execFileSync( process.execPath, [ cli ], { cwd: packageRoot, stdio: 'pipe' } );
+	} );
+
+	// Covers the actual CI gate end-to-end: the CLI must exit non-zero on a violation.
+	// WP_BUILD_POLYFILLS_SIMULATE_MISSING is a test-only hook to inject one.
+	it( 'the CLI exits non-zero and reports the violation on a skew', () => {
+		assert.throws(
+			() =>
+				execFileSync( process.execPath, [ cli ], {
+					cwd: packageRoot,
+					stdio: 'pipe',
+					env: {
+						...process.env,
+						WP_BUILD_POLYFILLS_SIMULATE_MISSING: '@wordpress/theme:ThemeProvider',
+					},
+				} ),
+			err => {
+				assert.notEqual( err.status, 0 );
+				assert.match( String( err.stderr ), /ThemeProvider/ );
+				return true;
 			}
 		);
 	} );


### PR DESCRIPTION
## Proposed changes

`wp-build-polyfills` ships a **matched set** of `@wordpress/*` packages that call each other's exports at runtime (e.g. `@wordpress/boot` imports `ThemeProvider` from `@wordpress/theme`, `SnackbarNotices` from `@wordpress/notices`). When those versions drift out of sync, an imported symbol resolves to `undefined` at runtime — a **blank dashboard with no build error and no obvious console message**. That is the class of failure that shipped in Jetpack 16.0 (fixed in the 16.0.1 point release via #50515 / #50465).

The existing post-build check (`validate-boot-asset.js`) verifies dependency **handle names**, which is a different failure class and did not catch 16.0. This PR adds a second, complementary build-time guard that catches the export-skew class directly:

* **New `bin/validate-export-contract.js` (+ `-lib.js`)** — after `webpack`, for every symbol a consumer package (`@wordpress/boot`, …) imports from a polyfilled provider (`@wordpress/theme`, `@wordpress/notices`, `@wordpress/private-apis`, `@wordpress/views`), it asserts the provider's shipped public API actually exports it. Both sides are read from the packages' published ESM source (`build-module/*.mjs`), which is stable across builds/minification — not from the webpack bundle. The provider/consumer lists are derived from `SCRIPT_HANDLES` / `MODULE_IDS` in `class-wp-build-polyfills.php` (single source of truth). Scoped in v1 to the classic-script providers (the `window.wp.<pkg>` globals, where a missing export silently becomes `undefined`); the ESM module providers (`route`, `a11y`) are a documented follow-up.
* **Wired into the `build` script**, so a violation fails `pnpm build` → fails the `build` and `test-js` CI jobs (same gate as the existing check). Run standalone with `pnpm run check-contracts`.
* **Regression-tested** — `tests/js/validate-export-contract.test.js` covers the exact 16.0 shape (a consumer imports a symbol the provider no longer exports), a real-installed-tree green check, a simulated-skew **red** check that asserts the CLI exits non-zero, import/export parsing, and a drift test keeping the derived package lists in sync with `webpack.config.js`.

No change to the polyfill's runtime behavior or public PHP/JS API — this is a build-time safety net only.

## Related product discussion/links
<!-- Automattician-only: add P2 / Slack / Linear shortlinks before marking ready for review. -->
* Jetpack 16.0 blank admin dashboards post-mortem → 16.0.1 point release (FORMS-731)
* Related version-pin tracking: MONOREP-410
* Complements the min-WP E2E cell in #50621 (runtime backstop) — this is the build-time half.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

From `projects/packages/wp-build-polyfills`:

* **Guard is green on trunk:**
  ```
  pnpm install
  pnpm run build            # webpack + validate-boot-asset + validate-export-contract, all pass
  pnpm run check-contracts  # exits 0
  ```
* **Tests pass (incl. the 16.0 regression and the CLI red-path):**
  ```
  pnpm run build && pnpm run test   # build must run first — a pre-existing test reads its output
  ```
* **See the guard stop a broken build (authentic end-to-end):** edit `package.json` → `"@wordpress/theme": "0.15.1"` (a version that only exposed `ThemeProvider` privately — the real 16.0 cause), then `pnpm install && pnpm run build` → the build fails at `validate-export-contract.js`. Revert the pin + `pnpm install` when done. (The same red path is also asserted in the test suite via the “CLI exits non-zero … on a skew” case.)
