### PR TITLE
VideoPress: improve escaping of block attributes rendered into inline styles

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-poster-css-escaping
+++ b/projects/packages/videopress/changelog/fix-videopress-poster-css-escaping
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+VideoPress: improve escaping of block attributes rendered into inline styles.

--- a/projects/packages/videopress/src/class-initializer.php
+++ b/projects/packages/videopress/src/class-initializer.php
@@ -244,9 +244,17 @@ class Initializer {
 
 		// Inline style.
 		$style     = '';
-		$max_width = $block_attributes['maxWidth'] ?? null;
+		$max_width = isset( $block_attributes['maxWidth'] ) && is_string( $block_attributes['maxWidth'] )
+			? trim( $block_attributes['maxWidth'] )
+			: '';
 
-		if ( $max_width && $max_width !== '100%' ) {
+		// maxWidth is rendered into an inline style. Accept only a plain CSS length
+		// or percentage so the value stays a single, well-formed declaration;
+		// anything else is dropped and the block renders at full width (as with the
+		// "100%" default).
+		if ( '' !== $max_width && '100%' !== $max_width
+			&& preg_match( '/^\d+(\.\d+)?(px|%|em|rem|vw|vh|vmin|vmax|ch|ex|cm|mm|in|pt|pc|q)$/i', $max_width )
+		) {
 			$style    = sprintf( 'max-width: %s;', $max_width );
 			$classes .= ' wp-block-jetpack-videopress--has-max-width';
 		}
@@ -309,10 +317,18 @@ class Initializer {
 			// Create inline style in case video has a custom poster.
 			$inline_style = '';
 			if ( $poster ) {
-				$inline_style = sprintf(
-					'style="background-image: url(%s); background-size: cover; background-position: center center;"',
-					esc_attr( $poster )
-				);
+				// Emit the poster URL as a double-quoted CSS string so it stays
+				// contained within url(). esc_url() does not escape every character
+				// that is significant in a CSS url() context, so quoting keeps the
+				// value from affecting the surrounding style. esc_url() has already
+				// removed " and \, so the quoted string cannot be closed early.
+				$poster_url = esc_url( $poster );
+				if ( $poster_url ) {
+					$inline_style = sprintf(
+						'style="background-image: url(&quot;%s&quot;); background-size: cover; background-position: center center;"',
+						$poster_url
+					);
+				}
 			}
 
 			// Expose the preview on hover data to the client.

--- a/projects/packages/videopress/tests/php/Initializer_Test.php
+++ b/projects/packages/videopress/tests/php/Initializer_Test.php
@@ -269,4 +269,46 @@ class Initializer_Test extends BaseTestCase {
 			'Active-module VideoPress route should register on rest_api_init via the active_initialization deferral block.'
 		);
 	}
+
+	/**
+	 * The preview-on-hover overlay renders the poster URL into a CSS url(). It is
+	 * emitted as a double-quoted CSS string so an arbitrary URL stays contained
+	 * within url() and does not affect the surrounding style.
+	 */
+	public function test_preview_on_hover_poster_url_is_quoted_in_css() {
+		// A value with characters esc_url() leaves intact but that are significant
+		// in a CSS url() context.
+		$value = 'https://example.test/a);b:c';
+
+		$html = $this->render(
+			array(
+				'posterData' => array(
+					'url'                 => $value,
+					'previewOnHover'      => true,
+					'previewAtTime'       => 0,
+					'previewLoopDuration' => 5000,
+				),
+			)
+		);
+
+		// The value is emitted inside a single double-quoted CSS string...
+		$this->assertStringContainsString( 'url(&quot;' . esc_url( $value ) . '&quot;)', $html );
+		// ...and never as a bare, unquoted url() argument.
+		$this->assertStringNotContainsString( 'background-image: url(https', $html );
+	}
+
+	/**
+	 * The maxWidth block attribute is rendered into an inline style, so only a
+	 * plain CSS length or percentage is applied; any other value is dropped.
+	 */
+	public function test_max_width_only_accepts_css_lengths() {
+		// A value that is not a plain length/percentage is dropped, not rendered.
+		$other = $this->render( array( 'maxWidth' => '10px;color:red' ) );
+		$this->assertStringNotContainsString( 'color:red', $other );
+		$this->assertStringNotContainsString( 'max-width: 10px;color', $other );
+
+		// A well-formed length still applies.
+		$valid = $this->render( array( 'maxWidth' => '400px' ) );
+		$this->assertStringContainsString( 'max-width: 400px;', $valid );
+	}
 }


### PR DESCRIPTION
## Proposed changes

The VideoPress video block renders two author-supplied block attributes into inline CSS, and neither was escaped ideally for its context:

* **Poster URL** — rendered into a `background-image: url( … )`. `esc_url()` does not escape every character that is significant inside a CSS `url()`, so the value is now emitted as a double-quoted CSS string (`url("…")`) to keep it contained.
* **`maxWidth`** — rendered into `max-width: …`. It now only accepts a plain CSS length or percentage; any other value is dropped and the block falls back to full width (as with the `100%` default). Note `calc()` is also dropped, which the dimension control does not produce.

Both are escaping/validation hardening for values that go into inline styles. Adds render regression tests.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Add a VideoPress block with a custom poster (preview-on-hover) and a max width; on the front end the poster and sizing still render correctly.
* Confirm unusual poster or max-width values are handled safely — the poster stays inside `url("…")` and a non-length max-width is ignored rather than applied.
* `jp test php packages/videopress` — the new regression tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NZ2nEAgqJJ5zmczuyFngF9
