### PR TITLE
Help Center: support logged-out consumers

### DIFF
--- a/projects/packages/help-center/CHANGELOG.md
+++ b/projects/packages/help-center/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2026-07-27
+### Added
+- Allow consumers to load the logged-out Help Center bundle and proxy logged-out requests anonymously.
+
 ## 0.1.0 - 2026-07-27
 ### Added
 - Allow consumers to provide the WordPress.com authentication state and request client used by the Help Center.
 - Initial version, extracted from Jetpack MU WPCOM to its own package for external consumption.
+
+[0.2.0]: https://github.com/Automattic/jetpack-help-center/compare/v0.1.0...v0.2.0

--- a/projects/packages/help-center/README.md
+++ b/projects/packages/help-center/README.md
@@ -22,9 +22,26 @@ add_action( 'init', array( Help_Center::class, 'init' ), 10, 0 );
 
 The package expects the consuming plugin to load its Composer autoloader. Jetpack Autoloader is recommended when multiple plugins may ship Jetpack packages.
 
+### Public Frontend Surfaces
+
+Consumers can opt a frontend request into the existing logged-out Help Center
+bundle. The package continues to own variant selection and asset loading:
+
+```php
+add_filter(
+	'jetpack_help_center_should_load_logged_out',
+	static function ( $should_load ) {
+		return is_front_page() || $should_load;
+	}
+);
+```
+
 ### Custom WordPress.com Authentication
 
-By default, the package sends authenticated WordPress.com requests through Jetpack Connection. Consumers with another authentication system can implement `Wpcom_Request_Client` and provide it before Help Center initializes:
+By default, the package sends logged-in WordPress.com requests through Jetpack
+Connection and logged-out requests anonymously. Consumers with another
+authentication system can implement `Wpcom_Request_Client` and provide it before
+Help Center initializes:
 
 ```php
 use Automattic\Jetpack\Help_Center\Wpcom_Request_Client;
@@ -34,14 +51,18 @@ final class My_Help_Center_Request_Client implements Wpcom_Request_Client {
 		return my_wpcom_access_token() !== null;
 	}
 
-	public function request_as_user(
+	public function request(
 		$path,
 		$version = '2',
 		$args = array(),
 		$body = null,
 		$base_api_path = 'wpcom'
 	) {
-		return my_authenticated_wpcom_request( $path, $version, $args, $body, $base_api_path );
+		if ( is_user_logged_in() ) {
+			return my_authenticated_wpcom_request( $path, $version, $args, $body, $base_api_path );
+		}
+
+		return my_anonymous_wpcom_request( $path, $version, $args, $body, $base_api_path );
 	}
 }
 
@@ -60,7 +81,7 @@ Standalone consumers may instead pass the client directly to `Help_Center::init(
 - Loads Help Center bundles in wp-admin, the block editor, the customizer, and supported frontend contexts.
 - Adds the Help Center entry point to the WordPress admin bar.
 - Provides connected and disconnected variants based on Jetpack connection state.
-- Registers the `/help-center` REST namespace used by the frontend.
+- Registers the `/help-center` REST namespace used by the frontend, including anonymous proxy requests for logged-out users.
 - Limits persisted Help Center router history to 50 entries.
 
 ## Development

--- a/projects/packages/help-center/changelog/enable-logged-out-consumers
+++ b/projects/packages/help-center/changelog/enable-logged-out-consumers
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Allow consumers to load the logged-out Help Center bundle and proxy logged-out requests anonymously.

--- a/projects/packages/help-center/changelog/enable-logged-out-consumers
+++ b/projects/packages/help-center/changelog/enable-logged-out-consumers
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Allow consumers to load the logged-out Help Center bundle and proxy logged-out requests anonymously.

--- a/projects/packages/help-center/composer.json
+++ b/projects/packages/help-center/composer.json
@@ -45,7 +45,7 @@
 		"autorelease": true,
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "0.1.x-dev"
+			"dev-trunk": "0.2.x-dev"
 		},
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-help-center/compare/v${old}...v${new}"

