### PR TITLE
Backport Help Center package dependencies

### DIFF
--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [2.0.1] - 2026-07-27
+### Changed
+- Update package dependencies.
+
 ## [2.0.0] - 2026-07-22
 ### Removed
 - Number Slider: remove the NumberSlider component. It wrapped the unmaintained react-slider dependency (which blocked React 19) and had a single consumer; use the WordPress RangeControl component from @wordpress/components directly instead. [#50289]
@@ -1889,6 +1893,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[2.0.1]: https://github.com/Automattic/jetpack-components/compare/2.0.0...2.0.1
 [2.0.0]: https://github.com/Automattic/jetpack-components/compare/1.12.17...2.0.0
 [1.12.17]: https://github.com/Automattic/jetpack-components/compare/1.12.16...1.12.17
 [1.12.16]: https://github.com/Automattic/jetpack-components/compare/1.12.15...1.12.16

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"description": "Jetpack Components Package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/components/#readme",
 	"bugs": {

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## [2.2.0] - 2026-07-27
 ### Added
 - Add a `./state/store-id` subpath export so CONNECTION_STORE_ID can be imported without pulling the package barrel.
-- Connection: Support informational-only connection error notices. When an error's action is "none", the notice renders without a reconnect CTA.
+- Support informational-only connection error notices. When an error's action is "none", the notice renders without a reconnect CTA.
 
 ## [2.1.0] - 2026-07-22
 ### Removed

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## [2.2.0] - 2026-07-27
+### Added
+- Add a `./state/store-id` subpath export so CONNECTION_STORE_ID can be imported without pulling the package barrel.
+- Connection: Support informational-only connection error notices. When an error's action is "none", the notice renders without a reconnect CTA.
+
 ## [2.1.0] - 2026-07-22
 ### Removed
 - Connection UI: Unify error handling across Basic and Required Plan screens, modernize components, and remove the unused `ConnectUser` component. [#50663]
@@ -1435,6 +1440,7 @@
 - `Main` and `ConnectUser` components added.
 - `JetpackRestApiClient` API client added.
 
+[2.2.0]: https://github.com/Automattic/jetpack-connection-js/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/Automattic/jetpack-connection-js/compare/v2.0.2...v2.1.0
 [2.0.2]: https://github.com/Automattic/jetpack-connection-js/compare/v2.0.1...v2.0.2
 [2.0.1]: https://github.com/Automattic/jetpack-connection-js/compare/v2.0.0...v2.0.1

--- a/projects/js-packages/connection/changelog/add-connection-error-viewer-aware-display
+++ b/projects/js-packages/connection/changelog/add-connection-error-viewer-aware-display
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Connection: Support informational-only connection error notices. When an error's action is "none", the notice renders without a reconnect CTA.

--- a/projects/js-packages/connection/changelog/update-activity-log-wp-build
+++ b/projects/js-packages/connection/changelog/update-activity-log-wp-build
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add a `./state/store-id` subpath export so CONNECTION_STORE_ID can be imported without pulling the package barrel.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "2.1.0",
+	"version": "2.2.0",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/js-packages/i18n-check-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/i18n-check-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.44] - 2026-07-27
+### Changed
+- Update package dependencies.
+
 ## [1.1.43] - 2026-06-23
 ### Changed
 - Update package dependencies. [#49831]
@@ -350,6 +354,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[1.1.44]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.1.43...v1.1.44
 [1.1.43]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.1.42...v1.1.43
 [1.1.42]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.1.41...v1.1.42
 [1.1.41]: https://github.com/Automattic/i18n-check-webpack-plugin/compare/v1.1.40...v1.1.41

--- a/projects/js-packages/i18n-check-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-check-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-check-webpack-plugin",
-	"version": "1.1.43",
+	"version": "1.1.44",
 	"description": "A Webpack plugin to check that WordPress i18n hasn't been mangled by Webpack optimizations.",
 	"keywords": [
 		"webpack",

--- a/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
+++ b/projects/js-packages/i18n-loader-webpack-plugin/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.109] - 2026-07-27
+### Changed
+- Update package dependencies.
+
 ## [2.0.108] - 2026-07-20
 ### Changed
 - Update package dependencies. [#50529]
@@ -464,6 +468,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
+[2.0.109]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.108...v2.0.109
 [2.0.108]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.107...v2.0.108
 [2.0.107]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.106...v2.0.107
 [2.0.106]: https://github.com/Automattic/i18n-loader-webpack-plugin/compare/v2.0.105...v2.0.106

--- a/projects/js-packages/i18n-loader-webpack-plugin/package.json
+++ b/projects/js-packages/i18n-loader-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/i18n-loader-webpack-plugin",
-	"version": "2.0.108",
+	"version": "2.0.109",
 	"description": "A Webpack plugin to load WordPress i18n when Webpack lazy-loads a bundle.",
 	"keywords": [
 		"webpack",

--- a/projects/js-packages/idc/CHANGELOG.md
+++ b/projects/js-packages/idc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA IDC package releases.
 
+## 1.0.87 - 2026-07-27
+### Changed
+- Update dependencies.
+
 ## 1.0.86 - 2026-07-22
 ### Changed
 - Update dependencies. [#46035]

--- a/projects/js-packages/idc/package.json
+++ b/projects/js-packages/idc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-idc",
-	"version": "1.0.86",
+	"version": "1.0.87",
 	"description": "Jetpack Connection Component",
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic",

--- a/projects/js-packages/jetpack-shared-stores/CHANGELOG.md
+++ b/projects/js-packages/jetpack-shared-stores/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2026-07-27
+### Changed
+- Update dependencies.
+
 ## [0.2.1] - 2026-07-22
 ### Changed
 - Update dependencies.
@@ -44,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update package dependencies. [#49757]
 
+[0.2.2]: https://github.com/Automattic/jetpack-shared-stores/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/Automattic/jetpack-shared-stores/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Automattic/jetpack-shared-stores/compare/v0.1.5...v0.2.0
 [0.1.5]: https://github.com/Automattic/jetpack-shared-stores/compare/v0.1.4...v0.1.5

--- a/projects/js-packages/jetpack-shared-stores/package.json
+++ b/projects/js-packages/jetpack-shared-stores/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-stores",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"description": "Shared WordPress data stores used by the Jetpack block editor extensions, externalized into a single bundle to avoid duplicate store registration.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/jetpack-shared-stores/#readme",
 	"bugs": {

--- a/projects/js-packages/licensing/changelog/force-a-release
+++ b/projects/js-packages/licensing/changelog/force-a-release
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Update package dependencies.
+Update dependencies.

--- a/projects/js-packages/shared-extension-utils/changelog/force-a-release
+++ b/projects/js-packages/shared-extension-utils/changelog/force-a-release
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Update package dependencies.
+Update dependencies.

--- a/projects/js-packages/webpack-config/CHANGELOG.md
+++ b/projects/js-packages/webpack-config/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 4.1.0 - 2026-07-27
+### Added
+- Add `PnpmDeterministicChunkIds` plugin.
+
+### Changed
+- Update package dependencies.
+
 ## 4.0.1 - 2026-07-22
 ### Changed
 - Update package dependencies. [#50683]

--- a/projects/js-packages/webpack-config/changelog/add-webpack-pnpm-deterministic-chunk-ids
+++ b/projects/js-packages/webpack-config/changelog/add-webpack-pnpm-deterministic-chunk-ids
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add `PnpmDeterministicChunkIds` plugin.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "4.0.1",
+	"version": "4.1.0",
 	"private": true,
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",

--- a/projects/packages/admin-ui/CHANGELOG.md
+++ b/projects/packages/admin-ui/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.13] - 2026-07-27
+### Changed
+- Update package dependencies.
+
 ## [0.9.12] - 2026-07-22
 ### Changed
 - Update dependencies. [#48834]
@@ -327,6 +331,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixing menu visibility issues.
 
+[0.9.13]: https://github.com/Automattic/jetpack-admin-ui/compare/0.9.12...0.9.13
 [0.9.12]: https://github.com/Automattic/jetpack-admin-ui/compare/0.9.11...0.9.12
 [0.9.11]: https://github.com/Automattic/jetpack-admin-ui/compare/0.9.10...0.9.11
 [0.9.10]: https://github.com/Automattic/jetpack-admin-ui/compare/0.9.9...0.9.10

--- a/projects/packages/admin-ui/package.json
+++ b/projects/packages/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-admin-ui",
-	"version": "0.9.12",
+	"version": "0.9.13",
 	"private": true,
 	"description": "Generic Jetpack wp-admin UI elements",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/admin-ui/#readme",

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -17,7 +17,7 @@ use Jetpack_Tracks_Client;
  */
 class Admin_Menu {
 
-	const PACKAGE_VERSION = '0.9.12';
+	const PACKAGE_VERSION = '0.9.13';
 
 	/**
 	 * Slug used for the upgrade menu item and redirect URL.

--- a/projects/packages/assets/CHANGELOG.md
+++ b/projects/packages/assets/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.4.8] - 2026-07-27
+### Changed
+- Update package dependencies.
+
 ## [4.4.7] - 2026-07-22
 ### Changed
 - Update dependencies. [#50674]
@@ -904,6 +908,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Statically access asset tools
 
+[4.4.8]: https://github.com/Automattic/jetpack-assets/compare/v4.4.7...v4.4.8
 [4.4.7]: https://github.com/Automattic/jetpack-assets/compare/v4.4.6...v4.4.7
 [4.4.6]: https://github.com/Automattic/jetpack-assets/compare/v4.4.5...v4.4.6
 [4.4.5]: https://github.com/Automattic/jetpack-assets/compare/v4.4.4...v4.4.5

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.8.0] - 2026-07-27
+### Added
+- Make connection error notices owner-aware: on sites where connection ownership is locked, non-owner admins see who needs to reconnect instead of a reconnect button. Attribute errors to the affected user via error data when the token cannot identify one, and stop displaying errors that cannot be attributed to anyone. The owner's identity is only exposed to users who can manage the connection, and the new initial-state owner field is derived from the connection ownership record instead of the owner's token, so it stays available while that token is broken; existing connection data fields keep describing the connected owner. Errors injected via the jetpack_connection_get_verified_errors filter continue to take precedence and are left untouched.
+
+### Changed
+- Update package dependencies.
+
 ## [8.7.10] - 2026-07-22
 ### Changed
 - Update dependencies. [#50674]
@@ -1953,6 +1960,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[8.8.0]: https://github.com/Automattic/jetpack-connection/compare/v8.7.10...v8.8.0
 [8.7.10]: https://github.com/Automattic/jetpack-connection/compare/v8.7.9...v8.7.10
 [8.7.9]: https://github.com/Automattic/jetpack-connection/compare/v8.7.8...v8.7.9
 [8.7.8]: https://github.com/Automattic/jetpack-connection/compare/v8.7.7...v8.7.8

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [8.8.0] - 2026-07-27
 ### Added
-- Make connection error notices owner-aware: on sites where connection ownership is locked, non-owner admins see who needs to reconnect instead of a reconnect button. Attribute errors to the affected user via error data when the token cannot identify one, and stop displaying errors that cannot be attributed to anyone. The owner's identity is only exposed to users who can manage the connection, and the new initial-state owner field is derived from the connection ownership record instead of the owner's token, so it stays available while that token is broken; existing connection data fields keep describing the connected owner. Errors injected via the jetpack_connection_get_verified_errors filter continue to take precedence and are left untouched.
+- Show non-owner admins who needs to reconnect instead of a reconnect button, and hide errors that can't be attributed to a user.
 
 ### Changed
 - Update package dependencies.

--- a/projects/packages/connection/changelog/add-connection-error-viewer-aware-display
+++ b/projects/packages/connection/changelog/add-connection-error-viewer-aware-display
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Make connection error notices owner-aware: on sites where connection ownership is locked, non-owner admins see who needs to reconnect instead of a reconnect button. Attribute errors to the affected user via error data when the token cannot identify one, and stop displaying errors that cannot be attributed to anyone. The owner's identity is only exposed to users who can manage the connection, and the new initial-state owner field is derived from the connection ownership record instead of the owner's token, so it stays available while that token is broken; existing connection data fields keep describing the connected owner. Errors injected via the jetpack_connection_get_verified_errors filter continue to take precedence and are left untouched.

--- a/projects/packages/connection/composer.json
+++ b/projects/packages/connection/composer.json
@@ -72,7 +72,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "8.7.x-dev"
+			"dev-trunk": "8.8.x-dev"
 		},
 		"dependencies": {
 			"test-only": [

--- a/projects/packages/connection/src/class-error-handler.php
+++ b/projects/packages/connection/src/class-error-handler.php
@@ -356,7 +356,7 @@ class Error_Handler {
 	 * Unattributable errors (user ID 'invalid') are skipped by the display pipeline
 	 * before classification, so this method only receives numeric user IDs.
 	 *
-	 * @since $$next-version$$
+	 * @since 8.8.0
 	 *
 	 * @param string|int $user_id  The user ID associated with the error (`0` or a positive integer).
 	 * @param int        $owner_id The local user ID of the connection owner, or 0 if there is none.

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -953,7 +953,7 @@ class Manager {
 	 * filter. This is the single chokepoint used both when deciding which connection-error
 	 * CTA to surface and (eventually) when performing an ownership change.
 	 *
-	 * @since $$next-version$$
+	 * @since 8.8.0
 	 *
 	 * @return bool True if ownership can be transferred, false if it is locked.
 	 */
@@ -963,7 +963,7 @@ class Manager {
 		 *
 		 * Return `false` to lock ownership so it can never be taken over.
 		 *
-		 * @since $$next-version$$
+		 * @since 8.8.0
 		 *
 		 * @param bool $transferable Whether ownership can be transferred. Default true.
 		 */

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '8.7.10';
+	const PACKAGE_VERSION = '8.8.0';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/help-center/CHANGELOG.md
+++ b/projects/packages/help-center/CHANGELOG.md
@@ -4,3 +4,8 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## 0.1.0 - 2026-07-27
+### Added
+- Allow consumers to provide the WordPress.com authentication state and request client used by the Help Center.
+- Initial version, extracted from Jetpack MU WPCOM to its own package for external consumption.

--- a/projects/packages/help-center/changelog/add-wpcom-request-client
+++ b/projects/packages/help-center/changelog/add-wpcom-request-client
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Allow consumers to provide the WordPress.com authentication state and request client used by the Help Center.

--- a/projects/packages/help-center/changelog/initial-version
+++ b/projects/packages/help-center/changelog/initial-version
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Initial version, extracted from Jetpack MU WPCOM to its own package for external consumption.

--- a/projects/packages/help-center/src/class-help-center.php
+++ b/projects/packages/help-center/src/class-help-center.php
@@ -18,7 +18,7 @@ class Help_Center {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.1.0-alpha';
+	const PACKAGE_VERSION = '0.1.0';
 
 	/**
 	 * Class instance.
@@ -192,7 +192,7 @@ class Help_Center {
 				/**
 				 * Filters the client used for authenticated WordPress.com requests.
 				 *
-				 * @since $$next-version$$
+				 * @since 0.1.0
 				 *
 				 * @param Wpcom_Request_Client $wpcom_request_client WP.com request client.
 				 */

--- a/projects/plugins/agents-manager/changelog/2026-07-27-08-54-29-470392
+++ b/projects/plugins/agents-manager/changelog/2026-07-27-08-54-29-470392
@@ -1,4 +1,3 @@
 Significance: patch
 Type: changed
-
-Update package dependencies.
+Comment: Update composer.lock.

--- a/projects/plugins/agents-manager/composer.lock
+++ b/projects/plugins/agents-manager/composer.lock
@@ -418,7 +418,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "ce362d9d8bf97228d5267f8d4a9b05379ff98aa2"
+                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -455,7 +455,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.7.x-dev"
+                    "dev-trunk": "8.8.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/automattic-for-agencies-client/changelog/2026-07-27-08-54-29-703208
+++ b/projects/plugins/automattic-for-agencies-client/changelog/2026-07-27-08-54-29-703208
@@ -1,4 +1,3 @@
 Significance: patch
 Type: changed
-
-Update package dependencies.
+Comment: Update composer.lock.

--- a/projects/plugins/automattic-for-agencies-client/composer.lock
+++ b/projects/plugins/automattic-for-agencies-client/composer.lock
@@ -414,7 +414,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "ce362d9d8bf97228d5267f8d4a9b05379ff98aa2"
+                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -451,7 +451,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.7.x-dev"
+                    "dev-trunk": "8.8.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/backup/changelog/2026-07-27-08-54-29-945037
+++ b/projects/plugins/backup/changelog/2026-07-27-08-54-29-945037
@@ -1,4 +1,3 @@
 Significance: patch
 Type: changed
-
-Update package dependencies.
+Comment: Update composer.lock.

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -751,7 +751,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "ce362d9d8bf97228d5267f8d4a9b05379ff98aa2"
+                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -788,7 +788,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.7.x-dev"
+                    "dev-trunk": "8.8.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/boost/changelog/2026-07-27-08-54-30-182684
+++ b/projects/plugins/boost/changelog/2026-07-27-08-54-30-182684
@@ -1,4 +1,3 @@
 Significance: patch
 Type: changed
-
-Update package dependencies.
+Comment: Update composer.lock.

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -608,7 +608,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "ce362d9d8bf97228d5267f8d4a9b05379ff98aa2"
+                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -645,7 +645,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.7.x-dev"
+                    "dev-trunk": "8.8.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/classic-theme-helper-plugin/changelog/2026-07-27-08-54-30-419364
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/2026-07-27-08-54-30-419364
@@ -1,4 +1,3 @@
 Significance: patch
 Type: changed
-
-Update package dependencies.
+Comment: Update composer.lock.

--- a/projects/plugins/classic-theme-helper-plugin/composer.lock
+++ b/projects/plugins/classic-theme-helper-plugin/composer.lock
@@ -599,7 +599,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "ce362d9d8bf97228d5267f8d4a9b05379ff98aa2"
+                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -636,7 +636,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.7.x-dev"
+                    "dev-trunk": "8.8.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/inspect/changelog/2026-07-27-08-54-30-660049
+++ b/projects/plugins/inspect/changelog/2026-07-27-08-54-30-660049
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.

--- a/projects/plugins/inspect/composer.lock
+++ b/projects/plugins/inspect/composer.lock
@@ -414,7 +414,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "ce362d9d8bf97228d5267f8d4a9b05379ff98aa2"
+                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -451,7 +451,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.7.x-dev"
+                    "dev-trunk": "8.8.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/jetpack/changelog/2026-07-27-08-54-30-898103
+++ b/projects/plugins/jetpack/changelog/2026-07-27-08-54-30-898103
@@ -1,0 +1,3 @@
+Significance: patch
+Type: other
+Comment: Update composer.lock.

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1190,7 +1190,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "ce362d9d8bf97228d5267f8d4a9b05379ff98aa2"
+                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -1227,7 +1227,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.7.x-dev"
+                    "dev-trunk": "8.8.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/mu-wpcom-plugin/changelog/2026-07-27-08-54-31-142097
+++ b/projects/plugins/mu-wpcom-plugin/changelog/2026-07-27-08-54-31-142097
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -716,7 +716,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "ce362d9d8bf97228d5267f8d4a9b05379ff98aa2"
+                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -753,7 +753,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.7.x-dev"
+                    "dev-trunk": "8.8.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/paypal-payment-buttons/changelog/2026-07-27-08-54-31-381783
+++ b/projects/plugins/paypal-payment-buttons/changelog/2026-07-27-08-54-31-381783
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.

--- a/projects/plugins/paypal-payment-buttons/composer.lock
+++ b/projects/plugins/paypal-payment-buttons/composer.lock
@@ -399,7 +399,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "ce362d9d8bf97228d5267f8d4a9b05379ff98aa2"
+                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -436,7 +436,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.7.x-dev"
+                    "dev-trunk": "8.8.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/premium-analytics/changelog/2026-07-27-08-54-31-620860
+++ b/projects/plugins/premium-analytics/changelog/2026-07-27-08-54-31-620860
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.

--- a/projects/plugins/premium-analytics/composer.lock
+++ b/projects/plugins/premium-analytics/composer.lock
@@ -477,7 +477,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "ce362d9d8bf97228d5267f8d4a9b05379ff98aa2"
+                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -514,7 +514,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.7.x-dev"
+                    "dev-trunk": "8.8.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/protect/changelog/2026-07-27-08-54-31-856143
+++ b/projects/plugins/protect/changelog/2026-07-27-08-54-31-856143
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -730,7 +730,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "ce362d9d8bf97228d5267f8d4a9b05379ff98aa2"
+                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -767,7 +767,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.7.x-dev"
+                    "dev-trunk": "8.8.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/search/changelog/2026-07-27-08-54-32-091239
+++ b/projects/plugins/search/changelog/2026-07-27-08-54-32-091239
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -608,7 +608,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "ce362d9d8bf97228d5267f8d4a9b05379ff98aa2"
+                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -645,7 +645,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.7.x-dev"
+                    "dev-trunk": "8.8.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/social/changelog/2026-07-27-08-54-32-324845
+++ b/projects/plugins/social/changelog/2026-07-27-08-54-32-324845
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -671,7 +671,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "ce362d9d8bf97228d5267f8d4a9b05379ff98aa2"
+                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -708,7 +708,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.7.x-dev"
+                    "dev-trunk": "8.8.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/starter-plugin/changelog/2026-07-27-08-54-32-561881
+++ b/projects/plugins/starter-plugin/changelog/2026-07-27-08-54-32-561881
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -608,7 +608,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "ce362d9d8bf97228d5267f8d4a9b05379ff98aa2"
+                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -645,7 +645,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.7.x-dev"
+                    "dev-trunk": "8.8.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/videopress/changelog/2026-07-27-08-54-32-795691
+++ b/projects/plugins/videopress/changelog/2026-07-27-08-54-32-795691
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -608,7 +608,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "ce362d9d8bf97228d5267f8d4a9b05379ff98aa2"
+                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -645,7 +645,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.7.x-dev"
+                    "dev-trunk": "8.8.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/wpcloud-sso/changelog/2026-07-27-08-54-33-029106
+++ b/projects/plugins/wpcloud-sso/changelog/2026-07-27-08-54-33-029106
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.

--- a/projects/plugins/wpcloud-sso/composer.lock
+++ b/projects/plugins/wpcloud-sso/composer.lock
@@ -414,7 +414,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "ce362d9d8bf97228d5267f8d4a9b05379ff98aa2"
+                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -451,7 +451,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.7.x-dev"
+                    "dev-trunk": "8.8.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/wpcomsh/changelog/2026-07-27-08-54-33-268851
+++ b/projects/plugins/wpcomsh/changelog/2026-07-27-08-54-33-268851
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -832,7 +832,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "ac92fb106fb48e2bdfe0946da6e387b2f61585fb"
+                "reference": "f2b33840260110de1b61cfdb42e537e33989a4a7"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -869,7 +869,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.7.x-dev"
+                    "dev-trunk": "8.8.x-dev"
                 },
                 "dependencies": {
                     "test-only": [


### PR DESCRIPTION
## Proposed changes

* Release `automattic/jetpack-help-center` 0.1.0 by consuming its two pending changelog entries and replacing the alpha package version.
* Release the pending PHP and JavaScript dependencies selected by `tools/changelogger-release.sh packages/help-center`, including Jetpack Connection 8.8.0.
* Refresh affected plugin Composer locks and add lockfile-only changelog entries for their consumers.

## Related product discussion/links

* Follows #50807.
* The package is registered at https://packagist.org/packages/automattic/jetpack-help-center and its mirror is https://github.com/Automattic/jetpack-help-center.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run `tools/changelogger-validate-all.sh`.
* Run `tools/fixup-project-versions.sh` with a supported Node version and confirm it produces no additional changes.
* Run `pnpm jetpack test php packages/help-center --verbose`.
* Run `pnpm jetpack test php packages/connection --verbose`.
* Run `composer phpcs:lint projects/packages/help-center/src/class-help-center.php projects/packages/connection/src/class-error-handler.php projects/packages/connection/src/class-manager.php projects/packages/connection/src/class-package-version.php projects/packages/admin-ui/src/class-admin-menu.php`.

Local results:

* Changelog and project-version validation pass.
* Help Center: 13 tests, 19 assertions.
* Connection: 806 tests, 1,752 assertions, with one PHPUnit notice and three skipped tests.
* PHPCS and the repository pre-commit checks pass.
