### PR TITLE
Premium Analytics: hide the UTM Insights report link on post detail

### DIFF
--- a/projects/packages/premium-analytics/changelog/add-pa-utm-insights-report-link-toggle
+++ b/projects/packages/premium-analytics/changelog/add-pa-utm-insights-report-link-toggle
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Post detail: hide the UTM Insights "See report" link to match the design mocks; detail-page widgets carry no report actions.

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.test.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.test.ts
@@ -27,7 +27,7 @@ describe( 'post detail tab layouts', () => {
 			{
 				uuid: 'post-utm',
 				type: 'jpa/utm-insights',
-				attributes: { utmDimension: 'utm_source,utm_medium', max: 10 },
+				attributes: { utmDimension: 'utm_source,utm_medium', max: 10, showReportLink: false },
 				placement: { width: 2, height: 2, order: 5 },
 			},
 			{

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
@@ -34,7 +34,10 @@ export const POST_DETAIL_TAB_LAYOUTS: Record< PostDetailTabId, DashboardWidget[]
 		{
 			uuid: 'post-utm',
 			type: 'jpa/utm-insights',
-			attributes: { utmDimension: 'utm_source,utm_medium', max: 10 },
+			// Detail-page widgets carry no "See report" action per the design
+			// mocks — the post detail page is itself the terminal page, and the
+			// site-wide UTM report would silently drop this post's scope.
+			attributes: { utmDimension: 'utm_source,utm_medium', max: 10, showReportLink: false },
 			placement: { width: 2, height: 2, order: 5 },
 		},
 		{

--- a/projects/packages/premium-analytics/widgets/utm-insights/__tests__/utm-insights.test.tsx
+++ b/projects/packages/premium-analytics/widgets/utm-insights/__tests__/utm-insights.test.tsx
@@ -45,4 +45,10 @@ describe( 'UtmInsightsWidget', () => {
 			expect.stringContaining( 'section=campaign-source-medium' )
 		);
 	} );
+
+	it( 'hides the report link when the host composition opts out', () => {
+		render( <UtmInsightsWidget attributes={ { showReportLink: false } } /> );
+
+		expect( screen.queryByRole( 'link', { name: 'See report' } ) ).not.toBeInTheDocument();
+	} );
 } );

--- a/projects/packages/premium-analytics/widgets/utm-insights/render.tsx
+++ b/projects/packages/premium-analytics/widgets/utm-insights/render.tsx
@@ -54,6 +54,10 @@ type UtmInsightsInnerProps = {
 	 * Max rows to display.
 	 */
 	max: number;
+	/**
+	 * Whether to render the "See report" footer link.
+	 */
+	showReportLink: boolean;
 };
 
 /** Map a widget dimension to a section supported by the UTM report. */
@@ -78,7 +82,7 @@ function getUtmReportSection( utmDimension: StatsUtmParam ): UtmReportSection {
  * @param {UtmInsightsInnerProps} props - The component props.
  * @return The rendered leaderboard or state placeholder.
  */
-function UtmInsightsInner( { utmDimension, max }: UtmInsightsInnerProps ) {
+function UtmInsightsInner( { utmDimension, max, showReportLink }: UtmInsightsInnerProps ) {
 	const { reportParams } = useWidgetRootContext();
 	const {
 		drillDownItem: selectedUtmLabel,
@@ -198,9 +202,11 @@ function UtmInsightsInner( { utmDimension, max }: UtmInsightsInnerProps ) {
 					/>
 				</WidgetState>
 			</div>
-			<WidgetFooter>
-				<ReportLink report="utm" section={ getUtmReportSection( utmDimension ) } />
-			</WidgetFooter>
+			{ showReportLink && (
+				<WidgetFooter>
+					<ReportLink report="utm" section={ getUtmReportSection( utmDimension ) } />
+				</WidgetFooter>
+			) }
 		</>
 	);
 }
@@ -218,11 +224,16 @@ function UtmInsightsInner( { utmDimension, max }: UtmInsightsInnerProps ) {
 export default function UtmInsightsWidget( { attributes = {} }: UtmInsightsWidgetProps ) {
 	const utmDimension = attributes.utmDimension ?? DEFAULT_UTM_DIMENSION;
 	const max = attributes.max ?? 10;
+	const showReportLink = attributes.showReportLink ?? true;
 
 	return (
 		<WidgetRoot attributes={ attributes }>
 			<div className={ styles.root }>
-				<UtmInsightsInner utmDimension={ utmDimension } max={ max } />
+				<UtmInsightsInner
+					utmDimension={ utmDimension }
+					max={ max }
+					showReportLink={ showReportLink }
+				/>
 			</div>
 		</WidgetRoot>
 	);

--- a/projects/packages/premium-analytics/widgets/utm-insights/widget.ts
+++ b/projects/packages/premium-analytics/widgets/utm-insights/widget.ts
@@ -13,12 +13,16 @@ import { SelectField } from '@jetpack-premium-analytics/fields';
 /**
  * Widget attributes shape.
  *
- * @property utmDimension - UTM dimension to break down by. Defaults to 'utm_source,utm_medium'.
- * @property max          - Maximum rows to display (0 = all). Defaults to 10.
+ * @property utmDimension   - UTM dimension to break down by. Defaults to 'utm_source,utm_medium'.
+ * @property max            - Maximum rows to display (0 = all). Defaults to 10.
+ * @property showReportLink - Whether to render the "See report" footer link. Defaults to true.
+ *                          Host compositions on terminal pages (post detail) set this to false;
+ *                          it is not a user-facing control.
  */
 export type UtmInsightsAttributes = {
 	utmDimension?: StatsUtmParam;
 	max?: number;
+	showReportLink?: boolean;
 };
 
 /**


### PR DESCRIPTION
Fixes N/A (aligns with the WOOA7S-1622 design mocks)

## Proposed changes

* Add a `showReportLink` attribute to the UTM Insights widget (default `true`) that lets a host composition opt out of the "See report" footer link. It is not a user-facing control — it is only set by fixed page compositions.
* Set `showReportLink: false` in the post detail Traffic tab's fixed layout. Per the design mocks, detail-page widgets carry no "See report" action: the post detail page is itself the terminal page, and the link went to the **site-wide** UTM report, silently dropping the post scope.
* The dashboard (Traffic tab) UTM Insights widget keeps its "See report" link unchanged.

## Related product discussion/links

* Post detail fixed composition: WOOA7S-1622
* UTM report page: WOOA7S-1699

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build Premium Analytics (`jetpack build --deps packages/premium-analytics`) on a connected test site.
* Go to **Jetpack → Analytics**, Traffic tab: the UTM Insights widget still shows the "See report" footer link, and it opens `/reports/utm` with the matching section.
* Click a post title to open its **post detail** page, Traffic tab: the UTM Insights widget renders with **no** "See report" footer link.
* Unit tests: `cd projects/packages/premium-analytics && pnpm test -- utm-insights tab-layouts`

|Before|After|
|-|-|
|<img width="744" height="626" alt="截圖 2026-07-22 晚上10 02 41" src="https://github.com/user-attachments/assets/29aa20d1-d180-4eec-b475-79f754bf87de" />|<img width="757" height="622" alt="截圖 2026-07-22 晚上10 46 25" src="https://github.com/user-attachments/assets/d84dd989-f6c7-4c30-a61a-31461fa3a049" />|