### PR TITLE
Search: fix uncaught URIError from malformed query params crashing Instant Search

### DIFF
--- a/projects/packages/search/changelog/2026-07-24-11-47-37-471417
+++ b/projects/packages/search/changelog/2026-07-24-11-47-37-471417
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: fix uncaught error when a malformed query string parameter (invalid percent-encoding) crashed Instant Search initialization

--- a/projects/packages/search/src/instant-search/external/query-string-decode.js
+++ b/projects/packages/search/src/instant-search/external/query-string-decode.js
@@ -1,24 +1,16 @@
 // These two functions are a temporary addition while we wait for @jsnmoon's PR
 // to be merged into the qss package: https://github.com/lukeed/qss/pull/8
-
-// Signals a value that's still undecodable after sanitizing bare `%`; decode() drops that key
-// rather than keep a still-encoded string that would get double-encoded by qss's encode() later.
-const MALFORMED = Symbol( 'malformed-query-value' );
-
-// A `%` not starting a valid `%XX` escape (bare `%`, or an unresolved merge tag like `%DONOR%`).
-// Escaping it to `%25` before decoding recovers the value as plain text instead of throwing.
-const BARE_PERCENT = /%(?![0-9A-Fa-f]{2})/g;
-
 function toValue( mix, tcBools, tcNumbers ) {
 	if ( ! mix ) {
 		return '';
 	}
 	let str;
 	try {
-		str = decodeURIComponent( mix.replace( BARE_PERCENT, '%25' ) );
+		str = decodeURIComponent( mix );
 	} catch {
-		// Only reachable for well-formed-but-undecodable escapes, e.g. a truncated UTF-8 sequence.
-		return MALFORMED;
+		// Malformed percent-encoding (e.g. an unresolved email merge tag) can't be decoded;
+		// treat it as an empty value rather than crash Instant Search init (#50709).
+		return '';
 	}
 	if ( tcBools && str === 'false' ) {
 		return false;
@@ -41,14 +33,10 @@ export function decode( str, tcBools, tcNumbers ) {
 	while ( ( tmp = arr.shift() ) ) {
 		tmp = tmp.split( '=' );
 		k = tmp.shift();
-		const value = toValue( tmp.shift(), tcBools, tcNumbers );
-		if ( value === MALFORMED ) {
-			continue; // Drop rather than crash init (#50709) or keep an unsafe-to-re-encode value.
-		}
 		if ( out[ k ] !== void 0 ) {
-			out[ k ] = [].concat( out[ k ], value );
+			out[ k ] = [].concat( out[ k ], toValue( tmp.shift(), tcBools, tcNumbers ) );
 		} else {
-			out[ k ] = value;
+			out[ k ] = toValue( tmp.shift(), tcBools, tcNumbers );
 		}
 	}
 

--- a/projects/packages/search/src/instant-search/external/query-string-decode.js
+++ b/projects/packages/search/src/instant-search/external/query-string-decode.js
@@ -1,10 +1,25 @@
 // These two functions are a temporary addition while we wait for @jsnmoon's PR
 // to be merged into the qss package: https://github.com/lukeed/qss/pull/8
+
+// Signals a value that's still undecodable after sanitizing bare `%`; decode() drops that key
+// rather than keep a still-encoded string that would get double-encoded by qss's encode() later.
+const MALFORMED = Symbol( 'malformed-query-value' );
+
+// A `%` not starting a valid `%XX` escape (bare `%`, or an unresolved merge tag like `%DONOR%`).
+// Escaping it to `%25` before decoding recovers the value as plain text instead of throwing.
+const BARE_PERCENT = /%(?![0-9A-Fa-f]{2})/g;
+
 function toValue( mix, tcBools, tcNumbers ) {
 	if ( ! mix ) {
 		return '';
 	}
-	const str = decodeURIComponent( mix );
+	let str;
+	try {
+		str = decodeURIComponent( mix.replace( BARE_PERCENT, '%25' ) );
+	} catch {
+		// Only reachable for well-formed-but-undecodable escapes, e.g. a truncated UTF-8 sequence.
+		return MALFORMED;
+	}
 	if ( tcBools && str === 'false' ) {
 		return false;
 	}
@@ -26,10 +41,14 @@ export function decode( str, tcBools, tcNumbers ) {
 	while ( ( tmp = arr.shift() ) ) {
 		tmp = tmp.split( '=' );
 		k = tmp.shift();
+		const value = toValue( tmp.shift(), tcBools, tcNumbers );
+		if ( value === MALFORMED ) {
+			continue; // Drop rather than crash init (#50709) or keep an unsafe-to-re-encode value.
+		}
 		if ( out[ k ] !== void 0 ) {
-			out[ k ] = [].concat( out[ k ], toValue( tmp.shift(), tcBools, tcNumbers ) );
+			out[ k ] = [].concat( out[ k ], value );
 		} else {
-			out[ k ] = toValue( tmp.shift(), tcBools, tcNumbers );
+			out[ k ] = value;
 		}
 	}
 

--- a/projects/packages/search/src/instant-search/external/test/query-string-decode.test.js
+++ b/projects/packages/search/src/instant-search/external/test/query-string-decode.test.js
@@ -10,27 +10,32 @@ describe( 'decode', () => {
 		expect( () => decode( 'x=100%' ) ).not.toThrow();
 		expect( () => decode( 'x=%' ) ).not.toThrow();
 		expect( () => decode( 'x=%zz' ) ).not.toThrow();
+		// Regression: a merge tag that happens to look hex-like (A-F) after the `%`.
+		expect( () => decode( 'x=%ABTEST%' ) ).not.toThrow();
 	} );
 
-	test( 'recovers bare/invalid percent escapes as literal text instead of dropping them', () => {
-		// e.g. an unresolved email merge tag like `%DONOR%` — kept as plain text.
-		expect( decode( 's=%MALFORMED%' ) ).toEqual( { s: '%MALFORMED%' } );
-		expect( decode( 'x=100%' ) ).toEqual( { x: '100%' } );
-		expect( decode( 'x=%' ) ).toEqual( { x: '%' } );
-		expect( decode( 'x=%zz' ) ).toEqual( { x: '%zz' } );
+	test( 'treats any malformed value as empty, uniformly', () => {
+		// Uniform regardless of what follows the `%` — no partial recovery, no special cases.
+		expect( decode( 'x=%MALFORMED%' ) ).toEqual( { x: '' } );
+		expect( decode( 'x=100%' ) ).toEqual( { x: '' } );
+		expect( decode( 'x=%' ) ).toEqual( { x: '' } );
+		expect( decode( 'x=%zz' ) ).toEqual( { x: '' } );
+		expect( decode( 'x=%ABTEST%' ) ).toEqual( { x: '' } );
 	} );
 
-	test( 'drops a key only for a well-formed-but-undecodable escape', () => {
-		// %E0%A4: a valid %XX pair (untouched by sanitizing) that's a truncated UTF-8 sequence.
-		expect( decode( 'x=%E0%A4' ) ).toEqual( {} );
-	} );
-
-	test( 'drops only the malformed key, keeping other well-formed keys intact', () => {
-		expect( decode( 's=foo&bad=%E0%A4&sort=date' ) ).toEqual( { s: 'foo', sort: 'date' } );
+	test( 'keeps the key present (as an empty value) rather than dropping it', () => {
+		// So a malformed search term still registers as an active query (see #50709 follow-up)
+		// instead of Instant Search treating the page as having no search at all.
+		expect( decode( 's=%MALFORMED%&sort=date' ) ).toEqual( { s: '', sort: 'date' } );
 	} );
 
 	test( 'still applies boolean/number coercion for the successful-decode path', () => {
 		expect( decode( 'x=true', true, false ) ).toEqual( { x: true } );
 		expect( decode( 'x=42', false, true ) ).toEqual( { x: 42 } );
+	} );
+
+	test( 'does not coerce a malformed value into a number', () => {
+		// +'' === 0, so this must return early rather than fall through to number coercion.
+		expect( decode( 'x=%zz', false, true ) ).toEqual( { x: '' } );
 	} );
 } );

--- a/projects/packages/search/src/instant-search/external/test/query-string-decode.test.js
+++ b/projects/packages/search/src/instant-search/external/test/query-string-decode.test.js
@@ -1,0 +1,36 @@
+import { decode } from '../query-string-decode';
+
+describe( 'decode', () => {
+	test( 'decodes well-formed percent-encoded values', () => {
+		expect( decode( 'x=hello%20world' ) ).toEqual( { x: 'hello world' } );
+	} );
+
+	test( 'does not throw on malformed percent-encoding', () => {
+		expect( () => decode( 'x=%MALFORMED%' ) ).not.toThrow();
+		expect( () => decode( 'x=100%' ) ).not.toThrow();
+		expect( () => decode( 'x=%' ) ).not.toThrow();
+		expect( () => decode( 'x=%zz' ) ).not.toThrow();
+	} );
+
+	test( 'recovers bare/invalid percent escapes as literal text instead of dropping them', () => {
+		// e.g. an unresolved email merge tag like `%DONOR%` — kept as plain text.
+		expect( decode( 's=%MALFORMED%' ) ).toEqual( { s: '%MALFORMED%' } );
+		expect( decode( 'x=100%' ) ).toEqual( { x: '100%' } );
+		expect( decode( 'x=%' ) ).toEqual( { x: '%' } );
+		expect( decode( 'x=%zz' ) ).toEqual( { x: '%zz' } );
+	} );
+
+	test( 'drops a key only for a well-formed-but-undecodable escape', () => {
+		// %E0%A4: a valid %XX pair (untouched by sanitizing) that's a truncated UTF-8 sequence.
+		expect( decode( 'x=%E0%A4' ) ).toEqual( {} );
+	} );
+
+	test( 'drops only the malformed key, keeping other well-formed keys intact', () => {
+		expect( decode( 's=foo&bad=%E0%A4&sort=date' ) ).toEqual( { s: 'foo', sort: 'date' } );
+	} );
+
+	test( 'still applies boolean/number coercion for the successful-decode path', () => {
+		expect( decode( 'x=true', true, false ) ).toEqual( { x: true } );
+		expect( decode( 'x=42', false, true ) ).toEqual( { x: 42 } );
+	} );
+} );


### PR DESCRIPTION
Fixes Automattic/jetpack#50709

## Proposed changes

* Guard `decodeURIComponent()` in Instant Search's vendored query-string decoder (`query-string-decode.js`) against malformed percent-encoding (e.g. a stray `%`, an unresolved email merge tag like `%DONOR%`, or invalid escapes like `%zz`), which previously threw an uncaught `URIError` on every page load and crashed Instant Search's initialization, leaving the page blank.
* Malformed sequences are sanitized (a bare `%` not starting a valid `%XX` escape is escaped to `%25`) and then decoded, so the value is recovered as literal plain text (e.g. `%DONOR%` decodes to the literal string `%DONOR%`) instead of throwing. This lets Instant Search keep treating the value as an active search term (e.g. showing its own "No results found" state) rather than silently dropping it or falling back to the site's classic search page.
* In the rare residual case of a value that's well-formed `%XX` escapes but decodes to an invalid byte sequence (e.g. a truncated UTF-8 sequence), that key is dropped rather than kept as a raw value — keeping a still-encoded raw string would get double-encoded (and corrupted) the next time the query object is round-tripped through `qss`'s `encode()`.

## Related product discussion/links

* [https://github.com/Automattic/jetpack/issues/50709](<https://github.com/Automattic/jetpack/issues/50709>)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site with Jetpack Search active and the Instant Search (overlay) experience enabled, visit a URL with a malformed query param typed directly in the address bar (not submitted via a form, which would properly encode it), e.g.:
  * `https://yoursite.com/?s=%MA`
  * `https://yoursite.com/?s=%zz`
  * `https://yoursite.com/?test=%MALFORMED%`
* Before this fix: the page renders blank, and the console shows an uncaught `URIError: URI malformed`.
* After this fix: the page renders normally. For a malformed `s` (search term) param, the Instant Search overlay opens showing "No results found" for the literal text (e.g. `%MA`). For a malformed bystander param unrelated to search, the page loads normally and that param is otherwise unaffected.
* Run the JS test suite: `pnpm test-scripts` (from `projects/packages/search/`) — includes new regression tests in `src/instant-search/external/test/query-string-decode.test.js`.