### PR TITLE
AI Launchpad: gate wp-admin launchpads on the launchpad-personalization ExPlat variation

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/dotobrd-567-ai-launchpad-integrate-explat-assignments
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotobrd-567-ai-launchpad-integrate-explat-assignments
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Add launchpad-personalization ExPlat gating for the AI Launchpad and old Launchpad in wp-admin.
+AI Launchpad: gate the wp-admin launchpads on the launchpad-personalization ExPlat experiment.

--- a/projects/packages/jetpack-mu-wpcom/changelog/dotobrd-567-ai-launchpad-integrate-explat-assignments
+++ b/projects/packages/jetpack-mu-wpcom/changelog/dotobrd-567-ai-launchpad-integrate-explat-assignments
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add launchpad-personalization ExPlat gating for the AI Launchpad and old Launchpad in wp-admin.

--- a/projects/packages/jetpack-mu-wpcom/src/common/class-launchpad-personalization-experiment.php
+++ b/projects/packages/jetpack-mu-wpcom/src/common/class-launchpad-personalization-experiment.php
@@ -64,6 +64,8 @@ class Launchpad_Personalization_Experiment {
 		if ( ( new Host() )->is_wpcom_simple() ) {
 			// Non-assigning read: rendering wp-admin must never create an assignment.
 			if ( function_exists( '\ExPlat\get_current_user_assignment' ) ) {
+				// The \ExPlat\ helpers live in wpcom, outside this monorepo, so Phan can't see them.
+				// @phan-suppress-next-line PhanUndeclaredFunction
 				return \ExPlat\get_current_user_assignment( self::EXPERIMENT_NAME );
 			}
 			return null;

--- a/projects/packages/jetpack-mu-wpcom/src/common/class-launchpad-personalization-experiment.php
+++ b/projects/packages/jetpack-mu-wpcom/src/common/class-launchpad-personalization-experiment.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Resolves the wpcom_launchpad_personalization_202607_v1 experiment arm server-side.
+ * Resolves the wpcom_launchpad_personalization_202607_v1 experiment variation server-side.
  *
  * @package automattic/jetpack-mu-wpcom
  */
@@ -12,7 +12,7 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Status\Host;
 
 /**
- * Reads the launchpad-personalization arm for the current user.
+ * Reads the launchpad-personalization variation for the current user.
  *
  * Simple sites use the native non-assigning ExPlat read; Atomic sites fetch the
  * assignment over the connected-user REST endpoint (segmentation-bounded). The result
@@ -23,17 +23,17 @@ class Launchpad_Personalization_Experiment {
 	const EXPERIMENT_NAME = 'wpcom_launchpad_personalization_202607_v1';
 
 	/**
-	 * The current user's arm: 'control', 'ai-launchpad', or 'no-guidance'.
+	 * The current user's variation: 'control', 'ai-launchpad', or 'no-guidance'.
 	 *
 	 * @return string
 	 */
-	public static function get_arm() {
+	public static function get_variation() {
 		/**
-		 * Overrides the resolved arm (testing / manual QA). Return one of the arm strings, or null to use ExPlat.
+		 * Overrides the resolved variation (testing / manual QA). Return one of the variation strings, or null to use ExPlat.
 		 *
-		 * @param string|null $override The forced arm, or null.
+		 * @param string|null $override The forced variation, or null.
 		 */
-		$override = apply_filters( 'wpcom_launchpad_personalization_arm', null );
+		$override = apply_filters( 'wpcom_launchpad_personalization_variation', null );
 		if ( null !== $override ) {
 			return self::normalize( $override );
 		}
@@ -43,16 +43,16 @@ class Launchpad_Personalization_Experiment {
 			return 'control';
 		}
 
-		$cache_key = 'launchpad-personalization-arm-' . $user_id;
+		$cache_key = 'launchpad-personalization-variation-' . $user_id;
 		$cached    = get_transient( $cache_key );
 		if ( false !== $cached ) {
 			return (string) $cached;
 		}
 
-		$arm = self::normalize( self::fetch_variation() );
-		set_transient( $cache_key, $arm, HOUR_IN_SECONDS );
+		$variation = self::normalize( self::fetch_variation() );
+		set_transient( $cache_key, $variation, HOUR_IN_SECONDS );
 
-		return $arm;
+		return $variation;
 	}
 
 	/**
@@ -94,7 +94,7 @@ class Launchpad_Personalization_Experiment {
 	}
 
 	/**
-	 * Map any variation onto a known arm; unknown/null becomes 'control'.
+	 * Map any variation onto a known value; unknown/null becomes 'control'.
 	 *
 	 * @param string|null $variation The raw variation name.
 	 * @return string

--- a/projects/packages/jetpack-mu-wpcom/src/common/class-launchpad-personalization-experiment.php
+++ b/projects/packages/jetpack-mu-wpcom/src/common/class-launchpad-personalization-experiment.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Resolves the wpcom_launchpad_personalization_202607_v1 experiment arm server-side.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Status\Host;
+
+/**
+ * Reads the launchpad-personalization arm for the current user.
+ *
+ * Simple sites use the native non-assigning ExPlat read; Atomic sites fetch the
+ * assignment over the connected-user REST endpoint (segmentation-bounded). The result
+ * is transient-cached per user for an hour, mirroring Help_Center::is_menu_panel_enabled().
+ */
+class Launchpad_Personalization_Experiment {
+
+	const EXPERIMENT_NAME = 'wpcom_launchpad_personalization_202607_v1';
+
+	/**
+	 * The current user's arm: 'control', 'ai-launchpad', or 'no-guidance'.
+	 *
+	 * @return string
+	 */
+	public static function get_arm() {
+		/**
+		 * Overrides the resolved arm (testing / manual QA). Return one of the arm strings, or null to use ExPlat.
+		 *
+		 * @param string|null $override The forced arm, or null.
+		 */
+		$override = apply_filters( 'wpcom_launchpad_personalization_arm', null );
+		if ( null !== $override ) {
+			return self::normalize( $override );
+		}
+
+		$user_id = get_current_user_id();
+		if ( ! $user_id ) {
+			return 'control';
+		}
+
+		$cache_key = 'launchpad-personalization-arm-' . $user_id;
+		$cached    = get_transient( $cache_key );
+		if ( false !== $cached ) {
+			return (string) $cached;
+		}
+
+		$arm = self::normalize( self::fetch_variation() );
+		set_transient( $cache_key, $arm, HOUR_IN_SECONDS );
+
+		return $arm;
+	}
+
+	/**
+	 * Fetch the raw variation name from ExPlat, or null.
+	 *
+	 * @return string|null
+	 */
+	private static function fetch_variation() {
+		if ( ( new Host() )->is_wpcom_simple() ) {
+			// Non-assigning read: rendering wp-admin must never create an assignment.
+			if ( function_exists( '\ExPlat\get_current_user_assignment' ) ) {
+				return \ExPlat\get_current_user_assignment( self::EXPERIMENT_NAME );
+			}
+			return null;
+		}
+
+		if ( ! ( new Connection_Manager() )->is_user_connected() ) {
+			return null;
+		}
+
+		// Atomic: no local ExPlat engine — ask wpcom as the connected user.
+		// NOTE: confirm the platform segment ('wpcom') matches how the experiment is registered.
+		$request_path = '/experiments/0.1.0/assignments/wpcom';
+		$response     = Client::wpcom_json_api_request_as_user(
+			add_query_arg( array( 'experiment_name' => self::EXPERIMENT_NAME ), $request_path ),
+			'v2'
+		);
+
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			return null;
+		}
+
+		$data = json_decode( wp_remote_retrieve_body( $response ), true );
+		if ( isset( $data['variations'][ self::EXPERIMENT_NAME ] ) ) {
+			return $data['variations'][ self::EXPERIMENT_NAME ];
+		}
+
+		return null;
+	}
+
+	/**
+	 * Map any variation onto a known arm; unknown/null becomes 'control'.
+	 *
+	 * @param string|null $variation The raw variation name.
+	 * @return string
+	 */
+	private static function normalize( $variation ) {
+		if ( 'ai-launchpad' === $variation || 'no-guidance' === $variation ) {
+			return $variation;
+		}
+		return 'control';
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/common/class-launchpad-personalization-experiment.php
+++ b/projects/packages/jetpack-mu-wpcom/src/common/class-launchpad-personalization-experiment.php
@@ -75,11 +75,11 @@ class Launchpad_Personalization_Experiment {
 			return null;
 		}
 
-		// Atomic: no local ExPlat engine — ask wpcom as the connected user.
-		// NOTE: confirm the platform segment ('wpcom') matches how the experiment is registered.
-		$request_path = '/experiments/0.1.0/assignments/wpcom';
+		// Atomic: no local ExPlat engine — ask wpcom as the connected user. The experiment is
+		// registered on the `calypso` platform, so the assignment must be fetched from there.
+		$request_path = '/experiments/0.1.0/assignments/calypso';
 		$response     = Client::wpcom_json_api_request_as_user(
-			add_query_arg( array( 'experiment_name' => self::EXPERIMENT_NAME ), $request_path ),
+			add_query_arg( array( 'experiment_names' => self::EXPERIMENT_NAME ), $request_path ),
 			'v2'
 		);
 

--- a/projects/packages/jetpack-mu-wpcom/src/common/class-launchpad-personalization-experiment.php
+++ b/projects/packages/jetpack-mu-wpcom/src/common/class-launchpad-personalization-experiment.php
@@ -23,7 +23,7 @@ class Launchpad_Personalization_Experiment {
 	const EXPERIMENT_NAME = 'wpcom_launchpad_personalization_202607_v1';
 
 	/**
-	 * The current user's variation: 'control', 'ai-launchpad', or 'no-guidance'.
+	 * The current user's variation: 'control', 'ai_launchpad', or 'no_guidance'.
 	 *
 	 * @return string
 	 */
@@ -100,7 +100,7 @@ class Launchpad_Personalization_Experiment {
 	 * @return string
 	 */
 	private static function normalize( $variation ) {
-		if ( 'ai-launchpad' === $variation || 'no-guidance' === $variation ) {
+		if ( 'ai_launchpad' === $variation || 'no_guidance' === $variation ) {
 			return $variation;
 		}
 		return 'control';

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
@@ -12,6 +12,7 @@ use Automattic\Jetpack\WP_Build_Polyfills\WP_Build_Polyfills;
 
 // helpers.php defines the shared option reader the listeners depend on, so it loads first.
 require_once __DIR__ . '/helpers.php';
+require_once __DIR__ . '/../../common/class-launchpad-personalization-experiment.php';
 require_once __DIR__ . '/eligibility.php';
 require_once __DIR__ . '/class-ai-launchpad-memberships.php';
 require_once __DIR__ . '/class-ai-launchpad-task-registry.php';
@@ -110,7 +111,13 @@ class AI_Launchpad {
 	 * @return bool
 	 */
 	private static function is_enabled_for_site() {
-		return (bool) get_option( 'wpcom_ai_launchpad_enabled' );
+		// Legacy per-site switch kept as a manual/dev override: the ?enable-ai-launchpad=1
+		// handler and the onboarding hand-off both set this option.
+		if ( (bool) get_option( 'wpcom_ai_launchpad_enabled' ) ) {
+			return true;
+		}
+
+		return 'ai-launchpad' === Launchpad_Personalization_Experiment::get_arm();
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
@@ -117,7 +117,7 @@ class AI_Launchpad {
 			return true;
 		}
 
-		return 'ai-launchpad' === Launchpad_Personalization_Experiment::get_variation();
+		return 'ai_launchpad' === Launchpad_Personalization_Experiment::get_variation();
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
@@ -117,7 +117,7 @@ class AI_Launchpad {
 			return true;
 		}
 
-		return 'ai-launchpad' === Launchpad_Personalization_Experiment::get_arm();
+		return 'ai-launchpad' === Launchpad_Personalization_Experiment::get_variation();
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -753,21 +753,21 @@ if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 
 /**
  * Filter for `get_option( 'launchpad_screen' )`: hide the old Launchpad for the
- * launchpad-personalization treatment arms. Derives from the arm rather than writing
- * the option, so no non-experiment site is ever mistaken for a cohort. Runs on Simple
- * and Atomic (not gated on IS_WPCOM).
+ * launchpad-personalization treatment variations. Derives from the variation rather than
+ * writing the option, so no non-experiment site is ever mistaken for a cohort. Runs on
+ * Simple and Atomic (not gated on IS_WPCOM).
  *
  * @param mixed $value The filterable option value, retrieved from the DB.
- * @return mixed 'off' for a treatment arm, the unaltered value otherwise.
+ * @return mixed 'off' for a treatment variation, the unaltered value otherwise.
  */
 function wpcom_maybe_disable_for_launchpad_personalization( $value ) {
-	// If it's already false, leave it — and avoid resolving the arm needlessly.
+	// If it's already false, leave it — and avoid resolving the variation needlessly.
 	if ( $value === false ) {
 		return $value;
 	}
 
-	$arm = \Automattic\Jetpack\Jetpack_Mu_Wpcom\Launchpad_Personalization_Experiment::get_arm();
-	if ( 'ai-launchpad' === $arm || 'no-guidance' === $arm ) {
+	$variation = \Automattic\Jetpack\Jetpack_Mu_Wpcom\Launchpad_Personalization_Experiment::get_variation();
+	if ( 'ai-launchpad' === $variation || 'no-guidance' === $variation ) {
 		return 'off';
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -21,6 +21,7 @@
 PHAN;
 
 require_once __DIR__ . '/../../utils.php';
+require_once __DIR__ . '/../../common/class-launchpad-personalization-experiment.php';
 require_once __DIR__ . '/class-launchpad-task-lists.php';
 require_once __DIR__ . '/launchpad-task-definitions.php';
 
@@ -749,6 +750,30 @@ function wpcom_maybe_disable_for_difm( $value ) {
 if ( defined( 'IS_WPCOM' ) && IS_WPCOM ) {
 	add_filter( 'option_launchpad_screen', 'wpcom_maybe_disable_for_difm' );
 }
+
+/**
+ * Filter for `get_option( 'launchpad_screen' )`: hide the old Launchpad for the
+ * launchpad-personalization treatment arms. Derives from the arm rather than writing
+ * the option, so no non-experiment site is ever mistaken for a cohort. Runs on Simple
+ * and Atomic (not gated on IS_WPCOM).
+ *
+ * @param mixed $value The filterable option value, retrieved from the DB.
+ * @return mixed 'off' for a treatment arm, the unaltered value otherwise.
+ */
+function wpcom_maybe_disable_for_launchpad_personalization( $value ) {
+	// If it's already false, leave it — and avoid resolving the arm needlessly.
+	if ( $value === false ) {
+		return $value;
+	}
+
+	$arm = \Automattic\Jetpack\Jetpack_Mu_Wpcom\Launchpad_Personalization_Experiment::get_arm();
+	if ( 'ai-launchpad' === $arm || 'no-guidance' === $arm ) {
+		return 'off';
+	}
+
+	return $value;
+}
+add_filter( 'option_launchpad_screen', 'wpcom_maybe_disable_for_launchpad_personalization' );
 
 add_action( 'wp_head', 'wpcom_maybe_preview_with_no_interactions', PHP_INT_MAX );
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/launchpad/launchpad.php
@@ -767,7 +767,7 @@ function wpcom_maybe_disable_for_launchpad_personalization( $value ) {
 	}
 
 	$variation = \Automattic\Jetpack\Jetpack_Mu_Wpcom\Launchpad_Personalization_Experiment::get_variation();
-	if ( 'ai-launchpad' === $variation || 'no-guidance' === $variation ) {
+	if ( 'ai_launchpad' === $variation || 'no_guidance' === $variation ) {
 		return 'off';
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/common/Launchpad_Personalization_Experiment_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/common/Launchpad_Personalization_Experiment_Test.php
@@ -43,8 +43,8 @@ class Launchpad_Personalization_Experiment_Test extends \WorDBless\BaseTestCase 
 			)
 		);
 		wp_set_current_user( $user_id );
-		add_filter( 'wpcom_launchpad_personalization_variation', fn() => 'no-guidance' );
-		$this->assertSame( 'no-guidance', Launchpad_Personalization_Experiment::get_variation() );
+		add_filter( 'wpcom_launchpad_personalization_variation', fn() => 'no_guidance' );
+		$this->assertSame( 'no_guidance', Launchpad_Personalization_Experiment::get_variation() );
 	}
 
 	public function test_unknown_override_normalizes_to_control() {

--- a/projects/packages/jetpack-mu-wpcom/tests/php/common/Launchpad_Personalization_Experiment_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/common/Launchpad_Personalization_Experiment_Test.php
@@ -17,11 +17,6 @@ require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/common/class-launchpad-personaliza
 #[CoversClass( Launchpad_Personalization_Experiment::class )]
 class Launchpad_Personalization_Experiment_Test extends \WorDBless\BaseTestCase {
 
-	public function set_up() {
-		parent::set_up();
-		delete_transient( 'launchpad-personalization-variation-' . get_current_user_id() );
-	}
-
 	public function tear_down() {
 		remove_all_filters( 'wpcom_launchpad_personalization_variation' );
 		wp_set_current_user( 0 );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/common/Launchpad_Personalization_Experiment_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/common/Launchpad_Personalization_Experiment_Test.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Tests for Launchpad_Personalization_Experiment.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+use Automattic\Jetpack\Jetpack_Mu_Wpcom\Launchpad_Personalization_Experiment;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/common/class-launchpad-personalization-experiment.php';
+
+/**
+ * @covers \Automattic\Jetpack\Jetpack_Mu_Wpcom\Launchpad_Personalization_Experiment
+ */
+#[CoversClass( Launchpad_Personalization_Experiment::class )]
+class Launchpad_Personalization_Experiment_Test extends \WorDBless\BaseTestCase {
+
+	public function set_up() {
+		parent::set_up();
+		delete_transient( 'launchpad-personalization-arm-' . get_current_user_id() );
+	}
+
+	public function tear_down() {
+		remove_all_filters( 'wpcom_launchpad_personalization_arm' );
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	public function test_returns_control_without_a_logged_in_user() {
+		wp_set_current_user( 0 );
+		$this->assertSame( 'control', Launchpad_Personalization_Experiment::get_arm() );
+	}
+
+	public function test_override_filter_wins() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'lpe_override_user',
+				'user_pass'  => 'password',
+				'user_email' => 'lpe_override_user@example.com',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+		add_filter( 'wpcom_launchpad_personalization_arm', fn() => 'no-guidance' );
+		$this->assertSame( 'no-guidance', Launchpad_Personalization_Experiment::get_arm() );
+	}
+
+	public function test_unknown_override_normalizes_to_control() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'lpe_unknown_user',
+				'user_pass'  => 'password',
+				'user_email' => 'lpe_unknown_user@example.com',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+		add_filter( 'wpcom_launchpad_personalization_arm', fn() => 'bogus' );
+		$this->assertSame( 'control', Launchpad_Personalization_Experiment::get_arm() );
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/common/Launchpad_Personalization_Experiment_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/common/Launchpad_Personalization_Experiment_Test.php
@@ -19,18 +19,18 @@ class Launchpad_Personalization_Experiment_Test extends \WorDBless\BaseTestCase 
 
 	public function set_up() {
 		parent::set_up();
-		delete_transient( 'launchpad-personalization-arm-' . get_current_user_id() );
+		delete_transient( 'launchpad-personalization-variation-' . get_current_user_id() );
 	}
 
 	public function tear_down() {
-		remove_all_filters( 'wpcom_launchpad_personalization_arm' );
+		remove_all_filters( 'wpcom_launchpad_personalization_variation' );
 		wp_set_current_user( 0 );
 		parent::tear_down();
 	}
 
 	public function test_returns_control_without_a_logged_in_user() {
 		wp_set_current_user( 0 );
-		$this->assertSame( 'control', Launchpad_Personalization_Experiment::get_arm() );
+		$this->assertSame( 'control', Launchpad_Personalization_Experiment::get_variation() );
 	}
 
 	public function test_override_filter_wins() {
@@ -43,8 +43,8 @@ class Launchpad_Personalization_Experiment_Test extends \WorDBless\BaseTestCase 
 			)
 		);
 		wp_set_current_user( $user_id );
-		add_filter( 'wpcom_launchpad_personalization_arm', fn() => 'no-guidance' );
-		$this->assertSame( 'no-guidance', Launchpad_Personalization_Experiment::get_arm() );
+		add_filter( 'wpcom_launchpad_personalization_variation', fn() => 'no-guidance' );
+		$this->assertSame( 'no-guidance', Launchpad_Personalization_Experiment::get_variation() );
 	}
 
 	public function test_unknown_override_normalizes_to_control() {
@@ -57,7 +57,7 @@ class Launchpad_Personalization_Experiment_Test extends \WorDBless\BaseTestCase 
 			)
 		);
 		wp_set_current_user( $user_id );
-		add_filter( 'wpcom_launchpad_personalization_arm', fn() => 'bogus' );
-		$this->assertSame( 'control', Launchpad_Personalization_Experiment::get_arm() );
+		add_filter( 'wpcom_launchpad_personalization_variation', fn() => 'bogus' );
+		$this->assertSame( 'control', Launchpad_Personalization_Experiment::get_variation() );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Eligibility_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Eligibility_Test.php
@@ -31,6 +31,7 @@ class AI_Launchpad_Eligibility_Test extends \WorDBless\BaseTestCase {
 	 * Tear down.
 	 */
 	public function tear_down() {
+		remove_all_filters( 'wpcom_launchpad_personalization_arm' );
 		\Brain\Monkey\tearDown();
 		parent::tear_down();
 	}
@@ -81,5 +82,58 @@ class AI_Launchpad_Eligibility_Test extends \WorDBless\BaseTestCase {
 			'onboarded blocks' => array( true, true, false, false ),
 			'dismissed blocks' => array( false, true, true, false ),
 		);
+	}
+
+	/**
+	 * The ai-launchpad arm makes the site eligible without the legacy option.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_ai_launchpad_arm_makes_the_site_eligible() {
+		add_filter( 'wpcom_launchpad_personalization_arm', fn() => 'ai-launchpad' );
+		$this->assertTrue( AI_Launchpad::is_eligible() );
+	}
+
+	/**
+	 * The no-guidance arm is not eligible for the AI Launchpad.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_no_guidance_arm_is_not_eligible() {
+		add_filter( 'wpcom_launchpad_personalization_arm', fn() => 'no-guidance' );
+		$this->assertFalse( AI_Launchpad::is_eligible() );
+	}
+
+	/**
+	 * The control arm without the legacy option is not eligible.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_control_without_legacy_option_is_not_eligible() {
+		add_filter( 'wpcom_launchpad_personalization_arm', fn() => 'control' );
+		$this->assertFalse( AI_Launchpad::is_eligible() );
+	}
+
+	/**
+	 * The legacy per-site option still enables the AI Launchpad as a dev override.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_legacy_option_still_enables_as_a_dev_override() {
+		add_filter( 'wpcom_launchpad_personalization_arm', fn() => 'control' );
+		update_option( 'wpcom_ai_launchpad_enabled', 1 );
+		$this->assertTrue( AI_Launchpad::is_eligible() );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Eligibility_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Eligibility_Test.php
@@ -31,7 +31,7 @@ class AI_Launchpad_Eligibility_Test extends \WorDBless\BaseTestCase {
 	 * Tear down.
 	 */
 	public function tear_down() {
-		remove_all_filters( 'wpcom_launchpad_personalization_arm' );
+		remove_all_filters( 'wpcom_launchpad_personalization_variation' );
 		\Brain\Monkey\tearDown();
 		parent::tear_down();
 	}
@@ -85,33 +85,33 @@ class AI_Launchpad_Eligibility_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * The ai-launchpad arm makes the site eligible without the legacy option.
+	 * The ai-launchpad variation makes the site eligible without the legacy option.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
-	public function test_ai_launchpad_arm_makes_the_site_eligible() {
-		add_filter( 'wpcom_launchpad_personalization_arm', fn() => 'ai-launchpad' );
+	public function test_ai_launchpad_variation_makes_the_site_eligible() {
+		add_filter( 'wpcom_launchpad_personalization_variation', fn() => 'ai-launchpad' );
 		$this->assertTrue( AI_Launchpad::is_eligible() );
 	}
 
 	/**
-	 * The no-guidance arm is not eligible for the AI Launchpad.
+	 * The no-guidance variation is not eligible for the AI Launchpad.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
-	public function test_no_guidance_arm_is_not_eligible() {
-		add_filter( 'wpcom_launchpad_personalization_arm', fn() => 'no-guidance' );
+	public function test_no_guidance_variation_is_not_eligible() {
+		add_filter( 'wpcom_launchpad_personalization_variation', fn() => 'no-guidance' );
 		$this->assertFalse( AI_Launchpad::is_eligible() );
 	}
 
 	/**
-	 * The control arm without the legacy option is not eligible.
+	 * The control variation without the legacy option is not eligible.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
@@ -119,7 +119,7 @@ class AI_Launchpad_Eligibility_Test extends \WorDBless\BaseTestCase {
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
 	public function test_control_without_legacy_option_is_not_eligible() {
-		add_filter( 'wpcom_launchpad_personalization_arm', fn() => 'control' );
+		add_filter( 'wpcom_launchpad_personalization_variation', fn() => 'control' );
 		$this->assertFalse( AI_Launchpad::is_eligible() );
 	}
 
@@ -132,7 +132,7 @@ class AI_Launchpad_Eligibility_Test extends \WorDBless\BaseTestCase {
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
 	public function test_legacy_option_still_enables_as_a_dev_override() {
-		add_filter( 'wpcom_launchpad_personalization_arm', fn() => 'control' );
+		add_filter( 'wpcom_launchpad_personalization_variation', fn() => 'control' );
 		update_option( 'wpcom_ai_launchpad_enabled', 1 );
 		$this->assertTrue( AI_Launchpad::is_eligible() );
 	}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Eligibility_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Eligibility_Test.php
@@ -93,7 +93,7 @@ class AI_Launchpad_Eligibility_Test extends \WorDBless\BaseTestCase {
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
 	public function test_ai_launchpad_variation_makes_the_site_eligible() {
-		add_filter( 'wpcom_launchpad_personalization_variation', fn() => 'ai-launchpad' );
+		add_filter( 'wpcom_launchpad_personalization_variation', fn() => 'ai_launchpad' );
 		$this->assertTrue( AI_Launchpad::is_eligible() );
 	}
 
@@ -106,7 +106,7 @@ class AI_Launchpad_Eligibility_Test extends \WorDBless\BaseTestCase {
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
 	public function test_no_guidance_variation_is_not_eligible() {
-		add_filter( 'wpcom_launchpad_personalization_variation', fn() => 'no-guidance' );
+		add_filter( 'wpcom_launchpad_personalization_variation', fn() => 'no_guidance' );
 		$this->assertFalse( AI_Launchpad::is_eligible() );
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/Launchpad_Personalization_Screen_Filter_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/Launchpad_Personalization_Screen_Filter_Test.php
@@ -12,20 +12,20 @@ require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/launchpad/launchpad.php';
 class Launchpad_Personalization_Screen_Filter_Test extends \WorDBless\BaseTestCase {
 
 	public function tear_down() {
-		remove_all_filters( 'wpcom_launchpad_personalization_arm' );
+		remove_all_filters( 'wpcom_launchpad_personalization_variation' );
 		parent::tear_down();
 	}
 
-	public function test_ai_launchpad_arm_forces_off() {
-		add_filter( 'wpcom_launchpad_personalization_arm', fn() => 'ai-launchpad' );
+	public function test_ai_launchpad_variation_forces_off() {
+		add_filter( 'wpcom_launchpad_personalization_variation', fn() => 'ai-launchpad' );
 		$this->assertSame(
 			'off',
 			wpcom_maybe_disable_for_launchpad_personalization( 'full' )
 		);
 	}
 
-	public function test_no_guidance_arm_forces_off() {
-		add_filter( 'wpcom_launchpad_personalization_arm', fn() => 'no-guidance' );
+	public function test_no_guidance_variation_forces_off() {
+		add_filter( 'wpcom_launchpad_personalization_variation', fn() => 'no-guidance' );
 		$this->assertSame(
 			'off',
 			wpcom_maybe_disable_for_launchpad_personalization( 'full' )
@@ -33,14 +33,14 @@ class Launchpad_Personalization_Screen_Filter_Test extends \WorDBless\BaseTestCa
 	}
 
 	public function test_control_passes_the_value_through() {
-		add_filter( 'wpcom_launchpad_personalization_arm', fn() => 'control' );
+		add_filter( 'wpcom_launchpad_personalization_variation', fn() => 'control' );
 		$this->assertSame(
 			'full',
 			wpcom_maybe_disable_for_launchpad_personalization( 'full' )
 		);
 	}
 
-	public function test_false_short_circuits_before_resolving_the_arm() {
+	public function test_false_short_circuits_before_resolving_the_variation() {
 		$this->assertFalse( wpcom_maybe_disable_for_launchpad_personalization( false ) );
 	}
 }

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/Launchpad_Personalization_Screen_Filter_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/Launchpad_Personalization_Screen_Filter_Test.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Tests for the launchpad_screen personalization filter.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/launchpad/launchpad.php';
+
+class Launchpad_Personalization_Screen_Filter_Test extends \WorDBless\BaseTestCase {
+
+	public function tear_down() {
+		remove_all_filters( 'wpcom_launchpad_personalization_arm' );
+		parent::tear_down();
+	}
+
+	public function test_ai_launchpad_arm_forces_off() {
+		add_filter( 'wpcom_launchpad_personalization_arm', fn() => 'ai-launchpad' );
+		$this->assertSame(
+			'off',
+			wpcom_maybe_disable_for_launchpad_personalization( 'full' )
+		);
+	}
+
+	public function test_no_guidance_arm_forces_off() {
+		add_filter( 'wpcom_launchpad_personalization_arm', fn() => 'no-guidance' );
+		$this->assertSame(
+			'off',
+			wpcom_maybe_disable_for_launchpad_personalization( 'full' )
+		);
+	}
+
+	public function test_control_passes_the_value_through() {
+		add_filter( 'wpcom_launchpad_personalization_arm', fn() => 'control' );
+		$this->assertSame(
+			'full',
+			wpcom_maybe_disable_for_launchpad_personalization( 'full' )
+		);
+	}
+
+	public function test_false_short_circuits_before_resolving_the_arm() {
+		$this->assertFalse( wpcom_maybe_disable_for_launchpad_personalization( false ) );
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/Launchpad_Personalization_Screen_Filter_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/launchpad/Launchpad_Personalization_Screen_Filter_Test.php
@@ -17,7 +17,7 @@ class Launchpad_Personalization_Screen_Filter_Test extends \WorDBless\BaseTestCa
 	}
 
 	public function test_ai_launchpad_variation_forces_off() {
-		add_filter( 'wpcom_launchpad_personalization_variation', fn() => 'ai-launchpad' );
+		add_filter( 'wpcom_launchpad_personalization_variation', fn() => 'ai_launchpad' );
 		$this->assertSame(
 			'off',
 			wpcom_maybe_disable_for_launchpad_personalization( 'full' )
@@ -25,7 +25,7 @@ class Launchpad_Personalization_Screen_Filter_Test extends \WorDBless\BaseTestCa
 	}
 
 	public function test_no_guidance_variation_forces_off() {
-		add_filter( 'wpcom_launchpad_personalization_variation', fn() => 'no-guidance' );
+		add_filter( 'wpcom_launchpad_personalization_variation', fn() => 'no_guidance' );
 		$this->assertSame(
 			'off',
 			wpcom_maybe_disable_for_launchpad_personalization( 'full' )


### PR DESCRIPTION
Part of DOTOBRD-567

## Proposed changes

Gate the wp-admin launchpads on the `wpcom_launchpad_personalization_202607_v1` ExPlat experiment. Three variations: `control` (today's experience), `ai_launchpad` (AI Launchpad shown, old Launchpad hidden), and `no_guidance` (no launchpads at all).

* Add `Launchpad_Personalization_Experiment` (`src/common/`): resolves the variation for the current user — Simple via the native non-assigning `\ExPlat\get_current_user_assignment()`, Atomic via the connected-user assignments REST endpoint — transient-cached per user, with a `wpcom_launchpad_personalization_variation` override filter for testing/QA. Mirrors the Simple/Atomic split in `Help_Center::is_menu_panel_enabled()`.
* AI Launchpad: gate eligibility on the `ai_launchpad` variation. The legacy `wpcom_ai_launchpad_enabled` option is kept as a manual/dev override, so `?enable-ai-launchpad=1` still works.
* Old Launchpad: add an `option_launchpad_screen` filter that returns `off` for both treatment variations, hiding it in Calypso and wp-admin. It is derived from the variation (no option write) and runs on Simple and Atomic (not gated on `IS_WPCOM`).

Additive only — no existing launchpad code is changed.

## Related product discussion/links

* DOTOBRD-567

## Does this pull request change what data or activity we track or use?

No new data collection. Reads existing ExPlat experiment assignments; only standard experiment exposure applies.

## Testing instructions

* Force a variation with the `wpcom_launchpad_personalization_variation` filter (return `'ai_launchpad'`, `'no_guidance'`, or `'control'`).
* AI Launchpad menu (`admin.php?page=site-setup-wp-admin`): visible for `ai_launchpad`; hidden for `no_guidance` and `control` (unless the legacy `wpcom_ai_launchpad_enabled` option is set).
* Old Launchpad: with `launchpad_screen` set to `full`, confirm it is suppressed under `ai_launchpad` and `no_guidance`, and unaffected under `control`.
* Run the unit tests: `composer phpunit -- --filter "Launchpad_Personalization|AI_Launchpad_Eligibility"` (15 passing).

One item to confirm before rollout: the Atomic REST `platform` segment (`/assignments/wpcom`) must match how the experiment is registered.

Companion Calypso PR: https://github.com/Automattic/wp-calypso/pull/112953
