### PR TITLE
Stats Dashboard: declare wp-components as a stylesheet dependency

### DIFF
--- a/projects/packages/stats-admin/changelog/fix-odyssey-stats-enqueue-wp-components
+++ b/projects/packages/stats-admin/changelog/fix-odyssey-stats-enqueue-wp-components
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Stats Dashboard: explicitly enqueue core's `wp-components` style alongside the Odyssey Stats script, so the dashboard's own component styling (Button, Card, Modal, etc.) no longer implicitly depends on some other admin feature or plugin happening to have already loaded it.

--- a/projects/packages/stats-admin/changelog/fix-odyssey-stats-enqueue-wp-components
+++ b/projects/packages/stats-admin/changelog/fix-odyssey-stats-enqueue-wp-components
@@ -1,4 +1,4 @@
 Significance: minor
 Type: fixed
 
-Stats Dashboard: explicitly enqueue core's `wp-components` style alongside the Odyssey Stats script, so the dashboard's own component styling (Button, Card, Modal, etc.) no longer implicitly depends on some other admin feature or plugin happening to have already loaded it.
+Stats Dashboard: declare `wp-components` as a stylesheet dependency, so the dashboard's own component styling (Button, Card, Modal, etc.) no longer relies on another admin feature enqueuing it as a side effect, and is emitted in the correct cascade order.