--- a/projects/packages/help-center/src/class-help-center.php
+++ b/projects/packages/help-center/src/class-help-center.php
@@ -18,7 +18,7 @@ class Help_Center {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.1.0';
+	const PACKAGE_VERSION = '0.2.0';
 
 	/**
 	 * Class instance.
@@ -714,7 +714,7 @@ class Help_Center {
 		 * Consumers can use this filter to opt public-facing surfaces into the
 		 * Help Center without taking ownership of its asset-loading logic.
 		 *
-		 * @since $$next-version$$
+		 * @since 0.2.0
 		 *
 		 * @param bool $should_load Whether to load the logged-out Help Center bundle.
 		 */

--- a/projects/packages/help-center/src/class-help-center.php
+++ b/projects/packages/help-center/src/class-help-center.php
@@ -369,7 +369,7 @@ class Help_Center {
 			$result = $experiment_variation === \ExPlat\assign_current_user( $experiment_name );
 		} elseif ( $this->wpcom_request_client->is_user_connected() ) {
 			$request_path = '/experiments/0.1.0/assignments/calypso';
-			$response     = $this->wpcom_request_client->request_as_user(
+			$response     = $this->wpcom_request_client->request(
 				add_query_arg( array( 'experiment_name' => $experiment_name ), $request_path ),
 				'v2'
 			);
@@ -708,23 +708,38 @@ class Help_Center {
 		$can_edit_posts = current_user_can( 'edit_posts' ) && is_user_member_of_blog();
 		$is_p2          = str_contains( get_stylesheet(), 'pub/p2' ) || function_exists( '\WPForTeams\is_wpforteams_site' ) && is_wpforteams_site( get_current_blog_id() );
 
+		/**
+		 * Filters whether to load the logged-out Help Center bundle on the current frontend request.
+		 *
+		 * Consumers can use this filter to opt public-facing surfaces into the
+		 * Help Center without taking ownership of its asset-loading logic.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool $should_load Whether to load the logged-out Help Center bundle.
+		 */
+		$should_load_logged_out = ! is_admin()
+			&& (bool) apply_filters( 'jetpack_help_center_should_load_logged_out', false );
+
 		// We will show the help center icon in the admin bar when;
 		// 1. On wp-admin
 		// 2. On the front end of the site if the current user can edit posts
 		// 3. On the front end of the site and the theme is not P2
 		// 4. If it is the frontend we show the disconnected version of the help center.
-		if ( ! is_admin() && ( ! $can_edit_posts || $is_p2 ) && ! $this->is_support_site ) {
+		if ( ! is_admin() && ( ! $can_edit_posts || $is_p2 ) && ! $this->is_support_site && ! $should_load_logged_out ) {
 			return;
 		}
 
 		// Do not load Help Center for logged-out users if we are not on support sites.
-		if ( ! is_user_logged_in() && ! $this->is_support_site ) {
+		if ( ! is_user_logged_in() && ! $this->is_support_site && ! $should_load_logged_out ) {
 			return;
 		}
 
 		$suffix = $this->is_jetpack_disconnected() ? '-disconnected' : '';
 
-		if ( $this->is_support_site ) {
+		if ( $should_load_logged_out ) {
+			$variant = 'logged-out';
+		} elseif ( $this->is_support_site ) {
 			if ( ! is_user_logged_in() ) {
 				$variant = 'logged-out';
 			} else {

--- a/projects/packages/help-center/src/class-jetpack-wpcom-request-client.php
+++ b/projects/packages/help-center/src/class-jetpack-wpcom-request-client.php
@@ -11,7 +11,7 @@ use Automattic\Jetpack\Connection\Client;
 use Automattic\Jetpack\Connection\Manager;
 
 /**
- * Sends authenticated WP.com requests through Jetpack Connection.
+ * Sends WP.com requests through Jetpack Connection or anonymously.
  */
 final class Jetpack_Wpcom_Request_Client implements Wpcom_Request_Client {
 	/**
@@ -24,7 +24,10 @@ final class Jetpack_Wpcom_Request_Client implements Wpcom_Request_Client {
 	}
 
 	/**
-	 * Send a request authenticated as the current Jetpack-connected user.
+	 * Send a request to WordPress.com.
+	 *
+	 * Logged-in requests use the current Jetpack-connected user. Logged-out
+	 * requests are sent directly to the public WordPress.com API.
 	 *
 	 * @param string            $path          REST API path.
 	 * @param string            $version       REST API version.
@@ -34,13 +37,33 @@ final class Jetpack_Wpcom_Request_Client implements Wpcom_Request_Client {
 	 *
 	 * @return array|\WP_Error Response data, or WP_Error on failure.
 	 */
-	public function request_as_user(
+	public function request(
 		$path,
 		$version = '2',
 		$args = array(),
 		$body = null,
 		$base_api_path = 'wpcom'
 	) {
-		return Client::wpcom_json_api_request_as_user( $path, $version, $args, $body, $base_api_path );
+		if ( is_user_logged_in() ) {
+			return Client::wpcom_json_api_request_as_user( $path, $version, $args, $body, $base_api_path );
+		}
+
+		$request_args = Client::validate_args_for_wpcom_json_api_request( $path, $version, $args, $base_api_path );
+		$url          = $request_args['url'];
+		unset( $request_args['url'] );
+
+		if ( isset( $body ) && ! isset( $request_args['headers'] ) && in_array( $request_args['method'], array( 'POST', 'PUT', 'PATCH' ), true ) ) {
+			$request_args['headers'] = array( 'Content-Type' => 'application/json' );
+		}
+
+		if ( isset( $body ) && ! is_string( $body ) ) {
+			$body = wp_json_encode( $body, JSON_UNESCAPED_SLASHES );
+		}
+
+		if ( isset( $body ) ) {
+			$request_args['body'] = $body;
+		}
+
+		return wp_remote_request( $url, $request_args );
 	}
 }

--- a/projects/packages/help-center/src/class-wp-rest-help-center-authenticate.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-authenticate.php
@@ -32,7 +32,7 @@ class WP_REST_Help_Center_Authenticate extends WP_REST_Help_Center_Controller {
 			array(
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'get_chat_authentication' ),
-				'permission_callback' => 'is_user_logged_in',
+				'permission_callback' => '__return_true',
 				'args'                => array(
 					'type'      => array(
 						'type'     => 'string',
@@ -60,7 +60,7 @@ class WP_REST_Help_Center_Authenticate extends WP_REST_Help_Center_Controller {
 			'type'      => $request['type'],
 		);
 
-		$body = $this->wpcom_request_client->request_as_user(
+		$body = $this->wpcom_request_client->request(
 			'help/authenticate/chat?' . http_build_query( $query_parameters ),
 			'2',
 			array(

--- a/projects/packages/help-center/src/class-wp-rest-help-center-email-support-enabled.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-email-support-enabled.php
@@ -32,7 +32,7 @@ class WP_REST_Help_Center_Email_Support_Enabled extends WP_REST_Help_Center_Cont
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_email_support_configuration' ),
-				'permission_callback' => 'is_user_logged_in',
+				'permission_callback' => '__return_true',
 			)
 		);
 	}
@@ -41,7 +41,7 @@ class WP_REST_Help_Center_Email_Support_Enabled extends WP_REST_Help_Center_Cont
 	 * Should return if email contact is enabled for the user.
 	 */
 	public function get_email_support_configuration() {
-		$body = $this->wpcom_request_client->request_as_user( 'help/eligibility/email/mine' );
+		$body = $this->wpcom_request_client->request( 'help/eligibility/email/mine' );
 
 		if ( is_wp_error( $body ) ) {
 			return $body;

--- a/projects/packages/help-center/src/class-wp-rest-help-center-fetch-post.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-fetch-post.php
@@ -32,7 +32,7 @@ class WP_REST_Help_Center_Fetch_Post extends WP_REST_Help_Center_Controller {
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_post' ),
-				'permission_callback' => 'is_user_logged_in',
+				'permission_callback' => '__return_true',
 				'args'                => array(
 					'blog_id'  => array(
 						'type' => 'number',
@@ -53,7 +53,7 @@ class WP_REST_Help_Center_Fetch_Post extends WP_REST_Help_Center_Controller {
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_blog_post_articles' ),
-				'permission_callback' => 'is_user_logged_in',
+				'permission_callback' => '__return_true',
 				'args'                => array(
 					'blog_id'  => array(
 						'type'     => 'number',
@@ -81,7 +81,7 @@ class WP_REST_Help_Center_Fetch_Post extends WP_REST_Help_Center_Controller {
 			'blog_id'  => $request['blog_id'],
 			'post_ids' => $request['post_ids'],
 		);
-		$body             = $this->wpcom_request_client->request_as_user(
+		$body             = $this->wpcom_request_client->request(
 			'/help/articles?' . http_build_query( $query_parameters )
 		);
 
@@ -101,7 +101,7 @@ class WP_REST_Help_Center_Fetch_Post extends WP_REST_Help_Center_Controller {
 	 */
 	public function get_post( \WP_REST_Request $request ) {
 		if ( isset( $request['post_url'] ) ) {
-			$body = $this->wpcom_request_client->request_as_user(
+			$body = $this->wpcom_request_client->request(
 				'/help/article?post_url=' . $request['post_url']
 			);
 		} else {
@@ -110,7 +110,7 @@ class WP_REST_Help_Center_Fetch_Post extends WP_REST_Help_Center_Controller {
 				return $alternate_data;
 			}
 
-			$body = $this->wpcom_request_client->request_as_user(
+			$body = $this->wpcom_request_client->request(
 				'/help/article/' . $alternate_data['blog_id'] . '/' . $alternate_data['post_id']
 			);
 		}
@@ -142,7 +142,7 @@ class WP_REST_Help_Center_Fetch_Post extends WP_REST_Help_Center_Controller {
 			return $default_alternate_data;
 		}
 
-		$body = $this->wpcom_request_client->request_as_user(
+		$body = $this->wpcom_request_client->request(
 			"/support/alternates/$blog_id/posts/$post_id",
 			'1.1',
 			array(),

--- a/projects/packages/help-center/src/class-wp-rest-help-center-forum.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-forum.php
@@ -32,7 +32,7 @@ class WP_REST_Help_Center_Forum extends WP_REST_Help_Center_Controller {
 			array(
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'submit_new_topic' ),
-				'permission_callback' => 'is_user_logged_in',
+				'permission_callback' => '__return_true',
 				'args'                => array(
 					'subject'                => array(
 						'type'     => 'string',
@@ -86,7 +86,7 @@ class WP_REST_Help_Center_Forum extends WP_REST_Help_Center_Controller {
 			'should_use_test_forums' => isset( $request['should_use_test_forums'] ) && $request['should_use_test_forums'],
 		);
 
-		$body = $this->wpcom_request_client->request_as_user(
+		$body = $this->wpcom_request_client->request(
 			'/help/forum/new',
 			'2',
 			array(

--- a/projects/packages/help-center/src/class-wp-rest-help-center-jetpack-connection-health.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-jetpack-connection-health.php
@@ -32,7 +32,7 @@ class WP_REST_Help_Center_Jetpack_Connection_Health extends WP_REST_Help_Center_
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_connection_health' ),
-				'permission_callback' => 'is_user_logged_in',
+				'permission_callback' => '__return_true',
 			)
 		);
 	}
@@ -52,7 +52,7 @@ class WP_REST_Help_Center_Jetpack_Connection_Health extends WP_REST_Help_Center_
 			$site = get_current_blog_id();
 		}
 
-		$body = $this->wpcom_request_client->request_as_user(
+		$body = $this->wpcom_request_client->request(
 			'sites/' . $site . '/jetpack-connection-health',
 			'2'
 		);

--- a/projects/packages/help-center/src/class-wp-rest-help-center-jetpack-search-ai.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-jetpack-search-ai.php
@@ -32,7 +32,7 @@ class WP_REST_Help_Center_Jetpack_Search_AI extends WP_REST_Help_Center_Controll
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_search_results' ),
-				'permission_callback' => 'is_user_logged_in',
+				'permission_callback' => '__return_true',
 			)
 		);
 	}
@@ -47,7 +47,7 @@ class WP_REST_Help_Center_Jetpack_Search_AI extends WP_REST_Help_Center_Controll
 			'query'   => $request['query'],
 			'stop_at' => $request['stop_at'],
 		);
-		$body             = $this->wpcom_request_client->request_as_user(
+		$body             = $this->wpcom_request_client->request(
 			'sites/' . $request['site'] . '/jetpack-search/ai/search?' . http_build_query( $query_parameters ),
 			'2',
 			array(

--- a/projects/packages/help-center/src/class-wp-rest-help-center-odie.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-odie.php
@@ -35,7 +35,7 @@ class WP_REST_Help_Center_Odie extends WP_REST_Help_Center_Controller {
 				array(
 					'methods'             => \WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_chat' ),
-					'permission_callback' => 'is_user_logged_in',
+					'permission_callback' => '__return_true',
 					'args'                => array(
 						'bot_id'           => array(
 							'description' => __( 'The bot id to get the chat for.', 'jetpack-help-center' ),
@@ -70,7 +70,7 @@ class WP_REST_Help_Center_Odie extends WP_REST_Help_Center_Controller {
 				array(
 					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'send_chat_message' ),
-					'permission_callback' => 'is_user_logged_in',
+					'permission_callback' => '__return_true',
 					'args'                => array(
 						'bot_id'  => array(
 							'description' => __( 'The bot id to chat with.', 'jetpack-help-center' ),
@@ -105,7 +105,7 @@ class WP_REST_Help_Center_Odie extends WP_REST_Help_Center_Controller {
 				array(
 					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'save_chat_message_feedback' ),
-					'permission_callback' => 'is_user_logged_in',
+					'permission_callback' => '__return_true',
 					'args'                => array(
 						'bot_id'       => array(
 							'description' => __( 'The bot id to chat with.', 'jetpack-help-center' ),
@@ -139,7 +139,7 @@ class WP_REST_Help_Center_Odie extends WP_REST_Help_Center_Controller {
 				array(
 					'methods'             => \WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'send_chat_message' ),
-					'permission_callback' => 'is_user_logged_in',
+					'permission_callback' => '__return_true',
 					'args'                => array(
 						'bot_id'  => array(
 							'description' => __( 'The bot id to chat with.', 'jetpack-help-center' ),
@@ -174,7 +174,7 @@ class WP_REST_Help_Center_Odie extends WP_REST_Help_Center_Controller {
 				array(
 					'methods'             => \WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_conversations' ),
-					'permission_callback' => 'is_user_logged_in',
+					'permission_callback' => '__return_true',
 					'args'                => array(
 						'bot_ids'        => array(
 							'description' => __( 'The bot id(s) to get the conversations for, separated by commas.', 'jetpack-help-center' ),
@@ -209,7 +209,7 @@ class WP_REST_Help_Center_Odie extends WP_REST_Help_Center_Controller {
 		$chat_id       = $request->get_param( 'chat_id' );
 
 		// Forward the request body to the support chat endpoint.
-		$body = $this->wpcom_request_client->request_as_user(
+		$body = $this->wpcom_request_client->request(
 			'/odie/chat/' . $bot_name_slug . '/' . $chat_id,
 			'2',
 			array(
@@ -252,7 +252,7 @@ class WP_REST_Help_Center_Odie extends WP_REST_Help_Center_Controller {
 			)
 		);
 
-		$body = $this->wpcom_request_client->request_as_user(
+		$body = $this->wpcom_request_client->request(
 			'/odie/chat/' . $bot_name_slug . '/' . $chat_id . '?' . $url_query_params
 		);
 
@@ -277,7 +277,7 @@ class WP_REST_Help_Center_Odie extends WP_REST_Help_Center_Controller {
 		$rating_value = $request->get_param( 'rating_value' );
 
 		// Forward the request body to the feedback endpoint.
-		$body = $this->wpcom_request_client->request_as_user(
+		$body = $this->wpcom_request_client->request(
 			'/odie/chat/' . $bot_id . '/' . $chat_id . '/' . $message_id . '/feedback',
 			'2',
 			array( 'method' => 'POST' ),
@@ -314,7 +314,7 @@ class WP_REST_Help_Center_Odie extends WP_REST_Help_Center_Controller {
 			)
 		);
 
-		$body = $this->wpcom_request_client->request_as_user(
+		$body = $this->wpcom_request_client->request(
 			'/odie/conversations/' . $bot_ids . '?' . $url_query_params
 		);
 

--- a/projects/packages/help-center/src/class-wp-rest-help-center-persisted-open-state.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-persisted-open-state.php
@@ -35,13 +35,13 @@ class WP_REST_Help_Center_Persisted_Open_State extends WP_REST_Help_Center_Contr
 				array(
 					'methods'             => \WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_state' ),
-					'permission_callback' => 'is_user_logged_in',
+					'permission_callback' => '__return_true',
 				),
 				// Set the open state
 				array(
 					'methods'             => \WP_REST_Server::EDITABLE,
 					'callback'            => array( $this, 'set_state' ),
-					'permission_callback' => 'is_user_logged_in',
+					'permission_callback' => '__return_true',
 				),
 			)
 		);
@@ -52,7 +52,7 @@ class WP_REST_Help_Center_Persisted_Open_State extends WP_REST_Help_Center_Contr
 	 */
 	public function get_state() {
 		// Forward the request body to the support chat endpoint.
-		$body = $this->wpcom_request_client->request_as_user(
+		$body = $this->wpcom_request_client->request(
 			'/me/preferences',
 			'2',
 			array( 'method' => 'GET' )
@@ -103,7 +103,7 @@ class WP_REST_Help_Center_Persisted_Open_State extends WP_REST_Help_Center_Contr
 			$data['calypso_preferences']['help_center_minimized'] = $minimized;
 		}
 
-		$body = $this->wpcom_request_client->request_as_user(
+		$body = $this->wpcom_request_client->request(
 			'/me/preferences',
 			'2',
 			array( 'method' => 'POST' ),

--- a/projects/packages/help-center/src/class-wp-rest-help-center-search.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-search.php
@@ -32,7 +32,7 @@ class WP_REST_Help_Center_Search extends WP_REST_Help_Center_Controller {
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_search_results' ),
-				'permission_callback' => 'is_user_logged_in',
+				'permission_callback' => '__return_true',
 				'args'                => array(
 					'query'   => array(
 						'type' => 'string',
@@ -73,7 +73,7 @@ class WP_REST_Help_Center_Search extends WP_REST_Help_Center_Controller {
 			$query_parameters['source'] = $source;
 		}
 
-		$body = $this->wpcom_request_client->request_as_user(
+		$body = $this->wpcom_request_client->request(
 			'/help/search?' . http_build_query( $query_parameters )
 		);
 

--- a/projects/packages/help-center/src/class-wp-rest-help-center-sibyl.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-sibyl.php
@@ -32,7 +32,7 @@ class WP_REST_Help_Center_Sibyl extends WP_REST_Help_Center_Controller {
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_sibyl_questions' ),
-				'permission_callback' => 'is_user_logged_in',
+				'permission_callback' => '__return_true',
 			)
 		);
 	}
@@ -46,7 +46,7 @@ class WP_REST_Help_Center_Sibyl extends WP_REST_Help_Center_Controller {
 		$query = $request['query'];
 		$site  = $request['site'];
 
-		$body = $this->wpcom_request_client->request_as_user(
+		$body = $this->wpcom_request_client->request(
 			'/help/sibyl?query=' . $query . '&site=' . $site
 		);
 

--- a/projects/packages/help-center/src/class-wp-rest-help-center-support-activity.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-support-activity.php
@@ -32,7 +32,7 @@ class WP_REST_Help_Center_Support_Activity extends WP_REST_Help_Center_Controlle
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_support_activity' ),
-				'permission_callback' => 'is_user_logged_in',
+				'permission_callback' => '__return_true',
 			)
 		);
 	}
@@ -41,7 +41,7 @@ class WP_REST_Help_Center_Support_Activity extends WP_REST_Help_Center_Controlle
 	 * Get support activity through Jetpack.
 	 */
 	public function get_support_activity() {
-		$body = $this->wpcom_request_client->request_as_user( '/support-activity' );
+		$body = $this->wpcom_request_client->request( '/support-activity' );
 
 		if ( is_wp_error( $body ) ) {
 			return $body;

--- a/projects/packages/help-center/src/class-wp-rest-help-center-support-interactions.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-support-interactions.php
@@ -32,7 +32,7 @@ class WP_REST_Help_Center_Support_Interactions extends WP_REST_Help_Center_Contr
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_support_interactions' ),
-				'permission_callback' => 'is_user_logged_in',
+				'permission_callback' => '__return_true',
 				'args'                => array(
 					'status'   => array(
 						'type'     => 'array',
@@ -71,7 +71,7 @@ class WP_REST_Help_Center_Support_Interactions extends WP_REST_Help_Center_Contr
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_support_interactions' ),
-				'permission_callback' => 'is_user_logged_in',
+				'permission_callback' => '__return_true',
 			)
 		);
 
@@ -81,7 +81,7 @@ class WP_REST_Help_Center_Support_Interactions extends WP_REST_Help_Center_Contr
 			array(
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'create_support_interaction' ),
-				'permission_callback' => 'is_user_logged_in',
+				'permission_callback' => '__return_true',
 				'args'                => array(
 					'event_external_id' => array(
 						'type'     => 'string',
@@ -113,7 +113,7 @@ class WP_REST_Help_Center_Support_Interactions extends WP_REST_Help_Center_Contr
 			array(
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'create_support_interaction_event' ),
-				'permission_callback' => 'is_user_logged_in',
+				'permission_callback' => '__return_true',
 				'args'                => array(
 					'event_external_id' => array(
 						'type'     => 'string',
@@ -137,7 +137,7 @@ class WP_REST_Help_Center_Support_Interactions extends WP_REST_Help_Center_Contr
 			array(
 				'methods'             => \WP_REST_Server::EDITABLE,
 				'callback'            => array( $this, 'update_support_interaction_status' ),
-				'permission_callback' => 'is_user_logged_in',
+				'permission_callback' => '__return_true',
 				'args'                => array(
 					'status' => array(
 						'type'     => 'string',
@@ -165,7 +165,7 @@ class WP_REST_Help_Center_Support_Interactions extends WP_REST_Help_Center_Contr
 			$url = '/support-interactions/?' . http_build_query( stripslashes_deep( $request->get_params() ) );
 		}
 
-		$body = $this->wpcom_request_client->request_as_user( $url );
+		$body = $this->wpcom_request_client->request( $url );
 
 		if ( is_wp_error( $body ) ) {
 			return $body;
@@ -204,7 +204,7 @@ class WP_REST_Help_Center_Support_Interactions extends WP_REST_Help_Center_Contr
 			$data['is_test_mode'] = $request['is_test_mode'];
 		}
 
-		$body = $this->wpcom_request_client->request_as_user(
+		$body = $this->wpcom_request_client->request(
 			'/support-interactions',
 			'2',
 			array(
@@ -248,7 +248,7 @@ class WP_REST_Help_Center_Support_Interactions extends WP_REST_Help_Center_Contr
 			$data['is_test_mode'] = $request['is_test_mode'];
 		}
 
-		$body = $this->wpcom_request_client->request_as_user(
+		$body = $this->wpcom_request_client->request(
 			"/support-interactions/$support_interaction_id/events",
 			'2',
 			array(
@@ -276,7 +276,7 @@ class WP_REST_Help_Center_Support_Interactions extends WP_REST_Help_Center_Contr
 
 		$status = $request['status'];
 
-		$body = $this->wpcom_request_client->request_as_user(
+		$body = $this->wpcom_request_client->request(
 			"/support-interactions/$support_interaction_id/status",
 			'2',
 			array(

--- a/projects/packages/help-center/src/class-wp-rest-help-center-support-status.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-support-status.php
@@ -32,7 +32,7 @@ class WP_REST_Help_Center_Support_Status extends WP_REST_Help_Center_Controller 
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_support_status' ),
-				'permission_callback' => 'is_user_logged_in',
+				'permission_callback' => '__return_true',
 			)
 		);
 
@@ -42,7 +42,7 @@ class WP_REST_Help_Center_Support_Status extends WP_REST_Help_Center_Controller 
 			array(
 				'methods'             => \WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_messaging_support_availability' ),
-				'permission_callback' => 'is_user_logged_in',
+				'permission_callback' => '__return_true',
 				'args'                => array(
 					'group'       => array(
 						'type'     => 'string',
@@ -61,7 +61,7 @@ class WP_REST_Help_Center_Support_Status extends WP_REST_Help_Center_Controller 
 	 * Should return the support status for the user
 	 */
 	public function get_support_status() {
-		$body = $this->wpcom_request_client->request_as_user( 'help/support-status' );
+		$body = $this->wpcom_request_client->request( 'help/support-status' );
 		if ( is_wp_error( $body ) ) {
 			return $body;
 		}
@@ -80,7 +80,7 @@ class WP_REST_Help_Center_Support_Status extends WP_REST_Help_Center_Controller 
 			'group'       => $request['group'],
 			'environment' => $request['environment'],
 		);
-		$body             = $this->wpcom_request_client->request_as_user( 'help/support-status/messaging?' . http_build_query( $query_parameters ) );
+		$body             = $this->wpcom_request_client->request( 'help/support-status/messaging?' . http_build_query( $query_parameters ) );
 		if ( is_wp_error( $body ) ) {
 			return $body;
 		}

--- a/projects/packages/help-center/src/class-wp-rest-help-center-ticket-csat.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-ticket-csat.php
@@ -32,7 +32,7 @@ class WP_REST_Help_Center_Ticket_CSAT extends WP_REST_Help_Center_Controller {
 			array(
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'submit_rating' ),
-				'permission_callback' => 'is_user_logged_in',
+				'permission_callback' => '__return_true',
 				'args'                => array(
 					'ticket_id' => array(
 						'required' => true,
@@ -74,7 +74,7 @@ class WP_REST_Help_Center_Ticket_CSAT extends WP_REST_Help_Center_Controller {
 			'test_mode' => $request['test_mode'],
 		);
 
-		$body = $this->wpcom_request_client->request_as_user(
+		$body = $this->wpcom_request_client->request(
 			'/help/csat',
 			'2',
 			array(

--- a/projects/packages/help-center/src/class-wp-rest-help-center-ticket.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-ticket.php
@@ -32,7 +32,7 @@ class WP_REST_Help_Center_Ticket extends WP_REST_Help_Center_Controller {
 			array(
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'new_ticket' ),
-				'permission_callback' => 'is_user_logged_in',
+				'permission_callback' => '__return_true',
 				'args'                => array(
 					'subject'          => array(
 						'type' => 'string',
@@ -73,7 +73,7 @@ class WP_REST_Help_Center_Ticket extends WP_REST_Help_Center_Controller {
 			'blog_url'         => $request['blog_url'],
 		);
 
-		$body = $this->wpcom_request_client->request_as_user(
+		$body = $this->wpcom_request_client->request(
 			'/help/ticket/new',
 			'2',
 			array(

--- a/projects/packages/help-center/src/class-wp-rest-help-center-user-fields.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-user-fields.php
@@ -32,7 +32,7 @@ class WP_REST_Help_Center_User_Fields extends WP_REST_Help_Center_Controller {
 			array(
 				'methods'             => \WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'update_user_fields' ),
-				'permission_callback' => 'is_user_logged_in',
+				'permission_callback' => '__return_true',
 				'args'                => array(
 					'fields' => array(
 						'type'     => 'object',
@@ -49,7 +49,7 @@ class WP_REST_Help_Center_User_Fields extends WP_REST_Help_Center_Controller {
 	 * @param \WP_REST_Request $request    The request sent to the API.
 	 */
 	public function update_user_fields( \WP_REST_Request $request ) {
-		$body = $this->wpcom_request_client->request_as_user(
+		$body = $this->wpcom_request_client->request(
 			'help/zendesk/update-user-fields',
 			'2',
 			array(

--- a/projects/packages/help-center/src/interface-wpcom-request-client.php
+++ b/projects/packages/help-center/src/interface-wpcom-request-client.php
@@ -8,7 +8,7 @@
 namespace Automattic\Jetpack\Help_Center;
 
 /**
- * Sends authenticated requests to the WordPress.com API.
+ * Sends requests to the WordPress.com API.
  */
 interface Wpcom_Request_Client {
 	/**
@@ -19,7 +19,10 @@ interface Wpcom_Request_Client {
 	public function is_user_connected();
 
 	/**
-	 * Send a request authenticated as the current user.
+	 * Send a request to WordPress.com.
+	 *
+	 * Implementations should authenticate the request as the current user when
+	 * possible and send it anonymously when the user is logged out.
 	 *
 	 * @param string            $path          REST API path.
 	 * @param string            $version       REST API version.
@@ -29,7 +32,7 @@ interface Wpcom_Request_Client {
 	 *
 	 * @return array|\WP_Error Response data, or WP_Error on failure.
 	 */
-	public function request_as_user(
+	public function request(
 		$path,
 		$version = '2',
 		$args = array(),

--- a/projects/packages/help-center/tests/php/Help_Center_Data_Test.php
+++ b/projects/packages/help-center/tests/php/Help_Center_Data_Test.php
@@ -142,13 +142,64 @@ class Help_Center_Data_Test extends \WorDBless\BaseTestCase {
 		$this->assertInstanceOf( Help_Center::class, Help_Center::get_instance() );
 	}
 
+	public function test_consumer_can_load_logged_out_bundle_on_frontend() {
+		wp_set_current_user( 0 );
+		set_transient(
+			'help-center-asset-logged-out.asset.json',
+			array(
+				'dependencies' => array(),
+				'version'      => 'test-version',
+			),
+			HOUR_IN_SECONDS
+		);
+
+		$should_load = static function () {
+			return true;
+		};
+		add_filter( 'jetpack_help_center_should_load_logged_out', $should_load );
+
+		try {
+			$this->help_center->enqueue_wp_admin_scripts();
+
+			$this->assertTrue( wp_script_is( 'help-center', 'enqueued' ) );
+			$this->assertStringContainsString(
+				'help-center-logged-out.min.js',
+				wp_scripts()->registered['help-center']->src
+			);
+			$this->assertTrue( wp_style_is( 'help-center-logged-out-style', 'enqueued' ) );
+		} finally {
+			remove_filter( 'jetpack_help_center_should_load_logged_out', $should_load );
+			delete_transient( 'help-center-asset-logged-out.asset.json' );
+			wp_dequeue_script( 'help-center' );
+			wp_deregister_script( 'help-center' );
+			wp_dequeue_style( 'help-center-logged-out-style' );
+			wp_deregister_style( 'help-center-logged-out-style' );
+		}
+	}
+
+	public function test_rest_proxy_routes_allow_logged_out_requests() {
+		wp_set_current_user( 0 );
+		$this->help_center->register_rest_api();
+
+		$routes = rest_get_server()->get_routes( 'help-center' );
+		$this->assertNotEmpty( $routes );
+
+		foreach ( $routes as $route_handlers ) {
+			foreach ( $route_handlers as $handler ) {
+				if ( isset( $handler['permission_callback'] ) ) {
+					$this->assertSame( '__return_true', $handler['permission_callback'] );
+				}
+			}
+		}
+	}
+
 	public function test_init_uses_filtered_wpcom_request_client() {
 		$wpcom_request_client = new class() implements Wpcom_Request_Client {
 			public function is_user_connected() {
 				return true;
 			}
 
-			public function request_as_user(
+			public function request(
 				$path,
 				$version = '2',
 				$args = array(),
@@ -192,7 +243,7 @@ class Help_Center_Data_Test extends \WorDBless\BaseTestCase {
 				return true;
 			}
 
-			public function request_as_user(
+			public function request(
 				$path,
 				$version = '2',
 				$args = array(),
@@ -227,7 +278,7 @@ class Help_Center_Data_Test extends \WorDBless\BaseTestCase {
 				return true;
 			}
 
-			public function request_as_user(
+			public function request(
 				$path,
 				$version = '2',
 				$args = array(),

--- a/projects/packages/help-center/tests/php/Logged_Out_Request_Test.php
+++ b/projects/packages/help-center/tests/php/Logged_Out_Request_Test.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Tests for logged-out Help Center requests.
+ *
+ * @package automattic/jetpack-help-center
+ */
+
+use Automattic\Jetpack\Help_Center\Jetpack_Wpcom_Request_Client;
+use Automattic\Jetpack\Help_Center\WP_REST_Help_Center_Search;
+use Automattic\Jetpack\Help_Center\Wpcom_Request_Client;
+
+/**
+ * Class Logged_Out_Request_Test
+ */
+class Logged_Out_Request_Test extends \WorDBless\BaseTestCase {
+	public function set_up() {
+		parent::set_up();
+		wp_set_current_user( 0 );
+	}
+
+	public function tear_down() {
+		wp_set_current_user( 0 );
+		parent::tear_down();
+	}
+
+	public function test_default_client_sends_logged_out_request_anonymously() {
+		$captured_request = null;
+		$response         = null;
+		$pre_http_request = static function ( $response, $request_args, $url ) use ( &$captured_request ) {
+			$captured_request = compact( 'request_args', 'url' );
+
+			return array(
+				'headers'  => array(),
+				'body'     => '{"results":[]}',
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+				'filename' => null,
+			);
+		};
+		add_filter( 'pre_http_request', $pre_http_request, 10, 3 );
+
+		try {
+			$client   = new Jetpack_Wpcom_Request_Client();
+			$response = $client->request(
+				'/help/search?query=payments',
+				'2',
+				array( 'method' => 'GET' )
+			);
+		} finally {
+			remove_filter( 'pre_http_request', $pre_http_request, 10 );
+		}
+
+		$this->assertFalse( is_wp_error( $response ) );
+		if ( ! is_array( $captured_request ) ) {
+			throw new \RuntimeException( 'The anonymous HTTP request was not captured.' );
+		}
+		$this->assertStringEndsWith( '/wpcom/v2/help/search?query=payments', $captured_request['url'] );
+		$this->assertSame( 'GET', $captured_request['request_args']['method'] );
+		$this->assertArrayNotHasKey( 'Authorization', $captured_request['request_args']['headers'] ?? array() );
+	}
+
+	public function test_search_proxy_forwards_logged_out_request() {
+		$wpcom_request_client = new class() implements Wpcom_Request_Client {
+			/**
+			 * Captured requests.
+			 *
+			 * @var array
+			 */
+			public $requests = array();
+
+			public function is_user_connected() {
+				return false;
+			}
+
+			public function request(
+				$path,
+				$version = '2',
+				$args = array(),
+				$body = null,
+				$base_api_path = 'wpcom'
+			) {
+				$this->requests[] = compact( 'path', 'version', 'args', 'body', 'base_api_path' );
+
+				return array(
+					'headers'  => array(),
+					'body'     => '{"results":[{"title":"Payments"}]}',
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'cookies'  => array(),
+					'filename' => null,
+				);
+			}
+		};
+
+		$request = new \WP_REST_Request( 'GET', '/help-center/search' );
+		$request->set_param( 'query', 'payments' );
+		$request->set_param( 'locale', 'en' );
+
+		$controller = new WP_REST_Help_Center_Search( $wpcom_request_client );
+		$response   = $controller->get_search_results( $request );
+
+		$this->assertSame(
+			array(
+				array(
+					'path'          => '/help/search?query=payments&locale=en',
+					'version'       => '2',
+					'args'          => array(),
+					'body'          => null,
+					'base_api_path' => 'wpcom',
+				),
+			),
+			$wpcom_request_client->requests
+		);
+		$response_data = $response->get_data();
+		$this->assertCount( 1, $response_data->results );
+		$this->assertSame( 'Payments', $response_data->results[0]->title );
+	}
+}

--- a/projects/plugins/mu-wpcom-plugin/changelog/agent-help-center-logged-out-consumers
+++ b/projects/plugins/mu-wpcom-plugin/changelog/agent-help-center-logged-out-consumers
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1044,7 +1044,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/help-center",
-                "reference": "91a45bf85bebe2f5792374b804fe40d3d157f118"
+                "reference": "48d4a0c0e828efd684bf626fbfd0428d6a235bb7"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1065,7 +1065,7 @@
                 "autorelease": true,
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.1.x-dev"
+                    "dev-trunk": "0.2.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-help-center/compare/v${old}...v${new}"

--- a/projects/plugins/wpcomsh/changelog/agent-help-center-logged-out-consumers
+++ b/projects/plugins/wpcomsh/changelog/agent-help-center-logged-out-consumers
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1160,7 +1160,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/help-center",
-                "reference": "4cfd3c9e4912209a64e7a9445b63d1406775612e"
+                "reference": "d0694e7d9bd86f99017e4e9f42348d2bb83480e6"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1181,7 +1181,7 @@
                 "autorelease": true,
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.1.x-dev"
+                    "dev-trunk": "0.2.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-help-center/compare/v${old}...v${new}"


### PR DESCRIPTION
Fixes #

## Proposed changes
* Add the `jetpack_help_center_should_load_logged_out` filter so consumers can opt frontend requests into the existing logged-out Help Center bundle while the package continues to own variant selection and asset loading.
* Generalize `Wpcom_Request_Client::request()` so logged-in requests retain their current user authentication and logged-out requests are forwarded directly to the public WordPress.com API.
* Allow logged-out access to every `/help-center` proxy route. WordPress.com remains responsible for authorizing each upstream operation.
* Add coverage for consumer-driven bundle loading, anonymous HTTP transport, logged-out search proxying, and all registered proxy permissions.
* Release `automattic/jetpack-help-center` as `0.2.0` and refresh the `mu-wpcom-plugin` and `wpcomsh` dependency locks.

## Related product discussion/links
* WooCommerce.com Help Center consumer integration.

## Does this pull request change what data or activity we track or use?
No. This changes how existing Help Center requests are authenticated and proxied; it does not add tracking or collect new data.

## Testing instructions
1. Run `pnpm jetpack test php packages/help-center -v`.
2. Run `vendor/bin/phpcs --standard=.phpcs.xml.dist projects/packages/help-center`.
3. Run `pnpm jetpack changelog validate packages/help-center`.
4. Run `pnpm jetpack changelog validate plugins/mu-wpcom-plugin`.
5. Run `pnpm jetpack changelog validate plugins/wpcomsh`.
6. Add a consumer filter that returns `true` for `jetpack_help_center_should_load_logged_out` on a frontend request.
7. Visit the frontend while logged out and confirm `help-center-logged-out.min.js` is enqueued.
8. Open the Help Center from the consuming surface and confirm the panel appears.
9. Search for `payments` and confirm support results appear.
10. Request `/wp-json/help-center/search?query=payments&locale=en` while logged out and confirm the response contains WordPress.com support results.
