### PR TITLE
Search: add highlightPhraseOnly option for phrase-only highlights

### DIFF
--- a/projects/packages/search/changelog/add-highlight-phrase-only
+++ b/projects/packages/search/changelog/add-highlight-phrase-only
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Search: add highlightPhraseOnly Instant Search option to request phrase-only highlights from the API.
+Search: add highlightPhraseOnly and highlightFilterStopwords Instant Search options for highlight API params.

--- a/projects/packages/search/changelog/add-highlight-phrase-only
+++ b/projects/packages/search/changelog/add-highlight-phrase-only
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Search: add highlightPhraseOnly Instant Search option to request phrase-only highlights from the API.

--- a/projects/packages/search/src/inline-search/class-inline-search.php
+++ b/projects/packages/search/src/inline-search/class-inline-search.php
@@ -482,6 +482,10 @@ class Inline_Search extends Classic_Search {
 			$api_query_args['highlight_phrase_only'] = true;
 		}
 
+		if ( ! empty( $options['highlightFilterStopwords'] ) && is_array( $options['highlightFilterStopwords'] ) ) {
+			$api_query_args['highlight_filter_stopwords'] = array_values( $options['highlightFilterStopwords'] );
+		}
+
 		return $api_query_args;
 	}
 

--- a/projects/packages/search/src/inline-search/class-inline-search.php
+++ b/projects/packages/search/src/inline-search/class-inline-search.php
@@ -478,6 +478,10 @@ class Inline_Search extends Classic_Search {
 			);
 		}
 
+		if ( ! empty( $options['highlightPhraseOnly'] ) ) {
+			$api_query_args['highlight_phrase_only'] = true;
+		}
+
 		return $api_query_args;
 	}
 

--- a/projects/packages/search/src/instant-search/components/search-app.jsx
+++ b/projects/packages/search/src/instant-search/components/search-app.jsx
@@ -262,6 +262,7 @@ class SearchApp extends Component {
 			adminQueryFilter: this.props.options.adminQueryFilter,
 			highlightFields: this.props.options.highlightFields,
 			highlightPhraseOnly: this.props.options.highlightPhraseOnly,
+			highlightFilterStopwords: this.props.options.highlightFilterStopwords,
 			customResults: this.props.options.customResults,
 			isInCustomizer: this.props.isInCustomizer,
 		} );

--- a/projects/packages/search/src/instant-search/components/search-app.jsx
+++ b/projects/packages/search/src/instant-search/components/search-app.jsx
@@ -261,6 +261,7 @@ class SearchApp extends Component {
 			postsPerPage: this.props.options.postsPerPage,
 			adminQueryFilter: this.props.options.adminQueryFilter,
 			highlightFields: this.props.options.highlightFields,
+			highlightPhraseOnly: this.props.options.highlightPhraseOnly,
 			customResults: this.props.options.customResults,
 			isInCustomizer: this.props.isInCustomizer,
 		} );

