### PR TITLE
jest: Fix coverage for wp-build stuff

### DIFF
--- a/projects/packages/agents-manager/.gitattributes
+++ b/projects/packages/agents-manager/.gitattributes
@@ -14,7 +14,6 @@ build/**          production-include
 # src/**/*.scss     production-exclude
 #
 # wp-build stuff compiled during build (uncomment as needed):
-# modules/**        production-exclude
+# packages/**       production-exclude
 # routes/**         production-exclude
-# scripts/**        production-exclude
-# styles/**         production-exclude
+# widgets/**        production-exclude

--- a/projects/packages/agents-manager/changelog/fix-js-coverage-for-wp-build
+++ b/projects/packages/agents-manager/changelog/fix-js-coverage-for-wp-build
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Update `.gitattributes` to match updated skeleton.
+
+

--- a/tools/cli/skeletons/packages/.gitattributes
+++ b/tools/cli/skeletons/packages/.gitattributes
@@ -13,7 +13,6 @@
 # src/**/*.scss     production-exclude
 #
 # wp-build stuff compiled during build (uncomment as needed):
-# modules/**        production-exclude
+# packages/**       production-exclude
 # routes/**         production-exclude
-# scripts/**        production-exclude
-# styles/**         production-exclude
+# widgets/**        production-exclude

--- a/tools/js-tools/jest/config.coverage.js
+++ b/tools/js-tools/jest/config.coverage.js
@@ -8,6 +8,12 @@ module.exports = {
 		'<rootDir>/index.{js,mjs,cjs,jsx,ts,tsx,mts,cts}',
 		'<rootDir>/*.d.ts',
 
+		// wp-build uses random dirs in the project root, sigh.
+		'<rootDir>/packages/**/*.{js,mjs,cjs,jsx,ts,tsx,mts,cts}',
+		'!<rootDir>/packages/**/(build|build-module)/**', // and it dumps build files in the source dirs, double sigh.
+		'<rootDir>/routes/**/*.{js,mjs,cjs,jsx,ts,tsx,mts,cts}',
+		'<rootDir>/widgets/**/*.{js,mjs,cjs,jsx,ts,tsx,mts,cts}',
+
 		// Exclude test files. Keep the patterns here in sync with testMatch in ./config.node.js and tools/js-tools/eslintrc/files.mjs.
 		'!<rootDir>/**/__tests__/**/*.[jt]s?(x)',
 		'!<rootDir>/**/?(*.)+(spec|test).[jt]s?(x)',


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
When people added the various wp-build `routes/`, `packages/`, and such, they didn't notice that the tests weren't recording coverage for them.

Add these dirs to `tools/js-tools/jest/config.coverage.js`, since wp-build usage is spreading quickly in the monorepo.

Also, update `tools/cli/skeletons/packages/.gitattributes` with the correct set of dirs.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
https://github.com/Automattic/jetpack/pull/50770#discussion_r3638275506

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI happy?
* Stuff covered now? No extraneous stuff covered?
