### PR TITLE
Jetpack AI: follow the writing and SEO toggles in the AI sidebar

### DIFF
--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-sidebar-visibility-gate
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-sidebar-visibility-gate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Jetpack AI: hide the AI sidebar when the writing assistant and SEO enhancer toggles are both off.

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-toolbar-button-writing-toggle
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-toolbar-button-writing-toggle
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Jetpack AI: the AI toolbar button now follows the writing assistant toggle.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -452,7 +452,7 @@ class Jetpack_AI_Sidebar {
 			'generateFeedback'        => $writing_on,
 			'proofreadContent'        => $writing_on,
 			'blockTransformations'    => $writing_on,
-			'blockToolbarButton'      => true,
+			'blockToolbarButton'      => $writing_on,
 			'optimizeTitleSuggestion' => $writing_on,
 			'seoSuggestions'          => self::is_seo_suggestions_enabled(),
 			'excerptSuggestion'       => $writing_on,
@@ -474,7 +474,7 @@ class Jetpack_AI_Sidebar {
 		$features['aiEditorialReview']       = (bool) $features['aiEditorialReview'] && $writing_on;
 		$features['generateFeedback']        = (bool) $features['generateFeedback'] && $writing_on;
 		$features['proofreadContent']        = (bool) $features['proofreadContent'] && $writing_on;
-		$features['blockToolbarButton']      = (bool) $features['blockToolbarButton'];
+		$features['blockToolbarButton']      = (bool) $features['blockToolbarButton'] && $writing_on;
 		$features['optimizeTitleSuggestion'] = (bool) $features['optimizeTitleSuggestion'] && $writing_on;
 		$features['seoSuggestions']          = (bool) $features['seoSuggestions'] && self::is_seo_suggestions_enabled();
 		$features['excerptSuggestion']       = (bool) $features['excerptSuggestion'] && $writing_on;
@@ -490,6 +490,12 @@ class Jetpack_AI_Sidebar {
 
 	/**
 	 * Whether the Jetpack AI Sidebar toolbar button replaces the legacy AI toolbar.
+	 *
+	 * The button is a writing entry point, so it follows the writing assistant
+	 * toggle. Switching it off cannot bring the legacy toolbar back in its place:
+	 * the editor renders that toolbar only while this feature is unavailable AND
+	 * the AI Assistant block and its ai-assistant-support extension are
+	 * registered, and both of those are themselves gated on the writing assistant.
 	 *
 	 * @return bool
 	 */

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -451,7 +451,7 @@ class Jetpack_AI_Sidebar {
 			'aiEditorialReview'       => (bool) apply_filters( 'jetpack_ai_editorial_review_enabled', true ) && $writing_on,
 			'generateFeedback'        => $writing_on,
 			'proofreadContent'        => $writing_on,
-			'blockTransformations'    => true,
+			'blockTransformations'    => $writing_on,
 			'blockToolbarButton'      => true,
 			'optimizeTitleSuggestion' => $writing_on,
 			'seoSuggestions'          => self::is_seo_suggestions_enabled(),
@@ -478,6 +478,9 @@ class Jetpack_AI_Sidebar {
 		$features['optimizeTitleSuggestion'] = (bool) $features['optimizeTitleSuggestion'] && $writing_on;
 		$features['seoSuggestions']          = (bool) $features['seoSuggestions'] && self::is_seo_suggestions_enabled();
 		$features['excerptSuggestion']       = (bool) $features['excerptSuggestion'] && $writing_on;
+		// Block transformations (Translate, Change Tone, etc.) are writing features
+		// and follow the writing assistant toggle.
+		$features['blockTransformations'] = (bool) $features['blockTransformations'] && $writing_on;
 
 		return array(
 			'enabled'  => self::is_jetpack_ai_sidebar_preview_enabled(),

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -352,7 +352,9 @@ class Jetpack_AI_Sidebar {
 	 * that have the Big Sky plugin present and enabled. Big Sky defaults on for
 	 * Simple sites and off on WoA/Atomic. The jetpack_ai_sidebar_enabled filter
 	 * is a host-level override of that default, respected by init() and every
-	 * sidebar surface that gates on this method.
+	 * sidebar surface that gates on this method. Independently of the filter,
+	 * the sidebar requires at least one of its features (writing assistant or
+	 * SEO enhancer) to be enabled.
 	 *
 	 * @return bool
 	 */
@@ -371,11 +373,34 @@ class Jetpack_AI_Sidebar {
 		 * Defaults to true only on WordPress.com platform sites with Big Sky
 		 * present and enabled. Acts as a host-level override that can force the
 		 * sidebar on (e.g. for local development) or off, and is respected by
-		 * init() and every sidebar surface.
+		 * init() and every sidebar surface. The override cannot force the
+		 * sidebar on while the writing-assistant and SEO enhancer features are
+		 * both off — a featureless sidebar never loads.
 		 *
 		 * @param bool $enabled Whether the Jetpack AI sidebar is enabled.
 		 */
-		return (bool) apply_filters( 'jetpack_ai_sidebar_enabled', $enabled );
+		$enabled = (bool) apply_filters( 'jetpack_ai_sidebar_enabled', $enabled );
+
+		// Re-asserted after the filter so a later filter cannot surface a
+		// sidebar whose features are all off.
+		return $enabled && self::has_enabled_sidebar_features();
+	}
+
+	/**
+	 * Whether any feature the sidebar surfaces is effectively enabled.
+	 *
+	 * The sidebar only hosts writing-assistant and SEO suggestions; when both
+	 * are off it has nothing to offer and must not load. The SEO half folds in
+	 * the ai_seo_enhancer_enabled kill-switch filter, the same way every other
+	 * SEO enhancer consumer resolves the effective value; the writing half gets
+	 * its filter inside is_feature_enabled() (owned feature).
+	 *
+	 * @return bool
+	 */
+	private static function has_enabled_sidebar_features(): bool {
+		return \Jetpack_AI_Settings::is_feature_enabled( 'writing_assistant' )
+			|| ( (bool) apply_filters( 'ai_seo_enhancer_enabled', true )
+				&& \Jetpack_AI_Settings::is_feature_enabled( 'seo_enhancer' ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -382,8 +382,11 @@ class Jetpack_AI_Sidebar {
 		$enabled = (bool) apply_filters( 'jetpack_ai_sidebar_enabled', $enabled );
 
 		// Re-asserted after the filter so a later filter cannot surface a
-		// sidebar whose features are all off.
-		return $enabled && self::has_enabled_sidebar_features();
+		// sidebar whose features are all off, or one blocked by the host or
+		// master gates — the gates are final, as with is_ai_enabled().
+		return $enabled
+			&& \Jetpack_AI_Settings::apply_master_gates( true )
+			&& self::has_enabled_sidebar_features();
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -1005,7 +1005,60 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['generateFeedback'] );
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['aiEditorialReview'] );
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['excerptSuggestion'] );
+		$this->assertSame( false, $data['jetpackAiSidebar']['features']['blockTransformations'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['seoSuggestions'] );
+	}
+
+	/**
+	 * Block transformations (Translate, Change Tone, etc.) are writing features:
+	 * with the writing assistant off they stay out of the payload even when the
+	 * generic preview-features filter tries to force them on.
+	 */
+	public function test_add_agents_manager_data_block_transformations_follow_writing_toggle_despite_filter() {
+		$this->set_block_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
+		update_option( 'ai_seo_enhancer_enabled', 1 );
+		add_filter(
+			'jetpack_ai_sidebar_preview_features',
+			function ( $features ) {
+				$features['blockTransformations'] = true;
+				return $features;
+			}
+		);
+
+		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
+
+		delete_option( 'jetpack_ai_writing_assistant_enabled' );
+		delete_option( 'ai_seo_enhancer_enabled' );
+
+		$this->assertSame( false, $data['jetpackAiSidebar']['features']['blockTransformations'] );
+	}
+
+	/**
+	 * AI Editorial Review is writing-gated like its sibling suggestions: with
+	 * the writing assistant off, the generic preview-features filter must not
+	 * be able to force it back into the payload.
+	 */
+	public function test_add_agents_manager_data_editorial_review_follows_writing_toggle_despite_filter() {
+		$this->set_block_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
+		update_option( 'ai_seo_enhancer_enabled', 1 );
+		add_filter(
+			'jetpack_ai_sidebar_preview_features',
+			function ( $features ) {
+				$features['aiEditorialReview'] = true;
+				return $features;
+			}
+		);
+
+		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
+
+		delete_option( 'jetpack_ai_writing_assistant_enabled' );
+		delete_option( 'ai_seo_enhancer_enabled' );
+
+		$this->assertSame( false, $data['jetpackAiSidebar']['features']['aiEditorialReview'] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -88,6 +88,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		( new \Automattic\Jetpack\Connection\Manager( 'jetpack' ) )->reset_connection_status();
 		delete_option( 'jetpack_offline_mode' );
 		delete_option( 'big_sky_enable' );
+		delete_option( \Jetpack_AI_Settings::MASTER_OPTION );
+		delete_option( 'jetpack_ai_writing_assistant_enabled' );
+		delete_option( 'ai_seo_enhancer_enabled' );
 		Constants::clear_single_constant( 'IS_WPCOM' );
 		Constants::clear_single_constant( 'ATOMIC_SITE_ID' );
 		Constants::clear_single_constant( 'ATOMIC_CLIENT_ID' );
@@ -517,6 +520,172 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	// ──────────────────────────────────────────────────
+	// Feature-toggle visibility gate tests
+	// ──────────────────────────────────────────────────
+
+	/**
+	 * The sidebar only surfaces writing-assistant and SEO suggestions, so the
+	 * gate follows the two toggles: it closes only when BOTH are off. Any single
+	 * enabled feature keeps the sidebar available.
+	 */
+	public function test_preview_follows_writing_and_seo_toggle_matrix() {
+		$combinations = array(
+			// writing, seo, expected gate.
+			array( 1, 1, true ),
+			array( 1, 0, true ),
+			array( 0, 1, true ),
+			array( 0, 0, false ),
+		);
+
+		foreach ( $combinations as list( $writing, $seo, $expected ) ) {
+			update_option( 'jetpack_ai_writing_assistant_enabled', $writing );
+			update_option( 'ai_seo_enhancer_enabled', $seo );
+
+			$open = $this->gate_open();
+
+			delete_option( 'jetpack_ai_writing_assistant_enabled' );
+			delete_option( 'ai_seo_enhancer_enabled' );
+
+			$this->assertSame(
+				$expected,
+				$open,
+				sprintf( 'Gate should be %s with writing=%d seo=%d.', $expected ? 'open' : 'closed', $writing, $seo )
+			);
+		}
+	}
+
+	/**
+	 * On an untouched site the SEO enhancer option is absent and defaults off,
+	 * so turning the writing assistant off alone hides the sidebar. This is the
+	 * agreed behavior, not an accident — pinned here on purpose.
+	 */
+	public function test_preview_disabled_when_writing_off_and_seo_option_absent() {
+		delete_option( 'ai_seo_enhancer_enabled' );
+		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
+
+		$open = $this->gate_open();
+
+		delete_option( 'jetpack_ai_writing_assistant_enabled' );
+
+		$this->assertFalse( $open, 'Writing off with SEO at its default (off) should hide the sidebar.' );
+	}
+
+	/**
+	 * The gate reads EFFECTIVE feature values: the ai_seo_enhancer_enabled
+	 * kill-switch filter can turn the stored SEO option off, the same way every
+	 * other SEO enhancer consumer resolves it. With writing off and the SEO
+	 * option on but filter-killed, both features are effectively off and the
+	 * sidebar must hide.
+	 */
+	public function test_preview_disabled_when_seo_filter_kills_enabled_option() {
+		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
+		update_option( 'ai_seo_enhancer_enabled', 1 );
+		add_filter( 'ai_seo_enhancer_enabled', '__return_false' );
+
+		$open = $this->gate_open();
+
+		delete_option( 'jetpack_ai_writing_assistant_enabled' );
+		delete_option( 'ai_seo_enhancer_enabled' );
+
+		$this->assertFalse( $open, 'A filter-killed SEO enhancer must not hold the sidebar open when writing is off.' );
+	}
+
+	/**
+	 * Contract state test: a filter added after the gate computes must not
+	 * re-enable a sidebar whose features are all off. The feature check is
+	 * re-asserted after the jetpack_ai_sidebar_enabled filter, mirroring how
+	 * the preview features are re-asserted after their generic filter.
+	 */
+	public function test_preview_stays_disabled_when_late_filter_forces_on() {
+		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
+		update_option( 'ai_seo_enhancer_enabled', 0 );
+		add_filter( 'jetpack_ai_sidebar_enabled', '__return_true', 999 );
+
+		$open = $this->gate_open();
+
+		delete_option( 'jetpack_ai_writing_assistant_enabled' );
+		delete_option( 'ai_seo_enhancer_enabled' );
+
+		$this->assertFalse( $open, 'A late jetpack_ai_sidebar_enabled filter must not resurrect a featureless sidebar.' );
+	}
+
+	/**
+	 * Master interplay, both directions. The master gate keeps flowing through
+	 * apply_master_gates on the jetpack_ai_sidebar_enabled filter (re-attached
+	 * here because set_up() strips the filter): master off hides the sidebar
+	 * regardless of the feature toggles, and master on cannot save a sidebar
+	 * whose features are both off.
+	 */
+	public function test_preview_master_gate_composes_with_feature_toggles() {
+		// Run the master gate after set_up()'s __return_true override so it
+		// narrows the forced-open base gate, as it does in production.
+		add_filter( 'jetpack_ai_sidebar_enabled', array( \Jetpack_AI_Settings::class, 'apply_master_gates' ), 11 );
+
+		// Master off + features on: hidden (existing rule, no regression).
+		update_option( \Jetpack_AI_Settings::MASTER_OPTION, 0 );
+		update_option( 'jetpack_ai_writing_assistant_enabled', 1 );
+		update_option( 'ai_seo_enhancer_enabled', 1 );
+		$master_off_features_on = $this->gate_open();
+
+		// Master on + both features off: hidden (the new rule).
+		update_option( \Jetpack_AI_Settings::MASTER_OPTION, 1 );
+		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
+		update_option( 'ai_seo_enhancer_enabled', 0 );
+		$master_on_features_off = $this->gate_open();
+
+		// Master on + a feature on: shown (sanity).
+		update_option( 'jetpack_ai_writing_assistant_enabled', 1 );
+		$master_on_writing_on = $this->gate_open();
+
+		delete_option( \Jetpack_AI_Settings::MASTER_OPTION );
+		delete_option( 'jetpack_ai_writing_assistant_enabled' );
+		delete_option( 'ai_seo_enhancer_enabled' );
+
+		$this->assertFalse( $master_off_features_on, 'Master off must hide the sidebar even with features on.' );
+		$this->assertFalse( $master_on_features_off, 'Master on must not save a sidebar whose features are both off.' );
+		$this->assertTrue( $master_on_writing_on, 'Master on with writing on should show the sidebar.' );
+	}
+
+	/**
+	 * With both feature toggles off, init() registers nothing — the sidebar
+	 * bundle, provider registration, and enqueue hooks all stay out.
+	 */
+	public function test_init_does_nothing_when_sidebar_features_are_off() {
+		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
+		update_option( 'ai_seo_enhancer_enabled', 0 );
+
+		Jetpack_AI_Sidebar::init();
+
+		delete_option( 'jetpack_ai_writing_assistant_enabled' );
+		delete_option( 'ai_seo_enhancer_enabled' );
+
+		$this->assertFalse(
+			has_filter( 'agents_manager_agent_providers', array( Jetpack_AI_Sidebar::class, 'register_provider' ) ),
+			'register_provider should not be hooked when both sidebar features are off.'
+		);
+		$this->assertFalse(
+			has_filter( 'jetpack_ai_sidebar_agents_manager_data', array( Jetpack_AI_Sidebar::class, 'add_agents_manager_data' ) ),
+			'add_agents_manager_data should not be hooked when both sidebar features are off.'
+		);
+		$this->assertFalse(
+			has_filter( 'agents_manager_enabled_in_block_editor', array( Jetpack_AI_Sidebar::class, 'enable_agents_manager_on_provider_surfaces' ) ),
+			'enable_agents_manager_on_provider_surfaces should not be hooked when both sidebar features are off.'
+		);
+		$this->assertFalse(
+			has_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_enqueue_abilities_script' ) ),
+			'maybe_enqueue_abilities_script should not be hooked when both sidebar features are off.'
+		);
+		$this->assertFalse(
+			has_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_patch_jetpack_ai_sidebar_preview_data' ) ),
+			'maybe_patch_jetpack_ai_sidebar_preview_data should not be hooked when both sidebar features are off.'
+		);
+		$this->assertFalse(
+			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_toolbar_button_extension' ) ),
+			'register_toolbar_button_extension should not be hooked when both sidebar features are off.'
+		);
+	}
+
+	// ──────────────────────────────────────────────────
 	// Sidebar toolbar button tests
 	// ──────────────────────────────────────────────────
 
@@ -791,24 +960,47 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * release defaults: a switched-off feature must not surface suggestions
 	 * even when an external host draws the sidebar. Writing assistant off kills
 	 * every writing suggestion (Proofreader, Optimize Title, Generate Feedback,
-	 * AI Editorial Review, and Generate Excerpt); the SEO suggestions follow the
-	 * SEO enhancer toggle, which defaults off.
+	 * AI Editorial Review, and Generate Excerpt) while the SEO suggestions stay
+	 * on their own toggle. SEO is switched on here so the sidebar itself stays
+	 * available — with both toggles off Jetpack contributes no data at all,
+	 * which the visibility-gate tests cover.
 	 */
 	public function test_add_agents_manager_data_honors_feature_toggles() {
 		$this->set_block_editor_screen();
 		$this->activate_seo_tools_module();
 		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
+		update_option( 'ai_seo_enhancer_enabled', 1 );
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
 		delete_option( 'jetpack_ai_writing_assistant_enabled' );
+		delete_option( 'ai_seo_enhancer_enabled' );
 
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['proofreadContent'] );
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['optimizeTitleSuggestion'] );
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['generateFeedback'] );
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['aiEditorialReview'] );
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['excerptSuggestion'] );
+		$this->assertSame( true, $data['jetpackAiSidebar']['features']['seoSuggestions'] );
+	}
+
+	/**
+	 * With writing on keeping the sidebar available, the SEO enhancer option at
+	 * its stored off value keeps SEO suggestions out of the emitted payload —
+	 * the option alone, independent of the ai_seo_enhancer_enabled kill switch.
+	 */
+	public function test_add_agents_manager_data_seo_suggestions_follow_option_off() {
+		$this->set_block_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		$this->activate_seo_tools_module();
+		update_option( 'ai_seo_enhancer_enabled', 0 );
+
+		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
+
+		delete_option( 'ai_seo_enhancer_enabled' );
+
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['seoSuggestions'] );
+		$this->assertSame( true, $data['jetpackAiSidebar']['features']['proofreadContent'] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -647,6 +647,30 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The master gate is final on the preview surface: with master off, a late
+	 * jetpack_ai_sidebar_enabled filter cannot re-open the gate, matching
+	 * is_ai_enabled() making the host and master gates final for plugin load
+	 * points.
+	 */
+	public function test_init_does_nothing_when_master_off_despite_late_filter() {
+		update_option( \Jetpack_AI_Settings::MASTER_OPTION, 0 );
+		add_filter( 'jetpack_ai_sidebar_enabled', '__return_true', 999 );
+
+		Jetpack_AI_Sidebar::init();
+
+		delete_option( \Jetpack_AI_Settings::MASTER_OPTION );
+
+		$this->assertFalse(
+			has_filter( 'agents_manager_agent_providers', array( Jetpack_AI_Sidebar::class, 'register_provider' ) ),
+			'register_provider should not be hooked when master is off, even with a late filter forcing the gate.'
+		);
+		$this->assertFalse(
+			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_toolbar_button_extension' ) ),
+			'register_toolbar_button_extension should not be hooked when master is off.'
+		);
+	}
+
+	/**
 	 * With both feature toggles off, init() registers nothing — the sidebar
 	 * bundle, provider registration, and enqueue hooks all stay out.
 	 */

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -714,12 +714,42 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	// ──────────────────────────────────────────────────
 
 	/**
-	 * Test that the toolbar button is enabled by default for eligible users.
+	 * Test that the toolbar button is enabled by default for eligible users. The
+	 * button is a writing entry point, so the writing assistant is switched on
+	 * explicitly rather than left to its default.
 	 */
 	public function test_toolbar_button_enabled_by_default() {
 		$this->set_block_editor_screen();
+		update_option( 'jetpack_ai_writing_assistant_enabled', 1 );
 
 		$this->assertTrue( Jetpack_AI_Sidebar::is_toolbar_button_enabled() );
+	}
+
+	/**
+	 * The toolbar button replaces the legacy AI toolbar, which is a writing
+	 * surface, so it follows the writing assistant toggle — and the generic
+	 * preview-features filter must not be able to force it back on. SEO stays on
+	 * so the sidebar itself remains available and the assertion is about the
+	 * button alone.
+	 */
+	public function test_toolbar_button_follows_writing_toggle_despite_filter() {
+		$this->set_block_editor_screen();
+		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
+		update_option( 'ai_seo_enhancer_enabled', 1 );
+		add_filter(
+			'jetpack_ai_sidebar_preview_features',
+			static function ( $features ) {
+				$features['blockToolbarButton'] = true;
+				return $features;
+			}
+		);
+
+		$enabled = Jetpack_AI_Sidebar::is_toolbar_button_enabled();
+
+		delete_option( 'jetpack_ai_writing_assistant_enabled' );
+		delete_option( 'ai_seo_enhancer_enabled' );
+
+		$this->assertFalse( $enabled );
 	}
 
 	/**
@@ -809,6 +839,30 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		);
 
 		Jetpack_AI_Sidebar::register_toolbar_button_extension();
+
+		$this->assertFalse( \Jetpack_Gutenberg::is_available( AiAssistantPlugin\AI_SIDEBAR_TOOLBAR_BUTTON_EXTENSION ) );
+		$availability = \Jetpack_Gutenberg::get_availability()[ AiAssistantPlugin\AI_SIDEBAR_TOOLBAR_BUTTON_EXTENSION ];
+		$this->assertFalse( $availability['available'] );
+		$this->assertSame( 'jetpack_ai_sidebar_feature_disabled', $availability['unavailable_reason'] );
+	}
+
+	/**
+	 * With the writing assistant off, the toolbar button extension is registered
+	 * as unavailable rather than merely reporting a false flag: the editor needs
+	 * the extension torn down for the button to disappear. SEO stays on so the
+	 * sidebar itself is still available and this covers the button alone.
+	 */
+	public function test_register_toolbar_button_extension_unavailable_when_writing_is_off() {
+		$this->set_block_editor_screen();
+		$this->make_legacy_block_toolbar_extensions_available();
+		$this->enable_sidebar_extension_availability_checks();
+		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
+		update_option( 'ai_seo_enhancer_enabled', 1 );
+
+		Jetpack_AI_Sidebar::register_toolbar_button_extension();
+
+		delete_option( 'jetpack_ai_writing_assistant_enabled' );
+		delete_option( 'ai_seo_enhancer_enabled' );
 
 		$this->assertFalse( \Jetpack_Gutenberg::is_available( AiAssistantPlugin\AI_SIDEBAR_TOOLBAR_BUTTON_EXTENSION ) );
 		$availability = \Jetpack_Gutenberg::get_availability()[ AiAssistantPlugin\AI_SIDEBAR_TOOLBAR_BUTTON_EXTENSION ];
@@ -924,6 +978,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_add_agents_manager_data_exposes_ai_editorial_review_by_default() {
 		$this->set_block_editor_screen();
+		// The writing features asserted below, the toolbar button among them,
+		// follow the writing assistant toggle, so switch it on explicitly.
+		update_option( 'jetpack_ai_writing_assistant_enabled', 1 );
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
@@ -983,8 +1040,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * The per-feature toggles from the AI settings page stay final over the
 	 * release defaults: a switched-off feature must not surface suggestions
 	 * even when an external host draws the sidebar. Writing assistant off kills
-	 * every writing suggestion (Proofreader, Optimize Title, Generate Feedback,
-	 * AI Editorial Review, and Generate Excerpt) while the SEO suggestions stay
+	 * every writing surface (Proofreader, Optimize Title, Generate Feedback, AI
+	 * Editorial Review, Generate Excerpt, block transformations, and the toolbar
+	 * button) while the SEO suggestions stay
 	 * on their own toggle. SEO is switched on here so the sidebar itself stays
 	 * available — with both toggles off Jetpack contributes no data at all,
 	 * which the visibility-gate tests cover.
@@ -1006,6 +1064,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['aiEditorialReview'] );
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['excerptSuggestion'] );
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['blockTransformations'] );
+		$this->assertSame( false, $data['jetpackAiSidebar']['features']['blockToolbarButton'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['seoSuggestions'] );
 	}
 


### PR DESCRIPTION
Fixes N/A (FORNO-368, item 1)

## Proposed changes

* Hide the Jetpack AI sidebar when the writing assistant and SEO enhancer toggles are both off — with both off it registers and enqueues nothing, including the provider abilities script.
* The check runs after the `jetpack_ai_sidebar_enabled` filter, so a later filter can't re-enable a featureless sidebar. The host and master gates are final on the preview surface too.
* Block transformations and editorial review follow the writing assistant toggle: with writing off, the block writing actions (Translate, Change tone, Check grammar, Simplify text) drop out while the sidebar stays available for SEO.
* The AI toolbar button follows the writing assistant toggle, so the editor offers no entry point to a feature that is switched off.
* Master gating is unchanged and stays upstream; since SEO defaults off, writing off alone hides the sidebar (intended, covered by a test).

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Screenshots

<details>
<summary>Screenshots- Atomic </summary>

Sidebar preview surface forced on via the `jetpack_ai_sidebar_enabled` filter; states set through the feature-settings endpoint.

| Writing on (baseline) | Writing + SEO both off |
|---|---|
|  <img width="1477" height="832" alt="atomic-baseline-loaded" src="https://github.com/user-attachments/assets/335f2fad-795d-459e-b90b-0e07dd3c8026" /> | <img width="1456" height="820" alt="atomic-both-off-hidden" src="https://github.com/user-attachments/assets/6b23cf98-9502-4797-96f3-24b5b30ceeb7" /> |

Both off: the sidebar, its suggestion cards, and the toolbar entry are gone. The floating chat shell still visible bottom-right is the host-owned Agents Manager surface, which the contract explicitly leaves in place.

| Block selected, writing on | Block selected, writing off + SEO on |
|---|---|
| <img width="1477" height="832" alt="atomic-writing-off-no-block-actions" src="https://github.com/user-attachments/assets/2eefab6f-5cc3-4172-b7a0-21b56335ca72" /> | <img width="1477" height="832" alt="atomic-writing-on-block-actions" src="https://github.com/user-attachments/assets/af66f6fb-b851-4224-8ec3-079cd2aa5cb3" /> |

With writing off, the block writing actions (Translate content, Change tone, Check grammar, Simplify text) drop out while the sidebar stays available for SEO.

</details>

## Testing instructions

On self-hosted, first force the preview surface on: `add_filter( 'jetpack_ai_sidebar_enabled', '__return_true' );` in an mu-plugin.

* Open a post, confirm the sidebar loads.
* `wp option update jetpack_ai_writing_assistant_enabled 0`, hard-reload: sidebar gone, no `jetpack-ai-sidebar` assets in the network panel, and no AI toolbar button.
* `wp option update ai_seo_enhancer_enabled 1`, hard-reload: sidebar is back, but the block writing actions (Translate, Change tone, Check grammar, Simplify text) stay out. Console check:
  ```js
  window.agentsManagerData?.jetpackAiSidebar?.features?.blockTransformations
  false with writing off, true with writing on.
- PHPUnit: Jetpack_AI_Sidebar_Test covers the full matrix, master interplay, and the late-filter case.

🤖 Description drafted with AI assistance, reviewed and tested by me
