### PR TITLE
SEO: polish the GEO tab — chips, headings, an acronym explainer, and clearer state tags

### DIFF
--- a/projects/packages/seo/_inc/admin-page-layout.scss
+++ b/projects/packages/seo/_inc/admin-page-layout.scss
@@ -46,6 +46,43 @@ body.toplevel_page_jetpack-seo {
 	flex-direction: column;
 }
 
+// The tabs strip carries one non-tab affordance — the GEO infotip — so it has
+// to lay its children out in a row. The shared `.jp-admin-page-tabs` wrapper is
+// a block (it only ever held `Tabs.List`, which is `width: fit-content`), so
+// without this the icon drops to its own line under the tabs. Scoped to this
+// package rather than added to the shared mixin, which no one else needs.
+.jetpack-seo-tabs-strip {
+	display: flex;
+	align-items: center;
+	gap: var(--wpds-dimension-gap-xs);
+}
+
+// Reset the trigger's button chrome so it reads as an icon beside the tab label
+// rather than a control of its own. Sized to the 20px glyph; the tab row's own
+// height keeps it vertically centered.
+.jetpack-seo-tabs-strip__infotip {
+	display: inline-flex;
+	align-items: center;
+	padding: 0;
+	border: 0;
+	border-radius: var(--wpds-border-radius-sm);
+	background: none;
+	color: var(--wpds-color-foreground-content-neutral-weak);
+	cursor: var(--wpds-cursor-control);
+
+	&:hover {
+		color: var(--wpds-color-foreground-content-neutral);
+	}
+}
+
+// `Popover.Popup` sizes to its content, so a single sentence lays out as one
+// ~600px line — wider than the space left of the trigger, which put the start
+// of the sentence off the content area and clipped it. Cap it so the text
+// wraps into a compact block the positioner can keep on screen.
+.jetpack-seo-tabs-strip__infotip-popup {
+	max-inline-size: 20rem;
+}
+
 // The full-bleed Content (DataViews) tab opts out of the `0 0 auto` sizing:
 // it used to be a direct flex child of the page column and so inherited the
 // layout mixin's fill treatment (`flex: 1 1 auto; min-height: 0; display:

--- a/projects/packages/seo/_inc/dashboard/dashboard-nav.tsx
+++ b/projects/packages/seo/_inc/dashboard/dashboard-nav.tsx
@@ -1,7 +1,8 @@
 import { useCallback } from '@wordpress/element';
 import { __, _x } from '@wordpress/i18n';
+import { info } from '@wordpress/icons';
 import { useNavigate } from '@wordpress/route';
-import { Tabs } from '@wordpress/ui';
+import { Icon, Popover, Tabs, VisuallyHidden } from '@wordpress/ui';
 import { isGated } from '../data/is-gated';
 import type { ReactNode } from 'react';
 
@@ -15,6 +16,50 @@ const ROUTE_BY_TAB: Record< SeoTab, string > = {
 	content: '/content',
 	ai: '/ai',
 };
+
+const geoInfotipLabel = __( 'What is GEO?', 'jetpack-seo' );
+
+/**
+ * An "infotip" explaining the GEO acronym, sat beside the GEO tab.
+ *
+ * A `Popover` with `openOnHover` rather than a `Tooltip`, following the design
+ * system's own guidance: tooltip popups aren't exposed to assistive technologies
+ * (only the trigger's accessible name is) and are disabled outright on touch
+ * devices, so a tooltip would show this to sighted mouse users only. A popover
+ * opens on hover, click and tap, and its content is announced.
+ *
+ * It renders *after* `Tabs.List` rather than inside it. `Tabs.Tab` is a
+ * `<button>`, so nesting the trigger in the GEO tab would put a button inside a
+ * button — invalid, and it would break the list's arrow-key navigation. A
+ * non-tab child of the `tablist` has the same problem. Sitting outside the list
+ * still reads as belonging to the GEO tab because **GEO is the last tab**; a tab
+ * added after it would need this moved (or promoted to a per-tab affordance).
+ *
+ * @return The GEO infotip.
+ */
+const GeoInfotip = () => (
+	<Popover.Root>
+		<Popover.Trigger
+			openOnHover
+			delay={ 200 }
+			closeDelay={ 200 }
+			aria-label={ geoInfotipLabel }
+			className="jetpack-seo-tabs-strip__infotip"
+		>
+			<Icon icon={ info } size={ 20 } />
+		</Popover.Trigger>
+		<Popover.Popup className="jetpack-seo-tabs-strip__infotip-popup">
+			<Popover.Arrow />
+			<VisuallyHidden render={ <Popover.Title /> }>{ geoInfotipLabel }</VisuallyHidden>
+			<Popover.Description>
+				{ __(
+					'GEO stands for generative engine optimization. These settings control how AI tools see and use your site.',
+					'jetpack-seo'
+				) }
+			</Popover.Description>
+		</Popover.Popup>
+	</Popover.Root>
+);
 
 /**
  * The SEO dashboard's top navigation — a `@wordpress/ui` tab bar that drives
@@ -52,7 +97,7 @@ const DashboardNav = ( { active, children }: { active: SeoTab; children: ReactNo
 
 	return (
 		<Tabs.Root className="jetpack-seo-tabs" value={ active } onValueChange={ onTabChange }>
-			<div className="jp-admin-page-tabs jp-admin-page-tabs--minimal">
+			<div className="jp-admin-page-tabs jp-admin-page-tabs--minimal jetpack-seo-tabs-strip">
 				<Tabs.List variant="minimal">
 					<Tabs.Tab value="overview">{ __( 'Overview', 'jetpack-seo' ) }</Tabs.Tab>
 					<Tabs.Tab value="settings">{ __( 'Settings', 'jetpack-seo' ) }</Tabs.Tab>
@@ -67,6 +112,8 @@ const DashboardNav = ( { active, children }: { active: SeoTab; children: ReactNo
 						</Tabs.Tab>
 					) }
 				</Tabs.List>
+				{ /* Same gate as the tab it explains — no orphaned icon on gated sites. */ }
+				{ ! gated && <GeoInfotip /> }
 			</div>
 			{ children }
 		</Tabs.Root>

--- a/projects/packages/seo/_inc/dashboard/dashboard-nav.tsx
+++ b/projects/packages/seo/_inc/dashboard/dashboard-nav.tsx
@@ -53,7 +53,7 @@ const GeoInfotip = () => (
 			<VisuallyHidden render={ <Popover.Title /> }>{ geoInfotipLabel }</VisuallyHidden>
 			<Popover.Description>
 				{ __(
-					'GEO stands for generative engine optimization. These settings control how AI tools see and use your site.',
+					'GEO stands for generative engine optimization. These settings control how AI sees and uses your site.',
 					'jetpack-seo'
 				) }
 			</Popover.Description>

--- a/projects/packages/seo/_inc/dashboard/test/dashboard-nav.test.tsx
+++ b/projects/packages/seo/_inc/dashboard/test/dashboard-nav.test.tsx
@@ -59,4 +59,48 @@ describe( 'DashboardNav', () => {
 		expect( screen.queryByRole( 'tab', { name: 'Content' } ) ).not.toBeInTheDocument();
 		expect( screen.queryByRole( 'tab', { name: 'GEO' } ) ).not.toBeInTheDocument();
 	} );
+
+	describe( 'the GEO infotip', () => {
+		it( 'is a real button, so it works on touch and reaches assistive tech', () => {
+			render( <DashboardNav active="overview">content</DashboardNav> );
+
+			// A `Tooltip` would satisfy neither: its popup isn't exposed to assistive
+			// technologies and it's disabled on touch devices. The affordance being a
+			// button in the accessibility tree is the whole reason for using `Popover`.
+			expect( screen.getByRole( 'button', { name: 'What is GEO?' } ) ).toBeInTheDocument();
+		} );
+
+		it( 'reveals the definition of the acronym on click', () => {
+			render( <DashboardNav active="overview">content</DashboardNav> );
+
+			// Asserting it is absent first is what makes the assertion below meaningful:
+			// a popover that rendered its content eagerly would pass either way.
+			expect( screen.queryByText( /generative engine optimization/ ) ).not.toBeInTheDocument();
+
+			// eslint-disable-next-line testing-library/prefer-user-event -- fireEvent keeps this off the @testing-library/user-event devDep (avoids lockfile churn), matching the sibling tests.
+			fireEvent.click( screen.getByRole( 'button', { name: 'What is GEO?' } ) );
+
+			expect( screen.getByText( /generative engine optimization/ ) ).toBeInTheDocument();
+		} );
+
+		it( 'stays out of the tablist, so it cannot disturb tab navigation', () => {
+			render( <DashboardNav active="overview">content</DashboardNav> );
+
+			const trigger = screen.getByRole( 'button', { name: 'What is GEO?' } );
+
+			// `Tabs.Tab` renders a `<button>`, so nesting the trigger inside the GEO tab
+			// would be a button within a button; a non-tab child of the `tablist` would
+			// break its arrow-key navigation. Both are ruled out by construction here.
+			expect( screen.getByRole( 'tablist' ) ).not.toContainElement( trigger );
+			expect( screen.getByRole( 'tab', { name: 'GEO' } ) ).not.toContainElement( trigger );
+		} );
+
+		it( 'is hidden along with the tab it explains on gated sites', () => {
+			isGated.mockReturnValue( true );
+
+			render( <DashboardNav active="overview">content</DashboardNav> );
+
+			expect( screen.queryByRole( 'button', { name: 'What is GEO?' } ) ).not.toBeInTheDocument();
+		} );
+	} );
 } );

