### PR TITLE
wpcomsh: ignore Gutenberg plugin when older than core's bundled version

### DIFF
--- a/projects/plugins/wpcomsh/changelog/ignore-gutenberg-plugin-on-wp-beta
+++ b/projects/plugins/wpcomsh/changelog/ignore-gutenberg-plugin-on-wp-beta
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: patch
 Type: added
 
 Ignore the Gutenberg plugin when it is older than the Gutenberg version bundled in the running WordPress core, so the site uses the newer core-bundled Gutenberg.

--- a/projects/plugins/wpcomsh/changelog/ignore-gutenberg-plugin-on-wp-beta
+++ b/projects/plugins/wpcomsh/changelog/ignore-gutenberg-plugin-on-wp-beta
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Ignore the Gutenberg plugin when it is older than the Gutenberg version bundled in the running WordPress core, so the site uses the newer core-bundled Gutenberg.
+On the WordPress beta track, ignore the Gutenberg plugin when it is older than the Gutenberg version bundled in the running WordPress core, so the site uses the newer core-bundled Gutenberg.

--- a/projects/plugins/wpcomsh/changelog/ignore-gutenberg-plugin-on-wp-beta
+++ b/projects/plugins/wpcomsh/changelog/ignore-gutenberg-plugin-on-wp-beta
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Ignore the Gutenberg plugin on sites running a beta build of WordPress core so the core-bundled block editor is used, and expose the editor source and WP version from the gutenberg-version endpoint.
+Ignore the Gutenberg plugin on sites running a beta build of WordPress core so the core-bundled Gutenberg is used.

--- a/projects/plugins/wpcomsh/changelog/ignore-gutenberg-plugin-on-wp-beta
+++ b/projects/plugins/wpcomsh/changelog/ignore-gutenberg-plugin-on-wp-beta
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Ignore the Gutenberg plugin on sites running a beta build of WordPress core so the core-bundled Gutenberg is used.
+Ignore the Gutenberg plugin when it is older than the Gutenberg version bundled in the running WordPress core, so the site uses the newer core-bundled Gutenberg.

--- a/projects/plugins/wpcomsh/changelog/ignore-gutenberg-plugin-on-wp-beta
+++ b/projects/plugins/wpcomsh/changelog/ignore-gutenberg-plugin-on-wp-beta
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Ignore the Gutenberg plugin on sites running a beta build of WordPress core so the core-bundled block editor is used, and expose the editor source and WP version from the gutenberg-version endpoint.

