### PR TITLE
Premium Analytics: hide commerce widget categories without their plugin

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-wooa7s-1775-hide-woo-bookings-widgets
+++ b/projects/packages/premium-analytics/changelog/update-wooa7s-1775-hide-woo-bookings-widgets
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Hide WooCommerce widget categories (store, orders, coupons, bookings) when WooCommerce is inactive, and bookings widgets when the WooCommerce Bookings extension is inactive.

--- a/projects/packages/premium-analytics/src/widget-availability.php
+++ b/projects/packages/premium-analytics/src/widget-availability.php
@@ -5,9 +5,11 @@
  * Premium Analytics' policy over the neutral filters in widget-types.php:
  * availability is the consumer's job, core only offers the hooks.
  *
- * Ships one policy: the developer-only React Query Devtools widget is never
- * registered in production. Hooking the registry-time filter (a hard hide)
- * keeps every registry consumer correct without a filtered accessor.
+ * Ships two policies, both hooked on the registry-time filter (a hard hide,
+ * which keeps every registry consumer correct without a filtered accessor):
+ * developer-only widget types are never registered in production, and the
+ * commerce widget categories are only registered while the plugin backing
+ * them (WooCommerce, plus WooCommerce Bookings for `bookings`) is active.
  *
  * @package automattic/jetpack-premium-analytics
  */
@@ -15,12 +17,20 @@
 namespace Automattic\Jetpack\PremiumAnalytics;
 
 /**
+ * Widget categories that are only meaningful with WooCommerce active.
+ *
+ * The `bookings` category additionally requires the WooCommerce Bookings
+ * extension; see remove_plugin_gated_widget_types().
+ */
+const WOOCOMMERCE_WIDGET_CATEGORIES = array( 'store', 'orders', 'coupons', 'bookings' );
+
+/**
  * Removes developer-only candidates in production.
  *
  * Split from the hook callback so both branches are testable without touching
  * the global environment.
  *
- * @param array  $widget_candidates Manifest candidates, each with a `name`.
+ * @param array  $widget_candidates Manifest candidates, each with a `name` and `category`.
  * @param string $environment       Site environment type.
  * @return array The candidates, minus developer-only types in production.
  */
@@ -29,17 +39,11 @@ function remove_dev_only_widget_types( $widget_candidates, $environment ) {
 		return $widget_candidates;
 	}
 
