### PR TITLE
paypal-payments: Remove erroneous `coverageDirectory` from jest config

### DIFF
--- a/projects/packages/paypal-payments/changelog/fix-paypal-payments-js-coverage
+++ b/projects/packages/paypal-payments/changelog/fix-paypal-payments-js-coverage
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Remove erroneous `coverageDirectory` from jest config, so the monorepo test framework can find the coverage.
+
+

--- a/projects/packages/paypal-payments/jest.config.js
+++ b/projects/packages/paypal-payments/jest.config.js
@@ -23,6 +23,5 @@ module.exports = {
 		'!<rootDir>/src/**/*.stories.{js,jsx,ts,tsx}',
 		'!<rootDir>/src/**/index.{js,jsx,ts,tsx}',
 	],
-	coverageDirectory: '<rootDir>/coverage',
 	testMatch: [ '<rootDir>/tests/js/**/*.test.[jt]s?(x)' ],
 };


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
The monorepo testing framework needs this to be set from the `COVERAGE_DIR` environment variable, as is already done by the imported `baseConfig`.

As-is, JS coverage for the package was being ignored because it wasn't written to the correct location.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI happy?
* Coverage being reported now?