### PR TITLE
fix: crop slideshow images to a square grid in email

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-slideshow-email-square-crop
+++ b/projects/plugins/jetpack/changelog/fix-slideshow-email-square-crop
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Slideshow: crop images to a uniform square grid when rendering in email, so the gallery aspect-ratio crop fix also applies to slideshows instead of leaving mismatched image heights.

--- a/projects/plugins/jetpack/extensions/blocks/slideshow/render.php
+++ b/projects/plugins/jetpack/extensions/blocks/slideshow/render.php
@@ -115,12 +115,19 @@ function render_email_implementation( $block_content, array $parsed_block, $rend
 	// The renderer uses $block_content parameter to extract gallery-level captions
 	$block_content_html = '<figure class="wp-block-gallery has-nested-images columns-default is-cropped"><ul class="blocks-gallery-grid"></ul></figure>';
 
-	// Create a mock parsed block that WooCommerce's gallery renderer can handle
-	// The renderer uses columns from attrs (defaults to 3, but 2 works better for email)
+	// Create a mock parsed block that WooCommerce's gallery renderer can handle.
+	// columns: the renderer defaults to 3, but 2 reads better in a narrow email column.
+	// aspectRatio: a slideshow has no authored aspect ratio (only a sizeSlug), so email has
+	// nothing to inherit and images would otherwise render at their natural, mismatched heights.
+	// Passing a square ratio engages the gallery renderer's crop path (WooCommerce's
+	// woocommerce_email_editor_gallery_cropped_image_url filter, served via Photon on
+	// WordPress.com), giving a uniform grid. 1:1 is the floor of the live slideshow container
+	// clamp -- max( min( --aspect-ratio, 16/9 ), 1 ) -- and the tidiest fit for two columns.
 	$mock_parsed_block = array(
 		'innerBlocks' => $inner_blocks,
 		'attrs'       => array(
-			'columns' => 2,
+			'columns'     => 2,
+			'aspectRatio' => '1',
 		),
 	);
 

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Slideshow_Block_Email_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Slideshow_Block_Email_Test.php
@@ -245,6 +245,29 @@ class Slideshow_Block_Email_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test render_email hands the gallery renderer a square (1:1) aspect ratio.
+	 *
+	 * A slideshow carries no authored aspect ratio, so without this the gallery
+	 * renderer's crop path never engages and images render at mismatched natural
+	 * heights. Passing aspectRatio "1" is what makes the email grid uniform.
+	 */
+	public function test_render_email_sets_square_aspect_ratio() {
+		Mock_WooCommerce_Gallery_Renderer::$last_parsed_block = null;
+
+		$parsed_block = $this->create_parsed_block_with_images();
+		$mock_context = $this->create_rendering_context_mock();
+		\Automattic\Jetpack\Extensions\Slideshow\render_email( '', $parsed_block, $mock_context );
+
+		$captured = Mock_WooCommerce_Gallery_Renderer::$last_parsed_block;
+
+		$this->assertIsArray( $captured, 'Gallery renderer should have received a parsed block.' );
+		$this->assertArrayHasKey( 'attrs', $captured );
+		$this->assertArrayHasKey( 'aspectRatio', $captured['attrs'], 'Mock gallery must request an aspect ratio so the crop path engages.' );
+		$this->assertSame( '1', $captured['attrs']['aspectRatio'], 'Slideshow email grid should crop to a 1:1 square.' );
+		$this->assertSame( 2, $captured['attrs']['columns'], 'Slideshow email grid should keep the two-column layout.' );
+	}
+
+	/**
 	 * Test render_email with missing attrs.
 	 */
 	public function test_render_email_with_missing_attrs() {

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/mocks/class-mock-woocommerce-gallery-renderer.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/mocks/class-mock-woocommerce-gallery-renderer.php
@@ -12,6 +12,14 @@ if ( ! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Rend
 	 */
 	class Mock_WooCommerce_Gallery_Renderer {
 		/**
+		 * The most recent parsed block handed to render(), captured so tests can
+		 * assert what the caller passed to the gallery renderer (e.g. aspectRatio).
+		 *
+		 * @var array|null
+		 */
+		public static $last_parsed_block = null;
+
+		/**
 		 * Mock render method
 		 *
 		 * @param string $block_content The block content.
@@ -20,6 +28,8 @@ if ( ! class_exists( '\Automattic\WooCommerce\EmailEditor\Integrations\Core\Rend
 		 * @return string
 		 */
 		public function render( $block_content, $parsed_block, $rendering_context ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			self::$last_parsed_block = $parsed_block;
+
 			$inner_blocks = $parsed_block['innerBlocks'] ?? array();
 			$attributes   = $parsed_block['attrs'] ?? array();
 			$columns      = $attributes['columns'] ?? 3;


### PR DESCRIPTION
Fixes NL-741

## Proposed changes

The slideshow block can't run its Swiper carousel in email, so it degrades by building a mock `core/gallery` and handing it to WooCommerce's email gallery renderer. That mock only set `columns => 2`.

The gallery renderer's aspect-ratio crop path (added in woocommerce/woocommerce#66570) only engages when an `aspectRatio` attribute is present — per-image, falling back to gallery-level. A slideshow carries no authored aspect ratio (only a `sizeSlug`), so nothing was inherited and the grid images rendered at their **natural, mismatched heights**.

This passes a gallery-level `aspectRatio => '1'` on the mock gallery so the crop path engages. On WordPress.com the `woocommerce_email_editor_gallery_cropped_image_url` filter serves Photon-cropped square URLs; elsewhere it falls back to inline `aspect-ratio` + `object-fit: cover`. Either way the result is a uniform 2-column square grid.

Why 1:1: it's the floor of the live slideshow container's own clamp — `max( min( --aspect-ratio, 16/9 ), 1 )` — and the tidiest fit for a narrow two-column email layout.

Notes on the sibling concerns in the issue:
- **Web-only attrs (`srcset`/`sizes`/`loading`)**: not applicable to this path — the slideshow builds its own minimal `<img src alt class>`, so those attributes are never emitted.
- **Hardcoded `columns => 2`**: left as-is; it's a reasonable email default, not a bug.

## Related product discussion/links

* NL-741

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Create a post with a Jetpack Slideshow block containing several images of differing aspect ratios (e.g. a portrait mixed with landscapes).
* Send/preview it as a subscription email (WooCommerce email editor path on WordPress.com).
* **Before:** the slideshow degrades to a 2-column grid where cells have mismatched heights (images at natural aspect ratio).
* **After:** all cells are uniform 1:1 squares; on WordPress.com the image URLs are Photon-cropped (`?resize=W,H&crop=1`).
* Automated: `jetpack docker --type tests phpunit jetpack -- .../tests/php/extensions/blocks/Slideshow_Block_Email_Test.php` — 12 tests pass, including a new `test_render_email_sets_square_aspect_ratio` that asserts the mock gallery is handed `aspectRatio => '1'` and `columns => 2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)