### PR TITLE
Agents Manager: Remove legacy review fixture terminology

### DIFF
--- a/projects/packages/agents-manager/changelog/ai-editorial-review-nomenclature-parity
+++ b/projects/packages/agents-manager/changelog/ai-editorial-review-nomenclature-parity
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Tests: Replace a legacy feature-specific fixture name with generic terminology. No functional change.

--- a/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
+++ b/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
@@ -1728,7 +1728,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		add_filter(
 			'jetpack_ai_sidebar_agents_manager_data',
 			function ( $data ) {
-				$data['reviewMediatorEnabled'] = true;
+				$data['customFeatureEnabled'] = true;
 				return $data;
 			}
 		);
@@ -1739,7 +1739,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		$inline_scripts = $wp_scripts->registered['agents-manager']->extra['before'] ?? array();
 		$inline_script  = implode( "\n", array_filter( $inline_scripts ) );
 
-		$this->assertStringContainsString( '"reviewMediatorEnabled":true', $inline_script );
+		$this->assertStringContainsString( '"customFeatureEnabled":true', $inline_script );
 
 		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
 	}


### PR DESCRIPTION
Part of FORNO-376.

## Proposed changes

* Replace the legacy feature-specific `reviewMediatorEnabled` fixture key with the generic `customFeatureEnabled` key in the Agents Manager inline-data extension-filter test.
* Update the matching assertion so the test continues to verify that custom `agentsManagerData` values are passed through to the inline script.
* Add the required Agents Manager package changelog entry for this test-only cleanup.
* Leave production code, runtime contracts, analytics, feature availability, and the customer-facing **Editorial Review** wording unchanged.

## Related product discussion/links

* 228473-ghe-Automattic/wpcom — additive rename foundation.
* 228590-ghe-Automattic/wpcom — canonical server implementation and compatibility seams.
* 228621-ghe-Automattic/wpcom — versioned contract negotiation and canonical cutover architecture.
* 228900-ghe-Automattic/wpcom — production activation of contract negotiation.
* [Automattic/wp-calypso#112763](https://github.com/Automattic/wp-calypso/pull/112763) — canonical Agents Manager client nomenclature and contract capability.

## Does this pull request change what data or activity we track or use?

No. This PR only renames an arbitrary test fixture key and its matching assertion.

## Testing instructions

The code change is test-only. These steps verify that the existing AI Editorial Review flow remains functional with this Jetpack branch.

### Simple site

1. Install this Jetpack branch using `bin/jetpack-downloader test jetpack update/ai-editorial-review-nomenclature-parity-jetpack`.
2. Sandbox the Simple site and `public-api.wordpress.com`.
3. Use production Calypso and the production Agents Manager bundle.
4. Open the Agents Manager sidebar on a draft post and request **Editorial Review**.
5. Confirm the review completes successfully and displays the expected review interface without errors, missing output, or a failed ability invocation.

### Atomic site

1. Install this Jetpack branch on an Atomic test site using the Jetpack Beta plugin.
3. Open a draft post and open the Agents Manager sidebar.
4. Request **Editorial Review**.
5. Confirm the review completes successfully and displays the expected review interface without errors, missing output, or a failed ability invocation.

### Automated checks

* `php -l projects/packages/agents-manager/tests/php/Agents_Manager_Test.php`
* `projects/packages/changelogger/vendor/bin/changelogger validate projects/packages/agents-manager/changelog/ai-editorial-review-nomenclature-parity --no-interaction --no-ansi`
* `git diff --check`
* Repository pre-push lockfile policy, filename-collision, and changelog-requirement checks

The package PHPUnit suite was not run locally.
