### PR TITLE
Podcast: align settings checklist wording with the controls it points to

### DIFF
--- a/projects/packages/podcast/changelog/pods-208-checklist-wording
+++ b/projects/packages/podcast/changelog/pods-208-checklist-wording
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Settings: align setup checklist wording with the controls it points to.

--- a/projects/packages/podcast/src/dashboard/distribution/index.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/index.tsx
@@ -162,7 +162,7 @@ const DistributionTab = ( { onEditSettings }: DistributionTabProps ) => {
 							) : (
 								<Text variant="muted">
 									{ __(
-										'Set your podcast category to generate the feed URL you can submit to directories.',
+										'Set your post category to generate the feed URL you can submit to directories.',
 										'jetpack-podcast'
 									) }
 								</Text>

--- a/projects/packages/podcast/src/dashboard/distribution/podcast-apps/pocketcasts/submit-modal.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/podcast-apps/pocketcasts/submit-modal.tsx
@@ -118,7 +118,7 @@ const PocketCastsSubmitModal = ( { app, feedUrl, onClose, onFirstSave }: Podcast
 								'jetpack-podcast'
 						  )
 						: __(
-								'Set your podcast category in the Settings tab to generate your RSS feed before submitting.',
+								'Set your post category in the Settings tab to generate your RSS feed before submitting.',
 								'jetpack-podcast'
 						  ) }
 				</Text>

--- a/projects/packages/podcast/src/dashboard/distribution/submit-modal.tsx
+++ b/projects/packages/podcast/src/dashboard/distribution/submit-modal.tsx
@@ -244,7 +244,7 @@ const SubmitModal = ( { app, feedUrl, onClose, onFirstSave }: PodcastAppModalPro
 									app.name
 							  )
 							: __(
-									'Set your podcast category in the Settings tab to generate your RSS feed URL.',
+									'Set your post category in the Settings tab to generate your RSS feed URL.',
 									'jetpack-podcast'
 							  ) }
 					</Text>

