### PR TITLE
Social: mount & open the connection-flow modal on the dashboard

### DIFF
--- a/projects/packages/publicize/_inc/components/connection-flow/index.tsx
+++ b/projects/packages/publicize/_inc/components/connection-flow/index.tsx
@@ -1,7 +1,7 @@
 import { ThemeProvider } from '@automattic/jetpack-components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { useCallback } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import { chevronLeft } from '@wordpress/icons';
 import { Dialog, IconButton, Text, Tooltip } from '@wordpress/ui';
 import { store as socialStore } from '../../social-store';
@@ -40,6 +40,29 @@ function renderStep( step: ConnectionFlowStep ): JSX.Element {
 }
 
 /**
+ * The dialog title for the current step. `platform-input` names the chosen
+ * platform; the other steps use a static title.
+ *
+ * @param step         - The current flow step.
+ * @param serviceLabel - Label of the selected service, for `platform-input`.
+ * @return The dialog title.
+ */
+function getStepTitle( step: ConnectionFlowStep, serviceLabel: string ): string {
+	switch ( step ) {
+		case 'select-platform':
+			return __( 'Select your account platform', 'jetpack-publicize-pkg' );
+		case 'platform-input':
+			return sprintf(
+				// translators: %s is the platform name, e.g. "Mastodon".
+				__( 'Connect %s account', 'jetpack-publicize-pkg' ),
+				serviceLabel
+			);
+		default:
+			return __( 'Add an account', 'jetpack-publicize-pkg' );
+	}
+}
+
+/**
  * The open connection-flow dialog. Only rendered while the flow is active, so
  * the controlled `open` prop stays `true` and any close intent (Esc, backdrop,
  * close button) routes through `onOpenChange` to reset the flow.
@@ -47,11 +70,18 @@ function renderStep( step: ConnectionFlowStep ): JSX.Element {
  * @return The dialog.
  */
 const ConnectionFlowDialog = () => {
-	const { step, canGoBack } = useSelect( select => {
-		const { getConnectionFlowStep, canGoToPreviousConnectionFlowStep } = select( socialStore );
+	const { step, canGoBack, serviceLabel } = useSelect( select => {
+		const {
+			getConnectionFlowStep,
+			canGoToPreviousConnectionFlowStep,
+			getConnectionFlowSelectedServiceId,
+			getService,
+		} = select( socialStore );
+		const serviceId = getConnectionFlowSelectedServiceId();
 		return {
 			step: getConnectionFlowStep(),
 			canGoBack: canGoToPreviousConnectionFlowStep(),
+			serviceLabel: serviceId ? getService( serviceId )?.label ?? '' : '',
 		};
 	}, [] );
 
@@ -85,7 +115,7 @@ const ConnectionFlowDialog = () => {
 								onClick={ goToPreviousStep }
 							/>
 						) }
-						<Dialog.Title>{ __( 'Add an account', 'jetpack-publicize-pkg' ) }</Dialog.Title>
+						<Dialog.Title>{ getStepTitle( step, serviceLabel ) }</Dialog.Title>
 						<Dialog.CloseIcon />
 					</Dialog.Header>
 					<Dialog.Content>{ renderStep( step ) }</Dialog.Content>

--- a/projects/packages/publicize/_inc/components/connection-flow/index.tsx
+++ b/projects/packages/publicize/_inc/components/connection-flow/index.tsx
@@ -1,0 +1,114 @@
+import { ThemeProvider } from '@automattic/jetpack-components';
+import { useDispatch, useSelect } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import { chevronLeft } from '@wordpress/icons';
+import { Dialog, IconButton, Text, Tooltip } from '@wordpress/ui';
+import { store as socialStore } from '../../social-store';
+import type { ConnectionFlowStep } from '../../social-store/types';
+
+/**
+ * Placeholder body shown until a step's own component lands. Each of M2-01…04
+ * replaces its branch in `renderStep` with the real step UI.
+ *
+ * @param props      - Props.
+ * @param props.step - The step being rendered.
+ * @return The placeholder body.
+ */
+const StepPlaceholder = ( { step }: { step: ConnectionFlowStep } ) => (
+	<Text variant="body-sm" render={ <p /> }>
+		{ step }
+	</Text>
+);
+
+/**
+ * Step router: maps the current connection-flow step to its content. Every step
+ * renders a placeholder for now; M2-01…04 slot their components in here.
+ *
+ * @param step - The current flow step.
+ * @return The step content.
+ */
+function renderStep( step: ConnectionFlowStep ): JSX.Element {
+	switch ( step ) {
+		case 'select-platform':
+		case 'platform-input':
+		case 'authorizing':
+		case 'confirm':
+		case 'creating':
+			return <StepPlaceholder step={ step } />;
+	}
+}
+
+/**
+ * The open connection-flow dialog. Only rendered while the flow is active, so
+ * the controlled `open` prop stays `true` and any close intent (Esc, backdrop,
+ * close button) routes through `onOpenChange` to reset the flow.
+ *
+ * @return The dialog.
+ */
+const ConnectionFlowDialog = () => {
+	const { step, canGoBack } = useSelect( select => {
+		const { getConnectionFlowStep, canGoToPreviousConnectionFlowStep } = select( socialStore );
+		return {
+			step: getConnectionFlowStep(),
+			canGoBack: canGoToPreviousConnectionFlowStep(),
+		};
+	}, [] );
+
+	const { cancelConnectionFlow, goToPreviousStep } = useDispatch( socialStore );
+
+	const onOpenChange = useCallback(
+		( open: boolean ) => {
+			if ( ! open ) {
+				cancelConnectionFlow();
+			}
+		},
+		[ cancelConnectionFlow ]
+	);
+
+	if ( ! step ) {
+		return null;
+	}
+
+	return (
+		<Tooltip.Provider delay={ 0 }>
+			<Dialog.Root open onOpenChange={ onOpenChange }>
+				<Dialog.Popup size="medium">
+					<Dialog.Header>
+						{ canGoBack && (
+							<IconButton
+								variant="minimal"
+								tone="neutral"
+								size="small"
+								icon={ chevronLeft }
+								label={ __( 'Back', 'jetpack-publicize-pkg' ) }
+								onClick={ goToPreviousStep }
+							/>
+						) }
+						<Dialog.Title>{ __( 'Add an account', 'jetpack-publicize-pkg' ) }</Dialog.Title>
+						<Dialog.CloseIcon />
+					</Dialog.Header>
+					<Dialog.Content>{ renderStep( step ) }</Dialog.Content>
+				</Dialog.Popup>
+			</Dialog.Root>
+		</Tooltip.Provider>
+	);
+};
+
+/**
+ * Container for the redesigned add-account flow. Mirrors `ThemedConnectionsModal`:
+ * it self-gates on the store's flow state and portals into `document.body` under
+ * its own theme, so mount sites can render it unconditionally. Callers open it by
+ * dispatching `startConnectionFlow`.
+ *
+ * @return The themed connection-flow modal.
+ */
+export function ConnectionFlowModal() {
+	const isActive = useSelect( select => select( socialStore ).isConnectionFlowActive(), [] );
+
+	return (
+		<ThemeProvider targetDom={ document.body }>
+			{ isActive ? <ConnectionFlowDialog /> : null }
+		</ThemeProvider>
+	);
+}

--- a/projects/packages/publicize/_inc/components/connection-management/index.tsx
+++ b/projects/packages/publicize/_inc/components/connection-management/index.tsx
@@ -5,6 +5,8 @@ import { Button } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useUserCanShareConnection } from '../../hooks/use-user-can-share-connection';
 import { store } from '../../social-store';
+import { hasAdminUiV2 } from '../../utils/script-data';
+import { ConnectionFlowModal } from '../connection-flow';
 import { ThemedConnectionsModal as ManageConnectionsModal } from '../manage-connections-modal';
 import { useService } from '../services/use-service';
 import { ConnectionInfo } from './connection-info';
@@ -84,7 +86,7 @@ const ConnectionManagement = ( {
 					</ul>
 				</>
 			) : null }
-			<ManageConnectionsModal />
+			{ hasAdminUiV2() ? <ConnectionFlowModal /> : <ManageConnectionsModal /> }
 			{ ! hideConnectButton && (
 				<Button
 					variant={ connections.length ? 'outline' : 'solid' }

--- a/projects/packages/publicize/_inc/components/overview-tab/index.tsx
+++ b/projects/packages/publicize/_inc/components/overview-tab/index.tsx
@@ -3,10 +3,13 @@ import useConnectionErrorNotice, {
 } from '@automattic/jetpack-connection/use-connection-error-notice';
 import { currentUserCan } from '@automattic/jetpack-script-data';
 import { useDispatch, useSelect } from '@wordpress/data';
+import { useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { share } from '@wordpress/icons';
 import { Button, Card, EmptyState } from '@wordpress/ui';
 import { store as socialStore } from '../../social-store';
+import { hasAdminUiV2 } from '../../utils/script-data';
+import { ConnectionFlowModal } from '../connection-flow';
 import ConnectionManagement from '../connection-management';
 import { ThemedConnectionsModal } from '../manage-connections-modal';
 import TrafficChartCard from './traffic-chart-card';
@@ -21,7 +24,15 @@ import './style.scss';
  * @return The empty-state body.
  */
 const NoConnectionsEmptyState = () => {
-	const { openConnectionsModal } = useDispatch( socialStore );
+	const { openConnectionsModal, startConnectionFlow } = useDispatch( socialStore );
+
+	const onAddAccount = useCallback( () => {
+		if ( hasAdminUiV2() ) {
+			startConnectionFlow( { origin: 'dashboard' } );
+		} else {
+			openConnectionsModal();
+		}
+	}, [ openConnectionsModal, startConnectionFlow ] );
 
 	return (
 		<div className="jetpack-social-overview__empty">
@@ -37,7 +48,7 @@ const NoConnectionsEmptyState = () => {
 					) }
 				</EmptyState.Description>
 				<EmptyState.Actions>
-					<Button variant="solid" onClick={ openConnectionsModal }>
+					<Button variant="solid" onClick={ onAddAccount }>
 						{ __( 'Add account', 'jetpack-publicize-pkg' ) }
 					</Button>
 				</EmptyState.Actions>
@@ -86,9 +97,11 @@ export default function OverviewTab(): JSX.Element {
 			 * empty state replaces the connections list, so the
 			 * "Add account" header + empty-state buttons stay
 			 * functional. When `ConnectionManagement` renders, it
-			 * already brings its own `ManageConnectionsModal`.
+			 * already brings its own modal. Behind ADMIN_UI_V2 this is
+			 * the new `ConnectionFlowModal`; otherwise today's modal.
 			 */ }
-			{ ! hasConnections && <ThemedConnectionsModal /> }
+			{ ! hasConnections &&
+				( hasAdminUiV2() ? <ConnectionFlowModal /> : <ThemedConnectionsModal /> ) }
 			{ /*
 			 * Traffic chart only renders for admins with at least one
 			 * connection. The no-connections state focuses the user on

--- a/projects/packages/publicize/_inc/components/overview-tab/test/index.test.tsx
+++ b/projects/packages/publicize/_inc/components/overview-tab/test/index.test.tsx
@@ -14,6 +14,9 @@ jest.mock( '../../connection-management', () => () => <div data-testid="connecti
 jest.mock( '../../manage-connections-modal', () => ( {
 	ThemedConnectionsModal: () => <div data-testid="connections-modal" />,
 } ) );
+jest.mock( '../../connection-flow', () => ( {
+	ConnectionFlowModal: () => <div data-testid="connection-flow-modal" />,
+} ) );
 
 jest.mock( '@automattic/jetpack-connection/use-connection-error-notice', () => ( {
 	__esModule: true,

--- a/projects/packages/publicize/_inc/utils/script-data.ts
+++ b/projects/packages/publicize/_inc/utils/script-data.ts
@@ -21,6 +21,16 @@ export function hasSocialPaidFeatures() {
 }
 
 /**
+ * Whether the redesigned admin UI (v2) is enabled — gates the new
+ * add-account connection flow behind the `ADMIN_UI_V2` feature.
+ *
+ * @return Whether the v2 admin UI is enabled.
+ */
+export function hasAdminUiV2() {
+	return siteHasFeature( features.ADMIN_UI_V2 );
+}
+
+/**
  * Get the url for the Social admin page.
  *
  * @return The Social admin page URL.

--- a/projects/packages/publicize/changelog/add-connection-flow-modal-dashboard
+++ b/projects/packages/publicize/changelog/add-connection-flow-modal-dashboard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add the connection-flow modal and open it from the Social dashboard behind the admin UI v2 flag.

--- a/projects/packages/publicize/routes/dashboard/stage.tsx
+++ b/projects/packages/publicize/routes/dashboard/stage.tsx
@@ -12,6 +12,7 @@ import { TurnOnSocialProvider } from '../../_inc/components/settings-tab/turn-on
 import SocialPage, { type SocialTab } from '../../_inc/components/social-page';
 import { store as socialStore } from '../../_inc/social-store';
 import { canToggleSocialModule } from '../../_inc/utils/misc';
+import { hasAdminUiV2 } from '../../_inc/utils/script-data';
 
 type StageSearch = Record< string, unknown > & {
 	tab?: string;
@@ -23,16 +24,25 @@ const queryClient = new QueryClient();
 
 /**
  * "Add account" action rendered into the Page header on the Overview
- * tab. Dispatches `openConnectionsModal` so the existing
- * `ManageConnectionsModal` (rendered inside `ConnectionManagement`)
- * takes over from there.
+ * tab. Behind `ADMIN_UI_V2` it starts the new connection flow
+ * (`ConnectionFlowModal`); otherwise it opens today's
+ * `ManageConnectionsModal` — both mounted by the Overview tab.
  *
  * @return The page-header action button.
  */
 const AddAccountAction = () => {
-	const { openConnectionsModal } = useDispatch( socialStore );
+	const { openConnectionsModal, startConnectionFlow } = useDispatch( socialStore );
+
+	const onClick = useCallback( () => {
+		if ( hasAdminUiV2() ) {
+			startConnectionFlow( { origin: 'dashboard' } );
+		} else {
+			openConnectionsModal();
+		}
+	}, [ openConnectionsModal, startConnectionFlow ] );
+
 	return (
-		<Button variant="solid" size="compact" onClick={ openConnectionsModal }>
+		<Button variant="solid" size="compact" onClick={ onClick }>
 			{ __( 'Add account', 'jetpack-publicize-pkg' ) }
 		</Button>
 	);


### PR DESCRIPTION
Fixes [SOCIAL-548](https://linear.app/a8c/issue/SOCIAL-548/m2-00-mount-and-open-the-connection-flow-modal-on-the-dashboard)

## Proposed changes

Walking skeleton for the redesigned add-account flow (M2-00): a mountable, openable `ConnectionFlowModal` on the Social **dashboard**, behind `siteHasFeature( ADMIN_UI_V2 )`, so later steps (M2-01…04) are testable inside a real open modal.

* New `components/connection-flow/index.tsx` — a step-router that reads `step` from the connection-flow store slice (M1-02) and renders the matching step, wrapped in a plain WPDS `Dialog` frame (title / close / optional back chevron). Each step renders a placeholder for now; M2-01…04 slot their components into the router. Self-gates on `isConnectionFlowActive` and portals into `document.body` under its own theme; any close intent resets the flow via `cancelConnectionFlow`.
* Behind the flag, mount `ConnectionFlowModal` in place of today's `ManageConnectionsModal` at the same three sites: `overview-tab` (empty-state path), `connection-management`, and `global-modals`.
* `AddAccountAction` (dashboard header) and `overview-tab`'s empty-state button dispatch `startConnectionFlow( { origin: 'dashboard' } )` behind the flag; unchanged (`openConnectionsModal`) when off.
* Add a `hasAdminUiV2()` helper.

Flag **off** is byte-for-byte trunk behavior. Not here (M2-05): the editor entry point, the `Accounts connected` heading rename, and both-surfaces verification.

## Related product discussion/links

* [SOCIAL-548](https://linear.app/a8c/issue/SOCIAL-548/m2-00-mount-and-open-the-connection-flow-modal-on-the-dashboard)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Add the `social-admin-ui-v2` blog sticker to the site to enable the feature flag, then go to **Jetpack → Social**.

* With connections: click **Add account** (top right) → the new modal opens showing the current step placeholder. Esc / backdrop / close resets the flow.
* With **zero** connections: the empty-state **Add account** button opens the same modal.
* Disable the flag → today's Manage connections modal opens, unchanged.

<img width="982" height="664" alt="image" src="https://github.com/user-attachments/assets/0cfe33c5-33ff-454d-8c2f-2bb1a7712617" />

