### PR TITLE
Claude: fix the AGENTS.md import path in .claude/CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,1 +1,1 @@
-@AGENTS.md
+@../AGENTS.md


### PR DESCRIPTION
Fixes # N/A

## Proposed changes
* Fix the import path in `.claude/CLAUDE.md`, changing `@AGENTS.md` to `@../AGENTS.md`.
* Claude Code resolves `@` import paths relative to the file containing them, so `@AGENTS.md` inside `.claude/CLAUDE.md` pointed at `.claude/AGENTS.md` — a file that does not exist. Our monorepo guidance lives in `AGENTS.md` at the repo root, so **none of it was being loaded** into sessions started at the repo root: not the public-repo confidentiality rule, not the `$$next-version$$` rules, not the `jp` command reference.
* The nested pointers under `projects/` were already correct — each `projects/**/CLAUDE.md` sits next to its own `AGENTS.md`, so `@AGENTS.md` resolves there. Only the root pointer was broken.

## Related product discussion/links
* N/A

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

The bug is verifiable without running an agent — the old path simply had no target:

* On `trunk`: `cat .claude/CLAUDE.md` shows `@AGENTS.md`, and `ls .claude/AGENTS.md` reports "No such file or directory". The real file is `AGENTS.md` at the repo root (~13 KB).
* On this branch: `cat .claude/CLAUDE.md` shows `@../AGENTS.md`, and `ls .claude/../AGENTS.md` resolves to `AGENTS.md` at the repo root.

To confirm the guidance now actually reaches the agent:

* Start a fresh Claude Code session from the repo root and run `/context`. The project-instructions/memory entry should account for roughly 3.5k tokens of `AGENTS.md` content, rather than the single-line pointer it counted before.
* Optional strict check: temporarily append a line to `AGENTS.md` such as `When asked for the memory canary, reply exactly: JETPACK-CANARY-7Q2.`, start a fresh session, and ask "Without using any tools, what is the memory canary?" It answers with the token only if `AGENTS.md` was loaded as context. Remove the line afterwards.

No changelog entry: this PR touches only `.claude/`, outside `/projects`.
