### PR TITLE
My Jetpack: serve purchases from a cross-platform wpcom/v2 route

### DIFF
--- a/projects/packages/my-jetpack/_inc/data/constants.ts
+++ b/projects/packages/my-jetpack/_inc/data/constants.ts
@@ -1,8 +1,11 @@
 // API
 const REST_API_NAMESPACE = 'my-jetpack/v1';
 const ODYSSEY_STATS_API_NAMESPACE = 'jetpack/v4/stats-app';
+// `my-jetpack/v1` is not available on WordPress.com Simple. Endpoints the UI must reach on every
+// platform live under `wpcom/v2`, which is registered on Simple, Atomic and self-hosted alike.
+const REST_API_PORTABLE_NAMESPACE = 'wpcom/v2/my-jetpack';
 
-export const REST_API_SITE_PURCHASES_ENDPOINT = `${ REST_API_NAMESPACE }/site/purchases`;
+export const REST_API_SITE_PURCHASES_ENDPOINT = `${ REST_API_PORTABLE_NAMESPACE }/purchases`;
 export const REST_API_REWINDABLE_BACKUP_EVENTS_ENDPOINT = `${ REST_API_NAMESPACE }/site/backup/undo-event`;
 export const REST_API_CHAT_AVAILABILITY_ENDPOINT = `${ REST_API_NAMESPACE }/chat/availability`;
 export const REST_API_CHAT_AUTHENTICATION_ENDPOINT = `${ REST_API_NAMESPACE }/chat/authentication`;

--- a/projects/packages/my-jetpack/changelog/add-my-jetpack-purchases-portable-endpoint
+++ b/projects/packages/my-jetpack/changelog/add-my-jetpack-purchases-portable-endpoint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+My Jetpack: serve site purchases from a cross-platform `wpcom/v2/my-jetpack/purchases` route so the UI calls one path on Simple, Atomic and self-hosted Jetpack sites. The `my-jetpack/v1/site/purchases` route is retained and now returns the same data.

--- a/projects/packages/my-jetpack/changelog/add-my-jetpack-purchases-portable-endpoint
+++ b/projects/packages/my-jetpack/changelog/add-my-jetpack-purchases-portable-endpoint
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-My Jetpack: serve site purchases from a cross-platform `wpcom/v2/my-jetpack/purchases` route so the UI calls one path on Simple, Atomic and self-hosted Jetpack sites. The `my-jetpack/v1/site/purchases` route is retained and now returns the same data.
+My Jetpack: add a cross-platform `wpcom/v2/my-jetpack/purchases` endpoint so the products page works on WordPress.com Simple sites. The existing `my-jetpack/v1/site/purchases` endpoint is retained and returns the same data.

