### PR TITLE
Stats widgets: share chart granularity and metric-tab helpers

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1754-chart-helpers
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1754-chart-helpers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Stats widgets: Share the chart granularity and metric tab helpers across chart widgets.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/build-metric-tab.test.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/build-metric-tab.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Internal dependencies
+ */
+import { buildMetricTab } from '../build-metric-tab';
+
+describe( 'buildMetricTab', () => {
+	it( 'reads the headline from summary, not by re-summing the data points', () => {
+		// Deliberately disagree: a real sanitizer never produces this, but WordAds
+		// `cpm` is a period-weighted average, not a sum of point values — if this
+		// ever regressed to re-summing, every traffic-chart test (where summary and
+		// the row sum coincide) would stay green while CPM silently corrupted.
+		const tab = buildMetricTab( {
+			primary: { summary: { views: 999 }, data: [ { date_start: '2026-05-01', views: 1 } ] },
+			comparison: undefined,
+			hasComparison: false,
+			field: 'views',
+			label: 'Views',
+		} );
+
+		expect( tab.value ).toBe( 999 );
+	} );
+
+	it( 'passes dataFormat through unchanged', () => {
+		const dataFormat = { type: 'currency' as const };
+		const tab = buildMetricTab( {
+			primary: { summary: { cpm: 4.5 }, data: [] },
+			comparison: undefined,
+			hasComparison: false,
+			field: 'cpm',
+			label: 'CPM',
+			dataFormat,
+		} );
+
+		expect( tab.dataFormat ).toBe( dataFormat );
+	} );
+
+	it( 'maps one point per row, oldest first, with a real Date', () => {
+		const tab = buildMetricTab( {
+			primary: {
+				summary: { views: 30 },
+				data: [
+					{ date_start: '2026-05-01', views: 10 },
+					{ date_start: '2026-05-02', views: 20 },
+				],
+			},
+			comparison: undefined,
+			hasComparison: false,
+			field: 'views',
+			label: 'Views',
+		} );
+
+		expect( tab.current ).toHaveLength( 2 );
+		expect( tab.current[ 0 ].value ).toBe( 10 );
+		expect( tab.current[ 1 ].value ).toBe( 20 );
+		expect( tab.current[ 0 ].date ).toBeInstanceOf( Date );
+		expect( tab.current[ 0 ].date.getTime() ).toBeLessThan( tab.current[ 1 ].date.getTime() );
+	} );
+
+	it( 'includes real previous-period values when comparison is on and has rows', () => {
+		const tab = buildMetricTab( {
+			primary: { summary: { views: 30 }, data: [ { date_start: '2026-05-01', views: 30 } ] },
+			comparison: { summary: { views: 12 }, data: [ { date_start: '2026-04-01', views: 12 } ] },
+			hasComparison: true,
+			field: 'views',
+			label: 'Views',
+		} );
+
+		expect( tab.previousValue ).toBe( 12 );
+		expect( tab.previous ).toHaveLength( 1 );
+		expect( tab.previous?.[ 0 ].value ).toBe( 12 );
+	} );
+
+	it( 'omits previous when comparison is off', () => {
+		const tab = buildMetricTab( {
+			primary: { summary: { views: 30 }, data: [ { date_start: '2026-05-01', views: 30 } ] },
+			comparison: { summary: { views: 12 }, data: [ { date_start: '2026-04-01', views: 12 } ] },
+			hasComparison: false,
+			field: 'views',
+			label: 'Views',
+		} );
+
+		expect( tab.previousValue ).toBeUndefined();
+		expect( tab.previous ).toBeUndefined();
+	} );
+
+	// The misleading-zero guard: comparison is on, but the comparison report has
+	// no rows (still loading, or a genuinely empty period). `previousValue` must
+	// read as absent, not as a previous total of 0.
+	it( 'omits previous when comparison is on but the comparison report has no rows', () => {
+		const tab = buildMetricTab( {
+			primary: { summary: { views: 30 }, data: [ { date_start: '2026-05-01', views: 30 } ] },
+			comparison: { summary: { views: 0 }, data: [] },
+			hasComparison: true,
+			field: 'views',
+			label: 'Views',
+		} );
+
+		expect( tab.previousValue ).toBeUndefined();
+		expect( tab.previous ).toBeUndefined();
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/default-period-for-interval.test.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/default-period-for-interval.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Internal dependencies
+ */
+import { defaultPeriodForInterval } from '../default-period-for-interval';
+
+// The two period sets in use. Both are ordered finest to coarsest, which the
+// helper relies on when clamping.
+const DAY_WEEK_MONTH = [ 'day', 'week', 'month' ] as const;
+const DAY_WEEK_MONTH_YEAR = [ 'day', 'week', 'month', 'year' ] as const;
+
+describe( 'defaultPeriodForInterval', () => {
+	describe( 'day/week/month widgets (traffic chart, subscribers chart)', () => {
+		it.each( [
+			[ 'week', 'week' ],
+			[ 'month', 'month' ],
+			[ 'quarter', 'month' ],
+			// No year option in the dropdown, so year clamps to the coarsest allowed.
+			[ 'year', 'month' ],
+			[ 'day', 'day' ],
+			[ 'hour', 'day' ],
+			[ undefined, 'day' ],
+			[ 'nonsense', 'day' ],
+		] )( 'maps %s to %s', ( interval, expected ) => {
+			expect( defaultPeriodForInterval( interval, DAY_WEEK_MONTH ) ).toBe( expected );
+		} );
+	} );
+
+	describe( 'day/week/month/year widgets (wordads chart tabs)', () => {
+		it.each( [
+			[ 'week', 'week' ],
+			[ 'month', 'month' ],
+			[ 'quarter', 'month' ],
+			// Year is offered here, so it is kept rather than collapsed.
+			[ 'year', 'year' ],
+			[ 'day', 'day' ],
+			[ undefined, 'day' ],
+			[ 'nonsense', 'day' ],
+		] )( 'maps %s to %s', ( interval, expected ) => {
+			expect( defaultPeriodForInterval( interval, DAY_WEEK_MONTH_YEAR ) ).toBe( expected );
+		} );
+	} );
+
+	it( 'clamps to the coarsest allowed period when the mapped one is unsupported', () => {
+		expect( defaultPeriodForInterval( 'year', [ 'day', 'week' ] as const ) ).toBe( 'week' );
+		expect( defaultPeriodForInterval( 'month', [ 'day' ] as const ) ).toBe( 'day' );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/to-day.test.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/to-day.test.ts
@@ -26,9 +26,13 @@ describe( 'toDay', () => {
 		expect( toDay( 'not-a-date' ) ).toBeUndefined();
 	} );
 
-	// The reason the stricter of the two former copies is the one hoisted:
-	// callers feed the result to parseISO/eachDayOfInterval, which throw on a
-	// well-shaped but non-existent calendar day.
+	// The reason the stricter of the two former copies is the one hoisted: it
+	// protects two callers for two different reasons. `post-traffic-activity`
+	// feeds the result to parseISO/eachDayOfInterval, which throw on a
+	// well-shaped but non-existent day. `post-detail-highlights` only compares
+	// days as strings, so it wouldn't throw — but the loose check let a bad
+	// `from` still lexically match real days, producing a plausible-looking
+	// windowed sum instead of the documented all-time fallback.
 	it( 'returns undefined for a well-shaped but impossible calendar date', () => {
 		expect( toDay( '2026-02-31' ) ).toBeUndefined();
 		expect( toDay( '2026-13-01' ) ).toBeUndefined();

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/build-metric-tab.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/build-metric-tab.ts
@@ -34,7 +34,8 @@ export type BuildMetricTabOptions< TReport extends MetricReport > = {
 
 /**
  * Read a field's total from a report's summary. Reports carry dynamic WPCOM
- * keys, so the field is looked up rather than typed.
+ * keys, so the field is looked up rather than typed. Deliberately does not use
+ * `summaryCount`: a chart headline needs a number to render, not an absence.
  *
  * @param report - The normalized report, or undefined while loading.
  * @param field  - The metric field to read.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/build-metric-tab.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/build-metric-tab.ts
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import { localTZDate } from '@jetpack-premium-analytics/data';
+/**
+ * Internal dependencies
+ */
+import type { MetricTab } from '../components';
+import type { DataFormat } from '../types';
+
+/**
+ * The shape `buildMetricTab` reads: a normalized Stats report's summary plus its
+ * time series. Both `StatsVisitsResponse` and `StatsWordAdsResponse` satisfy it.
+ */
+export type MetricReport = {
+	summary?: Record< string, unknown >;
+	data?: Array< { date_start: string } >;
+};
+
+export type BuildMetricTabOptions< TReport extends MetricReport > = {
+	/** The current-period report for this field. */
+	primary: TReport | undefined;
+	/** The previous-period report, when comparison is on. */
+	comparison: TReport | undefined;
+	/** Whether the dashboard comparison is enabled. */
+	hasComparison: boolean;
+	/** The metric field, also used as the tab key. */
+	field: string;
+	/** The translated tab label. */
+	label: string;
+	/** Per-metric format override (e.g. currency); falls back to the chart default. */
+	dataFormat?: DataFormat;
+};
+
+/**
+ * Read a field's total from a report's summary. Reports carry dynamic WPCOM
+ * keys, so the field is looked up rather than typed.
+ *
+ * @param report - The normalized report, or undefined while loading.
+ * @param field  - The metric field to read.
+ * @return The summary total, or 0 when the report is empty.
+ */
+function total( report: MetricReport | undefined, field: string ): number {
+	return Number( report?.summary?.[ field ] ?? 0 );
+}
+
+/**
+ * Map a field of a normalized report into chart points.
+ *
+ * @param report - The normalized report, or undefined while loading.
+ * @param field  - The metric field to read from each period.
+ * @return One point per period, oldest first.
+ */
+function toPoints( report: MetricReport | undefined, field: string ) {
+	return ( report?.data ?? [] ).map( point => ( {
+		date: localTZDate( point.date_start ),
+		value: Number( ( point as Record< string, unknown > )[ field ] ?? 0 ),
+	} ) );
+}
+
+/**
+ * Build one metric tab from a primary/comparison report pair. The headline is
+ * the period total; the previous-period total and overlay are included only when
+ * comparison is on *and* the comparison request actually returned rows — while
+ * that request is still loading or came back empty, its total would be `0`,
+ * which would render a misleading previous-period value.
+ *
+ * @param options - The report pair, field, and presentation options.
+ * @return The metric tab.
+ */
+export function buildMetricTab< TReport extends MetricReport >(
+	options: BuildMetricTabOptions< TReport >
+): MetricTab {
+	const { primary, comparison, hasComparison, field, label, dataFormat } = options;
+	const previous = hasComparison ? toPoints( comparison, field ) : undefined;
+	const hasPrevious = !! previous?.length;
+
+	return {
+		key: field,
+		label,
+		value: total( primary, field ),
+		previousValue: hasPrevious ? total( comparison, field ) : undefined,
+		current: toPoints( primary, field ),
+		previous: hasPrevious ? previous : undefined,
+		dataFormat,
+	};
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/default-period-for-interval.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/default-period-for-interval.ts
@@ -1,0 +1,30 @@
+/**
+ * Default chart granularity for a dashboard interval: opens a granularity
+ * control at the setting the range implies, and — until the user picks one
+ * explicitly — keeps following the range.
+ *
+ * A widget's dropdown rarely offers every granularity, so the mapped period is
+ * clamped to the coarsest one the widget does offer. That is why a quarter or
+ * year range lands on `month` for a day/week/month widget but keeps `year` for
+ * one that offers it.
+ *
+ * @param interval - The dashboard-derived interval.
+ * @param allowed  - The periods this widget offers, ordered finest to coarsest.
+ * @return The matching selectable granularity.
+ */
+export function defaultPeriodForInterval< P extends string >(
+	interval: string | undefined,
+	allowed: readonly P[]
+): P {
+	const mapped =
+		{
+			week: 'week',
+			month: 'month',
+			quarter: 'month',
+			year: 'year',
+		}[ interval ?? '' ] ?? 'day';
+
+	const supported = allowed.includes( mapped as P );
+
+	return supported ? ( mapped as P ) : allowed[ allowed.length - 1 ];
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/default-period-for-interval.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/default-period-for-interval.ts
@@ -8,13 +8,19 @@
  * year range lands on `month` for a day/week/month widget but keeps `year` for
  * one that offers it.
  *
+ * The clamp always falls back to the *coarsest* end of `allowed`. That is only
+ * correct because every caller's set includes `day`, the finest granularity —
+ * an unmapped/unsupported interval defaults to `day` before the clamp runs, so
+ * the fallback is only ever reached from "too coarse". A widget whose set omits
+ * `day` (e.g. `[ 'week', 'month' ]`) would clamp in the wrong direction.
+ *
  * @param interval - The dashboard-derived interval.
  * @param allowed  - The periods this widget offers, ordered finest to coarsest.
  * @return The matching selectable granularity.
  */
 export function defaultPeriodForInterval< P extends string >(
 	interval: string | undefined,
-	allowed: readonly P[]
+	allowed: readonly [ P, ...P[] ]
 ): P {
 	const mapped =
 		{

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/index.ts
@@ -52,3 +52,4 @@ export { getVideoKey, getVideoLabel } from './video-plays';
 export { toMaxRows } from './to-max-rows';
 export { summaryCount } from './summary-count';
 export { toDay } from './to-day';
+export { defaultPeriodForInterval } from './default-period-for-interval';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/index.ts
@@ -53,3 +53,4 @@ export { toMaxRows } from './to-max-rows';
 export { summaryCount } from './summary-count';
 export { toDay } from './to-day';
 export { defaultPeriodForInterval } from './default-period-for-interval';
+export { buildMetricTab, type MetricReport, type BuildMetricTabOptions } from './build-metric-tab';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -133,6 +133,7 @@ export {
 	toMaxRows,
 	summaryCount,
 	toDay,
+	defaultPeriodForInterval,
 } from './helpers';
 
 /**

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -134,6 +134,7 @@ export {
 	summaryCount,
 	toDay,
 	defaultPeriodForInterval,
+	buildMetricTab,
 } from './helpers';
 
 /**

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/render.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/render.tsx
@@ -7,6 +7,7 @@ import {
 	WidgetState,
 	useWidgetRootContext,
 	ChartEmptyState,
+	defaultPeriodForInterval,
 	type MetricTab,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
@@ -47,29 +48,14 @@ const DATA_FORMAT = {
 	options: { useMultipliers: true, decimals: 0 },
 };
 
-/**
- * Default granularity for the dashboard interval: opens the dropdown at the
- * granularity the range implies (and, until the user picks one explicitly,
- * keeps following the range). The subscribers endpoint only buckets by
- * day/week/month, so finer/coarser dashboard intervals collapse onto those —
- * this mirrors `getStatsPeriodFromInterval` + `toSubscribersUnit` in the data
- * layer, narrowed to the dropdown's options.
- *
- * @param interval - The dashboard-derived interval.
- * @return The matching selectable granularity.
- */
-function defaultPeriodForInterval( interval?: string ): SubscribersPeriod {
-	switch ( interval ) {
-		case 'week':
-			return 'week';
-		case 'month':
-		case 'quarter':
-		case 'year':
-			return 'month';
-		default:
-			return 'day';
-	}
-}
+// Ordered finest to coarsest, as `defaultPeriodForInterval` requires. Mirrors
+// `getStatsPeriodFromInterval` + `toSubscribersUnit` in the data layer, narrowed
+// to the dropdown's options.
+const SUBSCRIBERS_PERIODS = [
+	'day',
+	'week',
+	'month',
+] as const satisfies readonly SubscribersPeriod[];
 
 /**
  * The latest value of a metric in a window — each point is the cumulative count
@@ -162,7 +148,9 @@ function SubscribersChartInner( {
 	// `day` granularity (and blowing up the bucket count) while the user
 	// hasn't picked a granularity themselves.
 	const period: SubscribersPeriod =
-		granularity === 'auto' ? defaultPeriodForInterval( reportParams.interval ) : granularity;
+		granularity === 'auto'
+			? defaultPeriodForInterval( reportParams.interval, SUBSCRIBERS_PERIODS )
+			: granularity;
 
 	const state = useSubscribersChart( reportParams, period );
 	const metricTabs = useMemo( () => buildMetrics( state, metricIds ), [ state, metricIds ] );

--- a/projects/packages/premium-analytics/widgets/traffic-chart/__tests__/use-traffic-chart.test.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/__tests__/use-traffic-chart.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * External dependencies
+ */
+import { queryClient } from '@jetpack-premium-analytics/data';
+import { QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+/**
+ * Internal dependencies
+ */
+import useTrafficChart from '../use-traffic-chart';
+import type { ReportParams } from '@jetpack-premium-analytics/data';
+import type { ReactNode } from 'react';
+
+jest.mock( '@wordpress/api-fetch' );
+
+const mockApiFetch = apiFetch as jest.MockedFunction< typeof apiFetch >;
+
+// Raw WPCOM `stats/visits` matrix shape. Two monthly buckets, so each field's
+// summary is the total across both.
+const VIEWS_VISITORS_RESPONSE = {
+	unit: 'month',
+	fields: [ 'period', 'views', 'visitors' ],
+	data: [
+		[ '2026-05', 1200, 900 ],
+		[ '2026-06', 800, 600 ],
+	],
+};
+
+const LIKES_COMMENTS_RESPONSE = {
+	unit: 'month',
+	fields: [ 'period', 'likes', 'comments' ],
+	data: [
+		[ '2026-05', 30, 12 ],
+		[ '2026-06', 20, 8 ],
+	],
+};
+
+// Lower comparison periods, one bucket each, so previous values are distinct.
+const VIEWS_VISITORS_COMPARISON = {
+	unit: 'month',
+	fields: [ 'period', 'views', 'visitors' ],
+	data: [ [ '2026-03', 500, 400 ] ],
+};
+
+const LIKES_COMMENTS_COMPARISON = {
+	unit: 'month',
+	fields: [ 'period', 'likes', 'comments' ],
+	data: [ [ '2026-03', 10, 4 ] ],
+};
+
+const RANGE: ReportParams = {
+	from: '2026-05-01',
+	to: '2026-06-30',
+	interval: 'month',
+};
+
+const RANGE_WITH_COMPARISON: ReportParams = {
+	...RANGE,
+	comp: '1',
+	compare_from: '2026-03-01',
+	compare_to: '2026-03-31',
+};
+
+/** Per-pair comparison fixtures, keyed by which of the two concurrent requests they answer. */
+type ComparisonFixtures = {
+	viewsVisitors: unknown;
+	likesComments: unknown;
+};
+
+/**
+ * Route each of the two concurrent requests (and their comparison variants) to
+ * its own fixture.
+ *
+ * @param comparison - Optional per-pair comparison fixtures.
+ */
+function routeRequests( comparison?: ComparisonFixtures ) {
+	mockApiFetch.mockImplementation( ( { path = '' }: { path?: string } ) => {
+		const isViewsVisitors = path.includes( 'views' );
+
+		if ( comparison && path.includes( 'date=2026-03-31' ) ) {
+			return Promise.resolve(
+				isViewsVisitors ? comparison.viewsVisitors : comparison.likesComments
+			);
+		}
+
+		return Promise.resolve( isViewsVisitors ? VIEWS_VISITORS_RESPONSE : LIKES_COMMENTS_RESPONSE );
+	} );
+}
+
+function wrapper( { children }: { children: ReactNode } ) {
+	return <QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>;
+}
+
+describe( 'useTrafficChart', () => {
+	beforeEach( () => {
+		// The data package's query client is a module-level singleton; drop its
+		// cache so each test starts from a fresh fetch.
+		queryClient.clear();
+		mockApiFetch.mockReset();
+		routeRequests();
+	} );
+
+	it( 'builds one tab per metric in canonical order, with summary totals', async () => {
+		const { result } = renderHook( () => useTrafficChart( RANGE, 'month' ), { wrapper } );
+
+		await waitFor( () => expect( result.current.isFetching ).toBe( false ) );
+
+		const metrics = result.current.metrics;
+		expect( metrics.map( metric => metric.key ) ).toEqual( [
+			'views',
+			'visitors',
+			'likes',
+			'comments',
+		] );
+		// This only proves `value` is each metric's correct total (not a
+		// hardcoded or swapped field) — sanitizeStatsTimeSeriesResponse derives
+		// the summary by summing these same rows, so it can't tell a
+		// summary-read apart from a re-sum of the points.
+		expect( metrics[ 0 ].value ).toBe( 2000 );
+		expect( metrics[ 1 ].value ).toBe( 1500 );
+		expect( metrics[ 2 ].value ).toBe( 50 );
+		expect( metrics[ 3 ].value ).toBe( 20 );
+	} );
+
+	it( 'maps one chart point per period, oldest first', async () => {
+		const { result } = renderHook( () => useTrafficChart( RANGE, 'month' ), { wrapper } );
+
+		await waitFor( () => expect( result.current.isFetching ).toBe( false ) );
+
+		const views = result.current.metrics[ 0 ];
+		expect( views.current ).toHaveLength( 2 );
+		expect( views.current[ 0 ].value ).toBe( 1200 );
+		expect( views.current[ 1 ].value ).toBe( 800 );
+		expect( views.current[ 0 ].date ).toBeInstanceOf( Date );
+		expect( views.current[ 0 ].date.getTime() ).toBeLessThan( views.current[ 1 ].date.getTime() );
+	} );
+
+	it( 'omits the previous period when comparison is off', async () => {
+		const { result } = renderHook( () => useTrafficChart( RANGE, 'month' ), { wrapper } );
+
+		await waitFor( () => expect( result.current.isFetching ).toBe( false ) );
+
+		for ( const metric of result.current.metrics ) {
+			expect( metric.previous ).toBeUndefined();
+			expect( metric.previousValue ).toBeUndefined();
+		}
+	} );
+
+	it( 'maps previous-period totals when comparison params are present', async () => {
+		routeRequests( {
+			viewsVisitors: VIEWS_VISITORS_COMPARISON,
+			likesComments: LIKES_COMMENTS_COMPARISON,
+		} );
+
+		const { result } = renderHook( () => useTrafficChart( RANGE_WITH_COMPARISON, 'month' ), {
+			wrapper,
+		} );
+
+		await waitFor( () => expect( result.current.isFetching ).toBe( false ) );
+
+		const metrics = result.current.metrics;
+		expect( metrics[ 0 ].previousValue ).toBe( 500 );
+		expect( metrics[ 1 ].previousValue ).toBe( 400 );
+		expect( metrics[ 2 ].previousValue ).toBe( 10 );
+		expect( metrics[ 3 ].previousValue ).toBe( 4 );
+		expect( metrics[ 0 ].previous ).toHaveLength( 1 );
+	} );
+
+	// The misleading-zero guard: an empty comparison response must read as "no
+	// previous period", not as a previous total of 0 (which would render a
+	// -100% delta against a real current value).
+	it( 'omits the previous period when the comparison request returns no rows', async () => {
+		const empty = {
+			unit: 'month',
+			fields: [ 'period', 'views', 'visitors' ],
+			data: [],
+		};
+		routeRequests( { viewsVisitors: empty, likesComments: empty } );
+
+		const { result } = renderHook( () => useTrafficChart( RANGE_WITH_COMPARISON, 'month' ), {
+			wrapper,
+		} );
+
+		await waitFor( () => expect( result.current.isFetching ).toBe( false ) );
+
+		for ( const metric of result.current.metrics ) {
+			expect( metric.previous ).toBeUndefined();
+			expect( metric.previousValue ).toBeUndefined();
+		}
+	} );
+
+	it( 'yields only the selected metrics, in canonical order', async () => {
+		// Ids passed out of canonical order to prove the order comes from the
+		// definitions, not the selection.
+		const { result } = renderHook(
+			() => useTrafficChart( RANGE, 'month', [ 'comments', 'views' ] ),
+			{ wrapper }
+		);
+
+		await waitFor( () => expect( result.current.isFetching ).toBe( false ) );
+
+		expect( result.current.metrics.map( metric => metric.key ) ).toEqual( [ 'views', 'comments' ] );
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/traffic-chart/__tests__/use-traffic-chart.test.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/__tests__/use-traffic-chart.test.tsx
@@ -171,9 +171,11 @@ describe( 'useTrafficChart', () => {
 	// previous period", not as a previous total of 0 (which would render a
 	// -100% delta against a real current value).
 	it( 'omits the previous period when the comparison request returns no rows', async () => {
+		// Shared between the views/visitors and likes/comments requests below, so
+		// `fields` names neither pair specifically; `data: []` means it's never read.
 		const empty = {
 			unit: 'month',
-			fields: [ 'period', 'views', 'visitors' ],
+			fields: [ 'period' ],
 			data: [],
 		};
 		routeRequests( { viewsVisitors: empty, likesComments: empty } );

--- a/projects/packages/premium-analytics/widgets/traffic-chart/render.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/render.tsx
@@ -6,6 +6,7 @@ import {
 	WidgetRoot,
 	WidgetState,
 	useWidgetRootContext,
+	defaultPeriodForInterval,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { reports } from '@jetpack-premium-analytics/icons';
@@ -36,27 +37,8 @@ const DATA_FORMAT = {
 	options: { useMultipliers: true, decimals: 0 },
 };
 
-/**
- * Default granularity for the dashboard interval: opens the control at the
- * granularity the range implies (and, until the user picks one explicitly,
- * keeps following the range). The dropdown only offers day/week/month, so
- * finer/coarser dashboard intervals collapse onto those.
- *
- * @param interval - The dashboard-derived interval.
- * @return The matching selectable granularity.
- */
-function defaultPeriodForInterval( interval?: string ): TrafficPeriod {
-	switch ( interval ) {
-		case 'week':
-			return 'week';
-		case 'month':
-		case 'quarter':
-		case 'year':
-			return 'month';
-		default:
-			return 'day';
-	}
-}
+// Ordered finest to coarsest, as `defaultPeriodForInterval` requires.
+const TRAFFIC_PERIODS = [ 'day', 'week', 'month' ] as const satisfies readonly TrafficPeriod[];
 
 type TrafficChartInnerProps = {
 	/**
@@ -86,7 +68,9 @@ function TrafficChartInner( { granularity, metrics }: TrafficChartInnerProps ) {
 	// granularity (and blow up the bucket count) while the user hasn't picked
 	// a granularity themselves.
 	const period: TrafficPeriod =
-		granularity === 'auto' ? defaultPeriodForInterval( reportParams.interval ) : granularity;
+		granularity === 'auto'
+			? defaultPeriodForInterval( reportParams.interval, TRAFFIC_PERIODS )
+			: granularity;
 
 	const {
 		metrics: metricTabs,

--- a/projects/packages/premium-analytics/widgets/traffic-chart/use-traffic-chart.ts
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/use-traffic-chart.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import {
-	localTZDate,
 	useStatsVisits,
 	type ReportParams,
 	type StatsPeriod,
@@ -19,7 +18,7 @@ import {
 	TRAFFIC_CHART_METRICS,
 	type TrafficChartMetricId,
 } from './widget';
-import type { MetricTab } from '@jetpack-premium-analytics/widgets-toolkit';
+import { buildMetricTab, type MetricTab } from '@jetpack-premium-analytics/widgets-toolkit';
 
 /**
  * Granularity the chart can be grouped by. Layered onto the dashboard range as
@@ -40,65 +39,6 @@ export interface TrafficChartState {
 	isFetching: boolean;
 	isError: boolean;
 	refetch: () => void;
-}
-
-/**
- * Sum a single field across every period of a normalized visits report — the
- * period total the metric card shows as its headline.
- *
- * @param report - The normalized visits report, or undefined while loading.
- * @param field  - The metric field to total (views/visitors/likes/comments).
- * @return The period total, or 0 when the report is empty.
- */
-function total( report: StatsVisitsResponse | undefined, field: string ): number {
-	return Number( report?.summary?.[ field ] ?? 0 );
-}
-
-/**
- * Map a single field of a normalized visits report into chart points.
- *
- * @param report - The normalized visits report, or undefined while loading.
- * @param field  - The metric field to read from each period.
- * @return One point per period, oldest first.
- */
-function toPoints( report: StatsVisitsResponse | undefined, field: string ) {
-	return ( report?.data ?? [] ).map( point => ( {
-		date: localTZDate( point.date_start ),
-		value: Number( point[ field ] ?? 0 ),
-	} ) );
-}
-
-/**
- * Build one metric tab from the request that carries its field. The headline is
- * the period total; the previous-period total and overlay are included only when
- * comparison is on *and* the comparison request actually returned rows — while
- * that request is still loading or came back empty, `total()` would be `0`, which
- * would render a misleading previous-period value.
- *
- * @param primary       - The current-period report for this field.
- * @param comparison    - The previous-period report, when comparison is on.
- * @param hasComparison - Whether the dashboard comparison is enabled.
- * @param field         - The metric field, also used as the tab key.
- * @param label         - The translated tab label.
- * @return The metric tab.
- */
-function toMetric(
-	primary: StatsVisitsResponse | undefined,
-	comparison: StatsVisitsResponse | undefined,
-	hasComparison: boolean,
-	field: string,
-	label: string
-): MetricTab {
-	const previous = hasComparison ? toPoints( comparison, field ) : undefined;
-	const hasPrevious = !! previous?.length;
-	return {
-		key: field,
-		label,
-		value: total( primary, field ),
-		previousValue: hasPrevious ? total( comparison, field ) : undefined,
-		current: toPoints( primary, field ),
-		previous: hasPrevious ? previous : undefined,
-	};
 }
 
 /**
@@ -168,13 +108,13 @@ export default function useTrafficChart(
 		() =>
 			TRAFFIC_CHART_METRICS.filter( metric => selected.has( metric.id ) ).map( metric => {
 				const isViewsVisitors = metric.id === 'views' || metric.id === 'visitors';
-				return toMetric(
-					isViewsVisitors ? vvPrimary : lcPrimary,
-					isViewsVisitors ? vvComparison : lcComparison,
-					isViewsVisitors ? vvHasComparison : lcHasComparison,
-					metric.id,
-					metric.label
-				);
+				return buildMetricTab( {
+					primary: isViewsVisitors ? vvPrimary : lcPrimary,
+					comparison: isViewsVisitors ? vvComparison : lcComparison,
+					hasComparison: isViewsVisitors ? vvHasComparison : lcHasComparison,
+					field: metric.id,
+					label: metric.label,
+				} );
 			} ),
 		[ selected, vvPrimary, vvComparison, vvHasComparison, lcPrimary, lcComparison, lcHasComparison ]
 	);

--- a/projects/packages/premium-analytics/widgets/wordads-chart-tabs/render.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-chart-tabs/render.tsx
@@ -7,6 +7,7 @@ import {
 	WidgetRoot,
 	WidgetState,
 	useWidgetRootContext,
+	defaultPeriodForInterval,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';
@@ -28,28 +29,14 @@ const DATA_FORMAT = {
 	options: { useMultipliers: true, decimals: 0 },
 };
 
-/**
- * Default granularity for the dashboard interval: opens the control at the
- * granularity the range implies (and, until the user picks one explicitly,
- * keeps following the range). The dropdown offers day/week/month/year, so a
- * dashboard quarter interval collapses onto month.
- *
- * @param interval - The dashboard-derived interval.
- * @return The matching selectable granularity.
- */
-function defaultPeriodForInterval( interval?: string ): WordAdsPeriod {
-	switch ( interval ) {
-		case 'week':
-			return 'week';
-		case 'month':
-		case 'quarter':
-			return 'month';
-		case 'year':
-			return 'year';
-		default:
-			return 'day';
-	}
-}
+// Ordered finest to coarsest, as `defaultPeriodForInterval` requires. Unlike the
+// traffic and subscribers charts, this dropdown offers year.
+const WORDADS_PERIODS = [
+	'day',
+	'week',
+	'month',
+	'year',
+] as const satisfies readonly WordAdsPeriod[];
 
 type WordAdsChartTabsInnerProps = {
 	/**
@@ -81,7 +68,9 @@ function WordAdsChartTabsInner( { granularity, metricIds }: WordAdsChartTabsInne
 	// granularity (and blow up the bucket count) while the user hasn't picked
 	// a granularity themselves.
 	const period: WordAdsPeriod =
-		granularity === 'auto' ? defaultPeriodForInterval( reportParams.interval ) : granularity;
+		granularity === 'auto'
+			? defaultPeriodForInterval( reportParams.interval, WORDADS_PERIODS )
+			: granularity;
 
 	const { metrics, isLoading, isFetching, isError, isEmpty, refetch } = useWordAdsChart(
 		reportParams,

--- a/projects/packages/premium-analytics/widgets/wordads-chart-tabs/use-wordads-chart.ts
+++ b/projects/packages/premium-analytics/widgets/wordads-chart-tabs/use-wordads-chart.ts
@@ -2,7 +2,6 @@
  * External dependencies
  */
 import {
-	localTZDate,
 	sliceWordAdsStatsReport,
 	useStatsWordAdsStats,
 	type ReportParams,
@@ -19,7 +18,7 @@ import {
 	WORDADS_CHART_METRICS,
 	type WordAdsChartMetricId,
 } from './metrics';
-import type { DataFormat, MetricTab } from '@jetpack-premium-analytics/widgets-toolkit';
+import { buildMetricTab, type MetricTab } from '@jetpack-premium-analytics/widgets-toolkit';
 
 /**
  * Granularity the chart can be grouped by. Layered onto the dashboard range as
@@ -43,69 +42,6 @@ export interface WordAdsChartState {
 	/** True when the current period resolved without any rows. */
 	isEmpty: boolean;
 	refetch: () => void;
-}
-
-/**
- * Read a single field's total from a normalized WordAds report's summary — the
- * headline value the metric card shows (impressions/revenue are period sums; CPM
- * is the period-weighted average the sanitizer computes).
- *
- * @param report - The normalized WordAds report, or undefined while loading.
- * @param field  - The metric field to total (impressions/revenue/cpm).
- * @return The summary total, or 0 when the report is empty.
- */
-function total( report: StatsWordAdsResponse | undefined, field: string ): number {
-	return Number( report?.summary?.[ field ] ?? 0 );
-}
-
-/**
- * Map a single field of a normalized WordAds report into chart points.
- *
- * @param report - The normalized WordAds report, or undefined while loading.
- * @param field  - The metric field to read from each period.
- * @return One point per period, oldest first.
- */
-function toPoints( report: StatsWordAdsResponse | undefined, field: string ) {
-	return ( report?.data ?? [] ).map( point => ( {
-		date: localTZDate( point.date_start ),
-		value: Number( point[ field as keyof typeof point ] ?? 0 ),
-	} ) );
-}
-
-/**
- * Build one metric tab. The headline is the period total; the previous-period
- * total and overlay are included only when comparison is on *and* the comparison
- * request actually returned rows — while that request is still loading or came
- * back empty, `total()` would be `0`, which would render a misleading
- * previous-period value.
- *
- * @param primary       - The current-period report.
- * @param comparison    - The previous-period report, when comparison is on.
- * @param hasComparison - Whether the dashboard comparison is enabled.
- * @param field         - The metric field, also used as the tab key.
- * @param label         - The translated tab label.
- * @param dataFormat    - Optional per-metric format override (currency for revenue/CPM).
- * @return The metric tab.
- */
-function toMetric(
-	primary: StatsWordAdsResponse | undefined,
-	comparison: StatsWordAdsResponse | undefined,
-	hasComparison: boolean,
-	field: string,
-	label: string,
-	dataFormat?: DataFormat
-): MetricTab {
-	const previous = hasComparison ? toPoints( comparison, field ) : undefined;
-	const hasPrevious = !! previous?.length;
-	return {
-		key: field,
-		label,
-		value: total( primary, field ),
-		previousValue: hasPrevious ? total( comparison, field ) : undefined,
-		current: toPoints( primary, field ),
-		previous: hasPrevious ? previous : undefined,
-		dataFormat,
-	};
 }
 
 /**
@@ -171,14 +107,14 @@ export default function useWordAdsChart(
 	const metrics = useMemo(
 		() =>
 			enabledMetrics.map( metric =>
-				toMetric(
-					primaryData,
-					comparisonData,
+				buildMetricTab( {
+					primary: primaryData,
+					comparison: comparisonData,
 					hasComparison,
-					metric.id,
-					metric.label,
-					metric.dataFormat
-				)
+					field: metric.id,
+					label: metric.label,
+					dataFormat: metric.dataFormat,
+				} )
 			),
 		[ enabledMetrics, primaryData, comparisonData, hasComparison ]
 	);


### PR DESCRIPTION
Fixes WOOA7S-1754

Part 2 of 2. Part 1 (#50724) is merged; this half generalizes the chart helpers, which carried more risk, so it was kept separate. (Supersedes #50725, which GitHub auto-closed when part 1's branch was deleted on merge.)

## Proposed changes

* Replace the three local `defaultPeriodForInterval()` copies (`traffic-chart`, `subscribers-chart`, `wordads-chart-tabs`) with one shared helper parameterized by the widget's allowed period set, typed `readonly [P, ...P[]]` so an empty set is a compile error.
* Replace the near-identical `total`/`toPoints`/`toMetric` trios in `use-traffic-chart` and `use-wordads-chart` with a generic `buildMetricTab()` in `widgets-toolkit`; the wordads-only `dataFormat` passthrough becomes optional and the generic form removes a `keyof` cast.
* Add a characterization test for `useTrafficChart` (previously untested), written before the refactor, plus a direct `buildMetricTab` unit test.

Two chart widgets each carried a near-verbatim copy of these helpers, but one copy deliberately differs — `wordads` maps a `year` interval to `year` (its dropdown offers it) while the other two clamp it to `month` — and a naive merge would silently erase that. The shared helper preserves it via the allowed-period parameter. The subtlest preserved behavior is the misleading-zero guard: when comparison is on but the comparison report has no rows, `previousValue`/`previous` must be `undefined`, never `0` (a `0` renders a false −100% delta). `build-metric-tab.test.ts` pins this directly, alongside the `dataFormat` passthrough that drives WordAds currency formatting — neither of which the hook-level tests can isolate.

## Related product discussion/links

* WOOA7S-1754

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run `pnpm --filter @automattic/jetpack-premium-analytics test` and `pnpm --filter @automattic/jetpack-premium-analytics typecheck`; both should be clean.
* No user-facing change: the three chart widgets' granularity defaults and metric tabs render exactly as before.
