### PR TITLE
Premium Analytics: elide a shared month or year in date ranges where the locale allows it

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1766-elide-date-ranges
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1766-elide-date-ranges
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Shorten date ranges by eliding a month or year shared by both ends, where the site's language has a rule for it.

--- a/projects/packages/premium-analytics/packages/formatters/README.md
+++ b/projects/packages/premium-analytics/packages/formatters/README.md
@@ -89,15 +89,37 @@ Format a date range into a human-readable string.
 Returns `''` when range or dates are missing.
 
 ```typescript
+// On a site left on its locale's default date format:
 formatDateRange( { from, to } );
-// same day: 'June 21, 2025'
-// range:    'June 21, 2025 – June 25, 2025'
+// same day:    'June 21, 2025'
+// same month:  'June 21 – 25, 2025'
+// same year:   'June 21 – July 25, 2025'
+// cross-year:  'June 21, 2024 – July 25, 2025'
+
+// The same-month range above on an es_ES site:
+// '21–25 de junio de 2025'
 ```
 
-Both ends are spelled out in full. Eliding the shared month or year
-("Jun 21-25, 2025") is an English typographic convention that does not carry
-over — on an es_ES site it yields "21 de junio-25 de junio de 2025" — and
-WordPress publishes no per-locale elision rules to draw on.
+A month or year shared by both ends is elided where the site's locale has a
+rule for it. Those rules are not written by hand — "Jun 21-25, 2025" is an
+English convention that, translated literally, gives the wrong result in
+Spanish. They are borrowed from CLDR via `Intl.DateTimeFormat.formatRange()`,
+which only holds where WordPress and CLDR agree on what a single date looks
+like. Two checks establish that per site, so no allowlist of trusted locales
+has to be maintained:
+
+1. `Intl` renders a single date exactly as `formatDate` does. A site with a
+   custom `date_format` fails here and keeps the format it asked for.
+2. `Intl` builds an un-elidable range out of that same rendering. `ja` and `zh`
+   fail here: their single dates read `2025年6月21日`, but their ranges switch
+   to `2025/06/21～2025/06/25`.
+
+Where neither holds, both ends are spelled out in full instead:
+
+```typescript
+// Site with a custom `date_format` of 'd/m/Y':
+// '21/06/2025 – 25/06/2025'
+```
 
 | Parameter | Type                         | Description       |
 | --------- | ---------------------------- | ----------------- |

--- a/projects/packages/premium-analytics/packages/formatters/README.md
+++ b/projects/packages/premium-analytics/packages/formatters/README.md
@@ -104,17 +104,19 @@ A month or year shared by both ends is elided where the site's locale has a
 rule for it. Those rules are not written by hand — "Jun 21-25, 2025" is an
 English convention that, translated literally, gives the wrong result in
 Spanish. They are borrowed from CLDR via `Intl.DateTimeFormat.formatRange()`,
-which only holds where WordPress and CLDR agree on what a single date looks
-like. Two checks establish that per site, so no allowlist of trusted locales
-has to be maintained:
+which only holds where WordPress and CLDR agree on how dates look. Two checks
+establish that per site, so no allowlist of trusted locales has to be
+maintained:
 
-1. `Intl` renders a single date exactly as `formatDate` does. A site with a
-   custom `date_format` fails here and keeps the format it asked for.
+1. `Intl` renders representative dates exactly as `formatDate` does. A site
+   with a custom `date_format` or different month translations fails here and
+   keeps the format it asked for.
 2. `Intl` builds an un-elidable range out of that same rendering. `ja` and `zh`
-   fail here: their single dates read `2025年6月21日`, but their ranges switch
-   to `2025/06/21～2025/06/25`.
+   fail here because their range patterns switch to numeric dates and
+   locale-specific separators.
 
