### PR TITLE
Forms, Scan, AI Launchpad: remove redundant boot import-map ordering workaround

### DIFF
--- a/projects/packages/forms/changelog/remove-forms-boot-importmap-workaround
+++ b/projects/packages/forms/changelog/remove-forms-boot-importmap-workaround
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Dashboard: remove the redundant boot import-map ordering workaround, now that the bundled @wordpress/build loader defers boot until DOMContentLoaded. No functional change.

--- a/projects/packages/forms/changelog/remove-forms-boot-importmap-workaround
+++ b/projects/packages/forms/changelog/remove-forms-boot-importmap-workaround
@@ -1,4 +1,4 @@
 Significance: patch
 Type: removed
 
-Dashboard: remove the redundant boot import-map ordering workaround, now that the bundled @wordpress/build loader defers boot until DOMContentLoaded. No functional change.
+Dashboard: Remove redundant workaround for a dashboard loading edge case now fixed in bundled dependencies. No functional change.

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -78,66 +78,6 @@ class Dashboard {
 	}
 
 	/**
-	 * Fix import map ordering for the wp-build boot script.
-	 *
-	 * In wp-admin, _wp_footer_scripts (classic scripts) and print_import_map
-	 * both hook into admin_print_footer_scripts at priority 10, but
-	 * _wp_footer_scripts is registered first. This causes the inline
-	 * import("@wordpress/boot") to execute before the import map exists.
-	 *
-	 * This fix moves the import() call from the classic inline script to a
-	 * <script type="module"> printed at priority 20 (after the import map).
-	 *
-	 * @todo Remove once @wordpress/build ships with the loader.js fix upstream
-	 *       (WordPress/gutenberg#76870) and Jetpack updates the dependency.
-	 */
-	public static function fix_boot_import_map_ordering() {
-		$handle = self::FORMS_WPBUILD_ADMIN_SLUG . '-prerequisites';
-
-		add_action(
-			'admin_enqueue_scripts',
-			static function () use ( $handle ) {
-				if ( ! Dashboard::is_jetpack_forms_admin_page() ) {
-					return;
-				}
-
-				$data = wp_scripts()->get_data( $handle, 'after' );
-				if ( empty( $data ) ) {
-					return;
-				}
-
-				// Find and extract the import("@wordpress/boot") inline script.
-				$boot_script = null;
-				$remaining   = array();
-				foreach ( $data as $line ) {
-					if ( strpos( $line, '@wordpress/boot' ) !== false ) {
-						$boot_script = $line;
-					} else {
-						$remaining[] = $line;
-					}
-				}
-
-				if ( $boot_script === null ) {
-					return;
-				}
-
-				// Remove from the classic script handle.
-				wp_scripts()->add_data( $handle, 'after', $remaining );
-
-				// Re-emit as a module script after the import map.
-				add_action(
-					'admin_print_footer_scripts',
-					static function () use ( $boot_script ) {
-						wp_print_inline_script_tag( $boot_script, array( 'type' => 'module' ) );
-					},
-					20
-				);
-			},
-			PHP_INT_MAX
-		);
-	}
-
-	/**
 	 * Script handle for the JS file we enqueue in the Feedback admin page.
 	 *
 	 * @var string
@@ -184,7 +124,6 @@ class Dashboard {
 
 		if ( $is_wp_build_enabled ) {
 			self::load_wp_build();
-			self::fix_boot_import_map_ordering();
 		}
 
 		add_action( 'admin_enqueue_scripts', array( $this, 'load_admin_scripts' ) );

--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-forms-boot-importmap-workaround
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-forms-boot-importmap-workaround
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+AI Launchpad: Remove redundant workaround for a page loading edge case now fixed in bundled dependencies. No functional change.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
@@ -51,7 +51,6 @@ class AI_Launchpad {
 		}
 
 		self::load_wp_build();
-		self::fix_boot_import_map_ordering();
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_jwt_initial_state' ), 20 );
 	}
 
@@ -183,56 +182,6 @@ class AI_Launchpad {
 			array(
 				'wpcomBlogId' => get_wpcom_blog_id(),
 			)
-		);
-	}
-
-	/**
-	 * Fix import map ordering for the wp-build boot script.
-	 *
-	 * In wp-admin both _wp_footer_scripts and print_import_map hook admin_print_footer_scripts at priority 10, but
-	 * _wp_footer_scripts runs first, so the inline import("@wordpress/boot") executes before the import map exists.
-	 * This moves the import() call to a <script type="module"> printed at priority 20, after the import map.
-	 *
-	 * @todo Remove once @wordpress/build ships the loader.js fix upstream
-	 *       (WordPress/gutenberg#76870) and Jetpack updates the dependency.
-	 */
-	private static function fix_boot_import_map_ordering() {
-		$handle = self::MENU_SLUG . '-prerequisites';
-
-		add_action(
-			'admin_enqueue_scripts',
-			static function () use ( $handle ) {
-				$data = wp_scripts()->get_data( $handle, 'after' );
-				if ( empty( $data ) ) {
-					return;
-				}
-
-				$boot_script = null;
-				$remaining   = array();
-				foreach ( $data as $line ) {
-					if ( strpos( $line, '@wordpress/boot' ) !== false ) {
-						$boot_script = $line;
-					} else {
-						$remaining[] = $line;
-					}
-				}
-
-				if ( $boot_script === null ) {
-					return;
-				}
-
-				wp_scripts()->add_data( $handle, 'after', $remaining );
-
-				// Re-emit as a module script after the import map.
-				add_action(
-					'admin_print_footer_scripts',
-					static function () use ( $boot_script ) {
-						wp_print_inline_script_tag( $boot_script, array( 'type' => 'module' ) );
-					},
-					20
-				);
-			},
-			PHP_INT_MAX
 		);
 	}
 }

