### PR TITLE
codesniffer: Exclude vulnerable WPCS EnqueuedResourceParameters sniff

### DIFF
--- a/projects/packages/codesniffer/Jetpack/ruleset.xml
+++ b/projects/packages/codesniffer/Jetpack/ruleset.xml
@@ -3,7 +3,14 @@
 	<description>Jetpack coding standards. Based on the WordPress coding standards, with some additions.</description>
 
 	<rule ref="PHPCompatibilityWP" />
-	<rule ref="WordPress"/>
+	<rule ref="WordPress">
+		<!-- Versions of WordPressCS before 3.4.1 pass the `$ver` argument of enqueue/register calls
+		     through `eval()`, allowing arbitrary code execution when scanning untrusted code
+		     (GHSA-3pwp-g2mj-5p3v). WordPressCS 3.4.1 is currently blocked by
+		     mediawiki/mediawiki-codesniffer pinning phpcsstandards/phpcsextra to 1.5.0.
+		     Remove this exclusion once WordPressCS >= 3.4.1 is installable. -->
+		<exclude name="WordPress.WP.EnqueuedResourceParameters" />
+	</rule>
 	<rule ref="VariableAnalysis" />
 
 	<!-- We only include some rules from mediawiki/mediawiki-codesniffer. -->

--- a/projects/packages/codesniffer/changelog/update-wpcs-3.4.1-security
+++ b/projects/packages/codesniffer/changelog/update-wpcs-3.4.1-security
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Exclude the WordPress.WP.EnqueuedResourceParameters sniff from the Jetpack standard: versions of WordPressCS before 3.4.1 pass untrusted code through eval() when the sniff runs (GHSA-3pwp-g2mj-5p3v).

--- a/projects/packages/scheduled-updates/.phpcs.dir.xml
+++ b/projects/packages/scheduled-updates/.phpcs.dir.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0"?>
 <ruleset>
-	<rule ref="WordPress" />
+	<rule ref="WordPress">
+		<!-- Excluded for security (GHSA-3pwp-g2mj-5p3v), see the exclusion in the Jetpack standard's
+		     ruleset.xml. Remove once WordPressCS >= 3.4.1 is installable. -->
+		<exclude name="WordPress.WP.EnqueuedResourceParameters" />
+	</rule>
 
 	<rule ref="WordPress.WP.I18n">
 		<properties>

--- a/projects/packages/scheduled-updates/changelog/update-wpcs-3.4.1-security
+++ b/projects/packages/scheduled-updates/changelog/update-wpcs-3.4.1-security
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Exclude the WordPress.WP.EnqueuedResourceParameters sniff in the dev-only phpcs config (GHSA-3pwp-g2mj-5p3v). No change to the shipped package.
+
+


### PR DESCRIPTION
Fixes # N/A

## Proposed changes

WordPressCS published a security release today ([3.4.1](https://github.com/WordPress/WordPress-Coding-Standards/releases/tag/3.4.1), [GHSA-3pwp-g2mj-5p3v](https://github.com/WordPress/WordPress-Coding-Standards/security/advisories/GHSA-3pwp-g2mj-5p3v), severity high): the `WordPress.WP.EnqueuedResourceParameters` sniff passes the reconstructed `$ver` argument of `wp_enqueue_script()`-style calls through `eval()`, so scanning a maliciously crafted PHP file executes arbitrary commands on the scanning host. The monorepo is exposed: we lock WPCS 3.3.0 (vulnerable range is `>= 0.14.1, < 3.4.1`), the `Jetpack` standard includes the full `WordPress` ruleset, and CI lints fork PRs — the exact attack scenario from the advisory. Developer machines running phpcs on a contributor branch are exposed the same way.

We can't simply update: WPCS 3.4.1 requires `phpcsstandards/phpcsextra ^1.5.1`, and `mediawiki/mediawiki-codesniffer` v51.0.0 (their latest release) pins phpcsextra to exactly 1.5.0. WPCS 3.4.0 is *not* a fix despite the advisory prose — the `eval()` is still present at that tag (the machine-readable advisory range and the 3.4.1 release notes are what's correct).

So this PR applies the advisory's documented workaround instead:

* Exclude `WordPress.WP.EnqueuedResourceParameters` from the `Jetpack` standard in `projects/packages/codesniffer/Jetpack/ruleset.xml`. This also protects external consumers of `automattic/jetpack-codesniffer`.
* Exclude it in `projects/packages/scheduled-updates/.phpcs.dir.xml`, which re-includes the full `WordPress` ruleset for that directory and would otherwise re-register the sniff there.

Both exclusions carry comments noting they should be removed once WPCS >= 3.4.1 is installable (i.e. once mediawiki-codesniffer allows phpcsextra 1.5.1).

The exclusion can only remove violations, never add them, so there is no lint fallout risk.

## Related product discussion/links
* https://github.com/WordPress/WordPress-Coding-Standards/security/advisories/GHSA-3pwp-g2mj-5p3v

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run `vendor/bin/phpcs -e --standard=Jetpack | grep Enqueued` — only `WordPress.WP.EnqueuedResources` should appear; `WordPress.WP.EnqueuedResourceParameters` must not.
* Confirm the sniff no longer fires under either config:
  ```
  echo '<?php wp_enqueue_script( "foo", "foo.js" );' | vendor/bin/phpcs --standard=.phpcs.xml.dist --stdin-path=projects/packages/stats/src/fake.php --report=csv -
  echo '<?php wp_enqueue_script( "foo", "foo.js" );' | vendor/bin/phpcs --standard=.phpcs.xml.dist --stdin-path=projects/packages/scheduled-updates/src/fake.php --report=csv -
  ```
  Neither should report `EnqueuedResourceParameters` warnings. As a control, `--standard=WordPress` on the same snippet reports `EnqueuedResourceParameters.MissingVersion` / `.NotInFooter`.
