### PR TITLE
Premium Analytics: Align UTM CSV exports with Jetpack Stats

### DIFF
--- a/projects/packages/premium-analytics/changelog/align-utm-csv-hierarchy
+++ b/projects/packages/premium-analytics/changelog/align-utm-csv-hierarchy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+CSV exports: Preserve UTM parent and child grouping.

--- a/projects/packages/premium-analytics/routes/reports/report-csv-exports.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/report-csv-exports.test.tsx
@@ -482,13 +482,20 @@ describe( 'report CSV exports', () => {
 		);
 	} );
 
-	it( 'configures the active UTM tab export', () => {
+	it( 'configures the active UTM tab export in hierarchy order', () => {
 		useSectionTabMock.mockReturnValue( [ 'source-medium', jest.fn() ] as ReturnType<
 			typeof useSectionTab
 		> );
 		const rows = [
-			{ id: 'first', label: 'First source', views: 2 },
-			{ id: 'second', label: 'Second source', views: 5 },
+			{ id: 'first', label: 'First source', views: 2, isGroup: true },
+			{
+				id: 'first-post',
+				parentId: 'first',
+				label: 'First post',
+				groupLabel: 'First source',
+				views: 10,
+			},
+			{ id: 'second', label: 'Second source', views: 5, isGroup: true },
 		];
 		useUtmReportRecordsMock.mockReturnValue( {
 			...reportStatus,
@@ -498,8 +505,13 @@ describe( 'report CSV exports', () => {
 		expectCsvExport(
 			UtmReportPage,
 			'utm-source-medium',
-			[ rows[ 1 ], rows[ 0 ] ],
-			[ 'Second source', 5 ]
+			rows,
+			[ 'First source', 2 ]
 		);
+
+		const actionProps = reportCsvActionMock.mock.calls.at( -1 )?.[ 0 ] as ExportActionProps;
+		expect(
+			actionProps.columns.map( column => column.getValue( actionProps.rows[ 1 ] ) )
+		).toEqual( [ 'First source > First post', 10 ] );
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/reports/report-csv-exports.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/report-csv-exports.test.tsx
@@ -502,16 +502,11 @@ describe( 'report CSV exports', () => {
 			rows,
 		} as ReturnType< typeof useUtmReportRecords > );
 
-		expectCsvExport(
-			UtmReportPage,
-			'utm-source-medium',
-			rows,
-			[ 'First source', 2 ]
-		);
+		expectCsvExport( UtmReportPage, 'utm-source-medium', rows, [ 'First source', 2 ] );
 
 		const actionProps = reportCsvActionMock.mock.calls.at( -1 )?.[ 0 ] as ExportActionProps;
-		expect(
-			actionProps.columns.map( column => column.getValue( actionProps.rows[ 1 ] ) )
-		).toEqual( [ 'First source > First post', 10 ] );
+		expect( actionProps.columns.map( column => column.getValue( actionProps.rows[ 1 ] ) ) ).toEqual(
+			[ 'First source > First post', 10 ]
+		);
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/reports/utm/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/utm/page.tsx
@@ -51,8 +51,6 @@ const RECORDS_VIEW = {
 	},
 };
 
-const sortUtmCsvRows = ( a: UtmReportRow, b: UtmReportRow ) => b.views - a.views;
-
 /**
  * Stable row id for the UTM records table.
  *
@@ -74,6 +72,16 @@ function getUtmRowParentId( item: UtmReportRow ): string | undefined {
 }
 
 /**
+ * Keep nested posts identifiable after the UTM hierarchy is flattened into CSV rows.
+ *
+ * @param item - The UTM parent or nested post row.
+ * @return The UTM value or UTM-qualified post title.
+ */
+function getUtmCsvLabel( item: UtmReportRow ): string {
+	return item.groupLabel ? `${ item.groupLabel } > ${ item.label }` : item.label;
+}
+
+/**
  * Premium Analytics UTM report page.
  *
  * @return The UTM report page.
@@ -91,7 +99,7 @@ function UtmReport(): JSX.Element {
 	const fields = useMemo( () => getUtmFields( activeTab ), [ activeTab ] );
 	const csvColumns = useMemo< CsvColumn< UtmReportRow >[] >(
 		() => [
-			{ label: getUtmTabLabel( activeTab ), getValue: row => row.label },
+			{ label: getUtmTabLabel( activeTab ), getValue: getUtmCsvLabel },
 			{ label: __( 'Views', 'jetpack-premium-analytics-pkg' ), getValue: row => row.views },
 		],
 		[ activeTab ]
@@ -105,7 +113,6 @@ function UtmReport(): JSX.Element {
 		filenamePrefix: `utm-${ activeTab }`,
 		range: reportParams,
 		status: records,
-		sort: sortUtmCsvRows,
 	} );
 	const dateFilters = useReportDateFilters( ROUTE_FROM );
 	const dashboardLink = useDashboardLink();


### PR DESCRIPTION
Part of WOOA7S-1838.

## Proposed changes

* Preserve UTM parent and child order in CSV exports.
* Qualify nested post labels with their parent UTM value, matching current Jetpack Stats `parent > child` output.
* Add regression coverage for hierarchy order and nested labels.

## Related product discussion/links

* Follow-up to [#50716](https://github.com/Automattic/jetpack/pull/50716).

## Does this pull request change what data or activity we track or use?

No. This only changes the ordering and labels of client-side CSV rows already loaded by Premium Analytics.

## Testing instructions

* Use a Premium Analytics site with UTM data containing nested posts.
* Select the same date range in Premium Analytics and Jetpack Stats.
* Export the Source / Medium UTM report from both systems.
* Verify each UTM parent is immediately followed by its posts and nested rows are labeled `parent > child`.
* Verify view counts match between systems, allowing for live traffic recorded between downloads.
* Switch to another UTM tab and verify its filename and first-column header follow the active tab while preserving the same hierarchy.

## Automated validation

* Premium Analytics JavaScript suite passed.
* Premium Analytics dependency build passed.
