### PR TITLE
AI Launchpad: drop the AI-onboarded exclusion

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/2026-07-27-10-00-00-000000
+++ b/projects/packages/jetpack-mu-wpcom/changelog/2026-07-27-10-00-00-000000
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Launchpad: keep explicitly enabled sites eligible after a Big Sky build; the AI-onboarded exclusion now only applies to experiment-variation enablement.

--- a/projects/packages/jetpack-mu-wpcom/changelog/2026-07-27-10-00-00-000000
+++ b/projects/packages/jetpack-mu-wpcom/changelog/2026-07-27-10-00-00-000000
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-AI Launchpad: keep explicitly enabled sites eligible after a Big Sky build; the AI-onboarded exclusion now only applies to experiment-variation enablement.
+AI Launchpad: drop the AI-onboarded exclusion — sites built with Big Sky are now eligible like any other; the tasklist tailors to what the build already covered.

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
@@ -75,17 +75,14 @@ class AI_Launchpad {
 	 * Whether the current site is eligible for the AI Launchpad.
 	 *
 	 * Gate: enabled for the site (see is_enabled_for_site()) and not dismissed (skipping the
-	 * wizard dismisses it, reverting the site to the regular launchpad). The paid-plan
-	 * requirement is temporarily lifted (see below).
+	 * wizard dismisses it, reverting the site to the regular launchpad).
 	 *
 	 * @return bool
 	 */
 	public static function is_eligible() {
 		static $eligible = null;
 
-		if ( null === $eligible ) {
-			// TEMPORARY: the paid-plan gate is lifted so the AI Launchpad is available on all plans, including free.
-			// Revert this commit to re-require a paid bundle (the removed has_paid_plan() check).
+		if (null === $eligible) {
 			$eligible = self::is_enabled_for_site()
 				&& ! get_option( \AI_Launchpad_REST::OPTION_DISMISSED );
 		}
@@ -102,9 +99,7 @@ class AI_Launchpad {
 	 */
 	private static function is_enabled_for_site() {
 		// Explicit per-site switch: set at site creation for the ai_launchpad onboarding
-		// cohort, by the ?enable-ai-launchpad=1 dev handler, or manually. AI-built sites
-		// (Big Sky) are eligible like any other: the tasklist tailors to what the build
-		// already covered, so an AI onboarding is no reason to withhold the launchpad.
+		// cohort, by the ?enable-ai-launchpad=1 dev handler, or manually.
 		if ( (bool) get_option( 'wpcom_ai_launchpad_enabled' ) ) {
 			return true;
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
@@ -82,7 +82,7 @@ class AI_Launchpad {
 	public static function is_eligible() {
 		static $eligible = null;
 
-		if (null === $eligible) {
+		if ( null === $eligible ) {
 			$eligible = self::is_enabled_for_site()
 				&& ! get_option( \AI_Launchpad_REST::OPTION_DISMISSED );
 		}

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
@@ -94,15 +94,6 @@ class AI_Launchpad {
 	}
 
 	/**
-	 * Whether the site already went through an AI onboarding flow.
-	 *
-	 * @return bool
-	 */
-	private static function was_ai_onboarded() {
-		return get_option( 'site_intent' ) === 'ai-assembler' || get_option( 'site_creation_flow' ) === 'ai-site-builder';
-	}
-
-	/**
 	 * Whether the AI Launchpad has been explicitly enabled for this site.
 	 *
 	 * Set per-site with `wp option update wpcom_ai_launchpad_enabled 1`.
@@ -111,17 +102,14 @@ class AI_Launchpad {
 	 */
 	private static function is_enabled_for_site() {
 		// Explicit per-site switch: set at site creation for the ai_launchpad onboarding
-		// cohort, by the ?enable-ai-launchpad=1 dev handler, or manually. It deliberately
-		// bypasses the AI-onboarded exclusion below, so an explicitly enabled site keeps
-		// its AI Launchpad even after building with Big Sky.
+		// cohort, by the ?enable-ai-launchpad=1 dev handler, or manually. AI-built sites
+		// (Big Sky) are eligible like any other: the tasklist tailors to what the build
+		// already covered, so an AI onboarding is no reason to withhold the launchpad.
 		if ( (bool) get_option( 'wpcom_ai_launchpad_enabled' ) ) {
 			return true;
 		}
 
-		// Implicit enablement via the experiment variation: excludes sites that already
-		// went through an AI onboarding flow, which covers the setup the launchpad guides.
-		return 'ai_launchpad' === Launchpad_Personalization_Experiment::get_variation()
-			&& ! self::was_ai_onboarded();
+		return 'ai_launchpad' === Launchpad_Personalization_Experiment::get_variation();
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/ai-launchpad/ai-launchpad.php
@@ -74,9 +74,9 @@ class AI_Launchpad {
 	/**
 	 * Whether the current site is eligible for the AI Launchpad.
 	 *
-	 * Gate: not already AI-onboarded, not dismissed (skipping the wizard dismisses it, reverting the site
-	 * to the regular launchpad), and explicitly enabled for the site via the `wpcom_ai_launchpad_enabled`
-	 * option. The paid-plan requirement is temporarily lifted (see below).
+	 * Gate: enabled for the site (see is_enabled_for_site()) and not dismissed (skipping the
+	 * wizard dismisses it, reverting the site to the regular launchpad). The paid-plan
+	 * requirement is temporarily lifted (see below).
 	 *
 	 * @return bool
 	 */
@@ -87,7 +87,6 @@ class AI_Launchpad {
 			// TEMPORARY: the paid-plan gate is lifted so the AI Launchpad is available on all plans, including free.
 			// Revert this commit to re-require a paid bundle (the removed has_paid_plan() check).
 			$eligible = self::is_enabled_for_site()
-				&& ! self::was_ai_onboarded()
 				&& ! get_option( \AI_Launchpad_REST::OPTION_DISMISSED );
 		}
 
@@ -111,13 +110,18 @@ class AI_Launchpad {
 	 * @return bool
 	 */
 	private static function is_enabled_for_site() {
-		// Legacy per-site switch kept as a manual/dev override: the ?enable-ai-launchpad=1
-		// handler and the onboarding hand-off both set this option.
+		// Explicit per-site switch: set at site creation for the ai_launchpad onboarding
+		// cohort, by the ?enable-ai-launchpad=1 dev handler, or manually. It deliberately
+		// bypasses the AI-onboarded exclusion below, so an explicitly enabled site keeps
+		// its AI Launchpad even after building with Big Sky.
 		if ( (bool) get_option( 'wpcom_ai_launchpad_enabled' ) ) {
 			return true;
 		}
 
-		return 'ai_launchpad' === Launchpad_Personalization_Experiment::get_variation();
+		// Implicit enablement via the experiment variation: excludes sites that already
+		// went through an AI onboarding flow, which covers the setup the launchpad guides.
+		return 'ai_launchpad' === Launchpad_Personalization_Experiment::get_variation()
+			&& ! self::was_ai_onboarded();
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Eligibility_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Eligibility_Test.php
@@ -71,18 +71,18 @@ class AI_Launchpad_Eligibility_Test extends \WorDBless\BaseTestCase {
 	 *
 	 * The paid-plan requirement is temporarily lifted, so eligibility depends on the
 	 * per-site enabled option and the user not having dismissed the AI Launchpad
-	 * (skipping the wizard dismisses it). The AI-onboarded exclusion does not apply
-	 * to the explicit per-site option, only to variation-based enablement.
+	 * (skipping the wizard dismisses it). Being AI-onboarded (e.g. built with Big Sky)
+	 * does not affect eligibility either way.
 	 *
 	 * @return array
 	 */
 	public static function provide_eligibility_inputs() {
 		return array(
-			'enabled'                         => array( false, true, false, true ),
-			'not enabled'                     => array( false, false, false, false ),
-			'onboarded keeps explicit enable' => array( true, true, false, true ),
-			'onboarded without enable blocks' => array( true, false, false, false ),
-			'dismissed blocks'                => array( false, true, true, false ),
+			'enabled'                     => array( false, true, false, true ),
+			'not enabled'                 => array( false, false, false, false ),
+			'ai-onboarded stays eligible' => array( true, true, false, true ),
+			'ai-onboarded without enable' => array( true, false, false, false ),
+			'dismissed blocks'            => array( false, true, true, false ),
 		);
 	}
 
@@ -100,18 +100,18 @@ class AI_Launchpad_Eligibility_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Variation-based enablement is still excluded for AI-onboarded sites (e.g. a site
-	 * built with Big Sky without the explicit per-site option).
+	 * Variation-based enablement also covers AI-onboarded sites (e.g. a site built
+	 * with Big Sky): the tasklist tailors to what the build already covered.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
 	#[RunInSeparateProcess]
 	#[PreserveGlobalState( false )]
-	public function test_ai_launchpad_variation_is_not_eligible_when_ai_onboarded() {
+	public function test_ai_launchpad_variation_is_eligible_for_ai_built_sites() {
 		add_filter( 'wpcom_launchpad_personalization_variation', fn() => 'ai_launchpad' );
 		update_option( 'site_intent', 'ai-assembler' );
-		$this->assertFalse( AI_Launchpad::is_eligible() );
+		$this->assertTrue( AI_Launchpad::is_eligible() );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Eligibility_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Eligibility_Test.php
@@ -70,17 +70,19 @@ class AI_Launchpad_Eligibility_Test extends \WorDBless\BaseTestCase {
 	 * Data provider for test_is_eligible.
 	 *
 	 * The paid-plan requirement is temporarily lifted, so eligibility depends on the
-	 * per-site enabled option, the site not already being AI-onboarded, and the user
-	 * not having dismissed the AI Launchpad (skipping the wizard dismisses it).
+	 * per-site enabled option and the user not having dismissed the AI Launchpad
+	 * (skipping the wizard dismisses it). The AI-onboarded exclusion does not apply
+	 * to the explicit per-site option, only to variation-based enablement.
 	 *
 	 * @return array
 	 */
 	public static function provide_eligibility_inputs() {
 		return array(
-			'enabled'          => array( false, true, false, true ),
-			'not enabled'      => array( false, false, false, false ),
-			'onboarded blocks' => array( true, true, false, false ),
-			'dismissed blocks' => array( false, true, true, false ),
+			'enabled'                          => array( false, true, false, true ),
+			'not enabled'                      => array( false, false, false, false ),
+			'onboarded keeps explicit enable'  => array( true, true, false, true ),
+			'onboarded without enable blocks'  => array( true, false, false, false ),
+			'dismissed blocks'                 => array( false, true, true, false ),
 		);
 	}
 
@@ -95,6 +97,21 @@ class AI_Launchpad_Eligibility_Test extends \WorDBless\BaseTestCase {
 	public function test_ai_launchpad_variation_makes_the_site_eligible() {
 		add_filter( 'wpcom_launchpad_personalization_variation', fn() => 'ai_launchpad' );
 		$this->assertTrue( AI_Launchpad::is_eligible() );
+	}
+
+	/**
+	 * Variation-based enablement is still excluded for AI-onboarded sites (e.g. a site
+	 * built with Big Sky without the explicit per-site option).
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_ai_launchpad_variation_is_not_eligible_when_ai_onboarded() {
+		add_filter( 'wpcom_launchpad_personalization_variation', fn() => 'ai_launchpad' );
+		update_option( 'site_intent', 'ai-assembler' );
+		$this->assertFalse( AI_Launchpad::is_eligible() );
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Eligibility_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/ai-launchpad/AI_Launchpad_Eligibility_Test.php
@@ -78,11 +78,11 @@ class AI_Launchpad_Eligibility_Test extends \WorDBless\BaseTestCase {
 	 */
 	public static function provide_eligibility_inputs() {
 		return array(
-			'enabled'                          => array( false, true, false, true ),
-			'not enabled'                      => array( false, false, false, false ),
-			'onboarded keeps explicit enable'  => array( true, true, false, true ),
-			'onboarded without enable blocks'  => array( true, false, false, false ),
-			'dismissed blocks'                 => array( false, true, true, false ),
+			'enabled'                         => array( false, true, false, true ),
+			'not enabled'                     => array( false, false, false, false ),
+			'onboarded keeps explicit enable' => array( true, true, false, true ),
+			'onboarded without enable blocks' => array( true, false, false, false ),
+			'dismissed blocks'                => array( false, true, true, false ),
 		);
 	}
 


### PR DESCRIPTION
Follow-up to #50803. Part of DOTOBRD-567.

## Proposed changes

* Drop the `was_ai_onboarded()` exclusion from the AI Launchpad eligibility gate: sites built via an AI onboarding (Big Sky / `ai-site-builder`) are now eligible like any other, whether enabled via the explicit `wpcom_ai_launchpad_enabled` option or the `ai_launchpad` experiment variation.

## Related product discussion/links

* DOTOBRD-567
* Automattic/wp-calypso#112953

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site with `wp option update wpcom_ai_launchpad_enabled 1` and `wp option update site_intent ai-assembler`: the AI Launchpad menu/page registers (previously it did not).
* Same with only the `ai_launchpad` experiment variation (no option): the AI Launchpad registers too.
* `composer phpunit -- --filter AI_Launchpad_Eligibility_Test` in `projects/packages/jetpack-mu-wpcom` (10 passing).

### Why

In the `wpcom_launchpad_personalization_202607_v1` experiment, `ai_launchpad`-cohort sites are created with the option already set (companion Calypso PR: Automattic/wp-calypso#112953, plus a wpcom change that accepts the option in `/sites/new`). These users see the Big Sky chooser post-checkout in all arms; if they build with Big Sky, the site gains the `ai-assembler` intent, which previously flipped `was_ai_onboarded()` and stranded the site: Calypso (which reads the raw option) would keep redirecting `/home` to a Site Setup page wp-admin no longer registers. The AI Launchpad's tasklist already tailors to what an AI build covered, so there is no product reason to withhold it from AI-built sites — the exclusion is dropped rather than special-cased.