--- a/projects/packages/scan/changelog/remove-forms-boot-importmap-workaround
+++ b/projects/packages/scan/changelog/remove-forms-boot-importmap-workaround
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove redundant workaround for a page loading edge case now fixed in bundled dependencies. No functional change.

--- a/projects/packages/scan/src/class-jetpack-scan.php
+++ b/projects/packages/scan/src/class-jetpack-scan.php
@@ -27,8 +27,6 @@ use function is_multisite;
 use function remove_action;
 use function remove_all_actions;
 use function sanitize_text_field;
-use function wp_print_inline_script_tag;
-use function wp_scripts;
 use function wp_unslash;
 
 /**
@@ -83,7 +81,6 @@ class Jetpack_Scan {
 		}
 
 		self::load_wp_build();
-		self::fix_boot_import_map_ordering();
 		self::bridge_wp_build_enqueue();
 
 		add_action( 'admin_menu', array( __CLASS__, 'add_wp_admin_submenu' ) );
@@ -184,67 +181,6 @@ class Jetpack_Scan {
 				// phpcs:enable WordPress.Security.NonceVerification.Recommended,WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			},
 			9
-		);
-	}
-
-	/**
-	 * Fix import map ordering for the wp-build boot script.
-	 *
-	 * In wp-admin, `_wp_footer_scripts` (classic scripts) and
-	 * `print_import_map` both hook into `admin_print_footer_scripts` at
-	 * priority 10, but `_wp_footer_scripts` is registered first. This
-	 * causes the inline `import("@wordpress/boot")` to execute before
-	 * the import map exists.
-	 *
-	 * This fix moves the import() call from the classic inline script to
-	 * a `<script type="module">` printed at priority 20 (after the import
-	 * map).
-	 *
-	 * @todo Remove once @wordpress/build ships with the loader.js fix
-	 *       upstream (WordPress/gutenberg#76870) and Jetpack updates the
-	 *       dependency.
-	 */
-	public static function fix_boot_import_map_ordering() {
-		$handle = self::WP_BUILD_SLUG . '-prerequisites';
-
-		add_action(
-			'admin_enqueue_scripts',
-			static function () use ( $handle ) {
-				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				if ( ! isset( $_GET['page'] ) || self::PAGE_SLUG !== $_GET['page'] ) {
-					return;
-				}
-
-				$data = wp_scripts()->get_data( $handle, 'after' );
-				if ( empty( $data ) ) {
-					return;
-				}
-
-				$boot_script = null;
-				$remaining   = array();
-				foreach ( $data as $line ) {
-					if ( strpos( $line, '@wordpress/boot' ) !== false ) {
-						$boot_script = $line;
-					} else {
-						$remaining[] = $line;
-					}
-				}
-
-				if ( null === $boot_script ) {
-					return;
-				}
-
-				wp_scripts()->add_data( $handle, 'after', $remaining );
-
-				add_action(
-					'admin_print_footer_scripts',
-					static function () use ( $boot_script ) {
-						wp_print_inline_script_tag( $boot_script, array( 'type' => 'module' ) );
-					},
-					20
-				);
-			},
-			PHP_INT_MAX
 		);
 	}
 


