### PR TITLE
AI Launchpad: sidebar-top menu, entity decoding, id_map task dedupe

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2962,6 +2962,9 @@ importers:
       '@wordpress/hooks':
         specifier: 4.51.0
         version: 4.51.0
+      '@wordpress/html-entities':
+        specifier: 4.51.0
+        version: 4.51.0
       '@wordpress/i18n':
         specifier: 6.24.0
         version: 6.24.0

--- a/projects/packages/jetpack-mu-wpcom/changelog/dotobrd-564-ai-launchpad-move-site-setup-item-to-the-top-of-the-sidebar
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotobrd-564-ai-launchpad-move-site-setup-item-to-the-top-of-the-sidebar
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI Launchpad: move the Site Setup menu item to the top of the sidebar, decode HTML entities in the wizard prefill and site preview title, and collapse id_map twin tasks onto a single id.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -80,6 +80,7 @@
 		"@wordpress/editor": "14.51.0",
 		"@wordpress/element": "8.3.0",
 		"@wordpress/hooks": "4.51.0",
+		"@wordpress/html-entities": "4.51.0",
 		"@wordpress/i18n": "6.24.0",
 		"@wordpress/icons": "15.1.0",
 		"@wordpress/keycodes": "4.51.0",

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
@@ -137,7 +137,7 @@ class AI_Launchpad {
 			self::MENU_SLUG,
 			$callback,
 			'data:image/svg+xml;base64,' . base64_encode( $icon ), // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode -- Encoding an inline SVG for the menu icon data URI.
-			2.01
+			1 // Above Dashboard (position 2): setup is the site's primary surface until it's done.
 		);
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/class-ai-launchpad-rest.php
@@ -21,8 +21,9 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 
 	const MIN_VALID_TASKS = 4;
 
