### PR TITLE
webpack-config: Add PnpmDeterministicChunkIds plugin

### DIFF
--- a/projects/js-packages/webpack-config/README.md
+++ b/projects/js-packages/webpack-config/README.md
@@ -116,7 +116,8 @@ Note if you're setting `output.library.name`, you may want to also set `output.u
 * `minimizer` is configured with `TerserPlugin` and `CssMinimizerPlugin` configured as described below.
 * `emitOnErrors` is set true to facilitate debugging.
 * `concatenateModules` is set to false as that setting [may mangle WordPress's i18n function names](https://github.com/Automattic/jetpack/issues/21204).
-* `moduleIds` is set to false in production mode, as `PnpmDeterministicModuleIdsPlugin` is intended to be used instead. The Webpack default 'name' is set in development mode.
+* `chunkIds` is set to false in production mode, as `PnpmDeterministicChunkIdsPlugin` is intended to be used instead. The Webpack default 'named' is set in development mode.
+* `moduleIds` is set to false in production mode, as `PnpmDeterministicModuleIdsPlugin` is intended to be used instead. The Webpack default 'named' is set in development mode.
 * `mangleExports` is set to false in production mode, as `I18nSafeMangleExportsPlugin` is intended to be used instead.
 
 #### `TerserPlugin( options )`
@@ -205,7 +206,7 @@ plugins: {
 }
 ```
 
-Note that I18nCheckPlugin, PnpmDeterministicModuleIdsPlugin, and I18nSafeMangleExportsPlugin are only included by default in production mode. They can be turned on in development mode by passing an options object.
+Note that I18nCheckPlugin, PnpmDeterministicChunkIdsPlugin,, PnpmDeterministicModuleIdsPlugin, and I18nSafeMangleExportsPlugin are only included by default in production mode. They can be turned on in development mode by passing an options object.
 
 ##### `DefinePlugin( defines )`
 
@@ -263,6 +264,10 @@ Options are:
 ##### `MomentLocaleIgnorePlugin()`
 
 This provides an instance of Webpack's `IgnorePlugin` configured to ignore moment.js locale modules.
+
+##### `PnpmDeterministicChunkIdsPlugin( options )`
+
+This provides an slightly modified instance of Webpack's built-in DeterministicChunkIdsPlugin that does a better job of handling the paths produced by pnpm. The `options` are passed to the plugin.
 
 ##### `PnpmDeterministicModuleIdsPlugin( options )`
 

--- a/projects/js-packages/webpack-config/changelog/add-webpack-pnpm-deterministic-chunk-ids
+++ b/projects/js-packages/webpack-config/changelog/add-webpack-pnpm-deterministic-chunk-ids
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add `PnpmDeterministicChunkIds` plugin.

--- a/projects/js-packages/webpack-config/src/webpack.js
+++ b/projects/js-packages/webpack-config/src/webpack.js
@@ -16,7 +16,8 @@ const DevServer = require( './webpack/dev-server' );
 const FileRule = require( './webpack/file-rule' );
 const loadTextDomainFromComposerJson = require( './webpack/load-textdomain-from-composer-json.js' );
 const MiniCSSWithRTLWebpackPlugin = require( './webpack/mini-css-with-rtl' );
-const PnpmDeterministicModuleIdsWebpackPlugin = require( './webpack/pnpm-deterministic-ids.js' );
+const PnpmDeterministicChunkIdsWebpackPlugin = require( './webpack/pnpm-deterministic-chunk-ids.js' );
+const PnpmDeterministicModuleIdsWebpackPlugin = require( './webpack/pnpm-deterministic-module-ids.js' );
 const TerserPlugin = require( './webpack/terser' );
 const TranspileRule = require( './webpack/transpile-rule' );
 
@@ -79,6 +80,7 @@ const optimization = {
 	minimizer: [ TerserPlugin(), CssMinimizerPlugin() ],
 	mangleExports: false,
 	concatenateModules: false,
+	chunkIds: isProduction ? false : 'named',
 	moduleIds: isProduction ? false : 'named',
 	emitOnErrors: true,
 };
@@ -223,6 +225,10 @@ const MomentLocaleIgnorePlugin = () => [
 	} ),
 ];
 
+const PnpmDeterministicChunkIdsPlugin = options => [
+	new PnpmDeterministicChunkIdsWebpackPlugin( options ),
+];
+
 const PnpmDeterministicModuleIdsPlugin = options => [
 	new PnpmDeterministicModuleIdsWebpackPlugin( options ),
 ];
@@ -235,6 +241,9 @@ const StandardPlugins = ( options = {} ) => {
 	}
 	if ( typeof options.I18nSafeMangleExportsPlugin === 'undefined' && isDevelopment ) {
 		options.I18nSafeMangleExportsPlugin = false;
+	}
+	if ( typeof options.PnpmDeterministicChunkIdsPlugin === 'undefined' && isDevelopment ) {
+		options.PnpmDeterministicChunkIdsPlugin = false;
 	}
 	if ( typeof options.PnpmDeterministicModuleIdsPlugin === 'undefined' && isDevelopment ) {
 		options.PnpmDeterministicModuleIdsPlugin = false;
@@ -262,6 +271,9 @@ const StandardPlugins = ( options = {} ) => {
 		...( options.MomentLocaleIgnorePlugin === false
 			? []
 			: MomentLocaleIgnorePlugin( options.MomentLocaleIgnorePlugin ) ),
+		...( options.PnpmDeterministicChunkIdsPlugin === false
+			? []
+			: PnpmDeterministicChunkIdsPlugin( options.PnpmDeterministicChunkIdsPlugin ) ),
 		...( options.PnpmDeterministicModuleIdsPlugin === false
 			? []
 			: PnpmDeterministicModuleIdsPlugin( options.PnpmDeterministicModuleIdsPlugin ) ),
@@ -305,6 +317,7 @@ module.exports = {
 	MiniCssExtractPlugin,
 	MiniCssWithRtlPlugin,
 	MomentLocaleIgnorePlugin,
+	PnpmDeterministicChunkIdsPlugin,
 	PnpmDeterministicModuleIdsPlugin,
 	WebpackRtlPlugin,
 	ReactRefreshWebpackPlugin,

--- a/projects/js-packages/webpack-config/src/webpack/pnpm-deterministic-chunk-ids.js
+++ b/projects/js-packages/webpack-config/src/webpack/pnpm-deterministic-chunk-ids.js
@@ -1,0 +1,61 @@
+/**
+ * Webpack plugin to make chunk IDs more deterministic when used with pnpm.
+ *
+ * Based on Webpack's DeterministicChunkIdsPlugin. This is the same except for the
+ * addition of `fixPnpmPaths`.
+ */
+
+const {
+	assignDeterministicIds,
+	getFullChunkName,
+	getUsedChunkIds,
+} = require( 'webpack/lib/ids/IdHelpers' );
+const { compareChunksNatural } = require( 'webpack/lib/util/comparators' );
+const { fixPnpmPaths } = require( './pnpm-fix-paths.js' );
+
+/** @typedef {import("webpack/lib/Compiler")} Compiler */
+
+const PLUGIN_NAME = 'PnpmDeterministicChunkIdsPlugin';
+
+class PnpmDeterministicChunkIdsPlugin {
+	constructor( options = {} ) {
+		this.options = options;
+	}
+
+	/**
+	 * Applies the plugin by registering its hooks on the compiler.
+	 * @param {Compiler} compiler - the compiler instance
+	 * @return {void}
+	 */
+	apply( compiler ) {
+		compiler.hooks.compilation.tap( PLUGIN_NAME, compilation => {
+			compilation.hooks.chunkIds.tap( PLUGIN_NAME, chunks => {
+				const chunkGraph = compilation.chunkGraph;
+				const context = this.options.context ? this.options.context : compiler.context;
+				const maxLength = this.options.maxLength || 3;
+
+				const compareNatural = compareChunksNatural( chunkGraph );
+
+				const usedIds = getUsedChunkIds( compilation );
+				assignDeterministicIds(
+					[ ...chunks ].filter( chunk => chunk.id === null ),
+					chunk => fixPnpmPaths( getFullChunkName( chunk, chunkGraph, context, compiler.root ) ),
+					compareNatural,
+					( chunk, id ) => {
+						const size = usedIds.size;
+						usedIds.add( `${ id }` );
+						if ( size === usedIds.size ) return false;
+						chunk.id = id;
+						chunk.ids = [ id ];
+						return true;
+					},
+					[ 10 ** maxLength ],
+					10,
+					usedIds.size
+				);
+			} );
+		} );
+	}
+}
+
+module.exports = PnpmDeterministicChunkIdsPlugin;

--- a/projects/js-packages/webpack-config/src/webpack/pnpm-deterministic-module-ids.js
+++ b/projects/js-packages/webpack-config/src/webpack/pnpm-deterministic-module-ids.js
@@ -11,38 +11,12 @@ const {
 	assignDeterministicIds,
 } = require( 'webpack/lib/ids/IdHelpers' );
 const { compareModulesByPreOrderIndexOrIdentifier } = require( 'webpack/lib/util/comparators' );
+const { fixPnpmPaths } = require( './pnpm-fix-paths.js' );
 
-const PNPM_PATH_REGEXP =
-	/(?<=^|[|!])(?:\.\.\/)*node_modules\/\.pnpm\/[^/!|]*\/node_modules\/([^|!]+)/g;
+/** @typedef {import("webpack/lib/Compiler")} Compiler */
+/** @typedef {import("webpack/lib/Module")} Module */
 
-/*
- * With `enableGlobalVirtualStore`, packages live at
- * `<store>/v<N>/links/<@scope|@>/<name>/<version>/<hash>/node_modules/<path>`.
- */
-const PNPM_GLOBAL_STORE_PATH_REGEXP =
-	/(?<=^|[|!])[^|!]*?\/v[0-9]+\/links\/@[^/!|]*\/[^/!|]+\/[^/!|]+\/[0-9a-f]{32,}\/node_modules\/([^|!]+)/g;
-
-/**
- * Replace pnpm store paths in an identifier.
- *
- * Pnpm's store paths contain the version number of the package, which means
- * the identifier would change every time the package is updated. This strips
- * those out of the identifier.
- *
- * This does mean that a bundle with multiple versions of a package might wind
- * up with colliding identifiers, but Webpack already handles that.
- *
- * @param {string} identifier - Identifier.
- * @return {string} Transformed identifier.
- */
-function fixPnpmPaths( identifier ) {
-	return identifier
-		.replace( PNPM_PATH_REGEXP, '.pnpm/$1' )
-		.replace( PNPM_GLOBAL_STORE_PATH_REGEXP, '.pnpm/$1' );
-}
-
-/** @typedef {import("../Compiler")} Compiler */
-/** @typedef {import("../Module")} Module */
+const PLUGIN_NAME = 'PnpmDeterministicModuleIdsPlugin';
 
 class PnpmDeterministicModuleIdsPlugin {
 	constructor( options = {} ) {
@@ -50,14 +24,13 @@ class PnpmDeterministicModuleIdsPlugin {
 	}
 
 	/**
-	 * Apply the plugin
-	 *
+	 * Applies the plugin by registering its hooks on the compiler.
 	 * @param {Compiler} compiler - the compiler instance
 	 * @return {void}
 	 */
 	apply( compiler ) {
-		compiler.hooks.compilation.tap( 'PnpmDeterministicModuleIdsPlugin', compilation => {
-			compilation.hooks.moduleIds.tap( 'PnpmDeterministicModuleIdsPlugin', () => {
+		compiler.hooks.compilation.tap( PLUGIN_NAME, compilation => {
+			compilation.hooks.moduleIds.tap( PLUGIN_NAME, () => {
 				const chunkGraph = compilation.chunkGraph;
 				const context = this.options.context ? this.options.context : compiler.context;
 				const maxLength = this.options.maxLength || 3;
@@ -83,7 +56,7 @@ class PnpmDeterministicModuleIdsPlugin {
 						chunkGraph.setModuleId( module, id );
 						return true;
 					},
-					[ Math.pow( 10, maxLength ) ],
+					[ 10 ** maxLength ],
 					fixedLength ? 0 : 10,
 					usedIds.size,
 					salt

--- a/projects/js-packages/webpack-config/src/webpack/pnpm-fix-paths.js
+++ b/projects/js-packages/webpack-config/src/webpack/pnpm-fix-paths.js
@@ -1,0 +1,36 @@
+/**
+ * Helper to strip versions from pnpm's store paths.
+ */
+
+const PNPM_PATH_REGEXP =
+	/(?<=^|[|!])(?:\.\.\/)*node_modules\/\.pnpm\/[^/!|]*\/node_modules\/([^|!]+)/g;
+
+/*
+ * With `enableGlobalVirtualStore`, packages live at
+ * `<store>/v<N>/links/<@scope|@>/<name>/<version>/<hash>/node_modules/<path>`.
+ */
+const PNPM_GLOBAL_STORE_PATH_REGEXP =
+	/(?<=^|[|!])[^|!]*?\/v[0-9]+\/links\/@[^/!|]*\/[^/!|]+\/[^/!|]+\/[0-9a-f]{32,}\/node_modules\/([^|!]+)/g;
+
+/**
+ * Replace pnpm store paths in an identifier.
+ *
+ * Pnpm's store paths contain the version number of the package, which means
+ * the identifier would change every time the package is updated. This strips
+ * those out of the identifier.
+ *
+ * This does mean that a bundle with multiple versions of a package might wind
+ * up with colliding identifiers, but Webpack already handles that.
+ *
+ * @param {string} identifier - Identifier.
+ * @return {string} Transformed identifier.
+ */
+function fixPnpmPaths( identifier ) {
+	return identifier
+		.replace( PNPM_PATH_REGEXP, '.pnpm/$1' )
+		.replace( PNPM_GLOBAL_STORE_PATH_REGEXP, '.pnpm/$1' );
+}
+
+module.exports = {
+	fixPnpmPaths,
+};


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
Webpack's "deterministic" ID determination looks at the path to the file to choose a consistent ID number. This works pretty well for npm, where the paths tend to look like `node_modules/something/dist/file.js`. Not so well for pnpm where they look like
`node_modules/something@version/node_modules/something/dist/file.js` and the "version" bit changes every time the package is updated (and worse when there are peer dependencies involved!)

Back in 2022 (#24302), we added a custom plugin to make the module IDs more deterministic by filtering out the "version" part. This PR does the same for chunk IDs.

For good measure, this also re-syncs the PnpmDeterministicModuleIds plugin from Webpack, even though there seem to have been minimal upstream changes.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Cherry-pick this onto 33ee7193ce618dd58bcda3ffcc21137ea70ef2ca and 8b1c5c274f79a5d3b9f522356a39c73cf011651d, and do production builds of `packages/forms` for each. Both should generate `dist/blocks/187.js`, rather than `dist/blocks/993.js` vs `dist/blocks/841.js` as in https://github.com/Automattic/jetpack-forms/commit/a491f3c6994ff3a272765e283ad905a87092e1a0.