### PR TITLE
Publicize: gate the `shared` param on connection create

### DIFF
--- a/projects/packages/publicize/AGENTS.md
+++ b/projects/packages/publicize/AGENTS.md
@@ -98,7 +98,6 @@ Defined as constants/properties on `Publicize_Base`:
 ### Entry Points (via `webpack.config.js`)
 
 Webpack entry points (defined in `webpack.config.js`), bundled into `build/`:
-- **`social-admin-page.tsx`** — Standalone Social admin dashboard
 - **`block-editor-social.tsx`** — Block editor sidebar panel (Social plugin context)
 - **`block-editor-jetpack.tsx`** — Block editor sidebar panel (Jetpack plugin context)
 - **`classic-editor.js`** — Classic editor integration

--- a/projects/packages/publicize/changelog/fix-shared-connection-create-permission
+++ b/projects/packages/publicize/changelog/fix-shared-connection-create-permission
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+REST API: Require the `edit_others_posts` capability to create a shared connection, matching the update check.

--- a/projects/packages/publicize/src/rest-api/class-connections-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-connections-controller.php
@@ -310,14 +310,46 @@ class Connections_Controller extends Base_Controller {
 	 * @param WP_REST_Request $request Full details about the request.
 	 * @return true|WP_Error True if the request has access to create items, WP_Error object otherwise.
 	 */
-	public function create_item_permissions_check( $request ) {// phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+	public function create_item_permissions_check( $request ) {
 		$permissions = parent::publicize_permissions_check();
 
 		if ( is_wp_error( $permissions ) ) {
 			return $permissions;
 		}
 
+		$shared_permission = $this->check_shared_param_permission( $request );
+
+		if ( is_wp_error( $shared_permission ) ) {
+			return $shared_permission;
+		}
+
 		return current_user_can( 'publish_posts' );
+	}
+
+	/**
+	 * Check whether the request is allowed to set the `shared` flag on a connection.
+	 *
+	 * Shared connections are usable by every author on the site, so only editors
+	 * and above may set the flag. Used by both the create and the update permission
+	 * check, so the rule cannot drift between the two.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return true|WP_Error True if the request may proceed, WP_Error object otherwise.
+	 */
+	protected function check_shared_param_permission( $request ) {
+		if ( ! $request->has_param( 'shared' ) ) {
+			return true;
+		}
+
+		if ( ! current_user_can( 'edit_others_posts' ) ) {
+			return new WP_Error(
+				'rest_cannot_share_connection',
+				__( 'Sorry, you are not allowed to share connections with other users.', 'jetpack-publicize-pkg' ),
+				array( 'status' => rest_authorization_required_code() )
+			);
+		}
+
+		return true;
 	}
 
 	/**
@@ -395,10 +427,10 @@ class Connections_Controller extends Base_Controller {
 			);
 		}
 
-		// If the connection is being marked/unmarked as shared.
-		if ( $request->has_param( 'shared' ) ) {
-			// Only editors and above can mark a connection as shared.
-			return current_user_can( 'edit_others_posts' );
+		$shared_permission = $this->check_shared_param_permission( $request );
+
+		if ( is_wp_error( $shared_permission ) ) {
+			return $shared_permission;
 		}
 
 		return current_user_can( 'publish_posts' );

--- a/projects/packages/publicize/tests/php/Connections_Controller_Test.php
+++ b/projects/packages/publicize/tests/php/Connections_Controller_Test.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Tests for the connection create/update permission checks.
+ *
+ * @package automattic/jetpack-publicize
+ */
+
+namespace Automattic\Jetpack\Publicize;
+
+use Automattic\Jetpack\Publicize\REST_API\Connections_Controller;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\TestCase;
+use WorDBless\Options as WorDBless_Options;
+use WorDBless\Posts as WorDBless_Posts;
+use WorDBless\Users as WorDBless_Users;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * Class Connections_Controller_Test
+ */
+#[AllowMockObjectsWithoutExpectations /* getStubBuilder() (for partial stubs) doesn't exist until PHPUnit 12.5. */]
+class Connections_Controller_Test extends TestCase {
+
+	/**
+	 * The create route.
+	 *
+	 * @var string
+	 */
+	private const ROUTE = '/wpcom/v2/publicize/connections';
+
+	/**
+	 * The user IDs, keyed by role.
+	 *
+	 * @var array
+	 */
+	private $user_ids = array();
+
+	/**
+	 * REST Server object.
+	 *
+	 * @var WP_REST_Server
+	 */
+	private $server;
+
+	/**
+	 * Publicize instance.
+	 *
+	 * @var ?Publicize
+	 */
+	private $publicize = null;
+
+	/**
+	 * Connections controller instance.
+	 *
+	 * @var ?Connections_Controller
+	 */
+	private $controller = null;
+
+	/**
+	 * Setting up the test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		global $publicize, $wp_rest_server;
+
+		$this->publicize = $this->getMockBuilder( Publicize::class )->onlyMethods( array( 'save_meta' ) )->getMock();
+		$publicize       = $this->publicize;
+
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
+		foreach ( array( 'editor', 'author' ) as $role ) {
+			$this->user_ids[ $role ] = wp_insert_user(
+				array(
+					'user_login' => 'dummy_' . $role,
+					'user_pass'  => 'dummy_pass',
+					'role'       => $role,
+				)
+			);
+		}
+
+		$this->controller = new Connections_Controller();
+
+		add_action( 'rest_api_init', array( $this->controller, 'register_routes' ) );
+
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Returning the environment into its initial state.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		wp_set_current_user( 0 );
+
+		// Leaving this registered would add the routes to every later test in the process.
+		remove_action( 'rest_api_init', array( $this->controller, 'register_routes' ) );
+
+		/*
+		 * Firing `rest_api_init` makes core cache a REST controller - and with it the
+		 * item schema - on every post type object. Drop them, so that later tests see
+		 * the post meta they register themselves.
+		 */
+		foreach ( get_post_types( array(), 'objects' ) as $post_type ) {
+			$post_type->rest_controller = null;
+		}
+
+		WorDBless_Options::init()->clear_options();
+		WorDBless_Posts::init()->clear_all_posts();
+		WorDBless_Users::init()->clear_all_users();
+
+		$this->publicize  = null;
+		$this->controller = null;
+		$this->user_ids   = array();
+	}
+
+	/**
+	 * An author cannot create a shared connection.
+	 */
+	public function test_author_cannot_create_shared_connection() {
+		wp_set_current_user( $this->user_ids['author'] );
+
+		$response = $this->server->dispatch( $this->create_request( true ) );
+
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( 'rest_cannot_share_connection', $response->get_data()['code'] );
+	}
+
+	/**
+	 * Passing `shared: false` is still setting the flag, so it is gated too.
+	 */
+	public function test_author_cannot_create_connection_with_shared_false() {
+		wp_set_current_user( $this->user_ids['author'] );
+
+		$response = $this->server->dispatch( $this->create_request( false ) );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * An author can still create a regular connection.
+	 *
+	 * The permission check is asserted directly, so that the request does not
+	 * get proxied to WPCOM.
+	 */
+	public function test_author_can_create_connection_without_shared() {
+		wp_set_current_user( $this->user_ids['author'] );
+
+		$this->assertTrue( $this->controller->create_item_permissions_check( $this->create_request( null ) ) );
+	}
+
+	/**
+	 * An editor can create a shared connection.
+	 */
+	public function test_editor_can_create_shared_connection() {
+		wp_set_current_user( $this->user_ids['editor'] );
+
+		$this->assertTrue( $this->controller->create_item_permissions_check( $this->create_request( true ) ) );
+	}
+
+	/**
+	 * Build a create request, optionally carrying the `shared` param.
+	 *
+	 * @param bool|null $shared The `shared` param, or null to omit it.
+	 *
+	 * @return WP_REST_Request
+	 */
+	private function create_request( $shared ) {
+		$request = new WP_REST_Request( 'POST', self::ROUTE );
+
+		$request->set_param( 'keyring_connection_ID', 123 );
+
+		if ( null !== $shared ) {
+			$request->set_param( 'shared', $shared );
+		}
+
+		return $request;
+	}
+}


### PR DESCRIPTION
Fixes SOCIAL-526

## Proposed changes

* `shared` was gated inconsistently: `update_item_permissions_check()` required `edit_others_posts` when the request carried `shared`, while `create_item_permissions_check()` only checked `publish_posts` — so an author could create a shared connection by POSTing `shared: true`. The UI hides the checkbox from them, which is why it went unnoticed, but the API is the boundary.
* The rule now lives in one helper, `check_shared_param_permission()`, used by both permission checks so they cannot drift again.
* Rejecting rather than silently ignoring, consistent with update. The denial is a `rest_cannot_share_connection` 403; update's `shared` denial now returns that labelled error instead of a bare `false`.
* Passing `shared: false` is gated too — sending the param at all is setting the flag, and update behaves the same way.
* The legacy `POST /jetpack/v4/social/connections` route has the same hole; it is being removed #50723
* Unrelated: drops a stale `social-admin-page.tsx` entry from `AGENTS.md`.

## Related product discussion/links

* https://linear.app/a8c/issue/SOCIAL-526/m0-02-fix-authors-can-create-a-shared-connection-via-the-rest-api

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* As an admin, mark a connection as shared and unshared and confirm that it works fine.
* Add a new connection and check marking shared works as expected.
