### PR TITLE
Social: add the platform picker step for the new connection flow

### DIFF
--- a/projects/packages/publicize/_inc/components/connection-flow/index.tsx
+++ b/projects/packages/publicize/_inc/components/connection-flow/index.tsx
@@ -1,8 +1,8 @@
 import { ThemeProvider } from '@automattic/jetpack-components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
-import { chevronLeft } from '@wordpress/icons';
+import { __, isRTL, sprintf } from '@wordpress/i18n';
+import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { Dialog, IconButton, Text, Tooltip } from '@wordpress/ui';
 import { store as socialStore } from '../../social-store';
 import { SelectPlatform } from './select-platform';
@@ -111,7 +111,7 @@ const ConnectionFlowDialog = () => {
 								variant="minimal"
 								tone="neutral"
 								size="small"
-								icon={ chevronLeft }
+								icon={ isRTL() ? chevronRight : chevronLeft }
 								label={ __( 'Back', 'jetpack-publicize-pkg' ) }
 								onClick={ goToPreviousStep }
 							/>

--- a/projects/packages/publicize/_inc/components/connection-flow/index.tsx
+++ b/projects/packages/publicize/_inc/components/connection-flow/index.tsx
@@ -5,6 +5,7 @@ import { __, sprintf } from '@wordpress/i18n';
 import { chevronLeft } from '@wordpress/icons';
 import { Dialog, IconButton, Text, Tooltip } from '@wordpress/ui';
 import { store as socialStore } from '../../social-store';
+import { SelectPlatform } from './select-platform';
 import type { ConnectionFlowStep } from '../../social-store/types';
 
 /**
@@ -22,8 +23,7 @@ const StepPlaceholder = ( { step }: { step: ConnectionFlowStep } ) => (
 );
 
 /**
- * Step router: maps the current connection-flow step to its content. Every step
- * renders a placeholder for now; M2-01…04 slot their components in here.
+ * Step router: maps the current connection-flow step to its content.
  *
  * @param step - The current flow step.
  * @return The step content.
@@ -31,6 +31,7 @@ const StepPlaceholder = ( { step }: { step: ConnectionFlowStep } ) => (
 function renderStep( step: ConnectionFlowStep ): JSX.Element {
 	switch ( step ) {
 		case 'select-platform':
+			return <SelectPlatform />;
 		case 'platform-input':
 		case 'authorizing':
 		case 'confirm':

--- a/projects/packages/publicize/_inc/components/connection-flow/platform-grid/index.tsx
+++ b/projects/packages/publicize/_inc/components/connection-flow/platform-grid/index.tsx
@@ -1,0 +1,64 @@
+import { useCallback } from '@wordpress/element';
+import { Text } from '@wordpress/ui';
+import { SupportedService } from '../../services/types';
+import { useSupportedServices } from '../../services/use-supported-services';
+import styles from './style.module.scss';
+
+interface PlatformCardProps {
+	service: SupportedService;
+	onSelect: ( serviceId: string ) => void;
+}
+
+/**
+ * A single platform card button.
+ *
+ * @param {PlatformCardProps} props - Component props.
+ *
+ * @return The platform card button.
+ */
+function PlatformCard( { service, onSelect }: PlatformCardProps ) {
+	const ServiceIcon = service.icon;
+
+	const handleClick = useCallback( () => onSelect( service.id ), [ onSelect, service.id ] );
+
+	return (
+		<button type="button" className={ styles.card } onClick={ handleClick }>
+			<ServiceIcon iconSize={ 48 } />
+			<span className={ styles.details }>
+				<Text variant="body-lg" render={ <span className={ styles.title } /> }>
+					{ service.shortLabel || service.label }
+				</Text>
+				<Text variant="body-md" render={ <span className={ styles[ 'account-type' ] } /> }>
+					{ service.accountType }
+				</Text>
+			</span>
+		</button>
+	);
+}
+
+interface PlatformGridProps {
+	onSelect: ( serviceId: string ) => void;
+}
+
+/**
+ * A 3-column grid of every supported platform. Shared between the connection
+ * flow's `select-platform` step and the dashboard "get started" empty state;
+ * each context decides what selecting a platform does via `onSelect`.
+ *
+ * @param {PlatformGridProps} props - Component props.
+ *
+ * @return The platform grid.
+ */
+export function PlatformGrid( { onSelect }: PlatformGridProps ) {
+	const supportedServices = useSupportedServices();
+
+	return (
+		<ul className={ styles.grid }>
+			{ supportedServices.map( service => (
+				<li key={ service.id }>
+					<PlatformCard service={ service } onSelect={ onSelect } />
+				</li>
+			) ) }
+		</ul>
+	);
+}

--- a/projects/packages/publicize/_inc/components/connection-flow/platform-grid/style.module.scss
+++ b/projects/packages/publicize/_inc/components/connection-flow/platform-grid/style.module.scss
@@ -1,0 +1,63 @@
+.grid {
+	display: grid;
+	grid-template-columns: repeat(3, minmax(0, 1fr));
+	gap: var(--wpds-dimension-gap-lg);
+	inline-size: 100%;
+	margin: 0;
+	list-style: none;
+
+	// The design only specifies a desktop 3-column layout. Below `small` a
+	// 3-up grid of 132px cards overflows, so drop to a single column rather
+	// than invent an undesigned mobile layout.
+	@media (max-width: 600px) {
+		grid-template-columns: 1fr;
+	}
+}
+
+// Each card is a real button so it is tab-navigable and activates on
+// Enter/Space out of the box.
+.card {
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	justify-content: center;
+	gap: var(--wpds-dimension-gap-sm);
+	width: 100%;
+	// Fixed height so every card is uniform, matching the design, regardless of
+	// whether a label wraps.
+	height: 132px;
+	padding: var(--wpds-dimension-padding-lg);
+	background: var(--wpds-color-background-surface-neutral);
+	border: 1px solid var(--wpds-color-stroke-surface-neutral);
+	border-radius: var(--wpds-border-radius-lg);
+	cursor: var(--wpds-cursor-control);
+	text-align: center;
+
+	@media not (prefers-reduced-motion) {
+		transition: border-color var(--wpds-motion-duration-md) var(--wpds-motion-easing-balanced);
+	}
+
+	&:hover {
+		border-color: var(--wpds-color-stroke-surface-neutral-strong);
+	}
+
+	&:focus-visible {
+		outline: var(--wpds-border-width-focus) solid var(--wpds-color-stroke-focus);
+		outline-offset: calc(var(--wpds-border-width-focus) * -1);
+	}
+}
+
+.details {
+	display: flex;
+	flex-direction: column;
+	gap: var(--wpds-dimension-gap-xs);
+}
+
+.title {
+	color: var(--wpds-color-foreground-content-neutral);
+	font-weight: var(--wpds-typography-font-weight-medium);
+}
+
+.account-type {
+	color: var(--wpds-color-foreground-content-neutral-weak);
+}

--- a/projects/packages/publicize/_inc/components/connection-flow/select-platform/index.tsx
+++ b/projects/packages/publicize/_inc/components/connection-flow/select-platform/index.tsx
@@ -1,0 +1,19 @@
+import { useDispatch } from '@wordpress/data';
+import { store } from '../../../social-store';
+import { PlatformGrid } from '../platform-grid';
+
+/**
+ * The platform picker step of the connection flow.
+ *
+ * Renders the platform grid as the body of the connection-flow modal's
+ * `Dialog.Content` (the modal owns the header/close/back chrome). Selecting a
+ * card advances the flow: services with custom inputs land on `platform-input`,
+ * the rest go straight to `authorizing` (routing lives in the reducer).
+ *
+ * @return {import('react').ReactNode} The platform picker step.
+ */
+export function SelectPlatform() {
+	const { selectPlatform } = useDispatch( store );
+
+	return <PlatformGrid onSelect={ selectPlatform } />;
+}

--- a/projects/packages/publicize/_inc/components/connection-flow/select-platform/tests/index.test.jsx
+++ b/projects/packages/publicize/_inc/components/connection-flow/select-platform/tests/index.test.jsx
@@ -1,0 +1,64 @@
+import { render, renderHook, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useSelect } from '@wordpress/data';
+import { SelectPlatform } from '..';
+import { store } from '../../../../social-store';
+import { setup } from '../../../../utils/test-factory';
+
+// The step is body-only; the connection-flow modal owns the Dialog chrome.
+const renderStep = () => render( <SelectPlatform /> );
+
+const getStoreSelect = () => {
+	let storeSelect;
+	renderHook( () => useSelect( select => ( storeSelect = select( store ) ) ) );
+	return storeSelect;
+};
+
+describe( 'SelectPlatform', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	test( 'renders a card for each supported service', () => {
+		setup();
+		renderStep();
+
+		// The shared factory seeds Facebook, LinkedIn and Instagram Business.
+		expect( screen.getByRole( 'button', { name: /Facebook/ } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: /LinkedIn/ } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: /Instagram/ } ) ).toBeInTheDocument();
+		expect( screen.getAllByRole( 'listitem' ) ).toHaveLength( 3 );
+		// The account-type descriptor is rendered alongside the platform name.
+		expect( screen.getByText( 'Page' ) ).toBeInTheDocument();
+	} );
+
+	test( 'selecting a service with custom inputs advances to platform-input', async () => {
+		const user = userEvent.setup();
+		setup();
+		const storeSelect = getStoreSelect();
+		jest
+			.spyOn( storeSelect, 'getServicesList' )
+			.mockReturnValue( [ { id: 'bluesky', label: 'Bluesky', status: 'ok' } ] );
+
+		renderStep();
+		await user.click( screen.getByRole( 'button', { name: /Bluesky/ } ) );
+
+		expect( storeSelect.getConnectionFlowSelectedServiceId() ).toBe( 'bluesky' );
+		expect( storeSelect.getConnectionFlowStep() ).toBe( 'platform-input' );
+	} );
+
+	test( 'selecting a regular service advances straight to authorizing', async () => {
+		const user = userEvent.setup();
+		setup();
+		const storeSelect = getStoreSelect();
+		jest
+			.spyOn( storeSelect, 'getServicesList' )
+			.mockReturnValue( [ { id: 'facebook', label: 'Facebook', status: 'ok' } ] );
+
+		renderStep();
+		await user.click( screen.getByRole( 'button', { name: /Facebook/ } ) );
+
+		expect( storeSelect.getConnectionFlowSelectedServiceId() ).toBe( 'facebook' );
+		expect( storeSelect.getConnectionFlowStep() ).toBe( 'authorizing' );
+	} );
+} );

