### PR TITLE
Add a build-time check that pre-rendered components ship with their styles

### DIFF
--- a/projects/js-packages/shared-extension-utils/changelog/pre-rendered-component-style-check
+++ b/projects/js-packages/shared-extension-utils/changelog/pre-rendered-component-style-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Upgrade nudge: stop emitting an "undefined__description" class when no className is passed.

--- a/projects/js-packages/shared-extension-utils/changelog/pre-rendered-component-style-check
+++ b/projects/js-packages/shared-extension-utils/changelog/pre-rendered-component-style-check
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Upgrade nudge: stop emitting an "undefined__description" class when no className is passed.

--- a/projects/plugins/jetpack/changelog/pre-rendered-component-style-check
+++ b/projects/plugins/jetpack/changelog/pre-rendered-component-style-check
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Add a build-time check that the pre-rendered frontend components only use CSS classes their own stylesheet defines.

--- a/projects/plugins/jetpack/package.json
+++ b/projects/plugins/jetpack/package.json
@@ -17,7 +17,7 @@
 		"build-asset-cdn-json": "php tools/build-asset-cdn-json.php",
 		"build-client": "concurrently --names js,css,module-headings 'webpack --config ./tools/webpack.config.js' 'webpack --config ./tools/webpack.config.css.js' 'php tools/build-module-headings-translations.php'",
 		"build-concurrently": "pnpm run clean && concurrently 'pnpm:build-client' 'pnpm:build-extensions' 'pnpm:build-widget-visibility' && pnpm run build-asset-cdn-json",
-		"build-extensions": "webpack --config ./tools/webpack.config.extensions.js && tools/check-block-assets.php && php tools/build-block-manifest.php",
+		"build-extensions": "webpack --config ./tools/webpack.config.extensions.js && tools/check-block-assets.php && tools/check-component-styles.php && php tools/build-block-manifest.php",
 		"build-production": "pnpm run clean && pnpm run build-production-client && pnpm run build-production-extensions && pnpm run build-production-widget-visibility && pnpm run build-asset-cdn-json",
 		"build-production-client": "NODE_ENV=production BABEL_ENV=production pnpm run build-client && pnpm exec validate-es ./_inc/build/",
 		"build-production-concurrently": "pnpm run clean && concurrently 'pnpm:build-production-client' 'pnpm:build-production-extensions' 'pnpm:build-production-widget-visibility' && pnpm run build-asset-cdn-json",

