### PR TITLE
SEO: polish the Settings tab — chips, statuses, title previews, and clearer copy

### DIFF
--- a/projects/packages/seo/_inc/components/card-title-icon.module.scss
+++ b/projects/packages/seo/_inc/components/card-title-icon.module.scss
@@ -1,0 +1,25 @@
+// A card title led by an accent icon in a small tinted "chip" badge, the
+// placement Jetpack's other cards use. Matches the Overview cards' chip so the
+// Settings modules and Overview cards read as one family.
+.cardTitle {
+	display: inline-flex;
+	align-items: center;
+	// `sm` (8px) matches the icon-to-label spacing used elsewhere in these cards,
+	// rather than the tighter `xs`.
+	gap: var(--wpds-dimension-gap-sm);
+}
+
+// A 24px icon (the @wordpress/ui default) in a `size-md` (32px) chip — both
+// from the WPDS size scale, so the glyph fills the badge instead of floating
+// in an oversized circle.
+.titleIcon {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	flex: none;
+	inline-size: var(--wpds-dimension-size-md);
+	block-size: var(--wpds-dimension-size-md);
+	border-radius: 50%;
+	color: var(--wpds-color-foreground-interactive-brand);
+	background: var(--wpds-color-background-surface-brand);
+}

--- a/projects/packages/seo/_inc/components/card-title-icon.tsx
+++ b/projects/packages/seo/_inc/components/card-title-icon.tsx
@@ -1,0 +1,34 @@
+import { Icon } from '@wordpress/ui';
+import styles from './card-title-icon.module.scss';
+import type { ComponentProps, FC } from 'react';
+
+interface Props {
+	// The `@wordpress/icons` glyph shown in the leading chip.
+	icon: ComponentProps< typeof Icon >[ 'icon' ];
+	title: string;
+}
+
+/**
+ * A card title led by an `@wordpress/icons` glyph in a small tinted chip.
+ *
+ * Renders only the inner title span (chip + text), so it drops into any existing
+ * `Card.Title` — the collapsible Settings modules wrap their title in a header
+ * `Stack` alongside a status indicator, unlike the Overview cards' plain `Card.Header`.
+ * Sharing the chip here keeps the Settings modules and Overview cards visually
+ * one family from a single source.
+ *
+ * @param props       - Component props.
+ * @param props.icon  - The leading icon glyph.
+ * @param props.title - The card title text.
+ * @return The chip-led title span.
+ */
+const CardTitleIcon: FC< Props > = ( { icon, title } ) => (
+	<span className={ styles.cardTitle }>
+		<span className={ styles.titleIcon }>
+			<Icon icon={ icon } size={ 24 } />
+		</span>
+		{ title }
+	</span>
+);
+
+export default CardTitleIcon;

--- a/projects/packages/seo/_inc/components/status-indicator.module.scss
+++ b/projects/packages/seo/_inc/components/status-indicator.module.scss
@@ -1,0 +1,29 @@
+// A compact 3-state setting-completion indicator: a status label followed by
+// its icon, colored with the WPDS semantic status tokens. Shared across the
+// Settings modules so completion reads consistently.
+.status {
+	display: inline-flex;
+	align-items: center;
+	// Label first, icon second → the icon sits to the right of the text.
+	gap: var(--wpds-dimension-gap-xs);
+}
+
+// The color lives on the wrapper so both the label (color: inherit) and the
+// currentColor icon pick up the same status hue.
+.notStarted {
+	color: var(--wpds-color-foreground-content-neutral-weak);
+}
+
+.inProgress {
+	color: var(--wpds-color-foreground-content-warning-weak);
+}
+
+.complete {
+	color: var(--wpds-color-foreground-content-success-weak);
+}
+
+.label {
+	color: inherit;
+	font-weight: 600;
+	white-space: nowrap;
+}

--- a/projects/packages/seo/_inc/components/status-indicator.tsx
+++ b/projects/packages/seo/_inc/components/status-indicator.tsx
@@ -1,0 +1,63 @@
+import { __ } from '@wordpress/i18n';
+import { border, drafts, published, Icon } from '@wordpress/icons';
+import { Text } from '@wordpress/ui';
+import clsx from 'clsx';
+import styles from './status-indicator.module.scss';
+import type { ComponentProps, FC } from 'react';
+
+/**
+ * The three completion states a Settings module can be in.
+ */
+export type SettingStatus = 'not-started' | 'in-progress' | 'complete';
+
+// Label, glyph, and status-color class per state. Pre-resolved at module load
+// (not per render). Icons: `border` (empty), `drafts` (partial), `published`
+// (done) from the WordPress icon set — a natural "filling in" progression.
+const STATES: Record<
+	SettingStatus,
+	{ label: string; icon: ComponentProps< typeof Icon >[ 'icon' ]; className: string }
+> = {
+	'not-started': {
+		label: __( 'Not started', 'jetpack-seo' ),
+		icon: border,
+		className: styles.notStarted,
+	},
+	'in-progress': {
+		label: __( 'In progress', 'jetpack-seo' ),
+		icon: drafts,
+		className: styles.inProgress,
+	},
+	complete: {
+		label: __( 'Complete', 'jetpack-seo' ),
+		icon: published,
+		className: styles.complete,
+	},
+};
+
+interface Props {
+	status: SettingStatus;
+}
+
+/**
+ * A compact completion indicator for a Settings module: the status label followed
+ * by its icon (icon on the right), colored with the WPDS neutral / warning /
+ * success tokens. Presentational — the caller decides which state applies and how
+ * "complete" is defined for that module.
+ *
+ * @param props        - Component props.
+ * @param props.status - The module's completion state.
+ * @return The status indicator.
+ */
+const StatusIndicator: FC< Props > = ( { status } ) => {
+	const { label, icon, className } = STATES[ status ];
+	return (
+		<span className={ clsx( styles.status, className ) }>
+			<Text variant="body-sm" className={ styles.label }>
+				{ label }
+			</Text>
+			<Icon icon={ icon } size={ 20 } />
+		</span>
+	);
+};
+
+export default StatusIndicator;

