### PR TITLE
Carousel: show the in-page thumbnail while the full-size image loads

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-tiled-gallery-swipe
+++ b/projects/plugins/jetpack/changelog/fix-carousel-tiled-gallery-swipe
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Carousel: show the already-loaded thumbnail while the full-size image downloads, so slides are no longer blank when moving quickly through a gallery
+Carousel: show the already-loaded thumbnail while the full-size image downloads, so slides are no longer blank when moving quickly through a gallery.

--- a/projects/plugins/jetpack/changelog/fix-carousel-tiled-gallery-swipe
+++ b/projects/plugins/jetpack/changelog/fix-carousel-tiled-gallery-swipe
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Carousel: show the already-loaded thumbnail while the full-size image downloads, so slides are no longer blank when moving quickly through a gallery

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1295,23 +1295,40 @@
 		}
 
 		function loadFullImage( slide ) {
-			var el = slide.el;
 			var attrs = slide.attrs;
-			var image = el.querySelector( 'img' );
+			var image = slide.el.querySelector( 'img' );
 
-			if ( ! image.hasAttribute( 'data-loaded' ) ) {
-				var hasPreview = !! attrs.previewImage;
-				var thumbSize = attrs.thumbSize;
-
-				if ( ! hasPreview || ( thumbSize && el.offsetWidth > thumbSize.width ) ) {
-					image.src = attrs.src;
-				} else {
-					image.src = attrs.previewImage;
-				}
-
-				image.setAttribute( 'itemprop', 'image' );
-				image.setAttribute( 'data-loaded', 1 );
+			if ( image.hasAttribute( 'data-loaded' ) ) {
+				return;
 			}
+
+			image.setAttribute( 'itemprop', 'image' );
+			image.setAttribute( 'data-loaded', 1 );
+
+			// Show the thumbnail the browser has already decoded for this image in the
+			// post itself. Without it the slide stays empty until the full-size image
+			// arrives, which reads as a black screen whenever the reader moves through
+			// the gallery faster than the images can download.
+			if ( attrs.previewImage && attrs.previewImage !== attrs.src ) {
+				image.src = attrs.previewImage;
+				// The thumbnail is much smaller than the slide, so soften the upscale
+				// until the full-size image replaces it.
+				image.style.filter = 'blur(8px)';
+			}
+
+			var fullImage = new window.Image();
+
+			fullImage.addEventListener( 'load', function () {
+				// Cached by this point, so swapping it in is effectively instant.
+				image.src = attrs.src;
+				image.style.filter = '';
+			} );
+
+			fullImage.addEventListener( 'error', function () {
+				image.style.filter = '';
+			} );
+
+			fullImage.src = attrs.src;
 		}
 
 		function preloadAdjacentImages( currentIndex ) {
@@ -1347,30 +1364,44 @@
 		}
 
 		function loadBackgroundImage( slide ) {
-			var currentSlide = slide.el;
-
-			if ( swiper && swiper.slides ) {
-				currentSlide = swiper.slides[ swiper.activeIndex ];
-			}
-
 			var image = slide.attrs.originalElement;
-			var isLoaded = image.complete && image.naturalHeight !== 0;
 
-			if ( isLoaded ) {
-				applyBackgroundImage( slide, currentSlide, image );
+			if ( ! image ) {
 				return;
 			}
 
-			image.onload = function () {
-				applyBackgroundImage( slide, currentSlide, image );
-			};
+			if ( image.complete && image.naturalHeight !== 0 ) {
+				applyBackgroundImage( slide, image );
+				return;
+			}
+
+			// The thumbnail in the post may still be loading, or may be lazy-loaded.
+			// Use an event listener rather than `onload`, which would overwrite any
+			// handler the page has already attached to its own image.
+			image.addEventListener(
+				'load',
+				function () {
+					applyBackgroundImage( slide, image );
+				},
+				{ once: true }
+			);
 		}
 
-		function applyBackgroundImage( slide, currentSlide, image ) {
+		function applyBackgroundImage( slide, image ) {
 			var url = util.getBackgroundImage( image );
+
+			if ( ! url ) {
+				return;
+			}
+
+			// Always paint onto the slide the image belongs to. Preloading runs this
+			// for the neighbouring slides too, so painting onto whichever slide happens
+			// to be active would put the wrong image behind it and leave the slide it
+			// was meant for with no placeholder at all.
 			slide.backgroundImage = url;
-			currentSlide.style.backgroundImage = 'url(' + url + ')';
-			currentSlide.style.backgroundSize = 'cover';
+			slide.el.style.backgroundImage = 'url(' + url + ')';
+			slide.el.style.backgroundSize = 'cover';
+			slide.el.style.backgroundPosition = 'center';
 		}
 
 		function clearCommentTextAreaValue() {
@@ -1403,8 +1434,6 @@
 				var img = new Image();
 				img.src = items[ startIndex ].getAttribute( 'data-gallery-src' );
 			}
-
-			var useInPageThumbnails = !! domUtil.closest( items[ 0 ], '.tiled-gallery.type-rectangular' );
 
 			// create the 'slide'
 			Array.prototype.forEach.call( items, function ( item, i ) {
@@ -1491,10 +1520,10 @@
 					slideEl.setAttribute( 'data-permalink', attrs.permalink );
 					slideEl.setAttribute( 'data-orig-file', attrs.origFile );
 
-					if ( useInPageThumbnails ) {
-						// Use the image already loaded in the gallery as a preview.
-						attrs.previewImage = attrs.src;
-					}
+					// Reuse the thumbnail the browser has already decoded for this image
+					// in the post. It costs nothing to display and gives the slide
+					// something to show while the full-size image is downloading.
+					attrs.previewImage = item.currentSrc || item.getAttribute( 'src' ) || '';
 
 					var slide = { el: slideEl, attrs: attrs, index: i };
 					carousel.slides.push( slide );

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1305,28 +1305,46 @@
 			image.setAttribute( 'itemprop', 'image' );
 			image.setAttribute( 'data-loaded', 1 );
 
+			var hasPreview = attrs.previewImage && attrs.previewImage !== attrs.src;
+
+			if ( ! hasPreview ) {
+				// No usable in-page thumbnail (e.g. a lazy-loading plugin swapped the
+				// gallery src for a placeholder). Load the full-size image straight
+				// into the visible element so the slide is never left without a src.
+				image.src = attrs.src;
+				return;
+			}
+
 			// Show the thumbnail the browser has already decoded for this image in the
 			// post itself. Without it the slide stays empty until the full-size image
 			// arrives, which reads as a black screen whenever the reader moves through
 			// the gallery faster than the images can download.
-			if ( attrs.previewImage && attrs.previewImage !== attrs.src ) {
-				image.src = attrs.previewImage;
-				// The thumbnail is much smaller than the slide, so soften the upscale
-				// until the full-size image replaces it.
-				image.style.filter = 'blur(8px)';
-			}
+			image.src = attrs.previewImage;
+			// The thumbnail is much smaller than the slide, so soften the upscale
+			// until the full-size image replaces it.
+			image.style.filter = 'blur(8px)';
 
+			// Load the full-size image off-DOM, then swap it in over the preview. On
+			// error the (blurred) preview stays put rather than reverting to blank.
 			var fullImage = new window.Image();
 
-			fullImage.addEventListener( 'load', function () {
-				// Cached by this point, so swapping it in is effectively instant.
-				image.src = attrs.src;
-				image.style.filter = '';
-			} );
+			fullImage.addEventListener(
+				'load',
+				function () {
+					// Cached by this point, so swapping it in is effectively instant.
+					image.src = attrs.src;
+					image.style.filter = '';
+				},
+				{ once: true }
+			);
 
-			fullImage.addEventListener( 'error', function () {
-				image.style.filter = '';
-			} );
+			fullImage.addEventListener(
+				'error',
+				function () {
+					image.style.filter = '';
+				},
+				{ once: true }
+			);
 
 			fullImage.src = attrs.src;
 		}
@@ -1377,14 +1395,18 @@
 
 			// The thumbnail in the post may still be loading, or may be lazy-loaded.
 			// Use an event listener rather than `onload`, which would overwrite any
-			// handler the page has already attached to its own image.
-			image.addEventListener(
-				'load',
-				function () {
-					applyBackgroundImage( slide, image );
-				},
-				{ once: true }
-			);
+			// handler the page has already attached to its own image. Pair the load
+			// handler with an error handler so a thumbnail that never loads doesn't
+			// leave a listener (and its reference to the slide) attached for good.
+			var onLoad = function () {
+				image.removeEventListener( 'error', onError );
+				applyBackgroundImage( slide, image );
+			};
+			var onError = function () {
+				image.removeEventListener( 'load', onLoad );
+			};
+			image.addEventListener( 'load', onLoad, { once: true } );
+			image.addEventListener( 'error', onError, { once: true } );
 		}
 
 		function applyBackgroundImage( slide, image ) {


### PR DESCRIPTION
## Proposed changes

Moving quickly through a gallery in the Carousel shows a run of black slides. The counter and caption advance correctly, but the image area stays empty until the full-size image finishes downloading — and on a slow connection that is well after the reader has already swiped past.

Three things combined to cause it:

* **The preview was never a preview.** `attrs.previewImage` was assigned `attrs.src` — the full-size carousel URL, not a thumbnail — so the "show a preview first" branch in `loadFullImage()` downloaded exactly the same image it was meant to stand in for.
* **It was gated to classic galleries anyway.** `useInPageThumbnails` only matched `.tiled-gallery.type-rectangular`, so the Tiled Gallery *block* never took that path at all.
* **Loading was single-stage.** `loadFullImage()` picked preview *or* full and set `image.src` once, so there was no moment at which the slide had something cheap to display.

The gallery in the post has already downloaded and decoded a thumbnail for every image. This reuses it:

* `attrs.previewImage` now comes from the in-page `<img>` (`currentSrc`), for every gallery type.
* `loadFullImage()` is now two-stage: paint the cached thumbnail immediately (blurred, since it is upscaled), fetch the full-size image off-DOM, and swap it in on load. A slide is never empty.

Also fixed while in here, in the background-image path (`display_background_image`, currently only set on WordPress.com Simple):

* `loadBackgroundImage()` captured `swiper.slides[swiper.activeIndex]` as its render target and then applied the background asynchronously in `onload`. Because it also runs for preloaded neighbours, it would paint the *neighbouring* image behind the *current* slide. It now always paints onto the slide the image belongs to.
* It used `image.onload`, which overwrites any handler the page itself attached to its own thumbnail. Now uses `addEventListener(..., { once: true })`.
* Guards added for a missing element and for `getBackgroundImage()` returning nothing.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Reproducing needs the full-size images to be slower than your navigation, so throttle the network — on a fast connection the preloader keeps up and the bug hides.

1. Create a post with a Tiled Gallery block containing ~20 images, and publish it.
2. Open the post on the front end, in a device-emulated or real mobile viewport.
3. Open DevTools → Network and set throttling to **Slow 4G** (or use a real phone on cellular).
4. Tap an image to open the Carousel, then move quickly through the gallery — swipe, or hold the right arrow key, at roughly 2–3 slides per second.

**Before:** most slides are pure black for their entire time on screen; the image only appears if you stop and wait. Opening the carousel is also black for the first ~0.5–1.8s even though the thumbnail you just tapped was already on screen.

**After:** every slide shows the blurred thumbnail immediately and sharpens to the full image as it arrives. No black frames.

Also worth checking:

* A classic `[gallery type="rectangular"]` shortcode gallery behaves the same.
* A single image (`.wp-block-image`) still opens correctly.
* Pinch-zoom on a slide still works after the full image swaps in.
* On an unthrottled connection, nothing looks different from before apart from a brief blur on open.

I verified this with a Playwright script that samples the active slide once per animation frame and records how long it goes without a decoded image, with the carousel's full-size requests held to a fixed 1500ms so the result does not depend on CDN warmth. Against `trunk` it reports 12 of 13 slides never showing an image at all (6509ms cumulative blank); with this change, 0 slides blank and 0ms cumulative. Happy to attach the script if useful — it is not included here since this file has no JS test harness.