--- a/projects/packages/search/src/instant-search/lib/api.js
+++ b/projects/packages/search/src/instant-search/lib/api.js
@@ -268,6 +268,7 @@ export function generateApiQueryString( {
 	additionalBlogIds = [],
 	highlightFields = [ 'title', 'content', 'comments' ],
 	highlightPhraseOnly = false,
+	highlightFilterStopwords = [],
 	customResults = [],
 } ) {
 	if ( query === null ) {
@@ -335,6 +336,10 @@ export function generateApiQueryString( {
 	// Only highlight spans that match the full query phrase (not individual terms).
 	if ( highlightPhraseOnly ) {
 		params.highlight_phrase_only = true;
+	}
+
+	if ( Array.isArray( highlightFilterStopwords ) && highlightFilterStopwords.length > 0 ) {
+		params.highlight_filter_stopwords = highlightFilterStopwords;
 	}
 
 	// Support search through multiple blogs.

--- a/projects/packages/search/src/instant-search/lib/api.js
+++ b/projects/packages/search/src/instant-search/lib/api.js
@@ -253,7 +253,7 @@ function mapSortToApiValue( sort ) {
  * @param {object} options - Options object for the function
  * @return {string} The generated query string.
  */
-function generateApiQueryString( {
+export function generateApiQueryString( {
 	aggregations,
 	excludedPostTypes,
 	filter,
@@ -267,6 +267,7 @@ function generateApiQueryString( {
 	isInCustomizer = false,
 	additionalBlogIds = [],
 	highlightFields = [ 'title', 'content', 'comments' ],
+	highlightPhraseOnly = false,
 	customResults = [],
 } ) {
 	if ( query === null ) {
@@ -330,6 +331,11 @@ function generateApiQueryString( {
 		page_handle: pageHandle,
 		size: postsPerPage,
 	};
+
+	// Only highlight spans that match the full query phrase (not individual terms).
+	if ( highlightPhraseOnly ) {
+		params.highlight_phrase_only = true;
+	}
 
 	// Support search through multiple blogs.
 	if ( additionalBlogIds?.length > 0 ) {

--- a/projects/packages/search/src/instant-search/lib/test/api.test.js
+++ b/projects/packages/search/src/instant-search/lib/test/api.test.js
@@ -1,4 +1,9 @@
-import { buildFilterAggregations, generateDateRangeFilter, setDocumentCountsToZero } from '../api';
+import {
+	buildFilterAggregations,
+	generateApiQueryString,
+	generateDateRangeFilter,
+	setDocumentCountsToZero,
+} from '../api';
 
 describe( 'buildFilterAggregations', () => {
 	test( 'generates aggregations for product_attribute filters', () => {
@@ -135,5 +140,32 @@ describe( 'setDocumentCountsToZero', () => {
 		expect( setDocumentCountsToZero( null ) ).toEqual( {} );
 		expect( setDocumentCountsToZero( undefined ) ).toEqual( {} );
 		expect( setDocumentCountsToZero( {} ) ).toEqual( {} );
+	} );
+} );
+
+describe( 'generateApiQueryString', () => {
+	test( 'includes highlight_phrase_only when highlightPhraseOnly is true', () => {
+		const queryString = generateApiQueryString( {
+			aggregations: {},
+			filter: {},
+			query: 'the search',
+			sort: 'relevance',
+			highlightPhraseOnly: true,
+		} );
+
+		expect( queryString ).toContain( 'highlight_phrase_only=true' );
+		expect( queryString ).toContain( 'highlight_fields' );
+	} );
+
+	test( 'omits highlight_phrase_only when highlightPhraseOnly is false', () => {
+		const queryString = generateApiQueryString( {
+			aggregations: {},
+			filter: {},
+			query: 'the search',
+			sort: 'relevance',
+			highlightPhraseOnly: false,
+		} );
+
+		expect( queryString ).not.toContain( 'highlight_phrase_only' );
 	} );
 } );

--- a/projects/packages/search/src/instant-search/lib/test/api.test.js
+++ b/projects/packages/search/src/instant-search/lib/test/api.test.js
@@ -168,4 +168,30 @@ describe( 'generateApiQueryString', () => {
 
 		expect( queryString ).not.toContain( 'highlight_phrase_only' );
 	} );
+
+	test( 'includes highlight_filter_stopwords when highlightFilterStopwords is set', () => {
+		const queryString = generateApiQueryString( {
+			aggregations: {},
+			filter: {},
+			query: 'the search',
+			sort: 'relevance',
+			highlightFilterStopwords: [ 'the', 'a' ],
+		} );
+
+		expect( queryString ).toContain( 'highlight_filter_stopwords' );
+		expect( queryString ).toContain( 'the' );
+		expect( queryString ).toContain( 'a' );
+	} );
+
+	test( 'omits highlight_filter_stopwords when highlightFilterStopwords is empty', () => {
+		const queryString = generateApiQueryString( {
+			aggregations: {},
+			filter: {},
+			query: 'the search',
+			sort: 'relevance',
+			highlightFilterStopwords: [],
+		} );
+
+		expect( queryString ).not.toContain( 'highlight_filter_stopwords' );
+	} );
 } );

--- a/projects/packages/search/tests/php/Inline_Search_Filters_Test.php
+++ b/projects/packages/search/tests/php/Inline_Search_Filters_Test.php
@@ -304,7 +304,7 @@ class Inline_Search_Filters_Test extends TestCase {
 	 */
 	public static function data_provider_instant_search_options_filter(): array {
 		return array(
-			'additional_should'     => array(
+			'additional_should'          => array(
 				'wp_query_args'     => array(
 					's'              => 'hello_world',
 					'posts_per_page' => 5,
@@ -362,7 +362,7 @@ class Inline_Search_Filters_Test extends TestCase {
 					),
 				),
 			),
-			'additional_must_not'   => array(
+			'additional_must_not'        => array(
 				'wp_query_args'     => array(
 					's'              => 'hello_world',
 					'posts_per_page' => 5,
@@ -418,7 +418,7 @@ class Inline_Search_Filters_Test extends TestCase {
 					),
 				),
 			),
-			'highlight_phrase_only' => array(
+			'highlight_phrase_only'      => array(
 				'wp_query_args'     => array(
 					's'              => 'the search',
 					'posts_per_page' => 5,
@@ -456,6 +456,46 @@ class Inline_Search_Filters_Test extends TestCase {
 						'fields' => array( 'title', 'content', 'comments' ),
 					),
 					'highlight_phrase_only' => '1',
+				),
+			),
+			'highlight_filter_stopwords' => array(
+				'wp_query_args'     => array(
+					's'              => 'the search',
+					'posts_per_page' => 5,
+					'post_type'      => 'any',
+				),
+				'is_opt_filter'     => function ( $options ) {
+					$options['highlightFilterStopwords'] = array( 'the', 'a' );
+
+					return $options;
+				},
+				'expected_api_args' => array(
+					'size'                       => '5',
+					'from'                       => '0',
+					'fields'                     => array( 'post_id' ),
+					'query'                      => 'the search',
+					'sort'                       => 'score_recency',
+					'langs'                      => array( 'en_US' ),
+					'filter'                     => array(
+						'bool' => array(
+							'must' => array(
+								array(
+									'terms' => array(
+										'post_type' => array(
+											'post',
+											'page',
+											'attachment',
+										),
+									),
+								),
+							),
+						),
+					),
+					'highlight_fields'           => array( 'title', 'content', 'comments' ),
+					'highlight'                  => array(
+						'fields' => array( 'title', 'content', 'comments' ),
+					),
+					'highlight_filter_stopwords' => array( 'the', 'a' ),
 				),
 			),
 		);

--- a/projects/packages/search/tests/php/Inline_Search_Filters_Test.php
+++ b/projects/packages/search/tests/php/Inline_Search_Filters_Test.php
@@ -304,7 +304,7 @@ class Inline_Search_Filters_Test extends TestCase {
 	 */
 	public static function data_provider_instant_search_options_filter(): array {
 		return array(
-			'additional_should'   => array(
+			'additional_should'     => array(
 				'wp_query_args'     => array(
 					's'              => 'hello_world',
 					'posts_per_page' => 5,
@@ -362,7 +362,7 @@ class Inline_Search_Filters_Test extends TestCase {
 					),
 				),
 			),
-			'additional_must_not' => array(
+			'additional_must_not'   => array(
 				'wp_query_args'     => array(
 					's'              => 'hello_world',
 					'posts_per_page' => 5,
@@ -416,6 +416,46 @@ class Inline_Search_Filters_Test extends TestCase {
 					'highlight'        => array(
 						'fields' => array( 'title', 'content', 'comments' ),
 					),
+				),
+			),
+			'highlight_phrase_only' => array(
+				'wp_query_args'     => array(
+					's'              => 'the search',
+					'posts_per_page' => 5,
+					'post_type'      => 'any',
+				),
+				'is_opt_filter'     => function ( $options ) {
+					$options['highlightPhraseOnly'] = true;
+
+					return $options;
+				},
+				'expected_api_args' => array(
+					'size'                  => '5',
+					'from'                  => '0',
+					'fields'                => array( 'post_id' ),
+					'query'                 => 'the search',
+					'sort'                  => 'score_recency',
+					'langs'                 => array( 'en_US' ),
+					'filter'                => array(
+						'bool' => array(
+							'must' => array(
+								array(
+									'terms' => array(
+										'post_type' => array(
+											'post',
+											'page',
+											'attachment',
+										),
+									),
+								),
+							),
+						),
+					),
+					'highlight_fields'      => array( 'title', 'content', 'comments' ),
+					'highlight'             => array(
+						'fields' => array( 'title', 'content', 'comments' ),
+					),
+					'highlight_phrase_only' => '1',
 				),
 			),
 		);


### PR DESCRIPTION
## Summary
- Adds `highlightPhraseOnly` and `highlightFilterStopwords` Instant Search options via `jetpack_instant_search_options`
- When set, Instant Search and Inline Search forward `highlight_phrase_only` and `highlight_filter_stopwords` to the WPCOM Search API
- Includes JS and PHP coverage for both options

## Usage

It is only allowed to use one or the other option, not both. 
```php
add_filter(
	'jetpack_instant_search_options',
	function ( $options ) {
		$options['highlightPhraseOnly'] = true;
		return $options;
	}
);

#OR
add_filter(
	'jetpack_instant_search_options',
	function ( $options ) {
		$options['highlightFilterStopwords'] = array( 'the', 'a', 'an' );
		return $options;
	}
);

```

Depends on corresponding WPCOM Search API support for these params. See 229608-ghe-Automattic/wpcom

## Test plan
- [ ] Confirm Instant Search API requests include `highlight_phrase_only=true` when the filter sets `highlightPhraseOnly`
- [ ] Confirm requests include `highlight_filter_stopwords` when `highlightFilterStopwords` is a non-empty array
- [ ] Confirm both params are omitted when unset/empty/false
- [ ] With Inline Search enabled, confirm the same options are forwarded from `jetpack_instant_search_options`
- [ ] Run `pnpm test-scripts` in `projects/packages/search` (api.test.js covers the query-string behavior)