### PR TITLE
Newsletter: show subscription categories in the subscriber detail panel

### DIFF
--- a/projects/packages/newsletter/_inc/subscribers/components/detail/subscriber-detail-content.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/detail/subscriber-detail-content.tsx
@@ -1,6 +1,7 @@
 import Gravatar from '@automattic/jetpack-components/gravatar';
 import { Spinner } from '@wordpress/components';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
+import { decodeEntities } from '@wordpress/html-entities';
 import { __, sprintf } from '@wordpress/i18n';
 import { Card, Link, Stack, Text } from '@wordpress/ui';
 import {
@@ -173,9 +174,11 @@ export default function SubscriberDetailContent( { open }: Props ): JSX.Element 
 	const stats = statsQuery.data;
 
 	const categoriesEnabled = !! categoriesQuery.data?.enabled;
+	// WordPress stores term names HTML-encoded (`Tips &amp; Tricks`) and WP.com passes them through
+	// as stored, so they have to be decoded before rendering as text.
 	const subscribedCategories = ( categoriesQuery.data?.newsletter_categories ?? [] )
 		.filter( category => category.subscribed )
-		.map( category => category.name );
+		.map( category => decodeEntities( category.name ) );
 
 	if ( detailsQuery.isLoading || ! subscriber ) {
 		return (

--- a/projects/packages/newsletter/_inc/subscribers/components/detail/subscriber-detail-content.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/detail/subscriber-detail-content.tsx
@@ -3,7 +3,11 @@ import { Spinner } from '@wordpress/components';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { __, sprintf } from '@wordpress/i18n';
 import { Card, Link, Stack, Text } from '@wordpress/ui';
-import { useSubscriberDetails, useSubscriberStats } from '../../data/use-subscriber-details';
+import {
+	useSubscribedNewsletterCategories,
+	useSubscriberDetails,
+	useSubscriberStats,
+} from '../../data/use-subscriber-details';
 import { getSubscribedAt } from '../../lib/subscriber-helpers';
 import SubscriptionStatusCell from '../cells/subscription-status-cell';
 import SubscriptionTypeCell from '../cells/subscription-type-cell';
@@ -160,8 +164,18 @@ export default function SubscriberDetailContent( { open }: Props ): JSX.Element 
 		user_id: open.userId,
 	} );
 
+	const categoriesQuery = useSubscribedNewsletterCategories( {
+		subscription_id: open.subscriptionId,
+		user_id: open.userId,
+	} );
+
 	const subscriber = detailsQuery.data;
 	const stats = statsQuery.data;
+
+	const categoriesEnabled = !! categoriesQuery.data?.enabled;
+	const subscribedCategories = ( categoriesQuery.data?.newsletter_categories ?? [] )
+		.filter( category => category.subscribed )
+		.map( category => category.name );
 
 	if ( detailsQuery.isLoading || ! subscriber ) {
 		return (
@@ -246,6 +260,16 @@ export default function SubscriberDetailContent( { open }: Props ): JSX.Element 
 						label={ __( 'Date subscribed', 'jetpack-newsletter' ) }
 						value={ formatDate( getSubscribedAt( subscriber ) ) }
 					/>
+					{ categoriesEnabled ? (
+						<DetailRow
+							label={ __( 'Receives emails for', 'jetpack-newsletter' ) }
+							value={
+								subscribedCategories.length
+									? subscribedCategories.join( ', ' )
+									: __( 'Not subscribed to any newsletter categories', 'jetpack-newsletter' )
+							}
+						/>
+					) : null }
 					<DetailRow
 						label={ __( 'Email subscription', 'jetpack-newsletter' ) }
 						value={

--- a/projects/packages/newsletter/_inc/subscribers/data/api.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/api.ts
@@ -5,6 +5,7 @@ import type {
 	ImportJob,
 	RemoveSubscriberPayload,
 	RemoveSubscriberResponse,
+	SubscribedNewsletterCategories,
 	SubscriberDetails,
 	SubscriberStats,
 	SubscribersQueryParams,
@@ -144,6 +145,28 @@ export function fetchSubscriberStats( params: IndividualParams ): Promise< Subsc
 			subscription_id: params.subscription_id ?? 0,
 			user_id: params.user_id ?? 0,
 		} ),
+		method: 'GET',
+	} );
+}
+
+/**
+ * Fetch the site's newsletter categories annotated with this subscriber's opt-in state, via the
+ * Jetpack proxy. Mirrors Calypso's `useSubscribedNewsletterCategories`: WP.com keys the record by
+ * subscription id, but accepts a WP.com user id instead when `type=wpcom` is passed, so prefer
+ * `user_id` when we have one (an email-only subscriber has no user id).
+ *
+ * @param params - Subscription identifiers.
+ * @return Site categories plus the feature flag and per-category `subscribed` state.
+ */
+export function fetchSubscribedNewsletterCategories(
+	params: IndividualParams
+): Promise< SubscribedNewsletterCategories > {
+	const userId = params.user_id ?? 0;
+	const id = userId || params.subscription_id || 0;
+	const path = `/wpcom/v2/newsletter-categories/subscriptions/${ id }`;
+
+	return apiFetch< SubscribedNewsletterCategories >( {
+		path: userId ? addQueryArgs( path, { type: 'wpcom' } ) : path,
 		method: 'GET',
 	} );
 }

