### PR TITLE
wpcomsh: sync BLAZE_CREDITS_VOUCHER gating with WordPress.com

### DIFF
--- a/projects/plugins/wpcomsh/changelog/update-wpcomsh-blaze-credits-voucher-all-terms
+++ b/projects/plugins/wpcomsh/changelog/update-wpcomsh-blaze-credits-voucher-all-terms
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync wpcom-features with WordPress.com: BLAZE_CREDITS_VOUCHER no longer requires the gating-business-q1 sticker and now includes the monthly Business and Ecommerce bundles.

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -664,13 +664,14 @@ class WPCOM_Features {
 		),
 		self::BLAZE_CREDITS_VOUCHER             => array(
 			array(
-				'required_sticker' => 'gating-business-q1',
-				// Business (Excluding Monthly).
+				// Business.
 				self::BUSINESS_BUNDLE,
+				self::BUSINESS_BUNDLE_MONTHLY,
 				self::BUSINESS_BUNDLE_2Y,
 				self::BUSINESS_BUNDLE_3Y,
-				// Ecommerce (Excluding Monthly).
+				// Ecommerce.
 				self::ECOMMERCE_BUNDLE,
+				self::ECOMMERCE_BUNDLE_MONTHLY,
 				self::ECOMMERCE_BUNDLE_2Y,
 				self::ECOMMERCE_BUNDLE_3Y,
 			),


### PR DESCRIPTION
## Proposed changes

* Sync `projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php` with the WordPress.com copy: `BLAZE_CREDITS_VOUCHER` no longer requires the `gating-business-q1` sticker and now includes the monthly Business and Ecommerce bundles, so the feature map matches every eligible plan term (monthly, 1y, 2y, 3y).

## Related product discussion/links

* Internal reference: DOTCOM-17871. Companion to the WordPress.com-side change (230012 on the internal wpcom repo) — this keeps the shared wpcom-features file from drifting, as flagged by the sync check there.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* No functional consumer of `BLAZE_CREDITS_VOUCHER` exists in wpcomsh today, so this is a mirror-consistency change: verify the `BLAZE_CREDITS_VOUCHER` entry in `wpcom-features/class-wpcom-features.php` matches the WordPress.com copy after its companion change (no sticker requirement, monthly bundles included).
* `php -l projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php` passes.