### PR TITLE
wpcomsh: Un-gate RECURRING_PAYMENTS from gating-business-q1

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-recurring-payments-ungate-business-q1
+++ b/projects/plugins/wpcomsh/changelog/fix-recurring-payments-ungate-business-q1
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Recurring Payments: stop gating on the gating-business-q1 sticker so free-tier paid newsletters keep working.

--- a/projects/plugins/wpcomsh/changelog/fix-recurring-payments-ungate-business-q1
+++ b/projects/plugins/wpcomsh/changelog/fix-recurring-payments-ungate-business-q1
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Recurring Payments: stop gating on the gating-business-q1 sticker so free-tier paid newsletters keep working.
+Recurring Payments: restore the unconditional free-tier branch so free-plan sites keep paid newsletters and paid subscriptions.

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -1210,6 +1210,7 @@ class WPCOM_Features {
 		),
 
 		self::RECURRING_PAYMENTS                => array(
+			self::WPCOM_ALL_SITES,
 			self::WPCOM_STARTER_PLANS,
 			self::WPCOM_PREMIUM_AND_HIGHER_PLANS,
 			self::JETPACK_ALL_SITES,

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -1210,10 +1210,6 @@ class WPCOM_Features {
 		),
 
 		self::RECURRING_PAYMENTS                => array(
-			array(
-				'sticker_not_present' => 'gating-business-q1',
-				self::WPCOM_ALL_SITES,
-			),
 			self::WPCOM_STARTER_PLANS,
 			self::WPCOM_PREMIUM_AND_HIGHER_PLANS,
 			self::JETPACK_ALL_SITES,


### PR DESCRIPTION
Fixes #

## Proposed changes

* Mirrors the merged wpcom change 229819-ghe-Automattic/wpcom into wpcomsh's synced copy of `WPCOM_Features`.
* In `projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php`, unwraps the `RECURRING_PAYMENTS` free-tier branch from the `gating-business-q1` sticker conditional back to a plain `self::WPCOM_ALL_SITES` entry. This restores paid newsletters / paid subscriptions on free-plan sites, which regressed when the branch was swept into the Q1 pricing-grid gating experiment. Only Donations / Payment buttons / PayPal buttons are intended to be gated behind Premium — not Recurring Payments.

Before:

```php
self::RECURRING_PAYMENTS => array(
    array(
        'sticker_not_present' => 'gating-business-q1',
        self::WPCOM_ALL_SITES,
    ),
    self::WPCOM_STARTER_PLANS,
    ...
```

After:

```php
self::RECURRING_PAYMENTS => array(
    self::WPCOM_ALL_SITES,
    self::WPCOM_STARTER_PLANS,
    ...
```

## Related product discussion/links

* 229819-ghe-Automattic/wpcom

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a WordPress.com free-plan site that has the `gating-business-q1` sticker, confirm `wpcom_site_has_feature( WPCOM_Features::RECURRING_PAYMENTS )` returns `true` and a paid newsletter / paid subscription tier can be set up.
* Confirm Donations / Payment buttons / PayPal buttons remain gated on that same free-plan site (unchanged).
* Confirm no regression for Starter, Premium-and-higher, and Jetpack sites, which continue to have Recurring Payments.
* CI runs `WpcomFeaturesTest` (the smoke test for the synced feature map).

🤖 Generated with [Claude Code](https://claude.com/claude-code)