### PR TITLE
Premium Analytics: drive dashboard sections from a core-data entity

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-dashboard-sections-core-data
+++ b/projects/packages/premium-analytics/changelog/update-dashboard-sections-core-data
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Dashboard: drive the section tab bar from the server-side registry through a core-data entity, and carry each section's default layout in the sections response so reset reads it from the store without a request.

--- a/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/components/dashboard-sections/dashboard-sections.tsx
@@ -32,6 +32,9 @@ type DashboardSectionsProps = {
  * changes upward. Panel children are rendered inside the same Tabs.Root so the
  * tablist and section content share a complete tab/panel relationship.
  *
+ * Tabs are keyed by the section `slug` (the URL-facing identifier the active
+ * section state uses), not the namespaced `id`.
+ *
  * @param props          - Component props.
  * @param props.sections - The sections to render, in order.
  * @param props.value    - The currently active section ID.
@@ -47,7 +50,7 @@ export function DashboardSections( {
 }: DashboardSectionsProps ) {
 	return (
 		<SectionTabs
-			tabs={ sections }
+			tabs={ sections.map( ( { slug, label } ) => ( { id: slug, label } ) ) }
 			value={ value }
 			onChange={ onChange }
 			rootClassName={ styles.root }

--- a/projects/packages/premium-analytics/routes/dashboard/config/index.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/index.ts
@@ -1,11 +1,3 @@
-export {
-	DASHBOARD_SECTION_IDS,
-	DEFAULT_SECTION_ID,
-	getSectionLabel,
-	getDashboardSections,
-	resolveSectionId,
-	type DashboardSection,
-	type DashboardSectionId,
-} from './sections';
+export { resolveSectionId, type DashboardSection, type DashboardSectionId } from './sections';
 
 export { isDashboardSectionLayouts, type DashboardSectionLayouts } from './section-layouts';

--- a/projects/packages/premium-analytics/routes/dashboard/config/section-layouts.test.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/section-layouts.test.ts
@@ -13,12 +13,18 @@ describe( 'section layouts config', () => {
 		).toBe( true );
 	} );
 
-	it( 'rejects unknown section keys', () => {
+	it( 'accepts any string key, since slugs are server-driven', () => {
 		expect(
 			isDashboardSectionLayouts( {
-				unknown: [],
+				store: [],
+				conversions: [],
 			} )
-		).toBe( false );
+		).toBe( true );
+	} );
+
+	it( 'rejects non-object values', () => {
+		expect( isDashboardSectionLayouts( [] ) ).toBe( false );
+		expect( isDashboardSectionLayouts( null ) ).toBe( false );
 	} );
 
 	it( 'rejects non-array layouts', () => {

--- a/projects/packages/premium-analytics/routes/dashboard/config/section-layouts.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/section-layouts.ts
@@ -6,10 +6,8 @@ export type DashboardSectionLayouts = Partial< Record< DashboardSectionId, Dashb
 /**
  * Check whether a value can be used as the persisted section layout map.
  *
- * Keys are section slugs, which are server-driven, so any string key is
- * accepted: a stored layout must survive its section becoming unavailable
- * (e.g. the store section after WooCommerce is deactivated) so it is still
- * there when the section comes back.
+ * Keys are server-driven section slugs, so any string key is accepted: a stored
+ * layout must survive its section becoming temporarily unavailable.
  *
  * @param value - Candidate preference value.
  * @return Whether the value is a valid section layout map.

--- a/projects/packages/premium-analytics/routes/dashboard/config/section-layouts.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/section-layouts.ts
@@ -1,13 +1,15 @@
-import { DASHBOARD_SECTION_IDS } from './sections';
 import type { DashboardSectionId } from './sections';
 import type { DashboardWidget } from '@wordpress/widget-dashboard';
 
 export type DashboardSectionLayouts = Partial< Record< DashboardSectionId, DashboardWidget[] > >;
 
-const SECTION_IDS = new Set< string >( DASHBOARD_SECTION_IDS );
-
 /**
  * Check whether a value can be used as the persisted section layout map.
+ *
+ * Keys are section slugs, which are server-driven, so any string key is
+ * accepted: a stored layout must survive its section becoming unavailable
+ * (e.g. the store section after WooCommerce is deactivated) so it is still
+ * there when the section comes back.
  *
  * @param value - Candidate preference value.
  * @return Whether the value is a valid section layout map.
@@ -17,7 +19,5 @@ export function isDashboardSectionLayouts( value: unknown ): value is DashboardS
 		return false;
 	}
 
-	return Object.entries( value ).every(
-		( [ sectionId, layout ] ) => SECTION_IDS.has( sectionId ) && Array.isArray( layout )
-	);
+	return Object.values( value ).every( layout => Array.isArray( layout ) );
 }

--- a/projects/packages/premium-analytics/routes/dashboard/config/sections.test.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/sections.test.ts
@@ -1,35 +1,32 @@
-import { __ } from '@wordpress/i18n';
-import {
-	DASHBOARD_SECTION_IDS,
-	DEFAULT_SECTION_ID,
-	getDashboardSections,
-	resolveSectionId,
-} from './sections';
+import { resolveSectionId, type DashboardSection } from './sections';
 
-jest.mock( '@wordpress/i18n', () => ( {
-	__: jest.fn( ( text: string ) => text ),
-} ) );
+const SECTIONS: DashboardSection[] = [
+	{ id: 'analytics/traffic', slug: 'traffic', label: 'Traffic', order: 10, default_layout: [] },
+	{ id: 'analytics/insights', slug: 'insights', label: 'Insights', order: 20, default_layout: [] },
+	{
+		id: 'analytics/subscribers',
+		slug: 'subscribers',
+		label: 'Subscribers',
+		order: 30,
+		default_layout: [],
+	},
+];
 
-describe( 'dashboard sections', () => {
-	it( 'builds the ordered section definitions', () => {
-		expect( getDashboardSections() ).toEqual( [
-			{ id: 'traffic', label: 'Traffic' },
-			{ id: 'insights', label: 'Insights' },
-			{ id: 'subscribers', label: 'Subscribers' },
-			{ id: 'store', label: 'Store' },
-		] );
-
-		expect( __ ).toHaveBeenCalledWith( 'Traffic', 'jetpack-premium-analytics' );
+describe( 'resolveSectionId', () => {
+	it( 'keeps a slug matching an available section', () => {
+		expect( resolveSectionId( 'insights', SECTIONS ) ).toBe( 'insights' );
 	} );
 
-	it( 'keeps the default section first', () => {
-		expect( DEFAULT_SECTION_ID ).toBe( 'traffic' );
-		expect( DASHBOARD_SECTION_IDS[ 0 ] ).toBe( DEFAULT_SECTION_ID );
+	it( 'falls back to the first section by order for stale or unavailable slugs', () => {
+		expect( resolveSectionId( 'store', SECTIONS ) ).toBe( 'traffic' );
+		expect( resolveSectionId( 'missing', SECTIONS ) ).toBe( 'traffic' );
 	} );
 
-	it( 'resolves unknown section search values to the default section', () => {
-		expect( resolveSectionId( 'insights' ) ).toBe( 'insights' );
-		expect( resolveSectionId( 'missing' ) ).toBe( DEFAULT_SECTION_ID );
-		expect( resolveSectionId( undefined ) ).toBe( DEFAULT_SECTION_ID );
+	it( 'falls back to the first section when no value is given', () => {
+		expect( resolveSectionId( undefined, SECTIONS ) ).toBe( 'traffic' );
+	} );
+
+	it( 'returns an empty slug when no sections are available yet', () => {
+		expect( resolveSectionId( 'traffic', [] ) ).toBe( '' );
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/dashboard/config/sections.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/sections.ts
@@ -1,87 +1,69 @@
 /**
  * External dependencies
  */
-import { __ } from '@wordpress/i18n';
+import type { DashboardWidget } from '@wordpress/widget-dashboard';
 
 /**
- * Ordered list of the dashboard section IDs.
+ * A dashboard section definition, served by `GET /dashboards/{name}/sections`
+ * and read through the `dashboardSection` core-data entity.
  *
- * This is the single source of truth for which sections exist and in what order.
- * Each section is surfaced as a tab and renders the customizable widget grid,
- * so the IDs are kept stable and URL-friendly (they are persisted in the
- * `?section=` search param).
- */
-export const DASHBOARD_SECTION_IDS = [ 'traffic', 'insights', 'subscribers', 'store' ] as const;
-
-/**
- * Dashboard section identifier.
- * Derived from DASHBOARD_SECTION_IDS to keep the union in sync with the source list.
- */
-export type DashboardSectionId = ( typeof DASHBOARD_SECTION_IDS )[ number ];
-
-/**
- * Default section shown when the URL has no (or an unknown) `section` param.
- */
-export const DEFAULT_SECTION_ID: DashboardSectionId = 'traffic';
-
-/**
- * A dashboard section definition.
- *
- * For now a section is just an ID and a display label. This is the natural place
- * to attach per-section metadata such as the default widget layout.
+ * The server-side section registry is the single source of truth for which
+ * sections exist, in what order, and with which labels. The WooCommerce
+ * section, for example, is only present when WooCommerce is active.
  */
 export type DashboardSection = {
-	id: DashboardSectionId;
+	/**
+	 * Canonical namespaced identifier, e.g. `analytics/traffic`.
+	 */
+	id: string;
+
+	/**
+	 * URL-facing slug (the segment after the namespace), e.g. `traffic`.
+	 * Persisted in the `?section=` search param and as the section-layout
+	 * preference key.
+	 */
+	slug: string;
+
+	/**
+	 * Translated display label.
+	 */
 	label: string;
+
+	/**
+	 * Sort order (ascending).
+	 */
+	order: number;
+
+	/**
+	 * Bundled default widget layout, consumed by the reset action.
+	 */
+	default_layout: DashboardWidget[];
 };
 
 /**
- * Canonical section definitions with lazy label getters, in display order.
- *
- * Labels are defined once here, as getters resolved at call time, so translations
- * are applied after the i18n locale data has loaded. Mirrors the datetime
- * package's `PRESET_DEFINITIONS`.
+ * Dashboard section identifier as used by the frontend: the URL-facing `slug`
+ * of a `DashboardSection`. Server-driven, so no longer a static union.
  */
-const SECTION_DEFINITIONS: ReadonlyArray< {
-	id: DashboardSectionId;
-	getLabel: () => string;
-} > = [
-	{ id: 'traffic', getLabel: () => __( 'Traffic', 'jetpack-premium-analytics' ) },
-	{ id: 'insights', getLabel: () => __( 'Insights', 'jetpack-premium-analytics' ) },
-	{ id: 'subscribers', getLabel: () => __( 'Subscribers', 'jetpack-premium-analytics' ) },
-	{ id: 'store', getLabel: () => __( 'Store', 'jetpack-premium-analytics' ) },
-];
+export type DashboardSectionId = string;
 
 /**
- * Get the translated display label for a section.
+ * Narrow an arbitrary string to an available section slug, falling back to the
+ * first section by order.
  *
- * @param id - The section identifier.
- * @return Translated label for the section.
+ * A miss covers both stale slugs (an old bookmark) and currently unavailable
+ * sections (`?section=store` with WooCommerce off).
+ *
+ * @param value    - The candidate section slug (e.g. from the URL).
+ * @param sections - The available sections, in order.
+ * @return The resolved section slug, or an empty string when no sections exist.
  */
-export function getSectionLabel( id: DashboardSectionId ): string {
-	return SECTION_DEFINITIONS.find( section => section.id === id )?.getLabel() ?? id;
-}
+export function resolveSectionId(
+	value: string | undefined,
+	sections: DashboardSection[]
+): DashboardSectionId {
+	if ( value && sections.some( section => section.slug === value ) ) {
+		return value;
+	}
 
-/**
- * Build the ordered list of section definitions ({ id, label }).
- *
- * Labels are resolved lazily (at call time) so translations are applied after
- * the i18n locale data has loaded.
- *
- * @return Ordered list of section definitions.
- */
-export function getDashboardSections(): DashboardSection[] {
-	return SECTION_DEFINITIONS.map( ( { id, getLabel } ) => ( { id, label: getLabel() } ) );
-}
-
-/**
- * Narrow an arbitrary string to a known section ID, falling back to the default.
- *
- * @param value - The candidate section ID (e.g. from the URL).
- * @return A valid section ID.
- */
-export function resolveSectionId( value: string | undefined ): DashboardSectionId {
-	return value && ( DASHBOARD_SECTION_IDS as readonly string[] ).includes( value )
-		? ( value as DashboardSectionId )
-		: DEFAULT_SECTION_ID;
+	return sections[ 0 ]?.slug ?? '';
 }

--- a/projects/packages/premium-analytics/routes/dashboard/config/sections.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/sections.ts
@@ -4,12 +4,9 @@
 import type { DashboardWidget } from '@wordpress/widget-dashboard';
 
 /**
- * A dashboard section definition, served by `GET /dashboards/{name}/sections`
- * and read through the `dashboardSection` core-data entity.
- *
- * The server-side section registry is the single source of truth for which
- * sections exist, in what order, and with which labels. The WooCommerce
- * section, for example, is only present when WooCommerce is active.
+ * A dashboard section, served by `GET /dashboards/{name}/sections` and read
+ * through the `dashboardSection` core-data entity. The server-side registry is
+ * the source of truth for which sections exist, their order, and labels.
  */
 export type DashboardSection = {
 	/**
@@ -41,17 +38,15 @@ export type DashboardSection = {
 };
 
 /**
- * Dashboard section identifier as used by the frontend: the URL-facing `slug`
- * of a `DashboardSection`. Server-driven, so no longer a static union.
+ * Dashboard section identifier: the URL-facing `slug` of a `DashboardSection`.
+ * Server-driven, so an open string.
  */
 export type DashboardSectionId = string;
 
 /**
- * Narrow an arbitrary string to an available section slug, falling back to the
- * first section by order.
- *
- * A miss covers both stale slugs (an old bookmark) and currently unavailable
- * sections (`?section=store` with WooCommerce off).
+ * Narrow a candidate slug to an available section, falling back to the first
+ * section by order. A miss is a stale slug or a section unavailable now
+ * (`?section=store` with WooCommerce off).
  *
  * @param value    - The candidate section slug (e.g. from the URL).
  * @param sections - The available sections, in order.

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/use-active-section.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/use-active-section.ts
@@ -20,17 +20,12 @@ type SectionSearch = {
 };
 
 /**
- * Read and update the active dashboard section via the `?section=` search param.
+ * Read and update the active dashboard section via the `?section=` search
+ * param, so sections are deep-linkable. Built on `useStagedSearch`: switching a
+ * section is an immediate stage + commit (one history entry per change).
  *
- * Keeping the active section in the URL makes sections deep-linkable and gives
- * the widget grid a single, stable place to read the current section from.
- * Built on the package's `useStagedSearch`, so switching a section is an
- * immediate stage + commit (one history entry per change).
- *
- * The raw `?section=` value is validated against the available sections: a miss
- * (a stale slug, or a currently unavailable section like `store` with
- * WooCommerce off) resolves to the first section by order, and the URL is
- * rewritten in place to the resolved slug.
+ * `?section=` is validated against the available sections. A miss resolves to
+ * the first section by order and the URL is rewritten to it.
  *
  * @param sections - The available sections, in order.
  * @return A tuple of the active section slug and a setter to change it.

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/use-active-section.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/use-active-section.ts
@@ -2,11 +2,11 @@
  * External dependencies
  */
 import { useStagedSearch } from '@jetpack-premium-analytics/routing';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 /**
  * Internal dependencies
  */
-import { resolveSectionId, type DashboardSectionId } from '../config';
+import { resolveSectionId, type DashboardSection, type DashboardSectionId } from '../config';
 import { route } from '../package.json';
 
 /**
@@ -22,20 +22,41 @@ type SectionSearch = {
 /**
  * Read and update the active dashboard section via the `?section=` search param.
  *
- * Keeping the active section in the URL makes sections deep-linkable and gives the
- * future Dashboard/widget integration a single, stable place to read the
- * current section from. Built on the package's `useStagedSearch` so the section
- * shares the same search-param model as the date filters; switching a section is an
+ * Keeping the active section in the URL makes sections deep-linkable and gives
+ * the widget grid a single, stable place to read the current section from.
+ * Built on the package's `useStagedSearch`, so switching a section is an
  * immediate stage + commit (one history entry per change).
  *
- * @return A tuple of the active section ID and a setter to change it.
+ * The raw `?section=` value is validated against the available sections: a miss
+ * (a stale slug, or a currently unavailable section like `store` with
+ * WooCommerce off) resolves to the first section by order, and the URL is
+ * rewritten in place to the resolved slug.
+ *
+ * @param sections - The available sections, in order.
+ * @return A tuple of the active section slug and a setter to change it.
  */
-export function useActiveSection(): [ DashboardSectionId, ( id: DashboardSectionId ) => void ] {
+export function useActiveSection(
+	sections: DashboardSection[]
+): [ DashboardSectionId, ( id: DashboardSectionId ) => void ] {
 	const { effective, stage, commit } = useStagedSearch< SectionSearch, typeof ROUTE_FROM >( {
 		from: ROUTE_FROM,
 	} );
 
-	const activeSection = resolveSectionId( effective.section );
+	const activeSection = resolveSectionId( effective.section, sections );
+
+	// Rewrite an unresolvable `?section=` to the slug actually rendered, so the
+	// URL never advertises a section that isn't shown. Replace instead of push:
+	// the invalid URL should not survive as a history entry.
+	useEffect( () => {
+		if ( sections.length === 0 || effective.section === undefined ) {
+			return;
+		}
+
+		if ( effective.section !== activeSection ) {
+			stage( { section: activeSection } );
+			commit( { replace: true } );
+		}
+	}, [ sections.length, effective.section, activeSection, stage, commit ] );
 
 	const setActiveSection = useCallback(
 		( id: DashboardSectionId ) => {

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-section-layout.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-section-layout.ts
@@ -16,14 +16,11 @@ type PreferencesActions = {
 };
 
 /**
- * Manage the customizable widget layout for the currently active dashboard section.
+ * Manage the customizable widget layout for the active dashboard section.
  *
- * The shared `useDashboardLayout` hook stores one dashboard-wide layout. This
- * route layers a section map on top of that hook so each section can commit its
- * own customized layout, while reset restores the section's bundled default.
- *
- * The default comes from the active section's `default_layout`, carried on the
- * `dashboardSection` record, so reset is a local store write with no request.
+ * Layers a per-section map over the dashboard-wide `useDashboardLayout`, so each
+ * section keeps its own layout. Reset restores the section's `default_layout`
+ * from the `dashboardSection` record: a local store write, no request.
  *
  * @param dashboardName   - Dashboard registration name for the base layout.
  * @param activeSectionId - Currently active section slug.

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-section-layout.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-section-layout.ts
@@ -1,11 +1,10 @@
-import apiFetch from '@wordpress/api-fetch';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as preferencesStore } from '@wordpress/preferences';
 import { useCallback, useMemo } from 'react';
 import { isDashboardSectionLayouts } from '../config';
-import { DASHBOARD_PREFERENCES_SCOPE, DASHBOARD_REST_NAMESPACE } from './constants';
+import { DASHBOARD_PREFERENCES_SCOPE } from './constants';
 import { useDashboardLayout } from './use-dashboard-layout';
-import type { DashboardSectionId, DashboardSectionLayouts } from '../config';
+import type { DashboardSection, DashboardSectionId, DashboardSectionLayouts } from '../config';
 import type { DashboardName } from './use-dashboard-layout';
 import type { DashboardWidget } from '@wordpress/widget-dashboard';
 
@@ -20,18 +19,22 @@ type PreferencesActions = {
  * Manage the customizable widget layout for the currently active dashboard section.
  *
  * The shared `useDashboardLayout` hook stores one dashboard-wide layout. This
- * route layers a section map on top of that hook so each section can commit
- * its own customized layout while reset can fetch the active section's bundled
- * default.
+ * route layers a section map on top of that hook so each section can commit its
+ * own customized layout, while reset restores the section's bundled default.
  *
- * @param dashboardName   - Dashboard registration name for fetching defaults.
- * @param activeSectionId - Currently active section ID.
+ * The default comes from the active section's `default_layout`, carried on the
+ * `dashboardSection` record, so reset is a local store write with no request.
+ *
+ * @param dashboardName   - Dashboard registration name for the base layout.
+ * @param activeSectionId - Currently active section slug.
+ * @param sections        - The available sections, carrying their defaults.
  * @return Active section layout, setter, and reset action.
  */
 export function useDashboardSectionLayout(
 	dashboardName: DashboardName,
-	activeSectionId: DashboardSectionId
-): [ DashboardWidget[], ( layout: DashboardWidget[] ) => void, () => Promise< void > ] {
+	activeSectionId: DashboardSectionId,
+	sections: DashboardSection[]
+): [ DashboardWidget[], ( layout: DashboardWidget[] ) => void, () => void ] {
 	const [ defaultLayout ] = useDashboardLayout( dashboardName );
 
 	const sectionLayouts = useSelect( select => {
@@ -61,16 +64,15 @@ export function useDashboardSectionLayout(
 		[ activeSectionId, sectionLayouts, set ]
 	);
 
-	const resetLayout = useCallback( async () => {
-		const fresh = ( await apiFetch( {
-			path: `/${ DASHBOARD_REST_NAMESPACE }/dashboards/${ activeSectionId }/default-layout`,
-		} ) ) as DashboardWidget[];
+	const resetLayout = useCallback( () => {
+		const sectionDefault =
+			sections.find( section => section.slug === activeSectionId )?.default_layout ?? [];
 
 		void set( DASHBOARD_PREFERENCES_SCOPE, PREFERENCES_KEY, {
 			...sectionLayouts,
-			[ activeSectionId ]: fresh,
+			[ activeSectionId ]: sectionDefault,
 		} );
-	}, [ activeSectionId, sectionLayouts, set ] );
+	}, [ sections, activeSectionId, sectionLayouts, set ] );
 
 	return [ layout, setLayout, resetLayout ];
 }

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-sections.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-sections.ts
@@ -1,21 +1,33 @@
 /**
  * External dependencies
  */
-import { useMemo } from 'react';
+import { store as coreStore } from '@wordpress/core-data';
+import { useSelect } from '@wordpress/data';
 /**
  * Internal dependencies
  */
-import { getDashboardSections, type DashboardSection } from '../config';
+import type { DashboardSection } from '../config';
 
 /**
- * Get the ordered list of dashboard sections.
+ * Get the ordered list of dashboard sections from the server-side registry.
  *
- * Wraps the pure `getDashboardSections()` builder in `useMemo` so the section
- * list (and its translated labels) is built once per mount instead of on every
- * render. The section set is static, so an empty dependency array is correct.
+ * Reads the `dashboardSection` core-data entity (registered in the route's
+ * `beforeLoad`), which resolves from `GET /sections`. The section set is
+ * server-driven, so conditional sections (e.g. the store section, present only
+ * when WooCommerce is active) never render a dead tab.
  *
- * @return The ordered, memoized list of dashboard sections.
+ * @return The ordered list of dashboard sections.
  */
 export function useDashboardSections(): DashboardSection[] {
-	return useMemo( () => getDashboardSections(), [] );
+	return useSelect( select => {
+		const core = select( coreStore ) as unknown as {
+			getEntityRecords: (
+				kind: string,
+				name: string,
+				query?: Record< string, unknown >
+			) => DashboardSection[] | null;
+		};
+
+		return core.getEntityRecords( 'root', 'dashboardSection', { per_page: -1 } ) ?? [];
+	}, [] );
 }

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-sections.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-sections.ts
@@ -9,12 +9,9 @@ import { useSelect } from '@wordpress/data';
 import type { DashboardSection } from '../config';
 
 /**
- * Get the ordered list of dashboard sections from the server-side registry.
- *
- * Reads the `dashboardSection` core-data entity (registered in the route's
- * `beforeLoad`), which resolves from `GET /sections`. The section set is
- * server-driven, so conditional sections (e.g. the store section, present only
- * when WooCommerce is active) never render a dead tab.
+ * Get the ordered list of dashboard sections. Reads the `dashboardSection`
+ * core-data entity (registered in the route's `beforeLoad`), which resolves
+ * from `GET /sections`.
  *
  * @return The ordered list of dashboard sections.
  */

--- a/projects/packages/premium-analytics/routes/dashboard/route.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/route.ts
@@ -13,7 +13,7 @@ import {
 	isPremiumAnalyticsInitialSyncFinished,
 	isPremiumAnalyticsSiteConnected,
 } from '../site-readiness';
-import { DASHBOARD_REST_NAMESPACE } from './hooks/constants';
+import { DASHBOARD_NAME, DASHBOARD_REST_NAMESPACE } from './hooks/constants';
 
 type DashboardSearch = Record< string, string | undefined >;
 
@@ -119,6 +119,15 @@ export const route = {
 				baseURL: `/${ DASHBOARD_REST_NAMESPACE }/widget-modules`,
 				plural: 'widgetModules',
 				label: __( 'Widget modules', 'jetpack-premium-analytics' ),
+				supportsPagination: false,
+			},
+			{
+				name: 'dashboardSection',
+				kind: 'root',
+				key: 'slug',
+				baseURL: `/${ DASHBOARD_REST_NAMESPACE }/dashboards/${ DASHBOARD_NAME }/sections`,
+				plural: 'dashboardSections',
+				label: __( 'Dashboard sections', 'jetpack-premium-analytics' ),
 				supportsPagination: false,
 			},
 		] );

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -28,7 +28,8 @@ function Dashboard(): JSX.Element {
 	const [ activeSection, setActiveSection ] = useActiveSection( sections );
 	const [ layout, setLayout, resetLayout ] = useDashboardSectionLayout(
 		DASHBOARD_NAME,
-		activeSection
+		activeSection,
+		sections
 	);
 	const [ gridSettings ] = useDashboardGridSettings();
 

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -25,7 +25,7 @@ import styles from './stage.module.scss';
  */
 function Dashboard(): JSX.Element {
 	const sections = useDashboardSections();
-	const [ activeSection, setActiveSection ] = useActiveSection();
+	const [ activeSection, setActiveSection ] = useActiveSection( sections );
 	const [ layout, setLayout, resetLayout ] = useDashboardSectionLayout(
 		DASHBOARD_NAME,
 		activeSection
@@ -105,8 +105,12 @@ function Dashboard(): JSX.Element {
 							<DateFiltersPanel { ...dateFilters } containerElement={ containerElement } />
 						</div>
 						{ sections.map( section => (
-							<SectionTabPanel key={ section.id } value={ section.id } className={ styles.content }>
-								{ activeSection === section.id ? (
+							<SectionTabPanel
+								key={ section.slug }
+								value={ section.slug }
+								className={ styles.content }
+							>
+								{ activeSection === section.slug ? (
 									<>
 										<WidgetDashboard.NoWidgetsState />
 										<WidgetDashboard.Widgets />

--- a/projects/packages/premium-analytics/src/class-dashboard-section.php
+++ b/projects/packages/premium-analytics/src/class-dashboard-section.php
@@ -126,10 +126,11 @@ final class Dashboard_Section {
 	 */
 	public function to_array() {
 		return array(
-			'id'    => $this->id,
-			'slug'  => $this->slug,
-			'label' => $this->label,
-			'order' => (int) $this->order,
+			'id'             => $this->id,
+			'slug'           => $this->slug,
+			'label'          => $this->label,
+			'order'          => (int) $this->order,
+			'default_layout' => $this->get_default_layout(),
 		);
 	}
 

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
@@ -226,6 +226,20 @@ class Dashboard_Section_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Section to_array() carries its default layout.
+	 */
+	public function test_to_array_includes_default_layout() {
+		register_default_dashboard_sections();
+
+		$traffic = get_registered_dashboard_section( DASHBOARD_NAME, 'analytics/traffic' );
+		$data    = $traffic->to_array();
+
+		$this->assertArrayHasKey( 'default_layout', $data );
+		$this->assertSame( $traffic->get_default_layout(), $data['default_layout'] );
+		$this->assertNotEmpty( $data['default_layout'] );
+	}
+
+	/**
 	 * Dashboard names can omit underscores when they match the REST route grammar.
 	 */
 	public function test_accepts_dashboard_names_without_underscores() {
@@ -251,10 +265,11 @@ class Dashboard_Section_Test extends BaseTestCase {
 		$this->assertSame(
 			array(
 				array(
-					'id'    => 'analytics/traffic',
-					'slug'  => 'traffic',
-					'label' => 'Traffic',
-					'order' => 10,
+					'id'             => 'analytics/traffic',
+					'slug'           => 'traffic',
+					'label'          => 'Traffic',
+					'order'          => 10,
+					'default_layout' => array(),
 				),
 			),
 			$response->get_data()
@@ -385,7 +400,12 @@ class Dashboard_Section_Test extends BaseTestCase {
 			),
 			array_map(
 				static function ( Dashboard_Section $section ) {
-					return $section->to_array();
+					// Assert on the metadata shape here; the default layout is
+					// covered by test_to_array_includes_default_layout().
+					$data = $section->to_array();
+					unset( $data['default_layout'] );
+
+					return $data;
 				},
 				get_available_dashboard_sections( DASHBOARD_NAME )
 			)
@@ -507,16 +527,18 @@ class Dashboard_Section_Test extends BaseTestCase {
 		$this->assertSame(
 			array(
 				array(
-					'id'    => 'example/first',
-					'slug'  => 'first',
-					'label' => 'First',
-					'order' => 10,
+					'id'             => 'example/first',
+					'slug'           => 'first',
+					'label'          => 'First',
+					'order'          => 10,
+					'default_layout' => array(),
 				),
 				array(
-					'id'    => 'example/later',
-					'slug'  => 'later',
-					'label' => 'Later',
-					'order' => 20,
+					'id'             => 'example/later',
+					'slug'           => 'later',
+					'label'          => 'Later',
+					'order'          => 20,
+					'default_layout' => array(),
 				),
 			),
 			$response->get_data()
@@ -558,9 +580,9 @@ class Dashboard_Section_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Sections route responses carry definition fields only.
+	 * Sections route responses carry the definition fields and the default layout.
 	 */
-	public function test_sections_route_returns_lean_section_shape() {
+	public function test_sections_route_returns_section_shape() {
 		register_dashboard_section(
 			'route_sections_dashboard',
 			'analytics/traffic',
@@ -586,10 +608,16 @@ class Dashboard_Section_Test extends BaseTestCase {
 		$this->assertSame(
 			array(
 				array(
-					'id'    => 'analytics/traffic',
-					'slug'  => 'traffic',
-					'label' => 'Traffic',
-					'order' => 10,
+					'id'             => 'analytics/traffic',
+					'slug'           => 'traffic',
+					'label'          => 'Traffic',
+					'order'          => 10,
+					'default_layout' => array(
+						array(
+							'uuid' => 'default-route-widget',
+							'type' => 'example/widget',
+						),
+					),
 				),
 			),
 			$response->get_data()

--- a/projects/packages/premium-analytics/widgets/hello-world/stories/dashboard-sections-grid.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/hello-world/stories/dashboard-sections-grid.stories.tsx
@@ -2,7 +2,6 @@ import { useState } from '@wordpress/element';
 import { Tabs } from '@wordpress/ui';
 import { WidgetDashboard, type DashboardWidget } from '@wordpress/widget-dashboard';
 import { DashboardSections } from '../../../routes/dashboard/components';
-import { DEFAULT_SECTION_ID, getDashboardSections } from '../../../routes/dashboard/config';
 import styles from '../../../routes/dashboard/stage.module.scss';
 import type { Meta, StoryObj } from '@storybook/react';
 import type {
@@ -92,14 +91,29 @@ const resolveWidgetModule: ResolveWidgetModule = moduleId =>
 		? Promise.resolve( { default: StoryWidget } )
 		: Promise.reject( new Error( `Unknown story widget module: ${ moduleId }` ) );
 
+// In product the section list is server-driven (the dashboardSection entity);
+// the story pins a static list mirroring that response shape.
+const storySections = [
+	{ id: 'analytics/traffic', slug: 'traffic', label: 'Traffic', order: 10, default_layout: [] },
+	{ id: 'analytics/insights', slug: 'insights', label: 'Insights', order: 20, default_layout: [] },
+	{
+		id: 'analytics/subscribers',
+		slug: 'subscribers',
+		label: 'Subscribers',
+		order: 30,
+		default_layout: [],
+	},
+	{ id: 'woocommerce/store', slug: 'store', label: 'Store', order: 40, default_layout: [] },
+];
+
 /**
  * Story showing the dashboard section panel scroll surface around a widget grid.
  *
  * @return Story component.
  */
 function DashboardSectionsGridStory() {
-	const sections = getDashboardSections();
-	const [ activeSection, setActiveSection ] = useState( DEFAULT_SECTION_ID );
+	const sections = storySections;
+	const [ activeSection, setActiveSection ] = useState( sections[ 0 ].slug );
 	const [ layout, setLayout ] = useState< DashboardWidget[] >( initialLayout );
 
 	return (
@@ -131,8 +145,8 @@ function DashboardSectionsGridStory() {
 				onChange={ setActiveSection }
 			>
 				{ sections.map( section => (
-					<Tabs.Panel key={ section.id } value={ section.id } className={ styles.content }>
-						{ activeSection === section.id ? (
+					<Tabs.Panel key={ section.slug } value={ section.slug } className={ styles.content }>
+						{ activeSection === section.slug ? (
 							<WidgetDashboard
 								widgetTypes={ widgetTypes }
 								layout={ layout }


### PR DESCRIPTION
## What?

Alternative approach for wiring the dashboard section tab bar to the server-side registry. Instead of a bespoke `apiFetch` + `useState`/`useEffect` hook with a script-data preload, this models the sections as a `@wordpress/core-data` custom entity (`dashboardSection`) read through `getEntityRecords`, the same way the dashboard already reads `widgetModule`, `site`, and `settings`.

It builds on the existing server-side section registry and:

- Embeds each section's `default_layout` in the `/sections` REST shape.
- Registers the `dashboardSection` entity in the route's `beforeLoad`.
- Reads the section list from the entity in `useDashboardSections`.
- Validates `?section=` against the live list, rewriting the URL on a miss.
- Resets a section's layout from the record's `default_layout` (a local store write, no request).

## Why?

The package already treats server resources as core-data entities (`widgetModule`, `site`, `settings`). Fetching sections with a raw `apiFetch` hook leaves the same `Dashboard` component with two data-access styles.

It also reimplements caching, dedup, and loading state that the store gives for free.

As an entity, data access stays in one place: `getEntityRecords`, no `apiFetch` in the UI. Reset reads the default from the record instead of hitting the dashboard-level endpoint through the slug alias table.

The frontend also stays agnostic to the section set: adding a section is server-side only (`register_dashboard_section`), no JS change.

This follows the Next Admin data-layer direction (pgle0O-ID-p2): rely on core-data entities, and reconsider `api-fetch` used directly or inline data passed via server-rendered scripts.

Trade-off: embedding `default_layout` in `/sections` makes the response no longer definition-only, so the reset needs no request.

## How?

Six atomic commits, server first: embed the default in `to_array()`, register the entity, read from it, reset from the record, then update the JS and PHP tests.

No preload in this PR: the entity resolver fetches `/sections` once on first render. A preload can follow as a separate step, using the canonical apiFetch preloading middleware rather than a manual store prime.

## Testing

1. Build the package (`pnpm run build`) and open the dashboard.
2. Tabs load from the server; the Store tab appears only with WooCommerce active.
3. Deep-link `?section=<slug>`: a valid slug is kept; a stale or unavailable one falls back to the first section and rewrites the URL.
4. In edit mode, customize a section and use reset: it restores the section default with no network request.
5. `pnpm test -- config/sections.test` and `composer phpunit -- --filter Dashboard_Section_Test` pass.

## Follow-ups

- [ ] Optional preload via the canonical apiFetch preloading middleware if the first-paint flash matters.
- [ ] Hook tests for `useActiveSection` (URL rewrite) and the reset action.

---

Draft: alternative approach to the sections-frontend PR, opened to compare the core-data entity direction against the `apiFetch` + preload one.