### PR TITLE
Premium Analytics: replace Clicks chart with table deltas

### DIFF
--- a/projects/packages/premium-analytics/changelog/remove-clicks-report-performance-chart
+++ b/projects/packages/premium-analytics/changelog/remove-clicks-report-performance-chart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Clicks report: Replace the performance chart with comparison deltas in the records table.

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/clicks.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/clicks.test.ts
@@ -1,5 +1,7 @@
 import { mergeStatsClicksComparisonRows, sanitizeStatsClicksResponse } from '..';
 import { clicksFixture, clicksSummaryFixture } from '../__fixtures__/clicks';
+import type { StatsClicksItem } from '../clicks';
+import type { StatsNormalizedReport } from '../types';
 
 describe( 'Stats clicks normalizer', () => {
 	it( 'normalizes summarized clicks into range data', () => {
@@ -360,5 +362,95 @@ describe( 'Stats clicks normalizer', () => {
 				} ),
 			],
 		} );
+	} );
+
+	it( 'matches rows whose URL cannot be parsed by falling back to the raw value', () => {
+		// Not every `url` the endpoint returns is absolute — a root-relative one
+		// makes `new URL()` throw. Both periods have to key off the same raw
+		// string, or such rows would never match and would lose their delta.
+		const buildReport = ( views: number, date: string ) =>
+			sanitizeStatsClicksResponse(
+				{
+					date,
+					summary: {
+						clicks: [ { name: '', views, url: '/downloads/report.pdf', children: null } ],
+					},
+				},
+				{ period: 'day', start_date: date, end_date: date, summarize: true }
+			);
+
+		expect(
+			mergeStatsClicksComparisonRows(
+				buildReport( 42, '2026-06-29' ),
+				buildReport( 28, '2026-06-22' )
+			)
+		).toEqual( {
+			hasComparison: true,
+			rows: [
+				expect.objectContaining( {
+					// An empty name falls back to the link for the display label.
+					label: '/downloads/report.pdf',
+					views: 42,
+					previousValue: 28,
+				} ),
+			],
+		} );
+	} );
+
+	it( 'reports comparison on grandchildren of a nested click group', () => {
+		const buildReport = ( leafViews: number ): StatsNormalizedReport< StatsClicksItem > => ( {
+			summary: {},
+			data: [
+				{
+					time_interval: '2026-06-29',
+					date_start: '2026-06-29T00:00:00+00:00',
+					date_end: '2026-06-29T23:59:59+00:00',
+					items: [
+						{
+							label: 'wordpress.org',
+							views: leafViews,
+							link: null,
+							icon: null,
+							labelIcon: null,
+							children: [
+								{
+									label: '/plugins',
+									views: leafViews,
+									link: 'https://wordpress.org/plugins',
+									icon: null,
+									labelIcon: 'external',
+									children: [
+										{
+											label: '/plugins/jetpack-search',
+											views: leafViews,
+											link: 'https://wordpress.org/plugins/jetpack-search',
+											icon: null,
+											labelIcon: 'external',
+											children: null,
+										},
+									],
+								},
+							],
+						},
+					],
+				},
+			],
+		} );
+
+		const result = mergeStatsClicksComparisonRows( buildReport( 42 ), buildReport( 28 ) );
+
+		expect( result.rows[ 0 ].children?.[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				link: 'https://wordpress.org/plugins',
+				previousValue: 28,
+				childrenHaveComparison: true,
+				children: [
+					expect.objectContaining( {
+						link: 'https://wordpress.org/plugins/jetpack-search',
+						previousValue: 28,
+					} ),
+				],
+			} )
+		);
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/clicks.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/clicks.test.ts
@@ -453,4 +453,185 @@ describe( 'Stats clicks normalizer', () => {
 			} )
 		);
 	} );
+
+	it( 'matches an unlinked child by label inside its comparison group', () => {
+		const buildReport = (
+			groupViews: number,
+			linkedViews: number,
+			unlinkedViews: number
+		): StatsNormalizedReport< StatsClicksItem > => ( {
+			summary: {},
+			data: [
+				{
+					time_interval: '2026-06-29',
+					date_start: '2026-06-29T00:00:00+00:00',
+					date_end: '2026-06-29T23:59:59+00:00',
+					items: [
+						{
+							label: 'wordpress.org',
+							views: groupViews,
+							link: null,
+							icon: null,
+							labelIcon: null,
+							children: [
+								{
+									label: '/plugins/jetpack-search',
+									views: linkedViews,
+									link: 'https://wordpress.org/plugins/jetpack-search',
+									icon: null,
+									labelIcon: 'external',
+									children: null,
+								},
+								{
+									label: 'untracked',
+									views: unlinkedViews,
+									link: null,
+									icon: null,
+									labelIcon: null,
+									children: null,
+								},
+							],
+						},
+					],
+				},
+			],
+		} );
+
+		const result = mergeStatsClicksComparisonRows( buildReport( 9, 6, 3 ), buildReport( 7, 5, 2 ) );
+
+		expect( result.hasComparison ).toBe( true );
+		expect( result.rows[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				label: 'wordpress.org',
+				previousValue: 7,
+				childrenHaveComparison: true,
+			} )
+		);
+		expect( result.rows[ 0 ].children ).toEqual( [
+			expect.objectContaining( {
+				link: 'https://wordpress.org/plugins/jetpack-search',
+				previousValue: 5,
+			} ),
+			expect.objectContaining( { label: 'untracked', link: null, previousValue: 2 } ),
+		] );
+	} );
+
+	it( 'does not pair an unlinked child with a linked comparison row of the same label', () => {
+		const buildReport = (
+			children: StatsClicksItem[]
+		): StatsNormalizedReport< StatsClicksItem > => ( {
+			summary: {},
+			data: [
+				{
+					time_interval: '2026-06-29',
+					date_start: '2026-06-29T00:00:00+00:00',
+					date_end: '2026-06-29T23:59:59+00:00',
+					items: [
+						{
+							label: 'wordpress.org',
+							views: 9,
+							link: null,
+							icon: null,
+							labelIcon: null,
+							children,
+						},
+					],
+				},
+			],
+		} );
+		const linkedChild = ( views: number ): StatsClicksItem => ( {
+			label: '/plugins',
+			views,
+			link: 'https://wordpress.org/plugins',
+			icon: null,
+			labelIcon: 'external',
+			children: null,
+		} );
+
+		const result = mergeStatsClicksComparisonRows(
+			buildReport( [
+				linkedChild( 6 ),
+				{
+					label: '/plugins',
+					views: 3,
+					link: null,
+					icon: null,
+					labelIcon: null,
+					children: null,
+				},
+			] ),
+			buildReport( [ linkedChild( 5 ) ] )
+		);
+
+		// The linked comparison row belongs to the primary row that shares its
+		// URL. Pairing it by label as well would count the same 5 clicks twice.
+		expect( result.rows[ 0 ].children ).toEqual( [
+			expect.objectContaining( { link: 'https://wordpress.org/plugins', previousValue: 5 } ),
+			expect.objectContaining( { link: null, previousValue: undefined } ),
+		] );
+	} );
+
+	it( 'keeps unlinked children of different click groups apart', () => {
+		const buildGroup = (
+			domain: string,
+			groupViews: number,
+			linkedViews: number,
+			unlinkedViews: number
+		): StatsClicksItem => ( {
+			label: domain,
+			views: groupViews,
+			link: null,
+			icon: null,
+			labelIcon: null,
+			children: [
+				{
+					label: '/page',
+					views: linkedViews,
+					link: `https://${ domain }/page`,
+					icon: null,
+					labelIcon: 'external',
+					children: null,
+				},
+				{
+					label: 'untracked',
+					views: unlinkedViews,
+					link: null,
+					icon: null,
+					labelIcon: null,
+					children: null,
+				},
+			],
+		} );
+
+		const buildReport = (
+			items: StatsClicksItem[]
+		): StatsNormalizedReport< StatsClicksItem > => ( {
+			summary: {},
+			data: [
+				{
+					time_interval: '2026-06-29',
+					date_start: '2026-06-29T00:00:00+00:00',
+					date_end: '2026-06-29T23:59:59+00:00',
+					items,
+				},
+			],
+		} );
+
+		const result = mergeStatsClicksComparisonRows(
+			buildReport( [
+				buildGroup( 'a.example.com', 9, 6, 3 ),
+				buildGroup( 'b.example.com', 5, 4, 1 ),
+			] ),
+			buildReport( [ buildGroup( 'a.example.com', 7, 5, 2 ) ] )
+		);
+
+		expect( result.rows[ 0 ].children?.[ 1 ] ).toEqual(
+			expect.objectContaining( { label: 'untracked', previousValue: 2 } )
+		);
+		// The comparison period has no b.example.com group, so its unlinked
+		// child must not borrow the delta of the same label under a.example.com.
+		expect( result.rows[ 1 ].children?.[ 1 ] ).toEqual(
+			expect.objectContaining( { label: 'untracked', previousValue: undefined } )
+		);
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/clicks.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/clicks.test.ts
@@ -213,4 +213,152 @@ describe( 'Stats clicks normalizer', () => {
 			],
 		} );
 	} );
