### PR TITLE
Newsletters: fix subscription options translations and persistent

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-newsletter-subscription-options-persistence
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-subscription-options-persistence
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Subscriptions: Stop the site settings endpoint from saving unchanged subscription message defaults, which could lock a site's welcome email to the language the settings screen happened to be viewed in.
+Subscriptions: Stop the site settings endpoint from saving unchanged subscription message defaults; translate the default subscription options using the user locale.

--- a/projects/plugins/jetpack/changelog/fix-newsletter-subscription-options-persistence
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-subscription-options-persistence
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscriptions: Stop the site settings endpoint from saving unchanged subscription message defaults, which could lock a site's welcome email to the language the settings screen happened to be viewed in.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -656,12 +656,6 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 		// re-populating the defaults, so a partial row stays partial before the merge.
 		$default_subscription_options = (array) apply_filters( 'default_option_subscription_options', array(), 'subscription_options', false );
 		$stored_subscription_options  = (array) get_option( 'subscription_options', array() );
-		// Resolve the defaults the same way get_option() does for a missing row (via the
-		// `default_option_*` filter with $passed_default = false), then let any stored
-		// sub-keys take precedence. Passing an array default keeps get_option() from
-		// re-populating the defaults, so a partial row stays partial before the merge.
-		$default_subscription_options = (array) apply_filters( 'default_option_subscription_options', array(), 'subscription_options', false );
-		$stored_subscription_options  = (array) get_option( 'subscription_options', array() );
 		$subscription_options         = array_merge( $default_subscription_options, $stored_subscription_options );
 
 		if ( $switched_locale ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -503,7 +503,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						'show_on_front'                    => (string) get_option( 'show_on_front' ),
 						'page_on_front'                    => (string) get_option( 'page_on_front' ),
 						'page_for_posts'                   => (string) get_option( 'page_for_posts' ),
-						'subscription_options'             => (array) get_option( 'subscription_options' ),
+						'subscription_options'             => $this->get_subscription_options_in_user_locale(),
 						'supports_free_tier_customization' => true,
 						'jetpack_verbum_subscription_modal' => (bool) get_option( 'jetpack_verbum_subscription_modal', true ),
 						'enable_verbum_commenting'         => (bool) get_option( 'enable_verbum_commenting', true ),
@@ -630,6 +630,32 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Reads `subscription_options` with the current user's locale active, to
+	 * ensure that the defaults would be translated when displaying to the user
+	 * or comparing the options before saving.
+	 *
+	 * @return array The `subscription_options` value, defaults included.
+	 */
+	private function get_subscription_options_in_user_locale() {
+		$switched_locale = false;
+
+		if ( function_exists( 'wpcom_switch_to_user_locale' ) ) {
+			// Compare the locales before/after switch to decide if we should switch back
+			$locale_before = determine_locale();
+			wpcom_switch_to_user_locale();
+			$switched_locale = determine_locale() !== $locale_before;
+		}
+
+		$subscription_options = (array) get_option( 'subscription_options' );
+
+		if ( $switched_locale ) {
+			wpcom_restore_current_locale();
+		}
+
+		return $subscription_options;
 	}
 
 	/**
@@ -1039,7 +1065,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					// touched. This could result in a translated value inadvertently
 					// saved in the database.
 					// Get the value from db or the default options populated by filter.
-					$current_subscription_options = (array) get_option( 'subscription_options' );
+					$current_subscription_options = $this->get_subscription_options_in_user_locale();
 					$changed_subscription_options = array();
 
 					foreach ( $filtered_value as $subscription_option_key => $subscription_option_value ) {

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -650,7 +650,19 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 			$switched_locale = determine_locale() !== $locale_before;
 		}
 
-		$subscription_options = (array) get_option( 'subscription_options' );
+		// Resolve the defaults the same way get_option() does for a missing row (via the
+		// `default_option_*` filter with $passed_default = false), then let any stored
+		// sub-keys take precedence. Passing an array default keeps get_option() from
+		// re-populating the defaults, so a partial row stays partial before the merge.
+		$default_subscription_options = (array) apply_filters( 'default_option_subscription_options', array(), 'subscription_options', false );
+		$stored_subscription_options  = (array) get_option( 'subscription_options', array() );
+		// Resolve the defaults the same way get_option() does for a missing row (via the
+		// `default_option_*` filter with $passed_default = false), then let any stored
+		// sub-keys take precedence. Passing an array default keeps get_option() from
+		// re-populating the defaults, so a partial row stays partial before the merge.
+		$default_subscription_options = (array) apply_filters( 'default_option_subscription_options', array(), 'subscription_options', false );
+		$stored_subscription_options  = (array) get_option( 'subscription_options', array() );
+		$subscription_options         = array_merge( $default_subscription_options, $stored_subscription_options );
 
 		if ( $switched_locale ) {
 			restore_previous_locale();

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -1072,6 +1072,25 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 					foreach ( $filtered_value as $subscription_option_key => $subscription_option_value ) {
 						$current_subscription_option = $current_subscription_options[ $subscription_option_key ] ?? null;
 
+						// The incoming value has already been through wp_kses() above, and
+						// wp_kses() is not guaranteed to be byte-preserving — it rewrites
+						// attribute quoting, and differently across WordPress versions. Put the
+						// current value through the same pass so the comparison reflects a real
+						// edit rather than a sanitizer rewrite; without this, a default carrying
+						// markup (`invitation`) never compares equal and is persisted on every
+						// save. Safe to apply to an already-sanitized value: the pass is
+						// idempotent.
+						if ( is_string( $current_subscription_option ) ) {
+							$current_subscription_option = wp_kses(
+								$current_subscription_option,
+								array(
+									'a' => array(
+										'href' => array(),
+									),
+								)
+							);
+						}
+
 						// A sub-key the site has never stored reads as unset everywhere this
 						// option is consumed, so an empty incoming value for it is not a change.
 						if (

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -1034,11 +1034,43 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 						$filtered_value['hide_free_tier'] = $hide_free_tier;
 					}
 
+					// Clients that render the settings form tend to post the whole
+					// `subscription_options` bag back, including sub-keys the user never
+					// touched. This could result in a translated value inadvertently
+					// saved in the database.
+					// Get the value from db or the default options populated by filter.
+					$current_subscription_options = (array) get_option( 'subscription_options' );
+					$changed_subscription_options = array();
+
+					foreach ( $filtered_value as $subscription_option_key => $subscription_option_value ) {
+						$current_subscription_option = $current_subscription_options[ $subscription_option_key ] ?? null;
+
+						// A sub-key the site has never stored reads as unset everywhere this
+						// option is consumed, so an empty incoming value for it is not a change.
+						if (
+							null === $current_subscription_option
+							&& ( '' === $subscription_option_value || false === $subscription_option_value )
+						) {
+							continue;
+						}
+
+						if ( $current_subscription_option === $subscription_option_value ) {
+							continue;
+						}
+
+						$changed_subscription_options[ $subscription_option_key ] = $subscription_option_value;
+					}
+
+					if ( empty( $changed_subscription_options ) ) {
+						break;
+					}
+
+					// Get the value from the database or an empty array.
 					$old_subscription_options = get_option( 'subscription_options', array() );
-					$new_subscription_options = array_merge( $old_subscription_options, $filtered_value );
+					$new_subscription_options = array_merge( $old_subscription_options, $changed_subscription_options );
 
 					if ( update_option( $key, $new_subscription_options ) ) {
-						$updated[ $key ] = $filtered_value;
+						$updated[ $key ] = $changed_subscription_options;
 					}
 					break;
 

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-site-settings-endpoint.php
@@ -645,6 +645,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 		if ( function_exists( 'wpcom_switch_to_user_locale' ) ) {
 			// Compare the locales before/after switch to decide if we should switch back
 			$locale_before = determine_locale();
+			// @phan-suppress-next-line PhanUndeclaredFunction -- Checked above. See also https://github.com/phan/phan/issues/1204.
 			wpcom_switch_to_user_locale();
 			$switched_locale = determine_locale() !== $locale_before;
 		}
@@ -652,7 +653,7 @@ class WPCOM_JSON_API_Site_Settings_Endpoint extends WPCOM_JSON_API_Endpoint {
 		$subscription_options = (array) get_option( 'subscription_options' );
 
 		if ( $switched_locale ) {
-			wpcom_restore_current_locale();
+			restore_previous_locale();
 		}
 
 		return $subscription_options;

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
@@ -324,6 +324,48 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Once any sub-key has been saved, the option row exists without the untouched
+	 * defaults — the `default_option_subscription_options` filter only fires for a
+	 * missing row. The GET response must still expose those defaults so the form
+	 * renders the translated welcome/invitation/comment_follow text rather than
+	 * blanks.
+	 */
+	public function test_get_settings_populates_defaults_after_partial_row_saved() {
+		$defaults = $this->register_subscription_options_default();
+
+		// A prior save of a non-default sub-key leaves the row partial.
+		update_option( 'subscription_options', array( 'subscribe_modal_heading' => 'My heading' ) );
+
+		$response = $this->make_get_request();
+		$settings = $response['settings'];
+
+		$this->assertSame( $defaults['invitation'], $settings['subscription_options']['invitation'] );
+		$this->assertSame( $defaults['welcome'], $settings['subscription_options']['welcome'] );
+		$this->assertSame( $defaults['comment_follow'], $settings['subscription_options']['comment_follow'] );
+		$this->assertSame( 'My heading', $settings['subscription_options']['subscribe_modal_heading'] );
+	}
+
+	/**
+	 * The same partial-row state must not break change detection on save: re-posting
+	 * the untouched defaults alongside the stored sub-key is still a no-op, so the
+	 * translated defaults aren't frozen into the row on the next save.
+	 */
+	public function test_post_subscription_options_ignores_defaults_after_partial_row_saved() {
+		$defaults = $this->register_subscription_options_default();
+
+		update_option( 'subscription_options', array( 'subscribe_modal_heading' => 'My heading' ) );
+
+		$setting  = wp_json_encode(
+			array( 'subscription_options' => $defaults ),
+			JSON_UNESCAPED_SLASHES
+		);
+		$response = $this->make_post_request( $setting );
+
+		$this->assertArrayNotHasKey( 'subscription_options', $response['updated'] );
+		$this->assertSame( array( 'subscribe_modal_heading' => 'My heading' ), get_option( 'subscription_options' ) );
+	}
+
+	/**
 	 * Data provider of falsy `hide_free_tier` representations.
 	 *
 	 * @return array<string,array{mixed}> [ $posted_value ]

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
@@ -230,9 +230,9 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 	private function register_subscription_options_default() {
 		$defaults = array(
 			// The real `invitation` default writes its anchor with single-quoted
-			// attributes. Mirrored here because the change detection compares a posted
-			// value against a freshly rendered default, which only holds if the value
-			// survives the endpoint's wp_kses() pass byte-for-byte.
+			// attributes. Mirrored here because wp_kses() may rewrite that quoting, so
+			// this is what exercises the endpoint normalizing both sides of the change
+			// detection rather than comparing a raw default against a sanitized echo.
 			'invitation'     => "Default invitation to <a href='https://example.org'>example.org</a>",
 			'comment_follow' => 'Default comment follow',
 			'welcome'        => 'Default welcome',
@@ -251,13 +251,14 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The change detection compares a posted value against a freshly rendered
-	 * default, so a default containing markup only compares equal if the endpoint's
-	 * own wp_kses() pass leaves it byte-for-byte intact. `wp_kses_attr()` rebuilds
-	 * attributes from the original source text rather than re-quoting them, which is
-	 * what makes the single-quoted anchor in the `invitation` default survive — this
-	 * pins that behaviour, because if it ever changed the guard would silently stop
-	 * working for exactly the sub-key most likely to be echoed back.
+	 * A default carrying markup must survive the round trip unchanged.
+	 *
+	 * The posted value reaches the comparison already sanitized, and wp_kses() is not
+	 * byte-preserving — it rewrites attribute quoting, and not identically across
+	 * WordPress versions. So the endpoint has to normalize the current value the same
+	 * way before comparing. Without that, `invitation` — the one default containing
+	 * markup, and so the sub-key this guard most needs to catch — never compares equal
+	 * and is persisted on every save.
 	 */
 	public function test_post_subscription_options_ignores_unchanged_default_containing_markup() {
 		$defaults = $this->register_subscription_options_default();

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
@@ -221,6 +221,136 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Registers a `subscription_options` default that stands in for the one
+	 * `modules/subscriptions/views.php` adds, so these tests exercise the
+	 * endpoint's contract without depending on that module being loaded.
+	 *
+	 * @return array The defaults that `get_option( 'subscription_options' )` now returns.
+	 */
+	private function register_subscription_options_default() {
+		$defaults = array(
+			'invitation'     => 'Default invitation',
+			'comment_follow' => 'Default comment follow',
+			'welcome'        => 'Default welcome',
+		);
+
+		add_filter(
+			'default_option_subscription_options',
+			static function ( $default_value, $option, $passed_default ) use ( $defaults ) {
+				return $passed_default ? $default_value : $defaults;
+			},
+			10,
+			3
+		);
+
+		return $defaults;
+	}
+
+	/**
+	 * Clients that render the settings form post the whole `subscription_options`
+	 * bag back, defaults included. Re-sending values the user never edited must
+	 * not create the option row: those defaults are translated at read time, so
+	 * persisting them would freeze whichever locale the form was rendered in.
+	 */
+	public function test_post_subscription_options_ignores_unchanged_defaults() {
+		$defaults = $this->register_subscription_options_default();
+
+		$setting  = wp_json_encode( array( 'subscription_options' => $defaults ), JSON_UNESCAPED_SLASHES );
+		$response = $this->make_post_request( $setting );
+
+		$this->assertArrayNotHasKey( 'subscription_options', $response['updated'] );
+		$this->assertFalse( get_option( 'subscription_options', false ) );
+	}
+
+	/**
+	 * Only the sub-key the user actually edited is persisted; the untouched
+	 * defaults posted alongside it stay out of the stored row.
+	 */
+	public function test_post_subscription_options_persists_only_changed_sub_keys() {
+		$defaults = $this->register_subscription_options_default();
+
+		$setting  = wp_json_encode(
+			array( 'subscription_options' => array_merge( $defaults, array( 'welcome' => 'My own welcome' ) ) ),
+			JSON_UNESCAPED_SLASHES
+		);
+		$response = $this->make_post_request( $setting );
+
+		$this->assertSame( array( 'welcome' => 'My own welcome' ), $response['updated']['subscription_options'] );
+		$this->assertSame( array( 'welcome' => 'My own welcome' ), get_option( 'subscription_options' ) );
+	}
+
+	/**
+	 * Re-posting the stored value unchanged is also a no-op, so a save that only
+	 * touches other settings doesn't rewrite this option.
+	 */
+	public function test_post_subscription_options_ignores_unchanged_stored_value() {
+		update_option( 'subscription_options', array( 'welcome' => 'Stored welcome' ) );
+
+		$setting  = wp_json_encode(
+			array( 'subscription_options' => array( 'welcome' => 'Stored welcome' ) ),
+			JSON_UNESCAPED_SLASHES
+		);
+		$response = $this->make_post_request( $setting );
+
+		$this->assertArrayNotHasKey( 'subscription_options', $response['updated'] );
+		$this->assertSame( array( 'welcome' => 'Stored welcome' ), get_option( 'subscription_options' ) );
+	}
+
+	/**
+	 * Data provider of falsy `hide_free_tier` representations.
+	 *
+	 * @return array<string,array{mixed}> [ $posted_value ]
+	 */
+	public static function falsy_hide_free_tier_values() {
+		return array(
+			'boolean false' => array( false ),
+			'string false'  => array( 'false' ),
+			'string zero'   => array( '0' ),
+		);
+	}
+
+	/**
+	 * An unset `hide_free_tier` and a false one mean the same thing everywhere the
+	 * option is read, so posting a falsy flag against an unset option is a no-op
+	 * rather than a reason to create the row.
+	 *
+	 * @param mixed $posted_value The falsy value to post.
+	 * @dataProvider falsy_hide_free_tier_values
+	 */
+	#[DataProvider( 'falsy_hide_free_tier_values' )]
+	public function test_post_subscription_options_falsy_hide_free_tier_is_noop_when_unset( $posted_value ) {
+		$setting  = wp_json_encode(
+			array( 'subscription_options' => array( 'hide_free_tier' => $posted_value ) ),
+			JSON_UNESCAPED_SLASHES
+		);
+		$response = $this->make_post_request( $setting );
+
+		$this->assertArrayNotHasKey( 'subscription_options', $response['updated'] );
+		$this->assertFalse( get_option( 'subscription_options', false ) );
+	}
+
+	/**
+	 * The flag can still be turned off once it has been turned on — the no-op
+	 * above applies to "never set", not to "set to true".
+	 *
+	 * @param mixed $posted_value The falsy value to post.
+	 * @dataProvider falsy_hide_free_tier_values
+	 */
+	#[DataProvider( 'falsy_hide_free_tier_values' )]
+	public function test_post_subscription_options_falsy_hide_free_tier_clears_stored_true( $posted_value ) {
+		update_option( 'subscription_options', array( 'hide_free_tier' => true ) );
+
+		$setting  = wp_json_encode(
+			array( 'subscription_options' => array( 'hide_free_tier' => $posted_value ) ),
+			JSON_UNESCAPED_SLASHES
+		);
+		$response = $this->make_post_request( $setting );
+
+		$this->assertSame( array( 'hide_free_tier' => false ), $response['updated']['subscription_options'] );
+		$this->assertSame( array( 'hide_free_tier' => false ), get_option( 'subscription_options' ) );
+	}
+
+	/**
 	 * Returns the response of a successful GET request to `sites/%s/settings`.
 	 */
 	public function make_get_request() {
@@ -525,18 +655,12 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 					'hide_free_tier' => true,
 				),
 			),
-			'subscription_options hide free tier false' => array(
-				'subscription_options',
-				array(
-					'hide_free_tier' => false,
-				),
-				array(
-					'hide_free_tier' => false,
-				),
-			),
 			// Stringy booleans must be parsed by value via is_truthy(), not by
 			// truthiness — otherwise the non-empty string "false" would be stored
 			// as `true`. These guard the WPCOM JSON API write path against regressions.
+			// The falsy counterparts live in
+			// `test_post_subscription_options_falsy_hide_free_tier_*` below, because
+			// against an unset option they are a no-op rather than a write.
 			'subscription_options hide free tier string true' => array(
 				'subscription_options',
 				array(
@@ -546,15 +670,6 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 					'hide_free_tier' => true,
 				),
 			),
-			'subscription_options hide free tier string false' => array(
-				'subscription_options',
-				array(
-					'hide_free_tier' => 'false',
-				),
-				array(
-					'hide_free_tier' => false,
-				),
-			),
 			'subscription_options hide free tier string one' => array(
 				'subscription_options',
 				array(
@@ -562,15 +677,6 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 				),
 				array(
 					'hide_free_tier' => true,
-				),
-			),
-			'subscription_options hide free tier string zero' => array(
-				'subscription_options',
-				array(
-					'hide_free_tier' => '0',
-				),
-				array(
-					'hide_free_tier' => false,
 				),
 			),
 			// Add MCP settings POST tests

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
@@ -455,6 +455,11 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 			)
 		);
 
