### PR TITLE
Notifications: show the bell icon node in the Post / Site editors

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-notifications-show-in-editor
+++ b/projects/plugins/jetpack/changelog/fix-notifications-show-in-editor
@@ -1,0 +1,5 @@
+Significance: patch
+Type: compat
+
+Notifications: show the notification bell in the admin bar on the Post editor and Site editor,
+now that Gutenberg 23.6+ renders the admin bar there.

--- a/projects/plugins/jetpack/modules/notes.php
+++ b/projects/plugins/jetpack/modules/notes.php
@@ -85,20 +85,6 @@ class Jetpack_Notifications {
 			return;
 		}
 
-		// Do not show notifications in the Site Editor, which is always in fullscreen mode.
-		global $pagenow;
-
-		// Pre 13.7 pages that still need to be supported if < 13.7 is
-		// still installed.
-		$allowed_old_pages       = array( 'admin.php', 'themes.php' );
-		$is_old_site_editor_page = in_array( $pagenow, $allowed_old_pages, true ) && isset( $_GET['page'] ) && 'gutenberg-edit-site' === $_GET['page']; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		// For Gutenberg > 13.7, the core `site-editor.php` route is used instead
-		$is_site_editor_page = 'site-editor.php' === $pagenow;
-
-		if ( $is_site_editor_page || $is_old_site_editor_page ) {
-			return;
-		}
-
 		add_action( 'admin_bar_menu', array( $this, 'admin_bar_menu' ), 120 );
 		add_action( 'wp_head', array( $this, 'styles_and_scripts' ), 120 );
 		add_action( 'admin_head', array( $this, 'styles_and_scripts' ) );
@@ -110,9 +96,6 @@ class Jetpack_Notifications {
 	 * @return void
 	 */
 	public function styles_and_scripts() {
-		if ( self::is_block_editor() ) {
-			return;
-		}
 		$is_rtl = is_rtl();
 
 		if ( ( new Host() )->is_woa_site() ) {
@@ -171,10 +154,6 @@ class Jetpack_Notifications {
 		global $wp_admin_bar;
 
 		if ( ! is_object( $wp_admin_bar ) ) {
-			return;
-		}
-
-		if ( self::is_block_editor() ) {
 			return;
 		}
 


### PR DESCRIPTION
Fixes DOTCOM-17746

## Proposed changes

Render the notification bell icon in the admin bar on Post and Site Editor screens, now that admin bar is shown there on Gutenberg 23.6+ (see: https://github.com/WordPress/gutenberg/pull/79197).

This PR simply removes the guard that hid that.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Apply this patch to Atomic sites via Jetpack Beta Tester.
    - Simple sites is done on 229260-ghe-Automattic/wpcom
3. Open Post and Site Editors.
4. Verify the notification bell icon is there and working.