### PR TITLE
VideoPress: roll the modernized dashboard out to all WordPress.com Simple sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/update-videopress-simple-dashboard-rollout-100
+++ b/projects/packages/jetpack-mu-wpcom/changelog/update-videopress-simple-dashboard-rollout-100
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+VideoPress: roll the modernized dashboard out to all WordPress.com Simple sites, removing the Automattician-and-sticker rollout gate

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-videopress/wpcom-videopress.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-videopress/wpcom-videopress.php
@@ -34,14 +34,6 @@ function wpcom_videopress_init_admin_ui() {
 		return;
 	}
 
-	/*
-	 * VIDP-285: rolled out at 100%. No callback is registered on the
-	 * rsm_jetpack_ui_modernization_videopress filter anymore, so Simple keeps
-	 * the filter's default (enabled) exactly like self-hosted and Atomic. The
-	 * staged gate (Automatticians + the videopress-modernized-dashboard blog
-	 * sticker for CFT testers) lived here until the July 2026 CFT concluded;
-	 * the sticker and its Blog RC toggle are inert now and can be retired.
-	 */
 	if ( ! class_exists( '\Automattic\Jetpack\VideoPress\Admin_UI' ) ) {
 		return;
 	}

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-videopress/wpcom-videopress.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-videopress/wpcom-videopress.php
@@ -19,31 +19,6 @@
 use Automattic\Jetpack\Status\Host;
 
 /**
- * Whether the modernized VideoPress dashboard is rolled out to this Simple
- * site and user (VIDP-285).
- *
- * The whole admin UI keys off Admin_UI::is_modernized() — menu registration
- * (add_wp_admin_submenu bails without it), the wp-build asset load, and the
- * boot payload — so this is the Simple staged-rollout switch: off by default,
- * on for CFT testers via the blog sticker, and always on for Automatticians.
- * UI-only by design: the REST surface (wpcom/v2 routes, attachment query
- * filters, the server-side token mint) stays registered regardless, so the
- * API contract doesn't flap with the flag.
- *
- * @return bool Whether the modernized dashboard should be enabled.
- */
-function wpcom_videopress_modernized_dashboard_enabled() {
-	if (
-		function_exists( 'wpcom_has_blog_sticker' ) && function_exists( 'get_wpcom_blog_id' )
-		&& wpcom_has_blog_sticker( 'videopress-modernized-dashboard', get_wpcom_blog_id() )
-	) {
-		return true;
-	}
-
-	return function_exists( 'is_automattician' ) && is_automattician( get_current_user_id() );
-}
-
-/**
  * Initialize the VideoPress Admin UI on WordPress.com Simple sites.
  *
  * Guarded on Simple because on Atomic and standalone Jetpack the VideoPress package
@@ -60,13 +35,13 @@ function wpcom_videopress_init_admin_ui() {
 	}
 
 	/*
-	 * VIDP-285: staged rollout. Registered on Simple only, so self-hosted and
-	 * Atomic keep the filter's default (enabled). The callbacks that consult
-	 * Admin_UI::is_modernized() run at admin_menu time, well after this
-	 * plugins_loaded-time registration.
+	 * VIDP-285: rolled out at 100%. No callback is registered on the
+	 * rsm_jetpack_ui_modernization_videopress filter anymore, so Simple keeps
+	 * the filter's default (enabled) exactly like self-hosted and Atomic. The
+	 * staged gate (Automatticians + the videopress-modernized-dashboard blog
+	 * sticker for CFT testers) lived here until the July 2026 CFT concluded;
+	 * the sticker and its Blog RC toggle are inert now and can be retired.
 	 */
-	add_filter( 'rsm_jetpack_ui_modernization_videopress', 'wpcom_videopress_modernized_dashboard_enabled' );
-
 	if ( ! class_exists( '\Automattic\Jetpack\VideoPress\Admin_UI' ) ) {
 		return;
 	}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-videopress/Wpcom_Videopress_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/wpcom-videopress/Wpcom_Videopress_Test.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * VideoPress dashboard rollout flag tests.
+ * VideoPress dashboard rollout tests.
  *
  * @package automattic/jetpack-mu-wpcom
  */
