### PR TITLE
wp-build dashboards: throttle i18n catalog downloads and load widget catalogs on demand

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-wp-build-i18n-catalog-burst
+++ b/projects/packages/premium-analytics/changelog/fix-wp-build-i18n-catalog-burst
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: load each widget's translation catalogs when the widget loads, instead of requesting all of them at once at boot.

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -9,7 +9,8 @@ import { useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Stack } from '@wordpress/ui';
 import { WidgetDashboard } from '@wordpress/widget-dashboard';
-import { useWidgetTypes, type WidgetModuleRecord } from '@wordpress/widget-primitives';
+import { type WidgetModuleRecord } from '@wordpress/widget-primitives';
+import { resolveWidgetModuleWithI18n, useWidgetTypesWithI18n } from '../widget-module-i18n';
 import { DashboardSections } from './components';
 import {
 	useActiveSection,
@@ -48,7 +49,7 @@ function Dashboard(): JSX.Element {
 		[]
 	);
 
-	const [ widgetTypes, isResolvingWidgetTypes ] = useWidgetTypes( widgetModules );
+	const [ widgetTypes, isResolvingWidgetTypes ] = useWidgetTypesWithI18n( widgetModules );
 
 	const [ editMode, setEditMode ] = useState( false );
 
@@ -79,6 +80,7 @@ function Dashboard(): JSX.Element {
 			<WidgetDashboard
 				widgetTypes={ widgetTypes }
 				isResolvingWidgetTypes={ isResolvingWidgetTypes }
+				resolveWidgetModule={ resolveWidgetModuleWithI18n }
 				layout={ layout }
 				onLayoutChange={ setLayout }
 				onLayoutReset={ resetLayout }

--- a/projects/packages/premium-analytics/routes/post-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.tsx
@@ -9,7 +9,8 @@ import { __ } from '@wordpress/i18n';
 import { useParams } from '@wordpress/route';
 import { Button } from '@wordpress/ui';
 import { DEFAULT_GRID, ROW_HEIGHT_PRESETS, WidgetDashboard } from '@wordpress/widget-dashboard';
-import { useWidgetTypes, type WidgetModuleRecord } from '@wordpress/widget-primitives';
+import { type WidgetModuleRecord } from '@wordpress/widget-primitives';
+import { resolveWidgetModuleWithI18n, useWidgetTypesWithI18n } from '../widget-module-i18n';
 import { PostDetailTabs, PostSummaryCard } from './components';
 import { EMAIL_WIDGET_TYPE_ALIASES } from './config';
 import { usePostDetailTabs, usePostSummary } from './hooks';
@@ -67,7 +68,7 @@ function PostDetail(): JSX.Element {
 		[]
 	);
 
-	const [ widgetTypes, isResolvingWidgetTypes ] = useWidgetTypes( widgetModules );
+	const [ widgetTypes, isResolvingWidgetTypes ] = useWidgetTypesWithI18n( widgetModules );
 
 	// The fixed email compositions reuse registered widget types under
 	// page-local aliases so each card carries its design title — the host
@@ -106,6 +107,7 @@ function PostDetail(): JSX.Element {
 			<WidgetDashboard
 				widgetTypes={ pageWidgetTypes }
 				isResolvingWidgetTypes={ isResolvingWidgetTypes }
+				resolveWidgetModule={ resolveWidgetModuleWithI18n }
 				layout={ layout }
 				onLayoutChange={ noopLayoutChange }
 				gridSettings={ POST_DETAIL_GRID }

--- a/projects/packages/premium-analytics/routes/video-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/video-detail/stage.tsx
@@ -10,14 +10,15 @@ import { __ } from '@wordpress/i18n';
 import { Link, useParams, useSearch } from '@wordpress/route';
 import { Button, Stack, Text } from '@wordpress/ui';
 import { WidgetDashboard } from '@wordpress/widget-dashboard';
-import { useWidgetTypes, type WidgetModuleRecord } from '@wordpress/widget-primitives';
+import { type WidgetModuleRecord } from '@wordpress/widget-primitives';
+import { useDashboardGridSettings } from '../dashboard/hooks/use-dashboard-grid-settings';
+import { resolveWidgetModuleWithI18n, useWidgetTypesWithI18n } from '../widget-module-i18n';
 /**
  * Internal dependencies
  */
 // Grid settings are intentionally shared across analytics dashboards (see the
 // hook's own note), so the video-detail page reuses the dashboard's hook rather
 // than storing a separate copy.
-import { useDashboardGridSettings } from '../dashboard/hooks/use-dashboard-grid-settings';
 import { VideoSummaryCard } from './components';
 import { VIDEO_DETAIL_LAYOUT } from './config';
 import { useVideoSummary } from './hooks';
@@ -58,7 +59,7 @@ function VideoDetail(): JSX.Element {
 		[]
 	);
 
-	const [ widgetTypes, isResolvingWidgetTypes ] = useWidgetTypes( widgetModules );
+	const [ widgetTypes, isResolvingWidgetTypes ] = useWidgetTypesWithI18n( widgetModules );
 
 	const dashboardLink = useDashboardLink();
 	const search = useSearch( { strict: false } ) as Record< string, unknown > | undefined;
@@ -111,6 +112,7 @@ function VideoDetail(): JSX.Element {
 		<WidgetDashboard
 			widgetTypes={ widgetTypes }
 			isResolvingWidgetTypes={ isResolvingWidgetTypes }
+			resolveWidgetModule={ resolveWidgetModuleWithI18n }
 			layout={ VIDEO_DETAIL_LAYOUT }
 			onLayoutChange={ noopLayoutChange }
 			gridSettings={ gridSettings }

--- a/projects/packages/premium-analytics/routes/video-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/video-detail/stage.tsx
@@ -11,14 +11,14 @@ import { Link, useParams, useSearch } from '@wordpress/route';
 import { Button, Stack, Text } from '@wordpress/ui';
 import { WidgetDashboard } from '@wordpress/widget-dashboard';
 import { type WidgetModuleRecord } from '@wordpress/widget-primitives';
-import { useDashboardGridSettings } from '../dashboard/hooks/use-dashboard-grid-settings';
-import { resolveWidgetModuleWithI18n, useWidgetTypesWithI18n } from '../widget-module-i18n';
 /**
  * Internal dependencies
  */
 // Grid settings are intentionally shared across analytics dashboards (see the
 // hook's own note), so the video-detail page reuses the dashboard's hook rather
 // than storing a separate copy.
+import { useDashboardGridSettings } from '../dashboard/hooks/use-dashboard-grid-settings';
+import { resolveWidgetModuleWithI18n, useWidgetTypesWithI18n } from '../widget-module-i18n';
 import { VideoSummaryCard } from './components';
 import { VIDEO_DETAIL_LAYOUT } from './config';
 import { useVideoSummary } from './hooks';

--- a/projects/packages/premium-analytics/routes/widget-module-i18n.ts
+++ b/projects/packages/premium-analytics/routes/widget-module-i18n.ts
@@ -87,9 +87,13 @@ export function resolveWidgetModuleWithI18n(
 	if ( ! bundlePath ) {
 		return importModule( moduleId );
 	}
-	// Never rejects: a missing catalog resolves and the widget renders in
-	// English, and a stalled download resolves after a bounded wait.
-	return loadBundleI18nCatalog( TEXT_DOMAIN, bundlePath ).then( () => importModule( moduleId ) );
+	// A missing catalog resolves and the widget renders in English, and a
+	// stalled download resolves after a bounded wait — so this should not
+	// reject. If one ever escapes, import the module anyway: a widget that
+	// never loads at all is worse than an untranslated one.
+	return loadBundleI18nCatalog( TEXT_DOMAIN, bundlePath )
+		.catch( () => undefined )
+		.then( () => importModule( moduleId ) );
 }
 
 /**

--- a/projects/packages/premium-analytics/routes/widget-module-i18n.ts
+++ b/projects/packages/premium-analytics/routes/widget-module-i18n.ts
@@ -1,0 +1,145 @@
+/**
+ * Per-widget translation catalog loading.
+ *
+ * The boot init module (`packages/init`) downloads catalogs only for the
+ * route/module bundles it knows will load; widget bundles — two per widget,
+ * `widget.js` metadata and `render.js` — are excluded so a page load doesn't
+ * pay one HTTP request per widget for widgets that may never render. This
+ * module is the other half of that split: it loads a widget bundle's catalog
+ * at the moment the bundle itself is imported.
+ *
+ * Both halves matter because widget bundles evaluate `__()` at module scope
+ * (e.g. metric label tables in `widget.ts`), so a catalog that arrives after
+ * the import has evaluated leaves those strings untranslated for the rest of
+ * the page. The catalog download is therefore awaited (bounded — a stalled
+ * network falls back to English rather than wedging the import) *before* the
+ * module is imported.
+ */
+
+/**
+ * External dependencies
+ */
+import { loadBundleI18nCatalog } from '@automattic/jetpack-wp-build-polyfills/src/js/load-i18n-catalogs';
+import { useEffect, useState } from '@wordpress/element';
+import { useWidgetTypes } from '@wordpress/widget-primitives';
+import type { WidgetModuleRecord, WidgetType } from '@wordpress/widget-primitives';
+
+const TEXT_DOMAIN = 'jetpack-premium-analytics-pkg';
+
+/**
+ * Bound on the metadata-catalog preload. More generous than the loader's
+ * per-download default because the preload pushes dozens of downloads through
+ * the shared concurrency queue at once and each call's bound includes its
+ * queue wait — on a slow origin the tail of the queue would trip a 5s bound
+ * while draining normally. The preload gates only the widget registry (the
+ * grid renders placeholders meanwhile), not first paint, so waiting longer is
+ * cheap.
+ */
+const METADATA_CATALOG_TIMEOUT_MS = 15000;
+
+/**
+ * Widget script-module ids as registered by `build/widgets.php`:
+ * `jetpack-premium-analytics/widgets/{widget-dir-name}/render` and
+ * `…/widget`. The corresponding bundles land at
+ * `build/widgets/{widget-dir-name}/{render,widget}.js`, which is the
+ * package-relative path format the build's i18n manifest lists.
+ */
+const WIDGET_MODULE_ID = /^jetpack-premium-analytics\/widgets\/([^/]+)\/(render|widget)$/;
+
+/**
+ * Map a widget script-module id to the bundle path its catalog is keyed by.
+ *
+ * @param moduleId - A script-module id from the page import map.
+ * @return The package-relative bundle path, or `null` when the id is not a widget module.
+ */
+export function widgetModuleBundlePath( moduleId: string ): string | null {
+	const match = WIDGET_MODULE_ID.exec( moduleId );
+	return match ? `build/widgets/${ match[ 1 ] }/${ match[ 2 ] }.js` : null;
+}
+
+/**
+ * `import()` a widget module, installing its translation catalog first.
+ *
+ * Drop-in for `WidgetDashboard`'s `resolveWidgetModule` prop, replacing the
+ * default bare `import()`.
+ *
+ * @param moduleId     - The script-module id to import.
+ * @param importModule - The import implementation; a parameter so tests can observe ordering.
+ * @return The imported module.
+ */
+export function resolveWidgetModuleWithI18n(
+	moduleId: string,
+	importModule: ( id: string ) => Promise< unknown > = id => import( /* webpackIgnore: true */ id )
+): Promise< unknown > {
+	const bundlePath = widgetModuleBundlePath( moduleId );
+	if ( ! bundlePath ) {
+		return importModule( moduleId );
+	}
+	// Never rejects: a missing catalog resolves and the widget renders in
+	// English, and a stalled download resolves after a bounded wait.
+	return loadBundleI18nCatalog( TEXT_DOMAIN, bundlePath ).then( () => importModule( moduleId ) );
+}
+
+/**
+ * Install the metadata (`widget.js`) catalogs for a set of widget records.
+ *
+ * @param records - Widget module records from the `/widget-modules` REST route.
+ * @return Resolves once every catalog is installed (or has fallen back to English).
+ */
+export function preloadWidgetModuleCatalogs( records: WidgetModuleRecord[] ): Promise< void > {
+	return Promise.all(
+		records.map( record => {
+			const bundlePath = record.widget_module
+				? widgetModuleBundlePath( record.widget_module )
+				: null;
+			return bundlePath
+				? loadBundleI18nCatalog( TEXT_DOMAIN, bundlePath, METADATA_CATALOG_TIMEOUT_MS )
+				: Promise.resolve();
+		} )
+	).then( () => undefined );
+}
+
+/**
+ * `useWidgetTypes`, gated on the records' translation catalogs.
+ *
+ * `useWidgetTypes` imports every record's `widget.js` metadata module, which
+ * evaluates `__()` at module scope — so the records are handed over only once
+ * their catalogs are installed. Until then the hook reports resolving, same
+ * as while the records themselves are still loading.
+ *
+ * @param records - Host-supplied records, or `null`/`undefined` while loading.
+ * @return The resolved widget types and whether resolution is still in progress.
+ */
+export function useWidgetTypesWithI18n(
+	records: WidgetModuleRecord[] | null | undefined
+): readonly [ WidgetType[], boolean ] {
+	const [ readyRecords, setReadyRecords ] = useState< WidgetModuleRecord[] | null >( null );
+
+	useEffect( () => {
+		if ( ! records || records.length === 0 ) {
+			// Nothing to preload; these records pass straight through below.
+			return;
+		}
+		let cancelled = false;
+		preloadWidgetModuleCatalogs( records ).then( () => {
+			if ( ! cancelled ) {
+				setReadyRecords( records );
+			}
+		} );
+		return () => {
+			cancelled = true;
+		};
+	}, [ records ] );
+
+	// Gate by identity: only the exact records array whose preload finished is
+	// handed over, so a records update closes the gate until its own preload
+	// completes — and loading/empty records need no state round-trip at all.
+	let gatedRecords: WidgetModuleRecord[] | null;
+	if ( ! records || records.length === 0 ) {
+		gatedRecords = records ?? null;
+	} else {
+		gatedRecords = readyRecords === records ? records : null;
+	}
+
+	return useWidgetTypes( gatedRecords );
+}

--- a/projects/packages/premium-analytics/routes/widget-module-i18n.ts
+++ b/projects/packages/premium-analytics/routes/widget-module-i18n.ts
@@ -22,7 +22,18 @@
 import { loadBundleI18nCatalog } from '@automattic/jetpack-wp-build-polyfills/src/js/load-i18n-catalogs';
 import { useEffect, useState } from '@wordpress/element';
 import { useWidgetTypes } from '@wordpress/widget-primitives';
-import type { WidgetModuleRecord, WidgetType } from '@wordpress/widget-primitives';
+import type {
+	ResolveWidgetModule,
+	WidgetModuleRecord,
+	WidgetType,
+} from '@wordpress/widget-primitives';
+
+/**
+ * The module shape `ResolveWidgetModule` must yield. Not exported by
+ * `@wordpress/widget-primitives` (only the resolver type is), so it is
+ * derived here.
+ */
+type WidgetModule = Awaited< ReturnType< ResolveWidgetModule > >;
 
 const TEXT_DOMAIN = 'jetpack-premium-analytics-pkg';
 
@@ -69,8 +80,9 @@ export function widgetModuleBundlePath( moduleId: string ): string | null {
  */
 export function resolveWidgetModuleWithI18n(
 	moduleId: string,
-	importModule: ( id: string ) => Promise< unknown > = id => import( /* webpackIgnore: true */ id )
-): Promise< unknown > {
+	importModule: ( id: string ) => Promise< WidgetModule > = id =>
+		import( /* webpackIgnore: true */ id )
+): Promise< WidgetModule > {
 	const bundlePath = widgetModuleBundlePath( moduleId );
 	if ( ! bundlePath ) {
 		return importModule( moduleId );

--- a/projects/packages/premium-analytics/routes/widget-module-i18n.ts
+++ b/projects/packages/premium-analytics/routes/widget-module-i18n.ts
@@ -133,11 +133,17 @@ export function useWidgetTypesWithI18n(
 			return;
 		}
 		let cancelled = false;
-		preloadWidgetModuleCatalogs( records ).then( () => {
-			if ( ! cancelled ) {
-				setReadyRecords( records );
-			}
-		} );
+		preloadWidgetModuleCatalogs( records )
+			// Defensive: every failure path inside the preload already falls
+			// back to English on its own, so this should not fire. If one ever
+			// escapes, open the gate anyway — an untranslated grid beats one
+			// stranded on placeholders for the rest of the page.
+			.catch( () => undefined )
+			.then( () => {
+				if ( ! cancelled ) {
+					setReadyRecords( records );
+				}
+			} );
 		return () => {
 			cancelled = true;
 		};

--- a/projects/packages/premium-analytics/tests/js/widget-module-i18n.test.tsx
+++ b/projects/packages/premium-analytics/tests/js/widget-module-i18n.test.tsx
@@ -6,7 +6,9 @@ import {
 	useWidgetTypesWithI18n,
 	widgetModuleBundlePath,
 } from '../../routes/widget-module-i18n';
-import type { WidgetModuleRecord } from '@wordpress/widget-primitives';
+import type { ResolveWidgetModule, WidgetModuleRecord } from '@wordpress/widget-primitives';
+
+type WidgetModule = Awaited< ReturnType< ResolveWidgetModule > >;
 
 jest.mock( '@automattic/jetpack-wp-build-polyfills/src/js/load-i18n-catalogs', () => ( {
 	loadBundleI18nCatalog: jest.fn( () => Promise.resolve() ),
@@ -55,9 +57,10 @@ describe( 'resolveWidgetModuleWithI18n', () => {
 					}, 0 )
 				)
 		);
+		const theModule = { default: () => null } as unknown as WidgetModule;
 		const importModule = jest.fn( () => {
 			catalogResolvedWhenImported = catalogResolved;
-			return Promise.resolve( { default: 'the-module' } );
+			return Promise.resolve( theModule );
 		} );
 
 		const result = await resolveWidgetModuleWithI18n(
@@ -70,11 +73,13 @@ describe( 'resolveWidgetModuleWithI18n', () => {
 			'build/widgets/search-terms/render.js'
 		);
 		expect( catalogResolvedWhenImported ).toBe( true );
-		expect( result ).toEqual( { default: 'the-module' } );
+		expect( result ).toBe( theModule );
 	} );
 
 	it( 'imports non-widget module ids without a catalog request', async () => {
-		const importModule = jest.fn( () => Promise.resolve( { default: 'x' } ) );
+		const importModule = jest.fn( () =>
+			Promise.resolve( { default: () => null } as unknown as WidgetModule )
+		);
 
 		await resolveWidgetModuleWithI18n( 'some/other/module', importModule );
 

--- a/projects/packages/premium-analytics/tests/js/widget-module-i18n.test.tsx
+++ b/projects/packages/premium-analytics/tests/js/widget-module-i18n.test.tsx
@@ -91,6 +91,23 @@ describe( 'resolveWidgetModuleWithI18n', () => {
 		expect( result ).toBe( theModule );
 	} );
 
+	it( 'still imports the module when the catalog load rejects', async () => {
+		loadCatalogMock.mockImplementation( () => Promise.reject( new Error( 'boom' ) ) );
+		const theModule = { default: () => null } as unknown as WidgetModule;
+		const importModule = jest.fn( () => Promise.resolve( theModule ) );
+
+		// A widget that never loads at all is worse than an untranslated one.
+		await expect(
+			resolveWidgetModuleWithI18n(
+				'jetpack-premium-analytics/widgets/search-terms/render',
+				importModule
+			)
+		).resolves.toBe( theModule );
+		expect( importModule ).toHaveBeenCalledWith(
+			'jetpack-premium-analytics/widgets/search-terms/render'
+		);
+	} );
+
 	it( 'imports non-widget module ids without a catalog request', async () => {
 		const importModule = jest.fn( () =>
 			Promise.resolve( { default: () => null } as unknown as WidgetModule )

--- a/projects/packages/premium-analytics/tests/js/widget-module-i18n.test.tsx
+++ b/projects/packages/premium-analytics/tests/js/widget-module-i18n.test.tsx
@@ -1,5 +1,6 @@
 import { loadBundleI18nCatalog } from '@automattic/jetpack-wp-build-polyfills/src/js/load-i18n-catalogs';
 import { renderHook, waitFor } from '@testing-library/react';
+import { useWidgetTypes } from '@wordpress/widget-primitives';
 import {
 	preloadWidgetModuleCatalogs,
 	resolveWidgetModuleWithI18n,
@@ -14,11 +15,25 @@ jest.mock( '@automattic/jetpack-wp-build-polyfills/src/js/load-i18n-catalogs', (
 	loadBundleI18nCatalog: jest.fn( () => Promise.resolve() ),
 } ) );
 
+jest.mock( '@wordpress/widget-primitives', () => ( {
+	// Synchronous stand-in for the real hook, which resolves its metadata
+	// imports asynchronously and so reports `isResolving` on first render no
+	// matter what it was handed. Resolving immediately for any non-null
+	// argument leaves the gate as the only thing that can keep the hook
+	// resolving, which is what these tests are here to check.
+	useWidgetTypes: jest.fn( ( records: WidgetModuleRecord[] | null | undefined ) => [
+		[],
+		! records,
+	] ),
+} ) );
+
 const loadCatalogMock = loadBundleI18nCatalog as jest.Mock;
+const useWidgetTypesMock = useWidgetTypes as jest.Mock;
 
 beforeEach( () => {
 	loadCatalogMock.mockClear();
 	loadCatalogMock.mockImplementation( () => Promise.resolve() );
+	useWidgetTypesMock.mockClear();
 } );
 
 describe( 'widgetModuleBundlePath', () => {
@@ -117,27 +132,91 @@ describe( 'useWidgetTypesWithI18n', () => {
 		},
 	] as WidgetModuleRecord[];
 
-	it( 'stays resolving until the metadata catalogs are installed', async () => {
-		let releaseCatalog = () => {};
+	/**
+	 * The records argument of the most recent `useWidgetTypes` call — what the
+	 * gate has actually handed downstream on the latest render.
+	 *
+	 * @return The records the hook was last called with.
+	 */
+	function lastRecordsArg(): WidgetModuleRecord[] | null | undefined {
+		const { calls } = useWidgetTypesMock.mock;
+		if ( calls.length === 0 ) {
+			throw new Error( 'useWidgetTypes was never called' );
+		}
+		return calls[ calls.length - 1 ][ 0 ];
+	}
+
+	/**
+	 * Make catalog loads hang until the returned release function is called.
+	 *
+	 * @return Releases every pending catalog load.
+	 */
+	function holdCatalogs(): () => void {
+		let release = () => {};
 		loadCatalogMock.mockImplementation(
 			() =>
 				new Promise< void >( resolve => {
-					releaseCatalog = resolve;
+					release = resolve;
 				} )
 		);
+		return () => release();
+	}
+
+	it( 'withholds the records from useWidgetTypes until their catalogs are installed', async () => {
+		const releaseCatalogs = holdCatalogs();
 
 		const { result } = renderHook( () => useWidgetTypesWithI18n( RECORDS ) );
 
-		// Catalog pending: the records must not have been handed to
-		// useWidgetTypes yet, so the hook still reports resolving.
+		// Catalog pending: the records must not have reached useWidgetTypes,
+		// which would import their metadata modules and evaluate the
+		// module-scope `__()` calls against a catalog that is not installed
+		// yet. Until then the hook reports resolving.
+		expect( lastRecordsArg() ).toBeNull();
 		expect( result.current[ 1 ] ).toBe( true );
 
-		releaseCatalog();
-		await waitFor( () => expect( result.current[ 1 ] ).toBe( false ) );
+		releaseCatalogs();
+
+		// Handed over by identity, not by an equal copy.
+		await waitFor( () => expect( lastRecordsArg() ).toBe( RECORDS ) );
+		expect( result.current[ 1 ] ).toBe( false );
+	} );
+
+	it( 'closes the gate again when a new records array arrives', async () => {
+		const { result, rerender } = renderHook(
+			( { records }: { records: WidgetModuleRecord[] } ) => useWidgetTypesWithI18n( records ),
+			{ initialProps: { records: RECORDS } }
+		);
+		await waitFor( () => expect( lastRecordsArg() ).toBe( RECORDS ) );
+
+		// A refetch yields an equal-but-new array whose own catalogs have not
+		// been preloaded; it must not pass through on the strength of the
+		// previous array's preload.
+		const releaseCatalogs = holdCatalogs();
+		const nextRecords = [ ...RECORDS ];
+		rerender( { records: nextRecords } );
+
+		expect( lastRecordsArg() ).toBeNull();
+		expect( result.current[ 1 ] ).toBe( true );
+
+		releaseCatalogs();
+		await waitFor( () => expect( lastRecordsArg() ).toBe( nextRecords ) );
+	} );
+
+	it( 'opens the gate even when a catalog load rejects', async () => {
+		// The preload is not supposed to reject — each catalog load falls back
+		// to English on its own. If one ever escapes, the grid must still get
+		// its widgets rather than sitting on placeholders for the page.
+		loadCatalogMock.mockImplementation( () => Promise.reject( new Error( 'catalog exploded' ) ) );
+
+		const { result } = renderHook( () => useWidgetTypesWithI18n( RECORDS ) );
+
+		await waitFor( () => expect( lastRecordsArg() ).toBe( RECORDS ) );
+		expect( result.current[ 1 ] ).toBe( false );
 	} );
 
 	it( 'reports resolving while records are still loading', () => {
 		const { result } = renderHook( () => useWidgetTypesWithI18n( null ) );
+		expect( lastRecordsArg() ).toBeNull();
 		expect( result.current[ 1 ] ).toBe( true );
 		expect( loadCatalogMock ).not.toHaveBeenCalled();
 	} );
@@ -149,6 +228,7 @@ describe( 'useWidgetTypesWithI18n', () => {
 		const { result } = renderHook( () => useWidgetTypesWithI18n( emptyRecords ) );
 		// No async gate for zero records: nothing to translate, so the empty
 		// set must not wait on a preload round-trip.
+		expect( lastRecordsArg() ).toBe( emptyRecords );
 		expect( result.current ).toEqual( [ [], false ] );
 		expect( loadCatalogMock ).not.toHaveBeenCalled();
 	} );

--- a/projects/packages/premium-analytics/tests/js/widget-module-i18n.test.tsx
+++ b/projects/packages/premium-analytics/tests/js/widget-module-i18n.test.tsx
@@ -1,0 +1,150 @@
+import { loadBundleI18nCatalog } from '@automattic/jetpack-wp-build-polyfills/src/js/load-i18n-catalogs';
+import { renderHook, waitFor } from '@testing-library/react';
+import {
+	preloadWidgetModuleCatalogs,
+	resolveWidgetModuleWithI18n,
+	useWidgetTypesWithI18n,
+	widgetModuleBundlePath,
+} from '../../routes/widget-module-i18n';
+import type { WidgetModuleRecord } from '@wordpress/widget-primitives';
+
+jest.mock( '@automattic/jetpack-wp-build-polyfills/src/js/load-i18n-catalogs', () => ( {
+	loadBundleI18nCatalog: jest.fn( () => Promise.resolve() ),
+} ) );
+
+const loadCatalogMock = loadBundleI18nCatalog as jest.Mock;
+
+beforeEach( () => {
+	loadCatalogMock.mockClear();
+	loadCatalogMock.mockImplementation( () => Promise.resolve() );
+} );
+
+describe( 'widgetModuleBundlePath', () => {
+	it( 'maps a widget render module id to its build bundle path', () => {
+		expect(
+			widgetModuleBundlePath( 'jetpack-premium-analytics/widgets/search-terms/render' )
+		).toBe( 'build/widgets/search-terms/render.js' );
+	} );
+
+	it( 'maps a widget metadata module id to its build bundle path', () => {
+		expect(
+			widgetModuleBundlePath( 'jetpack-premium-analytics/widgets/search-terms/widget' )
+		).toBe( 'build/widgets/search-terms/widget.js' );
+	} );
+
+	it( 'returns null for module ids that are not widget modules', () => {
+		expect( widgetModuleBundlePath( '@jetpack-premium-analytics/init' ) ).toBeNull();
+		expect( widgetModuleBundlePath( 'other-plugin/widgets/foo/render' ) ).toBeNull();
+		expect(
+			widgetModuleBundlePath( 'jetpack-premium-analytics/widgets/foo/render/extra' )
+		).toBeNull();
+		expect( widgetModuleBundlePath( 'jetpack-premium-analytics/widgets/foo/other' ) ).toBeNull();
+	} );
+} );
+
+describe( 'resolveWidgetModuleWithI18n', () => {
+	it( 'installs the widget catalog before importing the module', async () => {
+		let catalogResolved = false;
+		let catalogResolvedWhenImported: boolean | null = null;
+		loadCatalogMock.mockImplementation(
+			() =>
+				new Promise< void >( resolve =>
+					setTimeout( () => {
+						catalogResolved = true;
+						resolve();
+					}, 0 )
+				)
+		);
+		const importModule = jest.fn( () => {
+			catalogResolvedWhenImported = catalogResolved;
+			return Promise.resolve( { default: 'the-module' } );
+		} );
+
+		const result = await resolveWidgetModuleWithI18n(
+			'jetpack-premium-analytics/widgets/search-terms/render',
+			importModule
+		);
+
+		expect( loadCatalogMock ).toHaveBeenCalledWith(
+			'jetpack-premium-analytics-pkg',
+			'build/widgets/search-terms/render.js'
+		);
+		expect( catalogResolvedWhenImported ).toBe( true );
+		expect( result ).toEqual( { default: 'the-module' } );
+	} );
+
+	it( 'imports non-widget module ids without a catalog request', async () => {
+		const importModule = jest.fn( () => Promise.resolve( { default: 'x' } ) );
+
+		await resolveWidgetModuleWithI18n( 'some/other/module', importModule );
+
+		expect( loadCatalogMock ).not.toHaveBeenCalled();
+		expect( importModule ).toHaveBeenCalledWith( 'some/other/module' );
+	} );
+} );
+
+describe( 'preloadWidgetModuleCatalogs', () => {
+	it( 'requests one catalog per record with a mappable widget module, with a generous bound', async () => {
+		await preloadWidgetModuleCatalogs( [
+			{ name: 'jpa/a', widget_module: 'jetpack-premium-analytics/widgets/a/widget' },
+			{ name: 'jpa/b', widget_module: 'jetpack-premium-analytics/widgets/b/widget' },
+			{ name: 'jpa/no-module' },
+			{ name: 'jpa/odd', widget_module: 'not-a-widget-module' },
+		] as WidgetModuleRecord[] );
+
+		// The 15s bound: dozens of downloads drain through the shared
+		// concurrency queue, and each call's bound includes its queue wait —
+		// the default per-download bound would flag the tail of the queue on a
+		// slow origin.
+		expect( loadCatalogMock.mock.calls ).toEqual( [
+			[ 'jetpack-premium-analytics-pkg', 'build/widgets/a/widget.js', 15000 ],
+			[ 'jetpack-premium-analytics-pkg', 'build/widgets/b/widget.js', 15000 ],
+		] );
+	} );
+} );
+
+describe( 'useWidgetTypesWithI18n', () => {
+	const RECORDS = [
+		{
+			name: 'jpa/a',
+			widget_module: 'jetpack-premium-analytics/widgets/a/widget',
+			render_module: 'jetpack-premium-analytics/widgets/a/render',
+		},
+	] as WidgetModuleRecord[];
+
+	it( 'stays resolving until the metadata catalogs are installed', async () => {
+		let releaseCatalog = () => {};
+		loadCatalogMock.mockImplementation(
+			() =>
+				new Promise< void >( resolve => {
+					releaseCatalog = resolve;
+				} )
+		);
+
+		const { result } = renderHook( () => useWidgetTypesWithI18n( RECORDS ) );
+
+		// Catalog pending: the records must not have been handed to
+		// useWidgetTypes yet, so the hook still reports resolving.
+		expect( result.current[ 1 ] ).toBe( true );
+
+		releaseCatalog();
+		await waitFor( () => expect( result.current[ 1 ] ).toBe( false ) );
+	} );
+
+	it( 'reports resolving while records are still loading', () => {
+		const { result } = renderHook( () => useWidgetTypesWithI18n( null ) );
+		expect( result.current[ 1 ] ).toBe( true );
+		expect( loadCatalogMock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'passes an empty record set straight through, with no catalog requests', () => {
+		// Stable reference, as core-data returns in production — `useWidgetTypes`
+		// (upstream) re-runs its effect on every records identity change.
+		const emptyRecords: WidgetModuleRecord[] = [];
+		const { result } = renderHook( () => useWidgetTypesWithI18n( emptyRecords ) );
+		// No async gate for zero records: nothing to translate, so the empty
+		// set must not wait on a preload round-trip.
+		expect( result.current ).toEqual( [ [], false ] );
+		expect( loadCatalogMock ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/packages/wp-build-polyfills/changelog/fix-wp-build-i18n-catalog-burst
+++ b/projects/packages/wp-build-polyfills/changelog/fix-wp-build-i18n-catalog-burst
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Throttle translation catalog downloads and stop requesting widget catalogs at boot — they now load on demand via loadBundleI18nCatalog().

--- a/projects/packages/wp-build-polyfills/src/js/load-i18n-catalogs.ts
+++ b/projects/packages/wp-build-polyfills/src/js/load-i18n-catalogs.ts
@@ -94,21 +94,75 @@ interface SharedCatalogState {
 }
 
 /**
+ * State private to this copy of the module, used only when the window slot
+ * holds a shape this copy doesn't recognize.
+ */
+let unsharedState: SharedCatalogState | undefined;
+
+/**
+ * A fresh, empty shared state.
+ *
+ * @return The new state.
+ */
+function newCatalogState(): SharedCatalogState {
+	return { manifests: new Map(), downloads: new Map(), active: 0, queue: [] };
+}
+
+/**
+ * Whether a value parked on `window` is state this copy of the module can use.
+ *
+ * @param value - Whatever the window slot holds.
+ * @return Whether it matches `SharedCatalogState`.
+ */
+function isCatalogState( value: unknown ): value is SharedCatalogState {
+	const state = value as Partial< SharedCatalogState > | null;
+	return (
+		!! state &&
+		state.manifests instanceof Map &&
+		state.downloads instanceof Map &&
+		typeof state.active === 'number' &&
+		Array.isArray( state.queue )
+	);
+}
+
+/**
  * Fetch (lazily creating) the window-parked shared state.
+ *
+ * The window slot is one global name shared by every copy of this module on the
+ * page, including copies from other plugins built at other versions — so what
+ * it holds is not guaranteed to be a shape this copy understands. Using a
+ * foreign shape blind would throw out of `manifests.get()`, and since the init
+ * modules that call `loadI18nCatalogs()` are awaited by boot without a catch,
+ * that surfaces as a blank dashboard rather than an untranslated one.
  *
  * @return The shared catalog state.
  */
 function sharedState(): SharedCatalogState {
 	const host = window as typeof window & {
-		__jetpackWpBuildI18nCatalogs?: SharedCatalogState;
+		__jetpackWpBuildI18nCatalogs?: unknown;
 	};
-	host.__jetpackWpBuildI18nCatalogs ??= {
-		manifests: new Map(),
-		downloads: new Map(),
-		active: 0,
-		queue: [],
-	};
-	return host.__jetpackWpBuildI18nCatalogs;
+	const parked = host.__jetpackWpBuildI18nCatalogs;
+	if ( parked === undefined ) {
+		const state = newCatalogState();
+		host.__jetpackWpBuildI18nCatalogs = state;
+		return state;
+	}
+	if ( isCatalogState( parked ) ) {
+		return parked;
+	}
+	// Fall back to state private to this copy rather than replacing what's
+	// parked: the copy that put it there is still using it, and each copy
+	// overwriting the other's on every call would leave neither with a usable
+	// dedupe map. Unshared state costs a few repeat downloads per page and
+	// splits the concurrency budget between the copies; both are cheaper than
+	// the alternatives.
+	if ( ! unsharedState ) {
+		warn(
+			'Shared catalog state on window has an unrecognized shape; downloads will not be deduped across module copies.'
+		);
+		unsharedState = newCatalogState();
+	}
+	return unsharedState;
 }
 
 /**
@@ -330,6 +384,13 @@ export async function loadI18nCatalogs(
 				timer = setTimeout( resolve, timeoutMs );
 			} ),
 		] );
+	} catch ( error ) {
+		// Every failure path above resolves to English on its own, so this
+		// should not fire. Catch anyway so the "never rejects" contract holds
+		// structurally: boot awaits the init modules that call this without a
+		// catch of its own, and a rejection escaping here blanks the dashboard.
+		warn( `Unexpected failure loading "${ domain }" catalogs: ${ errorMessage( error ) }` );
+		return;
 	} finally {
 		clearTimeout( timer );
 	}
@@ -406,6 +467,16 @@ export async function loadBundleI18nCatalog(
 				timer = setTimeout( resolve, timeoutMs );
 			} ),
 		] );
+	} catch ( error ) {
+		// As in `loadI18nCatalogs()`: callers chain the bundle's own import off
+		// this promise, so a rejection would leave the bundle unimported rather
+		// than untranslated.
+		warn(
+			`Unexpected failure loading the "${ domain }" catalog for ${ bundlePath }: ${ errorMessage(
+				error
+			) }`
+		);
+		return;
 	} finally {
 		clearTimeout( timer );
 	}

--- a/projects/packages/wp-build-polyfills/src/js/load-i18n-catalogs.ts
+++ b/projects/packages/wp-build-polyfills/src/js/load-i18n-catalogs.ts
@@ -18,12 +18,14 @@
  * the stamp step, so there is no manifest and the UI falls back to English —
  * same caveat as the stamping itself.)
  *
- * Only route/script/module catalogs are awaited before render. Widget bundles
- * (`build/widgets/**`) are lazy-loaded, so their catalog downloads are kicked
- * off here but not awaited — a dashboard with dozens of widgets (Premium
- * Analytics has ~76) must not block first paint on catalogs for widgets that
- * may never render, and the downloads have until the widget's own dynamic
- * import resolves to arrive.
+ * Only route/script/module catalogs are downloaded at boot, through a small
+ * concurrency-limited queue so the burst cannot starve the origin and stall
+ * the dashboard's own requests behind it. Widget bundles (`build/widgets/**`)
+ * are not requested at boot at all: a dashboard with dozens of widgets
+ * (Premium Analytics has ~40, two bundles each) must not pay one HTTP request
+ * per widget for widgets that may never render. Their catalogs load on demand
+ * via `loadBundleI18nCatalog()`, which the dashboard calls as part of
+ * importing a widget's module.
  *
  * Relies on `wp.jpI18nLoader` (jetpack-assets package, classic script
  * `wp-jp-i18n-loader`), which hashes a bundle's plugin-relative path the way
@@ -51,6 +53,130 @@ interface JpI18nLoader {
  * still install in the background (affecting subsequently rendered strings).
  */
 const CATALOG_TIMEOUT_MS = 5000;
+
+/**
+ * Cap on catalog downloads in flight at once. Sized to keep the origin
+ * responsive: on HTTP/2 the browser happily multiplexes the whole manifest
+ * (100+ requests on Premium Analytics) in one burst, and a slow origin then
+ * serves nothing else — REST calls and lazy route modules queue behind
+ * catalogs — until the burst drains.
+ */
+const MAX_CONCURRENT_DOWNLOADS = 6;
+
+/**
+ * State shared across every inlined copy of this module. wp-build bundles each
+ * entry point separately, so the boot init module and a route bundle calling
+ * `loadBundleI18nCatalog()` hold *different copies* of this file — plain
+ * module-level state would not be shared between them. Parking the state on
+ * `window` gives all copies the same manifest cache, download dedupe map, and
+ * concurrency queue.
+ */
+interface SharedCatalogState {
+	/** Per-domain manifest bundle set, keyed by text domain. */
+	manifests: Map< string, Promise< Set< string > > >;
+	/** Settled-once download per `domain|path`, so repeat requests reuse it. */
+	downloads: Map< string, Promise< void > >;
+	/** Downloads currently in flight. */
+	active: number;
+	/** Downloads waiting for a free slot. */
+	queue: Array< () => void >;
+}
+
+/**
+ * Fetch (lazily creating) the window-parked shared state.
+ *
+ * @return The shared catalog state.
+ */
+function sharedState(): SharedCatalogState {
+	const host = window as typeof window & {
+		__jetpackWpBuildI18nCatalogs?: SharedCatalogState;
+	};
+	host.__jetpackWpBuildI18nCatalogs ??= {
+		manifests: new Map(),
+		downloads: new Map(),
+		active: 0,
+		queue: [],
+	};
+	return host.__jetpackWpBuildI18nCatalogs;
+}
+
+/**
+ * Run a download task once a concurrency slot is free.
+ *
+ * @param state - The shared catalog state.
+ * @param task  - The task to run.
+ * @return Resolves/rejects with the task once it has run.
+ */
+function throttled( state: SharedCatalogState, task: () => Promise< void > ): Promise< void > {
+	return new Promise( ( resolve, reject ) => {
+		const run = () => {
+			state.active++;
+			task().then(
+				value => {
+					releaseSlot( state );
+					resolve( value );
+				},
+				error => {
+					releaseSlot( state );
+					reject( error );
+				}
+			);
+		};
+		if ( state.active < MAX_CONCURRENT_DOWNLOADS ) {
+			run();
+		} else {
+			state.queue.push( run );
+		}
+	} );
+}
+
+/**
+ * Free a concurrency slot and start the next queued download, if any.
+ *
+ * @param state - The shared catalog state.
+ */
+function releaseSlot( state: SharedCatalogState ): void {
+	state.active--;
+	const next = state.queue.shift();
+	if ( next ) {
+		next();
+	}
+}
+
+/**
+ * Download and install one bundle's catalog, at most once per page. A 404
+ * means no catalog exists for this locale/build — the expected English
+ * fallback, kept silent. Any other failure (another HTTP status, loader state
+ * not set, malformed catalog JSON) is a real misconfiguration worth surfacing,
+ * but must never block the render, so the returned promise always resolves.
+ *
+ * @param loader - The `wp.jpI18nLoader` instance.
+ * @param state  - The shared catalog state.
+ * @param domain - The package text domain.
+ * @param path   - Package-relative bundle path.
+ * @return Resolves once the download settles (or is found already requested).
+ */
+function downloadOnce(
+	loader: JpI18nLoader,
+	state: SharedCatalogState,
+	domain: string,
+	path: string
+): Promise< void > {
+	const key = `${ domain }|${ path }`;
+	let download = state.downloads.get( key );
+	if ( ! download ) {
+		download = throttled( state, () => loader.downloadI18n( path, domain, 'plugin' ) ).catch(
+			( error: unknown ) => {
+				const message = errorMessage( error );
+				if ( ! isMissingCatalog( message ) ) {
+					warn( `Failed to load "${ domain }" catalog (${ path }): ${ message }` );
+				}
+			}
+		);
+		state.downloads.set( key, download );
+	}
+	return download;
+}
 
 /**
  * Log an i18n bootstrap diagnostic. Untranslated-UI failures are otherwise
@@ -151,35 +277,32 @@ export async function loadI18nCatalogs(
 		return;
 	}
 
-	const download = ( path: string ) =>
-		// A 404 means no catalog exists for this locale/build — the expected
-		// English fallback, kept silent. Any other failure (another HTTP
-		// status, loader state not set, malformed catalog JSON) is a real
-		// misconfiguration worth surfacing, but must never block the render.
-		loader.downloadI18n( path, domain, 'plugin' ).catch( ( error: unknown ) => {
-			const message = errorMessage( error );
-			if ( ! isMissingCatalog( message ) ) {
-				warn( `Failed to load "${ domain }" catalog (${ path }): ${ message }` );
-			}
-		} );
+	const state = sharedState();
 
 	const load = async () => {
 		// A missing manifest (dev watch build) 404s — expected, kept silent.
 		// Anything else is surfaced.
-		const bundles = await fetchManifest( moduleUrl ).catch( ( error: unknown ) => {
-			const message = errorMessage( error );
-			if ( ! isMissingCatalog( message ) ) {
-				warn( `Failed to load the i18n manifest for "${ domain }": ${ message }` );
-			}
-			return [] as string[];
-		} );
+		const manifest = fetchManifest( moduleUrl )
+			.catch( ( error: unknown ) => {
+				const message = errorMessage( error );
+				if ( ! isMissingCatalog( message ) ) {
+					warn( `Failed to load the i18n manifest for "${ domain }": ${ message }` );
+				}
+				return [] as string[];
+			} )
+			.then( bundles => new Set( bundles ) );
+		// Published for `loadBundleI18nCatalog()` before it resolves, so an
+		// on-demand request never races the manifest fetch.
+		state.manifests.set( domain, manifest );
 
 		const blocking: Promise< void >[] = [];
-		for ( const path of bundles ) {
-			const catalog = download( path );
-			if ( ! path.includes( '/widgets/' ) ) {
-				blocking.push( catalog );
+		for ( const path of await manifest ) {
+			if ( path.includes( '/widgets/' ) ) {
+				// Widget catalogs load on demand, when the widget's own module
+				// is imported — see `loadBundleI18nCatalog()`.
+				continue;
 			}
+			blocking.push( downloadOnce( loader, state, domain, path ) );
 		}
 		await Promise.all( blocking );
 	};
@@ -201,6 +324,82 @@ export async function loadI18nCatalogs(
 	if ( ! settled ) {
 		warn(
 			`"${ domain }" catalog downloads still pending after ${ timeoutMs }ms; rendering may start untranslated.`
+		);
+	}
+}
+
+/**
+ * Download and install one bundle's translation catalog on demand.
+ *
+ * The complement of `loadI18nCatalogs()` for lazy-loaded bundles: call it as
+ * part of dynamically importing the bundle (e.g. a dashboard widget's render
+ * module), so a catalog is only ever requested for a bundle actually being
+ * loaded. Requires `loadI18nCatalogs()` to have run for the domain — that call
+ * caches the build's manifest; without it (dev watch build, default locale,
+ * loader missing) this resolves immediately and the bundle falls back to
+ * English. Bundles the manifest doesn't list carry no strings and are skipped
+ * without a request. Repeat calls for the same bundle reuse the first
+ * download.
+ *
+ * Resolves once the catalog is installed, when anything fails (missing
+ * catalogs fall back to English), or after a bounded wait — a stalled network
+ * must not wedge the caller's import.
+ *
+ * @param domain     - The package text domain the catalog is registered under.
+ * @param bundlePath - Package-relative path of the bundle (as listed in the build's i18n manifest).
+ * @param timeoutMs  - Maximum time to block before resolving anyway.
+ */
+export async function loadBundleI18nCatalog(
+	domain: string,
+	bundlePath: string,
+	timeoutMs: number = CATALOG_TIMEOUT_MS
+): Promise< void > {
+	const loader = ( window as typeof window & { wp?: { jpI18nLoader?: JpI18nLoader } } ).wp
+		?.jpI18nLoader;
+
+	// Boot already warned about a missing loader; stay quiet here.
+	if ( ! loader || typeof loader.downloadI18n !== 'function' ) {
+		return;
+	}
+
+	if ( loader.state?.locale === 'en_US' ) {
+		return;
+	}
+
+	const state = sharedState();
+	const manifest = state.manifests.get( domain );
+	if ( ! manifest ) {
+		// `loadI18nCatalogs()` never ran for this domain (dev watch build, or
+		// called out of order) — the expected English fallback.
+		return;
+	}
+
+	const load = async () => {
+		const bundles = await manifest;
+		if ( ! bundles.has( bundlePath ) ) {
+			// The bundle carries no gettext calls; there is no catalog to fetch.
+			return;
+		}
+		await downloadOnce( loader, state, domain, bundlePath );
+	};
+
+	let timer: ReturnType< typeof setTimeout > | undefined;
+	let settled = false;
+	try {
+		await Promise.race( [
+			load().finally( () => {
+				settled = true;
+			} ),
+			new Promise< void >( resolve => {
+				timer = setTimeout( resolve, timeoutMs );
+			} ),
+		] );
+	} finally {
+		clearTimeout( timer );
+	}
+	if ( ! settled ) {
+		warn(
+			`"${ domain }" catalog for ${ bundlePath } still pending after ${ timeoutMs }ms; rendering may start untranslated.`
 		);
 	}
 }

--- a/projects/packages/wp-build-polyfills/src/js/load-i18n-catalogs.ts
+++ b/projects/packages/wp-build-polyfills/src/js/load-i18n-catalogs.ts
@@ -64,6 +64,17 @@ const CATALOG_TIMEOUT_MS = 5000;
 const MAX_CONCURRENT_DOWNLOADS = 6;
 
 /**
+ * Bundles whose catalogs are left to on-demand loading: the widget tree, one
+ * directory below the build root (`build/widgets/…`). Anchored rather than a
+ * bare `/widgets/` substring so a route or module that happens to be *named*
+ * `widgets` (`build/routes/widgets/content.js`) is still downloaded at boot —
+ * nothing would load its catalog later, since the on-demand callers derive
+ * `build/widgets/<name>/<file>.js` paths of their own. The leading segment is
+ * matched loosely because it is the build directory's own name.
+ */
+const WIDGET_BUNDLE_PATH = /^[^/]+\/widgets\//;
+
+/**
  * State shared across every inlined copy of this module. wp-build bundles each
  * entry point separately, so the boot init module and a route bundle calling
  * `loadBundleI18nCatalog()` hold *different copies* of this file — plain
@@ -108,19 +119,12 @@ function sharedState(): SharedCatalogState {
  * @return Resolves/rejects with the task once it has run.
  */
 function throttled( state: SharedCatalogState, task: () => Promise< void > ): Promise< void > {
-	return new Promise( ( resolve, reject ) => {
+	return new Promise( resolve => {
 		const run = () => {
 			state.active++;
-			task().then(
-				value => {
-					releaseSlot( state );
-					resolve( value );
-				},
-				error => {
-					releaseSlot( state );
-					reject( error );
-				}
-			);
+			// `finally` frees the slot on both outcomes; `resolve()` adopts the
+			// task's promise, so a rejection still reaches the caller.
+			resolve( task().finally( () => releaseSlot( state ) ) );
 		};
 		if ( state.active < MAX_CONCURRENT_DOWNLOADS ) {
 			run();
@@ -250,7 +254,8 @@ async function fetchManifest( moduleUrl: string ): Promise< string[] > {
  * Resolves once the route/script/module catalogs are installed, when anything
  * fails (missing manifest or catalogs fall back to English), or after a
  * bounded wait — a stalled network must not wedge first render. Widget
- * catalogs are downloaded in the background and never awaited.
+ * catalogs (`<build>/widgets/**`) are not requested here at all; they load
+ * through `loadBundleI18nCatalog()` when a widget's module is imported.
  *
  * @param domain    - The package text domain the catalogs are registered under.
  * @param moduleUrl - `import.meta.url` of the calling init module; used to locate the build's i18n manifest.
@@ -280,24 +285,31 @@ export async function loadI18nCatalogs(
 	const state = sharedState();
 
 	const load = async () => {
-		// A missing manifest (dev watch build) 404s — expected, kept silent.
-		// Anything else is surfaced.
-		const manifest = fetchManifest( moduleUrl )
-			.catch( ( error: unknown ) => {
-				const message = errorMessage( error );
-				if ( ! isMissingCatalog( message ) ) {
-					warn( `Failed to load the i18n manifest for "${ domain }": ${ message }` );
-				}
-				return [] as string[];
-			} )
-			.then( bundles => new Set( bundles ) );
-		// Published for `loadBundleI18nCatalog()` before it resolves, so an
-		// on-demand request never races the manifest fetch.
-		state.manifests.set( domain, manifest );
+		// Fetched at most once per domain per page: the manifest is a static
+		// build artifact, and a repeat call must not be able to replace a good
+		// bundle set with the empty one a failed refetch yields — every widget
+		// loading after that would quietly skip its catalog.
+		let manifest = state.manifests.get( domain );
+		if ( ! manifest ) {
+			// A missing manifest (dev watch build) 404s — expected, kept silent.
+			// Anything else is surfaced.
+			manifest = fetchManifest( moduleUrl )
+				.catch( ( error: unknown ) => {
+					const message = errorMessage( error );
+					if ( ! isMissingCatalog( message ) ) {
+						warn( `Failed to load the i18n manifest for "${ domain }": ${ message }` );
+					}
+					return [] as string[];
+				} )
+				.then( bundles => new Set( bundles ) );
+			// Published for `loadBundleI18nCatalog()` before it resolves, so an
+			// on-demand request never races the manifest fetch.
+			state.manifests.set( domain, manifest );
+		}
 
 		const blocking: Promise< void >[] = [];
 		for ( const path of await manifest ) {
-			if ( path.includes( '/widgets/' ) ) {
+			if ( WIDGET_BUNDLE_PATH.test( path ) ) {
 				// Widget catalogs load on demand, when the widget's own module
 				// is imported — see `loadBundleI18nCatalog()`.
 				continue;

--- a/projects/packages/wp-build-polyfills/tests/js/load-i18n-catalogs.test.js
+++ b/projects/packages/wp-build-polyfills/tests/js/load-i18n-catalogs.test.js
@@ -98,25 +98,49 @@ describe( 'loadI18nCatalogs', () => {
 		] );
 	} );
 
-	it( 'starts widget catalog downloads but does not block on them', async () => {
-		const calls = installLoader( path =>
-			// Widget catalog downloads never settle; route download resolves.
-			path.includes( '/widgets/' ) ? new Promise( () => {} ) : Promise.resolve()
-		);
+	it( 'does not request widget catalogs at boot — they load on demand', async () => {
+		const calls = installLoader( () => Promise.resolve() );
 		installFetch( {
 			bundles: [ 'build/routes/a/content.js', 'build/widgets/latest-post/render.js' ],
 		} );
 		const { loadI18nCatalogs } = await import( HELPER );
 
-		// Default (5s) timeout: only prompt resolution proves widgets aren't awaited.
 		await loadI18nCatalogs( 'jetpack-test', MODULE_URL );
 
 		assert.deepEqual(
 			calls.map( ( [ path ] ) => path ),
-			[ 'build/routes/a/content.js', 'build/widgets/latest-post/render.js' ],
-			'the widget catalog download is still initiated'
+			[ 'build/routes/a/content.js' ],
+			'only non-widget catalogs are requested at boot'
 		);
-		assert.deepEqual( warnings, [], 'resolving via the widget split is not a timeout' );
+		assert.deepEqual( warnings, [] );
+	} );
+
+	it( 'limits how many catalog downloads run concurrently', async () => {
+		const resolvers = [];
+		const calls = installLoader(
+			() => new Promise( resolve => resolvers.push( resolve ) ) // Settles only when the test says so.
+		);
+		installFetch( {
+			bundles: Array.from( { length: 10 }, ( _, i ) => `build/routes/r${ i }/content.js` ),
+		} );
+		const { loadI18nCatalogs } = await import( HELPER );
+
+		const boot = loadI18nCatalogs( 'jetpack-test', MODULE_URL );
+		await new Promise( resolve => setTimeout( resolve, 0 ) );
+
+		assert.equal( calls.length, 6, 'only 6 of the 10 downloads start immediately' );
+
+		resolvers.shift()();
+		await new Promise( resolve => setTimeout( resolve, 0 ) );
+		assert.equal( calls.length, 7, 'a finished download frees a slot for the next one' );
+
+		while ( resolvers.length ) {
+			resolvers.shift()();
+			await new Promise( resolve => setTimeout( resolve, 0 ) );
+		}
+		await boot;
+		assert.equal( calls.length, 10, 'every download eventually runs' );
+		assert.deepEqual( warnings, [] );
 	} );
 
 	it( 'ignores non-string manifest entries and a malformed manifest shape', async () => {
@@ -264,5 +288,92 @@ describe( 'loadI18nCatalogs', () => {
 
 		await assert.doesNotReject( loadI18nCatalogs( 'jetpack-test', MODULE_URL ) );
 		assert.equal( warnings.length, 1 );
+	} );
+} );
+
+describe( 'loadBundleI18nCatalog', () => {
+	const WIDGET_BUNDLE = 'build/widgets/latest-post/render.js';
+
+	/**
+	 * Run the boot helper so the manifest is cached for on-demand loads.
+	 *
+	 * @param {string[]} bundles - Manifest bundle list to serve.
+	 * @return {Promise<{calls: Array, api: object}>} Recorded downloadI18n calls and the imported module.
+	 */
+	async function bootWithManifest( bundles ) {
+		const calls = installLoader( () => Promise.resolve() );
+		installFetch( { bundles } );
+		const api = await import( HELPER );
+		await api.loadI18nCatalogs( 'jetpack-test', MODULE_URL );
+		return { calls, api };
+	}
+
+	it( 'downloads a manifest-listed widget catalog on demand', async () => {
+		const { calls, api } = await bootWithManifest( [ 'build/routes/a/content.js', WIDGET_BUNDLE ] );
+		calls.length = 0;
+
+		await api.loadBundleI18nCatalog( 'jetpack-test', WIDGET_BUNDLE );
+
+		assert.deepEqual( calls, [ [ WIDGET_BUNDLE, 'jetpack-test', 'plugin' ] ] );
+		assert.deepEqual( warnings, [] );
+	} );
+
+	it( 'skips bundles the manifest does not list — they carry no strings', async () => {
+		const { calls, api } = await bootWithManifest( [ 'build/routes/a/content.js' ] );
+		calls.length = 0;
+
+		await api.loadBundleI18nCatalog( 'jetpack-test', WIDGET_BUNDLE );
+
+		assert.deepEqual( calls, [], 'no download for a bundle without gettext calls' );
+	} );
+
+	it( 'downloads each bundle once no matter how often it is requested', async () => {
+		const { calls, api } = await bootWithManifest( [ WIDGET_BUNDLE ] );
+		calls.length = 0;
+
+		await Promise.all( [
+			api.loadBundleI18nCatalog( 'jetpack-test', WIDGET_BUNDLE ),
+			api.loadBundleI18nCatalog( 'jetpack-test', WIDGET_BUNDLE ),
+		] );
+		await api.loadBundleI18nCatalog( 'jetpack-test', WIDGET_BUNDLE );
+
+		assert.equal( calls.length, 1, 'repeat requests reuse the first download' );
+	} );
+
+	it( 'resolves without downloading when the boot helper never ran', async () => {
+		const calls = installLoader( () => Promise.resolve() );
+		const requests = installFetch( { bundles: [ WIDGET_BUNDLE ] } );
+		const { loadBundleI18nCatalog } = await import( HELPER );
+
+		await assert.doesNotReject( loadBundleI18nCatalog( 'jetpack-test', WIDGET_BUNDLE ) );
+
+		assert.deepEqual( calls, [], 'no manifest means the English fallback' );
+		assert.deepEqual( requests, [], 'no stray manifest fetch either' );
+	} );
+
+	it( 'resolves without downloading for the en_US locale', async () => {
+		const calls = installLoader( () => Promise.resolve(), { locale: 'en_US' } );
+		installFetch( { bundles: [ WIDGET_BUNDLE ] } );
+		const api = await import( HELPER );
+		await api.loadI18nCatalogs( 'jetpack-test', MODULE_URL );
+		calls.length = 0;
+
+		await api.loadBundleI18nCatalog( 'jetpack-test', WIDGET_BUNDLE );
+
+		assert.deepEqual( calls, [] );
+	} );
+
+	it( 'resolves after the bounded wait when the download stalls, and says so', async () => {
+		const calls = installLoader( () => Promise.resolve() );
+		installFetch( { bundles: [ WIDGET_BUNDLE ] } );
+		const api = await import( HELPER );
+		await api.loadI18nCatalogs( 'jetpack-test', MODULE_URL );
+		calls.length = 0;
+		window.wp.jpI18nLoader.downloadI18n = () => new Promise( () => {} ); // Never settles.
+
+		await assert.doesNotReject( api.loadBundleI18nCatalog( 'jetpack-test', WIDGET_BUNDLE, 25 ) );
+
+		assert.equal( warnings.length, 1 );
+		assert.match( warnings[ 0 ], /still pending after 25ms/ );
 	} );
 } );

--- a/projects/packages/wp-build-polyfills/tests/js/load-i18n-catalogs.test.js
+++ b/projects/packages/wp-build-polyfills/tests/js/load-i18n-catalogs.test.js
@@ -344,6 +344,37 @@ describe( 'loadI18nCatalogs', () => {
 		await assert.doesNotReject( loadI18nCatalogs( 'jetpack-test', MODULE_URL ) );
 		assert.equal( warnings.length, 1 );
 	} );
+
+	// Keep this the only test that drives the unrecognized-shape path: the
+	// fallback state it installs is module-level (one per copy of the helper,
+	// by design — a page that hits this stays on it), and the helper module is
+	// cached across tests in this file, so a second test here would inherit
+	// this one's download map and see no warning.
+	it( 'keeps working when another build parked a foreign shape on the window slot', async () => {
+		const calls = installLoader( () => Promise.resolve() );
+		// A hypothetical other version of this module: same global name, plain
+		// objects where this copy expects Maps. Reading it blind would throw
+		// out of `manifests.get()`, and boot awaits this helper uncaught.
+		const foreign = { manifests: {}, downloads: {}, active: 0, queue: [] };
+		window.__jetpackWpBuildI18nCatalogs = foreign;
+		installFetch( { bundles: [ 'build/routes/a/content.js' ] } );
+		const { loadI18nCatalogs } = await import( HELPER );
+
+		await assert.doesNotReject( loadI18nCatalogs( 'jetpack-test', MODULE_URL ) );
+
+		assert.deepEqual(
+			calls,
+			[ [ 'build/routes/a/content.js', 'jetpack-test', 'plugin' ] ],
+			'catalogs still download, from state private to this copy'
+		);
+		assert.equal(
+			window.__jetpackWpBuildI18nCatalogs,
+			foreign,
+			'the other copy keeps the state it is using'
+		);
+		assert.equal( warnings.length, 1 );
+		assert.match( warnings[ 0 ], /unrecognized shape/ );
+	} );
 } );
 
 describe( 'loadBundleI18nCatalog', () => {

--- a/projects/packages/wp-build-polyfills/tests/js/load-i18n-catalogs.test.js
+++ b/projects/packages/wp-build-polyfills/tests/js/load-i18n-catalogs.test.js
@@ -15,6 +15,8 @@ const MODULE_URL =
 const MANIFEST_URL =
 	'https://example.org/wp-content/plugins/x/jetpack_vendor/automattic/jetpack-test/build/i18n-manifest.json?ver=abc123';
 
+const WIDGET_BUNDLE = 'build/widgets/latest-post/render.js';
+
 /* eslint-disable no-console -- capture the helper's console.warn diagnostics */
 const realWarn = console.warn;
 let warnings;
@@ -115,6 +117,29 @@ describe( 'loadI18nCatalogs', () => {
 		assert.deepEqual( warnings, [] );
 	} );
 
+	it( 'only defers the widget tree itself, not bundles that merely sit under a "widgets" name', async () => {
+		const calls = installLoader( () => Promise.resolve() );
+		installFetch( {
+			bundles: [
+				'build/routes/widgets/content.js',
+				'build/scripts/widgets/index.js',
+				WIDGET_BUNDLE,
+			],
+		} );
+		const { loadI18nCatalogs } = await import( HELPER );
+
+		await loadI18nCatalogs( 'jetpack-test', MODULE_URL );
+
+		// Only `<build>/widgets/**` loads on demand. A route or script called
+		// `widgets` has no on-demand caller to pick it up later — the widget
+		// resolvers build `build/widgets/<name>/<file>.js` paths of their own —
+		// so skipping it here would leave it untranslated for the whole page.
+		assert.deepEqual(
+			calls.map( ( [ path ] ) => path ),
+			[ 'build/routes/widgets/content.js', 'build/scripts/widgets/index.js' ]
+		);
+	} );
+
 	it( 'limits how many catalog downloads run concurrently', async () => {
 		const resolvers = [];
 		const calls = installLoader(
@@ -143,18 +168,48 @@ describe( 'loadI18nCatalogs', () => {
 		assert.deepEqual( warnings, [] );
 	} );
 
-	it( 'ignores non-string manifest entries and a malformed manifest shape', async () => {
+	it( 'ignores non-string manifest entries', async () => {
 		const calls = installLoader( () => Promise.resolve() );
 		installFetch( { bundles: [ 'build/a.js', 42, null, { path: 'build/b.js' } ] } );
 		const { loadI18nCatalogs } = await import( HELPER );
 
 		await loadI18nCatalogs( 'jetpack-test', MODULE_URL );
-		assert.deepEqual( calls, [ [ 'build/a.js', 'jetpack-test', 'plugin' ] ] );
 
-		calls.length = 0;
+		assert.deepEqual( calls, [ [ 'build/a.js', 'jetpack-test', 'plugin' ] ] );
+	} );
+
+	it( 'downloads nothing when the manifest has no bundles array', async () => {
+		const calls = installLoader( () => Promise.resolve() );
 		installFetch( { something: 'else' } );
+		const { loadI18nCatalogs } = await import( HELPER );
+
 		await loadI18nCatalogs( 'jetpack-test', MODULE_URL );
-		assert.deepEqual( calls, [], 'no downloads when the manifest has no bundles array' );
+
+		assert.deepEqual( calls, [] );
+	} );
+
+	it( 'fetches the manifest once per domain, keeping a good bundle set on a repeat call', async () => {
+		const calls = installLoader( () => Promise.resolve() );
+		const requests = installFetch( { bundles: [ WIDGET_BUNDLE ] } );
+		const api = await import( HELPER );
+		await api.loadI18nCatalogs( 'jetpack-test', MODULE_URL );
+
+		// A second boot whose manifest request fails must not replace the
+		// cached bundle set with the empty one — every widget loading after
+		// that would quietly skip its catalog.
+		const repeatRequests = installFetch( new Error( 'network down' ) );
+		await api.loadI18nCatalogs( 'jetpack-test', MODULE_URL );
+
+		assert.equal( requests.length, 1, 'the first call fetched the manifest' );
+		assert.deepEqual( repeatRequests, [], 'the repeat call reuses it, with no second request' );
+		assert.deepEqual( warnings, [], 'and so has no manifest failure to report' );
+
+		await api.loadBundleI18nCatalog( 'jetpack-test', WIDGET_BUNDLE );
+		assert.deepEqual(
+			calls,
+			[ [ WIDGET_BUNDLE, 'jetpack-test', 'plugin' ] ],
+			'the widget catalog is still known to the manifest'
+		);
 	} );
 
 	it( 'resolves and warns when the manifest request fails unexpectedly', async () => {
@@ -292,8 +347,6 @@ describe( 'loadI18nCatalogs', () => {
 } );
 
 describe( 'loadBundleI18nCatalog', () => {
-	const WIDGET_BUNDLE = 'build/widgets/latest-post/render.js';
-
 	/**
 	 * Run the boot helper so the manifest is cached for on-demand loads.
 	 *


### PR DESCRIPTION
Fixes # N/A (reported in WOOA7S-1822, follow-up to #50762 — see [this comment](https://github.com/Automattic/jetpack/pull/50762#issuecomment-5114875596))

## Proposed changes

On any non-English locale, `loadI18nCatalogs()` issued one translation-catalog request per bundle in the build's i18n manifest — **100 requests for the current Premium Analytics build** — all in one unthrottled loop at boot. On HTTP/2 origins nothing caps that burst, and a slow origin serves nothing else until it drains (measured at ~48s to first render in WOOA7S-1822). Widget catalogs (84 of the 100) were "non-blocking" only in the sense of not being awaited; they were still all requested for widgets that may never render.

* **`wp-build-polyfills`**: `loadI18nCatalogs()` now downloads only route/module/script catalogs at boot, through a 6-slot concurrency queue, so the burst can never starve the origin regardless of protocol. Widget bundles are no longer requested at boot. A new `loadBundleI18nCatalog( domain, bundlePath, timeoutMs? )` export downloads a single bundle's catalog on demand — it checks manifest membership (bundles without gettext calls are skipped without a request), dedupes repeat requests, and shares the queue. Shared state lives on `window`, since each wp-build bundle inlines its own copy of the helper.
* **`premium-analytics`**: each widget bundle's catalog now loads as part of importing that bundle. Render modules go through a custom `resolveWidgetModule` on `WidgetDashboard`; metadata (`widget.js`) records are gated in a `useWidgetTypes` wrapper until their catalogs are installed. Both are awaited (bounded) *before* the import because widget bundles evaluate `__()` at module scope — a catalog that arrives after evaluation leaves those strings untranslated for the session.

The other five packages sharing `loadI18nCatalogs` (videopress, forms, activity-log, newsletter, publicize, backup) have no widget bundles; they pick up the boot throttle with no behavior change.

### Measured (local Docker site via a tunnel, `pt_BR`, one full dashboard load each)

| Metric | trunk | this PR |
|---|---|---|
| Catalog requests (+ manifest) | 100 + 1 | 56 + 1 (−44%) |
| Catalog drain window | ~23s | ~17s |
| Last dashboard REST data request | page+33s | page+23s |
| Requests when switching to the Insights tab | 0 (all pre-paid at boot) | 9 (only newly rendered widgets) |

Note: over HTTP/1.1 the browser's 6-connections-per-host cap already serializes the old burst, which hides the pathology locally. The unthrottled burst manifests on HTTP/2 (as in WOOA7S-1822), where the browser multiplexes all 100 requests at once; the new queue bounds concurrency in both cases.

## Related product discussion/links
* WOOA7S-1822
* Follow-up to #50762

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

1. On a Jetpack site with Premium Analytics, set the site (or user) language to any non-`en_US` locale, e.g. Español.
2. Open DevTools → Network, filter by `languages`, and load `wp-admin/admin.php?page=jetpack-premium-analytics-wp-admin`.
3. Expect roughly 55–70 catalog requests (16 route/module catalogs plus one per widget module the dashboard actually imports), with at most 6 in flight at a time — instead of ~100 issued simultaneously right after boot.
4. Switch to a dashboard tab whose widgets haven't rendered yet (e.g. Insights): a small batch of new catalog requests should fire, one per newly rendered widget.
5. Check the console: there should be no `[jetpack-i18n]` warnings.
6. Requests 404ing is expected on a test site — no language packs exist for these bundles yet, and the UI falls back to English. On `en_US` no catalog requests should fire at all.

JS tests: `jp test js packages/wp-build-polyfills` and `jp test js packages/premium-analytics`.

