### PR TITLE
Premium Analytics: run JavaScript tests in CI

### DIFF
--- a/projects/packages/premium-analytics/changelog/enable-premium-analytics-js-tests-ci
+++ b/projects/packages/premium-analytics/changelog/enable-premium-analytics-js-tests-ci
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Enable the existing JavaScript test and coverage suites in CI.

--- a/projects/packages/premium-analytics/composer.json
+++ b/projects/packages/premium-analytics/composer.json
@@ -30,6 +30,8 @@
 		],
 		"test-php": "@composer phpunit",
 		"test-php-coverage": "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\"",
+		"test-js": "pnpm run test",
+		"test-js-coverage": "pnpm run test-coverage",
 		"build-development": [
 			"pnpm run build"
 		],

--- a/projects/packages/premium-analytics/package.json
+++ b/projects/packages/premium-analytics/package.json
@@ -11,6 +11,7 @@
 		"build-production": "NODE_ENV=production BABEL_ENV=production pnpm run build:wp-build && pnpm run build:strip-unminified-prod && pnpm run build:boot-asset && pnpm run validate",
 		"storybook": "cd ../../js-packages/storybook && pnpm run storybook:dev",
 		"test": "jest --config=tests/jest.config.cjs",
+		"test-coverage": "pnpm run test --coverage",
 		"typecheck": "tsgo --noEmit",
 		"validate": "pnpm exec validate-es --no-error-on-unmatched-pattern build/",
 		"watch": "wp-build --watch"

--- a/projects/plugins/mu-wpcom-plugin/changelog/enable-premium-analytics-js-tests-ci
+++ b/projects/plugins/mu-wpcom-plugin/changelog/enable-premium-analytics-js-tests-ci
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+Comment: Sync Premium Analytics dependency metadata.
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1727,7 +1727,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/premium-analytics",
-                "reference": "8a37e653800a0f6eab73996b880000796cd0ff4c"
+                "reference": "65140eaa3f8196b645d464edf243e9282a392e13"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1774,6 +1774,12 @@
                 ],
                 "test-php-coverage": [
                     "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-js": [
+                    "pnpm run test"
+                ],
+                "test-js-coverage": [
+                    "pnpm run test-coverage"
                 ],
                 "build-development": [
                     "pnpm run build"

--- a/projects/plugins/premium-analytics/changelog/enable-premium-analytics-js-tests-ci
+++ b/projects/plugins/premium-analytics/changelog/enable-premium-analytics-js-tests-ci
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+Comment: Sync Premium Analytics dependency metadata.
+

--- a/projects/plugins/premium-analytics/composer.lock
+++ b/projects/plugins/premium-analytics/composer.lock
@@ -844,7 +844,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/premium-analytics",
-                "reference": "8a37e653800a0f6eab73996b880000796cd0ff4c"
+                "reference": "65140eaa3f8196b645d464edf243e9282a392e13"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -891,6 +891,12 @@
                 ],
                 "test-php-coverage": [
                     "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-js": [
+                    "pnpm run test"
+                ],
+                "test-js-coverage": [
+                    "pnpm run test-coverage"
                 ],
                 "build-development": [
                     "pnpm run build"

--- a/projects/plugins/wpcomsh/changelog/enable-premium-analytics-js-tests-ci
+++ b/projects/plugins/wpcomsh/changelog/enable-premium-analytics-js-tests-ci
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+Comment: Sync Premium Analytics dependency metadata.
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1908,7 +1908,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/premium-analytics",
-                "reference": "2e38923863dbc23890ece6403cd0ad2fb153b650"
+                "reference": "3692f77bd05e041fc092112b82042c0c826e52bb"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -1955,6 +1955,12 @@
                 ],
                 "test-php-coverage": [
                     "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-js": [
+                    "pnpm run test"
+                ],
+                "test-js-coverage": [
+                    "pnpm run test-coverage"
                 ],
                 "build-development": [
                     "pnpm run build"


### PR DESCRIPTION
Related to WOOA7S-1717

## Proposed changes

Premium Analytics already has a JavaScript test suite, but the package does not expose Composer `test-js` / `test-js-coverage` scripts. The standard Jetpack JS test jobs therefore skip the package.

- Add `test-js` and `test-js-coverage` so the existing suite runs in CI, including under coverage.
- Refresh only the Composer lockfiles that embed Premium Analytics package metadata.
- Keep this CI configuration separate from the widget availability changes in #50732.

No change is needed in `projects/packages/premium-analytics/tests/jest.config.cjs`: since #50782 added the wp-build paths to `tools/js-tools/jest/config.coverage.js`, and `config.base.js` inherits `collectCoverageFrom` through `config.node.js`, the package picks them up already.

## Related product discussion/links

- WOOA7S-1717
- #50732
- #50782

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Run `pnpm install --frozen-lockfile`.
2. Run `pnpm jetpack test js packages/premium-analytics`.
3. Confirm all Premium Analytics JavaScript tests pass.
4. Run `pnpm jetpack test js-coverage -v packages/premium-analytics`.
5. Open the generated JS coverage report and confirm it includes the `packages/`, `routes/`, and `widgets/` directories rather than being empty.
6. Run the Composer monorepo update tool for the Premium Analytics, mu-wpcom-plugin, and wpcomsh plugin lockfiles.
7. Confirm each reports `Nothing to modify in lock file`.
