### PR TITLE
Premium Analytics: author widget metadata in widget.json, not widget.ts

### DIFF
--- a/.agents/rules/widgets.md
+++ b/.agents/rules/widgets.md
@@ -4,8 +4,8 @@ A registered dashboard widget is a folder under `widgets/`, auto-discovered by c
 (no registration):
 
 - `package.json` — workspace package for the lazy-loaded render bundle.
-- `widget.json` — static metadata (name, title, description, category, presentation).
-- `widget.ts` — live metadata (default export: title, icon, attributes, example).
+- `widget.json` — static metadata (name, title, description, help, category, presentation).
+- `widget.ts` — live, non-serializable metadata (default export: icon, attributes, example).
 - `render.tsx` — default-export React component.
 - `style.module.css` — optional; CSS Modules, tokens from `@wordpress/theme` (`--wpds-*`).
 

--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -197,16 +197,16 @@ Each new widget MUST ship as a self-contained folder with these files:
 ```text
 widgets/<widget-name>/
 ├── package.json                            # workspace package; link: deps on widgets-toolkit
-├── widget.json                             # declarative metadata (name, title, description, category)
-├── widget.ts                               # runtime widget type definition (icon + translatable strings)
+├── widget.json                             # declarative metadata (name, title, description, help, category, presentation)
+├── widget.ts                               # runtime-only definition (icon, attributes, example)
 ├── render.tsx                              # the React component, wrapped in <WidgetRoot> from widgets-toolkit
 └── stories/<widget-name>-widget.stories.tsx
 ```
 
 Notes:
 
-- `name` in both `widget.json` and `widget.ts` MUST use the `jpa/` prefix
-  (e.g. `jpa/<widget-name>`).
+- `name` lives in `widget.json` and MUST use the `jpa/` prefix
+  (e.g. `jpa/<widget-name>`). `widget.ts` no longer declares it.
 - Keep `render.tsx` thin: compose toolkit primitives (`WidgetRoot`,
   `OrderMetricWidget`, etc.) rather than reimplementing data fetching, chart wiring, or
   theming.
@@ -318,10 +318,12 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import MyWidgetRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -377,7 +379,7 @@ function MyWidgetDashboardStory( dashboardArgs: WidgetDashboardWithWidgetControl
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ MY_WIDGET_RENDER_MODULE }
 			renderComponent={ MyWidgetRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ { reportParams: getDefaultQueryParams( true ) } }
@@ -476,8 +478,10 @@ stories so it hits the mock fresh instead of reading their cached success. See
   legacy widgets that haven't been migrated yet.
 - Using the legacy `withWidgetRoot()` decorator for new stories — new widgets render via the
   real `WidgetDashboard` through the shared story helper instead.
-- Declaring `presentation` in `widget.ts` — `widget.json` is the source of truth for that
-  field; omit it from `widget.ts` entirely.
+- Declaring `name`, `title`, `help`, `description`, `category`, or `presentation` in
+  `widget.ts` — `widget.json` is the source of truth for all declarative metadata; the
+  `widget.ts` default export carries only `icon`, `attributes`, and `example`. Stories read
+  those declarative fields from `widget.json` via `createStoryWidgetType()`.
 - Re-declaring the attribute type in `render.tsx` — the shape is declared once in `widget.ts`
   and imported in `render.tsx`; render-only types may compose that imported shape with host
   fields like `Partial<ReportParamsFieldAttributes>`, but must not duplicate the shape.

--- a/projects/packages/premium-analytics/changelog/update-widget-metadata-json
+++ b/projects/packages/premium-analytics/changelog/update-widget-metadata-json
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Widgets: author declarative metadata (name, title, help) in widget.json instead of widget.ts, and build story widget types from the manifest via a shared createStoryWidgetType() helper. The widget.ts default export now carries only icon, attributes, and example. No user-facing change.

--- a/projects/packages/premium-analytics/widgets/all-time-stats/stories/all-time-stats-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/all-time-stats/stories/all-time-stats-widget.stories.tsx
@@ -24,14 +24,16 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import AllTimeStatsRender from '../render';
 import widgetDefinition, {
 	DEFAULT_ALL_TIME_STATS_METRICS,
 	type AllTimeStatsMetricId,
 } from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
-import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
@@ -39,17 +41,10 @@ registerReportMocks();
 const ALL_TIME_STATS_RENDER_MODULE = 'storybook/all-time-stats';
 
 // Carry the widget's metadata, including the metric-visibility attribute schema
