### PR TITLE
SEO: polish the Overview tab (card-title icons, primary buttons, interactive coverage charts) [JETPACK-2034]

### DIFF
--- a/projects/packages/seo/_inc/screens/content/index.tsx
+++ b/projects/packages/seo/_inc/screens/content/index.tsx
@@ -2,7 +2,7 @@ import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { pencil } from '@wordpress/icons';
-import { useNavigate } from '@wordpress/route';
+import { useNavigate, useSearch } from '@wordpress/route';
 import { Badge, IconButton, Link } from '@wordpress/ui';
 import useSeoPosts from '../../data/use-seo-posts';
 import styles from './style.module.scss';
@@ -20,6 +20,10 @@ const DESCRIPTION_FIELD = 'description';
 // Filter-only field id for search visibility; the displayed column is
 // 'searchVisibility'.
 const SEARCH_FIELD = 'searchFilter';
+// Filter-only field id for SEO-title set/not-set; the displayed column is
+// 'seoTitle'. Lets the Overview "SEO title set" ring deep-link to the rows
+// that still need a title.
+const TITLE_FIELD = 'titleFilter';
 
 // Schema filter sentinel for the no-override rows. The schema column's raw
 // value for those rows is '' (empty meta); the filter element uses this value
@@ -52,6 +56,34 @@ const DEFAULT_VIEW: View = {
 };
 
 const defaultLayouts = { table: {} };
+
+// A coverage ring on the Overview deep-links here with `?needs=`, naming the
+// unconfigured slice to show. Map it to the matching filter-only field so the
+// user lands pre-filtered to exactly the rows that still need that field.
+type ContentSearch = Record< string, unknown > & { needs?: string };
+type ViewFilter = NonNullable< View[ 'filters' ] >[ number ];
+
+/**
+ * Map an Overview `?needs=` value to the DataViews filter that narrows the list
+ * to the rows still missing that field.
+ *
+ * @param needs - The `?needs=` query value (schema | title | description | search).
+ * @return The matching filter, or null when the value is absent or unrecognized.
+ */
+function needsToFilter( needs: string | undefined ): ViewFilter | null {
+	switch ( needs ) {
+		case 'schema':
+			return { field: SCHEMA_FIELD, operator: 'is', value: SCHEMA_DEFAULT };
+		case 'title':
+			return { field: TITLE_FIELD, operator: 'is', value: 'not_set' };
+		case 'description':
+			return { field: DESCRIPTION_FIELD, operator: 'is', value: 'not_set' };
+		case 'search':
+			return { field: SEARCH_FIELD, operator: 'is', value: 'hidden' };
+		default:
+			return null;
+	}
+}
 
 interface EditButtonProps {
 	item: ContentRow;
@@ -100,8 +132,19 @@ function schemaLabel( schemaType: ContentRow[ 'schemaType' ] ): string {
  * @return The Content stage content.
  */
 const ContentScreen: FC = () => {
-	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
 	const navigate = useNavigate();
+
+	// Overview coverage rings deep-link here with `?needs=` to pre-filter the list
+	// to the rows still missing that field. Seed the initial view once from it; the
+	// filter then behaves like any user-applied filter (visible chip, dismissable).
+	const search = useSearch( {
+		from: '/content' as unknown as never,
+		strict: false,
+	} ) as ContentSearch;
+	const [ view, setView ] = useState< View >( () => {
+		const filter = needsToFilter( search.needs );
+		return filter ? { ...DEFAULT_VIEW, filters: [ filter ] } : DEFAULT_VIEW;
+	} );
 
 	const { items, isLoading, postTypeOptions } = useSeoPosts();
 
@@ -177,6 +220,19 @@ const ContentScreen: FC = () => {
 						{ item.hasCustomTitle ? setLabel : notSetLabel }
 					</Badge>
 				),
+			},
+			{
+				id: TITLE_FIELD,
+				label: __( 'SEO title set', 'jetpack-seo' ),
+				elements: [
+					{ value: 'set', label: setLabel },
+					{ value: 'not_set', label: notSetLabel },
+				],
+				filterBy: { operators: [ 'is' ] as Operator[] },
+				enableSorting: false,
+				enableHiding: false,
+				render: () => null,
+				getValue: ( { item } ) => ( item.hasCustomTitle ? 'set' : 'not_set' ),
 			},
 			{
 				id: 'metaDescription',

--- a/projects/packages/seo/_inc/screens/content/index.tsx
+++ b/projects/packages/seo/_inc/screens/content/index.tsx
@@ -57,9 +57,7 @@ const DEFAULT_VIEW: View = {
 
 const defaultLayouts = { table: {} };
 
-// A coverage ring on the Overview deep-links here with `?needs=`, naming the
-// unconfigured slice to show. Map it to the matching filter-only field so the
-// user lands pre-filtered to exactly the rows that still need that field.
+// The Overview's coverage rings deep-link here via `?needs=` (see needsToFilter).
 type ContentSearch = Record< string, unknown > & { needs?: string };
 type ViewFilter = NonNullable< View[ 'filters' ] >[ number ];
 

--- a/projects/packages/seo/_inc/screens/content/test/index.test.tsx
+++ b/projects/packages/seo/_inc/screens/content/test/index.test.tsx
@@ -66,6 +66,26 @@ describe( 'ContentScreen — ?needs= deep-link seeding', () => {
 		] );
 	} );
 
+	it( 'seeds the meta-description filter from ?needs=description', () => {
+		useSearch.mockReturnValue( { needs: 'description' } );
+
+		render( <ContentScreen /> );
+
+		expect( capturedView?.filters ).toEqual( [
+			{ field: 'description', operator: 'is', value: 'not_set' },
+		] );
+	} );
+
+	it( 'seeds the search-visibility filter from ?needs=search', () => {
+		useSearch.mockReturnValue( { needs: 'search' } );
+
+		render( <ContentScreen /> );
+
+		expect( capturedView?.filters ).toEqual( [
+			{ field: 'searchFilter', operator: 'is', value: 'hidden' },
+		] );
+	} );
+
 	it( 'starts unfiltered when there is no ?needs= param', () => {
 		useSearch.mockReturnValue( {} );
 

--- a/projects/packages/seo/_inc/screens/content/test/index.test.tsx
+++ b/projects/packages/seo/_inc/screens/content/test/index.test.tsx
@@ -1,0 +1,84 @@
+import '@testing-library/jest-dom';
+import { jest } from '@jest/globals';
+import { render } from '@testing-library/react';
+import type { View } from '@wordpress/dataviews';
+
+// `--experimental-vm-modules` (true ESM): mock with `jest.unstable_mockModule`
+// and import the component under test dynamically after the mocks are registered.
+// DataViews is stubbed to capture the props the screen hands it, so we can assert
+// the initial view/fields without rendering the (heavy) real grid.
+let capturedView: View | undefined;
+let capturedFields: Array< { id: string } > = [];
+
+const useSearch = jest.fn< () => { needs?: string } >();
+
+jest.unstable_mockModule( '@wordpress/route', () => ( {
+	useNavigate: () => jest.fn(),
+	useSearch,
+} ) );
+
+jest.unstable_mockModule( '../../../data/use-seo-posts', () => ( {
+	default: () => ( {
+		items: [],
+		isLoading: false,
+		postTypeOptions: [ { value: 'post', label: 'Posts' } ],
+	} ),
+} ) );
+
+jest.unstable_mockModule( '@wordpress/dataviews', () => ( {
+	DataViews: ( props: { view: View; fields: Array< { id: string } > } ) => {
+		capturedView = props.view;
+		capturedFields = props.fields;
+		return null;
+	},
+	filterSortAndPaginate: () => ( {
+		data: [],
+		paginationInfo: { totalItems: 0, totalPages: 0 },
+	} ),
+} ) );
+
+const { default: ContentScreen } = await import( '../index' );
+
+describe( 'ContentScreen — ?needs= deep-link seeding', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		capturedView = undefined;
+		capturedFields = [];
+	} );
+
+	it( 'seeds the SEO-title filter from ?needs=title', () => {
+		useSearch.mockReturnValue( { needs: 'title' } );
+
+		render( <ContentScreen /> );
+
+		expect( capturedView?.filters ).toEqual( [
+			{ field: 'titleFilter', operator: 'is', value: 'not_set' },
+		] );
+	} );
+
+	it( 'seeds the schema filter from ?needs=schema', () => {
+		useSearch.mockReturnValue( { needs: 'schema' } );
+
+		render( <ContentScreen /> );
+
+		expect( capturedView?.filters ).toEqual( [
+			{ field: 'schemaType', operator: 'is', value: 'default' },
+		] );
+	} );
+
+	it( 'starts unfiltered when there is no ?needs= param', () => {
+		useSearch.mockReturnValue( {} );
+
+		render( <ContentScreen /> );
+
+		expect( capturedView?.filters ).toEqual( [] );
+	} );
+
+	it( 'exposes a filter-only field for SEO-title set/not-set', () => {
+		useSearch.mockReturnValue( {} );
+
+		render( <ContentScreen /> );
+
+		expect( capturedFields.some( field => field.id === 'titleFilter' ) ).toBe( true );
+	} );
+} );

--- a/projects/packages/seo/_inc/screens/overview/ai-crawler-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/ai-crawler-card.tsx
@@ -120,7 +120,7 @@ const AiCrawlerCard: FC< Props > = ( { data, searchEnginesVisible, onManage } ) 
 					<Text>{ blockedLabel }</Text>
 				) }
 				<Stack direction="row" justify="flex-end" className={ styles.footer }>
