### PR TITLE
Activity Log: ignore the wp-build .content-entry.js route artifact

### DIFF
--- a/projects/packages/activity-log/.gitignore
+++ b/projects/packages/activity-log/.gitignore
@@ -5,3 +5,4 @@ jetpack_vendor
 .cache
 build
 build-module
+/routes/**/.content-entry.js

--- a/projects/packages/activity-log/changelog/activity-log-gitignore
+++ b/projects/packages/activity-log/changelog/activity-log-gitignore
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Ignore the wp-build .content-entry.js route artifact.

--- a/projects/packages/activity-log/changelog/activity-log-gitignore
+++ b/projects/packages/activity-log/changelog/activity-log-gitignore
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
+Comment: Ignore the wp-build .content-entry.js route artifact.
 
-Ignore the wp-build .content-entry.js route artifact.


### PR DESCRIPTION
## Proposed changes

The `activity-log` package uses `wp-build`, which generates a `.content-entry.js` file inside each route directory (e.g. `routes/dashboard/.content-entry.js`) as an intermediate esbuild entry point whenever the package is built locally. That file is a build artifact and should not be tracked in git, but the package's `.gitignore` was missing the ignore rule, so it showed up as untracked after any local build. The `routes/` directory is relatively new here (added in the wp-build migration, PR 50714), which is why the rule was never added.

Every other wp-build package already ignores it — e.g. `projects/packages/forms/.gitignore` has `/routes/**/.content-entry.js`. This adds the same rule to `activity-log`.

* Add `/routes/**/.content-entry.js` to `projects/packages/activity-log/.gitignore`.

## Related product discussion/links

* Pre-existing gap surfaced while working on the shared-store treeshaking work; split out as its own single-purpose PR.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Check out this branch.
* Run `jp build packages/activity-log` to regenerate the build artifacts (the build may fail on unrelated workspace dependency-build-order errors — that's fine; you only care that `routes/dashboard/.content-entry.js` is generated).
* Run `git status` and confirm the working tree is clean — the generated `.content-entry.js` is now ignored rather than showing up as untracked.
* Optionally, `git check-ignore projects/packages/activity-log/routes/dashboard/.content-entry.js` should print the path, confirming the rule matches.
