### PR TITLE
Premium Analytics: show File downloads only on WPCOM Simple sites

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-wooa7s-1717-hide-file-downloads-on-self-hosted
+++ b/projects/packages/premium-analytics/changelog/add-wooa7s-1717-hide-file-downloads-on-self-hosted
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Hide the File downloads widget and report outside WordPress.com Simple sites, matching the Calypso Stats gating.

--- a/projects/packages/premium-analytics/routes/reports/registry.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/registry.test.ts
@@ -1,0 +1,45 @@
+/**
+ * External dependencies
+ */
+import { isSimpleSite } from '@automattic/jetpack-script-data';
+/**
+ * Internal dependencies
+ */
+import { getReportDefinition } from './registry';
+
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	isSimpleSite: jest.fn( () => true ),
+} ) );
+
+const mockIsSimpleSite = isSimpleSite as jest.Mock;
+
+describe( 'getReportDefinition', () => {
+	beforeEach( () => {
+		mockIsSimpleSite.mockReturnValue( true );
+	} );
+
+	it( 'returns undefined for an unknown report', () => {
+		expect( getReportDefinition( 'unknown' ) ).toBeUndefined();
+		expect( getReportDefinition( undefined ) ).toBeUndefined();
+	} );
+
+	it( 'returns the downloads report on Simple sites', () => {
+		expect( getReportDefinition( 'downloads' )?.id ).toBe( 'downloads' );
+	} );
+
+	it( 'hides the downloads report on non-Simple sites', () => {
+		// Calypso only shows file downloads on Simple sites ("not yet supported
+		// in Jetpack environment", which includes Atomic); the route guard
+		// redirects an unavailable report to the dashboard, same as an unknown
+		// one.
+		mockIsSimpleSite.mockReturnValue( false );
+
+		expect( getReportDefinition( 'downloads' ) ).toBeUndefined();
+	} );
+
+	it( 'keeps other reports available on non-Simple sites', () => {
+		mockIsSimpleSite.mockReturnValue( false );
+
+		expect( getReportDefinition( 'posts' )?.id ).toBe( 'posts' );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/reports/registry.ts
+++ b/projects/packages/premium-analytics/routes/reports/registry.ts
@@ -1,6 +1,7 @@
 /**
  * External dependencies
  */
+import { isSimpleSite } from '@automattic/jetpack-script-data';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -56,6 +57,13 @@ export type ReportDefinition = {
 	resolveSection?: ( value: string | undefined ) => string;
 
 	/**
+	 * Whether the report is available on this site, resolved at lookup time.
+	 * An unavailable report is treated like an unknown one — the route guard
+	 * redirects it to the dashboard. Omit for reports available everywhere.
+	 */
+	isAvailable?: () => boolean;
+
+	/**
 	 * Dynamic import of the report's page component (default export). Kept as a
 	 * thunk so React/UI is only pulled in when the report actually renders, and
 	 * so this module stays importable from `route.ts` guards.
@@ -107,6 +115,11 @@ export const REPORTS: Record< string, ReportDefinition > = {
 	downloads: {
 		id: 'downloads',
 		getTitle: () => __( 'File downloads', 'jetpack-premium-analytics' ),
+		// File download tracking happens on WPCOM infrastructure; Calypso only
+		// shows the module on Simple sites ("not yet supported in Jetpack
+		// environment") and we mirror that boundary. Mirrors the widget-level
+		// gate in `src/widget-type-support.php`.
+		isAvailable: isSimpleSite,
 		load: () => import( './downloads/page' ),
 	},
 	emails: {
@@ -161,5 +174,11 @@ export const REPORTS: Record< string, ReportDefinition > = {
  * @return The matching definition, or `undefined` when the id is missing or unknown.
  */
 export function getReportDefinition( id: string | undefined ): ReportDefinition | undefined {
-	return id ? REPORTS[ id ] : undefined;
+	const definition = id ? REPORTS[ id ] : undefined;
+
+	if ( definition?.isAvailable && ! definition.isAvailable() ) {
+		return undefined;
+	}
+
+	return definition;
 }

--- a/projects/packages/premium-analytics/src/dashboard-layout.php
+++ b/projects/packages/premium-analytics/src/dashboard-layout.php
@@ -16,6 +16,9 @@ namespace Automattic\Jetpack\PremiumAnalytics;
 
 require_once __DIR__ . '/dashboard-grammar.php';
 require_once __DIR__ . '/rest-namespace.php';
+// Availability policy for default layout instances: defaults are read outside
+// the widget registry bootstrap, so the policy must be loaded here explicitly.
+require_once __DIR__ . '/widget-type-support.php';
 
 /**
  * Identifier of the Premium Analytics dashboard, formatted as `<plugin>_<page>`
@@ -62,7 +65,11 @@ function get_dashboard_default_layout_for( $dashboard_name ) {
 	 */
 	$default = apply_filters( DASHBOARD_DEFAULT_LAYOUT_FILTER, array(), $dashboard_name );
 
-	return is_array( $default ) ? array_values( $default ) : array();
+	return remove_unsupported_widget_items(
+		is_array( $default ) ? array_values( $default ) : array(),
+		'type',
+		get_widget_support_context()
+	);
 }
 
 /**

--- a/projects/packages/premium-analytics/src/widget-availability.php
+++ b/projects/packages/premium-analytics/src/widget-availability.php
@@ -5,16 +5,18 @@
  * Premium Analytics' policy over the neutral filters in widget-types.php:
  * availability is the consumer's job, core only offers the hooks.
  *
- * Ships two policies, both hooked on the registry-time filter (a hard hide,
- * which keeps every registry consumer correct without a filtered accessor):
- * developer-only widget types are never registered in production, and the
- * commerce widget categories are only registered while the plugin backing
- * them (WooCommerce, plus WooCommerce Bookings for `bookings`) is active.
+ * Policies are hooked on the registry-time filter (a hard hide, which keeps
+ * every registry consumer correct without a filtered accessor): developer-only
+ * widget types are never registered in production, Simple-only types are only
+ * registered on WPCOM Simple, and commerce categories require their plugins.
  *
  * @package automattic/jetpack-premium-analytics
  */
 
 namespace Automattic\Jetpack\PremiumAnalytics;
+
+require_once __DIR__ . '/widget-types.php';
+require_once __DIR__ . '/widget-type-support.php';
 
 /**
  * Widget categories that are only meaningful with WooCommerce active.
@@ -68,6 +70,22 @@ function filter_registrable_widget_types_by_environment( $widget_candidates ) {
 }
 
 add_filter( REGISTRABLE_WIDGET_TYPES_FILTER, __NAMESPACE__ . '\\filter_registrable_widget_types_by_environment' );
+
+/**
+ * Applies shared type-level availability at registry time.
+ *
+ * @param array $widget_candidates Manifest candidates.
+ * @return array Filtered candidates.
+ */
+function filter_registrable_widget_types_by_availability( $widget_candidates ) {
+	return remove_unsupported_widget_items(
+		$widget_candidates,
+		'name',
+		get_widget_support_context()
+	);
+}
+
+add_filter( REGISTRABLE_WIDGET_TYPES_FILTER, __NAMESPACE__ . '\\filter_registrable_widget_types_by_availability' );
 
 /**
  * Removes candidates whose commerce category lacks its backing plugin.

--- a/projects/packages/premium-analytics/src/widget-type-support.php
+++ b/projects/packages/premium-analytics/src/widget-type-support.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Widget type support shared by the registry and default layouts.
+ *
+ * Persisted layouts are left unchanged so missing types remain as removable
+ * ghost widgets. Temporary restrictions belong in the runtime types filter.
+ *
+ * @package automattic/jetpack-premium-analytics
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics;
+
+use Automattic\Jetpack\Status\Host;
+
+/**
+ * Returns the current widget support context.
+ *
+ * @return array{is_wpcom_simple:bool} Widget support context.
+ */
+function get_widget_support_context() {
+	return array(
+		'is_wpcom_simple' => ( new Host() )->is_wpcom_simple(),
+	);
+}
+
+/**
+ * Returns unsupported widget types for a context.
+ *
+ * @param array{is_wpcom_simple:bool} $context Widget support context.
+ * @return string[] Unsupported widget type names.
+ */
+function get_unsupported_widget_types( $context ) {
+	$unsupported = array();
+
+	// File download tracking is served only on WPCOM Simple. Calypso applies
+	// the same boundary, which excludes self-hosted Jetpack and Atomic sites.
+	if ( ! $context['is_wpcom_simple'] ) {
+		$unsupported[] = 'jpa/file-downloads';
+	}
+
+	return $unsupported;
+}
+
+/**
+ * Removes unsupported widget records.
+ *
+ * @param array                       $items    Widget records.
+ * @param string                      $type_key Record key containing the widget type.
+ * @param array{is_wpcom_simple:bool} $context  Widget support context.
+ * @return array Filtered and re-indexed widget records.
+ */
+function remove_unsupported_widget_items( $items, $type_key, $context ) {
+	$unsupported = get_unsupported_widget_types( $context );
+
+	if ( empty( $unsupported ) ) {
+		return $items;
+	}
+
+	return array_values(
+		array_filter(
+			$items,
+			static function ( $item ) use ( $type_key, $unsupported ) {
+				return ! is_array( $item )
+					|| ! in_array( $item[ $type_key ] ?? '', $unsupported, true );
+			}
+		)
+	);
+}

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\PremiumAnalytics;
 
+use Automattic\Jetpack\Constants;
 use PHPUnit\Framework\TestCase;
 use WP_REST_Server;
 
@@ -21,11 +22,12 @@ class Dashboard_Layout_Test extends TestCase {
 	const LEGACY_ROUTE = '/jetpack/v4/dashboards/(?P<name>[a-z][a-z0-9-]*(?:_[a-z0-9-]+)*)/default-layout';
 
 	/**
-	 * Reset REST globals after route registration tests.
+	 * Reset REST globals and constants between tests.
 	 */
 	protected function tearDown(): void {
 		global $wp_rest_server;
 		$wp_rest_server = null;
+		Constants::clear_constants();
 		parent::tearDown();
 	}
 
@@ -73,6 +75,28 @@ class Dashboard_Layout_Test extends TestCase {
 		$this->assertSame( $traffic, $layout );
 		$this->assertContains( 'jpa/traffic-chart', $layout_types );
 		$this->assertNotContains( 'jpa/hello-world', $layout_types );
+	}
+
+	/**
+	 * Default layouts pass through the availability policy: on self-hosted
+	 * Jetpack sites (this test env), Simple-only widget instances are dropped.
+	 */
+	public function test_traffic_default_excludes_simple_only_widgets_on_self_hosted() {
+		$layout_types = array_column( get_dashboard_default_layout_for( DASHBOARD_TRAFFIC_SECTION_ID ), 'type' );
+
+		$this->assertNotContains( 'jpa/file-downloads', $layout_types, 'Simple-only widget instances must not be part of the default layout on self-hosted sites.' );
+		$this->assertContains( 'jpa/clicks', $layout_types, 'Regular widget instances remain in the default layout.' );
+	}
+
+	/**
+	 * WPCOM Simple keeps Simple-only widgets in the default layout.
+	 */
+	public function test_traffic_default_keeps_simple_only_widgets_on_wpcom_simple() {
+		Constants::set_constant( 'IS_WPCOM', true );
+
+		$layout_types = array_column( get_dashboard_default_layout_for( DASHBOARD_TRAFFIC_SECTION_ID ), 'type' );
+
+		$this->assertContains( 'jpa/file-downloads', $layout_types );
 	}
 
 	/**

--- a/projects/packages/premium-analytics/tests/php/Widget_Availability_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Widget_Availability_Test.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\PremiumAnalytics;
 
+use Automattic\Jetpack\Constants;
 use PHPUnit\Framework\Attributes\CoversFunction;
 use WorDBless\BaseTestCase;
 
@@ -16,12 +17,20 @@ require_once __DIR__ . '/../../src/widget-availability.php';
 
 /**
  * @covers ::Automattic\Jetpack\PremiumAnalytics\get_available_widget_types
+ * @covers ::Automattic\Jetpack\PremiumAnalytics\get_widget_support_context
+ * @covers ::Automattic\Jetpack\PremiumAnalytics\get_unsupported_widget_types
+ * @covers ::Automattic\Jetpack\PremiumAnalytics\remove_unsupported_widget_items
+ * @covers ::Automattic\Jetpack\PremiumAnalytics\filter_registrable_widget_types_by_availability
  * @covers ::Automattic\Jetpack\PremiumAnalytics\filter_registrable_widget_types_by_environment
  * @covers ::Automattic\Jetpack\PremiumAnalytics\remove_dev_only_widget_types
  * @covers ::Automattic\Jetpack\PremiumAnalytics\filter_registrable_widget_types_by_plugin
  * @covers ::Automattic\Jetpack\PremiumAnalytics\remove_plugin_gated_widget_types
  */
 #[CoversFunction( 'Automattic\Jetpack\PremiumAnalytics\get_available_widget_types' )]
+#[CoversFunction( 'Automattic\Jetpack\PremiumAnalytics\get_widget_support_context' )]
+#[CoversFunction( 'Automattic\Jetpack\PremiumAnalytics\get_unsupported_widget_types' )]
+#[CoversFunction( 'Automattic\Jetpack\PremiumAnalytics\remove_unsupported_widget_items' )]
+#[CoversFunction( 'Automattic\Jetpack\PremiumAnalytics\filter_registrable_widget_types_by_availability' )]
 #[CoversFunction( 'Automattic\Jetpack\PremiumAnalytics\filter_registrable_widget_types_by_environment' )]
 #[CoversFunction( 'Automattic\Jetpack\PremiumAnalytics\remove_dev_only_widget_types' )]
 #[CoversFunction( 'Automattic\Jetpack\PremiumAnalytics\filter_registrable_widget_types_by_plugin' )]
@@ -29,9 +38,10 @@ require_once __DIR__ . '/../../src/widget-availability.php';
 class Widget_Availability_Test extends BaseTestCase {
 
 	/**
-	 * Reset availability filters between tests.
+	 * Reset constants and availability filters between tests.
 	 */
 	public function tear_down() {
+		Constants::clear_constants();
 		remove_all_filters( WOOCOMMERCE_DASHBOARD_SECTION_AVAILABLE_FILTER );
 
 		parent::tear_down();
@@ -47,6 +57,10 @@ class Widget_Availability_Test extends BaseTestCase {
 			array(
 				'name'     => 'jpa/react-query-dev-tool',
 				'category' => 'developer',
+			),
+			array(
+				'name'     => 'jpa/file-downloads',
+				'category' => 'traffic',
 			),
 			array(
 				'name'     => 'jpa/hello-world',
@@ -83,6 +97,84 @@ class Widget_Availability_Test extends BaseTestCase {
 				'category' => 'bookings',
 			),
 		);
+	}
+
+	/**
+	 * Filters the standard candidates with explicit host context.
+	 *
+	 * @param bool $is_wpcom_simple Whether the site is WPCOM Simple.
+	 * @return string[] Remaining type names.
+	 */
+	private function available_names( $is_wpcom_simple ) {
+		return array_column(
+			remove_unsupported_widget_items(
+				$this->widget_candidates(),
+				'name',
+				array( 'is_wpcom_simple' => $is_wpcom_simple )
+			),
+			'name'
+		);
+	}
+
+	/**
+	 * File downloads is unavailable outside WPCOM Simple.
+	 */
+	public function test_type_policy_removes_file_downloads_on_non_simple() {
+		$names = $this->available_names( false );
+
+		$this->assertNotContains( 'jpa/file-downloads', $names );
+		$this->assertContains( 'jpa/hello-world', $names );
+	}
+
+	/**
+	 * WPCOM Simple keeps File downloads.
+	 */
+	public function test_type_policy_keeps_file_downloads_on_simple() {
+		$this->assertContains( 'jpa/file-downloads', $this->available_names( true ) );
+	}
+
+	/**
+	 * Non-array records pass through unchanged.
+	 */
+	public function test_type_policy_keeps_non_array_records() {
+		$record = (object) array( 'name' => 'jpa/file-downloads' );
+
+		$this->assertSame(
+			array( $record ),
+			remove_unsupported_widget_items(
+				array(
+					$record,
+					array( 'name' => 'jpa/file-downloads' ),
+				),
+				'name',
+				array( 'is_wpcom_simple' => false )
+			)
+		);
+	}
+
+	/**
+	 * Records without the type key are not support-gated.
+	 */
+	public function test_type_policy_keeps_records_without_type_key() {
+		$items = array( array( 'uuid' => 'no-type' ) );
+
+		$this->assertSame(
+			$items,
+			remove_unsupported_widget_items( $items, 'type', array( 'is_wpcom_simple' => false ) )
+		);
+	}
+
+	/**
+	 * Filtered candidates are re-indexed so they stay a JSON list.
+	 */
+	public function test_type_policy_reindexes_filtered_records() {
+		$filtered = remove_unsupported_widget_items(
+			$this->widget_candidates(),
+			'name',
+			array( 'is_wpcom_simple' => false )
+		);
+
+		$this->assertSame( range( 0, count( $filtered ) - 1 ), array_keys( $filtered ), 'Filtered candidates must stay a JSON list.' );
 	}
 
 	/**
@@ -164,6 +256,35 @@ class Widget_Availability_Test extends BaseTestCase {
 			remove_plugin_gated_widget_types( $candidates, false, false ),
 			'A candidate without a category must not be plugin-gated.'
 		);
+	}
+
+	/**
+	 * The host callback removes File downloads on Atomic.
+	 */
+	public function test_registry_callback_removes_file_downloads_on_atomic() {
+		Constants::set_constant( 'ATOMIC_SITE_ID', 123 );
+		Constants::set_constant( 'ATOMIC_CLIENT_ID', 456 );
+
+		$names = array_column(
+			filter_registrable_widget_types_by_availability( $this->widget_candidates() ),
+			'name'
+		);
+
+		$this->assertNotContains( 'jpa/file-downloads', $names );
+	}
+
+	/**
+	 * The host callback keeps File downloads on WPCOM Simple.
+	 */
+	public function test_registry_callback_keeps_file_downloads_on_wpcom_simple() {
+		Constants::set_constant( 'IS_WPCOM', true );
+
+		$names = array_column(
+			filter_registrable_widget_types_by_availability( $this->widget_candidates() ),
+			'name'
+		);
+
+		$this->assertContains( 'jpa/file-downloads', $names );
 	}
 
 	/**

--- a/projects/packages/premium-analytics/widgets/file-downloads/render.tsx
+++ b/projects/packages/premium-analytics/widgets/file-downloads/render.tsx
@@ -41,93 +41,6 @@ type FileDownloadsRenderAttributes = FileDownloadsAttributes &
 type FileDownloadsWidgetProps = WidgetRenderProps< FileDownloadsRenderAttributes >;
 
 const DATA_FORMAT = { type: 'number' as const, options: { useMultipliers: true, decimals: 0 } };
-const FILE_DOWNLOADS_UNAVAILABLE_STATUS = 404;
-
-function toStatusNumber( value: unknown ): number | null {
-	if ( typeof value === 'number' ) {
-		return value;
-	}
-
-	if ( typeof value === 'string' ) {
-		const status = Number.parseInt( value, 10 );
-		return Number.isNaN( status ) ? null : status;
-	}
-
-	return null;
-}
-
-function getErrorStatus( error: unknown ): number | null {
-	if ( ! error || typeof error !== 'object' ) {
-		return null;
-	}
-
-	const err = error as Record< string, unknown >;
-
-	const status = toStatusNumber( err.status );
-	if ( status !== null ) {
-		return status;
-	}
-
-	if ( err.data && typeof err.data === 'object' ) {
-		const data = err.data as Record< string, unknown >;
-		const dataStatus = toStatusNumber( data.status );
-		if ( dataStatus !== null ) {
-			return dataStatus;
-		}
-	}
-
-	if ( err.response && typeof err.response === 'object' ) {
-		const response = err.response as Record< string, unknown >;
-		const responseStatus = toStatusNumber( response.status );
-		if ( responseStatus !== null ) {
-			return responseStatus;
-		}
-	}
-
-	return null;
-}
-
-function getErrorText( error: unknown ): string {
-	if ( ! error || typeof error !== 'object' ) {
-		return '';
-	}
-
-	const err = error as Record< string, unknown >;
-	const candidates = [
-		err.message,
-		err.error,
-		err.code,
-		err.data && typeof err.data === 'object'
-			? ( err.data as Record< string, unknown > ).message
-			: undefined,
-		err.data && typeof err.data === 'object'
-			? ( err.data as Record< string, unknown > ).error
-			: undefined,
-		err.response && typeof err.response === 'object'
-			? ( err.response as Record< string, unknown > ).message
-			: undefined,
-	];
-
-	return candidates
-		.filter( ( candidate ): candidate is string => typeof candidate === 'string' )
-		.join( ' ' );
-}
-
-function getFileDownloadsErrorMessage( error: unknown ) {
-	const errorText = getErrorText( error ).toLowerCase();
-	const isUnavailableMessage =
-		errorText.includes( 'file download' ) &&
-		( errorText.includes( 'not available' ) || errorText.includes( 'jetpack site' ) );
-
-	if ( getErrorStatus( error ) === FILE_DOWNLOADS_UNAVAILABLE_STATUS || isUnavailableMessage ) {
-		return __(
-			'File download stats are not available for Jetpack sites.',
-			'jetpack-premium-analytics'
-		);
-	}
-
-	return undefined;
-}
 
 /**
  * A single normalized file-downloads row, ready for the leaderboard.
@@ -264,11 +177,8 @@ type FileDownloadsInnerProps = {
  */
 function FileDownloadsInner( { max }: FileDownloadsInnerProps ) {
 	const { reportParams } = useWidgetRootContext();
-	const { comparisonRows, hasComparison, isLoading, isFetching, isError, error, refetch } =
+	const { comparisonRows, hasComparison, isLoading, isFetching, isError, refetch } =
 		useStatsFileDownloads( reportParams as StatsReportParams, { maxRows: max } );
-	// File downloads has a known unsupported case (404 on Jetpack sites); Retry
-	// can't succeed there, so the action is dropped for that message.
-	const unavailableMessage = getFileDownloadsErrorMessage( error );
 
 	const rows = useMemo(
 		() => toFileDownloadRows( comparisonRows?.rows ?? [] ),
@@ -288,15 +198,11 @@ function FileDownloadsInner( { max }: FileDownloadsInnerProps ) {
 					isError={ rows.length === 0 && isError }
 					isEmpty={ rows.length === 0 }
 					error={ {
-						description:
-							unavailableMessage ??
-							__(
-								"We couldn't load file downloads. Please try again in a moment.",
-								'jetpack-premium-analytics'
-							),
-						actions: unavailableMessage
-							? []
-							: [ { label: __( 'Retry', 'jetpack-premium-analytics' ), onClick: refetch } ],
+						description: __(
+							"We couldn't load file downloads. Please try again in a moment.",
+							'jetpack-premium-analytics'
+						),
+						actions: [ { label: __( 'Retry', 'jetpack-premium-analytics' ), onClick: refetch } ],
 					} }
 					empty={ {
 						icon: download,


### PR DESCRIPTION
Fixes WOOA7S-1717
Fixes WOOA7S-1709

## Proposed changes

File download tracking is provided only for WordPress.com Simple sites. The endpoint returns 404 elsewhere, but Premium Analytics registered and rendered the widget on every site.

- Treat `jpa/file-downloads` as unsupported outside WordPress.com Simple.
- Apply the same type-level policy to the widget registry and default layouts, keeping the REST list, import map, widget picker, and defaults consistent.
- Preserve saved layouts. Gutenberg intentionally renders missing types as removable ghost widgets, so availability changes do not silently rewrite user preferences ([WordPress/gutenberg#78502](https://github.com/WordPress/gutenberg/pull/78502)).
- Keep environment, plugin/category, and shared type-level policies separate and composable. Future permanent type restrictions have one shared resolver; temporary plan or capability restrictions remain runtime concerns.
- Preserve non-array records supplied through the public default-layout filter so third-party callbacks remain compatible.
- Hide the `/reports/downloads` route outside WordPress.com Simple.
- Remove the widget's obsolete 404-specific UI.

## Related product discussion/links

- WOOA7S-1717
- WOOA7S-1709
- WOOA7S-1716
- #50770

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

### Self-hosted Jetpack or another non-Simple site

1. Build the package: `jetpack build packages/premium-analytics --deps`.
2. Open Premium Analytics in wp-admin.
3. Reset the Traffic layout and confirm File downloads is not included.
4. Confirm File downloads is absent from the Add widget picker.
5. Confirm no `stats/file-downloads` requests are made.
6. Visit `admin.php?page=jetpack-premium-analytics-wp-admin&p=%2Freports%2Fdownloads` and confirm it redirects to the dashboard.
7. If the site has a layout saved before this branch with File downloads, confirm it appears as a removable unavailable widget. Enter `Customize` mode and remove it.

<img width="948" height="797" alt="Screenshot 2026-07-23 at 3 44 30 PM" src="https://github.com/user-attachments/assets/47fc4b26-aa68-4473-9f3f-a0a9a869c34f" />
<img width="2560" height="1325" alt="Screenshot 2026-07-23 at 3 43 42 PM" src="https://github.com/user-attachments/assets/4148c0b7-9c3e-4ecb-a877-86a2a775d4a9" />


### WordPress.com Simple

1. On a sandbox, fetch this branch's build: `bin/jetpack-downloader test jetpack-mu-wpcom-plugin add/wooa7s-1717-hide-file-downloads-on-self-hosted`.
2. Sandbox the test site and `public-api.wordpress.com` in `/etc/hosts`.
3. Open Premium Analytics on a Simple site with the `jetpack-premium-analytics` sticker. To add the sticker, run this on the sandbox:

   ```
   wp blog-stickers add --sticker=jetpack-premium-analytics --who=<your_wpcom_login> --blog_id=<blog_id>
   ```

4. Confirm File downloads remains in the Traffic default and widget picker.
5. Confirm its request returns data and `/reports/downloads` still renders.

<img width="2560" height="1322" alt="Screenshot 2026-07-23 at 4 42 54 PM" src="https://github.com/user-attachments/assets/b5de9d4a-b904-4eda-88fd-669b121ffaac" />
<img width="2560" height="1319" alt="Screenshot 2026-07-23 at 4 43 26 PM" src="https://github.com/user-attachments/assets/6cbe3f9f-c8be-417e-9e7b-87d7570dd006" />
