### PR TITLE
[DO NOT MERGE] AI Launchpad: localize UI strings and generate AI output in the site language

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotobrd-474-ai-launchpad-decide-ai-output-localization-for-non-english
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotobrd-474-ai-launchpad-decide-ai-output-localization-for-non-english
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+AI Launchpad: localize the remaining UI strings and generate AI output in the site language.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -17,7 +17,7 @@
 	"scripts": {
 		"build": "echo 'Not implemented.'",
 		"build:boot-asset": "provide-boot-asset-file",
-		"build:strip-unminified-prod": "strip-unminified-prod",
+		"build:strip-unminified-prod": "strip-unminified-prod '--keep=routes/**/*.js'",
 		"build:wp-build": "wp-build",
 		"build-js": "pnpm clean && webpack && pnpm run build:wp-build && pnpm run build:boot-asset",
 		"build-production": "echo 'Not implemented.'",

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
@@ -184,6 +184,14 @@ class AI_Launchpad {
 				'wpcomBlogId' => get_wpcom_blog_id(),
 			)
 		);
+
+		// wp-build route modules have no core translation-loading path, so the
+		// language-pack JED for the app bundle is inlined here: the prerequisites
+		// script depends on wp-i18n, and the boot module runs after it.
+		$translations = wpcom_ai_launchpad_script_translations_inline( determine_locale() );
+		if ( null !== $translations ) {
+			wp_add_inline_script( $handle, $translations );
+		}
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -371,13 +371,16 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			'checklist_statuses' => $checklist_statuses,
 			'dismissed'          => (bool) get_option( self::OPTION_DISMISSED, false ),
 			'is_eligible'        => true,
-			// Site context the client needs for the launch-task CTA, the preview thumbnail/title, and wizard prefill.
+			// Site context the client needs for the launch-task CTA, the preview thumbnail/title,
+			// wizard prefill, and the AI output language.
 			'site'               => array(
 				'url'         => home_url(),
 				'title'       => get_bloginfo( 'name' ),
 				'description' => get_bloginfo( 'description' ),
 				// Block themes open the Site Editor; classic themes fall back to the Customizer.
 				'edit_url'    => wp_is_block_theme() ? admin_url( 'site-editor.php' ) : admin_url( 'customize.php' ),
+				// The site's content language; the AI writes its output in this language.
+				'language'    => get_locale(),
 			),
 		);
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/helpers.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/helpers.php
@@ -151,3 +151,38 @@ if ( ! function_exists( 'wpcom_ai_launchpad_get_ai_task_ids' ) ) {
 		return $task_ids;
 	}
 }