-					<Button variant="outline" tone="neutral" onClick={ onManage }>
+					<Button variant="solid" onClick={ onManage }>
 						{ __( 'Manage AI crawlers', 'jetpack-seo' ) }
 					</Button>
 				</Stack>

--- a/projects/packages/seo/_inc/screens/overview/ai-crawler-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/ai-crawler-card.tsx
@@ -93,10 +93,10 @@ const AiCrawlerCard: FC< Props > = ( { data, searchEnginesVisible, onManage } ) 
 			<Card.Header>
 				<Card.Title>
 					<span className={ styles.cardTitle }>
-						{ __( 'AI crawler access', 'jetpack-seo' ) }
 						<span className={ styles.titleIcon }>
-							<Icon icon={ key } size={ 20 } />
+							<Icon icon={ key } size={ 24 } />
 						</span>
+						{ __( 'AI crawler access', 'jetpack-seo' ) }
 					</span>
 				</Card.Title>
 			</Card.Header>

--- a/projects/packages/seo/_inc/screens/overview/ai-crawler-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/ai-crawler-card.tsx
@@ -1,6 +1,7 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { key } from '@wordpress/icons';
-import { Button, Card, Icon, Stack, Text } from '@wordpress/ui';
+import { Button, Card, Stack, Text } from '@wordpress/ui';
+import CardHeaderIcon from './card-header-icon';
 import StatusDot from './status-dot';
 import styles from './style.module.scss';
 import type { AiCrawler, AiState } from '../../data/ai-types';