--- a/projects/packages/podcast/src/dashboard/episodes/index.tsx
+++ b/projects/packages/podcast/src/dashboard/episodes/index.tsx
@@ -319,7 +319,7 @@ const EpisodesTab = () => {
 				</h2>
 				<p>
 					{ __(
-						'Set a podcast category in your podcasting settings to start showing episodes here.',
+						'Set a post category in your podcasting settings to start showing episodes here.',
 						'jetpack-podcast'
 					) }
 				</p>

--- a/projects/packages/podcast/src/dashboard/hooks/use-validation-issues.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-validation-issues.ts
@@ -24,7 +24,7 @@ export const getValidationIssues = ( settings: PodcastSettings | undefined ): st
 	}
 	const issues: string[] = [];
 	if ( ! settings.podcasting_category_id ) {
-		issues.push( __( 'Choose a category to use as your podcast feed.', 'jetpack-podcast' ) );
+		issues.push( __( 'Choose a post category to use as your podcast feed.', 'jetpack-podcast' ) );
 	}
 	if ( ! settings.podcasting_title ) {
 		issues.push( __( 'Add a podcast title.', 'jetpack-podcast' ) );
@@ -43,7 +43,7 @@ export const getValidationIssues = ( settings: PodcastSettings | undefined ): st
 		);
 	}
 	if ( ! settings.podcasting_category_1 ) {
-		issues.push( __( 'Pick at least one Apple Podcasts category.', 'jetpack-podcast' ) );
+		issues.push( __( 'Pick at least one podcast topic.', 'jetpack-podcast' ) );
 	}
 	if ( ! settings.podcasting_image ) {
 		issues.push( __( 'Upload a cover image at least 1400×1400 pixels.', 'jetpack-podcast' ) );

--- a/projects/packages/podcast/src/dashboard/settings/index.tsx
+++ b/projects/packages/podcast/src/dashboard/settings/index.tsx
@@ -364,7 +364,7 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 							{ subtopicHints.length > 0 && (
 								<Notice status="warning" isDismissible={ false }>
 									{ __(
-										'These categories have subcategories. Picking one helps Apple Podcasts and other directories place your show accurately:',
+										'These topics have subtopics. Picking one helps Apple Podcasts and other directories place your show accurately:',
 										'jetpack-podcast'
 									) }
 									<ul className="podcast__settings-issues">

--- a/projects/packages/podcast/src/dashboard/welcome/index.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/index.tsx
@@ -113,14 +113,14 @@ const PAID_FEATURES_SELF_HOSTED: ReadonlyArray< string > = [
 const STEPS: ReadonlyArray< { number: string; title: string; body: string } > = [
 	{
 		number: '1',
-		title: __( 'Pick a category', 'jetpack-podcast' ),
-		body: __( 'Choose or create the category that holds your episodes.', 'jetpack-podcast' ),
+		title: __( 'Pick a post category', 'jetpack-podcast' ),
+		body: __( 'Choose or create the post category that holds your episodes.', 'jetpack-podcast' ),
 	},
 	{
 		number: '2',
 		title: __( 'Publish a post with audio', 'jetpack-podcast' ),
 		body: __(
-			'Add an audio or podcast episode block to any post and assign it to your podcast category.',
+			'Add an audio or podcast episode block to any post and assign it to your post category.',
 			'jetpack-podcast'
 		),
 	},


### PR DESCRIPTION
Fixes PODS-208

### Proposed changes

The podcast settings checklist used the word "category" for two different things, so one warning pointed at a control the user couldn't find:

* **"Pick at least one Apple Podcasts category."** — satisfied by the **Podcast topics** field. Nothing on the page is labeled "Apple Podcasts category", so a user reading the checklist has no obvious target.
* **"Choose a category to use as your podcast feed."** — satisfied by the **Post category** picker, a completely different control that happens to share the word.

This renames the checklist items to match the controls, and applies the same vocabulary to the rest of the dashboard so the distinction holds up everywhere:

* Checklist: `Pick at least one Apple Podcasts category.` → `Pick at least one podcast topic.`
* Checklist: `Choose a category…` → `Choose a post category…`
* Topics subtopic notice: "These categories have subcategories" → "These topics have subtopics"
* Distribution tab, both submit modals, Episodes empty state, Welcome steps 1 & 2: "podcast category" → "post category"

Settled vocabulary: **Post category** is the WordPress category whose posts become episodes; **Podcast topics** is the Apple taxonomy emitted as `<itunes:category>`. The existing help text under the topics field already explains that mapping, so dropping "Apple Podcasts" from the checklist item loses nothing.

String changes only — no logic, markup, or behavior touched.

## Does this pull request change what data or activity we track or use?

No

### Testing instructions

On a site with the Podcast module active, go to **Jetpack → Podcast**.

1. **Welcome screen** (podcasting not yet enabled): step 1 reads "Pick a post category" / "Choose or create the post category that holds your episodes."; step 2 ends with "…assign it to your post category."
2. Enable podcasting, then open the **Settings** tab with a fresh/empty configuration. The yellow "Finish setting up your podcast" notice should list:
   * "Choose a post category to use as your podcast feed."
   * "Pick at least one podcast topic."
3. Select a value in the **Podcast topics** field. The "Pick at least one podcast topic." item disappears from the checklist — the label now matches the control that clears it.
4. Pick a top-level topic that has subtopics (e.g. **Arts**, **Business**). The warning below the field reads "These topics have subtopics. Picking one helps Apple Podcasts and other directories place your show accurately:".
5. **Episodes** tab with no post category set: empty state reads "Set a post category in your podcasting settings to start showing episodes here."
6. **Distribution** tab with no post category set: the RSS feed section reads "Set your post category to generate the feed URL you can submit to directories." Open any directory's submit modal — it reads "Set your post category in the Settings tab to generate your RSS feed URL." (Pocket Casts: "…to generate your RSS feed before submitting.")

No saved data changes, so an already-configured site should look identical apart from the copy.
