### PR TITLE
Boost: defer sync callable construction to invocation time

### DIFF
--- a/projects/packages/sync/AGENTS.md
+++ b/projects/packages/sync/AGENTS.md
@@ -126,6 +126,9 @@ Adding a new item to the whitelist in this package controls whether it gets sent
 **Custom post types must be registered via sync**
 Custom post types must be registered through callables/config sync, or posts will land in `jps_non-reg` status on the cache site.
 
+**Callable whitelist values must not instantiate objects at registration**
+The callable whitelist is rebuilt on every request, but callables are only invoked at send time. Use function-name strings, static `array( 'Class', 'method' )` references, or closures that defer construction to invocation time — never `array( new Object(), 'method' )`. Also beware: values failing `is_callable()` are silently skipped (never synced, no error logged), so a typo'd or later-removed method goes unnoticed; cover whitelist entries with a test that invokes them.
+
 **Both test suites must pass**
 Tests live in this package (`tests/php/`) and in the Jetpack plugin (`projects/plugins/jetpack/tests/php/sync/`). Running only one can miss regressions.
 

--- a/projects/packages/sync/README.md
+++ b/projects/packages/sync/README.md
@@ -134,6 +134,21 @@ $config->ensure(
 ```
 
 **When it comes to configuring callables, you need to pass an associative array where the key is the name of your callable and the value the corresponding callback function.**
+
+**Callable values must be statically resolvable — never instantiate objects while registering the whitelist.** The whitelist is registered on every request (typically at `plugins_loaded`), but the callables are only invoked when Sync actually sends data. Any work done while building the array — object construction and, worse, option reads inside constructors — is paid on every request for nothing. Use one of:
+
+- a function name string: `'my_callable' => 'my_get_value_function'`
+- a static method reference: `'my_callable' => array( 'My_Plugin_Class', 'get_settings' )`
+- a closure, when the value can only be produced by an object instance, so construction is deferred to invocation time:
+
+```php
+'my_callable' => static function () {
+	return ( new My_Plugin_Settings() )->get();
+},
+```
+
+Also note that entries failing `is_callable()` (e.g. a typo in the method name, or a method removed later) are **silently skipped** — the callable is never synced and no error is logged — so make sure the reference actually resolves, ideally with a test invoking your whitelist entries.
+
 It's important to note that we consider a list of certain callables required for Sync to properly function, therefore the following callables will be synced no matter the configuration:
 
 - `site_url`               

--- a/projects/packages/sync/changelog/update-boost-lazy-sync-callable-whitelist
+++ b/projects/packages/sync/changelog/update-boost-lazy-sync-callable-whitelist
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Docs: document that sync callable whitelist values must be statically resolvable (no object instantiation at registration) and that is_callable failures are silently skipped

--- a/projects/packages/sync/changelog/update-boost-lazy-sync-callable-whitelist
+++ b/projects/packages/sync/changelog/update-boost-lazy-sync-callable-whitelist
@@ -1,4 +1,3 @@
 Significance: patch
 Type: changed
-
-Docs: document that sync callable whitelist values must be statically resolvable (no object instantiation at registration) and that is_callable failures are silently skipped
+Comment: Documentation only: document that callable whitelist values must be statically resolvable (no object instantiation at registration) and that is_callable failures are silently skipped.

--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -365,9 +365,7 @@ class Jetpack_Boost {
 				'jetpack_sync_callable_whitelist' => array(
 					'boost_modules'                => array( new Modules_Setup(), 'get_status' ),
 					'boost_sub_modules_state'      => array( new Modules_Setup(), 'get_all_sub_modules_state' ),
-					// Closures defer construction (and the non-autoloaded option reads in these
-					// constructors) to Sync invocation time. Sync only ever invokes these values;
-					// they must never be serialized as definitions.
+					// Closures defer construction (and option reads) to Sync invocation time.
 					'boost_latest_scores'          => static function () {
 						return ( new Speed_Score_History( get_home_url() ) )->latest();
 					},

--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -362,10 +362,13 @@ class Jetpack_Boost {
 		$jetpack_config->ensure(
 			'sync',
 			array(
+				// Closures defer construction (and option reads) to Sync invocation time.
 				'jetpack_sync_callable_whitelist' => array(
-					'boost_modules'                => array( new Modules_Setup(), 'get_status' ),
-					'boost_sub_modules_state'      => array( new Modules_Setup(), 'get_all_sub_modules_state' ),
-					// Closures defer construction (and option reads) to Sync invocation time.
+					// boost_sub_modules_state was removed: it pointed at a method that never
+					// existed, so the callable never resolved and Sync never sent it.
+					'boost_modules'                => static function () {
+						return ( new Modules_Setup() )->get_status();
+					},
 					'boost_latest_scores'          => static function () {
 						return ( new Speed_Score_History( get_home_url() ) )->latest();
 					},

--- a/projects/plugins/boost/app/class-jetpack-boost.php
+++ b/projects/plugins/boost/app/class-jetpack-boost.php
@@ -365,10 +365,21 @@ class Jetpack_Boost {
 				'jetpack_sync_callable_whitelist' => array(
 					'boost_modules'                => array( new Modules_Setup(), 'get_status' ),
 					'boost_sub_modules_state'      => array( new Modules_Setup(), 'get_all_sub_modules_state' ),
-					'boost_latest_scores'          => array( new Speed_Score_History( get_home_url() ), 'latest' ),
-					'boost_latest_no_boost_scores' => array( new Speed_Score_History( add_query_arg( Module::DISABLE_MODULE_QUERY_VAR, 'all', get_home_url() ) ), 'latest' ),
-					'critical_css_state'           => array( new Critical_CSS_State(), 'get' ),
-					'lcp_state'                    => array( new LCP_State(), 'get' ),
+					// Closures defer construction (and the non-autoloaded option reads in these
+					// constructors) to Sync invocation time. Sync only ever invokes these values;
+					// they must never be serialized as definitions.
+					'boost_latest_scores'          => static function () {
+						return ( new Speed_Score_History( get_home_url() ) )->latest();
+					},
+					'boost_latest_no_boost_scores' => static function () {
+						return ( new Speed_Score_History( add_query_arg( Module::DISABLE_MODULE_QUERY_VAR, 'all', get_home_url() ) ) )->latest();
+					},
+					'critical_css_state'           => static function () {
+						return ( new Critical_CSS_State() )->get();
+					},
+					'lcp_state'                    => static function () {
+						return ( new LCP_State() )->get();
+					},
 				),
 			)
 		);

--- a/projects/plugins/boost/changelog/update-boost-lazy-sync-callable-whitelist
+++ b/projects/plugins/boost/changelog/update-boost-lazy-sync-callable-whitelist
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Sync: lazy-load speed score history, Critical CSS and LCP state callables to avoid reading their non-autoloaded options on every request

--- a/projects/plugins/boost/changelog/update-boost-lazy-sync-callable-whitelist
+++ b/projects/plugins/boost/changelog/update-boost-lazy-sync-callable-whitelist
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Sync: lazy-load speed score history, Critical CSS and LCP state callables to avoid reading their non-autoloaded options on every request
+Sync: lazy-load all callables to avoid object construction and non-autoloaded option reads on every request; remove the boost_sub_modules_state entry, which referenced a method that never existed and was never synced

--- a/projects/plugins/boost/changelog/update-boost-lazy-sync-callable-whitelist
+++ b/projects/plugins/boost/changelog/update-boost-lazy-sync-callable-whitelist
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Sync: lazy-load all callables to avoid object construction and non-autoloaded option reads on every request; remove the boost_sub_modules_state entry, which referenced a method that never existed and was never synced
+Performance: reduce the number of database reads performed on every page load by preparing Sync data only when it is actually sent to WordPress.com.

--- a/projects/plugins/boost/tests/php/Jetpack_Boost_Test.php
+++ b/projects/plugins/boost/tests/php/Jetpack_Boost_Test.php
@@ -2,7 +2,10 @@
 
 namespace Automattic\Jetpack_Boost\Tests;
 
+use Automattic\Jetpack\Boost_Speed_Score\Speed_Score_History;
 use Automattic\Jetpack_Boost\Jetpack_Boost;
+use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_State;
+use Automattic\Jetpack_Boost\Modules\Optimizations\Lcp\LCP_State;
 use WorDBless\BaseTestCase;
 
 // Include the main plugin file to load all functions and classes
@@ -71,5 +74,41 @@ class Jetpack_Boost_Test extends BaseTestCase {
 		// Verify that the array remains unchanged
 		$this->assertIsArray( $updated_pages, 'The updated pages should be an array' );
 		$this->assertEquals( array_map( 'home_url', $initial_pages ), $updated_pages, 'The array should remain unchanged when no empty string is present' );
+	}
+
+	/**
+	 * Test that the lazy sync callables are invocable and read current state at invocation time.
+	 */
+	public function test_sync_callable_whitelist_closures_are_invocable() {
+		// Data_Settings only adds the filter hook once per process, but WorDBless
+		// resets hooks between tests, so start from a clean slate.
+		( new \Automattic\Jetpack\Sync\Data_Settings() )->empty_data_settings_and_hooks();
+		new Jetpack_Boost();
+
+		$whitelist = apply_filters( 'jetpack_sync_callable_whitelist', array() );
+
+		foreach ( array( 'boost_latest_scores', 'boost_latest_no_boost_scores', 'critical_css_state', 'lcp_state' ) as $key ) {
+			$this->assertArrayHasKey( $key, $whitelist );
+			$this->assertIsCallable( $whitelist[ $key ] );
+		}
+
+		// History is read at invocation time: an entry pushed after registration is visible.
+		$this->assertNull( call_user_func( $whitelist['boost_latest_scores'] ) );
+		$entry = array(
+			'timestamp' => 1234567890,
+			'scores'    => array(
+				'mobile'  => 80,
+				'desktop' => 90,
+			),
+		);
+		( new Speed_Score_History( get_home_url() ) )->push( $entry );
+		$this->assertSame( $entry, call_user_func( $whitelist['boost_latest_scores'] ) );
+
+		// The no-boost variant reads its own, still empty, history bucket.
+		$this->assertNull( call_user_func( $whitelist['boost_latest_no_boost_scores'] ) );
+
+		// State callables return the same data as direct access.
+		$this->assertEquals( ( new Critical_CSS_State() )->get(), call_user_func( $whitelist['critical_css_state'] ) );
+		$this->assertEquals( ( new LCP_State() )->get(), call_user_func( $whitelist['lcp_state'] ) );
 	}
 }

--- a/projects/plugins/boost/tests/php/Jetpack_Boost_Test.php
+++ b/projects/plugins/boost/tests/php/Jetpack_Boost_Test.php
@@ -5,6 +5,7 @@ namespace Automattic\Jetpack_Boost\Tests;
 use Automattic\Jetpack\Boost_Speed_Score\Speed_Score_History;
 use Automattic\Jetpack_Boost\Jetpack_Boost;
 use Automattic\Jetpack_Boost\Lib\Critical_CSS\Critical_CSS_State;
+use Automattic\Jetpack_Boost\Modules\Modules_Setup;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Lcp\LCP_State;
 use WorDBless\BaseTestCase;
 
@@ -87,10 +88,13 @@ class Jetpack_Boost_Test extends BaseTestCase {
 
 		$whitelist = apply_filters( 'jetpack_sync_callable_whitelist', array() );
 
-		foreach ( array( 'boost_latest_scores', 'boost_latest_no_boost_scores', 'critical_css_state', 'lcp_state' ) as $key ) {
+		foreach ( array( 'boost_modules', 'boost_latest_scores', 'boost_latest_no_boost_scores', 'critical_css_state', 'lcp_state' ) as $key ) {
 			$this->assertArrayHasKey( $key, $whitelist );
 			$this->assertIsCallable( $whitelist[ $key ] );
 		}
+
+		// The module status callable returns the same data as direct access.
+		$this->assertEquals( ( new Modules_Setup() )->get_status(), call_user_func( $whitelist['boost_modules'] ) );
 
 		// History is read at invocation time: an entry pushed after registration is visible.
 		$this->assertNull( call_user_func( $whitelist['boost_latest_scores'] ) );


### PR DESCRIPTION
Fixes [BOOST-606](https://linear.app/a8c/issue/BOOST-606/boost-defer-sync-callable-option-reads-closures)
## Proposed changes

* Convert five entries of Boost's `jetpack_sync_callable_whitelist` (`boost_modules`, `boost_latest_scores`, `boost_latest_no_boost_scores`, `critical_css_state`, `lcp_state`) from eagerly-constructed array-callables to static closures that construct the objects at Sync invocation time.
* Remove the `boost_sub_modules_state` entry: it referenced `Modules_Setup::get_all_sub_modules_state()`, a method that never existed (added that way in #37505), so `is_callable()` always failed and Sync never transmitted it.

## Why are these changes being made

On every request at `plugins_loaded` we register the whitelist, and these options get up to 4 `wp_options` SELECTs per request without a persistent object cache. The callables are only ever invoked by Sync in sender contexts, so by moving to invocation time we only request the options when really needed. `boost_modules` reads no options but is converted too so no whitelist entry constructs objects at registration time.

## Related product discussion/links

* JETPACK-1539 

## Does this pull request change what data or activity we track or use?

No. The same callables return the same values; only when the objects are constructed changes. The removed `boost_sub_modules_state` entry was never transmitted (broken method reference), so removing it changes nothing.

## Testing instructions

* Use a site without a persistent object cache with Jetpack Boost active and connected.
* Before applying this PR: install Query Monitor, load the front end logged out, and note `SELECT option_value FROM wp_options` queries for `jetpack_boost_speed_score_history_*`, `jetpack_boost_ds_critical_css_state` and `jetpack_boost_ds_lcp_state` on every request.
* Apply this PR and reload the front end logged out: those queries should be gone.
* Verify end-to-end sync: run a speed score from the Boost dashboard (or regenerate Critical CSS), and confirm the values arrive on the WPCOM side.
* All whitelist entries (including `boost_modules`) are covered by `Jetpack_Boost_Test::test_sync_callable_whitelist_closures_are_invocable`.