@@ -90,16 +91,7 @@ const AiCrawlerCard: FC< Props > = ( { data, searchEnginesVisible, onManage } ) 
 
 	return (
 		<Card.Root>
-			<Card.Header>
-				<Card.Title>
-					<span className={ styles.cardTitle }>
-						<span className={ styles.titleIcon }>
-							<Icon icon={ key } size={ 24 } />
-						</span>
-						{ __( 'AI crawler access', 'jetpack-seo' ) }
-					</span>
-				</Card.Title>
-			</Card.Header>
+			<CardHeaderIcon icon={ key } title={ __( 'AI crawler access', 'jetpack-seo' ) } />
 			<Stack render={ <Card.Content /> } direction="column" className={ styles.cardContent }>
 				{ settingsApply ? (
 					<Stack direction="column" gap="xs">

--- a/projects/packages/seo/_inc/screens/overview/ai-crawler-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/ai-crawler-card.tsx
@@ -128,7 +128,7 @@ const AiCrawlerCard: FC< Props > = ( { data, searchEnginesVisible, onManage } ) 
 					<Text>{ blockedLabel }</Text>
 				) }
 				<Stack direction="row" justify="flex-end" className={ styles.footer }>
-					<Button variant="solid" onClick={ onManage }>
+					<Button variant="solid" size="compact" onClick={ onManage }>
 						{ __( 'Manage AI crawlers', 'jetpack-seo' ) }
 					</Button>
 				</Stack>

--- a/projects/packages/seo/_inc/screens/overview/ai-crawler-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/ai-crawler-card.tsx
@@ -1,5 +1,6 @@
 import { __, sprintf } from '@wordpress/i18n';
-import { Button, Card, Stack, Text } from '@wordpress/ui';
+import { key } from '@wordpress/icons';
+import { Button, Card, Icon, Stack, Text } from '@wordpress/ui';
 import StatusDot from './status-dot';
 import styles from './style.module.scss';
 import type { AiCrawler, AiState } from '../../data/ai-types';
@@ -90,7 +91,14 @@ const AiCrawlerCard: FC< Props > = ( { data, searchEnginesVisible, onManage } ) 
 	return (
 		<Card.Root>
 			<Card.Header>
-				<Card.Title>{ __( 'AI crawler access', 'jetpack-seo' ) }</Card.Title>
+				<Card.Title>
+					<span className={ styles.cardTitle }>
+						{ __( 'AI crawler access', 'jetpack-seo' ) }
+						<span className={ styles.titleIcon }>
+							<Icon icon={ key } size={ 20 } />
+						</span>
+					</span>
+				</Card.Title>
 			</Card.Header>
 			<Stack render={ <Card.Content /> } direction="column" className={ styles.cardContent }>
 				{ settingsApply ? (

--- a/projects/packages/seo/_inc/screens/overview/card-header-icon.tsx
+++ b/projects/packages/seo/_inc/screens/overview/card-header-icon.tsx
@@ -1,0 +1,34 @@
+import { Card, Icon } from '@wordpress/ui';
+import styles from './style.module.scss';
+import type { ComponentProps, FC } from 'react';
+
+interface Props {
+	// The `@wordpress/icons` glyph shown in the leading chip.
+	icon: ComponentProps< typeof Icon >[ 'icon' ];
+	title: string;
+}
+
+/**
+ * Overview card header: a title led by an `@wordpress/icons` glyph in a small
+ * tinted chip. Shared by the four Overview cards so the chip markup and icon
+ * size live in one place rather than being repeated (and drifting) per card.
+ *
+ * @param props       - Component props.
+ * @param props.icon  - The leading icon glyph.
+ * @param props.title - The card title text.
+ * @return The card header.
+ */
+const CardHeaderIcon: FC< Props > = ( { icon, title } ) => (
+	<Card.Header>
+		<Card.Title>
+			<span className={ styles.cardTitle }>
+				<span className={ styles.titleIcon }>
+					<Icon icon={ icon } size={ 24 } />
+				</span>
+				{ title }
+			</span>
+		</Card.Title>
+	</Card.Header>
+);
+
+export default CardHeaderIcon;

--- a/projects/packages/seo/_inc/screens/overview/content-coverage-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/content-coverage-card.tsx
@@ -80,7 +80,9 @@ const CoverageRing: FC< RingProps > = ( { label, action, segment, total, need, o
 					thickness="4"
 				/>
 				<span className={ styles.pct } aria-hidden="true">
-					<Text variant="heading-lg">{ percent }</Text>
+					<Text variant="heading-lg" className={ styles.pctValue }>
+						{ percent }
+					</Text>
 				</span>
 			</div>
 			<Text variant="heading-lg">{ count }</Text>

--- a/projects/packages/seo/_inc/screens/overview/content-coverage-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/content-coverage-card.tsx
@@ -162,7 +162,7 @@ const ContentCoverageCard: FC< Props > = ( { data, onManage, onFilter } ) => {
 				) }
 				<Stack direction="row" justify="flex-end" className={ styles.footer }>
 					<Button variant="solid" onClick={ onManage }>
-						{ __( 'Manage content', 'jetpack-seo' ) }
+						{ __( 'Manage content SEO', 'jetpack-seo' ) }
 					</Button>
 				</Stack>
 			</Card.Content>

--- a/projects/packages/seo/_inc/screens/overview/content-coverage-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/content-coverage-card.tsx
@@ -1,7 +1,7 @@
 import { DonutMeter } from '@automattic/jetpack-components';
 import { useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { postList } from '@wordpress/icons';
+import { formatListBullets } from '@wordpress/icons';
 import { Button, Card, Icon, Stack, Text, Tooltip } from '@wordpress/ui';
 import styles from './style.module.scss';
 import type { ContentCoverage } from '../../data/overview-types';
@@ -115,7 +115,9 @@ const ContentCoverageCard: FC< Props > = ( { data, onManage, onFilter } ) => {
 				<Card.Title>
 					<span className={ styles.cardTitle }>
 						{ __( 'Content SEO', 'jetpack-seo' ) }
-						<Icon icon={ postList } size={ 20 } className={ styles.titleIcon } />
+						<span className={ styles.titleIcon }>
+							<Icon icon={ formatListBullets } size={ 20 } />
+						</span>
 					</span>
 				</Card.Title>
 			</Card.Header>

--- a/projects/packages/seo/_inc/screens/overview/content-coverage-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/content-coverage-card.tsx
@@ -2,7 +2,8 @@ import { DonutMeter } from '@automattic/jetpack-components';
 import { useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { formatListBullets } from '@wordpress/icons';
-import { Button, Card, Icon, Stack, Text, Tooltip } from '@wordpress/ui';
+import { Button, Card, Stack, Text, Tooltip } from '@wordpress/ui';
+import CardHeaderIcon from './card-header-icon';
 import styles from './style.module.scss';
 import type { ContentCoverage } from '../../data/overview-types';
 import type { FC, ReactNode } from 'react';
@@ -22,7 +23,7 @@ interface Props {
 interface RingProps {
 	label: string;
 	// Localized action for the interactive ring: describes what filtering to the
-	// unconfigured rows will show. Doubles as the ring's accessible label.
+	// unconfigured rows will show, and seeds the ring's accessible name.
 	action: string;
 	segment: number;
 	total: number;
@@ -43,7 +44,7 @@ interface RingProps {
  *
  * @param props          - Component props.
  * @param props.label    - Localized label for the metric.
- * @param props.action   - Localized action/aria label for the interactive ring.
+ * @param props.action   - Localized action; also seeds the ring's accessible name.
  * @param props.segment  - Number of posts with the field set.
  * @param props.total    - Total published supported content items.
  * @param props.need     - The unconfigured slice this ring filters to.
@@ -60,18 +61,21 @@ const CoverageRing: FC< RingProps > = ( { label, action, segment, total, need, o
 		total
 	);
 
+	// Round to whole percent, but never show a misleading "100%" while the ring is
+	// still incomplete (e.g. 199/200 → 99%). A fully-covered ring reads exactly 100%.
+	const rounded = segment >= total ? 100 : Math.min( 99, Math.round( ( segment / total ) * 100 ) );
 	const percent = sprintf(
 		/* translators: %d: percentage of posts with the field set. */
 		__( '%d%%', 'jetpack-seo' ),
-		Math.round( ( segment / total ) * 100 )
+		rounded
 	);
 
 	const inner: ReactNode = (
 		<>
-			{ /* Chart is decorative: the ring's aria-label carries the action and the
-			     count/label are visible text below, so the DonutMeter and the centered
-			     percentage are aria-hidden — this also removes the DonutMeter's native
-			     SVG `<title>` tooltip, which duplicated the action tooltip on hover. */ }
+			{ /* Chart is decorative: the interactive ring's aria-label carries the action
+			     and count, and the count/label are visible text below, so the DonutMeter
+			     and the centered percentage are aria-hidden — this also removes the
+			     DonutMeter's native SVG `<title>` tooltip, which duplicated the tooltip. */ }
 			<div className={ styles.donutWrap }>
 				<DonutMeter
 					totalCount={ total }
@@ -99,21 +103,30 @@ const CoverageRing: FC< RingProps > = ( { label, action, segment, total, need, o
 		);
 	}
 
+	// The button's aria-label overrides its contents for the accessible name, so
+	// fold the count in — otherwise a screen reader hears the action but loses the
+	// coverage value the sighted user sees.
+	const accessibleName = sprintf(
+		/* translators: %1$s: the action (e.g. "Set SEO titles"); %2$d: posts with the field set; %3$d: total posts. */
+		__( '%1$s. %2$d of %3$d.', 'jetpack-seo' ),
+		action,
+		segment,
+		total
+	);
+
 	return (
-		<Tooltip.Provider delay={ 150 }>
-			<Tooltip.Root>
-				<Tooltip.Trigger
-					className={ styles.ringTrigger }
-					aria-label={ action }
-					onClick={ handleFilter }
-				>
-					<Stack direction="column" align="center" gap="xs" className={ styles.ring }>
-						{ inner }
-					</Stack>
-				</Tooltip.Trigger>
-				<Tooltip.Popup>{ action }</Tooltip.Popup>
-			</Tooltip.Root>
-		</Tooltip.Provider>
+		<Tooltip.Root>
+			<Tooltip.Trigger
+				className={ styles.ringTrigger }
+				aria-label={ accessibleName }
+				onClick={ handleFilter }
+			>
+				<Stack direction="column" align="center" gap="xs" className={ styles.ring }>
+					{ inner }
+				</Stack>
+			</Tooltip.Trigger>
+			<Tooltip.Popup>{ action }</Tooltip.Popup>
+		</Tooltip.Root>
 	);
 };
 
@@ -130,56 +143,51 @@ const ContentCoverageCard: FC< Props > = ( { data, onManage, onFilter } ) => {
 
 	return (
 		<Card.Root>
-			<Card.Header>
-				<Card.Title>
-					<span className={ styles.cardTitle }>
-						<span className={ styles.titleIcon }>
-							<Icon icon={ formatListBullets } size={ 24 } />
-						</span>
-						{ __( 'Content SEO', 'jetpack-seo' ) }
-					</span>
-				</Card.Title>
-			</Card.Header>
+			<CardHeaderIcon icon={ formatListBullets } title={ __( 'Content SEO', 'jetpack-seo' ) } />
 			<Card.Content>
 				{ total === 0 ? (
 					<Text variant="body-md" render={ <p /> }>
 						{ __( 'No published posts or pages yet.', 'jetpack-seo' ) }
 					</Text>
 				) : (
-					<div className={ styles.rings }>
-						<CoverageRing
-							label={ __( 'Schema applied', 'jetpack-seo' ) }
-							action={ schemaAction }
-							segment={ with_schema }
-							total={ total }
-							need="schema"
-							onFilter={ onFilter }
-						/>
-						<CoverageRing
-							label={ __( 'SEO title set', 'jetpack-seo' ) }
-							action={ titleAction }
-							segment={ with_title }
-							total={ total }
-							need="title"
-							onFilter={ onFilter }
-						/>
-						<CoverageRing
-							label={ __( 'Meta description added', 'jetpack-seo' ) }
-							action={ descriptionAction }
-							segment={ with_description }
-							total={ total }
-							need="description"
-							onFilter={ onFilter }
-						/>
-						<CoverageRing
-							label={ __( 'Visible to search engines', 'jetpack-seo' ) }
-							action={ searchAction }
-							segment={ with_search_visible }
-							total={ total }
-							need="search"
-							onFilter={ onFilter }
-						/>
-					</div>
+					// One shared Tooltip.Provider for all rings so hovering between
+					// adjacent rings re-opens instantly instead of re-waiting the delay.
+					<Tooltip.Provider delay={ 150 }>
+						<div className={ styles.rings }>
+							<CoverageRing
+								label={ __( 'Schema applied', 'jetpack-seo' ) }
+								action={ schemaAction }
+								segment={ with_schema }
+								total={ total }
+								need="schema"
+								onFilter={ onFilter }
+							/>
+							<CoverageRing
+								label={ __( 'SEO title set', 'jetpack-seo' ) }
+								action={ titleAction }
+								segment={ with_title }
+								total={ total }
+								need="title"
+								onFilter={ onFilter }
+							/>
+							<CoverageRing
+								label={ __( 'Meta description added', 'jetpack-seo' ) }
+								action={ descriptionAction }
+								segment={ with_description }
+								total={ total }
+								need="description"
+								onFilter={ onFilter }
+							/>
+							<CoverageRing
+								label={ __( 'Visible to search engines', 'jetpack-seo' ) }
+								action={ searchAction }
+								segment={ with_search_visible }
+								total={ total }
+								need="search"
+								onFilter={ onFilter }
+							/>
+						</div>
+					</Tooltip.Provider>
 				) }
 				<Stack direction="row" justify="flex-end" className={ styles.footer }>
 					<Button variant="solid" size="compact" onClick={ onManage }>

--- a/projects/packages/seo/_inc/screens/overview/content-coverage-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/content-coverage-card.tsx
@@ -163,7 +163,7 @@ const ContentCoverageCard: FC< Props > = ( { data, onManage, onFilter } ) => {
 					</div>
 				) }
 				<Stack direction="row" justify="flex-end" className={ styles.footer }>
-					<Button variant="solid" onClick={ onManage }>
+					<Button variant="solid" size="compact" onClick={ onManage }>
 						{ __( 'Manage content SEO', 'jetpack-seo' ) }
 					</Button>
 				</Stack>

--- a/projects/packages/seo/_inc/screens/overview/content-coverage-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/content-coverage-card.tsx
@@ -83,18 +83,20 @@ const CoverageRing: FC< RingProps > = ( { label, action, segment, total, need, o
 	}
 
 	return (
-		<Tooltip.Root>
-			<Tooltip.Trigger
-				className={ styles.ringTrigger }
-				aria-label={ action }
-				onClick={ handleFilter }
-			>
-				<Stack direction="column" align="center" gap="xs" className={ styles.ring }>
-					{ inner }
-				</Stack>
-			</Tooltip.Trigger>
-			<Tooltip.Popup>{ action }</Tooltip.Popup>
-		</Tooltip.Root>
+		<Tooltip.Provider delay={ 150 }>
+			<Tooltip.Root>
+				<Tooltip.Trigger
+					className={ styles.ringTrigger }
+					aria-label={ action }
+					onClick={ handleFilter }
+				>
+					<Stack direction="column" align="center" gap="xs" className={ styles.ring }>
+						{ inner }
+					</Stack>
+				</Tooltip.Trigger>
+				<Tooltip.Popup>{ action }</Tooltip.Popup>
+			</Tooltip.Root>
+		</Tooltip.Provider>
 	);
 };
 

--- a/projects/packages/seo/_inc/screens/overview/content-coverage-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/content-coverage-card.tsx
@@ -1,19 +1,33 @@
 import { DonutMeter } from '@automattic/jetpack-components';
+import { useCallback } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { Button, Card, Stack, Text } from '@wordpress/ui';
+import { postList } from '@wordpress/icons';
+import { Button, Card, Icon, Stack, Text, Tooltip } from '@wordpress/ui';
 import styles from './style.module.scss';
 import type { ContentCoverage } from '../../data/overview-types';
-import type { FC } from 'react';
+import type { FC, ReactNode } from 'react';
+
+// The unconfigured slice a ring deep-links to on the Content tab. Each value is
+// read back off the URL by the Content screen (`?needs=`) and seeded as a
+// DataViews filter so the user lands on exactly the rows that still need work.
+export type ContentNeed = 'schema' | 'title' | 'description' | 'search';
 
 interface Props {
 	data: ContentCoverage;
 	onManage: () => void;
+	// Deep-link to the Content tab filtered to the rows still missing this field.
+	onFilter: ( need: ContentNeed ) => void;
 }
 
 interface RingProps {
 	label: string;
+	// Localized action for the interactive ring: describes what filtering to the
+	// unconfigured rows will show. Doubles as the ring's accessible label.
+	action: string;
 	segment: number;
 	total: number;
+	need: ContentNeed;
+	onFilter: ( need: ContentNeed ) => void;
 }
 
 /**
@@ -22,45 +36,96 @@ interface RingProps {
  * adaptive — fuller is not "better", it's just how many posts have the field
  * set. The admin decides what matters.
  *
- * @param props         - Component props.
- * @param props.label   - Localized label for the metric.
- * @param props.segment - Number of posts with the field set.
- * @param props.total   - Total published supported content items.
- * @return A labelled coverage ring.
+ * When some items still lack the field, the ring is an interactive control that
+ * deep-links to the Content tab filtered to *those* rows — the ones there's an
+ * action to take. A fully-covered ring has nothing to fix, so it stays static.
+ *
+ * @param props          - Component props.
+ * @param props.label    - Localized label for the metric.
+ * @param props.action   - Localized action/aria label for the interactive ring.
+ * @param props.segment  - Number of posts with the field set.
+ * @param props.total    - Total published supported content items.
+ * @param props.need     - The unconfigured slice this ring filters to.
+ * @param props.onFilter - Deep-link handler for the unconfigured rows.
+ * @return A labelled coverage ring, interactive when work remains.
  */
-const CoverageRing: FC< RingProps > = ( { label, segment, total } ) => (
-	<Stack direction="column" align="center" gap="xs" className={ styles.ring }>
-		<DonutMeter
-			totalCount={ total }
-			segmentCount={ segment }
-			donutWidth="56px"
-			title={ label }
-			description={ sprintf(
-				/* translators: %1$d: posts with the field set, %2$d: total published posts. */
-				__( '%1$d of %2$d', 'jetpack-seo' ),
-				segment,
-				total
-			) }
-		/>
-		<Text variant="heading-md">
-			{ sprintf(
-				/* translators: %1$d: posts with the field set, %2$d: total published posts. */
-				__( '%1$d / %2$d', 'jetpack-seo' ),
-				segment,
-				total
-			) }
-		</Text>
-		<Text variant="body-sm">{ label }</Text>
-	</Stack>
-);
+const CoverageRing: FC< RingProps > = ( { label, action, segment, total, need, onFilter } ) => {
+	const handleFilter = useCallback( () => onFilter( need ), [ need, onFilter ] );
 
-const ContentCoverageCard: FC< Props > = ( { data, onManage } ) => {
+	const description = sprintf(
+		/* translators: %1$d: posts with the field set, %2$d: total published posts. */
+		__( '%1$d of %2$d', 'jetpack-seo' ),
+		segment,
+		total
+	);
+	const count = sprintf(
+		/* translators: %1$d: posts with the field set, %2$d: total published posts. */
+		__( '%1$d / %2$d', 'jetpack-seo' ),
+		segment,
+		total
+	);
+
+	const inner: ReactNode = (
+		<>
+			<div className={ styles.donutWrap }>
+				<DonutMeter
+					totalCount={ total }
+					segmentCount={ segment }
+					donutWidth="56px"
+					title={ label }
+					description={ description }
+				/>
+			</div>
+			<Text variant="heading-md">{ count }</Text>
+			<Text variant="body-sm">{ label }</Text>
+		</>
+	);
+
+	// Everything set → nothing to filter to; keep it a static, non-interactive ring.
+	if ( segment >= total ) {
+		return (
+			<Stack direction="column" align="center" gap="xs" className={ styles.ring }>
+				{ inner }
+			</Stack>
+		);
+	}
+
+	return (
+		<Tooltip.Root>
+			<Tooltip.Trigger
+				className={ styles.ringTrigger }
+				aria-label={ action }
+				onClick={ handleFilter }
+			>
+				<Stack direction="column" align="center" gap="xs" className={ styles.ring }>
+					{ inner }
+				</Stack>
+			</Tooltip.Trigger>
+			<Tooltip.Popup>{ action }</Tooltip.Popup>
+		</Tooltip.Root>
+	);
+};
+
+// Per-ring action copy resolved at module scope (static, one per ring) so the
+// production minifier can't fold adjacent `__()` calls. See
+// feedback_i18n_ternary_minifier_fold.
+const schemaAction = __( 'View content without a schema type', 'jetpack-seo' );
+const titleAction = __( 'View content missing an SEO title', 'jetpack-seo' );
+const descriptionAction = __( 'View content missing a meta description', 'jetpack-seo' );
+const searchAction = __( 'View content hidden from search engines', 'jetpack-seo' );
+
+const ContentCoverageCard: FC< Props > = ( { data, onManage, onFilter } ) => {
 	const { total, with_schema, with_title, with_description, with_search_visible } = data;
 
 	return (
 		<Card.Root>
 			<Card.Header>
-				<Card.Title>{ __( 'Content SEO', 'jetpack-seo' ) }</Card.Title>
+				<Card.Title>
+					<span className={ styles.cardTitle }>
+						{ __( 'Content SEO', 'jetpack-seo' ) }
+						<Icon icon={ postList } size={ 20 } className={ styles.titleIcon } />
+					</span>
+				</Card.Title>
 			</Card.Header>
 			<Card.Content>
 				{ total === 0 ? (
@@ -71,28 +136,40 @@ const ContentCoverageCard: FC< Props > = ( { data, onManage } ) => {
 					<div className={ styles.rings }>
 						<CoverageRing
 							label={ __( 'Schema applied', 'jetpack-seo' ) }
+							action={ schemaAction }
 							segment={ with_schema }
 							total={ total }
+							need="schema"
+							onFilter={ onFilter }
 						/>
 						<CoverageRing
 							label={ __( 'SEO title set', 'jetpack-seo' ) }
+							action={ titleAction }
 							segment={ with_title }
 							total={ total }
+							need="title"
+							onFilter={ onFilter }
 						/>
 						<CoverageRing
 							label={ __( 'Meta description added', 'jetpack-seo' ) }
+							action={ descriptionAction }
 							segment={ with_description }
 							total={ total }
+							need="description"
+							onFilter={ onFilter }
 						/>
 						<CoverageRing
 							label={ __( 'Visible to search engines', 'jetpack-seo' ) }
+							action={ searchAction }
 							segment={ with_search_visible }
 							total={ total }
+							need="search"
+							onFilter={ onFilter }
 						/>
 					</div>
 				) }
 				<Stack direction="row" justify="flex-end" className={ styles.footer }>
-					<Button variant="outline" tone="neutral" onClick={ onManage }>
+					<Button variant="solid" onClick={ onManage }>
 						{ __( 'Manage content', 'jetpack-seo' ) }
 					</Button>
 				</Stack>

--- a/projects/packages/seo/_inc/screens/overview/content-coverage-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/content-coverage-card.tsx
@@ -66,7 +66,7 @@ const CoverageRing: FC< RingProps > = ( { label, action, segment, total, need, o
 			     unlabeled (aria-hidden) — this also removes its native SVG `<title>`
 			     tooltip, which otherwise duplicated the action tooltip on hover. */ }
 			<div className={ styles.donutWrap }>
-				<DonutMeter totalCount={ total } segmentCount={ segment } donutWidth="56px" />
+				<DonutMeter totalCount={ total } segmentCount={ segment } donutWidth="96px" thickness="5" />
 			</div>
 			<Text variant="heading-md">{ count }</Text>
 			<Text variant="body-sm">{ label }</Text>

--- a/projects/packages/seo/_inc/screens/overview/content-coverage-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/content-coverage-card.tsx
@@ -52,12 +52,6 @@ interface RingProps {
 const CoverageRing: FC< RingProps > = ( { label, action, segment, total, need, onFilter } ) => {
 	const handleFilter = useCallback( () => onFilter( need ), [ need, onFilter ] );
 
-	const description = sprintf(
-		/* translators: %1$d: posts with the field set, %2$d: total published posts. */
-		__( '%1$d of %2$d', 'jetpack-seo' ),
-		segment,
-		total
-	);
 	const count = sprintf(
 		/* translators: %1$d: posts with the field set, %2$d: total published posts. */
 		__( '%1$d / %2$d', 'jetpack-seo' ),
@@ -67,14 +61,12 @@ const CoverageRing: FC< RingProps > = ( { label, action, segment, total, need, o
 
 	const inner: ReactNode = (
 		<>
+			{ /* Chart is decorative here: the ring's aria-label carries the action and
+			     the count/label are visible text below, so the DonutMeter is left
+			     unlabeled (aria-hidden) — this also removes its native SVG `<title>`
+			     tooltip, which otherwise duplicated the action tooltip on hover. */ }
 			<div className={ styles.donutWrap }>
-				<DonutMeter
-					totalCount={ total }
-					segmentCount={ segment }
-					donutWidth="56px"
-					title={ label }
-					description={ description }
-				/>
+				<DonutMeter totalCount={ total } segmentCount={ segment } donutWidth="56px" />
 			</div>
 			<Text variant="heading-md">{ count }</Text>
 			<Text variant="body-sm">{ label }</Text>
@@ -109,10 +101,10 @@ const CoverageRing: FC< RingProps > = ( { label, action, segment, total, need, o
 // Per-ring action copy resolved at module scope (static, one per ring) so the
 // production minifier can't fold adjacent `__()` calls. See
 // feedback_i18n_ternary_minifier_fold.
-const schemaAction = __( 'View content without a schema type', 'jetpack-seo' );
-const titleAction = __( 'View content missing an SEO title', 'jetpack-seo' );
-const descriptionAction = __( 'View content missing a meta description', 'jetpack-seo' );
-const searchAction = __( 'View content hidden from search engines', 'jetpack-seo' );
+const schemaAction = __( 'Add schema to content', 'jetpack-seo' );
+const titleAction = __( 'Set SEO titles', 'jetpack-seo' );
+const descriptionAction = __( 'Add meta descriptions', 'jetpack-seo' );
+const searchAction = __( 'Configure search visibility', 'jetpack-seo' );
 
 const ContentCoverageCard: FC< Props > = ( { data, onManage, onFilter } ) => {
 	const { total, with_schema, with_title, with_description, with_search_visible } = data;

--- a/projects/packages/seo/_inc/screens/overview/content-coverage-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/content-coverage-card.tsx
@@ -116,10 +116,10 @@ const ContentCoverageCard: FC< Props > = ( { data, onManage, onFilter } ) => {
 			<Card.Header>
 				<Card.Title>
 					<span className={ styles.cardTitle }>
-						{ __( 'Content SEO', 'jetpack-seo' ) }
 						<span className={ styles.titleIcon }>
-							<Icon icon={ formatListBullets } size={ 20 } />
+							<Icon icon={ formatListBullets } size={ 24 } />
 						</span>
+						{ __( 'Content SEO', 'jetpack-seo' ) }
 					</span>
 				</Card.Title>
 			</Card.Header>

--- a/projects/packages/seo/_inc/screens/overview/content-coverage-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/content-coverage-card.tsx
@@ -32,9 +32,10 @@ interface RingProps {
 
 /**
  * One factual coverage ring: a proportion (segment of total) plus the literal
- * count beneath it. Deliberately a single neutral fill colour and never
- * adaptive — fuller is not "better", it's just how many posts have the field
- * set. The admin decides what matters.
+ * count and a centered percentage. Uses the DonutMeter's default Jetpack-brand
+ * green — a deliberate brand choice, not a health grade, and never adaptive (a
+ * fuller ring never turns yellow/red); more posts with the field set just means
+ * a fuller ring. The admin decides what matters.
  *
  * When some items still lack the field, the ring is an interactive control that
  * deep-links to the Content tab filtered to *those* rows — the ones there's an
@@ -59,16 +60,30 @@ const CoverageRing: FC< RingProps > = ( { label, action, segment, total, need, o
 		total
 	);
 
+	const percent = sprintf(
+		/* translators: %d: percentage of posts with the field set. */
+		__( '%d%%', 'jetpack-seo' ),
+		Math.round( ( segment / total ) * 100 )
+	);
+
 	const inner: ReactNode = (
 		<>
-			{ /* Chart is decorative here: the ring's aria-label carries the action and
-			     the count/label are visible text below, so the DonutMeter is left
-			     unlabeled (aria-hidden) — this also removes its native SVG `<title>`
-			     tooltip, which otherwise duplicated the action tooltip on hover. */ }
+			{ /* Chart is decorative: the ring's aria-label carries the action and the
+			     count/label are visible text below, so the DonutMeter and the centered
+			     percentage are aria-hidden — this also removes the DonutMeter's native
+			     SVG `<title>` tooltip, which duplicated the action tooltip on hover. */ }
 			<div className={ styles.donutWrap }>
-				<DonutMeter totalCount={ total } segmentCount={ segment } donutWidth="96px" thickness="5" />
+				<DonutMeter
+					totalCount={ total }
+					segmentCount={ segment }
+					donutWidth="112px"
+					thickness="4"
+				/>
+				<span className={ styles.pct } aria-hidden="true">
+					<Text variant="heading-lg">{ percent }</Text>
+				</span>
 			</div>
-			<Text variant="heading-md">{ count }</Text>
+			<Text variant="heading-lg">{ count }</Text>
 			<Text variant="body-sm">{ label }</Text>
 		</>
 	);

--- a/projects/packages/seo/_inc/screens/overview/index.tsx
+++ b/projects/packages/seo/_inc/screens/overview/index.tsx
@@ -14,7 +14,7 @@ import getOverview from '../../data/get-overview';
 import { isGated } from '../../data/is-gated';
 import { settingsStore } from '../../data/settings-store';
 import AiCrawlerCard from './ai-crawler-card';
-import ContentCoverageCard from './content-coverage-card';
+import ContentCoverageCard, { type ContentNeed } from './content-coverage-card';
 import DisableSeoTools from './disable-seo-tools';
 import SiteVerificationCard from './site-verification-card';
 import SiteVisibilityCard from './site-visibility-card';
@@ -50,6 +50,14 @@ const OverviewScreen: FC = () => {
 
 	// Deep-link to the Content route.
 	const goToContent = useCallback( () => navigate( { href: '/content' } ), [ navigate ] );
+
+	// Deep-link to the Content route filtered to the rows still missing a field
+	// (`?needs=`, read by the Content screen). Clicking a coverage ring lands the
+	// user on exactly the content there's an action to take on.
+	const goToContentNeeds = useCallback(
+		( need: ContentNeed ) => navigate( { href: `/content?needs=${ encodeURIComponent( need ) }` } ),
+		[ navigate ]
+	);
 
 	// Deep-link to the GEO route (AI crawler management).
 	const goToAi = useCallback( () => navigate( { href: '/ai' } ), [ navigate ] );
@@ -140,7 +148,11 @@ const OverviewScreen: FC = () => {
 				) }
 			</div>
 			<div className={ styles.contentCard }>
-				<ContentCoverageCard data={ coverage ?? data.content_coverage } onManage={ goToContent } />
+				<ContentCoverageCard
+					data={ coverage ?? data.content_coverage }
+					onManage={ goToContent }
+					onFilter={ goToContentNeeds }
+				/>
 			</div>
 			{ /* Hidden on WordPress.com Simple, where `Modules::is_active()` reports
 			     every module active regardless of stored state, so SEO tools can't

--- a/projects/packages/seo/_inc/screens/overview/site-verification-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/site-verification-card.tsx
@@ -1,7 +1,8 @@
 import { __ } from '@wordpress/i18n';
 import { check } from '@wordpress/icons';
-import { Button, Card, Icon, Stack } from '@wordpress/ui';
+import { Button, Card, Stack } from '@wordpress/ui';
 import { VERIFICATION_SERVICES } from '../../data/verification-services';
+import CardHeaderIcon from './card-header-icon';
 import StatusDot from './status-dot';
 import styles from './style.module.scss';
 import type { SiteVerification } from '../../data/overview-types';
@@ -19,16 +20,7 @@ const notSetLabel = __( 'Not set', 'jetpack-seo' );
 
 const SiteVerificationCard: FC< Props > = ( { data, onManage } ) => (
 	<Card.Root>
-		<Card.Header>
-			<Card.Title>
-				<span className={ styles.cardTitle }>
-					<span className={ styles.titleIcon }>
-						<Icon icon={ check } size={ 24 } />
-					</span>
-					{ __( 'Site verification', 'jetpack-seo' ) }
-				</span>
-			</Card.Title>
-		</Card.Header>
+		<CardHeaderIcon icon={ check } title={ __( 'Site verification', 'jetpack-seo' ) } />
 		<Stack render={ <Card.Content /> } direction="column" className={ styles.cardContent }>
 			{ VERIFICATION_SERVICES.map( ( { key, label } ) => (
 				<Stack

--- a/projects/packages/seo/_inc/screens/overview/site-verification-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/site-verification-card.tsx
@@ -43,7 +43,7 @@ const SiteVerificationCard: FC< Props > = ( { data, onManage } ) => (
 				</Stack>
 			) ) }
 			<Stack direction="row" justify="flex-end" className={ styles.footer }>
-				<Button variant="solid" onClick={ onManage }>
+				<Button variant="solid" size="compact" onClick={ onManage }>
 					{ __( 'Manage verification', 'jetpack-seo' ) }
 				</Button>
 			</Stack>

--- a/projects/packages/seo/_inc/screens/overview/site-verification-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/site-verification-card.tsx
@@ -22,10 +22,10 @@ const SiteVerificationCard: FC< Props > = ( { data, onManage } ) => (
 		<Card.Header>
 			<Card.Title>
 				<span className={ styles.cardTitle }>
-					{ __( 'Site verification', 'jetpack-seo' ) }
 					<span className={ styles.titleIcon }>
-						<Icon icon={ check } size={ 20 } />
+						<Icon icon={ check } size={ 24 } />
 					</span>
+					{ __( 'Site verification', 'jetpack-seo' ) }
 				</span>
 			</Card.Title>
 		</Card.Header>

--- a/projects/packages/seo/_inc/screens/overview/site-verification-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/site-verification-card.tsx
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
-import { Button, Card, Stack } from '@wordpress/ui';
+import { shield } from '@wordpress/icons';
+import { Button, Card, Icon, Stack } from '@wordpress/ui';
 import { VERIFICATION_SERVICES } from '../../data/verification-services';
 import StatusDot from './status-dot';
 import styles from './style.module.scss';
@@ -19,7 +20,12 @@ const notSetLabel = __( 'Not set', 'jetpack-seo' );
 const SiteVerificationCard: FC< Props > = ( { data, onManage } ) => (
 	<Card.Root>
 		<Card.Header>
-			<Card.Title>{ __( 'Site verification', 'jetpack-seo' ) }</Card.Title>
+			<Card.Title>
+				<span className={ styles.cardTitle }>
+					{ __( 'Site verification', 'jetpack-seo' ) }
+					<Icon icon={ shield } size={ 20 } className={ styles.titleIcon } />
+				</span>
+			</Card.Title>
 		</Card.Header>
 		<Stack render={ <Card.Content /> } direction="column" className={ styles.cardContent }>
 			{ VERIFICATION_SERVICES.map( ( { key, label } ) => (
@@ -35,7 +41,7 @@ const SiteVerificationCard: FC< Props > = ( { data, onManage } ) => (
 				</Stack>
 			) ) }
 			<Stack direction="row" justify="flex-end" className={ styles.footer }>
-				<Button variant="outline" tone="neutral" onClick={ onManage }>
+				<Button variant="solid" onClick={ onManage }>
 					{ __( 'Manage verification', 'jetpack-seo' ) }
 				</Button>
 			</Stack>

--- a/projects/packages/seo/_inc/screens/overview/site-verification-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/site-verification-card.tsx
@@ -1,5 +1,5 @@
 import { __ } from '@wordpress/i18n';
-import { shield } from '@wordpress/icons';
+import { check } from '@wordpress/icons';
 import { Button, Card, Icon, Stack } from '@wordpress/ui';
 import { VERIFICATION_SERVICES } from '../../data/verification-services';
 import StatusDot from './status-dot';
@@ -23,7 +23,9 @@ const SiteVerificationCard: FC< Props > = ( { data, onManage } ) => (
 			<Card.Title>
 				<span className={ styles.cardTitle }>
 					{ __( 'Site verification', 'jetpack-seo' ) }
-					<Icon icon={ shield } size={ 20 } className={ styles.titleIcon } />
+					<span className={ styles.titleIcon }>
+						<Icon icon={ check } size={ 20 } />
+					</span>
 				</span>
 			</Card.Title>
 		</Card.Header>

--- a/projects/packages/seo/_inc/screens/overview/site-visibility-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/site-visibility-card.tsx
@@ -32,10 +32,10 @@ const SiteVisibilityCard: FC< Props > = ( { data, onManage } ) => {
 			<Card.Header>
 				<Card.Title>
 					<span className={ styles.cardTitle }>
-						{ __( 'Site visibility', 'jetpack-seo' ) }
 						<span className={ styles.titleIcon }>
-							<Icon icon={ seen } size={ 20 } />
+							<Icon icon={ seen } size={ 24 } />
 						</span>
+						{ __( 'Site visibility', 'jetpack-seo' ) }
 					</span>
 				</Card.Title>
 			</Card.Header>

--- a/projects/packages/seo/_inc/screens/overview/site-visibility-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/site-visibility-card.tsx
@@ -33,7 +33,9 @@ const SiteVisibilityCard: FC< Props > = ( { data, onManage } ) => {
 				<Card.Title>
 					<span className={ styles.cardTitle }>
 						{ __( 'Site visibility', 'jetpack-seo' ) }
-						<Icon icon={ seen } size={ 20 } className={ styles.titleIcon } />
+						<span className={ styles.titleIcon }>
+							<Icon icon={ seen } size={ 20 } />
+						</span>
 					</span>
 				</Card.Title>
 			</Card.Header>

--- a/projects/packages/seo/_inc/screens/overview/site-visibility-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/site-visibility-card.tsx
@@ -1,5 +1,6 @@
 import { __ } from '@wordpress/i18n';
-import { Button, Card, Stack } from '@wordpress/ui';
+import { seen } from '@wordpress/icons';
+import { Button, Card, Icon, Stack } from '@wordpress/ui';
 import StatusDot from './status-dot';
 import styles from './style.module.scss';
 import type { OverviewResponse } from '../../data/overview-types';
@@ -29,7 +30,12 @@ const SiteVisibilityCard: FC< Props > = ( { data, onManage } ) => {
 	return (
 		<Card.Root>
 			<Card.Header>
-				<Card.Title>{ __( 'Site visibility', 'jetpack-seo' ) }</Card.Title>
+				<Card.Title>
+					<span className={ styles.cardTitle }>
+						{ __( 'Site visibility', 'jetpack-seo' ) }
+						<Icon icon={ seen } size={ 20 } className={ styles.titleIcon } />
+					</span>
+				</Card.Title>
 			</Card.Header>
 			<Stack render={ <Card.Content /> } direction="column" className={ styles.cardContent }>
 				<Stack direction="column" gap="xs">
@@ -47,7 +53,7 @@ const SiteVisibilityCard: FC< Props > = ( { data, onManage } ) => {
 					/>
 				</Stack>
 				<Stack direction="row" justify="flex-end" className={ styles.footer }>
-					<Button variant="outline" tone="neutral" onClick={ onManage }>
+					<Button variant="solid" onClick={ onManage }>
 						{ __( 'Manage visibility', 'jetpack-seo' ) }
 					</Button>
 				</Stack>

--- a/projects/packages/seo/_inc/screens/overview/site-visibility-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/site-visibility-card.tsx
@@ -1,6 +1,7 @@
 import { __ } from '@wordpress/i18n';
 import { seen } from '@wordpress/icons';
-import { Button, Card, Icon, Stack } from '@wordpress/ui';
+import { Button, Card, Stack } from '@wordpress/ui';
+import CardHeaderIcon from './card-header-icon';
 import StatusDot from './status-dot';
 import styles from './style.module.scss';
 import type { OverviewResponse } from '../../data/overview-types';
@@ -29,16 +30,7 @@ const SiteVisibilityCard: FC< Props > = ( { data, onManage } ) => {
 
 	return (
 		<Card.Root>
-			<Card.Header>
-				<Card.Title>
-					<span className={ styles.cardTitle }>
-						<span className={ styles.titleIcon }>
-							<Icon icon={ seen } size={ 24 } />
-						</span>
-						{ __( 'Site visibility', 'jetpack-seo' ) }
-					</span>
-				</Card.Title>
-			</Card.Header>
+			<CardHeaderIcon icon={ seen } title={ __( 'Site visibility', 'jetpack-seo' ) } />
 			<Stack render={ <Card.Content /> } direction="column" className={ styles.cardContent }>
 				<Stack direction="column" gap="xs">
 					<StatusDot

--- a/projects/packages/seo/_inc/screens/overview/site-visibility-card.tsx
+++ b/projects/packages/seo/_inc/screens/overview/site-visibility-card.tsx
@@ -55,7 +55,7 @@ const SiteVisibilityCard: FC< Props > = ( { data, onManage } ) => {
 					/>
 				</Stack>
 				<Stack direction="row" justify="flex-end" className={ styles.footer }>
-					<Button variant="solid" onClick={ onManage }>
+					<Button variant="solid" size="compact" onClick={ onManage }>
 						{ __( 'Manage visibility', 'jetpack-seo' ) }
 					</Button>
 				</Stack>

--- a/projects/packages/seo/_inc/screens/overview/style.module.scss
+++ b/projects/packages/seo/_inc/screens/overview/style.module.scss
@@ -122,6 +122,13 @@
 	justify-content: center;
 }
 
+// Bold (600 — the WPDS emphasis weight, which has no lint-approved token, so a
+// literal per the house convention) so the percentage leads the value hierarchy
+// while keeping the same heading-lg size as the count.
+.pctValue {
+	font-weight: 600;
+}
+
 .ringTrigger:hover .donutWrap,
 .ringTrigger:focus-visible .donutWrap {
 	transform: scale(1.06);

--- a/projects/packages/seo/_inc/screens/overview/style.module.scss
+++ b/projects/packages/seo/_inc/screens/overview/style.module.scss
@@ -122,9 +122,10 @@
 	justify-content: center;
 }
 
-// Bold (700) so the percentage clearly leads the medium-weight count below,
-// while keeping the same heading-lg size. Literal weight per the house
-// convention (WPDS exposes no lint-approved emphasis/bold weight token).
+// Bold (700): leads the medium-weight count, same heading-lg size.
+// Literal weight (WPDS has no lint-approved bold weight token). It only wins
+// over @wordpress/ui's layered variant weight because this module CSS is
+// unlayered; if it's ever moved into a cascade layer, make it win explicitly.
 .pctValue {
 	font-weight: 700;
 }

--- a/projects/packages/seo/_inc/screens/overview/style.module.scss
+++ b/projects/packages/seo/_inc/screens/overview/style.module.scss
@@ -66,7 +66,9 @@
 .cardTitle {
 	display: inline-flex;
 	align-items: center;
-	gap: var(--wpds-dimension-gap-xs);
+	// `sm` (8px) matches the icon-to-label spacing used by StatusDot in these
+	// same cards, rather than the tighter `xs`.
+	gap: var(--wpds-dimension-gap-sm);
 }
 
 .titleIcon {

--- a/projects/packages/seo/_inc/screens/overview/style.module.scss
+++ b/projects/packages/seo/_inc/screens/overview/style.module.scss
@@ -60,8 +60,9 @@
 	color: var(--wpds-color-foreground-content-neutral-weak);
 }
 
-// Card title with a trailing accent icon. The icon sits after the title text so
-// the title still left-aligns with the card body below it.
+// Card title with a trailing accent icon, presented as a small tinted "chip"
+// badge. The icon sits after the title text so the title still left-aligns with
+// the card body below it.
 .cardTitle {
 	display: inline-flex;
 	align-items: center;
@@ -69,8 +70,15 @@
 }
 
 .titleIcon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
 	flex: none;
+	inline-size: 30px;
+	block-size: 30px;
+	border-radius: 50%;
 	color: var(--wpds-color-foreground-interactive-brand);
+	background: color-mix(in sRGB, var(--wpds-color-foreground-interactive-brand) 13%, transparent);
 }
 
 // Interactive coverage ring: the whole ring is a button that deep-links to the

--- a/projects/packages/seo/_inc/screens/overview/style.module.scss
+++ b/projects/packages/seo/_inc/screens/overview/style.module.scss
@@ -60,9 +60,8 @@
 	color: var(--wpds-color-foreground-content-neutral-weak);
 }
 
-// Card title with a trailing accent icon, presented as a small tinted "chip"
-// badge. The icon sits after the title text so the title still left-aligns with
-// the card body below it.
+// Card title with a leading accent icon, presented as a small tinted "chip"
+// badge before the title text (the placement Jetpack's other cards use).
 .cardTitle {
 	display: inline-flex;
 	align-items: center;
@@ -71,13 +70,16 @@
 	gap: var(--wpds-dimension-gap-sm);
 }
 
+// A 24px icon (the @wordpress/ui default) in a `size-md` (32px) chip — both from
+// the WPDS scale — reads as a filled badge rather than a small icon floating in
+// an oversized circle.
 .titleIcon {
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
 	flex: none;
-	inline-size: 30px;
-	block-size: 30px;
+	inline-size: var(--wpds-dimension-size-md);
+	block-size: var(--wpds-dimension-size-md);
 	border-radius: 50%;
 	color: var(--wpds-color-foreground-interactive-brand);
 	background: var(--wpds-color-background-surface-brand);

--- a/projects/packages/seo/_inc/screens/overview/style.module.scss
+++ b/projects/packages/seo/_inc/screens/overview/style.module.scss
@@ -107,7 +107,19 @@
 }
 
 .donutWrap {
+	position: relative;
+	display: inline-flex;
 	transition: transform 0.18s ease;
+}
+
+// Percentage centered in the donut hole. Visual summary only — the count and
+// label below carry the same value for assistive tech, so it's aria-hidden.
+.pct {
+	position: absolute;
+	inset: 0;
+	display: flex;
+	align-items: center;
+	justify-content: center;
 }
 
 .ringTrigger:hover .donutWrap,

--- a/projects/packages/seo/_inc/screens/overview/style.module.scss
+++ b/projects/packages/seo/_inc/screens/overview/style.module.scss
@@ -122,11 +122,11 @@
 	justify-content: center;
 }
 
-// Bold (600 — the WPDS emphasis weight, which has no lint-approved token, so a
-// literal per the house convention) so the percentage leads the value hierarchy
-// while keeping the same heading-lg size as the count.
+// Bold (700) so the percentage clearly leads the medium-weight count below,
+// while keeping the same heading-lg size. Literal weight per the house
+// convention (WPDS exposes no lint-approved emphasis/bold weight token).
 .pctValue {
-	font-weight: 600;
+	font-weight: 700;
 }
 
 .ringTrigger:hover .donutWrap,

--- a/projects/packages/seo/_inc/screens/overview/style.module.scss
+++ b/projects/packages/seo/_inc/screens/overview/style.module.scss
@@ -70,9 +70,9 @@
 	gap: var(--wpds-dimension-gap-sm);
 }
 
-// A 24px icon (the @wordpress/ui default) in a `size-md` (32px) chip — both from
-// the WPDS scale — reads as a filled badge rather than a small icon floating in
-// an oversized circle.
+// A 24px icon (the @wordpress/ui default) in a `size-md` (32px) chip — both
+// from the WPDS size scale, so the glyph fills the badge instead of floating
+// in an oversized circle.
 .titleIcon {
 	display: inline-flex;
 	align-items: center;

--- a/projects/packages/seo/_inc/screens/overview/style.module.scss
+++ b/projects/packages/seo/_inc/screens/overview/style.module.scss
@@ -78,7 +78,7 @@
 	block-size: 30px;
 	border-radius: 50%;
 	color: var(--wpds-color-foreground-interactive-brand);
-	background: color-mix(in sRGB, var(--wpds-color-foreground-interactive-brand) 13%, transparent);
+	background: var(--wpds-color-background-surface-brand);
 }
 
 // Interactive coverage ring: the whole ring is a button that deep-links to the

--- a/projects/packages/seo/_inc/screens/overview/style.module.scss
+++ b/projects/packages/seo/_inc/screens/overview/style.module.scss
@@ -59,3 +59,58 @@
 	margin-block-start: var(--wpds-dimension-gap-lg);
 	color: var(--wpds-color-foreground-content-neutral-weak);
 }
+
+// Card title with a trailing accent icon. The icon sits after the title text so
+// the title still left-aligns with the card body below it.
+.cardTitle {
+	display: inline-flex;
+	align-items: center;
+	gap: var(--wpds-dimension-gap-xs);
+}
+
+.titleIcon {
+	flex: none;
+	color: var(--wpds-color-foreground-interactive-brand);
+}
+
+// Interactive coverage ring: the whole ring is a button that deep-links to the
+// Content tab filtered to the rows still missing this field. Reset the native
+// button chrome; the donut lifts on hover/focus to signal it's actionable.
+.ringTrigger {
+	display: block;
+	inline-size: 100%;
+	margin: 0;
+	padding: var(--wpds-dimension-gap-xs);
+	border: 0;
+	border-radius: 6px;
+	background: transparent;
+	color: inherit;
+	font: inherit;
+	cursor: pointer;
+}
+
+.ringTrigger:focus-visible {
+	outline: 2px solid var(--wpds-color-stroke-interactive-brand);
+	outline-offset: 2px;
+}
+
+.donutWrap {
+	transition: transform 0.18s ease;
+}
+
+.ringTrigger:hover .donutWrap,
+.ringTrigger:focus-visible .donutWrap {
+	transform: scale(1.06);
+}
+
+@media ( prefers-reduced-motion: reduce ) {
+
+	.donutWrap {
+		transition: none;
+	}
+
+	.ringTrigger:hover .donutWrap,
+	.ringTrigger:focus-visible .donutWrap {
+		transform: none;
+	}
+}

--- a/projects/packages/seo/_inc/screens/overview/test/content-coverage-card.test.tsx
+++ b/projects/packages/seo/_inc/screens/overview/test/content-coverage-card.test.tsx
@@ -28,7 +28,7 @@ describe( 'ContentCoverageCard', () => {
 		);
 
 		// eslint-disable-next-line testing-library/prefer-user-event -- fireEvent keeps this off the @testing-library/user-event devDep (avoids lockfile churn) for a single click.
-		fireEvent.click( screen.getByRole( 'button', { name: 'View content missing an SEO title' } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Set SEO titles' } ) );
 
 		expect( onFilter ).toHaveBeenCalledWith( 'title' );
 	} );
@@ -41,7 +41,7 @@ describe( 'ContentCoverageCard', () => {
 		// with_search_visible === total, so the "Visible to search engines" ring is
 		// not a button.
 		expect(
-			screen.queryByRole( 'button', { name: 'View content hidden from search engines' } )
+			screen.queryByRole( 'button', { name: 'Configure search visibility' } )
 		).not.toBeInTheDocument();
 	} );
 
@@ -74,7 +74,7 @@ describe( 'ContentCoverageCard', () => {
 
 		expect( screen.getByText( 'No published posts or pages yet.' ) ).toBeInTheDocument();
 		expect(
-			screen.queryByRole( 'button', { name: 'View content without a schema type' } )
+			screen.queryByRole( 'button', { name: 'Add schema to content' } )
 		).not.toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/seo/_inc/screens/overview/test/content-coverage-card.test.tsx
+++ b/projects/packages/seo/_inc/screens/overview/test/content-coverage-card.test.tsx
@@ -1,0 +1,80 @@
+import '@testing-library/jest-dom';
+import { jest } from '@jest/globals';
+import { fireEvent, render, screen } from '@testing-library/react';
+import ContentCoverageCard from '../content-coverage-card';
+import type { ContentCoverage } from '../../../data/overview-types';
+
+/**
+ * Build a content-coverage payload. Defaults leave three metrics partially
+ * covered (interactive rings) and search-visibility fully covered (static ring).
+ *
+ * @param overrides - Fields to override on the default payload.
+ * @return The coverage payload.
+ */
+const buildCoverage = ( overrides: Partial< ContentCoverage > = {} ): ContentCoverage => ( {
+	total: 10,
+	with_schema: 3,
+	with_title: 4,
+	with_description: 5,
+	with_search_visible: 10,
+	...overrides,
+} );
+
+describe( 'ContentCoverageCard', () => {
+	it( 'renders an interactive ring that deep-links to the unconfigured rows', () => {
+		const onFilter = jest.fn();
+		render(
+			<ContentCoverageCard data={ buildCoverage() } onManage={ jest.fn() } onFilter={ onFilter } />
+		);
+
+		// eslint-disable-next-line testing-library/prefer-user-event -- fireEvent keeps this off the @testing-library/user-event devDep (avoids lockfile churn) for a single click.
+		fireEvent.click( screen.getByRole( 'button', { name: 'View content missing an SEO title' } ) );
+
+		expect( onFilter ).toHaveBeenCalledWith( 'title' );
+	} );
+
+	it( 'leaves a fully-covered ring static, since there is nothing to fix', () => {
+		render(
+			<ContentCoverageCard data={ buildCoverage() } onManage={ jest.fn() } onFilter={ jest.fn() } />
+		);
+
+		// with_search_visible === total, so the "Visible to search engines" ring is
+		// not a button.
+		expect(
+			screen.queryByRole( 'button', { name: 'View content hidden from search engines' } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'calls onManage from the primary action button', () => {
+		const onManage = jest.fn();
+		render(
+			<ContentCoverageCard data={ buildCoverage() } onManage={ onManage } onFilter={ jest.fn() } />
+		);
+
+		// eslint-disable-next-line testing-library/prefer-user-event -- fireEvent keeps this off the @testing-library/user-event devDep (avoids lockfile churn) for a single click.
+		fireEvent.click( screen.getByRole( 'button', { name: 'Manage content' } ) );
+
+		expect( onManage ).toHaveBeenCalled();
+	} );
+
+	it( 'shows the empty state and no ring buttons when there is no content', () => {
+		render(
+			<ContentCoverageCard
+				data={ buildCoverage( {
+					total: 0,
+					with_schema: 0,
+					with_title: 0,
+					with_description: 0,
+					with_search_visible: 0,
+				} ) }
+				onManage={ jest.fn() }
+				onFilter={ jest.fn() }
+			/>
+		);
+
+		expect( screen.getByText( 'No published posts or pages yet.' ) ).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'button', { name: 'View content without a schema type' } )
+		).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/seo/_inc/screens/overview/test/content-coverage-card.test.tsx
+++ b/projects/packages/seo/_inc/screens/overview/test/content-coverage-card.test.tsx
@@ -52,7 +52,7 @@ describe( 'ContentCoverageCard', () => {
 		);
 
 		// eslint-disable-next-line testing-library/prefer-user-event -- fireEvent keeps this off the @testing-library/user-event devDep (avoids lockfile churn) for a single click.
-		fireEvent.click( screen.getByRole( 'button', { name: 'Manage content' } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Manage content SEO' } ) );
 
 		expect( onManage ).toHaveBeenCalled();
 	} );

--- a/projects/packages/seo/_inc/screens/overview/test/content-coverage-card.test.tsx
+++ b/projects/packages/seo/_inc/screens/overview/test/content-coverage-card.test.tsx
@@ -28,7 +28,7 @@ describe( 'ContentCoverageCard', () => {
 		);
 
 		// eslint-disable-next-line testing-library/prefer-user-event -- fireEvent keeps this off the @testing-library/user-event devDep (avoids lockfile churn) for a single click.
-		fireEvent.click( screen.getByRole( 'button', { name: 'Set SEO titles' } ) );
+		fireEvent.click( screen.getByRole( 'button', { name: /Set SEO titles/ } ) );
 
 		expect( onFilter ).toHaveBeenCalledWith( 'title' );
 	} );
@@ -41,7 +41,7 @@ describe( 'ContentCoverageCard', () => {
 		// with_search_visible === total, so the "Visible to search engines" ring is
 		// not a button.
 		expect(
-			screen.queryByRole( 'button', { name: 'Configure search visibility' } )
+			screen.queryByRole( 'button', { name: /Configure search visibility/ } )
 		).not.toBeInTheDocument();
 	} );
 
@@ -74,7 +74,7 @@ describe( 'ContentCoverageCard', () => {
 
 		expect( screen.getByText( 'No published posts or pages yet.' ) ).toBeInTheDocument();
 		expect(
-			screen.queryByRole( 'button', { name: 'Add schema to content' } )
+			screen.queryByRole( 'button', { name: /Add schema to content/ } )
 		).not.toBeInTheDocument();
 	} );
 } );

--- a/projects/packages/seo/changelog/add-seo-overview-visual-polish
+++ b/projects/packages/seo/changelog/add-seo-overview-visual-polish
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+SEO: polish the Overview tab — trailing card-title icons, primary action buttons, and interactive coverage rings that deep-link to the Content tab filtered to the posts still missing that field.

--- a/projects/packages/seo/changelog/add-seo-overview-visual-polish
+++ b/projects/packages/seo/changelog/add-seo-overview-visual-polish
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-SEO: polish the Overview tab — trailing card-title icons, primary action buttons, and interactive coverage rings that deep-link to the Content tab filtered to the posts still missing that field.
+SEO: polish the Overview tab — card-title icons, primary action buttons, and interactive coverage rings that deep-link to the Content tab filtered to the posts still missing that field.


### PR DESCRIPTION
## Proposed changes

A visual-interest pass on the SEO **Overview** tab — testing feedback (Filipe Varela, Jetpack 16.0) called the tab "not that compelling," with "no hierarchy to the information." No card behavior changes beyond one new deep-link.

* **Card-title icon chips** — each card title now leads with a small `@wordpress/icons` glyph in a tinted circle: Site visibility → `seen`, Site verification → `check`, AI crawler access → `key`, Content SEO → `formatListBullets`. A 24px icon (the `@wordpress/ui` default) in a 32px (`--wpds-dimension-size-md`) chip, tinted with `--wpds-color-background-surface-brand`.
* **Primary action buttons** — the four "Manage…" CTAs use the current WPDS `variant="solid"` button at `size="compact"`.
* **Interactive coverage rings** (Content SEO card) — each ring wraps the shared `DonutMeter` in a `Tooltip.Trigger` and **deep-links to the Content tab filtered to the rows still missing that field** (the actionable ones), with a task-oriented tooltip ("Set SEO titles", "Add schema to content", …), a hover/focus lift, and a short tooltip delay. Rings are enlarged (112px) with a bold, centered percentage; a fully-covered ring is non-interactive (nothing to fix).

Implementation notes:
* Reuses the shared `DonutMeter` untouched — the green fill is the component's default, a deliberate brand-consistent choice (not a health grade; the ring never adapts to yellow/red).
* Adds one filter-only "SEO title set" field to the Content `DataViews` and seeds the view from a `?needs=` query param, mirroring the existing Settings `?focus=` deep-link pattern.
* Built on existing WPDS primitives and tokens throughout; the only bespoke CSS is the icon-chip container and the ring hover/focus interaction (the design system has no primitive for either).
* New unit tests cover the ring interactivity (interactive vs. static, deep-link callback) and the `?needs=` filter seeding.

## Related product discussion/links

* [JETPACK-2034](https://linear.app/a8c/issue/JETPACK-2034) — SEO Overview tab: visual polish (this PR)
* [JETPACK-2033](https://linear.app/a8c/issue/JETPACK-2033) — origin: Jetpack 16.0 testing-feedback verification pass
* [JETPACK-2035](https://linear.app/a8c/issue/JETPACK-2035) — follow-up: dashboard accessibility review

## Does this pull request change what data or activity we track or use?

No. The ring click is client-side route navigation (`?needs=`); it adds no Tracks events and reads no new data.

## Testing instructions

Requires the SEO dashboard visible: SEO tools enabled and the `rsm_jetpack_seo` flag on (`add_filter( 'rsm_jetpack_seo', '__return_true' );`). Create several posts/pages, leaving some **without** an SEO title / meta description / schema so the coverage rings are partially filled.

1. Go to **Jetpack → SEO** (Overview tab).
2. **Icons:** each card title leads with a tinted icon chip.
3. **Buttons:** the "Manage…" buttons are the compact solid (blue) style.
4. **Coverage rings** (Content SEO card): each ring shows a bold centered percentage and a `count / total` below.
   * Hover or keyboard-focus a partially-filled ring — it lifts and shows a task-oriented tooltip; the fully-covered ring is not interactive.
   * Click it (or press Enter/Space) — the Content tab opens pre-filtered to the rows still missing that field; confirm the filter shows as a dismissable chip.
5. Enable OS "reduce motion" — the hover lift should not animate.

## Screenshots

**Before**
<img width="1567" height="864" alt="Jetpack SEO Overview design BEFORE" src="https://github.com/user-attachments/assets/58778cde-4c64-4050-89e4-d839c34eda4f" />

**After**
<img width="1567" height="867" alt="Jetpack SEO Overview design AFTER" src="https://github.com/user-attachments/assets/75ab4b7e-1fac-4f6c-838e-d35896ebf9df" />

