### PR TITLE
AI Sidebar: align AI Editorial Review enablement

### DIFF
--- a/projects/plugins/jetpack/changelog/align-ai-editorial-review-enablement
+++ b/projects/plugins/jetpack/changelog/align-ai-editorial-review-enablement
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Sidebar: Align Editorial Review enablement with the other writing-assistance features.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -276,22 +276,6 @@ class Jetpack_AI_Sidebar {
 	// ──────────────────────────────────────────────────
 
 	/**
-	 * UI feature flag for AI Editorial Review.
-	 *
-	 * Server-side permission checks still gate execution. This site-side flag
-	 * controls whether the sidebar suggestion is exposed, while keeping a
-	 * feature-specific filter available as a kill switch.
-	 *
-	 * @return bool
-	 */
-	private static function is_ai_editorial_review_enabled(): bool {
-		return (bool) apply_filters(
-			'jetpack_ai_editorial_review_enabled',
-			true
-		);
-	}
-
-	/**
 	 * UI feature flag for the SEO Enhancer suggestions (SEO title and meta description).
 	 *
 	 * Exposed only where the suggestions can actually be used: the SEO Enhancer
@@ -402,7 +386,7 @@ class Jetpack_AI_Sidebar {
 		// Ability permission callbacks enforce server-side access for these
 		// features. SEO additionally requires the site-side gates below.
 		$features = array(
-			'aiEditorialReview'       => self::is_ai_editorial_review_enabled(),
+			'aiEditorialReview'       => true,
 			'generateFeedback'        => true,
 			'proofreadContent'        => true,
 			'blockTransformations'    => true,
@@ -424,6 +408,7 @@ class Jetpack_AI_Sidebar {
 
 		// Normalize the flags released here while leaving host-added values
 		// untouched. Keep SEO's site-side requirements final.
+		$features['aiEditorialReview']       = (bool) $features['aiEditorialReview'];
 		$features['generateFeedback']        = (bool) $features['generateFeedback'];
 		$features['proofreadContent']        = (bool) $features['proofreadContent'];
 		$features['blockToolbarButton']      = (bool) $features['blockToolbarButton'];
@@ -485,7 +470,7 @@ class Jetpack_AI_Sidebar {
 		// Set our fields in place, leaving the rest of $data (including agentProviders)
 		// untouched so the client-side gate can drop Jetpack AI Sidebar while keeping
 		// fallbacks such as the Big Sky provider. Hosts that need intentional overrides
-		// should use the AI Editorial Review and preview filters.
+		// should use the sidebar and preview feature filters.
 		foreach ( $fields as $key => $value ) {
 			$data[ $key ] = $value;
 		}

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -107,7 +107,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		remove_all_filters( 'jetpack_ai_sidebar_enabled' );
 		remove_all_filters( 'agents_manager_agent_providers' );
 		remove_all_filters( 'agents_manager_enabled_in_block_editor' );
-		remove_all_filters( 'jetpack_ai_editorial_review_enabled' );
 		remove_all_filters( 'jetpack_ai_sidebar_preview_enabled' );
 		remove_all_filters( 'jetpack_ai_sidebar_preview_features' );
 		remove_all_filters( 'jetpack_ai_sidebar_agents_manager_data' );
@@ -328,7 +327,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	// ──────────────────────────────────────────────────
 
 	/**
-	 * Test that init() registers hooks by default for AI Editorial Review.
+	 * Test that init() registers the Jetpack AI Sidebar hooks by default.
 	 */
 	public function test_init_registers_hooks_by_default() {
 		Jetpack_AI_Sidebar::init();
@@ -391,23 +390,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$this->assertFalse(
 			has_action( 'jetpack_register_gutenberg_extensions', array( Jetpack_AI_Sidebar::class, 'register_toolbar_button_extension' ) ),
 			'register_toolbar_button_extension should not be hooked when the preview gate is false.'
-		);
-	}
-
-	/**
-	 * Test that the preview surface can initialize without AI Editorial Review.
-	 */
-	public function test_init_registers_hooks_when_preview_is_enabled_without_ai_editorial_review() {
-		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
-		Jetpack_AI_Sidebar::init();
-
-		$this->assertNotFalse(
-			has_filter( 'agents_manager_agent_providers', array( Jetpack_AI_Sidebar::class, 'register_provider' ) ),
-			'register_provider should be hooked when the preview gate is true.'
-		);
-		$this->assertNotFalse(
-			has_action( 'admin_enqueue_scripts', array( Jetpack_AI_Sidebar::class, 'maybe_enqueue_abilities_script' ) ),
-			'maybe_enqueue_abilities_script should be hooked when the preview gate is true.'
 		);
 	}
 
@@ -701,23 +683,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * Test that the Agents Manager block-editor gate preserves existing true values.
 	 */
 	public function test_enable_agents_manager_on_provider_surfaces_preserves_existing_true() {
-		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
 		$this->set_page_block_editor_screen();
 
 		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_on_provider_surfaces( true ) );
-	}
-
-	/**
-	 * The AI Editorial Review filter is decoupled from this Agents Manager entrypoint.
-	 *
-	 * The preview gate is wpcom/Big Sky-based, so turning AI Editorial Review off
-	 * does not close the gate (AI Editorial Review only affects the exposed data).
-	 */
-	public function test_enable_agents_manager_on_provider_surfaces_ignores_ai_editorial_review_filter() {
-		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
-		$this->set_block_editor_screen();
-
-		$this->assertTrue( Jetpack_AI_Sidebar::enable_agents_manager_on_provider_surfaces( false ) );
 	}
 
 	/**
@@ -735,11 +703,10 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	// ──────────────────────────────────────────────────
 
 	/**
-	 * Platform-emitted Agents Manager data gets the AI Editorial Review flag.
+	 * Platform-emitted Agents Manager data enables AI Editorial Review by default.
 	 */
