### PR TITLE
Carousel: Fetch comments when the panel is opened, not on every slide

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-lazy-comments
+++ b/projects/plugins/jetpack/changelog/fix-carousel-lazy-comments
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Carousel: Stop fetching comments on every slide change; fetch them when the comments panel is opened.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -307,6 +307,12 @@
 	/////////////////////////////////////
 	function init() {
 		var commentInterval;
+		// Rendered comments per attachment, kept for the lifetime of one overlay session.
+		var commentsCache = {};
+		// Attachment IDs with a comments request in flight, to prevent overlapping fetches.
+		var commentsFetching = {};
+		// Comments the server returns per page; mirrors the `number` arg in get_attachment_comments().
+		var COMMENTS_PER_PAGE = 10;
 		var screenPadding;
 		var originalOverflow;
 		var originalHOverflow;
@@ -602,6 +608,18 @@
 						}
 						if ( response.comment_status === 'approved' ) {
 							updatePostResults( jetpackCarouselStrings.comment_approved, true );
+							/*
+							Reflect the new comment in the badge total straight away. The refetch
+							below only returns the first page, so on attachments with a full page
+							of comments it cannot see the increment on its own. Bump the slide the
+							comment was posted to -- captured as `attachmentId` -- not whichever
+							slide happens to be current when this async response lands.
+							*/
+							var postedSlide = getSlideByAttachmentId( attachmentId );
+							if ( postedSlide ) {
+								postedSlide.attrs.commentsCount =
+									( parseInt( postedSlide.attrs.commentsCount, 10 ) || 0 ) + 1;
+							}
 						} else if ( response.comment_status === 'unapproved' ) {
 							updatePostResults( jetpackCarouselStrings.comment_unapproved, true );
 						} else {
@@ -609,7 +627,11 @@
 							updatePostResults( jetpackCarouselStrings.comment_post_error, false );
 						}
 						clearCommentTextAreaValue();
-						fetchComments( attachmentId );
+						// The new comment invalidates whatever we cached for this attachment.
+						delete commentsCache[ attachmentId ];
+						// Force past the in-flight guard so a still-pending first page can't
+						// suppress this refresh.
+						fetchComments( attachmentId, undefined, true );
 						submit.value = jetpackCarouselStrings.post_comment;
 						domUtil.hide( spinner );
 						form.classList.remove( 'jp-carousel-is-disabled' );
@@ -680,6 +702,17 @@
 					commentsContainer.classList.toggle( 'jp-carousel-show' );
 					if ( commentsContainer.classList.contains( 'jp-carousel-show' ) ) {
 						extraInfoContainer.classList.add( 'jp-carousel-show' );
+						// The panel is only now on screen, so this is when the comments are worth fetching.
+						var current = carousel.currentSlide;
+						if ( current ) {
+							var currentCache = commentsCache[ current.attrs.attachmentId ];
+							if ( ! currentCache ) {
+								fetchComments( current.attrs.attachmentId );
+							} else if ( currentCache.hasMore ) {
+								// Cached page is already shown; re-arm paging for the rest.
+								scheduleNextCommentsPage( current.attrs.attachmentId, currentCache.nextOffset );
+							}
+						}
 					} else {
 						extraInfoContainer.classList.remove( 'jp-carousel-show' );
 					}
@@ -779,6 +812,15 @@
 			}
 		}
 
