### PR TITLE
Premium Analytics: add hourly Group-by option to the Traffic widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/echo-wooa7s-1834-hourly-traffic-chart
+++ b/projects/packages/premium-analytics/changelog/echo-wooa7s-1834-hourly-traffic-chart
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a "By hours" option to the Traffic widget's Group by dropdown, showing hourly Views (Visitors, Likes, and Comments aren't available hourly and show disabled).

--- a/projects/packages/premium-analytics/changelog/echo-wooa7s-1834-hourly-traffic-chart
+++ b/projects/packages/premium-analytics/changelog/echo-wooa7s-1834-hourly-traffic-chart
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Add a "By hours" option to the Traffic widget's Group by dropdown, showing hourly Views (Visitors, Likes, and Comments aren't available hourly and show disabled). Group by options the selected date range doesn't support are disabled, and a selection the range no longer allows resets to Auto.
+Add a "By hours" option to the Traffic widget's Group by dropdown, showing hourly Views (Visitors, Likes, and Comments aren't available hourly and show disabled). Group by options the selected date range doesn't support are disabled, and a selection the range no longer allows resets to Auto. The chart's time axis follows the grouping — hour markers for hourly, dates for days/weeks, months for monthly — and hourly tooltips include the hour.

--- a/projects/packages/premium-analytics/changelog/echo-wooa7s-1834-hourly-traffic-chart
+++ b/projects/packages/premium-analytics/changelog/echo-wooa7s-1834-hourly-traffic-chart
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Add a "By hours" option to the Traffic widget's Group by dropdown, showing hourly Views (Visitors, Likes, and Comments aren't available hourly and show disabled).
+Add a "By hours" option to the Traffic widget's Group by dropdown, showing hourly Views (Visitors, Likes, and Comments aren't available hourly and show disabled). Group by options the selected date range doesn't support are disabled, and a selection the range no longer allows resets to Auto.

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/time-series.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/time-series.test.ts
@@ -264,6 +264,43 @@ describe( 'Stats time-series normalizer', () => {
 		);
 	} );
 