--- a/projects/packages/newsletter/_inc/subscribers/data/types.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/types.ts
@@ -138,12 +138,10 @@ export type SubscriberDetails = Subscriber & {
 	url?: string | null;
 	open_rate?: number;
 
-	// The individual endpoint names things differently from the list: one `date_subscribed`
-	// (already a full ISO string with an offset, unlike the list's naive UTC timestamps) rather
-	// than the `wpcom_`/`email_` pair, and `subscription_id` rather than the two id fields.
+	// The individual endpoint names the subscription date differently from the list: one
+	// `date_subscribed`, already a full ISO string with an offset, rather than the `wpcom_`/`email_`
+	// pair of naive UTC timestamps.
 	date_subscribed?: string;
-	subscription_id?: number;
-	is_email_subscriber?: boolean;
 };
 
 export type NewsletterCategory = {

--- a/projects/packages/newsletter/_inc/subscribers/data/types.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/types.ts
@@ -137,6 +137,33 @@ export type SubscriberDetails = Subscriber & {
 	country?: SubscriberCountry | null;
 	url?: string | null;
 	open_rate?: number;
+
+	// The individual endpoint names things differently from the list: one `date_subscribed`
+	// (already a full ISO string with an offset, unlike the list's naive UTC timestamps) rather
+	// than the `wpcom_`/`email_` pair, and `subscription_id` rather than the two id fields.
+	date_subscribed?: string;
+	subscription_id?: number;
+	is_email_subscriber?: boolean;
+};
+
+export type NewsletterCategory = {
+	id: number;
+	name: string;
+	slug?: string;
+	description?: string;
+	parent?: number;
+	subscription_count?: number;
+	// Only present on the per-subscriber response: false when the subscriber opted out of this
+	// category. WP.com stores opt-outs, so every site category comes back and `subscribed` is the
+	// discriminator — not the presence of the entry.
+	subscribed?: boolean;
+};
+
+export type SubscribedNewsletterCategories = {
+	// Whether the site has Newsletter categories turned on. When false the categories are
+	// meaningless and the UI hides the field entirely (mirrors Calypso).
+	enabled: boolean;
+	newsletter_categories: NewsletterCategory[];
 };
 
 export type SubscriberStats = {

--- a/projects/packages/newsletter/_inc/subscribers/data/use-subscriber-details.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/use-subscriber-details.ts
@@ -1,6 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
-import { fetchSubscriberDetails, fetchSubscriberStats } from './api';
-import type { SubscriberDetails, SubscriberStats } from './types';
+import {
+	fetchSubscribedNewsletterCategories,
+	fetchSubscriberDetails,
+	fetchSubscriberStats,
+} from './api';
+import type { SubscribedNewsletterCategories, SubscriberDetails, SubscriberStats } from './types';
 
 type Identifiers = {
 	subscription_id?: number;
@@ -21,6 +25,38 @@ export function useSubscriberDetails( ids: Identifiers ) {
 	return useQuery< SubscriberDetails, Error >( {
 		queryKey: [ 'subscriber-details', subscriptionId, userId ],
 		queryFn: () => fetchSubscriberDetails( { subscription_id: subscriptionId, user_id: userId } ),
+		enabled,
+		placeholderData: previous => previous,
+	} );
+}
+
+const NO_CATEGORIES: SubscribedNewsletterCategories = {
+	enabled: false,
+	newsletter_categories: [],
+};
+
+/**
+ * Fetch the newsletter categories a single subscriber receives emails for.
+ *
+ * Errors resolve to "feature off" rather than rejecting, mirroring Calypso: WP.com 404s this route
+ * when the subscriber has no subscription record on the blog, and older Jetpack versions have no
+ * proxy for it at all. Neither is worth failing the whole detail panel over — the row simply hides.
+ *
+ * @param ids - Subscription / user ids.
+ * @return React Query handle.
+ */
+export function useSubscribedNewsletterCategories( ids: Identifiers ) {
+	const subscriptionId = ids.subscription_id ?? 0;
+	const userId = ids.user_id ?? 0;
+	const enabled = !! ( subscriptionId || userId );
+
+	return useQuery< SubscribedNewsletterCategories, Error >( {
+		queryKey: [ 'subscribed-newsletter-categories', subscriptionId, userId ],
+		queryFn: () =>
+			fetchSubscribedNewsletterCategories( {
+				subscription_id: subscriptionId,
+				user_id: userId,
+			} ).catch( () => NO_CATEGORIES ),
 		enabled,
 		placeholderData: previous => previous,
 	} );

--- a/projects/packages/newsletter/_inc/subscribers/data/use-subscriber-details.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/use-subscriber-details.ts
@@ -36,11 +36,26 @@ const NO_CATEGORIES: SubscribedNewsletterCategories = {
 };
 
 /**
+ * Whether a failed categories request means "there is nothing to show here" rather than "this
+ * request failed". WP.com 404s the route when the subscriber has no subscription record on the
+ * blog, and a Jetpack version without the proxy has no route at all — neither is retryable, and
+ * neither is worth failing the whole detail panel over.
+ *
+ * @param error - Rejection from `apiFetch`.
+ * @return True when the absence is expected.
+ */
+function isMissingCategoriesRecord( error: unknown ): boolean {
+	const { code, data } = ( error ?? {} ) as { code?: string; data?: { status?: number } };
+	return data?.status === 404 || code === 'rest_no_route';
+}
+
+/**
  * Fetch the newsletter categories a single subscriber receives emails for.
  *
- * Errors resolve to "feature off" rather than rejecting, mirroring Calypso: WP.com 404s this route
- * when the subscriber has no subscription record on the blog, and older Jetpack versions have no
- * proxy for it at all. Neither is worth failing the whole detail panel over — the row simply hides.
+ * An expected absence resolves to "feature off" so the row simply hides. Anything else — a 500, a
+ * dropped connection — is left to reject, so React Query still retries it rather than caching a
+ * transient failure as a successful "feature off" for the rest of the session. The row is hidden
+ * either way; the difference is whether it can come back.
  *
  * @param ids - Subscription / user ids.
  * @return React Query handle.
@@ -56,7 +71,12 @@ export function useSubscribedNewsletterCategories( ids: Identifiers ) {
 			fetchSubscribedNewsletterCategories( {
 				subscription_id: subscriptionId,
 				user_id: userId,
-			} ).catch( () => NO_CATEGORIES ),
+			} ).catch( error => {
+				if ( isMissingCategoriesRecord( error ) ) {
+					return NO_CATEGORIES;
+				}
+				throw error;
+			} ),
 		enabled,
 		placeholderData: previous => previous,
 	} );

--- a/projects/packages/newsletter/_inc/subscribers/lib/subscriber-helpers.ts
+++ b/projects/packages/newsletter/_inc/subscribers/lib/subscriber-helpers.ts
@@ -1,4 +1,11 @@
-import type { RemoveSubscriberPayload, Subscriber } from '../data/types';
+import type { RemoveSubscriberPayload, Subscriber, SubscriberDetails } from '../data/types';
+
+// Trailing `Z` or `±HH:MM` / `±HHMM` offset.
+const HAS_TIMEZONE = /(?:Z|[+-]\d{2}:?\d{2})$/i;
+
+// WP.com passes through a zero date when the record carries no subscription timestamp, rather
+// than omitting the field. Rendering it would print a year-0000 date, so treat it as absent.
+const ZERO_DATE = /^0000-00-00/;
 
 /**
  * Coerce a URL search-param value into a positive finite number.
@@ -15,20 +22,31 @@ export function toFiniteNumber( value: unknown ): number | undefined {
 }
 
 /**
- * Best-effort subscription date — Calypso prefers `wpcom_date_subscribed`, falling back to the
- * email subscription date for email-only subscribers. Returns the value with a `+00:00` suffix
- * appended (matching Calypso's `getFormattedSubscriptionDate` helper) so the date renders in the
- * caller's locale rather than UTC.
+ * Best-effort subscription date, accepting either payload shape.
  *
- * @param subscriber - Subscriber.
+ * List rows carry the `wpcom_`/`email_` pair — Calypso prefers `wpcom_date_subscribed`, falling
+ * back to the email subscription date for email-only subscribers. The individual-subscriber
+ * endpoint instead sends a single `date_subscribed`, which is why the detail panel showed nothing
+ * before it was handled here.
+ *
+ * The two shapes also differ in format: list dates are naive UTC (`2026-07-28 19:02:09`) and need
+ * pinning to UTC so they render in the caller's locale rather than being read as local time
+ * (matching Calypso's `getFormattedSubscriptionDate`), while the individual date already carries an
+ * offset — appending a second one would make it unparseable.
+ *
+ * @param subscriber - Subscriber row or detail payload.
  * @return ISO-ish date string or empty.
  */
-export function getSubscribedAt( subscriber: Subscriber ): string {
-	const raw = subscriber.wpcom_date_subscribed || subscriber.email_date_subscribed || '';
-	if ( ! raw ) {
+export function getSubscribedAt( subscriber: Subscriber | SubscriberDetails ): string {
+	const raw =
+		subscriber.wpcom_date_subscribed ||
+		subscriber.email_date_subscribed ||
+		( subscriber as SubscriberDetails ).date_subscribed ||
+		'';
+	if ( ! raw || ZERO_DATE.test( raw ) ) {
 		return '';
 	}
-	return `${ raw }+00:00`;
+	return HAS_TIMEZONE.test( raw ) ? raw : `${ raw }+00:00`;
 }
 
 /**

--- a/projects/packages/newsletter/changelog/fix-newsletter-subscriber-categories
+++ b/projects/packages/newsletter/changelog/fix-newsletter-subscriber-categories
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Subscribers: show the newsletter categories a subscriber receives emails for, and restore the missing subscription date, in the subscriber details panel.

--- a/projects/packages/newsletter/tests/subscriber-detail-content.test.tsx
+++ b/projects/packages/newsletter/tests/subscriber-detail-content.test.tsx
@@ -1,0 +1,173 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import SubscriberDetailContent from '../_inc/subscribers/components/detail/subscriber-detail-content';
+import type {
+	SubscribedNewsletterCategories,
+	SubscriberDetails,
+} from '../_inc/subscribers/data/types';
+
+const mockFetchSubscriberDetails = jest.fn();
+const mockFetchSubscriberStats = jest.fn();
+const mockFetchSubscribedNewsletterCategories = jest.fn();
+
+jest.mock( '../_inc/subscribers/data/api', () => ( {
+	fetchSubscriberDetails: ( ...args: unknown[] ) => mockFetchSubscriberDetails( ...args ),
+	fetchSubscriberStats: ( ...args: unknown[] ) => mockFetchSubscriberStats( ...args ),
+	fetchSubscribedNewsletterCategories: ( ...args: unknown[] ) =>
+		mockFetchSubscribedNewsletterCategories( ...args ),
+} ) );
+
+jest.mock( '@automattic/jetpack-components/gravatar', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
+const OPEN = { subscriptionId: 946836646, userId: 229907063 };
+
+/**
+ * Individual-endpoint payload, matching the real shape: one `date_subscribed` rather than the
+ * list's `wpcom_`/`email_` pair.
+ *
+ * @param overrides - Fields to override.
+ * @return Subscriber details payload.
+ */
+function makeDetails( overrides: Partial< SubscriberDetails > = {} ): SubscriberDetails {
+	return {
+		user_id: OPEN.userId,
+		subscription_id: OPEN.subscriptionId,
+		display_name: 'douglashenritest',
+		email_address: 'reader@example.com',
+		subscription_status: 'Subscribed',
+		date_subscribed: '2026-07-28T19:02:09+00:00',
+		...overrides,
+	};
+}
+
+/**
+ * Build the categories payload the WP.com endpoint returns: every site category, discriminated by
+ * `subscribed`.
+ *
+ * @param enabled - Whether the site has newsletter categories turned on.
+ * @return Categories payload.
+ */
+function makeCategories( enabled: boolean ): SubscribedNewsletterCategories {
+	return {
+		enabled,
+		newsletter_categories: [
+			{ id: 23, name: 'Test Posts', subscribed: true },
+			{ id: 24, name: 'Category 2', subscribed: false },
+			{ id: 1, name: 'Uncategorized', subscribed: false },
+		],
+	};
+}
+
+/**
+ * Render the detail panel with a fresh query client.
+ *
+ * @return The query client used for the render.
+ */
+function renderPanel(): QueryClient {
+	const queryClient = new QueryClient( {
+		defaultOptions: { queries: { retry: false } },
+	} );
+
+	render(
+		<QueryClientProvider client={ queryClient }>
+			<SubscriberDetailContent open={ OPEN } />
+		</QueryClientProvider>
+	);
+
+	return queryClient;
+}
+
+describe( 'SubscriberDetailContent', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockFetchSubscriberDetails.mockResolvedValue( makeDetails() );
+		mockFetchSubscriberStats.mockResolvedValue( {
+			emails_sent: 0,
+			unique_opens: 0,
+			unique_clicks: 0,
+		} );
+		mockFetchSubscribedNewsletterCategories.mockResolvedValue( makeCategories( true ) );
+	} );
+
+	it( 'lists the categories the subscriber receives emails for', async () => {
+		renderPanel();
+
+		await expect( screen.findByText( 'Receives emails for' ) ).resolves.toBeInTheDocument();
+		// Only categories flagged `subscribed` — WP.com returns every site category and stores
+		// opt-outs, so presence in the array means nothing on its own.
+		expect( screen.getByText( 'Test Posts' ) ).toBeInTheDocument();
+		expect( screen.queryByText( /Category 2/ ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'queries the categories endpoint by the identifiers the panel was opened with', async () => {
+		renderPanel();
+
+		await waitFor( () =>
+			expect( mockFetchSubscribedNewsletterCategories ).toHaveBeenCalledWith( {
+				subscription_id: OPEN.subscriptionId,
+				user_id: OPEN.userId,
+			} )
+		);
+	} );
+
+	it( 'says so when the subscriber opted out of every category', async () => {
+		mockFetchSubscribedNewsletterCategories.mockResolvedValue( {
+			enabled: true,
+			newsletter_categories: [ { id: 23, name: 'Test Posts', subscribed: false } ],
+		} );
+
+		renderPanel();
+
+		await expect(
+			screen.findByText( 'Not subscribed to any newsletter categories' )
+		).resolves.toBeInTheDocument();
+	} );
+
+	it( 'hides the row entirely when the site has newsletter categories turned off', async () => {
+		mockFetchSubscribedNewsletterCategories.mockResolvedValue( makeCategories( false ) );
+
+		renderPanel();
+
+		// Wait for the panel to settle before asserting an absence.
+		await expect( screen.findByText( 'Subscription type' ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( 'Receives emails for' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'keeps the panel usable when the categories request fails', async () => {
+		mockFetchSubscribedNewsletterCategories.mockRejectedValue( new Error( 'rest_no_route' ) );
+
+		renderPanel();
+
+		await expect( screen.findByText( 'Subscription type' ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( 'Receives emails for' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the date the individual endpoint reports', async () => {
+		renderPanel();
+
+		await expect( screen.findByText( 'Date subscribed' ) ).resolves.toBeInTheDocument();
+	} );
+
+	it( 'renders the email subscription status the individual endpoint reports', async () => {
+		renderPanel();
+
+		await expect( screen.findByText( 'Email subscription' ) ).resolves.toBeInTheDocument();
+		expect( screen.getByText( 'Subscribed' ) ).toBeInTheDocument();
+	} );
+
+	it( 'omits the status field when the endpoint has no status for the subscriber', async () => {
+		mockFetchSubscriberDetails.mockResolvedValue(
+			makeDetails( {
+				subscription_status: null as unknown as SubscriberDetails[ 'subscription_status' ],
+			} )
+		);
+
+		renderPanel();
+
+		await expect( screen.findByText( 'Subscription type' ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( 'Email subscription' ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/newsletter/tests/subscriber-detail-content.test.tsx
+++ b/projects/packages/newsletter/tests/subscriber-detail-content.test.tsx
@@ -34,7 +34,6 @@ const OPEN = { subscriptionId: 946836646, userId: 229907063 };
 function makeDetails( overrides: Partial< SubscriberDetails > = {} ): SubscriberDetails {
 	return {
 		user_id: OPEN.userId,
-		subscription_id: OPEN.subscriptionId,
 		display_name: 'douglashenritest',
 		email_address: 'reader@example.com',
 		subscription_status: 'Subscribed',
@@ -113,6 +112,20 @@ describe( 'SubscriberDetailContent', () => {
 		);
 	} );
 
+	it( 'decodes HTML entities in category names', async () => {
+		// WordPress stores term names encoded (`Tips &amp; Tricks`) and WP.com passes them through
+		// as stored, so an undecoded name renders the raw entity to the user.
+		mockFetchSubscribedNewsletterCategories.mockResolvedValue( {
+			enabled: true,
+			newsletter_categories: [ { id: 23, name: 'Tips &amp; Tricks', subscribed: true } ],
+		} );
+
+		renderPanel();
+
+		await expect( screen.findByText( 'Tips & Tricks' ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( /&amp;/ ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'says so when the subscriber opted out of every category', async () => {
 		mockFetchSubscribedNewsletterCategories.mockResolvedValue( {
 			enabled: true,
@@ -136,8 +149,36 @@ describe( 'SubscriberDetailContent', () => {
 		expect( screen.queryByText( 'Receives emails for' ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'keeps the panel usable when the categories request fails', async () => {
-		mockFetchSubscribedNewsletterCategories.mockRejectedValue( new Error( 'rest_no_route' ) );
+	it( 'hides the row when WP.com has no categories record for the subscriber', async () => {
+		// A 404 is an expected absence, not a failure: it resolves to "feature off" so the query
+		// settles rather than retrying something that will never succeed.
+		mockFetchSubscribedNewsletterCategories.mockRejectedValue( {
+			code: 'rest_subscriber_not_found',
+			data: { status: 404 },
+		} );
+
+		renderPanel();
+
+		await expect( screen.findByText( 'Subscription type' ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( 'Receives emails for' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'hides the row on a missing route, for a Jetpack version without the proxy', async () => {
+		mockFetchSubscribedNewsletterCategories.mockRejectedValue( { code: 'rest_no_route' } );
+
+		renderPanel();
+
+		await expect( screen.findByText( 'Subscription type' ) ).resolves.toBeInTheDocument();
+		expect( screen.queryByText( 'Receives emails for' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'leaves the rest of the panel intact when the categories request errors outright', async () => {
+		// A 500 is left to reject so React Query can retry it, rather than being cached as a
+		// successful "feature off" for the rest of the session.
+		mockFetchSubscribedNewsletterCategories.mockRejectedValue( {
+			code: 'internal_server_error',
+			data: { status: 500 },
+		} );
 
 		renderPanel();
 

--- a/projects/packages/newsletter/tests/subscriber-helpers.test.ts
+++ b/projects/packages/newsletter/tests/subscriber-helpers.test.ts
@@ -1,8 +1,9 @@
 import {
+	getSubscribedAt,
 	hasNoSubscribersOtherThanOwner,
 	isOpenSubscriberRemoved,
 } from '../_inc/subscribers/lib/subscriber-helpers';
-import type { Subscriber } from '../_inc/subscribers/data/types';
+import type { Subscriber, SubscriberDetails } from '../_inc/subscribers/data/types';
 
 /**
  * Build a minimal subscriber row for the matcher tests.
@@ -84,5 +85,67 @@ describe( 'hasNoSubscribersOtherThanOwner', () => {
 	it( 'is false once there is more than one subscriber, owner included', () => {
 		expect( hasNoSubscribersOtherThanOwner( 2, true ) ).toBe( false );
 		expect( hasNoSubscribersOtherThanOwner( 5, false ) ).toBe( false );
+	} );
+} );
+
+describe( 'getSubscribedAt', () => {
+	it( 'prefers the wpcom date and pins the naive list timestamp to UTC', () => {
+		const subscriber = makeSubscriber( {
+			wpcom_date_subscribed: '2026-07-28 19:02:09',
+			email_date_subscribed: '2020-01-01 00:00:00',
+		} );
+		expect( getSubscribedAt( subscriber ) ).toBe( '2026-07-28 19:02:09+00:00' );
+	} );
+
+	it( 'falls back to the email date for email-only subscribers', () => {
+		const subscriber = makeSubscriber( { email_date_subscribed: '2026-06-12 08:30:00' } );
+		expect( getSubscribedAt( subscriber ) ).toBe( '2026-06-12 08:30:00+00:00' );
+	} );
+
+	it( 'reads `date_subscribed` from the individual-subscriber payload', () => {
+		// The detail panel rendered a blank date before this shape was handled: the individual
+		// endpoint sends one `date_subscribed` rather than the list's wpcom_/email_ pair.
+		const details: SubscriberDetails = {
+			...makeSubscriber( {} ),
+			date_subscribed: '2026-07-28T19:02:09+00:00',
+		};
+		expect( getSubscribedAt( details ) ).toBe( '2026-07-28T19:02:09+00:00' );
+	} );
+
+	it( 'does not append a second offset to an already-zoned date', () => {
+		const zoned: SubscriberDetails = {
+			...makeSubscriber( {} ),
+			date_subscribed: '2026-07-28T16:02:09-03:00',
+		};
+		expect( getSubscribedAt( zoned ) ).toBe( '2026-07-28T16:02:09-03:00' );
+		expect( Number.isNaN( new Date( getSubscribedAt( zoned ) ).getTime() ) ).toBe( false );
+	} );
+
+	it( 'treats a `Z` suffix as already zoned', () => {
+		const utc: SubscriberDetails = {
+			...makeSubscriber( {} ),
+			date_subscribed: '2026-07-28T19:02:09Z',
+		};
+		expect( getSubscribedAt( utc ) ).toBe( '2026-07-28T19:02:09Z' );
+	} );
+
+	it( 'is empty when no date is present', () => {
+		expect( getSubscribedAt( makeSubscriber( {} ) ) ).toBe( '' );
+	} );
+} );
+
+describe( 'getSubscribedAt zero dates', () => {
+	it( 'treats WP.com’s zero date as absent rather than rendering year 0000', () => {
+		const zero: SubscriberDetails = {
+			...makeSubscriber( {} ),
+			date_subscribed: '0000-00-00T00:00:00+00:00',
+		};
+		expect( getSubscribedAt( zero ) ).toBe( '' );
+	} );
+
+	it( 'treats a naive zero date from a list row as absent too', () => {
+		expect(
+			getSubscribedAt( makeSubscriber( { wpcom_date_subscribed: '0000-00-00 00:00:00' } ) )
+		).toBe( '' );
 	} );
 } );

--- a/projects/packages/newsletter/tests/subscribers-api.test.ts
+++ b/projects/packages/newsletter/tests/subscribers-api.test.ts
@@ -1,0 +1,51 @@
+import apiFetch from '@wordpress/api-fetch';
+import { fetchSubscribedNewsletterCategories } from '../_inc/subscribers/data/api';
+
+jest.mock( '@wordpress/api-fetch' );
+
+const mockApiFetch = apiFetch as unknown as jest.Mock;
+
+/**
+ * The path the fetcher asked `apiFetch` for.
+ *
+ * @return Request path.
+ */
+function requestedPath(): string {
+	return mockApiFetch.mock.calls[ 0 ][ 0 ].path;
+}
+
+describe( 'fetchSubscribedNewsletterCategories', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockApiFetch.mockResolvedValue( { enabled: true, newsletter_categories: [] } );
+	} );
+
+	it( 'keys the request by user id and flags type=wpcom when a user id is present', async () => {
+		// WP.com reads a *subscription* record by default and only treats the path segment as a user
+		// id when told to, so getting this branch wrong silently reads the wrong record.
+		await fetchSubscribedNewsletterCategories( { subscription_id: 946836646, user_id: 229907063 } );
+
+		expect( requestedPath() ).toBe(
+			'/wpcom/v2/newsletter-categories/subscriptions/229907063?type=wpcom'
+		);
+	} );
+
+	it( 'keys the request by subscription id, with no type, for an email-only subscriber', async () => {
+		await fetchSubscribedNewsletterCategories( { subscription_id: 946836646 } );
+
+		expect( requestedPath() ).toBe( '/wpcom/v2/newsletter-categories/subscriptions/946836646' );
+	} );
+
+	it( 'treats a zero user id as absent', async () => {
+		// Callers pass `user_id: 0` rather than omitting it for email-only subscribers.
+		await fetchSubscribedNewsletterCategories( { subscription_id: 946836646, user_id: 0 } );
+
+		expect( requestedPath() ).toBe( '/wpcom/v2/newsletter-categories/subscriptions/946836646' );
+	} );
+
+	it( 'issues a GET', async () => {
+		await fetchSubscribedNewsletterCategories( { user_id: 229907063 } );
+
+		expect( mockApiFetch.mock.calls[ 0 ][ 0 ].method ).toBe( 'GET' );
+	} );
+} );

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-newsletter-categories-subscriptions.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-newsletter-categories-subscriptions.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * REST API endpoint exposing a single subscriber's newsletter category subscriptions.
+ *
+ * @package automattic/jetpack
+ * @since $$next-version$$
+ */
+
+use Automattic\Jetpack\Connection\Traits\WPCOM_REST_API_Proxy_Request;
+use Automattic\Jetpack\Status\Host;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
+/**
+ * Class WPCOM_REST_API_V2_Endpoint_Newsletter_Categories_Subscriptions
+ *
+ * Proxies `GET /sites/{blog_id}/newsletter-categories/subscriptions/{id}` so the Newsletter
+ * dashboard can show which categories a subscriber receives emails for. WP.com owns the
+ * implementation, but flags it as a site-specific, WP.com-only endpoint — meaning it only exists
+ * under `/wpcom/v2/sites/{blog_id}/…` on public-api and is unreachable from a Jetpack site's own
+ * REST API without this proxy.
+ */
+class WPCOM_REST_API_V2_Endpoint_Newsletter_Categories_Subscriptions extends WP_REST_Controller {
+	use WPCOM_REST_API_Proxy_Request;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		$this->wpcom_is_wpcom_only_endpoint    = true;
+		$this->wpcom_is_site_specific_endpoint = true;
+		$this->base_api_path                   = 'wpcom';
+		$this->version                         = 'v2';
+		$this->namespace                       = $this->base_api_path . '/' . $this->version;
+		$this->rest_base                       = '/newsletter-categories/subscriptions';
+
+		add_action( 'rest_api_init', array( $this, 'register_routes' ) );
+	}
+
+	/**
+	 * Register routes.
+	 *
+	 * Unlike its sibling newsletter-categories endpoints, this route is not registered on WP.com
+	 * Simple: WP.com already registers its own implementation at this exact path there, and a
+	 * second registration would shadow it.
+	 */
+	public function register_routes() {
+		if ( ( new Host() )->is_wpcom_simple() ) {
+			return;
+		}
+
+		register_rest_route(
+			$this->namespace,
+			$this->rest_base . '/(?P<subscription_id>[0-9]+)',
+			array(
+				'show_in_index'       => true,
+				'methods'             => 'GET',
+				'callback'            => array( $this, 'get_newsletter_categories_subscriptions' ),
+				'permission_callback' => function () {
+					return current_user_can( 'manage_options' );
+				},
+				'args'                => array(
+					'subscription_id' => array(
+						'required'          => true,
+						'validate_callback' => function ( $param ) {
+							return is_numeric( $param );
+						},
+					),
+					'type'            => array(
+						'required'          => false,
+						'validate_callback' => function ( $param ) {
+							return 'wpcom' === $param;
+						},
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Proxy the request to WP.com, forwarding the id as a path segment.
+	 *
+	 * The id is a subscription id by default, or a WP.com user id when `type=wpcom` is passed —
+	 * WP.com resolves the latter to the matching subscription. Query params (including `type`) are
+	 * forwarded by the proxy trait.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return mixed|WP_Error Response from WP.com, or an error.
+	 */
+	public function get_newsletter_categories_subscriptions( $request ) {
+		return $this->proxy_request_to_wpcom_as_user( $request, (string) (int) $request->get_param( 'subscription_id' ) );
+	}
+}
+
+wpcom_rest_api_v2_load_plugin( 'WPCOM_REST_API_V2_Endpoint_Newsletter_Categories_Subscriptions' );

--- a/projects/plugins/jetpack/changelog/fix-newsletter-subscriber-categories
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-subscriber-categories
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Newsletter: add the REST proxy the subscriber details panel needs to show which newsletter categories a subscriber receives emails for.

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Newsletter_Categories_Subscriptions_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Newsletter_Categories_Subscriptions_Test.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Tests for the /wpcom/v2/newsletter-categories/subscriptions/{id} proxy endpoint.
+ *
+ * @covers WPCOM_REST_API_V2_Endpoint_Newsletter_Categories_Subscriptions
+ */
+
+use Automattic\Jetpack\Constants;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WpOrg\Requests\Requests;
+
+require_once dirname( __DIR__, 2 ) . '/lib/Jetpack_REST_TestCase.php';
+
+/**
+ * Class WPCOM_REST_API_V2_Endpoint_Newsletter_Categories_Subscriptions_Test
+ *
+ * @covers \WPCOM_REST_API_V2_Endpoint_Newsletter_Categories_Subscriptions
+ */
+#[CoversClass( WPCOM_REST_API_V2_Endpoint_Newsletter_Categories_Subscriptions::class )]
+class WPCOM_REST_API_V2_Endpoint_Newsletter_Categories_Subscriptions_Test extends Jetpack_REST_TestCase {
+
+	/**
+	 * Mock admin user ID.
+	 *
+	 * @var int
+	 */
+	private static $admin_id = 0;
+
+	/**
+	 * Mock author user ID.
+	 *
+	 * @var int
+	 */
+	private static $author_id = 0;
+
+	/**
+	 * The route under test, with a stand-in id.
+	 *
+	 * @var string
+	 */
+	private const ROUTE = '/wpcom/v2/newsletter-categories/subscriptions/229907063';
+
+	/**
+	 * Create shared database fixtures.
+	 *
+	 * @param WP_UnitTest_Factory $factory Fixture factory.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		static::$admin_id  = $factory->user->create( array( 'role' => 'administrator' ) );
+		static::$author_id = $factory->user->create( array( 'role' => 'author' ) );
+	}
+
+	/**
+	 * Set up the environment for a test.
+	 */
+	public function set_up() {
+		wp_set_current_user( static::$admin_id );
+
+		// Manually load the class under test — `wpcom_rest_api_v2_load_plugin()` only runs on
+		// `plugins_loaded`, which has already passed by the time the test harness boots.
+		// @phan-suppress-next-line PhanNoopNew -- instantiated for the constructor's add_action side effect.
+		new WPCOM_REST_API_V2_Endpoint_Newsletter_Categories_Subscriptions();
+
+		parent::set_up();
+	}
+
+	/**
+	 * Reset the environment to its original state after the test.
+	 */
+	public function tear_down() {
+		Constants::clear_constants();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * The route is registered on Jetpack-connected sites, where WP.com's own implementation is
+	 * out of reach.
+	 */
+	public function test_route_is_registered() {
+		$routes = $this->server->get_routes( 'wpcom/v2' );
+
+		$this->assertArrayHasKey(
+			'/wpcom/v2/newsletter-categories/subscriptions/(?P<subscription_id>[0-9]+)',
+			$routes
+		);
+	}
+
+	/**
+	 * On WP.com Simple, WP.com registers this exact route itself — registering a proxy there would
+	 * shadow the real implementation, so the class stands down.
+	 */
+	public function test_route_is_not_registered_on_wpcom_simple() {
+		Constants::set_constant( 'IS_WPCOM', true );
+
+		$GLOBALS['wp_rest_server'] = new JPTest_Spy_REST_Server();
+		// @phan-suppress-next-line PhanNoopNew -- instantiated for the constructor's add_action side effect.
+		new WPCOM_REST_API_V2_Endpoint_Newsletter_Categories_Subscriptions();
+		do_action( 'rest_api_init' );
+		$this->server = $GLOBALS['wp_rest_server'];
+
+		$this->assertArrayNotHasKey(
+			'/wpcom/v2/newsletter-categories/subscriptions/(?P<subscription_id>[0-9]+)',
+			$this->server->get_routes( 'wpcom/v2' )
+		);
+	}
+
+	/**
+	 * Anonymous requests are rejected before any proxying happens.
+	 */
+	public function test_rejects_anonymous() {
+		wp_set_current_user( 0 );
+
+		$response = $this->server->dispatch( new WP_REST_Request( Requests::GET, self::ROUTE ) );
+
+		$this->assertSame( 401, $response->get_status() );
+	}
+
+	/**
+	 * A subscriber's categories are site management data, so contributors and authors can't read
+	 * them either.
+	 */
+	public function test_rejects_non_admin() {
+		wp_set_current_user( static::$author_id );
+
+		$response = $this->server->dispatch( new WP_REST_Request( Requests::GET, self::ROUTE ) );
+
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * The id is part of the path, so a non-numeric one simply doesn't match the route.
+	 */
+	public function test_non_numeric_id_does_not_match_the_route() {
+		$request  = new WP_REST_Request( Requests::GET, '/wpcom/v2/newsletter-categories/subscriptions/abc' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 404, $response->get_status() );
+		$this->assertSame( 'rest_no_route', $response->get_data()['code'] );
+	}
+
+	/**
+	 * `type` only accepts `wpcom` — WP.com uses it to decide whether the path id is a user id or a
+	 * subscription id, and any other value would silently change which record is read.
+	 */
+	public function test_rejects_unknown_type() {
+		$request = new WP_REST_Request( Requests::GET, self::ROUTE );
+		$request->set_param( 'type', 'email' );
+
+		$response = $this->server->dispatch( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+	}
+}


### PR DESCRIPTION
Fixes JETPACK-2036

## Proposed changes

The modernized Newsletter dashboard's subscriber detail panel never showed which newsletter categories a subscriber receives emails for — the field the legacy Calypso view labels "Receives emails for". Nothing fetched them, and there was no route to fetch them from.

* **Add a REST proxy for the per-subscriber categories endpoint.** WP.com serves them from `/sites/{blog_id}/newsletter-categories/subscriptions/{id}`, but flags it as a site-specific, WP.com-only endpoint — so it exists only under `/wpcom/v2/sites/{blog_id}/…` on public-api, and a Jetpack site's own REST API returns `rest_no_route`. The new endpoint mirrors the two existing `newsletter-categories` proxies. The id is a subscription id by default, or a WP.com user id when `type=wpcom`.
  * Deliberately **not** registered on WP.com Simple: WP.com registers this exact path itself there, and a second registration would shadow the real implementation.
* **Render a "Receives emails for" row**, mirroring Calypso: gated on the site-level `enabled` flag, listing only categories flagged `subscribed`, with a "Not subscribed to any newsletter categories" fallback. Request failures resolve to "feature off" rather than rejecting, so a 404 (subscriber has no subscription record on the blog) or an older Jetpack without the proxy doesn't break the whole panel.
* **Fix the silently blank "Date subscribed" row** — an unrelated bug in the same card. `getSubscribedAt()` only knew the list payload's `wpcom_date_subscribed` / `email_date_subscribed` pair; the individual-subscriber endpoint sends a single `date_subscribed`. The two also differ in format: list dates are naive UTC and need a `+00:00` suffix, while `date_subscribed` already carries an offset — appending a second one makes it unparseable. WP.com also passes through a literal `0000-00-00` zero date instead of omitting the field, now treated as absent so the row hides rather than rendering year 0000.

The panel hides rows with empty values, so both bugs presented as *silently missing fields* rather than errors.

### Note on the "Email subscription" row

That row is also blank today, for a third and separate reason: `/subscribers/individual` returns `subscription_status: null` for every subscriber, because WP.com computes that field while assembling the *list* and the single-subscriber path reads it off a raw record that never carries it. **That fix is landing WP.com-side** and needs no change here — this PR's client already prefers the endpoint's value, verified against a sandbox. There is no ordering dependency between the two: without the WP.com fix that row stays blank exactly as it is on trunk today, so nothing here regresses.

## Screenshots

Subscriber detail panel for the same subscriber, before and after, at 1494×822 on a Jetpack-connected dev site. Subscriber names, email addresses, avatars and the site URL are redacted; the category names and panel layout are untouched.

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/fix/newsletter-subscriber-categories/before-subscriber-detail.jpg) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/fix/newsletter-subscriber-categories/after-subscriber-detail.jpg) |

Before, **Newsletter subscription details** shows only *Email subscription* and *Subscription type*. After, it also shows **Date subscribed** and **Receives emails for** — here listing the three categories this subscriber receives, matching the Calypso view.

## Related product discussion/links

* JETPACK-2036
* Companion WP.com change (subscription status on the individual endpoint) — in review separately.

## Does this pull request change what data or activity we track or use?

No. The new endpoint is a read-only, `manage_options`-gated proxy of an existing WP.com endpoint that the Calypso Subscribers view already calls.

## Testing instructions

Requires a Jetpack-connected site (this cannot be exercised on WP.com Simple, where the route is served by WP.com itself).

**Setup**

* Enable newsletter categories: **Jetpack → Newsletter → Settings**, turn on newsletter categories and mark at least two categories as newsletter categories.
* Have a subscriber subscribed to a *subset* of those categories (opt them out of at least one), so the row proves it filters rather than listing everything.

**Test**

1. Go to **Jetpack → Newsletter → Subscribers** and click a subscriber to open the detail panel.
2. Under **Newsletter subscription details**, confirm a **Receives emails for** row listing only the categories that subscriber actually receives — compare against the same subscriber in the Calypso view at `cloud.jetpack.com/subscribers/<site>`, which should list the identical categories.
3. Confirm **Date subscribed** now shows a date instead of being absent, and that it matches the subscriber's row in the table.
4. Opt the subscriber out of *every* newsletter category and reopen the panel — the row should read "Not subscribed to any newsletter categories".
5. Turn newsletter categories off in Settings and reopen the panel — the **Receives emails for** row should disappear entirely (rather than showing an empty value).
6. Reload the page directly on a URL that already names a subscriber (`…&p=%2F%3Fsubscriber%3D<id>%26u%3D<user_id>`) to confirm the panel populates on a cold load, not just after clicking a row.

**Automated coverage**

* `jp test js packages/newsletter` — 137 tests, including 8 for the detail panel (categories listed / empty / feature-off / request failure) and the date-shape helpers.
* `jp docker phpunit jetpack -- --filter=Newsletter_Categories_Subscriptions` — 6 tests covering route registration, the Simple stand-down, permissions, and arg validation.

