### PR TITLE
Agents Manager: fix missing AI entry points in the editor admin bar on Atomic sites

### DIFF
--- a/projects/packages/agents-manager/changelog/fix-agents-manager-omnibar-experiment-slug
+++ b/projects/packages/agents-manager/changelog/fix-agents-manager-omnibar-experiment-slug
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Recognize the renamed Gutenberg omnibar experiment slug (gutenberg-omnibar, Gutenberg 23.5+) so the editor admin bar entry points keep working.

--- a/projects/packages/agents-manager/changelog/fix-agents-manager-omnibar-experiment-slug
+++ b/projects/packages/agents-manager/changelog/fix-agents-manager-omnibar-experiment-slug
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Fix the editor admin bar AI entry points missing on sites running Gutenberg 23.5 or later.
+Fix missing AI entry points in the editor admin bar on sites running Gutenberg 23.5 or later.

--- a/projects/packages/agents-manager/changelog/fix-agents-manager-omnibar-experiment-slug
+++ b/projects/packages/agents-manager/changelog/fix-agents-manager-omnibar-experiment-slug
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Recognize the renamed Gutenberg omnibar experiment slug (gutenberg-omnibar, Gutenberg 23.5+) so the editor admin bar entry points keep working.
+Fix the editor admin bar AI entry points missing on sites running Gutenberg 23.5 or later.

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -932,7 +932,7 @@ class Agents_Manager {
 	/**
 	 * Returns true when Gutenberg's "admin bar in editor" (omnibar) experiment is active.
 	 *
-	 * Mirrors Gutenberg core's gate in `lib/experimental/omnibar/load.php`, and fails safe when
+	 * Mirrors Gutenberg core's gate in `lib/experimental/omnibar/load.php`, and returns false when
 	 * `gutenberg_is_experiment_enabled()` is unavailable. Gutenberg 23.5 renamed the experiment
 	 * slug from `gutenberg-admin-bar-in-editor` to `gutenberg-omnibar`; both are checked since
 	 * pre-rename builds are still deployed (e.g. wpcom's bundled gutenberg-core).

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -932,17 +932,26 @@ class Agents_Manager {
 	/**
 	 * Returns true when Gutenberg's "admin bar in editor" (omnibar) experiment is active.
 	 *
-	 * Mirrors Gutenberg core's gate in `lib/experimental/admin-bar-in-editor/load.php`, and fails
-	 * safe when `gutenberg_is_experiment_enabled()` is unavailable.
+	 * Mirrors Gutenberg core's gate in `lib/experimental/omnibar/load.php`, and fails safe when
+	 * `gutenberg_is_experiment_enabled()` is unavailable. Gutenberg 23.5 renamed the experiment
+	 * slug from `gutenberg-admin-bar-in-editor` to `gutenberg-omnibar`; both are checked since
+	 * pre-rename builds are still deployed (e.g. wpcom's bundled gutenberg-core).
 	 *
 	 * @return bool
 	 */
 	private static function is_admin_bar_in_editor() {
-		return self::is_block_editor()
-			&& is_admin_bar_showing()
-			&& function_exists( 'gutenberg_is_experiment_enabled' )
+		if (
+			! self::is_block_editor()
+			|| ! is_admin_bar_showing()
+			|| ! function_exists( 'gutenberg_is_experiment_enabled' )
+		) {
+			return false;
+		}
+
+		// @phan-suppress-next-line PhanUndeclaredFunction -- Guarded by function_exists() above.
+		return \gutenberg_is_experiment_enabled( 'gutenberg-omnibar' )
 			// @phan-suppress-next-line PhanUndeclaredFunction -- Guarded by function_exists() above.
-			&& \gutenberg_is_experiment_enabled( 'gutenberg-admin-bar-in-editor' );
+			|| \gutenberg_is_experiment_enabled( 'gutenberg-admin-bar-in-editor' );
 	}
 
 	/**

--- a/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
+++ b/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
@@ -683,6 +683,52 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Tests that the omnibar experiment is recognized when only the renamed slug
+	 * (`gutenberg-omnibar`, Gutenberg 23.5+) is enabled.
+	 */
+	public function test_ai_chat_button_registered_in_editor_omnibar_with_renamed_slug() {
+		$this->set_up_block_editor_request();
+
+		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
+		Functions\when( 'gutenberg_is_experiment_enabled' )->alias(
+			function ( $experiment ) {
+				return 'gutenberg-omnibar' === $experiment;
+			}
+		);
+
+		$this->agents_manager->enqueue_scripts();
+
+		$this->assertNotFalse(
+			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_ai_chat_button' ) )
+		);
+
+		remove_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
+	}
+
+	/**
+	 * Tests that the omnibar experiment is recognized when only the pre-rename slug
+	 * (`gutenberg-admin-bar-in-editor`, Gutenberg ≤ 23.4) is enabled.
+	 */
+	public function test_ai_chat_button_registered_in_editor_omnibar_with_legacy_slug() {
+		$this->set_up_block_editor_request();
+
+		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
+		Functions\when( 'gutenberg_is_experiment_enabled' )->alias(
+			function ( $experiment ) {
+				return 'gutenberg-admin-bar-in-editor' === $experiment;
+			}
+		);
+
+		$this->agents_manager->enqueue_scripts();
+
+		$this->assertNotFalse(
+			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_ai_chat_button' ) )
+		);
+
+		remove_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
+	}
+
+	/**
 	 * Tests that the Ask AI button is not added to the editor admin bar when the omnibar
 	 * experiment is inactive, even though Agents Manager is enabled.
 	 */


### PR DESCRIPTION
Fixes AI-1088

## Proposed changes

* `Agents_Manager::is_admin_bar_in_editor()` now recognizes both Gutenberg omnibar experiment slugs: `gutenberg-omnibar` (Gutenberg 23.5+) and the pre-rename `gutenberg-admin-bar-in-editor` (≤ 23.4).
* Gutenberg 23.5 renamed the experiment slug, so on sites running 23.5+ with the omnibar enabled, the editor admin bar entry points (the Ask AI button and the Help "?" menu) were never added — while the frontend still hid the editor toolbar buttons (the browser-side signals kept their old names), leaving no entry point at all.
* The old slug is kept for pre-rename builds still deployed (e.g. wpcom's bundled gutenberg-core 23.3.x). Gutenberg ≥ 23.6 removed the experiment entirely, so both lookups are simply false there.
* Add unit tests pinning each slug individually, since the existing omnibar tests mock the experiment check as always-true and pass regardless of which slug is consulted.

## Related product discussion/links

* AI-1088

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Sandbox this PR on your Atomic site.
* Go to `/wp-admin/profile.php` and disable the unified AI chat experience in Help Center.
* Open the Site Editor — the spark icon (with the legacy Help Center button) appears in the omnibar:

https://github.com/user-attachments/assets/e8a4ab9e-bcc4-4bab-9e2c-73bbda2b4786

* Go to `/wp-admin/profile.php` and enable the unified AI chat experience in Help Center.
* Open the Site Editor — the spark icon (with the new Help Center button) appears in the omnibar:

https://github.com/user-attachments/assets/c752ecdc-b3d2-4189-a55e-af959ec26689
