### PR TITLE
Jetpack AI: release Jetpack AI writing assistance features

### DIFF
--- a/projects/plugins/jetpack/changelog/align-ai-editorial-review-enablement
+++ b/projects/plugins/jetpack/changelog/align-ai-editorial-review-enablement
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Sidebar: Align Editorial Review enablement with the other writing-assistance features.

--- a/projects/plugins/jetpack/changelog/release-jetpack-ai-sidebar-features
+++ b/projects/plugins/jetpack/changelog/release-jetpack-ai-sidebar-features
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+AI Sidebar: Enable writing and SEO suggestions, the block toolbar button, and page and site editor support for all eligible users.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -292,49 +292,14 @@ class Jetpack_AI_Sidebar {
 	}
 
 	/**
-	 * UI feature flag for the Generate Feedback suggestion.
-	 *
-	 * Exposed only in internal testing environments while the feature is in development.
-	 *
-	 * @return bool
-	 */
-	private static function is_generate_feedback_enabled(): bool {
-		return jetpack_is_internal_testing_environment();
-	}
-
-	/**
-	 * UI feature flag for the Optimize Title suggestion.
-	 *
-	 * Exposed only in internal testing environments while the feature is in development.
-	 *
-	 * @return bool
-	 */
-	private static function is_optimize_title_suggestion_enabled(): bool {
-		return jetpack_is_internal_testing_environment();
-	}
-
-	/**
-	 * UI feature flag for Proofreader (spelling and grammar).
-	 *
-	 * Server-side permission checks still gate execution. This site-side flag
-	 * controls whether the Jetpack AI Sidebar exposes the Proofreader
-	 * suggestion. It follows Image Studio's internal rollout pattern.
-	 *
-	 * @return bool
-	 */
-	private static function is_proofread_content_enabled(): bool {
-		return jetpack_is_internal_testing_environment();
-	}
-
-	/**
 	 * UI feature flag for the SEO Enhancer suggestions (SEO title and meta description).
 	 *
-	 * Exposed only in internal testing environments while the feature is in development,
-	 * and only where the suggestions can actually be used: the SEO Enhancer is not
-	 * killed via its filter, the site's plan includes the Jetpack SEO feature (the
-	 * suggestions write to the plan-gated SEO title and meta description fields), and
-	 * SEO tools are usable on the site. Kept independent of the Optimize Title flag:
-	 * SEO suggestions target the SEO meta fields, not the visible post title.
+	 * Exposed only where the suggestions can actually be used: the SEO Enhancer
+	 * is not killed via its filter, the site's plan includes the Jetpack SEO
+	 * feature (the suggestions write to the plan-gated SEO title and meta
+	 * description fields), and SEO tools are usable on the site. Kept independent
+	 * of the Optimize Title suggestion: SEO suggestions target the SEO meta fields,
+	 * not the visible post title.
 	 *
 	 * The user-facing ai_seo_enhancer_enabled *option* is deliberately not consulted —
 	 * it only governs automatic generation on publish, while these suggestions are
@@ -343,34 +308,9 @@ class Jetpack_AI_Sidebar {
 	 * @return bool
 	 */
 	private static function is_seo_suggestions_enabled(): bool {
-		return jetpack_is_internal_testing_environment()
-			&& (bool) apply_filters( 'ai_seo_enhancer_enabled', true )
+		return (bool) apply_filters( 'ai_seo_enhancer_enabled', true )
 			&& self::has_seo_feature()
 			&& self::is_seo_tools_usable();
-	}
-
-	/**
-	 * UI feature flag for the Generate Excerpt suggestion.
-	 *
-	 * Exposed only in internal testing environments while the feature is in development.
-	 * No plan gate: the excerpt is a core editorial field, and the ability's own
-	 * permission callback (edit_posts) gates execution server-side.
-	 *
-	 * @return bool
-	 */
-	private static function is_excerpt_suggestion_enabled(): bool {
-		return jetpack_is_internal_testing_environment();
-	}
-
-	/**
-	 * UI feature flag for the block toolbar button that replaces the legacy AI toolbar.
-	 *
-	 * Exposed only in internal testing environments while the feature is in development.
-	 *
-	 * @return bool
-	 */
-	private static function is_block_toolbar_button_enabled(): bool {
-		return jetpack_is_internal_testing_environment();
 	}
 
 	/**
@@ -442,16 +382,14 @@ class Jetpack_AI_Sidebar {
 	 * Whether the Jetpack AI provider bundle should be exposed for this request.
 	 *
 	 * This is scoped to the supported editor surfaces: post editor, page editor,
-	 * and site editor. The existing post editor surface remains available when
-	 * preview and AI feature gates pass, while the new page and site editor
-	 * surfaces require an internal testing environment.
+	 * and site editor. Each surface remains subject to the preview and AI feature
+	 * gates.
 	 *
 	 * @return bool
 	 */
 	private static function should_expose_provider(): bool {
 		return self::is_jetpack_ai_sidebar_preview_enabled()
 			&& self::is_supported_provider_surface()
-			&& self::is_provider_rollout_enabled()
 			&& self::has_ai_features();
 	}
 
