### PR TITLE
VideoPress library: show an orientation indicator icon on each video

### DIFF
--- a/projects/packages/videopress/changelog/jetpack-2003-library-orientation-icon
+++ b/projects/packages/videopress/changelog/jetpack-2003-library-orientation-icon
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Library: show an orientation indicator icon on each video in the dashboard library.

--- a/projects/packages/videopress/routes/library/stage.tsx
+++ b/projects/packages/videopress/routes/library/stage.tsx
@@ -36,13 +36,14 @@ const PRIVACY_LABELS: Record< LibraryItemPrivacy, string > = {
 // Grid tiles already lead with the thumbnail + title; the filename
 // below repeats information the title implies and clutters the tile.
 // Keep it hidden by default — users who want it can still toggle it
-// on via the DataViews field-visibility control.
-const GRID_VISIBLE_FIELDS: string[] = [];
+// on via the DataViews field-visibility control. The orientation
+// indicator is icon-only, so it earns its spot on the tile.
+const GRID_VISIBLE_FIELDS: string[] = [ 'orientation' ];
 // `fileSize` is intentionally omitted: it's only populated for local
 // (non-VideoPress) uploads today, so it's blank for most rows. Users
 // who want the column can still toggle it on via the DataViews column-
 // visibility control.
-const TABLE_VISIBLE_FIELDS = [ 'filename', 'duration', 'uploadDate', 'privacy' ];
+const TABLE_VISIBLE_FIELDS = [ 'filename', 'duration', 'orientation', 'uploadDate', 'privacy' ];
 
 const DEFAULT_VIEW: View = {
 	type: 'grid',
@@ -383,6 +384,7 @@ const StageInner = () => {
 				allowDownloads: false,
 				shortcode: '',
 				isProcessing: false,
+				orientation: null,
 				tracks: [],
 			} ) );
 		// Overlay an in-flight state on items currently being promoted from

--- a/projects/packages/videopress/routes/library/style.scss
+++ b/projects/packages/videopress/routes/library/style.scss
@@ -71,6 +71,18 @@
 		}
 	}
 
+	// Orientation indicator: the core `mobile` icon reads as a portrait
+	// phone; a quarter turn makes it read as a landscape one.
+	&__orientation {
+		display: inline-flex;
+		align-items: center;
+		color: currentColor;
+
+		&--landscape svg {
+			transform: rotate(90deg);
+		}
+	}
+
 	// Overlays — flex/centering live on the wp/ui Stack wrappers in JSX. The SCSS
 	// only owns position, background, and color so the visual treatment stays
 	// thumbnail-shaped (full overlay) while layout uses design-system primitives.

--- a/projects/packages/videopress/src/dashboard/components/library/fields.tsx
+++ b/projects/packages/videopress/src/dashboard/components/library/fields.tsx
@@ -1,5 +1,6 @@
 import { getSettings as getDateSettings } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
+import { Icon, mobile } from '@wordpress/icons';
 import { Badge, Stack, Text } from '@wordpress/ui';
 import { useProcessingProgress } from '../../hooks/use-processing-progress';
 import { formatBytes, formatDuration } from '../../utils/format';
@@ -44,6 +45,39 @@ const TitleText = ( { item }: { item: LibraryItem } ) => {
 	return (
 		<span className="vp-library__title-text" title={ title }>
 			{ title }
+		</span>
+	);
+};
+
+const orientationLabel = ( orientation: NonNullable< LibraryItem[ 'orientation' ] > ): string =>
+	orientation === 'landscape'
+		? __( 'Landscape', 'jetpack-videopress-pkg' )
+		: __( 'Portrait', 'jetpack-videopress-pkg' );
+
+/**
+ * Render the orientation indicator: the core `mobile` icon, upright for
+ * portrait videos and rotated a quarter turn (via CSS) for landscape ones.
+ * Videos with unknown dimensions or a square frame render nothing.
+ *
+ * @param props      - Component props.
+ * @param props.item - The library item rendered by this cell.
+ * @return The orientation indicator, or null.
+ */
+const OrientationCell = ( { item }: { item: LibraryItem } ) => {
+	if ( ! item.orientation ) {
+		return null;
+	}
+
+	const label = orientationLabel( item.orientation );
+
+	return (
+		<span
+			role="img"
+			aria-label={ label }
+			title={ label }
+			className={ `vp-library__orientation vp-library__orientation--${ item.orientation }` }
+		>
+			<Icon icon={ mobile } size={ 16 } />
 		</span>
 	);
 };
@@ -174,6 +208,13 @@ export const libraryFields: Field< LibraryItem >[] = [
 		label: __( 'Duration', 'jetpack-videopress-pkg' ),
 		getValue: ( { item } ) => item.durationSeconds,
 		render: ( { item } ) => formatDuration( item.durationSeconds ),
+		enableSorting: false,
+	},
+	{
+		id: 'orientation',
+		label: __( 'Orientation', 'jetpack-videopress-pkg' ),
+		getValue: ( { item } ) => item.orientation ?? '',
+		render: OrientationCell,
 		enableSorting: false,
 	},
 	{

--- a/projects/packages/videopress/src/dashboard/components/library/fields.tsx
+++ b/projects/packages/videopress/src/dashboard/components/library/fields.tsx
@@ -77,7 +77,7 @@ const OrientationCell = ( { item }: { item: LibraryItem } ) => {
 			title={ label }
 			className={ `vp-library__orientation vp-library__orientation--${ item.orientation }` }
 		>
-			<Icon icon={ mobile } size={ 16 } />
+			<Icon icon={ mobile } size={ 24 } />
 		</span>
 	);
 };

