### PR TITLE
wp-build-polyfills: strip minified sourcemaps from production builds

### DIFF
--- a/projects/packages/wp-build-polyfills/bin/strip-unminified-prod-lib.js
+++ b/projects/packages/wp-build-polyfills/bin/strip-unminified-prod-lib.js
@@ -19,12 +19,18 @@
  * fallback that none of its patches recognised (indicating the wp-build
  * PHP template changed shape and the patches need updating).
  *
+ * It also deletes the `*.min.js.map` / `*.min.css.map` sourcemaps that
+ * wp-build emits unconditionally for package bundles (build/modules/** and
+ * build/scripts/**), and strips the trailing `sourceMappingURL` comment
+ * from each minified asset so browsers don't request the now-missing map.
+ * The maps bundle the original sources and add ~11 MiB to every production
+ * mirror while only ever being fetched with devtools open.
+ *
  * Note about SCRIPT_DEBUG-on-production debugging: after this runs, a
  * deploy target with SCRIPT_DEBUG=true gets the minified bundle, not the
- * unminified one. Devtools sourcemaps still resolve names, but in-page
- * stack traces and `view-source` are no longer readable. This is a small
- * trade-off relative to the ~10 MiB of dead bytes the unminified copies
- * would otherwise add to every production mirror.
+ * unminified one, and devtools no longer resolve original sources. This is
+ * a trade-off relative to the ~20 MiB of dead bytes the unminified copies
+ * and sourcemaps would otherwise add to every production mirror.
  */
 
 const { readdirSync, existsSync, unlinkSync, readFileSync, writeFileSync } = require( 'fs' );
@@ -95,6 +101,42 @@ function walk( dir, visit ) {
 	}
 }
 
