### PR TITLE
Forms: keep response JSON intact when a label or page title contains a < character

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-responses-kses-corrupts-json
+++ b/projects/packages/forms/changelog/fix-forms-responses-kses-corrupts-json
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Forms: keep responses readable when a field label or page title contains a "<" character.
+Keep responses readable when a field label, submitted value, or page title contains a "<" character.

--- a/projects/packages/forms/changelog/fix-forms-responses-kses-corrupts-json
+++ b/projects/packages/forms/changelog/fix-forms-responses-kses-corrupts-json
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: keep responses readable when a field label or page title contains a "<" character.

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -1587,6 +1587,24 @@ class Feedback {
 		/*
 		 * JSON_HEX_TAG escapes every `<` and `>` as a \u003C / \u003E sequence,
 		 * which is what keeps this payload intact on the way into the database.
+		 * It is load-bearing here, not cosmetic - do not drop it.
+		 *
+		 * This payload is written to `post_content`, and any submitter without
+		 * `unfiltered_html` - every logged-out visitor, and every non-super-admin
+		 * on a multisite - has `wp_filter_post_kses` attached to `content_save_pre`.
+		 * A bare `<` anywhere in the payload (a field label, a submitted value, or
+		 * the source page title) then reads as the start of a tag, and core's
+		 * `wp_pre_kses_less_than()` runs esc_html() over everything from that `<` to
+		 * the end of the string. The quotes inside it become `&quot;`, so
+		 * `json_decode()` can no longer read the payload and the entire response
+		 * comes back empty.
+		 *
+		 * `json_decode()` resolves the escaped sequences natively, so no decode step
+		 * is needed and payloads written before this flag was added still parse.
+		 *
+		 * This deliberately diverges from Jetpack.Functions.JsonEncodeFlags, which
+		 * recommends JSON_UNESCAPED_SLASHES alone for database-field writes. That
+		 * guidance assumes the write is not KSES-filtered; this one is.
 		 */
 		return addslashes( wp_json_encode( $fields_to_serialize, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG ) );
 	}

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -1584,7 +1584,11 @@ class Feedback {
 			$fields_to_serialize['country_code'] = null;
 		}
 
