### PR TITLE
Write editor: remove beta data-loss disclaimer banner

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-write-editor-beta-data-loss-warning
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-write-editor-beta-data-loss-warning
@@ -1,0 +1,4 @@
+Significance: minor
+Type: removed
+
+Write editor: remove the beta disclaimer banner warning about possible data loss.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/style.css
@@ -359,78 +359,6 @@
 	padding-top: 164px;
 }
 
-/* ===== Beta disclaimer banner ===== */
-.bw-disclaimer-banner {
-	position: fixed;
-	top: 56px;
-	left: 0;
-	right: 0;
-	z-index: 100001;
-	box-sizing: border-box;
-	height: 44px;
-	background: #fff8e6;
-	border-bottom: 1px solid #e8c84a;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	gap: 12px;
-	animation: bw-fade-in 0.2s ease;
-}
-
-.bw-disclaimer-banner[hidden] {
-	display: none;
-}
-
-.bw-disclaimer-text {
-	font-size: 14px;
-	color: #1a1a1a;
-}
-
-.bw-disclaimer-dismiss {
-	border: none;
-	background: transparent;
-	color: #999;
-	font-size: 20px;
-	cursor: pointer;
-	padding: 4px 8px;
-	line-height: 1;
-}
-
-.bw-disclaimer-dismiss:hover {
-	color: #333;
-}
-
-/* Push toolbar, link popover, and content down
-   when disclaimer banner is visible */
-.bw-disclaimer-banner:not([hidden]) ~ .bw-toolbar {
-	top: 100px;
-}
-
-.bw-disclaimer-banner:not([hidden]) ~ .bw-link-popover {
-	top: 144px;
-}
-
-.bw-disclaimer-banner:not([hidden]) ~ .bw-main {
-	padding-top: 164px;
-}
-
-/* Both disclaimer and recovery visible — stack recovery below disclaimer */
-.bw-disclaimer-banner:not([hidden]) ~ .bw-recovery-banner:not([hidden]) {
-	top: 100px;
-}
-
-.bw-disclaimer-banner:not([hidden]) ~ .bw-recovery-banner:not([hidden]) ~ .bw-toolbar {
-	top: 144px;
-}
-
-.bw-disclaimer-banner:not([hidden]) ~ .bw-recovery-banner:not([hidden]) ~ .bw-link-popover {
-	top: 188px;
-}
-
-.bw-disclaimer-banner:not([hidden]) ~ .bw-recovery-banner:not([hidden]) ~ .bw-main {
-	padding-top: 208px;
-}
-
 /* ===== Persistent formatting toolbar ===== */
 .bw-toolbar {
 	position: fixed;
@@ -1692,10 +1620,10 @@ body.bw-modal-open {
 	align-items: flex-start;
 	justify-content: center;
 
-	/* Anchor the modal below the disclaimer banner (~56px) + toolbar (~88px
-	 * incl. its shifted top), with a small breathing gap. Pairs with the
-	 * modal's max-height: calc(100vh - 200px) so the modal can't grow
-	 * behind the toolbar even when both expanders + a preview are open. */
+	/* Anchor the modal below the header (~56px) + toolbar (~88px incl. its
+	 * shifted top), with a small breathing gap. Pairs with the modal's
+	 * max-height: calc(100vh - 200px) so the modal can't grow behind the
+	 * toolbar even when both expanders + a preview are open. */
 	padding: 168px 0 32px;
 	box-sizing: border-box;
 	animation: bw-fade-in 0.15s ease;
@@ -1712,11 +1640,10 @@ body.bw-modal-open {
 	width: 420px;
 	max-width: 90vw;
 
-	/* Hard cap below "banner + toolbar height + bottom breathing room" so the
-	 * modal never grows behind the toolbar. With the disclaimer banner
-	 * visible the toolbar's bottom sits at ~144px; we leave ~24px of air
-	 * above and below the modal — anything taller scrolls internally.
-	 * border-box so max-height includes the padding. */
+	/* Hard cap below "header + toolbar height + bottom breathing room" so the
+	 * modal never grows behind the toolbar, whose bottom sits at ~144px; we
+	 * leave ~24px of air above and below the modal — anything taller scrolls
+	 * internally. border-box so max-height includes the padding. */
 	box-sizing: border-box;
 	max-height: calc(100vh - 200px);
 	overflow-y: auto;
@@ -2444,8 +2371,7 @@ body.bw-modal-open {
 		padding: 0 16px;
 	}
 
-	.bw-recovery-banner,
-	.bw-disclaimer-banner {
+	.bw-recovery-banner {
 		padding: 0 16px;
 	}
 
@@ -2529,7 +2455,6 @@ html.bw-anon .bw-back,
 html.bw-anon .bw-help-wrap,
 html.bw-anon .bw-more-wrap,
 html.bw-anon .bw-btn-draft,
-html.bw-anon .bw-disclaimer-banner,
 html.bw-anon .bw-toolbar [data-wp-on--click="actions.openImageModal"],
 html.bw-anon #bw-slash-opt-image,
 html.bw-anon .bw-unsupported-open-editor {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -23,7 +23,6 @@ const AUTOSAVE_INTERVAL_MS = 30000; // 30 seconds.
 const AUTOSAVE_MESSAGE_DURATION_MS = 2000;
 const AUTOSAVE_STORAGE_KEY = 'wpcom-write-autosave-draft';
 const ANON_DRAFT_STORAGE_KEY = 'wpcom-write-anon-draft';
-const DISCLAIMER_STORAGE_KEY = 'wpcom-write-disclaimer-dismissed';
 
 /**
  * Whether the editor is running on a logged-out page that opts into the
@@ -6096,11 +6095,6 @@ const { state } = store( 'wpcom-write', {
 			state.showRecoveryBanner = false;
 		},
 
-		dismissDisclaimer() {
-			localStorage.setItem( DISCLAIMER_STORAGE_KEY, '1' );
-			state.showDisclaimer = false;
-		},
-
 		// --- Unsupported content warning ---
 		goBack() {
 			const sameOrigin =
@@ -6671,17 +6665,6 @@ const autosaveReady = setInterval( () => {
 	autosaveTimer = setInterval( () => {
 		actions.autosave();
 	}, AUTOSAVE_INTERVAL_MS );
-
-	// Show the beta disclaimer unless previously dismissed. Anon visitors
-	// skip this entirely — not just because the banner is irrelevant, but
-	// because the layout's sibling selectors (`.bw-disclaimer-banner:not(
-	// [hidden]) ~ .bw-toolbar`) push the toolbar down based on the `hidden`
-	// attribute, which the Interactivity API only sets when the state is
-	// false. Leaving state true would shift the toolbar down by 44px even
-	// though our anon CSS hides the banner itself.
-	if ( ! isAnon() && ! localStorage.getItem( DISCLAIMER_STORAGE_KEY ) ) {
-		state.showDisclaimer = true;
-	}
 
 	// Check for a recoverable autosaved draft (only for new posts).
 	if ( isAnon() ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -1070,12 +1070,6 @@ function wpcom_write_template( $edit_title = '', $edit_content = '', $edit_post_
 		</div>
 	</header>
 
-	<!-- Beta disclaimer banner -->
-	<div class="bw-disclaimer-banner" hidden data-wp-bind--hidden="!state.showDisclaimer">
-		<span class="bw-disclaimer-text"><?php echo esc_html__( 'Beta: This is an early-access feature. Data loss is possible.', 'jetpack-mu-wpcom' ); ?></span>
-		<button class="bw-disclaimer-dismiss" data-wp-on--click="actions.dismissDisclaimer" aria-label="<?php echo esc_attr__( 'Dismiss beta disclaimer', 'jetpack-mu-wpcom' ); ?>">&times;</button>
-	</div>
-
 	<!-- Recovery banner -->
 	<div class="bw-recovery-banner" hidden data-wp-bind--hidden="!state.showRecoveryBanner">
 		<span class="bw-recovery-text"><?php echo esc_html__( 'You have a recent draft — continue editing?', 'jetpack-mu-wpcom' ); ?></span>

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -624,30 +624,6 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Test that the template contains the beta disclaimer banner markup.
-	 */
-	public function test_template_contains_disclaimer_banner() {
-		wp_set_current_user( $this->admin_id );
-
-		$output = $this->render_template();
-
-		$this->assertStringContainsString( 'class="bw-disclaimer-banner"', $output );
-		$this->assertStringContainsString( 'actions.dismissDisclaimer', $output );
-		$this->assertStringContainsString( 'Data loss is possible', $output );
-	}
-
-	/**
-	 * Test that the disclaimer banner is hidden by default (shown via JS after localStorage check).
-	 */
-	public function test_disclaimer_banner_hidden_by_default() {
-		wp_set_current_user( $this->admin_id );
-
-		$output = $this->render_template();
-
-		$this->assertStringContainsString( 'bw-disclaimer-banner" hidden', $output );
-	}
-
-	/**
 	 * Test that autosave i18n strings are included in the rendered page state.
 	 */
 	public function test_autosave_i18n_strings_registered() {


### PR DESCRIPTION
## Proposed changes
* Remove the beta "Data loss is possible" disclaimer banner from the Write editor.
* Delete the banner markup in `write.php`, the `showDisclaimer` state / `dismissDisclaimer` action and its `localStorage` key in `view.js`, and the banner styles plus sibling-selector layout rules in `style.css`.
* Drop the two PHPUnit tests that asserted the banner markup.
* With the banner gone, the formatting toolbar sits directly under the header again (no leftover 44px offset).

Before | After
--- | ---
<img width="817" height="398" alt="Screenshot 2026-07-21 at 12 51 59 PM" src="https://github.com/user-attachments/assets/eb2d6e02-9a0c-4294-8737-1d3c27ba5672" /> | <img width="948" height="364" alt="Screenshot 2026-07-21 at 12 50 09 PM" src="https://github.com/user-attachments/assets/7b57c131-5a1a-4d57-9685-94fed8d38dfa" />


## Related product discussion/links
* Loop team product decision.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Go to the Write editor (`/wp-admin/admin.php?page=write`) as a logged-in user.
* Confirm the yellow "Beta: This is an early-access feature. Data loss is possible." banner no longer appears at the top.
* Confirm the formatting toolbar sits flush beneath the header with no empty gap where the banner used to be.
* Clear the `wpcom-write-disclaimer-dismissed` localStorage key (to simulate a fresh user) and reload — the banner should still not appear.
* Confirm the recovery banner ("You have a recent draft…") still displays and positions correctly when a draft is available.
