### PR TITLE
Forms: dedupe shared dashboard helpers

### DIFF
--- a/projects/packages/forms/changelog/dedupe-forms-shared-helpers
+++ b/projects/packages/forms/changelog/dedupe-forms-shared-helpers
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Consolidate duplicated empty-responses and copy-to-clipboard helper logic behind shared hooks. No functional change.

--- a/projects/packages/forms/src/dashboard/components/copy-clipboard-button/index.tsx
+++ b/projects/packages/forms/src/dashboard/components/copy-clipboard-button/index.tsx
@@ -2,10 +2,12 @@
  * External dependencies
  */
 import { Button, Tooltip } from '@wordpress/components';
-import { useCopyToClipboard } from '@wordpress/compose';
-import { useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { copySmall, check } from '@wordpress/icons';
+/**
+ * Internal dependencies
+ */
+import useCopyConfirmation from '../../../hooks/use-copy-confirmation';
 import './style.scss';
 
 type CopyClipboardButtonProps = {
@@ -25,25 +27,7 @@ export default function CopyClipboardButton( {
 	copyMessage,
 	copiedMessage,
 }: CopyClipboardButtonProps ): JSX.Element {
-	const [ showCopyConfirmation, setShowCopyConfirmation ] = useState( false );
-	const timeoutIdRef = useRef< number | null >( null );
-	const ref = useCopyToClipboard( text, () => {
-		setShowCopyConfirmation( true );
-		if ( timeoutIdRef.current ) {
-			clearTimeout( timeoutIdRef.current );
-		}
-		timeoutIdRef.current = setTimeout( () => {
-			setShowCopyConfirmation( false );
-		}, 4000 );
-	} );
-
-	useEffect( () => {
-		return () => {
-			if ( timeoutIdRef.current ) {
-				clearTimeout( timeoutIdRef.current );
-			}
-		};
-	}, [] );
+	const { ref, copied: showCopyConfirmation } = useCopyConfirmation( text );
 
 	const copied = copiedMessage || __( 'Copied!', 'jetpack-forms' );
 	const copy = copyMessage || __( 'Copy', 'jetpack-forms' );

--- a/projects/packages/forms/src/dashboard/hooks/use-empty-responses.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-empty-responses.ts
@@ -1,0 +1,174 @@
+/**
+ * External dependencies
+ */
+import jetpackAnalytics from '@automattic/jetpack-analytics';
+import { formatNumber } from '@automattic/number-formatters';
+import apiFetch from '@wordpress/api-fetch';
+import { store as coreStore } from '@wordpress/core-data';
+import { useDispatch } from '@wordpress/data';
+import { useState, useCallback, useEffect } from '@wordpress/element';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { store as noticesStore } from '@wordpress/notices';
+/**
+ * Internal dependencies
+ */
+import { store as dashboardStore } from '../store/index';
+import useInboxData from './use-inbox-data';
+
+type EmptyFlow = 'spam' | 'trash';
+
+/**
+ * Per-flow settings. Keyed on `flow` so the count, delete status filter, Tracks
+ * event, and notice id can't be mixed up (e.g. a spam status on the trash count).
+ * The error message is resolved inside the hook because `__()` must run at render
+ * time, not module-eval time.
+ */
+const FLOW_SETTINGS: Record<
+	EmptyFlow,
+	{
+		countKey: 'totalItemsSpam' | 'totalItemsTrash';
+		status?: 'spam';
+		analyticsEvent: string;
+		noticeId: string;
+	}
+> = {
+	spam: {
+		countKey: 'totalItemsSpam',
+		status: 'spam',
+		analyticsEvent: 'jetpack_forms_empty_spam_click',
+		noticeId: 'empty-spam',
+	},
+	trash: {
+		countKey: 'totalItemsTrash',
+		analyticsEvent: 'jetpack_forms_empty_trash_click',
+		noticeId: 'empty-trash',
+	},
+};
+
+export type UseEmptyResponsesReturn = {
+	isConfirmDialogOpen: boolean;
+	openConfirmDialog: () => void;
+	closeConfirmDialog: () => void;
+	onConfirmEmptying: () => Promise< void >;
+	isEmpty: boolean;
+	isEmptying: boolean;
+	totalItems: number;
+	selectedResponsesCount: number;
+};
+
+/**
+ * Shared implementation behind `useEmptySpam` and `useEmptyTrash`. The two flows
+ * differ only in the inbox count they watch, the delete status filter, the Tracks
+ * event, and the notice copy/id — all derived from `flow`.
+ *
+ * @param props                - Hook props.
+ * @param props.flow           - Which flow to run: `'spam'` or `'trash'`.
+ * @param props.totalItemsProp - Optional count override; falls back to the inbox count.
+ * @return Object with empty-responses state and handlers.
+ */
+export default function useEmptyResponses( {
+	flow,
+	totalItemsProp,
+}: {
+	flow: EmptyFlow;
+	totalItemsProp?: number;
+} ): UseEmptyResponsesReturn {
+	const { countKey, status, analyticsEvent, noticeId } = FLOW_SETTINGS[ flow ];
+	// Keyed lookup rather than a ternary so production minification can't hoist the two
+	// calls into a single `__( cond ? … : … )`, which the makepot check rejects.
+	const errorMessage = {
+		spam: __( 'Could not empty spam.', 'jetpack-forms' ),
+		trash: __( 'Could not empty trash.', 'jetpack-forms' ),
+	}[ flow ];
+
+	const [ isConfirmDialogOpen, setConfirmDialogOpen ] = useState( false );
+	const [ isEmptying, setIsEmptying ] = useState( false );
+	const [ isEmpty, setIsEmpty ] = useState( true );
+	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const { invalidateResolutionForStoreSelector } = useDispatch( coreStore ) as unknown as {
+		invalidateResolutionForStoreSelector: ( selector: string ) => void;
+	};
+	const { invalidateCounts } = useDispatch( dashboardStore );
+
+	// Use props if provided, otherwise use hook
+	const hookData = useInboxData();
+	const totalItems = totalItemsProp ?? hookData[ countKey ] ?? 0;
+	const { selectedResponsesCount } = hookData;
+
+	useEffect( () => {
+		setIsEmpty( ! totalItems );
+	}, [ totalItems ] );
+
+	const openConfirmDialog = useCallback( () => setConfirmDialogOpen( true ), [] );
+	const closeConfirmDialog = useCallback( () => setConfirmDialogOpen( false ), [] );
+
+	const onConfirmEmptying = useCallback( async () => {
+		if ( isEmptying || isEmpty ) {
+			return;
+		}
+
+		closeConfirmDialog();
+		setIsEmptying( true );
+
+		jetpackAnalytics.tracks.recordEvent( analyticsEvent );
+
+		apiFetch( {
+			method: 'DELETE',
+			path: status ? `/wp/v2/feedback/trash?status=${ status }` : '/wp/v2/feedback/trash',
+		} )
+			.then( ( response: { deleted?: number } ) => {
+				const deleted = response?.deleted ?? 0;
+				const successMessage =
+					deleted === 1
+						? __( 'Response deleted permanently.', 'jetpack-forms' )
+						: sprintf(
+								/* translators: %s: The number of responses. */
+								_n(
+									'%s response deleted permanently.',
+									'%s responses deleted permanently.',
+									deleted,
+									'jetpack-forms'
+								),
+								formatNumber( deleted )
+						  );
+
+				createSuccessNotice( successMessage, { type: 'snackbar', id: noticeId } );
+			} )
+			.catch( () => {
+				createErrorNotice( errorMessage, {
+					type: 'snackbar',
+					id: `${ noticeId }-error`,
+				} );
+			} )
+			.finally( () => {
+				setIsEmptying( false );
+				// invalidate counts to refresh the counts across all status tabs
+				invalidateCounts();
+				// invalidate all entity record resolutions (feedback items, forms list entries_count, etc.)
+				invalidateResolutionForStoreSelector( 'getEntityRecords' );
+			} );
+	}, [
+		analyticsEvent,
+		closeConfirmDialog,
+		createErrorNotice,
+		createSuccessNotice,
+		errorMessage,
+		invalidateResolutionForStoreSelector,
+		invalidateCounts,
+		isEmpty,
+		isEmptying,
+		noticeId,
+		status,
+	] );
+
+	return {
+		isConfirmDialogOpen,
+		openConfirmDialog,
+		closeConfirmDialog,
+		onConfirmEmptying,
+		isEmpty,
+		isEmptying,
+		totalItems,
+		selectedResponsesCount,
+	};
+}

--- a/projects/packages/forms/src/dashboard/hooks/use-empty-spam.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-empty-spam.ts
@@ -1,29 +1,10 @@
 /**
- * External dependencies
- */
-import jetpackAnalytics from '@automattic/jetpack-analytics';
-import { formatNumber } from '@automattic/number-formatters';
-import apiFetch from '@wordpress/api-fetch';
-import { store as coreStore } from '@wordpress/core-data';
-import { useDispatch } from '@wordpress/data';
-import { useState, useCallback, useEffect } from '@wordpress/element';
-import { __, _n, sprintf } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
-/**
  * Internal dependencies
  */
-import { store as dashboardStore } from '../store/index';
-import useInboxData from './use-inbox-data';
+import useEmptyResponses, { type UseEmptyResponsesReturn } from './use-empty-responses';
 
-type UseEmptySpamReturn = {
-	isConfirmDialogOpen: boolean;
-	openConfirmDialog: () => void;
-	closeConfirmDialog: () => void;
-	onConfirmEmptying: () => Promise< void >;
-	isEmpty: boolean;
-	isEmptying: boolean;
+type UseEmptySpamReturn = Omit< UseEmptyResponsesReturn, 'totalItems' > & {
 	totalItemsSpam: number;
-	selectedResponsesCount: number;
 };
 
 /**
@@ -38,90 +19,10 @@ export default function useEmptySpam( {
 }: {
 	totalItemsSpam?: number;
 } = {} ): UseEmptySpamReturn {
-	const [ isConfirmDialogOpen, setConfirmDialogOpen ] = useState( false );
-	const [ isEmptying, setIsEmptying ] = useState( false );
-	const [ isEmpty, setIsEmpty ] = useState( true );
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const { invalidateResolutionForStoreSelector } = useDispatch( coreStore ) as unknown as {
-		invalidateResolutionForStoreSelector: ( selector: string ) => void;
-	};
-	const { invalidateCounts } = useDispatch( dashboardStore );
+	const { totalItems, ...rest } = useEmptyResponses( {
+		flow: 'spam',
+		totalItemsProp: totalItemsSpamProp,
+	} );
 
-	// Use props if provided, otherwise use hook
-	const hookData = useInboxData();
-	const totalItemsSpam = totalItemsSpamProp ?? hookData.totalItemsSpam ?? 0;
-	const { selectedResponsesCount } = hookData;
-
-	useEffect( () => {
-		setIsEmpty( ! totalItemsSpam );
-	}, [ totalItemsSpam ] );
-
-	const openConfirmDialog = useCallback( () => setConfirmDialogOpen( true ), [] );
-	const closeConfirmDialog = useCallback( () => setConfirmDialogOpen( false ), [] );
-
-	const onConfirmEmptying = useCallback( async () => {
-		if ( isEmptying || isEmpty ) {
-			return;
-		}
-
-		closeConfirmDialog();
-		setIsEmptying( true );
-
-		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_empty_spam_click' );
-
-		apiFetch( {
-			method: 'DELETE',
-			path: `/wp/v2/feedback/trash?status=spam`,
-		} )
-			.then( ( response: { deleted?: number } ) => {
-				const deleted = response?.deleted ?? 0;
-				const successMessage =
-					deleted === 1
-						? __( 'Response deleted permanently.', 'jetpack-forms' )
-						: sprintf(
-								/* translators: %s: The number of responses. */
-								_n(
-									'%s response deleted permanently.',
-									'%s responses deleted permanently.',
-									deleted,
-									'jetpack-forms'
-								),
-								formatNumber( deleted )
-						  );
-
-				createSuccessNotice( successMessage, { type: 'snackbar', id: 'empty-spam' } );
-			} )
-			.catch( () => {
-				createErrorNotice( __( 'Could not empty spam.', 'jetpack-forms' ), {
-					type: 'snackbar',
-					id: 'empty-spam-error',
-				} );
-			} )
-			.finally( () => {
-				setIsEmptying( false );
-				// invalidate counts to refresh the counts across all status tabs
-				invalidateCounts();
-				// invalidate all entity record resolutions (feedback items, forms list entries_count, etc.)
-				invalidateResolutionForStoreSelector( 'getEntityRecords' );
-			} );
-	}, [
-		closeConfirmDialog,
-		createErrorNotice,
-		createSuccessNotice,
-		invalidateResolutionForStoreSelector,
-		invalidateCounts,
-		isEmpty,
-		isEmptying,
-	] );
-
-	return {
-		isConfirmDialogOpen,
-		openConfirmDialog,
-		closeConfirmDialog,
-		onConfirmEmptying,
-		isEmpty,
-		isEmptying,
-		totalItemsSpam,
-		selectedResponsesCount,
-	};
+	return { ...rest, totalItemsSpam: totalItems };
 }

