### PR TITLE
Search Blocks: fix parse_blocks() OOM in collect_filter_configs_from_post()

### DIFF
--- a/projects/packages/search/changelog/fix-search-blocks-parse-blocks-oom
+++ b/projects/packages/search/changelog/fix-search-blocks-parse-blocks-oom
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: Avoid parsing post content for filter blocks when none are present, preventing out-of-memory errors on large posts.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -2107,7 +2107,8 @@ HTML;
 			return array();
 		}
 		// Bail if any helper is missing — half-loaded feature would ship inconsistent filterConfigs.
-		foreach ( static::filter_block_helpers() as $helper ) {
+		$helpers = static::filter_block_helpers();
+		foreach ( $helpers as $helper ) {
 			if ( ! class_exists( $helper ) ) {
 				return array();
 			}
@@ -2116,9 +2117,29 @@ HTML;
 		if ( ! $post || empty( $post->post_content ) ) {
 			return array();
 		}
+		if ( ! static::post_content_has_filter_block( $post, array_keys( $helpers ) ) ) {
+			return array();
+		}
 		$configs = array();
 		static::walk_blocks_for_filter_configs( parse_blocks( $post->post_content ), $configs );
 		return $configs;
+	}
+
+	/**
+	 * Does the post contain any of the given block names? SEARCH-295: a
+	 * has_block() scan to gate parse_blocks() on large, filter-less posts.
+	 *
+	 * @param \WP_Post $post        Post to scan.
+	 * @param string[] $block_names Block names to scan for.
+	 * @return bool
+	 */
+	protected static function post_content_has_filter_block( \WP_Post $post, array $block_names ): bool {
+		foreach ( $block_names as $block_name ) {
+			if ( has_block( $block_name, $post ) ) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -2566,6 +2566,95 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
+	 * Seed `$GLOBALS['post']` with a saved post; content is set in-memory
+	 * post-fetch to avoid wp_insert_post()'s KSES pass mangling block JSON.
+	 *
+	 * @param string $post_content Raw post content, block markup included.
+	 * @return callable Cleanup callback — call from `finally`.
+	 */
+	private function seed_current_post( string $post_content ): callable {
+		$original_post      = $GLOBALS['post'] ?? null;
+		$post_id            = wp_insert_post(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_title'  => 'collect_filter_configs_from_post fixture',
+			)
+		);
+		$post               = get_post( $post_id );
+		$post->post_content = $post_content;
+		$GLOBALS['post']    = $post;
+
+		return static function () use ( $original_post, $post_id ) {
+			$GLOBALS['post'] = $original_post;
+			wp_delete_post( $post_id, true );
+		};
+	}
+
+	/**
+	 * SEARCH-295: a large body with no filter blocks must skip parse_blocks().
+	 */
+	public function test_collect_filter_configs_from_post_returns_empty_for_large_body_without_filter_blocks() {
+		$paragraph     = "<!-- wp:paragraph -->\n<p>" . str_repeat( 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. ', 20 ) . "</p>\n<!-- /wp:paragraph -->\n\n";
+		$large_content = str_repeat( $paragraph, 3000 );
+		$helper_names  = array_keys( $this->invoke_protected( 'filter_block_helpers' ) );
+
+		$cleanup = $this->seed_current_post( $large_content );
+		try {
+			$this->assertFalse( $this->invoke_protected( 'post_content_has_filter_block', $GLOBALS['post'], $helper_names ) );
+			$configs = $this->invoke_protected( 'collect_filter_configs_from_post' );
+			$this->assertSame( array(), $configs );
+		} finally {
+			$cleanup();
+		}
+	}
+
+	/**
+	 * Posts that do contain a filter block must collect its config as before.
+	 */
+	public function test_collect_filter_configs_from_post_still_collects_configs_when_filter_block_present() {
+		$content      = '<!-- wp:paragraph --><p>Intro text.</p><!-- /wp:paragraph -->' .
+			'<!-- wp:jetpack-search/filter-checkbox {"filterType":"taxonomy","taxonomy":"category"} /-->';
+		$helper_names = array_keys( $this->invoke_protected( 'filter_block_helpers' ) );
+
+		$cleanup = $this->seed_current_post( $content );
+		try {
+			$this->assertTrue( $this->invoke_protected( 'post_content_has_filter_block', $GLOBALS['post'], $helper_names ) );
+			$configs  = $this->invoke_protected( 'collect_filter_configs_from_post' );
+			$expected = Filter_Checkbox::build_config(
+				array(
+					'filterType' => 'taxonomy',
+					'taxonomy'   => 'category',
+				),
+				'category'
+			);
+			$this->assertSame( array( 'category' => $expected ), $configs );
+		} finally {
+			$cleanup();
+		}
+	}
+
+	/**
+	 * A WC-only block name in a non-Woo post's body must not match — the
+	 * scan uses the helper-derived name list, not a blanket prefix.
+	 */
+	public function test_collect_filter_configs_from_post_ignores_wc_only_block_name_on_non_woo_site() {
+		Search_Blocks::set_woocommerce_blocks_enabled_for_testing( false );
+		$content = '<!-- wp:jetpack-search/filter-wc-stock-status /-->';
+
+		$cleanup = $this->seed_current_post( $content );
+		try {
+			$helper_names = array_keys( $this->invoke_protected( 'filter_block_helpers' ) );
+			$this->assertNotContains( 'jetpack-search/filter-wc-stock-status', $helper_names );
+			$this->assertFalse( $this->invoke_protected( 'post_content_has_filter_block', $GLOBALS['post'], $helper_names ) );
+			$configs = $this->invoke_protected( 'collect_filter_configs_from_post' );
+			$this->assertSame( array(), $configs );
+		} finally {
+			$cleanup();
+		}
+	}
+
+	/**
 	 * `min_price` / `max_price` are WC-only; `filter-wc-price` isn't
 	 * Registered on non-Woo sites. A stray deep link must not seed the
 	 * `priceRange` slice — otherwise the JS store would re-emit the params


### PR DESCRIPTION
Fixes [Search-295](https://linear.app/a8c/issue/SEARCH-295/jetpack-search-collect-filter-configs-from-post-parse-blocks-oom-on)

## Proposed changes
* `Search_Blocks::collect_filter_configs_from_post()` runs on every front-end request (via `seed_interactivity_state()`, hooked on `template_redirect` and `wp_enqueue_scripts`) and unconditionally called `parse_blocks()` on the full post body, even when the post contained no Jetpack Search filter blocks. On large posts this exhausted PHP's memory limit in production.
* Add a cheap `has_block()` pre-check (`Search_Blocks::post_content_has_filter_block()`) that skips the `parse_blocks()` walk entirely unless the post actually contains one of the known filter-block names.
* No behavior change for posts that do contain a filter block — the full walk still runs and produces the same `filterConfigs`.

## Related product discussion/links

* SEARCH-295

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Checkout this branch.
* Run the automated suite: `jetpack test php packages/search -v` — all tests should pass, including three new ones in `Search_Blocks_Test.php` covering: a large post body with no filter blocks (pre-check short-circuits, empty result), a post that does contain a filter block (config collection unchanged), and a WooCommerce-only filter block name on a non-WooCommerce site (still excluded).
* Manual check: on a site with Jetpack Search's blocks-powered search experience active (Embedded or Blocks Overlay experience), create a post/page with a large body (several thousand words) containing no Jetpack Search filter block, and confirm the front end loads normally.
* Add a Jetpack Search filter block (e.g. "Filter by Category") to a search page/template and confirm filters still render and function as before.
