### PR TITLE
WOOA7S-1696: Premium Analytics: show nested rows and deltas in the Referrers report

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-wooa7s-1696-referrers-report
+++ b/projects/packages/premium-analytics/changelog/update-wooa7s-1696-referrers-report
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Referrers report: Replace the chart with nested referrer groups and comparison deltas in the records table.

--- a/projects/packages/premium-analytics/changelog/update-wooa7s-1696-referrers-report
+++ b/projects/packages/premium-analytics/changelog/update-wooa7s-1696-referrers-report
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Referrers report: Replace the chart with nested referrer groups and comparison deltas in the records table.
+Referrers report: Replace the chart with nested referrer groups and comparison deltas in the records table, keeping referrer labels aligned whether or not a row shows a favicon.

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -51,6 +51,7 @@ import { statsLocationsQuery } from '../stats-locations-query';
 import { statsPostCommentsQuery } from '../stats-post-comments-query';
 import { statsPostQuery } from '../stats-post-query';
 import { statsPublicizeQuery } from '../stats-publicize-query';
+import { statsReferrersQuery } from '../stats-referrers-query';
 import { statsSingleVideoQuery } from '../stats-single-video-query';
 import { statsStreakQuery } from '../stats-streak-query';
 import {
@@ -92,6 +93,34 @@ describe( 'Stats query factories', () => {
 
 	it( 'disables report queries until a date range is available', () => {
 		expect( statsTopPostsQuery( {} as StatsReportParams ).enabled ).toBe( false );
+	} );
+
+	it( 'matches the Calypso referrers range request', () => {
+		const query = statsReferrersQuery( {
+			from: '2026-07-01',
+			to: '2026-07-07',
+			interval: 'day',
+			period: 'day',
+			max: 0,
+			summarize: 1,
+		} );
+
+		expect( query.queryKey ).toEqual( [
+			'stats',
+			'referrers',
+			'1.1',
+			'stats/referrers',
+			'GET',
+			{
+				period: 'day',
+				max: 0,
+				summarize: 1,
+				date: '2026-07-07',
+				start_date: '2026-07-01',
+			},
+			undefined,
+			'referrers',
+		] );
 	} );
 
 	it( 'builds post stats query keys with fields', () => {

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-query.ts
@@ -56,6 +56,11 @@ import type { UseQueryOptions } from '@tanstack/react-query';
 export type StatsReportParams = ReportParams & StatsQueryParamFields;
 type StatsSanitizer< TData = unknown > = ( response: unknown, params?: StatsQueryParams ) => TData;
 
+type StatsReportQuerySettings = {
+	/** Query params derived from the shared report range that this endpoint does not accept. */
+	omitParams?: readonly ( keyof StatsQueryParamFields )[];
+};
+
 const statsSanitizers = {
 	passthrough: sanitizeStatsPassthroughResponse,
 	post: sanitizeStatsPostResponse,
@@ -171,7 +176,8 @@ export function statsReportQuery< TSanitizer extends StatsSanitizerKey >(
 	version: StatsProxyVersion = '1.1',
 	// Endpoint-specific params that should reach the API but are not in the
 	// reportParamsToStatsQueryParams allow-list (e.g. filter_by_country).
-	extraParams?: StatsProxyParams
+	extraParams?: StatsProxyParams,
+	settings?: StatsReportQuerySettings
 ): StatsReportQueryOptions< TSanitizer > {
 	const statsParams = reportParamsToStatsQueryParams( params );
 	const reportParams = {
@@ -189,13 +195,18 @@ export function statsReportQuery< TSanitizer extends StatsSanitizerKey >(
 			? { summarize: 1 }
 			: {} ),
 	};
+	const queryParams: StatsQueryParams = { ...reportParams };
+
+	for ( const param of settings?.omitParams ?? [] ) {
+		delete queryParams[ param ];
+	}
 
 	return statsProxyQuery( {
 		name,
 		version,
 		endpoint,
-		params: reportParams,
+		params: queryParams,
 		sanitizer,
-		enabled: !! ( reportParams.end_date || reportParams.date || reportParams.start_date ),
+		enabled: !! ( queryParams.end_date || queryParams.date || queryParams.start_date ),
 	} );
 }

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-referrers-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-referrers-query.ts
@@ -4,4 +4,8 @@
 import { statsReportQuery, type StatsReportParams } from './stats-query';
 
 export const statsReferrersQuery = ( params: StatsReportParams ) =>
-	statsReportQuery( 'referrers', 'stats/referrers', params, 'referrers' );
+	statsReportQuery( 'referrers', 'stats/referrers', params, 'referrers', '1.1', undefined, {
+		// Calypso summarizes explicit ranges with start_date/date rather than the
+		// generic Stats `days` parameter. Keep the range query parameters aligned.
+		omitParams: [ 'days' ],
+	} );

--- a/projects/packages/premium-analytics/packages/ui/src/dataviews-drilldown-native/drilldown-leaf-cell.module.scss
+++ b/projects/packages/premium-analytics/packages/ui/src/dataviews-drilldown-native/drilldown-leaf-cell.module.scss
@@ -8,12 +8,15 @@
 }
 
 /*
- * DataViews' own `.dataviews-title-field a` (0,1,1) paints title links as
- * neutral, undecorated text — it also outweighs `Link`'s layered styles.
- * `span.leaf a` (0,1,2) deterministically wins and covers any composed link
- * (the built-in external `Link` or an internal router link) alike.
+ * DataViews' own `.dataviews-title-field a` paints title links as neutral,
+ * undecorated blocks. The drilldown stylesheet scopes that selector beneath
+ * its root class, so this selector includes the link's `href` attribute to
+ * deterministically outweigh it while covering external and router links.
  */
-span.leaf a {
+span.leaf a[href] {
+	display: inline-flex;
+	align-items: center;
+	max-inline-size: 100%;
 	color: var(--wpds-color-foreground-interactive-brand);
 	text-decoration: underline;
 }

--- a/projects/packages/premium-analytics/packages/ui/src/dataviews-drilldown-native/drilldown-leaf-cell.module.scss
+++ b/projects/packages/premium-analytics/packages/ui/src/dataviews-drilldown-native/drilldown-leaf-cell.module.scss
@@ -8,15 +8,11 @@
 }
 
 /*
- * DataViews' own `.dataviews-title-field a` paints title links as neutral,
- * undecorated blocks. The drilldown stylesheet scopes that selector beneath
- * its root class, so this selector includes the link's `href` attribute to
- * deterministically outweigh it while covering external and router links.
+ * DataViews' scoped title-link selector makes composed links blocks. Include
+ * the link's `href` attribute here to win only the layout properties while
+ * leaving its color to the report table's standard link treatment.
  */
 span.leaf a[href] {
 	display: inline-flex;
 	align-items: center;
-	max-inline-size: 100%;
-	color: var(--wpds-color-foreground-interactive-brand);
-	text-decoration: underline;
 }

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/aggregate.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/aggregate.test.ts
@@ -1,9 +1,10 @@
-import { aggregateReferrerRows, flattenReferrerRows, referrersToTimeSeries } from './aggregate';
-import type { StatsNormalizedReport, StatsReferrersItem } from '@jetpack-premium-analytics/data';
+import { flattenReferrerRows } from './aggregate';
+import type { StatsReferrersComparisonItem } from '@jetpack-premium-analytics/data';
 
-const searchEngines: StatsReferrersItem = {
+const searchEngines: StatsReferrersComparisonItem = {
 	label: 'Search Engines',
 	views: 12,
+	previousValue: 10,
 	link: null,
 	icon: null,
 	labelIcon: null,
@@ -11,6 +12,7 @@ const searchEngines: StatsReferrersItem = {
 		{
 			label: 'Google Search',
 			views: 12,
+			previousValue: 8,
 			link: null,
 			icon: 'https://icons.example/google.png',
 			labelIcon: null,
@@ -18,6 +20,7 @@ const searchEngines: StatsReferrersItem = {
 				{
 					label: 'google.com',
 					views: 12,
+					previousValue: 8,
 					link: 'https://www.google.com/',
 					icon: null,
 					labelIcon: 'external',
@@ -28,57 +31,41 @@ const searchEngines: StatsReferrersItem = {
 	],
 };
 
-const bucketedReport: StatsNormalizedReport< StatsReferrersItem > = {
-	summary: {},
-	data: [
-		{
-			time_interval: '2026-06-01',
-			date_start: '2026-06-01T00:00:00+00:00',
-			date_end: '2026-06-01T23:59:59+00:00',
-			items: [ searchEngines ],
-		},
-		{
-			time_interval: '2026-06-02',
-			date_start: '2026-06-02T00:00:00+00:00',
-			date_end: '2026-06-02T23:59:59+00:00',
-			items: [
-				{
-					...searchEngines,
-					views: 8,
-					children: [
-						{
-							...searchEngines.children![ 0 ],
-							views: 8,
-							children: [
-								{
-									...searchEngines.children![ 0 ].children![ 0 ],
-									views: 8,
-								},
-							],
-						},
-					],
-				},
-			],
-		},
-	],
-};
-
-describe( 'report referrers aggregate', () => {
-	it( 'flattens hierarchy leaves, keeps the parent path as the group, and inherits ancestor icons', () => {
+describe( 'report referrers hierarchy', () => {
+	it( 'emits every hierarchy level with stable parent ids and inherited icons', () => {
 		expect( flattenReferrerRows( [ searchEngines ] ) ).toEqual( [
 			{
-				id: '["Search Engines / Google Search","google.com","https://www.google.com/"]',
-				label: 'google.com',
-				group: 'Search Engines / Google Search',
+				id: '["Search Engines"]',
+				label: 'Search Engines',
 				views: 12,
+				previousValue: 10,
+				hasChildren: true,
+			},
+			{
+				id: '["Search Engines","Google Search"]',
+				parentId: '["Search Engines"]',
+				parentLabel: 'Search Engines',
+				label: 'Google Search',
+				views: 12,
+				previousValue: 8,
+				icon: 'https://icons.example/google.png',
+				hasChildren: true,
+			},
+			{
+				id: '["Search Engines","Google Search","https://www.google.com/"]',
+				parentId: '["Search Engines","Google Search"]',
+				parentLabel: 'Google Search',
+				label: 'google.com',
+				views: 12,
+				previousValue: 8,
 				link: 'https://www.google.com/',
 				icon: 'https://icons.example/google.png',
 			},
 		] );
 	} );
 
-	it( 'keeps ungrouped leaf referrers as top-level rows with their own icon', () => {
-		const direct: StatsReferrersItem = {
+	it( 'keeps ungrouped referrers as top-level rows', () => {
+		const direct: StatsReferrersComparisonItem = {
 			label: 'jetpack.com',
 			views: 4,
 			link: 'https://jetpack.com/',
@@ -89,55 +76,13 @@ describe( 'report referrers aggregate', () => {
 
 		expect( flattenReferrerRows( [ direct ] ) ).toEqual( [
 			{
-				id: '["","jetpack.com","https://jetpack.com/"]',
+				id: '["https://jetpack.com/"]',
 				label: 'jetpack.com',
-				group: '',
 				views: 4,
+				previousValue: undefined,
 				link: 'https://jetpack.com/',
 				icon: 'https://icons.example/jetpack.png',
 			},
-		] );
-	} );
-
-	it( 'uses top-level totals for chart buckets and aggregates table leaves across buckets', () => {
-		const series = referrersToTimeSeries( bucketedReport, 'day' );
-		expect( series.data.map( point => point.views ) ).toEqual( [ 12, 8 ] );
-		expect( series.summary ).toEqual( {
-			date_start: '2026-06-01T00:00:00+00:00',
-			date_end: '2026-06-02T23:59:59+00:00',
-		} );
-		expect( aggregateReferrerRows( bucketedReport ) ).toEqual( [
-			expect.objectContaining( {
-				label: 'google.com',
-				group: 'Search Engines / Google Search',
-				views: 20,
-			} ),
-		] );
-	} );
-
-	it( 'groups daily totals into ISO weeks for the chart', () => {
-		const series = referrersToTimeSeries( bucketedReport, 'week' );
-
-		expect( series.data ).toEqual( [
-			expect.objectContaining( {
-				time_interval: '2026-06-01',
-				date_start: '2026-06-01T00:00:00+00:00',
-				date_end: '2026-06-02T23:59:59+00:00',
-				views: 20,
-			} ),
-		] );
-	} );
-
-	it( 'groups daily totals into calendar months for the chart', () => {
-		const series = referrersToTimeSeries( bucketedReport, 'month' );
-
-		expect( series.data ).toEqual( [
-			expect.objectContaining( {
-				time_interval: '2026-06-01',
-				date_start: '2026-06-01T00:00:00+00:00',
-				date_end: '2026-06-02T23:59:59+00:00',
-				views: 20,
-			} ),
 		] );
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/aggregate.ts
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/aggregate.ts
@@ -1,110 +1,52 @@
 /**
- * External dependencies
- */
-import {
-	bucketStatsTimeSeries,
-	flattenStatsLeaves,
-	type StatsChartBucketPeriod,
-	type StatsNormalizedReport,
-	type StatsReferrersItem,
-	type StatsTimeSeriesReport,
-} from '@jetpack-premium-analytics/data';
-/**
  * Internal dependencies
  */
 import type { ReferrerRecord } from './fields';
-
-const GROUP_SEPARATOR = ' / ';
-
-/**
- * Read a referrer item's display label.
- *
- * @param item - The referrer item.
- * @return The item label.
- */
-function getReferrerLabel( item: StatsReferrersItem ): string {
-	return String( item.label ?? '' );
-}
+import type { StatsReferrersComparisonItem } from '@jetpack-premium-analytics/data';
 
 /**
- * Flatten one bucket's referrer hierarchy into leaf table rows. DataViews does
- * not currently support nested table rows, so the parent path is retained in
- * the Group field instead.
+ * Flatten nested comparison rows into the parent-linked shape consumed by
+ * DataViews' native hierarchy support.
  *
  * @param items - Top-level referrer items.
- * @return Flattened leaf rows.
+ * @return Parent and child rows in depth-first display order.
  */
-export function flattenReferrerRows( items: StatsReferrersItem[] ): ReferrerRecord[] {
-	return flattenStatsLeaves< StatsReferrersItem, ReferrerRecord >( items, {
-		getChildren: item => item.children,
-		mapLeaf: ( item, { ancestors } ) => {
-			const label = getReferrerLabel( item );
-			const link = typeof item.link === 'string' ? item.link : undefined;
-			const group = ancestors.map( getReferrerLabel ).filter( Boolean ).join( GROUP_SEPARATOR );
-			// Leaves inherit the closest ancestor favicon, like the dashboard
-			// widget (e.g. Google Search → google.com keeps the Google icon).
-			const icon =
-				item.icon ??
-				[ ...ancestors ].reverse().find( ancestor => ancestor.icon )?.icon ??
-				undefined;
-
-			return {
-				id: JSON.stringify( [ group, label, link ?? null ] ),
-				label,
-				group,
-				views: item.views,
-				link,
-				icon,
-			};
-		},
-	} );
-}
-
-/**
- * Build the views-over-time chart from daily referrers data.
- *
- * Top-level values already represent each group's complete total, so summing
- * that level avoids counting the same hierarchy at every nested level. Week
- * and month chart intervals are derived client-side so changing the chart does
- * not change the exact report window or the table totals.
- *
- * @param report - The bucketed referrers report.
- * @param period - The chart bucket period.
- * @return The chart-ready time series.
- */
-export function referrersToTimeSeries(
-	report: StatsNormalizedReport< StatsReferrersItem > | undefined,
-	period: StatsChartBucketPeriod = 'day'
-): StatsTimeSeriesReport {
-	return bucketStatsTimeSeries( report, period, point => {
-		const views = point.items.reduce( ( total, item ) => total + item.views, 0 );
-
-		return { value: views, views };
-	} );
-}
-
-/**
- * Aggregate bucketed referrers into one table row per hierarchy leaf.
- *
- * @param report - The bucketed referrers report.
- * @return Aggregated table rows.
- */
-export function aggregateReferrerRows(
-	report?: StatsNormalizedReport< StatsReferrersItem >
+export function flattenReferrerRows(
+	items: readonly StatsReferrersComparisonItem[]
 ): ReferrerRecord[] {
-	const byKey = new Map< string, ReferrerRecord >();
+	const rows: ReferrerRecord[] = [];
 
-	for ( const point of report?.data ?? [] ) {
-		for ( const row of flattenReferrerRows( point.items ) ) {
-			const existing = byKey.get( row.id );
+	const appendRows = (
+		children: readonly StatsReferrersComparisonItem[],
+		parentId: string | undefined,
+		parentLabel: string | undefined,
+		parentPath: string[],
+		inheritedIcon?: string
+	) => {
+		for ( const item of children ) {
+			const itemChildren = item.children ?? [];
+			const itemKey = item.link ?? item.label;
+			const path = [ ...parentPath, itemKey ];
+			const id = JSON.stringify( path );
+			const icon = item.icon ?? inheritedIcon;
 
-			if ( existing ) {
-				existing.views += row.views;
-			} else {
-				byKey.set( row.id, { ...row } );
-			}
+			rows.push( {
+				id,
+				...( parentId ? { parentId } : {} ),
+				...( parentLabel ? { parentLabel } : {} ),
+				label: item.label,
+				views: item.views,
+				previousValue: item.previousValue,
+				...( item.link ? { link: item.link } : {} ),
+				...( icon ? { icon } : {} ),
+				...( itemChildren.length ? { hasChildren: true } : {} ),
+			} );
+
+			appendRows( itemChildren, id, item.label, path, icon ?? undefined );
 		}
-	}
+	};
 
-	return [ ...byKey.values() ];
+	appendRows( items, undefined, undefined, [] );
+
+	return rows;
 }

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/fields.module.css
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/fields.module.css
@@ -1,0 +1,7 @@
+.favicon {
+	inline-size: var(--wpds-dimension-size-2xs);
+	block-size: var(--wpds-dimension-size-2xs);
+	flex-shrink: 0;
+	border-radius: var(--wpds-border-radius-sm);
+	object-fit: cover;
+}

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/fields.module.css
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/fields.module.css
@@ -1,7 +1,24 @@
+/*
+ * The slot, not the image, carries the favicon's size, so a row keeps the
+ * same label indent whether or not it ends up showing an icon.
+ */
+.faviconSlot {
+	display: flex;
+	flex-shrink: 0;
+	align-items: center;
+	justify-content: center;
+	inline-size: var(--wpds-dimension-size-2xs);
+	block-size: var(--wpds-dimension-size-2xs);
+}
+
+/*
+ * Keep in step with the `width`/`height` attributes on the image. Those carry
+ * the intrinsic size so the box is reserved before the favicon loads; this
+ * rule is what actually sizes it once it has.
+ */
 .favicon {
 	inline-size: var(--wpds-dimension-size-2xs);
 	block-size: var(--wpds-dimension-size-2xs);
-	flex-shrink: 0;
 	border-radius: var(--wpds-border-radius-sm);
 	object-fit: cover;
 }

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/fields.test.tsx
@@ -47,7 +47,7 @@ describe( 'referrer field', () => {
 		} );
 
 		const link = screen.getByRole( 'link', {
-			name: ( accessibleName: string ) => accessibleName.startsWith( 'google.com' ),
+			name: 'google.com (opens in a new tab)',
 		} );
 		expect( link ).toHaveAttribute( 'href', 'https://www.google.com/' );
 		expect( link ).toHaveAttribute( 'target', '_blank' );

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/fields.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { getReferrerFields, type ReferrerRecord } from './fields';
 
 /**
@@ -120,6 +120,21 @@ describe( 'referrer field', () => {
 			'src',
 			'https://icons.example/google.png'
 		);
+	} );
+
+	it( 'hides a referrer favicon when the image cannot be loaded', () => {
+		renderReferrerField( {
+			id: 'search|google.com|https://www.google.com/',
+			label: 'google.com',
+			views: 10,
+			link: 'https://www.google.com/',
+			icon: 'https://icons.example/missing.png',
+		} );
+
+		const favicon = screen.getByRole( 'presentation' );
+		fireEvent.error( favicon );
+
+		expect( favicon ).not.toBeVisible();
 	} );
 
 	it( 'renders no favicon image when the row has no icon', () => {

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/fields.test.tsx
@@ -52,6 +52,7 @@ describe( 'referrer field', () => {
 		expect( link ).toHaveAttribute( 'href', 'https://www.google.com/' );
 		expect( link ).toHaveAttribute( 'target', '_blank' );
 		expect( link ).toHaveAttribute( 'rel', 'noopener noreferrer' );
+		expect( screen.getByText( 'google.com' ).parentElement?.tagName ).toBe( 'SPAN' );
 	} );
 
 	it( 'renders referrers without a URL as plain text', () => {

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/fields.test.tsx
@@ -5,7 +5,7 @@ import { getReferrerFields, type ReferrerRecord } from './fields';
  * Mount the referrer field's render component for a table row.
  *
  * @param item - The referrer row to render.
- * @return The Testing Library render result.
+ * @return The Testing Library render result, with `rerender` taking a row.
  */
 function renderReferrerField( item: ReferrerRecord ) {
 	const field = getReferrerFields().find( candidate => candidate.id === 'referrer' );
@@ -16,7 +16,13 @@ function renderReferrerField( item: ReferrerRecord ) {
 		throw new Error( 'Referrer field render callback is unavailable' );
 	}
 
-	return render( <ReferrerField item={ item } field={ field as never } /> );
+	const utils = render( <ReferrerField item={ item } field={ field as never } /> );
+
+	return {
+		...utils,
+		rerender: ( nextItem: ReferrerRecord ) =>
+			utils.rerender( <ReferrerField item={ nextItem } field={ field as never } /> ),
+	};
 }
 
 /**
@@ -123,7 +129,7 @@ describe( 'referrer field', () => {
 		);
 	} );
 
-	it( 'hides a referrer favicon when the image cannot be loaded', () => {
+	it( 'drops a referrer favicon that cannot be loaded but keeps its slot', () => {
 		renderReferrerField( {
 			id: 'search|google.com|https://www.google.com/',
 			label: 'google.com',
@@ -132,13 +138,36 @@ describe( 'referrer field', () => {
 			icon: 'https://icons.example/missing.png',
 		} );
 
-		const favicon = screen.getByRole( 'presentation' );
-		fireEvent.error( favicon );
+		fireEvent.error( screen.getByRole( 'presentation' ) );
 
-		expect( favicon ).not.toBeVisible();
+		// The slot stays so the label keeps the indent of siblings whose
+		// favicon did load, instead of jumping left once the error fires. The
+		// slot is presentational, so structure is the only thing to assert on.
+		expect( screen.queryByRole( 'presentation' ) ).not.toBeInTheDocument();
+		// eslint-disable-next-line testing-library/no-node-access -- The reserved slot is a layout box with no role or text.
+		expect( screen.getByText( 'google.com' ).previousElementSibling ).not.toBeNull();
 	} );
 
-	it( 'renders no favicon image when the row has no icon', () => {
+	it( 'retries a referrer favicon when the row renders a different icon', () => {
+		const item: ReferrerRecord = {
+			id: 'search|google.com|https://www.google.com/',
+			label: 'google.com',
+			views: 10,
+			link: 'https://www.google.com/',
+			icon: 'https://icons.example/missing.png',
+		};
+		const { rerender } = renderReferrerField( item );
+
+		fireEvent.error( screen.getByRole( 'presentation' ) );
+		rerender( { ...item, icon: 'https://icons.example/google.png' } );
+
+		expect( screen.getByRole( 'presentation' ) ).toHaveAttribute(
+			'src',
+			'https://icons.example/google.png'
+		);
+	} );
+
+	it( 'reserves the favicon slot when the row has no icon', () => {
 		renderReferrerField( {
 			id: '|Unknown|',
 			label: 'Unknown',
@@ -146,6 +175,8 @@ describe( 'referrer field', () => {
 		} );
 
 		expect( screen.queryByRole( 'presentation' ) ).not.toBeInTheDocument();
+		// eslint-disable-next-line testing-library/no-node-access -- The reserved slot is a layout box with no role or text.
+		expect( screen.getByText( 'Unknown' ).previousElementSibling ).not.toBeNull();
 	} );
 
 	it( 'renders the views delta when a comparison value is available', () => {

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/fields.test.tsx
@@ -19,17 +19,36 @@ function renderReferrerField( item: ReferrerRecord ) {
 	return render( <ReferrerField item={ item } field={ field as never } /> );
 }
 
+/**
+ * Mount the views field's render component for a table row.
+ *
+ * @param item - The referrer row to render.
+ * @return The Testing Library render result.
+ */
+function renderViewsField( item: ReferrerRecord ) {
+	const field = getReferrerFields().find( candidate => candidate.id === 'views' );
+	// eslint-disable-next-line testing-library/render-result-naming-convention -- `render` is the DataViews field render component.
+	const ViewsField = field?.render;
+
+	if ( ! field || ! ViewsField ) {
+		throw new Error( 'Views field render callback is unavailable' );
+	}
+
+	return render( <ViewsField item={ item } field={ field as never } /> );
+}
+
 describe( 'referrer field', () => {
 	it( 'renders URL-backed referrers as safe external links', () => {
 		renderReferrerField( {
 			id: 'search|google.com|https://www.google.com/',
 			label: 'google.com',
-			group: 'Search Engines',
 			views: 10,
 			link: 'https://www.google.com/',
 		} );
 
-		const link = screen.getByRole( 'link', { name: 'google.com' } );
+		const link = screen.getByRole( 'link', {
+			name: ( accessibleName: string ) => accessibleName.startsWith( 'google.com' ),
+		} );
 		expect( link ).toHaveAttribute( 'href', 'https://www.google.com/' );
 		expect( link ).toHaveAttribute( 'target', '_blank' );
 		expect( link ).toHaveAttribute( 'rel', 'noopener noreferrer' );
@@ -39,7 +58,6 @@ describe( 'referrer field', () => {
 		renderReferrerField( {
 			id: '|Unknown|',
 			label: 'Unknown',
-			group: '',
 			views: 2,
 		} );
 
@@ -47,11 +65,38 @@ describe( 'referrer field', () => {
 		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'announces the parent group for nested referrer leaves', () => {
+		renderReferrerField( {
+			id: '["Search Engines","google.com"]',
+			parentId: '["Search Engines"]',
+			parentLabel: 'Search Engines',
+			label: 'google.com',
+			views: 10,
+			link: 'https://www.google.com/',
+		} );
+
+		// The nesting is visual-only (no aria-level), so the parent context is
+		// announced as visually-hidden text before the link.
+		expect( screen.getByText( 'Search Engines:' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders parent referrers as group labels instead of outbound links', () => {
+		renderReferrerField( {
+			id: '["Search Engines"]',
+			label: 'Search Engines',
+			views: 10,
+			link: 'https://example.com/search-engines',
+			hasChildren: true,
+		} );
+
+		expect( screen.getByText( 'Search Engines' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'link' ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'renders referrers with unsafe URL schemes as plain text', () => {
 		renderReferrerField( {
 			id: '|Evil|javascript:alert(1)',
 			label: 'Evil',
-			group: '',
 			views: 1,
 
 			link: 'javascript:alert(1)',
@@ -65,7 +110,6 @@ describe( 'referrer field', () => {
 		renderReferrerField( {
 			id: 'search|google.com|https://www.google.com/',
 			label: 'google.com',
-			group: 'Search Engines',
 			views: 10,
 			link: 'https://www.google.com/',
 			icon: 'https://icons.example/google.png',
@@ -82,10 +126,32 @@ describe( 'referrer field', () => {
 		renderReferrerField( {
 			id: '|Unknown|',
 			label: 'Unknown',
-			group: '',
 			views: 2,
 		} );
 
 		expect( screen.queryByRole( 'presentation' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the views delta when a comparison value is available', () => {
+		renderViewsField( {
+			id: '["example.com"]',
+			label: 'example.com',
+			views: 10,
+			previousValue: 8,
+		} );
+
+		expect( screen.getByText( '10' ) ).toBeInTheDocument();
+		expect( screen.getByText( '+25%' ) ).toBeInTheDocument();
+	} );
+
+	it( 'renders only the views count when comparison is disabled', () => {
+		renderViewsField( {
+			id: '["example.com"]',
+			label: 'example.com',
+			views: 10,
+		} );
+
+		expect( screen.getByText( '10' ) ).toBeInTheDocument();
+		expect( screen.queryByText( /%/ ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/fields.tsx
@@ -2,10 +2,15 @@
  * External dependencies
  */
 import { DrilldownLeafCell, safeHttpUrl } from '@jetpack-premium-analytics/ui';
-import { LeaderboardLabel, MetricWithComparison } from '@jetpack-premium-analytics/widgets-toolkit';
+import { MetricWithComparison } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';
-import { Link } from '@wordpress/ui';
+import { Link, Stack } from '@wordpress/ui';
+/**
+ * Internal dependencies
+ */
+import styles from './fields.module.css';
 import type { Field } from '@wordpress/dataviews';
+import type { SyntheticEvent } from 'react';
 
 /**
  * A flattened referrer group, source, or domain shown in the records table.
@@ -23,6 +28,15 @@ export type ReferrerRecord = {
 };
 
 /**
+ * Hide an unavailable referrer favicon without replacing it with a broken-image indicator.
+ *
+ * @param event - The favicon image error event.
+ */
+function handleFaviconError( event: SyntheticEvent< HTMLImageElement > ): void {
+	event.currentTarget.hidden = true;
+}
+
+/**
  * DataViews field config for the Referrers records table.
  *
  * @return The field config.
@@ -38,11 +52,17 @@ export function getReferrerFields(): Field< ReferrerRecord >[] {
 			render: ( { item } ) => {
 				const safeUrl = safeHttpUrl( item.link );
 				const label = (
-					<LeaderboardLabel
-						label={ item.label }
-						media={ { kind: 'favicon', url: item.icon } }
-						decorativeMedia={ Boolean( safeUrl ) }
-					/>
+					<Stack direction="row" gap="sm" align="center">
+						{ item.icon && (
+							<img
+								src={ item.icon }
+								onError={ handleFaviconError }
+								alt=""
+								className={ styles.favicon }
+							/>
+						) }
+						<span>{ item.label }</span>
+					</Stack>
 				);
 
 				// Group/source rows keep DataViews' title treatment and never link

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/fields.tsx
@@ -52,7 +52,7 @@ export function getReferrerFields(): Field< ReferrerRecord >[] {
 			render: ( { item } ) => {
 				const safeUrl = safeHttpUrl( item.link );
 				const label = (
-					<Stack direction="row" gap="sm" align="center">
+					<Stack render={ <span /> } direction="row" gap="sm" align="center">
 						{ item.icon && (
 							<img
 								src={ item.icon }
@@ -75,7 +75,7 @@ export function getReferrerFields(): Field< ReferrerRecord >[] {
 					<DrilldownLeafCell groupLabel={ item.parentLabel }>
 						{ safeUrl ? (
 							<Link href={ safeUrl } openInNewTab rel="noopener noreferrer">
-								{ label }
+								{ label }{ ' ' }
 							</Link>
 						) : (
 							label

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/fields.tsx
@@ -1,22 +1,25 @@
 /**
  * External dependencies
  */
-import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
-import { safeHttpUrl } from '@jetpack-premium-analytics/ui';
-import { LeaderboardLabel } from '@jetpack-premium-analytics/widgets-toolkit';
+import { DrilldownLeafCell, safeHttpUrl } from '@jetpack-premium-analytics/ui';
+import { LeaderboardLabel, MetricWithComparison } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';
+import { Link } from '@wordpress/ui';
 import type { Field } from '@wordpress/dataviews';
 
 /**
- * A flattened referrer leaf shown in the records table.
+ * A flattened referrer group, source, or domain shown in the records table.
  */
 export type ReferrerRecord = {
 	id: string;
+	parentId?: string;
+	parentLabel?: string;
 	label: string;
-	group: string;
 	views: number;
+	previousValue?: number;
 	link?: string;
 	icon?: string;
+	hasChildren?: boolean;
 };
 
 /**
@@ -42,29 +45,39 @@ export function getReferrerFields(): Field< ReferrerRecord >[] {
 					/>
 				);
 
-				if ( ! safeUrl ) {
+				// Group/source rows keep DataViews' title treatment and never link
+				// away; only leaf referrers use the drilldown leaf treatment.
+				if ( item.hasChildren ) {
 					return label;
 				}
 
 				return (
-					<a href={ safeUrl } target="_blank" rel="noopener noreferrer">
-						{ label }
-					</a>
+					<DrilldownLeafCell groupLabel={ item.parentLabel }>
+						{ safeUrl ? (
+							<Link href={ safeUrl } openInNewTab rel="noopener noreferrer">
+								{ label }
+							</Link>
+						) : (
+							label
+						) }
+					</DrilldownLeafCell>
 				);
 			},
-		},
-		{
-			id: 'group',
-			label: __( 'Group', 'jetpack-premium-analytics' ),
-			enableGlobalSearch: true,
-			getValue: ( { item } ) => item.group,
 		},
 		{
 			id: 'views',
 			label: __( 'Views', 'jetpack-premium-analytics' ),
 			getValue: ( { item } ) => item.views,
 			render: ( { item } ) => (
-				<>{ formatMetricValue( item.views, 'number', { decimals: 0, useMultipliers: false } ) }</>
+				<MetricWithComparison
+					value={ item.views }
+					previousValue={ item.previousValue }
+					dataFormat={ {
+						type: 'number',
+						options: { decimals: 0, useMultipliers: false },
+					} }
+					fontSize="md"
+				/>
 			),
 		},
 	];

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/fields.tsx
@@ -3,6 +3,7 @@
  */
 import { DrilldownLeafCell, safeHttpUrl } from '@jetpack-premium-analytics/ui';
 import { MetricWithComparison } from '@jetpack-premium-analytics/widgets-toolkit';
+import { useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Link, Stack } from '@wordpress/ui';
 /**
@@ -10,7 +11,6 @@ import { Link, Stack } from '@wordpress/ui';
  */
 import styles from './fields.module.css';
 import type { Field } from '@wordpress/dataviews';
-import type { SyntheticEvent } from 'react';
 
 /**
  * A flattened referrer group, source, or domain shown in the records table.
@@ -28,12 +28,42 @@ export type ReferrerRecord = {
 };
 
 /**
- * Hide an unavailable referrer favicon without replacing it with a broken-image indicator.
+ * Fixed-size favicon slot for a referrer row.
  *
- * @param event - The favicon image error event.
+ * Rendered for every row, with or without a usable favicon: Stats leaves
+ * `icon` empty for many referrers, and the remote favicons it does return can
+ * 404. Reserving the slot keeps sibling labels on one indent instead of
+ * shifting them by the icon's width as each image resolves.
+ *
+ * @param props      - The component props.
+ * @param props.icon - The row's favicon URL, when it has one.
+ * @return The favicon slot.
  */
-function handleFaviconError( event: SyntheticEvent< HTMLImageElement > ): void {
-	event.currentTarget.hidden = true;
+function ReferrerFavicon( { icon }: { icon?: string } ) {
+	// Remember which URL failed rather than a boolean, so a row that later
+	// renders a different favicon tries that one instead of staying blank.
+	const [ failedIcon, setFailedIcon ] = useState< string | undefined >( undefined );
+	const showIcon = !! icon && failedIcon !== icon;
+	const handleError = useCallback( () => setFailedIcon( icon ), [ icon ] );
+
+	return (
+		<span className={ styles.faviconSlot }>
+			{ showIcon && (
+				// The intrinsic size must come from the attributes, not just the
+				// stylesheet: without them the image has no height until it loads,
+				// which moves the slot's baseline and nudges the whole row. Keep
+				// them in step with `--wpds-dimension-size-2xs` in the stylesheet.
+				<img
+					src={ icon }
+					onError={ handleError }
+					alt=""
+					width={ 16 }
+					height={ 16 }
+					className={ styles.favicon }
+				/>
+			) }
+		</span>
+	);
 }
 
 /**
@@ -53,14 +83,7 @@ export function getReferrerFields(): Field< ReferrerRecord >[] {
 				const safeUrl = safeHttpUrl( item.link );
 				const label = (
 					<Stack render={ <span /> } direction="row" gap="sm" align="center">
-						{ item.icon && (
-							<img
-								src={ item.icon }
-								onError={ handleFaviconError }
-								alt=""
-								className={ styles.favicon }
-							/>
-						) }
+						<ReferrerFavicon icon={ item.icon } />
 						<span>{ item.label }</span>
 					</Stack>
 				);

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/index.ts
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/index.ts
@@ -1,3 +1,3 @@
-export { aggregateReferrerRows, flattenReferrerRows, referrersToTimeSeries } from './aggregate';
+export { flattenReferrerRows } from './aggregate';
 export { getReferrerFields, type ReferrerRecord } from './fields';
 export { useReferrersReportRecords } from './use-report-records';

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/use-report-records.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/use-report-records.test.ts
@@ -1,11 +1,7 @@
 import { useStatsReferrers } from '@jetpack-premium-analytics/data';
 import { renderHook } from '@testing-library/react';
 import { useReferrersReportRecords } from './use-report-records';
-import type {
-	ReportParams,
-	StatsNormalizedReport,
-	StatsReferrersItem,
-} from '@jetpack-premium-analytics/data';
+import type { ReportParams, StatsReferrersComparisonItem } from '@jetpack-premium-analytics/data';
 
 jest.mock( '@jetpack-premium-analytics/data', () => ( {
 	...jest.requireActual( '@jetpack-premium-analytics/data' ),
@@ -14,167 +10,83 @@ jest.mock( '@jetpack-premium-analytics/data', () => ( {
 
 const mockUseStatsReferrers = useStatsReferrers as jest.MockedFunction< typeof useStatsReferrers >;
 
-const report: StatsNormalizedReport< StatsReferrersItem > = {
-	summary: {},
-	data: [
-		{
-			time_interval: '2026-07-09',
-			date_start: '2026-07-09T00:00:00+00:00',
-			date_end: '2026-07-09T23:59:59+00:00',
-			items: [
-				{
-					label: 'example.com',
-					views: 7,
-					link: 'https://example.com/',
-					icon: null,
-					labelIcon: 'external',
-					children: null,
-				},
-			],
-		},
-		{
-			time_interval: '2026-07-10',
-			date_start: '2026-07-10T00:00:00+00:00',
-			date_end: '2026-07-10T23:59:59+00:00',
-			items: [
-				{
-					label: 'example.com',
-					views: 6,
-					link: 'https://example.com/',
-					icon: null,
-					labelIcon: 'external',
-					children: null,
-				},
-			],
-		},
-	],
-};
-
-const comparisonReport: StatsNormalizedReport< StatsReferrersItem > = {
-	summary: {},
-	data: [
-		{
-			time_interval: '2026-07-07',
-			date_start: '2026-07-07T00:00:00+00:00',
-			date_end: '2026-07-07T23:59:59+00:00',
-			items: [
-				{
-					label: 'wordpress.com',
-					views: 4,
-					link: 'https://wordpress.com/',
-					icon: null,
-					labelIcon: 'external',
-					children: null,
-				},
-			],
-		},
-		{
-			time_interval: '2026-07-08',
-			date_start: '2026-07-08T00:00:00+00:00',
-			date_end: '2026-07-08T23:59:59+00:00',
-			items: [
-				{
-					label: 'wordpress.org',
-					views: 5,
-					link: 'https://wordpress.org/',
-					icon: null,
-					labelIcon: 'external',
-					children: null,
-				},
-			],
-		},
-	],
-};
+const comparisonRows: StatsReferrersComparisonItem[] = [
+	{
+		label: 'Search Engines',
+		views: 13,
+		previousValue: 10,
+		link: null,
+		icon: null,
+		labelIcon: null,
+		children: [
+			{
+				label: 'google.com',
+				views: 13,
+				previousValue: 8,
+				link: 'https://www.google.com/',
+				icon: null,
+				labelIcon: 'external',
+				children: null,
+			},
+		],
+	},
+];
 
 describe( 'useReferrersReportRecords', () => {
 	beforeEach( () => {
 		mockUseStatsReferrers.mockReturnValue( {
-			primary: { data: report },
+			primary: { data: undefined },
 			comparison: { data: undefined },
-			hasComparison: false,
+			comparisonRows: { rows: comparisonRows, hasComparison: true },
+			hasComparison: true,
 			isLoading: false,
-		} as ReturnType< typeof useStatsReferrers > );
+			isError: false,
+			refetch: jest.fn(),
+		} as unknown as ReturnType< typeof useStatsReferrers > );
 	} );
 
 	afterEach( () => {
 		jest.clearAllMocks();
 	} );
 
-	it( 'keeps the request day-bucketed while grouping only the chart by week', () => {
+	it( 'matches the summarized Calypso request and returns parent-linked comparison rows', () => {
 		const params: ReportParams = {
 			from: '2026-07-09',
 			to: '2026-07-10',
 			interval: 'day',
-		};
-		const { result: dayResult } = renderHook( () => useReferrersReportRecords( params, 'day' ) );
-		const { result: weekResult } = renderHook( () => useReferrersReportRecords( params, 'week' ) );
-
-		expect( mockUseStatsReferrers ).toHaveBeenLastCalledWith( {
-			...params,
-			max: 0,
-			summarize: 0,
-			period: 'day',
-		} );
-		expect( weekResult.current.chart.primary ).toEqual( {
-			summary: {
-				date_start: '2026-07-09T00:00:00+00:00',
-				date_end: '2026-07-10T23:59:59+00:00',
-			},
-			data: [
-				expect.objectContaining( {
-					time_interval: '2026-07-06',
-					date_start: '2026-07-06T00:00:00+00:00',
-					views: 13,
-				} ),
-			],
-		} );
-		expect( weekResult.current.rows ).toEqual( dayResult.current.rows );
-	} );
-
-	it( 'includes comparison chart buckets when referrers do not overlap the primary period', () => {
-		mockUseStatsReferrers.mockReturnValue( {
-			primary: { data: report },
-			comparison: { data: comparisonReport },
-			hasComparison: false,
-			isLoading: false,
-		} as ReturnType< typeof useStatsReferrers > );
-		const params: ReportParams = {
-			from: '2026-07-09',
-			to: '2026-07-10',
-			interval: 'day',
+			comp: '1',
 			compare_from: '2026-07-07',
 			compare_to: '2026-07-08',
 		};
+		const { result } = renderHook( () => useReferrersReportRecords( params ) );
 
-		const { result } = renderHook( () => useReferrersReportRecords( params, 'day' ) );
-
-		expect( result.current.chart.comparison ).toBeDefined();
-		expect( result.current.chart.comparison?.data.map( point => point.views ) ).toEqual( [ 4, 5 ] );
-	} );
-
-	it( 'omits the comparison chart when comparison params are absent', () => {
-		mockUseStatsReferrers.mockReturnValue( {
-			primary: { data: report },
-			comparison: { data: comparisonReport },
-			hasComparison: false,
-			isLoading: false,
-		} as ReturnType< typeof useStatsReferrers > );
-		const params: ReportParams = {
-			from: '2026-07-09',
-			to: '2026-07-10',
-			interval: 'day',
-		};
-
-		const { result } = renderHook( () => useReferrersReportRecords( params, 'day' ) );
-
-		expect( result.current.chart.comparison ).toBeUndefined();
+		expect( mockUseStatsReferrers ).toHaveBeenCalledWith( {
+			...params,
+			max: 0,
+			summarize: 1,
+			period: 'day',
+		} );
+		expect( result.current.rows ).toEqual( [
+			expect.objectContaining( {
+				id: '["Search Engines"]',
+				label: 'Search Engines',
+				previousValue: 10,
+				hasChildren: true,
+			} ),
+			expect.objectContaining( {
+				parentId: '["Search Engines"]',
+				label: 'google.com',
+				previousValue: 8,
+			} ),
+		] );
 	} );
 
 	it( 'surfaces error and refetch from the report', () => {
 		const refetch = jest.fn();
 		mockUseStatsReferrers.mockReturnValue( {
-			primary: { data: report },
+			primary: { data: undefined },
 			comparison: { data: undefined },
+			comparisonRows: { rows: [], hasComparison: false },
 			hasComparison: false,
 			isLoading: false,
 			isError: true,
@@ -186,7 +98,7 @@ describe( 'useReferrersReportRecords', () => {
 			interval: 'day',
 		};
 
-		const { result } = renderHook( () => useReferrersReportRecords( params, 'day' ) );
+		const { result } = renderHook( () => useReferrersReportRecords( params ) );
 
 		expect( result.current.isError ).toBe( true );
 		expect( result.current.refetch ).toBe( refetch );

--- a/projects/packages/premium-analytics/routes/reports/referrers/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/referrers/config/use-report-records.ts
@@ -1,66 +1,38 @@
 /**
  * External dependencies
  */
-import {
-	useStatsReferrers,
-	type ReportParams,
-	type StatsChartBucketPeriod,
-} from '@jetpack-premium-analytics/data';
+import { useStatsReferrers, type ReportParams } from '@jetpack-premium-analytics/data';
 import { useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { aggregateReferrerRows, referrersToTimeSeries } from './aggregate';
+import { flattenReferrerRows } from './aggregate';
 
 /**
- * Fetch and derive the Referrers report chart and table records.
+ * Fetch and derive the Referrers report table records.
  *
  * @param reportParams - The shared report-window parameters.
- * @param chartPeriod  - The chart's bucket period.
- * @return Chart data and table records.
+ * @return Hierarchical table records.
  */
-export function useReferrersReportRecords(
-	reportParams: ReportParams,
-	chartPeriod: StatsChartBucketPeriod
-) {
-	// A single bucketed query feeds both report sections. `summarize: 0`
-	// preserves the time buckets for the chart, and `max: 0` requests every
-	// referrer so table search, sorting, and pagination remain client-side.
+export function useReferrersReportRecords( reportParams: ReportParams ) {
+	// Match Calypso's detailed Referrers request: summarize the selected day
+	// range and request every row for client-side search, sorting, and pagination.
 	const recordsParams = useMemo(
 		() => ( {
 			...reportParams,
 			max: 0,
-			summarize: 0,
+			summarize: 1,
 			period: 'day',
 		} ),
 		[ reportParams ]
 	);
 	const report = useStatsReferrers( recordsParams );
-
-	const chartPrimary = useMemo(
-		() => referrersToTimeSeries( report.primary.data, chartPeriod ),
-		[ report.primary.data, chartPeriod ]
-	);
-	const chartComparison = useMemo( () => {
-		if ( ! reportParams.compare_from || ! reportParams.compare_to ) {
-			return undefined;
-		}
-
-		return referrersToTimeSeries( report.comparison.data, chartPeriod );
-	}, [ reportParams, report.comparison.data, chartPeriod ] );
-	const rows = useMemo(
-		() => aggregateReferrerRows( report.primary.data ),
-		[ report.primary.data ]
-	);
+	const comparisonRows = report.comparisonRows?.rows;
+	const rows = useMemo( () => flattenReferrerRows( comparisonRows ?? [] ), [ comparisonRows ] );
 
 	return {
 		isError: report.isError,
 		refetch: report.refetch,
-		chart: {
-			primary: chartPrimary,
-			comparison: report.comparison.data ? chartComparison : undefined,
-			isLoading: report.isLoading,
-		},
 		rows,
 		isLoading: report.isLoading,
 	};

--- a/projects/packages/premium-analytics/routes/reports/referrers/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/referrers/page.tsx
@@ -1,26 +1,20 @@
 /**
  * External dependencies
  */
-import {
-	normalizeReportParams,
-	type IntervalType,
-	type StatsChartBucketPeriod,
-} from '@jetpack-premium-analytics/data';
+import { normalizeReportParams } from '@jetpack-premium-analytics/data';
 import { useDashboardLink, useReportDateFilters } from '@jetpack-premium-analytics/routing';
 import { DateFiltersPanel } from '@jetpack-premium-analytics/ui';
 import {
-	formatLegendLabels,
+	ReportDrilldownTable,
 	ReportErrorState,
 	ReportPageLayout,
 	ReportPageShell,
-	ReportPerformanceChart,
-	ReportRecordsTable,
 	useReportRetry,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { Breadcrumbs } from '@wordpress/admin-ui';
-import { useCallback, useMemo, useState } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useNavigate, useSearch } from '@wordpress/route';
+import { useSearch } from '@wordpress/route';
 /**
  * Internal dependencies
  */
@@ -28,40 +22,6 @@ import { route } from '../package.json';
 import { getReferrerFields, useReferrersReportRecords, type ReferrerRecord } from './config';
 
 const ROUTE_FROM = route.path;
-const REPORT_PARAMS = { report: 'referrers' };
-const CHART_PERIODS = [
-	'day',
-	'week',
-	'month',
-] as const satisfies readonly StatsChartBucketPeriod[];
-
-/**
- * Check whether a URL value is a supported chart period.
- *
- * @param value - The URL search value.
- * @return Whether the value is a chart period.
- */
-function isChartPeriod( value: unknown ): value is StatsChartBucketPeriod {
-	return CHART_PERIODS.includes( value as StatsChartBucketPeriod );
-}
-
-/**
- * Choose the chart bucket period for a report interval.
- *
- * @param interval - The report date interval.
- * @return The default chart bucket period.
- */
-function getDefaultChartPeriod( interval?: IntervalType ): StatsChartBucketPeriod {
-	if ( interval === 'week' ) {
-		return 'week';
-	}
-
-	if ( interval === 'month' || interval === 'quarter' || interval === 'year' ) {
-		return 'month';
-	}
-
-	return 'day';
-}
 
 /**
  * Stable row id for the Referrers records table.
@@ -73,8 +33,21 @@ function getReferrerRowId( item: ReferrerRecord ): string {
 	return item.id;
 }
 
+/**
+ * Resolve the parent row for nested referrers.
+ *
+ * @param item - The referrer row.
+ * @return The parent row id, if present.
+ */
+function getReferrerParentId( item: ReferrerRecord ): string | undefined {
+	return item.parentId;
+}
+
 const RECORDS_VIEW = {
 	sort: { field: 'views', direction: 'desc' as const },
+	// Keep Referrer as the title field so DataViews renders native hierarchy
+	// levels on the same nested group/source/domain structure as the widget.
+	fields: [ 'referrer', 'views' ],
 	layout: {
 		styles: {
 			referrer: { width: '100%' },
@@ -95,40 +68,9 @@ function ReferrersReport(): JSX.Element {
 		[ search ]
 	);
 
-	const chartPeriod = isChartPeriod( search.period )
-		? search.period
-		: getDefaultChartPeriod( reportParams.interval );
-	const records = useReferrersReportRecords( reportParams, chartPeriod );
+	const records = useReferrersReportRecords( reportParams );
 	const retry = useReportRetry( records.refetch );
 	const fields = useMemo( () => getReferrerFields(), [] );
-	const chartMetrics = useMemo(
-		() => [ { key: 'views', label: __( 'Views', 'jetpack-premium-analytics' ) } ],
-		[]
-	);
-	const chartLegendLabels = useMemo( () => formatLegendLabels( reportParams ), [ reportParams ] );
-
-	const navigate = useNavigate();
-	const handleIntervalChange = useCallback(
-		( interval: IntervalType ) => {
-			const period = isChartPeriod( interval ) ? interval : getDefaultChartPeriod( interval );
-			navigate( {
-				to: ROUTE_FROM,
-				/*
-				 * The router is built dynamically, so `/reports/$report` has no
-				 * statically-typed params/search schema (tanstack widens them to
-				 * `never`). Cast the same way the routing package does when it
-				 * writes the URL.
-				 */
-				params: REPORT_PARAMS as unknown as never,
-				replace: true,
-				search: ( ( current: Record< string, unknown > ) => ( {
-					...current,
-					period,
-				} ) ) as unknown as never,
-			} );
-		},
-		[ navigate ]
-	);
 
 	const dateFilters = useReportDateFilters( ROUTE_FROM );
 	const dashboardLink = useDashboardLink();
@@ -161,25 +103,16 @@ function ReferrersReport(): JSX.Element {
 						onRetry={ retry }
 					/>
 				) : (
-					<>
-						<ReportPerformanceChart
-							primary={ records.chart.primary }
-							comparison={ records.chart.comparison }
-							isLoading={ records.chart.isLoading }
-							metrics={ chartMetrics }
-							interval={ chartPeriod }
-							onIntervalChange={ handleIntervalChange }
-							legendLabels={ chartLegendLabels }
-						/>
-						<ReportRecordsTable
-							data={ records.rows }
-							fields={ fields }
-							getItemId={ getReferrerRowId }
-							isLoading={ records.isLoading }
-							initialView={ RECORDS_VIEW }
-							searchLabel={ __( 'Search referrers', 'jetpack-premium-analytics' ) }
-						/>
-					</>
+					<ReportDrilldownTable< ReferrerRecord >
+						data={ records.rows }
+						fields={ fields }
+						getItemId={ getReferrerRowId }
+						getItemParentId={ getReferrerParentId }
+						hideLevelMarkers
+						isLoading={ records.isLoading }
+						initialView={ RECORDS_VIEW }
+						searchLabel={ __( 'Search referrers', 'jetpack-premium-analytics' ) }
+					/>
 				) }
 			</ReportPageLayout>
 		</ReportPageShell>


### PR DESCRIPTION
## Proposed changes
* Remove the performance chart from the Referrers report.
* Match the detailed Calypso Referrers request by summarizing the selected day range, requesting all rows, and omitting the generic `days` parameter.
* Render referrer groups, sources, and domains as nested rows in the shared drilldown table.
* Show Views comparison deltas when comparison is enabled, while preserving favicons, safe links, error handling, and accessible group context.

<img width="1894" height="1766" alt="Google Chrome -2026-07-24 at 18 38 28@2x" src="https://github.com/user-attachments/assets/fea12b06-1f51-4a67-b53c-34e6d2190e84" />


## Related product discussion/links
* [WOOA7S-1696: Report page: Referrers (`/reports/referrers`)](https://linear.app/a8c/issue/WOOA7S-1696/report-page-referrers-reportsreferrers)

## Does this pull request change what data or activity we track or use?
No. It changes how existing Stats referrer data is requested and displayed; it does not add or change tracking.

## Testing instructions
* Build Premium Analytics and open **Analytics → Referrers**.
* Select a date preset and enable comparison.
* Verify the page has no chart and the table shows Referrer and Views columns.
* Verify group, source, and domain rows retain their nested indentation without visible dash markers.
* Verify comparison deltas appear beside Views and referrer favicons and safe external links still work.
* Search for a nested domain and verify its ancestor rows remain visible.
* Automated verification: 79 affected Jest suites (541 tests), TypeScript, ESLint, stylelint, package build, and plugin build pass.