-	// Types that must never reach a production dashboard. Matched by name, not
-	// by `category: developer`: wp-build does not copy `category` into the PHP
-	// manifest yet, so it is not queryable here. Switch to a category check
-	// once the manifest carries it.
-	$dev_only = array( 'jpa/react-query-dev-tool' );
-
 	return array_values(
 		array_filter(
 			$widget_candidates,
-			static function ( $widget ) use ( $dev_only ) {
-				return ! in_array( $widget['name'] ?? '', $dev_only, true );
+			static function ( $widget ) {
+				return 'developer' !== ( $widget['category'] ?? '' );
 			}
 		)
 	);
@@ -59,3 +63,72 @@ function filter_registrable_widget_types_by_environment( $widget_candidates ) {
 }
 
 add_filter( REGISTRABLE_WIDGET_TYPES_FILTER, __NAMESPACE__ . '\\filter_registrable_widget_types_by_environment' );
+
+/**
+ * Removes candidates whose commerce category lacks its backing plugin.
+ *
+ * Every WooCommerce category needs WooCommerce itself; `bookings` needs the
+ * WooCommerce Bookings extension on top. Split from the hook callback so the
+ * branches are testable without touching global plugin state.
+ *
+ * @param array $widget_candidates     Manifest candidates, each with a `category`.
+ * @param bool  $woocommerce_available Whether WooCommerce is available.
+ * @param bool  $bookings_available    Whether WooCommerce Bookings is available.
+ * @return array The candidates, minus commerce categories missing their plugin.
+ */
+function remove_plugin_gated_widget_types( $widget_candidates, $woocommerce_available, $bookings_available ) {
+	return array_values(
+		array_filter(
+			$widget_candidates,
+			static function ( $widget ) use ( $woocommerce_available, $bookings_available ) {
+				$category = $widget['category'] ?? '';
+
+				if ( ! in_array( $category, WOOCOMMERCE_WIDGET_CATEGORIES, true ) ) {
+					return true;
+				}
+
+				if ( ! $woocommerce_available ) {
+					return false;
+				}
+
+				return 'bookings' !== $category || $bookings_available;
+			}
+		)
+	);
+}
+
+/**
+ * Whether the WooCommerce Bookings extension is active.
+ *
+ * Mirrors the detection in woocommerce-analytics' Bookings sync module;
+ * `is_plugin_active()` only exists in admin contexts, hence the guard.
+ *
+ * @return bool Whether WooCommerce Bookings was detected in the current request.
+ */
+function is_bookings_plugin_active() {
+	return class_exists( 'WC_Bookings' )
+		|| ( function_exists( 'is_plugin_active' ) && \is_plugin_active( 'woocommerce-bookings/woocommerce-bookings.php' ) );
+}
+
+/**
+ * Registry-time callback: hides commerce widget categories without their plugin.
+ *
+ * WooCommerce availability is read through the store section's signal
+ * (dashboard-sections.php, including its availability filter) so section and
+ * widgets can't disagree — a consumer overriding the section filter gets
+ * matching widget types. Both dashboard entry points load
+ * dashboard-sections.php before the widget registry can hydrate, so the
+ * function is always defined by the time this callback runs.
+ *
+ * @param array $widget_candidates Manifest candidates.
+ * @return array The candidates, minus commerce categories missing their plugin.
+ */
+function filter_registrable_widget_types_by_plugin( $widget_candidates ) {
+	return remove_plugin_gated_widget_types(
+		$widget_candidates,
+		is_woocommerce_dashboard_section_available(),
+		is_bookings_plugin_active()
+	);
+}
+
+add_filter( REGISTRABLE_WIDGET_TYPES_FILTER, __NAMESPACE__ . '\\filter_registrable_widget_types_by_plugin' );

--- a/projects/packages/premium-analytics/src/widget-availability.php
+++ b/projects/packages/premium-analytics/src/widget-availability.php
@@ -18,11 +18,16 @@ namespace Automattic\Jetpack\PremiumAnalytics;
 
 /**
  * Widget categories that are only meaningful with WooCommerce active.
- *
- * The `bookings` category additionally requires the WooCommerce Bookings
- * extension; see remove_plugin_gated_widget_types().
  */
-const WOOCOMMERCE_WIDGET_CATEGORIES = array( 'store', 'orders', 'coupons', 'bookings' );
+const WOOCOMMERCE_WIDGET_CATEGORIES = array( 'store', 'orders', 'coupons' );
+
+/**
+ * Widget categories that are only meaningful with WooCommerce Bookings active.
+ *
+ * Checked independently of WOOCOMMERCE_WIDGET_CATEGORIES: the Bookings
+ * extension cannot run without WooCommerce, so its presence implies both.
+ */
+const WOOCOMMERCE_BOOKINGS_WIDGET_CATEGORIES = array( 'bookings' );
 
 /**
  * Removes developer-only candidates in production.
@@ -67,9 +72,8 @@ add_filter( REGISTRABLE_WIDGET_TYPES_FILTER, __NAMESPACE__ . '\\filter_registrab
 /**
  * Removes candidates whose commerce category lacks its backing plugin.
  *
- * Every WooCommerce category needs WooCommerce itself; `bookings` needs the
- * WooCommerce Bookings extension on top. Split from the hook callback so the
- * branches are testable without touching global plugin state.
+ * Split from the hook callback so the branches are testable without touching
+ * global plugin state.
  *
  * @param array $widget_candidates     Manifest candidates, each with a `category`.
  * @param bool  $woocommerce_available Whether WooCommerce is available.
@@ -83,15 +87,15 @@ function remove_plugin_gated_widget_types( $widget_candidates, $woocommerce_avai
 			static function ( $widget ) use ( $woocommerce_available, $bookings_available ) {
 				$category = $widget['category'] ?? '';
 
-				if ( ! in_array( $category, WOOCOMMERCE_WIDGET_CATEGORIES, true ) ) {
-					return true;
-				}
-
-				if ( ! $woocommerce_available ) {
+				if ( ! $woocommerce_available && in_array( $category, WOOCOMMERCE_WIDGET_CATEGORIES, true ) ) {
 					return false;
 				}
 
-				return 'bookings' !== $category || $bookings_available;
+				if ( ! $bookings_available && in_array( $category, WOOCOMMERCE_BOOKINGS_WIDGET_CATEGORIES, true ) ) {
+					return false;
+				}
+
+				return true;
 			}
 		)
 	);

--- a/projects/packages/premium-analytics/tests/php/Widget_Availability_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Widget_Availability_Test.php
@@ -11,17 +11,31 @@ use PHPUnit\Framework\Attributes\CoversFunction;
 use WorDBless\BaseTestCase;
 
 require_once __DIR__ . '/../../src/widget-types.php';
+require_once __DIR__ . '/../../src/dashboard-sections.php';
 require_once __DIR__ . '/../../src/widget-availability.php';
 
 /**
  * @covers ::Automattic\Jetpack\PremiumAnalytics\get_available_widget_types
  * @covers ::Automattic\Jetpack\PremiumAnalytics\filter_registrable_widget_types_by_environment
  * @covers ::Automattic\Jetpack\PremiumAnalytics\remove_dev_only_widget_types
+ * @covers ::Automattic\Jetpack\PremiumAnalytics\filter_registrable_widget_types_by_plugin
+ * @covers ::Automattic\Jetpack\PremiumAnalytics\remove_plugin_gated_widget_types
  */
 #[CoversFunction( 'Automattic\Jetpack\PremiumAnalytics\get_available_widget_types' )]
 #[CoversFunction( 'Automattic\Jetpack\PremiumAnalytics\filter_registrable_widget_types_by_environment' )]
 #[CoversFunction( 'Automattic\Jetpack\PremiumAnalytics\remove_dev_only_widget_types' )]
+#[CoversFunction( 'Automattic\Jetpack\PremiumAnalytics\filter_registrable_widget_types_by_plugin' )]
+#[CoversFunction( 'Automattic\Jetpack\PremiumAnalytics\remove_plugin_gated_widget_types' )]
 class Widget_Availability_Test extends BaseTestCase {
+
+	/**
+	 * Reset availability filters between tests.
+	 */
+	public function tear_down() {
+		remove_all_filters( WOOCOMMERCE_DASHBOARD_SECTION_AVAILABLE_FILTER );
+
+		parent::tear_down();
+	}
 
 	/**
 	 * Candidate set shaped like the build manifest entries.
@@ -30,8 +44,44 @@ class Widget_Availability_Test extends BaseTestCase {
 	 */
 	private function widget_candidates() {
 		return array(
-			array( 'name' => 'jpa/react-query-dev-tool' ),
-			array( 'name' => 'jpa/hello-world' ),
+			array(
+				'name'     => 'jpa/react-query-dev-tool',
+				'category' => 'developer',
+			),
+			array(
+				'name'     => 'jpa/hello-world',
+				'category' => 'demo',
+			),
+		);
+	}
+
+	/**
+	 * Candidate set spanning the commerce categories and an ungated one.
+	 *
+	 * @return array[] List of widget candidates.
+	 */
+	private function commerce_widget_candidates() {
+		return array(
+			array(
+				'name'     => 'jpa/traffic-chart',
+				'category' => 'traffic',
+			),
+			array(
+				'name'     => 'jpa/store-performance',
+				'category' => 'store',
+			),
+			array(
+				'name'     => 'jpa/orders-over-time',
+				'category' => 'orders',
+			),
+			array(
+				'name'     => 'jpa/sales-by-coupon-usage',
+				'category' => 'coupons',
+			),
+			array(
+				'name'     => 'jpa/bookings-over-time',
+				'category' => 'bookings',
+			),
 		);
 	}
 
@@ -68,6 +118,71 @@ class Widget_Availability_Test extends BaseTestCase {
 
 		$this->assertNotContains( 'jpa/react-query-dev-tool', $names, 'The registry-time callback must drop the developer widget in production.' );
 		$this->assertContains( 'jpa/hello-world', $names, 'Regular widgets remain available.' );
+	}
+
+	/**
+	 * Without WooCommerce, every commerce category is dropped; the rest pass
+	 * through. The Bookings extension alone cannot rescue `bookings`.
+	 */
+	public function test_commerce_widgets_removed_without_woocommerce() {
+		foreach ( array( false, true ) as $bookings_available ) {
+			$names = array_column( remove_plugin_gated_widget_types( $this->commerce_widget_candidates(), false, $bookings_available ), 'name' );
+
+			$this->assertSame( array( 'jpa/traffic-chart' ), $names, 'Without WooCommerce only ungated categories remain, regardless of Bookings.' );
+		}
+	}
+
+	/**
+	 * With WooCommerce but no Bookings extension, only `bookings` is dropped.
+	 */
+	public function test_bookings_widgets_removed_without_bookings_plugin() {
+		$names = array_column( remove_plugin_gated_widget_types( $this->commerce_widget_candidates(), true, false ), 'name' );
+
+		$this->assertNotContains( 'jpa/bookings-over-time', $names, 'Bookings widgets must be hidden without the Bookings extension.' );
+		$this->assertContains( 'jpa/store-performance', $names, 'Store widgets only need WooCommerce.' );
+		$this->assertContains( 'jpa/orders-over-time', $names, 'Orders widgets only need WooCommerce.' );
+		$this->assertContains( 'jpa/sales-by-coupon-usage', $names, 'Coupons widgets only need WooCommerce.' );
+	}
+
+	/**
+	 * With both plugins available, everything passes through.
+	 */
+	public function test_commerce_widgets_kept_with_both_plugins() {
+		$this->assertSame(
+			$this->commerce_widget_candidates(),
+			remove_plugin_gated_widget_types( $this->commerce_widget_candidates(), true, true ),
+			'With WooCommerce and Bookings available no candidate is dropped.'
+		);
+	}
+
+	/**
+	 * Candidates without a category are never plugin-gated.
+	 */
+	public function test_uncategorized_widgets_pass_through() {
+		$candidates = array( array( 'name' => 'jpa/no-category' ) );
+
+		$this->assertSame(
+			$candidates,
+			remove_plugin_gated_widget_types( $candidates, false, false ),
+			'A candidate without a category must not be plugin-gated.'
+		);
+	}
+
+	/**
+	 * The registry-time callback follows the store section's availability
+	 * signal, so forcing the section visible also surfaces its widgets.
+	 */
+	public function test_registry_filter_callback_follows_section_availability() {
+		$this->assertFalse( is_woocommerce_dashboard_section_available(), 'The test environment must not have WooCommerce loaded.' );
+
+		$names = array_column( filter_registrable_widget_types_by_plugin( $this->commerce_widget_candidates() ), 'name' );
+		$this->assertSame( array( 'jpa/traffic-chart' ), $names, 'Without WooCommerce the callback drops every commerce category.' );
+
+		add_filter( WOOCOMMERCE_DASHBOARD_SECTION_AVAILABLE_FILTER, '__return_true' );
+
+		$names = array_column( filter_registrable_widget_types_by_plugin( $this->commerce_widget_candidates() ), 'name' );
+		$this->assertContains( 'jpa/store-performance', $names, 'Forcing the section available must surface the store widgets.' );
+		$this->assertNotContains( 'jpa/bookings-over-time', $names, 'Bookings widgets still require the Bookings extension.' );
 	}
 
 	/**

--- a/projects/packages/premium-analytics/tests/php/Widget_Availability_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Widget_Availability_Test.php
@@ -121,15 +121,13 @@ class Widget_Availability_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Without WooCommerce, every commerce category is dropped; the rest pass
-	 * through. The Bookings extension alone cannot rescue `bookings`.
+	 * Without WooCommerce (and thus without its Bookings extension), every
+	 * commerce category is dropped; the rest pass through.
 	 */
 	public function test_commerce_widgets_removed_without_woocommerce() {
-		foreach ( array( false, true ) as $bookings_available ) {
-			$names = array_column( remove_plugin_gated_widget_types( $this->commerce_widget_candidates(), false, $bookings_available ), 'name' );
+		$names = array_column( remove_plugin_gated_widget_types( $this->commerce_widget_candidates(), false, false ), 'name' );
 
-			$this->assertSame( array( 'jpa/traffic-chart' ), $names, 'Without WooCommerce only ungated categories remain, regardless of Bookings.' );
-		}
+		$this->assertSame( array( 'jpa/traffic-chart' ), $names, 'Without WooCommerce only ungated categories remain.' );
 	}
 
 	/**

--- a/projects/packages/premium-analytics/widgets/top-performing-bookings/widget.json
+++ b/projects/packages/premium-analytics/widgets/top-performing-bookings/widget.json
@@ -5,6 +5,6 @@
 	"help": {
 		"content": "Your best-selling bookings by revenue over the selected time period."
 	},
-	"category": "store",
+	"category": "bookings",
 	"presentation": "framed"
 }


### PR DESCRIPTION
Fixes WOOA7S-1775

## Proposed changes

* Add a registry-time widget availability policy, `filter_registrable_widget_types_by_plugin`, hooked on `REGISTRABLE_WIDGET_TYPES_FILTER` (same pattern as the dev-only gate from #50002): the WooCommerce widget categories — `store`, `orders`, `coupons`, and `bookings` — are only registered while WooCommerce is active.
* Read WooCommerce availability through the store section's signal (`is_woocommerce_dashboard_section_available()`, including its `jetpack_premium_analytics_woocommerce_dashboard_section_available` filter), so the store section and its widgets can't disagree — forcing the section available via the filter surfaces the widgets too.
* Additionally gate the `bookings` category on the WooCommerce Bookings extension, mirroring the detection used by woocommerce-analytics' Bookings sync module (`class_exists( 'WC_Bookings' )`, with a guarded `is_plugin_active()` fallback).
* Recategorize `jpa/top-performing-bookings` from `store` to `bookings` — it renders bookings data, so it belongs behind the Bookings gate.
* Switch the existing developer-only gate from a name match to a `category: developer` check, as its own comment instructed now that the wp-build manifest carries `category`.

Out of scope, by design:

* Scrubbing persisted layouts that still carry gated widget instances — #50732 introduces that mechanism generically.
* The `demo` category (`jpa/hello-world`) and report-route gating.

## Related product discussion/links

* https://linear.app/a8c/issue/WOOA7S-1775/woocommerce-and-bookings-widgets-hidden-when-woo-is-not-installed
* https://linear.app/a8c/issue/WOOA7S-1722/store-woocommerce-tab-conditional-visibility (parent audit: WOOA7S-1721/WOOA7S-1716)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run the unit tests: `cd projects/packages/premium-analytics && composer phpunit -- --filter Widget_Availability_Test` (or the full suite).
* On a site with this branch and **WooCommerce deactivated**:
  * Open the Premium Analytics dashboard and the widget library — no store/orders/coupons/bookings widgets should be offered.
  * The widget-modules REST list (`/wpcom/v2/dashboards/widget-modules` via the dashboard, or observe the network tab on dashboard load) should contain no widgets from those categories.
* Activate **WooCommerce** (without WooCommerce Bookings):
  * The store/orders/coupons widgets are registered again, and the Store section is visible.
  * The five bookings widgets (`bookings-*`, `store-conversion-rate-bookings`, `top-performing-bookings`) remain hidden.
* Activate **WooCommerce Bookings**: the bookings widgets appear as well.