+		function getSlideByAttachmentId( attachmentId ) {
+			for ( var i = 0; i < carousel.slides.length; i++ ) {
+				if ( carousel.slides[ i ].attrs.attachmentId === attachmentId ) {
+					return carousel.slides[ i ];
+				}
+			}
+			return null;
+		}
+
 		function selectSlideAtIndex( index ) {
 			if ( ! index || index < 0 || index > carousel.slides.length ) {
 				index = 0;
@@ -814,7 +856,7 @@
 
 			if ( Number( jetpackCarouselStrings.display_comments ) === 1 ) {
 				testCommentsOpened( carousel.slides[ index ].attrs.commentsOpened );
-				fetchComments( attachmentId );
+				showCommentsForSlide( current );
 				domUtil.hide( carousel.info.querySelector( '#jp-carousel-comment-post-results' ) );
 			}
 
@@ -863,6 +905,8 @@
 			swiper.destroy();
 			// Clear slide data for DOM garbage collection.
 			carousel.slides = [];
+			commentsCache = {};
+			commentsFetching = {};
 			carousel.currentSlide = undefined;
 			carousel.gallery.innerHTML = '';
 
@@ -1215,17 +1259,106 @@
 			}
 		}
 
-		function fetchComments( attachmentId, offset ) {
-			var shouldClear = offset === undefined;
-			var commentsIndicator = carousel.info.querySelector(
+		function isCommentsPanelOpen() {
+			var wrapper = carousel.info.querySelector( '.jp-carousel-comments-wrapper' );
+			return !! wrapper && wrapper.classList.contains( 'jp-carousel-show' );
+		}
+
+		function updateCommentsIndicator( count ) {
+			var indicator = carousel.info.querySelector(
 				'.jp-carousel-icon-comments .jp-carousel-has-comments-indicator'
 			);
 
-			commentsIndicator.classList.remove( 'jp-carousel-show' );
+			if ( ! indicator ) {
+				return;
+			}
+
+			if ( count > 0 ) {
+				indicator.innerText = count;
+				indicator.classList.add( 'jp-carousel-show' );
+			} else {
+				indicator.classList.remove( 'jp-carousel-show' );
+			}
+		}
+
+		/**
+		 * Show what we already know about a slide's comments, and fetch the rest only if the
+		 * comments panel is actually on screen. The comment list used to be re-fetched from
+		 * admin-ajax on every single slide change, even though it is hidden by default.
+		 * @param {object} slide - The slide being shown.
+		 */
+		function showCommentsForSlide( slide ) {
+			var attachmentId = slide.attrs.attachmentId;
+			var comments = carousel.info.querySelector( '.jp-carousel-comments' );
+			var cached = commentsCache[ attachmentId ];
+
+			clearInterval( commentInterval );
+			domUtil.hide( carousel.info.querySelector( '#jp-carousel-comments-loading' ) );
+
+			if ( cached ) {
+				comments.innerHTML = cached.html;
+				updateCommentsIndicator( cached.count );
+				domUtil.show( comments );
+				/*
+				Resume paging if the cached run ended on a full page, so returning to a slide
+				does not strand the comments past the first page. Only while the panel is on
+				screen, mirroring the fresh-fetch path below.
+				*/
+				if ( cached.hasMore && isCommentsPanelOpen() ) {
+					scheduleNextCommentsPage( attachmentId, cached.nextOffset );
+				}
+				return;
+			}
+
+			comments.innerHTML = '';
+			domUtil.hide( comments );
+			// The server tells us the count up front, so the badge costs no request.
+			updateCommentsIndicator( parseInt( slide.attrs.commentsCount, 10 ) || 0 );
+
+			if ( isCommentsPanelOpen() ) {
+				fetchComments( attachmentId );
+			}
+		}
+
+		/**
+		 * Fetch the next page of comments once the reader scrolls near the bottom.
+		 * @param {string} attachmentId - The attachment whose comments are shown.
+		 * @param {number} nextOffset   - Offset of the page to load next.
+		 */
+		function scheduleNextCommentsPage( attachmentId, nextOffset ) {
+			clearInterval( commentInterval );
+			commentInterval = setInterval( function () {
+				if ( carousel.container.scrollTop + 150 > window.innerHeight ) {
+					clearInterval( commentInterval );
+					fetchComments( attachmentId, nextOffset );
+				}
+			}, 300 );
+		}
+
+		function fetchComments( attachmentId, offset, force ) {
+			var shouldClear = offset === undefined;
 
 			clearInterval( commentInterval );
 
 			if ( ! attachmentId ) {
+				return;
+			}
+
+			/*
+			The comments UI is shared and only ever shows the current slide, so a request for
+			any other slide (e.g. a post-submit refetch after the reader has navigated on) must
+			not touch it.
+			*/
+			if ( ! carousel.currentSlide || carousel.currentSlide.attrs.attachmentId !== attachmentId ) {
+				return;
+			}
+
+			/*
+			One request per attachment at a time, so a reopen mid-flight can't double-load.
+			`force` (a post-submit refresh) supersedes instead: the newest request is recorded
+			below and any older one's response bails on the identity check.
+			*/
+			if ( commentsFetching[ attachmentId ] && ! force ) {
 				return;
 			}
 
@@ -1243,6 +1376,14 @@
 			}
 
 			var xhr = new XMLHttpRequest();
+			// Record this as the live request for the attachment; a later `force` fetch replaces it.
+			commentsFetching[ attachmentId ] = xhr;
+
+			// True while `xhr` is still the attachment's live request (not superseded).
+			var isLiveRequest = function () {
+				return commentsFetching[ attachmentId ] === xhr;
+			};
+
 			var url =
 				jetpackCarouselStrings.ajaxurl +
 				'?action=get_attachment_comments' +
@@ -1255,12 +1396,38 @@
 			xhr.open( 'GET', url );
 			xhr.setRequestHeader( 'X-Requested-With', 'XMLHttpRequest' );
 
-			var onError = function () {
+			// Reveal the comments and clear the loading state; callers gate this themselves.
+			var revealComments = function () {
 				domUtil.fadeIn( comments );
 				domUtil.fadeOut( commentsLoading );
 			};
 
+			// Network-level failure (fires without onload); guard it like a late response.
+			var onError = function () {
+				// A newer (forced) request has superseded this one; leave the UI to it.
+				if ( ! isLiveRequest() ) {
+					return;
+				}
+				delete commentsFetching[ attachmentId ];
+
+				// Only touch the shared UI if this attachment is still on screen.
+				if (
+					! carousel.currentSlide ||
+					carousel.currentSlide.attrs.attachmentId !== attachmentId
+				) {
+					return;
+				}
+				revealComments();
+			};
+
 			xhr.onload = function () {
+				// A newer (forced) request has superseded this one; drop its result.
+				if ( ! isLiveRequest() ) {
+					return;
+				}
+				// The request is done, whatever the outcome below.
+				delete commentsFetching[ attachmentId ];
+
 				// Ignore the results if they arrive late and we're now on a different slide.
 				if (
 					! carousel.currentSlide ||
@@ -1278,7 +1445,9 @@
 				}
 
 				if ( ! isSuccess || ! data || ! Array.isArray( data ) ) {
-					return onError();
+					// Already past the identity/current-slide guards above.
+					revealComments();
+					return;
 				}
 
 				if ( shouldClear ) {
@@ -1287,6 +1456,11 @@
 
 				for ( var i = 0; i < data.length; i++ ) {
 					var entry = data[ i ];
+					// Skip anything already on screen: a page can be requested twice if the
+					// reader re-opens a slide while its previous request is still in flight.
+					if ( comments.querySelector( '#jp-carousel-comment-' + entry.id ) ) {
+						continue;
+					}
 					var comment = document.createElement( 'div' );
 					comment.classList.add( 'jp-carousel-comment' );
 					comment.setAttribute( 'id', 'jp-carousel-comment-' + entry.id );
@@ -1304,22 +1478,43 @@
 						entry.content +
 						'</div>';
 					comments.appendChild( comment );
-
-					// Set the interval to check for a new page of comments.
-					clearInterval( commentInterval );
-					commentInterval = setInterval( function () {
-						if ( carousel.container.scrollTop + 150 > window.innerHeight ) {
-							fetchComments( attachmentId, offset + 10 );
-							clearInterval( commentInterval );
-						}
-					}, 300 );
 				}
+
+				/*
+				A full page back means there may be more; watch for a scroll to the bottom to
+				load the next one. A short page means we have reached the end.
+				*/
+				var hasMore = data.length >= COMMENTS_PER_PAGE;
+				var nextOffset = offset + COMMENTS_PER_PAGE;
+				if ( hasMore ) {
+					scheduleNextCommentsPage( attachmentId, nextOffset );
+				}
+
+				/*
+				The endpoint returns at most one page, so prefer the server's total where we
+				have it and only count what we rendered as a fallback.
+				*/
+				var rendered = comments.querySelectorAll( '.jp-carousel-comment' ).length;
+				var count = Math.max(
+					parseInt( carousel.currentSlide.attrs.commentsCount, 10 ) || 0,
+					rendered
+				);
 
 				if ( data.length > 0 ) {
 					domUtil.show( comments );
-					commentsIndicator.innerText = data.length;
-					commentsIndicator.classList.add( 'jp-carousel-show' );
+					updateCommentsIndicator( count );
 				}
+
+				/*
+				Keep what we rendered for as long as the overlay is open, so going back to a
+				slide costs nothing -- including where to resume paging from.
+				*/
+				commentsCache[ attachmentId ] = {
+					html: comments.innerHTML,
+					count: count,
+					hasMore: hasMore,
+					nextOffset: nextOffset,
+				};
 
 				domUtil.hide( commentsLoading );
 			};
@@ -1512,6 +1707,7 @@
 					originalElement: item,
 					attachmentId: attrID,
 					commentsOpened: item.getAttribute( 'data-comments-opened' ) || '0',
+					commentsCount: item.getAttribute( 'data-comments-count' ) || '0',
 					imageMeta: domUtil.getJSONAttribute( item, 'data-image-meta' ) || {},
 					title: item.getAttribute( 'data-image-title' ) || '',
 					desc: item.getAttribute( 'data-image-description' ) || '',
@@ -1659,6 +1855,8 @@
 
 			domUtil.emitEvent( carousel.overlay, 'jp_carousel.beforeOpen' );
 			carousel.gallery.innerHTML = '';
+			commentsCache = {};
+			commentsFetching = {};
 
 			// Need to set the overlay manually to block or swiper does't initialise properly.
 			carousel.overlay.style.opacity = 1;

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -985,6 +985,16 @@ class Jetpack_Carousel {
 		$attr['data-orig-size']       = $size;
 		$attr['data-comments-opened'] = $comments_opened;
 
+		/*
+		Lets the Carousel show its "has comments" badge without fetching the comments
+		themselves. Omitted when there are none, which is the common case, so galleries
+		without comments pay nothing for it.
+		*/
+		$comments_count = (int) $attachment->comment_count;
+		if ( $comments_count > 0 ) {
+			$attr['data-comments-count'] = $comments_count;
+		}
+
 		if ( $display_exif ) {
 			// See https://github.com/Automattic/jetpack/issues/2765.
 			if ( isset( $img_meta['keywords'] ) ) {

--- a/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/templates/partials/carousel-image-args.php
+++ b/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/templates/partials/carousel-image-args.php
@@ -21,6 +21,12 @@ $item = $context['item'];
 $display_exif     = 1 === (int) Jetpack_Options::get_option_and_ensure_autoload( 'carousel_display_exif', 1 );
 $fuzzy_image_meta = '';
 
+/*
+Lets the Carousel show its "has comments" badge without fetching the comments
+themselves. Omitted when there are none. Mirrors Jetpack_Carousel::add_data_to_images().
+*/
+$comments_count = (int) $item->image->comment_count;
+
 if ( $display_exif ) {
 	$image_meta = $item->fuzzy_image_meta(); // See https://github.com/Automattic/jetpack/issues/2765 .
 	if ( isset( $image_meta['keywords'] ) ) {
@@ -36,6 +42,9 @@ data-attachment-id="<?php echo esc_attr( $item->image->ID ); ?>"
 data-orig-file="<?php echo esc_url( wp_get_attachment_url( $item->image->ID ) ); ?>"
 data-orig-size="<?php echo esc_attr( $item->meta_width() ); ?>,<?php echo esc_attr( $item->meta_height() ); ?>"
 data-comments-opened="<?php echo esc_attr( comments_open( $item->image->ID ) ); ?>"
+<?php if ( $comments_count > 0 ) : ?>
+data-comments-count="<?php echo esc_attr( $comments_count ); ?>"
+<?php endif; ?>
 <?php if ( $display_exif ) : ?>
 data-image-meta="<?php echo esc_attr( $fuzzy_image_meta ); ?>"
 <?php endif; ?>

--- a/projects/plugins/jetpack/tests/php/modules/carousel/Jetpack_Carousel_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/carousel/Jetpack_Carousel_Test.php
@@ -213,4 +213,31 @@ class Jetpack_Carousel_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'data-permalink', $attr );
 		$this->assertArrayHasKey( 'data-image-title', $attr );
 	}
+
+	/**
+	 * An attachment with no comments should not carry a data-comments-count attribute,
+	 * so galleries without comments pay nothing for it.
+	 */
+	public function test_add_data_to_images_omits_comments_count_when_there_are_none() {
+		$attachment = $this->create_image_attachment_with_exif();
+
+		$attr = $this->instance->add_data_to_images( array(), $attachment );
+
+		$this->assertArrayNotHasKey( 'data-comments-count', $attr );
+	}
+
+	/**
+	 * The carousel shows its "has comments" badge from this attribute, so it must
+	 * carry the attachment's approved comment count.
+	 */
+	public function test_add_data_to_images_includes_comments_count() {
+		$attachment = $this->create_image_attachment_with_exif();
+
+		self::factory()->comment->create_post_comments( $attachment->ID, 2 );
+
+		$attr = $this->instance->add_data_to_images( array(), get_post( $attachment->ID ) );
+
+		$this->assertArrayHasKey( 'data-comments-count', $attr );
+		$this->assertSame( 2, $attr['data-comments-count'] );
+	}
 }


### PR DESCRIPTION
Related to JETPACK-1517

## Proposed changes
* `selectSlideAtIndex()` fired a `get_attachment_comments` admin-ajax request on **every** slide change, even though the comments panel is hidden by default. Fetch when the panel is actually opened instead, and cache the rendered comments per attachment for the lifetime of the overlay so returning to a slide costs nothing.
* The "has comments" badge depended on that eager fetch, so the approved comment count now comes from the server in a new `data-comments-count` attribute, read straight off the attachment's existing `comment_count` (no extra query) and omitted when zero. Tiled Gallery builds its own carousel attributes from a template, so it gets the same attribute.
* Scroll-pagination is preserved across navigation (re-armed from cache when a page was full), concurrent/duplicate fetches are guarded (in-flight guard + de-dupe by comment id), and posting an approved comment bumps the badge immediately.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No new data collected. Adds a `data-comments-count` attribute (sourced from the existing `comment_count`) on gallery images that have comments.

## Testing instructions
Prereq: Carousel "Comments" (Settings → Sharing / Media) enabled, and a few attachments with approved comments (put >10 on one to exercise pagination).

* Open a gallery, filter DevTools Network to `admin-ajax`. Page through slides — **no** request fires on slide changes (before: one per slide). The footer comment badge still shows the right count on each slide, with no request.
* Open the comments panel — exactly one request fires and comments render. Navigate to another slide with the panel open — one request for that slide; navigate back — **no** new request (served from cache), no duplicate comments.
* On the slide with >10 comments, scroll the panel to the bottom — the next page loads; leave and return, scroll again — the rest still loads (no duplicates).
* Post a comment (an approved one): it appears and the badge count increments immediately.
* Repeat the badge + panel checks on a `jetpack/tiled-gallery`.

Result: **XHRs per slide change 1 → 0.**

| Before | After |
|---|---|
|  |  |