+		// The API object is a shared singleton, so a preceding POST test can leave the
+		// method set to 'POST'. Set it explicitly so the GET path is exercised regardless
+		// of test order.
+		$endpoint->api->method = 'GET';
+
 		return $endpoint->callback( '/sites/%s/settings', $blog_id );
 	}
 

--- a/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test.php
@@ -229,7 +229,11 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 	 */
 	private function register_subscription_options_default() {
 		$defaults = array(
-			'invitation'     => 'Default invitation',
+			// The real `invitation` default writes its anchor with single-quoted
+			// attributes. Mirrored here because the change detection compares a posted
+			// value against a freshly rendered default, which only holds if the value
+			// survives the endpoint's wp_kses() pass byte-for-byte.
+			'invitation'     => "Default invitation to <a href='https://example.org'>example.org</a>",
 			'comment_follow' => 'Default comment follow',
 			'welcome'        => 'Default welcome',
 		);
@@ -244,6 +248,28 @@ class WPCOM_JSON_API_Site_Settings_V1_4_Endpoint_Test extends WP_UnitTestCase {
 		);
 
 		return $defaults;
+	}
+
+	/**
+	 * The change detection compares a posted value against a freshly rendered
+	 * default, so a default containing markup only compares equal if the endpoint's
+	 * own wp_kses() pass leaves it byte-for-byte intact. `wp_kses_attr()` rebuilds
+	 * attributes from the original source text rather than re-quoting them, which is
+	 * what makes the single-quoted anchor in the `invitation` default survive — this
+	 * pins that behaviour, because if it ever changed the guard would silently stop
+	 * working for exactly the sub-key most likely to be echoed back.
+	 */
+	public function test_post_subscription_options_ignores_unchanged_default_containing_markup() {
+		$defaults = $this->register_subscription_options_default();
+
+		$setting  = wp_json_encode(
+			array( 'subscription_options' => array( 'invitation' => $defaults['invitation'] ) ),
+			JSON_UNESCAPED_SLASHES
+		);
+		$response = $this->make_post_request( $setting );
+
+		$this->assertArrayNotHasKey( 'subscription_options', $response['updated'] );
+		$this->assertFalse( get_option( 'subscription_options', false ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes I18N-289

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Switch to the user locale before retrieving subscription options, so that the defaults would be translated.
* Compare the subscription options with the translated defaults on save, to avoid saving a value in the database if no changes were made.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Create two test sites, switch your user locale to a popular not-English one, like Spanish, French, German or Japanese.
* On the first test site, go to /wp-admin/admin.php?page=jetpack-newsletter&p=%2F%3Ftab%3Dsettings, confirm that "Welcome email message" appears in English.
* Make the 'Save' button appear by cutting the text from the textarea, then pasting it back, save the message.
* Checkout the PR and sandbox public-api.
* On site two confirm that the Welcome message appears translated, try saving it in the same way as for the first site.
* Change your user locale to another non-English one.
* Refresh the pages and confirm that the message appears in English on the first site and in the new locale on the second site.