--- a/projects/plugins/jetpack/tools/check-component-styles.php
+++ b/projects/plugins/jetpack/tools/check-component-styles.php
@@ -1,0 +1,131 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Script to check that the pre-rendered components ship with the styles they need.
+ *
+ * The components in `extensions/shared/components/index.jsx` are rendered to static
+ * HTML at build time and served by `Jetpack_Components::render_component()`, which
+ * enqueues a single stylesheet: `_inc/blocks/components.css`. Nothing else loads on
+ * the page, so any class in that markup whose rules live in an editor-only stylesheet
+ * silently renders unstyled on the frontend.
+ *
+ * This checks the one invariant that catches that: every class the markup uses must
+ * be defined by the stylesheet that ships with it.
+ *
+ * @package automattic/jetpack
+ */
+
+// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped, WordPress.WP.AlternativeFunctions -- This is not WordPress code.
+
+/**
+ * Classes that come from a stylesheet `components.css` depends on rather than from
+ * `components.css` itself.
+ *
+ * `render_component()` enqueues `jetpack-components` with `wp-components` as a
+ * dependency, so WordPress' own component styles are on the page too.
+ *
+ * @var string[]
+ */
+$external_classes = array(
+	'components-button',
+	'is-primary',
+);
+
+chdir( dirname( __DIR__ ) );
+$base   = 'projects/plugins/jetpack/';
+$script = 'projects/plugins/jetpack/tools/check-component-styles.php';
+$issues = array();
+
+$tmp = $external_classes;
+sort( $external_classes );
+if ( $tmp !== $external_classes ) {
+	$issues[ $script ][] = 'The `$external_classes` array is not sorted. Please sort it.';
+}
+
+/**
+ * Extracts the class names used by a chunk of HTML.
+ *
+ * @param string $html HTML markup.
+ * @return string[] Class names, deduplicated.
+ */
+function jetpack_extract_html_classes( $html ) {
+	$classes = array();
+	if ( preg_match_all( '/\sclass=(["\'])(.*?)\1/s', $html, $matches ) ) {
+		foreach ( $matches[2] as $attr ) {
+			$classes = array_merge( $classes, preg_split( '/\s+/', trim( $attr ), -1, PREG_SPLIT_NO_EMPTY ) );
+		}
+	}
+	return array_unique( $classes );
+}
+
+/**
+ * Extracts the class names a stylesheet defines rules for.
+ *
+ * Walks the stylesheet collecting everything that precedes a `{`, which is where
+ * selectors (and at-rule preludes, which contain no classes) live, and pulls the
+ * class names out of that. Declaration values are skipped, so a `content` or
+ * `background-image` value that happens to contain a dot is not mistaken for a rule.
+ *
+ * @param string $css Stylesheet contents.
+ * @return string[] Class names, deduplicated.
+ */
+function jetpack_extract_css_classes( $css ) {
+	// Drop comments so a commented-out selector doesn't count as a rule.
+	$css = preg_replace( '#/\*.*?\*/#s', '', $css );
+
+	$classes = array();
+	$buffer  = '';
+	$length  = strlen( $css );
+	for ( $i = 0; $i < $length; $i++ ) {
+		$char = $css[ $i ];
+		if ( '{' === $char ) {
+			if ( preg_match_all( '/\.(-?[_a-zA-Z][_a-zA-Z0-9-]*)/', $buffer, $matches ) ) {
+				$classes = array_merge( $classes, $matches[1] );
+			}
+			$buffer = '';
+		} elseif ( '}' === $char || ';' === $char ) {
+			$buffer = '';
+		} else {
+			$buffer .= $char;
+		}
+	}
+	return array_unique( $classes );
+}
+
+$stylesheet = '_inc/blocks/components.css';
+if ( ! file_exists( $stylesheet ) ) {
+	$issues[ $script ][] = "Cannot check the pre-rendered components, $stylesheet was not found.";
+} else {
+	$defined = array_fill_keys( jetpack_extract_css_classes( (string) file_get_contents( $stylesheet ) ), true );
+	$defined = array_merge( $defined, array_fill_keys( $external_classes, true ) );
+
+	$components = glob( '_inc/blocks/*.html' );
+	if ( empty( $components ) ) {
+		$issues[ $script ][] = 'Cannot check the pre-rendered components, no `_inc/blocks/*.html` files were found.';
+	}
+	foreach ( $components as $component ) {
+		$undefined = array();
+		foreach ( jetpack_extract_html_classes( (string) file_get_contents( $component ) ) as $class ) {
+			if ( ! isset( $defined[ $class ] ) ) {
+				$undefined[] = $class;
+			}
+		}
+		if ( $undefined ) {
+			sort( $undefined );
+			$issues[ $base . $component ][] = sprintf(
+				"Class(es) used by this pre-rendered component have no rule in %s, so they render unstyled on the frontend: %s.\nEither add the rules to a stylesheet that `Jetpack_Components::render_component()` loads, or drop the class from the markup.",
+				$base . $stylesheet,
+				implode( ', ', $undefined )
+			);
+		}
+	}
+}
+
+if ( ! empty( $issues ) ) {
+	echo "\n\n\e[1mPre-rendered component style check detected issues!\e[0m\n";
+	foreach ( $issues as $file => $msgs ) {
+		echo "\n\e[1mIn $file\e[0m\n" . implode( "\n", $msgs ) . "\n";
+	}
+	echo "\n\e[32mClasses provided by a stylesheet other than components.css may be allowed by editing the array at the top of $script.\e[0m\n\n";
+	exit( 1 );
+}

--- a/projects/plugins/jetpack/tools/check-component-styles.php
+++ b/projects/plugins/jetpack/tools/check-component-styles.php
@@ -24,12 +24,14 @@
  * `render_component()` enqueues `jetpack-components` with `wp-components` as a
  * dependency, so WordPress' own component styles are on the page too.
  *
