### PR TITLE
Publicize: surface keyring-result fetch errors instead of failing silently

### DIFF
--- a/projects/packages/publicize/_inc/social-store/actions/connection-data.ts
+++ b/projects/packages/publicize/_inc/social-store/actions/connection-data.ts
@@ -96,8 +96,16 @@ export function fetchKeyringResult( requestId: string ) {
 			if ( response?.code === 'success' && response.data ) {
 				return response.data;
 			}
-		} catch {
-			// Swallow the error: an absent result is surfaced to the user as "no accounts found".
+		} catch ( error ) {
+			let message: string = __( 'Error verifying the connection.', 'jetpack-publicize-pkg' );
+
+			if ( typeof error === 'object' && 'message' in error && error.message ) {
+				message = `${ message } ${ error.message }`;
+			}
+
+			const { createErrorNotice } = coreDispatch( globalNoticesStore );
+
+			createErrorNotice( message, { type: 'snackbar', isDismissible: true } );
 		} finally {
 			dispatch( setFetchingKeyringResult( false ) );
 		}

--- a/projects/packages/publicize/changelog/fix-keyring-result-error-handling
+++ b/projects/packages/publicize/changelog/fix-keyring-result-error-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Surface a visible error when fetching the keyring result fails during a connection, instead of failing silently.

--- a/projects/plugins/jetpack/changelog/fix-keyring-result-error-handling
+++ b/projects/plugins/jetpack/changelog/fix-keyring-result-error-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Social: Surface a visible error when fetching the keyring result fails during a connection, instead of failing silently.

--- a/projects/plugins/social/changelog/fix-keyring-result-error-handling
+++ b/projects/plugins/social/changelog/fix-keyring-result-error-handling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Surface a visible error when fetching the keyring result fails during a connection, instead of failing silently.


### PR DESCRIPTION
Fixes SOCIAL-549

## Proposed changes
* When the `auth_flow=v2` keyring-result fetch fails during a social connection, surface the error as a snackbar instead of swallowing it. Previously `fetchKeyringResult` had a bare `catch {}`, so any failure (e.g. a `400` from the keyring-result request) left the popup closing with nothing shown — the connection silently never appeared.
* The error notice matches how sibling connection actions in the store report failures, and appends the server's message when present.

No REST/PHP changes: WP already returns a standard error for the failing request; we just stop discarding it on the client.

## Related product discussion/links
* SOCIAL-549

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Simulate a failing keyring-result fetch (e.g. block/return an error for `GET /wpcom/v2/publicize/keyring-result`, or reproduce on a host whose REST rewrite drops the query string).
* Go to Jetpack Social connection management and connect (or reconnect) a social account.
* Complete the OAuth popup.
* Confirm an error snackbar now appears instead of the popup closing with no feedback.
* On the happy path, confirm the connection still completes normally and no error notice is shown.

| Before | After |
| --- | --- |
|  |  |
