### PR TITLE
Premium Analytics: prevent widget content clipping on Simple sites

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-premium-analytics-widget-clipping
+++ b/projects/packages/premium-analytics/changelog/fix-premium-analytics-widget-clipping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix dashboard widget content clipping on WordPress.com Simple sites.

--- a/projects/packages/premium-analytics/routes/dashboard/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.module.scss
@@ -9,6 +9,13 @@
 	block-size: 100%;
 }
 
+.widgetGrid [data-wp-grid-item-key] > [role="button"][aria-roledescription="sortable"] > div > section {
+	// WordPress.com Simple loads a legacy, unlayered `section { display: block; }`
+	// rule that outranks the layered Card styles from `@wordpress/ui`.
+	display: flex;
+	flex-direction: column;
+}
+
 .content {
 	flex: 1 1 auto;
 	min-block-size: 0;

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -123,7 +123,7 @@ function Dashboard(): JSX.Element {
 								{ activeSection === section.slug ? (
 									<>
 										<WidgetDashboard.NoWidgetsState />
-										<WidgetDashboard.Widgets />
+										<WidgetDashboard.Widgets className={ styles.widgetGrid } />
 									</>
 								) : null }
 							</SectionTabPanel>


### PR DESCRIPTION
Fixes #

## Proposed changes

* Add an app-owned class to the Premium Analytics dashboard widget grid.
* Restore the widget Card's flex-column layout with a selector scoped to the grid-item/card boundary.
* Prevent charts and widget report footers from being clipped on WordPress.com Simple sites.

The root cause is a legacy, unlayered `section { display: block; }` rule loaded on Simple sites. That rule outranks the layered Card styles from `@wordpress/ui`, so the Card content no longer receives the remaining height and overflows its fixed widget tile.

## Related product discussion/links

* N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a WordPress.com Simple site with Premium Analytics enabled, open the Traffic dashboard and select a date range that displays chart data.
* Verify the Traffic chart's x-axis and bottom content remain visible within the widget card.
* Scroll to widgets that include a report link, such as Most viewed, and verify the report footer remains visible inside the card.
* Verify widget layout and resizing continue to work in both grid and masonry modes.
* Confirm the dashboard remains unchanged on a non-Simple site.

Validation completed locally:

* ESLint and Stylelint
* TypeScript type checking
* Jest: 185 suites and 1,246 tests passed
* Production build and generated asset validation