--- a/projects/packages/forms/src/dashboard/hooks/use-empty-trash.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-empty-trash.ts
@@ -1,29 +1,10 @@
 /**
- * External dependencies
- */
-import jetpackAnalytics from '@automattic/jetpack-analytics';
-import { formatNumber } from '@automattic/number-formatters';
-import apiFetch from '@wordpress/api-fetch';
-import { store as coreStore } from '@wordpress/core-data';
-import { useDispatch } from '@wordpress/data';
-import { useState, useCallback, useEffect } from '@wordpress/element';
-import { __, _n, sprintf } from '@wordpress/i18n';
-import { store as noticesStore } from '@wordpress/notices';
-/**
  * Internal dependencies
  */
-import { store as dashboardStore } from '../store/index';
-import useInboxData from './use-inbox-data';
+import useEmptyResponses, { type UseEmptyResponsesReturn } from './use-empty-responses';
 
-type UseEmptyTrashReturn = {
-	isConfirmDialogOpen: boolean;
-	openConfirmDialog: () => void;
-	closeConfirmDialog: () => void;
-	onConfirmEmptying: () => Promise< void >;
-	isEmpty: boolean;
-	isEmptying: boolean;
+type UseEmptyTrashReturn = Omit< UseEmptyResponsesReturn, 'totalItems' > & {
 	totalItemsTrash: number;
-	selectedResponsesCount: number;
 };
 
 /**
@@ -38,90 +19,10 @@ export default function useEmptyTrash( {
 }: {
 	totalItemsTrash?: number;
 } = {} ): UseEmptyTrashReturn {
-	const [ isConfirmDialogOpen, setConfirmDialogOpen ] = useState( false );
-	const [ isEmptying, setIsEmptying ] = useState( false );
-	const [ isEmpty, setIsEmpty ] = useState( true );
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
-	const { invalidateResolutionForStoreSelector } = useDispatch( coreStore ) as unknown as {
-		invalidateResolutionForStoreSelector: ( selector: string ) => void;
-	};
-	const { invalidateCounts } = useDispatch( dashboardStore );
+	const { totalItems, ...rest } = useEmptyResponses( {
+		flow: 'trash',
+		totalItemsProp: totalItemsTrashProp,
+	} );
 
-	// Use props if provided, otherwise use hook
-	const hookData = useInboxData();
-	const totalItemsTrash = totalItemsTrashProp ?? hookData.totalItemsTrash ?? 0;
-	const { selectedResponsesCount } = hookData;
-
-	useEffect( () => {
-		setIsEmpty( ! totalItemsTrash );
-	}, [ totalItemsTrash ] );
-
-	const openConfirmDialog = useCallback( () => setConfirmDialogOpen( true ), [] );
-	const closeConfirmDialog = useCallback( () => setConfirmDialogOpen( false ), [] );
-
-	const onConfirmEmptying = useCallback( async () => {
-		if ( isEmptying || isEmpty ) {
-			return;
-		}
-
-		closeConfirmDialog();
-		setIsEmptying( true );
-
-		jetpackAnalytics.tracks.recordEvent( 'jetpack_forms_empty_trash_click' );
-
-		apiFetch( {
-			method: 'DELETE',
-			path: `/wp/v2/feedback/trash`,
-		} )
-			.then( ( response: { deleted?: number } ) => {
-				const deleted = response?.deleted ?? 0;
-				const successMessage =
-					deleted === 1
-						? __( 'Response deleted permanently.', 'jetpack-forms' )
-						: sprintf(
-								/* translators: %s: the number of responses deleted permanently. */
-								_n(
-									'%s response deleted permanently.',
-									'%s responses deleted permanently.',
-									deleted,
-									'jetpack-forms'
-								),
-								formatNumber( deleted )
-						  );
-
-				createSuccessNotice( successMessage, { type: 'snackbar', id: 'empty-trash' } );
-			} )
-			.catch( () => {
-				createErrorNotice( __( 'Could not empty trash.', 'jetpack-forms' ), {
-					type: 'snackbar',
-					id: 'empty-trash-error',
-				} );
-			} )
-			.finally( () => {
-				setIsEmptying( false );
-				// invalidate counts to refresh the counts across all status tabs
-				invalidateCounts();
-				// invalidate all entity record resolutions (feedback items, forms list entries_count, etc.)
-				invalidateResolutionForStoreSelector( 'getEntityRecords' );
-			} );
-	}, [
-		closeConfirmDialog,
-		createErrorNotice,
-		createSuccessNotice,
-		invalidateResolutionForStoreSelector,
-		invalidateCounts,
-		isEmpty,
-		isEmptying,
-	] );
-
-	return {
-		isConfirmDialogOpen,
-		openConfirmDialog,
-		closeConfirmDialog,
-		onConfirmEmptying,
-		isEmpty,
-		isEmptying,
-		totalItemsTrash,
-		selectedResponsesCount,
-	};
+	return { ...rest, totalItemsTrash: totalItems };
 }

