### PR TITLE
VideoPress block: promote local library videos in place on WordPress.com Simple

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-block-promote-on-simple
+++ b/projects/packages/videopress/changelog/fix-videopress-block-promote-on-simple
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress block: fix selecting an existing local video from the media library on WordPress.com Simple (promote in place instead of the unreachable videopress/v1 upload), and stop the error screen's Retry from crashing when there is no file to restart

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.jsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/index.jsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { getRedirectUrl } from '@automattic/jetpack-components';
+import { isSimpleSite } from '@automattic/jetpack-script-data';
 import apiFetch from '@wordpress/api-fetch';
 import { BlockIcon, MediaPlaceholder } from '@wordpress/block-editor';
 import { Spinner, withNotices, Button } from '@wordpress/components';
@@ -14,6 +15,7 @@ import { Link } from '@wordpress/ui';
 import useResumableUploader from '../../../../../hooks/use-resumable-uploader';
 import { uploadFromLibrary } from '../../../../../hooks/use-uploader';
 import { isSiteConnected } from '../../../../../lib/connection';
+import { promoteOnSimple } from '../../../../../lib/promote-on-simple';
 import {
 	buildVideoPressURL,
 	buildVideoPressVideoByFileName,
@@ -216,6 +218,30 @@ const VideoPressUploader = ( {
 
 		// Handle selection of Media Library regular attachment
 		if ( media.id ) {
+			// Store the selection so the error screen's Retry can re-dispatch
+			// this flow — the library path has no File to hand to startUpload.
+			setFile( media );
+
+			// On WordPress.com Simple the videopress/v1 upload routes never
+			// reach the REST dispatcher (the public-api router 404s them).
+			// The file is already on WordPress.com storage, so promote the
+			// attachment in place with a single wpcom/v2 POST instead of
+			// probing and walking the chunked upload endpoint.
+			if ( isSimpleSite() ) {
+				setUploadingProgress( 1, 1 );
+				setIsUploadingInProgress( true );
+				promoteOnSimple( media.id )
+					.then( ( { guid, mediaId } ) => {
+						setUploadedVideoData( { guid, id: mediaId, src: media.url } );
+					} )
+					.catch( error => {
+						setUploadErrorDataState( {
+							data: { message: error?.message },
+						} );
+					} );
+				return;
+			}
+
 			const path = `videopress/v1/upload/${ media.id }`;
 
 			setIsVerifyingLocalMedia( true );
@@ -291,15 +317,26 @@ const VideoPressUploader = ( {
 
 	// Showing error if upload fails
 	if ( uploadErrorData ) {
-		const onRetry = () => {
-			startUpload( uploadFile );
-		};
-
 		const onCancel = () => {
 			setFile( null );
 			setUploadingProgress( [] );
 			setUploadErrorData( null );
 			setIsUploadingInProgress( false );
+		};
+
+		const onRetry = () => {
+			if ( ! uploadFile ) {
+				// Nothing stored to retry (e.g. the failure came from the URL
+				// path) — startUpload( null ) would crash reading file.size,
+				// so reset back to the picker instead.
+				onCancel();
+				return;
+			}
+			// Re-dispatch by shape: a File restarts the resumable upload; a
+			// media-library attachment re-runs the library flow (probe/walker,
+			// or the one-shot promote on WordPress.com Simple).
+			setUploadErrorData( null );
+			onSelectVideo( uploadFile );
 		};
 
 		return <UploadError onRetry={ onRetry } onCancel={ onCancel } errorData={ uploadErrorData } />;

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/test/index.test.jsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/videopress-uploader/test/index.test.jsx
@@ -1,0 +1,199 @@
+import { render, act, waitFor } from '@testing-library/react';
+import VideoPressUploader from '../index.jsx';
+
+const mockApiFetch = jest.fn();
+const mockPromoteOnSimple = jest.fn();
+const mockIsSimpleSite = jest.fn();
+const mockUploadFromLibrary = jest.fn();
+const mockUploadHandler = jest.fn();
+// Capture the props handed to child components so tests can drive the
+// MediaPlaceholder's onSelect and the error screen's Retry directly.
+const mockMediaPlaceholder = jest.fn( () => null );
+const mockUploadError = jest.fn( () => null );
+const mockUploadProgress = jest.fn( () => null );
+
+jest.mock(
+	'@wordpress/api-fetch',
+	() =>
+		( ...args ) =>
+			mockApiFetch( ...args )
+);
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	isSimpleSite: ( ...args ) => mockIsSimpleSite( ...args ),
+} ) );
+jest.mock( '@automattic/jetpack-components', () => ( {
+	getRedirectUrl: () => '',
+} ) );
+jest.mock( '@wordpress/block-editor', () => ( {
+	BlockIcon: () => null,
+	MediaPlaceholder: ( ...args ) => mockMediaPlaceholder( ...args ),
+} ) );
+jest.mock( '@wordpress/components', () => ( {
+	Spinner: () => null,
+	Button: () => null,
+	withNotices: Component => props => (
+		<Component
+			{ ...props }
+			noticeUI={ null }
+			noticeOperations={ { removeAllNotices: () => {}, createErrorNotice: () => {} } }
+		/>
+	),
+} ) );
+jest.mock( '@wordpress/i18n', () => ( {
+	__: s => s,
+} ) );
+jest.mock( '@wordpress/ui', () => ( {
+	Link: () => null,
+} ) );
+jest.mock( '../../../../../../hooks/use-resumable-uploader', () => () => ( {
+	uploadHandler: ( ...args ) => mockUploadHandler( ...args ),
+	resumeHandler: null,
+	error: null,
+} ) );
+jest.mock( '../../../../../../hooks/use-uploader', () => ( {
+	uploadFromLibrary: ( ...args ) => mockUploadFromLibrary( ...args ),
+} ) );
+jest.mock( '../../../../../../lib/connection', () => ( {
+	isSiteConnected: () => true,
+} ) );
+jest.mock( '../../../../../../lib/promote-on-simple', () => ( {
+	promoteOnSimple: ( ...args ) => mockPromoteOnSimple( ...args ),
+} ) );
+jest.mock( '../../../../../../lib/url', () => ( {
+	buildVideoPressURL: () => ( {} ),
+	buildVideoPressVideoByFileName: jest.fn(),
+	pickVideoBlockAttributesFromUrl: () => ( {} ),
+	getVideoNameFromUrl: () => null,
+} ) );
+jest.mock( '../../../edit', () => ( {
+	PlaceholderWrapper: ( { children } ) => <div>{ children }</div>,
+} ) );
+jest.mock( '../../icons', () => ( {
+	VideoPressIcon: null,
+} ) );
+jest.mock(
+	'../uploader-error.jsx',
+	() =>
+		( ...args ) =>
+			mockUploadError( ...args )
+);
+jest.mock(
+	'../uploader-progress.jsx',
+	() =>
+		( ...args ) =>
+			mockUploadProgress( ...args )
+);
+
+const renderUploader = () =>
+	render(
+		<VideoPressUploader
+			attributes={ {} }
+			setAttributes={ jest.fn() }
+			handleDoneUpload={ jest.fn() }
+			fileToUpload={ null }
+			isReplacing={ false }
+			onReplaceCancel={ jest.fn() }
+			isActive
+		/>
+	);
+
+const lastProps = mock => mock.mock.calls[ mock.mock.calls.length - 1 ][ 0 ];
+
+// A media-library attachment as the editor's media modal hands it to
+// onSelect: it has an id and url but no File fields (name/size/type).
+const libraryAttachment = { id: 10, url: 'https://example.test/clip.mov' };
+
+describe( 'VideoPressUploader — media library selection', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockIsSimpleSite.mockReturnValue( false );
+	} );
+
+	it( 'promotes in place via wpcom/v2 on Simple instead of the videopress/v1 walker', async () => {
+		mockIsSimpleSite.mockReturnValue( true );
+		mockPromoteOnSimple.mockResolvedValue( { guid: 'g1234567', mediaId: 10 } );
+
+		renderUploader();
+		await act( async () => {
+			lastProps( mockMediaPlaceholder ).onSelect( libraryAttachment );
+		} );
+
+		expect( mockPromoteOnSimple ).toHaveBeenCalledWith( 10 );
+		// The videopress/v1 probe 404s at the public-api router on Simple —
+		// the whole point of the promote branch is that it never fires.
+		expect( mockApiFetch ).not.toHaveBeenCalled();
+		expect( mockUploadFromLibrary ).not.toHaveBeenCalled();
+
+		// The promote result feeds the same post-upload editor flow as a
+		// finished chunked upload, with the attachment URL as the source.
+		await waitFor( () =>
+			expect( lastProps( mockUploadProgress ).uploadedVideoData ).toEqual( {
+				guid: 'g1234567',
+				id: 10,
+				src: 'https://example.test/clip.mov',
+			} )
+		);
+	} );
+
+	it( 'keeps probing videopress/v1 and walking the upload off Simple', async () => {
+		mockApiFetch.mockResolvedValue( { status: 'new', file_size: 100 } );
+		mockUploadFromLibrary.mockReturnValue( new Promise( () => {} ) );
+
+		renderUploader();
+		await act( async () => {
+			lastProps( mockMediaPlaceholder ).onSelect( libraryAttachment );
+		} );
+
+		expect( mockApiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( { path: 'videopress/v1/upload/10', method: 'GET' } )
+		);
+		expect( mockUploadFromLibrary ).toHaveBeenCalledWith( 10 );
+		expect( mockPromoteOnSimple ).not.toHaveBeenCalled();
+	} );
+
+	it( 'shows the promote failure and Retry re-runs the promote instead of crashing', async () => {
+		mockIsSimpleSite.mockReturnValue( true );
+		mockPromoteOnSimple.mockRejectedValueOnce( new Error( 'Tombstoned.' ) );
+
+		renderUploader();
+		await act( async () => {
+			lastProps( mockMediaPlaceholder ).onSelect( libraryAttachment );
+		} );
+
+		expect( lastProps( mockUploadError ).errorData ).toEqual( {
+			data: { message: 'Tombstoned.' },
+		} );
+
+		// Before the fix Retry called startUpload( null ) and crashed
+		// reading `.size`; now it re-dispatches the stored library
+		// selection through the promote path.
+		mockPromoteOnSimple.mockResolvedValue( { guid: 'g1234567', mediaId: 10 } );
+		await act( async () => {
+			lastProps( mockUploadError ).onRetry();
+		} );
+
+		expect( mockPromoteOnSimple ).toHaveBeenCalledTimes( 2 );
+		expect( mockPromoteOnSimple ).toHaveBeenLastCalledWith( 10 );
+	} );
+
+	it( 'Retry with nothing stored resets to the picker instead of crashing', async () => {
+		// Reach the error screen through the URL path, which stores no file:
+		// the mocked url lib rejects every source, so onSelectURL errors.
+		renderUploader();
+		await act( async () => {
+			lastProps( mockMediaPlaceholder ).onSelectURL( 'https://example.test/not-a-video' );
+		} );
+
+		expect( lastProps( mockUploadError ).errorData ).toEqual( {
+			data: { message: 'Invalid VideoPress URL' },
+		} );
+
+		await act( async () => {
+			lastProps( mockUploadError ).onRetry();
+		} );
+
+		// Back to the picker: the placeholder rendered again after the reset.
+		expect( mockMediaPlaceholder ).toHaveBeenCalled();
+		expect( mockUploadHandler ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/packages/videopress/src/client/lib/promote-on-simple/index.ts
+++ b/projects/packages/videopress/src/client/lib/promote-on-simple/index.ts
@@ -1,0 +1,61 @@
+/**
+ * External dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+export type PromoteOnSimpleResult = {
+	guid: string;
+	mediaId: number;
+};
+
+type WpcomPromoteResponse = {
+	guid: string;
+	media_id: number;
+	// Present (true) when the attachment was already on VideoPress and the
+	// endpoint reported success idempotently instead of re-promoting.
+	already_videopress?: boolean;
+};
+
+/**
+ * Promote a local attachment in-process on WordPress.com Simple. The file
+ * already lives on WordPress.com storage, so there is no chunked upload to
+ * walk: a single POST creates the videos-table row and enqueues the
+ * transcode. Promotion is in-place — the attachment keeps its id (no
+ * sibling attachment is created), and shows up as a processing VideoPress
+ * video on the next refetch.
+ *
+ * Shared by the dashboard library's promote flow and the VideoPress block's
+ * media-library picker: `videopress/v1` upload routes never reach Simple's
+ * REST dispatcher (the public-api router 404s them), so every surface that
+ * turns an existing attachment into a VideoPress video must use this
+ * endpoint there.
+ *
+ * @param attachmentId - The numeric or string WordPress attachment ID.
+ * @return The VideoPress GUID and (unchanged) media post ID.
+ */
+export async function promoteOnSimple(
+	attachmentId: string | number
+): Promise< PromoteOnSimpleResult > {
+	let result: WpcomPromoteResponse;
+	try {
+		result = await apiFetch< WpcomPromoteResponse >( {
+			path: `/wpcom/v2/videopress/promote/${ attachmentId }`,
+			method: 'POST',
+		} );
+	} catch ( err ) {
+		// apiFetch rejects REST errors as plain { code, message } objects;
+		// normalize to Error so callers can rely on `.message` when
+		// reporting the failure.
+		if ( err instanceof Error ) {
+			throw err;
+		}
+		const message = ( err as { message?: string } )?.message;
+		throw new Error(
+			typeof message === 'string' && message !== ''
+				? message
+				: 'Failed to promote video to VideoPress.',
+			{ cause: err }
+		);
+	}
+	return { guid: result.guid, mediaId: result.media_id };
+}

--- a/projects/packages/videopress/src/dashboard/hooks/use-upload-from-library.ts
+++ b/projects/packages/videopress/src/dashboard/hooks/use-upload-from-library.ts
@@ -1,6 +1,7 @@
 import { isSimpleSite } from '@automattic/jetpack-script-data';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import apiFetch from '@wordpress/api-fetch';
+import { promoteOnSimple } from '../../client/lib/promote-on-simple';
 import { LIBRARY_QUERY_KEY } from './use-library';
 
 type UploadStatusResponse = {
@@ -136,51 +137,11 @@ export type UploadFromLibraryVariables = {
 	onProgress?: ( percent: number ) => void;
 };
 
-type WpcomPromoteResponse = {
-	guid: string;
-	media_id: number;
-	// Present (true) when the attachment was already on VideoPress and the
-	// endpoint reported success idempotently instead of re-promoting.
-	already_videopress?: boolean;
-};
+// The implementation lives in client/lib so the VideoPress block's
+// media-library picker can share it (client never imports from dashboard);
+// re-exported here to keep the dashboard-side import surface unchanged.
+export { promoteOnSimple };
 
-/**
- * Promote a local attachment in-process on WordPress.com Simple. The file
- * already lives on WordPress.com storage, so there is no chunked upload to
- * walk: a single POST creates the videos-table row and enqueues the
- * transcode. Promotion is in-place — the attachment keeps its id (no
- * sibling attachment is created), and the next library refetch shows the
- * same row as a processing VideoPress video.
- *
- * @param attachmentId - The numeric or string WordPress attachment ID.
- * @return The VideoPress GUID and (unchanged) media post ID.
- */
-export async function promoteOnSimple(
-	attachmentId: string | number
-): Promise< UploadFromLibraryResult > {
-	let result: WpcomPromoteResponse;
-	try {
-		result = await apiFetch< WpcomPromoteResponse >( {
-			path: `/wpcom/v2/videopress/promote/${ attachmentId }`,
-			method: 'POST',
-		} );
-	} catch ( err ) {
-		// apiFetch rejects REST errors as plain { code, message } objects;
-		// normalize to Error so the mutation's declared error type stays
-		// truthful and stage-level notices can rely on `.message`.
-		if ( err instanceof Error ) {
-			throw err;
-		}
-		const message = ( err as { message?: string } )?.message;
-		throw new Error(
-			typeof message === 'string' && message !== ''
-				? message
-				: 'Failed to promote video to VideoPress.',
-			{ cause: err }
-		);
-	}
-	return { guid: result.guid, mediaId: result.media_id };
-}
 /**
  * Promote an existing local WordPress media attachment to a
  * VideoPress-hosted video. On WordPress.com Simple this is one in-process


### PR DESCRIPTION
Fixes VIDP-327

## Proposed changes

* VideoPress block: selecting an existing **local** (non-VideoPress) video from the media library now works on WordPress.com Simple sites. The block's library path probed `GET videopress/v1/upload/{id}` and then walked the chunked `POST` endpoint — but `videopress/v1` routes never reach Simple's REST dispatcher, so the public-api router 404s (`{"error":"not_found"}`) and the block showed a generic error. On Simple the block now promotes the attachment in place through `wpcom/v2/videopress/promote/{id}` — the same endpoint the dashboard's promote flow uses (Automattic/jetpack#50611) — one in-process POST, no chunked upload, feeding the same post-upload title/poster editor as a finished upload.
* `promoteOnSimple()` moves from the dashboard hook into `src/client/lib/promote-on-simple/` so the block can share it (the dashboard already imports from client, never the reverse); it stays re-exported from `use-upload-from-library.ts` so the dashboard-side import surface is unchanged.
* Fixed a crash on the upload-error screen's **Retry** button (all platforms, not just Simple): it called `startUpload( uploadFile )`, but the library and URL paths never set a file, so Retry crashed with `Cannot read properties of null (reading 'size')`. The selection is now stored when the library flow starts, and Retry re-dispatches it by shape — a File restarts the resumable upload, a library attachment re-runs the probe/walker (or the promote on Simple), and with nothing stored it resets to the picker.
* The post-upload editors (poster, title/meta) already use `wpcom/v2/videopress/*`, which works on Simple — no changes needed there.

## Related product discussion/links

* VIDP-327 (reported in the VideoPress-admin-UI-on-Simple CFT on cftp2, comment-9126)
* VIDP-300 / Automattic/jetpack#50611 — the dashboard promote flow this reuses.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

You need a Simple site with local videos (e.g. create a test site on Premium, upload a few videos, upgrade to Business).

* Open the block editor on the Simple site, insert a **VideoPress block**, click "Media Library", and pick one of the local videos.
* Before this PR: a generic error appears, and the console shows a 404 on `videopress/v1/sites/{blog}/upload/{id}` (plus an uncaught TypeError if you click Retry).
* After: the block goes to the uploading state and straight into the post-upload editor (title/poster); Done inserts the block with the new VideoPress GUID. The video shows as processing until transcoding finishes, like any fresh upload.
* Error path: promote the same attachment from a second tab first (or pick a previously-deleted-from-VideoPress file) to get a real failure — the error screen should show the endpoint's message, Retry should re-run the promote (no console crash), and Cancel should return to the picker.
* Off-Simple regression check (Jetpack/Atomic): selecting a local library video still uses `videopress/v1/upload/{id}` and completes as before.
* `pnpm jest src/dashboard/hooks routes/library src/client/block-editor/blocks/video/components/videopress-uploader` from `projects/packages/videopress` (193 tests).
