### PR TITLE
SEO: Preserve settings and output parity

### DIFF
--- a/projects/packages/seo/_inc/data/build-payload.ts
+++ b/projects/packages/seo/_inc/data/build-payload.ts
@@ -30,8 +30,14 @@ export function buildJetpackPayload(
 		// The payload key is the module slug; `/jetpack/v4/settings` toggles the module.
 		payload[ 'canonical-urls' ] = local.canonical_active;
 	}
-	if ( JSON.stringify( local.title_formats ) !== JSON.stringify( baseline.title_formats ) ) {
+	if (
+		baseline.title_formats_editable &&
+		JSON.stringify( local.title_formats ) !== JSON.stringify( baseline.title_formats )
+	) {
 		payload.advanced_seo_title_formats = local.title_formats;
+	}
+	if ( local.verification_tools_active !== baseline.verification_tools_active ) {
+		payload[ 'verification-tools' ] = local.verification_tools_active;
 	}
 	if ( local.front_page_description !== baseline.front_page_description ) {
 		payload.advanced_seo_front_page_description = local.front_page_description;

--- a/projects/packages/seo/_inc/data/settings-types.ts
+++ b/projects/packages/seo/_inc/data/settings-types.ts
@@ -21,6 +21,10 @@ export interface SettingsResponse {
 	// default `-`). Used to preview the default title of a page type that has no
 	// stored format. Read-only, never sent back.
 	title_separator: string;
+	// Server-owned conflict state. False keeps saved formats visible but read-only
+	// and prevents them from being included in a save payload.
+	title_formats_editable: boolean;
+	verification_tools_active: boolean;
 	verification: {
 		google: string;
 		bing: string;

--- a/projects/packages/seo/_inc/data/test/build-payload.test.ts
+++ b/projects/packages/seo/_inc/data/test/build-payload.test.ts
@@ -10,6 +10,8 @@ const makeSettings = ( overrides: Partial< SettingsResponse > = {} ): SettingsRe
 	has_legacy_front_page_meta: false,
 	title_formats: { posts: [ { type: 'token', value: 'site_name' } ] },
 	title_separator: '-',
+	title_formats_editable: true,
+	verification_tools_active: true,
 	verification: { google: '', bing: '', pinterest: '', yandex: '', facebook: '' },
 	search_engines_visible: true,
 	sitemap_active: false,
@@ -52,6 +54,28 @@ describe( 'buildJetpackPayload', () => {
 		} );
 		expect( buildJetpackPayload( baseline, local ) ).toEqual( {
 			advanced_seo_title_formats: { posts: [ { type: 'token', value: 'post_title' } ] },
+		} );
+	} );
+
+	it( 'never emits title formats from a read-only conflict state', () => {
+		const baseline = makeSettings( {
+			title_formats: { posts: [ { type: 'token', value: 'site_name' } ] },
+			title_formats_editable: false,
+		} );
+		const local = makeSettings( {
+			title_formats: { posts: [] },
+			title_formats_editable: false,
+		} );
+
+		expect( buildJetpackPayload( baseline, local ) ).toEqual( {} );
+	} );
+
+	it( 'maps the verification module toggle to verification-tools', () => {
+		const baseline = makeSettings( { verification_tools_active: true } );
+		const local = makeSettings( { verification_tools_active: false } );
+
+		expect( buildJetpackPayload( baseline, local ) ).toEqual( {
+			'verification-tools': false,
 		} );
 	} );
 

--- a/projects/packages/seo/_inc/data/test/fixtures/store-fixtures.ts
+++ b/projects/packages/seo/_inc/data/test/fixtures/store-fixtures.ts
@@ -28,6 +28,8 @@ export const SEEDED_SETTINGS: SettingsResponse = {
 	has_legacy_front_page_meta: false,
 	title_formats: {},
 	title_separator: '-',
+	title_formats_editable: true,
+	verification_tools_active: true,
 	verification: { google: '', bing: '', pinterest: '', yandex: '', facebook: '' },
 	search_engines_visible: true,
 	sitemap_active: false,

--- a/projects/packages/seo/_inc/data/test/use-settings.test.ts
+++ b/projects/packages/seo/_inc/data/test/use-settings.test.ts
@@ -17,6 +17,8 @@ const SEED: SettingsResponse = {
 	has_legacy_front_page_meta: false,
 	title_formats: { posts: [ { type: 'token', value: 'site_name' } ] },
 	title_separator: '-',
+	title_formats_editable: true,
+	verification_tools_active: true,
 	verification: { google: '', bing: '', pinterest: '', yandex: '', facebook: '' },
 	search_engines_visible: true,
 	sitemap_active: false,

--- a/projects/packages/seo/_inc/screens/overview/index.tsx
+++ b/projects/packages/seo/_inc/screens/overview/index.tsx
@@ -96,6 +96,7 @@ const OverviewScreen: FC = () => {
 					/>
 					<SiteVerificationCard
 						data={ data.site_verification }
+						active={ settings?.verification_tools_active ?? false }
 						onManage={ () => goToSection( 'verification' ) }
 					/>
 				</div>
@@ -135,6 +136,7 @@ const OverviewScreen: FC = () => {
 				/>
 				<SiteVerificationCard
 					data={ data.site_verification }
+					active={ settings?.verification_tools_active ?? false }
 					onManage={ () => goToSection( 'verification' ) }
 				/>
 				{ crawlers && (

--- a/projects/packages/seo/_inc/screens/overview/site-verification-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/site-verification-card.tsx
@@ -10,6 +10,7 @@ import type { FC } from 'react';
 
 interface Props {
 	data: SiteVerification;
+	active: boolean;
 	onManage: () => void;
 }
 
@@ -17,8 +18,16 @@ interface Props {
 // `__()` into `__(cond ? A : B)`. See feedback_i18n_ternary_minifier_fold.
 const setLabel = __( 'Set', 'jetpack-seo' );
 const notSetLabel = __( 'Not set', 'jetpack-seo' );
+const disabledLabel = __( 'Disabled', 'jetpack-seo' );
 
-const SiteVerificationCard: FC< Props > = ( { data, onManage } ) => {
+const getStatusLabel = ( active: boolean, set: boolean ) => {
+	if ( ! active ) {
+		return disabledLabel;
+	}
+	return set ? setLabel : notSetLabel;
+};
+
+const SiteVerificationCard: FC< Props > = ( { data, active, onManage } ) => {
 	// The globally-relevant services always get a row; the rest only when this site
 	// has actually verified with them. Listing all five padded the summary with
 	// services most sites will never use, but hiding a verified one outright would
@@ -43,8 +52,8 @@ const SiteVerificationCard: FC< Props > = ( { data, onManage } ) => {
 						justify="space-between"
 						className={ styles.statRow }
 					>
-						<StatusDot status={ data[ key ] ? 'ok' : 'warn' } label={ label } />
-						<span>{ data[ key ] ? setLabel : notSetLabel }</span>
+						<StatusDot status={ active && data[ key ] ? 'ok' : 'warn' } label={ label } />
+						<span>{ getStatusLabel( active, data[ key ] ) }</span>
 					</Stack>
 				) ) }
 				<Stack direction="row" justify="flex-end" className={ styles.footer }>

--- a/projects/packages/seo/_inc/screens/overview/test/site-verification-card.test.tsx
+++ b/projects/packages/seo/_inc/screens/overview/test/site-verification-card.test.tsx
@@ -21,7 +21,7 @@ const buildVerification = ( overrides: Partial< SiteVerification > = {} ): SiteV
 
 describe( 'SiteVerificationCard', () => {
 	it( 'lists only the globally-relevant services when nothing else is verified', () => {
-		render( <SiteVerificationCard data={ buildVerification() } onManage={ jest.fn() } /> );
+		render( <SiteVerificationCard data={ buildVerification() } active onManage={ jest.fn() } /> );
 
 		for ( const label of [ 'Google', 'Bing', 'Facebook' ] ) {
 			expect( screen.getByText( label ) ).toBeInTheDocument();
@@ -39,6 +39,7 @@ describe( 'SiteVerificationCard', () => {
 			render(
 				<SiteVerificationCard
 					data={ buildVerification( { [ key ]: true } ) }
+					active
 					onManage={ jest.fn() }
 				/>
 			);
@@ -50,7 +51,11 @@ describe( 'SiteVerificationCard', () => {
 
 	it( 'keeps the hidden services hidden when only a primary one is verified', () => {
 		render(
-			<SiteVerificationCard data={ buildVerification( { google: true } ) } onManage={ jest.fn() } />
+			<SiteVerificationCard
+				data={ buildVerification( { google: true } ) }
+				active
+				onManage={ jest.fn() }
+			/>
 		);
 
 		expect( screen.getByText( 'Set' ) ).toBeInTheDocument();
@@ -60,7 +65,11 @@ describe( 'SiteVerificationCard', () => {
 
 	it( 'keeps the shared display order when an extra service is shown', () => {
 		render(
-			<SiteVerificationCard data={ buildVerification( { yandex: true } ) } onManage={ jest.fn() } />
+			<SiteVerificationCard
+				data={ buildVerification( { yandex: true } ) }
+				active
+				onManage={ jest.fn() }
+			/>
 		);
 
 		// VERIFICATION_SERVICES order is google, bing, pinterest, yandex, facebook —
@@ -69,5 +78,31 @@ describe( 'SiteVerificationCard', () => {
 			.getAllByText( /^(Google|Bing|Pinterest|Yandex|Facebook)$/ )
 			.map( node => node.textContent );
 		expect( labels ).toEqual( [ 'Google', 'Bing', 'Yandex', 'Facebook' ] );
+	} );
+
+	it( 'does not describe saved codes as emitted while the module is inactive', () => {
+		render(
+			<SiteVerificationCard
+				data={ buildVerification( { google: true } ) }
+				active={ false }
+				onManage={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getAllByText( 'Disabled' ) ).toHaveLength( 3 );
+		expect( screen.queryByText( 'Set' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows configured status while the module is active', () => {
+		render(
+			<SiteVerificationCard
+				data={ buildVerification( { google: true } ) }
+				active
+				onManage={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getByText( 'Set' ) ).toBeInTheDocument();
+		expect( screen.getAllByText( 'Not set' ) ).toHaveLength( 2 );
 	} );
 } );

--- a/projects/packages/seo/_inc/screens/settings/index.tsx
+++ b/projects/packages/seo/_inc/screens/settings/index.tsx
@@ -180,6 +180,7 @@ const SettingsScreen: FC< Props > = ( { form } ) => {
 						help={ frontPageHelp }
 						value={ local.front_page_description }
 						onChange={ next => setField( { front_page_description: next } ) }
+						maxLength={ 300 }
 						rows={ 3 }
 						disabled={ isSaving }
 						__nextHasNoMarginBottom
@@ -264,6 +265,8 @@ const SettingsScreen: FC< Props > = ( { form } ) => {
 			<div id="verification" className={ styles.section }>
 				<VerificationCard
 					value={ local.verification }
+					active={ local.verification_tools_active }
+					onToggle={ next => commit( { verification_tools_active: next } ) }
 					onChange={ setVerification }
 					onCommit={ () => commitFields( [ 'verification' ] ) }
 					disabled={ isSaving }
@@ -320,6 +323,7 @@ const SettingsScreen: FC< Props > = ( { form } ) => {
 						onSaveFormat={ pageType => commitTitleFormat( pageType ) }
 						isFormatDirty={ pageType => isTitleFormatDirty( pageType ) }
 						titleSeparator={ local.title_separator }
+						editable={ local.title_formats_editable }
 						disabled={ isSaving }
 					/>
 

--- a/projects/packages/seo/_inc/screens/settings/social-previews-card.tsx
+++ b/projects/packages/seo/_inc/screens/settings/social-previews-card.tsx
@@ -129,6 +129,7 @@ const SocialPreviewsCard: FC< Props > = ( { description } ) => {
 	if ( ! site ) {
 		return null;
 	}
+	const previewDescription = description || site.tagline;
 
 	return (
 		<CollapsibleCard.Root defaultOpen={ false }>
@@ -158,7 +159,7 @@ const SocialPreviewsCard: FC< Props > = ( { description } ) => {
 									{ __( 'Google search result', 'jetpack-seo' ) }
 								</Stack>
 							</Text>
-							<GooglePreview site={ site } description={ description } />
+							<GooglePreview site={ site } description={ previewDescription } />
 						</Stack>
 						<Stack direction="column" gap="md">
 							<Text variant="heading-lg" render={ <h3 /> }>
@@ -167,7 +168,7 @@ const SocialPreviewsCard: FC< Props > = ( { description } ) => {
 									{ __( 'Facebook', 'jetpack-seo' ) }
 								</Stack>
 							</Text>
-							<LinkCardPreview site={ site } description={ description } />
+							<LinkCardPreview site={ site } description={ previewDescription } />
 						</Stack>
 						<Stack direction="column" gap="md">
 							<Text variant="heading-lg" render={ <h3 /> }>
@@ -176,7 +177,7 @@ const SocialPreviewsCard: FC< Props > = ( { description } ) => {
 									{ __( 'X (Twitter)', 'jetpack-seo' ) }
 								</Stack>
 							</Text>
-							<LinkCardPreview site={ site } description={ description } />
+							<LinkCardPreview site={ site } description={ previewDescription } />
 						</Stack>
 					</Stack>
 				</Stack>

--- a/projects/packages/seo/_inc/screens/settings/test/gated.test.tsx
+++ b/projects/packages/seo/_inc/screens/settings/test/gated.test.tsx
@@ -53,6 +53,8 @@ const buildForm = ( hasLegacy: boolean ): SettingsForm => {
 		has_legacy_front_page_meta: hasLegacy,
 		title_formats: {},
 		title_separator: '-',
+		title_formats_editable: true,
+		verification_tools_active: true,
 		verification: { google: '', bing: '', pinterest: '', yandex: '', facebook: '' },
 		search_engines_visible: true,
 		sitemap_active: false,
@@ -93,7 +95,7 @@ describe( 'SettingsScreen — gated front-page description', () => {
 
 		render( <SettingsScreen form={ buildForm( true ) } /> );
 
-		expect( screen.getByLabelText( FRONT_PAGE_LABEL ) ).toBeInTheDocument();
+		expect( screen.getByLabelText( FRONT_PAGE_LABEL ) ).toHaveAttribute( 'maxlength', '300' );
 	} );
 
 	it( 'shows the front-page description on an ungated site regardless of the legacy flag', () => {

--- a/projects/packages/seo/_inc/screens/settings/test/settings-screen.test.tsx
+++ b/projects/packages/seo/_inc/screens/settings/test/settings-screen.test.tsx
@@ -61,6 +61,8 @@ const buildForm = ( overrides: Partial< SettingsResponse > = {} ): SettingsForm 
 		has_legacy_front_page_meta: false,
 		title_formats: {},
 		title_separator: '-',
+		title_formats_editable: true,
+		verification_tools_active: true,
 		verification: { ...EMPTY_VERIFICATION },
 		search_engines_visible: false,
 		sitemap_active: false,

--- a/projects/packages/seo/_inc/screens/settings/test/social-previews-card.test.tsx
+++ b/projects/packages/seo/_inc/screens/settings/test/social-previews-card.test.tsx
@@ -1,0 +1,34 @@
+/* eslint-disable testing-library/prefer-user-event */
+
+import '@testing-library/jest-dom';
+import { jest } from '@jest/globals';
+import { fireEvent, render, screen } from '@testing-library/react';
+
+jest.unstable_mockModule( '../../../data/get-site', () => ( {
+	default: () => ( {
+		title: 'Example site',
+		tagline: 'Example tagline',
+		url: 'https://example.com',
+		icon: '',
+		image: 'https://example.com/representative.jpg',
+	} ),
+} ) );
+
+const { default: SocialPreviewsCard } = await import( '../social-previews-card' );
+
+describe( 'SocialPreviewsCard', () => {
+	it( 'uses the site tagline when the front-page description is empty', () => {
+		render( <SocialPreviewsCard description="" /> );
+		fireEvent.click( screen.getByRole( 'button', { name: /Search & social previews/ } ) );
+
+		expect( screen.getAllByText( 'Example tagline' ) ).toHaveLength( 3 );
+	} );
+
+	it( 'prefers the front-page description over the tagline', () => {
+		render( <SocialPreviewsCard description="Custom description" /> );
+		fireEvent.click( screen.getByRole( 'button', { name: /Search & social previews/ } ) );
+
+		expect( screen.getAllByText( 'Custom description' ) ).toHaveLength( 3 );
+		expect( screen.queryByText( 'Example tagline' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/seo/_inc/screens/settings/test/title-structure-field.test.tsx
+++ b/projects/packages/seo/_inc/screens/settings/test/title-structure-field.test.tsx
@@ -1,4 +1,5 @@
 /* eslint-disable react/jsx-no-bind */
+/* eslint-disable testing-library/prefer-user-event */
 
 import '@testing-library/jest-dom';
 import { jest } from '@jest/globals';
@@ -40,6 +41,7 @@ const renderField = ( formats: Record< string, TitleFormatToken[] > = {} ) =>
 			onSaveFormat={ jest.fn() }
 			isFormatDirty={ () => false }
 			titleSeparator="-"
+			editable
 		/>
 	);
 
@@ -155,5 +157,40 @@ describe( 'TitleStructureField', () => {
 		renderField();
 		expand();
 		expect( screen.getByText( /Hello World - Your site/ ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows all saved formats read-only while title output is conflicted', () => {
+		const formats: Record< string, TitleFormatToken[] > = {
+			front_page: [ { type: 'string', value: 'Front value' } ],
+			posts: [ { type: 'string', value: 'Post value' } ],
+			pages: [ { type: 'string', value: 'Page value' } ],
+			groups: [ { type: 'string', value: 'Tag value' } ],
+			archives: [ { type: 'string', value: 'Archive value' } ],
+		};
+
+		render(
+			<TitleStructureField
+				formats={ formats }
+				onChange={ jest.fn() }
+				onSaveFormat={ jest.fn() }
+				isFormatDirty={ () => true }
+				titleSeparator="-"
+				editable={ false }
+			/>
+		);
+		fireEvent.click( screen.getByRole( 'button', { name: /Title structure/ } ) );
+
+		expect(
+			screen.getAllByText( /Another SEO plugin is controlling title output/ )
+		).not.toHaveLength( 0 );
+		expect( screen.getByRole( 'textbox', { name: 'Front page' } ) ).toHaveValue( 'Front value' );
+		expect( screen.getByRole( 'textbox', { name: 'Posts' } ) ).toHaveValue( 'Post value' );
+		expect( screen.getByRole( 'textbox', { name: 'Pages' } ) ).toHaveValue( 'Page value' );
+		expect( screen.getByRole( 'textbox', { name: 'Tags' } ) ).toHaveValue( 'Tag value' );
+		expect( screen.getByRole( 'textbox', { name: 'Archives' } ) ).toHaveValue( 'Archive value' );
+		screen.getAllByRole( 'textbox' ).forEach( input => expect( input ).toBeDisabled() );
+		screen
+			.getAllByRole( 'button', { name: 'Save' } )
+			.forEach( button => expect( button ).toHaveAttribute( 'aria-disabled', 'true' ) );
 	} );
 } );

--- a/projects/packages/seo/_inc/screens/settings/test/title-structure-field.test.tsx
+++ b/projects/packages/seo/_inc/screens/settings/test/title-structure-field.test.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable react/jsx-no-bind */
-/* eslint-disable testing-library/prefer-user-event */
 
 import '@testing-library/jest-dom';
 import { jest } from '@jest/globals';
@@ -178,7 +177,7 @@ describe( 'TitleStructureField', () => {
 				editable={ false }
 			/>
 		);
-		fireEvent.click( screen.getByRole( 'button', { name: /Title structure/ } ) );
+		expand();
 
 		expect(
 			screen.getAllByText( /Another SEO plugin is controlling title output/ )

--- a/projects/packages/seo/_inc/screens/settings/test/verification-card.test.tsx
+++ b/projects/packages/seo/_inc/screens/settings/test/verification-card.test.tsx
@@ -1,0 +1,53 @@
+import '@testing-library/jest-dom';
+import { jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+
+const mockUseGoogleVerify = jest.fn();
+
+jest.unstable_mockModule( '../../../data/use-google-verify', () => ( {
+	useGoogleVerify: mockUseGoogleVerify,
+} ) );
+
+const { default: VerificationCard } = await import( '../verification-card' );
+
+describe( 'VerificationCard', () => {
+	beforeEach( () => {
+		mockUseGoogleVerify.mockReturnValue( {
+			state: 'unverified',
+			isConnected: true,
+			isOwner: false,
+			searchConsoleUrl: '',
+			isVerifying: false,
+			autoVerify: jest.fn(),
+		} );
+	} );
+
+	it( 'retains saved codes but disables editing and Google verification while inactive', () => {
+		render(
+			<VerificationCard
+				value={ {
+					google: 'google-code',
+					bing: 'bing-code',
+					pinterest: 'pinterest-code',
+					yandex: 'yandex-code',
+					facebook: 'facebook-code',
+				} }
+				active={ false }
+				onToggle={ jest.fn() }
+				onChange={ jest.fn() }
+				open
+				onOpenChange={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getByRole( 'checkbox', { name: /Enable site verification/ } ) ).toBeEnabled();
+		expect( screen.getByRole( 'button', { name: /Verify with Google/ } ) ).toHaveAttribute(
+			'aria-disabled',
+			'true'
+		);
+		expect( screen.getByRole( 'textbox', { name: /Google verification code/ } ) ).toHaveValue(
+			'google-code'
+		);
+		screen.getAllByRole( 'textbox' ).forEach( input => expect( input ).toBeDisabled() );
+	} );
+} );

--- a/projects/packages/seo/_inc/screens/settings/title-structure-field.tsx
+++ b/projects/packages/seo/_inc/screens/settings/title-structure-field.tsx
@@ -6,7 +6,7 @@ import { TextControl } from '@wordpress/components';
 import { useCallback, useMemo, useRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { title as titleIcon } from '@wordpress/icons';
-import { Button, Card, CollapsibleCard, Stack, Text } from '@wordpress/ui';
+import { Button, Card, CollapsibleCard, Notice, Stack, Text } from '@wordpress/ui';
 import CardTitleIcon from '../../components/card-title-icon';
 import StatusIndicator from '../../components/status-indicator';
 import getSite from '../../data/get-site';
@@ -179,6 +179,8 @@ interface Props {
 	isFormatDirty: ( pageType: string ) => boolean;
 	/** The site's document-title separator, for previewing untouched page types. */
 	titleSeparator: string;
+	/** Whether Jetpack currently controls title output. */
+	editable: boolean;
 	disabled?: boolean;
 }
 
@@ -197,6 +199,7 @@ const TitleStructureField: FC< Props > = ( {
 	onSaveFormat,
 	isFormatDirty,
 	titleSeparator,
+	editable,
 	disabled,
 } ) => {
 	// A smart default counts as configured — the same rule the Schema module uses.
@@ -239,6 +242,16 @@ const TitleStructureField: FC< Props > = ( {
 					<Text variant="body-md" render={ <p /> }>
 						{ moduleDescription }
 					</Text>
+					{ ! editable && (
+						<Notice.Root intent="warning">
+							<Notice.Description>
+								{ __(
+									'Another SEO plugin is controlling title output. Your saved title structures are shown here but cannot be edited while it is active.',
+									'jetpack-seo'
+								) }
+							</Notice.Description>
+						</Notice.Root>
+					) }
 					{ PAGE_TYPES.map( pt => (
 						<TitleStructureRow
 							key={ pt.id }
@@ -250,7 +263,7 @@ const TitleStructureField: FC< Props > = ( {
 							canSave={ isFormatDirty( pt.id ) }
 							previewOverrides={ previewOverrides }
 							titleSeparator={ titleSeparator }
-							disabled={ disabled }
+							disabled={ disabled || ! editable }
 						/>
 					) ) }
 				</Stack>

--- a/projects/packages/seo/_inc/screens/settings/verification-card.tsx
+++ b/projects/packages/seo/_inc/screens/settings/verification-card.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-no-bind */
 
-import { TextControl } from '@wordpress/components';
+import { TextControl, ToggleControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { globe } from '@wordpress/icons';
 import { Card, CollapsibleCard, Stack, Text } from '@wordpress/ui';
@@ -14,6 +14,8 @@ import type { FC } from 'react';
 
 interface Props {
 	value: SettingsResponse[ 'verification' ];
+	active: boolean;
+	onToggle: ( active: boolean ) => void;
 	onChange: ( key: VerificationKey, value: string ) => void;
 	/** Save the current value — called on blur (auto-save, no Save button). */
 	onCommit?: () => void;
@@ -63,6 +65,8 @@ const HINTS: Record< Exclude< VerificationKey, 'google' >, string > = {
 
 const VerificationCard: FC< Props > = ( {
 	value,
+	active,
+	onToggle,
 	onChange,
 	onCommit,
 	disabled,
@@ -70,11 +74,13 @@ const VerificationCard: FC< Props > = ( {
 	onOpenChange,
 } ) => {
 	const verifiedCount = VERIFICATION_SERVICES.filter( ( { key } ) => !! value[ key ] ).length;
+	const controlsDisabled = disabled || ! active;
 
 	// All five services are optional and almost nobody verifies with more than
 	// one, so a single verified service counts as done rather than a fraction of
 	// five (JETPACK-2051). This module therefore never reports 'in-progress'.
-	const verificationStatus: SettingStatus = verifiedCount > 0 ? 'complete' : 'not-started';
+	const verificationStatus: SettingStatus =
+		active && verifiedCount > 0 ? 'complete' : 'not-started';
 
 	// CollapsibleCard.Root takes either controlled (`open`/`onOpenChange`) or
 	// uncontrolled (`defaultOpen`) props — one at a time.
@@ -101,12 +107,23 @@ const VerificationCard: FC< Props > = ( {
 					<Text variant="body-md" render={ <p /> }>
 						{ description }
 					</Text>
+					<ToggleControl
+						label={ __( 'Enable site verification', 'jetpack-seo' ) }
+						help={ __(
+							'Adds your saved verification codes to the site so supported services can confirm ownership.',
+							'jetpack-seo'
+						) }
+						checked={ active }
+						onChange={ onToggle }
+						disabled={ disabled }
+						__nextHasNoMarginBottom
+					/>
 					{ /* Google gets the keyring auto-verify flow; the rest are simple code fields. */ }
 					<GoogleVerificationField
 						value={ value.google }
 						onChange={ next => onChange( 'google', next ) }
 						onCommit={ onCommit }
-						disabled={ disabled }
+						disabled={ controlsDisabled }
 					/>
 					<Stack direction="column" gap="md">
 						{ VERIFICATION_SERVICES.filter( ( { key } ) => key !== 'google' ).map(
@@ -118,7 +135,7 @@ const VerificationCard: FC< Props > = ( {
 									onChange={ next => onChange( key, next ) }
 									onBlur={ onCommit }
 									help={ HINTS[ key ] }
-									disabled={ disabled }
+									disabled={ controlsDisabled }
 									__next40pxDefaultSize
 									__nextHasNoMarginBottom
 								/>

--- a/projects/packages/seo/changelog/fix-seo-settings-output-parity
+++ b/projects/packages/seo/changelog/fix-seo-settings-output-parity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Preserve SEO settings and keep dashboard previews and verification states aligned with site output.

--- a/projects/packages/seo/src/class-dashboard-data.php
+++ b/projects/packages/seo/src/class-dashboard-data.php
@@ -10,7 +10,6 @@
 namespace Automattic\Jetpack\SEO;
 
 use Automattic\Jetpack\Modules;
-use Jetpack_SEO_Titles;
 use Jetpack_SEO_Utils;
 
 /**
@@ -159,8 +158,15 @@ class Dashboard_Data {
 	public static function get_settings_data() {
 		$modules = new Modules();
 
-		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Jetpack_SEO_Titles lives in plugins/jetpack and is guarded by class_exists.
-		$title_formats = class_exists( 'Jetpack_SEO_Titles' ) ? Jetpack_SEO_Titles::get_custom_title_formats() : array();
+		// Read the stored values directly: Jetpack_SEO_Titles::get_custom_title_formats()
+		// intentionally hides them while another SEO plugin controls output, but the
+		// dashboard must still show the saved values without allowing edits.
+		$title_formats = get_option( 'advanced_seo_title_formats', array() );
+		if ( ! is_array( $title_formats ) ) {
+			$title_formats = array();
+		}
+		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Jetpack_SEO_Utils lives in plugins/jetpack and is guarded by class_exists.
+		$title_formats_editable = class_exists( 'Jetpack_SEO_Utils' ) && Jetpack_SEO_Utils::is_enabled_jetpack_seo();
 		// @phan-suppress-next-line PhanUndeclaredClassMethod -- Jetpack_SEO_Utils lives in plugins/jetpack and is guarded by class_exists.
 		$front_page_desc = class_exists( 'Jetpack_SEO_Utils' ) ? Jetpack_SEO_Utils::get_front_page_meta_description() : '';
 
@@ -197,8 +203,10 @@ class Dashboard_Data {
 			// the incoming value untouched, so core composes the title itself and the
 			// Settings tab replays that composition to preview it.
 			'title_separator'            => self::get_default_title_separator(),
+			'title_formats_editable'     => $title_formats_editable,
 			'front_page_description'     => (string) $front_page_desc,
 			'has_legacy_front_page_meta' => $has_legacy_front_page_meta,
+			'verification_tools_active'  => $modules->is_active( 'verification-tools' ),
 			'verification'               => array(
 				'google'    => isset( $codes['google'] ) ? (string) $codes['google'] : '',
 				'bing'      => isset( $codes['bing'] ) ? (string) $codes['bing'] : '',
@@ -304,13 +312,19 @@ class Dashboard_Data {
 
 		$logo_id  = (int) get_theme_mod( 'custom_logo' );
 		$logo_url = $logo_id ? (string) wp_get_attachment_image_url( $logo_id, 'full' ) : '';
+		if ( class_exists( 'Jetpack_Redux_State_Helper' ) ) {
+			// @phan-suppress-next-line PhanUndeclaredClassMethod -- Jetpack_Redux_State_Helper lives in plugins/jetpack and is guarded by class_exists.
+			$image_url = (string) \Jetpack_Redux_State_Helper::get_site_image();
+		} else {
+			$image_url = $logo_url ? $logo_url : $icon_url;
+		}
 
 		return array(
 			'title'   => (string) get_bloginfo( 'name' ),
 			'tagline' => (string) get_bloginfo( 'description' ),
 			'url'     => (string) home_url(),
 			'icon'    => $icon_url,
-			'image'   => $logo_url ? $logo_url : $icon_url,
+			'image'   => $image_url,
 		);
 	}
 

--- a/projects/packages/seo/tests/php/DashboardDataTest.php
+++ b/projects/packages/seo/tests/php/DashboardDataTest.php
@@ -24,6 +24,12 @@ class DashboardDataTest extends SeoTestCase {
 			unregister_post_type( 'seo_book' );
 		}
 
+		\Jetpack_SEO_Utils::$enabled                    = true;
+		\Jetpack_SEO_Utils::$has_legacy_front_page_meta = false;
+		\Jetpack_Redux_State_Helper::$site_image        = '';
+		delete_option( 'advanced_seo_title_formats' );
+		remove_all_filters( 'jetpack_active_modules' );
+
 		parent::tearDown();
 	}
 
@@ -136,6 +142,8 @@ class DashboardDataTest extends SeoTestCase {
 	 * icon.
 	 */
 	public function test_get_site_data_shape() {
+		\Jetpack_Redux_State_Helper::$site_image = 'https://example.com/representative.jpg';
+
 		$site = Dashboard_Data::get_site_data();
 
 		$this->assertArrayHasKey( 'title', $site );
@@ -148,6 +156,7 @@ class DashboardDataTest extends SeoTestCase {
 		$this->assertIsString( $site['url'] );
 		$this->assertIsString( $site['icon'] );
 		$this->assertIsString( $site['image'] );
+		$this->assertSame( 'https://example.com/representative.jpg', $site['image'] );
 	}
 
 	/**
@@ -191,19 +200,74 @@ class DashboardDataTest extends SeoTestCase {
 	public function test_get_settings_data_reads_module_toggles_from_options() {
 		update_option( Initializer::SITEMAP_ENABLED_OPTION, '1' );
 		update_option( Initializer::CANONICAL_ENABLED_OPTION, '' );
+		add_filter(
+			'jetpack_active_modules',
+			static function ( $modules ) {
+				$modules[] = 'verification-tools';
+				return $modules;
+			}
+		);
 
 		$settings = Dashboard_Data::get_settings_data();
 
 		$this->assertArrayHasKey( 'sitemap_active', $settings );
 		$this->assertArrayHasKey( 'canonical_active', $settings );
+		$this->assertArrayHasKey( 'verification_tools_active', $settings );
 		$this->assertArrayHasKey( 'schema', $settings );
 		$this->assertArrayHasKey( 'organization', $settings['schema'] );
 		$this->assertArrayHasKey( 'defaults', $settings['schema'] );
 		$this->assertTrue( $settings['sitemap_active'] );
 		$this->assertFalse( $settings['canonical_active'] );
+		$this->assertTrue( $settings['verification_tools_active'] );
 
 		delete_option( Initializer::SITEMAP_ENABLED_OPTION );
 		delete_option( Initializer::CANONICAL_ENABLED_OPTION );
+	}
+
+	/**
+	 * Stored title formats stay visible but read-only while conflicting SEO output
+	 * disables Jetpack SEO, preventing a blank dashboard save from erasing them.
+	 */
+	public function test_get_settings_data_preserves_title_formats_while_output_is_disabled() {
+		$formats = array(
+			'front_page' => array(
+				array(
+					'type'  => 'token',
+					'value' => 'site_name',
+				),
+			),
+			'posts'      => array(
+				array(
+					'type'  => 'token',
+					'value' => 'post_title',
+				),
+			),
+			'pages'      => array(
+				array(
+					'type'  => 'token',
+					'value' => 'page_title',
+				),
+			),
+			'groups'     => array(
+				array(
+					'type'  => 'token',
+					'value' => 'group_title',
+				),
+			),
+			'archives'   => array(
+				array(
+					'type'  => 'token',
+					'value' => 'archive_title',
+				),
+			),
+		);
+		update_option( 'advanced_seo_title_formats', $formats );
+		\Jetpack_SEO_Utils::$enabled = false;
+
+		$settings = Dashboard_Data::get_settings_data();
+
+		$this->assertEquals( (object) $formats, $settings['title_formats'] );
+		$this->assertFalse( $settings['title_formats_editable'] );
 	}
 
 	/**

--- a/projects/packages/seo/tests/php/bootstrap.php
+++ b/projects/packages/seo/tests/php/bootstrap.php
@@ -31,6 +31,7 @@ require_once __DIR__ . '/SeoTestCase.php';
 // and are not autoloaded in the package test context, so these let the tests
 // drive Schema_Builder's behavior. Tests set their public static properties.
 require_once __DIR__ . '/stubs/class-jetpack-seo-utils.php';
+require_once __DIR__ . '/stubs/class-jetpack-redux-state-helper.php';
 require_once __DIR__ . '/stubs/class-jetpack-seo-posts.php';
 require_once __DIR__ . '/stubs/class-jetpack-options.php';
 require_once __DIR__ . '/stubs/class-wc-structured-data.php';

--- a/projects/packages/seo/tests/php/stubs/class-jetpack-redux-state-helper.php
+++ b/projects/packages/seo/tests/php/stubs/class-jetpack-redux-state-helper.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Test stub for the host plugin's Jetpack_Redux_State_Helper class.
+ *
+ * @package automattic/jetpack-seo
+ */
+
+if ( ! class_exists( 'Jetpack_Redux_State_Helper' ) ) {
+
+	/**
+	 * Stub of the host plugin's representative-image helper.
+	 */
+	class Jetpack_Redux_State_Helper {
+
+		/**
+		 * Representative image returned to the dashboard.
+		 *
+		 * @var string
+		 */
+		public static $site_image = '';
+
+		/**
+		 * Return the configured representative image.
+		 *
+		 * @return string
+		 */
+		public static function get_site_image(): string {
+			return self::$site_image;
+		}
+	}
+}

--- a/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/class.jetpack-core-api-module-endpoints.php
@@ -821,6 +821,15 @@ class Jetpack_Core_API_Data extends Jetpack_Core_API_XMLRPC_Consumer_Endpoint {
 						: true;
 					break;
 
+				case Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION:
+					Jetpack_SEO_Utils::update_front_page_meta_description( $value );
+					$response[ $option ] = Jetpack_SEO_Utils::get_front_page_meta_description();
+					// The helper returns an empty string for a successful clear or
+					// same-value write, so use its authoritative getter for the response
+					// and treat every valid request reaching this switch as handled.
+					$updated = true;
+					break;
+
 				case 'sharing_services':
 					if ( ! class_exists( 'Sharing_Service' ) && ! include_once JETPACK__PLUGIN_DIR . 'modules/sharedaddy/sharing-service.php' ) {
 						break;

--- a/projects/plugins/jetpack/changelog/fix-seo-settings-output-parity
+++ b/projects/plugins/jetpack/changelog/fix-seo-settings-output-parity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+SEO: Preserve legacy homepage description storage and length limits when saving dashboard settings.

--- a/projects/plugins/jetpack/tests/php/core-api/Jetpack_Core_Api_Module_Activate_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/Jetpack_Core_Api_Module_Activate_Endpoint_Test.php
@@ -392,4 +392,51 @@ class Jetpack_Core_Api_Module_Activate_Endpoint_Test extends Jetpack_REST_TestCa
 			'string zero'  => array( '0', false ),
 		);
 	}
+
+	/**
+	 * Front-page descriptions use the SEO utility so grandfathered sites keep
+	 * writing the legacy option and retain its 300-character contract.
+	 */
+	public function test_update_data_front_page_description_uses_seo_utility() {
+		add_filter( 'jetpack_disable_seo_tools', '__return_true' );
+		update_option( Jetpack_SEO_Utils::LEGACY_META_OPTION, 'Legacy description.' );
+		delete_option( Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION );
+
+		try {
+			$description = str_repeat( 'a', 350 );
+			$request     = new WP_REST_Request();
+			$request->set_body_params(
+				array( Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION => $description )
+			);
+
+			$result = ( new Jetpack_Core_API_Data() )->update_data( $request );
+
+			$this->assertSame( 200, $result->get_status() );
+			$this->assertSame( str_repeat( 'a', 300 ), get_option( Jetpack_SEO_Utils::LEGACY_META_OPTION ) );
+			$this->assertSame( false, get_option( Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION ) );
+			$this->assertSame(
+				str_repeat( 'a', 300 ),
+				$result->get_data()[ Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION ]
+			);
+
+			// Repeating the stored value and clearing it are both successful even
+			// though update_front_page_meta_description() returns '' for those cases.
+			foreach ( array( str_repeat( 'a', 300 ), '' ) as $value ) {
+				$request = new WP_REST_Request();
+				$request->set_body_params(
+					array( Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION => $value )
+				);
+				$result = ( new Jetpack_Core_API_Data() )->update_data( $request );
+
+				$this->assertSame( 200, $result->get_status() );
+				$this->assertSame( $value, $result->get_data()[ Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION ] );
+			}
+
+			$this->assertSame( '', get_option( Jetpack_SEO_Utils::LEGACY_META_OPTION ) );
+		} finally {
+			remove_filter( 'jetpack_disable_seo_tools', '__return_true' );
+			delete_option( Jetpack_SEO_Utils::LEGACY_META_OPTION );
+			delete_option( Jetpack_SEO_Utils::FRONT_PAGE_META_OPTION );
+		}
+	}
 }


### PR DESCRIPTION
Fixes JETPACK-1999

## Proposed changes

* Preserve all five saved title structures while a conflicting SEO plugin controls output, show them read-only, and omit them from save payloads.
* Route front-page description saves through the existing SEO utility so legacy storage and the 300-character limit remain authoritative.
* Expose and toggle the Site Verification module state, keeping saved codes visible but inactive when output is disabled.
* Match search and social previews to the real tagline fallback and representative Open Graph image.

## Related product discussion/links

* JETPACK-1999
* #50546
* #49398

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

2. Save distinct values for all five title structures, activate a conflicting SEO plugin, and confirm the values remain visible but read-only. Save an unrelated setting and confirm the stored title structures are unchanged.
3. On a site with a legacy front-page description, update it with more than 300 characters, repeat the same save, and clear it. Confirm the legacy option is used and the saved value never exceeds 300 characters.
4. Toggle Site Verification off and on. Confirm saved codes remain stored, manual and Google verification controls are disabled while off, and verification tags disappear and return with the module state.
5. Leave the front-page description empty and confirm previews use the site tagline. Confirm social preview images match the representative Open Graph image.
6. On a below-Premium gated site, confirm the grandfathered description and free verification controls remain available while paid title and social controls remain hidden.