--- a/projects/plugins/wpcomsh/endpoints/rest-api-gutenberg-version.php
+++ b/projects/plugins/wpcomsh/endpoints/rest-api-gutenberg-version.php
@@ -10,26 +10,19 @@
  */
 
 /**
- * Returns the active Gutenberg version and where it comes from.
+ * Returns the active Gutenberg plugin version, or null if the plugin is not active.
  *
- * When the Gutenberg plugin is active, `version` is its release number and `source`
- * is `plugin`. Otherwise the block editor is served by WordPress core's bundle, which
- * carries no discrete Gutenberg version constant; in that case `version` is null,
- * `source` is `core`, and `wp_version` is returned so tooling can map the core release
- * to its bundled editor.
+ * On WordPress beta builds the Gutenberg plugin is ignored in favor of the
+ * core-bundled Gutenberg, which carries no version constant, so null is returned.
  *
  * @return WP_REST_Response
  */
 function wpcomsh_rest_api_gutenberg_version() {
-	global $wp_version;
-
-	$version = defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : null;
+	$version = ( ! wpcomsh_is_wp_beta_version() && defined( 'GUTENBERG_VERSION' ) ) ? GUTENBERG_VERSION : null;
 
 	return new WP_REST_Response(
 		array(
-			'version'    => $version,
-			'source'     => null === $version ? 'core' : 'plugin',
-			'wp_version' => is_string( $wp_version ) ? $wp_version : null,
+			'version' => $version,
 		),
 		200
 	);

--- a/projects/plugins/wpcomsh/endpoints/rest-api-gutenberg-version.php
+++ b/projects/plugins/wpcomsh/endpoints/rest-api-gutenberg-version.php
@@ -10,16 +10,26 @@
  */
 
 /**
- * Returns the active Gutenberg plugin version, or null if the plugin is not active.
+ * Returns the active Gutenberg version and where it comes from.
+ *
+ * When the Gutenberg plugin is active, `version` is its release number and `source`
+ * is `plugin`. Otherwise the block editor is served by WordPress core's bundle, which
+ * carries no discrete Gutenberg version constant; in that case `version` is null,
+ * `source` is `core`, and `wp_version` is returned so tooling can map the core release
+ * to its bundled editor.
  *
  * @return WP_REST_Response
  */
 function wpcomsh_rest_api_gutenberg_version() {
+	global $wp_version;
+
 	$version = defined( 'GUTENBERG_VERSION' ) ? GUTENBERG_VERSION : null;
 
 	return new WP_REST_Response(
 		array(
-			'version' => $version,
+			'version'    => $version,
+			'source'     => null === $version ? 'core' : 'plugin',
+			'wp_version' => is_string( $wp_version ) ? $wp_version : null,
 		),
 		200
 	);

--- a/projects/plugins/wpcomsh/endpoints/rest-api-gutenberg-version.php
+++ b/projects/plugins/wpcomsh/endpoints/rest-api-gutenberg-version.php
@@ -10,10 +10,7 @@
  */
 
 /**
- * Returns the active Gutenberg plugin version, or null if the plugin is not active.
- *
- * When the Gutenberg plugin is ignored in favor of the core-bundled Gutenberg, which
- * carries no version constant, null is returned.
+ * Returns the active Gutenberg plugin version, or null if the plugin is inactive or ignored.
  *
  * @return WP_REST_Response
  */

--- a/projects/plugins/wpcomsh/endpoints/rest-api-gutenberg-version.php
+++ b/projects/plugins/wpcomsh/endpoints/rest-api-gutenberg-version.php
@@ -12,13 +12,13 @@
 /**
  * Returns the active Gutenberg plugin version, or null if the plugin is not active.
  *
- * On WordPress beta builds the Gutenberg plugin is ignored in favor of the
- * core-bundled Gutenberg, which carries no version constant, so null is returned.
+ * When the Gutenberg plugin is ignored in favor of the core-bundled Gutenberg, which
+ * carries no version constant, null is returned.
  *
  * @return WP_REST_Response
  */
 function wpcomsh_rest_api_gutenberg_version() {
-	$version = ( ! wpcomsh_is_wp_beta_version() && defined( 'GUTENBERG_VERSION' ) ) ? GUTENBERG_VERSION : null;
+	$version = ( ! wpcomsh_is_gutenberg_plugin_ignored() && defined( 'GUTENBERG_VERSION' ) ) ? GUTENBERG_VERSION : null;
 
 	return new WP_REST_Response(
 		array(

--- a/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
+++ b/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
@@ -24,7 +24,7 @@ add_action( 'muplugins_loaded', 'wpcomsh_register_ignore_outdated_gutenberg_plug
  * @see https://developer.wordpress.org/block-editor/contributors/versions-in-wordpress/
  */
 const WPCOMSH_CORE_BUNDLED_GUTENBERG_VERSIONS = array(
-	'7.1' => '23.6',
+	'7.1' => '23.6.0',
 );
 
 /**

--- a/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
+++ b/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
@@ -15,18 +15,13 @@
 add_filter( 'default_option_gutenberg-experiments', 'wpcomsh_filter_gutenberg_experiments' );
 add_filter( 'option_gutenberg-experiments', 'wpcomsh_filter_gutenberg_experiments' );
 
-// Ignore the Gutenberg plugin when it is older than the Gutenberg version bundled in core,
-// so the site uses core's newer bundled Gutenberg instead of an outdated plugin.
+// Ignore the Gutenberg plugin when it is older than the version bundled in core.
 add_filter( 'option_active_plugins', 'wpcomsh_ignore_outdated_gutenberg_plugin' );
 
 /**
  * Minimum Gutenberg version bundled in each WordPress major release.
  *
- * Core exposes no Gutenberg version of its own, and the mapping lives outside core
- * (https://developer.wordpress.org/block-editor/contributors/versions-in-wordpress/),
- * so it is hard-coded here. Values are a minimum: beta, RC, and point releases cherry-pick
- * fixes from later Gutenberg versions, so the true bundled version may be a little higher.
- * Extend this list as new WordPress majors ship.
+ * @see https://developer.wordpress.org/block-editor/contributors/versions-in-wordpress/
  */
 const WPCOMSH_CORE_BUNDLED_GUTENBERG_VERSIONS = array(
 	'7.1' => '23.6',
@@ -48,10 +43,9 @@ function wpcomsh_get_core_bundled_gutenberg_version() {
 }
 
 /**
- * Returns the version of the installed Gutenberg plugin, or null if it can't be read.
+ * Returns the installed Gutenberg plugin version, or null if it can't be read.
  *
- * Reads the plugin header rather than the GUTENBERG_VERSION constant because this runs at
- * the `option_active_plugins` filter, before the Gutenberg plugin is loaded.
+ * Reads the plugin header, as this runs before the plugin (and GUTENBERG_VERSION) loads.
  *
  * @return string|null
  */
@@ -68,10 +62,7 @@ function wpcomsh_get_installed_gutenberg_plugin_version() {
 }
 
 /**
- * Whether the installed Gutenberg plugin should be ignored in favor of core's bundled Gutenberg.
- *
- * Only ignores the plugin when both versions are known and the plugin is older than the
- * version bundled in core; when either version is unknown the plugin is left active.
+ * Whether the plugin version is older than the version bundled in core (both must be known).
  *
  * @param string|null $plugin_version      Installed Gutenberg plugin version.
  * @param string|null $min_bundled_version Minimum Gutenberg version bundled in the running core.
@@ -98,11 +89,9 @@ function wpcomsh_is_gutenberg_plugin_ignored() {
 }
 
 /**
- * Ignore the Gutenberg plugin when it is older than the Gutenberg version bundled in core.
+ * Drop the Gutenberg plugin from the active plugins list when it is older than core's bundle.
  *
- * Removing it from the active plugins list at load time embraces the core-bundled Gutenberg
- * without touching the stored option, so the plugin returns once it is updated past the bundle
- * or the site moves to a WordPress version that bundles an older Gutenberg.
+ * The stored option is left untouched, so the plugin returns once it is updated past the bundle.
  *
  * @param mixed $plugins Value of the active_plugins option.
  * @return mixed

--- a/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
+++ b/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
@@ -15,8 +15,8 @@
 add_filter( 'default_option_gutenberg-experiments', 'wpcomsh_filter_gutenberg_experiments' );
 add_filter( 'option_gutenberg-experiments', 'wpcomsh_filter_gutenberg_experiments' );
 
-// Ignore the Gutenberg plugin when it is older than the version bundled in core.
-add_filter( 'option_active_plugins', 'wpcomsh_ignore_outdated_gutenberg_plugin' );
+// Ignore the Gutenberg plugin when it is older than the version bundled in core, on beta-track sites.
+add_action( 'muplugins_loaded', 'wpcomsh_register_ignore_outdated_gutenberg_plugin' );
 
 /**
  * Minimum Gutenberg version bundled in each WordPress major release.
@@ -26,6 +26,40 @@ add_filter( 'option_active_plugins', 'wpcomsh_ignore_outdated_gutenberg_plugin' 
 const WPCOMSH_CORE_BUNDLED_GUTENBERG_VERSIONS = array(
 	'7.1' => '23.6',
 );
+
+/**
+ * Attach the active-plugins filter only while core loads plugins, and only on the beta track.
+ *
+ * The filter is registered on `muplugins_loaded` and removed on `plugins_loaded`, so it only
+ * affects the read that core makes to load plugins. Outside that window the stored option is
+ * returned untouched, so the trimmed list can never be read and saved back to the database
+ * (which would deactivate the plugin permanently).
+ */
+function wpcomsh_register_ignore_outdated_gutenberg_plugin() {
+	if ( ! wpcomsh_is_wp_beta_version() ) {
+		return;
+	}
+
+	add_filter( 'option_active_plugins', 'wpcomsh_ignore_outdated_gutenberg_plugin' );
+	add_action(
+		'plugins_loaded',
+		static function () {
+			remove_filter( 'option_active_plugins', 'wpcomsh_ignore_outdated_gutenberg_plugin' );
+		},
+		0
+	);
+}
+
+/**
+ * Whether the site is running a pre-release (alpha/beta/RC) build of WordPress core.
+ *
+ * @return bool
+ */
+function wpcomsh_is_wp_beta_version() {
+	global $wp_version;
+
+	return is_string( $wp_version ) && (bool) preg_match( '/-(alpha|beta|RC)/i', $wp_version );
+}
 
 /**
  * Returns the minimum Gutenberg version bundled in the running WordPress core, or null if unknown.
@@ -62,14 +96,15 @@ function wpcomsh_get_installed_gutenberg_plugin_version() {
 }
 
 /**
- * Whether the plugin version is older than the version bundled in core (both must be known).
+ * Whether the plugin should be ignored: the site is on the beta track and the installed
+ * plugin is older than core's bundle (both versions must be known).
  *
  * @param string|null $plugin_version      Installed Gutenberg plugin version.
  * @param string|null $min_bundled_version Minimum Gutenberg version bundled in the running core.
  * @return bool
  */
 function wpcomsh_should_ignore_gutenberg_plugin( $plugin_version, $min_bundled_version ) {
-	if ( null === $plugin_version || null === $min_bundled_version ) {
+	if ( ! wpcomsh_is_wp_beta_version() || null === $plugin_version || null === $min_bundled_version ) {
 		return false;
 	}
 

--- a/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
+++ b/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
@@ -15,51 +15,111 @@
 add_filter( 'default_option_gutenberg-experiments', 'wpcomsh_filter_gutenberg_experiments' );
 add_filter( 'option_gutenberg-experiments', 'wpcomsh_filter_gutenberg_experiments' );
 
-// Ignore the Gutenberg plugin on beta builds of WordPress so the core-bundled Gutenberg is used.
-add_filter( 'option_active_plugins', 'wpcomsh_ignore_gutenberg_plugin_on_wp_beta' );
+// Ignore the Gutenberg plugin when it is older than the Gutenberg version bundled in core,
+// so the site uses core's newer bundled Gutenberg instead of an outdated plugin.
+add_filter( 'option_active_plugins', 'wpcomsh_ignore_outdated_gutenberg_plugin' );
 
 /**
- * Whether the site is running a pre-release (beta/RC/nightly) build of WordPress core.
+ * Minimum Gutenberg version bundled in each WordPress major release.
  *
- * Development builds carry an `-alpha`, `-beta`, or `-RC` suffix (e.g. `6.9-beta2`,
- * `6.9-RC1-59400`), whereas stable releases do not (e.g. `6.6.1`). WordPress.com
- * surfaces the pre-release track as the site's "beta" WP version.
- *
- * @return bool
+ * Core exposes no Gutenberg version of its own, and the mapping lives outside core
+ * (https://developer.wordpress.org/block-editor/contributors/versions-in-wordpress/),
+ * so it is hard-coded here. Values are a minimum: beta, RC, and point releases cherry-pick
+ * fixes from later Gutenberg versions, so the true bundled version may be a little higher.
+ * Extend this list as new WordPress majors ship.
  */
-function wpcomsh_is_wp_beta_version() {
+const WPCOMSH_CORE_BUNDLED_GUTENBERG_VERSIONS = array(
+	'7.1' => '23.6',
+);
+
+/**
+ * Returns the minimum Gutenberg version bundled in the running WordPress core, or null if unknown.
+ *
+ * @return string|null
+ */
+function wpcomsh_get_core_bundled_gutenberg_version() {
 	global $wp_version;
 
-	if ( ! is_string( $wp_version ) || '' === $wp_version ) {
-		return false;
+	if ( ! is_string( $wp_version ) || ! preg_match( '/^(\d+\.\d+)/', $wp_version, $matches ) ) {
+		return null;
 	}
 
-	return (bool) preg_match( '/-(alpha|beta|RC)/i', $wp_version );
+	return WPCOMSH_CORE_BUNDLED_GUTENBERG_VERSIONS[ $matches[1] ] ?? null;
 }
 
 /**
- * Ignore the Gutenberg plugin on sites running a beta build of WordPress core.
+ * Returns the version of the installed Gutenberg plugin, or null if it can't be read.
  *
- * Beta/RC builds already bundle a matching Gutenberg, so keeping the Gutenberg
- * plugin active on top can shadow core with an older or incompatible version. Removing
- * it from the active plugins list at load time embraces the core-bundled Gutenberg without
- * touching the stored option, so the plugin returns once the site leaves the beta track.
+ * Reads the plugin header rather than the GUTENBERG_VERSION constant because this runs at
+ * the `option_active_plugins` filter, before the Gutenberg plugin is loaded.
+ *
+ * @return string|null
+ */
+function wpcomsh_get_installed_gutenberg_plugin_version() {
+	$plugin_file = WP_PLUGIN_DIR . '/gutenberg/gutenberg.php';
+
+	if ( ! is_readable( $plugin_file ) ) {
+		return null;
+	}
+
+	$data = get_file_data( $plugin_file, array( 'Version' => 'Version' ) );
+
+	return empty( $data['Version'] ) ? null : $data['Version'];
+}
+
+/**
+ * Whether the installed Gutenberg plugin should be ignored in favor of core's bundled Gutenberg.
+ *
+ * Only ignores the plugin when both versions are known and the plugin is older than the
+ * version bundled in core; when either version is unknown the plugin is left active.
+ *
+ * @param string|null $plugin_version      Installed Gutenberg plugin version.
+ * @param string|null $min_bundled_version Minimum Gutenberg version bundled in the running core.
+ * @return bool
+ */
+function wpcomsh_should_ignore_gutenberg_plugin( $plugin_version, $min_bundled_version ) {
+	if ( null === $plugin_version || null === $min_bundled_version ) {
+		return false;
+	}
+
+	return version_compare( $plugin_version, $min_bundled_version, '<' );
+}
+
+/**
+ * Whether the installed Gutenberg plugin is being ignored in favor of core's bundled Gutenberg.
+ *
+ * @return bool
+ */
+function wpcomsh_is_gutenberg_plugin_ignored() {
+	return wpcomsh_should_ignore_gutenberg_plugin(
+		wpcomsh_get_installed_gutenberg_plugin_version(),
+		wpcomsh_get_core_bundled_gutenberg_version()
+	);
+}
+
+/**
+ * Ignore the Gutenberg plugin when it is older than the Gutenberg version bundled in core.
+ *
+ * Removing it from the active plugins list at load time embraces the core-bundled Gutenberg
+ * without touching the stored option, so the plugin returns once it is updated past the bundle
+ * or the site moves to a WordPress version that bundles an older Gutenberg.
  *
  * @param mixed $plugins Value of the active_plugins option.
  * @return mixed
  */
-function wpcomsh_ignore_gutenberg_plugin_on_wp_beta( $plugins ) {
-	if ( ! is_array( $plugins ) || ! wpcomsh_is_wp_beta_version() ) {
+function wpcomsh_ignore_outdated_gutenberg_plugin( $plugins ) {
+	if ( ! is_array( $plugins ) ) {
 		return $plugins;
 	}
 
 	$key = array_search( 'gutenberg/gutenberg.php', $plugins, true );
-	if ( false !== $key ) {
-		unset( $plugins[ $key ] );
-		$plugins = array_values( $plugins );
+	if ( false === $key || ! wpcomsh_is_gutenberg_plugin_ignored() ) {
+		return $plugins;
 	}
 
-	return $plugins;
+	unset( $plugins[ $key ] );
+
+	return array_values( $plugins );
 }
 
 /**

--- a/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
+++ b/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
@@ -15,7 +15,7 @@
 add_filter( 'default_option_gutenberg-experiments', 'wpcomsh_filter_gutenberg_experiments' );
 add_filter( 'option_gutenberg-experiments', 'wpcomsh_filter_gutenberg_experiments' );
 
-// Ignore the Gutenberg plugin on beta builds of WordPress so the core-bundled block editor is used.
+// Ignore the Gutenberg plugin on beta builds of WordPress so the core-bundled Gutenberg is used.
 add_filter( 'option_active_plugins', 'wpcomsh_ignore_gutenberg_plugin_on_wp_beta' );
 
 /**
@@ -40,9 +40,9 @@ function wpcomsh_is_wp_beta_version() {
 /**
  * Ignore the Gutenberg plugin on sites running a beta build of WordPress core.
  *
- * Beta/RC builds already bundle a matching block editor, so keeping the Gutenberg
- * plugin active on top can shadow core with an older or incompatible editor. Removing
- * it from the active plugins list at load time embraces core's bundled version without
+ * Beta/RC builds already bundle a matching Gutenberg, so keeping the Gutenberg
+ * plugin active on top can shadow core with an older or incompatible version. Removing
+ * it from the active plugins list at load time embraces the core-bundled Gutenberg without
  * touching the stored option, so the plugin returns once the site leaves the beta track.
  *
  * @param mixed $plugins Value of the active_plugins option.

--- a/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
+++ b/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
@@ -15,6 +15,53 @@
 add_filter( 'default_option_gutenberg-experiments', 'wpcomsh_filter_gutenberg_experiments' );
 add_filter( 'option_gutenberg-experiments', 'wpcomsh_filter_gutenberg_experiments' );
 
+// Ignore the Gutenberg plugin on beta builds of WordPress so the core-bundled block editor is used.
+add_filter( 'option_active_plugins', 'wpcomsh_ignore_gutenberg_plugin_on_wp_beta' );
+
+/**
+ * Whether the site is running a pre-release (beta/RC/nightly) build of WordPress core.
+ *
+ * Development builds carry an `-alpha`, `-beta`, or `-RC` suffix (e.g. `6.9-beta2`,
+ * `6.9-RC1-59400`), whereas stable releases do not (e.g. `6.6.1`). WordPress.com
+ * surfaces the pre-release track as the site's "beta" WP version.
+ *
+ * @return bool
+ */
+function wpcomsh_is_wp_beta_version() {
+	global $wp_version;
+
+	if ( ! is_string( $wp_version ) || '' === $wp_version ) {
+		return false;
+	}
+
+	return (bool) preg_match( '/-(alpha|beta|RC)/i', $wp_version );
+}
+
+/**
+ * Ignore the Gutenberg plugin on sites running a beta build of WordPress core.
+ *
+ * Beta/RC builds already bundle a matching block editor, so keeping the Gutenberg
+ * plugin active on top can shadow core with an older or incompatible editor. Removing
+ * it from the active plugins list at load time embraces core's bundled version without
+ * touching the stored option, so the plugin returns once the site leaves the beta track.
+ *
+ * @param mixed $plugins Value of the active_plugins option.
+ * @return mixed
+ */
+function wpcomsh_ignore_gutenberg_plugin_on_wp_beta( $plugins ) {
+	if ( ! is_array( $plugins ) || ! wpcomsh_is_wp_beta_version() ) {
+		return $plugins;
+	}
+
+	$key = array_search( 'gutenberg/gutenberg.php', $plugins, true );
+	if ( false !== $key ) {
+		unset( $plugins[ $key ] );
+		$plugins = array_values( $plugins );
+	}
+
+	return $plugins;
+}
+
 /**
  * Disable all Gutenberg experiments except explicitly allowed ones.
  *

--- a/projects/plugins/wpcomsh/tests/GutenbergModsTest.php
+++ b/projects/plugins/wpcomsh/tests/GutenbergModsTest.php
@@ -47,7 +47,7 @@ class GutenbergModsTest extends WP_UnitTestCase {
 		return array(
 			'mapped major'         => array( '7.1', '23.6' ),
 			'mapped with point'    => array( '7.1.2', '23.6' ),
-			'mapped beta'          => array( '7.1-beta1', '23.6' ),
+			'mapped beta'          => array( '7.1-beta2', '23.6' ),
 			'mapped rc with build' => array( '7.1-RC1-59400', '23.6' ),
 			'unmapped newer'       => array( '7.2', null ),
 			'unmapped older'       => array( '6.6.1', null ),

--- a/projects/plugins/wpcomsh/tests/GutenbergModsTest.php
+++ b/projects/plugins/wpcomsh/tests/GutenbergModsTest.php
@@ -45,10 +45,10 @@ class GutenbergModsTest extends WP_UnitTestCase {
 	 */
 	public static function provide_wp_versions() {
 		return array(
-			'mapped major'         => array( '7.1', '23.6' ),
-			'mapped with point'    => array( '7.1.2', '23.6' ),
-			'mapped beta'          => array( '7.1-beta2', '23.6' ),
-			'mapped rc with build' => array( '7.1-RC1-59400', '23.6' ),
+			'mapped major'         => array( '7.1', '23.6.0' ),
+			'mapped with point'    => array( '7.1.2', '23.6.0' ),
+			'mapped beta'          => array( '7.1-beta2', '23.6.0' ),
+			'mapped rc with build' => array( '7.1-RC1-59400', '23.6.0' ),
 			'unmapped newer'       => array( '7.2', null ),
 			'unmapped older'       => array( '6.6.1', null ),
 			'empty'                => array( '', null ),
@@ -78,11 +78,11 @@ class GutenbergModsTest extends WP_UnitTestCase {
 	 */
 	public static function provide_ignore_decisions() {
 		return array(
-			'plugin older than bundle' => array( '23.0', '23.6', true ),
-			'plugin much older'        => array( '19.5', '23.6', true ),
-			'plugin equal to bundle'   => array( '23.6', '23.6', false ),
-			'plugin newer than bundle' => array( '24.0', '23.6', false ),
-			'unknown plugin version'   => array( null, '23.6', false ),
+			'plugin older than bundle' => array( '23.0', '23.6.0', true ),
+			'plugin much older'        => array( '19.5', '23.6.0', true ),
+			'plugin equal to bundle'   => array( '23.6.0', '23.6.0', false ),
+			'plugin newer than bundle' => array( '24.0', '23.6.0', false ),
+			'unknown plugin version'   => array( null, '23.6.0', false ),
 			'unknown bundled version'  => array( '23.0', null, false ),
 			'both unknown'             => array( null, null, false ),
 		);
@@ -114,7 +114,7 @@ class GutenbergModsTest extends WP_UnitTestCase {
 		global $wp_version;
 		$wp_version = '7.1';
 
-		$this->assertFalse( wpcomsh_should_ignore_gutenberg_plugin( '23.0', '23.6' ) );
+		$this->assertFalse( wpcomsh_should_ignore_gutenberg_plugin( '23.0', '23.6.0' ) );
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/tests/GutenbergModsTest.php
+++ b/projects/plugins/wpcomsh/tests/GutenbergModsTest.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Gutenberg Mods Test file.
+ *
+ * @package wpcomsh
+ */
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Class GutenbergModsTest.
+ */
+class GutenbergModsTest extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Original $wp_version, restored after each test.
+	 *
+	 * @var string
+	 */
+	private $original_wp_version;
+
+	/**
+	 * Stash the global WordPress version before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		global $wp_version;
+		$this->original_wp_version = $wp_version;
+	}
+
+	/**
+	 * Restore the global WordPress version after each test.
+	 */
+	public function tear_down() {
+		global $wp_version;
+		$wp_version = $this->original_wp_version;
+		parent::tear_down();
+	}
+
+	/**
+	 * Data provider for beta version detection.
+	 *
+	 * @return array<string, array{0: string, 1: bool}>
+	 */
+	public function provide_wp_versions() {
+		return array(
+			'stable release'    => array( '6.6.1', false ),
+			'stable major'      => array( '6.7', false ),
+			'alpha nightly'     => array( '6.9-alpha-59123', true ),
+			'beta'              => array( '6.9-beta2', true ),
+			'beta with build'   => array( '6.9-beta2-59300', true ),
+			'release candidate' => array( '6.9-RC1', true ),
+			'rc with build'     => array( '6.9-RC1-59400', true ),
+			'empty'             => array( '', false ),
+		);
+	}
+
+	/**
+	 * Tests that beta/RC/alpha builds are detected as beta versions.
+	 *
+	 * @dataProvider provide_wp_versions
+	 *
+	 * @param string $version  The WordPress version string.
+	 * @param bool   $expected Whether it should be treated as a beta version.
+	 */
+	#[DataProvider( 'provide_wp_versions' )]
+	public function test_is_wp_beta_version( $version, $expected ) {
+		global $wp_version;
+		$wp_version = $version;
+
+		$this->assertSame( $expected, wpcomsh_is_wp_beta_version() );
+	}
+
+	/**
+	 * Tests that the Gutenberg plugin is removed from the active plugins list on beta builds.
+	 */
+	public function test_gutenberg_ignored_on_beta() {
+		global $wp_version;
+		$wp_version = '6.9-beta1';
+
+		$plugins  = array( 'jetpack/jetpack.php', 'gutenberg/gutenberg.php', 'akismet/akismet.php' );
+		$filtered = wpcomsh_ignore_gutenberg_plugin_on_wp_beta( $plugins );
+
+		$this->assertNotContains( 'gutenberg/gutenberg.php', $filtered );
+		$this->assertContains( 'jetpack/jetpack.php', $filtered );
+		$this->assertContains( 'akismet/akismet.php', $filtered );
+		$this->assertSame( array_values( $filtered ), $filtered, 'List should be re-indexed.' );
+	}
+
+	/**
+	 * Tests that the Gutenberg plugin is left untouched on stable builds.
+	 */
+	public function test_gutenberg_kept_on_stable() {
+		global $wp_version;
+		$wp_version = '6.6.1';
+
+		$plugins = array( 'jetpack/jetpack.php', 'gutenberg/gutenberg.php' );
+
+		$this->assertSame( $plugins, wpcomsh_ignore_gutenberg_plugin_on_wp_beta( $plugins ) );
+	}
+
+	/**
+	 * Tests that a non-array option value is returned unchanged.
+	 */
+	public function test_non_array_value_passed_through() {
+		global $wp_version;
+		$wp_version = '6.9-beta1';
+
+		$this->assertFalse( wpcomsh_ignore_gutenberg_plugin_on_wp_beta( false ) );
+	}
+}

--- a/projects/plugins/wpcomsh/tests/GutenbergModsTest.php
+++ b/projects/plugins/wpcomsh/tests/GutenbergModsTest.php
@@ -43,7 +43,7 @@ class GutenbergModsTest extends WP_UnitTestCase {
 	 *
 	 * @return array<string, array{0: string, 1: bool}>
 	 */
-	public function provide_wp_versions() {
+	public static function provide_wp_versions() {
 		return array(
 			'stable release'    => array( '6.6.1', false ),
 			'stable major'      => array( '6.7', false ),

--- a/projects/plugins/wpcomsh/tests/GutenbergModsTest.php
+++ b/projects/plugins/wpcomsh/tests/GutenbergModsTest.php
@@ -39,74 +39,88 @@ class GutenbergModsTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Data provider for beta version detection.
+	 * Data provider for the core-bundled Gutenberg version lookup.
 	 *
-	 * @return array<string, array{0: string, 1: bool}>
+	 * @return array<string, array{0: string, 1: string|null}>
 	 */
 	public static function provide_wp_versions() {
 		return array(
-			'stable release'    => array( '6.6.1', false ),
-			'stable major'      => array( '6.7', false ),
-			'alpha nightly'     => array( '6.9-alpha-59123', true ),
-			'beta'              => array( '6.9-beta2', true ),
-			'beta with build'   => array( '6.9-beta2-59300', true ),
-			'release candidate' => array( '6.9-RC1', true ),
-			'rc with build'     => array( '6.9-RC1-59400', true ),
-			'empty'             => array( '', false ),
+			'mapped major'         => array( '7.1', '23.6' ),
+			'mapped with point'    => array( '7.1.2', '23.6' ),
+			'mapped beta'          => array( '7.1-beta1', '23.6' ),
+			'mapped rc with build' => array( '7.1-RC1-59400', '23.6' ),
+			'unmapped newer'       => array( '7.2', null ),
+			'unmapped older'       => array( '6.6.1', null ),
+			'empty'                => array( '', null ),
 		);
 	}
 
 	/**
-	 * Tests that beta/RC/alpha builds are detected as beta versions.
+	 * Tests that the running WordPress version maps to the correct bundled Gutenberg version.
 	 *
 	 * @dataProvider provide_wp_versions
 	 *
-	 * @param string $version  The WordPress version string.
-	 * @param bool   $expected Whether it should be treated as a beta version.
+	 * @param string      $version  The WordPress version string.
+	 * @param string|null $expected The expected bundled Gutenberg version.
 	 */
 	#[DataProvider( 'provide_wp_versions' )]
-	public function test_is_wp_beta_version( $version, $expected ) {
+	public function test_get_core_bundled_gutenberg_version( $version, $expected ) {
 		global $wp_version;
 		$wp_version = $version;
 
-		$this->assertSame( $expected, wpcomsh_is_wp_beta_version() );
+		$this->assertSame( $expected, wpcomsh_get_core_bundled_gutenberg_version() );
 	}
 
 	/**
-	 * Tests that the Gutenberg plugin is removed from the active plugins list on beta builds.
+	 * Data provider for the ignore decision.
+	 *
+	 * @return array<string, array{0: string|null, 1: string|null, 2: bool}>
 	 */
-	public function test_gutenberg_ignored_on_beta() {
-		global $wp_version;
-		$wp_version = '6.9-beta1';
-
-		$plugins  = array( 'jetpack/jetpack.php', 'gutenberg/gutenberg.php', 'akismet/akismet.php' );
-		$filtered = wpcomsh_ignore_gutenberg_plugin_on_wp_beta( $plugins );
-
-		$this->assertNotContains( 'gutenberg/gutenberg.php', $filtered );
-		$this->assertContains( 'jetpack/jetpack.php', $filtered );
-		$this->assertContains( 'akismet/akismet.php', $filtered );
-		$this->assertSame( array_values( $filtered ), $filtered, 'List should be re-indexed.' );
+	public static function provide_ignore_decisions() {
+		return array(
+			'plugin older than bundle' => array( '23.0', '23.6', true ),
+			'plugin much older'        => array( '19.5', '23.6', true ),
+			'plugin equal to bundle'   => array( '23.6', '23.6', false ),
+			'plugin newer than bundle' => array( '24.0', '23.6', false ),
+			'unknown plugin version'   => array( null, '23.6', false ),
+			'unknown bundled version'  => array( '23.0', null, false ),
+			'both unknown'             => array( null, null, false ),
+		);
 	}
 
 	/**
-	 * Tests that the Gutenberg plugin is left untouched on stable builds.
+	 * Tests that the plugin is only ignored when it is known to be older than the core bundle.
+	 *
+	 * @dataProvider provide_ignore_decisions
+	 *
+	 * @param string|null $plugin_version  Installed Gutenberg plugin version.
+	 * @param string|null $bundled_version Minimum bundled Gutenberg version.
+	 * @param bool        $expected        Whether the plugin should be ignored.
 	 */
-	public function test_gutenberg_kept_on_stable() {
+	#[DataProvider( 'provide_ignore_decisions' )]
+	public function test_should_ignore_gutenberg_plugin( $plugin_version, $bundled_version, $expected ) {
+		$this->assertSame( $expected, wpcomsh_should_ignore_gutenberg_plugin( $plugin_version, $bundled_version ) );
+	}
+
+	/**
+	 * Tests that a non-array active_plugins value is returned unchanged.
+	 */
+	public function test_non_array_value_passed_through() {
+		$this->assertFalse( wpcomsh_ignore_outdated_gutenberg_plugin( false ) );
+	}
+
+	/**
+	 * Tests that the Gutenberg plugin is left in place when the WordPress version isn't mapped.
+	 *
+	 * The Gutenberg plugin isn't installed in the test environment, so its version can't be read
+	 * and the plugin is never ignored; an unmapped WordPress version keeps it in place regardless.
+	 */
+	public function test_gutenberg_kept_when_not_ignored() {
 		global $wp_version;
 		$wp_version = '6.6.1';
 
 		$plugins = array( 'jetpack/jetpack.php', 'gutenberg/gutenberg.php' );
 
-		$this->assertSame( $plugins, wpcomsh_ignore_gutenberg_plugin_on_wp_beta( $plugins ) );
-	}
-
-	/**
-	 * Tests that a non-array option value is returned unchanged.
-	 */
-	public function test_non_array_value_passed_through() {
-		global $wp_version;
-		$wp_version = '6.9-beta1';
-
-		$this->assertFalse( wpcomsh_ignore_gutenberg_plugin_on_wp_beta( false ) );
+		$this->assertSame( $plugins, wpcomsh_ignore_outdated_gutenberg_plugin( $plugins ) );
 	}
 }

--- a/projects/plugins/wpcomsh/tests/GutenbergModsTest.php
+++ b/projects/plugins/wpcomsh/tests/GutenbergModsTest.php
@@ -89,7 +89,8 @@ class GutenbergModsTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that the plugin is only ignored when it is known to be older than the core bundle.
+	 * Tests that, on the beta track, the plugin is only ignored when it is known to be older
+	 * than the core bundle.
 	 *
 	 * @dataProvider provide_ignore_decisions
 	 *
@@ -99,7 +100,53 @@ class GutenbergModsTest extends WP_UnitTestCase {
 	 */
 	#[DataProvider( 'provide_ignore_decisions' )]
 	public function test_should_ignore_gutenberg_plugin( $plugin_version, $bundled_version, $expected ) {
+		global $wp_version;
+		$wp_version = '7.1-beta2';
+
 		$this->assertSame( $expected, wpcomsh_should_ignore_gutenberg_plugin( $plugin_version, $bundled_version ) );
+	}
+
+	/**
+	 * Tests that the plugin is never ignored on a stable (non-beta) WordPress build, even when
+	 * the installed plugin is older than the core bundle.
+	 */
+	public function test_stable_build_never_ignores_plugin() {
+		global $wp_version;
+		$wp_version = '7.1';
+
+		$this->assertFalse( wpcomsh_should_ignore_gutenberg_plugin( '23.0', '23.6' ) );
+	}
+
+	/**
+	 * Data provider for the beta-track check.
+	 *
+	 * @return array<string, array{0: string, 1: bool}>
+	 */
+	public static function provide_wp_beta_versions() {
+		return array(
+			'stable'        => array( '7.1', false ),
+			'stable point'  => array( '7.1.2', false ),
+			'beta'          => array( '7.1-beta2', true ),
+			'rc with build' => array( '7.1-RC1-59400', true ),
+			'alpha'         => array( '7.2-alpha-59500', true ),
+			'empty'         => array( '', false ),
+		);
+	}
+
+	/**
+	 * Tests that pre-release WordPress builds are detected as beta-track versions.
+	 *
+	 * @dataProvider provide_wp_beta_versions
+	 *
+	 * @param string $version  The WordPress version string.
+	 * @param bool   $expected Whether the version is on the beta track.
+	 */
+	#[DataProvider( 'provide_wp_beta_versions' )]
+	public function test_is_wp_beta_version( $version, $expected ) {
+		global $wp_version;
+		$wp_version = $version;
+
+		$this->assertSame( $expected, wpcomsh_is_wp_beta_version() );
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/tests/GutenbergVersionEndpointTest.php
+++ b/projects/plugins/wpcomsh/tests/GutenbergVersionEndpointTest.php
@@ -21,7 +21,7 @@ class GutenbergVersionEndpointTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that the callback reports the plugin version and `plugin` source when the plugin is active.
+	 * Tests that the callback returns the Gutenberg plugin version on a stable WordPress build.
 	 */
 	public function test_callback_returns_version_payload() {
 		if ( ! defined( 'GUTENBERG_VERSION' ) ) {
@@ -29,15 +29,35 @@ class GutenbergVersionEndpointTest extends WP_UnitTestCase {
 		}
 
 		global $wp_version;
+		$original   = $wp_version;
+		$wp_version = '6.6.1';
 
 		$response = wpcomsh_rest_api_gutenberg_version();
-		$data     = $response->get_data();
+
+		$wp_version = $original;
 
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
 		$this->assertSame( 200, $response->get_status() );
-		$this->assertSame( GUTENBERG_VERSION, $data['version'] );
-		$this->assertSame( 'plugin', $data['source'] );
-		$this->assertSame( $wp_version, $data['wp_version'] );
+		$this->assertSame( array( 'version' => GUTENBERG_VERSION ), $response->get_data() );
+	}
+
+	/**
+	 * Tests that the callback returns a null version on a beta build, where the Gutenberg plugin is ignored.
+	 */
+	public function test_callback_returns_null_version_on_beta() {
+		if ( ! defined( 'GUTENBERG_VERSION' ) ) {
+			define( 'GUTENBERG_VERSION', '99.9.9-test' );
+		}
+
+		global $wp_version;
+		$original   = $wp_version;
+		$wp_version = '6.9-beta1';
+
+		$response = wpcomsh_rest_api_gutenberg_version();
+
+		$wp_version = $original;
+
+		$this->assertSame( array( 'version' => null ), $response->get_data() );
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/tests/GutenbergVersionEndpointTest.php
+++ b/projects/plugins/wpcomsh/tests/GutenbergVersionEndpointTest.php
@@ -21,18 +21,23 @@ class GutenbergVersionEndpointTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that the callback returns a WP_REST_Response with a version key.
+	 * Tests that the callback reports the plugin version and `plugin` source when the plugin is active.
 	 */
 	public function test_callback_returns_version_payload() {
 		if ( ! defined( 'GUTENBERG_VERSION' ) ) {
 			define( 'GUTENBERG_VERSION', '99.9.9-test' );
 		}
 
+		global $wp_version;
+
 		$response = wpcomsh_rest_api_gutenberg_version();
+		$data     = $response->get_data();
 
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
 		$this->assertSame( 200, $response->get_status() );
-		$this->assertSame( array( 'version' => GUTENBERG_VERSION ), $response->get_data() );
+		$this->assertSame( GUTENBERG_VERSION, $data['version'] );
+		$this->assertSame( 'plugin', $data['source'] );
+		$this->assertSame( $wp_version, $data['wp_version'] );
 	}
 
 	/**

--- a/projects/plugins/wpcomsh/tests/GutenbergVersionEndpointTest.php
+++ b/projects/plugins/wpcomsh/tests/GutenbergVersionEndpointTest.php
@@ -21,43 +21,21 @@ class GutenbergVersionEndpointTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Tests that the callback returns the Gutenberg plugin version on a stable WordPress build.
+	 * Tests that the callback returns the Gutenberg plugin version when the plugin is active and not ignored.
+	 *
+	 * The Gutenberg plugin isn't installed in the test environment, so it is never ignored in favor
+	 * of the core bundle, and the defined GUTENBERG_VERSION is returned.
 	 */
 	public function test_callback_returns_version_payload() {
 		if ( ! defined( 'GUTENBERG_VERSION' ) ) {
 			define( 'GUTENBERG_VERSION', '99.9.9-test' );
 		}
 
-		global $wp_version;
-		$original   = $wp_version;
-		$wp_version = '6.6.1';
-
 		$response = wpcomsh_rest_api_gutenberg_version();
-
-		$wp_version = $original;
 
 		$this->assertInstanceOf( WP_REST_Response::class, $response );
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( array( 'version' => GUTENBERG_VERSION ), $response->get_data() );
-	}
-
-	/**
-	 * Tests that the callback returns a null version on a beta build, where the Gutenberg plugin is ignored.
-	 */
-	public function test_callback_returns_null_version_on_beta() {
-		if ( ! defined( 'GUTENBERG_VERSION' ) ) {
-			define( 'GUTENBERG_VERSION', '99.9.9-test' );
-		}
-
-		global $wp_version;
-		$original   = $wp_version;
-		$wp_version = '6.9-beta1';
-
-		$response = wpcomsh_rest_api_gutenberg_version();
-
-		$wp_version = $original;
-
-		$this->assertSame( array( 'version' => null ), $response->get_data() );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

## Proposed changes
* On the **WordPress beta track** (pre-release `-alpha`/`-beta`/`-RC` core builds), ignore the Gutenberg plugin when its installed version is **older than the Gutenberg version bundled in the running WordPress core**, so the site uses core's newer bundled Gutenberg instead of an outdated plugin. Stable releases are unaffected, keeping the blast radius small. The plugin is removed from the active plugins list at load time (via the `option_active_plugins` filter); the stored `active_plugins` option is left untouched, so the plugin returns automatically once it is updated past the bundle or the site leaves the beta track.
* The `option_active_plugins` filter is attached on `muplugins_loaded` and detached on `plugins_loaded`, so it only shapes the read core makes to load plugins. Outside that window `get_option( 'active_plugins' )` returns the stored value untouched, so the trimmed list can never be read and saved back to the database (which would deactivate the plugin permanently).
* Add a hard-coded WordPress-major → minimum-bundled-Gutenberg map (`WPCOMSH_CORE_BUNDLED_GUTENBERG_VERSIONS`, currently `7.1 => 23.6`). Core exposes no Gutenberg version of its own and the mapping lives outside core, so it is hard-coded; values are a floor since beta/RC/point releases cherry-pick fixes from later Gutenberg versions. Extend the list as new WordPress majors ship.
* The Gutenberg plugin version is read from its plugin header (not the `GUTENBERG_VERSION` constant) because the check runs before the plugin loads. When either the installed or bundled version is unknown, the plugin is left active (conservative default).
* The `wpcomsh/v1/gutenberg-version` endpoint returns `null` when the plugin is ignored in favor of the core bundle. The response format is unchanged (`{ "version": ... }`).
* Add unit tests (`GutenbergModsTest`) for the version map, the beta-track check, and the ignore decision, and update `GutenbergVersionEndpointTest`.

## Related product discussion/links
* pgle0O-1L7-p2#comment-3038

## Does this pull request change what data or activity we track or use?
No. The gutenberg-version endpoint already exposes the Gutenberg version behind the existing `wpcomsh_expose_gutenberg_version` opt-in option; the response format is unchanged.

## Testing instructions
* On a WoA/Atomic test site running a **beta build** of a WordPress version listed in the map (e.g. `7.1-beta2`) with the Gutenberg plugin installed at a version **below** the mapped minimum (e.g. Gutenberg `23.0` < `23.6`), confirm the Gutenberg plugin is no longer loaded (editing comes from the core-bundled Gutenberg) and that the stored `active_plugins` option still lists `gutenberg/gutenberg.php` (nothing was permanently deactivated).
* Update the Gutenberg plugin to a version at or above the mapped minimum (e.g. `23.6`+) and confirm the plugin loads again automatically.
* On a **stable** WordPress release (e.g. `7.1`), confirm the Gutenberg plugin is left active regardless of its version — the ignore only applies on the beta track.
* On a beta build of a WordPress version not in the map, confirm the Gutenberg plugin is left active regardless of its version.
* With the `wpcomsh_expose_gutenberg_version` option enabled, `GET /wp-json/wpcomsh/v1/gutenberg-version` returns `{ "version": "<x.y>" }` when the plugin is active, and `{ "version": null }` when the plugin is ignored in favor of the core bundle.
* Go to Editor, and ensure the assets under Gutenberg plugin is not loaded
