### PR TITLE
Newsletter: add categories inline instead of redirecting to wp-admin

### DIFF
--- a/projects/packages/newsletter/changelog/fix-nl-785-inline-add-category
+++ b/projects/packages/newsletter/changelog/fix-nl-785-inline-add-category
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Newsletter categories: add categories inline instead of linking out to wp-admin, so a new category appears and is selected without a page refresh.

--- a/projects/packages/newsletter/src/settings/api.ts
+++ b/projects/packages/newsletter/src/settings/api.ts
@@ -199,3 +199,57 @@ async function fetchCategoriesViaWpApi(): Promise< Category[] > {
 
 	return allCategories;
 }
+
+/**
+ * Create a new category.
+ * On Simple sites, uses the WordPress.com REST API; otherwise the WordPress REST API.
+ *
+ * Mirrors the Simple-vs-self-hosted split used by `fetchCategories` — the plain
+ * `/wp/v2/categories` endpoint isn't directly reachable on WordPress.com Simple
+ * sites, so we can't rely on `@wordpress/core-data` here.
+ *
+ * @param {string} name - The name of the category to create.
+ * @return {Promise<Category>} The created category.
+ */
+export async function createCategory( name: string ): Promise< Category > {
+	const blogId = getBlogId();
+	if ( isSimpleSite() && blogId ) {
+		return createCategoryViaWpcomApi( name, blogId );
+	}
+
+	return createCategoryViaWpApi( name );
+}
+
+/**
+ * Create a category via the WordPress.com REST API.
+ *
+ * @param {string} name   - The name of the category to create.
+ * @param {number} blogId - The blog ID.
+ * @return {Promise<Category>} The created category.
+ */
+async function createCategoryViaWpcomApi( name: string, blogId: number ): Promise< Category > {
+	const term = ( await apiFetch( {
+		path: `/rest/v1.1/sites/${ blogId }/taxonomies/category/terms/new`,
+		method: 'POST',
+		data: { name },
+	} ) ) as { ID: number; name: string };
+
+	// WordPress.com API returns ID (uppercase), normalize to id (lowercase).
+	return { id: term.ID, name: term.name };
+}
+
+/**
+ * Create a category via the WordPress REST API.
+ *
+ * @param {string} name - The name of the category to create.
+ * @return {Promise<Category>} The created category.
+ */
+async function createCategoryViaWpApi( name: string ): Promise< Category > {
+	const category = ( await apiFetch( {
+		path: '/wp/v2/categories',
+		method: 'POST',
+		data: { name },
+	} ) ) as { id: number; name: string };
+
+	return { id: category.id, name: category.name };
+}