+
+if ( ! function_exists( 'wpcom_ai_launchpad_script_translations_inline' ) ) {
+	/**
+	 * Builds the inline `setLocaleData` call carrying the Site Setup app bundle's translations.
+	 *
+	 * Route modules built by wp-build have no core translation-loading path, so the language-pack
+	 * JED produced by translate.wordpress.com is inlined onto the page's prerequisites script. The
+	 * pack keys each JSON to the md5 of the source reference `wp i18n make-pot` recorded — the
+	 * unminified route bundle kept in the production build for exactly this purpose. On Atomic
+	 * the pack is installed to `WP_LANG_DIR/mu-plugins/` by the `wpcomsh_translation_update`
+	 * cron; where no file exists (English, or packs not yet synced) this is a no-op.
+	 *
+	 * @param string      $locale   The locale to load, usually `determine_locale()`.
+	 * @param string|null $lang_dir Directory holding the pack files. Defaults to `WP_LANG_DIR . '/mu-plugins'`.
+	 * @return string|null The inline script, or null when no usable JED file exists.
+	 */
+	function wpcom_ai_launchpad_script_translations_inline( $locale, $lang_dir = null ) {
+		$lang_dir  = $lang_dir ?? WP_LANG_DIR . '/mu-plugins';
+		$reference = 'jetpack_vendor/automattic/jetpack-mu-wpcom/build/routes/site-setup/content.js';
+		$file      = $lang_dir . '/jetpack-mu-wpcom-' . $locale . '-' . md5( $reference ) . '.json';
+
+		if ( ! is_readable( $file ) ) {
+			return null;
+		}
+
+		$data     = json_decode( (string) file_get_contents( $file ), true ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- local language-pack file.
+		$messages = $data['locale_data']['messages'] ?? null;
+		if ( ! is_array( $messages ) || array() === $messages ) {
+			return null;
+		}
+
+		// HEX_TAG keeps a literal "</script>" in a translation from closing the inline script tag.
+		return 'wp.i18n.setLocaleData( ' . wp_json_encode( $messages, JSON_HEX_TAG | JSON_HEX_AMP ) . ', "jetpack-mu-wpcom" );';
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/app.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/app.tsx
@@ -71,6 +71,7 @@ export function App() {
 				initialSiteName={ initialData?.site?.title }
 				initialIntent={ initialData?.site?.description }
 				siteUrl={ initialData?.site?.url }
+				locale={ initialData?.site?.language }
 				onComplete={ ( input, tailoring ) => {
 					setPendingTailor( () => tailoring );
 					setGoal( input.goal );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/about-page.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/about-page.ts
@@ -1,4 +1,5 @@
 import apiFetch from '@wordpress/api-fetch';
+import { _x } from '@wordpress/i18n';
 import { paragraphsToBlocks } from './paragraph-blocks.ts';
 import type { AboutPageDraft } from './types.ts';
 
@@ -19,8 +20,8 @@ export async function createAboutPage(
 	draft: AboutPageDraft | undefined,
 	fetcher: ( options: Parameters< typeof apiFetch >[ 0 ] ) => Promise< unknown > = apiFetch
 ): Promise< { page_id: number; edit_url: string } > {
-	// Untranslated placeholder title (like core's "Auto Draft"); the AI draft normally supplies it.
-	const title = draft?.title ?? 'About';
+	// Fallback title in the admin language; the AI draft normally supplies it in the site language.
+	const title = draft?.title ?? _x( 'About', 'page title', 'jetpack-mu-wpcom' );
 	const content = draft ? paragraphsToBlocks( draft.paragraphs ) : '';
 
 	const page = ( await fetcher( {

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/fallback.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/fallback.ts
@@ -1,26 +1,30 @@
+import { __, _x, sprintf } from '@wordpress/i18n';
 import type { GoalSlug, TailoredOutput, TailoredTask, WizardInput } from './types.ts';
 
 /**
- * English subtitles for catalog task IDs. Unmapped IDs get a generic subtitle so
- * subtitle's minLength:1 is always satisfied.
+ * Subtitles for catalog task IDs, in the admin user's language. Unmapped IDs get
+ * a generic subtitle so subtitle's minLength:1 is always satisfied. Built inside
+ * a function so `__()` runs after the i18n locale data has loaded, not at import.
+ *
+ * @return The subtitle map.
  */
-const TASK_SUBTITLES: Record< string, string > = {
-	first_post_published: 'Write and publish your first post.',
-	woo_products: 'Add your first product to the store.',
-	woo_customize_store: 'Customize how your store looks.',
-	set_up_payments: 'Set up a way to get paid.',
-	add_10_email_subscribers: 'Grow your list to your first subscribers.',
-	site_theme_selected: 'Pick a theme that fits your site.',
-	add_about_page: 'Tell visitors who you are.',
-	design_edited: 'Make the design your own.',
-	complete_profile: 'Complete your public profile.',
-	verify_email: 'Confirm your email address.',
-	connect_social_media: 'Connect your social accounts.',
-	site_launched: 'Launch your site for the world to see.',
-	blog_launched: 'Launch your blog for the world to see.',
-};
-
-const GENERIC_SUBTITLE = 'Get this set up.';
+function taskSubtitles(): Record< string, string > {
+	return {
+		first_post_published: __( 'Write and publish your first post.', 'jetpack-mu-wpcom' ),
+		woo_products: __( 'Add your first product to the store.', 'jetpack-mu-wpcom' ),
+		woo_customize_store: __( 'Customize how your store looks.', 'jetpack-mu-wpcom' ),
+		set_up_payments: __( 'Set up a way to get paid.', 'jetpack-mu-wpcom' ),
+		add_10_email_subscribers: __( 'Grow your list to your first subscribers.', 'jetpack-mu-wpcom' ),
+		site_theme_selected: __( 'Pick a theme that fits your site.', 'jetpack-mu-wpcom' ),
+		add_about_page: __( 'Tell visitors who you are.', 'jetpack-mu-wpcom' ),
+		design_edited: __( 'Make the design your own.', 'jetpack-mu-wpcom' ),
+		complete_profile: __( 'Complete your public profile.', 'jetpack-mu-wpcom' ),
+		verify_email: __( 'Confirm your email address.', 'jetpack-mu-wpcom' ),
+		connect_social_media: __( 'Connect your social accounts.', 'jetpack-mu-wpcom' ),
+		site_launched: __( 'Launch your site for the world to see.', 'jetpack-mu-wpcom' ),
+		blog_launched: __( 'Launch your blog for the world to see.', 'jetpack-mu-wpcom' ),
+	};
+}
 
 /**
  * Per-goal task ID lists. Exactly six IDs each; the last is always a launch task.
@@ -83,9 +87,10 @@ const GOAL_TASK_IDS: Record< GoalSlug, string[] > = {
  * @return The six tasks for the goal.
  */
 function buildTasks( goal: GoalSlug ): TailoredTask[] {
+	const subtitles = taskSubtitles();
 	return GOAL_TASK_IDS[ goal ].map( id => ( {
 		id,
-		subtitle: TASK_SUBTITLES[ id ] ?? GENERIC_SUBTITLE,
+		subtitle: subtitles[ id ] ?? __( 'Get this set up.', 'jetpack-mu-wpcom' ),
 	} ) );
 }
 
@@ -107,7 +112,7 @@ function clamp( value: string, max: number ): string {
  * @return A schema-valid tailored output.
  */
 export function selectFallback( input: WizardInput ): TailoredOutput {
-	const siteName = input.site_name.trim() || 'your new site';
+	const siteName = input.site_name.trim() || __( 'your new site', 'jetpack-mu-wpcom' );
 
 	return {
 		tasks: buildTasks( input.goal ),
@@ -116,22 +121,52 @@ export function selectFallback( input: WizardInput ): TailoredOutput {
 			brand_name: clamp( input.site_name, 80 ),
 		},
 		first_post_draft: {
-			title: clamp( 'Getting started with ' + siteName, 80 ),
-			subtitle: clamp( 'Introduce ' + siteName + ' to your readers.', 120 ),
+			title: clamp(
+				sprintf(
+					/* translators: %s: the site name. */
+					__( 'Getting started with %s', 'jetpack-mu-wpcom' ),
+					siteName
+				),
+				80
+			),
+			subtitle: clamp(
+				sprintf(
+					/* translators: %s: the site name. */
+					__( 'Introduce %s to your readers.', 'jetpack-mu-wpcom' ),
+					siteName
+				),
+				120
+			),
 			paragraphs: [
-				'This is the first post on ' +
-					siteName +
-					'. It marks the starting point of something new, and there is plenty more to come.',
-				'Thanks for being here at the very beginning. Stay tuned for what comes next.',
+				sprintf(
+					/* translators: %s: the site name. */
+					__(
+						'This is the first post on %s. It marks the starting point of something new, and there is plenty more to come.',
+						'jetpack-mu-wpcom'
+					),
+					siteName
+				),
+				__(
+					'Thanks for being here at the very beginning. Stay tuned for what comes next.',
+					'jetpack-mu-wpcom'
+				),
 			],
 		},
 		about_page_draft: {
-			title: 'About',
+			title: _x( 'About', 'page title', 'jetpack-mu-wpcom' ),
 			paragraphs: [
-				'This is where the story of ' +
-					siteName +
-					' begins. Use this page to share who is behind the site and what it is all about.',
-				'Tell visitors how it started, what they can expect to find here, and where it is headed next.',
+				sprintf(
+					/* translators: %s: the site name. */
+					__(
+						'This is where the story of %s begins. Use this page to share who is behind the site and what it is all about.',
+						'jetpack-mu-wpcom'
+					),
+					siteName
+				),
+				__(
+					'Tell visitors how it started, what they can expect to find here, and where it is headed next.',
+					'jetpack-mu-wpcom'
+				),
 			],
 		},
 	};

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/pattern-page.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/pattern-page.test.mts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { pickPattern, selectGalleryPage, type PtkPattern } from './pattern-page.ts';
+import { pickPattern, ptkLocaleSlugs, selectGalleryPage, type PtkPattern } from './pattern-page.ts';
 import type { TailoredInferred } from './types.ts';
 
 const inferred: TailoredInferred = {
@@ -162,5 +162,22 @@ describe( 'selectGalleryPage', () => {
 		// "art" must not match "Smart": the pick falls back rather than reporting a match.
 		assert.equal( result.log.picked_score, 0 );
 		assert.equal( result.log.fallback, 'first_usable' );
+	} );
+} );
+
+describe( 'ptkLocaleSlugs', () => {
+	it( 'tries most-specific first and always ends in en', () => {
+		assert.deepEqual( ptkLocaleSlugs( 'it_IT' ), [ 'it-it', 'it', 'en' ] );
+		assert.deepEqual( ptkLocaleSlugs( 'pt_BR' ), [ 'pt-br', 'pt', 'en' ] );
+	} );
+
+	it( 'deduplicates bare language codes and English', () => {
+		assert.deepEqual( ptkLocaleSlugs( 'it' ), [ 'it', 'en' ] );
+		assert.deepEqual( ptkLocaleSlugs( 'en_US' ), [ 'en-us', 'en' ] );
+		assert.deepEqual( ptkLocaleSlugs( 'en' ), [ 'en' ] );
+	} );
+
+	it( 'degrades to plain en for an empty locale', () => {
+		assert.deepEqual( ptkLocaleSlugs( '' ), [ 'en' ] );
 	} );
 } );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/pattern-page.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/pattern-page.ts
@@ -1,4 +1,5 @@
 import apiFetch from '@wordpress/api-fetch';
+import { _x } from '@wordpress/i18n';
 import { logContentTailored } from './content-log.ts';
 import type { TailoredInferred } from './types.ts';
 
@@ -7,7 +8,20 @@ import type { TailoredInferred } from './types.ts';
  * its content is images; the About page writes AI-drafted content instead (about-page.ts).
  */
 
-const PTK_ENDPOINT = 'https://public-api.wordpress.com/rest/v1/ptk/patterns/en';
+const PTK_ENDPOINT_BASE = 'https://public-api.wordpress.com/rest/v1/ptk/patterns/';
+
+/**
+ * Candidate PTK locale slugs for a WP locale, most specific first and always
+ * ending in "en": "pt_BR" → [ "pt-br", "pt", "en" ].
+ *
+ * @param locale - The site's WP locale.
+ * @return The deduplicated slug candidates.
+ */
+export function ptkLocaleSlugs( locale: string ): string[] {
+	const tag = locale.toLowerCase().replace( /_/g, '-' );
+	const lang = tag.split( '-' )[ 0 ];
+	return [ ...new Set( [ tag, lang, 'en' ] ) ].filter( Boolean );
+}
 
 interface PtkTaxonomyTerm {
 	title?: string;
@@ -169,9 +183,8 @@ export function selectGalleryPage(
 		fallback = 'first_usable';
 	}
 
-	// Fixed, untranslated placeholder title (like core's "Auto Draft"); the pattern's own name
-	// ("Gallery: Two columns…") is not a useful title.
-	const title = 'Gallery';
+	// Fixed placeholder title; the pattern's own name ("Gallery: Two columns…") is not a useful title.
+	const title = _x( 'Gallery', 'page title', 'jetpack-mu-wpcom' );
 	const rawContent = pattern?.html ?? GALLERY_FALLBACK_HTML;
 
 	return {
@@ -191,26 +204,35 @@ export function selectGalleryPage(
 let cachedPatterns: PtkPattern[] | null = null;
 
 /**
- * Fetch the English pattern library, pick a gallery pattern matching the inferred
- * niche, and create a draft page from it.
+ * Fetch the pattern library for the site language (falling back to English), pick
+ * a gallery pattern matching the inferred niche, and create a draft page from it.
  *
  * @param inferred - The AI-inferred site details.
+ * @param locale   - The site's WP locale, used to localize the pattern library.
  * @return The created page id and its editor URL.
  */
 export async function createGalleryPage(
-	inferred: TailoredInferred
+	inferred: TailoredInferred,
+	locale: string = 'en'
 ): Promise< { page_id: number; edit_url: string } > {
 	if ( cachedPatterns === null ) {
-		try {
-			const response = await fetch( PTK_ENDPOINT );
-			if ( response.ok ) {
-				const body = await response.json();
-				if ( Array.isArray( body ) ) {
-					cachedPatterns = body as PtkPattern[];
+		// Site language first so the inserted pattern content matches it, then
+		// progressively broader slugs ending in English. Only one site language per
+		// page load, so the single module cache stays correct.
+		for ( const slug of ptkLocaleSlugs( locale ) ) {
+			try {
+				const response = await fetch( PTK_ENDPOINT_BASE + slug );
+				if ( ! response.ok ) {
+					continue;
 				}
+				const body = await response.json();
+				if ( Array.isArray( body ) && body.length > 0 ) {
+					cachedPatterns = body as PtkPattern[];
+					break;
+				}
+			} catch {
+				// Leave the cache unset so a later click retries; the page is still created below.
 			}
-		} catch {
-			// Leave the cache unset so a later click retries; the page is still created below.
 		}
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.test.mts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.test.mts
@@ -100,3 +100,40 @@ describe( 'buildTailorPrompt', () => {
 		assert.ok( /specific subject/i.test( prompt ), 'subject-over-bucket guidance missing' );
 	} );
 } );
+
+describe( 'buildTailorPrompt output language', () => {
+	const base = fixtures[ 0 ].input;
+
+	it( 'keeps the prompt byte-identical for English locales', () => {
+		const reference = buildTailorPrompt( base ); // fixture locale is "en"
+		for ( const locale of [ 'en', 'en_US', 'en-gb', 'en_AU' ] ) {
+			assert.equal( buildTailorPrompt( { ...base, locale } ), reference );
+		}
+		assert.ok( ! reference.includes( 'output language' ) );
+	} );
+
+	it( 'adds the output-language section for non-English locales', () => {
+		const prompt = buildTailorPrompt( { ...base, locale: 'it_IT' } );
+		assert.ok( prompt.includes( '============ output language ============' ) );
+		assert.ok( prompt.includes( 'Italian' ), 'resolved language name missing' );
+		assert.ok( prompt.includes( 'Keep these in English verbatim' ), 'slug carve-out missing' );
+	} );
+
+	it( 'swaps "Plain English" for the target language', () => {
+		assert.ok( buildTailorPrompt( base ).includes( 'Plain English, no jargon' ) );
+		const prompt = buildTailorPrompt( { ...base, locale: 'it_IT' } );
+		assert.ok( ! prompt.includes( 'Plain English, no jargon' ) );
+		assert.ok( /Plain Italian[^,]*, no jargon/.test( prompt ) );
+	} );
+
+	it( 'asks for the target-language equivalent of the About title', () => {
+		assert.ok( buildTailorPrompt( base ).includes( 'Usually just "About" or "About" plus' ) );
+		const prompt = buildTailorPrompt( { ...base, locale: 'de_DE' } );
+		assert.ok( prompt.includes( 'equivalent of "About"' ) );
+	} );
+
+	it( 'falls back to the raw code when the locale cannot be resolved', () => {
+		const prompt = buildTailorPrompt( { ...base, locale: '!!invalid!!' } );
+		assert.ok( prompt.includes( '!!invalid!!' ) );
+	} );
+} );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
@@ -76,6 +76,35 @@ export function chooseTailoringMenu(
 }
 
 /**
+ * True for English locales (en, en_US, en-gb, …), where the prompt carries no
+ * output-language section and stays byte-identical to the tuned English prompt.
+ *
+ * @param locale - The site's WP locale.
+ * @return Whether the locale is English.
+ */
+function isEnglishLocale( locale: string ): boolean {
+	return /^en([-_]|$)/i.test( locale );
+}
+
+/**
+ * Resolve a WP locale ("it_IT") to an English language name ("Italian (Italy)")
+ * for the prompt, falling back to the raw code when resolution fails.
+ *
+ * @param locale - The site's WP locale.
+ * @return The display name.
+ */
+function languageDisplayName( locale: string ): string {
+	try {
+		return (
+			new Intl.DisplayNames( [ 'en' ], { type: 'language' } ).of( locale.replace( /_/g, '-' ) ) ??
+			locale
+		);
+	} catch {
+		return locale;
+	}
+}
+
+/**
  * Build the single combined prompt sent to jetpack-ai-query, producing the
  * inferred blob, task list, and first-post draft in one JSON response. Hard rules
  * mirror the server-side validation so valid output is not rejected.
@@ -89,6 +118,19 @@ export function buildTailorPrompt(
 	availableTaskIds?: readonly string[]
 ): string {
 	const { goal, site_name, description } = input;
+	// `||` (not `??`) so an empty-string locale also falls back to English.
+	const locale = input.locale || 'en';
+	const english = isEnglishLocale( locale );
+	// "English" for en* keeps the tuned prompt byte-identical; see the tests.
+	const language = english ? 'English' : languageDisplayName( locale );
+	const languageSection = english
+		? ''
+		: `
+============ output language ============
+Write ALL free-text output in ${ language }: every task "subtitle", the "inferred" fields "niche", "vibe", "audience", and "tagline", and every field of "first_post_draft" and "about_page_draft".
+Keep these in English verbatim, exactly as listed elsewhere in this prompt: task "id" values and the "goal", "inferred_goal", and "theme_category" slugs.
+The GOOD vs BAD examples in this prompt are English illustrations only - your output must be in ${ language }.
+`;
 
 	// Offer only tasks that will actually render on this site+goal, so the model never spends a pick on a task the
 	// server would drop. Falls back to the full menu when availability is unknown (e.g. the lookup failed).
@@ -104,7 +146,7 @@ Produce a single JSON object with FOUR parts, in this order: an inferred-context
 Site name: ${ site_name }
 Goal: ${ goal }
 User description: ${ description }
-
+${ languageSection }
 ============ STEP 1 - inferred ============
 First, read the description closely and infer the site's context. You will use this to choose and describe the tasks, so do it before anything else.
 - "goal": echo the goal value above verbatim. One of: write, build, sell, newsletter, educate, portfolio. Required.
@@ -143,11 +185,15 @@ HARD RULES (do not break - the server rejects output that violates these):
 Write a friendly starter blog post the user can edit and publish.
 - "title": clear and evocative, max 8 words.
 - "subtitle": ONE line, verb-led, max 10 words, describing what publishing this post does for them. Optional.
-- "paragraphs": exactly 2 short paragraphs of opening body text. First introduces the topic in a warm, personal voice grounded in the user's niche; second invites the reader in. Plain English, no jargon. Avoid "Welcome to my blog" and "Hello world" cliches.
+- "paragraphs": exactly 2 short paragraphs of opening body text. First introduces the topic in a warm, personal voice grounded in the user's niche; second invites the reader in. Plain ${ language }, no jargon. Avoid "Welcome to my blog" and "Hello world" cliches.
 
 ============ STEP 4 - about_page_draft ============
 Write starter content for the site's About page, grounded in the user's own description - never generic filler.
-- "title": the page title, max 4 words. Usually just "About" or "About" plus the brand name.
+- "title": the page title, max 4 words. Usually just ${
+		english
+			? '"About" or "About" plus the brand name'
+			: `the ${ language } equivalent of "About", alone or plus the brand name`
+	}.
 - "paragraphs": 2 or 3 short paragraphs in the same warm voice: who is behind the site, what visitors will find here (reference the niche and what the user actually does), and a closing invitation to look around or get in touch. Use first person where it reads naturally. Never use placeholders like "[your name]" - if a detail is unknown, write around it.
 
 ============ name resolution ============

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/model.ts
@@ -41,6 +41,8 @@ export interface SiteData {
 	description?: string;
 	// The appearance-editor URL (Site Editor on block themes, Customizer on classic).
 	edit_url?: string | null;
+	// The site's content language (WP locale, e.g. "it_IT"); the AI output language.
+	language?: string;
 }
 
 /** The slice of the `GET /ai-launchpad/` response the tailored list renders from. */
@@ -295,8 +297,11 @@ export function tasksFromFixture( output: TailoredOutput ): EnrichedTask[] {
 }
 
 /**
- * Turn a snake_case catalog ID into a Title Case label, for dev-mode rendering
- * where the server-provided title is unavailable.
+ * Turn a snake_case catalog ID into a Title Case label, for the degraded render
+ * path where the server-provided title is unavailable. Intentionally untranslated:
+ * the label is computed from the ID at runtime, so `__()` cannot extract it, and
+ * duplicating the catalog's ~50 localized titles client-side would drift. The
+ * next successful read replaces these with the catalog's translated titles.
  *
  * @param id - The catalog task ID.
  * @return A humanized label.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
@@ -104,6 +104,10 @@ export function TailoredList( { pendingTailor, initialData, site, goal }: Props 
 	const [ siteEditUrl, setSiteEditUrl ] = useState< string | null >(
 		() => initialData?.site?.edit_url ?? site?.edit_url ?? null
 	);
+	// The site language, forwarded to the gallery pattern fetch.
+	const [ siteLanguage, setSiteLanguage ] = useState< string | null >(
+		() => initialData?.site?.language ?? site?.language ?? null
+	);
 
 	// One viewed event per screen shown; the launchpad screen includes its
 	// loading skeleton. The host seeds the context before mounting this view.
@@ -120,6 +124,7 @@ export function TailoredList( { pendingTailor, initialData, site, goal }: Props 
 				setSiteUrl( initialData.site.url ?? null );
 				setSiteTitle( initialData.site.title ?? null );
 				setSiteEditUrl( initialData.site.edit_url ?? null );
+				setSiteLanguage( initialData.site.language ?? null );
 			}
 			return;
 		}
@@ -147,6 +152,7 @@ export function TailoredList( { pendingTailor, initialData, site, goal }: Props 
 				// missing one coalesces to null.
 				setSiteTitle( data.site.title != null ? decodeEntities( data.site.title ) : null );
 				setSiteEditUrl( data.site.edit_url ?? null );
+				setSiteLanguage( data.site.language ?? null );
 			}
 
 			let nextOutput: TailoredOutput | null = null;
@@ -250,7 +256,7 @@ export function TailoredList( { pendingTailor, initialData, site, goal }: Props 
 					trackTaskCtaClicked,
 					createFirstPostDraft,
 					createAboutPage,
-					createGalleryPage,
+					createGalleryPage: inferred => createGalleryPage( inferred, siteLanguage ?? 'en' ),
 				},
 				siteUrl
 			);

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
@@ -1,5 +1,5 @@
 import { Icon } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { border, drafts, lock, published } from '@wordpress/icons';
 import { Button, Card, CollapsibleCard } from '@wordpress/ui';
 import { ctaKind, type EnrichedTask } from './model.ts';
@@ -42,7 +42,7 @@ function getCtaLabel( taskId: string, inProgress: boolean ): string {
 
 	// An in-progress task reopens its existing draft, so the CTA invites the user to pick up where they left off.
 	if ( inProgress ) {
-		return __( 'Continue', 'jetpack-mu-wpcom' );
+		return _x( 'Continue', 'task action', 'jetpack-mu-wpcom' );
 	}
 
 	switch ( taskId ) {
@@ -209,7 +209,7 @@ export function TaskCard( {
 					) }
 					{ /* Skip persists a server write too, so it shares the lock with the primary action. */ }
 					<Button variant="minimal" tone="neutral" onClick={ onSkip } disabled={ isLocked }>
-						{ __( 'Skip', 'jetpack-mu-wpcom' ) }
+						{ _x( 'Skip', 'task action', 'jetpack-mu-wpcom' ) }
 					</Button>
 				</div>
 			</CollapsibleCard.Content>

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/wizard.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/wizard/wizard.tsx
@@ -1,7 +1,7 @@
 import apiFetch from '@wordpress/api-fetch';
 import { Modal, Button } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { getPrewarmedTailor, usePrewarm } from '../lib/prewarm.ts';
 import {
 	setTracksContext,
@@ -34,7 +34,7 @@ interface Props {
 	initialIntent?: string;
 	// The site's front-end URL, used to key the Calypso My Home URL on Skip.
 	siteUrl?: string;
-	// User locale, forwarded to the wizard payload and the AI call.
+	// Site language, forwarded to the wizard payload and the AI call.
 	locale?: string;
 	// Fired once Finish completes, with the persisted input and the in-flight
 	// tailor promise, so the host can swap to the tailored list.
@@ -49,7 +49,7 @@ interface Props {
  * @param props.initialSiteName - Existing site title used to pre-fill Name.
  * @param props.initialIntent   - Existing site tagline used to pre-fill the description.
  * @param props.siteUrl         - The site's front-end URL (for the Skip redirect).
- * @param props.locale          - User locale forwarded to the payload.
+ * @param props.locale          - Site language forwarded to the payload.
  * @param props.onComplete      - Called with the input and tailor promise on Finish.
  * @return The wizard element.
  */
@@ -189,7 +189,7 @@ export function Wizard( {
 
 			<footer className="ai-launchpad-wizard__footer">
 				<Button variant="link" onClick={ handleSkip } disabled={ skipping }>
-					{ __( 'Skip', 'jetpack-mu-wpcom' ) }
+					{ _x( 'Skip', 'wizard navigation', 'jetpack-mu-wpcom' ) }
 				</Button>
 				<div className="ai-launchpad-wizard__footer-right">
 					{ step > 0 && (
@@ -204,7 +204,7 @@ export function Wizard( {
 					>
 						{ isLastStep( step )
 							? __( 'Finish', 'jetpack-mu-wpcom' )
-							: __( 'Continue', 'jetpack-mu-wpcom' ) }
+							: _x( 'Continue', 'wizard navigation', 'jetpack-mu-wpcom' ) }
 					</Button>
 				</div>
 			</footer>

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_I18n_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_I18n_Test.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * Test class for the AI Launchpad script-translation inline loader.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use PHPUnit\Framework\Attributes\CoversFunction;
+
+//phpcs:ignore WordPressVIPMinimum.Files.IncludingFile.NotAbsolutePath
+require_once \Automattic\Jetpack\Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/ai-launchpad/helpers.php';
+
+/**
+ * Tests for the inline JED loader feeding wp.i18n on the Site Setup page.
+ *
+ * @covers ::wpcom_ai_launchpad_script_translations_inline
+ */
+#[CoversFunction( 'wpcom_ai_launchpad_script_translations_inline' )]
+class AI_Launchpad_I18n_Test extends \WorDBless\BaseTestCase {
+
+	/**
+	 * Temp dir standing in for WP_LANG_DIR/mu-plugins.
+	 *
+	 * @var string
+	 */
+	private $lang_dir;
+
+	/**
+	 * The md5 the language pack uses for the app bundle's JED file: keyed to the
+	 * unminified route bundle path the make-pot extraction records.
+	 *
+	 * @var string
+	 */
+	private $bundle_md5;
+
+	/**
+	 * Set up a fake language-pack directory.
+	 */
+	protected function set_up() {
+		parent::set_up();
+		$this->lang_dir   = sys_get_temp_dir() . '/ai-launchpad-i18n-test-' . wp_rand();
+		$this->bundle_md5 = md5( 'jetpack_vendor/automattic/jetpack-mu-wpcom/build/routes/site-setup/content.js' );
+		mkdir( $this->lang_dir, 0777, true );
+	}
+
+	/**
+	 * Remove the fake language-pack directory.
+	 */
+	protected function tear_down() {
+		foreach ( (array) glob( $this->lang_dir . '/*' ) as $file ) {
+			unlink( $file );
+		}
+		rmdir( $this->lang_dir );
+		parent::tear_down();
+	}
+
+	/**
+	 * Write a pack JSON for a locale into the fake directory.
+	 *
+	 * @param string $locale  The WP locale.
+	 * @param mixed  $payload The decoded file contents to encode, or a raw string to write as-is.
+	 */
+	private function write_pack_file( $locale, $payload ) {
+		file_put_contents( // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+			$this->lang_dir . '/jetpack-mu-wpcom-' . $locale . '-' . $this->bundle_md5 . '.json',
+			is_string( $payload ) ? $payload : wp_json_encode( $payload, JSON_UNESCAPED_SLASHES )
+		);
+	}
+
+	/**
+	 * A valid pack file produces a setLocaleData inline carrying the messages.
+	 */
+	public function test_inlines_set_locale_data_from_a_valid_pack_file() {
+		$this->write_pack_file(
+			'it_IT',
+			array(
+				'locale_data' => array(
+					'messages' => array(
+						''     => array( 'domain' => 'messages' ),
+						'Skip' => array( 'Salta' ),
+					),
+				),
+			)
+		);
+
+		$inline = wpcom_ai_launchpad_script_translations_inline( 'it_IT', $this->lang_dir );
+
+		$this->assertNotNull( $inline );
+		$this->assertStringContainsString( 'wp.i18n.setLocaleData(', $inline );
+		$this->assertStringContainsString( '"Salta"', $inline );
+		$this->assertStringContainsString( '"jetpack-mu-wpcom"', $inline );
+	}
+
+	/**
+	 * A locale with no pack file is a no-op.
+	 */
+	public function test_returns_null_when_no_pack_file_exists() {
+		$this->assertNull( wpcom_ai_launchpad_script_translations_inline( 'it_IT', $this->lang_dir ) );
+	}
+
+	/**
+	 * The pack file for another locale is not picked up.
+	 */
+	public function test_pack_files_are_per_locale() {
+		$this->write_pack_file( 'de_DE', array( 'locale_data' => array( 'messages' => array( 'x' => array( 'y' ) ) ) ) );
+
+		$this->assertNull( wpcom_ai_launchpad_script_translations_inline( 'it_IT', $this->lang_dir ) );
+	}
+
+	/**
+	 * Malformed JSON and empty message sets are no-ops rather than broken inlines.
+	 */
+	public function test_returns_null_for_malformed_or_empty_pack_files() {
+		$this->write_pack_file( 'it_IT', 'not json {' );
+		$this->assertNull( wpcom_ai_launchpad_script_translations_inline( 'it_IT', $this->lang_dir ) );
+
+		$this->write_pack_file( 'it_IT', array( 'locale_data' => array( 'messages' => array() ) ) );
+		$this->assertNull( wpcom_ai_launchpad_script_translations_inline( 'it_IT', $this->lang_dir ) );
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -202,6 +202,16 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 		$this->assertSame( home_url(), $data['site']['url'] );
 		$this->assertSame( get_bloginfo( 'name' ), $data['site']['title'] );
 		$this->assertSame( get_bloginfo( 'description' ), $data['site']['description'] );
+		$this->assertSame( get_locale(), $data['site']['language'] );
+
+		// The language field passes through a non-default site locale, not just the test default.
+		$force_italian = static function () {
+			return 'it_IT';
+		};
+		add_filter( 'locale', $force_italian );
+		$localized = rest_do_request( new WP_REST_Request( 'GET', '/wpcom/v2/ai-launchpad' ) )->get_data();
+		remove_filter( 'locale', $force_italian );
+		$this->assertSame( 'it_IT', $localized['site']['language'] );
 
 		$this->assertCount( 6, $data['tasks'] );
 

--- a/projects/packages/wp-build-polyfills/bin/strip-unminified-prod-lib.js
+++ b/projects/packages/wp-build-polyfills/bin/strip-unminified-prod-lib.js
@@ -96,6 +96,27 @@ function walk( dir, visit ) {
 }
 
 /**
+ * The path of the `.min` sibling that pairs with an unminified candidate,
+ * or `null` when the file is already minified, orphaned (no `.min`
+ * counterpart on disk), or of an unrelated extension.
+ *
+ * @param {string} filePath - Absolute path to the candidate file.
+ * @return {string|null} The existing `.min` sibling path, or `null`.
+ */
+function pairedMinPath( filePath ) {
+	for ( const ext of STRIPPABLE_EXTS ) {
+		if ( filePath.endsWith( '.min' + ext ) ) {
+			return null;
+		}
+		if ( filePath.endsWith( ext ) ) {
+			const minPath = filePath.slice( 0, -ext.length ) + '.min' + ext;
+			return existsSync( minPath ) ? minPath : null;
+		}
+	}
+	return null;
+}
+
+/**
  * Delete a file if it is the unminified sibling of an existing
  * `.min.js`/`.min.css` counterpart. Also drops any sibling source map.
  * Files that are already minified, orphaned (no `.min` counterpart), or of
@@ -105,24 +126,31 @@ function walk( dir, visit ) {
  * @return {boolean} `true` if the file was deleted, `false` otherwise.
  */
 function stripIfPaired( filePath ) {
-	for ( const ext of STRIPPABLE_EXTS ) {
-		if ( filePath.endsWith( '.min' + ext ) ) {
-			return false;
-		}
-		if ( filePath.endsWith( ext ) ) {
-			const minPath = filePath.slice( 0, -ext.length ) + '.min' + ext;
-			if ( ! existsSync( minPath ) ) {
-				return false;
-			}
-			unlinkSync( filePath );
-			const mapPath = filePath + '.map';
-			if ( existsSync( mapPath ) ) {
-				unlinkSync( mapPath );
-			}
-			return true;
-		}
+	if ( pairedMinPath( filePath ) === null ) {
+		return false;
 	}
-	return false;
+	unlinkSync( filePath );
+	const mapPath = filePath + '.map';
+	if ( existsSync( mapPath ) ) {
+		unlinkSync( mapPath );
+	}
+	return true;
+}
+
+/**
+ * Compile a keep glob into an anchored RegExp over a build-relative POSIX
+ * path. `**` matches across path segments, `*` within one segment; all
+ * other characters are literal.
+ *
+ * @param {string} pattern - Keep glob, relative to the build/ directory (e.g. `routes/**\/*.js`).
+ * @return {RegExp} The compiled matcher.
+ */
+function keepPatternToRegExp( pattern ) {
+	const body = pattern
+		.split( '**' )
+		.map( part => part.replace( /[.+^${}()|[\]\\]/g, '\\$&' ).replace( /\*/g, '[^/]*' ) )
+		.join( '.*' );
+	return new RegExp( '^' + body + '$' );
 }
 
 /**
@@ -156,19 +184,37 @@ function hasUnpatchedFallback( source ) {
  * Strip unminified JS/CSS siblings from a wp-build output tree and rewrite
  * the generated PHP loaders. See module docstring for context.
  *
- * @param {string} buildDir - Absolute path to the package's build/ directory.
- * @return {{deletedFiles: number, patchedFiles: number, skipped: boolean}} Summary of what changed. `skipped: true` if `buildDir` doesn't exist.
+ * `keep` globs exempt matching unminified files from deletion. The kept
+ * copies are never served — the loaders are still collapsed to `.min` —
+ * they exist so downstream string extraction (`wp i18n make-pot`, which
+ * skips `*.min.js` by filename) can see the bundle's translation calls and
+ * translator comments. See the language-pack pipeline notes in the
+ * consuming package.
+ *
+ * @param {string}   buildDir       - Absolute path to the package's build/ directory.
+ * @param {object}   [options]      - Options.
+ * @param {string[]} [options.keep] - Keep globs relative to `buildDir` (POSIX separators; `**` crosses segments, `*` doesn't).
+ * @return {{deletedFiles: number, keptFiles: number, patchedFiles: number, skipped: boolean}} Summary of what changed. `skipped: true` if `buildDir` doesn't exist.
  */
-function strip( buildDir ) {
+function strip( buildDir, { keep = [] } = {} ) {
 	if ( ! existsSync( buildDir ) ) {
-		return { deletedFiles: 0, patchedFiles: 0, skipped: true };
+		return { deletedFiles: 0, keptFiles: 0, patchedFiles: 0, skipped: true };
 	}
 
+	const keepMatchers = keep.map( keepPatternToRegExp );
 	let deletedFiles = 0;
+	let keptFiles = 0;
 	let patchedFiles = 0;
 
 	for ( const sub of TARGET_SUBDIRS ) {
 		walk( path.join( buildDir, sub ), filePath => {
+			const rel = path.relative( buildDir, filePath ).split( path.sep ).join( '/' );
+			if ( keepMatchers.some( re => re.test( rel ) ) ) {
+				if ( pairedMinPath( filePath ) !== null ) {
+					keptFiles++;
+				}
+				return;
+			}
 			if ( stripIfPaired( filePath ) ) {
 				deletedFiles++;
 			}
@@ -204,12 +250,14 @@ function strip( buildDir ) {
 		patchedFiles++;
 	}
 
-	return { deletedFiles, patchedFiles, skipped: false };
+	return { deletedFiles, keptFiles, patchedFiles, skipped: false };
 }
 
 module.exports = {
 	strip,
 	stripIfPaired,
+	pairedMinPath,
+	keepPatternToRegExp,
 	patchPhpSource,
 	hasUnpatchedFallback,
 	walk,

--- a/projects/packages/wp-build-polyfills/bin/strip-unminified-prod.js
+++ b/projects/packages/wp-build-polyfills/bin/strip-unminified-prod.js
@@ -12,15 +12,27 @@
 const path = require( 'path' );
 const { strip } = require( './strip-unminified-prod-lib.js' );
 
+// --keep=<glob>[,<glob>…] (repeatable): unminified files to retain for i18n
+// string extraction. See strip()'s docs for the glob semantics.
+const keep = [];
+for ( const arg of process.argv.slice( 2 ) ) {
+	if ( arg.startsWith( '--keep=' ) ) {
+		keep.push( ...arg.slice( '--keep='.length ).split( ',' ).filter( Boolean ) );
+	} else {
+		throw new Error( `[strip-unminified-prod] unknown argument: ${ arg }` );
+	}
+}
+
 const buildDir = path.join( process.cwd(), 'build' );
-const { deletedFiles, patchedFiles, skipped } = strip( buildDir );
+const { deletedFiles, keptFiles, patchedFiles, skipped } = strip( buildDir, { keep } );
 
 if ( skipped ) {
 	// eslint-disable-next-line no-console
 	console.log( `[strip-unminified-prod] no build/ at ${ buildDir }, skipping.` );
-} else if ( deletedFiles || patchedFiles ) {
+} else if ( deletedFiles || keptFiles || patchedFiles ) {
+	const kept = keptFiles ? `; kept ${ keptFiles } for string extraction` : '';
 	// eslint-disable-next-line no-console
 	console.log(
-		`[strip-unminified-prod] removed ${ deletedFiles } unminified file(s); patched ${ patchedFiles } PHP loader(s).`
+		`[strip-unminified-prod] removed ${ deletedFiles } unminified file(s)${ kept }; patched ${ patchedFiles } PHP loader(s).`
 	);
 }

--- a/projects/packages/wp-build-polyfills/changelog/dotobrd-474-ai-launchpad-decide-ai-output-localization-for-non-english
+++ b/projects/packages/wp-build-polyfills/changelog/dotobrd-474-ai-launchpad-decide-ai-output-localization-for-non-english
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+strip-unminified-prod: add a --keep option to retain unminified bundles for i18n string extraction.

--- a/projects/packages/wp-build-polyfills/tests/js/strip-unminified-prod-real-fixture.test.js
+++ b/projects/packages/wp-build-polyfills/tests/js/strip-unminified-prod-real-fixture.test.js
@@ -26,6 +26,7 @@ const path = require( 'path' );
 const {
 	strip,
 	hasUnpatchedFallback,
+	keepPatternToRegExp,
 	PHP_TARGETS,
 } = require( '../../bin/strip-unminified-prod-lib.js' );
 
@@ -155,7 +156,112 @@ describe(
 
 		it( 'is idempotent on real output — a second pass changes nothing', () => {
 			const result = strip( FIXTURE_BUILD );
-			assert.deepEqual( result, { deletedFiles: 0, patchedFiles: 0, skipped: false } );
+			assert.deepEqual( result, {
+				deletedFiles: 0,
+				keptFiles: 0,
+				patchedFiles: 0,
+				skipped: false,
+			} );
+		} );
+	}
+);
+
+describe( 'keepPatternToRegExp', () => {
+	it( 'matches ** across path segments and * within one', () => {
+		assert.equal(
+			keepPatternToRegExp( 'routes/**/*.js' ).test( 'routes/dashboard/content.js' ),
+			true
+		);
+		assert.equal(
+			keepPatternToRegExp( 'routes/**/content.js' ).test( 'routes/a/b/content.js' ),
+			true
+		);
+		assert.equal(
+			keepPatternToRegExp( 'routes/*.js' ).test( 'routes/dashboard/content.js' ),
+			false
+		);
+	} );
+
+	it( 'treats regex metacharacters as literals and anchors the match', () => {
+		assert.equal( keepPatternToRegExp( 'routes/a.js' ).test( 'routes/aXjs' ), false );
+		assert.equal( keepPatternToRegExp( 'routes/content.js' ).test( 'xroutes/content.js' ), false );
+		assert.equal(
+			keepPatternToRegExp( 'routes/content.js' ).test( 'routes/content.js.map' ),
+			false
+		);
+	} );
+} );
+
+describe(
+	'strip-unminified-prod --keep against real wp-build output',
+	{ skip: ! wpBuildAvailable },
+	() => {
+		before( () => {
+			rmSync( FIXTURE_BUILD, { recursive: true, force: true } );
+			const result = spawnSync( WP_BUILD_BIN, [], {
+				cwd: FIXTURE_DIR,
+				encoding: 'utf8',
+			} );
+			if ( result.status !== 0 ) {
+				throw new Error(
+					`wp-build failed (exit ${ result.status }):\n` +
+						`stdout: ${ result.stdout }\nstderr: ${ result.stderr }`
+				);
+			}
+		} );
+
+		after( () => {
+			rmSync( FIXTURE_BUILD, { recursive: true, force: true } );
+			rmSync( path.join( FIXTURE_DIR, 'packages', 'css-test', 'build' ), {
+				recursive: true,
+				force: true,
+			} );
+		} );
+
+		it( 'retains keep-matched unminified files while stripping the rest', () => {
+			const result = strip( FIXTURE_BUILD, { keep: [ 'routes/**/content.js' ] } );
+			assert.equal( result.skipped, false );
+			// One of the six paired bundles (routes/dashboard/content.js) is kept.
+			assert.equal( result.deletedFiles, 5 );
+			assert.equal( result.keptFiles, 1 );
+			assert.equal( result.patchedFiles, 5 );
+
+			assert.equal(
+				existsSync( path.join( FIXTURE_BUILD, 'routes/dashboard/content.js' ) ),
+				true,
+				'keep-matched content.js should survive'
+			);
+			assert.equal(
+				existsSync( path.join( FIXTURE_BUILD, 'routes/dashboard/content.min.js' ) ),
+				true,
+				'its minified sibling is untouched'
+			);
+			assert.equal(
+				existsSync( path.join( FIXTURE_BUILD, 'routes/dashboard/route.js' ) ),
+				false,
+				'non-matching route.js is still stripped'
+			);
+
+			// Keeping a file must not stop the loaders collapsing to .min —
+			// the kept copy is for string extraction, never for serving.
+			for ( const name of PHP_TARGETS ) {
+				const src = readFileSync( path.join( FIXTURE_BUILD, name ), 'utf8' );
+				assert.equal(
+					hasUnpatchedFallback( src ),
+					false,
+					`${ name } still has a SCRIPT_DEBUG fallback after stripping with keep`
+				);
+			}
+		} );
+
+		it( 'is idempotent with keep — the kept file is re-counted, nothing else changes', () => {
+			const result = strip( FIXTURE_BUILD, { keep: [ 'routes/**/content.js' ] } );
+			assert.deepEqual( result, {
+				deletedFiles: 0,
+				keptFiles: 1,
+				patchedFiles: 0,
+				skipped: false,
+			} );
 		} );
 	}
 );


### PR DESCRIPTION
## Proposed changes

Non-English users currently get an incoherent AI Launchpad: the shell (buttons, labels, catalog task titles) is localized, but everything the AI generates — task subtitles, the first-post and About drafts, the tagline — is English-only, a handful of fallback strings were hardcoded, and the app's JS strings never reached translate.wordpress.com at all. With the A/B test approaching and no locale gate planned, the whole surface needs to be translation-ready and the AI output needs to follow the requester's language.

**Commit 1 — localized strings + locale-aware AI output.** Resolves the DOTOBRD-474 decision as the locale-aware prompt option (no English-locale gate), with the **site language** (`get_locale()`) driving generated output — drafts become published site content, so the site's content language wins over the admin locale:

* The composite GET now exposes `site.language`, threaded through the wizard's existing (previously unused) `locale` prop into the persisted wizard payload and the AI prompt.
* `buildTailorPrompt` gains an `output language` section **only for non-English locales** — a unit test proves the English prompt stays byte-identical, so English users see zero behavior change. Free-text fields follow the target language; `goal`/`inferred_goal`/`theme_category` slugs and task ids stay English for server-side validation.
* The deterministic-fallback tasklist and drafts (`fallback.ts`), and the `About`/`Gallery` fallback page titles, are now translatable; `Skip`/`Continue` get `_x()` contexts.
* The gallery task fetches the PTK pattern library for the site locale with an English fallback (`it-it` → `it` → `en`; verified live that `it` serves a full library).

**Commit 2 — JS strings into the language-pack pipeline.** The translate.wordpress.com pipeline extracts strings with `wp i18n make-pot` over the plugin mirror, which skips `*.min.js` — and the production build stripped the only other copy of the wp-build route bundle, so none of the Site Setup app's JS strings were ever extracted:

* `strip-unminified-prod` (wp-build-polyfills) gains a `--keep` glob option, and this package's production build now retains the unminified route bundles for extraction. They are never served — the loaders still collapse to `.min.js` — the cost is ~250 K of artifact disk.
* Route modules have no core translation-loading path, so the page inlines the bundle's language-pack JED (keyed to the kept file's path, installed under `WP_LANG_DIR/mu-plugins/` by the `wpcomsh_translation_update` cron) onto the prerequisites script as a `setLocaleData` call, following the admin user's locale. Verified end-to-end on an Atomic test site with a synthetic pack file (headings, the `sprintf` progress label, and `_x()` context strings all resolve).

Remaining follow-ups (not in this PR): the JS strings appear in GlotPress only after this merges and the mirror's next hourly import runs; a later iteration will split task subtitles (wp-admin UI) to the user's language while content stays in the site language; gallery pattern *scoring* still uses an English tokenizer and degrades gracefully.

## Related product discussion/links

* DOTOBRD-474

## Does this pull request change what data or activity we track or use?

No new tracking. The existing persisted wizard payload's `locale` field (previously always `'en'`) now carries the real site locale.

## Testing instructions

* On a test site with the AI Launchpad enabled, set Settings → General → Site Language to Italiano (or any non-English language) and reset the launchpad state (delete the `wpcom_ai_launchpad_*` options).
* Go to wp-admin → Site Setup and complete the wizard with an Italian site name and description.
* Verify the tailored list's task subtitles are Italian and reference your described niche; verify via `wp option get wpcom_ai_launchpad_ai_output --format=json` that the drafts and tagline are Italian while `goal`, `theme_category`, and task `id`s remain English slugs, and `wpcom_ai_launchpad_wizard` shows `locale: it_IT`.
* Click the gallery task (portfolio/photo-niche goal) and confirm a gallery page is created.
* Switch the site language back to English, reset the options, re-run the wizard, and confirm behavior identical to production today.
* For the JS translation loading: drop a JED file named `jetpack-mu-wpcom-{locale}-$(md5 of 'jetpack_vendor/automattic/jetpack-mu-wpcom/build/routes/site-setup/content.js').json` into `wp-content/languages/mu-plugins/` with a translation for e.g. "Let's get your blog ready to launch", set your user language to that locale, and reload Site Setup — the heading renders translated. (Real packs appear once the post-merge extraction lands in GlotPress.)
* Build-tooling check: `pnpm run build-production-js` in the package leaves `build/routes/site-setup/content.js` in place while other unminified bundles are stripped and the loaders reference only `.min.js`.
