### PR TITLE
Subscribers dashboard: auto-refresh the list and report the outcome when an import completes

### DIFF
--- a/projects/packages/newsletter/_inc/subscribers/components/subscribers-body.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/subscribers-body.tsx
@@ -33,28 +33,30 @@ type RenderProps = {
  * between tab changes — re-mounting per route would reset it).
  *
  * @param props                      - Props.
- * @param props.canManageSubscribers - Whether this visitor can import (connected + feature
- *                                   enabled); gates the import-completion poll so gated and
- *                                   Settings-only loads don't hit the WP.com import endpoint.
+ * @param props.importRefreshEnabled - Whether to run the import-completion poll: true only when the
+ *                                   visitor can import (connected + feature enabled) AND the
+ *                                   Subscribers tab is active. This shell stays mounted on every
+ *                                   Newsletter page load, so the flag keeps the WP.com import
+ *                                   endpoint from being polled off the Subscribers surface.
  * @param props.children             - Render-prop receiving `{ body, actions }` so the
  *                                   caller decides how to slot them into the page.
  * @return Whatever `children` returns.
  */
 export default function SubscribersBody( {
-	canManageSubscribers,
+	importRefreshEnabled,
 	children,
 }: {
-	canManageSubscribers: boolean;
+	importRefreshEnabled: boolean;
 	children: ( props: RenderProps ) => ReactNode;
 } ): JSX.Element {
 	const blogId = useMemo( () => getBlogId(), [] );
 
-	// Refresh the list when an async import job finishes — the poll lives here (not in the modal)
-	// so it survives the Add Subscribers modal closing right after a submit. Gated on whether this
-	// visitor can actually import (connected + feature enabled): this shell mounts on every
-	// Newsletter page load, so an ungated poll would hit the WP.com import endpoint on the Settings
-	// tab, for connection-gated users, and on Settings-only sites.
-	useImportCompletionRefresh( canManageSubscribers );
+	// Refresh the list when an async import job finishes — the poll lives here (not in the modal) so
+	// it survives the Add Subscribers modal closing right after a submit (the user stays on the
+	// Subscribers tab). The caller gates it to the Subscribers tab of an import-capable visitor, so
+	// this always-mounted shell doesn't poll the WP.com import endpoint on the Settings tab, for
+	// connection-gated users, or on Settings-only sites.
+	useImportCompletionRefresh( importRefreshEnabled );
 
 	const [ isAddOpen, setAddOpen ] = useState( false );
 	const openAdd = useCallback( () => setAddOpen( true ), [] );

--- a/projects/packages/newsletter/_inc/subscribers/components/subscribers-body.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/subscribers-body.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { useNavigate, useSearch } from '@wordpress/route';
+import { useImportCompletionRefresh } from '../data/use-import-completion-refresh';
 import { installDataViewsFooterI18n } from '../lib/dataviews-i18n';
 import { getBlogId } from '../lib/site';
 import { isOpenSubscriberRemoved, toFiniteNumber } from '../lib/subscriber-helpers';
@@ -42,6 +43,11 @@ export default function SubscribersBody( {
 	children: ( props: RenderProps ) => ReactNode;
 } ): JSX.Element {
 	const blogId = useMemo( () => getBlogId(), [] );
+
+	// Refresh the list when an async import job finishes — the poll lives here (not in the modal)
+	// so it survives the Add Subscribers modal closing right after a submit.
+	useImportCompletionRefresh();
+
 	const [ isAddOpen, setAddOpen ] = useState( false );
 	const openAdd = useCallback( () => setAddOpen( true ), [] );
 	const closeAdd = useCallback( () => setAddOpen( false ), [] );

--- a/projects/packages/newsletter/_inc/subscribers/components/subscribers-body.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/subscribers-body.tsx
@@ -32,21 +32,29 @@ type RenderProps = {
  * (the `Tabs.Root` indicator slides only when the tab control persists
  * between tab changes — re-mounting per route would reset it).
  *
- * @param props          - Props.
- * @param props.children - Render-prop receiving `{ body, actions }` so the
- *                       caller decides how to slot them into the page.
+ * @param props                      - Props.
+ * @param props.canManageSubscribers - Whether this visitor can import (connected + feature
+ *                                   enabled); gates the import-completion poll so gated and
+ *                                   Settings-only loads don't hit the WP.com import endpoint.
+ * @param props.children             - Render-prop receiving `{ body, actions }` so the
+ *                                   caller decides how to slot them into the page.
  * @return Whatever `children` returns.
  */
 export default function SubscribersBody( {
+	canManageSubscribers,
 	children,
 }: {
+	canManageSubscribers: boolean;
 	children: ( props: RenderProps ) => ReactNode;
 } ): JSX.Element {
 	const blogId = useMemo( () => getBlogId(), [] );
 
 	// Refresh the list when an async import job finishes — the poll lives here (not in the modal)
-	// so it survives the Add Subscribers modal closing right after a submit.
-	useImportCompletionRefresh();
+	// so it survives the Add Subscribers modal closing right after a submit. Gated on whether this
+	// visitor can actually import (connected + feature enabled): this shell mounts on every
+	// Newsletter page load, so an ungated poll would hit the WP.com import endpoint on the Settings
+	// tab, for connection-gated users, and on Settings-only sites.
+	useImportCompletionRefresh( canManageSubscribers );
 
 	const [ isAddOpen, setAddOpen ] = useState( false );
 	const openAdd = useCallback( () => setAddOpen( true ), [] );

--- a/projects/packages/newsletter/_inc/subscribers/data/types.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/types.ts
@@ -104,13 +104,26 @@ export type AddSubscribersResponse = {
 	[ key: string ]: unknown;
 };
 
-export type ImportJobStatus = 'pending' | 'importing' | 'imported' | 'failed' | 'cancelled';
+export type ImportJobStatus =
+	| 'pending'
+	| 'awaiting'
+	| 'importing'
+	| 'imported'
+	| 'failed'
+	| 'cancelled';
 
 export type ImportJob = {
 	id: number;
 	status: ImportJobStatus;
 	// WP.com sends counts as numeric strings (e.g. `"1"`).
 	email_count?: number | string;
+	// Per-outcome counts, populated once the job reaches a terminal state. Same numeric-string
+	// quirk as email_count. WP.com does not return a human-readable failure reason on the job — the
+	// per-email reasons only go to the import confirmation email — so these counts are all the
+	// dashboard has to describe the outcome.
+	subscribed_count?: number | string;
+	already_subscribed_count?: number | string;
+	failed_subscribed_count?: number | string;
 	scheduled_at?: string;
 	[ key: string ]: unknown;
 };

--- a/projects/packages/newsletter/_inc/subscribers/data/use-add-subscribers-mutation.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/use-add-subscribers-mutation.ts
@@ -3,12 +3,16 @@ import { useDispatch } from '@wordpress/data';
 import { _n, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { addSubscribers } from './api';
+import { IMPORT_IN_PROGRESS_NOTICE_ID } from './use-import-jobs';
 import type { AddSubscribersResponse } from './types';
 
 /**
  * Add-subscribers mutation. POSTs `emails` to the proxy, which starts an async WP.com import
  * job, then invalidates the subscribers list cache. Fast imports show up on the refetch; larger
  * ones land once WP.com finishes the job and sends its "Subscriber import completed" email.
+ *
+ * The "Importing…" snackbar is created under {@link IMPORT_IN_PROGRESS_NOTICE_ID} so
+ * `useImportCompletionRefresh` can resolve it into a success / failure notice when the job ends.
  *
  * @return React-Query mutation handle.
  */
@@ -32,7 +36,7 @@ export function useAddSubscribersMutation() {
 					),
 					emails.length
 				),
-				{ type: 'snackbar' }
+				{ type: 'snackbar', id: IMPORT_IN_PROGRESS_NOTICE_ID }
 			);
 		},
 		onError: error => {

--- a/projects/packages/newsletter/_inc/subscribers/data/use-import-completion-refresh.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/use-import-completion-refresh.ts
@@ -42,14 +42,16 @@ export function describeImportOutcome( job: ImportJob ): OutcomeNotice | null {
 
 	if ( failed > 0 ) {
 		// Some addresses were rejected (bounced, blocked, invalid). Most succeeded, so keep it a
-		// success notice but surface the shortfall.
+		// success notice but surface the shortfall. The trailing clause is noun-free
+		// ("%2$d couldn't be added") so it reads correctly for any count — a single _n can only
+		// pluralize on one number, and that one is the imported count.
 		return {
 			status: 'success',
 			message: sprintf(
 				// translators: %1$d: subscribers imported. %2$d: email addresses that couldn't be added.
 				_n(
-					'Imported %1$d subscriber. %2$d email address couldn’t be added — check your import confirmation email for details.',
-					'Imported %1$d subscribers. %2$d email addresses couldn’t be added — check your import confirmation email for details.',
+					'Imported %1$d subscriber. %2$d couldn’t be added — check your import confirmation email for details.',
+					'Imported %1$d subscribers. %2$d couldn’t be added — check your import confirmation email for details.',
 					subscribed,
 					'jetpack-newsletter'
 				),

--- a/projects/packages/newsletter/_inc/subscribers/data/use-import-completion-refresh.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/use-import-completion-refresh.ts
@@ -46,10 +46,10 @@ export function describeImportOutcome( job: ImportJob ): OutcomeNotice | null {
 		return {
 			status: 'success',
 			message: sprintf(
-				// translators: %1$d: subscribers imported. %2$d: addresses that couldn't be added.
+				// translators: %1$d: subscribers imported. %2$d: email addresses that couldn't be added.
 				_n(
-					'Imported %1$d subscriber. %2$d address couldn’t be added — check your import confirmation email for details.',
-					'Imported %1$d subscribers. %2$d addresses couldn’t be added — check your import confirmation email for details.',
+					'Imported %1$d subscriber. %2$d email address couldn’t be added — check your import confirmation email for details.',
+					'Imported %1$d subscribers. %2$d email addresses couldn’t be added — check your import confirmation email for details.',
 					subscribed,
 					'jetpack-newsletter'
 				),
@@ -79,10 +79,10 @@ export function describeImportOutcome( job: ImportJob ): OutcomeNotice | null {
 		return {
 			status: 'success',
 			message: sprintf(
-				// translators: %d: number of addresses that were already subscribed.
+				// translators: %d: number of email addresses that were already subscribed.
 				_n(
-					'%d address was already subscribed.',
-					'%d addresses were already subscribed.',
+					'%d email address is already subscribed.',
+					'%d email addresses are already subscribed.',
 					already,
 					'jetpack-newsletter'
 				),

--- a/projects/packages/newsletter/_inc/subscribers/data/use-import-completion-refresh.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/use-import-completion-refresh.ts
@@ -144,13 +144,14 @@ export function describeImportOutcome( job: ImportJob ): OutcomeNotice | null {
  * "already announced" so old imports aren't re-announced on every visit. Mount once, near the top of
  * the subscribers dashboard.
  *
- * @param enabled - Whether to run at all. Gate this on the subscribers feature actually being
- *                usable by this visitor (connected + feature enabled): the dashboard shell mounts
- *                on every Newsletter page load — including the Settings tab, connection-gated users,
- *                and Settings-only sites — and without this gate each of those would poll the WP.com
- *                import endpoint (a 401/403 + retries for unconnected users). Pass `true` while the
- *                poll should stay alive even across tab changes, so an in-flight import still
- *                resolves if the user flips to Settings mid-import.
+ * @param enabled - Whether to run at all. Gate this on the subscribers feature being usable by this
+ *                visitor (connected + feature enabled) AND the Subscribers tab being active: the
+ *                dashboard shell mounts on every Newsletter page load — including the Settings tab,
+ *                connection-gated users, and Settings-only sites — and without this gate each of
+ *                those would poll the WP.com import endpoint (a 401/403 + retries for unconnected
+ *                users). An import started on the Subscribers tab keeps polling once the modal
+ *                closes (the user stays on the tab); if they leave for Settings mid-import it
+ *                resolves when they return — the list only matters on the Subscribers tab anyway.
  */
 export function useImportCompletionRefresh( enabled: boolean ): void {
 	const queryClient = useQueryClient();

--- a/projects/packages/newsletter/_inc/subscribers/data/use-import-completion-refresh.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/use-import-completion-refresh.ts
@@ -5,23 +5,115 @@ import { __, _n, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { toFiniteNumber } from '../lib/subscriber-helpers';
 import { IMPORT_IN_PROGRESS_NOTICE_ID, isJobInProgress, useImportJobs } from './use-import-jobs';
+import type { ImportJob } from './types';
+
+type OutcomeNotice = { status: 'success' | 'error'; message: string };
 
 /**
- * Refreshes the subscribers list when a running import finishes, and resolves the "Importing…"
- * snackbar into a final status.
+ * Map a finished import job to the snackbar it should show, or null when it shouldn't show one
+ * (e.g. a user-cancelled reset). WP.com returns no human-readable failure reason on the job — only
+ * outcome counts — so the copy is built from those counts and points at the import confirmation
+ * email for the per-address detail. Note that "already subscribed" is a successful no-op on WP.com's
+ * side (status `imported`, not `failed`), so it gets its own success message rather than an error.
+ *
+ * @param job - The import job that just reached a terminal state.
+ * @return The notice to show, or null for no notice.
+ */
+export function describeImportOutcome( job: ImportJob ): OutcomeNotice | null {
+	if ( job.status === 'failed' ) {
+		return {
+			status: 'error',
+			message: __(
+				'We couldn’t import your subscribers. Check your import confirmation email for details, then try again.',
+				'jetpack-newsletter'
+			),
+		};
+	}
+
+	// Only `imported` carries a reportable outcome; `cancelled` (and any unexpected terminal state)
+	// is silent.
+	if ( job.status !== 'imported' ) {
+		return null;
+	}
+
+	const subscribed = toFiniteNumber( job.subscribed_count ) ?? 0;
+	const already = toFiniteNumber( job.already_subscribed_count ) ?? 0;
+	const failed = toFiniteNumber( job.failed_subscribed_count ) ?? 0;
+
+	if ( failed > 0 ) {
+		// Some addresses were rejected (bounced, blocked, invalid). Most succeeded, so keep it a
+		// success notice but surface the shortfall.
+		return {
+			status: 'success',
+			message: sprintf(
+				// translators: %1$d: subscribers imported. %2$d: addresses that couldn't be added.
+				_n(
+					'Imported %1$d subscriber. %2$d address couldn’t be added — check your import confirmation email for details.',
+					'Imported %1$d subscribers. %2$d addresses couldn’t be added — check your import confirmation email for details.',
+					subscribed,
+					'jetpack-newsletter'
+				),
+				subscribed,
+				failed
+			),
+		};
+	}
+
+	if ( subscribed > 0 ) {
+		return {
+			status: 'success',
+			message: sprintf(
+				// translators: %d: number of subscribers imported.
+				_n(
+					'%d subscriber imported.',
+					'%d subscribers imported.',
+					subscribed,
+					'jetpack-newsletter'
+				),
+				subscribed
+			),
+		};
+	}
+
+	if ( already > 0 ) {
+		return {
+			status: 'success',
+			message: sprintf(
+				// translators: %d: number of addresses that were already subscribed.
+				_n(
+					'%d address was already subscribed.',
+					'%d addresses were already subscribed.',
+					already,
+					'jetpack-newsletter'
+				),
+				already
+			),
+		};
+	}
+
+	return {
+		status: 'success',
+		message: __( 'Your subscribers have been imported.', 'jetpack-newsletter' ),
+	};
+}
+
+/**
+ * Refreshes the subscribers list when an import finishes, and resolves the "Importing…" snackbar
+ * into a final status.
  *
  * Adding subscribers starts an async WP.com import job. The add mutation invalidates the list
  * immediately, but the job usually hasn't processed the emails yet, so that first refetch returns
  * the pre-import list — and the "Add subscribers" modal closes right after submitting, which would
  * otherwise stop the import-jobs poll before the job lands. This watcher keeps that poll alive at
- * the dashboard level and, on the in-progress → done transition, invalidates the `subscribers`
- * cache (so freshly imported subscribers appear without a manual reload) and swaps the stale
+ * the dashboard level, and announces each import as it reaches a terminal state: it refreshes the
+ * `subscribers` cache (so imported subscribers appear without a manual reload) and swaps the stale
  * "Importing…" notice for a success / failure snackbar.
  *
- * The completion snackbar is built from the job's outcome counts because WP.com does not return a
- * human-readable failure reason on the import job — the per-email reasons only reach the user via
- * the import confirmation email — so counts (imported vs. couldn't-be-added) are the most specific
- * feedback the dashboard can give. Mount once, near the top of the subscribers dashboard.
+ * Announcements are keyed by job id, not by watching for an in-progress → done transition — a small
+ * or already-subscribed import can finish before any poll observes it running, and id-based
+ * detection still catches those. Jobs already finished when the dashboard loads are recorded as
+ * "already announced" so old imports aren't re-announced on every visit. Mount once, near the top of
+ * the subscribers dashboard.
  */
 export function useImportCompletionRefresh(): void {
 	const queryClient = useQueryClient();
@@ -30,72 +122,47 @@ export function useImportCompletionRefresh(): void {
 	// `useImportJobs( isOpen )` — React Query dedupes both to a single query by key). The query only
 	// polls the network while a job is actually in progress, so an idle dashboard makes one request.
 	const { data } = useImportJobs( true );
-	const wasInProgress = useRef( false );
 
-	// Newest first, so `jobs[ 0 ]` is the import that just finished on the falling edge. Memoized so
-	// the effect below doesn't re-run on every render off a fresh `[]` fallback.
+	const announced = useRef< Set< number > >( new Set() );
+	const seeded = useRef( false );
+
 	const jobs = useMemo( () => data ?? [], [ data ] );
-	const inProgress = jobs.some( isJobInProgress );
 
 	useEffect( () => {
-		// Falling edge only: a job we saw running is no longer running. Invalidating on mount or
-		// while still running would refetch needlessly (and the mutation already invalidates once
-		// up front for imports fast enough to land on the first refetch).
-		if ( wasInProgress.current && ! inProgress ) {
-			queryClient.invalidateQueries( { queryKey: [ 'subscribers' ] } );
-
-			// Replace the fire-and-forget "Importing…" snackbar with the real outcome. `cancelled`
-			// is a user-initiated reset, not a failure, so it gets no notice.
-			removeNotice( IMPORT_IN_PROGRESS_NOTICE_ID );
-			const finished = jobs[ 0 ];
-			const status = finished?.status;
-			const subscribed = toFiniteNumber( finished?.subscribed_count ) ?? 0;
-			const failed = toFiniteNumber( finished?.failed_subscribed_count ) ?? 0;
-
-			if ( status === 'imported' && failed > 0 ) {
-				// Partial import — most succeeded, so keep it a success notice, but surface the
-				// shortfall. The job carries only the count, not which addresses or why, so point
-				// at the confirmation email.
-				createSuccessNotice(
-					sprintf(
-						// translators: %1$d: subscribers imported. %2$d: addresses that couldn't be added.
-						_n(
-							'Imported %1$d subscriber. %2$d address couldn’t be added — check your import confirmation email for details.',
-							'Imported %1$d subscribers. %2$d addresses couldn’t be added — check your import confirmation email for details.',
-							subscribed,
-							'jetpack-newsletter'
-						),
-						subscribed,
-						failed
-					),
-					{ type: 'snackbar' }
-				);
-			} else if ( status === 'imported' ) {
-				createSuccessNotice(
-					subscribed > 0
-						? sprintf(
-								// translators: %d: number of subscribers imported.
-								_n(
-									'%d subscriber imported.',
-									'%d subscribers imported.',
-									subscribed,
-									'jetpack-newsletter'
-								),
-								subscribed
-						  )
-						: __( 'Your subscribers have been imported.', 'jetpack-newsletter' ),
-					{ type: 'snackbar' }
-				);
-			} else if ( status === 'failed' ) {
-				createErrorNotice(
-					__(
-						'We couldn’t import your subscribers. Check your import confirmation email for details, then try again.',
-						'jetpack-newsletter'
-					),
-					{ type: 'snackbar' }
-				);
-			}
+		// Wait for the first real payload before seeding — `undefined` is the initial loading state.
+		if ( data === undefined ) {
+			return;
 		}
-		wasInProgress.current = inProgress;
-	}, [ inProgress, jobs, queryClient, createSuccessNotice, createErrorNotice, removeNotice ] );
+
+		// Seed once: anything already finished when the dashboard loaded predates this session, so
+		// mark it announced and don't surface it. Jobs still running at load time are left unseeded
+		// so we announce them when they finish.
+		if ( ! seeded.current ) {
+			seeded.current = true;
+			for ( const job of jobs ) {
+				if ( ! isJobInProgress( job ) ) {
+					announced.current.add( job.id );
+				}
+			}
+			return;
+		}
+
+		// One import runs per site at a time, so the newest job is the one to report. Announce it
+		// once it reaches a terminal state we haven't reported yet.
+		const newest = jobs[ 0 ];
+		if ( ! newest || isJobInProgress( newest ) || announced.current.has( newest.id ) ) {
+			return;
+		}
+		announced.current.add( newest.id );
+
+		queryClient.invalidateQueries( { queryKey: [ 'subscribers' ] } );
+		removeNotice( IMPORT_IN_PROGRESS_NOTICE_ID );
+
+		const outcome = describeImportOutcome( newest );
+		if ( outcome?.status === 'success' ) {
+			createSuccessNotice( outcome.message, { type: 'snackbar' } );
+		} else if ( outcome?.status === 'error' ) {
+			createErrorNotice( outcome.message, { type: 'snackbar' } );
+		}
+	}, [ data, jobs, queryClient, createSuccessNotice, createErrorNotice, removeNotice ] );
 }

--- a/projects/packages/newsletter/_inc/subscribers/data/use-import-completion-refresh.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/use-import-completion-refresh.ts
@@ -45,6 +45,12 @@ export function describeImportOutcome( job: ImportJob ): OutcomeNotice | null {
 		// success notice but surface the shortfall. The trailing clause is noun-free
 		// ("%2$d couldn't be added") so it reads correctly for any count — a single _n can only
 		// pluralize on one number, and that one is the imported count.
+		//
+		// This branch intentionally takes precedence over the already-subscribed cases below: a
+		// batch that is partly rejected AND partly already-subscribed reports only the rejections,
+		// since "couldn't be added" is the actionable signal (points at the confirmation email) and
+		// already-subscribed is a benign no-op. The copy never claims a total, so omitting the
+		// duplicate count reads as incomplete, not wrong — and a three-count snackbar would be worse.
 		return {
 			status: 'success',
 			message: sprintf(
@@ -137,14 +143,23 @@ export function describeImportOutcome( job: ImportJob ): OutcomeNotice | null {
  * detection still catches those. Jobs already finished when the dashboard loads are recorded as
  * "already announced" so old imports aren't re-announced on every visit. Mount once, near the top of
  * the subscribers dashboard.
+ *
+ * @param enabled - Whether to run at all. Gate this on the subscribers feature actually being
+ *                usable by this visitor (connected + feature enabled): the dashboard shell mounts
+ *                on every Newsletter page load — including the Settings tab, connection-gated users,
+ *                and Settings-only sites — and without this gate each of those would poll the WP.com
+ *                import endpoint (a 401/403 + retries for unconnected users). Pass `true` while the
+ *                poll should stay alive even across tab changes, so an in-flight import still
+ *                resolves if the user flips to Settings mid-import.
  */
-export function useImportCompletionRefresh(): void {
+export function useImportCompletionRefresh( enabled: boolean ): void {
 	const queryClient = useQueryClient();
 	const { createSuccessNotice, createErrorNotice, removeNotice } = useDispatch( noticesStore );
-	// Always enabled so the poll outlives the Add Subscribers modal (which mounts its own
-	// `useImportJobs( isOpen )` — React Query dedupes both to a single query by key). The query only
-	// polls the network while a job is actually in progress, so an idle dashboard makes one request.
-	const { data } = useImportJobs( true );
+	// Enabled only when the visitor can actually import; see the `enabled` param note. The query
+	// outlives the Add Subscribers modal (which mounts its own `useImportJobs( isOpen )` — React
+	// Query dedupes both to a single query by key), and only polls the network while a job is
+	// actually in progress, so an idle dashboard makes one request.
+	const { data } = useImportJobs( enabled );
 
 	const announced = useRef< Set< number > >( new Set() );
 	const seeded = useRef( false );

--- a/projects/packages/newsletter/_inc/subscribers/data/use-import-completion-refresh.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/use-import-completion-refresh.ts
@@ -1,0 +1,35 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useRef } from '@wordpress/element';
+import { isJobInProgress, useImportJobs } from './use-import-jobs';
+
+/**
+ * Refreshes the subscribers list when a running import finishes.
+ *
+ * Adding subscribers starts an async WP.com import job. The add mutation invalidates the list
+ * immediately, but the job usually hasn't processed the emails yet, so that first refetch returns
+ * the pre-import list — and the "Add subscribers" modal closes right after submitting, which would
+ * otherwise stop the import-jobs poll before the job lands. This watcher keeps that poll alive at
+ * the dashboard level and invalidates the `subscribers` cache on the in-progress → done transition,
+ * so freshly imported subscribers appear without a manual page reload. Mount once, near the top of
+ * the subscribers dashboard.
+ */
+export function useImportCompletionRefresh(): void {
+	const queryClient = useQueryClient();
+	// Always enabled so the poll outlives the Add Subscribers modal (which mounts its own
+	// `useImportJobs( isOpen )` — React Query dedupes both to a single query by key). The query only
+	// polls the network while a job is actually in progress, so an idle dashboard makes one request.
+	const { data } = useImportJobs( true );
+	const wasInProgress = useRef( false );
+
+	const inProgress = ( data ?? [] ).some( isJobInProgress );
+
+	useEffect( () => {
+		// Falling edge only: a job we saw running is no longer running. Invalidating on mount or
+		// while still running would refetch needlessly (and the mutation already invalidates once
+		// up front for imports fast enough to land on the first refetch).
+		if ( wasInProgress.current && ! inProgress ) {
+			queryClient.invalidateQueries( { queryKey: [ 'subscribers' ] } );
+		}
+		wasInProgress.current = inProgress;
+	}, [ inProgress, queryClient ] );
+}

--- a/projects/packages/newsletter/_inc/subscribers/data/use-import-completion-refresh.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/use-import-completion-refresh.ts
@@ -1,27 +1,41 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { useEffect, useRef } from '@wordpress/element';
-import { isJobInProgress, useImportJobs } from './use-import-jobs';
+import { useDispatch } from '@wordpress/data';
+import { useEffect, useMemo, useRef } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+import { toFiniteNumber } from '../lib/subscriber-helpers';
+import { IMPORT_IN_PROGRESS_NOTICE_ID, isJobInProgress, useImportJobs } from './use-import-jobs';
 
 /**
- * Refreshes the subscribers list when a running import finishes.
+ * Refreshes the subscribers list when a running import finishes, and resolves the "Importing…"
+ * snackbar into a final status.
  *
  * Adding subscribers starts an async WP.com import job. The add mutation invalidates the list
  * immediately, but the job usually hasn't processed the emails yet, so that first refetch returns
  * the pre-import list — and the "Add subscribers" modal closes right after submitting, which would
  * otherwise stop the import-jobs poll before the job lands. This watcher keeps that poll alive at
- * the dashboard level and invalidates the `subscribers` cache on the in-progress → done transition,
- * so freshly imported subscribers appear without a manual page reload. Mount once, near the top of
- * the subscribers dashboard.
+ * the dashboard level and, on the in-progress → done transition, invalidates the `subscribers`
+ * cache (so freshly imported subscribers appear without a manual reload) and swaps the stale
+ * "Importing…" notice for a success / failure snackbar.
+ *
+ * The completion snackbar is built from the job's outcome counts because WP.com does not return a
+ * human-readable failure reason on the import job — the per-email reasons only reach the user via
+ * the import confirmation email — so counts (imported vs. couldn't-be-added) are the most specific
+ * feedback the dashboard can give. Mount once, near the top of the subscribers dashboard.
  */
 export function useImportCompletionRefresh(): void {
 	const queryClient = useQueryClient();
+	const { createSuccessNotice, createErrorNotice, removeNotice } = useDispatch( noticesStore );
 	// Always enabled so the poll outlives the Add Subscribers modal (which mounts its own
 	// `useImportJobs( isOpen )` — React Query dedupes both to a single query by key). The query only
 	// polls the network while a job is actually in progress, so an idle dashboard makes one request.
 	const { data } = useImportJobs( true );
 	const wasInProgress = useRef( false );
 
-	const inProgress = ( data ?? [] ).some( isJobInProgress );
+	// Newest first, so `jobs[ 0 ]` is the import that just finished on the falling edge. Memoized so
+	// the effect below doesn't re-run on every render off a fresh `[]` fallback.
+	const jobs = useMemo( () => data ?? [], [ data ] );
+	const inProgress = jobs.some( isJobInProgress );
 
 	useEffect( () => {
 		// Falling edge only: a job we saw running is no longer running. Invalidating on mount or
@@ -29,7 +43,58 @@ export function useImportCompletionRefresh(): void {
 		// up front for imports fast enough to land on the first refetch).
 		if ( wasInProgress.current && ! inProgress ) {
 			queryClient.invalidateQueries( { queryKey: [ 'subscribers' ] } );
+
+			// Replace the fire-and-forget "Importing…" snackbar with the real outcome. `cancelled`
+			// is a user-initiated reset, not a failure, so it gets no notice.
+			removeNotice( IMPORT_IN_PROGRESS_NOTICE_ID );
+			const finished = jobs[ 0 ];
+			const status = finished?.status;
+			const subscribed = toFiniteNumber( finished?.subscribed_count ) ?? 0;
+			const failed = toFiniteNumber( finished?.failed_subscribed_count ) ?? 0;
+
+			if ( status === 'imported' && failed > 0 ) {
+				// Partial import — some addresses were rejected (bounced, blocked, invalid). The
+				// job carries only the count, not which ones or why, so point at the email.
+				createErrorNotice(
+					sprintf(
+						// translators: %1$d: subscribers imported. %2$d: addresses that couldn't be added.
+						_n(
+							'Imported %1$d subscriber. %2$d address couldn’t be added — check your import confirmation email for details.',
+							'Imported %1$d subscribers. %2$d addresses couldn’t be added — check your import confirmation email for details.',
+							subscribed,
+							'jetpack-newsletter'
+						),
+						subscribed,
+						failed
+					),
+					{ type: 'snackbar' }
+				);
+			} else if ( status === 'imported' ) {
+				createSuccessNotice(
+					subscribed > 0
+						? sprintf(
+								// translators: %d: number of subscribers imported.
+								_n(
+									'%d subscriber imported.',
+									'%d subscribers imported.',
+									subscribed,
+									'jetpack-newsletter'
+								),
+								subscribed
+						  )
+						: __( 'Your subscribers have been imported.', 'jetpack-newsletter' ),
+					{ type: 'snackbar' }
+				);
+			} else if ( status === 'failed' ) {
+				createErrorNotice(
+					__(
+						'We couldn’t import your subscribers. Check your import confirmation email for details, then try again.',
+						'jetpack-newsletter'
+					),
+					{ type: 'snackbar' }
+				);
+			}
 		}
 		wasInProgress.current = inProgress;
-	}, [ inProgress, queryClient ] );
+	}, [ inProgress, jobs, queryClient, createSuccessNotice, createErrorNotice, removeNotice ] );
 }

--- a/projects/packages/newsletter/_inc/subscribers/data/use-import-completion-refresh.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/use-import-completion-refresh.ts
@@ -59,6 +59,27 @@ export function describeImportOutcome( job: ImportJob ): OutcomeNotice | null {
 		};
 	}
 
+	if ( subscribed > 0 && already > 0 ) {
+		// Mixed batch: some new, some already on the list. Already-subscribed isn't a failure, so
+		// this stays a success — it just also accounts for the skipped duplicates. The trailing
+		// clause is verb-free ("%2$d already subscribed") so it reads correctly for any count, since
+		// a single _n can only pluralize on one number.
+		return {
+			status: 'success',
+			message: sprintf(
+				// translators: %1$d: subscribers imported. %2$d: email addresses already subscribed.
+				_n(
+					'%1$d subscriber imported. %2$d already subscribed.',
+					'%1$d subscribers imported. %2$d already subscribed.',
+					subscribed,
+					'jetpack-newsletter'
+				),
+				subscribed,
+				already
+			),
+		};
+	}
+
 	if ( subscribed > 0 ) {
 		return {
 			status: 'success',

--- a/projects/packages/newsletter/_inc/subscribers/data/use-import-completion-refresh.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/use-import-completion-refresh.ts
@@ -53,9 +53,10 @@ export function useImportCompletionRefresh(): void {
 			const failed = toFiniteNumber( finished?.failed_subscribed_count ) ?? 0;
 
 			if ( status === 'imported' && failed > 0 ) {
-				// Partial import — some addresses were rejected (bounced, blocked, invalid). The
-				// job carries only the count, not which ones or why, so point at the email.
-				createErrorNotice(
+				// Partial import — most succeeded, so keep it a success notice, but surface the
+				// shortfall. The job carries only the count, not which addresses or why, so point
+				// at the confirmation email.
+				createSuccessNotice(
 					sprintf(
 						// translators: %1$d: subscribers imported. %2$d: addresses that couldn't be added.
 						_n(

--- a/projects/packages/newsletter/_inc/subscribers/data/use-import-jobs.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/use-import-jobs.ts
@@ -6,14 +6,24 @@ const DAY_IN_MS = 24 * 60 * 60 * 1000;
 const ACTIVE_POLL_INTERVAL_MS = 5000;
 
 /**
+ * Stable id for the "Importing…" snackbar. The add-subscribers mutation creates the notice under
+ * this id when it kicks off an import; `useImportCompletionRefresh` removes it (and replaces it with
+ * a success / failure notice) once the job reaches a terminal state, so the message tracks the
+ * import instead of the notice system's auto-dismiss timer.
+ */
+export const IMPORT_IN_PROGRESS_NOTICE_ID = 'jetpack-newsletter/subscribers-import-in-progress';
+
+/**
  * Whether an import job is still running. WP.com refuses to start a new import while any job is
- * in one of these states.
+ * in one of these states. `awaiting` is the gap between "enqueued" and "picked up by a worker" —
+ * still in-flight, so it must count as in progress or a poll landing mid-queue would read the job
+ * as finished.
  *
  * @param job - Import job.
- * @return Whether the job is pending or importing.
+ * @return Whether the job is pending, awaiting, or importing.
  */
 export function isJobInProgress( job: ImportJob ): boolean {
-	return job.status === 'pending' || job.status === 'importing';
+	return job.status === 'pending' || job.status === 'awaiting' || job.status === 'importing';
 }
 
 /**

--- a/projects/packages/newsletter/changelog/fix-nl-747-subscribers-import-refresh
+++ b/projects/packages/newsletter/changelog/fix-nl-747-subscribers-import-refresh
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Subscribers dashboard: refresh the subscriber list automatically once an import finishes, instead of requiring a manual page reload.

--- a/projects/packages/newsletter/changelog/fix-nl-747-subscribers-import-refresh
+++ b/projects/packages/newsletter/changelog/fix-nl-747-subscribers-import-refresh
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Subscribers dashboard: refresh the subscriber list automatically once an import finishes, instead of requiring a manual page reload.
+Subscribers dashboard: refresh the subscriber list automatically once an import finishes, and replace the "Importing…" notice with a success or failure message reporting the outcome, instead of requiring a manual page reload.

--- a/projects/packages/newsletter/routes/dashboard/stage.tsx
+++ b/projects/packages/newsletter/routes/dashboard/stage.tsx
@@ -114,7 +114,11 @@ const Stage = () => {
 
 	return (
 		<QueryClientProvider client={ queryClient }>
-			<SubscribersBody canManageSubscribers={ subscribersEnabled && canManageSubscribers }>
+			<SubscribersBody
+				importRefreshEnabled={
+					subscribersEnabled && canManageSubscribers && activeTab === 'subscribers'
+				}
+			>
 				{ ( { body, actions } ) => {
 					// Gate the Subscribers tab: connected visitors get the data view,
 					// everyone else gets the connect prompt.

--- a/projects/packages/newsletter/routes/dashboard/stage.tsx
+++ b/projects/packages/newsletter/routes/dashboard/stage.tsx
@@ -114,7 +114,7 @@ const Stage = () => {
 
 	return (
 		<QueryClientProvider client={ queryClient }>
-			<SubscribersBody>
+			<SubscribersBody canManageSubscribers={ subscribersEnabled && canManageSubscribers }>
 				{ ( { body, actions } ) => {
 					// Gate the Subscribers tab: connected visitors get the data view,
 					// everyone else gets the connect prompt.

--- a/projects/packages/newsletter/tests/import-job-helpers.test.ts
+++ b/projects/packages/newsletter/tests/import-job-helpers.test.ts
@@ -11,7 +11,7 @@ const job = ( overrides: Partial< ImportJob > ): ImportJob => ( {
 } );
 
 describe( 'isJobInProgress', () => {
-	it.each( [ 'pending', 'importing' ] as const )( 'is true for %s jobs', status => {
+	it.each( [ 'pending', 'awaiting', 'importing' ] as const )( 'is true for %s jobs', status => {
 		expect( isJobInProgress( job( { status } ) ) ).toBe( true );
 	} );
 

--- a/projects/packages/newsletter/tests/stage.test.tsx
+++ b/projects/packages/newsletter/tests/stage.test.tsx
@@ -53,14 +53,22 @@ jest.mock( '@wordpress/ui', () => ( {
 
 // SubscribersBody is a render-prop component; the Stage passes a function
 // that builds the panels. The mock invokes it with empty slot data so the
-// downstream render path is exercised without any data-views machinery.
+// downstream render path is exercised without any data-views machinery, and
+// records the `importRefreshEnabled` prop so we can assert the poll gating.
+let mockImportRefreshEnabled: boolean | undefined;
+
 jest.mock( '../_inc/subscribers/components/subscribers-body', () => ( {
 	__esModule: true,
 	default: ( {
+		importRefreshEnabled,
 		children,
 	}: {
+		importRefreshEnabled: boolean;
 		children: ( ctx: { body: React.ReactNode; actions: React.ReactNode } ) => React.ReactNode;
-	} ) => <>{ children( { body: <div data-testid="subscribers-body" />, actions: null } ) }</>,
+	} ) => {
+		mockImportRefreshEnabled = importRefreshEnabled;
+		return <>{ children( { body: <div data-testid="subscribers-body" />, actions: null } ) }</>;
+	},
 } ) );
 
 jest.mock( '../_inc/subscribers/components/connection-gate', () => ( {
@@ -116,7 +124,17 @@ beforeEach( () => {
 		userIsConnecting: false,
 		handleRegisterSite: jest.fn(),
 	} );
+	mockImportRefreshEnabled = undefined;
 } );
+
+const connected = {
+	isRegistered: true,
+	hasConnectedOwner: true,
+	isUserConnected: true,
+	siteIsRegistering: false,
+	userIsConnecting: false,
+	handleRegisterSite: jest.fn(),
+};
 
 describe( 'Newsletter dashboard Stage analytics', () => {
 	it( 'records jetpack_newsletter_tab_view once on initial mount with the landing tab', () => {
@@ -207,18 +225,40 @@ describe( 'Newsletter dashboard Stage connection gate', () => {
 	} );
 
 	it( 'shows the subscribers body on a fully connected non-Simple site', () => {
-		mockConnection.mockReturnValue( {
-			isRegistered: true,
-			hasConnectedOwner: true,
-			isUserConnected: true,
-			siteIsRegistering: false,
-			userIsConnecting: false,
-			handleRegisterSite: jest.fn(),
-		} );
+		mockConnection.mockReturnValue( connected );
 
 		render( <Stage /> );
 
 		expect( screen.getByTestId( 'subscribers-body' ) ).toBeInTheDocument();
 		expect( screen.queryByTestId( 'connection-gate' ) ).not.toBeInTheDocument();
+	} );
+} );
+
+describe( 'Newsletter dashboard Stage import-poll gating', () => {
+	// The import-completion poll lives in the always-mounted SubscribersBody. It must run only for a
+	// visitor who can actually import AND is on the Subscribers tab, so it doesn't hit the WP.com
+	// import endpoint on the Settings tab, for connection-gated users, or on Settings-only sites.
+	it( 'enables the poll for a connected visitor on the Subscribers tab', () => {
+		mockConnection.mockReturnValue( connected );
+
+		render( <Stage /> );
+
+		expect( mockImportRefreshEnabled ).toBe( true );
+	} );
+
+	it( 'disables the poll on the Settings tab, even when connected', () => {
+		mockConnection.mockReturnValue( connected );
+		mockSearch.mockReturnValue( { tab: 'settings' } );
+
+		render( <Stage /> );
+
+		expect( mockImportRefreshEnabled ).toBe( false );
+	} );
+
+	it( 'disables the poll for a connection-gated visitor', () => {
+		// Default mocks: disconnected non-Simple site → cannot manage subscribers.
+		render( <Stage /> );
+
+		expect( mockImportRefreshEnabled ).toBe( false );
 	} );
 } );

--- a/projects/packages/newsletter/tests/use-import-completion-refresh.test.tsx
+++ b/projects/packages/newsletter/tests/use-import-completion-refresh.test.tsx
@@ -87,16 +87,16 @@ describe( 'useImportCompletionRefresh', () => {
 		expect( mockCreateErrorNotice ).not.toHaveBeenCalled();
 	} );
 
-	it( 'warns about the shortfall when an import only partially succeeds', () => {
+	it( 'surfaces the shortfall in a success notice when an import only partially succeeds', () => {
 		mockJobs = [ job( 'importing' ) ];
 		const { rerender } = renderWatcher();
 		// WP.com sends counts as numeric strings; the watcher must coerce them.
 		mockJobs = [ job( 'imported', { subscribed_count: '8', failed_subscribed_count: '2' } ) ];
 		rerender();
 
-		expect( mockCreateSuccessNotice ).not.toHaveBeenCalled();
-		expect( mockCreateErrorNotice ).toHaveBeenCalledTimes( 1 );
-		const message = mockCreateErrorNotice.mock.calls[ 0 ][ 0 ];
+		expect( mockCreateErrorNotice ).not.toHaveBeenCalled();
+		expect( mockCreateSuccessNotice ).toHaveBeenCalledTimes( 1 );
+		const message = mockCreateSuccessNotice.mock.calls[ 0 ][ 0 ];
 		expect( message ).toContain( '8' );
 		expect( message ).toContain( '2' );
 	} );

--- a/projects/packages/newsletter/tests/use-import-completion-refresh.test.tsx
+++ b/projects/packages/newsletter/tests/use-import-completion-refresh.test.tsx
@@ -1,6 +1,9 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook } from '@testing-library/react';
-import { useImportCompletionRefresh } from '../_inc/subscribers/data/use-import-completion-refresh';
+import {
+	describeImportOutcome,
+	useImportCompletionRefresh,
+} from '../_inc/subscribers/data/use-import-completion-refresh';
 import { IMPORT_IN_PROGRESS_NOTICE_ID } from '../_inc/subscribers/data/use-import-jobs';
 import type { ImportJob, ImportJobStatus } from '../_inc/subscribers/data/types';
 
@@ -59,64 +62,115 @@ beforeEach( () => {
 	mockRemoveNotice.mockReset();
 } );
 
-describe( 'useImportCompletionRefresh', () => {
-	it( 'refreshes the list and shows a success notice when an import finishes', () => {
-		mockJobs = [ job( 'importing' ) ];
-		const { rerender, invalidateSpy } = renderWatcher();
-		// Still running: nothing to refresh yet.
-		expect( invalidateSpy ).not.toHaveBeenCalled();
+describe( 'describeImportOutcome', () => {
+	it( 'reports a failed job as an error pointing at the confirmation email', () => {
+		const outcome = describeImportOutcome( job( 'failed' ) );
+		expect( outcome?.status ).toBe( 'error' );
+		expect( outcome?.message ).toContain( 'confirmation email' );
+	} );
 
-		// Next poll: the job completed.
-		mockJobs = [ job( 'imported' ) ];
+	it( 'reports the imported count on a clean success', () => {
+		const outcome = describeImportOutcome( job( 'imported', { subscribed_count: 3 } ) );
+		expect( outcome?.status ).toBe( 'success' );
+		expect( outcome?.message ).toContain( '3' );
+	} );
+
+	it( 'reports both counts as a success caveat on a partial import', () => {
+		const outcome = describeImportOutcome(
+			job( 'imported', { subscribed_count: 8, failed_subscribed_count: 2 } )
+		);
+		expect( outcome?.status ).toBe( 'success' );
+		expect( outcome?.message ).toContain( '8' );
+		expect( outcome?.message ).toContain( '2' );
+		expect( outcome?.message ).toContain( 'couldn’t be added' );
+	} );
+
+	it( 'distinguishes an already-subscribed no-op from a real import', () => {
+		const outcome = describeImportOutcome(
+			job( 'imported', { subscribed_count: 0, already_subscribed_count: 2 } )
+		);
+		expect( outcome?.status ).toBe( 'success' );
+		expect( outcome?.message ).toContain( 'already subscribed' );
+		expect( outcome?.message ).toContain( '2' );
+	} );
+
+	it( 'coerces WP.com numeric-string counts', () => {
+		const outcome = describeImportOutcome( job( 'imported', { subscribed_count: '4' } ) );
+		expect( outcome?.message ).toContain( '4' );
+	} );
+
+	it( 'falls back to a generic success when no counts are present', () => {
+		const outcome = describeImportOutcome( job( 'imported' ) );
+		expect( outcome?.status ).toBe( 'success' );
+		expect( outcome?.message ).toContain( 'imported' );
+	} );
+
+	it( 'stays silent for cancelled and still-running jobs', () => {
+		expect( describeImportOutcome( job( 'cancelled' ) ) ).toBeNull();
+		expect( describeImportOutcome( job( 'pending' ) ) ).toBeNull();
+	} );
+} );
+
+describe( 'useImportCompletionRefresh', () => {
+	it( 'announces an import that finishes after being seen in progress', () => {
+		mockJobs = [];
+		const { rerender, invalidateSpy } = renderWatcher();
+
+		mockJobs = [ job( 'importing', { id: 2 } ) ];
+		rerender();
+		expect( mockCreateSuccessNotice ).not.toHaveBeenCalled();
+
+		mockJobs = [ job( 'imported', { id: 2, subscribed_count: 1 } ) ];
 		rerender();
 
 		expect( invalidateSpy ).toHaveBeenCalledWith( { queryKey: [ 'subscribers' ] } );
 		expect( mockRemoveNotice ).toHaveBeenCalledWith( IMPORT_IN_PROGRESS_NOTICE_ID );
 		expect( mockCreateSuccessNotice ).toHaveBeenCalledTimes( 1 );
-		expect( mockCreateErrorNotice ).not.toHaveBeenCalled();
 	} );
 
-	it( 'reports the imported count in the success notice when the job carries one', () => {
-		mockJobs = [ job( 'importing' ) ];
-		const { rerender } = renderWatcher();
-		mockJobs = [ job( 'imported', { subscribed_count: 3, failed_subscribed_count: 0 } ) ];
-		rerender();
-
-		expect( mockCreateSuccessNotice ).toHaveBeenCalledTimes( 1 );
-		expect( mockCreateSuccessNotice.mock.calls[ 0 ][ 0 ] ).toContain( '3' );
-		expect( mockCreateErrorNotice ).not.toHaveBeenCalled();
-	} );
-
-	it( 'surfaces the shortfall in a success notice when an import only partially succeeds', () => {
-		mockJobs = [ job( 'importing' ) ];
-		const { rerender } = renderWatcher();
-		// WP.com sends counts as numeric strings; the watcher must coerce them.
-		mockJobs = [ job( 'imported', { subscribed_count: '8', failed_subscribed_count: '2' } ) ];
-		rerender();
-
-		expect( mockCreateErrorNotice ).not.toHaveBeenCalled();
-		expect( mockCreateSuccessNotice ).toHaveBeenCalledTimes( 1 );
-		const message = mockCreateSuccessNotice.mock.calls[ 0 ][ 0 ];
-		expect( message ).toContain( '8' );
-		expect( message ).toContain( '2' );
-	} );
-
-	it( 'shows an error notice when the import job ends in failure', () => {
-		mockJobs = [ job( 'pending' ) ];
+	it( 'announces an instant import that was never observed running', () => {
+		// The bug this fixes: a tiny / already-subscribed import can finish before any poll sees it
+		// "in progress", so a transition-based watcher would never fire. Id-based detection does.
+		mockJobs = [];
 		const { rerender, invalidateSpy } = renderWatcher();
-		mockJobs = [ job( 'failed' ) ];
+
+		mockJobs = [ job( 'imported', { id: 7, subscribed_count: 1 } ) ];
 		rerender();
 
 		expect( invalidateSpy ).toHaveBeenCalledWith( { queryKey: [ 'subscribers' ] } );
+		expect( mockRemoveNotice ).toHaveBeenCalledWith( IMPORT_IN_PROGRESS_NOTICE_ID );
+		expect( mockCreateSuccessNotice ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'reports an already-subscribed instant import', () => {
+		mockJobs = [];
+		const { rerender } = renderWatcher();
+
+		mockJobs = [ job( 'imported', { id: 8, subscribed_count: 0, already_subscribed_count: 1 } ) ];
+		rerender();
+
+		expect( mockCreateSuccessNotice ).toHaveBeenCalledTimes( 1 );
+		expect( mockCreateSuccessNotice.mock.calls[ 0 ][ 0 ] ).toContain( 'already subscribed' );
+		expect( mockCreateErrorNotice ).not.toHaveBeenCalled();
+	} );
+
+	it( 'shows an error notice when the import job ends in failure', () => {
+		mockJobs = [];
+		const { rerender } = renderWatcher();
+
+		mockJobs = [ job( 'failed', { id: 9 } ) ];
+		rerender();
+
 		expect( mockRemoveNotice ).toHaveBeenCalledWith( IMPORT_IN_PROGRESS_NOTICE_ID );
 		expect( mockCreateErrorNotice ).toHaveBeenCalledTimes( 1 );
 		expect( mockCreateSuccessNotice ).not.toHaveBeenCalled();
 	} );
 
 	it( 'clears the notice but reports nothing when a stuck import is cancelled', () => {
-		mockJobs = [ job( 'importing' ) ];
+		mockJobs = [];
 		const { rerender } = renderWatcher();
-		mockJobs = [ job( 'cancelled' ) ];
+
+		mockJobs = [ job( 'cancelled', { id: 10 } ) ];
 		rerender();
 
 		expect( mockRemoveNotice ).toHaveBeenCalledWith( IMPORT_IN_PROGRESS_NOTICE_ID );
@@ -124,9 +178,10 @@ describe( 'useImportCompletionRefresh', () => {
 		expect( mockCreateErrorNotice ).not.toHaveBeenCalled();
 	} );
 
-	it( 'does nothing on mount when a prior import is already finished', () => {
-		mockJobs = [ job( 'imported' ) ];
-		const { invalidateSpy } = renderWatcher();
+	it( 'does not re-announce imports that were already finished when the dashboard loaded', () => {
+		mockJobs = [ job( 'imported', { id: 1, subscribed_count: 5 } ) ];
+		const { rerender, invalidateSpy } = renderWatcher();
+		rerender();
 
 		expect( invalidateSpy ).not.toHaveBeenCalled();
 		expect( mockRemoveNotice ).not.toHaveBeenCalled();
@@ -134,9 +189,10 @@ describe( 'useImportCompletionRefresh', () => {
 	} );
 
 	it( 'does nothing while an import is still in progress', () => {
-		mockJobs = [ job( 'importing' ) ];
+		mockJobs = [];
 		const { rerender, invalidateSpy } = renderWatcher();
-		mockJobs = [ job( 'importing' ) ];
+
+		mockJobs = [ job( 'importing', { id: 3 } ) ];
 		rerender();
 
 		expect( invalidateSpy ).not.toHaveBeenCalled();

--- a/projects/packages/newsletter/tests/use-import-completion-refresh.test.tsx
+++ b/projects/packages/newsletter/tests/use-import-completion-refresh.test.tsx
@@ -1,0 +1,84 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook } from '@testing-library/react';
+import { useImportCompletionRefresh } from '../_inc/subscribers/data/use-import-completion-refresh';
+import type { ImportJob, ImportJobStatus } from '../_inc/subscribers/data/types';
+
+// The watcher reads its jobs through `useImportJobs`; we drive that hook's return value from this
+// module-level handle so a `rerender()` simulates the next poll returning a new job status. The
+// real `isJobInProgress` is kept (via requireActual) so the transition logic under test is real.
+let mockJobs: ImportJob[] | undefined;
+
+jest.mock( '../_inc/subscribers/data/use-import-jobs', () => {
+	const actual = jest.requireActual( '../_inc/subscribers/data/use-import-jobs' );
+	return {
+		...actual,
+		useImportJobs: () => ( { data: mockJobs } ),
+	};
+} );
+
+const job = ( status: ImportJobStatus ): ImportJob => ( { id: 1, status } );
+
+const renderWatcher = () => {
+	const queryClient = new QueryClient( {
+		defaultOptions: { queries: { retry: false } },
+	} );
+	const invalidateSpy = jest.spyOn( queryClient, 'invalidateQueries' );
+	const wrapper = ( { children }: { children: React.ReactNode } ) => (
+		<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+	);
+	const view = renderHook( () => useImportCompletionRefresh(), { wrapper } );
+	return { ...view, invalidateSpy };
+};
+
+beforeEach( () => {
+	mockJobs = undefined;
+} );
+
+describe( 'useImportCompletionRefresh', () => {
+	it( 'refreshes the subscribers list when a running import finishes', () => {
+		mockJobs = [ job( 'importing' ) ];
+		const { rerender, invalidateSpy } = renderWatcher();
+		// Still running: nothing to refresh yet.
+		expect( invalidateSpy ).not.toHaveBeenCalled();
+
+		// Next poll: the job completed.
+		mockJobs = [ job( 'imported' ) ];
+		rerender();
+
+		expect( invalidateSpy ).toHaveBeenCalledWith( { queryKey: [ 'subscribers' ] } );
+	} );
+
+	it( 'refreshes on the falling edge even when the import ends in failure', () => {
+		mockJobs = [ job( 'pending' ) ];
+		const { rerender, invalidateSpy } = renderWatcher();
+		mockJobs = [ job( 'failed' ) ];
+		rerender();
+
+		expect( invalidateSpy ).toHaveBeenCalledWith( { queryKey: [ 'subscribers' ] } );
+	} );
+
+	it( 'does not refresh on mount when a prior import is already finished', () => {
+		mockJobs = [ job( 'imported' ) ];
+		const { invalidateSpy } = renderWatcher();
+
+		expect( invalidateSpy ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not refresh while an import is still in progress', () => {
+		mockJobs = [ job( 'importing' ) ];
+		const { rerender, invalidateSpy } = renderWatcher();
+		mockJobs = [ job( 'importing' ) ];
+		rerender();
+
+		expect( invalidateSpy ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not refresh when no import ever runs', () => {
+		mockJobs = [];
+		const { rerender, invalidateSpy } = renderWatcher();
+		mockJobs = [];
+		rerender();
+
+		expect( invalidateSpy ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/packages/newsletter/tests/use-import-completion-refresh.test.tsx
+++ b/projects/packages/newsletter/tests/use-import-completion-refresh.test.tsx
@@ -85,6 +85,16 @@ describe( 'describeImportOutcome', () => {
 		expect( outcome?.message ).toContain( 'couldn’t be added' );
 	} );
 
+	it( 'accounts for both counts on a mixed new + already-subscribed import', () => {
+		const outcome = describeImportOutcome(
+			job( 'imported', { subscribed_count: 3, already_subscribed_count: 2 } )
+		);
+		expect( outcome?.status ).toBe( 'success' );
+		expect( outcome?.message ).toContain( '3' );
+		expect( outcome?.message ).toContain( '2' );
+		expect( outcome?.message ).toContain( 'already subscribed' );
+	} );
+
 	it( 'distinguishes an already-subscribed no-op from a real import', () => {
 		const outcome = describeImportOutcome(
 			job( 'imported', { subscribed_count: 0, already_subscribed_count: 2 } )

--- a/projects/packages/newsletter/tests/use-import-completion-refresh.test.tsx
+++ b/projects/packages/newsletter/tests/use-import-completion-refresh.test.tsx
@@ -10,14 +10,15 @@ import type { ImportJob, ImportJobStatus } from '../_inc/subscribers/data/types'
 // The watcher reads its jobs through `useImportJobs`; we drive that hook's return value from this
 // module-level handle so a `rerender()` simulates the next poll returning a new job status. The
 // real `isJobInProgress` and `IMPORT_IN_PROGRESS_NOTICE_ID` are kept (via requireActual) so the
-// transition logic and notice id under test are real.
+// transition logic and notice id under test are real. The mock honours `enabled` (returning no data
+// when disabled) so the gating path is exercised, mirroring the real query.
 let mockJobs: ImportJob[] | undefined;
 
 jest.mock( '../_inc/subscribers/data/use-import-jobs', () => {
 	const actual = jest.requireActual( '../_inc/subscribers/data/use-import-jobs' );
 	return {
 		...actual,
-		useImportJobs: () => ( { data: mockJobs } ),
+		useImportJobs: ( enabled: boolean ) => ( { data: enabled ? mockJobs : undefined } ),
 	};
 } );
 
@@ -43,7 +44,7 @@ const job = ( status: ImportJobStatus, overrides: Partial< ImportJob > = {} ): I
 	...overrides,
 } );
 
-const renderWatcher = () => {
+const renderWatcher = ( enabled = true ) => {
 	const queryClient = new QueryClient( {
 		defaultOptions: { queries: { retry: false } },
 	} );
@@ -51,7 +52,7 @@ const renderWatcher = () => {
 	const wrapper = ( { children }: { children: React.ReactNode } ) => (
 		<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
 	);
-	const view = renderHook( () => useImportCompletionRefresh(), { wrapper } );
+	const view = renderHook( () => useImportCompletionRefresh( enabled ), { wrapper } );
 	return { ...view, invalidateSpy };
 };
 
@@ -228,5 +229,20 @@ describe( 'useImportCompletionRefresh', () => {
 
 		expect( invalidateSpy ).not.toHaveBeenCalled();
 		expect( mockRemoveNotice ).not.toHaveBeenCalled();
+	} );
+
+	it( 'stays inert when disabled, even if an import finishes', () => {
+		// Gated visitors (Settings tab, connection-gated, Settings-only sites) pass `enabled=false`,
+		// which withholds the poll entirely — so a finished job must not invalidate or announce.
+		mockJobs = [];
+		const { rerender, invalidateSpy } = renderWatcher( false );
+
+		mockJobs = [ job( 'imported', { id: 11, subscribed_count: 1 } ) ];
+		rerender();
+
+		expect( invalidateSpy ).not.toHaveBeenCalled();
+		expect( mockRemoveNotice ).not.toHaveBeenCalled();
+		expect( mockCreateSuccessNotice ).not.toHaveBeenCalled();
+		expect( mockCreateErrorNotice ).not.toHaveBeenCalled();
 	} );
 } );

--- a/projects/packages/newsletter/tests/use-import-completion-refresh.test.tsx
+++ b/projects/packages/newsletter/tests/use-import-completion-refresh.test.tsx
@@ -85,6 +85,17 @@ describe( 'describeImportOutcome', () => {
 		expect( outcome?.message ).toContain( 'couldn’t be added' );
 	} );
 
+	it( 'stays grammatical when the imported and failed counts differ in plurality', () => {
+		// 1 imported (singular) + 2 failed (plural): a single _n can only agree with one count, so
+		// the failed clause must not carry a count-sensitive noun.
+		const outcome = describeImportOutcome(
+			job( 'imported', { subscribed_count: 1, failed_subscribed_count: 2 } )
+		);
+		expect( outcome?.message ).toContain( 'Imported 1 subscriber.' );
+		expect( outcome?.message ).toContain( '2 couldn’t be added' );
+		expect( outcome?.message ).not.toContain( 'email address' );
+	} );
+
 	it( 'accounts for both counts on a mixed new + already-subscribed import', () => {
 		const outcome = describeImportOutcome(
 			job( 'imported', { subscribed_count: 3, already_subscribed_count: 2 } )

--- a/projects/packages/newsletter/tests/use-import-completion-refresh.test.tsx
+++ b/projects/packages/newsletter/tests/use-import-completion-refresh.test.tsx
@@ -1,11 +1,13 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook } from '@testing-library/react';
 import { useImportCompletionRefresh } from '../_inc/subscribers/data/use-import-completion-refresh';
+import { IMPORT_IN_PROGRESS_NOTICE_ID } from '../_inc/subscribers/data/use-import-jobs';
 import type { ImportJob, ImportJobStatus } from '../_inc/subscribers/data/types';
 
 // The watcher reads its jobs through `useImportJobs`; we drive that hook's return value from this
 // module-level handle so a `rerender()` simulates the next poll returning a new job status. The
-// real `isJobInProgress` is kept (via requireActual) so the transition logic under test is real.
+// real `isJobInProgress` and `IMPORT_IN_PROGRESS_NOTICE_ID` are kept (via requireActual) so the
+// transition logic and notice id under test are real.
 let mockJobs: ImportJob[] | undefined;
 
 jest.mock( '../_inc/subscribers/data/use-import-jobs', () => {
@@ -16,7 +18,27 @@ jest.mock( '../_inc/subscribers/data/use-import-jobs', () => {
 	};
 } );
 
-const job = ( status: ImportJobStatus ): ImportJob => ( { id: 1, status } );
+const mockCreateSuccessNotice = jest.fn();
+const mockCreateErrorNotice = jest.fn();
+const mockRemoveNotice = jest.fn();
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( {
+		createSuccessNotice: mockCreateSuccessNotice,
+		createErrorNotice: mockCreateErrorNotice,
+		removeNotice: mockRemoveNotice,
+	} ),
+} ) );
+
+jest.mock( '@wordpress/notices', () => ( {
+	store: 'core/notices',
+} ) );
+
+const job = ( status: ImportJobStatus, overrides: Partial< ImportJob > = {} ): ImportJob => ( {
+	id: 1,
+	status,
+	...overrides,
+} );
 
 const renderWatcher = () => {
 	const queryClient = new QueryClient( {
@@ -32,10 +54,13 @@ const renderWatcher = () => {
 
 beforeEach( () => {
 	mockJobs = undefined;
+	mockCreateSuccessNotice.mockReset();
+	mockCreateErrorNotice.mockReset();
+	mockRemoveNotice.mockReset();
 } );
 
 describe( 'useImportCompletionRefresh', () => {
-	it( 'refreshes the subscribers list when a running import finishes', () => {
+	it( 'refreshes the list and shows a success notice when an import finishes', () => {
 		mockJobs = [ job( 'importing' ) ];
 		const { rerender, invalidateSpy } = renderWatcher();
 		// Still running: nothing to refresh yet.
@@ -46,39 +71,85 @@ describe( 'useImportCompletionRefresh', () => {
 		rerender();
 
 		expect( invalidateSpy ).toHaveBeenCalledWith( { queryKey: [ 'subscribers' ] } );
+		expect( mockRemoveNotice ).toHaveBeenCalledWith( IMPORT_IN_PROGRESS_NOTICE_ID );
+		expect( mockCreateSuccessNotice ).toHaveBeenCalledTimes( 1 );
+		expect( mockCreateErrorNotice ).not.toHaveBeenCalled();
 	} );
 
-	it( 'refreshes on the falling edge even when the import ends in failure', () => {
+	it( 'reports the imported count in the success notice when the job carries one', () => {
+		mockJobs = [ job( 'importing' ) ];
+		const { rerender } = renderWatcher();
+		mockJobs = [ job( 'imported', { subscribed_count: 3, failed_subscribed_count: 0 } ) ];
+		rerender();
+
+		expect( mockCreateSuccessNotice ).toHaveBeenCalledTimes( 1 );
+		expect( mockCreateSuccessNotice.mock.calls[ 0 ][ 0 ] ).toContain( '3' );
+		expect( mockCreateErrorNotice ).not.toHaveBeenCalled();
+	} );
+
+	it( 'warns about the shortfall when an import only partially succeeds', () => {
+		mockJobs = [ job( 'importing' ) ];
+		const { rerender } = renderWatcher();
+		// WP.com sends counts as numeric strings; the watcher must coerce them.
+		mockJobs = [ job( 'imported', { subscribed_count: '8', failed_subscribed_count: '2' } ) ];
+		rerender();
+
+		expect( mockCreateSuccessNotice ).not.toHaveBeenCalled();
+		expect( mockCreateErrorNotice ).toHaveBeenCalledTimes( 1 );
+		const message = mockCreateErrorNotice.mock.calls[ 0 ][ 0 ];
+		expect( message ).toContain( '8' );
+		expect( message ).toContain( '2' );
+	} );
+
+	it( 'shows an error notice when the import job ends in failure', () => {
 		mockJobs = [ job( 'pending' ) ];
 		const { rerender, invalidateSpy } = renderWatcher();
 		mockJobs = [ job( 'failed' ) ];
 		rerender();
 
 		expect( invalidateSpy ).toHaveBeenCalledWith( { queryKey: [ 'subscribers' ] } );
+		expect( mockRemoveNotice ).toHaveBeenCalledWith( IMPORT_IN_PROGRESS_NOTICE_ID );
+		expect( mockCreateErrorNotice ).toHaveBeenCalledTimes( 1 );
+		expect( mockCreateSuccessNotice ).not.toHaveBeenCalled();
 	} );
 
-	it( 'does not refresh on mount when a prior import is already finished', () => {
+	it( 'clears the notice but reports nothing when a stuck import is cancelled', () => {
+		mockJobs = [ job( 'importing' ) ];
+		const { rerender } = renderWatcher();
+		mockJobs = [ job( 'cancelled' ) ];
+		rerender();
+
+		expect( mockRemoveNotice ).toHaveBeenCalledWith( IMPORT_IN_PROGRESS_NOTICE_ID );
+		expect( mockCreateSuccessNotice ).not.toHaveBeenCalled();
+		expect( mockCreateErrorNotice ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does nothing on mount when a prior import is already finished', () => {
 		mockJobs = [ job( 'imported' ) ];
 		const { invalidateSpy } = renderWatcher();
 
 		expect( invalidateSpy ).not.toHaveBeenCalled();
+		expect( mockRemoveNotice ).not.toHaveBeenCalled();
+		expect( mockCreateSuccessNotice ).not.toHaveBeenCalled();
 	} );
 
-	it( 'does not refresh while an import is still in progress', () => {
+	it( 'does nothing while an import is still in progress', () => {
 		mockJobs = [ job( 'importing' ) ];
 		const { rerender, invalidateSpy } = renderWatcher();
 		mockJobs = [ job( 'importing' ) ];
 		rerender();
 
 		expect( invalidateSpy ).not.toHaveBeenCalled();
+		expect( mockRemoveNotice ).not.toHaveBeenCalled();
 	} );
 
-	it( 'does not refresh when no import ever runs', () => {
+	it( 'does nothing when no import ever runs', () => {
 		mockJobs = [];
 		const { rerender, invalidateSpy } = renderWatcher();
 		mockJobs = [];
 		rerender();
 
 		expect( invalidateSpy ).not.toHaveBeenCalled();
+		expect( mockRemoveNotice ).not.toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
## Proposed changes

Fixes the "no feedback after import" bug on the modernized Subscribers dashboard (`page=jetpack-newsletter`): after adding subscribers, the import notice appeared and then disappeared, but the subscriber list never updated until a manual page reload — and a stale "Importing…" snackbar lingered next to the already-imported row.

Root cause is a race with the async WP.com import pipeline:

* "Add subscribers" starts an **async** WP.com import job — `useAddSubscribersMutation` invalidates the `['subscribers']` cache immediately, but the job hasn't processed the emails yet, so that refetch returns the pre-import list.
* The Add Subscribers modal closes right after submit, which disables `useImportJobs( isOpen )` and stops the import-jobs poll before the job lands — so nothing ever refetches the list when the import actually finishes.

### What this PR does

1. **Auto-refresh the list.** New `useImportCompletionRefresh` hook, mounted once at the dashboard level (`SubscribersBody`) so it outlives the modal. It keeps the import-jobs poll alive and, when an import reaches a terminal state, invalidates the `['subscribers']` cache so imported subscribers appear without a manual reload. The poll only hits the network while a job is in progress, so an idle dashboard makes a single request.

2. **Detect finished imports by job id, not by an in-progress → done transition.** A small or already-subscribed import can finish before any poll observes it running; a transition-based watcher would miss those entirely. Instead we seed the job ids already finished at page load (so old imports aren't re-announced on every visit) and report the newest job once it reaches a terminal state we haven't seen yet — whether or not a poll caught it running.

3. **Resolve the "Importing…" snackbar into a real outcome.** The mutation tags that snackbar with a stable id; on completion the watcher removes it and shows the actual result (via a pure, unit-tested `describeImportOutcome` helper):
   * **Success** — `"N subscribers imported."` (or a generic "Your subscribers have been imported." when no count is returned).
   * **Already subscribed** — `"N email addresses are already subscribed."` WP.com treats this as a *successful* no-op (status `imported`, not `failed`), so it reads as a success, not an error.
   * **Mixed** (some new, some already on the list) — `"N subscribers imported. M already subscribed."`
   * **Partial** (`imported` with a non-zero `failed_subscribed_count`) — a **success** snackbar surfacing the shortfall: `"Imported N subscribers. M couldn't be added — check your import confirmation email for details."`
   * **Failure** (`failed`) — an error snackbar: `"We couldn't import your subscribers. Check your import confirmation email for details, then try again."`
   * **Cancelled** — no notice (user-initiated reset, not a failure).

<img width="228" height="83" alt="Screenshot 2026-07-22 at 5 09 02 PM" src="https://github.com/user-attachments/assets/6fb2297f-d243-49b5-bb4d-a24bca14d645" />

   Notes: WP.com's `GET /sites/{blog_id}/subscribers/import` response carries **no human-readable failure reason** on a job — only outcome counts (`subscribed_count`, `already_subscribed_count`, `failed_subscribed_count`); the per-address reasons only reach the user via the import confirmation email. So the messages are built from counts and point users at that email for detail. Count-bearing clauses that a single `_n()` can't pluralize (the "already subscribed" / "couldn't be added" tails) are phrased noun-free so they stay grammatical for any count.

4. **Count `awaiting` as in-progress.** WP.com has an `awaiting` status (enqueued but not yet picked up by a worker) that the `ImportJobStatus` type omitted and `isJobInProgress` didn't handle — a poll landing mid-queue would otherwise read the job as finished. Added it to the type and the helper.

## Related product discussion/links

* NL-747

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Requires a WP.com-connected site (e.g. a Jurassic Ninja or WoA site) with the modernized Newsletter dashboard enabled (`rsm_jetpack_ui_modernization_newsletter` filter returning true).

1. Go to `{site}/wp-admin/admin.php?page=jetpack-newsletter`.
2. Click **Add subscribers**, enter an email address, and click **Add subscribers**.
3. Observe the "Importing 1 subscriber…" snackbar. The modal closes.
4. **Expected:** once the import finishes, the new subscriber appears in the list automatically — no manual page refresh — and the "Importing…" snackbar is replaced by **"1 subscriber imported."**
5. **Already-subscribed path** (easy to reproduce): add an email that's already a subscriber → the snackbar reads **"1 email address is already subscribed."**
6. **Partial / failure paths** are harder to trigger by hand (a genuine `failed` status needs a Bkismet block or corrupt file); they're covered by unit tests. A batch containing some addresses WP.com rejects will exercise the partial-success message with real counts.

Automated coverage: `pnpm test` in `projects/packages/newsletter`:
* `tests/use-import-completion-refresh.test.tsx` — `describeImportOutcome` for every count combination (clean success, already-subscribed, mixed, partial, failure, generic, numeric-string coercion, and a singular/plural-boundary grammar case), plus the watcher announcing slow imports, **instant imports never observed running**, already-subscribed, failure, and cancelled — and not re-announcing imports already finished at load, while running, or when no import runs.
* `tests/import-job-helpers.test.ts` — `awaiting` counts as in-progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)