### PR TITLE
Search: stop printing theme-token-sampler once the Search module is disabled

### DIFF
--- a/projects/packages/search/changelog/fix-search-299-theme-token-sampler-module-gate
+++ b/projects/packages/search/changelog/fix-search-299-theme-token-sampler-module-gate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: Stop printing the theme-token-sampler script once the Search module is disabled.

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1210,9 +1210,15 @@ class Search_Blocks {
 	 * theme paints on the browser canvas) or when bg equals ink (vintage
 	 * frame-themes like Twenty Sixteen use body as a colored border around a
 	 * lighter `.site` content wrapper). See AGENTS.md § Theme tokens.
+	 *
+	 * Hooked unconditionally in `init()` (registration must happen before the
+	 * module-active check so editor-facing registration isn't disturbed — see
+	 * `Initializer::init_search_blocks()`), so the module-active gate lives
+	 * here instead. Nothing in the sampled tokens' consumers (the Search
+	 * blocks' own stylesheets) matters once the module is off.
 	 */
 	public static function print_theme_token_sampler(): void {
-		if ( is_admin() ) {
+		if ( is_admin() || ! ( new Module_Control() )->is_active() ) {
 			return;
 		}
 		echo "<script id='jetpack-search-theme-token-sampler'>(function(){try{var c=getComputedStyle(document.body),r=document.documentElement,ink=c.color,bg=c.backgroundColor;if(ink){r.style.setProperty('--jp-search-page-ink',ink);}if(bg&&bg!==ink&&bg!=='rgba(0, 0, 0, 0)'&&bg!=='transparent'){r.style.setProperty('--jp-search-page-surface',bg);}}catch(e){}})();</script>";

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -1211,11 +1211,9 @@ class Search_Blocks {
 	 * frame-themes like Twenty Sixteen use body as a colored border around a
 	 * lighter `.site` content wrapper). See AGENTS.md § Theme tokens.
 	 *
-	 * Hooked unconditionally in `init()` (registration must happen before the
-	 * module-active check so editor-facing registration isn't disturbed — see
-	 * `Initializer::init_search_blocks()`), so the module-active gate lives
-	 * here instead. Nothing in the sampled tokens' consumers (the Search
-	 * blocks' own stylesheets) matters once the module is off.
+	 * The `wp_body_open` hook registers unconditionally in `init()`, before
+	 * the module-active check in `Initializer::init_search_blocks()` — so the
+	 * module gate lives here instead, front-end only.
 	 */
 	public static function print_theme_token_sampler(): void {
 		if ( is_admin() || ! ( new Module_Control() )->is_active() ) {

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -1323,6 +1323,61 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
+	 * `print_theme_token_sampler()` is hooked into `wp_body_open` regardless
+	 * of module state — it runs before the module-active check on purpose
+	 * (see `Initializer::init_search_blocks()`), so the module gate has to
+	 * live inside the callback itself (SEARCH-299) rather than the hook.
+	 */
+	public function test_init_registers_theme_token_sampler_hook_regardless_of_module_state() {
+		$this->reset_search_blocks_hooks();
+		$this->set_module_active( false );
+		delete_option( Module_Control::SEARCH_MODULE_EXPERIENCE_OPTION_KEY );
+
+		Search_Blocks::init();
+
+		$this->assertNotFalse(
+			has_action( 'wp_body_open', array( Search_Blocks::class, 'print_theme_token_sampler' ) ),
+			'print_theme_token_sampler must hook into wp_body_open even while the module is inactive'
+		);
+	}
+
+	/**
+	 * The sampler script prints on the front end while the Search module is active.
+	 */
+	public function test_print_theme_token_sampler_prints_when_module_active() {
+		$this->set_module_active( true );
+
+		ob_start();
+		Search_Blocks::print_theme_token_sampler();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString(
+			"id='jetpack-search-theme-token-sampler'",
+			$output,
+			'The sampler script must print on the front end while the Search module is active.'
+		);
+	}
+
+	/**
+	 * Disabling the Search module must stop the sampler script from printing
+	 * on the front end (SEARCH-299) — even though its `wp_body_open`
+	 * registration happens before the module-active check.
+	 */
+	public function test_print_theme_token_sampler_skipped_when_module_inactive() {
+		$this->set_module_active( false );
+
+		ob_start();
+		Search_Blocks::print_theme_token_sampler();
+		$output = ob_get_clean();
+
+		$this->assertSame(
+			'',
+			$output,
+			'The sampler script must not print once the Search module is disabled.'
+		);
+	}
+
+	/**
 	 * Read the private `registered` map off the WP_Script_Modules singleton.
 	 *
 	 * @return array<string,array> Registered script modules keyed by id.

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -1323,10 +1323,8 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * `print_theme_token_sampler()` is hooked into `wp_body_open` regardless
-	 * of module state — it runs before the module-active check on purpose
-	 * (see `Initializer::init_search_blocks()`), so the module gate has to
-	 * live inside the callback itself (SEARCH-299) rather than the hook.
+	 * The `wp_body_open` registration itself stays unconditional (SEARCH-299)
+	 * — the module gate lives inside the callback instead.
 	 */
 	public function test_init_registers_theme_token_sampler_hook_regardless_of_module_state() {
 		$this->reset_search_blocks_hooks();
@@ -1359,9 +1357,7 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
-	 * Disabling the Search module must stop the sampler script from printing
-	 * on the front end (SEARCH-299) — even though its `wp_body_open`
-	 * registration happens before the module-active check.
+	 * Disabling the Search module stops the sampler script from printing (SEARCH-299).
 	 */
 	public function test_print_theme_token_sampler_skipped_when_module_inactive() {
 		$this->set_module_active( false );


### PR DESCRIPTION
Fixes SEARCH-299

## Proposed changes
* Gate `Search_Blocks::print_theme_token_sampler()` on `Module_Control()->is_active()` so the `jetpack-search-theme-token-sampler` inline script stops printing as soon as the Search module is disabled.

## Related product discussion/links
* Linear: SEARCH-299

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

**Root cause:** `Search_Blocks::init()` hooks `print_theme_token_sampler()` into `wp_body_open` unconditionally, and `Initializer::init_search_blocks()` (which calls `Search_Blocks::init()`) intentionally runs *before* the `Module_Control()->is_active()` check further down in `Initializer::init()` — that ordering exists so admins can still configure Search blocks in the block editor while the runtime module is off. The `print_theme_token_sampler()` callback already no-ops in `is_admin()`, so it gets zero benefit from the early registration, but it was still printing on every front-end page load regardless of module state. On at least one site (Chaplin theme) the always-present script conflicted with the theme's own JS and broke a "Load More" button.

Fix: add the same `Module_Control()->is_active()` check directly inside `print_theme_token_sampler()`, alongside the existing `is_admin()` check. This only affects the front-end script output — block/editor registration is untouched.

* With the Search module **enabled**, load any front-end page and confirm `<script id='jetpack-search-theme-token-sampler'>` still appears in the page source.
* Disable the Search module (Jetpack → Settings → Search, or `wp jetpack module deactivate search`).
* Reload the same front-end page and confirm the sampler script is gone.
* Confirm the block editor (Search blocks in the inserter) still works normally regardless of module state.

Covered by new unit tests in `Search_Blocks_Test.php`:
* `test_init_registers_theme_token_sampler_hook_regardless_of_module_state` — the `wp_body_open` hook still registers even while the module is inactive (editor-facing registration unaffected).
* `test_print_theme_token_sampler_prints_when_module_active` — script prints on the front end while active.
* `test_print_theme_token_sampler_skipped_when_module_inactive` — script is suppressed once the module is inactive.
