### PR TITLE
VideoPress: keep the Jetpack submenu item when the module is inactive

### DIFF
--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/product-card-action.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/product-card-action.tsx
@@ -3,7 +3,10 @@ import { __, sprintf } from '@wordpress/i18n';
 import { Badge } from '@wordpress/ui';
 import { useCallback } from 'react';
 import { useNavigate } from 'react-router';
-import { PRODUCTS_MUST_HAVE_A_STANDALONE_PLUGIN } from '../../../constants';
+import {
+	PRODUCTS_MUST_HAVE_A_STANDALONE_PLUGIN,
+	PRODUCTS_NEEDING_RELOAD_AFTER_TOGGLE,
+} from '../../../constants';
 import useActivatePlugins from '../../../data/products/use-activate-plugins';
 import { useDeactivatePlugins } from '../../../data/products/use-deactivate-plugins';
 import useProduct from '../../../data/products/use-product';
@@ -138,6 +141,7 @@ function ActivationToggle( {
  */
 export function ProductCardAction( { product, module: $module }: ProductCardActionProps ) {
 	const { data: interstitials } = useInterstitialsState();
+	const reloadOnToggle = PRODUCTS_NEEDING_RELOAD_AFTER_TOGGLE.includes( product.slug );
 
 	// Forms is a free module feature with no interstitial yet — show the activation
 	// toggle directly instead of a "Learn more" link. (An interstitial may be added later.)
@@ -147,7 +151,7 @@ export function ProductCardAction( { product, module: $module }: ProductCardActi
 				product={ product }
 				active={ product.status === PRODUCT_STATUSES.ACTIVE }
 				disabled={ ! $module?.available }
-				reloadOnToggle
+				reloadOnToggle={ reloadOnToggle }
 			/>
 		);
 	}
@@ -165,6 +169,7 @@ export function ProductCardAction( { product, module: $module }: ProductCardActi
 			<ActivationToggle
 				product={ product }
 				active={ product.standalonePluginInfo.isStandaloneActive }
+				reloadOnToggle={ reloadOnToggle }
 			/>
 		);
 	}
@@ -179,6 +184,12 @@ export function ProductCardAction( { product, module: $module }: ProductCardActi
 			return <UpgradeAction product={ product } />;
 
 		default:
-			return <ActivationToggle product={ product } disabled={ ! $module?.available } />;
+			return (
+				<ActivationToggle
+					product={ product }
+					disabled={ ! $module?.available }
+					reloadOnToggle={ reloadOnToggle }
+				/>
+			);
 	}
 }

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/reload-page.ts
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/reload-page.ts
@@ -1,4 +1,5 @@
 /* istanbul ignore file */ // This is intended to be mocked in tests, because we can't mock window.location.
+import { getMyJetpackUrl } from '@automattic/jetpack-script-data';
 
 /**
  * Wrapper to reload the current page.
@@ -9,4 +10,15 @@
  */
 export function reloadPage() {
 	window.location.reload();
+}
+
+/**
+ * Wrapper to leave the app with a full page load to the My Jetpack overview page.
+ *
+ * Extracted so it can be mocked in tests.
+ *
+ * @return {undefined}
+ */
+export function loadMyJetpackHomePage() {
+	window.location.href = getMyJetpackUrl();
 }

--- a/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/test/product-card-action.test.tsx
+++ b/projects/packages/my-jetpack/_inc/components/my-jetpack-tab-panel/products/test/product-card-action.test.tsx
@@ -100,4 +100,48 @@ describe( 'ProductCardAction', () => {
 		);
 		expect( reloadPage ).toHaveBeenCalled();
 	} );
