### PR TITLE
JITM: shared JetpackAdminNotices container + in-column JITMs across Jetpack dashboards

### DIFF
--- a/projects/js-packages/components/changelog/add-jitm-container-shared-component
+++ b/projects/js-packages/components/changelog/add-jitm-container-shared-component
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add JetpackAdminNotices: a shared #jp-admin-notices JITM mount point component.

--- a/projects/js-packages/components/components/jetpack-admin-notices/index.tsx
+++ b/projects/js-packages/components/components/jetpack-admin-notices/index.tsx
@@ -1,0 +1,26 @@
+type JetpackAdminNoticesProps = {
+	/** Optional extra class appended to the container. */
+	className?: string;
+};
+
+/**
+ * Renders the `#jp-admin-notices` mount point that the shared jetpack-jitm
+ * script injects the JITM `.jitm-card` into.
+ *
+ * This is ONLY the JITM slot — it does not render or manage other admin
+ * notices. Render at most one per page (the jitm JS targets the first
+ * element by id).
+ *
+ * @param {JetpackAdminNoticesProps} props           - Component props.
+ * @param {string}                   props.className - Optional extra class appended to the container.
+ * @return {JSX.Element} The mount point element.
+ */
+export default function JetpackAdminNotices( { className = '' }: JetpackAdminNoticesProps ) {
+	return (
+		<div
+			id="jp-admin-notices"
+			className={ `jetpack-jitm-card ${ className }`.trim() }
+			aria-live="polite"
+		/>
+	);
+}

--- a/projects/js-packages/components/components/jetpack-admin-notices/test/component.tsx
+++ b/projects/js-packages/components/components/jetpack-admin-notices/test/component.tsx
@@ -1,0 +1,21 @@
+/* eslint-disable testing-library/no-container */
+/* eslint-disable testing-library/no-node-access */
+import { render } from '@testing-library/react';
+import JetpackAdminNotices from '../index.tsx';
+
+describe( 'JetpackAdminNotices', () => {
+	it( 'renders a single #jp-admin-notices mount with the base class and aria-live', () => {
+		const { container } = render( <JetpackAdminNotices /> );
+		const mounts = container.querySelectorAll( '#jp-admin-notices' );
+		expect( mounts ).toHaveLength( 1 );
+		expect( mounts[ 0 ] ).toHaveClass( 'jetpack-jitm-card' );
+		expect( mounts[ 0 ] ).toHaveAttribute( 'aria-live', 'polite' );
+	} );
+
+	it( 'appends a passed className without dropping the base class', () => {
+		const { container } = render( <JetpackAdminNotices className="custom-x" /> );
+		const el = container.querySelector( '#jp-admin-notices' );
+		expect( el ).toHaveClass( 'jetpack-jitm-card' );
+		expect( el ).toHaveClass( 'custom-x' );
+	} );
+} );

--- a/projects/js-packages/components/index.ts
+++ b/projects/js-packages/components/index.ts
@@ -68,6 +68,7 @@ export { default as RecordMeterBar } from './components/record-meter-bar/index.t
 export { default as ContextualUpgradeTrigger } from './components/contextual-upgrade-trigger/index.tsx';
 export { default as Alert } from './components/alert/index.tsx';
 export { default as Notice } from './components/notice/index.tsx';
+export { default as JetpackAdminNotices } from './components/jetpack-admin-notices/index.tsx';
 export { default as Popover } from './components/popover/index.tsx';
 export { default as Status } from './components/status/index.tsx';
 export { default as IndeterminateProgressBar } from './components/indeterminate-progress-bar/index.tsx';

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -43,6 +43,11 @@
 			"types": "./build/components/gravatar/index.d.ts",
 			"default": "./build/components/gravatar/index.js"
 		},