-		return addslashes( wp_json_encode( $fields_to_serialize, JSON_UNESCAPED_SLASHES ) );
+		/*
+		 * JSON_HEX_TAG escapes every `<` and `>` as a \u003C / \u003E sequence,
+		 * which is what keeps this payload intact on the way into the database.
+		 */
+		return addslashes( wp_json_encode( $fields_to_serialize, JSON_UNESCAPED_SLASHES | JSON_HEX_TAG ) );
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Data_Integrity_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Data_Integrity_Test.php
@@ -900,9 +900,15 @@ class Feedback_Data_Integrity_Test extends BaseTestCase {
 	 * and escapes everything after it, which turns the JSON payload into
 	 * something `json_decode()` can't read - the whole response is lost.
 	 *
-	 * Set up the logged-out submitter state shared by the tests below.
+	 * Set up the logged-out submitter state shared by the tests below. No paired
+	 * kses_remove_filters() is needed: WorDBless restores $wp_filter after each
+	 * test, along with posts, users and options.
 	 */
 	private function set_up_anonymous_submitter() {
+		// Registers the `contact-field` shortcode, without which the form below
+		// parses to zero fields and the assertions become vacuous.
+		Contact_Form_Plugin::init();
+
 		wp_set_current_user( 0 );
 		kses_init_filters();
 
@@ -930,6 +936,14 @@ class Feedback_Data_Integrity_Test extends BaseTestCase {
 		$response = Feedback::from_submission( $_post_data, $form );
 		$post_id  = $response->save();
 
+		// Assert on the bytes that actually reached the database first, since
+		// that is what KSES rewrites. Comparing two in-memory serializations
+		// would pass even on a mangled payload, because both sides would be
+		// re-encoded from the same parsed data.
+		$stored = get_post( $post_id )->post_content;
+		$this->assertStringNotContainsString( '<', $stored, 'A bare `<` in the stored payload is what KSES latches onto.' );
+		$this->assertStringNotContainsString( '&quot;', $stored, 'Escaped quotes are the signature of KSES having rewritten the payload.' );
+
 		$saved_response = Feedback::get( $post_id );
 		$saved_fields   = $saved_response->get_fields();
 
@@ -938,12 +952,6 @@ class Feedback_Data_Integrity_Test extends BaseTestCase {
 		$saved_field = array_shift( $saved_fields );
 		$this->assertSame( '> < Name', $saved_field->get_label(), 'The label should round-trip unchanged.' );
 		$this->assertSame( 'Jane Doe', $saved_field->get_value(), 'The value should round-trip unchanged.' );
-
-		$this->assertEquals(
-			$response->serialize(),
-			$saved_response->serialize(),
-			'The stored payload should match what was serialized.'
-		);
 	}
 
 	/**
@@ -972,7 +980,5 @@ class Feedback_Data_Integrity_Test extends BaseTestCase {
 
 		$this->assertSame( 'RSVP < 2026', $saved->get_entry_title(), 'The source title should round-trip unchanged.' );
 		$this->assertCount( 1, $saved->get_fields(), 'The saved response should still hold the submitted field.' );
-
-		wp_delete_post( $current_post->ID, true );
 	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Data_Integrity_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Data_Integrity_Test.php
@@ -891,4 +891,88 @@ class Feedback_Data_Integrity_Test extends BaseTestCase {
 		wp_delete_user( $author_id );
 		wp_delete_user( $subscriber_id );
 	}
+
+	/**
+	 * Submitters without `unfiltered_html` (every logged-out visitor, and every
+	 * user on a multisite who isn't a super admin) have `wp_filter_post_kses`
+	 * attached to `content_save_pre`, so the serialized response runs through
+	 * KSES on `wp_insert_post()`. KSES reads a bare `<` as the start of a tag
+	 * and escapes everything after it, which turns the JSON payload into
+	 * something `json_decode()` can't read - the whole response is lost.
+	 *
+	 * Set up the logged-out submitter state shared by the tests below.
+	 */
+	private function set_up_anonymous_submitter() {
+		wp_set_current_user( 0 );
+		kses_init_filters();
+
+		$this->assertNotFalse(
+			has_filter( 'content_save_pre', 'wp_filter_post_kses' ),
+			'Precondition: KSES post filters must be active for a submitter without unfiltered_html.'
+		);
+	}
+
+	/**
+	 * A field label containing angle brackets must survive being saved by an
+	 * anonymous submitter.
+	 */
+	public function test_anonymous_submission_preserves_label_with_angle_brackets() {
+		$this->set_up_anonymous_submitter();
+
+		$_post_data = array( 'name' => 'Jane Doe' );
+
+		// A name field labelled "> < Name" in the editor renders to this shortcode.
+		$form = new Contact_Form(
+			array(),
+			"[contact-field id='name' label='&gt; &lt; Name' type='name' required='1'/]"
+		);
+
+		$response = Feedback::from_submission( $_post_data, $form );
+		$post_id  = $response->save();
+
+		$saved_response = Feedback::get( $post_id );
+		$saved_fields   = $saved_response->get_fields();
+
+		$this->assertCount( 1, $saved_fields, 'The saved response should still hold the submitted field.' );
+
+		$saved_field = array_shift( $saved_fields );
+		$this->assertSame( '> < Name', $saved_field->get_label(), 'The label should round-trip unchanged.' );
+		$this->assertSame( 'Jane Doe', $saved_field->get_value(), 'The value should round-trip unchanged.' );
+
+		$this->assertEquals(
+			$response->serialize(),
+			$saved_response->serialize(),
+			'The stored payload should match what was serialized.'
+		);
+	}
+
+	/**
+	 * The label is not the only way a bare `<` reaches the payload: the source
+	 * entry title is stored decoded too, so a page titled `RSVP < 2026` would
+	 * corrupt every response collected on it.
+	 */
+	public function test_anonymous_submission_preserves_source_title_with_angle_brackets() {
+		$this->set_up_anonymous_submitter();
+
+		$current_post = get_post(
+			wp_insert_post(
+				array(
+					'post_title'   => 'RSVP &lt; 2026',
+					'post_content' => 'POST CONTENT',
+					'post_status'  => 'publish',
+				)
+			)
+		);
+
+		$_post_data = array( 'name' => 'Jane Doe' );
+		$form       = new Contact_Form( array(), "[contact-field id='name' label='Name' type='name' required='1'/]" );
+
+		$response = Feedback::from_submission( $_post_data, $form, $current_post );
+		$saved    = Feedback::get( $response->save() );
+
+		$this->assertSame( 'RSVP < 2026', $saved->get_entry_title(), 'The source title should round-trip unchanged.' );
+		$this->assertCount( 1, $saved->get_fields(), 'The saved response should still hold the submitted field.' );
+
+		wp_delete_post( $current_post->ID, true );
+	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Data_Integrity_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Data_Integrity_Test.php
@@ -23,6 +23,14 @@ use WorDBless\BaseTestCase;
 class Feedback_Data_Integrity_Test extends BaseTestCase {
 
 	/**
+	 * The JSON escape sequence JSON_HEX_TAG writes for a `<`. Kept as a constant
+	 * so the literal backslash-u form is spelled out in exactly one place.
+	 *
+	 * @var string
+	 */
+	const HEX_ESCAPED_LT = '\\u003C';
+
+	/**
 	 *
 	 * Test file uploads in feedback
 	 */
@@ -940,9 +948,21 @@ class Feedback_Data_Integrity_Test extends BaseTestCase {
 		// that is what KSES rewrites. Comparing two in-memory serializations
 		// would pass even on a mangled payload, because both sides would be
 		// re-encoded from the same parsed data.
-		$stored = get_post( $post_id )->post_content;
-		$this->assertStringNotContainsString( '<', $stored, 'A bare `<` in the stored payload is what KSES latches onto.' );
+		//
+		// Note that an `assertStringNotContainsString( '<', ... )` check would be
+		// vacuous here: KSES escapes the bare `<` to `&lt;`, so it passes on the
+		// corrupted payload too. What distinguishes the two is that KSES also
+		// esc_html()s every quote from that `<` onwards, which is what breaks
+		// json_decode().
+		//
+		// post_content is stored slashed, so mirror what parse_content_v3() does
+		// before decoding rather than calling json_decode() on the raw bytes.
+		$stored    = get_post( $post_id )->post_content;
+		$unslashed = stripslashes( trim( $stored ) );
+
+		$this->assertStringContainsString( self::HEX_ESCAPED_LT, $unslashed, 'Angle brackets must reach the database hex-escaped.' );
 		$this->assertStringNotContainsString( '&quot;', $stored, 'Escaped quotes are the signature of KSES having rewritten the payload.' );
+		$this->assertNotNull( json_decode( $unslashed, true ), 'The stored payload must still decode after KSES has run.' );
 
 		$saved_response = Feedback::get( $post_id );
 		$saved_fields   = $saved_response->get_fields();
@@ -976,7 +996,18 @@ class Feedback_Data_Integrity_Test extends BaseTestCase {
 		$form       = new Contact_Form( array(), "[contact-field id='name' label='Name' type='name' required='1'/]" );
 
 		$response = Feedback::from_submission( $_post_data, $form, $current_post );
-		$saved    = Feedback::get( $response->save() );
+		$post_id  = $response->save();
+
+		// post_content is stored slashed, so mirror what parse_content_v3() does
+		// before decoding rather than calling json_decode() on the raw bytes.
+		$stored    = get_post( $post_id )->post_content;
+		$unslashed = stripslashes( trim( $stored ) );
+
+		$this->assertStringContainsString( self::HEX_ESCAPED_LT, $unslashed, 'Angle brackets must reach the database hex-escaped.' );
+		$this->assertStringNotContainsString( '&quot;', $stored, 'Escaped quotes are the signature of KSES having rewritten the payload.' );
+		$this->assertNotNull( json_decode( $unslashed, true ), 'The stored payload must still decode after KSES has run.' );
+
+		$saved = Feedback::get( $post_id );
 
 		$this->assertSame( 'RSVP < 2026', $saved->get_entry_title(), 'The source title should round-trip unchanged.' );
 		$this->assertCount( 1, $saved->get_fields(), 'The saved response should still hold the submitted field.' );


### PR DESCRIPTION
Fixes FORMS-722

## Proposed changes

Submitting a form as a logged-out visitor produced a response that saved but came back empty in the dashboard, the notification email, and the on-page success summary, whenever a field label, a submitted value, or the source page title contained a `<` character.

`Feedback::save()` writes the response as a JSON payload into `post_content`. `wp_insert_post()` runs `post_content` through `content_save_pre`, where `kses_init_filters()` attaches `wp_filter_post_kses` for every submitter without `unfiltered_html` — which means every logged-out visitor, and every non-super-admin on a multisite.

Inside `wp_kses()`, the `pre_kses` filter runs first, and core registers `wp_pre_kses_less_than()` there unconditionally (`default-filters.php:307`). It matches `%<[^>]*?((?=<)|>|$)%` and, for any run with no closing `>`, applies `esc_html()` to the whole thing. A bare `<` in the payload therefore takes every quote after it with it:

```
IN:  ...,"label":"> < Name","value":"Jane Doe","type":"name",...
OUT: ...,"label":"&gt; &lt; Name&quot;,&quot;value&quot;:&quot;Jane Doe&quot;,...
```

The payload is no longer decodable, so `Feedback::get()->get_fields()` returns an empty array. Admins never see it, because they hold `unfiltered_html` and KSES never runs for them.

* `Feedback::serialize()` now adds `JSON_HEX_TAG`, so `<` and `>` are written as `\u003C` / `\u003E` and the stored payload contains no angle bracket for KSES to act on. KSES stays fully attached — nothing is detached and no `save_post` window is opened.
* No decode step is needed: `json_decode()` resolves those sequences natively, so `parse_content_v3()` is untouched and payloads written before this change still parse unchanged.
* Two regression tests covering a logged-out submitter, asserting on the bytes that actually reach `post_content`.

Two notes on scope:

* The label is not the only path to a bare `<`. Submitted values and the source entry title are stored decoded too, so a visitor typing `I <3 this` into a textarea, or a page titled `RSVP < 2026`, corrupted the response just as thoroughly — the title case taking out *every* response collected on that page. Escaping at the payload level covers all of them, rather than encoding each field individually.
* `JSON_HEX_AMP` was deliberately left off, to keep this change scoped to `<`. The `&` story is separately broken and is *not* addressed here: `wp_kses_normalize_entities()` already rewrites a bare `&` to `&amp;` for anonymous submitters, so a submitted value of `Tom & Jerry` is stored — and displayed — as `Tom &amp; Jerry` on those rows today, and dashboard search (a raw `post_content LIKE`) has never matched it there. Crucially the payload still *decodes*, so `&` is value corruption rather than total data loss — a different severity class. Adding `JSON_HEX_AMP` would fix the display corruption, at the cost of also breaking `&` search on admin-submitted rows, where it does currently work. That trade deserves its own decision, so it is left out here — happy to fold it in if reviewers prefer.

### Already-corrupted rows

This fixes new submissions only. Existing mangled rows stay unreadable until something repairs them, but the damage **is** recoverable: `wp_pre_kses_less_than()` escapes rather than deletes, so the transform is lossless and byte-growing. Measured against core, the label case goes 66 bytes in → 117 out, and `html_entity_decode( $stored, ENT_QUOTES )` returns the original payload *exactly*, after which `json_decode()` succeeds. A repair migration is therefore straightforward, and worth doing as a follow-up.

(An earlier revision of this description claimed the transform was irreversible on the theory that `wp_kses_split2()` deletes disallowed elements. That is true of `wp_kses_split2()` in isolation, but it never sees the payload — `pre_kses` has already escaped the `<` by then, so nothing downstream matches a tag.)

### Known behavior change

Dashboard search no longer matches `<` or `>` on newly-stored rows. `get_status_counts()` (`class-contact-form-endpoint.php:493`) and the inherited REST `s=` search both run `post_content LIKE` against raw bytes, so a page titled `RSVP < 2026` is now stored as `RSVP \u003C 2026` and won't match a search for `<`. Search-filtered CSV export inherits this. Narrow, but real.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?

No. The same fields are stored; only the on-disk escaping of the existing JSON payload changes.

## Security note

KSES was incidentally acting as a second filter over this payload. It no longer rewrites anything here, so the guarantees rest entirely on the two layers that were always the real ones — and of those, **the render layer is the one doing the work**:

* **On the way out**, every render path escapes: labels via `Contact_Form::escape_and_sanitize_field_label()` and values via `escape_and_sanitize_field_value()`, both ending in `wp_kses( $value, array() )` — all tags stripped. The REST/dashboard path hands JSON to React, which escapes on render.
* **On the way in**, most submitted values go through `sanitize_text_field()` / `sanitize_textarea_field()`, which strip tags.

To be precise about the second bullet, since it is weaker than an earlier revision of this description claimed: not every field reaches the payload sanitized. `process_image_select_field_value()` assigns `json_decode()` output straight into `$value['choices']` with no sanitizing, and the User-Agent capture uses `filter_var()` with no filter argument (`FILTER_UNSAFE_RAW` — a no-op that reads like sanitizing). On `trunk`, KSES destroyed those payloads, which incidentally meant no stored markup; after this change they round-trip verbatim, so a raw `<script>` in a User-Agent header is now stored as-is.

That is not live XSS — every render path escapes — but the honest framing is "output escaping is what protects this", not "nothing dangerous can reach the payload". Both input gaps are pre-existing and orthogonal to the JSON encoding, so they are left for a separate PR rather than widened into this one.

Labels are not visitor-controlled: they come from the form definition in post content, authored by someone who can already edit the post.

## Testing instructions

Automated:

* From `projects/packages/forms`, run `composer phpunit`. All 906 tests pass.
* To confirm the new tests are not vacuous, revert the `JSON_HEX_TAG` flag in `src/contact-form/class-feedback.php` and re-run — `test_anonymous_submission_preserves_label_with_angle_brackets` and `test_anonymous_submission_preserves_source_title_with_angle_brackets` both fail on the first stored-bytes assertion.

Manual:

1. On a test site, create a page with a Form block. Give one field the label `> < Name`. For extra coverage, title the page `RSVP < 2026` and include a textarea you can type `I <3 this` into.
2. Publish, then open the page in a logged-out browser (private window).
3. Fill in the form and submit.
4. On `trunk`: the success summary renders with no fields, and the entry in Jetpack → Forms → Form Responses is blank.
5. With this change: the summary lists every field with its label, and the dashboard entry shows the label as `> < Name` and the submitted values intact.
6. Repeat while logged in as an admin to confirm no change in behaviour there — it worked before and should still work.
7. Confirm existing responses saved before this change still open normally in the dashboard.