+// Trailing sourceMappingURL comments as emitted by esbuild: a `//#` line for
+// JS, a `/*# ... */` comment for CSS. Anchored to the end of the file so an
+// occurrence inside string content is never touched.
+const MAP_COMMENTS = {
+	'.js': /\n?\/\/# sourceMappingURL=\S+\s*$/,
+	'.css': /\n?\/\*# sourceMappingURL=\S+ \*\/\s*$/,
+};
+
+/**
+ * Delete a `*.min.js.map`/`*.min.css.map` sourcemap and strip the trailing
+ * `sourceMappingURL` comment from its minified sibling so browsers don't
+ * request the deleted map. Non-map files (and maps of unrelated extensions)
+ * are left alone.
+ *
+ * @param {string} filePath - Absolute path to the candidate file.
+ * @return {boolean} `true` if the file was deleted, `false` otherwise.
+ */
+function stripMinifiedMap( filePath ) {
+	for ( const ext of STRIPPABLE_EXTS ) {
+		if ( ! filePath.endsWith( '.min' + ext + '.map' ) ) {
+			continue;
+		}
+		unlinkSync( filePath );
+		const assetPath = filePath.slice( 0, -'.map'.length );
+		if ( existsSync( assetPath ) ) {
+			const source = readFileSync( assetPath, 'utf8' );
+			const next = source.replace( MAP_COMMENTS[ ext ], '\n' );
+			if ( next !== source ) {
+				writeFileSync( assetPath, next );
+			}
+		}
+		return true;
+	}
+	return false;
+}
+
 /**
  * Delete a file if it is the unminified sibling of an existing
  * `.min.js`/`.min.css` counterpart. Also drops any sibling source map.
@@ -157,20 +199,23 @@ function hasUnpatchedFallback( source ) {
  * the generated PHP loaders. See module docstring for context.
  *
  * @param {string} buildDir - Absolute path to the package's build/ directory.
- * @return {{deletedFiles: number, patchedFiles: number, skipped: boolean}} Summary of what changed. `skipped: true` if `buildDir` doesn't exist.
+ * @return {{deletedFiles: number, deletedMaps: number, patchedFiles: number, skipped: boolean}} Summary of what changed. `skipped: true` if `buildDir` doesn't exist.
  */
 function strip( buildDir ) {
 	if ( ! existsSync( buildDir ) ) {
-		return { deletedFiles: 0, patchedFiles: 0, skipped: true };
+		return { deletedFiles: 0, deletedMaps: 0, patchedFiles: 0, skipped: true };
 	}
 
 	let deletedFiles = 0;
+	let deletedMaps = 0;
 	let patchedFiles = 0;
 
 	for ( const sub of TARGET_SUBDIRS ) {
 		walk( path.join( buildDir, sub ), filePath => {
 			if ( stripIfPaired( filePath ) ) {
 				deletedFiles++;
+			} else if ( stripMinifiedMap( filePath ) ) {
+				deletedMaps++;
 			}
 		} );
 	}
@@ -204,12 +249,13 @@ function strip( buildDir ) {
 		patchedFiles++;
 	}
 
-	return { deletedFiles, patchedFiles, skipped: false };
+	return { deletedFiles, deletedMaps, patchedFiles, skipped: false };
 }
 
 module.exports = {
 	strip,
 	stripIfPaired,
+	stripMinifiedMap,
 	patchPhpSource,
 	hasUnpatchedFallback,
 	walk,

--- a/projects/packages/wp-build-polyfills/bin/strip-unminified-prod.js
+++ b/projects/packages/wp-build-polyfills/bin/strip-unminified-prod.js
@@ -13,14 +13,14 @@ const path = require( 'path' );
 const { strip } = require( './strip-unminified-prod-lib.js' );
 
 const buildDir = path.join( process.cwd(), 'build' );
-const { deletedFiles, patchedFiles, skipped } = strip( buildDir );
+const { deletedFiles, deletedMaps, patchedFiles, skipped } = strip( buildDir );
 
 if ( skipped ) {
 	// eslint-disable-next-line no-console
 	console.log( `[strip-unminified-prod] no build/ at ${ buildDir }, skipping.` );
-} else if ( deletedFiles || patchedFiles ) {
+} else if ( deletedFiles || deletedMaps || patchedFiles ) {
 	// eslint-disable-next-line no-console
 	console.log(
-		`[strip-unminified-prod] removed ${ deletedFiles } unminified file(s); patched ${ patchedFiles } PHP loader(s).`
+		`[strip-unminified-prod] removed ${ deletedFiles } unminified file(s) and ${ deletedMaps } minified sourcemap(s); patched ${ patchedFiles } PHP loader(s).`
 	);
 }

--- a/projects/packages/wp-build-polyfills/changelog/strip-minified-sourcemaps-in-production
+++ b/projects/packages/wp-build-polyfills/changelog/strip-minified-sourcemaps-in-production
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+strip-unminified-prod: also remove `*.min.js.map` / `*.min.css.map` sourcemaps from production builds, stripping the `sourceMappingURL` reference from the minified assets.

--- a/projects/packages/wp-build-polyfills/tests/js/strip-unminified-prod-real-fixture.test.js
+++ b/projects/packages/wp-build-polyfills/tests/js/strip-unminified-prod-real-fixture.test.js
@@ -26,7 +26,9 @@ const path = require( 'path' );
 const {
 	strip,
 	hasUnpatchedFallback,
+	walk,
 	PHP_TARGETS,
+	TARGET_SUBDIRS,
 } = require( '../../bin/strip-unminified-prod-lib.js' );
 
 const POLYFILLS_DIR = path.join( __dirname, '..', '..' );
@@ -115,11 +117,39 @@ describe(
 		} );
 
 		it( 'strips paired unminified bundles and patches every PHP loader', () => {
+			// Collect the minified sourcemaps wp-build emitted, so we can
+			// assert each one is deleted and its asset's reference stripped.
+			const minMaps = [];
+			for ( const sub of TARGET_SUBDIRS ) {
+				walk( path.join( FIXTURE_BUILD, sub ), filePath => {
+					if ( filePath.endsWith( '.min.js.map' ) || filePath.endsWith( '.min.css.map' ) ) {
+						minMaps.push( filePath );
+					}
+				} );
+			}
+			// wp-build emits sourcemaps for package bundles (scripts/modules);
+			// if this goes to zero the sourcemap-stripping path is untested.
+			assert.ok(
+				minMaps.length > 0,
+				'wp-build should emit at least one .min sourcemap before stripping'
+			);
+
 			const result = strip( FIXTURE_BUILD );
 			assert.equal( result.skipped, false );
 			// 2 routes paired + 1 wpScript paired + 1 CSS paired + 1 widget (2 paired) = 6 deletions.
 			assert.equal( result.deletedFiles, 6 );
+			assert.equal( result.deletedMaps, minMaps.length );
 			assert.equal( result.patchedFiles, 5 );
+
+			// Minified sourcemaps gone, and their assets no longer reference them.
+			for ( const mapPath of minMaps ) {
+				assert.equal( existsSync( mapPath ), false, `${ mapPath } should be removed` );
+				const assetPath = mapPath.slice( 0, -'.map'.length );
+				assert.ok(
+					! readFileSync( assetPath, 'utf8' ).includes( 'sourceMappingURL' ),
+					`${ assetPath } should not reference its deleted sourcemap`
+				);
+			}
 
 			// Paired bundles gone, minified siblings retained.
 			for ( const [ unminified, minified ] of PAIRED_BUNDLES ) {
@@ -155,7 +185,12 @@ describe(
 
 		it( 'is idempotent on real output — a second pass changes nothing', () => {
 			const result = strip( FIXTURE_BUILD );
-			assert.deepEqual( result, { deletedFiles: 0, patchedFiles: 0, skipped: false } );
+			assert.deepEqual( result, {
+				deletedFiles: 0,
+				deletedMaps: 0,
+				patchedFiles: 0,
+				skipped: false,
+			} );
 		} );
 	}
 );


### PR DESCRIPTION
_Not sure if we will go ahead with this yet, as it would mean that SCRIPT_DEBUG=true is of no use_

## Proposed changes

`@wordpress/build` (wp-build) hardcodes `sourcemap: true` for package bundles, so every production build emits `*.min.js.map` files under `build/modules/**` and `build/scripts/**`. Since the whole `build/**` tree is `production-include`, those maps ship to the package mirror and into consumer plugin zips — ~11 MiB for Premium Analytics today (e.g. `build/modules/ui/index.min.js.map` alone is 3.2 MiB). Widget and route bundles get no sourcemaps at all, so the maps that do ship are inconsistent dead weight. (No upstream toggle exists yet; nearest analogs are WordPress/gutenberg#75395 and WordPress/gutenberg#75993.)

* Extend `strip-unminified-prod` in `wp-build-polyfills` to also delete `*.min.js.map` / `*.min.css.map` under its target subdirs (`routes`, `scripts`, `modules`, `styles`, `widgets`).
* Strip the trailing `sourceMappingURL` comment from each minified asset whose map was deleted, so browsers don't request a 404'd map.
* Report the removed sourcemap count in the bin's summary line and in `strip()`'s return value (`deletedMaps`).
* Extend the end-to-end test (real wp-build output) to assert maps are deleted and asset references stripped, and that the pass stays idempotent.

## Related product discussion/links
* Upstream: WordPress/gutenberg#75395 (proposed `--no-script-debug` flag), WordPress/gutenberg#75993 (sourcemaps disabled for WASM workers for the same size reason)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `cd projects/packages/wp-build-polyfills && pnpm run build && pnpm run test` — all tests pass, including `strip-unminified-prod-real-fixture.test.js` which builds a real wp-build fixture and asserts the `.min.js.map` files are removed and their `sourceMappingURL` references stripped.
* For an end-to-end check: `cd projects/packages/premium-analytics && pnpm run build-production`, then confirm `find build -name '*.map'` returns nothing and `grep -r sourceMappingURL build --include='*.min.js'` finds no references (the summary line reports `removed ... 8 minified sourcemap(s)`).
* Confirm the dashboard still loads normally from such a build (loaders collapse to `.min.js` as before; only the map files and their references are gone).