+		"./jetpack-admin-notices": {
+			"jetpack:src": "./components/jetpack-admin-notices/index.tsx",
+			"types": "./build/components/jetpack-admin-notices/index.d.ts",
+			"default": "./build/components/jetpack-admin-notices/index.js"
+		},
 		"./jetpack-footer": {
 			"jetpack:src": "./components/jetpack-footer/index.tsx",
 			"types": "./build/components/jetpack-footer/index.d.ts",

--- a/projects/packages/activity-log/changelog/add-jitm-container-shared-component
+++ b/projects/packages/activity-log/changelog/add-jitm-container-shared-component
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Render JITMs inside the Activity Log content column via JetpackAdminNotices.

--- a/projects/packages/activity-log/src/js/components/ActivityLog/index.tsx
+++ b/projects/packages/activity-log/src/js/components/ActivityLog/index.tsx
@@ -6,7 +6,7 @@
  * column isn't linked, and the "Manage backup" row action is stubbed
  * until #48236 lands.
  */
-import { AdminPage } from '@automattic/jetpack-components';
+import { AdminPage, JetpackAdminNotices } from '@automattic/jetpack-components';
 import {
 	ConnectionError,
 	useConnectionErrorNotice,
@@ -555,6 +555,7 @@ export default function ActivityLog() {
 				 * overrides needed.
 				 */ }
 				<div className="jp-activity-log__inner">
+					<JetpackAdminNotices />
 					{ showConnectionError ? (
 						<ConnectionError
 							// `<ConnectionError>` re-runs `useConnectionErrorNotice`

--- a/projects/packages/forms/changelog/add-jitm-container-shared-component
+++ b/projects/packages/forms/changelog/add-jitm-container-shared-component
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Render JITMs in the Forms dashboard via the shared JetpackAdminNotices component.

--- a/projects/packages/forms/src/dashboard/components/layout/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/layout/index.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import jetpackAnalytics from '@automattic/jetpack-analytics';
+import { JetpackAdminNotices } from '@automattic/jetpack-components';
 import { useViewportMatch } from '@wordpress/compose';
 import { useEffect } from '@wordpress/element';
 import { Outlet, useLocation } from 'react-router';
@@ -46,6 +47,7 @@ const Layout = () => {
 	return (
 		<div className="jp-forms-layout">
 			<div className="jp-forms-layout__content">
+				<JetpackAdminNotices />
 				{ ! isLoadingConfig && <Outlet /> }
 				{ isIntegrationsOpen && showDashboardIntegrations && <Integrations /> }
 			</div>

--- a/projects/packages/forms/src/dashboard/components/layout/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/layout/index.tsx
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import jetpackAnalytics from '@automattic/jetpack-analytics';
-import { JetpackAdminNotices } from '@automattic/jetpack-components';
+import JetpackAdminNotices from '@automattic/jetpack-components/jetpack-admin-notices';
 import { useViewportMatch } from '@wordpress/compose';
 import { useEffect } from '@wordpress/element';
 import { Outlet, useLocation } from 'react-router';

--- a/projects/packages/jitm/changelog/add-jitm-container-shared-component
+++ b/projects/packages/jitm/changelog/add-jitm-container-shared-component
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add placement styling for the shared .jetpack-jitm-card JITM container.

--- a/projects/packages/jitm/src/css/jetpack-admin-jitm.scss
+++ b/projects/packages/jitm/src/css/jetpack-admin-jitm.scss
@@ -188,8 +188,9 @@ $jp-gray-20:             #a7aaad;
 }
 
 // Shared container rendered by the JetpackAdminNotices component.
+// The content column is already sized, so no extra margin is needed.
 .jetpack-jitm-card .jitm-card {
-	margin: 0 0 1.5rem; // full width in the column, bottom spacing, no top gap
+	margin: 0;
 }
 
 // if JITM appears directly below WordPress "help" menu adjust margins

--- a/projects/packages/jitm/src/css/jetpack-admin-jitm.scss
+++ b/projects/packages/jitm/src/css/jetpack-admin-jitm.scss
@@ -187,6 +187,11 @@ $jp-gray-20:             #a7aaad;
 	}
 }
 
+// Shared container rendered by the JetpackAdminNotices component.
+.jetpack-jitm-card .jitm-card {
+	margin: 0 0 1.5rem; // full width in the column, bottom spacing, no top gap
+}
+
 // if JITM appears directly below WordPress "help" menu adjust margins
 #screen-meta-links + .jitm-card {
 	margin: rem.convert(40px) 1.5385em 0 auto;

--- a/projects/packages/jitm/src/css/jetpack-admin-jitm.scss
+++ b/projects/packages/jitm/src/css/jetpack-admin-jitm.scss
@@ -187,10 +187,11 @@ $jp-gray-20:             #a7aaad;
 	}
 }
 
-// Shared container rendered by the JetpackAdminNotices component.
-// The content column is already sized, so no extra margin is needed.
-.jetpack-jitm-card .jitm-card {
-	margin: 0;
+// Shared container (JetpackAdminNotices) and the Social container: the content
+// column is already sized, so render full width with only a bottom gap.
+.jetpack-jitm-card .jitm-card,
+.jetpack-social-jitm-card .jitm-card {
+	margin: 0 0 1.5rem;
 }
 
 // if JITM appears directly below WordPress "help" menu adjust margins

--- a/projects/packages/search/changelog/add-jitm-container-shared-component
+++ b/projects/packages/search/changelog/add-jitm-container-shared-component
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Render JITMs via the shared JetpackAdminNotices component (in-column).

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.jsx
@@ -1,4 +1,9 @@
-import { AdminPage, Button, getProductCheckoutUrl } from '@automattic/jetpack-components';
+import {
+	AdminPage,
+	Button,
+	getProductCheckoutUrl,
+	JetpackAdminNotices,
+} from '@automattic/jetpack-components';
 import { useConnectionErrorNotice, ConnectionError } from '@automattic/jetpack-connection';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
@@ -339,10 +344,7 @@ export default function DashboardPage( { isLoading = false } ) {
 						<div className="jp-search-dashboard-top jp-search-dashboard-wrap">
 							{ /* Always in the DOM so JITM JS finds it immediately (Path A). */ }
 							<div className="jp-search-dashboard-row">
-								<div
-									id="jp-admin-notices"
-									className="jetpack-search-jitm-card sm-col-span-4 md-col-span-8 lg-col-span-12"
-								/>
+								<JetpackAdminNotices className="sm-col-span-4 md-col-span-8 lg-col-span-12" />
 							</div>
 							{ isPageLoading && <Loading /> }
 							{ ! isPageLoading && (

--- a/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
+++ b/projects/packages/search/src/dashboard/components/pages/dashboard-page.scss
@@ -85,14 +85,6 @@
 	}
 }
 
-.jetpack-search-jitm-card {
-
-	.jitm-card {
-		margin-right: 0;
-		margin-bottom: 0;
-	}
-}
-
 .jp-search-additional-settings__heading {
 	margin: var(--wpds-dimension-padding-3xl) 0 0;
 	font-size: var(--wpds-typography-font-size-xl);

--- a/projects/packages/videopress/changelog/add-jitm-container-shared-component
+++ b/projects/packages/videopress/changelog/add-jitm-container-shared-component
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Render JITMs via the shared JetpackAdminNotices component (in-column).

--- a/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/index.tsx
@@ -9,6 +9,7 @@ import {
 	Container,
 	Button,
 	Col,
+	JetpackAdminNotices,
 } from '@automattic/jetpack-components';
 import {
 	useProductCheckoutWorkflow,
@@ -110,10 +111,7 @@ const Admin = () => {
 						<AdminSectionHero>
 							<Container horizontalSpacing={ 0 }>
 								<Col>
-									<div
-										id="jp-admin-notices"
-										className={ styles[ 'jetpack-videopress-jitm-card' ] }
-									/>
+									<JetpackAdminNotices />
 								</Col>
 							</Container>
 

--- a/projects/packages/videopress/src/client/admin/components/admin-page/styles.module.scss
+++ b/projects/packages/videopress/src/client/admin/components/admin-page/styles.module.scss
@@ -117,14 +117,3 @@
 		}
 	}
 }
-
-.jetpack-videopress-jitm-card {
-
-	:global {
-
-		.jitm-card {
-			margin-right: 0;
-			margin-bottom: 0;
-		}
-	}
-}

--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -4,7 +4,7 @@
  * Manages the view stack (hub → read | write | setup) and owns the MCP settings state.
  */
 
-import { AdminPage } from '@automattic/jetpack-components';
+import { AdminPage, JetpackAdminNotices } from '@automattic/jetpack-components';
 import { Spinner } from '@wordpress/components';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -130,6 +130,8 @@ export default function App() {
 			apiNonce={ apiNonce }
 		>
 			<div className="jetpack-ai-admin__content">
+				<JetpackAdminNotices />
+
 				{ isLoading && (
 					<div className="jetpack-ai-admin__loading">
 						<Spinner />

--- a/projects/plugins/jetpack/changelog/add-jitm-container-shared-component
+++ b/projects/plugins/jetpack/changelog/add-jitm-container-shared-component
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI dashboard: render JITMs inside the content column via JetpackAdminNotices.


### PR DESCRIPTION
## Proposed changes

JITMs render inconsistently across Jetpack dashboards: the shared jitm JS drops the JITM card into `#jp-admin-notices` **if that element exists**, otherwise it floats wherever the hidden trigger landed. Boost, Social, and My Jetpack render that container so their JITM sits inside the app column; several other dashboards don't, so the card floats out of place.

This introduces a shared component and brings several dashboards to the in-column pattern:

* **New `JetpackAdminNotices` component** in `@automattic/jetpack-components` — renders the single `#jp-admin-notices` JITM mount point (`class="jetpack-jitm-card"`, `aria-live="polite"`, optional appended `className`). Presentational and JITM-only; replaces the ad-hoc per-plugin `<div id="jp-admin-notices" class="…-jitm-card">` copies going forward.
* **Global placement rule** in the `jetpack-jitm` package SCSS: `.jetpack-jitm-card .jitm-card, .jetpack-social-jitm-card .jitm-card { margin: 0 0 1.5rem; }` — full width in the app column with a bottom gap (the `.jitm-card` is injected by vanilla JS, so its placement must be a global rule, not a CSS module). Also applied to the existing **Social** container so its banner is full-width.
* **AI dashboard** (`_inc/client/ai/main.jsx`) and **Activity Log** (`activity-log` package) now render `<JetpackAdminNotices />` at the top of their content, so their JITMs appear in-column instead of floating.
* **VideoPress, Search, and Forms** also render `<JetpackAdminNotices />`:
  * **VideoPress & Search** previously had their own ad-hoc `#jp-admin-notices` divs (`jetpack-videopress-jitm-card` / `jetpack-search-jitm-card`); those are **consolidated** into the shared component and the now-dead per-plugin CSS rules removed. Their container lives in the licensed **dashboard** views (VideoPress's non-pricing branch; Search's Overview tab), so in-column rendering applies on paid/dashboard states — this couldn't be visually verified on the free JN test site (which shows their pricing/upsell views). Extending the container to the upsell/pricing/connection view-states is a follow-up.
  * **Forms** had no container; one is added at the top of its dashboard layout. Forms imports the component via the `@automattic/jetpack-components/jetpack-admin-notices` **subpath export** (added here) to keep its esbuild bundle small — matching how Forms imports other jetpack-components. Not live-verified (its dashboard build has unrelated worktree-only dependency gaps); it builds in CI.

Out of scope (follow-ups): **Protect**, and migrating the remaining **My Jetpack / Boost** divs to the shared component. Note: on a **standalone** Search-only or VideoPress-only install (no main Jetpack plugin) the jitm package isn't configured, so the container renders empty there — unchanged from before. There's also a pre-existing render race (the React container can mount after the JITM fetch resolves, leaving the card floating occasionally); not addressed here.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On a Jetpack-connected site, inject a test JITM (or use a real one) so a JITM is available.
2. Visit **Jetpack → AI** (`admin.php?page=jetpack-ai`) and **Jetpack → Activity Log** (`admin.php?page=jetpack-activity-log`).
3. Confirm the JITM banner now renders **inside the page content column** (not floating at the top-right / outside the app). In devtools, the `.jitm-card` should be a child of `#jp-admin-notices` (`class="jetpack-jitm-card"`), with `margin: 0 0 1.5rem`.
4. Regression check: **Social** and **My Jetpack** JITMs still render in-column as before (unchanged).

## Screenshots

Captured on a live Jurassic Ninja site (test JITM injected). The `.jitm-card` now renders as a child of `#jp-admin-notices` (`class="jetpack-jitm-card"`, `margin: 0 0 1.5rem`) inside the app column, instead of floating in the WP admin-notices strip.

### AI (`admin.php?page=jetpack-ai`)

| Before (floating) | After (in-column) |
|---|---|
| ![before-ai](https://github.com/Automattic/jetpack/raw/screenshots/add/jitm-container-shared-component/before-ai.png) | ![after-ai](https://github.com/Automattic/jetpack/raw/screenshots/add/jitm-container-shared-component/after-ai.png) |

### Activity Log (`admin.php?page=jetpack-activity-log`)

| Before (floating) | After (in-column) |
|---|---|
| ![before-al](https://github.com/Automattic/jetpack/raw/screenshots/add/jitm-container-shared-component/before-activity-log.png) | ![after-al](https://github.com/Automattic/jetpack/raw/screenshots/add/jitm-container-shared-component/after-activity-log.png) |

### Social (`admin.php?page=jetpack-social`) — existing container, now full-width

| Before (narrow, wraps) | After (full-width) |
|---|---|
| ![before-social](https://github.com/Automattic/jetpack/raw/screenshots/add/jitm-container-shared-component/before-social.png) | ![after-social](https://github.com/Automattic/jetpack/raw/screenshots/add/jitm-container-shared-component/after-social.png) |