--- a/projects/packages/forms/src/form-editor/plugins/copy-code-row.tsx
+++ b/projects/packages/forms/src/form-editor/plugins/copy-code-row.tsx
@@ -3,10 +3,13 @@
  */
 import './copy-code-row.scss';
 import { Button, Popover } from '@wordpress/components';
-import { useCopyToClipboard } from '@wordpress/compose';
-import { useState, useEffect, useRef, useCallback } from '@wordpress/element';
+import { useRef, useCallback } from '@wordpress/element';
 import { __, isRTL, sprintf } from '@wordpress/i18n';
 import { copySmall, check } from '@wordpress/icons';
+/**
+ * Internal dependencies
+ */
+import useCopyConfirmation from '../../hooks/use-copy-confirmation';
 
 type CopyCodeRowProps = {
 	text: string;
@@ -20,9 +23,8 @@ type CopyCodeRowProps = {
  * @return {JSX.Element} The copy code row component.
  */
 export const CopyCodeRow = ( { text, label }: CopyCodeRowProps ) => {
-	const [ showCopyConfirmation, setShowCopyConfirmation ] = useState( false );
-	const timeoutIdRef = useRef< number | null >( null );
 	const textRef = useRef< HTMLSpanElement >( null );
+	const { ref, copied: showCopyConfirmation } = useCopyConfirmation( text, 2000 );
 
 	const handleTextClick = useCallback( () => {
 		if ( ! textRef.current ) {
@@ -47,26 +49,6 @@ export const CopyCodeRow = ( { text, label }: CopyCodeRowProps ) => {
 		},
 		[ handleTextClick ]
 	);
-
-	const ref = useCopyToClipboard( text, () => {
-		setShowCopyConfirmation( true );
-		if ( timeoutIdRef.current ) {
-			clearTimeout( timeoutIdRef.current );
-		}
-		timeoutIdRef.current = setTimeout( () => {
-			setShowCopyConfirmation( false );
-		}, 2000 );
-	} );
-
-	useEffect( () => {
-		return () => {
-			if ( timeoutIdRef.current ) {
-				clearTimeout( timeoutIdRef.current );
-			}
-		};
-	}, [] );
-	/* translators: %s: label for the code row (e.g. "Embed code", "Shortcode") */
-	const buttonLabel = __( 'Copy %s', 'jetpack-forms' );
 
 	return (
 		<div className="jetpack-form-embed-code__row">
@@ -104,7 +86,11 @@ export const CopyCodeRow = ( { text, label }: CopyCodeRowProps ) => {
 						ref={ ref }
 						icon={ copySmall }
 						size="compact"
-						label={ sprintf( buttonLabel, label.toLowerCase() ) }
+						label={ sprintf(
+							/* translators: %s: label for the code row (e.g. "Embed code", "Shortcode") */
+							__( 'Copy %s', 'jetpack-forms' ),
+							label.toLowerCase()
+						) }
 					/>
 				) }
 			</div>

--- a/projects/packages/forms/src/hooks/use-copy-confirmation.ts
+++ b/projects/packages/forms/src/hooks/use-copy-confirmation.ts
@@ -1,0 +1,40 @@
+/**
+ * WordPress dependencies
+ */
+import { useCopyToClipboard } from '@wordpress/compose';
+import { useEffect, useRef, useState } from '@wordpress/element';
+
+/**
+ * Copy `text` to the clipboard and surface a short-lived "copied" confirmation.
+ *
+ * Wraps `useCopyToClipboard` with the confirmation-flag + auto-reset timeout that
+ * both the dashboard copy button and the form-editor copy row need.
+ *
+ * @param text    - The text to copy.
+ * @param resetMs - How long the confirmation stays true, in ms. Defaults to 4000.
+ * @return `ref` to attach to the trigger element, and the `copied` flag.
+ */
+export default function useCopyConfirmation( text: string, resetMs = 4000 ) {
+	const [ copied, setCopied ] = useState( false );
+	const timeoutIdRef = useRef< number | null >( null );
+
+	const ref = useCopyToClipboard( text, () => {
+		setCopied( true );
+		if ( timeoutIdRef.current !== null ) {
+			clearTimeout( timeoutIdRef.current );
+		}
+		timeoutIdRef.current = setTimeout( () => {
+			setCopied( false );
+		}, resetMs );
+	} );
+
+	useEffect( () => {
+		return () => {
+			if ( timeoutIdRef.current !== null ) {
+				clearTimeout( timeoutIdRef.current );
+			}
+		};
+	}, [] );
+
+	return { ref, copied };
+}

--- a/projects/packages/forms/tests/js/dashboard/hooks/use-empty-spam.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/hooks/use-empty-spam.test.jsx
@@ -165,6 +165,46 @@ describe( 'useEmptySpam', () => {
 		} );
 	} );
 
+	it( 'uses the singular success message when a single response is deleted', async () => {
+		const apiFetchModule = await import( '@wordpress/api-fetch' );
+		apiFetchModule.default.mockImplementationOnce( () => Promise.resolve( { deleted: 1 } ) );
+		const { useDispatch } = await import( '@wordpress/data' );
+
+		const { result } = renderHook( () => useEmptySpam() );
+
+		await act( async () => {
+			await result.current.onConfirmEmptying();
+		} );
+
+		const mockDispatch = useDispatch( 'notices' );
+		await waitFor( () => {
+			expect( mockDispatch.createSuccessNotice ).toHaveBeenCalledWith(
+				'Response deleted permanently.',
+				{ type: 'snackbar', id: 'empty-spam' }
+			);
+		} );
+	} );
+
+	it( 'shows an error notice when the API call fails', async () => {
+		const apiFetchModule = await import( '@wordpress/api-fetch' );
+		apiFetchModule.default.mockImplementationOnce( () => Promise.reject( new Error( 'boom' ) ) );
+		const { useDispatch } = await import( '@wordpress/data' );
+
+		const { result } = renderHook( () => useEmptySpam() );
+
+		await act( async () => {
+			await result.current.onConfirmEmptying();
+		} );
+
+		const mockDispatch = useDispatch( 'notices' );
+		await waitFor( () => {
+			expect( mockDispatch.createErrorNotice ).toHaveBeenCalledWith( 'Could not empty spam.', {
+				type: 'snackbar',
+				id: 'empty-spam-error',
+			} );
+		} );
+	} );
+
 	it( 'does not call API when isEmpty is true', async () => {
 		const useInboxDataModule = await import( '../../../../src/dashboard/hooks/use-inbox-data' );
 		useInboxDataModule.default.mockReturnValueOnce( {

--- a/projects/packages/forms/tests/js/dashboard/hooks/use-empty-trash.test.jsx
+++ b/projects/packages/forms/tests/js/dashboard/hooks/use-empty-trash.test.jsx
@@ -165,6 +165,46 @@ describe( 'useEmptyTrash', () => {
 		} );
 	} );
 
+	it( 'uses the singular success message when a single response is deleted', async () => {
+		const apiFetchModule = await import( '@wordpress/api-fetch' );
+		apiFetchModule.default.mockImplementationOnce( () => Promise.resolve( { deleted: 1 } ) );
+		const { useDispatch } = await import( '@wordpress/data' );
+
+		const { result } = renderHook( () => useEmptyTrash() );
+
+		await act( async () => {
+			await result.current.onConfirmEmptying();
+		} );
+
+		const mockDispatch = useDispatch( 'notices' );
+		await waitFor( () => {
+			expect( mockDispatch.createSuccessNotice ).toHaveBeenCalledWith(
+				'Response deleted permanently.',
+				{ type: 'snackbar', id: 'empty-trash' }
+			);
+		} );
+	} );
+
+	it( 'shows an error notice when the API call fails', async () => {
+		const apiFetchModule = await import( '@wordpress/api-fetch' );
+		apiFetchModule.default.mockImplementationOnce( () => Promise.reject( new Error( 'boom' ) ) );
+		const { useDispatch } = await import( '@wordpress/data' );
+
+		const { result } = renderHook( () => useEmptyTrash() );
+
+		await act( async () => {
+			await result.current.onConfirmEmptying();
+		} );
+
+		const mockDispatch = useDispatch( 'notices' );
+		await waitFor( () => {
+			expect( mockDispatch.createErrorNotice ).toHaveBeenCalledWith( 'Could not empty trash.', {
+				type: 'snackbar',
+				id: 'empty-trash-error',
+			} );
+		} );
+	} );
+
 	it( 'does not call API when isEmpty is true', async () => {
 		const useInboxDataModule = await import( '../../../../src/dashboard/hooks/use-inbox-data' );
 		useInboxDataModule.default.mockReturnValueOnce( {

--- a/projects/packages/forms/tests/js/hooks/use-copy-confirmation.test.jsx
+++ b/projects/packages/forms/tests/js/hooks/use-copy-confirmation.test.jsx
@@ -1,0 +1,91 @@
+/**
+ * External dependencies
+ */
+import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { act, renderHook } from '@testing-library/react';
+
+// Capture the onCopy callback passed to useCopyToClipboard so the test can fire it,
+// simulating a successful clipboard copy.
+let capturedOnCopy;
+await jest.unstable_mockModule( '@wordpress/compose', () => ( {
+	useCopyToClipboard: jest.fn( ( _text, onCopy ) => {
+		capturedOnCopy = onCopy;
+		return jest.fn(); // the ref callback; irrelevant to this hook's logic
+	} ),
+} ) );
+
+const { default: useCopyConfirmation } = await import( '../../../src/hooks/use-copy-confirmation' );
+
+describe( 'useCopyConfirmation', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+		capturedOnCopy = undefined;
+	} );
+
+	afterEach( () => {
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
+	} );
+
+	it( 'starts not copied and exposes a ref', () => {
+		const { result } = renderHook( () => useCopyConfirmation( 'hello' ) );
+
+		expect( result.current.copied ).toBe( false );
+		expect( result.current.ref ).toBeDefined();
+	} );
+
+	it( 'flips copied to true on copy and resets after the given delay', () => {
+		const { result } = renderHook( () => useCopyConfirmation( 'hello', 2000 ) );
+
+		act( () => capturedOnCopy() );
+		expect( result.current.copied ).toBe( true );
+
+		act( () => jest.advanceTimersByTime( 2000 ) );
+		expect( result.current.copied ).toBe( false );
+	} );
+
+	it( 'defaults the reset delay to 4000ms', () => {
+		const { result } = renderHook( () => useCopyConfirmation( 'hello' ) );
+
+		act( () => capturedOnCopy() );
+
+		act( () => jest.advanceTimersByTime( 3999 ) );
+		expect( result.current.copied ).toBe( true );
+
+		act( () => jest.advanceTimersByTime( 1 ) );
+		expect( result.current.copied ).toBe( false );
+	} );
+
+	it( 'restarts the reset timer when copied again before it elapses', () => {
+		const { result } = renderHook( () => useCopyConfirmation( 'hello', 2000 ) );
+
+		act( () => capturedOnCopy() );
+		act( () => jest.advanceTimersByTime( 1000 ) );
+
+		// Copy again half-way through: the pending reset should be cleared and restarted.
+		act( () => capturedOnCopy() );
+		act( () => jest.advanceTimersByTime( 1000 ) );
+		expect( result.current.copied ).toBe( true );
+
+		act( () => jest.advanceTimersByTime( 1000 ) );
+		expect( result.current.copied ).toBe( false );
+	} );
+
+	it( 'clears the pending timeout — with its own timer id — on unmount', () => {
+		const setSpy = jest.spyOn( globalThis, 'setTimeout' );
+		const clearSpy = jest.spyOn( globalThis, 'clearTimeout' );
+		const { unmount } = renderHook( () => useCopyConfirmation( 'hello', 2000 ) );
+
+		act( () => capturedOnCopy() );
+
+		// The hook's reset timer is the one scheduled with the resetMs delay.
+		const scheduled = setSpy.mock.calls.findIndex( ( [ , delay ] ) => delay === 2000 );
+		const timerId = setSpy.mock.results[ scheduled ].value;
+
+		unmount();
+
+		expect( clearSpy ).toHaveBeenCalledWith( timerId );
+		setSpy.mockRestore();
+		clearSpy.mockRestore();
+	} );
+} );


### PR DESCRIPTION
Part of https://github.com/Automattic/jetpack/issues/50712 — step 6a of the Forms dashboard cleanup.

## Proposed changes

Collapses two sets of near-duplicate helpers behind shared implementations. **No functional change** — same analytics events, API paths, notice copy/ids, and return shapes.

**Empty spam / empty trash hooks.** `use-empty-spam` and `use-empty-trash` were ~identical 127-line hooks, differing only in the watched count, the delete status filter, the Tracks event, and the notice copy/id. Extracted `use-empty-responses` with those five values as config; the two hooks are now thin wrappers that **preserve their existing return shapes** (`totalItemsSpam` / `totalItemsTrash`), so no consumer changes.

**Copy-to-clipboard confirmation.** `copy-clipboard-button` (dashboard) and `copy-code-row` (form-editor) both hand-rolled the same `useCopyToClipboard` + confirmation-flag + auto-reset-timeout state machine. Extracted `use-copy-confirmation`; each component keeps its own UI (Tooltip button vs. code row + Popover), just drops the duplicated logic.

## Related product discussion/links

* https://github.com/Automattic/jetpack/issues/50712

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Pure refactor; the goal is that both flows behave exactly as before.

1. **Empty spam / trash:** in Jetpack → Forms, add some responses, move to spam and to trash. Confirm "Empty spam" and "Empty trash" each open the confirm dialog, delete on confirm, show the correct snackbar (singular/plural count), and refresh the tab counts.
2. **Copy buttons:** in a response's details, use the copy-to-clipboard button — confirm it copies and shows the "Copied!" tooltip that resets after a few seconds. In the block editor, open the embed-form modal and use the "Copy embed code" / "Copy shortcode" rows — confirm they copy and show the "Copied!" confirmation.

Verified locally: typecheck, full jest suite (678 tests), build, and eslint all pass.
