### PR TITLE
Help Center: Allow injecting the WP.com request client

### DIFF
--- a/projects/packages/help-center/AGENTS.md
+++ b/projects/packages/help-center/AGENTS.md
@@ -5,7 +5,9 @@
 This package is the backend for the Help Center. It is consumed by `jetpack-mu-wpcom` and may also be used by other WordPress plugins. It is responsible for:
 
 1. **Loading the Help Center UI** — enqueues the webpack bundles (built in `wp-calypso/apps/help-center/`) from `widgets.wp.com` into wp-admin, the block editor, the customizer, CIAB, `/support`, and `/forums`.
-2. **Registering REST API endpoints** — all under the `/help-center/` namespace. These are used by the frontend on Atomic sites when `canAccessWpcomApis()` returns `false`. Every endpoint proxies to a WPcom REST API via `Client::wpcom_json_api_request_as_user()`.
+2. **Registering REST API endpoints** — all under the `/help-center/` namespace. These are used by the frontend on Atomic sites when `canAccessWpcomApis()` returns `false`. Every endpoint proxies to a WPcom REST API through the configured `Wpcom_Request_Client`; the default adapter uses `Client::wpcom_json_api_request_as_user()`.
+
+Consumers may replace the default Jetpack Connection transport by implementing `Wpcom_Request_Client` and using the `jetpack_help_center_wpcom_request_client` filter before `Help_Center::init()` runs.
 
 The frontend code lives in a separate repo: `wp-calypso/packages/help-center/`.
 

--- a/projects/packages/help-center/README.md
+++ b/projects/packages/help-center/README.md
@@ -22,6 +22,35 @@ add_action( 'init', array( Help_Center::class, 'init' ) );
 
 The package expects the consuming plugin to load its Composer autoloader. Jetpack Autoloader is recommended when multiple plugins may ship Jetpack packages.
 
+### Custom WordPress.com Authentication
+
+By default, the package sends authenticated WordPress.com requests through Jetpack Connection. Consumers with another authentication system can implement `Wpcom_Request_Client` and provide it before Help Center initializes:
+
+```php
+use Automattic\Jetpack\Help_Center\Wpcom_Request_Client;
+
+final class My_Help_Center_Request_Client implements Wpcom_Request_Client {
+	public function request_as_user(
+		string $path,
+		string $version = '2',
+		array $args = array(),
+		array|string|null $body = null,
+		string $base_api_path = 'wpcom'
+	): array|\WP_Error {
+		return my_authenticated_wpcom_request( $path, $version, $args, $body, $base_api_path );
+	}
+}
+
+add_filter(
+	'jetpack_help_center_wpcom_request_client',
+	static function () {
+		return new My_Help_Center_Request_Client();
+	}
+);
+```
+
+Standalone consumers may instead pass the client directly to `Help_Center::init()`.
+
 ## Features
 
 - Loads Help Center bundles in wp-admin, the block editor, the customizer, and supported frontend contexts.

--- a/projects/packages/help-center/changelog/add-wpcom-request-client
+++ b/projects/packages/help-center/changelog/add-wpcom-request-client
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Allow consumers to provide the authenticated WordPress.com request client used by the Help Center.

--- a/projects/packages/help-center/src/class-help-center.php
+++ b/projects/packages/help-center/src/class-help-center.php
@@ -7,7 +7,6 @@
 
 namespace Automattic\Jetpack\Help_Center;
 
-use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Status\Host;
 
