### PR TITLE
Carousel: Fade the overlay with a CSS transition instead of a rAF loop

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-css-fade
+++ b/projects/plugins/jetpack/changelog/fix-carousel-css-fade
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Carousel: Run the overlay fade as a CSS transition instead of a main-thread animation loop, and honour prefers-reduced-motion.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -4,6 +4,24 @@
 	--jp-carousel-bg-color: #000;
 	--jp-carousel-bg-faded-color: #222;
 	--jp-carousel-border-color: #3a3a3a;
+	--jp-carousel-fade-duration: 100ms;
+}
+
+/*
+Every opacity fade in the module runs through this class, so it stays on the
+compositor and JS only has to flip the target value.
+*/
+.jp-carousel-fade {
+	transition: opacity var(--jp-carousel-fade-duration) ease-out;
+}
+
+@media ( prefers-reduced-motion: reduce ) {
+
+	.jp-carousel-fade {
+
+		/* Not 0s: `transitionend` still has to fire for the fade callbacks to run. */
+		transition-duration: 1ms;
+	}
 }
 
 :root .jp-carousel-light {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.css
@@ -18,9 +18,7 @@ compositor and JS only has to flip the target value.
 @media ( prefers-reduced-motion: reduce ) {
 
 	.jp-carousel-fade {
-
-		/* Not 0s: `transitionend` still has to fire for the fade callbacks to run. */
-		transition-duration: 1ms;
+		transition-duration: 0s;
 	}
 }
 

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -108,38 +108,48 @@
 			}
 		}
 
+		/**
+		 * CSS-transition fade (compositor). Duration + reduced-motion live in the
+		 * `.jp-carousel-fade` rule. A timer drives the finish, not `transitionend` -- that
+		 * event is skipped in background tabs / `transition: none` / zero duration, so the
+		 * timer is the reliable single source. `callback` fires once, after the fade.
+		 */
 		function fade( el, start, end, callback ) {
 			if ( ! el ) {
 				return callback();
 			}
 
-			// Prepare for transition.
-			// Ensure the item is in the render tree, in its initial state.
+			// A fade already running on this element must not deliver its callback any more.
+			if ( el.jpCarouselCancelFade ) {
+				el.jpCarouselCancelFade();
+			}
+
+			// Set + commit the start state before attaching the transition, or the fade is swallowed.
+			el.classList.remove( 'jp-carousel-fade' );
 			el.style.removeProperty( 'display' );
 			el.style.opacity = start;
 			el.style.pointerEvents = 'none';
 
-			var animate = function ( t0, duration ) {
-				var t = performance.now();
-				var diff = t - t0;
-				var ratio = diff / duration;
+			// Commit the starting opacity, otherwise the browser has nothing to animate from.
+			void el.offsetWidth;
 
-				if ( ratio < 1 ) {
-					el.style.opacity = start + ( end - start ) * ratio;
-					requestAnimationFrame( () => animate( t0, duration ) );
-				} else {
-					el.style.opacity = end;
-					el.style.removeProperty( 'pointer-events' );
-					callback();
-				}
+			el.classList.add( 'jp-carousel-fade' );
+			el.style.opacity = end;
+
+			// Read the duration back from the stylesheet so the timer always outlives the transition.
+			var duration = parseFloat( getComputedStyle( el ).transitionDuration ) * 1000 || 0;
+
+			var timer = setTimeout( function () {
+				el.jpCarouselCancelFade = null;
+				el.style.opacity = end;
+				el.style.removeProperty( 'pointer-events' );
+				callback();
+			}, duration + 50 );
+
+			el.jpCarouselCancelFade = function () {
+				clearTimeout( timer );
+				el.jpCarouselCancelFade = null;
 			};
-
-			requestAnimationFrame( function () {
-				// Double rAF for browser compatibility.
-				requestAnimationFrame( function () {
-					animate( performance.now(), 200 );
-				} );
-			} );
 		}
 
 		function fadeIn( el, callback ) {

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -141,7 +141,6 @@
 
 			var timer = setTimeout( function () {
 				el.jpCarouselCancelFade = null;
-				el.style.opacity = end;
 				el.style.removeProperty( 'pointer-events' );
 				callback();
 			}, duration + 50 );


### PR DESCRIPTION
Related to JETPACK-1517

## Proposed changes
* Replace `domUtil.fade()`'s main-thread `requestAnimationFrame` opacity ramp (hard-coded 200ms, behind a double-rAF) with a CSS `transition` on the compositor. The duration lives in the stylesheet as `--jp-carousel-fade-duration` (100ms).
* Honour `prefers-reduced-motion` (fade shortened to 1ms).
* Keep the `fadeIn`/`fadeOut` callback contract: `jp_carousel.afterOpen`/`afterClose` still fire and `fadeOut` still sets `display:none`. A watchdog timer covers a dropped `transitionend` so the overlay can never be left visible or pointer-blocking, and a second fade on an element cancels the first one's callback.

⚠️ The **100ms** duration is a taste call — needs a human eye. Median-of-7 sweep (warm, click → photo at full opacity): 50ms → 53ms, 80ms → 81ms, **100ms → 96ms**, 150ms → 144ms, 200ms (old) → 186ms. It's a one-line CSS change.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a `core/gallery` post (logged out), open and close the lightbox several times — the fade is visibly shorter than before but still a fade, no jank.
* After opening, click a control (arrow/close) to confirm the overlay is interactive; after closing, confirm it is fully gone (`.jp-carousel-overlay` has `display:none`).
* DevTools → Rendering → "Emulate CSS prefers-reduced-motion: reduce": the overlay appears and disappears instantly, and still opens/closes correctly.
* Open the lightbox, immediately switch to another browser tab, wait ~1s, return — the overlay must not be stuck half-faded or blocking clicks.
* Open the comments panel and toggle it — it still fades in/out (same `fade()` helper).

| Before | After |
|---|---|
|  |  |
