### PR TITLE
Analytics: update widget titles and helper copy

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-widget-titles-and-helper-copy
+++ b/projects/packages/premium-analytics/changelog/update-widget-titles-and-helper-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update Analytics dashboard widget titles and helper copy to the agreed Jetpack Stats naming.

--- a/projects/packages/premium-analytics/widgets/annual-highlights/widget.json
+++ b/projects/packages/premium-analytics/widgets/annual-highlights/widget.json
@@ -1,6 +1,6 @@
 {
 	"name": "jpa/annual-highlights",
-	"title": "Annual highlights",
+	"title": "Highlights",
 	"description": "Your totals for the year at a glance — posts, words, likes, and comments.",
 	"help": {
 		"content": "Your totals for the year at a glance — posts, words, likes, and comments."

--- a/projects/packages/premium-analytics/widgets/authors/widget.json
+++ b/projects/packages/premium-analytics/widgets/authors/widget.json
@@ -1,6 +1,6 @@
 {
 	"name": "jpa/authors",
-	"title": "Authors",
+	"title": "Popular authors",
 	"description": "Top authors by views, with their most viewed posts.",
 	"help": {
 		"content": "The authors whose content received the most views.",

--- a/projects/packages/premium-analytics/widgets/clicks/widget.json
+++ b/projects/packages/premium-analytics/widgets/clicks/widget.json
@@ -1,6 +1,6 @@
 {
 	"name": "jpa/clicks",
-	"title": "Clicks",
+	"title": "Top links clicked",
 	"description": "Most clicked external links on your site.",
 	"help": {
 		"content": "The external links your visitors clicked most often, sorted by clicks.",

--- a/projects/packages/premium-analytics/widgets/emails/widget.json
+++ b/projects/packages/premium-analytics/widgets/emails/widget.json
@@ -1,6 +1,6 @@
 {
 	"name": "jpa/stats-emails",
-	"title": "Emails",
+	"title": "Latest emails sent",
 	"description": "Open and click rates for your latest emails.",
 	"help": {
 		"content": "Your most recently sent emails, including their open and click rates."

--- a/projects/packages/premium-analytics/widgets/file-downloads/widget.json
+++ b/projects/packages/premium-analytics/widgets/file-downloads/widget.json
@@ -1,6 +1,6 @@
 {
 	"name": "jpa/file-downloads",
-	"title": "File downloads",
+	"title": "Top downloaded",
 	"description": "Most downloaded files on your site.",
 	"help": {
 		"content": "The files your visitors downloaded most often, sorted by number of downloads.",

--- a/projects/packages/premium-analytics/widgets/locations/widget.json
+++ b/projects/packages/premium-analytics/widgets/locations/widget.json
@@ -1,6 +1,6 @@
 {
 	"name": "jpa/locations",
-	"title": "Locations",
+	"title": "Top locations",
 	"description": "Where your visitors are viewing from — by country, region, or city.",
 	"help": {
 		"content": "The countries, regions, and cities where your visitors came from, sorted by views.",

--- a/projects/packages/premium-analytics/widgets/referrers/widget.json
+++ b/projects/packages/premium-analytics/widgets/referrers/widget.json
@@ -1,6 +1,6 @@
 {
 	"name": "jpa/referrers",
-	"title": "Referrers",
+	"title": "Top referrers",
 	"description": "Websites and search engines referring visitors to your site.",
 	"help": {
 		"content": "The sources that sent the most visitors to your site, sorted by clicks.",

--- a/projects/packages/premium-analytics/widgets/search-terms/widget.json
+++ b/projects/packages/premium-analytics/widgets/search-terms/widget.json
@@ -1,6 +1,6 @@
 {
 	"name": "jpa/search-terms",
-	"title": "Search Terms",
+	"title": "Top searched terms",
 	"description": "The search terms visitors use to find your site.",
 	"help": {
 		"content": "The most popular search terms visitors used to find your site.",

--- a/projects/packages/premium-analytics/widgets/shares/widget.json
+++ b/projects/packages/premium-analytics/widgets/shares/widget.json
@@ -1,6 +1,6 @@
 {
 	"name": "jpa/shares",
-	"title": "Shares",
+	"title": "Top social media shares",
 	"description": "The number of times your content was shared to social networks.",
 	"help": {
 		"content": "The platforms where your content was shared most often, sorted by number of shares."

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/widget.json
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/widget.json
@@ -1,9 +1,9 @@
 {
 	"name": "jpa/subscribers-chart",
-	"title": "Subscribers",
+	"title": "Subscribers summary",
 	"description": "Track subscriber growth over time, with paid subscribers and the previous period overlaid for comparison.",
 	"help": {
-		"content": "A summary of your subscriber growth over time, with paid subscribers and the previous period overlaid for comparison."
+		"content": "A summary of the new subscribers you gained over time."
 	},
 	"category": "subscribers",
 	"presentation": "framed"

--- a/projects/packages/premium-analytics/widgets/subscribers-list/widget.json
+++ b/projects/packages/premium-analytics/widgets/subscribers-list/widget.json
@@ -1,6 +1,6 @@
 {
 	"name": "jpa/subscribers-list",
-	"title": "Latest Subscribers",
+	"title": "Latest subscribers",
 	"description": "Your most recent subscribers.",
 	"help": {
 		"content": "Your most recent subscribers."

--- a/projects/packages/premium-analytics/widgets/tags/widget.json
+++ b/projects/packages/premium-analytics/widgets/tags/widget.json
@@ -1,6 +1,6 @@
 {
 	"name": "jpa/tags",
-	"title": "Tags & categories",
+	"title": "Top tags & categories",
 	"description": "Your most visited tags and categories, ranked by views.",
 	"help": {
 		"content": "The tags and categories associated with your most-viewed content, sorted by views.",

--- a/projects/packages/premium-analytics/widgets/top-platforms/widget.json
+++ b/projects/packages/premium-analytics/widgets/top-platforms/widget.json
@@ -1,6 +1,6 @@
 {
 	"name": "jpa/top-platforms",
-	"title": "Top Platforms",
+	"title": "Top platforms",
 	"description": "Top browsers and operating systems your visitors use.",
 	"help": {
 		"content": "A breakdown of the operating systems and browsers your visitors used, sorted by views.",

--- a/projects/packages/premium-analytics/widgets/top-posts/widget.json
+++ b/projects/packages/premium-analytics/widgets/top-posts/widget.json
@@ -1,6 +1,6 @@
 {
 	"name": "jpa/stats-top-posts",
-	"title": "Most viewed",
+	"title": "Top pages",
 	"description": "Your most viewed posts, pages, and archives.",
 	"help": {
 		"content": "Your most popular posts and pages, sorted by views.",

--- a/projects/packages/premium-analytics/widgets/traffic-chart/widget.json
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/widget.json
@@ -1,9 +1,9 @@
 {
 	"name": "jpa/traffic-chart",
-	"title": "Traffic",
+	"title": "Summary",
 	"description": "Compare views, visitors, likes, and comments over the selected period, with the previous period overlaid for comparison.",
 	"help": {
-		"content": "A summary of your site's views, visitors, likes, and comments, with the previous period overlaid for comparison."
+		"content": "A summary of your site's views, visitors, likes, and comments."
 	},
 	"category": "traffic",
 	"presentation": "framed"

--- a/projects/packages/premium-analytics/widgets/utm-insights/widget.json
+++ b/projects/packages/premium-analytics/widgets/utm-insights/widget.json
@@ -1,6 +1,6 @@
 {
 	"name": "jpa/utm-insights",
-	"title": "UTM Insights",
+	"title": "Top UTM",
 	"description": "Traffic breakdown by UTM parameters — source, medium, campaign, and combinations.",
 	"help": {
 		"content": "Your top UTM campaigns, sorted by views.",

--- a/projects/packages/premium-analytics/widgets/videopress/widget.json
+++ b/projects/packages/premium-analytics/widgets/videopress/widget.json
@@ -1,6 +1,6 @@
 {
 	"name": "jpa/videopress",
-	"title": "VideoPress",
+	"title": "Top videos",
 	"description": "Your most played VideoPress videos, sourced from Jetpack Stats.",
 	"help": {
 		"content": "The published videos your visitors watched most often, sorted by views.",


### PR DESCRIPTION
## Proposed changes

Applies the agreed widget naming/helper copy from the **Analytics – Helpers mapping → Widgets mapping** sheet to the Premium Analytics dashboard. All changes are copy-only, in `widget.json` (`title` and `help.content`).

### Traffic

| Widget | Title | Helper |
| --- | --- | --- |
| `traffic-chart` | Traffic → **Summary** | now “A summary of your site's views, visitors, likes, and comments.” |
| `top-posts` | Most viewed → **Top pages** | already matched |
| `referrers` | Referrers → **Top referrers** | already matched |
| `locations` | Locations → **Top locations** | already matched |
| `utm-insights` | UTM Insights → **Top UTM** | already matched |
| `clicks` | Clicks → **Top links clicked** | already matched |
| `authors` | Authors → **Popular authors** | already matched |
| `search-terms` | Search Terms → **Top searched terms** | already matched |
| `videopress` | VideoPress → **Top videos** | already matched |
| `file-downloads` | File downloads → **Top downloaded** | already matched |
| `devices` | Devices (unchanged) | already matched |
| `top-platforms` | Top Platforms → **Top platforms** (casing) | already matched |

### Insights

| Widget | Title | Helper |
| --- | --- | --- |
| `annual-highlights` | Annual highlights → **Highlights** | sheet says TBD — left as-is |
| `tags` | Tags & categories → **Top tags & categories** | already matched |
| `shares` | Shares → **Top social media shares** | already matched |
| `posting-activity`, `latest-post` | unchanged | already matched |

### Subscribers

| Widget | Title | Helper |
| --- | --- | --- |
| `subscribers-chart` | Subscribers → **Subscribers summary** | now “A summary of the new subscribers you gained over time.” |
| `subscribers-list` | Latest Subscribers → **Latest subscribers** (casing) | already matched |
| `emails` | Emails → **Latest emails sent** | already matched |

### Store (WooCommerce)

No changes needed — every helper string in the sheet's WooCommerce tab already matches the shipped `help.content` verbatim, and the sheet leaves the “Adjusted title” column empty for that tab.

## Not covered by this PR

These rows in the sheet could not be applied cleanly and are called out for a follow-up decision:

* **Traffic views activity** (Insights) — no site-level daily-views heatmap widget exists yet. `post-traffic-activity` is the post-detail equivalent, not this one.
* **Total views** / **Total visitors** (Insights) — not ported yet (tracked in WOOA7S-1512); today they are tiles inside `all-time-stats`, not standalone widgets.
* **Popular post** (Insights) — not ported yet (part of WOOA7S-1510).
* **Popular hours** / **Popular days** (Insights) — the sheet implies two split widgets (day-of-week vs hour-of-day). Today `most-popular-time` shows *both* best day and best hour in one card, and `most-popular-day` shows the single all-time record calendar date — which is not “the days of the week … on average”. Renaming either one would make the helper copy wrong, so both were left alone.
* **Top commented posts** / **Top commented authors** (Insights) — the sheet splits these into two widgets; today `comments` is a single widget with author/post tabs. Left alone pending a decision on whether to split it.
* **Top UTM** helper — the sheet reads “… Learn more **or generate a new URL**”, implying a second help link to a UTM URL builder. No builder exists in the dashboard yet and there is no href to point at, so only the existing “Learn more” link is kept.
* Drill-down back-links inside widgets (e.g. “All UTM Insights”, “All Locations”, “All Clicks”) still use the old titles. They are breadcrumb labels rather than widget titles and aren't in the sheet, so they're untouched — happy to align them in a follow-up.

## Related product discussion/links

* WOOA7S-1784

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Build the plugin: `jetpack build plugins/premium-analytics --deps`.
2. Activate the Premium Analytics plugin and go to **wp-admin → Analytics**.
3. On the **Traffic** tab, confirm the card headers read: Summary, Top pages, Top referrers, Top locations, Devices, Top platforms, Top videos, Popular authors, Top UTM, Top links clicked, Top searched terms, Top downloaded.
4. On the **Insights** tab, confirm: Highlights, Top tags & categories, Top social media shares (plus the unchanged Latest post / Posting activity / All-time stats / Most popular time / Most popular day).
5. On the **Subscribers** tab, confirm: Subscribers summary, Latest subscribers, Latest emails sent.
6. Hover the ⓘ help icon on **Summary** and **Subscribers summary** and confirm the shortened helper text.
7. Open the widget inserter and confirm the renamed widgets are findable under their new titles.