--- a/projects/packages/seo/_inc/dashboard/test/dashboard-nav.test.tsx
+++ b/projects/packages/seo/_inc/dashboard/test/dashboard-nav.test.tsx
@@ -61,15 +61,10 @@ describe( 'DashboardNav', () => {
 	} );
 
 	describe( 'the GEO infotip', () => {
-		it( 'is a real button, so it works on touch and reaches assistive tech', () => {
-			render( <DashboardNav active="overview">content</DashboardNav> );
-
-			// A `Tooltip` would satisfy neither: its popup isn't exposed to assistive
-			// technologies and it's disabled on touch devices. The affordance being a
-			// button in the accessibility tree is the whole reason for using `Popover`.
-			expect( screen.getByRole( 'button', { name: 'What is GEO?' } ) ).toBeInTheDocument();
-		} );
-
+		// Queried by role and name throughout: a `Tooltip` would satisfy neither half of
+		// that, since its popup isn't exposed to assistive technologies and it's disabled
+		// on touch devices. The affordance being a real button in the accessibility tree
+		// is the whole reason for using `Popover`, so every test below leans on it.
 		it( 'reveals the definition of the acronym on click', () => {
 			render( <DashboardNav active="overview">content</DashboardNav> );
 
@@ -93,6 +88,16 @@ describe( 'DashboardNav', () => {
 			// break its arrow-key navigation. Both are ruled out by construction here.
 			expect( screen.getByRole( 'tablist' ) ).not.toContainElement( trigger );
 			expect( screen.getByRole( 'tab', { name: 'GEO' } ) ).not.toContainElement( trigger );
+		} );
+
+		// The trigger sits after `Tabs.List`, which only reads as belonging to GEO while
+		// GEO is the last tab. If one is ever appended after it, this fails and points at
+		// the docblock in `dashboard-nav.tsx` that says the infotip needs moving.
+		it( 'keeps GEO last, which is what makes the placement read correctly', () => {
+			render( <DashboardNav active="overview">content</DashboardNav> );
+
+			const labels = screen.getAllByRole( 'tab' ).map( tab => tab.textContent );
+			expect( labels[ labels.length - 1 ] ).toBe( 'GEO' );
 		} );
 
 		it( 'is hidden along with the tab it explains on gated sites', () => {

--- a/projects/packages/seo/_inc/screens/ai/index.tsx
+++ b/projects/packages/seo/_inc/screens/ai/index.tsx
@@ -182,8 +182,16 @@ const CrawlerSection: FC< CrawlerSectionProps > = ( {
 						<CardTitleIcon icon={ icon } title={ title } />
 					</Card.Title>
 					{ /* The status tag reflects the toggle state; hide it when the toggles
-					   are governed elsewhere (the notice explains the state instead). */ }
-					{ ! notice && <Badge intent={ statusIntent }>{ statusLabel }</Badge> }
+					   are governed elsewhere (the notice explains the state instead).
+					   `HeaderDescription` renders it visibly but marks it `aria-hidden` and
+					   wires `aria-describedby` on the trigger, so the state is announced as
+					   a description instead of becoming part of the button's name — the
+					   header wraps all its children in the trigger. */ }
+					{ ! notice && (
+						<CollapsibleCard.HeaderDescription>
+							<Badge intent={ statusIntent }>{ statusLabel }</Badge>
+						</CollapsibleCard.HeaderDescription>
+					) }
 				</Stack>
 			</CollapsibleCard.Header>
 			{ notice }
@@ -453,9 +461,13 @@ const AiScreen: FC< Props > = ( { form, searchEnginesVisible, onManageVisibility
 							<Card.Title>
 								<CardTitleIcon icon={ page } title={ __( 'llms.txt', 'jetpack-seo' ) } />
 							</Card.Title>
-							<Badge intent={ llmsTxtEffectivelyOn ? 'stable' : 'draft' }>
-								{ llmsTxtStatusLabel }
-							</Badge>
+							{ /* Announced via `aria-describedby` rather than as part of the
+							   trigger's name — see the crawler section above. */ }
+							<CollapsibleCard.HeaderDescription>
+								<Badge intent={ llmsTxtEffectivelyOn ? 'stable' : 'draft' }>
+									{ llmsTxtStatusLabel }
+								</Badge>
+							</CollapsibleCard.HeaderDescription>
 						</Stack>
 					</CollapsibleCard.Header>
 					<CollapsibleCard.Content>

--- a/projects/packages/seo/_inc/screens/ai/index.tsx
+++ b/projects/packages/seo/_inc/screens/ai/index.tsx
@@ -39,6 +39,30 @@ const llmsTxtHelp = __(
 const allowedLabel = __( 'Allowed', 'jetpack-seo' );
 const blockedLabel = __( 'Blocked', 'jetpack-seo' );
 const partlyBlockedLabel = __( 'Partly blocked', 'jetpack-seo' );
+const crawlerAccessTitle = __( 'AI crawler access', 'jetpack-seo' );
+
+/**
+ * The card that stands in for the crawler groups when site-level controls can't
+ * take effect, wrapping the notice that explains why.
+ *
+ * The four blocked states are mutually exclusive and shared this header
+ * verbatim, so it lives here once — which also keeps the chip and heading on all
+ * four from drifting apart.
+ *
+ * @param props          - Component props.
+ * @param props.children - The notice, and any action, explaining the state.
+ * @return The crawler-access card.
+ */
+const CrawlerAccessCard: FC< { children: ReactNode } > = ( { children } ) => (
+	<CollapsibleCard.Root defaultOpen>
+		<CollapsibleCard.Header render={ <h2 /> }>
+			<Card.Title>
+				<CardTitleIcon icon={ key } title={ crawlerAccessTitle } />
+			</Card.Title>
+		</CollapsibleCard.Header>
+		<CollapsibleCard.Content>{ children }</CollapsibleCard.Content>
+	</CollapsibleCard.Root>
+);
 
 /**
  * Whether a crawler is currently blocked: an explicit override wins, otherwise
@@ -294,23 +318,16 @@ const AiScreen: FC< Props > = ( { form, searchEnginesVisible, onManageVisibility
 		// site-level setting cannot safely represent its scope.
 		if ( crawlers.pathBasedMultisite ) {
 			return (
-				<CollapsibleCard.Root defaultOpen>
-					<CollapsibleCard.Header render={ <h2 /> }>
-						<Card.Title>
-							<CardTitleIcon icon={ key } title={ __( 'AI crawler access', 'jetpack-seo' ) } />
-						</Card.Title>
-					</CollapsibleCard.Header>
-					<CollapsibleCard.Content>
-						<Notice.Root intent="info">
-							<Notice.Description>
-								{ __(
-									'Per-site AI crawler controls are unavailable on this path-based multisite network because every site shares one robots.txt. Manage crawler access at the network level instead.',
-									'jetpack-seo'
-								) }
-							</Notice.Description>
-						</Notice.Root>
-					</CollapsibleCard.Content>
-				</CollapsibleCard.Root>
+				<CrawlerAccessCard>
+					<Notice.Root intent="info">
+						<Notice.Description>
+							{ __(
+								'Per-site AI crawler controls are unavailable on this path-based multisite network because every site shares one robots.txt. Manage crawler access at the network level instead.',
+								'jetpack-seo'
+							) }
+						</Notice.Description>
+					</Notice.Root>
+				</CrawlerAccessCard>
 			);
 		}
 
@@ -318,23 +335,16 @@ const AiScreen: FC< Props > = ( { form, searchEnginesVisible, onManageVisibility
 		// indexable site can't apply these — explain and stop.
 		if ( crawlers.restrictedSubdomain ) {
 			return (
-				<CollapsibleCard.Root defaultOpen>
-					<CollapsibleCard.Header render={ <h2 /> }>
-						<Card.Title>
-							<CardTitleIcon icon={ key } title={ __( 'AI crawler access', 'jetpack-seo' ) } />
-						</Card.Title>
-					</CollapsibleCard.Header>
-					<CollapsibleCard.Content>
-						<Notice.Root intent="info">
-							<Notice.Description>
-								{ __(
-									'This site uses a temporary staging address (a .wpcomstaging.com subdomain), where search engines and AI crawlers are blocked. These settings will take effect once the site is on its own domain.',
-									'jetpack-seo'
-								) }
-							</Notice.Description>
-						</Notice.Root>
-					</CollapsibleCard.Content>
-				</CollapsibleCard.Root>
+				<CrawlerAccessCard>
+					<Notice.Root intent="info">
+						<Notice.Description>
+							{ __(
+								'This site uses a temporary staging address (a .wpcomstaging.com subdomain), where search engines and AI crawlers are blocked. These settings will take effect once the site is on its own domain.',
+								'jetpack-seo'
+							) }
+						</Notice.Description>
+					</Notice.Root>
+				</CrawlerAccessCard>
 			);
 		}
 
@@ -342,28 +352,21 @@ const AiScreen: FC< Props > = ( { form, searchEnginesVisible, onManageVisibility
 		// the user at the setting that turns indexing back on.
 		if ( ! searchEnginesVisible ) {
 			return (
-				<CollapsibleCard.Root defaultOpen>
-					<CollapsibleCard.Header render={ <h2 /> }>
-						<Card.Title>
-							<CardTitleIcon icon={ key } title={ __( 'AI crawler access', 'jetpack-seo' ) } />
-						</Card.Title>
-					</CollapsibleCard.Header>
-					<CollapsibleCard.Content>
-						<Stack direction="column" gap="md">
-							<Notice.Root intent="info">
-								<Notice.Description>
-									{ __(
-										"Search engines and AI crawlers are all blocked because this site isn't set to be indexed. To choose which AI crawlers can access your site, allow search engines to index it first.",
-										'jetpack-seo'
-									) }
-								</Notice.Description>
-							</Notice.Root>
-							<Button variant="link" onClick={ onManageVisibility }>
-								{ __( 'Open site visibility settings', 'jetpack-seo' ) }
-							</Button>
-						</Stack>
-					</CollapsibleCard.Content>
-				</CollapsibleCard.Root>
+				<CrawlerAccessCard>
+					<Stack direction="column" gap="md">
+						<Notice.Root intent="info">
+							<Notice.Description>
+								{ __(
+									"Search engines and AI crawlers are all blocked because this site isn't set to be indexed. To choose which AI crawlers can access your site, allow search engines to index it first.",
+									'jetpack-seo'
+								) }
+							</Notice.Description>
+						</Notice.Root>
+						<Button variant="link" onClick={ onManageVisibility }>
+							{ __( 'Open site visibility settings', 'jetpack-seo' ) }
+						</Button>
+					</Stack>
+				</CrawlerAccessCard>
 			);
 		}
 
@@ -371,23 +374,16 @@ const AiScreen: FC< Props > = ( { form, searchEnginesVisible, onManageVisibility
 		// the virtual output these settings change.
 		if ( crawlers.staticRobotsTxt ) {
 			return (
-				<CollapsibleCard.Root defaultOpen>
-					<CollapsibleCard.Header render={ <h2 /> }>
-						<Card.Title>
-							<CardTitleIcon icon={ key } title={ __( 'AI crawler access', 'jetpack-seo' ) } />
-						</Card.Title>
-					</CollapsibleCard.Header>
-					<CollapsibleCard.Content>
-						<Notice.Root intent="warning">
-							<Notice.Description>
-								{ __(
-									"Jetpack detected a static robots.txt file in the WordPress installation directory. These settings only change WordPress's virtual robots.txt; edit or remove the static file to manage AI crawler access here.",
-									'jetpack-seo'
-								) }
-							</Notice.Description>
-						</Notice.Root>
-					</CollapsibleCard.Content>
-				</CollapsibleCard.Root>
+				<CrawlerAccessCard>
+					<Notice.Root intent="warning">
+						<Notice.Description>
+							{ __(
+								"Jetpack detected a static robots.txt file in the WordPress installation directory. These settings only change WordPress's virtual robots.txt; edit or remove the static file to manage AI crawler access here.",
+								'jetpack-seo'
+							) }
+						</Notice.Description>
+					</Notice.Root>
+				</CrawlerAccessCard>
 			);
 		}
 

--- a/projects/packages/seo/_inc/screens/ai/index.tsx
+++ b/projects/packages/seo/_inc/screens/ai/index.tsx
@@ -458,7 +458,11 @@ const AiScreen: FC< Props > = ( { form, searchEnginesVisible, onManageVisibility
 					<CollapsibleCard.Header render={ <h2 /> }>
 						{ /* No status tag here, unlike the crawler groups: this module opens by
 						   default, so its toggle — the same information, in the control that
-						   changes it — is on screen already. A tag would just say it twice. */ }
+						   changes it — is on screen already, and a tag would say it twice.
+						   Collapsing the card does hide the state until it is reopened (a reload
+						   reopens it). Accepted deliberately: collapsing is a choice to hide this
+						   module's detail. The crawler groups differ because they open *closed*,
+						   so a tag is the only state they would ever show. */ }
 						<Card.Title>
 							<CardTitleIcon icon={ page } title={ __( 'llms.txt', 'jetpack-seo' ) } />
 						</Card.Title>

--- a/projects/packages/seo/_inc/screens/ai/index.tsx
+++ b/projects/packages/seo/_inc/screens/ai/index.tsx
@@ -34,8 +34,6 @@ const llmsTxtHelp = __(
 	'Publishes a curated, AI-readable map at /llms.txt to help AI assistants find and understand your supported content.',
 	'jetpack-seo'
 );
-const enabledLabel = __( 'Enabled', 'jetpack-seo' );
-const disabledLabel = __( 'Disabled', 'jetpack-seo' );
 // Crawler-group status tags. Module-scope (not inline ternaries) so the
 // production minifier can't fold `cond ? __() : __()` and break i18n extraction.
 const allowedLabel = __( 'Allowed', 'jetpack-seo' );
@@ -148,11 +146,17 @@ const CrawlerSection: FC< CrawlerSectionProps > = ( {
 	const allAllowed = blockedCount === 0;
 	const allBlocked = crawlers.length > 0 && blockedCount === crawlers.length;
 
-	// Header status tag, matching the Enabled/Disabled tags on the other module
-	// headers: green when every crawler is allowed, red when every one is blocked,
-	// grey when it's a mix. `statusLabel` typed `string` (not the inferred branded
-	// `TransformedText` of the first label) so the branches can assign other literals.
-	let statusIntent: 'stable' | 'high' | 'draft' = 'draft';
+	// Header status tag: green when every crawler is allowed, red when every one is
+	// blocked, amber in between. Red is the "stop" reading rather than a severity
+	// claim — blocking training crawlers is a legitimate choice, and `intent` is a
+	// CSS class with no `role` or `aria-*`, so every tag is announced alike.
+	//
+	// Amber matters because the mixed state used to be grey, identical to a module
+	// that is simply switched off — the one state you couldn't read at a glance.
+	//
+	// `statusLabel` typed `string` (not the inferred branded `TransformedText` of the
+	// first label) so the branches can assign other literals.
+	let statusIntent: 'stable' | 'high' | 'medium' = 'medium';
 	let statusLabel: string = partlyBlockedLabel;
 	if ( allAllowed ) {
 		statusIntent = 'stable';
@@ -450,25 +454,18 @@ const AiScreen: FC< Props > = ( { form, searchEnginesVisible, onManageVisibility
 	};
 
 	const llmsTxtEffectivelyOn = Boolean( searchEnginesVisible && llmsTxt?.enabled );
-	const llmsTxtStatusLabel = llmsTxtEffectivelyOn ? enabledLabel : disabledLabel;
 
 	return (
 		<div className="jetpack-seo-ai">
 			{ llmsTxt && (
 				<CollapsibleCard.Root defaultOpen>
 					<CollapsibleCard.Header render={ <h2 /> }>
-						<Stack direction="row" justify="space-between" align="center" gap="sm">
-							<Card.Title>
-								<CardTitleIcon icon={ page } title={ __( 'llms.txt', 'jetpack-seo' ) } />
-							</Card.Title>
-							{ /* Announced via `aria-describedby` rather than as part of the
-							   trigger's name — see the crawler section above. */ }
-							<CollapsibleCard.HeaderDescription>
-								<Badge intent={ llmsTxtEffectivelyOn ? 'stable' : 'draft' }>
-									{ llmsTxtStatusLabel }
-								</Badge>
-							</CollapsibleCard.HeaderDescription>
-						</Stack>
+						{ /* No status tag here, unlike the crawler groups: this module opens by
+						   default, so its toggle — the same information, in the control that
+						   changes it — is on screen already. A tag would just say it twice. */ }
+						<Card.Title>
+							<CardTitleIcon icon={ page } title={ __( 'llms.txt', 'jetpack-seo' ) } />
+						</Card.Title>
 					</CollapsibleCard.Header>
 					<CollapsibleCard.Content>
 						<Stack direction="column" gap="md">

--- a/projects/packages/seo/_inc/screens/ai/index.tsx
+++ b/projects/packages/seo/_inc/screens/ai/index.tsx
@@ -1,17 +1,34 @@
 import { Button, ToggleControl } from '@wordpress/components';
 import { createInterpolateElement, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
+import { commentContent, details, key, page } from '@wordpress/icons';
 import { Badge, Card, CollapsibleCard, Link, Notice, Stack } from '@wordpress/ui';
+import CardTitleIcon from '../../components/card-title-icon';
 import './style.scss';
 import type { AiCrawler } from '../../data/ai-types';
 import type { AiForm } from '../../data/use-ai';
-import type { FC, ReactNode } from 'react';
+import type { ComponentProps, FC, ReactNode } from 'react';
 
 interface Props {
 	form: AiForm;
 	searchEnginesVisible: boolean;
 	onManageVisibility: () => void;
 }
+
+// Jetpack's AI mark (three sparks), mirroring `AiIcon` in
+// `@automattic/jetpack-components`. Restated here as an element with svg props
+// because `@wordpress/ui`'s `Icon` spreads `icon.props` onto its own `SVG`
+// rather than rendering what it is given — so a component like `AiIcon`, whose
+// props are `size`/`color`, would spread those and produce an empty icon.
+// `@wordpress/icons` has no AI or sparkle glyph to use instead. Kept in sync by
+// hand; if Jetpack's AI mark changes, this needs the same paths.
+const aiSparks = (
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="currentColor">
+		<path d="M9.33301 5.33325L10.4644 8.20188L13.333 9.33325L10.4644 10.4646L9.33301 13.3333L8.20164 10.4646L5.33301 9.33325L8.20164 8.20188L9.33301 5.33325Z" />
+		<path d="M21.3333 5.33333L22.8418 9.15817L26.6667 10.6667L22.8418 12.1752L21.3333 16L19.8248 12.1752L16 10.6667L19.8248 9.15817L21.3333 5.33333Z" />
+		<path d="M14.6667 13.3333L16.5523 18.1144L21.3333 20L16.5523 21.8856L14.6667 26.6667L12.781 21.8856L8 20L12.781 18.1144L14.6667 13.3333Z" />
+	</svg>
+);
 
 const llmsTxtHelp = __(
 	'Publishes a curated, AI-readable map at /llms.txt to help AI assistants find and understand your supported content.',
@@ -77,6 +94,8 @@ const CrawlerToggle: FC< CrawlerToggleProps > = ( { crawler, blocked, disabled, 
 
 interface CrawlerSectionProps {
 	title: string;
+	/** The chip glyph for this group's title. */
+	icon: ComponentProps< typeof CardTitleIcon >[ 'icon' ];
 	intro: string;
 	crawlers: AiCrawler[];
 	type: AiCrawler[ 'type' ];
@@ -98,6 +117,7 @@ interface CrawlerSectionProps {
  *
  * @param props              - Component props.
  * @param props.title        - Section title.
+ * @param props.icon         - The chip glyph shown before the title.
  * @param props.intro        - One-line description of the group's purpose.
  * @param props.crawlers     - The crawlers in this group.
  * @param props.type         - The crawler group's type.
@@ -111,6 +131,7 @@ interface CrawlerSectionProps {
  */
 const CrawlerSection: FC< CrawlerSectionProps > = ( {
 	title,
+	icon,
 	intro,
 	crawlers,
 	type,
@@ -153,9 +174,13 @@ const CrawlerSection: FC< CrawlerSectionProps > = ( {
 		// controls are disabled) sits between the header and the collapsible content,
 		// so it stays visible while the module is closed; only Content collapses.
 		<CollapsibleCard.Root>
-			<CollapsibleCard.Header>
+			{ /* The heading wraps the trigger, per the W3C APG accordion pattern the
+			   component's own docblock points at. */ }
+			<CollapsibleCard.Header render={ <h2 /> }>
 				<Stack direction="row" justify="space-between" align="center" gap="sm">
-					<Card.Title>{ title }</Card.Title>
+					<Card.Title>
+						<CardTitleIcon icon={ icon } title={ title } />
+					</Card.Title>
 					{ /* The status tag reflects the toggle state; hide it when the toggles
 					   are governed elsewhere (the notice explains the state instead). */ }
 					{ ! notice && <Badge intent={ statusIntent }>{ statusLabel }</Badge> }
@@ -258,8 +283,10 @@ const AiScreen: FC< Props > = ( { form, searchEnginesVisible, onManageVisibility
 		if ( crawlers.pathBasedMultisite ) {
 			return (
 				<CollapsibleCard.Root defaultOpen>
-					<CollapsibleCard.Header>
-						<Card.Title>{ __( 'AI crawler access', 'jetpack-seo' ) }</Card.Title>
+					<CollapsibleCard.Header render={ <h2 /> }>
+						<Card.Title>
+							<CardTitleIcon icon={ key } title={ __( 'AI crawler access', 'jetpack-seo' ) } />
+						</Card.Title>
 					</CollapsibleCard.Header>
 					<CollapsibleCard.Content>
 						<Notice.Root intent="info">
@@ -280,8 +307,10 @@ const AiScreen: FC< Props > = ( { form, searchEnginesVisible, onManageVisibility
 		if ( crawlers.restrictedSubdomain ) {
 			return (
 				<CollapsibleCard.Root defaultOpen>
-					<CollapsibleCard.Header>
-						<Card.Title>{ __( 'AI crawler access', 'jetpack-seo' ) }</Card.Title>
+					<CollapsibleCard.Header render={ <h2 /> }>
+						<Card.Title>
+							<CardTitleIcon icon={ key } title={ __( 'AI crawler access', 'jetpack-seo' ) } />
+						</Card.Title>
 					</CollapsibleCard.Header>
 					<CollapsibleCard.Content>
 						<Notice.Root intent="info">
@@ -302,8 +331,10 @@ const AiScreen: FC< Props > = ( { form, searchEnginesVisible, onManageVisibility
 		if ( ! searchEnginesVisible ) {
 			return (
 				<CollapsibleCard.Root defaultOpen>
-					<CollapsibleCard.Header>
-						<Card.Title>{ __( 'AI crawler access', 'jetpack-seo' ) }</Card.Title>
+					<CollapsibleCard.Header render={ <h2 /> }>
+						<Card.Title>
+							<CardTitleIcon icon={ key } title={ __( 'AI crawler access', 'jetpack-seo' ) } />
+						</Card.Title>
 					</CollapsibleCard.Header>
 					<CollapsibleCard.Content>
 						<Stack direction="column" gap="md">
@@ -329,8 +360,10 @@ const AiScreen: FC< Props > = ( { form, searchEnginesVisible, onManageVisibility
 		if ( crawlers.staticRobotsTxt ) {
 			return (
 				<CollapsibleCard.Root defaultOpen>
-					<CollapsibleCard.Header>
-						<Card.Title>{ __( 'AI crawler access', 'jetpack-seo' ) }</Card.Title>
+					<CollapsibleCard.Header render={ <h2 /> }>
+						<Card.Title>
+							<CardTitleIcon icon={ key } title={ __( 'AI crawler access', 'jetpack-seo' ) } />
+						</Card.Title>
 					</CollapsibleCard.Header>
 					<CollapsibleCard.Content>
 						<Notice.Root intent="warning">
@@ -374,6 +407,7 @@ const AiScreen: FC< Props > = ( { form, searchEnginesVisible, onManageVisibility
 			<>
 				<CrawlerSection
 					title={ __( 'Answer engines', 'jetpack-seo' ) }
+					icon={ commentContent }
 					intro={ __(
 						'These crawlers fetch your pages so AI assistants can cite you in their answers. Keep them allowed to stay visible in tools like ChatGPT, Perplexity, and Claude.',
 						'jetpack-seo'
@@ -389,6 +423,7 @@ const AiScreen: FC< Props > = ( { form, searchEnginesVisible, onManageVisibility
 				/>
 				<CrawlerSection
 					title={ __( 'Training crawlers', 'jetpack-seo' ) }
+					icon={ details }
 					intro={ __(
 						'These crawlers use your content to train AI models. Some — like Google Gemini — also power the AI answers shown above search results, so blocking them protects privacy but can cost you that visibility.',
 						'jetpack-seo'
@@ -413,9 +448,11 @@ const AiScreen: FC< Props > = ( { form, searchEnginesVisible, onManageVisibility
 		<div className="jetpack-seo-ai">
 			{ llmsTxt && (
 				<CollapsibleCard.Root defaultOpen>
-					<CollapsibleCard.Header>
+					<CollapsibleCard.Header render={ <h2 /> }>
 						<Stack direction="row" justify="space-between" align="center" gap="sm">
-							<Card.Title>{ __( 'llms.txt', 'jetpack-seo' ) }</Card.Title>
+							<Card.Title>
+								<CardTitleIcon icon={ page } title={ __( 'llms.txt', 'jetpack-seo' ) } />
+							</Card.Title>
 							<Badge intent={ llmsTxtEffectivelyOn ? 'stable' : 'draft' }>
 								{ llmsTxtStatusLabel }
 							</Badge>
@@ -475,8 +512,10 @@ const AiScreen: FC< Props > = ( { form, searchEnginesVisible, onManageVisibility
 
 			{ enhancer.available && (
 				<CollapsibleCard.Root defaultOpen>
-					<CollapsibleCard.Header>
-						<Card.Title>{ __( 'AI SEO Enhancer', 'jetpack-seo' ) }</Card.Title>
+					<CollapsibleCard.Header render={ <h2 /> }>
+						<Card.Title>
+							<CardTitleIcon icon={ aiSparks } title={ __( 'AI SEO Enhancer', 'jetpack-seo' ) } />
+						</Card.Title>
 					</CollapsibleCard.Header>
 					<CollapsibleCard.Content>
 						<ToggleControl

--- a/projects/packages/seo/_inc/screens/ai/test/index.test.tsx
+++ b/projects/packages/seo/_inc/screens/ai/test/index.test.tsx
@@ -274,18 +274,55 @@ describe( 'AiScreen (GEO tab) — module titles', () => {
 	} );
 
 	// `Card.Title` and `CollapsibleCard.Header` both default to a div, so without
-	// opting in the tab has no heading structure to navigate at all. Names are
-	// matched loosely because the existing state badge sits inside the trigger and
-	// so forms part of its accessible name.
-	it( 'renders each module header as a heading that wraps its trigger', () => {
+	// opting in the tab has no heading structure to navigate at all.
+	//
+	// The names are matched EXACTLY on purpose: the header wraps all its children in
+	// the trigger, so a state badge left beside the title would land in the button's
+	// accessible name ("Answer enginesAllowed"). These assertions only pass while the
+	// badges stay in `HeaderDescription`, which is `aria-hidden` and surfaced through
+	// `aria-describedby` instead.
+	it( 'renders each module header as a heading, named by its title alone', () => {
 		render(
 			<AiScreen form={ allModulesForm() } searchEnginesVisible onManageVisibility={ noop } />
 		);
 
-		for ( const title of [ /^Answer engines/, /^Training crawlers/, /^llms\.txt/ ] ) {
+		for ( const title of [
+			'Answer engines',
+			'Training crawlers',
+			'llms.txt',
+			'AI SEO Enhancer',
+		] ) {
 			const trigger = screen.getByRole( 'button', { name: title } );
 			// eslint-disable-next-line testing-library/no-node-access -- the heading/trigger nesting is the contract.
 			expect( trigger.closest( 'h2' ) ).toBeInTheDocument();
+		}
+	} );
+
+	// The badge must stay visible — this is an accessibility relocation, not a
+	// removal. Asserting it through the trigger's `aria-describedby` target proves
+	// both halves at once: the badge still renders, and it now reaches assistive
+	// tech as the trigger's description instead of part of its name. (A bare text
+	// query would be ambiguous — the toggles inside the expanded content say
+	// "Allowed" too.)
+	it( 'keeps each state badge on screen, wired as the trigger description', () => {
+		render(
+			<AiScreen form={ allModulesForm() } searchEnginesVisible onManageVisibility={ noop } />
+		);
+
+		for ( const [ title, state ] of [
+			[ 'Answer engines', 'Allowed' ],
+			[ 'Training crawlers', 'Blocked' ],
+			[ 'llms.txt', 'Enabled' ],
+		] ) {
+			const describedBy = screen
+				.getByRole( 'button', { name: title } )
+				.getAttribute( 'aria-describedby' );
+			expect( describedBy ).toBeTruthy();
+
+			// eslint-disable-next-line testing-library/no-node-access -- resolving an id reference is the point.
+			const description = document.getElementById( describedBy as string );
+			expect( description ).toBeVisible();
+			expect( description ).toHaveTextContent( state );
 		}
 	} );
 

--- a/projects/packages/seo/_inc/screens/ai/test/index.test.tsx
+++ b/projects/packages/seo/_inc/screens/ai/test/index.test.tsx
@@ -115,7 +115,6 @@ describe( 'AiScreen (GEO tab) — llms.txt serving state', () => {
 			screen.getByRole( 'checkbox', { name: /generate an llms\.txt file/i } )
 		).not.toBeChecked();
 		expect( screen.getAllByText( /to enable, allow search engines/i ).length ).toBeGreaterThan( 0 );
-		expect( screen.getByText( 'Disabled' ) ).toBeInTheDocument();
 		expect(
 			screen.queryByRole( 'link', { name: /view your llms\.txt/i } )
 		).not.toBeInTheDocument();
@@ -298,6 +297,41 @@ describe( 'AiScreen (GEO tab) — module titles', () => {
 		}
 	} );
 
+	// Only the two crawler groups carry a state tag. The other modules open by
+	// default, so their toggle — the same fact, in the control that changes it — is
+	// already on screen; a tag would state it twice. If one of them ever opens
+	// closed, it needs a tag, and this test should be the thing that says so.
+	it( 'gives no state tag to the modules that open by default', () => {
+		render(
+			<AiScreen form={ allModulesForm() } searchEnginesVisible onManageVisibility={ noop } />
+		);
+
+		for ( const title of [ 'llms.txt', 'AI SEO Enhancer' ] ) {
+			expect( screen.getByRole( 'button', { name: title } ) ).not.toHaveAttribute(
+				'aria-describedby'
+			);
+		}
+	} );
+
+	// A partly-blocked group used to be grey — indistinguishable from a module that
+	// is simply switched off, which made it the one state you couldn't read from the
+	// header. Amber is what separates them, so the intent is worth pinning down.
+	it( 'marks a partly-blocked group amber, distinct from allowed and blocked', () => {
+		// `gptbot` allowed, `google-extended` left at the training default of blocked.
+		render(
+			<AiScreen
+				form={ crawlerForm( { overrides: { gptbot: false } } ) }
+				searchEnginesVisible
+				onManageVisibility={ noop }
+			/>
+		);
+
+		// The class name is hashed by the CSS-module build, so match the stable suffix
+		// rather than a literal. Asserted on `className` (a string) instead of via
+		// `toHaveClass`, whose types don't admit a pattern.
+		expect( screen.getByText( 'Partly blocked' ).className ).toMatch( /is-medium-intent/ );
+	} );
+
 	// The badge must stay visible — this is an accessibility relocation, not a
 	// removal. Asserting it through the trigger's `aria-describedby` target proves
 	// both halves at once: the badge still renders, and it now reaches assistive
@@ -312,7 +346,6 @@ describe( 'AiScreen (GEO tab) — module titles', () => {
 		for ( const [ title, state ] of [
 			[ 'Answer engines', 'Allowed' ],
 			[ 'Training crawlers', 'Blocked' ],
-			[ 'llms.txt', 'Enabled' ],
 		] ) {
 			const describedBy = screen
 				.getByRole( 'button', { name: title } )

--- a/projects/packages/seo/_inc/screens/ai/test/index.test.tsx
+++ b/projects/packages/seo/_inc/screens/ai/test/index.test.tsx
@@ -220,10 +220,6 @@ describe( 'AiScreen (GEO tab) — crawler policy state', () => {
 
 		expect( screen.getAllByText( /temporary staging address/i ).length ).toBeGreaterThan( 0 );
 		expect( screen.queryByText( 'Google Gemini (Google-Extended)' ) ).not.toBeInTheDocument();
-		// Shares `CrawlerAccessCard` with the other blocked states, so it gets the same
-		// chipped heading.
-		// eslint-disable-next-line testing-library/no-node-access -- the heading/trigger nesting is the contract.
-		expect( screen.getByText( 'AI crawler access' ).closest( 'h2' ) ).toBeInTheDocument();
 	} );
 
 	it( 'accurately describes a detected static robots.txt file', () => {

--- a/projects/packages/seo/_inc/screens/ai/test/index.test.tsx
+++ b/projects/packages/seo/_inc/screens/ai/test/index.test.tsx
@@ -318,6 +318,8 @@ describe( 'AiScreen (GEO tab) — module titles', () => {
 	// default, so their toggle — the same fact, in the control that changes it — is
 	// already on screen; a tag would state it twice. If one of them ever opens
 	// closed, it needs a tag, and this test should be the thing that says so.
+	// Collapsing one hides its state until reopened: an accepted trade-off, not an
+	// oversight — see the comment on the llms.txt header.
 	it( 'gives no state tag to the modules that open by default', () => {
 		render(
 			<AiScreen form={ allModulesForm() } searchEnginesVisible onManageVisibility={ noop } />

--- a/projects/packages/seo/_inc/screens/ai/test/index.test.tsx
+++ b/projects/packages/seo/_inc/screens/ai/test/index.test.tsx
@@ -34,7 +34,11 @@ const crawlerForm = (
 	flags: Partial<
 		Pick<
 			NonNullable< AiState[ 'crawlers' ] >,
-			'staticRobotsTxt' | 'dataSharingOptOut' | 'pathBasedMultisite' | 'overrides'
+			| 'staticRobotsTxt'
+			| 'dataSharingOptOut'
+			| 'pathBasedMultisite'
+			| 'restrictedSubdomain'
+			| 'overrides'
 		>
 	> = {}
 ): AiForm => ( {
@@ -203,6 +207,23 @@ describe( 'AiScreen (GEO tab) — crawler policy state', () => {
 
 		expect( screen.getAllByText( /shares one robots\.txt/i ).length ).toBeGreaterThan( 0 );
 		expect( screen.queryByText( 'Google Gemini (Google-Extended)' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'explains a staging subdomain instead of offering controls', () => {
+		render(
+			<AiScreen
+				form={ crawlerForm( { restrictedSubdomain: true } ) }
+				searchEnginesVisible
+				onManageVisibility={ noop }
+			/>
+		);
+
+		expect( screen.getAllByText( /temporary staging address/i ).length ).toBeGreaterThan( 0 );
+		expect( screen.queryByText( 'Google Gemini (Google-Extended)' ) ).not.toBeInTheDocument();
+		// Shares `CrawlerAccessCard` with the other blocked states, so it gets the same
+		// chipped heading.
+		// eslint-disable-next-line testing-library/no-node-access -- the heading/trigger nesting is the contract.
+		expect( screen.getByText( 'AI crawler access' ).closest( 'h2' ) ).toBeInTheDocument();
 	} );
 
 	it( 'accurately describes a detected static robots.txt file', () => {

--- a/projects/packages/seo/_inc/screens/ai/test/index.test.tsx
+++ b/projects/packages/seo/_inc/screens/ai/test/index.test.tsx
@@ -222,3 +222,88 @@ describe( 'AiScreen (GEO tab) — crawler policy state', () => {
 		expect( screen.queryByText( /can't reach.*robots\.txt/i ) ).not.toBeInTheDocument();
 	} );
 } );
+
+/**
+ * A form with every module visible at once, so the title treatment can be checked
+ * across all four. The other fixtures deliberately switch modules off.
+ *
+ * @return A form controller with crawlers, llms.txt and the enhancer all present.
+ */
+const allModulesForm = (): AiForm => ( {
+	...crawlerForm(),
+	enhancer: { available: true, enabled: false },
+	llmsTxt: { enabled: true, url: 'https://example.com/llms.txt', canServe: true },
+} );
+
+describe( 'AiScreen (GEO tab) — module titles', () => {
+	// The chip must not swallow the title text, which is how these modules are found
+	// by assistive tech and by every other test in this file.
+	it( 'leads every module title with an icon chip, keeping the title readable', () => {
+		render(
+			<AiScreen form={ allModulesForm() } searchEnginesVisible onManageVisibility={ noop } />
+		);
+
+		for ( const title of [
+			'Answer engines',
+			'Training crawlers',
+			'llms.txt',
+			'AI SEO Enhancer',
+		] ) {
+			// `getByText` resolves to the chip wrapper, whose text is the title alone —
+			// the glyph beside it is a decorative SVG with no role of its own.
+			const heading = screen.getByText( title );
+			expect( heading ).toBeInTheDocument();
+			// eslint-disable-next-line testing-library/no-node-access -- asserting the decorative glyph rendered.
+			expect( heading.querySelector( 'svg' ) ).toBeInTheDocument();
+		}
+	} );
+
+	// The two crawler groups are opposite decisions about the same content, so a
+	// shared glyph would hide the only distinction on the tab that needs acting on.
+	it( 'gives the two crawler groups different glyphs', () => {
+		render(
+			<AiScreen form={ allModulesForm() } searchEnginesVisible onManageVisibility={ noop } />
+		);
+
+		const glyphOf = ( title: string ) =>
+			// eslint-disable-next-line testing-library/no-node-access -- comparing the two decorative glyphs.
+			screen.getByText( title ).querySelector( 'svg' )?.innerHTML;
+
+		expect( glyphOf( 'Answer engines' ) ).toBeTruthy();
+		expect( glyphOf( 'Answer engines' ) ).not.toBe( glyphOf( 'Training crawlers' ) );
+	} );
+
+	// `Card.Title` and `CollapsibleCard.Header` both default to a div, so without
+	// opting in the tab has no heading structure to navigate at all. Names are
+	// matched loosely because the existing state badge sits inside the trigger and
+	// so forms part of its accessible name.
+	it( 'renders each module header as a heading that wraps its trigger', () => {
+		render(
+			<AiScreen form={ allModulesForm() } searchEnginesVisible onManageVisibility={ noop } />
+		);
+
+		for ( const title of [ /^Answer engines/, /^Training crawlers/, /^llms\.txt/ ] ) {
+			const trigger = screen.getByRole( 'button', { name: title } );
+			// eslint-disable-next-line testing-library/no-node-access -- the heading/trigger nesting is the contract.
+			expect( trigger.closest( 'h2' ) ).toBeInTheDocument();
+		}
+	} );
+
+	// Only one blocked state renders at a time, and it stands for both crawler
+	// groups — so it carries the combined glyph rather than either group's.
+	it( 'still titles and chips the blocked state', () => {
+		render(
+			<AiScreen
+				form={ crawlerForm( { pathBasedMultisite: true } ) }
+				searchEnginesVisible
+				onManageVisibility={ noop }
+			/>
+		);
+
+		const heading = screen.getByText( 'AI crawler access' );
+		// eslint-disable-next-line testing-library/no-node-access -- asserting the decorative glyph rendered.
+		expect( heading.querySelector( 'svg' ) ).toBeInTheDocument();
+		// eslint-disable-next-line testing-library/no-node-access -- the heading/trigger nesting is the contract.
+		expect( screen.getByText( 'AI crawler access' ).closest( 'h2' ) ).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/seo/changelog/add-seo-geo-icon-chips
+++ b/projects/packages/seo/changelog/add-seo-geo-icon-chips
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Add an icon chip to each GEO module title and give the module headers heading semantics.
+Add an icon chip to each GEO module title, give the module headers heading semantics, and keep the state badges out of the collapsible buttons' accessible names.

--- a/projects/packages/seo/changelog/add-seo-geo-icon-chips
+++ b/projects/packages/seo/changelog/add-seo-geo-icon-chips
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Add an icon chip to each GEO module title, give the module headers heading semantics, and keep the state badges out of the collapsible buttons' accessible names.
+Add an icon chip to each GEO module title, give the module headers heading semantics, keep the state badges out of the collapsible buttons' accessible names, and explain the GEO acronym beside the tab.

--- a/projects/packages/seo/changelog/add-seo-geo-icon-chips
+++ b/projects/packages/seo/changelog/add-seo-geo-icon-chips
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Add an icon chip to each GEO module title, give the module headers heading semantics, keep the state badges out of the collapsible buttons' accessible names, and explain the GEO acronym beside the tab.
+Add an icon chip to each GEO module title, give the module headers heading semantics, explain the GEO acronym beside the tab, and show a clearer state tag on the crawler modules.

--- a/projects/packages/seo/changelog/add-seo-geo-icon-chips
+++ b/projects/packages/seo/changelog/add-seo-geo-icon-chips
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Add an icon chip to each GEO module title, give the module headers heading semantics, explain the GEO acronym beside the tab, and show a clearer state tag on the crawler modules.
+Refresh the GEO tab: an icon chip on every module title, headings you can navigate to, an explanation of what GEO means, and clearer state tags.

--- a/projects/packages/seo/changelog/add-seo-geo-icon-chips
+++ b/projects/packages/seo/changelog/add-seo-geo-icon-chips
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add an icon chip to each GEO module title and give the module headers heading semantics.


### PR DESCRIPTION
Fixes JETPACK-2076

Based on `trunk`, following #50883 which landed the shared `CardTitleIcon` and the header treatment this reuses.

## Proposed changes

Brings the GEO tab in line with the Settings tab. Presentational only — no data, API, save-path or behaviour changes.

**An icon chip on every module title**, via the shared `CardTitleIcon`:

| Module | Icon |
| --- | --- |
| Answer engines | `commentContent` |
| Training crawlers | `details` |
| llms.txt | `page` |
| AI SEO Enhancer | Jetpack's AI mark (three sparks) |
| blocked-state cards ("AI crawler access") | `key` |

The two crawler groups deliberately get **contrasting** glyphs. They're opposite decisions about the same content — answer engines read it to cite you now, training crawlers take it to train a model later — so a similar-looking pair would bury the only distinction on this tab a person has to act on. `key` on the blocked-state cards matches the Overview card, and fits because those stand for both groups at once.

**Heading semantics on the module headers.** `Card.Title` and `CollapsibleCard.Header` both default to a `div`, so the tab previously had no heading structure to navigate. The heading goes on `CollapsibleCard.Header` via `render={ <h2 /> }` — following the W3C APG accordion pattern that the component's own docblock points at (heading wraps button) — rather than on `Card.Title`, which would nest a heading *inside* the trigger.

**The state badges stay out of the trigger's accessible name.** `CollapsibleCard.Header` wraps *all* its children in the collapsible trigger, so a badge sitting beside the title became part of the button's name — screen readers announced "Answer enginesAllowed", "Training crawlersBlocked", "llms.txtEnabled". Each badge now renders inside `CollapsibleCard.HeaderDescription`, which looks identical but marks itself `aria-hidden` and wires `aria-describedby` on the trigger, so the state is announced as the button's description instead. **No visual change** — same text, same placement, same colours.

**An infotip explaining the GEO acronym**, beside the tab. "GEO" appears nowhere else on the dashboard with an explanation, so an info icon next to the tab now reveals: *"GEO stands for generative engine optimization. These settings control how AI tools see and use your site."*

It's a `Popover` with `openOnHover` rather than a `Tooltip`, following [the design system's own guidance](https://wordpress.github.io/gutenberg/?path=/docs/design-system-components-tooltip--docs): tooltip popups aren't exposed to assistive technologies (only the trigger's accessible name is) and are disabled outright on touch devices, so a tooltip would reach sighted mouse users only. This opens on hover, click and tap, closes on Escape, and its content is announced.

**Placement is load-bearing.** `Tabs.Tab` renders a `<button>`, so nesting the trigger inside the GEO tab would be a button within a button; a non-tab child of the `tablist` would break its arrow-key navigation. It therefore sits *after* `Tabs.List` — which still reads as belonging to GEO because **GEO is the last tab**. That coupling is called out in a comment, since a tab added after GEO would need this moved. It's hidden on plan-gated sites under the same condition as the tab it explains.

**No status indicators.** Every module here is a preference rather than a fill-in task, and for the crawler groups both answers are legitimate: blocking training crawlers is a deliberate choice many publishers make, so a "Not started" state would nudge people toward allowing them, which isn't a position the product should take. This is the same reasoning that excluded Search & social previews on the Settings tab.

**State tags now sit only on the two crawler groups**, and the mixed state is finally distinguishable:

| Module | Before | After |
| --- | --- | --- |
| Answer engines | `stable` "Allowed" | unchanged |
| Training crawlers — all blocked | `high` "Blocked" | unchanged |
| Training crawlers — mixed | `draft` "Partly blocked" (grey) | **`medium` (amber)** |
| llms.txt | `stable`/`draft` "Enabled"/"Disabled" | **no tag** |
| AI SEO Enhancer | no tag | unchanged |

*Amber for the mixed state:* it shared `draft` grey with a switched-off module, so a group with some crawlers allowed and others blocked looked identical to a feature that was simply off — the one state you couldn't read from the header. Green / amber / red now reads as a stop-light.

*Red stays for "Blocked".* It's the "stop" association rather than a severity claim. That's safe because `intent` is a CSS class and nothing else — no `role`, no `aria-*`, no hidden text — confirmed in the live accessibility tree, where both tags resolve to a plain `generic` node carrying only their word. "Blocked" is announced exactly like "Allowed". The word carries the meaning, so colour isn't load-bearing on its own.

*No tag on llms.txt:* it opens by default, so its toggle — the same fact, in the control that changes it — is already on screen. The AI SEO Enhancer never had one and also opens by default. That leaves tags precisely on the modules that open **closed**, which are the only ones an at-a-glance state helps.

**Known and accepted:** these two modules can still be collapsed, and while collapsed they show no state at all — llms.txt previously kept its badge through a collapse, so that is a deliberate regression, not an oversight. It doesn't persist (a reload reopens the card), and collapsing is a choice to hide that module's detail. The crawler groups differ because they open *closed*, so a tag is the only state they would ever show. Raised in review prep and decided against restoring; noted in a comment at the header and in the test that encodes the rule.

**The badge shape is unchanged** — the filled rounded rectangle stays. The fill is what separates the state from the title (they share one clickable header, so without a container "Training crawlers Blocked" starts to read as a single phrase), it holds a family look across labels of very different length, and it's the WPDS default, so it inherits token, dark-mode and contrast changes for free.

## Screenshots

<img width="1399" height="866" alt="Screenshot 2026-07-29 at 7 42 50 PM" src="https://github.com/user-attachments/assets/9a87b50d-8d87-4631-8303-e81b50b82ce2" />

## Related product discussion/links

* JETPACK-2076 — follows JETPACK-2050 / JETPACK-2051

## Does this pull request change what data or activity we track or use?

No. Markup and styling only.

## Testing instructions

Requires the `rsm_jetpack_seo` feature flag.

* Go to **Jetpack → SEO → GEO**. Confirm each module title is led by a chip matching the table above, and that Answer engines and Training crawlers have visibly *different* glyphs.
* Confirm the existing green/grey badges are unchanged — same text, same placement, same colours.
* Confirm each header still expands and collapses on click, and that the chip hasn't disturbed the layout.
* With a screen reader or an accessibility inspector, confirm the page now has an `h1` → `h2` outline instead of jumping straight to the `h3`s inside the modules, and that each module button is announced by its title alone ("Answer engines") with the state as a separate description ("Allowed") — not as one run-together name.
* To see a blocked state, either set a static `robots.txt` in the WordPress install directory or turn off "Allow search engines to index this site" on the Settings tab. Confirm the "AI crawler access" card that replaces the groups also has a chip and a heading.
* **State tags:** confirm only Answer engines and Training crawlers carry one, and that llms.txt and the AI SEO Enhancer show their toggle instead. To see the amber "Partly blocked", allow one training crawler and leave the other blocked — grey previously made this indistinguishable from a switched-off module.
* **The GEO infotip:** hover, click and tap the ⓘ beside the GEO tab — all three should open it, and Escape should close it. Confirm the sentence isn't clipped. Confirm arrow keys still walk the tab strip and wrap from GEO back to Overview *without* stopping on the icon, and that Tab does reach it. On a plan-gated WordPress.com site (below Premium), confirm the icon is gone along with the GEO tab.

### What I tested

* Package suites: **228 JS tests** (11 net-new) and the PHP suite, plus `tsgo --noEmit`, ESLint and Stylelint — all clean.
* Ran a review battery over the diff — core review (conventions, bugs, git history, prior reviewer comments, comment-accuracy), a skeptical accessibility pass that re-verified every a11y claim against the `@wordpress/ui` source, a simplifier pass, and an adversarial pass. It changed four things: the four blocked-state cards were folded onto one component, a redundant test was cut, a duplicated assertion was dropped, and "GEO is the last tab" — which the infotip's placement quietly depends on — is now enforced by a test instead of only a comment. It also found the collapsed-state gap noted above. No independent-model pass was available (no `codex` installed), so that coverage is missing.
* Both badge rules are pinned by tests that were each verified to fail when broken: the amber intent (matched on the hashed class's stable suffix, since CSS-module names are hashed) and the absence of a description on the modules that open by default — so if one of them ever opens closed, that test is what says it needs a tag.
* Verified the new tests actually catch the regressions they're written for: giving both crawler groups the same glyph, and dropping a heading, each fail exactly the intended assertion, and restoring returns the suite to green.
* Verified the infotip on a real render rather than in jsdom alone, because the risks here are all things jsdom can't see: arrow keys still walk the tab strip and wrap from GEO to Overview without landing on the icon, the trigger is in the tab order (`tabIndex 0`), Escape closes, hover and click both open, and the popup fits on screen. That last one caught a real bug — `Popover.Popup` sizes to its content, so the sentence laid out as one ~600px line whose start fell outside the content area and was clipped. Fixed with a width cap.
* Verified the accessible names on the live site before and after: the headings read `H2: Answer enginesAllowed` before the fix, and the tightened test asserting the exact name `Answer engines` is what proves it left the computed name — `textContent` includes `aria-hidden` nodes and would have looked unchanged either way.

### What I did NOT test

* **The amber "Partly blocked" tag hasn't been seen on a real render** — it needs a mixed toggle state, which means changing a setting on the test site. Verified by test and in a mock only.
* The **AI SEO Enhancer** chip hasn't been seen rendered: the enhancer needs a plan that supports it, so it doesn't appear on Jurassic Ninja. Pending a look on a Dotcom test site once the Beta build lands.
* No real screen-reader pass — the accessible-name change is verified through the computed-name APIs (`getByRole` with an exact name, and the live DOM), not VoiceOver/NVDA.
* **No real touch-device pass.** Choosing `Popover` over `Tooltip` is what makes the infotip reachable by tap at all, but that was verified from the component's documented behaviour, not on a phone.
* RTL layouts, and Windows/Linux high-contrast mode.

### Known, and deliberate

**Jetpack's AI mark is restated locally as an element with svg props** rather than imported. `@wordpress/ui`'s `Icon` spreads `icon.props` onto its own `SVG` instead of rendering what it's handed, so `AiIcon` from `@automattic/jetpack-components` — a component whose props are `size` and `color` — would spread those and produce an empty icon. `@wordpress/icons` has no AI or sparkle glyph to use instead. The paths are duplicated and kept in sync by hand; the comment at the definition says so, and this is the one chip on the page whose glyph doesn't come from `@wordpress/icons`.

**The green/grey state badges are unchanged visually**, but they no longer sit in the trigger's accessible name — see the accessibility note above. Whether the badges themselves change is still a separate decision.
