### PR TITLE
Social Image Generator: sync attached media with the current generated image

### DIFF
--- a/projects/packages/publicize/changelog/fix-social-image-template-attachment
+++ b/projects/packages/publicize/changelog/fix-social-image-template-attachment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Social Image Generator: share the current generated image after changing the template.

--- a/projects/packages/publicize/src/social-image-generator/class-setup.php
+++ b/projects/packages/publicize/src/social-image-generator/class-setup.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Publicize\Social_Image_Generator;
 
 use Automattic\Jetpack\Publicize\Jetpack_Social_Settings\Settings;
+use Automattic\Jetpack\Publicize\Publicize;
 
 /**
  * Class for setting up Social Image Generator-related functionality.
@@ -55,6 +56,47 @@ class Setup {
 		}
 
 		$post_settings->update_setting( 'token', sanitize_text_field( $token ) );
+
+		$this->sync_attached_media( $post_settings->post_id );
+	}
+
+	/**
+	 * Point the shared attachment at the post's current generated image.
+	 *
+	 * When the post shares the generated image as an attachment, attached_media holds a
+	 * plain URL instead of being derived from the token at render time like the OG tag is.
+	 * It therefore goes stale whenever the token changes — most visibly after a template
+	 * edit, which shares the previous template's image. This runs alongside the
+	 * authoritative token write so the two can't drift, including when the editor closes
+	 * before its debounced preview ever produced a token.
+	 *
+	 * @param int $post_id Post whose attachment should follow the generated image.
+	 */
+	private function sync_attached_media( $post_id ) {
+		$options = get_post_meta( $post_id, Publicize::POST_JETPACK_SOCIAL_OPTIONS, true );
+
+		if ( ! is_array( $options ) || ( $options['media_source'] ?? '' ) !== 'sig' ) {
+			return;
+		}
+
+		// A non-empty id means real library media, which must not be replaced.
+		if ( ! isset( $options['attached_media'][0] ) || ! empty( $options['attached_media'][0]['id'] ) ) {
+			return;
+		}
+
+		$url = get_image_url( $post_id );
+
+		if ( empty( $url ) || ( $options['attached_media'][0]['url'] ?? '' ) === $url ) {
+			return;
+		}
+
+		$options['attached_media'][0] = array(
+			'id'   => 0,
+			'url'  => $url,
+			'type' => 'image/png',
+		);
+
+		update_post_meta( $post_id, Publicize::POST_JETPACK_SOCIAL_OPTIONS, $options );
 	}
 
 	/**

--- a/projects/packages/publicize/tests/php/test-social-image-generator/Setup_Test.php
+++ b/projects/packages/publicize/tests/php/test-social-image-generator/Setup_Test.php
@@ -7,7 +7,9 @@
 
 namespace Automattic\Jetpack\Publicize;
 
+use Automattic\Jetpack\Connection\Tokens;
 use Automattic\Jetpack\Publicize\Social_Image_Generator\Setup;
+use Jetpack_Options;
 use WorDBless\BaseTestCase;
 use WorDBless\Options as WorDBless_Options;
 use WorDBless\Posts as WorDBless_Posts;
@@ -99,12 +101,142 @@ class Setup_Test extends BaseTestCase {
 
 		return array(
 			'headers'  => array(),
-			'body'     => '',
+			// The token endpoint responds with a bare JSON string; other callers ignore the body.
+			'body'     => '"generated-token"',
 			'response' => array(
 				'code'    => 200,
 				'message' => 'OK',
 			),
 		);
+	}
+
+	/**
+	 * Fake a site-level connection so token generation reaches the proxied request,
+	 * which the HTTP mock above then answers.
+	 */
+	private function connect_blog() {
+		( new Tokens() )->update_blog_token( 'new.blogtoken' );
+		Jetpack_Options::update_option( 'id', get_current_blog_id() );
+	}
+
+	/**
+	 * Save the post the way WordPress does after the editor writes its meta.
+	 */
+	private function save_post() {
+		$this->setup->generate_token_on_save( $this->post_id, get_post( $this->post_id ), true );
+	}
+
+	/**
+	 * Store the post's social options wholesale.
+	 *
+	 * @param array $options Options to store.
+	 */
+	private function set_social_options( $options ) {
+		update_post_meta( $this->post_id, Publicize::POST_JETPACK_SOCIAL_OPTIONS, $options );
+	}
+
+	/**
+	 * Read back the post's stored attached media.
+	 *
+	 * @return array
+	 */
+	private function get_attached_media() {
+		$options = get_post_meta( $this->post_id, Publicize::POST_JETPACK_SOCIAL_OPTIONS, true );
+
+		return $options['attached_media'] ?? array();
+	}
+
+	/**
+	 * Build the social options for a post sharing the generated image as an attachment.
+	 *
+	 * @param string $media_source   Which media the post shares.
+	 * @param array  $attached_media Attachment entries to store.
+	 * @return array
+	 */
+	private function sig_options( $media_source, $attached_media ) {
+		return array(
+			'media_source'             => $media_source,
+			'attached_media'           => $attached_media,
+			'image_generator_settings' => array(
+				'enabled'  => true,
+				'template' => 'dois',
+			),
+		);
+	}
+
+	/**
+	 * Saving re-points the shared attachment at the post's current generated image, so a
+	 * template change doesn't leave the previous template's image attached to the post.
+	 */
+	public function test_saving_repoints_a_stale_sig_attachment() {
+		$this->connect_blog();
+		$this->set_social_options(
+			$this->sig_options(
+				'sig',
+				array(
+					array(
+						'id'   => 0,
+						'url'  => 'https://jetpack.com/redirect/?source=sigenerate&query=t%3Dold-token',
+						'type' => 'image/png',
+					),
+				)
+			)
+		);
+
+		$this->save_post();
+
+		$attached_media = $this->get_attached_media();
+		$this->assertStringContainsString( 'generated-token', $attached_media[0]['url'] );
+		$this->assertSame( 0, $attached_media[0]['id'] );
+		$this->assertSame( 'image/png', $attached_media[0]['type'] );
+	}
+
+	/**
+	 * Media attached from the library is real content and must never be replaced.
+	 */
+	public function test_saving_leaves_library_media_alone() {
+		$attachment = array(
+			'id'   => 42,
+			'url'  => 'https://example.com/photo.jpg',
+			'type' => 'image/jpeg',
+		);
+
+		$this->connect_blog();
+		$this->set_social_options( $this->sig_options( 'sig', array( $attachment ) ) );
+
+		$this->save_post();
+
+		$this->assertSame( array( $attachment ), $this->get_attached_media() );
+	}
+
+	/**
+	 * A post sharing something other than the generated image is left untouched.
+	 */
+	public function test_saving_ignores_other_media_sources() {
+		$attachment = array(
+			'id'   => 0,
+			'url'  => 'https://example.com/stale.png',
+			'type' => 'image/png',
+		);
+
+		$this->connect_blog();
+		$this->set_social_options( $this->sig_options( 'featured-image', array( $attachment ) ) );
+
+		$this->save_post();
+
+		$this->assertSame( array( $attachment ), $this->get_attached_media() );
+	}
+
+	/**
+	 * A post that shares no media does not gain an attachment.
+	 */
+	public function test_saving_does_not_attach_media_to_a_post_without_any() {
+		$this->connect_blog();
+		$this->set_social_options( $this->sig_options( 'sig', array() ) );
+
+		$this->save_post();
+
+		$this->assertSame( array(), $this->get_attached_media() );
 	}
 
 	/**


### PR DESCRIPTION
Fixes SOCIAL-551

## Proposed changes

* Re-point a post's `attached_media` at its current generated image whenever the Social Image Generator token is written on save.

When a post shares the generated image as an attachment, `attached_media` stores a plain URL rather than deriving it from the token at render time like the Open Graph tag does. Changing the template regenerated the token but left that URL pointing at the previous template's image, so the post was shared with the old layout while the editor preview showed the new one. The sync runs alongside the authoritative token write in `Setup::generate_token`, so it applies on every save regardless of what the editor did. Media attached from the library and posts using another media source are left untouched.

## Related product discussion/links

* SOCIAL-551

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site with Jetpack Social and a paid plan, create a post with a featured image and connect at least one social account.
* In the Jetpack sharing panel, set Media to the generated image and turn on "Share as attachment".
* Open the template editor, pick a template, and close it. Save the post.
* Inspect the post's `_wpas_options` meta and confirm the `attached_media` URL token matches the `image_generator_settings` token.
* Change to a different template, save again, and confirm the `attached_media` URL changed to the new token.
* Publish and confirm the image shared to the connected account uses the template you selected.
* Switch Media to an image from the media library, save, and confirm `attached_media` still points at that image rather than the generated one.
* Automated checks run locally: `jp test php packages/publicize` (117 tests, 275 assertions), `jp phan packages/publicize` (0 issues), PHPCS via the pre-commit hook.
