### PR TITLE
Jetpack AI: Add a module for the site-wide master switch

### DIFF
--- a/projects/packages/my-jetpack/.phan/config.php
+++ b/projects/packages/my-jetpack/.phan/config.php
@@ -22,6 +22,7 @@ return make_phan_config(
 			// If there are truly optional dependencies or circular dependencies that can't be cleaned up, one package may list the
 			// other in 'require-dev' and `extra.dependencies.test-only' instead. See packages/config for an example.
 			__DIR__ . '/../../../plugins/jetpack/jetpack.php',                             // JETPACK__VERSION
+			__DIR__ . '/../../../plugins/jetpack/functions.global.php',                    // function jetpack_is_internal_testing_environment
 			__DIR__ . '/../../../plugins/jetpack/class.jetpack.php',                       // class Jetpack
 			__DIR__ . '/../../../plugins/jetpack/_inc/lib/class-jetpack-ai-helper.php',    // class Jetpack_AI_Helper
 			__DIR__ . '/../../../plugins/jetpack/3rd-party/class.jetpack-amp-support.php', // class Jetpack_AMP_Support

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/mappings.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/mappings.ts
@@ -1,3 +1,4 @@
+import { getMyJetpackWindowInitialState } from '../../../data/utils/get-my-jetpack-window-state';
 import { JetpackModuleSlug, JetpackProductWithCard } from '../../../types';
 import AntiSpamIcon from '../../products-table-view/icons/anti-spam';
 import BackupIcon from '../../products-table-view/icons/backup';
@@ -115,3 +116,24 @@ export const PRODUCT_MODULES: {
 	'jetpack-forms': 'contact-form',
 	'jetpack-ai': 'ai',
 };
+
+/**
+ * The product-to-module map to build cards from.
+ *
+ * Pre-release gate: outside internal testing environments the AI card is not
+ * backed by the 'ai' module, so its cards resolve no module and render exactly
+ * as they did before the module existed. Remove when the AI settings page goes
+ * public.
+ *
+ * @return The map, without the AI entry while the gate is on.
+ */
+export function getProductModules() {
+	const { showAiModuleToggle = false } = getMyJetpackWindowInitialState( 'myJetpackFlags' );
+	if ( showAiModuleToggle ) {
+		return PRODUCT_MODULES;
+	}
+
+	const gated = { ...PRODUCT_MODULES };
+	delete gated[ 'jetpack-ai' ];
+	return gated;
+}

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/mappings.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/mappings.ts
@@ -113,4 +113,5 @@ export const PRODUCT_MODULES: {
 	backup: 'vaultpress',
 	social: 'publicize',
 	'jetpack-forms': 'contact-form',
+	'jetpack-ai': 'ai',
 };

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/product-card-action.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/product-card-action.tsx
@@ -11,6 +11,7 @@ import useActivatePlugins from '../../../data/products/use-activate-plugins';
 import { useDeactivatePlugins } from '../../../data/products/use-deactivate-plugins';
 import useProduct from '../../../data/products/use-product';
 import { ProductCamelCase } from '../../../data/types';
+import { getMyJetpackWindowInitialState } from '../../../data/utils/get-my-jetpack-window-state';
 import { useInterstitialsState } from '../../../hooks/use-interstitials-state';
 import { MyJetpackModule } from '../../../types';
 import { PRODUCT_STATUSES } from '../../product-card';
@@ -142,13 +143,19 @@ function ActivationToggle( {
 export function ProductCardAction( { product, module: $module }: ProductCardActionProps ) {
 	const { data: interstitials } = useInterstitialsState();
 	const reloadOnToggle = PRODUCTS_NEEDING_RELOAD_AFTER_TOGGLE.includes( product.slug );
+	const { showAiModuleToggle = false } = getMyJetpackWindowInitialState( 'myJetpackFlags' );
 
 	// Forms and AI surface the activation toggle directly instead of a "Learn more"
 	// upsell link. Forms is a free module with no interstitial; AI is the site-wide
 	// master switch, and the Content AI settings design shows the card with an inline
 	// Active/off toggle in both states (the AI upsell lives on the AI page, not on
-	// this master control).
-	if ( product.slug === 'jetpack-forms' || product.slug === 'jetpack-ai' ) {
+	// this master control). The AI toggle is limited to internal testing environments
+	// until the AI settings page goes public (pre-release gate); everyone else keeps
+	// the standard card action.
+	if (
+		product.slug === 'jetpack-forms' ||
+		( product.slug === 'jetpack-ai' && showAiModuleToggle )
+	) {
 		// Drive on/off from the module's real activated state, not product.status:
 		// a free product that also has a paid tier (Jetpack AI) reports
 		// "can_upgrade" even when its module is active, which would leave the master

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/product-card-action.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/product-card-action.tsx
@@ -143,13 +143,21 @@ export function ProductCardAction( { product, module: $module }: ProductCardActi
 	const { data: interstitials } = useInterstitialsState();
 	const reloadOnToggle = PRODUCTS_NEEDING_RELOAD_AFTER_TOGGLE.includes( product.slug );
 
-	// Forms is a free module feature with no interstitial yet — show the activation
-	// toggle directly instead of a "Learn more" link. (An interstitial may be added later.)
-	if ( product.slug === 'jetpack-forms' ) {
+	// Forms and AI surface the activation toggle directly instead of a "Learn more"
+	// upsell link. Forms is a free module with no interstitial; AI is the site-wide
+	// master switch, and the Content AI settings design shows the card with an inline
+	// Active/off toggle in both states (the AI upsell lives on the AI page, not on
+	// this master control).
+	if ( product.slug === 'jetpack-forms' || product.slug === 'jetpack-ai' ) {
+		// Drive on/off from the module's real activated state, not product.status:
+		// a free product that also has a paid tier (Jetpack AI) reports
+		// "can_upgrade" even when its module is active, which would leave the master
+		// toggle stuck in the off position while AI is actually running.
+		const isActive = $module?.activated ?? product.status === PRODUCT_STATUSES.ACTIVE;
 		return (
 			<ActivationToggle
 				product={ product }
-				active={ product.status === PRODUCT_STATUSES.ACTIVE }
+				active={ isActive }
 				disabled={ ! $module?.available }
 				reloadOnToggle={ reloadOnToggle }
 			/>

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/test/mappings.test.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/test/mappings.test.ts
@@ -1,0 +1,24 @@
+import { getProductModules, PRODUCT_MODULES } from '../mappings';
+
+describe( 'getProductModules', () => {
+	it( 'omits the AI mapping while the pre-release gate is on', () => {
+		window.myJetpackInitialState = {
+			myJetpackFlags: {},
+		} as unknown as Window[ 'myJetpackInitialState' ];
+
+		const map = getProductModules();
+
+		// No AI mapping means AI cards resolve no module, exactly as they did
+		// before AI became a module. Other products keep theirs.
+		expect( map ).not.toHaveProperty( 'jetpack-ai' );
+		expect( map[ 'jetpack-forms' ] ).toBe( 'contact-form' );
+	} );
+
+	it( 'keeps the AI mapping for internal testing environments', () => {
+		window.myJetpackInitialState = {
+			myJetpackFlags: { showAiModuleToggle: true },
+		} as unknown as Window[ 'myJetpackInitialState' ];
+
+		expect( getProductModules() ).toEqual( PRODUCT_MODULES );
+	} );
+} );

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/test/product-card-action.test.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/test/product-card-action.test.tsx
@@ -96,6 +96,27 @@ describe( 'ProductCardAction', () => {
 		expect( screen.getByRole( 'checkbox' ) ).toBeChecked();
 	} );
 
+	it( 'reloads the page after toggling AI: the toggle reads module state the mutation does not update', async () => {
+		// The AI toggle is driven by $module.activated (not product.status), and
+		// the activate mutation only updates product.status — without a reload
+		// the just-flipped toggle keeps showing the old state.
+		const inactiveModule = { available: true, activated: false } as unknown as MyJetpackModule;
+		render(
+			<ProductCardAction
+				product={ buildProduct( { slug: 'jetpack-ai', name: 'AI', status: 'inactive' } ) }
+				module={ inactiveModule }
+			/>
+		);
+
+		await userEvent.click( screen.getByRole( 'checkbox' ) );
+
+		expect( mockActivate ).toHaveBeenCalled();
+		expect( setPendingSuccessNotice ).toHaveBeenCalledWith(
+			expect.stringContaining( 'activated' )
+		);
+		expect( reloadPage ).toHaveBeenCalled();
+	} );
+
 	it( 'pre-release gate: hides the AI toggle without the showAiModuleToggle flag', () => {
 		// Outside internal testing environments the AI card keeps its standard
 		// action: an inactive free product falls through to "Learn more".

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/test/product-card-action.test.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/test/product-card-action.test.tsx
@@ -59,6 +59,37 @@ describe( 'ProductCardAction', () => {
 		expect( screen.getByRole( 'checkbox' ) ).toBeInTheDocument();
 	} );
 
+	it( 'renders the activation toggle for AI even when inactive, instead of a Learn more link', () => {
+		// AI is the site-wide master switch: the card must show an inline on/off toggle
+		// in both states rather than the "Learn more" upsell that routes to the pricing
+		// interstitial. An inactive product with no paid plan would otherwise fall through
+		// to the UpgradeAction ("Learn more") path.
+		render(
+			<ProductCardAction
+				product={ buildProduct( { slug: 'jetpack-ai', name: 'AI', status: 'inactive' } ) }
+				module={ formsModule }
+			/>
+		);
+
+		expect( screen.queryByRole( 'button', { name: /learn more/i } ) ).not.toBeInTheDocument();
+		expect( screen.getByRole( 'checkbox' ) ).toBeInTheDocument();
+	} );
+
+	it( 'reflects the AI module active state, not product.status (free tier reports can_upgrade)', () => {
+		// Jetpack AI on a free site reports status "can_upgrade" even when its module
+		// is active. The toggle must follow the module's activated state, or it reads
+		// "off" while AI is actually running.
+		const activeModule = { available: true, activated: true } as unknown as MyJetpackModule;
+		render(
+			<ProductCardAction
+				product={ buildProduct( { slug: 'jetpack-ai', name: 'AI', status: 'can_upgrade' } ) }
+				module={ activeModule }
+			/>
+		);
+
+		expect( screen.getByRole( 'checkbox' ) ).toBeChecked();
+	} );
+
 	it( 'disables the toggle when the Forms module is unavailable', () => {
 		const unavailableModule = { available: false, activated: false } as unknown as MyJetpackModule;
 		render(
@@ -85,10 +116,12 @@ describe( 'ProductCardAction', () => {
 	} );
 
 	it( 'reloads the page after activating Forms so the admin sidebar updates', async () => {
+		// Toggle starts off (module inactive), so clicking it activates.
+		const inactiveModule = { available: true, activated: false } as unknown as MyJetpackModule;
 		render(
 			<ProductCardAction
 				product={ buildProduct( { status: 'inactive' } ) }
-				module={ formsModule }
+				module={ inactiveModule }
 			/>
 		);
 

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/test/product-card-action.test.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/test/product-card-action.test.tsx
@@ -137,6 +137,27 @@ describe( 'ProductCardAction', () => {
 		expect( screen.queryByRole( 'checkbox' ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'pre-release gate: an AI card built without a module renders an inert toggle', () => {
+		// Gated cards are built with no module (see getProductModules), which is
+		// what the card looked like before AI became a module: the generic
+		// branch renders a toggle that cannot be flipped.
+		window.myJetpackInitialState = {
+			myJetpackFlags: {},
+		} as unknown as Window[ 'myJetpackInitialState' ];
+		render(
+			<ProductCardAction
+				product={ buildProduct( {
+					slug: 'jetpack-ai',
+					name: 'AI',
+					status: 'active',
+					hasPaidPlanForProduct: true,
+				} ) }
+			/>
+		);
+
+		expect( screen.getByRole( 'checkbox' ) ).toBeDisabled();
+	} );
+
 	it( 'pre-release gate: the Forms toggle is unaffected by the flag', () => {
 		window.myJetpackInitialState = {
 			myJetpackFlags: {},

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/test/product-card-action.test.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/test/product-card-action.test.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router';
 import { ProductCamelCase } from '../../../../data/types';
 import { MyJetpackModule } from '../../../../types';
 import { setPendingSuccessNotice } from '../pending-notice';
@@ -48,6 +49,11 @@ const formsModule = { available: true, activated: true } as unknown as MyJetpack
 describe( 'ProductCardAction', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		// The suite renders as an internal tester by default so the AI toggle is
+		// visible; the pre-release gate tests below override this per test.
+		window.myJetpackInitialState = {
+			myJetpackFlags: { showAiModuleToggle: true },
+		} as unknown as Window[ 'myJetpackInitialState' ];
 	} );
 
 	it( 'renders the activation toggle for the Forms product instead of a Learn more link', () => {
@@ -88,6 +94,35 @@ describe( 'ProductCardAction', () => {
 		);
 
 		expect( screen.getByRole( 'checkbox' ) ).toBeChecked();
+	} );
+
+	it( 'pre-release gate: hides the AI toggle without the showAiModuleToggle flag', () => {
+		// Outside internal testing environments the AI card keeps its standard
+		// action: an inactive free product falls through to "Learn more".
+		window.myJetpackInitialState = {
+			myJetpackFlags: {},
+		} as unknown as Window[ 'myJetpackInitialState' ];
+		// UpgradeAction navigates to the interstitial, so it needs a router.
+		render(
+			<MemoryRouter>
+				<ProductCardAction
+					product={ buildProduct( { slug: 'jetpack-ai', name: 'AI', status: 'inactive' } ) }
+					module={ formsModule }
+				/>
+			</MemoryRouter>
+		);
+
+		expect( screen.getByRole( 'button', { name: /learn more/i } ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'checkbox' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'pre-release gate: the Forms toggle is unaffected by the flag', () => {
+		window.myJetpackInitialState = {
+			myJetpackFlags: {},
+		} as unknown as Window[ 'myJetpackInitialState' ];
+		render( <ProductCardAction product={ buildProduct() } module={ formsModule } /> );
+
+		expect( screen.getByRole( 'checkbox' ) ).toBeInTheDocument();
 	} );
 
 	it( 'disables the toggle when the Forms module is unavailable', () => {

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/use-filtered-plans.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/use-filtered-plans.ts
@@ -5,7 +5,7 @@ import { useAllProducts } from '../../../data/products/use-all-products';
 import { WP_Error } from '../../../data/types';
 import useSimpleQuery from '../../../data/use-simple-query';
 import { JetpackProductWithCard } from '../../../types';
-import { PRODUCT_MODULES } from './mappings';
+import { getProductModules } from './mappings';
 import { ProductSection } from './types';
 import { useAllJetpackModules } from './use-all-jetpack-modules';
 import { filterAndSortModules, filterSections } from './utils';
@@ -50,7 +50,7 @@ export function useFilteredPlans( { search }: UseFilteredPlansOptions ): {
 			id: String( purchase.ID ),
 			title: purchase.product_name,
 			cards: $products.map( ( [ slug, product ] ) => {
-				const moduleSlug = PRODUCT_MODULES[ slug ] || slug;
+				const moduleSlug = getProductModules()[ slug ] || slug;
 
 				return {
 					product,

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/use-filtered-products.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/use-filtered-products.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useAllProducts } from '../../../data/products/use-all-products';
-import { CATEGORY_CARDS_AND_MODULES, PRODUCT_MODULES } from './mappings';
+import { CATEGORY_CARDS_AND_MODULES, getProductModules } from './mappings';
 import { ProductFilter } from './types';
 import { useAllJetpackModules } from './use-all-jetpack-modules';
 import { buildCards, filterAndSortModules, getSectionTitle, searchAndRankItems } from './utils';
@@ -48,7 +48,7 @@ export function useFilteredProducts( { search, selectedFilter }: UseFilteredProd
 			ALL_CATEGORIES.map( ( [ category, { cards, modules } ] ) => ( {
 				id: category,
 				title: getSectionTitle( category ),
-				cards: buildCards( cards, allProducts, allModules, PRODUCT_MODULES ),
+				cards: buildCards( cards, allProducts, allModules, getProductModules() ),
 				modules: filterAndSortModules( modules.map( slug => allModules[ slug ] ) ),
 			} ) ),
 		[ allProducts, allModules ]

--- a/projects/packages/my-jetpack/_inc/constants.ts
+++ b/projects/packages/my-jetpack/_inc/constants.ts
@@ -100,6 +100,7 @@ export const PRODUCTS_NEEDING_RELOAD_AFTER_TOGGLE = [ 'jetpack-forms', 'videopre
  */
 export const JETPACK_NON_PAID_MODULES = [
 	'account-protection',
+	'ai',
 	'blaze',
 	'blocks',
 	'canonical-urls',

--- a/projects/packages/my-jetpack/_inc/constants.ts
+++ b/projects/packages/my-jetpack/_inc/constants.ts
@@ -92,7 +92,7 @@ export const PRODUCTS_MUST_HAVE_A_STANDALONE_PLUGIN = [ 'anti-spam', 'boost', 'c
  * deactivating them from My Jetpack must force a full page load so that UI is
  * re-rendered with the new state.
  */
-export const PRODUCTS_NEEDING_RELOAD_AFTER_TOGGLE = [ 'jetpack-forms', 'videopress' ];
+export const PRODUCTS_NEEDING_RELOAD_AFTER_TOGGLE = [ 'jetpack-ai', 'jetpack-forms', 'videopress' ];
 
 /**
  * Non-paid here means that the module is available for free users,

--- a/projects/packages/my-jetpack/_inc/utils/module-benefit-messages.ts
+++ b/projects/packages/my-jetpack/_inc/utils/module-benefit-messages.ts
@@ -19,6 +19,10 @@ function getModuleBenefitMessages(): Record< JetpackModuleSlug, string > {
 			'Your login page now has rate-limiting and secure authentication safeguards.',
 			'jetpack-my-jetpack'
 		),
+		ai: __(
+			'You can now generate and edit content, images, and more with Jetpack AI in the editor.',
+			'jetpack-my-jetpack'
+		),
 		blaze: __(
 			'You can now promote your posts across millions of sites in the WordPress.com and Tumblr ad network.',
 			'jetpack-my-jetpack'

--- a/projects/packages/my-jetpack/changelog/add-jetpack-ai-card-toggle-a11n-gate
+++ b/projects/packages/my-jetpack/changelog/add-jetpack-ai-card-toggle-a11n-gate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: limit the AI card's module toggle to internal testing environments ahead of release.

--- a/projects/packages/my-jetpack/changelog/add-jetpack-ai-master-switch-module
+++ b/projects/packages/my-jetpack/changelog/add-jetpack-ai-master-switch-module
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-My Jetpack: show an inline on/off toggle on the Jetpack AI product card in every state instead of a Learn more link, so the AI master switch can be toggled directly from the card

--- a/projects/packages/my-jetpack/changelog/add-jetpack-ai-master-switch-module
+++ b/projects/packages/my-jetpack/changelog/add-jetpack-ai-master-switch-module
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+My Jetpack: show an inline on/off toggle on the Jetpack AI product card in every state instead of a Learn more link, so the AI master switch can be toggled directly from the card

--- a/projects/packages/my-jetpack/changelog/add-jetpack-ai-module-product
+++ b/projects/packages/my-jetpack/changelog/add-jetpack-ai-module-product
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Jetpack AI: Drive the product card from the new AI module.
+Jetpack AI: Drive the product card from the new AI module with an inline on/off toggle.

--- a/projects/packages/my-jetpack/changelog/add-jetpack-ai-module-product
+++ b/projects/packages/my-jetpack/changelog/add-jetpack-ai-module-product
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Jetpack AI: Drive the product card from the new AI module.

--- a/projects/packages/my-jetpack/changelog/fix-jetpack-ai-card-reload
+++ b/projects/packages/my-jetpack/changelog/fix-jetpack-ai-card-reload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+My Jetpack: reload after toggling the AI card, so the toggle and every other surface reflect the new module state.

--- a/projects/packages/my-jetpack/global.d.ts
+++ b/projects/packages/my-jetpack/global.d.ts
@@ -483,6 +483,7 @@ interface Window {
 		loadAddLicenseScreen: string;
 		myJetpackCheckoutUri: string;
 		myJetpackFlags: {
+			showAiModuleToggle: boolean;
 			showFullJetpackStatsCard: boolean;
 			videoPressStats: boolean;
 		};

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -531,6 +531,11 @@ class Initializer {
 			// Only says which destination `manage_url` is: the legacy Stats page
 			// caches its report and wants a `force_refresh` hint the dashboard does not.
 			'premiumAnalyticsEnabled'  => Products\Stats::is_premium_analytics_enabled(),
+			// Pre-release gate: only internal testing environments get the AI
+			// card's module toggle. The helper lives in the Jetpack plugin, so
+			// standalone installs resolve to false. Remove when the AI settings
+			// page goes public.
+			'showAiModuleToggle'       => function_exists( 'jetpack_is_internal_testing_environment' ) && jetpack_is_internal_testing_environment(),
 		);
 
 		return $flags;

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -9,7 +9,7 @@ namespace Automattic\Jetpack\My_Jetpack\Products;
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\My_Jetpack\Initializer;
-use Automattic\Jetpack\My_Jetpack\Product;
+use Automattic\Jetpack\My_Jetpack\Module_Product;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 use WP_Post;
 
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Class responsible for handling the Jetpack AI product
  */
-class Jetpack_Ai extends Product {
+class Jetpack_Ai extends Module_Product {
 
 	const CURRENT_TIER_SLUG  = 'free';
 	const UPGRADED_TIER_SLUG = 'upgraded';
@@ -31,6 +31,13 @@ class Jetpack_Ai extends Product {
 	 * @var string
 	 */
 	public static $slug = 'jetpack-ai';
+
+	/**
+	 * The Jetpack module name associated with this product
+	 *
+	 * @var string
+	 */
+	public static $module_name = 'ai';
 
 	/**
 	 * The category of the product
@@ -539,7 +546,10 @@ class Jetpack_Ai extends Product {
 	/**
 	 * Checks whether the Product is active
 	 *
-	 * Overrides the parent method to respect the jetpack_ai_enabled filter.
+	 * Overrides Module_Product::is_active() to also respect the jetpack_ai_enabled
+	 * filter. The parent already checks that the Jetpack plugin and the 'ai' module
+	 * are active; this override layers the host/master-off signal on top so the
+	 * product card reflects it.
 	 *
 	 * @return boolean
 	 */

--- a/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
+++ b/projects/packages/my-jetpack/src/products/class-jetpack-ai.php
@@ -567,6 +567,29 @@ class Jetpack_Ai extends Module_Product {
 	}
 
 	/**
+	 * Whether the 'ai' module backs this product.
+	 *
+	 * Pre-release gate: the module-backed card is limited to internal testing
+	 * environments. Everywhere else this reports the module as active so the
+	 * product's status and every card built from it match the pre-module
+	 * behavior — the module state never surfaces in My Jetpack.
+	 *
+	 * Remove this override when the AI settings page goes public.
+	 *
+	 * @return bool
+	 */
+	public static function is_module_active() {
+		if (
+			! function_exists( 'jetpack_is_internal_testing_environment' ) ||
+			! jetpack_is_internal_testing_environment()
+		) {
+			return true;
+		}
+
+		return parent::is_module_active();
+	}
+
+	/**
 	 * Get data about the AI Assistant feature
 	 *
 	 * @return array

--- a/projects/packages/my-jetpack/tests/php/Initializer_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Initializer_Test.php
@@ -239,14 +239,16 @@ class Initializer_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The AI card's pre-release toggle flag is present and resolves false where
-	 * the Jetpack plugin's internal-testing helper is unavailable (standalone
-	 * installs, and this test environment).
+	 * The AI card's pre-release toggle flag follows the Jetpack plugin's
+	 * internal-testing helper.
 	 */
 	public function test_my_jetpack_flags_gate_the_ai_module_toggle() {
-		$flags = Initializer::get_my_jetpack_flags();
+		$GLOBALS['jetpack_mock_internal_testing_environment'] = true;
+		$this->assertTrue( Initializer::get_my_jetpack_flags()['showAiModuleToggle'] );
 
-		$this->assertArrayHasKey( 'showAiModuleToggle', $flags );
-		$this->assertFalse( $flags['showAiModuleToggle'] );
+		$GLOBALS['jetpack_mock_internal_testing_environment'] = false;
+		$this->assertFalse( Initializer::get_my_jetpack_flags()['showAiModuleToggle'] );
+
+		unset( $GLOBALS['jetpack_mock_internal_testing_environment'] );
 	}
 }

--- a/projects/packages/my-jetpack/tests/php/Initializer_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Initializer_Test.php
@@ -237,4 +237,16 @@ class Initializer_Test extends BaseTestCase {
 
 		return $location;
 	}
+
+	/**
+	 * The AI card's pre-release toggle flag is present and resolves false where
+	 * the Jetpack plugin's internal-testing helper is unavailable (standalone
+	 * installs, and this test environment).
+	 */
+	public function test_my_jetpack_flags_gate_the_ai_module_toggle() {
+		$flags = Initializer::get_my_jetpack_flags();
+
+		$this->assertArrayHasKey( 'showAiModuleToggle', $flags );
+		$this->assertFalse( $flags['showAiModuleToggle'] );
+	}
 }

--- a/projects/packages/my-jetpack/tests/php/Jetpack_Ai_Product_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Jetpack_Ai_Product_Test.php
@@ -2,7 +2,9 @@
 
 namespace Automattic\Jetpack\My_Jetpack;
 
+use Automattic\Jetpack\Connection\Tokens;
 use Automattic\Jetpack\My_Jetpack\Products\Jetpack_Ai;
+use Jetpack_Options;
 use PHPUnit\Framework\TestCase;
 use WorDBless\Options as WorDBless_Options;
 use WorDBless\Users as WorDBless_Users;
@@ -60,6 +62,13 @@ class Jetpack_Ai_Product_Test extends TestCase {
 		WorDBless_Users::init()->clear_all_users();
 		// Remove all filters to avoid interference between tests.
 		remove_all_filters( 'jetpack_ai_enabled' );
+		// Reset the mock Jetpack module state so it doesn't leak between tests.
+		if ( class_exists( 'Jetpack' ) && property_exists( 'Jetpack', 'active_modules' ) ) {
+			// @phan-suppress-next-line PhanUndeclaredStaticProperty -- Declared on the mock in ./assets/jetpack-mock-plugin.txt
+			\Jetpack::$active_modules = array();
+			// @phan-suppress-next-line PhanUndeclaredStaticProperty -- Declared on the mock in ./assets/jetpack-mock-plugin.txt
+			\Jetpack::$return_false = false;
+		}
 	}
 
 	/**
@@ -68,6 +77,13 @@ class Jetpack_Ai_Product_Test extends TestCase {
 	public function test_jetpack_ai_is_active_when_plugin_active() {
 		activate_plugins( 'jetpack/jetpack.php' );
 		$this->assertTrue( Jetpack_Ai::is_plugin_active() );
+	}
+
+	/**
+	 * Tests that the product declares the 'ai' Jetpack module.
+	 */
+	public function test_jetpack_ai_module_name_is_ai() {
+		$this->assertSame( 'ai', Jetpack_Ai::$module_name );
 	}
 
 	/**
@@ -89,10 +105,51 @@ class Jetpack_Ai_Product_Test extends TestCase {
 	public function test_jetpack_ai_respects_filter_when_enabled() {
 		activate_plugins( 'jetpack/jetpack.php' );
 
+		// Now that the product extends Module_Product, is_active() also requires the
+		// underlying 'ai' module to be active, so activate it for this scenario.
+		\Jetpack::activate_module( 'ai' );
+
 		// Add filter to enable AI (default behavior)
 		add_filter( 'jetpack_ai_enabled', '__return_true', 99 );
 
 		// Since AI has free offering and doesn't require a plan, is_active() should return true
 		$this->assertTrue( Jetpack_Ai::is_active() );
+	}
+
+	/**
+	 * Tests that is_active() stays false when the jetpack_ai_enabled filter is false
+	 * even if the underlying module is active. This proves the is_active() override
+	 * survived the switch to Module_Product as the base class.
+	 */
+	public function test_jetpack_ai_is_inactive_when_filter_off_even_if_module_active() {
+		activate_plugins( 'jetpack/jetpack.php' );
+
+		\Jetpack::activate_module( 'ai' );
+		$this->assertTrue( Jetpack_Ai::is_module_active() );
+
+		// The filter (host/master off) must override an otherwise-active module.
+		add_filter( 'jetpack_ai_enabled', '__return_false', 99 );
+
+		$this->assertFalse( Jetpack_Ai::is_active() );
+	}
+
+	/**
+	 * Tests that get_status() reports the module as disabled when the 'ai' module
+	 * is inactive, even with the plugin active and the site fully connected.
+	 */
+	public function test_jetpack_ai_status_is_module_disabled_when_module_inactive() {
+		// Mock a full connection so the module-disabled status is not masked by
+		// site/user connection errors in the parent get_status() flow.
+		( new Tokens() )->update_blog_token( 'test.test.1' );
+		( new Tokens() )->update_user_token( self::$user_id, 'test.test.' . self::$user_id, true );
+		Jetpack_Options::update_option( 'id', 123 );
+
+		activate_plugins( 'jetpack/jetpack.php' );
+
+		// Make sure the 'ai' module is not active.
+		\Jetpack::deactivate_module( 'ai' );
+
+		$this->assertFalse( Jetpack_Ai::is_module_active() );
+		$this->assertSame( Products::STATUS_MODULE_DISABLED, Jetpack_Ai::get_status() );
 	}
 }

--- a/projects/packages/my-jetpack/tests/php/Jetpack_Ai_Product_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Jetpack_Ai_Product_Test.php
@@ -62,6 +62,7 @@ class Jetpack_Ai_Product_Test extends TestCase {
 		WorDBless_Users::init()->clear_all_users();
 		// Remove all filters to avoid interference between tests.
 		remove_all_filters( 'jetpack_ai_enabled' );
+		unset( $GLOBALS['jetpack_mock_internal_testing_environment'] );
 		// Reset the mock Jetpack module state so it doesn't leak between tests.
 		if ( class_exists( 'Jetpack' ) && property_exists( 'Jetpack', 'active_modules' ) ) {
 			// @phan-suppress-next-line PhanUndeclaredStaticProperty -- Declared on the mock in ./assets/jetpack-mock-plugin.txt
@@ -151,5 +152,21 @@ class Jetpack_Ai_Product_Test extends TestCase {
 
 		$this->assertFalse( Jetpack_Ai::is_module_active() );
 		$this->assertSame( Products::STATUS_MODULE_DISABLED, Jetpack_Ai::get_status() );
+	}
+
+	/**
+	 * Pre-release gate: outside internal testing environments the product is not
+	 * module-backed at all, so an inactive module never surfaces — the status is
+	 * what it was before the module existed.
+	 */
+	public function test_jetpack_ai_ignores_the_module_outside_internal_testing() {
+		$GLOBALS['jetpack_mock_internal_testing_environment'] = false;
+
+		Jetpack_Options::update_option( 'id', 123 );
+		activate_plugins( 'jetpack/jetpack.php' );
+		\Jetpack::deactivate_module( 'ai' );
+
+		$this->assertTrue( Jetpack_Ai::is_module_active() );
+		$this->assertNotSame( Products::STATUS_MODULE_DISABLED, Jetpack_Ai::get_status() );
 	}
 }

--- a/projects/packages/my-jetpack/tests/php/assets/jetpack-mock-plugin.txt
+++ b/projects/packages/my-jetpack/tests/php/assets/jetpack-mock-plugin.txt
@@ -16,6 +16,14 @@ define( 'JETPACK__API_VERSION', 1 );
 define( 'JETPACK__PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'JETPACK__PLUGIN_FILE', __FILE__ );
 
+// Mirrors the real plugin's helper (functions.global.php). Defaults to true so
+// module-backed behavior is what tests see unless they opt out; flip
+// $GLOBALS['jetpack_mock_internal_testing_environment'] to exercise the
+// pre-release AI gate.
+function jetpack_is_internal_testing_environment() {
+	return $GLOBALS['jetpack_mock_internal_testing_environment'] ?? true;
+}
+
 class Jetpack {
 
 	static $active_modules = array();

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-settings.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-settings.php
@@ -148,7 +148,12 @@ class Jetpack_AI_Settings {
 					'type'              => 'boolean',
 					'description'       => $description,
 					'sanitize_callback' => 'rest_sanitize_boolean',
-					'show_in_rest'      => $show_in_rest,
+					// The master option is never exposed over core settings REST:
+					// off-Simple the `ai` module is the master and the option only
+					// holds the legacy pre-module opt-out (a core-REST write would
+					// clobber it without touching the real master); on Simple the
+					// dedicated feature-settings endpoint is the writable surface.
+					'show_in_rest'      => self::MASTER_OPTION === $option ? false : $show_in_rest,
 					'default'           => true,
 				)
 			);
@@ -156,18 +161,22 @@ class Jetpack_AI_Settings {
 	}
 
 	/**
-	 * Add the AI settings options to Jetpack Sync's option whitelist.
+	 * Add the per-feature AI options to Jetpack Sync's option whitelist.
 	 *
 	 * Atomic and self-hosted sites write these locally; syncing them lets
 	 * WordPress.com (Calypso, the multi-site dashboard) read toggle state and
 	 * is the prerequisite for mirroring the dashboard AI toggle later.
 	 *
+	 * The master switch is deliberately absent: off-Simple the `ai` module is
+	 * the master, and module state already reaches WordPress.com through the
+	 * synced `active_modules` callable — syncing the option as well would add
+	 * a second, driftable source of truth for the same bit.
+	 *
 	 * @param array $options Option names allowed to sync.
 	 * @return array Updated option names.
 	 */
 	public static function add_sync_options_whitelist( $options ) {
-		$options   = (array) $options;
-		$options[] = self::MASTER_OPTION;
+		$options = (array) $options;
 		foreach ( self::OWNED_FEATURES as $feature ) {
 			$options[] = self::FEATURE_OPTIONS[ $feature ];
 		}
@@ -250,7 +259,8 @@ class Jetpack_AI_Settings {
 	 * WordPress.com Simple no Jetpack modules run, so the `jetpack_ai_enabled`
 	 * option is the master. Everywhere else (self-hosted and Atomic) the `ai`
 	 * module is the real master switch, toggled through the standard Jetpack
-	 * module machinery; the option is only kept in sync for reference there.
+	 * module machinery; there the option only carries the legacy pre-module
+	 * value the one-time opt-out migration reads, and is never written again.
 	 *
 	 * @return bool
 	 */
@@ -281,14 +291,12 @@ class Jetpack_AI_Settings {
 			return;
 		}
 
+		// The module alone is the master off-Simple. The option is deliberately NOT
+		// written here: WordPress.com derives the master state from the synced
+		// `active_modules` callable, and the stored option must keep its legacy
+		// pre-module value so Jetpack::reconcile_ai_master_optout() can read an
+		// explicit opt-out on sites that upgrade later.
 		( new Modules() )->update_status( self::AI_MODULE, $enabled, false, false );
-
-		// The module is the authoritative master off-Simple, but keep the option in
-		// step with the module's *resulting* state so Jetpack Sync mirrors the right
-		// value to WordPress.com (Calypso / the multi-site dashboard read it — see
-		// self::add_sync_options_whitelist()). Reading it back means a blocked
-		// activation can't leave the synced option out of step with the module.
-		update_option( self::MASTER_OPTION, self::is_master_enabled() );
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-settings.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-ai-settings.php
@@ -20,6 +20,7 @@
  * @package automattic/jetpack
  */
 
+use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Status\Host;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -43,6 +44,14 @@ class Jetpack_AI_Settings {
 	 * @var string
 	 */
 	const MASTER_OPTION = 'jetpack_ai_enabled';
+
+	/**
+	 * Slug of the `ai` module that acts as the site-wide master switch off
+	 * WordPress.com Simple (self-hosted and Atomic), where modules run.
+	 *
+	 * @var string
+	 */
+	const AI_MODULE = 'ai';
 
 	/**
 	 * Feature key => option name for every toggle on the AI settings page.
@@ -237,10 +246,49 @@ class Jetpack_AI_Settings {
 	/**
 	 * Gate 3: whether the site-wide AI master switch is on.
 	 *
+	 * The master lives in a different place depending on the platform. On
+	 * WordPress.com Simple no Jetpack modules run, so the `jetpack_ai_enabled`
+	 * option is the master. Everywhere else (self-hosted and Atomic) the `ai`
+	 * module is the real master switch, toggled through the standard Jetpack
+	 * module machinery; the option is only kept in sync for reference there.
+	 *
 	 * @return bool
 	 */
 	public static function is_master_enabled() {
-		return (bool) get_option( self::MASTER_OPTION, true );
+		if ( ( new Host() )->is_wpcom_simple() ) {
+			return (bool) get_option( self::MASTER_OPTION, true );
+		}
+
+		return ( new Modules() )->is_active( self::AI_MODULE );
+	}
+
+	/**
+	 * Set the site-wide AI master switch, writing to whichever store backs it on
+	 * this platform (see {@see self::is_master_enabled()}).
+	 *
+	 * On WordPress.com Simple the `jetpack_ai_enabled` option is the master, so
+	 * we update it. Off-Simple the `ai` module is the master, so we activate or
+	 * deactivate it. The no-exit / no-redirect arguments are passed to
+	 * `Modules::update_status()` so this is safe to call outside a request that
+	 * expects to terminate (REST handlers, migrations, CLI).
+	 *
+	 * @param bool $enabled Whether AI should be enabled site-wide.
+	 * @return void
+	 */
+	public static function set_master_enabled( bool $enabled ) {
+		if ( ( new Host() )->is_wpcom_simple() ) {
+			update_option( self::MASTER_OPTION, $enabled );
+			return;
+		}
+
+		( new Modules() )->update_status( self::AI_MODULE, $enabled, false, false );
+
+		// The module is the authoritative master off-Simple, but keep the option in
+		// step with the module's *resulting* state so Jetpack Sync mirrors the right
+		// value to WordPress.com (Calypso / the multi-site dashboard read it — see
+		// self::add_sync_options_whitelist()). Reading it back means a blocked
+		// activation can't leave the synced option out of step with the module.
+		update_option( self::MASTER_OPTION, self::is_master_enabled() );
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai-feature-settings.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai-feature-settings.php
@@ -146,7 +146,10 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings extends WP_REST_Controller 
 		}
 
 		if ( $request->has_param( 'master_enabled' ) ) {
-			update_option( Jetpack_AI_Settings::MASTER_OPTION, (bool) $request->get_param( 'master_enabled' ) );
+			// Routes through the setter so the write lands on whichever store backs
+			// the master on this platform: the option on Simple, the `ai` module
+			// off-Simple.
+			Jetpack_AI_Settings::set_master_enabled( (bool) $request->get_param( 'master_enabled' ) );
 		}
 
 		$features = $request->get_param( 'features' );

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-drop-master-option-mirror
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-drop-master-option-mirror
@@ -1,4 +1,0 @@
-Significance: patch
-Type: other
-
-AI: Stop mirroring the ai module state into the jetpack_ai_enabled option off WordPress.com Simple; the synced active_modules list is the single source of truth for the master switch, and the option is no longer exposed over core settings REST.

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-drop-master-option-mirror
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-drop-master-option-mirror
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI: Stop mirroring the ai module state into the jetpack_ai_enabled option off WordPress.com Simple; the synced active_modules list is the single source of truth for the master switch, and the option is no longer exposed over core settings REST.

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-master-switch-enforcement
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-master-switch-enforcement
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+AI: Make the Jetpack AI module the site-wide master switch on self-hosted and Atomic, preserving explicit opt-outs.

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-master-switch-enforcement
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-master-switch-enforcement
@@ -1,4 +1,0 @@
-Significance: minor
-Type: enhancement
-
-AI: Make the Jetpack AI module the site-wide master switch on self-hosted and Atomic, preserving explicit opt-outs.

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-module
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-module
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+AI: Add a Jetpack AI module so the feature can be toggled site-wide.

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-module
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-module
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-AI: Add a Jetpack AI module so the feature can be toggled site-wide.
+AI: Add a Jetpack AI module as the site-wide master switch on self-hosted and Atomic, preserving explicit opt-outs.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -495,7 +495,7 @@ class Jetpack {
 					self::update_active_modules( $modules );
 				}
 
-				add_action( 'init', array( __CLASS__, 'activate_new_modules' ) );
+				self::register_upgrade_init_hooks();
 
 				// Upgrade to 4.3.0.
 				if ( Jetpack_Options::get_option( 'identity_crisis_whitelist' ) ) {
@@ -3023,6 +3023,74 @@ p {
 		if ( self::is_module_active( 'subscriptions' ) || self::activate_module( 'subscriptions', false, false ) ) {
 			update_option( 'jetpack_subscriptions_default_on_migrated', true );
 		}
+	}
+
+	/**
+	 * Option flag that records the AI master-switch opt-out reconciliation has run,
+	 * so it never runs twice.
+	 *
+	 * @var string
+	 */
+	const AI_MASTER_OPTOUT_MIGRATED_OPTION = 'jetpack_ai_master_optout_migrated';
+
+	/**
+	 * Register the on-upgrade init hooks whose relative ORDER matters, extracted so
+	 * the ordering can be asserted in tests without invoking plugin_upgrade() (whose
+	 * guards make it unreliable to trigger under test). activate_new_modules()
+	 * (init, default priority 10) auto-activates "Auto Activate: Yes" modules
+	 * including the `ai` master; reconcile_ai_master_optout() must run at a LATER
+	 * priority to honor an explicit AI opt-out.
+	 *
+	 * @return void
+	 */
+	public static function register_upgrade_init_hooks() {
+		add_action( 'init', array( __CLASS__, 'activate_new_modules' ) );
+		add_action( 'init', array( __CLASS__, 'reconcile_ai_master_optout' ), 20 );
+	}
+
+	/**
+	 * Preserves an explicit Jetpack AI opt-out when the `ai` module becomes the site-wide
+	 * master switch off WordPress.com Simple (self-hosted and Atomic).
+	 *
+	 * The `ai` module is "Auto Activate: Yes", so on upgrade {@see self::activate_new_modules()}
+	 * turns it on for connected sites — the desired default-on / auto-enable-on-connection
+	 * behavior, which this method deliberately leaves alone. The one case it corrects is a site
+	 * that had explicitly disabled Jetpack AI (the `jetpack_ai_enabled` option present and falsey)
+	 * before the module shipped: that opt-out must survive the module becoming the master, so the
+	 * module is deactivated for exactly those sites. An absent or truthy option is left untouched.
+	 *
+	 * Ordering is the whole point. `activate_new_modules()` is hooked on `init` at priority 10 and
+	 * auto-activates the module there; this method is hooked on `init` at priority 20 (see
+	 * {@see self::plugin_upgrade()}), so it runs AFTER the auto-activation and its deactivation is
+	 * the final state. A version-guarded block that ran inline during `plugins_loaded` would be
+	 * undone by the later auto-activation, which is why this is a late-init hook rather than an
+	 * inline upgrade step.
+	 *
+	 * WordPress.com Simple never runs modules — the option stays the master there — so this is a
+	 * no-op on Simple. The {@see self::AI_MASTER_OPTOUT_MIGRATED_OPTION} flag makes it run exactly
+	 * once, which matters because off-Simple the option is no longer the master after this runs:
+	 * a stale falsey option must not keep re-deactivating a module the user later turns back on.
+	 *
+	 * @return void
+	 */
+	public static function reconcile_ai_master_optout() {
+		if ( get_option( self::AI_MASTER_OPTOUT_MIGRATED_OPTION ) ) {
+			return;
+		}
+
+		// Simple keeps the `jetpack_ai_enabled` option as the master; modules don't run there.
+		if ( ( new Host() )->is_wpcom_simple() ) {
+			return;
+		}
+
+		// A sentinel default distinguishes an absent option (leave auto-activation alone) from one
+		// explicitly stored falsey (an opt-out to preserve).
+		$stored = get_option( 'jetpack_ai_enabled', 'not-set' );
+		if ( 'not-set' !== $stored && ! (bool) $stored ) {
+			( new Modules() )->deactivate( 'ai' );
+		}
+
+		update_option( self::AI_MASTER_OPTOUT_MIGRATED_OPTION, true );
 	}
 
 	/**

--- a/projects/plugins/jetpack/modules/ai.php
+++ b/projects/plugins/jetpack/modules/ai.php
@@ -1,0 +1,30 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Module Name: AI
+ * Module Description: Turn your ideas into ready-to-publish content and generate images with the power of AI.
+ * Sort Order: 40
+ * Recommendation Order: 15
+ * First Introduced: 16.2
+ * Requires Connection: Yes
+ * Requires User Connection: Yes
+ * Auto Activate: Yes
+ * Module Tags: Writing
+ * Feature: Writing
+ * Additional Search Queries: ai, artificial intelligence, jetpack ai, ai assistant, generate, content, images
+ *
+ * @package automattic/jetpack
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
+/*
+ * This module is intentionally a toggle only: it bootstraps no code of its own.
+ *
+ * Jetpack AI enforcement already lives in `_inc/lib/class-jetpack-ai-settings.php`,
+ * which self-initializes on load, so there is nothing to wire up here. The module
+ * exists so that Jetpack AI can be turned on and off site-wide through the standard
+ * Jetpack module machinery (and, for existing sites, keep auto-enabling on connection
+ * via the normal module upgrade routine). Deliberately leave the body empty.
+ */

--- a/projects/plugins/jetpack/tests/php/bootstrap.php
+++ b/projects/plugins/jetpack/tests/php/bootstrap.php
@@ -116,6 +116,7 @@ if ( '1' !== getenv( 'JETPACK_TEST_WOOCOMMERCE' ) ) {
 }
 
 require __DIR__ . '/lib/mock-functions.php';
+require __DIR__ . '/lib/trait-activates-ai-module.php';
 require __DIR__ . '/lib/CallableMock.php';
 require __DIR__ . '/_inc/lib/mocks/simplepie.php';
 require $test_root . '/includes/functions.php';

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test.php
@@ -12,6 +12,7 @@
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Current_Plan;
+use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Search\Plan as Search_Plan;
 use Automattic\Jetpack\Status\Cache as StatusCache;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -97,6 +98,7 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 
 		remove_all_filters( 'ai_seo_enhancer_enabled' );
 		remove_all_filters( 'jetpack_active_modules' );
+		\Jetpack_Options::update_option( 'active_modules', array() );
 		// Only our own priority, so an environment's plan pin survives.
 		remove_all_filters( self::PLAN_FILTER, self::PLAN_FILTER_PRIORITY );
 		self::reset_active_plan_cache();
@@ -162,6 +164,30 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 				$modules = array_diff( (array) $modules, array( 'seo-tools' ) );
 				if ( $active ) {
 					$modules[] = 'seo-tools';
+				}
+				return array_values( $modules );
+			}
+		);
+	}
+
+	/**
+	 * Force the `ai` module — the site-wide master switch off WordPress.com
+	 * Simple — on or off.
+	 *
+	 * Off-Simple the master lives in the `ai` module, not the
+	 * `jetpack_ai_enabled` option, so tests drive it here. Filtering is applied
+	 * last in `Modules::get_active()` (after the availability intersection), so
+	 * it controls the master regardless of which modules the build ships.
+	 *
+	 * @param bool $active Whether the master (the `ai` module) should be on.
+	 */
+	private static function set_ai_module_active( $active ) {
+		add_filter(
+			'jetpack_active_modules',
+			static function ( $modules ) use ( $active ) {
+				$modules = array_diff( (array) $modules, array( 'ai' ) );
+				if ( $active ) {
+					$modules[] = 'ai';
 				}
 				return array_values( $modules );
 			}
@@ -277,6 +303,7 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 	public function test_feature_clip_available_in_normal_environment() {
 		wp_set_current_user( self::$admin_id );
 		self::connect_owner();
+		self::set_ai_module_active( true );
 
 		$this->assertTrue( $this->get_feature_clip_available() );
 	}
@@ -290,7 +317,8 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 		wp_set_current_user( self::$admin_id );
 		self::connect_owner();
 
-		update_option( Jetpack_AI_Settings::MASTER_OPTION, false );
+		// Off-Simple the master is the `ai` module; turn it off.
+		self::set_ai_module_active( false );
 
 		$this->assertFalse( $this->get_feature_clip_available() );
 	}
@@ -303,6 +331,7 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 	public function test_feature_clip_unavailable_when_image_editor_off() {
 		wp_set_current_user( self::$admin_id );
 		self::connect_owner();
+		self::set_ai_module_active( true );
 
 		update_option( Jetpack_AI_Settings::FEATURE_OPTIONS['image_editor'], false );
 
@@ -379,6 +408,8 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 	 */
 	public function test_get_returns_gate_state_and_defaults() {
 		wp_set_current_user( self::$admin_id );
+		// Off-Simple the master is the `ai` module; turn it on for the default shape.
+		self::set_ai_module_active( true );
 
 		$response = $this->dispatch( 'GET' );
 		$data     = $response->get_data();
@@ -552,9 +583,15 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings_Test extends Jetpack_REST_T
 	public function test_post_master_switch() {
 		wp_set_current_user( self::$admin_id );
 
+		// Off-Simple the master is the `ai` module; start it active so the write
+		// actually flips state and we exercise the setter's module routing.
+		\Jetpack_Options::update_option( 'active_modules', array( 'ai' ) );
+		$this->assertTrue( ( new Modules() )->is_active( 'ai' ), 'Precondition: the master is on.' );
+
 		$data = $this->dispatch( 'POST', array( 'master_enabled' => false ) )->get_data();
 
 		$this->assertFalse( $data['master_enabled'] );
+		$this->assertFalse( ( new Modules() )->is_active( 'ai' ), 'The setter routed the write to the ai module.' );
 		$this->assertFalse( apply_filters( 'jetpack_ai_enabled', true ) );
 	}
 

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_AI_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_AI_Test.php
@@ -24,6 +24,8 @@ require_once dirname( __DIR__, 2 ) . '/lib/Jetpack_REST_TestCase.php';
 #[CoversClass( WPCOM_REST_API_V2_Endpoint_AI::class )]
 class WPCOM_REST_API_V2_Endpoint_AI_Test extends Jetpack_REST_TestCase {
 
+	use \Activates_Ai_Module;
+
 	const BASIC_ROUTE        = '/wpcom/v2/jetpack-ai/ai-assistant-feature';
 	const GATED_ROUTE        = '/wpcom/v2/jetpack-ai/completions';
 	const GATED_IMAGES_ROUTE = '/wpcom/v2/jetpack-ai/images/generations';
@@ -39,7 +41,19 @@ class WPCOM_REST_API_V2_Endpoint_AI_Test extends Jetpack_REST_TestCase {
 	 * `jetpack_ai_chat_enabled` filter (e.g. on WordPress.com) and leak that
 	 * into later tests.
 	 */
+	/**
+	 * Off-Simple the `ai` module is the AI master, and the gated routes now register
+	 * only when is_ai_enabled() — which reads the module — is true. The PHPUnit env
+	 * never activates it, so force it on; the disabled cases force the gate off via
+	 * the jetpack_ai_enabled filter, which wins regardless of module state.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->activate_ai_module_for_test();
+	}
+
 	public function tear_down() {
+		$this->deactivate_ai_module_for_test();
 		remove_filter( 'jetpack_ai_enabled', '__return_false' );
 		remove_filter( 'jetpack_ai_enabled', '__return_true' );
 		remove_filter( 'jetpack_ai_chat_enabled', '__return_false' );

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Agent_Guidelines_AI_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Agent_Guidelines_AI_Test.php
@@ -22,6 +22,8 @@ require_once dirname( __DIR__, 2 ) . '/lib/Jetpack_REST_TestCase.php';
 #[CoversClass( WPCOM_REST_API_V2_Endpoint_Agent_Guidelines_AI::class )]
 class WPCOM_REST_API_V2_Endpoint_Agent_Guidelines_AI_Test extends Jetpack_REST_TestCase {
 
+	use \Activates_Ai_Module;
+
 	const ROUTE = '/wpcom/v2/jetpack-ai/suggest-guidelines';
 
 	/**
@@ -31,7 +33,18 @@ class WPCOM_REST_API_V2_Endpoint_Agent_Guidelines_AI_Test extends Jetpack_REST_T
 	 * which would also drop a platform-registered `jetpack_ai_enabled` filter
 	 * (e.g. on WordPress.com) and leak that into later tests.
 	 */
+	/**
+	 * Off-Simple the `ai` module is the AI master and the gated route registers only
+	 * when is_ai_enabled() (which reads the module) is true; the PHPUnit env never
+	 * activates it, so force it on. Disabled cases force the gate off via the filter.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->activate_ai_module_for_test();
+	}
+
 	public function tear_down() {
+		$this->deactivate_ai_module_for_test();
 		remove_filter( 'jetpack_ai_enabled', '__return_false' );
 		remove_filter( 'jetpack_ai_enabled', '__return_true' );
 

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/ai-assistant/AI_Assistant_Block_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/ai-assistant/AI_Assistant_Block_Test.php
@@ -15,6 +15,7 @@ require_once JETPACK__PLUGIN_DIR . '/extensions/blocks/ai-assistant/ai-assistant
  */
 class AI_Assistant_Block_Test extends WP_UnitTestCase {
 	use Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+	use \Activates_Ai_Module;
 
 	const BLOCK_NAME = 'jetpack/ai-assistant';
 
@@ -38,7 +39,9 @@ class AI_Assistant_Block_Test extends WP_UnitTestCase {
 		delete_option( 'jetpack_ai_enabled' );
 		delete_option( 'jetpack_ai_writing_assistant_enabled' );
 		delete_option( 'jetpack_ai_image_editor_enabled' );
-		update_option( 'jetpack_ai_enabled', 1 );
+		// Off-Simple the `ai` module is the master switch (the option is ignored
+		// there), so activate the module to put the master on.
+		$this->activate_ai_module_for_test();
 
 		$this->registered_block = WP_Block_Type_Registry::get_instance()->get_registered( self::BLOCK_NAME );
 		if ( $this->registered_block ) {
@@ -57,6 +60,7 @@ class AI_Assistant_Block_Test extends WP_UnitTestCase {
 			WP_Block_Type_Registry::get_instance()->register( $this->registered_block );
 		}
 
+		$this->deactivate_ai_module_for_test();
 		delete_option( 'jetpack_ai_enabled' );
 		delete_option( 'jetpack_ai_writing_assistant_enabled' );
 		delete_option( 'jetpack_ai_image_editor_enabled' );
@@ -95,7 +99,8 @@ class AI_Assistant_Block_Test extends WP_UnitTestCase {
 	 * The master toggle prevents both the block and its extensions from registering.
 	 */
 	public function test_block_and_extensions_not_registered_when_master_disabled() {
-		update_option( 'jetpack_ai_enabled', 0 );
+		// Off-Simple the master is the `ai` module; turn it off there.
+		$this->deactivate_ai_module_for_test();
 
 		AIAssistant\register_block();
 		do_action( 'jetpack_register_gutenberg_extensions' );

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/ai-chat/AI_Chat_Block_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/ai-chat/AI_Chat_Block_Test.php
@@ -19,6 +19,7 @@ require_once JETPACK__PLUGIN_DIR . '/extensions/blocks/ai-chat/ai-chat.php';
  */
 class AI_Chat_Block_Test extends \WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+	use \Activates_Ai_Module;
 
 	const BLOCK_NAME = 'jetpack/ai-chat';
 
@@ -37,6 +38,9 @@ class AI_Chat_Block_Test extends \WP_UnitTestCase {
 
 		add_filter( 'jetpack_offline_mode', '__return_false' );
 		$this->simulate_connected_owner();
+		// Off-Simple the `ai` module is the AI master switch; activate it so the
+		// jetpack_ai_enabled gate reads on.
+		$this->activate_ai_module_for_test();
 
 		$this->registered_block = WP_Block_Type_Registry::get_instance()->get_registered( self::BLOCK_NAME );
 		if ( $this->registered_block ) {
@@ -55,6 +59,7 @@ class AI_Chat_Block_Test extends \WP_UnitTestCase {
 			WP_Block_Type_Registry::get_instance()->register( $this->registered_block );
 		}
 
+		$this->deactivate_ai_module_for_test();
 		remove_filter( 'jetpack_ai_enabled', '__return_false' );
 		remove_filter( 'jetpack_offline_mode', '__return_false' );
 		delete_option( 'jetpack_ai_enabled' );
@@ -105,7 +110,8 @@ class AI_Chat_Block_Test extends \WP_UnitTestCase {
 	 * The AI master switch option turns the block off.
 	 */
 	public function test_not_registered_when_master_option_off() {
-		update_option( 'jetpack_ai_enabled', 0 );
+		// Off-Simple the master is the `ai` module; turn it off there.
+		$this->deactivate_ai_module_for_test();
 
 		AIChat\register_block();
 

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-assistant-plugin/AI_Assistant_Plugin_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-assistant-plugin/AI_Assistant_Plugin_Test.php
@@ -15,11 +15,23 @@ require_once JETPACK__PLUGIN_DIR . '/extensions/plugins/ai-assistant-plugin/ai-a
  */
 class AI_Assistant_Plugin_Test extends WP_UnitTestCase {
 	use Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+	use \Activates_Ai_Module;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		// Off-Simple the `ai` module is the AI master switch; activate it so the
+		// legacy panel's jetpack_ai_enabled gate reads on.
+		$this->activate_ai_module_for_test();
+	}
 
 	/**
 	 * Tear down after each test.
 	 */
 	public function tear_down() {
+		$this->deactivate_ai_module_for_test();
 		unregister_setting( 'general', 'jetpack_ai_agents_enabled' );
 		Constants::clear_single_constant( 'IS_WPCOM' );
 
@@ -148,7 +160,8 @@ class AI_Assistant_Plugin_Test extends WP_UnitTestCase {
 	public function test_not_registered_when_master_option_off() {
 		$this->reset_availability();
 		$this->simulate_connected_owner();
-		update_option( 'jetpack_ai_enabled', 0 );
+		// Off-Simple the master is the `ai` module; turn it off there.
+		$this->deactivate_ai_module_for_test();
 
 		AiAssistantPlugin\register_plugin();
 

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-assistant-plugin/reader-chat/Jetpack_Reader_Chat_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-assistant-plugin/reader-chat/Jetpack_Reader_Chat_Test.php
@@ -17,6 +17,7 @@ require_once JETPACK__PLUGIN_DIR . '/extensions/plugins/ai-assistant-plugin/read
  */
 class Jetpack_Reader_Chat_Test extends WP_UnitTestCase {
 	use Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+	use \Activates_Ai_Module;
 
 	/**
 	 * Saved wp_scripts global.
@@ -47,6 +48,9 @@ class Jetpack_Reader_Chat_Test extends WP_UnitTestCase {
 		// tests that don't intend to simulate an AJAX request.
 		add_filter( 'wp_doing_ajax', '__return_false' );
 		$this->simulate_connected_owner();
+		// Off-Simple the `ai` module is the AI master switch; activate it so the
+		// default has_ai_features() path (jetpack_ai_enabled) reads on.
+		$this->activate_ai_module_for_test();
 		$this->set_search_plan_access( true );
 	}
 
@@ -54,6 +58,7 @@ class Jetpack_Reader_Chat_Test extends WP_UnitTestCase {
 	 * Tear down after each test.
 	 */
 	public function tear_down() {
+		$this->deactivate_ai_module_for_test();
 		delete_transient( AiAssistantPlugin\READER_CHAT_ASSET_TRANSIENT );
 		remove_all_filters( 'jetpack_reader_chat_enabled' );
 		remove_all_filters( 'jetpack_reader_chat_enqueue_enabled' );

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-content-lens/AI_Content_Lens_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-content-lens/AI_Content_Lens_Test.php
@@ -18,6 +18,7 @@ require_once JETPACK__PLUGIN_DIR . '/extensions/plugins/ai-content-lens/ai-conte
  */
 class AI_Content_Lens_Test extends \WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+	use \Activates_Ai_Module;
 
 	/**
 	 * Set up before each test.
@@ -26,12 +27,16 @@ class AI_Content_Lens_Test extends \WP_UnitTestCase {
 		parent::set_up();
 		$this->reset_availability();
 		$this->simulate_connected_owner();
+		// Off-Simple the `ai` module is the AI master switch; activate it so the
+		// jetpack_ai_enabled gate reads on.
+		$this->activate_ai_module_for_test();
 	}
 
 	/**
 	 * Tear down after each test.
 	 */
 	public function tear_down() {
+		$this->deactivate_ai_module_for_test();
 		remove_filter( 'jetpack_ai_enabled', '__return_false' );
 		delete_option( 'jetpack_ai_writing_assistant_enabled' );
 		delete_option( 'jetpack_ai_enabled' );
@@ -84,7 +89,8 @@ class AI_Content_Lens_Test extends \WP_UnitTestCase {
 	 * The AI master switch option turns the extension off.
 	 */
 	public function test_not_registered_when_master_option_off() {
-		update_option( 'jetpack_ai_enabled', 0 );
+		// Off-Simple the master is the `ai` module; turn it off there.
+		$this->deactivate_ai_module_for_test();
 
 		Content_Lens\register_plugin();
 

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -17,6 +17,7 @@ require_once JETPACK__PLUGIN_DIR . '/extensions/plugins/ai-assistant-plugin/ai-s
  */
 class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	use Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+	use \Activates_Ai_Module;
 
 	/**
 	 * Saved wp_scripts global.
@@ -64,6 +65,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->saved_screen          = $GLOBALS['current_screen'] ?? null;
 		$this->saved_current_user_id = get_current_user_id();
 		$this->simulate_connected_owner();
+		// Off-Simple the `ai` module is the AI master switch; activate it so the
+		// AI-features gate behind these surfaces reads on.
+		$this->activate_ai_module_for_test();
 		// Enable the sidebar by default via the override filter so the behaviour
 		// tests exercise the downstream wiring. has_ai_features() stays on the
 		// self-hosted connection path. The wpcom/Big Sky gating itself is covered
@@ -75,6 +79,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * Tear down after each test.
 	 */
 	public function tear_down() {
+		$this->deactivate_ai_module_for_test();
 		delete_transient( AiAssistantPlugin\AI_SIDEBAR_ASSET_TRANSIENT );
 		$this->reset_sidebar_hooks();
 		remove_all_filters( 'pre_http_request' );

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/image-studio/Image_Studio_Test.php
@@ -18,6 +18,7 @@ require_once JETPACK__PLUGIN_DIR . '/extensions/plugins/ai-assistant-plugin/ai-a
  */
 class Image_Studio_Test extends \WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+	use \Activates_Ai_Module;
 
 	/**
 	 * Get the AI image extensions list from the source function.
@@ -70,6 +71,9 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		$GLOBALS['wp_styles']   = new WP_Styles();
 		$this->reset_availability();
 		$this->simulate_connected_owner();
+		// Off-Simple the `ai` module is the AI master switch, so activate it to put
+		// the master on. The PHPUnit env never runs activate_default_modules().
+		$this->activate_ai_module_for_test();
 		// Ensure Big Sky is disabled by default so tests aren't affected by the
 		// Big_Sky class persisting across tests once simulate_big_sky_class() runs.
 		update_option( 'big_sky_enable', '0' );
@@ -81,6 +85,7 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	 * Tear down after each test.
 	 */
 	public function tear_down() {
+		$this->deactivate_ai_module_for_test();
 		delete_transient( ImageStudio\ASSET_TRANSIENT );
 		remove_all_filters( 'jetpack_image_studio_enabled' );
 		remove_all_filters( 'jetpack_image_studio_can_generate_video_clips' );
@@ -518,7 +523,8 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	 * Big Sky/CIAB environments (it flows through the jetpack_ai_enabled filter).
 	 */
 	public function test_master_option_off_disables_image_studio() {
-		update_option( 'jetpack_ai_enabled', 0 );
+		// Off-Simple the master is the `ai` module; turn it off there.
+		$this->deactivate_ai_module_for_test();
 
 		$this->assertFalse( ImageStudio\is_image_studio_enabled() );
 	}
@@ -530,7 +536,8 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 		$this->enable_big_sky();
 		$this->assertTrue( ImageStudio\is_image_studio_enabled() );
 
-		update_option( 'jetpack_ai_enabled', 0 );
+		// Off-Simple the master is the `ai` module; turn it off there.
+		$this->deactivate_ai_module_for_test();
 		$this->set_block_editor_screen();
 		ImageStudio\register_plugin();
 		set_transient(
@@ -559,7 +566,8 @@ class Image_Studio_Test extends \WP_UnitTestCase {
 	 */
 	public function test_master_off_cannot_be_reenabled_by_late_filter() {
 		$this->enable_big_sky();
-		update_option( 'jetpack_ai_enabled', 0 );
+		// Off-Simple the master is the `ai` module; turn it off there.
+		$this->deactivate_ai_module_for_test();
 		add_filter( 'jetpack_ai_enabled', '__return_true', 99 );
 
 		$this->assertFalse( ImageStudio\is_image_studio_environment_available() );

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Master_Optout_Migration_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Master_Optout_Migration_Test.php
@@ -1,0 +1,181 @@
+<?php
+/**
+ * Tests for the Jetpack AI master-switch opt-out migration.
+ *
+ * When the `ai` module becomes the site-wide master switch off WordPress.com
+ * Simple, it is "Auto Activate: Yes", so activate_new_modules() turns it on for
+ * connected sites on upgrade — the desired default-on / auto-enable behavior.
+ * The one thing that must not happen is silently re-enabling AI on a site that
+ * had explicitly opted out (the jetpack_ai_enabled option present and falsey).
+ * {@see Jetpack::reconcile_ai_master_optout()} runs at a later init priority than
+ * the auto-activation and deactivates the module for exactly those sites.
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Modules;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+/**
+ * Class Jetpack_AI_Master_Optout_Migration_Test
+ *
+ * @covers \Jetpack
+ */
+#[CoversClass( Jetpack::class )]
+class Jetpack_AI_Master_Optout_Migration_Test extends \WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Reset the platform, the migration guard, the option, and module state.
+	 */
+	public function tear_down() {
+		delete_option( 'jetpack_ai_enabled' );
+		delete_option( Jetpack::AI_MASTER_OPTOUT_MIGRATED_OPTION );
+		Constants::set_constant( 'IS_WPCOM', false );
+		\Jetpack_Options::update_option( 'active_modules', array() );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Put the site off-Simple with the `ai` module already auto-activated, as
+	 * activate_new_modules() would leave it on upgrade.
+	 */
+	private function set_up_auto_activated_off_simple() {
+		Constants::set_constant( 'IS_WPCOM', false );
+		\Jetpack_Options::update_option( 'active_modules', array( 'ai' ) );
+		$this->assertTrue( ( new Modules() )->is_active( 'ai' ), 'Precondition: the module is auto-activated.' );
+	}
+
+	/**
+	 * THE safety property: a site that explicitly opted out (option present and
+	 * falsey) ends with the module INACTIVE, even though auto-activation turned it
+	 * on first. Reconciliation runs after auto-activation and has the final word.
+	 */
+	public function test_explicit_optout_survives_auto_activation() {
+		update_option( 'jetpack_ai_enabled', 0 );
+		$this->set_up_auto_activated_off_simple();
+
+		Jetpack::reconcile_ai_master_optout();
+
+		$this->assertFalse(
+			( new Modules() )->is_active( 'ai' ),
+			'An explicit opt-out must survive the module becoming the master: the module ends inactive.'
+		);
+	}
+
+	/**
+	 * The same safety property, but with the module activated through the REAL path
+	 * Modules::update_active() (as activate_default_modules() does on upgrade), which
+	 * fires jetpack_activate_module_ai. The seed-active_modules-directly tests never
+	 * exercise that hook: this guards against any module-activation side effect
+	 * overwriting the jetpack_ai_enabled opt-out before reconcile reads it.
+	 */
+	public function test_explicit_optout_survives_auto_activation_via_module_hook() {
+		Constants::set_constant( 'IS_WPCOM', false );
+		update_option( 'jetpack_ai_enabled', 0 );
+
+		// Auto-activation, the way the upgrade routine really does it.
+		( new Modules() )->update_active( array( 'ai' ) );
+
+		Jetpack::reconcile_ai_master_optout();
+
+		$this->assertFalse(
+			( new Modules() )->is_active( 'ai' ),
+			'An explicit opt-out must survive auto-activation run through the module hook.'
+		);
+	}
+
+	/**
+	 * An absent option means no explicit opt-out, so auto-activation is preserved
+	 * (default-on / auto-enable-on-connection).
+	 */
+	public function test_absent_option_leaves_module_active() {
+		delete_option( 'jetpack_ai_enabled' );
+		$this->set_up_auto_activated_off_simple();
+
+		Jetpack::reconcile_ai_master_optout();
+
+		$this->assertTrue( ( new Modules() )->is_active( 'ai' ), 'No opt-out: auto-activation is preserved.' );
+	}
+
+	/**
+	 * A truthy option is not an opt-out, so the module stays active.
+	 */
+	public function test_truthy_option_leaves_module_active() {
+		update_option( 'jetpack_ai_enabled', 1 );
+		$this->set_up_auto_activated_off_simple();
+
+		Jetpack::reconcile_ai_master_optout();
+
+		$this->assertTrue( ( new Modules() )->is_active( 'ai' ) );
+	}
+
+	/**
+	 * The migration runs once. After it has reconciled an opt-out, a later
+	 * re-enable of the module is not reverted on a subsequent run — the guard
+	 * blocks it, so a now-stale falsey option can't keep turning AI back off.
+	 */
+	public function test_migration_is_idempotent_and_guarded() {
+		update_option( 'jetpack_ai_enabled', 0 );
+		$this->set_up_auto_activated_off_simple();
+
+		Jetpack::reconcile_ai_master_optout();
+		$this->assertFalse( ( new Modules() )->is_active( 'ai' ), 'First run deactivates the opted-out module.' );
+		$this->assertTrue( (bool) get_option( Jetpack::AI_MASTER_OPTOUT_MIGRATED_OPTION ), 'The guard flag is set.' );
+
+		// The user turns AI back on (the module), while the old option is still falsey.
+		\Jetpack_Options::update_option( 'active_modules', array( 'ai' ) );
+
+		Jetpack::reconcile_ai_master_optout();
+
+		$this->assertTrue(
+			( new Modules() )->is_active( 'ai' ),
+			'A second run is a no-op: the guard prevents re-deactivating a module the user re-enabled.'
+		);
+	}
+
+	/**
+	 * On WordPress.com Simple the option stays the master and modules do not run,
+	 * so the reconciliation is a no-op: it must not touch module state.
+	 */
+	public function test_no_op_on_simple() {
+		Constants::set_constant( 'IS_WPCOM', true );
+		update_option( 'jetpack_ai_enabled', 0 );
+		\Jetpack_Options::update_option( 'active_modules', array( 'ai' ) );
+
+		Jetpack::reconcile_ai_master_optout();
+
+		$this->assertContains(
+			'ai',
+			(array) \Jetpack_Options::get_option( 'active_modules' ),
+			'On Simple the migration leaves active_modules untouched.'
+		);
+	}
+
+	/**
+	 * The ordering contract, locked against the *production* registration (not a
+	 * priority hand-picked in the test): reconcile_ai_master_optout must be hooked
+	 * to run at a LATER init priority than activate_new_modules. Auto-activation
+	 * turns the module on; reconcile then deactivates it for an opted-out site — a
+	 * lower priority would let auto-activation win and silently re-enable AI.
+	 */
+	public function test_reconcile_hooked_after_activate_new_modules_on_upgrade() {
+		// Call the production registration directly — plugin_upgrade()'s guards (the
+		// upgrade lock, held across tests under wpcomsh's persistent cache) make it
+		// unreliable to trigger in the full suite.
+		Jetpack::register_upgrade_init_hooks();
+
+		$activate_priority  = has_action( 'init', array( 'Jetpack', 'activate_new_modules' ) );
+		$reconcile_priority = has_action( 'init', array( 'Jetpack', 'reconcile_ai_master_optout' ) );
+
+		$this->assertNotFalse( $activate_priority, 'activate_new_modules is registered on init.' );
+		$this->assertNotFalse( $reconcile_priority, 'reconcile_ai_master_optout is registered on init.' );
+		$this->assertGreaterThan(
+			$activate_priority,
+			$reconcile_priority,
+			'reconcile_ai_master_optout must run at a later init priority than activate_new_modules.'
+		);
+	}
+}

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Module_Header_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Module_Header_Test.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Tests for the ai module's header file and its generated registry entries.
+ *
+ * Deliberately carries no covers metadata: the module file has no class or
+ * function to point an attribute at, and the generated module-headings
+ * registries cache their arrays behind statics — a covers-restricted test
+ * that triggers the first call would execute those lines without crediting
+ * them, hiding them from coverage for the whole run.
+ *
+ * @package automattic/jetpack
+ */
+
+/**
+ * Class Jetpack_AI_Module_Header_Test
+ */
+class Jetpack_AI_Module_Header_Test extends \WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * The ai module is a toggle-only header file: loading it produces no output
+	 * and defines nothing, and the generated module registries carry its header.
+	 */
+	public function test_ai_module_is_a_toggle_only_header() {
+		ob_start();
+		require JETPACK__PLUGIN_DIR . 'modules/ai.php';
+		$this->assertSame( '', ob_get_clean() );
+
+		$i18n = jetpack_get_module_i18n( 'ai' );
+		$this->assertIsArray( $i18n );
+		$this->assertSame( 'AI', $i18n['name'] );
+
+		$info = jetpack_get_module_info( 'ai' );
+		$this->assertIsArray( $info );
+		$this->assertSame( 'Yes', $info['auto_activate'] );
+		$this->assertSame( 'Yes', $info['requires_connection'] );
+		$this->assertSame( 'Yes', $info['requires_user_connection'] );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Settings_Test.php
@@ -252,21 +252,45 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * Off-Simple the module is the master, but the setter keeps the
-	 * `jetpack_ai_enabled` option in step with the module's resulting state so
-	 * Jetpack Sync mirrors the right value to WordPress.com (Calypso / the MSD read
-	 * it). Without this, turning AI off leaves the synced option stale-truthy.
+	 * Off-Simple the module alone is the master: the setter must never write the
+	 * `jetpack_ai_enabled` option. WordPress.com reads the master state from the
+	 * synced active_modules list, and the option's only remaining off-Simple role
+	 * is the legacy pre-module opt-out that Jetpack::reconcile_ai_master_optout()
+	 * reads once — a write here would clobber that signal and re-create a second,
+	 * driftable source of truth.
 	 */
-	public function test_set_master_enabled_syncs_option_off_simple() {
+	public function test_set_master_enabled_leaves_option_untouched_off_simple() {
 		Constants::set_constant( 'IS_WPCOM', false );
-		// Module active and the option truthy; turning the master off must flip both.
 		\Jetpack_Options::update_option( 'active_modules', array( 'ai' ) );
-		update_option( Jetpack_AI_Settings::MASTER_OPTION, 1 );
+
+		// Seed the stored legacy opt-out. (Asserting on the stored representation
+		// is unreliable — the registered sanitizer casts to boolean and false
+		// round-trips as '' or a cached false — so the spies below carry the test.)
+		update_option( Jetpack_AI_Settings::MASTER_OPTION, 0 );
+
+		// Trip on any write or delete of the option, whatever the value.
+		$touches = 0;
+		$spy     = static function ( $value = null ) use ( &$touches ) {
+			++$touches;
+			return $value;
+		};
+		add_filter( 'pre_update_option_' . Jetpack_AI_Settings::MASTER_OPTION, $spy );
+		add_action( 'delete_option_' . Jetpack_AI_Settings::MASTER_OPTION, $spy );
 
 		Jetpack_AI_Settings::set_master_enabled( false );
+		$module_active_after_disable = ( new Modules() )->is_active( 'ai' );
 
-		$this->assertFalse( ( new Modules() )->is_active( 'ai' ), 'The module (authoritative master) is off.' );
-		$this->assertFalse( (bool) get_option( Jetpack_AI_Settings::MASTER_OPTION ), 'The synced option follows the module off-Simple.' );
+		Jetpack_AI_Settings::set_master_enabled( true );
+
+		remove_filter( 'pre_update_option_' . Jetpack_AI_Settings::MASTER_OPTION, $spy );
+		remove_action( 'delete_option_' . Jetpack_AI_Settings::MASTER_OPTION, $spy );
+
+		$this->assertFalse( $module_active_after_disable, 'The module (authoritative master) is off after disabling.' );
+		$this->assertSame( 0, $touches, 'The off-Simple setter must never write or delete the jetpack_ai_enabled option.' );
+
+		$stored = get_option( Jetpack_AI_Settings::MASTER_OPTION, 'ABSENT' );
+		$this->assertNotSame( 'ABSENT', $stored, 'The stored legacy opt-out is still present after master toggles.' );
+		$this->assertEmpty( $stored, 'The stored legacy opt-out still reads falsey after master toggles.' );
 	}
 
 	/**
@@ -379,19 +403,24 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	}
 
 	/**
-	 * The master switch and the owned per-feature options sync to WordPress.com.
+	 * The owned per-feature options sync to WordPress.com. The master option
+	 * deliberately does not: off-Simple the `ai` module is the master and its
+	 * state reaches WordPress.com via the synced active_modules callable.
 	 */
 	public function test_sync_options_whitelist() {
 		$whitelist = apply_filters( 'jetpack_sync_options_whitelist', array() );
 
-		$this->assertContains( 'jetpack_ai_enabled', $whitelist );
+		$this->assertNotContains( 'jetpack_ai_enabled', $whitelist );
 		$this->assertContains( 'jetpack_ai_writing_assistant_enabled', $whitelist );
 		$this->assertContains( 'jetpack_ai_image_editor_enabled', $whitelist );
 		$this->assertNotContains( 'jetpack_ai_image_label_enabled', $whitelist );
 	}
 
 	/**
-	 * The owned options are registered (register_setting on init).
+	 * The owned options are registered (register_setting on init). The master
+	 * option must stay OUT of core settings REST: off-Simple the module is the
+	 * master (a core-REST write would only clobber the legacy opt-out value),
+	 * and the dedicated feature-settings endpoint is the real writable surface.
 	 */
 	public function test_options_are_registered() {
 		Jetpack_AI_Settings::register_settings();
@@ -402,5 +431,8 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 		$this->assertArrayHasKey( 'jetpack_ai_writing_assistant_enabled', $registered );
 		$this->assertArrayHasKey( 'jetpack_ai_image_editor_enabled', $registered );
 		$this->assertArrayNotHasKey( 'jetpack_ai_image_label_enabled', $registered );
+
+		$this->assertFalse( $registered['jetpack_ai_enabled']['show_in_rest'], 'The master option is never exposed over core settings REST.' );
+		$this->assertTrue( (bool) $registered['jetpack_ai_writing_assistant_enabled']['show_in_rest'], 'Feature options stay REST-exposed off-Simple.' );
 	}
 }

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Settings_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Settings_Test.php
@@ -12,6 +12,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Modules;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
@@ -26,6 +27,28 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 
 	/**
+	 * Filter callback used to simulate the `ai` module being active without the
+	 * connection/plan setup a real activation needs. Applied after the module
+	 * availability intersection in Modules::get_active(), so it forces the state.
+	 *
+	 * @var callable|null
+	 */
+	private $force_ai_active_filter = null;
+
+	/**
+	 * Off-Simple, the `ai` module is the master switch. Force it active so the
+	 * master reads as on, mirroring the option-default-on baseline the gate
+	 * tests assume.
+	 */
+	private function force_ai_module_active() {
+		$this->force_ai_active_filter = static function ( $modules ) {
+			$modules[] = 'ai';
+			return $modules;
+		};
+		add_filter( 'jetpack_active_modules', $this->force_ai_active_filter );
+	}
+
+	/**
 	 * Reset the options and filters this test touches.
 	 */
 	public function tear_down() {
@@ -37,7 +60,16 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 		remove_filter( 'wp_supports_ai', '__return_false' );
 		remove_filter( 'jetpack_ai_enabled', '__return_true', PHP_INT_MAX );
 		remove_filter( 'jetpack_ai_enabled', '__return_true', 11 );
+		remove_filter( 'jetpack_is_connection_ready', '__return_true' );
+
+		if ( $this->force_ai_active_filter !== null ) {
+			remove_filter( 'jetpack_active_modules', $this->force_ai_active_filter );
+			$this->force_ai_active_filter = null;
+		}
+
+		// Reset the platform: every test in this class defaults to off-Simple.
 		Constants::clear_single_constant( 'IS_WPCOM' );
+		\Jetpack_Options::update_option( 'active_modules', array() );
 
 		parent::tear_down();
 	}
@@ -58,17 +90,20 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	 * computed default (false on plain self-hosted sites in Jetpack_AI_Helper).
 	 */
 	public function test_master_gate_is_restrictive_only() {
-		// Defaults: host allows, master option unset (defaults on).
+		// Host allows; make the master on. Off-Simple the master is the `ai`
+		// module, so activate it rather than the option.
+		$this->force_ai_module_active();
+
 		$this->assertFalse( apply_filters( 'jetpack_ai_enabled', false ), 'A call-site false must survive the gate.' );
 		$this->assertTrue( apply_filters( 'jetpack_ai_enabled', true ), 'A call-site true must pass when every gate is open.' );
 	}
 
 	/**
-	 * Master option off turns off every AI filter the settings class guards.
+	 * Master off (off-Simple: the `ai` module inactive) turns off every AI filter
+	 * the settings class guards.
 	 */
-	public function test_master_option_off_disables_ai_filters() {
-		update_option( Jetpack_AI_Settings::MASTER_OPTION, 0 );
-
+	public function test_master_off_disables_ai_filters() {
+		// Off-Simple, the module is the master and is inactive by default here.
 		$this->assertFalse( Jetpack_AI_Settings::is_master_enabled() );
 		$this->assertFalse( apply_filters( 'jetpack_ai_enabled', true ) );
 		$this->assertFalse( apply_filters( 'jetpack_search_ai_answers_enabled', true ) );
@@ -109,6 +144,9 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	 * come back true just because every gate happens to be open.
 	 */
 	public function test_is_ai_enabled_respects_call_site_default() {
+		// Off-Simple the master is the module, so open that gate to isolate the default.
+		$this->force_ai_module_active();
+
 		$this->assertFalse( Jetpack_AI_Settings::is_ai_enabled( false ), 'A call-site false must survive open gates.' );
 		$this->assertTrue( Jetpack_AI_Settings::is_ai_enabled( true ) );
 		$this->assertTrue( Jetpack_AI_Settings::is_ai_enabled(), 'The default parameter is true.' );
@@ -119,9 +157,116 @@ class Jetpack_AI_Settings_Test extends \WP_UnitTestCase {
 	 * from a false default — the gates only ever subtract.
 	 */
 	public function test_is_ai_enabled_filter_can_enable_when_gates_open() {
+		// Gates open means the master (the module off-Simple) is on too.
+		$this->force_ai_module_active();
 		add_filter( 'jetpack_ai_enabled', '__return_true', 11 );
 
 		$this->assertTrue( Jetpack_AI_Settings::is_ai_enabled( false ) );
+	}
+
+	/**
+	 * Off-Simple, the master reflects the `ai` module's active state, NOT the
+	 * `jetpack_ai_enabled` option. Modules are the master switch there.
+	 */
+	public function test_is_master_enabled_reflects_module_not_option_off_simple() {
+		Constants::set_constant( 'IS_WPCOM', false );
+
+		// Option on, module inactive: the module wins.
+		update_option( Jetpack_AI_Settings::MASTER_OPTION, 1 );
+		$this->assertFalse( Jetpack_AI_Settings::is_master_enabled(), 'An inactive module means master off even with the option on.' );
+
+		// Option off, module active: the module still wins.
+		update_option( Jetpack_AI_Settings::MASTER_OPTION, 0 );
+		$this->force_ai_module_active();
+		$this->assertTrue( Jetpack_AI_Settings::is_master_enabled(), 'An active module means master on even with the option off.' );
+	}
+
+	/**
+	 * On WordPress.com Simple, no Jetpack modules run, so the master reflects the
+	 * `jetpack_ai_enabled` option, NOT the module.
+	 */
+	public function test_is_master_enabled_reflects_option_on_simple() {
+		Constants::set_constant( 'IS_WPCOM', true );
+
+		update_option( Jetpack_AI_Settings::MASTER_OPTION, 0 );
+		$this->assertFalse( Jetpack_AI_Settings::is_master_enabled(), 'On Simple the option is the master.' );
+
+		update_option( Jetpack_AI_Settings::MASTER_OPTION, 1 );
+		$this->assertTrue( Jetpack_AI_Settings::is_master_enabled() );
+	}
+
+	/**
+	 * On Simple, the setter writes the option.
+	 */
+	public function test_set_master_enabled_writes_option_on_simple() {
+		Constants::set_constant( 'IS_WPCOM', true );
+
+		Jetpack_AI_Settings::set_master_enabled( false );
+		$this->assertFalse( (bool) get_option( Jetpack_AI_Settings::MASTER_OPTION ) );
+
+		Jetpack_AI_Settings::set_master_enabled( true );
+		$this->assertTrue( (bool) get_option( Jetpack_AI_Settings::MASTER_OPTION ) );
+	}
+
+	/**
+	 * Off-Simple, the setter deactivates the `ai` module.
+	 */
+	public function test_set_master_enabled_false_deactivates_module_off_simple() {
+		Constants::set_constant( 'IS_WPCOM', false );
+		\Jetpack_Options::update_option( 'active_modules', array( 'ai' ) );
+
+		Jetpack_AI_Settings::set_master_enabled( false );
+
+		$this->assertFalse( ( new Modules() )->is_active( 'ai' ) );
+	}
+
+	/**
+	 * Off-Simple, the setter drives the `ai` module rather than the
+	 * jetpack_ai_enabled option: it must call through to Modules::activate( 'ai' ).
+	 *
+	 * We assert the routing (the setter invokes module activation) rather than the
+	 * resulting active state, because activation's own plan and connection gates
+	 * belong to Modules::activate() and are environment-specific — under wpcomsh the
+	 * plan feature check (wpcom_site_has_feature) refuses an unentitled test site,
+	 * which is Modules' concern, not set_master_enabled()'s platform routing.
+	 */
+	public function test_set_master_enabled_true_activates_module_off_simple() {
+		Constants::set_constant( 'IS_WPCOM', false );
+		\Jetpack_Options::update_option( 'active_modules', array() );
+
+		// Modules::activate() fires this action before any plan/connection gate, so
+		// it deterministically records the activation attempt in every environment.
+		$activated = array();
+		$spy       = static function ( $module ) use ( &$activated ) {
+			$activated[] = $module;
+		};
+		add_action( 'jetpack_pre_activate_module', $spy );
+
+		Jetpack_AI_Settings::set_master_enabled( true );
+
+		remove_action( 'jetpack_pre_activate_module', $spy );
+
+		// A no-op setter, or one that wrote the option (the on-Simple path), would
+		// never fire this action — so it proves the module-activation branch was taken.
+		$this->assertContains( 'ai', $activated, 'Off-Simple the setter must activate the ai module.' );
+	}
+
+	/**
+	 * Off-Simple the module is the master, but the setter keeps the
+	 * `jetpack_ai_enabled` option in step with the module's resulting state so
+	 * Jetpack Sync mirrors the right value to WordPress.com (Calypso / the MSD read
+	 * it). Without this, turning AI off leaves the synced option stale-truthy.
+	 */
+	public function test_set_master_enabled_syncs_option_off_simple() {
+		Constants::set_constant( 'IS_WPCOM', false );
+		// Module active and the option truthy; turning the master off must flip both.
+		\Jetpack_Options::update_option( 'active_modules', array( 'ai' ) );
+		update_option( Jetpack_AI_Settings::MASTER_OPTION, 1 );
+
+		Jetpack_AI_Settings::set_master_enabled( false );
+
+		$this->assertFalse( ( new Modules() )->is_active( 'ai' ), 'The module (authoritative master) is off.' );
+		$this->assertFalse( (bool) get_option( Jetpack_AI_Settings::MASTER_OPTION ), 'The synced option follows the module off-Simple.' );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/lib/trait-activates-ai-module.php
+++ b/projects/plugins/jetpack/tests/php/lib/trait-activates-ai-module.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Test helper trait for simulating the `ai` module being active.
+ *
+ * @package automattic/jetpack
+ */
+
+/**
+ * Forces the `ai` module active for the duration of a test.
+ *
+ * Off WordPress.com Simple (self-hosted and Atomic) the `ai` module is the AI
+ * master switch that {@see Jetpack_AI_Settings::is_master_enabled()} reads, so
+ * every AI feature gates off when it is inactive. The PHPUnit environment never
+ * runs activate_default_modules(), which leaves the module inactive, so tests
+ * that assume AI is on must force it active. This filters `jetpack_active_modules`
+ * to append `ai`, mirroring the connected-and-on baseline a live site has — the
+ * same approach Jetpack_AI_Settings_Test uses.
+ *
+ * On WordPress.com Simple this is unnecessary: Modules::is_active() is true
+ * unconditionally there and the master reads the `jetpack_ai_enabled` option
+ * instead, so the filter is a harmless no-op.
+ */
+trait Activates_Ai_Module {
+
+	/**
+	 * The `jetpack_active_modules` filter callback that appends `ai`. Stored so it
+	 * can be removed again — both to exercise master-off assertions and to keep the
+	 * filter from leaking into the next test.
+	 *
+	 * @var callable|null
+	 */
+	private $activates_ai_module_filter = null;
+
+	/**
+	 * Force the `ai` module active so is_master_enabled() reads on off-Simple.
+	 *
+	 * @return void
+	 */
+	protected function activate_ai_module_for_test() {
+		if ( null !== $this->activates_ai_module_filter ) {
+			return;
+		}
+
+		$this->activates_ai_module_filter = static function ( $modules ) {
+			$modules   = is_array( $modules ) ? $modules : array();
+			$modules[] = 'ai';
+			return array_values( array_unique( $modules ) );
+		};
+
+		add_filter( 'jetpack_active_modules', $this->activates_ai_module_filter );
+	}
+
+	/**
+	 * Remove the forced `ai` module activation, so is_master_enabled() reads off
+	 * again (for master-off assertions) and no filter leaks into the next test.
+	 *
+	 * @return void
+	 */
+	protected function deactivate_ai_module_for_test() {
+		if ( null === $this->activates_ai_module_filter ) {
+			return;
+		}
+
+		remove_filter( 'jetpack_active_modules', $this->activates_ai_module_filter );
+		$this->activates_ai_module_filter = null;
+	}
+}

--- a/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Options_Test.php
+++ b/projects/plugins/jetpack/tests/php/sync/Jetpack_Sync_Options_Test.php
@@ -277,7 +277,6 @@ class Jetpack_Sync_Options_Test extends Jetpack_Sync_TestBase {
 			'wpcom_ai_launchpad_completed'                 => true,
 			'wpcom_ai_site_prompt'                         => '',
 			'reader_chat'                                  => false,
-			'jetpack_ai_enabled'                           => false,
 			'jetpack_ai_writing_assistant_enabled'         => false,
 			'jetpack_ai_image_editor_enabled'              => false,
 			'jetpack_ai_feature_clip_enabled'              => false,


### PR DESCRIPTION
Fixes related to FORNO-392

## Proposed changes

This PR adds the new `ai` module as the AI master switch off Simple (self-hosted+Atomic), module is activated through My Jetpack -> Products -> AI card toggle.
This module is gated to internal testing environments (proxied a12s, JN, localhost) - everyone else keeps the card they have today (no way to reach the master switch from it).

## Behavior at a glance

**Where the master lives, per platform:**

| Platform | Master switch | Where you flip it |
|---|---|---|
| Self-hosted | the `ai` module | My Jetpack → Products card, or `wp jetpack module activate/deactivate ai` |
| Atomic | the `ai` module | My Jetpack → Products card |
| WordPress.com Simple | the `jetpack_ai_enabled` option | the existing WordPress.com / MSD setting (modules don't run on Simple) |

**The My Jetpack card - a12s only.** Outside internal testing environments the card is unchanged from today: the module never reaches it, so nothing about the master switch is visible or reachable.

| Jetpack AI is… | Before | After (a12s only) |
|---|---|---|
| off | "Learn more" button → pricing interstitial | inline toggle (off) — one click to turn on |
| on | toggle rendered disabled — couldn't turn off | toggle enabled — one click to turn off |

## Screenshots

<details>

<summary>My Jetpack AI card — on, off</summary>

 Screenshots show the internal-testing (a12s) view;

1. My Jetpack card — AI on, enabled toggle ("Active")

<img width="1425" height="862" alt="ai-card-ON-active-toggle-deea35838e" src="https://github.com/user-attachments/assets/0b4e4a85-886d-430d-9dd3-5db267aea213" />

<img width="1430" height="840" alt="ai-card-ON-active-toggle" src="https://github.com/user-attachments/assets/aaf23634-2adb-420f-a595-d4f0d5a58e9a" />

2. My Jetpack card — AI off, inline toggle (not "Learn more")
<img width="1425" height="862" alt="ai-card-OFF-toggle-deea35838e" src="https://github.com/user-attachments/assets/94cc8893-0d4e-4c70-8533-d0c3f97fd4ff" />
<img width="1430" height="840" alt="ai-card-OFF-toggle" src="https://github.com/user-attachments/assets/40ab9454-4e0d-4bab-90c7-dc9bb0e48ae2" />


</details>

## Related product discussion/links

* The Jetpack AI toggle contract and the module-as-master direction: pcO4xN-3hk-p2 (discussed in the comments).

## Does this pull request change what data or activity we track or use?

No new event tracking. Registers the `ai` module (its active state in `jetpack_active_modules` now backs the AI master switch off Simple), maps the My Jetpack `jetpack-ai` product to that module, and writes a one-time `jetpack_ai_master_optout_migrated` flag.

## Testing instructions

Test on a **connected self-hosted or Atomic site** (a Jurassic Ninja site works). On WordPress.com Simple the option stays master and modules don't run, so these steps are off-Simple only.

Install the branch: `bin/jetpack-downloader test jetpack add/jetpack-ai-master-switch-module` (or Jetpack → Jetpack Beta → activate this branch), then build if prompted.

<details>
<summary>Step-by-step (module recognition, card, CLI + final gate, inert option, feature toggle, opt-out migration, reset)</summary>

**0. Confirm the module is recognized** (WP-CLI's module cache can be stale after a branch swap):
```
wp eval 'Jetpack_Options::delete_option("available_modules");'
wp jetpack module list | grep -w ai
```
`ai` should appear. If it shows **Inactive**, activate it — auto-activation only runs on a fresh connect/upgrade (and never on alpha builds, where `16.2-a.x` sorts below the module's `First Introduced: 16.2`):
```
wp jetpack module activate ai
```

**1. My Jetpack → Products, the Jetpack AI card (a12s only — see step 6 for what everyone else sees):**
* With AI **on**, the card shows an **"Active"** badge and an **enabled** toggle. Flipping it **off** deactivates the module (editor AI features stop loading).
* With AI **off**, the card shows the **toggle in its off position** — *not* a "Learn more" link — and flipping it **on** reactivates the module.
* Toggling via the card **reloads the page automatically** (expected — it refreshes server-rendered UI like the admin sidebar, and the success notice survives the reload). Only if you flip the module **via CLI while the page is open** do you need to reload manually — the page fetches product state on load, same as every My Jetpack card.

**2. Core master switch (CLI) — and the gate is final:**
```
wp jetpack module deactivate ai     # AI off site-wide
wp eval 'add_filter("jetpack_ai_enabled","__return_true",999); var_export(Jetpack_AI_Settings::is_ai_enabled());'   # PASS = false — a late filter can't bypass the master
wp jetpack module activate ai       # AI returns
```

**3. The option is inert off-Simple** (the module alone is the master; nothing writes the option):
```
wp option add jetpack_ai_enabled 1                      # seed a legacy value (option add — update with 1 is a no-op against the registered default)
wp jetpack module deactivate ai && wp jetpack module activate ai
wp option get jetpack_ai_enabled                        # PASS = still exactly 1
wp option delete jetpack_ai_enabled
```

**4. A feature toggle survives a master flip** (the master must not reset per-feature choices):
```
wp option update jetpack_ai_writing_assistant_enabled 0
wp jetpack module deactivate ai && wp jetpack module activate ai
wp option get jetpack_ai_writing_assistant_enabled   # PASS = still falsey (0 or blank), not 1
```

**5. An explicit opt-out survives the module becoming the master** (the migration):
```
wp option update jetpack_ai_enabled 0                 # a site that opted out before the module shipped
wp option delete jetpack_ai_master_optout_migrated    # reset the run-once guard
wp jetpack module activate ai                          # simulate Auto-Activate turning it on
wp eval 'Jetpack::reconcile_ai_master_optout();'
wp jetpack module list | grep -w ai                    # PASS = "ai   Inactive" (opt-out preserved)
```

**Reset to default-on when done:**
```
wp option delete jetpack_ai_writing_assistant_enabled jetpack_ai_enabled jetpack_ai_master_optout_migrated
wp jetpack module activate ai
```

</details>


For the full row-by-row runbook: One Bin 3c2d6-pb

🤖 Parts of description drafted with AI assistance