+	it( 'resolves visits hourly rows whose period packs date and hour into one string', () => {
+		// Unlike the email timeline (a separate `hour` column), the visits endpoint's
+		// hourly rows label each bucket with a single `YYYY-MM-DD HH:mm:ss` period —
+		// this must resolve to the same bucket, not fall through to the bare-date
+		// fallback (which would double-stamp a time suffix onto an already-timed
+		// string and produce an unparseable date).
+		const result = sanitizeStatsTimeSeriesResponse(
+			{
+				unit: 'hour',
+				fields: [ 'period', 'views', 'visitors' ],
+				data: [
+					[ '2026-06-30 00:00:00', 5, null ],
+					[ '2026-06-30 09:00:00', 12, null ],
+				],
+			},
+			{ period: 'hour' }
+		);
+
+		expect( result.data[ 0 ] ).toEqual(
+			expect.objectContaining( {
+				time_interval: '2026-06-30 00:00',
+				date_start: '2026-06-30T00:00:00+00:00',
+				date_end: '2026-06-30T00:59:59+00:00',
+				views: 5,
+				visitors: null,
+			} )
+		);
+		expect( result.data[ 1 ] ).toEqual(
+			expect.objectContaining( {
+				time_interval: '2026-06-30 09:00',
+				date_start: '2026-06-30T09:00:00+00:00',
+				date_end: '2026-06-30T09:59:59+00:00',
+				views: 12,
+			} )
+		);
+	} );
+
 	it( 'returns an empty email time series report when the timeline key is missing', () => {
 		const result = sanitizeStatsEmailTimeSeriesResponse( {} );
 

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
@@ -210,9 +210,28 @@ function getHourIntervalFields( date: string, hour: unknown ) {
 	};
 }
 
+// The visits endpoint's hourly rows pack date and hour into one `period` string
+// (`YYYY-MM-DD HH:mm:ss`) instead of a separate `hour` field — unlike the email
+// timeline, which labels an explicit `hour` column. Parse that combined string
+// directly so a bare-date fallback doesn't get double-stamped with a time suffix
+// (`getStatsIntervalFields` appending `T00:00:00` to an already-timed string
+// produces an unparseable date, which crashes the chart's time scale).
+function getHourPeriodIntervalFields( period: string ) {
+	const match = period.match( /^(\d{4}-\d{2}-\d{2})[ T](\d{2}):/ );
+
+	return match ? getHourIntervalFields( match[ 1 ], match[ 2 ] ) : null;
+}
+
 function getRowIntervalFields( row: StatsRecord, rawPeriod: unknown, unit: string ) {
-	if ( unit === 'hour' && row.hour !== undefined && typeof rawPeriod === 'string' ) {
-		return getHourIntervalFields( rawPeriod, row.hour );
+	if ( unit === 'hour' && typeof rawPeriod === 'string' ) {
+		if ( row.hour !== undefined ) {
+			return getHourIntervalFields( rawPeriod, row.hour );
+		}
+
+		const hourPeriodFields = getHourPeriodIntervalFields( rawPeriod );
+		if ( hourPeriodFields ) {
+			return hourPeriodFields;
+		}
 	}
 
 	if ( typeof row.date_start === 'string' && typeof row.date_end === 'string' ) {

--- a/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/__tests__/stats-queries.test.ts
@@ -1281,6 +1281,27 @@ describe( 'Stats query factories', () => {
 		expect( apiParams ).not.toHaveProperty( 'quantity' );
 	} );
 
+	it( 'expands visits date/start_date to full datetimes for hourly ranges', () => {
+		const query = statsVisitsQuery( {
+			from: '2026-06-01',
+			to: '2026-06-01',
+			interval: 'hour',
+		} );
+		const apiParams = query.queryKey[ 5 ] as Record< string, unknown >;
+
+		// A bare calendar date resolves to 00:00:00 on the API side, which would
+		// silently truncate the last 23 hours of the range — the widget must send
+		// the full day span instead of relying on `quantity`.
+		expect( apiParams ).toEqual(
+			expect.objectContaining( {
+				unit: 'hour',
+				date: '2026-06-01 23:59:59',
+				start_date: '2026-06-01 00:00:00',
+			} )
+		);
+		expect( apiParams ).not.toHaveProperty( 'quantity' );
+	} );
+
 	it( 'builds insights query keys without report params', () => {
 		expect( statsInsightsQuery().queryKey ).toEqual( [
 			'stats',

--- a/projects/packages/premium-analytics/packages/data/src/queries/stats-visits-query.ts
+++ b/projects/packages/premium-analytics/packages/data/src/queries/stats-visits-query.ts
@@ -30,10 +30,18 @@ export const statsVisitsQuery = (
 ): StatsReportQueryOptions< 'visits' > => {
 	const statsParams = reportParamsToStatsQueryParams( params );
 	const apiParams = statsQueryParamsToApiParams( statsParams );
+	const isHourly = apiParams.period === 'hour';
+	// The hourly bucket endpoint reads `date`/`start_date` as full datetimes and derives the
+	// bucket count from their span; by this point they're bare calendar dates (yyyy-MM-dd),
+	// which the API resolves to 00:00:00 and silently truncates the last 23 hours of the range.
+	// Span the whole start/end day explicitly so a one-day range still returns 24 buckets.
 	const visitsParams: StatsProxyParams = {
 		unit: apiParams.period,
-		date: apiParams.date,
-		start_date: apiParams.start_date,
+		date: isHourly && apiParams.date ? `${ apiParams.date } 23:59:59` : apiParams.date,
+		start_date:
+			isHourly && apiParams.start_date
+				? `${ apiParams.start_date } 00:00:00`
+				: apiParams.start_date,
 		...( apiParams.period === 'day' ? { quantity: apiParams.days } : {} ),
 		stat_fields: params.stat_fields ?? 'views,visitors',
 	};

--- a/projects/packages/premium-analytics/packages/data/src/utils/__tests__/interval.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/utils/__tests__/interval.test.ts
@@ -1,8 +1,59 @@
 /**
  * Internal dependencies
  */
-import { getDefaultIntervalForPeriod, resolveIntervalForRange } from '../interval';
+import {
+	getAllowedIntervalsForPreset,
+	getDefaultIntervalForPeriod,
+	resolveIntervalForRange,
+} from '../interval';
 import { needsReportDateParamsSeed } from '../search';
+
+describe( 'getAllowedIntervalsForPreset', () => {
+	it( 'maps known presets to their allowed intervals, finest first', () => {
+		expect( getAllowedIntervalsForPreset( 'today', 'a', 'b' ) ).toEqual( [ 'hour', 'day' ] );
+		expect( getAllowedIntervalsForPreset( 'last-7-days', 'a', 'b' ) ).toEqual( [ 'day' ] );
+		expect( getAllowedIntervalsForPreset( 'last-30-days', 'a', 'b' ) ).toEqual( [ 'day', 'week' ] );
+		expect( getAllowedIntervalsForPreset( 'last-90-days', 'a', 'b' ) ).toEqual( [
+			'week',
+			'month',
+		] );
+		expect( getAllowedIntervalsForPreset( 'last-12-months', 'a', 'b' ) ).toEqual( [
+			'month',
+			'quarter',
+		] );
+	} );
+
+	it( 'derives the list from range length for custom presets', () => {
+		expect(
+			getAllowedIntervalsForPreset(
+				'custom',
+				'2026-06-01T00:00:00.000Z',
+				'2026-06-01T23:59:59.999Z'
+			)
+		).toEqual( [ 'hour', 'day' ] );
+		expect(
+			getAllowedIntervalsForPreset(
+				'custom',
+				'2026-06-01T00:00:00.000Z',
+				'2026-06-02T23:59:59.999Z'
+			)
+		).toEqual( [ 'hour', 'day' ] );
+		expect(
+			getAllowedIntervalsForPreset(
+				'custom',
+				'2026-06-01T00:00:00.000Z',
+				'2026-06-07T23:59:59.999Z'
+			)
+		).toEqual( [ 'day' ] );
+		expect(
+			getAllowedIntervalsForPreset(
+				'custom',
+				'2020-01-01T00:00:00.000Z',
+				'2026-06-30T23:59:59.999Z'
+			)
+		).toEqual( [ 'quarter', 'year' ] );
+	} );
+} );
 
 describe( 'resolveIntervalForRange', () => {
 	it( 'keeps the current interval when it is still allowed', () => {

--- a/projects/packages/premium-analytics/packages/fields/src/field-select/index.ts
+++ b/projects/packages/premium-analytics/packages/fields/src/field-select/index.ts
@@ -1,1 +1,1 @@
-export { default as SelectField } from './select-field';
+export { default as SelectField, type SelectOption } from './select-field';

--- a/projects/packages/premium-analytics/packages/fields/src/field-select/select-field.tsx
+++ b/projects/packages/premium-analytics/packages/fields/src/field-select/select-field.tsx
@@ -10,10 +10,17 @@ import { useCallback, useMemo } from '@wordpress/element';
 import useElements from '../helpers/use-elements';
 import type { DataFormControlProps, Option } from '@jetpack-premium-analytics/externals';
 
-export function toSelectItems( elements: Option[] ) {
+/**
+ * `Option` plus the per-item `disabled` flag `SelectControl` items support,
+ * so an Edit control can gray out choices the current context disallows.
+ */
+export type SelectOption = Option & { disabled?: boolean };
+
+export function toSelectItems( elements: SelectOption[] ) {
 	return elements.map( element => ( {
 		label: element.label,
 		value: String( element.value ),
+		disabled: element.disabled,
 	} ) );
 }
 

--- a/projects/packages/premium-analytics/packages/fields/src/index.ts
+++ b/projects/packages/premium-analytics/packages/fields/src/index.ts
@@ -5,4 +5,4 @@ export {
 
 export { ArrayCheckboxField } from './field-array-checkbox';
 
-export { SelectField } from './field-select';
+export { SelectField, type SelectOption } from './field-select';

--- a/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-date.test.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-date.test.ts
@@ -6,7 +6,7 @@ import { setSettings } from '@wordpress/date';
  * Internal dependencies
  */
 import { EN_US_SETTINGS, ES_ES_SETTINGS, settingsFor } from '../__fixtures__/wp-date-settings';
-import { formatDate } from '../format-date';
+import { formatDate, formatWallDate } from '../format-date';
 
 // Midnight UTC, matching the fixtures' timezone, so no day shift is in play.
 const JUNE_21 = new Date( '2025-06-21T00:00:00+00:00' );
@@ -44,6 +44,10 @@ describe( 'formatDate', () => {
 		it( 'leads "fullNoYear" with the weekday and drops the year', () => {
 			expect( formatDate( JUNE_21, 'fullNoYear' ) ).toBe( 'Saturday, June 21' );
 		} );
+
+		it( 'formats "datetime" with the site datetime format', () => {
+			expect( formatDate( JUNE_21, 'datetime' ) ).toBe( 'June 21, 2025 12:00 am' );
+		} );
 	} );
 
 	describe( 'es_ES site', () => {
@@ -74,5 +78,21 @@ describe( 'formatDate', () => {
 		setSettings( settingsFor( 'weekday-format-test', 'l, F j, Y' ) );
 
 		expect( formatDate( JUNE_21, 'full' ) ).toBe( 'Saturday, June 21, 2025' );
+	} );
+} );
+
+describe( 'formatWallDate', () => {
+	beforeEach( () => {
+		setSettings( EN_US_SETTINGS );
+	} );
+
+	it( 'reproduces the wall-clock reading regardless of the site timezone', () => {
+		// A browser-local wall-clock value, as chart points carry (see
+		// `buildMetricTab`). The local getters define the expected output, so the
+		// assertion holds in any runner timezone.
+		const wall = new Date( 2025, 5, 21, 15, 30 );
+
+		expect( formatWallDate( wall ) ).toBe( 'June 21, 2025' );
+		expect( formatWallDate( wall, 'datetime' ) ).toBe( 'June 21, 2025 3:30 pm' );
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/formatters/src/date/format-date.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/format-date.ts
@@ -18,6 +18,7 @@ export type DateFormatName =
 	| 'compact'
 	| 'short'
 	| 'year'
+	| 'datetime'
 	| 'iso'
 	| 'full'
 	| 'fullNoYear';
@@ -47,7 +48,12 @@ function formatFor( name: DateFormatName ): string {
 		return YEAR_FORMAT;
 	}
 
-	const siteFormat = getSettings().formats.date;
+	const { date: siteFormat, datetime } = getSettings().formats;
+
+	if ( name === 'datetime' ) {
+		return datetime;
+	}
+
 	const withoutYearFormat = withoutYear( siteFormat ) || siteFormat;
 
 	if ( name === 'compact' ) {
@@ -88,3 +94,19 @@ function formatFor( name: DateFormatName ): string {
  */
 export const formatDate = ( date: DateInput, name: DateFormatName = 'medium' ): string =>
 	dateI18n( formatFor( name ), date );
+
+/**
+ * Format a wall-clock date in its own (browser-local) frame, in the site's
+ * locale.
+ *
+ * For `Date`s that carry a wall-clock reading in the browser frame — the chart
+ * library's convention for time-series points — rather than a real instant.
+ * `formatDate`'s site-timezone rendering would shift such a value by the
+ * browser-to-site offset; this reproduces exactly what the date reads as.
+ *
+ * @param date - The wall-clock date to render.
+ * @param name - Named format. Defaults to `'medium'`.
+ * @return The formatted date.
+ */
+export const formatWallDate = ( date: Date, name: DateFormatName = 'medium' ): string =>
+	dateI18n( formatFor( name ), date, -date.getTimezoneOffset() );

--- a/projects/packages/premium-analytics/packages/formatters/src/date/index.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/index.ts
@@ -1,4 +1,4 @@
-export { formatDate, type DateFormatName } from './format-date';
+export { formatDate, formatWallDate, type DateFormatName } from './format-date';
 export { formatDateRange, formatDateRangeCompact } from './format-date-range';
 export { formatDateRangeLong } from './format-date-range-long';
 export {

--- a/projects/packages/premium-analytics/packages/formatters/src/index.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/index.ts
@@ -1,5 +1,6 @@
 export {
 	formatDate,
+	formatWallDate,
 	formatDateRange,
 	formatDateRangeCompact,
 	formatDateRangeLong,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-line/comparative-line-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-line/comparative-line-chart.tsx
@@ -5,6 +5,7 @@ import { LineChart, Stack } from '@jetpack-premium-analytics/externals';
 import {
 	formatDate,
 	formatMetricValue,
+	formatWallDate,
 	type DateFormatName,
 } from '@jetpack-premium-analytics/formatters';
 import { useResizeObserver } from '@wordpress/compose';
@@ -65,6 +66,8 @@ const DEFAULT_MARGIN = { right: 0 };
  * a sparkline (no y-axis, grid, or legend).
  */
 const COMPACT_CHART_HEIGHT = 140;
+
+const DAY_IN_MS = 24 * 60 * 60 * 1000;
 
 /**
  * Applies resolved styles to series data for the internal LineChart.
@@ -193,13 +196,27 @@ export function ComparativeLineChart( {
 	 * @param datum - The data point with date information
 	 * @param index - Index of this entry in the tooltip
 	 */
+	// Sub-daily series (hourly buckets) label tooltip entries with date + time:
+	// a date alone cannot distinguish the 24 points of one day.
+	const isSubDaily = useMemo( () => {
+		const points = series[ 0 ]?.data;
+		return (
+			!! points &&
+			points.length > 1 &&
+			points[ 1 ].date.getTime() - points[ 0 ].date.getTime() < DAY_IN_MS
+		);
+	}, [ series ] );
+
 	const getTooltipLabel = useCallback(
 		( datum: { date: Date; realDate?: Date }, index: number ): string => {
 			const isComparison = index > 0;
 			const displayDate = isComparison ? datum.realDate ?? datum.date : datum.date;
-			return formatDate( displayDate );
+			// Chart dates are wall-clock in the browser frame (the chart library's
+			// convention — see `buildMetricTab`), so render in that same frame; the
+			// site-frame default would shift the label by the browser-to-site offset.
+			return formatWallDate( displayDate, isSubDaily ? 'datetime' : 'medium' );
 		},
-		[]
+		[ isSubDaily ]
 	);
 
 	const renderTooltip = useCallback(
@@ -310,10 +327,11 @@ export function ComparativeLineChart( {
 		const baseOptions = {
 			axis: {
 				x: {
-					// Must stay conditional: `formatDate` defaults to `medium`, so an
-					// unconditional `xTickFormat` would put full site-format dates on every
-					// tick. Without the prop, the chart library's own tick labels stay in use.
-					tickFormat: xTickFormatType ? xTickFormat : undefined,
+					// The key must be OMITTED (not set to undefined) when no format is
+					// requested: LineChart spreads these options over its own defaults,
+					// so an explicit `tickFormat: undefined` would wipe out the library's
+					// span-based formatter and fall through to d3's mixed-format ticks.
+					...( xTickFormatType ? { tickFormat: xTickFormat } : {} ),
 				},
 				y: {
 					tickFormat: yTickFormat,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-line/comparative-line-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-line/comparative-line-chart.tsx
@@ -106,6 +106,8 @@ function applyStylesToSeries(
  */
 type LineChartProps = ComponentProps< typeof LineChart >;
 type RenderTooltipParams = Parameters< NonNullable< LineChartProps[ 'renderTooltip' ] > >[ 0 ];
+type XAxisOptions = NonNullable< NonNullable< LineChartProps[ 'options' ] >[ 'axis' ] >[ 'x' ];
+export type TickResolution = NonNullable< NonNullable< XAxisOptions >[ 'tickResolution' ] >;
 
 /**
  * Props for the ComparativeLineChart component.
@@ -144,6 +146,13 @@ export type ComparativeLineChartProps = {
 	tickFormat?: DateFormatName;
 
 	/**
+	 * Known bucket resolution of the series, passed to the chart's automatic
+	 * tick formatter so it doesn't have to infer it from point spacing.
+	 * Ignored when `tickFormat` is set.
+	 */
+	tickResolution?: TickResolution;
+
+	/**
 	 * Degrade to a sparkline (no y-axis, grid, or legend) when the chart area
 	 * is too short for readable axis labels. Defaults to false.
 	 */
@@ -167,6 +176,7 @@ export function ComparativeLineChart( {
 	className,
 	dataFormat,
 	tickFormat: xTickFormatType,
+	tickResolution,
 	maxWidth = Infinity,
 	compactWhenShort = false,
 }: ComparativeLineChartProps ) {
@@ -332,6 +342,7 @@ export function ComparativeLineChart( {
 					// so an explicit `tickFormat: undefined` would wipe out the library's
 					// span-based formatter and fall through to d3's mixed-format ticks.
 					...( xTickFormatType ? { tickFormat: xTickFormat } : {} ),
+					...( tickResolution ? { tickResolution } : {} ),
 				},
 				y: {
 					tickFormat: yTickFormat,
@@ -361,6 +372,7 @@ export function ComparativeLineChart( {
 	}, [
 		xTickFormat,
 		xTickFormatType,
+		tickResolution,
 		yTickFormat,
 		percentageDomain,
 		isEmptyData,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-line/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-line/index.ts
@@ -1,3 +1,3 @@
 export { ComparativeLineChart } from './comparative-line-chart';
-export type { ComparativeLineChartProps } from './comparative-line-chart';
+export type { ComparativeLineChartProps, TickResolution } from './comparative-line-chart';
 export type { ComparativeLineChartSeries, SeriesStyle } from './types';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/index.ts
@@ -12,6 +12,7 @@ export {
 	WidgetRoot,
 	WidgetRootContext,
 	useWidgetRootContext,
+	useResolvedReportParams,
 	type WidgetRootContextValue,
 } from './widget-root';
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.module.scss
@@ -114,3 +114,16 @@
 	min-width: 0;
 	min-height: 0;
 }
+
+/* Stands in for the chart when the active metric is disabled — its values are
+ * placeholders (see `tabLabel`'s "—"), so plotting them would draw a flat
+ * zero line that reads as real (empty) data instead of "not supported". */
+.disabledChart {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: 100%;
+	min-height: 0;
+	color: var(--wpds-color-foreground-content-neutral-weak);
+	text-align: center;
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
@@ -144,6 +144,14 @@ function MetricChart( {
 	// pattern on the previous-period series.
 	const seriesStyles = useSeriesStyles( series );
 
+	// A disabled metric's `current`/`previous` points are placeholders (e.g. a
+	// hourly bucket the API doesn't support), not real zeros — plotting them
+	// would draw a flat line that reads as "no activity" instead of "not
+	// available". Skip the chart and surface the same explanation as the tab.
+	if ( metric.disabled ) {
+		return <div className={ styles.disabledChart }>{ metric.description }</div>;
+	}
+
 	return (
 		<>
 			<ComparativeLineChart

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
@@ -52,6 +52,8 @@ export interface MetricTab {
 	dataFormat?: DataFormat;
 	/** Optional explanatory text, surfaced as the card's tooltip. */
 	description?: string;
+	/** Unselectable and shown with a placeholder instead of its (e.g. unsupported) value. */
+	disabled?: boolean;
 }
 
 export interface MetricTabsChartProps {
@@ -178,7 +180,9 @@ export function MetricTabsChart( {
 	loading = false,
 	groupLabel = __( 'Select metric', 'jetpack-premium-analytics-pkg' ),
 }: MetricTabsChartProps ) {
-	const [ selectedKey, setSelectedKey ] = useState( defaultMetricKey ?? metrics[ 0 ]?.key );
+	const [ selectedKey, setSelectedKey ] = useState(
+		defaultMetricKey ?? metrics.find( metric => ! metric.disabled )?.key ?? metrics[ 0 ]?.key
+	);
 
 	// Controlled open state: the dashboard's focusable drag-sortable wrapper
 	// closes the popup (reason 'none') right after it opens, so we open on
@@ -220,10 +224,28 @@ export function MetricTabsChart( {
 		[ onMetricChange ]
 	);
 
+	// A metric can flip from enabled to disabled after mount (e.g. the traffic
+	// chart's granularity changes to hourly while a now-unsupported metric was
+	// selected). A disabled tab can't be reselected by the user, so re-select
+	// the first enabled metric rather than leaving the chart stuck on one.
+	useEffect( () => {
+		if ( activeMetric?.disabled ) {
+			const fallback = metrics.find( metric => ! metric.disabled );
+			if ( fallback && fallback.key !== selectedKey ) {
+				handleValueChange( fallback.key );
+			}
+		}
+	}, [ activeMetric, metrics, selectedKey, handleValueChange ] );
+
 	// Memoised: an unstable `items` identity makes the select re-initialise and
 	// close its popup as it opens.
 	const metricItems = useMemo(
-		() => metrics.map( metric => ( { label: metric.label, value: metric.key } ) ),
+		() =>
+			metrics.map( metric => ( {
+				label: metric.label,
+				value: metric.key,
+				disabled: metric.disabled,
+			} ) ),
 		[ metrics ]
 	);
 
@@ -277,13 +299,17 @@ export function MetricTabsChart( {
 								activeMetric && (
 									<span className={ styles.tabContent }>
 										<Text className={ styles.tabLabel }>{ activeMetric.label }</Text>
-										<MetricWithComparison
-											value={ activeMetric.value }
-											previousValue={ activeMetric.previousValue }
-											dataFormat={ activeMetric.dataFormat ?? dataFormat }
-											direction="row"
-											align="flex-end"
-										/>
+										{ activeMetric.disabled ? (
+											<Text className={ styles.tabLabel }>{ '—' }</Text>
+										) : (
+											<MetricWithComparison
+												value={ activeMetric.value }
+												previousValue={ activeMetric.previousValue }
+												dataFormat={ activeMetric.dataFormat ?? dataFormat }
+												direction="row"
+												align="flex-end"
+											/>
+										) }
 									</span>
 								)
 							}
@@ -315,16 +341,21 @@ export function MetricTabsChart( {
 							value={ metric.key }
 							className={ styles.tab }
 							title={ metric.description }
+							disabled={ metric.disabled }
 						>
 							<span className={ styles.tabContent }>
 								<Text className={ styles.tabLabel }>{ metric.label }</Text>
-								<MetricWithComparison
-									value={ metric.value }
-									previousValue={ metric.previousValue }
-									dataFormat={ metric.dataFormat ?? dataFormat }
-									direction="row"
-									align="flex-end"
-								/>
+								{ metric.disabled ? (
+									<Text className={ styles.tabLabel }>{ '—' }</Text>
+								) : (
+									<MetricWithComparison
+										value={ metric.value }
+										previousValue={ metric.previousValue }
+										dataFormat={ metric.dataFormat ?? dataFormat }
+										direction="row"
+										align="flex-end"
+									/>
+								) }
 							</span>
 						</Tabs.Tab>
 					) ) }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
@@ -17,6 +17,7 @@ import { MetricWithComparison } from '../metric-with-comparison';
 import { WidgetLoadingOverlay } from '../widget-loading-overlay';
 import styles from './metric-tabs-chart.module.scss';
 import type { DataFormat } from '../../types';
+import type { TickResolution } from '../chart-comparative-line';
 import type { ComparativeLineChartSeries } from '../chart-comparative-line/types';
 import type { ReactNode } from 'react';
 
@@ -73,6 +74,8 @@ export interface MetricTabsChartProps {
 	loading?: boolean;
 	/** Accessible label for the metric tab list. */
 	groupLabel?: string;
+	/** Known bucket resolution of the series; see `ComparativeLineChartProps`. */
+	tickResolution?: TickResolution;
 }
 
 /**
@@ -139,20 +142,23 @@ function buildSeries( metric: MetricTab ): ComparativeLineChartSeries[] {
  * sparkline (dropping its axis, grid, and legend) on short tiles instead of
  * squashing its labels on top of each other.
  *
- * @param {object}     props            - The component props.
- * @param {MetricTab}  props.metric     - The metric to chart.
- * @param {DataFormat} props.dataFormat - Fallback value/axis format.
- * @param {boolean}    props.loading    - Whether to overlay the loading state.
+ * @param {object}         props                - The component props.
+ * @param {MetricTab}      props.metric         - The metric to chart.
+ * @param {DataFormat}     props.dataFormat     - Fallback value/axis format.
+ * @param {boolean}        props.loading        - Whether to overlay the loading state.
+ * @param {TickResolution} props.tickResolution - Known bucket resolution of the series.
  * @return The chart for the metric.
  */
 function MetricChart( {
 	metric,
 	dataFormat,
 	loading,
+	tickResolution,
 }: {
 	metric: MetricTab;
 	dataFormat: DataFormat;
 	loading: boolean;
+	tickResolution?: TickResolution;
 } ) {
 	const series = useMemo( () => buildSeries( metric ), [ metric ] );
 
@@ -179,6 +185,7 @@ function MetricChart( {
 				series={ series }
 				styles={ seriesStyles }
 				dataFormat={ metric.dataFormat ?? dataFormat }
+				tickResolution={ tickResolution }
 				compactWhenShort
 			/>
 			{ loading && <WidgetLoadingOverlay /> }
@@ -208,6 +215,7 @@ export function MetricTabsChart( {
 	controls,
 	loading = false,
 	groupLabel = __( 'Select metric', 'jetpack-premium-analytics-pkg' ),
+	tickResolution,
 }: MetricTabsChartProps ) {
 	const [ selectedKey, setSelectedKey ] = useState(
 		defaultMetricKey ?? metrics.find( metric => ! metric.disabled )?.key ?? metrics[ 0 ]?.key
@@ -348,7 +356,12 @@ export function MetricTabsChart( {
 				</div>
 				<div className={ styles.chart }>
 					{ activeMetric && (
-						<MetricChart metric={ activeMetric } dataFormat={ dataFormat } loading={ loading } />
+						<MetricChart
+							metric={ activeMetric }
+							dataFormat={ dataFormat }
+							loading={ loading }
+							tickResolution={ tickResolution }
+						/>
 					) }
 				</div>
 			</div>
@@ -395,7 +408,12 @@ export function MetricTabsChart( {
 			     metric's panel renders its chart; the rest stay empty. */ }
 			{ metrics.map( metric => (
 				<Tabs.Panel key={ metric.key } value={ metric.key } className={ styles.chart }>
-					<MetricChart metric={ metric } dataFormat={ dataFormat } loading={ loading } />
+					<MetricChart
+						metric={ metric }
+						dataFormat={ dataFormat }
+						loading={ loading }
+						tickResolution={ tickResolution }
+					/>
 				</Tabs.Panel>
 			) ) }
 		</Tabs.Root>

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
@@ -149,7 +149,11 @@ function MetricChart( {
 	// would draw a flat line that reads as "no activity" instead of "not
 	// available". Skip the chart and surface the same explanation as the tab.
 	if ( metric.disabled ) {
-		return <div className={ styles.disabledChart }>{ metric.description }</div>;
+		return (
+			<div className={ styles.disabledChart }>
+				{ metric.description ?? __( 'Not available', 'jetpack-premium-analytics-pkg' ) }
+			</div>
+		);
 	}
 
 	return (

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
@@ -1,10 +1,12 @@
 /**
  * External dependencies
  */
+import { parseSiteDateTime } from '@jetpack-premium-analytics/datetime';
 import { SelectControl, Tabs, Text } from '@jetpack-premium-analytics/externals';
 import { formatDateRange } from '@jetpack-premium-analytics/formatters';
 import { useResizeObserver } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
+import { format } from 'date-fns';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 /**
  * Internal dependencies
@@ -74,6 +76,19 @@ export interface MetricTabsChartProps {
 }
 
 /**
+ * Re-anchor a chart point's wall-clock date (browser frame, the chart
+ * library's convention — see `buildMetricTab`) into a site-frame instant, so
+ * `formatDateRange` — which renders in the site frame — reproduces the same
+ * wall-clock date.
+ *
+ * @param wall - The wall-clock date.
+ * @return The site-frame instant.
+ */
+function toSiteInstant( wall: Date ): Date {
+	return parseSiteDateTime( format( wall, "yyyy-MM-dd'T'HH:mm:ss" ) ) ?? wall;
+}
+
+/**
  * Format a series' legend label as its date range (first to last point), so the
  * legend reads as date ranges — consistent with the other comparative charts
  * (see `buildTimeSeriesChartData`). The selected card names the metric.
@@ -84,7 +99,9 @@ export interface MetricTabsChartProps {
 function rangeLabel( points: MetricTabDatum[] ): string {
 	const first = points[ 0 ];
 	const last = points[ points.length - 1 ];
-	return first && last ? formatDateRange( { from: first.date, to: last.date } ) : '';
+	return first && last
+		? formatDateRange( { from: toSiteInstant( first.date ), to: toSiteInstant( last.date ) } )
+		: '';
 }
 
 /**

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-root/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-root/index.ts
@@ -1,3 +1,3 @@
-export { WidgetRoot } from './widget-root';
+export { WidgetRoot, useResolvedReportParams } from './widget-root';
 export { WidgetRootContext, useWidgetRootContext } from './context';
 export type { WidgetRootContextValue } from './context';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-root/widget-root.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-root/widget-root.tsx
@@ -82,6 +82,28 @@ function useResolveReportParams( attributes?: Partial< ReportParamsFieldAttribut
 }
 
 /**
+ * Resolved, normalized report params for a widget or its settings fields:
+ * host-provided `attributes.reportParams` when present, the matched route's
+ * search params otherwise. Shared by `WidgetRoot` and attribute Edit controls
+ * that need the dashboard range outside the widget body (e.g. to disable
+ * options the range disallows).
+ *
+ * @param attributes - The widget attributes, possibly carrying `reportParams`.
+ * @return The normalized report params.
+ */
+export function useResolvedReportParams( attributes?: Partial< ReportParamsFieldAttributes > ) {
+	const rawReportParams = useResolveReportParams( attributes );
+
+	const { launchedDate } = getStoreInfo();
+	const defaultPreset = getDefaultPreset( launchedDate );
+
+	return useMemo(
+		() => normalizeReportParams( rawReportParams, defaultPreset ),
+		[ rawReportParams, defaultPreset ]
+	);
+}
+
+/**
  * WidgetRoot
  *
  * A wrapper component that encapsulates all the infrastructure a lazy-loaded
@@ -107,15 +129,7 @@ function useResolveReportParams( attributes?: Partial< ReportParamsFieldAttribut
  */
 export function WidgetRoot( { attributes, children, setError }: WidgetRootProps ) {
 	const chartTheme = useChartTheme();
-	const rawReportParams = useResolveReportParams( attributes );
-
-	const { launchedDate } = getStoreInfo();
-	const defaultPreset = getDefaultPreset( launchedDate );
-
-	const reportParams = useMemo(
-		() => normalizeReportParams( rawReportParams, defaultPreset ),
-		[ rawReportParams, defaultPreset ]
-	);
+	const reportParams = useResolvedReportParams( attributes );
 
 	const contextValue = useMemo( () => ( { reportParams, setError } ), [ reportParams, setError ] );
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/build-metric-tab.test.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/__tests__/build-metric-tab.test.ts
@@ -20,6 +20,29 @@ describe( 'buildMetricTab', () => {
 		expect( tab.value ).toBe( 999 );
 	} );
 
+	it( 'parses date_start as browser-local wall-clock, stripping the nominal +00:00 stamp', () => {
+		const tab = buildMetricTab( {
+			primary: {
+				summary: { views: 3 },
+				data: [
+					{ date_start: '2026-05-01T14:00:00.000+00:00', views: 1 },
+					{ date_start: '2026-05-01 15:00:00', views: 2 },
+				],
+			},
+			comparison: undefined,
+			hasComparison: false,
+			field: 'views',
+			label: 'Views',
+		} );
+
+		// Local getters read the intended wall time regardless of the runner's
+		// timezone — parsing the stamp as a real instant would shift these by
+		// the runner's UTC offset.
+		expect( tab.current[ 0 ].date.getHours() ).toBe( 14 );
+		expect( tab.current[ 0 ].date.getDate() ).toBe( 1 );
+		expect( tab.current[ 1 ].date.getHours() ).toBe( 15 );
+	} );
+
 	it( 'passes dataFormat through unchanged', () => {
 		const dataFormat = { type: 'currency' as const };
 		const tab = buildMetricTab( {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/build-metric-tab.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/build-metric-tab.ts
@@ -1,8 +1,4 @@
 /**
- * External dependencies
- */
-import { localTZDate } from '@jetpack-premium-analytics/data';
-/**
  * Internal dependencies
  */
 import type { MetricTab } from '../components';
@@ -46,6 +42,27 @@ function total( report: MetricReport | undefined, field: string ): number {
 }
 
 /**
+ * Parse a bucket's `date_start` as a wall-clock date in the browser frame —
+ * the chart library's convention (its own parsing treats naive date strings
+ * as local, and its auto axis ticks and time scale operate browser-locally).
+ * Stats buckets label site-local wall-clock stamped with a nominal `+00:00`,
+ * so the stamp is stripped rather than honored: parsing it as a real instant
+ * would shift every bucket by the browser offset — an hourly chart's ticks
+ * and points would read hours (or, across midnight, a day) off.
+ *
+ * @param value - The bucket's `date_start`.
+ * @return The wall-clock date.
+ */
+function toWallClockDate( value: string ): Date {
+	const naive = value
+		.trim()
+		.replace( /(?:Z|[+-]00:?00)$/, '' )
+		.replace( ' ', 'T' );
+
+	return new Date( naive.includes( 'T' ) ? naive : `${ naive }T00:00:00` );
+}
+
+/**
  * Map a field of a normalized report into chart points.
  *
  * @param report - The normalized report, or undefined while loading.
@@ -54,7 +71,7 @@ function total( report: MetricReport | undefined, field: string ): number {
  */
 function toPoints( report: MetricReport | undefined, field: string ) {
 	return ( report?.data ?? [] ).map( point => ( {
-		date: localTZDate( point.date_start ),
+		date: toWallClockDate( point.date_start ),
 		value: Number( ( point as Record< string, unknown > )[ field ] ?? 0 ),
 	} ) );
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -18,6 +18,7 @@ export {
 	WidgetRoot,
 	WidgetRootContext,
 	useWidgetRootContext,
+	useResolvedReportParams,
 	type DonutChartData,
 	type WidgetRootContextValue,
 	type LegendItem,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/mocks/register-report-mocks.ts
@@ -126,6 +126,7 @@ const STATS_API_BASE = '/jetpack-premium-analytics/v1/proxy/v1.1/stats';
  */
 const SPECTRUM_DAYS = 90;
 const DAY_MS = 24 * 60 * 60 * 1000;
+const HOUR_MS = 60 * 60 * 1000;
 
 /**
  * Parameters for dynamic mock data generation.
@@ -867,6 +868,51 @@ function buildSubscribersResponse( query: URLSearchParams ) {
 const VISITS_STEP_DAYS: Record< string, number > = { day: 1, week: 7, month: 30, year: 365 };
 
 /**
+ * Builds the stats/visits hourly response. Mirrors the real `unit=hour`
+ * endpoint: only `views` gets real per-hour numbers, every other requested
+ * field comes back `null` (not zero) — so the traffic chart's disabled-tab
+ * handling has something real to render against in Storybook. The real
+ * endpoint packs date and hour into a single `period` string
+ * (`YYYY-MM-DD HH:mm:ss`) rather than a separate `hour` column — see
+ * `getHourPeriodIntervalFields` in `processing/stats/time-series.ts`.
+ *
+ * @param query - Parsed query params (`date`, `start_date`, `stat_fields`).
+ * @return Raw hourly visits response in the WPCOM matrix shape.
+ */
+function buildHourlyVisitsResponse( query: URLSearchParams ) {
+	const fields = ( query.get( 'stat_fields' ) || 'views,visitors' ).split( ',' );
+	const endDate = parseDateParam( query.get( 'date' ), new Date() );
+	const startDate = parseDateParam(
+		query.get( 'start_date' ),
+		new Date( endDate.getTime() - 23 * HOUR_MS )
+	);
+
+	const spanHours = Math.round( ( endDate.getTime() - startDate.getTime() ) / HOUR_MS );
+	// Bounded well below the API's 1440-hour cap — a story only needs enough
+	// buckets to read as a real hourly chart.
+	const count = Math.max( 1, Math.min( 48, spanHours + 1 ) );
+
+	const rows = Array.from( { length: count }, ( _, index ) => {
+		const bucket = new Date( endDate.getTime() - ( count - 1 - index ) * HOUR_MS );
+		const absHour = Math.floor( bucket.getTime() / HOUR_MS );
+		const wave = 40 * Math.sin( absHour / 4 ) + 20 * Math.cos( absHour / 7 );
+		const views = Math.max( 0, Math.round( 120 + wave ) );
+		const period = `${ bucket.toISOString().slice( 0, 10 ) } ${ String(
+			bucket.getUTCHours()
+		).padStart( 2, '0' ) }:00:00`;
+
+		return [ period, ...fields.map( field => ( field === 'views' ? views : null ) ) ];
+	} );
+
+	return {
+		date: endDate.toISOString().slice( 0, 10 ),
+		unit: 'hour',
+		fields: [ 'period', ...fields ],
+		data: rows,
+	};
+}
+
+/**
  * Builds the stats/visits time-series response for the traffic chart.
  *
  * Honours the `unit`, `date`, `start_date`, and `stat_fields` query params, and
@@ -875,13 +921,19 @@ const VISITS_STEP_DAYS: Record< string, number > = { day: 1, week: 7, month: 30,
  * bucket's absolute date so the current window trends above the comparison
  * window and each metric shows a positive period-over-period delta; the series
  * is wavy so the dashed previous-period overlay reads clearly against the solid
- * current line.
+ * current line. `unit=hour` delegates to `buildHourlyVisitsResponse`, which
+ * mocks the real endpoint's views-only hourly support instead.
  *
  * @param query - Parsed query params (`unit`, `date`, `start_date`, `stat_fields`).
  * @return Raw visits response in the WPCOM matrix shape.
  */
 function buildVisitsResponse( query: URLSearchParams ) {
 	const unit = query.get( 'unit' ) || 'day';
+
+	if ( unit === 'hour' ) {
+		return buildHourlyVisitsResponse( query );
+	}
+
 	const stepDays = VISITS_STEP_DAYS[ unit ] ?? 1;
 	const fields = ( query.get( 'stat_fields' ) || 'views,visitors' ).split( ',' );
 	const endDate = parseDateParam( query.get( 'date' ), new Date() );

--- a/projects/packages/premium-analytics/types/wordpress-jest-console.d.ts
+++ b/projects/packages/premium-analytics/types/wordpress-jest-console.d.ts
@@ -1,0 +1,15 @@
+/**
+ * Matcher declarations for `@wordpress/jest-console` (loaded by the shared
+ * jest setup). The package ships these in its own `declarations.d.ts`, but
+ * that file is not part of this tsconfig's type roots, so the subset used by
+ * tests is declared here.
+ */
+declare namespace jest {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars -- mirrors the upstream interface signature.
+	interface Matchers< R, T > {
+		toHaveErrored(): R;
+		toHaveErroredWith( ...args: unknown[] ): R;
+		toHaveWarned(): R;
+		toHaveWarnedWith( ...args: unknown[] ): R;
+	}
+}

--- a/projects/packages/premium-analytics/widgets/traffic-chart/__tests__/granularity-field.test.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/__tests__/granularity-field.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * External dependencies
+ */
+import { SelectField, type SelectOption } from '@jetpack-premium-analytics/fields';
+import { render } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import GranularityField from '../granularity-field';
+import type { ReportParams } from '@jetpack-premium-analytics/data';
+import type { ComponentProps } from 'react';
+
+jest.mock( '@jetpack-premium-analytics/fields', () => ( {
+	SelectField: jest.fn( () => null ),
+} ) );
+
+const mockSelectField = SelectField as unknown as jest.Mock;
+
+const ELEMENTS: SelectOption[] = [
+	{ value: 'auto', label: 'Auto' },
+	{ value: 'hour', label: 'By hours' },
+	{ value: 'day', label: 'By days' },
+	{ value: 'week', label: 'By weeks' },
+	{ value: 'month', label: 'By months' },
+];
+
+type FieldProp = ComponentProps< typeof GranularityField >[ 'field' ];
+
+function elementsFor( reportParams: ReportParams ): SelectOption[] {
+	// Without a matched route (as in Storybook), the resolver falls back to the
+	// report params carried in the attributes being edited.
+	render(
+		<GranularityField
+			data={ { granularity: 'auto', reportParams } }
+			field={ { id: 'granularity', label: 'Group by', elements: ELEMENTS } as FieldProp }
+			onChange={ jest.fn() }
+		/>
+	);
+
+	// The router-less fallback path warns once per render; that's the path
+	// under test, not a defect.
+	expect( console ).toHaveWarnedWith(
+		'Warning: useRouter must be used inside a <RouterProvider> component!'
+	);
+
+	return mockSelectField.mock.calls.at( -1 )[ 0 ].field.elements;
+}
+
+function disabledValues( elements: SelectOption[] ): string[] {
+	return elements.filter( element => element.disabled ).map( element => String( element.value ) );
+}
+
+describe( 'GranularityField', () => {
+	beforeEach( () => {
+		mockSelectField.mockClear();
+	} );
+
+	it( 'disables the options the range disallows, keeping Auto untouched', () => {
+		const elements = elementsFor( {
+			from: '2026-07-04',
+			to: '2026-08-02',
+			interval: 'day',
+			preset: 'last-30-days',
+		} );
+
+		expect( disabledValues( elements ) ).toEqual( [ 'hour', 'month' ] );
+		expect( elements[ 0 ] ).toEqual( { value: 'auto', label: 'Auto' } );
+	} );
+
+	it( 'enables hourly on a single-day range and disables the coarse options', () => {
+		const elements = elementsFor( {
+			from: '2026-08-02',
+			to: '2026-08-02',
+			interval: 'hour',
+			preset: 'today',
+		} );
+
+		expect( disabledValues( elements ) ).toEqual( [ 'week', 'month' ] );
+	} );
+
+	it( 'leaves only months selectable on a year-long range', () => {
+		const elements = elementsFor( {
+			from: '2025-08-03',
+			to: '2026-08-02',
+			interval: 'month',
+			preset: 'last-12-months',
+		} );
+
+		expect( disabledValues( elements ) ).toEqual( [ 'hour', 'day', 'week' ] );
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/traffic-chart/__tests__/granularity.test.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/__tests__/granularity.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * External dependencies
+ */
+import { renderHook } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import { enabledTrafficPeriods, useTrafficPeriod } from '../granularity';
+import type { ReportParams } from '@jetpack-premium-analytics/data';
+
+function params( overrides: Partial< ReportParams > = {} ): ReportParams {
+	return {
+		from: '2026-06-01',
+		to: '2026-06-30',
+		interval: 'day',
+		preset: 'last-30-days',
+		...overrides,
+	};
+}
+
+describe( 'enabledTrafficPeriods', () => {
+	it( 'narrows to the allowed intervals for the preset', () => {
+		expect( enabledTrafficPeriods( params( { preset: 'today' } ) ) ).toEqual(
+			new Set( [ 'hour', 'day' ] )
+		);
+		expect( enabledTrafficPeriods( params( { preset: 'last-7-days' } ) ) ).toEqual(
+			new Set( [ 'day' ] )
+		);
+		expect( enabledTrafficPeriods( params( { preset: 'last-30-days' } ) ) ).toEqual(
+			new Set( [ 'day', 'week' ] )
+		);
+		expect( enabledTrafficPeriods( params( { preset: 'last-90-days' } ) ) ).toEqual(
+			new Set( [ 'week', 'month' ] )
+		);
+	} );
+
+	it( 'collapses quarter/year onto month, the coarsest offered option', () => {
+		expect( enabledTrafficPeriods( params( { preset: 'last-12-months' } ) ) ).toEqual(
+			new Set( [ 'month' ] )
+		);
+		expect(
+			enabledTrafficPeriods(
+				params( {
+					preset: undefined,
+					from: '2020-01-01T00:00:00.000Z',
+					to: '2026-06-30T23:59:59.999Z',
+				} )
+			)
+		).toEqual( new Set( [ 'month' ] ) );
+	} );
+
+	it( 'derives from range length when the preset is unknown', () => {
+		expect(
+			enabledTrafficPeriods(
+				params( {
+					preset: undefined,
+					from: '2026-06-01T00:00:00.000Z',
+					to: '2026-06-01T23:59:59.999Z',
+				} )
+			)
+		).toEqual( new Set( [ 'hour', 'day' ] ) );
+	} );
+} );
+
+describe( 'useTrafficPeriod', () => {
+	it( 'keeps an explicit granularity the range allows', () => {
+		const setAttributes = jest.fn();
+		const { result } = renderHook( () => useTrafficPeriod( 'week', params(), setAttributes ) );
+
+		expect( result.current ).toBe( 'week' );
+		expect( setAttributes ).not.toHaveBeenCalled();
+	} );
+
+	it( 'falls back to the range default and resets a disallowed granularity', () => {
+		const setAttributes = jest.fn();
+		const { result } = renderHook( () => useTrafficPeriod( 'hour', params(), setAttributes ) );
+
+		expect( result.current ).toBe( 'day' );
+		expect( setAttributes ).toHaveBeenCalledTimes( 1 );
+		expect( setAttributes ).toHaveBeenCalledWith( { granularity: 'auto' } );
+	} );
+
+	it( 'renders as auto without crashing when the host cannot write attributes', () => {
+		const { result } = renderHook( () => useTrafficPeriod( 'hour', params() ) );
+
+		expect( result.current ).toBe( 'day' );
+	} );
+
+	it( 'follows the dashboard interval on auto, including hourly', () => {
+		const setAttributes = jest.fn();
+		const { result: hourlyResult } = renderHook( () =>
+			useTrafficPeriod( 'auto', params( { preset: 'today', interval: 'hour' } ), setAttributes )
+		);
+		const { result: quarterlyResult } = renderHook( () =>
+			useTrafficPeriod(
+				'auto',
+				params( { preset: 'last-12-months', interval: 'quarter' } ),
+				setAttributes
+			)
+		);
+
+		expect( hourlyResult.current ).toBe( 'hour' );
+		expect( quarterlyResult.current ).toBe( 'month' );
+		expect( setAttributes ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/traffic-chart/granularity-field.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/granularity-field.tsx
@@ -1,0 +1,46 @@
+/**
+ * External dependencies
+ */
+import { SelectField, type SelectOption } from '@jetpack-premium-analytics/fields';
+import {
+	useResolvedReportParams,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { useMemo } from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import { enabledTrafficPeriods } from './granularity';
+import type { TrafficPeriod } from './use-traffic-chart';
+import type { ComponentProps } from 'react';
+
+type SelectFieldProps = ComponentProps< typeof SelectField >;
+
+/**
+ * Granularity select that disables the options the dashboard range disallows
+ * (per the range's allowed-intervals rule — e.g. hours beyond a ~2-day range,
+ * days on a year-long range). Auto is always selectable.
+ *
+ * @param {SelectFieldProps} props - The DataForm control props.
+ * @return The select control.
+ */
+export default function GranularityField( props: SelectFieldProps ) {
+	const reportParams = useResolvedReportParams(
+		props.data as Partial< ReportParamsFieldAttributes >
+	);
+	const enabled = useMemo( () => enabledTrafficPeriods( reportParams ), [ reportParams ] );
+
+	const field = useMemo(
+		() => ( {
+			...props.field,
+			elements: props.field.elements?.map( ( element: SelectOption ) =>
+				element.value === 'auto'
+					? element
+					: { ...element, disabled: ! enabled.has( element.value as TrafficPeriod ) }
+			),
+		} ),
+		[ props.field, enabled ]
+	);
+
+	return <SelectField { ...props } field={ field } />;
+}

--- a/projects/packages/premium-analytics/widgets/traffic-chart/granularity.ts
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/granularity.ts
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import { getAllowedIntervalsForPreset, type ReportParams } from '@jetpack-premium-analytics/data';
+import { defaultPeriodForInterval } from '@jetpack-premium-analytics/widgets-toolkit';
+import { useEffect, useMemo } from '@wordpress/element';
+/**
+ * Internal dependencies
+ */
+import type { TrafficPeriod } from './use-traffic-chart';
+import type { TrafficChartAttributes, TrafficChartGranularity } from './widget';
+
+// Ordered finest to coarsest, as `defaultPeriodForInterval` requires.
+const TRAFFIC_PERIODS = [ 'day', 'week', 'month' ] as const satisfies readonly TrafficPeriod[];
+
+/**
+ * Default granularity for the dashboard interval: opens the control at the
+ * granularity the range implies (and, until the user picks one explicitly,
+ * keeps following the range). The dropdown only offers hour/day/week/month,
+ * so a coarser dashboard interval (quarter/year) collapses onto month.
+ *
+ * Hourly is resolved locally rather than via the shared
+ * `defaultPeriodForInterval` helper: its mapping table has no `hour` entry,
+ * and adding one there would flip its "unsupported" fallback toward the
+ * coarsest end for every other widget that doesn't offer hourly (the
+ * helper's clamp only handles "too coarse", not "too fine").
+ *
+ * @param interval - The dashboard-derived interval.
+ * @return The matching selectable granularity.
+ */
+export function resolveAutoPeriod( interval?: string ): TrafficPeriod {
+	return interval === 'hour' ? 'hour' : defaultPeriodForInterval( interval, TRAFFIC_PERIODS );
+}
+
+/**
+ * Group-by granularities selectable for the dashboard range: the range's
+ * allowed intervals (the same rule the date picker resolves `interval` with)
+ * narrowed to the dropdown's options, with intervals coarser than the
+ * dropdown offers (quarter/year) collapsing onto month — mirroring
+ * `resolveAutoPeriod`, so the selectable set always contains what Auto
+ * resolves to.
+ *
+ * @param reportParams - The dashboard report params.
+ * @return The selectable granularities.
+ */
+export function enabledTrafficPeriods( reportParams: ReportParams ): Set< TrafficPeriod > {
+	const allowed = getAllowedIntervalsForPreset(
+		reportParams.preset,
+		reportParams.from,
+		reportParams.to
+	);
+
+	return new Set(
+		allowed.map( interval =>
+			interval === 'quarter' || interval === 'year' ? 'month' : interval
+		)
+	);
+}
+
+/**
+ * Resolve the granularity the chart fetches with. An explicit selection holds
+ * while the range still allows it; once the range disallows it the chart
+ * renders as Auto immediately and the stored attribute is reset to `auto`
+ * (when the host supports writes), so the stored value and the rendered chart
+ * cannot drift apart.
+ *
+ * @param granularity   - The stored granularity attribute.
+ * @param reportParams  - The dashboard report params.
+ * @param setAttributes - Host attribute writer, when available.
+ * @return The granularity to fetch with.
+ */
+export function useTrafficPeriod(
+	granularity: TrafficChartGranularity,
+	reportParams: ReportParams,
+	setAttributes?: ( next: Partial< TrafficChartAttributes > ) => void
+): TrafficPeriod {
+	const enabled = useMemo( () => enabledTrafficPeriods( reportParams ), [ reportParams ] );
+	const isExplicitAllowed = granularity !== 'auto' && enabled.has( granularity );
+
+	useEffect( () => {
+		if ( granularity !== 'auto' && ! enabled.has( granularity ) ) {
+			setAttributes?.( { granularity: 'auto' } );
+		}
+	}, [ granularity, enabled, setAttributes ] );
+
+	return isExplicitAllowed ? granularity : resolveAutoPeriod( reportParams.interval );
+}

--- a/projects/packages/premium-analytics/widgets/traffic-chart/render.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/render.tsx
@@ -131,6 +131,7 @@ function TrafficChartInner( { granularity, metrics, setAttributes }: TrafficChar
 						dataFormat={ DATA_FORMAT }
 						loading
 						groupLabel={ groupLabel }
+						tickResolution={ period }
 					/>
 				}
 			>
@@ -141,6 +142,7 @@ function TrafficChartInner( { granularity, metrics, setAttributes }: TrafficChar
 					dataFormat={ DATA_FORMAT }
 					loading={ isFetching }
 					groupLabel={ groupLabel }
+					tickResolution={ period }
 				/>
 			</WidgetState>
 		</div>

--- a/projects/packages/premium-analytics/widgets/traffic-chart/render.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/render.tsx
@@ -6,7 +6,6 @@ import {
 	WidgetRoot,
 	WidgetState,
 	useWidgetRootContext,
-	defaultPeriodForInterval,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { reports } from '@jetpack-premium-analytics/icons';
@@ -14,8 +13,9 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
+import { useTrafficPeriod } from './granularity';
 import styles from './style.module.css';
-import useTrafficChart, { type TrafficPeriod } from './use-traffic-chart';
+import useTrafficChart from './use-traffic-chart';
 import type {
 	TrafficChartAttributes,
 	TrafficChartGranularity,
@@ -37,28 +37,6 @@ const DATA_FORMAT = {
 	options: { useMultipliers: true, decimals: 0 },
 };
 
-// Ordered finest to coarsest, as `defaultPeriodForInterval` requires.
-const TRAFFIC_PERIODS = [ 'day', 'week', 'month' ] as const satisfies readonly TrafficPeriod[];
-
-/**
- * Default granularity for the dashboard interval: opens the control at the
- * granularity the range implies (and, until the user picks one explicitly,
- * keeps following the range). The dropdown only offers hour/day/week/month,
- * so a coarser dashboard interval (quarter/year) collapses onto month.
- *
- * Hourly is resolved locally rather than via the shared
- * `defaultPeriodForInterval` helper: its mapping table has no `hour` entry,
- * and adding one there would flip its "unsupported" fallback toward the
- * coarsest end for every other widget that doesn't offer hourly (the
- * helper's clamp only handles "too coarse", not "too fine").
- *
- * @param interval - The dashboard-derived interval.
- * @return The matching selectable granularity.
- */
-function resolveAutoPeriod( interval?: string ): TrafficPeriod {
-	return interval === 'hour' ? 'hour' : defaultPeriodForInterval( interval, TRAFFIC_PERIODS );
-}
-
 type TrafficChartInnerProps = {
 	/**
 	 * Selected granularity; `auto` follows the dashboard range.
@@ -68,6 +46,10 @@ type TrafficChartInnerProps = {
 	 * Selected metric tab ids; defaults to every metric.
 	 */
 	metrics?: TrafficChartMetricId[];
+	/**
+	 * Host attribute writer; used to reset a range-disallowed granularity.
+	 */
+	setAttributes?: ( next: Partial< TrafficChartAttributes > ) => void;
 };
 
 /**
@@ -80,14 +62,13 @@ type TrafficChartInnerProps = {
  * @param {TrafficChartInnerProps} props - The component props.
  * @return The widget body.
  */
-function TrafficChartInner( { granularity, metrics }: TrafficChartInnerProps ) {
+function TrafficChartInner( { granularity, metrics, setAttributes }: TrafficChartInnerProps ) {
 	const { reportParams } = useWidgetRootContext();
-	// `auto` means "follow the dashboard range"; an explicit value sticks
-	// across range changes, so a wide range doesn't stay stuck on `day`
-	// granularity (and blow up the bucket count) while the user hasn't picked
-	// a granularity themselves.
-	const period: TrafficPeriod =
-		granularity === 'auto' ? resolveAutoPeriod( reportParams.interval ) : granularity;
+	// `auto` follows the dashboard range; an explicit value sticks while the
+	// range still allows it and resets to `auto` once it doesn't (see
+	// `useTrafficPeriod`), so a range change can never leave the chart
+	// fetching a bucket size the range disallows.
+	const period = useTrafficPeriod( granularity, reportParams, setAttributes );
 
 	const {
 		metrics: metricTabs,
@@ -177,12 +158,20 @@ function TrafficChartInner( { granularity, metrics }: TrafficChartInnerProps ) {
  * @param {TrafficChartWidgetProps} props - The widget render props.
  * @return The rendered widget.
  */
-export default function TrafficChart( { attributes = {}, setError }: TrafficChartWidgetProps ) {
+export default function TrafficChart( {
+	attributes = {},
+	setAttributes,
+	setError,
+}: TrafficChartWidgetProps ) {
 	const granularity = attributes.granularity ?? 'auto';
 
 	return (
 		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
-			<TrafficChartInner granularity={ granularity } metrics={ attributes.metrics } />
+			<TrafficChartInner
+				granularity={ granularity }
+				metrics={ attributes.metrics }
+				setAttributes={ setAttributes }
+			/>
 		</WidgetRoot>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/traffic-chart/render.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/render.tsx
@@ -41,12 +41,16 @@ const DATA_FORMAT = {
 const TRAFFIC_PERIODS = [ 'day', 'week', 'month' ] as const satisfies readonly TrafficPeriod[];
 
 /**
- * Resolves Auto down to hourly for narrow dashboard ranges. The shared
- * `defaultPeriodForInterval` helper's mapping table has no `hour` entry —
- * adding one there would flip its "unsupported" fallback toward the coarsest
- * end for every other widget that doesn't offer hourly (the helper's clamp
- * only handles "too coarse", not "too fine") — so hourly is resolved locally
- * before deferring to the shared helper for everything else.
+ * Default granularity for the dashboard interval: opens the control at the
+ * granularity the range implies (and, until the user picks one explicitly,
+ * keeps following the range). The dropdown only offers hour/day/week/month,
+ * so a coarser dashboard interval (quarter/year) collapses onto month.
+ *
+ * Hourly is resolved locally rather than via the shared
+ * `defaultPeriodForInterval` helper: its mapping table has no `hour` entry,
+ * and adding one there would flip its "unsupported" fallback toward the
+ * coarsest end for every other widget that doesn't offer hourly (the
+ * helper's clamp only handles "too coarse", not "too fine").
  *
  * @param interval - The dashboard-derived interval.
  * @return The matching selectable granularity.
@@ -105,6 +109,16 @@ function TrafficChartInner( { granularity, metrics }: TrafficChartInnerProps ) {
 		);
 	}
 
+	// Disabled tabs (hourly's unsupported metrics) render their own "not available"
+	// placeholder regardless of data, so they're excluded from the empty check —
+	// otherwise a widget configured with only those metrics would show the generic
+	// "no traffic data" message instead of the disabled tabs' explanation. When every
+	// selected metric is disabled there's nothing left to judge emptiness by, so the
+	// widget isn't considered empty and the disabled tabs render instead.
+	const enabledMetrics = metricTabs.filter( metric => ! metric.disabled );
+	const isEmpty =
+		enabledMetrics.length > 0 && enabledMetrics.every( metric => metric.current.length === 0 );
+
 	return (
 		<div className={ styles.root }>
 			<WidgetState
@@ -116,7 +130,7 @@ function TrafficChartInner( { granularity, metrics }: TrafficChartInnerProps ) {
 				// `useTrafficChart` already gates `isError` per query on that query
 				// having no rows, so a transient refetch failure keeps the chart.
 				isError={ isError }
-				isEmpty={ metricTabs.every( metric => metric.current.length === 0 ) }
+				isEmpty={ isEmpty }
 				error={ {
 					description: __(
 						"We couldn't load traffic data. Please try again in a moment.",

--- a/projects/packages/premium-analytics/widgets/traffic-chart/render.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/render.tsx
@@ -40,6 +40,21 @@ const DATA_FORMAT = {
 // Ordered finest to coarsest, as `defaultPeriodForInterval` requires.
 const TRAFFIC_PERIODS = [ 'day', 'week', 'month' ] as const satisfies readonly TrafficPeriod[];
 
+/**
+ * Resolves Auto down to hourly for narrow dashboard ranges. The shared
+ * `defaultPeriodForInterval` helper's mapping table has no `hour` entry —
+ * adding one there would flip its "unsupported" fallback toward the coarsest
+ * end for every other widget that doesn't offer hourly (the helper's clamp
+ * only handles "too coarse", not "too fine") — so hourly is resolved locally
+ * before deferring to the shared helper for everything else.
+ *
+ * @param interval - The dashboard-derived interval.
+ * @return The matching selectable granularity.
+ */
+function resolveAutoPeriod( interval?: string ): TrafficPeriod {
+	return interval === 'hour' ? 'hour' : defaultPeriodForInterval( interval, TRAFFIC_PERIODS );
+}
+
 type TrafficChartInnerProps = {
 	/**
 	 * Selected granularity; `auto` follows the dashboard range.
@@ -68,9 +83,7 @@ function TrafficChartInner( { granularity, metrics }: TrafficChartInnerProps ) {
 	// granularity (and blow up the bucket count) while the user hasn't picked
 	// a granularity themselves.
 	const period: TrafficPeriod =
-		granularity === 'auto'
-			? defaultPeriodForInterval( reportParams.interval, TRAFFIC_PERIODS )
-			: granularity;
+		granularity === 'auto' ? resolveAutoPeriod( reportParams.interval ) : granularity;
 
 	const {
 		metrics: metricTabs,

--- a/projects/packages/premium-analytics/widgets/traffic-chart/stories/traffic-chart-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/stories/traffic-chart-widget.stories.tsx
@@ -104,6 +104,23 @@ export const WithComparison: Story = {
 };
 
 /**
+ * "By hours" granularity: only Views has real hourly data, so Visitors, Likes,
+ * and Comments render disabled with a tooltip instead of a misleading `0`.
+ */
+export const Hourly: Story = {
+	render: () => (
+		<TrafficChartRender
+			attributes={ {
+				reportParams: getDefaultQueryParams( false ),
+				granularity: 'hour',
+				metrics: DEFAULT_TRAFFIC_CHART_METRICS,
+			} }
+		/>
+	),
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
  * First load: both visits fetches are in flight, so the widget shows its loading
  * state (the metric tabs over the chart's loading overlay). The mock is forced
  * to never resolve for the duration of this story. Both of the widget's requests

--- a/projects/packages/premium-analytics/widgets/traffic-chart/use-traffic-chart.ts
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/use-traffic-chart.ts
@@ -79,11 +79,13 @@ export default function useTrafficChart(
 	metricIds: TrafficChartMetricId[] = DEFAULT_TRAFFIC_CHART_METRICS
 ): TrafficChartState {
 	const selected = useMemo( () => new Set( metricIds ), [ metricIds ] );
-	const needsViewsVisitors = selected.has( 'views' ) || selected.has( 'visitors' );
 	// The hourly bucket only returns real numbers for `views` (visitors/likes/comments come
-	// back null per row), so skip the likes/comments request entirely rather than fetch a
-	// response that's guaranteed to be empty for both its fields.
+	// back null per row), so skip a request entirely when it would only serve disabled
+	// metrics — fetching it anyway would waste a call and let a transient failure surface
+	// as the widget's error state instead of the metrics' own disabled placeholder.
 	const isHourly = period === 'hour';
+	const needsViewsVisitors =
+		selected.has( 'views' ) || ( selected.has( 'visitors' ) && ! isHourly );
 	const needsLikesComments =
 		! isHourly && ( selected.has( 'likes' ) || selected.has( 'comments' ) );
 

--- a/projects/packages/premium-analytics/widgets/traffic-chart/use-traffic-chart.ts
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/use-traffic-chart.ts
@@ -10,6 +10,7 @@ import {
 	type StatsVisitsStatFields,
 } from '@jetpack-premium-analytics/data';
 import { useCallback, useMemo } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
@@ -25,7 +26,7 @@ import { buildMetricTab, type MetricTab } from '@jetpack-premium-analytics/widge
  * its `period` (mapped to the visits endpoint's `unit`); the range and
  * comparison stay dashboard-driven.
  */
-export type TrafficPeriod = Extract< StatsPeriod, 'day' | 'week' | 'month' >;
+export type TrafficPeriod = Extract< StatsPeriod, 'hour' | 'day' | 'week' | 'month' >;
 
 /**
  * Normalized traffic chart state: one metric tab per traffic field plus the
@@ -79,7 +80,12 @@ export default function useTrafficChart(
 ): TrafficChartState {
 	const selected = useMemo( () => new Set( metricIds ), [ metricIds ] );
 	const needsViewsVisitors = selected.has( 'views' ) || selected.has( 'visitors' );
-	const needsLikesComments = selected.has( 'likes' ) || selected.has( 'comments' );
+	// The hourly bucket only returns real numbers for `views` (visitors/likes/comments come
+	// back null per row), so skip the likes/comments request entirely rather than fetch a
+	// response that's guaranteed to be empty for both its fields.
+	const isHourly = period === 'hour';
+	const needsLikesComments =
+		! isHourly && ( selected.has( 'likes' ) || selected.has( 'comments' ) );
 
 	// Memoize each request's params (as sibling Stats widgets do) so the query key
 	// is stable across renders.
@@ -103,20 +109,44 @@ export default function useTrafficChart(
 	const lcHasComparison = likesComments.hasComparison;
 
 	// One tab per selected metric, in canonical definition order regardless of
-	// the order the ids were toggled in.
+	// the order the ids were toggled in. Hourly only has real data for `views`;
+	// the other tabs stay visible but disabled with an explanatory tooltip
+	// rather than rendering their (guaranteed-null) values as a misleading 0.
 	const metrics = useMemo(
 		() =>
 			TRAFFIC_CHART_METRICS.filter( metric => selected.has( metric.id ) ).map( metric => {
 				const isViewsVisitors = metric.id === 'views' || metric.id === 'visitors';
-				return buildMetricTab( {
+				const built = buildMetricTab( {
 					primary: isViewsVisitors ? vvPrimary : lcPrimary,
 					comparison: isViewsVisitors ? vvComparison : lcComparison,
 					hasComparison: isViewsVisitors ? vvHasComparison : lcHasComparison,
 					field: metric.id,
 					label: metric.label,
 				} );
+
+				if ( isHourly && metric.id !== 'views' ) {
+					return {
+						...built,
+						disabled: true,
+						description: __(
+							"Hourly data isn't available for this metric.",
+							'jetpack-premium-analytics-pkg'
+						),
+					};
+				}
+
+				return built;
 			} ),
-		[ selected, vvPrimary, vvComparison, vvHasComparison, lcPrimary, lcComparison, lcHasComparison ]
+		[
+			selected,
+			isHourly,
+			vvPrimary,
+			vvComparison,
+			vvHasComparison,
+			lcPrimary,
+			lcComparison,
+			lcHasComparison,
+		]
 	);
 
 	// Depend on the underlying refetch callbacks (each a stable `useReport`

--- a/projects/packages/premium-analytics/widgets/traffic-chart/use-traffic-chart.ts
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/use-traffic-chart.ts
@@ -153,13 +153,20 @@ export default function useTrafficChart(
 
 	// Depend on the underlying refetch callbacks (each a stable `useReport`
 	// `useCallback`), not the fresh result objects, so this stays stable across
-	// renders.
+	// renders. `enabled: false` only stops a query's automatic fetch — calling
+	// its `refetch()` still runs it — so Retry must skip whichever pair was
+	// intentionally disabled for hourly, or it would fire (and could error on)
+	// a request for metrics the UI already shows as unavailable.
 	const { refetch: refetchViewsVisitors } = viewsVisitors;
 	const { refetch: refetchLikesComments } = likesComments;
 	const refetch = useCallback( () => {
-		refetchViewsVisitors();
-		refetchLikesComments();
-	}, [ refetchViewsVisitors, refetchLikesComments ] );
+		if ( needsViewsVisitors ) {
+			refetchViewsVisitors();
+		}
+		if ( needsLikesComments ) {
+			refetchLikesComments();
+		}
+	}, [ needsViewsVisitors, needsLikesComments, refetchViewsVisitors, refetchLikesComments ] );
 
 	// Gate the error per query — the two independent queries back separate tabs, so
 	// one failing on first load must surface an error rather than render as empty

--- a/projects/packages/premium-analytics/widgets/traffic-chart/widget.ts
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/widget.ts
@@ -8,12 +8,14 @@ import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 /**
  * Internal dependencies
  */
-import { ArrayCheckboxField, SelectField } from '@jetpack-premium-analytics/fields';
+import { ArrayCheckboxField } from '@jetpack-premium-analytics/fields';
+import GranularityField from './granularity-field';
 
 /**
  * Granularity the chart can be grouped by. `auto` follows the dashboard date
  * range (a wide range buckets by month, a narrow one by day); an explicit
- * value sticks across range changes.
+ * value sticks across range changes while the range still allows it, and
+ * resets to `auto` once it doesn't.
  */
 export type TrafficChartGranularity = 'auto' | 'hour' | 'day' | 'week' | 'month';
 
@@ -74,7 +76,7 @@ export default {
 			id: 'granularity',
 			label: __( 'Group by', 'jetpack-premium-analytics-pkg' ),
 			type: 'text',
-			Edit: SelectField,
+			Edit: GranularityField,
 			elements: [
 				{
 					label: __( 'Auto', 'jetpack-premium-analytics-pkg' ),

--- a/projects/packages/premium-analytics/widgets/traffic-chart/widget.ts
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/widget.ts
@@ -15,7 +15,7 @@ import { ArrayCheckboxField, SelectField } from '@jetpack-premium-analytics/fiel
  * range (a wide range buckets by month, a narrow one by day); an explicit
  * value sticks across range changes.
  */
-export type TrafficChartGranularity = 'auto' | 'day' | 'week' | 'month';
+export type TrafficChartGranularity = 'auto' | 'hour' | 'day' | 'week' | 'month';
 
 /**
  * The metric tabs the chart can show, in display order: the persisted id and
@@ -79,6 +79,10 @@ export default {
 				{
 					label: __( 'Auto', 'jetpack-premium-analytics-pkg' ),
 					value: 'auto',
+				},
+				{
+					label: __( 'By hours', 'jetpack-premium-analytics-pkg' ),
+					value: 'hour',
 				},
 				{
 					label: __( 'By days', 'jetpack-premium-analytics-pkg' ),


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/WOOA7S-1834/add-hourly-stats-to-the-traffic-chart

## Why
The Traffic widget's chart couldn't show hourly stats — the "Group by" dropdown only offered Auto/By days/By weeks/By months, so a site owner looking at a single day of traffic had no way to see hour-by-hour activity, and the dashboard's own automatic hourly interval (already computed for narrow date ranges) was silently coarsened to daily by the widget.

## Proposed changes
* Add a "By hours" option to the Traffic widget's Group-by dropdown, positioned between Auto and By days
* Auto now follows the dashboard's automatic interval down to hourly for narrow ranges (e.g. "Last 24 hours", "Today") instead of coarsening it to daily; an explicit widget-level selection stays scoped to the widget and never writes back to the dashboard's shared date-range state
* WPCOM's `stats/visits` endpoint only returns real numbers for Views at the hourly grain — Visitors/Likes/Comments come back `null` — so those three tabs render disabled with an explanatory tooltip ("Hourly data isn't available for this metric.") instead of a misleading `0`, their chart shows the same explanation instead of a flat zero line, and their network request is skipped entirely rather than fetching data guaranteed to be empty
* Fix the hourly time-series parser: the real endpoint packs date and hour into a single `period` string (`YYYY-MM-DD HH:mm:ss`) rather than a separate `hour` column like the email timeline uses, which the existing parser didn't handle and which crashed the chart on real hourly data (found while testing against the live proxy, not from the issue description)
* Add `disabled` support to the shared `MetricTabsChart` component (also used by the subscribers chart) so a metric tab can be shown but marked unavailable
* Gate every Group-by option by the dashboard's allowed-intervals rule for the selected range — the same rule the date picker resolves its automatic interval with — so the dropdown can never disagree with what Auto resolves to (e.g. "By hours" is disabled on a 30-day range, "By days" on a 12-month range; quarter/year ranges collapse onto "By months", the dropdown's coarsest option). Auto is always selectable
* Reset a stored Group-by selection to Auto when a date-range change disallows it (e.g. "By hours" picked on "Last 24 hours", then range widened to 30 days), so the stored attribute and the rendered chart can't drift apart and the chart never fetches a bucket size the range disallows
* Make the chart's date axis and tooltips follow the grouping: fix `ComparativeLineChart` wiping the chart library's span-based auto tick formatter with an explicit `tickFormat: undefined`, anchor Stats buckets as wall-clock dates in the frame the chart library expects (their nominal `+00:00` stamp previously shifted labels by the viewer's UTC offset), and teach the library's auto formatter to pick ticks by bucket resolution as well as span (the chart-library formatter change is split out as #51010, which this PR is based on) — hour ticks (with the date at midnight boundaries) for sub-daily series, dates for days/weeks, months (with the year at January) for monthly buckets. Hourly tooltips include the hour

## Related product discussion/links
* Builds on #51010 (merged) — the chart-library tick-formatter change extracted from this PR
* Based on #51017 (which stacks on #51013) — the widget now declares its Group-by selection to the chart as `tickResolution`, so tick formats come from the known granularity instead of being inferred from point spacing; those must merge first
* https://linear.app/a8c/issue/WOOA7S-1834/add-hourly-stats-to-the-traffic-chart

## Does this pull request change what data or activity we track or use?
No. This surfaces existing hourly buckets from the `stats/visits` endpoint that were already being fetched at coarser granularity; no new data is tracked or requested beyond what the dropdown already requested for day/week/month.

## Testing instructions

* Go to the Premium Analytics dashboard (`wp-admin/admin.php?page=jetpack-premium-analytics`), add the Traffic widget if it isn't already on the dashboard
* Open the widget's "Group by" dropdown — confirm "By hours" now appears between "Auto" and "By days"
* Select "By hours" — confirm the chart re-renders with hourly buckets for Views, and Visitors/Likes/Comments render greyed out with a "—" placeholder and an explanatory tooltip instead of a `0`
* Switch the dashboard's date range to "Last 24 hours" (or "Today") with the widget's Group-by left on "Auto" — confirm it also renders hourly without touching the dropdown, since the dashboard's own automatic interval is now respected
* Change the widget's Group-by back to "By days" — confirm the dashboard's date-range picker and any other widget are unaffected (the selection stays scoped to this widget, not promoted to the page)
* In the widget's "Metrics" control, select only Visitors (or only Likes/Comments) while hourly is active — confirm the disabled tab/placeholder still renders correctly instead of a generic "no traffic data" empty state or an error
* With "Last 30 days" selected, open the Group-by dropdown — confirm "By hours" and "By months" are disabled while Auto/By days/By weeks stay selectable; switch to "Last 12 months" — confirm only Auto and "By months" are selectable
* Select "By hours" on "Last 24 hours", then switch the range to "Last 30 days" — confirm the widget resets to Auto (day buckets) rather than staying stuck on a disallowed hourly selection
* With "Last 24 hours" selected, check the chart's x-axis — confirm it shows hour markers (e.g. `6 AM · 12 PM · 6 PM`, with the date at midnight when the window crosses midnight) rather than one or two day labels, and that hovering a point shows the date and hour in the tooltip
* Check "Last 30 days" shows uniform day ticks and "Last 12 months" shows month ticks with the year at January

## Screenshots
![Group-by dropdown gains "By hours"; hourly-selected state shows Views live with Visitors/Likes/Comments disabled](https://github.com/user-attachments/assets/b96c8622-73df-4aa1-a9cb-fba9ba59c99c)




