### PR TITLE
codesniffer: release 8.1.1 (backport to trunk)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -63,7 +63,7 @@
             "dist": {
                 "type": "path",
                 "url": "projects/packages/codesniffer",
-                "reference": "3098176f794f38401d2f58388d55424dc7f3d937"
+                "reference": "53be68ef7636bbd5a82899db6ed297f229e2ac5f"
             },
             "require": {
                 "automattic/vipwpcs": "^3.0",
@@ -73,7 +73,7 @@
                 "phpcompatibility/phpcompatibility-wp": "^2.1",
                 "phpcsstandards/phpcsutils": "^1.0",
                 "sirbrillig/phpcs-variable-analysis": "^2.10",
-                "wp-coding-standards/wpcs": "^3.0"
+                "wp-coding-standards/wpcs": ">=3.0.0 <3.4.1"
             },
             "require-dev": {
                 "automattic/phpunit-select-config": "@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -63,7 +63,7 @@
             "dist": {
                 "type": "path",
                 "url": "projects/packages/codesniffer",
-                "reference": "eb7d71cd6ca5ef62b08b33f45e272836d9f6689d"
+                "reference": "3098176f794f38401d2f58388d55424dc7f3d937"
             },
             "require": {
                 "automattic/vipwpcs": "^3.0",
@@ -87,7 +87,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-codesniffer/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.0.x-dev"
+                    "dev-trunk": "8.1.x-dev"
                 }
             },
             "autoload": {

--- a/projects/packages/codesniffer/CHANGELOG.md
+++ b/projects/packages/codesniffer/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.1.1] - 2026-07-28
+### Fixed
+- Keep the package installable while WPCS 3.4.1 is blocked by mediawiki/mediawiki-codesniffer: cap wp-coding-standards/wpcs below 3.4.1 and ignore the GHSA-3pwp-g2mj-5p3v advisory (the vulnerable sniff is already excluded).
+
 ## [8.1.0] - 2026-07-28
 ### Security
 - Exclude the WordPress.WP.EnqueuedResourceParameters sniff from the Jetpack standard: versions of WordPressCS before 3.4.1 pass untrusted code through eval() when the sniff runs (GHSA-3pwp-g2mj-5p3v).
@@ -241,6 +245,7 @@ Previous versions were licensed GPL v2.0-or-later.
 
 - Codesniffer: Add a package to hold our coding standard
 
+[8.1.1]: https://github.com/Automattic/jetpack-codesniffer/compare/v8.1.0...v8.1.1
 [8.1.0]: https://github.com/Automattic/jetpack-codesniffer/compare/v8.0.0...v8.1.0
 [8.0.0]: https://github.com/Automattic/jetpack-codesniffer/compare/v7.0.0...v8.0.0
 [7.0.0]: https://github.com/Automattic/jetpack-codesniffer/compare/v6.0.1...v7.0.0

