### PR TITLE
Reader Chat: Rename Reader Chat to Site Chat

### DIFF
--- a/projects/packages/search/changelog/update-site-chat-name
+++ b/projects/packages/search/changelog/update-site-chat-name
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Search: Rename the Reader Chat setting to Site Chat.
+Search: Rename the Reader Chat setting to Site Chat, and describe it as answering visitor questions about the site.

--- a/projects/packages/search/changelog/update-site-chat-name
+++ b/projects/packages/search/changelog/update-site-chat-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Search: Rename the Reader Chat setting to Site Chat.

--- a/projects/packages/search/src/dashboard/components/reader-chat-control/index.jsx
+++ b/projects/packages/search/src/dashboard/components/reader-chat-control/index.jsx
@@ -4,7 +4,7 @@ import { Badge } from '@wordpress/ui';
 import { useCallback } from 'react';
 
 const READER_CHAT_DESCRIPTION = __(
-	'Let readers ask your blog questions and get answers from your content.',
+	'Let visitors ask your site questions and get answers from your content.',
 	'jetpack-search-pkg'
 );
 

--- a/projects/packages/search/src/dashboard/components/reader-chat-control/index.jsx
+++ b/projects/packages/search/src/dashboard/components/reader-chat-control/index.jsx
@@ -49,7 +49,7 @@ export default function ReaderChatControl( {
 					className="jp-search-dashboard-toggle lg-col-span-12 md-col-span-8 sm-col-span-4"
 					label={
 						<>
-							{ __( 'Enable Reader Chat', 'jetpack-search-pkg' ) }
+							{ __( 'Enable Site Chat', 'jetpack-search-pkg' ) }
 							<Badge intent="informational" className="jp-reader-chat-control__preview-badge">
 								{ __( 'Preview', 'jetpack-search-pkg' ) }
 							</Badge>

--- a/projects/packages/search/src/dashboard/components/reader-chat-control/test/index.test.jsx
+++ b/projects/packages/search/src/dashboard/components/reader-chat-control/test/index.test.jsx
@@ -73,7 +73,7 @@ describe( 'ReaderChatControl', () => {
 		render( <ReaderChatControl { ...defaultProps } isEnabled /> );
 
 		const toggle = screen.getByRole( 'checkbox', {
-			name: /Enable Reader Chat/i,
+			name: /Enable Site Chat/i,
 		} );
 
 		expect( toggle ).toBeChecked();
@@ -103,7 +103,7 @@ describe( 'ReaderChatControl', () => {
 		render( <ReaderChatControl { ...defaultProps } isEnabled={ false } /> );
 
 		const toggle = screen.getByRole( 'checkbox', {
-			name: /Enable Reader Chat/i,
+			name: /Enable Site Chat/i,
 		} );
 
 		expect( toggle ).not.toBeChecked();
@@ -119,7 +119,7 @@ describe( 'ReaderChatControl', () => {
 		render( <ReaderChatControl { ...defaultProps } updateOptions={ updateOptions } /> );
 
 		const toggle = screen.getByRole( 'checkbox', {
-			name: /Enable Reader Chat/i,
+			name: /Enable Site Chat/i,
 		} );
 		fireEvent.click( toggle );
 
@@ -131,7 +131,7 @@ describe( 'ReaderChatControl', () => {
 
 		expect(
 			screen.getByRole( 'checkbox', {
-				name: /Enable Reader Chat/i,
+				name: /Enable Site Chat/i,
 			} )
 		).toBeDisabled();
 	} );

--- a/projects/plugins/jetpack/changelog/update-site-chat-name
+++ b/projects/plugins/jetpack/changelog/update-site-chat-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Site Chat: Rename the public feature text from Reader Chat.

--- a/projects/plugins/jetpack/changelog/update-site-chat-name
+++ b/projects/plugins/jetpack/changelog/update-site-chat-name
@@ -1,4 +1,4 @@
 Significance: patch
 Type: enhancement
 
-Site Chat: Rename the public feature text from Reader Chat.
+Site Chat: Rename the public feature text from Reader Chat to Site Chat.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/reader-chat/class-jetpack-reader-chat.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/reader-chat/class-jetpack-reader-chat.php
@@ -86,7 +86,7 @@ class Jetpack_Reader_Chat {
 			'reader_chat',
 			array(
 				'type'              => 'boolean',
-				'description'       => __( 'Whether Reader Chat is enabled on this site.', 'jetpack' ),
+				'description'       => __( 'Whether Site Chat is enabled on this site.', 'jetpack' ),
 				'sanitize_callback' => 'rest_sanitize_boolean',
 				'default'           => false,
 			)

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-assistant-plugin/reader-chat/Jetpack_Reader_Chat_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-assistant-plugin/reader-chat/Jetpack_Reader_Chat_Test.php
@@ -296,6 +296,11 @@ class Jetpack_Reader_Chat_Test extends WP_UnitTestCase {
 			$registered_settings['reader_chat']['show_in_rest'] ?? false,
 			'reader_chat should not be exposed through the core REST settings endpoint.'
 		);
+		$this->assertSame(
+			'Whether Site Chat is enabled on this site.',
+			$registered_settings['reader_chat']['description'] ?? '',
+			'reader_chat description should use the Site Chat name.'
+		);
 	}
 
 	// ──────────────────────────────────────────────────

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-assistant-plugin/reader-chat/Jetpack_Reader_Chat_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-assistant-plugin/reader-chat/Jetpack_Reader_Chat_Test.php
@@ -297,7 +297,7 @@ class Jetpack_Reader_Chat_Test extends WP_UnitTestCase {
 			'reader_chat should not be exposed through the core REST settings endpoint.'
 		);
 		$this->assertSame(
-			'Whether Site Chat is enabled on this site.',
+			__( 'Whether Site Chat is enabled on this site.', 'jetpack' ),
 			$registered_settings['reader_chat']['description'] ?? '',
 			'reader_chat description should use the Site Chat name.'
 		);


### PR DESCRIPTION
## Proposed changes

<img width="1065" height="203" alt="Screenshot 2026-07-30 at 11 10 23" src="https://github.com/user-attachments/assets/30bdc094-6396-4553-9175-fa80efdf27cf" />

Calypso [PR](https://github.com/Automattic/wp-calypso/pull/113035)
WPCOM PR 230736 

* Rename the Search dashboard toggle from "Enable Reader Chat" to "Enable Site Chat."
* Rename the registered setting description to Site Chat.
* Keep the `reader_chat` option, class names, filters, and other internal contracts unchanged.
* Add changelog entries for the Search package and Jetpack plugin.

## Related product discussion/links

* Public naming cleanup to distinguish the feature from the WordPress Reader product. Private coordination links are intentionally omitted from this public PR.

## Does this pull request change what data or activity we track or use?

No. Tracks event names and payloads are unchanged.

## Testing instructions

Automated checks run:

* From `projects/packages/search`, `pnpm test-scripts` — 81 suites and 1,101 tests passed.
* `jetpack test php packages/search -v` — 631 tests and 1,440 assertions passed.
* `jetpack test php packages/sync -v` — 135 tests and 508 assertions passed.
* `jetpack docker phpunit jetpack -- --filter=Jetpack_Reader_Chat_Test` — 50 tests and 96 assertions passed, with two existing skips.
* `jetpack changelog validate packages/search` and `jetpack changelog validate plugins/jetpack` — passed.

Manual review:

1. Open Jetpack > Search on a site where the preview feature is available.
2. Confirm the toggle reads "Enable Site Chat" and still shows the Preview badge.
3. Toggle the setting on and off.
4. Confirm the value still persists through the existing `reader_chat` option and no other behavior changes.