--- a/projects/packages/publicize/_inc/components/services/types.ts
+++ b/projects/packages/publicize/_inc/components/services/types.ts
@@ -2,6 +2,17 @@ import { ConnectionService } from '../../types';
 
 export interface ServiceUiDetails {
 	description: string;
+	/**
+	 * Short account-type descriptor shown on the platform picker card
+	 * (e.g. "Profile", "Page"). Distinct from the longer `description`.
+	 */
+	accountType: string;
+	/**
+	 * Shorter label for the picker card, when the service `label` is too long
+	 * (e.g. "Instagram" for the "Instagram Business" service). Falls back to
+	 * `label`.
+	 */
+	shortLabel?: string;
 	icon: React.ComponentType< { iconSize: number } >;
 	examples?: Array< React.ComponentType >;
 	needsCustomInputs?: boolean;

--- a/projects/packages/publicize/_inc/components/services/utils.tsx
+++ b/projects/packages/publicize/_inc/components/services/utils.tsx
@@ -1,6 +1,6 @@
 import { SocialServiceIcon } from '@automattic/jetpack-components';
 import { createInterpolateElement } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { Link } from '@wordpress/ui';
 import { ConnectionService } from '../../types';
 import { assetUrl } from '../../utils';
@@ -26,6 +26,7 @@ export function getServiceUiDetails( id: ConnectionService[ 'id' ] ): ServiceUiD
 			return {
 				needsCustomInputs: true,
 				icon: props => <SocialServiceIcon serviceName="bluesky" { ...props } />,
+				accountType: _x( 'Profile', 'social account type', 'jetpack-publicize-pkg' ),
 				description: __( 'Share with your network.', 'jetpack-publicize-pkg' ),
 				examples: [
 					() => (
@@ -41,6 +42,7 @@ export function getServiceUiDetails( id: ConnectionService[ 'id' ] ): ServiceUiD
 		case 'facebook':
 			return {
 				icon: props => <SocialServiceIcon serviceName="facebook" { ...props } />,
+				accountType: _x( 'Page', 'social account type', 'jetpack-publicize-pkg' ),
 				description: __( 'Share to your pages', 'jetpack-publicize-pkg' ),
 				examples: [
 					() => (
@@ -66,6 +68,8 @@ export function getServiceUiDetails( id: ConnectionService[ 'id' ] ): ServiceUiD
 		case 'instagram-business':
 			return {
 				icon: props => <SocialServiceIcon serviceName="instagram" { ...props } />,
+				shortLabel: __( 'Instagram', 'jetpack-publicize-pkg' ),
+				accountType: _x( 'Business', 'social account type', 'jetpack-publicize-pkg' ),
 				description: __( 'Share to your Instagram Business account.', 'jetpack-publicize-pkg' ),
 				examples: [
 					() => (
@@ -124,6 +128,7 @@ export function getServiceUiDetails( id: ConnectionService[ 'id' ] ): ServiceUiD
 		case 'linkedin':
 			return {
 				icon: props => <SocialServiceIcon serviceName="linkedin" { ...props } />,
+				accountType: _x( 'Profile / Company', 'social account type', 'jetpack-publicize-pkg' ),
 				description: __( 'Share with your LinkedIn community.', 'jetpack-publicize-pkg' ),
 				examples: [
 					() => (
@@ -150,6 +155,7 @@ export function getServiceUiDetails( id: ConnectionService[ 'id' ] ): ServiceUiD
 			return {
 				needsCustomInputs: true,
 				icon: props => <SocialServiceIcon serviceName="mastodon" { ...props } />,
+				accountType: _x( 'Profile', 'social account type', 'jetpack-publicize-pkg' ),
 				description: __( 'Share with your network.', 'jetpack-publicize-pkg' ),
 				examples: [
 					() => (
@@ -166,6 +172,7 @@ export function getServiceUiDetails( id: ConnectionService[ 'id' ] ): ServiceUiD
 		case 'nextdoor':
 			return {
 				icon: props => <SocialServiceIcon serviceName="nextdoor" { ...props } />,
+				accountType: _x( 'Profile', 'social account type', 'jetpack-publicize-pkg' ),
 				description: __( 'Share on communities', 'jetpack-publicize-pkg' ),
 				examples: [
 					() => (
@@ -191,6 +198,7 @@ export function getServiceUiDetails( id: ConnectionService[ 'id' ] ): ServiceUiD
 		case 'threads':
 			return {
 				icon: props => <SocialServiceIcon serviceName="threads" { ...props } />,
+				accountType: _x( 'Profile', 'social account type', 'jetpack-publicize-pkg' ),
 				description: __( 'Share posts to your Threads feed.', 'jetpack-publicize-pkg' ),
 				examples: [
 					() => (
@@ -213,6 +221,7 @@ export function getServiceUiDetails( id: ConnectionService[ 'id' ] ): ServiceUiD
 		case 'tumblr':
 			return {
 				icon: props => <SocialServiceIcon serviceName="tumblr-alt" { ...props } />,
+				accountType: _x( 'Page', 'social account type', 'jetpack-publicize-pkg' ),
 				description: __( 'Share to your Tumblr blog.', 'jetpack-publicize-pkg' ),
 				examples: [
 					() => (

--- a/projects/packages/publicize/changelog/add-connection-flow-select-platform-step
+++ b/projects/packages/publicize/changelog/add-connection-flow-select-platform-step
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add the platform picker step for the new connection flow.


### PR DESCRIPTION
Fixes SOCIAL-530

## Proposed changes
* Add `components/connection-flow/platform-grid/` — a reusable 3-column grid of every supported platform (icon + name + account-type descriptor). Selecting a card calls the provided `onSelect`; cards are buttons (tab-navigable, visible focus ring).
* Add `components/connection-flow/select-platform/` — the picker step; binds the grid to `selectPlatform`. Wired into the modal's `renderStep` (`select-platform` case).
* Add a short `accountType` ("Profile", "Page", "Business", "Profile / Company") and a `shortLabel` ("Instagram") to `getServiceUiDetails` / `ServiceUiDetails`, distinct from the long `description`.
* Flip the modal's back arrow in RTL (`isRTL() ? chevronRight : chevronLeft`) — follow-up to a review note on #50775.
* Step routing (custom-input services → `platform-input`, the rest → `authorizing`) lives in the reducer. No feature-flag check here — the whole flow is gated once at the modal mount point.

## Related product discussion/links
* https://linear.app/a8c/issue/SOCIAL-530/m2-01-new-connection-flow-platform-picker-step
* Design: https://www.figma.com/design/DDjUX6bySvzZ302nXgNPfo/?node-id=6889-10045

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Open the Social dashboard and click **Add account**.
* The modal opens on the platform grid, titled **Select your account platform** — confirm every `status === 'ok'` service renders, cards are keyboard-navigable with a visible focus ring, and "Instagram" fits on one line.
* Click a regular platform (e.g. Facebook) → advances to `authorizing`. Click Bluesky or Mastodon → `platform-input`, titled **Connect Mastodon account**. The back button returns to the grid.
* Switch the site to an RTL language and confirm the back arrow points right.

| Before | After |
| --- | --- |
|  |  |