-	// `woo_launch_site` stays a valid launch task so a stray AI emission passes PUT validation and is normalized to
-	// `site_launched` on read (see build_tasks), rather than failing the whole list into the deterministic fallback.
+	// `woo_launch_site`, `link_in_bio_launched`, and `videopress_launched` stay valid launch tasks so a stray AI
+	// emission passes PUT validation and is normalized to `site_launched` on read (see build_tasks), rather than
+	// failing the whole list into the deterministic fallback.
 	const LAUNCH_TASK_IDS = array( 'site_launched', 'blog_launched', 'woo_launch_site', 'link_in_bio_launched', 'videopress_launched' );
 
 	/**
@@ -91,10 +92,10 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 
 	/**
 	 * Jetpack Social tasks, hidden on private sites where wpcom does not load Publicize (so their CTA page would 404).
+	 * `drive_traffic` needs no entry: it remaps onto `connect_social_media` before this gate runs.
 	 */
 	const SOCIAL_PAGE_TASK_IDS = array(
 		'connect_social_media',
-		'drive_traffic',
 	);
 
 	/**
@@ -102,10 +103,10 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	 *
 	 * Detected through the `_wpcom_ai_launchpad_first_post` marker meta (via AI_Launchpad_First_Post_Listener), so an
 	 * unrelated pre-existing draft never counts. Paired with `add_about_page`, which has its own marker meta.
+	 * `first_post_published_newsletter` needs no entry: it remaps onto `first_post_published` before this runs.
 	 */
 	const IN_PROGRESS_FIRST_POST_TASK_IDS = array(
 		'first_post_published',
-		'first_post_published_newsletter',
 	);
 
 	/**
@@ -450,9 +451,10 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 	 * The catalog visibility gate in build_tasks() drops any task it hides on this site (e.g. add_about_page needs a
 	 * page-template meta key that is absent during a REST request) with no replacement, so a gate-heavy AI pick can
 	 * collapse the list to two or three cards. This backfills from a small pool of broadly-useful tasks and keeps the
-	 * launch task last. The pool is run through build_tasks() in one pass, which gates and dedups it, so a pool task
-	 * the site hides simply does not appear. Backfilled cards are skippable (see skip_task); a fuller, AI-ranked
-	 * overflow pool is the eventual replacement.
+	 * launch task last. Candidates are built one at a time, stopping at the target, so the tail of the pool is only
+	 * evaluated when the earlier fillers were not enough — mobile_app_installed's completion check does a remote
+	 * lookup while incomplete, which the common short-by-one list never has to pay for. Backfilled cards are
+	 * skippable (see skip_task); a fuller, AI-ranked overflow pool is the eventual replacement.
 	 *
 	 * @param array  $tasks              The rendered task list, already gated, launch task last.
 	 * @param string $theme_cta          Pre-resolved themes-showcase CTA passed through to build_tasks().
@@ -465,25 +467,35 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			return $tasks;
 		}
 
-		$present    = array_column( $tasks, 'id' );
-		$candidates = array();
 		foreach ( $this->backfill_pool() as $id => $subtitle ) {
-			if ( ! in_array( $id, $present, true ) ) {
-				$candidates[] = array(
-					'id'       => $id,
-					'subtitle' => $subtitle,
-				);
-			}
-		}
-
-		// One build over every candidate: build_tasks() drops the gated ones and dedups, preserving pool order.
-		$built = $this->build_tasks( $candidates, false, $theme_cta, $disable_hidden_woo );
-		foreach ( $built as $task ) {
 			if ( count( $tasks ) >= $target ) {
 				break;
 			}
-			// A filler card that is already complete offers nothing to do; better a shorter list.
-			if ( ! empty( $task['completed'] ) ) {
+			$present = array_column( $tasks, 'id' );
+			if ( in_array( $id, $present, true ) ) {
+				continue;
+			}
+
+			// build_tasks() applies the same gating and remap the AI list gets, so a pool task the site
+			// hides simply does not appear.
+			$built = $this->build_tasks(
+				array(
+					array(
+						'id'       => $id,
+						'subtitle' => $subtitle,
+					),
+				),
+				false,
+				$theme_cta,
+				$disable_hidden_woo
+			);
+			if ( empty( $built ) ) {
+				continue;
+			}
+			$task = $built[0];
+			// A filler card that is already complete offers nothing to do; better a shorter list. The remap
+			// inside build_tasks() can also land the card on an id already present — skip that too.
+			if ( ! empty( $task['completed'] ) || in_array( $task['id'], $present, true ) ) {
 				continue;
 			}
 			$tasks = $this->insert_before_launch_task( $tasks, $task );
@@ -506,7 +518,7 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			'design_edited'        => __( 'Make the design your own.', 'jetpack-mu-wpcom' ),
 			'add_new_page'         => __( 'Add a page your visitors will want, like About or Contact.', 'jetpack-mu-wpcom' ),
 			'connect_social_media' => __( 'Connect your social accounts to reach more people.', 'jetpack-mu-wpcom' ),
-			'drive_traffic'        => __( 'Help people discover your site.', 'jetpack-mu-wpcom' ),
+			'mobile_app_installed' => __( 'Manage your site from anywhere with the Jetpack app.', 'jetpack-mu-wpcom' ),
 		);
 	}
 
@@ -581,9 +593,11 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 			}
 		}
 
-		// null = no key yet, i.e. the baseline pass right after tailoring.
+		// null = no key yet, i.e. the baseline pass right after tailoring. Remapped like the skip overlay: a
+		// baseline recorded under a since-remapped id must keep covering the id its card renders as now, or the
+		// same completion would be re-reported once under the new id.
 		$reported = isset( $ai_output['tracked_completed'] ) && is_array( $ai_output['tracked_completed'] )
-			? $ai_output['tracked_completed']
+			? array_values( array_unique( array_map( 'wpcom_ai_launchpad_remap_task_id', $ai_output['tracked_completed'] ) ) )
 			: null;
 		$newly    = array_values( array_diff( $completed, $reported ?? array() ) );
 
@@ -1566,8 +1580,6 @@ class AI_Launchpad_REST extends WP_REST_Controller {
 				return $in_progress
 					? __( 'Continue to write your first post', 'jetpack-mu-wpcom' )
 					: __( 'Write your first post', 'jetpack-mu-wpcom' );
-			case 'first_post_published_newsletter':
-				return $in_progress ? __( 'Continue writing your first post', 'jetpack-mu-wpcom' ) : $default;
 			default:
 				return $default;
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/helpers.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/helpers.php
@@ -14,18 +14,25 @@ if ( ! function_exists( 'wpcom_ai_launchpad_remap_task_id' ) ) {
 	 * the guided setup was skipped; `post_sharing_enabled` is born completed (the sharing module is
 	 * active by default on wpcom); `design_selected` is born completed and `design_completed` has no
 	 * wp-admin completion path, so both consolidate onto the actionable `site_theme_selected` task.
-	 * The prompt no longer offers these ids, so this only catches stray AI emissions and outputs
-	 * persisted before the replacement.
+	 * Catalog `id_map` twins are the same underlying task under two names, so each pair collapses
+	 * onto the one the menu still offers. The prompt no longer offers any of these ids, so this only
+	 * catches stray AI emissions and outputs persisted before the replacement.
 	 *
 	 * @param string $task_id A task id from the persisted AI output.
 	 * @return string The task id to render (and listen/skip) instead.
 	 */
 	function wpcom_ai_launchpad_remap_task_id( $task_id ) {
 		$remap = array(
-			'woo_launch_site'      => 'site_launched',
-			'post_sharing_enabled' => 'connect_social_media',
-			'design_selected'      => 'site_theme_selected',
-			'design_completed'     => 'site_theme_selected',
+			'woo_launch_site'                 => 'site_launched',
+			'post_sharing_enabled'            => 'connect_social_media',
+			'design_selected'                 => 'site_theme_selected',
+			'design_completed'                => 'site_theme_selected',
+			// id_map twins, keyed dropped => kept.
+			'drive_traffic'                   => 'connect_social_media',
+			'first_post_published_newsletter' => 'first_post_published',
+			'link_in_bio_launched'            => 'site_launched',
+			'videopress_launched'             => 'site_launched',
+			'subscribers_added'               => 'import_subscribers',
 		);
 
 		return $remap[ $task_id ] ?? $task_id;

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/app.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/app.tsx
@@ -1,5 +1,6 @@
 import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useState } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 import { decideInitialView, isAllTasksMode, type View } from './lib/orchestration.ts';
 import { contextFromInferred, contextFromTaskIds, setTracksContext } from './lib/tracks.ts';
 import { TailoredList } from './tailored-list/tailored-list.tsx';
