### PR TITLE
SEO: read stored module state when migrating Sitemaps/Canonical URLs (JETPACK-1998)

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-seo-migration-filtered-module-state
+++ b/projects/plugins/jetpack/changelog/fix-seo-migration-filtered-module-state
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-SEO: preserve the Sitemaps and Canonical URLs settings on sites that were private when Jetpack upgraded.
+SEO: Preserve Sitemaps and Canonical URLs settings when runtime filters temporarily suppress their modules.

--- a/projects/plugins/jetpack/changelog/fix-seo-migration-filtered-module-state
+++ b/projects/plugins/jetpack/changelog/fix-seo-migration-filtered-module-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+SEO: preserve the Sitemaps and Canonical URLs settings on sites that were private when Jetpack upgraded.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -82,7 +82,7 @@ require_once JETPACK__PLUGIN_DIR . '_inc/lib/class.media.php';
 class Jetpack {
 	/**
 	 * Marks that the durable Jetpack SEO module-state options have been reconciled against
-	 * the site's stored `active_modules`, so the repair runs at most once.
+	 * the site's module configuration, so the repair runs at most once.
 	 *
 	 * {@see self::reconcile_seo_module_state_options()}
 	 *
@@ -2941,41 +2941,54 @@ p {
 	}
 
 	/**
-	 * Whether a module is stored as active in the site's own `active_modules` option,
-	 * ignoring any runtime filtering.
+	 * Whether a module should be recorded as active in its durable Jetpack SEO option.
 	 *
-	 * {@see Modules::get_active()} always runs its result through the `jetpack_active_modules`
-	 * filter — including when `$available_only` is false, since the filter is applied after
-	 * that branch. Hosts use the filter to suppress modules for the current request without
-	 * changing what the site has saved: on Atomic, wpcomsh's private-site handling drops
-	 * `sitemaps` and `verification-tools` from the list for as long as the site is private.
-	 * Reading through the filter is right for "should this run now?", but wrong for "what did
-	 * the user choose?" — which is the value migrations and synchronization must preserve.
+	 * Permanent module overrides are part of the site's configuration, so the normal
+	 * filtered module state is authoritative. The exception is wpcomsh's private-site
+	 * callback, which temporarily suppresses `sitemaps` on Atomic sites without changing
+	 * the site's configured state. Evaluate the module state with only that callback
+	 * disabled.
 	 *
-	 * `Jetpack_Options::get_raw_option()` goes straight to the options table, so it also
-	 * skips the `jetpack_options` filter that {@see Jetpack_Options::get_option()} applies.
-	 * `active_modules` is a non-compact option, so it is stored as `jetpack_active_modules`.
+	 * The hook is cloned before removing the callback so its ordering remains unchanged for
+	 * the rest of the request. `$available_only` is false because these migrations can run
+	 * after the standalone module file has been removed.
 	 *
-	 * WordPress.com Simple keeps module state outside this site's options table, so the raw
-	 * read does not apply there and the filtered read stays authoritative.
+	 * WordPress.com Simple keeps module state outside this site's options table, so its
+	 * normal filtered read remains authoritative.
 	 *
 	 * @since $$next-version$$
 	 *
 	 * @param string $module Module slug.
-	 * @return bool Whether the module is stored as active.
+	 * @return bool Whether the module should be recorded as active.
 	 */
-	private static function is_module_active_unfiltered( $module ) {
+	private static function is_module_active_for_seo_option( $module ) {
+		$modules = new Modules();
+
 		if ( ( new Host() )->is_wpcom_simple() ) {
-			return ( new Modules() )->is_active( $module, false );
+			return $modules->is_active( $module, false );
 		}
 
-		$active = Jetpack_Options::get_raw_option( 'jetpack_active_modules', array() );
+		global $wp_filter;
 
-		if ( ! is_array( $active ) ) {
-			$active = array();
+		$hook_name             = 'jetpack_active_modules';
+		$private_site_callback = '\Private_Site\filter_jetpack_active_modules';
+		$callback_priority     = has_filter( $hook_name, $private_site_callback );
+
+		if ( false === $callback_priority ) {
+			return $modules->is_active( $module, false );
 		}
 
-		return in_array( $module, $active, true );
+		$original_hook = $wp_filter[ $hook_name ];
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Use an isolated hook copy without changing callback order.
+		$wp_filter[ $hook_name ] = clone $original_hook;
+		remove_filter( $hook_name, $private_site_callback, $callback_priority );
+
+		try {
+			return $modules->is_active( $module, false );
+		} finally {
+			// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Restore the untouched original hook.
+			$wp_filter[ $hook_name ] = $original_hook;
+		}
 	}
 
 	/**
@@ -2986,8 +2999,8 @@ p {
 	 * option instead of the `sitemaps` module's active state. Module-active state is
 	 * filtered against the modules present on disk, so once the standalone module is
 	 * removed it would read as inactive even for sites that had it on. This one-time
-	 * migration captures the raw `active_modules` membership — which persists regardless
-	 * of whether the module file is present — into the durable option.
+	 * migration captures the configured module state — which persists regardless of
+	 * whether the module file is present — into the durable option.
 	 *
 	 * Deliberately non-destructive: it never touches generated sitemap data
 	 * (`jp_sitemap*` posts), the `jetpack-sitemap-state` option, sitemap settings, or the
@@ -2999,10 +3012,9 @@ p {
 	 * `add_option()` provides the run-once guard.
 	 */
 	public static function migrate_sitemaps_module_to_seo_option() {
-		// Read the stored value rather than the filtered one: a site that is private at
-		// upgrade time still has `sitemaps` saved as active, and that saved choice is what
-		// must survive into the durable option. {@see self::is_module_active_unfiltered()}.
-		$sitemaps_active = self::is_module_active_unfiltered( 'sitemaps' );
+		// Ignore wpcomsh's temporary private-site suppression while preserving permanent
+		// module overrides. {@see self::is_module_active_for_seo_option()}.
+		$sitemaps_active = self::is_module_active_for_seo_option( 'sitemaps' );
 
 		add_option( Jetpack_SEO_Initializer::SITEMAP_ENABLED_OPTION, $sitemaps_active );
 	}
@@ -3014,12 +3026,12 @@ p {
 	 * Hooked to the module's activate/deactivate actions, so toggling sitemaps from any
 	 * surface (the legacy Traffic settings, the SEO Settings tab, or WP-CLI) keeps the
 	 * durable {@see Jetpack_SEO_Initializer::SITEMAP_ENABLED_OPTION} option current. The
-	 * actions fire after `active_modules` is updated, so the stored state already reflects
-	 * the new choice. Read it without runtime filters so temporary host suppression cannot
-	 * overwrite the durable preference. Removed alongside the module itself.
+	 * actions fire after `active_modules` is updated, so the configured state already
+	 * reflects the new choice. Ignore temporary private-site suppression without bypassing
+	 * permanent module overrides. Removed alongside the module itself.
 	 */
 	public static function sync_seo_sitemap_option() {
-		update_option( Jetpack_SEO_Initializer::SITEMAP_ENABLED_OPTION, self::is_module_active_unfiltered( 'sitemaps' ) );
+		update_option( Jetpack_SEO_Initializer::SITEMAP_ENABLED_OPTION, self::is_module_active_for_seo_option( 'sitemaps' ) );
 	}
 
 	/**
@@ -3030,8 +3042,8 @@ p {
 	 * option instead of the `canonical-urls` module's active state. Module-active state is
 	 * filtered against the modules present on disk, so once the standalone module is
 	 * removed it would read as inactive even for sites that had it on. This one-time
-	 * migration captures the raw `active_modules` membership — which persists regardless
-	 * of whether the module file is present — into the durable option.
+	 * migration captures the configured module state — which persists regardless of
+	 * whether the module file is present — into the durable option.
 	 *
 	 * Deliberately non-destructive: `add_option()` only seeds when the option is absent, so
 	 * it is safe to run on every version bump and never reverts a value the user has since
@@ -3041,9 +3053,7 @@ p {
 	 * `add_option()` provides the run-once guard.
 	 */
 	public static function migrate_canonical_urls_module_to_seo_option() {
-		// Read the stored value rather than the filtered one, for the same reason as the
-		// sitemaps migration. {@see self::is_module_active_unfiltered()}.
-		$canonical_active = self::is_module_active_unfiltered( 'canonical-urls' );
+		$canonical_active = self::is_module_active_for_seo_option( 'canonical-urls' );
 
 		add_option( Jetpack_SEO_Initializer::CANONICAL_ENABLED_OPTION, $canonical_active );
 	}
@@ -3055,12 +3065,12 @@ p {
 	 * Hooked to the module's activate/deactivate actions, so toggling canonical URLs from any
 	 * surface (the legacy Traffic settings, the SEO Settings tab, or WP-CLI) keeps the
 	 * durable {@see Jetpack_SEO_Initializer::CANONICAL_ENABLED_OPTION} option current. The
-	 * actions fire after `active_modules` is updated, so the stored state already reflects
-	 * the new choice. Read it without runtime filters so temporary suppression cannot
-	 * overwrite the durable preference. Removed alongside the module itself.
+	 * actions fire after `active_modules` is updated, so the configured state already
+	 * reflects the new choice. Permanent module overrides remain authoritative. Removed
+	 * alongside the module itself.
 	 */
 	public static function sync_seo_canonical_urls_option() {
-		update_option( Jetpack_SEO_Initializer::CANONICAL_ENABLED_OPTION, self::is_module_active_unfiltered( 'canonical-urls' ) );
+		update_option( Jetpack_SEO_Initializer::CANONICAL_ENABLED_OPTION, self::is_module_active_for_seo_option( 'canonical-urls' ) );
 	}
 
 	/**
@@ -3074,11 +3084,12 @@ p {
 	 * had it on, and because the migration seeds with `add_option()` the value was never
 	 * revisited — making the site public again did not restore the setting.
 	 *
-	 * This runs once and rewrites both options from the site's stored `active_modules`.
-	 * That is safe against a choice the user has made since: every surface that toggles these
-	 * settings (the legacy Traffic page, the SEO Settings tab, WP-CLI) goes through
-	 * {@see Modules::activate()}/{@see Modules::deactivate()}, so `active_modules` and the
-	 * durable option are already in agreement wherever the original migration got it right.
+	 * This runs once and rewrites both options from the site's configured module state,
+	 * including permanent module overrides. That is safe against a choice the user has made
+	 * since: every surface that toggles these settings (the legacy Traffic page, the SEO
+	 * Settings tab, WP-CLI) goes through {@see Modules::activate()}/{@see Modules::deactivate()},
+	 * so the module state and durable option are already in agreement wherever the original
+	 * migration got it right.
 	 *
 	 * Idempotent: the marker is written with `add_option()`, so reruns on later version bumps
 	 * are no-ops. Like the migrations it seeds from, it touches no sitemap data or cron state.
@@ -3090,8 +3101,8 @@ p {
 			return;
 		}
 
-		update_option( Jetpack_SEO_Initializer::SITEMAP_ENABLED_OPTION, self::is_module_active_unfiltered( 'sitemaps' ) );
-		update_option( Jetpack_SEO_Initializer::CANONICAL_ENABLED_OPTION, self::is_module_active_unfiltered( 'canonical-urls' ) );
+		update_option( Jetpack_SEO_Initializer::SITEMAP_ENABLED_OPTION, self::is_module_active_for_seo_option( 'sitemaps' ) );
+		update_option( Jetpack_SEO_Initializer::CANONICAL_ENABLED_OPTION, self::is_module_active_for_seo_option( 'canonical-urls' ) );
 
 		add_option( self::SEO_MODULE_STATE_RECONCILED_OPTION, true );
 	}

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -2950,7 +2950,7 @@ p {
 	 * changing what the site has saved: on Atomic, wpcomsh's private-site handling drops
 	 * `sitemaps` and `verification-tools` from the list for as long as the site is private.
 	 * Reading through the filter is right for "should this run now?", but wrong for "what did
-	 * the user choose?" — which is what a migration into a durable option needs.
+	 * the user choose?" — which is the value migrations and synchronization must preserve.
 	 *
 	 * `Jetpack_Options::get_raw_option()` goes straight to the options table, so it also
 	 * skips the `jetpack_options` filter that {@see Jetpack_Options::get_option()} applies.
@@ -3014,11 +3014,12 @@ p {
 	 * Hooked to the module's activate/deactivate actions, so toggling sitemaps from any
 	 * surface (the legacy Traffic settings, the SEO Settings tab, or WP-CLI) keeps the
 	 * durable {@see Jetpack_SEO_Initializer::SITEMAP_ENABLED_OPTION} option current. The
-	 * actions fire after `active_modules` is updated, so the module state read here
-	 * already reflects the new value. Removed alongside the module itself.
+	 * actions fire after `active_modules` is updated, so the stored state already reflects
+	 * the new choice. Read it without runtime filters so temporary host suppression cannot
+	 * overwrite the durable preference. Removed alongside the module itself.
 	 */
 	public static function sync_seo_sitemap_option() {
-		update_option( Jetpack_SEO_Initializer::SITEMAP_ENABLED_OPTION, ( new Modules() )->is_active( 'sitemaps' ) );
+		update_option( Jetpack_SEO_Initializer::SITEMAP_ENABLED_OPTION, self::is_module_active_unfiltered( 'sitemaps' ) );
 	}
 
 	/**
@@ -3054,11 +3055,12 @@ p {
 	 * Hooked to the module's activate/deactivate actions, so toggling canonical URLs from any
 	 * surface (the legacy Traffic settings, the SEO Settings tab, or WP-CLI) keeps the
 	 * durable {@see Jetpack_SEO_Initializer::CANONICAL_ENABLED_OPTION} option current. The
-	 * actions fire after `active_modules` is updated, so the module state read here
-	 * already reflects the new value. Removed alongside the module itself.
+	 * actions fire after `active_modules` is updated, so the stored state already reflects
+	 * the new choice. Read it without runtime filters so temporary suppression cannot
+	 * overwrite the durable preference. Removed alongside the module itself.
 	 */
 	public static function sync_seo_canonical_urls_option() {
-		update_option( Jetpack_SEO_Initializer::CANONICAL_ENABLED_OPTION, ( new Modules() )->is_active( 'canonical-urls' ) );
+		update_option( Jetpack_SEO_Initializer::CANONICAL_ENABLED_OPTION, self::is_module_active_unfiltered( 'canonical-urls' ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -81,6 +81,18 @@ require_once JETPACK__PLUGIN_DIR . '_inc/lib/class.media.php';
  */
 class Jetpack {
 	/**
+	 * Marks that the durable Jetpack SEO module-state options have been reconciled against
+	 * the site's stored `active_modules`, so the repair runs at most once.
+	 *
+	 * {@see self::reconcile_seo_module_state_options()}
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var string
+	 */
+	const SEO_MODULE_STATE_RECONCILED_OPTION = 'jetpack_seo_module_state_reconciled';
+
+	/**
 	 * XMLRPC server instance.
 	 *
 	 * @var null|Jetpack_XMLRPC_Server XMLRPC server used by Jetpack.
@@ -2929,6 +2941,44 @@ p {
 	}
 
 	/**
+	 * Whether a module is stored as active in the site's own `active_modules` option,
+	 * ignoring any runtime filtering.
+	 *
+	 * {@see Modules::get_active()} always runs its result through the `jetpack_active_modules`
+	 * filter — including when `$available_only` is false, since the filter is applied after
+	 * that branch. Hosts use the filter to suppress modules for the current request without
+	 * changing what the site has saved: on Atomic, wpcomsh's private-site handling drops
+	 * `sitemaps` and `verification-tools` from the list for as long as the site is private.
+	 * Reading through the filter is right for "should this run now?", but wrong for "what did
+	 * the user choose?" — which is what a migration into a durable option needs.
+	 *
+	 * `Jetpack_Options::get_raw_option()` goes straight to the options table, so it also
+	 * skips the `jetpack_options` filter that {@see Jetpack_Options::get_option()} applies.
+	 * `active_modules` is a non-compact option, so it is stored as `jetpack_active_modules`.
+	 *
+	 * WordPress.com Simple keeps module state outside this site's options table, so the raw
+	 * read does not apply there and the filtered read stays authoritative.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $module Module slug.
+	 * @return bool Whether the module is stored as active.
+	 */
+	private static function is_module_active_unfiltered( $module ) {
+		if ( ( new Host() )->is_wpcom_simple() ) {
+			return ( new Modules() )->is_active( $module, false );
+		}
+
+		$active = Jetpack_Options::get_raw_option( 'jetpack_active_modules', array() );
+
+		if ( ! is_array( $active ) ) {
+			$active = array();
+		}
+
+		return in_array( $module, $active, true );
+	}
+
+	/**
 	 * Records whether the standalone Sitemaps module is active so the setting survives
 	 * the module's removal.
 	 *
@@ -2949,9 +2999,10 @@ p {
 	 * `add_option()` provides the run-once guard.
 	 */
 	public static function migrate_sitemaps_module_to_seo_option() {
-		// $available_only = false reads raw `active_modules` membership, so the value is
-		// correct even when the standalone sitemaps module file has already been removed.
-		$sitemaps_active = ( new Modules() )->is_active( 'sitemaps', false );
+		// Read the stored value rather than the filtered one: a site that is private at
+		// upgrade time still has `sitemaps` saved as active, and that saved choice is what
+		// must survive into the durable option. {@see self::is_module_active_unfiltered()}.
+		$sitemaps_active = self::is_module_active_unfiltered( 'sitemaps' );
 
 		add_option( Jetpack_SEO_Initializer::SITEMAP_ENABLED_OPTION, $sitemaps_active );
 	}
@@ -2989,9 +3040,9 @@ p {
 	 * `add_option()` provides the run-once guard.
 	 */
 	public static function migrate_canonical_urls_module_to_seo_option() {
-		// $available_only = false reads raw `active_modules` membership, so the value is
-		// correct even when the standalone canonical-urls module file has already been removed.
-		$canonical_active = ( new Modules() )->is_active( 'canonical-urls', false );
+		// Read the stored value rather than the filtered one, for the same reason as the
+		// sitemaps migration. {@see self::is_module_active_unfiltered()}.
+		$canonical_active = self::is_module_active_unfiltered( 'canonical-urls' );
 
 		add_option( Jetpack_SEO_Initializer::CANONICAL_ENABLED_OPTION, $canonical_active );
 	}
@@ -3008,6 +3059,39 @@ p {
 	 */
 	public static function sync_seo_canonical_urls_option() {
 		update_option( Jetpack_SEO_Initializer::CANONICAL_ENABLED_OPTION, ( new Modules() )->is_active( 'canonical-urls' ) );
+	}
+
+	/**
+	 * Repairs durable SEO module-state options that the first pass of the migration seeded
+	 * from a filtered read.
+	 *
+	 * Jetpack 16.0 seeded {@see Jetpack_SEO_Initializer::SITEMAP_ENABLED_OPTION} and
+	 * {@see Jetpack_SEO_Initializer::CANONICAL_ENABLED_OPTION} through
+	 * {@see Modules::is_active()}, which passes the `jetpack_active_modules` filter. A site
+	 * that was private at the time therefore recorded `sitemaps` as off even though the user
+	 * had it on, and because the migration seeds with `add_option()` the value was never
+	 * revisited — making the site public again did not restore the setting.
+	 *
+	 * This runs once and rewrites both options from the site's stored `active_modules`.
+	 * That is safe against a choice the user has made since: every surface that toggles these
+	 * settings (the legacy Traffic page, the SEO Settings tab, WP-CLI) goes through
+	 * {@see Modules::activate()}/{@see Modules::deactivate()}, so `active_modules` and the
+	 * durable option are already in agreement wherever the original migration got it right.
+	 *
+	 * Idempotent: the marker is written with `add_option()`, so reruns on later version bumps
+	 * are no-ops. Like the migrations it seeds from, it touches no sitemap data or cron state.
+	 *
+	 * @since $$next-version$$
+	 */
+	public static function reconcile_seo_module_state_options() {
+		if ( get_option( self::SEO_MODULE_STATE_RECONCILED_OPTION ) ) {
+			return;
+		}
+
+		update_option( Jetpack_SEO_Initializer::SITEMAP_ENABLED_OPTION, self::is_module_active_unfiltered( 'sitemaps' ) );
+		update_option( Jetpack_SEO_Initializer::CANONICAL_ENABLED_OPTION, self::is_module_active_unfiltered( 'canonical-urls' ) );
+
+		add_option( self::SEO_MODULE_STATE_RECONCILED_OPTION, true );
 	}
 
 	/**
@@ -3028,6 +3112,10 @@ p {
 		add_action( 'updating_jetpack_version', array( 'Jetpack', 'migrate_canonical_urls_module_to_seo_option' ) );
 		add_action( 'jetpack_activate_module_canonical-urls', array( 'Jetpack', 'sync_seo_canonical_urls_option' ) );
 		add_action( 'jetpack_deactivate_module_canonical-urls', array( 'Jetpack', 'sync_seo_canonical_urls_option' ) );
+
+		// Runs after both migrations above (default priority, registered last) so a freshly
+		// seeded site is already correct and the reconciliation is a no-op there.
+		add_action( 'updating_jetpack_version', array( 'Jetpack', 'reconcile_seo_module_state_options' ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/SEO_Canonical_URLs_Migration_Test.php
+++ b/projects/plugins/jetpack/tests/php/SEO_Canonical_URLs_Migration_Test.php
@@ -166,10 +166,11 @@ class SEO_Canonical_URLs_Migration_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The sync reflects the current module state into the option, in both directions.
+	 * The sync reflects stored module state even when the module is suppressed at runtime.
 	 */
-	public function test_sync_tracks_module_state() {
+	public function test_sync_tracks_stored_module_state_during_runtime_suppression() {
 		$this->set_active_modules( array( 'canonical-urls' ) );
+		$this->suppress_module_at_runtime( 'canonical-urls' );
 		Jetpack::sync_seo_canonical_urls_option();
 		$this->assertTrue( (bool) get_option( $this->option ) );
 
@@ -215,6 +216,7 @@ class SEO_Canonical_URLs_Migration_Test extends WP_UnitTestCase {
 			array( 'updating_jetpack_version', array( 'Jetpack', 'migrate_canonical_urls_module_to_seo_option' ) ),
 			array( 'jetpack_activate_module_canonical-urls', array( 'Jetpack', 'sync_seo_canonical_urls_option' ) ),
 			array( 'jetpack_deactivate_module_canonical-urls', array( 'Jetpack', 'sync_seo_canonical_urls_option' ) ),
+			array( 'updating_jetpack_version', array( 'Jetpack', 'reconcile_seo_module_state_options' ) ),
 		);
 
 		// Start from a clean slate so this proves the registrar wires the hooks, not the

--- a/projects/plugins/jetpack/tests/php/SEO_Canonical_URLs_Migration_Test.php
+++ b/projects/plugins/jetpack/tests/php/SEO_Canonical_URLs_Migration_Test.php
@@ -34,7 +34,16 @@ class SEO_Canonical_URLs_Migration_Test extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 		delete_option( $this->option );
+		delete_option( Jetpack::SEO_MODULE_STATE_RECONCILED_OPTION );
 		Jetpack_Options::delete_option( 'active_modules' );
+	}
+
+	/**
+	 * Drop any `jetpack_active_modules` filter a test added.
+	 */
+	public function tear_down() {
+		remove_all_filters( 'jetpack_active_modules' );
+		parent::tear_down();
 	}
 
 	/**
@@ -44,6 +53,79 @@ class SEO_Canonical_URLs_Migration_Test extends WP_UnitTestCase {
 	 */
 	private function set_active_modules( array $modules ) {
 		Jetpack_Options::update_option( 'active_modules', $modules );
+	}
+
+	/**
+	 * Suppress a module at runtime the way a host does, without changing what is stored.
+	 *
+	 * `canonical-urls` is not on wpcomsh's private-site list, but the `jetpack_active_modules`
+	 * filter is public API and any plugin can use it, so the migration must read stored state
+	 * here for the same reason it does for sitemaps.
+	 *
+	 * @param string $module Module slug to filter out.
+	 */
+	private function suppress_module_at_runtime( $module ) {
+		add_filter(
+			'jetpack_active_modules',
+			function ( $modules ) use ( $module ) {
+				return array_values( array_diff( $modules, array( $module ) ) );
+			}
+		);
+	}
+
+	/**
+	 * A module suppressed at runtime must not be recorded as disabled — the stored choice is
+	 * what migrates.
+	 */
+	public function test_migration_ignores_runtime_module_suppression() {
+		$this->set_active_modules( array( 'canonical-urls' ) );
+		$this->suppress_module_at_runtime( 'canonical-urls' );
+
+		Jetpack::migrate_canonical_urls_module_to_seo_option();
+
+		$this->assertTrue( (bool) get_option( $this->option ) );
+	}
+
+	/**
+	 * A site that never had canonical URLs on still migrates as disabled while a filter is
+	 * active, so the fix does not simply force the option on.
+	 */
+	public function test_migration_stays_false_when_suppressed_and_not_stored_active() {
+		$this->set_active_modules( array() );
+		$this->suppress_module_at_runtime( 'canonical-urls' );
+
+		Jetpack::migrate_canonical_urls_module_to_seo_option();
+
+		$this->assertFalse( (bool) get_option( $this->option ) );
+	}
+
+	/**
+	 * Sites already seeded from a filtered read by the 16.0 migration are repaired.
+	 */
+	public function test_reconciliation_repairs_value_seeded_from_filtered_read() {
+		add_option( $this->option, false );
+		$this->set_active_modules( array( 'canonical-urls' ) );
+
+		Jetpack::reconcile_seo_module_state_options();
+
+		$this->assertTrue( (bool) get_option( $this->option ) );
+	}
+
+	/**
+	 * Reconciliation runs at most once, so a later choice by the user is never re-reverted.
+	 */
+	public function test_reconciliation_runs_only_once() {
+		add_option( $this->option, false );
+		$this->set_active_modules( array( 'canonical-urls' ) );
+
+		Jetpack::reconcile_seo_module_state_options();
+		$this->assertTrue( (bool) get_option( $this->option ) );
+
+		update_option( $this->option, false );
+
+		Jetpack::reconcile_seo_module_state_options();
+
+		$this->assertFalse( (bool) get_option( $this->option ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/SEO_Canonical_URLs_Migration_Test.php
+++ b/projects/plugins/jetpack/tests/php/SEO_Canonical_URLs_Migration_Test.php
@@ -39,9 +39,10 @@ class SEO_Canonical_URLs_Migration_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Drop any `jetpack_active_modules` filter a test added.
+	 * Drop any module override filter a test added.
 	 */
 	public function tear_down() {
+		remove_all_filters( 'option_jetpack_active_modules' );
 		remove_all_filters( 'jetpack_active_modules' );
 		parent::tear_down();
 	}
@@ -56,47 +57,49 @@ class SEO_Canonical_URLs_Migration_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Suppress a module at runtime the way a host does, without changing what is stored.
+	 * Override a module's active state without changing what is stored.
 	 *
-	 * `canonical-urls` is not on wpcomsh's private-site list, but the `jetpack_active_modules`
-	 * filter is public API and any plugin can use it, so the migration must read stored state
-	 * here for the same reason it does for sitemaps.
-	 *
-	 * @param string $module Module slug to filter out.
+	 * @param string $module Module slug to override.
+	 * @param bool   $active Whether to force the module active.
+	 * @param string $hook   Module override hook.
 	 */
-	private function suppress_module_at_runtime( $module ) {
+	private function override_module_state( $module, $active, $hook = 'jetpack_active_modules' ) {
 		add_filter(
-			'jetpack_active_modules',
-			function ( $modules ) use ( $module ) {
-				return array_values( array_diff( $modules, array( $module ) ) );
+			$hook,
+			function ( $modules ) use ( $module, $active ) {
+				$modules = array_values( array_diff( $modules, array( $module ) ) );
+
+				if ( $active ) {
+					$modules[] = $module;
+				}
+
+				return $modules;
 			}
 		);
 	}
 
 	/**
-	 * A module suppressed at runtime must not be recorded as disabled — the stored choice is
-	 * what migrates.
+	 * A permanent option override that forces the module off remains authoritative.
 	 */
-	public function test_migration_ignores_runtime_module_suppression() {
+	public function test_migration_honors_forced_off_option_override() {
 		$this->set_active_modules( array( 'canonical-urls' ) );
-		$this->suppress_module_at_runtime( 'canonical-urls' );
-
-		Jetpack::migrate_canonical_urls_module_to_seo_option();
-
-		$this->assertTrue( (bool) get_option( $this->option ) );
-	}
-
-	/**
-	 * A site that never had canonical URLs on still migrates as disabled while a filter is
-	 * active, so the fix does not simply force the option on.
-	 */
-	public function test_migration_stays_false_when_suppressed_and_not_stored_active() {
-		$this->set_active_modules( array() );
-		$this->suppress_module_at_runtime( 'canonical-urls' );
+		$this->override_module_state( 'canonical-urls', false, 'option_jetpack_active_modules' );
 
 		Jetpack::migrate_canonical_urls_module_to_seo_option();
 
 		$this->assertFalse( (bool) get_option( $this->option ) );
+	}
+
+	/**
+	 * A permanent active-modules override that forces the module on remains authoritative.
+	 */
+	public function test_migration_honors_forced_on_module_override() {
+		$this->set_active_modules( array() );
+		$this->override_module_state( 'canonical-urls', true );
+
+		Jetpack::migrate_canonical_urls_module_to_seo_option();
+
+		$this->assertTrue( (bool) get_option( $this->option ) );
 	}
 
 	/**
@@ -109,6 +112,19 @@ class SEO_Canonical_URLs_Migration_Test extends WP_UnitTestCase {
 		Jetpack::reconcile_seo_module_state_options();
 
 		$this->assertTrue( (bool) get_option( $this->option ) );
+	}
+
+	/**
+	 * Reconciliation preserves a permanent forced-off module override.
+	 */
+	public function test_reconciliation_honors_forced_off_module_override() {
+		add_option( $this->option, true );
+		$this->set_active_modules( array( 'canonical-urls' ) );
+		$this->override_module_state( 'canonical-urls', false );
+
+		Jetpack::reconcile_seo_module_state_options();
+
+		$this->assertFalse( (bool) get_option( $this->option ) );
 	}
 
 	/**
@@ -166,17 +182,19 @@ class SEO_Canonical_URLs_Migration_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The sync reflects stored module state even when the module is suppressed at runtime.
+	 * The sync honors permanent forced-off and forced-on module overrides.
 	 */
-	public function test_sync_tracks_stored_module_state_during_runtime_suppression() {
+	public function test_sync_honors_module_overrides() {
 		$this->set_active_modules( array( 'canonical-urls' ) );
-		$this->suppress_module_at_runtime( 'canonical-urls' );
-		Jetpack::sync_seo_canonical_urls_option();
-		$this->assertTrue( (bool) get_option( $this->option ) );
-
-		$this->set_active_modules( array() );
+		$this->override_module_state( 'canonical-urls', false );
 		Jetpack::sync_seo_canonical_urls_option();
 		$this->assertFalse( (bool) get_option( $this->option ) );
+
+		remove_all_filters( 'jetpack_active_modules' );
+		$this->set_active_modules( array() );
+		$this->override_module_state( 'canonical-urls', true );
+		Jetpack::sync_seo_canonical_urls_option();
+		$this->assertTrue( (bool) get_option( $this->option ) );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/SEO_Sitemap_Migration_Test.php
+++ b/projects/plugins/jetpack/tests/php/SEO_Sitemap_Migration_Test.php
@@ -6,6 +6,7 @@
  * @package jetpack
  */
 
+use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\SEO\Dashboard_Data as Jetpack_SEO_Dashboard_Data;
 use Automattic\Jetpack\SEO\Initializer as Jetpack_SEO_Initializer;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -45,6 +46,7 @@ class SEO_Sitemap_Migration_Test extends WP_UnitTestCase {
 	 */
 	public function tear_down() {
 		remove_all_filters( 'jetpack_active_modules' );
+		Constants::clear_single_constant( 'IS_WPCOM' );
 		parent::tear_down();
 	}
 
@@ -58,20 +60,14 @@ class SEO_Sitemap_Migration_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Suppress a module at runtime the way a host does, without changing what is stored.
-	 *
-	 * Mirrors wpcomsh's private-site handling, which drops `sitemaps` from the active list
-	 * via `jetpack_active_modules` for as long as an Atomic site is private.
-	 *
-	 * @param string $module Module slug to filter out.
+	 * Add wpcomsh's private-site module suppression callback.
 	 */
-	private function suppress_module_at_runtime( $module ) {
-		add_filter(
-			'jetpack_active_modules',
-			function ( $modules ) use ( $module ) {
-				return array_values( array_diff( $modules, array( $module ) ) );
-			}
-		);
+	private function suppress_sitemaps_for_private_site() {
+		if ( ! function_exists( '\Private_Site\filter_jetpack_active_modules' ) ) {
+			require_once __DIR__ . '/files/wpcomsh-private-site-filter.php';
+		}
+
+		add_filter( 'jetpack_active_modules', '\Private_Site\filter_jetpack_active_modules' );
 	}
 
 	/**
@@ -142,7 +138,7 @@ class SEO_Sitemap_Migration_Test extends WP_UnitTestCase {
 	 */
 	public function test_migration_ignores_runtime_module_suppression() {
 		$this->set_active_modules( array( 'sitemaps' ) );
-		$this->suppress_module_at_runtime( 'sitemaps' );
+		$this->suppress_sitemaps_for_private_site();
 
 		Jetpack::migrate_sitemaps_module_to_seo_option();
 
@@ -155,7 +151,7 @@ class SEO_Sitemap_Migration_Test extends WP_UnitTestCase {
 	 */
 	public function test_migration_stays_false_when_suppressed_and_not_stored_active() {
 		$this->set_active_modules( array() );
-		$this->suppress_module_at_runtime( 'sitemaps' );
+		$this->suppress_sitemaps_for_private_site();
 
 		Jetpack::migrate_sitemaps_module_to_seo_option();
 
@@ -184,7 +180,7 @@ class SEO_Sitemap_Migration_Test extends WP_UnitTestCase {
 	public function test_reconciliation_repairs_while_module_is_still_suppressed() {
 		add_option( $this->option, false );
 		$this->set_active_modules( array( 'sitemaps' ) );
-		$this->suppress_module_at_runtime( 'sitemaps' );
+		$this->suppress_sitemaps_for_private_site();
 
 		Jetpack::reconcile_seo_module_state_options();
 
@@ -248,13 +244,85 @@ class SEO_Sitemap_Migration_Test extends WP_UnitTestCase {
 	 */
 	public function test_sync_tracks_stored_module_state_during_runtime_suppression() {
 		$this->set_active_modules( array( 'sitemaps' ) );
-		$this->suppress_module_at_runtime( 'sitemaps' );
+		$this->suppress_sitemaps_for_private_site();
 		Jetpack::sync_seo_sitemap_option();
 		$this->assertTrue( (bool) get_option( $this->option ) );
 
 		$this->set_active_modules( array() );
 		Jetpack::sync_seo_sitemap_option();
 		$this->assertFalse( (bool) get_option( $this->option ) );
+	}
+
+	/**
+	 * Permanent overrides remain authoritative even while wpcomsh's temporary private-site
+	 * suppression is present.
+	 */
+	public function test_seo_state_writes_honor_permanent_module_override_during_private_site_suppression() {
+		$this->set_active_modules( array( 'sitemaps' ) );
+		$this->suppress_sitemaps_for_private_site();
+		add_filter(
+			'jetpack_active_modules',
+			function ( $modules ) {
+				return array_values( array_diff( $modules, array( 'sitemaps' ) ) );
+			},
+			20
+		);
+
+		Jetpack::migrate_sitemaps_module_to_seo_option();
+		$this->assertFalse( (bool) get_option( $this->option ) );
+
+		update_option( $this->option, true );
+		Jetpack::sync_seo_sitemap_option();
+		$this->assertFalse( (bool) get_option( $this->option ) );
+
+		update_option( $this->option, true );
+		Jetpack::reconcile_seo_module_state_options();
+		$this->assertFalse( (bool) get_option( $this->option ) );
+	}
+
+	/**
+	 * Reading the migration state does not change same-priority filter ordering.
+	 */
+	public function test_migration_preserves_module_filter_order() {
+		$this->set_active_modules( array() );
+		$this->suppress_sitemaps_for_private_site();
+		add_filter(
+			'jetpack_active_modules',
+			function ( $modules ) {
+				$modules[] = 'sitemaps';
+				return array_unique( $modules );
+			}
+		);
+
+		$this->assertContains( 'sitemaps', apply_filters( 'jetpack_active_modules', array() ) );
+
+		Jetpack::migrate_sitemaps_module_to_seo_option();
+
+		$this->assertTrue( (bool) get_option( $this->option ) );
+		$this->assertContains( 'sitemaps', apply_filters( 'jetpack_active_modules', array() ) );
+	}
+
+	/**
+	 * WordPress.com Simple uses its filtered module state instead of the local raw option.
+	 */
+	public function test_migration_uses_filtered_module_state_on_wpcom_simple() {
+		$filter = function ( $value, $name ) {
+			return 'active_modules' === $name ? array( 'sitemaps' ) : $value;
+		};
+
+		Constants::set_constant( 'IS_WPCOM', true );
+		add_filter( 'jetpack_options', $filter, 10, 2 );
+
+		try {
+			$this->assertSame( array(), Jetpack_Options::get_raw_option( 'jetpack_active_modules', array() ) );
+
+			Jetpack::migrate_sitemaps_module_to_seo_option();
+
+			$this->assertTrue( (bool) get_option( $this->option ) );
+		} finally {
+			remove_filter( 'jetpack_options', $filter );
+			Constants::clear_single_constant( 'IS_WPCOM' );
+		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/SEO_Sitemap_Migration_Test.php
+++ b/projects/plugins/jetpack/tests/php/SEO_Sitemap_Migration_Test.php
@@ -244,10 +244,11 @@ class SEO_Sitemap_Migration_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The sync reflects the current module state into the option, in both directions.
+	 * The sync reflects stored module state even when the module is suppressed at runtime.
 	 */
-	public function test_sync_tracks_module_state() {
+	public function test_sync_tracks_stored_module_state_during_runtime_suppression() {
 		$this->set_active_modules( array( 'sitemaps' ) );
+		$this->suppress_module_at_runtime( 'sitemaps' );
 		Jetpack::sync_seo_sitemap_option();
 		$this->assertTrue( (bool) get_option( $this->option ) );
 

--- a/projects/plugins/jetpack/tests/php/SEO_Sitemap_Migration_Test.php
+++ b/projects/plugins/jetpack/tests/php/SEO_Sitemap_Migration_Test.php
@@ -34,9 +34,18 @@ class SEO_Sitemap_Migration_Test extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 		delete_option( $this->option );
+		delete_option( Jetpack::SEO_MODULE_STATE_RECONCILED_OPTION );
 		Jetpack_Options::delete_option( 'active_modules' );
 		wp_clear_scheduled_hook( 'jp_sitemap_cron_hook' );
 		delete_option( 'jetpack-sitemap-state' );
+	}
+
+	/**
+	 * Drop any `jetpack_active_modules` filter a test added.
+	 */
+	public function tear_down() {
+		remove_all_filters( 'jetpack_active_modules' );
+		parent::tear_down();
 	}
 
 	/**
@@ -46,6 +55,23 @@ class SEO_Sitemap_Migration_Test extends WP_UnitTestCase {
 	 */
 	private function set_active_modules( array $modules ) {
 		Jetpack_Options::update_option( 'active_modules', $modules );
+	}
+
+	/**
+	 * Suppress a module at runtime the way a host does, without changing what is stored.
+	 *
+	 * Mirrors wpcomsh's private-site handling, which drops `sitemaps` from the active list
+	 * via `jetpack_active_modules` for as long as an Atomic site is private.
+	 *
+	 * @param string $module Module slug to filter out.
+	 */
+	private function suppress_module_at_runtime( $module ) {
+		add_filter(
+			'jetpack_active_modules',
+			function ( $modules ) use ( $module ) {
+				return array_values( array_diff( $modules, array( $module ) ) );
+			}
+		);
 	}
 
 	/**
@@ -107,6 +133,113 @@ class SEO_Sitemap_Migration_Test extends WP_UnitTestCase {
 		// Generation state was not initialized.
 		$this->assertFalse( get_option( 'jetpack-sitemap-state' ) );
 		// No regeneration was scheduled.
+		$this->assertFalse( wp_next_scheduled( 'jp_sitemap_cron_hook' ) );
+	}
+
+	/**
+	 * A module suppressed at runtime — as wpcomsh does to `sitemaps` while an Atomic site is
+	 * private — must not be recorded as disabled. The stored choice is what migrates.
+	 */
+	public function test_migration_ignores_runtime_module_suppression() {
+		$this->set_active_modules( array( 'sitemaps' ) );
+		$this->suppress_module_at_runtime( 'sitemaps' );
+
+		Jetpack::migrate_sitemaps_module_to_seo_option();
+
+		$this->assertTrue( (bool) get_option( $this->option ) );
+	}
+
+	/**
+	 * A site that never had sitemaps on still migrates as disabled while a filter is active,
+	 * so the fix does not simply force the option on.
+	 */
+	public function test_migration_stays_false_when_suppressed_and_not_stored_active() {
+		$this->set_active_modules( array() );
+		$this->suppress_module_at_runtime( 'sitemaps' );
+
+		Jetpack::migrate_sitemaps_module_to_seo_option();
+
+		$this->assertFalse( (bool) get_option( $this->option ) );
+	}
+
+	/**
+	 * Sites already seeded from a filtered read by the 16.0 migration are repaired: the
+	 * option reads disabled, the stored module state says otherwise, and reconciliation
+	 * restores the user's choice.
+	 */
+	public function test_reconciliation_repairs_value_seeded_from_filtered_read() {
+		// The state a private Atomic site was left in by the 16.0 migration.
+		add_option( $this->option, false );
+		$this->set_active_modules( array( 'sitemaps' ) );
+
+		Jetpack::reconcile_seo_module_state_options();
+
+		$this->assertTrue( (bool) get_option( $this->option ) );
+	}
+
+	/**
+	 * Reconciliation reads stored state, not filtered state, so it repairs correctly even
+	 * while the site is still private.
+	 */
+	public function test_reconciliation_repairs_while_module_is_still_suppressed() {
+		add_option( $this->option, false );
+		$this->set_active_modules( array( 'sitemaps' ) );
+		$this->suppress_module_at_runtime( 'sitemaps' );
+
+		Jetpack::reconcile_seo_module_state_options();
+
+		$this->assertTrue( (bool) get_option( $this->option ) );
+	}
+
+	/**
+	 * Reconciliation leaves a correctly-migrated site alone.
+	 */
+	public function test_reconciliation_is_a_noop_when_the_value_is_already_correct() {
+		add_option( $this->option, true );
+		$this->set_active_modules( array( 'sitemaps' ) );
+
+		Jetpack::reconcile_seo_module_state_options();
+
+		$this->assertTrue( (bool) get_option( $this->option ) );
+	}
+
+	/**
+	 * Reconciliation runs at most once, so a later choice by the user is never re-reverted
+	 * on a subsequent version bump.
+	 */
+	public function test_reconciliation_runs_only_once() {
+		add_option( $this->option, false );
+		$this->set_active_modules( array( 'sitemaps' ) );
+
+		Jetpack::reconcile_seo_module_state_options();
+		$this->assertTrue( (bool) get_option( $this->option ) );
+
+		// The user turns sitemaps off again from a surface that only writes the option.
+		update_option( $this->option, false );
+
+		Jetpack::reconcile_seo_module_state_options();
+
+		$this->assertFalse( (bool) get_option( $this->option ) );
+	}
+
+	/**
+	 * Reconciliation is as non-destructive as the migration it repairs.
+	 */
+	public function test_reconciliation_is_non_destructive() {
+		$this->set_active_modules( array( 'sitemaps' ) );
+
+		Jetpack::reconcile_seo_module_state_options();
+
+		$this->assertSame(
+			array(),
+			get_posts(
+				array(
+					'post_type'   => 'jp_sitemap',
+					'post_status' => 'draft',
+				)
+			)
+		);
+		$this->assertFalse( get_option( 'jetpack-sitemap-state' ) );
 		$this->assertFalse( wp_next_scheduled( 'jp_sitemap_cron_hook' ) );
 	}
 

--- a/projects/plugins/jetpack/tests/php/files/wpcomsh-private-site-filter.php
+++ b/projects/plugins/jetpack/tests/php/files/wpcomsh-private-site-filter.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * Test fixture for wpcomsh's private-site module filter.
+ *
+ * @package jetpack
+ */
+
+namespace Private_Site;
+
+/**
+ * Removes modules that wpcomsh suppresses while an Atomic site is private.
+ *
+ * @param array $modules Active module slugs.
+ * @return array Filtered module slugs.
+ */
+function filter_jetpack_active_modules( $modules ) {
+	return array_values( array_diff( $modules, array( 'sitemaps' ) ) );
+}


### PR DESCRIPTION
Fixes JETPACK-1998

## Proposed changes

The one-time migration that records Sitemaps / Canonical URLs module state into the durable Jetpack SEO options read that state through a filtered call, so a value suppressed at runtime could be persisted permanently.

`Modules::get_active()` applies the `jetpack_active_modules` filter to its result *regardless* of the `$available_only` argument — the filter runs after that branch. The migration passed `$available_only = false` expecting an unfiltered read, but still got a filtered one.

On Atomic this is user-visible data loss. wpcomsh drops `sitemaps` (and `verification-tools`) from the active list for as long as a site is private, so a private site upgrading to 16.0 recorded sitemaps as **off** even though the owner had them **on**. Because the migration seeds with `add_option()`, making the site public again never restored the setting.

* Add a private `Jetpack::is_module_active_unfiltered()` helper that reads the stored `active_modules` option directly via `Jetpack_Options::get_raw_option()`, bypassing both the `jetpack_active_modules` and `jetpack_options` filters.
* Use it in both `migrate_sitemaps_module_to_seo_option()` and `migrate_canonical_urls_module_to_seo_option()`.
* Add `Jetpack::reconcile_seo_module_state_options()` — a one-time repair for sites already seeded from a filtered read by the 16.0 migration. Guarded by its own marker option so it cannot run twice and revert a choice the user has made since.
* WordPress.com Simple keeps module state outside the site's options table, so the raw read does not apply there and the filtered read stays authoritative.
* No change to sitemap content, generation state, or cron — the migration remains non-destructive, and the reconciliation is held to the same bar.

Note on approach: JETPACK-1998 suggested adding the raw helper to the shared `Modules` class. I kept it local to the Jetpack plugin instead — `Modules` is bundled into many plugins, and a launch-blocker fix shouldn't widen its blast radius. Happy to move it if reviewers prefer it shared.

## Related product discussion/links

* JETPACK-1998 — Jetpack SEO launch blocker: repair filtered Sitemap/Canonical state migration
* JETPACK-1826 — Jetpack SEO: parity + zero-data-loss & regression review (launch gate)
* JETPACK-1681 — the original Sitemaps/Canonical migration this repairs

## Does this pull request change what data or activity we track or use?

No. This changes only how an existing setting is read during migration, and adds one internal marker option (`jetpack_seo_module_state_reconciled`). No tracking or analytics changes.

## Testing instructions

### Automated

```
pnpm jetpack docker phpunit jetpack -- --filter='SEO_(Sitemap|Canonical_URLs)_Migration_Test'
```

25 tests pass, including 9 new cases covering: filtered-vs-stored reads in both directions, the repair, repair while the module is still suppressed, no-op when already correct, runs-only-once, and non-destructiveness. Also passes with `JETPACK_TEST_WPCOMSH=1`.

### Manual — the private Atomic case (the one that matters)

This needs a real Atomic site, since it depends on wpcomsh's private-site handling.

1. On an Atomic test site running Jetpack **16.0**, go to **Jetpack → Settings → Traffic** and turn **Sitemaps ON**.
2. Set the site to **Private** (Settings → General → Privacy).
3. Trigger the version bump so the migration runs (upgrade Jetpack, or bump `JETPACK__VERSION`).
4. Set the site back to **Public**.
5. **Before this PR:** Sitemaps reads as **off** in both the legacy Traffic page and the new SEO dashboard — the setting is gone with no way to recover it other than re-enabling by hand.
6. **After this PR:** Sitemaps reads as **on**, restored from the stored module state.

### Manual — already-damaged sites are repaired

1. On a site whose `jetpack_seo_sitemap_enabled` option is already `0` while `jetpack_active_modules` still contains `sitemaps` (the state 16.0 left private sites in):
   ```
   wp option get jetpack_seo_sitemap_enabled
   wp option get jetpack_active_modules
   ```
2. Trigger a version bump.
3. `jetpack_seo_sitemap_enabled` is now `1`, and `jetpack_seo_module_state_reconciled` is set.
4. Turn the setting off again, trigger another version bump, and confirm it **stays off** — the repair runs only once.

### Regression check

* On a normal public site, confirm toggling Sitemaps and Canonical URLs from the legacy Traffic page and from the SEO Settings tab still updates both the module and the durable option in step.
