### PR TITLE
Carousel: Stop emitting empty EXIF values in data-image-meta

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-empty-exif
+++ b/projects/plugins/jetpack/changelog/fix-carousel-empty-exif
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Carousel: Stop serialising empty EXIF values into every gallery image.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -991,8 +991,24 @@ class Jetpack_Carousel {
 				unset( $img_meta['keywords'] );
 			}
 
-			$img_meta                = wp_json_encode( array_map( 'strval', array_filter( $img_meta, 'is_scalar' ) ), JSON_UNESCAPED_SLASHES | JSON_HEX_AMP );
-			$attr['data-image-meta'] = esc_attr( $img_meta );
+			/*
+			Filtering on `is_scalar` alone kept every "" and "0" in the metadata array, which
+			on a typical photo is most of it. The carousel skips those values when it renders
+			the EXIF panel anyway, so serialising them only inflates the page. Mirror that
+			check here: drop empties and numeric zeroes, but keep text that merely casts to
+			zero, such as a camera name.
+			*/
+			$img_meta = array_filter(
+				array_map( 'strval', array_filter( $img_meta, 'is_scalar' ) ),
+				function ( $value ) {
+					return '' !== $value && ! ( is_numeric( $value ) && 0.0 === (float) $value );
+				}
+			);
+
+			// With nothing left to show, the attribute itself is dead weight.
+			if ( ! empty( $img_meta ) ) {
+				$attr['data-image-meta'] = esc_attr( wp_json_encode( $img_meta, JSON_UNESCAPED_SLASHES | JSON_HEX_AMP ) );
+			}
 		}
 
 		// The lines below use `esc_attr( htmlspecialchars( ) )` because esc_attr tries to be too smart and won't double-encode, and we need that here.

--- a/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/templates/partials/carousel-image-args.php
+++ b/projects/plugins/jetpack/modules/tiled-gallery/tiled-gallery/templates/partials/carousel-image-args.php
@@ -27,8 +27,23 @@ if ( $display_exif ) {
 		unset( $image_meta['keywords'] );
 	}
 
+	/*
+	Drop empties and numeric zeroes, which the carousel skips when rendering the EXIF
+	panel anyway and which are most of a typical photo's metadata. Text that merely
+	casts to zero, such as a camera name, is kept.
+	Mirrors Jetpack_Carousel::add_data_to_images().
+	*/
+	$image_meta = array_filter(
+		array_map( 'strval', array_filter( $image_meta, 'is_scalar' ) ),
+		function ( $value ) {
+			return '' !== $value && ! ( is_numeric( $value ) && 0.0 === (float) $value );
+		}
+	);
+
 	// Using JSON_HEX_AMP avoids breakage due to `esc_attr()` refusing to double-encode.
-	$fuzzy_image_meta = (string) wp_json_encode( map_deep( $image_meta, 'strval' ), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
+	$fuzzy_image_meta = empty( $image_meta )
+		? ''
+		: (string) wp_json_encode( $image_meta, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
 }
 
 ?>
@@ -36,7 +51,7 @@ data-attachment-id="<?php echo esc_attr( $item->image->ID ); ?>"
 data-orig-file="<?php echo esc_url( wp_get_attachment_url( $item->image->ID ) ); ?>"
 data-orig-size="<?php echo esc_attr( $item->meta_width() ); ?>,<?php echo esc_attr( $item->meta_height() ); ?>"
 data-comments-opened="<?php echo esc_attr( comments_open( $item->image->ID ) ); ?>"
-<?php if ( $display_exif ) : ?>
+<?php if ( '' !== $fuzzy_image_meta ) : ?>
 data-image-meta="<?php echo esc_attr( $fuzzy_image_meta ); ?>"
 <?php endif; ?>
 <?php // The two lines below use `esc_attr( htmlspecialchars( ) )` because esc_attr tries to be too smart and won't double-encode, and we need that here. ?>

--- a/projects/plugins/jetpack/tests/php/modules/carousel/Jetpack_Carousel_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/carousel/Jetpack_Carousel_Test.php
@@ -213,4 +213,72 @@ class Jetpack_Carousel_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'data-permalink', $attr );
 		$this->assertArrayHasKey( 'data-image-title', $attr );
 	}
