### PR TITLE
VideoPress library: allow multiple file selection in the Upload video button

### DIFF
--- a/projects/packages/videopress/changelog/jetpack-1889-videopress-bulk-upload-local-videos-to-videopress
+++ b/projects/packages/videopress/changelog/jetpack-1889-videopress-bulk-upload-local-videos-to-videopress
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Library: allow selecting multiple video files from the Upload video button for bulk uploading

--- a/projects/packages/videopress/routes/library/stage.tsx
+++ b/projects/packages/videopress/routes/library/stage.tsx
@@ -118,16 +118,6 @@ const StageInner = () => {
 		}
 		filePickerRef.current?.click();
 	}, [ isAtLimit ] );
-	const onFilePicked = useCallback(
-		( event: ChangeEvent< HTMLInputElement > ) => {
-			const file = event.target.files?.[ 0 ];
-			if ( file ) {
-				startUpload( file );
-			}
-			event.target.value = '';
-		},
-		[ startUpload ]
-	);
 
 	const navigate = useNavigate();
 
@@ -140,10 +130,10 @@ const StageInner = () => {
 
 	const { createSuccessNotice, createErrorNotice, createInfoNotice } = useGlobalNotices();
 
-	// Drag-and-drop entry point. Mirrors the file-picker's `startUpload`
-	// path but accepts multiple files and enforces the free-tier cap up
-	// front so a drop can't sneak past the limit the picker button guards.
-	const handleFilesDrop = useCallback(
+	// Shared multi-file entry point for both the DropZone and the header
+	// "Upload video" file picker. Enforces the free-tier cap up front so
+	// neither path can sneak past the limit the picker button guards.
+	const handleFilesSelected = useCallback(
 		( files: File[] ) => {
 			const decision = planVideoDrop( files, {
 				isFree,
@@ -188,6 +178,17 @@ const StageInner = () => {
 			}
 		},
 		[ isFree, isUnlimited, limit, videoCount, startUpload, createErrorNotice, runUpgrade ]
+	);
+
+	const onFilePicked = useCallback(
+		( event: ChangeEvent< HTMLInputElement > ) => {
+			const files = Array.from( event.target.files ?? [] );
+			if ( files.length > 0 ) {
+				handleFilesSelected( files );
+			}
+			event.target.value = '';
+		},
+		[ handleFilesSelected ]
 	);
 
 	// The factory owns the in-flight progress map (re-entry guard + overlay
@@ -418,6 +419,10 @@ const StageInner = () => {
 						ref={ filePickerRef }
 						type="file"
 						accept="video/*"
+						// The capped free tier can only ever host `limit` videos, so
+						// multi-select there would only produce skipped-file notices;
+						// paid and grandfathered-unlimited plans get bulk selection.
+						multiple={ ! isFree || isUnlimited }
 						style={ { display: 'none' } }
 						onChange={ onFilePicked }
 					/>
@@ -446,8 +451,8 @@ const StageInner = () => {
 			<UploadActionsProvider value={ { promoteLocal, retryUpload, openVideoDetails } }>
 				<div className={ `vp-library__viewport vp-library__viewport--${ view.type }` }>
 					<DropZone
-						label={ __( 'Drop a video to upload', 'jetpack-videopress-pkg' ) }
-						onFilesDrop={ handleFilesDrop }
+						label={ __( 'Drop videos to upload', 'jetpack-videopress-pkg' ) }
+						onFilesDrop={ handleFilesSelected }
 					/>
 					{ isError && items.length === 0 ? (
 						// A failed listing request would otherwise render as DataViews'


### PR DESCRIPTION
Fixes JETPACK-1889

## Proposed changes

* VideoPress library: the header "Upload video" button's file picker now allows selecting multiple video files for bulk uploading (paid and grandfathered-unlimited plans; the capped free tier keeps single selection since it can only host one video).
* Picked files are now routed through the same `planVideoDrop` path used by drag-and-drop, so the file picker gets the same server allow-list filtering and free-tier cap notices as drops (previously it uploaded the single chosen file with no validation).
* Updated the DropZone label from "Drop a video to upload" to "Drop videos to upload".

## Related product discussion/links

* Linear: https://linear.app/a8c/issue/JETPACK-1889/videopress-bulk-upload-local-videos-to-videopress

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site with a VideoPress plan, go to the VideoPress dashboard library (Jetpack → VideoPress).
* Click the "Upload video" button in the header.
* Verify the file dialog allows selecting multiple video files.
* Select several videos and confirm they all queue and upload, appearing at the top of the library with progress.
* Verify selecting a non-video file (choose "All files" in the dialog) shows the "Only video files can be uploaded." notice instead of silently failing.
* On a free (capped) site, verify the picker still allows only a single file, and that the button remains guarded when at the 1-video limit.
* Drag-and-drop of multiple files should behave exactly as before.
