### PR TITLE
Carousel: Prefetch the Swiper library instead of fetching it on first click

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-prefetch-swiper
+++ b/projects/plugins/jetpack/changelog/fix-carousel-prefetch-swiper
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Carousel: Prefetch the Swiper library so the first click on a gallery image does not wait for it.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -455,6 +455,7 @@ class Jetpack_Carousel {
 				'url' => plugins_url( '_inc/blocks/swiper.js', JETPACK__PLUGIN_FILE ),
 			);
 			wp_localize_script( 'jetpack-carousel', 'jetpackSwiperLibraryPath', $swiper_library_path );
+			add_action( 'wp_footer', array( $this, 'prefetch_swiper_library' ) );
 
 			// Note: using  home_url() instead of admin_url() for ajaxurl to be sure  to get same domain on wpcom when using mapped domains (also works on self-hosted).
 			// Also: not hardcoding path since there is no guarantee site is running on site root in self-hosted context.
@@ -569,6 +570,22 @@ class Jetpack_Carousel {
 
 			$this->first_run = false;
 		}
+	}
+
+	/**
+	 * Hint the browser to fetch the Swiper library while it is idle.
+	 *
+	 * Swiper is only requested when the lightbox is first opened, which puts a network
+	 * round trip in front of that first click. This is deliberately `prefetch` rather than
+	 * `preload`: most visitors never open the lightbox, so the fetch must stay at low
+	 * priority and out of the way of the page's own images. `loadSwiper()` still loads the
+	 * library on demand, since a prefetch is a hint the browser is free to ignore.
+	 */
+	public function prefetch_swiper_library() {
+		printf(
+			'<link rel="prefetch" href="%s" as="script" />' . "\n",
+			esc_url( plugins_url( '_inc/blocks/swiper.js', JETPACK__PLUGIN_FILE ) )
+		);
 	}
 
 	/**


### PR DESCRIPTION
Related to JETPACK-1517

## Proposed changes
* Swiper was only requested when the lightbox was first opened, putting a network round trip behind a spinner in front of that first click. Emit a `<link rel="prefetch" as="script">` for `swiper.js` on pages that already enqueue the Carousel.
* Deliberately `prefetch`, not `preload`: the library is ~46KB brotli and most visitors never open the lightbox, so it must fetch at idle/low priority and not compete with the page's own images.
* `loadSwiper()` keeps its on-demand path — a prefetch is only a hint, so the spinner still works if it's ignored. Swiper is not bundled into the main script (that would add 46KB to every gallery page).

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Load a gallery page in a **fresh** profile with DevTools → Network open. `swiper.js` is requested at "Lowest" priority during idle, before you click anything.
* Click a gallery image: the second `swiper.js` request shows `(prefetch cache)` / size 0, and the loading spinner does **not** appear.
* In DevTools Network, right-click → "Block request URL" on `swiper.js`, reload, then click an image — the spinner path still works and the lightbox still opens once it loads.
* Confirm no `<link rel="prefetch">` for swiper is emitted on an AMP view of the page (the module falls back to `amp-lightbox` and doesn't enqueue the carousel there).

Cold first open (fresh profile, 4× CPU / Fast 4G, mid-gallery image, production-built swiper.js): **2732ms → 913ms** to first pixels.