--- a/projects/packages/videopress/src/dashboard/components/library/test/fields.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/library/test/fields.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import { makeLibraryItem } from '../../../test-utils/library-item';
+import { libraryFields } from '../fields';
+import type { LibraryItem } from '../../../types/library';
+import type { Field } from '@wordpress/dataviews';
+
+const getField = ( id: string ): Field< LibraryItem > => {
+	const field = libraryFields.find( candidate => candidate.id === id );
+	if ( ! field ) {
+		throw new Error( `Field ${ id } is not registered` );
+	}
+	return field;
+};
+
+describe( 'orientation field', () => {
+	const renderOrientation = ( item: LibraryItem ) => {
+		const OrientationRender = getField( 'orientation' ).render as React.ComponentType< {
+			item: LibraryItem;
+		} >;
+		return render( <OrientationRender item={ item } /> );
+	};
+
+	it( 'shows a labelled portrait indicator for portrait videos', () => {
+		renderOrientation( makeLibraryItem( { orientation: 'portrait' } ) );
+
+		const indicator = screen.getByRole( 'img', { name: 'Portrait' } );
+		expect( indicator ).toHaveClass( 'vp-library__orientation--portrait' );
+	} );
+
+	it( 'shows a labelled landscape indicator for landscape videos', () => {
+		renderOrientation( makeLibraryItem( { orientation: 'landscape' } ) );
+
+		const indicator = screen.getByRole( 'img', { name: 'Landscape' } );
+		expect( indicator ).toHaveClass( 'vp-library__orientation--landscape' );
+	} );
+
+	it( 'renders nothing when the orientation is unknown', () => {
+		const { container } = renderOrientation( makeLibraryItem( { orientation: null } ) );
+
+		expect( container ).toBeEmptyDOMElement();
+	} );
+
+	it( 'exposes the orientation as the field value', () => {
+		const field = getField( 'orientation' );
+
+		expect( field.getValue?.( { item: makeLibraryItem( { orientation: 'landscape' } ) } ) ).toBe(
+			'landscape'
+		);
+		expect( field.getValue?.( { item: makeLibraryItem( { orientation: null } ) } ) ).toBe( '' );
+	} );
+} );

--- a/projects/packages/videopress/src/dashboard/components/video-details/test/preview-player.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/test/preview-player.test.tsx
@@ -29,6 +29,7 @@ const baseVideo: LibraryItem = {
 	shortcode: '[videopress abc123]',
 	sourceUrl: 'https://example.test/movie.mp4',
 	isProcessing: false,
+	orientation: null,
 	tracks: [],
 };
 

--- a/projects/packages/videopress/src/dashboard/components/video-details/test/thumbnail-card.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/test/thumbnail-card.test.tsx
@@ -80,6 +80,7 @@ const baseVideo: LibraryItem = {
 	shortcode: '[videopress abc123]',
 	sourceUrl: 'https://example.test/movie.mp4',
 	isProcessing: false,
+	orientation: null,
 	tracks: [],
 };
 

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-library.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-library.test.ts
@@ -358,6 +358,26 @@ describe( 'on WordPress.com Simple', () => {
 			expect( local.type ).toBe( 'local' );
 		} );
 
