### PR TITLE
Premium Analytics: keep widget states inside the body on short tiles

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1776-widget-state-short-tile-overlap
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1776-widget-state-short-tile-overlap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Widget error, empty, and loading states no longer overlap the widget footer on short (height 1) tiles; overflowing state content scrolls instead.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-empty-state/chart-empty-state.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-empty-state/chart-empty-state.module.scss
@@ -1,17 +1,52 @@
 .container {
 	display: flex;
 	align-items: center;
-	justify-content: center;
 
 	// On short tiles the icon + text can outgrow the widget body; scroll the
-	// overflow instead of painting over the widget footer, with `safe`
-	// centering falling back to flex-start so the top stays reachable.
-	justify-content: safe center;
+	// overflow instead of painting over the widget footer.
 	overflow-y: auto;
 	height: 100%;
 	width: 100%;
 	margin-inline: auto;
+
+	// Size container so the icon can hide on short tiles (see the query below).
+	// Safe here: the empty state always sits in a definite-height body (grid
+	// tile, chart area, or story canvas), so size containment cannot collapse it.
+	container-type: size;
+
+	// Match the error state's container padding so adjacent widgets showing
+	// different states keep the same vertical rhythm.
+	padding: var(--wpds-dimension-padding-md);
 	gap: var(--wpds-dimension-gap-lg);
+}
+
+// Mirror the error state's short-tile degradation (see widget-state): below
+// the threshold every state renders text only, vertically centered, so
+// adjacent widgets in different states stay visually aligned.
+@container (max-block-size: 140px) {
+
+	.icon {
+		display: none;
+	}
+}
+
+// Keep the icon and text at their intrinsic size: flex children default to
+// `flex-shrink: 1`, so a too-short tile would squash them (a visibly shrunken
+// icon) before the container ever scrolls.
+.container > * {
+	flex-shrink: 0;
+}
+
+// Overflow-safe vertical centering: auto margins center the content when there
+// is room and collapse to zero when there is not, so the state top-anchors and
+// stays fully scrollable. `justify-content: center` would push the overflow
+// past the top edge where it cannot be scrolled to.
+.container > :first-child {
+	margin-block-start: auto;
+}
+
+.container > :last-child {
+	margin-block-end: auto;
 }
 
 .icon {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-empty-state/chart-empty-state.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-empty-state/chart-empty-state.module.scss
@@ -2,6 +2,12 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+
+	// On short tiles the icon + text can outgrow the widget body; scroll the
+	// overflow instead of painting over the widget footer, with `safe`
+	// centering falling back to flex-start so the top stays reachable.
+	justify-content: safe center;
+	overflow-y: auto;
 	height: 100%;
 	width: 100%;
 	margin-inline: auto;

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-empty-state/chart-empty-state.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-empty-state/chart-empty-state.module.scss
@@ -28,6 +28,13 @@
 	.icon {
 		display: none;
 	}
+
+	// The hidden icon generates no flex box, so the start auto margin on
+	// `:first-child` stops centering; hand it to the first visible sibling so
+	// the text stays vertically centered.
+	.container > .icon + * {
+		margin-block-start: auto;
+	}
 }
 
 // Keep the icon and text at their intrinsic size: flex children default to

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-empty-state/chart-empty-state.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-empty-state/chart-empty-state.tsx
@@ -50,7 +50,9 @@ export function ChartEmptyState( {
 }: ChartEmptyStateProps ) {
 	return (
 		<EmptyState.Root className={ styles.container }>
-			{ icon && <Icon size={ 48 } className={ styles.icon } icon={ icon } /> }
+			{ /* 40px matches the error state's glyph so adjacent widgets showing
+			     different states keep the same vertical rhythm. */ }
+			{ icon && <Icon size={ 40 } className={ styles.icon } icon={ icon } /> }
 			<EmptyState.Description>{ text }</EmptyState.Description>
 		</EmptyState.Root>
 	);

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/stories/widget-state.stories.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/stories/widget-state.stories.tsx
@@ -1,3 +1,4 @@
+import { search } from '@wordpress/icons';
 import { withChartTheme } from '../../../stories/with-chart-theme';
 import { BarChart } from '../../chart-bar';
 import { WidgetState } from '../widget-state';
@@ -8,11 +9,19 @@ import type { Meta, StoryObj } from '@storybook/react';
  * Widget card wrapper, simulating a dashboard widget container so each state is
  * shown within typical widget dimensions.
  */
-const WidgetCard = ( { title, children }: { title: string; children: React.ReactNode } ) => (
+const WidgetCard = ( {
+	title,
+	height = '320px',
+	children,
+}: {
+	title: string;
+	height?: string;
+	children: React.ReactNode;
+} ) => (
 	<div
 		style={ {
 			width: '360px',
-			height: '320px',
+			height,
 			border: '1px solid var(--wpds-color-stroke-surface-neutral-weak)',
 			borderRadius: 'var(--wpds-border-radius-md)',
 			background: 'var(--wpds-color-background-surface-neutral)',
@@ -36,8 +45,13 @@ const WidgetCard = ( { title, children }: { title: string; children: React.React
 	</div>
 );
 
-const withWidgetCard = ( Story: React.ComponentType ) => (
-	<WidgetCard title="Traffic by source">
+// `widgetCardHeight` story parameter sizes the mock card, so height-dependent
+// behavior (the 140px short-tile breakpoint) can be shown per story.
+const withWidgetCard = (
+	Story: React.ComponentType,
+	context: { parameters: { widgetCardHeight?: string } }
+) => (
+	<WidgetCard title="Traffic by source" height={ context.parameters.widgetCardHeight }>
 		<Story />
 	</WidgetCard>
 );
@@ -137,6 +151,55 @@ export const Empty: Story = {
 		isError: false,
 		isEmpty: true,
 		empty: { description: 'No traffic recorded for this period.' },
+		children: <MockChart />,
+	},
+};
+
+/**
+ * Empty state with an opt-in icon at a regular tile height (above the 140px
+ * short-tile breakpoint): the glyph renders above the text.
+ */
+export const EmptyWithIcon: Story = {
+	args: {
+		isLoading: false,
+		isError: false,
+		isEmpty: true,
+		empty: { icon: search, description: 'No traffic recorded for this period.' },
+		children: <MockChart />,
+	},
+};
+
+/**
+ * Error on a short tile (below the 140px body breakpoint): the container query
+ * hides the glyph so the text-only state stays vertically centered inside the
+ * body and never overlaps the widget footer.
+ */
+export const ErrorShortTile: Story = {
+	parameters: { widgetCardHeight: '180px' },
+	args: {
+		isLoading: false,
+		isError: true,
+		isEmpty: false,
+		error: {
+			description: "We couldn't load this data. Please try again in a moment.",
+			// eslint-disable-next-line no-console
+			actions: [ { label: 'Retry', onClick: () => console.log( 'Retry clicked' ) } ],
+		},
+		children: <MockChart />,
+	},
+};
+
+/**
+ * Empty (with an opt-in icon) on a short tile: same degradation as the error
+ * state — the glyph hides and the text stays vertically centered.
+ */
+export const EmptyShortTileWithIcon: Story = {
+	parameters: { widgetCardHeight: '180px' },
+	args: {
+		isLoading: false,
+		isError: false,
+		isEmpty: true,
+		empty: { icon: search, description: 'No traffic recorded for this period.' },
 		children: <MockChart />,
 	},
 };

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/widget-state.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/widget-state.module.scss
@@ -1,6 +1,16 @@
 .state {
 	block-size: 100%;
-	min-block-size: 120px;
+
+	// No fixed floor: on short tiles (height 1) the widget body gets less than
+	// 120px, and a hard minimum would push the state past the body and paint it
+	// over the widget footer. Overflowing content scrolls instead, and `safe`
+	// centering falls back to flex-start so the top stays reachable. (Vertical
+	// centering lives here rather than on the Stack's `justify` prop, whose
+	// inline style would win over these rules.)
+	min-block-size: 0;
+	overflow-y: auto;
+	justify-content: center;
+	justify-content: safe center;
 	padding: var(--wpds-dimension-padding-md);
 	text-align: center;
 }
@@ -19,7 +29,10 @@
 .loading {
 	position: relative;
 	block-size: 100%;
-	min-block-size: 120px;
+
+	// Same rationale as `.state`: no floor, so a short tile's loading box stays
+	// inside the widget body instead of underlapping the footer.
+	min-block-size: 0;
 }
 
 .ready {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/widget-state.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/widget-state.module.scss
@@ -3,16 +3,48 @@
 
 	// No fixed floor: on short tiles (height 1) the widget body gets less than
 	// 120px, and a hard minimum would push the state past the body and paint it
-	// over the widget footer. Overflowing content scrolls instead, and `safe`
-	// centering falls back to flex-start so the top stays reachable. (Vertical
-	// centering lives here rather than on the Stack's `justify` prop, whose
-	// inline style would win over these rules.)
+	// over the widget footer. Overflowing content scrolls instead.
 	min-block-size: 0;
 	overflow-y: auto;
-	justify-content: center;
-	justify-content: safe center;
+
+	// Size container so the icon can hide on short tiles (see the query below).
+	// Safe here: the state always sits in a definite-height body (grid tile or
+	// story canvas), so size containment cannot collapse it.
+	container-type: size;
 	padding: var(--wpds-dimension-padding-md);
 	text-align: center;
+}
+
+// On short tiles the icon steals the room the text needs, and a state showing
+// icon + text next to one that fits text-only reads as misaligned. Below the
+// threshold drop the glyph so every state degrades the same way: text only,
+// vertically centered. 140px keeps height-1 tiles (≈100px body) icon-free and
+// height-2 tiles (≈300px) untouched.
+@container (max-block-size: 140px) {
+
+	.stateIcon {
+		display: none;
+	}
+}
+
+// Keep the icon and text at their intrinsic size: flex children default to
+// `flex-shrink: 1`, so a too-short tile would squash them (a visibly shrunken
+// icon) before the container ever scrolls.
+.state > * {
+	flex-shrink: 0;
+}
+
+// Overflow-safe vertical centering (in place of the Stack's `justify` prop,
+// whose inline style would win over class rules): auto margins center the
+// content when there is room and collapse to zero when there is not, so the
+// state top-anchors and stays fully scrollable. `justify-content: center`
+// would push the overflow past the top edge where it cannot be scrolled to.
+.state > :first-child {
+	margin-block-start: auto;
+}
+
+.state > :last-child {
+	margin-block-end: auto;
 }
 
 .title {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/widget-state.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/widget-state.module.scss
@@ -25,6 +25,13 @@
 	.stateIcon {
 		display: none;
 	}
+
+	// The hidden icon generates no flex box, so the start auto margin on
+	// `:first-child` stops centering; hand it to the first visible sibling so
+	// the text stays vertically centered.
+	.state > .stateIcon + * {
+		margin-block-start: auto;
+	}
 }
 
 // Keep the icon and text at their intrinsic size: flex children default to

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/widget-state.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/widget-state.tsx
@@ -73,15 +73,11 @@ export function WidgetState( {
 	children,
 }: WidgetStateProps ) {
 	if ( isError ) {
+		// Vertical centering lives in the stylesheet (`safe center`), not the
+		// `justify` prop: the prop's inline style would beat the class rule and
+		// reintroduce the unreachable-top overflow on short tiles.
 		return (
-			<Stack
-				className={ styles.state }
-				direction="column"
-				gap="lg"
-				align="center"
-				justify="center"
-				role="alert"
-			>
+			<Stack className={ styles.state } direction="column" gap="lg" align="center" role="alert">
 				<Icon size={ 40 } icon={ errorStateIcon } />
 				{ error?.title && <div className={ styles.title }>{ error.title }</div> }
 				<div className={ styles.description }>

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/widget-state.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/widget-state.tsx
@@ -78,7 +78,7 @@ export function WidgetState( {
 		// reintroduce the unreachable-top overflow on short tiles.
 		return (
 			<Stack className={ styles.state } direction="column" gap="lg" align="center" role="alert">
-				<Icon size={ 40 } icon={ errorStateIcon } />
+				<Icon size={ 40 } className={ styles.stateIcon } icon={ errorStateIcon } />
 				{ error?.title && <div className={ styles.title }>{ error.title }</div> }
 				<div className={ styles.description }>
 					{ error?.description ??


### PR DESCRIPTION
Fixes WOOA7S-1776.

## Problem

On a **height-1 tile at the small (200px) row height**, the widget body gets less than the widget states' hard `min-block-size: 120px`, so the error/loading state box extended past the body and **painted over the `See report` footer** — e.g. the File downloads error state rendered its description on top of the footer link (`SeFile report…`). A tall empty state (48px icon + text) could overflow the same way, and flex compression squashed the state glyphs before anything scrolled.

**Pre-existing bug, not introduced by #50667.** Verified on plain trunk: with the default medium (300px) row height an h1 body is ~190px, which still clears the 120px floor — no overlap. Setting the stored grid preference to 200px on trunk reproduces the same overlap immediately. The states' fixed floor has always been unsafe below ~120px of body height; #50667 (which proposes small/200px as the default) merely surfaces it out of the box, and the toolkit should tolerate any row height the host uses.

## Proposed changes

All in `widgets-toolkit`, so every widget on the shared state mechanism (43 use `WidgetState`; `ChartEmptyState` also serves chart empty states) is covered:

- **No fixed floor, scroll instead**: drop the 120px `min-block-size` on `.state`/`.loading` and let overflowing state content scroll (`overflow-y: auto`) — the state can never paint over the widget footer again.
- **Overflow-safe centering**: replace the Stack's `justify="center"` (inline style) with first/last-child **auto block margins** — they center the content when there is room and collapse to zero on overflow, so the state top-anchors and stays fully scrollable in every browser (`justify-content: center` pushes overflow past an unreachable top edge; `safe center` support proved unreliable).
- **No flex squashing**: `flex-shrink: 0` on state children — flex compression was visibly shrinking the glyph before the container ever scrolled.
- **One geometry for both states**: the empty state's glyph goes 48px → **40px** and its container gains the same padding as the error state, so adjacent widgets showing different states share a vertical rhythm.
- **Uniform short-tile degradation**: the state containers become size containers, and below a **140px body** (height-1 tiles) a container query hides the glyphs — every state degrades the same way, **text only and vertically centered**, instead of one neighbor top-anchoring (icon + two lines) while another centers (one line). Height-2 tiles (~300px body) are untouched.

Hand-rolled states in the store/Woo widgets (`emptyStateText` and friends) are outside this fix; they pick it up as they migrate to `WidgetState` (tracked migration).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. `jetpack build packages/premium-analytics plugins/premium-analytics`, with the grid at the **small (200px) row height** (on trunk there is no UI for it yet — write `dashboardGridSettings: { model: "grid", rowHeight: 200 }` into the `jetpack-premium-analytics/dashboard` scope of `wp_persisted_preferences`, or test on top of #50667 where small is the default).
2. On the Traffic tab, enter edit mode and resize **File downloads** (error state on sites without file-download stats) and an empty-state widget (e.g. **Clicks**) down to **height 1**.
3. Both render the same way: **text only, vertically centered**, no glyph, nothing on top of the `See report` link; a state that still can't fit scrolls internally.
4. At height 2+ (and at the medium row height), states are unchanged apart from the empty glyph being 40px: glyph + text, centered, intrinsic sizes (no squashed icons).
5. While a widget loads at height 1, the loading overlay stays inside the body.

|Before|After|
|-|-|
|<img width="610" height="231" alt="截圖 2026-07-22 晚上10 31 54" src="https://github.com/user-attachments/assets/ed563067-21f0-4445-9749-b3b1f19d2a07" />|<img width="618" height="232" alt="截圖 2026-07-22 晚上10 28 21" src="https://github.com/user-attachments/assets/2036c283-1a53-45b4-a767-52fba104149b" />|

🤖 Generated with [Claude Code](https://claude.com/claude-code)
