### PR TITLE
AI Launchpad: hide the legacy Dashboard widget and My Home menu for no_guidance

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/2026-07-27-13-00-00-000000
+++ b/projects/packages/jetpack-mu-wpcom/changelog/2026-07-27-13-00-00-000000
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+AI Launchpad: hide the legacy Dashboard launchpad widget and the My Home menu for the no_guidance launchpad-personalization variation.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-admin-menu/wpcom-admin-menu.php
@@ -8,11 +8,13 @@
  */
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Jetpack_Mu_Wpcom\Launchpad_Personalization_Experiment;
 use Automattic\Jetpack\Newsletter\Settings as Newsletter_Settings;
 use Automattic\Jetpack\Podcast\Admin_Page as Podcast_Admin_Page;
 use Automattic\Jetpack\Redirect;
 
 require_once __DIR__ . '/../../common/wpcom-callout.php';
+require_once __DIR__ . '/../../common/class-launchpad-personalization-experiment.php';
 
 /**
  * Checks if the current user has a WordPress.com account connected.
@@ -98,6 +100,13 @@ function wpcom_add_my_home_menu() {
 		&& function_exists( 'wpcom_ai_launchpad_is_eligible' )
 		&& wpcom_ai_launchpad_is_eligible()
 	) {
+		return;
+	}
+
+	// The no_guidance launchpad-personalization variation gets no My Home at all: these
+	// users work from the wp-admin dashboard. Removing the menu item here also removes it
+	// from the Calypso sidebar, which is built from this menu via the admin-menu endpoint.
+	if ( 'no_guidance' === Launchpad_Personalization_Experiment::get_variation() ) {
 		return;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-dashboard-widgets/wpcom-dashboard-widgets.php
@@ -67,9 +67,17 @@ function load_wpcom_dashboard_widgets() {
 	$has_ai_launchpad = function_exists( 'wpcom_ai_launchpad_is_eligible' )
 		&& wpcom_ai_launchpad_is_eligible();
 
+	// The no_guidance launchpad-personalization variation gets no launchpad surface at all.
+	// Unlike the ai_launchpad arm above, there is no dismissal fallback: dismissing nothing
+	// cannot bring the widget back.
+	require_once __DIR__ . '/../../common/class-launchpad-personalization-experiment.php';
+	$is_no_guidance =
+		'no_guidance' === \Automattic\Jetpack\Jetpack_Mu_Wpcom\Launchpad_Personalization_Experiment::get_variation();
+
 	if (
 		defined( 'IS_WPCOM' ) && IS_WPCOM &&
 		! $has_ai_launchpad &&
+		! $is_no_guidance &&
 		get_option( 'launch-status', 'launched' ) !== 'launched' &&
 		! empty( wpcom_get_launchpad_checklist_by_checklist_slug( $checklist_slug, $launchpad_context ) ) &&
 		! wpcom_launchpad_is_task_list_dismissed( $checklist_slug )


### PR DESCRIPTION
Follow-up to #50803 / #50830. Part of DOTOBRD-567.

## Proposed changes

Field testing the launchpad-personalization experiment surfaced two `no_guidance` gaps — the variation suppressed the fullscreen Launchpad (via the `option_launchpad_screen` filter) but left two other guidance surfaces visible:

* **Legacy launchpad Dashboard widget**: `load_wpcom_dashboard_widgets()` only checked AI Launchpad eligibility (false for `no_guidance`) and never consulted the variation. The widget is now suppressed for `no_guidance`. The `ai_launchpad` arm's behavior is deliberately unchanged: dismissing the AI Launchpad still brings the legacy widget back.
* **My Home menu**: `wpcom_add_my_home_menu()` now bails for `no_guidance`, removing the item from the wp-admin menu — and therefore also from the Calypso sidebar, which is built from this menu via the admin-menu endpoint.

## Related product discussion/links

* DOTOBRD-567
* Companion Calypso PR: Automattic/wp-calypso#113017

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Force the variation with `add_filter( 'wpcom_launchpad_personalization_variation', fn() => 'no_guidance' );` (or a real ExPlat assignment) on an unlaunched Simple site.
* wp-admin Dashboard: the "Site Setup" launchpad widget no longer renders; with `control` it still does.
* wp-admin menu and Calypso sidebar: no "My Home" entry for `no_guidance`; `control` keeps it.
* `ai_launchpad` variation: unchanged — Site Setup replaces My Home; dismissing the AI Launchpad restores the legacy widget.
* `composer phpunit -- --filter 'Launchpad_Personalization|AI_Launchpad_Eligibility'` in `projects/packages/jetpack-mu-wpcom` (17 passing).