-Where neither holds, both ends are spelled out in full instead:
+Where either check fails, both ends are spelled out in full using the
+translated WordPress range pattern instead:
 
 ```typescript
 // Site with a custom `date_format` of 'd/m/Y':

--- a/projects/packages/premium-analytics/packages/formatters/package.json
+++ b/projects/packages/premium-analytics/packages/formatters/package.json
@@ -8,6 +8,7 @@
 	"sideEffects": false,
 	"dependencies": {
 		"@automattic/number-formatters": "workspace:*",
-		"@wordpress/date": "5.51.0"
+		"@wordpress/date": "5.51.0",
+		"@wordpress/i18n": "^6.9.0"
 	}
 }

--- a/projects/packages/premium-analytics/packages/formatters/package.json
+++ b/projects/packages/premium-analytics/packages/formatters/package.json
@@ -8,7 +8,6 @@
 	"sideEffects": false,
 	"dependencies": {
 		"@automattic/number-formatters": "workspace:*",
-		"@wordpress/date": "5.51.0",
-		"@wordpress/i18n": "^6.9.0"
+		"@wordpress/date": "5.51.0"
 	}
 }

--- a/projects/packages/premium-analytics/packages/formatters/src/date/__fixtures__/wp-date-settings.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/__fixtures__/wp-date-settings.ts
@@ -71,13 +71,13 @@ export const settingsFor = (
 } );
 
 /** A site left on the US English default. */
-export const EN_US_SETTINGS = settingsFor( 'en-us-test', 'F j, Y' );
+export const EN_US_SETTINGS = settingsFor( 'en_US_test', 'F j, Y' );
 
 /**
  * A Spanish site. Its `date_format` puts the day first and spells "de" with
  * escaped literals (`\d\e`), which double as the day and timezone tokens.
  */
-export const ES_ES_SETTINGS = settingsFor( 'es-es-test', 'j \\d\\e F \\d\\e Y', ES_MONTHS );
+export const ES_ES_SETTINGS = settingsFor( 'es_ES_test', 'j \\d\\e F \\d\\e Y', ES_MONTHS );
 
 /**
  * Build a UTC date, matching the fixtures' timezone so no day shift is in play.

--- a/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/elide-range.test.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/elide-range.test.ts
@@ -85,4 +85,22 @@ describe( 'elideRange compatibility checks', () => {
 
 		expect( elideRange( utcDate( 2025, 6, 21 ), utcDate( 2025, 6, 25 ) ) ).toBeDefined();
 	} );
+
+	it( 'rejects a runtime whose formatter has no formatRange', () => {
+		// `formatRange` is optional here only so the method can be removed and
+		// put back; the runtimes this guards against never declared it.
+		const prototype = Intl.DateTimeFormat.prototype as { formatRange?: unknown };
+		const { formatRange } = prototype;
+		delete prototype.formatRange;
+
+		try {
+			// Settings no other test uses, so the memoized formatter cannot
+			// stand in for the one this test wants built.
+			setSettings( settingsFor( 'en_GB', 'j F Y' ) );
+
+			expect( elideRange( utcDate( 2025, 6, 21 ), utcDate( 2025, 6, 25 ) ) ).toBeUndefined();
+		} finally {
+			prototype.formatRange = formatRange;
+		}
+	} );
 } );

--- a/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/elide-range.test.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/elide-range.test.ts
@@ -1,0 +1,88 @@
+/**
+ * External dependencies
+ */
+import { setSettings } from '@wordpress/date';
+/**
+ * Internal dependencies
+ */
+import { settingsFor, utcDate } from '../__fixtures__/wp-date-settings';
+import { elideRange, intlLocale } from '../elide-range';
+
+const SR_MONTHS = [
+	'јануар',
+	'фебруар',
+	'март',
+	'април',
+	'мај',
+	'јун',
+	'јул',
+	'август',
+	'септембар',
+	'октобар',
+	'новембар',
+	'децембар',
+];
+
+const RU_MONTHS = [
+	'января',
+	'февраля',
+	'марта',
+	'апреля',
+	'мая',
+	'июня',
+	'июля',
+	'августа',
+	'сентября',
+	'октября',
+	'ноября',
+	'декабря',
+];
+
+describe( 'intlLocale', () => {
+	afterEach( () => jest.restoreAllMocks() );
+
+	it( 'normalizes an underscored WordPress locale', () => {
+		setSettings( settingsFor( 'es_ES', 'j \\d\\e F \\d\\e Y' ) );
+
+		expect( intlLocale() ).toBe( 'es-ES' );
+	} );
+
+	it( 'keeps a supported WordPress variant', () => {
+		setSettings( settingsFor( 'de_DE_formal', 'j. F Y' ) );
+
+		expect( intlLocale() ).toBe( 'de-DE-formal' );
+	} );
+
+	it( 'drops an invalid variant until it finds a supported ancestor', () => {
+		setSettings( settingsFor( 'pt_PT_ao90', 'j \\d\\e F \\d\\e Y' ) );
+
+		expect( intlLocale() ).toBe( 'pt-PT' );
+	} );
+
+	it( 'returns undefined when the locale is exhausted', () => {
+		setSettings( settingsFor( 'x', 'F j, Y' ) );
+
+		expect( intlLocale() ).toBeUndefined();
+	} );
+
+	it( 'rejects a well-formed locale with no runtime data', () => {
+		setSettings( settingsFor( 'bal', 'F j, Y' ) );
+		jest.spyOn( Intl.DateTimeFormat, 'supportedLocalesOf' ).mockReturnValue( [] );
+
+		expect( intlLocale() ).toBeUndefined();
+	} );
+} );
+
+describe( 'elideRange compatibility checks', () => {
+	it( 'rejects a range that pads a single date as a substring', () => {
+		setSettings( settingsFor( 'sr_RS', 'j. F Y.', SR_MONTHS ) );
+
+		expect( elideRange( utcDate( 2025, 6, 21 ), utcDate( 2025, 6, 25 ) ) ).toBeUndefined();
+	} );
+
+	it( 'accepts a range that only changes Unicode spacing', () => {
+		setSettings( settingsFor( 'ru_RU', 'j F Y г.', RU_MONTHS ) );
+
+		expect( elideRange( utcDate( 2025, 6, 21 ), utcDate( 2025, 6, 25 ) ) ).toBeDefined();
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-date-range.test.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-date-range.test.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { setSettings } from '@wordpress/date';
+import { resetLocaleData, setLocaleData } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
@@ -15,6 +16,9 @@ import { formatDateRange } from '../format-date-range';
 
 // The en dash between thin spaces that CLDR puts between the ends of a range.
 const SEP = '\u2009\u2013\u2009';
+
+// The package's translatable spelled-out range pattern.
+const FALLBACK_SEP = ' \u2013 ';
 
 const JA_MONTHS = [
 	'1\u6708',
@@ -45,6 +49,12 @@ describe( 'formatDateRange', () => {
 
 		it( 'returns an empty string when the range itself is missing', () => {
 			expect( formatDateRange() ).toBe( '' );
+		} );
+
+		it( 'falls back instead of throwing when one date is invalid', () => {
+			expect(
+				formatDateRange( { from: new Date( Number.NaN ), to: utcDate( 2025, 6, 21 ) } )
+			).toBe( `Invalid date${ FALLBACK_SEP }June 21, 2025` );
 		} );
 	} );
 
@@ -107,7 +117,7 @@ describe( 'formatDateRange', () => {
 		it( 'still spells out both ends of a range spanning years', () => {
 			expect(
 				formatDateRange( { from: utcDate( 2024, 6, 21 ), to: utcDate( 2025, 6, 21 ) } )
-			).toBe( `June 21${ SEP }June 21` );
+			).toBe( `June 21${ FALLBACK_SEP }June 21` );
 		} );
 
 		it( 'collapses a genuine single-day range', () => {
@@ -117,6 +127,10 @@ describe( 'formatDateRange', () => {
 	} );
 
 	describe( 'falling back where no elision rule can be trusted', () => {
+		afterEach( () => {
+			resetLocaleData( {}, 'jetpack-premium-analytics-pkg' );
+		} );
+
 		// A custom `date_format` is the site telling us how it wants dates
 		// written. CLDR's rules describe a different format, so borrowing its
 		// elision would quietly overrule the setting.
@@ -125,7 +139,24 @@ describe( 'formatDateRange', () => {
 
 			expect(
 				formatDateRange( { from: utcDate( 2025, 6, 21 ), to: utcDate( 2025, 6, 25 ) } )
-			).toBe( `21/06/2025${ SEP }25/06/2025` );
+			).toBe( `21/06/2025${ FALLBACK_SEP }25/06/2025` );
+		} );
+
+		it( 'rejects a custom format that only matches the first probe date', () => {
+			setSettings( settingsFor( 'en_literal_probe', '\\J\\a\\n\\u\\a\\r\\y j, Y' ) );
+
+			expect(
+				formatDateRange( { from: utcDate( 2025, 6, 21 ), to: utcDate( 2025, 6, 25 ) } )
+			).toBe( `January 21, 2025${ FALLBACK_SEP }January 25, 2025` );
+		} );
+
+		it( 'uses the translated range pattern when spelling both ends out', () => {
+			setSettings( settingsFor( 'en_translated_fallback', 'd/m/Y' ) );
+			setLocaleData( { '%1$s – %2$s': [ '%1$s - %2$s' ] }, 'jetpack-premium-analytics-pkg' );
+
+			expect(
+				formatDateRange( { from: utcDate( 2025, 6, 21 ), to: utcDate( 2025, 6, 25 ) } )
+			).toBe( '21/06/2025 - 25/06/2025' );
 		} );
 
 		// `ja` renders a single date as 2025年6月21日 but switches its ranges to
@@ -136,7 +167,7 @@ describe( 'formatDateRange', () => {
 
 			expect(
 				formatDateRange( { from: utcDate( 2025, 6, 21 ), to: utcDate( 2025, 6, 25 ) } )
-			).toBe( `2025年6月21日${ SEP }2025年6月25日` );
+			).toBe( `2025年6月21日${ FALLBACK_SEP }2025年6月25日` );
 		} );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-date-range.test.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-date-range.test.ts
@@ -13,6 +13,24 @@ import {
 } from '../__fixtures__/wp-date-settings';
 import { formatDateRange } from '../format-date-range';
 
+// The en dash between thin spaces that CLDR puts between the ends of a range.
+const SEP = '\u2009\u2013\u2009';
+
+const JA_MONTHS = [
+	'1\u6708',
+	'2\u6708',
+	'3\u6708',
+	'4\u6708',
+	'5\u6708',
+	'6\u6708',
+	'7\u6708',
+	'8\u6708',
+	'9\u6708',
+	'10\u6708',
+	'11\u6708',
+	'12\u6708',
+];
+
 describe( 'formatDateRange', () => {
 	describe( 'edge cases', () => {
 		beforeEach( () => setSettings( EN_US_SETTINGS ) );
@@ -38,26 +56,40 @@ describe( 'formatDateRange', () => {
 			expect( formatDateRange( { from: date, to: date } ) ).toBe( 'June 21, 2025' );
 		} );
 
-		it( 'spells out both ends of a range within one month', () => {
+		it( 'elides the month and year shared within one month', () => {
 			expect(
 				formatDateRange( { from: utcDate( 2025, 6, 21 ), to: utcDate( 2025, 6, 25 ) } )
-			).toBe( 'June 21, 2025 – June 25, 2025' );
+			).toBe( `June 21${ SEP }25, 2025` );
 		} );
 
-		it( 'spells out both ends of a range spanning years', () => {
+		it( 'elides only the year across months of the same year', () => {
+			expect(
+				formatDateRange( { from: utcDate( 2025, 6, 21 ), to: utcDate( 2025, 7, 25 ) } )
+			).toBe( `June 21${ SEP }July 25, 2025` );
+		} );
+
+		it( 'elides nothing across years', () => {
 			expect(
 				formatDateRange( { from: utcDate( 2024, 6, 21 ), to: utcDate( 2025, 7, 25 ) } )
-			).toBe( 'June 21, 2024 – July 25, 2025' );
+			).toBe( `June 21, 2024${ SEP }July 25, 2025` );
 		} );
 	} );
 
 	describe( 'es_ES site', () => {
 		beforeEach( () => setSettings( ES_ES_SETTINGS ) );
 
-		it( 'follows the site date format on both ends', () => {
+		// The elision rule is Spanish, not a translated English one: the day
+		// range leads and the shared "de junio de 2025" trails it once.
+		it( 'elides the way Spanish does, not the way English does', () => {
 			expect(
 				formatDateRange( { from: utcDate( 2025, 6, 21 ), to: utcDate( 2025, 6, 25 ) } )
-			).toBe( '21 de junio de 2025 – 25 de junio de 2025' );
+			).toBe( '21–25 de junio de 2025' );
+		} );
+
+		it( 'elides nothing across years', () => {
+			expect(
+				formatDateRange( { from: utcDate( 2024, 6, 21 ), to: utcDate( 2025, 7, 25 ) } )
+			).toBe( `21 de junio de 2024${ SEP }25 de julio de 2025` );
 		} );
 
 		it( 'collapses a single-day range to one date', () => {
@@ -75,12 +107,36 @@ describe( 'formatDateRange', () => {
 		it( 'still spells out both ends of a range spanning years', () => {
 			expect(
 				formatDateRange( { from: utcDate( 2024, 6, 21 ), to: utcDate( 2025, 6, 21 ) } )
-			).toBe( 'June 21 – June 21' );
+			).toBe( `June 21${ SEP }June 21` );
 		} );
 
 		it( 'collapses a genuine single-day range', () => {
 			const date = utcDate( 2025, 6, 21 );
 			expect( formatDateRange( { from: date, to: date } ) ).toBe( 'June 21' );
+		} );
+	} );
+
+	describe( 'falling back where no elision rule can be trusted', () => {
+		// A custom `date_format` is the site telling us how it wants dates
+		// written. CLDR's rules describe a different format, so borrowing its
+		// elision would quietly overrule the setting.
+		it( 'keeps a custom date format and spells both ends out', () => {
+			setSettings( settingsFor( 'en-custom-test', 'd/m/Y' ) );
+
+			expect(
+				formatDateRange( { from: utcDate( 2025, 6, 21 ), to: utcDate( 2025, 6, 25 ) } )
+			).toBe( `21/06/2025${ SEP }25/06/2025` );
+		} );
+
+		// `ja` renders a single date as 2025年6月21日 but switches its ranges to
+		// 2025/06/21～2025/06/25, so its elision cannot be mixed with the rest
+		// of the dashboard's dates.
+		it( 'spells both ends out where the locale restyles its ranges', () => {
+			setSettings( settingsFor( 'ja-JP', 'Y年n月j日', JA_MONTHS ) );
+
+			expect(
+				formatDateRange( { from: utcDate( 2025, 6, 21 ), to: utcDate( 2025, 6, 25 ) } )
+			).toBe( `2025年6月21日${ SEP }2025年6月25日` );
 		} );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/site-time-zone.test.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/site-time-zone.test.ts
@@ -1,0 +1,62 @@
+/**
+ * External dependencies
+ */
+import { setSettings } from '@wordpress/date';
+/**
+ * Internal dependencies
+ */
+import { EN_US_SETTINGS } from '../__fixtures__/wp-date-settings';
+import { siteTimeZone } from '../site-time-zone';
+
+/**
+ * Install settings carrying a specific timezone.
+ *
+ * @param timezone        - The `timezone` block WordPress would send.
+ * @param timezone.offset - Offset in hours.
+ * @param timezone.string - IANA zone name, empty for offset-configured sites.
+ */
+const withTimezone = ( timezone: { offset: number; string: string } ) =>
+	setSettings( {
+		...EN_US_SETTINGS,
+		timezone: { ...timezone, offsetFormatted: String( timezone.offset ), abbr: '' },
+	} );
+
+describe( 'siteTimeZone', () => {
+	it( 'prefers the named timezone', () => {
+		withTimezone( { offset: 2, string: 'Europe/Amsterdam' } );
+
+		expect( siteTimeZone() ).toBe( 'Europe/Amsterdam' );
+	} );
+
+	// A site set to a manual UTC offset rather than a city has no timezone
+	// string at all, so the offset is the only thing left to go on.
+	it( 'falls back to the offset when there is no named timezone', () => {
+		withTimezone( { offset: 8, string: '' } );
+
+		expect( siteTimeZone() ).toBe( '+08:00' );
+	} );
+
+	it( 'formats a negative offset', () => {
+		withTimezone( { offset: -5, string: '' } );
+
+		expect( siteTimeZone() ).toBe( '-05:00' );
+	} );
+
+	it( 'formats a fractional offset', () => {
+		withTimezone( { offset: 5.5, string: '' } );
+
+		expect( siteTimeZone() ).toBe( '+05:30' );
+	} );
+
+	it( 'formats a negative fractional offset', () => {
+		withTimezone( { offset: -3.5, string: '' } );
+
+		expect( siteTimeZone() ).toBe( '-03:30' );
+	} );
+
+	it( 'formats a zero offset', () => {
+		withTimezone( { offset: 0, string: '' } );
+
+		expect( siteTimeZone() ).toBe( '+00:00' );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/formatters/src/date/elide-range.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/elide-range.ts
@@ -8,7 +8,7 @@ import { getSettings } from '@wordpress/date';
 import { formatDate } from './format-date';
 import { siteTimeZone } from './site-time-zone';
 
-/** The parts a locale's default `date_format` renders. */
+/** The date parts requested from `Intl` when comparing it with WordPress. */
 const RANGE_PARTS: Intl.DateTimeFormatOptions = {
 	year: 'numeric',
 	month: 'long',
@@ -16,31 +16,57 @@ const RANGE_PARTS: Intl.DateTimeFormatOptions = {
 };
 
 /**
- * Two dates over a year apart, so no locale can elide anything from a range
- * between them. Noon UTC keeps them on the same calendar day in every zone.
+ * Dates spread across the calendar catch custom formats and translated month
+ * tables that happen to agree with `Intl` for only one date.
  */
-const PROBE_FROM = new Date( Date.UTC( 2020, 0, 2, 12 ) );
+const SINGLE_PROBES = [
+	...Array.from(
+		{ length: 12 },
+		( _, month ) => new Date( Date.UTC( 2020, month, month + 1, 12 ) )
+	),
+	new Date( Date.UTC( 2021, 0, 1, 12 ) ),
+];
+
+/**
+ * Two dates with no requested date part in common. The site timezone is
+ * applied by both formatters, so a probe crossing a UTC day boundary is safe.
+ */
+const PROBE_FROM = SINGLE_PROBES[ 0 ];
 const PROBE_TO = new Date( Date.UTC( 2021, 1, 3, 12 ) );
+
+/** Treat typographically different Unicode spaces as equivalent. */
+const normalizeSpaces = ( value: string ): string =>
+	value.replace( /[\u00a0\u1680\u2000-\u200a\u202f\u205f\u3000]/g, ' ' );
 
 /**
  * The site's locale as a tag `Intl` accepts.
  *
- * WordPress sends its own locale name (`es_ES`, `de_DE_formal`), which is close
- * to BCP 47 but not always a valid tag. Subtags are dropped from the right
- * until one parses, so `es_ES` becomes `es-ES` and a test fixture's
- * `en-us-test` still resolves to `en-US`.
+ * WordPress sends its own locale name (`es_ES`, `de_DE_formal`), which first
+ * needs underscores converted to BCP 47 separators. Some WordPress variants
+ * remain invalid after that conversion, so subtags are dropped from the right
+ * until a supported ancestor is found; for example, `pt_PT_ao90` resolves to
+ * `pt-PT`.
  *
- * @return The tag, or `undefined` when nothing parses.
+ * A structurally valid but unsupported tag is not usable: `Intl` would resolve
+ * it to the visitor's locale, making range output depend on who views the site.
+ *
+ * @return The supported tag, or `undefined` when no supported ancestor exists.
  */
-function intlLocale(): string | undefined {
+export function intlLocale(): string | undefined {
 	const parts = getSettings().l10n.locale.replace( /_/g, '-' ).split( '-' );
 
 	while ( parts.length ) {
 		try {
-			return Intl.getCanonicalLocales( parts.join( '-' ) )[ 0 ];
+			const locale = Intl.getCanonicalLocales( parts.join( '-' ) )[ 0 ];
+
+			if ( Intl.DateTimeFormat.supportedLocalesOf( locale ).length ) {
+				return locale;
+			}
 		} catch {
-			parts.pop();
+			// Keep removing variants until the remainder parses.
 		}
+
+		parts.pop();
 	}
 
 	return undefined;
@@ -52,15 +78,15 @@ function intlLocale(): string | undefined {
  * WordPress publishes whole date formats and no rules for eliding a month or
  * year shared by both ends of a range — but CLDR, which `Intl` is built on, has
  * them for every locale. They can only be borrowed where WordPress and `Intl`
- * agree on what a single date looks like, which holds while the site is on its
- * locale's default `date_format`. Two checks establish that, so no allowlist of
+ * agree on how dates look. Two checks establish that, so no allowlist of
  * trusted locales has to be kept in step with CLDR:
  *
- * 1. `Intl` renders a single date exactly as `formatDate` does. A site with a
- *    custom `date_format` fails here and keeps the format it asked for.
+ * 1. `Intl` renders representative dates exactly as `formatDate` does. A site
+ *    with a custom `date_format` or different month translations fails here
+ *    and keeps the format it asked for.
  * 2. `Intl` builds a range that cannot be elided out of that same rendering.
- *    `ja` and `zh` fail here: their single dates read `2025年6月21日`, but
- *    their ranges switch to `2025/06/21～2025/06/25`.
+ *    Japanese and Chinese fail here: their range patterns use numeric dates
+ *    and locale-specific separators instead of their single-date rendering.
  *
  * @return The formatter, or `undefined` when the two do not agree.
  */
@@ -84,9 +110,13 @@ function buildRangeFormatter(): Intl.DateTimeFormat | undefined {
 		return undefined;
 	}
 
+	const rendersLikeSite = SINGLE_PROBES.every(
+		probe => formatter.format( probe ) === formatDate( probe )
+	);
 	const single = formatter.format( PROBE_FROM );
-	const rendersLikeSite = single === formatDate( PROBE_FROM );
-	const rangeKeepsRendering = formatter.formatRange( PROBE_FROM, PROBE_TO ).includes( single );
+	const rangeKeepsRendering = normalizeSpaces(
+		formatter.formatRange( PROBE_FROM, PROBE_TO )
+	).startsWith( normalizeSpaces( single ) );
 
 	return rendersLikeSite && rangeKeepsRendering ? formatter : undefined;
 }
@@ -97,15 +127,19 @@ let cache: { key: string; formatter: Intl.DateTimeFormat | undefined } | undefin
  * Format a range with the shared month or year elided, where the site's own
  * date format allows it.
  *
- * The probes in `buildRangeFormatter` cost two formats, so the result is held
- * against the settings it was derived from; those only change when the page
- * reloads, or when a test installs new ones.
+ * The probes in `buildRangeFormatter` run once per settings combination, so
+ * the result is held against the locale, date format, and timezone it was
+ * derived from.
  *
  * @param from - Start of the range.
  * @param to   - End of the range.
  * @return The elided range, or `undefined` to fall back to spelling both ends out.
  */
 export function elideRange( from: Date, to: Date ): string | undefined {
+	if ( Number.isNaN( from.getTime() ) || Number.isNaN( to.getTime() ) ) {
+		return undefined;
+	}
+
 	const settings = getSettings();
 	const key = `${ settings.l10n.locale }|${ settings.formats.date }|${ siteTimeZone() }`;
 

--- a/projects/packages/premium-analytics/packages/formatters/src/date/elide-range.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/elide-range.ts
@@ -1,0 +1,117 @@
+/**
+ * External dependencies
+ */
+import { getSettings } from '@wordpress/date';
+/**
+ * Internal dependencies
+ */
+import { formatDate } from './format-date';
+import { siteTimeZone } from './site-time-zone';
+
+/** The parts a locale's default `date_format` renders. */
+const RANGE_PARTS: Intl.DateTimeFormatOptions = {
+	year: 'numeric',
+	month: 'long',
+	day: 'numeric',
+};
+
+/**
+ * Two dates over a year apart, so no locale can elide anything from a range
+ * between them. Noon UTC keeps them on the same calendar day in every zone.
+ */
+const PROBE_FROM = new Date( Date.UTC( 2020, 0, 2, 12 ) );
+const PROBE_TO = new Date( Date.UTC( 2021, 1, 3, 12 ) );
+
+/**
+ * The site's locale as a tag `Intl` accepts.
+ *
+ * WordPress sends its own locale name (`es_ES`, `de_DE_formal`), which is close
+ * to BCP 47 but not always a valid tag. Subtags are dropped from the right
+ * until one parses, so `es_ES` becomes `es-ES` and a test fixture's
+ * `en-us-test` still resolves to `en-US`.
+ *
+ * @return The tag, or `undefined` when nothing parses.
+ */
+function intlLocale(): string | undefined {
+	const parts = getSettings().l10n.locale.replace( /_/g, '-' ).split( '-' );
+
+	while ( parts.length ) {
+		try {
+			return Intl.getCanonicalLocales( parts.join( '-' ) )[ 0 ];
+		} catch {
+			parts.pop();
+		}
+	}
+
+	return undefined;
+}
+
+/**
+ * Build a range formatter for the current settings, if one can be trusted.
+ *
+ * WordPress publishes whole date formats and no rules for eliding a month or
+ * year shared by both ends of a range — but CLDR, which `Intl` is built on, has
+ * them for every locale. They can only be borrowed where WordPress and `Intl`
+ * agree on what a single date looks like, which holds while the site is on its
+ * locale's default `date_format`. Two checks establish that, so no allowlist of
+ * trusted locales has to be kept in step with CLDR:
+ *
+ * 1. `Intl` renders a single date exactly as `formatDate` does. A site with a
+ *    custom `date_format` fails here and keeps the format it asked for.
+ * 2. `Intl` builds a range that cannot be elided out of that same rendering.
+ *    `ja` and `zh` fail here: their single dates read `2025年6月21日`, but
+ *    their ranges switch to `2025/06/21～2025/06/25`.
+ *
+ * @return The formatter, or `undefined` when the two do not agree.
+ */
+function buildRangeFormatter(): Intl.DateTimeFormat | undefined {
+	const locale = intlLocale();
+
+	if ( ! locale ) {
+		return undefined;
+	}
+
+	let formatter: Intl.DateTimeFormat;
+
+	try {
+		formatter = new Intl.DateTimeFormat( locale, {
+			...RANGE_PARTS,
+			timeZone: siteTimeZone(),
+		} );
+	} catch {
+		// An unusable locale, or an offset identifier this runtime will not take
+		// as a `timeZone`.
+		return undefined;
+	}
+
+	const single = formatter.format( PROBE_FROM );
+	const rendersLikeSite = single === formatDate( PROBE_FROM );
+	const rangeKeepsRendering = formatter.formatRange( PROBE_FROM, PROBE_TO ).includes( single );
+
+	return rendersLikeSite && rangeKeepsRendering ? formatter : undefined;
+}
+
+let cache: { key: string; formatter: Intl.DateTimeFormat | undefined } | undefined;
+
+/**
+ * Format a range with the shared month or year elided, where the site's own
+ * date format allows it.
+ *
+ * The probes in `buildRangeFormatter` cost two formats, so the result is held
+ * against the settings it was derived from; those only change when the page
+ * reloads, or when a test installs new ones.
+ *
+ * @param from - Start of the range.
+ * @param to   - End of the range.
+ * @return The elided range, or `undefined` to fall back to spelling both ends out.
+ */
+export function elideRange( from: Date, to: Date ): string | undefined {
+	const settings = getSettings();
+	const key = `${ settings.l10n.locale }|${ settings.formats.date }|${ siteTimeZone() }`;
+
+	if ( cache?.key !== key ) {
+		cache = { key, formatter: buildRangeFormatter() };
+	}
+
+	return cache.formatter?.formatRange( from, to );
+}

--- a/projects/packages/premium-analytics/packages/formatters/src/date/elide-range.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/elide-range.ts
@@ -110,6 +110,14 @@ function buildRangeFormatter(): Intl.DateTimeFormat | undefined {
 		return undefined;
 	}
 
+	// `formatRange` was added to ECMA-402 later than `Intl.DateTimeFormat`
+	// itself. Refusing the formatter here is what keeps a runtime that has the
+	// class but not the method on the spelled-out path, since every later call
+	// goes through a formatter this function returned.
+	if ( typeof formatter.formatRange !== 'function' ) {
+		return undefined;
+	}
+
 	const rendersLikeSite = SINGLE_PROBES.every(
 		probe => formatter.format( probe ) === formatDate( probe )
 	);

--- a/projects/packages/premium-analytics/packages/formatters/src/date/format-date-range.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/format-date-range.ts
@@ -1,10 +1,7 @@
 /**
- * External dependencies
- */
-import { __, sprintf } from '@wordpress/i18n';
-/**
  * Internal dependencies
  */
+import { elideRange } from './elide-range';
 import { formatDate } from './format-date';
 
 /**
@@ -18,10 +15,22 @@ import { formatDate } from './format-date';
 type DateRange = { from?: Date; to?: Date };
 
 /**
+ * En dash between thin spaces, matching what CLDR puts between the ends of a
+ * range. A legend can show an elided range beside a spelled-out one, so the two
+ * paths have to space their separator the same way.
+ */
+const RANGE_SEPARATOR = '\u2009\u2013\u2009';
+
+/**
  * Format a date range into a human-readable string.
  *
- * Both ends are spelled out because WordPress provides no locale-specific
- * range-elision rules.
+ * A shared month or year is elided where the site's locale has a rule for it —
+ * see `elideRange`, which borrows those rules from CLDR rather than inventing
+ * them. Eliding by hand is not an option: "Jun 21-25, 2025" is an English
+ * typographic convention that, applied to a Spanish site, yields
+ * "21 de junio-25 de junio de 2025". Where no rule can be trusted — a custom
+ * `date_format`, or a locale whose ranges do not read like its single dates —
+ * both ends are spelled out in full instead.
  *
  * Returns `''` when `range`, `from`, or `to` is missing.
  *
@@ -29,8 +38,9 @@ type DateRange = { from?: Date; to?: Date };
  * @return The formatted range.
  *
  * @example
- * formatDateRange( { from, to } ) // same day: 'June 21, 2025'
- *                                 // range:    'June 21, 2025 – June 25, 2025'
+ * formatDateRange( { from, to } ) // same day:  'June 21, 2025'
+ *                                 // elided:    'June 21 – 25, 2025'
+ *                                 // spelt out: 'June 21, 2025 – June 25, 2025'
  */
 export const formatDateRange = ( range?: DateRange ): string => {
 	const { from, to } = range ?? {};
@@ -44,10 +54,7 @@ export const formatDateRange = ( range?: DateRange ): string => {
 		return formatDate( from );
 	}
 
-	return sprintf(
-		/* translators: 1: Start date. 2: End date. */
-		__( '%1$s – %2$s', 'jetpack-premium-analytics-pkg' ),
-		formatDate( from ),
-		formatDate( to )
+	return (
+		elideRange( from, to ) ?? `${ formatDate( from ) }${ RANGE_SEPARATOR }${ formatDate( to ) }`
 	);
 };

--- a/projects/packages/premium-analytics/packages/formatters/src/date/format-date-range.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/format-date-range.ts
@@ -1,4 +1,8 @@
 /**
+ * External dependencies
+ */
+import { __, sprintf } from '@wordpress/i18n';
+/**
  * Internal dependencies
  */
 import { elideRange } from './elide-range';
@@ -13,13 +17,6 @@ import { formatDate } from './format-date';
  * `link:` wiring is settled.
  */
 type DateRange = { from?: Date; to?: Date };
-
-/**
- * En dash between thin spaces, matching what CLDR puts between the ends of a
- * range. A legend can show an elided range beside a spelled-out one, so the two
- * paths have to space their separator the same way.
- */
-const RANGE_SEPARATOR = '\u2009\u2013\u2009';
 
 /**
  * Format a date range into a human-readable string.
@@ -55,6 +52,12 @@ export const formatDateRange = ( range?: DateRange ): string => {
 	}
 
 	return (
-		elideRange( from, to ) ?? `${ formatDate( from ) }${ RANGE_SEPARATOR }${ formatDate( to ) }`
+		elideRange( from, to ) ??
+		sprintf(
+			/* translators: 1: Start date. 2: End date. */
+			__( '%1$s – %2$s', 'jetpack-premium-analytics-pkg' ),
+			formatDate( from ),
+			formatDate( to )
+		)
 	);
 };

--- a/projects/packages/premium-analytics/packages/formatters/src/date/site-time-zone.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/site-time-zone.ts
@@ -15,9 +15,8 @@ import { getSettings } from '@wordpress/date';
  * and a single date formatted there agree on the calendar day. Note that
  * `getSiteTimezone()` in `@jetpack-premium-analytics/data` answers the same
  * question from a different source — the core-data `root/site` entity, falling
- * back to the *browser* zone before it loads — and its `formatGmtOffset()`
- * duplicates the `±HH:MM` formatting below, already disagreeing on a zero
- * offset. Keep the two in step until they are collapsed into one accessor.
+ * back to the *browser* zone before it loads — so it cannot replace this
+ * settings-backed accessor.
  *
  * @return An IANA zone name, or a `±HH:MM` offset.
  */

--- a/projects/packages/premium-analytics/packages/formatters/src/date/site-time-zone.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/site-time-zone.ts
@@ -1,0 +1,37 @@
+/**
+ * External dependencies
+ */
+import { getSettings } from '@wordpress/date';
+
+/**
+ * The site's timezone, as an identifier `Intl` accepts.
+ *
+ * Sites configured with a manual UTC offset instead of a city have no
+ * `timezone_string` at all, so WordPress sends an empty string and carries the
+ * zone in `offset` alone. `Intl` rejects `''` as a `timeZone`, so the offset is
+ * rendered as a fixed `±HH:MM` identifier instead.
+ *
+ * This reads the same settings `formatDate` renders in, so a range built here
+ * and a single date formatted there agree on the calendar day. Note that
+ * `getSiteTimezone()` in `@jetpack-premium-analytics/data` answers the same
+ * question from a different source — the core-data `root/site` entity, falling
+ * back to the *browser* zone before it loads — and its `formatGmtOffset()`
+ * duplicates the `±HH:MM` formatting below, already disagreeing on a zero
+ * offset. Keep the two in step until they are collapsed into one accessor.
+ *
+ * @return An IANA zone name, or a `±HH:MM` offset.
+ */
+export function siteTimeZone(): string {
+	const { string: name, offset } = getSettings().timezone;
+
+	if ( name ) {
+		return name;
+	}
+
+	const sign = offset < 0 ? '-' : '+';
+	const totalMinutes = Math.round( Math.abs( offset ) * 60 );
+	const hours = String( Math.floor( totalMinutes / 60 ) ).padStart( 2, '0' );
+	const minutes = String( totalMinutes % 60 ).padStart( 2, '0' );
+
+	return `${ sign }${ hours }:${ minutes }`;
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/format-legend-labels.test.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/format-legend-labels.test.ts
@@ -27,6 +27,9 @@ const siteIn = ( timeZone: string, offset: number, locale: string ) =>
 		timezone: { offset, offsetFormatted: String( offset ), string: timeZone, abbr: '' },
 	} );
 
+// The en dash between thin spaces CLDR puts between the ends of a range.
+const SEP = '\u2009\u2013\u2009';
+
 describe( 'formatLegendLabels', () => {
 	// A date-only param has no offset of its own. Read as UTC it lands on the
 	// previous day for every site west of Greenwich.
@@ -41,8 +44,8 @@ describe( 'formatLegendLabels', () => {
 			interval: 'day',
 		} as ReportParams );
 
-		expect( labels.primary ).toBe( 'January 1, 2026 – January 31, 2026' );
-		expect( labels.comparison ).toBe( 'December 1, 2025 – December 31, 2025' );
+		expect( labels.primary ).toBe( `January 1${ SEP }31, 2026` );
+		expect( labels.comparison ).toBe( `December 1${ SEP }31, 2025` );
 	} );
 
 	it( 'keeps date-only params on their own calendar day for a site east of UTC', () => {
@@ -54,7 +57,7 @@ describe( 'formatLegendLabels', () => {
 			interval: 'day',
 		} as ReportParams );
 
-		expect( labels.primary ).toBe( 'January 1, 2026 – January 31, 2026' );
+		expect( labels.primary ).toBe( `January 1${ SEP }31, 2026` );
 	} );
 
 	it( 'honours the offset a full ISO param already carries', () => {
@@ -66,7 +69,7 @@ describe( 'formatLegendLabels', () => {
 			interval: 'day',
 		} as ReportParams );
 
-		expect( labels.primary ).toBe( 'June 29, 2026 – July 28, 2026' );
+		expect( labels.primary ).toBe( `June 29${ SEP }July 28, 2026` );
 	} );
 
 	it( 'falls back to the generic comparison label without comparison params', () => {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/format-legend-labels.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/format-legend-labels.ts
@@ -30,7 +30,7 @@ import type { ReportParams } from '@jetpack-premium-analytics/data';
  *   compare_to: '2023-12-31',
  *   interval: 'day'
  * });
- * // Returns: { primary: 'January 1, 2024 – January 31, 2024', … }
+ * // Returns: { primary: 'January 1 – 31, 2024', … }
  * ```
  */
 export function formatLegendLabels( reportParams: ReportParams ): LegendLabels {


### PR DESCRIPTION
Fixes WOOA7S-1766


## Proposed changes

#50888 made date ranges honor the site's `date_format`, which requires spelling out both dates in full. This PR uses CLDR (Common Locale Data Repository) rules exposed by `Intl.DateTimeFormat.formatRange()` to elide a shared month or year when doing so is compatible with the site's locale and date format.

- **Locale-aware elision:** Add `elideRange()` to produce ranges such as `June 21 – 25, 2025` and `21–25 de junio de 2025`.
- **Preserve site settings:** Compare representative dates across the calendar before using `Intl`; custom `date_format` values and WordPress month translations continue to spell out both dates.
- **Avoid incompatible patterns:** Normalize Unicode spacing, then require an un-elidable range to begin with the single-date rendering. This rejects pattern changes such as padded Serbian days while accepting harmless spacing differences.
- **Runtime locale support:** Require the browser's ICU data to support the WordPress locale or a valid ancestor, preventing an unsupported locale from falling back to the visitor's locale.
- **Localized fallback:** Keep WordPress's translated `%1$s – %2$s` pattern when spelling both dates out instead of imposing one CLDR separator on every locale.
- **Invalid-input safety:** Return to the spelled-out path for invalid dates so malformed analytics data renders an ugly label instead of throwing from `formatRange()`.
- **Automatic compatibility:** Compare `Intl` with the live WordPress date output instead of maintaining a locale allowlist; cache the result by locale, date format, and timezone.

Examples:

| Site | Result |
| --- | --- |
| `en_US`, same month | `June 21 – 25, 2025` |
| `en_US`, same year | `June 21 – July 25, 2025` |
| `en_US`, across years | `June 21, 2024 – July 25, 2025` |
| `es_ES`, same month | `21–25 de junio de 2025` |
| Custom `date_format` of `d/m/Y` | `21/06/2025 – 25/06/2025` (spelled out using the translated range pattern) |
| `ja_JP` | `2025年6月21日 – 2025年6月25日` (spelled out using the translated range pattern) |

This does not restore the shorter, hardcoded abbreviated-month labels from before #50888. In the chart legend, the measured same-year label changes from 173px with #50888 alone to 137px here, compared with 115px on trunk. This recovers about 21% of the added width, and no tested variant overflowed or truncated.

## Related product discussion/links

- WOOA7S-1766
- #50888 (the PR this is stacked on)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Elision only shows up when the ends share a month or a year. Build the package from this branch first — a stale `build/` renders the old spelled-out labels, which looks like the change did nothing.

### On an English site — no language switch needed

- Go to **Analytics** and choose a **Custom** range entirely within one month. The **Compare to:** control and chart legend should show the shared month and year once, for example `July 16 – 22, 2026` rather than `July 16, 2026 – July 22, 2026`.
- Choose a range that crosses a month boundary but stays within one year. Only the shared year should be elided, for example `June 30 – July 29, 2026`.
- Choose a range across a year boundary. Both ends should spell out again.
- Set **Settings → General → Date Format** to `d/m/Y` and reload. Both ends should spell out in that format, for example `23/07/2026 – 29/07/2026`: a format the site asked for is never overruled by a CLDR rule.
- Spelled-out fallbacks continue to use the package's translated range pattern; the separator is not forced to match the locale-specific separator returned by `Intl`.

### The locale rules, confirmed directly

The rules come from CLDR rather than from this PR, and each one is a single console line:

```js
const parts = { year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC' };
const from = new Date( Date.UTC( 2025, 5, 21 ) ), to = new Date( Date.UTC( 2025, 5, 25 ) );

new Intl.DateTimeFormat( 'es-ES', parts ).formatRange( from, to ); // '21–25 de junio de 2025'
new Intl.DateTimeFormat( 'ja-JP', parts ).formatRange( from, to ); // '2025/06/21～2025/06/25'
```

The first is the Spanish rule this PR borrows: the day range leads and "de junio de 2025" trails it once, which is not the English shape translated. The second is why `ja` falls back — its single dates read `2025年6月21日`, so a slash-separated range cannot sit beside the rest of the dashboard's dates. The formatter tests pin both against real `@wordpress/date` settings and also cover underscored WordPress locales, unsupported ICU locales, Unicode spacing, padded range dates, translated fallbacks, and invalid input.

### Seeing a non-English site render

Switching **Site Language** works, but two things get in the way.

`date_format` is not part of the language. Switching an English site to Español leaves the option at `F j, Y`, which then renders `junio 21, 2026` — a shape no `es-ES` rule describes, so the range spells both ends out and reads like a bug. A Spanish site ships `j \d\e F \d\e Y`, so re-pick the first **Date Format** radio after changing the language. `wp eval 'switch_to_locale( "es_ES" ); echo __( "F j, Y" );'` prints what a site of that locale actually uses. The dashboard also takes about 45 seconds to load on any non-`en_US` locale, for a reason unrelated to this PR: WOOA7S-1822.

To skip both, install the settings a Spanish site would send from the console of an `en_US` dashboard. The translation-catalog burst behind WOOA7S-1822 stays on its `en_US` short-circuit, and `elideRange` re-derives its formatter because the settings changed:

```js
const s = wp.date.getSettings();
wp.date.setSettings( {
	...s,
	l10n: { ...s.l10n, locale: 'es_ES', months: [ 'enero', 'febrero', 'marzo',
		'abril', 'mayo', 'junio', 'julio', 'agosto', 'septiembre', 'octubre',
		'noviembre', 'diciembre' ] },
	formats: { ...s.formats, date: 'j \\d\\e F \\d\\e Y' },
} );
```

Click another preset to force a re-render. Swapping in `'ja_JP'`, `'Y年n月j日'`, and month names `1月` … `12月` gives the fallback instead, as in the screenshots below.

Verified locally with the site on `Europe/Amsterdam`, against the site date format, a custom `d/m/Y`, and the two sets of locale settings above.

## Before / after

The comparison legend of the **Orders over time** widget, rendered in Storybook at the widget's own width. The label is the only thing that differs — the legend stacks its two entries vertically either way, so this is a density change rather than a layout fix.

| Before (#50888 alone) | After (this PR) |
| --- | --- |
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/wooa7s-1766-elide-date-ranges/before-legend.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/wooa7s-1766-elide-date-ranges/after-legend.png) |
| `June 28, 2026 – July 28, 2026` | `June 28 – July 28, 2026` |

### The same legend under two sets of date settings

The **Last 7 days** range on a live dashboard: the site's own English settings, then the `ja_JP` settings from the console snippet above. The data and the layout are identical; only the labels move.

| Date settings | Legend and **Compare to:** control |
| --- | --- |
| `en_US`, `F j, Y` | ![en_US](https://github.com/Automattic/jetpack/raw/screenshots/wooa7s-1766-elide-date-ranges/dashboard-en.png) |
| `ja_JP`, `Y年n月j日` | <img  alt="Screenshot 2026-07-30 at 5 14 56 PM" src="https://github.com/user-attachments/assets/c2774a14-8a21-4c1c-aa00-ac7a5e705e79" /> |

