### PR TITLE
AI Launchpad: user-scoped enablement in the site payload

### DIFF
--- a/projects/plugins/jetpack/changelog/dotobrd-567-ai-launchpad-user-scoped-site-payload
+++ b/projects/plugins/jetpack/changelog/dotobrd-567-ai-launchpad-user-scoped-site-payload
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-AI Launchpad: the site payload's wpcom_ai_launchpad_enabled now reflects user-scoped enablement (the ai_launchpad launchpad-personalization variation), not just the per-site option, so Calypso agrees with wp-admin for every site of an assigned user.
+AI Launchpad: enable on all sites of a user in the ai_launchpad experiment variation, matching wp-admin.

--- a/projects/plugins/jetpack/changelog/dotobrd-567-ai-launchpad-user-scoped-site-payload
+++ b/projects/plugins/jetpack/changelog/dotobrd-567-ai-launchpad-user-scoped-site-payload
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+AI Launchpad: the site payload's wpcom_ai_launchpad_enabled now reflects user-scoped enablement (the ai_launchpad launchpad-personalization variation), not just the per-site option, so Calypso agrees with wp-admin for every site of an assigned user.

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1602,6 +1602,7 @@ abstract class SAL_Site {
 		}
 
 		return class_exists( '\Automattic\Jetpack\Jetpack_Mu_Wpcom\Launchpad_Personalization_Experiment' )
+			// @phan-suppress-next-line PhanUndeclaredClassMethod -- Lives in jetpack-mu-wpcom, outside this plugin's dependency graph; the class_exists guard above covers contexts where it isn't loaded.
 			&& 'ai_launchpad' === \Automattic\Jetpack\Jetpack_Mu_Wpcom\Launchpad_Personalization_Experiment::get_variation();
 	}
 

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1586,12 +1586,23 @@ abstract class SAL_Site {
 	}
 
 	/**
-	 * Whether the AI Launchpad is enabled for this site.
+	 * Whether the AI Launchpad is enabled for this site, for the requesting user.
+	 *
+	 * The launchpad-personalization assignment is user-scoped: every site of an
+	 * ai_launchpad user gets the AI Launchpad, however the site was created. Mirrors
+	 * AI_Launchpad::is_enabled_for_site() in jetpack-mu-wpcom, so wp-admin and the
+	 * Calypso-facing payload agree. Like the capabilities in this payload, the value
+	 * is relative to the current user.
 	 *
 	 * @return bool
 	 */
 	public function is_ai_launchpad_enabled() {
-		return (bool) get_option( 'wpcom_ai_launchpad_enabled' );
+		if ( (bool) get_option( 'wpcom_ai_launchpad_enabled' ) ) {
+			return true;
+		}
+
+		return class_exists( '\Automattic\Jetpack\Jetpack_Mu_Wpcom\Launchpad_Personalization_Experiment' )
+			&& 'ai_launchpad' === \Automattic\Jetpack\Jetpack_Mu_Wpcom\Launchpad_Personalization_Experiment::get_variation();
 	}
 
 	/**


### PR DESCRIPTION
Follow-up to #50803 / #50830 / #50837. Part of DOTOBRD-567.

## Proposed changes

* `SAL_Site::is_ai_launchpad_enabled()` — the source of `options.wpcom_ai_launchpad_enabled` in the site payload (get-site endpoint and sites list) — now returns true when the per-site option is set **or** the requesting user's launchpad-personalization variation is `ai_launchpad`, mirroring `AI_Launchpad::is_enabled_for_site()` in jetpack-mu-wpcom. Guarded with `class_exists`, so contexts without jetpack-mu-wpcom keep the raw-option behavior. Like the payload's `capabilities`, the value is relative to the requesting user.

## Why

The experiment assignment is user-scoped: every site belonging to an `ai_launchpad` user should comply, however the site was created. wp-admin already behaves this way (#50803), but Calypso reads the site payload's raw option — so a site created outside the instrumented onboarding flow (field-tested: the `ai-site-builder-onboarding` flow from the sites dashboard) was AI-Launchpad-eligible in wp-admin while Calypso reverted it to legacy My Home and MSD UX. Deriving effective enablement at read time closes the gap for every creation path at once, instead of instrumenting flows one by one. The onboarding creation-time option remains as the durable per-site record; the variation read here is ExPlat's non-assigning read, so rendering a payload never creates an assignment.

## Related product discussion/links

* DOTOBRD-567
* Automattic/wp-calypso#112953, Automattic/wp-calypso#113017

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* As a user with the `ai_launchpad` variation (or `add_filter( 'wpcom_launchpad_personalization_variation', fn() => 'ai_launchpad' )`), fetch `/rest/v1.1/sites/{site}` for a site **without** `wpcom_ai_launchpad_enabled`: `options.wpcom_ai_launchpad_enabled` is `true`.
* Same request as a `control` user: `false` (unchanged).
* Sites with the per-site option set: `true` for everyone with `manage_options`, unchanged.
* End to end: an `ai_launchpad` user creating a site via `/setup/ai-site-builder-onboarding` (sites dashboard → new site → build with AI) now gets the `/home` → Site Setup redirect and AI-launchpad MSD UX, matching wp-admin.
