### PR TITLE
ci: Improve GitHub concurrency for E2E runs

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -16,7 +16,7 @@ on:
 
 concurrency:
   # wp_version keeps concurrent dispatches for different WordPress versions from cancelling each other.
-  group: e2e-tests-${{ github.event_name }}-${{ github.ref }}-${{ github.event.action }}-${{ inputs.wp_version }}
+  group: e2e-tests-${{ github.event_name }}-${{ github.ref }}-${{ case( github.event_name == 'repository_dispatch', github.event.action, '' ) }}-${{ inputs.wp_version }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
It seems that #27384 added `github.event.action` to the concurrency group for `repository_dispatch` events. But this also had the side effect that, on PRs, the run for "opened" would not be cancelled by the run for "synchronize".

Since the action is only needed for `repository_dispatch`, let's only use it for that event.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* [x] https://github.com/Automattic/jetpack/actions/runs/29928609867
