### PR TITLE
Claude skills: symlink the .claude/skills adapters at their .agents sources

### DIFF
--- a/.claude/skills/charts-docs/SKILL.md
+++ b/.claude/skills/charts-docs/SKILL.md
@@ -1,1 +1,1 @@
-@../../../.agents/skills/charts-docs.md
+../../../.agents/skills/charts-docs.md

--- a/.claude/skills/jetpack-screenshot/SKILL.md
+++ b/.claude/skills/jetpack-screenshot/SKILL.md
@@ -1,1 +1,1 @@
-@../../../.agents/skills/jetpack-screenshot.md
+../../../.agents/skills/jetpack-screenshot.md

--- a/.claude/skills/jetpack-test-jurassic-ninja/SKILL.md
+++ b/.claude/skills/jetpack-test-jurassic-ninja/SKILL.md
@@ -1,1 +1,1 @@
-@../../../.agents/skills/jetpack-test-jurassic-ninja.md
+../../../.agents/skills/jetpack-test-jurassic-ninja.md

--- a/.claude/skills/jn-pr-review/SKILL.md
+++ b/.claude/skills/jn-pr-review/SKILL.md
@@ -1,1 +1,1 @@
-@../../../.agents/skills/jn-pr-review.md
+../../../.agents/skills/jn-pr-review.md

--- a/.claude/skills/ship-wp-ability/SKILL.md
+++ b/.claude/skills/ship-wp-ability/SKILL.md
@@ -1,1 +1,1 @@
-@../../../.agents/skills/ship-wp-ability.md
+../../../.agents/skills/ship-wp-ability.md

--- a/.claude/skills/wp-abilities-api/SKILL.md
+++ b/.claude/skills/wp-abilities-api/SKILL.md
@@ -1,1 +1,1 @@
-@../../../.agents/skills/wp-abilities-api.md
+../../../.agents/skills/wp-abilities-api.md

--- a/.claude/skills/wp-abilities-audit/SKILL.md
+++ b/.claude/skills/wp-abilities-audit/SKILL.md
@@ -1,1 +1,1 @@
-@../../../.agents/skills/wp-abilities-audit.md
+../../../.agents/skills/wp-abilities-audit.md

--- a/.claude/skills/wp-abilities-verify/SKILL.md
+++ b/.claude/skills/wp-abilities-verify/SKILL.md
@@ -1,1 +1,1 @@
-@../../../.agents/skills/wp-abilities-verify.md
+../../../.agents/skills/wp-abilities-verify.md


### PR DESCRIPTION
Fixes # N/A

## Proposed changes
* Replace each of the eight `.claude/skills/*/SKILL.md` adapters with a symlink to its source in `.agents/skills/`.
* **The bug:** every adapter contained a single line — `@../../../.agents/skills/<name>.md`. Claude Code parses skill frontmatter from the file it discovers, and an `@` import splices in *body text* without merging the imported file's frontmatter. So all eight skills were registered with no `description`; the raw import line was surfaced in its place. Concretely, the skill list read `charts-docs: @../../../.agents/skills/charts-docs.md` instead of the description sitting in the source file.
* **The consequences:** these skills could only run when named explicitly (`/charts-docs`), never selected on relevance — the carefully written "Use when the user asks to…" trigger text in `.agents/skills/` never reached the agent. The `allowed-tools` declared by `jetpack-screenshot` and `jn-pr-review` was ignored for the same reason.
* **Why a symlink** rather than copying the frontmatter into each adapter: frontmatter is then read from the resolved file, so descriptions *and* `allowed-tools` apply with nothing duplicated between the two trees and nothing to drift. This is already how the repo shares files — 173 of the 177 tracked symlinks are per-project `phpunit.{8,12}.xml.dist` links pointing at a single source.
* `.agents/` remains the single home for skill bodies, so other agent tooling that reads `.agents/skills/` directly is unaffected. No skill content is modified by this PR.

## Related product discussion/links
* N/A

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

Verify the plumbing:

* `git show --stat HEAD` — eight `mode change 100644 => 120000`, no content changes.
* `ls -l .claude/skills/*/SKILL.md` — each is a symlink to `../../../.agents/skills/<name>.md`, and `head -3` through any of them shows the source's frontmatter.

Verify the behavior in Claude Code (this is the part that matters):

* On `trunk`, start a session in the monorepo and check the available-skills list — entries appear as `charts-docs: @../../../.agents/skills/charts-docs.md`, i.e. the pointer text in the description slot.
* On this branch, start a fresh session — the same entries now carry their real descriptions, e.g. `charts-docs: Create or update @automattic/charts docs using the standard docs and API templates`.
* Functional check: ask something matching a description without naming the skill — e.g. "test this PR on Jurassic Ninja" should now select `jn-pr-review`, which previously required typing the name.

Windows note: development on Windows goes through WSL2 per `docs/development-environment.md`, which handles symlinks natively, and the existing 173 `phpunit.*.xml.dist` symlinks already depend on this.

Out of scope, spotted while working here: the `wp-abilities-*` and `ship-wp-ability` bodies reference bundled resources as `wp-abilities-api/references/*.md`, paths that resolve only relative to `.agents/skills/` — not from the skill directory or the repo root. That predates this change (the `@import` version had the same problem) and is left for a separate PR. `work-on` and `jetpack-blueprint-builder` also still have no adapter of any kind, which is a deliberate hold, not an oversight to fix here.

No changelog entry: this PR touches only `.claude/`, outside `/projects`.