+
+	it( 'matches a flat primary URL to the same URL inside a grouped comparison domain', () => {
+		const primary = sanitizeStatsClicksResponse(
+			{
+				date: '2026-06-29',
+				summary: {
+					clicks: [
+						{
+							name: 'wordpress.org/plugins/jetpack-search',
+							views: 42,
+							url: 'https://wordpress.org/plugins/jetpack-search',
+							children: null,
+						},
+					],
+				},
+			},
+			{
+				period: 'day',
+				start_date: '2026-06-29',
+				end_date: '2026-06-29',
+				summarize: true,
+			}
+		);
+		const comparison = sanitizeStatsClicksResponse(
+			{
+				date: '2026-06-22',
+				summary: {
+					clicks: [
+						{
+							name: 'wordpress.org',
+							views: 40,
+							url: null,
+							children: [
+								{
+									name: 'wordpress.org/plugins/jetpack-search',
+									views: 28,
+									url: 'https://wordpress.org/plugins/jetpack-search',
+								},
+								{
+									name: 'wordpress.org/plugins/jetpack-boost',
+									views: 12,
+									url: 'https://wordpress.org/plugins/jetpack-boost',
+								},
+							],
+						},
+					],
+				},
+			},
+			{
+				period: 'day',
+				start_date: '2026-06-22',
+				end_date: '2026-06-22',
+				summarize: true,
+			}
+		);
+
+		expect( mergeStatsClicksComparisonRows( primary, comparison ) ).toEqual( {
+			hasComparison: true,
+			rows: [
+				expect.objectContaining( {
+					link: 'https://wordpress.org/plugins/jetpack-search',
+					views: 42,
+					previousValue: 28,
+					children: null,
+				} ),
+			],
+		} );
+	} );
+
+	it( 'matches grouped primary totals and nested URLs to a flat comparison row', () => {
+		const primary = sanitizeStatsClicksResponse(
+			{
+				date: '2026-06-29',
+				summary: {
+					clicks: [
+						{
+							name: 'wordpress.org',
+							views: 42,
+							url: null,
+							children: [
+								{
+									name: 'wordpress.org/plugins/jetpack-search',
+									views: 30,
+									url: 'https://wordpress.org/plugins/jetpack-search',
+								},
+								{
+									name: 'wordpress.org/plugins/jetpack-boost',
+									views: 12,
+									url: 'https://wordpress.org/plugins/jetpack-boost',
+								},
+							],
+						},
+					],
+				},
+			},
+			{
+				period: 'day',
+				start_date: '2026-06-29',
+				end_date: '2026-06-29',
+				summarize: true,
+			}
+		);
+		const comparison = sanitizeStatsClicksResponse(
+			{
+				date: '2026-06-22',
+				summary: {
+					clicks: [
+						{
+							name: 'wordpress.org/plugins/jetpack-search',
+							views: 28,
+							url: 'https://wordpress.org/plugins/jetpack-search',
+							children: null,
+						},
+					],
+				},
+			},
+			{
+				period: 'day',
+				start_date: '2026-06-22',
+				end_date: '2026-06-22',
+				summarize: true,
+			}
+		);
+
+		expect( mergeStatsClicksComparisonRows( primary, comparison ) ).toEqual( {
+			hasComparison: true,
+			rows: [
+				expect.objectContaining( {
+					label: 'wordpress.org',
+					views: 42,
+					previousValue: 28,
+					childrenHaveComparison: true,
+					children: [
+						expect.objectContaining( {
+							link: 'https://wordpress.org/plugins/jetpack-search',
+							views: 30,
+							previousValue: 28,
+						} ),
+						expect.objectContaining( {
+							link: 'https://wordpress.org/plugins/jetpack-boost',
+							views: 12,
+							previousValue: undefined,
+						} ),
+					],
+				} ),
+			],
+		} );
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/clicks.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/clicks.ts
@@ -95,20 +95,51 @@ export function mergeStatsClicksComparisonRows(
 		return urlKey ? comparisonByUrl.get( urlKey ) : undefined;
 	};
 
+	// An unlinked row carries no URL to match on, so it matches by label. The URL
+	// index is flat, so an unscoped label lookup would pair rows from different
+	// groups: search the matched comparison parent's own children instead. Only
+	// unlinked candidates qualify, because a linked one already matches by URL.
+	const findComparisonChildByLabel = (
+		child: StatsClicksItem,
+		comparisonParent: StatsClicksItem | undefined,
+		parentLabel: string
+	): StatsClicksItem | undefined => {
+		const label = getStatsClicksItemLabel( child, parentLabel ).trim().toLowerCase();
+
+		if ( ! label ) {
+			return undefined;
+		}
+
+		const comparisonParentLabel = comparisonParent
+			? getStatsClicksItemLabel( comparisonParent )
+			: '';
+
+		return ( comparisonParent?.children ?? [] ).find(
+			candidate =>
+				! candidate.link &&
+				getStatsClicksItemLabel( candidate, comparisonParentLabel ).trim().toLowerCase() === label
+		);
+	};
+
 	const mapChildren = (
 		children: StatsClicksItem[],
-		parent: StatsClicksItem
-	): StatsClicksComparisonItem[] =>
-		sortStatsClicksComparisonItems(
+		parent: StatsClicksItem,
+		comparisonParent: StatsClicksItem | undefined
+	): StatsClicksComparisonItem[] => {
+		const parentLabel = getStatsClicksItemLabel( parent );
+
+		return sortStatsClicksComparisonItems(
 			children.map( child => {
-				const comparison = findComparisonMatch( child );
-				const mappedChildren = mapChildren( child.children ?? [], child );
+				const comparison = child.link
+					? findComparisonMatch( child )?.item
+					: findComparisonChildByLabel( child, comparisonParent, parentLabel );
+				const mappedChildren = mapChildren( child.children ?? [], child, comparison );
 
 				return {
 					...child,
-					label: getStatsClicksItemLabel( child, getStatsClicksItemLabel( parent ) ),
+					label: getStatsClicksItemLabel( child, parentLabel ),
 					icon: child.icon ?? parent.icon ?? null,
-					previousValue: comparison?.item.views,
+					previousValue: comparison?.views,
 					children: mappedChildren.length ? mappedChildren : null,
 					childrenHaveComparison: mappedChildren.some(
 						mappedChild => mappedChild.previousValue !== undefined
@@ -116,9 +147,9 @@ export function mergeStatsClicksComparisonRows(
 				};
 			} )
 		);
+	};
 
 	const rows = getStatsReportItems( primaryReport ).map( item => {
-		const children = mapChildren( item.children ?? [], item );
 		const directMatch = findComparisonMatch( item );
 		const childMatch = ( item.children ?? [] )
 			.map( findComparisonMatch )
@@ -129,15 +160,17 @@ export function mergeStatsClicksComparisonRows(
 		// multi-URL domain is returned as a parent with children. A linked row
 		// compares to the same URL; a parent compares to the matching domain
 		// total, falling back to the top-level record containing a matched URL
-		// when one side changed shape.
-		const previousValue = item.children?.length
-			? ( matchingGroup ?? childMatch?.topLevelItem )?.views
-			: directMatch?.item.views;
+		// when one side changed shape. An unlinked row has only its label, which
+		// is the key the group index uses.
+		const comparisonItem = item.children?.length
+			? matchingGroup ?? childMatch?.topLevelItem
+			: directMatch?.item ?? ( item.link ? undefined : matchingGroup );
+		const children = mapChildren( item.children ?? [], item, comparisonItem );
 
 		return {
 			...item,
 			label: getStatsClicksItemLabel( item ),
-			previousValue,
+			previousValue: comparisonItem?.views,
 			children: children.length ? children : null,
 			childrenHaveComparison: children.some( child => child.previousValue !== undefined ),
 		};

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/clicks.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/clicks.ts
@@ -2,9 +2,9 @@ import { safeParseFloat } from '../../utils/parsing';
 import {
 	coerceStatsArray,
 	getStatsReportItems,
+	limitStatsRows,
 	mapNestedItems,
 	mapStatsReportDataPoints,
-	mergeStatsTreeComparisonRows,
 	normalizeStatsReportSummary,
 } from './utils';
 import type { StatsNormalizedItemBase, StatsNormalizedReport, StatsRecord } from './types';
@@ -23,11 +23,6 @@ export interface StatsClicksComparisonItem extends Omit< StatsClicksItem, 'child
 	childrenHaveComparison?: boolean;
 }
 
-type ClickParentContext = {
-	label: string;
-	icon?: string | null;
-};
-
 function getStatsClicksItemLabel( item: StatsClicksItem, parentLabel?: string ): string {
 	if ( typeof item.label === 'string' && item.label ) {
 		return item.label;
@@ -36,9 +31,20 @@ function getStatsClicksItemLabel( item: StatsClicksItem, parentLabel?: string ):
 	return item.link ?? parentLabel ?? '';
 }
 
-function getStatsClicksItemKey( item: StatsClicksItem, parentLabel?: string ): string {
-	const label = getStatsClicksItemLabel( item, parentLabel );
-	return item.link ?? label;
+function getStatsClicksUrlKey( item: StatsClicksItem ): string | undefined {
+	if ( ! item.link ) {
+		return undefined;
+	}
+
+	try {
+		return new URL( item.link ).href;
+	} catch {
+		return item.link;
+	}
+}
+
+function getStatsClicksGroupKey( item: StatsClicksItem ): string {
+	return getStatsClicksItemLabel( item ).trim().toLowerCase();
 }
 
 function sortStatsClicksComparisonItems(
@@ -52,37 +58,96 @@ export function mergeStatsClicksComparisonRows(
 	comparisonReport: StatsNormalizedReport< StatsClicksItem > | undefined,
 	maxRows?: number
 ): { rows: StatsClicksComparisonItem[]; hasComparison: boolean } {
-	return mergeStatsTreeComparisonRows<
-		StatsClicksItem,
-		StatsClicksItem,
-		StatsClicksComparisonItem,
-		ClickParentContext
-	>( {
-		primaryRows: getStatsReportItems( primaryReport ),
-		comparisonRows: getStatsReportItems( comparisonReport ),
-		maxRows,
-		getPrimaryKey: ( item, parent ) => getStatsClicksItemKey( item, parent?.label ),
-		getComparisonKey: ( item, parent ) => getStatsClicksItemKey( item, parent?.label ),
-		getComparisonValue: item => item.views,
-		getPrimaryChildren: item => item.children,
-		getComparisonChildren: item => item.children,
-		mapRow: ( item, { previousValue }, parent ) => ( {
+	type ComparisonMatch = {
+		item: StatsClicksItem;
+		topLevelItem: StatsClicksItem;
+	};
+
+	const comparisonRows = getStatsReportItems( comparisonReport );
+	const comparisonGroups = new Map< string, StatsClicksItem >();
+	const comparisonByUrl = new Map< string, ComparisonMatch >();
+
+	const indexComparisonUrl = ( item: StatsClicksItem, topLevelItem: StatsClicksItem ) => {
+		const key = getStatsClicksUrlKey( item );
+
+		if ( key && ! comparisonByUrl.has( key ) ) {
+			comparisonByUrl.set( key, { item, topLevelItem } );
+		}
+
+		for ( const child of item.children ?? [] ) {
+			indexComparisonUrl( child, topLevelItem );
+		}
+	};
+
+	for ( const item of comparisonRows ) {
+		if ( item.children?.length || ! item.link ) {
+			const groupKey = getStatsClicksGroupKey( item );
+			if ( groupKey && ! comparisonGroups.has( groupKey ) ) {
+				comparisonGroups.set( groupKey, item );
+			}
+		}
+
+		indexComparisonUrl( item, item );
+	}
+
+	const findComparisonMatch = ( item: StatsClicksItem ): ComparisonMatch | undefined => {
+		const urlKey = getStatsClicksUrlKey( item );
+		return urlKey ? comparisonByUrl.get( urlKey ) : undefined;
+	};
+
+	const mapChildren = (
+		children: StatsClicksItem[],
+		parent: StatsClicksItem
+	): StatsClicksComparisonItem[] =>
+		sortStatsClicksComparisonItems(
+			children.map( child => {
+				const comparison = findComparisonMatch( child );
+				const mappedChildren = mapChildren( child.children ?? [], child );
+
+				return {
+					...child,
+					label: getStatsClicksItemLabel( child, getStatsClicksItemLabel( parent ) ),
+					icon: child.icon ?? parent.icon ?? null,
+					previousValue: comparison?.item.views,
+					children: mappedChildren.length ? mappedChildren : null,
+					childrenHaveComparison: mappedChildren.some(
+						mappedChild => mappedChild.previousValue !== undefined
+					),
+				};
+			} )
+		);
+
+	const rows = getStatsReportItems( primaryReport ).map( item => {
+		const children = mapChildren( item.children ?? [], item );
+		const directMatch = findComparisonMatch( item );
+		const childMatch = ( item.children ?? [] )
+			.map( findComparisonMatch )
+			.find( match => match !== undefined );
+		const matchingGroup = comparisonGroups.get( getStatsClicksGroupKey( item ) );
+
+		// A one-URL domain is returned as a linked top-level row, while a
+		// multi-URL domain is returned as a parent with children. A linked row
+		// compares to the same URL; a parent compares to the matching domain
+		// total, falling back to the top-level record containing a matched URL
+		// when one side changed shape.
+		const previousValue = item.children?.length
+			? ( matchingGroup ?? childMatch?.topLevelItem )?.views
+			: directMatch?.item.views;
+
+		return {
 			...item,
-			label: getStatsClicksItemLabel( item, parent?.label ),
-			icon: item.icon ?? parent?.icon ?? null,
+			label: getStatsClicksItemLabel( item ),
 			previousValue,
-		} ),
-		setChildren: ( item, children, childrenHaveComparison ) => ( {
-			...item,
 			children: children.length ? children : null,
-			childrenHaveComparison,
-		} ),
-		getChildContext: item => ( {
-			label: typeof item.label === 'string' ? item.label : '',
-			icon: item.icon,
-		} ),
-		sortRows: sortStatsClicksComparisonItems,
+			childrenHaveComparison: children.some( child => child.previousValue !== undefined ),
+		};
 	} );
+	const visibleRows = limitStatsRows( sortStatsClicksComparisonItems( rows ), maxRows );
+
+	return {
+		rows: visibleRows,
+		hasComparison: visibleRows.some( row => row.previousValue !== undefined ),
+	};
 }
 
 export function sanitizeStatsClicksResponse(

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -32,6 +32,7 @@ import {
 } from '../stats-app-referrers-spam-query';
 import { statsAppSiteHasNeverPublishedPostQuery } from '../stats-app-site-has-never-published-post-query';
 import { statsArchivesQuery } from '../stats-archives-query';
+import { statsClicksQuery } from '../stats-clicks-query';
 import { statsCommentFollowersQuery } from '../stats-comment-followers-query';
 import { statsCommentsQuery } from '../stats-comments-query';
 import { statsDevicesQuery } from '../stats-devices-query';
@@ -347,6 +348,34 @@ describe( 'Stats query factories', () => {
 				} ),
 			] )
 		);
+	} );
+
+	it( 'matches the legacy Clicks custom-range request without a days parameter', () => {
+		const query = statsClicksQuery( {
+			from: '2026-06-01',
+			to: '2026-06-07',
+			interval: 'month',
+			max: 0,
+			summarize: 1,
+		} );
+
+		expect( query.queryKey ).toEqual( [
+			'stats',
+			'clicks',
+			'1.1',
+			'stats/clicks',
+			'GET',
+			{
+				period: 'day',
+				start_date: '2026-06-01',
+				date: '2026-06-07',
+				max: 0,
+				summarize: 1,
+			},
+			undefined,
+			'clicks',
+		] );
+		expect( query.queryKey[ 5 ] ).not.toHaveProperty( 'days' );
 	} );
 
 	it( 'keeps the complete video summary mode out of the request params', () => {

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-clicks-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-clicks-query.ts
@@ -1,36 +1,12 @@
 /**
  * Internal dependencies
  */
-import { reportParamsToStatsQueryParams } from '../utils/stats-params';
-import { statsProxyQuery, type StatsReportParams } from './stats-query';
+import { statsReportQuery, type StatsReportParams } from './stats-query';
 
-export const statsClicksQuery = ( params: StatsReportParams ) => {
-	const statsParams = reportParamsToStatsQueryParams( params );
-	const requestParams = { ...statsParams };
-
-	// The Clicks endpoint uses start_date + date to delimit custom ranges.
-	// Calypso omits the generic day count, and doing the same avoids sending a
-	// parameter this endpoint does not accept.
-	delete requestParams.days;
-
-	if ( params.period === undefined ) {
-		requestParams.period = 'day';
-	}
-
-	if (
-		statsParams.summarize === undefined &&
-		typeof statsParams.days === 'number' &&
-		statsParams.days > 1
-	) {
-		requestParams.summarize = 1;
-	}
-
-	return statsProxyQuery( {
-		name: 'clicks',
-		version: '1.1',
-		endpoint: 'stats/clicks',
-		params: requestParams,
-		sanitizer: 'clicks',
-		enabled: !! ( requestParams.end_date || requestParams.date || requestParams.start_date ),
+export const statsClicksQuery = ( params: StatsReportParams ) =>
+	statsReportQuery( 'clicks', 'stats/clicks', params, 'clicks', '1.1', undefined, {
+		// The Clicks endpoint uses start_date + date to delimit custom ranges.
+		// Calypso omits the generic day count, and doing the same avoids sending
+		// a parameter this endpoint does not accept.
+		omitParams: [ 'days' ],
 	} );
-};

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-clicks-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-clicks-query.ts
@@ -1,7 +1,36 @@
 /**
  * Internal dependencies
  */
-import { statsReportQuery, type StatsReportParams } from './stats-query';
+import { reportParamsToStatsQueryParams } from '../utils/stats-params';
+import { statsProxyQuery, type StatsReportParams } from './stats-query';
 
-export const statsClicksQuery = ( params: StatsReportParams ) =>
-	statsReportQuery( 'clicks', 'stats/clicks', params, 'clicks' );
+export const statsClicksQuery = ( params: StatsReportParams ) => {
+	const statsParams = reportParamsToStatsQueryParams( params );
+	const requestParams = { ...statsParams };
+
+	// The Clicks endpoint uses start_date + date to delimit custom ranges.
+	// Calypso omits the generic day count, and doing the same avoids sending a
+	// parameter this endpoint does not accept.
+	delete requestParams.days;
+
+	if ( params.period === undefined ) {
+		requestParams.period = 'day';
+	}
+
+	if (
+		statsParams.summarize === undefined &&
+		typeof statsParams.days === 'number' &&
+		statsParams.days > 1
+	) {
+		requestParams.summarize = 1;
+	}
+
+	return statsProxyQuery( {
+		name: 'clicks',
+		version: '1.1',
+		endpoint: 'stats/clicks',
+		params: requestParams,
+		sanitizer: 'clicks',
+		enabled: !! ( requestParams.end_date || requestParams.date || requestParams.start_date ),
+	} );
+};

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/aggregate.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/aggregate.test.ts
@@ -1,133 +1,47 @@
-import { aggregateClickRows, clicksToTimeSeries } from './aggregate';
-import type { StatsClicksItem, StatsNormalizedReport } from '@jetpack-premium-analytics/data';
-
-/**
- * Build a top-level click item with the requested total.
- *
- * @param views - The item's click count.
- * @return The click item.
- */
-function makeClickItem( views: number ): StatsClicksItem {
-	return {
-		label: 'jetpack.com',
-		views,
-		link: 'https://jetpack.com/',
-		icon: null,
-		labelIcon: 'external',
-		children: null,
-	};
-}
-
-const dailyReport: StatsNormalizedReport< StatsClicksItem > = {
-	summary: {},
-	data: [
-		{
-			time_interval: '2026-07-09',
-			date_start: '2026-07-09T00:00:00+00:00',
-			date_end: '2026-07-09T23:59:59+00:00',
-			items: [ makeClickItem( 8 ) ],
-		},
-		{
-			time_interval: '2026-07-10',
-			date_start: '2026-07-10T00:00:00+00:00',
-			date_end: '2026-07-10T23:59:59+00:00',
-			items: [ makeClickItem( 5 ) ],
-		},
-	],
-};
+import { aggregateClickRows } from './aggregate';
+import type {
+	StatsClicksComparisonItem,
+	StatsClicksItem,
+	StatsNormalizedReport,
+} from '@jetpack-premium-analytics/data';
 
 describe( 'report clicks aggregate', () => {
-	it( 'builds the chart from top-level totals without double-counting children', () => {
-		const report: StatsNormalizedReport< StatsClicksItem > = {
-			summary: {},
-			data: [
-				{
-					time_interval: '2026-06-01',
-					date_start: '2026-06-01T00:00:00+00:00',
-					date_end: '2026-06-01T23:59:59+00:00',
-					items: [
-						{
-							label: 'wordpress.org',
-							views: 12,
-							link: null,
-							icon: null,
-							labelIcon: null,
-							children: [
-								{
-									label: '/plugins/jetpack-search',
-									views: 8,
-									link: 'https://wordpress.org/plugins/jetpack-search',
-									icon: null,
-									labelIcon: 'external',
-									children: null,
-								},
-							],
-						},
-					],
-				},
-			],
-		};
+	it( 'preserves comparison values on click groups and nested URLs', () => {
+		const items: StatsClicksComparisonItem[] = [
+			{
+				label: 'wordpress.org',
+				views: 55,
+				previousValue: 40,
+				link: null,
+				icon: null,
+				labelIcon: null,
+				children: [
+					{
+						label: '/plugins/jetpack-search',
+						views: 42,
+						previousValue: 28,
+						link: 'https://wordpress.org/plugins/jetpack-search',
+						icon: null,
+						labelIcon: 'external',
+						children: null,
+					},
+				],
+			},
+		];
 
-		const series = clicksToTimeSeries( report );
-
-		expect( series.data[ 0 ] ).toEqual( expect.objectContaining( { clicks: 12, value: 12 } ) );
-		expect( series.summary ).toEqual( {
-			date_start: '2026-06-01T00:00:00+00:00',
-			date_end: '2026-06-01T23:59:59+00:00',
-		} );
-	} );
-
-	it( 'groups daily totals into ISO calendar weeks for the chart', () => {
-		const series = clicksToTimeSeries( dailyReport, 'week' );
-
-		expect( series.summary ).toEqual( {
-			date_start: '2026-07-09T00:00:00+00:00',
-			date_end: '2026-07-10T23:59:59+00:00',
-		} );
-		expect( series.data ).toEqual( [
+		expect( aggregateClickRows( { data: [ { items } ] } ) ).toEqual( [
 			expect.objectContaining( {
-				time_interval: '2026-07-06',
-				date_start: '2026-07-06T00:00:00+00:00',
-				date_end: '2026-07-10T23:59:59+00:00',
-				clicks: 13,
-				value: 13,
-			} ),
-		] );
-	} );
-
-	it( 'groups daily totals into calendar months for the chart', () => {
-		const reportWithNextMonth = {
-			...dailyReport,
-			data: [
-				...dailyReport.data,
-				{
-					time_interval: '2026-08-02',
-					date_start: '2026-08-02T00:00:00+00:00',
-					date_end: '2026-08-02T23:59:59+00:00',
-					items: [ makeClickItem( 3 ) ],
-				},
-			],
-		};
-		const series = clicksToTimeSeries( reportWithNextMonth, 'month' );
-
-		expect( series.summary ).toEqual( {
-			date_start: '2026-07-09T00:00:00+00:00',
-			date_end: '2026-08-02T23:59:59+00:00',
-		} );
-		expect( series.data ).toEqual( [
-			expect.objectContaining( {
-				time_interval: '2026-07-01',
-				date_start: '2026-07-01T00:00:00+00:00',
-				date_end: '2026-07-10T23:59:59+00:00',
-				clicks: 13,
-				value: 13,
+				id: 'wordpress.org',
+				clickedUrl: 'wordpress.org',
+				clicks: 55,
+				previousClicks: 40,
 			} ),
 			expect.objectContaining( {
-				time_interval: '2026-08-01',
-				date_start: '2026-08-01T00:00:00+00:00',
-				date_end: '2026-08-02T23:59:59+00:00',
-				clicks: 3,
-				value: 3,
+				id: 'wordpress.org|https://wordpress.org/plugins/jetpack-search',
+				parentId: 'wordpress.org',
+				clickedUrl: 'https://wordpress.org/plugins/jetpack-search',
+				clicks: 42,
+				previousClicks: 28,
 			} ),
 		] );
 	} );

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/aggregate.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/aggregate.test.ts
@@ -212,7 +212,7 @@ describe( 'report clicks aggregate', () => {
 		expect( aggregateClickRows( undefined ) ).toEqual( [] );
 	} );
 
-	it( 'drops an unlinked leaf, which has no stable id to aggregate on', () => {
+	it( 'keeps an unlinked leaf, which the Clicks widget also lists', () => {
 		const report: StatsNormalizedReport< StatsClicksItem > = {
 			summary: {},
 			data: [
@@ -238,6 +238,61 @@ describe( 'report clicks aggregate', () => {
 								},
 								{
 									label: 'untracked',
+									views: 3,
+									link: null,
+									icon: null,
+									labelIcon: null,
+									children: null,
+								},
+							],
+						},
+					],
+				},
+			],
+		};
+
+		const rows = aggregateClickRows( report );
+
+		expect( rows.map( row => row.clickedUrl ) ).toEqual( [
+			'wordpress.org',
+			'https://wordpress.org/plugins/jetpack-search',
+			'untracked',
+		] );
+		// The label carries the row, so the cell renders as plain text.
+		expect( rows[ 2 ] ).toMatchObject( {
+			id: 'wordpress.org|label:untracked',
+			parentId: 'wordpress.org',
+			clicks: 3,
+			href: undefined,
+		} );
+	} );
+
+	it( 'drops a leaf with no label and no URL, which has no stable id', () => {
+		const report: StatsNormalizedReport< StatsClicksItem > = {
+			summary: {},
+			data: [
+				{
+					time_interval: '2026-06-01',
+					date_start: '2026-06-01T00:00:00+00:00',
+					date_end: '2026-06-01T23:59:59+00:00',
+					items: [
+						{
+							label: 'wordpress.org',
+							views: 9,
+							link: null,
+							icon: null,
+							labelIcon: null,
+							children: [
+								{
+									label: '/plugins/jetpack-search',
+									views: 6,
+									link: 'https://wordpress.org/plugins/jetpack-search',
+									icon: null,
+									labelIcon: 'external',
+									children: null,
+								},
+								{
+									label: '',
 									views: 3,
 									link: null,
 									icon: null,

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/aggregate.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/aggregate.test.ts
@@ -206,4 +206,56 @@ describe( 'report clicks aggregate', () => {
 		// A single-URL group stays one flat row — no drill-down parent.
 		expect( aggregateClickRows( report ) ).toHaveLength( 1 );
 	} );
+
+	it( 'returns no rows when the report is missing or carries no data', () => {
+		expect( aggregateClickRows() ).toEqual( [] );
+		expect( aggregateClickRows( undefined ) ).toEqual( [] );
+	} );
+
+	it( 'drops an unlinked leaf, which has no stable id to aggregate on', () => {
+		const report: StatsNormalizedReport< StatsClicksItem > = {
+			summary: {},
+			data: [
+				{
+					time_interval: '2026-06-01',
+					date_start: '2026-06-01T00:00:00+00:00',
+					date_end: '2026-06-01T23:59:59+00:00',
+					items: [
+						{
+							label: 'wordpress.org',
+							views: 9,
+							link: null,
+							icon: null,
+							labelIcon: null,
+							children: [
+								{
+									label: '/plugins/jetpack-search',
+									views: 6,
+									link: 'https://wordpress.org/plugins/jetpack-search',
+									icon: null,
+									labelIcon: 'external',
+									children: null,
+								},
+								{
+									label: 'untracked',
+									views: 3,
+									link: null,
+									icon: null,
+									labelIcon: null,
+									children: null,
+								},
+							],
+						},
+					],
+				},
+			],
+		};
+
+		const rows = aggregateClickRows( report );
+
+		expect( rows.map( row => row.clickedUrl ) ).toEqual( [
+			'wordpress.org',
+			'https://wordpress.org/plugins/jetpack-search',
+		] );
+	} );
 } );

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/aggregate.ts
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/aggregate.ts
@@ -3,12 +3,10 @@
  */
 import {
 	aggregateStatsDrilldownRows,
-	bucketStatsTimeSeries,
-	type StatsChartBucketPeriod,
+	type StatsClicksComparisonItem,
 	type StatsClicksItem,
 	type StatsDrilldownItemContext,
-	type StatsNormalizedReport,
-	type StatsTimeSeriesReport,
+	type StatsDrilldownSourceReport,
 } from '@jetpack-premium-analytics/data';
 /**
  * Internal dependencies
@@ -17,7 +15,10 @@ import type { ClickRow } from './fields';
 
 type ClickDrilldownMetadata = {
 	href?: string;
+	previousClicks?: number;
 };
+
+type ClickItem = StatsClicksItem | StatsClicksComparisonItem;
 
 /**
  * Return the display label used by the Clicks hierarchy.
@@ -25,7 +26,7 @@ type ClickDrilldownMetadata = {
  * @param item - A normalized Clicks item.
  * @return The item label.
  */
-function getClickLabel( item: StatsClicksItem ): string {
+function getClickLabel( item: ClickItem ): string {
 	return String( item.label ?? item.link ?? '' );
 }
 
@@ -37,8 +38,8 @@ function getClickLabel( item: StatsClicksItem ): string {
  * @return The row id, or null for an unlinked leaf.
  */
 function getClickRowId(
-	item: StatsClicksItem,
-	context: StatsDrilldownItemContext< StatsClicksItem >
+	item: ClickItem,
+	context: StatsDrilldownItemContext< ClickItem >
 ): string | null {
 	const label = getClickLabel( item );
 
@@ -61,9 +62,9 @@ function getClickRowId(
  * @param groupByUrl - Destination URL-to-group map.
  */
 function registerClickGroupUrls(
-	item: StatsClicksItem,
-	group: StatsClicksItem,
-	groupByUrl: Map< string, StatsClicksItem >
+	item: ClickItem,
+	group: ClickItem,
+	groupByUrl: Map< string, ClickItem >
 ): void {
 	if ( item.link && ! groupByUrl.has( item.link ) ) {
 		groupByUrl.set( item.link, group );
@@ -84,13 +85,13 @@ function registerClickGroupUrls(
  * @return A report with known single-URL records nested under their group.
  */
 function normalizeClickDrilldownGroups(
-	report: StatsNormalizedReport< StatsClicksItem > | undefined
-): StatsNormalizedReport< StatsClicksItem > | undefined {
-	if ( ! report ) {
+	report: StatsDrilldownSourceReport< ClickItem > | undefined
+): StatsDrilldownSourceReport< ClickItem > | undefined {
+	if ( ! report?.data ) {
 		return undefined;
 	}
 
-	const groupByUrl = new Map< string, StatsClicksItem >();
+	const groupByUrl = new Map< string, ClickItem >();
 
 	for ( const point of report.data ) {
 		for ( const item of point.items ) {
@@ -128,45 +129,26 @@ function normalizeClickDrilldownGroups(
 }
 
 /**
- * Convert a daily clicks report to a clicks-per-bucket time series.
- *
- * Top-level click groups already contain their children's totals, so only
- * top-level values are summed to avoid double-counting flattened child URLs.
- *
- * @param report - The daily clicks report.
- * @param period - The chart bucket period.
- * @return The chart-ready time series.
- */
-export function clicksToTimeSeries(
-	report: StatsNormalizedReport< StatsClicksItem > | undefined,
-	period: StatsChartBucketPeriod = 'day'
-): StatsTimeSeriesReport {
-	return bucketStatsTimeSeries( report, period, point => {
-		const clicks = point.items.reduce( ( total, item ) => total + item.views, 0 );
-
-		return { value: clicks, clicks };
-	} );
-}
-
-/**
  * Aggregate bucketed click groups into nested rows: one parent row per click
  * group with its clicked URLs as child rows, in display order.
  *
  * @param report - The bucketed clicks report.
  * @return Nested click rows in display order.
  */
-export function aggregateClickRows(
-	report?: StatsNormalizedReport< StatsClicksItem >
-): ClickRow[] {
-	return aggregateStatsDrilldownRows< StatsClicksItem, ClickDrilldownMetadata >(
+export function aggregateClickRows( report?: StatsDrilldownSourceReport< ClickItem > ): ClickRow[] {
+	return aggregateStatsDrilldownRows< ClickItem, ClickDrilldownMetadata >(
 		normalizeClickDrilldownGroups( report ),
 		{
 			getChildren: item => item.children,
 			getId: getClickRowId,
 			getLabel: getClickLabel,
 			getValue: item => item.views,
-			getRowMetadata: ( item, { isGroup } ) =>
-				! isGroup && item.link ? { href: item.link } : {},
+			getRowMetadata: ( item, { isGroup } ) => ( {
+				...( ! isGroup && item.link ? { href: item.link } : {} ),
+				...( 'previousValue' in item && item.previousValue !== undefined
+					? { previousClicks: item.previousValue }
+					: {} ),
+			} ),
 		}
 	).map( row => ( {
 		id: row.id,
@@ -176,5 +158,6 @@ export function aggregateClickRows(
 		href: row.href,
 		isGroup: row.isGroup,
 		clicks: row.value,
+		...( row.previousClicks !== undefined ? { previousClicks: row.previousClicks } : {} ),
 	} ) );
 }

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/aggregate.ts
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/aggregate.ts
@@ -35,7 +35,7 @@ function getClickLabel( item: ClickItem ): string {
  *
  * @param item    - A normalized Clicks item.
  * @param context - The item's hierarchy context.
- * @return The row id, or null for an unlinked leaf.
+ * @return The row id, or null for a row with no label and no URL.
  */
 function getClickRowId(
 	item: ClickItem,
@@ -48,7 +48,13 @@ function getClickRowId(
 	}
 
 	if ( ! item.link ) {
-		return null;
+		// The Clicks widget lists unlinked rows, so the table lists them too.
+		// Without a URL the label is the only stable key.
+		if ( ! label ) {
+			return null;
+		}
+
+		return context.parentId ? `${ context.parentId }|label:${ label }` : `label:${ label }`;
 	}
 
 	return context.parentId ? `${ context.parentId }|${ item.link }` : `${ label }|${ item.link }`;

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/fields.test.tsx
@@ -9,6 +9,26 @@ const row: ClickRow = {
 	clicks: 42,
 };
 
+/**
+ * Mount a Clicks table field's render component.
+ *
+ * @param fieldId        - The field to render.
+ * @param item           - The Clicks row.
+ * @param withComparison - Whether comparison deltas are enabled.
+ * @return The Testing Library render result.
+ */
+function renderField( fieldId: 'clickedUrl' | 'clicks', item: ClickRow, withComparison = false ) {
+	const field = getClicksFields( withComparison ).find( candidate => candidate.id === fieldId );
+	// eslint-disable-next-line testing-library/render-result-naming-convention -- `render` is the DataViews field render component.
+	const FieldComponent = field?.render;
+
+	if ( ! field || ! FieldComponent ) {
+		throw new Error( `Clicks ${ fieldId } field render callback is unavailable` );
+	}
+
+	return render( <FieldComponent item={ item } field={ field as never } /> );
+}
+
 describe( 'clicks fields', () => {
 	it( 'renders clicked URLs as safe external links', () => {
 		const field = getClicksFields().find( candidate => candidate.id === 'clickedUrl' );
@@ -97,5 +117,19 @@ describe( 'clicks fields', () => {
 		const fields = getClicksFields();
 
 		expect( fields.find( field => field.id === 'clickedUrl' )?.enableGlobalSearch ).toBe( true );
+	} );
+
+	it( 'shows the clicks delta when a comparison row is available', () => {
+		renderField( 'clicks', { ...row, previousClicks: 28 }, true );
+
+		expect( screen.getByText( '42' ) ).toBeInTheDocument();
+		expect( screen.getByText( '+50%' ) ).toBeInTheDocument();
+	} );
+
+	it( 'hides the clicks delta when comparison is disabled', () => {
+		renderField( 'clicks', { ...row, previousClicks: 28 } );
+
+		expect( screen.getByText( '42' ) ).toBeInTheDocument();
+		expect( screen.queryByText( '+50%' ) ).not.toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/fields.tsx
@@ -1,11 +1,16 @@
 /**
  * External dependencies
  */
-import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
 import { DrilldownLeafCell, safeHttpUrl } from '@jetpack-premium-analytics/ui';
+import { MetricWithComparison } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';
 import { Link } from '@wordpress/ui';
 import type { Field } from '@wordpress/dataviews';
+
+const CLICKS_DATA_FORMAT = {
+	type: 'number',
+	options: { decimals: 0, useMultipliers: false },
+} as const;
 
 export type ClickRow = {
 	id: string;
@@ -17,14 +22,17 @@ export type ClickRow = {
 	/** Group parent rows keep the title-field styling; leaf rows opt out. */
 	isGroup?: boolean;
 	clicks: number;
+	/** Click count for the matching row in the comparison period. */
+	previousClicks?: number;
 };
 
 /**
  * DataViews field config for the Clicks records table.
  *
+ * @param withComparison - Whether to render available period-over-period deltas.
  * @return The field config.
  */
-export function getClicksFields(): Field< ClickRow >[] {
+export function getClicksFields( withComparison = false ): Field< ClickRow >[] {
 	return [
 		{
 			id: 'clickedUrl',
@@ -62,7 +70,12 @@ export function getClicksFields(): Field< ClickRow >[] {
 			label: __( 'Clicks', 'jetpack-premium-analytics-pkg' ),
 			getValue: ( { item } ) => item.clicks,
 			render: ( { item } ) => (
-				<>{ formatMetricValue( item.clicks, 'number', { decimals: 0, useMultipliers: false } ) }</>
+				<MetricWithComparison
+					value={ item.clicks }
+					previousValue={ withComparison ? item.previousClicks : undefined }
+					dataFormat={ CLICKS_DATA_FORMAT }
+					fontSize="md"
+				/>
 			),
 		},
 	];

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/index.ts
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/index.ts
@@ -1,3 +1,3 @@
-export { aggregateClickRows, clicksToTimeSeries } from './aggregate';
+export { aggregateClickRows } from './aggregate';
 export { getClicksFields, type ClickRow } from './fields';
 export { useClicksReportRecords } from './use-report-records';

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/use-report-records.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/use-report-records.test.ts
@@ -73,6 +73,7 @@ describe( 'useClicksReportRecords', () => {
 			comparisonRows: { rows: primaryRows, hasComparison: false },
 			hasComparison: false,
 			isLoading: false,
+			isFetching: false,
 		} as ReturnType< typeof useStatsClicks > );
 	} );
 
@@ -103,6 +104,7 @@ describe( 'useClicksReportRecords', () => {
 			comparisonRows: { rows: comparisonRows, hasComparison: true },
 			hasComparison: true,
 			isLoading: false,
+			isFetching: false,
 		} as ReturnType< typeof useStatsClicks > );
 
 		const { result } = renderHook( () =>
@@ -131,12 +133,30 @@ describe( 'useClicksReportRecords', () => {
 			comparisonRows: { rows: primaryRows, hasComparison: false },
 			hasComparison: false,
 			isLoading: true,
+			isFetching: true,
 		} as ReturnType< typeof useStatsClicks > );
 
 		const { result } = renderHook( () => useClicksReportRecords( reportParams ) );
 
 		expect( result.current.isLoading ).toBe( true );
+		expect( result.current.isFetching ).toBe( true );
 		expect( result.current.rows ).toHaveLength( 1 );
+	} );
+
+	it( 'surfaces active fetching after the initial load has settled', () => {
+		mockUseStatsClicks.mockReturnValue( {
+			primary: { data: report },
+			comparison: { data: report },
+			comparisonRows: { rows: comparisonRows, hasComparison: true },
+			hasComparison: true,
+			isLoading: false,
+			isFetching: true,
+		} as ReturnType< typeof useStatsClicks > );
+
+		const { result } = renderHook( () => useClicksReportRecords( reportParams ) );
+
+		expect( result.current.isLoading ).toBe( false );
+		expect( result.current.isFetching ).toBe( true );
 	} );
 
 	it( 'surfaces error and refetch from the report', () => {
@@ -147,6 +167,7 @@ describe( 'useClicksReportRecords', () => {
 			comparisonRows: { rows: primaryRows, hasComparison: false },
 			hasComparison: false,
 			isLoading: false,
+			isFetching: false,
 			isError: true,
 			refetch,
 		} as unknown as ReturnType< typeof useStatsClicks > );

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/use-report-records.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/use-report-records.test.ts
@@ -1,8 +1,15 @@
+/**
+ * External dependencies
+ */
 import { useStatsClicks } from '@jetpack-premium-analytics/data';
 import { renderHook } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
 import { useClicksReportRecords } from './use-report-records';
 import type {
 	ReportParams,
+	StatsClicksComparisonItem,
 	StatsClicksItem,
 	StatsNormalizedReport,
 } from '@jetpack-premium-analytics/data';
@@ -20,26 +27,11 @@ const report: StatsNormalizedReport< StatsClicksItem > = {
 		{
 			time_interval: '2026-07-09',
 			date_start: '2026-07-09T00:00:00+00:00',
-			date_end: '2026-07-09T23:59:59+00:00',
-			items: [
-				{
-					label: 'jetpack.com',
-					views: 7,
-					link: 'https://jetpack.com/',
-					icon: null,
-					labelIcon: 'external',
-					children: null,
-				},
-			],
-		},
-		{
-			time_interval: '2026-07-10',
-			date_start: '2026-07-10T00:00:00+00:00',
 			date_end: '2026-07-10T23:59:59+00:00',
 			items: [
 				{
 					label: 'jetpack.com',
-					views: 6,
+					views: 13,
 					link: 'https://jetpack.com/',
 					icon: null,
 					labelIcon: 'external',
@@ -50,280 +42,101 @@ const report: StatsNormalizedReport< StatsClicksItem > = {
 	],
 };
 
-const nestedReport: StatsNormalizedReport< StatsClicksItem > = {
-	summary: {},
-	data: [
-		{
-			time_interval: '2026-07-09',
-			date_start: '2026-07-09T00:00:00+00:00',
-			date_end: '2026-07-09T23:59:59+00:00',
-			items: [
-				{
-					label: 'github.com',
-					views: 5,
-					link: null,
-					icon: null,
-					labelIcon: null,
-					children: [
-						{
-							label: 'github.com/Automattic/jetpack',
-							views: 3,
-							link: 'https://github.com/Automattic/jetpack',
-							icon: null,
-							labelIcon: 'external',
-							children: null,
-						},
-						{
-							label: 'github.com/Automattic/themes',
-							views: 2,
-							link: 'https://github.com/Automattic/themes',
-							icon: null,
-							labelIcon: 'external',
-							children: null,
-						},
-					],
-				},
-				{
-					label: 'jetpack.com',
-					views: 7,
-					link: 'https://jetpack.com/',
-					icon: null,
-					labelIcon: 'external',
-					children: null,
-				},
-			],
-		},
-		{
-			time_interval: '2026-07-10',
-			date_start: '2026-07-10T00:00:00+00:00',
-			date_end: '2026-07-10T23:59:59+00:00',
-			items: [
-				{
-					label: 'github.com',
-					views: 4,
-					link: null,
-					icon: null,
-					labelIcon: null,
-					children: [
-						{
-							label: 'github.com/Automattic/jetpack',
-							views: 3,
-							link: 'https://github.com/Automattic/jetpack',
-							icon: null,
-							labelIcon: 'external',
-							children: null,
-						},
-						{
-							label: 'github.com/Automattic/themes',
-							views: 1,
-							link: 'https://github.com/Automattic/themes',
-							icon: null,
-							labelIcon: 'external',
-							children: null,
-						},
-					],
-				},
-				{
-					label: 'jetpack.com',
-					views: 6,
-					link: 'https://jetpack.com/',
-					icon: null,
-					labelIcon: 'external',
-					children: null,
-				},
-			],
-		},
-	],
-};
-
-const comparisonReport: StatsNormalizedReport< StatsClicksItem > = {
-	summary: {},
-	data: [
-		{
-			time_interval: '2026-07-07',
-			date_start: '2026-07-07T00:00:00+00:00',
-			date_end: '2026-07-07T23:59:59+00:00',
-			items: [
-				{
-					label: 'wordpress.com',
-					views: 4,
-					link: 'https://wordpress.com/',
-					icon: null,
-					labelIcon: 'external',
-					children: null,
-				},
-			],
-		},
-		{
-			time_interval: '2026-07-08',
-			date_start: '2026-07-08T00:00:00+00:00',
-			date_end: '2026-07-08T23:59:59+00:00',
-			items: [
-				{
-					label: 'wordpress.org',
-					views: 5,
-					link: 'https://wordpress.org/',
-					icon: null,
-					labelIcon: 'external',
-					children: null,
-				},
-			],
-		},
-	],
-};
-
-const params: ReportParams = {
+const reportParams: ReportParams = {
 	from: '2026-07-09',
 	to: '2026-07-10',
 	interval: 'day',
 };
 
-/**
- * Configure the mocked Stats hook with the daily report fixture.
- */
-function mockClicksReport() {
-	mockUseStatsClicks.mockReturnValue( {
-		primary: { data: report },
-		comparison: { data: undefined },
-		hasComparison: false,
-		isLoading: false,
-	} as ReturnType< typeof useStatsClicks > );
-}
+const comparisonRows: StatsClicksComparisonItem[] = [
+	{
+		label: 'jetpack.com',
+		views: 13,
+		previousValue: 10,
+		link: 'https://jetpack.com/',
+		icon: null,
+		labelIcon: 'external',
+		children: null,
+	},
+];
+const primaryRows: StatsClicksComparisonItem[] = comparisonRows.map( row => ( {
+	...row,
+	previousValue: undefined,
+} ) );
 
 describe( 'useClicksReportRecords', () => {
 	beforeEach( () => {
 		mockUseStatsClicks.mockReset();
-		mockClicksReport();
-	} );
-
-	it( 'derives table and daily chart data from a day-bucketed request', () => {
-		const { result } = renderHook( () => useClicksReportRecords( params, 'day' ) );
-
-		expect( mockUseStatsClicks ).toHaveBeenCalledWith( {
-			...params,
-			max: 0,
-			summarize: 0,
-			period: 'day',
-		} );
-		expect( result.current.chart.primary.data.map( point => point.clicks ) ).toEqual( [ 7, 6 ] );
-		expect( result.current.rows ).toEqual( [
-			expect.objectContaining( { clickedUrl: 'https://jetpack.com/', clicks: 13 } ),
-		] );
-	} );
-
-	it( 'nests clicked URLs under their click group, ordered by clicks', () => {
 		mockUseStatsClicks.mockReturnValue( {
-			primary: { data: nestedReport },
+			primary: { data: report },
 			comparison: { data: undefined },
+			comparisonRows: { rows: primaryRows, hasComparison: false },
 			hasComparison: false,
 			isLoading: false,
 		} as ReturnType< typeof useStatsClicks > );
-
-		const { result } = renderHook( () => useClicksReportRecords( params, 'day' ) );
-
-		expect( result.current.rows ).toEqual( [
-			// Single-URL groups stay flat top-level rows.
-			{
-				id: 'jetpack.com|https://jetpack.com/',
-				clickedUrl: 'https://jetpack.com/',
-				href: 'https://jetpack.com/',
-				clicks: 13,
-			},
-			// Multi-URL groups become a parent row with nested URL rows.
-			{ id: 'github.com', clickedUrl: 'github.com', isGroup: true, clicks: 9 },
-			{
-				id: 'github.com|https://github.com/Automattic/jetpack',
-				parentId: 'github.com',
-				clickedUrl: 'https://github.com/Automattic/jetpack',
-				href: 'https://github.com/Automattic/jetpack',
-				clicks: 6,
-			},
-			{
-				id: 'github.com|https://github.com/Automattic/themes',
-				parentId: 'github.com',
-				clickedUrl: 'https://github.com/Automattic/themes',
-				href: 'https://github.com/Automattic/themes',
-				clicks: 3,
-			},
-		] );
 	} );
 
-	it( 'keeps the request day-bucketed while grouping only the chart by week', () => {
-		const { result: dayResult, unmount } = renderHook( () =>
-			useClicksReportRecords( params, 'day' )
-		);
-		const dayRows = dayResult.current.rows;
-		unmount();
-		mockUseStatsClicks.mockClear();
-
-		const { result } = renderHook( () => useClicksReportRecords( params, 'week' ) );
+	it( 'requests the full summarized Clicks report for the selected date range', () => {
+		const paramsWithStaleChartPeriod = { ...reportParams, period: 'month' as const };
+		const { result } = renderHook( () => useClicksReportRecords( paramsWithStaleChartPeriod ) );
 
 		expect( mockUseStatsClicks ).toHaveBeenCalledWith( {
-			...params,
+			...paramsWithStaleChartPeriod,
 			max: 0,
-			summarize: 0,
+			summarize: 1,
 			period: 'day',
 		} );
-		expect( result.current.chart.primary.data ).toEqual( [
+		expect( result.current.rows ).toEqual( [
 			expect.objectContaining( {
-				time_interval: '2026-07-06',
+				clickedUrl: 'https://jetpack.com/',
 				clicks: 13,
-				value: 13,
 			} ),
 		] );
-		expect( result.current.rows ).toEqual( dayRows );
+		expect( result.current.rows[ 0 ] ).not.toHaveProperty( 'previousClicks' );
+		expect( result.current.hasComparison ).toBe( false );
 	} );
 
-	it( 'includes comparison chart buckets when clicked URLs do not overlap the primary period', () => {
+	it( 'returns matched comparison values when comparison is enabled', () => {
 		mockUseStatsClicks.mockReturnValue( {
 			primary: { data: report },
-			comparison: { data: comparisonReport },
-			hasComparison: false,
+			comparison: { data: report },
+			comparisonRows: { rows: comparisonRows, hasComparison: true },
+			hasComparison: true,
 			isLoading: false,
 		} as ReturnType< typeof useStatsClicks > );
-		const comparisonParams: ReportParams = {
-			...params,
-			compare_from: '2026-07-07',
-			compare_to: '2026-07-08',
-		};
 
-		const { result } = renderHook( () => useClicksReportRecords( comparisonParams, 'day' ) );
+		const { result } = renderHook( () =>
+			useClicksReportRecords( {
+				...reportParams,
+				comp: '1',
+				compare_from: '2026-07-07',
+				compare_to: '2026-07-08',
+			} )
+		);
 
-		expect( result.current.chart.comparison ).toBeDefined();
-		expect( result.current.chart.comparison?.data.map( point => point.clicks ) ).toEqual( [
-			4, 5,
+		expect( result.current.rows ).toEqual( [
+			expect.objectContaining( {
+				clickedUrl: 'https://jetpack.com/',
+				clicks: 13,
+				previousClicks: 10,
+			} ),
 		] );
+		expect( result.current.hasComparison ).toBe( true );
 	} );
 
-	it( 'omits the comparison chart when comparison params are absent', () => {
-		mockUseStatsClicks.mockReturnValue( {
-			primary: { data: report },
-			comparison: { data: comparisonReport },
-			hasComparison: false,
-			isLoading: false,
-		} as ReturnType< typeof useStatsClicks > );
-
-		const { result } = renderHook( () => useClicksReportRecords( params, 'day' ) );
-
-		expect( result.current.chart.comparison ).toBeUndefined();
-	} );
-
-	it( 'omits the comparison chart while the comparison query is loading', () => {
+	it( 'preserves the report loading state while comparison data loads', () => {
 		mockUseStatsClicks.mockReturnValue( {
 			primary: { data: report },
 			comparison: { data: undefined },
+			comparisonRows: { rows: primaryRows, hasComparison: false },
 			hasComparison: false,
 			isLoading: true,
 		} as ReturnType< typeof useStatsClicks > );
-		const comparisonParams: ReportParams = {
-			...params,
-			compare_from: '2026-07-07',
-			compare_to: '2026-07-08',
-		};
 
-		const { result } = renderHook( () => useClicksReportRecords( comparisonParams, 'day' ) );
+		const { result } = renderHook( () => useClicksReportRecords( reportParams ) );
 
-		expect( result.current.chart.comparison ).toBeUndefined();
+		expect( result.current.isLoading ).toBe( true );
+		expect( result.current.rows ).toHaveLength( 1 );
 	} );
 
 	it( 'surfaces error and refetch from the report', () => {
@@ -331,13 +144,14 @@ describe( 'useClicksReportRecords', () => {
 		mockUseStatsClicks.mockReturnValue( {
 			primary: { data: report },
 			comparison: { data: undefined },
+			comparisonRows: { rows: primaryRows, hasComparison: false },
 			hasComparison: false,
 			isLoading: false,
 			isError: true,
 			refetch,
 		} as unknown as ReturnType< typeof useStatsClicks > );
 
-		const { result } = renderHook( () => useClicksReportRecords( params, 'day' ) );
+		const { result } = renderHook( () => useClicksReportRecords( reportParams ) );
 
 		expect( result.current.isError ).toBe( true );
 		expect( result.current.refetch ).toBe( refetch );

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/use-report-records.ts
@@ -1,61 +1,44 @@
 /**
  * External dependencies
  */
-import {
-	useStatsClicks,
-	type ReportParams,
-	type StatsChartBucketPeriod,
-} from '@jetpack-premium-analytics/data';
+import { useStatsClicks, type ReportParams } from '@jetpack-premium-analytics/data';
 import { useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { aggregateClickRows, clicksToTimeSeries } from './aggregate';
+import { aggregateClickRows } from './aggregate';
 
 /**
- * Fetch and derive the Clicks chart and table from one bucketed query.
+ * Fetch and derive the Clicks table records.
  *
  * @param reportParams - The shared report-window parameters.
- * @param chartPeriod  - The chart's bucket period.
- * @return Chart data and flat clicked-URL rows.
+ * @return Nested clicked-URL rows.
  */
-export function useClicksReportRecords(
-	reportParams: ReportParams,
-	chartPeriod: StatsChartBucketPeriod
-) {
+export function useClicksReportRecords( reportParams: ReportParams ) {
 	const recordsParams = useMemo(
 		() => ( {
 			...reportParams,
 			max: 0,
-			summarize: 0,
+			summarize: 1,
 			period: 'day',
 		} ),
 		[ reportParams ]
 	);
 	const report = useStatsClicks( recordsParams );
-
-	const chartPrimary = useMemo(
-		() => clicksToTimeSeries( report.primary.data, chartPeriod ),
-		[ report.primary.data, chartPeriod ]
+	const comparisonRows = report.comparisonRows?.rows;
+	const rows = useMemo(
+		() =>
+			aggregateClickRows(
+				comparisonRows ? { data: [ { items: comparisonRows } ] } : report.primary.data
+			),
+		[ comparisonRows, report.primary.data ]
 	);
-	const chartComparison = useMemo( () => {
-		if ( ! reportParams.compare_from || ! reportParams.compare_to ) {
-			return undefined;
-		}
-
-		return clicksToTimeSeries( report.comparison.data, chartPeriod );
-	}, [ reportParams, report.comparison.data, chartPeriod ] );
-	const rows = useMemo( () => aggregateClickRows( report.primary.data ), [ report.primary.data ] );
 
 	return {
 		isError: report.isError,
 		refetch: report.refetch,
-		chart: {
-			primary: chartPrimary,
-			comparison: report.comparison.data ? chartComparison : undefined,
-			isLoading: report.isLoading,
-		},
 		rows,
+		hasComparison: report.hasComparison,
 		isLoading: report.isLoading,
 	};
 }

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/use-report-records.ts
@@ -27,11 +27,8 @@ export function useClicksReportRecords( reportParams: ReportParams ) {
 	const report = useStatsClicks( recordsParams );
 	const comparisonRows = report.comparisonRows?.rows;
 	const rows = useMemo(
-		() =>
-			aggregateClickRows(
-				comparisonRows ? { data: [ { items: comparisonRows } ] } : report.primary.data
-			),
-		[ comparisonRows, report.primary.data ]
+		() => aggregateClickRows( { data: [ { items: comparisonRows ?? [] } ] } ),
+		[ comparisonRows ]
 	);
 
 	return {

--- a/projects/packages/premium-analytics/routes/reports/clicks/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/clicks/config/use-report-records.ts
@@ -40,5 +40,6 @@ export function useClicksReportRecords( reportParams: ReportParams ) {
 		rows,
 		hasComparison: report.hasComparison,
 		isLoading: report.isLoading,
+		isFetching: report.isFetching,
 	};
 }

--- a/projects/packages/premium-analytics/routes/reports/clicks/page.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/clicks/page.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * External dependencies
+ */
+import { ReportDrilldownTable } from '@jetpack-premium-analytics/widgets-toolkit';
+import { render } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import { useClicksReportRecords } from './config';
+import ClicksReportPage from './page';
+import type { ClickRow } from './config';
+import type { ReactNode } from 'react';
+
+jest.mock( './config', () => ( {
+	getClicksFields: () => [],
+	useClicksReportRecords: jest.fn(),
+} ) );
+
+jest.mock( '@jetpack-premium-analytics/routing', () => ( {
+	useDashboardLink: () => '/',
+	useReportDateFilters: () => ( {} ),
+} ) );
+
+jest.mock( '@jetpack-premium-analytics/ui', () => ( {
+	DateFiltersPanel: () => null,
+} ) );
+
+jest.mock( '@jetpack-premium-analytics/widgets-toolkit', () => ( {
+	ReportDrilldownTable: jest.fn( () => null ),
+	ReportErrorState: () => null,
+	ReportPageLayout: ( { children }: { children: ReactNode } ) => <>{ children }</>,
+	ReportPageShell: ( { children }: { children: ReactNode } ) => <>{ children }</>,
+	useReportRetry: ( refetch: () => unknown ) => refetch,
+} ) );
+
+jest.mock( '@wordpress/admin-ui', () => ( {
+	Breadcrumbs: () => null,
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: () => ( {
+		from: '2026-06-01',
+		to: '2026-06-07',
+		interval: 'day',
+	} ),
+} ) );
+
+const useRecordsMock = jest.mocked( useClicksReportRecords );
+const reportDrilldownTableMock = jest.mocked( ReportDrilldownTable );
+
+const row: ClickRow = {
+	id: 'wordpress.org',
+	clickedUrl: 'wordpress.org',
+	isGroup: true,
+	clicks: 42,
+};
+
+/**
+ * Stub the records hook with one populated row, settled by default.
+ *
+ * @param overrides - Request-state fields to override for the case under test.
+ */
+function mockRecords( overrides: Record< string, unknown > ) {
+	useRecordsMock.mockReturnValue( {
+		isError: false,
+		refetch: jest.fn(),
+		rows: [ row ],
+		hasComparison: true,
+		isLoading: false,
+		isFetching: false,
+		...overrides,
+	} as unknown as ReturnType< typeof useClicksReportRecords > );
+}
+
+describe( 'ClicksReportPage', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'reports the loading state on first load, when there is nothing to show yet', () => {
+		mockRecords( { rows: [], hasComparison: false, isLoading: true, isFetching: true } );
+
+		render( <ClicksReportPage /> );
+
+		expect( reportDrilldownTableMock.mock.calls[ 0 ][ 0 ] ).toEqual(
+			expect.objectContaining( { data: [], isLoading: true } )
+		);
+	} );
+
+	it( 'keeps the rows on screen while a background refetch is in flight', () => {
+		// The queries carry `placeholderData`, so a refetch triggered by a date or
+		// comparison change still has the previous rows. Handing the table an empty
+		// set would drop the user's search, sorting, page position, and the expanded
+		// state of every click group mid-refetch, so the rows stay mounted and only
+		// the loading state reflects the refetch.
+		mockRecords( { isFetching: true } );
+
+		render( <ClicksReportPage /> );
+
+		expect( reportDrilldownTableMock.mock.calls[ 0 ][ 0 ] ).toEqual(
+			expect.objectContaining( { data: [ row ], isLoading: true } )
+		);
+	} );
+
+	it( 'shows current rows once the requests are settled', () => {
+		mockRecords( {} );
+
+		render( <ClicksReportPage /> );
+
+		expect( reportDrilldownTableMock.mock.calls[ 0 ][ 0 ] ).toEqual(
+			expect.objectContaining( { data: [ row ], isLoading: false } )
+		);
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/reports/clicks/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/clicks/page.tsx
@@ -79,6 +79,7 @@ function ClicksReport(): JSX.Element {
 	const dateFilters = useReportDateFilters( ROUTE_FROM );
 	const dashboardLink = useDashboardLink();
 	const [ containerElement, setContainerElement ] = useState< HTMLDivElement | null >( null );
+	const isTableLoading = records.isLoading || records.isFetching;
 
 	return (
 		<ReportPageShell
@@ -108,11 +109,11 @@ function ClicksReport(): JSX.Element {
 					/>
 				) : (
 					<ReportDrilldownTable< ClickRow >
-						data={ records.rows }
+						data={ isTableLoading ? [] : records.rows }
 						fields={ fields }
 						getItemId={ getClickRowId }
 						getItemParentId={ getClickRowParentId }
-						isLoading={ records.isLoading }
+						isLoading={ isTableLoading }
 						initialView={ RECORDS_VIEW }
 						searchLabel={ __( 'Search clicked URLs', 'jetpack-premium-analytics-pkg' ) }
 						hideLevelMarkers

--- a/projects/packages/premium-analytics/routes/reports/clicks/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/clicks/page.tsx
@@ -1,26 +1,20 @@
 /**
  * External dependencies
  */
-import {
-	normalizeReportParams,
-	type IntervalType,
-	type StatsChartBucketPeriod,
-} from '@jetpack-premium-analytics/data';
+import { normalizeReportParams } from '@jetpack-premium-analytics/data';
 import { useDashboardLink, useReportDateFilters } from '@jetpack-premium-analytics/routing';
 import { DateFiltersPanel } from '@jetpack-premium-analytics/ui';
 import {
-	formatLegendLabels,
 	ReportDrilldownTable,
 	ReportErrorState,
 	ReportPageLayout,
 	ReportPageShell,
-	ReportPerformanceChart,
 	useReportRetry,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { Breadcrumbs } from '@wordpress/admin-ui';
-import { useCallback, useMemo, useState } from '@wordpress/element';
+import { useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useNavigate, useSearch } from '@wordpress/route';
+import { useSearch } from '@wordpress/route';
 /**
  * Internal dependencies
  */
@@ -28,40 +22,6 @@ import { route } from '../package.json';
 import { getClicksFields, useClicksReportRecords, type ClickRow } from './config';
 
 const ROUTE_FROM = route.path;
-const REPORT_PARAMS = { report: 'clicks' };
-const CHART_PERIODS = [
-	'day',
-	'week',
-	'month',
-] as const satisfies readonly StatsChartBucketPeriod[];
-
-/**
- * Check whether a URL value is a supported chart period.
- *
- * @param value - The URL search value.
- * @return Whether the value is a chart period.
- */
-function isChartPeriod( value: unknown ): value is StatsChartBucketPeriod {
-	return CHART_PERIODS.includes( value as StatsChartBucketPeriod );
-}
-
-/**
- * Choose the chart bucket period for a report interval.
- *
- * @param interval - The report date interval.
- * @return The default chart bucket period.
- */
-function getDefaultChartPeriod( interval?: IntervalType ): StatsChartBucketPeriod {
-	if ( interval === 'week' ) {
-		return 'week';
-	}
-
-	if ( interval === 'month' || interval === 'quarter' || interval === 'year' ) {
-		return 'month';
-	}
-
-	return 'day';
-}
 
 /**
  * Stable row id for the Clicks records table.
@@ -109,39 +69,11 @@ function ClicksReport(): JSX.Element {
 		[ search ]
 	);
 
-	const chartPeriod = isChartPeriod( search.period )
-		? search.period
-		: getDefaultChartPeriod( reportParams.interval );
-	const records = useClicksReportRecords( reportParams, chartPeriod );
+	const records = useClicksReportRecords( reportParams );
 	const retry = useReportRetry( records.refetch );
-	const fields = useMemo( () => getClicksFields(), [] );
-	const chartMetrics = useMemo(
-		() => [ { key: 'clicks', label: __( 'Clicks', 'jetpack-premium-analytics-pkg' ) } ],
-		[]
-	);
-	const chartLegendLabels = useMemo( () => formatLegendLabels( reportParams ), [ reportParams ] );
-
-	const navigate = useNavigate();
-	const handleIntervalChange = useCallback(
-		( interval: IntervalType ) => {
-			const period = isChartPeriod( interval ) ? interval : getDefaultChartPeriod( interval );
-			navigate( {
-				to: ROUTE_FROM,
-				/*
-				 * The router is built dynamically, so `/reports/$report` has no
-				 * statically-typed params/search schema (tanstack widens them to
-				 * `never`). Cast the same way the routing package does when it
-				 * writes the URL.
-				 */
-				params: REPORT_PARAMS as unknown as never,
-				replace: true,
-				search: ( ( current: Record< string, unknown > ) => ( {
-					...current,
-					period,
-				} ) ) as unknown as never,
-			} );
-		},
-		[ navigate ]
+	const fields = useMemo(
+		() => getClicksFields( records.hasComparison ),
+		[ records.hasComparison ]
 	);
 
 	const dateFilters = useReportDateFilters( ROUTE_FROM );
@@ -175,27 +107,16 @@ function ClicksReport(): JSX.Element {
 						onRetry={ retry }
 					/>
 				) : (
-					<>
-						<ReportPerformanceChart
-							primary={ records.chart.primary }
-							comparison={ records.chart.comparison }
-							isLoading={ records.chart.isLoading }
-							metrics={ chartMetrics }
-							interval={ chartPeriod }
-							onIntervalChange={ handleIntervalChange }
-							legendLabels={ chartLegendLabels }
-						/>
-						<ReportDrilldownTable< ClickRow >
-							data={ records.rows }
-							fields={ fields }
-							getItemId={ getClickRowId }
-							getItemParentId={ getClickRowParentId }
-							isLoading={ records.isLoading }
-							initialView={ RECORDS_VIEW }
-							searchLabel={ __( 'Search clicked URLs', 'jetpack-premium-analytics-pkg' ) }
-							hideLevelMarkers
-						/>
-					</>
+					<ReportDrilldownTable< ClickRow >
+						data={ records.rows }
+						fields={ fields }
+						getItemId={ getClickRowId }
+						getItemParentId={ getClickRowParentId }
+						isLoading={ records.isLoading }
+						initialView={ RECORDS_VIEW }
+						searchLabel={ __( 'Search clicked URLs', 'jetpack-premium-analytics-pkg' ) }
+						hideLevelMarkers
+					/>
 				) }
 			</ReportPageLayout>
 		</ReportPageShell>

--- a/projects/packages/premium-analytics/routes/reports/clicks/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/clicks/page.tsx
@@ -109,7 +109,7 @@ function ClicksReport(): JSX.Element {
 					/>
 				) : (
 					<ReportDrilldownTable< ClickRow >
-						data={ isTableLoading ? [] : records.rows }
+						data={ records.rows }
 						fields={ fields }
 						getItemId={ getClickRowId }
 						getItemParentId={ getClickRowParentId }


### PR DESCRIPTION
## Proposed changes

* Remove the performance chart and its chart-only period handling from the Clicks report.
* Request the summarized Clicks records for the selected date range while preserving grouped and nested clicked URLs.
* Show Clicks period-over-period deltas in the records table when comparison is enabled, including matched nested URLs.
* Keep deltas hidden when comparison is disabled or no matching comparison row exists.

<img width="1850" height="1684" alt="Google Chrome -2026-07-28 at 18 58 04@2x" src="https://github.com/user-attachments/assets/ac35108a-8213-41ef-ae99-b18f95a010aa" />


## Related product discussion/links

* [WOOA7S-1698: Report page: Clicks](https://linear.app/a8c/issue/WOOA7S-1698/report-page-clicks-reportsclicks)

## Does this pull request change what data or activity we track or use?

No. It changes how existing Stats Clicks data is requested and displayed; it does not add or change tracking.

## Testing instructions

* Build Premium Analytics and open **Analytics → Clicks** on a site with Clicks data.
* Select a date preset and enable comparison.
* Verify the page has no performance chart and the table still shows Clicked URL and Clicks columns.
* Verify comparison deltas appear beside Clicks for matching group and nested URL rows.
* Disable comparison and verify the table continues to show Clicks values without deltas.
* Verify grouped URLs retain their nested presentation, safe external links still work, and table search still finds nested URLs.
* Automated verification completed before publication: the affected focused tests, TypeScript checks, lint/formatting checks, and the full dependency-stack build passed.