-	public function test_add_agents_manager_data_exposes_ai_editorial_review_enabled() {
+	public function test_add_agents_manager_data_exposes_ai_editorial_review_by_default() {
 		$this->set_block_editor_screen();
-		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_true' );
 
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
@@ -800,6 +767,7 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		add_filter(
 			'jetpack_ai_sidebar_preview_features',
 			function ( $features ) {
+				$features['aiEditorialReview']       = false;
 				$features['generateFeedback']        = false;
 				$features['proofreadContent']        = false;
 				$features['blockToolbarButton']      = false;
@@ -813,9 +781,11 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
 
 		$this->assertSame( 'wp-orchestrator', $data['agentId'] );
-		$this->assertTrue( $data['jetpackAiSidebar']['features']['aiEditorialReview'] );
+		$this->assertTrue( $data['jetpackAiSidebar']['enabled'] );
+		$this->assertFalse( $data['jetpackAiSidebar']['features']['aiEditorialReview'] );
 		$this->assertFalse( $data['jetpackAiSidebar']['features']['generateFeedback'] );
 		$this->assertFalse( $data['jetpackAiSidebar']['features']['proofreadContent'] );
+		$this->assertTrue( $data['jetpackAiSidebar']['features']['blockTransformations'] );
 		$this->assertFalse( $data['jetpackAiSidebar']['features']['blockToolbarButton'] );
 		$this->assertFalse( $data['jetpackAiSidebar']['features']['optimizeTitleSuggestion'] );
 		$this->assertFalse( $data['jetpackAiSidebar']['features']['seoSuggestions'] );
@@ -903,22 +873,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		);
 
 		$this->assertSame( $providers, $data['agentProviders'] );
-	}
-
-	/**
-	 * Preview and AI Editorial Review have separate gates.
-	 */
-	public function test_add_agents_manager_data_allows_preview_without_ai_editorial_review() {
-		$this->set_block_editor_screen();
-		add_filter( 'jetpack_ai_editorial_review_enabled', '__return_false' );
-
-		$data = Jetpack_AI_Sidebar::add_agents_manager_data( array( 'sectionName' => 'gutenberg' ) );
-
-		$this->assertSame( 'wp-orchestrator', $data['agentId'] );
-		$this->assertSame( true, $data['jetpackAiSidebar']['enabled'] );
-		$this->assertSame( false, $data['jetpackAiSidebar']['features']['aiEditorialReview'] );
-		$this->assertSame( true, $data['jetpackAiSidebar']['features']['blockTransformations'] );
-		$this->assertSame( true, $data['jetpackAiSidebar']['features']['blockToolbarButton'] );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #

## Proposed changes

* Enable AI Editorial Review by default alongside Generate Feedback and Proofreader.
* Remove the dedicated `jetpack_ai_editorial_review_enabled` filter.
* Allow `jetpack_ai_sidebar_preview_features` to disable AI Editorial Review in the same way as the other released sidebar features.
* Update the Jetpack AI Sidebar tests for the shared feature-filter behavior.

## Related product discussion/links

* Builds on #50901.

## Does this pull request change what data or activity we track or use?

No. This changes feature eligibility and filter behavior only; it does not add or change tracking.

## Testing instructions

Automated checks completed:

* `jp docker phpunit jetpack -- --filter=Jetpack_AI_Sidebar_Test` — 61 tests, 142 assertions, 1 skipped.
* `jp phan plugins/jetpack --allow-polyfill-parser --include-analysis-file-list=projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php` — 0 issues.
* `composer phpcs:lint -- projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php` — pass.
* `jp changelog validate plugins/jetpack` — pass.

Manual release verification:

1. Use a connected site where Jetpack AI and the AI Sidebar are enabled at `wp.com/settings/ai-tools`.
2. Open a post editor. Confirm the sidebar loads and **Editorial Review** is available alongside Generate Feedback and Proofreader.
3. Open a page editor and repeat the check. Confirm **Editorial Review** is available and the provider loads without console errors.
4. Use `jetpack_ai_sidebar_preview_features` to set `aiEditorialReview` to `false`. Confirm **Editorial Review** is hidden while the sidebar and the other released features remain available.
5. Turn off `wp.com/settings/ai-tools`. Confirm the sidebar and **Editorial Review** are disabled across the supported editor surfaces.
