### PR TITLE
Newsletter: fix the dashboard widget's bottom corners looking cut off

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-nl-796-newsletter-widget-corner
+++ b/projects/plugins/jetpack/changelog/fix-nl-796-newsletter-widget-corner
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Newsletter: round the dashboard widget footer so it stops covering the rounded bottom corner of the WP Admin box.

--- a/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/style.scss
+++ b/projects/plugins/jetpack/modules/subscriptions/newsletter-widget/src/style.scss
@@ -129,4 +129,11 @@ $spacing-lg: variables.$grid-unit-20;      // 16px
 		padding: 0;
 		margin: 0;
 	}
+
+	// Core rounds dashboard postboxes to 8px but leaves overflow visible, so the
+	// footer has to round with the box or its background covers the corner.
+	.newsletter-widget__footer {
+		border-end-start-radius: variables.$radius-large;
+		border-end-end-radius: variables.$radius-large;
+	}
 }


### PR DESCRIPTION
Fixes NL-796

## Proposed changes

* On the WP Admin dashboard, the bottom corners of the Jetpack Newsletter box look cut off. The border is meant to curve, but it squares off and vanishes at both bottom corners.
* Core rounds dashboard boxes to 8px and leaves overflow visible, so any child with a background that reaches the bottom edge paints over the curve. This widget zeroes out the `.inside` padding, which puts its grey footer right against that edge.
* Rounding the footer's bottom corners to the same 8px fixes it. I used logical properties, so RTL needs no separate rule.
* The Stats widget has the same bug from the same cause, tracked separately in STATS-269. That one lives in the Odyssey app, so it needs its own fix.

## Related product discussion/links

* NL-796

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open the WP Admin dashboard on a Jetpack-connected site where the Newsletter widget renders. It only appears once the site has subscribers and the Stats module is active.
* Look at the bottom left and bottom right corners of the "Jetpack Newsletter" box. Zoom the browser to 400% if it is hard to see at 100%.
* Before the fix, the grey footer fills both corners square and covers the border, so the curve looks broken.
* After the fix, the border curves cleanly through both corners.
* Switch the site to an RTL language and check that both corners still look right.

Before

<img width="606" height="136" alt="CleanShot 2026-07-28 at 17 02 08@2x" src="https://github.com/user-attachments/assets/440e18e5-5c64-4b4e-a503-287078b583b5" />

After

<img width="588" height="136" alt="CleanShot 2026-07-28 at 17 02 21@2x" src="https://github.com/user-attachments/assets/b49427b7-c7fe-46dc-a14d-3095c9b3c447" />

