### PR TITLE
Media API: Accept ai_generated flag on the media update endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/add-media-endpoint-ai-generated-flag
+++ b/projects/plugins/jetpack/changelog/add-media-endpoint-ai-generated-flag
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Media API: accept an ai_generated flag on the media update endpoint so AI-image provenance postmeta is stored on the site that owns the attachment (Atomic and self-hosted Jetpack sites).

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-media-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-media-v1-1-endpoint.php
@@ -35,6 +35,7 @@ new WPCOM_JSON_API_Update_Media_v1_1_Endpoint(
 			'privacy_setting' => '(int) Video only. The privacy level for the video.',
 			'artist'          => '(string) Audio Only. Artist metadata for the audio track.',
 			'album'           => '(string) Audio Only. Album metadata for the audio track.',
+			'ai_generated'    => '(bool) Flag the attachment as AI-generated.',
 		),
 
 		'response_format'      => array(
@@ -130,6 +131,12 @@ class WPCOM_JSON_API_Update_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint 
 		if ( isset( $input['alt'] ) ) {
 			$alt = wp_strip_all_tags( $input['alt'], true );
 			update_post_meta( $media_id, '_wp_attachment_image_alt', $alt );
+		}
+
+		// Runs on the site that owns the attachment, so the flag reaches the real
+		// attachment on Atomic and self-hosted Jetpack sites, not the shadow row.
+		if ( isset( $input['ai_generated'] ) && $input['ai_generated'] ) {
+			update_post_meta( $media_id, '_wpcom_image_studio_ai_generated', true );
 		}
 
 		// audio only artist/album info.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-media-v1-1-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-update-media-v1-1-endpoint.php
@@ -133,8 +133,11 @@ class WPCOM_JSON_API_Update_Media_v1_1_Endpoint extends WPCOM_JSON_API_Endpoint 
 			update_post_meta( $media_id, '_wp_attachment_image_alt', $alt );
 		}
 
-		// Runs on the site that owns the attachment, so the flag reaches the real
-		// attachment on Atomic and self-hosted Jetpack sites, not the shadow row.
+		// AI provenance. The `ai_generated` field and this meta key are the
+		// contract with wpcom's Jetpack_Client_Action::build_ai_generated_request();
+		// keep them in sync. This runs on the site that owns the attachment, so
+		// the flag reaches the real attachment on Atomic and self-hosted Jetpack
+		// sites, not the shadow row.
 		if ( isset( $input['ai_generated'] ) && $input['ai_generated'] ) {
 			update_post_meta( $media_id, '_wpcom_image_studio_ai_generated', true );
 		}

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Update_Media_v1_1_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Update_Media_v1_1_Endpoint_Test.php
@@ -165,4 +165,20 @@ class WPCOM_JSON_API_Update_Media_v1_1_Endpoint_Test extends WP_UnitTestCase { /
 			'Requests without ai_generated must not set the provenance postmeta.'
 		);
 	}
