### PR TITLE
WPCOM Features: give Atomic sites the baseline free-plan purchase

### DIFF
--- a/projects/plugins/wpcomsh/changelog/fix-wpcom-features-atomic-baseline-purchase
+++ b/projects/plugins/wpcomsh/changelog/fix-wpcom-features-atomic-baseline-purchase
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+WPCOM Features: give Atomic sites the baseline free-plan purchase, so feature rules nesting WPCOM_ALL_SITES resolve the same on Atomic as they do WPCOM-side.

--- a/projects/plugins/wpcomsh/tests/WpcomFeaturesTest.php
+++ b/projects/plugins/wpcomsh/tests/WpcomFeaturesTest.php
@@ -12,6 +12,18 @@ class WpcomFeaturesTest extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 
 	/**
+	 * Clear the Atomic Persistent Data the tests below write, so purchases cannot leak between them.
+	 *
+	 * A leaked grant is the dangerous direction: it turns a later denial assertion into a confusing
+	 * pass somewhere else in the suite.
+	 */
+	public function tear_down() {
+		Atomic_Persistent_Data::delete( 'WPCOM_PURCHASES' );
+
+		parent::tear_down();
+	}
+
+	/**
 	 * Smoke-testing WPCOM Features.
 	 *
 	 * Pretty much just ensures there are no fatal errors, which is all we're interested in when syncing
@@ -33,8 +45,71 @@ class WpcomFeaturesTest extends WP_UnitTestCase {
 
 		$this->assertTrue( wpcom_site_has_feature( WPCOM_Features::CONCIERGE_BUSINESS ) );
 		$this->assertFalse( wpcom_site_has_feature( WPCOM_Features::ECOMMERCE_MANAGED_PLUGINS ) );
+	}
 
-		// Cleanup.
-		Atomic_Persistent_Data::delete( 'WPCOM_PURCHASES' );
+	/**
+	 * Atomic sites must receive the same baseline free-plan purchase that WPCOM-side evaluation appends.
+	 *
+	 * `wpcom_site_has_feature()` only reaches `add_free_plan_purchase()` when `$blog->registered` is
+	 * set, and `$blog` is never populated under IS_ATOMIC because the blogs table lives WPCOM-side.
+	 * The result was that feature rules nesting WPCOM_ALL_SITES inside a sub-array answered false on
+	 * Atomic while WPCOM answered true for the same blog.
+	 *
+	 * DONATIONS is the subject because it is reachable *only* through that baseline purchase. The
+	 * first assertion pins that property, so this test cannot start passing for the wrong reason if
+	 * DONATIONS is ever given a top-level WPCOM_ALL_SITES entry.
+	 */
+	public function test_atomic_site_receives_the_baseline_free_plan_purchase() {
+		$this->assertFalse(
+			WPCOM_Features::has_feature( WPCOM_Features::DONATIONS, array(), 'wpcom' ),
+			'DONATIONS is only a valid subject here while it stays unreachable without the baseline purchase.'
+		);
+
+		$this->assertTrue( wpcom_site_has_feature( WPCOM_Features::DONATIONS ) );
+	}
+
+	/**
+	 * The baseline purchase must not carry a subscription date.
+	 *
+	 * Atomic has no trustworthy registration date, and `purchase_in_products_map()` reads
+	 * `subscribed_date` to decide legacy date-gated rules. Passing a stand-in date instead of null
+	 * would hand out features nobody granted: an old date makes both features below match their
+	 * `'before'` branches. Left null, `isset()` fails and those branches stay closed.
+	 */
+	public function test_baseline_purchase_does_not_unlock_date_gated_features() {
+		$this->assertFalse( wpcom_site_has_feature( WPCOM_Features::STATS_FREE ) );
+		$this->assertFalse( wpcom_site_has_feature( WPCOM_Features::STATS_BASIC_TEMP ) );
+	}
+
+	/**
+	 * Owning a paid plan is no substitute for the baseline purchase.
+	 *
+	 * A nested all-sites rule is keyed on the literal `wpcom-all-sites` slug, which only
+	 * `add_free_plan_purchase()` produces — no real product slug matches it, however expensive. So
+	 * the baseline purchase has to be appended for every Atomic site, not just for sites that have
+	 * no purchase record.
+	 *
+	 * This is asserted against a rule built here rather than a real feature on purpose: today every
+	 * nested all-sites rule in FEATURES_MAP is also reachable from a paid plan through some other
+	 * branch, so no live feature can tell the two cases apart.
+	 */
+	public function test_paid_plans_do_not_satisfy_a_nested_all_sites_rule() {
+		$rule = array( array( 'wpcom-all-sites' ) );
+
+		$business                  = new stdClass();
+		$business->product_slug    = 'business-bundle';
+		$business->subscribed_date = '2024-01-01';
+
+		$baseline = array();
+		WPCOM_Features::add_free_plan_purchase( $baseline, 'wpcom', null );
+
+		$this->assertFalse(
+			WPCOM_Features::purchase_in_products_map( $business, $rule ),
+			'A paid plan must not match a nested all-sites rule, or this fix would be unnecessary for paid Atomic sites.'
+		);
+		$this->assertTrue(
+			WPCOM_Features::purchase_in_products_map( $baseline[0], $rule ),
+			'The baseline purchase is the only thing that satisfies a nested all-sites rule.'
+		);
 	}
 }

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-features.php
@@ -1884,9 +1884,11 @@ class WPCOM_Features {
 	 * Treat free plan as a purchase so the logic for purchase_in_products_map are applied when checking for legacy features.
 	 * As the free plan isn't actually a purchase, there is no subscribed_date, so we use the blog_registered_date instead.
 	 *
-	 * @param array  $purchases Reference to an array of purchases, this function adds a free plan to the end of the array passed in.
-	 * @param string $site_type Site type to check. Can be 'wpcom' or 'jetpack'.
-	 * @param string $blog_registered_date The date the blog was registered.
+	 * @param array       $purchases Reference to an array of purchases, this function adds a free plan to the end of the array passed in.
+	 * @param string      $site_type Site type to check. Can be 'wpcom' or 'jetpack'.
+	 * @param string|null $blog_registered_date The date the blog was registered, or null where no trustworthy date is
+	 *                                          available (Atomic). A null date leaves subscribed_date unset, so the
+	 *                                          purchase can never satisfy a legacy date-gated rule.
 	 */
 	public static function add_free_plan_purchase( &$purchases, $site_type, $blog_registered_date ) {
 		$free_purchase_object                  = new stdClass();

--- a/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
@@ -85,6 +85,20 @@ function wpcom_site_has_feature( $feature, $blog_id = 0 ) {
 
 	if ( isset( $blog->registered ) ) {
 		WPCOM_Features::add_free_plan_purchase( $purchases, $site_type, $blog->registered );
+	} elseif ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
+		/*
+		 * Atomic-side evaluation never populates $blog — the branch above needs the blogs table,
+		 * which only exists WPCOM-side. Without this, the baseline purchase that every site is
+		 * supposed to carry is missing on Atomic only, so feature rules that nest WPCOM_ALL_SITES
+		 * inside a sub-array resolve differently here than they do for the same blog on WPCOM.
+		 *
+		 * The date is deliberately null rather than a stand-in: Atomic has no trustworthy
+		 * registration date, and purchase_in_products_map() reads subscribed_date to decide legacy
+		 * date-gated rules. A fabricated date would hand out features nobody granted — an old one
+		 * unlocks STATS_FREE and STATS_BASIC_TEMP, for instance. Left null, isset() fails and every
+		 * date-gated branch stays closed, which is the behavior Atomic already has today.
+		 */
+		WPCOM_Features::add_free_plan_purchase( $purchases, $site_type, null );
 	}
 
 	return WPCOM_Features::has_feature( $feature, $purchases, $site_type, $blog_id );


### PR DESCRIPTION
Fixes #

## Proposed changes

- `wpcom_site_has_feature()` now appends the baseline free-plan purchase on Atomic sites, which it previously only did WPCOM-side.
- The Atomic purchase carries no subscription date, so it cannot satisfy legacy date-gated rules.
- Documents `add_free_plan_purchase()`'s `$blog_registered_date` as nullable.
- Adds WPCOMSH tests for the Atomic path, the date-gate guard, and the paid-plan case.

`add_free_plan_purchase()` appends a synthetic `wpcom-all-sites` purchase representing the baseline every site carries, independent of what it bought. `has_feature()` short-circuits on a _direct_ `WPCOM_ALL_SITES` element only — once the constant is nested inside a sub-array to pair it with a sticker gate or a date range, that synthetic purchase is the only thing that can match the rule.

The call is guarded on `isset( $blog->registered )`, and `$blog` is never populated under `IS_ATOMIC` because the branch that fills it reads the blogs table, which only exists WPCOM-side. Atomic therefore never received the purchase, and every nested-`WPCOM_ALL_SITES` rule answered false there while WPCOM answered true for the same blog. That split is the bug: `wpcom_site_has_feature()` is supposed to give one answer per site, and both answers are consumed — WPCOM's lands in `plan.features.active` on `/sites/%d` and is cached locally as `jetpack_active_plan`, while the Atomic one is what in-site callers and `Current_Plan::supports()` read.

Owning a plan does not paper over it. The rules are keyed on the literal `wpcom-all-sites` slug, which no real product slug matches, so a Business Atomic site is affected exactly as much as a free one.

### Why the date is null rather than a stand-in

Atomic has no trustworthy registration date, and `purchase_in_products_map()` reads `subscribed_date` to decide legacy date-gated rules. Passing a plausible-looking date would grant features nobody intended: measured against the current `FEATURES_MAP`, a 2020 date additionally unlocks `stats-free` and `stats-basic`. Left null, `isset()` fails and every date-gated branch stays closed — the behavior Atomic has today.

### Behavior change

Across all 158 registered features, exactly three change on Atomic:

| Feature                  | Before | After |
| ------------------------ | ------ | ----- |
| `donations`              | false  | true  |
| `payment-buttons`        | false  | true  |
| `paypal-payment-buttons` | false  | true  |

All three are branches shaped `array( 'sticker_not_present' => 'gating-business-q1', WPCOM_ALL_SITES )`, and all three are what WPCOM already answers for the same blog — so this converges Atomic onto the authoritative answer rather than granting anything new. Sites with a plan purchase see no change at all, because those features are already granted through their plan's branch.

The shared-file change is isolated in its own commit so it can be reviewed and, if needed, reverted independently.

## Related product discussion/links

- WOOA7S-1635

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The change only takes effect under `IS_ATOMIC`, which the WPCOMSH test suite defines.

- `jetpack docker phpunit wpcomsh -- --filter WpcomFeaturesTest` — 5 tests pass.
- Revert the `elseif` block in `wpcom_site_has_feature()` and re-run: `test_atomic_site_receives_the_baseline_free_plan_purchase` fails, the rest still pass.
- `jetpack docker phpunit wpcomsh` — full suite, 262 tests, no failures.
- `jetpack phan plugins/wpcomsh` — 0 issues.

On a real Atomic site, `wpcom_site_has_feature( WPCOM_Features::DONATIONS )` returns true after this change and matches what `/sites/<blog_id>` reports in `plan.features.active`; it returned false before.

The matching change to the WPCOM copy of these files is up for review separately; the two have to
land together, WPCOM first. Both copies carry the same edit byte for byte.