+ * Empty today: every class the pre-rendered markup uses, `components.css` defines
+ * itself. Add to this only when the check reports a class that is genuinely styled
+ * by one of those dependencies — entries that stop being needed are reported below,
+ * so the allowlist cannot silently widen the check.
+ *
  * @var string[]
  */
-$external_classes = array(
-	'components-button',
-	'is-primary',
-);
+$external_classes = array();
 
 chdir( dirname( __DIR__ ) );
 $base   = 'projects/plugins/jetpack/';
@@ -45,10 +47,15 @@ if ( $tmp !== $external_classes ) {
 /**
  * Extracts the class names used by a chunk of HTML.
  *
+ * The pre-rendered components carry PHP for the server to execute, so that is dropped
+ * first: a `class=` inside a PHP string is not a class the component renders, and its
+ * value is not knowable at build time anyway.
+ *
  * @param string $html HTML markup.
  * @return string[] Class names, deduplicated.
  */
 function jetpack_extract_html_classes( $html ) {
+	$html    = preg_replace( '/<\?(?:php|=).*?\?>/s', '', $html );
 	$classes = array();
 	if ( preg_match_all( '/\sclass=(["\'])(.*?)\1/s', $html, $matches ) ) {
 		foreach ( $matches[2] as $attr ) {
@@ -96,8 +103,12 @@ $stylesheet = '_inc/blocks/components.css';
 if ( ! file_exists( $stylesheet ) ) {
 	$issues[ $script ][] = "Cannot check the pre-rendered components, $stylesheet was not found.";
 } else {
-	$defined = array_fill_keys( jetpack_extract_css_classes( (string) file_get_contents( $stylesheet ) ), true );
-	$defined = array_merge( $defined, array_fill_keys( $external_classes, true ) );
+	$in_stylesheet = array_fill_keys( jetpack_extract_css_classes( (string) file_get_contents( $stylesheet ) ), true );
+	$defined       = array_merge( $in_stylesheet, array_fill_keys( $external_classes, true ) );
+
+	// Allowlist entries start out unneeded, and earn their place by being the only
+	// thing that keeps a class the markup actually uses out of the report below.
+	$unneeded = array_fill_keys( $external_classes, true );
 
 	$components = glob( '_inc/blocks/*.html' );
 	if ( empty( $components ) ) {
@@ -106,6 +117,9 @@ if ( ! file_exists( $stylesheet ) ) {
 	foreach ( $components as $component ) {
 		$undefined = array();
 		foreach ( jetpack_extract_html_classes( (string) file_get_contents( $component ) ) as $class ) {
+			if ( ! isset( $in_stylesheet[ $class ] ) ) {
+				unset( $unneeded[ $class ] );
+			}
 			if ( ! isset( $defined[ $class ] ) ) {
 				$undefined[] = $class;
 			}
@@ -118,6 +132,16 @@ if ( ! file_exists( $stylesheet ) ) {
 				implode( ', ', $undefined )
 			);
 		}
+	}
+
+	if ( ! empty( $unneeded ) ) {
+		$unneeded = array_keys( $unneeded );
+		sort( $unneeded );
+		$issues[ $script ][] = sprintf(
+			'The `$external_classes` allowlist lists classes that no pre-rendered component needs it for, because %s defines them itself or nothing uses them: %s. Please remove them, so the allowlist cannot hide a class that later stops being styled.',
+			$base . $stylesheet,
+			implode( ', ', $unneeded )
+		);
 	}
 }
 


### PR DESCRIPTION
## Proposed changes

Follow-up to PR 50873, which fixed a collapsed upgrade nudge on the frontend. It adds a build-time check in the same spirit — that the pre-rendered components only use CSS classes their own shipped stylesheet defines.

**Scope note — this is not regression cover for PR 50873.** That collapse came from missing *declarations* (spacing rules like `flex-wrap` and `margin-block`) on classes `components.css` already defined, and a class-existence invariant can't see that — see the design notes below. What this check catches is a different, related failure: a class that ships in the frontend markup with no rule anywhere in `components.css`, so it renders unstyled. When first written it found one real instance (`undefined__description`); that has since been fixed independently in PR 50873, so this branch is now just the check itself. Think of it as a floor under the pre-rendered artifacts, not a guarantee the exact PR 50873 bug can't recur.

**Background.** `Jetpack_Gutenberg::get_render_callback_with_availability_check()` prints an upgrade nudge above plan-gated blocks on the site frontend for admins. That nudge is pre-rendered at build time via `renderToStaticMarkup` into static HTML, and served by `Jetpack_Components::render_component()`, which enqueues exactly one stylesheet: `_inc/blocks/components.css`.

So any class in that markup with no matching rule in `components.css` renders unstyled on the frontend — nothing else loads on the page to style it. Build artifacts have no test coverage, and the nudge only renders for an admin, on a site missing the plan, viewing a plan-gated block — one block on self-hosted today — so a stray class there is easy to miss.

**Changes:**

* Add `tools/check-component-styles.php`, run from `build-extensions` alongside the existing `check-block-assets.php`. It parses the classes out of `_inc/blocks/*.html` and the selectors out of `components.css`, and fails the build on any class with no rule. It reports every violation rather than stopping at the first.

**Design notes for review:**

* **It is an invariant check, not an assertion about specific rules.** It does not check that `components.css` contains any particular declaration — that would be tautological and would break on every legitimate restyle. It checks only that every class the markup uses is defined by the stylesheet that ships with it. The flip side, spelled out in the scope note above: a class counts as defined if it appears in *any* selector, so it cannot catch a missing declaration on an already-styled class (the PR 50873 family), nor a rule scoped so it can never match the pre-rendered markup.
* **Markup to CSS only, deliberately.** `components.css` legitimately carries `.block-editor-warning` rules whose markup is generated elsewhere in PHP, so checking the reverse direction would produce false positives.
* **The `$external_classes` allowlist is empty today, on purpose.** It exists for classes that are genuinely on the page but come from a stylesheet `components.css` depends on (e.g. `@wordpress/components`, enqueued via `jetpack-components`'s `wp-components` style dependency). Right now `components.css` scopes every class the markup uses itself, so nothing needs allowlisting — and the check reports any allowlist entry that is no longer needed, so it can't silently widen.
* **Embedded PHP in the artifacts is stripped before extraction.** The `_inc/blocks/*.html` files can carry PHP for the server to execute; a `class=` inside a PHP string is not a class the component actually renders (and its value isn't knowable at build time), so it's dropped rather than mistaken for frontend markup.

## Related product discussion/links

* PR 50873 — the fix this follows up on.
* https://linear.app/a8c/issue/FORMS-737/file-upload-upsell-banner-visually-broken

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This is build tooling, so the meaningful test is that it fails when it should. Passing the build only proves there are no false positives.

**Confirm it passes as-is:**

* `jp build plugins/jetpack`
* The build should complete. `php projects/plugins/jetpack/tools/check-component-styles.php` exits 0.

**Confirm it actually fails when styles go missing:**

* Empty `projects/js-packages/shared-extension-utils/src/components/upgrade-nudge/style.scss`. That is where the `.jetpack-upgrade-plan-banner` rules currently reach `components.css` from, via the `Nudge` component's own import.
* `jp build plugins/jetpack`
* The build aborts, and the check reports:

```
Pre-rendered component style check detected issues!

In projects/plugins/jetpack/_inc/blocks/frontend-nudge.html
Class(es) used by this pre-rendered component have no rule in
projects/plugins/jetpack/_inc/blocks/components.css, so they render unstyled
on the frontend: banner-description, jetpack-upgrade-plan-banner,
jetpack-upgrade-plan-banner__wrapper.
Either add the rules to a stylesheet that
`Jetpack_Components::render_component()` loads, or drop the class from the markup.

In projects/plugins/jetpack/_inc/blocks/upgrade-nudge.html
Class(es) used by this pre-rendered component have no rule in
projects/plugins/jetpack/_inc/blocks/components.css, so they render unstyled
on the frontend: banner-description, jetpack-upgrade-plan-banner,
jetpack-upgrade-plan-banner__wrapper.
Either add the rules to a stylesheet that
`Jetpack_Components::render_component()` loads, or drop the class from the markup.
```

* Note that it caught both components rather than only the first, and named all three missing classes rather than only one.
* Restore the stylesheet and rebuild. The check goes back to exiting 0.
