### PR TITLE
VideoPress: route media-new.php video uploads to VideoPress

### DIFF
--- a/projects/plugins/jetpack/changelog/add-videopress-media-new-upload
+++ b/projects/plugins/jetpack/changelog/add-videopress-media-new-upload
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+VideoPress: upload videos added via the classic media-new.php uploader directly to VideoPress, matching the Media Library behavior.

--- a/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
+++ b/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
@@ -157,7 +157,7 @@ class Jetpack_VideoPress {
 			'hasVideoPressPurchase' => $has_videopress_purchase,
 			'hasUsedVideo'          => $has_used_video,
 			'strings'               => array(
-				'usedVideoUpload' => sprintf(
+				'usedVideoUpload'        => sprintf(
 					wp_kses(
 						/* translators: %s is the url to upgrade the VideoPress plan */
 						__( 'You have used your free video upload. The free plan includes one video upload. <a href="%s">Upgrade now</a> to unlock unlimited videos, 1TB of storage, and more!', 'jetpack' ),
@@ -165,10 +165,18 @@ class Jetpack_VideoPress {
 					),
 					esc_url( $upgrade_url )
 				),
-				'multipleVideos'  => sprintf(
+				'multipleVideos'         => sprintf(
 					wp_kses(
 						/* translators: %s is the url to upgrade the VideoPress plan */
 						__( 'The free plan includes one video upload. <a href="%s">Upgrade now</a> to upload more videos and unlock unlimited videos, 1TB of storage, and more!', 'jetpack' ),
+						$allowed_html
+					),
+					esc_url( $upgrade_url )
+				),
+				'multipleVideosSelected' => sprintf(
+					wp_kses(
+						/* translators: %s is the url to upgrade the VideoPress plan */
+						__( 'Uploading multiple videos requires a paid plan. The free plan includes one video upload. <a href="%s">Upgrade now</a> to unlock unlimited videos, 1TB of storage, and more!', 'jetpack' ),
 						$allowed_html
 					),
 					esc_url( $upgrade_url )

--- a/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
+++ b/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
@@ -91,6 +91,15 @@ class Jetpack_VideoPress {
 			return;
 		}
 
+		// Version with the served file's mtime so browsers and page caches pick
+		// up new builds even when JETPACK__VERSION has not changed (branch
+		// testing, beta builds).
+		$script_relative = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG
+			? 'modules/videopress/js/videopress-media-new.js'
+			: '_inc/build/videopress/js/videopress-media-new.min.js';
+		$script_path     = JETPACK__PLUGIN_DIR . $script_relative;
+		$script_version  = file_exists( $script_path ) ? (string) filemtime( $script_path ) : JETPACK__VERSION;
+
 		wp_enqueue_script(
 			'videopress-media-new',
 			Assets::get_file_url_for_environment(
@@ -101,7 +110,7 @@ class Jetpack_VideoPress {
 				'jquery',
 				'plupload-handlers',
 			),
-			JETPACK__VERSION,
+			$script_version,
 			true
 		);
 

--- a/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
+++ b/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
@@ -1,6 +1,8 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Current_Plan;
+use Automattic\Jetpack\Status;
 use Automattic\Jetpack\VideoPress\Attachment_Handler;
 use Automattic\Jetpack\VideoPress\Jwt_Token_Bridge;
 use Automattic\Jetpack\VideoPress\Options as VideoPress_Options;
@@ -103,7 +105,76 @@ class Jetpack_VideoPress {
 			true
 		);
 
+		wp_localize_script( 'videopress-media-new', 'videoPressMediaNew', $this->get_media_new_upload_limits() );
+
 		add_filter( 'plupload_init', array( $this, 'videopress_pluploder_config' ) );
+	}
+
+	/**
+	 * Returns the free-plan upload limit data used by the media-new.php script.
+	 *
+	 * The free plan includes a single video upload, so the script needs to know
+	 * whether the site has a paid VideoPress plan, whether the free upload has
+	 * already been used, and where to send the user to upgrade. Mirrors the
+	 * checks behind the VideoPress dashboard's upgrade notice: the paid check
+	 * matches Admin_UI::initial_state()'s paidFeatures, and the used check
+	 * matches the dashboard's VideoPress video count (video/videopress
+	 * attachments).
+	 *
+	 * @return array
+	 */
+	public function get_media_new_upload_limits() {
+		$has_videopress_purchase = Current_Plan::supports( 'videopress-1tb-storage' )
+			|| Current_Plan::supports( 'videopress-unlimited-storage' )
+			|| ( function_exists( 'wpcom_site_has_feature' ) && wpcom_site_has_feature( 'videopress' ) );
+
+		$has_used_video = false;
+		if ( ! $has_videopress_purchase ) {
+			$videopress_videos = get_posts(
+				array(
+					'post_type'      => 'attachment',
+					'post_status'    => 'inherit',
+					'post_mime_type' => 'video/videopress',
+					'posts_per_page' => 1,
+					'fields'         => 'ids',
+				)
+			);
+
+			$has_used_video = count( $videopress_videos ) > 0;
+		}
+
+		$upgrade_url = sprintf(
+			'https://wordpress.com/checkout/%s/jetpack_videopress?redirect_to=%s',
+			rawurlencode( ( new Status() )->get_site_suffix() ),
+			rawurlencode( admin_url( 'media-new.php' ) )
+		);
+
+		$allowed_html = array(
+			'a' => array( 'href' => array() ),
+		);
+
+		return array(
+			'hasVideoPressPurchase' => $has_videopress_purchase,
+			'hasUsedVideo'          => $has_used_video,
+			'strings'               => array(
+				'usedVideoUpload' => sprintf(
+					wp_kses(
+						/* translators: %s is the url to upgrade the VideoPress plan */
+						__( 'You have used your free video upload. The free plan includes one video upload. <a href="%s">Upgrade now</a> to unlock unlimited videos, 1TB of storage, and more!', 'jetpack' ),
+						$allowed_html
+					),
+					esc_url( $upgrade_url )
+				),
+				'multipleVideos'  => sprintf(
+					wp_kses(
+						/* translators: %s is the url to upgrade the VideoPress plan */
+						__( 'The free plan includes one video upload. <a href="%s">Upgrade now</a> to upload more videos and unlock unlimited videos, 1TB of storage, and more!', 'jetpack' ),
+						$allowed_html
+					),
+					esc_url( $upgrade_url )
+				),
+			),
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
+++ b/projects/plugins/jetpack/modules/videopress/class.jetpack-videopress.php
@@ -52,12 +52,9 @@ class Jetpack_VideoPress {
 
 		add_action( 'admin_print_footer_scripts', array( $this, 'print_in_footer_open_media_add_new' ) );
 		add_action( 'admin_head', array( $this, 'enqueue_admin_styles' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_media_new_scripts' ) );
 
 		VideoPress_Scheduler::init();
-
-		if ( $this->is_videopress_enabled() ) {
-			add_action( 'admin_notices', array( $this, 'media_new_page_admin_notice' ) );
-		}
 	}
 
 	/**
@@ -71,32 +68,42 @@ class Jetpack_VideoPress {
 	}
 
 	/**
-	 * The media-new.php page isn't supported for uploading to VideoPress.
+	 * Enqueues the script that routes media-new.php video uploads to VideoPress.
 	 *
-	 * There is either a technical reason for this (bulk uploader isn't overridable),
-	 * or it is an intentional way to give site owners an option for uploading videos that bypass VideoPress.
+	 * The classic uploader on media-new.php builds a raw plupload.Uploader
+	 * (via plupload-handlers) instead of wp.Uploader, so the override in
+	 * videopress-plupload.js never engages there. This companion script
+	 * registers the same videopress_check_uploads plupload filter and
+	 * re-targets video uploads to VideoPress. The filter is injected into the
+	 * uploader settings through the plupload_init filter, which
+	 * media_upload_form() applies when it renders later in the request.
+	 *
+	 * @param string $hook_suffix The current admin page.
 	 */
-	public function media_new_page_admin_notice() {
-		global $pagenow;
-		if ( 'media-new.php' !== $pagenow ) {
+	public function enqueue_media_new_scripts( $hook_suffix ) {
+		if ( 'media-new.php' !== $hook_suffix ) {
 			return;
 		}
 
-		$message = sprintf(
-			wp_kses(
-				/* translators: %s is the url to the Media Library */
-				__( 'VideoPress uploads are not supported here. To upload to VideoPress, add your videos from the <a href="%s">Media Library</a> or the block editor using the Video block.', 'jetpack' ),
-				array( 'a' => array( 'href' => array() ) )
+		if ( ! $this->is_videopress_enabled() ) {
+			return;
+		}
+
+		wp_enqueue_script(
+			'videopress-media-new',
+			Assets::get_file_url_for_environment(
+				'_inc/build/videopress/js/videopress-media-new.min.js',
+				'modules/videopress/js/videopress-media-new.js'
 			),
-			esc_url( admin_url( 'upload.php?mode=grid&action=add-new' ) )
-		);
-		wp_admin_notice(
-			$message,
 			array(
-				'type'        => 'warning',
-				'dismissible' => true,
-			)
+				'jquery',
+				'plupload-handlers',
+			),
+			JETPACK__VERSION,
+			true
 		);
+
+		add_filter( 'plupload_init', array( $this, 'videopress_pluploder_config' ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/videopress/js/test/test-videopress-media-new.js
+++ b/projects/plugins/jetpack/modules/videopress/js/test/test-videopress-media-new.js
@@ -1,0 +1,345 @@
+import { jest } from '@jest/globals';
+
+/**
+ * Creates a chainable jqXHR-like mock for jQuery.post whose done/fail
+ * callbacks can be triggered from the test.
+ *
+ * @return {object} The mock with `jqXhr`, `resolve` and `reject` helpers.
+ */
+function makePostMock() {
+	const callbacks = {};
+	const jqXhr = {
+		done: fn => {
+			callbacks.done = fn;
+			return jqXhr;
+		},
+		fail: fn => {
+			callbacks.fail = fn;
+			return jqXhr;
+		},
+	};
+
+	return {
+		jqXhr,
+		resolve: response => callbacks.done( response ),
+		reject: () => callbacks.fail(),
+	};
+}
+
+describe( 'videopress-media-new', () => {
+	let fileFilter;
+	let readyCallback;
+	let postMock;
+	let uploader;
+	let stockUploadSuccess;
+
+	/**
+	 * Loads the script fresh with mocked globals and captures the plupload
+	 * file filter and the jQuery ready callback it registers.
+	 */
+	function loadScript() {
+		postMock = makePostMock();
+
+		global.plupload = {
+			HTTP_ERROR: 'HTTP_ERROR',
+			FILE_SIZE_ERROR: 'FILE_SIZE_ERROR',
+			addFileFilter: jest.fn( ( name, fn ) => {
+				fileFilter = fn;
+			} ),
+			parseSize: size => parseInt( size, 10 ),
+			translate: string => string,
+		};
+
+		const jQueryMock = jest.fn( fn => {
+			readyCallback = fn;
+		} );
+		jQueryMock.post = () => {};
+		jest.spyOn( jQueryMock, 'post' ).mockImplementation( () => postMock.jqXhr );
+		global.jQuery = jQueryMock;
+
+		global.ajaxurl = 'admin-ajax.php';
+		global.pluploadL10n = {
+			default_error: 'An error occurred in the upload.',
+			file_exceeds_size_limit: '%s exceeds the maximum upload size.',
+		};
+
+		jest.isolateModules( () => {
+			require( '../videopress-media-new' );
+		} );
+	}
+
+	/**
+	 * Runs the captured ready callback with a mocked global uploader and
+	 * stock upload handlers in place.
+	 */
+	function runReadyCallback() {
+		global.wpUploaderInit = {};
+
+		uploader = {
+			bind: jest.fn(),
+			getOption: jest.fn(
+				option =>
+					( {
+						url: 'async-upload.php',
+						file_data_name: 'async-upload',
+						headers: undefined,
+					} )[ option ]
+			),
+			setOption: jest.fn(),
+		};
+		window.uploader = uploader;
+
+		stockUploadSuccess = jest.fn();
+		window.uploadSuccess = stockUploadSuccess;
+		window.wpFileError = () => {};
+		jest.spyOn( window, 'wpFileError' ).mockImplementation();
+
+		readyCallback();
+	}
+
+	/**
+	 * Returns the handlers bound to the given uploader event.
+	 *
+	 * @param {string} event - The plupload event name.
+	 * @return {Function[]} The bound handlers.
+	 */
+	function boundHandlers( event ) {
+		return uploader.bind.mock.calls.filter( call => call[ 0 ] === event ).map( call => call[ 1 ] );
+	}
+
+	beforeEach( () => {
+		fileFilter = undefined;
+		readyCallback = undefined;
+		loadScript();
+	} );
+
+	afterEach( () => {
+		delete global.plupload;
+		delete global.jQuery;
+		delete global.ajaxurl;
+		delete global.pluploadL10n;
+		delete global.wpUploaderInit;
+		delete window.uploader;
+		delete window.uploadSuccess;
+		delete window.wpFileError;
+	} );
+
+	it( 'bails when plupload is not on the page', () => {
+		delete global.plupload;
+		const jQueryMock = jest.fn();
+		jQueryMock.post = () => {};
+		jest.spyOn( jQueryMock, 'post' ).mockImplementation();
+		global.jQuery = jQueryMock;
+
+		jest.isolateModules( () => {
+			require( '../videopress-media-new' );
+		} );
+
+		expect( jQueryMock ).not.toHaveBeenCalled();
+	} );
+
+	describe( 'videopress_check_uploads file filter', () => {
+		it( 'is registered', () => {
+			expect( global.plupload.addFileFilter ).toHaveBeenCalledWith(
+				'videopress_check_uploads',
+				expect.any( Function )
+			);
+		} );
+
+		it( 'fetches an upload token for video files and accepts them', () => {
+			const file = { name: 'movie.mp4', type: 'video/mp4' };
+			const cb = jest.fn();
+
+			fileFilter.call( { trigger: jest.fn() }, '100b', file, cb );
+
+			expect( global.jQuery.post ).toHaveBeenCalledWith( 'admin-ajax.php', {
+				action: 'videopress-get-upload-token',
+				filename: 'movie.mp4',
+			} );
+
+			const tokenData = {
+				upload_action_url: 'https://public-api.wordpress.com/rest/v1.1/sites/1234/media/new',
+				upload_token: 'token',
+				upload_blog_id: 1234,
+			};
+			postMock.resolve( { success: true, data: tokenData } );
+
+			expect( file.videopress ).toEqual( tokenData );
+			expect( cb ).toHaveBeenCalledWith( true );
+		} );
+
+		it( 'rejects video files when the token endpoint reports an error', () => {
+			const file = { name: 'movie.mp4', type: 'video/mp4' };
+			const cb = jest.fn();
+			const context = { trigger: jest.fn() };
+
+			fileFilter.call( context, '100b', file, cb );
+			postMock.resolve( { success: false, data: { message: 'No VideoPress for you' } } );
+
+			expect( context.trigger ).toHaveBeenCalledWith( 'Error', {
+				code: 'HTTP_ERROR',
+				message: 'No VideoPress for you',
+				file,
+			} );
+			expect( cb ).toHaveBeenCalledWith( false );
+		} );
+
+		it( 'rejects video files when the token request fails', () => {
+			const file = { name: 'movie.mp4', type: 'video/mp4' };
+			const cb = jest.fn();
+			const context = { trigger: jest.fn() };
+
+			fileFilter.call( context, '100b', file, cb );
+			postMock.reject();
+
+			expect( context.trigger ).toHaveBeenCalledWith( 'Error', {
+				code: 'HTTP_ERROR',
+				message: 'Could not get the VideoPress token needed for uploading',
+				file,
+			} );
+			expect( cb ).toHaveBeenCalledWith( false );
+		} );
+
+		it( 'rejects non-video files above the maximum size', () => {
+			const file = { name: 'image.jpg', type: 'image/jpeg', size: 200 };
+			const cb = jest.fn();
+			const context = { trigger: jest.fn() };
+
+			fileFilter.call( context, '100b', file, cb );
+
+			expect( context.trigger ).toHaveBeenCalledWith( 'Error', {
+				code: 'FILE_SIZE_ERROR',
+				message: 'image.jpg exceeds the maximum upload size.',
+				file,
+			} );
+			expect( cb ).toHaveBeenCalledWith( false );
+			expect( global.jQuery.post ).not.toHaveBeenCalled();
+		} );
+
+		it( 'accepts non-video files within the maximum size', () => {
+			const file = { name: 'image.jpg', type: 'image/jpeg', size: 50 };
+			const cb = jest.fn();
+
+			fileFilter.call( { trigger: jest.fn() }, '100b', file, cb );
+
+			expect( cb ).toHaveBeenCalledWith( true );
+			expect( global.jQuery.post ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'uploader wiring', () => {
+		it( 'does nothing when the classic uploader is not on the page', () => {
+			readyCallback();
+
+			expect( window.uploadSuccess ).toBeUndefined();
+		} );
+
+		it( 'binds the upload lifecycle events', () => {
+			runReadyCallback();
+
+			expect( boundHandlers( 'BeforeUpload' ) ).toHaveLength( 1 );
+			expect( boundHandlers( 'Error' ) ).toHaveLength( 1 );
+			expect( boundHandlers( 'UploadComplete' ) ).toHaveLength( 1 );
+		} );
+
+		it( 're-targets VideoPress files and restores stock settings afterwards', () => {
+			runReadyCallback();
+
+			const beforeUpload = boundHandlers( 'BeforeUpload' )[ 0 ];
+			const file = {
+				videopress: {
+					upload_action_url: 'https://public-api.wordpress.com/rest/v1.1/sites/1234/media/new',
+					upload_token: 'token',
+					upload_blog_id: 1234,
+				},
+			};
+
+			beforeUpload( uploader, file );
+
+			expect( uploader.setOption ).toHaveBeenCalledWith( 'url', file.videopress.upload_action_url );
+			expect( uploader.setOption ).toHaveBeenCalledWith( 'file_data_name', 'media[]' );
+			expect( uploader.setOption ).toHaveBeenCalledWith( 'headers', {
+				Authorization: 'X_UPLOAD_TOKEN token="token" blog_id="1234"',
+			} );
+
+			uploader.setOption.mockClear();
+
+			// A later non-VideoPress file in the batch gets the stock settings back.
+			beforeUpload( uploader, {} );
+
+			expect( uploader.setOption ).toHaveBeenCalledWith( 'url', 'async-upload.php' );
+			expect( uploader.setOption ).toHaveBeenCalledWith( 'file_data_name', 'async-upload' );
+			expect( uploader.setOption ).toHaveBeenCalledWith( 'headers', undefined );
+		} );
+
+		it( 'leaves the stock settings alone for non-VideoPress files', () => {
+			runReadyCallback();
+
+			boundHandlers( 'BeforeUpload' )[ 0 ]( uploader, {} );
+
+			expect( uploader.setOption ).not.toHaveBeenCalled();
+		} );
+
+		it( 'restores stock settings when an upload batch completes', () => {
+			runReadyCallback();
+
+			boundHandlers( 'BeforeUpload' )[ 0 ]( uploader, { videopress: { upload_token: 't' } } );
+			uploader.setOption.mockClear();
+
+			boundHandlers( 'UploadComplete' )[ 0 ]( uploader );
+
+			expect( uploader.setOption ).toHaveBeenCalledWith( 'url', 'async-upload.php' );
+		} );
+
+		it( 'restores stock settings when an upload errors', () => {
+			runReadyCallback();
+
+			boundHandlers( 'BeforeUpload' )[ 0 ]( uploader, { videopress: { upload_token: 't' } } );
+			uploader.setOption.mockClear();
+
+			boundHandlers( 'Error' )[ 0 ]( uploader );
+
+			expect( uploader.setOption ).toHaveBeenCalledWith( 'url', 'async-upload.php' );
+		} );
+	} );
+
+	describe( 'uploadSuccess wrapper', () => {
+		it( 'passes non-VideoPress uploads through untouched', () => {
+			runReadyCallback();
+
+			const file = { name: 'image.jpg' };
+			window.uploadSuccess( file, '42' );
+
+			expect( stockUploadSuccess ).toHaveBeenCalledWith( file, '42' );
+		} );
+
+		it( 'hands the attachment ID from the REST response to the stock handler', () => {
+			runReadyCallback();
+
+			const file = { videopress: { upload_token: 't' } };
+			window.uploadSuccess( file, JSON.stringify( { media: [ { ID: 123 } ] } ) );
+
+			expect( stockUploadSuccess ).toHaveBeenCalledWith( file, '123' );
+		} );
+
+		it( 'reports an error when the response is not valid JSON', () => {
+			runReadyCallback();
+
+			const file = { videopress: { upload_token: 't' } };
+			window.uploadSuccess( file, 'this is not JSON' );
+
+			expect( stockUploadSuccess ).not.toHaveBeenCalled();
+			expect( window.wpFileError ).toHaveBeenCalledWith( file, 'An error occurred in the upload.' );
+		} );
+
+		it( 'reports the API error message when the response has no media', () => {
+			runReadyCallback();
+
+			const file = { videopress: { upload_token: 't' } };
+			window.uploadSuccess( file, JSON.stringify( { message: 'Upload rejected' } ) );
+
+			expect( stockUploadSuccess ).not.toHaveBeenCalled();
+			expect( window.wpFileError ).toHaveBeenCalledWith( file, 'Upload rejected' );
+		} );
+	} );
+} );

--- a/projects/plugins/jetpack/modules/videopress/js/test/test-videopress-media-new.js
+++ b/projects/plugins/jetpack/modules/videopress/js/test/test-videopress-media-new.js
@@ -117,6 +117,7 @@ describe( 'videopress-media-new', () => {
 	} );
 
 	afterEach( () => {
+		document.body.innerHTML = '';
 		delete global.plupload;
 		delete global.jQuery;
 		delete global.ajaxurl;
@@ -335,6 +336,52 @@ describe( 'videopress-media-new', () => {
 			expect( cb ).toHaveBeenCalledWith( true );
 		} );
 
+		it( 'renders the notice outside the error area the stock uploader clears', () => {
+			document.body.innerHTML =
+				'<div class="media-upload-form"><div id="media-upload-error"></div></div>';
+			setUploadLimits( { hasVideoPressPurchase: false, hasUsedVideo: false } );
+			runReadyCallback();
+
+			const videoA = { name: 'a.mp4', type: 'video/mp4' };
+			const videoB = { name: 'b.mp4', type: 'video/mp4' };
+			window.uploader.addFile( [ videoA, videoB ] );
+			fileFilter.call( { trigger: jest.fn() }, '100b', videoA, jest.fn() );
+
+			const notice = document.querySelector( '.videopress-media-new-notice' );
+			expect( notice ).not.toBeNull();
+			expect( notice ).toHaveTextContent( 'Multiple videos need a paid plan' );
+			expect( notice.querySelector( 'a' ) ).not.toBeNull();
+			expect( window.wpQueueError ).not.toHaveBeenCalled();
+
+			// The stock FilesAdded handler empties #media-upload-error when
+			// part of a selection is accepted; the notice must survive that.
+			document.getElementById( 'media-upload-error' ).innerHTML = '';
+			expect( document.querySelector( '.videopress-media-new-notice' ) ).not.toBeNull();
+		} );
+
+		it( 'clears the previous notice when a new selection starts', () => {
+			document.body.innerHTML =
+				'<div class="media-upload-form"><div id="media-upload-error"></div></div>';
+			setUploadLimits( { hasVideoPressPurchase: false, hasUsedVideo: false } );
+			runReadyCallback();
+
+			window.uploader.addFile( [
+				{ name: 'a.mp4', type: 'video/mp4' },
+				{ name: 'b.mp4', type: 'video/mp4' },
+			] );
+			fileFilter.call(
+				{ trigger: jest.fn() },
+				'100b',
+				{ name: 'a.mp4', type: 'video/mp4' },
+				jest.fn()
+			);
+			expect( document.querySelector( '.videopress-media-new-notice' ) ).not.toBeNull();
+
+			window.uploader.addFile( [ { name: 'c.mp4', type: 'video/mp4' } ] );
+
+			expect( document.querySelector( '.videopress-media-new-notice' ) ).toBeNull();
+		} );
+
 		it( 'allows multi-video selections with a VideoPress purchase', () => {
 			setUploadLimits( { hasVideoPressPurchase: true, hasUsedVideo: false } );
 			runReadyCallback();
@@ -400,6 +447,17 @@ describe( 'videopress-media-new', () => {
 			expect( firstCb ).toHaveBeenCalledWith( true );
 			expect( secondCb ).toHaveBeenCalledWith( true );
 			expect( window.wpQueueError ).not.toHaveBeenCalled();
+		} );
+
+		it( 'still rejects the video when the notice strings are missing', () => {
+			setUploadLimits( { hasVideoPressPurchase: false, hasUsedVideo: true, strings: {} } );
+
+			const cb = jest.fn();
+			fileFilter.call( { trigger: jest.fn() }, '100b', { name: 'a.mp4', type: 'video/mp4' }, cb );
+
+			expect( cb ).toHaveBeenCalledWith( false );
+			expect( window.wpQueueError ).not.toHaveBeenCalled();
+			expect( document.querySelector( '.videopress-media-new-notice' ) ).toBeNull();
 		} );
 
 		it( 'does not restrict non-video files on the free plan', () => {

--- a/projects/plugins/jetpack/modules/videopress/js/test/test-videopress-media-new.js
+++ b/projects/plugins/jetpack/modules/videopress/js/test/test-videopress-media-new.js
@@ -119,10 +119,42 @@ describe( 'videopress-media-new', () => {
 		delete global.ajaxurl;
 		delete global.pluploadL10n;
 		delete global.wpUploaderInit;
+		delete global.videoPressMediaNew;
 		delete window.uploader;
 		delete window.uploadSuccess;
 		delete window.wpFileError;
+		delete window.wpQueueError;
 	} );
+
+	/**
+	 * Sets the localized upload limit data and a spied wpQueueError global.
+	 *
+	 * @param {object} limits - The videoPressMediaNew payload.
+	 */
+	function setUploadLimits( limits ) {
+		global.videoPressMediaNew = {
+			strings: {
+				usedVideoUpload: 'Free video upload used. <a href="checkout">Upgrade now</a>',
+				multipleVideos: 'One video on the free plan. <a href="checkout">Upgrade now</a>',
+			},
+			...limits,
+		};
+		window.wpQueueError = () => {};
+		jest.spyOn( window, 'wpQueueError' ).mockImplementation();
+	}
+
+	/**
+	 * Accepts a video file through the filter, resolving the token request.
+	 *
+	 * @param {object} file - The plupload file object.
+	 * @return {Function} The filter continuation callback mock.
+	 */
+	function acceptVideoThroughFilter( file ) {
+		const cb = jest.fn();
+		fileFilter.call( { trigger: jest.fn() }, '100b', file, cb );
+		postMock.resolve( { success: true, data: { upload_action_url: 'url', upload_token: 't' } } );
+		return cb;
+	}
 
 	it( 'bails when plupload is not on the page', () => {
 		delete global.plupload;
@@ -224,6 +256,87 @@ describe( 'videopress-media-new', () => {
 
 			expect( cb ).toHaveBeenCalledWith( true );
 			expect( global.jQuery.post ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	describe( 'free plan upload limits', () => {
+		it( 'rejects videos with the upgrade notice when the free video upload was used', () => {
+			setUploadLimits( { hasVideoPressPurchase: false, hasUsedVideo: true } );
+
+			const cb = jest.fn();
+			fileFilter.call( { trigger: jest.fn() }, '100b', { name: 'a.mp4', type: 'video/mp4' }, cb );
+
+			expect( cb ).toHaveBeenCalledWith( false );
+			expect( window.wpQueueError ).toHaveBeenCalledWith(
+				'Free video upload used. <a href="checkout">Upgrade now</a>'
+			);
+			expect( global.jQuery.post ).not.toHaveBeenCalled();
+		} );
+
+		it( 'allows a single video and rejects the rest of the batch with the upgrade notice', () => {
+			setUploadLimits( { hasVideoPressPurchase: false, hasUsedVideo: false } );
+
+			const firstCb = acceptVideoThroughFilter( { name: 'a.mp4', type: 'video/mp4' } );
+			expect( firstCb ).toHaveBeenCalledWith( true );
+			expect( window.wpQueueError ).not.toHaveBeenCalled();
+
+			const secondCb = jest.fn();
+			fileFilter.call(
+				{ trigger: jest.fn() },
+				'100b',
+				{ name: 'b.mp4', type: 'video/mp4' },
+				secondCb
+			);
+
+			expect( secondCb ).toHaveBeenCalledWith( false );
+			expect( window.wpQueueError ).toHaveBeenCalledWith(
+				'One video on the free plan. <a href="checkout">Upgrade now</a>'
+			);
+			expect( global.jQuery.post ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'does not consume the free video slot when the token request fails', () => {
+			setUploadLimits( { hasVideoPressPurchase: false, hasUsedVideo: false } );
+
+			const failedCb = jest.fn();
+			fileFilter.call(
+				{ trigger: jest.fn() },
+				'100b',
+				{ name: 'a.mp4', type: 'video/mp4' },
+				failedCb
+			);
+			postMock.reject();
+			expect( failedCb ).toHaveBeenCalledWith( false );
+
+			const retryCb = acceptVideoThroughFilter( { name: 'a.mp4', type: 'video/mp4' } );
+			expect( retryCb ).toHaveBeenCalledWith( true );
+			expect( window.wpQueueError ).not.toHaveBeenCalled();
+		} );
+
+		it( 'allows multiple videos with a VideoPress purchase', () => {
+			setUploadLimits( { hasVideoPressPurchase: true, hasUsedVideo: true } );
+
+			const firstCb = acceptVideoThroughFilter( { name: 'a.mp4', type: 'video/mp4' } );
+			const secondCb = acceptVideoThroughFilter( { name: 'b.mp4', type: 'video/mp4' } );
+
+			expect( firstCb ).toHaveBeenCalledWith( true );
+			expect( secondCb ).toHaveBeenCalledWith( true );
+			expect( window.wpQueueError ).not.toHaveBeenCalled();
+		} );
+
+		it( 'does not restrict non-video files on the free plan', () => {
+			setUploadLimits( { hasVideoPressPurchase: false, hasUsedVideo: true } );
+
+			const cb = jest.fn();
+			fileFilter.call(
+				{ trigger: jest.fn() },
+				'100b',
+				{ name: 'image.jpg', type: 'image/jpeg', size: 50 },
+				cb
+			);
+
+			expect( cb ).toHaveBeenCalledWith( true );
+			expect( window.wpQueueError ).not.toHaveBeenCalled();
 		} );
 	} );
 

--- a/projects/plugins/jetpack/modules/videopress/js/test/test-videopress-media-new.js
+++ b/projects/plugins/jetpack/modules/videopress/js/test/test-videopress-media-new.js
@@ -32,6 +32,7 @@ describe( 'videopress-media-new', () => {
 	let postMock;
 	let uploader;
 	let stockUploadSuccess;
+	let stockAddFileMock;
 
 	/**
 	 * Loads the script fresh with mocked globals and captures the plupload
@@ -76,6 +77,7 @@ describe( 'videopress-media-new', () => {
 		global.wpUploaderInit = {};
 
 		uploader = {
+			addFile: jest.fn(),
 			bind: jest.fn(),
 			getOption: jest.fn(
 				option =>
@@ -87,6 +89,7 @@ describe( 'videopress-media-new', () => {
 			),
 			setOption: jest.fn(),
 		};
+		stockAddFileMock = uploader.addFile;
 		window.uploader = uploader;
 
 		stockUploadSuccess = jest.fn();
@@ -136,6 +139,8 @@ describe( 'videopress-media-new', () => {
 			strings: {
 				usedVideoUpload: 'Free video upload used. <a href="checkout">Upgrade now</a>',
 				multipleVideos: 'One video on the free plan. <a href="checkout">Upgrade now</a>',
+				multipleVideosSelected:
+					'Multiple videos need a paid plan. <a href="checkout">Upgrade now</a>',
 			},
 			...limits,
 		};
@@ -273,7 +278,80 @@ describe( 'videopress-media-new', () => {
 			expect( global.jQuery.post ).not.toHaveBeenCalled();
 		} );
 
-		it( 'allows a single video and rejects the rest of the batch with the upgrade notice', () => {
+		it( 'blocks every video of a multi-video selection with the upgrade notice', () => {
+			setUploadLimits( { hasVideoPressPurchase: false, hasUsedVideo: false } );
+			runReadyCallback();
+
+			const videoA = { name: 'a.mp4', type: 'video/mp4' };
+			const videoB = { name: 'b.mp4', type: 'video/mp4' };
+			window.uploader.addFile( [ videoA, videoB ] );
+
+			expect( stockAddFileMock ).toHaveBeenCalledWith( [ videoA, videoB ], undefined );
+
+			const firstCb = jest.fn();
+			const secondCb = jest.fn();
+			fileFilter.call( { trigger: jest.fn() }, '100b', videoA, firstCb );
+			fileFilter.call( { trigger: jest.fn() }, '100b', videoB, secondCb );
+
+			expect( firstCb ).toHaveBeenCalledWith( false );
+			expect( secondCb ).toHaveBeenCalledWith( false );
+			expect( window.wpQueueError ).toHaveBeenCalledWith(
+				'Multiple videos need a paid plan. <a href="checkout">Upgrade now</a>'
+			);
+			expect( global.jQuery.post ).not.toHaveBeenCalled();
+		} );
+
+		it( 'still allows a single-video selection after a blocked multi-video selection', () => {
+			setUploadLimits( { hasVideoPressPurchase: false, hasUsedVideo: false } );
+			runReadyCallback();
+
+			window.uploader.addFile( [
+				{ name: 'a.mp4', type: 'video/mp4' },
+				{ name: 'b.mp4', type: 'video/mp4' },
+			] );
+
+			const single = { name: 'c.mp4', type: 'video/mp4' };
+			window.uploader.addFile( [ single ] );
+
+			const cb = acceptVideoThroughFilter( single );
+
+			expect( cb ).toHaveBeenCalledWith( true );
+		} );
+
+		it( 'lets non-videos of a multi-video selection through', () => {
+			setUploadLimits( { hasVideoPressPurchase: false, hasUsedVideo: false } );
+			runReadyCallback();
+
+			const image = { name: 'image.jpg', type: 'image/jpeg', size: 50 };
+			window.uploader.addFile( [
+				image,
+				{ name: 'a.mp4', type: 'video/mp4' },
+				{ name: 'b.mp4', type: 'video/mp4' },
+			] );
+
+			const cb = jest.fn();
+			fileFilter.call( { trigger: jest.fn() }, '100b', image, cb );
+
+			expect( cb ).toHaveBeenCalledWith( true );
+		} );
+
+		it( 'allows multi-video selections with a VideoPress purchase', () => {
+			setUploadLimits( { hasVideoPressPurchase: true, hasUsedVideo: false } );
+			runReadyCallback();
+
+			const videoA = { name: 'a.mp4', type: 'video/mp4' };
+			const videoB = { name: 'b.mp4', type: 'video/mp4' };
+			window.uploader.addFile( [ videoA, videoB ] );
+
+			const firstCb = acceptVideoThroughFilter( videoA );
+			const secondCb = acceptVideoThroughFilter( videoB );
+
+			expect( firstCb ).toHaveBeenCalledWith( true );
+			expect( secondCb ).toHaveBeenCalledWith( true );
+			expect( window.wpQueueError ).not.toHaveBeenCalled();
+		} );
+
+		it( 'allows a single video and rejects a subsequent video selection with the upgrade notice', () => {
 			setUploadLimits( { hasVideoPressPurchase: false, hasUsedVideo: false } );
 
 			const firstCb = acceptVideoThroughFilter( { name: 'a.mp4', type: 'video/mp4' } );

--- a/projects/plugins/jetpack/modules/videopress/js/videopress-media-new.js
+++ b/projects/plugins/jetpack/modules/videopress/js/videopress-media-new.js
@@ -21,6 +21,33 @@
 	// enforce the free plan's single-video limit within an upload session.
 	var acceptedVideoCount = 0;
 
+	// Video files in the selection currently being added to the uploader,
+	// recorded before the file filters run so the free-plan gate can block a
+	// multi-video selection before any upload starts.
+	var pendingBatchVideoCount = 0;
+
+	/**
+	 * Counts the video files in an addFile() argument.
+	 *
+	 * @param {Array|FileList|object} file What was passed to addFile: a single
+	 *                                     file or an array-like of files.
+	 * @return {number} How many of them are videos.
+	 */
+	function countVideoFiles( file ) {
+		var files = file && typeof file.length === 'number' ? file : [ file ];
+		var count = 0;
+
+		for ( var i = 0; i < files.length; i++ ) {
+			var type = files[ i ] && files[ i ].type;
+
+			if ( type && type.split( '/' )[ 0 ] === 'video' ) {
+				count++;
+			}
+		}
+
+		return count;
+	}
+
 	/**
 	 * Returns the upload limit data localized by the module.
 	 *
@@ -64,6 +91,14 @@
 
 		if ( limits.hasUsedVideo ) {
 			showUpgradeNotice( strings.usedVideoUpload );
+			cb( false );
+			return true;
+		}
+
+		// A selection with more than one video is blocked entirely — including
+		// its first video — so no upload starts until the user upgrades.
+		if ( pendingBatchVideoCount > 1 ) {
+			showUpgradeNotice( strings.multipleVideosSelected );
 			cb( false );
 			return true;
 		}
@@ -178,6 +213,19 @@
 		}
 
 		var uploader = window.uploader;
+
+		/**
+		 * Record how many videos each selection contains before plupload runs
+		 * the file filters, so the free-plan gate can reject every video of a
+		 * multi-video selection. Both the file selector and drag-and-drop
+		 * funnel their whole selection through a single addFile() call.
+		 */
+		var stockAddFile = uploader.addFile;
+
+		uploader.addFile = function ( file, fileName ) {
+			pendingBatchVideoCount = countVideoFiles( file );
+			return stockAddFile.call( this, file, fileName );
+		};
 
 		/**
 		 * Re-target VideoPress files right before each upload starts and

--- a/projects/plugins/jetpack/modules/videopress/js/videopress-media-new.js
+++ b/projects/plugins/jetpack/modules/videopress/js/videopress-media-new.js
@@ -1,0 +1,188 @@
+/* global plupload, pluploadL10n, ajaxurl, wpUploaderInit, uploadSuccess, wpFileError */
+
+/**
+ * Routes video uploads from wp-admin/media-new.php to VideoPress.
+ *
+ * The classic uploader (plupload-handlers) creates a raw plupload.Uploader
+ * rather than wp.Uploader, so the override in videopress-plupload.js never
+ * engages there. This shim registers the same videopress_check_uploads file
+ * filter and re-targets video uploads to VideoPress, then hands the local
+ * attachment ID created during the upload back to the stock uploadSuccess
+ * handler so the classic UI renders the media item as usual.
+ */
+( function ( $ ) {
+	if ( typeof plupload === 'undefined' ) {
+		return;
+	}
+
+	var originalOptions = {};
+
+	/**
+	 * Restores the stock upload settings saved before a VideoPress upload.
+	 *
+	 * @param {plupload.Uploader} up Uploader instance.
+	 */
+	function restoreOriginalOptions( up ) {
+		if ( typeof originalOptions.url === 'undefined' ) {
+			return;
+		}
+
+		up.setOption( 'url', originalOptions.url );
+		up.setOption( 'file_data_name', originalOptions.file_data_name );
+		up.setOption( 'headers', originalOptions.headers );
+
+		originalOptions = {};
+	}
+
+	/**
+	 * For video files, fetch a VideoPress upload token and attach it to the
+	 * file before it is queued. Mirrors the videopress_check_uploads filter in
+	 * videopress-uploader.js without depending on wp.media, which is not
+	 * loaded on media-new.php. Non-video files get the stock max_file_size
+	 * behavior this filter replaces.
+	 */
+	plupload.addFileFilter( 'videopress_check_uploads', function ( maxSize, file, cb ) {
+		var self = this;
+
+		/**
+		 * Rejects the file with an uploader error.
+		 *
+		 * @param {string} [message] Error message to display.
+		 */
+		function fail( message ) {
+			self.trigger( 'Error', {
+				code: plupload.HTTP_ERROR,
+				message:
+					message ||
+					plupload.translate( 'Could not get the VideoPress token needed for uploading' ),
+				file: file,
+			} );
+			cb( false );
+		}
+
+		if ( file.type && file.type.split( '/' )[ 0 ] === 'video' ) {
+			$.post( ajaxurl, { action: 'videopress-get-upload-token', filename: file.name } )
+				.done( function ( response ) {
+					if (
+						! response ||
+						! response.success ||
+						! response.data ||
+						! response.data.upload_action_url
+					) {
+						fail( response && response.data && response.data.message );
+						return;
+					}
+
+					file.videopress = response.data;
+					cb( true );
+				} )
+				.fail( function () {
+					fail();
+				} );
+
+			return;
+		}
+
+		// Handles the stock max_file_size functionality for non-video files.
+		if (
+			typeof file.size !== 'undefined' &&
+			maxSize &&
+			file.size > plupload.parseSize( maxSize )
+		) {
+			this.trigger( 'Error', {
+				code: plupload.FILE_SIZE_ERROR,
+				message: pluploadL10n.file_exceeds_size_limit.replace( '%s', file.name ),
+				file: file,
+			} );
+			cb( false );
+			return;
+		}
+
+		cb( true );
+	} );
+
+	$( function () {
+		// plupload-handlers is a dependency of this script, so its ready
+		// callback ran first and the global `uploader` already exists.
+		if (
+			typeof wpUploaderInit === 'undefined' ||
+			typeof window.uploader === 'undefined' ||
+			! window.uploader
+		) {
+			return;
+		}
+
+		var uploader = window.uploader;
+
+		/**
+		 * Re-target VideoPress files right before each upload starts and
+		 * restore the stock settings for everything else, so mixed batches
+		 * of videos and other media both land in the right place.
+		 */
+		uploader.bind( 'BeforeUpload', function ( up, file ) {
+			if ( typeof file.videopress === 'undefined' ) {
+				restoreOriginalOptions( up );
+				return;
+			}
+
+			if ( typeof originalOptions.url === 'undefined' ) {
+				originalOptions.url = up.getOption( 'url' );
+				originalOptions.file_data_name = up.getOption( 'file_data_name' );
+				originalOptions.headers = up.getOption( 'headers' );
+			}
+
+			up.setOption( 'url', file.videopress.upload_action_url );
+			up.setOption( 'file_data_name', 'media[]' );
+			up.setOption( 'headers', {
+				Authorization:
+					'X_UPLOAD_TOKEN token="' +
+					file.videopress.upload_token +
+					'" blog_id="' +
+					file.videopress.upload_blog_id +
+					'"',
+			} );
+		} );
+
+		uploader.bind( 'Error', function ( up ) {
+			restoreOriginalOptions( up );
+		} );
+
+		uploader.bind( 'UploadComplete', function ( up ) {
+			restoreOriginalOptions( up );
+		} );
+
+		/**
+		 * The stock FileUploaded handler calls the global uploadSuccess with
+		 * the raw server response, which for VideoPress uploads is the REST
+		 * API media response instead of the attachment ID async-upload.php
+		 * returns. Wrap uploadSuccess to translate the former into the
+		 * latter; the stock handler then loads the media item row from
+		 * async-upload.php as it would for any other upload.
+		 */
+		var stockUploadSuccess = uploadSuccess;
+
+		window.uploadSuccess = function ( fileObj, serverData ) {
+			if ( typeof fileObj.videopress === 'undefined' ) {
+				return stockUploadSuccess( fileObj, serverData );
+			}
+
+			var response = null;
+
+			try {
+				response = JSON.parse( serverData );
+			} catch {
+				// Handled below.
+			}
+
+			var media = response && response.media && response.media[ 0 ];
+
+			if ( ! media || ! media.ID ) {
+				var message = response && ( response.message || response.error );
+				wpFileError( fileObj, message || pluploadL10n.default_error );
+				return;
+			}
+
+			return stockUploadSuccess( fileObj, String( media.ID ) );
+		};
+	} );
+} )( jQuery );

--- a/projects/plugins/jetpack/modules/videopress/js/videopress-media-new.js
+++ b/projects/plugins/jetpack/modules/videopress/js/videopress-media-new.js
@@ -1,4 +1,4 @@
-/* global plupload, pluploadL10n, ajaxurl, wpUploaderInit, uploadSuccess, wpFileError */
+/* global plupload, pluploadL10n, ajaxurl, wpUploaderInit, uploadSuccess, wpFileError, wpQueueError, videoPressMediaNew */
 
 /**
  * Routes video uploads from wp-admin/media-new.php to VideoPress.
@@ -16,6 +16,66 @@
 	}
 
 	var originalOptions = {};
+
+	// Videos accepted for VideoPress upload since the page loaded, used to
+	// enforce the free plan's single-video limit within an upload session.
+	var acceptedVideoCount = 0;
+
+	/**
+	 * Returns the upload limit data localized by the module.
+	 *
+	 * @return {object} The limit data.
+	 */
+	function getUploadLimits() {
+		return typeof videoPressMediaNew !== 'undefined' ? videoPressMediaNew : {};
+	}
+
+	/**
+	 * Shows the free-plan upgrade notice above the upload queue.
+	 *
+	 * The message is pre-escaped HTML built server-side, containing the link
+	 * to the upgrade path. wpQueueError renders it inside the stock
+	 * media-upload-error notice, like other queue-level upload errors.
+	 *
+	 * @param {string} message The notice HTML.
+	 */
+	function showUpgradeNotice( message ) {
+		if ( typeof wpQueueError === 'function' && message ) {
+			wpQueueError( message );
+		}
+	}
+
+	/**
+	 * Free-plan gate for a video file: the free plan includes a single video
+	 * upload, so reject every video once the site already has a VideoPress
+	 * video, and allow only one video per upload session otherwise.
+	 *
+	 * @param {plupload.File} file The video file being queued.
+	 * @param {Function}      cb   The file filter continuation callback.
+	 * @return {boolean} Whether the file was rejected.
+	 */
+	function rejectedByFreePlanLimits( file, cb ) {
+		var limits = getUploadLimits();
+		var strings = limits.strings || {};
+
+		if ( limits.hasVideoPressPurchase ) {
+			return false;
+		}
+
+		if ( limits.hasUsedVideo ) {
+			showUpgradeNotice( strings.usedVideoUpload );
+			cb( false );
+			return true;
+		}
+
+		if ( acceptedVideoCount >= 1 ) {
+			showUpgradeNotice( strings.multipleVideos );
+			cb( false );
+			return true;
+		}
+
+		return false;
+	}
 
 	/**
 	 * Restores the stock upload settings saved before a VideoPress upload.
@@ -61,6 +121,10 @@
 		}
 
 		if ( file.type && file.type.split( '/' )[ 0 ] === 'video' ) {
+			if ( rejectedByFreePlanLimits( file, cb ) ) {
+				return;
+			}
+
 			$.post( ajaxurl, { action: 'videopress-get-upload-token', filename: file.name } )
 				.done( function ( response ) {
 					if (
@@ -74,6 +138,7 @@
 					}
 
 					file.videopress = response.data;
+					acceptedVideoCount++;
 					cb( true );
 				} )
 				.fail( function () {

--- a/projects/plugins/jetpack/modules/videopress/js/videopress-media-new.js
+++ b/projects/plugins/jetpack/modules/videopress/js/videopress-media-new.js
@@ -57,19 +57,59 @@
 		return typeof videoPressMediaNew !== 'undefined' ? videoPressMediaNew : {};
 	}
 
+	// Class of the container the upgrade notice renders in.
+	var NOTICE_CLASS = 'videopress-media-new-notice';
+
+	/**
+	 * Removes any previously rendered upgrade notice.
+	 */
+	function removeUpgradeNotice() {
+		var notices = document.querySelectorAll( '.' + NOTICE_CLASS );
+
+		for ( var i = 0; i < notices.length; i++ ) {
+			notices[ i ].parentNode.removeChild( notices[ i ] );
+		}
+	}
+
 	/**
 	 * Shows the free-plan upgrade notice above the upload queue.
 	 *
 	 * The message is pre-escaped HTML built server-side, containing the link
-	 * to the upgrade path. wpQueueError renders it inside the stock
-	 * media-upload-error notice, like other queue-level upload errors.
+	 * to the upgrade path. It renders in a container of its own next to the
+	 * stock #media-upload-error area rather than inside it: the stock
+	 * FilesAdded handler empties #media-upload-error as soon as any file of
+	 * the selection is accepted, which would wipe a notice rendered there
+	 * before the user could read it.
 	 *
 	 * @param {string} message The notice HTML.
 	 */
 	function showUpgradeNotice( message ) {
-		if ( typeof wpQueueError === 'function' && message ) {
-			wpQueueError( message );
+		if ( ! message ) {
+			return;
 		}
+
+		var anchor = document.getElementById( 'media-upload-error' );
+
+		if ( ! anchor || ! anchor.parentNode ) {
+			// The stock error area is better than no notice at all.
+			if ( typeof wpQueueError === 'function' ) {
+				wpQueueError( message );
+			}
+			return;
+		}
+
+		removeUpgradeNotice();
+
+		var notice = document.createElement( 'div' );
+		notice.className = 'notice notice-warning ' + NOTICE_CLASS;
+
+		var paragraph = document.createElement( 'p' );
+		// The message is localized server-side and passed through wp_kses;
+		// it only contains the upgrade link markup.
+		paragraph.innerHTML = message;
+
+		notice.appendChild( paragraph );
+		anchor.parentNode.insertBefore( notice, anchor.nextSibling );
 	}
 
 	/**
@@ -223,6 +263,9 @@
 		var stockAddFile = uploader.addFile;
 
 		uploader.addFile = function ( file, fileName ) {
+			// Each selection starts clean: a notice about a previous
+			// selection no longer applies to this one.
+			removeUpgradeNotice();
 			pendingBatchVideoCount = countVideoFiles( file );
 			return stockAddFile.call( this, file, fileName );
 		};

--- a/projects/plugins/jetpack/tests/php/modules/videopress/Jetpack_VideoPress_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/videopress/Jetpack_VideoPress_Test.php
@@ -201,6 +201,7 @@ class Jetpack_VideoPress_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'https://wordpress.com/checkout/', $limits['strings']['usedVideoUpload'] );
 		$this->assertStringContainsString( 'jetpack_videopress', $limits['strings']['usedVideoUpload'] );
 		$this->assertStringContainsString( 'jetpack_videopress', $limits['strings']['multipleVideos'] );
+		$this->assertStringContainsString( 'jetpack_videopress', $limits['strings']['multipleVideosSelected'] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/videopress/Jetpack_VideoPress_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/videopress/Jetpack_VideoPress_Test.php
@@ -71,9 +71,17 @@ class Jetpack_VideoPress_Test extends WP_UnitTestCase {
 	private function reset_plan_and_options_caches() {
 		VideoPress_Options::delete_options();
 
-		$cache = new ReflectionProperty( Current_Plan::class, 'active_plan_cache' );
-		$cache->setAccessible( true );
-		$cache->setValue( null, null );
+		// Clear Current_Plan::$active_plan_cache. A bound closure works on
+		// every supported PHP version, unlike ReflectionProperty::setAccessible
+		// (required before PHP 8.1, deprecated as of PHP 8.5).
+		$reset_plan_cache = Closure::bind(
+			static function () {
+				self::$active_plan_cache = null;
+			},
+			null,
+			Current_Plan::class
+		);
+		$reset_plan_cache();
 	}
 
 	/**
@@ -82,6 +90,22 @@ class Jetpack_VideoPress_Test extends WP_UnitTestCase {
 	private function connect_site() {
 		Jetpack_Options::update_option( 'id', 1234 );
 		$this->reset_plan_and_options_caches();
+	}
+
+	/**
+	 * Skips the current test when the suite runs with wpcomsh active.
+	 *
+	 * With wpcomsh loaded, wpcom_feature_exists()/wpcom_site_has_feature()
+	 * exist, so Current_Plan::supports() resolves plan features through WPCOM
+	 * feature gating instead of the jetpack_active_plan option. Purchases come
+	 * from Atomic_Persistent_Data, which is a null stub in the wpcomsh repo
+	 * (the real implementation lives on the Atomic platform), so plan states
+	 * cannot be simulated in that environment.
+	 */
+	private function skip_when_wpcomsh_is_active() {
+		if ( '1' === getenv( 'JETPACK_TEST_WPCOMSH' ) ) {
+			self::markTestSkipped( 'Plan features resolve through WPCOM feature gating when wpcomsh is active and cannot be simulated.' );
+		}
 	}
 
 	/**
@@ -149,6 +173,7 @@ class Jetpack_VideoPress_Test extends WP_UnitTestCase {
 	 * plupload filter when VideoPress is enabled.
 	 */
 	public function test_media_new_script_enqueued_with_limits_and_filter() {
+		$this->skip_when_wpcomsh_is_active();
 		$this->connect_site();
 
 		$this->instance->enqueue_media_new_scripts( 'media-new.php' );
@@ -210,6 +235,7 @@ class Jetpack_VideoPress_Test extends WP_UnitTestCase {
 	 * A site with a paid VideoPress plan is not limited.
 	 */
 	public function test_upload_limits_with_videopress_purchase() {
+		$this->skip_when_wpcomsh_is_active();
 		$this->connect_site();
 		$this->add_videopress_purchase();
 		$this->create_videopress_attachment();

--- a/projects/plugins/jetpack/tests/php/modules/videopress/Jetpack_VideoPress_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/videopress/Jetpack_VideoPress_Test.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * Jetpack_VideoPress module tests.
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Current_Plan;
+use Automattic\Jetpack\VideoPress\Options as VideoPress_Options;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+require_once JETPACK__PLUGIN_DIR . 'modules/videopress/class.jetpack-videopress.php';
+require_once JETPACK__PLUGIN_DIR . 'modules/videopress/class.videopress-scheduler.php';
+
+/**
+ * Tests the Jetpack_VideoPress module class, focused on the media-new.php
+ * upload integration.
+ *
+ * To run: jetpack docker phpunit jetpack -- --filter=Jetpack_VideoPress_Test
+ *
+ * @covers \Jetpack_VideoPress
+ */
+#[CoversClass( Jetpack_VideoPress::class )]
+class Jetpack_VideoPress_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * The module instance under test.
+	 *
+	 * @var Jetpack_VideoPress
+	 */
+	private $instance;
+
+	/**
+	 * Saved global WP_Scripts instance, restored after each test.
+	 *
+	 * @var WP_Scripts|null
+	 */
+	private $saved_wp_scripts;
+
+	/**
+	 * Start each test with an empty script queue and fresh plan/option caches.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->saved_wp_scripts = $GLOBALS['wp_scripts'] ?? null;
+		$GLOBALS['wp_scripts']  = new WP_Scripts();
+
+		$this->instance = Jetpack_VideoPress::init();
+		$this->reset_plan_and_options_caches();
+	}
+
+	/**
+	 * Restore globals and drop the state the tests created.
+	 */
+	public function tear_down() {
+		$GLOBALS['wp_scripts'] = $this->saved_wp_scripts;
+
+		remove_filter( 'plupload_init', array( $this->instance, 'videopress_pluploder_config' ) );
+		Jetpack_Options::delete_option( 'id' );
+		delete_option( 'jetpack_active_plan' );
+		$this->reset_plan_and_options_caches();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Resets the Current_Plan and VideoPress_Options static caches so each
+	 * test sees the options it sets up.
+	 */
+	private function reset_plan_and_options_caches() {
+		VideoPress_Options::delete_options();
+
+		$cache = new ReflectionProperty( Current_Plan::class, 'active_plan_cache' );
+		$cache->setAccessible( true );
+		$cache->setValue( null, null );
+	}
+
+	/**
+	 * Simulates a connected site, which enables VideoPress on the free tier.
+	 */
+	private function connect_site() {
+		Jetpack_Options::update_option( 'id', 1234 );
+		$this->reset_plan_and_options_caches();
+	}
+
+	/**
+	 * Simulates a site with a paid VideoPress plan.
+	 */
+	private function add_videopress_purchase() {
+		update_option(
+			'jetpack_active_plan',
+			array(
+				'product_slug' => 'jetpack_free',
+				'features'     => array(
+					'active' => array( 'videopress-1tb-storage' ),
+				),
+			)
+		);
+		$this->reset_plan_and_options_caches();
+	}
+
+	/**
+	 * Creates a VideoPress video attachment.
+	 *
+	 * @return int The attachment ID.
+	 */
+	private function create_videopress_attachment() {
+		return wp_insert_attachment(
+			array(
+				'post_title'     => 'A VideoPress video',
+				'post_mime_type' => 'video/videopress',
+			)
+		);
+	}
+
+	/**
+	 * The module registers the media-new.php enqueue callback on init.
+	 */
+	public function test_on_init_registers_media_new_enqueue_hook() {
+		$this->instance->on_init();
+
+		$this->assertNotFalse( has_action( 'admin_enqueue_scripts', array( $this->instance, 'enqueue_media_new_scripts' ) ) );
+	}
+
+	/**
+	 * The media-new.php script is not enqueued on other admin pages.
+	 */
+	public function test_media_new_script_not_enqueued_on_other_pages() {
+		$this->connect_site();
+
+		$this->instance->enqueue_media_new_scripts( 'upload.php' );
+
+		$this->assertFalse( wp_script_is( 'videopress-media-new', 'enqueued' ) );
+	}
+
+	/**
+	 * The media-new.php script is not enqueued when VideoPress is not enabled.
+	 */
+	public function test_media_new_script_not_enqueued_without_videopress() {
+		$this->instance->enqueue_media_new_scripts( 'media-new.php' );
+
+		$this->assertFalse( wp_script_is( 'videopress-media-new', 'enqueued' ) );
+		$this->assertFalse( has_filter( 'plupload_init', array( $this->instance, 'videopress_pluploder_config' ) ) );
+	}
+
+	/**
+	 * The media-new.php script is enqueued with the upload limit data and the
+	 * plupload filter when VideoPress is enabled.
+	 */
+	public function test_media_new_script_enqueued_with_limits_and_filter() {
+		$this->connect_site();
+
+		$this->instance->enqueue_media_new_scripts( 'media-new.php' );
+
+		$this->assertTrue( wp_script_is( 'videopress-media-new', 'enqueued' ) );
+		$this->assertNotFalse( has_filter( 'plupload_init', array( $this->instance, 'videopress_pluploder_config' ) ) );
+
+		$data = $GLOBALS['wp_scripts']->get_data( 'videopress-media-new', 'data' );
+		$this->assertStringContainsString( 'videoPressMediaNew', $data );
+		$this->assertStringContainsString( 'hasVideoPressPurchase', $data );
+	}
+
+	/**
+	 * A free-plan site with no VideoPress videos has the free upload available.
+	 */
+	public function test_upload_limits_free_plan_with_unused_upload() {
+		$this->connect_site();
+
+		$limits = $this->instance->get_media_new_upload_limits();
+
+		$this->assertFalse( $limits['hasVideoPressPurchase'] );
+		$this->assertFalse( $limits['hasUsedVideo'] );
+		$this->assertStringContainsString( 'https://wordpress.com/checkout/', $limits['strings']['usedVideoUpload'] );
+		$this->assertStringContainsString( 'jetpack_videopress', $limits['strings']['usedVideoUpload'] );
+		$this->assertStringContainsString( 'jetpack_videopress', $limits['strings']['multipleVideos'] );
+	}
+
+	/**
+	 * A free-plan site with a VideoPress video has used the free upload.
+	 */
+	public function test_upload_limits_free_plan_with_used_upload() {
+		$this->connect_site();
+		$this->create_videopress_attachment();
+
+		$limits = $this->instance->get_media_new_upload_limits();
+
+		$this->assertFalse( $limits['hasVideoPressPurchase'] );
+		$this->assertTrue( $limits['hasUsedVideo'] );
+	}
+
+	/**
+	 * Local videos that are not on VideoPress do not consume the free upload.
+	 */
+	public function test_upload_limits_ignores_non_videopress_videos() {
+		$this->connect_site();
+		wp_insert_attachment(
+			array(
+				'post_title'     => 'A local video',
+				'post_mime_type' => 'video/mp4',
+			)
+		);
+
+		$limits = $this->instance->get_media_new_upload_limits();
+
+		$this->assertFalse( $limits['hasUsedVideo'] );
+	}
+
+	/**
+	 * A site with a paid VideoPress plan is not limited.
+	 */
+	public function test_upload_limits_with_videopress_purchase() {
+		$this->connect_site();
+		$this->add_videopress_purchase();
+		$this->create_videopress_attachment();
+
+		$limits = $this->instance->get_media_new_upload_limits();
+
+		$this->assertTrue( $limits['hasVideoPressPurchase'] );
+		$this->assertFalse( $limits['hasUsedVideo'] );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/modules/videopress/Jetpack_VideoPress_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/videopress/Jetpack_VideoPress_Test.php
@@ -75,8 +75,10 @@ class Jetpack_VideoPress_Test extends WP_UnitTestCase {
 		// every supported PHP version, unlike ReflectionProperty::setAccessible
 		// (required before PHP 8.1, deprecated as of PHP 8.5).
 		$reset_plan_cache = Closure::bind(
+			/** @phan-closure-scope \Automattic\Jetpack\Current_Plan */
 			static function () {
-				self::$active_plan_cache = null;
+				// An empty array is a cache miss for Current_Plan::get().
+				self::$active_plan_cache = array();
 			},
 			null,
 			Current_Plan::class


### PR DESCRIPTION
## Proposed changes

The classic uploader on `wp-admin/media-new.php` builds a raw `plupload.Uploader` via core's `plupload-handlers` script instead of `wp.Uploader`, so the VideoPress override in `videopress-plupload.js` never engages there: videos land on the site's server, and the page showed a "VideoPress uploads are not supported here" notice.

This PR gives media-new.php the same client-side VideoPress upload path the media library grid has:

* Adds `modules/videopress/js/videopress-media-new.js`, which:
  * registers the `videopress_check_uploads` plupload file filter (as `videopress-uploader.js` does for the grid), fetching the upload token via the existing `videopress-get-upload-token` admin-ajax endpoint — without depending on `wp.media`, which is not loaded on media-new.php;
  * re-targets video uploads to the VideoPress REST endpoint (`rest/v1.1/sites/{blog}/media/new` with the `X_UPLOAD_TOKEN` header) in a `BeforeUpload` handler, restoring the stock settings for non-video files so mixed batches land in the right places;
  * wraps the global `uploadSuccess` handler to translate the VideoPress REST response into the numeric local attachment ID (created via the `jetpack.createMediaItem` XML-RPC callback during the upload) that the classic UI expects, so the media item row renders as usual.
* Enqueues the script on the media-new.php screen only, and injects the plupload filter through the `plupload_init` filter by reusing the existing `videopress_pluploder_config()` method unchanged.
* Removes the `media_new_page_admin_notice` warning, which no longer applies.

### Free-plan single-video limit

The free VideoPress plan includes one video upload, so the page enforces the same limits the VideoPress dashboard communicates via its upgrade notice:

* The paid check mirrors the dashboard's `paidFeatures` (`videopress-1tb-storage` / `videopress-unlimited-storage` via `Current_Plan`, or the `videopress` feature on the WordPress.com platform).
* If the site is on the free plan and already has a VideoPress video (`video/videopress` attachment), all further video uploads are rejected and an upgrade notice (with a checkout link for `jetpack_videopress`) is shown.
* If the free upload hasn't been used: selecting more than one video at once blocks the entire selection — no upload starts and the upgrade notice is shown. A single video is accepted, and any further video selection in the same session is rejected with the notice. A failed token fetch does not consume the free slot.
* Non-video files and sites with a VideoPress purchase are unaffected.

Known limitations (matching existing upload.php behavior):
* The "browser uploader" fallback link (plain HTML form post) is untouched and still uploads locally.
* If the token fetch fails (no plan/connection), video files are rejected with an error rather than falling back to a server upload.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?

No.

## Screenshots

**Multiple videos uploading on a free plan with no videos**
<img width="2920" height="1508" alt="image" src="https://github.com/user-attachments/assets/4e362dc3-25b5-4d1e-9c66-a75233867fe3" />

**Uploading a video on a free plan with 1 video uploaded**
<img width="2938" height="1210" alt="image" src="https://github.com/user-attachments/assets/e2a9e21c-febe-414f-b065-39649dddd1a9" />


## Testing instructions

On a Jetpack-connected site with VideoPress active:

* Go to **Media → Add New Media File** (`wp-admin/media-new.php`).
* Upload a video file (e.g. an mp4).
* Confirm the upload goes to VideoPress: the media item appears in the list, the resulting attachment has the `video/videopress` mime type, and no local copy of the video is stored in `wp-content/uploads`.
* Upload a mixed batch (an image and a video together): the image should upload to the site as usual, the video to VideoPress.
* Upload only an image and confirm the stock flow still works, including the max-file-size rejection for oversized files.
* Deactivate the VideoPress module and confirm media-new.php behaves like stock WordPress (no script enqueued, videos upload locally).

Free-plan limits (site without a paid VideoPress plan):

* With no VideoPress videos on the site, select two or more videos at once: nothing should upload — all selected videos are rejected and an upgrade notice with a checkout link appears above the queue. Repeat via drag-and-drop with the same result. Then select a single video: it should upload to VideoPress.
* After one VideoPress video exists on the site, try uploading another video: it should be rejected with the upgrade notice.
* On a site with a paid VideoPress plan, confirm multiple videos upload without any notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
