### PR TITLE
VideoPress library: make local rows bulk-selectable (bulk Upload to VideoPress)

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-library-local-bulk-selection
+++ b/projects/packages/videopress/changelog/fix-videopress-library-local-bulk-selection
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Library: allow multi-selecting local videos; Upload to VideoPress works as a bulk action and Delete covers local rows

--- a/projects/packages/videopress/src/dashboard/components/library/actions.ts
+++ b/projects/packages/videopress/src/dashboard/components/library/actions.ts
@@ -17,6 +17,8 @@ type Api = {
 const isVideoPressIdle = ( item: LibraryItem ) =>
 	item.type === 'videopress' && item.upload.status === 'idle';
 
+const isLocalIdle = ( item: LibraryItem ) => item.type === 'local' && item.upload.status === 'idle';
+
 /**
  * Eligibility for a privacy action: the item must be an idle VideoPress video
  * that does not already have the target privacy. Local items, in-flight videos,
@@ -49,12 +51,19 @@ const PRIVACY_ACTIONS: { idSuffix: string; label: string; privacy: LibraryItemPr
 /**
  * Build the DataViews actions array for the Library tab. Eligibility predicates
  * gate per-row availability based on `item.type` and `item.upload.status`. The
- * Delete and privacy actions set `supportsBulk: true` and use `isEligible` to
- * filter out items that can't accept the change (local items, in-flight videos,
- * or videos already at the target privacy). DataViews silently skips ineligible
- * items, so a mixed selection only applies to the rows that qualify. Rows with a
- * delete already in flight are ineligible for every action so a slow delete
- * can't be double-fired or raced by an edit.
+ * Delete, privacy, and Upload to VideoPress actions set `supportsBulk: true`
+ * and use `isEligible` to filter out items that can't accept the change
+ * (in-flight videos, videos already at the target privacy, non-local items for
+ * the promote). DataViews silently skips ineligible items, so a mixed selection
+ * only applies to the rows that qualify. Rows with a delete already in flight
+ * are ineligible for every action so a slow delete can't be double-fired or
+ * raced by an edit.
+ *
+ * Invariant: every idle row — local or VideoPress — must satisfy at least one
+ * `supportsBulk` action's `isEligible`. DataViews disables an item's selection
+ * checkbox when no bulk action applies to it, so a row type with zero
+ * bulk-capable actions silently becomes unselectable in both layouts (the bug
+ * behind JETPACK-2032, where local rows only had single-item actions).
  *
  * @param api - Hook mutators forwarded into the action callbacks.
  * @return The actions array for `<DataViews>`.
@@ -102,7 +111,10 @@ export function buildLibraryActions( api: Api ): Action< LibraryItem >[] {
 			id: 'delete',
 			label: __( 'Delete', 'jetpack-videopress-pkg' ),
 			supportsBulk: true,
-			isEligible: isVideoPressIdle,
+			// Local rows are deletable too: the pipeline is a plain core
+			// DELETE /wp/v2/media/{id}?force=true either way, with nothing
+			// VideoPress-specific about it.
+			isEligible: item => isVideoPressIdle( item ) || isLocalIdle( item ),
 			callback: items => {
 				api.deleteItems( items.map( i => i.id ) );
 			},
@@ -111,19 +123,19 @@ export function buildLibraryActions( api: Api ): Action< LibraryItem >[] {
 			id: 'upload-to-vp',
 			label: __( 'Upload to VideoPress', 'jetpack-videopress-pkg' ),
 			isPrimary: true,
-			supportsBulk: false,
+			supportsBulk: true,
 			// On WordPress.com Simple the promote mutation routes through
 			// wpcom/v2/videopress/promote (in-process — the file is already on
 			// WordPress.com storage); elsewhere it walks /videopress/v1/upload/{id}.
 			// Allowlist on 'idle' (matching the design note at the top of this
 			// file) so a row whose promote is already in flight — overlaid as
 			// 'promoting' — can't double-fire it.
-			isEligible: item => item.type === 'local' && item.upload.status === 'idle',
+			isEligible: isLocalIdle,
+			// Fan out per item: promoteLocal owns per-id in-flight state (a
+			// re-entrant id is a no-op) and each promote settles independently
+			// with its own notice and row overlay.
 			callback: items => {
-				const [ item ] = items;
-				if ( item ) {
-					api.promoteLocal( item.id );
-				}
+				items.forEach( item => api.promoteLocal( item.id ) );
 			},
 		},
 		{

--- a/projects/packages/videopress/src/dashboard/components/library/test/actions.test.ts
+++ b/projects/packages/videopress/src/dashboard/components/library/test/actions.test.ts
@@ -55,6 +55,27 @@ describe( 'buildLibraryActions', () => {
 		expect( actions.find( a => a.id === 'manage-captions' )?.isEligible?.( idle ) ).toBe( true );
 	} );
 
+	it( 'makes an idle local row deletable (plain attachment delete)', () => {
+		const actions = buildLibraryActions( makeApi() );
+		const local = item( { type: 'local' } );
+
+		expect( actions.find( a => a.id === 'delete' )?.isEligible?.( local ) ).toBe( true );
+	} );
+
+	it( 'gives every idle row a bulk-capable action so DataViews enables its checkbox', () => {
+		// DataViews disables an item's selection checkbox when no
+		// `supportsBulk` action is eligible for it (useHasAPossibleBulkAction,
+		// same gate in the grid and table layouts). Local rows used to have
+		// zero bulk-capable actions and were silently unselectable
+		// (JETPACK-2032); this pins the invariant for both row types.
+		const actions = buildLibraryActions( makeApi() );
+		const hasAPossibleBulkAction = ( row: ReturnType< typeof item > ) =>
+			actions.some( a => a.supportsBulk && ( ! a.isEligible || a.isEligible( row ) ) );
+
+		expect( hasAPossibleBulkAction( item() ) ).toBe( true );
+		expect( hasAPossibleBulkAction( item( { type: 'local' } ) ) ).toBe( true );
+	} );
+
 	it( 'offers Upload to VideoPress for idle local items on every host', () => {
 		const local = item( { type: 'local' } );
 		const eligible = ( actions: ReturnType< typeof buildLibraryActions > ) =>
@@ -72,6 +93,19 @@ describe( 'buildLibraryActions', () => {
 		} finally {
 			unsetSimpleSite();
 		}
+	} );
+
+	it( 'fans a bulk Upload to VideoPress out to every selected item', () => {
+		const api = makeApi();
+		const action = buildLibraryActions( api ).find( a => a.id === 'upload-to-vp' );
+
+		expect( action?.supportsBulk ).toBe( true );
+
+		const rows = [ item( { type: 'local', id: '11' } ), item( { type: 'local', id: '12' } ) ];
+		if ( action && 'callback' in action ) {
+			action.callback( rows, { registry: {} } );
+		}
+		expect( api.promoteLocal.mock.calls ).toEqual( [ [ '11' ], [ '12' ] ] );
 	} );
 
 	it( 'makes a local row with any operation in flight ineligible for Upload to VideoPress', () => {


### PR DESCRIPTION
Fixes JETPACK-2032

## Proposed changes

* VideoPress library: local ("Local video") rows can now be multi-selected. DataViews disables an item's selection checkbox when the item has no eligible `supportsBulk` action, and local rows had none — every bulk action (Delete + the three privacy actions) was gated to idle VideoPress items — so their checkboxes took focus but never checked, in both the grid and list layouts.
* "Upload to VideoPress" is now a bulk action: select several local videos and promote them in one go. The callback fans out to the existing per-item promote, which already handles concurrency (per-id in-flight guard and progress overlay client-side; mutex + idempotent replay server-side on wpcom Simple), so each video keeps its own progress overlay and settle notice.
* Delete is now eligible for idle local rows too. Deletion is a plain core `DELETE /wp/v2/media/{id}?force=true` for every row type — nothing VideoPress-specific — so the VideoPress-only gate was never a technical necessity, and it was half of what kept local rows unselectable.
* Privacy actions stay VideoPress-only (local videos have no privacy controls); DataViews silently skips ineligible items in mixed selections, so selecting a mix of local and VideoPress rows applies each bulk action only to the rows that qualify.
* A regression test pins the invariant that every idle row type satisfies at least one bulk action's eligibility, mirroring DataViews' `useHasAPossibleBulkAction` gate.

## Related product discussion/links

* JETPACK-2032 (reported in the VideoPress-admin-UI-on-Simple CFT on cftp2, comment-9127)
* Related: JETPACK-1889 / Automattic/jetpack#50794 covered multi-file selection in the header "Upload video" file picker; this PR covers the batch path for videos already in the media library.
* Promote flow shipped in Automattic/jetpack#50611.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

You need a Simple site with local videos (videos in the media library not hosted by VideoPress). The quickest recipe: create a test site on Premium, upload a few videos, then upgrade to Business — or use any existing site from the CFT round.

* Go to wp-admin → Jetpack → VideoPress (Library tab).
* In the grid view, click the selection checkbox on a "Local video" tile: it should now actually check (previously it only took focus). Same in the list view.
* Select several local videos and choose "Upload to VideoPress" from the bulk actions bar: each selected tile should switch to its own promoting overlay, then "Processing", with one settle notice per video. Re-running the bulk action while promotes are in flight is a no-op for the in-flight rows.
* Select a mix of local and VideoPress videos: "Upload to VideoPress" should only act on the local ones, privacy actions only on the VideoPress ones, and Delete on both.
* Delete a local video via the bulk bar and confirm the attachment is removed from the media library.
* `pnpm jest src/dashboard/components/library routes/library` from `projects/packages/videopress` (51 tests).
