### PR TITLE
Connection: deliberate take-over-ownership and reconnect hardening (draft)

### DIFF
--- a/projects/js-packages/api/changelog/add-connection-takeover-ownership
+++ b/projects/js-packages/api/changelog/add-connection-takeover-ownership
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add setConnectionOwner method to change the Jetpack connection owner.

--- a/projects/js-packages/api/index.jsx
+++ b/projects/js-packages/api/index.jsx
@@ -177,6 +177,13 @@ function JetpackRestApiClient( root, nonce ) {
 				.then( checkStatus )
 				.then( parseJsonResponse ),
 
+		setConnectionOwner: ownerId =>
+			postRequest( `${ apiRoot }jetpack/v4/connection/owner`, postParams, {
+				body: JSON.stringify( { owner: ownerId } ),
+			} )
+				.then( checkStatus )
+				.then( parseJsonResponse ),
+
 		fetchConnectedPlugins: () =>
 			getRequest( `${ apiRoot }jetpack/v4/connection/plugins`, getParams )
 				.then( checkStatus )

--- a/projects/js-packages/connection/changelog/add-connection-takeover-ownership
+++ b/projects/js-packages/connection/changelog/add-connection-takeover-ownership
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Connection: Add a built-in "take over ownership" call to action for connection error notices, and select the surfaced error deterministically by how actionable it is for the viewer.

--- a/projects/js-packages/connection/hooks/use-connection-error-notice/index.tsx
+++ b/projects/js-packages/connection/hooks/use-connection-error-notice/index.tsx
@@ -1,6 +1,7 @@
 import ConnectionErrorNotice from '../../components/connection-error-notice';
 import useConnection from '../../components/use-connection';
 import useRestoreConnection from '../../hooks/use-restore-connection';
+import useTakeOverConnection from '../../hooks/use-take-over-connection';
 import { resolveConnectionErrorActions } from './resolve-actions';
 import type {
 	ConnectionErrorMap,
@@ -16,6 +17,43 @@ export type {
 	ConnectionErrorMap,
 	ConnectionErrorObject,
 } from './types';
+
+/**
+ * Audience ordering used to pick the single notice to surface: prefer errors the
+ * viewer can act on (site-wide, then their own user error, then the owner's). Errors
+ * with no audience (e.g. consumer-injected) default to site-wide and keep top priority.
+ */
+const AUDIENCE_PRIORITY: Record< string, number > = { site: 0, user: 1, owner: 2 };
+
+/**
+ * Deterministically select the most relevant error from the map by audience priority.
+ *
+ * Replaces insertion-order selection, which is nondeterministic when several errors are
+ * stored, so the notice a viewer sees no longer depends on option write order.
+ *
+ * @param {ConnectionErrorMap} errorMap - The nested error map (code => userId => error).
+ * @return {ConnectionErrorObject | undefined} The selected error, or undefined when empty.
+ */
+function selectPrimaryError( errorMap: ConnectionErrorMap ): ConnectionErrorObject | undefined {
+	let best: ConnectionErrorObject | undefined;
+	let bestRank = Number.POSITIVE_INFINITY;
+
+	for ( const users of Object.values( errorMap ) ) {
+		if ( ! users || typeof users !== 'object' ) {
+			continue;
+		}
+		for ( const error of Object.values( users ) ) {
+			const audience = error?.audience ?? 'site';
+			const rank = AUDIENCE_PRIORITY[ audience ] ?? 0;
+			if ( rank < bestRank ) {
+				bestRank = rank;
+				best = error;
+			}
+		}
+	}
+
+	return best;
+}
 
 /**
  * Connection error notice hook.
@@ -41,6 +79,16 @@ export default function useConnectionErrorNotice( {
 	const { connectionErrors, connectionHealthErrors } = useConnection( {} );
 	const { restoreConnection, isRestoringConnection, restoreConnectionError } =
 		useRestoreConnection();
+	const { takeOverOwnership } = useTakeOverConnection();
+
+	// Built-in handler for the package's `take_over_ownership` action. Consumer-supplied
+	// handlers take precedence, so a consumer can still override the behavior.
+	const mergedActionHandlers = {
+		take_over_ownership: () => {
+			takeOverOwnership().catch( () => {} );
+		},
+		...actionHandlers,
+	};
 
 	// connectionErrors is typed as Array<string|object> but is actually a nested
 	// object at runtime; the store selector can also fall back to `[]`. Normalize
@@ -63,18 +111,14 @@ export default function useConnectionErrorNotice( {
 	const errorMap: ConnectionErrorMap = Object.keys( storedErrorMap ).length
 		? storedErrorMap
 		: healthErrorMap;
-	const connectionErrorList = Object.values( errorMap ).shift();
-	const firstError: ConnectionErrorObject | undefined =
-		connectionErrorList && Object.values( connectionErrorList ).length
-			? Object.values( connectionErrorList ).shift()
-			: undefined;
+	const firstError: ConnectionErrorObject | undefined = selectPrimaryError( errorMap );
 
 	const connectionErrorMessage = firstError?.error_message;
 	const hasConnectionError = Boolean( connectionErrorMessage );
 
 	const actions = firstError
 		? resolveConnectionErrorActions( firstError, {
-				actionHandlers,
+				actionHandlers: mergedActionHandlers,
 				trackingCallback,
 				customActions,
 				restoreConnection,

--- a/projects/js-packages/connection/hooks/use-connection-error-notice/resolve-actions.ts
+++ b/projects/js-packages/connection/hooks/use-connection-error-notice/resolve-actions.ts
@@ -15,6 +15,16 @@ export const DEFAULT_RECONNECT_TRACKING_EVENT =
 	'jetpack_connection_error_notice_reconnect_cta_click';
 
 /**
+ * Default button labels for the package's built-in named actions, used when the error
+ * does not supply an explicit `action_label`.
+ */
+const DEFAULT_ACTION_LABELS: Record< string, string > = {
+	get take_over_ownership() {
+		return __( 'Take over ownership', 'jetpack-connection-js' );
+	},
+};
+
+/**
  * The resolver's options: the public `ConnectionErrorProps` plus the two fields
  * the hook supplies internally (`restoreConnection` / `isRestoringConnection`).
  */
@@ -86,7 +96,10 @@ export function resolveConnectionErrorActions(
 		// Named handler from the error data.
 		actions = [
 			{
-				label: errorData.action_label || __( 'Take Action', 'jetpack-connection-js' ),
+				label:
+					errorData.action_label ||
+					DEFAULT_ACTION_LABELS[ suggestedAction ] ||
+					__( 'Take Action', 'jetpack-connection-js' ),
 				onClick: () => {
 					try {
 						track( errorData.tracking_event );

--- a/projects/js-packages/connection/hooks/use-connection-error-notice/test/connection-error.test.tsx
+++ b/projects/js-packages/connection/hooks/use-connection-error-notice/test/connection-error.test.tsx
@@ -20,6 +20,18 @@ jest.unstable_mockModule( '../../use-restore-connection', () => ( {
 	} ),
 } ) );
 
+// Take-over-connection also touches window/REST at import; stub it out and expose the
+// handler so tests can assert the built-in take_over_ownership CTA is wired to it.
+const takeOverOwnership = jest.fn( () => Promise.resolve() );
+jest.unstable_mockModule( '../../use-take-over-connection', () => ( {
+	__esModule: true,
+	default: () => ( {
+		takeOverOwnership,
+		isTakingOver: false,
+		takeOverError: null,
+	} ),
+} ) );
+
 // Mock the presentational notice so these tests assert the wiring (which props
 // ConnectionError passes), not the @wordpress/ui rendering.
 const ConnectionErrorNotice = jest.fn< ( props: ConnectionErrorNoticeProps ) => ReactNode >(
@@ -92,5 +104,52 @@ describe( 'ConnectionError', () => {
 		expect( props.actions ).toHaveLength( 0 );
 		// The default "Restore Connection" fallback must also be suppressed.
 		expect( props.restoreConnectionCallback ).toBeNull();
+	} );
+
+	it( 'wires the built-in take_over_ownership CTA to the takeover handler', () => {
+		mockConnection( {
+			connectionErrors: {
+				no_valid_user_token: {
+					'42': {
+						error_message: 'The connection owner needs to reconnect. You can take over ownership.',
+						error_type: 'xmlrpc',
+						audience: 'owner',
+						error_data: { action: 'take_over_ownership' },
+					},
+				},
+			},
+		} );
+
+		render( <ConnectionError /> );
+
+		const props = ConnectionErrorNotice.mock.calls[ 0 ][ 0 ];
+		expect( props.actions ).toHaveLength( 1 );
+		expect( props.actions[ 0 ].label ).toBe( 'Take over ownership' );
+
+		props.actions[ 0 ].onClick();
+		expect( takeOverOwnership ).toHaveBeenCalled();
+	} );
+
+	it( 'selects the most actionable error (site over owner) when several exist', () => {
+		mockConnection( {
+			connectionErrors: {
+				// Owner error listed first, but a site-wide error should win.
+				owner_error: {
+					'42': {
+						error_message: 'Owner message',
+						audience: 'owner',
+						error_data: { action: 'take_over_ownership' },
+					},
+				},
+				site_error: {
+					'0': { error_message: 'Site message', audience: 'site' },
+				},
+			},
+		} );
+
+		render( <ConnectionError /> );
+
+		const props = ConnectionErrorNotice.mock.calls[ 0 ][ 0 ];
+		expect( props.message ).toBe( 'Site message' );
 	} );
 } );

--- a/projects/js-packages/connection/hooks/use-connection-error-notice/test/resolve-actions.test.ts
+++ b/projects/js-packages/connection/hooks/use-connection-error-notice/test/resolve-actions.test.ts
@@ -142,6 +142,26 @@ describe( 'resolveConnectionErrorActions', () => {
 		expect( actions[ 0 ].label ).toBe( 'Take Action' );
 	} );
 
+	it( 'uses the built-in default label for the take_over_ownership action', () => {
+		const handler = jest.fn();
+		const error: ConnectionErrorObject = {
+			error_message: 'The connection owner needs to reconnect.',
+			audience: 'owner',
+			error_data: { action: 'take_over_ownership' },
+		};
+
+		const actions = resolveConnectionErrorActions( error, {
+			...baseOptions,
+			actionHandlers: { take_over_ownership: handler },
+		} );
+
+		expect( actions ).toHaveLength( 1 );
+		expect( actions[ 0 ].label ).toBe( 'Take over ownership' );
+
+		actions[ 0 ].onClick();
+		expect( handler ).toHaveBeenCalledWith( error );
+	} );
+
 	it( 'resolves a URL action and navigates via the supplied navigate handler', () => {
 		const navigate = jest.fn();
 		const actions = resolveConnectionErrorActions(

--- a/projects/js-packages/connection/hooks/use-take-over-connection/index.tsx
+++ b/projects/js-packages/connection/hooks/use-take-over-connection/index.tsx
@@ -1,0 +1,74 @@
+import restApi from '@automattic/jetpack-api';
+import { getScriptData } from '@automattic/jetpack-script-data';
+import { useEffect, useState } from 'react';
+import useConnection from '../../components/use-connection';
+
+const { apiRoot, apiNonce } =
+	window?.JP_CONNECTION_INITIAL_STATE || getScriptData()?.connection || {};
+
+/**
+ * Take-over-ownership hook.
+ *
+ * Lets a non-owner admin become the connection owner when the current owner's
+ * connection is broken (the deliberate replacement for the previous accidental
+ * ownership claim during a reconnect). A disconnected admin is first routed through
+ * the user-connection flow; once they return connected, the takeover CTA re-renders so
+ * they can complete the takeover. The operation is idempotent: on a partial failure the
+ * notice re-renders with the CTA still present, so clicking again simply retries.
+ *
+ * @return {object} - `{ takeOverOwnership, isTakingOver, takeOverError }`.
+ */
+export default function useTakeOverConnection() {
+	const [ isTakingOver, setIsTakingOver ] = useState( false );
+	const [ takeOverError, setTakeOverError ] = useState< string | null >( null );
+
+	const { isUserConnected, handleConnectUser, userConnectionData } = useConnection( {} );
+
+	const currentUserId = userConnectionData?.currentUser?.id as number | undefined;
+
+	/**
+	 * Initiate the ownership takeover.
+	 *
+	 * @return {Promise<unknown>} - The API request (or user-connection) promise.
+	 */
+	const takeOverOwnership = () => {
+		setTakeOverError( null );
+
+		// A disconnected admin must connect their own WordPress.com account first.
+		if ( ! isUserConnected ) {
+			return Promise.resolve( handleConnectUser() );
+		}
+
+		if ( ! currentUserId ) {
+			setTakeOverError( 'missing_user_id' );
+			return Promise.reject( new Error( 'missing_user_id' ) );
+		}
+
+		setIsTakingOver( true );
+
+		return restApi
+			.setConnectionOwner( currentUserId )
+			.then( ( response: unknown ) => {
+				// Reload so every connection-aware surface reflects the new owner.
+				window.location.reload();
+				return response;
+			} )
+			.catch( ( error: unknown ) => {
+				const message =
+					typeof error === 'string'
+						? error
+						: ( error as { message?: string } )?.message ?? 'takeover_failed';
+				setTakeOverError( message );
+				setIsTakingOver( false );
+
+				throw error;
+			} );
+	};
+
+	useEffect( () => {
+		restApi.setApiRoot( apiRoot );
+		restApi.setApiNonce( apiNonce );
+	}, [] );
+
+	return { takeOverOwnership, isTakingOver, takeOverError };
+}

--- a/projects/js-packages/connection/hooks/use-take-over-connection/test/index.test.tsx
+++ b/projects/js-packages/connection/hooks/use-take-over-connection/test/index.test.tsx
@@ -1,0 +1,73 @@
+import { jest } from '@jest/globals';
+import { renderHook, act } from '@testing-library/react';
+
+// The connection store reader — mocked to drive connection state.
+const useConnection = jest.fn();
+jest.unstable_mockModule( '../../../components/use-connection', () => ( {
+	__esModule: true,
+	default: useConnection,
+} ) );
+
+// Script data is read at module load; return an empty connection blob.
+jest.unstable_mockModule( '@automattic/jetpack-script-data', () => ( {
+	__esModule: true,
+	getScriptData: () => ( { connection: {} } ),
+} ) );
+
+// The REST transport — mocked so we can assert the owner endpoint call.
+const setConnectionOwner = jest.fn();
+jest.unstable_mockModule( '@automattic/jetpack-api', () => ( {
+	__esModule: true,
+	default: {
+		setConnectionOwner,
+		setApiRoot: jest.fn(),
+		setApiNonce: jest.fn(),
+	},
+} ) );
+
+const { default: useTakeOverConnection } = await import( '../index' );
+
+describe( 'useTakeOverConnection', () => {
+	const handleConnectUser = jest.fn();
+
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'posts the current user as the new owner when connected', () => {
+		useConnection.mockReturnValue( {
+			isUserConnected: true,
+			handleConnectUser,
+			userConnectionData: { currentUser: { id: 42 } },
+		} );
+		// A pending promise so the success handler (which reloads the page) never runs;
+		// jsdom does not implement navigation. We only need to assert the request.
+		setConnectionOwner.mockReturnValue( new Promise( () => {} ) );
+
+		const { result } = renderHook( () => useTakeOverConnection() );
+
+		act( () => {
+			void result.current.takeOverOwnership();
+		} );
+
+		expect( setConnectionOwner ).toHaveBeenCalledWith( 42 );
+		expect( handleConnectUser ).not.toHaveBeenCalled();
+	} );
+
+	it( 'routes a disconnected admin through the user-connection flow first', async () => {
+		useConnection.mockReturnValue( {
+			isUserConnected: false,
+			handleConnectUser,
+			userConnectionData: { currentUser: { id: 42 } },
+		} );
+
+		const { result } = renderHook( () => useTakeOverConnection() );
+
+		await act( async () => {
+			await result.current.takeOverOwnership();
+		} );
+
+		expect( handleConnectUser ).toHaveBeenCalled();
+		expect( setConnectionOwner ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/packages/connection/changelog/add-connection-takeover-ownership
+++ b/projects/packages/connection/changelog/add-connection-takeover-ownership
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Connection: Offer a deliberate "take over ownership" action to admins when the owner's connection is broken (transferable model), fire a new jetpack_connection_owner_changed action on ownership change, prevent non-owners from silently seizing ownership via reconnect, and collapse site/owner errors into a single generic notice for non-admins.

--- a/projects/packages/connection/src/class-error-handler.php
+++ b/projects/packages/connection/src/class-error-handler.php
@@ -242,9 +242,25 @@ class Error_Handler {
 				'invalid_connection_owner',
 			);
 
-			$owner_id        = (int) \Jetpack_Options::get_option( 'master_user' );
-			$viewer_is_owner = $owner_id > 0 && $viewer_id === $owner_id;
-			$is_transferable = ( new Manager() )->is_ownership_transferable();
+			// Owner-identity error codes: those that mean "the connection owner's
+			// credential is broken" and can therefore be remedied by taking over
+			// ownership. Site-level faults that merely happen to be attributed to the
+			// owner (invalid_signature / signature_mismatch / could_not_sign, e.g. from
+			// clock skew or a domain change) are deliberately excluded so they can never
+			// suggest an ownership change - they keep the default reconnect CTA.
+			$owner_takeover_codes = array(
+				'no_valid_user_token',
+				'no_token_for_user',
+				'token_malformed',
+				'unknown_token',
+				'invalid_token',
+				'invalid_connection_owner',
+			);
+
+			$owner_id          = (int) \Jetpack_Options::get_option( 'master_user' );
+			$viewer_is_owner   = $owner_id > 0 && $viewer_id === $owner_id;
+			$is_transferable   = ( new Manager() )->is_ownership_transferable();
+			$viewer_can_manage = current_user_can( 'jetpack_connect' );
 
 			foreach ( $verified_errors as $error_code => $users ) {
 				// Skip error codes that are not meant to be displayed
@@ -261,34 +277,51 @@ class Error_Handler {
 
 					$audience = $this->classify_error_audience( $user_id, $owner_id );
 
+					// A specific (non-owner) user's token error is only actionable by that
+					// user (by relinking their own account). Omit it from every other
+					// viewer's set; it is low-signal clutter for everyone else.
+					if ( 'user' === $audience && (int) $user_id !== $viewer_id ) {
+						continue;
+					}
+
 					$message = __( "Your connection with WordPress.com seems to be broken. If you're experiencing issues, please try reconnecting.", 'jetpack-connection' );
 					$action  = null;
 
-					// A secondary admin looking at the connection owner's token error, on a
-					// site where ownership is locked (a consumer declared it non-transferable).
-					// This admin cannot resolve the error themselves, so surface an
-					// informational notice naming the owner and offer no reconnect CTA.
-					if ( 'owner' === $audience && ! $viewer_is_owner && ! $is_transferable ) {
+					// The connection owner's own credential is broken and a non-owner admin
+					// is looking at it. Depending on whether ownership is transferable and
+					// whether the error is remediable by a takeover, this becomes either a
+					// deliberate "take over ownership" CTA or an informational notice.
+					if ( 'owner' === $audience && ! $viewer_is_owner ) {
 						// Only name the owner for viewers who can act on connection issues:
 						// this output is also printed into the initial state for
 						// lower-capability users (e.g. contributors in the editor), who
 						// shouldn't learn who owns the connection. The name is resolved from
 						// the local user rather than get_connection_owner(), which
 						// re-reports the error and fails exactly when the token is broken.
-						$owner_name = '';
-						if ( current_user_can( 'jetpack_connect' ) ) {
-							$owner      = get_userdata( $owner_id );
-							$owner_name = $owner instanceof \WP_User ? $owner->display_name : '';
-						}
+						$owner_user    = $owner_id > 0 ? get_userdata( $owner_id ) : false;
+						$owner_deleted = $owner_id > 0 && false === $owner_user;
+						$owner_name    = ( $viewer_can_manage && $owner_user instanceof \WP_User ) ? $owner_user->display_name : '';
 
-						$message = $owner_name
-							? sprintf(
-								/* translators: %s is the display name of the Jetpack connection owner. */
-								__( 'The connection owner (%s) needs to reconnect their WordPress.com account to restore the connection.', 'jetpack-connection' ),
-								$owner_name
-							)
-							: __( 'The connection owner needs to reconnect their WordPress.com account to restore the connection.', 'jetpack-connection' );
-						$action = 'none';
+						// Takeover is only offered to a viewer who can manage the connection,
+						// on the transferable (default) ownership model, and only for
+						// owner-identity error codes (not site-level signature faults).
+						$can_take_over = $viewer_can_manage
+							&& $is_transferable
+							&& in_array( $error_code, $owner_takeover_codes, true );
+
+						if ( $can_take_over ) {
+							$action  = 'take_over_ownership';
+							$message = $this->get_owner_takeover_message( $owner_deleted, $owner_name );
+						} elseif ( ! $is_transferable ) {
+							// Ownership is locked, so this admin cannot resolve the error:
+							// surface an informational notice with no reconnect CTA.
+							$action  = 'none';
+							$message = $this->get_owner_locked_message( $owner_deleted, $owner_name );
+						}
+						// Otherwise (transferable but a non-takeover code, or a viewer who
+						// cannot manage the connection) fall through to the default generic
+						// message + reconnect CTA. Non-manager owner errors are collapsed
+						// into a single generic notice below.
 					}
 
 					$error['audience']      = $audience;
@@ -309,6 +342,14 @@ class Error_Handler {
 					}
 					$displayable_errors[ $error_code ][ $user_id ] = $error;
 				}
+			}
+
+			// Site/owner connection errors are an admin-level concern. For a viewer who
+			// cannot manage the connection, keep only their own (user-audience) error and
+			// collapse everything else into a single, diagnostics-free generic notice so
+			// we neither leak error internals nor imply an action they cannot take.
+			if ( ! $viewer_can_manage ) {
+				$displayable_errors = $this->collapse_errors_for_non_manager( $displayable_errors );
 			}
 		}
 
@@ -377,6 +418,149 @@ class Error_Handler {
 	}
 
 	/**
+	 * Builds the message for a non-owner admin who can take over a broken owner connection.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param bool   $owner_deleted Whether the connection owner's WordPress user no longer exists.
+	 * @param string $owner_name    The connection owner's display name, or '' when it should not be shown.
+	 * @return string The takeover-offer message.
+	 */
+	private function get_owner_takeover_message( $owner_deleted, $owner_name ) {
+		if ( $owner_deleted ) {
+			return __( "The previous connection owner's WordPress.com account no longer exists. You can take over ownership to restore this site's connection.", 'jetpack-connection' );
+		}
+
+		if ( $owner_name ) {
+			return sprintf(
+				/* translators: %s is the display name of the Jetpack connection owner. */
+				__( 'The connection owner (%s) needs to reconnect to WordPress.com. You can take over ownership to restore the connection.', 'jetpack-connection' ),
+				$owner_name
+			);
+		}
+
+		return __( 'The connection owner needs to reconnect to WordPress.com. You can take over ownership to restore the connection.', 'jetpack-connection' );
+	}
+
+	/**
+	 * Builds the informational message shown when ownership is locked (non-transferable)
+	 * and a non-owner admin cannot resolve the owner's broken connection themselves.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param bool   $owner_deleted Whether the connection owner's WordPress user no longer exists.
+	 * @param string $owner_name    The connection owner's display name, or '' when it should not be shown.
+	 * @return string The informational message.
+	 */
+	private function get_owner_locked_message( $owner_deleted, $owner_name ) {
+		if ( $owner_deleted ) {
+			return __( "The connection owner's WordPress.com account no longer exists, so this site's connection cannot be restored automatically. Please contact support.", 'jetpack-connection' );
+		}
+
+		if ( $owner_name ) {
+			return sprintf(
+				/* translators: %s is the display name of the Jetpack connection owner. */
+				__( 'The connection owner (%s) needs to reconnect their WordPress.com account to restore the connection.', 'jetpack-connection' ),
+				$owner_name
+			);
+		}
+
+		return __( 'The connection owner needs to reconnect their WordPress.com account to restore the connection.', 'jetpack-connection' );
+	}
+
+	/**
+	 * Collapses site/owner errors into a single generic notice for a viewer who cannot
+	 * manage the connection.
+	 *
+	 * Viewers without the `jetpack_connect` capability keep only their own user-audience
+	 * error (which they can resolve by relinking their account). All site- and
+	 * owner-audience errors are replaced by one synthetic `connection_error_generic`
+	 * entry that carries no diagnostic data (no error codes, timestamps or signature
+	 * metadata) and no CTA, so nothing sensitive leaks into the initial state and the
+	 * viewer is simply pointed at a site administrator.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $displayable_errors Hierarchical error map (error_code => user_id => error).
+	 * @return array The filtered error map for a non-managing viewer.
+	 */
+	private function collapse_errors_for_non_manager( $displayable_errors ) {
+		$viewer_errors     = array();
+		$has_site_or_owner = false;
+
+		foreach ( $displayable_errors as $error_code => $users ) {
+			foreach ( $users as $user_id => $error ) {
+				$audience = $error['audience'] ?? 'site';
+				if ( 'user' === $audience ) {
+					$viewer_errors[ $error_code ][ $user_id ] = $error;
+				} else {
+					$has_site_or_owner = true;
+				}
+			}
+		}
+
+		if ( $has_site_or_owner ) {
+			$viewer_errors['connection_error_generic'] = array(
+				'0' => array(
+					'error_code'    => 'connection_error_generic',
+					'user_id'       => '0',
+					'error_message' => __( "There is a problem with this site's connection to WordPress.com. Please contact a site administrator.", 'jetpack-connection' ),
+					'audience'      => 'site',
+					'error_data'    => array( 'action' => 'none' ),
+					'error_type'    => 'connection',
+				),
+			);
+		}
+
+		return $viewer_errors;
+	}
+
+	/**
+	 * Selects the single most relevant error to surface, ordered by how actionable it
+	 * is for the current viewer.
+	 *
+	 * When several errors are stored we show only one notice. Rather than depending on
+	 * option insertion order (nondeterministic), we prefer errors the viewer can act on:
+	 * site-wide first, then the viewer's own user error, then the owner's. Errors with no
+	 * `audience` (e.g. consumer-injected) default to site-wide, so they keep top priority.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $displayable_errors Hierarchical error map (error_code => user_id => error).
+	 * @return array|null [ $error_code, $error ] for the selected error, or null when empty.
+	 */
+	private function select_primary_error( $displayable_errors ) {
+		$priority  = array(
+			'site'  => 0,
+			'user'  => 1,
+			'owner' => 2,
+		);
+		$best      = null;
+		$best_code = null;
+		$best_rank = PHP_INT_MAX;
+
+		foreach ( $displayable_errors as $error_code => $users ) {
+			if ( ! is_array( $users ) ) {
+				continue;
+			}
+			foreach ( $users as $error ) {
+				if ( ! is_array( $error ) ) {
+					continue;
+				}
+				$audience = $error['audience'] ?? 'site';
+				$rank     = $priority[ $audience ] ?? 0;
+				if ( $rank < $best_rank ) {
+					$best_rank = $rank;
+					$best      = $error;
+					$best_code = $error_code;
+				}
+			}
+		}
+
+		return null === $best ? null : array( $best_code, $best );
+	}
+
+	/**
 	 * Sets up hooks for displaying verified errors on admin pages.
 	 *
 	 * This method is hooked into 'admin_init'. It retrieves displayable errors
@@ -441,18 +625,14 @@ class Error_Handler {
 	public function jetpack_react_dashboard_error( $errors ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
 		$displayable_errors = $this->get_displayable_errors();
 
-		// Get the first error only
-		$first_error_code = array_key_first( $displayable_errors );
-		if ( ! $first_error_code ) {
+		// Select a single error deterministically by how actionable it is for the
+		// current viewer (site > own-user > owner) rather than by option insertion order.
+		$primary = $this->select_primary_error( $displayable_errors );
+		if ( null === $primary ) {
 			return array(); // No errors
 		}
 
-		$first_user_errors = $displayable_errors[ $first_error_code ];
-		if ( ! is_array( $first_user_errors ) || empty( $first_user_errors ) ) {
-			return array(); // Invalid error structure
-		}
-
-		$first_error = reset( $first_user_errors );
+		list( $first_error_code, $first_error ) = $primary;
 
 		// Validate error structure
 		if ( ! is_array( $first_error ) || ! isset( $first_error['error_message'] ) ) {
@@ -957,6 +1137,52 @@ class Error_Handler {
 		}
 
 		// Invalidate cache since we may have deleted verified errors
+		$this->invalidate_displayable_errors_cache();
+	}
+
+	/**
+	 * Delete all stored and verified errors attributed to a single user.
+	 *
+	 * Used after an ownership takeover to clear the previous owner's now-stale token
+	 * errors without discarding unrelated site- or user-level errors.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int|string $user_id The user ID whose errors should be removed.
+	 * @return void
+	 */
+	public function delete_errors_for_user( $user_id ) {
+		$user_id = (string) $user_id;
+		$options = array(
+			self::STORED_ERRORS_OPTION          => $this->get_stored_errors(),
+			self::STORED_VERIFIED_ERRORS_OPTION => $this->get_verified_errors(),
+		);
+
+		foreach ( $options as $option => $errors ) {
+			if ( ! is_array( $errors ) || ! count( $errors ) ) {
+				continue;
+			}
+
+			$changed = false;
+			foreach ( $errors as $error_code => $users ) {
+				if ( is_array( $users ) && array_key_exists( $user_id, $users ) ) {
+					unset( $errors[ $error_code ][ $user_id ] );
+					$changed = true;
+					if ( ! count( $errors[ $error_code ] ) ) {
+						unset( $errors[ $error_code ] );
+					}
+				}
+			}
+
+			if ( $changed ) {
+				if ( count( $errors ) ) {
+					update_option( $option, $errors );
+				} else {
+					delete_option( $option );
+				}
+			}
+		}
+
 		$this->invalidate_displayable_errors_cache();
 	}
 

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -1149,6 +1149,19 @@ class Manager {
 	 * @return true|WP_Error True if owner successfully changed, WP_Error otherwise.
 	 */
 	public function update_connection_owner( $new_owner_id ) {
+		$new_owner_id = (int) $new_owner_id;
+
+		// Ownership changes are only permitted on the transferable (default) model.
+		// When a consumer has locked ownership (e.g. a managed host or a plugin that
+		// requires a fixed owner), this is the single chokepoint that refuses the change.
+		if ( ! $this->is_ownership_transferable() ) {
+			return new WP_Error(
+				'ownership_locked',
+				__( 'Connection ownership is locked and cannot be transferred on this site.', 'jetpack-connection' ),
+				array( 'status' => 403 )
+			);
+		}
+
 		$roles = new Roles();
 		if ( ! user_can( $new_owner_id, $roles->translate_role_to_cap( 'administrator' ) ) ) {
 			return new WP_Error(
@@ -1158,7 +1171,10 @@ class Manager {
 			);
 		}
 
-		$old_owner_id = $this->get_connection_owner_id();
+		// Use the record-based owner (master_user) rather than the token-derived owner:
+		// the latter returns false exactly when the current owner's token is broken,
+		// which is the scenario a takeover targets.
+		$old_owner_id = (int) \Jetpack_Options::get_option( 'master_user' );
 
 		if ( $old_owner_id === $new_owner_id ) {
 			return new WP_Error(
@@ -1176,6 +1192,9 @@ class Manager {
 			);
 		}
 
+		// Ownership changes are security-relevant; record the attempt.
+		( new Tracking() )->record_user_event( 'set_connection_owner_attempt' );
+
 		// Notify WPCOM about the connection owner change.
 		$owner_updated_wpcom = $this->update_connection_owner_wpcom( $new_owner_id );
 
@@ -1187,16 +1206,65 @@ class Manager {
 			// Clear the memoized connection owner ID since it changed
 			self::$connection_owner_id = null;
 
+			// Clear the previous owner's stale token errors and cached connection data
+			// for both users so the new owner does not immediately see notices about the
+			// previous owner.
+			$this->cleanup_after_owner_change( $old_owner_id, $new_owner_id );
+
 			// Track it.
 			( new Tracking() )->record_user_event( 'set_connection_owner_success' );
 
+			/**
+			 * Fires after the Jetpack connection owner has changed.
+			 *
+			 * Consumers can hook this to notify the previous owner or perform their own
+			 * bookkeeping. Jetpack ships no default notification.
+			 *
+			 * @since $$next-version$$
+			 *
+			 * @param int $old_owner_id The user ID of the previous connection owner (0 if none).
+			 * @param int $new_owner_id The user ID of the new connection owner.
+			 */
+			do_action( 'jetpack_connection_owner_changed', $old_owner_id, $new_owner_id );
+
 			return true;
 		}
+
+		( new Tracking() )->record_user_event( 'set_connection_owner_failure' );
+
 		return new WP_Error(
 			'error_setting_new_owner',
 			__( 'Could not confirm new owner.', 'jetpack-connection' ),
 			array( 'status' => 500 )
 		);
+	}
+
+	/**
+	 * Cleans up stale state after a connection ownership change.
+	 *
+	 * Removes the previous owner's (now-stale) local user token and connection errors and
+	 * clears the cached connection-user-data transients for both the previous and new
+	 * owner, so the new owner does not immediately see notices about the previous owner.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int $old_owner_id The user ID of the previous connection owner (0 if none).
+	 * @param int $new_owner_id The user ID of the new connection owner.
+	 * @return void
+	 */
+	private function cleanup_after_owner_change( $old_owner_id, $new_owner_id ) {
+		$old_owner_id = (int) $old_owner_id;
+		$new_owner_id = (int) $new_owner_id;
+
+		if ( $old_owner_id > 0 ) {
+			$this->get_tokens()->disconnect_user( $old_owner_id );
+			Error_Handler::get_instance()->delete_errors_for_user( $old_owner_id );
+			delete_transient( "jetpack_connected_user_data_$old_owner_id" );
+		}
+
+		if ( $new_owner_id > 0 ) {
+			delete_transient( "jetpack_connected_user_data_$new_owner_id" );
+		}
 	}
 
 	/**
@@ -1985,6 +2053,18 @@ class Manager {
 
 		// Tokens are both valid, or both invalid. We can't fix the problem we don't see, so the full reconnection is needed.
 		if ( $blog_token_healthy === $user_token_healthy ) {
+			// A full reconnect re-registers the site and lets the authorizing user become
+			// the connection owner. Refuse it for a non-owner while a live owner exists,
+			// so ownership cannot be silently seized by calling this endpoint directly -
+			// the deliberate "take over ownership" flow handles that case.
+			if ( $this->is_ownership_seizing_reconnect_blocked() ) {
+				return new WP_Error(
+					'reconnect_owner_required',
+					__( 'Only the connection owner can fully reconnect this site. To restore the connection yourself, take over ownership of the connection.', 'jetpack-connection' ),
+					array( 'status' => 403 )
+				);
+			}
+
 			$result = $this->reconnect();
 			return ( true === $result ) ? 'authorize' : $result;
 		}
@@ -1998,6 +2078,49 @@ class Manager {
 		}
 
 		return false;
+	}
+
+	/**
+	 * Determines whether a non-owner should be blocked from seizing connection ownership
+	 * via a full reconnect.
+	 *
+	 * A full reconnect re-registers the site and makes the authorizing user the connection
+	 * owner. On a site that already has a live owner, only that owner (or the deliberate
+	 * takeover flow) should be able to trigger it. When the owner is gone (never set, or the
+	 * WP user was deleted) this returns false as an escape hatch so a secondary admin can
+	 * still recover the site.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return bool True if the ownership-seizing reconnect should be blocked.
+	 */
+	private function is_ownership_seizing_reconnect_blocked() {
+		$owner_id = (int) \Jetpack_Options::get_option( 'master_user' );
+
+		// No owner on record, or the owner's WP user no longer exists: allow the reconnect
+		// as an escape hatch, otherwise the site would be permanently stuck.
+		if ( $owner_id <= 0 || ! get_userdata( $owner_id ) ) {
+			return false;
+		}
+
+		// The owner may always reconnect their own connection.
+		if ( get_current_user_id() === $owner_id ) {
+			return false;
+		}
+
+		/**
+		 * Filters whether a non-owner is blocked from seizing connection ownership via a
+		 * full reconnect.
+		 *
+		 * Return false to restore the legacy behavior where any user with the reconnect
+		 * capability could trigger a full reconnect (and thereby become the connection owner).
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool $blocked  Whether the ownership-seizing reconnect is blocked. Default true.
+		 * @param int  $owner_id The current connection owner's user ID.
+		 */
+		return (bool) apply_filters( 'jetpack_connection_block_ownership_seizing_reconnect', true, $owner_id );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/Error_Handler_Test.php
+++ b/projects/packages/connection/tests/php/Error_Handler_Test.php
@@ -57,6 +57,49 @@ class Error_Handler_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Insert a capable secondary admin (with jetpack_connect) and act as them.
+	 *
+	 * @param string $login A unique user login.
+	 * @return int The new user's ID.
+	 */
+	private function act_as_capable_admin( $login ) {
+		$admin_id = wp_insert_user(
+			array(
+				'user_login' => $login,
+				'user_pass'  => 'password',
+				'user_email' => $login . '@example.org',
+				'role'       => 'administrator',
+			)
+		);
+		get_user_by( 'id', $admin_id )->add_cap( 'jetpack_connect' );
+		wp_set_current_user( $admin_id );
+
+		return $admin_id;
+	}
+
+	/**
+	 * Build a deleted-owner invalid_connection_owner error stored under a nonexistent
+	 * master_user ID.
+	 *
+	 * @return array The verified-errors option value.
+	 */
+	private function deleted_owner_error_option() {
+		return array(
+			'invalid_connection_owner' => array(
+				'4242' => array(
+					'error_code'    => 'invalid_connection_owner',
+					'user_id'       => '4242',
+					'error_message' => 'Original message',
+					'error_data'    => array( 'has_user_token' => false ),
+					'timestamp'     => time(),
+					'nonce'         => 'nonce_gone',
+					'error_type'    => 'connection',
+				),
+			),
+		);
+	}
+
+	/**
 	 * Generates a sample WP_Error object in the same format Manager class does for broken signatures
 	 *
 	 * @param string $error_code The error code you want the error to have.
@@ -688,12 +731,12 @@ class Error_Handler_Test extends BaseTestCase {
 	public function test_handle_verified_errors() {
 		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
 
-		// Add an error that should trigger admin notices
-		$error = $this->get_sample_error( 'invalid_token', 1 );
+		// Add a site-wide (blog-token) error that is displayable to any viewer.
+		$error = $this->get_sample_error( 'invalid_token', 0 );
 		$this->error_handler->report_error( $error );
 
 		$stored_errors = $this->error_handler->get_stored_errors();
-		$this->error_handler->verify_error( $stored_errors['invalid_token']['1'] );
+		$this->error_handler->verify_error( $stored_errors['invalid_token']['0'] );
 
 		$this->error_handler->handle_verified_errors();
 
@@ -716,10 +759,10 @@ class Error_Handler_Test extends BaseTestCase {
 	 * Test get_displayable_errors method with displayable error
 	 */
 	public function test_displayable_errors_displayable_error() {
-		// Add a displayable error
+		// A site-wide (blog-token) error is visible to any admin viewer without collapsing.
 		$error = array(
 			'error_code'    => 'invalid_token',
-			'user_id'       => '1',
+			'user_id'       => '0',
 			'error_message' => 'Test message',
 			'error_data'    => array(),
 			'timestamp'     => time(),
@@ -729,26 +772,37 @@ class Error_Handler_Test extends BaseTestCase {
 
 		$verified_errors = array(
 			'invalid_token' => array(
-				'1' => $error,
+				'0' => $error,
 			),
 		);
 		update_option( Error_Handler::STORED_VERIFIED_ERRORS_OPTION, $verified_errors );
 
+		$viewer_id = wp_insert_user(
+			array(
+				'user_login' => 'displayable_viewer',
+				'user_pass'  => 'password',
+				'user_email' => 'displayable_viewer@example.org',
+				'role'       => 'administrator',
+			)
+		);
+		get_user_by( 'id', $viewer_id )->add_cap( 'jetpack_connect' );
+		wp_set_current_user( $viewer_id );
+
 		$result = $this->error_handler->get_displayable_errors();
 
 		$this->assertCount( 1, $result );
-		$this->assertStringContainsString( 'broken', $result['invalid_token']['1']['error_message'] );
-		$this->assertEquals( 'invalid_token', $result['invalid_token']['1']['error_code'] );
+		$this->assertStringContainsString( 'broken', $result['invalid_token']['0']['error_message'] );
+		$this->assertEquals( 'invalid_token', $result['invalid_token']['0']['error_code'] );
 	}
 
 	/**
 	 * Test get_displayable_errors method with filter (WoA site)
 	 */
 	public function test_displayable_errors_filter_woa_site() {
-		// Add a displayable error
+		// A site-wide (blog-token) error is visible to any admin viewer without collapsing.
 		$error = array(
 			'error_code'    => 'invalid_token',
-			'user_id'       => '1',
+			'user_id'       => '0',
 			'error_message' => 'Test message',
 			'error_data'    => array(),
 			'timestamp'     => time(),
@@ -758,16 +812,27 @@ class Error_Handler_Test extends BaseTestCase {
 
 		$verified_errors = array(
 			'invalid_token' => array(
-				'1' => $error,
+				'0' => $error,
 			),
 		);
 		update_option( Error_Handler::STORED_VERIFIED_ERRORS_OPTION, $verified_errors );
+
+		$viewer_id = wp_insert_user(
+			array(
+				'user_login' => 'woa_viewer',
+				'user_pass'  => 'password',
+				'user_email' => 'woa_viewer@example.org',
+				'role'       => 'administrator',
+			)
+		);
+		get_user_by( 'id', $viewer_id )->add_cap( 'jetpack_connect' );
+		wp_set_current_user( $viewer_id );
 
 		// Add filter that should be applied
 		add_filter(
 			'jetpack_connection_displayable_errors',
 			function ( $errors ) {
-				$errors['invalid_token']['1']['error_message'] = 'Filtered message for WoA';
+				$errors['invalid_token']['0']['error_message'] = 'Filtered message for WoA';
 				return $errors;
 			}
 		);
@@ -778,7 +843,7 @@ class Error_Handler_Test extends BaseTestCase {
 
 		// Verify the basic structure is correct
 		$this->assertCount( 1, $result );
-		$this->assertEquals( 'invalid_token', $result['invalid_token']['1']['error_code'] );
+		$this->assertEquals( 'invalid_token', $result['invalid_token']['0']['error_code'] );
 	}
 
 	/**
@@ -802,10 +867,10 @@ class Error_Handler_Test extends BaseTestCase {
 	 * Test handle_verified_errors method with displayable errors
 	 */
 	public function test_handle_verified_errors_with_displayable_errors() {
-		// Add a displayable error
+		// A site-wide (blog-token) error is displayable to any viewer.
 		$error = array(
 			'error_code'    => 'invalid_token',
-			'user_id'       => '1',
+			'user_id'       => '0',
 			'error_message' => 'Test message',
 			'error_data'    => array(),
 			'timestamp'     => time(),
@@ -815,7 +880,7 @@ class Error_Handler_Test extends BaseTestCase {
 
 		$verified_errors = array(
 			'invalid_token' => array(
-				'1' => $error,
+				'0' => $error,
 			),
 		);
 		update_option( Error_Handler::STORED_VERIFIED_ERRORS_OPTION, $verified_errors );
@@ -1135,12 +1200,25 @@ class Error_Handler_Test extends BaseTestCase {
 	 * Test jetpack_react_dashboard_error method
 	 */
 	public function test_jetpack_react_dashboard_error() {
-		// Add some test errors
+		// A capable admin viewer so site/owner errors are not collapsed.
+		$viewer_id = wp_insert_user(
+			array(
+				'user_login' => 'dashboard_viewer',
+				'user_pass'  => 'password',
+				'user_email' => 'dashboard_viewer@example.org',
+				'role'       => 'administrator',
+			)
+		);
+		get_user_by( 'id', $viewer_id )->add_cap( 'jetpack_connect' );
+		wp_set_current_user( $viewer_id );
+
+		// Add some test errors. The site-wide error (user 0) is the most actionable and is
+		// selected deterministically over the owner error.
 		$test_errors = array(
 			'invalid_token'       => array(
-				'1' => array(
+				'0' => array(
 					'error_code'    => 'invalid_token',
-					'user_id'       => '1',
+					'user_id'       => '0',
 					'error_message' => 'Test message',
 					'error_data'    => array( 'custom' => 'data' ),
 					'timestamp'     => time(),
@@ -1238,10 +1316,10 @@ class Error_Handler_Test extends BaseTestCase {
 	 * Test caching functionality of get_displayable_errors method
 	 */
 	public function test_get_displayable_errors_caching() {
-		// Add a displayable error
+		// A site-wide error, visible to an admin viewer without collapsing.
 		$error = array(
 			'error_code'    => 'invalid_token',
-			'user_id'       => '1',
+			'user_id'       => '0',
 			'error_message' => 'Test message',
 			'error_data'    => array(),
 			'timestamp'     => time(),
@@ -1251,10 +1329,21 @@ class Error_Handler_Test extends BaseTestCase {
 
 		$verified_errors = array(
 			'invalid_token' => array(
-				'1' => $error,
+				'0' => $error,
 			),
 		);
 		update_option( Error_Handler::STORED_VERIFIED_ERRORS_OPTION, $verified_errors );
+
+		$viewer_id = wp_insert_user(
+			array(
+				'user_login' => 'caching_viewer',
+				'user_pass'  => 'password',
+				'user_email' => 'caching_viewer@example.org',
+				'role'       => 'administrator',
+			)
+		);
+		get_user_by( 'id', $viewer_id )->add_cap( 'jetpack_connect' );
+		wp_set_current_user( $viewer_id );
 
 		// First call should process the data
 		$result1 = $this->error_handler->get_displayable_errors();
@@ -1273,10 +1362,22 @@ class Error_Handler_Test extends BaseTestCase {
 	 * Test cache invalidation when errors are modified
 	 */
 	public function test_cache_invalidation_on_error_modification() {
-		// Add initial error
+		// A capable admin viewer so distinct site errors are not collapsed.
+		$viewer_id = wp_insert_user(
+			array(
+				'user_login' => 'cache_mod_viewer',
+				'user_pass'  => 'password',
+				'user_email' => 'cache_mod_viewer@example.org',
+				'role'       => 'administrator',
+			)
+		);
+		get_user_by( 'id', $viewer_id )->add_cap( 'jetpack_connect' );
+		wp_set_current_user( $viewer_id );
+
+		// Add initial (site-wide) error
 		$error = array(
 			'error_code'    => 'invalid_token',
-			'user_id'       => '1',
+			'user_id'       => '0',
 			'error_message' => 'Test message',
 			'error_data'    => array(),
 			'timestamp'     => time(),
@@ -1286,7 +1387,7 @@ class Error_Handler_Test extends BaseTestCase {
 
 		$verified_errors = array(
 			'invalid_token' => array(
-				'1' => $error,
+				'0' => $error,
 			),
 		);
 		update_option( Error_Handler::STORED_VERIFIED_ERRORS_OPTION, $verified_errors );
@@ -1298,7 +1399,7 @@ class Error_Handler_Test extends BaseTestCase {
 		// Add a new error via verify_error (should invalidate cache)
 		$new_error = array(
 			'error_code'    => 'no_valid_user_token',
-			'user_id'       => '2',
+			'user_id'       => '0',
 			'error_message' => 'New error message',
 			'error_data'    => array(),
 			'timestamp'     => time(),
@@ -1318,10 +1419,10 @@ class Error_Handler_Test extends BaseTestCase {
 	 * Test cache invalidation when errors are deleted
 	 */
 	public function test_cache_invalidation_on_error_deletion() {
-		// Add initial error
+		// A site-wide error, visible to an admin viewer without collapsing.
 		$error = array(
 			'error_code'    => 'invalid_token',
-			'user_id'       => '1',
+			'user_id'       => '0',
 			'error_message' => 'Test message',
 			'error_data'    => array(),
 			'timestamp'     => time(),
@@ -1331,10 +1432,21 @@ class Error_Handler_Test extends BaseTestCase {
 
 		$verified_errors = array(
 			'invalid_token' => array(
-				'1' => $error,
+				'0' => $error,
 			),
 		);
 		update_option( Error_Handler::STORED_VERIFIED_ERRORS_OPTION, $verified_errors );
+
+		$viewer_id = wp_insert_user(
+			array(
+				'user_login' => 'cache_del_viewer',
+				'user_pass'  => 'password',
+				'user_email' => 'cache_del_viewer@example.org',
+				'role'       => 'administrator',
+			)
+		);
+		get_user_by( 'id', $viewer_id )->add_cap( 'jetpack_connect' );
+		wp_set_current_user( $viewer_id );
 
 		// First call to populate cache
 		$result1 = $this->error_handler->get_displayable_errors();
@@ -1398,12 +1510,25 @@ class Error_Handler_Test extends BaseTestCase {
 	 * Test jetpack_react_dashboard_error method with custom action
 	 */
 	public function test_jetpack_react_dashboard_error_with_custom_action() {
-		// Add a test error with custom action using a valid displayable error code
+		// A capable admin viewer so the error is not collapsed.
+		$viewer_id = wp_insert_user(
+			array(
+				'user_login' => 'dashboard_custom_viewer',
+				'user_pass'  => 'password',
+				'user_email' => 'dashboard_custom_viewer@example.org',
+				'role'       => 'administrator',
+			)
+		);
+		get_user_by( 'id', $viewer_id )->add_cap( 'jetpack_connect' );
+		wp_set_current_user( $viewer_id );
+
+		// A site-wide error carrying a custom action: the action is passed through to the
+		// dashboard unchanged (as consumer-injected errors rely on).
 		$test_errors = array(
 			'invalid_connection_owner' => array(
-				'1' => array(
+				'0' => array(
 					'error_code'    => 'invalid_connection_owner',
-					'user_id'       => '1',
+					'user_id'       => '0',
 					'error_message' => 'Test message',
 					'error_data'    => array( 'action' => 'create_missing_account' ),
 					'timestamp'     => time(),
@@ -1617,7 +1742,28 @@ class Error_Handler_Test extends BaseTestCase {
 	 * Test that get_displayable_errors classifies each error's audience by user ID.
 	 */
 	public function test_get_displayable_errors_classifies_audience() {
-		\Jetpack_Options::update_option( 'master_user', 7 );
+		$owner_id = wp_insert_user(
+			array(
+				'user_login' => 'owner_classify',
+				'user_pass'  => 'password',
+				'user_email' => 'owner_classify@example.org',
+				'role'       => 'administrator',
+			)
+		);
+		\Jetpack_Options::update_option( 'master_user', $owner_id );
+
+		// A capable admin viewer so site/owner errors are not collapsed. The user-audience
+		// error is attributed to the viewer so it is not omitted from their own set.
+		$viewer_id = wp_insert_user(
+			array(
+				'user_login' => 'viewer_classify',
+				'user_pass'  => 'password',
+				'user_email' => 'viewer_classify@example.org',
+				'role'       => 'administrator',
+			)
+		);
+		get_user_by( 'id', $viewer_id )->add_cap( 'jetpack_connect' );
+		wp_set_current_user( $viewer_id );
 
 		$make_error = function ( $error_code, $user_id ) {
 			return array(
@@ -1633,16 +1779,16 @@ class Error_Handler_Test extends BaseTestCase {
 
 		$verified_errors = array(
 			'invalid_token'       => array( '0' => $make_error( 'invalid_token', 0 ) ),
-			'no_valid_user_token' => array( '7' => $make_error( 'no_valid_user_token', 7 ) ),
-			'no_token_for_user'   => array( '3' => $make_error( 'no_token_for_user', 3 ) ),
+			'no_valid_user_token' => array( (string) $owner_id => $make_error( 'no_valid_user_token', $owner_id ) ),
+			'no_token_for_user'   => array( (string) $viewer_id => $make_error( 'no_token_for_user', $viewer_id ) ),
 		);
 		update_option( Error_Handler::STORED_VERIFIED_ERRORS_OPTION, $verified_errors );
 
 		$result = $this->error_handler->get_displayable_errors();
 
 		$this->assertSame( 'site', $result['invalid_token']['0']['audience'], 'A blog-token error (user 0) is site-wide.' );
-		$this->assertSame( 'owner', $result['no_valid_user_token']['7']['audience'], "The connection owner's token error is owner-scoped." );
-		$this->assertSame( 'user', $result['no_token_for_user']['3']['audience'], "A non-owner user's token error is user-scoped." );
+		$this->assertSame( 'owner', $result['no_valid_user_token'][ (string) $owner_id ]['audience'], "The connection owner's token error is owner-scoped." );
+		$this->assertSame( 'user', $result['no_token_for_user'][ (string) $viewer_id ]['audience'], "The viewer's own token error is user-scoped." );
 	}
 
 	/**
@@ -1693,10 +1839,18 @@ class Error_Handler_Test extends BaseTestCase {
 	 * error when connection ownership is locked (non-transferable).
 	 */
 	public function test_get_displayable_errors_locked_owner_shows_informational_notice() {
-		$owner_id = 999;
+		$owner_id = wp_insert_user(
+			array(
+				'user_login'   => 'locked_owner',
+				'user_pass'    => 'password',
+				'user_email'   => 'locked_owner@example.org',
+				'display_name' => 'Locked Owner',
+				'role'         => 'administrator',
+			)
+		);
 		\Jetpack_Options::update_option( 'master_user', $owner_id );
 
-		// Act as a secondary admin (a different user than the owner).
+		// Act as a capable secondary admin (a different user than the owner).
 		$admin_id = wp_insert_user(
 			array(
 				'user_login' => 'secondary_admin',
@@ -1707,6 +1861,7 @@ class Error_Handler_Test extends BaseTestCase {
 		);
 		$this->assertIsInt( $admin_id );
 		$this->assertNotSame( $owner_id, $admin_id );
+		get_user_by( 'id', $admin_id )->add_cap( 'jetpack_connect' );
 		wp_set_current_user( $admin_id );
 
 		// Lock ownership.
@@ -1732,11 +1887,19 @@ class Error_Handler_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test that a secondary admin still gets the reconnect CTA for an owner-token error
-	 * when ownership is transferable (the default model).
+	 * Test that a capable secondary admin is offered a deliberate "take over ownership"
+	 * CTA for a broken owner-token error when ownership is transferable (the default model).
 	 */
-	public function test_get_displayable_errors_transferable_owner_keeps_reconnect() {
-		$owner_id = 999;
+	public function test_get_displayable_errors_transferable_owner_offers_takeover() {
+		$owner_id = wp_insert_user(
+			array(
+				'user_login'   => 'transfer_owner',
+				'user_pass'    => 'password',
+				'user_email'   => 'transfer_owner@example.org',
+				'display_name' => 'Transfer Owner',
+				'role'         => 'administrator',
+			)
+		);
 		\Jetpack_Options::update_option( 'master_user', $owner_id );
 
 		$admin_id = wp_insert_user(
@@ -1747,6 +1910,7 @@ class Error_Handler_Test extends BaseTestCase {
 				'role'       => 'administrator',
 			)
 		);
+		get_user_by( 'id', $admin_id )->add_cap( 'jetpack_connect' );
 		wp_set_current_user( $admin_id );
 
 		// Ownership transferable is the default (no filter added).
@@ -1766,8 +1930,197 @@ class Error_Handler_Test extends BaseTestCase {
 
 		$displayed = $result['no_valid_user_token'][ (string) $owner_id ];
 		$this->assertSame( 'owner', $displayed['audience'] );
-		$this->assertArrayNotHasKey( 'action', $displayed['error_data'], 'No explicit action is emitted for the default behavior: readers fall back to the reconnect CTA.' );
-		$this->assertStringContainsString( 'broken', $displayed['error_message'] );
+		$this->assertSame( 'take_over_ownership', $displayed['error_data']['action'], 'A transferable owner error offers the takeover CTA to a capable admin.' );
+		$this->assertStringContainsString( 'take over ownership', $displayed['error_message'] );
+	}
+
+	/**
+	 * Test that a site-level fault attributed to the owner (invalid_signature) is NOT
+	 * eligible for takeover: it keeps the default reconnect behavior so a clock-skew or
+	 * domain-change fault can never suggest an ownership change.
+	 */
+	public function test_get_displayable_errors_excluded_code_keeps_reconnect() {
+		$owner_id = wp_insert_user(
+			array(
+				'user_login' => 'sig_owner',
+				'user_pass'  => 'password',
+				'user_email' => 'sig_owner@example.org',
+				'role'       => 'administrator',
+			)
+		);
+		\Jetpack_Options::update_option( 'master_user', $owner_id );
+
+		$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'secondary_admin',
+				'user_pass'  => 'password',
+				'user_email' => 'secondary_admin@example.org',
+				'role'       => 'administrator',
+			)
+		);
+		get_user_by( 'id', $admin_id )->add_cap( 'jetpack_connect' );
+		wp_set_current_user( $admin_id );
+
+		$error = array(
+			'error_code'    => 'invalid_signature',
+			'user_id'       => (string) $owner_id,
+			'error_message' => 'Original message',
+			'error_data'    => array(),
+			'timestamp'     => time(),
+			'nonce'         => 'nonce_sig',
+			'error_type'    => 'xmlrpc',
+		);
+		update_option( Error_Handler::STORED_VERIFIED_ERRORS_OPTION, array( 'invalid_signature' => array( (string) $owner_id => $error ) ) );
+
+		$result = $this->error_handler->get_displayable_errors();
+
+		$displayed = $result['invalid_signature'][ (string) $owner_id ];
+		$this->assertSame( 'owner', $displayed['audience'] );
+		$this->assertArrayNotHasKey( 'action', $displayed['error_data'], 'An excluded (site-level) code must not offer takeover; readers fall back to reconnect.' );
+	}
+
+	/**
+	 * Test the deleted-owner flavor on the transferable model: when master_user points at
+	 * a WP user that no longer exists, takeover is offered (the only remedy) with
+	 * account-gone messaging.
+	 */
+	public function test_get_displayable_errors_deleted_owner_transferable_offers_takeover() {
+		// master_user points at a nonexistent WP user.
+		\Jetpack_Options::update_option( 'master_user', 4242 );
+		$this->act_as_capable_admin( 'deleted_owner_admin' );
+
+		update_option( Error_Handler::STORED_VERIFIED_ERRORS_OPTION, $this->deleted_owner_error_option() );
+
+		$result    = $this->error_handler->get_displayable_errors();
+		$displayed = $result['invalid_connection_owner']['4242'];
+		$this->assertSame( 'take_over_ownership', $displayed['error_data']['action'] );
+		$this->assertStringContainsString( 'no longer exists', $displayed['error_message'] );
+	}
+
+	/**
+	 * Test the deleted-owner flavor on the locked model: an informational notice is shown
+	 * without the misleading "needs to reconnect" phrasing.
+	 */
+	public function test_get_displayable_errors_deleted_owner_locked_is_informational() {
+		// master_user points at a nonexistent WP user.
+		\Jetpack_Options::update_option( 'master_user', 4242 );
+		$this->act_as_capable_admin( 'deleted_owner_locked_admin' );
+
+		add_filter( 'jetpack_connection_ownership_transferable', '__return_false' );
+
+		update_option( Error_Handler::STORED_VERIFIED_ERRORS_OPTION, $this->deleted_owner_error_option() );
+
+		$result    = $this->error_handler->get_displayable_errors();
+		$displayed = $result['invalid_connection_owner']['4242'];
+		$this->assertSame( 'none', $displayed['error_data']['action'] );
+		$this->assertStringContainsString( 'no longer exists', $displayed['error_message'] );
+		$this->assertStringNotContainsString( 'needs to reconnect', $displayed['error_message'] );
+	}
+
+	/**
+	 * Test that a specific (non-owner) user's token error is omitted from every other
+	 * viewer's set: only that user should see (and can act on) their own error.
+	 */
+	public function test_get_displayable_errors_omits_other_users_errors() {
+		$owner_id = wp_insert_user(
+			array(
+				'user_login' => 'omit_owner',
+				'user_pass'  => 'password',
+				'user_email' => 'omit_owner@example.org',
+				'role'       => 'administrator',
+			)
+		);
+		\Jetpack_Options::update_option( 'master_user', $owner_id );
+
+		$viewer_id = wp_insert_user(
+			array(
+				'user_login' => 'omit_viewer',
+				'user_pass'  => 'password',
+				'user_email' => 'omit_viewer@example.org',
+				'role'       => 'administrator',
+			)
+		);
+		get_user_by( 'id', $viewer_id )->add_cap( 'jetpack_connect' );
+		wp_set_current_user( $viewer_id );
+
+		$other_user_id = 7654;
+		$error         = array(
+			'error_code'    => 'no_token_for_user',
+			'user_id'       => (string) $other_user_id,
+			'error_message' => 'Another user error',
+			'error_data'    => array(),
+			'timestamp'     => time(),
+			'nonce'         => 'nonce_other',
+			'error_type'    => 'xmlrpc',
+		);
+		update_option( Error_Handler::STORED_VERIFIED_ERRORS_OPTION, array( 'no_token_for_user' => array( (string) $other_user_id => $error ) ) );
+
+		$result = $this->error_handler->get_displayable_errors();
+
+		$this->assertArrayNotHasKey( 'no_token_for_user', $result, "Another user's token error must not be shown to this viewer." );
+	}
+
+	/**
+	 * Test that a viewer who cannot manage the connection sees their own user error but
+	 * has all site/owner errors collapsed into a single diagnostics-free generic notice.
+	 */
+	public function test_get_displayable_errors_collapses_for_non_manager() {
+		$owner_id = wp_insert_user(
+			array(
+				'user_login' => 'collapse_owner',
+				'user_pass'  => 'password',
+				'user_email' => 'collapse_owner@example.org',
+				'role'       => 'administrator',
+			)
+		);
+		\Jetpack_Options::update_option( 'master_user', $owner_id );
+
+		// A viewer without jetpack_connect (e.g. a contributor) who also has their own
+		// broken user token.
+		$viewer_id = wp_insert_user(
+			array(
+				'user_login' => 'collapse_viewer',
+				'user_pass'  => 'password',
+				'user_email' => 'collapse_viewer@example.org',
+				'role'       => 'contributor',
+			)
+		);
+		wp_set_current_user( $viewer_id );
+
+		$make_error = function ( $error_code, $user_id ) {
+			return array(
+				'error_code'    => $error_code,
+				'user_id'       => (string) $user_id,
+				'error_message' => 'Test message',
+				'error_data'    => array(),
+				'timestamp'     => time(),
+				'nonce'         => 'nonce_' . $user_id,
+				'error_type'    => 'xmlrpc',
+			);
+		};
+
+		$verified_errors = array(
+			'invalid_token'       => array( '0' => $make_error( 'invalid_token', 0 ) ),
+			'no_valid_user_token' => array( (string) $owner_id => $make_error( 'no_valid_user_token', $owner_id ) ),
+			'no_token_for_user'   => array( (string) $viewer_id => $make_error( 'no_token_for_user', $viewer_id ) ),
+		);
+		update_option( Error_Handler::STORED_VERIFIED_ERRORS_OPTION, $verified_errors );
+
+		$result = $this->error_handler->get_displayable_errors();
+
+		// Site/owner errors are collapsed away.
+		$this->assertArrayNotHasKey( 'invalid_token', $result );
+		$this->assertArrayNotHasKey( 'no_valid_user_token', $result );
+
+		// The viewer keeps their own user error.
+		$this->assertArrayHasKey( 'no_token_for_user', $result );
+
+		// A single diagnostics-free generic notice replaces the site/owner errors.
+		$this->assertArrayHasKey( 'connection_error_generic', $result );
+		$generic = $result['connection_error_generic']['0'];
+		$this->assertSame( 'none', $generic['error_data']['action'] );
+		$this->assertArrayNotHasKey( 'timestamp', $generic, 'The generic notice must not leak diagnostic data.' );
+		$this->assertStringContainsString( 'contact a site administrator', $generic['error_message'] );
 	}
 
 	/**
@@ -1842,7 +2195,8 @@ class Error_Handler_Test extends BaseTestCase {
 
 	/**
 	 * Test that the owner's display name is not exposed to viewers who cannot act on
-	 * connection issues (no jetpack_connect capability): displayable errors are printed
+	 * connection issues (no jetpack_connect capability): owner errors are collapsed into a
+	 * diagnostics-free generic notice that names no one. Displayable errors are printed
 	 * into the initial state for any logged-in user loading connection scripts.
 	 */
 	public function test_get_displayable_errors_hides_owner_name_without_capability() {
@@ -1868,9 +2222,6 @@ class Error_Handler_Test extends BaseTestCase {
 		);
 		wp_set_current_user( $contributor_id );
 
-		// Lock ownership so the informational branch (the only one naming the owner) runs.
-		add_filter( 'jetpack_connection_ownership_transferable', '__return_false' );
-
 		$error = array(
 			'error_code'    => 'no_valid_user_token',
 			'user_id'       => (string) $owner_id,
@@ -1884,10 +2235,11 @@ class Error_Handler_Test extends BaseTestCase {
 
 		$result = $this->error_handler->get_displayable_errors();
 
-		$displayed = $result['no_valid_user_token'][ (string) $owner_id ];
-		$this->assertSame( 'none', $displayed['error_data']['action'] );
-		$this->assertStringNotContainsString( 'Owner Person', $displayed['error_message'], 'The owner name must not be exposed to low-capability viewers.' );
-		$this->assertStringContainsString( 'reconnect their WordPress.com account', $displayed['error_message'], 'The nameless informational variant is used instead.' );
+		// The owner error is collapsed into the generic notice for a non-manager.
+		$this->assertArrayNotHasKey( 'no_valid_user_token', $result );
+		$this->assertArrayHasKey( 'connection_error_generic', $result );
+		$generic = $result['connection_error_generic']['0'];
+		$this->assertStringNotContainsString( 'Owner Person', $generic['error_message'], 'The owner name must not be exposed to low-capability viewers.' );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/ManagerTest.php
+++ b/projects/packages/connection/tests/php/ManagerTest.php
@@ -680,9 +680,9 @@ class ManagerTest extends TestCase {
 			)
 		);
 
-		$this->manager->method( 'get_connection_owner_id' )
-			->withAnyParameters()
-			->willReturn( $admin_id );
+		// The current owner is derived from the master_user record (not the token-derived
+		// owner, which is false exactly when the owner's token is broken).
+		Jetpack_Options::update_option( 'master_user', $admin_id );
 
 		$expected = new WP_Error( 'new_owner_is_existing_owner', __( 'New owner is same as existing owner', 'jetpack-connection' ), array( 'status' => 400 ) );
 
@@ -847,6 +847,170 @@ class ManagerTest extends TestCase {
 
 		// Verify that the cache properly reflects the updated owner.
 		$this->assertEquals( $admin3_id, $this->manager->get_connection_owner_id() );
+	}
+
+	/**
+	 * Test that an ownership takeover is refused when a consumer has locked ownership.
+	 */
+	public function test_update_connection_owner_refused_when_ownership_locked() {
+		$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'locked_admin',
+				'user_pass'  => 'pass',
+				'user_email' => 'locked_admin@admin.com',
+				'role'       => 'administrator',
+			)
+		);
+
+		add_filter( 'jetpack_connection_ownership_transferable', '__return_false' );
+
+		// The WPCOM ownership call must never be attempted when ownership is locked.
+		$this->manager->expects( $this->never() )
+			->method( 'update_connection_owner_wpcom' );
+
+		$result = $this->manager->update_connection_owner( $admin_id );
+
+		remove_filter( 'jetpack_connection_ownership_transferable', '__return_false' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'ownership_locked', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that a successful ownership change fires the jetpack_connection_owner_changed
+	 * action with the previous and new owner IDs.
+	 */
+	public function test_update_connection_owner_fires_owner_changed_hook() {
+		$old_owner_id = wp_insert_user(
+			array(
+				'user_login' => 'old_owner',
+				'user_pass'  => 'pass',
+				'user_email' => 'old_owner@admin.com',
+				'role'       => 'administrator',
+			)
+		);
+		$new_owner_id = wp_insert_user(
+			array(
+				'user_login' => 'new_owner',
+				'user_pass'  => 'pass',
+				'user_email' => 'new_owner@admin.com',
+				'role'       => 'administrator',
+			)
+		);
+		Jetpack_Options::update_option( 'master_user', $old_owner_id );
+
+		$this->tokens->method( 'get_access_token' )
+			->willReturn(
+				(object) array(
+					'secret'           => 'abcd1234',
+					'external_user_id' => $new_owner_id,
+				)
+			);
+		$this->manager->method( 'update_connection_owner_wpcom' )->willReturn( true );
+
+		$fired = array();
+		add_action(
+			'jetpack_connection_owner_changed',
+			function ( $old, $new ) use ( &$fired ) {
+				$fired = array( $old, $new );
+			},
+			10,
+			2
+		);
+
+		$result = $this->manager->update_connection_owner( $new_owner_id );
+
+		remove_all_actions( 'jetpack_connection_owner_changed' );
+
+		$this->assertTrue( $result );
+		$this->assertSame( array( $old_owner_id, $new_owner_id ), $fired, 'The owner-changed hook receives the previous and new owner IDs.' );
+	}
+
+	/**
+	 * Test that a non-owner cannot silently seize ownership via a full reconnect: when a
+	 * live owner exists and only the user token is unhealthy alongside an unhealthy blog
+	 * token, restore() refuses to escalate to a full reconnect.
+	 */
+	public function test_restore_blocks_non_owner_ownership_seizing_reconnect() {
+		$owner_id = wp_insert_user(
+			array(
+				'user_login' => 'restore_owner',
+				'user_pass'  => 'pass',
+				'user_email' => 'restore_owner@admin.com',
+				'role'       => 'administrator',
+			)
+		);
+		$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'restore_admin',
+				'user_pass'  => 'pass',
+				'user_email' => 'restore_admin@admin.com',
+				'role'       => 'administrator',
+			)
+		);
+		Jetpack_Options::update_option( 'master_user', $owner_id );
+		wp_set_current_user( $admin_id );
+
+		$manager = $this->getMockBuilder( Manager::class )
+			->onlyMethods( array( 'is_site_connection', 'get_tokens', 'reconnect' ) )
+			->getMock();
+		$manager->method( 'is_site_connection' )->willReturn( false );
+		$manager->expects( $this->never() )->method( 'reconnect' );
+
+		$tokens = $this->getMockBuilder( Tokens::class )
+			->onlyMethods( array( 'validate' ) )
+			->getMock();
+		$tokens->method( 'validate' )->willReturn(
+			array(
+				'blog_token' => array( 'is_healthy' => false ),
+				'user_token' => array( 'is_healthy' => false ),
+			)
+		);
+		$manager->method( 'get_tokens' )->willReturn( $tokens );
+
+		$result = $manager->restore();
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'reconnect_owner_required', $result->get_error_code() );
+	}
+
+	/**
+	 * Test the owner-is-gone escape hatch: when master_user points at a deleted user, a
+	 * secondary admin is still allowed to trigger a full reconnect so the site is not stuck.
+	 */
+	public function test_restore_allows_reconnect_when_owner_is_gone() {
+		$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'rescue_admin',
+				'user_pass'  => 'pass',
+				'user_email' => 'rescue_admin@admin.com',
+				'role'       => 'administrator',
+			)
+		);
+		// master_user points at a nonexistent WP user.
+		Jetpack_Options::update_option( 'master_user', 987654 );
+		wp_set_current_user( $admin_id );
+
+		$manager = $this->getMockBuilder( Manager::class )
+			->onlyMethods( array( 'is_site_connection', 'get_tokens', 'reconnect' ) )
+			->getMock();
+		$manager->method( 'is_site_connection' )->willReturn( false );
+		$manager->expects( $this->once() )->method( 'reconnect' )->willReturn( true );
+
+		$tokens = $this->getMockBuilder( Tokens::class )
+			->onlyMethods( array( 'validate' ) )
+			->getMock();
+		$tokens->method( 'validate' )->willReturn(
+			array(
+				'blog_token' => array( 'is_healthy' => false ),
+				'user_token' => array( 'is_healthy' => false ),
+			)
+		);
+		$manager->method( 'get_tokens' )->willReturn( $tokens );
+
+		$result = $manager->restore();
+
+		$this->assertSame( 'authorize', $result, 'When the owner is gone, a full reconnect is allowed (returns authorize).' );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

**Draft — starting point for resuming the connection-ownership work.** The audience-only, CTA-independent pieces have been split into a separate, mergeable PR; everything else remains here as a reference.

* Add a deliberate "take over ownership" action for admins when the connection owner's token is broken (transferable model), replacing the previous accidental ownership claim during a reconnect.
* Harden `Manager::update_connection_owner()`: gate on `is_ownership_transferable()`, fire a new `jetpack_connection_owner_changed` action, record Tracks events, and clean up the previous owner's stale token/errors/transients.
* Add a `Manager::restore()` escalation gate so a non-owner can't silently seize ownership via a full reconnect, with an escape hatch when the recorded owner is gone.
* Viewer-scoped omission of other users' errors, non-admin error collapsing into a single generic notice, and deterministic notice ordering (site > own-user > owner).
* JS: `setConnectionOwner` API method, `useTakeOverConnection` hook, and a built-in `take_over_ownership` CTA wired through the connection error notice.

## Related product discussion/links


## Does this pull request change what data or activity we track or use?

Adds `set_connection_owner_attempt`/`_success`/`_failure` Tracks events on ownership change.

## Testing instructions

* This is a draft and not intended to be merged as-is. See the split-out audience PR for the mergeable slice.
* To exercise locally: as a secondary admin on a site whose connection owner token is broken, confirm the "take over ownership" CTA appears (transferable model) and completes the takeover.