+
+	/**
+	 * A falsy `ai_generated` flag leaves the AI provenance postmeta untouched.
+	 */
+	public function test_falsy_flag_leaves_postmeta_unset() {
+		global $blog_id;
+
+		$this->set_input( array( 'ai_generated' => false ) );
+		$response = $this->get_endpoint()->callback( '', $blog_id, self::$attachment_id );
+
+		$this->assertNotWPError( $response );
+		$this->assertEmpty(
+			get_post_meta( self::$attachment_id, self::AI_GENERATED_META_KEY, true ),
+			'A falsy ai_generated flag must not set the provenance postmeta.'
+		);
+	}
 }

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Update_Media_v1_1_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Update_Media_v1_1_Endpoint_Test.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Tests for WPCOM_JSON_API_Update_Media_v1_1_Endpoint.
+ *
+ * @package automattic/jetpack
+ */
+
+use PHPUnit\Framework\Attributes\CoversClass;
+
+require_once JETPACK__PLUGIN_DIR . 'class.json-api-endpoints.php';
+
+/**
+ * Tests for the `ai_generated` flag on the media update endpoint.
+ *
+ * @covers \WPCOM_JSON_API_Update_Media_v1_1_Endpoint
+ */
+#[CoversClass( WPCOM_JSON_API_Update_Media_v1_1_Endpoint::class )]
+class WPCOM_JSON_API_Update_Media_v1_1_Endpoint_Test extends WP_UnitTestCase { // phpcs:ignore PEAR.NamingConventions.ValidClassName.Invalid, Generic.Classes.OpeningBraceSameLine.ContentAfterBrace -- matches source class naming.
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * AI-generated provenance postmeta key.
+	 */
+	const AI_GENERATED_META_KEY = '_wpcom_image_studio_ai_generated';
+
+	/**
+	 * Admin user ID.
+	 *
+	 * @var int
+	 */
+	private static $admin_user_id;
+
+	/**
+	 * Attachment ID.
+	 *
+	 * @var int
+	 */
+	private static $attachment_id;
+
+	/**
+	 * Create fixtures once before the class runs.
+	 *
+	 * @param WP_UnitTest_Factory $factory Fixture factory.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_user_id = $factory->user->create( array( 'role' => 'administrator' ) );
+		self::$attachment_id = $factory->post->create(
+			array(
+				'post_type'      => 'attachment',
+				'post_status'    => 'inherit',
+				'post_mime_type' => 'image/png',
+				'post_title'     => 'AI generated image',
+				'post_author'    => self::$admin_user_id,
+			)
+		);
+		// Give the attachment a file path so get_media_item_v1_1() doesn't call
+		// basename( null ) while building its response for this fixture.
+		update_post_meta( self::$attachment_id, '_wp_attached_file', 'ai-generated-image.png' );
+	}
+
+	/**
+	 * Inserts globals needed to initialize the endpoint.
+	 */
+	private function set_globals() {
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$_SERVER['HTTP_HOST']      = '127.0.0.1';
+		$_SERVER['REQUEST_URI']    = '/';
+	}
+
+	/**
+	 * Prepare the environment for the test.
+	 */
+	public function set_up() {
+		global $blog_id;
+
+		parent::set_up();
+
+		if ( ! defined( 'WPCOM_JSON_API__BASE' ) ) {
+			define( 'WPCOM_JSON_API__BASE', 'public-api.wordpress.com/rest/v1' );
+		}
+
+		$this->set_globals();
+
+		WPCOM_JSON_API::init()->token_details = array( 'blog_id' => $blog_id );
+
+		wp_set_current_user( self::$admin_user_id );
+	}
+
+	/**
+	 * Clean up after each test.
+	 */
+	public function tear_down() {
+		delete_post_meta( self::$attachment_id, self::AI_GENERATED_META_KEY );
+
+		WPCOM_JSON_API::init()->token_details = array();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Feed a JSON body to the endpoint's input() reader.
+	 *
+	 * @param array $input Request body.
+	 */
+	private function set_input( $input ) {
+		WPCOM_JSON_API::init()->post_body    = wp_json_encode( $input, JSON_UNESCAPED_SLASHES );
+		WPCOM_JSON_API::init()->content_type = 'application/json';
+	}
+
+	/**
+	 * Build the endpoint under test.
+	 *
+	 * @return WPCOM_JSON_API_Update_Media_v1_1_Endpoint
+	 */
+	private function get_endpoint() {
+		return new WPCOM_JSON_API_Update_Media_v1_1_Endpoint(
+			array(
+				'description'    => 'Edit basic information about a media item.',
+				'group'          => 'media',
+				'stat'           => 'media:1:POST',
+				'min_version'    => '1.1',
+				'max_version'    => '1.1',
+				'method'         => 'POST',
+				'path'           => '/sites/%s/media/%d',
+				'path_labels'    => array(
+					'$site'     => '(int|string) Site ID or domain',
+					'$media_ID' => '(int) The ID of the media item',
+				),
+				'request_format' => array(
+					'title'        => '(string) The file name.',
+					'ai_generated' => '(bool) Flag the attachment as AI-generated.',
+				),
+			)
+		);
+	}
+
+	/**
+	 * A truthy `ai_generated` flag records the AI provenance postmeta.
+	 */
+	public function test_ai_generated_flag_sets_postmeta() {
+		global $blog_id;
+
+		$this->set_input( array( 'ai_generated' => true ) );
+		$response = $this->get_endpoint()->callback( '', $blog_id, self::$attachment_id );
+
+		$this->assertNotWPError( $response );
+		$this->assertNotEmpty(
+			get_post_meta( self::$attachment_id, self::AI_GENERATED_META_KEY, true ),
+			'A truthy ai_generated flag must set the provenance postmeta.'
+		);
+	}
+
+	/**
+	 * A request without the flag leaves the AI provenance postmeta untouched.
+	 */
+	public function test_absent_flag_leaves_postmeta_unset() {
+		global $blog_id;
+
+		$this->set_input( array( 'title' => 'Just a title' ) );
+		$response = $this->get_endpoint()->callback( '', $blog_id, self::$attachment_id );
+
+		$this->assertNotWPError( $response );
+		$this->assertEmpty(
+			get_post_meta( self::$attachment_id, self::AI_GENERATED_META_KEY, true ),
+			'Requests without ai_generated must not set the provenance postmeta.'
+		);
+	}
+}


### PR DESCRIPTION
Relates to FORNO-402

## Proposed changes
* Add an `ai_generated` field to the media update endpoint (`POST /sites/{blog_id}/media/{id}`). When it is true, the endpoint sets the `_wpcom_image_studio_ai_generated` postmeta on the attachment.
* This endpoint runs on the site that owns the attachment. That lets WordPress.com flag AI images on Atomic and self-hosted Jetpack sites, where the media lives on the remote site instead of the WordPress.com shadow copy.
* Works the same way the endpoint already handles the `alt` field.

## Related product discussion/links
* Companion to a WordPress.com change for Linear FORNO-402 (Image Studio AI-provenance postmeta).

## Does this pull request change what data or activity we track or use?
No. It stores a flag on the attachment on the site that owns it. Nothing is tracked, collected, or sent off the site, and the flag is not synced to WordPress.com.

## Testing instructions
* On a Jetpack-connected site, send a POST to `/sites/{blog_id}/media/{attachment_id}` with `ai_generated: true` in the body.
* Confirm the attachment now has the postmeta set: `get_post_meta( $attachment_id, '_wpcom_image_studio_ai_generated', true )` returns a truthy value.
* Send the same request without `ai_generated` and confirm the postmeta is not set.
* Or run the unit test: `jetpack docker phpunit jetpack -- --filter WPCOM_JSON_API_Update_Media_v1_1_Endpoint_Test`.