@@ -28,6 +27,13 @@ class Help_Center {
 	 * @var Help_Center|null
 	 */
 	private static $instance = null;
+
+	/**
+	 * WP.com request client.
+	 *
+	 * @var Wpcom_Request_Client
+	 */
+	private $wpcom_request_client;
 
 	/**
 	 * Whether the current site is a support site.
@@ -52,8 +58,12 @@ class Help_Center {
 
 	/**
 	 * Help_Center constructor.
+	 *
+	 * @param Wpcom_Request_Client|null $wpcom_request_client WP.com request client.
 	 */
-	public function __construct() {
+	public function __construct( ?Wpcom_Request_Client $wpcom_request_client = null ) {
+		$this->wpcom_request_client = $wpcom_request_client ?? new Jetpack_Wpcom_Request_Client();
+
 		if ( function_exists( 'wpcom_get_site_purchases' ) ) {
 			$this->purchases = wp_list_filter( wpcom_get_site_purchases(), array( 'product_type' => 'bundle' ) );
 		}
@@ -168,18 +178,41 @@ class Help_Center {
 	/**
 	 * Creates instance.
 	 *
-	 * @return void
+	 * @param Wpcom_Request_Client|null $wpcom_request_client WP.com request client.
+	 * @return self|null
 	 */
-	public static function init() {
+	public static function init( ?Wpcom_Request_Client $wpcom_request_client = null ) {
 		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 
 		if ( str_contains( $request_uri, 'wp-content/plugins/gutenberg-core' ) || str_contains( $request_uri, 'preview=true' ) ) {
-			return;
+			return null;
 		}
 
 		if ( self::$instance === null ) {
-			self::$instance = new self();
+			if ( null === $wpcom_request_client ) {
+				/**
+				 * Filters the client used for authenticated WordPress.com requests.
+				 *
+				 * @since $$next-version$$
+				 *
+				 * @param Wpcom_Request_Client $wpcom_request_client WP.com request client.
+				 */
+				$wpcom_request_client = apply_filters( 'jetpack_help_center_wpcom_request_client', new Jetpack_Wpcom_Request_Client() );
+
+				if ( ! $wpcom_request_client instanceof Wpcom_Request_Client ) {
+					_doing_it_wrong(
+						__METHOD__,
+						esc_html__( 'The jetpack_help_center_wpcom_request_client filter must return a Wpcom_Request_Client instance.', 'jetpack-help-center' ),
+						esc_html( self::PACKAGE_VERSION )
+					);
+					$wpcom_request_client = new Jetpack_Wpcom_Request_Client();
+				}
+			}
+
+			self::$instance = new self( $wpcom_request_client );
 		}
+
+		return self::$instance;
 	}
 
 	/**
@@ -337,7 +370,7 @@ class Help_Center {
 			$result = $experiment_variation === \ExPlat\assign_current_user( $experiment_name );
 		} elseif ( ( new Connection_Manager() )->is_user_connected() ) {
 			$request_path = '/experiments/0.1.0/assignments/calypso';
-			$response     = Client::wpcom_json_api_request_as_user(
+			$response     = $this->wpcom_request_client->request_as_user(
 				add_query_arg( array( 'experiment_name' => $experiment_name ), $request_path ),
 				'v2'
 			);
@@ -470,67 +503,67 @@ class Help_Center {
 	 */
 	public function register_rest_api() {
 		require_once __DIR__ . '/class-wp-rest-help-center-authenticate.php';
-		$controller = new WP_REST_Help_Center_Authenticate();
+		$controller = new WP_REST_Help_Center_Authenticate( $this->wpcom_request_client );
 		$controller->register_rest_route();
 
 		require_once __DIR__ . '/class-wp-rest-help-center-sibyl.php';
-		$controller = new WP_REST_Help_Center_Sibyl();
+		$controller = new WP_REST_Help_Center_Sibyl( $this->wpcom_request_client );
 		$controller->register_rest_route();
 
 		require_once __DIR__ . '/class-wp-rest-help-center-support-status.php';
-		$controller = new WP_REST_Help_Center_Support_Status();
+		$controller = new WP_REST_Help_Center_Support_Status( $this->wpcom_request_client );
 		$controller->register_rest_route();
 
 		require_once __DIR__ . '/class-wp-rest-help-center-search.php';
-		$controller = new WP_REST_Help_Center_Search();
+		$controller = new WP_REST_Help_Center_Search( $this->wpcom_request_client );
 		$controller->register_rest_route();
 
 		require_once __DIR__ . '/class-wp-rest-help-center-jetpack-search-ai.php';
-		$controller = new WP_REST_Help_Center_Jetpack_Search_AI();
+		$controller = new WP_REST_Help_Center_Jetpack_Search_AI( $this->wpcom_request_client );
 		$controller->register_rest_route();
 
 		require_once __DIR__ . '/class-wp-rest-help-center-jetpack-connection-health.php';
-		$controller = new WP_REST_Help_Center_Jetpack_Connection_Health();
+		$controller = new WP_REST_Help_Center_Jetpack_Connection_Health( $this->wpcom_request_client );
 		$controller->register_rest_route();
 
 		require_once __DIR__ . '/class-wp-rest-help-center-fetch-post.php';
-		$controller = new WP_REST_Help_Center_Fetch_Post();
+		$controller = new WP_REST_Help_Center_Fetch_Post( $this->wpcom_request_client );
 		$controller->register_rest_route();
 
 		require_once __DIR__ . '/class-wp-rest-help-center-ticket.php';
-		$controller = new WP_REST_Help_Center_Ticket();
+		$controller = new WP_REST_Help_Center_Ticket( $this->wpcom_request_client );
 		$controller->register_rest_route();
 
 		require_once __DIR__ . '/class-wp-rest-help-center-forum.php';
-		$controller = new WP_REST_Help_Center_Forum();
+		$controller = new WP_REST_Help_Center_Forum( $this->wpcom_request_client );
 		$controller->register_rest_route();
 
 		require_once __DIR__ . '/class-wp-rest-help-center-support-activity.php';
-		$controller = new WP_REST_Help_Center_Support_Activity();
+		$controller = new WP_REST_Help_Center_Support_Activity( $this->wpcom_request_client );
 		$controller->register_rest_route();
 
 		require_once __DIR__ . '/class-wp-rest-help-center-support-interactions.php';
-		$controller = new WP_REST_Help_Center_Support_Interactions();
+		$controller = new WP_REST_Help_Center_Support_Interactions( $this->wpcom_request_client );
 		$controller->register_rest_route();
 
 		require_once __DIR__ . '/class-wp-rest-help-center-user-fields.php';
-		$controller = new WP_REST_Help_Center_User_Fields();
+		$controller = new WP_REST_Help_Center_User_Fields( $this->wpcom_request_client );
 		$controller->register_rest_route();
 
 		require_once __DIR__ . '/class-wp-rest-help-center-odie.php';
-		$controller = new WP_REST_Help_Center_Odie();
+		$controller = new WP_REST_Help_Center_Odie( $this->wpcom_request_client );
 		$controller->register_rest_route();
 
 		require_once __DIR__ . '/class-wp-rest-help-center-persisted-open-state.php';
-		$controller = new WP_REST_Help_Center_Persisted_Open_State();
+		$controller = new WP_REST_Help_Center_Persisted_Open_State( $this->wpcom_request_client );
 		$controller->register_rest_route();
 
 		require_once __DIR__ . '/class-wp-rest-help-center-email-support-enabled.php';
-		$controller = new WP_REST_Help_Center_Email_Support_Enabled();
+		$controller = new WP_REST_Help_Center_Email_Support_Enabled( $this->wpcom_request_client );
 		$controller->register_rest_route();
 
 		require_once __DIR__ . '/class-wp-rest-help-center-ticket-csat.php';
-		$controller = new WP_REST_Help_Center_Ticket_CSAT();
+		$controller = new WP_REST_Help_Center_Ticket_CSAT( $this->wpcom_request_client );
 		$controller->register_rest_route();
 	}
 

--- a/projects/packages/help-center/src/class-jetpack-wpcom-request-client.php
+++ b/projects/packages/help-center/src/class-jetpack-wpcom-request-client.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Jetpack WP.com request client.
+ *
+ * @package automattic/jetpack-help-center
+ */
+
+namespace Automattic\Jetpack\Help_Center;
+
+use Automattic\Jetpack\Connection\Client;
+
+/**
+ * Sends authenticated WP.com requests through Jetpack Connection.
+ */
+final class Jetpack_Wpcom_Request_Client implements Wpcom_Request_Client {
+	/**
+	 * Send a request authenticated as the current Jetpack-connected user.
+	 *
+	 * @param string            $path          REST API path.
+	 * @param string            $version       REST API version.
+	 * @param array             $args          Arguments passed to WP_Http.
+	 * @param array|string|null $body          Request body.
+	 * @param string            $base_api_path REST API root.
+	 *
+	 * @return array|\WP_Error Response data, or WP_Error on failure.
+	 */
+	public function request_as_user(
+		string $path,
+		string $version = '2',
+		array $args = array(),
+		array|string|null $body = null,
+		string $base_api_path = 'wpcom'
+	): array|\WP_Error {
+		return Client::wpcom_json_api_request_as_user( $path, $version, $args, $body, $base_api_path );
+	}
+}

--- a/projects/packages/help-center/src/class-wp-rest-help-center-authenticate.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-authenticate.php
@@ -7,16 +7,17 @@
 
 namespace Automattic\Jetpack\Help_Center;
 
-use Automattic\Jetpack\Connection\Client;
-
 /**
  * Class WP_REST_Help_Center_Authenticate.
  */
-class WP_REST_Help_Center_Authenticate extends \WP_REST_Controller {
+class WP_REST_Help_Center_Authenticate extends WP_REST_Help_Center_Controller {
 	/**
 	 * WP_REST_Help_Center_Authenticate constructor.
+	 *
+	 * @param Wpcom_Request_Client|null $wpcom_request_client WP.com request client.
 	 */
-	public function __construct() {
+	public function __construct( ?Wpcom_Request_Client $wpcom_request_client = null ) {
+		parent::__construct( $wpcom_request_client );
 		$this->namespace = 'help-center';
 		$this->rest_base = '/authenticate/chat';
 	}
@@ -59,7 +60,7 @@ class WP_REST_Help_Center_Authenticate extends \WP_REST_Controller {
 			'type'      => $request['type'],
 		);
 
-		$body = Client::wpcom_json_api_request_as_user(
+		$body = $this->wpcom_request_client->request_as_user(
 			'help/authenticate/chat?' . http_build_query( $query_parameters ),
 			'2',
 			array(

--- a/projects/packages/help-center/src/class-wp-rest-help-center-controller.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-controller.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Base Help Center REST controller.
+ *
+ * @package automattic/jetpack-help-center
+ */
+
+namespace Automattic\Jetpack\Help_Center;
+
+/**
+ * Shares the configured WP.com request client with Help Center REST controllers.
+ */
+abstract class WP_REST_Help_Center_Controller extends \WP_REST_Controller {
+	/**
+	 * WP.com request client.
+	 *
+	 * @var Wpcom_Request_Client
+	 */
+	protected $wpcom_request_client;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param Wpcom_Request_Client|null $wpcom_request_client WP.com request client.
+	 */
+	public function __construct( ?Wpcom_Request_Client $wpcom_request_client = null ) {
+		$this->wpcom_request_client = $wpcom_request_client ?? new Jetpack_Wpcom_Request_Client();
+	}
+}

--- a/projects/packages/help-center/src/class-wp-rest-help-center-email-support-enabled.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-email-support-enabled.php
@@ -7,16 +7,17 @@
 
 namespace Automattic\Jetpack\Help_Center;
 
-use Automattic\Jetpack\Connection\Client;
-
 /**
  * Class WP_REST_Help_Center_Email_Support_Enabled.
  */
-class WP_REST_Help_Center_Email_Support_Enabled extends \WP_REST_Controller {
+class WP_REST_Help_Center_Email_Support_Enabled extends WP_REST_Help_Center_Controller {
 	/**
 	 * WP_REST_Help_Center_Email_Support_Enabled constructor.
+	 *
+	 * @param Wpcom_Request_Client|null $wpcom_request_client WP.com request client.
 	 */
-	public function __construct() {
+	public function __construct( ?Wpcom_Request_Client $wpcom_request_client = null ) {
+		parent::__construct( $wpcom_request_client );
 		$this->namespace = 'help-center';
 		$this->rest_base = '/support-availability';
 	}
@@ -40,7 +41,7 @@ class WP_REST_Help_Center_Email_Support_Enabled extends \WP_REST_Controller {
 	 * Should return if email contact is enabled for the user.
 	 */
 	public function get_email_support_configuration() {
-		$body = Client::wpcom_json_api_request_as_user( 'help/eligibility/email/mine' );
+		$body = $this->wpcom_request_client->request_as_user( 'help/eligibility/email/mine' );
 
 		if ( is_wp_error( $body ) ) {
 			return $body;

--- a/projects/packages/help-center/src/class-wp-rest-help-center-fetch-post.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-fetch-post.php
@@ -7,16 +7,17 @@
 
 namespace Automattic\Jetpack\Help_Center;
 
-use Automattic\Jetpack\Connection\Client;
-
 /**
  * Class WP_REST_Help_Center_Fetch_Post.
  */
-class WP_REST_Help_Center_Fetch_Post extends \WP_REST_Controller {
+class WP_REST_Help_Center_Fetch_Post extends WP_REST_Help_Center_Controller {
 	/**
 	 * WP_REST_Help_Center_Fetch_Post constructor.
+	 *
+	 * @param Wpcom_Request_Client|null $wpcom_request_client WP.com request client.
 	 */
-	public function __construct() {
+	public function __construct( ?Wpcom_Request_Client $wpcom_request_client = null ) {
+		parent::__construct( $wpcom_request_client );
 		$this->namespace = 'help-center';
 		$this->rest_base = 'fetch-post';
 	}
@@ -80,7 +81,7 @@ class WP_REST_Help_Center_Fetch_Post extends \WP_REST_Controller {
 			'blog_id'  => $request['blog_id'],
 			'post_ids' => $request['post_ids'],
 		);
-		$body             = Client::wpcom_json_api_request_as_user(
+		$body             = $this->wpcom_request_client->request_as_user(
 			'/help/articles?' . http_build_query( $query_parameters )
 		);
 
@@ -100,7 +101,7 @@ class WP_REST_Help_Center_Fetch_Post extends \WP_REST_Controller {
 	 */
 	public function get_post( \WP_REST_Request $request ) {
 		if ( isset( $request['post_url'] ) ) {
-			$body = Client::wpcom_json_api_request_as_user(
+			$body = $this->wpcom_request_client->request_as_user(
 				'/help/article?post_url=' . $request['post_url']
 			);
 		} else {
@@ -109,7 +110,7 @@ class WP_REST_Help_Center_Fetch_Post extends \WP_REST_Controller {
 				return $alternate_data;
 			}
 
-			$body = Client::wpcom_json_api_request_as_user(
+			$body = $this->wpcom_request_client->request_as_user(
 				'/help/article/' . $alternate_data['blog_id'] . '/' . $alternate_data['post_id']
 			);
 		}
@@ -141,7 +142,7 @@ class WP_REST_Help_Center_Fetch_Post extends \WP_REST_Controller {
 			return $default_alternate_data;
 		}
 
-		$body = Client::wpcom_json_api_request_as_user(
+		$body = $this->wpcom_request_client->request_as_user(
 			"/support/alternates/$blog_id/posts/$post_id",
 			'1.1',
 			array(),

--- a/projects/packages/help-center/src/class-wp-rest-help-center-forum.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-forum.php
@@ -7,16 +7,17 @@
 
 namespace Automattic\Jetpack\Help_Center;
 
-use Automattic\Jetpack\Connection\Client;
-
 /**
  * Class WP_REST_Help_Center_Forum.
  */
-class WP_REST_Help_Center_Forum extends \WP_REST_Controller {
+class WP_REST_Help_Center_Forum extends WP_REST_Help_Center_Controller {
 	/**
 	 * WP_REST_Help_Center_Forum constructor.
+	 *
+	 * @param Wpcom_Request_Client|null $wpcom_request_client WP.com request client.
 	 */
-	public function __construct() {
+	public function __construct( ?Wpcom_Request_Client $wpcom_request_client = null ) {
+		parent::__construct( $wpcom_request_client );
 		$this->namespace = 'help-center';
 		$this->rest_base = '/forum';
 	}
@@ -85,7 +86,7 @@ class WP_REST_Help_Center_Forum extends \WP_REST_Controller {
 			'should_use_test_forums' => isset( $request['should_use_test_forums'] ) && $request['should_use_test_forums'],
 		);
 
-		$body = Client::wpcom_json_api_request_as_user(
+		$body = $this->wpcom_request_client->request_as_user(
 			'/help/forum/new',
 			'2',
 			array(

--- a/projects/packages/help-center/src/class-wp-rest-help-center-jetpack-connection-health.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-jetpack-connection-health.php
@@ -7,16 +7,17 @@
 
 namespace Automattic\Jetpack\Help_Center;
 
-use Automattic\Jetpack\Connection\Client;
-
 /**
  * Class WP_REST_Help_Center_Jetpack_Connection_Health.
  */
-class WP_REST_Help_Center_Jetpack_Connection_Health extends \WP_REST_Controller {
+class WP_REST_Help_Center_Jetpack_Connection_Health extends WP_REST_Help_Center_Controller {
 	/**
 	 * WP_REST_Help_Center_Jetpack_Connection_Health constructor.
+	 *
+	 * @param Wpcom_Request_Client|null $wpcom_request_client WP.com request client.
 	 */
-	public function __construct() {
+	public function __construct( ?Wpcom_Request_Client $wpcom_request_client = null ) {
+		parent::__construct( $wpcom_request_client );
 		$this->namespace = 'help-center';
 		$this->rest_base = '/jetpack-connection-health';
 	}
@@ -51,7 +52,7 @@ class WP_REST_Help_Center_Jetpack_Connection_Health extends \WP_REST_Controller 
 			$site = get_current_blog_id();
 		}
 
-		$body = Client::wpcom_json_api_request_as_user(
+		$body = $this->wpcom_request_client->request_as_user(
 			'sites/' . $site . '/jetpack-connection-health',
 			'2'
 		);

--- a/projects/packages/help-center/src/class-wp-rest-help-center-jetpack-search-ai.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-jetpack-search-ai.php
@@ -7,16 +7,17 @@
 
 namespace Automattic\Jetpack\Help_Center;
 
-use Automattic\Jetpack\Connection\Client;
-
 /**
  * Class WP_REST_Help_Center_Jetpack_Search_AI.
  */
-class WP_REST_Help_Center_Jetpack_Search_AI extends \WP_REST_Controller {
+class WP_REST_Help_Center_Jetpack_Search_AI extends WP_REST_Help_Center_Controller {
 	/**
 	 * WP_REST_Help_Center_Jetpack_Search_AI constructor.
+	 *
+	 * @param Wpcom_Request_Client|null $wpcom_request_client WP.com request client.
 	 */
-	public function __construct() {
+	public function __construct( ?Wpcom_Request_Client $wpcom_request_client = null ) {
+		parent::__construct( $wpcom_request_client );
 		$this->namespace = 'help-center';
 		$this->rest_base = '/jetpack-search/ai';
 	}
@@ -46,7 +47,7 @@ class WP_REST_Help_Center_Jetpack_Search_AI extends \WP_REST_Controller {
 			'query'   => $request['query'],
 			'stop_at' => $request['stop_at'],
 		);
-		$body             = Client::wpcom_json_api_request_as_user(
+		$body             = $this->wpcom_request_client->request_as_user(
 			'sites/' . $request['site'] . '/jetpack-search/ai/search?' . http_build_query( $query_parameters ),
 			'2',
 			array(

--- a/projects/packages/help-center/src/class-wp-rest-help-center-odie.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-odie.php
@@ -7,17 +7,18 @@
 
 namespace Automattic\Jetpack\Help_Center;
 
-use Automattic\Jetpack\Connection\Client;
-
 /**
  * Class WP_REST_Help_Center_Odie.
  */
-class WP_REST_Help_Center_Odie extends \WP_REST_Controller {
+class WP_REST_Help_Center_Odie extends WP_REST_Help_Center_Controller {
 
 	/**
 	 * WP_REST_Help_Center_Odie constructor.
+	 *
+	 * @param Wpcom_Request_Client|null $wpcom_request_client WP.com request client.
 	 */
-	public function __construct() {
+	public function __construct( ?Wpcom_Request_Client $wpcom_request_client = null ) {
+		parent::__construct( $wpcom_request_client );
 		$this->namespace = 'help-center';
 		$this->rest_base = '/odie';
 	}
@@ -208,7 +209,7 @@ class WP_REST_Help_Center_Odie extends \WP_REST_Controller {
 		$chat_id       = $request->get_param( 'chat_id' );
 
 		// Forward the request body to the support chat endpoint.
-		$body = Client::wpcom_json_api_request_as_user(
+		$body = $this->wpcom_request_client->request_as_user(
 			'/odie/chat/' . $bot_name_slug . '/' . $chat_id,
 			'2',
 			array(
@@ -251,7 +252,7 @@ class WP_REST_Help_Center_Odie extends \WP_REST_Controller {
 			)
 		);
 
-		$body = Client::wpcom_json_api_request_as_user(
+		$body = $this->wpcom_request_client->request_as_user(
 			'/odie/chat/' . $bot_name_slug . '/' . $chat_id . '?' . $url_query_params
 		);
 
@@ -276,7 +277,7 @@ class WP_REST_Help_Center_Odie extends \WP_REST_Controller {
 		$rating_value = $request->get_param( 'rating_value' );
 
 		// Forward the request body to the feedback endpoint.
-		$body = Client::wpcom_json_api_request_as_user(
+		$body = $this->wpcom_request_client->request_as_user(
 			'/odie/chat/' . $bot_id . '/' . $chat_id . '/' . $message_id . '/feedback',
 			'2',
 			array( 'method' => 'POST' ),
@@ -313,7 +314,7 @@ class WP_REST_Help_Center_Odie extends \WP_REST_Controller {
 			)
 		);
 
-		$body = Client::wpcom_json_api_request_as_user(
+		$body = $this->wpcom_request_client->request_as_user(
 			'/odie/conversations/' . $bot_ids . '?' . $url_query_params
 		);
 

--- a/projects/packages/help-center/src/class-wp-rest-help-center-persisted-open-state.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-persisted-open-state.php
@@ -7,17 +7,18 @@
 
 namespace Automattic\Jetpack\Help_Center;
 
-use Automattic\Jetpack\Connection\Client;
-
 /**
  * Class WP_REST_Help_Center_Persisted_Open_State.
  */
-class WP_REST_Help_Center_Persisted_Open_State extends \WP_REST_Controller {
+class WP_REST_Help_Center_Persisted_Open_State extends WP_REST_Help_Center_Controller {
 
 	/**
 	 * WP_REST_Help_Center_Persisted_Open_State constructor.
+	 *
+	 * @param Wpcom_Request_Client|null $wpcom_request_client WP.com request client.
 	 */
-	public function __construct() {
+	public function __construct( ?Wpcom_Request_Client $wpcom_request_client = null ) {
+		parent::__construct( $wpcom_request_client );
 		$this->namespace = 'help-center';
 		$this->rest_base = '/open-state';
 	}
@@ -51,7 +52,7 @@ class WP_REST_Help_Center_Persisted_Open_State extends \WP_REST_Controller {
 	 */
 	public function get_state() {
 		// Forward the request body to the support chat endpoint.
-		$body = Client::wpcom_json_api_request_as_user(
+		$body = $this->wpcom_request_client->request_as_user(
 			'/me/preferences',
 			'2',
 			array( 'method' => 'GET' )
@@ -102,7 +103,7 @@ class WP_REST_Help_Center_Persisted_Open_State extends \WP_REST_Controller {
 			$data['calypso_preferences']['help_center_minimized'] = $minimized;
 		}
 
-		$body = Client::wpcom_json_api_request_as_user(
+		$body = $this->wpcom_request_client->request_as_user(
 			'/me/preferences',
 			'2',
 			array( 'method' => 'POST' ),

--- a/projects/packages/help-center/src/class-wp-rest-help-center-search.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-search.php
@@ -7,16 +7,17 @@
 
 namespace Automattic\Jetpack\Help_Center;
 
-use Automattic\Jetpack\Connection\Client;
-
 /**
  * Class WP_REST_Help_Center_Search.
  */
-class WP_REST_Help_Center_Search extends \WP_REST_Controller {
+class WP_REST_Help_Center_Search extends WP_REST_Help_Center_Controller {
 	/**
 	 * WP_REST_Help_Center_Search constructor.
+	 *
+	 * @param Wpcom_Request_Client|null $wpcom_request_client WP.com request client.
 	 */
-	public function __construct() {
+	public function __construct( ?Wpcom_Request_Client $wpcom_request_client = null ) {
+		parent::__construct( $wpcom_request_client );
 		$this->namespace = 'help-center';
 		$this->rest_base = '/search';
 	}
@@ -72,7 +73,7 @@ class WP_REST_Help_Center_Search extends \WP_REST_Controller {
 			$query_parameters['source'] = $source;
 		}
 
-		$body = Client::wpcom_json_api_request_as_user(
+		$body = $this->wpcom_request_client->request_as_user(
 			'/help/search?' . http_build_query( $query_parameters )
 		);
 

--- a/projects/packages/help-center/src/class-wp-rest-help-center-sibyl.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-sibyl.php
@@ -7,16 +7,17 @@
 
 namespace Automattic\Jetpack\Help_Center;
 
-use Automattic\Jetpack\Connection\Client;
-
 /**
  * Class WP_REST_Help_Center_Sibyl.
  */
-class WP_REST_Help_Center_Sibyl extends \WP_REST_Controller {
+class WP_REST_Help_Center_Sibyl extends WP_REST_Help_Center_Controller {
 	/**
 	 * WP_REST_Help_Center_Sibyl constructor.
+	 *
+	 * @param Wpcom_Request_Client|null $wpcom_request_client WP.com request client.
 	 */
-	public function __construct() {
+	public function __construct( ?Wpcom_Request_Client $wpcom_request_client = null ) {
+		parent::__construct( $wpcom_request_client );
 		$this->namespace = 'help-center';
 		$this->rest_base = '/sibyl';
 	}
@@ -45,7 +46,7 @@ class WP_REST_Help_Center_Sibyl extends \WP_REST_Controller {
 		$query = $request['query'];
 		$site  = $request['site'];
 
-		$body = Client::wpcom_json_api_request_as_user(
+		$body = $this->wpcom_request_client->request_as_user(
 			'/help/sibyl?query=' . $query . '&site=' . $site
 		);
 

--- a/projects/packages/help-center/src/class-wp-rest-help-center-support-activity.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-support-activity.php
@@ -7,16 +7,17 @@
 
 namespace Automattic\Jetpack\Help_Center;
 
-use Automattic\Jetpack\Connection\Client;
-
 /**
  * Class WP_REST_Help_Center_Support_Activity.
  */
-class WP_REST_Help_Center_Support_Activity extends \WP_REST_Controller {
+class WP_REST_Help_Center_Support_Activity extends WP_REST_Help_Center_Controller {
 	/**
 	 * WP_REST_Help_Center_Support_Activity constructor.
+	 *
+	 * @param Wpcom_Request_Client|null $wpcom_request_client WP.com request client.
 	 */
-	public function __construct() {
+	public function __construct( ?Wpcom_Request_Client $wpcom_request_client = null ) {
+		parent::__construct( $wpcom_request_client );
 		$this->namespace = 'help-center';
 		$this->rest_base = '/support-activity';
 	}
@@ -40,7 +41,7 @@ class WP_REST_Help_Center_Support_Activity extends \WP_REST_Controller {
 	 * Get support activity through Jetpack.
 	 */
 	public function get_support_activity() {
-		$body = Client::wpcom_json_api_request_as_user( '/support-activity' );
+		$body = $this->wpcom_request_client->request_as_user( '/support-activity' );
 
 		if ( is_wp_error( $body ) ) {
 			return $body;

--- a/projects/packages/help-center/src/class-wp-rest-help-center-support-interactions.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-support-interactions.php
@@ -7,16 +7,17 @@
 
 namespace Automattic\Jetpack\Help_Center;
 
-use Automattic\Jetpack\Connection\Client;
-
 /**
  * Class WP_REST_Help_Center_Support_Interactions.
  */
-class WP_REST_Help_Center_Support_Interactions extends \WP_REST_Controller {
+class WP_REST_Help_Center_Support_Interactions extends WP_REST_Help_Center_Controller {
 	/**
 	 * WP_REST_Help_Center_Support_Interactions constructor.
+	 *
+	 * @param Wpcom_Request_Client|null $wpcom_request_client WP.com request client.
 	 */
-	public function __construct() {
+	public function __construct( ?Wpcom_Request_Client $wpcom_request_client = null ) {
+		parent::__construct( $wpcom_request_client );
 		$this->namespace = 'help-center';
 		$this->rest_base = '/support-interactions';
 	}
@@ -164,7 +165,7 @@ class WP_REST_Help_Center_Support_Interactions extends \WP_REST_Controller {
 			$url = '/support-interactions/?' . http_build_query( stripslashes_deep( $request->get_params() ) );
 		}
 
-		$body = Client::wpcom_json_api_request_as_user( $url );
+		$body = $this->wpcom_request_client->request_as_user( $url );
 
 		if ( is_wp_error( $body ) ) {
 			return $body;
@@ -203,7 +204,7 @@ class WP_REST_Help_Center_Support_Interactions extends \WP_REST_Controller {
 			$data['is_test_mode'] = $request['is_test_mode'];
 		}
 
-		$body = Client::wpcom_json_api_request_as_user(
+		$body = $this->wpcom_request_client->request_as_user(
 			'/support-interactions',
 			'2',
 			array(
@@ -247,7 +248,7 @@ class WP_REST_Help_Center_Support_Interactions extends \WP_REST_Controller {
 			$data['is_test_mode'] = $request['is_test_mode'];
 		}
 
-		$body = Client::wpcom_json_api_request_as_user(
+		$body = $this->wpcom_request_client->request_as_user(
 			"/support-interactions/$support_interaction_id/events",
 			'2',
 			array(
@@ -275,7 +276,7 @@ class WP_REST_Help_Center_Support_Interactions extends \WP_REST_Controller {
 
 		$status = $request['status'];
 
-		$body = Client::wpcom_json_api_request_as_user(
+		$body = $this->wpcom_request_client->request_as_user(
 			"/support-interactions/$support_interaction_id/status",
 			'2',
 			array(

--- a/projects/packages/help-center/src/class-wp-rest-help-center-support-status.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-support-status.php
@@ -7,16 +7,17 @@
 
 namespace Automattic\Jetpack\Help_Center;
 
-use Automattic\Jetpack\Connection\Client;
-
 /**
  * Class WP_REST_Help_Center_Support_Status.
  */
-class WP_REST_Help_Center_Support_Status extends \WP_REST_Controller {
+class WP_REST_Help_Center_Support_Status extends WP_REST_Help_Center_Controller {
 	/**
 	 * WP_REST_Help_Center_Support_Status constructor.
+	 *
+	 * @param Wpcom_Request_Client|null $wpcom_request_client WP.com request client.
 	 */
-	public function __construct() {
+	public function __construct( ?Wpcom_Request_Client $wpcom_request_client = null ) {
+		parent::__construct( $wpcom_request_client );
 		$this->namespace = 'help-center';
 		$this->rest_base = '/support-status';
 	}
@@ -60,7 +61,7 @@ class WP_REST_Help_Center_Support_Status extends \WP_REST_Controller {
 	 * Should return the support status for the user
 	 */
 	public function get_support_status() {
-		$body = Client::wpcom_json_api_request_as_user( 'help/support-status' );
+		$body = $this->wpcom_request_client->request_as_user( 'help/support-status' );
 		if ( is_wp_error( $body ) ) {
 			return $body;
 		}
@@ -79,7 +80,7 @@ class WP_REST_Help_Center_Support_Status extends \WP_REST_Controller {
 			'group'       => $request['group'],
 			'environment' => $request['environment'],
 		);
-		$body             = Client::wpcom_json_api_request_as_user( 'help/support-status/messaging?' . http_build_query( $query_parameters ) );
+		$body             = $this->wpcom_request_client->request_as_user( 'help/support-status/messaging?' . http_build_query( $query_parameters ) );
 		if ( is_wp_error( $body ) ) {
 			return $body;
 		}

--- a/projects/packages/help-center/src/class-wp-rest-help-center-ticket-csat.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-ticket-csat.php
@@ -7,16 +7,17 @@
 
 namespace Automattic\Jetpack\Help_Center;
 
-use Automattic\Jetpack\Connection\Client;
-
 /**
  * Class WP_REST_Help_Center_Ticket_CSAT.
  */
-class WP_REST_Help_Center_Ticket_CSAT extends \WP_REST_Controller {
+class WP_REST_Help_Center_Ticket_CSAT extends WP_REST_Help_Center_Controller {
 	/**
 	 * WP_REST_Help_Center_Ticket_CSAT constructor.
+	 *
+	 * @param Wpcom_Request_Client|null $wpcom_request_client WP.com request client.
 	 */
-	public function __construct() {
+	public function __construct( ?Wpcom_Request_Client $wpcom_request_client = null ) {
+		parent::__construct( $wpcom_request_client );
 		$this->namespace = 'help-center';
 		$this->rest_base = '/csat';
 	}
@@ -73,7 +74,7 @@ class WP_REST_Help_Center_Ticket_CSAT extends \WP_REST_Controller {
 			'test_mode' => $request['test_mode'],
 		);
 
-		$body = Client::wpcom_json_api_request_as_user(
+		$body = $this->wpcom_request_client->request_as_user(
 			'/help/csat',
 			'2',
 			array(

--- a/projects/packages/help-center/src/class-wp-rest-help-center-ticket.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-ticket.php
@@ -7,16 +7,17 @@
 
 namespace Automattic\Jetpack\Help_Center;
 
-use Automattic\Jetpack\Connection\Client;
-
 /**
  * Class WP_REST_Help_Center_Ticket.
  */
-class WP_REST_Help_Center_Ticket extends \WP_REST_Controller {
+class WP_REST_Help_Center_Ticket extends WP_REST_Help_Center_Controller {
 	/**
 	 * WP_REST_Help_Center_Ticket constructor.
+	 *
+	 * @param Wpcom_Request_Client|null $wpcom_request_client WP.com request client.
 	 */
-	public function __construct() {
+	public function __construct( ?Wpcom_Request_Client $wpcom_request_client = null ) {
+		parent::__construct( $wpcom_request_client );
 		$this->namespace = 'help-center';
 		$this->rest_base = '/ticket';
 	}
@@ -72,7 +73,7 @@ class WP_REST_Help_Center_Ticket extends \WP_REST_Controller {
 			'blog_url'         => $request['blog_url'],
 		);
 
-		$body = Client::wpcom_json_api_request_as_user(
+		$body = $this->wpcom_request_client->request_as_user(
 			'/help/ticket/new',
 			'2',
 			array(

--- a/projects/packages/help-center/src/class-wp-rest-help-center-user-fields.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-user-fields.php
@@ -7,16 +7,17 @@
 
 namespace Automattic\Jetpack\Help_Center;
 
-use Automattic\Jetpack\Connection\Client;
-
 /**
  * Class WP_REST_Help_Center_User_Fields.
  */
-class WP_REST_Help_Center_User_Fields extends \WP_REST_Controller {
+class WP_REST_Help_Center_User_Fields extends WP_REST_Help_Center_Controller {
 	/**
 	 * WP_REST_Help_Center_User_Fields constructor.
+	 *
+	 * @param Wpcom_Request_Client|null $wpcom_request_client WP.com request client.
 	 */
-	public function __construct() {
+	public function __construct( ?Wpcom_Request_Client $wpcom_request_client = null ) {
+		parent::__construct( $wpcom_request_client );
 		$this->namespace = 'help-center';
 		$this->rest_base = '/zendesk/user-fields';
 	}
@@ -48,7 +49,7 @@ class WP_REST_Help_Center_User_Fields extends \WP_REST_Controller {
 	 * @param \WP_REST_Request $request    The request sent to the API.
 	 */
 	public function update_user_fields( \WP_REST_Request $request ) {
-		$body = Client::wpcom_json_api_request_as_user(
+		$body = $this->wpcom_request_client->request_as_user(
 			'help/zendesk/update-user-fields',
 			'2',
 			array(

--- a/projects/packages/help-center/src/interface-wpcom-request-client.php
+++ b/projects/packages/help-center/src/interface-wpcom-request-client.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * WP.com request client interface.
+ *
+ * @package automattic/jetpack-help-center
+ */
+
+namespace Automattic\Jetpack\Help_Center;
+
+/**
+ * Sends authenticated requests to the WordPress.com API.
+ */
+interface Wpcom_Request_Client {
+	/**
+	 * Send a request authenticated as the current user.
+	 *
+	 * @param string            $path          REST API path.
+	 * @param string            $version       REST API version.
+	 * @param array             $args          Arguments passed to WP_Http.
+	 * @param array|string|null $body          Request body.
+	 * @param string            $base_api_path REST API root.
+	 *
+	 * @return array|\WP_Error Response data, or WP_Error on failure.
+	 */
+	public function request_as_user(
+		string $path,
+		string $version = '2',
+		array $args = array(),
+		array|string|null $body = null,
+		string $base_api_path = 'wpcom'
+	): array|\WP_Error;
+}

--- a/projects/packages/help-center/tests/php/Help_Center_Data_Test.php
+++ b/projects/packages/help-center/tests/php/Help_Center_Data_Test.php
@@ -6,6 +6,8 @@
  */
 
 use Automattic\Jetpack\Help_Center\Help_Center;
+use Automattic\Jetpack\Help_Center\WP_REST_Help_Center_Support_Activity;
+use Automattic\Jetpack\Help_Center\Wpcom_Request_Client;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
@@ -134,5 +136,71 @@ class Help_Center_Data_Test extends \WorDBless\BaseTestCase {
 	public function test_get_instance_returns_singleton_after_init() {
 		Help_Center::init();
 		$this->assertInstanceOf( Help_Center::class, Help_Center::get_instance() );
+	}
+
+	public function test_init_uses_filtered_wpcom_request_client() {
+		$wpcom_request_client = new class() implements Wpcom_Request_Client {
+			public function request_as_user(
+				string $path,
+				string $version = '2',
+				array $args = array(),
+				array|string|null $body = null,
+				string $base_api_path = 'wpcom'
+			): array|\WP_Error {
+				return compact( 'path', 'version', 'args', 'body', 'base_api_path' );
+			}
+		};
+
+		$filter = static function () use ( $wpcom_request_client ) {
+			return $wpcom_request_client;
+		};
+		add_filter( 'jetpack_help_center_wpcom_request_client', $filter );
+
+		try {
+			$help_center = Help_Center::init();
+		} finally {
+			remove_filter( 'jetpack_help_center_wpcom_request_client', $filter );
+		}
+
+		$property = new \ReflectionProperty( Help_Center::class, 'wpcom_request_client' );
+		$this->assertSame( $wpcom_request_client, $property->getValue( $help_center ) );
+	}
+
+	public function test_rest_controller_uses_injected_wpcom_request_client() {
+		$wpcom_request_client = new class() implements Wpcom_Request_Client {
+			/**
+			 * Captured requests.
+			 *
+			 * @var array
+			 */
+			public $requests = array();
+
+			public function request_as_user(
+				string $path,
+				string $version = '2',
+				array $args = array(),
+				array|string|null $body = null,
+				string $base_api_path = 'wpcom'
+			): array|\WP_Error {
+				$this->requests[] = compact( 'path', 'version', 'args', 'body', 'base_api_path' );
+				return array( 'body' => '{"items":[]}' );
+			}
+		};
+
+		$controller = new WP_REST_Help_Center_Support_Activity( $wpcom_request_client );
+		$controller->get_support_activity();
+
+		$this->assertSame(
+			array(
+				array(
+					'path'          => '/support-activity',
+					'version'       => '2',
+					'args'          => array(),
+					'body'          => null,
+					'base_api_path' => 'wpcom',
+				),
+			),
+			$wpcom_request_client->requests
+		);
 	}
 }


### PR DESCRIPTION
Related to #49468

## Proposed changes

* Add a public `Wpcom_Request_Client` interface for the Help Center package.
* Preserve existing behavior with a default adapter around Jetpack Connection's `Client::wpcom_json_api_request_as_user()`.
* Pass one configured request client through the Help Center and all REST controllers.
* Let consumers provide their authenticated transport through `jetpack_help_center_wpcom_request_client` or the explicit `Help_Center::init()` argument.
* Document the integration point and cover both filter injection and REST request delegation.

## Related product discussion/links

* Stacked on #50807. That extraction PR should merge first.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Check out this branch.
* Run `composer test-php` from `projects/packages/help-center`; all 12 tests and 17 assertions should pass.
* Run `composer test-php` from `projects/packages/jetpack-mu-wpcom`; all 837 tests and 2533 assertions should pass.
* Run `composer phpcs:lint projects/packages/help-center`; all package files should pass.
* Run `tools/fixup-project-versions.sh` twice; the second run should produce no changes.
