### PR TITLE
My Jetpack: skip the connection onboarding flow on WordPress.com Simple sites

### DIFF
--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-skip-onboarding-wpcom-simple
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-skip-onboarding-wpcom-simple
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: skip the connection onboarding flow on WordPress.com Simple sites, which are connected by definition.

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-skip-onboarding-wpcom-simple
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-skip-onboarding-wpcom-simple
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-My Jetpack: skip the connection onboarding flow on WordPress.com Simple sites, which are connected by definition.
+Skip the connection onboarding flow on WordPress.com Simple sites, which are connected by definition.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -576,6 +576,8 @@ class Initializer {
 		$step = isset( $_GET['step'] ) ? sanitize_text_field( wp_unslash( $_GET['step'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		// No connection check needed here: admin_init() has already redirected connected users away from onboarding.
+		// Availability IS re-checked on purpose: this render can run even when that redirect did not,
+		// and the check below is what keeps the onboarding route off WordPress.com Simple sites.
 		$is_onboarding = $step === 'onboarding' && self::is_onboarding_available();
 
 		// Add data attribute for onboarding, otherwise render normal container

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -191,15 +191,16 @@ class Initializer {
 		}
 
 		// Handle onboarding redirects based on connection status
-		$should_redirect = false;
-		$redirect_args   = array( 'page' => 'my-jetpack' );
+		$should_redirect      = false;
+		$redirect_args        = array( 'page' => 'my-jetpack' );
+		$onboarding_available = self::is_onboarding_available();
 
-		if ( ! $connection->is_connected() && $step !== 'onboarding' ) {
+		if ( $onboarding_available && ! $connection->is_connected() && $step !== 'onboarding' ) {
 			// Redirect to onboarding if not connected
 			$redirect_args['step'] = 'onboarding';
 			$should_redirect       = true;
-		} elseif ( $connection->is_connected() && $step === 'onboarding' ) {
-			// Redirect away from onboarding if already connected
+		} elseif ( $step === 'onboarding' && ( ! $onboarding_available || $connection->is_connected() ) ) {
+			// Redirect away from onboarding if already connected or onboarding is not available on this site
 			$should_redirect = true;
 		}
 
@@ -222,6 +223,19 @@ class Initializer {
 		self::$site_info = self::get_site_info();
 		add_filter( 'identity_crisis_container_id', array( static::class, 'get_idc_container_id' ) );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_scripts' ) );
+	}
+
+	/**
+	 * Whether the My Jetpack onboarding flow is available on this site.
+	 *
+	 * WordPress.com Simple sites are connected by definition and don't manage their
+	 * connection through My Jetpack, so the onboarding flow (which asks the user to
+	 * connect) never applies there.
+	 *
+	 * @return bool
+	 */
+	public static function is_onboarding_available() {
+		return ! ( new Status_Host() )->is_wpcom_simple();
 	}
 
 	/**

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -221,6 +221,8 @@ class Initializer {
 	 * connection through My Jetpack, so the onboarding flow (which asks the user to
 	 * connect) never applies there.
 	 *
+	 * @internal Not part of the package's public API.
+	 *
 	 * @return bool
 	 */
 	public static function is_onboarding_available() {
@@ -229,6 +231,8 @@ class Initializer {
 
 	/**
 	 * Decide whether the current My Jetpack request should redirect, and where to.
+	 *
+	 * @internal Not part of the package's public API.
 	 *
 	 * @param string $step                 The current `step` query param.
 	 * @param bool   $is_connected         Whether the site is connected to WordPress.com.
@@ -569,7 +573,9 @@ class Initializer {
 	 * @return void
 	 */
 	public static function admin_page() {
-		$step          = isset( $_GET['step'] ) ? sanitize_text_field( wp_unslash( $_GET['step'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$step = isset( $_GET['step'] ) ? sanitize_text_field( wp_unslash( $_GET['step'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		// No connection check needed here: admin_init() has already redirected connected users away from onboarding.
 		$is_onboarding = $step === 'onboarding' && self::is_onboarding_available();
 
 		// Add data attribute for onboarding, otherwise render normal container

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -191,20 +191,9 @@ class Initializer {
 		}
 
 		// Handle onboarding redirects based on connection status
-		$should_redirect      = false;
-		$redirect_args        = array( 'page' => 'my-jetpack' );
-		$onboarding_available = self::is_onboarding_available();
+		$redirect_args = self::get_onboarding_redirect_args( $step, $connection->is_connected(), self::is_onboarding_available() );
 
-		if ( $onboarding_available && ! $connection->is_connected() && $step !== 'onboarding' ) {
-			// Redirect to onboarding if not connected
-			$redirect_args['step'] = 'onboarding';
-			$should_redirect       = true;
-		} elseif ( $step === 'onboarding' && ( ! $onboarding_available || $connection->is_connected() ) ) {
-			// Redirect away from onboarding if already connected or onboarding is not available on this site
-			$should_redirect = true;
-		}
-
-		if ( $should_redirect ) {
+		if ( null !== $redirect_args ) {
 			$admin_page = add_query_arg( $redirect_args, admin_url( 'admin.php' ) );
 			$location   = wp_sanitize_redirect( $admin_page );
 
@@ -236,6 +225,31 @@ class Initializer {
 	 */
 	public static function is_onboarding_available() {
 		return ! ( new Status_Host() )->is_wpcom_simple();
+	}
+
+	/**
+	 * Decide whether the current My Jetpack request should redirect, and where to.
+	 *
+	 * @param string $step                 The current `step` query param.
+	 * @param bool   $is_connected         Whether the site is connected to WordPress.com.
+	 * @param bool   $onboarding_available Whether the onboarding flow is available on this site.
+	 * @return array|null Query args for the redirect, or null to stay on the current page.
+	 */
+	public static function get_onboarding_redirect_args( $step, $is_connected, $onboarding_available ) {
+		if ( $onboarding_available && ! $is_connected && $step !== 'onboarding' ) {
+			// Redirect to onboarding if not connected
+			return array(
+				'page' => 'my-jetpack',
+				'step' => 'onboarding',
+			);
+		}
+
+		if ( $step === 'onboarding' && ( ! $onboarding_available || $is_connected ) ) {
+			// Redirect away from onboarding if already connected or onboarding is not available on this site
+			return array( 'page' => 'my-jetpack' );
+		}
+
+		return null;
 	}
 
 	/**
@@ -556,7 +570,7 @@ class Initializer {
 	 */
 	public static function admin_page() {
 		$step          = isset( $_GET['step'] ) ? sanitize_text_field( wp_unslash( $_GET['step'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$is_onboarding = $step === 'onboarding';
+		$is_onboarding = $step === 'onboarding' && self::is_onboarding_available();
 
 		// Add data attribute for onboarding, otherwise render normal container
 		echo '<div id="my-jetpack-container" ' . ( $is_onboarding ? 'data-route="onboarding"' : '' ) . '></div>';

--- a/projects/packages/my-jetpack/tests/php/Initializer_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Initializer_Test.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\My_Jetpack;
 
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Status\Cache as StatusCache;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -18,23 +19,33 @@ use WorDBless\BaseTestCase;
 class Initializer_Test extends BaseTestCase {
 	/**
 	 * Set up before each test.
-	 *
-	 * Mirrors tear_down() so every test starts from a clean slate even if an
-	 * earlier test in the run leaked state.
 	 */
 	public function set_up() {
-		Constants::clear_constants();
-		StatusCache::clear();
-		unset( $_GET['step'] );
+		$this->reset_state();
 	}
 
 	/**
 	 * Tear down after each test.
 	 */
 	public function tear_down() {
+		$this->reset_state();
+	}
+
+	/**
+	 * Reset every piece of global state these tests touch, so each test starts
+	 * from a clean slate regardless of what ran before it in the shared process.
+	 *
+	 * Runs from both set_up() and tear_down() so the two can't drift.
+	 */
+	private function reset_state() {
 		Constants::clear_constants();
 		StatusCache::clear();
-		unset( $_GET['step'] );
+		unset( $_GET['step'], $_GET['showCouponRedemption'] );
+
+		// Connection_Manager memoizes is_connected() in a process-wide static that
+		// WorDBless teardown does not reset. Clear it so a sibling test leaving the
+		// site "connected" can't flip the disconnected admin_init redirect test.
+		( new Connection_Manager() )->reset_connection_status();
 	}
 
 	/**
@@ -182,10 +193,12 @@ class Initializer_Test extends BaseTestCase {
 	 */
 	private function capture_admin_init_redirect() {
 		$location = null;
-		$capture  = function ( $redirect_location ) use ( &$location ) {
-			$location = $redirect_location;
-			throw new \Exception( 'Intercepted redirect to skip exit().' );
-		};
+		$capture  =
+			/** @return never */
+			function ( $redirect_location ) use ( &$location ) {
+				$location = $redirect_location;
+				throw new \Exception( 'Intercepted redirect to skip exit().' );
+			};
 
 		add_filter( 'wp_redirect', $capture );
 		try {

--- a/projects/packages/my-jetpack/tests/php/Initializer_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Initializer_Test.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\My_Jetpack;
 
 use Automattic\Jetpack\Constants;
+use PHPUnit\Framework\Attributes\DataProvider;
 use WorDBless\BaseTestCase;
 
 /**
@@ -35,5 +36,45 @@ class Initializer_Test extends BaseTestCase {
 		Constants::set_constant( 'IS_WPCOM', true );
 
 		$this->assertFalse( Initializer::is_onboarding_available() );
+	}
+
+	/**
+	 * Data provider for the onboarding redirect decision.
+	 *
+	 * @return array
+	 */
+	public static function provide_onboarding_redirect_cases() {
+		$to_onboarding = array(
+			'page' => 'my-jetpack',
+			'step' => 'onboarding',
+		);
+		$to_home       = array( 'page' => 'my-jetpack' );
+
+		return array(
+			'available, disconnected, no step: redirect to onboarding' => array( '', false, true, $to_onboarding ),
+			'available, disconnected, on onboarding: stay' => array( 'onboarding', false, true, null ),
+			'available, connected, no step: stay'          => array( '', true, true, null ),
+			'available, connected, on onboarding: redirect home' => array( 'onboarding', true, true, $to_home ),
+			'unavailable, disconnected, no step: stay'     => array( '', false, false, null ),
+			'unavailable, disconnected, on onboarding: redirect home' => array( 'onboarding', false, false, $to_home ),
+			'unavailable, connected, no step: stay'        => array( '', true, false, null ),
+			'unavailable, connected, on onboarding: redirect home' => array( 'onboarding', true, false, $to_home ),
+		);
+	}
+
+	/**
+	 * The redirect decision is correct for every combination of step,
+	 * connection state, and onboarding availability.
+	 *
+	 * @dataProvider provide_onboarding_redirect_cases
+	 *
+	 * @param string     $step                 The `step` query param.
+	 * @param bool       $is_connected         Whether the site is connected.
+	 * @param bool       $onboarding_available Whether onboarding is available on this site.
+	 * @param array|null $expected             Expected redirect query args, or null to stay.
+	 */
+	#[DataProvider( 'provide_onboarding_redirect_cases' )]
+	public function test_get_onboarding_redirect_args( $step, $is_connected, $onboarding_available, $expected ) {
+		$this->assertSame( $expected, Initializer::get_onboarding_redirect_args( $step, $is_connected, $onboarding_available ) );
 	}
 }

--- a/projects/packages/my-jetpack/tests/php/Initializer_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Initializer_Test.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\My_Jetpack;
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Status\Cache as StatusCache;
 use PHPUnit\Framework\Attributes\DataProvider;
 use WorDBless\BaseTestCase;
 
@@ -20,6 +21,8 @@ class Initializer_Test extends BaseTestCase {
 	 */
 	public function tear_down() {
 		Constants::clear_constants();
+		StatusCache::clear();
+		unset( $_GET['step'] );
 	}
 
 	/**
@@ -36,6 +39,19 @@ class Initializer_Test extends BaseTestCase {
 		Constants::set_constant( 'IS_WPCOM', true );
 
 		$this->assertFalse( Initializer::is_onboarding_available() );
+	}
+
+	/**
+	 * Onboarding stays available on WordPress.com Atomic (WoA) sites: only
+	 * Simple sites are excluded, not the whole WordPress.com platform.
+	 */
+	public function test_onboarding_is_available_on_woa() {
+		Constants::set_constant( 'ATOMIC_SITE_ID', 123 );
+		Constants::set_constant( 'ATOMIC_CLIENT_ID', 123 );
+		Constants::set_constant( 'WPCOMSH__PLUGIN_FILE', '/tmp/wpcomsh/wpcomsh.php' );
+		StatusCache::clear();
+
+		$this->assertTrue( Initializer::is_onboarding_available() );
 	}
 
 	/**
@@ -76,5 +92,35 @@ class Initializer_Test extends BaseTestCase {
 	#[DataProvider( 'provide_onboarding_redirect_cases' )]
 	public function test_get_onboarding_redirect_args( $step, $is_connected, $onboarding_available, $expected ) {
 		$this->assertSame( $expected, Initializer::get_onboarding_redirect_args( $step, $is_connected, $onboarding_available ) );
+	}
+
+	/**
+	 * The admin page marks the container with the onboarding route when
+	 * onboarding is requested and available.
+	 */
+	public function test_admin_page_renders_onboarding_route_when_available() {
+		$_GET['step'] = 'onboarding';
+
+		ob_start();
+		Initializer::admin_page();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'data-route="onboarding"', $output );
+	}
+
+	/**
+	 * The admin page never marks the container with the onboarding route on
+	 * WordPress.com Simple sites, even when the redirect did not run.
+	 */
+	public function test_admin_page_does_not_render_onboarding_route_on_wpcom_simple() {
+		Constants::set_constant( 'IS_WPCOM', true );
+		$_GET['step'] = 'onboarding';
+
+		ob_start();
+		Initializer::admin_page();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'id="my-jetpack-container"', $output );
+		$this->assertStringNotContainsString( 'data-route', $output );
 	}
 }

--- a/projects/packages/my-jetpack/tests/php/Initializer_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Initializer_Test.php
@@ -17,6 +17,18 @@ use WorDBless\BaseTestCase;
  */
 class Initializer_Test extends BaseTestCase {
 	/**
+	 * Set up before each test.
+	 *
+	 * Mirrors tear_down() so every test starts from a clean slate even if an
+	 * earlier test in the run leaked state.
+	 */
+	public function set_up() {
+		Constants::clear_constants();
+		StatusCache::clear();
+		unset( $_GET['step'] );
+	}
+
+	/**
 	 * Tear down after each test.
 	 */
 	public function tear_down() {
@@ -44,6 +56,12 @@ class Initializer_Test extends BaseTestCase {
 	/**
 	 * Onboarding stays available on WordPress.com Atomic (WoA) sites: only
 	 * Simple sites are excluded, not the whole WordPress.com platform.
+	 *
+	 * The constants below make Host::is_woa_site() true, which no other test
+	 * sets up, so this is the only test that would catch a broadening of the
+	 * exclusion from is_wpcom_simple() to is_wpcom_platform(). Don't delete it
+	 * as a duplicate of the by-default test: that one sets no constants and
+	 * can't tell the two classifiers apart.
 	 */
 	public function test_onboarding_is_available_on_woa() {
 		Constants::set_constant( 'ATOMIC_SITE_ID', 123 );
@@ -122,5 +140,61 @@ class Initializer_Test extends BaseTestCase {
 
 		$this->assertStringContainsString( 'id="my-jetpack-container"', $output );
 		$this->assertStringNotContainsString( 'data-route', $output );
+	}
+
+	/**
+	 * A disconnected site with no step is funneled into onboarding by admin_init().
+	 *
+	 * Calls admin_init() itself (not the extracted helper) so the call-site
+	 * wiring is covered: the argument order passed to
+	 * get_onboarding_redirect_args() and the redirect performed on its result.
+	 */
+	public function test_admin_init_redirects_disconnected_site_to_onboarding() {
+		$location = $this->capture_admin_init_redirect();
+
+		$this->assertNotNull( $location, 'Expected admin_init() to redirect.' );
+		$this->assertStringContainsString( 'page=my-jetpack', $location );
+		$this->assertStringContainsString( 'step=onboarding', $location );
+	}
+
+	/**
+	 * An onboarding request on a WordPress.com Simple site is redirected home
+	 * by admin_init() instead of letting the onboarding screen load.
+	 */
+	public function test_admin_init_redirects_onboarding_request_home_on_wpcom_simple() {
+		Constants::set_constant( 'IS_WPCOM', true );
+		$_GET['step'] = 'onboarding';
+
+		$location = $this->capture_admin_init_redirect();
+
+		$this->assertNotNull( $location, 'Expected admin_init() to redirect away from onboarding.' );
+		$this->assertStringContainsString( 'page=my-jetpack', $location );
+		$this->assertStringNotContainsString( 'step=onboarding', $location );
+	}
+
+	/**
+	 * Run Initializer::admin_init() and capture the redirect it attempts.
+	 *
+	 * The wp_redirect filter throws so the exit() that follows the redirect
+	 * call never runs; the location is captured before the throw.
+	 *
+	 * @return string|null The redirect location, or null when no redirect happened.
+	 */
+	private function capture_admin_init_redirect() {
+		$location = null;
+		$capture  = function ( $redirect_location ) use ( &$location ) {
+			$location = $redirect_location;
+			throw new \Exception( 'Intercepted redirect to skip exit().' );
+		};
+
+		add_filter( 'wp_redirect', $capture );
+		try {
+			Initializer::admin_init();
+		} catch ( \Exception $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch -- Expected: thrown by the capture filter above.
+		} finally {
+			remove_filter( 'wp_redirect', $capture );
+		}
+
+		return $location;
 	}
 }

--- a/projects/packages/my-jetpack/tests/php/Initializer_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Initializer_Test.php
@@ -11,6 +11,8 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Status\Cache as StatusCache;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use WorDBless\BaseTestCase;
 
 /**
@@ -159,7 +161,20 @@ class Initializer_Test extends BaseTestCase {
 	 * Calls admin_init() itself (not the extracted helper) so the call-site
 	 * wiring is covered: the argument order passed to
 	 * get_onboarding_redirect_args() and the redirect performed on its result.
+	 *
+	 * Runs in a separate process. admin_init() makes a real is_connected() call,
+	 * which registers Connection_Manager's memo-invalidation hooks once per
+	 * process and sets a process-wide "added" flag. WorDBless teardown restores
+	 * the hook table but cannot reset that private flag, so a later test in the
+	 * same process would find the flag set but the hooks gone and never
+	 * reinstall them, leaving its own token writes unable to clear the connection
+	 * memo. Isolation keeps that mutation out of the shared process.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
 	public function test_admin_init_redirects_disconnected_site_to_onboarding() {
 		$location = $this->capture_admin_init_redirect();
 
@@ -171,7 +186,16 @@ class Initializer_Test extends BaseTestCase {
 	/**
 	 * An onboarding request on a WordPress.com Simple site is redirected home
 	 * by admin_init() instead of letting the onboarding screen load.
+	 *
+	 * Separate process for the same reason as the disconnected test above:
+	 * admin_init()'s real is_connected() call leaks Connection_Manager's
+	 * invalidation-hook registration flag across tests in a shared process.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
 	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
 	public function test_admin_init_redirects_onboarding_request_home_on_wpcom_simple() {
 		Constants::set_constant( 'IS_WPCOM', true );
 		$_GET['step'] = 'onboarding';

--- a/projects/packages/my-jetpack/tests/php/Initializer_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Initializer_Test.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Test the My Jetpack Initializer.
+ *
+ * @package automattic/my-jetpack
+ */
+
+namespace Automattic\Jetpack\My_Jetpack;
+
+use Automattic\Jetpack\Constants;
+use WorDBless\BaseTestCase;
+
+/**
+ * Tests for the Initializer class.
+ */
+class Initializer_Test extends BaseTestCase {
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		Constants::clear_constants();
+	}
+
+	/**
+	 * Onboarding is available on regular (non-Simple) sites.
+	 */
+	public function test_onboarding_is_available_by_default() {
+		$this->assertTrue( Initializer::is_onboarding_available() );
+	}
+
+	/**
+	 * Onboarding is never available on WordPress.com Simple sites.
+	 */
+	public function test_onboarding_is_not_available_on_wpcom_simple() {
+		Constants::set_constant( 'IS_WPCOM', true );
+
+		$this->assertFalse( Initializer::is_onboarding_available() );
+	}
+}

--- a/projects/packages/my-jetpack/tests/php/Initializer_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Initializer_Test.php
@@ -45,8 +45,11 @@ class Initializer_Test extends BaseTestCase {
 		unset( $_GET['step'], $_GET['showCouponRedemption'] );
 
 		// Connection_Manager memoizes is_connected() in a process-wide static that
-		// WorDBless teardown does not reset. Clear it so a sibling test leaving the
-		// site "connected" can't flip the disconnected admin_init redirect test.
+		// WorDBless teardown does not reset. The admin_init tests that depend on that
+		// memo run in their own process (see #[RunInSeparateProcess]), so isolation,
+		// not this line, is what keeps them from reading a sibling test's connection
+		// state. The reset is kept as defense-in-depth for any future shared-process
+		// test in this file that reads connection state.
 		( new Connection_Manager() )->reset_connection_status();
 	}
 


### PR DESCRIPTION
Fixes JETPACK-1945

## Proposed changes

My Jetpack is starting to appear on WordPress.com Simple sites. Those sites are already part of WordPress.com, so a flow that asks the user to connect makes no sense there. wpcom currently works around this by faking a `blog_token` on the My Jetpack page (228791-ghe-Automattic/wpcom) so the site reads as connected and onboarding stays hidden. This PR moves that handling into the package so it no longer depends on the fake token.

* Skip the connection onboarding flow on WordPress.com Simple sites.
* Adds `Initializer::is_onboarding_available()`, false on Simple sites. The `admin_init()` redirect uses it in both directions: disconnected Simple sites are no longer sent to `?step=onboarding`, and opening that URL directly redirects back to the My Jetpack home.
* The redirect decision lives in a pure helper, `get_onboarding_redirect_args()`, with unit tests covering the full step/connection/availability truth table.
* `admin_page()` also checks availability before rendering the onboarding container, so the onboarding UI can't appear on Simple sites even if the redirect never runs.

Scope: this PR handles the onboarding routing only. The fake `blog_token` also backs the rest of My Jetpack's connection state on Simple sites (localized/REST connection state, the missing-connection notice, and the purchases guard), so a token-less Simple site would still read as disconnected on those surfaces. Removing the stub is gated on a follow-up that makes Simple sites count as connected there; until that lands, the stub stays.

## Related product discussion/links

* JETPACK-1945

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Self-hosted, disconnected: `wp-admin/admin.php?page=my-jetpack` still redirects to `?step=onboarding`.
* Self-hosted, connected: `admin.php?page=my-jetpack&step=onboarding` still redirects back to the My Jetpack home.
* Simple site (or any environment with `IS_WPCOM` true): `admin.php?page=my-jetpack` loads the My Jetpack home directly, with no redirect into onboarding.
* Simple site: `admin.php?page=my-jetpack&step=onboarding` redirects to the My Jetpack home instead of showing onboarding.

Unit tests: `cd projects/packages/my-jetpack && composer phpunit -- --filter Initializer_Test`
