### PR TITLE
cookie-consent: Record coverage for PHP tests

### DIFF
--- a/projects/packages/cookie-consent/changelog/fix-record-coverage-for-cookie-consent
+++ b/projects/packages/cookie-consent/changelog/fix-record-coverage-for-cookie-consent
@@ -1,0 +1,5 @@
+Significance: patch
+Type: fixed
+Comment: Fix coverage for PHP tests.
+
+

--- a/projects/packages/cookie-consent/composer.json
+++ b/projects/packages/cookie-consent/composer.json
@@ -29,6 +29,9 @@
 		],
 		"test-php": [
 			"@composer phpunit"
+		],
+		"test-php-coverage": [
+			"php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
 		]
 	},
 	"repositories": [

--- a/projects/plugins/premium-analytics/changelog/fix-record-coverage-for-cookie-consent
+++ b/projects/plugins/premium-analytics/changelog/fix-record-coverage-for-cookie-consent
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update lock file
+
+

--- a/projects/plugins/premium-analytics/composer.lock
+++ b/projects/plugins/premium-analytics/composer.lock
@@ -619,7 +619,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/cookie-consent",
-                "reference": "92110df34cdb10905abd390cbd0d660853428783"
+                "reference": "dd9e44d90e1d39c705a3ef43d800bef179df4b45"
             },
             "require": {
                 "automattic/jetpack-ip": "@dev",
@@ -659,6 +659,9 @@
                 ],
                 "test-php": [
                     "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
                 ]
             },
             "license": [


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
The package had a `test-php` script but no `test-php-coverage`. Add one so coverage is reported.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
None

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* CI happy?
* Coverage being reported now?
