### PR TITLE
Write editor: thread `source` through the anon funnel Tracks events

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/read-641-anon-source-tracks
+++ b/projects/packages/jetpack-mu-wpcom/changelog/read-641-anon-source-tracks
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Write editor: thread the source query param through the anon funnel Tracks events and the signup handoff for cross-funnel attribution.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -54,6 +54,24 @@ const ANON_EDITOR_OPENED_AT = typeof Date !== 'undefined' ? Date.now() : 0;
 let anonWriteStartTracked = false;
 
 /**
+ * Read the funnel `source` from the current URL, sanitized to [a-z0-9_-]
+ * (lowercased first, mirroring PHP sanitize_key). '' when absent. Kept identical
+ * to the anon open-event reader on the server so the whole anon funnel reports
+ * one consistent source across signup.
+ *
+ * @return {string} Sanitized source, or '' when not present.
+ */
+function getAnonSource() {
+	try {
+		return ( new URLSearchParams( window.location.search ).get( 'source' ) || '' )
+			.toLowerCase()
+			.replace( /[^a-z0-9_-]/g, '' );
+	} catch {
+		return '';
+	}
+}
+
+/**
  * Fire a client-side Tracks event via the `_tkq` queue. Anon callers share the
  * `tk_ai` cookie, so these stitch to the eventual user at signup completion.
  *
@@ -121,7 +139,11 @@ function maybeTrackAnonWriteStart( text ) {
 		return;
 	}
 	anonWriteStartTracked = true;
-	recordTracksEvent( 'wpcom_write_editor_anon_write_start' );
+	const anonSource = getAnonSource();
+	recordTracksEvent(
+		'wpcom_write_editor_anon_write_start',
+		anonSource ? { source: anonSource } : {}
+	);
 }
 
 /**
@@ -5981,16 +6003,24 @@ const { state } = store( 'wpcom-write', {
 				// GET the browser cancels on unload — so a synchronous navigate
 				// would drop this event. The wait is bounded (and skipped entirely
 				// when Tracks isn't loaded) so the handoff is never stalled.
+				const anonSource = getAnonSource();
 				await recordTracksEventBeforeUnload( 'wpcom_write_editor_anon_publish_click', {
 					word_count: words,
 					time_to_publish_ms: Date.now() - ANON_EDITOR_OPENED_AT,
 					draft_size_bytes:
 						typeof Blob !== 'undefined' ? new Blob( [ draftContent ] ).size : draftContent.length,
+					...( anonSource ? { source: anonSource } : {} ),
 				} );
 
 				// Anon visitors hand off to the signup flow, which reads the draft
-				// from localStorage and publishes after signup completes.
-				window.location.assign( 'https://wordpress.com/setup/write-on' );
+				// from localStorage and publishes after signup completes. Forward
+				// `source` so the funnel stays attributable across the signup hop
+				// (the flow itself must read it for this to reach its Tracks events).
+				window.location.assign(
+					anonSource
+						? `https://wordpress.com/setup/write-on?source=${ encodeURIComponent( anonSource ) }`
+						: 'https://wordpress.com/setup/write-on'
+				);
 				return;
 			}
 			await savePost( 'publish' );


### PR DESCRIPTION
## Proposed changes
* Adds a `source` query-param property to the **logged-out (anon) Write editor** funnel Tracks events so `post.new` (and future anon entry points) are attributable end-to-end.
* New `getAnonSource()` reader parses `?source=` from `window.location.search`, sanitized to `[a-z0-9_-]` and lowercased to mirror PHP `sanitize_key`. It's read **client-side at runtime** (never server-rendered), so the anon response stays byte-identical per visitor and edge-cacheable.
* Attaches `source` to `wpcom_write_editor_anon_write_start` and `wpcom_write_editor_anon_publish_click`. The property is **omitted when empty** so events carry no `source: ""` noise.
* The **logged-in** path (`wpcom_write_editor_open`) is left untouched — this is anon-funnel only.

Values are free-form (`post_new` is the value we send) — there is intentionally **no allowlist**.

This is the funnel-events half of the change. The companion change threading `source` into the anon `open` event and the signup handoff is in 230168-ghe-Automattic/wpcom. Once this lands it ships downstream via the normal `mu-wpcom-plugin` sync — the vendored `view.js` copies are regenerated on sync, so no hand-edit is needed there.

## Related product discussion/links
* READ-641
* 230168-ghe-Automattic/wpcom

## Does this pull request change what data or activity we track or use?
Yes. It adds an optional `source` string property (sanitized `[a-z0-9_-]`) to two existing anon Tracks events: `wpcom_write_editor_anon_write_start` and `wpcom_write_editor_anon_publish_click`. No new events, no PII — `source` is a free-form campaign/entry-point label (e.g. `post_new`). Adding the **[Status] Needs Privacy Updates** label for review.

## Testing instructions
The anon Write editor only renders for logged-out visitors (`window.wpcomWriteIsAnon`), and reaches the downstream host via the `mu-wpcom-plugin` sync — so end-to-end funnel testing happens there after sync, not standalone in this repo. What's verified here:

* `pnpm --filter jetpack-mu-wpcom test` and ESLint on `view.js` pass.
* `getAnonSource()` sanitization is verified in isolation: `?source=post_new` → `post_new`; `Post_New` → `post_new`; `post.new%20x!` → `postnewx`; `my-ref_1` → `my-ref_1`; missing/empty `?source=` → `''` (property omitted).

To verify downstream after sync:
* Open the anon Write editor with `?source=post_new` in the URL.
* Type content → confirm `wpcom_write_editor_anon_write_start` fires with `source: "post_new"` (check the Network tab for the `pixel.wp.com` request; Tracks is JS-injected at runtime).
* Click Publish → confirm `wpcom_write_editor_anon_publish_click` carries `source: "post_new"` before the signup handoff.
* Open the editor with no `?source=` → confirm neither event carries a `source` property.

🤖 Generated with [Claude Code](https://claude.com/claude-code)