--- a/projects/packages/my-jetpack/src/class-rest-purchases.php
+++ b/projects/packages/my-jetpack/src/class-rest-purchases.php
@@ -73,9 +73,9 @@ class REST_Purchases {
 	/**
 	 * Site purchases endpoint.
 	 *
-	 * Delegates to Wpcom_Products so every caller shares one code path. That helper is where the
-	 * `my_jetpack_site_purchases` filter lives, which is how a platform holding the data locally
-	 * (WordPress.com Simple) serves it without a request to WordPress.com.
+	 * Delegates to Wpcom_Products so every caller shares one code path. That helper is what serves
+	 * the data locally on WordPress.com Simple - where there is no blog token to sign a request to
+	 * WordPress.com with - instead of fetching it.
 	 *
 	 * @return \WP_REST_Response|WP_Error of site purchases.
 	 */

--- a/projects/packages/my-jetpack/src/class-rest-purchases.php
+++ b/projects/packages/my-jetpack/src/class-rest-purchases.php
@@ -7,8 +7,8 @@
 
 namespace Automattic\Jetpack\My_Jetpack;
 
-use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Status\Host as Status_Host;
 use WP_Error;
 
 /**
@@ -21,15 +21,27 @@ class REST_Purchases {
 	 * Constructor.
 	 */
 	public function __construct() {
-		register_rest_route(
-			'my-jetpack/v1',
-			'/site/purchases',
-			array(
-				'methods'             => \WP_REST_Server::READABLE,
-				'callback'            => __CLASS__ . '::get_site_current_purchases',
-				'permission_callback' => __CLASS__ . '::permissions_callback',
-			)
+		$route_args = array(
+			'methods'             => \WP_REST_Server::READABLE,
+			'callback'            => __CLASS__ . '::get_site_current_purchases',
+			'permission_callback' => __CLASS__ . '::permissions_callback',
 		);
+
+		/*
+		 * The cross-platform route.
+		 *
+		 * `my-jetpack/v1` is not an available namespace on WordPress.com Simple, so the My Jetpack
+		 * UI cannot call it everywhere. `wpcom/v2` is registered on Simple, Atomic and self-hosted
+		 * Jetpack sites alike, which lets the UI request one path regardless of platform.
+		 */
+		register_rest_route( 'wpcom/v2', 'my-jetpack/purchases', $route_args );
+
+		/*
+		 * The original route, retained for backwards compatibility with any existing consumer.
+		 * It is not available on Simple and the My Jetpack UI no longer calls it; both routes
+		 * return the same data.
+		 */
+		register_rest_route( 'my-jetpack/v1', '/site/purchases', $route_args );
 	}
 
 	/**
@@ -41,10 +53,11 @@ class REST_Purchases {
 	 * @return true|WP_Error
 	 */
 	public static function permissions_callback() {
-		$connection        = new Connection_Manager();
-		$is_site_connected = $connection->is_connected();
+		// Simple sites hold this data locally and have no blog token to sign a request with, so
+		// the connection check would always fail there.
+		$is_wpcom_simple = ( new Status_Host() )->is_wpcom_simple();
 
-		if ( ! $is_site_connected ) {
+		if ( ! $is_wpcom_simple && ! ( new Connection_Manager() )->is_connected() ) {
 			return new WP_Error(
 				'not_connected',
 				__( 'Your site is not connected to Jetpack.', 'jetpack-my-jetpack' ),
@@ -60,20 +73,19 @@ class REST_Purchases {
 	/**
 	 * Site purchases endpoint.
 	 *
-	 * @return array|WP_Error of site purchases.
+	 * Delegates to Wpcom_Products so every caller shares one code path. That helper is where the
+	 * `my_jetpack_site_purchases` filter lives, which is how a platform holding the data locally
+	 * (WordPress.com Simple) serves it without a request to WordPress.com.
+	 *
+	 * @return \WP_REST_Response|WP_Error of site purchases.
 	 */
 	public static function get_site_current_purchases() {
-		$site_id           = \Jetpack_Options::get_option( 'id' );
-		$wpcom_endpoint    = sprintf( '/upgrades?site=%1$d&locale=%2$s', $site_id, get_user_locale() );
-		$wpcom_api_version = '1.2';
-		$response          = Client::wpcom_json_api_request_as_blog( $wpcom_endpoint, $wpcom_api_version );
-		$response_code     = wp_remote_retrieve_response_code( $response );
-		$body              = json_decode( wp_remote_retrieve_body( $response ) );
+		$purchases = Wpcom_Products::get_site_current_purchases();
 
-		if ( is_wp_error( $response ) || empty( $response['body'] ) || 200 !== $response_code ) {
-			return new WP_Error( 'site_data_fetch_failed', 'Site data fetch failed', array( 'status' => $response_code ? $response_code : 400 ) );
+		if ( is_wp_error( $purchases ) ) {
+			return new WP_Error( 'site_data_fetch_failed', 'Site data fetch failed', array( 'status' => 400 ) );
 		}
 
-		return rest_ensure_response( $body );
+		return rest_ensure_response( $purchases );
 	}
 }

--- a/projects/packages/my-jetpack/src/class-wpcom-products.php
+++ b/projects/packages/my-jetpack/src/class-wpcom-products.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\My_Jetpack;
 use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Current_Plan;
+use Automattic\Jetpack\Status\Host as Status_Host;
 use Automattic\Jetpack\Status\Visitor;
 use Jetpack_Options;
 use WP_Error;
@@ -314,6 +315,19 @@ class Wpcom_Products {
 
 		if ( $purchases !== null ) {
 			return $purchases;
+		}
+
+		// On WordPress.com Simple the purchases are held in-process; there is no blog token to sign
+		// a request to WordPress.com with, so serve them directly. This is a hard function call
+		// rather than a filter on purpose: a site cannot silently divert the lookup, so bypassing it
+		// requires editing the wpcom mu-plugin that defines the function. A null return means "not
+		// handled here", so we fall through to the normal fetch.
+		if ( ( new Status_Host() )->is_wpcom_simple() && function_exists( '\Automattic\WPCOM\My_Jetpack\get_site_purchases' ) ) {
+			$local_purchases = \Automattic\WPCOM\My_Jetpack\get_site_purchases();
+			if ( null !== $local_purchases ) {
+				$purchases = $local_purchases;
+				return $purchases;
+			}
 		}
 
 		// Check for a cached value before doing lookup

--- a/projects/packages/my-jetpack/src/class-wpcom-products.php
+++ b/projects/packages/my-jetpack/src/class-wpcom-products.php
@@ -330,7 +330,7 @@ class Wpcom_Products {
 		$site_id = Jetpack_Options::get_option( 'id' );
 
 		$response = Client::wpcom_json_api_request_as_blog(
-			sprintf( '/upgrades?site=%d', $site_id ),
+			sprintf( '/upgrades?site=%d&locale=%s', $site_id, rawurlencode( get_user_locale() ) ),
 			'1.2',
 			array(
 				'method' => 'GET',

--- a/projects/packages/my-jetpack/tests/php/Purchases_Rest_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Purchases_Rest_Test.php
@@ -301,6 +301,98 @@ class Purchases_Rest_Test extends TestCase {
 	}
 
 	/**
+	 * A platform that provides the purchases locally serves them without any HTTP request.
+	 *
+	 * This is the WordPress.com Simple path: My Jetpack calls
+	 * \Automattic\WPCOM\My_Jetpack\get_site_purchases() directly when it exists, ahead of both the
+	 * cache and the request. There is no blog token to sign a request with, so a fetch would fail
+	 * outright - the point is that none is attempted.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_local_purchases_are_served_without_fetching() {
+		Constants::set_constant( 'IS_WPCOM', true );
+		$local                                = array( (object) array( 'product_slug' => 'jetpack_backup_t1_monthly' ) );
+		$GLOBALS['__mj_test_local_purchases'] = $local;
+		require_once __DIR__ . '/stubs/wpcom-my-jetpack-purchases.php';
+
+		// Left in place deliberately: if the direct call fails to short-circuit, this would answer
+		// the request and the empty-URL assertion below is what catches it.
+		add_filter( 'pre_http_request', array( $this, 'mock_purchases_success' ), 10, 3 );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', self::PORTABLE_ROUTE ) );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals(
+			wp_json_encode( $local, JSON_UNESCAPED_SLASHES ),
+			wp_json_encode( $response->get_data(), JSON_UNESCAPED_SLASHES )
+		);
+		$this->assertSame( array(), $this->requested_urls, 'Expected no request to WordPress.com.' );
+
+		unset( $GLOBALS['__mj_test_local_purchases'] );
+	}
+
+	/**
+	 * When the local provider returns null - e.g. Atomic, where the signed request works - My
+	 * Jetpack must fall through to the normal WordPress.com fetch rather than treat null as an
+	 * answer.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_null_from_local_provider_falls_through_to_fetch() {
+		Constants::set_constant( 'IS_WPCOM', true );
+		$GLOBALS['__mj_test_local_purchases'] = null;
+		require_once __DIR__ . '/stubs/wpcom-my-jetpack-purchases.php';
+
+		add_filter( 'pre_http_request', array( $this, 'mock_purchases_success' ), 10, 3 );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', self::PORTABLE_ROUTE ) );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals(
+			wp_json_encode( $this->sample_purchases(), JSON_UNESCAPED_SLASHES ),
+			wp_json_encode( $response->get_data(), JSON_UNESCAPED_SLASHES )
+		);
+		$this->assertNotEmpty( $this->requested_urls, 'Expected a fallback request to WordPress.com.' );
+
+		unset( $GLOBALS['__mj_test_local_purchases'] );
+	}
+
+	/**
+	 * The local provider must not be consulted off WordPress.com Simple, even when the function
+	 * happens to exist. A non-Simple site fetches from WordPress.com as usual.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_local_provider_not_called_when_not_simple() {
+		// IS_WPCOM intentionally not set: this is not a Simple site.
+		$GLOBALS['__mj_test_local_purchases'] = array( (object) array( 'product_slug' => 'should_not_be_used' ) );
+		require_once __DIR__ . '/stubs/wpcom-my-jetpack-purchases.php';
+
+		add_filter( 'pre_http_request', array( $this, 'mock_purchases_success' ), 10, 3 );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', self::PORTABLE_ROUTE ) );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals(
+			wp_json_encode( $this->sample_purchases(), JSON_UNESCAPED_SLASHES ),
+			wp_json_encode( $response->get_data(), JSON_UNESCAPED_SLASHES )
+		);
+		$this->assertNotEmpty( $this->requested_urls, 'Expected the normal WordPress.com fetch off Simple.' );
+
+		unset( $GLOBALS['__mj_test_local_purchases'] );
+	}
+
+	/**
 	 * `edit_posts` is the bar, so an editor is allowed through.
 	 */
 	public function test_editor_can_read_purchases() {

--- a/projects/packages/my-jetpack/tests/php/Purchases_Rest_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Purchases_Rest_Test.php
@@ -1,0 +1,350 @@
+<?php
+
+namespace Automattic\Jetpack\My_Jetpack;
+
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Connection\Tokens;
+use Automattic\Jetpack\Constants;
+use Jetpack_Options;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+use PHPUnit\Framework\TestCase;
+use WorDBless\Options as WorDBless_Options;
+use WorDBless\Users as WorDBless_Users;
+use WP_REST_Request;
+use WP_REST_Server;
+
+/**
+ * Tests for the site purchases REST endpoints.
+ *
+ * My Jetpack serves purchases from two routes: the cross-platform `wpcom/v2` one the UI calls on
+ * every platform, and the original `my-jetpack/v1` one kept for backwards compatibility. Both must
+ * behave identically.
+ *
+ * @package automattic/my-jetpack
+ * @see \Automattic\Jetpack\My_Jetpack\REST_Purchases
+ */
+class Purchases_Rest_Test extends TestCase {
+
+	/**
+	 * The cross-platform route the My Jetpack UI calls.
+	 *
+	 * @var string
+	 */
+	const PORTABLE_ROUTE = '/wpcom/v2/my-jetpack/purchases';
+
+	/**
+	 * The original route, retained for backwards compatibility.
+	 *
+	 * @var string
+	 */
+	const LEGACY_ROUTE = '/my-jetpack/v1/site/purchases';
+
+	/**
+	 * REST Server object.
+	 *
+	 * @var WP_REST_Server
+	 */
+	private $server;
+
+	/**
+	 * An administrator user id.
+	 *
+	 * @var int
+	 */
+	private static $admin_id;
+
+	/**
+	 * An editor user id. Editors have `edit_posts`, which is what the endpoint requires.
+	 *
+	 * @var int
+	 */
+	private static $editor_id;
+
+	/**
+	 * A subscriber user id. Subscribers lack `edit_posts`.
+	 *
+	 * @var int
+	 */
+	private static $subscriber_id;
+
+	/**
+	 * URLs the mocked HTTP layer was asked for, so tests can assert on the outgoing request.
+	 *
+	 * @var array
+	 */
+	private $requested_urls = array();
+
+	/**
+	 * Setting up the test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// Mock site connection.
+		( new Tokens() )->update_blog_token( 'test.test' );
+		Jetpack_Options::update_option( 'id', 123 );
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+		( new Connection_Manager() )->reset_connection_status();
+
+		global $wp_rest_server;
+
+		$wp_rest_server = new WP_REST_Server();
+		$this->server   = $wp_rest_server;
+
+		Initializer::init();
+		do_action( 'rest_api_init' );
+
+		self::$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'test_admin',
+				'user_pass'  => '123',
+				'role'       => 'administrator',
+			)
+		);
+
+		self::$editor_id = wp_insert_user(
+			array(
+				'user_login' => 'test_editor',
+				'user_pass'  => '123',
+				'role'       => 'editor',
+			)
+		);
+
+		self::$subscriber_id = wp_insert_user(
+			array(
+				'user_login' => 'test_subscriber',
+				'user_pass'  => '123',
+				'role'       => 'subscriber',
+			)
+		);
+
+		wp_set_current_user( self::$admin_id );
+
+		$this->requested_urls = array();
+	}
+
+	/**
+	 * Returning the environment into its initial state.
+	 */
+	public function tearDown(): void {
+		parent::tearDown();
+
+		remove_filter( 'pre_http_request', array( $this, 'mock_purchases_success' ), 10 );
+		remove_filter( 'pre_http_request', array( $this, 'mock_purchases_failure' ), 10 );
+
+		delete_transient( Wpcom_Products::MY_JETPACK_PURCHASES_TRANSIENT_KEY );
+		Wpcom_Products::reset_request_failures();
+
+		WorDBless_Options::init()->clear_options();
+		WorDBless_Users::init()->clear_all_users();
+
+		unset( $_SERVER['REQUEST_METHOD'] );
+		$_GET = array();
+	}
+
+	/**
+	 * The purchase payload WordPress.com is pretended to return.
+	 *
+	 * @return array
+	 */
+	private function sample_purchases() {
+		return array(
+			array(
+				'ID'             => 28890112,
+				'product_slug'   => 'jetpack_backup_t1_monthly',
+				'product_name'   => 'Jetpack VaultPress Backup',
+				'expiry_message' => 'Expires on August 22, 2026',
+			),
+		);
+	}
+
+	/**
+	 * Intercept the WordPress.com request and return a successful purchases response.
+	 *
+	 * @param mixed  $response The preempted response.
+	 * @param array  $args     Request arguments.
+	 * @param string $url      The requested URL.
+	 * @return array
+	 */
+	public function mock_purchases_success( $response, $args, $url ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$this->requested_urls[] = $url;
+
+		return array(
+			'headers'  => array(),
+			'body'     => wp_json_encode( $this->sample_purchases(), JSON_UNESCAPED_SLASHES ),
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'cookies'  => array(),
+			'filename' => null,
+		);
+	}
+
+	/**
+	 * Intercept the WordPress.com request and return a failure.
+	 *
+	 * @param mixed  $response The preempted response.
+	 * @param array  $args     Request arguments.
+	 * @param string $url      The requested URL.
+	 * @return array
+	 */
+	public function mock_purchases_failure( $response, $args, $url ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		$this->requested_urls[] = $url;
+
+		return array(
+			'headers'  => array(),
+			'body'     => '',
+			'response' => array(
+				'code'    => 500,
+				'message' => 'Internal Server Error',
+			),
+			'cookies'  => array(),
+			'filename' => null,
+		);
+	}
+
+	/**
+	 * Both routes must exist. The `wpcom/v2` one is what the UI calls on every platform; the
+	 * `my-jetpack/v1` one is retained so any existing consumer keeps working.
+	 */
+	public function test_both_routes_are_registered() {
+		$routes = rest_get_server()->get_routes();
+
+		$this->assertArrayHasKey( self::PORTABLE_ROUTE, $routes );
+		$this->assertArrayHasKey( self::LEGACY_ROUTE, $routes );
+	}
+
+	/**
+	 * The endpoint returns the purchases WordPress.com reported.
+	 *
+	 * Runs in a separate process because Wpcom_Products::get_site_current_purchases() memoizes in a
+	 * function-static; a success recorded by an earlier test would be returned instead of the
+	 * mocked fetch this test is asserting on.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_portable_route_returns_the_site_purchases() {
+		add_filter( 'pre_http_request', array( $this, 'mock_purchases_success' ), 10, 3 );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', self::PORTABLE_ROUTE ) );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals(
+			wp_json_encode( $this->sample_purchases(), JSON_UNESCAPED_SLASHES ),
+			wp_json_encode( $response->get_data(), JSON_UNESCAPED_SLASHES )
+		);
+	}
+
+	/**
+	 * The two routes must not drift apart.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_both_routes_return_the_same_payload() {
+		add_filter( 'pre_http_request', array( $this, 'mock_purchases_success' ), 10, 3 );
+
+		$portable = $this->server->dispatch( new WP_REST_Request( 'GET', self::PORTABLE_ROUTE ) );
+		$legacy   = $this->server->dispatch( new WP_REST_Request( 'GET', self::LEGACY_ROUTE ) );
+
+		$this->assertEquals( $legacy->get_status(), $portable->get_status() );
+		$this->assertEquals(
+			wp_json_encode( $legacy->get_data(), JSON_UNESCAPED_SLASHES ),
+			wp_json_encode( $portable->get_data(), JSON_UNESCAPED_SLASHES )
+		);
+	}
+
+	/**
+	 * The upstream request must carry the user's locale.
+	 *
+	 * The response contains localized strings (product names, expiry messages). Dropping the locale
+	 * would silently serve them in English.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_upstream_request_carries_the_user_locale() {
+		add_filter( 'pre_http_request', array( $this, 'mock_purchases_success' ), 10, 3 );
+
+		$this->server->dispatch( new WP_REST_Request( 'GET', self::PORTABLE_ROUTE ) );
+
+		$this->assertNotEmpty( $this->requested_urls, 'Expected an upstream request to WordPress.com.' );
+		$this->assertStringContainsString( 'locale=' . rawurlencode( get_user_locale() ), $this->requested_urls[0] );
+	}
+
+	/**
+	 * An upstream failure surfaces as an error rather than an empty success.
+	 *
+	 * Runs in a separate process so no earlier test's successful fetch is memoized.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_upstream_failure_returns_an_error() {
+		add_filter( 'pre_http_request', array( $this, 'mock_purchases_failure' ), 10, 3 );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', self::PORTABLE_ROUTE ) );
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'site_data_fetch_failed', $response->get_data()['code'] );
+	}
+
+	/**
+	 * `edit_posts` is the bar, so an editor is allowed through.
+	 */
+	public function test_editor_can_read_purchases() {
+		add_filter( 'pre_http_request', array( $this, 'mock_purchases_success' ), 10, 3 );
+		wp_set_current_user( self::$editor_id );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', self::PORTABLE_ROUTE ) );
+
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * A subscriber lacks `edit_posts` and must be refused.
+	 */
+	public function test_subscriber_cannot_read_purchases() {
+		wp_set_current_user( self::$subscriber_id );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', self::PORTABLE_ROUTE ) );
+
+		$this->assertEquals( 403, $response->get_status() );
+	}
+
+	/**
+	 * A logged-out request must be refused.
+	 */
+	public function test_logged_out_cannot_read_purchases() {
+		wp_set_current_user( 0 );
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', self::PORTABLE_ROUTE ) );
+
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * A site with no Jetpack connection cannot sign the upstream request, so the endpoint says so
+	 * rather than attempting the fetch.
+	 */
+	public function test_disconnected_site_reports_not_connected() {
+		Jetpack_Options::delete_option( 'id' );
+		( new Connection_Manager() )->reset_connection_status();
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', self::PORTABLE_ROUTE ) );
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'not_connected', $response->get_data()['code'] );
+	}
+}

--- a/projects/packages/my-jetpack/tests/php/stubs/wpcom-my-jetpack-purchases.php
+++ b/projects/packages/my-jetpack/tests/php/stubs/wpcom-my-jetpack-purchases.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Test stub for the wpcom mu-plugin function My Jetpack calls to serve purchases locally on
+ * WordPress.com Simple. Returns whatever the test placed in $GLOBALS['__mj_test_local_purchases']
+ * (null by default), mirroring how the real function returns null to fall through to the fetch.
+ *
+ * Only ever loaded inside `@runInSeparateProcess` tests so this definition never leaks into the
+ * shared process and short-circuits the normal-fetch tests.
+ *
+ * @package automattic/my-jetpack
+ */
+
+namespace Automattic\WPCOM\My_Jetpack;
+
+if ( ! function_exists( 'Automattic\WPCOM\My_Jetpack\get_site_purchases' ) ) {
+	/**
+	 * @return null|array|object|\WP_Error
+	 */
+	function get_site_purchases() {
+		return $GLOBALS['__mj_test_local_purchases'] ?? null;
+	}
+}


### PR DESCRIPTION
Fixes JETPACK-1951

## Proposed changes

My Jetpack reads site purchases over `my-jetpack/v1/site/purchases`. That namespace is not available on WordPress.com Simple, so the UI cannot use one path across platforms.

* **New route `wpcom/v2/my-jetpack/purchases`.** `wpcom/v2` is registered on Simple, Atomic and self-hosted Jetpack alike — the same namespace `jetpack-mu-wpcom` already uses for its block-editor controllers — so the UI now requests one path everywhere. Intended prefix for the rest of the migration: `wpcom/v2/my-jetpack/{products,modules,…}`.
* **`my-jetpack/v1/site/purchases` is retained**, unchanged from a consumer's point of view. Nothing else in the monorepo calls it — the other `site/purchases` matches are separate endpoints in the Jetpack plugin and Backup — so this is purely defensive.
* **Both routes delegate to `Wpcom_Products::get_site_current_purchases()`** instead of `REST_Purchases` issuing its own `Client::wpcom_json_api_request_as_blog()`. Both already called the same `/upgrades?site=` v1.2 endpoint, so the payload is unchanged; this collapses two copies of the same request into one and gives platforms a single place to intercept.
* **Permission callback gains an `is_wpcom_simple()` escape hatch.** Simple has no blog token, so `Connection_Manager::is_connected()` is always false there and the endpoint would return `not_connected`. Mirrors the existing pattern in `Initializer`.
* **`locale` moved into the shared helper.** `REST_Purchases` was sending `&locale=`; `Wpcom_Products` was not. Delegating without it would have quietly un-localized product names and expiry messages. One line.

### WordPress.com Simple

Simple has no real blog token, so the signed request cannot succeed and the endpoint returned `site_data_fetch_failed`. Simple already holds this data in-process, so there is nothing to fetch.

* **`Wpcom_Products::get_site_current_purchases()` calls `\Automattic\WPCOM\My_Jetpack\get_site_purchases()` directly** (guarded by `function_exists`, ahead of both the transient and the HTTP request). A hard function call rather than a filter is deliberate: a site cannot silently divert the lookup, so bypassing it requires editing the wpcom mu-plugin. A `null` return means "not handled here", so My Jetpack falls through to the normal fetch.
* **The wpcom-side function is a separate change** in `wp-content/mu-plugins/jetpack/wpcom-my-jetpack.php` (not in this PR). It guards on `IS_WPCOM && ! IS_ATOMIC` and returns `WPCOM_Store_API::get_site_billing_upgrades( $blog_id, subscriptions_only: true )` - the exact call the v1.2 `/upgrades` endpoint makes for blog-token auth, so Simple returns the same shape Jetpack sites receive. On Atomic (real blog token, working HTTP path) it returns null and the normal fetch runs.

Nothing in this PR is Simple-specific beyond that one guarded call; on self-hosted the function does not exist and behavior is unchanged.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

### Automated

```
cd projects/packages/my-jetpack && composer phpunit -- --filter Purchases_Rest_Test
```

Twelve tests covering: both routes registered, the endpoint returns the site's purchases, both routes return the same payload, the upstream request carries the user's locale, upstream failure surfaces as an error, local purchases served with **no** HTTP request at all, a null local result falling through to the fetch, and the permission matrix (editor allowed, subscriber 403, logged-out 401, disconnected site 400 `not_connected`).

The full package suite should also be green — `composer phpunit` — 130 tests.

### Manual, on a Jetpack site

1. On a site that **owns at least one plan or product** (a site with no purchases returns `[]` from both paths and will not catch a shape regression):

```
wp eval '
wp_set_current_user( 1 );
do_action( "rest_api_init" );
$new = rest_do_request( new WP_REST_Request( "GET", "/wpcom/v2/my-jetpack/purchases" ) );
$old = rest_do_request( new WP_REST_Request( "GET", "/my-jetpack/v1/site/purchases" ) );
echo "new: " . $new->get_status() . " old: " . $old->get_status() . PHP_EOL;
echo "identical: " . ( wp_json_encode( $new->get_data() ) === wp_json_encode( $old->get_data() ) ? "YES" : "NO" ) . PHP_EOL;
'
```

2. Load My Jetpack and confirm in the Network tab that the request goes to `wpcom/v2/my-jetpack/purchases`, and that the Plans section still renders purchases correctly.

Verified on a Jurassic Ninja site owning Jetpack Backup T1: the new endpoint's response is byte-identical to a fresh signed `/upgrades?site=…&locale=…` request reproducing the pre-change code path.