+
+	it( 'reloads the page after toggling VideoPress so the admin sidebar link updates', async () => {
+		// The "Jetpack > VideoPress" sidebar item links to the VideoPress library
+		// or to the My Jetpack activation interstitial depending on the module
+		// state, so toggling it must force a page reload.
+		render(
+			<ProductCardAction
+				product={ buildProduct( {
+					slug: 'videopress',
+					name: 'VideoPress',
+					status: 'active',
+					hasPaidPlanForProduct: true,
+				} ) }
+				module={ formsModule }
+			/>
+		);
+
+		await userEvent.click( screen.getByRole( 'checkbox' ) );
+
+		expect( mockDeactivate ).toHaveBeenCalled();
+		expect( setPendingSuccessNotice ).toHaveBeenCalledWith(
+			expect.stringContaining( 'deactivated' )
+		);
+		expect( reloadPage ).toHaveBeenCalled();
+	} );
+
+	it( 'does not reload the page when toggling a product with no admin menu changes', async () => {
+		render(
+			<ProductCardAction
+				product={ buildProduct( {
+					slug: 'search',
+					name: 'Search',
+					status: 'active',
+					hasPaidPlanForProduct: true,
+				} ) }
+				module={ formsModule }
+			/>
+		);
+
+		await userEvent.click( screen.getByRole( 'checkbox' ) );
+
+		expect( mockDeactivate ).toHaveBeenCalled();
+		expect( reloadPage ).not.toHaveBeenCalled();
+	} );
 } );

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/pricing-interstitial.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/pricing-interstitial.jsx
@@ -14,13 +14,13 @@ import {
 import { useProductCheckoutWorkflow } from '@automattic/jetpack-connection';
 import { getScriptData, getMyJetpackUrl } from '@automattic/jetpack-script-data';
 import { Spinner } from '@wordpress/components';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { Button } from '@wordpress/ui';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 /**
  * Internal dependencies
  */
-import { MyJetpackRoutes } from '../../constants';
+import { MyJetpackRoutes, PRODUCTS_NEEDING_RELOAD_AFTER_TOGGLE } from '../../constants';
 import useActivatePlugins from '../../data/products/use-activate-plugins';
 import useProduct from '../../data/products/use-product';
 import useAnalytics from '../../hooks/use-analytics';
@@ -29,6 +29,7 @@ import { useInterstitialsState } from '../../hooks/use-interstitials-state';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 import GoBackLink from '../go-back-link';
+import { setPendingSuccessNotice } from '../my-jetpack-tab-panel/products/pending-notice';
 import { getProductConfigs } from './config';
 import ProductInterstitial from './product-interstitial';
 import styles from './style.module.scss';
@@ -217,6 +218,20 @@ export default function PricingInterstitial( { slug } ) {
 									if ( postRegisterRedirectUri ) {
 										// Redirect to the product's admin page
 										window.location.href = postRegisterRedirectUri;
+									} else if ( PRODUCTS_NEEDING_RELOAD_AFTER_TOGGLE.includes( slug ) ) {
+										// Products like VideoPress change server-rendered wp-admin UI
+										// (the sidebar menu item's link) on activation, so fall back
+										// with a full page load — rather than a client-side navigation —
+										// to re-render that UI with the new state. The success notice
+										// is persisted so it survives the reload.
+										setPendingSuccessNotice(
+											sprintf(
+												/* translators: %s is the product name, i.e.- "Jetpack VideoPress". */
+												__( '%s activated successfully!', 'jetpack-my-jetpack' ),
+												product?.title
+											)
+										);
+										window.location.href = myJetpackCheckoutUri;
 									} else {
 										// Fall back to the My Jetpack overview page.
 										return navigateToMyJetpackOverviewPage();

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/pricing-interstitial.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/pricing-interstitial.jsx
@@ -14,13 +14,13 @@ import {
 import { useProductCheckoutWorkflow } from '@automattic/jetpack-connection';
 import { getScriptData, getMyJetpackUrl } from '@automattic/jetpack-script-data';
 import { Spinner } from '@wordpress/components';
-import { __, sprintf } from '@wordpress/i18n';
+import { __ } from '@wordpress/i18n';
 import { Button } from '@wordpress/ui';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 /**
  * Internal dependencies
  */
-import { MyJetpackRoutes, PRODUCTS_NEEDING_RELOAD_AFTER_TOGGLE } from '../../constants';
+import { MyJetpackRoutes } from '../../constants';
 import useActivatePlugins from '../../data/products/use-activate-plugins';
 import useProduct from '../../data/products/use-product';
 import useAnalytics from '../../hooks/use-analytics';
@@ -29,9 +29,9 @@ import { useInterstitialsState } from '../../hooks/use-interstitials-state';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 import GoBackLink from '../go-back-link';
-import { setPendingSuccessNotice } from '../my-jetpack-tab-panel/products/pending-notice';
 import { getProductConfigs } from './config';
 import ProductInterstitial from './product-interstitial';
+import { reloadIfActivationChangesAdminMenu } from './reload-after-activation';
 import styles from './style.module.scss';
 
 /**
@@ -218,21 +218,7 @@ export default function PricingInterstitial( { slug } ) {
 									if ( postRegisterRedirectUri ) {
 										// Redirect to the product's admin page
 										window.location.href = postRegisterRedirectUri;
-									} else if ( PRODUCTS_NEEDING_RELOAD_AFTER_TOGGLE.includes( slug ) ) {
-										// Products like VideoPress change server-rendered wp-admin UI
-										// (the sidebar menu item's link) on activation, so fall back
-										// with a full page load — rather than a client-side navigation —
-										// to re-render that UI with the new state. The success notice
-										// is persisted so it survives the reload.
-										setPendingSuccessNotice(
-											sprintf(
-												/* translators: %s is the product name, i.e.- "Jetpack VideoPress". */
-												__( '%s activated successfully!', 'jetpack-my-jetpack' ),
-												product?.title
-											)
-										);
-										window.location.href = myJetpackCheckoutUri;
-									} else {
+									} else if ( ! reloadIfActivationChangesAdminMenu( slug, product?.title ) ) {
 										// Fall back to the My Jetpack overview page.
 										return navigateToMyJetpackOverviewPage();
 									}

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/product-interstitial.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/product-interstitial.jsx
@@ -10,7 +10,7 @@ import { useCallback, useEffect } from 'react';
 /**
  * Internal dependencies
  */
-import { MyJetpackRoutes } from '../../constants';
+import { MyJetpackRoutes, PRODUCTS_NEEDING_RELOAD_AFTER_TOGGLE } from '../../constants';
 import useActivatePlugins from '../../data/products/use-activate-plugins';
 import useProduct from '../../data/products/use-product';
 import useAnalytics from '../../hooks/use-analytics';
@@ -18,6 +18,7 @@ import { useGoBack } from '../../hooks/use-go-back';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 import GoBackLink from '../go-back-link';
+import { setPendingSuccessNotice } from '../my-jetpack-tab-panel/products/pending-notice';
 import ProductDetailCard from '../product-detail-card';
 import ProductDetailTable from '../product-detail-table';
 import styles from './style.module.scss';
@@ -167,6 +168,23 @@ export default function ProductInterstitial( {
 							// for free products, we still initiate the site connection
 							handleRegisterSite().then( postRegisterRedirectUri => {
 								if ( ! postRegisterRedirectUri ) {
+									// Products like VideoPress change server-rendered wp-admin UI
+									// (the sidebar menu item's link) on activation, so falling back
+									// with a full page load — rather than a client-side navigation —
+									// re-renders that UI with the new state. The success notice is
+									// persisted so it survives the reload.
+									if ( PRODUCTS_NEEDING_RELOAD_AFTER_TOGGLE.includes( slug ) ) {
+										setPendingSuccessNotice(
+											sprintf(
+												/* translators: %s is the product name, i.e.- "Jetpack VideoPress". */
+												__( '%s activated successfully!', 'jetpack-my-jetpack' ),
+												productName
+											)
+										);
+										window.location.href = getMyJetpackUrl();
+										return;
+									}
+
 									// Fall back to the My Jetpack overview page.
 									return navigateToMyJetpackOverviewPage();
 								}
@@ -190,6 +208,7 @@ export default function ProductInterstitial( {
 			activate,
 			handleRegisterSite,
 			navigateToMyJetpackOverviewPage,
+			productName,
 		]
 	);
 

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/product-interstitial.jsx
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/product-interstitial.jsx
@@ -10,7 +10,7 @@ import { useCallback, useEffect } from 'react';
 /**
  * Internal dependencies
  */
-import { MyJetpackRoutes, PRODUCTS_NEEDING_RELOAD_AFTER_TOGGLE } from '../../constants';
+import { MyJetpackRoutes } from '../../constants';
 import useActivatePlugins from '../../data/products/use-activate-plugins';
 import useProduct from '../../data/products/use-product';
 import useAnalytics from '../../hooks/use-analytics';
@@ -18,9 +18,9 @@ import { useGoBack } from '../../hooks/use-go-back';
 import useMyJetpackConnection from '../../hooks/use-my-jetpack-connection';
 import useMyJetpackNavigate from '../../hooks/use-my-jetpack-navigate';
 import GoBackLink from '../go-back-link';
-import { setPendingSuccessNotice } from '../my-jetpack-tab-panel/products/pending-notice';
 import ProductDetailCard from '../product-detail-card';
 import ProductDetailTable from '../product-detail-table';
+import { reloadIfActivationChangesAdminMenu } from './reload-after-activation';
 import styles from './style.module.scss';
 
 /**
@@ -167,24 +167,10 @@ export default function ProductInterstitial( {
 						if ( ! needsPurchase ) {
 							// for free products, we still initiate the site connection
 							handleRegisterSite().then( postRegisterRedirectUri => {
-								if ( ! postRegisterRedirectUri ) {
-									// Products like VideoPress change server-rendered wp-admin UI
-									// (the sidebar menu item's link) on activation, so falling back
-									// with a full page load — rather than a client-side navigation —
-									// re-renders that UI with the new state. The success notice is
-									// persisted so it survives the reload.
-									if ( PRODUCTS_NEEDING_RELOAD_AFTER_TOGGLE.includes( slug ) ) {
-										setPendingSuccessNotice(
-											sprintf(
-												/* translators: %s is the product name, i.e.- "Jetpack VideoPress". */
-												__( '%s activated successfully!', 'jetpack-my-jetpack' ),
-												productName
-											)
-										);
-										window.location.href = getMyJetpackUrl();
-										return;
-									}
-
+								if (
+									! postRegisterRedirectUri &&
+									! reloadIfActivationChangesAdminMenu( slug, productName )
+								) {
 									// Fall back to the My Jetpack overview page.
 									return navigateToMyJetpackOverviewPage();
 								}

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/reload-after-activation.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/reload-after-activation.ts
@@ -1,0 +1,33 @@
+import { __, sprintf } from '@wordpress/i18n';
+import { PRODUCTS_NEEDING_RELOAD_AFTER_TOGGLE } from '../../constants';
+import { setPendingSuccessNotice } from '../my-jetpack-tab-panel/products/pending-notice';
+import { loadMyJetpackHomePage } from '../my-jetpack-tab-panel/products/reload-page';
+
+/**
+ * Start a full page load back to the My Jetpack overview after activating a
+ * product that changes server-rendered wp-admin UI, such as sidebar menu items
+ * (e.g. the "Jetpack > VideoPress" item links to the VideoPress library only
+ * once the module is active). A client-side navigation would keep the stale
+ * pre-activation markup, so those products must leave the app through a real
+ * page load. The success notice is persisted so it survives the reload.
+ *
+ * @param {string} slug        - The slug of the product that was activated.
+ * @param {string} productName - The product name used in the success notice.
+ * @return {boolean} Whether a page load was started. When true, callers must skip their client-side navigation fallback.
+ */
+export function reloadIfActivationChangesAdminMenu( slug: string, productName?: string ): boolean {
+	if ( ! PRODUCTS_NEEDING_RELOAD_AFTER_TOGGLE.includes( slug ) ) {
+		return false;
+	}
+
+	setPendingSuccessNotice(
+		sprintf(
+			/* translators: %s is the product name, i.e.- "Jetpack VideoPress". */
+			__( '%s activated successfully!', 'jetpack-my-jetpack' ),
+			productName
+		)
+	);
+	loadMyJetpackHomePage();
+
+	return true;
+}

--- a/projects/packages/my-jetpack/_inc/components/product-interstitial/test/reload-after-activation.test.ts
+++ b/projects/packages/my-jetpack/_inc/components/product-interstitial/test/reload-after-activation.test.ts
@@ -1,0 +1,29 @@
+import { setPendingSuccessNotice } from '../../my-jetpack-tab-panel/products/pending-notice';
+import { loadMyJetpackHomePage } from '../../my-jetpack-tab-panel/products/reload-page';
+import { reloadIfActivationChangesAdminMenu } from '../reload-after-activation';
+
+// window.location can't be mocked directly, so the navigation lives in mockable wrappers.
+jest.mock( '../../my-jetpack-tab-panel/products/pending-notice' );
+jest.mock( '../../my-jetpack-tab-panel/products/reload-page' );
+
+describe( 'reloadIfActivationChangesAdminMenu', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'leaves with a full page load for VideoPress, persisting the success notice', () => {
+		// VideoPress changes the "Jetpack > VideoPress" sidebar link on activation,
+		// so the app must be left through a real page load to re-render it.
+		expect( reloadIfActivationChangesAdminMenu( 'videopress', 'VideoPress' ) ).toBe( true );
+
+		expect( setPendingSuccessNotice ).toHaveBeenCalledWith( 'VideoPress activated successfully!' );
+		expect( loadMyJetpackHomePage ).toHaveBeenCalled();
+	} );
+
+	it( 'does nothing for products that do not change wp-admin menus', () => {
+		expect( reloadIfActivationChangesAdminMenu( 'search', 'Search' ) ).toBe( false );
+
+		expect( setPendingSuccessNotice ).not.toHaveBeenCalled();
+		expect( loadMyJetpackHomePage ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/packages/my-jetpack/_inc/constants.ts
+++ b/projects/packages/my-jetpack/_inc/constants.ts
@@ -86,6 +86,15 @@ export const JETPACK_PRODUCTS_NOT_FOR_MULTISITE: Array< ( typeof JETPACK_PRODUCT
 export const PRODUCTS_MUST_HAVE_A_STANDALONE_PLUGIN = [ 'anti-spam', 'boost', 'crm' ];
 
 /**
+ * Products whose (de)activation changes server-rendered wp-admin UI, such as
+ * sidebar menu items (e.g. the "Jetpack > VideoPress" item switches between the
+ * VideoPress library and the My Jetpack activation interstitial). Activating or
+ * deactivating them from My Jetpack must force a full page load so that UI is
+ * re-rendered with the new state.
+ */
+export const PRODUCTS_NEEDING_RELOAD_AFTER_TOGGLE = [ 'jetpack-forms', 'videopress' ];
+
+/**
  * Non-paid here means that the module is available for free users,
  * i.e. it does not have a paid plan associated with it.
  */

--- a/projects/packages/my-jetpack/changelog/add-videopress-jetpack-submenu-when-inactive
+++ b/projects/packages/my-jetpack/changelog/add-videopress-jetpack-submenu-when-inactive
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Force a full page reload after activating or deactivating VideoPress from the products list or the add-videopress interstitial, so the wp-admin sidebar menu item is re-rendered with the link matching the new activation state.

--- a/projects/packages/videopress/changelog/add-videopress-jetpack-submenu-when-inactive
+++ b/projects/packages/videopress/changelog/add-videopress-jetpack-submenu-when-inactive
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Admin menu: keep the VideoPress item under the Jetpack menu when VideoPress is not active, linking to the My Jetpack page to activate it.

--- a/projects/packages/videopress/changelog/add-videopress-jetpack-submenu-when-inactive
+++ b/projects/packages/videopress/changelog/add-videopress-jetpack-submenu-when-inactive
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Admin menu: keep the VideoPress item under the Jetpack menu when VideoPress is not active, linking to the My Jetpack page to activate it.
+Admin menu: keep the VideoPress item under the Jetpack menu when VideoPress is not active, linking to the My Jetpack page to activate it. The item is only shown once Jetpack is connected.

--- a/projects/packages/videopress/changelog/add-videopress-jetpack-submenu-when-inactive
+++ b/projects/packages/videopress/changelog/add-videopress-jetpack-submenu-when-inactive
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Admin menu: keep the VideoPress item under the Jetpack menu when VideoPress is not active, linking to the My Jetpack page to activate it. The item is only shown once Jetpack is connected.
+Admin menu: keep the VideoPress item under the Jetpack menu when VideoPress is not active, linking to the My Jetpack page to activate it. The item is only shown to users with their own Jetpack user connection.

--- a/projects/packages/videopress/src/class-admin-ui.php
+++ b/projects/packages/videopress/src/class-admin-ui.php
@@ -193,10 +193,12 @@ class Admin_UI {
 	 * @return void
 	 */
 	public static function enable_inactive_menu() {
-		// Activating VideoPress requires a Jetpack connection, so don't offer the
-		// item while the site is disconnected. Checked here, at admin_menu time,
-		// so the item starts rendering as soon as the site gets connected.
-		if ( ! ( new Connection_Manager() )->is_connected() ) {
+		// Activating VideoPress from My Jetpack requires a connected user, so only
+		// offer the item to users with their own Jetpack connection. Checked here,
+		// at admin_menu time, so the item starts rendering as soon as the current
+		// user connects.
+		$connection = new Connection_Manager();
+		if ( ! $connection->is_connected() || ! $connection->is_user_connected() ) {
 			return;
 		}
 

--- a/projects/packages/videopress/src/class-admin-ui.php
+++ b/projects/packages/videopress/src/class-admin-ui.php
@@ -12,6 +12,7 @@ use Automattic\Jetpack\Assets;
 use Automattic\Jetpack\Connection\Initial_State as Connection_Initial_State;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Current_Plan;
+use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
 use Automattic\Jetpack\My_Jetpack\Products as My_Jetpack_Products;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
@@ -26,6 +27,14 @@ class Admin_UI {
 	const JETPACK_VIDEOPRESS_PKG_NAMESPACE = 'jetpack-videopress-pkg';
 
 	const ADMIN_PAGE_SLUG = 'jetpack-videopress';
+
+	/**
+	 * The My Jetpack interstitial where VideoPress can be activated, relative to wp-admin.
+	 *
+	 * Used as the target of the "Jetpack > VideoPress" menu item when VideoPress
+	 * is not active.
+	 */
+	const MY_JETPACK_ADD_VIDEOPRESS_URI = 'admin.php?page=my-jetpack#/add-videopress';
 
 	/**
 	 * Filter name that gates the wp-build–based dashboard.
@@ -127,6 +136,52 @@ class Admin_UI {
 			3
 		);
 		add_action( 'load-' . $page_suffix, array( __CLASS__, 'admin_init' ) );
+	}
+
+	/**
+	 * Initializes the "Jetpack > VideoPress" menu item shown when VideoPress is not active.
+	 *
+	 * This method is called by the Initializer class instead of init() when the
+	 * VideoPress module is not active. Instead of the dashboard, the menu item is a
+	 * plain link to the My Jetpack interstitial where VideoPress can be activated.
+	 *
+	 * @return void
+	 */
+	public static function init_inactive_menu() {
+		// On WordPress.com Simple the standalone menu system (Admin_Menu) is not used;
+		// the Jetpack menu is fully managed by wpcom-admin-menu.php. See init().
+		if ( ( new Host() )->is_wpcom_simple() ) {
+			return;
+		}
+
+		add_action( 'admin_menu', array( __CLASS__, 'enable_inactive_menu' ), 1 );
+	}
+
+	/**
+	 * Register the inactive-state menu item: a direct link to the My Jetpack
+	 * "add VideoPress" interstitial.
+	 *
+	 * A slug that is not a registered page makes WordPress render the item as a
+	 * plain link to that URI (same mechanism as the "Upgrade Jetpack" menu item).
+	 *
+	 * @return void
+	 */
+	public static function enable_inactive_menu() {
+		// The link targets My Jetpack; don't render a dead link when that page
+		// is not registered (e.g. offline mode).
+		if ( ! My_Jetpack_Initializer::should_initialize() ) {
+			return;
+		}
+
+		Admin_Menu::add_menu(
+			// "VideoPress" is a product name, do not translate.
+			'Jetpack VideoPress',
+			'VideoPress',
+			'manage_options',
+			self::MY_JETPACK_ADD_VIDEOPRESS_URI,
+			null,
+			3
+		);
 	}
 
 	/**

--- a/projects/packages/videopress/src/class-admin-ui.php
+++ b/projects/packages/videopress/src/class-admin-ui.php
@@ -18,6 +18,7 @@ use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 use Automattic\Jetpack\Terms_Of_Service;
 use Automattic\Jetpack\Tracking;
+use Automattic\Jetpack\VideoPress\Status as VideoPress_Status;
 
 /**
  * Initialized the VideoPress package
@@ -119,11 +120,34 @@ class Admin_UI {
 	}
 
 	/**
-	 * Enable the menu, separately to init due to translations needing to run early for the page suffix.
+	 * Register the "Jetpack > VideoPress" menu item, choosing its target dynamically.
+	 *
+	 * Hooked on admin_menu from both init() and init_inactive_menu(), so the item
+	 * reflects the module state when the menu renders rather than when the package
+	 * initialized: when VideoPress is active it opens the VideoPress library
+	 * (admin.php?page=jetpack-videopress); when it is not, it links to the
+	 * My Jetpack interstitial where VideoPress can be activated.
+	 *
+	 * Registered separately to init due to translations needing to run early for
+	 * the page suffix.
 	 *
 	 * @return void
 	 */
 	public static function enable_menu() {
+		if ( VideoPress_Status::is_active() ) {
+			self::enable_dashboard_menu();
+			return;
+		}
+
+		self::enable_inactive_menu();
+	}
+
+	/**
+	 * Register the VideoPress library dashboard page and its menu item.
+	 *
+	 * @return void
+	 */
+	private static function enable_dashboard_menu() {
 		$callback = self::get_dashboard_render_callback();
 
 		$page_suffix = Admin_Menu::add_menu(
@@ -139,11 +163,13 @@ class Admin_UI {
 	}
 
 	/**
-	 * Initializes the "Jetpack > VideoPress" menu item shown when VideoPress is not active.
+	 * Initializes the "Jetpack > VideoPress" menu item when VideoPress is not active.
 	 *
 	 * This method is called by the Initializer class instead of init() when the
-	 * VideoPress module is not active. Instead of the dashboard, the menu item is a
-	 * plain link to the My Jetpack interstitial where VideoPress can be activated.
+	 * VideoPress module is not active. It hooks the same enable_menu() callback as
+	 * init(), which picks the item's target from the module state at admin_menu
+	 * time — so if the state changed since package initialization, the rendered
+	 * link is still correct.
 	 *
 	 * @return void
 	 */
@@ -154,7 +180,7 @@ class Admin_UI {
 			return;
 		}
 
-		add_action( 'admin_menu', array( __CLASS__, 'enable_inactive_menu' ), 1 );
+		add_action( 'admin_menu', array( __CLASS__, 'enable_menu' ), 1 );
 	}
 
 	/**

--- a/projects/packages/videopress/src/class-admin-ui.php
+++ b/projects/packages/videopress/src/class-admin-ui.php
@@ -193,6 +193,13 @@ class Admin_UI {
 	 * @return void
 	 */
 	public static function enable_inactive_menu() {
+		// Activating VideoPress requires a Jetpack connection, so don't offer the
+		// item while the site is disconnected. Checked here, at admin_menu time,
+		// so the item starts rendering as soon as the site gets connected.
+		if ( ! ( new Connection_Manager() )->is_connected() ) {
+			return;
+		}
+
 		// The link targets My Jetpack; don't render a dead link when that page
 		// is not registered (e.g. offline mode).
 		if ( ! My_Jetpack_Initializer::should_initialize() ) {

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -35,6 +35,10 @@ class Initializer {
 
 			if ( Status::is_active() ) {
 				self::active_initialization();
+			} elseif ( self::should_initialize_admin_ui() ) {
+				// Keep "Jetpack > VideoPress" in the menu when the module is not
+				// active, linking to the My Jetpack interstitial to activate it.
+				Admin_UI::init_inactive_menu();
 			}
 		}
 

--- a/projects/packages/videopress/tests/php/Admin_UI_Test.php
+++ b/projects/packages/videopress/tests/php/Admin_UI_Test.php
@@ -29,6 +29,8 @@ class Admin_UI_Test extends BaseTestCase {
 		$this->set_admin_menu_items( array() );
 		\Jetpack_Options::delete_option( 'id' );
 		\Jetpack_Options::delete_option( 'blog_token' );
+		\Jetpack_Options::delete_option( 'user_tokens' );
+		wp_set_current_user( 0 );
 		$this->reset_connection_status_cache();
 	}
 
@@ -40,6 +42,25 @@ class Admin_UI_Test extends BaseTestCase {
 		\Jetpack_Options::update_option( 'id', 1234 );
 		\Jetpack_Options::update_option( 'blog_token', 'blog.token' );
 		$this->reset_connection_status_cache();
+	}
+
+	/**
+	 * Make Connection\Manager report a connected site whose current user has
+	 * their own user connection (is_user_connected()).
+	 */
+	private function mock_connected_user() {
+		$this->mock_connected_site();
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'videopress_admin',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		$this->assertIsInt( $user_id );
+		wp_set_current_user( $user_id );
+		\Jetpack_Options::update_option( 'user_tokens', array( $user_id => 'user.token.' . $user_id ) );
 	}
 
 	/**
@@ -124,7 +145,7 @@ class Admin_UI_Test extends BaseTestCase {
 	 * module inactive it queues the My Jetpack activation link, not the dashboard.
 	 */
 	public function test_enable_menu_registers_activation_link_when_module_inactive() {
-		$this->mock_connected_site();
+		$this->mock_connected_user();
 		add_filter( 'jetpack_my_jetpack_should_initialize', '__return_true' );
 
 		$this->assertFalse( Status::is_active() );
@@ -165,7 +186,7 @@ class Admin_UI_Test extends BaseTestCase {
 	 * My Jetpack "add VideoPress" interstitial.
 	 */
 	public function test_enable_inactive_menu_queues_my_jetpack_link() {
-		$this->mock_connected_site();
+		$this->mock_connected_user();
 		add_filter( 'jetpack_my_jetpack_should_initialize', '__return_true' );
 
 		Admin_UI::enable_inactive_menu();
@@ -184,7 +205,7 @@ class Admin_UI_Test extends BaseTestCase {
 	 * since the link would point to an unregistered page.
 	 */
 	public function test_enable_inactive_menu_bails_without_my_jetpack() {
-		$this->mock_connected_site();
+		$this->mock_connected_user();
 		add_filter( 'jetpack_my_jetpack_should_initialize', '__return_false' );
 
 		Admin_UI::enable_inactive_menu();
@@ -193,12 +214,25 @@ class Admin_UI_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test that no menu item is queued while Jetpack is not connected:
+	 * Test that no menu item is queued while Jetpack is not connected at all:
 	 * activating VideoPress requires a connection, so the item would be a
-	 * dead end. The check runs at admin_menu time, so the item starts
-	 * rendering as soon as the site gets connected.
+	 * dead end.
 	 */
 	public function test_enable_inactive_menu_bails_when_jetpack_not_connected() {
+		add_filter( 'jetpack_my_jetpack_should_initialize', '__return_true' );
+
+		Admin_UI::enable_inactive_menu();
+
+		$this->assertSame( array(), $this->get_admin_menu_items() );
+	}
+
+	/**
+	 * Test that a site-level connection is not enough: the item is only shown
+	 * to users with their own user connection. The check runs at admin_menu
+	 * time, so the item starts rendering as soon as the current user connects.
+	 */
+	public function test_enable_inactive_menu_bails_without_user_connection() {
+		$this->mock_connected_site();
 		add_filter( 'jetpack_my_jetpack_should_initialize', '__return_true' );
 
 		Admin_UI::enable_inactive_menu();

--- a/projects/packages/videopress/tests/php/Admin_UI_Test.php
+++ b/projects/packages/videopress/tests/php/Admin_UI_Test.php
@@ -68,7 +68,7 @@ class Admin_UI_Test extends BaseTestCase {
 	 * re-evaluates the connection options.
 	 */
 	private function reset_connection_status_cache() {
-		( new \ReflectionProperty( Connection_Manager::class, 'is_connected' ) )->setValue( null, null );
+		$this->accessible_property( Connection_Manager::class, 'is_connected' )->setValue( null, null );
 	}
 
 	/**
@@ -77,7 +77,7 @@ class Admin_UI_Test extends BaseTestCase {
 	 * @return array
 	 */
 	private function get_admin_menu_items() {
-		return $this->admin_menu_items_property()->getValue();
+		return $this->accessible_property( Admin_Menu::class, 'menu_items' )->getValue();
 	}
 
 	/**
@@ -86,18 +86,20 @@ class Admin_UI_Test extends BaseTestCase {
 	 * @param array $items The items to set.
 	 */
 	private function set_admin_menu_items( $items ) {
-		$this->admin_menu_items_property()->setValue( null, $items );
+		$this->accessible_property( Admin_Menu::class, 'menu_items' )->setValue( null, $items );
 	}
 
 	/**
-	 * Get an accessible reflection of Admin_Menu::$menu_items.
+	 * Get an accessible reflection of a non-public property.
 	 *
+	 * @param string $class_name    The class owning the property.
+	 * @param string $property_name The property name.
 	 * @return \ReflectionProperty
 	 */
-	private function admin_menu_items_property() {
-		$property = new \ReflectionProperty( Admin_Menu::class, 'menu_items' );
+	private function accessible_property( $class_name, $property_name ) {
+		$property = new \ReflectionProperty( $class_name, $property_name );
 		if ( \PHP_VERSION_ID < 80100 ) {
-			// Required to access private members before PHP 8.1; deprecated no-op since PHP 8.5.
+			// Required to access non-public members before PHP 8.1; deprecated no-op since PHP 8.5.
 			$property->setAccessible( true );
 		}
 		return $property;

--- a/projects/packages/videopress/tests/php/Admin_UI_Test.php
+++ b/projects/packages/videopress/tests/php/Admin_UI_Test.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\VideoPress;
 
+use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use WorDBless\BaseTestCase;
 
 /**
@@ -20,6 +21,27 @@ class Admin_UI_Test extends BaseTestCase {
 	public function tearDown(): void {
 		parent::tearDown();
 		remove_all_filters( Admin_UI::MODERNIZATION_FILTER );
+		remove_all_filters( 'jetpack_my_jetpack_should_initialize' );
+		remove_action( 'admin_menu', array( Admin_UI::class, 'enable_inactive_menu' ), 1 );
+		$this->set_admin_menu_items( array() );
+	}
+
+	/**
+	 * Read the Admin_Menu package's queued menu items.
+	 *
+	 * @return array
+	 */
+	private function get_admin_menu_items() {
+		return ( new \ReflectionProperty( Admin_Menu::class, 'menu_items' ) )->getValue();
+	}
+
+	/**
+	 * Overwrite the Admin_Menu package's queued menu items.
+	 *
+	 * @param array $items The items to set.
+	 */
+	private function set_admin_menu_items( $items ) {
+		( new \ReflectionProperty( Admin_Menu::class, 'menu_items' ) )->setValue( null, $items );
 	}
 
 	/**
@@ -48,5 +70,44 @@ class Admin_UI_Test extends BaseTestCase {
 		// The early return must fire before add_submenu_page() — with the flag
 		// off, no submenu entry (and no load- hook) may exist.
 		$this->assertSame( array(), $submenu );
+	}
+
+	/**
+	 * Test that init_inactive_menu() hooks the inactive menu registration on admin_menu.
+	 */
+	public function test_init_inactive_menu_hooks_admin_menu() {
+		Admin_UI::init_inactive_menu();
+
+		$this->assertSame( 1, has_action( 'admin_menu', array( Admin_UI::class, 'enable_inactive_menu' ) ) );
+	}
+
+	/**
+	 * Test that the inactive-state menu item is queued as a plain link to the
+	 * My Jetpack "add VideoPress" interstitial.
+	 */
+	public function test_enable_inactive_menu_queues_my_jetpack_link() {
+		add_filter( 'jetpack_my_jetpack_should_initialize', '__return_true' );
+
+		Admin_UI::enable_inactive_menu();
+
+		$items = $this->get_admin_menu_items();
+		$this->assertCount( 1, $items );
+		$this->assertSame( Admin_UI::MY_JETPACK_ADD_VIDEOPRESS_URI, $items[0]['menu_slug'] );
+		$this->assertSame( 'VideoPress', $items[0]['menu_title'] );
+		$this->assertSame( 'manage_options', $items[0]['capability'] );
+		// No render callback: WordPress renders an unregistered slug as a direct link.
+		$this->assertNull( $items[0]['function'] );
+	}
+
+	/**
+	 * Test that no menu item is queued when My Jetpack is not initialized,
+	 * since the link would point to an unregistered page.
+	 */
+	public function test_enable_inactive_menu_bails_without_my_jetpack() {
+		add_filter( 'jetpack_my_jetpack_should_initialize', '__return_false' );
+
+		Admin_UI::enable_inactive_menu();
+
+		$this->assertSame( array(), $this->get_admin_menu_items() );
 	}
 }

--- a/projects/packages/videopress/tests/php/Admin_UI_Test.php
+++ b/projects/packages/videopress/tests/php/Admin_UI_Test.php
@@ -32,7 +32,7 @@ class Admin_UI_Test extends BaseTestCase {
 	 * @return array
 	 */
 	private function get_admin_menu_items() {
-		return ( new \ReflectionProperty( Admin_Menu::class, 'menu_items' ) )->getValue();
+		return $this->admin_menu_items_property()->getValue();
 	}
 
 	/**
@@ -41,7 +41,21 @@ class Admin_UI_Test extends BaseTestCase {
 	 * @param array $items The items to set.
 	 */
 	private function set_admin_menu_items( $items ) {
-		( new \ReflectionProperty( Admin_Menu::class, 'menu_items' ) )->setValue( null, $items );
+		$this->admin_menu_items_property()->setValue( null, $items );
+	}
+
+	/**
+	 * Get an accessible reflection of Admin_Menu::$menu_items.
+	 *
+	 * @return \ReflectionProperty
+	 */
+	private function admin_menu_items_property() {
+		$property = new \ReflectionProperty( Admin_Menu::class, 'menu_items' );
+		if ( \PHP_VERSION_ID < 80100 ) {
+			// Required to access private members before PHP 8.1; deprecated no-op since PHP 8.5.
+			$property->setAccessible( true );
+		}
+		return $property;
 	}
 
 	/**

--- a/projects/packages/videopress/tests/php/Admin_UI_Test.php
+++ b/projects/packages/videopress/tests/php/Admin_UI_Test.php
@@ -8,6 +8,8 @@
 namespace Automattic\Jetpack\VideoPress;
 
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use WorDBless\BaseTestCase;
 
 /**
@@ -22,7 +24,7 @@ class Admin_UI_Test extends BaseTestCase {
 		parent::tearDown();
 		remove_all_filters( Admin_UI::MODERNIZATION_FILTER );
 		remove_all_filters( 'jetpack_my_jetpack_should_initialize' );
-		remove_action( 'admin_menu', array( Admin_UI::class, 'enable_inactive_menu' ), 1 );
+		remove_action( 'admin_menu', array( Admin_UI::class, 'enable_menu' ), 1 );
 		$this->set_admin_menu_items( array() );
 	}
 
@@ -87,12 +89,52 @@ class Admin_UI_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test that init_inactive_menu() hooks the inactive menu registration on admin_menu.
+	 * Test that init_inactive_menu() hooks the shared dynamic menu registration on admin_menu.
 	 */
 	public function test_init_inactive_menu_hooks_admin_menu() {
 		Admin_UI::init_inactive_menu();
 
-		$this->assertSame( 1, has_action( 'admin_menu', array( Admin_UI::class, 'enable_inactive_menu' ) ) );
+		$this->assertSame( 1, has_action( 'admin_menu', array( Admin_UI::class, 'enable_menu' ) ) );
+	}
+
+	/**
+	 * Test that enable_menu() resolves the menu target at call time: with the
+	 * module inactive it queues the My Jetpack activation link, not the dashboard.
+	 */
+	public function test_enable_menu_registers_activation_link_when_module_inactive() {
+		add_filter( 'jetpack_my_jetpack_should_initialize', '__return_true' );
+
+		$this->assertFalse( Status::is_active() );
+		Admin_UI::enable_menu();
+
+		$items = $this->get_admin_menu_items();
+		$this->assertCount( 1, $items );
+		$this->assertSame( Admin_UI::MY_JETPACK_ADD_VIDEOPRESS_URI, $items[0]['menu_slug'] );
+	}
+
+	/**
+	 * Test that enable_menu() registers the VideoPress library dashboard
+	 * (admin.php?page=jetpack-videopress) when the module is active.
+	 *
+	 * Runs in a separate process: forcing Status::is_active() true requires
+	 * loading the standalone-plugin class stub, which must not leak into the
+	 * rest of the suite.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_enable_menu_registers_dashboard_when_module_active() {
+		require_once __DIR__ . '/mocks/class-jetpack-videopress-plugin.php';
+
+		$this->assertTrue( Status::is_active() );
+		Admin_UI::enable_menu();
+
+		$items = $this->get_admin_menu_items();
+		$this->assertCount( 1, $items );
+		$this->assertSame( Admin_UI::ADMIN_PAGE_SLUG, $items[0]['menu_slug'] );
+		$this->assertNotNull( $items[0]['function'] );
 	}
 
 	/**

--- a/projects/packages/videopress/tests/php/Admin_UI_Test.php
+++ b/projects/packages/videopress/tests/php/Admin_UI_Test.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\VideoPress;
 
 use Automattic\Jetpack\Admin_UI\Admin_Menu;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use WorDBless\BaseTestCase;
@@ -26,6 +27,27 @@ class Admin_UI_Test extends BaseTestCase {
 		remove_all_filters( 'jetpack_my_jetpack_should_initialize' );
 		remove_action( 'admin_menu', array( Admin_UI::class, 'enable_menu' ), 1 );
 		$this->set_admin_menu_items( array() );
+		\Jetpack_Options::delete_option( 'id' );
+		\Jetpack_Options::delete_option( 'blog_token' );
+		$this->reset_connection_status_cache();
+	}
+
+	/**
+	 * Make Connection\Manager::is_connected() return true by storing the
+	 * blog ID and blog token it checks for.
+	 */
+	private function mock_connected_site() {
+		\Jetpack_Options::update_option( 'id', 1234 );
+		\Jetpack_Options::update_option( 'blog_token', 'blog.token' );
+		$this->reset_connection_status_cache();
+	}
+
+	/**
+	 * Reset the Connection\Manager::$is_connected static cache so each test
+	 * re-evaluates the connection options.
+	 */
+	private function reset_connection_status_cache() {
+		( new \ReflectionProperty( Connection_Manager::class, 'is_connected' ) )->setValue( null, null );
 	}
 
 	/**
@@ -102,6 +124,7 @@ class Admin_UI_Test extends BaseTestCase {
 	 * module inactive it queues the My Jetpack activation link, not the dashboard.
 	 */
 	public function test_enable_menu_registers_activation_link_when_module_inactive() {
+		$this->mock_connected_site();
 		add_filter( 'jetpack_my_jetpack_should_initialize', '__return_true' );
 
 		$this->assertFalse( Status::is_active() );
@@ -142,6 +165,7 @@ class Admin_UI_Test extends BaseTestCase {
 	 * My Jetpack "add VideoPress" interstitial.
 	 */
 	public function test_enable_inactive_menu_queues_my_jetpack_link() {
+		$this->mock_connected_site();
 		add_filter( 'jetpack_my_jetpack_should_initialize', '__return_true' );
 
 		Admin_UI::enable_inactive_menu();
@@ -160,7 +184,22 @@ class Admin_UI_Test extends BaseTestCase {
 	 * since the link would point to an unregistered page.
 	 */
 	public function test_enable_inactive_menu_bails_without_my_jetpack() {
+		$this->mock_connected_site();
 		add_filter( 'jetpack_my_jetpack_should_initialize', '__return_false' );
+
+		Admin_UI::enable_inactive_menu();
+
+		$this->assertSame( array(), $this->get_admin_menu_items() );
+	}
+
+	/**
+	 * Test that no menu item is queued while Jetpack is not connected:
+	 * activating VideoPress requires a connection, so the item would be a
+	 * dead end. The check runs at admin_menu time, so the item starts
+	 * rendering as soon as the site gets connected.
+	 */
+	public function test_enable_inactive_menu_bails_when_jetpack_not_connected() {
+		add_filter( 'jetpack_my_jetpack_should_initialize', '__return_true' );
 
 		Admin_UI::enable_inactive_menu();
 

--- a/projects/packages/videopress/tests/php/Initializer_Test.php
+++ b/projects/packages/videopress/tests/php/Initializer_Test.php
@@ -186,23 +186,6 @@ class Initializer_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The REST API endpoint classes are no longer constructed at init time; their construction is
-	 * deferred to priority-0 `rest_api_init` callbacks. Initializer::init() has two such blocks:
-	 * the always-run WPCOM v2 endpoints in unconditional_initialization(), and the active-module
-	 * endpoints in active_initialization(). Guard both: firing the hook must still register the
-	 * routes — each priority-0 callback constructs/inits the endpoints, which add their own
-	 * default-priority callbacks that register the routes within the same firing. A regression to
-	 * that re-entrancy (e.g. bumping a deferred priority off 0) would silently drop the routes.
-	 *
-	 * Runs in a separate process: driving the real Initializer autoloads VideoPress classes
-	 * (e.g. Jwt_Token_Bridge) that other tests in this suite replace with alias mocks, which
-	 * require the class to be unloaded. The isolated process also lets us force the module-active
-	 * path via a standalone-plugin class stub without leaking it into the rest of the suite.
-	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
-	 */
-	/**
 	 * When the VideoPress module is not active but the admin UI is enabled (as the
 	 * Jetpack plugin does via Config), init() must still register the dynamic menu
 	 * callback so "Jetpack > VideoPress" renders, linking to the My Jetpack
@@ -229,6 +212,19 @@ class Initializer_Test extends BaseTestCase {
 	}
 
 	/**
+	 * The REST API endpoint classes are no longer constructed at init time; their construction is
+	 * deferred to priority-0 `rest_api_init` callbacks. Initializer::init() has two such blocks:
+	 * the always-run WPCOM v2 endpoints in unconditional_initialization(), and the active-module
+	 * endpoints in active_initialization(). Guard both: firing the hook must still register the
+	 * routes — each priority-0 callback constructs/inits the endpoints, which add their own
+	 * default-priority callbacks that register the routes within the same firing. A regression to
+	 * that re-entrancy (e.g. bumping a deferred priority off 0) would silently drop the routes.
+	 *
+	 * Runs in a separate process: driving the real Initializer autoloads VideoPress classes
+	 * (e.g. Jwt_Token_Bridge) that other tests in this suite replace with alias mocks, which
+	 * require the class to be unloaded. The isolated process also lets us force the module-active
+	 * path via a standalone-plugin class stub without leaking it into the rest of the suite.
+	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */

--- a/projects/packages/videopress/tests/php/Initializer_Test.php
+++ b/projects/packages/videopress/tests/php/Initializer_Test.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack;
 
+use Automattic\Jetpack\VideoPress\Admin_UI as VideoPress_Admin_UI;
 use Automattic\Jetpack\VideoPress\Initializer as VideoPress_Initializer;
 use Automattic\Jetpack\VideoPress\Utils;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
@@ -198,6 +199,36 @@ class Initializer_Test extends BaseTestCase {
 	 * require the class to be unloaded. The isolated process also lets us force the module-active
 	 * path via a standalone-plugin class stub without leaking it into the rest of the suite.
 	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	/**
+	 * When the VideoPress module is not active but the admin UI is enabled (as the
+	 * Jetpack plugin does via Config), init() must still register the dynamic menu
+	 * callback so "Jetpack > VideoPress" renders, linking to the My Jetpack
+	 * interstitial where the module can be activated.
+	 *
+	 * Runs in a separate process: init() is guarded by the videopress_init action
+	 * and the admin_ui init option is static state, so neither may leak into (or
+	 * from) the rest of the suite.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_init_registers_inactive_menu_when_module_inactive() {
+		VideoPress_Initializer::update_init_options( array( 'admin_ui' => true ) );
+
+		VideoPress_Initializer::init();
+
+		$this->assertSame(
+			1,
+			has_action( 'admin_menu', array( VideoPress_Admin_UI::class, 'enable_menu' ) )
+		);
+	}
+
+	/**
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */

--- a/projects/plugins/jetpack/changelog/add-videopress-jetpack-submenu-when-inactive
+++ b/projects/plugins/jetpack/changelog/add-videopress-jetpack-submenu-when-inactive
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+VideoPress: keep the VideoPress item under the Jetpack menu when the module is not active, linking to the My Jetpack page to activate it.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -841,8 +841,9 @@ class Jetpack {
 		}
 
 		// Enable the VideoPress admin UI (the "Jetpack > VideoPress" dashboard) inside the
-		// Jetpack plugin, mirroring the standalone Jetpack VideoPress plugin. The page only
-		// renders when the VideoPress module is active (Status::is_active()).
+		// Jetpack plugin, mirroring the standalone Jetpack VideoPress plugin. The dashboard
+		// only renders when the VideoPress module is active (Status::is_active()); when it
+		// is not, the menu item links to the My Jetpack interstitial to activate it.
 		$config->ensure( 'videopress', array( 'admin_ui' => true ) );
 
 		/*


### PR DESCRIPTION
## Proposed changes

* Keep a **VideoPress** item under the Jetpack sidebar menu even when VideoPress is not active.
  * When the VideoPress module is **not active**, the item is a plain link to the My Jetpack interstitial at `/wp-admin/admin.php?page=my-jetpack#/add-videopress`, where the user can activate it.
  * When VideoPress **is active**, the item opens the VideoPress library (`admin.php?page=jetpack-videopress`), as before.
* The link target is a **dynamic condition resolved at render time**: both initialization paths hook the same `Admin_UI::enable_menu()` callback on `admin_menu`, and it checks `Status::is_active()` when the menu is built — active registers the VideoPress dashboard page, inactive registers the My Jetpack activation link.
* The inactive-state item **only renders for users with their own Jetpack user connection** (`is_connected() && is_user_connected()`, checked dynamically in the `admin_menu` callback, so it appears as soon as the current user connects). Activating VideoPress from My Jetpack requires a connected user, so the link would be a dead end otherwise. The item is also skipped on WordPress.com Simple (menus there are managed by `wpcom-admin-menu.php`) and when My Jetpack is not initialized (e.g. offline mode).
* **My Jetpack forces a full page reload after toggling VideoPress**, since the sidebar item is server-rendered and would otherwise keep its stale pre-activation link:
  * On the **`#/products` list**, the VideoPress activation toggle reuses the existing Forms reload-on-toggle mechanism (`PRODUCTS_NEEDING_RELOAD_AFTER_TOGGLE`), persisting the success notice across the reload.
  * On the **`#/add-videopress` interstitial**, the post-activation "stay in My Jetpack" fallback becomes a full page load to the My Jetpack overview instead of a client-side route change (checkout/redirect flows are untouched — those already leave the page). The logic lives in a tested helper, `reloadIfActivationChangesAdminMenu()`.
* The inactive-state item is registered through the shared `Admin_UI\Admin_Menu` with a URI slug and no render callback, the same mechanism used by the "Upgrade Jetpack" menu item, so WordPress renders it as a direct link.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Use a site with the Jetpack plugin **not connected** (or connected at the site level only, with the current wp-admin user not connected): the Jetpack sidebar menu should show no VideoPress item.
* Connect Jetpack **as the current user** (leave the VideoPress module deactivated, e.g. `wp jetpack module deactivate videopress`): a **VideoPress** item appears and links to `/wp-admin/admin.php?page=my-jetpack#/add-videopress`.
* From **My Jetpack > Products** (`#/products`), toggle VideoPress on: the page reloads and the sidebar VideoPress item now links to the VideoPress library (`admin.php?page=jetpack-videopress`). Toggle it off: the page reloads and the link points back to the interstitial.
* From the **`#/add-videopress` interstitial**, choose the free tier: after activation the page fully reloads into My Jetpack and the sidebar link is updated.
* PHP tests: `jetpack test php packages/videopress`. JS tests: `jetpack test js packages/my-jetpack`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)