### PR TITLE
WAF: Preserve approved login attempts during math fallback

### DIFF
--- a/projects/packages/waf/changelog/fix-protect-math-login-handoff
+++ b/projects/packages/waf/changelog/fix-protect-math-login-handoff
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Brute Force Protection: Preserve an approved login attempt when protection status changes during submission.

--- a/projects/packages/waf/src/brute-force-protection/class-login-attempt-token.php
+++ b/projects/packages/waf/src/brute-force-protection/class-login-attempt-token.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * Short-lived authorization for a login attempt that Protect already approved.
+ *
+ * @package automattic/jetpack-waf
+ */
+
+namespace Automattic\Jetpack\Waf\Brute_Force_Protection;
+
+/**
+ * Manages a short-lived, single-use login attempt token.
+ */
+class Brute_Force_Protection_Login_Attempt_Token {
+	/**
+	 * Login form field name.
+	 */
+	const FIELD_NAME = 'jetpack_protect_login_attempt';
+
+	/**
+	 * Token lifetime in seconds.
+	 */
+	const EXPIRATION = 600;
+
+	/**
+	 * Transient prefix. The full name stays within WordPress's 45-character limit.
+	 */
+	const TRANSIENT_PREFIX = 'jpp_attempt_';
+
+	/**
+	 * Brute Force Protection instance.
+	 *
+	 * @var Brute_Force_Protection
+	 */
+	private $protection;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Brute_Force_Protection $protection Brute Force Protection instance.
+	 */
+	public function __construct( Brute_Force_Protection $protection ) {
+		$this->protection = $protection;
+	}
+
+	/**
+	 * Render a token for a login attempt that Protect already approved.
+	 */
+	public function render_field() {
+		$token = str_replace( '-', '', wp_generate_uuid4() );
+
+		if ( ! $this->protection->set_transient( $this->transient_name(), hash( 'sha256', $token ), self::EXPIRATION ) ) {
+			return;
+		}
+
+		printf(
+			'<input type="hidden" name="%1$s" value="%2$s" />',
+			esc_attr( self::FIELD_NAME ),
+			esc_attr( $token )
+		);
+	}
+
+	/**
+	 * Consume a submitted token.
+	 *
+	 * @return bool Whether a valid token was consumed.
+	 */
+	public function consume() {
+		if ( ! isset( $_POST[ self::FIELD_NAME ] ) || ! is_string( $_POST[ self::FIELD_NAME ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- The random, single-use token authorizes this request.
+			return false;
+		}
+
+		$token = sanitize_key( wp_unslash( $_POST[ self::FIELD_NAME ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- The random, single-use token authorizes this request.
+		if ( 1 !== preg_match( '/\A[a-f0-9]{32}\z/D', $token ) ) {
+			return false;
+		}
+
+		$transient_name = $this->transient_name();
+		$expected_hash  = $this->protection->get_transient( $transient_name );
+
+		if ( ! is_string( $expected_hash ) || ! hash_equals( $expected_hash, hash( 'sha256', $token ) ) ) {
+			return false;
+		}
+
+		return $this->protection->delete_transient( $transient_name );
+	}
+
+	/**
+	 * Get the transient name for the current Protect client fingerprint.
+	 *
+	 * @return string
+	 */
+	private function transient_name() {
+		return self::TRANSIENT_PREFIX . md5( $this->protection->get_transient_name() );
+	}
+}

--- a/projects/packages/waf/src/brute-force-protection/class-login-attempt-token.php
+++ b/projects/packages/waf/src/brute-force-protection/class-login-attempt-token.php
@@ -107,9 +107,8 @@ class Brute_Force_Protection_Login_Attempt_Token {
 		}
 
 		if (
-			! $this->protection->add_transient(
+			! $this->protection->add_login_attempt_claim(
 				self::CLAIM_TRANSIENT_PREFIX . substr( hash( 'sha256', $token ), 0, 32 ),
-				1,
 				self::EXPIRATION
 			)
 		) {

--- a/projects/packages/waf/src/brute-force-protection/class-login-attempt-token.php
+++ b/projects/packages/waf/src/brute-force-protection/class-login-attempt-token.php
@@ -7,6 +7,8 @@
 
 namespace Automattic\Jetpack\Waf\Brute_Force_Protection;
 
+use Automattic\Jetpack\IP\Utils as IP_Utils;
+
 /**
  * Manages a short-lived, single-use login attempt token.
  */
@@ -25,6 +27,11 @@ class Brute_Force_Protection_Login_Attempt_Token {
 	 * Transient prefix. The full name stays within WordPress's 45-character limit.
 	 */
 	const TRANSIENT_PREFIX = 'jpp_attempt_';
+
+	/**
+	 * Prefix for the atomic, per-token claim.
+	 */
+	const CLAIM_TRANSIENT_PREFIX = 'jpp_claim_';
 
 	/**
 	 * Brute Force Protection instance.
@@ -46,9 +53,23 @@ class Brute_Force_Protection_Login_Attempt_Token {
 	 * Render a token for a login attempt that Protect already approved.
 	 */
 	public function render_field() {
-		$token = str_replace( '-', '', wp_generate_uuid4() );
+		$transient_name = $this->transient_name();
+		if ( ! $transient_name ) {
+			return;
+		}
 
-		if ( ! $this->protection->set_transient( $this->transient_name(), hash( 'sha256', $token ), self::EXPIRATION ) ) {
+		try {
+			$token = bin2hex( random_bytes( 16 ) );
+		} catch ( \Exception $error ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- Fail closed by omitting the token.
+			return;
+		}
+
+		$token_data = array(
+			'token_hash'       => hash( 'sha256', $token ),
+			'fingerprint_hash' => $this->fingerprint_hash(),
+		);
+
+		if ( ! $this->protection->set_transient( $transient_name, $token_data, self::EXPIRATION ) ) {
 			return;
 		}
 
@@ -69,27 +90,69 @@ class Brute_Force_Protection_Login_Attempt_Token {
 			return false;
 		}
 
-		$token = sanitize_key( wp_unslash( $_POST[ self::FIELD_NAME ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing -- The random, single-use token authorizes this request.
+		$token = wp_unslash( $_POST[ self::FIELD_NAME ] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Exact validation below rejects altered input.
 		if ( 1 !== preg_match( '/\A[a-f0-9]{32}\z/D', $token ) ) {
 			return false;
 		}
 
 		$transient_name = $this->transient_name();
-		$expected_hash  = $this->protection->get_transient( $transient_name );
-
-		if ( ! is_string( $expected_hash ) || ! hash_equals( $expected_hash, hash( 'sha256', $token ) ) ) {
+		if ( ! $transient_name ) {
 			return false;
 		}
 
-		return $this->protection->delete_transient( $transient_name );
+		$token_data = $this->protection->get_transient( $transient_name );
+
+		if ( ! $this->token_data_matches( $token_data, $token ) ) {
+			return false;
+		}
+
+		if (
+			! $this->protection->add_transient(
+				self::CLAIM_TRANSIENT_PREFIX . substr( hash( 'sha256', $token ), 0, 32 ),
+				1,
+				self::EXPIRATION
+			)
+		) {
+			return false;
+		}
+
+		return $this->token_data_matches( $this->protection->get_transient( $transient_name ), $token );
 	}
 
 	/**
-	 * Get the transient name for the current Protect client fingerprint.
+	 * Get the IP-keyed slot for the current outstanding login token.
+	 *
+	 * @return string|false
+	 */
+	private function transient_name() {
+		$ip = IP_Utils::get_ip();
+
+		return $ip ? self::TRANSIENT_PREFIX . md5( $ip ) : false;
+	}
+
+	/**
+	 * Hash the complete Protect fingerprint for validation inside the IP-keyed slot.
 	 *
 	 * @return string
 	 */
-	private function transient_name() {
-		return self::TRANSIENT_PREFIX . md5( $this->protection->get_transient_name() );
+	private function fingerprint_hash() {
+		return hash( 'sha256', $this->protection->get_transient_name() );
+	}
+
+	/**
+	 * Check token data against the submitted token and current Protect fingerprint.
+	 *
+	 * @param mixed  $token_data Stored token data.
+	 * @param string $token Submitted token.
+	 * @return bool
+	 */
+	private function token_data_matches( $token_data, $token ) {
+		return is_array( $token_data )
+			&& isset( $token_data['token_hash'] )
+			&& isset( $token_data['fingerprint_hash'] )
+			&& is_string( $token_data['token_hash'] )
+			&& is_string( $token_data['fingerprint_hash'] )
+			&& hash_equals( $token_data['token_hash'], hash( 'sha256', $token ) )
+			&& hash_equals( $token_data['fingerprint_hash'], $this->fingerprint_hash() );
 	}
 }

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -1142,47 +1142,45 @@ class Brute_Force_Protection {
 	}
 
 	/**
-	 * Atomically add a transient only when it does not already exist.
+	 * Atomically add a durable claim for a login attempt token.
 	 *
-	 * @param string $transient Transient name. Expected to not be SQL-escaped. Must be
-	 *                          45 characters or fewer in length.
-	 * @param mixed  $value Value to store. Must be serializable if non-scalar.
+	 * The claim intentionally remains in the options table when an external object
+	 * cache is active. Its unique option name is the source of truth for single use,
+	 * so selective cache eviction cannot make an approved token reusable.
+	 *
+	 * @param string $claim_name Claim name. Expected to not be SQL-escaped. Must be
+	 *                           45 characters or fewer in length.
 	 * @param int    $expiration Time until expiration in seconds.
 	 *
-	 * @return bool Whether the transient was added.
+	 * @return bool Whether the claim was added.
 	 */
-	public function add_transient( $transient, $value, $expiration ) {
+	public function add_login_attempt_claim( $claim_name, $expiration ) {
 		if ( is_multisite() && ! is_main_site() ) {
 			switch_to_blog( $this->get_main_blog_id() );
-			$return = $this->add_transient_for_current_site( $transient, $value, $expiration );
+			$return = $this->add_login_attempt_claim_for_current_site( $claim_name, $expiration );
 			restore_current_blog();
 
 			return $return;
 		}
 
-		return $this->add_transient_for_current_site( $transient, $value, $expiration );
+		return $this->add_login_attempt_claim_for_current_site( $claim_name, $expiration );
 	}
 
 	/**
-	 * Atomically add a transient on the current site.
+	 * Atomically add a durable login attempt claim on the current site.
 	 *
-	 * @param string $transient Transient name.
-	 * @param mixed  $value Value to store.
+	 * @param string $claim_name Claim name.
 	 * @param int    $expiration Time until expiration in seconds.
 	 *
-	 * @return bool Whether the transient was added.
+	 * @return bool Whether the claim was added.
 	 */
-	private function add_transient_for_current_site( $transient, $value, $expiration ) {
-		if ( wp_using_ext_object_cache() ) {
-			return wp_cache_add( $transient, $value, 'transient', $expiration );
-		}
-
-		$option_name = '_transient_' . $transient;
-		if ( ! add_option( $option_name, $value, '', false ) ) {
+	private function add_login_attempt_claim_for_current_site( $claim_name, $expiration ) {
+		$option_name = '_transient_' . $claim_name;
+		if ( ! add_option( $option_name, 1, '', false ) ) {
 			return false;
 		}
 
-		$timeout_name = '_transient_timeout_' . $transient;
+		$timeout_name = '_transient_timeout_' . $claim_name;
 		if ( $expiration && ! add_option( $timeout_name, time() + $expiration, '', false ) ) {
 			delete_option( $option_name );
 			delete_option( $timeout_name );

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -106,7 +106,7 @@ class Brute_Force_Protection {
 	 *
 	 * @var int
 	 */
-	private $block_login_with_math;
+	private $block_login_with_math = 0;
 
 	/**
 	 * Singleton implementation
@@ -142,6 +142,7 @@ class Brute_Force_Protection {
 
 		// This is a backup in case $pagenow fails for some reason.
 		add_action( 'login_form', array( $this, 'check_login_ability' ), 1 );
+		add_action( 'login_form', array( $this, 'render_login_attempt_token' ), 2 );
 
 		// Runs a script every day to clean up expired transients so they don't
 		// clog up our users' databases.
@@ -606,19 +607,31 @@ class Brute_Force_Protection {
 	 * @return string $user
 	 */
 	public function check_preauth( $user = 'Not Used By Protect', $username = 'Not Used By Protect', $password = 'Not Used By Protect' ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-		$allow_login = $this->check_login_ability( true );
-		$use_math    = $this->get_transient( 'brute_use_math' );
+		$login_attempt_allowed = ( new Brute_Force_Protection_Login_Attempt_Token( $this ) )->consume();
+		$allow_login           = $this->check_login_ability( true );
+		$use_math              = $this->get_transient( 'brute_use_math' );
 
-		if ( ! $allow_login ) {
+		if ( ! $allow_login && ! $login_attempt_allowed ) {
 			$this->block_with_math();
 		}
 
-		if ( ( 1 == $use_math || 1 == $this->block_login_with_math ) && isset( $_POST['log'] ) ) { // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual, WordPress.Security.NonceVerification.Missing -- POST request just determines if we use math authentication.
+		if ( ( 1 === $use_math || 1 === $this->block_login_with_math ) && isset( $_POST['log'] ) && ! $login_attempt_allowed ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- POST request just determines if we use math authentication.
 
 			Brute_Force_Protection_Math_Authenticate::math_authenticate();
 		}
 
 		return $user;
+	}
+
+	/**
+	 * Add a token to a login form that Protect has already approved.
+	 */
+	public function render_login_attempt_token() {
+		if ( 1 === $this->block_login_with_math || $this->get_transient( 'brute_use_math' ) ) {
+			return;
+		}
+
+		( new Brute_Force_Protection_Login_Attempt_Token( $this ) )->render_field();
 	}
 
 	/**

--- a/projects/packages/waf/src/class-brute-force-protection.php
+++ b/projects/packages/waf/src/class-brute-force-protection.php
@@ -102,7 +102,7 @@ class Brute_Force_Protection {
 	public $last_response;
 
 	/**
-	 * Block login with math, default is 1.
+	 * Block login with math, default is 0.
 	 *
 	 * @var int
 	 */
@@ -600,22 +600,25 @@ class Brute_Force_Protection {
 	 *
 	 * If we are using our math fallback, authenticate via math-fallback.php
 	 *
-	 * @param string $user     - the user.
+	 * @param mixed  $user     - the current authentication result.
 	 * @param string $username - the username.
 	 * @param string $password - the password.
 	 *
-	 * @return string $user
+	 * @return mixed $user
 	 */
 	public function check_preauth( $user = 'Not Used By Protect', $username = 'Not Used By Protect', $password = 'Not Used By Protect' ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$login_attempt_allowed = ( new Brute_Force_Protection_Login_Attempt_Token( $this ) )->consume();
-		$allow_login           = $this->check_login_ability( true );
-		$use_math              = $this->get_transient( 'brute_use_math' );
+
+		// Always refresh Protect's decision so a hard block remains authoritative. The token only
+		// prevents a newly introduced soft/math fallback from replacing an in-flight credential POST.
+		$allow_login = $this->check_login_ability( true );
+		$use_math    = $this->get_transient( 'brute_use_math' );
 
 		if ( ! $allow_login && ! $login_attempt_allowed ) {
 			$this->block_with_math();
 		}
 
-		if ( ( 1 === $use_math || 1 === $this->block_login_with_math ) && isset( $_POST['log'] ) && ! $login_attempt_allowed ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- POST request just determines if we use math authentication.
+		if ( ( 1 === (int) $use_math || 1 === $this->block_login_with_math ) && isset( $_POST['log'] ) && ! $login_attempt_allowed ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing -- POST request just determines if we use math authentication.
 
 			Brute_Force_Protection_Math_Authenticate::math_authenticate();
 		}
@@ -1136,6 +1139,57 @@ class Brute_Force_Protection {
 		}
 
 		return set_transient( $transient, $value, $expiration );
+	}
+
+	/**
+	 * Atomically add a transient only when it does not already exist.
+	 *
+	 * @param string $transient Transient name. Expected to not be SQL-escaped. Must be
+	 *                          45 characters or fewer in length.
+	 * @param mixed  $value Value to store. Must be serializable if non-scalar.
+	 * @param int    $expiration Time until expiration in seconds.
+	 *
+	 * @return bool Whether the transient was added.
+	 */
+	public function add_transient( $transient, $value, $expiration ) {
+		if ( is_multisite() && ! is_main_site() ) {
+			switch_to_blog( $this->get_main_blog_id() );
+			$return = $this->add_transient_for_current_site( $transient, $value, $expiration );
+			restore_current_blog();
+
+			return $return;
+		}
+
+		return $this->add_transient_for_current_site( $transient, $value, $expiration );
+	}
+
+	/**
+	 * Atomically add a transient on the current site.
+	 *
+	 * @param string $transient Transient name.
+	 * @param mixed  $value Value to store.
+	 * @param int    $expiration Time until expiration in seconds.
+	 *
+	 * @return bool Whether the transient was added.
+	 */
+	private function add_transient_for_current_site( $transient, $value, $expiration ) {
+		if ( wp_using_ext_object_cache() ) {
+			return wp_cache_add( $transient, $value, 'transient', $expiration );
+		}
+
+		$option_name = '_transient_' . $transient;
+		if ( ! add_option( $option_name, $value, '', false ) ) {
+			return false;
+		}
+
+		$timeout_name = '_transient_timeout_' . $transient;
+		if ( $expiration && ! add_option( $timeout_name, time() + $expiration, '', false ) ) {
+			delete_option( $option_name );
+			delete_option( $timeout_name );
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/projects/packages/waf/tests/php/integration/BruteForceProtectionLoginAttemptTokenTest.php
+++ b/projects/packages/waf/tests/php/integration/BruteForceProtectionLoginAttemptTokenTest.php
@@ -23,6 +23,11 @@ class BruteForceProtectionLoginAttemptTokenTest extends WorDBless\BaseTestCase {
 	 */
 	public function tearDown(): void {
 		$_POST = array();
+		delete_transient( 'brute_use_math' );
+
+		foreach ( array( 'jpp_li_browser', 'jpp_li_renderer', 'jpp_li_preauth', 'jpp_li_replay', 'jpp_li_hard-block' ) as $fingerprint ) {
+			delete_transient( 'jpp_attempt_' . md5( $fingerprint ) );
+		}
 
 		parent::tearDown();
 	}
@@ -81,19 +86,153 @@ class BruteForceProtectionLoginAttemptTokenTest extends WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Verify that an approved login form receives a login attempt token.
+	 */
+	public function test_protection_renders_token_for_approved_login_form() {
+		$this->assertTrue( method_exists( Brute_Force_Protection::class, 'render_login_attempt_token' ) );
+		$protection = $this->protection( 'jpp_li_renderer' );
+
+		ob_start();
+		$protection->render_login_attempt_token();
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'name="' . self::FIELD_NAME . '"', $html );
+	}
+
+	/**
+	 * Verify that the token is rendered after the login form status checks.
+	 */
+	public function test_protection_registers_token_after_login_form_status_checks() {
+		$reflection  = new ReflectionClass( Brute_Force_Protection::class );
+		$protection  = $reflection->newInstanceWithoutConstructor();
+		$constructor = $reflection->getConstructor();
+		$constructor->invoke( $protection );
+
+		$this->assertSame( 2, has_action( 'login_form', array( $protection, 'render_login_attempt_token' ) ) );
+	}
+
+	/**
+	 * Verify that no approval token is issued once the math fallback is active.
+	 */
+	public function test_protection_does_not_render_token_while_math_fallback_is_active() {
+		$this->assertTrue( method_exists( Brute_Force_Protection::class, 'render_login_attempt_token' ) );
+		$protection = $this->protection( 'jpp_li_renderer' );
+		$protection->set_transient( 'brute_use_math', 1, 600 );
+
+		ob_start();
+		$protection->render_login_attempt_token();
+
+		$this->assertSame( '', ob_get_clean() );
+	}
+
+	/**
+	 * Verify that no approval token is issued once a soft block selects math.
+	 */
+	public function test_protection_does_not_render_token_after_soft_block() {
+		$this->assertTrue( method_exists( Brute_Force_Protection::class, 'render_login_attempt_token' ) );
+		$protection = $this->protection( 'jpp_li_renderer' );
+		$property   = new ReflectionProperty( Brute_Force_Protection::class, 'block_login_with_math' );
+		$property->setValue( $protection, 1 );
+
+		ob_start();
+		$protection->render_login_attempt_token();
+
+		$this->assertSame( '', ob_get_clean() );
+	}
+
+	/**
+	 * Verify that a previously approved request bypasses a newly selected math fallback.
+	 */
+	public function test_approved_attempt_continues_when_status_changes_during_submission() {
+		$protection = $this->preauth_protection( 'jpp_li_preauth', 1 );
+		$protection->expects( $this->never() )->method( 'block_with_math' );
+		$token                     = $this->render_token_for_protection( $protection );
+		$_POST[ self::FIELD_NAME ] = $token;
+		$_POST['log']              = 'example';
+
+		$this->assertSame( 'approved-user', $protection->check_preauth( 'approved-user' ) );
+	}
+
+	/**
+	 * Verify that replaying an approved request follows the existing fallback path.
+	 */
+	public function test_replayed_attempt_does_not_bypass_fallback() {
+		$protection = $this->preauth_protection( 'jpp_li_replay', 2 );
+		$protection->expects( $this->once() )->method( 'block_with_math' )->willReturn( false );
+		$token                     = $this->render_token_for_protection( $protection );
+		$_POST[ self::FIELD_NAME ] = $token;
+		$_POST['log']              = 'example';
+
+		$this->assertSame( 'approved-user', $protection->check_preauth( 'approved-user' ) );
+		$this->assertSame( 'approved-user', $protection->check_preauth( 'approved-user' ) );
+	}
+
+	/**
+	 * Verify that a token never skips the authoritative status check.
+	 */
+	public function test_approved_attempt_does_not_bypass_hard_block_check() {
+		$protection = $this->getMockBuilder( Brute_Force_Protection::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'check_login_ability', 'get_transient_name' ) )
+			->getMock();
+		$protection->method( 'get_transient_name' )->willReturn( 'jpp_li_hard-block' );
+		$protection->expects( $this->once() )
+			->method( 'check_login_ability' )
+			->with( true )
+			->willThrowException( new RuntimeException( 'hard block' ) );
+		$_POST[ self::FIELD_NAME ] = $this->render_token_for_protection( $protection );
+
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage( 'hard block' );
+
+		$protection->check_preauth( 'approved-user' );
+	}
+
+	/**
 	 * Create a token manager with a stable Protect client fingerprint.
 	 *
 	 * @param string $fingerprint Protect client fingerprint.
 	 * @return Brute_Force_Protection_Login_Attempt_Token
 	 */
 	private function token_manager( $fingerprint ) {
+		return new Brute_Force_Protection_Login_Attempt_Token( $this->protection( $fingerprint ) );
+	}
+
+	/**
+	 * Create a testable Brute Force Protection instance with a stable fingerprint.
+	 *
+	 * @param string $fingerprint Protect client fingerprint.
+	 * @return Brute_Force_Protection
+	 */
+	private function protection( $fingerprint ) {
 		$protection = $this->getMockBuilder( Brute_Force_Protection::class )
 			->disableOriginalConstructor()
 			->onlyMethods( array( 'get_transient_name' ) )
 			->getMock();
 		$protection->method( 'get_transient_name' )->willReturn( $fingerprint );
 
-		return new Brute_Force_Protection_Login_Attempt_Token( $protection );
+		return $protection;
+	}
+
+	/**
+	 * Create a testable protection instance whose status check selects math.
+	 *
+	 * @param string $fingerprint Protect client fingerprint.
+	 * @param int    $check_count Number of expected status checks.
+	 * @return Brute_Force_Protection
+	 */
+	private function preauth_protection( $fingerprint, $check_count ) {
+		$protection = $this->getMockBuilder( Brute_Force_Protection::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'block_with_math', 'check_login_ability', 'get_transient_name' ) )
+			->getMock();
+		$protection->method( 'get_transient_name' )->willReturn( $fingerprint );
+		$protection->expects( $this->exactly( $check_count ) )
+			->method( 'check_login_ability' )
+			->with( true )
+			->willReturn( false );
+
+		return $protection;
 	}
 
 	/**
@@ -103,10 +242,19 @@ class BruteForceProtectionLoginAttemptTokenTest extends WorDBless\BaseTestCase {
 	 * @return string
 	 */
 	private function render_token( $fingerprint ) {
-		$this->assertTrue( method_exists( Brute_Force_Protection_Login_Attempt_Token::class, 'render_field' ) );
+		return $this->render_token_for_protection( $this->protection( $fingerprint ) );
+	}
+
+	/**
+	 * Render and extract a login attempt token for a protection instance.
+	 *
+	 * @param Brute_Force_Protection $protection Brute Force Protection instance.
+	 * @return string
+	 */
+	private function render_token_for_protection( $protection ) {
 
 		ob_start();
-		$this->token_manager( $fingerprint )->render_field();
+		( new Brute_Force_Protection_Login_Attempt_Token( $protection ) )->render_field();
 		$html = ob_get_clean();
 
 		$this->assertSame( 1, preg_match( '/value="([a-f0-9]{32})"/', $html, $matches ) );

--- a/projects/packages/waf/tests/php/integration/BruteForceProtectionLoginAttemptTokenTest.php
+++ b/projects/packages/waf/tests/php/integration/BruteForceProtectionLoginAttemptTokenTest.php
@@ -163,8 +163,10 @@ class BruteForceProtectionLoginAttemptTokenTest extends WorDBless\BaseTestCase {
 		$_POST[ self::FIELD_NAME ] = $token;
 		$_POST['log']              = 'example';
 
-		$this->assertSame( 'approved-user', $protection->check_preauth( 'approved-user' ) );
-		$this->assertSame( 'approved-user', $protection->check_preauth( 'approved-user' ) );
+		$first_attempt  = $protection->check_preauth( 'approved-user' );
+		$replay_attempt = $protection->check_preauth( 'approved-user' );
+
+		$this->assertSame( array( 'approved-user', 'approved-user' ), array( $first_attempt, $replay_attempt ) );
 	}
 
 	/**
@@ -202,7 +204,7 @@ class BruteForceProtectionLoginAttemptTokenTest extends WorDBless\BaseTestCase {
 	 * Create a testable Brute Force Protection instance with a stable fingerprint.
 	 *
 	 * @param string $fingerprint Protect client fingerprint.
-	 * @return Brute_Force_Protection
+	 * @return Brute_Force_Protection|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	private function protection( $fingerprint ) {
 		$protection = $this->getMockBuilder( Brute_Force_Protection::class )
@@ -219,7 +221,7 @@ class BruteForceProtectionLoginAttemptTokenTest extends WorDBless\BaseTestCase {
 	 *
 	 * @param string $fingerprint Protect client fingerprint.
 	 * @param int    $check_count Number of expected status checks.
-	 * @return Brute_Force_Protection
+	 * @return Brute_Force_Protection|\PHPUnit\Framework\MockObject\MockObject
 	 */
 	private function preauth_protection( $fingerprint, $check_count ) {
 		$protection = $this->getMockBuilder( Brute_Force_Protection::class )

--- a/projects/packages/waf/tests/php/integration/BruteForceProtectionLoginAttemptTokenTest.php
+++ b/projects/packages/waf/tests/php/integration/BruteForceProtectionLoginAttemptTokenTest.php
@@ -15,38 +15,49 @@ use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 #[AllowMockObjectsWithoutExpectations /* getStubBuilder() (for partial stubs) doesn't exist until PHPUnit 12.5. */ ]
 class BruteForceProtectionLoginAttemptTokenTest extends WorDBless\BaseTestCase {
 	/**
-	 * Form field used by the login attempt token.
+	 * Tokens issued during the current test.
+	 *
+	 * @var string[]
 	 */
-	private const FIELD_NAME = 'jetpack_protect_login_attempt';
+	private $issued_tokens = array();
+
+	/**
+	 * Set up each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$_SERVER['REMOTE_ADDR'] = '203.0.113.10';
+		unset( $_SERVER['HTTP_X_FORWARDED_FOR'] );
+		delete_site_option( 'trusted_ip_header' );
+	}
+
 	/**
 	 * Clean up after each test.
 	 */
 	public function tearDown(): void {
 		$_POST = array();
+		unset( $_SERVER['REMOTE_ADDR'], $_SERVER['HTTP_X_FORWARDED_FOR'] );
+		remove_filter( 'wp_die_handler', array( $this, 'throw_on_wp_die' ) );
 		delete_transient( 'brute_use_math' );
+		delete_site_option( 'trusted_ip_header' );
 
-		foreach ( array( 'jpp_li_browser', 'jpp_li_renderer', 'jpp_li_preauth', 'jpp_li_replay', 'jpp_li_hard-block' ) as $fingerprint ) {
-			delete_transient( 'jpp_attempt_' . md5( $fingerprint ) );
+		delete_transient( 'jpp_attempt_' . md5( '203.0.113.10' ) );
+
+		foreach ( $this->issued_tokens as $token ) {
+			delete_transient( 'jpp_claim_' . substr( hash( 'sha256', $token ), 0, 32 ) );
 		}
+		$this->issued_tokens = array();
 
 		parent::tearDown();
-	}
-
-	/**
-	 * Verify that the login attempt token helper is available.
-	 */
-	public function test_login_attempt_token_helper_is_available() {
-		$this->assertTrue(
-			class_exists( 'Automattic\Jetpack\Waf\Brute_Force_Protection\Brute_Force_Protection_Login_Attempt_Token' )
-		);
 	}
 
 	/**
 	 * Verify that a valid token cannot be replayed.
 	 */
 	public function test_token_can_only_be_consumed_once() {
-		$token                     = $this->render_token( 'jpp_li_browser' );
-		$_POST[ self::FIELD_NAME ] = $token;
+		$token = $this->render_token( 'jpp_li_browser' );
+		$_POST[ Brute_Force_Protection_Login_Attempt_Token::FIELD_NAME ] = $token;
 
 		$this->assertTrue( $this->token_manager( 'jpp_li_browser' )->consume() );
 		$this->assertFalse( $this->token_manager( 'jpp_li_browser' )->consume() );
@@ -56,17 +67,30 @@ class BruteForceProtectionLoginAttemptTokenTest extends WorDBless\BaseTestCase {
 	 * Verify that a token cannot move between Protect client fingerprints.
 	 */
 	public function test_token_is_bound_to_the_client_fingerprint() {
-		$_POST[ self::FIELD_NAME ] = $this->render_token( 'jpp_li_browser-a' );
+		$_POST[ Brute_Force_Protection_Login_Attempt_Token::FIELD_NAME ] = $this->render_token( 'jpp_li_browser-a' );
 
 		$this->assertFalse( $this->token_manager( 'jpp_li_browser-b' )->consume() );
+	}
+
+	/**
+	 * Verify that malformed input is not normalized into a valid token.
+	 */
+	public function test_malformed_token_does_not_consume_the_valid_token() {
+		$token = $this->render_token( 'jpp_li_browser' );
+		$_POST[ Brute_Force_Protection_Login_Attempt_Token::FIELD_NAME ] = $token . '!!!';
+
+		$this->assertFalse( $this->token_manager( 'jpp_li_browser' )->consume() );
+
+		$_POST[ Brute_Force_Protection_Login_Attempt_Token::FIELD_NAME ] = $token;
+		$this->assertTrue( $this->token_manager( 'jpp_li_browser' )->consume() );
 	}
 
 	/**
 	 * Verify that a token without its transient is rejected.
 	 */
 	public function test_expired_token_is_rejected() {
-		$_POST[ self::FIELD_NAME ] = $this->render_token( 'jpp_li_browser' );
-		delete_transient( 'jpp_attempt_' . md5( 'jpp_li_browser' ) );
+		$_POST[ Brute_Force_Protection_Login_Attempt_Token::FIELD_NAME ] = $this->render_token( 'jpp_li_browser' );
+		delete_transient( 'jpp_attempt_' . md5( '203.0.113.10' ) );
 
 		$this->assertFalse( $this->token_manager( 'jpp_li_browser' )->consume() );
 	}
@@ -78,25 +102,90 @@ class BruteForceProtectionLoginAttemptTokenTest extends WorDBless\BaseTestCase {
 		$old_token = $this->render_token( 'jpp_li_browser' );
 		$new_token = $this->render_token( 'jpp_li_browser' );
 
-		$_POST[ self::FIELD_NAME ] = $old_token;
+		$_POST[ Brute_Force_Protection_Login_Attempt_Token::FIELD_NAME ] = $old_token;
 		$this->assertFalse( $this->token_manager( 'jpp_li_browser' )->consume() );
 
-		$_POST[ self::FIELD_NAME ] = $new_token;
+		$_POST[ Brute_Force_Protection_Login_Attempt_Token::FIELD_NAME ] = $new_token;
 		$this->assertTrue( $this->token_manager( 'jpp_li_browser' )->consume() );
+	}
+
+	/**
+	 * Verify that attacker-controlled proxy headers cannot create extra token slots.
+	 */
+	public function test_untrusted_proxy_headers_do_not_create_additional_token_slots() {
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '198.51.100.1';
+		$old_token                       = $this->render_token( 'jpp_li_spoof-a' );
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '198.51.100.2';
+		$new_token                       = $this->render_token( 'jpp_li_spoof-b' );
+
+		$_POST[ Brute_Force_Protection_Login_Attempt_Token::FIELD_NAME ] = $old_token;
+		$this->assertFalse( $this->token_manager( 'jpp_li_spoof-a' )->consume() );
+
+		$_POST[ Brute_Force_Protection_Login_Attempt_Token::FIELD_NAME ] = $new_token;
+		$this->assertTrue( $this->token_manager( 'jpp_li_spoof-b' )->consume() );
+	}
+
+	/**
+	 * Verify that an interleaved render cannot make an old token reusable or destroy the replacement.
+	 */
+	public function test_render_during_consume_preserves_single_use_and_the_replacement_token() {
+		$state                = array();
+		$replacement_token    = '';
+		$replacement_rendered = false;
+		$protection           = $this->getMockBuilder( Brute_Force_Protection::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'delete_transient', 'get_transient', 'get_transient_name', 'set_transient' ) )
+			->getMock();
+		$protection->method( 'get_transient_name' )->willReturn( 'jpp_li_interleaved' );
+		$protection->method( 'set_transient' )
+			->willReturnCallback(
+				static function ( $name, $value ) use ( &$state ) {
+					$state[ $name ] = $value;
+					return true;
+				}
+			);
+		$protection->method( 'get_transient' )
+			->willReturnCallback(
+				function ( $name ) use ( &$state, &$replacement_token, &$replacement_rendered, $protection ) {
+					$value = $state[ $name ] ?? false;
+
+					if ( 0 === strpos( $name, 'jpp_attempt_' ) && ! $replacement_rendered ) {
+						$replacement_rendered = true;
+						$replacement_token    = $this->render_token_for_protection( $protection );
+					}
+
+					return $value;
+				}
+			);
+		$protection->method( 'delete_transient' )
+			->willReturnCallback(
+				static function ( $name ) use ( &$state ) {
+					unset( $state[ $name ] );
+					return true;
+				}
+			);
+
+		$old_token = $this->render_token_for_protection( $protection );
+		$_POST[ Brute_Force_Protection_Login_Attempt_Token::FIELD_NAME ] = $old_token;
+		$this->assertFalse( ( new Brute_Force_Protection_Login_Attempt_Token( $protection ) )->consume() );
+		$this->assertNotSame( '', $replacement_token );
+
+		$_POST[ Brute_Force_Protection_Login_Attempt_Token::FIELD_NAME ] = $replacement_token;
+		$this->assertTrue( ( new Brute_Force_Protection_Login_Attempt_Token( $protection ) )->consume() );
+		$this->assertFalse( ( new Brute_Force_Protection_Login_Attempt_Token( $protection ) )->consume() );
 	}
 
 	/**
 	 * Verify that an approved login form receives a login attempt token.
 	 */
 	public function test_protection_renders_token_for_approved_login_form() {
-		$this->assertTrue( method_exists( Brute_Force_Protection::class, 'render_login_attempt_token' ) );
 		$protection = $this->protection( 'jpp_li_renderer' );
 
 		ob_start();
 		$protection->render_login_attempt_token();
 		$html = ob_get_clean();
 
-		$this->assertStringContainsString( 'name="' . self::FIELD_NAME . '"', $html );
+		$this->assertStringContainsString( 'name="' . Brute_Force_Protection_Login_Attempt_Token::FIELD_NAME . '"', $html );
 	}
 
 	/**
@@ -106,6 +195,9 @@ class BruteForceProtectionLoginAttemptTokenTest extends WorDBless\BaseTestCase {
 		$reflection  = new ReflectionClass( Brute_Force_Protection::class );
 		$protection  = $reflection->newInstanceWithoutConstructor();
 		$constructor = $reflection->getConstructor();
+		if ( PHP_VERSION_ID < 80100 ) {
+			$constructor->setAccessible( true );
+		}
 		$constructor->invoke( $protection );
 
 		$this->assertSame( 2, has_action( 'login_form', array( $protection, 'render_login_attempt_token' ) ) );
@@ -115,7 +207,6 @@ class BruteForceProtectionLoginAttemptTokenTest extends WorDBless\BaseTestCase {
 	 * Verify that no approval token is issued once the math fallback is active.
 	 */
 	public function test_protection_does_not_render_token_while_math_fallback_is_active() {
-		$this->assertTrue( method_exists( Brute_Force_Protection::class, 'render_login_attempt_token' ) );
 		$protection = $this->protection( 'jpp_li_renderer' );
 		$protection->set_transient( 'brute_use_math', 1, 600 );
 
@@ -129,9 +220,11 @@ class BruteForceProtectionLoginAttemptTokenTest extends WorDBless\BaseTestCase {
 	 * Verify that no approval token is issued once a soft block selects math.
 	 */
 	public function test_protection_does_not_render_token_after_soft_block() {
-		$this->assertTrue( method_exists( Brute_Force_Protection::class, 'render_login_attempt_token' ) );
 		$protection = $this->protection( 'jpp_li_renderer' );
 		$property   = new ReflectionProperty( Brute_Force_Protection::class, 'block_login_with_math' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
 		$property->setValue( $protection, 1 );
 
 		ob_start();
@@ -141,16 +234,49 @@ class BruteForceProtectionLoginAttemptTokenTest extends WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Verify that a database-style string transient still invokes the math fallback.
+	 */
+	public function test_string_math_transient_still_requires_math_without_approved_token() {
+		$protection = $this->getMockBuilder( Brute_Force_Protection::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'check_login_ability', 'get_transient' ) )
+			->getMock();
+		$protection->method( 'check_login_ability' )->willReturn( true );
+		$protection->method( 'get_transient' )->with( 'brute_use_math' )->willReturn( '1' );
+		$_POST['log'] = 'example';
+		add_filter( 'wp_die_handler', array( $this, 'throw_on_wp_die' ) );
+
+		$this->expectException( Exception::class );
+
+		$protection->check_preauth();
+	}
+
+	/**
 	 * Verify that a previously approved request bypasses a newly selected math fallback.
 	 */
 	public function test_approved_attempt_continues_when_status_changes_during_submission() {
 		$protection = $this->preauth_protection( 'jpp_li_preauth', 1 );
 		$protection->expects( $this->never() )->method( 'block_with_math' );
-		$token                     = $this->render_token_for_protection( $protection );
-		$_POST[ self::FIELD_NAME ] = $token;
-		$_POST['log']              = 'example';
+		$token = $this->render_token_for_protection( $protection );
+		$_POST[ Brute_Force_Protection_Login_Attempt_Token::FIELD_NAME ] = $token;
+		$_POST['log'] = 'example';
 
 		$this->assertSame( 'approved-user', $protection->check_preauth( 'approved-user' ) );
+	}
+
+	/**
+	 * Verify that Protect leaves a downstream authentication error unchanged and consumes the token.
+	 */
+	public function test_approved_attempt_preserves_authentication_error_and_consumes_token() {
+		$protection = $this->preauth_protection( 'jpp_li_preauth', 1 );
+		$protection->expects( $this->never() )->method( 'block_with_math' );
+		$token = $this->render_token_for_protection( $protection );
+		$_POST[ Brute_Force_Protection_Login_Attempt_Token::FIELD_NAME ] = $token;
+		$_POST['log'] = 'example';
+		$error        = new WP_Error( 'incorrect_password', 'Incorrect password.' );
+
+		$this->assertSame( $error, $protection->check_preauth( $error ) );
+		$this->assertFalse( ( new Brute_Force_Protection_Login_Attempt_Token( $protection ) )->consume() );
 	}
 
 	/**
@@ -159,9 +285,9 @@ class BruteForceProtectionLoginAttemptTokenTest extends WorDBless\BaseTestCase {
 	public function test_replayed_attempt_does_not_bypass_fallback() {
 		$protection = $this->preauth_protection( 'jpp_li_replay', 2 );
 		$protection->expects( $this->once() )->method( 'block_with_math' )->willReturn( false );
-		$token                     = $this->render_token_for_protection( $protection );
-		$_POST[ self::FIELD_NAME ] = $token;
-		$_POST['log']              = 'example';
+		$token = $this->render_token_for_protection( $protection );
+		$_POST[ Brute_Force_Protection_Login_Attempt_Token::FIELD_NAME ] = $token;
+		$_POST['log'] = 'example';
 
 		$first_attempt  = $protection->check_preauth( 'approved-user' );
 		$replay_attempt = $protection->check_preauth( 'approved-user' );
@@ -175,14 +301,15 @@ class BruteForceProtectionLoginAttemptTokenTest extends WorDBless\BaseTestCase {
 	public function test_approved_attempt_does_not_bypass_hard_block_check() {
 		$protection = $this->getMockBuilder( Brute_Force_Protection::class )
 			->disableOriginalConstructor()
-			->onlyMethods( array( 'check_login_ability', 'get_transient_name' ) )
+			->onlyMethods( array( 'get_cached_status', 'get_transient_name', 'is_current_ip_allowed', 'kill_login' ) )
 			->getMock();
 		$protection->method( 'get_transient_name' )->willReturn( 'jpp_li_hard-block' );
+		$protection->method( 'is_current_ip_allowed' )->willReturn( false );
+		$protection->method( 'get_cached_status' )->willReturn( 'blocked-hard' );
 		$protection->expects( $this->once() )
-			->method( 'check_login_ability' )
-			->with( true )
+			->method( 'kill_login' )
 			->willThrowException( new RuntimeException( 'hard block' ) );
-		$_POST[ self::FIELD_NAME ] = $this->render_token_for_protection( $protection );
+		$_POST[ Brute_Force_Protection_Login_Attempt_Token::FIELD_NAME ] = $this->render_token_for_protection( $protection );
 
 		$this->expectException( RuntimeException::class );
 		$this->expectExceptionMessage( 'hard block' );
@@ -254,13 +381,29 @@ class BruteForceProtectionLoginAttemptTokenTest extends WorDBless\BaseTestCase {
 	 * @return string
 	 */
 	private function render_token_for_protection( $protection ) {
-
 		ob_start();
 		( new Brute_Force_Protection_Login_Attempt_Token( $protection ) )->render_field();
 		$html = ob_get_clean();
 
 		$this->assertSame( 1, preg_match( '/value="([a-f0-9]{32})"/', $html, $matches ) );
+		$this->issued_tokens[] = $matches[1];
 
 		return $matches[1];
+	}
+
+	/**
+	 * Return a wp_die handler that throws for assertions.
+	 *
+	 * @return callable
+	 */
+	public function throw_on_wp_die() {
+		/**
+		 * Throw instead of terminating the test process.
+		 *
+		 * @return never
+		 */
+		return static function () {
+			throw new Exception( 'wp_die called' );
+		};
 	}
 }

--- a/projects/packages/waf/tests/php/integration/BruteForceProtectionLoginAttemptTokenTest.php
+++ b/projects/packages/waf/tests/php/integration/BruteForceProtectionLoginAttemptTokenTest.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Tests for the Brute Force Protection login attempt token.
+ *
+ * @package automattic/jetpack-waf
+ */
+
+use Automattic\Jetpack\Waf\Brute_Force_Protection\Brute_Force_Protection;
+use Automattic\Jetpack\Waf\Brute_Force_Protection\Brute_Force_Protection_Login_Attempt_Token;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+
+/**
+ * Brute Force Protection login attempt token test case.
+ */
+#[AllowMockObjectsWithoutExpectations /* getStubBuilder() (for partial stubs) doesn't exist until PHPUnit 12.5. */ ]
+class BruteForceProtectionLoginAttemptTokenTest extends WorDBless\BaseTestCase {
+	/**
+	 * Form field used by the login attempt token.
+	 */
+	private const FIELD_NAME = 'jetpack_protect_login_attempt';
+	/**
+	 * Clean up after each test.
+	 */
+	public function tearDown(): void {
+		$_POST = array();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Verify that the login attempt token helper is available.
+	 */
+	public function test_login_attempt_token_helper_is_available() {
+		$this->assertTrue(
+			class_exists( 'Automattic\Jetpack\Waf\Brute_Force_Protection\Brute_Force_Protection_Login_Attempt_Token' )
+		);
+	}
+
+	/**
+	 * Verify that a valid token cannot be replayed.
+	 */
+	public function test_token_can_only_be_consumed_once() {
+		$token                     = $this->render_token( 'jpp_li_browser' );
+		$_POST[ self::FIELD_NAME ] = $token;
+
+		$this->assertTrue( $this->token_manager( 'jpp_li_browser' )->consume() );
+		$this->assertFalse( $this->token_manager( 'jpp_li_browser' )->consume() );
+	}
+
+	/**
+	 * Verify that a token cannot move between Protect client fingerprints.
+	 */
+	public function test_token_is_bound_to_the_client_fingerprint() {
+		$_POST[ self::FIELD_NAME ] = $this->render_token( 'jpp_li_browser-a' );
+
+		$this->assertFalse( $this->token_manager( 'jpp_li_browser-b' )->consume() );
+	}
+
+	/**
+	 * Verify that a token without its transient is rejected.
+	 */
+	public function test_expired_token_is_rejected() {
+		$_POST[ self::FIELD_NAME ] = $this->render_token( 'jpp_li_browser' );
+		delete_transient( 'jpp_attempt_' . md5( 'jpp_li_browser' ) );
+
+		$this->assertFalse( $this->token_manager( 'jpp_li_browser' )->consume() );
+	}
+
+	/**
+	 * Verify that rendering a new form invalidates an older form token.
+	 */
+	public function test_only_the_latest_rendered_token_is_valid() {
+		$old_token = $this->render_token( 'jpp_li_browser' );
+		$new_token = $this->render_token( 'jpp_li_browser' );
+
+		$_POST[ self::FIELD_NAME ] = $old_token;
+		$this->assertFalse( $this->token_manager( 'jpp_li_browser' )->consume() );
+
+		$_POST[ self::FIELD_NAME ] = $new_token;
+		$this->assertTrue( $this->token_manager( 'jpp_li_browser' )->consume() );
+	}
+
+	/**
+	 * Create a token manager with a stable Protect client fingerprint.
+	 *
+	 * @param string $fingerprint Protect client fingerprint.
+	 * @return Brute_Force_Protection_Login_Attempt_Token
+	 */
+	private function token_manager( $fingerprint ) {
+		$protection = $this->getMockBuilder( Brute_Force_Protection::class )
+			->disableOriginalConstructor()
+			->onlyMethods( array( 'get_transient_name' ) )
+			->getMock();
+		$protection->method( 'get_transient_name' )->willReturn( $fingerprint );
+
+		return new Brute_Force_Protection_Login_Attempt_Token( $protection );
+	}
+
+	/**
+	 * Render and extract a login attempt token.
+	 *
+	 * @param string $fingerprint Protect client fingerprint.
+	 * @return string
+	 */
+	private function render_token( $fingerprint ) {
+		$this->assertTrue( method_exists( Brute_Force_Protection_Login_Attempt_Token::class, 'render_field' ) );
+
+		ob_start();
+		$this->token_manager( $fingerprint )->render_field();
+		$html = ob_get_clean();
+
+		$this->assertSame( 1, preg_match( '/value="([a-f0-9]{32})"/', $html, $matches ) );
+
+		return $matches[1];
+	}
+}

--- a/projects/packages/waf/tests/php/integration/BruteForceProtectionLoginAttemptTokenTest.php
+++ b/projects/packages/waf/tests/php/integration/BruteForceProtectionLoginAttemptTokenTest.php
@@ -12,7 +12,7 @@ use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 /**
  * Brute Force Protection login attempt token test case.
  */
-#[AllowMockObjectsWithoutExpectations /* getStubBuilder() (for partial stubs) doesn't exist until PHPUnit 12.5. */ ]
+#[AllowMockObjectsWithoutExpectations /* getStubBuilder() (for partial stubs) doesn't exist until PHPUnit 12.5. */]
 class BruteForceProtectionLoginAttemptTokenTest extends WorDBless\BaseTestCase {
 	/**
 	 * Tokens issued during the current test.
@@ -22,12 +22,20 @@ class BruteForceProtectionLoginAttemptTokenTest extends WorDBless\BaseTestCase {
 	private $issued_tokens = array();
 
 	/**
+	 * Whether the test environment was using an external object cache.
+	 *
+	 * @var bool
+	 */
+	private $was_using_ext_object_cache;
+
+	/**
 	 * Set up each test.
 	 */
 	public function setUp(): void {
 		parent::setUp();
 
-		$_SERVER['REMOTE_ADDR'] = '203.0.113.10';
+		$this->was_using_ext_object_cache = wp_using_ext_object_cache();
+		$_SERVER['REMOTE_ADDR']           = '203.0.113.10';
 		unset( $_SERVER['HTTP_X_FORWARDED_FOR'] );
 		delete_site_option( 'trusted_ip_header' );
 	}
@@ -45,9 +53,13 @@ class BruteForceProtectionLoginAttemptTokenTest extends WorDBless\BaseTestCase {
 		delete_transient( 'jpp_attempt_' . md5( '203.0.113.10' ) );
 
 		foreach ( $this->issued_tokens as $token ) {
-			delete_transient( 'jpp_claim_' . substr( hash( 'sha256', $token ), 0, 32 ) );
+			$claim_name = 'jpp_claim_' . substr( hash( 'sha256', $token ), 0, 32 );
+			delete_transient( $claim_name );
+			delete_option( '_transient_' . $claim_name );
+			delete_option( '_transient_timeout_' . $claim_name );
 		}
 		$this->issued_tokens = array();
+		wp_using_ext_object_cache( $this->was_using_ext_object_cache );
 
 		parent::tearDown();
 	}
@@ -60,6 +72,20 @@ class BruteForceProtectionLoginAttemptTokenTest extends WorDBless\BaseTestCase {
 		$_POST[ Brute_Force_Protection_Login_Attempt_Token::FIELD_NAME ] = $token;
 
 		$this->assertTrue( $this->token_manager( 'jpp_li_browser' )->consume() );
+		$this->assertFalse( $this->token_manager( 'jpp_li_browser' )->consume() );
+	}
+
+	/**
+	 * Verify that evicting only an external-cache claim cannot make a token reusable.
+	 */
+	public function test_claim_survives_selective_external_object_cache_eviction() {
+		wp_using_ext_object_cache( true );
+		$token = $this->render_token( 'jpp_li_browser' );
+		$_POST[ Brute_Force_Protection_Login_Attempt_Token::FIELD_NAME ] = $token;
+
+		$this->assertTrue( $this->token_manager( 'jpp_li_browser' )->consume() );
+		wp_cache_delete( 'jpp_claim_' . substr( hash( 'sha256', $token ), 0, 32 ), 'transient' );
+
 		$this->assertFalse( $this->token_manager( 'jpp_li_browser' )->consume() );
 	}
 


### PR DESCRIPTION
Fixes PROTECT-179 #14576

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Add a short-lived, single-use approval token to login forms already approved by Brute Force Protection.
* Allow that in-flight credential submission to finish if Protect switches to the soft/math fallback after the form renders, while preserving authoritative hard blocks.
* Bind the token to the authoritative client IP and complete Protect fingerprint without storing credentials, usernames, user IDs, or authentication results.
* Persist the one-time claim with database-enforced uniqueness so cache eviction and concurrent requests cannot replay the approval.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* https://meta.trac.wordpress.org/ticket/4989

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Run `CI=1 jp test php packages/waf`.
* Run `jp phan packages/waf`.
* Confirm the login-attempt integration tests cover single use, expiry, fingerprint mismatch, concurrent replacement, external-cache eviction, soft/math fallback handoff, and hard-block precedence.
