### PR TITLE
Site Logo: show the current logo in WP Admin General Settings

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/edi-639-show-current-site-logo-wp-admin
+++ b/projects/packages/jetpack-mu-wpcom/changelog/edi-639-show-current-site-logo-wp-admin
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Site Logo: Show the currently set logo in WP Admin General Settings instead of only the Fiverr upsell.
+Site Logo: Show the currently set logo in WP Admin General Settings, alongside the Fiverr logo-maker upsell.

--- a/projects/packages/jetpack-mu-wpcom/changelog/edi-639-show-current-site-logo-wp-admin
+++ b/projects/packages/jetpack-mu-wpcom/changelog/edi-639-show-current-site-logo-wp-admin
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Site Logo: show the currently set logo in WP Admin General Settings instead of only the Fiverr upsell.
+Site Logo: Show the currently set logo in WP Admin General Settings instead of only the Fiverr upsell.

--- a/projects/packages/jetpack-mu-wpcom/changelog/edi-639-show-current-site-logo-wp-admin
+++ b/projects/packages/jetpack-mu-wpcom/changelog/edi-639-show-current-site-logo-wp-admin
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Site Logo: show the currently set logo in WP Admin General Settings instead of only the Fiverr upsell.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
@@ -96,8 +96,11 @@ function wpcom_fiverr_cta() {
 		// populated state is still announced to assistive technology.
 		$logo_alt = trim( wp_strip_all_tags( (string) get_post_meta( $logo_id, '_wp_attachment_image_alt', true ) ) );
 		if ( '' === $logo_alt ) {
-			/* translators: %s: The site title. */
-			$logo_alt = sprintf( __( 'Current site logo for %s', 'jetpack-mu-wpcom' ), get_bloginfo( 'name' ) );
+			$site_name = get_bloginfo( 'name' );
+			$logo_alt  = $site_name
+				/* translators: %s: The site title. */
+				? sprintf( __( 'Current site logo for %s', 'jetpack-mu-wpcom' ), $site_name )
+				: __( 'Current site logo', 'jetpack-mu-wpcom' );
 		}
 		// Request a proportionally-scaled size rather than a square (which can select the
 		// hard-cropped thumbnail and show only the logo's center); CSS caps its dimensions.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
@@ -24,6 +24,21 @@ function wpcom_normalize_site_logo_id( $value ) {
 }
 
 /**
+ * The Fiverr logo-maker CTA button's DOM.
+ */
+function wpcom_fiverr_cta_button() {
+	?>
+	<button class="wpcom-fiverr-cta-button button" type="button">
+		<svg width="20" height="20" viewBox="0 0 500 500" fill="none" xmlns="http://www.w3.org/2000/svg">
+			<circle cx="250" cy="250" r="177" fill="white"/>
+			<path d="M500 250C500 111.93 388.07 0 250 0C111.93 0 0 111.93 0 250C0 388.07 111.93 500 250 500C388.07 500 500 388.07 500 250ZM360.42 382.5H294.77V237.2H231.94V382.5H165.9V237.2H128.45V183.45H165.9V167.13C165.9 124.54 198.12 95.48 246.05 95.48H294.78V149.22H256.93C241.62 149.22 231.95 157.58 231.95 171.12V183.45H360.43V382.5H360.42Z" fill="#1DBF73"/>
+		</svg>
+		<?php esc_html_e( 'Try Fiverr Logo Maker', 'jetpack-mu-wpcom' ); ?>
+	</button>
+	<?php
+}
+
+/**
  * The fiverr cta's DOM.
  */
 function wpcom_fiverr_cta() {
@@ -58,27 +73,39 @@ function wpcom_fiverr_cta() {
 	?>
 	<div id="wpcom-fiverr-cta">
 		<?php if ( $logo_img ) : ?>
-			<div class="wpcom-site-logo-preview">
-				<?php echo $logo_img; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_get_attachment_image() returns escaped markup. ?>
+			<div class="wpcom-site-logo">
+				<div class="wpcom-site-logo-preview">
+					<?php echo $logo_img; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_get_attachment_image() returns escaped markup. ?>
+				</div>
+				<?php wpcom_fiverr_cta_button(); ?>
 			</div>
+			<p class="description">
+				<?php
+				if ( wp_is_block_theme() ) {
+					// Block themes render the logo via the Site Logo block and expose the
+					// Site Editor's Identity screen for editing it.
+					printf(
+						/* translators: %1$s: opening link tag to the Site Editor identity screen, %2$s: closing link tag. */
+						esc_html__( 'Displays in your site\'s layout via the Site Logo block. %1$sYou can change your site logo in the site editor%2$s.', 'jetpack-mu-wpcom' ),
+						'<a href="' . esc_url( admin_url( 'site-editor.php?p=%2Fidentity' ) ) . '">',
+						'</a>'
+					);
+				} else {
+					// Classic themes have no Site Editor; the logo lives in the Customizer.
+					printf(
+						/* translators: %1$s: opening link tag to the Customizer logo control, %2$s: closing link tag. */
+						esc_html__( '%1$sYou can change your site logo in the Customizer%2$s.', 'jetpack-mu-wpcom' ),
+						'<a href="' . esc_url( admin_url( 'customize.php?autofocus[control]=custom_logo' ) ) . '">',
+						'</a>'
+					);
+				}
+				?>
+			</p>
+		<?php else : ?>
+			<p><b><?php esc_html_e( 'Make an incredible logo in minutes', 'jetpack-mu-wpcom' ); ?></b></p>
+			<p><?php esc_html_e( 'Pre-designed by top talent. Just add your touch.', 'jetpack-mu-wpcom' ); ?></p>
+			<?php wpcom_fiverr_cta_button(); ?>
 		<?php endif; ?>
-		<button class="wpcom-fiverr-cta-button button" type="button">
-			<svg width="20" height="20" viewBox="0 0 500 500" fill="none" xmlns="http://www.w3.org/2000/svg">
-				<circle cx="250" cy="250" r="177" fill="white"/>
-				<path d="M500 250C500 111.93 388.07 0 250 0C111.93 0 0 111.93 0 250C0 388.07 111.93 500 250 500C388.07 500 500 388.07 500 250ZM360.42 382.5H294.77V237.2H231.94V382.5H165.9V237.2H128.45V183.45H165.9V167.13C165.9 124.54 198.12 95.48 246.05 95.48H294.78V149.22H256.93C241.62 149.22 231.95 157.58 231.95 171.12V183.45H360.43V382.5H360.42Z" fill="#1DBF73"/>
-			</svg>
-			<?php esc_html_e( 'Try Fiverr Logo Maker', 'jetpack-mu-wpcom' ); ?>
-		</button>
-		<p class="description">
-			<?php
-			printf(
-				/* translators: %1$s: opening link tag to the Site Editor identity screen, %2$s: closing link tag. */
-				esc_html__( 'Displays in your site\'s layout via the Site Logo block. %1$sYou can change your site logo in the site editor%2$s.', 'jetpack-mu-wpcom' ),
-				'<a href="' . esc_url( admin_url( 'site-editor.php?p=%2Fidentity' ) ) . '">',
-				'</a>'
-			);
-			?>
-		</p>
 	</div>
 	<?php
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
@@ -24,6 +24,45 @@ function wpcom_normalize_site_logo_id( $value ) {
 }
 
 /**
+ * Build the URL for editing the current site logo, and whether the block-theme
+ * copy applies.
+ *
+ * Block themes edit the logo in the Site Editor's Identity screen (falling back to
+ * the default Site Editor screen where that route may not exist yet). Classic
+ * themes edit it in the Customizer, whose control ID depends on which logo
+ * integration the theme supports — mirroring the logo-tool feature.
+ *
+ * @return array{url:string, is_block:bool} The edit URL and block-theme flag.
+ */
+function wpcom_site_logo_edit_link() {
+	if ( wp_is_block_theme() ) {
+		// The Identity screen shipped in Gutenberg 22.8 / WordPress 7.1; fall back to
+		// the default Site Editor screen when it may not be present.
+		$has_identity = defined( 'GUTENBERG_VERSION' )
+			? version_compare( GUTENBERG_VERSION, '22.8', '>=' )
+			: version_compare( get_bloginfo( 'version' ), '7.1', '>=' );
+
+		return array(
+			'url'      => admin_url( $has_identity ? 'site-editor.php?p=%2Fidentity' : 'site-editor.php' ),
+			'is_block' => true,
+		);
+	}
+
+	if ( current_theme_supports( 'custom-logo' ) ) {
+		$url = admin_url( 'customize.php?autofocus[control]=custom_logo' );
+	} elseif ( current_theme_supports( 'site-logo' ) ) {
+		$url = admin_url( 'customize.php?autofocus[control]=site_logo' );
+	} else {
+		$url = admin_url( 'customize.php' );
+	}
+
+	return array(
+		'url'      => $url,
+		'is_block' => false,
+	);
+}
+
+/**
  * The Fiverr logo-maker CTA button's DOM.
  */
 function wpcom_fiverr_cta_button() {
@@ -81,21 +120,19 @@ function wpcom_fiverr_cta() {
 			</div>
 			<p class="description">
 				<?php
-				if ( wp_is_block_theme() ) {
-					// Block themes render the logo via the Site Logo block and expose the
-					// Site Editor's Identity screen for editing it.
+				$logo_edit_link = wpcom_site_logo_edit_link();
+				if ( $logo_edit_link['is_block'] ) {
 					printf(
-						/* translators: %1$s: opening link tag to the Site Editor identity screen, %2$s: closing link tag. */
+						/* translators: %1$s: opening link tag to the Site Editor, %2$s: closing link tag. */
 						esc_html__( 'Displays in your site\'s layout via the Site Logo block. %1$sYou can change your site logo in the site editor%2$s.', 'jetpack-mu-wpcom' ),
-						'<a href="' . esc_url( admin_url( 'site-editor.php?p=%2Fidentity' ) ) . '">',
+						'<a href="' . esc_url( $logo_edit_link['url'] ) . '">',
 						'</a>'
 					);
 				} else {
-					// Classic themes have no Site Editor; the logo lives in the Customizer.
 					printf(
-						/* translators: %1$s: opening link tag to the Customizer logo control, %2$s: closing link tag. */
+						/* translators: %1$s: opening link tag to the Customizer, %2$s: closing link tag. */
 						esc_html__( '%1$sYou can change your site logo in the Customizer%2$s.', 'jetpack-mu-wpcom' ),
-						'<a href="' . esc_url( admin_url( 'customize.php?autofocus[control]=custom_logo' ) ) . '">',
+						'<a href="' . esc_url( $logo_edit_link['url'] ) . '">',
 						'</a>'
 					);
 				}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
@@ -13,9 +13,35 @@ use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 function wpcom_fiverr_cta() {
 	// The Site Logo can be set from the Site Editor's Identity section. Core keeps the
 	// `site_logo` option and the `custom_logo` theme mod in sync, so read either one.
-	$logo_id  = (int) get_option( 'site_logo' );
-	$logo_id  = $logo_id > 0 ? $logo_id : (int) get_theme_mod( 'custom_logo' );
-	$logo_img = $logo_id > 0 ? wp_get_attachment_image( $logo_id, array( 96, 96 ), false, array( 'class' => 'wpcom-site-logo-preview-image' ) ) : '';
+	// The option may hold an attachment ID, a legacy `array( 'id' => ... )`, or a
+	// WP_Error, so normalize to a positive ID before using it.
+	$logo_id = get_option( 'site_logo' );
+	if ( is_array( $logo_id ) && isset( $logo_id['id'] ) ) {
+		$logo_id = $logo_id['id'];
+	}
+	$logo_id = ( is_scalar( $logo_id ) && (int) $logo_id > 0 ) ? (int) $logo_id : (int) get_theme_mod( 'custom_logo' );
+
+	$logo_img = '';
+	if ( $logo_id > 0 ) {
+		// A logo's own alt text is often empty, so fall back to the site title so the
+		// populated state is still announced to assistive technology.
+		$logo_alt = trim( wp_strip_all_tags( (string) get_post_meta( $logo_id, '_wp_attachment_image_alt', true ) ) );
+		if ( '' === $logo_alt ) {
+			/* translators: %s: The site title. */
+			$logo_alt = sprintf( __( 'Current site logo for %s', 'jetpack-mu-wpcom' ), get_bloginfo( 'name' ) );
+		}
+		// Request a proportionally-scaled size rather than a square (which can select the
+		// hard-cropped thumbnail and show only the logo's center); CSS caps its dimensions.
+		$logo_img = wp_get_attachment_image(
+			$logo_id,
+			'medium',
+			false,
+			array(
+				'class' => 'wpcom-site-logo-preview-image',
+				'alt'   => $logo_alt,
+			)
+		);
+	}
 	?>
 	<div id="wpcom-fiverr-cta">
 		<?php if ( $logo_img ) : ?>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
@@ -8,18 +8,32 @@
 use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 
 /**
+ * Normalize a site logo value to a positive attachment ID.
+ *
+ * The `site_logo` option and `custom_logo` theme mod may hold an attachment ID, a
+ * legacy `array( 'id' => ... )`, or a WP_Error (core's site-logo filter can surface the
+ * same error through either), so anything that is not a positive scalar resolves to 0.
+ *
+ * @param mixed $value The raw site_logo option or custom_logo theme mod value.
+ * @return int A positive attachment ID, or 0 when none is usable.
+ */
+function wpcom_normalize_site_logo_id( $value ) {
+	if ( is_array( $value ) && isset( $value['id'] ) ) {
+		$value = $value['id'];
+	}
+	return ( is_scalar( $value ) && (int) $value > 0 ) ? (int) $value : 0;
+}
+
+/**
  * The fiverr cta's DOM.
  */
 function wpcom_fiverr_cta() {
 	// The Site Logo can be set from the Site Editor's Identity section. Core keeps the
 	// `site_logo` option and the `custom_logo` theme mod in sync, so read either one.
-	// The option may hold an attachment ID, a legacy `array( 'id' => ... )`, or a
-	// WP_Error, so normalize to a positive ID before using it.
-	$logo_id = get_option( 'site_logo' );
-	if ( is_array( $logo_id ) && isset( $logo_id['id'] ) ) {
-		$logo_id = $logo_id['id'];
+	$logo_id = wpcom_normalize_site_logo_id( get_option( 'site_logo' ) );
+	if ( $logo_id < 1 ) {
+		$logo_id = wpcom_normalize_site_logo_id( get_theme_mod( 'custom_logo' ) );
 	}
-	$logo_id = ( is_scalar( $logo_id ) && (int) $logo_id > 0 ) ? (int) $logo_id : (int) get_theme_mod( 'custom_logo' );
 
 	$logo_img = '';
 	if ( $logo_id > 0 ) {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
@@ -24,22 +24,18 @@ function wpcom_normalize_site_logo_id( $value ) {
 }
 
 /**
- * Build the URL for editing the current site logo, and whether the block-theme
- * copy applies.
+ * Resolve the URL for editing the current site logo.
  *
- * Block themes edit the logo in the Site Editor's Identity screen; classic themes
- * edit it in the Customizer, whose control ID depends on which logo integration
- * the theme supports — mirroring the logo-tool feature. The URL is empty when no
- * reliable destination exists (the Identity route is unavailable on older editors,
- * or a classic theme without logo support retains a leftover `site_logo` option),
- * so callers can omit the link.
+ * Block themes use the Site Editor's Identity screen; classic themes use the
+ * Customizer control matching their logo support (mirroring the logo-tool feature).
+ * The URL is empty when no reliable destination exists, so callers can omit the link.
  *
  * @return array{url:string, is_block:bool} The edit URL and block-theme flag.
  */
 function wpcom_site_logo_edit_link() {
 	if ( wp_is_block_theme() ) {
-		// The Identity screen shipped in Gutenberg 22.8 / WordPress 7.1. Without it
-		// there is no reliable in-editor logo control to link to, so omit the link.
+		// The Identity screen shipped in Gutenberg 22.8 / WordPress 7.1; omit the
+		// link when it is unavailable.
 		$has_identity = defined( 'GUTENBERG_VERSION' )
 			? version_compare( GUTENBERG_VERSION, '22.8', '>=' )
 			: version_compare( get_bloginfo( 'version' ), '7.1', '>=' );
@@ -83,8 +79,7 @@ function wpcom_fiverr_cta_button() {
  * The fiverr cta's DOM.
  */
 function wpcom_fiverr_cta() {
-	// The Site Logo can be set from the Site Editor's Identity section. Core keeps the
-	// `site_logo` option and the `custom_logo` theme mod in sync, so read either one.
+	// Core keeps the site_logo option and custom_logo theme mod in sync; read either.
 	$logo_id = wpcom_normalize_site_logo_id( get_option( 'site_logo' ) );
 	if ( ! $logo_id ) {
 		$logo_id = wpcom_normalize_site_logo_id( get_theme_mod( 'custom_logo' ) );
@@ -92,8 +87,8 @@ function wpcom_fiverr_cta() {
 
 	$logo_img = '';
 	if ( $logo_id ) {
-		// A logo's own alt text is often empty, so fall back to the site title so the
-		// populated state is still announced to assistive technology.
+		// Fall back to the site title when the logo has no alt text, so the preview
+		// is still announced to assistive technology.
 		$logo_alt = trim( wp_strip_all_tags( (string) get_post_meta( $logo_id, '_wp_attachment_image_alt', true ) ) );
 		if ( '' === $logo_alt ) {
 			$site_name = get_bloginfo( 'name' );
@@ -102,8 +97,8 @@ function wpcom_fiverr_cta() {
 				? sprintf( __( 'Current site logo for %s', 'jetpack-mu-wpcom' ), $site_name )
 				: __( 'Current site logo', 'jetpack-mu-wpcom' );
 		}
-		// Request a proportionally-scaled size rather than a square (which can select the
-		// hard-cropped thumbnail and show only the logo's center); CSS caps its dimensions.
+		// Request a proportional size, not a square, so wide logos aren't shown as a
+		// center-cropped thumbnail; CSS caps the dimensions.
 		$logo_img = wp_get_attachment_image(
 			$logo_id,
 			'medium',

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
@@ -10,9 +10,8 @@ use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 /**
  * Normalize a site logo value to a positive attachment ID.
  *
- * The `site_logo` option and `custom_logo` theme mod may hold an attachment ID, a
- * legacy `array( 'id' => ... )`, or a WP_Error (core's site-logo filter can surface the
- * same error through either), so anything that is not a positive scalar resolves to 0.
+ * The value may hold an attachment ID, a legacy `array( 'id' => ... )`, or a WP_Error,
+ * so anything that is not a positive scalar resolves to 0.
  *
  * @param mixed $value The raw site_logo option or custom_logo theme mod value.
  * @return int A positive attachment ID, or 0 when none is usable.
@@ -31,12 +30,12 @@ function wpcom_fiverr_cta() {
 	// The Site Logo can be set from the Site Editor's Identity section. Core keeps the
 	// `site_logo` option and the `custom_logo` theme mod in sync, so read either one.
 	$logo_id = wpcom_normalize_site_logo_id( get_option( 'site_logo' ) );
-	if ( $logo_id < 1 ) {
+	if ( ! $logo_id ) {
 		$logo_id = wpcom_normalize_site_logo_id( get_theme_mod( 'custom_logo' ) );
 	}
 
 	$logo_img = '';
-	if ( $logo_id > 0 ) {
+	if ( $logo_id ) {
 		// A logo's own alt text is often empty, so fall back to the site title so the
 		// populated state is still announced to assistive technology.
 		$logo_alt = trim( wp_strip_all_tags( (string) get_post_meta( $logo_id, '_wp_attachment_image_alt', true ) ) );

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
@@ -70,8 +70,14 @@ function wpcom_fiverr_cta() {
 			<?php esc_html_e( 'Try Fiverr Logo Maker', 'jetpack-mu-wpcom' ); ?>
 		</button>
 		<p class="description">
-			<b><?php esc_html_e( 'Make an incredible logo in minutes', 'jetpack-mu-wpcom' ); ?></b><br />
-			<?php esc_html_e( 'Pre-designed by top talent. Just add your touch.', 'jetpack-mu-wpcom' ); ?>
+			<?php
+			printf(
+				/* translators: %1$s: opening link tag to the Site Editor identity screen, %2$s: closing link tag. */
+				esc_html__( 'Displays in your site\'s layout via the Site Logo block. %1$sYou can change your site logo in the site editor%2$s', 'jetpack-mu-wpcom' ),
+				'<a href="' . esc_url( admin_url( 'site-editor.php?p=%2Fidentity' ) ) . '">',
+				'</a>'
+			);
+			?>
 		</p>
 	</div>
 	<?php

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
@@ -30,7 +30,9 @@ function wpcom_normalize_site_logo_id( $value ) {
  * Block themes edit the logo in the Site Editor's Identity screen (falling back to
  * the default Site Editor screen where that route may not exist yet). Classic
  * themes edit it in the Customizer, whose control ID depends on which logo
- * integration the theme supports — mirroring the logo-tool feature.
+ * integration the theme supports — mirroring the logo-tool feature. The URL is
+ * empty when no known logo control exists (e.g. a leftover `site_logo` option
+ * under a classic theme without logo support), so callers can omit the link.
  *
  * @return array{url:string, is_block:bool} The edit URL and block-theme flag.
  */
@@ -53,7 +55,7 @@ function wpcom_site_logo_edit_link() {
 	} elseif ( current_theme_supports( 'site-logo' ) ) {
 		$url = admin_url( 'customize.php?autofocus[control]=site_logo' );
 	} else {
-		$url = admin_url( 'customize.php' );
+		$url = '';
 	}
 
 	return array(
@@ -118,26 +120,33 @@ function wpcom_fiverr_cta() {
 				</div>
 				<?php wpcom_fiverr_cta_button(); ?>
 			</div>
-			<p class="description">
-				<?php
-				$logo_edit_link = wpcom_site_logo_edit_link();
-				if ( $logo_edit_link['is_block'] ) {
-					printf(
-						/* translators: %1$s: opening link tag to the Site Editor, %2$s: closing link tag. */
-						esc_html__( 'Displays in your site\'s layout via the Site Logo block. %1$sYou can change your site logo in the site editor%2$s.', 'jetpack-mu-wpcom' ),
-						'<a href="' . esc_url( $logo_edit_link['url'] ) . '">',
-						'</a>'
-					);
-				} else {
-					printf(
-						/* translators: %1$s: opening link tag to the Customizer, %2$s: closing link tag. */
-						esc_html__( '%1$sYou can change your site logo in the Customizer%2$s.', 'jetpack-mu-wpcom' ),
-						'<a href="' . esc_url( $logo_edit_link['url'] ) . '">',
-						'</a>'
-					);
-				}
+			<?php
+			$logo_edit_link = wpcom_site_logo_edit_link();
+			// Only promise an edit path when a known destination exists.
+			if ( $logo_edit_link['url'] ) :
 				?>
-			</p>
+				<p class="description">
+					<?php
+					if ( $logo_edit_link['is_block'] ) {
+						printf(
+							/* translators: %1$s: opening link tag to the Site Editor, %2$s: closing link tag. */
+							esc_html__( 'Displays in your site\'s layout via the Site Logo block. %1$sYou can change your site logo in the site editor%2$s.', 'jetpack-mu-wpcom' ),
+							'<a href="' . esc_url( $logo_edit_link['url'] ) . '">',
+							'</a>'
+						);
+					} else {
+						printf(
+							/* translators: %1$s: opening link tag to the Customizer, %2$s: closing link tag. */
+							esc_html__( '%1$sYou can change your site logo in the Customizer%2$s.', 'jetpack-mu-wpcom' ),
+							'<a href="' . esc_url( $logo_edit_link['url'] ) . '">',
+							'</a>'
+						);
+					}
+					?>
+				</p>
+				<?php
+			endif;
+			?>
 		<?php else : ?>
 			<p><b><?php esc_html_e( 'Make an incredible logo in minutes', 'jetpack-mu-wpcom' ); ?></b></p>
 			<p><?php esc_html_e( 'Pre-designed by top talent. Just add your touch.', 'jetpack-mu-wpcom' ); ?></p>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
@@ -27,25 +27,25 @@ function wpcom_normalize_site_logo_id( $value ) {
  * Build the URL for editing the current site logo, and whether the block-theme
  * copy applies.
  *
- * Block themes edit the logo in the Site Editor's Identity screen (falling back to
- * the default Site Editor screen where that route may not exist yet). Classic
- * themes edit it in the Customizer, whose control ID depends on which logo
- * integration the theme supports — mirroring the logo-tool feature. The URL is
- * empty when no known logo control exists (e.g. a leftover `site_logo` option
- * under a classic theme without logo support), so callers can omit the link.
+ * Block themes edit the logo in the Site Editor's Identity screen; classic themes
+ * edit it in the Customizer, whose control ID depends on which logo integration
+ * the theme supports — mirroring the logo-tool feature. The URL is empty when no
+ * reliable destination exists (the Identity route is unavailable on older editors,
+ * or a classic theme without logo support retains a leftover `site_logo` option),
+ * so callers can omit the link.
  *
  * @return array{url:string, is_block:bool} The edit URL and block-theme flag.
  */
 function wpcom_site_logo_edit_link() {
 	if ( wp_is_block_theme() ) {
-		// The Identity screen shipped in Gutenberg 22.8 / WordPress 7.1; fall back to
-		// the default Site Editor screen when it may not be present.
+		// The Identity screen shipped in Gutenberg 22.8 / WordPress 7.1. Without it
+		// there is no reliable in-editor logo control to link to, so omit the link.
 		$has_identity = defined( 'GUTENBERG_VERSION' )
 			? version_compare( GUTENBERG_VERSION, '22.8', '>=' )
 			: version_compare( get_bloginfo( 'version' ), '7.1', '>=' );
 
 		return array(
-			'url'      => admin_url( $has_identity ? 'site-editor.php?p=%2Fidentity' : 'site-editor.php' ),
+			'url'      => $has_identity ? admin_url( 'site-editor.php?p=%2Fidentity' ) : '',
 			'is_block' => true,
 		);
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
@@ -11,10 +11,21 @@ use Automattic\Jetpack\Jetpack_Mu_Wpcom;
  * The fiverr cta's DOM.
  */
 function wpcom_fiverr_cta() {
+	// The Site Logo can be set from the Site Editor's Identity section. Core keeps the
+	// `site_logo` option and the `custom_logo` theme mod in sync, so read either one.
+	$logo_id  = (int) get_option( 'site_logo' );
+	$logo_id  = $logo_id > 0 ? $logo_id : (int) get_theme_mod( 'custom_logo' );
+	$logo_img = $logo_id > 0 ? wp_get_attachment_image( $logo_id, array( 96, 96 ), false, array( 'class' => 'wpcom-site-logo-preview-image' ) ) : '';
 	?>
 	<div id="wpcom-fiverr-cta">
-		<p><b><?php esc_html_e( 'Make an incredible logo in minutes', 'jetpack-mu-wpcom' ); ?></b></p>
-		<p><?php esc_html_e( 'Pre-designed by top talent. Just add your touch.', 'jetpack-mu-wpcom' ); ?></p>
+		<?php if ( $logo_img ) : ?>
+			<div class="wpcom-site-logo-preview">
+				<?php echo $logo_img; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_get_attachment_image() returns escaped markup. ?>
+			</div>
+		<?php else : ?>
+			<p><b><?php esc_html_e( 'Make an incredible logo in minutes', 'jetpack-mu-wpcom' ); ?></b></p>
+			<p><?php esc_html_e( 'Pre-designed by top talent. Just add your touch.', 'jetpack-mu-wpcom' ); ?></p>
+		<?php endif; ?>
 		<button class="wpcom-fiverr-cta-button button" type="button">
 			<svg width="20" height="20" viewBox="0 0 500 500" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<circle cx="250" cy="250" r="177" fill="white"/>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
@@ -61,10 +61,9 @@ function wpcom_fiverr_cta() {
 			<div class="wpcom-site-logo-preview">
 				<?php echo $logo_img; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_get_attachment_image() returns escaped markup. ?>
 			</div>
-		<?php else : ?>
-			<p><b><?php esc_html_e( 'Make an incredible logo in minutes', 'jetpack-mu-wpcom' ); ?></b></p>
-			<p><?php esc_html_e( 'Pre-designed by top talent. Just add your touch.', 'jetpack-mu-wpcom' ); ?></p>
 		<?php endif; ?>
+		<p><b><?php esc_html_e( 'Make an incredible logo in minutes', 'jetpack-mu-wpcom' ); ?></b></p>
+		<p><?php esc_html_e( 'Pre-designed by top talent. Just add your touch.', 'jetpack-mu-wpcom' ); ?></p>
 		<button class="wpcom-fiverr-cta-button button" type="button">
 			<svg width="20" height="20" viewBox="0 0 500 500" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<circle cx="250" cy="250" r="177" fill="white"/>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
@@ -73,7 +73,7 @@ function wpcom_fiverr_cta() {
 			<?php
 			printf(
 				/* translators: %1$s: opening link tag to the Site Editor identity screen, %2$s: closing link tag. */
-				esc_html__( 'Displays in your site\'s layout via the Site Logo block. %1$sYou can change your site logo in the site editor%2$s', 'jetpack-mu-wpcom' ),
+				esc_html__( 'Displays in your site\'s layout via the Site Logo block. %1$sYou can change your site logo in the site editor%2$s.', 'jetpack-mu-wpcom' ),
 				'<a href="' . esc_url( admin_url( 'site-editor.php?p=%2Fidentity' ) ) . '">',
 				'</a>'
 			);

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
@@ -62,8 +62,6 @@ function wpcom_fiverr_cta() {
 				<?php echo $logo_img; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- wp_get_attachment_image() returns escaped markup. ?>
 			</div>
 		<?php endif; ?>
-		<p><b><?php esc_html_e( 'Make an incredible logo in minutes', 'jetpack-mu-wpcom' ); ?></b></p>
-		<p><?php esc_html_e( 'Pre-designed by top talent. Just add your touch.', 'jetpack-mu-wpcom' ); ?></p>
 		<button class="wpcom-fiverr-cta-button button" type="button">
 			<svg width="20" height="20" viewBox="0 0 500 500" fill="none" xmlns="http://www.w3.org/2000/svg">
 				<circle cx="250" cy="250" r="177" fill="white"/>
@@ -71,6 +69,10 @@ function wpcom_fiverr_cta() {
 			</svg>
 			<?php esc_html_e( 'Try Fiverr Logo Maker', 'jetpack-mu-wpcom' ); ?>
 		</button>
+		<p class="description">
+			<b><?php esc_html_e( 'Make an incredible logo in minutes', 'jetpack-mu-wpcom' ); ?></b><br />
+			<?php esc_html_e( 'Pre-designed by top talent. Just add your touch.', 'jetpack-mu-wpcom' ); ?>
+		</p>
 	</div>
 	<?php
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
@@ -6,9 +6,8 @@
 		padding: 8px;
 		border: 1px solid #dcdcde;
 		border-radius: 2px;
-		// Transparency-grid surface so white, dark, and transparent logos
-		// all stay visible: the medium-gray tiles reveal white logos while
-		// the light base keeps dark logos legible.
+		// Transparency grid so white, dark, and transparent logos all stay
+		// visible against WP Admin's light canvas.
 		background-color: #f6f7f7;
 		background-image:
 			linear-gradient(45deg, #c3c4c7 25%, transparent 25%),
@@ -20,10 +19,8 @@
 
 		.wpcom-site-logo-preview-image {
 			display: block;
-			// Override the width/height attributes emitted by
-			// wp_get_attachment_image() so the two max constraints scale the
-			// image proportionally instead of clamping each axis independently
-			// (which would distort non-square logos).
+			// Override wp_get_attachment_image()'s width/height attributes so the
+			// max constraints scale the image instead of distorting it.
 			inline-size: auto;
 			block-size: auto;
 			max-inline-size: 160px;
@@ -40,10 +37,8 @@
 	}
 
 	.wpcom-site-logo {
-		// Logo-present state: the preview and the button share one line, with the
-		// description on its own line below (the empty state keeps its original
-		// stacked layout). Wrap so the button drops below the preview on narrow
-		// screens rather than overflowing.
+		// Preview and button share one line, wrapping on narrow screens rather
+		// than overflowing.
 		display: flex;
 		flex-wrap: wrap;
 		align-items: center;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
@@ -1,19 +1,5 @@
 .options-general-php {
 
-	#wpcom-fiverr-cta {
-		// Preview and button share the first line; the description wraps onto its
-		// own full-width line beneath them.
-		display: flex;
-		flex-wrap: wrap;
-		align-items: center;
-		gap: 12px;
-
-		.description {
-			flex-basis: 100%;
-			margin: 0;
-		}
-	}
-
 	.wpcom-site-logo-preview {
 		inline-size: fit-content;
 		padding: 8px;
@@ -45,9 +31,28 @@
 	}
 
 	.button.wpcom-fiverr-cta-button {
+		margin-top: 0.4em;
+
 		svg {
 			vertical-align: middle;
 		}
+	}
+
+	.wpcom-site-logo {
+		// Logo-present state: the preview and the button share one line, with the
+		// description on its own line below (the empty state keeps its original
+		// stacked layout).
+		display: flex;
+		align-items: center;
+		gap: 12px;
+
+		.button.wpcom-fiverr-cta-button {
+			margin-top: 0;
+		}
+	}
+
+	.wpcom-site-logo + .description {
+		margin-top: 8px;
 	}
 
 	.button.wpcom-add-custom-address-button {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
@@ -1,11 +1,27 @@
 .options-general-php {
 
 	.wpcom-site-logo-preview {
-		margin-bottom: 0.4em;
+		display: inline-block;
+		margin-block-end: 0.4em;
+		padding: 8px;
+		border: 1px solid #dcdcde;
+		border-radius: 2px;
+		// Checkerboard surface so white, dark, and transparent logos all stay visible
+		// against WP Admin's light canvas.
+		background-color: #fff;
+		background-image:
+			linear-gradient(45deg, #f0f0f1 25%, transparent 25%),
+			linear-gradient(-45deg, #f0f0f1 25%, transparent 25%),
+			linear-gradient(45deg, transparent 75%, #f0f0f1 75%),
+			linear-gradient(-45deg, transparent 75%, #f0f0f1 75%);
+		background-size: 16px 16px;
+		background-position: 0 0, 0 8px, 8px -8px, -8px 0;
 
 		.wpcom-site-logo-preview-image {
-			height: auto;
-			max-width: 96px;
+			display: block;
+			block-size: auto;
+			max-inline-size: 200px;
+			max-block-size: 96px;
 		}
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
@@ -12,13 +12,13 @@
 		// all stay visible: the medium-gray tiles reveal white logos while
 		// the light base keeps dark logos legible.
 		background-color: #f6f7f7;
-		background-image: conic-gradient(
-			#c3c4c7 25%,
-			transparent 0 50%,
-			#c3c4c7 0 75%,
-			transparent 0
-		);
+		background-image:
+			linear-gradient(45deg, #c3c4c7 25%, transparent 25%),
+			linear-gradient(-45deg, #c3c4c7 25%, transparent 25%),
+			linear-gradient(45deg, transparent 75%, #c3c4c7 75%),
+			linear-gradient(-45deg, transparent 75%, #c3c4c7 75%);
 		background-size: 16px 16px;
+		background-position: 0 0, 0 8px, 8px -8px, -8px 0;
 
 		.wpcom-site-logo-preview-image {
 			display: block;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
@@ -1,10 +1,21 @@
 .options-general-php {
 
+	#wpcom-fiverr-cta {
+		// Preview and button share the first line; the description wraps onto its
+		// own full-width line beneath them.
+		display: flex;
+		flex-wrap: wrap;
+		align-items: center;
+		gap: 12px;
+
+		.description {
+			flex-basis: 100%;
+			margin: 0;
+		}
+	}
+
 	.wpcom-site-logo-preview {
-		// Shrink-wrap the box to the logo so the Fiverr button stays below the
-		// preview (matching the empty state) rather than beside it.
 		inline-size: fit-content;
-		margin-block-end: 0.4em;
 		padding: 8px;
 		border: 1px solid #dcdcde;
 		border-radius: 2px;
@@ -28,14 +39,12 @@
 			// (which would distort non-square logos).
 			inline-size: auto;
 			block-size: auto;
-			max-inline-size: 200px;
-			max-block-size: 96px;
+			max-inline-size: 160px;
+			max-block-size: 40px;
 		}
 	}
 
 	.button.wpcom-fiverr-cta-button {
-		margin-top: 0.4em;
-
 		svg {
 			vertical-align: middle;
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
@@ -3,7 +3,7 @@
 	.wpcom-site-logo-preview {
 		inline-size: fit-content;
 		max-inline-size: 100%;
-		padding: 8px;
+		padding: 4px;
 		border: 1px solid #dcdcde;
 		border-radius: 2px;
 		// Transparency grid so white, dark, and transparent logos all stay
@@ -24,7 +24,7 @@
 			inline-size: auto;
 			block-size: auto;
 			max-inline-size: 160px;
-			max-block-size: 40px;
+			max-block-size: 30px;
 		}
 	}
 
@@ -42,7 +42,7 @@
 		display: flex;
 		flex-wrap: wrap;
 		align-items: center;
-		gap: 12px;
+		gap: 10px;
 
 		.button.wpcom-fiverr-cta-button {
 			margin-top: 0;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
@@ -1,5 +1,14 @@
 .options-general-php {
 
+	.wpcom-site-logo-preview {
+		margin-bottom: 0.4em;
+
+		.wpcom-site-logo-preview-image {
+			height: auto;
+			max-width: 96px;
+		}
+	}
+
 	.button.wpcom-fiverr-cta-button {
 		margin-top: 0.4em;
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
@@ -1,9 +1,8 @@
 .options-general-php {
 
 	.wpcom-site-logo-preview {
-		// Block-level but shrink-wrapped, so the Fiverr button stays below
-		// the preview (matching the empty state) rather than beside it.
-		display: block;
+		// Shrink-wrap the box to the logo so the Fiverr button stays below the
+		// preview (matching the empty state) rather than beside it.
 		inline-size: fit-content;
 		margin-block-end: 0.4em;
 		padding: 8px;
@@ -13,13 +12,13 @@
 		// all stay visible: the medium-gray tiles reveal white logos while
 		// the light base keeps dark logos legible.
 		background-color: #f6f7f7;
-		background-image:
-			linear-gradient(45deg, #c3c4c7 25%, transparent 25%),
-			linear-gradient(-45deg, #c3c4c7 25%, transparent 25%),
-			linear-gradient(45deg, transparent 75%, #c3c4c7 75%),
-			linear-gradient(-45deg, transparent 75%, #c3c4c7 75%);
+		background-image: conic-gradient(
+			#c3c4c7 25%,
+			transparent 0 50%,
+			#c3c4c7 0 75%,
+			transparent 0
+		);
 		background-size: 16px 16px;
-		background-position: 0 0, 0 8px, 8px -8px, -8px 0;
 
 		.wpcom-site-logo-preview-image {
 			display: block;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
@@ -1,7 +1,10 @@
 .options-general-php {
 
 	.wpcom-site-logo-preview {
-		display: inline-block;
+		// Block-level but shrink-wrapped, so the Fiverr button stays below the preview
+		// (matching the empty state) instead of sitting beside it.
+		display: block;
+		inline-size: fit-content;
 		margin-block-end: 0.4em;
 		padding: 8px;
 		border: 1px solid #dcdcde;
@@ -19,6 +22,10 @@
 
 		.wpcom-site-logo-preview-image {
 			display: block;
+			// Override the width/height attributes emitted by wp_get_attachment_image() so
+			// the two max constraints scale the image proportionally instead of clamping
+			// each axis independently (which would distort non-square logos).
+			inline-size: auto;
 			block-size: auto;
 			max-inline-size: 200px;
 			max-block-size: 96px;

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
@@ -2,6 +2,7 @@
 
 	.wpcom-site-logo-preview {
 		inline-size: fit-content;
+		max-inline-size: 100%;
 		padding: 8px;
 		border: 1px solid #dcdcde;
 		border-radius: 2px;
@@ -41,8 +42,10 @@
 	.wpcom-site-logo {
 		// Logo-present state: the preview and the button share one line, with the
 		// description on its own line below (the empty state keeps its original
-		// stacked layout).
+		// stacked layout). Wrap so the button drops below the preview on narrow
+		// screens rather than overflowing.
 		display: flex;
+		flex-wrap: wrap;
 		align-items: center;
 		gap: 12px;
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
@@ -9,14 +9,15 @@
 		padding: 8px;
 		border: 1px solid #dcdcde;
 		border-radius: 2px;
-		// Checkerboard surface so white, dark, and transparent logos all stay visible
-		// against WP Admin's light canvas.
-		background-color: #fff;
+		// Transparency-grid surface so white, dark, and transparent logos all stay
+		// visible: the medium-gray tiles reveal white logos while the light base keeps
+		// dark logos legible.
+		background-color: #f6f7f7;
 		background-image:
-			linear-gradient(45deg, #f0f0f1 25%, transparent 25%),
-			linear-gradient(-45deg, #f0f0f1 25%, transparent 25%),
-			linear-gradient(45deg, transparent 75%, #f0f0f1 75%),
-			linear-gradient(-45deg, transparent 75%, #f0f0f1 75%);
+			linear-gradient(45deg, #c3c4c7 25%, transparent 25%),
+			linear-gradient(-45deg, #c3c4c7 25%, transparent 25%),
+			linear-gradient(45deg, transparent 75%, #c3c4c7 75%),
+			linear-gradient(-45deg, transparent 75%, #c3c4c7 75%);
 		background-size: 16px 16px;
 		background-position: 0 0, 0 8px, 8px -8px, -8px 0;
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
@@ -1,17 +1,17 @@
 .options-general-php {
 
 	.wpcom-site-logo-preview {
-		// Block-level but shrink-wrapped, so the Fiverr button stays below the preview
-		// (matching the empty state) instead of sitting beside it.
+		// Block-level but shrink-wrapped, so the Fiverr button stays below
+		// the preview (matching the empty state) rather than beside it.
 		display: block;
 		inline-size: fit-content;
 		margin-block-end: 0.4em;
 		padding: 8px;
 		border: 1px solid #dcdcde;
 		border-radius: 2px;
-		// Transparency-grid surface so white, dark, and transparent logos all stay
-		// visible: the medium-gray tiles reveal white logos while the light base keeps
-		// dark logos legible.
+		// Transparency-grid surface so white, dark, and transparent logos
+		// all stay visible: the medium-gray tiles reveal white logos while
+		// the light base keeps dark logos legible.
 		background-color: #f6f7f7;
 		background-image:
 			linear-gradient(45deg, #c3c4c7 25%, transparent 25%),
@@ -23,9 +23,10 @@
 
 		.wpcom-site-logo-preview-image {
 			display: block;
-			// Override the width/height attributes emitted by wp_get_attachment_image() so
-			// the two max constraints scale the image proportionally instead of clamping
-			// each axis independently (which would distort non-square logos).
+			// Override the width/height attributes emitted by
+			// wp_get_attachment_image() so the two max constraints scale the
+			// image proportionally instead of clamping each axis independently
+			// (which would distort non-square logos).
 			inline-size: auto;
 			block-size: auto;
 			max-inline-size: 200px;


### PR DESCRIPTION
## Proposed changes

* The **Site Logo** field on the WP Admin General Settings page (WordPress.com) previously rendered only the Fiverr logo-maker upsell and never read the site's stored logo, so the field always appeared empty — even when a logo had been set from the Site Editor's Identity section. This made it look like no logo existed.
* The field now reads the current logo (the `site_logo` option, falling back to the `custom_logo` theme mod, which core keeps in sync) and shows a preview when one is set. The Fiverr CTA becomes the empty state, shown only when no logo exists; the "Try Fiverr Logo Maker" button remains available in both states.


No logo:
<img width="1241" height="227" alt="Screenshot 2026-07-27 at 10 41 23 AM" src="https://github.com/user-attachments/assets/b288cfdc-4be1-4e8c-8e01-920047657ece" />

With logo - Block theme:
<img width="1258" height="214" alt="Screenshot 2026-07-27 at 10 45 24 AM" src="https://github.com/user-attachments/assets/cf4253e3-2229-4820-ad60-ceb54e35f363" />

With logo - Classic theme:
<img width="1264" height="207" alt="Screenshot 2026-07-27 at 10 46 44 AM" src="https://github.com/user-attachments/assets/f9d3a019-674d-45ca-bc77-b19925945111" />



## Related product discussion/links

* EDI-639

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a WordPress.com Simple or Atomic site, go to **Settings → General** in WP Admin.
* With **no** Site Logo set, confirm the "Site Logo" row shows the Fiverr upsell ("Make an incredible logo in minutes" + "Try Fiverr Logo Maker") as before.
* Set a Site Logo via the Site Editor's **Design → Styles → Identity** section (or `Appearance → Editor`), then reload **Settings → General**.
* Confirm the "Site Logo" row now shows a preview of the current logo, with the Fiverr button still available.
