### PR TITLE
Premium Analytics: make dashboard layout reset follow the entity default

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-premium-analytics-reset-layout-follow-default
+++ b/projects/packages/premium-analytics/changelog/fix-premium-analytics-reset-layout-follow-default
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Dashboard: make Reset to default follow the section's current default layout instead of pinning a snapshot of it
+Dashboard: make Reset to default follow the section's current default layout instead of pinning a snapshot of it.

--- a/projects/packages/premium-analytics/changelog/fix-premium-analytics-reset-layout-follow-default
+++ b/projects/packages/premium-analytics/changelog/fix-premium-analytics-reset-layout-follow-default
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: make Reset to default follow the section's current default layout instead of pinning a snapshot of it

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-section-layout.test.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-section-layout.test.ts
@@ -1,0 +1,124 @@
+/**
+ * External dependencies
+ */
+import { act, renderHook } from '@testing-library/react';
+import { dispatch, select } from '@wordpress/data';
+import { store as preferencesStore } from '@wordpress/preferences';
+/**
+ * Internal dependencies
+ */
+import { DASHBOARD_PREFERENCES_SCOPE } from './constants';
+import { useDashboardSectionLayout } from './use-dashboard-section-layout';
+import type { DashboardSection } from '../config';
+import type { DashboardWidget } from '@wordpress/widget-dashboard';
+
+const PREFERENCES_KEY = 'dashboardSectionLayouts';
+
+/**
+ * Build a minimal dashboard widget placement for layout fixtures.
+ *
+ * @param uuid - Unique instance identifier, reused to derive the type name.
+ * @return A dashboard widget placement.
+ */
+function widget( uuid: string ): DashboardWidget {
+	return { uuid, type: `jpa/${ uuid }` };
+}
+
+/**
+ * Build a dashboard section carrying a default layout.
+ *
+ * @param slug          - Section slug, used as the preference key.
+ * @param defaultLayout - The section's bundled default layout.
+ * @return A dashboard section.
+ */
+function section( slug: string, defaultLayout: DashboardWidget[] ): DashboardSection {
+	return {
+		id: `analytics/${ slug }`,
+		slug,
+		label: slug,
+		order: 0,
+		default_layout: defaultLayout,
+	};
+}
+
+/**
+ * Read the persisted section layout map from the preferences store.
+ *
+ * @return The stored section layout map.
+ */
+function storedLayouts(): unknown {
+	return (
+		select( preferencesStore ) as unknown as {
+			get: ( scope: string, key: string ) => unknown;
+		}
+	 ).get( DASHBOARD_PREFERENCES_SCOPE, PREFERENCES_KEY );
+}
+
+describe( 'useDashboardSectionLayout', () => {
+	const trafficDefault = [ widget( 'traffic-default' ) ];
+	const storeDefault = [ widget( 'store-default' ) ];
+	const sections = [ section( 'traffic', trafficDefault ), section( 'store', storeDefault ) ];
+
+	beforeEach( () => {
+		// The preferences store registers on the shared default registry, so
+		// clear the key between tests.
+		dispatch( preferencesStore ).set( DASHBOARD_PREFERENCES_SCOPE, PREFERENCES_KEY, {} );
+	} );
+
+	it( 'removes only the active section entry on reset', () => {
+		const trafficCustom = [ widget( 'traffic-custom' ) ];
+		const storeCustom = [ widget( 'store-custom' ) ];
+		dispatch( preferencesStore ).set( DASHBOARD_PREFERENCES_SCOPE, PREFERENCES_KEY, {
+			traffic: trafficCustom,
+			store: storeCustom,
+		} );
+
+		const { result } = renderHook( () => useDashboardSectionLayout( 'traffic', sections ) );
+
+		act( () => result.current[ 2 ]() );
+
+		expect( storedLayouts() ).toEqual( { store: storeCustom } );
+	} );
+
+	it( 'returns the entity default after a customize/reset round trip', () => {
+		const { result } = renderHook( () => useDashboardSectionLayout( 'traffic', sections ) );
+
+		act( () => result.current[ 1 ]( [ widget( 'traffic-custom' ) ] ) );
+		expect( result.current[ 0 ] ).not.toBe( trafficDefault );
+
+		act( () => result.current[ 2 ]() );
+
+		expect( result.current[ 0 ] ).toBe( trafficDefault );
+	} );
+
+	it( 'keeps tracking the entity default after reset when the default changes', () => {
+		dispatch( preferencesStore ).set( DASHBOARD_PREFERENCES_SCOPE, PREFERENCES_KEY, {
+			traffic: [ widget( 'traffic-custom' ) ],
+		} );
+
+		const { result, rerender } = renderHook(
+			( props: { sections: DashboardSection[] } ) =>
+				useDashboardSectionLayout( 'traffic', props.sections ),
+			{ initialProps: { sections } }
+		);
+
+		act( () => result.current[ 2 ]() );
+		expect( result.current[ 0 ] ).toBe( trafficDefault );
+
+		// A later release ships a different default for the section.
+		const newTrafficDefault = [ widget( 'traffic-new-default' ) ];
+		rerender( { sections: [ section( 'traffic', newTrafficDefault ), sections[ 1 ] ] } );
+
+		expect( result.current[ 0 ] ).toBe( newTrafficDefault );
+	} );
+
+	it( 'does not write the preference when the section was never customized', () => {
+		const stored = storedLayouts();
+
+		const { result } = renderHook( () => useDashboardSectionLayout( 'traffic', sections ) );
+
+		act( () => result.current[ 2 ]() );
+
+		expect( storedLayouts() ).toBe( stored );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-section-layout.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-section-layout.ts
@@ -47,7 +47,9 @@ export function useDashboardSectionLayout(
 		[ sections, activeSectionId ]
 	);
 
-	const layout = sectionLayouts[ activeSectionId ] ?? sectionDefault;
+	const layout = Object.hasOwn( sectionLayouts, activeSectionId )
+		? sectionLayouts[ activeSectionId ] ?? sectionDefault
+		: sectionDefault;
 
 	const setLayout = useCallback(
 		( nextLayout: DashboardWidget[] ) => {
@@ -60,7 +62,7 @@ export function useDashboardSectionLayout(
 	);
 
 	const resetLayout = useCallback( () => {
-		if ( ! ( activeSectionId in sectionLayouts ) ) {
+		if ( ! Object.hasOwn( sectionLayouts, activeSectionId ) ) {
 			return;
 		}
 

--- a/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-section-layout.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/hooks/use-dashboard-section-layout.ts
@@ -17,9 +17,10 @@ type PreferencesActions = {
  * Manage the customizable widget layout for the active dashboard section.
  *
  * Reads the customized layout from the preferences map, falling back to the
- * section's `default_layout` from the `dashboardSection` record. Reset writes
- * that same default back. Both first paint and reset come from the entity, so
- * there is no server-seeded preference.
+ * section's `default_layout` from the `dashboardSection` record. Reset deletes
+ * the section's entry instead of writing the default's contents: a stored
+ * snapshot would shadow the entity default forever, pinning users who asked to
+ * follow the default to whatever it happened to be at reset time.
  *
  * @param activeSectionId - Currently active section slug.
  * @param sections        - The available sections, carrying their defaults.
@@ -59,11 +60,14 @@ export function useDashboardSectionLayout(
 	);
 
 	const resetLayout = useCallback( () => {
-		void set( DASHBOARD_PREFERENCES_SCOPE, PREFERENCES_KEY, {
-			...sectionLayouts,
-			[ activeSectionId ]: sectionDefault,
-		} );
-	}, [ activeSectionId, sectionDefault, sectionLayouts, set ] );
+		if ( ! ( activeSectionId in sectionLayouts ) ) {
+			return;
+		}
+
+		const nextLayouts = { ...sectionLayouts };
+		delete nextLayouts[ activeSectionId ];
+		void set( DASHBOARD_PREFERENCES_SCOPE, PREFERENCES_KEY, nextLayouts );
+	}, [ activeSectionId, sectionLayouts, set ] );
 
 	return [ layout, setLayout, resetLayout ];
 }

--- a/projects/packages/premium-analytics/routes/dashboard/package.json
+++ b/projects/packages/premium-analytics/routes/dashboard/package.json
@@ -26,5 +26,8 @@
 		"date-fns": "4.1.0",
 		"fast-deep-equal": "^3.1.3",
 		"react": "18.3.1"
+	},
+	"devDependencies": {
+		"@testing-library/react": "16.3.2"
 	}
 }


### PR DESCRIPTION
Fixes N/A — follow-up to #50755, where this was found during review.

## Proposed changes

* In `useDashboardSectionLayout`, "Reset to default" now **deletes** the active section's entry from the `dashboardSectionLayouts` preferences map instead of writing a snapshot of the section's current `default_layout` into it.
* Why: the stored snapshot shadowed the entity default via the `?? sectionDefault` fallback. When a later release changes a section's default layout (e.g. ships a new default widget through the `jetpack_premium_analytics_dashboard_default_layout` filter), never-touched users pick it up, but a user who explicitly reset — asking to follow the default — stayed pinned to the stale snapshot forever. After this change, a reset layout falls through to the entity default and keeps tracking it.
* No empty-layout flash: the dashboard only mounts once the sections entity has resolved (the `hasResolvedSections` gate in `routes/dashboard/stage.tsx`), so after deleting the key the `?? sectionDefault` fallback is immediately non-empty.
* Reset is a no-op when the section was never customized, so it doesn't persist a pointless write.
* Intentionally **no migration** for previously seeded/reset preference entries — leaving existing stored layouts alone is the accepted behavior per the discussion on #50755.
* Added jest tests for the hook (reset removes only the active section's key; layout after reset equals the entity default, including when the default later changes; no-op when never customized). Also listed `@testing-library/react` in the route's lint-only `package.json`.
* The hook's public API (`[ layout, setLayout, resetLayout ]`) is unchanged.

## Related product discussion/links

* Automattic/jetpack#50755 (review discussion)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Note: this package's JS tests do not run in CI.

* In `projects/packages/premium-analytics` (Node ^24.15): `pnpm test routes/dashboard/hooks/use-dashboard-section-layout.test.ts` — 4 tests pass (full `pnpm test` is green too).
* Build: `pnpm jetpack build plugins/premium-analytics --deps`.
* Manual check on a local site:
  1. Open the Premium Analytics dashboard, click Customize, and change a section's layout (add/remove/move a widget), then leave edit mode.
  2. Re-enter Customize → header "More options" ⋮ → "Reset to default" → confirm "Reset". The section returns to the default layout with no flash of an empty dashboard.
  3. Verify persistence: the `jetpack-premium-analytics/dashboard` scope in the user's `wp_persisted_preferences` meta (e.g. `wp user meta get <id> wp_persisted_preferences`) should no longer contain the active section's key under `dashboardSectionLayouts`; other sections' customizations remain.
  4. Reload the dashboard — the section still shows the default layout.
