### PR TITLE
Enable React 19 on 1% of Atomic sites, add disabling sticker

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-gutenberg-react-19-segment
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-gutenberg-react-19-segment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Gutenberg: Enable the React 19 experiment on 1% of Atomic sites, with a blog sticker opt-out.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -109,7 +109,7 @@ class Jetpack_Mu_Wpcom {
 		add_filter( 'option_gutenberg-experiments', array( __CLASS__, 'enable_gutenberg_classic_block_deprecation_experiment' ) );
 		add_filter( 'default_option_gutenberg-experiments', array( __CLASS__, 'enable_gutenberg_classic_block_deprecation_experiment' ) );
 
-		// Enable the `gutenberg-react-19` Gutenberg experiment for sites with the `gutenberg-react-19` blog sticker.
+		// Enable the `gutenberg-react-19` Gutenberg experiment on selected sites.
 		add_filter( 'option_gutenberg-experiments', array( __CLASS__, 'enable_gutenberg_react_19_experiment' ) );
 		add_filter( 'default_option_gutenberg-experiments', array( __CLASS__, 'enable_gutenberg_react_19_experiment' ) );
 
@@ -873,13 +873,44 @@ class Jetpack_Mu_Wpcom {
 
 	/**
 	 * Add `gutenberg-react-19` to the list of enabled Gutenberg experiments.
-	 * Only sites with the `gutenberg-react-19` blog sticker are opted in.
+	 *
+	 * The `disable-gutenberg-react-19` blog sticker force-disables the experiment,
+	 * the `gutenberg-react-19` sticker opts the site in. With neither sticker,
+	 * the experiment is enabled on 1% of Atomic sites.
 	 *
 	 * @param mixed $experiments The current value of the gutenberg-experiments option.
 	 * @return mixed Original option value or the filtered experiments.
 	 */
 	public static function enable_gutenberg_react_19_experiment( $experiments ) {
-		if ( ! wpcom_has_blog_sticker( 'gutenberg-react-19', get_wpcom_blog_id() ) ) {
+		$blog_id = get_wpcom_blog_id();
+
+		if ( wpcom_has_blog_sticker( 'disable-gutenberg-react-19', $blog_id ) ) {
+			return $experiments;
+		}
+
+		$is_enabled = wpcom_has_blog_sticker( 'gutenberg-react-19', $blog_id );
+
+		if ( ! $is_enabled && function_exists( 'wpcomsh_get_atomic_site_id' ) ) {
+			$site_id = wpcomsh_get_atomic_site_id();
+
+			// Don't enable if the site ID is unknown (zero).
+			if ( ! $site_id ) {
+				$is_enabled = false;
+			} else {
+				$current_segment = 1; // Segment of Atomic sites in the experiment, in %.
+				$site_segment    = $site_id % 100;
+
+				/*
+				 * Sites whose Atomic site ID ends in digits < $current_segment are in the segment.
+				 * Must stay in sync with the error reporting rollout in wpcomsh
+				 * (wpcomsh_enable_error_reporting_for_react_19), so that every site in
+				 * the experiment also reports JS errors.
+				 */
+				$is_enabled = $site_segment < $current_segment;
+			}
+		}
+
+		if ( ! $is_enabled ) {
 			return $experiments;
 		}
 


### PR DESCRIPTION
Enables React 19 on 1% of Atomic sites, and uses a a new `disable-gutenberg-react-19` blog sticker as an emergency measure. There is now three state logic:

- A/B-style logic that enables React 19 on 1% of sites, regardless of stickers
- toggling the `disable-gutenberg-react-19` sticker on a blog RC immediately disables it, in emergency situations
- toggling the `gutenberg-react-19` sticker enables it manually, regardless of the A/B assignment

The wpcom-230299 PR must be landed first in order to start syncing the `disable-gutenberg-react-19` to Atomic sites.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Enable Jetpack from this branch on a test Atomic site using the Jetpack Beta plugin, verify that the sticker works and doesn't crash.