### PR TITLE
Connection: expose error audience to the Jetpack dashboard

### DIFF
--- a/projects/packages/connection/changelog/add-connection-error-audience
+++ b/projects/packages/connection/changelog/add-connection-error-audience
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Connection: Expose the connection-error audience (site/owner/user) to the Jetpack dashboard so error notices can be tailored to the viewer.

--- a/projects/packages/connection/src/class-error-handler.php
+++ b/projects/packages/connection/src/class-error-handler.php
@@ -478,6 +478,11 @@ class Error_Handler {
 			}
 		}
 
+		// Expose the error audience (site/owner/user) so the dashboard can render
+		// audience-aware copy. Falls back to site-wide for consumer-injected errors
+		// that predate the audience field.
+		$dashboard_data['audience'] = $first_error['audience'] ?? 'site';
+
 		$dashboard_error = array(
 			array(
 				'code'    => 'connection_error',

--- a/projects/packages/connection/src/class-error-handler.php
+++ b/projects/packages/connection/src/class-error-handler.php
@@ -433,7 +433,8 @@ class Error_Handler {
 	 *                   'action' => 'reconnect',
 	 *                   'data' => [
 	 *                     'api_error_code' => 'invalid_token',
-	 *                     'action' => 'reconnect'
+	 *                     'action' => 'reconnect',
+	 *                     'audience' => 'site' // Who the error is relevant to: 'site', 'owner', or 'user'.
 	 *                   ]
 	 *                 ]
 	 *               ]

--- a/projects/packages/connection/tests/php/Error_Handler_Test.php
+++ b/projects/packages/connection/tests/php/Error_Handler_Test.php
@@ -1426,27 +1426,14 @@ class Error_Handler_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test that jetpack_react_dashboard_error() exposes the error audience in its data
-	 * payload so the dashboard can render audience-aware copy. The audience is a
-	 * top-level field on the displayable error, so it must be threaded through the
-	 * reshape rather than being dropped with the other non-error_data fields.
+	 * Test that jetpack_react_dashboard_error() exposes a site-scoped audience.
+	 *
+	 * The audience is a top-level field on the displayable error, so it must be
+	 * threaded through the reshape rather than being dropped with the other
+	 * non-error_data fields. A blog-token error (user_id 0) is site-scoped.
 	 */
-	public function test_jetpack_react_dashboard_error_includes_audience() {
-		// A blog-token error (user_id 0) is site-scoped.
-		$test_errors = array(
-			'invalid_token' => array(
-				'0' => array(
-					'error_code'    => 'invalid_token',
-					'user_id'       => '0',
-					'error_message' => 'Test message',
-					'error_data'    => array(),
-					'timestamp'     => time(),
-					'nonce'         => 'test_nonce',
-					'error_type'    => 'xmlrpc',
-				),
-			),
-		);
-		update_option( Error_Handler::STORED_VERIFIED_ERRORS_OPTION, $test_errors );
+	public function test_jetpack_react_dashboard_error_includes_site_audience() {
+		$this->store_single_verified_error( 'invalid_token', '0' );
 
 		$result = $this->error_handler->jetpack_react_dashboard_error( array() );
 
@@ -1454,6 +1441,69 @@ class Error_Handler_Test extends BaseTestCase {
 		$this->assertCount( 1, $result );
 		$this->assertArrayHasKey( 'audience', $result[0]['data'], 'The dashboard error data must expose the audience.' );
 		$this->assertSame( 'site', $result[0]['data']['audience'], 'A blog-token (user_id 0) error is site-scoped.' );
+	}
+
+	/**
+	 * Test that jetpack_react_dashboard_error() exposes an owner-scoped audience:
+	 * an error stored under the connection owner's (master_user) ID.
+	 */
+	public function test_jetpack_react_dashboard_error_includes_owner_audience() {
+		$owner_id = wp_insert_user(
+			array(
+				'user_login' => 'dashboard_owner',
+				'user_pass'  => 'password',
+				'user_email' => 'dashboard_owner@example.org',
+				'role'       => 'administrator',
+			)
+		);
+		$this->assertIsInt( $owner_id );
+		\Jetpack_Options::update_option( 'master_user', $owner_id );
+
+		$this->store_single_verified_error( 'no_valid_user_token', (string) $owner_id );
+
+		$result = $this->error_handler->jetpack_react_dashboard_error( array() );
+
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'owner', $result[0]['data']['audience'], 'An error under the master_user ID is owner-scoped.' );
+	}
+
+	/**
+	 * Test that jetpack_react_dashboard_error() exposes a user-scoped audience: an
+	 * error tied to a specific (non-owner) user's token. With no connection owner on
+	 * record, a positive user ID is classified as that user's error.
+	 */
+	public function test_jetpack_react_dashboard_error_includes_user_audience() {
+		$this->store_single_verified_error( 'no_valid_user_token', '5' );
+
+		$result = $this->error_handler->jetpack_react_dashboard_error( array() );
+
+		$this->assertCount( 1, $result );
+		$this->assertSame( 'user', $result[0]['data']['audience'], "A non-owner user's token error is user-scoped." );
+	}
+
+	/**
+	 * Stores a single verified error under a given error code and user ID.
+	 *
+	 * @param string $error_code The (displayable) error code.
+	 * @param string $user_id    The user ID key the error is stored under.
+	 */
+	private function store_single_verified_error( $error_code, $user_id ) {
+		update_option(
+			Error_Handler::STORED_VERIFIED_ERRORS_OPTION,
+			array(
+				$error_code => array(
+					$user_id => array(
+						'error_code'    => $error_code,
+						'user_id'       => $user_id,
+						'error_message' => 'Test message',
+						'error_data'    => array(),
+						'timestamp'     => time(),
+						'nonce'         => 'test_nonce',
+						'error_type'    => 'xmlrpc',
+					),
+				),
+			)
+		);
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/Error_Handler_Test.php
+++ b/projects/packages/connection/tests/php/Error_Handler_Test.php
@@ -1426,6 +1426,37 @@ class Error_Handler_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test that jetpack_react_dashboard_error() exposes the error audience in its data
+	 * payload so the dashboard can render audience-aware copy. The audience is a
+	 * top-level field on the displayable error, so it must be threaded through the
+	 * reshape rather than being dropped with the other non-error_data fields.
+	 */
+	public function test_jetpack_react_dashboard_error_includes_audience() {
+		// A blog-token error (user_id 0) is site-scoped.
+		$test_errors = array(
+			'invalid_token' => array(
+				'0' => array(
+					'error_code'    => 'invalid_token',
+					'user_id'       => '0',
+					'error_message' => 'Test message',
+					'error_data'    => array(),
+					'timestamp'     => time(),
+					'nonce'         => 'test_nonce',
+					'error_type'    => 'xmlrpc',
+				),
+			),
+		);
+		update_option( Error_Handler::STORED_VERIFIED_ERRORS_OPTION, $test_errors );
+
+		$result = $this->error_handler->jetpack_react_dashboard_error( array() );
+
+		$this->assertIsArray( $result );
+		$this->assertCount( 1, $result );
+		$this->assertArrayHasKey( 'audience', $result[0]['data'], 'The dashboard error data must expose the audience.' );
+		$this->assertSame( 'site', $result[0]['data']['audience'], 'A blog-token (user_id 0) error is site-scoped.' );
+	}
+
+	/**
 	 * Test build_action_error_data method with default values
 	 */
 	public function test_build_action_error_data_defaults() {


### PR DESCRIPTION
## Proposed changes

* `Error_Handler::jetpack_react_dashboard_error()` reshapes a displayable connection error into the dashboard's `{ code, message, action, data }` structure. The `audience` classification (`site` / `owner` / `user`) is a **top-level** field on the displayable error, so it was dropped by the reshape (only `error_data` sub-keys survived).
* This threads `audience` into the `data` payload, defaulting to `site` for consumer-injected errors that predate the field, so the Jetpack plugin's React dashboard can render audience-aware error copy.

This is a small follow-up to #50662 (viewer- and owner-aware connection error notices). The modern shared `use-connection-error-notice` path already carries `audience` end-to-end via initial state; this closes the same gap for the legacy Jetpack-plugin dashboard surface.

## Related product discussion/links


## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run `jetpack test php packages/connection` — see `test_jetpack_react_dashboard_error_includes_audience`.
* Alternatively, trigger a connection error on a site running the Jetpack plugin and confirm the dashboard error object's `data.audience` reflects the error's audience (`site` for a blog-token error, `owner` for the connection owner's token, `user` for another user's token).