--- a/projects/packages/seo/_inc/components/test/card-title-icon.test.tsx
+++ b/projects/packages/seo/_inc/components/test/card-title-icon.test.tsx
@@ -1,0 +1,19 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import { code } from '@wordpress/icons';
+
+// `--experimental-vm-modules` (true ESM): import the component under test
+// dynamically, mirroring the other component tests. No mocks are needed — this
+// is a purely presentational chip.
+const { default: CardTitleIcon } = await import( '../card-title-icon' );
+
+describe( 'CardTitleIcon', () => {
+	it( 'renders the title alongside a leading icon chip', () => {
+		const { container } = render( <CardTitleIcon icon={ code } title="Schema" /> );
+
+		expect( screen.getByText( 'Schema' ) ).toBeInTheDocument();
+		// The chip glyph is a decorative SVG with no accessible role of its own.
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- asserting the decorative glyph rendered.
+		expect( container.querySelector( 'svg' ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/seo/_inc/components/test/status-indicator.test.tsx
+++ b/projects/packages/seo/_inc/components/test/status-indicator.test.tsx
@@ -1,0 +1,21 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+
+// `--experimental-vm-modules` (true ESM): import the component under test
+// dynamically, mirroring the other component tests. No mocks needed.
+const { default: StatusIndicator } = await import( '../status-indicator' );
+
+describe( 'StatusIndicator', () => {
+	it.each( [
+		[ 'not-started', 'Not started' ],
+		[ 'in-progress', 'In progress' ],
+		[ 'complete', 'Complete' ],
+	] as const )( 'renders the %s state with a label and icon', ( status, label ) => {
+		const { container } = render( <StatusIndicator status={ status } /> );
+
+		expect( screen.getByText( label ) ).toBeInTheDocument();
+		// The state glyph is a decorative SVG with no accessible role of its own.
+		// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- asserting the glyph rendered.
+		expect( container.querySelector( 'svg' ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/seo/_inc/data/settings-types.ts
+++ b/projects/packages/seo/_inc/data/settings-types.ts
@@ -17,6 +17,10 @@ export interface SettingsResponse {
 	// when otherwise plan-gated (the value stays live). Read-only, never sent back.
 	has_legacy_front_page_meta: boolean;
 	title_formats: Record< string, TitleFormatToken[] >;
+	// Separator WordPress joins document-title parts with (`document_title_separator`,
+	// default `-`). Used to preview the default title of a page type that has no
+	// stored format. Read-only, never sent back.
+	title_separator: string;
 	verification: {
 		google: string;
 		bing: string;

--- a/projects/packages/seo/_inc/data/test/build-payload.test.ts
+++ b/projects/packages/seo/_inc/data/test/build-payload.test.ts
@@ -9,6 +9,7 @@ const makeSettings = ( overrides: Partial< SettingsResponse > = {} ): SettingsRe
 	front_page_description: '',
 	has_legacy_front_page_meta: false,
 	title_formats: { posts: [ { type: 'token', value: 'site_name' } ] },
+	title_separator: '-',
 	verification: { google: '', bing: '', pinterest: '', yandex: '', facebook: '' },
 	search_engines_visible: true,
 	sitemap_active: false,

--- a/projects/packages/seo/_inc/data/test/fixtures/store-fixtures.ts
+++ b/projects/packages/seo/_inc/data/test/fixtures/store-fixtures.ts
@@ -27,6 +27,7 @@ export const SEEDED_SETTINGS: SettingsResponse = {
 	front_page_description: 'Welcome to the site.',
 	has_legacy_front_page_meta: false,
 	title_formats: {},
+	title_separator: '-',
 	verification: { google: '', bing: '', pinterest: '', yandex: '', facebook: '' },
 	search_engines_visible: true,
 	sitemap_active: false,

--- a/projects/packages/seo/_inc/data/test/title-format-tokens.test.ts
+++ b/projects/packages/seo/_inc/data/test/title-format-tokens.test.ts
@@ -5,6 +5,7 @@ import {
 	PAGE_TYPES,
 	PAGE_TYPE_SUGGESTIONS,
 	PAGE_TYPE_TOKENS,
+	buildDefaultPreview,
 	buildPreview,
 	fromDisplay,
 	stringToTokens,
@@ -112,6 +113,52 @@ describe( 'page-type token maps', () => {
 	} );
 } );
 
+// Mirrors how `wp_get_document_title()` composes a title when Jetpack has no
+// stored format for the page type and steps aside.
+describe( 'buildDefaultPreview', () => {
+	const overrides = { site_name: 'Acme Co', tagline: 'We make things' };
+
+	it( 'pairs the site title with the tagline on the front page', () => {
+		expect( buildDefaultPreview( 'front_page', '-', overrides ) ).toBe(
+			'Acme Co - We make things'
+		);
+	} );
+
+	it( 'pairs the page-specific title with the site title everywhere else', () => {
+		expect( buildDefaultPreview( 'posts', '-', overrides ) ).toBe( 'Hello World - Acme Co' );
+		expect( buildDefaultPreview( 'pages', '-', overrides ) ).toBe( 'Sample Page - Acme Co' );
+		expect( buildDefaultPreview( 'groups', '-', overrides ) ).toBe( 'News - Acme Co' );
+		expect( buildDefaultPreview( 'archives', '-', overrides ) ).toBe( 'Sample Archive - Acme Co' );
+	} );
+
+	it( 'uses the separator the site reports, since themes override it', () => {
+		expect( buildDefaultPreview( 'posts', '|', overrides ) ).toBe( 'Hello World | Acme Co' );
+		expect( buildDefaultPreview( 'posts', '–', overrides ) ).toBe( 'Hello World – Acme Co' );
+	} );
+
+	// Core runs `array_filter()` over the parts, so a missing one drops out rather
+	// than leaving a dangling separator.
+	it( 'omits an empty part instead of leaving a trailing separator', () => {
+		expect( buildDefaultPreview( 'front_page', '-', { site_name: 'Acme Co', tagline: '' } ) ).toBe(
+			'Acme Co'
+		);
+	} );
+
+	it( 'falls back to sample text when no real values are supplied', () => {
+		expect( buildDefaultPreview( 'posts', '-' ) ).toBe( 'Hello World - Your site' );
+	} );
+
+	it( 'returns an empty string for an unknown page type', () => {
+		expect( buildDefaultPreview( 'nonsense', '-', overrides ) ).toBe( '' );
+	} );
+
+	it( 'covers every page type the UI renders a row for', () => {
+		PAGE_TYPES.forEach( ( { id } ) => {
+			expect( buildDefaultPreview( id, '-', overrides ) ).not.toBe( '' );
+		} );
+	} );
+} );
+
 describe( 'buildPreview', () => {
 	it( 'swaps placeholders for sample text and passes literal fragments through', () => {
 		const tokens: TitleFormatToken[] = [
@@ -141,15 +188,24 @@ describe( 'buildPreview', () => {
 		);
 	} );
 
-	it( 'falls back to sample text when an override is missing or empty', () => {
-		const tokens: TitleFormatToken[] = [
-			{ type: 'token', value: 'site_name' },
-			{ type: 'string', value: ' | ' },
-			{ type: 'token', value: 'tagline' },
-		];
-		// site_name has a real value; tagline is empty, so it uses the sample.
-		expect( buildPreview( tokens, { site_name: 'Acme Co', tagline: '' } ) ).toBe(
+	const siteNameAndTagline: TitleFormatToken[] = [
+		{ type: 'token', value: 'site_name' },
+		{ type: 'string', value: ' | ' },
+		{ type: 'token', value: 'tagline' },
+	];
+
+	it( 'falls back to sample text when the site supplies no override at all', () => {
+		expect( buildPreview( siteNameAndTagline, { site_name: 'Acme Co' } ) ).toBe(
 			'Acme Co | Your tagline'
+		);
+	} );
+
+	// A site with no tagline really does render nothing there, and
+	// `Jetpack_SEO_Titles::get_custom_title()` concatenates the format straight
+	// through — so the separator is left dangling exactly as previewed.
+	it( 'renders a supplied-but-empty override as empty, keeping the separator', () => {
+		expect( buildPreview( siteNameAndTagline, { site_name: 'Acme Co', tagline: '' } ) ).toBe(
+			'Acme Co | '
 		);
 	} );
 } );

--- a/projects/packages/seo/_inc/data/test/use-settings.test.ts
+++ b/projects/packages/seo/_inc/data/test/use-settings.test.ts
@@ -16,6 +16,7 @@ const SEED: SettingsResponse = {
 	front_page_description: 'Old description.',
 	has_legacy_front_page_meta: false,
 	title_formats: { posts: [ { type: 'token', value: 'site_name' } ] },
+	title_separator: '-',
 	verification: { google: '', bing: '', pinterest: '', yandex: '', facebook: '' },
 	search_engines_visible: true,
 	sitemap_active: false,

--- a/projects/packages/seo/_inc/data/title-format-tokens.ts
+++ b/projects/packages/seo/_inc/data/title-format-tokens.ts
@@ -133,13 +133,19 @@ export const fromDisplay = ( display: string, allowedTokenIds?: string[] ): Titl
 
 /**
  * Render an ordered token list into a human-readable preview string. A placeholder
- * is swapped for its real value from `overrides` when one is supplied and non-empty
- * (e.g. the site's actual name/tagline), otherwise for representative sample text;
- * literal fragments pass through unchanged.
+ * is swapped for its real value from `overrides` when the site supplies one — even
+ * an empty one, since a site with no tagline genuinely renders nothing there — and
+ * for representative sample text when the site has no say (a post title varies per
+ * page). Literal fragments pass through unchanged.
+ *
+ * Nothing is dropped: `Jetpack_SEO_Titles::get_custom_title()` concatenates the
+ * format straight through, so an empty token leaves the surrounding separators
+ * dangling exactly as previewed here. That differs from
+ * {@link buildDefaultPreview}, where core filters empty parts out first.
  *
  * @param tokens    - The ordered token list.
- * @param overrides - Real values keyed by token id; an absent or empty value falls
- *                  back to the token's sample text.
+ * @param overrides - Real values keyed by token id. A key that is present but empty
+ *                  renders as empty; a key that is absent falls back to sample text.
  * @return The preview string.
  */
 export const buildPreview = (
@@ -147,12 +153,70 @@ export const buildPreview = (
 	overrides: Partial< Record< string, string > > = {}
 ): string =>
 	tokens
-		.map( token =>
-			token.type === 'string'
-				? token.value
-				: overrides[ token.value ] || TOKEN_PREVIEW_SAMPLES[ token.value ] || token.value
-		)
+		.map( token => {
+			if ( token.type === 'string' ) {
+				return token.value;
+			}
+			if ( token.value in overrides ) {
+				return overrides[ token.value ] ?? '';
+			}
+			return TOKEN_PREVIEW_SAMPLES[ token.value ] || token.value;
+		} )
 		.join( '' );
+
+// The token pair WordPress joins to build each page type's default title, in
+// order. A page type with no stored format keeps that default —
+// `Jetpack_SEO_Titles::get_custom_title()` is filtered onto `pre_get_document_title`
+// and returns the incoming value untouched, so `wp_get_document_title()` composes
+// the title itself. It uses the site title plus the tagline on the front page, and
+// the page's own title plus the site title everywhere else.
+const DEFAULT_TITLE_PARTS: Record< string, [ string, string ] > = {
+	front_page: [ 'site_name', 'tagline' ],
+	posts: [ 'post_title', 'site_name' ],
+	pages: [ 'page_title', 'site_name' ],
+	groups: [ 'group_title', 'site_name' ],
+	archives: [ 'archive_title', 'site_name' ],
+};
+
+/**
+ * Preview the title WordPress produces for a page type that has no stored format,
+ * replaying core's own composition: two parts joined by the site's document-title
+ * separator. Uses the same real values and sample text as {@link buildPreview}, so
+ * a defaulted row reads consistently beside a customized one.
+ *
+ * A theme can rewrite the parts through `document_title_parts`, which this can't
+ * account for — those filters usually test the query (`is_singular()` and friends),
+ * which has no meaning here. The separator is read from the site, since that is the
+ * piece themes routinely override.
+ *
+ * @param pageTypeId - The page type (`posts`, `pages`, …).
+ * @param separator  - The site's document-title separator.
+ * @param overrides  - Real values keyed by token id, as for `buildPreview`.
+ * @return The default title preview, or an empty string for an unknown page type.
+ */
+export const buildDefaultPreview = (
+	pageTypeId: string,
+	separator: string,
+	overrides: Partial< Record< string, string > > = {}
+): string => {
+	const parts = DEFAULT_TITLE_PARTS[ pageTypeId ];
+	if ( ! parts ) {
+		return '';
+	}
+	return (
+		parts
+			// Unlike `buildPreview`, a supplied-but-empty override means the part is
+			// genuinely absent, not unknown — so it is dropped rather than replaced with
+			// sample text. This preview claims to be the title WordPress produces, and a
+			// site with no tagline really does get just its name; showing "Your tagline"
+			// there would promise something the site doesn't have. Core does the same,
+			// running `array_filter()` over the parts before joining. Sample text still
+			// stands in for tokens with no override at all, such as the post title.
+			.map( token => ( token in overrides ? overrides[ token ] : TOKEN_PREVIEW_SAMPLES[ token ] ) )
+			.filter( Boolean )
+			.join( ` ${ separator } ` )
+	);
+};
 
 /**
  * Render an ordered token list into the single editable string shown in the

--- a/projects/packages/seo/_inc/data/title-format-tokens.ts
+++ b/projects/packages/seo/_inc/data/title-format-tokens.ts
@@ -184,10 +184,15 @@ const DEFAULT_TITLE_PARTS: Record< string, [ string, string ] > = {
  * separator. Uses the same real values and sample text as {@link buildPreview}, so
  * a defaulted row reads consistently beside a customized one.
  *
- * A theme can rewrite the parts through `document_title_parts`, which this can't
- * account for — those filters usually test the query (`is_singular()` and friends),
- * which has no meaning here. The separator is read from the site, since that is the
- * piece themes routinely override.
+ * The separator comes from the site already rendered — core texturizes the composed
+ * default title, so its `-` reaches a visitor as an en dash (see
+ * `Dashboard_Data::get_default_title_separator()`). That is why this differs from
+ * {@link buildPreview}, whose separators are literal text the user typed: a stored
+ * format short-circuits `pre_get_document_title` before the filter that texturizes.
+ *
+ * A theme can also rewrite the parts through `document_title_parts`, which this
+ * can't account for — those filters usually test the query (`is_singular()` and
+ * friends), which has no meaning here.
  *
  * @param pageTypeId - The page type (`posts`, `pages`, …).
  * @param separator  - The site's document-title separator.

--- a/projects/packages/seo/_inc/data/use-google-verify.ts
+++ b/projects/packages/seo/_inc/data/use-google-verify.ts
@@ -55,7 +55,7 @@ export interface GoogleVerify {
  * @param options             - Hook options.
  * @param options.onCodeSaved - Called with the verification code once auto-verify
  *                            persists it, so the consumer can mirror it into form
- *                            state (e.g. to keep a "configured" badge in sync).
+ *                            state (e.g. to keep the completion status in sync).
  * @return The Google-verification controller.
  */
 export function useGoogleVerify( {
@@ -168,7 +168,7 @@ export function useGoogleVerify( {
 				.then( () => {
 					// The code is now persisted to `verification_services_codes.google`;
 					// mirror it into the consumer's form state so the verification card's
-					// "configured" badge updates without a reload.
+					// completion status updates without a reload.
 					onCodeSaved?.( savedToken );
 					return apiFetch( {
 						path: ENDPOINT,

--- a/projects/packages/seo/_inc/screens/overview/card-header-icon.tsx
+++ b/projects/packages/seo/_inc/screens/overview/card-header-icon.tsx
@@ -1,10 +1,11 @@
-import { Card, Icon } from '@wordpress/ui';
-import styles from './style.module.scss';
+import { Card } from '@wordpress/ui';
+import CardTitleIcon from '../../components/card-title-icon';
 import type { ComponentProps, FC } from 'react';
 
 interface Props {
-	// The `@wordpress/icons` glyph shown in the leading chip.
-	icon: ComponentProps< typeof Icon >[ 'icon' ];
+	// The `@wordpress/icons` glyph shown in the leading chip. Taken from the chip
+	// itself, so this wrapper can't accept something the chip won't render.
+	icon: ComponentProps< typeof CardTitleIcon >[ 'icon' ];
 	title: string;
 }
 
@@ -13,6 +14,10 @@ interface Props {
  * tinted chip. Shared by the four Overview cards so the chip markup and icon
  * size live in one place rather than being repeated (and drifting) per card.
  *
+ * The chip itself comes from the shared `CardTitleIcon`, which the Settings
+ * modules also use; this wrapper only adds the `Card.Header`/`Card.Title` shell
+ * that the Overview cards need and the Settings modules supply themselves.
+ *
  * @param props       - Component props.
  * @param props.icon  - The leading icon glyph.
  * @param props.title - The card title text.
@@ -20,13 +25,12 @@ interface Props {
  */
 const CardHeaderIcon: FC< Props > = ( { icon, title } ) => (
 	<Card.Header>
-		<Card.Title>
-			<span className={ styles.cardTitle }>
-				<span className={ styles.titleIcon }>
-					<Icon icon={ icon } size={ 24 } />
-				</span>
-				{ title }
-			</span>
+		{ /* `Card.Title` renders a div by default. These cards sit directly under the
+		     page's h1, so they are its second-level headings — without this the
+		     Overview has no heading structure to navigate at all. The Settings
+		     modules do the same, on their collapsible header. */ }
+		<Card.Title render={ <h2 /> }>
+			<CardTitleIcon icon={ icon } title={ title } />
 		</Card.Title>
 	</Card.Header>
 );

--- a/projects/packages/seo/_inc/screens/overview/style.module.scss
+++ b/projects/packages/seo/_inc/screens/overview/style.module.scss
@@ -60,30 +60,8 @@
 	color: var(--wpds-color-foreground-content-neutral-weak);
 }
 
-// Card title with a leading accent icon, presented as a small tinted "chip"
-// badge before the title text (the placement Jetpack's other cards use).
-.cardTitle {
-	display: inline-flex;
-	align-items: center;
-	// `sm` (8px) matches the icon-to-label spacing used by StatusDot in these
-	// same cards, rather than the tighter `xs`.
-	gap: var(--wpds-dimension-gap-sm);
-}
-
-// A 24px icon (the @wordpress/ui default) in a `size-md` (32px) chip — both
-// from the WPDS size scale, so the glyph fills the badge instead of floating
-// in an oversized circle.
-.titleIcon {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	flex: none;
-	inline-size: var(--wpds-dimension-size-md);
-	block-size: var(--wpds-dimension-size-md);
-	border-radius: 50%;
-	color: var(--wpds-color-foreground-interactive-brand);
-	background: var(--wpds-color-background-surface-brand);
-}
+// The card-title chip (`.cardTitle` / `.titleIcon`) lives in the shared
+// `components/card-title-icon.module.scss`, which the Settings modules use too.
 
 // Interactive coverage ring: the whole ring is a button that deep-links to the
 // Content tab filtered to the rows still missing this field. Reset the native

--- a/projects/packages/seo/_inc/screens/settings/author-profile-card.tsx
+++ b/projects/packages/seo/_inc/screens/settings/author-profile-card.tsx
@@ -1,9 +1,11 @@
-import { __, sprintf } from '@wordpress/i18n';
-import { Badge, Card, CollapsibleCard, Stack } from '@wordpress/ui';
+import { __ } from '@wordpress/i18n';
+import { commentAuthorAvatar } from '@wordpress/icons';
+import { Card, CollapsibleCard, Stack } from '@wordpress/ui';
+import CardTitleIcon from '../../components/card-title-icon';
+import StatusIndicator from '../../components/status-indicator';
 import { useAuthorProfile } from '../../data/use-author-profile';
 import AuthorProfileSection from './schema-settings/author-profile-section';
-
-const notSetLabel = __( 'Not set', 'jetpack-seo' );
+import type { SettingStatus } from '../../components/status-indicator';
 
 /**
  * Per-user Author profile settings card.
@@ -24,8 +26,9 @@ function AuthorProfileCard() {
 	const form = useAuthorProfile();
 	const { profile, isLoading, hasLoadError } = form;
 
-	// Fields the header badge counts as "set": the optional ones an author fills
-	// in (name and avatar are always present). Hidden until the profile loads.
+	// Fields the header status counts as "set": the optional ones an author fills
+	// in (name and avatar are always present, so they'd never discriminate).
+	// Hidden until the profile loads.
 	const fieldsSet = [
 		profile.description,
 		profile.url,
@@ -34,22 +37,27 @@ function AuthorProfileCard() {
 	];
 	const setCount = fieldsSet.filter( Boolean ).length;
 
+	let profileStatus: SettingStatus = 'not-started';
+	if ( setCount === fieldsSet.length ) {
+		profileStatus = 'complete';
+	} else if ( setCount > 0 ) {
+		profileStatus = 'in-progress';
+	}
+
 	return (
 		<CollapsibleCard.Root defaultOpen={ false }>
-			<CollapsibleCard.Header>
+			<CollapsibleCard.Header render={ <h2 /> }>
 				<Stack direction="row" justify="space-between" align="center" gap="sm">
-					<Card.Title>{ __( 'Author profile', 'jetpack-seo' ) }</Card.Title>
+					<Card.Title>
+						<CardTitleIcon
+							icon={ commentAuthorAvatar }
+							title={ __( 'Author profile', 'jetpack-seo' ) }
+						/>
+					</Card.Title>
 					{ ! isLoading && ! hasLoadError && (
-						<Badge intent={ setCount === fieldsSet.length ? 'stable' : 'draft' }>
-							{ setCount > 0
-								? sprintf(
-										/* translators: %1$d: number of filled author profile fields. %2$d: total number of fields. */
-										__( '%1$d of %2$d set', 'jetpack-seo' ),
-										setCount,
-										fieldsSet.length
-								  )
-								: notSetLabel }
-						</Badge>
+						<CollapsibleCard.HeaderDescription>
+							<StatusIndicator status={ profileStatus } />
+						</CollapsibleCard.HeaderDescription>
 					) }
 				</Stack>
 			</CollapsibleCard.Header>

--- a/projects/packages/seo/_inc/screens/settings/google-verification-field.tsx
+++ b/projects/packages/seo/_inc/screens/settings/google-verification-field.tsx
@@ -16,8 +16,10 @@ interface Props {
 	disabled?: boolean;
 }
 
+// Matches the wording of the other services' hints in `verification-card`: both
+// a whole pasted meta tag and a bare code are accepted on save.
 const manualHelp = __(
-	'Paste the "content" attribute from the Google Search Console meta tag.',
+	'Paste the verification tag from Google Search Console, or just the code inside it.',
 	'jetpack-seo'
 );
 
@@ -35,7 +37,7 @@ const manualHelp = __(
  */
 const GoogleVerificationField: FC< Props > = ( { value, onChange, onCommit, disabled } ) => {
 	// `onCodeSaved` mirrors the auto-verified code into the form's local state so the
-	// card's "configured" badge stays in sync without a reload (the hook already
+	// card's completion status stays in sync without a reload (the hook already
 	// persisted it, so this only updates local state — no extra save).
 	const { state, isConnected, isOwner, searchConsoleUrl, isVerifying, autoVerify } =
 		useGoogleVerify( { onCodeSaved: onChange } );

--- a/projects/packages/seo/_inc/screens/settings/index.tsx
+++ b/projects/packages/seo/_inc/screens/settings/index.tsx
@@ -2,9 +2,12 @@
 
 import { TextareaControl, ToggleControl } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
+import { home, link, seen } from '@wordpress/icons';
 import { useSearch } from '@wordpress/route';
-import { Badge, Button, Card, CollapsibleCard, Link, Notice, Stack } from '@wordpress/ui';
+import { Button, Card, CollapsibleCard, Link, Notice, Stack, Text } from '@wordpress/ui';
+import CardTitleIcon from '../../components/card-title-icon';
+import StatusIndicator from '../../components/status-indicator';
 import UpsellBanner from '../../components/upsell-banner';
 import { isGated } from '../../data/is-gated';
 import AuthorProfileCard from './author-profile-card';
@@ -13,18 +16,17 @@ import SocialPreviewsCard from './social-previews-card';
 import styles from './style.module.scss';
 import TitleStructureField from './title-structure-field';
 import VerificationCard from './verification-card';
+import type { SettingStatus } from '../../components/status-indicator';
 import type { SettingsForm } from '../../data/use-settings';
 import type { FC } from 'react';
 
-// Pre-resolved so the production minifier can't fold adjacent ternary `__()`
-// calls (breaks i18n extraction). See feedback_i18n_ternary_minifier_fold.
-const setLabel = __( 'Set', 'jetpack-seo' );
-const notSetLabel = __( 'Not set', 'jetpack-seo' );
-const enabledLabel = __( 'Enabled', 'jetpack-seo' );
-const disabledLabel = __( 'Disabled', 'jetpack-seo' );
 const saveLabel = __( 'Save', 'jetpack-seo' );
+// The sitemap help swaps between these two, so both are pre-resolved: the
+// production minifier folds an adjacent `cond ? __(A) : __(B)` into
+// `__(cond ? A : B)`, which breaks i18n extraction. See
+// feedback_i18n_ternary_minifier_fold.
 const sitemapHelp = __(
-	"Publishes an XML sitemap that search engines crawl to discover your content, generated automatically from your site's published posts, pages, and custom post types.",
+	'Publishes a map of your posts and pages so search engines can find your content.',
 	'jetpack-seo'
 );
 // Shown when indexing is blocked: a sitemap can't be generated or served while
@@ -34,6 +36,19 @@ const sitemapBlockedHelp = __(
 	'jetpack-seo'
 );
 const sitemapViewLabel = __( 'View sitemap', 'jetpack-seo' );
+// Figures are what search *displays*, not a limit we enforce — the field is
+// deliberately uncapped. Google measures a pixel width (920px desktop / 680px
+// mobile), which works out around 155 and 120 characters.
+//
+// No social figure is quoted on purpose. `functions.opengraph.php` truncates
+// `og:description` at 197, but that happens *before* the `jetpack_open_graph_tags`
+// filter, and `Jetpack_SEO::set_custom_og_tags()` runs on that filter and
+// overwrites the value — so this field reaches social uncut, and each platform
+// truncates on display by its own rules.
+const frontPageHelp = __(
+	'Shown under your site name in search results and social shares. About the first 155 characters display in search, or 120 on mobile.',
+	'jetpack-seo'
+);
 
 interface Props {
 	form: SettingsForm;
@@ -108,6 +123,26 @@ const SettingsScreen: FC< Props > = ( { form } ) => {
 	const visibilityEnabledCount =
 		( local.search_engines_visible ? 1 : 0 ) + ( sitemapEffectivelyOn ? 1 : 0 );
 
+	// Module completion states for the card headers. Each module defines
+	// "complete" for itself (see JETPACK-2051); the indicator is presentational.
+	// Visibility counts its two toggles, the sitemap by its *effective* state
+	// since it can't run while indexing is blocked.
+	let visibilityStatus: SettingStatus = 'not-started';
+	if ( visibilityEnabledCount === 2 ) {
+		visibilityStatus = 'complete';
+	} else if ( visibilityEnabledCount > 0 ) {
+		visibilityStatus = 'in-progress';
+	}
+
+	// Count code points, not UTF-16 units, so an emoji or an astral character
+	// counts once rather than twice.
+	const descriptionLength = [ ...local.front_page_description ].length;
+
+	// Single toggles and single fields are binary — they have no partial state,
+	// so they move straight from not-started to complete.
+	const canonicalStatus: SettingStatus = local.canonical_active ? 'complete' : 'not-started';
+	const frontPageStatus: SettingStatus = local.front_page_description ? 'complete' : 'not-started';
+
 	// On plan-gated sites (below-Premium WordPress.com) the Settings tab keeps only
 	// the two always-valid sections (site visibility + verification, both backed by
 	// core WordPress options) topped with the upsell banner. Schema, author profile,
@@ -119,25 +154,44 @@ const SettingsScreen: FC< Props > = ( { form } ) => {
 
 	const frontPageDescriptionCard = (
 		<CollapsibleCard.Root defaultOpen={ false }>
-			<CollapsibleCard.Header>
+			<CollapsibleCard.Header render={ <h2 /> }>
 				<Stack direction="row" justify="space-between" align="center" gap="sm">
-					<Card.Title>{ __( 'Front-page description', 'jetpack-seo' ) }</Card.Title>
-					<Badge intent={ local.front_page_description ? 'stable' : 'draft' }>
-						{ local.front_page_description ? setLabel : notSetLabel }
-					</Badge>
+					<Card.Title>
+						<CardTitleIcon icon={ home } title={ __( 'Front-page description', 'jetpack-seo' ) } />
+					</Card.Title>
+					<CollapsibleCard.HeaderDescription>
+						<StatusIndicator status={ frontPageStatus } />
+					</CollapsibleCard.HeaderDescription>
 				</Stack>
 			</CollapsibleCard.Header>
 			<CollapsibleCard.Content>
 				<Stack direction="column" gap="md">
 					<TextareaControl
-						label={ __( 'Meta description shown on the home page', 'jetpack-seo' ) }
+						// Short label: the design system renders control labels as 11px
+						// all-caps, which a sentence-length label is unreadable in. The
+						// explanation belongs in `help`, which renders in sentence case.
+						// Named for the home page rather than just "Description", which
+						// would collide with the Organization/Person description field
+						// also on this tab and leave two controls indistinguishable to a
+						// screen reader.
+						label={ __( 'Home page description', 'jetpack-seo' ) }
+						help={ frontPageHelp }
 						value={ local.front_page_description }
 						onChange={ next => setField( { front_page_description: next } ) }
 						rows={ 3 }
 						disabled={ isSaving }
 						__nextHasNoMarginBottom
 					/>
-					<Stack direction="row" justify="flex-end">
+					{ /* Count and Save share a row, matching the title-structure footer. The
+					     count is informational only — nothing here is capped. */ }
+					<Stack direction="row" justify="space-between" align="center" gap="sm">
+						<Text variant="body-sm" className={ styles.charCount }>
+							{ sprintf(
+								/* translators: %d: number of characters currently in the front-page description. */
+								_n( '%d character', '%d characters', descriptionLength, 'jetpack-seo' ),
+								descriptionLength
+							) }
+						</Text>
 						<Button
 							onClick={ () => commitFields( [ 'front_page_description' ] ) }
 							disabled={ isSaving || ! isDirty( [ 'front_page_description' ] ) }
@@ -154,17 +208,14 @@ const SettingsScreen: FC< Props > = ( { form } ) => {
 		<Stack direction="column" gap="lg" className={ styles.root }>
 			<div id="visibility" className={ styles.section }>
 				<CollapsibleCard.Root defaultOpen>
-					<CollapsibleCard.Header>
+					<CollapsibleCard.Header render={ <h2 /> }>
 						<Stack direction="row" justify="space-between" align="center" gap="sm">
-							<Card.Title>{ __( 'Site visibility', 'jetpack-seo' ) }</Card.Title>
-							<Badge intent={ visibilityEnabledCount === 2 ? 'stable' : 'draft' }>
-								{ sprintf(
-									/* translators: %1$d: number of enabled visibility settings, %2$d: total. */
-									__( '%1$d of %2$d enabled', 'jetpack-seo' ),
-									visibilityEnabledCount,
-									2
-								) }
-							</Badge>
+							<Card.Title>
+								<CardTitleIcon icon={ seen } title={ __( 'Site visibility', 'jetpack-seo' ) } />
+							</Card.Title>
+							<CollapsibleCard.HeaderDescription>
+								<StatusIndicator status={ visibilityStatus } />
+							</CollapsibleCard.HeaderDescription>
 						</Stack>
 					</CollapsibleCard.Header>
 					<CollapsibleCard.Content>
@@ -172,7 +223,7 @@ const SettingsScreen: FC< Props > = ( { form } ) => {
 							<ToggleControl
 								label={ __( 'Allow search engines to index this site', 'jetpack-seo' ) }
 								help={ __(
-									'Mirrors Settings → Reading → "Discourage search engines from indexing this site". Turning this off asks search engines to stop indexing your site; honored by Google and Bing, ignored by others. Use only for staging or pre-launch sites.',
+									'Turning this off asks search engines to stop indexing your site — Google and Bing honor it, others ignore it. Same setting as Settings → Reading.',
 									'jetpack-seo'
 								) }
 								checked={ local.search_engines_visible }
@@ -234,19 +285,21 @@ const SettingsScreen: FC< Props > = ( { form } ) => {
 					</div>
 
 					<CollapsibleCard.Root defaultOpen={ false }>
-						<CollapsibleCard.Header>
+						<CollapsibleCard.Header render={ <h2 /> }>
 							<Stack direction="row" justify="space-between" align="center" gap="sm">
-								<Card.Title>{ __( 'Canonical URLs', 'jetpack-seo' ) }</Card.Title>
-								<Badge intent={ local.canonical_active ? 'stable' : 'draft' }>
-									{ local.canonical_active ? enabledLabel : disabledLabel }
-								</Badge>
+								<Card.Title>
+									<CardTitleIcon icon={ link } title={ __( 'Canonical URLs', 'jetpack-seo' ) } />
+								</Card.Title>
+								<CollapsibleCard.HeaderDescription>
+									<StatusIndicator status={ canonicalStatus } />
+								</CollapsibleCard.HeaderDescription>
 							</Stack>
 						</CollapsibleCard.Header>
 						<CollapsibleCard.Content>
 							<ToggleControl
 								label={ __( 'Add canonical URLs to archive pages', 'jetpack-seo' ) }
 								help={ __(
-									'Adds a rel="canonical" link to archive pages, helping search engines identify the preferred URL and avoid indexing duplicate content.',
+									"Points search engines to one preferred URL for archive pages, so duplicates aren't indexed separately.",
 									'jetpack-seo'
 								) }
 								checked={ local.canonical_active }
@@ -264,6 +317,7 @@ const SettingsScreen: FC< Props > = ( { form } ) => {
 						}
 						onSaveFormat={ pageType => commitTitleFormat( pageType ) }
 						isFormatDirty={ pageType => isTitleFormatDirty( pageType ) }
+						titleSeparator={ local.title_separator }
 						disabled={ isSaving }
 					/>
 

--- a/projects/packages/seo/_inc/screens/settings/schema-settings/author-profile-section.tsx
+++ b/projects/packages/seo/_inc/screens/settings/schema-settings/author-profile-section.tsx
@@ -22,7 +22,7 @@ interface Props {
  * are Jetpack SEO user meta.
  *
  * Presentational: the Author profile card owns the {@link useAuthorProfile}
- * controller (so the header badge and this form share one state) and passes it
+ * controller (so the header status and this form share one state) and passes it
  * in via `form`.
  *
  * @param props      - Component props.
@@ -41,7 +41,7 @@ const AuthorProfileSection: FC< Props > = ( { form } ) => {
 		<Stack direction="column" gap="lg">
 			<Text variant="body-sm" className={ styles.muted }>
 				{ __(
-					'Shown as Person schema on your articles and author archive. Name, bio, and website update your WordPress profile.',
+					'Adds Person schema to your articles and author archive. Name, bio, and website also update your WordPress profile.',
 					'jetpack-seo'
 				) }
 			</Text>
@@ -101,10 +101,7 @@ const AuthorProfileSection: FC< Props > = ( { form } ) => {
 
 			<ProfileUrlList
 				label={ __( 'Social profiles', 'jetpack-seo' ) }
-				help={ __(
-					'Links to your public profiles (for example Facebook, X, LinkedIn). Shown as sameAs.',
-					'jetpack-seo'
-				) }
+				help={ __( 'Links to your public profiles — Facebook, X, LinkedIn.', 'jetpack-seo' ) }
 				urls={ sameAs }
 				onChange={ next => setProfileField( { sameAs: next } ) }
 				disabled={ disabled }

--- a/projects/packages/seo/_inc/screens/settings/schema-settings/local-business-fields.tsx
+++ b/projects/packages/seo/_inc/screens/settings/schema-settings/local-business-fields.tsx
@@ -179,10 +179,7 @@ const LocalBusinessFields: FC< Props > = ( { form } ) => {
 		<Stack direction="column" gap="lg">
 			{ storedAddressEmpty && defaultAddressEmpty && (
 				<Text variant="body-sm" className={ styles.muted }>
-					{ __(
-						'Add your business address — Google requires it before LocalBusiness info is shown.',
-						'jetpack-seo'
-					) }
+					{ __( 'Google requires an address before showing LocalBusiness info.', 'jetpack-seo' ) }
 				</Text>
 			) }
 
@@ -255,10 +252,7 @@ const LocalBusinessFields: FC< Props > = ( { form } ) => {
 						help={
 							! isPriceRange( localBusiness.priceRange )
 								? PRICE_RANGE_ERROR
-								: __(
-										'Use a numerical range (for example $10–$20) or a relative price level (for example $$).',
-										'jetpack-seo'
-								  )
+								: __( 'A range like $10–$20, or a level like $$.', 'jetpack-seo' )
 						}
 						value={ localBusiness.priceRange }
 						onChange={ next => setLocalBusinessField( { priceRange: next } ) }

--- a/projects/packages/seo/_inc/screens/settings/social-previews-card.tsx
+++ b/projects/packages/seo/_inc/screens/settings/social-previews-card.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable jsdoc/require-param, jsdoc/require-returns */
 
 import { __ } from '@wordpress/i18n';
+import { search } from '@wordpress/icons';
 import { Card, CollapsibleCard, Stack, Text } from '@wordpress/ui';
+import CardTitleIcon from '../../components/card-title-icon';
 import getSite from '../../data/get-site';
 import styles from './social-previews-card.module.scss';
 import type { SiteData } from '../../data/get-site';
@@ -130,14 +132,19 @@ const SocialPreviewsCard: FC< Props > = ( { description } ) => {
 
 	return (
 		<CollapsibleCard.Root defaultOpen={ false }>
-			<CollapsibleCard.Header>
-				<Card.Title>{ __( 'Search & social previews', 'jetpack-seo' ) }</Card.Title>
+			<CollapsibleCard.Header render={ <h2 /> }>
+				<Card.Title>
+					<CardTitleIcon
+						icon={ search }
+						title={ __( 'Search & social previews', 'jetpack-seo' ) }
+					/>
+				</Card.Title>
 			</CollapsibleCard.Header>
 			<CollapsibleCard.Content>
 				<Stack direction="column" gap="xl">
 					<Text variant="body-md" render={ <p /> }>
 						{ __(
-							'A preview of how your home page looks in search results and when shared on social media. It updates as you edit the front-page description above.',
+							'How your home page looks in search results and social shares. Updates as you edit the front-page description above.',
 							'jetpack-seo'
 						) }
 					</Text>

--- a/projects/packages/seo/_inc/screens/settings/style.module.scss
+++ b/projects/packages/seo/_inc/screens/settings/style.module.scss
@@ -18,3 +18,18 @@
 .sitemapLink {
 	margin-inline-start: 40px;
 }
+
+// Secondary copy. Paired with `variant="body-sm"`, this is the established
+// treatment for explanatory text across the tab (schema sections, social
+// previews, title structure).
+.muted {
+	color: var(--wpds-color-foreground-content-neutral-weak);
+}
+
+// Live character count in the front-page description footer, paired with that
+// section's Save button (the same footer shape the title-structure rows use).
+// Tabular figures so the width doesn't jitter while typing.
+.charCount {
+	color: var(--wpds-color-foreground-content-neutral-weak);
+	font-variant-numeric: tabular-nums;
+}

--- a/projects/packages/seo/_inc/screens/settings/test/author-profile-card.test.tsx
+++ b/projects/packages/seo/_inc/screens/settings/test/author-profile-card.test.tsx
@@ -104,25 +104,25 @@ describe( 'AuthorProfileCard', () => {
 		} ) );
 	} );
 
-	it( 'renders collapsed by default, without a badge while loading', () => {
+	it( 'renders collapsed by default, without a status while loading', () => {
 		renderCard();
 
 		expect( screen.getByRole( 'button', { name: /Author profile/ } ) ).toHaveAttribute(
 			'aria-expanded',
 			'false'
 		);
-		expect( screen.queryByText( 'Not set' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Not started' ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'keeps loading when core-data returns the initial empty current user', () => {
 		currentUser = {};
 		renderCard();
 
-		expect( screen.queryByText( 'Not set' ) ).not.toBeInTheDocument();
+		expect( screen.queryByText( 'Not started' ) ).not.toBeInTheDocument();
 		expect( createErrorNotice ).not.toHaveBeenCalled();
 	} );
 
-	it( 'renders the fields from the current user and counts them in the header badge', async () => {
+	it( 'renders the fields from the current user and reports complete in the header', async () => {
 		mockAuthorEntity();
 		renderCard();
 		expand();
@@ -136,8 +136,9 @@ describe( 'AuthorProfileCard', () => {
 			'src',
 			'https://example.test/avatar.jpg'
 		);
-		// Bio, website, job title, and a social profile are all filled.
-		expect( screen.getByText( '4 of 4 set' ) ).toBeInTheDocument();
+		// Bio, website, job title, and a social profile are all filled, so all four
+		// counted fields are set and the module reports complete.
+		expect( screen.getByText( 'Complete' ) ).toBeInTheDocument();
 	} );
 
 	it( 'saves changes through the core user entity', async () => {

--- a/projects/packages/seo/_inc/screens/settings/test/gated.test.tsx
+++ b/projects/packages/seo/_inc/screens/settings/test/gated.test.tsx
@@ -37,7 +37,7 @@ jest.unstable_mockModule( '../verification-card', () => ( {
 
 const { default: SettingsScreen } = await import( '../index' );
 
-const FRONT_PAGE_LABEL = 'Meta description shown on the home page';
+const FRONT_PAGE_LABEL = 'Home page description';
 
 /**
  * Build a minimal Settings form whose `local` snapshot varies only the legacy
@@ -52,6 +52,7 @@ const buildForm = ( hasLegacy: boolean ): SettingsForm => {
 		front_page_description: 'Live description.',
 		has_legacy_front_page_meta: hasLegacy,
 		title_formats: {},
+		title_separator: '-',
 		verification: { google: '', bing: '', pinterest: '', yandex: '', facebook: '' },
 		search_engines_visible: true,
 		sitemap_active: false,

--- a/projects/packages/seo/_inc/screens/settings/test/schema-card.test.tsx
+++ b/projects/packages/seo/_inc/screens/settings/test/schema-card.test.tsx
@@ -144,7 +144,7 @@ describe( 'SchemaCard', () => {
 		expandLocalBusiness();
 
 		expect( screen.getByRole( 'textbox', { name: /Street address/ } ) ).toBeInTheDocument();
-		expect( screen.getByText( /Google requires it/ ) ).toBeInTheDocument();
+		expect( screen.getByText( /Google requires an address/ ) ).toBeInTheDocument();
 	} );
 
 	it( 'updates the LocalBusiness toggle through the hook', () => {

--- a/projects/packages/seo/_inc/screens/settings/test/settings-screen.test.tsx
+++ b/projects/packages/seo/_inc/screens/settings/test/settings-screen.test.tsx
@@ -1,0 +1,226 @@
+import '@testing-library/jest-dom';
+import { jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import type { SettingsResponse } from '../../../data/settings-types';
+import type { SettingsForm } from '../../../data/use-settings';
+
+// `--experimental-vm-modules` (true ESM): mock with `jest.unstable_mockModule`
+// and import the components under test dynamically after the mocks are registered.
+jest.unstable_mockModule( '../../../data/is-gated', () => ( {
+	isGated: () => false,
+	getUpsellUrl: () => 'https://wordpress.com/checkout/example.com/value_bundle',
+} ) );
+
+jest.unstable_mockModule( '@wordpress/route', () => ( {
+	useSearch: () => ( {} ),
+} ) );
+
+// Stub the cards that own their own header, so each assertion below is
+// unambiguously about the module it names. The verification card is left real —
+// its completion threshold is one of the rules under test — but the Google field
+// inside it reaches for the verify endpoint, so that one field is stubbed.
+jest.unstable_mockModule( '../author-profile-card', () => ( {
+	default: () => <div>author</div>,
+} ) );
+jest.unstable_mockModule( '../schema-card', () => ( {
+	default: () => <div>schema</div>,
+} ) );
+jest.unstable_mockModule( '../social-previews-card', () => ( {
+	default: () => <div>social previews</div>,
+} ) );
+jest.unstable_mockModule( '../title-structure-field', () => ( {
+	default: () => <div>title structure</div>,
+} ) );
+jest.unstable_mockModule( '../google-verification-field', () => ( {
+	default: () => <div>google field</div>,
+} ) );
+
+const { default: SettingsScreen } = await import( '../index' );
+
+const EMPTY_VERIFICATION = {
+	google: '',
+	bing: '',
+	pinterest: '',
+	yandex: '',
+	facebook: '',
+};
+
+/**
+ * Settings form stub whose stored values can be varied per test; the screen
+ * reads `local` for rendering and the callbacks are no-ops here.
+ *
+ * @param overrides - Stored settings to override on top of an all-off baseline.
+ * @return A stub Settings form.
+ */
+const buildForm = ( overrides: Partial< SettingsResponse > = {} ): SettingsForm => {
+	const local: SettingsResponse = {
+		front_page_description: '',
+		has_legacy_front_page_meta: false,
+		title_formats: {},
+		title_separator: '-',
+		verification: { ...EMPTY_VERIFICATION },
+		search_engines_visible: false,
+		sitemap_active: false,
+		sitemap_url: '',
+		canonical_active: false,
+		schema: {} as SettingsResponse[ 'schema' ],
+		...overrides,
+	};
+
+	return {
+		local,
+		isSaving: false,
+		setField: jest.fn(),
+		setSchemaSettings: jest.fn(),
+		setVerification: jest.fn(),
+		commit: jest.fn(),
+		commitFields: jest.fn(),
+		isDirty: () => false,
+		commitTitleFormat: jest.fn(),
+		isTitleFormatDirty: () => false,
+	} as unknown as SettingsForm;
+};
+
+const STATUS_LABELS = [ 'Not started', 'In progress', 'Complete' ];
+
+/**
+ * The status shown in a given module's header. `Card.Title` is itself an
+ * element wrapping only the title, so walk out from the title until reaching the
+ * header row that also holds the status — the nearest such ancestor is this
+ * module's own header, not a neighbouring module's.
+ *
+ * @param moduleTitle - The module's visible title.
+ * @return The status label text for that module, or undefined if it has none.
+ */
+const statusFor = ( moduleTitle: string ): string | undefined => {
+	let node: HTMLElement | null = screen.getByText( moduleTitle );
+	// Bounded so a module with no status can't climb out and report a sibling's.
+	for ( let depth = 0; node && depth < 4; depth++ ) {
+		const text = node.textContent ?? '';
+		const found = STATUS_LABELS.find( label => text.includes( label ) );
+		if ( found ) {
+			return found;
+		}
+		// eslint-disable-next-line testing-library/no-node-access -- walking from the title out to its header row.
+		node = node.parentElement;
+	}
+	return undefined;
+};
+
+describe( 'Settings module completion status', () => {
+	describe( 'Site visibility — counts its two toggles', () => {
+		it( 'reports not started when neither indexing nor the sitemap is on', () => {
+			render( <SettingsScreen form={ buildForm() } /> );
+			expect( statusFor( 'Site visibility' ) ).toBe( 'Not started' );
+		} );
+
+		it( 'reports in progress when indexing is on but the sitemap is not', () => {
+			render( <SettingsScreen form={ buildForm( { search_engines_visible: true } ) } /> );
+			expect( statusFor( 'Site visibility' ) ).toBe( 'In progress' );
+		} );
+
+		it( 'reports complete when both are on', () => {
+			render(
+				<SettingsScreen
+					form={ buildForm( { search_engines_visible: true, sitemap_active: true } ) }
+				/>
+			);
+			expect( statusFor( 'Site visibility' ) ).toBe( 'Complete' );
+		} );
+
+		// A sitemap can't be built while indexing is blocked, so a stored-on sitemap
+		// preference must not count toward completion until indexing is allowed.
+		it( 'does not count a stored sitemap preference while indexing is blocked', () => {
+			render(
+				<SettingsScreen
+					form={ buildForm( { search_engines_visible: false, sitemap_active: true } ) }
+				/>
+			);
+			expect( statusFor( 'Site visibility' ) ).toBe( 'Not started' );
+		} );
+	} );
+
+	describe( 'binary modules — no partial state', () => {
+		it( 'reports canonical URLs as not started when off and complete when on', () => {
+			const { unmount } = render( <SettingsScreen form={ buildForm() } /> );
+			expect( statusFor( 'Canonical URLs' ) ).toBe( 'Not started' );
+			unmount();
+
+			render( <SettingsScreen form={ buildForm( { canonical_active: true } ) } /> );
+			expect( statusFor( 'Canonical URLs' ) ).toBe( 'Complete' );
+		} );
+
+		it( 'reports the front-page description as not started when empty and complete when set', () => {
+			const { unmount } = render( <SettingsScreen form={ buildForm() } /> );
+			expect( statusFor( 'Front-page description' ) ).toBe( 'Not started' );
+			unmount();
+
+			render(
+				<SettingsScreen form={ buildForm( { front_page_description: 'A description.' } ) } />
+			);
+			expect( statusFor( 'Front-page description' ) ).toBe( 'Complete' );
+		} );
+	} );
+
+	// The count is purely informational — the field is deliberately uncapped,
+	// because the real limits differ per surface (search truncates for display,
+	// Jetpack's own og:description cuts at 197) and none is enforced on this save path.
+	describe( 'Front-page description character count', () => {
+		it( 'counts an empty description as zero, pluralized', () => {
+			render( <SettingsScreen form={ buildForm() } /> );
+			expect( screen.getByText( '0 characters' ) ).toBeInTheDocument();
+		} );
+
+		it( 'uses the singular form for a one-character description', () => {
+			render( <SettingsScreen form={ buildForm( { front_page_description: 'x' } ) } /> );
+			expect( screen.getByText( '1 character' ) ).toBeInTheDocument();
+		} );
+
+		it( 'reports the length of a filled-in description', () => {
+			const description = 'A summary of the site.';
+			render( <SettingsScreen form={ buildForm( { front_page_description: description } ) } /> );
+			expect( screen.getByText( `${ description.length } characters` ) ).toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'Site verification — one service is enough', () => {
+		it( 'reports not started with no codes stored', () => {
+			render( <SettingsScreen form={ buildForm() } /> );
+			expect( statusFor( 'Site verification' ) ).toBe( 'Not started' );
+		} );
+
+		// Deliberate: verifying with a single search engine is the realistic end
+		// state, so this module goes straight to complete and never sits at
+		// in-progress (JETPACK-2051). Bing rather than Google, to show no single
+		// service is privileged.
+		it( 'reports complete — not in progress — with a single service verified', () => {
+			render(
+				<SettingsScreen
+					form={ buildForm( {
+						verification: { ...EMPTY_VERIFICATION, bing: 'bing-code' },
+					} ) }
+				/>
+			);
+			expect( statusFor( 'Site verification' ) ).toBe( 'Complete' );
+		} );
+	} );
+} );
+
+describe( 'Settings module title chips', () => {
+	// The chip must not swallow the title text: the header is how these modules are
+	// found by assistive tech, and by every other test in this file.
+	it.each( [ 'Site visibility', 'Site verification', 'Canonical URLs', 'Front-page description' ] )(
+		'renders %s with its title text and a leading icon chip',
+		moduleTitle => {
+			render( <SettingsScreen form={ buildForm() } /> );
+
+			// `getByText` resolves to the chip wrapper, whose text content is the title
+			// alone — the glyph beside it is a decorative SVG with no role.
+			const title = screen.getByText( moduleTitle );
+
+			expect( title ).toBeInTheDocument();
+			// eslint-disable-next-line testing-library/no-node-access -- asserting the decorative glyph rendered.
+			expect( title.querySelector( 'svg' ) ).toBeInTheDocument();
+		}
+	);
+} );

--- a/projects/packages/seo/_inc/screens/settings/test/title-structure-field.test.tsx
+++ b/projects/packages/seo/_inc/screens/settings/test/title-structure-field.test.tsx
@@ -1,0 +1,159 @@
+/* eslint-disable react/jsx-no-bind */
+
+import '@testing-library/jest-dom';
+import { jest } from '@jest/globals';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { SiteData } from '../../../data/get-site';
+import type { TitleFormatToken } from '../../../data/settings-types';
+
+// `--experimental-vm-modules` (true ESM): register the mock, then import the
+// component dynamically. `getSite()` reads the page bootstrap, which doesn't
+// exist under jsdom.
+let site: SiteData | null;
+
+jest.unstable_mockModule( '../../../data/get-site', () => ( {
+	default: () => site,
+} ) );
+
+const { default: TitleStructureField } = await import( '../title-structure-field' );
+
+const SITE: SiteData = {
+	title: 'Acme Co',
+	tagline: 'We make things',
+	url: 'https://example.com',
+	icon: '',
+	image: '',
+};
+
+/**
+ * Render the module with the given stored formats. Page types absent from
+ * `formats` are untouched, which is the case the default preview exists for.
+ *
+ * @param formats - Stored title formats, keyed by page type.
+ * @return The render result.
+ */
+const renderField = ( formats: Record< string, TitleFormatToken[] > = {} ) =>
+	render(
+		<TitleStructureField
+			formats={ formats }
+			onChange={ jest.fn() }
+			onSaveFormat={ jest.fn() }
+			isFormatDirty={ () => false }
+			titleSeparator="-"
+		/>
+	);
+
+/**
+ * Open the module — like the other Settings cards it renders collapsed.
+ *
+ * @return Whether the click event was dispatched.
+ */
+const expand = () =>
+	// eslint-disable-next-line testing-library/prefer-user-event -- single click; fireEvent avoids the user-event devDep (lockfile churn).
+	fireEvent.click( screen.getByRole( 'button', { name: /Title structure/ } ) );
+
+describe( 'TitleStructureField', () => {
+	beforeEach( () => {
+		site = SITE;
+	} );
+
+	// The rule is deliberate and load-bearing (JETPACK-2051): an untouched page
+	// type still produces a title, so nothing here is ever unfinished. Without
+	// this, reverting to a count-based status passes the rest of the suite.
+	describe( 'completion status', () => {
+		it( 'reports complete with no formats stored at all', () => {
+			renderField();
+			expect( screen.getByText( 'Complete' ) ).toBeInTheDocument();
+			expect( screen.queryByText( 'Not started' ) ).not.toBeInTheDocument();
+			expect( screen.queryByText( 'In progress' ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'still reports complete when only some page types are customized', () => {
+			renderField( { posts: [ { type: 'token', value: 'post_title' } ] } );
+			expect( screen.getByText( 'Complete' ) ).toBeInTheDocument();
+			expect( screen.queryByText( 'In progress' ) ).not.toBeInTheDocument();
+		} );
+	} );
+
+	describe( 'previews', () => {
+		it( 'previews the default title for an untouched page type', () => {
+			renderField();
+			expand();
+			// Core pairs the page-specific title with the site title everywhere but
+			// the front page, where it pairs the site title with the tagline. Each
+			// preview is unique, so no per-row scoping is needed.
+			expect( screen.getByText( /Hello World - Acme Co/ ) ).toBeInTheDocument();
+			expect( screen.getByText( /Acme Co - We make things/ ) ).toBeInTheDocument();
+		} );
+
+		it( 'marks an untouched field as using the default', () => {
+			renderField();
+			expand();
+			expect( screen.getByRole( 'textbox', { name: 'Posts' } ) ).toHaveAttribute(
+				'placeholder',
+				'Using the default title'
+			);
+		} );
+
+		it( 'previews a stored format from its tokens', () => {
+			renderField( {
+				posts: [
+					{ type: 'token', value: 'post_title' },
+					{ type: 'string', value: ' | ' },
+					{ type: 'token', value: 'site_name' },
+				],
+			} );
+			expand();
+			expect( screen.getByText( /Hello World \| Acme Co/ ) ).toBeInTheDocument();
+		} );
+	} );
+
+	// A site can have no tagline. The preview says so honestly rather than
+	// substituting sample text for a value the site doesn't have.
+	describe( 'empty site values', () => {
+		beforeEach( () => {
+			site = { ...SITE, tagline: '' };
+		} );
+
+		it( 'drops an empty part from a default title, as core does', () => {
+			renderField();
+			expand();
+			// The front page pairs site title + tagline; with no tagline core drops
+			// that part rather than leaving a dangling separator.
+			expect( screen.getByText( /^\s*Acme Co\s*$/ ) ).toBeInTheDocument();
+			expect( screen.queryByText( /Your tagline/ ) ).not.toBeInTheDocument();
+		} );
+
+		it( 'keeps the separator in a custom format, as Jetpack does', () => {
+			renderField( {
+				front_page: [
+					{ type: 'token', value: 'site_name' },
+					{ type: 'string', value: ' - ' },
+					{ type: 'token', value: 'tagline' },
+				],
+			} );
+			expand();
+			expect( screen.getByText( /^\s*Acme Co -\s*$/ ) ).toBeInTheDocument();
+			expect( screen.queryByText( /Your tagline/ ) ).not.toBeInTheDocument();
+		} );
+
+		// Regression: gating the preview on a non-empty string hid it entirely for a
+		// format that evaluates to nothing — the opposite of previewing honestly.
+		it( 'still shows the preview line for a custom format that renders nothing', () => {
+			renderField( { front_page: [ { type: 'token', value: 'tagline' } ] } );
+			expand();
+			// Every page type keeps its preview line, including the one that renders
+			// nothing — hiding it would undo the point of previewing honestly.
+			expect( screen.getAllByText( /^Preview:/ ) ).toHaveLength( 5 );
+		} );
+	} );
+
+	// Absent bootstrap data is "unknown", not "empty": sample text still stands in,
+	// so a failed load can't masquerade as a site with no name.
+	it( 'falls back to sample text when the site data is missing', () => {
+		site = null;
+		renderField();
+		expand();
+		expect( screen.getByText( /Hello World - Your site/ ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/seo/_inc/screens/settings/title-structure-field.tsx
+++ b/projects/packages/seo/_inc/screens/settings/title-structure-field.tsx
@@ -4,29 +4,43 @@
 
 import { TextControl } from '@wordpress/components';
 import { useCallback, useMemo, useRef } from '@wordpress/element';
-import { __, sprintf } from '@wordpress/i18n';
-import { Badge, Button, Card, CollapsibleCard, Stack, Text } from '@wordpress/ui';
+import { __ } from '@wordpress/i18n';
+import { title as titleIcon } from '@wordpress/icons';
+import { Button, Card, CollapsibleCard, Stack, Text } from '@wordpress/ui';
+import CardTitleIcon from '../../components/card-title-icon';
+import StatusIndicator from '../../components/status-indicator';
 import getSite from '../../data/get-site';
 import {
 	PAGE_TYPES,
 	PAGE_TYPE_SUGGESTIONS,
 	PAGE_TYPE_TOKENS,
 	TOKEN_LABELS,
+	buildDefaultPreview,
 	buildPreview,
 	stringToTokens,
 	tokensToString,
 } from '../../data/title-format-tokens';
 import styles from './title-structure-field.module.scss';
+import type { SettingStatus } from '../../components/status-indicator';
 import type { TitleFormatToken } from '../../data/settings-types';
 import type { FC } from 'react';
 
-// Pre-resolved so the production minifier can't fold an adjacent
-// `cond ? __(A) : __(B)` into `__(cond ? A : B)`, which breaks i18n
-// extraction. See feedback_i18n_ternary_minifier_fold.
-const defaultLabel = __( 'Default', 'jetpack-seo' );
 const previewLabel = __( 'Preview', 'jetpack-seo' );
-const insertLabel = __( 'Insert placeholder', 'jetpack-seo' );
+// "Placeholder" is avoided deliberately: in this codebase (and in HTML) it
+// already means an input's grey hint text, which is a different thing.
+const insertLabel = __( 'Insert a title part', 'jetpack-seo' );
 const saveLabel = __( 'Save', 'jetpack-seo' );
+// Deliberately says "show as empty" rather than "are left out": a custom format is
+// concatenated straight through by `Jetpack_SEO_Titles::get_custom_title()`, so an
+// empty part leaves the separator around it in place. Only the *default* title
+// drops empty parts, because core runs `array_filter()` before joining.
+const moduleDescription = __(
+	'How your titles appear in search results and browser tabs. Each page type keeps the default until you set a format; parts your site has no value for show as empty.',
+	'jetpack-seo'
+);
+// Shown in the empty input so the blank field reads as "this already has a title"
+// rather than "this is unset".
+const defaultPlaceholder = __( 'Using the default title', 'jetpack-seo' );
 
 interface RowProps {
 	pageTypeId: string;
@@ -36,6 +50,8 @@ interface RowProps {
 	onSave: () => void;
 	canSave: boolean;
 	previewOverrides: Partial< Record< string, string > >;
+	/** The site's document-title separator, for previewing an untouched page type. */
+	titleSeparator: string;
 	disabled?: boolean;
 }
 
@@ -62,14 +78,20 @@ const TitleStructureRow: FC< RowProps > = ( {
 	onSave,
 	canSave,
 	previewOverrides,
+	titleSeparator,
 	disabled,
 } ) => {
 	const inputRef = useRef< HTMLInputElement | null >( null );
 	const value = useMemo( () => tokensToString( tokens ), [ tokens ] );
 	const allowed = PAGE_TYPE_TOKENS[ pageTypeId ];
+	// An untouched page type still has a title — WordPress composes it — so preview
+	// that instead of leaving the row blank under the module's "Complete" status.
 	const preview = useMemo(
-		() => buildPreview( tokens, previewOverrides ),
-		[ tokens, previewOverrides ]
+		() =>
+			tokens.length > 0
+				? buildPreview( tokens, previewOverrides )
+				: buildDefaultPreview( pageTypeId, titleSeparator, previewOverrides ),
+		[ tokens, previewOverrides, pageTypeId, titleSeparator ]
 	);
 
 	const setFromString = useCallback(
@@ -102,6 +124,7 @@ const TitleStructureRow: FC< RowProps > = ( {
 				ref={ inputRef }
 				label={ label }
 				value={ value }
+				placeholder={ defaultPlaceholder }
 				onChange={ setFromString }
 				disabled={ disabled }
 				__next40pxDefaultSize
@@ -117,7 +140,9 @@ const TitleStructureRow: FC< RowProps > = ( {
 							key={ tokenId }
 							variant="outline"
 							tone="neutral"
-							size="compact"
+							// `small` (24px), not `compact` (32px): against the 40px field these
+							// are a secondary affordance and shouldn't compete with it.
+							size="small"
 							disabled={ disabled }
 							onClick={ () => insertToken( tokenId ) }
 						>
@@ -127,7 +152,12 @@ const TitleStructureRow: FC< RowProps > = ( {
 				</Stack>
 			</Stack>
 			<Stack direction="row" align="flex-start" gap="lg">
-				{ tokens.length > 0 && (
+				{ /* Shown for a defaulted row too, so every page type demonstrates the
+				     title it produces rather than leaving a blank the module's
+				     "Complete" status appears to contradict. A custom format always
+				     shows its preview even when it evaluates to nothing — that empty
+				     result is the honest one, and hiding it would undo the point. */ }
+				{ ( tokens.length > 0 || preview ) && (
 					<Text variant="body-md" className={ styles.preview }>
 						<strong>{ previewLabel }:</strong> { preview }
 					</Text>
@@ -147,6 +177,8 @@ interface Props {
 	onSaveFormat: ( pageType: string ) => void;
 	/** Whether a page type has unsaved edits (enables that row's Save button). */
 	isFormatDirty: ( pageType: string ) => boolean;
+	/** The site's document-title separator, for previewing untouched page types. */
+	titleSeparator: string;
 	disabled?: boolean;
 }
 
@@ -164,40 +196,49 @@ const TitleStructureField: FC< Props > = ( {
 	onChange,
 	onSaveFormat,
 	isFormatDirty,
+	titleSeparator,
 	disabled,
 } ) => {
-	const customizedCount = PAGE_TYPES.filter( pt => ( formats[ pt.id ]?.length ?? 0 ) > 0 ).length;
+	// A smart default counts as configured — the same rule the Schema module uses.
+	// An untouched page type (an empty token list) still produces a title: Jetpack
+	// has no default format of its own, it just steps aside and lets WordPress
+	// compose the title. So leaving one alone is a good outcome rather than
+	// unfinished work, and this module is always complete. Deliberate: reporting
+	// "Not started" here read as a criticism of a site that simply has no reason to
+	// customize its titles (JETPACK-2051). Each row previews that default, so the
+	// status is backed by something visible.
+	const titleStatus: SettingStatus = 'complete';
 
 	// Fill the site-wide placeholders in each row's preview with the site's real
-	// name and tagline (bootstrapped in `seo.site`). Coalesce to '' when the site
-	// data is absent so the empty value falls through to the sample text in
-	// `buildPreview`. Per-page tokens like [Post title] keep their representative
-	// samples since they vary per page.
+	// name and tagline (bootstrapped in `seo.site`) — including when one of them is
+	// empty, which previews as empty because that is what the site renders. Omit the
+	// overrides entirely when the site data is missing, so an unknown value still
+	// falls back to sample text rather than previewing as a gap the site doesn't
+	// actually have. Per-page tokens like [Post title] are never overridden; they
+	// vary per page and always show their sample.
 	const site = getSite();
 	const previewOverrides = useMemo(
-		() => ( { site_name: site?.title ?? '', tagline: site?.tagline ?? '' } ),
-		[ site?.title, site?.tagline ]
+		() => ( site ? { site_name: site.title, tagline: site.tagline } : {} ),
+		[ site ]
 	);
 
 	return (
 		<CollapsibleCard.Root defaultOpen={ false }>
-			<CollapsibleCard.Header>
+			<CollapsibleCard.Header render={ <h2 /> }>
 				<Stack direction="row" justify="space-between" align="center" gap="sm">
-					<Card.Title>{ __( 'Title structure', 'jetpack-seo' ) }</Card.Title>
-					<Badge intent={ customizedCount > 0 ? 'stable' : 'draft' }>
-						{ customizedCount > 0
-							? sprintf(
-									/* translators: %1$d: number of customized page types, %2$d: total page types. */
-									__( '%1$d of %2$d customized', 'jetpack-seo' ),
-									customizedCount,
-									PAGE_TYPES.length
-							  )
-							: defaultLabel }
-					</Badge>
+					<Card.Title>
+						<CardTitleIcon icon={ titleIcon } title={ __( 'Title structure', 'jetpack-seo' ) } />
+					</Card.Title>
+					<CollapsibleCard.HeaderDescription>
+						<StatusIndicator status={ titleStatus } />
+					</CollapsibleCard.HeaderDescription>
 				</Stack>
 			</CollapsibleCard.Header>
 			<CollapsibleCard.Content>
 				<Stack direction="column" gap="lg">
+					<Text variant="body-sm" className={ styles.muted } render={ <p /> }>
+						{ moduleDescription }
+					</Text>
 					{ PAGE_TYPES.map( pt => (
 						<TitleStructureRow
 							key={ pt.id }
@@ -208,6 +249,7 @@ const TitleStructureField: FC< Props > = ( {
 							onSave={ () => onSaveFormat( pt.id ) }
 							canSave={ isFormatDirty( pt.id ) }
 							previewOverrides={ previewOverrides }
+							titleSeparator={ titleSeparator }
 							disabled={ disabled }
 						/>
 					) ) }

--- a/projects/packages/seo/_inc/screens/settings/verification-card.tsx
+++ b/projects/packages/seo/_inc/screens/settings/verification-card.tsx
@@ -1,10 +1,15 @@
 /* eslint-disable react/jsx-no-bind */
 
 import { TextControl } from '@wordpress/components';
-import { __, sprintf, _n } from '@wordpress/i18n';
-import { Badge, Card, CollapsibleCard, Stack } from '@wordpress/ui';
+import { __ } from '@wordpress/i18n';
+import { check } from '@wordpress/icons';
+import { Card, CollapsibleCard, Stack, Text } from '@wordpress/ui';
+import CardTitleIcon from '../../components/card-title-icon';
+import StatusIndicator from '../../components/status-indicator';
 import { VERIFICATION_SERVICES } from '../../data/verification-services';
 import GoogleVerificationField from './google-verification-field';
+import styles from './style.module.scss';
+import type { SettingStatus } from '../../components/status-indicator';
 import type { SettingsResponse, VerificationKey } from '../../data/settings-types';
 import type { FC } from 'react';
 
@@ -19,20 +24,43 @@ interface Props {
 	onOpenChange?: ( open: boolean ) => void;
 }
 
+const description = __(
+	"Confirm you own this site to unlock each service's own tools, like Google Search Console, for tracking performance and submitting your sitemap.",
+	'jetpack-seo'
+);
+
 // Per-service input hints, keyed by the shared service id. The service list and
 // brand labels live in `data/verification-services` (single source of truth).
-const HINTS: Record< VerificationKey, string > = {
-	google: __(
-		'Paste the "content" attribute from the Google Search Console meta tag.',
+//
+// Each hint names where to fetch the tag and says both forms are accepted. This
+// page saves through `/jetpack/v4/settings`, which validates the value
+// (`validate_verification_service()`) and stores it; the code is unwrapped from a
+// pasted tag on the way in (`class.jetpack-core-api-module-endpoints.php`) and
+// again at render (`jetpack_verification_print_meta()`). Both unwrappers expect
+// the `<meta name="…" content="…" />` shape the services actually emit.
+// Deliberately not repeating each service's own name for the tag ("HTML tag",
+// "HTML Meta Tag", …): those are third-party UI labels that drift out of date.
+//
+// Google is absent by design — its field is the keyring component below, which
+// carries its own hint.
+const HINTS: Record< Exclude< VerificationKey, 'google' >, string > = {
+	bing: __(
+		'Paste the verification tag from Bing Webmaster Tools, or just the code inside it.',
 		'jetpack-seo'
 	),
-	bing: __( 'Bing Webmaster Tools meta tag.', 'jetpack-seo' ),
-	pinterest: __( 'Pinterest meta tag.', 'jetpack-seo' ),
-	yandex: __( 'Yandex Webmaster meta tag.', 'jetpack-seo' ),
-	facebook: __( 'Facebook domain verification meta tag.', 'jetpack-seo' ),
+	pinterest: __(
+		'Paste the verification tag from Pinterest, or just the code inside it.',
+		'jetpack-seo'
+	),
+	yandex: __(
+		'Paste the verification tag from Yandex Webmaster, or just the code inside it.',
+		'jetpack-seo'
+	),
+	facebook: __(
+		'Paste the domain verification tag from Meta Business, or just the code inside it.',
+		'jetpack-seo'
+	),
 };
-
-const notSetLabel = __( 'Not set', 'jetpack-seo' );
 
 const VerificationCard: FC< Props > = ( {
 	value,
@@ -44,28 +72,34 @@ const VerificationCard: FC< Props > = ( {
 } ) => {
 	const verifiedCount = VERIFICATION_SERVICES.filter( ( { key } ) => !! value[ key ] ).length;
 
+	// All five services are optional and almost nobody verifies with more than
+	// one, so a single verified service counts as done rather than a fraction of
+	// five (JETPACK-2051). This module therefore never reports 'in-progress'.
+	const verificationStatus: SettingStatus = verifiedCount > 0 ? 'complete' : 'not-started';
+
 	// CollapsibleCard.Root takes either controlled (`open`/`onOpenChange`) or
 	// uncontrolled (`defaultOpen`) props — one at a time.
 	const collapsibleProps = open === undefined ? { defaultOpen: false } : { open, onOpenChange };
 
 	return (
 		<CollapsibleCard.Root { ...collapsibleProps }>
-			<CollapsibleCard.Header>
+			<CollapsibleCard.Header render={ <h2 /> }>
 				<Stack direction="row" justify="space-between" align="center" gap="sm">
-					<Card.Title>{ __( 'Site verification', 'jetpack-seo' ) }</Card.Title>
-					<Badge intent={ verifiedCount > 0 ? 'stable' : 'draft' }>
-						{ verifiedCount > 0
-							? sprintf(
-									/* translators: %d: number of verification services configured */
-									_n( '%d set', '%d set', verifiedCount, 'jetpack-seo' ),
-									verifiedCount
-							  )
-							: notSetLabel }
-					</Badge>
+					<Card.Title>
+						<CardTitleIcon icon={ check } title={ __( 'Site verification', 'jetpack-seo' ) } />
+					</Card.Title>
+					<CollapsibleCard.HeaderDescription>
+						<StatusIndicator status={ verificationStatus } />
+					</CollapsibleCard.HeaderDescription>
 				</Stack>
 			</CollapsibleCard.Header>
 			<CollapsibleCard.Content>
 				<Stack direction="column" gap="lg">
+					{ /* `body-sm` + muted matches every other explanatory paragraph on this
+					     tab (schema sections, social previews, title structure). */ }
+					<Text variant="body-sm" className={ styles.muted } render={ <p /> }>
+						{ description }
+					</Text>
 					{ /* Google gets the keyring auto-verify flow; the rest are simple code fields. */ }
 					<GoogleVerificationField
 						value={ value.google }

--- a/projects/packages/seo/changelog/update-seo-settings-icon-chips
+++ b/projects/packages/seo/changelog/update-seo-settings-icon-chips
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Add icon chips and completion statuses to each Settings module, clarify the help text, and preview the title every page type produces.

--- a/projects/packages/seo/src/class-dashboard-data.php
+++ b/projects/packages/seo/src/class-dashboard-data.php
@@ -192,12 +192,11 @@ class Dashboard_Data {
 			'canonical_active'           => self::is_canonical_enabled( $modules ),
 			// Cast to object so an empty format set serializes as `{}`, not `[]`.
 			'title_formats'              => (object) $title_formats,
-			// Separator WordPress joins document-title parts with. A page type with no
-			// stored format keeps the default title: `Jetpack_SEO_Titles::get_custom_title()`
-			// returns the incoming value untouched, so core composes the title itself.
-			// The Settings tab replays that composition to preview the default, and the
-			// separator is the one part of it a theme routinely overrides.
-			'title_separator'            => (string) apply_filters( 'document_title_separator', '-' ),
+			// Separator WordPress joins default document-title parts with. A page type
+			// with no stored format keeps the default title: `get_custom_title()` returns
+			// the incoming value untouched, so core composes the title itself and the
+			// Settings tab replays that composition to preview it.
+			'title_separator'            => self::get_default_title_separator(),
 			'front_page_description'     => (string) $front_page_desc,
 			'has_legacy_front_page_meta' => $has_legacy_front_page_meta,
 			'verification'               => array(
@@ -361,6 +360,38 @@ class Dashboard_Data {
 		}
 
 		return (bool) $enabled;
+	}
+
+	/**
+	 * The separator, as rendered, that WordPress joins default document-title parts
+	 * with — for previewing the title a page type with no stored format produces.
+	 *
+	 * `document_title_separator` alone is not what a visitor sees. `wp_get_document_title()`
+	 * composes the parts, then passes the whole title through the `document_title`
+	 * filter, which WordPress texturizes by default — turning the default spaced
+	 * hyphen into an en dash. Previewing the raw filter value would show `-` on a site
+	 * that renders `–`, which is every site running core's defaults.
+	 *
+	 * This applies only to the default title. A stored format short-circuits
+	 * `pre_get_document_title`, which returns before the `document_title` filter, so a
+	 * custom format keeps the separator the user typed verbatim — the front end renders
+	 * `Site - MARKER - Page` for a custom format while producing `Page – Site` for the
+	 * default one.
+	 *
+	 * @return string The rendered separator.
+	 */
+	private static function get_default_title_separator() {
+		$separator = (string) apply_filters( 'document_title_separator', '-' );
+
+		// Only texturize when the title itself would be: a site that unhooks
+		// `wptexturize` renders the raw separator, and the preview should match.
+		if ( has_filter( 'document_title', 'wptexturize' ) ) {
+			$separator = trim(
+				html_entity_decode( wptexturize( ' ' . $separator . ' ' ), ENT_QUOTES, 'UTF-8' )
+			);
+		}
+
+		return $separator;
 	}
 
 	/**

--- a/projects/packages/seo/src/class-dashboard-data.php
+++ b/projects/packages/seo/src/class-dashboard-data.php
@@ -192,6 +192,12 @@ class Dashboard_Data {
 			'canonical_active'           => self::is_canonical_enabled( $modules ),
 			// Cast to object so an empty format set serializes as `{}`, not `[]`.
 			'title_formats'              => (object) $title_formats,
+			// Separator WordPress joins document-title parts with. A page type with no
+			// stored format keeps the default title: `Jetpack_SEO_Titles::get_custom_title()`
+			// returns the incoming value untouched, so core composes the title itself.
+			// The Settings tab replays that composition to preview the default, and the
+			// separator is the one part of it a theme routinely overrides.
+			'title_separator'            => (string) apply_filters( 'document_title_separator', '-' ),
 			'front_page_description'     => (string) $front_page_desc,
 			'has_legacy_front_page_meta' => $has_legacy_front_page_meta,
 			'verification'               => array(

--- a/projects/packages/seo/tests/php/DashboardDataTest.php
+++ b/projects/packages/seo/tests/php/DashboardDataTest.php
@@ -260,4 +260,35 @@ class DashboardDataTest extends SeoTestCase {
 		$overview = Dashboard_Data::get_overview_data();
 		$this->assertArrayNotHasKey( 'sitemap_url', $overview['site_visibility'] );
 	}
+
+	/**
+	 * `title_separator` must be the separator as *rendered*, not the raw
+	 * `document_title_separator` value. `wp_get_document_title()` runs the composed
+	 * title through the `document_title` filter, which WordPress texturizes by
+	 * default — so core's `-` reaches a visitor as an en dash. Previewing the raw
+	 * value showed `-` on every site running core's defaults, which render `–`.
+	 */
+	public function test_get_settings_data_title_separator_is_rendered_not_raw() {
+		$settings = Dashboard_Data::get_settings_data();
+
+		$this->assertArrayHasKey( 'title_separator', $settings );
+		$this->assertIsString( $settings['title_separator'] );
+		$this->assertSame( "\u{2013}", $settings['title_separator'] );
+	}
+
+	/**
+	 * A theme's own separator still wins — it is texturized, not replaced.
+	 */
+	public function test_get_settings_data_title_separator_honors_the_filter() {
+		$filter = static function () {
+			return '|';
+		};
+		add_filter( 'document_title_separator', $filter );
+
+		$settings = Dashboard_Data::get_settings_data();
+
+		remove_filter( 'document_title_separator', $filter );
+
+		$this->assertSame( '|', $settings['title_separator'] );
+	}
 }


### PR DESCRIPTION
Fixes JETPACK-2050
Fixes JETPACK-2051

**Based on `trunk` — this ships on its own.** It carries the shared `CardTitleIcon` and `StatusIndicator`, which were introduced in #50875; that branch drops its own copies when it rebases.

**The Schema module is deliberately untouched here.** On `trunk` it is still three separate cards (Breadcrumbs, Organization, Local business) that #50875 replaces with a single guided module, so styling them in this PR would be discarded on that merge. Its chip, status and copy belong in #50875. Until both land, those three cards have no chip or status — invisible outside the `rsm_jetpack_seo` flag, which is still off.

## Proposed changes

A presentational pass over the whole SEO **Settings** tab. No save-path or behaviour changes. The one back-end addition is `title_separator`, a read-only value derived from a core filter — it joins the page bootstrap and, since that same method backs the registered route, the `/jetpack/v4/seo/settings` response gains a field (additive).

**Icon chips on every module title** (JETPACK-2050) — using the shared `CardTitleIcon` built for Schema in #50875. Site visibility (`seen`) · Site verification (`check`) · Author profile (`commentAuthorAvatar`) · Canonical URLs (`link`) · Title structure (`title`) · Front-page description (`home`) · Search & social previews (`search`). The first two deliberately reuse the icons their Overview counterparts already use, so a module that appears on both tabs looks the same in both places.

**Completion statuses** (JETPACK-2051) — the shared `StatusIndicator` (Not started / In progress / Complete) replaces each module's status `Badge`. Search & social previews is deliberately excluded and keeps no badge: it's a read-only preview with no settings, so it has nothing to complete. Per-module rules are recorded on the issue; the ones worth knowing here:

* **Site visibility** counts its two toggles, the sitemap by its *effective* state — a stored sitemap preference doesn't count while indexing is blocked, because no sitemap can be built then.
* **Site verification** reaches Complete on a single verified service. All five are optional and almost nobody uses more than one, so this module never sits at In progress.
* **Title structure** is always Complete: an untouched page type still produces a title, so leaving it alone is a good outcome rather than unfinished work.
* **Schema** keeps its existing badges for now — see the note above.
* Replacing the badges drops the header counts ("3 of 5 set"). That detail is still visible inside each expanded module.

**Every Title structure row now previews its title, including untouched ones.** This is the substantive change. A page type with no stored format still gets a title — `Jetpack_SEO_Titles::get_custom_title()` is filtered onto `pre_get_document_title` and returns the incoming value untouched, so WordPress composes the title itself. `buildDefaultPreview()` replays that composition, so a "Complete" status is backed by something visible instead of contradicted by an empty row.

* The separator is read from the site (`document_title_separator`) and bootstrapped as `title_separator`, since that's the piece themes routinely override.
* Empty placeholders now preview honestly. A format using `[Tagline]` on a site with no tagline previewed as "Acme Co - Your tagline", promising a title the site never renders; it now previews as "Acme Co - ".
* The two preview paths deliberately differ, because the code they model differs: `buildPreview` keeps the dangling separator (Jetpack concatenates the format straight through) while `buildDefaultPreview` drops empty parts (core runs `array_filter()` before joining).

**Copy pass over every module**, with nothing moved behind a tooltip or a disclosure. Tooltips were considered and rejected: roughly half these strings are the reason someone picks one option over another, not optional background, and hiding those behind hover costs comprehension on the surface that can least afford it — and gives nothing at all on touch. Mostly the trimming meant dropping mechanism detail in favour of what a person acts on.

* **Site visibility** — dropped "Use only for staging or pre-launch sites." It had no clear subject, so it read as though indexing should only ever be switched *on* for staging sites.
* **Site verification** — added a module description, and rewrote all five field hints. The old ones named a thing ("Bing Webmaster Tools meta tag.") rather than saying what to do. Each now says where to fetch the tag and that a whole pasted tag *or* a bare code both work — this page posts to `/jetpack/v4/settings`, which validates the value and unwraps a pasted tag on the way in, and `jetpack_verification_print_meta()` unwraps again at render — so the old Google hint ("paste the `content` attribute") asked for more work than necessary. Deliberately not repeating each service's own name for the tag ("HTML tag", "HTML Meta Tag", …), since those are third-party UI labels that drift.
* **Title structure** — "Insert placeholder" → "Insert a title part": in this codebase (and in HTML) "placeholder" already means an input's grey hint text, which the Schema fields genuinely use, so both meanings were live on one tab. Also gained a module description, and its insert buttons drop from `size="compact"` (32px) to `size="small"` (24px) — they sat only 8px shorter than the 40px field and competed with it.
* **Front-page description** — the control label was a nine-word sentence, and the design system renders labels as 11px all-caps. Shortened to "Home page description" — not just "Description", which would collide with the Organization/Person description field on the same tab and leave two controls indistinguishable to a screen reader — with the explanation moved to help text, which renders in sentence case. Added a live character count, measured in code points so an emoji counts once.
* **Author profile and Local business** — trimmed. The Schema, Organization and Person copy is trimmed in #50875, where those sections are being rewritten anyway.

**Accessibility.** Two fixes using slots the design system already provides, neither a regression but both worth taking while every header is being rewritten:

* **Heading semantics.** No card on this page had any — `Card.Title` and `CollapsibleCard.Header` both render a `div`, so the outline went from the page's h1 straight to the h3s inside Search & social previews. `CollapsibleCard.Header`'s docblock asks the consumer to opt in ("pass `render` to wrap the trigger in a heading, following the W3C APG accordion pattern"), so the heading goes on the header rather than on `Card.Title` inside it, which would put a heading *within* the button. The Overview's cards aren't collapsible, so there the title itself is the heading.
* **Status out of the trigger's accessible name.** The header wraps all its children in the trigger, so the button announced as "Front-page description Complete" — a name that changed whenever a setting flipped. `CollapsibleCard.HeaderDescription` renders visibly, marks itself `aria-hidden`, and wires `aria-describedby`, so the status becomes a description instead. Verified with an exact-name query, which only matches if the status is excluded from the computed name.

**Housekeeping** — the Overview's private `CardHeaderIcon` now delegates to the shared `CardTitleIcon`, and its duplicated `.cardTitle` / `.titleIcon` rules are gone from `screens/overview/style.module.scss`. The chip existed in two places and would have drifted the moment either tab changed. **No visual change on the Overview.**

## Screenshots

<img width="1401" height="864" alt="Jetpack SEO settings with icon chip in title and status" src="https://github.com/user-attachments/assets/87c9fb77-afd3-4086-a977-5336f46fca67" />

<img width="1399" height="860" alt="Jetpack SEO settings better title structure guidance" src="https://github.com/user-attachments/assets/8974c4ef-6625-407a-94ef-0a7ed08d16fc" />

## Related product discussion/links

* JETPACK-2050 · JETPACK-2051

## Does this pull request change what data or activity we track or use?

No. Presentational markup, styles and copy. The one back-end change adds `title_separator` to the existing page bootstrap — a read-only value derived from a core filter, never sent back, not persisted, and not user data.

## Testing instructions

Requires the `rsm_jetpack_seo` feature flag and an ungated plan (the Settings tab hides most modules on gated sites).

* Go to **Jetpack → SEO → Settings**. Confirm the seven modules listed above show an icon chip, that six show a completion status while **Search & social previews shows none**, and that the Schema-area cards are untouched.
* Confirm a status responds to a real change: switch off "Allow search engines to index this site" and Site visibility drops from Complete to Not started — the sitemap stops counting too, since it can't run.
* Add any single verification code (Bing will do) and confirm Site verification jumps straight to Complete rather than showing In progress.
* Expand **Title structure**. Every page type should show a `Preview:` line, including ones you've never touched, and untouched fields should read "Using the default title" in grey.
* **On a site with no tagline**, add `[Tagline]` to a format and confirm the preview leaves a real gap rather than substituting sample text.
* Go to **Jetpack → SEO → Overview** and confirm the four cards look **exactly** as before — this PR changes where their chip markup comes from, so the goal is that nothing changed.
* On a plan-gated site, confirm the reduced Settings tab (Site visibility, Site verification, grandfathered front-page description) still renders with chips and statuses intact.

### What I tested

* Package suites: **216 JS tests** and the PHP suite, plus `tsgo --noEmit`, ESLint, Stylelint and PHPCS — all clean. Phan crashes locally in this environment, so CI covers it.
* Ran the branch on a Jurassic Ninja site with the flag on and confirmed on screen: every chip, all seven statuses against that site's real stored settings, no leftover count badges anywhere, and the Overview pixel-identical to before the dedup.
* That test site has **no tagline**, which exercised the empty-placeholder path directly — it's what caught the sample-text substitution.

### What I did NOT test

* **Themes that filter `document_title_parts`.** The default-title preview replays core's composition and reads the separator from the site, but can't replay part-rewriting filters — those generally test the query (`is_singular()` and friends), which has no meaning in wp-admin. A theme that only changes the separator previews exactly; one that rewrites parts may preview differently from what it renders. Judged an acceptable and uncommon gap.
* RTL layouts. The chip uses logical properties inherited unchanged from the existing Overview chip, so RTL should be identical to what already ships, but I didn't view it.
* Windows/Linux high-contrast mode.
* A plan-gated site — the test site is ungated, so the reduced tab above is unverified on screen. The gating logic is untouched here.

### Known, not fixed

The front-page description's length limits are a mess, and the field is deliberately **uncapped** rather than advertising one this UI doesn't apply. Saving through this page applies no limit (`sanitize_front_page_meta_description` only strips tags); saving through the WP.com site-settings API truncates at 300. `functions.opengraph.php` truncates `og:description` at 197 — but that runs *before* the `jetpack_open_graph_tags` filter, and `Jetpack_SEO::set_custom_og_tags()` runs on that filter and overwrites the value, so this field is not subject to it. The help text therefore quotes only what search displays, and the counter is informational. Reconciling the two save paths is out of scope for a Settings pass.
