### PR TITLE
Jetpack AI: make the Try it out links pre-open their surface

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
@@ -59,7 +59,12 @@ const SECTIONS = [
 					'Generate and edit professional-quality images without leaving WordPress.',
 					'jetpack'
 				),
-				enabledAction: { label: __( 'Try it out', 'jetpack' ), href: 'upload.php' },
+				enabledAction: {
+					label: __( 'Try it out', 'jetpack' ),
+					// ai-assistant makes the Image Studio bundle open Generate mode
+					// on the Media Library (it strips the param once handled).
+					href: 'upload.php?ai-assistant',
+				},
 				disabledAction: {
 					label: __( 'Learn more', 'jetpack' ),
 					href: getRedirectUrl( 'jetpack-ai-settings-image-editor-learn-more' ),

--- a/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
@@ -36,7 +36,9 @@ const SECTIONS = [
 				),
 				enabledAction: {
 					label: __( 'Try it out in the editor', 'jetpack' ),
-					href: 'post-new.php',
+					// The arg asks the ai-assistant-plugin sidebar to open itself
+					// once the editor loads (same convention as openSidebar=global-styles).
+					href: 'post-new.php?openSidebar=jetpack-ai-assistant',
 				},
 				disabledAction: {
 					label: __( 'Learn more', 'jetpack' ),

--- a/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
@@ -350,11 +350,11 @@ describe( 'AiFeatures rendering', () => {
 			'post-new.php?openSidebar=jetpack-ai-assistant'
 		);
 
-		// Image Studio has no URL-driven open mechanism (its bundle only adds
-		// click handlers on the Media Library), so the link stays upload.php.
+		// The Image Studio bundle opens Generate mode when the Media Library
+		// URL carries ai-assistant (handled bundle-side, param then stripped).
 		expect( screen.getByRole( 'link', { name: 'Try it out' } ) ).toHaveAttribute(
 			'href',
-			'upload.php'
+			'upload.php?ai-assistant'
 		);
 	} );
 } );

--- a/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
@@ -326,4 +326,35 @@ describe( 'AiFeatures rendering', () => {
 		const tryIt = screen.getByRole( 'link', { name: /Try it out/ } );
 		expect( tryIt ).not.toHaveAttribute( 'target' );
 	} );
+
+	test( 'Try it out links target each feature surface', () => {
+		render(
+			<AiFeatures
+				settings={ {
+					master_enabled: true,
+					is_connected: true,
+					features: {
+						writing_assistant: { enabled: true },
+						image_editor: { enabled: true },
+					},
+				} }
+				savingKeys={ new Set() }
+				onUpdate={ jest.fn() }
+			/>
+		);
+
+		// Writing Assistant asks the editor to pre-open the AI Assistant panel
+		// (handled by the ai-assistant-plugin sidebar on the other end).
+		expect( screen.getByRole( 'link', { name: 'Try it out in the editor' } ) ).toHaveAttribute(
+			'href',
+			'post-new.php?openSidebar=jetpack-ai-assistant'
+		);
+
+		// Image Studio has no URL-driven open mechanism (its bundle only adds
+		// click handlers on the Media Library), so the link stays upload.php.
+		expect( screen.getByRole( 'link', { name: 'Try it out' } ) ).toHaveAttribute(
+			'href',
+			'upload.php'
+		);
+	} );
 } );

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-try-it-out-pre-open
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-try-it-out-pre-open
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+AI settings: the Writing Assistant Try it out link now opens the editor with the AI Assistant sidebar pre-opened

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-try-it-out-pre-open
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-try-it-out-pre-open
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-AI settings: the Writing Assistant Try it out link now opens the editor with the AI Assistant sidebar pre-opened
+AI settings: the Try it out links now pre-open their surface — the editor with the AI Assistant sidebar expanded, the Media Library with Image Studio in generate mode

--- a/projects/plugins/jetpack/changelog/add-jetpack-ai-try-it-out-pre-open
+++ b/projects/plugins/jetpack/changelog/add-jetpack-ai-try-it-out-pre-open
@@ -1,4 +1,4 @@
 Significance: minor
 Type: enhancement
 