@@ -14,30 +14,20 @@ use Automattic\Jetpack\Jetpack_Mu_Wpcom;
 require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/wpcom-videopress/wpcom-videopress.php';
 
 /**
- * Tests for the VIDP-285 staged-rollout flag.
+ * Tests for the VIDP-285 rollout, now at 100%.
  */
 class Wpcom_Videopress_Test extends \WorDBless\BaseTestCase {
 	/**
-	 * The rollout defaults to OFF: without the wpcom platform's sticker and
-	 * a11n primitives (absent in this environment, function_exists-guarded in
-	 * the callback), the modernized dashboard must not be enabled. This pins
-	 * the fail-closed default — a Simple site outside the cohort gets no
-	 * VideoPress menu at all rather than a dead dashboard.
+	 * The rollout is at 100%: init must not register any callback on the
+	 * modernization filter, so every host — Simple included — keeps
+	 * Admin_UI::is_modernized()'s default (enabled). This pins the absence
+	 * of the old staged gate (Automatticians + the CFT blog sticker); a
+	 * stray re-registration of a restricting callback shows up here.
 	 */
-	public function test_rollout_defaults_to_disabled() {
-		$this->assertFalse( \wpcom_videopress_modernized_dashboard_enabled() );
-	}
-
-	/**
-	 * Off-Simple, init must not register the rollout filter: self-hosted and
-	 * Atomic keep Admin_UI::is_modernized()'s default (enabled), and the
-	 * Host::is_wpcom_simple() guard is what protects them.
-	 */
-	public function test_rollout_filter_not_registered_off_simple() {
+	public function test_no_rollout_gate_registered() {
 		\wpcom_videopress_init_admin_ui();
 
-		$this->assertFalse(
-			has_filter( 'rsm_jetpack_ui_modernization_videopress', 'wpcom_videopress_modernized_dashboard_enabled' )
-		);
+		$this->assertFalse( has_filter( 'rsm_jetpack_ui_modernization_videopress' ) );
+		$this->assertFalse( function_exists( 'wpcom_videopress_modernized_dashboard_enabled' ) );
 	}
 }


### PR DESCRIPTION
Fixes VIDP-285

## Proposed changes

* Roll the modernized VideoPress dashboard out to **all WordPress.com Simple sites** by removing the staged-rollout gate (`wpcom_videopress_modernized_dashboard_enabled()`), which limited it to Automatticians and to CFT testers carrying the `videopress-modernized-dashboard` blog sticker.
* With no callback registered on the `rsm_jetpack_ui_modernization_videopress` filter, Simple now keeps the filter's default (enabled) — exactly like self-hosted and Atomic, which have shipped the modernized dashboard since the June CFT. The whole admin surface keys off `Admin_UI::is_modernized()` (menu registration, wp-build asset load, boot payload), so no other change is needed.
* The REST surface (wpcom/v2 routes, attachment query filters, server-side token mint) was never gated and is unchanged.
* The blog sticker and its Blog RC toggle become inert; they can be retired separately once this ships.
* Test updated to pin the new invariant: init registers **no** callback on the modernization filter, so a stray re-registration of a restricting gate fails the suite.

## Related product discussion/links

* VIDP-285 (rollout plan; the July CFT on cftp2 concluded July 27, with its reported issues triaged into JETPACK-2032, VIDP-327, and VIDP-328)
* Gate introduced in Automattic/jetpack#50410; CFT sticker toggle in Blog RC via missioncontrol PR 163670.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a WordPress.com Simple site as a **non-Automattician** user, without the `videopress-modernized-dashboard` sticker: wp-admin → Jetpack → VideoPress should now show the modernized dashboard (Library / Stats / Settings tabs).
* Sandbox: drop this file into the active `jetpack-mu-wpcom-plugin` slot's `jetpack_vendor/automattic/jetpack-mu-wpcom/src/features/wpcom-videopress/` and load the dashboard with a non-a11n test account on an unstickered Simple site.
* Atomic / self-hosted: unaffected (the `Host::is_wpcom_simple()` guard means this feature never ran there; the filter default was already enabled).
* `composer phpunit -- --filter Wpcom_Videopress` from `projects/packages/jetpack-mu-wpcom` (1 test, 2 assertions).
