### PR TITLE
Carousel: Request the zoom-resolution image only when the visitor zooms

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-carousel-image-sizing
+++ b/projects/plugins/jetpack/changelog/fix-carousel-image-sizing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Carousel: Request the zoom-resolution image only when the visitor zooms.

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.js
@@ -956,6 +956,19 @@
 				args.maxHeight = args.maxHeight * window.devicePixelRatio;
 			}
 
+			/*
+			`maxWidth`/`maxHeight` now describe the device resolution. Anything beyond that is
+			headroom for zooming, so only the zoom request asks for it. The multiplier is folded
+			in here -- ahead of the size checks below -- so the zoom rendition keeps its extra
+			resolution even when the unzoomed one is already covered by `data-large-file`.
+			Without it, every slide would fetch ~4x the pixels the screen can show.
+			*/
+			var headroom = args.zoomHeadroom || 1;
+			if ( headroom > 1 ) {
+				args.maxWidth = args.maxWidth * headroom;
+				args.maxHeight = args.maxHeight * headroom;
+			}
+
 			if ( largeWidth >= args.maxWidth || largeHeight >= args.maxHeight ) {
 				return args.largeFile;
 			}
@@ -973,9 +986,8 @@
 				// If we have a really large image load a smaller version
 				// that is closer to the viewable size
 				if ( args.origWidth > args.maxWidth || args.origHeight > args.maxHeight ) {
-					// @2x the max sizes so we get a high enough resolution for zooming.
-					args.origMaxWidth = args.maxWidth * 2;
-					args.origMaxHeight = args.maxHeight * 2;
+					args.origMaxWidth = args.maxWidth;
+					args.origMaxHeight = args.maxHeight;
 					// Add the fit arg to the list of Photon args.
 					sanitizedUrl.searchParams.set( 'fit', args.origMaxWidth + ',' + args.origMaxHeight );
 				}
@@ -1366,8 +1378,14 @@
 			fullImage.addEventListener(
 				'load',
 				function () {
-					// Cached by this point, so swapping it in is effectively instant.
-					image.src = attrs.src;
+					/*
+					If the visitor zoomed while this was still downloading, a larger rendition
+					is already in place -- don't downgrade it back to the fit-to-screen src.
+					*/
+					if ( ! image.hasAttribute( 'data-zoom-loaded' ) ) {
+						// Cached by this point, so swapping it in is effectively instant.
+						image.src = attrs.src;
+					}
 					image.style.filter = '';
 				},
 				{ once: true }
@@ -1382,6 +1400,28 @@
 			);
 
 			fullImage.src = attrs.src;
+		}
+
+		/**
+		 * Swap in a higher-resolution rendition now that the visitor is zoomed in.
+		 *
+		 * The zoomed-out slide only ever loads what the screen can actually show. The browser
+		 * keeps painting the image it already has until this one decodes, so the picture
+		 * sharpens rather than blanking.
+		 * @param {object} slide - The slide being zoomed.
+		 */
+		function loadZoomImage( slide ) {
+			if ( ! slide || ! slide.attrs.zoomSrc || slide.attrs.zoomSrc === slide.attrs.src ) {
+				return;
+			}
+
+			var image = slide.el.querySelector( 'img' );
+			if ( ! image || image.hasAttribute( 'data-zoom-loaded' ) ) {
+				return;
+			}
+
+			image.setAttribute( 'data-zoom-loaded', 1 );
+			image.src = slide.attrs.zoomSrc;
 		}
 
 		function preloadAdjacentImages( currentIndex ) {
@@ -1539,14 +1579,26 @@
 				if ( typeof wpcom !== 'undefined' && wpcom.carousel && wpcom.carousel.generateImgSrc ) {
 					attrs.src = wpcom.carousel.generateImgSrc( item, max );
 				} else {
-					attrs.src = selectBestImageUrl( {
-						origFile: attrs.src,
-						origWidth: attrs.origWidth,
-						origHeight: attrs.origHeight,
-						maxWidth: max.width,
-						maxHeight: max.height,
-						largeFile: attrs.largeFile,
-					} );
+					var urlArgs = function ( zoomHeadroom ) {
+						// A fresh object each time: selectBestImageUrl() mutates what it is given.
+						return {
+							origFile: attrs.src,
+							origWidth: attrs.origWidth,
+							origHeight: attrs.origHeight,
+							maxWidth: max.width,
+							maxHeight: max.height,
+							largeFile: attrs.largeFile,
+							zoomHeadroom: zoomHeadroom,
+						};
+					};
+
+					/*
+					The zoom rendition is kept aside until the visitor actually zooms. On sources
+					that cannot serve a larger one it comes back identical to `src`, and nothing
+					ever happens.
+					*/
+					attrs.zoomSrc = selectBestImageUrl( urlArgs( 2 ) );
+					attrs.src = selectBestImageUrl( urlArgs( 1 ) );
 				}
 
 				// Set the final src.
@@ -1702,6 +1754,7 @@
 
 			swiper.on( 'zoomChange', function ( swiper, scale ) {
 				if ( scale > 1 ) {
+					loadZoomImage( carousel.currentSlide );
 					carousel.overlay.classList.add( 'jp-carousel-hide-controls' );
 				}
 


### PR DESCRIPTION
Related to JETPACK-1517

## Proposed changes
* `selectBestImageUrl()` asked Photon for twice the viewport **on top of** `devicePixelRatio`, so every slide fetched roughly 4× the pixels the screen can show — for zoom headroom most visitors never use.
* Request device resolution up front, and swap in the larger rendition on `zoomChange`. Zoom quality is unchanged: the higher-res image is fetched the moment anyone zooms, and the browser keeps painting the one it already has while it decodes. Builds on #50760's single `<img>`, and guards its swap-on-load so a mid-download zoom isn't downgraded.
* Only the Photon branch is affected; sources that can't serve a larger rendition produce an identical URL and nothing happens.

Note: the @2× was **not** touch-only headroom — Swiper emits `doubleTap` for mouse double-clicks too, so desktop pointer users can zoom. Gating it on touch would have quietly degraded them.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
Prereq: a site with **Image CDN (Photon) enabled** — the non-Photon branch is a no-op here.

* Open a gallery of large photos, DevTools → Network. The slide image is requested at `fit=<viewport × DPR>` (e.g. `fit=2400,1132` on a 1200×630 DPR2 screen), where before it was `fit=4800,2264`.
* Double-click (desktop) or pinch / double-tap (touch) to zoom: a larger rendition is requested (bigger `fit=`, or the native original when it's smaller than 2× device) and the image visibly sharpens without going blank. Zoom out and back in — no further request.
* On a **non-Photon** site, confirm the requested image URLs are unchanged from trunk.

Measured on live Photon (per slide): device-res `fit=2400` ≈ 234KB vs old `fit=4800` ≈ 519KB — **~55% fewer bytes**, no loss of zoom quality.
