### PR TITLE
Error Reporting: enable for 1% of Atomic sites

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-error-reporting-site-segment
+++ b/projects/plugins/wpcomsh/changelog/update-error-reporting-site-segment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Gutenberg: Enable wp-admin JS error reporting on 1% of Atomic sites.

--- a/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
+++ b/projects/plugins/wpcomsh/feature-plugins/gutenberg-mods.php
@@ -65,7 +65,8 @@ function wpcomsh_remove_gutenberg_experimental_menu() {
 
 /**
  * Enable wp-admin JS error reporting on sites participating in the `gutenberg-react-19`
- * experiment, so that errors caused by the React 19 upgrade are captured.
+ * experiment, and on 1% of all sites, so that errors caused by the React 19 upgrade
+ * are captured.
  *
  * Reporting is enabled only for WP.com-connected users, who have accepted the WP.com
  * terms of service and privacy policy. Local users have made no such agreement.
@@ -82,7 +83,20 @@ function wpcomsh_enable_error_reporting_for_react_19( $is_enabled ) {
 		return false;
 	}
 
-	return function_exists( 'wpcomsh_is_site_sticker_active' ) && wpcomsh_is_site_sticker_active( 'gutenberg-react-19' );
+	if ( function_exists( 'wpcomsh_is_site_sticker_active' ) && wpcomsh_is_site_sticker_active( 'gutenberg-react-19' ) ) {
+		return true;
+	}
+
+	$site_id = wpcomsh_get_atomic_site_id();
+	if ( ! $site_id ) {
+		return false;
+	}
+
+	$current_segment = 1; // Segment of sites that get error reporting, in %.
+	$site_segment    = $site_id % 100;
+
+	// Sites whose id ends in digits < $current_segment are in the segment.
+	return $site_segment < $current_segment;
 }
 add_filter( 'a8c_enable_error_reporting', 'wpcomsh_enable_error_reporting_for_react_19' );
 


### PR DESCRIPTION
Let's enable error reporting for 1% of Atomic sites, i.e., for every site ID that ends with `*00`. This should provide a "background" information about common errors from Atomic sites.

The experience from observing Simple site errors is that the set of reported errors is surprisingly small, there are some 10 common errors and nothing much besides that. Let's see what kind of errors Atomic sites will contribute.

## Does this pull request change what data or activity we track or use?
Yes, it starts collecting error data from a subset of Atomic sites.

## Testing instructions
Follow the classic `wpcomsh` testing instructions and verify this change doesn't break your site.
