### PR TITLE
Email breakdown: localize row labels and pin the aggregated row by flag

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-email-breakdown-untranslated-labels
+++ b/projects/packages/premium-analytics/changelog/fix-email-breakdown-untranslated-labels
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Email breakdown: localize row labels and pin the aggregated row by flag instead of its label

--- a/projects/packages/premium-analytics/changelog/fix-email-breakdown-untranslated-labels
+++ b/projects/packages/premium-analytics/changelog/fix-email-breakdown-untranslated-labels
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Email breakdown: localize row labels and pin the aggregated row by flag instead of its label
+Email breakdown: localize row labels and pin the aggregated row by flag instead of its label.

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/email-breakdown.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/email-breakdown.ts
@@ -30,10 +30,12 @@ export const emailFieldlessCountriesFixture = {
 	},
 };
 
+// `Other` outranks `Gmail` by value so the fixture proves the catch-all bucket is
+// pinned last rather than merely landing last by value.
 export const emailFieldlessClientsFixture = {
 	clients: {
 		data: [
-			[ 'Other', '1' ],
+			[ 'Other', '9' ],
 			[ 'Apple Mail', '10' ],
 			[ 'Gmail', '8' ],
 		],

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/email-breakdown.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__fixtures__/email-breakdown.ts
@@ -42,6 +42,20 @@ export const emailFieldlessClientsFixture = {
 	},
 };
 
+// Matrix (fields-based) counterpart of the clients breakdown. `Other` outranks
+// every named client by value, so the fixture proves the matrix path pins the
+// catch-all bucket last rather than returning rows in raw API order.
+export const emailMatrixClientsFixture = {
+	clients: {
+		fields: [ 'client', 'opens_count' ],
+		data: [
+			[ 'Other', '265' ],
+			[ 'Apple Mail', '200' ],
+			[ 'Thunderbird', '180' ],
+		],
+	},
+};
+
 export const emailFieldlessLinksFixture = {
 	links: {
 		data: [

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/email-breakdown.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/email-breakdown.test.ts
@@ -1,4 +1,5 @@
-import { sanitizeStatsEmailBreakdownResponse } from '..';
+import { setLocaleData } from '@wordpress/i18n';
+import { compareEmailBreakdownItems, sanitizeStatsEmailBreakdownResponse } from '..';
 import {
 	emailCountriesFixture,
 	emailFieldlessClientsFixture,
@@ -70,8 +71,15 @@ describe( 'Stats email breakdown normalizer', () => {
 		).toEqual( [
 			expect.objectContaining( { label: 'Apple Mail', value: 10 } ),
 			expect.objectContaining( { label: 'Gmail', value: 8 } ),
-			expect.objectContaining( { label: 'Other', value: 1 } ),
+			expect.objectContaining( { label: 'Other', value: 9, isOther: true } ),
 		] );
+	} );
+
+	it( 'flags the catch-all client bucket so sorting never depends on its label', () => {
+		const [ appleMail ] = sanitizeStatsEmailBreakdownResponse( emailFieldlessClientsFixture )
+			.data[ 0 ].items;
+
+		expect( appleMail.isOther ).toBeUndefined();
 	} );
 
 	it( 'normalizes fieldless email link breakdowns', () => {
@@ -86,7 +94,74 @@ describe( 'Stats email breakdown normalizer', () => {
 			} ),
 			expect.objectContaining( { label: 'https://example.com/b', value: 2 } ),
 			expect.objectContaining( { label: 'Like', value: 1 } ),
-			expect.objectContaining( { label: 'Other', value: 3 } ),
+			expect.objectContaining( { label: 'Other', value: 3, isOther: true } ),
+		] );
+	} );
+} );
+
+describe( 'Stats email breakdown localization', () => {
+	afterEach( () => {
+		// The i18n instance is a module-level singleton, so drop the locale data
+		// again or the sibling suites stop seeing the untranslated labels.
+		setLocaleData( {}, 'jetpack-premium-analytics' );
+	} );
+
+	it( 'translates the catch-all label and keeps it pinned last', () => {
+		setLocaleData( { Other: [ 'Sonstige' ] }, 'jetpack-premium-analytics' );
+
+		const items = sanitizeStatsEmailBreakdownResponse( emailFieldlessClientsFixture ).data[ 0 ]
+			.items;
+
+		expect( items.map( item => item.label ) ).toEqual( [ 'Apple Mail', 'Gmail', 'Sonstige' ] );
+	} );
+
+	it( 'translates internal link type labels', () => {
+		setLocaleData(
+			{ 'Post URL': [ 'URL des Beitrags' ], Like: [ 'Gefällt mir' ] },
+			'jetpack-premium-analytics'
+		);
+
+		const items = sanitizeStatsEmailBreakdownResponse( emailFieldlessLinksFixture ).data[ 0 ].items;
+
+		expect( items.map( item => item.label ) ).toEqual(
+			expect.arrayContaining( [ 'URL des Beitrags', 'Gefällt mir' ] )
+		);
+	} );
+
+	it( 'translates the unknown-country fallback label', () => {
+		setLocaleData( { Unknown: [ 'Unbekannt' ] }, 'jetpack-premium-analytics' );
+
+		const items = sanitizeStatsEmailBreakdownResponse( emailFieldlessCountriesFixture ).data[ 0 ]
+			.items;
+
+		expect( items.map( item => item.label ) ).toContain( 'Unbekannt' );
+	} );
+} );
+
+describe( 'compareEmailBreakdownItems', () => {
+	it( 'pins the catch-all row last even when its label is localized', () => {
+		const rows = [
+			{ label: 'Sonstige', value: 500, isOther: true },
+			{ label: 'Gmail', value: 8 },
+			{ label: 'Apple Mail', value: 10 },
+		];
+
+		expect( [ ...rows ].sort( compareEmailBreakdownItems ).map( row => row.label ) ).toEqual( [
+			'Apple Mail',
+			'Gmail',
+			'Sonstige',
+		] );
+	} );
+
+	it( 'sorts an unflagged row labelled "Other" by value like any other row', () => {
+		const rows = [
+			{ label: 'Gmail', value: 8 },
+			{ label: 'Other', value: 500 },
+		];
+
+		expect( [ ...rows ].sort( compareEmailBreakdownItems ).map( row => row.label ) ).toEqual( [
+			'Other',
+			'Gmail',
 		] );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/email-breakdown.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/email-breakdown.test.ts
@@ -5,6 +5,7 @@ import {
 	emailFieldlessClientsFixture,
 	emailFieldlessCountriesFixture,
 	emailFieldlessLinksFixture,
+	emailMatrixClientsFixture,
 } from '../__fixtures__/email-breakdown';
 
 describe( 'Stats email breakdown normalizer', () => {
@@ -72,6 +73,16 @@ describe( 'Stats email breakdown normalizer', () => {
 			expect.objectContaining( { label: 'Apple Mail', value: 10 } ),
 			expect.objectContaining( { label: 'Gmail', value: 8 } ),
 			expect.objectContaining( { label: 'Other', value: 9, isOther: true } ),
+		] );
+	} );
+
+	it( 'normalizes matrix email clients and keeps Other last', () => {
+		expect(
+			sanitizeStatsEmailBreakdownResponse( emailMatrixClientsFixture ).data[ 0 ].items
+		).toEqual( [
+			expect.objectContaining( { label: 'Apple Mail', value: 200 } ),
+			expect.objectContaining( { label: 'Thunderbird', value: 180 } ),
+			expect.objectContaining( { label: 'Other', value: 265, isOther: true } ),
 		] );
 	} );
 

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/email-breakdown.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/email-breakdown.test.ts
@@ -1,4 +1,4 @@
-import { setLocaleData } from '@wordpress/i18n';
+import { resetLocaleData, setLocaleData } from '@wordpress/i18n';
 import { compareEmailBreakdownItems, sanitizeStatsEmailBreakdownResponse } from '..';
 import {
 	emailCountriesFixture,
@@ -103,7 +103,7 @@ describe( 'Stats email breakdown localization', () => {
 	afterEach( () => {
 		// The i18n instance is a module-level singleton, so drop the locale data
 		// again or the sibling suites stop seeing the untranslated labels.
-		setLocaleData( {}, 'jetpack-premium-analytics' );
+		resetLocaleData( {}, 'jetpack-premium-analytics' );
 	} );
 
 	it( 'translates the catch-all label and keeps it pinned last', () => {
@@ -117,14 +117,18 @@ describe( 'Stats email breakdown localization', () => {
 
 	it( 'translates internal link type labels', () => {
 		setLocaleData(
-			{ 'Post URL': [ 'URL des Beitrags' ], Like: [ 'Gefällt mir' ] },
+			{
+				'Email link type\u0004Post URL': [ 'URL des Beitrags' ],
+				'Email link type\u0004Like': [ 'Gefällt mir' ],
+				'Email link type\u0004Other': [ 'Sonstige Links' ],
+			},
 			'jetpack-premium-analytics'
 		);
 
 		const items = sanitizeStatsEmailBreakdownResponse( emailFieldlessLinksFixture ).data[ 0 ].items;
 
 		expect( items.map( item => item.label ) ).toEqual(
-			expect.arrayContaining( [ 'URL des Beitrags', 'Gefällt mir' ] )
+			expect.arrayContaining( [ 'URL des Beitrags', 'Gefällt mir', 'Sonstige Links' ] )
 		);
 	} );
 

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/email-breakdown.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/email-breakdown.ts
@@ -287,7 +287,7 @@ function parseStatsEmailBreakdownRows( response: unknown ): {
 		};
 	} );
 
-	return { items, metricKey };
+	return { items: sortEmailBreakdownItems( items ), metricKey };
 }
 
 export function sanitizeStatsEmailBreakdownResponse(

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/email-breakdown.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/email-breakdown.ts
@@ -1,3 +1,4 @@
+import { __ } from '@wordpress/i18n';
 import { safeParseFloat } from '../../utils/parsing';
 import { coerceStatsArray, coerceStatsRecord, createStatsListDataPoint } from './utils';
 import type { StatsNormalizedItemBase, StatsNormalizedReport, StatsRecord } from './types';
@@ -8,15 +9,58 @@ export interface StatsEmailBreakdownItem extends StatsNormalizedItemBase< null >
 	countryCode?: string;
 	countryFull?: unknown;
 	link?: string;
+	/**
+	 * Marks the aggregated catch-all row, which always sorts last. Consumers must
+	 * key off this rather than the label, which is localized.
+	 */
+	isOther?: boolean;
 	[ key: string ]: unknown;
 }
 
-const emailLinkLabels: Record< string, string > = {
-	'post-url': 'Post URL',
-	'like-post': 'Like',
-	'comment-post': 'Comment',
-	'remove-subscription': 'Unsubscribe',
-};
+const EMAIL_LINK_TYPES = [
+	'post-url',
+	'like-post',
+	'comment-post',
+	'remove-subscription',
+] as const;
+
+type EmailLinkType = ( typeof EMAIL_LINK_TYPES )[ number ];
+
+/**
+ * The literal WPCOM returns for its aggregated bucket in the `clients` and
+ * `devices` breakdowns. Matching it here, at the API boundary, is what lets the
+ * row carry a localized label while sorting stays keyed on `isOther`.
+ */
+const API_OTHER_BUCKET = 'Other';
+
+function isEmailLinkType( value: unknown ): value is EmailLinkType {
+	return typeof value === 'string' && EMAIL_LINK_TYPES.includes( value as EmailLinkType );
+}
+
+/**
+ * Display label for a known internal email link type. Resolved per call, not from
+ * a module-level map, so the strings translate against the locale data loaded at
+ * render time rather than whatever was loaded when this module was imported.
+ *
+ * @param linkType - The internal link type reported by the API.
+ * @return The localized display label.
+ */
+function emailLinkLabel( linkType: EmailLinkType ): string {
+	switch ( linkType ) {
+		case 'post-url':
+			return __( 'Post URL', 'jetpack-premium-analytics' );
+		case 'like-post':
+			return __( 'Like', 'jetpack-premium-analytics' );
+		case 'comment-post':
+			return __( 'Comment', 'jetpack-premium-analytics' );
+		case 'remove-subscription':
+			return __( 'Unsubscribe', 'jetpack-premium-analytics' );
+	}
+}
+
+function otherLabel(): string {
+	return __( 'Other', 'jetpack-premium-analytics' );
+}
 
 function isEmailBreakdownSummaryValue( value: unknown ): boolean {
 	return (
@@ -34,25 +78,29 @@ function normalizeEmailBreakdownScalarSummary( response: StatsRecord ) {
 }
 
 /**
- * Comparator ordering breakdown items by value, descending, with the
- * aggregated "Other" row pinned last. Exported for consumers that merge rows
- * from several breakdown reports and need to restore this order — e.g. the
- * email breakdown widget's links view.
+ * Comparator ordering breakdown items by value, descending, with the aggregated
+ * catch-all row pinned last. Exported for consumers that merge rows from several
+ * breakdown reports and need to restore this order — e.g. the email breakdown
+ * widget's links view.
+ *
+ * Pinning keys on `isOther`, never on the label: the label is localized, so a
+ * string comparison would silently stop matching in every non-English locale.
  *
  * @param a - The first item.
  * @param b - The second item.
  * @return A standard comparator result.
  */
 export function compareEmailBreakdownItems(
-	a: Pick< StatsEmailBreakdownItem, 'label' | 'value' >,
-	b: Pick< StatsEmailBreakdownItem, 'label' | 'value' >
+	a: Pick< StatsEmailBreakdownItem, 'value' | 'isOther' >,
+	b: Pick< StatsEmailBreakdownItem, 'value' | 'isOther' >
 ): number {
-	if ( a.label === 'Other' ) {
-		return 1;
-	}
+	// Coerce: rows from breakdowns that have no catch-all bucket omit the flag
+	// entirely, so `undefined` and `false` must compare equal.
+	const aIsOther = Boolean( a.isOther );
+	const bIsOther = Boolean( b.isOther );
 
-	if ( b.label === 'Other' ) {
-		return -1;
+	if ( aIsOther !== bIsOther ) {
+		return aIsOther ? 1 : -1;
 	}
 
 	return b.value - a.value;
@@ -73,7 +121,7 @@ function parseFieldlessEmailCountryRows( response: StatsRecord ): StatsEmailBrea
 			const countryFull = country.country_full;
 
 			return {
-				label: countryFull ?? 'Unknown',
+				label: countryFull ?? __( 'Unknown', 'jetpack-premium-analytics' ),
 				value: safeParseFloat( row[ 1 ] ),
 				countryCode: countryFull ? countryCode : undefined,
 				countryFull,
@@ -91,11 +139,16 @@ function parseFieldlessEmailListRows(
 	const rows = coerceStatsArray< unknown[] >( coerceStatsRecord( response[ key ] ).data );
 
 	return sortEmailBreakdownItems(
-		rows.map( row => ( {
-			label: row[ 0 ],
-			value: safeParseFloat( row[ 1 ] ),
-			children: null,
-		} ) )
+		rows.map( row => {
+			const isOther = row[ 0 ] === API_OTHER_BUCKET;
+
+			return {
+				label: isOther ? otherLabel() : row[ 0 ],
+				value: safeParseFloat( row[ 1 ] ),
+				...( isOther && { isOther: true } ),
+				children: null,
+			};
+		} )
 	);
 }
 
@@ -104,25 +157,34 @@ function parseFieldlessEmailLinkRows( response: StatsRecord ): StatsEmailBreakdo
 	const userContentLinks = coerceStatsArray< unknown[] >(
 		coerceStatsRecord( response[ 'user-content-links' ] ).data
 	);
-	const items: StatsEmailBreakdownItem[] = internalLinks
-		.filter( row => typeof row[ 0 ] === 'string' && emailLinkLabels[ row[ 0 ] ] )
-		.map( row => ( {
-			label: emailLinkLabels[ String( row[ 0 ] ) ],
-			value: safeParseFloat( row[ 1 ] ),
-			children: null,
-		} ) );
-	const otherInternalLinks = internalLinks.reduce( ( total, row ) => {
-		const linkType = String( row[ 0 ] ?? '' );
+	// flatMap rather than filter+map: the type guard narrows `linkType` for the
+	// `emailLinkLabel` call, which a separate filter step would not.
+	const items: StatsEmailBreakdownItem[] = internalLinks.flatMap( row => {
+		const linkType = row[ 0 ];
 
-		return emailLinkLabels[ linkType ] || linkType === 'user_link'
+		return isEmailLinkType( linkType )
+			? [
+					{
+						label: emailLinkLabel( linkType ),
+						value: safeParseFloat( row[ 1 ] ),
+						children: null,
+					},
+			  ]
+			: [];
+	} );
+	const otherInternalLinks = internalLinks.reduce( ( total, row ) => {
+		const linkType = row[ 0 ];
+
+		return isEmailLinkType( linkType ) || linkType === 'user_link'
 			? total
 			: total + safeParseFloat( row[ 1 ] );
 	}, 0 );
 
 	if ( otherInternalLinks ) {
 		items.push( {
-			label: 'Other',
+			label: otherLabel(),
 			value: otherInternalLinks,
+			isOther: true,
 			children: null,
 		} );
 	}
@@ -197,15 +259,23 @@ function parseStatsEmailBreakdownRows( response: unknown ): {
 			}
 		} );
 
-		const country = coerceStatsRecord( countryInfo[ String( parsed[ labelKey ] ) ] );
+		const rawLabel = parsed[ labelKey ];
+		const country = coerceStatsRecord( countryInfo[ String( rawLabel ) ] );
 		// Matrix link payloads keep their API labels; fieldless all-time link payloads map known
 		// link types to display labels to match the legacy email stats parser.
-		const label =
-			matrixKey === 'countries' ? country.country_full ?? parsed[ labelKey ] : parsed[ labelKey ];
+		const isOther = matrixKey !== 'countries' && rawLabel === API_OTHER_BUCKET;
+		let label = rawLabel;
+
+		if ( isOther ) {
+			label = otherLabel();
+		} else if ( matrixKey === 'countries' ) {
+			label = country.country_full ?? rawLabel;
+		}
 
 		return {
 			...parsed,
 			label,
+			...( isOther && { isOther: true } ),
 			value: safeParseFloat( parsed[ metricKey ] ),
 			countryCode: matrixKey === 'countries' ? String( parsed[ labelKey ] ) : undefined,
 			countryFull: country.country_full,

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/email-breakdown.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/email-breakdown.ts
@@ -1,4 +1,4 @@
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { safeParseFloat } from '../../utils/parsing';
 import { coerceStatsArray, coerceStatsRecord, createStatsListDataPoint } from './utils';
 import type { StatsNormalizedItemBase, StatsNormalizedReport, StatsRecord } from './types';
@@ -48,18 +48,22 @@ function isEmailLinkType( value: unknown ): value is EmailLinkType {
 function emailLinkLabel( linkType: EmailLinkType ): string {
 	switch ( linkType ) {
 		case 'post-url':
-			return __( 'Post URL', 'jetpack-premium-analytics' );
+			return _x( 'Post URL', 'Email link type', 'jetpack-premium-analytics' );
 		case 'like-post':
-			return __( 'Like', 'jetpack-premium-analytics' );
+			return _x( 'Like', 'Email link type', 'jetpack-premium-analytics' );
 		case 'comment-post':
-			return __( 'Comment', 'jetpack-premium-analytics' );
+			return _x( 'Comment', 'Email link type', 'jetpack-premium-analytics' );
 		case 'remove-subscription':
-			return __( 'Unsubscribe', 'jetpack-premium-analytics' );
+			return _x( 'Unsubscribe', 'Email link type', 'jetpack-premium-analytics' );
 	}
 }
 
 function otherLabel(): string {
 	return __( 'Other', 'jetpack-premium-analytics' );
+}
+
+function otherEmailLinkLabel(): string {
+	return _x( 'Other', 'Email link type', 'jetpack-premium-analytics' );
 }
 
 function isEmailBreakdownSummaryValue( value: unknown ): boolean {
@@ -182,7 +186,7 @@ function parseFieldlessEmailLinkRows( response: StatsRecord ): StatsEmailBreakdo
 
 	if ( otherInternalLinks ) {
 		items.push( {
-			label: otherLabel(),
+			label: otherEmailLinkLabel(),
 			value: otherInternalLinks,
 			isOther: true,
 			children: null,

--- a/projects/packages/premium-analytics/widgets/email-breakdown/__tests__/email-breakdown.test.tsx
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/__tests__/email-breakdown.test.tsx
@@ -56,11 +56,14 @@ const COUNTRY_RESPONSE = {
 	},
 };
 
+// `some-other-internal` aggregates into the catch-all row and outranks every other
+// row by value, so the fixture proves that row is pinned last across the merge
+// rather than just landing there.
 const INTERNAL_LINKS_RESPONSE = {
 	links: {
 		data: [
 			[ 'post-url', 640 ],
-			[ 'some-other-internal', 22 ],
+			[ 'some-other-internal', 900 ],
 		],
 	},
 };
@@ -195,7 +198,13 @@ describe( 'EmailBreakdownWidget', () => {
 		// Known internal link types are mapped to display labels; unknown ones are
 		// aggregated into "Other".
 		expect( screen.getByText( 'Post URL' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Other' ) ).toBeInTheDocument();
+		const otherRow = screen.getByText( 'Other' );
+		expect( otherRow ).toBeInTheDocument();
+
+		// The catch-all row stays pinned last after the two breakdowns are merged
+		// and re-sorted, even though it holds the highest value. The two nodes sit in
+		// separate rows, so the position mask is exactly PRECEDING or FOLLOWING.
+		expect( otherRow.compareDocumentPosition( link ) ).toBe( Node.DOCUMENT_POSITION_PRECEDING );
 
 		// The links view fetches both clicks breakdowns, matching Calypso.
 		const requestedPaths = mockApiFetch.mock.calls.map( call => call[ 0 ].path as string );

--- a/projects/packages/premium-analytics/widgets/email-breakdown/use-email-breakdown-rows.ts
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/use-email-breakdown-rows.ts
@@ -44,6 +44,12 @@ export type EmailBreakdownRow = {
 	 * External URL, present only for clicked user-content links (`links` view).
 	 */
 	link?: string;
+	/**
+	 * Marks the aggregated catch-all row. Must be carried through from the data
+	 * layer: `compareEmailBreakdownItems` pins the row by this flag, and the label
+	 * is localized, so dropping it silently unpins the row.
+	 */
+	isOther?: boolean;
 };
 
 /**
@@ -76,6 +82,7 @@ function toRows( report: StatsEmailBreakdown | undefined ): Omit< EmailBreakdown
 		countryCode: item.countryCode,
 		countryFull: item.countryFull ? String( item.countryFull ) : undefined,
 		link: item.link,
+		isOther: item.isOther,
 	} ) );
 }
 


### PR DESCRIPTION
Fixes WOOA7S-1679

## Proposed changes

**Why**

The email breakdown sanitizer emitted hardcoded English row labels — `Post URL`, `Like`, `Comment`, `Unsubscribe`, `Other`, `Unknown` — so non-English users saw English strings in the links, countries, devices and clients views. Sorting also pinned the aggregated row last by comparing its label to the literal `'Other'`, which meant localizing the label would silently break the sort. The two had to change together.

**How**

* Labels now go through `__()`. They are resolved **per call** rather than from a module-level map, so they translate against the locale data loaded at render time instead of whatever was loaded when the module was first imported.
* Rows carry an `isOther` flag and `compareEmailBreakdownItems` keys on it, never on the label. The flag is coerced with `Boolean()` because breakdowns with no catch-all bucket omit it entirely, so `undefined` and `false` must compare equal.
* WPCOM returns its **own** `Other` bucket in the `clients` and `devices` breakdowns (it is not only a row we synthesize). That bucket is now recognized at the API boundary and flagged there, which keeps the raw string out of sorting and lets the row carry a localized label. Without this the clients/devices views would have lost their pinning the moment the label was translated — in the fixtures `Other` (265) outranks Thunderbird (180), so the pin is load-bearing.
* `use-email-breakdown-rows.ts` carries `isOther` through into `EmailBreakdownRow`. The widget re-sorts merged rows in the links view, so dropping the flag there would unpin the row — and because the field is optional, TypeScript does **not** catch it. There is now a test that does.

**What**

* `packages/data/src/processing/stats/email-breakdown.ts` — localized labels, `isOther` flag, flag-based comparator, API bucket normalized in both the fieldless and matrix parse paths.
* `widgets/email-breakdown/use-email-breakdown-rows.ts` — carry `isOther` through.
* Tests + fixtures.

## Related product discussion/links

* WOOA7S-1679 (follow-up from the WOOA7S-1517 / #50308 review)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions


1. `cd projects/js-packages/storybook && pnpm exec storybook dev`
2. Open **Packages / Premium Analytics / Widgets / EmailBreakdown → Default**.
3. Switch the `view` control to `clients`. `Other` (265) must still render **below** Thunderbird (180) despite the higher value.
4. Switch to `countries` and `links` and confirm rows render as before.


<img width="2560" height="1325" alt="Screenshot 2026-07-21 at 5 57 01 PM" src="https://github.com/user-attachments/assets/3bf33563-042c-4ddf-ad14-a01927e1d92b" />

<img width="2560" height="1323" alt="Screenshot 2026-07-21 at 5 57 22 PM" src="https://github.com/user-attachments/assets/438fc338-7edb-4067-a7b0-8f6b49666c49" />
