### PR TITLE
Jetpack AI Sidebar: Skip AI surfaces for disconnected users

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-ai-sidebar-skip-enqueue-disconnected
+++ b/projects/plugins/jetpack/changelog/fix-ai-sidebar-skip-enqueue-disconnected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Jetpack AI: Skip the AI sidebar bundle, provider registration, and toolbar button for users without a connected WordPress.com account.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -100,6 +100,10 @@ class Jetpack_AI_Sidebar {
 			return;
 		}
 
+		if ( self::is_agents_manager_disconnected() ) {
+			return;
+		}
+
 		// Guard against double-enqueue (e.g. hooked multiple times).
 		if ( wp_script_is( 'jetpack-ai-provider' ) ) {
 			return;
@@ -211,6 +215,11 @@ class Jetpack_AI_Sidebar {
 		// wrapper is registered. Avoid registering the wrapper when AM may
 		// import it before window.__JetpackAIProvider exists.
 		if ( ! self::should_expose_provider() ) {
+			return $providers;
+		}
+
+		// The providers filter still runs for disconnected variants.
+		if ( self::is_agents_manager_disconnected() ) {
 			return $providers;
 		}
 
@@ -378,6 +387,19 @@ class Jetpack_AI_Sidebar {
 	}
 
 	/**
+	 * Whether the Agents Manager is loading a disconnected build, which it does
+	 * when the current user has no linked WordPress.com account.
+	 *
+	 * @return bool
+	 */
+	private static function is_agents_manager_disconnected(): bool {
+		$variant = Agents_Manager::get_active_variant();
+
+		// Null means the Agents Manager is not loading at all, which is not a disconnection.
+		return is_string( $variant ) && str_contains( $variant, 'disconnected' );
+	}
+
+	/**
 	 * Preview configuration consumed by the Agents Manager and Jetpack AI provider bundles.
 	 *
 	 * @return array Preview mode and feature availability.
@@ -431,6 +453,7 @@ class Jetpack_AI_Sidebar {
 		$preview_config = self::get_jetpack_ai_sidebar_preview_config();
 
 		return self::should_expose_provider()
+			&& ! self::is_agents_manager_disconnected()
 			&& true === ( $preview_config['features']['blockToolbarButton'] ?? false );
 	}
 

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -569,6 +569,11 @@ class Jetpack_AI_Sidebar {
 			return;
 		}
 
+		// The second path the provider URL can reach agentsManagerData by.
+		if ( self::is_agents_manager_disconnected() ) {
+			return;
+		}
+
 		// Build the assignments from the same field source as the data filter so the
 		// two emit paths cannot drift. agentId is guarded client-side because the
 		// externally emitted payload may already define the active agent.

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -84,6 +84,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		remove_all_filters( 'jetpack_disable_seo_tools' );
 		remove_all_filters( 'ai_seo_enhancer_enabled' );
 		Status_Cache::clear();
+		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
 		( new \Automattic\Jetpack\Connection\Manager( 'jetpack' ) )->reset_connection_status();
 		delete_option( 'jetpack_offline_mode' );
 		delete_option( 'big_sky_enable' );
@@ -1036,6 +1037,42 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		Jetpack_AI_Sidebar::maybe_patch_jetpack_ai_sidebar_preview_data();
 
 		$this->assertFalse( wp_script_is( 'agents-manager', 'enqueued' ) );
+	}
+
+	/**
+	 * Test that the preview data patch is a no-op for a disconnected variant.
+	 */
+	public function test_patch_jetpack_ai_sidebar_preview_data_skips_when_agents_manager_variant_is_disconnected() {
+		$this->set_block_editor_screen();
+		$this->cache_sidebar_asset_data();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		add_filter( 'agents_manager_variant', array( __CLASS__, 'return_gutenberg_disconnected_variant' ) );
+		wp_enqueue_script( 'agents-manager', 'https://example.com/am.js', array(), '1.0', true );
+
+		Jetpack_AI_Sidebar::maybe_patch_jetpack_ai_sidebar_preview_data();
+
+		$inline_script = $this->get_agents_manager_inline_script();
+
+		$this->assertStringNotContainsString( 'agentsManagerData.agentProviders', $inline_script );
+		$this->assertStringNotContainsString( 'agentsManagerData.jetpackAiSidebar', $inline_script );
+	}
+
+	/**
+	 * Test that the preview data patch still runs for a connected variant.
+	 */
+	public function test_patch_jetpack_ai_sidebar_preview_data_runs_when_agents_manager_variant_is_connected() {
+		$this->set_block_editor_screen();
+		$this->cache_sidebar_asset_data();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		add_filter( 'agents_manager_variant', array( __CLASS__, 'return_gutenberg_variant' ) );
+		wp_enqueue_script( 'agents-manager', 'https://example.com/am.js', array(), '1.0', true );
+
+		Jetpack_AI_Sidebar::maybe_patch_jetpack_ai_sidebar_preview_data();
+
+		$inline_script = $this->get_agents_manager_inline_script();
+
+		$this->assertStringContainsString( 'agentsManagerData.agentProviders', $inline_script );
+		$this->assertStringContainsString( 'agentsManagerData.jetpackAiSidebar', $inline_script );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -107,6 +107,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
 		remove_all_filters( 'agents_manager_agent_providers' );
 		remove_all_filters( 'agents_manager_enabled_in_block_editor' );
+		remove_all_filters( 'agents_manager_variant' );
 		remove_all_filters( 'jetpack_ai_sidebar_preview_enabled' );
 		remove_all_filters( 'jetpack_ai_sidebar_preview_features' );
 		remove_all_filters( 'jetpack_ai_sidebar_agents_manager_data' );
@@ -558,6 +559,28 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		add_filter( 'jetpack_ai_sidebar_enabled', '__return_false' );
 
 		$this->assertFalse( Jetpack_AI_Sidebar::is_toolbar_button_enabled() );
+	}
+
+	/**
+	 * Test that the toolbar button is disabled for a disconnected variant.
+	 */
+	public function test_toolbar_button_disabled_when_agents_manager_variant_is_disconnected() {
+		$this->set_block_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		add_filter( 'agents_manager_variant', array( __CLASS__, 'return_gutenberg_disconnected_variant' ) );
+
+		$this->assertFalse( Jetpack_AI_Sidebar::is_toolbar_button_enabled() );
+	}
+
+	/**
+	 * Test that the toolbar button stays enabled for a connected variant.
+	 */
+	public function test_toolbar_button_enabled_when_agents_manager_variant_is_connected() {
+		$this->set_block_editor_screen();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		add_filter( 'agents_manager_variant', array( __CLASS__, 'return_gutenberg_variant' ) );
+
+		$this->assertTrue( Jetpack_AI_Sidebar::is_toolbar_button_enabled() );
 	}
 
 	/**
@@ -1184,6 +1207,52 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertFalse( wp_script_is( 'jetpack-ai-provider', 'enqueued' ) );
 	}
 
+	/**
+	 * Test that the abilities script is skipped for a disconnected variant.
+	 */
+	public function test_abilities_script_skips_when_agents_manager_variant_is_disconnected() {
+		$this->set_block_editor_screen();
+		$this->cache_sidebar_asset_data();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		add_filter( 'agents_manager_variant', array( __CLASS__, 'return_gutenberg_disconnected_variant' ) );
+
+		Jetpack_AI_Sidebar::maybe_enqueue_abilities_script();
+
+		$this->assertFalse( wp_script_is( 'jetpack-ai-provider', 'enqueued' ) );
+	}
+
+	/**
+	 * Test that the abilities script is still enqueued for a connected variant.
+	 */
+	public function test_abilities_script_enqueues_when_agents_manager_variant_is_connected() {
+		$this->set_block_editor_screen();
+		$this->cache_sidebar_asset_data();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		add_filter( 'agents_manager_variant', array( __CLASS__, 'return_gutenberg_variant' ) );
+
+		Jetpack_AI_Sidebar::maybe_enqueue_abilities_script();
+
+		$this->assertTrue( wp_script_is( 'jetpack-ai-provider', 'enqueued' ) );
+	}
+
+	/**
+	 * Agents Manager variant for a block editor request by a disconnected user.
+	 *
+	 * @return string
+	 */
+	public static function return_gutenberg_disconnected_variant() {
+		return 'gutenberg-disconnected';
+	}
+
+	/**
+	 * Agents Manager variant for a block editor request by a connected user.
+	 *
+	 * @return string
+	 */
+	public static function return_gutenberg_variant() {
+		return 'gutenberg';
+	}
+
 	// ──────────────────────────────────────────────────
 	// register_provider() tests
 	// ──────────────────────────────────────────────────
@@ -1225,6 +1294,35 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		// No hardcoded fallback — skip registration when asset manifest is unavailable.
 		$this->assertCount( 1, $providers );
 		$this->assertSame( 'https://example.com/other-provider.mjs', $providers[0] );
+	}
+
+	/**
+	 * Test that register_provider adds nothing for a disconnected variant.
+	 */
+	public function test_register_provider_skips_when_agents_manager_variant_is_disconnected() {
+		$this->set_block_editor_screen();
+		$this->cache_sidebar_asset_data();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		add_filter( 'agents_manager_variant', array( __CLASS__, 'return_gutenberg_disconnected_variant' ) );
+
+		$existing  = array( 'https://example.com/other-provider.mjs' );
+		$providers = Jetpack_AI_Sidebar::register_provider( $existing );
+
+		$this->assertSame( $existing, $providers );
+	}
+
+	/**
+	 * Test that register_provider still registers for a connected variant.
+	 */
+	public function test_register_provider_registers_when_agents_manager_variant_is_connected() {
+		$this->set_block_editor_screen();
+		$this->cache_sidebar_asset_data();
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		add_filter( 'agents_manager_variant', array( __CLASS__, 'return_gutenberg_variant' ) );
+
+		$providers = Jetpack_AI_Sidebar::register_provider( array( 'https://example.com/other-provider.mjs' ) );
+
+		$this->assertContains( AiAssistantPlugin\AI_SIDEBAR_PROVIDER_URL, $providers );
 	}
 
 	/**


### PR DESCRIPTION
Relates to FORNO-435

## Proposed changes
* Skip three Jetpack AI surfaces when the Agents Manager has loaded a `*-disconnected` build: the provider bundle (`jetpack-ai-sidebar.min.js` and its stylesheet), the Agents Manager provider registration, and the AI toolbar button.
* The gates only checked `has_connected_owner()` — a site-level check — while the Agents Manager picks its variant from `is_user_connected()`, a per-user check. An admin without a linked WordPress.com account therefore got all three from a build that cannot host them.
* Adds one predicate reading `Agents_Manager::get_active_variant()` so the two sides can't drift. A `null` variant (Agents Manager not loading at all) still loads, since the abilities also serve Big Sky standalone.
* The predicate is deliberately **not** folded into `should_expose_provider()`: that method backs the `agents_manager_enabled_in_block_editor` filter, which the variant calculation applies, so checking there recurses until PHP segfaults. The docblock records this.

## Related product discussion/links
* FORNO-435

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* On a Jetpack-connected site, sign in as an admin whose WordPress.com account is **not** linked (a second admin who never completed the user connection).
* Open any post in the block editor. Check the Network tab: `agents-manager-gutenberg-disconnected.min.js` should load, `jetpack-ai-sidebar.min.js` should **not**.
* Confirm the block toolbar shows the legacy AI button rather than the Jetpack AI Sidebar one.
* Connect your user from the "My Jetpack" page and reload the block editor: `agents-manager-gutenberg.min.js` and `jetpack-ai-sidebar.min.js` should both load and the sidebar toolbar button should return, as before.