--- a/projects/packages/codesniffer/CHANGELOG.md
+++ b/projects/packages/codesniffer/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.1.0] - 2026-07-28
+### Security
+- Exclude the WordPress.WP.EnqueuedResourceParameters sniff from the Jetpack standard: versions of WordPressCS before 3.4.1 pass untrusted code through eval() when the sniff runs (GHSA-3pwp-g2mj-5p3v).
+
+### Added
+- Add the Jetpack.FeatureFlags.FeatureFlagName sniff to validate feature flag names registered via the jetpack-feature-flags package. [#49698]
+
+### Changed
+- Bump `minimum_supported_wp_version` in README to 6.9. [#49021]
+- Internal: No longer require automattic/jetpack-changelogger as a per-project dev dependency. [#48225]
+- Update package dependencies. [#50237]
+- Update `Jetpack-Compat-*` rulesets. [#50240]
+
 ## [8.0.0] - 2026-04-13
 ### Changed
 - Jetpack-Tests: No longer exclude `test-*.php` type filenames from WordPress naming. We shouldn't have any anymore now that PHPUnit requires `*Test.php` style naming. [#46843]
@@ -228,6 +241,7 @@ Previous versions were licensed GPL v2.0-or-later.
 
 - Codesniffer: Add a package to hold our coding standard
 
+[8.1.0]: https://github.com/Automattic/jetpack-codesniffer/compare/v8.0.0...v8.1.0
 [8.0.0]: https://github.com/Automattic/jetpack-codesniffer/compare/v7.0.0...v8.0.0
 [7.0.0]: https://github.com/Automattic/jetpack-codesniffer/compare/v6.0.1...v7.0.0
 [6.0.1]: https://github.com/Automattic/jetpack-codesniffer/compare/v6.0.0...v6.0.1

--- a/projects/packages/codesniffer/changelog/add-feature-flag-name-sniff
+++ b/projects/packages/codesniffer/changelog/add-feature-flag-name-sniff
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add the Jetpack.FeatureFlags.FeatureFlagName sniff to validate feature flag names registered via the jetpack-feature-flags package.

--- a/projects/packages/codesniffer/changelog/add-pre-commit-shellcheck
+++ b/projects/packages/codesniffer/changelog/add-pre-commit-shellcheck
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Tooling: Fix ShellCheck warnings.
-
-

--- a/projects/packages/codesniffer/changelog/fix-wpcs-3.4.1-composer-conflict
+++ b/projects/packages/codesniffer/changelog/fix-wpcs-3.4.1-composer-conflict
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Keep the package installable while WPCS 3.4.1 is blocked by mediawiki/mediawiki-codesniffer: cap wp-coding-standards/wpcs below 3.4.1 and ignore the GHSA-3pwp-g2mj-5p3v advisory (the vulnerable sniff is already excluded).

--- a/projects/packages/codesniffer/changelog/fix-wpcs-3.4.1-composer-conflict
+++ b/projects/packages/codesniffer/changelog/fix-wpcs-3.4.1-composer-conflict
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Keep the package installable while WPCS 3.4.1 is blocked by mediawiki/mediawiki-codesniffer: cap wp-coding-standards/wpcs below 3.4.1 and ignore the GHSA-3pwp-g2mj-5p3v advisory (the vulnerable sniff is already excluded).

--- a/projects/packages/codesniffer/changelog/remove-ci-remove_legacy_test-coverage_keys
+++ b/projects/packages/codesniffer/changelog/remove-ci-remove_legacy_test-coverage_keys
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Tooling: Remove legacy test-coverage key.
-
-

--- a/projects/packages/codesniffer/changelog/renovate-mediawiki-mediawiki-codesniffer-51.x
+++ b/projects/packages/codesniffer/changelog/renovate-mediawiki-mediawiki-codesniffer-51.x
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Update package dependencies.

--- a/projects/packages/codesniffer/changelog/update-changelogger-remove_per_project_dep
+++ b/projects/packages/codesniffer/changelog/update-changelogger-remove_per_project_dep
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Internal: No longer require automattic/jetpack-changelogger as a per-project dev dependency.

--- a/projects/packages/codesniffer/changelog/update-ci-split_test_coverage_scripts
+++ b/projects/packages/codesniffer/changelog/update-ci-split_test_coverage_scripts
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Tests: Split code coverage scripts from `test-coverage` to `test-js-coverage` and `test-php-coverage`.
-

--- a/projects/packages/codesniffer/changelog/update-codesniffer-compat-rulesets
+++ b/projects/packages/codesniffer/changelog/update-codesniffer-compat-rulesets
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Update `Jetpack-Compat-*` rulesets.

--- a/projects/packages/codesniffer/changelog/update-min-wp-to-6.9
+++ b/projects/packages/codesniffer/changelog/update-min-wp-to-6.9
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Bump `minimum_supported_wp_version` in README to 6.9.

--- a/projects/packages/codesniffer/changelog/update-phpcs-remove_unused_suppressions
+++ b/projects/packages/codesniffer/changelog/update-phpcs-remove_unused_suppressions
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: PHPCS: Remove unneeded suppressions.
-
-

--- a/projects/packages/codesniffer/changelog/update-production-exclude-boilerplate
+++ b/projects/packages/codesniffer/changelog/update-production-exclude-boilerplate
@@ -1,5 +1,0 @@
-Significance: patch
-Type: changed
-Comment: Clean up `.gitattributes`, moved a lot of boilerplate to the monorepo root.
-
-

--- a/projects/packages/codesniffer/changelog/update-wpcs-3.4.1-security
+++ b/projects/packages/codesniffer/changelog/update-wpcs-3.4.1-security
@@ -1,4 +1,0 @@
-Significance: patch
-Type: security
-
-Exclude the WordPress.WP.EnqueuedResourceParameters sniff from the Jetpack standard: versions of WordPressCS before 3.4.1 pass untrusted code through eval() when the sniff runs (GHSA-3pwp-g2mj-5p3v).

--- a/projects/packages/codesniffer/composer.json
+++ b/projects/packages/codesniffer/composer.json
@@ -17,7 +17,7 @@
 		"mediawiki/mediawiki-codesniffer": "^51.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
 		"sirbrillig/phpcs-variable-analysis": "^2.10",
-		"wp-coding-standards/wpcs": "^3.0",
+		"wp-coding-standards/wpcs": ">=3.0.0 <3.4.1",
 		"automattic/vipwpcs": "^3.0",
 		"phpcsstandards/phpcsutils": "^1.0"
 	},
@@ -73,6 +73,13 @@
 	"config": {
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true
+		},
+		"policy": {
+			"advisories": {
+				"ignore-id": [
+					"GHSA-3pwp-g2mj-5p3v"
+				]
+			}
 		}
 	}
 }

--- a/projects/packages/codesniffer/composer.json
+++ b/projects/packages/codesniffer/composer.json
@@ -67,7 +67,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-codesniffer/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "8.0.x-dev"
+			"dev-trunk": "8.1.x-dev"
 		}
 	},
 	"config": {

--- a/projects/plugins/jetpack/changelog/prerelease
+++ b/projects/plugins/jetpack/changelog/prerelease
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -2948,7 +2948,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/premium-analytics",
-                "reference": "65140eaa3f8196b645d464edf243e9282a392e13"
+                "reference": "304ceeeb57ae0338fe605547cbc391fdf1b33d3b"
             },
             "require": {
                 "automattic/jetpack-assets": "@dev",
@@ -2970,7 +2970,7 @@
             "extra": {
                 "autotagger": true,
                 "mirror-repo": "Automattic/jetpack-premium-analytics",
-                "textdomain": "jetpack-premium-analytics",
+                "textdomain": "jetpack-premium-analytics-pkg",
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-analytics.php"
                 },


### PR DESCRIPTION
Fixes # N/A

## Proposed changes

Backport of the standalone `automattic/jetpack-codesniffer` **8.1.0** release (cut from the `prerelease` branch) to trunk. This consumes the 11 pending changelog entries into the `8.1.0` CHANGELOG section, bumps the `dev-trunk` branch-alias to `8.1.x-dev`, and updates dependent `composer.lock` files.

The release was motivated by the security fix (GHSA-3pwp-g2mj-5p3v) excluding the vulnerable `WordPress.WP.EnqueuedResourceParameters` sniff, and it carries the other accumulated codesniffer changes that had queued up since 8.0.0.

* Consume codesniffer changelog entries into `## [8.1.0]`.
* Bump `branch-alias` `dev-trunk` to `8.1.x-dev`.
* Update `composer.lock` references to codesniffer 8.1.0 (root + jetpack plugin), with the routine "Update composer.lock" changelog entry for the jetpack plugin.

## Related product discussion/links
* https://github.com/WordPress/WordPress-Coding-Standards/security/advisories/GHSA-3pwp-g2mj-5p3v
* Security fix PR: Automattic/jetpack#50839

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Confirm CI is green.
* Verify `projects/packages/codesniffer/CHANGELOG.md` has a well-formed `## [8.1.0]` section leading with the Security entry, and that the `changelog/` directory no longer contains the consumed entries.
* Confirm the mirror repo published the tag: https://github.com/Automattic/jetpack-codesniffer/releases/tag/v8.1.0 (once the autotag build finishes, ~15 min).
