### PR TITLE
Renovate: merge WP deps config blocks

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -51,6 +51,17 @@
 			extends: [ 'monorepo:wordpress' ],
 			separateMajorMinor: false,
 			prPriority: 1,
+			// Bundled WordPress dependencies are still considered unstable and can have
+			// significant breaking changes. Since they're not externalized to WP, they have
+			// a higher chance of impacting functionality.
+			additionalReviewers: [
+				'team:jetpack-social', // Social
+				'team:jetpack-my-jetpack', // My Jetpack
+				'team:loop', // Newsletter dashboard & subscriber management
+				'team:jetpack-newsletter', // Newsletter dashboard & subscriber management
+				'team:jetpack-forms', // Forms and related component work
+				'team:jetpack-stats', // Premium Analytics
+			],
 		},
 		{
 			extends: [ 'monorepo:react' ],
@@ -108,55 +119,6 @@
 			matchUpdateTypes: [ 'minor', 'patch', 'pin', 'digest', 'pinDigest' ],
 			schedule: [ '* 0-3 * * 1' ],
 			additionalReviewers: [ 'team:qualityops' ],
-		},
-
-		// Bundled WordPress dependencies are separated from 'monorepo:wordpress' while
-		// they're still considered unstable and can have significant breaking changes.
-		// Since they're not externalized to WP, they have higher chance of impacting functionality.
-		//
-		// Some related packages are included here too.
-		{
-			groupName: 'Bundled @wordpress/* monorepo',
-			matchPackageNames: [
-				// Bundled packages, from the list at https://github.com/WordPress/gutenberg/blob/trunk/packages/dependency-extraction-webpack-plugin/lib/util.js#L2
-				'@wordpress/admin-ui',
-				'@wordpress/dataviews',
-				'@wordpress/fields',
-				'@wordpress/icons',
-				'@wordpress/interface',
-				'@wordpress/style-runtime',
-				'@wordpress/ui',
-				'@wordpress/undo-manager',
-				'@wordpress/views',
-				// Additional packages polyfilled by wp-build-polyfills, which need to be kept in sync with each other.
-				'@wordpress/a11y',
-				'@wordpress/boot',
-				// Bundled into the rich-text polyfill (rich-text unlocks its private
-				// APIs at module scope), so it must move in lockstep with rich-text.
-				'@wordpress/compose',
-				'@wordpress/notices',
-				'@wordpress/private-apis',
-				'@wordpress/rich-text',
-				'@wordpress/route',
-				'@wordpress/theme',
-				// @wordpress/build is still heavily developed; its dashboards share the same bundled
-				// packages and test surface, so exercising build alongside the rest is practical.
-				'@wordpress/build',
-				// Widgets Dashboard packages used by Premium Analytics
-				'@wordpress/grid',
-				'@wordpress/widget-dashboard',
-				'@wordpress/widget-primitives',
-			],
-			separateMajorMinor: false,
-			// Teams that can help test the update
-			additionalReviewers: [
-				'team:jetpack-social', // Social
-				'team:jetpack-my-jetpack', // My Jetpack
-				'team:loop', // Newsletter dashboard & subscriber management
-				'team:jetpack-newsletter', // Newsletter dashboard & subscriber management
-				'team:jetpack-forms', // Forms and related component work
-				'team:jetpack-stats', // Premium Analytics
-			],
 		},
 
 		// 🤷

--- a/projects/packages/wp-build-polyfills/changelog/update-renovate-wordpress-monorepo
+++ b/projects/packages/wp-build-polyfills/changelog/update-renovate-wordpress-monorepo
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Update comment after Renovate config change.

--- a/projects/packages/wp-build-polyfills/webpack.config.js
+++ b/projects/packages/wp-build-polyfills/webpack.config.js
@@ -170,8 +170,7 @@ const disabledPlugins = {
 
 // ── Polyfill definitions ────────────────────────────────────────────────────
 //
-// If adding or removing something here, you'll probably also want to add or remove it
-// from the "Bundled @wordpress/* monorepo" group in `.github/renovate.json5`.
+// Keep these package versions in sync with each other.
 
 const classicPolyfills = [
 	{

--- a/projects/packages/wp-build-polyfills/webpack.config.js
+++ b/projects/packages/wp-build-polyfills/webpack.config.js
@@ -169,8 +169,6 @@ const disabledPlugins = {
 };
 
 // ── Polyfill definitions ────────────────────────────────────────────────────
-//
-// Keep these package versions in sync with each other.
 
 const classicPolyfills = [
 	{


### PR DESCRIPTION

## Proposed changes
<!--- Explain what functional changes your PR includes -->
Merges the two separate "externalized" and "bundled" wp deps configs into one.

While this makes each update more elaborate (especially when studying changelogs) and harder to grok which packages are "externalized" and which "bundled", it's still beneficial to combine these.

Devs testing need to pay special attention to bundled packages, as they may contain larger changes that affect product UIs. Meanwhile, it's hard to keep up with new packages added to bundled deps, and we may end up with situations where we're updating a package in two separate deploys, potentially days or weeks apart, but they depended on specific versions of each other.

Following changes to what is bundled and what isn't can be challenging, and configs can drift from upstream:

- Jetpack bundles some additional dependencies separately from WP's own determination (see wp-build-polyfill package or various Webpack configs bundling wp-theme).
- WP-Build tool and Webpack configs in Gutenberg use different ways to determine what needs bundling ([ref](https://github.com/WordPress/gutenberg/pull/79945)) 
- We use wp-theme (an externalised dependency) as part of build and linter processes

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* Avoids issues described in peKye1-26O-p2

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* N/A
