### PR TITLE
Connection: Fetch connected user data from WordPress.com over REST instead of XML-RPC

### DIFF
--- a/projects/packages/connection/changelog/connect-379-user-data-rest
+++ b/projects/packages/connection/changelog/connect-379-user-data-rest
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Connection: Fetch connected user data from WordPress.com over REST instead of XML-RPC

--- a/projects/packages/connection/changelog/connect-379-user-data-rest
+++ b/projects/packages/connection/changelog/connect-379-user-data-rest
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Connection: Fetch connected user data from WordPress.com over REST instead of XML-RPC
+Connection: Fetch connected user data from WordPress.com over REST instead of XML-RPC.

--- a/projects/packages/connection/src/class-error-handler.php
+++ b/projects/packages/connection/src/class-error-handler.php
@@ -1177,12 +1177,18 @@ class Error_Handler {
 		}
 
 		$body = json_decode( $body_raw, true );
-		if ( empty( $body['error'] ) || ( ! is_string( $body['error'] ) && ! is_int( $body['error'] ) ) ) {
+
+		// Support both error envelopes: the legacy v1 JSON-API shape (`error`) and the
+		// WP-API v2 shape (`code`), the latter used by `wpcom/v2` endpoints such as
+		// `jetpack-wpcom-user-data`. Prefer `error` for backwards compatibility.
+		$error_code = is_array( $body ) ? ( $body['error'] ?? $body['code'] ?? null ) : null;
+
+		if ( empty( $error_code ) || ( ! is_string( $error_code ) && ! is_int( $error_code ) ) ) {
 			return;
 		}
 
 		$error = new \WP_Error(
-			$body['error'],
+			$error_code,
 			empty( $body['message'] ) ? '' : $body['message'],
 			array(
 				'signature_details' => array(

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -2300,6 +2300,10 @@ class Manager {
 
 		$this->get_tokens()->update_user_token( $current_user_id, sprintf( '%s.%d', $token, $current_user_id ), $is_connection_owner );
 
+		// Delete cached connected user data, so a cached failure from the
+		// previous (broken) token doesn't linger after reconnecting.
+		delete_transient( "jetpack_connected_user_data_$current_user_id" );
+
 		/**
 		 * Fires after user has successfully received an auth token.
 		 *

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -850,7 +850,12 @@ class Manager {
 	/**
 	 * Get the wpcom user data of the current|specified connected user.
 	 *
-	 * @todo Refactor to properly load the XMLRPC client independently.
+	 * Fetches the data from the WordPress.com `jetpack-wpcom-user-data` REST endpoint
+	 * with a signed request as the connected user. Routing this through
+	 * Client::remote_request() (rather than the legacy `wpcom.getUser` XML-RPC method)
+	 * ensures any connection errors are captured by the Error_Handler.
+	 *
+	 * @since $$next-version$$ Fetch the data over REST instead of the `wpcom.getUser` XML-RPC method.
 	 *
 	 * @param int|null $user_id the user identifier.
 	 * @return bool|array An array with the WPCOM user data on success, false otherwise.
@@ -876,25 +881,40 @@ class Manager {
 			return $cached_user_data;
 		}
 
-		$xml = new Jetpack_IXR_Client(
-			array(
-				'user_id' => $user_id,
-			)
-		);
-		$xml->query( 'wpcom.getUser' );
+		$blog_id = (int) \Jetpack_Options::get_option( 'id' );
 
-		if ( ! $xml->isError() ) {
-			$user_data = $xml->getResponse();
-			set_transient( $transient_key, $xml->getResponse(), DAY_IN_SECONDS );
-			return $user_data;
+		// Build a signed request as the connected user. We can't use
+		// Client::wpcom_json_api_request_as_user() because it always signs as the
+		// current user, whereas this method may be called for an arbitrary $user_id.
+		$args            = Client::validate_args_for_wpcom_json_api_request(
+			"/sites/{$blog_id}/jetpack-wpcom-user-data",
+			'2',
+			array( 'method' => 'GET' )
+		);
+		$args['user_id'] = $user_id;
+
+		$response = Client::remote_request( $args );
+
+		if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+			// Cache errors briefly so a failing remote request doesn't result in
+			// a blocking request on every call, e.g. on each admin page
+			// load via Initial_State::set_connection_script_data().
+			set_transient( $transient_key, 'error', 5 * MINUTE_IN_SECONDS );
+
+			return false;
 		}
 
-		// Cache errors briefly so a failing remote request doesn't result in
-		// a blocking XML-RPC request on every call, e.g. on each admin page
-		// load via Initial_State::set_connection_script_data().
-		set_transient( $transient_key, 'error', 5 * MINUTE_IN_SECONDS );
+		$user_data = json_decode( wp_remote_retrieve_body( $response ), true );
 
-		return false;
+		if ( ! is_array( $user_data ) || empty( $user_data ) ) {
+			set_transient( $transient_key, 'error', 5 * MINUTE_IN_SECONDS );
+
+			return false;
+		}
+
+		set_transient( $transient_key, $user_data, DAY_IN_SECONDS );
+
+		return $user_data;
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/Error_Handler_Test.php
+++ b/projects/packages/connection/tests/php/Error_Handler_Test.php
@@ -370,6 +370,83 @@ class Error_Handler_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test that `check_api_response_for_errors()` captures the WP-API v2 error envelope,
+	 * which uses `code` (rather than the legacy v1 `error` key). This is the shape returned
+	 * by `wpcom/v2` endpoints such as `jetpack-wpcom-user-data`.
+	 */
+	public function test_check_api_response_for_errors_v2_code_envelope() {
+		// Keep the assertion order-independent regardless of the hourly reporting gate.
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+
+		$this->error_handler->check_api_response_for_errors(
+			array(
+				'response' => array(
+					'code' => 500,
+				),
+				'body'     => '{"code":"unknown_token","message":"It looks like your Jetpack connection is broken.","data":{"status":403}}',
+			),
+			array( 'token' => 'broken:1:0' ),
+			'https://localhost/',
+			'GET',
+			'rest'
+		);
+
+		$stored_errors   = $this->error_handler->get_stored_errors();
+		$verified_errors = $this->error_handler->get_verified_errors();
+
+		$this->assertArrayHasKey( 'unknown_token', $stored_errors );
+		$this->assertEquals( 'rest', $stored_errors['unknown_token']['0']['error_type'] );
+		$this->assertArrayHasKey( 'unknown_token', $verified_errors );
+		$this->assertEquals( 'rest', $verified_errors['unknown_token']['0']['error_type'] );
+	}
+
+	/**
+	 * Test that a v2 `code` that is not in the `known_errors` allowlist is not stored.
+	 */
+	public function test_check_api_response_for_errors_v2_code_not_in_allowlist() {
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+
+		$this->error_handler->check_api_response_for_errors(
+			array(
+				'response' => array(
+					'code' => 403,
+				),
+				'body'     => '{"code":"rest_forbidden","message":"The user is not a member of this site.","data":{"status":403}}',
+			),
+			array( 'token' => 'broken:1:0' ),
+			'https://localhost/',
+			'GET',
+			'rest'
+		);
+
+		$this->assertEmpty( $this->error_handler->get_stored_errors() );
+		$this->assertEmpty( $this->error_handler->get_verified_errors() );
+	}
+
+	/**
+	 * Test that a 200 response is never inspected for an error body, even if it carries a `code`.
+	 */
+	public function test_check_api_response_for_errors_ignores_200_with_code_body() {
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+
+		$this->error_handler->check_api_response_for_errors(
+			array(
+				'response' => array(
+					'code' => 200,
+				),
+				'body'     => '{"code":"unknown_token","message":"Should be ignored on a 200 response."}',
+			),
+			array( 'token' => 'broken:1:0' ),
+			'https://localhost/',
+			'GET',
+			'rest'
+		);
+
+		$this->assertEmpty( $this->error_handler->get_stored_errors() );
+		$this->assertEmpty( $this->error_handler->get_verified_errors() );
+	}
+
+	/**
 	 * Test storing errors
 	 */
 	public function test_delete_all_api_errors() {

--- a/projects/packages/connection/tests/php/ManagerIntegrationTest.php
+++ b/projects/packages/connection/tests/php/ManagerIntegrationTest.php
@@ -44,7 +44,7 @@ class ManagerIntegrationTest extends \WorDBless\BaseTestCase {
 	/**
 	 * The canned response the user-data endpoint filter returns for a matching request.
 	 *
-	 * @var array|null
+	 * @var array|\WP_Error|null
 	 */
 	private $http_response = null;
 
@@ -931,38 +931,79 @@ class ManagerIntegrationTest extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Test that a non-200 response returns false and is not cached.
+	 * Test that a failed fetch returns false and caches an `error` sentinel, so
+	 * the failing request is not repeated on every call.
+	 *
+	 * @dataProvider get_connected_user_data_error_responses
+	 *
+	 * @param array|\WP_Error $http_response The canned HTTP response for the request.
 	 */
-	public function test_get_connected_user_data_returns_false_on_error_response() {
+	#[DataProvider( 'get_connected_user_data_error_responses' )]
+	public function test_get_connected_user_data_returns_false_on_error_response( $http_response ) {
 		$user_id = $this->set_up_connected_user();
 
-		$this->http_response = array(
-			'body'     => wp_json_encode(
-				array(
-					'error'   => 'unknown_token',
-					'message' => 'Invalid token.',
-				),
-				JSON_UNESCAPED_SLASHES
-			),
-			'response' => array(
-				'code'    => 403,
-				'message' => 'Forbidden',
-			),
-			'headers'  => array(),
-		);
+		$this->http_response = $http_response;
 
 		add_filter( 'pre_http_request', array( $this, 'intercept_user_data_request' ), 10, 3 );
 
-		$result = $this->manager->get_connected_user_data( $user_id );
-		$cached = get_transient( "jetpack_connected_user_data_$user_id" );
+		$result        = $this->manager->get_connected_user_data( $user_id );
+		$cached        = get_transient( "jetpack_connected_user_data_$user_id" );
+		$requested_url = $this->intercepted_url;
+
+		// A repeated call must be served the cached failure without a new request.
+		$this->intercepted_url = null;
+		$repeat_result         = $this->manager->get_connected_user_data( $user_id );
+		$repeat_requested_url  = $this->intercepted_url;
 
 		remove_filter( 'pre_http_request', array( $this, 'intercept_user_data_request' ), 10 );
 		delete_transient( "jetpack_connected_user_data_$user_id" );
 
 		$this->assertFalse( $result );
+		$this->assertStringContainsString( 'jetpack-wpcom-user-data', (string) $requested_url );
 		// Failures are cached briefly with an 'error' sentinel so a failing
 		// request is not retried on every call.
 		$this->assertSame( 'error', $cached );
+		$this->assertFalse( $repeat_result );
+		$this->assertNull( $repeat_requested_url );
+	}
+
+	/**
+	 * Data provider for test_get_connected_user_data_returns_false_on_error_response.
+	 *
+	 * @return array
+	 */
+	public static function get_connected_user_data_error_responses() {
+		return array(
+			'transport error (WP_Error)' => array(
+				new \WP_Error( 'http_request_failed', 'Request blocked.' ),
+			),
+			'non-200 response'           => array(
+				array(
+					'body'     => wp_json_encode(
+						array(
+							'error'   => 'unknown_token',
+							'message' => 'Invalid token.',
+						),
+						JSON_UNESCAPED_SLASHES
+					),
+					'response' => array(
+						'code'    => 403,
+						'message' => 'Forbidden',
+					),
+					'headers'  => array(),
+				),
+			),
+			'200 with malformed body'    => array(
+				array(
+					'body'     => 'not-json',
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'headers'  => array(),
+				),
+			),
+		);
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/ManagerIntegrationTest.php
+++ b/projects/packages/connection/tests/php/ManagerIntegrationTest.php
@@ -28,6 +28,27 @@ class ManagerIntegrationTest extends \WorDBless\BaseTestCase {
 	private $manager;
 
 	/**
+	 * The URL of the last HTTP request intercepted by the user-data endpoint filter.
+	 *
+	 * @var string|null
+	 */
+	private $intercepted_url = null;
+
+	/**
+	 * The arguments of the last HTTP request intercepted by the user-data endpoint filter.
+	 *
+	 * @var array|null
+	 */
+	private $intercepted_args = null;
+
+	/**
+	 * The canned response the user-data endpoint filter returns for a matching request.
+	 *
+	 * @var array|null
+	 */
+	private $http_response = null;
+
+	/**
 	 * Initialize the hooks to reset memoized connection properties.
 	 *
 	 * @beforeClass
@@ -799,5 +820,164 @@ class ManagerIntegrationTest extends \WorDBless\BaseTestCase {
 
 			$this->reset_connection_status();
 		}
+	}
+
+	/**
+	 * Set up a connected blog and user so a signed request can be built as $user_id.
+	 *
+	 * @param int $user_id The local user id to connect.
+	 * @return int The connected user id.
+	 */
+	private function set_up_connected_user( $user_id = 2 ) {
+		// A fully-qualified API base is required for the request URL to be signable.
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+		\Jetpack_Options::update_option( 'id', 1234 );
+		\Jetpack_Options::update_option( 'blog_token', 'blogkey.blogsecret' );
+		\Jetpack_Options::update_option( 'user_tokens', array( $user_id => "userkey.usersecret.$user_id" ) );
+		\Jetpack_Options::update_option( 'master_user', $user_id );
+
+		return $user_id;
+	}
+
+	/**
+	 * Intercept the outgoing request to the jetpack-wpcom-user-data endpoint and
+	 * return the canned response, recording the request URL and args.
+	 *
+	 * @param false|array $response The preempted response.
+	 * @param array       $args     The request arguments.
+	 * @param string      $url      The request URL.
+	 * @return false|array
+	 */
+	public function intercept_user_data_request( $response, $args, $url ) {
+		if ( false !== strpos( $url, 'jetpack-wpcom-user-data' ) ) {
+			$this->intercepted_url  = $url;
+			$this->intercepted_args = $args;
+			return $this->http_response;
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Test that `get_connected_user_data()` fetches the connected user data from the
+	 * WordPress.com REST endpoint and caches the decoded payload.
+	 */
+	public function test_get_connected_user_data_fetches_from_rest_endpoint() {
+		$user_id = $this->set_up_connected_user();
+
+		$payload = array(
+			'ID'                => 99,
+			'login'             => 'wpcom_user',
+			'email'             => 'wpcom@example.com',
+			'display_name'      => 'WPCOM User',
+			'text_direction'    => 'ltr',
+			'site_count'        => 3,
+			'jetpack_connect'   => '',
+			'color_scheme'      => 'classic-dark',
+			'sidebar_collapsed' => false,
+			'user_locale'       => 'en_US',
+			'user_currency'     => 'USD',
+		);
+
+		$this->http_response = array(
+			'body'     => wp_json_encode( $payload, JSON_UNESCAPED_SLASHES ),
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'headers'  => array(),
+		);
+
+		add_filter( 'pre_http_request', array( $this, 'intercept_user_data_request' ), 10, 3 );
+
+		$result = $this->manager->get_connected_user_data( $user_id );
+
+		$cached           = get_transient( "jetpack_connected_user_data_$user_id" );
+		$requested_url    = $this->intercepted_url;
+		$requested_method = isset( $this->intercepted_args['method'] ) ? $this->intercepted_args['method'] : null;
+
+		remove_filter( 'pre_http_request', array( $this, 'intercept_user_data_request' ), 10 );
+		delete_transient( "jetpack_connected_user_data_$user_id" );
+
+		$this->assertSame( $payload, $result );
+		$this->assertSame( $payload, $cached );
+		$this->assertStringContainsString( '/wpcom/v2/sites/1234/jetpack-wpcom-user-data', (string) $requested_url );
+		$this->assertSame( 'GET', $requested_method );
+	}
+
+	/**
+	 * Test that a cached transient is returned without making an HTTP request.
+	 */
+	public function test_get_connected_user_data_returns_cached_value() {
+		$user_id = $this->set_up_connected_user();
+
+		$cached = array(
+			'ID'    => 5,
+			'login' => 'cached_user',
+		);
+		set_transient( "jetpack_connected_user_data_$user_id", $cached, DAY_IN_SECONDS );
+
+		add_filter( 'pre_http_request', array( $this, 'intercept_user_data_request' ), 10, 3 );
+
+		$result        = $this->manager->get_connected_user_data( $user_id );
+		$requested_url = $this->intercepted_url;
+
+		remove_filter( 'pre_http_request', array( $this, 'intercept_user_data_request' ), 10 );
+		delete_transient( "jetpack_connected_user_data_$user_id" );
+
+		$this->assertSame( $cached, $result );
+		// No HTTP request should have been attempted.
+		$this->assertNull( $requested_url );
+	}
+
+	/**
+	 * Test that a non-200 response returns false and is not cached.
+	 */
+	public function test_get_connected_user_data_returns_false_on_error_response() {
+		$user_id = $this->set_up_connected_user();
+
+		$this->http_response = array(
+			'body'     => wp_json_encode(
+				array(
+					'error'   => 'unknown_token',
+					'message' => 'Invalid token.',
+				),
+				JSON_UNESCAPED_SLASHES
+			),
+			'response' => array(
+				'code'    => 403,
+				'message' => 'Forbidden',
+			),
+			'headers'  => array(),
+		);
+
+		add_filter( 'pre_http_request', array( $this, 'intercept_user_data_request' ), 10, 3 );
+
+		$result = $this->manager->get_connected_user_data( $user_id );
+		$cached = get_transient( "jetpack_connected_user_data_$user_id" );
+
+		remove_filter( 'pre_http_request', array( $this, 'intercept_user_data_request' ), 10 );
+		delete_transient( "jetpack_connected_user_data_$user_id" );
+
+		$this->assertFalse( $result );
+		// Failures are cached briefly with an 'error' sentinel so a failing
+		// request is not retried on every call.
+		$this->assertSame( 'error', $cached );
+	}
+
+	/**
+	 * Test that no request is made and false is returned when the user is not connected.
+	 */
+	public function test_get_connected_user_data_returns_false_when_user_not_connected() {
+		add_filter( 'pre_http_request', array( $this, 'intercept_user_data_request' ), 10, 3 );
+
+		$result        = $this->manager->get_connected_user_data( 999 );
+		$requested_url = $this->intercepted_url;
+
+		remove_filter( 'pre_http_request', array( $this, 'intercept_user_data_request' ), 10 );
+
+		$this->assertFalse( $result );
+		// No HTTP request should have been attempted for an unconnected user.
+		$this->assertNull( $requested_url );
 	}
 }

--- a/projects/packages/connection/tests/php/ManagerIntegrationTest.php
+++ b/projects/packages/connection/tests/php/ManagerIntegrationTest.php
@@ -894,7 +894,7 @@ class ManagerIntegrationTest extends \WorDBless\BaseTestCase {
 
 		$cached           = get_transient( "jetpack_connected_user_data_$user_id" );
 		$requested_url    = $this->intercepted_url;
-		$requested_method = isset( $this->intercepted_args['method'] ) ? $this->intercepted_args['method'] : null;
+		$requested_method = $this->intercepted_args['method'] ?? null;
 
 		remove_filter( 'pre_http_request', array( $this, 'intercept_user_data_request' ), 10 );
 		delete_transient( "jetpack_connected_user_data_$user_id" );

--- a/projects/packages/connection/tests/php/ManagerTest.php
+++ b/projects/packages/connection/tests/php/ManagerTest.php
@@ -443,83 +443,45 @@ class ManagerTest extends TestCase {
 	}
 
 	/**
-	 * Test that `get_connected_user_data` caches remote request failures so a
-	 * failing request is not repeated on every call.
+	 * Test that `authorize` deletes cached connected user data, so a cached
+	 * `error` sentinel from a previously broken token does not linger after
+	 * the user reconnects.
 	 */
-	public function test_get_connected_user_data_caches_error_responses() {
-		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
-		Jetpack_Options::update_option( 'blog_token', 'blogtoken.secret' );
-		Jetpack_Options::update_option( 'id', 1234 );
-		Jetpack_Options::update_option( 'user_tokens', array( $this->user_id => 'usertoken.secret.' . $this->user_id ) );
-
-		$http_request_count = 0;
-		$intercept          = function () use ( &$http_request_count ) {
-			++$http_request_count;
-			return new WP_Error( 'http_request_failed', 'Request blocked in test.' );
-		};
-		add_filter( 'pre_http_request', $intercept );
-
-		try {
-			$manager = new Manager();
-
-			$this->assertFalse( $manager->get_connected_user_data( $this->user_id ) );
-			$this->assertSame( 1, $http_request_count );
-			$this->assertSame( 'error', get_transient( 'jetpack_connected_user_data_' . $this->user_id ) );
-
-			// A repeated call must not trigger another remote request.
-			$this->assertFalse( $manager->get_connected_user_data( $this->user_id ) );
-			$this->assertSame( 1, $http_request_count );
-		} finally {
-			remove_filter( 'pre_http_request', $intercept );
-		}
-	}
-
-	/**
-	 * Test that `get_connected_user_data` returns and caches the user data on success.
-	 */
-	public function test_get_connected_user_data_returns_and_caches_user_data() {
-		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
-		Jetpack_Options::update_option( 'blog_token', 'blogtoken.secret' );
-		Jetpack_Options::update_option( 'id', 1234 );
-		Jetpack_Options::update_option( 'user_tokens', array( $this->user_id => 'usertoken.secret.' . $this->user_id ) );
-
-		$body = wp_json_encode(
+	public function test_authorize_deletes_cached_connected_user_data() {
+		$user_id = wp_insert_user(
 			array(
-				'ID'    => 7,
-				'email' => 'user@example.com',
+				'user_login' => 'test_authorize_deletes_cached_user_data',
+				'user_pass'  => '123',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		set_transient( "jetpack_connected_user_data_$user_id", 'error', 5 * MINUTE_IN_SECONDS );
+
+		$tokens = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Tokens' )
+			->onlyMethods( array( 'get', 'update_user_token' ) )
+			->getMock();
+		$tokens->method( 'get' )->willReturn( 'usertoken.secret' );
+		$tokens->method( 'update_user_token' )->willReturn( true );
+
+		$manager = $this->getMockBuilder( 'Automattic\Jetpack\Connection\Manager' )
+			->onlyMethods( array( 'get_tokens', 'get_connection_owner_id' ) )
+			->getMock();
+		$manager->method( 'get_tokens' )->willReturn( $tokens );
+		$manager->method( 'get_connection_owner_id' )->willReturn( 123 );
+
+		$result = $manager->authorize(
+			array(
+				'state' => (string) $user_id,
+				'code'  => 'authorization_code',
 			)
 		);
 
-		$http_request_count = 0;
-		$intercept          = function () use ( &$http_request_count, $body ) {
-			++$http_request_count;
-			return array(
-				'headers'  => array(),
-				'body'     => $body,
-				'response' => array(
-					'code'    => 200,
-					'message' => 'OK',
-				),
-				'cookies'  => array(),
-				'filename' => null,
-			);
-		};
-		add_filter( 'pre_http_request', $intercept );
+		$cached = get_transient( "jetpack_connected_user_data_$user_id" );
 
-		try {
-			$manager   = new Manager();
-			$user_data = $manager->get_connected_user_data( $this->user_id );
-
-			$this->assertSame( 7, $user_data['ID'] );
-			$this->assertSame( 'user@example.com', $user_data['email'] );
-			$this->assertSame( $user_data, get_transient( 'jetpack_connected_user_data_' . $this->user_id ) );
-
-			// A repeated call must be served from the cache.
-			$this->assertSame( $user_data, $manager->get_connected_user_data( $this->user_id ) );
-			$this->assertSame( 1, $http_request_count );
-		} finally {
-			remove_filter( 'pre_http_request', $intercept );
-		}
+		$this->assertSame( 'linked', $result );
+		$this->assertFalse( $cached );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/ManagerTest.php
+++ b/projects/packages/connection/tests/php/ManagerTest.php
@@ -443,11 +443,11 @@ class ManagerTest extends TestCase {
 	}
 
 	/**
-	 * Test that `get_connected_user_data` caches XML-RPC failures so a failing
-	 * request is not repeated on every call.
+	 * Test that `get_connected_user_data` caches remote request failures so a
+	 * failing request is not repeated on every call.
 	 */
 	public function test_get_connected_user_data_caches_error_responses() {
-		Constants::set_constant( 'JETPACK__API_BASE', 'https://jetpack.wordpress.com/' );
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
 		Jetpack_Options::update_option( 'blog_token', 'blogtoken.secret' );
 		Jetpack_Options::update_option( 'id', 1234 );
 		Jetpack_Options::update_option( 'user_tokens', array( $this->user_id => 'usertoken.secret.' . $this->user_id ) );
@@ -478,15 +478,17 @@ class ManagerTest extends TestCase {
 	 * Test that `get_connected_user_data` returns and caches the user data on success.
 	 */
 	public function test_get_connected_user_data_returns_and_caches_user_data() {
-		Constants::set_constant( 'JETPACK__API_BASE', 'https://jetpack.wordpress.com/' );
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
 		Jetpack_Options::update_option( 'blog_token', 'blogtoken.secret' );
 		Jetpack_Options::update_option( 'id', 1234 );
 		Jetpack_Options::update_option( 'user_tokens', array( $this->user_id => 'usertoken.secret.' . $this->user_id ) );
 
-		$body = '<?xml version="1.0"?><methodResponse><params><param><value><struct>'
-			. '<member><name>ID</name><value><int>7</int></value></member>'
-			. '<member><name>email</name><value><string>user@example.com</string></value></member>'
-			. '</struct></value></param></params></methodResponse>';
+		$body = wp_json_encode(
+			array(
+				'ID'    => 7,
+				'email' => 'user@example.com',
+			)
+		);
 
 		$http_request_count = 0;
 		$intercept          = function () use ( &$http_request_count, $body ) {


### PR DESCRIPTION
Related to  CONNECT-379

~~**Do not merge** till https://github.com/Automattic/jetpack/pull/50230 gets merged (needs rebase).~~ Done

## Proposed changes

* Refactor `Manager::get_connected_user_data()` in the Connection package to fetch the connected user's WordPress.com data from the new `jetpack-wpcom-user-data` REST endpoint (`GET /wpcom/v2/sites/<blog_id>/jetpack-wpcom-user-data`) instead of the legacy `wpcom.getUser` XML-RPC method.
* The request is signed as the target user via `Client::remote_request()`. Because XML-RPC faults arrive as HTTP 200 with an XML body, so the error handler never sees them, connection/auth failures from this very high-traffic call (it backs `get_wpcom_current_user()`, used by virtually every plugin that displays the connected user) were previously invisible to `Error_Handler`. Routing it through REST means those errors now flow through `check_api_response_for_errors()`.
* Teach `Error_Handler::check_api_response_for_errors()` to recognize the WP-API v2 error envelope (`{"code": ...}`) in addition to the legacy v1 shape (`{"error": ...}`). The v2 `jetpack-wpcom-user-data` endpoint returns errors under `code`, which the handler previously ignored — so without this change the migration would have silently dropped exactly the errors it is meant to surface (e.g. `unknown_token`). The `known_errors` allowlist and the hourly reporting gate are unchanged, so **error noise and performance are unaffected.**
* Behavior is otherwise preserved: the method still accepts an arbitrary `$user_id` (signing as that user), keeps the 1-day transient cache, and returns `false` on failure. `wpcom_json_api_request_as_user()` was intentionally **not** used because it always signs as the current user, which would break callers that pass a specific user id.
* Adds unit coverage:
  * `ManagerIntegrationTest` — the success path (correct endpoint + cached payload), the transient short-circuit, the error-response path, and the not-connected path.
  * `Error_Handler_Test` — the v2 `code` envelope is captured (`error_type = 'rest'`), a v2 `code` not in `known_errors` is ignored, a 200 response carrying a `code` body is ignored, and the legacy v1 `error` envelope still works.

## Related product discussion/links

* Linear: CONNECT-379
* Companion WPCOM change introducing the endpoint: 230852-ghe-Automattic/wpcom (must be deployed for the REST call to succeed in production).

## Does this pull request change what data or activity we track or use?

No. The same user-data fields are fetched as before (`ID`, `login`, `email`, `display_name`, `text_direction`, `site_count`, `jetpack_connect`, `color_scheme`, `sidebar_collapsed`, `user_locale`, `user_currency`) — only the transport changes from XML-RPC to a signed REST request.

## Testing instructions

Automated:

* `cd projects/packages/connection && composer phpunit -- --filter get_connected_user_data` — all 4 new tests pass.
* `cd projects/packages/connection && composer phpunit -- --filter check_api_response_for_errors` — the v1 regression plus the three new v2-envelope tests pass.
* Full package suite is green: `cd projects/packages/connection && composer phpunit`.

Manual (on a Jetpack-connected site, logged in as the connected user; requires the companion WPCOM PR to be live on the sandbox/environment you point at):

**No errors / shape of connected user data** 
* Confirm the connected user (username, Gravatar, email) still displays correctly across the dashboard — e.g. My Jetpack, the Connection screen, Publicize — since these read through `get_connected_user_data()`. 
* Check the stored transient on trunks vs current branch via wp cli:
```
wp transient delete jetpack_connected_user_data_<USER_ID>
wp transient get jetpack_connected_user_data_<USER_ID> // After reloading My Jetpack
```
**Error handling - Connection errors**
- Make sure only Jetpack Social is active.
- Remove the user token on WPCOM (see 230852-ghe-Automattic/wpcom)
- Clear the following transients:
```
wp transient delete jetpack_connected_user_data_<USER_ID> // To trigger the remote request to /jetpack-wpcom-user-data
wp transient delete jetpack_connection_error_reporting_gate_unknown_token // error reporting gate
```
- Confirm a Connection error is present on both MyJetpack and Social page on current branch / no errors on trunk
- Restore your connection by clicking on the corresponding CTA: You will be redirected to connect your account and then bac to the site - The flow should complete successfully and no errors should appear once you are redirected back to wp-admin

**Bonus points:** Make sure to test this on a WoA dev site, since WoA has additional error handling logic