### PR TITLE
Stats widgets: share summaryCount and toDay helpers, dedup refetch comment

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1754-shared-widget-helpers
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1754-shared-widget-helpers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Stats widgets: Share the summary-count and date-only helpers across widgets.

--- a/projects/packages/premium-analytics/packages/data/src/hooks/use-report.ts
+++ b/projects/packages/premium-analytics/packages/data/src/hooks/use-report.ts
@@ -120,8 +120,9 @@ export function useReport< TData, TParams extends ReportParams = ReportParams >(
 		Boolean( ( comparison.data as any )?.data?.length ) ||
 		Boolean( ( comparison.data as any )?.steps?.length );
 
-	// Combined refetch function that refetches both queries.
-	// If both primary and comparison queries fail, clicking "Retry" should refetch both.
+	// Combined refetch: memoized, awaits both queries, and skips the comparison
+	// query when comparison is disabled. If both queries fail, one "Retry" must
+	// refetch both — so widgets can surface this directly as their retry action.
 	const primaryRefetch = primary.refetch;
 	const comparisonRefetch = comparison.refetch;
 	const refetch = useCallback( async () => {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/summary-count.test.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/summary-count.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Internal dependencies
+ */
+import { summaryCount } from '../summary-count';
+
+describe( 'summaryCount', () => {
+	it( 'reads a numeric field', () => {
+		expect( summaryCount( { views: 42 }, 'views' ) ).toBe( 42 );
+	} );
+
+	it( 'coerces a numeric string, as WPCOM sends for some fields', () => {
+		expect( summaryCount( { views: '42' }, 'views' ) ).toBe( 42 );
+	} );
+
+	it( 'returns undefined for a missing key', () => {
+		expect( summaryCount( { views: 42 }, 'visitors' ) ).toBeUndefined();
+	} );
+
+	it( 'returns undefined for an undefined summary', () => {
+		expect( summaryCount( undefined, 'views' ) ).toBeUndefined();
+	} );
+
+	it( 'returns undefined for a non-numeric string', () => {
+		expect( summaryCount( { views: 'lots' }, 'views' ) ).toBeUndefined();
+	} );
+
+	it( 'returns undefined for non-finite values', () => {
+		expect( summaryCount( { views: Infinity }, 'views' ) ).toBeUndefined();
+		expect( summaryCount( { views: NaN }, 'views' ) ).toBeUndefined();
+	} );
+
+	it( 'returns undefined for values that are neither number nor string', () => {
+		expect( summaryCount( { views: null }, 'views' ) ).toBeUndefined();
+		expect( summaryCount( { views: { count: 1 } }, 'views' ) ).toBeUndefined();
+	} );
+
+	it( 'preserves zero, which is a real count rather than a missing one', () => {
+		expect( summaryCount( { views: 0 }, 'views' ) ).toBe( 0 );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/to-day.test.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/to-day.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Internal dependencies
+ */
+import { toDay } from '../to-day';
+
+describe( 'toDay', () => {
+	it( 'extracts the date-only part of an ISO date-time', () => {
+		expect( toDay( '2026-05-04T13:45:00Z' ) ).toBe( '2026-05-04' );
+	} );
+
+	it( 'passes through a bare date', () => {
+		expect( toDay( '2026-05-04' ) ).toBe( '2026-05-04' );
+	} );
+
+	it( 'returns undefined for undefined', () => {
+		expect( toDay( undefined ) ).toBeUndefined();
+	} );
+
+	it( 'returns undefined for an empty string', () => {
+		expect( toDay( '' ) ).toBeUndefined();
+	} );
+
+	it( 'returns undefined for a malformed shape', () => {
+		expect( toDay( '04/05/2026' ) ).toBeUndefined();
+		expect( toDay( '2026-5-4' ) ).toBeUndefined();
+		expect( toDay( 'not-a-date' ) ).toBeUndefined();
+	} );
+
+	// The reason the stricter of the two former copies is the one hoisted:
+	// callers feed the result to parseISO/eachDayOfInterval, which throw on a
+	// well-shaped but non-existent calendar day.
+	it( 'returns undefined for a well-shaped but impossible calendar date', () => {
+		expect( toDay( '2026-02-31' ) ).toBeUndefined();
+		expect( toDay( '2026-13-01' ) ).toBeUndefined();
+	} );
+
+	it( 'accepts a real leap day', () => {
+		expect( toDay( '2024-02-29' ) ).toBe( '2024-02-29' );
+	} );
+
+	it( 'rejects a leap day in a non-leap year', () => {
+		expect( toDay( '2026-02-29' ) ).toBeUndefined();
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/index.ts
@@ -51,3 +51,4 @@ export { sharePercentage } from './share-percentage';
 export { getVideoKey, getVideoLabel } from './video-plays';
 export { toMaxRows } from './to-max-rows';
 export { summaryCount } from './summary-count';
+export { toDay } from './to-day';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/index.ts
@@ -50,3 +50,4 @@ export { buildCsv, buildCsvDateRangeFilename, saveCsv, type CsvColumn } from './
 export { sharePercentage } from './share-percentage';
 export { getVideoKey, getVideoLabel } from './video-plays';
 export { toMaxRows } from './to-max-rows';
+export { summaryCount } from './summary-count';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/summary-count.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/summary-count.ts
@@ -1,0 +1,19 @@
+/**
+ * Read a numeric field from a Stats summary. Summaries carry dynamic WPCOM keys
+ * whose values arrive numeric or as numeric strings, so both forms are accepted
+ * and anything else reads as absent — letting callers skip a metric rather than
+ * render a misleading `0`.
+ *
+ * @param summary - The normalized summary, or undefined while loading.
+ * @param key     - The summary field to read.
+ * @return The finite number, or undefined when unavailable.
+ */
+export function summaryCount(
+	summary: Record< string, unknown > | undefined,
+	key: string
+): number | undefined {
+	const value = summary?.[ key ];
+	const parsed = typeof value === 'string' ? Number( value ) : value;
+
+	return typeof parsed === 'number' && Number.isFinite( parsed ) ? parsed : undefined;
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/to-day.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/to-day.ts
@@ -1,0 +1,21 @@
+/**
+ * External dependencies
+ */
+import { parseISO } from 'date-fns';
+
+/**
+ * Extract a calendar-valid `YYYY-MM-DD` day from an ISO report param. Params
+ * originate from URL search params, so a hand-edited deep link can carry a
+ * well-shaped but non-existent day like `2026-02-31`; `parseISO` rejects those
+ * before they reach date maths that would throw on them.
+ *
+ * @param value - The ISO date-time string.
+ * @return The date-only day, or undefined when missing, malformed, or impossible.
+ */
+export function toDay( value?: string ): string | undefined {
+	const day = value?.slice( 0, 10 );
+
+	return day && /^\d{4}-\d{2}-\d{2}$/.test( day ) && ! Number.isNaN( parseISO( day ).getTime() )
+		? day
+		: undefined;
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -132,6 +132,7 @@ export {
 	getVideoLabel,
 	toMaxRows,
 	summaryCount,
+	toDay,
 } from './helpers';
 
 /**

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -131,6 +131,7 @@ export {
 	getVideoKey,
 	getVideoLabel,
 	toMaxRows,
+	summaryCount,
 } from './helpers';
 
 /**

--- a/projects/packages/premium-analytics/widgets/all-time-stats/render.tsx
+++ b/projects/packages/premium-analytics/widgets/all-time-stats/render.tsx
@@ -4,6 +4,7 @@
 import { useStatsSite } from '@jetpack-premium-analytics/data';
 import {
 	MetricTileGrid,
+	summaryCount,
 	WidgetRoot,
 	WidgetState,
 	type DataFormat,
@@ -62,21 +63,6 @@ type AllTimeStatsTile = {
 };
 
 /**
- * Reads a numeric summary field, returning `undefined` when the key is absent
- * or not a finite number, so tiles for missing fields can be skipped.
- *
- * @param summary - The normalized all-time summary.
- * @param key     - The summary field to read.
- * @return The numeric value, or undefined when unavailable.
- */
-function readCount( summary: StatsSummary | undefined, key: string ): number | undefined {
-	const value = summary?.[ key ];
-	const parsed = typeof value === 'string' ? Number( value ) : value;
-
-	return typeof parsed === 'number' && Number.isFinite( parsed ) ? parsed : undefined;
-}
-
-/**
  * Fetches the all-time site summary through the designated `useStatsSite` hook
  * and renders the lifetime totals as a grid of metric tiles. Which tiles
  * appear is controlled by the `metrics` attribute; fields absent from the
@@ -107,7 +93,7 @@ function AllTimeStatsReport( {
 	const tiles = useMemo(
 		() =>
 			enabledMetrics.flatMap( ( { id, label } ): AllTimeStatsTile[] => {
-				const value = readCount( summary, id );
+				const value = summaryCount( summary, id );
 				return value === undefined
 					? []
 					: [ { key: id, label, icon: TILE_CONFIG[ id ].icon, value } ];

--- a/projects/packages/premium-analytics/widgets/devices/use-device-views.ts
+++ b/projects/packages/premium-analytics/widgets/devices/use-device-views.ts
@@ -106,8 +106,6 @@ export default function useDeviceViews( {
 		// refetch failure doesn't replace populated rows with the error state.
 		isError: items.length === 0 && isError,
 		errorReason,
-		// The data layer's combined refetch: memoized, awaits both queries, and
-		// skips the comparison query when comparison is disabled.
 		refetch,
 	};
 }

--- a/projects/packages/premium-analytics/widgets/locations/use-location-views.ts
+++ b/projects/packages/premium-analytics/widgets/locations/use-location-views.ts
@@ -124,8 +124,6 @@ export default function useLocationViews( {
 		// refetch failure doesn't replace populated rows with the error state.
 		isError: items.length === 0 && isError,
 		isPlaceholderData,
-		// The data layer's combined refetch: memoized, awaits both queries, and
-		// skips the comparison query when comparison is disabled.
 		refetch,
 	};
 }

--- a/projects/packages/premium-analytics/widgets/most-popular-day/render.tsx
+++ b/projects/packages/premium-analytics/widgets/most-popular-day/render.tsx
@@ -5,6 +5,7 @@ import { useStatsSite } from '@jetpack-premium-analytics/data';
 import { formatDate, formatMetricValue } from '@jetpack-premium-analytics/formatters';
 import { calendar } from '@jetpack-premium-analytics/icons';
 import {
+	summaryCount,
 	WidgetRoot,
 	WidgetState,
 	type ReportParamsFieldAttributes,
@@ -97,22 +98,6 @@ export const MostPopularDayHighlight = ( {
 );
 
 /**
- * Reads a numeric summary field, returning `undefined` when the key is absent
- * or not a finite number, so a malformed value falls through to the empty state
- * rather than rendering a misleading `0`.
- *
- * @param {Record< string, unknown > | undefined} summary - The site summary.
- * @param {string}                                key     - The field to read.
- * @return The finite number, or undefined when unavailable.
- */
-function readCount( summary: Record< string, unknown > | undefined, key: string ) {
-	const value = summary?.[ key ];
-	const parsed = typeof value === 'string' ? Number( value ) : value;
-
-	return typeof parsed === 'number' && Number.isFinite( parsed ) ? parsed : undefined;
-}
-
-/**
  * Parses the best-day field (`YYYY-MM-DD`) into a date. `parseISO` validates the
  * calendar date, so `isValid` rejects the "-" / empty sentinels low-traffic
  * sites send and impossible days like `2020-02-31`, falling through to the empty
@@ -144,8 +129,8 @@ function MostPopularDayReport() {
 
 	const summary = data?.stats;
 	const date = readBestDay( summary );
-	const views = readCount( summary, 'views_best_day_total' );
-	const totalViews = readCount( summary, 'views' );
+	const views = summaryCount( summary, 'views_best_day_total' );
+	const totalViews = summaryCount( summary, 'views' );
 	const isEmpty = date === undefined || views === undefined;
 
 	return (

--- a/projects/packages/premium-analytics/widgets/post-detail-highlights/use-post-highlights.ts
+++ b/projects/packages/premium-analytics/widgets/post-detail-highlights/use-post-highlights.ts
@@ -6,6 +6,7 @@ import {
 	type ReportParams,
 	type StatsPostDay,
 } from '@jetpack-premium-analytics/data';
+import { toDay } from '@jetpack-premium-analytics/widgets-toolkit';
 import { useMemo } from '@wordpress/element';
 
 /**
@@ -31,20 +32,6 @@ export interface PostHighlightsState {
 	isError: boolean;
 	hasData: boolean;
 	refetch: () => void;
-}
-
-/**
- * Extract a shape-validated `YYYY-MM-DD` day from an ISO report param. The
- * params originate from URL search params; days are only compared as strings
- * here, so shape validation is sufficient (a malformed bound simply matches
- * no history days).
- *
- * @param value - The ISO date-time string.
- * @return The date-only day, or undefined when missing/malformed.
- */
-function toDay( value?: string ): string | undefined {
-	const day = value?.slice( 0, 10 );
-	return day && /^\d{4}-\d{2}-\d{2}$/.test( day ) ? day : undefined;
 }
 
 /**

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/use-post-traffic-activity.ts
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/use-post-traffic-activity.ts
@@ -12,7 +12,7 @@ import {
 	startOfWeek,
 	subDays,
 } from 'date-fns';
-import type { DataPointDate } from '@jetpack-premium-analytics/widgets-toolkit';
+import { toDay, type DataPointDate } from '@jetpack-premium-analytics/widgets-toolkit';
 
 /**
  * Normalized activity state: one point per calendar day of the visible page
@@ -34,21 +34,6 @@ export interface PostTrafficActivityState {
 	isError: boolean;
 	hasData: boolean;
 	refetch: () => void;
-}
-
-/**
- * Extract a shape-validated `YYYY-MM-DD` day from an ISO report param. The
- * params originate from URL search params; a malformed bound disables the
- * window rather than reaching `parseISO`/`eachDayOfInterval` (which throw).
- *
- * @param value - The ISO date-time string.
- * @return The date-only day, or undefined when missing/malformed.
- */
-function toDay( value?: string ): string | undefined {
-	const day = value?.slice( 0, 10 );
-	return day && /^\d{4}-\d{2}-\d{2}$/.test( day ) && ! Number.isNaN( parseISO( day ).getTime() )
-		? day
-		: undefined;
 }
 
 /**

--- a/projects/packages/premium-analytics/widgets/search-terms/use-search-term-views.ts
+++ b/projects/packages/premium-analytics/widgets/search-terms/use-search-term-views.ts
@@ -73,8 +73,6 @@ export default function useSearchTermViews( {
 		// refetch failure doesn't replace populated rows with the error state.
 		isError: items.length === 0 && hasError,
 		hasComparison: comparisonUsable,
-		// The data layer's combined refetch: memoized, awaits both queries, and
-		// skips the comparison query when comparison is disabled.
 		refetch,
 	};
 }

--- a/projects/packages/premium-analytics/widgets/top-platforms/use-platform-views.ts
+++ b/projects/packages/premium-analytics/widgets/top-platforms/use-platform-views.ts
@@ -117,8 +117,6 @@ export default function usePlatformViews( {
 		// refetch failure doesn't replace populated rows with the error state.
 		isError: rows.length === 0 && isError,
 		errorReason,
-		// The data layer's combined refetch: memoized, awaits both queries, and
-		// skips the comparison query when comparison is disabled.
 		refetch,
 	};
 }

--- a/projects/packages/premium-analytics/widgets/utm-insights/use-utm-insights.ts
+++ b/projects/packages/premium-analytics/widgets/utm-insights/use-utm-insights.ts
@@ -97,8 +97,6 @@ export default function useUtmInsights( {
 		// Stats queries keep previous data via `placeholderData`, so a failed
 		// range refetch should not replace populated rows with the error state.
 		isError: rows.length === 0 && isError,
-		// The data layer's combined refetch: memoized, awaits both queries, and
-		// skips the comparison query when comparison is disabled.
 		refetch,
 	};
 }


### PR DESCRIPTION
Fixes WOOA7S-1754

Part 1 of 2. This half is the low-risk helper moves; the chart-helper generalization is a stacked follow-up (#50725).

## Proposed changes

* Move the two identical `readCount()` copies (`all-time-stats`, `most-popular-day`) into `widgets-toolkit` as `summaryCount()`, renamed to drop the `read`/`get` prefix now that it is public API.
* Hoist `toDay()` into `widgets-toolkit`, converging on the stricter of the two former copies — the one that adds a `parseISO` calendar-validity check.
* Delete a two-line combined-refetch comment restated verbatim in five view hooks, and extend the canonical statement where the `refetch` is built (`packages/data/src/hooks/use-report.ts`) to also cover the memoization and disabled-comparison skip.
* Add direct unit tests for both moved helpers, which were previously module-private and untested.

A function-level audit of the Stats widgets found duplication an earlier file-level pass missed. Widgets may not import one another, so shared code moves up into `widgets-toolkit`. Adopting the stricter `toDay()` changes `post-detail-highlights` for a well-shaped but impossible date such as `2026-02-31` — it now returns `undefined` instead of the string. That path is reachable only via a hand-edited deep link (every producer of these params goes through a real `Date`), and on it the new behavior is the safer one: the highlight falls through to its documented "all-time when the window is missing" branch instead of a window that lexically matched real days and produced a plausible-but-wrong sum.

## Related product discussion/links

* WOOA7S-1754

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run `pnpm --filter @automattic/jetpack-premium-analytics test` and `pnpm --filter @automattic/jetpack-premium-analytics typecheck`; both should be clean.
* No user-facing change under normal, UI-driven use.