+
+	/**
+	 * Empty strings and numeric zeroes are never rendered in the EXIF panel, so they
+	 * should not be serialised into the page either.
+	 */
+	public function test_add_data_to_images_strips_empty_image_meta_values() {
+		update_option( 'carousel_display_exif', 1 );
+		$attachment = $this->create_image_attachment_with_exif();
+
+		wp_update_attachment_metadata(
+			$attachment->ID,
+			array(
+				'width'      => 100,
+				'height'     => 100,
+				'file'       => 'jetpack-icon.jpg',
+				'image_meta' => array(
+					'camera'        => 'JetpackCam',
+					'aperture'      => '0',
+					'focal_length'  => '0',
+					'shutter_speed' => '0',
+					'iso'           => '0',
+					'credit'        => '',
+					'copyright'     => '',
+					'orientation'   => '1',
+				),
+			)
+		);
+
+		$attr = $this->instance->add_data_to_images( array(), $attachment );
+		$meta = json_decode( html_entity_decode( $attr['data-image-meta'], ENT_QUOTES ), true );
+
+		$this->assertSame(
+			array(
+				'camera'      => 'JetpackCam',
+				'orientation' => '1',
+			),
+			$meta
+		);
+	}
+
+	/**
+	 * When every metadata value is empty there is nothing to show, so the attribute
+	 * should be dropped rather than emitted full of zeroes.
+	 */
+	public function test_add_data_to_images_omits_image_meta_when_all_values_are_empty() {
+		update_option( 'carousel_display_exif', 1 );
+		$attachment = $this->create_image_attachment_with_exif();
+
+		wp_update_attachment_metadata(
+			$attachment->ID,
+			array(
+				'width'      => 100,
+				'height'     => 100,
+				'file'       => 'jetpack-icon.jpg',
+				'image_meta' => array(
+					'camera'        => '',
+					'aperture'      => '0',
+					'focal_length'  => '0',
+					'shutter_speed' => '0.0',
+					'iso'           => '0',
+				),
+			)
+		);
+
+		$attr = $this->instance->add_data_to_images( array(), $attachment );
+
+		$this->assertArrayNotHasKey( 'data-image-meta', $attr );
+	}
 }


### PR DESCRIPTION
Related to JETPACK-1517

Also related to JETPACK-1707.

## Proposed changes
* `array_filter( $img_meta, 'is_scalar' )` kept every `""` and `"0"` the metadata array carries, which on a typical photo is most of it — serialised into `data-image-meta` on every gallery image. The Carousel already skips those when rendering the EXIF panel, so they were pure page weight.
* Drop empty strings and numeric zeroes (text that merely casts to `0`, e.g. a camera name, is kept), and omit the `data-image-meta` attribute entirely when nothing is left.
* Tiled Gallery serialises its own copy from a template, so it gets the same fix.

Note: the attribute is already correctly gated on the `carousel_display_exif` setting — this PR does not change that gating.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No. It removes empty values from markup that was already emitted.

## Testing instructions
* View source on a gallery of photos with **no** camera metadata: `data-image-meta` is gone entirely (or contains only real values), where before it held `aperture:0`, `camera:""`, etc.
* View source on a photo **with** real EXIF: all non-empty values are still present.
* Open that photo in the lightbox and press the info (ⓘ) icon — the EXIF panel still lists camera, aperture, focal length, shutter speed exactly as before.
* Repeat both checks on a `jetpack/tiled-gallery`.

Measured on a 100-image gallery: `data-image-meta` total **46.6KB → 15.0KB** of raw HTML.

PHP unit tests added in `Jetpack_Carousel_Test.php` cover the stripping and the omit-when-empty cases.
