### PR TITLE
SEO Tools: only use per-page SEO title on a static front page

### DIFF
--- a/projects/plugins/jetpack/changelog/jetpack-2052-seo-front-page-title
+++ b/projects/plugins/jetpack/changelog/jetpack-2052-seo-front-page-title
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+SEO Tools: Stop the newest post's custom SEO title from replacing the homepage title on sites that show latest posts.

--- a/projects/plugins/jetpack/modules/seo-tools/class-jetpack-seo-titles.php
+++ b/projects/plugins/jetpack/modules/seo-tools/class-jetpack-seo-titles.php
@@ -97,11 +97,15 @@ class Jetpack_SEO_Titles {
 			return $default_title;
 		}
 
-		// If it's a singular -- page or post -- check for a meta title override.
-		// Also check the front page: when a static page is used as the homepage and the
-		// user has set a per-page SEO title, that title should take precedence over (or
-		// serve as a fallback for) the site-wide Front Page title format.
-		if ( 'pages' === $page_type || 'posts' === $page_type || 'front_page' === $page_type ) {
+		// If it's a singular -- page or post -- check for a meta title override. Also
+		// check a static front page, where get_post() returns that page. On a latest-posts
+		// homepage it would instead return the first post in the loop, letting the newest
+		// post's SEO title hijack the homepage title.
+		$check_post_meta = 'pages' === $page_type
+			|| 'posts' === $page_type
+			|| ( 'front_page' === $page_type && 'page' === get_option( 'show_on_front' ) );
+
+		if ( $check_post_meta ) {
 			$post = get_post();
 			if ( $post instanceof WP_Post ) {
 				$custom_title = get_post_meta( $post->ID, Jetpack_SEO_Posts::HTML_TITLE_META_KEY, true );

--- a/projects/plugins/jetpack/tests/php/modules/seo-tools/Jetpack_SEO_Titles_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/seo-tools/Jetpack_SEO_Titles_Test.php
@@ -59,6 +59,45 @@ class Jetpack_SEO_Titles_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * When the front page lists the latest posts, there is no page carrying a per-page
+	 * SEO title. get_custom_title() must not fall back to the meta of the first post in
+	 * the loop, which would let the newest post's SEO title hijack the homepage title.
+	 *
+	 * Regression test for: newest post's custom SEO title overriding the homepage title
+	 * on latest-posts sites.
+	 */
+	public function test_front_page_ignores_post_meta_when_showing_latest_posts() {
+		// Create a post with a custom SEO title. It will be the first post in the loop.
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, Jetpack_SEO_Posts::HTML_TITLE_META_KEY, 'Newest Post SEO Title' );
+
+		// The site lists the latest posts on the front page.
+		update_option( 'show_on_front', 'posts' );
+
+		// The site-wide Front Page title format is empty, so the default title should win.
+		update_option(
+			Jetpack_SEO_Titles::TITLE_FORMATS_OPTION,
+			array(
+				'front_page' => array(),
+				'posts'      => array(),
+				'pages'      => array(),
+				'groups'     => array(),
+				'archives'   => array(),
+			)
+		);
+
+		// Navigate to the front page so WordPress conditional tags work correctly.
+		$this->go_to( home_url( '/' ) );
+
+		$title = Jetpack_SEO_Titles::get_custom_title( 'Default Title' );
+
+		$this->assertSame( 'Default Title', $title );
+
+		// Clean up.
+		delete_option( Jetpack_SEO_Titles::TITLE_FORMATS_OPTION );
+	}
+
+	/**
 	 * Test for expected output after sanitizing the custom SEO page title structures.
 	 */
 	public function test_sanitize_title_formats() {

--- a/projects/plugins/jetpack/tests/php/modules/seo-tools/Jetpack_SEO_Titles_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/seo-tools/Jetpack_SEO_Titles_Test.php
@@ -98,6 +98,43 @@ class Jetpack_SEO_Titles_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * On a latest-posts homepage the site-wide Front Page title format should still be
+	 * applied. This proves the front page falls through to the format lookup rather than
+	 * returning early, which asserting on the default title alone cannot show.
+	 */
+	public function test_front_page_uses_configured_format_when_showing_latest_posts() {
+		// Create a post with a custom SEO title. It will be the first post in the loop.
+		$post_id = self::factory()->post->create();
+		update_post_meta( $post_id, Jetpack_SEO_Posts::HTML_TITLE_META_KEY, 'Newest Post SEO Title' );
+
+		// The site lists the latest posts on the front page.
+		update_option( 'show_on_front', 'posts' );
+
+		// A site-wide Front Page title format is configured.
+		update_option(
+			Jetpack_SEO_Titles::TITLE_FORMATS_OPTION,
+			array(
+				'front_page' => array(
+					array(
+						'type'  => 'string',
+						'value' => 'Site Home Page',
+					),
+				),
+			)
+		);
+
+		// Navigate to the front page so WordPress conditional tags work correctly.
+		$this->go_to( home_url( '/' ) );
+
+		$title = Jetpack_SEO_Titles::get_custom_title( 'Default Title' );
+
+		$this->assertSame( 'Site Home Page', $title );
+
+		// Clean up.
+		delete_option( Jetpack_SEO_Titles::TITLE_FORMATS_OPTION );
+	}
+
+	/**
 	 * Test for expected output after sanitizing the custom SEO page title structures.
 	 */
 	public function test_sanitize_title_formats() {


### PR DESCRIPTION
## Proposed changes

* Only consult the per-post `jetpack_seo_html_title` meta on the front page when the front page is actually a static page (`show_on_front === 'page'`).

Since #50845, `Jetpack_SEO_Titles::get_custom_title()` checks the per-post SEO title meta for the `front_page` page type. That is right for a static page set as the homepage, but `get_page_type()` returns `front_page` for *any* `is_front_page()`, including a latest-posts homepage. There, `get_post()` returns the first post in the main loop, so the **newest post's custom SEO title becomes the homepage title** — and it changes again with every new post.

The same method feeds `Jetpack_SEO::set_custom_og_tags()`, so `og:title` is affected too.

Live example — a site with a latest-posts homepage renders its newest post's SEO title in place of the site title:

```html
<title>Paolo Belcastro of Automattic on how a text-first culture is the key to asynchronous communication.</title>
<meta property="og:title" content="Paolo Belcastro of Automattic on how a text-first culture is the key to asynchronous communication." />
```

The site title is "The Full Stack Leader". Only page 1 of the homepage is wrong; `/page/2/`, single posts, pages, and archives are all correct.

There is also a scope angle worth flagging: `jetpack_seo_html_title` is registered with `show_in_rest` and no `auth_callback`, so it falls back to core's `edit_post` gate — a per-post capability. On a latest-posts homepage there is no page object to check that capability against, so any user who could publish a post could set the sitewide `<title>` and `og:title` for as long as their post stayed newest. Gating on `show_on_front` means `get_post()` in this branch only ever resolves to the actual static front page, which is writable only by whoever can edit that page.

Adds a regression test for the latest-posts homepage. The existing test only covered the static-front-page case, which is how this got through.

## Related product discussion/links

* https://linear.app/a8c/issue/JETPACK-2052/seo-tools-newest-posts-custom-seo-title-overrides-the-homepage-title
* Introduced in #50845

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Regression (the bug this fixes):

1. Settings → Reading → set the homepage to **Your latest posts**.
2. Enable Jetpack SEO Tools.
3. Edit the most recently published post, open the SEO panel in the editor sidebar, and set an **SEO title** distinct from the post title.
4. Load the homepage and view source. On trunk, `<title>` and `og:title` are the post's SEO title. With this branch, they are the site title (or the Front Page title format, if one is set).
5. Confirm `/page/2/`, a single post, a page, and a category archive are all unchanged.

No regression on the original fix:

6. Settings → Reading → set the homepage to **A static page**.
7. Give that page a custom SEO title and leave the site-wide Front Page title format blank.
8. Load the homepage — `<title>` is still the page's custom SEO title.

Automated:

```
jp docker phpunit jetpack -- --filter=Jetpack_SEO
```

Locally: 14 tests / 41 assertions pass with the fix. Reverting only the production file and re-running fails the new test with `-'Default Title'` / `+'Newest Post SEO Title'`, confirming it captures the regression.


## Definition of done

Each item is something a reviewer can check directly, with where to look.

| # | What to validate | How | Expected |
|---|---|---|---|
| 1 | The reported bug is gone | Latest-posts homepage, newest post has an SEO title set. View source on `/`. | `<title>` and `og:title` are the site title (or the Front Page title format), not the post's SEO title |
| 2 | #50845's fix still works | Set a static page as the homepage, give it an SEO title, leave the Front Page title format blank. View source on `/`. | `<title>` is that page's SEO title — unchanged from before this PR |
| 3 | Nothing else moved | View source on a single post, a page, a category archive, and `/page/2/` | All titles unchanged from trunk |
| 4 | The tests are load-bearing | Revert only `class-jetpack-seo-titles.php` to trunk, keep the tests, run the suite | Both new tests fail: `+'Newest Post SEO Title'` against `-'Default Title'` and `-'Site Home Page'` |
| 5 | The suite passes | `jp docker phpunit jetpack -- --filter=Jetpack_SEO` | 15 tests, 42 assertions, green |
| 6 | CI is clean | PR checks | Green, or any failure identified as unrelated to SEO tools |

### Scope of the condition

The fix turns on one question: is the front page a static page or the posts index? `get_page_type()` returns `front_page` for both, which is what made the original change over-reach. `is_front_page()` is only true in two cases — `show_on_front === 'posts'` with `is_home()`, or `show_on_front === 'page'` with a matching `page_on_front` — so gating on `show_on_front` partitions them exactly, with no third case to worry about. If `page_on_front` is unset, `is_front_page()` is never true and this branch is not reached at all.

### Not in scope

Changing how `jetpack_seo_html_title` is registered or sanitized. It has no `sanitize_callback` today; that is pre-existing and deliberately untouched here.
