### PR TITLE
Boost: fix LCP analysis results silently discarded by fragile lcp_state handling [BOOST-604]

### DIFF
--- a/projects/plugins/boost/app/assets/src/js/features/lcp/lib/stores/lcp-state-types.test.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/lcp/lib/stores/lcp-state-types.test.ts
@@ -119,10 +119,28 @@ describe( 'LcpStateSchema', () => {
 		const result = LcpStateSchema.parse( state );
 
 		expect( result.pages ).toHaveLength( 2 );
-		// The page keeps its real identity; only the bad error degrades to `unknown`.
+		// The page keeps its real identity; only the bad error degrades to the full `unknown`
+		// fallback (both `type` and `meta`, matching the schema's inferred output contract).
 		const badPage = result.pages.find( page => page.key === 'bad-error' );
 		expect( badPage?.url ).toBe( 'https://example.com/bad-error' );
-		expect( badPage?.errors?.[ 0 ].type ).toBe( 'unknown' );
+		expect( badPage?.errors?.[ 0 ] ).toEqual( { type: 'unknown', meta: {} } );
+	} );
+
+	it( 'normalizes an error object with no meta key to an empty meta', () => {
+		// Dropping `.optional()` on `meta` means an absent key must still resolve to `{}` via
+		// `.catch({})` rather than staying undefined; guards that behavior against a future zod change.
+		const state = analyzedState( [
+			{
+				key: 'home',
+				url: 'https://example.com/',
+				status: 'error',
+				errors: [ { type: 'unknown' } ],
+			},
+		] );
+
+		const result = LcpStateSchema.parse( state );
+
+		expect( result.pages[ 0 ].errors?.[ 0 ].meta ).toEqual( {} );
 	} );
 
 	it( 'isolates a malformed page instead of collapsing the array', () => {

--- a/projects/plugins/boost/app/assets/src/js/features/lcp/lib/stores/lcp-state-types.test.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/lcp/lib/stores/lcp-state-types.test.ts
@@ -84,6 +84,26 @@ describe( 'LcpStateSchema', () => {
 		expect( result.pages[ 0 ].errors?.[ 0 ].meta ).toEqual( {} );
 	} );
 
+	it( 'preserves the error type when a non-empty meta is malformed', () => {
+		const state = analyzedState( [
+			{
+				key: 'home',
+				url: 'https://example.com/',
+				status: 'error',
+				// `code` must be a number; a malformed non-empty meta degrades to `{}` but must not
+				// drag the whole error down to the generic `unknown` type (the reason `meta.catch({})`
+				// replaced the previous outer preprocess).
+				errors: [ { type: 'http-error', meta: { code: 'not-a-number' } } ],
+			},
+		] );
+
+		const result = LcpStateSchema.parse( state );
+
+		const error = result.pages[ 0 ].errors?.[ 0 ];
+		expect( error?.type ).toBe( 'http-error' );
+		expect( error?.meta ).toEqual( {} );
+	} );
+
 	it( 'isolates a malformed error entry instead of failing its page', () => {
 		const state = analyzedState( [
 			okPage( 'good' ),
@@ -116,15 +136,28 @@ describe( 'LcpStateSchema', () => {
 		expect( result.pages[ 2 ].key ).toBe( 'b' );
 	} );
 
-	it( 'degrades a malformed top-level state to the not_analyzed fallback instead of throwing', () => {
+	it( 'degrades a non-object top-level state to the not_analyzed fallback instead of throwing', () => {
 		// The disabled-module optimize response is `{ success: false, state: [] }`; the action
 		// schema parses `state` through LcpStateSchema before the `success: false` handler runs, so
-		// `[]` (and any other malformed top-level shape) must degrade rather than throw a ZodError.
-		expect( LcpStateSchema.parse( [] ) ).toEqual( { pages: [], status: 'not_analyzed' } );
-		expect( LcpStateSchema.parse( { status: 'bogus', pages: [] } ) ).toEqual( {
+		// `[]` (a non-object top-level shape) must degrade rather than throw a ZodError.
+		expect( LcpStateSchema.parse( [] ) ).toEqual( {
 			pages: [],
 			status: 'not_analyzed',
+			created: 0,
+			updated: 0,
 		} );
+	} );
+
+	it( 'degrades an invalid top-level status in place without wiping valid pages', () => {
+		const result = LcpStateSchema.parse( {
+			status: 'bogus',
+			pages: [ okPage( 'a' ), okPage( 'b' ) ],
+		} );
+
+		// The status field catches to `not_analyzed`; the two valid pages survive rather than being
+		// collapsed to an empty array by the outer `.catch()`.
+		expect( result.status ).toBe( 'not_analyzed' );
+		expect( result.pages ).toHaveLength( 2 );
 	} );
 
 	it( 'parses a normal analyzed state unchanged', () => {

--- a/projects/plugins/boost/app/assets/src/js/features/lcp/lib/stores/lcp-state-types.test.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/lcp/lib/stores/lcp-state-types.test.ts
@@ -116,6 +116,17 @@ describe( 'LcpStateSchema', () => {
 		expect( result.pages[ 2 ].key ).toBe( 'b' );
 	} );
 
+	it( 'degrades a malformed top-level state to the not_analyzed fallback instead of throwing', () => {
+		// The disabled-module optimize response is `{ success: false, state: [] }`; the action
+		// schema parses `state` through LcpStateSchema before the `success: false` handler runs, so
+		// `[]` (and any other malformed top-level shape) must degrade rather than throw a ZodError.
+		expect( LcpStateSchema.parse( [] ) ).toEqual( { pages: [], status: 'not_analyzed' } );
+		expect( LcpStateSchema.parse( { status: 'bogus', pages: [] } ) ).toEqual( {
+			pages: [],
+			status: 'not_analyzed',
+		} );
+	} );
+
 	it( 'parses a normal analyzed state unchanged', () => {
 		const state = analyzedState( [ okPage( 'a' ), okPage( 'b' ) ] );
 

--- a/projects/plugins/boost/app/assets/src/js/features/lcp/lib/stores/lcp-state-types.test.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/lcp/lib/stores/lcp-state-types.test.ts
@@ -1,0 +1,128 @@
+import { LcpStateSchema } from './lcp-state-types';
+
+/**
+ * Regression coverage for BOOST-604: an LCP state with a valid analysis was silently
+ * discarded because one fragile error `meta` shape collapsed the whole client parse to the
+ * not_analyzed fallback. See the `.catch()` placement and meta tolerance in lcp-state-types.ts.
+ */
+describe( 'LcpStateSchema', () => {
+	const analyzedState = ( pages: unknown[] ) => ( {
+		status: 'analyzed',
+		created: 1,
+		updated: 2,
+		pages,
+	} );
+
+	const okPage = ( key: string ) => ( {
+		key,
+		url: `https://example.com/${ key }`,
+		status: 'success',
+	} );
+
+	it( 'keeps nine good results when one page carries a page-navigated error with empty meta', () => {
+		// The exact live repro: boost-cloud emits `{ type: 'page-navigated', meta: { finalUrl } }`,
+		// the server strips the unknown key and stores `meta` as an empty PHP array, and it reaches
+		// the client JSON-encoded as `[]`.
+		const state = analyzedState( [
+			...Array.from( { length: 9 }, ( _v, i ) => okPage( `page-${ i }` ) ),
+			{
+				key: 'home',
+				url: 'https://example.com/',
+				status: 'error',
+				errors: [ { type: 'page-navigated', meta: [] } ],
+			},
+		] );
+
+		const result = LcpStateSchema.parse( state );
+
+		// Before the fix this collapsed to `{ pages: [], status: 'not_analyzed' }`.
+		expect( result.status ).toBe( 'analyzed' );
+		expect( result.pages ).toHaveLength( 10 );
+
+		const homePage = result.pages.find( page => page.key === 'home' );
+		expect( homePage?.status ).toBe( 'error' );
+		expect( homePage?.errors ).toHaveLength( 1 );
+		// The error survives intact; the empty `[]` meta normalizes to an empty object.
+		expect( homePage?.errors?.[ 0 ].type ).toBe( 'page-navigated' );
+		expect( homePage?.errors?.[ 0 ].meta ).toEqual( {} );
+	} );
+
+	it( 'preserves finalUrl on a page-navigated error meta', () => {
+		const state = analyzedState( [
+			{
+				key: 'home',
+				url: 'https://example.com/',
+				status: 'error',
+				errors: [ { type: 'page-navigated', meta: { finalUrl: 'https://example.com/landing/' } } ],
+			},
+		] );
+
+		const result = LcpStateSchema.parse( state );
+
+		expect( result.pages[ 0 ].errors?.[ 0 ].meta ).toEqual( {
+			finalUrl: 'https://example.com/landing/',
+		} );
+	} );
+
+	it.each( [
+		[ 'empty array', [] ],
+		[ 'null', null ],
+		[ 'empty object', {} ],
+	] )( 'accepts %s as an empty meta', ( _label, meta ) => {
+		const state = analyzedState( [
+			{
+				key: 'home',
+				url: 'https://example.com/',
+				status: 'error',
+				errors: [ { type: 'unknown', meta } ],
+			},
+		] );
+
+		const result = LcpStateSchema.parse( state );
+
+		expect( result.status ).toBe( 'analyzed' );
+		expect( result.pages[ 0 ].errors?.[ 0 ].meta ).toEqual( {} );
+	} );
+
+	it( 'isolates a malformed error entry instead of failing its page', () => {
+		const state = analyzedState( [
+			okPage( 'good' ),
+			{
+				key: 'bad-error',
+				url: 'https://example.com/bad-error',
+				status: 'error',
+				// `null` cannot be an error object; the error-level `.catch()` degrades it.
+				errors: [ null ],
+			},
+		] );
+
+		const result = LcpStateSchema.parse( state );
+
+		expect( result.pages ).toHaveLength( 2 );
+		// The page keeps its real identity; only the bad error degrades to `unknown`.
+		const badPage = result.pages.find( page => page.key === 'bad-error' );
+		expect( badPage?.url ).toBe( 'https://example.com/bad-error' );
+		expect( badPage?.errors?.[ 0 ].type ).toBe( 'unknown' );
+	} );
+
+	it( 'isolates a malformed page instead of collapsing the array', () => {
+		const state = analyzedState( [ okPage( 'a' ), null, okPage( 'b' ) ] );
+
+		const result = LcpStateSchema.parse( state );
+
+		expect( result.status ).toBe( 'analyzed' );
+		expect( result.pages ).toHaveLength( 3 );
+		expect( result.pages[ 0 ].key ).toBe( 'a' );
+		expect( result.pages[ 2 ].key ).toBe( 'b' );
+	} );
+
+	it( 'parses a normal analyzed state unchanged', () => {
+		const state = analyzedState( [ okPage( 'a' ), okPage( 'b' ) ] );
+
+		const result = LcpStateSchema.parse( state );
+
+		expect( result.status ).toBe( 'analyzed' );
+		expect( result.pages ).toHaveLength( 2 );
+		expect( result.pages.every( page => page.status === 'success' ) ).toBe( true );
+	} );
+} );

--- a/projects/plugins/boost/app/assets/src/js/features/lcp/lib/stores/lcp-state-types.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/lcp/lib/stores/lcp-state-types.ts
@@ -30,10 +30,10 @@ export const LcpErrorDetailsSchema = z
 		type: z.union( [ LcpErrorTypeSchema, z.string() ] ),
 		// The server stores empty error meta as an empty PHP array (`[]`), and older payloads may
 		// send `null`; a bare object schema rejects both. `.catch({})` degrades any unparseable
-		// meta (empty array, null, or a malformed known key) to `{}` while preserving the error's
-		// real `type`, so a `page-navigated` (or any empty-meta) error can't fail its page and, in
-		// turn, collapse every analyzed page to the not_analyzed fallback.
-		meta: LcpErrorMetaSchema.catch( {} ).optional(),
+		// meta (empty array, null, absent, or a malformed known key) to `{}` while preserving the
+		// error's real `type`, so a `page-navigated` (or any empty-meta) error can't fail its page
+		// and, in turn, collapse every analyzed page to the not_analyzed fallback.
+		meta: LcpErrorMetaSchema.catch( {} ),
 	} )
 	// Isolate a single malformed error entry: fall back to a benign `unknown` error rather
 	// than throwing, so the page (with its real key/url/status) and all sibling pages survive.
@@ -63,11 +63,14 @@ export const LcpStateSchema = z
 	.object( {
 		// Pages to optimize
 		pages: z.array( PageSchema ),
-		status: z.enum( [ 'not_analyzed', 'pending', 'analyzed', 'error' ] ),
+		// `.catch()` on the enum so an invalid top-level status degrades in place (mirroring
+		// PageSchema.status and the server's own `->fallback('not_analyzed')`) instead of failing
+		// the whole object and wiping otherwise-valid pages via the outer `.catch()` below.
+		status: z.enum( [ 'not_analyzed', 'pending', 'analyzed', 'error' ] ).catch( 'not_analyzed' ),
 		created: z.coerce.number().optional(),
 		updated: z.coerce.number().optional(),
 	} )
-	.catch( { pages: [], status: 'not_analyzed' } );
+	.catch( { pages: [], status: 'not_analyzed', created: 0, updated: 0 } );
 
 /**
  * Infer Zod Types

--- a/projects/plugins/boost/app/assets/src/js/features/lcp/lib/stores/lcp-state-types.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/lcp/lib/stores/lcp-state-types.ts
@@ -24,23 +24,16 @@ export const LcpErrorMetaSchema = z.object( {
 	finalUrl: z.string().optional(),
 } );
 
-/**
- * The server stores an empty error meta as an empty PHP array, which JSON-encodes as `[]`
- * (older/edge payloads may also send `null`). A bare `z.object()` rejects `[]`/`null`, so
- * normalize those empty encodings to `{}` before validating the known meta keys. This keeps
- * a `page-navigated` (or any empty-meta) error from failing its page and, in turn, collapsing
- * every analyzed page to the not_analyzed fallback UI.
- */
-const LcpErrorMetaField = z.preprocess(
-	value => ( value == null || Array.isArray( value ) ? {} : value ),
-	LcpErrorMetaSchema
-);
-
 export const LcpErrorDetailsSchema = z
 	.object( {
 		// Adding a generic string type to handle the case where the error type is not in the enum, so the schema is still valid.
 		type: z.union( [ LcpErrorTypeSchema, z.string() ] ),
-		meta: LcpErrorMetaField.optional(),
+		// The server stores empty error meta as an empty PHP array (`[]`), and older payloads may
+		// send `null`; a bare object schema rejects both. `.catch({})` degrades any unparseable
+		// meta (empty array, null, or a malformed known key) to `{}` while preserving the error's
+		// real `type`, so a `page-navigated` (or any empty-meta) error can't fail its page and, in
+		// turn, collapse every analyzed page to the not_analyzed fallback.
+		meta: LcpErrorMetaSchema.catch( {} ).optional(),
 	} )
 	// Isolate a single malformed error entry: fall back to a benign `unknown` error rather
 	// than throwing, so the page (with its real key/url/status) and all sibling pages survive.
@@ -61,16 +54,20 @@ export const PageSchema = z
 	// keeps one bad entry from collapsing nine good results into the not_analyzed fallback.
 	.catch( { key: '', url: '', status: 'error', errors: [] } );
 
-// No whole-state `.catch()`: resilience now lives at the page and error level (above), so one
-// bad page or error entry degrades in place instead of wiping every analyzed result. The server
-// schema guarantees the top-level shape and a valid `status`.
-export const LcpStateSchema = z.object( {
-	// Pages to optimize
-	pages: z.array( PageSchema ),
-	status: z.enum( [ 'not_analyzed', 'pending', 'analyzed', 'error' ] ),
-	created: z.coerce.number().optional(),
-	updated: z.coerce.number().optional(),
-} );
+// Resilience against a single bad entry lives at the page and error level (above), so one bad
+// page or error degrades in place instead of wiping every analyzed result. The top-level `.catch()`
+// only fires for a malformed top-level shape, e.g. the disabled-module optimize response
+// `{ success: false, state: [] }` where `state` is `[]`: it keeps that from throwing a ZodError
+// before the action's own `success: false` handler can map it to the LCP error state.
+export const LcpStateSchema = z
+	.object( {
+		// Pages to optimize
+		pages: z.array( PageSchema ),
+		status: z.enum( [ 'not_analyzed', 'pending', 'analyzed', 'error' ] ),
+		created: z.coerce.number().optional(),
+		updated: z.coerce.number().optional(),
+	} )
+	.catch( { pages: [], status: 'not_analyzed' } );
 
 /**
  * Infer Zod Types

--- a/projects/plugins/boost/app/assets/src/js/features/lcp/lib/stores/lcp-state-types.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/lcp/lib/stores/lcp-state-types.ts
@@ -37,7 +37,9 @@ export const LcpErrorDetailsSchema = z
 	} )
 	// Isolate a single malformed error entry: fall back to a benign `unknown` error rather
 	// than throwing, so the page (with its real key/url/status) and all sibling pages survive.
-	.catch( { type: 'unknown' } );
+	// `meta: {}` is required because dropping `.optional()` above makes `meta` a present key in the
+	// inferred type, so the fallback object must supply it to satisfy the schema's output contract.
+	.catch( { type: 'unknown', meta: {} } );
 
 export const PageSchema = z
 	.object( {

--- a/projects/plugins/boost/app/assets/src/js/features/lcp/lib/stores/lcp-state-types.ts
+++ b/projects/plugins/boost/app/assets/src/js/features/lcp/lib/stores/lcp-state-types.ts
@@ -20,39 +20,57 @@ export const LcpErrorTypeSchema = z.enum( [
 export const LcpErrorMetaSchema = z.object( {
 	code: z.number().optional(),
 	selector: z.string().optional(),
+	// `page-navigated` errors from boost-cloud (BOOST-597) carry the redirect target here.
+	finalUrl: z.string().optional(),
 } );
 
-export const LcpErrorDetailsSchema = z.object( {
-	// Adding a generic string type to handle the case where the error type is not in the enum, so the schema is still valid.
-	type: z.union( [ LcpErrorTypeSchema, z.string() ] ),
-	meta: LcpErrorMetaSchema.optional(),
-} );
+/**
+ * The server stores an empty error meta as an empty PHP array, which JSON-encodes as `[]`
+ * (older/edge payloads may also send `null`). A bare `z.object()` rejects `[]`/`null`, so
+ * normalize those empty encodings to `{}` before validating the known meta keys. This keeps
+ * a `page-navigated` (or any empty-meta) error from failing its page and, in turn, collapsing
+ * every analyzed page to the not_analyzed fallback UI.
+ */
+const LcpErrorMetaField = z.preprocess(
+	value => ( value == null || Array.isArray( value ) ? {} : value ),
+	LcpErrorMetaSchema
+);
 
-export const PageSchema = z.object( {
-	// Unique page key
-	key: z.coerce.string(),
-	// Page URL
-	url: z.coerce.string(),
-	// Status
-	status: z.enum( [ 'success', 'pending', 'error' ] ).catch( 'pending' ),
-	// Error details
-	errors: z.array( LcpErrorDetailsSchema ).optional(),
-} );
-
-export const LcpStateSchema = z
+export const LcpErrorDetailsSchema = z
 	.object( {
-		// Pages to optimize
-		pages: z.array( PageSchema ),
-		status: z.enum( [ 'not_analyzed', 'pending', 'analyzed', 'error' ] ),
-		created: z.coerce.number().optional(),
-		updated: z.coerce.number().optional(),
+		// Adding a generic string type to handle the case where the error type is not in the enum, so the schema is still valid.
+		type: z.union( [ LcpErrorTypeSchema, z.string() ] ),
+		meta: LcpErrorMetaField.optional(),
 	} )
-	.catch( {
-		pages: [],
-		status: 'not_analyzed',
-		created: 0,
-		updated: 0,
-	} );
+	// Isolate a single malformed error entry: fall back to a benign `unknown` error rather
+	// than throwing, so the page (with its real key/url/status) and all sibling pages survive.
+	.catch( { type: 'unknown' } );
+
+export const PageSchema = z
+	.object( {
+		// Unique page key
+		key: z.coerce.string(),
+		// Page URL
+		url: z.coerce.string(),
+		// Status
+		status: z.enum( [ 'success', 'pending', 'error' ] ).catch( 'pending' ),
+		// Error details
+		errors: z.array( LcpErrorDetailsSchema ).optional(),
+	} )
+	// Isolate a single malformed page so it can't fail the whole pages array. This is what
+	// keeps one bad entry from collapsing nine good results into the not_analyzed fallback.
+	.catch( { key: '', url: '', status: 'error', errors: [] } );
+
+// No whole-state `.catch()`: resilience now lives at the page and error level (above), so one
+// bad page or error entry degrades in place instead of wiping every analyzed result. The server
+// schema guarantees the top-level shape and a valid `status`.
+export const LcpStateSchema = z.object( {
+	// Pages to optimize
+	pages: z.array( PageSchema ),
+	status: z.enum( [ 'not_analyzed', 'pending', 'analyzed', 'error' ] ),
+	created: z.coerce.number().optional(),
+	updated: z.coerce.number().optional(),
+} );
 
 /**
  * Infer Zod Types

--- a/projects/plugins/boost/app/assets/src/js/features/lcp/status/error-details.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/lcp/status/error-details.tsx
@@ -73,15 +73,15 @@ const PageError = ( { url, error }: PageErrorProps ) => {
 		if ( type === 'page-navigated' ) {
 			return meta?.finalUrl
 				? createInterpolateElement(
-						sprintf(
-							/* translators: %s is the URL the page redirected to */
-							__(
-								'This page redirected to <b>%s</b> during analysis, so Boost could not measure its LCP. Remove it from your Cornerstone Pages, or make sure it loads without redirecting.',
-								'jetpack-boost'
-							),
-							meta.finalUrl
+						/* translators: <url /> is replaced with the URL the page redirected to. */
+						__(
+							'This page redirected to <url /> during analysis, so Boost could not measure its LCP. Remove it from your Cornerstone Pages, or make sure it loads without redirecting.',
+							'jetpack-boost'
 						),
-						{ b: <strong /> }
+						// Pass finalUrl as a React text child, not interpolated into the markup string,
+						// so a redirect target containing `<`/`>` renders as inert text instead of
+						// corrupting the createInterpolateElement token structure.
+						{ url: <strong>{ meta.finalUrl }</strong> }
 				  )
 				: __(
 						'This page redirected during analysis, so Boost could not measure its LCP. Remove it from your Cornerstone Pages, or make sure it loads without redirecting.',

--- a/projects/plugins/boost/app/assets/src/js/features/lcp/status/error-details.tsx
+++ b/projects/plugins/boost/app/assets/src/js/features/lcp/status/error-details.tsx
@@ -70,6 +70,25 @@ const PageError = ( { url, error }: PageErrorProps ) => {
 			);
 		}
 
+		if ( type === 'page-navigated' ) {
+			return meta?.finalUrl
+				? createInterpolateElement(
+						sprintf(
+							/* translators: %s is the URL the page redirected to */
+							__(
+								'This page redirected to <b>%s</b> during analysis, so Boost could not measure its LCP. Remove it from your Cornerstone Pages, or make sure it loads without redirecting.',
+								'jetpack-boost'
+							),
+							meta.finalUrl
+						),
+						{ b: <strong /> }
+				  )
+				: __(
+						'This page redirected during analysis, so Boost could not measure its LCP. Remove it from your Cornerstone Pages, or make sure it loads without redirecting.',
+						'jetpack-boost'
+				  );
+		}
+
 		return sprintf(
 			/* translators: %s is the error type */
 			__(

--- a/projects/plugins/boost/app/lib/cornerstone/class-cornerstone-utils.php
+++ b/projects/plugins/boost/app/lib/cornerstone/class-cornerstone-utils.php
@@ -20,7 +20,41 @@ class Cornerstone_Utils {
 		 *
 		 * @param string[] $urls The absolute URLs of all the cornerstone pages.
 		 */
-		return apply_filters( 'jetpack_boost_cornerstone_pages_list_complete', array_merge( self::get_predefined_list(), self::get_custom_list() ) );
+		$urls = apply_filters( 'jetpack_boost_cornerstone_pages_list_complete', array_merge( self::get_predefined_list(), self::get_custom_list() ) );
+
+		return self::dedupe_by_provider_key( $urls );
+	}
+
+	/**
+	 * Dedupe a list of cornerstone URLs by their provider key.
+	 *
+	 * Different URL forms of the same page collapse to one provider key: the predefined
+	 * home_url() and a "/" (or "") homepage entry in the custom list both hash to
+	 * `cornerstone_d41d8cd9`. Keeping both produces two page entries with the same key, and
+	 * LCP_State::set_pending_pages() only marks the first — leaving the duplicate without a
+	 * `status`, which fails the lcp_state schema on write and silently stores the empty
+	 * not_analyzed fallback. The first occurrence wins, so the predefined entry is kept.
+	 *
+	 * @param string[] $urls The URLs to dedupe.
+	 * @return string[] The URLs with provider-key duplicates removed, re-indexed.
+	 */
+	private static function dedupe_by_provider_key( $urls ) {
+		if ( ! is_array( $urls ) ) {
+			return array();
+		}
+
+		$seen    = array();
+		$deduped = array();
+		foreach ( $urls as $url ) {
+			$key = self::get_provider_key( $url );
+			if ( isset( $seen[ $key ] ) ) {
+				continue;
+			}
+			$seen[ $key ] = true;
+			$deduped[]    = $url;
+		}
+
+		return $deduped;
 	}
 
 	/**

--- a/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-state.php
+++ b/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp-state.php
@@ -194,7 +194,19 @@ class LCP_State {
 	 * @since 4.0.0
 	 */
 	public function set_pages( $pages ) {
-		$this->state['pages'] = $pages;
+		// Guarantee every page carries a status. Entries from prepare_provider_data() only have
+		// `key` and `url`; set_pending_pages() normally supplies the status, but it marks each key
+		// only once, so a duplicate key would otherwise land here with no status and fail the
+		// lcp_state schema on write. Existing statuses (e.g. from a prior run) are preserved.
+		$this->state['pages'] = array_map(
+			function ( $page ) {
+				if ( ! isset( $page['status'] ) ) {
+					$page['status'] = self::PAGE_STATES['pending'];
+				}
+				return $page;
+			},
+			$pages
+		);
 		return $this;
 	}
 

--- a/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp.php
+++ b/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp.php
@@ -156,10 +156,12 @@ class Lcp implements Feature, Changes_Output_After_Activation, Optimization, Has
 									Schema::as_assoc_array(
 										array(
 											'type' => Schema::as_string(),
-											// `meta` is nullable so an empty (`[]`/`{}`) or otherwise
-											// unrecognized shape parses to null instead of throwing and
-											// collapsing the whole lcp_state to its not_analyzed fallback.
-											// Unknown keys are dropped; every declared key is optional.
+											// `meta` is nullable: a literal null (and, outside Schema
+											// debug mode, any non-assoc scalar) resolves through Type_Void
+											// instead of throwing and aborting the whole error item. An
+											// empty `[]`/`{}` parses to an empty assoc array, not null,
+											// since every declared key is optional and dropped when absent.
+											// The client tolerates both. Unknown keys are dropped.
 											'meta' => Schema::as_assoc_array(
 												array(
 													'code' => Schema::as_number()->nullable(),

--- a/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp.php
+++ b/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp.php
@@ -171,6 +171,18 @@ class Lcp implements Feature, Changes_Output_After_Activation, Optimization, Has
 												)
 											)->nullable(),
 										)
+									)->fallback(
+										// Isolate a single malformed error at the item boundary. Type_Array
+										// aborts the whole list on the first Schema_Error, and the list-level
+										// nullable() below would then null out `errors` entirely, discarding
+										// every valid sibling error (and its finalUrl) before the client parser
+										// ever sees them. Degrading only the bad item to a benign `unknown`
+										// error mirrors the client-side LcpErrorDetailsSchema.catch and keeps
+										// the good siblings intact.
+										array(
+											'type' => 'unknown',
+											'meta' => null,
+										)
 									)
 								)->nullable(),
 							)

--- a/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp.php
+++ b/projects/plugins/boost/app/modules/optimizations/lcp/class-lcp.php
@@ -156,10 +156,18 @@ class Lcp implements Feature, Changes_Output_After_Activation, Optimization, Has
 									Schema::as_assoc_array(
 										array(
 											'type' => Schema::as_string(),
+											// `meta` is nullable so an empty (`[]`/`{}`) or otherwise
+											// unrecognized shape parses to null instead of throwing and
+											// collapsing the whole lcp_state to its not_analyzed fallback.
+											// Unknown keys are dropped; every declared key is optional.
 											'meta' => Schema::as_assoc_array(
 												array(
 													'code' => Schema::as_number()->nullable(),
 													'selector' => Schema::as_string()->nullable(),
+													// `page-navigated` errors from boost-cloud (BOOST-597) carry
+													// the redirect target here. Without this key it was stripped
+													// and stored as an empty `[]`, which broke the client parse.
+													'finalUrl' => Schema::as_string()->nullable(),
 												)
 											)->nullable(),
 										)

--- a/projects/plugins/boost/app/rest-api/endpoints/class-update-lcp.php
+++ b/projects/plugins/boost/app/rest-api/endpoints/class-update-lcp.php
@@ -63,9 +63,11 @@ class Update_LCP implements Endpoint {
 			return $api_successful;
 		}
 
+		$update_errors = array();
+		$applied       = 0;
 		foreach ( $pages as $entry ) {
 			if ( $entry['success'] ) {
-				$state->set_page_success( $entry['key'] );
+				$result = $state->set_page_success( $entry['key'] );
 			} else {
 				$errors = array();
 				foreach ( $entry['reports'] as $report ) {
@@ -74,7 +76,13 @@ class Update_LCP implements Endpoint {
 					}
 				}
 
-				$state->set_page_errors( $entry['key'], $errors );
+				$result = $state->set_page_errors( $entry['key'], $errors );
+			}
+
+			if ( is_wp_error( $result ) ) {
+				$update_errors[] = $entry['key'] . ': ' . $result->get_error_message();
+			} else {
+				++$applied;
 			}
 
 			// Store the LCP data for this page.
@@ -84,8 +92,19 @@ class Update_LCP implements Endpoint {
 			// @TODO: figure out what to do with failures.
 		}
 
-		// Save the state changes.
-		$state->save();
+		if ( ! empty( $update_errors ) ) {
+			error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				'Jetpack Boost: LCP update could not apply results to the stored state: ' . implode( '; ', $update_errors )
+			);
+		}
+
+		// Only persist when at least one result was actually applied. If every update failed
+		// (e.g. the stored state was reset to the not_analyzed fallback and has no pages),
+		// saving would just re-persist that empty state and shadow the good data already
+		// written to jb_store_lcp storage above.
+		if ( $applied > 0 ) {
+			$state->save();
+		}
 
 		return $api_successful;
 	}

--- a/projects/plugins/boost/app/rest-api/endpoints/class-update-lcp.php
+++ b/projects/plugins/boost/app/rest-api/endpoints/class-update-lcp.php
@@ -80,12 +80,19 @@ class Update_LCP implements Endpoint {
 			}
 
 			if ( is_wp_error( $result ) ) {
-				$update_errors[] = $entry['key'] . ': ' . $result->get_error_message();
-			} else {
-				++$applied;
+				// Strip CR/LF from the cloud-controlled key so a malicious signed payload can't
+				// forge extra log lines (CWE-117).
+				$safe_key        = str_replace( array( "\r", "\n" ), ' ', (string) $entry['key'] );
+				$update_errors[] = $safe_key . ': ' . $result->get_error_message();
+				continue;
 			}
 
-			// Store the LCP data for this page.
+			++$applied;
+
+			// Persist the raw LCP reports only for a key that actually applied to the state. Storing
+			// a rejected key (a page removed from the cornerstone list, or a late/duplicate callback
+			// after a reset) would orphan reports in jb_store_lcp that the render path later serves
+			// with no matching lcp_state entry to gate them.
 			$storage->store_lcp( $entry['key'], $entry['reports'] );
 
 			// Failures must have an array of urls.
@@ -98,10 +105,9 @@ class Update_LCP implements Endpoint {
 			);
 		}
 
-		// Only persist when at least one result was actually applied. If every update failed
-		// (e.g. the stored state was reset to the not_analyzed fallback and has no pages),
-		// saving would just re-persist that empty state and shadow the good data already
-		// written to jb_store_lcp storage above.
+		// Only persist the aggregate state when at least one result actually applied. If every
+		// update failed (e.g. the stored state was reset to the not_analyzed fallback and has no
+		// matching pages), saving would just re-persist that empty state over the good data.
 		if ( $applied > 0 ) {
 			$state->save();
 		}

--- a/projects/plugins/boost/changelog/fix-boost-604-lcp-state-schema
+++ b/projects/plugins/boost/changelog/fix-boost-604-lcp-state-schema
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-LCP: stop silently discarding analysis results when an error meta has an empty or page-navigated shape, or when the homepage appears in the custom cornerstone list.
+LCP: Preserve analysis results when a page reports an error or when the homepage is also configured as a cornerstone page.

--- a/projects/plugins/boost/changelog/fix-boost-604-lcp-state-schema
+++ b/projects/plugins/boost/changelog/fix-boost-604-lcp-state-schema
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+LCP: stop silently discarding analysis results when an error meta has an empty or page-navigated shape, or when the homepage appears in the custom cornerstone list.

--- a/projects/plugins/boost/tests/php/lib/cornerstone/Cornerstone_Utils_Test.php
+++ b/projects/plugins/boost/tests/php/lib/cornerstone/Cornerstone_Utils_Test.php
@@ -65,4 +65,34 @@ class Cornerstone_Utils_Test extends TestCase {
 		// The key is derived from the sanitized URL, so it never carries the trailing slash itself.
 		$this->assertStringEndsNotWith( '/', $with_slash['key'] );
 	}
+
+	/**
+	 * BOOST-604: a homepage entry in the custom list ("/" or "") hashes to the same provider key as
+	 * the predefined home_url() entry (`cornerstone_d41d8cd9`). Without de-duplication the merged
+	 * list carries two pages with the same key; set_pending_pages() only marks the first, leaving the
+	 * duplicate statusless and failing the lcp_state schema on write. get_list() must collapse them.
+	 */
+	public function test_get_list_dedupes_homepage_from_custom_list() {
+		// No trailing-slash permalink structure, so URLs are left untouched.
+		Functions\when( 'get_option' )->justReturn( '' );
+		// Custom list contains the homepage as the relative "/" form plus a distinct page.
+		Functions\when( 'jetpack_boost_ds_get' )->justReturn( array( '/', '/about' ) );
+
+		$list = Cornerstone_Utils::get_list();
+		$keys = array_map( array( Cornerstone_Utils::class, 'get_provider_key' ), $list );
+
+		// No provider-key duplicates survive.
+		$this->assertSame( array_values( array_unique( $keys ) ), $keys, 'get_list() must not contain provider-key duplicates.' );
+
+		// The homepage key appears exactly once even though it is both predefined and custom.
+		$home_key = Cornerstone_Utils::get_provider_key( 'https://example.com' );
+		$this->assertCount( 1, array_keys( $keys, $home_key, true ) );
+
+		// The predefined home_url() entry wins; the duplicate custom "/" is dropped.
+		$this->assertContains( 'https://example.com', $list );
+		$this->assertNotContains( '/', $list );
+
+		// The unrelated custom page survives.
+		$this->assertContains( '/about', $list );
+	}
 }

--- a/projects/plugins/boost/tests/php/modules/optimizations/lcp/LCP_State_Schema_Test.php
+++ b/projects/plugins/boost/tests/php/modules/optimizations/lcp/LCP_State_Schema_Test.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Tests\Modules\Optimizations\Lcp;
+
+use Automattic\Jetpack\Schema\Schema_Parser;
+use Automattic\Jetpack_Boost\Modules\Optimizations\Lcp\Lcp;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression coverage for BOOST-604 at the PHP Data Sync boundary.
+ *
+ * The `lcp_state` schema stores an array of error details per page. `Type_Array` aborts the whole
+ * array on the first item that fails to parse, and the list-level `->nullable()` then converts the
+ * entire `errors` value to null, so one malformed error used to discard every valid sibling on that
+ * page before the client parser could preserve them. The error item now carries a `->fallback()`, so
+ * a single bad item degrades in place. These tests parse through the real registered schema so a
+ * future edit that drops the item fallback fails here.
+ */
+class LCP_State_Schema_Test extends TestCase {
+
+	/**
+	 * Pull the real `lcp_state` Schema_Parser out of Lcp::register_data_sync() via a capturing stub,
+	 * so the assertions run against the exact schema that ships, not a hand-rebuilt copy.
+	 *
+	 * @return Schema_Parser
+	 */
+	private function get_lcp_state_schema() {
+		$captured = null;
+
+		$instance = new class( $captured ) {
+			private $captured_ref;
+
+			public function __construct( &$captured ) {
+				$this->captured_ref = &$captured;
+			}
+
+			public function register( $key, $parser ) {
+				if ( 'lcp_state' === $key ) {
+					$this->captured_ref = $parser;
+				}
+			}
+
+			public function register_action() {
+				// no-op: the schema is all we need. Extra args from the caller are ignored.
+			}
+		};
+
+		// @phan-suppress-next-line PhanTypeMismatchArgument -- Deliberate capturing stub in place of the real Data_Sync.
+		( new Lcp() )->register_data_sync( $instance );
+
+		$this->assertInstanceOf( Schema_Parser::class, $captured, 'register_data_sync() must register an lcp_state parser.' );
+
+		return $captured;
+	}
+
+	/**
+	 * Build a minimal analyzed state whose single page carries the given errors array.
+	 *
+	 * @param array $errors The errors array to place on the page.
+	 *
+	 * @return array
+	 */
+	private function analyzed_state_with_errors( array $errors ) {
+		return array(
+			'pages'   => array(
+				array(
+					'key'    => 'home',
+					'url'    => 'https://example.com/',
+					'status' => 'error',
+					'errors' => $errors,
+				),
+			),
+			'status'  => 'analyzed',
+			'created' => 1.0,
+			'updated' => 2.0,
+		);
+	}
+
+	public function test_malformed_error_item_isolates_and_preserves_valid_siblings() {
+		$schema = $this->get_lcp_state_schema();
+
+		$parsed = $schema->parse(
+			$this->analyzed_state_with_errors(
+				array(
+					array(
+						'type' => 'http-error',
+						'meta' => array( 'code' => 404 ),
+					),
+					// A scalar can never be an error object; before the item fallback this aborted the
+					// whole array and nulled `errors`, dropping the valid http-error above.
+					42,
+				)
+			)
+		);
+
+		// The whole state survives (not the not_analyzed fallback) and the page keeps its errors key.
+		$this->assertSame( 'analyzed', $parsed['status'] );
+		$this->assertArrayHasKey( 'errors', $parsed['pages'][0], 'The valid sibling error must survive the malformed one.' );
+		$this->assertCount( 2, $parsed['pages'][0]['errors'] );
+
+		// The valid error is untouched.
+		$this->assertSame( 'http-error', $parsed['pages'][0]['errors'][0]['type'] );
+		$this->assertSame( 404, $parsed['pages'][0]['errors'][0]['meta']['code'] );
+
+		// The malformed item degraded to the benign unknown fallback.
+		$this->assertSame( 'unknown', $parsed['pages'][0]['errors'][1]['type'] );
+	}
+
+	public function test_finalurl_survives_alongside_a_malformed_sibling() {
+		$schema = $this->get_lcp_state_schema();
+
+		$parsed = $schema->parse(
+			$this->analyzed_state_with_errors(
+				array(
+					array(
+						'type' => 'page-navigated',
+						'meta' => array( 'finalUrl' => 'https://example.com/landing/' ),
+					),
+					'not-an-error',
+				)
+			)
+		);
+
+		$this->assertCount( 2, $parsed['pages'][0]['errors'] );
+		$this->assertSame( 'page-navigated', $parsed['pages'][0]['errors'][0]['type'] );
+		$this->assertSame( 'https://example.com/landing/', $parsed['pages'][0]['errors'][0]['meta']['finalUrl'] );
+		$this->assertSame( 'unknown', $parsed['pages'][0]['errors'][1]['type'] );
+	}
+
+	public function test_a_fully_valid_errors_array_parses_unchanged() {
+		$schema = $this->get_lcp_state_schema();
+
+		$parsed = $schema->parse(
+			$this->analyzed_state_with_errors(
+				array(
+					array(
+						'type' => 'http-error',
+						'meta' => array( 'code' => 500 ),
+					),
+				)
+			)
+		);
+
+		$this->assertCount( 1, $parsed['pages'][0]['errors'] );
+		$this->assertSame( 'http-error', $parsed['pages'][0]['errors'][0]['type'] );
+		$this->assertSame( 500, $parsed['pages'][0]['errors'][0]['meta']['code'] );
+	}
+}

--- a/projects/plugins/boost/tests/php/modules/optimizations/lcp/LCP_State_Test.php
+++ b/projects/plugins/boost/tests/php/modules/optimizations/lcp/LCP_State_Test.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Tests\Modules\Optimizations\Lcp;
+
+use Automattic\Jetpack_Boost\Modules\Optimizations\Lcp\LCP_State;
+use Brain\Monkey\Functions;
+use Mockery;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+#[RunTestsInSeparateProcesses]
+#[PreserveGlobalState( false )]
+class LCP_State_Test extends TestCase {
+
+	/**
+	 * The value handed to jetpack_boost_ds_set() by save(), captured for assertions.
+	 *
+	 * @var array|null
+	 */
+	private $stored;
+
+	public function setUp(): void {
+		parent::setUp();
+		\Brain\Monkey\setUp();
+
+		$this->stored = null;
+
+		// LCP_State::__construct() reads the current option; start from an empty state.
+		Functions\when( 'jetpack_boost_ds_get' )->justReturn( array() );
+		// Capture what save() persists.
+		Functions\when( 'jetpack_boost_ds_set' )->alias(
+			function ( $_key, $value ) {
+				$this->stored = $value;
+			}
+		);
+	}
+
+	public function tearDown(): void {
+		Mockery::close();
+		\Brain\Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * BOOST-604: two provider-data entries that share a key (the homepage-in-custom-list collision)
+	 * used to reach save() with the duplicate lacking a `status`, because set_pending_pages() only
+	 * marks the first key match. The statusless page failed the lcp_state schema, and WP_JS_Data_Sync
+	 * silently stored the `{ pages: [], status: 'not_analyzed' }` fallback. set_pages() must now give
+	 * every entry a default status so the persisted state keeps the pending pages.
+	 */
+	public function test_write_path_persists_pending_pages_even_with_duplicate_keys() {
+		// prepare_provider_data() output carries only key + url (no status). Two entries share a key.
+		$pages = array(
+			array(
+				'key' => 'cornerstone_d41d8cd9',
+				'url' => 'https://example.com',
+			),
+			array(
+				'key' => 'cornerstone_d41d8cd9',
+				'url' => 'https://example.com/',
+			),
+			array(
+				'key' => 'cornerstone_2b1c4d5e',
+				'url' => 'https://example.com/about',
+			),
+		);
+
+		$state = new LCP_State();
+		$state
+			->prepare_request()
+			->set_pages( $pages )
+			->set_pending_pages( $pages )
+			->save();
+
+		$this->assertIsArray( $this->stored, 'save() must persist a state array.' );
+
+		// The state is NOT the not_analyzed fallback: pending pages are preserved.
+		$this->assertSame( 'pending', $this->stored['status'] );
+		$this->assertCount( 3, $this->stored['pages'] );
+
+		// Every page carries a status, including the duplicate that set_pending_pages() skips.
+		foreach ( $this->stored['pages'] as $page ) {
+			$this->assertArrayHasKey( 'status', $page, 'Every page must have a status or the schema rejects the write.' );
+			$this->assertSame( 'pending', $page['status'] );
+		}
+	}
+
+	/**
+	 * A status that already exists (e.g. a page carried over from a previous run via
+	 * start_partial_analysis()) must not be clobbered by set_pages().
+	 */
+	public function test_set_pages_preserves_existing_status() {
+		$pages = array(
+			array(
+				'key'    => 'cornerstone_abc',
+				'url'    => 'https://example.com/one',
+				'status' => 'success',
+			),
+			array(
+				'key' => 'cornerstone_def',
+				'url' => 'https://example.com/two',
+			),
+		);
+
+		$state = new LCP_State();
+		$state->prepare_request()->set_pages( $pages );
+
+		$result = $state->get_pages();
+
+		$this->assertSame( 'success', $result[0]['status'], 'An existing status must be preserved.' );
+		$this->assertSame( 'pending', $result[1]['status'], 'A missing status defaults to pending.' );
+	}
+}

--- a/projects/plugins/boost/tests/php/modules/optimizations/lcp/LCP_State_Test.php
+++ b/projects/plugins/boost/tests/php/modules/optimizations/lcp/LCP_State_Test.php
@@ -77,14 +77,18 @@ class LCP_State_Test extends TestCase {
 			->set_pending_pages( $pages )
 			->save();
 
-		$this->assertIsArray( $this->stored, 'save() must persist a state array.' );
+		$stored = $this->stored;
+		$this->assertIsArray( $stored, 'save() must persist a state array.' );
+		if ( ! is_array( $stored ) ) {
+			return; // Unreachable after assertIsArray; narrows the type for static analysis.
+		}
 
 		// The state is NOT the not_analyzed fallback: pending pages are preserved.
-		$this->assertSame( 'pending', $this->stored['status'] );
-		$this->assertCount( 3, $this->stored['pages'] );
+		$this->assertSame( 'pending', $stored['status'] );
+		$this->assertCount( 3, $stored['pages'] );
 
 		// Every page carries a status, including the duplicate that set_pending_pages() skips.
-		foreach ( $this->stored['pages'] as $page ) {
+		foreach ( $stored['pages'] as $page ) {
 			$this->assertArrayHasKey( 'status', $page, 'Every page must have a status or the schema rejects the write.' );
 			$this->assertSame( 'pending', $page['status'] );
 		}


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/BOOST-604

A finished LCP analysis was being thrown away on the plugin side with nothing logged. On a live Atomic site the cloud returned correct results for nine cornerstone pages, yet the dashboard still said "Click the optimize button to start optimizing". Two independent paths cause it, and both are live on trunk today.

## Proposed changes

A `page-navigated` error blanks the whole panel:
* `class-lcp.php`: add `finalUrl` to the error `meta` schema so boost-cloud's `page-navigated` meta (Automattic/boost-cloud#736) stops being stripped to an empty `[]`. `meta` stays nullable, so an unknown shape parses to null instead of failing the whole state.
* `lcp-state-types.ts`: mirror `finalUrl`, accept `[]`/`null`/`{}` as empty meta, and move the `.catch()` off the whole state down to the page and error level so one bad entry no longer wipes the good ones.

A homepage entry in the custom cornerstone list wipes state on write:
* `Cornerstone_Utils::get_list()`: dedupe by provider key, since a `/` homepage collides with the predefined `home_url()`.
* `LCP_State::set_pages()`: give every entry a default status so a duplicate key can't produce a status-less page that fails the schema.
* `Update_LCP::response()`: check the update return, log failures, and save only when a result was actually applied.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Run `pnpm jetpack test js plugins/boost` and `pnpm jetpack test php plugins/boost`. Both chains have regression tests:
* JS: a state with `errors: [{ type: 'page-navigated', meta: [] }]` used to parse to the not_analyzed fallback; it now parses intact.
* PHP: state built from a `get_list()` with a homepage custom entry, then `set_pages()->set_pending_pages()->save()`, used to store `{ pages: [], status: 'not_analyzed' }`; it now stores the pending pages.