@@ -461,15 +399,17 @@ class Jetpack_AI_Sidebar {
 	 * @return array Preview mode and feature availability.
 	 */
 	private static function get_jetpack_ai_sidebar_preview_config(): array {
+		// Ability permission callbacks enforce server-side access for these
+		// features. SEO additionally requires the site-side gates below.
 		$features = array(
 			'aiEditorialReview'       => self::is_ai_editorial_review_enabled(),
-			'generateFeedback'        => self::is_generate_feedback_enabled(),
-			'proofreadContent'        => self::is_proofread_content_enabled(),
+			'generateFeedback'        => true,
+			'proofreadContent'        => true,
 			'blockTransformations'    => true,
-			'blockToolbarButton'      => self::is_block_toolbar_button_enabled(),
-			'optimizeTitleSuggestion' => self::is_optimize_title_suggestion_enabled(),
+			'blockToolbarButton'      => true,
+			'optimizeTitleSuggestion' => true,
 			'seoSuggestions'          => self::is_seo_suggestions_enabled(),
-			'excerptSuggestion'       => self::is_excerpt_suggestion_enabled(),
+			'excerptSuggestion'       => true,
 			'chatHistory'             => false,
 			'supportGuides'           => false,
 		);
@@ -482,14 +422,14 @@ class Jetpack_AI_Sidebar {
 		$filtered_features = apply_filters( 'jetpack_ai_sidebar_preview_features', $features );
 		$features          = is_array( $filtered_features ) ? array_merge( $features, $filtered_features ) : $features;
 
-		// Re-assert the testing-environment gates so the generic features filter cannot
-		// expose in-development suggestions outside internal testing environments.
-		$features['generateFeedback']        = self::is_generate_feedback_enabled();
-		$features['proofreadContent']        = self::is_proofread_content_enabled();
-		$features['optimizeTitleSuggestion'] = (bool) $features['optimizeTitleSuggestion'] && self::is_optimize_title_suggestion_enabled();
-		$features['blockToolbarButton']      = (bool) $features['blockToolbarButton'] && self::is_block_toolbar_button_enabled();
+		// Normalize the flags released here while leaving host-added values
+		// untouched. Keep SEO's site-side requirements final.
+		$features['generateFeedback']        = (bool) $features['generateFeedback'];
+		$features['proofreadContent']        = (bool) $features['proofreadContent'];
+		$features['blockToolbarButton']      = (bool) $features['blockToolbarButton'];
+		$features['optimizeTitleSuggestion'] = (bool) $features['optimizeTitleSuggestion'];
 		$features['seoSuggestions']          = (bool) $features['seoSuggestions'] && self::is_seo_suggestions_enabled();
-		$features['excerptSuggestion']       = (bool) $features['excerptSuggestion'] && self::is_excerpt_suggestion_enabled();
+		$features['excerptSuggestion']       = (bool) $features['excerptSuggestion'];
 
 		return array(
 			'enabled'  => self::is_jetpack_ai_sidebar_preview_enabled(),
@@ -691,22 +631,6 @@ class Jetpack_AI_Sidebar {
 		return self::is_block_editor()
 			&& 'post' === $screen->base
 			&& in_array( $screen->post_type, array( 'post', 'page' ), true );
-	}
-
-	/**
-	 * Keep the existing post editor rollout while gating newly supported surfaces.
-	 *
-	 * @return bool
-	 */
-	private static function is_provider_rollout_enabled(): bool {
-		if ( jetpack_is_internal_testing_environment() ) {
-			return true;
-		}
-
-		$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
-		return $screen instanceof \WP_Screen
-			&& 'post' === $screen->base
-			&& 'post' === $screen->post_type;
 	}
 
 	/**

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -276,22 +276,6 @@ class Jetpack_AI_Sidebar {
 	// ──────────────────────────────────────────────────
 
 	/**
-	 * UI feature flag for AI Editorial Review.
-	 *
-	 * Server-side permission checks still gate execution. This site-side flag
-	 * controls whether the sidebar suggestion is exposed, while keeping a
-	 * feature-specific filter available as a kill switch.
-	 *
-	 * @return bool
-	 */
-	private static function is_ai_editorial_review_enabled(): bool {
-		return (bool) apply_filters(
-			'jetpack_ai_editorial_review_enabled',
-			true
-		);
-	}
-
-	/**
 	 * UI feature flag for the SEO Enhancer suggestions (SEO title and meta description).
 	 *
 	 * Exposed only where the suggestions can actually be used: the SEO Enhancer
@@ -402,7 +386,7 @@ class Jetpack_AI_Sidebar {
 		// Ability permission callbacks enforce server-side access for these
 		// features. SEO additionally requires the site-side gates below.
 		$features = array(
-			'aiEditorialReview'       => self::is_ai_editorial_review_enabled(),
+			'aiEditorialReview'       => true,
 			'generateFeedback'        => true,
 			'proofreadContent'        => true,
 			'blockTransformations'    => true,
@@ -424,6 +408,7 @@ class Jetpack_AI_Sidebar {
 
 		// Normalize the flags released here while leaving host-added values
 		// untouched. Keep SEO's site-side requirements final.
+		$features['aiEditorialReview']       = (bool) $features['aiEditorialReview'];
 		$features['generateFeedback']        = (bool) $features['generateFeedback'];
 		$features['proofreadContent']        = (bool) $features['proofreadContent'];
 		$features['blockToolbarButton']      = (bool) $features['blockToolbarButton'];
@@ -485,7 +470,7 @@ class Jetpack_AI_Sidebar {
 		// Set our fields in place, leaving the rest of $data (including agentProviders)
 		// untouched so the client-side gate can drop Jetpack AI Sidebar while keeping
 		// fallbacks such as the Big Sky provider. Hosts that need intentional overrides
-		// should use the AI Editorial Review and preview filters.
+		// should use the sidebar and preview feature filters.
 		foreach ( $fields as $key => $value ) {
 			$data[ $key ] = $value;
 		}

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -84,7 +84,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		remove_all_filters( 'jetpack_disable_seo_tools' );
 		remove_all_filters( 'ai_seo_enhancer_enabled' );
 		Status_Cache::clear();
-		unset( $_SERVER['A8C_PROXIED_REQUEST'] );
 		( new \Automattic\Jetpack\Connection\Manager( 'jetpack' ) )->reset_connection_status();
 		delete_option( 'jetpack_offline_mode' );
 		delete_option( 'big_sky_enable' );
@@ -186,6 +185,13 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Set the current screen to an unsupported admin surface.
+	 */
+	private function set_unsupported_admin_screen() {
+		set_current_screen( 'edit-post' );
+	}
+
+	/**
 	 * Enable the AI sidebar feature via filter.
 	 */
 	private function enable_sidebar() {
@@ -248,16 +254,15 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * Whether the preview gate is open, observed through a public surface.
 	 *
 	 * Uses enable_agents_manager_on_provider_surfaces(), which returns the preview gate
-	 * ANDed with supported-surface, internal-testing-environment, and AI-features
-	 * checks — all satisfied by the gate tests (set_up connects an owner; this
-	 * helper sets a supported editor screen and internal testing signal) — so it
-	 * reflects is_jetpack_ai_sidebar_preview_enabled() without reflection.
+	 * ANDed with supported-surface and AI-features checks — both satisfied by the
+	 * gate tests (set_up connects an owner; this helper sets a supported editor
+	 * screen) — so it reflects is_jetpack_ai_sidebar_preview_enabled() without
+	 * reflection.
 	 *
 	 * @return bool
 	 */
 	private function gate_open(): bool {
 		$this->set_block_editor_screen();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		return Jetpack_AI_Sidebar::enable_agents_manager_on_provider_surfaces( false );
 	}
 
@@ -532,31 +537,19 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	// ──────────────────────────────────────────────────
 
 	/**
-	 * Test that the toolbar button stays disabled until its preview feature is released.
+	 * Test that the toolbar button is enabled by default for eligible users.
 	 */
-	public function test_toolbar_button_disabled_by_default() {
+	public function test_toolbar_button_enabled_by_default() {
 		$this->set_block_editor_screen();
-
-		$this->assertFalse( Jetpack_AI_Sidebar::is_toolbar_button_enabled() );
-	}
-
-	/**
-	 * Test that the toolbar button is exposed by default in internal testing environments,
-	 * without needing the preview feature filter.
-	 */
-	public function test_toolbar_button_enabled_by_default_in_internal_testing() {
-		$this->set_block_editor_screen();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		$this->assertTrue( Jetpack_AI_Sidebar::is_toolbar_button_enabled() );
 	}
 
 	/**
-	 * Test that a host filter can still force the toolbar button off inside internal testing.
+	 * Test that a host filter can still force the toolbar button off.
 	 */
-	public function test_toolbar_button_filter_can_force_off_in_internal_testing() {
+	public function test_toolbar_button_filter_can_force_off() {
 		$this->set_block_editor_screen();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		add_filter(
 			'jetpack_ai_sidebar_preview_features',
 			static function ( $features ) {
@@ -566,23 +559,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertFalse( Jetpack_AI_Sidebar::is_toolbar_button_enabled() );
-	}
-
-	/**
-	 * Test that the preview feature flag activates the toolbar button.
-	 */
-	public function test_toolbar_button_enabled_by_preview_feature_flag() {
-		$this->set_block_editor_screen();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
-		add_filter(
-			'jetpack_ai_sidebar_preview_features',
-			static function ( $features ) {
-				$features['blockToolbarButton'] = true;
-				return $features;
-			}
-		);
-
-		$this->assertTrue( Jetpack_AI_Sidebar::is_toolbar_button_enabled() );
 	}
 
 	/**
@@ -607,18 +583,8 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_register_toolbar_button_extension_marks_feature_available() {
 		$this->set_block_editor_screen();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		$this->make_legacy_block_toolbar_extensions_available();
 		$this->enable_sidebar_extension_availability_checks();
-		add_filter( 'jetpack_ai_sidebar_enabled', '__return_true' );
-		add_filter( 'jetpack_ai_sidebar_preview_enabled', '__return_true' );
-		add_filter(
-			'jetpack_ai_sidebar_preview_features',
-			static function ( $features ) {
-				$features['blockToolbarButton'] = true;
-				return $features;
-			}
-		);
 
 		Jetpack_AI_Sidebar::register_toolbar_button_extension();
 
@@ -629,9 +595,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the toolbar button feature stays unavailable until the preview feature is released.
+	 * Test that the toolbar button feature can be disabled by the feature filter.
 	 */
-	public function test_register_toolbar_button_extension_skips_when_toolbar_button_disabled() {
+	public function test_register_toolbar_button_extension_honors_disabled_feature_filter() {
 		$this->set_block_editor_screen();
 		$this->make_legacy_block_toolbar_extensions_available();
 		$this->enable_sidebar_extension_availability_checks();
@@ -656,16 +622,8 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_register_toolbar_button_extension_marks_feature_available_in_page_editor() {
 		$this->set_page_block_editor_screen();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		$this->make_legacy_block_toolbar_extensions_available();
 		$this->enable_sidebar_extension_availability_checks();
-		add_filter(
-			'jetpack_ai_sidebar_preview_features',
-			static function ( $features ) {
-				$features['blockToolbarButton'] = true;
-				return $features;
-			}
-		);
 
 		Jetpack_AI_Sidebar::register_toolbar_button_extension();
 
@@ -679,16 +637,8 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_register_toolbar_button_extension_marks_feature_available_in_site_editor() {
 		$this->set_site_editor_screen();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		$this->make_legacy_block_toolbar_extensions_available();
 		$this->enable_sidebar_extension_availability_checks();
-		add_filter(
-			'jetpack_ai_sidebar_preview_features',
-			static function ( $features ) {
-				$features['blockToolbarButton'] = true;
-				return $features;
-			}
-		);
 
 		Jetpack_AI_Sidebar::register_toolbar_button_extension();
 
@@ -702,9 +652,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	// ──────────────────────────────────────────────────
 
 	/**
-	 * Test that the existing Simple post editor remains available outside internal testing.
+	 * Test that the existing Simple post editor remains available.
 	 */
-	public function test_enable_agents_manager_on_provider_surfaces_enables_simple_post_editor_outside_internal_testing() {
+	public function test_enable_agents_manager_on_provider_surfaces_enables_simple_post_editor() {
 		$this->set_block_editor_screen();
 		$this->simulate_wpcom_simple();
 
@@ -712,22 +662,19 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that newly supported editor surfaces remain limited to internal testing.
+	 * Test that the provider remains disabled when no editor screen is available.
 	 */
-	public function test_enable_agents_manager_on_provider_surfaces_gates_new_surfaces_outside_internal_testing() {
-		$this->set_page_block_editor_screen();
-		$this->assertFalse( Jetpack_AI_Sidebar::enable_agents_manager_on_provider_surfaces( false ) );
+	public function test_enable_agents_manager_on_provider_surfaces_skips_without_current_screen() {
+		$GLOBALS['current_screen'] = null;
 
-		$this->set_site_editor_screen();
 		$this->assertFalse( Jetpack_AI_Sidebar::enable_agents_manager_on_provider_surfaces( false ) );
 	}
 
 	/**
-	 * Test that the provider remains disabled when no editor screen is available.
+	 * Test that the provider remains disabled on unsupported admin screens.
 	 */
-	public function test_enable_agents_manager_on_provider_surfaces_skips_without_current_screen() {
-		$GLOBALS['current_screen']      = null;
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+	public function test_enable_agents_manager_on_provider_surfaces_skips_unsupported_admin_screen() {
+		$this->set_unsupported_admin_screen();
 
 		$this->assertFalse( Jetpack_AI_Sidebar::enable_agents_manager_on_provider_surfaces( false ) );
 	}
@@ -737,7 +684,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_enable_agents_manager_on_provider_surfaces_enables_page_editor_provider_surface() {
 		$this->set_page_block_editor_screen();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_on_provider_surfaces( false ) );
 	}
@@ -747,7 +693,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_enable_agents_manager_on_provider_surfaces_enables_site_editor_provider_surface() {
 		$this->set_site_editor_screen();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_on_provider_surfaces( false ) );
 	}
@@ -771,7 +716,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_enable_agents_manager_on_provider_surfaces_ignores_ai_editorial_review_filter() {
 		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
 		$this->set_block_editor_screen();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_on_provider_surfaces( false ) );
 	}
@@ -795,7 +739,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_add_agents_manager_data_exposes_ai_editorial_review_enabled() {
 		$this->set_block_editor_screen();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_true' );
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
@@ -805,10 +748,8 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['aiEditorialReview'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['blockTransformations'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['blockToolbarButton'] );
-		// A8C_PROXIED_REQUEST marks an internal testing environment, which is the same gate that
-		// emits this payload at all, so the in-development Generate Feedback, Optimize Title,
-		// Excerpt, and block toolbar button features are exposed here. SEO suggestions stay off
-		// because the seo-tools module and plan gate are not satisfied in this test.
+		// SEO suggestions stay off because the seo-tools module and plan gate are
+		// not satisfied in this test.
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['generateFeedback'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['optimizeTitleSuggestion'] );
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['seoSuggestions'] );
@@ -833,14 +774,12 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * In an internal testing environment, the in-development suggestions (Generate
-	 * Feedback, Proofreader, Optimize Title, SEO suggestions and the excerpt
-	 * suggestion) are exposed. The test plan supports advanced-seo, and the
-	 * seo-tools module is activated so the SEO suggestions gate is satisfied.
+	 * Released suggestions are exposed to eligible users. The test plan supports
+	 * advanced-seo, and the seo-tools module is activated so the SEO suggestions
+	 * gate is satisfied.
 	 */
-	public function test_add_agents_manager_data_exposes_in_development_features_in_testing_environment() {
+	public function test_add_agents_manager_data_exposes_released_features() {
 		$this->set_block_editor_screen();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		$this->activate_seo_tools_module();
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
@@ -853,20 +792,20 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The public post editor keeps AI Editorial Review while in-development suggestions
-	 * remain disabled outside internal testing, even when the generic filter enables them.
+	 * The generic preview features filter can still disable released features.
 	 */
-	public function test_add_agents_manager_data_keeps_aer_and_gates_in_development_features_outside_internal_testing() {
+	public function test_add_agents_manager_data_preview_features_filter_can_disable_released_features() {
 		$this->set_block_editor_screen();
 		$this->simulate_wpcom_simple();
 		add_filter(
 			'jetpack_ai_sidebar_preview_features',
 			function ( $features ) {
-				$features['generateFeedback']        = true;
-				$features['proofreadContent']        = true;
-				$features['optimizeTitleSuggestion'] = true;
-				$features['seoSuggestions']          = true;
-				$features['excerptSuggestion']       = true;
+				$features['generateFeedback']        = false;
+				$features['proofreadContent']        = false;
+				$features['blockToolbarButton']      = false;
+				$features['optimizeTitleSuggestion'] = false;
+				$features['seoSuggestions']          = false;
+				$features['excerptSuggestion']       = false;
 				return $features;
 			}
 		);
@@ -877,58 +816,17 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertTrue( $data['jetpackAiSidebar']['features']['aiEditorialReview'] );
 		$this->assertFalse( $data['jetpackAiSidebar']['features']['generateFeedback'] );
 		$this->assertFalse( $data['jetpackAiSidebar']['features']['proofreadContent'] );
+		$this->assertFalse( $data['jetpackAiSidebar']['features']['blockToolbarButton'] );
 		$this->assertFalse( $data['jetpackAiSidebar']['features']['optimizeTitleSuggestion'] );
 		$this->assertFalse( $data['jetpackAiSidebar']['features']['seoSuggestions'] );
 		$this->assertFalse( $data['jetpackAiSidebar']['features']['excerptSuggestion'] );
 	}
 
 	/**
-	 * The generic preview features filter can still disable the excerpt suggestion
-	 * inside a testing environment (the gate raises the floor, not the ceiling).
+	 * The generic preview features filter can still disable SEO suggestions.
 	 */
-	public function test_add_agents_manager_data_preview_features_filter_can_disable_excerpt_suggestion_in_testing_environment() {
+	public function test_add_agents_manager_data_preview_features_filter_can_disable_seo_suggestions() {
 		$this->set_block_editor_screen();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
-		add_filter(
-			'jetpack_ai_sidebar_preview_features',
-			function ( $features ) {
-				$features['excerptSuggestion'] = false;
-				return $features;
-			}
-		);
-
-		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
-
-		$this->assertSame( false, $data['jetpackAiSidebar']['features']['excerptSuggestion'] );
-	}
-
-	/**
-	 * The generic preview features filter can still disable Optimize Title inside a
-	 * testing environment (the gate raises the floor, not the ceiling).
-	 */
-	public function test_add_agents_manager_data_preview_features_filter_can_disable_optimize_title_in_testing_environment() {
-		$this->set_block_editor_screen();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
-		add_filter(
-			'jetpack_ai_sidebar_preview_features',
-			function ( $features ) {
-				$features['optimizeTitleSuggestion'] = false;
-				return $features;
-			}
-		);
-
-		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
-
-		$this->assertSame( false, $data['jetpackAiSidebar']['features']['optimizeTitleSuggestion'] );
-	}
-
-	/**
-	 * The generic preview features filter can still disable SEO suggestions inside a
-	 * testing environment (the gate raises the floor, not the ceiling).
-	 */
-	public function test_add_agents_manager_data_preview_features_filter_can_disable_seo_suggestions_in_testing_environment() {
-		$this->set_block_editor_screen();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		$this->activate_seo_tools_module();
 		add_filter(
 			'jetpack_ai_sidebar_preview_features',
@@ -944,13 +842,11 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * SEO suggestions require the seo-tools module: hidden even in a testing
-	 * environment while the module is inactive, since the SEO meta fields the
-	 * suggestions write to are not registered.
+	 * SEO suggestions require the seo-tools module because it registers the SEO
+	 * meta fields the suggestions write to.
 	 */
 	public function test_seo_suggestions_disabled_when_seo_tools_module_inactive() {
 		$this->set_block_editor_screen();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
@@ -964,7 +860,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_seo_suggestions_disabled_when_seo_tools_disabled_by_filter() {
 		$this->set_block_editor_screen();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		$this->activate_seo_tools_module();
 		add_filter( 'jetpack_disable_seo_tools', '__return_true' );
 
@@ -979,7 +874,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_seo_suggestions_disabled_when_seo_enhancer_disabled_by_filter() {
 		$this->set_block_editor_screen();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		$this->activate_seo_tools_module();
 		add_filter( 'ai_seo_enhancer_enabled', '__return_false' );
 
@@ -1016,7 +910,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_add_agents_manager_data_allows_preview_without_ai_editorial_review() {
 		$this->set_block_editor_screen();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
@@ -1025,8 +918,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertSame( true, $data['jetpackAiSidebar']['enabled'] );
 		$this->assertSame( false, $data['jetpackAiSidebar']['features']['aiEditorialReview'] );
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['blockTransformations'] );
-		// A8C_PROXIED_REQUEST marks an internal testing environment, so the in-development block
-		// toolbar button feature is exposed here even though AI Editorial Review is filtered off.
 		$this->assertSame( true, $data['jetpackAiSidebar']['features']['blockToolbarButton'] );
 	}
 
@@ -1035,7 +926,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_add_agents_manager_data_preserves_existing_agent_id() {
 		$this->set_block_editor_screen();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data(
 			array(
@@ -1049,13 +939,12 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Platform-emitted provider data is exposed in the Simple internal-testing
-	 * page editor and sets the default agent when upstream has not selected one.
+	 * Platform-emitted provider data is exposed in the Simple page editor and
+	 * sets the default agent when upstream has not selected one.
 	 */
-	public function test_add_agents_manager_data_adds_simple_internal_testing_provider_config_in_page_editor() {
+	public function test_add_agents_manager_data_adds_simple_provider_config_in_page_editor() {
 		$this->set_page_block_editor_screen();
 		$this->simulate_wpcom_simple();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
@@ -1071,7 +960,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_add_agents_manager_data_preserves_existing_agent_id_in_page_editor() {
 		$this->set_page_block_editor_screen();
 		$this->simulate_wpcom_simple();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data(
 			array(
@@ -1085,13 +973,12 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Platform-emitted provider data is exposed in the Simple internal-testing
-	 * site editor and sets the default agent when upstream has not selected one.
+	 * Platform-emitted provider data is exposed in the Simple site editor and
+	 * sets the default agent when upstream has not selected one.
 	 */
-	public function test_add_agents_manager_data_adds_simple_internal_testing_provider_config_in_site_editor() {
+	public function test_add_agents_manager_data_adds_simple_provider_config_in_site_editor() {
 		$this->set_site_editor_screen();
 		$this->simulate_wpcom_simple();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'site-editor' ) );
 
@@ -1102,17 +989,11 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Page editor provider data is limited to internal testing environments with
-	 * Jetpack AI enabled.
+	 * Page editor provider data remains gated by Jetpack AI availability.
 	 */
-	public function test_add_agents_manager_data_gates_page_editor_provider_data() {
+	public function test_add_agents_manager_data_requires_ai_enabled_in_page_editor() {
 		$this->set_page_block_editor_screen();
 		$this->simulate_wpcom_simple();
-
-		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
-		$this->assertArrayNotHasKey( 'jetpackAiSidebar', $data );
-
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		add_filter( 'jetpack_ai_enabled', '__return_false' );
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
@@ -1138,7 +1019,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_patch_jetpack_ai_sidebar_preview_data_sets_fields_when_am_enqueued_externally() {
 		$this->set_block_editor_screen();
 		$this->cache_sidebar_asset_data();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		// Simulate an external host having enqueued AM and declared upstream
 		// data with both Jetpack AI Sidebar and Big Sky providers.
 		wp_enqueue_script( 'agents-manager', 'https://example.com/am.js', array(), '1.0', true );
@@ -1175,7 +1055,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_patch_jetpack_ai_sidebar_preview_data_noop_when_am_not_enqueued() {
 		$this->set_block_editor_screen();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		Jetpack_AI_Sidebar::maybe_patch_jetpack_ai_sidebar_preview_data();
 
@@ -1185,11 +1064,10 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	/**
 	 * The external AM payload patch adds provider config in the page editor and guards the default agent assignment.
 	 */
-	public function test_patch_jetpack_ai_sidebar_preview_data_adds_internal_testing_provider_config_in_page_editor() {
+	public function test_patch_jetpack_ai_sidebar_preview_data_adds_provider_config_in_page_editor() {
 		$this->set_page_block_editor_screen();
 		$this->simulate_wpcom_platform();
 		$this->cache_sidebar_asset_data();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		wp_enqueue_script( 'agents-manager', 'https://example.com/am.js', array(), '1.0', true );
 		wp_add_inline_script( 'agents-manager', 'const agentsManagerData = { sectionName: "gutenberg", agentId: "dolly" };', 'before' );
 
@@ -1224,7 +1102,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_patch_jetpack_ai_sidebar_preview_data_skips_provider_url_when_asset_data_fails() {
 		$this->set_block_editor_screen();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		wp_enqueue_script( 'agents-manager', 'https://example.com/am.js', array(), '1.0', true );
 		wp_add_inline_script( 'agents-manager', 'const agentsManagerData = { sectionName: "gutenberg" };', 'before' );
 		add_filter(
@@ -1291,25 +1168,11 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that abilities script is enqueued in the page editor.
-	 */
-	public function test_abilities_script_enqueues_in_page_editor() {
-		$this->set_page_block_editor_screen();
-		$this->cache_sidebar_asset_data();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
-
-		Jetpack_AI_Sidebar::maybe_enqueue_abilities_script();
-
-		$this->assertTrue( wp_script_is( 'jetpack-ai-provider', 'enqueued' ) );
-	}
-
-	/**
 	 * Test that abilities script is enqueued in the site editor.
 	 */
 	public function test_abilities_script_enqueues_in_site_editor() {
 		$this->set_site_editor_screen();
 		$this->cache_sidebar_asset_data();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		Jetpack_AI_Sidebar::maybe_enqueue_abilities_script();
 
@@ -1322,7 +1185,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_abilities_script_skips_when_preview_disabled() {
 		$this->set_block_editor_screen();
 		$this->cache_sidebar_asset_data();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		add_filter( 'jetpack_ai_sidebar_enabled', '__return_false' );
 
 		Jetpack_AI_Sidebar::maybe_enqueue_abilities_script();
@@ -1331,21 +1193,21 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that abilities script is not enqueued in the page editor outside internal testing.
+	 * Test that the abilities script is enqueued in the page editor for eligible users.
 	 */
-	public function test_abilities_script_skips_page_editor_outside_internal_testing_environment() {
+	public function test_abilities_script_enqueues_in_page_editor() {
 		$this->set_page_block_editor_screen();
 		$this->cache_sidebar_asset_data();
 
 		Jetpack_AI_Sidebar::maybe_enqueue_abilities_script();
 
-		$this->assertFalse( wp_script_is( 'jetpack-ai-provider', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'jetpack-ai-provider', 'enqueued' ) );
 	}
 
 	/**
-	 * Test that abilities script remains enqueued in the post editor outside internal testing.
+	 * Test that the abilities script remains enqueued in the post editor.
 	 */
-	public function test_abilities_script_enqueues_in_post_editor_outside_internal_testing() {
+	public function test_abilities_script_enqueues_in_post_editor() {
 		$this->set_block_editor_screen();
 		$this->cache_sidebar_asset_data();
 		$this->simulate_wpcom_simple();
@@ -1361,7 +1223,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_abilities_script_skips_when_ai_disabled() {
 		$this->set_block_editor_screen();
 		$this->cache_sidebar_asset_data();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		add_filter( 'jetpack_ai_enabled', '__return_false' );
 
 		Jetpack_AI_Sidebar::maybe_enqueue_abilities_script();
@@ -1379,7 +1240,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_register_provider_adds_url() {
 		$this->set_block_editor_screen();
 		$this->cache_sidebar_asset_data();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		$providers = Jetpack_AI_Sidebar::register_provider( array() );
 
@@ -1395,7 +1255,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_register_provider_returns_unchanged_when_no_asset_data() {
 		$this->set_block_editor_screen();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		// Block remote fetches.
 		add_filter(
 			'pre_http_request',
@@ -1420,7 +1279,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_register_provider_preserves_existing_providers() {
 		$this->set_block_editor_screen();
 		$this->cache_sidebar_asset_data();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		$existing  = array( 'https://example.com/provider-a.mjs', 'https://example.com/provider-b.mjs' );
 		$providers = Jetpack_AI_Sidebar::register_provider( $existing );
@@ -1437,7 +1295,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_register_provider_adds_url_in_page_editor() {
 		$this->set_page_block_editor_screen();
 		$this->cache_sidebar_asset_data();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		$existing  = array( 'https://example.com/provider-a.mjs' );
 		$providers = Jetpack_AI_Sidebar::register_provider( $existing );
@@ -1453,7 +1310,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	public function test_register_provider_adds_url_in_site_editor() {
 		$this->set_site_editor_screen();
 		$this->cache_sidebar_asset_data();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 
 		$existing  = array( 'https://example.com/provider-a.mjs' );
 		$providers = Jetpack_AI_Sidebar::register_provider( $existing );
@@ -1464,13 +1320,11 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that register_provider returns existing providers when the preview gate is disabled.
+	 * Test that register_provider leaves providers unchanged on unsupported admin screens.
 	 */
-	public function test_register_provider_skips_when_preview_disabled() {
-		$this->set_block_editor_screen();
+	public function test_register_provider_skips_unsupported_admin_screen() {
+		$this->set_unsupported_admin_screen();
 		$this->cache_sidebar_asset_data();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
-		add_filter( 'jetpack_ai_sidebar_enabled', '__return_false' );
 
 		$existing  = array( 'https://example.com/provider-a.mjs' );
 		$providers = Jetpack_AI_Sidebar::register_provider( $existing );
@@ -1479,11 +1333,12 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that register_provider returns existing providers on new surfaces outside internal testing.
+	 * Test that register_provider returns existing providers when the preview gate is disabled.
 	 */
-	public function test_register_provider_skips_page_editor_outside_internal_testing_environment() {
-		$this->set_page_block_editor_screen();
+	public function test_register_provider_skips_when_preview_disabled() {
+		$this->set_block_editor_screen();
 		$this->cache_sidebar_asset_data();
+		add_filter( 'jetpack_ai_sidebar_enabled', '__return_false' );
 
 		$existing  = array( 'https://example.com/provider-a.mjs' );
 		$providers = Jetpack_AI_Sidebar::register_provider( $existing );
@@ -1504,7 +1359,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		}
 
 		$this->set_block_editor_screen();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		$this->cache_sidebar_asset_data(
 			array(
 				'version'      => 'cached-version',
@@ -1526,7 +1380,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_sidebar_asset_data_skips_enqueue_when_fetch_fails() {
 		$this->set_block_editor_screen();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		// Block remote fetches.
 		add_filter(
 			'pre_http_request',
@@ -1552,7 +1405,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_full_flow_with_default_enabled() {
 		$this->set_block_editor_screen();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		Jetpack_AI_Sidebar::init();
 		$this->cache_sidebar_asset_data();
 
@@ -1569,7 +1421,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 */
 	public function test_full_flow_injects_agents_manager_data() {
 		$this->set_block_editor_screen();
-		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
 		Jetpack_AI_Sidebar::init();
 
 		$data = apply_filters(

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -107,7 +107,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
 		remove_all_filters( 'agents_manager_agent_providers' );
 		remove_all_filters( 'agents_manager_enabled_in_block_editor' );
-		remove_all_filters( 'jetpack_ai_editorial_review_enabled' );
 		remove_all_filters( 'jetpack_ai_sidebar_preview_enabled' );
 		remove_all_filters( 'jetpack_ai_sidebar_preview_features' );
 		remove_all_filters( 'jetpack_ai_sidebar_agents_manager_data' );
@@ -328,7 +327,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	// ──────────────────────────────────────────────────
 
 	/**
-	 * Test that init() registers hooks by default for AI Editorial Review.
+	 * Test that init() registers the Jetpack AI Sidebar hooks by default.
 	 */
 	public function test_init_registers_hooks_by_default() {
 		Jetpack_AI_Sidebar::init();
@@ -391,23 +390,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertFalse(
 			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_toolbar_button_extension' ) ),
 			'register_toolbar_button_extension should not be hooked when the preview gate is false.'
-		);
-	}
-
-	/**
-	 * Test that the preview surface can initialize without AI Editorial Review.
-	 */
-	public function test_init_registers_hooks_when_preview_is_enabled_without_ai_editorial_review() {
-		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
-		Jetpack_AI_Sidebar::init();
-
-		$this->assertNotFalse(
-			has_filter( 'agents_manager_agent_providers', array( Jetpack_AI_Sidebar::class, 'register_provider' ) ),
-			'register_provider should be hooked when the preview gate is true.'
-		);
-		$this->assertNotFalse(
-			has_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_enqueue_abilities_script' ) ),
-			'maybe_enqueue_abilities_script should be hooked when the preview gate is true.'
 		);
 	}
 
@@ -701,23 +683,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * Test that the Agents Manager block-editor gate preserves existing true values.
 	 */
 	public function test_enable_agents_manager_on_provider_surfaces_preserves_existing_true() {
-		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
 		$this->set_page_block_editor_screen();
 
 		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_on_provider_surfaces( true ) );
-	}
-
-	/**
-	 * The AI Editorial Review filter is decoupled from this Agents Manager entrypoint.
-	 *
-	 * The preview gate is wpcom/Big Sky-based, so turning AI Editorial Review off
-	 * does not close the gate (AI Editorial Review only affects the exposed data).
-	 */
-	public function test_enable_agents_manager_on_provider_surfaces_ignores_ai_editorial_review_filter() {
-		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
-		$this->set_block_editor_screen();
-
-		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_on_provider_surfaces( false ) );
 	}
 
 	/**
@@ -735,11 +703,10 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	// ──────────────────────────────────────────────────
 
 	/**
-	 * Platform-emitted Agents Manager data gets the AI Editorial Review flag.
+	 * Platform-emitted Agents Manager data enables AI Editorial Review by default.
 	 */
-	public function test_add_agents_manager_data_exposes_ai_editorial_review_enabled() {
+	public function test_add_agents_manager_data_exposes_ai_editorial_review_by_default() {
 		$this->set_block_editor_screen();
-		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_true' );
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
@@ -800,6 +767,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		add_filter(
 			'jetpack_ai_sidebar_preview_features',
 			function ( $features ) {
+				$features['aiEditorialReview']       = false;
 				$features['generateFeedback']        = false;
 				$features['proofreadContent']        = false;
 				$features['blockToolbarButton']      = false;
@@ -813,9 +781,11 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
 		$this->assertSame( 'wp-orchestrator', $data['agentId'] );
-		$this->assertTrue( $data['jetpackAiSidebar']['features']['aiEditorialReview'] );
+		$this->assertTrue( $data['jetpackAiSidebar']['enabled'] );
+		$this->assertFalse( $data['jetpackAiSidebar']['features']['aiEditorialReview'] );
 		$this->assertFalse( $data['jetpackAiSidebar']['features']['generateFeedback'] );
 		$this->assertFalse( $data['jetpackAiSidebar']['features']['proofreadContent'] );
+		$this->assertTrue( $data['jetpackAiSidebar']['features']['blockTransformations'] );
 		$this->assertFalse( $data['jetpackAiSidebar']['features']['blockToolbarButton'] );
 		$this->assertFalse( $data['jetpackAiSidebar']['features']['optimizeTitleSuggestion'] );
 		$this->assertFalse( $data['jetpackAiSidebar']['features']['seoSuggestions'] );
@@ -903,22 +873,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( $providers, $data['agentProviders'] );
-	}
-
-	/**
-	 * Preview and AI Editorial Review have separate gates.
-	 */
-	public function test_add_agents_manager_data_allows_preview_without_ai_editorial_review() {
-		$this->set_block_editor_screen();
-		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
-
-		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
-
-		$this->assertSame( 'wp-orchestrator', $data['agentId'] );
-		$this->assertSame( true, $data['jetpackAiSidebar']['enabled'] );
-		$this->assertSame( false, $data['jetpackAiSidebar']['features']['aiEditorialReview'] );
-		$this->assertSame( true, $data['jetpackAiSidebar']['features']['blockTransformations'] );
-		$this->assertSame( true, $data['jetpackAiSidebar']['features']['blockToolbarButton'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Remove the internal-testing-environment checks from the Jetpack AI Sidebar writing suggestions, Proofreader, Optimize Title, Excerpt, SEO suggestions, and block toolbar button.
* Release the Jetpack AI provider on eligible post, page, and site editor surfaces while retaining the supported-surface, Jetpack AI availability, connection, and offline-mode gates.
* Keep SEO suggestions behind the existing SEO Enhancer filter, plan feature, and `seo-tools` module requirements.
* Keep `jetpack_ai_sidebar_enabled` as the global rollback switch and allow `jetpack_ai_sidebar_preview_features` to disable individual released features. This makes previously ignored `generateFeedback` and `proofreadContent` filter values effective.

This is intentionally a full-population release for eligible users rather than a percentage rollout. Unsupported admin screens and custom post types remain excluded.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* None.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No. This changes feature eligibility and editor surfaces only; it does not add or change tracking.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

Automated checks completed:

* `jp docker phpunit jetpack -- --filter=Jetpack_AI_Sidebar_Test` — 64 tests, 148 assertions, 1 skipped.
* `jp phan plugins/jetpack --allow-polyfill-parser --include-analysis-file-list=projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php` — 0 issues.
* `composer phpcs:lint -- projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php` — pass.
* `jp changelog validate plugins/jetpack` — pass.

Manual release verification:

1. Use a connected site where Jetpack AI and the AI Sidebar are enabled `wp.com/settings/ai-tools`
2. Open a post editor. Confirm the sidebar loads and Generate Feedback, Proofreader, Optimize Title, Excerpt, and the AI block toolbar button are available.
3. Open a page editor and repeat the check. Confirm the provider loads without console errors.
4. Open the site editor. Confirm the provider loads without console errors and post-specific suggestions either remain contextually hidden or degrade safely.
5. Open a block editor for a custom post type. Confirm the Jetpack AI provider is not exposed.
6. Disable the `seo-tools` module or test a plan without the SEO feature. Confirm SEO suggestions remain hidden while the other released features remain available.
7. Turn off `wp.com/settings/ai-tools`. Confirm the sidebar, provider, and toolbar button are disabled across all supported editor surfaces.