-// so the dashboard story's settings drawer renders the real checkboxes. The
-// attribute schema is typed loosely on the widget definition, so it is cast to
-// the WidgetType shape.
-const storyWidgetType = {
-	name: widgetDefinition.name,
-	title: widgetDefinition.title,
-	icon: widgetDefinition.icon,
-	presentation: 'framed' as const,
-	attributes: widgetDefinition.attributes as WidgetType[ 'attributes' ],
-	example: widgetDefinition.example,
-};
+// so the dashboard story's settings drawer renders the real checkboxes.
+// `presentation` comes from widget.json ( 'framed' ), so the host frames the
+// widget and renders its identity (title + icon).
+const storyWidgetType = createStoryWidgetType( widgetManifest, widgetDefinition );
 
 interface AllTimeStatsStoryControls {
 	/**

--- a/projects/packages/premium-analytics/widgets/all-time-stats/widget.json
+++ b/projects/packages/premium-analytics/widgets/all-time-stats/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/all-time-stats",
 	"title": "All-time stats",
 	"description": "Lifetime totals for your site — views, visitors, posts, and comments.",
+	"help": {
+		"content": "Lifetime totals for your site — views, visitors, posts, and comments."
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/all-time-stats/widget.ts
+++ b/projects/packages/premium-analytics/widgets/all-time-stats/widget.ts
@@ -58,14 +58,6 @@ export const DEFAULT_ALL_TIME_STATS_METRICS: AllTimeStatsMetricId[] = ALL_TIME_S
  * doubles as the defaults applied to new instances: every metric enabled.
  */
 export default {
-	name: 'jpa/all-time-stats',
-	title: __( 'All-time stats', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Lifetime totals for your site — views, visitors, posts, and comments.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: trendingUp,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/annual-highlights/stories/annual-highlights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/annual-highlights/stories/annual-highlights-widget.stories.tsx
@@ -16,6 +16,7 @@ import {
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
 import { withStoryRouter } from '../../stories/with-story-router';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -23,8 +24,9 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import AnnualHighlightsRender from '../render';
 import widgetDefinition, { DEFAULT_HIGHLIGHT_METRICS, type AnnualHighlightMetric } from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
-import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
@@ -33,16 +35,9 @@ const ANNUAL_HIGHLIGHTS_RENDER_MODULE = 'storybook/annual-highlights';
 
 // Carry the widget's metadata, including the metric-visibility attribute schema
 // so the dashboard story's settings drawer renders the real checkboxes.
-// Presentation is left unset so the host frames the widget and renders its
-// identity (title + icon), matching widget.json. The attribute schema is typed
-// loosely on the widget definition, so it is cast to the WidgetType shape.
-const storyWidgetType = {
-	name: widgetDefinition.name,
-	title: widgetDefinition.title,
-	icon: widgetDefinition.icon,
-	attributes: widgetDefinition.attributes as WidgetType[ 'attributes' ],
-	example: widgetDefinition.example,
-};
+// `presentation` comes from widget.json ( 'framed' ), so the host frames the
+// widget and renders its identity (title + icon).
+const storyWidgetType = createStoryWidgetType( widgetManifest, widgetDefinition );
 
 interface AnnualHighlightsStoryControls {
 	/**

--- a/projects/packages/premium-analytics/widgets/annual-highlights/widget.json
+++ b/projects/packages/premium-analytics/widgets/annual-highlights/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/annual-highlights",
 	"title": "Annual highlights",
 	"description": "Your totals for the year at a glance — posts, words, likes, and comments.",
+	"help": {
+		"content": "Your totals for the year at a glance — posts, words, likes, and comments."
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/annual-highlights/widget.ts
+++ b/projects/packages/premium-analytics/widgets/annual-highlights/widget.ts
@@ -40,14 +40,6 @@ export const DEFAULT_HIGHLIGHT_METRICS: AnnualHighlightMetric[] = [
  * metric enabled.
  */
 export default {
-	name: 'jpa/annual-highlights',
-	title: __( 'Annual highlights', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Your totals for the year at a glance — posts, words, likes, and comments.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: calendar,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/authors/stories/authors-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/authors/stories/authors-widget.stories.tsx
@@ -5,6 +5,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -12,6 +13,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import AuthorsRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -20,12 +22,7 @@ registerReportMocks();
 
 const AUTHORS_RENDER_MODULE = 'storybook/authors';
 
-const storyWidgetType = {
-	name: widgetDefinition.name,
-	title: widgetDefinition.title,
-	icon: widgetDefinition.icon,
-	presentation: 'framed' as const,
-};
+const storyWidgetType = createStoryWidgetType( widgetManifest, widgetDefinition );
 
 interface AuthorsStoryControls {
 	withComparison: boolean;

--- a/projects/packages/premium-analytics/widgets/authors/widget.json
+++ b/projects/packages/premium-analytics/widgets/authors/widget.json
@@ -2,6 +2,15 @@
 	"name": "jpa/authors",
 	"title": "Authors",
 	"description": "Top authors by views, with their most viewed posts.",
+	"help": {
+		"content": "The authors whose content received the most views.",
+		"links": [
+			{
+				"label": "Learn more",
+				"href": "https://jetpack.com/support/jetpack-stats/"
+			}
+		]
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/authors/widget.ts
+++ b/projects/packages/premium-analytics/widgets/authors/widget.ts
@@ -21,20 +21,6 @@ export type AuthorsAttributes = {
  * Widget type definition.
  */
 export default {
-	name: 'jpa/authors',
-	title: __( 'Authors', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'The authors whose content received the most views.',
-			'jetpack-premium-analytics'
-		),
-		links: [
-			{
-				label: __( 'Learn more', 'jetpack-premium-analytics' ),
-				href: 'https://jetpack.com/support/jetpack-stats/',
-			},
-		],
-	},
 	icon: postAuthor,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/average-items-per-order/stories/average-items-per-order-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/average-items-per-order/stories/average-items-per-order-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -13,6 +14,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import AverageItemsPerOrderRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -100,7 +102,7 @@ function AverageItemsPerOrderDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ AVERAGE_ITEMS_RENDER_MODULE }
 			renderComponent={
 				AverageItemsPerOrderRender as ComponentType< WidgetRenderProps< unknown > >

--- a/projects/packages/premium-analytics/widgets/average-items-per-order/widget.json
+++ b/projects/packages/premium-analytics/widgets/average-items-per-order/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/average-items-per-order",
 	"title": "Average items per order",
 	"description": "Show the average number of products per order over a set period of time.",
+	"help": {
+		"content": "Show the average number of products per order over a set period of time."
+	},
 	"category": "orders",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/average-items-per-order/widget.ts
+++ b/projects/packages/premium-analytics/widgets/average-items-per-order/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
@@ -23,13 +22,5 @@ export type AverageItemsPerOrderAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/average-items-per-order',
-	title: __( 'Average items per order', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Show the average number of products per order over a set period of time.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/average-order-value/stories/average-order-value-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/average-order-value/stories/average-order-value-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -13,6 +14,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import AverageOrderValueRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -94,7 +96,7 @@ function AverageOrderValueDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ AVERAGE_ORDER_VALUE_RENDER_MODULE }
 			renderComponent={ AverageOrderValueRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ getAverageOrderValueAttributes( withComparison, preset ) }

--- a/projects/packages/premium-analytics/widgets/average-order-value/widget.json
+++ b/projects/packages/premium-analytics/widgets/average-order-value/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/average-order-value",
 	"title": "Average order value",
 	"description": "Track the average value of each order over a set period of time.",
+	"help": {
+		"content": "Track the average value of each order over a set period of time."
+	},
 	"category": "orders",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/average-order-value/widget.ts
+++ b/projects/packages/premium-analytics/widgets/average-order-value/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
@@ -23,13 +22,5 @@ export type AverageOrderValueAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/average-order-value',
-	title: __( 'Average order value', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Track the average value of each order over a set period of time.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/bookings-by-device/stories/bookings-by-device-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-by-device/stories/bookings-by-device-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -13,6 +14,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import BookingsByDeviceRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -94,7 +96,7 @@ function BookingsByDeviceDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ BOOKINGS_BY_DEVICE_RENDER_MODULE }
 			renderComponent={ BookingsByDeviceRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ getBookingsByDeviceAttributes( withComparison, preset ) }

--- a/projects/packages/premium-analytics/widgets/bookings-by-device/widget.json
+++ b/projects/packages/premium-analytics/widgets/bookings-by-device/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/bookings-by-device",
 	"title": "Bookings by device",
 	"description": "See which devices your customers are using to make bookings in your store.",
+	"help": {
+		"content": "See which devices your customers are using to make bookings in your store."
+	},
 	"category": "bookings",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/bookings-by-device/widget.ts
+++ b/projects/packages/premium-analytics/widgets/bookings-by-device/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
@@ -23,13 +22,5 @@ export type BookingsByDeviceAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/bookings-by-device',
-	title: __( 'Bookings by device', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'See which devices your customers are using to make bookings in your store.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/bookings-by-status/stories/bookings-by-status-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-by-status/stories/bookings-by-status-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -13,6 +14,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import BookingsByStatusRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -94,7 +96,7 @@ function BookingsByStatusDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ BOOKINGS_BY_STATUS_RENDER_MODULE }
 			renderComponent={ BookingsByStatusRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ {

--- a/projects/packages/premium-analytics/widgets/bookings-by-status/widget.json
+++ b/projects/packages/premium-analytics/widgets/bookings-by-status/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/bookings-by-status",
 	"title": "Bookings by status",
 	"description": "Number of bookings by status over the selected time period.",
+	"help": {
+		"content": "Number of bookings by status over the selected time period."
+	},
 	"category": "bookings",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/bookings-by-status/widget.ts
+++ b/projects/packages/premium-analytics/widgets/bookings-by-status/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
@@ -23,13 +22,5 @@ export type BookingsByStatusAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/bookings-by-status',
-	title: __( 'Bookings by status', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Number of bookings by status over the selected time period.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/bookings-over-time/stories/bookings-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-over-time/stories/bookings-over-time-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import LineChart from '../../../../../js-packages/charts/src/charts/line-chart/line-chart';
 import {
@@ -14,6 +15,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import BookingsOverTimeRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -104,7 +106,7 @@ function BookingsOverTimeDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ BOOKINGS_OVER_TIME_RENDER_MODULE }
 			renderComponent={ BookingsOverTimeRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ getBookingsOverTimeAttributes( withComparison, preset ) }

--- a/projects/packages/premium-analytics/widgets/bookings-over-time/widget.json
+++ b/projects/packages/premium-analytics/widgets/bookings-over-time/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/bookings-over-time",
 	"title": "Bookings over time",
 	"description": "See a breakdown of when bookings are placed to identify peak selling periods.",
+	"help": {
+		"content": "See a breakdown of when bookings are placed to identify peak selling periods."
+	},
 	"category": "bookings",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/bookings-over-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/bookings-over-time/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
@@ -23,13 +22,5 @@ export type BookingsOverTimeAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/bookings-over-time',
-	title: __( 'Bookings over time', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'See a breakdown of when bookings are placed to identify peak selling periods.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/stories/bookings-revenue-by-customer-type-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/stories/bookings-revenue-by-customer-type-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -13,6 +14,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import BookingsRevenueByCustomerTypeRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -107,7 +109,7 @@ function BookingsRevenueByCustomerTypeDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ BOOKINGS_REVENUE_BY_CUSTOMER_TYPE_RENDER_MODULE }
 			renderComponent={
 				BookingsRevenueByCustomerTypeRender as ComponentType< WidgetRenderProps< unknown > >

--- a/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/widget.json
+++ b/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/bookings-revenue-by-customer-type",
 	"title": "Bookings revenue by customer type",
 	"description": "Revenue breakdown from new customers vs returning customers for bookings over the selected time period.",
+	"help": {
+		"content": "Revenue breakdown from new customers vs returning customers for bookings over the selected time period."
+	},
 	"category": "bookings",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/widget.ts
+++ b/projects/packages/premium-analytics/widgets/bookings-revenue-by-customer-type/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
@@ -23,13 +22,5 @@ export type BookingsRevenueByCustomerTypeAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/bookings-revenue-by-customer-type',
-	title: __( 'Bookings revenue by customer type', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Revenue breakdown from new customers vs returning customers for bookings over the selected time period.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/clicks/stories/clicks-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/clicks/stories/clicks-widget.stories.tsx
@@ -15,9 +15,11 @@ import {
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
 import { withStoryRouter } from '../../stories/with-story-router';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import ClicksRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -27,12 +29,7 @@ registerStatsMocks();
 
 const CLICKS_RENDER_MODULE = 'storybook/clicks';
 
-const storyWidgetType = {
-	name: widgetDefinition.name,
-	title: widgetDefinition.title,
-	icon: widgetDefinition.icon,
-	presentation: 'framed' as const,
-};
+const storyWidgetType = createStoryWidgetType( widgetManifest, widgetDefinition );
 
 interface ClicksStoryControls {
 	withComparison: boolean;

--- a/projects/packages/premium-analytics/widgets/clicks/widget.json
+++ b/projects/packages/premium-analytics/widgets/clicks/widget.json
@@ -2,6 +2,15 @@
 	"name": "jpa/clicks",
 	"title": "Clicks",
 	"description": "Most clicked external links on your site.",
+	"help": {
+		"content": "The external links your visitors clicked most often, sorted by clicks.",
+		"links": [
+			{
+				"label": "Learn more",
+				"href": "https://jetpack.com/support/jetpack-stats/"
+			}
+		]
+	},
 	"category": "traffic",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/clicks/widget.ts
+++ b/projects/packages/premium-analytics/widgets/clicks/widget.ts
@@ -22,20 +22,6 @@ export type ClicksAttributes = {
  * via the PA proxy at `stats/clicks`.
  */
 export default {
-	name: 'jpa/clicks',
-	title: __( 'Clicks', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'The external links your visitors clicked most often, sorted by clicks.',
-			'jetpack-premium-analytics'
-		),
-		links: [
-			{
-				label: __( 'Learn more', 'jetpack-premium-analytics' ),
-				href: 'https://jetpack.com/support/jetpack-stats/',
-			},
-		],
-	},
 	icon: link,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/comments/stories/comments-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/comments/stories/comments-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
 import { withStoryRouter } from '../../stories/with-story-router';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -13,25 +14,19 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import CommentsRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { CommentsView } from '../widget';
 import type { Meta, StoryObj } from '@storybook/react';
-import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
 
 const COMMENTS_RENDER_MODULE = 'storybook/comments';
 
-const storyWidgetType = {
-	name: widgetDefinition.name,
-	title: widgetDefinition.title,
-	icon: widgetDefinition.icon,
-	// attributes/example let the dashboard host render the real "View by" header
-	// control for the `relevance: 'high'` attribute, as in Top Platforms.
-	attributes: widgetDefinition.attributes as WidgetType[ 'attributes' ],
-	example: widgetDefinition.example,
-	presentation: 'framed' as const,
-};
+// attributes/example let the dashboard host render the real "View by" header
+// control for the `relevance: 'high'` attribute, as in Top Platforms.
+const storyWidgetType = createStoryWidgetType( widgetManifest, widgetDefinition );
 
 const VIEW_CONTROL = {
 	control: 'inline-radio' as const,

--- a/projects/packages/premium-analytics/widgets/comments/widget.json
+++ b/projects/packages/premium-analytics/widgets/comments/widget.json
@@ -2,6 +2,15 @@
 	"name": "jpa/comments",
 	"title": "Comments",
 	"description": "The authors and posts that receive the most comments on your site.",
+	"help": {
+		"content": "A breakdown of comments, grouped by author and by post or page.",
+		"links": [
+			{
+				"label": "Learn more",
+				"href": "https://jetpack.com/support/jetpack-stats/"
+			}
+		]
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/comments/widget.ts
+++ b/projects/packages/premium-analytics/widgets/comments/widget.ts
@@ -41,20 +41,6 @@ export type CommentsAttributes = {
  * the dashboard date range.
  */
 export default {
-	name: 'jpa/comments',
-	title: __( 'Comments', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'A breakdown of comments, grouped by author and by post or page.',
-			'jetpack-premium-analytics'
-		),
-		links: [
-			{
-				label: __( 'Learn more', 'jetpack-premium-analytics' ),
-				href: 'https://jetpack.com/support/jetpack-stats/',
-			},
-		],
-	},
 	icon: comment,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/conversion-rate/stories/conversion-rate-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/conversion-rate/stories/conversion-rate-widget.stories.tsx
@@ -7,11 +7,13 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import ConversionRateRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { APIFetchMiddleware } from '@wordpress/api-fetch';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
@@ -150,7 +152,7 @@ function ConversionRateDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ CONVERSION_RATE_RENDER_MODULE }
 			renderComponent={ ConversionRateRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ getConversionRateAttributes( withComparison, preset ) }

--- a/projects/packages/premium-analytics/widgets/conversion-rate/widget.json
+++ b/projects/packages/premium-analytics/widgets/conversion-rate/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/conversion-rate",
 	"title": "Store conversion rate",
 	"description": "Store conversion rate over the selected time period.",
+	"help": {
+		"content": "Conversion funnel from visitors to completed purchases over the selected time period."
+	},
 	"category": "store",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/conversion-rate/widget.ts
+++ b/projects/packages/premium-analytics/widgets/conversion-rate/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
@@ -22,13 +21,5 @@ export type ConversionRateAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/conversion-rate',
-	title: __( 'Store conversion rate', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Conversion funnel from visitors to completed purchases over the selected time period.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/coupon-usage-over-time/stories/coupon-usage-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/coupon-usage-over-time/stories/coupon-usage-over-time-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -13,6 +14,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import CouponUsageOverTimeRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -97,7 +99,7 @@ function CouponUsageOverTimeDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ COUPON_USAGE_OVER_TIME_RENDER_MODULE }
 			renderComponent={ CouponUsageOverTimeRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ getCouponUsageOverTimeAttributes( withComparison, preset ) }

--- a/projects/packages/premium-analytics/widgets/coupon-usage-over-time/widget.json
+++ b/projects/packages/premium-analytics/widgets/coupon-usage-over-time/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/coupon-usage-over-time",
 	"title": "Coupon usage over time",
 	"description": "Coupon usage over the selected time period.",
+	"help": {
+		"content": "Track how effective your discounts and promotions have been over a set period of time."
+	},
 	"category": "coupons",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/coupon-usage-over-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/coupon-usage-over-time/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
@@ -22,13 +21,5 @@ export type CouponUsageOverTimeAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/coupon-usage-over-time',
-	title: __( 'Coupon usage over time', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Track how effective your discounts and promotions have been over a set period of time.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/devices/stories/devices-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/devices/stories/devices-widget.stories.tsx
@@ -5,12 +5,14 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import { registerStatsMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-stats-mocks';
 import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import DevicesRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -20,14 +22,9 @@ registerStatsMocks();
 
 const DEVICES_RENDER_MODULE = 'storybook/devices';
 
-// Pick only the fields that StoryWidgetMetadata accepts — the attribute schema
-// and example arrays are typed differently in WidgetType and cause a type error.
-const storyWidgetType = {
-	name: widgetDefinition.name,
-	title: widgetDefinition.title,
-	icon: widgetDefinition.icon,
-	presentation: 'framed' as const,
-};
+// Carry the widget's metadata. `presentation` comes from widget.json ( 'framed' ),
+// so the host frames the widget and renders its identity (title + icon).
+const storyWidgetType = createStoryWidgetType( widgetManifest, widgetDefinition );
 
 interface DevicesStoryControls {
 	withComparison: boolean;

--- a/projects/packages/premium-analytics/widgets/devices/widget.json
+++ b/projects/packages/premium-analytics/widgets/devices/widget.json
@@ -2,6 +2,15 @@
 	"name": "jpa/devices",
 	"title": "Devices",
 	"description": "Top device types and screen sizes for your visitors.",
+	"help": {
+		"content": "A breakdown of the device types your visitors used, sorted by views.",
+		"links": [
+			{
+				"label": "Learn more",
+				"href": "https://jetpack.com/support/jetpack-stats/"
+			}
+		]
+	},
 	"category": "traffic",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/devices/widget.ts
+++ b/projects/packages/premium-analytics/widgets/devices/widget.ts
@@ -23,20 +23,6 @@ export type DevicesAttributes = {
  * reportParams (the shared dashboard date picker).
  */
 export default {
-	name: 'jpa/devices',
-	title: __( 'Devices', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'A breakdown of the device types your visitors used, sorted by views.',
-			'jetpack-premium-analytics'
-		),
-		links: [
-			{
-				label: __( 'Learn more', 'jetpack-premium-analytics' ),
-				href: 'https://jetpack.com/support/jetpack-stats/',
-			},
-		],
-	},
 	icon: desktop,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/email-breakdown/stories/email-breakdown-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/stories/email-breakdown-widget.stories.tsx
@@ -26,9 +26,11 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import EmailBreakdownRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { EmailBreakdownMetric, EmailBreakdownView } from '../widget';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
@@ -212,7 +214,7 @@ function EmailBreakdownDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
-			widgetType={ { ...widgetDefinition, presentation: 'framed' } }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ EMAIL_BREAKDOWN_RENDER_MODULE }
 			renderComponent={ EmailBreakdownRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ {

--- a/projects/packages/premium-analytics/widgets/email-breakdown/widget.json
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/email-breakdown",
 	"title": "Email breakdown",
 	"description": "Breaks a sent email down by countries, devices, email clients, or clicked links.",
+	"help": {
+		"content": "Breaks a sent email down by countries, devices, email clients, or clicked links."
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/email-breakdown/widget.ts
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/widget.ts
@@ -66,14 +66,6 @@ export type EmailBreakdownAttributes = {
  * range or comparison period.
  */
 export default {
-	name: 'jpa/email-breakdown',
-	title: __( 'Email breakdown', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Breaks a sent email down by countries, devices, email clients, or clicked links.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: envelope,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/email-time-series/stories/email-time-series-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-time-series/stories/email-time-series-widget.stories.tsx
@@ -28,9 +28,11 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import EmailTimeSeriesRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { EmailTimeSeriesGranularity, EmailTimeSeriesMetric } from '../widget';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
@@ -233,7 +235,7 @@ function EmailTimeSeriesDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
-			widgetType={ { ...widgetDefinition, presentation: 'framed' } }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ EMAIL_TIME_SERIES_RENDER_MODULE }
 			renderComponent={ EmailTimeSeriesRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ {

--- a/projects/packages/premium-analytics/widgets/email-time-series/widget.json
+++ b/projects/packages/premium-analytics/widgets/email-time-series/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/email-time-series",
 	"title": "Email performance",
 	"description": "A single email's opens or clicks over time since it was sent.",
+	"help": {
+		"content": "How a single email performed over time: opens or clicks per day since it was sent, following the dashboard date range. Weekly and monthly grouping aggregate the daily buckets."
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/email-time-series/widget.ts
+++ b/projects/packages/premium-analytics/widgets/email-time-series/widget.ts
@@ -47,15 +47,7 @@ export type EmailTimeSeriesAttributes = {
  * the timeline spans the dashboard date range.
  */
 export default {
-	name: 'jpa/email-time-series',
-	title: __( 'Email performance', 'jetpack-premium-analytics' ),
 	icon: envelope,
-	help: {
-		content: __(
-			'How a single email performed over time: opens or clicks per day since it was sent, following the dashboard date range. Weekly and monthly grouping aggregate the daily buckets.',
-			'jetpack-premium-analytics'
-		),
-	},
 	attributes: [
 		{
 			id: 'metric',

--- a/projects/packages/premium-analytics/widgets/email-top-row/stories/email-top-row-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-top-row/stories/email-top-row-widget.stories.tsx
@@ -25,9 +25,11 @@ import {
 	registerReportMocks,
 	setReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import EmailTopRowRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { EmailMetric } from '../widget';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
@@ -166,7 +168,7 @@ function EmailTopRowDashboardStory( { metric, ...dashboardArgs }: EmailTopRowDas
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ EMAIL_TOP_ROW_RENDER_MODULE }
 			renderComponent={ EmailTopRowRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ {

--- a/projects/packages/premium-analytics/widgets/email-top-row/widget.json
+++ b/projects/packages/premium-analytics/widgets/email-top-row/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/email-top-row",
 	"title": "Email highlights",
 	"description": "Headline open and click totals for a single email, split into Opens and Clicks views.",
+	"help": {
+		"content": "Headline stats for a single email. The Opens view shows total sends, unique opens, total opens, and open rate; the Clicks view shows total sends, unique opens, total clicks, and click rate. Rates are measured against total sends. Figures are all-time and are not affected by the dashboard date range."
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/email-top-row/widget.ts
+++ b/projects/packages/premium-analytics/widgets/email-top-row/widget.ts
@@ -57,15 +57,7 @@ export type EmailTopRowAttributes = {
  * ignores the dashboard date range and never shows period-over-period deltas.
  */
 export default {
-	name: 'jpa/email-top-row',
-	title: __( 'Email highlights', 'jetpack-premium-analytics' ),
 	icon: envelope,
-	help: {
-		content: __(
-			'Headline stats for a single email. The Opens view shows total sends, unique opens, total opens, and open rate; the Clicks view shows total sends, unique opens, total clicks, and click rate. Rates are measured against total sends. Figures are all-time and are not affected by the dashboard date range.',
-			'jetpack-premium-analytics'
-		),
-	},
 	attributes: [
 		{
 			id: 'metric',

--- a/projects/packages/premium-analytics/widgets/emails/stories/emails-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/emails/stories/emails-widget.stories.tsx
@@ -22,9 +22,11 @@ import {
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
 import { withStoryRouter } from '../../stories/with-story-router';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import EmailsRender, { EmailsLeaderboard, type EmailRow } from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj, Decorator } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentType } from 'react';
@@ -246,12 +248,7 @@ function EmailsDashboardStory( props: WidgetDashboardWithWidgetControls ) {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...props }
-			widgetType={ {
-				name: widgetDefinition.name,
-				title: widgetDefinition.title,
-				icon: widgetDefinition.icon,
-				presentation: 'framed',
-			} }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ EMAILS_RENDER_MODULE }
 			renderComponent={ EmailsRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ { max: 6, metric: 'opens' } }

--- a/projects/packages/premium-analytics/widgets/emails/widget.json
+++ b/projects/packages/premium-analytics/widgets/emails/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/stats-emails",
 	"title": "Emails",
 	"description": "Open and click rates for your latest emails.",
+	"help": {
+		"content": "Your most recently sent emails, including their open and click rates."
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/emails/widget.ts
+++ b/projects/packages/premium-analytics/widgets/emails/widget.ts
@@ -42,14 +42,6 @@ export type EmailsAttributes = {
  * there is no date range or comparison period.
  */
 export default {
-	name: 'jpa/stats-emails',
-	title: __( 'Emails', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Your most recently sent emails, including their open and click rates.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: envelope,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/file-downloads/stories/file-downloads-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/file-downloads/stories/file-downloads-widget.stories.tsx
@@ -15,9 +15,11 @@ import {
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
 import { withStoryRouter } from '../../stories/with-story-router';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import FileDownloadsRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -27,12 +29,7 @@ registerStatsMocks();
 
 const FILE_DOWNLOADS_RENDER_MODULE = 'storybook/file-downloads';
 
-const storyWidgetType = {
-	name: widgetDefinition.name,
-	title: widgetDefinition.title,
-	icon: widgetDefinition.icon,
-	presentation: 'framed' as const,
-};
+const storyWidgetType = createStoryWidgetType( widgetManifest, widgetDefinition );
 
 interface FileDownloadsStoryControls {
 	withComparison: boolean;

--- a/projects/packages/premium-analytics/widgets/file-downloads/widget.json
+++ b/projects/packages/premium-analytics/widgets/file-downloads/widget.json
@@ -2,6 +2,15 @@
 	"name": "jpa/file-downloads",
 	"title": "File downloads",
 	"description": "Most downloaded files on your site.",
+	"help": {
+		"content": "The files your visitors downloaded most often, sorted by number of downloads.",
+		"links": [
+			{
+				"label": "Learn more",
+				"href": "https://jetpack.com/support/jetpack-stats/"
+			}
+		]
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/file-downloads/widget.ts
+++ b/projects/packages/premium-analytics/widgets/file-downloads/widget.ts
@@ -23,20 +23,6 @@ export type FileDownloadsAttributes = {
  * (the shared dashboard date picker).
  */
 export default {
-	name: 'jpa/file-downloads',
-	title: __( 'File downloads', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'The files your visitors downloaded most often, sorted by number of downloads.',
-			'jetpack-premium-analytics'
-		),
-		links: [
-			{
-				label: __( 'Learn more', 'jetpack-premium-analytics' ),
-				href: 'https://jetpack.com/support/jetpack-stats/',
-			},
-		],
-	},
 	icon: download,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/gross-sales-over-time/stories/gross-sales-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/gross-sales-over-time/stories/gross-sales-over-time-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import LineChart from '../../../../../js-packages/charts/src/charts/line-chart/line-chart';
 import {
@@ -14,6 +15,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import GrossSalesOverTimeRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -105,7 +107,7 @@ function GrossSalesOverTimeDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ GROSS_SALES_OVER_TIME_RENDER_MODULE }
 			renderComponent={ GrossSalesOverTimeRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ getGrossSalesOverTimeAttributes( withComparison, preset ) }

--- a/projects/packages/premium-analytics/widgets/gross-sales-over-time/widget.json
+++ b/projects/packages/premium-analytics/widgets/gross-sales-over-time/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/gross-sales-over-time",
 	"title": "Gross sales over time",
 	"description": "Gross sales over the selected time period.",
+	"help": {
+		"content": "Monitor your total revenue — before any discounts, returns, or adjustments — over a set period of time."
+	},
 	"category": "store",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/gross-sales-over-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/gross-sales-over-time/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
@@ -23,13 +22,5 @@ export type GrossSalesOverTimeAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/gross-sales-over-time',
-	title: __( 'Gross sales over time', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Monitor your total revenue — before any discounts, returns, or adjustments — over a set period of time.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/hello-world/widget.ts
+++ b/projects/packages/premium-analytics/widgets/hello-world/widget.ts
@@ -16,8 +16,6 @@ export type HelloWorldAttributes = {
  * Widget type definition.
  */
 export default {
-	name: 'jpa/hello-world',
-	title: __( 'Hello World', 'jetpack-premium-analytics' ),
 	icon: wordpress,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/latest-post/stories/latest-post-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/latest-post/stories/latest-post-widget.stories.tsx
@@ -25,9 +25,11 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import LatestPostRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { APIFetchMiddleware, APIFetchOptions } from '@wordpress/api-fetch';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
@@ -218,7 +220,7 @@ function LatestPostDashboardStory( dashboardArgs: WidgetDashboardWithWidgetContr
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
-			widgetType={ { ...widgetDefinition, presentation: 'framed' } }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ LATEST_POST_RENDER_MODULE }
 			renderComponent={ LatestPostRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ { reportParams: getDefaultQueryParams( true ) } }

--- a/projects/packages/premium-analytics/widgets/latest-post/widget.json
+++ b/projects/packages/premium-analytics/widgets/latest-post/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/latest-post",
 	"title": "Latest post",
 	"description": "Your most recently published post with its views, likes, and comments.",
+	"help": {
+		"content": "Your most recently published post with its views, likes, and comments."
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/latest-post/widget.ts
+++ b/projects/packages/premium-analytics/widgets/latest-post/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { postList } from '@wordpress/icons';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
@@ -22,14 +21,6 @@ export type LatestPostAttributes = Record< never, never >;
  * period.
  */
 export default {
-	name: 'jpa/latest-post',
-	title: __( 'Latest post', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Your most recently published post with its views, likes, and comments.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: postList,
 	attributes: [] as WidgetAttributeField< LatestPostAttributes >[],
 	example: {

--- a/projects/packages/premium-analytics/widgets/locations/stories/locations-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/stories/locations-widget.stories.tsx
@@ -5,14 +5,16 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import { registerStatsMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-stats-mocks';
 import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import LocationsRender from '../render';
 import widgetDefinition, { type LocationsAttributes } from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
-import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
@@ -20,14 +22,7 @@ registerStatsMocks();
 
 const LOCATIONS_RENDER_MODULE = 'storybook/locations';
 
-const storyWidgetType = {
-	name: widgetDefinition.name,
-	title: widgetDefinition.title,
-	icon: widgetDefinition.icon,
-	attributes: widgetDefinition.attributes as WidgetType[ 'attributes' ],
-	example: widgetDefinition.example,
-	presentation: 'framed' as const,
-};
+const storyWidgetType = createStoryWidgetType( widgetManifest, widgetDefinition );
 
 interface LocationsStoryControls {
 	withComparison: boolean;

--- a/projects/packages/premium-analytics/widgets/locations/widget.json
+++ b/projects/packages/premium-analytics/widgets/locations/widget.json
@@ -2,6 +2,15 @@
 	"name": "jpa/locations",
 	"title": "Locations",
 	"description": "Where your visitors are viewing from — by country, region, or city.",
+	"help": {
+		"content": "The countries, regions, and cities where your visitors came from, sorted by views.",
+		"links": [
+			{
+				"label": "Learn more",
+				"href": "https://jetpack.com/support/jetpack-stats/"
+			}
+		]
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/locations/widget.ts
+++ b/projects/packages/premium-analytics/widgets/locations/widget.ts
@@ -32,20 +32,6 @@ export type LocationsAttributes = {
  * highlighting the country on the world map.
  */
 export default {
-	name: 'jpa/locations',
-	title: __( 'Locations', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'The countries, regions, and cities where your visitors came from, sorted by views.',
-			'jetpack-premium-analytics'
-		),
-		links: [
-			{
-				label: __( 'Learn more', 'jetpack-premium-analytics' ),
-				href: 'https://jetpack.com/support/jetpack-stats/',
-			},
-		],
-	},
 	icon: mapMarker,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/most-popular-day/stories/most-popular-day-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/stories/most-popular-day-widget.stories.tsx
@@ -17,6 +17,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -24,6 +25,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import MostPopularDayRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -138,7 +140,7 @@ function MostPopularDayDashboardStory( dashboardArgs: WidgetDashboardWithWidgetC
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ MOST_POPULAR_DAY_RENDER_MODULE }
 			renderComponent={ MostPopularDayRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ { reportParams: getDefaultQueryParams( true ) } }

--- a/projects/packages/premium-analytics/widgets/most-popular-day/widget.json
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/most-popular-day",
 	"title": "Most popular day",
 	"description": "The day your site received the most views.",
+	"help": {
+		"content": "The day your site received the most views."
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/most-popular-day/widget.ts
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { calendar } from '@wordpress/icons';
 
 /**
@@ -18,10 +17,5 @@ export type MostPopularDayAttributes = Record< never, never >;
  * drew the most views, with that day's view count and its share of all views.
  */
 export default {
-	name: 'jpa/most-popular-day',
-	title: __( 'Most popular day', 'jetpack-premium-analytics' ),
-	help: {
-		content: __( 'The day your site received the most views.', 'jetpack-premium-analytics' ),
-	},
 	icon: calendar,
 };

--- a/projects/packages/premium-analytics/widgets/most-popular-time/stories/most-popular-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-time/stories/most-popular-time-widget.stories.tsx
@@ -21,9 +21,11 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import MostPopularTimeRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -137,12 +139,7 @@ function MostPopularTimeDashboardStory( dashboardArgs: WidgetDashboardWithWidget
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
-			widgetType={ {
-				name: widgetDefinition.name,
-				title: widgetDefinition.title,
-				icon: widgetDefinition.icon,
-				presentation: 'framed',
-			} }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ MOST_POPULAR_TIME_RENDER_MODULE }
 			renderComponent={ MostPopularTimeRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ { reportParams: getDefaultQueryParams( true ) } }

--- a/projects/packages/premium-analytics/widgets/most-popular-time/widget.json
+++ b/projects/packages/premium-analytics/widgets/most-popular-time/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/most-popular-time",
 	"title": "Most popular time",
 	"description": "The day of week and hour of day when your site gets the most views.",
+	"help": {
+		"content": "The day of week and hour of day when your site gets the most views."
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/most-popular-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/most-popular-time/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { scheduled } from '@wordpress/icons';
 
 /**
@@ -20,13 +19,5 @@ export type MostPopularTimeAttributes = Record< never, never >;
  * total.
  */
 export default {
-	name: 'jpa/most-popular-time',
-	title: __( 'Most popular time', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'The day of week and hour of day when your site gets the most views.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: scheduled,
 };

--- a/projects/packages/premium-analytics/widgets/net-sales-over-time/stories/net-sales-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/net-sales-over-time/stories/net-sales-over-time-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import LineChart from '../../../../../js-packages/charts/src/charts/line-chart/line-chart';
 import {
@@ -14,6 +15,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import NetSalesOverTimeRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -103,7 +105,7 @@ function NetSalesOverTimeDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ NET_SALES_OVER_TIME_RENDER_MODULE }
 			renderComponent={ NetSalesOverTimeRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ getNetSalesOverTimeAttributes( withComparison, preset ) }

--- a/projects/packages/premium-analytics/widgets/net-sales-over-time/widget.json
+++ b/projects/packages/premium-analytics/widgets/net-sales-over-time/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/net-sales-over-time",
 	"title": "Net sales over time",
 	"description": "Monitor your total revenue after discounts, returns, or adjustments over a set period of time.",
+	"help": {
+		"content": "Monitor your total revenue — after any discounts, returns, or adjustments — over a set period of time."
+	},
 	"category": "orders",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/net-sales-over-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/net-sales-over-time/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
@@ -23,13 +22,5 @@ export type NetSalesOverTimeAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/net-sales-over-time',
-	title: __( 'Net sales over time', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Monitor your total revenue — after any discounts, returns, or adjustments — over a set period of time.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/new-vs-returning-customer/stories/new-vs-returning-customer-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/new-vs-returning-customer/stories/new-vs-returning-customer-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -13,6 +14,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import NewVsReturningCustomerRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -102,7 +104,7 @@ function NewVsReturningCustomerDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ NEW_VS_RETURNING_CUSTOMER_RENDER_MODULE }
 			renderComponent={
 				NewVsReturningCustomerRender as ComponentType< WidgetRenderProps< unknown > >

--- a/projects/packages/premium-analytics/widgets/new-vs-returning-customer/widget.json
+++ b/projects/packages/premium-analytics/widgets/new-vs-returning-customer/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/new-vs-returning-customer",
 	"title": "New vs returning customer",
 	"description": "Unique customer counts broken down by new vs returning customers over the selected time period.",
+	"help": {
+		"content": "Unique customer counts broken down by new vs returning customers over the selected time period."
+	},
 	"category": "store",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/new-vs-returning-customer/widget.ts
+++ b/projects/packages/premium-analytics/widgets/new-vs-returning-customer/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
@@ -23,13 +22,5 @@ export type NewVsReturningCustomerAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/new-vs-returning-customer',
-	title: __( 'New vs returning customer', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Unique customer counts broken down by new vs returning customers over the selected time period.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/orders-fulfillment/stories/orders-fulfillment-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/orders-fulfillment/stories/orders-fulfillment-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -13,6 +14,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import OrdersFulfillmentRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -94,7 +96,7 @@ function OrdersFulfillmentDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ ORDERS_FULFILLMENT_RENDER_MODULE }
 			renderComponent={ OrdersFulfillmentRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ getOrdersFulfillmentAttributes( withComparison, preset ) }

--- a/projects/packages/premium-analytics/widgets/orders-fulfillment/widget.json
+++ b/projects/packages/premium-analytics/widgets/orders-fulfillment/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/orders-fulfillment",
 	"title": "Orders fulfillment",
 	"description": "Shows the breakdown of fulfilled vs unfulfilled order counts over the selected time period.",
+	"help": {
+		"content": "Shows the breakdown of fulfilled vs unfulfilled order counts over the selected time period."
+	},
 	"category": "store",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/orders-fulfillment/widget.ts
+++ b/projects/packages/premium-analytics/widgets/orders-fulfillment/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
@@ -23,13 +22,5 @@ export type OrdersFulfillmentAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/orders-fulfillment',
-	title: __( 'Orders fulfillment', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Shows the breakdown of fulfilled vs unfulfilled order counts over the selected time period.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/orders-over-time/stories/orders-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/orders-over-time/stories/orders-over-time-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import LineChart from '../../../../../js-packages/charts/src/charts/line-chart/line-chart';
 import {
@@ -14,6 +15,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import OrdersOverTimeRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -102,7 +104,7 @@ function OrdersOverTimeDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ ORDERS_OVER_TIME_RENDER_MODULE }
 			renderComponent={ OrdersOverTimeRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ getOrdersOverTimeAttributes( withComparison, preset ) }

--- a/projects/packages/premium-analytics/widgets/orders-over-time/widget.json
+++ b/projects/packages/premium-analytics/widgets/orders-over-time/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/orders-over-time",
 	"title": "Orders over time",
 	"description": "See a breakdown of when orders are placed to identify peak selling periods.",
+	"help": {
+		"content": "See a breakdown of when orders are placed to identify peak selling periods."
+	},
 	"category": "orders",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/orders-over-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/orders-over-time/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
@@ -23,13 +22,5 @@ export type OrdersOverTimeAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/orders-over-time',
-	title: __( 'Orders over time', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'See a breakdown of when orders are placed to identify peak selling periods.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/payment-status/stories/payment-status-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/payment-status/stories/payment-status-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -13,6 +14,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import PaymentStatusRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -92,7 +94,7 @@ function PaymentStatusDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ PAYMENT_STATUS_RENDER_MODULE }
 			renderComponent={ PaymentStatusRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ getPaymentStatusAttributes( withComparison, preset ) }

--- a/projects/packages/premium-analytics/widgets/payment-status/widget.json
+++ b/projects/packages/premium-analytics/widgets/payment-status/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/payment-status",
 	"title": "Payment status",
 	"description": "Shows the breakdown of paid vs unpaid order revenue over the selected time period.",
+	"help": {
+		"content": "Shows the breakdown of paid vs unpaid order revenue over the selected time period."
+	},
 	"category": "store",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/payment-status/widget.ts
+++ b/projects/packages/premium-analytics/widgets/payment-status/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
@@ -23,13 +22,5 @@ export type PaymentStatusAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/payment-status',
-	title: __( 'Payment status', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Shows the breakdown of paid vs unpaid order revenue over the selected time period.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/plan-usage/stories/plan-usage-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/plan-usage/stories/plan-usage-widget.stories.tsx
@@ -24,9 +24,11 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import PlanUsageRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -204,7 +206,7 @@ function PlanUsageDashboardStory( dashboardArgs: WidgetDashboardWithWidgetContro
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
-			widgetType={ { ...widgetDefinition, presentation: 'framed' } }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ PLAN_USAGE_RENDER_MODULE }
 			renderComponent={ PlanUsageRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ { reportParams: getDefaultQueryParams( true ) } }

--- a/projects/packages/premium-analytics/widgets/plan-usage/widget.json
+++ b/projects/packages/premium-analytics/widgets/plan-usage/widget.json
@@ -2,6 +2,15 @@
 	"name": "jpa/plan-usage",
 	"title": "Plan usage",
 	"description": "How your billable views compare to your plan's monthly limit.",
+	"help": {
+		"content": "Billable views are your total views minus your two highest-traffic days each billing cycle, so big spikes won't count against your limit. You'll only need to upgrade if you exceed your limit for three cycles in a row.",
+		"links": [
+			{
+				"label": "Learn more",
+				"href": "https://jetpack.com/support/jetpack-stats/free-or-paid/"
+			}
+		]
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/plan-usage/widget.ts
+++ b/projects/packages/premium-analytics/widgets/plan-usage/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { percent } from '@wordpress/icons';
 
 /**
@@ -25,21 +24,7 @@ export type PlanUsageAttributes = Record< never, never >;
  * how billable views are counted and when an upgrade is needed.
  */
 export default {
-	name: 'jpa/plan-usage',
-	title: __( 'Plan usage', 'jetpack-premium-analytics' ),
 	icon: percent,
-	help: {
-		content: __(
-			"Billable views are your total views minus your two highest-traffic days each billing cycle, so big spikes won't count against your limit. You'll only need to upgrade if you exceed your limit for three cycles in a row.",
-			'jetpack-premium-analytics'
-		),
-		links: [
-			{
-				label: __( 'Learn more', 'jetpack-premium-analytics' ),
-				href: 'https://jetpack.com/support/jetpack-stats/free-or-paid/',
-			},
-		],
-	},
 	attributes: [],
 	example: {
 		attributes: {},

--- a/projects/packages/premium-analytics/widgets/post-comments/stories/post-comments-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/post-comments/stories/post-comments-widget.stories.tsx
@@ -12,9 +12,11 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import PostCommentsRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -90,7 +92,7 @@ function PostCommentsDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
-			widgetType={ { ...widgetDefinition, presentation: 'framed' } }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ POST_COMMENTS_RENDER_MODULE }
 			renderComponent={ PostCommentsRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ getPostCommentsAttributes( { hasPostScope } ) }

--- a/projects/packages/premium-analytics/widgets/post-comments/widget.json
+++ b/projects/packages/premium-analytics/widgets/post-comments/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/post-comments",
 	"title": "Latest comments",
 	"description": "The latest comments on the post or page being viewed.",
+	"help": {
+		"content": "The latest comments on the post or page being viewed."
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/post-comments/widget.ts
+++ b/projects/packages/premium-analytics/widgets/post-comments/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { comment } from '@wordpress/icons';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
@@ -16,14 +15,6 @@ export type PostCommentsAttributes = Record< never, never >;
  * card. The list is a lifetime roster and is not date-scoped.
  */
 export default {
-	name: 'jpa/post-comments',
-	title: __( 'Latest comments', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'The latest comments on the post or page being viewed.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: comment,
 	attributes: [] as WidgetAttributeField< PostCommentsAttributes >[],
 	example: {

--- a/projects/packages/premium-analytics/widgets/post-detail-highlights/stories/post-detail-highlights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/post-detail-highlights/stories/post-detail-highlights-widget.stories.tsx
@@ -25,9 +25,11 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import PostDetailHighlightsRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -159,7 +161,7 @@ function PostDetailHighlightsDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
-			widgetType={ { ...widgetDefinition, presentation: 'framed' } }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ POST_DETAIL_HIGHLIGHTS_RENDER_MODULE }
 			renderComponent={
 				PostDetailHighlightsRender as ComponentType< WidgetRenderProps< unknown > >

--- a/projects/packages/premium-analytics/widgets/post-detail-highlights/widget.json
+++ b/projects/packages/premium-analytics/widgets/post-detail-highlights/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/post-detail-highlights",
 	"title": "Post highlights",
 	"description": "Views, comments, and likes for the post or page being viewed.",
+	"help": {
+		"content": "Views, comments, and likes for the post or page being viewed."
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/post-detail-highlights/widget.ts
+++ b/projects/packages/premium-analytics/widgets/post-detail-highlights/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { starEmpty } from '@wordpress/icons';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
@@ -26,14 +25,6 @@ export type PostDetailHighlightsAttributes = Record< never, never >;
  * summary header, not repeated here.
  */
 export default {
-	name: 'jpa/post-detail-highlights',
-	title: __( 'Post highlights', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Views, comments, and likes for the post or page being viewed.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: starEmpty,
 	attributes: [] as WidgetAttributeField< PostDetailHighlightsAttributes >[],
 	example: {

--- a/projects/packages/premium-analytics/widgets/post-likes/stories/post-likes-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/post-likes/stories/post-likes-widget.stories.tsx
@@ -23,9 +23,11 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import PostLikesRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -132,7 +134,7 @@ function PostLikesDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
-			widgetType={ { ...widgetDefinition, presentation: 'framed' } }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ POST_LIKES_RENDER_MODULE }
 			renderComponent={ PostLikesRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ getPostLikesAttributes( { hasPostScope } ) }

--- a/projects/packages/premium-analytics/widgets/post-likes/widget.json
+++ b/projects/packages/premium-analytics/widgets/post-likes/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/post-likes",
 	"title": "Latest likes",
 	"description": "The people who liked the post or page being viewed.",
+	"help": {
+		"content": "The people who liked the post or page being viewed."
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/post-likes/widget.ts
+++ b/projects/packages/premium-analytics/widgets/post-likes/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { starEmpty } from '@wordpress/icons';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
@@ -23,14 +22,6 @@ export type PostLikesAttributes = Record< never, never >;
  * shown. The list is a lifetime roster and is not date-scoped.
  */
 export default {
-	name: 'jpa/post-likes',
-	title: __( 'Latest likes', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'The people who liked the post or page being viewed.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: starEmpty,
 	attributes: [] as WidgetAttributeField< PostLikesAttributes >[],
 	example: {

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/stories/post-traffic-activity-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/stories/post-traffic-activity-widget.stories.tsx
@@ -25,9 +25,11 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import PostTrafficActivityRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -155,7 +157,7 @@ function PostTrafficActivityDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
-			widgetType={ { ...widgetDefinition, presentation: 'framed' } }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ POST_TRAFFIC_ACTIVITY_RENDER_MODULE }
 			renderComponent={ PostTrafficActivityRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ getPostTrafficActivityAttributes( { hasPostScope, preset }, true ) }

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/widget.json
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/post-traffic-activity",
 	"title": "Traffic activity",
 	"description": "Daily views for the post or page being viewed, as a calendar heatmap.",
+	"help": {
+		"content": "Daily views for the post or page being viewed, as a calendar heatmap."
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/widget.ts
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { calendar } from '@wordpress/icons';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
@@ -24,14 +23,6 @@ export type PostTrafficActivityAttributes = Record< never, never >;
  * traffic stay blank cells, per the design, while the grid stays complete.
  */
 export default {
-	name: 'jpa/post-traffic-activity',
-	title: __( 'Traffic activity', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Daily views for the post or page being viewed, as a calendar heatmap.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: calendar,
 	attributes: [] as WidgetAttributeField< PostTrafficActivityAttributes >[],
 	example: {

--- a/projects/packages/premium-analytics/widgets/post-views/stories/post-views-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/post-views/stories/post-views-widget.stories.tsx
@@ -24,9 +24,11 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import PostViewsRender from '../render';
 import widgetDefinition, { type PostViewsGranularity } from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -163,7 +165,7 @@ function PostViewsDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
-			widgetType={ { ...widgetDefinition, presentation: 'framed' } }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ POST_VIEWS_RENDER_MODULE }
 			renderComponent={ PostViewsRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ getPostViewsAttributes( { withComparison, hasPostScope, granularity } ) }

--- a/projects/packages/premium-analytics/widgets/post-views/widget.json
+++ b/projects/packages/premium-analytics/widgets/post-views/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/post-views",
 	"title": "Post views",
 	"description": "The view trend of the post or page being viewed over the selected period.",
+	"help": {
+		"content": "The view trend of the post or page being viewed over the selected period."
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/post-views/widget.ts
+++ b/projects/packages/premium-analytics/widgets/post-views/widget.ts
@@ -36,14 +36,6 @@ export type PostViewsAttributes = {
  * `granularity` attribute (`relevance: 'high'`) chooses the bucket size.
  */
 export default {
-	name: 'jpa/post-views',
-	title: __( 'Post views', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'The view trend of the post or page being viewed over the selected period.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/posting-activity/stories/posting-activity-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/posting-activity/stories/posting-activity-widget.stories.tsx
@@ -15,9 +15,11 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import PostingActivityRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { APIFetchMiddleware, APIFetchOptions } from '@wordpress/api-fetch';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
@@ -184,7 +186,7 @@ function PostingActivityDashboardStory( dashboardArgs: WidgetDashboardWithWidget
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ POSTING_ACTIVITY_RENDER_MODULE }
 			renderComponent={ PostingActivityRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ { reportParams: getDefaultQueryParams( true ) } }

--- a/projects/packages/premium-analytics/widgets/posting-activity/widget.json
+++ b/projects/packages/premium-analytics/widgets/posting-activity/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/posting-activity",
 	"title": "Posting activity",
 	"description": "How often you publish — a calendar heatmap of posts per day.",
+	"help": {
+		"content": "Your posting activity, shown as a heatmap to help you spot your most and least active days."
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/posting-activity/widget.ts
+++ b/projects/packages/premium-analytics/widgets/posting-activity/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { calendar } from '@wordpress/icons';
 
 /**
@@ -19,13 +18,5 @@ export type PostingActivityAttributes = Record< never, never >;
  * `stats/streak` endpoint has no comparison period, so no delta is shown.
  */
 export default {
-	name: 'jpa/posting-activity',
-	title: __( 'Posting activity', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Your posting activity, shown as a heatmap to help you spot your most and least active days.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: calendar,
 };

--- a/projects/packages/premium-analytics/widgets/react-query-dev-tool/widget.ts
+++ b/projects/packages/premium-analytics/widgets/react-query-dev-tool/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { bug } from '@wordpress/icons';
 
 /**
@@ -19,7 +18,5 @@ export type ReactQueryDevToolAttributes = Record< never, never >;
  * dashboard's widget picker.
  */
 export default {
-	name: 'jpa/react-query-dev-tool',
-	title: __( 'React Query Devtools', 'jetpack-premium-analytics' ),
 	icon: bug,
 };

--- a/projects/packages/premium-analytics/widgets/referrers/stories/referrers-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/stories/referrers-widget.stories.tsx
@@ -15,9 +15,11 @@ import {
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
 import { withStoryRouter } from '../../stories/with-story-router';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import ReferrersRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -27,12 +29,7 @@ registerStatsMocks();
 
 const REFERRERS_RENDER_MODULE = 'storybook/referrers';
 
-const storyWidgetType = {
-	name: widgetDefinition.name,
-	title: widgetDefinition.title,
-	icon: widgetDefinition.icon,
-	presentation: 'framed' as const,
-};
+const storyWidgetType = createStoryWidgetType( widgetManifest, widgetDefinition );
 
 interface ReferrersStoryControls {
 	withComparison: boolean;

--- a/projects/packages/premium-analytics/widgets/referrers/widget.json
+++ b/projects/packages/premium-analytics/widgets/referrers/widget.json
@@ -2,6 +2,15 @@
 	"name": "jpa/referrers",
 	"title": "Referrers",
 	"description": "Websites and search engines referring visitors to your site.",
+	"help": {
+		"content": "The sources that sent the most visitors to your site, sorted by clicks.",
+		"links": [
+			{
+				"label": "Learn more",
+				"href": "https://jetpack.com/support/jetpack-stats/"
+			}
+		]
+	},
 	"category": "traffic",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/referrers/widget.ts
+++ b/projects/packages/premium-analytics/widgets/referrers/widget.ts
@@ -21,20 +21,6 @@ export type ReferrersAttributes = {
  * dashboard date range via the PA proxy at `stats/referrers`.
  */
 export default {
-	name: 'jpa/referrers',
-	title: __( 'Referrers', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'The sources that sent the most visitors to your site, sorted by clicks.',
-			'jetpack-premium-analytics'
-		),
-		links: [
-			{
-				label: __( 'Learn more', 'jetpack-premium-analytics' ),
-				href: 'https://jetpack.com/support/jetpack-stats/',
-			},
-		],
-	},
 	icon: globe,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/revenue-by-customer-type/stories/revenue-by-customer-type-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/revenue-by-customer-type/stories/revenue-by-customer-type-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -13,6 +14,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import RevenueByCustomerTypeRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -102,7 +104,7 @@ function RevenueByCustomerTypeDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ REVENUE_BY_CUSTOMER_TYPE_RENDER_MODULE }
 			renderComponent={
 				RevenueByCustomerTypeRender as ComponentType< WidgetRenderProps< unknown > >

--- a/projects/packages/premium-analytics/widgets/revenue-by-customer-type/widget.json
+++ b/projects/packages/premium-analytics/widgets/revenue-by-customer-type/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/revenue-by-customer-type",
 	"title": "Revenue by customer type",
 	"description": "Shows the breakdown of order revenue from new and returning customers over the selected time period.",
+	"help": {
+		"content": "Revenue breakdown from new customers vs returning customers over the selected time period."
+	},
 	"category": "store",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/revenue-by-customer-type/widget.ts
+++ b/projects/packages/premium-analytics/widgets/revenue-by-customer-type/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
@@ -23,13 +22,5 @@ export type RevenueByCustomerTypeAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/revenue-by-customer-type',
-	title: __( 'Revenue by customer type', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Revenue breakdown from new customers vs returning customers over the selected time period.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/stories/sales-by-coupon-usage-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/stories/sales-by-coupon-usage-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -13,6 +14,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SalesByCouponUsageRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -96,7 +98,7 @@ function SalesByCouponUsageDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ SALES_BY_COUPON_USAGE_RENDER_MODULE }
 			renderComponent={ SalesByCouponUsageRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ getSalesByCouponUsageAttributes( withComparison, preset ) }

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/widget.json
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/sales-by-coupon-usage",
 	"title": "Sales by coupon usage",
 	"description": "Sales by coupon usage over the selected time period.",
+	"help": {
+		"content": "Compare sales with and without coupons."
+	},
 	"category": "coupons",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/widget.ts
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon-usage/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
@@ -23,10 +22,5 @@ export type SalesByCouponUsageAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/sales-by-coupon-usage',
-	title: __( 'Sales by coupon usage', 'jetpack-premium-analytics' ),
-	help: {
-		content: __( 'Compare sales with and without coupons.', 'jetpack-premium-analytics' ),
-	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon/stories/sales-by-coupon-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon/stories/sales-by-coupon-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -13,6 +14,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SalesByCouponRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -85,7 +87,7 @@ function SalesByCouponDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ SALES_BY_COUPON_RENDER_MODULE }
 			renderComponent={ SalesByCouponRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ getSalesByCouponAttributes( withComparison, preset ) }

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon/widget.json
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/sales-by-coupon",
 	"title": "Sales by coupon",
 	"description": "Shows the top coupon codes by order revenue over the selected time period.",
+	"help": {
+		"content": "Revenue from physical product sales using coupons over the selected time period."
+	},
 	"category": "store",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/sales-by-coupon/widget.ts
+++ b/projects/packages/premium-analytics/widgets/sales-by-coupon/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
@@ -23,13 +22,5 @@ export type SalesByCouponAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/sales-by-coupon',
-	title: __( 'Sales by coupon', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Revenue from physical product sales using coupons over the selected time period.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/sales-by-device/stories/sales-by-device-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-device/stories/sales-by-device-widget.stories.tsx
@@ -10,9 +10,11 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import SalesByDeviceRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -104,7 +106,7 @@ function SalesByDeviceDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ SALES_BY_DEVICE_RENDER_MODULE }
 			renderComponent={ SalesByDeviceRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ getSalesByDeviceAttributes( withComparison, preset ) }

--- a/projects/packages/premium-analytics/widgets/sales-by-device/widget.json
+++ b/projects/packages/premium-analytics/widgets/sales-by-device/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/sales-by-device",
 	"title": "Sales by device",
 	"description": "Shows the sales breakdown by device type over the selected time period.",
+	"help": {
+		"content": "See which devices your customers are using to make purchases in your store."
+	},
 	"category": "store",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/sales-by-device/widget.ts
+++ b/projects/packages/premium-analytics/widgets/sales-by-device/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
@@ -23,13 +22,5 @@ export type SalesByDeviceAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/sales-by-device',
-	title: __( 'Sales by device', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'See which devices your customers are using to make purchases in your store.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-campaign/stories/sales-by-utm-campaign-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-campaign/stories/sales-by-utm-campaign-widget.stories.tsx
@@ -10,9 +10,11 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import SalesByUtmCampaignRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -108,7 +110,7 @@ function SalesByUtmCampaignDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ SALES_BY_UTM_CAMPAIGN_RENDER_MODULE }
 			renderComponent={ SalesByUtmCampaignRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ getSalesByUtmCampaignAttributes( withComparison, preset ) }

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-campaign/widget.json
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-campaign/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/sales-by-utm-campaign",
 	"title": "Sales by UTM campaign",
 	"description": "Shows the top UTM campaigns by order revenue over the selected time period.",
+	"help": {
+		"content": "See which marketing campaigns are driving sales in your store."
+	},
 	"category": "store",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-campaign/widget.ts
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-campaign/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
@@ -23,13 +22,5 @@ export type SalesByUtmCampaignAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/sales-by-utm-campaign',
-	title: __( 'Sales by UTM campaign', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'See which marketing campaigns are driving sales in your store.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-channel/stories/sales-by-utm-channel-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-channel/stories/sales-by-utm-channel-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -13,6 +14,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SalesByUtmChannelRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -66,7 +68,7 @@ function SalesByUtmChannelDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ SALES_BY_UTM_CHANNEL_RENDER_MODULE }
 			renderComponent={ SalesByUtmChannelRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ getSalesByUtmChannelAttributes( withComparison, preset ) }

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-channel/widget.json
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-channel/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/sales-by-utm-channel",
 	"title": "Sales by UTM channel",
 	"description": "Shows the top UTM channels by order revenue over the selected time period.",
+	"help": {
+		"content": "See which marketing channels are driving sales in your store."
+	},
 	"category": "store",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-channel/widget.ts
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-channel/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
@@ -23,13 +22,5 @@ export type SalesByUtmChannelAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/sales-by-utm-channel',
-	title: __( 'Sales by UTM channel', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'See which marketing channels are driving sales in your store.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-source/stories/sales-by-utm-source-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-source/stories/sales-by-utm-source-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -13,6 +14,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SalesByUtmSourceRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -94,7 +96,7 @@ function SalesByUtmSourceDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ SALES_BY_UTM_SOURCE_RENDER_MODULE }
 			renderComponent={ SalesByUtmSourceRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ getSalesByUtmSourceAttributes( withComparison, preset ) }

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-source/widget.json
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-source/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/sales-by-utm-source",
 	"title": "Sales by UTM source",
 	"description": "Shows the top UTM sources by order revenue over the selected time period.",
+	"help": {
+		"content": "See which referral sources are driving sales in your store."
+	},
 	"category": "store",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/sales-by-utm-source/widget.ts
+++ b/projects/packages/premium-analytics/widgets/sales-by-utm-source/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
@@ -23,13 +22,5 @@ export type SalesByUtmSourceAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/sales-by-utm-source',
-	title: __( 'Sales by UTM source', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'See which referral sources are driving sales in your store.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/search-terms/stories/search-terms-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/search-terms/stories/search-terms-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
 import { withStoryRouter } from '../../stories/with-story-router';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -13,6 +14,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SearchTermsRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -21,14 +23,9 @@ registerReportMocks();
 
 const SEARCH_TERMS_RENDER_MODULE = 'storybook/search-terms';
 
-// Pick only the fields that StoryWidgetMetadata accepts; the attribute schema
-// and example arrays are typed differently in WidgetType and cause a type error.
-const storyWidgetType = {
-	name: widgetDefinition.name,
-	title: widgetDefinition.title,
-	icon: widgetDefinition.icon,
-	presentation: 'framed' as const,
-};
+// Build the story widget type from its manifest and module. `presentation`
+// comes from widget.json ( 'framed' ), so the host frames the widget.
+const storyWidgetType = createStoryWidgetType( widgetManifest, widgetDefinition );
 
 interface SearchTermsStoryControls {
 	withComparison: boolean;

--- a/projects/packages/premium-analytics/widgets/search-terms/widget.json
+++ b/projects/packages/premium-analytics/widgets/search-terms/widget.json
@@ -2,6 +2,15 @@
 	"name": "jpa/search-terms",
 	"title": "Search Terms",
 	"description": "The search terms visitors use to find your site.",
+	"help": {
+		"content": "The most popular search terms visitors used to find your site.",
+		"links": [
+			{
+				"label": "Learn more",
+				"href": "https://jetpack.com/support/jetpack-stats/"
+			}
+		]
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/search-terms/widget.ts
+++ b/projects/packages/premium-analytics/widgets/search-terms/widget.ts
@@ -22,20 +22,6 @@ export type SearchTermsAttributes = {
  * Date range comes from WidgetRoot's reportParams (the shared dashboard date picker).
  */
 export default {
-	name: 'jpa/search-terms',
-	title: __( 'Search Terms', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'The most popular search terms visitors used to find your site.',
-			'jetpack-premium-analytics'
-		),
-		links: [
-			{
-				label: __( 'Learn more', 'jetpack-premium-analytics' ),
-				href: 'https://jetpack.com/support/jetpack-stats/',
-			},
-		],
-	},
 	icon: search,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/sessions-by-device/stories/sessions-by-device-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/sessions-by-device/stories/sessions-by-device-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -13,6 +14,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SessionsByDeviceRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -94,7 +96,7 @@ function SessionsByDeviceDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ SESSIONS_BY_DEVICE_RENDER_MODULE }
 			renderComponent={ SessionsByDeviceRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ getSessionsByDeviceAttributes( withComparison, preset ) }

--- a/projects/packages/premium-analytics/widgets/sessions-by-device/widget.json
+++ b/projects/packages/premium-analytics/widgets/sessions-by-device/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/sessions-by-device",
 	"title": "Sessions by device",
 	"description": "Shows the sessions breakdown by device type over the selected time period.",
+	"help": {
+		"content": "See which devices visitors are using to browse your store."
+	},
 	"category": "store",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/sessions-by-device/widget.ts
+++ b/projects/packages/premium-analytics/widgets/sessions-by-device/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
@@ -23,13 +22,5 @@ export type SessionsByDeviceAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/sessions-by-device',
-	title: __( 'Sessions by device', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'See which devices visitors are using to browse your store.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/shares/stories/shares-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/shares/stories/shares-widget.stories.tsx
@@ -17,6 +17,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -24,6 +25,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SharesRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -53,14 +55,9 @@ function forceSiteSummaryState( state: 'loading' | 'error' | 'empty' ) {
 	};
 }
 
-// Pick only the fields that StoryWidgetMetadata accepts; the attribute schema and
-// example arrays are typed differently in WidgetType and cause a type error.
-const storyWidgetType = {
-	name: widgetDefinition.name,
-	title: widgetDefinition.title,
-	icon: widgetDefinition.icon,
-	presentation: 'framed' as const,
-};
+// Build the story widget type from its manifest and module. `presentation`
+// comes from widget.json ( 'framed' ), so the host frames the widget.
+const storyWidgetType = createStoryWidgetType( widgetManifest, widgetDefinition );
 
 function renderShares() {
 	return <SharesRender attributes={ { max: 10, reportParams: getDefaultQueryParams() } } />;

--- a/projects/packages/premium-analytics/widgets/shares/widget.json
+++ b/projects/packages/premium-analytics/widgets/shares/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/shares",
 	"title": "Shares",
 	"description": "The number of times your content was shared to social networks.",
+	"help": {
+		"content": "The platforms where your content was shared most often, sorted by number of shares."
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/shares/widget.ts
+++ b/projects/packages/premium-analytics/widgets/shares/widget.ts
@@ -23,14 +23,6 @@ export type SharesAttributes = {
  * and has no comparison period, so the widget ignores the dashboard date range.
  */
 export default {
-	name: 'jpa/shares',
-	title: __( 'Shares', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'The platforms where your content was shared most often, sorted by number of shares.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: share,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/site-overview/stories/site-overview-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/site-overview/stories/site-overview-widget.stories.tsx
@@ -24,14 +24,16 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import SiteOverviewRender from '../render';
 import widgetDefinition, {
 	DEFAULT_SITE_OVERVIEW_METRICS,
 	type SiteOverviewMetricId,
 } from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
-import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
@@ -39,16 +41,8 @@ registerReportMocks();
 const SITE_OVERVIEW_RENDER_MODULE = 'storybook/site-overview';
 
 // Carry the widget's metadata, including the metric-visibility attribute schema,
-// so the dashboard story's settings drawer renders the real checkboxes. The
-// attribute schema is typed loosely on the widget definition, so it is cast to
-// the WidgetType shape.
-const storyWidgetType = {
-	name: widgetDefinition.name,
-	title: widgetDefinition.title,
-	icon: widgetDefinition.icon,
-	attributes: widgetDefinition.attributes as WidgetType[ 'attributes' ],
-	example: widgetDefinition.example,
-};
+// so the dashboard story's settings drawer renders the real checkboxes.
+const storyWidgetType = createStoryWidgetType( widgetManifest, widgetDefinition );
 
 interface SiteOverviewStoryControls {
 	/**

--- a/projects/packages/premium-analytics/widgets/site-overview/widget.json
+++ b/projects/packages/premium-analytics/widgets/site-overview/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/site-overview",
 	"title": "Site overview",
 	"description": "Views, visitors, likes, and comments for the selected period, with period-over-period change.",
+	"help": {
+		"content": "A summary of your site's views, visitors, likes, and comments, with period-over-period change."
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/site-overview/widget.ts
+++ b/projects/packages/premium-analytics/widgets/site-overview/widget.ts
@@ -57,14 +57,6 @@ export const DEFAULT_SITE_OVERVIEW_METRICS: SiteOverviewMetricId[] = SITE_OVERVI
  * instances: every metric enabled.
  */
 export default {
-	name: 'jpa/site-overview',
-	title: __( 'Site overview', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			"A summary of your site's views, visitors, likes, and comments, with period-over-period change.",
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: globe,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/stories/store-conversion-rate-bookings-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/stories/store-conversion-rate-bookings-widget.stories.tsx
@@ -8,10 +8,12 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import StoreConversionRateBookingsRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { APIFetchMiddleware } from '@wordpress/api-fetch';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
@@ -182,7 +184,7 @@ function StoreConversionRateBookingsDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ STORE_CONVERSION_RATE_BOOKINGS_RENDER_MODULE }
 			renderComponent={
 				StoreConversionRateBookingsRender as ComponentType< WidgetRenderProps< unknown > >

--- a/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/widget.json
+++ b/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/store-conversion-rate-bookings",
 	"title": "Store conversion rate - Bookings",
 	"description": "Store conversion rate for booking products over the selected time period.",
+	"help": {
+		"content": "Track your booking conversion funnel from sessions to completed bookings over the selected time period."
+	},
 	"category": "bookings",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/widget.ts
+++ b/projects/packages/premium-analytics/widgets/store-conversion-rate-bookings/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
@@ -22,13 +21,5 @@ export type StoreConversionRateBookingsAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/store-conversion-rate-bookings',
-	title: __( 'Store conversion rate - Bookings', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Track your booking conversion funnel from sessions to completed bookings over the selected time period.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/store-performance/stories/store-performance-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/store-performance/stories/store-performance-widget.stories.tsx
@@ -11,12 +11,14 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import { DEFAULT_STORE_PERFORMANCE_METRICS, type StorePerformanceMetricId } from '../metrics';
 import StorePerformanceRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
-import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
@@ -29,17 +31,9 @@ const ensureLineChartComposition = () => LineChart.Legend;
 
 // Carry the widget's metadata, including the metric-visibility attribute schema
 // so the dashboard story's settings drawer renders the real checkboxes.
-// Presentation is left unset so the host frames the widget and renders its
-// identity (title + icon), matching widget.json. The attribute schema is typed
-// loosely on the widget definition, so it is cast to the WidgetType shape.
-const storyWidgetType = {
-	name: widgetDefinition.name,
-	title: widgetDefinition.title,
-	help: widgetDefinition.help,
-	icon: widgetDefinition.icon,
-	attributes: widgetDefinition.attributes as WidgetType[ 'attributes' ],
-	example: widgetDefinition.example,
-};
+// Presentation is left unset in widget.json, so the host frames the widget and
+// renders its identity (title + icon).
+const storyWidgetType = createStoryWidgetType( widgetManifest, widgetDefinition );
 
 type StorePerformanceRenderProps = ComponentProps< typeof StorePerformanceRender >;
 

--- a/projects/packages/premium-analytics/widgets/store-performance/widget.json
+++ b/projects/packages/premium-analytics/widgets/store-performance/widget.json
@@ -2,5 +2,8 @@
 	"name": "jpa/store-performance",
 	"title": "Store performance",
 	"description": "Shows key store performance metrics at a glance.",
+	"help": {
+		"content": "Shows key store performance metrics at a glance."
+	},
 	"category": "store"
 }

--- a/projects/packages/premium-analytics/widgets/store-performance/widget.ts
+++ b/projects/packages/premium-analytics/widgets/store-performance/widget.ts
@@ -39,11 +39,6 @@ export type StorePerformanceAttributes = {
  * instances: every metric enabled.
  */
 export default {
-	name: 'jpa/store-performance',
-	title: __( 'Store performance', 'jetpack-premium-analytics' ),
-	help: {
-		content: __( 'Shows key store performance metrics at a glance.', 'jetpack-premium-analytics' ),
-	},
 	icon: store,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/stories/create-story-widget-type.ts
+++ b/projects/packages/premium-analytics/widgets/stories/create-story-widget-type.ts
@@ -1,0 +1,74 @@
+/**
+ * WordPress dependencies
+ */
+import type { WidgetType } from '@wordpress/widget-primitives';
+
+/**
+ * Identity and declarative metadata a widget authors in `widget.json` — the
+ * fields the dashboard reads from the REST manifest rather than from the
+ * lazily-imported module.
+ */
+export interface StoryWidgetManifest {
+	name: string;
+	title: string;
+	description?: string;
+	help?: WidgetType[ 'help' ];
+	category?: string;
+	presentation?: string;
+	keywords?: string[];
+}
+
+/**
+ * Runtime-only fields a widget declares in `widget.ts` (its default export):
+ * the ones that cannot live in JSON because they hold a React element or
+ * component references. Typed loosely so any widget module is accepted without
+ * a per-call-site cast.
+ */
+interface StoryWidgetModule {
+	icon?: unknown;
+	attributes?: unknown;
+	example?: unknown;
+}
+
+/**
+ * The widget type a story hands to `<WidgetDashboardWithWidget>`: identity plus
+ * any authoring metadata, with the module's runtime-only fields.
+ */
+export type StoryWidgetType = {
+	name: string;
+	title: string;
+} & Partial< Omit< WidgetType, 'apiVersion' | 'name' | 'renderModule' | 'title' > >;
+
+/**
+ * Combine a widget's `widget.json` manifest (identity + declarative metadata)
+ * with its `widget.ts` module export (icon, attributes, example) into the
+ * widget type a Storybook story hands to the dashboard helper.
+ *
+ * This mirrors what the dashboard does at runtime — merge the REST manifest
+ * over the lazily-imported module — which Storybook has no REST layer to
+ * perform. `name`/`title`/`help` and the other declarative fields come from the
+ * manifest; `icon`, `attributes`, and `example` come from the module. The
+ * attribute list is typed against the widget's own `Item`, so it is widened
+ * here once instead of at every call site.
+ */
+export function createStoryWidgetType(
+	manifest: StoryWidgetManifest,
+	moduleDefinition: StoryWidgetModule
+): StoryWidgetType {
+	return {
+		name: manifest.name,
+		title: manifest.title,
+		icon: moduleDefinition.icon as WidgetType[ 'icon' ],
+		attributes: moduleDefinition.attributes as WidgetType[ 'attributes' ],
+		example: moduleDefinition.example as WidgetType[ 'example' ],
+		...( manifest.description ? { description: manifest.description } : {} ),
+		...( manifest.category ? { category: manifest.category } : {} ),
+		...( manifest.keywords ? { keywords: manifest.keywords } : {} ),
+		...( manifest.help ? { help: manifest.help } : {} ),
+		...( manifest.presentation
+			? {
+					presentation: manifest.presentation as WidgetType[ 'presentation' ],
+			  }
+			: {} ),
+	};
+}

--- a/projects/packages/premium-analytics/widgets/subscriber-highlights/stories/subscriber-highlights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/subscriber-highlights/stories/subscriber-highlights-widget.stories.tsx
@@ -11,6 +11,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -18,8 +19,9 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SubscriberHighlightsRender from '../render';
 import widgetDefinition, { DEFAULT_SUBSCRIBER_METRICS, type SubscriberMetricId } from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
-import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
@@ -29,15 +31,8 @@ const SUBSCRIBER_HIGHLIGHTS_RENDER_MODULE = 'storybook/subscriber-highlights';
 // Carry the widget's metadata, including the metric-visibility attribute schema
 // so the dashboard story's settings drawer renders the real checkboxes.
 // Presentation is left unset so the host frames the widget and renders its
-// identity (title + icon), matching widget.json. The attribute schema is typed
-// loosely on the widget definition, so it is cast to the WidgetType shape.
-const storyWidgetType = {
-	name: widgetDefinition.name,
-	title: widgetDefinition.title,
-	icon: widgetDefinition.icon,
-	attributes: widgetDefinition.attributes as WidgetType[ 'attributes' ],
-	example: widgetDefinition.example,
-};
+// identity (title + icon), matching widget.json.
+const storyWidgetType = createStoryWidgetType( widgetManifest, widgetDefinition );
 
 interface SubscriberHighlightsStoryControls {
 	/**

--- a/projects/packages/premium-analytics/widgets/subscriber-highlights/widget.json
+++ b/projects/packages/premium-analytics/widgets/subscriber-highlights/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/subscriber-highlights",
 	"title": "Subscriber highlights",
 	"description": "Your subscriber totals at a glance — total, paid, free, and social followers.",
+	"help": {
+		"content": "A summary of your subscribers — total, paid, free, and social followers."
+	},
 	"category": "subscribers",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/subscriber-highlights/widget.ts
+++ b/projects/packages/premium-analytics/widgets/subscriber-highlights/widget.ts
@@ -54,14 +54,6 @@ export const DEFAULT_SUBSCRIBER_METRICS: SubscriberMetricId[] = SUBSCRIBER_METRI
  * metric enabled.
  */
 export default {
-	name: 'jpa/subscriber-highlights',
-	title: __( 'Subscriber highlights', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'A summary of your subscribers — total, paid, free, and social followers.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: people,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/stories/subscribers-chart-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/stories/subscribers-chart-widget.stories.tsx
@@ -11,6 +11,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -21,8 +22,9 @@ import widgetDefinition, {
 	DEFAULT_SUBSCRIBERS_CHART_METRICS,
 	type SubscribersChartMetricId,
 } from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
-import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
@@ -30,16 +32,8 @@ registerReportMocks();
 const SUBSCRIBERS_CHART_RENDER_MODULE = 'storybook/subscribers-chart';
 
 // Carry the widget's metadata, including the metric-visibility attribute schema
-// so the dashboard story's settings drawer renders the real controls. The
-// attribute schema is typed loosely on the widget definition, so it is cast to
-// the WidgetType shape.
-const storyWidgetType = {
-	name: widgetDefinition.name,
-	title: widgetDefinition.title,
-	icon: widgetDefinition.icon,
-	attributes: widgetDefinition.attributes as WidgetType[ 'attributes' ],
-	example: widgetDefinition.example,
-};
+// so the dashboard story's settings drawer renders the real controls.
+const storyWidgetType = createStoryWidgetType( widgetManifest, widgetDefinition );
 
 interface SubscribersChartStoryControls {
 	withComparison: boolean;

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/widget.json
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/subscribers-chart",
 	"title": "Subscribers",
 	"description": "Track subscriber growth over time, with paid subscribers and the previous period overlaid for comparison.",
+	"help": {
+		"content": "A summary of your subscriber growth over time, with paid subscribers and the previous period overlaid for comparison."
+	},
 	"category": "subscribers",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/widget.ts
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/widget.ts
@@ -65,14 +65,6 @@ export const DEFAULT_SUBSCRIBERS_CHART_METRICS: SubscribersChartMetricId[] =
  * as the defaults applied to new instances.
  */
 export default {
-	name: 'jpa/subscribers-chart',
-	title: __( 'Subscribers', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'A summary of your subscriber growth over time, with paid subscribers and the previous period overlaid for comparison.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: trendingUp,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/subscribers-list/stories/subscribers-list-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-list/stories/subscribers-list-widget.stories.tsx
@@ -7,6 +7,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -14,6 +15,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SubscribersListRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentType } from 'react';
@@ -108,7 +110,7 @@ export const WidgetDashboardWithWidget: DashboardStory = {
 	render: args => (
 		<WidgetDashboardWithWidgetStory
 			{ ...args }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ SUBSCRIBERS_LIST_RENDER_MODULE }
 			renderComponent={ SubscribersListRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ { num: 6 } }

--- a/projects/packages/premium-analytics/widgets/subscribers-list/widget.json
+++ b/projects/packages/premium-analytics/widgets/subscribers-list/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/subscribers-list",
 	"title": "Latest Subscribers",
 	"description": "Your most recent subscribers.",
+	"help": {
+		"content": "Your most recent subscribers."
+	},
 	"category": "subscribers",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/subscribers-list/widget.ts
+++ b/projects/packages/premium-analytics/widgets/subscribers-list/widget.ts
@@ -24,11 +24,6 @@ export type SubscribersListAttributes = {
  * six most recent subscribers.
  */
 export default {
-	name: 'jpa/subscribers-list',
-	title: __( 'Latest Subscribers', 'jetpack-premium-analytics' ),
-	help: {
-		content: __( 'Your most recent subscribers.', 'jetpack-premium-analytics' ),
-	},
 	icon: people,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/tags/stories/tags-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/tags/stories/tags-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
 import { withStoryRouter } from '../../stories/with-story-router';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -13,6 +14,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import TagsRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -21,14 +23,9 @@ registerReportMocks();
 
 const TAGS_RENDER_MODULE = 'storybook/tags';
 
-// Pick only the fields that StoryWidgetMetadata accepts; the attribute schema
-// and example arrays are typed differently in WidgetType and cause a type error.
-const storyWidgetType = {
-	name: widgetDefinition.name,
-	title: widgetDefinition.title,
-	icon: widgetDefinition.icon,
-	presentation: 'framed' as const,
-};
+// Build the story widget type from its manifest and module. `presentation`
+// comes from widget.json ( 'framed' ), so the host frames the widget.
+const storyWidgetType = createStoryWidgetType( widgetManifest, widgetDefinition );
 
 function renderTags() {
 	return <TagsRender attributes={ { max: 10, reportParams: getDefaultQueryParams() } } />;

--- a/projects/packages/premium-analytics/widgets/tags/widget.json
+++ b/projects/packages/premium-analytics/widgets/tags/widget.json
@@ -2,6 +2,15 @@
 	"name": "jpa/tags",
 	"title": "Tags & categories",
 	"description": "Your most visited tags and categories, ranked by views.",
+	"help": {
+		"content": "The tags and categories associated with your most-viewed content, sorted by views.",
+		"links": [
+			{
+				"label": "Learn more",
+				"href": "https://jetpack.com/support/jetpack-stats/"
+			}
+		]
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/tags/widget.ts
+++ b/projects/packages/premium-analytics/widgets/tags/widget.ts
@@ -23,20 +23,6 @@ export type TagsAttributes = {
  * archive URL and drill down to their individual members instead.
  */
 export default {
-	name: 'jpa/tags',
-	title: __( 'Tags & categories', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'The tags and categories associated with your most-viewed content, sorted by views.',
-			'jetpack-premium-analytics'
-		),
-		links: [
-			{
-				label: __( 'Learn more', 'jetpack-premium-analytics' ),
-				href: 'https://jetpack.com/support/jetpack-stats/',
-			},
-		],
-	},
 	icon: tag,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/top-performing-bookings/stories/top-performing-bookings-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-performing-bookings/stories/top-performing-bookings-widget.stories.tsx
@@ -8,10 +8,12 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import TopPerformingBookingsRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { APIFetchMiddleware } from '@wordpress/api-fetch';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
@@ -229,7 +231,7 @@ function TopPerformingBookingsDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ TOP_PERFORMING_BOOKINGS_RENDER_MODULE }
 			renderComponent={
 				TopPerformingBookingsRender as ComponentType< WidgetRenderProps< unknown > >

--- a/projects/packages/premium-analytics/widgets/top-performing-bookings/widget.json
+++ b/projects/packages/premium-analytics/widgets/top-performing-bookings/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/top-performing-bookings",
 	"title": "Top performing bookings",
 	"description": "Shows the top booking products by net revenue over the selected time period.",
+	"help": {
+		"content": "Your best-selling bookings by revenue over the selected time period."
+	},
 	"category": "store",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/top-performing-bookings/widget.ts
+++ b/projects/packages/premium-analytics/widgets/top-performing-bookings/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
@@ -23,13 +22,5 @@ export type TopPerformingBookingsAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/top-performing-bookings',
-	title: __( 'Top performing bookings', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Your best-selling bookings by revenue over the selected time period.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/top-performing-products/stories/top-performing-products-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-performing-products/stories/top-performing-products-widget.stories.tsx
@@ -8,10 +8,12 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import TopPerformingProductsRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { APIFetchMiddleware } from '@wordpress/api-fetch';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
@@ -221,7 +223,7 @@ function TopPerformingProductsDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ TOP_PERFORMING_PRODUCTS_RENDER_MODULE }
 			renderComponent={
 				TopPerformingProductsRender as ComponentType< WidgetRenderProps< unknown > >

--- a/projects/packages/premium-analytics/widgets/top-performing-products/widget.json
+++ b/projects/packages/premium-analytics/widgets/top-performing-products/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/top-performing-products",
 	"title": "Top performing products",
 	"description": "Shows the top products by net revenue over the selected time period.",
+	"help": {
+		"content": "Your best-selling products by revenue over the selected time period."
+	},
 	"category": "store",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/top-performing-products/widget.ts
+++ b/projects/packages/premium-analytics/widgets/top-performing-products/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
@@ -23,13 +22,5 @@ export type TopPerformingProductsAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/top-performing-products',
-	title: __( 'Top performing products', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Your best-selling products by revenue over the selected time period.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/top-platforms/stories/top-platforms-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-platforms/stories/top-platforms-widget.stories.tsx
@@ -5,14 +5,16 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import { registerStatsMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-stats-mocks';
 import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import TopPlatformsRender from '../render';
 import widgetDefinition, { type TopPlatformsAttributes } from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
-import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
@@ -20,16 +22,10 @@ registerStatsMocks();
 
 const TOP_PLATFORMS_RENDER_MODULE = 'storybook/top-platforms';
 
-const storyWidgetType = {
-	name: widgetDefinition.name,
-	title: widgetDefinition.title,
-	icon: widgetDefinition.icon,
-	// attributes/example let the dashboard host render the real "View by"
-	// toolbar control for the `relevance: 'high'` attribute, as in Locations.
-	attributes: widgetDefinition.attributes as WidgetType[ 'attributes' ],
-	example: widgetDefinition.example,
-	presentation: 'framed' as const,
-};
+// attributes/example flow through from the module so the dashboard host renders
+// the real "View by" toolbar control for the `relevance: 'high'` attribute, as
+// in Locations. `presentation` comes from widget.json ( 'framed' ).
+const storyWidgetType = createStoryWidgetType( widgetManifest, widgetDefinition );
 
 interface TopPlatformsStoryControls {
 	withComparison: boolean;

--- a/projects/packages/premium-analytics/widgets/top-platforms/widget.json
+++ b/projects/packages/premium-analytics/widgets/top-platforms/widget.json
@@ -2,6 +2,15 @@
 	"name": "jpa/top-platforms",
 	"title": "Top Platforms",
 	"description": "Top browsers and operating systems your visitors use.",
+	"help": {
+		"content": "A breakdown of the operating systems and browsers your visitors used, sorted by views.",
+		"links": [
+			{
+				"label": "Learn more",
+				"href": "https://jetpack.com/support/jetpack-stats/"
+			}
+		]
+	},
 	"category": "traffic",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/top-platforms/widget.ts
+++ b/projects/packages/premium-analytics/widgets/top-platforms/widget.ts
@@ -29,20 +29,6 @@ export type TopPlatformsAttributes = {
  * so the widget host renders its control.
  */
 export default {
-	name: 'jpa/top-platforms',
-	title: __( 'Top Platforms', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'A breakdown of the operating systems and browsers your visitors used, sorted by views.',
-			'jetpack-premium-analytics'
-		),
-		links: [
-			{
-				label: __( 'Learn more', 'jetpack-premium-analytics' ),
-				href: 'https://jetpack.com/support/jetpack-stats/',
-			},
-		],
-	},
 	icon: chartBar,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/top-posts/stories/top-posts.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/top-posts/stories/top-posts.stories.tsx
@@ -15,11 +15,13 @@ import {
 } from '../../stories/widget-dashboard-with-widget';
 import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import { withStoryRouter } from '../../stories/with-story-router';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import TopPostsRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
-import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
@@ -27,16 +29,10 @@ registerStatsMocks();
 
 const TOP_POSTS_RENDER_MODULE = 'storybook/top-posts';
 
-const storyWidgetType = {
-	name: widgetDefinition.name,
-	title: widgetDefinition.title,
-	icon: widgetDefinition.icon,
-	// Attribute metadata drives the host-rendered chrome: the high-relevance
-	// `contentView` control in the framed header and the settings fields.
-	attributes: widgetDefinition.attributes as WidgetType[ 'attributes' ],
-	example: widgetDefinition.example,
-	presentation: 'framed' as const,
-};
+// Attribute metadata flows through from the module to drive the host-rendered
+// chrome: the high-relevance `contentView` control in the framed header and the
+// settings fields. `presentation` comes from widget.json ( 'framed' ).
+const storyWidgetType = createStoryWidgetType( widgetManifest, widgetDefinition );
 
 interface TopPostsStoryControls {
 	withComparison: boolean;

--- a/projects/packages/premium-analytics/widgets/top-posts/widget.json
+++ b/projects/packages/premium-analytics/widgets/top-posts/widget.json
@@ -2,6 +2,15 @@
 	"name": "jpa/stats-top-posts",
 	"title": "Most viewed",
 	"description": "Your most viewed posts, pages, and archives.",
+	"help": {
+		"content": "Your most popular posts and pages, sorted by views.",
+		"links": [
+			{
+				"label": "Learn more",
+				"href": "https://jetpack.com/support/jetpack-stats/"
+			}
+		]
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/top-posts/widget.ts
+++ b/projects/packages/premium-analytics/widgets/top-posts/widget.ts
@@ -21,6 +21,7 @@ export type TopPostsAttributes = {
 	 * Maximum number of rows to display.
 	 */
 	num?: number;
+
 	/**
 	 * Which report the widget shows: published posts and pages (including the
 	 * homepage entry, via `skip_archives=1`), or archive pages (taxonomy,
@@ -41,20 +42,6 @@ export type TopPostsAttributes = {
  * rows, Posts & pages view. The date range comes from the dashboard picker.
  */
 export default {
-	name: 'jpa/stats-top-posts',
-	title: __( 'Most viewed', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Your most popular posts and pages, sorted by views.',
-			'jetpack-premium-analytics'
-		),
-		links: [
-			{
-				label: __( 'Learn more', 'jetpack-premium-analytics' ),
-				href: 'https://jetpack.com/support/jetpack-stats/',
-			},
-		],
-	},
 	icon: postList,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/total-returns/stories/total-returns-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/total-returns/stories/total-returns-widget.stories.tsx
@@ -10,9 +10,11 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import TotalReturnsRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -73,7 +75,7 @@ function TotalReturnsDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ TOTAL_RETURNS_RENDER_MODULE }
 			renderComponent={ TotalReturnsRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ getTotalReturnsAttributes( withComparison, preset ) }

--- a/projects/packages/premium-analytics/widgets/total-returns/widget.json
+++ b/projects/packages/premium-analytics/widgets/total-returns/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/total-returns",
 	"title": "Total returns",
 	"description": "Shows refunds and net sales over the selected time period.",
+	"help": {
+		"content": "Total value of returns issued for physical products over the selected time period."
+	},
 	"category": "store",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/total-returns/widget.ts
+++ b/projects/packages/premium-analytics/widgets/total-returns/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
@@ -23,13 +22,5 @@ export type TotalReturnsAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/total-returns',
-	title: __( 'Total returns', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Total value of returns issued for physical products over the selected time period.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/total-sales-over-time/stories/total-sales-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/total-sales-over-time/stories/total-sales-over-time-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -14,6 +15,7 @@ import {
 import LineChart from '../../../../../js-packages/charts/src/charts/line-chart/line-chart';
 import TotalSalesOverTimeRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -105,7 +107,7 @@ function TotalSalesOverTimeDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ TOTAL_SALES_OVER_TIME_RENDER_MODULE }
 			renderComponent={ TotalSalesOverTimeRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ {

--- a/projects/packages/premium-analytics/widgets/total-sales-over-time/widget.json
+++ b/projects/packages/premium-analytics/widgets/total-sales-over-time/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/total-sales-over-time",
 	"title": "Total sales over time",
 	"description": "Track total sales including all orders and transactions.",
+	"help": {
+		"content": "Track total sales including all orders and transactions."
+	},
 	"category": "store",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/total-sales-over-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/total-sales-over-time/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 
 /**
@@ -23,13 +22,5 @@ export type TotalSalesOverTimeAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/total-sales-over-time',
-	title: __( 'Total sales over time', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Track total sales including all orders and transactions.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 };

--- a/projects/packages/premium-analytics/widgets/traffic-chart/stories/traffic-chart-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/stories/traffic-chart-widget.stories.tsx
@@ -8,6 +8,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -18,8 +19,9 @@ import widgetDefinition, {
 	DEFAULT_TRAFFIC_CHART_METRICS,
 	type TrafficChartMetricId,
 } from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
-import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
@@ -27,16 +29,8 @@ registerReportMocks();
 const TRAFFIC_CHART_RENDER_MODULE = 'storybook/traffic-chart';
 
 // Carry the widget's metadata, including the metric-visibility attribute schema
-// so the dashboard story's settings drawer renders the real controls. The
-// attribute schema is typed loosely on the widget definition, so it is cast to
-// the WidgetType shape.
-const storyWidgetType = {
-	name: widgetDefinition.name,
-	title: widgetDefinition.title,
-	icon: widgetDefinition.icon,
-	attributes: widgetDefinition.attributes as WidgetType[ 'attributes' ],
-	example: widgetDefinition.example,
-};
+// so the dashboard story's settings drawer renders the real controls.
+const storyWidgetType = createStoryWidgetType( widgetManifest, widgetDefinition );
 
 interface TrafficChartStoryControls {
 	withComparison: boolean;

--- a/projects/packages/premium-analytics/widgets/traffic-chart/widget.json
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/traffic-chart",
 	"title": "Traffic",
 	"description": "Compare views, visitors, likes, and comments over the selected period, with the previous period overlaid for comparison.",
+	"help": {
+		"content": "A summary of your site's views, visitors, likes, and comments, with the previous period overlaid for comparison."
+	},
 	"category": "traffic",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/traffic-chart/widget.ts
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/widget.ts
@@ -68,14 +68,6 @@ export const DEFAULT_TRAFFIC_CHART_METRICS: TrafficChartMetricId[] = TRAFFIC_CHA
  * `example.attributes` doubles as the defaults applied to new instances.
  */
 export default {
-	name: 'jpa/traffic-chart',
-	title: __( 'Traffic', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			"A summary of your site's views, visitors, likes, and comments, with the previous period overlaid for comparison.",
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/utm-insights/stories/utm-insights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/utm-insights/stories/utm-insights-widget.stories.tsx
@@ -6,12 +6,14 @@ import {
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
 import { withStoryRouter } from '../../stories/with-story-router';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import { registerReportMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import { registerStatsMocks } from '../../../packages/widgets-toolkit/src/stories/mocks/register-stats-mocks';
 import { forceStatsMockState } from '../../stories/force-stats-mock-state';
 import UtmInsightsRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -21,12 +23,7 @@ registerStatsMocks();
 
 const UTM_INSIGHTS_RENDER_MODULE = 'storybook/utm-insights';
 
-const storyWidgetType = {
-	name: widgetDefinition.name,
-	title: widgetDefinition.title,
-	icon: widgetDefinition.icon,
-	presentation: 'framed' as const,
-};
+const storyWidgetType = createStoryWidgetType( widgetManifest, widgetDefinition );
 
 interface UtmInsightsStoryControls {
 	withComparison: boolean;

--- a/projects/packages/premium-analytics/widgets/utm-insights/widget.json
+++ b/projects/packages/premium-analytics/widgets/utm-insights/widget.json
@@ -2,6 +2,15 @@
 	"name": "jpa/utm-insights",
 	"title": "UTM Insights",
 	"description": "Traffic breakdown by UTM parameters — source, medium, campaign, and combinations.",
+	"help": {
+		"content": "Your top UTM campaigns, sorted by views.",
+		"links": [
+			{
+				"label": "Learn more",
+				"href": "https://jetpack.com/support/jetpack-stats/"
+			}
+		]
+	},
 	"category": "traffic",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/utm-insights/widget.ts
+++ b/projects/packages/premium-analytics/widgets/utm-insights/widget.ts
@@ -31,17 +31,6 @@ export type UtmInsightsAttributes = {
  * shared dashboard date picker).
  */
 export default {
-	name: 'jpa/utm-insights',
-	title: __( 'UTM Insights', 'jetpack-premium-analytics' ),
-	help: {
-		content: __( 'Your top UTM campaigns, sorted by views.', 'jetpack-premium-analytics' ),
-		links: [
-			{
-				label: __( 'Learn more', 'jetpack-premium-analytics' ),
-				href: 'https://jetpack.com/support/jetpack-stats/',
-			},
-		],
-	},
 	icon: trendingUp,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/video-detail-embeds/stories/video-detail-embeds-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/video-detail-embeds/stories/video-detail-embeds-widget.stories.tsx
@@ -15,9 +15,11 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import VideoDetailEmbedsRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -156,7 +158,7 @@ function VideoDetailEmbedsDashboardStory( dashboardArgs: WidgetDashboardWithWidg
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ VIDEO_DETAIL_EMBEDS_RENDER_MODULE }
 			renderComponent={ VideoDetailEmbedsRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ { reportParams: reportParamsForVideo( undefined, true ) } }

--- a/projects/packages/premium-analytics/widgets/video-detail-embeds/widget.json
+++ b/projects/packages/premium-analytics/widgets/video-detail-embeds/widget.json
@@ -2,6 +2,15 @@
 	"name": "jpa/video-detail-embeds",
 	"title": "Video embeds",
 	"description": "Pages where the selected video is embedded, sourced from Jetpack Stats.",
+	"help": {
+		"content": "Lists every page on your site where the selected video is embedded, so you can see where it is being watched.",
+		"links": [
+			{
+				"label": "Learn more",
+				"href": "https://jetpack.com/support/jetpack-stats/"
+			}
+		]
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/video-detail-embeds/widget.ts
+++ b/projects/packages/premium-analytics/widgets/video-detail-embeds/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { video } from '@wordpress/icons';
 
 /**
@@ -24,19 +23,5 @@ export type VideoDetailEmbedsAttributes = Record< never, never >;
  * than a widget attribute.
  */
 export default {
-	name: 'jpa/video-detail-embeds',
-	title: __( 'Video embeds', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Lists every page on your site where the selected video is embedded, so you can see where it is being watched.',
-			'jetpack-premium-analytics'
-		),
-		links: [
-			{
-				label: __( 'Learn more', 'jetpack-premium-analytics' ),
-				href: 'https://jetpack.com/support/jetpack-stats/',
-			},
-		],
-	},
 	icon: video,
 };

--- a/projects/packages/premium-analytics/widgets/video-detail-highlights/stories/video-detail-highlights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/video-detail-highlights/stories/video-detail-highlights-widget.stories.tsx
@@ -25,9 +25,11 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import VideoDetailHighlightsRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -158,7 +160,7 @@ function VideoDetailHighlightsDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
-			widgetType={ { ...widgetDefinition, presentation: 'framed' } }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ VIDEO_DETAIL_HIGHLIGHTS_RENDER_MODULE }
 			renderComponent={
 				VideoDetailHighlightsRender as ComponentType< WidgetRenderProps< unknown > >

--- a/projects/packages/premium-analytics/widgets/video-detail-highlights/widget.json
+++ b/projects/packages/premium-analytics/widgets/video-detail-highlights/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/video-detail-highlights",
 	"title": "Video highlights",
 	"description": "Views, impressions, hours watched, and retention rate for the video being viewed.",
+	"help": {
+		"content": "Views, impressions, hours watched, and retention rate for the video being viewed."
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/video-detail-highlights/widget.ts
+++ b/projects/packages/premium-analytics/widgets/video-detail-highlights/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { video } from '@wordpress/icons';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
@@ -15,14 +14,6 @@ export type VideoDetailHighlightsAttributes = Record< never, never >;
  * Widget type definition for the selected video's complete Stats metrics.
  */
 export default {
-	name: 'jpa/video-detail-highlights',
-	title: __( 'Video highlights', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Views, impressions, hours watched, and retention rate for the video being viewed.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: video,
 	attributes: [] as WidgetAttributeField< VideoDetailHighlightsAttributes >[],
 	example: {

--- a/projects/packages/premium-analytics/widgets/videopress/stories/videopress-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/stories/videopress-widget.stories.tsx
@@ -16,9 +16,11 @@ import {
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
 import { withStoryRouter } from '../../stories/with-story-router';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import VideoPressRender from '../render';
 import widgetDefinition, { DEFAULT_MAX } from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -162,7 +164,7 @@ function VideoPressDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ VIDEOPRESS_RENDER_MODULE }
 			renderComponent={ VideoPressRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ { max: DEFAULT_MAX, reportParams: getDefaultQueryParams( withComparison ) } }

--- a/projects/packages/premium-analytics/widgets/videopress/widget.json
+++ b/projects/packages/premium-analytics/widgets/videopress/widget.json
@@ -2,6 +2,15 @@
 	"name": "jpa/videopress",
 	"title": "VideoPress",
 	"description": "Your most played VideoPress videos, sourced from Jetpack Stats.",
+	"help": {
+		"content": "The published videos your visitors watched most often, sorted by views.",
+		"links": [
+			{
+				"label": "Learn more",
+				"href": "https://jetpack.com/support/jetpack-stats/"
+			}
+		]
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/videopress/widget.ts
+++ b/projects/packages/premium-analytics/widgets/videopress/widget.ts
@@ -28,20 +28,6 @@ export type VideoPressAttributes = {
  * Widget type definition.
  */
 export default {
-	name: 'jpa/videopress',
-	title: __( 'VideoPress', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'The published videos your visitors watched most often, sorted by views.',
-			'jetpack-premium-analytics'
-		),
-		links: [
-			{
-				label: __( 'Learn more', 'jetpack-premium-analytics' ),
-				href: 'https://jetpack.com/support/jetpack-stats/',
-			},
-		],
-	},
 	icon: video,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/visitors-by-location/stories/visitors-by-location-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/visitors-by-location/stories/visitors-by-location-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { WidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -13,6 +14,7 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import VisitorsByLocationRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -107,7 +109,7 @@ function VisitorsByLocationDashboardStory( {
 		<GlobalErrorProvider>
 			<WidgetDashboardWithWidgetStory
 				{ ...dashboardStoryArgs }
-				widgetType={ widgetDefinition }
+				widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 				renderModule={ VISITORS_BY_LOCATION_RENDER_MODULE }
 				renderComponent={
 					VisitorsByLocationRender as ComponentType< WidgetRenderProps< unknown > >

--- a/projects/packages/premium-analytics/widgets/visitors-by-location/widget.json
+++ b/projects/packages/premium-analytics/widgets/visitors-by-location/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/visitors-by-location",
 	"title": "Visitors by location",
 	"description": "See where your store visitors are located geographically.",
+	"help": {
+		"content": "See where your store visitors are located geographically."
+	},
 	"category": "visitors",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/visitors-by-location/widget.ts
+++ b/projects/packages/premium-analytics/widgets/visitors-by-location/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { mapMarker } from '@wordpress/icons';
 
 /**
@@ -23,13 +22,5 @@ export type VisitorsByLocationAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/visitors-by-location',
-	title: __( 'Visitors by location', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'See where your store visitors are located geographically.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: mapMarker,
 };

--- a/projects/packages/premium-analytics/widgets/visitors-over-time/stories/visitors-over-time-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/visitors-over-time/stories/visitors-over-time-widget.stories.tsx
@@ -6,6 +6,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	registerReportMocks,
@@ -14,6 +15,7 @@ import {
 import LineChart from '../../../../../js-packages/charts/src/charts/line-chart/line-chart';
 import VisitorsOverTimeRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -110,7 +112,7 @@ function VisitorsOverTimeDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardStoryArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ VISITORS_OVER_TIME_RENDER_MODULE }
 			renderComponent={ VisitorsOverTimeRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ getVisitorsOverTimeAttributes( withComparison, preset ) }

--- a/projects/packages/premium-analytics/widgets/visitors-over-time/widget.json
+++ b/projects/packages/premium-analytics/widgets/visitors-over-time/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/visitors-over-time",
 	"title": "Visitors over time",
 	"description": "Track website visitor trends and monitor traffic patterns over time.",
+	"help": {
+		"content": "Track website visitor trends and monitor traffic patterns over time."
+	},
 	"category": "visitors",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/visitors-over-time/widget.ts
+++ b/projects/packages/premium-analytics/widgets/visitors-over-time/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { seen } from '@wordpress/icons';
 
 /**
@@ -23,13 +22,5 @@ export type VisitorsOverTimeAttributes = Record< never, never >;
  * dashboards can opt in.
  */
 export default {
-	name: 'jpa/visitors-over-time',
-	title: __( 'Visitors over time', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Track website visitor trends and monitor traffic patterns over time.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: seen,
 };

--- a/projects/packages/premium-analytics/widgets/wordads-adjustments-history/stories/wordads-adjustments-history-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-adjustments-history/stories/wordads-adjustments-history-widget.stories.tsx
@@ -27,9 +27,11 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import WordAdsAdjustmentsHistoryRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentType } from 'react';
@@ -98,7 +100,7 @@ function WordAdsAdjustmentsHistoryDashboardStory(
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
-			widgetType={ { ...widgetDefinition, presentation: 'content-bleed' } }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ RENDER_MODULE }
 			renderComponent={
 				WordAdsAdjustmentsHistoryRender as ComponentType< WidgetRenderProps< unknown > >

--- a/projects/packages/premium-analytics/widgets/wordads-adjustments-history/widget.json
+++ b/projects/packages/premium-analytics/widgets/wordads-adjustments-history/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/wordads-adjustments-history",
 	"title": "Adjustments History",
 	"description": "WordAds earnings adjustments by period, with amounts, ads served, and payment status.",
+	"help": {
+		"content": "Ads Served is the number of ads we attempted to display (page impressions × available ad slots). Not every ad served results in a paid impression."
+	},
 	"category": "stats",
 	"presentation": "content-bleed"
 }

--- a/projects/packages/premium-analytics/widgets/wordads-adjustments-history/widget.ts
+++ b/projects/packages/premium-analytics/widgets/wordads-adjustments-history/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
@@ -21,14 +20,6 @@ export type WordAdsAdjustmentsHistoryAttributes = Record< never, never >;
  * site.
  */
 export default {
-	name: 'jpa/wordads-adjustments-history',
-	title: __( 'Adjustments History', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Ads Served is the number of ads we attempted to display (page impressions × available ad slots). Not every ad served results in a paid impression.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 	attributes: [] as WidgetAttributeField< WordAdsAdjustmentsHistoryAttributes >[],
 	example: {

--- a/projects/packages/premium-analytics/widgets/wordads-chart-tabs/stories/wordads-chart-tabs-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-chart-tabs/stories/wordads-chart-tabs-widget.stories.tsx
@@ -12,10 +12,12 @@ import {
 	registerReportMocks,
 	setReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import { DEFAULT_WORDADS_CHART_METRICS, type WordAdsChartMetricId } from '../metrics';
 import WordAdsChartTabsRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
@@ -155,7 +157,7 @@ function WordAdsChartTabsDashboardStory( {
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
-			widgetType={ widgetDefinition }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ WORDADS_CHART_TABS_RENDER_MODULE }
 			renderComponent={ WordAdsChartTabsRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ { reportParams: getDefaultQueryParams( withComparison ), metrics } }

--- a/projects/packages/premium-analytics/widgets/wordads-chart-tabs/widget.json
+++ b/projects/packages/premium-analytics/widgets/wordads-chart-tabs/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/wordads-chart-tabs",
 	"title": "WordAds",
 	"description": "Compare ads served, average CPM, and revenue over the selected period, with the previous period overlaid for comparison.",
+	"help": {
+		"content": "Compare ads served, average CPM, and revenue over the selected period, with the previous period overlaid for comparison."
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/wordads-chart-tabs/widget.ts
+++ b/projects/packages/premium-analytics/widgets/wordads-chart-tabs/widget.ts
@@ -51,14 +51,6 @@ export type WordAdsChartTabsAttributes = {
  * site.
  */
 export default {
-	name: 'jpa/wordads-chart-tabs',
-	title: __( 'WordAds', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Compare ads served, average CPM, and revenue over the selected period, with the previous period overlaid for comparison.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 	attributes: [
 		{

--- a/projects/packages/premium-analytics/widgets/wordads-earnings-history/stories/wordads-earnings-history-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-earnings-history/stories/wordads-earnings-history-widget.stories.tsx
@@ -25,9 +25,11 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import WordAdsEarningsHistoryRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentType } from 'react';
@@ -94,7 +96,7 @@ function WordAdsEarningsHistoryDashboardStory( dashboardArgs: WidgetDashboardWit
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
-			widgetType={ { ...widgetDefinition, presentation: 'content-bleed' } }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ RENDER_MODULE }
 			renderComponent={
 				WordAdsEarningsHistoryRender as ComponentType< WidgetRenderProps< unknown > >

--- a/projects/packages/premium-analytics/widgets/wordads-earnings-history/widget.json
+++ b/projects/packages/premium-analytics/widgets/wordads-earnings-history/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/wordads-earnings-history",
 	"title": "Earnings History",
 	"description": "Your WordAds earnings by period, with amounts, ads served, and payment status.",
+	"help": {
+		"content": "Ads Served is the number of ads we attempted to display (page impressions × available ad slots). Not every ad served results in a paid impression."
+	},
 	"category": "stats",
 	"presentation": "content-bleed"
 }

--- a/projects/packages/premium-analytics/widgets/wordads-earnings-history/widget.ts
+++ b/projects/packages/premium-analytics/widgets/wordads-earnings-history/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
@@ -21,14 +20,6 @@ export type WordAdsEarningsHistoryAttributes = Record< never, never >;
  * site.
  */
 export default {
-	name: 'jpa/wordads-earnings-history',
-	title: __( 'Earnings History', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Ads Served is the number of ads we attempted to display (page impressions × available ad slots). Not every ad served results in a paid impression.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 	attributes: [] as WidgetAttributeField< WordAdsEarningsHistoryAttributes >[],
 	example: {

--- a/projects/packages/premium-analytics/widgets/wordads-highlights/stories/wordads-highlights-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-highlights/stories/wordads-highlights-widget.stories.tsx
@@ -11,6 +11,7 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import {
 	forceWordAdsEarningsState,
@@ -21,8 +22,9 @@ import widgetDefinition, {
 	DEFAULT_WORDADS_EARNINGS_METRICS,
 	type WordAdsEarningsMetricId,
 } from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
-import type { WidgetRenderProps, WidgetType } from '@wordpress/widget-primitives';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps, ComponentType } from 'react';
 
 registerReportMocks();
@@ -31,16 +33,9 @@ const WORDADS_HIGHLIGHTS_RENDER_MODULE = 'storybook/wordads-highlights';
 
 // Carry the widget's metadata, including the metric-visibility attribute schema
 // so the dashboard story's settings drawer renders the real checkboxes.
-// Presentation is left unset so the host frames the widget and renders its
-// identity (title + icon), matching widget.json.
-const storyWidgetType = {
-	name: widgetDefinition.name,
-	title: widgetDefinition.title,
-	icon: widgetDefinition.icon,
-	help: widgetDefinition.help,
-	attributes: widgetDefinition.attributes as WidgetType[ 'attributes' ],
-	example: widgetDefinition.example,
-};
+// `presentation` comes from widget.json ( 'framed' ), so the host frames the
+// widget and renders its identity (title + icon).
+const storyWidgetType = createStoryWidgetType( widgetManifest, widgetDefinition );
 
 interface WordAdsHighlightsStoryControls {
 	/**

--- a/projects/packages/premium-analytics/widgets/wordads-highlights/widget.json
+++ b/projects/packages/premium-analytics/widgets/wordads-highlights/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/wordads-highlights",
 	"title": "WordAds highlights",
 	"description": "Your WordAds earnings at a glance — total earnings, amount paid, and outstanding balance.",
+	"help": {
+		"content": "Payment is made once your outstanding balance reaches $100, approximately 45 days after the end of the month in which it was earned."
+	},
 	"category": "stats",
 	"presentation": "framed"
 }

--- a/projects/packages/premium-analytics/widgets/wordads-highlights/widget.ts
+++ b/projects/packages/premium-analytics/widgets/wordads-highlights/widget.ts
@@ -50,15 +50,7 @@ export const DEFAULT_WORDADS_EARNINGS_METRICS: WordAdsEarningsMetricId[] =
  * card enabled.
  */
 export default {
-	name: 'jpa/wordads-highlights',
-	title: __( 'WordAds highlights', 'jetpack-premium-analytics' ),
 	icon: megaphone,
-	help: {
-		content: __(
-			'Payment is made once your outstanding balance reaches $100, approximately 45 days after the end of the month in which it was earned.',
-			'jetpack-premium-analytics'
-		),
-	},
 	attributes: [
 		{
 			id: 'metrics',

--- a/projects/packages/premium-analytics/widgets/wordads-sponsored-content-history/stories/wordads-sponsored-content-history-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-sponsored-content-history/stories/wordads-sponsored-content-history-widget.stories.tsx
@@ -27,9 +27,11 @@ import {
 	widgetDashboardWithWidgetArgTypes,
 	type WidgetDashboardWithWidgetControls,
 } from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
 import WordAdsSponsoredContentHistoryRender from '../render';
 import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentType } from 'react';
@@ -98,7 +100,7 @@ function WordAdsSponsoredContentHistoryDashboardStory(
 	return (
 		<WidgetDashboardWithWidgetStory
 			{ ...dashboardArgs }
-			widgetType={ { ...widgetDefinition, presentation: 'content-bleed' } }
+			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ RENDER_MODULE }
 			renderComponent={
 				WordAdsSponsoredContentHistoryRender as ComponentType< WidgetRenderProps< unknown > >

--- a/projects/packages/premium-analytics/widgets/wordads-sponsored-content-history/widget.json
+++ b/projects/packages/premium-analytics/widgets/wordads-sponsored-content-history/widget.json
@@ -2,6 +2,9 @@
 	"name": "jpa/wordads-sponsored-content-history",
 	"title": "Sponsored Content History",
 	"description": "Your WordAds sponsored-content earnings by period, with amounts, ads served, and payment status.",
+	"help": {
+		"content": "Ads Served is the number of ads we attempted to display (page impressions × available ad slots). Not every ad served results in a paid impression."
+	},
 	"category": "stats",
 	"presentation": "content-bleed"
 }

--- a/projects/packages/premium-analytics/widgets/wordads-sponsored-content-history/widget.ts
+++ b/projects/packages/premium-analytics/widgets/wordads-sponsored-content-history/widget.ts
@@ -1,7 +1,6 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
@@ -21,14 +20,6 @@ export type WordAdsSponsoredContentHistoryAttributes = Record< never, never >;
  * site.
  */
 export default {
-	name: 'jpa/wordads-sponsored-content-history',
-	title: __( 'Sponsored Content History', 'jetpack-premium-analytics' ),
-	help: {
-		content: __(
-			'Ads Served is the number of ads we attempted to display (page impressions × available ad slots). Not every ad served results in a paid impression.',
-			'jetpack-premium-analytics'
-		),
-	},
 	icon: chartBar,
 	attributes: [] as WidgetAttributeField< WordAdsSponsoredContentHistoryAttributes >[],
 	example: {


### PR DESCRIPTION
## What?

Follow-up to #50615. Moves declarative widget metadata (`name`, `title`, `help`) out of each widget's `widget.ts` module and into its `widget.json` manifest, across all 74 widgets. `widget.ts` now carries only the non-serializable runtime fields (`icon`, `attributes`, `example`). Stories build their widget type from the manifest via a new shared `createStoryWidgetType()` helper.

## Why?

#50615 wired the `widget.json` → PHP → REST metadata pipeline, with the dashboard merging the REST manifest over the lazily-imported module. That already made `name`/`title`/`help` on the module dead weight in production, since the REST value always wins. This follow-up completes the split the pipeline enabled: `widget.json` is the single source of truth for declarative metadata, and `widget.ts` holds only what cannot be serialized to JSON (a React icon element, attribute field components, example data). It also unifies how stories construct the widget type and removes ~50 ad-hoc `as WidgetType[...]` casts.

## How?

- **`widget.ts` → `widget.json`:** moved `help` (unwrapping `__()`) into the manifest for 71 widgets, removed `name`/`title`/`help` from every `widget.ts`, and dropped the 44 now-orphan `__` imports. Done with a TypeScript AST script (locate + extract + delete by text range, so formatting is preserved).
- **Story helper:** new `widgets/stories/create-story-widget-type.ts`. `createStoryWidgetType( manifest, moduleDefinition )` combines identity + declarative metadata (from `widget.json`) with the runtime-only fields (from `widget.ts`), centralizing the casts in one place. It mirrors the runtime REST-over-module merge, which Storybook has no REST layer to perform.
- **72 stories migrated** to the helper. The direct-pass (`widgetType={ widgetDefinition }`), spread, and explicit-object patterns all collapse to a single helper call. Incidental win: stories that previously omitted `help`/`attributes` now render them.
- **Docs:** `AGENTS.md` and `rules/widgets.md` updated (folder contract, `name` bullet, pitfall, and the story template future widgets copy).

## Testing

- `pnpm run typecheck`: clean.
- `eslint` (touched `ts`/`tsx`): clean.
- `pnpm run test`: 1105/1109 pass. The 4 failures (`clicks`/`referrers` drill-down) are timeout flakes under load and pass in isolation (12/12). Those tests render `render.tsx` with attributes and touch none of the changed code.
- Storybook: each widget still renders its title, icon, and help in the dashboard story, now sourced from `widget.json`.

## Follow-ups

- [ ] **i18n extraction gap.** `widget.json` strings are emitted by wp-build as bare PHP literals in the generated manifest, which no gettext extractor picks up (unlike `block.json`, which WP-CLI extracts via a dedicated `BlockExtractor`). The runtime translate pipeline added in #50615 therefore has no strings to look up. This is pre-existing (the `title`/`description` already in `widget.json` were never extracted either), but this PR widens it to `help`. The fix belongs upstream in `@wordpress/build` (emit translatable strings wrapped in `__()` with the text domain). Tracked separately.
