### PR TITLE
Publicize: Remove the use of message templates feature flag

### DIFF
--- a/projects/packages/publicize/_inc/components/connection-management/connection-template/index.tsx
+++ b/projects/packages/publicize/_inc/components/connection-management/connection-template/index.tsx
@@ -1,5 +1,5 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { isSimpleSite, siteHasFeature } from '@automattic/jetpack-script-data';
+import { isSimpleSite } from '@automattic/jetpack-script-data';
 import { getSiteFragment, useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { useDebounce } from '@wordpress/compose';
 import { useDispatch, useSelect } from '@wordpress/data';
@@ -12,10 +12,9 @@ import {
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Link } from '@wordpress/ui';
-import { useIsDashboard } from '../../../hooks/use-is-dashboard';
 import { store as socialStore } from '../../../social-store';
 import { Connection } from '../../../social-store/types';
-import { features } from '../../../utils/constants';
+import { hasSocialPaidFeatures } from '../../../utils';
 import { MessageTemplateEditor } from '../../message-template-editor';
 import styles from './style.module.scss';
 
@@ -42,13 +41,10 @@ const NOOP = () => {};
 /**
  * Per-connection message template editor.
  *
- * The per-connection message area only exists once the `social-message-templates`
- * engine is enabled (currently a rollout flag, not a purchasable plan feature),
- * so the component renders nothing for every connection until then. With the
- * engine on, it renders the live editor when the site also has the
- * `social-enhanced-publishing` paid plan and the user can manage the connection,
- * or — in the Social dashboard only — a disabled-textarea variant with an
- * Upgrade link for plan tiers that lack per-connection customization.
+ * Renders the live editor when the site has social paid features and the user
+ * can manage the connection. On plan tiers without paid features it renders a
+ * disabled-textarea variant with an Upgrade link showing the global default
+ * message; Simple sites render nothing.
  *
  * @param {ConnectionTemplateEditorProps} props - The component's props.
  * @return The rendered editor, its locked upsell variant, or null.
@@ -56,19 +52,13 @@ const NOOP = () => {};
 export function ConnectionTemplateEditor( props: ConnectionTemplateEditorProps ) {
 	const { connection } = props;
 
-	const isDashboard = useIsDashboard();
-
 	const { canManageConnection, globalTemplate } = useSelect(
 		select => ( {
 			canManageConnection: select( socialStore ).canUserManageConnection( connection ),
-			// Only the Social dashboard renders the gated upsell, which is the
-			// only consumer of the global default message. Keeping this read out
-			// of the legacy path preserves the trunk data dependencies exactly.
-			globalTemplate: isDashboard
-				? select( socialStore ).getSocialSettings().messageTemplate ?? ''
-				: '',
+			// The upsell variant shows the site's default message.
+			globalTemplate: select( socialStore ).getSocialSettings().messageTemplate ?? '',
 		} ),
-		[ connection, isDashboard ]
+		[ connection ]
 	);
 
 	const { recordEvent } = useAnalytics();
@@ -117,25 +107,10 @@ export function ConnectionTemplateEditor( props: ConnectionTemplateEditorProps )
 		return null;
 	}
 
-	// The message-templates engine is a rollout flag (a WPCOM blog sticker), not
-	// a purchasable plan feature, so no plan unlocks it. Hide the per-connection
-	// message area entirely until the engine is on — otherwise every site,
-	// including paid plans that already have `social-enhanced-publishing`, sees a
-	// misleading "upgrade your plan" upsell for something no plan can unlock.
-	// Once the engine ships the area appears and the plan-based upsell below
-	// becomes meaningful again.
-	if ( ! siteHasFeature( features.MESSAGE_TEMPLATES ) ) {
-		return null;
-	}
-
-	const planEnabled = siteHasFeature( features.ENHANCED_PUBLISHING );
-
-	if ( ! planEnabled ) {
-		// Engine is on but the site's plan tier lacks per-connection
-		// customization; surface the upgrade path. Ships only in the Social
-		// dashboard — the block editor keeps the trunk behavior (no editor when
-		// the plan is missing).
-		if ( ! isDashboard || isSimpleSite() ) {
+	if ( ! hasSocialPaidFeatures() ) {
+		// The site's plan tier lacks per-connection customization; surface the
+		// upgrade path. Simple sites render nothing.
+		if ( isSimpleSite() ) {
 			return null;
 		}
 

--- a/projects/packages/publicize/_inc/components/connection-management/tests/specs/connection-template.test.jsx
+++ b/projects/packages/publicize/_inc/components/connection-management/tests/specs/connection-template.test.jsx
@@ -1,6 +1,5 @@
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { DashboardProvider } from '../../../../hooks/use-is-dashboard';
 import { setup } from '../../../../utils/test-factory';
 import { clearMockedScriptData, mockScriptData } from '../../../../utils/test-utils';
 import { ConnectionTemplateEditor } from '../../connection-template';
@@ -18,10 +17,6 @@ const setupFeatures = ( ...active ) => {
 	} );
 };
 
-// Renders inside the Social dashboard context, where the gated upsell
-// variant is shown.
-const renderInDashboard = ui => render( <DashboardProvider>{ ui }</DashboardProvider> );
-
 describe( 'ConnectionTemplateEditor', () => {
 	afterEach( () => {
 		clearMockedScriptData();
@@ -29,8 +24,8 @@ describe( 'ConnectionTemplateEditor', () => {
 		jest.useRealTimers();
 	} );
 
-	test( 'renders the editor when both message-templates and enhanced-publishing are on', () => {
-		setupFeatures( 'social-message-templates', 'social-enhanced-publishing' );
+	test( 'renders the editor when the site has social paid features', () => {
+		setupFeatures( 'social-enhanced-publishing' );
 		setup();
 
 		render( <ConnectionTemplateEditor connection={ FB } /> );
@@ -38,12 +33,13 @@ describe( 'ConnectionTemplateEditor', () => {
 		expect(
 			screen.getByRole( 'textbox', { name: /Custom message for this connection/i } )
 		).toBeInTheDocument();
+		expect( screen.queryByRole( 'link', { name: /upgrade your plan/i } ) ).not.toBeInTheDocument();
 	} );
 
 	test( 'saves without marking the connection as updating', async () => {
 		jest.useFakeTimers();
 		const user = userEvent.setup( { advanceTimers: jest.advanceTimersByTime } );
-		setupFeatures( 'social-message-templates', 'social-enhanced-publishing' );
+		setupFeatures( 'social-enhanced-publishing' );
 		const { stubUpdateConnectionById } = setup();
 
 		render( <ConnectionTemplateEditor connection={ FB } /> );
@@ -61,17 +57,34 @@ describe( 'ConnectionTemplateEditor', () => {
 		);
 	} );
 
-	test( 'renders nothing when the message-templates feature is off', () => {
-		setupFeatures( 'social-enhanced-publishing' );
+	test( 'renders the locked upsell variant when the site lacks paid features', () => {
+		setupFeatures();
 		setup();
 
-		const { container } = render( <ConnectionTemplateEditor connection={ FB } /> );
+		render( <ConnectionTemplateEditor connection={ FB } /> );
 
-		expect( container ).toBeEmptyDOMElement();
+		const textarea = screen.getByRole( 'textbox', {
+			name: /Custom message for this connection/i,
+		} );
+		expect( textarea ).toBeDisabled();
+		expect( screen.getByRole( 'link', { name: /upgrade your plan/i } ) ).toBeInTheDocument();
 	} );
 
-	test( 'renders nothing when the enhanced-publishing plan is off', () => {
-		setupFeatures( 'social-message-templates' );
+	test( 'surfaces the global default message inside the locked textarea', () => {
+		setupFeatures();
+		setup( { socialSettings: { messageTemplate: 'Read my latest: {url}' } } );
+
+		render( <ConnectionTemplateEditor connection={ FB } /> );
+
+		expect(
+			screen.getByRole( 'textbox', { name: /Custom message for this connection/i } )
+		).toHaveValue( 'Read my latest: {url}' );
+	} );
+
+	test( 'renders nothing on Simple sites when the site lacks paid features', () => {
+		mockScriptData( {
+			site: { host: 'wpcom', plan: { features: { active: [] } } },
+		} );
 		setup();
 
 		const { container } = render( <ConnectionTemplateEditor connection={ FB } /> );
@@ -80,64 +93,11 @@ describe( 'ConnectionTemplateEditor', () => {
 	} );
 
 	test( 'renders nothing when the user cannot manage the connection', () => {
-		setupFeatures( 'social-message-templates', 'social-enhanced-publishing' );
+		setupFeatures( 'social-enhanced-publishing' );
 		setup( { canUserManageConnection: false } );
 
 		const { container } = render( <ConnectionTemplateEditor connection={ FB } /> );
 
 		expect( container ).toBeEmptyDOMElement();
-	} );
-
-	describe( 'Social dashboard (gated upsell)', () => {
-		test( 'renders nothing when the message-templates engine is off, even with the paid plan', () => {
-			// The engine is a rollout sticker, not a plan feature, so an "upgrade
-			// your plan" upsell would be misleading — hide the whole area instead.
-			setupFeatures( 'social-enhanced-publishing' );
-			setup();
-
-			const { container } = renderInDashboard( <ConnectionTemplateEditor connection={ FB } /> );
-
-			expect( container ).toBeEmptyDOMElement();
-		} );
-
-		test( 'renders the locked upsell variant when the enhanced-publishing plan is off', () => {
-			setupFeatures( 'social-message-templates' );
-			setup();
-
-			renderInDashboard( <ConnectionTemplateEditor connection={ FB } /> );
-
-			const textarea = screen.getByRole( 'textbox', {
-				name: /Custom message for this connection/i,
-			} );
-			expect( textarea ).toBeDisabled();
-			expect( screen.getByRole( 'link', { name: /upgrade your plan/i } ) ).toBeInTheDocument();
-		} );
-
-		test( 'surfaces the global default message inside the locked textarea', () => {
-			// Engine on, paid plan off: the plan upsell shows the global default.
-			mockScriptData( {
-				site: { plan: { features: { active: [ 'social-message-templates' ] } } },
-				social: { settings: { messageTemplate: 'Read my latest: {url}' } },
-			} );
-			setup();
-
-			renderInDashboard( <ConnectionTemplateEditor connection={ FB } /> );
-
-			expect(
-				screen.getByRole( 'textbox', { name: /Custom message for this connection/i } )
-			).toHaveValue( 'Read my latest: {url}' );
-		} );
-
-		test( 'renders nothing on Simple sites when the plan upsell would otherwise show', () => {
-			// Engine on, paid plan off, Simple site: keeps the trunk no-editor behavior.
-			mockScriptData( {
-				site: { host: 'wpcom', plan: { features: { active: [ 'social-message-templates' ] } } },
-			} );
-			setup();
-
-			const { container } = renderInDashboard( <ConnectionTemplateEditor connection={ FB } /> );
-
-			expect( container ).toBeEmptyDOMElement();
-		} );
 	} );
 } );

--- a/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.test.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.test.tsx
@@ -75,13 +75,13 @@ function getSharePostFormProps( connectionOverrides: Partial< Connection > = {} 
 describe( 'PerNetworkCustomizationForm', () => {
 	const mockCustomizeConnectionById = jest.fn();
 	let globalMessage = '';
-	let templatesEnabled = true;
+	let hasPaidFeatures = true;
 
 	beforeEach( () => {
 		jest.clearAllMocks();
 
 		globalMessage = '';
-		templatesEnabled = true;
+		hasPaidFeatures = true;
 
 		mockUseDispatch.mockReturnValue( {
 			customizeConnectionById: mockCustomizeConnectionById,
@@ -94,7 +94,7 @@ describe( 'PerNetworkCustomizationForm', () => {
 		} ) );
 
 		mockSiteHasFeature.mockImplementation( flag => {
-			return flag === 'social-message-templates' ? templatesEnabled : false;
+			return flag === 'social-enhanced-publishing' ? hasPaidFeatures : false;
 		} );
 	} );
 
@@ -130,8 +130,8 @@ describe( 'PerNetworkCustomizationForm', () => {
 		expect( sharePostFormProps.messageHelp ).toBe( 'A template will be used if this is empty.' );
 	} );
 
-	it( 'omits the helper text when message templates feature is off', () => {
-		templatesEnabled = false;
+	it( 'omits the helper text when the site lacks paid features', () => {
+		hasPaidFeatures = false;
 		globalMessage = 'Global custom message';
 
 		const sharePostFormProps = getSharePostFormProps( {

--- a/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/customization-forms/per-network.tsx
@@ -1,10 +1,9 @@
-import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { useDispatch } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { useCallback } from 'react';
 import { store as socialStore } from '../../../social-store';
 import { Connection } from '../../../social-store/types';
-import { features } from '../../../utils/constants';
+import { hasSocialPaidFeatures } from '../../../utils';
 import { SharePostForm, SharePostFormProps } from '../../form/share-post-form';
 
 type PerNetworkCustomizationFormProps = {
@@ -24,13 +23,12 @@ const FALLBACK_TEMPLATE_HELP = __(
  */
 export function PerNetworkCustomizationForm( { connection }: PerNetworkCustomizationFormProps ) {
 	const { customizeConnectionById } = useDispatch( socialStore );
-	const templatesEnabled = siteHasFeature( features.MESSAGE_TEMPLATES );
 
 	/*
 	 * The message field is bound strictly to `connection.message`.
 	 */
 	const message = connection.message ?? '';
-	const fallbackHelp = templatesEnabled ? FALLBACK_TEMPLATE_HELP : undefined;
+	const fallbackHelp = hasSocialPaidFeatures() ? FALLBACK_TEMPLATE_HELP : undefined;
 
 	/*
 	 * Per-network values come strictly from the connection. We don't fall back to global

--- a/projects/packages/publicize/_inc/components/form/instagram-no-media-notice.tsx
+++ b/projects/packages/publicize/_inc/components/form/instagram-no-media-notice.tsx
@@ -1,8 +1,7 @@
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { Notice } from '@wordpress/components';
 import { __, _x } from '@wordpress/i18n';
-import { features } from '../../utils/constants';
+import { hasSocialPaidFeatures } from '../../utils';
 
 /**
  * Notice displayed when trying to share to Instagram without media.
@@ -21,7 +20,7 @@ export function InstagramNoMediaNotice() {
 				},
 			] }
 		>
-			{ siteHasFeature( features.ENHANCED_PUBLISHING )
+			{ hasSocialPaidFeatures()
 				? __(
 						'To share to Instagram, add an image/video, or enable Social Image Generator.',
 						'jetpack-publicize-pkg'

--- a/projects/packages/publicize/_inc/components/message-box-control/index.tsx
+++ b/projects/packages/publicize/_inc/components/message-box-control/index.tsx
@@ -1,10 +1,9 @@
-import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { TextareaControl } from '@wordpress/components';
 import { createInterpolateElement } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { useCallback, useRef } from 'react';
-import { features } from '../../utils/constants';
+import { hasSocialPaidFeatures } from '../../utils/script-data';
 import PlaceholdersHelp from '../placeholders-help';
 import styles from './styles.module.scss';
 import type { ReactNode } from 'react';
@@ -77,7 +76,7 @@ export default function MessageBoxControl( {
 	const { recordEvent } = useAnalytics();
 	const isFirstChange = useRef( true );
 
-	const templatesEnabled = siteHasFeature( features.MESSAGE_TEMPLATES );
+	const templatesEnabled = hasSocialPaidFeatures();
 
 	const charactersRemaining = maxLength - message.length;
 

--- a/projects/packages/publicize/_inc/components/overview-tab/traffic-chart-card.tsx
+++ b/projects/packages/publicize/_inc/components/overview-tab/traffic-chart-card.tsx
@@ -1,7 +1,7 @@
 import { LineChart } from '@automattic/charts';
 import '@automattic/charts/style.css';
 import { getRedirectUrl } from '@automattic/jetpack-components';
-import { getScriptData, siteHasFeature } from '@automattic/jetpack-script-data';
+import { getScriptData } from '@automattic/jetpack-script-data';
 import { Spinner, SelectControl } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback, useMemo } from '@wordpress/element';
@@ -9,7 +9,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { trendingUp } from '@wordpress/icons';
 import { Button, Card, EmptyState, Notice, Stack, Text, Tooltip } from '@wordpress/ui';
 import { store as socialStore } from '../../social-store';
-import { features } from '../../utils';
+import { hasSocialPaidFeatures } from '../../utils';
 import { getRefreshPlanQuery } from '../../utils/script-data';
 import { buildSeries } from '../../utils/traffic-series';
 import './traffic-chart-card.scss';
@@ -38,7 +38,7 @@ const INTERVAL_OPTIONS: Array< { label: string; value: string } > = [
  * @return The chart card element.
  */
 export default function TrafficChartCard(): JSX.Element {
-	const needsUpgrade = ! siteHasFeature( features.ENHANCED_PUBLISHING );
+	const needsUpgrade = ! hasSocialPaidFeatures();
 	const { setTrafficInterval } = useDispatch( socialStore );
 
 	// Only read real referrer data when we'd actually show it. Reading

--- a/projects/packages/publicize/_inc/components/settings-tab/default-share-message-card.tsx
+++ b/projects/packages/publicize/_inc/components/settings-tab/default-share-message-card.tsx
@@ -17,10 +17,9 @@ const SAVE_DEBOUNCE_MS = 1000;
  * chassis surface re-homes that editor when the legacy
  * `SocialModuleToggle` retires in PR 5.
  *
- * The parent Settings tab gates the entire card on
- * `siteHasFeature( 'social-message-templates' )` so stickerless sites
- * never see it. That keeps this component free of feature-flag
- * branching — when it renders, the feature is on.
+ * The parent Settings tab gates the entire card on `hasSocialPaidFeatures()`
+ * (and `manage_options`) so non-paid sites never see it. That keeps this
+ * component free of feature-flag branching — when it renders, the feature is on.
  *
  * @return The card.
  */

--- a/projects/packages/publicize/_inc/components/settings-tab/index.tsx
+++ b/projects/packages/publicize/_inc/components/settings-tab/index.tsx
@@ -2,7 +2,7 @@ import { currentUserCan, siteHasFeature } from '@automattic/jetpack-script-data'
 import { useSelect } from '@wordpress/data';
 import { Card, Stack } from '@wordpress/ui';
 import { store as socialStore } from '../../social-store';
-import { features, getSocialScriptData } from '../../utils';
+import { features, getSocialScriptData, hasSocialPaidFeatures } from '../../utils';
 import { canToggleSocialModule } from '../../utils/misc';
 import ContentCreationCard from './content-creation-card';
 import CustomizeLinksCard from './customize-links-card';
@@ -18,7 +18,7 @@ import './style.scss';
  * → `Tabs.Panel value="settings"`). Composes four WPDS `Card` groups
  * that mirror the design's section grouping:
  *
- * - **Default share message** — global message-template editor, sticker-gated.
+ * - **Default share message** — global message-template editor, paid-gated.
  * - **Content creation** — Social Notes (Social-plugin only — the CPT registration lives in the plugin).
  * - **Customize media** — Social Image Generator (paid).
  * - **Customize links** — UTM parameters.
@@ -58,8 +58,7 @@ export default function SettingsTab(): JSX.Element {
 
 	const hasSocialPlugin = Boolean( getSocialScriptData().plugin_info.social.version );
 	const hasImageGenerator = siteHasFeature( features.IMAGE_GENERATOR );
-	const hasMessageTemplates =
-		siteHasFeature( features.MESSAGE_TEMPLATES ) && currentUserCan( 'manage_options' );
+	const hasMessageTemplates = hasSocialPaidFeatures() && currentUserCan( 'manage_options' );
 
 	return (
 		<Stack direction="column" gap="lg" className="jetpack-social-settings">

--- a/projects/packages/publicize/_inc/components/settings-tab/test/index.test.tsx
+++ b/projects/packages/publicize/_inc/components/settings-tab/test/index.test.tsx
@@ -2,7 +2,7 @@ import { currentUserCan, siteHasFeature } from '@automattic/jetpack-script-data'
 import { render, screen } from '@testing-library/react';
 import { useSelect } from '@wordpress/data';
 import SettingsTab from '..';
-import { getSocialScriptData } from '../../../utils';
+import { getSocialScriptData, hasSocialPaidFeatures } from '../../../utils';
 import { canToggleSocialModule } from '../../../utils/misc';
 import { useTurnOnSocial } from '../turn-on-social-context';
 
@@ -37,9 +37,9 @@ jest.mock( '@automattic/jetpack-script-data', () => ( {
 jest.mock( '../../../utils', () => ( {
 	features: {
 		IMAGE_GENERATOR: 'social-image-generator',
-		MESSAGE_TEMPLATES: 'social-message-templates',
 	},
 	getSocialScriptData: jest.fn(),
+	hasSocialPaidFeatures: jest.fn(),
 } ) );
 
 jest.mock( '../../../utils/misc', () => ( { canToggleSocialModule: jest.fn() } ) );
@@ -47,6 +47,7 @@ jest.mock( '../../../utils/misc', () => ( { canToggleSocialModule: jest.fn() } )
 const mockUseSelect = useSelect as jest.Mock;
 const mockCurrentUserCan = currentUserCan as jest.Mock;
 const mockSiteHasFeature = siteHasFeature as jest.Mock;
+const mockHasSocialPaidFeatures = hasSocialPaidFeatures as jest.Mock;
 const mockGetSocialScriptData = getSocialScriptData as jest.Mock;
 const mockCanToggleSocialModule = canToggleSocialModule as jest.Mock;
 const mockUseTurnOnSocial = useTurnOnSocial as jest.Mock;
@@ -60,7 +61,8 @@ const mockUseTurnOnSocial = useTurnOnSocial as jest.Mock;
  * @param overrides.canToggle           - Whether the current user can toggle Social modules.
  * @param overrides.socialPluginVersion - The Social plugin version (null when the plugin is inactive).
  * @param overrides.manageOptions       - Whether the current user has the manage_options capability.
- * @param overrides.features            - Map of paid feature slugs to whether the site has them.
+ * @param overrides.features            - Map of feature slugs to whether the site has them.
+ * @param overrides.hasPaidFeatures     - Whether the site has social paid features.
  * @param overrides.isEnabling          - Whether Social is mid-way through being turned on.
  */
 function setupSite(
@@ -70,6 +72,7 @@ function setupSite(
 		socialPluginVersion?: string | null;
 		manageOptions?: boolean;
 		features?: Record< string, boolean >;
+		hasPaidFeatures?: boolean;
 		isEnabling?: boolean;
 	} = {}
 ) {
@@ -78,7 +81,8 @@ function setupSite(
 		canToggle = true,
 		socialPluginVersion = '1.0.0',
 		manageOptions = true,
-		features = { 'social-image-generator': true, 'social-message-templates': true },
+		features = { 'social-image-generator': true },
+		hasPaidFeatures = true,
 		isEnabling = false,
 	} = overrides;
 
@@ -96,6 +100,7 @@ function setupSite(
 		cap === 'manage_options' ? manageOptions : false
 	);
 	mockSiteHasFeature.mockImplementation( feature => features[ feature ] ?? false );
+	mockHasSocialPaidFeatures.mockReturnValue( hasPaidFeatures );
 	mockUseTurnOnSocial.mockReturnValue( { isEnabling, turnOn: jest.fn() } );
 }
 
@@ -158,13 +163,18 @@ describe( 'SettingsTab', () => {
 		expect( screen.getByTestId( 'customize-links-card' ) ).toBeInTheDocument();
 	} );
 
-	it( 'renders the Default share message card only with the message-templates feature AND manage_options', () => {
-		setupSite( { features: { 'social-message-templates': true }, manageOptions: true } );
+	it( 'renders the Default share message card only with paid features AND manage_options', () => {
+		setupSite( { hasPaidFeatures: true, manageOptions: true } );
 		const { unmount } = render( <SettingsTab /> );
 		expect( screen.getByTestId( 'default-share-message-card' ) ).toBeInTheDocument();
 		unmount();
 
-		setupSite( { features: { 'social-message-templates': true }, manageOptions: false } );
+		setupSite( { hasPaidFeatures: true, manageOptions: false } );
+		const { unmount: unmount2 } = render( <SettingsTab /> );
+		expect( screen.queryByTestId( 'default-share-message-card' ) ).not.toBeInTheDocument();
+		unmount2();
+
+		setupSite( { hasPaidFeatures: false, manageOptions: true } );
 		render( <SettingsTab /> );
 		expect( screen.queryByTestId( 'default-share-message-card' ) ).not.toBeInTheDocument();
 	} );

--- a/projects/packages/publicize/_inc/components/share-buttons/useShareButtonText.ts
+++ b/projects/packages/publicize/_inc/components/share-buttons/useShareButtonText.ts
@@ -1,10 +1,9 @@
-import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useCallback } from '@wordpress/element';
 import { useManualShareMessage } from '../../hooks/use-manual-share-message';
 import { usePostMeta } from '../../hooks/use-post-meta';
-import { features } from '../../utils';
+import { hasSocialPaidFeatures } from '../../utils';
 
 /**
  * Prepares the text to share.
@@ -12,7 +11,7 @@ import { features } from '../../utils';
  * @return {(textWithPlaceholders: string, isUrl: boolean) => string} A function that accepts the text with placeholders and returns the text with the placeholders replaced.
  */
 export function useShareButtonText() {
-	const templatesEnabled = siteHasFeature( features.MESSAGE_TEMPLATES );
+	const templatesEnabled = hasSocialPaidFeatures();
 	const { shareMessage } = usePostMeta();
 	const manual = useManualShareMessage();
 

--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
@@ -3,7 +3,7 @@ import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useMemo, useRef } from 'react';
 import { store as socialStore } from '../../social-store';
-import { features } from '../../utils';
+import { features, hasSocialPaidFeatures } from '../../utils';
 import useMediaDetails from '../use-media-details';
 import { usePerNetworkCustomization } from '../use-per-network-customization';
 import { usePostMeta } from '../use-post-meta';
@@ -89,7 +89,7 @@ export function useConnectionPreviewData( connection: Connection ): ConnectionPr
 		sig.url,
 	] );
 
-	const templatesEnabled = siteHasFeature( features.MESSAGE_TEMPLATES );
+	const templatesEnabled = hasSocialPaidFeatures();
 	const { items, postIntent } = useRenderMessageInputs();
 	const siteMessageTemplate = useSelect(
 		select =>

--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
@@ -49,8 +49,7 @@ export function useConnectionPreviewData( connection: Connection ): ConnectionPr
 
 	const sig = useSigPreview( generateSigPreview );
 
-	const isPerNetworkMode =
-		siteHasFeature( features.ENHANCED_PUBLISHING ) && usingPerNetworkCustomization;
+	const isPerNetworkMode = hasSocialPaidFeatures() && usingPerNetworkCustomization;
 
 	const media = useMemo< PostPreviewData[ 'media' ] >( () => {
 		if ( ! isPerNetworkMode ) {

--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/test/index.test.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/test/index.test.ts
@@ -421,11 +421,9 @@ describe( 'useConnectionPreviewData', () => {
 		expect( result.current.isLoading ).toBe( false );
 	} );
 
-	it( 'ignores rendered message when MESSAGE_TEMPLATES feature is off', () => {
+	it( 'ignores rendered message when the site lacks paid features', () => {
 		mockSelectCalls( { rendered: 'Should not be used', isLoadingRendered: true } );
-		mockSiteHasFeature.mockImplementation(
-			( feature: string ) => feature !== 'social-message-templates'
-		);
+		mockSiteHasFeature.mockReturnValue( false );
 		mockUseRenderMessageInputs.mockReturnValue( {
 			items: [
 				{

--- a/projects/packages/publicize/_inc/hooks/use-manual-share-message/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-manual-share-message/index.ts
@@ -1,9 +1,8 @@
-import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { useRegistry, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useEffect, useMemo } from '@wordpress/element';
 import { store as socialStore } from '../../social-store';
-import { features } from '../../utils';
+import { hasSocialPaidFeatures } from '../../utils';
 import { MANUAL_SHARE_SENTINEL, type RenderItem } from '../../utils/render-messages';
 import { useDebouncedRenderInputs, usePostIntent } from '../use-render-message-items';
 import useSocialMediaMessage from '../use-social-media-message';
@@ -34,7 +33,7 @@ export type ManualShareMessage = {
  * template, returns `{ message: null, isLoading: false }`.
  */
 export function useManualShareMessage(): ManualShareMessage {
-	const templatesEnabled = siteHasFeature( features.MESSAGE_TEMPLATES );
+	const templatesEnabled = hasSocialPaidFeatures();
 	const registry = useRegistry();
 
 	const { message: globalMessage } = useSocialMediaMessage();

--- a/projects/packages/publicize/_inc/hooks/use-per-network-customization/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-per-network-customization/index.ts
@@ -1,11 +1,10 @@
-import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useCallback, useMemo } from '@wordpress/element';
 import { store as socialStore } from '../../social-store';
 import { CUSTOMIZE_PER_NETWORK_KEY } from '../../social-store/constants';
-import { features, hasSocialPaidFeatures } from '../../utils';
+import { hasSocialPaidFeatures } from '../../utils';
 import useFeaturedImage from '../use-featured-image';
 import useMediaDetails from '../use-media-details';
 import { usePostMeta } from '../use-post-meta';
@@ -38,9 +37,9 @@ export function usePerNetworkCustomization() {
 
 	const syncConnections = useCallback( () => {
 		/*
-		 * Don't sync when the message-templates feature is on. Server-side defaults
+		 * Don't sync on paid sites — server-side defaults handle the templates.
 		 */
-		if ( siteHasFeature( features.MESSAGE_TEMPLATES ) ) {
+		if ( hasSocialPaidFeatures() ) {
 			return;
 		}
 

--- a/projects/packages/publicize/_inc/hooks/use-post-meta/index.js
+++ b/projects/packages/publicize/_inc/hooks/use-post-meta/index.js
@@ -1,8 +1,7 @@
-import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useCallback, useMemo, useRef } from '@wordpress/element';
-import { features, useShareMessageMaxLength } from '../../utils';
+import { hasSocialPaidFeatures, useShareMessageMaxLength } from '../../utils';
 
 /**
  * This is to avoid creating a new empty array each time the value is requested.
@@ -36,7 +35,12 @@ export function usePostMeta() {
 
 			let shareMessage = meta.jetpack_publicize_message || '';
 
-			if ( ! siteHasFeature( features.MESSAGE_TEMPLATES ) ) {
+			/*
+			 * Paid sites can use placeholders (e.g. {title}) that expand at render time,
+			 * so the raw character limit doesn't apply. Non-paid sites share the literal
+			 * text, so cap it to the max length.
+			 */
+			if ( ! hasSocialPaidFeatures() ) {
 				shareMessage = shareMessage.substring( 0, maxCharacterLength );
 			}
 

--- a/projects/packages/publicize/_inc/hooks/use-render-message-items/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-render-message-items/index.ts
@@ -4,7 +4,7 @@ import { store as editorStore } from '@wordpress/editor';
 import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { store as socialStore } from '../../social-store';
 import { Connection } from '../../social-store/types';
-import { features } from '../../utils';
+import { features, hasSocialPaidFeatures } from '../../utils';
 import useFeaturedImage from '../use-featured-image';
 import useMediaDetails from '../use-media-details';
 import { usePerNetworkCustomization } from '../use-per-network-customization';
@@ -103,7 +103,7 @@ export function useRenderMessageItems(): RenderItem[] {
  * @return The current post intent.
  */
 export function usePostIntent(): RenderPostIntent {
-	const templatesEnabled = siteHasFeature( features.MESSAGE_TEMPLATES );
+	const templatesEnabled = hasSocialPaidFeatures();
 
 	return useSelect(
 		select => {
@@ -132,7 +132,7 @@ export function useRenderMessageInputs(): {
 	items: RenderItem[];
 	postIntent: RenderPostIntent;
 } {
-	const templatesEnabled = siteHasFeature( features.MESSAGE_TEMPLATES );
+	const templatesEnabled = hasSocialPaidFeatures();
 
 	// All connections (not just enabled ones) — the per-connection customization
 	// editor is visible for the focused tab regardless of toggle state, so editing

--- a/projects/packages/publicize/_inc/hooks/use-render-message-items/test/index.test.ts
+++ b/projects/packages/publicize/_inc/hooks/use-render-message-items/test/index.test.ts
@@ -111,9 +111,7 @@ const mockSelect = ( connections: Connection[], siteMessageTemplate = '' ) => {
 };
 
 const allFeaturesOn = ( feature: string ) =>
-	[ 'social-message-templates', 'social-image-generator', 'social-enhanced-publishing' ].includes(
-		feature
-	);
+	[ 'social-image-generator', 'social-enhanced-publishing' ].includes( feature );
 
 let mockConnections: Connection[];
 let mockPostIntent: {
@@ -186,7 +184,7 @@ describe( 'useRenderMessageItems', () => {
 		clearMockedScriptData();
 	} );
 
-	it( 'returns empty items when MESSAGE_TEMPLATES is off', () => {
+	it( 'returns empty items when the site lacks paid features', () => {
 		mockSiteHasFeature.mockReturnValue( false );
 		mockSelect( [] );
 

--- a/projects/packages/publicize/_inc/hooks/use-schedule-post/index.tsx
+++ b/projects/packages/publicize/_inc/hooks/use-schedule-post/index.tsx
@@ -4,7 +4,7 @@ import { useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as socialStore } from '../../social-store';
-import { features, SHARING_ACTIVITY_TABS } from '../../utils';
+import { features, hasSocialPaidFeatures, SHARING_ACTIVITY_TABS } from '../../utils';
 import useSocialMediaConnections from '../use-social-media-connections';
 import useSocialMediaMessage from '../use-social-media-message';
 
@@ -53,9 +53,7 @@ export function useSchedulePost() {
 			 * SIG is saved to the post meta and will be read on wpcom. Because of that we need to save
 			 * the post before sharing it, if it has the media features to make sure we use the latest data.
 			 */
-			const savePost =
-				siteHasFeature( features.IMAGE_GENERATOR ) ||
-				siteHasFeature( features.ENHANCED_PUBLISHING );
+			const savePost = siteHasFeature( features.IMAGE_GENERATOR ) || hasSocialPaidFeatures();
 
 			return await scheduleShares( { connectionIds, message, timestamp }, { savePost, actions } );
 		},

--- a/projects/packages/publicize/_inc/hooks/use-share-post/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-share-post/index.ts
@@ -2,7 +2,7 @@ import { siteHasFeature } from '@automattic/jetpack-script-data';
 import { useDispatch } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
 import { store as socialStore } from '../../social-store';
-import { features, getSocialScriptData } from '../../utils';
+import { features, getSocialScriptData, hasSocialPaidFeatures } from '../../utils';
 import useSocialMediaConnections from '../use-social-media-connections';
 import useSocialMediaMessage from '../use-social-media-message';
 
@@ -31,9 +31,7 @@ export function useSharePost() {
 			 * SIG is saved to the post meta and will be read on wpcom. Because of that we need to save
 			 * the post before sharing it, if it has the media features to make sure we use the latest data.
 			 */
-			const savePost =
-				siteHasFeature( features.IMAGE_GENERATOR ) ||
-				siteHasFeature( features.ENHANCED_PUBLISHING );
+			const savePost = siteHasFeature( features.IMAGE_GENERATOR ) || hasSocialPaidFeatures();
 
 			return await shareCurrentPost(
 				{ message, skipped_connections },

--- a/projects/packages/publicize/_inc/utils/constants.ts
+++ b/projects/packages/publicize/_inc/utils/constants.ts
@@ -3,7 +3,6 @@ export const features = {
 	ENHANCED_PUBLISHING: 'social-enhanced-publishing',
 	IMAGE_FOCAL_POINT: 'social-image-focal-point',
 	IMAGE_GENERATOR: 'social-image-generator',
-	MESSAGE_TEMPLATES: 'social-message-templates',
 };
 
 export const SHARING_ACTIVITY_TABS = {

--- a/projects/packages/publicize/_inc/utils/test-factory.jsx
+++ b/projects/packages/publicize/_inc/utils/test-factory.jsx
@@ -23,6 +23,7 @@ export const setup = ( {
 	getDeletingConnections = [],
 	getUpdatingConnections = [],
 	canUserManageConnection = true,
+	socialSettings = { messageTemplate: '' },
 } = {} ) => {
 	let storeSelect;
 	renderHook( () => useSelect( select => ( storeSelect = select( store ) ) ) );
@@ -44,6 +45,7 @@ export const setup = ( {
 		.spyOn( storeSelect, 'canUserManageConnection' )
 		.mockReset()
 		.mockReturnValue( canUserManageConnection );
+	jest.spyOn( storeSelect, 'getSocialSettings' ).mockReset().mockReturnValue( socialSettings );
 
 	const { result: dispatch } = renderHook( () => useDispatch( store ) );
 	const stubDeleteConnectionById = jest

--- a/projects/packages/publicize/changelog/remove-social-message-templates-feature-check
+++ b/projects/packages/publicize/changelog/remove-social-message-templates-feature-check
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Remove the use of message templates feature flag.
+
+

--- a/projects/packages/publicize/src/class-publicize-base.php
+++ b/projects/packages/publicize/src/class-publicize-base.php
@@ -1133,7 +1133,7 @@ abstract class Publicize_Base {
 		/*
 		 * Default the share-message meta to the saved global template
 		 */
-		$message_default = Current_Plan::supports( 'social-message-templates' )
+		$message_default = $this->has_paid_features()
 			? ( new Jetpack_Social_Settings\Settings() )->get_message_template()
 			: '';
 
@@ -1286,7 +1286,7 @@ abstract class Publicize_Base {
 		);
 
 		$customize_per_network_default = (
-			Current_Plan::supports( 'social-message-templates' )
+			$this->has_paid_features()
 			&& $this->any_connection_has_custom_template()
 		);
 

--- a/projects/packages/publicize/src/class-publicize-ui.php
+++ b/projects/packages/publicize/src/class-publicize-ui.php
@@ -573,7 +573,7 @@ jQuery( function($) {
 
 		$is_post_published = 'publish' === get_post_status( $post->ID );
 
-		$templates_enabled = Current_Plan::supports( 'social-message-templates' );
+		$templates_enabled = $this->publicize->has_paid_features();
 
 		$placeholders = $this->get_message_placeholders();
 

--- a/projects/packages/publicize/src/rest-api/class-connections-post-field.php
+++ b/projects/packages/publicize/src/rest-api/class-connections-post-field.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\Publicize\REST_API;
 
-use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Publicize\Publicize_Base;
 use WP_Error;
 use WP_Post;
@@ -248,7 +247,7 @@ class Connections_Post_Field {
 			$connection_overrides  = array();
 		}
 
-		$message_templates_enabled = Current_Plan::supports( 'social-message-templates' );
+		$message_templates_enabled = $publicize && $publicize->has_paid_features();
 
 		$output_connections = array();
 		foreach ( $connections as $connection ) {

--- a/projects/packages/publicize/src/rest-api/class-render-messages-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-render-messages-controller.php
@@ -22,8 +22,8 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * Renders Publicize message templates for a given post and a batch of
  * connection inputs in a single request, so the block-editor preview can
- * fetch all enabled connections' previews in one round-trip when the
- * `social-message-templates` feature is enabled.
+ * fetch all enabled connections' previews in one round-trip on sites with
+ * social paid features.
  *
  * POST takes a JSON body of `{ post_id, items: [...], post_intent: {...} }`
  * and returns one record per input item, in input order, keyed by the
@@ -215,9 +215,7 @@ class Render_Messages_Controller extends Base_Controller {
 	 */
 	public function render_messages( $request ) {
 		if ( Utils::is_wpcom() ) {
-			require_lib( 'publicize/util/message-templates' );
-
-			if ( ! \Publicize\is_message_templates_enabled() ) {
+			if ( ! wpcom_site_has_feature( \WPCOM_Features::SOCIAL_ENHANCED_PUBLISHING ) ) {
 				return new WP_Error(
 					'feature_not_enabled',
 					__( 'Publicize message templates are not enabled for this site.', 'jetpack-publicize-pkg' ),

--- a/projects/packages/publicize/src/rest-api/class-render-messages-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-render-messages-controller.php
@@ -237,6 +237,8 @@ class Render_Messages_Controller extends Base_Controller {
 				);
 			}
 
+			require_lib( 'publicize/util/message-templates' );
+
 			return rest_ensure_response(
 				\Publicize\render_messages( $post, $items, $intent )
 			);

--- a/projects/packages/publicize/tests/php/Connections_Post_Field_Test.php
+++ b/projects/packages/publicize/tests/php/Connections_Post_Field_Test.php
@@ -322,7 +322,7 @@ class Connections_Post_Field_Test extends TestCase {
 	public function test_customize_per_network_defaults_on_with_custom_connection_template() {
 		$this->publicize->method( 'has_paid_features' )
 			->willReturn( true );
-		$this->set_active_plan_features( array( 'social-message-templates' ) );
+		$this->set_active_plan_features( array( 'social-enhanced-publishing' ) );
 		$this->set_cached_connection_with_template( 'Custom template' );
 		$this->reregister_publicize_post_meta();
 
@@ -341,7 +341,7 @@ class Connections_Post_Field_Test extends TestCase {
 	public function test_customize_per_network_defaults_off_without_custom_connection_template() {
 		$this->publicize->method( 'has_paid_features' )
 			->willReturn( true );
-		$this->set_active_plan_features( array( 'social-message-templates' ) );
+		$this->set_active_plan_features( array( 'social-enhanced-publishing' ) );
 		$this->set_cached_connection_with_template( '   ' );
 		$this->reregister_publicize_post_meta();
 
@@ -354,7 +354,7 @@ class Connections_Post_Field_Test extends TestCase {
 	public function test_customize_per_network_explicit_false_overrides_template_default() {
 		$this->publicize->method( 'has_paid_features' )
 			->willReturn( true );
-		$this->set_active_plan_features( array( 'social-message-templates' ) );
+		$this->set_active_plan_features( array( 'social-enhanced-publishing' ) );
 		$this->set_cached_connection_with_template( 'Custom template' );
 		$this->reregister_publicize_post_meta();
 


### PR DESCRIPTION
Corresponding wpcom change - 229914-ghe-Automattic/wpcom

## Proposed changes

The `social-message-templates` feature has shipped and is gated identically to `social-enhanced-publishing` (the paid social gate) on both Simple and Atomic sites, so `siteHasFeature( features.MESSAGE_TEMPLATES )` is now equivalent to `hasSocialPaidFeatures()`.

* Replace every `siteHasFeature( features.MESSAGE_TEMPLATES )` check with the `hasSocialPaidFeatures()` helper and remove the `MESSAGE_TEMPLATES` constant.
* **Fix a bug in `connection-template`**: the message-templates gate short-circuited (returned `null`) *before* the plan-based upsell could render, and since it was gated on the same paid plan as the upsell's `enhanced-publishing` check, the "upgrade your plan" prompt was unreachable — non-paid sites saw nothing for per-connection customization. Removing the redundant gate restores the upsell, and dropping the dashboard-only restriction lets it show in the block editor too (Simple sites still render nothing).
* Second commit: replace the remaining direct `siteHasFeature( features.ENHANCED_PUBLISHING )` UI/hook checks with `hasSocialPaidFeatures()` for consistency.
* **PHP:** the same graduation server-side. The four `Current_Plan::supports( 'social-message-templates' )` checks in `src/` now use the existing `has_paid_features()` helper, and the wpcom render-messages endpoint gates on `wpcom_site_has_feature( WPCOM_Features::SOCIAL_ENHANCED_PUBLISHING )` instead of `\Publicize\is_message_templates_enabled()` (removed in the linked wpcom change). All behavior-preserving — the two features share plan gating.

Non-paid sites keep the literal-message truncation, `maxLength` cap, and hidden template UI; the only behavior change is that the per-connection upgrade upsell now renders as intended.

## Related product discussion/links

<!-- TODO: add the Linear issue link -->

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site **with** social paid features: the block editor Social panel and the Social dashboard Settings tab behave exactly as before — message/template UI, per-connection template editor, and Default share message card.
* On a non-Simple site **without** paid features: the per-connection message area now shows a disabled textarea with your default share message and an "upgrade your plan" link (previously it showed nothing). This appears in both the block editor and the Social dashboard.
* On a Simple site without paid features: still renders nothing.
* `jetpack test js packages/publicize` and `jetpack test php packages/publicize` pass.

This upsell on the free plan should be visible

<img width="821" height="227" alt="image" src="https://github.com/user-attachments/assets/73cede63-2675-408e-875e-5a9f6594106e" />