### PR DESCRIPTION
Part of https://github.com/Automattic/jetpack/issues/50712 — step 9 of the Forms dashboard cleanup.

## Proposed changes

Removes `fix_boot_import_map_ordering()` and its call from all three packages that carry a copy:

| Package | Method | Page |
|---|---|---|
| `packages/forms` | `Dashboard::fix_boot_import_map_ordering()` | Jetpack → Forms |
| `packages/scan` | `Jetpack_Scan::fix_boot_import_map_ordering()` | Jetpack → Scan |
| `packages/jetpack-mu-wpcom` | `AI_Launchpad::fix_boot_import_map_ordering()` | Site Setup (AI Launchpad) |

It was a stopgap for FORMS-667 — an import-map ordering race that blanked a wp-build admin page when a plugin shifted classic→module script execution (e.g. The Events Calendar). The method pulled the `import("@wordpress/boot")` inline script off the classic handle and re-emitted it as `<script type="module">` after the import map.

That is no longer needed. The bundled `@wordpress/build` loader defers `import("@wordpress/boot")` to `DOMContentLoaded`, so the import map is always parsed before boot runs, regardless of emission order. The deferral shipped in `@wordpress/build` 0.15.0 via WordPress/gutenberg#78136 — which superseded WordPress/gutenberg#76870, the PR each `@todo` cited and which never merged.

All three packages pin `@wordpress/build` 0.18.0, and each package's generated `build/pages/*/page-wp-admin.php` contains the deferral. **No functional change.**

## Related product discussion/links

* https://github.com/Automattic/jetpack/issues/50712

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Each page must still boot without the workaround, including under the condition that originally triggered FORMS-667.

**Setup:** activate **The Events Calendar** — that is the canonical trigger. Keep the browser console open throughout and watch for `@wordpress/boot` errors or "Failed to resolve module specifier".

1. **Forms** — go to **Jetpack → Forms**. The dashboard renders, not a blank screen.
2. **Scan** — the page is behind a filter. Add `add_filter( 'rsm_jetpack_ui_modernization_scan', '__return_true' );`, then go to **Jetpack → Scan** (`admin.php?page=jetpack-scan`) and confirm the overview renders.
3. **AI Launchpad** — WordPress.com Simple or Atomic only, on a site eligible for the launchpad. Load `admin.php?page=site-setup-wp-admin` and confirm the wizard renders.
4. **Older WP** — repeat step 1 on **WP 6.9**. The loader deferral is bundled, not core, so it holds there too.

Each page should render with an empty console. A regression looks like a blank page plus a module-specifier error.

**Already verified:** Forms on WP 6.9 and 7.0, workaround on and off, TEC active, across the modernized dashboards — all render cleanly. Scan and AI Launchpad are verified by code and build-artifact inspection only (same pinned dependency, same generated deferral); they have not been clicked through on a live site.