-AI settings: the Try it out links now pre-open their surface — the editor with the AI Assistant sidebar expanded, the Media Library with Image Studio in generate mode
+AI settings: Make the Try it out links pre-open their target — the AI Assistant sidebar in the editor, and Image Studio's generate mode in the Media Library.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/index.tsx
@@ -43,6 +43,7 @@ import {
 	PLACEMENT_JETPACK_SIDEBAR,
 	PLACEMENT_PRE_PUBLISH,
 } from './constants';
+import { useSidebarOpenFromUrl } from './open-sidebar-from-url';
 import Upgrade from './upgrade';
 import './style.scss';
 /**
@@ -248,6 +249,9 @@ export default function AiAssistantPluginSidebar() {
 
 	const planType = usePlanType( currentTier );
 
+	// The AI settings "Try it out" link asks for the sidebar to start open.
+	const sidebarOpenRequested = useSidebarOpenFromUrl();
+
 	// If the post type is not viewable, do not render my plugin.
 	if ( ! isViewable ) {
 		return null;
@@ -270,7 +274,7 @@ export default function AiAssistantPluginSidebar() {
 			<JetpackPluginSidebar>
 				<PanelBody
 					title={ title }
-					initialOpen={ false }
+					initialOpen={ sidebarOpenRequested }
 					onToggle={ isOpen => {
 						isOpen && panelToggleTracker( PLACEMENT_JETPACK_SIDEBAR );
 					} }

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/open-sidebar-from-url.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/open-sidebar-from-url.ts
@@ -1,0 +1,59 @@
+/**
+ * External dependencies
+ */
+import { dispatch } from '@wordpress/data';
+import { getQueryArg } from '@wordpress/url';
+import { useEffect, useMemo } from 'react';
+
+// The AI settings "Try it out" link lands on post-new.php with this arg so the
+// editor greets the user with the AI panel already open. The arg name follows
+// the existing openSidebar=global-styles convention; the value names us as the
+// target, since other features share the arg.
+const OPEN_SIDEBAR_QUERY_VALUE = 'jetpack-ai-assistant';
+
+// The AI panel lives in the shared Jetpack sidebar (a JetpackPluginSidebar
+// fill), so that is the sidebar to open: plugin 'jetpack-sidebar', name 'jetpack'.
+const JETPACK_SIDEBAR_IDENTIFIER = 'jetpack-sidebar/jetpack';
+
+/**
+ * Whether the current URL asks for the AI Assistant sidebar to be pre-opened.
+ *
+ * @return {boolean} True when openSidebar=jetpack-ai-assistant is present.
+ */
+export function isSidebarOpenRequested(): boolean {
+	return getQueryArg( window.location.href, 'openSidebar' ) === OPEN_SIDEBAR_QUERY_VALUE;
+}
+
+/**
+ * Open the shared Jetpack sidebar. A no-op outside the post editor, where the
+ * edit-post store is not registered.
+ */
+export function openJetpackSidebar(): void {
+	// Addressed as a string on purpose: importing the edit-post store object
+	// would register it as a side effect in editors that don't have it.
+	const editPostDispatch = dispatch( 'core/edit-post' ) as
+		| { openGeneralSidebar?: ( sidebar: string ) => void }
+		| undefined;
+
+	editPostDispatch?.openGeneralSidebar?.( JETPACK_SIDEBAR_IDENTIFIER );
+}
+
+/**
+ * Open the Jetpack sidebar once on mount when the URL requests it. Running
+ * from the sidebar plugin's own mount means the editor is necessarily up and
+ * the plugin registered — with no request, or outside the editor, nothing happens.
+ *
+ * @return {boolean} Whether the pre-open was requested, so the caller can
+ * start its AI panel expanded.
+ */
+export function useSidebarOpenFromUrl(): boolean {
+	const requested = useMemo( isSidebarOpenRequested, [] );
+
+	useEffect( () => {
+		if ( requested ) {
+			openJetpackSidebar();
+		}
+	}, [ requested ] );
+
+	return requested;
+}

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/open-sidebar-from-url.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/open-sidebar-from-url.ts
@@ -50,9 +50,14 @@ export function useSidebarOpenFromUrl(): boolean {
 	const requested = useMemo( isSidebarOpenRequested, [] );
 
 	useEffect( () => {
-		if ( requested ) {
-			openJetpackSidebar();
+		if ( ! requested ) {
+			return;
 		}
+		// Defer a task: the editor's open-document-sidebar-by-default effect
+		// runs later in this same commit with a render-time closure that saw no
+		// active sidebar, so a synchronous dispatch here would be overwritten.
+		const timer = setTimeout( openJetpackSidebar, 0 );
+		return () => clearTimeout( timer );
 	}, [ requested ] );
 
 	return requested;

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/test/open-sidebar-from-url.test.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/test/open-sidebar-from-url.test.ts
@@ -1,0 +1,95 @@
+import { renderHook } from '@testing-library/react';
+import { dispatch } from '@wordpress/data';
+import {
+	isSidebarOpenRequested,
+	openJetpackSidebar,
+	useSidebarOpenFromUrl,
+} from '../open-sidebar-from-url';
+
+jest.mock( '@wordpress/data', () => ( {
+	dispatch: jest.fn(),
+} ) );
+
+const dispatchMock = dispatch as jest.Mock;
+
+describe( 'open-sidebar-from-url', () => {
+	afterEach( () => {
+		dispatchMock.mockReset();
+		window.history.pushState( {}, '', '/wp-admin/post-new.php' );
+	} );
+
+	describe( 'isSidebarOpenRequested', () => {
+		test( 'true when the URL carries openSidebar=jetpack-ai-assistant', () => {
+			window.history.pushState( {}, '', '/wp-admin/post-new.php?openSidebar=jetpack-ai-assistant' );
+
+			expect( isSidebarOpenRequested() ).toBe( true );
+		} );
+
+		test( 'false without the query arg', () => {
+			window.history.pushState( {}, '', '/wp-admin/post-new.php' );
+
+			expect( isSidebarOpenRequested() ).toBe( false );
+		} );
+
+		test( 'false when openSidebar names a different target', () => {
+			// The arg name is shared with other sidebar-openers (global-styles);
+			// only our own value may trigger the AI sidebar.
+			window.history.pushState( {}, '', '/wp-admin/post-new.php?openSidebar=global-styles' );
+
+			expect( isSidebarOpenRequested() ).toBe( false );
+		} );
+	} );
+
+	describe( 'openJetpackSidebar', () => {
+		test( 'opens the shared Jetpack sidebar through core/edit-post', () => {
+			const openGeneralSidebar = jest.fn();
+			dispatchMock.mockReturnValue( { openGeneralSidebar } );
+
+			openJetpackSidebar();
+
+			expect( dispatchMock ).toHaveBeenCalledWith( 'core/edit-post' );
+			expect( openGeneralSidebar ).toHaveBeenCalledWith( 'jetpack-sidebar/jetpack' );
+		} );
+
+		test( 'is a no-op when the edit-post store is not registered', () => {
+			// Outside the post editor dispatch() has no store to return.
+			dispatchMock.mockReturnValue( undefined );
+
+			expect( () => openJetpackSidebar() ).not.toThrow();
+		} );
+	} );
+
+	describe( 'useSidebarOpenFromUrl', () => {
+		test( 'opens the sidebar on mount and reports the request', () => {
+			window.history.pushState( {}, '', '/wp-admin/post-new.php?openSidebar=jetpack-ai-assistant' );
+			const openGeneralSidebar = jest.fn();
+			dispatchMock.mockReturnValue( { openGeneralSidebar } );
+
+			const { result, rerender } = renderHook( () => useSidebarOpenFromUrl() );
+
+			expect( result.current ).toBe( true );
+			expect( openGeneralSidebar ).toHaveBeenCalledWith( 'jetpack-sidebar/jetpack' );
+
+			// Re-renders must not re-open a sidebar the user may have closed.
+			rerender();
+			expect( openGeneralSidebar ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		test( 'stays quiet without the query arg', () => {
+			const { result } = renderHook( () => useSidebarOpenFromUrl() );
+
+			expect( result.current ).toBe( false );
+			expect( dispatchMock ).not.toHaveBeenCalled();
+		} );
+	} );
+
+	test( 'importing the module does not touch the stores', async () => {
+		// The open must be driven by the sidebar component's mount (which
+		// implies the editor is up), never by module evaluation.
+		await jest.isolateModulesAsync( async () => {
+			await import( '../open-sidebar-from-url' );
+		} );
+
+		expect( dispatchMock ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/test/open-sidebar-from-url.test.ts
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/ai-assistant-plugin-sidebar/test/open-sidebar-from-url.test.ts
@@ -60,7 +60,8 @@ describe( 'open-sidebar-from-url', () => {
 	} );
 
 	describe( 'useSidebarOpenFromUrl', () => {
-		test( 'opens the sidebar on mount and reports the request', () => {
+		test( 'opens the sidebar after mount and reports the request', () => {
+			jest.useFakeTimers();
 			window.history.pushState( {}, '', '/wp-admin/post-new.php?openSidebar=jetpack-ai-assistant' );
 			const openGeneralSidebar = jest.fn();
 			dispatchMock.mockReturnValue( { openGeneralSidebar } );
@@ -68,11 +69,33 @@ describe( 'open-sidebar-from-url', () => {
 			const { result, rerender } = renderHook( () => useSidebarOpenFromUrl() );
 
 			expect( result.current ).toBe( true );
+			// The open is deferred a task: the editor's open-document-sidebar-by-
+			// default effect runs after ours in the same commit and would stomp a
+			// synchronous dispatch (its closure still sees no active sidebar).
+			expect( openGeneralSidebar ).not.toHaveBeenCalled();
+
+			jest.runAllTimers();
 			expect( openGeneralSidebar ).toHaveBeenCalledWith( 'jetpack-sidebar/jetpack' );
 
 			// Re-renders must not re-open a sidebar the user may have closed.
 			rerender();
+			jest.runAllTimers();
 			expect( openGeneralSidebar ).toHaveBeenCalledTimes( 1 );
+			jest.useRealTimers();
+		} );
+
+		test( 'unmounting before the deferred open cancels it', () => {
+			jest.useFakeTimers();
+			window.history.pushState( {}, '', '/wp-admin/post-new.php?openSidebar=jetpack-ai-assistant' );
+			const openGeneralSidebar = jest.fn();
+			dispatchMock.mockReturnValue( { openGeneralSidebar } );
+
+			const { unmount } = renderHook( () => useSidebarOpenFromUrl() );
+			unmount();
+			jest.runAllTimers();
+
+			expect( openGeneralSidebar ).not.toHaveBeenCalled();
+			jest.useRealTimers();
 		} );
 
 		test( 'stays quiet without the query arg', () => {


### PR DESCRIPTION
Fixes FORNO-424

## Proposed changes

* Writing Assistant's "Try it out" now links to `post-new.php?openSidebar=jetpack-ai-assistant`. The AI Assistant plugin picks the arg up on mount and opens the Jetpack sidebar with the "Improve with AI" panel expanded — same approach as the existing `openSidebar=global-styles` handling.
* Image Editor's link now goes to `upload.php?ai-assistant`, which the Image Studio bundle already handles: it opens Generate mode and strips the param.
* If the extension isn't available, the args do nothing — the editor and Media Library load as before.
~~* Feature Clip keeps its plain `post-new.php` link (clips live in the Image Studio flow, not the AI sidebar). All three hrefs are pinned by tests.~~

## Related product discussion/links

[@ilonagl's comment](https://github.com/Automattic/jetpack/pull/50386#issuecomment-5020327047)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

On a connected site with an AI plan and the features toggled on, and as a proxied A11n.

* From Jetpack -> AI -> WordPress Agent, (set the toggle on if off), click "Try it out in the editor" on Writing Assistant -> the editor opens with the Jetpack sidebar open and "Improve with AI" expanded, no console errors
* (set the toggle on if off) Click "Try it out" on Image Editor-> the Media Library opens with Image Studio in Generate mode
* Open `post-new.php` directly -> sidebar should stay closed, as before
* Toggle Writing Assistant off and open `post-new.php?openSidebar=jetpack-ai-assistant` by hand-> normal editor, no errors.