+		it( 'derives the orientation from the source dimensions', () => {
+			const withDimensions = ( width?: number, height?: number ) =>
+				toLibraryItem(
+					{
+						id: 10,
+						title: { rendered: 'Oriented' },
+						mime_type: 'video/mp4',
+						media_details: { width, height },
+					},
+					false
+				);
+
+			expect( withDimensions( 1920, 1080 ).orientation ).toBe( 'landscape' );
+			expect( withDimensions( 1080, 1920 ).orientation ).toBe( 'portrait' );
+			// Square and unknown dimensions carry no orientation.
+			expect( withDimensions( 1080, 1080 ).orientation ).toBeNull();
+			expect( withDimensions( undefined, undefined ).orientation ).toBeNull();
+			expect( withDimensions( 1920, undefined ).orientation ).toBeNull();
+		} );
+
 		it( 'sends the privacy filter as a server param in a single request, totals from headers', async () => {
 			// Server-side filtering: the privacy filter is a query param, the
 			// server does the narrowing, and the hook reads X-WP-Total verbatim.

--- a/projects/packages/videopress/src/dashboard/hooks/test/use-poster-url.test.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/test/use-poster-url.test.ts
@@ -32,6 +32,7 @@ const baseVideo: LibraryItem = {
 	shortcode: '[videopress abc123]',
 	sourceUrl: 'https://example.test/movie.mp4',
 	isProcessing: false,
+	orientation: null,
 	tracks: [],
 };
 

--- a/projects/packages/videopress/src/dashboard/hooks/use-library.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-library.ts
@@ -231,6 +231,13 @@ export function toLibraryItem( raw: ApiMediaItem, simple: boolean ): LibraryItem
 	// on Simple that flag is absent (no media_details.videopress), so the poster check
 	// carries it. Rendered as a processing placeholder instead of a blank/black tile.
 	const isProcessing = isVideoPress && ( ! poster || finished === false );
+	// Orientation is derived from the source dimensions; unknown (missing
+	// dimensions) and square videos carry no orientation.
+	const { width, height } = details ?? {};
+	let orientation: LibraryItem[ 'orientation' ] = null;
+	if ( width && height && width !== height ) {
+		orientation = width > height ? 'landscape' : 'portrait';
+	}
 	return {
 		id: String( raw.id ),
 		guid: vp?.guid ?? '',
@@ -251,6 +258,7 @@ export function toLibraryItem( raw: ApiMediaItem, simple: boolean ): LibraryItem
 		shortcode: buildShortcode( vp?.guid, raw.media_details?.width, raw.media_details?.height ),
 		sourceUrl: raw.source_url,
 		isProcessing,
+		orientation,
 		// The media REST field omits `tracks` today, so this is seed-only:
 		// the caption manager modal fetches the authoritative list itself.
 		tracks: flattenVideoTracks( vp?.tracks ),

--- a/projects/packages/videopress/src/dashboard/test-utils/library-item.ts
+++ b/projects/packages/videopress/src/dashboard/test-utils/library-item.ts
@@ -27,6 +27,7 @@ export function makeLibraryItem( overrides: Partial< LibraryItem > = {} ): Libra
 		allowDownloads: false,
 		shortcode: '',
 		isProcessing: false,
+		orientation: null,
 		tracks: [],
 		...overrides,
 	};

--- a/projects/packages/videopress/src/dashboard/types/library.ts
+++ b/projects/packages/videopress/src/dashboard/types/library.ts
@@ -8,6 +8,8 @@ export type LibraryItemPrivacy = 'public' | 'private' | 'site-default';
 // thumbnail button, action eligibility) handles it without extra plumbing.
 export type UploadStatus = 'idle' | 'uploading' | 'promoting' | 'deleting' | 'failed';
 export type VideoRating = 'G' | 'PG-13' | 'R';
+// null when the orientation is unknown (missing dimensions) or square.
+export type VideoOrientation = 'landscape' | 'portrait' | null;
 
 export interface UploadState {
 	status: UploadStatus;
@@ -34,6 +36,7 @@ export interface LibraryItem {
 	shortcode: string;
 	sourceUrl?: string;
 	isProcessing: boolean;
+	orientation: VideoOrientation;
 	tracks: VideoTextTrack[];
 }
 


### PR DESCRIPTION
## Proposed changes

Adds a dynamic orientation indicator to the VideoPress library DataViews items (JETPACK-2003):

* `LibraryItem` gains an `orientation` property (`'landscape' | 'portrait' | null`), derived in `toLibraryItem()` from `media_details.width`/`height` — the shared mapper used by the library list and the video details view. Square or dimensionless videos carry no orientation.
* A new `orientation` DataViews field renders the WordPress core `mobile` icon: upright (portrait phone) for portrait videos, quarter-turned via CSS for landscape ones — core ships no landscape-phone icon. The indicator is wrapped in a `role="img"` span with an accessible label and tooltip ("Portrait" / "Landscape"), and renders nothing when the orientation is unknown.
* The field is visible by default in both layouts: on grid tiles (icon-only, so it doesn't clutter the card) and as a table column between Duration and Uploaded. Being a regular `libraryFields` entry, it can be toggled via the DataViews field-visibility control and is covered by the persisted-view whitelist automatically.

Note: users with an already-persisted library view keep their saved field list, so they'll see the indicator after toggling the Orientation field on (or resetting the view); fresh users get it by default.

## Related product discussion/links
* JETPACK-2003

## Does this pull request change what data or activity we track or use?

No.

## Screenshots

<img width="2544" height="1408" alt="image" src="https://github.com/user-attachments/assets/681d4888-14e5-4cdf-9175-677ef86328a5" />


## Testing instructions

On a site with the modernized VideoPress dashboard (`rsm_jetpack_ui_modernization_videopress` enabled) and a mix of landscape and portrait videos:

* Go to **Jetpack → VideoPress → Library**.
* In the default grid view, each tile shows a small phone icon under the title: upright for portrait videos, rotated for landscape ones. Hover it to see the "Portrait"/"Landscape" tooltip.
* Switch to the table layout: an **Orientation** column appears between Duration and Uploaded with the same icons.
* A square video (or one still processing, with no dimensions yet) shows no indicator.
* Toggle the Orientation field off via the DataViews view options and confirm it disappears and the preference persists across reloads.
* Verify with a screen reader (or the accessibility tree) that the indicator is announced as "Portrait"/"Landscape".

🤖 Generated with [Claude Code](https://claude.com/claude-code)