@@ -30,6 +31,16 @@ export function App() {
 		apiFetch< LaunchpadData >( { path } ).then( data => {
 			if ( cancelled ) {
 				return;
+			}
+			// blogname/blogdescription arrive HTML-escaped (sanitize_option stores them
+			// that way); decode so React doesn't render literal entities in the wizard
+			// prefill and the preview title.
+			if ( data.site ) {
+				data.site = {
+					...data.site,
+					title: data.site.title && decodeEntities( data.site.title ),
+					description: data.site.description && decodeEntities( data.site.description ),
+				};
 			}
 			setInitialData( data );
 			setView( allTasks ? 'list' : decideInitialView( data ) );

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/fallback.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/fallback.ts
@@ -6,7 +6,6 @@ import type { GoalSlug, TailoredOutput, TailoredTask, WizardInput } from './type
  */
 const TASK_SUBTITLES: Record< string, string > = {
 	first_post_published: 'Write and publish your first post.',
-	first_post_published_newsletter: 'Send your first newsletter to subscribers.',
 	woo_products: 'Add your first product to the store.',
 	woo_customize_store: 'Customize how your store looks.',
 	set_up_payments: 'Set up a way to get paid.',
@@ -17,10 +16,8 @@ const TASK_SUBTITLES: Record< string, string > = {
 	complete_profile: 'Complete your public profile.',
 	verify_email: 'Confirm your email address.',
 	connect_social_media: 'Connect your social accounts.',
-	drive_traffic: 'Help people find your site.',
 	site_launched: 'Launch your site for the world to see.',
 	blog_launched: 'Launch your blog for the world to see.',
-	link_in_bio_launched: 'Launch your link-in-bio page.',
 };
 
 const GENERIC_SUBTITLE = 'Get this set up.';
@@ -34,7 +31,7 @@ const GOAL_TASK_IDS: Record< GoalSlug, string[] > = {
 		'site_theme_selected',
 		'add_about_page',
 		'complete_profile',
-		'drive_traffic',
+		'connect_social_media',
 		'site_launched',
 	],
 	build: [
@@ -42,7 +39,7 @@ const GOAL_TASK_IDS: Record< GoalSlug, string[] > = {
 		'site_theme_selected',
 		'design_edited',
 		'complete_profile',
-		'drive_traffic',
+		'connect_social_media',
 		'site_launched',
 	],
 	sell: [
@@ -54,7 +51,7 @@ const GOAL_TASK_IDS: Record< GoalSlug, string[] > = {
 		'site_launched',
 	],
 	newsletter: [
-		'first_post_published_newsletter',
+		'first_post_published',
 		'add_10_email_subscribers',
 		'add_about_page',
 		'site_theme_selected',
@@ -66,7 +63,7 @@ const GOAL_TASK_IDS: Record< GoalSlug, string[] > = {
 		'add_about_page',
 		'site_theme_selected',
 		'complete_profile',
-		'drive_traffic',
+		'connect_social_media',
 		'site_launched',
 	],
 	portfolio: [

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/lib/prompts.ts
@@ -3,10 +3,14 @@ import type { WizardInput } from './types.ts';
 /**
  * Allowed task IDs the model may pick from, drawn from the catalog. A PHP test
  * guards this list against catalog drift.
+ *
+ * Catalog `id_map` twins are the same underlying task, so only one of each pair
+ * is offered; the dropped twin remaps onto the kept one on read (see
+ * wpcom_ai_launchpad_remap_task_id). Dropped: first_post_published_newsletter,
+ * link_in_bio_launched, subscribers_added, drive_traffic.
  */
 export const TASK_MENU: readonly string[] = [
 	'first_post_published',
-	'first_post_published_newsletter',
 	'site_theme_selected',
 	'add_about_page',
 	'add_new_page',
@@ -22,7 +26,6 @@ export const TASK_MENU: readonly string[] = [
 	'setup_general',
 	'site_launched',
 	'blog_launched',
-	'link_in_bio_launched',
 	'set_up_payments',
 	'stripe_connected',
 	'paid_offer_created',
@@ -33,7 +36,6 @@ export const TASK_MENU: readonly string[] = [
 	'woo_marketing',
 	'woo_add_domain',
 	'add_10_email_subscribers',
-	'subscribers_added',
 	'import_subscribers',
 	'newsletter_plan_created',
 	'customize_welcome_message',
@@ -50,7 +52,6 @@ export const TASK_MENU: readonly string[] = [
 	'mobile_app_installed',
 	'share_site',
 	'front_page_updated',
-	'drive_traffic',
 	'start_building_your_audience',
 ];
 
@@ -125,17 +126,17 @@ For each chosen task write a "subtitle" (max 200 characters) that is specific an
 GOOD vs BAD subtitles (illustrations - adapt to the user's own niche, do not copy):
 - For a handmade-ceramics studio, "add_about_page" -> GOOD: "Share the story behind your studio and what makes each handmade piece one of a kind." BAD: "Tell visitors who you are."
 - For a handmade-ceramics studio, "site_theme_selected" -> GOOD: "Pick a clean, gallery-style theme that lets your ceramics photos take center stage." BAD: "Choose a theme."
-- For a weekly cycling newsletter, "first_post_published_newsletter" -> GOOD: "Send your first issue with this week's route, ride notes, and gear picks." BAD: "Send your first newsletter."
+- For a weekly cycling newsletter, "first_post_published" -> GOOD: "Send your first issue with this week's route, ride notes, and gear picks." BAD: "Send your first newsletter."
 
 HARD RULES (do not break - the server rejects output that violates these):
 - Every "id" MUST come from the menu below, verbatim. Never invent IDs. Drop any task you cannot map to a menu ID.
 - Return exactly 6 tasks.
-- At least one task must create content (e.g. "first_post_published", "first_post_published_newsletter", "woo_products", or "add_about_page").
-- The 6th and final task MUST be a launch task: one of "site_launched" (canonical), "blog_launched", or "link_in_bio_launched".
+- At least one task must create content (e.g. "first_post_published", "woo_products", or "add_about_page").
+- The 6th and final task MUST be a launch task: "site_launched" (canonical) or "blog_launched".
 - Only include "woo_products", "woo_customize_store", "set_up_payments", "stripe_connected", or "woo_woocommerce_payments" if the goal is sell OR the user explicitly mentions selling, products, store, shop, or commerce.
 - For the sell goal, order the commerce tasks store-first: "woo_customize_store", then "woo_products", then "set_up_payments", keeping the launch task last. Installing WooCommerce is added automatically as the first step, so do not include a task for it.
-- Only include "add_10_email_subscribers", "subscribers_added", "newsletter_plan_created", or "import_subscribers" if the goal is newsletter OR the user explicitly mentions email subscribers or a newsletter.
-- For the social tasks "connect_social_media" and "drive_traffic", keep the subtitle general - about growing the site's audience and engaging visitors (e.g. "Build the audience of your blog and engage with your visitors."). Do NOT name specific social networks (Instagram, Pinterest, X, Facebook, TikTok, etc.); the user has not said which platforms they use.
+- Only include "add_10_email_subscribers", "newsletter_plan_created", or "import_subscribers" if the goal is newsletter OR the user explicitly mentions email subscribers or a newsletter.
+- For the social task "connect_social_media", keep the subtitle general - about growing the site's audience and engaging visitors (e.g. "Build the audience of your blog and engage with your visitors."). Do NOT name specific social networks (Instagram, Pinterest, X, Facebook, TikTok, etc.); the user has not said which platforms they use.
 - Subtitles must be plain text: no URLs, no HTML, and no template syntax such as {{ }} or [[ ]].
 
 ============ STEP 3 - first_post_draft ============

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/tailored-list.tsx
@@ -1,5 +1,6 @@
 import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { createAboutPage } from '../lib/about-page.ts';
 import { createFirstPostDraft } from '../lib/first-post.ts';
@@ -141,7 +142,10 @@ export function TailoredList( { pendingTailor, initialData, site, goal }: Props 
 
 			if ( data?.site ) {
 				setSiteUrl( data.site.url ?? null );
-				setSiteTitle( data.site.title ?? null );
+				// blogname is stored HTML-escaped; decode it or the preview renders literal entities. A
+				// present-but-blank title stays blank (matches the initial read in app.tsx), only a
+				// missing one coalesces to null.
+				setSiteTitle( data.site.title != null ? decodeEntities( data.site.title ) : null );
 				setSiteEditUrl( data.site.edit_url ?? null );
 			}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/js/tailored-list/task-card.tsx
@@ -62,8 +62,10 @@ function getCtaLabel( taskId: string, inProgress: boolean ): string {
 			return __( 'Set up payments', 'jetpack-mu-wpcom' );
 		case 'connect_social_media':
 			return __( 'Connect socials', 'jetpack-mu-wpcom' );
-		// Both the AI-selectable id and the deterministic fallback id, so the label
-		// holds on the fallback path too.
+		// The subscriber tasks all share this label: the menu id (import_subscribers), the
+		// deterministic-fallback id (add_10_email_subscribers), and the pre-remap alias
+		// (subscribers_added), which can still surface via the in-memory fixture fallback.
+		case 'import_subscribers':
 		case 'subscribers_added':
 		case 'add_10_email_subscribers':
 			return __( 'Add subscribers', 'jetpack-mu-wpcom' );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_REST_Test.php
@@ -274,10 +274,11 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Test that an unpublished AI-created first-post draft puts the newsletter first-post task "in progress": it's
-	 * detected through the first-post marker meta (not any latest draft), gets the drafts-aware "Continue writing"
-	 * title override, and reopens that draft. The marker query is short-circuited via `posts_pre_query` (WorDBless
-	 * can't run WP_Query).
+	 * Test that an unpublished AI-created first-post draft puts the first-post task "in progress": it's detected
+	 * through the first-post marker meta (not any latest draft), gets the drafts-aware "Continue" title override,
+	 * and reopens that draft. Seeds the `first_post_published_newsletter` id_map twin, which must render as the
+	 * canonical `first_post_published` with the in-progress treatment intact. The marker query is short-circuited
+	 * via `posts_pre_query` (WorDBless can't run WP_Query).
 	 */
 	public function test_get_marks_first_post_in_progress_with_marked_draft() {
 		wp_set_current_user( $this->admin_id );
@@ -286,7 +287,7 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 
 		$get_first_post = function () {
 			foreach ( $this->call_api( Requests::GET )->get_data()['tasks'] as $task ) {
-				if ( 'first_post_published_newsletter' === $task['id'] ) {
+				if ( 'first_post_published' === $task['id'] ) {
 					return $task;
 				}
 			}
@@ -315,7 +316,7 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 		$after = $get_first_post();
 		$this->assertNotNull( $after );
 		$this->assertTrue( $after['in_progress'] );
-		$this->assertSame( 'Continue writing your first post', $after['title'] );
+		$this->assertSame( 'Continue to write your first post', $after['title'] );
 		$this->assertSame( admin_url( 'post.php?post=' . $draft_id . '&action=edit' ), $after['calypso_path'] );
 	}
 
@@ -1505,8 +1506,9 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Test that the Jetpack Social tasks are hidden on a private site, where wpcom
-	 * doesn't load the Social admin page their CTA points to.
+	 * Test that the Jetpack Social task is hidden on a private site, where wpcom
+	 * doesn't load the Social admin page its CTA points to. A persisted
+	 * `drive_traffic` (the id_map twin) folds into the same single card first.
 	 */
 	public function test_get_hides_social_tasks_on_private_site() {
 		wp_set_current_user( $this->admin_id );
@@ -1518,17 +1520,16 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 			return array_column( $this->call_api( Requests::GET )->get_data()['tasks'], 'id' );
 		};
 
-		// Public site: the Social tasks show.
+		// Public site: one social card — the drive_traffic twin collapses into connect_social_media.
 		update_option( 'blog_public', '1' );
 		$public_ids = $ids();
 		$this->assertContains( 'connect_social_media', $public_ids );
-		$this->assertContains( 'drive_traffic', $public_ids );
+		$this->assertNotContains( 'drive_traffic', $public_ids );
 
-		// Private site: the Social tasks are gone, the rest remain.
+		// Private site: the Social task is gone, the rest remain.
 		update_option( 'blog_public', '-1' );
 		$private_ids = $ids();
 		$this->assertNotContains( 'connect_social_media', $private_ids );
-		$this->assertNotContains( 'drive_traffic', $private_ids );
 		$this->assertContains( 'first_post_published', $private_ids );
 
 		update_option( 'blog_public', '1' );
@@ -1550,6 +1551,26 @@ class AI_Launchpad_REST_Test extends \WorDBless\BaseTestCase {
 
 		$this->assertNotContains( 'post_sharing_enabled', $ids );
 		$this->assertSame( 1, array_count_values( $ids )['connect_social_media'] );
+	}
+
+	/**
+	 * Test that persisted id_map twins render as the id the menu still offers:
+	 * `subscribers_added` as `import_subscribers` and `link_in_bio_launched` as
+	 * `site_launched`. A payload holding a twin and its target collapses to one card.
+	 */
+	public function test_get_remaps_id_map_twins_to_kept_ids() {
+		wp_set_current_user( $this->admin_id );
+		$this->seed_ai_output_with_tasks(
+			array( 'subscribers_added', 'first_post_published', 'link_in_bio_launched', 'videopress_launched', 'site_launched' )
+		);
+
+		$ids = array_column( $this->call_api( Requests::GET )->get_data()['tasks'], 'id' );
+
+		$this->assertNotContains( 'subscribers_added', $ids );
+		$this->assertContains( 'import_subscribers', $ids );
+		$this->assertNotContains( 'link_in_bio_launched', $ids );
+		$this->assertNotContains( 'videopress_launched', $ids );
+		$this->assertSame( 1, array_count_values( $ids )['site_launched'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes DOTOBRD-564

## Proposed changes

Three AI Launchpad quality fixes, one per commit:

* **Move the Site Setup menu item to the top of the sidebar.** Site Setup is the site's primary surface while onboarding, so it should lead the menu rather than sit below Dashboard. `add_menu_page` position `2.01` → `1`.
* **Decode HTML entities in user-generated content.** WordPress stores `blogname`/`blogdescription` HTML-escaped (`sanitize_option` runs `esc_html` on save), and React escapes again on render — so a title like `Copons' Travelogue & "Other Stuff"` displayed as `Copons&#039; Travelogue &amp; &quot;Other Stuff&quot;` in the wizard Name/description prefills and the preview-card title. The fix decodes with `@wordpress/html-entities` at the two places API data enters the client (the app's initial read and the tailored list's refetch), so every consumer downstream gets clean text. This also stops progressive double-escaping: finishing the wizard with an unedited encoded prefill used to write the entities back through the PUT, re-escaping them on every pass.
* **Collapse `id_map` twin tasks onto a single id.** Four catalog `id_map` pairs sat on the AI task menu as two ids for the same underlying task, so the model could spend two of its six picks on duplicates. The menu now offers one of each pair, chosen for the stronger title/behavior: `connect_social_media` over `drive_traffic`, `first_post_published` (draft-aware title) over `first_post_published_newsletter`, `site_launched` over `link_in_bio_launched` (identical titles), and `import_subscribers` over `subscribers_added` (the latter is visibility-gated on a Calypso onboarding goal AI Launchpad users don't have). Dropped ids stay valid on PUT and remap onto the kept twin on read — same pattern as `woo_launch_site` — so persisted outputs and stray AI emissions keep rendering, and skips/listeners/analytics follow automatically. `drive_traffic`'s backfill-pool slot goes to `mobile_app_installed` (computed, self-caching completion), keeping the pool at the four fillers the six-task floor needs.

## Related product discussion/links
* https://linear.app/a8c/issue/DOTOBRD-564

## Does this pull request change what data or activity we track or use?

No new tracking. Tracks events that carried a dropped twin id now carry the kept id, via the existing remap-aware context helpers.

## Testing instructions

On a site with the AI Launchpad enabled (`wp option update wpcom_ai_launchpad_enabled 1`):

* Set an entity-prone title: `wp option update blogname "Copons' Travelogue & \"Other Stuff\""`.
* Load wp-admin: **Site Setup** should be the first sidebar item, above Dashboard.
* Open Site Setup with a tailored list persisted: the preview-card title should read `Copons' Travelogue & "Other Stuff"` with no literal entities.
* Delete `wpcom_ai_launchpad_ai_output`/`wpcom_ai_launchpad_wizard` and reload: the wizard's Name and Brief description prefills should also show decoded text.
* Seed an AI output containing `drive_traffic`, `first_post_published_newsletter`, `link_in_bio_launched`, and `subscribers_added`: the rendered list should show only `connect_social_media`, `first_post_published`, `site_launched`, and `import_subscribers`, with no duplicate cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
