### PR TITLE
Tiled Gallery: fix images collapsing to ~105px when the editor canvas is not iframed

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-tiled-gallery-noniframe-canvas-collapse
+++ b/projects/plugins/jetpack/changelog/fix-tiled-gallery-noniframe-canvas-collapse
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Tiled Gallery: fix images collapsing to ~105px in the editor when the canvas is not iframed

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/index.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/index.jsx
@@ -50,6 +50,16 @@ export default class Mosaic extends Component {
 		// Start above the gallery node itself (which is its own flex row container).
 		let el = node.parentElement;
 		while ( el && el.parentElement ) {
+			// Never climb past the block-canvas root into editor chrome. In a
+			// non-iframed editor (a classic theme with an apiVersion < 3 block keeps
+			// the canvas non-iframed) the first flex ancestor outside the canvas is an
+			// emotion-styled chrome div; laying the mosaic out against it divides its
+			// width by its many children and collapses every item to ~105px. Only flex
+			// containers inside the canvas (e.g. a Row/Stack block) are valid targets.
+			// See JETPACK-1900.
+			if ( el.matches( '.is-root-container, .editor-styles-wrapper' ) ) {
+				return null;
+			}
 			const parent = el.parentElement;
 			const display = view.getComputedStyle( parent ).display;
 			if ( 'flex' === display || 'inline-flex' === display ) {
@@ -58,6 +68,31 @@ export default class Mosaic extends Component {
 			el = parent;
 		}
 		return null;
+	}
+
+	/**
+	 * Number of real flex items among a container's children. Excludes children that
+	 * are not laid-out flex items — non-rendered elements (`<style>`, `<script>`,
+	 * `<template>`, `<link>`) and elements taken out of flow (display:none or
+	 * absolutely positioned, e.g. a popover slot) — which would otherwise inflate the
+	 * equal-share divisor in getLayoutWidth. See JETPACK-1900.
+	 *
+	 * @param {HTMLElement} container - The flex container.
+	 * @param {Window}      view      - The container's owning window.
+	 * @return {number} Count of laid-out flex items.
+	 */
+	countFlexItems( container, view ) {
+		const nonItemTags = [ 'STYLE', 'SCRIPT', 'TEMPLATE', 'LINK' ];
+		return Array.from( container.children ).filter( child => {
+			if ( nonItemTags.includes( child.tagName ) ) {
+				return false;
+			}
+			const style = view.getComputedStyle( child );
+			if ( 'none' === style.display ) {
+				return false;
+			}
+			return 'absolute' !== style.position && 'fixed' !== style.position;
+		} ).length;
 	}
 
 	/**
@@ -79,11 +114,12 @@ export default class Mosaic extends Component {
 		if ( ! container ) {
 			return this.gallery.current ? this.gallery.current.clientWidth : 0;
 		}
-		// children.length is a deliberate, pragmatic proxy for "number of flex
-		// items", and the division below assumes those items are equal width — it
-		// does not honor per-item flex-grow/flex-basis. That's enough for the common
-		// Row/Stack of galleries; non-uniform rows are left as a follow-up.
-		const count = container.children.length;
+		const view = container.ownerDocument?.defaultView || window;
+		// countFlexItems is a deliberate, pragmatic proxy for "number of flex items",
+		// and the division below assumes those items are equal width — it does not
+		// honor per-item flex-grow/flex-basis. That's enough for the common Row/Stack
+		// of galleries; non-uniform rows are left as a follow-up.
+		const count = this.countFlexItems( container, view );
 		if ( count <= 1 ) {
 			return container.clientWidth;
 		}
@@ -93,7 +129,6 @@ export default class Mosaic extends Component {
 		// own layout and settles to a different value on each reload in Firefox.
 		// Dividing the container width is content-independent, so the result is
 		// stable across browsers/reloads. See JETPACK-1726.
-		const view = container.ownerDocument?.defaultView || window;
 		const gap = parseFloat( view.getComputedStyle( container ).columnGap ) || 0;
 		return ( container.clientWidth - gap * ( count - 1 ) ) / count;
 	}

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/mosaic.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/test/mosaic.jsx
@@ -181,4 +181,68 @@ describe( 'Mosaic layout-width anchoring', () => {
 		expect( mosaic.getFlexContainer() ).toBeNull();
 		expect( mosaic.getLayoutWidth() ).toBe( 620 );
 	} );
+
+	it( 'stops at the block-canvas root and never lays out against editor chrome (JETPACK-1900)', () => {
+		// chrome(flex, 1244) > rootContainer(.is-root-container) > item > wrapper > gallery
+		// In a non-iframed editor the only flex ancestor is emotion-styled editor
+		// chrome outside the canvas. The walk must stop at the canvas root and fall
+		// back to the gallery's own width; laying out against chrome divides its
+		// width by its many children and collapses every item to ~105px.
+		const chrome = document.createElement( 'div' );
+		const rootContainer = document.createElement( 'div' );
+		rootContainer.className = 'is-root-container';
+		const item = document.createElement( 'div' );
+		const wrapper = document.createElement( 'div' );
+		const gallery = document.createElement( 'div' );
+		chrome.appendChild( rootContainer );
+		rootContainer.appendChild( item );
+		item.appendChild( wrapper );
+		wrapper.appendChild( gallery );
+		// The classless chrome div holds mostly non-item children (style tags).
+		for ( let i = 0; i < 8; i++ ) {
+			chrome.appendChild( document.createElement( 'style' ) );
+		}
+
+		defineClientWidth( chrome, 1244 );
+		defineClientWidth( gallery, 620 );
+
+		mockFlex( chrome );
+
+		const mosaic = instanceFor( gallery );
+		expect( mosaic.getFlexContainer() ).toBeNull();
+		expect( mosaic.getLayoutWidth() ).toBe( 620 );
+	} );
+
+	it( 'counts only real flex items, ignoring <style> tags and out-of-flow slots (JETPACK-1900)', () => {
+		// container(flex, 800, 20px gap) > [itemA > galleryA, itemB > galleryB, slot(absolute), 8x <style>]
+		// Only the two galleries are real flex items, so each gets (800 - 20) / 2 = 390.
+		// The style tags and absolutely-positioned popover slot must not inflate the divisor.
+		const container = document.createElement( 'div' );
+		const itemA = document.createElement( 'div' );
+		const itemB = document.createElement( 'div' );
+		const galleryA = document.createElement( 'div' );
+		const galleryB = document.createElement( 'div' );
+		const slot = document.createElement( 'div' );
+		container.appendChild( itemA );
+		container.appendChild( itemB );
+		container.appendChild( slot );
+		itemA.appendChild( galleryA );
+		itemB.appendChild( galleryB );
+		for ( let i = 0; i < 8; i++ ) {
+			container.appendChild( document.createElement( 'style' ) );
+		}
+
+		defineClientWidth( container, 800 );
+
+		// container is flex (20px gap); the popover slot is taken out of flow.
+		computedStyleSpy = jest.spyOn( window, 'getComputedStyle' ).mockImplementation( el => ( {
+			display: el === container ? 'flex' : 'block',
+			columnGap: el === container ? '20px' : 'normal',
+			position: el === slot ? 'absolute' : 'static',
+		} ) );
+
+		const mosaic = instanceFor( galleryA );
+		expect( mosaic.getFlexContainer() ).toBe( container );
+		expect( mosaic.getLayoutWidth() ).toBe( 390 );
+	} );
 } );


### PR DESCRIPTION
Fixes #50435
Fixes JETPACK-1900

## Proposed changes
* Bound the Tiled Gallery mosaic's `getFlexContainer()` ancestor walk at the block-canvas root (`.is-root-container` / `.editor-styles-wrapper`). On a **non-iframed** editor canvas the walk previously escaped the post content and matched an emotion-styled chrome `<div>`; `getLayoutWidth()` then divided that element's width by its child count, collapsing every `.tiled-gallery__item` to ~105px. Editor chrome is now never a layout target.
* Add `countFlexItems()` and use it instead of `container.children.length` — it counts only real flex items, excluding `<style>`/`<script>`/`<template>`/`<link>`, `display:none`, and absolutely-positioned slots, so the equal-share division is correct even when a legitimate flex container carries injected style tags or popover slots.
* Regression tests in `layout/mosaic/test/mosaic.jsx` covering the non-iframed chrome escape and the flex-item counting.

This is a regression from #50016 (the JETPACK-1726 Row/Stack infinite-resize fix), which introduced the unbounded ancestor walk. Flex containers **inside** the canvas (e.g. a Row/Stack block) are still found, so that fix is preserved. The front end was never affected (the view script recalculates against the real container).

## Related product discussion/links
* https://linear.app/a8c/issue/JETPACK-1900

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

The bug only manifests when the block-editor canvas is **not iframed**. On a classic theme, WordPress keeps the canvas non-iframed whenever at least one registered block uses `apiVersion < 3`. Merely activating ACF is *not* enough (it registers no blocks until you define one), so use this minimal mu-plugin to force the condition deterministically.

1. Drop this file into `wp-content/mu-plugins/` (e.g. `mu-plugins/force-noniframe.php`):

   ```php
   <?php
   /**
    * Plugin Name: Force non-iframed editor canvas (JETPACK-1900 repro)
    * Description: Registers one dummy apiVersion 2 block so a classic theme keeps the editor canvas non-iframed.
    */
   add_action(
       'enqueue_block_editor_assets',
       function () {
           wp_add_inline_script(
               'wp-blocks',
               <<<'JS'
   ( function ( b ) {
       if ( ! b || b.getBlockType( 'jetpack1900/force-noniframe' ) ) {
           return;
       }
       b.registerBlockType( 'jetpack1900/force-noniframe', {
           apiVersion: 2,
           title: 'JETPACK-1900 repro (v2)',
           category: 'widgets',
           edit: function () { return null; },
           save: function () { return null; },
       } );
   } )( window.wp && window.wp.blocks );
   JS
           );
       }
   );
   ```

2. Activate a **classic** (non-block) theme, e.g. Twenty Twenty-One or Twenty Ten.
3. Create/edit a post and add a **Tiled Gallery** block (Mosaic layout) with 3+ images.
4. Confirm the canvas is non-iframed — in the browser console, `document.querySelector('iframe[name="editor-canvas"]')` returns `null`.
5. **Before this PR:** on load (once images resolve) or on any resize/sidebar toggle, every item collapses to `width:105px` (or smaller) and the gallery shrinks to a tiny cluster.
   **After this PR:** the gallery lays out at full content width and stays stable through resizes/sidebar toggles.
6. Regression checks:
   * Remove the mu-plugin (or switch to a **block theme**) → canvas is iframed → gallery renders correctly (unchanged).
   * Put a Tiled Gallery inside a **Row** or **Stack** block → it still lays out against the Row/Stack width (the #50016 / JETPACK-1726 fix is preserved; no infinite resize loop).
7. Run the unit tests:
   ```
   cd projects/plugins/jetpack
   TZ=UTC pnpm jest --config=tests/jest.config.extensions.js extensions/blocks/tiled-gallery/layout/mosaic/
   ```

Remember to delete the repro mu-plugin when you're done — it forces every classic-theme editor on the site into the non-iframed canvas.