--- a/projects/packages/stats-admin/src/class-odyssey-assets.php
+++ b/projects/packages/stats-admin/src/class-odyssey-assets.php
@@ -17,6 +17,15 @@ use Automattic\Jetpack\Assets;
 class Odyssey_Assets {
 	// This is a fixed list @see https://github.com/Automattic/wp-calypso/pull/71442/
 	const JS_DEPENDENCIES = array( 'lodash', 'react', 'react-dom', 'wp-api-fetch', 'wp-components', 'wp-compose', 'wp-element', 'wp-html-entities', 'wp-i18n', 'wp-is-shallow-equal', 'wp-polyfill', 'wp-primitives', 'wp-url', 'wp-warning', 'moment' );
+	/**
+	 * Odyssey's UI is built on @wordpress/components and runs against the page's own
+	 * `wp.components` (externalized, see JS_DEPENDENCIES above), so it needs that package's
+	 * matching stylesheet. Declare it rather than relying on some other admin feature loading it
+	 * as a side effect — WP 7.0's command palette happens to enqueue it globally today, but that's
+	 * an implementation detail of the palette, not a contract. Declaring it also fixes cascade
+	 * order: WP emits dependencies first, so Odyssey's own overrides of these classes reliably win.
+	 */
+	const CSS_DEPENDENCIES = array( 'wp-components' );
 	// Sometimes custom scripts would strip the `ver` query params, so we need to make sure it doesn't by adding a custom version param `osv` here.
 	const ODYSSEY_CDN_URL = 'https://widgets.wp.com/odyssey-stats/%s/%s?minify=false&osv=%s';
 
@@ -40,14 +49,6 @@ class Odyssey_Assets {
 			'enqueue_css'          => true,
 		);
 		$options         = wp_parse_args( $options, $default_options );
-
-		// Odyssey bundles its own copy of @wordpress/components' base CSS (scoped to its own
-		// elements via a `.is-odyssey-stats` marker, so it can't leak onto wp-admin's own
-		// instances of the same components). Explicitly enqueuing core's own `wp-components`
-		// style here guarantees Odyssey's Button/Card/Modal/etc. styling doesn't depend on some
-		// other plugin or admin feature happening to have already loaded it as a side effect.
-		wp_enqueue_style( 'wp-components' );
-
 		if ( file_exists( __DIR__ . "/../dist/{$asset_name}.js" ) ) {
 			// Load local assets for the convinience of development.
 			Assets::register_script(
@@ -55,8 +56,9 @@ class Odyssey_Assets {
 				"../dist/{$asset_name}.js",
 				__FILE__,
 				array(
-					'in_footer'  => true,
-					'textdomain' => 'jetpack-stats-admin',
+					'in_footer'        => true,
+					'textdomain'       => 'jetpack-stats-admin',
+					'css_dependencies' => self::CSS_DEPENDENCIES,
 				)
 			);
 			Assets::enqueue_script( $asset_handle );
@@ -78,7 +80,7 @@ class Odyssey_Assets {
 				wp_register_style(
 					$css_handle,
 					sprintf( self::ODYSSEY_CDN_URL, self::ODYSSEY_STATS_VERSION, $css_url, $this->get_cdn_asset_cache_buster() ),
-					array(),
+					self::CSS_DEPENDENCIES,
 					$this->get_cdn_asset_cache_buster()
 				);
 				wp_enqueue_style( $css_handle );

--- a/projects/packages/stats-admin/src/class-odyssey-assets.php
+++ b/projects/packages/stats-admin/src/class-odyssey-assets.php
@@ -40,6 +40,14 @@ class Odyssey_Assets {
 			'enqueue_css'          => true,
 		);
 		$options         = wp_parse_args( $options, $default_options );
+
+		// Odyssey bundles its own copy of @wordpress/components' base CSS (scoped to its own
+		// elements via a `.is-odyssey-stats` marker, so it can't leak onto wp-admin's own
+		// instances of the same components). Explicitly enqueuing core's own `wp-components`
+		// style here guarantees Odyssey's Button/Card/Modal/etc. styling doesn't depend on some
+		// other plugin or admin feature happening to have already loaded it as a side effect.
+		wp_enqueue_style( 'wp-components' );
+
 		if ( file_exists( __DIR__ . "/../dist/{$asset_name}.js" ) ) {
 			// Load local assets for the convinience of development.
 			Assets::register_script(

--- a/projects/packages/stats-admin/tests/php/Odyssey_Assets_Test.php
+++ b/projects/packages/stats-admin/tests/php/Odyssey_Assets_Test.php
@@ -16,17 +16,54 @@ class Odyssey_Assets_Test extends Stats_TestCase {
 	 * another admin feature (e.g. WP 7.0's command palette) enqueuing it as a side effect.
 	 * Asserted as a registered dependency, not just "is enqueued", because the dependency edge is
 	 * what also guarantees WP emits wp-components *before* Odyssey's own overrides of its classes.
+	 *
+	 * `load_admin_scripts()` takes one of two branches depending on `file_exists( dist/{asset_name}.js )`
+	 * -- real behaviour on a dev machine with a local build present, but also something that can
+	 * happen to be true or false in CI/local test runs depending on whatever's sitting in dist/,
+	 * independent of anything this test controls. Both branches are asserted explicitly below with
+	 * that condition forced, so the result doesn't depend on the filesystem state a test run
+	 * happens to find.
 	 */
-	public function test_odyssey_style_declares_wp_components_dependency() {
+	public function test_odyssey_style_declares_wp_components_dependency_cdn_branch() {
+		$this->reset_wp_styles();
 		wp_register_style( 'wp-components', false );
 		$this->assertFalse( wp_style_is( 'wp-components', 'enqueued' ) );
 
-		( new Odyssey_Assets() )->load_admin_scripts( 'jp-stats-dashboard', 'build.min' );
+		// An asset name with no dist/ file forces the CDN branch regardless of what's on disk.
+		( new Odyssey_Assets() )->load_admin_scripts( 'jp-stats-dashboard', 'nonexistent-test-build' );
 
-		$registered = wp_styles()->query( 'jp-stats-dashboard', 'registered' );
+		// The CDN branch registers the stylesheet under "{$asset_handle}-style", not $asset_handle
+		// itself -- that bare handle is reserved for the script.
+		$registered = wp_styles()->query( 'jp-stats-dashboard-style', 'registered' );
 		$this->assertNotFalse( $registered, 'Odyssey should register a stylesheet handle.' );
 		$this->assertContains( 'wp-components', $registered->deps );
 		$this->assertTrue( wp_style_is( 'wp-components', 'enqueued' ) );
+	}
+
+	public function test_odyssey_style_declares_wp_components_dependency_local_dist_branch() {
+		$this->reset_wp_styles();
+		wp_register_style( 'wp-components', false );
+		$this->assertFalse( wp_style_is( 'wp-components', 'enqueued' ) );
+
+		// Assets::register_script() only registers a stylesheet at all -- under $asset_handle, no
+		// suffix -- when both a JS and a matching CSS file exist in dist/, so both are needed to
+		// force this branch.
+		$dist_dir = __DIR__ . '/../../dist';
+		wp_mkdir_p( $dist_dir );
+		file_put_contents( "$dist_dir/local-test-build.js", '' );
+		file_put_contents( "$dist_dir/local-test-build.css", '' );
+
+		try {
+			( new Odyssey_Assets() )->load_admin_scripts( 'jp-stats-dashboard', 'local-test-build' );
+
+			$registered = wp_styles()->query( 'jp-stats-dashboard', 'registered' );
+			$this->assertNotFalse( $registered, 'Odyssey should register a stylesheet handle.' );
+			$this->assertContains( 'wp-components', $registered->deps );
+			$this->assertTrue( wp_style_is( 'wp-components', 'enqueued' ) );
+		} finally {
+			unlink( "$dist_dir/local-test-build.js" );
+			unlink( "$dist_dir/local-test-build.css" );
+		}
 	}
 
 	/**
@@ -135,5 +172,21 @@ class Odyssey_Assets_Test extends Stats_TestCase {
 		}
 
 		return $get_cdn_asset_cache_buster->invoke( $odyssey_assets );
+	}
+
+	/**
+	 * The style handles both tests above register/enqueue are process-global state (via
+	 * `$GLOBALS['wp_styles']`) that persists across tests within a run -- WorDBless resets
+	 * options/posts/users in TestCase::setUp(), but not this. Without clearing them, a handle left
+	 * registered or enqueued by one test is still there for the next one. Dequeuing/deregistering
+	 * the specific handles rather than replacing the whole `WP_Styles` object, since a fresh
+	 * `new \WP_Styles()` reruns its constructor's `wp_default_styles` hook, which needs more of the
+	 * request environment set up than this test bootstrap provides.
+	 */
+	protected function reset_wp_styles() {
+		foreach ( array( 'wp-components', 'jp-stats-dashboard', 'jp-stats-dashboard-style' ) as $handle ) {
+			wp_dequeue_style( $handle );
+			wp_deregister_style( $handle );
+		}
 	}
 }

--- a/projects/packages/stats-admin/tests/php/Odyssey_Assets_Test.php
+++ b/projects/packages/stats-admin/tests/php/Odyssey_Assets_Test.php
@@ -12,6 +12,20 @@ use WP_Error;
 class Odyssey_Assets_Test extends Stats_TestCase {
 
 	/**
+	 * load_admin_scripts() must guarantee core's `wp-components` style is enqueued, independent of
+	 * whatever else on the page might otherwise pull it in (some other plugin's own admin notice,
+	 * a WP admin feature, etc.) — Odyssey's own component styling shouldn't depend on that.
+	 */
+	public function test_load_admin_scripts_enqueues_wp_components_style() {
+		wp_register_style( 'wp-components', false );
+		$this->assertFalse( wp_style_is( 'wp-components', 'enqueued' ) );
+
+		( new Odyssey_Assets() )->load_admin_scripts( 'jp-stats-dashboard', 'build.min' );
+
+		$this->assertTrue( wp_style_is( 'wp-components', 'enqueued' ) );
+	}
+
+	/**
 	 * Test remote cache buster.
 	 */
 	public function test_get_cdn_asset_cache_buster() {

--- a/projects/packages/stats-admin/tests/php/Odyssey_Assets_Test.php
+++ b/projects/packages/stats-admin/tests/php/Odyssey_Assets_Test.php
@@ -12,16 +12,20 @@ use WP_Error;
 class Odyssey_Assets_Test extends Stats_TestCase {
 
 	/**
-	 * load_admin_scripts() must guarantee core's `wp-components` style is enqueued, independent of
-	 * whatever else on the page might otherwise pull it in (some other plugin's own admin notice,
-	 * a WP admin feature, etc.) — Odyssey's own component styling shouldn't depend on that.
+	 * Odyssey's stylesheet must declare `wp-components` as a dependency rather than relying on
+	 * another admin feature (e.g. WP 7.0's command palette) enqueuing it as a side effect.
+	 * Asserted as a registered dependency, not just "is enqueued", because the dependency edge is
+	 * what also guarantees WP emits wp-components *before* Odyssey's own overrides of its classes.
 	 */
-	public function test_load_admin_scripts_enqueues_wp_components_style() {
+	public function test_odyssey_style_declares_wp_components_dependency() {
 		wp_register_style( 'wp-components', false );
 		$this->assertFalse( wp_style_is( 'wp-components', 'enqueued' ) );
 
 		( new Odyssey_Assets() )->load_admin_scripts( 'jp-stats-dashboard', 'build.min' );
 
+		$registered = wp_styles()->query( 'jp-stats-dashboard', 'registered' );
+		$this->assertNotFalse( $registered, 'Odyssey should register a stylesheet handle.' );
+		$this->assertContains( 'wp-components', $registered->deps );
 		$this->assertTrue( wp_style_is( 'wp-components', 'enqueued' ) );
 	}
 

--- a/projects/packages/stats-admin/tests/php/Odyssey_Assets_Test.php
+++ b/projects/packages/stats-admin/tests/php/Odyssey_Assets_Test.php
@@ -12,21 +12,23 @@ use WP_Error;
 class Odyssey_Assets_Test extends Stats_TestCase {
 
 	/**
+	 * Returning the environment into its initial state.
+	 */
+	public function tearDown(): void {
+		$this->reset_wp_styles();
+		parent::tearDown();
+	}
+
+	/**
 	 * Odyssey's stylesheet must declare `wp-components` as a dependency rather than relying on
 	 * another admin feature (e.g. WP 7.0's command palette) enqueuing it as a side effect.
 	 * Asserted as a registered dependency, not just "is enqueued", because the dependency edge is
 	 * what also guarantees WP emits wp-components *before* Odyssey's own overrides of its classes.
 	 *
-	 * `load_admin_scripts()` also declares it on the local-dev branch (a real `dist/` build present
-	 * on disk), via the same `self::CSS_DEPENDENCIES` constant this test exercises through the CDN
-	 * branch -- that branch never runs in CI (no `dist/` in a fresh checkout) or in production
-	 * (Jetpack releases don't ship one either; only a developer's own local build creates it), and a
-	 * regression there would be immediately visible as unstyled components to whoever's building
-	 * locally, so it isn't separately integration-tested here. An earlier version of this test tried
-	 * to force that branch by writing stub files under the package's own `dist/`, but the real
-	 * package directory isn't reliably writable in every environment this suite runs in (CI's
-	 * checkout for this job doesn't allow it) -- coupling a test's pass/fail to that is a bad trade
-	 * for coverage of a path with this little production risk.
+	 * Only the CDN branch is exercised. The local-dev branch declares the same
+	 * `self::CSS_DEPENDENCIES` constant, but reaching it needs a `dist/` build that exists only on a
+	 * developer's own machine -- never in CI or in a release -- and a regression there surfaces
+	 * immediately as unstyled components.
 	 */
 	public function test_odyssey_style_declares_wp_components_dependency() {
 		$this->reset_wp_styles();
@@ -153,13 +155,12 @@ class Odyssey_Assets_Test extends Stats_TestCase {
 	}
 
 	/**
-	 * The style handles both tests above register/enqueue are process-global state (via
-	 * `$GLOBALS['wp_styles']`) that persists across tests within a run -- WorDBless resets
-	 * options/posts/users in TestCase::setUp(), but not this. Without clearing them, a handle left
-	 * registered or enqueued by one test is still there for the next one. Dequeuing/deregistering
-	 * the specific handles rather than replacing the whole `WP_Styles` object, since a fresh
-	 * `new \WP_Styles()` reruns its constructor's `wp_default_styles` hook, which needs more of the
-	 * request environment set up than this test bootstrap provides.
+	 * Style handles live in process-global state (`$GLOBALS['wp_styles']`) that persists across
+	 * tests within a run -- WorDBless resets options/posts/users in TestCase::setUp(), but not
+	 * this -- so they leak in both directions and this runs at both ends of the style test.
+	 * Dequeuing/deregistering the specific handles rather than replacing the whole `WP_Styles`
+	 * object, since a fresh `new \WP_Styles()` reruns its constructor's `wp_default_styles` hook,
+	 * which needs more of the request environment set up than this test bootstrap provides.
 	 */
 	protected function reset_wp_styles() {
 		foreach ( array( 'wp-components', 'jp-stats-dashboard', 'jp-stats-dashboard-style' ) as $handle ) {

--- a/projects/packages/stats-admin/tests/php/Odyssey_Assets_Test.php
+++ b/projects/packages/stats-admin/tests/php/Odyssey_Assets_Test.php
@@ -17,14 +17,18 @@ class Odyssey_Assets_Test extends Stats_TestCase {
 	 * Asserted as a registered dependency, not just "is enqueued", because the dependency edge is
 	 * what also guarantees WP emits wp-components *before* Odyssey's own overrides of its classes.
 	 *
-	 * `load_admin_scripts()` takes one of two branches depending on `file_exists( dist/{asset_name}.js )`
-	 * -- real behaviour on a dev machine with a local build present, but also something that can
-	 * happen to be true or false in CI/local test runs depending on whatever's sitting in dist/,
-	 * independent of anything this test controls. Both branches are asserted explicitly below with
-	 * that condition forced, so the result doesn't depend on the filesystem state a test run
-	 * happens to find.
+	 * `load_admin_scripts()` also declares it on the local-dev branch (a real `dist/` build present
+	 * on disk), via the same `self::CSS_DEPENDENCIES` constant this test exercises through the CDN
+	 * branch -- that branch never runs in CI (no `dist/` in a fresh checkout) or in production
+	 * (Jetpack releases don't ship one either; only a developer's own local build creates it), and a
+	 * regression there would be immediately visible as unstyled components to whoever's building
+	 * locally, so it isn't separately integration-tested here. An earlier version of this test tried
+	 * to force that branch by writing stub files under the package's own `dist/`, but the real
+	 * package directory isn't reliably writable in every environment this suite runs in (CI's
+	 * checkout for this job doesn't allow it) -- coupling a test's pass/fail to that is a bad trade
+	 * for coverage of a path with this little production risk.
 	 */
-	public function test_odyssey_style_declares_wp_components_dependency_cdn_branch() {
+	public function test_odyssey_style_declares_wp_components_dependency() {
 		$this->reset_wp_styles();
 		wp_register_style( 'wp-components', false );
 		$this->assertFalse( wp_style_is( 'wp-components', 'enqueued' ) );
@@ -38,32 +42,6 @@ class Odyssey_Assets_Test extends Stats_TestCase {
 		$this->assertNotFalse( $registered, 'Odyssey should register a stylesheet handle.' );
 		$this->assertContains( 'wp-components', $registered->deps );
 		$this->assertTrue( wp_style_is( 'wp-components', 'enqueued' ) );
-	}
-
-	public function test_odyssey_style_declares_wp_components_dependency_local_dist_branch() {
-		$this->reset_wp_styles();
-		wp_register_style( 'wp-components', false );
-		$this->assertFalse( wp_style_is( 'wp-components', 'enqueued' ) );
-
-		// Assets::register_script() only registers a stylesheet at all -- under $asset_handle, no
-		// suffix -- when both a JS and a matching CSS file exist in dist/, so both are needed to
-		// force this branch.
-		$dist_dir = __DIR__ . '/../../dist';
-		wp_mkdir_p( $dist_dir );
-		file_put_contents( "$dist_dir/local-test-build.js", '' );
-		file_put_contents( "$dist_dir/local-test-build.css", '' );
-
-		try {
-			( new Odyssey_Assets() )->load_admin_scripts( 'jp-stats-dashboard', 'local-test-build' );
-
-			$registered = wp_styles()->query( 'jp-stats-dashboard', 'registered' );
-			$this->assertNotFalse( $registered, 'Odyssey should register a stylesheet handle.' );
-			$this->assertContains( 'wp-components', $registered->deps );
-			$this->assertTrue( wp_style_is( 'wp-components', 'enqueued' ) );
-		} finally {
-			unlink( "$dist_dir/local-test-build.js" );
-			unlink( "$dist_dir/local-test-build.css" );
-		}
 	}
 
 	/**


### PR DESCRIPTION
## Why this matters

Site owners viewing Jetpack Stats get a dashboard whose buttons, cards and modals are styled by the Odyssey app itself, instead of by whatever styling another admin feature happened to load onto the page. Today the dashboard looks right only because WP 7.0's command palette enqueues `wp-components` globally — a coincidence that ~37% of installs (still below 7.0) don't benefit from, and that any future change to how the palette loads would quietly take away, leaving the dashboard unstyled.

## Proposed changes

* Declare `wp-components` as a dependency of Odyssey Stats' stylesheet, on both asset paths — `css_dependencies` for the local-dist path, the `$deps` argument of `wp_register_style()` for the CDN path.

## Related product discussion/links

* Companion to Automattic/wp-calypso#113038.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Odyssey's UI is built on `@wordpress/components` and runs against the page's own `wp.components` — already externalized, see `JS_DEPENDENCIES` — so it needs that package's matching stylesheet. Today it never asks for it. It renders correctly anyway because WP 7.0 core enqueues `wp-components` globally in wp-admin for the command palette, but that's an implementation detail of the palette rather than a contract: if a future release makes the palette lazy-loaded, gates it behind a preference, or moves it to a script module, Odyssey would silently lose its component styling. ~37% of WordPress installs are also still below 7.0.

Declaring the dependency also fixes cascade order. WP emits dependencies before their dependents, so Odyssey's own overrides of these classes (`.stats-feedback-modal.components-modal__frame`, `.components-modal__frame.stats-upsell-modal`) now reliably come after the base styles instead of relying on enqueue order.

* Load `wp-admin/admin.php?page=stats` on a Jetpack-connected site.
* Confirm `wp-components-css` is present, and that it appears **before** Odyssey's own stylesheet in the document. Note the handle differs by asset path — a connected site loads from the CDN and registers `jp-stats-dashboard-style` (element id `jp-stats-dashboard-style-css`), while a local `dist/` build registers the bare `jp-stats-dashboard`. This snippet covers either:
  ```js
  const l = [...document.querySelectorAll('link[rel=stylesheet]')].map(x => x.id);
  const odyssey = l.find(id => id.startsWith('jp-stats-dashboard'));
  l.indexOf('wp-components-css') < l.indexOf(odyssey); // true
  ```
* Confirm the dashboard's components (Buttons, Cards, and the URL Builder / upsell / feedback modals) render correctly.
* Unit test: `test_odyssey_style_declares_wp_components_dependency` asserts the registered dependency edge rather than mere enqueued-ness. Verified as a real regression guard by mutation — reverting the `$deps` argument to `array()` fails exactly this test.
