### PR TITLE
Search: gate the AI Answer block on the Jetpack AI master switch

### DIFF
--- a/projects/packages/search/changelog/add-search-ai-answers-master-gate
+++ b/projects/packages/search/changelog/add-search-ai-answers-master-gate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+AI Answers: Follow the Jetpack AI master switch in the search overlay and the AI Answer block — live on WordPress.com Simple, internal testing environments elsewhere ahead of release.

--- a/projects/packages/search/src/class-ai-answers.php
+++ b/projects/packages/search/src/class-ai-answers.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Search;
 
 use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Status\Host;
 
 /**
@@ -17,6 +18,8 @@ use Automattic\Jetpack\Status\Host;
 class AI_Answers {
 	const BEHAVIOR_META_KEY   = '_guideline_block_jetpack_search-ai-summary';
 	const BEHAVIOR_OPTION_KEY = 'jetpack_search_ai_behavior_instructions';
+	const AI_MODULE           = 'ai';
+	const AI_MASTER_OPTION    = 'jetpack_ai_enabled';
 	const ENABLED_OPTION      = 'jetpack_search_ai_answers_enabled';
 
 	/**
@@ -89,25 +92,8 @@ class AI_Answers {
 	}
 
 	/**
-	 * Whether AI Answers is enabled for the current site.
-	 */
-	public static function is_enabled() {
-		return (bool) apply_filters( 'jetpack_search_ai_answers_enabled', self::is_saved_on() );
-	}
-
-	/**
-	 * The saved AI Answers choice — the raw option, ignoring any gates on the filter.
-	 *
-	 * @since $$next-version$$
-	 *
-	 * @return bool
-	 */
-	public static function is_saved_on() {
-		return (bool) get_option( self::ENABLED_OPTION, false );
-	}
-
-	/**
-	 * Whether the site-wide AI gates currently allow AI Answers.
+	 * Whether the site-wide AI gates currently allow AI Answers — the reporting
+	 * predicate.
 	 *
 	 * The Jetpack plugin enforces the AI master switch and the host's AI opt-out
 	 * through the `jetpack_search_ai_answers_enabled` filter; probing the chain
@@ -125,7 +111,10 @@ class AI_Answers {
 			return true;
 		}
 
-		return (bool) apply_filters( 'jetpack_search_ai_answers_enabled', true );
+		// ANDed with the computed predicate so reporting can never be more
+		// permissive than enforcement — e.g. a Simple request where the plugin's
+		// filter never registered, or plugin/package version skew.
+		return (bool) apply_filters( 'jetpack_search_ai_answers_enabled', true ) && self::should_enforce_master();
 	}
 
 	/**
@@ -141,6 +130,65 @@ class AI_Answers {
 		}
 
 		return function_exists( 'jetpack_is_internal_testing_environment' ) && jetpack_is_internal_testing_environment();
+	}
+
+	/**
+	 * Whether this package should enforce the master switch — the rollout-scoped
+	 * enforcement predicate behind the block gate.
+	 *
+	 * Mirrors `Jetpack_AI_Settings::is_master_enabled()` in the Jetpack plugin —
+	 * the source of truth, unreferenceable from standalone installs. Computed
+	 * rather than filtered so no plugin can flip a gate that must hold.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return bool True when Jetpack AI is on, or when the site has no master switch.
+	 */
+	public static function should_enforce_master() {
+		if ( ! self::is_master_rollout_active() ) {
+			return true;
+		}
+
+		if ( ( new Host() )->is_wpcom_simple() ) {
+			return (bool) get_option( self::AI_MASTER_OPTION, true );
+		}
+
+		$modules = new Modules();
+
+		// Without the Jetpack plugin — a standalone Jetpack Search install — the
+		// `ai` module is not registered, so is_active() would report false for a
+		// master switch that was never installed. Don't gate those sites.
+		if ( ! in_array( self::AI_MODULE, $modules->get_available(), true ) ) {
+			return true;
+		}
+
+		// Availability is already proven above, so skip is_active()'s repeat intersect.
+		return $modules->is_active( self::AI_MODULE, false );
+	}
+
+	/**
+	 * The stored AI Answers choice, ignoring every gate.
+	 *
+	 * The dashboard shows this while the master switch is off, so a saved choice
+	 * isn't misreported back to the user as off.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return bool
+	 */
+	public static function is_saved_on() {
+		return (bool) get_option( self::ENABLED_OPTION, false );
+	}
+
+	/**
+	 * Whether AI Answers is enabled for the current site.
+	 */
+	public static function is_enabled() {
+		$enabled = (bool) apply_filters( 'jetpack_search_ai_answers_enabled', self::is_saved_on() );
+
+		// The master gate is applied after the filter chain so it cannot be
+		// filtered back on, matching `Jetpack_AI_Settings::is_ai_enabled()`.
+		return $enabled && self::should_enforce_master();
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/blocks/ai-answer/edit.jsx
+++ b/projects/packages/search/src/search-blocks/blocks/ai-answer/edit.jsx
@@ -11,6 +11,10 @@
  * gate in render.php so authors don't insert a block that won't render. The
  * paid-plan flag is localized onto `window.JetpackSearchBlocksConfig`
  * (`supportsPaidSearch`); the source of truth is the matching PHP gate.
+ *
+ * The Jetpack AI master switch gates the block the same way (`aiMasterEnabled`
+ * on the same config object), and its notice wins over the upgrade prompt —
+ * never upsell a plan while site-wide AI is off.
  */
 import { InspectorControls, useBlockProps } from '@wordpress/block-editor';
 import { Button, PanelBody, Placeholder, TextControl, ToggleControl } from '@wordpress/components';
@@ -24,10 +28,10 @@ const SAMPLE_CITATIONS = [
 // Editor preview defaults to "paid" when the localized config isn't present
 // (e.g. a Jest harness or a non-enqueued bundle context) so existing tests
 // see the full preview and the gate is opt-in via an explicit `false`.
-const supportsPaidSearch = () =>
+const configFlagOn = key =>
 	typeof window === 'undefined' ||
 	! window.JetpackSearchBlocksConfig ||
-	window.JetpackSearchBlocksConfig.supportsPaidSearch !== false;
+	window.JetpackSearchBlocksConfig[ key ] !== false;
 
 const UPGRADE_URL = 'https://jetpack.com/upgrade/search/?utm_source=ai-answer-block';
 
@@ -42,7 +46,21 @@ const UPGRADE_URL = 'https://jetpack.com/upgrade/search/?utm_source=ai-answer-bl
 export default function AiAnswerEdit( { attributes, setAttributes } ) {
 	const blockProps = useBlockProps();
 
-	if ( ! supportsPaidSearch() ) {
+	if ( ! configFlagOn( 'aiMasterEnabled' ) ) {
+		return (
+			<div { ...blockProps }>
+				<Placeholder
+					label={ __( 'AI Answer', 'jetpack-search-pkg' ) }
+					instructions={ __(
+						'Jetpack AI is turned off for this site, so visitors won’t see this block. Turn Jetpack AI on to show AI-generated answers in your search results.',
+						'jetpack-search-pkg'
+					) }
+				/>
+			</div>
+		);
+	}
+
+	if ( ! configFlagOn( 'supportsPaidSearch' ) ) {
 		return (
 			<div { ...blockProps }>
 				<Placeholder

--- a/projects/packages/search/src/search-blocks/blocks/ai-answer/render.php
+++ b/projects/packages/search/src/search-blocks/blocks/ai-answer/render.php
@@ -3,16 +3,12 @@
  * AI Answer block render.
  *
  * Renders the panel scaffold that the Interactivity store hydrates with the
- * streaming brief / extended AI answer. The author's decision to insert the
- * block in their post content is the only opt-in switch — there's no site-wide
- * option gate here. The `jetpack_search_ai_answers_enabled` option still
- * governs the instant-search overlay's AI Answers, which is the default UX
- * on any search page; the embedded block is an explicit opt-in surface.
+ * streaming AI answer. Inserting the block is its own opt-in switch — the
+ * `jetpack_search_ai_answers_enabled` option governs the overlay, not the block.
  *
- * AI Answer is a paid feature, so the render is additionally gated on the
- * site having a paid Search plan. Free / no-plan sites emit nothing — the
- * saved block instance is silently hidden on the front end, matching how
- * WordAds / Premium Content behave when their plan check fails.
+ * The gates below (paid Search plan, host AI opt-out, Jetpack AI master
+ * switch) emit nothing when they fail, matching how WordAds / Premium
+ * Content hide on a failed plan check.
  *
  * @package automattic/jetpack-search
  */
@@ -30,6 +26,10 @@ if ( ! Search_Blocks::supports_paid_search() ) {
 // Host-owner AI opt-out (core's wp_supports_ai() / WP_AI_SUPPORT). The overlay
 // already honors it through the plugin's filter gate; the block must agree.
 if ( ! AI_Answers::host_allows_ai() ) {
+	return;
+}
+
+if ( ! AI_Answers::should_enforce_master() ) {
 	return;
 }
 

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -684,6 +684,7 @@ class Search_Blocks {
 					'isWooCommerceBlocksEnabled' => self::woocommerce_blocks_enabled(),
 					'woocommerceOnlyBlocks'      => self::woocommerce_only_block_names(),
 					'supportsPaidSearch'         => self::supports_paid_search(),
+					'aiMasterEnabled'            => AI_Answers::should_enforce_master(),
 					'supportedCustomTaxonomies'  => self::supported_custom_taxonomies(),
 					'customTaxonomyMap'          => (object) self::custom_taxonomy_map(),
 					// Resolved the same way `search-results/render.php` resolves the

--- a/projects/packages/search/tests/js/search-blocks/ai-answer-edit.test.jsx
+++ b/projects/packages/search/tests/js/search-blocks/ai-answer-edit.test.jsx
@@ -140,4 +140,38 @@ describe( 'AiAnswerEdit', () => {
 		expect( screen.queryByTestId( 'placeholder' ) ).not.toBeInTheDocument();
 		expect( screen.getByText( 'AI answer' ) ).toBeInTheDocument();
 	} );
+
+	it( 'renders the disabled Placeholder instead of the preview when aiMasterEnabled is false', () => {
+		globalThis.JetpackSearchBlocksConfig = { aiMasterEnabled: false };
+		render( <AiAnswerEdit attributes={ {} } setAttributes={ () => {} } /> );
+
+		expect( screen.getByTestId( 'placeholder' ) ).toBeInTheDocument();
+		expect(
+			screen.getByText(
+				'Jetpack AI is turned off for this site, so visitors won’t see this block. Turn Jetpack AI on to show AI-generated answers in your search results.'
+			)
+		).toBeInTheDocument();
+		expect( screen.queryByText( 'Getting started with WordPress' ) ).not.toBeInTheDocument();
+		expect( screen.queryByTestId( 'inspector' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'shows the disabled Placeholder, not the upgrade prompt, when the master is off on a free site', () => {
+		// Upselling a paid plan while the site has AI switched off would sell
+		// a feature that still wouldn't run — the master notice wins.
+		globalThis.JetpackSearchBlocksConfig = { aiMasterEnabled: false, supportsPaidSearch: false };
+		render( <AiAnswerEdit attributes={ {} } setAttributes={ () => {} } /> );
+
+		expect( screen.getByTestId( 'placeholder' ) ).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'link', { name: 'Upgrade Jetpack Search' } )
+		).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the preview when the config lacks aiMasterEnabled', () => {
+		globalThis.JetpackSearchBlocksConfig = {};
+		render( <AiAnswerEdit attributes={ {} } setAttributes={ () => {} } /> );
+
+		expect( screen.queryByTestId( 'placeholder' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( 'AI answer' ) ).toBeInTheDocument();
+	} );
 } );

--- a/projects/packages/search/tests/php/AI_Answers_Test.php
+++ b/projects/packages/search/tests/php/AI_Answers_Test.php
@@ -73,6 +73,110 @@ class AI_Answers_Test extends Search_TestCase {
 	// -------------------------------------------------------------------------
 
 	/**
+	 * Off Simple, the `ai` module is the master switch.
+	 */
+	public function test_should_enforce_master_is_true_when_the_ai_module_is_active() {
+		$this->turn_ai_master_on();
+
+		$this->assertTrue( AI_Answers::should_enforce_master() );
+	}
+
+	public function test_should_enforce_master_is_false_when_the_ai_module_is_inactive() {
+		$this->turn_ai_master_off();
+
+		$this->assertFalse( AI_Answers::should_enforce_master() );
+	}
+
+	public function test_should_enforce_master_is_true_when_the_ai_module_is_not_registered() {
+		// Standalone Jetpack Search plugin: no Jetpack plugin, so no `ai` module and
+		// no master switch to obey. Sites that never had one must not be gated.
+		$this->assertTrue( AI_Answers::should_enforce_master() );
+	}
+
+	/**
+	 * Turn the Simple master off.
+	 *
+	 * Stores the empty string rather than `false`, which is what WordPress
+	 * persists for a false option — and what WorDBless can round-trip, since it
+	 * returns the default for a stored `false`.
+	 */
+	private function disable_simple_master() {
+		update_option( AI_Answers::AI_MASTER_OPTION, '' );
+	}
+
+	public function test_should_enforce_master_reads_the_option_on_wpcom_simple() {
+		Constants::set_constant( 'IS_WPCOM', true );
+		$this->disable_simple_master();
+
+		$this->assertFalse( AI_Answers::should_enforce_master() );
+	}
+
+	public function test_should_enforce_master_defaults_to_true_on_wpcom_simple() {
+		Constants::set_constant( 'IS_WPCOM', true );
+
+		$this->assertTrue( AI_Answers::should_enforce_master() );
+	}
+
+	public function test_should_enforce_master_holds_on_wpcom_simple_regardless_of_environment() {
+		// Simple keeps its option contract: enforcement applies there even
+		// outside internal testing environments (is_master_rollout_active()).
+		Constants::set_constant( 'IS_WPCOM', true );
+		$this->disable_simple_master();
+		$GLOBALS['jetpack_search_test_internal_env'] = false;
+
+		$this->assertFalse( AI_Answers::should_enforce_master() );
+	}
+
+	public function test_should_enforce_master_ignores_the_ai_module_on_wpcom_simple() {
+		// Modules never run on Simple, and Modules::is_active() answers true there
+		// unconditionally — the option stays the master.
+		Constants::set_constant( 'IS_WPCOM', true );
+		$this->turn_ai_master_on();
+		$this->disable_simple_master();
+
+		$this->assertFalse( AI_Answers::should_enforce_master() );
+	}
+
+	public function test_should_enforce_master_is_true_outside_internal_testing_environments() {
+		// The master switch UI ships internal-only for now, so a public site must not be
+		// gated on a switch its owner cannot see. Module present but inactive, yet ungated.
+		$this->turn_ai_module_off();
+		$GLOBALS['jetpack_search_test_internal_env'] = false;
+
+		$this->assertTrue( AI_Answers::should_enforce_master() );
+	}
+
+	public function test_is_enabled_ignores_the_module_outside_internal_testing_environments() {
+		// Module-only setup: pins that the package's own enforcement is env-scoped.
+		// (With the Jetpack plugin loaded, its filter gate still applies publicly.)
+		update_option( 'jetpack_search_ai_answers_enabled', true );
+		$this->turn_ai_module_off();
+		$GLOBALS['jetpack_search_test_internal_env'] = false;
+
+		$this->assertTrue( AI_Answers::is_enabled() );
+	}
+
+	public function test_is_enabled_is_false_when_the_master_is_off() {
+		// The saved choice persists while the master is off; only is_enabled() gates it.
+		update_option( 'jetpack_search_ai_answers_enabled', true );
+		$this->turn_ai_master_off();
+
+		$this->assertTrue( AI_Answers::is_saved_on() );
+		$this->assertFalse( AI_Answers::is_enabled() );
+	}
+
+	public function test_is_enabled_master_gate_cannot_be_filtered_back_on() {
+		// The master gate is applied after the filter chain, so a filter cannot
+		// re-enable AI Answers while the site-wide switch is off.
+		$this->turn_ai_master_off();
+		add_filter( 'jetpack_search_ai_answers_enabled', '__return_true' );
+
+		$this->assertFalse( AI_Answers::is_enabled() );
+
+		remove_filter( 'jetpack_search_ai_answers_enabled', '__return_true' );
+	}
+
+	/**
 	 * The saved choice is the raw option.
 	 */
 	public function test_is_saved_on_returns_the_raw_option() {
@@ -89,20 +193,9 @@ class AI_Answers_Test extends Search_TestCase {
 		remove_filter( 'jetpack_search_ai_answers_enabled', '__return_true' );
 	}
 
-	public function test_is_enabled_is_false_when_the_master_is_off() {
-		// The saved choice persists while the master is off; only is_enabled() gates it.
-		update_option( 'jetpack_search_ai_answers_enabled', true );
-		$this->turn_ai_master_off();
-
-		$this->assertTrue( AI_Answers::is_saved_on() );
-		$this->assertFalse( AI_Answers::is_enabled() );
-
-		delete_option( 'jetpack_search_ai_answers_enabled' );
-	}
-
 	public function test_is_master_enabled_is_true_without_a_master_gate() {
 		// Standalone Jetpack Search plugin: nothing subscribes to the filter, so
-		// there is no master switch to obey and the site must not be gated.
+		// there is no master switch to obey and the site must not report gated.
 		$this->assertTrue( AI_Answers::is_master_enabled() );
 	}
 
@@ -136,6 +229,16 @@ class AI_Answers_Test extends Search_TestCase {
 		$this->assertFalse( AI_Answers::is_master_enabled() );
 	}
 
+	public function test_is_master_enabled_never_reports_above_enforcement_on_wpcom_simple() {
+		// On Simple the probe depends on the plugin's filter being registered,
+		// which wpcom's loader doesn't guarantee per request. With no filter and
+		// the option off, reporting must still follow enforcement.
+		Constants::set_constant( 'IS_WPCOM', true );
+		update_option( AI_Answers::AI_MASTER_OPTION, '' );
+
+		$this->assertFalse( AI_Answers::is_master_enabled() );
+	}
+
 	public function test_is_enabled_still_gated_outside_internal_testing_environments() {
 		// Enforcement is the plugin's public filter — only the *reporting* is
 		// scoped. A public master-off site still reports the feature off.
@@ -149,7 +252,7 @@ class AI_Answers_Test extends Search_TestCase {
 	}
 
 	public function test_is_master_enabled_ignores_the_option() {
-		// The master state is about the gates, not the feature's saved choice.
+		// The reported master state is about the gates, not the feature's saved choice.
 		update_option( 'jetpack_search_ai_answers_enabled', false );
 		$this->turn_ai_master_on();
 		$this->assertTrue( AI_Answers::is_master_enabled() );

--- a/projects/packages/search/tests/php/Ai_Answer_Render_Test.php
+++ b/projects/packages/search/tests/php/Ai_Answer_Render_Test.php
@@ -93,6 +93,7 @@ class Ai_Answer_Render_Test extends TestCase {
 		remove_filter( 'wp_supports_ai', '__return_false' );
 		remove_filter( 'wp_supports_ai', '__return_true' );
 		$this->remove_ai_master_filters();
+		unset( $GLOBALS['jetpack_search_test_internal_env'] );
 		parent::tearDown();
 	}
 
@@ -225,6 +226,18 @@ class Ai_Answer_Render_Test extends TestCase {
 		$this->assertStringNotContainsString( 'data-wp-interactive', $markup );
 	}
 
+	public function test_renders_nothing_when_ai_master_is_off() {
+		// Paid plan, but the site-wide Jetpack AI master switch is off: the
+		// block must emit nothing, same as a failed plan check — the master
+		// is a site-wide off switch, not a preference the block may ignore.
+		$this->turn_ai_master_off();
+
+		$markup = $this->render();
+
+		$this->assertStringNotContainsString( 'jp-search-answers-panel', $markup );
+		$this->assertStringNotContainsString( 'data-wp-interactive', $markup );
+	}
+
 	public function test_renders_with_the_master_on_independent_of_site_option() {
 		// The contract's Search row: with the master on, the site option only
 		// governs the overlay — the embedded block renders either way.
@@ -259,6 +272,39 @@ class Ai_Answer_Render_Test extends TestCase {
 
 		$this->assertStringNotContainsString( 'jp-search-answers-panel', $markup );
 		$this->assertStringNotContainsString( 'data-wp-interactive', $markup );
+	}
+
+	public function test_renders_when_ai_master_is_on() {
+		$this->turn_ai_master_on();
+
+		$markup = $this->render();
+
+		$this->assertStringContainsString( 'jp-search-answers-panel', $markup );
+		$this->assertStringContainsString( 'data-wp-interactive="jetpack-search"', $markup );
+	}
+
+	public function test_renders_when_master_is_off_outside_internal_testing_environments() {
+		// The master switch UI ships internal-only for now, so on a public site
+		// the front-end gate must stay inert: even with the master off, the
+		// block keeps rendering. If the rollout scoping ever moves out of
+		// `should_enforce_master()`, this pin has to change deliberately with it.
+		$this->turn_ai_master_off();
+		$GLOBALS['jetpack_search_test_internal_env'] = false;
+
+		$markup = $this->render();
+
+		$this->assertStringContainsString( 'jp-search-answers-panel', $markup );
+		$this->assertStringContainsString( 'data-wp-interactive="jetpack-search"', $markup );
+	}
+
+	public function test_renders_when_ai_module_is_not_registered() {
+		// Standalone Jetpack Search: no Jetpack plugin, so the `ai` module —
+		// and with it the master switch — was never installed. Those sites
+		// must keep rendering the block.
+		$markup = $this->render();
+
+		$this->assertStringContainsString( 'jp-search-answers-panel', $markup );
+		$this->assertStringContainsString( 'data-wp-interactive="jetpack-search"', $markup );
 	}
 
 	public function test_renders_when_the_host_allows_ai() {

--- a/projects/packages/search/tests/php/Settings_Test.php
+++ b/projects/packages/search/tests/php/Settings_Test.php
@@ -13,6 +13,13 @@ use Automattic\Jetpack\Search\TestCase as Search_TestCase;
  * Unit tests for the Settings class.
  */
 class Settings_Test extends Search_TestCase {
+	use Toggles_Ai_Master;
+
+	public function tearDown(): void {
+		$this->remove_ai_master_filters();
+		parent::tearDown();
+	}
+
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
 		// Instantiating Settings hooks settings_register onto admin_init and
@@ -28,6 +35,35 @@ class Settings_Test extends Search_TestCase {
 		$setting = $registered[ Options::OPTION_PREFIX . 'ai_answers_enabled' ];
 		$this->assertEquals( 'boolean', $setting['type'] );
 		$this->assertFalse( $setting['default'] );
+	}
+
+	public function test_ai_answers_setting_persists_while_the_ai_master_is_off() {
+		// The AI feature-settings endpoint writes feature choices even while the
+		// master is off so they survive it; this option follows the same contract
+		// as the other AI feature options. Enforcement lives in is_enabled().
+		$this->turn_ai_master_off();
+
+		update_option( Options::OPTION_PREFIX . 'ai_answers_enabled', true );
+
+		$this->assertTrue( (bool) get_option( Options::OPTION_PREFIX . 'ai_answers_enabled', false ) );
+		$this->assertFalse( AI_Answers::is_enabled() );
+	}
+
+	public function test_ai_answers_setting_can_still_be_turned_off_while_the_ai_master_is_off() {
+		update_option( Options::OPTION_PREFIX . 'ai_answers_enabled', true );
+		$this->turn_ai_master_off();
+
+		update_option( Options::OPTION_PREFIX . 'ai_answers_enabled', false );
+
+		$this->assertFalse( (bool) get_option( Options::OPTION_PREFIX . 'ai_answers_enabled', false ) );
+	}
+
+	public function test_ai_answers_setting_can_be_turned_on_while_the_ai_master_is_on() {
+		$this->turn_ai_master_on();
+
+		update_option( Options::OPTION_PREFIX . 'ai_answers_enabled', true );
+
+		$this->assertTrue( (bool) get_option( Options::OPTION_PREFIX . 'ai_answers_enabled', false ) );
 	}
 
 	public function test_settings_register_registers_result_format() {

--- a/projects/packages/search/tests/php/trait-toggles-ai-master.php
+++ b/projects/packages/search/tests/php/trait-toggles-ai-master.php
@@ -8,14 +8,43 @@
 namespace Automattic\Jetpack\Search;
 
 /**
- * The Jetpack plugin enforces the master switch (and the host's AI opt-out)
- * through the `jetpack_search_ai_answers_enabled` filter; these helpers stand
- * in for its gate callback. Call remove_ai_master_filters() in tearDown().
+ * On a real site the master exists twice: as the `ai` module (read by
+ * should_enforce_master()) and as the Jetpack plugin's restrictive callback on
+ * the `jetpack_search_ai_answers_enabled` filter (read by is_master_enabled()).
+ * These helpers stand in for both so the two predicates agree the way they do
+ * in production. Call remove_ai_master_filters() in tearDown().
  */
 trait Toggles_Ai_Master {
 
 	/**
-	 * The plugin's gate callback with the master off: restrictive for any input.
+	 * Register `ai` as an available module, the way the Jetpack plugin does.
+	 *
+	 * @param array $modules Available module slugs.
+	 * @return array
+	 */
+	public function add_ai_module( $modules ) {
+		$modules[] = AI_Answers::AI_MODULE;
+		return $modules;
+	}
+
+	/**
+	 * Report `ai` among the active modules.
+	 *
+	 * @param mixed  $value Option value.
+	 * @param string $name  Option name.
+	 * @return mixed
+	 */
+	public function activate_ai_module( $value, $name ) {
+		if ( 'active_modules' !== $name ) {
+			return $value;
+		}
+		// Append rather than replace, so a test that activated other modules
+		// (e.g. search) doesn't silently lose them.
+		return array_unique( array_merge( (array) $value, array( AI_Answers::AI_MODULE ) ) );
+	}
+
+	/**
+	 * The plugin's filter gate with the master off: restrictive for any input.
 	 *
 	 * @return bool
 	 */
@@ -24,7 +53,7 @@ trait Toggles_Ai_Master {
 	}
 
 	/**
-	 * The plugin's gate callback with the master on: passes the value through.
+	 * The plugin's filter gate with the master on: passes the value through.
 	 *
 	 * @param mixed $enabled Filtered value.
 	 * @return bool
@@ -34,10 +63,21 @@ trait Toggles_Ai_Master {
 	}
 
 	/**
-	 * Site has a master switch and it is off.
+	 * Only the module half, off: `ai` available but inactive, no filter gate.
+	 * Models the package-side view alone — used by the env-scoping tests, which
+	 * pin should_enforce_master() without the plugin's chain in the way.
+	 */
+	protected function turn_ai_module_off() {
+		$this->remove_ai_master_filters();
+		add_filter( 'jetpack_get_available_standalone_modules', array( $this, 'add_ai_module' ) );
+	}
+
+	/**
+	 * Site has a master switch and it is off: the `ai` module is available but
+	 * inactive, and the plugin's filter gate folds false into the chain.
 	 */
 	protected function turn_ai_master_off() {
-		$this->remove_ai_master_filters();
+		$this->turn_ai_module_off();
 		add_filter( 'jetpack_search_ai_answers_enabled', array( $this, 'apply_master_off_gate' ) );
 	}
 
@@ -46,6 +86,8 @@ trait Toggles_Ai_Master {
 	 */
 	protected function turn_ai_master_on() {
 		$this->remove_ai_master_filters();
+		add_filter( 'jetpack_get_available_standalone_modules', array( $this, 'add_ai_module' ) );
+		add_filter( 'jetpack_options', array( $this, 'activate_ai_module' ), 10, 2 );
 		add_filter( 'jetpack_search_ai_answers_enabled', array( $this, 'apply_master_on_gate' ) );
 	}
 
@@ -53,6 +95,8 @@ trait Toggles_Ai_Master {
 	 * Drop everything the helpers added.
 	 */
 	protected function remove_ai_master_filters() {
+		remove_filter( 'jetpack_get_available_standalone_modules', array( $this, 'add_ai_module' ) );
+		remove_filter( 'jetpack_options', array( $this, 'activate_ai_module' ) );
 		remove_filter( 'jetpack_search_ai_answers_enabled', array( $this, 'apply_master_off_gate' ) );
 		remove_filter( 'jetpack_search_ai_answers_enabled', array( $this, 'apply_master_on_gate' ) );
 	}


### PR DESCRIPTION
Fixes #

## Proposed changes

Stacked on #51538. This PR is now just one thing: **when the site-wide Jetpack AI switch is off, the AI Answer block goes dark.**

* On the front end the block renders nothing — no markup, no request to the AI service.
* In the editor the block shows an "AI is turned off" message instead of its preview.
* A filter can't turn it back on while the switch is off.
* Like the rest of the stack, this only applies in internal testing environments (and on WordPress.com Simple, where the switch is the existing option) until launch. Regular sites see no change.
* Pinned by test: with the switch **on**, the AI Answers site option still only affects the search overlay — the block renders regardless, as before.

## Related product discussion/links

* Internal: FORNO-427, and the Jetpack AI toggles contract P2.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Live run on an Atomic site, 26–27 Aug: 36/36 rows — onebin `3c588`.

Automated: from `projects/packages/search/` run `composer phpunit`, `pnpm test-scripts`, `pnpm test-url-tests`.

Manual, on a Jurassic Ninja site with paid Search and a page containing the AI Answer block:
* `wp jetpack module deactivate ai`, reload the page: no block markup, no AI request in the network panel; in the editor the block shows the AI-off message.
* `wp jetpack module activate ai`: the block is back.
* `wp option update jetpack_search_ai_answers_enabled 0`: the block is unchanged — only the overlay follows that option.

---

🤖 Written by Claude, reviewed by me.