--- a/projects/packages/newsletter/src/settings/api.ts
+++ b/projects/packages/newsletter/src/settings/api.ts
@@ -201,22 +201,22 @@ async function fetchCategoriesViaWpApi(): Promise< Category[] > {
 }
 
 /**
- * Create a new category.
- * On Simple sites, uses the WordPress.com REST API; otherwise the WordPress REST API.
+ * Create a new category via the WordPress REST API (`/wp/v2/categories`).
  *
- * Mirrors the Simple-vs-self-hosted split used by `fetchCategories` — the plain
- * `/wp/v2/categories` endpoint isn't directly reachable on WordPress.com Simple
- * sites, so we can't rely on `@wordpress/core-data` here.
+ * This endpoint works on both self-hosted and WordPress.com Simple sites — in the
+ * wp-admin context the request is proxied to WordPress.com — and, crucially, it
+ * returns errors in the standard WP-REST shape (`{ code: 'term_exists', … }`)
+ * that `@wordpress/api-fetch` parses natively. The older
+ * `/rest/v1.1/…/taxonomies/category/terms/new` endpoint returns wpcom-format
+ * errors (`{ error: 'duplicate' }`) that apiFetch can't parse, so it collapses
+ * them to a generic `unknown_error` and the duplicate signal is lost before we
+ * can read it — hence we use `/wp/v2/categories` everywhere here.
  *
  * @param {string} name - The name of the category to create.
  * @return {Promise<Category>} The created category.
  */
 export async function createCategory( name: string ): Promise< Category > {
-	const blogId = getBlogId();
-	const category =
-		isSimpleSite() && blogId
-			? await createCategoryViaWpcomApi( name, blogId )
-			: await createCategoryViaWpApi( name );
+	const category = await createCategoryViaWpApi( name );
 
 	// Guard against an unexpected success payload: without a numeric id the caller
 	// would select a bogus token (e.g. `String( undefined )`). Surface it as a
@@ -226,45 +226,6 @@ export async function createCategory( name: string ): Promise< Category > {
 	}
 
 	return category;
-}
-
-/**
- * Create a category via the WordPress.com REST API.
- *
- * @param {string} name   - The name of the category to create.
- * @param {number} blogId - The blog ID.
- * @return {Promise<Category>} The created category.
- */
-async function createCategoryViaWpcomApi( name: string, blogId: number ): Promise< Category > {
-	const term = ( await apiFetch( {
-		path: `/rest/v1.1/sites/${ blogId }/taxonomies/category/terms/new`,
-		method: 'POST',
-		data: { name },
-	} ) ) as {
-		ID?: number;
-		name?: string;
-		code?: number;
-		error?: string;
-		message?: string;
-		body?: { code?: number; error?: string; message?: string };
-	};
-
-	// The WordPress.com proxy can *resolve* (not reject) with an error envelope —
-	// e.g. a duplicate comes back as `{ code: 409, body: { error: 'duplicate' } }`.
-	// Re-throw it carrying the error signals so the caller maps it (to the
-	// "already exists" message) instead of treating the missing ID as a generic
-	// failure.
-	const error = term.error ?? term.body?.error;
-	const code = term.code ?? term.body?.code;
-	if ( error || code ) {
-		throw Object.assign(
-			new Error( term.message ?? term.body?.message ?? 'Category creation failed.' ),
-			{ code, error, body: term.body }
-		);
-	}
-
-	// WordPress.com API returns ID (uppercase), normalize to id (lowercase).
-	return { id: term.ID as number, name: term.name as string };
 }
 
 /**

--- a/projects/packages/newsletter/src/settings/api.ts
+++ b/projects/packages/newsletter/src/settings/api.ts
@@ -240,10 +240,31 @@ async function createCategoryViaWpcomApi( name: string, blogId: number ): Promis
 		path: `/rest/v1.1/sites/${ blogId }/taxonomies/category/terms/new`,
 		method: 'POST',
 		data: { name },
-	} ) ) as { ID: number; name: string };
+	} ) ) as {
+		ID?: number;
+		name?: string;
+		code?: number;
+		error?: string;
+		message?: string;
+		body?: { code?: number; error?: string; message?: string };
+	};
+
+	// The WordPress.com proxy can *resolve* (not reject) with an error envelope —
+	// e.g. a duplicate comes back as `{ code: 409, body: { error: 'duplicate' } }`.
+	// Re-throw it carrying the error signals so the caller maps it (to the
+	// "already exists" message) instead of treating the missing ID as a generic
+	// failure.
+	const error = term.error ?? term.body?.error;
+	const code = term.code ?? term.body?.code;
+	if ( error || code ) {
+		throw Object.assign(
+			new Error( term.message ?? term.body?.message ?? 'Category creation failed.' ),
+			{ code, error, body: term.body }
+		);
+	}
 
 	// WordPress.com API returns ID (uppercase), normalize to id (lowercase).
-	return { id: term.ID, name: term.name };
+	return { id: term.ID as number, name: term.name as string };
 }
 
 /**

--- a/projects/packages/newsletter/src/settings/api.ts
+++ b/projects/packages/newsletter/src/settings/api.ts
@@ -213,11 +213,19 @@ async function fetchCategoriesViaWpApi(): Promise< Category[] > {
  */
 export async function createCategory( name: string ): Promise< Category > {
 	const blogId = getBlogId();
-	if ( isSimpleSite() && blogId ) {
-		return createCategoryViaWpcomApi( name, blogId );
+	const category =
+		isSimpleSite() && blogId
+			? await createCategoryViaWpcomApi( name, blogId )
+			: await createCategoryViaWpApi( name );
+
+	// Guard against an unexpected success payload: without a numeric id the caller
+	// would select a bogus token (e.g. `String( undefined )`). Surface it as a
+	// normal failure instead.
+	if ( typeof category.id !== 'number' || ! Number.isFinite( category.id ) ) {
+		throw new Error( 'Unexpected response while creating the category.' );
 	}
 
-	return createCategoryViaWpApi( name );
+	return category;
 }
 
 /**

--- a/projects/packages/newsletter/src/settings/sections/creatable-categories-control.tsx
+++ b/projects/packages/newsletter/src/settings/sections/creatable-categories-control.tsx
@@ -20,9 +20,10 @@
  * "Create ‘…’" via `displayTransform`.
  */
 
-import { FormTokenField } from '@wordpress/components';
+import { FormTokenField, Icon } from '@wordpress/components';
 import { createContext, useCallback, useContext, useMemo, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
+import { caution } from '@wordpress/icons';
 import { createCategory } from '../api';
 import type { NewsletterSettings, WordPressCategory } from '../types';
 
@@ -285,6 +286,16 @@ export function CreatableCategoriesControl( {
 		[ nameToId, selectedIds, handleCreate, commit ]
 	);
 
+	// Clear a prior creation error (e.g. "This category already exists.") as soon
+	// as the user edits the name, rather than leaving it up until the next submit.
+	const handleInputChange = useCallback(
+		( value: string ) => {
+			setSearch( value );
+			context?.onError( null );
+		},
+		[ context ]
+	);
+
 	// DataViews delegates validity display to the control. Surface the field's
 	// custom rule ("select at least one category") beneath the token field.
 	const validationMessage = validity?.custom?.message;
@@ -299,7 +310,7 @@ export function CreatableCategoriesControl( {
 				suggestions={ suggestions }
 				displayTransform={ displayTransform }
 				onChange={ onChangeTokens }
-				onInputChange={ setSearch }
+				onInputChange={ handleInputChange }
 				placeholder={ __( 'Search or create a category', 'jetpack-newsletter' ) }
 				disabled={ disabled || isCreating }
 				__experimentalExpandOnFocus={ elements.length > 0 }
@@ -311,7 +322,10 @@ export function CreatableCategoriesControl( {
 				<p className="newsletter-categories-control__help">{ field.description }</p>
 			) }
 			{ validationMessage && (
-				<p className="newsletter-categories-control__error">{ validationMessage }</p>
+				<p className="newsletter-categories-control__error">
+					<Icon icon={ caution } size={ 20 } />
+					<span>{ validationMessage }</span>
+				</p>
 			) }
 		</div>
 	);

--- a/projects/packages/newsletter/src/settings/sections/creatable-categories-control.tsx
+++ b/projects/packages/newsletter/src/settings/sections/creatable-categories-control.tsx
@@ -1,0 +1,310 @@
+/**
+ * Creatable categories control (NL-785)
+ *
+ * A custom DataViews `Edit` control for the newsletter-categories field. It
+ * renders a single `FormTokenField` that lets the user both *search* existing
+ * categories and *create* a new one from the same input: typing a name that
+ * doesn't match an existing category surfaces a "Create ‘…’" row at the bottom
+ * of the suggestions. Choosing it (or pressing Enter on a new name) creates the
+ * category, adds it to the list without a page refresh, and selects it.
+ *
+ * This collapses the previous two affordances — a token field for existing
+ * categories plus a separate "Add new category" link — into one, removing the
+ * ambiguity between "add an existing category" and "create a new one".
+ *
+ * The model mirrors the WordPress editor's `FlatTermSelector`: selections are
+ * stored as category IDs (the form value), while the token field works in
+ * display-name space via `displayTransform`. The "create" row is encoded as a
+ * sentinel-prefixed suggestion so it can be told apart from a real category by
+ * value, not by its (translated) label.
+ */
+
+import { FormTokenField } from '@wordpress/components';
+import { useCallback, useMemo, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import { createContext, useContext } from 'react';
+import { createCategory } from '../api';
+import type { NewsletterSettings, WordPressCategory } from '../types';
+
+/**
+ * Sentinel prefixing the "create" suggestion's value. Lets us distinguish the
+ * create row from a real category by value rather than by its (translated)
+ * label, and is vanishingly unlikely to collide with a real name. Built from a
+ * private-use code point via `String.fromCodePoint` so no invisible source
+ * character can be silently normalized away by an editor or formatter.
+ */
+const CREATE_PREFIX = String.fromCodePoint( 0xf8ff ) + 'create:';
+
+interface CategoryElement {
+	value: string;
+	label: string;
+}
+
+/**
+ * Extra wiring the control needs from the section, provided via context so the
+ * control component keeps a stable identity across the section's re-renders
+ * (a new `Edit` component identity would remount the field and drop focus).
+ */
+export interface CreatableCategoryContextValue {
+	/** Append a freshly created category to the section's list (deduped). */
+	appendCategory: ( category: WordPressCategory ) => void;
+	/** Surface (or clear) an inline error message for a failed creation. */
+	onError: ( message: string | null ) => void;
+	/** Notify the section that a category was created (for analytics). */
+	onCreated: () => void;
+}
+
+export const CreatableCategoryContext = createContext< CreatableCategoryContextValue | null >(
+	null
+);
+
+/**
+ * Map a category-creation error to a short, translated message.
+ *
+ * Duplicate-name detection differs by platform and error envelope: self-hosted
+ * WP REST rejects with `code: 'term_exists'`; the WordPress.com v1.1 endpoint
+ * rejects with `error: 'duplicate'`, sometimes wrapped in a proxy envelope
+ * (`{ code: 409, body: { error: 'duplicate' } }`) where the top-level `code` is
+ * the HTTP status. Anything else gets a friendly generic message rather than
+ * the raw, English-only server text.
+ *
+ * @param err - The rejection thrown by `createCategory`.
+ * @return A translated, user-facing error message.
+ */
+export function mapCreateCategoryError( err: unknown ): string {
+	const errorLike = err as {
+		code?: string | number;
+		error?: string;
+		body?: { code?: string | number; error?: string };
+	};
+	const signals = [ errorLike.code, errorLike.error, errorLike.body?.code, errorLike.body?.error ];
+	const isDuplicate =
+		signals.includes( 'term_exists' ) ||
+		signals.includes( 'duplicate' ) ||
+		// A 409 Conflict when creating a term always means a name clash.
+		errorLike.code === 409 ||
+		errorLike.body?.code === 409;
+
+	// Assign each translated string to its own variable rather than branching a
+	// single ternary between two `__()` calls: production minification hoists the
+	// shared `__( …, 'jetpack-newsletter' )` wrapper out of the conditional,
+	// leaving a non-literal msgid that fails the i18n string check.
+	const duplicateMessage = __( 'This category already exists.', 'jetpack-newsletter' );
+	const genericMessage = __(
+		'Could not create the category. Please try again.',
+		'jetpack-newsletter'
+	);
+	return isDuplicate ? duplicateMessage : genericMessage;
+}
+
+/**
+ * The `field` shape DataViews passes to a custom `Edit` control. The precise
+ * `NormalizedField` type isn't exported by `@wordpress/dataviews`, so we type
+ * only the members this control uses.
+ */
+interface NormalizedCategoryField {
+	label: string;
+	description?: string;
+	elements?: CategoryElement[];
+	getValue: ( args: { item: NewsletterSettings } ) => string[] | undefined;
+	setValue: ( args: {
+		item: NewsletterSettings;
+		value: string[];
+	} ) => Partial< NewsletterSettings >;
+	isDisabled?: ( args: { item: NewsletterSettings; field: unknown } ) => boolean;
+}
+
+/** Subset of DataViews' `FieldValidity` this control renders. */
+interface CategoryFieldValidity {
+	custom?: { type?: string; message?: string };
+	elements?: { type?: string; message?: string };
+}
+
+export interface CreatableCategoriesControlProps {
+	data: NewsletterSettings;
+	field: NormalizedCategoryField;
+	onChange: ( value: Partial< NewsletterSettings > ) => void;
+	hideLabelFromVision?: boolean;
+	validity?: CategoryFieldValidity;
+}
+
+/**
+ * Deduplicate an array of IDs, preserving order.
+ *
+ * @param ids - The IDs to dedupe.
+ * @return The IDs with duplicates removed.
+ */
+function uniqueIds( ids: string[] ): string[] {
+	return Array.from( new Set( ids ) );
+}
+
+/**
+ * The combined search-and-create categories control.
+ *
+ * @param props                     - DataViews control props.
+ * @param props.data                - The form item being edited.
+ * @param props.field               - The normalized categories field.
+ * @param props.onChange            - Called with the field's partial update.
+ * @param props.hideLabelFromVision - Whether to visually hide the field label.
+ * @param props.validity            - Validity state for the field, if any.
+ * @return The rendered `FormTokenField`.
+ */
+export function CreatableCategoriesControl( {
+	data,
+	field,
+	onChange,
+	hideLabelFromVision,
+	validity,
+}: CreatableCategoriesControlProps ): JSX.Element {
+	const context = useContext( CreatableCategoryContext );
+	const [ search, setSearch ] = useState( '' );
+	const [ isCreating, setIsCreating ] = useState( false );
+
+	// `field.elements` is a fresh array each render; memoize a stable reference so
+	// the callbacks below don't rebuild on every render.
+	const elements = useMemo( () => field.elements ?? [], [ field.elements ] );
+	const selectedIds = field.getValue( { item: data } ) ?? [];
+	const disabled = field.isDisabled?.( { item: data, field } ) ?? false;
+
+	// Work in category-name space (like the editor's FlatTermSelector): the token
+	// field matches typed text against the visible names, so we drive it with
+	// names and translate names ↔ IDs at the form-data boundary. (FormTokenField
+	// filters suggestions by their raw value, so name-valued suggestions are what
+	// make search-by-typing work.)
+	const idToName = useMemo(
+		() => new Map( elements.map( element => [ element.value, element.label ] as const ) ),
+		[ elements ]
+	);
+	const nameToId = useMemo(
+		() =>
+			new Map( elements.map( element => [ element.label.toLowerCase(), element.value ] as const ) ),
+		[ elements ]
+	);
+	const selectedNames = selectedIds.map( id => idToName.get( id ) ?? id );
+
+	const trimmed = search.trim();
+	const hasExactMatch = nameToId.has( trimmed.toLowerCase() );
+
+	// Existing category names plus, when the query names something new, a trailing
+	// "create" row (sentinel-encoded so it's told apart from a real name).
+	const suggestions = [
+		...elements.map( element => element.label ),
+		...( trimmed && ! hasExactMatch ? [ CREATE_PREFIX + trimmed ] : [] ),
+	];
+
+	const commit = useCallback(
+		( ids: string[] ) => {
+			onChange( field.setValue( { item: data, value: uniqueIds( ids ) } ) );
+		},
+		[ onChange, field, data ]
+	);
+
+	const handleCreate = useCallback(
+		( name: string, keepIds: string[] ) => {
+			const trimmedName = name.trim();
+			if ( ! trimmedName || isCreating || ! context ) {
+				return;
+			}
+
+			context.onError( null );
+			setIsCreating( true );
+
+			createCategory( trimmedName )
+				.then( created => {
+					const id = String( created.id );
+					// Add to the section's list so it renders as a token without a
+					// page refresh, then select it alongside the existing choices.
+					context.appendCategory( { id, name: created.name } );
+					context.onCreated();
+					commit( [ ...keepIds, id ] );
+				} )
+				.catch( ( err: unknown ) => {
+					context.onError( mapCreateCategoryError( err ) );
+				} )
+				.finally( () => {
+					setIsCreating( false );
+					setSearch( '' );
+				} );
+		},
+		[ isCreating, context, commit ]
+	);
+
+	const displayTransform = useCallback( ( token: string ): string => {
+		if ( token.startsWith( CREATE_PREFIX ) ) {
+			return sprintf(
+				// translators: %s: the category name the user typed.
+				__( 'Create “%s”', 'jetpack-newsletter' ),
+				token.slice( CREATE_PREFIX.length )
+			);
+		}
+		// Tokens are already category names.
+		return token;
+	}, [] );
+
+	const onChangeTokens = useCallback(
+		( tokens: Array< string | { value: string } > ) => {
+			const names = tokens.map( token =>
+				typeof token === 'object' && token && 'value' in token ? token.value : token
+			) as string[];
+
+			let createName: string | null = null;
+			const keepIds: string[] = [];
+
+			for ( const token of names ) {
+				if ( token.startsWith( CREATE_PREFIX ) ) {
+					// The explicit "Create ‘…’" row.
+					createName = token.slice( CREATE_PREFIX.length );
+				} else {
+					const existingId = nameToId.get( token.toLowerCase() );
+					if ( existingId ) {
+						keepIds.push( existingId );
+					} else {
+						// A free-typed new name (e.g. Enter without picking the Create row).
+						createName = token;
+					}
+				}
+			}
+
+			if ( createName ) {
+				handleCreate( createName, keepIds );
+				return;
+			}
+
+			commit( keepIds );
+			setSearch( '' );
+		},
+		[ nameToId, handleCreate, commit ]
+	);
+
+	// DataViews delegates validity display to the control. Surface the field's
+	// custom rule ("select at least one category") — and any element error —
+	// beneath the token field.
+	const validationMessage = validity?.custom?.message ?? validity?.elements?.message;
+
+	return (
+		<div className="newsletter-categories-control">
+			<FormTokenField
+				__next40pxDefaultSize
+				__nextHasNoMarginBottom
+				label={ hideLabelFromVision ? undefined : field.label }
+				value={ selectedNames }
+				suggestions={ suggestions }
+				displayTransform={ displayTransform }
+				onChange={ onChangeTokens }
+				onInputChange={ setSearch }
+				placeholder={ __( 'Search or create a category', 'jetpack-newsletter' ) }
+				disabled={ disabled || isCreating }
+				__experimentalExpandOnFocus={ elements.length > 0 }
+				// The placeholder and the "Create ‘…’" row already convey the
+				// interaction; drop the default "Separate with commas…" hint.
+				__experimentalShowHowTo={ false }
+			/>
+			{ field.description && (
+				<p className="newsletter-categories-control__help">{ field.description }</p>
+			) }
+			{ validationMessage && (
+				<p className="newsletter-categories-control__error">{ validationMessage }</p>
+			) }
+		</div>
+	);
+}

--- a/projects/packages/newsletter/src/settings/sections/creatable-categories-control.tsx
+++ b/projects/packages/newsletter/src/settings/sections/creatable-categories-control.tsx
@@ -62,32 +62,59 @@ export const CreatableCategoryContext = createContext< CreatableCategoryContextV
 );
 
 /**
- * Map a category-creation error to a short, translated message.
+ * Whether a category-creation rejection is a duplicate-name clash.
  *
- * Duplicate-name detection differs by platform and error envelope: self-hosted
- * WP REST rejects with `code: 'term_exists'`; the WordPress.com v1.1 endpoint
- * rejects with `error: 'duplicate'`, sometimes wrapped in a proxy envelope
- * (`{ code: 409, body: { error: 'duplicate' } }`) where the top-level `code` is
- * the HTTP status. Anything else gets a friendly generic message rather than
- * the raw, English-only server text.
+ * The shape is unpredictable: it varies by platform (self-hosted WP REST vs. the
+ * WordPress.com `/rest/v1.1` endpoint) and by transport. On WordPress.com the
+ * `http_envelope` middleware wraps the real status/body in an envelope
+ * (`{ code: 409, body: { error: 'duplicate' } }`) and can surface it either as a
+ * resolved value we re-throw or as a rejection whose nesting we can't reliably
+ * predict. Rather than target one exact structure (which has bitten us
+ * repeatedly), scan the whole error object for a duplicate signal at any depth,
+ * then fall back to the server message as a last resort.
+ *
+ * @param err - The value `createCategory` rejected with.
+ * @return Whether it represents a duplicate-name error.
+ */
+function isDuplicateCreateError( err: unknown ): boolean {
+	const seen = new Set< unknown >();
+	const scan = ( value: unknown, depth: number ): boolean => {
+		if ( value == null || depth > 5 || seen.has( value ) ) {
+			return false;
+		}
+		if ( typeof value === 'string' ) {
+			return value === 'duplicate' || value === 'term_exists';
+		}
+		if ( typeof value === 'object' ) {
+			seen.add( value );
+			const record = value as Record< string, unknown >;
+			// A 409 Conflict on term creation is always a name clash.
+			if ( record.code === 409 || record.status === 409 ) {
+				return true;
+			}
+			return Object.values( record ).some( nested => scan( nested, depth + 1 ) );
+		}
+		return false;
+	};
+
+	if ( scan( err, 0 ) ) {
+		return true;
+	}
+
+	// Last resort when no structured signal survives the transport: match the
+	// (English) server message. Guarded behind the structured checks above so it
+	// only matters when nothing better is available.
+	const message = ( err as { message?: string } )?.message;
+	return typeof message === 'string' && /already exists/i.test( message );
+}
+
+/**
+ * Map a category-creation error to a short, translated message.
  *
  * @param err - The rejection thrown by `createCategory`.
  * @return A translated, user-facing error message.
  */
 export function mapCreateCategoryError( err: unknown ): string {
-	const errorLike = err as {
-		code?: string | number;
-		error?: string;
-		body?: { code?: string | number; error?: string };
-	};
-	const signals = [ errorLike.code, errorLike.error, errorLike.body?.code, errorLike.body?.error ];
-	const isDuplicate =
-		signals.includes( 'term_exists' ) ||
-		signals.includes( 'duplicate' ) ||
-		// A 409 Conflict when creating a term always means a name clash.
-		errorLike.code === 409 ||
-		errorLike.body?.code === 409;
-
 	// Assign each translated string to its own variable rather than branching a
 	// single ternary between two `__()` calls: production minification hoists the
 	// shared `__( …, 'jetpack-newsletter' )` wrapper out of the conditional,
@@ -97,7 +124,7 @@ export function mapCreateCategoryError( err: unknown ): string {
 		'Could not create the category. Please try again.',
 		'jetpack-newsletter'
 	);
-	return isDuplicate ? duplicateMessage : genericMessage;
+	return isDuplicateCreateError( err ) ? duplicateMessage : genericMessage;
 }
 
 /**

--- a/projects/packages/newsletter/src/settings/sections/creatable-categories-control.tsx
+++ b/projects/packages/newsletter/src/settings/sections/creatable-categories-control.tsx
@@ -12,11 +12,12 @@
  * categories plus a separate "Add new category" link — into one, removing the
  * ambiguity between "add an existing category" and "create a new one".
  *
- * The model mirrors the WordPress editor's `FlatTermSelector`: selections are
- * stored as category IDs (the form value), while the token field works in
- * display-name space via `displayTransform`. The "create" row is encoded as a
- * sentinel-prefixed suggestion so it can be told apart from a real category by
- * value, not by its (translated) label.
+ * The model mirrors the WordPress editor's `FlatTermSelector`: the token field
+ * works in category-name space (its value and suggestions are names), while the
+ * form value stays a list of IDs — names and IDs are translated at the data
+ * boundary. The "create" row is a sentinel-prefixed suggestion, told apart from
+ * a real category by value (not its translated label) and rendered as
+ * "Create ‘…’" via `displayTransform`.
  */
 
 import { FormTokenField } from '@wordpress/components';

--- a/projects/packages/newsletter/src/settings/sections/creatable-categories-control.tsx
+++ b/projects/packages/newsletter/src/settings/sections/creatable-categories-control.tsx
@@ -21,9 +21,8 @@
  */
 
 import { FormTokenField } from '@wordpress/components';
-import { useCallback, useMemo, useState } from '@wordpress/element';
+import { createContext, useCallback, useContext, useMemo, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { createContext, useContext } from 'react';
 import { createCategory } from '../api';
 import type { NewsletterSettings, WordPressCategory } from '../types';
 
@@ -163,7 +162,10 @@ export function CreatableCategoriesControl( {
 	// `field.elements` is a fresh array each render; memoize a stable reference so
 	// the callbacks below don't rebuild on every render.
 	const elements = useMemo( () => field.elements ?? [], [ field.elements ] );
-	const selectedIds = field.getValue( { item: data } ) ?? [];
+	// Memoize on the raw form value so `selectedIds` is stable across renders
+	// unless the selection actually changes (it feeds `onChangeTokens`' deps).
+	const rawSelectedIds = field.getValue( { item: data } );
+	const selectedIds = useMemo( () => rawSelectedIds ?? [], [ rawSelectedIds ] );
 	const disabled = field.isDisabled?.( { item: data, field } ) ?? false;
 
 	// Work in category-name space (like the editor's FlatTermSelector): the token
@@ -247,6 +249,12 @@ export function CreatableCategoriesControl( {
 				typeof token === 'object' && token && 'value' in token ? token.value : token
 			) as string[];
 
+			// A selected ID that isn't in `elements` (a deleted category, or one not
+			// yet loaded) renders as its raw ID. Keep such tokens as-is on change
+			// rather than mistaking an unresolved existing selection for a new name
+			// to create — otherwise touching the field would spawn a category named
+			// after the ID and drop the real selection.
+			const selectedIdSet = new Set( selectedIds );
 			let createName: string | null = null;
 			const keepIds: string[] = [];
 
@@ -254,14 +262,15 @@ export function CreatableCategoriesControl( {
 				if ( token.startsWith( CREATE_PREFIX ) ) {
 					// The explicit "Create ‘…’" row.
 					createName = token.slice( CREATE_PREFIX.length );
+					continue;
+				}
+				const id =
+					nameToId.get( token.toLowerCase() ) ?? ( selectedIdSet.has( token ) ? token : undefined );
+				if ( id ) {
+					keepIds.push( id );
 				} else {
-					const existingId = nameToId.get( token.toLowerCase() );
-					if ( existingId ) {
-						keepIds.push( existingId );
-					} else {
-						// A free-typed new name (e.g. Enter without picking the Create row).
-						createName = token;
-					}
+					// A genuinely new, free-typed name (e.g. Enter without the Create row).
+					createName = token;
 				}
 			}
 
@@ -273,7 +282,7 @@ export function CreatableCategoriesControl( {
 			commit( keepIds );
 			setSearch( '' );
 		},
-		[ nameToId, handleCreate, commit ]
+		[ nameToId, selectedIds, handleCreate, commit ]
 	);
 
 	// DataViews delegates validity display to the control. Surface the field's

--- a/projects/packages/newsletter/src/settings/sections/creatable-categories-control.tsx
+++ b/projects/packages/newsletter/src/settings/sections/creatable-categories-control.tsx
@@ -117,7 +117,6 @@ interface NormalizedCategoryField {
 /** Subset of DataViews' `FieldValidity` this control renders. */
 interface CategoryFieldValidity {
 	custom?: { type?: string; message?: string };
-	elements?: { type?: string; message?: string };
 }
 
 export interface CreatableCategoriesControlProps {
@@ -277,9 +276,8 @@ export function CreatableCategoriesControl( {
 	);
 
 	// DataViews delegates validity display to the control. Surface the field's
-	// custom rule ("select at least one category") — and any element error —
-	// beneath the token field.
-	const validationMessage = validity?.custom?.message ?? validity?.elements?.message;
+	// custom rule ("select at least one category") beneath the token field.
+	const validationMessage = validity?.custom?.message;
 
 	return (
 		<div className="newsletter-categories-control">

--- a/projects/packages/newsletter/src/settings/sections/creatable-categories-control.tsx
+++ b/projects/packages/newsletter/src/settings/sections/creatable-categories-control.tsx
@@ -23,7 +23,9 @@
 import { FormTokenField, Icon } from '@wordpress/components';
 import { createContext, useCallback, useContext, useMemo, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
-import { caution } from '@wordpress/icons';
+// `error` is the triangle-exclamation the design system (and @wordpress/components'
+// own validity indicator) uses for form-validation errors.
+import { error as errorIcon } from '@wordpress/icons';
 import { createCategory } from '../api';
 import type { NewsletterSettings, WordPressCategory } from '../types';
 
@@ -323,7 +325,7 @@ export function CreatableCategoriesControl( {
 			) }
 			{ validationMessage && (
 				<p className="newsletter-categories-control__error">
-					<Icon icon={ caution } size={ 20 } />
+					<Icon icon={ errorIcon } size={ 20 } />
 					<span>{ validationMessage }</span>
 				</p>
 			) }

--- a/projects/packages/newsletter/src/settings/sections/creatable-categories-control.tsx
+++ b/projects/packages/newsletter/src/settings/sections/creatable-categories-control.tsx
@@ -192,23 +192,30 @@ export function CreatableCategoriesControl( {
 	);
 
 	const handleCreate = useCallback(
-		( name: string, keepIds: string[] ) => {
-			const trimmedName = name.trim();
-			if ( ! trimmedName || isCreating || ! context ) {
+		( names: string[], keepIds: string[] ) => {
+			// A single change can carry more than one new name (e.g. a
+			// comma-separated paste), so create them all rather than dropping the
+			// extras. Trim, drop blanks, and de-dupe first.
+			const toCreate = Array.from( new Set( names.map( name => name.trim() ).filter( Boolean ) ) );
+			if ( ! toCreate.length || isCreating || ! context ) {
 				return;
 			}
 
 			context.onError( null );
 			setIsCreating( true );
 
-			createCategory( trimmedName )
+			Promise.all( toCreate.map( name => createCategory( name ) ) )
 				.then( created => {
-					const id = String( created.id );
-					// Add to the section's list so it renders as a token without a
-					// page refresh, then select it alongside the existing choices.
-					context.appendCategory( { id, name: created.name } );
-					context.onCreated();
-					commit( [ ...keepIds, id ] );
+					const createdIds = created.map( category => {
+						const id = String( category.id );
+						// Add to the section's list so it renders as a token without a
+						// page refresh, and record the creation.
+						context.appendCategory( { id, name: category.name } );
+						context.onCreated();
+						return id;
+					} );
+					// Select the new categories alongside the existing choices.
+					commit( [ ...keepIds, ...createdIds ] );
 				} )
 				.catch( ( err: unknown ) => {
 					context.onError( mapCreateCategoryError( err ) );
@@ -245,13 +252,13 @@ export function CreatableCategoriesControl( {
 			// to create — otherwise touching the field would spawn a category named
 			// after the ID and drop the real selection.
 			const selectedIdSet = new Set( selectedIds );
-			let createName: string | null = null;
+			const createNames: string[] = [];
 			const keepIds: string[] = [];
 
 			for ( const token of names ) {
 				if ( token.startsWith( CREATE_PREFIX ) ) {
 					// The explicit "Create ‘…’" row.
-					createName = token.slice( CREATE_PREFIX.length );
+					createNames.push( token.slice( CREATE_PREFIX.length ) );
 					continue;
 				}
 				const id =
@@ -260,12 +267,12 @@ export function CreatableCategoriesControl( {
 					keepIds.push( id );
 				} else {
 					// A genuinely new, free-typed name (e.g. Enter without the Create row).
-					createName = token;
+					createNames.push( token );
 				}
 			}
 
-			if ( createName ) {
-				handleCreate( createName, keepIds );
+			if ( createNames.length ) {
+				handleCreate( createNames, keepIds );
 				return;
 			}
 
@@ -311,7 +318,7 @@ export function CreatableCategoriesControl( {
 				<p className="newsletter-categories-control__help">{ field.description }</p>
 			) }
 			{ validationMessage && (
-				<p className="newsletter-categories-control__error">
+				<p className="newsletter-categories-control__error" aria-live="polite">
 					<Icon icon={ errorIcon } size={ 20 } />
 					<span>{ validationMessage }</span>
 				</p>

--- a/projects/packages/newsletter/src/settings/sections/creatable-categories-control.tsx
+++ b/projects/packages/newsletter/src/settings/sections/creatable-categories-control.tsx
@@ -62,59 +62,19 @@ export const CreatableCategoryContext = createContext< CreatableCategoryContextV
 );
 
 /**
- * Whether a category-creation rejection is a duplicate-name clash.
- *
- * The shape is unpredictable: it varies by platform (self-hosted WP REST vs. the
- * WordPress.com `/rest/v1.1` endpoint) and by transport. On WordPress.com the
- * `http_envelope` middleware wraps the real status/body in an envelope
- * (`{ code: 409, body: { error: 'duplicate' } }`) and can surface it either as a
- * resolved value we re-throw or as a rejection whose nesting we can't reliably
- * predict. Rather than target one exact structure (which has bitten us
- * repeatedly), scan the whole error object for a duplicate signal at any depth,
- * then fall back to the server message as a last resort.
- *
- * @param err - The value `createCategory` rejected with.
- * @return Whether it represents a duplicate-name error.
- */
-function isDuplicateCreateError( err: unknown ): boolean {
-	const seen = new Set< unknown >();
-	const scan = ( value: unknown, depth: number ): boolean => {
-		if ( value == null || depth > 5 || seen.has( value ) ) {
-			return false;
-		}
-		if ( typeof value === 'string' ) {
-			return value === 'duplicate' || value === 'term_exists';
-		}
-		if ( typeof value === 'object' ) {
-			seen.add( value );
-			const record = value as Record< string, unknown >;
-			// A 409 Conflict on term creation is always a name clash.
-			if ( record.code === 409 || record.status === 409 ) {
-				return true;
-			}
-			return Object.values( record ).some( nested => scan( nested, depth + 1 ) );
-		}
-		return false;
-	};
-
-	if ( scan( err, 0 ) ) {
-		return true;
-	}
-
-	// Last resort when no structured signal survives the transport: match the
-	// (English) server message. Guarded behind the structured checks above so it
-	// only matters when nothing better is available.
-	const message = ( err as { message?: string } )?.message;
-	return typeof message === 'string' && /already exists/i.test( message );
-}
-
-/**
  * Map a category-creation error to a short, translated message.
+ *
+ * `createCategory` uses `/wp/v2/categories`, whose duplicate rejection is the
+ * standard WP-REST `{ code: 'term_exists', … }` on both self-hosted and
+ * WordPress.com Simple sites. Anything else gets a friendly generic message
+ * rather than the raw, English-only server text.
  *
  * @param err - The rejection thrown by `createCategory`.
  * @return A translated, user-facing error message.
  */
 export function mapCreateCategoryError( err: unknown ): string {
+	const isDuplicate = ( err as { code?: string | number } )?.code === 'term_exists';
+
 	// Assign each translated string to its own variable rather than branching a
 	// single ternary between two `__()` calls: production minification hoists the
 	// shared `__( …, 'jetpack-newsletter' )` wrapper out of the conditional,
@@ -124,7 +84,7 @@ export function mapCreateCategoryError( err: unknown ): string {
 		'Could not create the category. Please try again.',
 		'jetpack-newsletter'
 	);
-	return isDuplicateCreateError( err ) ? duplicateMessage : genericMessage;
+	return isDuplicate ? duplicateMessage : genericMessage;
 }
 
 /**

--- a/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
@@ -4,23 +4,26 @@
 import analytics from '@automattic/jetpack-analytics';
 import { getSiteData, getSiteType, isWpcomPlatformSite } from '@automattic/jetpack-script-data';
 import { WpcomSupportLink } from '@automattic/jetpack-shared-extension-utils/components/wpcom-support-link';
-import { TextControl } from '@wordpress/components';
 import { DataForm, type Field, useFormValidity } from '@wordpress/dataviews';
 import {
 	createInterpolateElement,
 	useCallback,
 	useEffect,
-	useRef,
+	useMemo,
 	useState,
 } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Button, Card, Fieldset, Link, Notice, Stack, Text } from '@wordpress/ui';
+import { Button, Card, Fieldset, Link, Notice, Text } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
-import { createCategory, fetchCategories } from '../api';
+import { fetchCategories } from '../api';
+import {
+	CreatableCategoriesControl,
+	CreatableCategoryContext,
+} from './creatable-categories-control';
 import type { NewsletterSettings, WordPressCategory } from '../types';
-import type { KeyboardEvent } from 'react';
+import type { CreatableCategoryContextValue } from './creatable-categories-control';
 
 interface NewsletterCategoriesSectionProps {
 	data: NewsletterSettings;
@@ -52,38 +55,8 @@ export function NewsletterCategoriesSection( {
 	const [ categories, setCategories ] = useState< WordPressCategory[] >( [] );
 	const [ isFetchingCategories, setIsFetchingCategories ] = useState( true );
 	const [ categoriesError, setCategoriesError ] = useState< string | null >( null );
-
-	// Inline "add new category" flow. Replaces the old wp-admin link so the new
-	// category is created in place and shows up in the list without a refresh.
-	const [ isAddingCategory, setIsAddingCategory ] = useState( false );
-	const [ newCategoryName, setNewCategoryName ] = useState( '' );
-	const [ isCreatingCategory, setIsCreatingCategory ] = useState( false );
+	// Error surfaced by the combined create/search control when a creation fails.
 	const [ createCategoryError, setCreateCategoryError ] = useState< string | null >( null );
-
-	// Focus targets for the disclosure pattern: move focus into the form on open,
-	// return it to the trigger on close.
-	const newCategoryInputRef = useRef< HTMLInputElement >( null );
-	const addCategoryTriggerRef = useRef< HTMLButtonElement >( null );
-	const wasAddingCategoryRef = useRef( false );
-
-	// Latest saved selection, read inside the async create handler so a category
-	// the user toggles while the request is in flight isn't clobbered by a stale
-	// closure over `data.wpcom_newsletter_categories`.
-	const selectedCategoriesRef = useRef( data.wpcom_newsletter_categories );
-	useEffect( () => {
-		selectedCategoriesRef.current = data.wpcom_newsletter_categories;
-	}, [ data.wpcom_newsletter_categories ] );
-
-	// Move focus into the form when it opens; return it to the trigger on close
-	// (but not on the initial render, when the form was never open).
-	useEffect( () => {
-		if ( isAddingCategory ) {
-			newCategoryInputRef.current?.focus();
-		} else if ( wasAddingCategoryRef.current ) {
-			addCategoryTriggerRef.current?.focus();
-		}
-		wasAddingCategoryRef.current = isAddingCategory;
-	}, [ isAddingCategory ] );
 
 	// Track section save with the keys that changed since the last save.
 	const handleSave = useCallback( () => {
@@ -96,113 +69,29 @@ export function NewsletterCategoriesSection( {
 		onSave();
 	}, [ changedKeys, onSave, siteType ] );
 
-	const trimmedNewCategoryName = newCategoryName.trim();
-
-	// Open the inline add-category form.
-	const startAddCategory = useCallback( () => {
-		setIsAddingCategory( true );
+	// Append a freshly created category to the list so it renders as a token
+	// without a page refresh (deduped in case it already slipped in).
+	const appendCategory = useCallback( ( category: WordPressCategory ) => {
+		setCategories( prev =>
+			prev.some( cat => cat.id === category.id ) ? prev : [ ...prev, category ]
+		);
 	}, [] );
 
-	// Reset and close the inline add-category form.
-	const cancelAddCategory = useCallback( () => {
-		setIsAddingCategory( false );
-		setNewCategoryName( '' );
-		setCreateCategoryError( null );
-	}, [] );
+	// Fired by the control when a category is successfully created.
+	const handleCategoryCreated = useCallback( () => {
+		analytics.tracks.recordEvent( 'jetpack_newsletter_category_created', {
+			site_type: siteType,
+		} );
+	}, [ siteType ] );
 
-	// Create the category, append it to the list, and auto-select it.
-	const handleCreateCategory = useCallback( () => {
-		if ( ! trimmedNewCategoryName || isCreatingCategory ) {
-			return;
-		}
-
-		setIsCreatingCategory( true );
-		setCreateCategoryError( null );
-
-		createCategory( trimmedNewCategoryName )
-			.then( created => {
-				analytics.tracks.recordEvent( 'jetpack_newsletter_category_created', {
-					site_type: siteType,
-				} );
-
-				const newCategory: WordPressCategory = {
-					id: String( created.id ),
-					name: created.name,
-				};
-
-				// Add to the local list so it appears in the DataForm without a
-				// page refresh, avoiding duplicates if it somehow already exists.
-				setCategories( prev =>
-					prev.some( cat => cat.id === newCategory.id ) ? prev : [ ...prev, newCategory ]
-				);
-
-				// Auto-select the newly created category (staged for save). Read the
-				// latest selection from the ref so a concurrent toggle isn't lost.
-				const selected = selectedCategoriesRef.current ?? [];
-				if ( ! selected.includes( newCategory.id ) ) {
-					onChange( { wpcom_newsletter_categories: [ ...selected, newCategory.id ] } );
-				}
-
-				setIsAddingCategory( false );
-				setNewCategoryName( '' );
-			} )
-			.catch( ( err: Error ) => {
-				// Duplicate-name detection differs by platform and error envelope:
-				// - self-hosted WP REST (`/wp/v2/categories`) rejects with
-				//   `code: 'term_exists'`.
-				// - the WordPress.com v1.1 endpoint used on Simple sites rejects with
-				//   `error: 'duplicate'`, sometimes wrapped in a proxy envelope
-				//   (`{ code: 409, body: { error: 'duplicate' } }`) where the top-level
-				//   `code` is the HTTP status, not the error slug.
-				// Both carry a long, English-only server message (and the inline form
-				// has no parent picker), so map either one to a short, translated
-				// string. Everything else (permissions, expired nonce, network failure)
-				// gets a friendly generic message rather than the raw server text.
-				const errorLike = err as Error & {
-					code?: string | number;
-					error?: string;
-					body?: { code?: string | number; error?: string };
-				};
-				const signals = [
-					errorLike.code,
-					errorLike.error,
-					errorLike.body?.code,
-					errorLike.body?.error,
-				];
-				const isDuplicate =
-					signals.includes( 'term_exists' ) ||
-					signals.includes( 'duplicate' ) ||
-					// A 409 Conflict when creating a term always means a name clash.
-					errorLike.code === 409 ||
-					errorLike.body?.code === 409;
-				// Assign each translated string to its own variable rather than
-				// branching a single ternary between two `__()` calls: production
-				// minification hoists the shared `__( …, 'jetpack-newsletter' )`
-				// wrapper out of the conditional, leaving a non-literal msgid that
-				// fails the i18n string check.
-				const duplicateMessage = __( 'This category already exists.', 'jetpack-newsletter' );
-				const genericMessage = __(
-					'Could not create the category. Please try again.',
-					'jetpack-newsletter'
-				);
-				setCreateCategoryError( isDuplicate ? duplicateMessage : genericMessage );
-			} )
-			.finally( () => {
-				setIsCreatingCategory( false );
-			} );
-	}, [ trimmedNewCategoryName, isCreatingCategory, onChange, siteType ] );
-
-	// Submit the inline form on Enter, matching the category token field above
-	// it. `handleCreateCategory` already no-ops on an empty name or while a
-	// create is in flight, so no extra guard is needed here.
-	const handleNewCategoryKeyDown = useCallback(
-		( event: KeyboardEvent< HTMLInputElement > ) => {
-			if ( event.key === 'Enter' ) {
-				event.preventDefault();
-				handleCreateCategory();
-			}
-		},
-		[ handleCreateCategory ]
+	// Stable wiring handed to the combined control via context.
+	const creatableContext = useMemo< CreatableCategoryContextValue >(
+		() => ( {
+			appendCategory,
+			onError: setCreateCategoryError,
+			onCreated: handleCategoryCreated,
+		} ),
+		[ appendCategory, handleCategoryCreated ]
 	);
 
 	// Fetch WordPress categories on mount
@@ -242,6 +131,10 @@ export function NewsletterCategoriesSection( {
 				'jetpack-newsletter'
 			),
 			type: 'array' as const,
+			// Custom control: one field that both searches existing categories and
+			// creates new ones (via a "Create ‘…’" suggestion row), replacing the
+			// separate "Add new category" link.
+			Edit: CreatableCategoriesControl as unknown as Field< NewsletterSettings >[ 'Edit' ],
 			elements: categories.map( cat => ( {
 				value: cat.id,
 				label: cat.name,
@@ -329,63 +222,21 @@ export function NewsletterCategoriesSection( {
 					</Notice.Root>
 				) }
 				<Fieldset.Root disabled={ ! isNewsletterEnabled || !! categoriesError }>
-					<DataForm
-						data={ data }
-						fields={ newsletterCategoriesFields }
-						form={ newsletterCategoriesForm }
-						onChange={ onChange }
-						validity={ validity }
-					/>
+					<CreatableCategoryContext.Provider value={ creatableContext }>
+						<DataForm
+							data={ data }
+							fields={ newsletterCategoriesFields }
+							form={ newsletterCategoriesForm }
+							onChange={ onChange }
+							validity={ validity }
+						/>
+					</CreatableCategoryContext.Provider>
 
-					{ data.wpcom_newsletter_categories_enabled &&
-						( isAddingCategory ? (
-							<Stack direction="column" gap="sm" className="newsletter-add-category-form">
-								{ createCategoryError && (
-									<Notice.Root intent="error">
-										<Notice.Description>{ createCategoryError }</Notice.Description>
-									</Notice.Root>
-								) }
-								<TextControl
-									ref={ newCategoryInputRef }
-									__next40pxDefaultSize
-									__nextHasNoMarginBottom
-									label={ __( 'New category name', 'jetpack-newsletter' ) }
-									value={ newCategoryName }
-									onChange={ setNewCategoryName }
-									onKeyDown={ handleNewCategoryKeyDown }
-									disabled={ isCreatingCategory }
-								/>
-								<Stack direction="row" gap="sm" align="center" justify="flex-start">
-									<Button
-										variant="solid"
-										onClick={ handleCreateCategory }
-										disabled={ ! trimmedNewCategoryName || isCreatingCategory }
-										loading={ isCreatingCategory }
-										loadingAnnouncement={ __( 'Adding…', 'jetpack-newsletter' ) }
-									>
-										{ __( 'Add category', 'jetpack-newsletter' ) }
-									</Button>
-									<Button
-										variant="minimal"
-										onClick={ cancelAddCategory }
-										disabled={ isCreatingCategory }
-									>
-										{ __( 'Cancel', 'jetpack-newsletter' ) }
-									</Button>
-								</Stack>
-							</Stack>
-						) : (
-							<p>
-								<Button
-									ref={ addCategoryTriggerRef }
-									variant="unstyled"
-									className="newsletter-add-category-trigger"
-									onClick={ startAddCategory }
-								>
-									{ __( 'Add new category', 'jetpack-newsletter' ) }
-								</Button>
-							</p>
-						) ) }
+					{ data.wpcom_newsletter_categories_enabled && createCategoryError && (
+						<Notice.Root intent="error">
+							<Notice.Description>{ createCategoryError }</Notice.Description>
+						</Notice.Root>
+					) }
 				</Fieldset.Root>
 				<div className="newsletter-card-footer">
 					<Button

--- a/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
@@ -127,7 +127,7 @@ export function NewsletterCategoriesSection( {
 			id: 'wpcom_newsletter_categories',
 			label: __( 'Newsletter categories', 'jetpack-newsletter' ),
 			description: __(
-				'Which categories will you use for newsletter subscribers? Select all that apply.',
+				'Search to add existing categories, or create a new one.',
 				'jetpack-newsletter'
 			),
 			type: 'array' as const,

--- a/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
@@ -140,7 +140,9 @@ export function NewsletterCategoriesSection( {
 				label: cat.name,
 			} ) ),
 			isValid: {
-				elements: true,
+				// No `elements: true` — the custom control creates categories and
+				// appends them to `elements` before selecting, so a selected value is
+				// never out of range. Only the "select at least one" rule applies.
 				custom: ( item: NewsletterSettings ) => {
 					if (
 						item.wpcom_newsletter_categories_enabled &&

--- a/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
@@ -20,6 +20,7 @@ import { Button, Card, Fieldset, Link, Notice, Stack, Text } from '@wordpress/ui
  */
 import { createCategory, fetchCategories } from '../api';
 import type { NewsletterSettings, WordPressCategory } from '../types';
+import type { KeyboardEvent } from 'react';
 
 interface NewsletterCategoriesSectionProps {
 	data: NewsletterSettings;
@@ -171,6 +172,19 @@ export function NewsletterCategoriesSection( {
 			} );
 	}, [ trimmedNewCategoryName, isCreatingCategory, onChange ] );
 
+	// Submit the inline form on Enter, matching the category token field above
+	// it. `handleCreateCategory` already no-ops on an empty name or while a
+	// create is in flight, so no extra guard is needed here.
+	const handleNewCategoryKeyDown = useCallback(
+		( event: KeyboardEvent< HTMLInputElement > ) => {
+			if ( event.key === 'Enter' ) {
+				event.preventDefault();
+				handleCreateCategory();
+			}
+		},
+		[ handleCreateCategory ]
+	);
+
 	// Fetch WordPress categories on mount
 	useEffect( () => {
 		fetchCategories()
@@ -318,6 +332,7 @@ export function NewsletterCategoriesSection( {
 									label={ __( 'New category name', 'jetpack-newsletter' ) }
 									value={ newCategoryName }
 									onChange={ setNewCategoryName }
+									onKeyDown={ handleNewCategoryKeyDown }
 									disabled={ isCreatingCategory }
 								/>
 								<Stack direction="row" gap="sm" align="center" justify="flex-start">
@@ -343,7 +358,7 @@ export function NewsletterCategoriesSection( {
 							<p>
 								<Button
 									ref={ addCategoryTriggerRef }
-									variant="minimal"
+									variant="unstyled"
 									className="newsletter-add-category-trigger"
 									onClick={ startAddCategory }
 								>

--- a/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
@@ -121,6 +121,10 @@ export function NewsletterCategoriesSection( {
 
 		createCategory( trimmedNewCategoryName )
 			.then( created => {
+				analytics.tracks.recordEvent( 'jetpack_newsletter_category_created', {
+					site_type: siteType,
+				} );
+
 				const newCategory: WordPressCategory = {
 					id: String( created.id ),
 					name: created.name,
@@ -143,18 +147,34 @@ export function NewsletterCategoriesSection( {
 				setNewCategoryName( '' );
 			} )
 			.catch( ( err: Error ) => {
-				// Duplicate-name detection differs by platform: self-hosted WP REST
-				// (`/wp/v2/categories`) rejects with `code: 'term_exists'`, while the
-				// WordPress.com v1.1 endpoint used on Simple sites rejects with
-				// `error: 'duplicate'`. Both carry a long, English-only server message
-				// (and the inline form has no parent picker), so map either one to a
-				// short, translated string. Everything else (permissions, expired
-				// nonce, network failure) gets a friendly generic message rather than
-				// the raw server text.
-				const errorCode =
-					( err as Error & { code?: string; error?: string } )?.code ??
-					( err as Error & { error?: string } )?.error;
-				const isDuplicate = errorCode === 'term_exists' || errorCode === 'duplicate';
+				// Duplicate-name detection differs by platform and error envelope:
+				// - self-hosted WP REST (`/wp/v2/categories`) rejects with
+				//   `code: 'term_exists'`.
+				// - the WordPress.com v1.1 endpoint used on Simple sites rejects with
+				//   `error: 'duplicate'`, sometimes wrapped in a proxy envelope
+				//   (`{ code: 409, body: { error: 'duplicate' } }`) where the top-level
+				//   `code` is the HTTP status, not the error slug.
+				// Both carry a long, English-only server message (and the inline form
+				// has no parent picker), so map either one to a short, translated
+				// string. Everything else (permissions, expired nonce, network failure)
+				// gets a friendly generic message rather than the raw server text.
+				const errorLike = err as Error & {
+					code?: string | number;
+					error?: string;
+					body?: { code?: string | number; error?: string };
+				};
+				const signals = [
+					errorLike.code,
+					errorLike.error,
+					errorLike.body?.code,
+					errorLike.body?.error,
+				];
+				const isDuplicate =
+					signals.includes( 'term_exists' ) ||
+					signals.includes( 'duplicate' ) ||
+					// A 409 Conflict when creating a term always means a name clash.
+					errorLike.code === 409 ||
+					errorLike.body?.code === 409;
 				// Assign each translated string to its own variable rather than
 				// branching a single ternary between two `__()` calls: production
 				// minification hoists the shared `__( …, 'jetpack-newsletter' )`
@@ -170,7 +190,7 @@ export function NewsletterCategoriesSection( {
 			.finally( () => {
 				setIsCreatingCategory( false );
 			} );
-	}, [ trimmedNewCategoryName, isCreatingCategory, onChange ] );
+	}, [ trimmedNewCategoryName, isCreatingCategory, onChange, siteType ] );
 
 	// Submit the inline form on Enter, matching the category token field above
 	// it. `handleCreateCategory` already no-ops on an empty name or while a

--- a/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
@@ -6,7 +6,13 @@ import { getSiteData, getSiteType, isWpcomPlatformSite } from '@automattic/jetpa
 import { WpcomSupportLink } from '@automattic/jetpack-shared-extension-utils/components/wpcom-support-link';
 import { TextControl } from '@wordpress/components';
 import { DataForm, type Field, useFormValidity } from '@wordpress/dataviews';
-import { createInterpolateElement, useCallback, useEffect, useState } from '@wordpress/element';
+import {
+	createInterpolateElement,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Button, Card, Fieldset, Link, Notice, Stack, Text } from '@wordpress/ui';
 /**
@@ -52,6 +58,31 @@ export function NewsletterCategoriesSection( {
 	const [ newCategoryName, setNewCategoryName ] = useState( '' );
 	const [ isCreatingCategory, setIsCreatingCategory ] = useState( false );
 	const [ createCategoryError, setCreateCategoryError ] = useState< string | null >( null );
+
+	// Focus targets for the disclosure pattern: move focus into the form on open,
+	// return it to the trigger on close.
+	const newCategoryInputRef = useRef< HTMLInputElement >( null );
+	const addCategoryTriggerRef = useRef< HTMLButtonElement >( null );
+	const wasAddingCategoryRef = useRef( false );
+
+	// Latest saved selection, read inside the async create handler so a category
+	// the user toggles while the request is in flight isn't clobbered by a stale
+	// closure over `data.wpcom_newsletter_categories`.
+	const selectedCategoriesRef = useRef( data.wpcom_newsletter_categories );
+	useEffect( () => {
+		selectedCategoriesRef.current = data.wpcom_newsletter_categories;
+	}, [ data.wpcom_newsletter_categories ] );
+
+	// Move focus into the form when it opens; return it to the trigger on close
+	// (but not on the initial render, when the form was never open).
+	useEffect( () => {
+		if ( isAddingCategory ) {
+			newCategoryInputRef.current?.focus();
+		} else if ( wasAddingCategoryRef.current ) {
+			addCategoryTriggerRef.current?.focus();
+		}
+		wasAddingCategoryRef.current = isAddingCategory;
+	}, [ isAddingCategory ] );
 
 	// Track section save with the keys that changed since the last save.
 	const handleSave = useCallback( () => {
@@ -100,8 +131,9 @@ export function NewsletterCategoriesSection( {
 					prev.some( cat => cat.id === newCategory.id ) ? prev : [ ...prev, newCategory ]
 				);
 
-				// Auto-select the newly created category (staged for save).
-				const selected = data.wpcom_newsletter_categories ?? [];
+				// Auto-select the newly created category (staged for save). Read the
+				// latest selection from the ref so a concurrent toggle isn't lost.
+				const selected = selectedCategoriesRef.current ?? [];
 				if ( ! selected.includes( newCategory.id ) ) {
 					onChange( { wpcom_newsletter_categories: [ ...selected, newCategory.id ] } );
 				}
@@ -110,15 +142,20 @@ export function NewsletterCategoriesSection( {
 				setNewCategoryName( '' );
 			} )
 			.catch( ( err: Error ) => {
-				// WordPress surfaces a long parent-aware message for duplicates
-				// ("A term with the name provided already exists…"); the inline
-				// form has no parent picker, so show a short, plain message.
-				// Everything else (permissions, expired nonce, network failure)
-				// gets a friendly generic string rather than the raw, English-only
-				// server message.
-				const code = ( err as Error & { code?: string } )?.code;
+				// Duplicate-name detection differs by platform: self-hosted WP REST
+				// (`/wp/v2/categories`) rejects with `code: 'term_exists'`, while the
+				// WordPress.com v1.1 endpoint used on Simple sites rejects with
+				// `error: 'duplicate'`. Both carry a long, English-only server message
+				// (and the inline form has no parent picker), so map either one to a
+				// short, translated string. Everything else (permissions, expired
+				// nonce, network failure) gets a friendly generic message rather than
+				// the raw server text.
+				const errorCode =
+					( err as Error & { code?: string; error?: string } )?.code ??
+					( err as Error & { error?: string } )?.error;
+				const isDuplicate = errorCode === 'term_exists' || errorCode === 'duplicate';
 				setCreateCategoryError(
-					code === 'term_exists'
+					isDuplicate
 						? __( 'This category already exists.', 'jetpack-newsletter' )
 						: __( 'Could not create the category. Please try again.', 'jetpack-newsletter' )
 				);
@@ -126,7 +163,7 @@ export function NewsletterCategoriesSection( {
 			.finally( () => {
 				setIsCreatingCategory( false );
 			} );
-	}, [ trimmedNewCategoryName, isCreatingCategory, data.wpcom_newsletter_categories, onChange ] );
+	}, [ trimmedNewCategoryName, isCreatingCategory, onChange ] );
 
 	// Fetch WordPress categories on mount
 	useEffect( () => {
@@ -269,6 +306,7 @@ export function NewsletterCategoriesSection( {
 									</Notice.Root>
 								) }
 								<TextControl
+									ref={ newCategoryInputRef }
 									__next40pxDefaultSize
 									__nextHasNoMarginBottom
 									label={ __( 'New category name', 'jetpack-newsletter' ) }
@@ -298,6 +336,7 @@ export function NewsletterCategoriesSection( {
 						) : (
 							<p>
 								<Button
+									ref={ addCategoryTriggerRef }
 									variant="minimal"
 									className="newsletter-add-category-trigger"
 									onClick={ startAddCategory }

--- a/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
@@ -154,11 +154,17 @@ export function NewsletterCategoriesSection( {
 					( err as Error & { code?: string; error?: string } )?.code ??
 					( err as Error & { error?: string } )?.error;
 				const isDuplicate = errorCode === 'term_exists' || errorCode === 'duplicate';
-				setCreateCategoryError(
-					isDuplicate
-						? __( 'This category already exists.', 'jetpack-newsletter' )
-						: __( 'Could not create the category. Please try again.', 'jetpack-newsletter' )
+				// Assign each translated string to its own variable rather than
+				// branching a single ternary between two `__()` calls: production
+				// minification hoists the shared `__( …, 'jetpack-newsletter' )`
+				// wrapper out of the conditional, leaving a non-literal msgid that
+				// fails the i18n string check.
+				const duplicateMessage = __( 'This category already exists.', 'jetpack-newsletter' );
+				const genericMessage = __(
+					'Could not create the category. Please try again.',
+					'jetpack-newsletter'
 				);
+				setCreateCategoryError( isDuplicate ? duplicateMessage : genericMessage );
 			} )
 			.finally( () => {
 				setIsCreatingCategory( false );

--- a/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
@@ -2,21 +2,17 @@
  * External dependencies
  */
 import analytics from '@automattic/jetpack-analytics';
-import {
-	getAdminUrl,
-	getSiteData,
-	getSiteType,
-	isWpcomPlatformSite,
-} from '@automattic/jetpack-script-data';
+import { getSiteData, getSiteType, isWpcomPlatformSite } from '@automattic/jetpack-script-data';
 import { WpcomSupportLink } from '@automattic/jetpack-shared-extension-utils/components/wpcom-support-link';
+import { TextControl } from '@wordpress/components';
 import { DataForm, type Field, useFormValidity } from '@wordpress/dataviews';
 import { createInterpolateElement, useCallback, useEffect, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { Button, Card, Fieldset, Link, Notice, Text } from '@wordpress/ui';
+import { Button, Card, Fieldset, Link, Notice, Stack, Text } from '@wordpress/ui';
 /**
  * Internal dependencies
  */
-import { fetchCategories } from '../api';
+import { createCategory, fetchCategories } from '../api';
 import type { NewsletterSettings, WordPressCategory } from '../types';
 
 interface NewsletterCategoriesSectionProps {
@@ -50,6 +46,13 @@ export function NewsletterCategoriesSection( {
 	const [ isFetchingCategories, setIsFetchingCategories ] = useState( true );
 	const [ categoriesError, setCategoriesError ] = useState< string | null >( null );
 
+	// Inline "add new category" flow. Replaces the old wp-admin link so the new
+	// category is created in place and shows up in the list without a refresh.
+	const [ isAddingCategory, setIsAddingCategory ] = useState( false );
+	const [ newCategoryName, setNewCategoryName ] = useState( '' );
+	const [ isCreatingCategory, setIsCreatingCategory ] = useState( false );
+	const [ createCategoryError, setCreateCategoryError ] = useState< string | null >( null );
+
 	// Track section save with the keys that changed since the last save.
 	const handleSave = useCallback( () => {
 		analytics.tracks.recordEvent( 'jetpack_newsletter_section_save', {
@@ -60,6 +63,68 @@ export function NewsletterCategoriesSection( {
 		} );
 		onSave();
 	}, [ changedKeys, onSave, siteType ] );
+
+	const trimmedNewCategoryName = newCategoryName.trim();
+
+	// Open the inline add-category form.
+	const startAddCategory = useCallback( () => {
+		setIsAddingCategory( true );
+	}, [] );
+
+	// Reset and close the inline add-category form.
+	const cancelAddCategory = useCallback( () => {
+		setIsAddingCategory( false );
+		setNewCategoryName( '' );
+		setCreateCategoryError( null );
+	}, [] );
+
+	// Create the category, append it to the list, and auto-select it.
+	const handleCreateCategory = useCallback( () => {
+		if ( ! trimmedNewCategoryName || isCreatingCategory ) {
+			return;
+		}
+
+		setIsCreatingCategory( true );
+		setCreateCategoryError( null );
+
+		createCategory( trimmedNewCategoryName )
+			.then( created => {
+				const newCategory: WordPressCategory = {
+					id: String( created.id ),
+					name: created.name,
+				};
+
+				// Add to the local list so it appears in the DataForm without a
+				// page refresh, avoiding duplicates if it somehow already exists.
+				setCategories( prev =>
+					prev.some( cat => cat.id === newCategory.id ) ? prev : [ ...prev, newCategory ]
+				);
+
+				// Auto-select the newly created category (staged for save).
+				const selected = data.wpcom_newsletter_categories ?? [];
+				if ( ! selected.includes( newCategory.id ) ) {
+					onChange( { wpcom_newsletter_categories: [ ...selected, newCategory.id ] } );
+				}
+
+				setIsAddingCategory( false );
+				setNewCategoryName( '' );
+			} )
+			.catch( ( err: Error ) => {
+				// WordPress surfaces a long parent-aware message for duplicates
+				// ("A term with the name provided already exists…"); the inline
+				// form has no parent picker, so show a short, plain message.
+				const code = ( err as Error & { code?: string } )?.code;
+				setCreateCategoryError(
+					code === 'term_exists'
+						? __( 'This category already exists.', 'jetpack-newsletter' )
+						: err.message ||
+								__( 'Could not create the category. Please try again.', 'jetpack-newsletter' )
+				);
+			} )
+			.finally( () => {
+				setIsCreatingCategory( false );
+			} );
+	}, [ trimmedNewCategoryName, isCreatingCategory, data.wpcom_newsletter_categories, onChange ] );
 
 	// Fetch WordPress categories on mount
 	useEffect( () => {
@@ -193,18 +258,52 @@ export function NewsletterCategoriesSection( {
 						validity={ validity }
 					/>
 
-					{ data.wpcom_newsletter_categories_enabled && (
-						<p>
-							<Link
-								openInNewTab
-								href={ getAdminUrl(
-									'edit-tags.php?taxonomy=category&referer=newsletter-categories'
+					{ data.wpcom_newsletter_categories_enabled &&
+						( isAddingCategory ? (
+							<Stack direction="column" gap="sm" className="newsletter-add-category-form">
+								{ createCategoryError && (
+									<Notice.Root intent="error">
+										<Notice.Description>{ createCategoryError }</Notice.Description>
+									</Notice.Root>
 								) }
-							>
-								{ __( 'Add new category', 'jetpack-newsletter' ) }
-							</Link>
-						</p>
-					) }
+								<TextControl
+									__next40pxDefaultSize
+									__nextHasNoMarginBottom
+									label={ __( 'New category name', 'jetpack-newsletter' ) }
+									value={ newCategoryName }
+									onChange={ setNewCategoryName }
+									disabled={ isCreatingCategory }
+								/>
+								<Stack direction="row" gap="sm" align="center" justify="flex-start">
+									<Button
+										variant="solid"
+										onClick={ handleCreateCategory }
+										disabled={ ! trimmedNewCategoryName || isCreatingCategory }
+										loading={ isCreatingCategory }
+										loadingAnnouncement={ __( 'Adding…', 'jetpack-newsletter' ) }
+									>
+										{ __( 'Add category', 'jetpack-newsletter' ) }
+									</Button>
+									<Button
+										variant="minimal"
+										onClick={ cancelAddCategory }
+										disabled={ isCreatingCategory }
+									>
+										{ __( 'Cancel', 'jetpack-newsletter' ) }
+									</Button>
+								</Stack>
+							</Stack>
+						) : (
+							<p>
+								<Button
+									variant="minimal"
+									className="newsletter-add-category-trigger"
+									onClick={ startAddCategory }
+								>
+									{ __( 'Add new category', 'jetpack-newsletter' ) }
+								</Button>
+							</p>
+						) ) }
 				</Fieldset.Root>
 				<div className="newsletter-card-footer">
 					<Button

--- a/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
@@ -113,12 +113,14 @@ export function NewsletterCategoriesSection( {
 				// WordPress surfaces a long parent-aware message for duplicates
 				// ("A term with the name provided already exists…"); the inline
 				// form has no parent picker, so show a short, plain message.
+				// Everything else (permissions, expired nonce, network failure)
+				// gets a friendly generic string rather than the raw, English-only
+				// server message.
 				const code = ( err as Error & { code?: string } )?.code;
 				setCreateCategoryError(
 					code === 'term_exists'
 						? __( 'This category already exists.', 'jetpack-newsletter' )
-						: err.message ||
-								__( 'Could not create the category. Please try again.', 'jetpack-newsletter' )
+						: __( 'Could not create the category. Please try again.', 'jetpack-newsletter' )
 				);
 			} )
 			.finally( () => {

--- a/projects/packages/newsletter/src/settings/style.scss
+++ b/projects/packages/newsletter/src/settings/style.scss
@@ -98,8 +98,20 @@ body.jetpack_page_jetpack-newsletter {
 	}
 
 	.newsletter-categories-control__error {
+		display: flex;
+		align-items: center;
+		gap: var(--wpds-dimension-gap-xs);
 		margin-block: var(--wpds-dimension-gap-xs) 0;
-		color: var(--wpds-color-foreground-content-error);
+		// Matches the @wordpress/components form-validation red used on trunk (and
+		// across wp-admin form errors). There is no wpds token at this brightness —
+		// the wpds error-foreground tokens are a much darker maroon — so mirror the
+		// components literal to stay consistent with the platform's error styling.
+		color: #cc1818;
 		font-size: var(--wpds-typography-font-size-sm);
+
+		svg {
+			flex-shrink: 0;
+			fill: currentColor;
+		}
 	}
 }

--- a/projects/packages/newsletter/src/settings/style.scss
+++ b/projects/packages/newsletter/src/settings/style.scss
@@ -89,25 +89,17 @@ body.jetpack_page_jetpack-newsletter {
 		}
 	}
 
-	// The "Add new category" trigger reveals an inline form (an in-page action),
-	// so it stays a real <button> for accessibility but is styled to read as a
-	// text link — matching the WPDS `Link` brand tone. The `unstyled` variant
-	// strips the button chrome, leaving it flush with the surrounding content.
-	.newsletter-add-category-trigger {
-		color: var(--wpds-color-foreground-interactive-brand);
-		text-decoration: underline;
-		text-underline-offset: 0.2em;
-		text-decoration-thickness: from-font;
-		cursor: pointer;
-
-		&:hover,
-		&:active {
-			color: var(--wpds-color-foreground-interactive-brand-active);
-		}
+	// Combined search-and-create categories control: help text and the field's
+	// validation message render beneath the token field.
+	.newsletter-categories-control__help {
+		margin-block: var(--wpds-dimension-gap-xs) 0;
+		color: var(--wpds-color-foreground-interactive-neutral);
+		font-size: var(--wpds-typography-font-size-sm);
 	}
 
-	// The inline create-category form sits between the field and the footer.
-	.newsletter-add-category-form {
-		margin-block: var(--wpds-dimension-gap-sm);
+	.newsletter-categories-control__error {
+		margin-block: var(--wpds-dimension-gap-xs) 0;
+		color: var(--wpds-color-foreground-interactive-error-strong);
+		font-size: var(--wpds-typography-font-size-sm);
 	}
 }

--- a/projects/packages/newsletter/src/settings/style.scss
+++ b/projects/packages/newsletter/src/settings/style.scss
@@ -93,13 +93,13 @@ body.jetpack_page_jetpack-newsletter {
 	// validation message render beneath the token field.
 	.newsletter-categories-control__help {
 		margin-block: var(--wpds-dimension-gap-xs) 0;
-		color: var(--wpds-color-foreground-interactive-neutral);
+		color: var(--wpds-color-foreground-content-neutral-weak);
 		font-size: var(--wpds-typography-font-size-sm);
 	}
 
 	.newsletter-categories-control__error {
 		margin-block: var(--wpds-dimension-gap-xs) 0;
-		color: var(--wpds-color-foreground-interactive-error-strong);
+		color: var(--wpds-color-foreground-content-error);
 		font-size: var(--wpds-typography-font-size-sm);
 	}
 }

--- a/projects/packages/newsletter/src/settings/style.scss
+++ b/projects/packages/newsletter/src/settings/style.scss
@@ -89,11 +89,21 @@ body.jetpack_page_jetpack-newsletter {
 		}
 	}
 
-	// The "Add new category" trigger is a minimal button styled as a link. Pull it
-	// flush with the surrounding content by offsetting the button's own inline
-	// padding token, which otherwise leaves a stray gap to its start edge.
+	// The "Add new category" trigger reveals an inline form (an in-page action),
+	// so it stays a real <button> for accessibility but is styled to read as a
+	// text link — matching the WPDS `Link` brand tone. The `unstyled` variant
+	// strips the button chrome, leaving it flush with the surrounding content.
 	.newsletter-add-category-trigger {
-		margin-inline-start: calc(-1 * var(--wpds-dimension-padding-md));
+		color: var(--wpds-color-foreground-interactive-brand);
+		text-decoration: underline;
+		text-underline-offset: 0.2em;
+		text-decoration-thickness: from-font;
+		cursor: pointer;
+
+		&:hover,
+		&:active {
+			color: var(--wpds-color-foreground-interactive-brand-active);
+		}
 	}
 
 	// The inline create-category form sits between the field and the footer.

--- a/projects/packages/newsletter/src/settings/style.scss
+++ b/projects/packages/newsletter/src/settings/style.scss
@@ -88,4 +88,16 @@ body.jetpack_page_jetpack-newsletter {
 			justify-content: space-between;
 		}
 	}
+
+	// The "Add new category" trigger is a minimal button styled as a link. Pull it
+	// flush with the surrounding content by offsetting the button's own inline
+	// padding token, which otherwise leaves a stray gap to its start edge.
+	.newsletter-add-category-trigger {
+		margin-inline-start: calc(-1 * var(--wpds-dimension-padding-md));
+	}
+
+	// The inline create-category form sits between the field and the footer.
+	.newsletter-add-category-form {
+		margin-block: var(--wpds-dimension-gap-sm);
+	}
 }

--- a/projects/packages/newsletter/tests/api-create-category.test.ts
+++ b/projects/packages/newsletter/tests/api-create-category.test.ts
@@ -96,4 +96,19 @@ describe( 'createCategory (NL-785)', () => {
 
 		await expect( createCategory( 'News' ) ).rejects.toThrow();
 	} );
+
+	it( 'throws a duplicate-signal error when the WPCOM proxy resolves with an error envelope', async () => {
+		mockIsSimpleSite.mockReturnValue( true );
+		mockGetSiteData.mockReturnValue( { wpcom: { blog_id: 123 } } );
+		// On Simple a duplicate can resolve (not reject) with an error envelope.
+		mockApiFetch.mockResolvedValue( {
+			code: 409,
+			body: { error: 'duplicate', message: 'A taxonomy with that name already exists' },
+		} );
+
+		await expect( createCategory( 'News' ) ).rejects.toMatchObject( {
+			code: 409,
+			error: 'duplicate',
+		} );
+	} );
 } );

--- a/projects/packages/newsletter/tests/api-create-category.test.ts
+++ b/projects/packages/newsletter/tests/api-create-category.test.ts
@@ -87,4 +87,13 @@ describe( 'createCategory (NL-785)', () => {
 
 		await expect( createCategory( 'News' ) ).rejects.toMatchObject( { code: 'term_exists' } );
 	} );
+
+	it( 'rejects when the success payload has no numeric id', async () => {
+		mockIsSimpleSite.mockReturnValue( false );
+		mockGetSiteData.mockReturnValue( { wpcom: { blog_id: 123 } } );
+		// Malformed response: no id — must not resolve to a bogus category.
+		mockApiFetch.mockResolvedValue( { name: 'News' } );
+
+		await expect( createCategory( 'News' ) ).rejects.toThrow();
+	} );
 } );

--- a/projects/packages/newsletter/tests/api-create-category.test.ts
+++ b/projects/packages/newsletter/tests/api-create-category.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Unit tests for `createCategory` in the Newsletter settings API (NL-785).
+ *
+ * The component test (`newsletter-categories-section.test.tsx`) mocks this whole
+ * module, so it never exercises the real request/normalization logic. These tests
+ * drive `createCategory` directly to cover both transport branches. WordPress.com
+ * Simple sites POST to the WPCOM taxonomy endpoint and get back an uppercase `ID`,
+ * which we normalize to `id`; self-hosted sites POST to `/wp/v2/categories` and
+ * already return a lowercase `id`.
+ */
+
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
+} ) );
+
+const mockGetSiteData = jest.fn();
+const mockIsSimpleSite = jest.fn();
+
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	__esModule: true,
+	getSiteData: ( ...args: unknown[] ) => mockGetSiteData( ...args ),
+	isSimpleSite: ( ...args: unknown[] ) => mockIsSimpleSite( ...args ),
+} ) );
+
+import { createCategory } from '../src/settings/api';
+
+describe( 'createCategory (NL-785)', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'creates via the WPCOM endpoint and normalizes ID→id on Simple sites', async () => {
+		mockIsSimpleSite.mockReturnValue( true );
+		mockGetSiteData.mockReturnValue( { wpcom: { blog_id: 123 } } );
+		// WordPress.com returns an uppercase `ID`.
+		mockApiFetch.mockResolvedValue( { ID: 42, name: 'Weekly Digest' } );
+
+		const result = await createCategory( 'Weekly Digest' );
+
+		expect( mockApiFetch ).toHaveBeenCalledWith( {
+			path: '/rest/v1.1/sites/123/taxonomies/category/terms/new',
+			method: 'POST',
+			data: { name: 'Weekly Digest' },
+		} );
+		expect( result ).toEqual( { id: 42, name: 'Weekly Digest' } );
+	} );
+
+	it( 'creates via the WP REST endpoint on self-hosted sites', async () => {
+		mockIsSimpleSite.mockReturnValue( false );
+		mockGetSiteData.mockReturnValue( { wpcom: { blog_id: 123 } } );
+		mockApiFetch.mockResolvedValue( { id: 7, name: 'Monthly Roundup' } );
+
+		const result = await createCategory( 'Monthly Roundup' );
+
+		expect( mockApiFetch ).toHaveBeenCalledWith( {
+			path: '/wp/v2/categories',
+			method: 'POST',
+			data: { name: 'Monthly Roundup' },
+		} );
+		expect( result ).toEqual( { id: 7, name: 'Monthly Roundup' } );
+	} );
+
+	it( 'falls back to the WP REST endpoint when a Simple site has no blog ID', async () => {
+		mockIsSimpleSite.mockReturnValue( true );
+		mockGetSiteData.mockReturnValue( { wpcom: { blog_id: 0 } } );
+		mockApiFetch.mockResolvedValue( { id: 9, name: 'News' } );
+
+		const result = await createCategory( 'News' );
+
+		expect( mockApiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( { path: '/wp/v2/categories' } )
+		);
+		expect( result ).toEqual( { id: 9, name: 'News' } );
+	} );
+
+	it( 'propagates API errors (e.g. duplicate term) to the caller', async () => {
+		mockIsSimpleSite.mockReturnValue( false );
+		mockGetSiteData.mockReturnValue( { wpcom: { blog_id: 123 } } );
+		mockApiFetch.mockRejectedValue(
+			Object.assign( new Error( 'A term with the name provided already exists.' ), {
+				code: 'term_exists',
+			} )
+		);
+
+		await expect( createCategory( 'News' ) ).rejects.toMatchObject( { code: 'term_exists' } );
+	} );
+} );

--- a/projects/packages/newsletter/tests/api-create-category.test.ts
+++ b/projects/packages/newsletter/tests/api-create-category.test.ts
@@ -1,12 +1,10 @@
 /**
  * Unit tests for `createCategory` in the Newsletter settings API (NL-785).
  *
- * The component test (`newsletter-categories-section.test.tsx`) mocks this whole
- * module, so it never exercises the real request/normalization logic. These tests
- * drive `createCategory` directly to cover both transport branches. WordPress.com
- * Simple sites POST to the WPCOM taxonomy endpoint and get back an uppercase `ID`,
- * which we normalize to `id`; self-hosted sites POST to `/wp/v2/categories` and
- * already return a lowercase `id`.
+ * `createCategory` posts to `/wp/v2/categories` on every platform — in the
+ * wp-admin context WordPress.com proxies it and returns standard WP-REST
+ * responses, unlike the older wpcom taxonomy endpoint whose error body apiFetch
+ * can't parse (it collapses duplicates to a generic `unknown_error`).
  */
 
 const mockApiFetch = jest.fn();
@@ -16,13 +14,10 @@ jest.mock( '@wordpress/api-fetch', () => ( {
 	default: ( ...args: unknown[] ) => mockApiFetch( ...args ),
 } ) );
 
-const mockGetSiteData = jest.fn();
-const mockIsSimpleSite = jest.fn();
-
 jest.mock( '@automattic/jetpack-script-data', () => ( {
 	__esModule: true,
-	getSiteData: ( ...args: unknown[] ) => mockGetSiteData( ...args ),
-	isSimpleSite: ( ...args: unknown[] ) => mockIsSimpleSite( ...args ),
+	getSiteData: jest.fn( () => ( { wpcom: { blog_id: 123 } } ) ),
+	isSimpleSite: jest.fn( () => false ),
 } ) );
 
 import { createCategory } from '../src/settings/api';
@@ -32,25 +27,7 @@ describe( 'createCategory (NL-785)', () => {
 		jest.clearAllMocks();
 	} );
 
-	it( 'creates via the WPCOM endpoint and normalizes ID→id on Simple sites', async () => {
-		mockIsSimpleSite.mockReturnValue( true );
-		mockGetSiteData.mockReturnValue( { wpcom: { blog_id: 123 } } );
-		// WordPress.com returns an uppercase `ID`.
-		mockApiFetch.mockResolvedValue( { ID: 42, name: 'Weekly Digest' } );
-
-		const result = await createCategory( 'Weekly Digest' );
-
-		expect( mockApiFetch ).toHaveBeenCalledWith( {
-			path: '/rest/v1.1/sites/123/taxonomies/category/terms/new',
-			method: 'POST',
-			data: { name: 'Weekly Digest' },
-		} );
-		expect( result ).toEqual( { id: 42, name: 'Weekly Digest' } );
-	} );
-
-	it( 'creates via the WP REST endpoint on self-hosted sites', async () => {
-		mockIsSimpleSite.mockReturnValue( false );
-		mockGetSiteData.mockReturnValue( { wpcom: { blog_id: 123 } } );
+	it( 'creates via the /wp/v2/categories endpoint', async () => {
 		mockApiFetch.mockResolvedValue( { id: 7, name: 'Monthly Roundup' } );
 
 		const result = await createCategory( 'Monthly Roundup' );
@@ -63,22 +40,7 @@ describe( 'createCategory (NL-785)', () => {
 		expect( result ).toEqual( { id: 7, name: 'Monthly Roundup' } );
 	} );
 
-	it( 'falls back to the WP REST endpoint when a Simple site has no blog ID', async () => {
-		mockIsSimpleSite.mockReturnValue( true );
-		mockGetSiteData.mockReturnValue( { wpcom: { blog_id: 0 } } );
-		mockApiFetch.mockResolvedValue( { id: 9, name: 'News' } );
-
-		const result = await createCategory( 'News' );
-
-		expect( mockApiFetch ).toHaveBeenCalledWith(
-			expect.objectContaining( { path: '/wp/v2/categories' } )
-		);
-		expect( result ).toEqual( { id: 9, name: 'News' } );
-	} );
-
-	it( 'propagates API errors (e.g. duplicate term) to the caller', async () => {
-		mockIsSimpleSite.mockReturnValue( false );
-		mockGetSiteData.mockReturnValue( { wpcom: { blog_id: 123 } } );
+	it( 'propagates a duplicate (term_exists) rejection to the caller', async () => {
 		mockApiFetch.mockRejectedValue(
 			Object.assign( new Error( 'A term with the name provided already exists.' ), {
 				code: 'term_exists',
@@ -89,26 +51,9 @@ describe( 'createCategory (NL-785)', () => {
 	} );
 
 	it( 'rejects when the success payload has no numeric id', async () => {
-		mockIsSimpleSite.mockReturnValue( false );
-		mockGetSiteData.mockReturnValue( { wpcom: { blog_id: 123 } } );
 		// Malformed response: no id — must not resolve to a bogus category.
 		mockApiFetch.mockResolvedValue( { name: 'News' } );
 
 		await expect( createCategory( 'News' ) ).rejects.toThrow();
-	} );
-
-	it( 'throws a duplicate-signal error when the WPCOM proxy resolves with an error envelope', async () => {
-		mockIsSimpleSite.mockReturnValue( true );
-		mockGetSiteData.mockReturnValue( { wpcom: { blog_id: 123 } } );
-		// On Simple a duplicate can resolve (not reject) with an error envelope.
-		mockApiFetch.mockResolvedValue( {
-			code: 409,
-			body: { error: 'duplicate', message: 'A taxonomy with that name already exists' },
-		} );
-
-		await expect( createCategory( 'News' ) ).rejects.toMatchObject( {
-			code: 409,
-			error: 'duplicate',
-		} );
 	} );
 } );

--- a/projects/packages/newsletter/tests/map-create-category-error.test.ts
+++ b/projects/packages/newsletter/tests/map-create-category-error.test.ts
@@ -46,6 +46,28 @@ describe( 'mapCreateCategoryError', () => {
 		).toBe( GENERIC );
 	} );
 
+	it( 'detects a duplicate signal nested deep in the error object', () => {
+		expect( mapCreateCategoryError( { response: { body: { error: 'duplicate' } } } ) ).toBe(
+			DUPLICATE
+		);
+	} );
+
+	it( 'detects a 409 status nested in the error object', () => {
+		expect( mapCreateCategoryError( { data: { status: 409 } } ) ).toBe( DUPLICATE );
+	} );
+
+	it( 'falls back to matching the server message when no structured signal survives', () => {
+		expect(
+			mapCreateCategoryError( new Error( 'A taxonomy with that name already exists' ) )
+		).toBe( DUPLICATE );
+	} );
+
+	it( 'tolerates circular error objects without looping', () => {
+		const err: Record< string, unknown > = { message: 'boom' };
+		err.self = err;
+		expect( mapCreateCategoryError( err ) ).toBe( GENERIC );
+	} );
+
 	it( 'falls back to a generic message when there is no error shape', () => {
 		expect( mapCreateCategoryError( new Error( 'network down' ) ) ).toBe( GENERIC );
 	} );

--- a/projects/packages/newsletter/tests/map-create-category-error.test.ts
+++ b/projects/packages/newsletter/tests/map-create-category-error.test.ts
@@ -1,9 +1,9 @@
 /**
  * Unit tests for `mapCreateCategoryError` (NL-785).
  *
- * Duplicate-name rejections vary by platform and error envelope; this maps them
- * all to one short, translated message, and everything else to a generic one
- * (never the raw, English-only server text).
+ * `createCategory` uses `/wp/v2/categories`, so a duplicate is the standard
+ * WP-REST `{ code: 'term_exists' }` on every platform; everything else maps to a
+ * generic message (never the raw, English-only server text).
  */
 
 import { mapCreateCategoryError } from '../src/settings/sections/creatable-categories-control';
@@ -12,29 +12,9 @@ const DUPLICATE = 'This category already exists.';
 const GENERIC = 'Could not create the category. Please try again.';
 
 describe( 'mapCreateCategoryError', () => {
-	it( 'maps the self-hosted WP REST duplicate code', () => {
+	it( 'maps a term_exists rejection to the duplicate message', () => {
 		expect(
 			mapCreateCategoryError( Object.assign( new Error( 'exists' ), { code: 'term_exists' } ) )
-		).toBe( DUPLICATE );
-	} );
-
-	it( 'maps the WordPress.com flattened duplicate error', () => {
-		expect(
-			mapCreateCategoryError( Object.assign( new Error( 'exists' ), { error: 'duplicate' } ) )
-		).toBe( DUPLICATE );
-	} );
-
-	it( 'maps the WordPress.com proxy envelope (409 + body.error)', () => {
-		expect(
-			mapCreateCategoryError(
-				Object.assign( new Error( 'exists' ), { code: 409, body: { error: 'duplicate' } } )
-			)
-		).toBe( DUPLICATE );
-	} );
-
-	it( 'maps a bare 409 conflict as a duplicate', () => {
-		expect(
-			mapCreateCategoryError( Object.assign( new Error( 'conflict' ), { code: 409 } ) )
 		).toBe( DUPLICATE );
 	} );
 
@@ -44,28 +24,6 @@ describe( 'mapCreateCategoryError', () => {
 				Object.assign( new Error( 'not allowed' ), { code: 'rest_cannot_create' } )
 			)
 		).toBe( GENERIC );
-	} );
-
-	it( 'detects a duplicate signal nested deep in the error object', () => {
-		expect( mapCreateCategoryError( { response: { body: { error: 'duplicate' } } } ) ).toBe(
-			DUPLICATE
-		);
-	} );
-
-	it( 'detects a 409 status nested in the error object', () => {
-		expect( mapCreateCategoryError( { data: { status: 409 } } ) ).toBe( DUPLICATE );
-	} );
-
-	it( 'falls back to matching the server message when no structured signal survives', () => {
-		expect(
-			mapCreateCategoryError( new Error( 'A taxonomy with that name already exists' ) )
-		).toBe( DUPLICATE );
-	} );
-
-	it( 'tolerates circular error objects without looping', () => {
-		const err: Record< string, unknown > = { message: 'boom' };
-		err.self = err;
-		expect( mapCreateCategoryError( err ) ).toBe( GENERIC );
 	} );
 
 	it( 'falls back to a generic message when there is no error shape', () => {

--- a/projects/packages/newsletter/tests/map-create-category-error.test.ts
+++ b/projects/packages/newsletter/tests/map-create-category-error.test.ts
@@ -1,0 +1,52 @@
+/**
+ * Unit tests for `mapCreateCategoryError` (NL-785).
+ *
+ * Duplicate-name rejections vary by platform and error envelope; this maps them
+ * all to one short, translated message, and everything else to a generic one
+ * (never the raw, English-only server text).
+ */
+
+import { mapCreateCategoryError } from '../src/settings/sections/creatable-categories-control';
+
+const DUPLICATE = 'This category already exists.';
+const GENERIC = 'Could not create the category. Please try again.';
+
+describe( 'mapCreateCategoryError', () => {
+	it( 'maps the self-hosted WP REST duplicate code', () => {
+		expect(
+			mapCreateCategoryError( Object.assign( new Error( 'exists' ), { code: 'term_exists' } ) )
+		).toBe( DUPLICATE );
+	} );
+
+	it( 'maps the WordPress.com flattened duplicate error', () => {
+		expect(
+			mapCreateCategoryError( Object.assign( new Error( 'exists' ), { error: 'duplicate' } ) )
+		).toBe( DUPLICATE );
+	} );
+
+	it( 'maps the WordPress.com proxy envelope (409 + body.error)', () => {
+		expect(
+			mapCreateCategoryError(
+				Object.assign( new Error( 'exists' ), { code: 409, body: { error: 'duplicate' } } )
+			)
+		).toBe( DUPLICATE );
+	} );
+
+	it( 'maps a bare 409 conflict as a duplicate', () => {
+		expect(
+			mapCreateCategoryError( Object.assign( new Error( 'conflict' ), { code: 409 } ) )
+		).toBe( DUPLICATE );
+	} );
+
+	it( 'falls back to a generic message for other errors', () => {
+		expect(
+			mapCreateCategoryError(
+				Object.assign( new Error( 'not allowed' ), { code: 'rest_cannot_create' } )
+			)
+		).toBe( GENERIC );
+	} );
+
+	it( 'falls back to a generic message when there is no error shape', () => {
+		expect( mapCreateCategoryError( new Error( 'network down' ) ) ).toBe( GENERIC );
+	} );
+} );

--- a/projects/packages/newsletter/tests/newsletter-categories-section.test.tsx
+++ b/projects/packages/newsletter/tests/newsletter-categories-section.test.tsx
@@ -12,65 +12,82 @@
  * we can assert a freshly created category shows up in the list without a reload.
  */
 
-jest.mock( '@wordpress/ui', () => ( {
-	__esModule: true,
-	Button: ( {
-		children,
-		onClick,
-		disabled,
-	}: {
-		children: React.ReactNode;
-		onClick?: () => void;
-		disabled?: boolean;
-		loading?: boolean;
-	} ) => (
-		<button onClick={ onClick } disabled={ disabled }>
-			{ children }
-		</button>
-	),
-	Card: {
-		Root: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
-		Header: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
-		Title: ( { children }: { children: React.ReactNode } ) => <h2>{ children }</h2>,
-		Content: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
-	},
-	Fieldset: {
-		Root: ( { children }: { children: React.ReactNode } ) => <fieldset>{ children }</fieldset>,
-	},
-	Link: ( { children, href }: { children: React.ReactNode; href?: string } ) => (
-		<a href={ href }>{ children }</a>
-	),
-	Notice: {
-		Root: ( { children }: { children: React.ReactNode } ) => <div role="alert">{ children }</div>,
-		Description: ( { children }: { children: React.ReactNode } ) => <p>{ children }</p>,
-	},
-	Stack: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
-	Text: ( { children }: { children: React.ReactNode } ) => <span>{ children }</span>,
-} ) );
+jest.mock( '@wordpress/ui', () => {
+	// forwardRef so the component can focus the "Add new category" trigger.
+	return {
+		__esModule: true,
+		Button: mockForwardRef(
+			(
+				{
+					children,
+					onClick,
+					disabled,
+				}: {
+					children: React.ReactNode;
+					onClick?: () => void;
+					disabled?: boolean;
+					loading?: boolean;
+				},
+				ref: React.Ref< HTMLButtonElement >
+			) => (
+				<button ref={ ref } onClick={ onClick } disabled={ disabled }>
+					{ children }
+				</button>
+			)
+		),
+		Card: {
+			Root: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+			Header: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+			Title: ( { children }: { children: React.ReactNode } ) => <h2>{ children }</h2>,
+			Content: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+		},
+		Fieldset: {
+			Root: ( { children }: { children: React.ReactNode } ) => <fieldset>{ children }</fieldset>,
+		},
+		Link: ( { children, href }: { children: React.ReactNode; href?: string } ) => (
+			<a href={ href }>{ children }</a>
+		),
+		Notice: {
+			Root: ( { children }: { children: React.ReactNode } ) => <div role="alert">{ children }</div>,
+			Description: ( { children }: { children: React.ReactNode } ) => <p>{ children }</p>,
+		},
+		Stack: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+		Text: ( { children }: { children: React.ReactNode } ) => <span>{ children }</span>,
+	};
+} );
 
-jest.mock( '@wordpress/components', () => ( {
-	__esModule: true,
-	TextControl: ( {
-		label,
-		value,
-		onChange,
-		disabled,
-	}: {
-		label: string;
-		value: string;
-		onChange: ( next: string ) => void;
-		disabled?: boolean;
-	} ) => (
-		<input
-			aria-label={ label }
-			value={ value }
-			disabled={ disabled }
-			// Test-only mock; the re-bind-per-render cost is irrelevant in a jest render.
-			// eslint-disable-next-line react/jsx-no-bind
-			onChange={ e => onChange( e.target.value ) }
-		/>
-	),
-} ) );
+jest.mock( '@wordpress/components', () => {
+	// forwardRef so the component can focus the name field when the form opens.
+	return {
+		__esModule: true,
+		TextControl: mockForwardRef(
+			(
+				{
+					label,
+					value,
+					onChange,
+					disabled,
+				}: {
+					label: string;
+					value: string;
+					onChange: ( next: string ) => void;
+					disabled?: boolean;
+				},
+				ref: React.Ref< HTMLInputElement >
+			) => (
+				<input
+					ref={ ref }
+					aria-label={ label }
+					value={ value }
+					disabled={ disabled }
+					// Test-only mock; the re-bind-per-render cost is irrelevant in a jest render.
+					// eslint-disable-next-line react/jsx-no-bind
+					onChange={ e => onChange( e.target.value ) }
+				/>
+			)
+		),
+	};
+} );
 
 interface StubField {
 	id: string;
@@ -115,6 +132,8 @@ jest.mock( '../src/settings/api', () => ( {
 } ) );
 
 import { act, render, screen, waitFor } from '@testing-library/react';
+// `mock`-prefixed so it may be referenced inside the hoisted jest.mock factories above.
+import { forwardRef as mockForwardRef } from 'react';
 import { createCategory, fetchCategories } from '../src/settings/api';
 import { NewsletterCategoriesSection } from '../src/settings/sections/newsletter-categories-section';
 import type { NewsletterSettings } from '../src/settings/types';
@@ -236,6 +255,77 @@ describe( 'NewsletterCategoriesSection — inline add category (NL-785)', () => 
 		);
 	} );
 
+	it( 'auto-selects using the latest selection when it changes mid-request', async () => {
+		// Hold the create promise open so we can change the selection while the
+		// request is "in flight".
+		let resolveCreate: ( category: { id: number; name: string } ) => void = () => {};
+		mockedCreateCategory.mockReturnValue(
+			new Promise< { id: number; name: string } >( resolve => {
+				resolveCreate = resolve;
+			} )
+		);
+
+		const onChange = jest.fn();
+		const sharedProps = {
+			onChange,
+			onSave: jest.fn(),
+			isSaving: false,
+			hasChanges: false,
+			changedKeys: [],
+			isNewsletterEnabled: true,
+		};
+		const { rerender } = render(
+			<NewsletterCategoriesSection
+				data={ buildData( { wpcom_newsletter_categories: [] } ) }
+				{ ...sharedProps }
+			/>
+		);
+		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
+
+		clickButton( 'Add new category' );
+		typeInto( 'New category name', 'Weekly Digest' );
+		clickButton( 'Add category' );
+
+		// The user selects an existing category while the request is pending; the
+		// parent re-renders with the updated selection.
+		rerender(
+			<NewsletterCategoriesSection
+				data={ buildData( { wpcom_newsletter_categories: [ '1' ] } ) }
+				{ ...sharedProps }
+			/>
+		);
+
+		await act( async () => {
+			resolveCreate( { id: 42, name: 'Weekly Digest' } );
+		} );
+
+		// The new id is appended to the latest selection, not the stale empty one.
+		await waitFor( () =>
+			expect( onChange ).toHaveBeenCalledWith( {
+				wpcom_newsletter_categories: [ '1', '42' ],
+			} )
+		);
+	} );
+
+	it( 'moves focus to the name field when the add-category form opens', async () => {
+		renderSection();
+		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
+
+		clickButton( 'Add new category' );
+
+		expect( screen.getByLabelText( 'New category name' ) ).toHaveFocus();
+	} );
+
+	it( 'returns focus to the trigger when the form is cancelled', async () => {
+		renderSection();
+		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
+
+		clickButton( 'Add new category' );
+		clickButton( 'Cancel' );
+
+		expect( screen.getByRole( 'button', { name: 'Add new category' } ) ).toHaveFocus();
+	} );
+
 	it( 'trims the name and does not create a whitespace-only category', async () => {
 		mockedCreateCategory.mockResolvedValue( { id: 7, name: 'Trimmed' } );
 		renderSection();
@@ -271,6 +361,30 @@ describe( 'NewsletterCategoriesSection — inline add category (NL-785)', () => 
 		expect( alert ).toHaveTextContent( 'This category already exists.' );
 		// The long parent-aware core message is not shown to the user.
 		expect( alert ).not.toHaveTextContent( 'already exists with this parent' );
+		// Nothing was selected, and the form stays open for a retry.
+		expect( onChange ).not.toHaveBeenCalled();
+		expect( screen.getByLabelText( 'New category name' ) ).toBeInTheDocument();
+	} );
+
+	it( 'surfaces the friendly duplicate error for the WordPress.com Simple-site error shape', async () => {
+		// WordPress.com's `/rest/v1.1` terms/new endpoint rejects duplicates with
+		// `error: 'duplicate'`, not the self-hosted WP REST `code: 'term_exists'`.
+		mockedCreateCategory.mockRejectedValue(
+			Object.assign( new Error( 'A taxonomy with that name already exists' ), {
+				error: 'duplicate',
+			} )
+		);
+		const { onChange } = renderSection();
+		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
+
+		clickButton( 'Add new category' );
+		typeInto( 'New category name', 'News' );
+		clickButton( 'Add category' );
+
+		const alert = await screen.findByRole( 'alert' );
+		expect( alert ).toHaveTextContent( 'This category already exists.' );
+		// The raw server message is not shown to the user.
+		expect( alert ).not.toHaveTextContent( 'A taxonomy with that name already exists' );
 		// Nothing was selected, and the form stays open for a retry.
 		expect( onChange ).not.toHaveBeenCalled();
 		expect( screen.getByLabelText( 'New category name' ) ).toBeInTheDocument();

--- a/projects/packages/newsletter/tests/newsletter-categories-section.test.tsx
+++ b/projects/packages/newsletter/tests/newsletter-categories-section.test.tsx
@@ -1,0 +1,293 @@
+/**
+ * Tests for inline category creation in the Newsletter categories section (NL-785).
+ *
+ * The section used to link out to wp-admin's `edit-tags.php` to add a category,
+ * which meant the new term only appeared after a full page refresh. These tests
+ * exercise the inline "add new category" flow against the real component:
+ * creating a term appends it to the list (no refresh) and auto-selects it, and
+ * failures surface an inline error instead of navigating away.
+ *
+ * `@wordpress/ui` / `@wordpress/components` / `@wordpress/dataviews` are stubbed
+ * to plain HTML. The `DataForm` stub renders the category field's `elements` so
+ * we can assert a freshly created category shows up in the list without a reload.
+ */
+
+jest.mock( '@wordpress/ui', () => ( {
+	__esModule: true,
+	Button: ( {
+		children,
+		onClick,
+		disabled,
+	}: {
+		children: React.ReactNode;
+		onClick?: () => void;
+		disabled?: boolean;
+		loading?: boolean;
+	} ) => (
+		<button onClick={ onClick } disabled={ disabled }>
+			{ children }
+		</button>
+	),
+	Card: {
+		Root: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+		Header: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+		Title: ( { children }: { children: React.ReactNode } ) => <h2>{ children }</h2>,
+		Content: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+	},
+	Fieldset: {
+		Root: ( { children }: { children: React.ReactNode } ) => <fieldset>{ children }</fieldset>,
+	},
+	Link: ( { children, href }: { children: React.ReactNode; href?: string } ) => (
+		<a href={ href }>{ children }</a>
+	),
+	Notice: {
+		Root: ( { children }: { children: React.ReactNode } ) => <div role="alert">{ children }</div>,
+		Description: ( { children }: { children: React.ReactNode } ) => <p>{ children }</p>,
+	},
+	Stack: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+	Text: ( { children }: { children: React.ReactNode } ) => <span>{ children }</span>,
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	__esModule: true,
+	TextControl: ( {
+		label,
+		value,
+		onChange,
+		disabled,
+	}: {
+		label: string;
+		value: string;
+		onChange: ( next: string ) => void;
+		disabled?: boolean;
+	} ) => (
+		<input
+			aria-label={ label }
+			value={ value }
+			disabled={ disabled }
+			// Test-only mock; the re-bind-per-render cost is irrelevant in a jest render.
+			// eslint-disable-next-line react/jsx-no-bind
+			onChange={ e => onChange( e.target.value ) }
+		/>
+	),
+} ) );
+
+interface StubField {
+	id: string;
+	elements?: Array< { value: string; label: string } >;
+}
+
+jest.mock( '@wordpress/dataviews', () => ( {
+	__esModule: true,
+	// Render the category field's elements so a newly created category is
+	// observable in the list without a page refresh.
+	DataForm: ( { fields }: { fields: StubField[] } ) => {
+		const categoryField = fields?.find( f => f.id === 'wpcom_newsletter_categories' );
+		return (
+			<div data-testid="data-form">
+				{ categoryField?.elements?.map( el => <span key={ el.value }>{ el.label }</span> ) }
+			</div>
+		);
+	},
+	useFormValidity: () => ( { validity: {}, isValid: true } ),
+} ) );
+
+jest.mock( '@automattic/jetpack-analytics', () => ( {
+	__esModule: true,
+	default: {
+		tracks: { recordEvent: jest.fn() },
+	},
+} ) );
+
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	getSiteType: jest.fn( () => 'jetpack' ),
+	getSiteData: jest.fn( () => ( { wpcom: { blog_id: 123 } } ) ),
+	isWpcomPlatformSite: jest.fn( () => false ),
+} ) );
+
+jest.mock( '@automattic/jetpack-shared-extension-utils/components/wpcom-support-link', () => ( {
+	WpcomSupportLink: () => <a href="https://example.com/support">support</a>,
+} ) );
+
+jest.mock( '../src/settings/api', () => ( {
+	fetchCategories: jest.fn(),
+	createCategory: jest.fn(),
+} ) );
+
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { createCategory, fetchCategories } from '../src/settings/api';
+import { NewsletterCategoriesSection } from '../src/settings/sections/newsletter-categories-section';
+import type { NewsletterSettings } from '../src/settings/types';
+
+const mockedFetchCategories = fetchCategories as jest.MockedFunction< typeof fetchCategories >;
+const mockedCreateCategory = createCategory as jest.MockedFunction< typeof createCategory >;
+
+// The package intentionally doesn't pull in `@testing-library/user-event`
+// (mirrors the sibling shell tests), so drive interactions natively.
+const nativeInputSetter = Object.getOwnPropertyDescriptor(
+	window.HTMLInputElement.prototype,
+	'value'
+)?.set as ( value: string ) => void;
+
+/**
+ * Click a button by its accessible name.
+ *
+ * @param name - The button's accessible name.
+ */
+function clickButton( name: string ): void {
+	// Native click: the package doesn't pull in @testing-library/user-event.
+	const button = screen.getByRole( 'button', { name } );
+	act( () => {
+		button.click();
+	} );
+}
+
+/**
+ * Set a text field's value the way a user would, triggering React's onChange.
+ *
+ * @param label - The field's accessible label.
+ * @param value - The value to enter.
+ */
+function typeInto( label: string, value: string ): void {
+	const input = screen.getByLabelText( label ) as HTMLInputElement;
+	act( () => {
+		nativeInputSetter.call( input, value );
+		input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
+	} );
+}
+
+/**
+ * Build a `NewsletterSettings`-shaped object with newsletter categories enabled.
+ *
+ * @param overrides - Subset of settings to merge over the defaults.
+ * @return Settings object ready to pass to `<NewsletterCategoriesSection data />`.
+ */
+function buildData( overrides: Partial< NewsletterSettings > = {} ): NewsletterSettings {
+	return {
+		wpcom_newsletter_categories_enabled: true,
+		wpcom_newsletter_categories: [],
+		...overrides,
+	} as NewsletterSettings;
+}
+
+/**
+ * Render `<NewsletterCategoriesSection>` with sensible defaults so each test only
+ * has to override the props it cares about.
+ *
+ * @param props - Prop overrides to apply on top of the defaults.
+ * @return RTL render helpers plus the `onChange` spy.
+ */
+function renderSection(
+	props: Partial< React.ComponentProps< typeof NewsletterCategoriesSection > > = {}
+) {
+	const onChange = ( props.onChange as jest.Mock ) ?? jest.fn();
+	const utils = render(
+		<NewsletterCategoriesSection
+			data={ ( props.data as NewsletterSettings ) ?? buildData() }
+			onChange={ onChange }
+			onSave={ jest.fn() }
+			isSaving={ false }
+			hasChanges={ false }
+			changedKeys={ [] }
+			isNewsletterEnabled={ true }
+			{ ...props }
+		/>
+	);
+	return { ...utils, onChange };
+}
+
+describe( 'NewsletterCategoriesSection — inline add category (NL-785)', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockedFetchCategories.mockResolvedValue( [ { id: 1, name: 'News' } ] );
+	} );
+
+	it( 'does not link out to wp-admin to add a category', async () => {
+		renderSection();
+		// Wait for the initial category fetch to settle.
+		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
+
+		const links = screen.queryAllByRole( 'link' ) as HTMLAnchorElement[];
+		expect( links.some( link => link.getAttribute( 'href' )?.includes( 'edit-tags.php' ) ) ).toBe(
+			false
+		);
+		// The affordance is now an in-page action, not a navigation link.
+		expect( screen.getByRole( 'button', { name: 'Add new category' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'creates a category inline, shows it without a refresh, and auto-selects it', async () => {
+		mockedCreateCategory.mockResolvedValue( { id: 42, name: 'Weekly Digest' } );
+		const { onChange } = renderSection();
+		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
+
+		clickButton( 'Add new category' );
+		typeInto( 'New category name', 'Weekly Digest' );
+		clickButton( 'Add category' );
+
+		expect( mockedCreateCategory ).toHaveBeenCalledWith( 'Weekly Digest' );
+
+		// The new category appears in the list without a page reload...
+		await expect( screen.findByText( 'Weekly Digest' ) ).resolves.toBeInTheDocument();
+		// ...and is auto-selected (staged for save) alongside any existing selection.
+		await waitFor( () =>
+			expect( onChange ).toHaveBeenCalledWith( {
+				wpcom_newsletter_categories: [ '42' ],
+			} )
+		);
+	} );
+
+	it( 'trims the name and does not create a whitespace-only category', async () => {
+		mockedCreateCategory.mockResolvedValue( { id: 7, name: 'Trimmed' } );
+		renderSection();
+		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
+
+		clickButton( 'Add new category' );
+		typeInto( 'New category name', '   ' );
+
+		// The submit button is disabled while the name is only whitespace.
+		expect( screen.getByRole( 'button', { name: 'Add category' } ) ).toBeDisabled();
+
+		typeInto( 'New category name', '  Trimmed  ' );
+		clickButton( 'Add category' );
+
+		await waitFor( () => expect( mockedCreateCategory ).toHaveBeenCalledWith( 'Trimmed' ) );
+	} );
+
+	it( 'surfaces a friendly error when the category already exists', async () => {
+		mockedCreateCategory.mockRejectedValue(
+			Object.assign(
+				new Error( 'A term with the name provided already exists with this parent.' ),
+				{ code: 'term_exists' }
+			)
+		);
+		const { onChange } = renderSection();
+		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
+
+		clickButton( 'Add new category' );
+		typeInto( 'New category name', 'News' );
+		clickButton( 'Add category' );
+
+		const alert = await screen.findByRole( 'alert' );
+		expect( alert ).toHaveTextContent( 'This category already exists.' );
+		// The long parent-aware core message is not shown to the user.
+		expect( alert ).not.toHaveTextContent( 'already exists with this parent' );
+		// Nothing was selected, and the form stays open for a retry.
+		expect( onChange ).not.toHaveBeenCalled();
+		expect( screen.getByLabelText( 'New category name' ) ).toBeInTheDocument();
+	} );
+
+	it( 'closes the inline form and clears input when cancelled', async () => {
+		renderSection();
+		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
+
+		clickButton( 'Add new category' );
+		typeInto( 'New category name', 'Discarded' );
+		clickButton( 'Cancel' );
+
+		expect( screen.queryByLabelText( 'New category name' ) ).not.toBeInTheDocument();
+		expect( mockedCreateCategory ).not.toHaveBeenCalled();
+		// Reopening starts from an empty field, not the discarded value.
+		clickButton( 'Add new category' );
+		expect( screen.getByLabelText( 'New category name' ) ).toHaveValue( '' );
+	} );
+} );

--- a/projects/packages/newsletter/tests/newsletter-categories-section.test.tsx
+++ b/projects/packages/newsletter/tests/newsletter-categories-section.test.tsx
@@ -276,6 +276,28 @@ describe( 'NewsletterCategoriesSection — inline add category (NL-785)', () => 
 		expect( screen.getByLabelText( 'New category name' ) ).toBeInTheDocument();
 	} );
 
+	it( 'shows a generic message for non-duplicate errors and never leaks the raw server text', async () => {
+		mockedCreateCategory.mockRejectedValue(
+			Object.assign( new Error( 'Sorry, you are not allowed to create terms in this taxonomy.' ), {
+				code: 'rest_cannot_create',
+			} )
+		);
+		const { onChange } = renderSection();
+		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
+
+		clickButton( 'Add new category' );
+		typeInto( 'New category name', 'Announcements' );
+		clickButton( 'Add category' );
+
+		const alert = await screen.findByRole( 'alert' );
+		expect( alert ).toHaveTextContent( 'Could not create the category. Please try again.' );
+		// The raw, English-only server message is not surfaced to the user.
+		expect( alert ).not.toHaveTextContent( 'not allowed to create terms' );
+		// Nothing was selected, and the form stays open for a retry.
+		expect( onChange ).not.toHaveBeenCalled();
+		expect( screen.getByLabelText( 'New category name' ) ).toBeInTheDocument();
+	} );
+
 	it( 'closes the inline form and clears input when cancelled', async () => {
 		renderSection();
 		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();

--- a/projects/packages/newsletter/tests/newsletter-categories-section.test.tsx
+++ b/projects/packages/newsletter/tests/newsletter-categories-section.test.tsx
@@ -66,11 +66,13 @@ jest.mock( '@wordpress/components', () => {
 					label,
 					value,
 					onChange,
+					onKeyDown,
 					disabled,
 				}: {
 					label: string;
 					value: string;
 					onChange: ( next: string ) => void;
+					onKeyDown?: ( event: React.KeyboardEvent< HTMLInputElement > ) => void;
 					disabled?: boolean;
 				},
 				ref: React.Ref< HTMLInputElement >
@@ -80,6 +82,7 @@ jest.mock( '@wordpress/components', () => {
 					aria-label={ label }
 					value={ value }
 					disabled={ disabled }
+					onKeyDown={ onKeyDown }
 					// Test-only mock; the re-bind-per-render cost is irrelevant in a jest render.
 					// eslint-disable-next-line react/jsx-no-bind
 					onChange={ e => onChange( e.target.value ) }
@@ -176,6 +179,21 @@ function typeInto( label: string, value: string ): void {
 }
 
 /**
+ * Press the Enter key in a text field, the way a user submitting a single-field
+ * form would.
+ *
+ * @param label - The field's accessible label.
+ */
+function pressEnter( label: string ): void {
+	const input = screen.getByLabelText( label ) as HTMLInputElement;
+	act( () => {
+		input.dispatchEvent(
+			new KeyboardEvent( 'keydown', { key: 'Enter', bubbles: true, cancelable: true } )
+		);
+	} );
+}
+
+/**
  * Build a `NewsletterSettings`-shaped object with newsletter categories enabled.
  *
  * @param overrides - Subset of settings to merge over the defaults.
@@ -253,6 +271,29 @@ describe( 'NewsletterCategoriesSection — inline add category (NL-785)', () => 
 				wpcom_newsletter_categories: [ '42' ],
 			} )
 		);
+	} );
+
+	it( 'creates the category when Enter is pressed in the name field', async () => {
+		mockedCreateCategory.mockResolvedValue( { id: 55, name: 'Weekly Digest' } );
+		renderSection();
+		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
+
+		clickButton( 'Add new category' );
+		typeInto( 'New category name', 'Weekly Digest' );
+		// Enter submits the single-field form without reaching for the button.
+		pressEnter( 'New category name' );
+
+		await waitFor( () => expect( mockedCreateCategory ).toHaveBeenCalledWith( 'Weekly Digest' ) );
+	} );
+
+	it( 'does not create anything when Enter is pressed with an empty name', async () => {
+		renderSection();
+		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
+
+		clickButton( 'Add new category' );
+		pressEnter( 'New category name' );
+
+		expect( mockedCreateCategory ).not.toHaveBeenCalled();
 	} );
 
 	it( 'auto-selects using the latest selection when it changes mid-request', async () => {

--- a/projects/packages/newsletter/tests/newsletter-categories-section.test.tsx
+++ b/projects/packages/newsletter/tests/newsletter-categories-section.test.tsx
@@ -1,115 +1,151 @@
 /**
- * Tests for inline category creation in the Newsletter categories section (NL-785).
+ * Tests for the Newsletter categories section (NL-785).
  *
- * The section used to link out to wp-admin's `edit-tags.php` to add a category,
- * which meant the new term only appeared after a full page refresh. These tests
- * exercise the inline "add new category" flow against the real component:
- * creating a term appends it to the list (no refresh) and auto-selects it, and
- * failures surface an inline error instead of navigating away.
+ * The section used to link out to wp-admin's `edit-tags.php` to add a category
+ * (new terms only appeared after a full refresh); it was then reworked into a
+ * single combined field that both *searches* existing categories and *creates*
+ * new ones inline via a "Create ‘…’" suggestion row.
  *
- * `@wordpress/ui` / `@wordpress/components` / `@wordpress/dataviews` are stubbed
- * to plain HTML. The `DataForm` stub renders the category field's `elements` so
- * we can assert a freshly created category shows up in the list without a reload.
+ * These are integration tests: the `DataForm` stub renders the categories
+ * field's real custom `Edit` control (`CreatableCategoriesControl`) with a
+ * stubbed `FormTokenField`, so creating a category exercises the real
+ * create/select/error wiring end to end — appearing without a refresh,
+ * auto-selecting, firing analytics, and surfacing inline errors.
  */
 
-jest.mock( '@wordpress/ui', () => {
-	// forwardRef so the component can focus the "Add new category" trigger.
-	return {
-		__esModule: true,
-		Button: mockForwardRef(
-			(
-				{
-					children,
-					onClick,
-					disabled,
-				}: {
-					children: React.ReactNode;
-					onClick?: () => void;
-					disabled?: boolean;
-					loading?: boolean;
-				},
-				ref: React.Ref< HTMLButtonElement >
-			) => (
-				<button ref={ ref } onClick={ onClick } disabled={ disabled }>
-					{ children }
-				</button>
-			)
-		),
-		Card: {
-			Root: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
-			Header: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
-			Title: ( { children }: { children: React.ReactNode } ) => <h2>{ children }</h2>,
-			Content: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
-		},
-		Fieldset: {
-			Root: ( { children }: { children: React.ReactNode } ) => <fieldset>{ children }</fieldset>,
-		},
-		Link: ( { children, href }: { children: React.ReactNode; href?: string } ) => (
-			<a href={ href }>{ children }</a>
-		),
-		Notice: {
-			Root: ( { children }: { children: React.ReactNode } ) => <div role="alert">{ children }</div>,
-			Description: ( { children }: { children: React.ReactNode } ) => <p>{ children }</p>,
-		},
-		Stack: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
-		Text: ( { children }: { children: React.ReactNode } ) => <span>{ children }</span>,
-	};
-} );
+interface TokenFieldProps {
+	label?: string;
+	placeholder?: string;
+	value: string[];
+	suggestions: string[];
+	displayTransform?: ( token: string ) => string;
+	onChange: ( tokens: string[] ) => void;
+	onInputChange?: ( input: string ) => void;
+}
 
-jest.mock( '@wordpress/components', () => {
-	// forwardRef so the component can focus the name field when the form opens.
-	return {
-		__esModule: true,
-		TextControl: mockForwardRef(
-			(
-				{
-					label,
-					value,
-					onChange,
-					onKeyDown,
-					disabled,
-				}: {
-					label: string;
-					value: string;
-					onChange: ( next: string ) => void;
-					onKeyDown?: ( event: React.KeyboardEvent< HTMLInputElement > ) => void;
-					disabled?: boolean;
-				},
-				ref: React.Ref< HTMLInputElement >
-			) => (
+jest.mock( '@wordpress/components', () => ( {
+	__esModule: true,
+	// Minimal FormTokenField: an input that drives `onInputChange`, the selected
+	// tokens, and one button per suggestion that adds it via `onChange`.
+	FormTokenField: ( {
+		label,
+		placeholder,
+		value,
+		suggestions,
+		displayTransform,
+		onChange,
+		onInputChange,
+	}: TokenFieldProps ) => {
+		const show = ( token: string ) => ( displayTransform ? displayTransform( token ) : token );
+		return (
+			<div>
 				<input
-					ref={ ref }
-					aria-label={ label }
-					value={ value }
-					disabled={ disabled }
-					onKeyDown={ onKeyDown }
-					// Test-only mock; the re-bind-per-render cost is irrelevant in a jest render.
+					aria-label={ label || placeholder }
 					// eslint-disable-next-line react/jsx-no-bind
-					onChange={ e => onChange( e.target.value ) }
+					onChange={ e => onInputChange?.( e.target.value ) }
 				/>
-			)
-		),
-	};
-} );
+				<ul aria-label="Selected categories">
+					{ value.map( token => (
+						<li key={ token }>{ show( token ) }</li>
+					) ) }
+				</ul>
+				{ suggestions.map( token => (
+					<button
+						key={ token }
+						type="button"
+						// eslint-disable-next-line react/jsx-no-bind
+						onClick={ () => onChange( [ ...value, token ] ) }
+					>
+						{ show( token ) }
+					</button>
+				) ) }
+			</div>
+		);
+	},
+} ) );
 
 interface StubField {
 	id: string;
+	Edit?: ( props: Record< string, unknown > ) => React.ReactNode;
 	elements?: Array< { value: string; label: string } >;
 }
 
 jest.mock( '@wordpress/dataviews', () => ( {
 	__esModule: true,
-	// Render the category field's elements so a newly created category is
-	// observable in the list without a page refresh.
-	DataForm: ( { fields }: { fields: StubField[] } ) => {
-		const categoryField = fields?.find( f => f.id === 'wpcom_newsletter_categories' );
-		return (
-			<div data-testid="data-form">
-				{ categoryField?.elements?.map( el => <span key={ el.value }>{ el.label }</span> ) }
-			</div>
-		);
-	},
+	// Render each field's real custom `Edit` control (the categories field), so
+	// tests drive the actual create/search behavior. Non-custom fields (the
+	// enable toggle) render nothing — they aren't under test here.
+	DataForm: ( {
+		data,
+		fields,
+		onChange,
+		validity,
+	}: {
+		data: Record< string, unknown >;
+		fields: StubField[];
+		onChange: ( updates: Record< string, unknown > ) => void;
+		validity?: Record< string, unknown >;
+	} ) => (
+		<div data-testid="data-form">
+			{ fields.map( field => {
+				if ( typeof field.Edit === 'function' ) {
+					const Edit = field.Edit;
+					const normalized = {
+						...field,
+						getValue: ( { item }: { item: Record< string, unknown > } ) => item[ field.id ],
+						setValue: ( { value }: { value: unknown } ) => ( { [ field.id ]: value } ),
+						isDisabled: () => false,
+					};
+					return (
+						<Edit
+							key={ field.id }
+							data={ data }
+							field={ normalized }
+							onChange={ onChange }
+							validity={ validity?.[ field.id ] }
+							hideLabelFromVision={ false }
+						/>
+					);
+				}
+				return <div key={ field.id } data-field={ field.id } />;
+			} ) }
+		</div>
+	),
 	useFormValidity: () => ( { validity: {}, isValid: true } ),
+} ) );
+
+jest.mock( '@wordpress/ui', () => ( {
+	__esModule: true,
+	Button: ( {
+		children,
+		onClick,
+		disabled,
+	}: {
+		children: React.ReactNode;
+		onClick?: () => void;
+		disabled?: boolean;
+	} ) => (
+		<button onClick={ onClick } disabled={ disabled }>
+			{ children }
+		</button>
+	),
+	Card: {
+		Root: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+		Header: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+		Title: ( { children }: { children: React.ReactNode } ) => <h2>{ children }</h2>,
+		Content: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+	},
+	Fieldset: {
+		Root: ( { children }: { children: React.ReactNode } ) => <fieldset>{ children }</fieldset>,
+	},
+	Link: ( { children, href }: { children: React.ReactNode; href?: string } ) => (
+		<a href={ href }>{ children }</a>
+	),
+	Notice: {
+		Root: ( { children }: { children: React.ReactNode } ) => <div role="alert">{ children }</div>,
+		Description: ( { children }: { children: React.ReactNode } ) => <p>{ children }</p>,
+	},
+	Text: ( { children }: { children: React.ReactNode } ) => <span>{ children }</span>,
 } ) );
 
 jest.mock( '@automattic/jetpack-analytics', () => ( {
@@ -135,9 +171,8 @@ jest.mock( '../src/settings/api', () => ( {
 } ) );
 
 import analytics from '@automattic/jetpack-analytics';
-import { act, render, screen, waitFor } from '@testing-library/react';
-// `mock`-prefixed so it may be referenced inside the hoisted jest.mock factories above.
-import { forwardRef as mockForwardRef } from 'react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
+import { useState } from 'react';
 import { createCategory, fetchCategories } from '../src/settings/api';
 import { NewsletterCategoriesSection } from '../src/settings/sections/newsletter-categories-section';
 import type { NewsletterSettings } from '../src/settings/types';
@@ -148,8 +183,6 @@ const mockedRecordEvent = analytics.tracks.recordEvent as jest.MockedFunction<
 	typeof analytics.tracks.recordEvent
 >;
 
-// The package intentionally doesn't pull in `@testing-library/user-event`
-// (mirrors the sibling shell tests), so drive interactions natively.
 const nativeInputSetter = Object.getOwnPropertyDescriptor(
 	window.HTMLInputElement.prototype,
 	'value'
@@ -161,7 +194,6 @@ const nativeInputSetter = Object.getOwnPropertyDescriptor(
  * @param name - The button's accessible name.
  */
 function clickButton( name: string ): void {
-	// Native click: the package doesn't pull in @testing-library/user-event.
 	const button = screen.getByRole( 'button', { name } );
 	act( () => {
 		button.click();
@@ -169,13 +201,12 @@ function clickButton( name: string ): void {
 }
 
 /**
- * Set a text field's value the way a user would, triggering React's onChange.
+ * Type into the category search input, triggering the field's `onInputChange`.
  *
- * @param label - The field's accessible label.
- * @param value - The value to enter.
+ * @param value - The text to enter.
  */
-function typeInto( label: string, value: string ): void {
-	const input = screen.getByLabelText( label ) as HTMLInputElement;
+function typeSearch( value: string ): void {
+	const input = screen.getByLabelText( 'Newsletter categories' ) as HTMLInputElement;
 	act( () => {
 		nativeInputSetter.call( input, value );
 		input.dispatchEvent( new Event( 'input', { bubbles: true } ) );
@@ -183,61 +214,52 @@ function typeInto( label: string, value: string ): void {
 }
 
 /**
- * Press the Enter key in a text field, the way a user submitting a single-field
- * form would.
+ * Render the section inside a small controlled wrapper so `onChange` updates the
+ * `data` prop (as the real settings screen does), letting a created + selected
+ * category render as a token without a refresh.
  *
- * @param label - The field's accessible label.
+ * @param overrides - Settings overrides merged over the defaults.
+ * @return RTL helpers plus the `onChange` spy.
  */
-function pressEnter( label: string ): void {
-	const input = screen.getByLabelText( label ) as HTMLInputElement;
-	act( () => {
-		input.dispatchEvent(
-			new KeyboardEvent( 'keydown', { key: 'Enter', bubbles: true, cancelable: true } )
+function renderSection( overrides: Partial< NewsletterSettings > = {} ) {
+	const onChange = jest.fn();
+
+	/**
+	 * Controlled wrapper that owns `data` so a create/select round-trips back
+	 * into the field via `onChange`, as the real settings screen does.
+	 *
+	 * @return The rendered section.
+	 */
+	function Wrapper() {
+		const [ data, setData ] = useState< NewsletterSettings >( {
+			wpcom_newsletter_categories_enabled: true,
+			wpcom_newsletter_categories: [],
+			...overrides,
+		} as NewsletterSettings );
+
+		const handleChange = ( updates: Partial< NewsletterSettings > ) => {
+			onChange( updates );
+			setData( prev => ( { ...prev, ...updates } ) );
+		};
+		return (
+			<NewsletterCategoriesSection
+				data={ data }
+				// eslint-disable-next-line react/jsx-no-bind
+				onChange={ handleChange }
+				onSave={ jest.fn() }
+				isSaving={ false }
+				hasChanges={ false }
+				changedKeys={ [] }
+				isNewsletterEnabled={ true }
+			/>
 		);
-	} );
-}
+	}
 
-/**
- * Build a `NewsletterSettings`-shaped object with newsletter categories enabled.
- *
- * @param overrides - Subset of settings to merge over the defaults.
- * @return Settings object ready to pass to `<NewsletterCategoriesSection data />`.
- */
-function buildData( overrides: Partial< NewsletterSettings > = {} ): NewsletterSettings {
-	return {
-		wpcom_newsletter_categories_enabled: true,
-		wpcom_newsletter_categories: [],
-		...overrides,
-	} as NewsletterSettings;
-}
-
-/**
- * Render `<NewsletterCategoriesSection>` with sensible defaults so each test only
- * has to override the props it cares about.
- *
- * @param props - Prop overrides to apply on top of the defaults.
- * @return RTL render helpers plus the `onChange` spy.
- */
-function renderSection(
-	props: Partial< React.ComponentProps< typeof NewsletterCategoriesSection > > = {}
-) {
-	const onChange = ( props.onChange as jest.Mock ) ?? jest.fn();
-	const utils = render(
-		<NewsletterCategoriesSection
-			data={ ( props.data as NewsletterSettings ) ?? buildData() }
-			onChange={ onChange }
-			onSave={ jest.fn() }
-			isSaving={ false }
-			hasChanges={ false }
-			changedKeys={ [] }
-			isNewsletterEnabled={ true }
-			{ ...props }
-		/>
-	);
+	const utils = render( <Wrapper /> );
 	return { ...utils, onChange };
 }
 
-describe( 'NewsletterCategoriesSection — inline add category (NL-785)', () => {
+describe( 'NewsletterCategoriesSection — combined search + create (NL-785)', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		mockedFetchCategories.mockResolvedValue( [ { id: 1, name: 'News' } ] );
@@ -245,36 +267,47 @@ describe( 'NewsletterCategoriesSection — inline add category (NL-785)', () => 
 
 	it( 'does not link out to wp-admin to add a category', async () => {
 		renderSection();
-		// Wait for the initial category fetch to settle.
 		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
 
 		const links = screen.queryAllByRole( 'link' ) as HTMLAnchorElement[];
 		expect( links.some( link => link.getAttribute( 'href' )?.includes( 'edit-tags.php' ) ) ).toBe(
 			false
 		);
-		// The affordance is now an in-page action, not a navigation link.
-		expect( screen.getByRole( 'button', { name: 'Add new category' } ) ).toBeInTheDocument();
+		// The old standalone "Add new category" affordance is gone.
+		expect( screen.queryByRole( 'button', { name: 'Add new category' } ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'creates a category inline, shows it without a refresh, and auto-selects it', async () => {
+	it( 'shows a "Create" row only for a name that does not already exist', async () => {
+		renderSection();
+		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
+
+		typeSearch( 'Weekly Digest' );
+		expect( screen.getByRole( 'button', { name: 'Create “Weekly Digest”' } ) ).toBeInTheDocument();
+
+		// Typing an existing name (case-insensitively) offers no create row.
+		typeSearch( 'news' );
+		expect( screen.queryByRole( 'button', { name: 'Create “news”' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'creates a category from the Create row, shows it without a refresh, and selects it', async () => {
 		mockedCreateCategory.mockResolvedValue( { id: 42, name: 'Weekly Digest' } );
 		const { onChange } = renderSection();
 		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
 
-		clickButton( 'Add new category' );
-		typeInto( 'New category name', 'Weekly Digest' );
-		clickButton( 'Add category' );
+		typeSearch( 'Weekly Digest' );
+		clickButton( 'Create “Weekly Digest”' );
 
 		expect( mockedCreateCategory ).toHaveBeenCalledWith( 'Weekly Digest' );
 
-		// The new category appears in the list without a page reload...
-		await expect( screen.findByText( 'Weekly Digest' ) ).resolves.toBeInTheDocument();
-		// ...and is auto-selected (staged for save) alongside any existing selection.
+		// Selected (staged for save)...
 		await waitFor( () =>
-			expect( onChange ).toHaveBeenCalledWith( {
-				wpcom_newsletter_categories: [ '42' ],
-			} )
+			expect( onChange ).toHaveBeenCalledWith( { wpcom_newsletter_categories: [ '42' ] } )
 		);
+		// ...and rendered as a selected token without a page reload.
+		await waitFor( () => {
+			const selected = screen.getByRole( 'list', { name: 'Selected categories' } );
+			expect( within( selected ).getByText( 'Weekly Digest' ) ).toBeInTheDocument();
+		} );
 	} );
 
 	it( 'records a tracking event when a category is created', async () => {
@@ -282,9 +315,8 @@ describe( 'NewsletterCategoriesSection — inline add category (NL-785)', () => 
 		renderSection();
 		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
 
-		clickButton( 'Add new category' );
-		typeInto( 'New category name', 'Weekly Digest' );
-		clickButton( 'Add category' );
+		typeSearch( 'Weekly Digest' );
+		clickButton( 'Create “Weekly Digest”' );
 
 		await waitFor( () =>
 			expect( mockedRecordEvent ).toHaveBeenCalledWith(
@@ -294,206 +326,38 @@ describe( 'NewsletterCategoriesSection — inline add category (NL-785)', () => 
 		);
 	} );
 
-	it( 'does not record a creation event when the create request fails', async () => {
-		mockedCreateCategory.mockRejectedValue(
-			Object.assign( new Error( 'nope' ), { code: 'term_exists' } )
-		);
-		renderSection();
+	it( 'selects an existing category without creating anything', async () => {
+		const { onChange } = renderSection();
 		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
 
-		clickButton( 'Add new category' );
-		typeInto( 'New category name', 'News' );
-		clickButton( 'Add category' );
+		clickButton( 'News' );
 
-		await expect( screen.findByRole( 'alert' ) ).resolves.toBeInTheDocument();
+		expect( onChange ).toHaveBeenCalledWith( { wpcom_newsletter_categories: [ '1' ] } );
+		expect( mockedCreateCategory ).not.toHaveBeenCalled();
+	} );
+
+	it( 'surfaces the friendly duplicate message for the WordPress.com envelope shape', async () => {
+		mockedCreateCategory.mockRejectedValue(
+			Object.assign( new Error( 'A taxonomy with that name already exists' ), {
+				code: 409,
+				body: { error: 'duplicate' },
+			} )
+		);
+		const { onChange } = renderSection();
+		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
+
+		typeSearch( 'News Two' );
+		clickButton( 'Create “News Two”' );
+
+		const alert = await screen.findByRole( 'alert' );
+		expect( alert ).toHaveTextContent( 'This category already exists.' );
+		expect( alert ).not.toHaveTextContent( 'A taxonomy with that name already exists' );
+		// Nothing was recorded or selected.
+		expect( onChange ).not.toHaveBeenCalled();
 		expect( mockedRecordEvent ).not.toHaveBeenCalledWith(
 			'jetpack_newsletter_category_created',
 			expect.anything()
 		);
-	} );
-
-	it( 'creates the category when Enter is pressed in the name field', async () => {
-		mockedCreateCategory.mockResolvedValue( { id: 55, name: 'Weekly Digest' } );
-		renderSection();
-		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
-
-		clickButton( 'Add new category' );
-		typeInto( 'New category name', 'Weekly Digest' );
-		// Enter submits the single-field form without reaching for the button.
-		pressEnter( 'New category name' );
-
-		await waitFor( () => expect( mockedCreateCategory ).toHaveBeenCalledWith( 'Weekly Digest' ) );
-	} );
-
-	it( 'does not create anything when Enter is pressed with an empty name', async () => {
-		renderSection();
-		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
-
-		clickButton( 'Add new category' );
-		pressEnter( 'New category name' );
-
-		expect( mockedCreateCategory ).not.toHaveBeenCalled();
-	} );
-
-	it( 'auto-selects using the latest selection when it changes mid-request', async () => {
-		// Hold the create promise open so we can change the selection while the
-		// request is "in flight".
-		let resolveCreate: ( category: { id: number; name: string } ) => void = () => {};
-		mockedCreateCategory.mockReturnValue(
-			new Promise< { id: number; name: string } >( resolve => {
-				resolveCreate = resolve;
-			} )
-		);
-
-		const onChange = jest.fn();
-		const sharedProps = {
-			onChange,
-			onSave: jest.fn(),
-			isSaving: false,
-			hasChanges: false,
-			changedKeys: [],
-			isNewsletterEnabled: true,
-		};
-		const { rerender } = render(
-			<NewsletterCategoriesSection
-				data={ buildData( { wpcom_newsletter_categories: [] } ) }
-				{ ...sharedProps }
-			/>
-		);
-		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
-
-		clickButton( 'Add new category' );
-		typeInto( 'New category name', 'Weekly Digest' );
-		clickButton( 'Add category' );
-
-		// The user selects an existing category while the request is pending; the
-		// parent re-renders with the updated selection.
-		rerender(
-			<NewsletterCategoriesSection
-				data={ buildData( { wpcom_newsletter_categories: [ '1' ] } ) }
-				{ ...sharedProps }
-			/>
-		);
-
-		await act( async () => {
-			resolveCreate( { id: 42, name: 'Weekly Digest' } );
-		} );
-
-		// The new id is appended to the latest selection, not the stale empty one.
-		await waitFor( () =>
-			expect( onChange ).toHaveBeenCalledWith( {
-				wpcom_newsletter_categories: [ '1', '42' ],
-			} )
-		);
-	} );
-
-	it( 'moves focus to the name field when the add-category form opens', async () => {
-		renderSection();
-		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
-
-		clickButton( 'Add new category' );
-
-		expect( screen.getByLabelText( 'New category name' ) ).toHaveFocus();
-	} );
-
-	it( 'returns focus to the trigger when the form is cancelled', async () => {
-		renderSection();
-		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
-
-		clickButton( 'Add new category' );
-		clickButton( 'Cancel' );
-
-		expect( screen.getByRole( 'button', { name: 'Add new category' } ) ).toHaveFocus();
-	} );
-
-	it( 'trims the name and does not create a whitespace-only category', async () => {
-		mockedCreateCategory.mockResolvedValue( { id: 7, name: 'Trimmed' } );
-		renderSection();
-		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
-
-		clickButton( 'Add new category' );
-		typeInto( 'New category name', '   ' );
-
-		// The submit button is disabled while the name is only whitespace.
-		expect( screen.getByRole( 'button', { name: 'Add category' } ) ).toBeDisabled();
-
-		typeInto( 'New category name', '  Trimmed  ' );
-		clickButton( 'Add category' );
-
-		await waitFor( () => expect( mockedCreateCategory ).toHaveBeenCalledWith( 'Trimmed' ) );
-	} );
-
-	it( 'surfaces a friendly error when the category already exists', async () => {
-		mockedCreateCategory.mockRejectedValue(
-			Object.assign(
-				new Error( 'A term with the name provided already exists with this parent.' ),
-				{ code: 'term_exists' }
-			)
-		);
-		const { onChange } = renderSection();
-		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
-
-		clickButton( 'Add new category' );
-		typeInto( 'New category name', 'News' );
-		clickButton( 'Add category' );
-
-		const alert = await screen.findByRole( 'alert' );
-		expect( alert ).toHaveTextContent( 'This category already exists.' );
-		// The long parent-aware core message is not shown to the user.
-		expect( alert ).not.toHaveTextContent( 'already exists with this parent' );
-		// Nothing was selected, and the form stays open for a retry.
-		expect( onChange ).not.toHaveBeenCalled();
-		expect( screen.getByLabelText( 'New category name' ) ).toBeInTheDocument();
-	} );
-
-	it( 'surfaces the friendly duplicate error for the WordPress.com Simple-site error shape', async () => {
-		// WordPress.com's `/rest/v1.1` terms/new endpoint rejects duplicates with
-		// `error: 'duplicate'`, not the self-hosted WP REST `code: 'term_exists'`.
-		mockedCreateCategory.mockRejectedValue(
-			Object.assign( new Error( 'A taxonomy with that name already exists' ), {
-				error: 'duplicate',
-			} )
-		);
-		const { onChange } = renderSection();
-		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
-
-		clickButton( 'Add new category' );
-		typeInto( 'New category name', 'News' );
-		clickButton( 'Add category' );
-
-		const alert = await screen.findByRole( 'alert' );
-		expect( alert ).toHaveTextContent( 'This category already exists.' );
-		// The raw server message is not shown to the user.
-		expect( alert ).not.toHaveTextContent( 'A taxonomy with that name already exists' );
-		// Nothing was selected, and the form stays open for a retry.
-		expect( onChange ).not.toHaveBeenCalled();
-		expect( screen.getByLabelText( 'New category name' ) ).toBeInTheDocument();
-	} );
-
-	it( 'surfaces the friendly duplicate error for the WordPress.com proxy envelope shape', async () => {
-		// On Simple sites the v1.1 endpoint can reject inside a proxy envelope where
-		// the top-level `code` is the HTTP status (409) and the real slug lives in
-		// `body.error`.
-		mockedCreateCategory.mockRejectedValue(
-			Object.assign( new Error( 'A taxonomy with that name already exists' ), {
-				code: 409,
-				body: { error: 'duplicate', message: 'A taxonomy with that name already exists' },
-			} )
-		);
-		const { onChange } = renderSection();
-		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
-
-		clickButton( 'Add new category' );
-		typeInto( 'New category name', 'News' );
-		clickButton( 'Add category' );
-
-		const alert = await screen.findByRole( 'alert' );
-		expect( alert ).toHaveTextContent( 'This category already exists.' );
-		// The raw server message is not shown to the user.
-		expect( alert ).not.toHaveTextContent( 'A taxonomy with that name already exists' );
-		// Nothing was selected, and the form stays open for a retry.
-		expect( onChange ).not.toHaveBeenCalled();
-		expect( screen.getByLabelText( 'New category name' ) ).toBeInTheDocument();
 	} );
 
 	it( 'shows a generic message for non-duplicate errors and never leaks the raw server text', async () => {
@@ -502,34 +366,14 @@ describe( 'NewsletterCategoriesSection — inline add category (NL-785)', () => 
 				code: 'rest_cannot_create',
 			} )
 		);
-		const { onChange } = renderSection();
-		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
-
-		clickButton( 'Add new category' );
-		typeInto( 'New category name', 'Announcements' );
-		clickButton( 'Add category' );
-
-		const alert = await screen.findByRole( 'alert' );
-		expect( alert ).toHaveTextContent( 'Could not create the category. Please try again.' );
-		// The raw, English-only server message is not surfaced to the user.
-		expect( alert ).not.toHaveTextContent( 'not allowed to create terms' );
-		// Nothing was selected, and the form stays open for a retry.
-		expect( onChange ).not.toHaveBeenCalled();
-		expect( screen.getByLabelText( 'New category name' ) ).toBeInTheDocument();
-	} );
-
-	it( 'closes the inline form and clears input when cancelled', async () => {
 		renderSection();
 		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
 
-		clickButton( 'Add new category' );
-		typeInto( 'New category name', 'Discarded' );
-		clickButton( 'Cancel' );
+		typeSearch( 'Announcements' );
+		clickButton( 'Create “Announcements”' );
 
-		expect( screen.queryByLabelText( 'New category name' ) ).not.toBeInTheDocument();
-		expect( mockedCreateCategory ).not.toHaveBeenCalled();
-		// Reopening starts from an empty field, not the discarded value.
-		clickButton( 'Add new category' );
-		expect( screen.getByLabelText( 'New category name' ) ).toHaveValue( '' );
+		const alert = await screen.findByRole( 'alert' );
+		expect( alert ).toHaveTextContent( 'Could not create the category. Please try again.' );
+		expect( alert ).not.toHaveTextContent( 'not allowed to create terms' );
 	} );
 } );

--- a/projects/packages/newsletter/tests/newsletter-categories-section.test.tsx
+++ b/projects/packages/newsletter/tests/newsletter-categories-section.test.tsx
@@ -62,6 +62,7 @@ jest.mock( '@wordpress/components', () => ( {
 			</div>
 		);
 	},
+	Icon: () => null,
 } ) );
 
 interface StubField {
@@ -396,5 +397,23 @@ describe( 'NewsletterCategoriesSection — combined search + create (NL-785)', (
 		const alert = await screen.findByRole( 'alert' );
 		expect( alert ).toHaveTextContent( 'Could not create the category. Please try again.' );
 		expect( alert ).not.toHaveTextContent( 'not allowed to create terms' );
+	} );
+
+	it( 'clears the creation error once the user edits the name', async () => {
+		mockedCreateCategory.mockRejectedValue(
+			Object.assign( new Error( 'exists' ), { code: 'term_exists' } )
+		);
+		renderSection();
+		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
+
+		typeSearch( 'News Two' );
+		clickButton( 'Create “News Two”' );
+		await expect( screen.findByRole( 'alert' ) ).resolves.toHaveTextContent(
+			'This category already exists.'
+		);
+
+		// Editing the name dismisses the error.
+		typeSearch( 'News Three' );
+		await waitFor( () => expect( screen.queryByRole( 'alert' ) ).not.toBeInTheDocument() );
 	} );
 } );

--- a/projects/packages/newsletter/tests/newsletter-categories-section.test.tsx
+++ b/projects/packages/newsletter/tests/newsletter-categories-section.test.tsx
@@ -358,12 +358,12 @@ describe( 'NewsletterCategoriesSection — combined search + create (NL-785)', (
 		expect( mockedCreateCategory ).not.toHaveBeenCalled();
 	} );
 
-	it( 'surfaces the friendly duplicate message for the WordPress.com envelope shape', async () => {
+	it( 'surfaces the friendly duplicate message for a term_exists rejection', async () => {
 		mockedCreateCategory.mockRejectedValue(
-			Object.assign( new Error( 'A taxonomy with that name already exists' ), {
-				code: 409,
-				body: { error: 'duplicate' },
-			} )
+			Object.assign(
+				new Error( 'A term with the name provided already exists with this parent.' ),
+				{ code: 'term_exists' }
+			)
 		);
 		const { onChange } = renderSection();
 		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
@@ -373,7 +373,7 @@ describe( 'NewsletterCategoriesSection — combined search + create (NL-785)', (
 
 		const alert = await screen.findByRole( 'alert' );
 		expect( alert ).toHaveTextContent( 'This category already exists.' );
-		expect( alert ).not.toHaveTextContent( 'A taxonomy with that name already exists' );
+		expect( alert ).not.toHaveTextContent( 'already exists with this parent' );
 		// Nothing was recorded or selected.
 		expect( onChange ).not.toHaveBeenCalled();
 		expect( mockedRecordEvent ).not.toHaveBeenCalledWith(

--- a/projects/packages/newsletter/tests/newsletter-categories-section.test.tsx
+++ b/projects/packages/newsletter/tests/newsletter-categories-section.test.tsx
@@ -134,6 +134,7 @@ jest.mock( '../src/settings/api', () => ( {
 	createCategory: jest.fn(),
 } ) );
 
+import analytics from '@automattic/jetpack-analytics';
 import { act, render, screen, waitFor } from '@testing-library/react';
 // `mock`-prefixed so it may be referenced inside the hoisted jest.mock factories above.
 import { forwardRef as mockForwardRef } from 'react';
@@ -143,6 +144,9 @@ import type { NewsletterSettings } from '../src/settings/types';
 
 const mockedFetchCategories = fetchCategories as jest.MockedFunction< typeof fetchCategories >;
 const mockedCreateCategory = createCategory as jest.MockedFunction< typeof createCategory >;
+const mockedRecordEvent = analytics.tracks.recordEvent as jest.MockedFunction<
+	typeof analytics.tracks.recordEvent
+>;
 
 // The package intentionally doesn't pull in `@testing-library/user-event`
 // (mirrors the sibling shell tests), so drive interactions natively.
@@ -270,6 +274,41 @@ describe( 'NewsletterCategoriesSection — inline add category (NL-785)', () => 
 			expect( onChange ).toHaveBeenCalledWith( {
 				wpcom_newsletter_categories: [ '42' ],
 			} )
+		);
+	} );
+
+	it( 'records a tracking event when a category is created', async () => {
+		mockedCreateCategory.mockResolvedValue( { id: 42, name: 'Weekly Digest' } );
+		renderSection();
+		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
+
+		clickButton( 'Add new category' );
+		typeInto( 'New category name', 'Weekly Digest' );
+		clickButton( 'Add category' );
+
+		await waitFor( () =>
+			expect( mockedRecordEvent ).toHaveBeenCalledWith(
+				'jetpack_newsletter_category_created',
+				expect.objectContaining( { site_type: 'jetpack' } )
+			)
+		);
+	} );
+
+	it( 'does not record a creation event when the create request fails', async () => {
+		mockedCreateCategory.mockRejectedValue(
+			Object.assign( new Error( 'nope' ), { code: 'term_exists' } )
+		);
+		renderSection();
+		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
+
+		clickButton( 'Add new category' );
+		typeInto( 'New category name', 'News' );
+		clickButton( 'Add category' );
+
+		await expect( screen.findByRole( 'alert' ) ).resolves.toBeInTheDocument();
+		expect( mockedRecordEvent ).not.toHaveBeenCalledWith(
+			'jetpack_newsletter_category_created',
+			expect.anything()
 		);
 	} );
 
@@ -413,6 +452,32 @@ describe( 'NewsletterCategoriesSection — inline add category (NL-785)', () => 
 		mockedCreateCategory.mockRejectedValue(
 			Object.assign( new Error( 'A taxonomy with that name already exists' ), {
 				error: 'duplicate',
+			} )
+		);
+		const { onChange } = renderSection();
+		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
+
+		clickButton( 'Add new category' );
+		typeInto( 'New category name', 'News' );
+		clickButton( 'Add category' );
+
+		const alert = await screen.findByRole( 'alert' );
+		expect( alert ).toHaveTextContent( 'This category already exists.' );
+		// The raw server message is not shown to the user.
+		expect( alert ).not.toHaveTextContent( 'A taxonomy with that name already exists' );
+		// Nothing was selected, and the form stays open for a retry.
+		expect( onChange ).not.toHaveBeenCalled();
+		expect( screen.getByLabelText( 'New category name' ) ).toBeInTheDocument();
+	} );
+
+	it( 'surfaces the friendly duplicate error for the WordPress.com proxy envelope shape', async () => {
+		// On Simple sites the v1.1 endpoint can reject inside a proxy envelope where
+		// the top-level `code` is the HTTP status (409) and the real slug lives in
+		// `body.error`.
+		mockedCreateCategory.mockRejectedValue(
+			Object.assign( new Error( 'A taxonomy with that name already exists' ), {
+				code: 409,
+				body: { error: 'duplicate', message: 'A taxonomy with that name already exists' },
 			} )
 		);
 		const { onChange } = renderSection();

--- a/projects/packages/newsletter/tests/newsletter-categories-section.test.tsx
+++ b/projects/packages/newsletter/tests/newsletter-categories-section.test.tsx
@@ -23,6 +23,10 @@ interface TokenFieldProps {
 	onInputChange?: ( input: string ) => void;
 }
 
+// `mock`-prefixed so the jest.mock factory below may capture the field's latest
+// `onChange`, letting tests simulate a multi-token change (e.g. a paste).
+const mockTokenField: { onChange?: ( tokens: string[] ) => void } = {};
+
 jest.mock( '@wordpress/components', () => ( {
 	__esModule: true,
 	// Minimal FormTokenField: an input that drives `onInputChange`, the selected
@@ -36,6 +40,7 @@ jest.mock( '@wordpress/components', () => ( {
 		onChange,
 		onInputChange,
 	}: TokenFieldProps ) => {
+		mockTokenField.onChange = onChange;
 		const show = ( token: string ) => ( displayTransform ? displayTransform( token ) : token );
 		return (
 			<div>
@@ -356,6 +361,29 @@ describe( 'NewsletterCategoriesSection — combined search + create (NL-785)', (
 
 		expect( onChange ).toHaveBeenCalledWith( { wpcom_newsletter_categories: [ '1' ] } );
 		expect( mockedCreateCategory ).not.toHaveBeenCalled();
+	} );
+
+	it( 'creates every new name when a single change carries several (e.g. a paste)', async () => {
+		mockedCreateCategory.mockImplementation( ( name: string ) =>
+			Promise.resolve( { id: name === 'Alpha' ? 101 : 102, name } )
+		);
+		const { onChange } = renderSection();
+		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();
+
+		// Simulate FormTokenField delivering two new names in one change.
+		await act( async () => {
+			mockTokenField.onChange?.( [ 'Alpha', 'Beta' ] );
+		} );
+
+		await waitFor( () => expect( mockedCreateCategory ).toHaveBeenCalledTimes( 2 ) );
+		expect( mockedCreateCategory ).toHaveBeenCalledWith( 'Alpha' );
+		expect( mockedCreateCategory ).toHaveBeenCalledWith( 'Beta' );
+		// Both are created and selected — neither is dropped.
+		await waitFor( () =>
+			expect( onChange ).toHaveBeenCalledWith( {
+				wpcom_newsletter_categories: [ '101', '102' ],
+			} )
+		);
 	} );
 
 	it( 'surfaces the friendly duplicate message for a term_exists rejection', async () => {

--- a/projects/packages/newsletter/tests/newsletter-categories-section.test.tsx
+++ b/projects/packages/newsletter/tests/newsletter-categories-section.test.tsx
@@ -326,6 +326,27 @@ describe( 'NewsletterCategoriesSection — combined search + create (NL-785)', (
 		);
 	} );
 
+	it( 'preserves a selected category absent from the loaded list instead of re-creating it', async () => {
+		// "99" is selected but not returned by fetchCategories (deleted, or still
+		// loading), so it renders as its raw ID. Selecting another category must
+		// keep "99" as-is, not treat it as a new name to create.
+		mockedFetchCategories.mockResolvedValue( [
+			{ id: 1, name: 'News' },
+			{ id: 2, name: 'Sports' },
+		] );
+		const { onChange } = renderSection( {
+			wpcom_newsletter_categories: [ '1', '99' ],
+		} as Partial< NewsletterSettings > );
+		await expect( screen.findByRole( 'button', { name: 'Sports' } ) ).resolves.toBeInTheDocument();
+
+		clickButton( 'Sports' );
+
+		expect( mockedCreateCategory ).not.toHaveBeenCalled();
+		expect( onChange ).toHaveBeenCalledWith( {
+			wpcom_newsletter_categories: [ '1', '99', '2' ],
+		} );
+	} );
+
 	it( 'selects an existing category without creating anything', async () => {
 		const { onChange } = renderSection();
 		await expect( screen.findByText( 'News' ) ).resolves.toBeInTheDocument();


### PR DESCRIPTION
## Proposed changes

* Replace the "Add new category" wp-admin link in Newsletter settings with a create option in the existing categories field.
* The new category is created via REST and appears in the categories list without a page refresh.
* No go: creating or recognizing category hierarchies from Newsletter settings.

Before:

<img width="679" height="466" alt="Screenshot 2026-07-29 at 4 47 08 PM" src="https://github.com/user-attachments/assets/5023bf2b-d3f2-4b57-80e4-0a1e684c8fb0" />

After:

https://github.com/user-attachments/assets/1f8985d8-975d-4aa0-bc75-dbb6d6c3d7e7


## Implementation notes

* To get the combined *search-and-create* behavior, the categories field is now a custom DataViews `Edit` control built on the **public** `FormTokenField`, instead of DataViews' built-in `ArrayControl`.
* `ArrayControl` internally renders `@wordpress/components`' **private** `ValidatedFormTokenField`, which is where trunk's validation message ("Please select at least one category") gets its bright-red + triangle-icon styling for free. Private components are only unlockable by WP-core packages (via `@wordpress/private-apis`), so this package can't reuse it — the moment the field became create-capable, that built-in validation UI was gone.
* The validation message is therefore reconstructed on the public field: the `error` (triangle) icon the design system uses, and the `#cc1818` form-validation red. There is no wpds token at that brightness (the wpds error-foreground tokens are a much darker maroon), so the literal mirrors the `@wordpress/components` value to stay consistent with trunk and the rest of wp-admin.
* **Category creation uses `/wp/v2/categories` on every platform**, not the wpcom `/rest/v1.1/…/taxonomies/category/terms/new` endpoint the rest of `settings/api.ts` uses for reads. On WordPress.com Simple, `@wordpress/api-fetch` can't parse v1.1's wpcom-format error body (`{ error: 'duplicate' }` — it expects WP-REST's `{ code }`), so it collapses the failure to a generic `unknown_error` and the duplicate signal is lost before our handler runs. `/wp/v2/categories` is proxied on Simple and rejects with the standard `{ code: 'term_exists' }` that apiFetch parses natively, so one code path handles duplicates on Simple, Atomic, and self-hosted. (The `fetchCategories`/`fetchSettings` v1.1 split remains untouched, and it's legitimate: category *reads* paginate via the `X-WP-TotalPages` header, which the wpcom `http_envelope` nests inside the envelope so `apiFetch({ parse: false })` can't read it — hence reads use v1.1's body `found` count on Simple. Creation is a single POST with no pagination, so `/wp/v2/` is unaffected.)

## Related product discussion/links

* NL-785

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site with the Newsletter (Subscriptions) module active, go to **Jetpack → Newsletter → Settings**.
* Enable **newsletter categories**.
* In the categories field, type a new name and pick the **Create "…"** option (or press Enter): the category is created and selected, with no page reload.
* Type part of an existing category name: it shows as a suggestion to select (no Create row when the name already matches exactly).
* Duplicate guard: add a category in wp-admin that the page hasn't loaded yet, then type its name and pick Create — an inline "This category already exists." error shows.

