### PR TITLE
My Jetpack: show only the Products section on WordPress.com Simple sites

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-screen/index.jsx
@@ -33,9 +33,8 @@ import { useQueryParameter } from '../../hooks/use-query-parameter';
 import EvaluationRecommendations from '../evaluation-recommendations';
 import IDCModal from '../idc-modal';
 import { MyJetpackTabPanel } from '../my-jetpack-tab-panel';
-import { MY_JETPACK_SECTION_OVERVIEW } from '../my-jetpack-tab-panel/constants';
 import { useReplayPendingNotice } from '../my-jetpack-tab-panel/products/pending-notice';
-import { isValidMyJetpackSection } from '../my-jetpack-tab-panel/utils';
+import { getDefaultMyJetpackSection, isValidMyJetpackSection } from '../my-jetpack-tab-panel/utils';
 import OnboardingTour from '../onboarding-tour';
 import buildOptionalMenuItems from './build-optional-menu-items';
 import styles from './styles.module.scss';
@@ -123,7 +122,7 @@ export default function MyJetpackScreen() {
 	// Determine current tab
 	const currentTab = isValidMyJetpackSection( params.section )
 		? params.section
-		: MY_JETPACK_SECTION_OVERVIEW;
+		: getDefaultMyJetpackSection();
 
 	useLayoutEffect( () => {
 		let customTracksData = {};

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/index.tsx
@@ -92,6 +92,20 @@ export function MyJetpackTabPanel( { beforeContent }: { beforeContent?: ReactNod
 		tabStartTimeRef.current = Date.now();
 	}, [ currentTab ] );
 
+	// Canonicalize a stale or invalid section hash. `currentTab` already resolves
+	// such a hash to a real section for rendering, but `onTabSelect` only reacts to
+	// genuine tab changes, so the URL itself is left as-is. Interstitials redirect
+	// to `MyJetpackRoutes.Home` — the literal route pattern `/:section` — and rely on
+	// the page settling on a concrete URL; without this the address bar keeps
+	// `#/:section` (previously masked by the mount-time navigation this component no
+	// longer fires). Rewrite with `replace` so it emits no `tab_click` and adds no
+	// history entry.
+	useEffect( () => {
+		if ( params.section !== currentTab ) {
+			navigate( `/${ currentTab }`, { replace: true } );
+		}
+	}, [ params.section, currentTab, navigate ] );
+
 	useEffect( () => {
 		// Track tab view event
 		recordEvent( 'jetpack_myjetpack_tab_view', {

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/index.tsx
@@ -34,7 +34,14 @@ export function MyJetpackTabPanel( { beforeContent }: { beforeContent?: ReactNod
 	}, [ params.section ] );
 	const onTabSelect = useCallback(
 		( tabName: string ) => {
-			if ( tabName !== params.section ) {
+			// Compare against the resolved `currentTab`, not the raw URL param. On mount
+			// TabPanel calls onSelect with the tab it settled on, which is always
+			// `currentTab`; treating that as a click records a synthetic
+			// `jetpack_myjetpack_tab_click` and pushes a history entry. Gating on
+			// `currentTab` fires only on a genuine tab change and also covers
+			// invalid/stale hashes (e.g. `#/overview` on a Simple site that resolves to
+			// Products) without emitting a phantom event.
+			if ( tabName !== currentTab ) {
 				// Mark this as an internal navigation (user clicked a tab)
 				lastNavigationSourceRef.current = 'internal';
 
@@ -44,7 +51,7 @@ export function MyJetpackTabPanel( { beforeContent }: { beforeContent?: ReactNod
 				// Record tab click event
 				recordEvent( 'jetpack_myjetpack_tab_click', {
 					tab_name: tabName,
-					previous_tab: params.section || getDefaultMyJetpackSection(),
+					previous_tab: currentTab,
 					session_duration: sessionDuration,
 					user_type: isNewUser ? 'new' : 'returning',
 				} );
@@ -55,7 +62,7 @@ export function MyJetpackTabPanel( { beforeContent }: { beforeContent?: ReactNod
 				navigate( `/${ tabName }` );
 			}
 		},
-		[ navigate, params.section, recordEvent, isNewUser ]
+		[ navigate, currentTab, recordEvent, isNewUser ]
 	);
 
 	const tabRenderer = useCallback(

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/index.tsx
@@ -104,17 +104,28 @@ export function MyJetpackTabPanel( { beforeContent }: { beforeContent?: ReactNod
 
 	const tabs = useMemo( () => getMyJetpackSections(), [] );
 
+	// A single section has nothing to switch between, so render it directly instead
+	// of a TabPanel with its tab bar hidden. This skips TabPanel's selection
+	// lifecycle (mount `onSelect`, keyed remount, `initialTabName` matching) for a
+	// non-choice, and reproduces the surface `.components-tab-panel__tab-content`
+	// would provide (see `single-tab-content` in the stylesheet).
+	if ( tabs.length === 1 ) {
+		return (
+			<div className={ clsx( styles[ 'single-tab-content' ], 'jetpack-my-jetpack-tab-panel' ) }>
+				<FullWidthSeparator />
+				{ beforeContent }
+				<TabContent name={ currentTab as MyJetpackSection } />
+			</div>
+		);
+	}
+
 	return (
 		<TabPanel
 			key={ tabKey }
 			className={ clsx(
 				styles[ 'tab-panel' ],
 				styles[ 'my-jetpack-tab-panel--full-width' ],
-				'jetpack-my-jetpack-tab-panel',
-				{
-					// With a single section there is nothing to switch between, so hide the tab bar.
-					[ styles[ 'my-jetpack-tab-panel--single-tab' ] ]: tabs.length === 1,
-				}
+				'jetpack-my-jetpack-tab-panel'
 			) }
 			initialTabName={ currentTab }
 			onSelect={ onTabSelect }

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/index.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/index.tsx
@@ -4,12 +4,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate, useParams } from 'react-router';
 import useAnalytics from '../../hooks/use-analytics';
 import useIsJetpackUserNew from '../../hooks/use-is-jetpack-user-new';
-import { MY_JETPACK_SECTION_OVERVIEW } from './constants';
 import { FullWidthSeparator } from './full-width-separator';
 import styles from './styles.module.scss';
 import { TabContent } from './tab-content';
 import { MyJetpackSection } from './types';
-import { getMyJetpackSections, isValidMyJetpackSection } from './utils';
+import { getDefaultMyJetpackSection, getMyJetpackSections, isValidMyJetpackSection } from './utils';
 import type { ReactNode } from 'react';
 
 /**
@@ -31,7 +30,7 @@ export function MyJetpackTabPanel( { beforeContent }: { beforeContent?: ReactNod
 	// If the tab is not valid, use the default one.
 	const currentTab = useMemo( () => {
 		const validTab = isValidMyJetpackSection( params.section );
-		return validTab ? params.section : MY_JETPACK_SECTION_OVERVIEW;
+		return validTab ? params.section : getDefaultMyJetpackSection();
 	}, [ params.section ] );
 	const onTabSelect = useCallback(
 		( tabName: string ) => {
@@ -45,7 +44,7 @@ export function MyJetpackTabPanel( { beforeContent }: { beforeContent?: ReactNod
 				// Record tab click event
 				recordEvent( 'jetpack_myjetpack_tab_click', {
 					tab_name: tabName,
-					previous_tab: params.section || MY_JETPACK_SECTION_OVERVIEW,
+					previous_tab: params.section || getDefaultMyJetpackSection(),
 					session_duration: sessionDuration,
 					user_type: isNewUser ? 'new' : 'returning',
 				} );
@@ -104,7 +103,11 @@ export function MyJetpackTabPanel( { beforeContent }: { beforeContent?: ReactNod
 			className={ clsx(
 				styles[ 'tab-panel' ],
 				styles[ 'my-jetpack-tab-panel--full-width' ],
-				'jetpack-my-jetpack-tab-panel'
+				'jetpack-my-jetpack-tab-panel',
+				{
+					// With a single section there is nothing to switch between, so hide the tab bar.
+					[ styles[ 'my-jetpack-tab-panel--single-tab' ] ]: tabs.length === 1,
+				}
 			) }
 			initialTabName={ currentTab }
 			onSelect={ onTabSelect }

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/styles.module.scss
@@ -42,6 +42,13 @@
 	margin: 0 auto;
 }
 
+.my-jetpack-tab-panel--single-tab {
+
+	:global(.components-tab-panel__tabs) {
+		display: none;
+	}
+}
+
 .my-jetpack-tab-panel--full-width {
 
 	width: 100%;

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/styles.module.scss
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/styles.module.scss
@@ -42,11 +42,23 @@
 	margin: 0 auto;
 }
 
-.my-jetpack-tab-panel--single-tab {
+// The content surface TabPanel renders inside its
+// `.components-tab-panel__tab-content`: an off-white band with the inner
+// content centered. Shared so the single-section path (rendered without
+// TabPanel) matches the tabbed layout exactly.
+@mixin tab-content-surface {
+	background-color: #fcfcfc;
 
-	:global(.components-tab-panel__tabs) {
-		display: none;
+	.my-jetpack-tab-panel-inner {
+
+		@include full-width-container;
 	}
+}
+
+// Single-section view: rendered directly, without a TabPanel wrapper.
+.single-tab-content {
+
+	@include tab-content-surface;
 }
 
 .my-jetpack-tab-panel--full-width {
@@ -66,11 +78,7 @@
 	}
 
 	:global(.components-tab-panel__tab-content) {
-		background-color: #fcfcfc;
 
-		.my-jetpack-tab-panel-inner {
-
-			@include full-width-container;
-		}
+		@include tab-content-surface;
 	}
 }

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/test/index.test.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/test/index.test.tsx
@@ -61,15 +61,22 @@ beforeEach( () => {
 describe( 'MyJetpackTabPanel', () => {
 	it( 'renders the single Products section directly, with no tab bar, on Simple sites', () => {
 		mockIsSimpleSite.mockReturnValue( true );
+		mockSection = MY_JETPACK_SECTION_PRODUCTS;
 
 		render( <MyJetpackTabPanel /> );
 
 		expect( screen.getByTestId( 'tab-content' ) ).toHaveTextContent( MY_JETPACK_SECTION_PRODUCTS );
 		// The direct-render path renders no TabPanel, so there is no tab bar.
 		expect( screen.queryByRole( 'tablist' ) ).not.toBeInTheDocument();
-		// No synthetic click; the page view still fires exactly once.
+		// The canonical Products hash needs no rewrite.
+		expect( mockNavigate ).not.toHaveBeenCalled();
+		// No synthetic click; the view fires exactly once, attributed to Products.
 		expect( callsFor( 'jetpack_myjetpack_tab_click' ) ).toHaveLength( 0 );
 		expect( callsFor( 'jetpack_myjetpack_tab_view' ) ).toHaveLength( 1 );
+		expect( mockRecordEvent ).toHaveBeenCalledWith(
+			'jetpack_myjetpack_tab_view',
+			expect.objectContaining( { tab_name: MY_JETPACK_SECTION_PRODUCTS } )
+		);
 	} );
 
 	it( 'does not record a tab click when the multi-section panel mounts', async () => {
@@ -86,8 +93,8 @@ describe( 'MyJetpackTabPanel', () => {
 		expect( callsFor( 'jetpack_myjetpack_tab_view' ) ).toHaveLength( 1 );
 	} );
 
-	it( 'does not record a tab click when mounting on a stale or invalid hash', async () => {
-		// Resolves to the default (Overview) rather than erroring or emitting a click.
+	it( 'canonicalizes a stale or invalid hash without recording a tab click', async () => {
+		// Resolves to the default (Overview) for rendering rather than erroring.
 		mockSection = 'does-not-exist';
 
 		render( <MyJetpackTabPanel /> );
@@ -95,8 +102,13 @@ describe( 'MyJetpackTabPanel', () => {
 			'Overview'
 		);
 
+		// The URL is rewritten to the resolved section via `replace`: no synthetic
+		// tab_click and no extra history entry (the interstitials' `/:section`
+		// redirect depends on this settling on a concrete hash).
 		expect( callsFor( 'jetpack_myjetpack_tab_click' ) ).toHaveLength( 0 );
-		expect( mockNavigate ).not.toHaveBeenCalled();
+		expect( mockNavigate ).toHaveBeenCalledWith( `/${ MY_JETPACK_SECTION_OVERVIEW }`, {
+			replace: true,
+		} );
 	} );
 
 	it( 'records one tab click, with the resolved previous tab, on a genuine switch', async () => {

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/test/index.test.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/test/index.test.tsx
@@ -1,0 +1,118 @@
+import '@testing-library/jest-dom';
+import { currentUserCan, isSimpleSite } from '@automattic/jetpack-script-data';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {
+	MY_JETPACK_SECTION_HELP,
+	MY_JETPACK_SECTION_OVERVIEW,
+	MY_JETPACK_SECTION_PRODUCTS,
+} from '../constants';
+import { MyJetpackTabPanel } from '../index';
+
+// `getMyJetpackSections()` derives the tab set from these two flags, so driving
+// them exercises the real section/validation/default logic rather than a stub.
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	currentUserCan: jest.fn(),
+	isSimpleSite: jest.fn(),
+} ) );
+
+// The router boundary is the only thing mocked out of the panel itself: the
+// `onTabSelect` gate and the keyed-remount effect run for real against it.
+const mockNavigate = jest.fn();
+let mockSection: string | undefined;
+jest.mock( 'react-router', () => ( {
+	useNavigate: () => mockNavigate,
+	useParams: () => ( { section: mockSection } ),
+} ) );
+
+const mockRecordEvent = jest.fn();
+jest.mock( '../../../hooks/use-analytics', () => ( {
+	__esModule: true,
+	default: () => ( { recordEvent: mockRecordEvent } ),
+} ) );
+
+jest.mock( '../../../hooks/use-is-jetpack-user-new', () => ( {
+	__esModule: true,
+	default: () => false,
+} ) );
+
+// The real `TabContent` pulls in the full products/overview/help trees; a stub
+// that echoes its section name is enough to assert which section rendered.
+jest.mock( '../tab-content', () => ( {
+	TabContent: ( { name }: { name: string } ) => {
+		const react = jest.requireActual( 'react' );
+		return react.createElement( 'div', { 'data-testid': 'tab-content' }, name );
+	},
+} ) );
+
+const mockIsSimpleSite = isSimpleSite as jest.Mock;
+const mockCurrentUserCan = currentUserCan as jest.Mock;
+
+const callsFor = ( event: string ) =>
+	mockRecordEvent.mock.calls.filter( ( [ name ] ) => name === event );
+
+beforeEach( () => {
+	jest.clearAllMocks();
+	mockCurrentUserCan.mockReturnValue( true );
+	mockIsSimpleSite.mockReturnValue( false );
+	mockSection = undefined;
+} );
+
+describe( 'MyJetpackTabPanel', () => {
+	it( 'renders the single Products section directly, with no tab bar, on Simple sites', () => {
+		mockIsSimpleSite.mockReturnValue( true );
+
+		render( <MyJetpackTabPanel /> );
+
+		expect( screen.getByTestId( 'tab-content' ) ).toHaveTextContent( MY_JETPACK_SECTION_PRODUCTS );
+		// The direct-render path renders no TabPanel, so there is no tab bar.
+		expect( screen.queryByRole( 'tablist' ) ).not.toBeInTheDocument();
+		// No synthetic click; the page view still fires exactly once.
+		expect( callsFor( 'jetpack_myjetpack_tab_click' ) ).toHaveLength( 0 );
+		expect( callsFor( 'jetpack_myjetpack_tab_view' ) ).toHaveLength( 1 );
+	} );
+
+	it( 'does not record a tab click when the multi-section panel mounts', async () => {
+		mockSection = MY_JETPACK_SECTION_OVERVIEW;
+
+		render( <MyJetpackTabPanel /> );
+		// Awaiting the query lets TabPanel's async post-mount selection settle in act().
+		await expect( screen.findByRole( 'tablist' ) ).resolves.toBeInTheDocument();
+
+		expect( screen.getAllByRole( 'tab' ) ).toHaveLength( 3 );
+		// Mount and the keyed remount both settle on the current tab: no phantom click.
+		expect( callsFor( 'jetpack_myjetpack_tab_click' ) ).toHaveLength( 0 );
+		expect( mockNavigate ).not.toHaveBeenCalled();
+		expect( callsFor( 'jetpack_myjetpack_tab_view' ) ).toHaveLength( 1 );
+	} );
+
+	it( 'does not record a tab click when mounting on a stale or invalid hash', async () => {
+		// Resolves to the default (Overview) rather than erroring or emitting a click.
+		mockSection = 'does-not-exist';
+
+		render( <MyJetpackTabPanel /> );
+		await expect( screen.findByRole( 'tab', { selected: true } ) ).resolves.toHaveTextContent(
+			'Overview'
+		);
+
+		expect( callsFor( 'jetpack_myjetpack_tab_click' ) ).toHaveLength( 0 );
+		expect( mockNavigate ).not.toHaveBeenCalled();
+	} );
+
+	it( 'records one tab click, with the resolved previous tab, on a genuine switch', async () => {
+		mockSection = MY_JETPACK_SECTION_OVERVIEW;
+
+		render( <MyJetpackTabPanel /> );
+		await userEvent.click( screen.getByRole( 'tab', { name: 'Help' } ) );
+
+		expect( callsFor( 'jetpack_myjetpack_tab_click' ) ).toHaveLength( 1 );
+		expect( mockRecordEvent ).toHaveBeenCalledWith(
+			'jetpack_myjetpack_tab_click',
+			expect.objectContaining( {
+				tab_name: MY_JETPACK_SECTION_HELP,
+				previous_tab: MY_JETPACK_SECTION_OVERVIEW,
+			} )
+		);
+		expect( mockNavigate ).toHaveBeenCalledWith( `/${ MY_JETPACK_SECTION_HELP }` );
+	} );
+} );

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/test/utils.test.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/test/utils.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment node
+ */
+import { currentUserCan, isSimpleSite } from '@automattic/jetpack-script-data';
+import {
+	MY_JETPACK_SECTION_HELP,
+	MY_JETPACK_SECTION_OVERVIEW,
+	MY_JETPACK_SECTION_PRODUCTS,
+} from '../constants';
+import {
+	getDefaultMyJetpackSection,
+	getMyJetpackSections,
+	isValidMyJetpackSection,
+} from '../utils';
+
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	currentUserCan: jest.fn(),
+	isSimpleSite: jest.fn(),
+} ) );
+
+const mockCurrentUserCan = currentUserCan as jest.Mock;
+const mockIsSimpleSite = isSimpleSite as jest.Mock;
+
+beforeEach( () => {
+	mockCurrentUserCan.mockReturnValue( true );
+	mockIsSimpleSite.mockReturnValue( false );
+} );
+
+describe( 'getMyJetpackSections', () => {
+	it( 'returns all sections for an admin', () => {
+		expect( getMyJetpackSections().map( tab => tab.name ) ).toEqual( [
+			MY_JETPACK_SECTION_OVERVIEW,
+			MY_JETPACK_SECTION_PRODUCTS,
+			MY_JETPACK_SECTION_HELP,
+		] );
+	} );
+
+	it( 'omits the Products section for non-admins', () => {
+		mockCurrentUserCan.mockReturnValue( false );
+
+		expect( getMyJetpackSections().map( tab => tab.name ) ).toEqual( [
+			MY_JETPACK_SECTION_OVERVIEW,
+			MY_JETPACK_SECTION_HELP,
+		] );
+	} );
+
+	it( 'returns only the Products section on WordPress.com Simple sites', () => {
+		mockIsSimpleSite.mockReturnValue( true );
+
+		expect( getMyJetpackSections().map( tab => tab.name ) ).toEqual( [
+			MY_JETPACK_SECTION_PRODUCTS,
+		] );
+	} );
+
+	it( 'returns only the Products section on Simple sites for non-admins too', () => {
+		mockIsSimpleSite.mockReturnValue( true );
+		mockCurrentUserCan.mockReturnValue( false );
+
+		expect( getMyJetpackSections().map( tab => tab.name ) ).toEqual( [
+			MY_JETPACK_SECTION_PRODUCTS,
+		] );
+	} );
+} );
+
+describe( 'isValidMyJetpackSection', () => {
+	it( 'accepts the Overview section on regular sites', () => {
+		expect( isValidMyJetpackSection( MY_JETPACK_SECTION_OVERVIEW ) ).toBe( true );
+	} );
+
+	it( 'rejects the Overview and Help sections on Simple sites', () => {
+		mockIsSimpleSite.mockReturnValue( true );
+
+		expect( isValidMyJetpackSection( MY_JETPACK_SECTION_OVERVIEW ) ).toBe( false );
+		expect( isValidMyJetpackSection( MY_JETPACK_SECTION_HELP ) ).toBe( false );
+		expect( isValidMyJetpackSection( MY_JETPACK_SECTION_PRODUCTS ) ).toBe( true );
+	} );
+} );
+
+describe( 'getDefaultMyJetpackSection', () => {
+	it( 'defaults to the Overview section on regular sites', () => {
+		expect( getDefaultMyJetpackSection() ).toBe( MY_JETPACK_SECTION_OVERVIEW );
+	} );
+
+	it( 'defaults to the Products section on Simple sites', () => {
+		mockIsSimpleSite.mockReturnValue( true );
+
+		expect( getDefaultMyJetpackSection() ).toBe( MY_JETPACK_SECTION_PRODUCTS );
+	} );
+} );

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/test/utils.test.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/test/utils.test.ts
@@ -22,6 +22,7 @@ const mockCurrentUserCan = currentUserCan as jest.Mock;
 const mockIsSimpleSite = isSimpleSite as jest.Mock;
 
 beforeEach( () => {
+	jest.clearAllMocks();
 	mockCurrentUserCan.mockReturnValue( true );
 	mockIsSimpleSite.mockReturnValue( false );
 } );

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/utils.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/utils.ts
@@ -1,4 +1,4 @@
-import { currentUserCan } from '@automattic/jetpack-script-data';
+import { currentUserCan, isSimpleSite } from '@automattic/jetpack-script-data';
 import { __ } from '@wordpress/i18n';
 import {
 	MY_JETPACK_SECTION_HELP,
@@ -16,8 +16,6 @@ type TabPanelProps = ComponentProps< typeof TabPanel >;
  * @return The sections for the My Jetpack tab panel.
  */
 export function getMyJetpackSections(): TabPanelProps[ 'tabs' ] {
-	const isAdmin = currentUserCan( 'manage_options' );
-
 	const tabs = [
 		{
 			name: MY_JETPACK_SECTION_OVERVIEW,
@@ -33,12 +31,26 @@ export function getMyJetpackSections(): TabPanelProps[ 'tabs' ] {
 		},
 	];
 
-	if ( isAdmin ) {
+	// WordPress.com Simple sites only get the Products section.
+	if ( isSimpleSite() ) {
+		return tabs.filter( tab => tab.name === MY_JETPACK_SECTION_PRODUCTS );
+	}
+
+	if ( currentUserCan( 'manage_options' ) ) {
 		return tabs;
 	}
 
 	// If the user is not an admin, remove the Products tab.
 	return tabs.filter( tab => tab.name !== MY_JETPACK_SECTION_PRODUCTS );
+}
+
+/**
+ * Get the default My Jetpack section.
+ *
+ * @return The name of the first available section.
+ */
+export function getDefaultMyJetpackSection() {
+	return getMyJetpackSections()[ 0 ].name;
 }
 
 /**

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-synthetic-tab-click
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-synthetic-tab-click
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Record a tab-click analytics event only on a genuine tab change, not when the initial or normalized section is resolved on load. Also rewrite a stale or invalid section hash to the resolved section, so a redirect to the section route no longer leaves an unresolved URL in the address bar.
+Record the tab-click analytics event only on a real tab change, and rewrite a stale or invalid section hash to the section shown.

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-synthetic-tab-click
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-synthetic-tab-click
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: only record a tab-click analytics event on a genuine tab change, not when the initial or normalized section is resolved on load.

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-synthetic-tab-click
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-synthetic-tab-click
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Record a tab-click analytics event only on a genuine tab change, not when the initial or normalized section is resolved on load.
+Record a tab-click analytics event only on a genuine tab change, not when the initial or normalized section is resolved on load. Also rewrite a stale or invalid section hash to the resolved section, so a redirect to the section route no longer leaves an unresolved URL in the address bar.

--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-synthetic-tab-click
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-synthetic-tab-click
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-My Jetpack: only record a tab-click analytics event on a genuine tab change, not when the initial or normalized section is resolved on load.
+Record a tab-click analytics event only on a genuine tab change, not when the initial or normalized section is resolved on load.

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-simple-sites-products-only
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-simple-sites-products-only
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+My Jetpack: show only the Products section, without the tab bar, on WordPress.com Simple sites.

--- a/projects/packages/my-jetpack/changelog/update-my-jetpack-simple-sites-products-only
+++ b/projects/packages/my-jetpack/changelog/update-my-jetpack-simple-sites-products-only
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-My Jetpack: show only the Products section, without the tab bar, on WordPress.com Simple sites.
+Show only the Products section, without the tab bar, on WordPress.com Simple sites.


### PR DESCRIPTION
Fixes JETPACK-1944

## Why

On WordPress.com Simple sites the Overview and Help sections don't apply: Overview is built around connection and plan status Simple sites don't have, and Help points at Jetpack plugin flows that don't exist there. Those sites should land on Products directly.

## Proposed changes

* Simple sites render only the Products section, with no tab bar. Every other site is unchanged.
* The default section is now the first available one (`getDefaultMyJetpackSection()`) instead of a hardcoded Overview: Products on Simple sites, Overview everywhere else.
* Non-admins on Simple sites also get Products. Otherwise the existing "hide Products from non-admins" rule would leave them an empty page.
* `jetpack_myjetpack_tab_click` records only on a genuine tab change. `TabPanel` fires `onSelect` on mount with the tab it already settled on, so recording that emitted a synthetic click. The handler now compares against the resolved current tab, so the initial load and stale hashes record nothing.
* The panel rewrites a stale or invalid hash to the section it actually shows: `#/overview` on a Simple site, or the `/:section` an interstitial redirect lands on, becomes `#/products`. It navigates with `replace`, so there's no synthetic click and no extra history entry.

Detection reuses the existing `isSimpleSite()` helper from `@automattic/jetpack-script-data` (`site.host === 'wpcom'`), so there's no new PHP.

## Before / After

Same build on a Jurassic Ninja site at `/wp-admin/admin.php?page=my-jetpack` (1440x900); only site detection differs. "Before" is the site as it reports itself (`site.host` is `atomic`); "after" forces `site.host` to `wpcom`, which is what a Simple site sends. In the "after" state one section remains and the panel renders it directly, with no tab bar.

| Before (tab bar, defaults to Overview) | After (Products only, no tab bar) |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/update/my-jetpack-simple-sites-products-only/before-my-jetpack.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/update/my-jetpack-simple-sites-products-only/after-my-jetpack.png) |

## Related product discussion/links

* JETPACK-1944

## Does this pull request change what data or activity we track or use?

No new event types. `jetpack_myjetpack_tab_click` now fires only on a real tab change, not when the initial or normalized section resolves on load. `page_view` and `tab_view` are unchanged; on Simple sites `tab_name` reports `products`.

## Testing instructions

* Regular Jetpack site: open My Jetpack and confirm nothing changed. Overview, Products, and Help render, and the page defaults to Overview.
* Simple site (with the `my-jetpack` sticker, or `window.JetpackScriptData.site.host` set to `wpcom` before the app renders): open My Jetpack. Only the Products listing shows, with no tab bar.
* Still on Simple, visit `#/overview` or `#/help` directly: Products renders, the URL updates to `#/products`, and no `jetpack_myjetpack_tab_click` fires.
* `pnpm run test` in `projects/packages/my-jetpack` covers the section logic and the panel render/analytics gating (`_inc/components/my-jetpack-tab-panel/test/`).
