### PR TITLE
Update woocommerce-analytics to 0.16.7

### DIFF
--- a/projects/plugins/jetpack/changelog/update-woocommerce-analytics-0.16.7
+++ b/projects/plugins/jetpack/changelog/update-woocommerce-analytics-0.16.7
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Updated package dependencies.

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -4075,16 +4075,16 @@
         },
         {
             "name": "automattic/woocommerce-analytics",
-            "version": "0.16.6",
+            "version": "0.16.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/woocommerce-analytics.git",
-                "reference": "92b67c5f12b3f9b3dcb34e1b668743cfbe552666"
+                "reference": "0437625896899842389fe38c3f807d46066edd1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/woocommerce-analytics/zipball/92b67c5f12b3f9b3dcb34e1b668743cfbe552666",
-                "reference": "92b67c5f12b3f9b3dcb34e1b668743cfbe552666",
+                "url": "https://api.github.com/repos/Automattic/woocommerce-analytics/zipball/0437625896899842389fe38c3f807d46066edd1a",
+                "reference": "0437625896899842389fe38c3f807d46066edd1a",
                 "shasum": ""
             },
             "require": {
@@ -4121,9 +4121,9 @@
             ],
             "description": "Enhanced analytics for WooCommerce users.",
             "support": {
-                "source": "https://github.com/Automattic/woocommerce-analytics/tree/v0.16.6"
+                "source": "https://github.com/Automattic/woocommerce-analytics/tree/v0.16.7"
             },
-            "time": "2026-06-17T08:21:41+00:00"
+            "time": "2026-07-27T09:32:22+00:00"
         },
         {
             "name": "wikimedia/aho-corasick",


### PR DESCRIPTION
Fixes #

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Bump the `automattic/woocommerce-analytics` dependency in the Jetpack plugin lock file from `0.16.6` to `0.16.7`.

The `^0.16` constraint in `projects/plugins/jetpack/composer.json` and `projects/packages/premium-analytics/composer.json` already allows `0.16.7`, so only `projects/plugins/jetpack/composer.lock` needs updating — this matches the previous bump in #48689.

`0.16.7` contains three patch-level changes from the WooCommerce monorepo:

* Stop emitting request-derived properties into cacheable front-end page HTML (security).
* Recognize active WooCommerce installations in custom plugin directories.
* Update package dependencies.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* Package release PR: woocommerce/woocommerce#67011
* Packagist: https://packagist.org/packages/automattic/woocommerce-analytics#0.16.7

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

Yes, indirectly, and in a privacy-reducing direction: `0.16.7` stops the package from emitting request-derived properties into cacheable front-end page HTML. No new data is collected.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Check out this branch and run `composer install` in `projects/plugins/jetpack`.
* Confirm `jetpack_vendor/automattic/woocommerce-analytics/composer.json` reports version `0.16.7`.
* On a site with WooCommerce and the Jetpack WooCommerce Analytics feature active, visit a product page and add a product to the cart.
* Confirm analytics events are still recorded as before, and that the front-end page HTML no longer contains request-derived properties.
