### PR TITLE
Carousel: Shorten the slide-to-slide transition to 150ms

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-slide-speed
+++ b/projects/plugins/jetpack/changelog/fix-carousel-slide-speed
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Carousel: Shorten the slide transition, and disable it entirely under prefers-reduced-motion.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -206,6 +206,12 @@
 			);
 		}
 
+		function prefersReducedMotion() {
+			return (
+				!! window.matchMedia && window.matchMedia( '(prefers-reduced-motion: reduce)' ).matches
+			);
+		}
+
 		function scrollToElement( el, container, callback ) {
 			if ( ! el || ! container ) {
 				if ( callback ) {
@@ -299,6 +305,7 @@
 			stripHTML: stripHTML,
 			emitEvent: emitEvent,
 			isTouch: isTouch,
+			prefersReducedMotion: prefersReducedMotion,
 		};
 	} )();
 
@@ -1668,6 +1675,11 @@
 
 			swiper = new window.JetpackSwiper( '.jp-carousel-swiper-container', {
 				centeredSlides: true,
+				/*
+				Swiper's 300ms default is most of what makes slide-to-slide feel slow. Keep a
+				visible movement -- the slide is a real affordance on touch -- but a shorter one.
+				*/
+				speed: domUtil.prefersReducedMotion() ? 0 : 150,
 				zoom: true,
 				loop: carousel.slides.length > 1,
 				// Turn off interactions and hide navigation arrows if there is only one slide.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -1679,7 +1679,7 @@
 				Swiper's 300ms default is most of what makes slide-to-slide feel slow. Keep a
 				visible movement -- the slide is a real affordance on touch -- but a shorter one.
 				*/
-				speed: domUtil.prefersReducedMotion() ? 0 : 150,
+				speed: domUtil.prefersReducedMotion() ? 0 : 250,
 				zoom: true,
 				loop: carousel.slides.length > 1,
 				// Turn off interactions and hide navigation arrows if there is only one slide.


### PR DESCRIPTION
Related to JETPACK-1517

## Proposed changes
* Swiper was left on its 300ms default slide transition. Set `speed` to **150ms**.
* Disable the slide animation entirely under `prefers-reduced-motion` (`speed: 0`).

Not cut to 0 for everyone: the slide gesture is a real affordance on touch, which Core's lightbox lacks.

⚠️ The **150ms** is a taste call — needs a human eye. Median-of-7 sweep for "incoming image becomes the dominant one on screen": 300ms (old) → 90ms, 200ms → 61ms, **150ms → 48ms**, 120ms → 57ms.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Open a `core/gallery` and page through it with the on-screen arrows and the ←/→ keys — transitions feel quicker but not like a hard cut.
* On a touch device (or DevTools device mode), swipe between slides — the gesture still tracks the finger and settles naturally.
* DevTools → Rendering → "Emulate CSS prefers-reduced-motion: reduce": slides change instantly, navigation still works.

| Before | After |
|---|---|
|  |  |
