### PR TITLE
charts: Attempt to improve build stability

### DIFF
--- a/projects/js-packages/charts/changelog/add-charts-ts-stable-type-ordering
+++ b/projects/js-packages/charts/changelog/add-charts-ts-stable-type-ordering
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Set `stableTypeOrdering` flag in `tsconfig.json` to try to make builds more stable.
+
+

--- a/projects/js-packages/charts/tsconfig.json
+++ b/projects/js-packages/charts/tsconfig.json
@@ -1,6 +1,7 @@
 {
 	"extends": "jetpack-js-tools/tsconfig.base.json",
 	"compilerOptions": {
+		"stableTypeOrdering": true,
 		"outDir": "dist",
 		"rootDir": "src"
 	},


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
I've noticed the charts build is frequently having dirty diffs, doing changes like

```diff
-}: Omit<BarListChartProps, "size" | "width" | "height"> & {
+}: Omit<BarListChartProps, "height" | "size" | "width"> & {
```

and then a later build will do the same thing with the strings in a different order.

TypeScript 6 added a `stableTypeOrdering` flag (which is supposed to become the default behavior is TS 7). Setting that seems to help.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* You'd have to run a bunch of builds, and see if it stays stable now.