### PR TITLE
Search: honor jetpack_instant_search_options across all experiences

### DIFF
--- a/projects/packages/search/changelog/fix-search-highlight-options-all-experiences
+++ b/projects/packages/search/changelog/fix-search-highlight-options-all-experiences
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search: Honor highlightPhraseOnly, highlightFilterStopwords, adminQueryFilter, customResults, highlightFields, and additionalBlogIds Instant Search options in Embedded, Overlay Blocks, and Theme search experiences.

--- a/projects/packages/search/src/class-helper.php
+++ b/projects/packages/search/src/class-helper.php
@@ -1032,8 +1032,13 @@ class Helper {
 	 *               `additionalBlogIds`, `adminQueryFilter`, and `customResults`.
 	 */
 	public static function parse_instant_search_query_options( array $options ): array {
+		$highlight_phrase_only = ! empty( $options['highlightPhraseOnly'] );
+
+		// The v1.3 API rejects requests combining `highlight_filter_stopwords` with
+		// `highlight_phrase_only` (phrase-only wins server-side) — drop the stopword
+		// list so requests stay valid when a filter sets both.
 		$stopwords = array();
-		if ( ! empty( $options['highlightFilterStopwords'] ) && is_array( $options['highlightFilterStopwords'] ) ) {
+		if ( ! $highlight_phrase_only && ! empty( $options['highlightFilterStopwords'] ) && is_array( $options['highlightFilterStopwords'] ) ) {
 			$stopwords = array_values(
 				array_filter(
 					$options['highlightFilterStopwords'],
@@ -1088,7 +1093,7 @@ class Helper {
 		}
 
 		return array(
-			'highlightPhraseOnly'      => ! empty( $options['highlightPhraseOnly'] ),
+			'highlightPhraseOnly'      => $highlight_phrase_only,
 			'highlightFilterStopwords' => $stopwords,
 			'highlightFields'          => $highlight_fields,
 			'additionalBlogIds'        => $additional_blog_ids,

--- a/projects/packages/search/src/class-helper.php
+++ b/projects/packages/search/src/class-helper.php
@@ -1112,9 +1112,7 @@ class Helper {
 	 * }
 	 */
 	public static function get_instant_search_query_options(): array {
-		$options = function_exists( 'apply_filters' )
-			? apply_filters( 'jetpack_instant_search_options', array() )
-			: array();
+		$options = apply_filters( 'jetpack_instant_search_options', array() );
 		if ( ! is_array( $options ) ) {
 			$options = array();
 		}

--- a/projects/packages/search/src/class-helper.php
+++ b/projects/packages/search/src/class-helper.php
@@ -1007,6 +1007,216 @@ class Helper {
 	}
 
 	/**
+	 * Default highlight fields when `highlightFields` is unset in
+	 * `jetpack_instant_search_options`. Matches instant search's JS default.
+	 */
+	const DEFAULT_INSTANT_SEARCH_HIGHLIGHT_FIELDS = array( 'title', 'content', 'comments' );
+
+	/**
+	 * Fields added to API `fields` when searching additional blogs.
+	 */
+	const MULTISITE_SEARCH_FIELD_NAMES = array( 'author', 'blog_name', 'blog_icon_url', 'blog_id' );
+
+	/**
+	 * Read Instant Search query-customization options from a filtered options array.
+	 *
+	 * @param array $options Raw `jetpack_instant_search_options` value.
+	 * @return array{
+	 *     highlightPhraseOnly: bool,
+	 *     highlightFilterStopwords: array<int, string>,
+	 *     highlightFields: array<int, string>|null,
+	 *     additionalBlogIds: array<int, int|string>,
+	 *     adminQueryFilter: array<string, mixed>|null,
+	 *     customResults: array<int, array{pattern: string, ids: array<int, int|string>}>,
+	 * }
+	 */
+	public static function parse_instant_search_query_options( array $options ): array {
+		$stopwords = array();
+		if ( ! empty( $options['highlightFilterStopwords'] ) && is_array( $options['highlightFilterStopwords'] ) ) {
+			$stopwords = array_values(
+				array_filter(
+					$options['highlightFilterStopwords'],
+					static function ( $word ) {
+						return is_string( $word ) && '' !== $word;
+					}
+				)
+			);
+		}
+
+		$highlight_fields = null;
+		if ( ! empty( $options['highlightFields'] ) && is_array( $options['highlightFields'] ) ) {
+			$highlight_fields = array_values(
+				array_filter(
+					$options['highlightFields'],
+					static function ( $field ) {
+						return is_string( $field ) && '' !== $field;
+					}
+				)
+			);
+			if ( array() === $highlight_fields ) {
+				$highlight_fields = null;
+			}
+		}
+
+		$additional_blog_ids = array();
+		if ( ! empty( $options['additionalBlogIds'] ) && is_array( $options['additionalBlogIds'] ) ) {
+			$additional_blog_ids = array_values( $options['additionalBlogIds'] );
+		}
+
+		$admin_query_filter = null;
+		if ( ! empty( $options['adminQueryFilter'] ) && is_array( $options['adminQueryFilter'] ) ) {
+			$admin_query_filter = $options['adminQueryFilter'];
+		}
+
+		$custom_results = array();
+		if ( ! empty( $options['customResults'] ) && is_array( $options['customResults'] ) ) {
+			foreach ( $options['customResults'] as $rule ) {
+				if ( ! is_array( $rule ) ) {
+					continue;
+				}
+				$pattern = isset( $rule['pattern'] ) && is_string( $rule['pattern'] ) ? $rule['pattern'] : '';
+				$ids     = isset( $rule['ids'] ) && is_array( $rule['ids'] ) ? array_values( $rule['ids'] ) : array();
+				if ( '' === $pattern || array() === $ids ) {
+					continue;
+				}
+				$custom_results[] = array(
+					'pattern' => $pattern,
+					'ids'     => $ids,
+				);
+			}
+		}
+
+		return array(
+			'highlightPhraseOnly'      => ! empty( $options['highlightPhraseOnly'] ),
+			'highlightFilterStopwords' => $stopwords,
+			'highlightFields'          => $highlight_fields,
+			'additionalBlogIds'        => $additional_blog_ids,
+			'adminQueryFilter'         => $admin_query_filter,
+			'customResults'            => $custom_results,
+		);
+	}
+
+	/**
+	 * Read Instant Search query-customization options via `jetpack_instant_search_options`.
+	 *
+	 * Passing an empty array into the filter matches `Filter_Static::read_raw_entries()`
+	 * — callbacks only add keys.
+	 *
+	 * @return array{
+	 *     highlightPhraseOnly: bool,
+	 *     highlightFilterStopwords: array<int, string>,
+	 *     highlightFields: array<int, string>|null,
+	 *     additionalBlogIds: array<int, int|string>,
+	 *     adminQueryFilter: array<string, mixed>|null,
+	 *     customResults: array<int, array{pattern: string, ids: array<int, int|string>}>,
+	 * }
+	 */
+	public static function get_instant_search_query_options(): array {
+		$options = function_exists( 'apply_filters' )
+			? apply_filters( 'jetpack_instant_search_options', array() )
+			: array();
+		if ( ! is_array( $options ) ) {
+			$options = array();
+		}
+
+		return self::parse_instant_search_query_options( $options );
+	}
+
+	/**
+	 * Merge Instant Search query-customization options into v1.3 API args.
+	 *
+	 * Shared by Inline Search (Theme) and any server-side v1.3 callers.
+	 *
+	 * @param array      $api_query_args API query arguments.
+	 * @param array|null $options        Filtered `jetpack_instant_search_options` value. Defaults to `generate_initial_javascript_state()`.
+	 * @return array
+	 */
+	public static function apply_instant_search_query_options_to_api_args( array $api_query_args, ?array $options = null ): array {
+		if ( null === $options ) {
+			$options = self::generate_initial_javascript_state();
+		}
+		if ( ! is_array( $options ) ) {
+			return $api_query_args;
+		}
+
+		$query_options = self::parse_instant_search_query_options( $options );
+
+		if ( null !== $query_options['adminQueryFilter'] ) {
+			$api_query_args['filter'] = array(
+				'bool' => array(
+					'filter' => $api_query_args['filter'] ?? array(),
+					'must'   => $query_options['adminQueryFilter'],
+				),
+			);
+		}
+
+		if ( $query_options['highlightPhraseOnly'] ) {
+			$api_query_args['highlight_phrase_only'] = true;
+		}
+
+		if ( ! empty( $query_options['highlightFilterStopwords'] ) ) {
+			$api_query_args['highlight_filter_stopwords'] = $query_options['highlightFilterStopwords'];
+		}
+
+		if ( null !== $query_options['highlightFields'] ) {
+			$api_query_args['highlight_fields'] = $query_options['highlightFields'];
+			$api_query_args['highlight']        = array(
+				'fields' => $query_options['highlightFields'],
+			);
+		}
+
+		if ( ! empty( $query_options['additionalBlogIds'] ) ) {
+			$api_query_args['additional_blog_ids'] = $query_options['additionalBlogIds'];
+			$fields                                = isset( $api_query_args['fields'] ) && is_array( $api_query_args['fields'] )
+				? $api_query_args['fields']
+				: array();
+			$api_query_args['fields']              = array_values(
+				array_unique( array_merge( $fields, self::MULTISITE_SEARCH_FIELD_NAMES ) )
+			);
+		}
+
+		$matched_custom_results = self::resolve_instant_search_custom_results(
+			(string) ( $api_query_args['query'] ?? '' ),
+			$query_options['customResults']
+		);
+		if ( null !== $matched_custom_results ) {
+			$api_query_args['custom_results'] = $matched_custom_results;
+		}
+
+		return $api_query_args;
+	}
+
+	/**
+	 * Resolve `customResults` post IDs for a search query.
+	 *
+	 * Mirrors instant search's exact / `regex:` pattern matching.
+	 *
+	 * @param string $query          Current search query.
+	 * @param array  $custom_results Normalized custom-results rules.
+	 * @return array<int, int|string>|null
+	 */
+	public static function resolve_instant_search_custom_results( string $query, array $custom_results ): ?array {
+		if ( array() === $custom_results ) {
+			return null;
+		}
+
+		foreach ( $custom_results as $rule ) {
+			$pattern = $rule['pattern'];
+			$ids     = $rule['ids'];
+			if ( 0 === strpos( $pattern, 'regex:' ) ) {
+				$regex = '/^' . substr( $pattern, strlen( 'regex:' ) ) . '$/';
+				if ( @preg_match( $regex, $query ) ) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Invalid user regex should be skipped, not fatal.
+					return $ids;
+				}
+			} elseif ( $query === $pattern ) {
+				return $ids;
+			}
+		}
+
+		return null;
+	}
+
+	/**
 	 * Returns true if the site is a WordPress.com simple site, i.e. the code runs on WPCOM.
 	 */
 	public static function is_wpcom() {

--- a/projects/packages/search/src/class-helper.php
+++ b/projects/packages/search/src/class-helper.php
@@ -1021,14 +1021,9 @@ class Helper {
 	 * Read Instant Search query-customization options from a filtered options array.
 	 *
 	 * @param array $options Raw `jetpack_instant_search_options` value.
-	 * @return array{
-	 *     highlightPhraseOnly: bool,
-	 *     highlightFilterStopwords: array<int, string>,
-	 *     highlightFields: array<int, string>|null,
-	 *     additionalBlogIds: array<int, int|string>,
-	 *     adminQueryFilter: array<string, mixed>|null,
-	 *     customResults: array<int, array{pattern: string, ids: array<int, int|string>}>,
-	 * }
+	 * @return array Query options with keys:
+	 *               `highlightPhraseOnly`, `highlightFilterStopwords`, `highlightFields`,
+	 *               `additionalBlogIds`, `adminQueryFilter`, and `customResults`.
 	 */
 	public static function parse_instant_search_query_options( array $options ): array {
 		$stopwords = array();
@@ -1102,14 +1097,9 @@ class Helper {
 	 * Passing an empty array into the filter matches `Filter_Static::read_raw_entries()`
 	 * — callbacks only add keys.
 	 *
-	 * @return array{
-	 *     highlightPhraseOnly: bool,
-	 *     highlightFilterStopwords: array<int, string>,
-	 *     highlightFields: array<int, string>|null,
-	 *     additionalBlogIds: array<int, int|string>,
-	 *     adminQueryFilter: array<string, mixed>|null,
-	 *     customResults: array<int, array{pattern: string, ids: array<int, int|string>}>,
-	 * }
+	 * @return array Query options with keys:
+	 *               `highlightPhraseOnly`, `highlightFilterStopwords`, `highlightFields`,
+	 *               `additionalBlogIds`, `adminQueryFilter`, and `customResults`.
 	 */
 	public static function get_instant_search_query_options(): array {
 		$options = apply_filters( 'jetpack_instant_search_options', array() );

--- a/projects/packages/search/src/class-helper.php
+++ b/projects/packages/search/src/class-helper.php
@@ -1009,16 +1009,22 @@ class Helper {
 	/**
 	 * Default highlight fields when `highlightFields` is unset in
 	 * `jetpack_instant_search_options`. Matches instant search's JS default.
+	 *
+	 * @since $$next-version$$
 	 */
 	const DEFAULT_INSTANT_SEARCH_HIGHLIGHT_FIELDS = array( 'title', 'content', 'comments' );
 
 	/**
 	 * Fields added to API `fields` when searching additional blogs.
+	 *
+	 * @since $$next-version$$
 	 */
 	const MULTISITE_SEARCH_FIELD_NAMES = array( 'author', 'blog_name', 'blog_icon_url', 'blog_id' );
 
 	/**
 	 * Read Instant Search query-customization options from a filtered options array.
+	 *
+	 * @since $$next-version$$
 	 *
 	 * @param array $options Raw `jetpack_instant_search_options` value.
 	 * @return array Query options with keys:
@@ -1097,6 +1103,8 @@ class Helper {
 	 * Passing an empty array into the filter matches `Filter_Static::read_raw_entries()`
 	 * — callbacks only add keys.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @return array Query options with keys:
 	 *               `highlightPhraseOnly`, `highlightFilterStopwords`, `highlightFields`,
 	 *               `additionalBlogIds`, `adminQueryFilter`, and `customResults`.
@@ -1114,6 +1122,8 @@ class Helper {
 	 * Merge Instant Search query-customization options into v1.3 API args.
 	 *
 	 * Shared by Inline Search (Theme) and any server-side v1.3 callers.
+	 *
+	 * @since $$next-version$$
 	 *
 	 * @param array      $api_query_args API query arguments.
 	 * @param array|null $options        Filtered `jetpack_instant_search_options` value. Defaults to `generate_initial_javascript_state()`.
@@ -1179,6 +1189,8 @@ class Helper {
 	 *
 	 * Mirrors instant search's exact / `regex:` pattern matching.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @param string $query          Current search query.
 	 * @param array  $custom_results Normalized custom-results rules.
 	 * @return array<int, int|string>|null
@@ -1192,7 +1204,8 @@ class Helper {
 			$pattern = $rule['pattern'];
 			$ids     = $rule['ids'];
 			if ( 0 === strpos( $pattern, 'regex:' ) ) {
-				$regex = '/^' . substr( $pattern, strlen( 'regex:' ) ) . '$/';
+				// Escape the delimiter so patterns containing `/` (e.g. `regex:docs/.*`) stay valid PCRE.
+				$regex = '/^' . str_replace( '/', '\/', substr( $pattern, strlen( 'regex:' ) ) ) . '$/';
 				if ( @preg_match( $regex, $query ) ) { // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- Invalid user regex should be skipped, not fatal.
 					return $ids;
 				}

--- a/projects/packages/search/src/inline-search/class-inline-search.php
+++ b/projects/packages/search/src/inline-search/class-inline-search.php
@@ -352,11 +352,7 @@ class Inline_Search extends Classic_Search {
 			}
 		}
 
-		$highlight_fields = array(
-			'title',
-			'content',
-			'comments',
-		);
+		$highlight_fields = Helper::DEFAULT_INSTANT_SEARCH_HIGHLIGHT_FIELDS;
 
 		$fields = array(
 			'blog_id',

--- a/projects/packages/search/src/inline-search/class-inline-search.php
+++ b/projects/packages/search/src/inline-search/class-inline-search.php
@@ -229,6 +229,14 @@ class Inline_Search extends Classic_Search {
 			'post_id',
 		);
 
+		if ( ! empty( $api_query_args['additional_blog_ids'] ) ) {
+			$api_query_args['fields'] = array_values(
+				array_unique(
+					array_merge( $api_query_args['fields'], Helper::MULTISITE_SEARCH_FIELD_NAMES )
+				)
+			);
+		}
+
 		// Do the actual search query!
 		$this->search_result = $this->search( $api_query_args );
 
@@ -466,27 +474,7 @@ class Inline_Search extends Classic_Search {
 	 * @return array
 	 */
 	private function trigger_instant_search_query_args_filter( array $api_query_args ): array {
-		// this will trigger jetpack_instant_search_options filter
-		$options = Helper::generate_initial_javascript_state();
-
-		if ( isset( $options['adminQueryFilter'] ) ) {
-			$api_query_args['filter'] = array(
-				'bool' => array(
-					'filter' => $api_query_args['filter'],
-					'must'   => $options['adminQueryFilter'],
-				),
-			);
-		}
-
-		if ( ! empty( $options['highlightPhraseOnly'] ) ) {
-			$api_query_args['highlight_phrase_only'] = true;
-		}
-
-		if ( ! empty( $options['highlightFilterStopwords'] ) && is_array( $options['highlightFilterStopwords'] ) ) {
-			$api_query_args['highlight_filter_stopwords'] = array_values( $options['highlightFilterStopwords'] );
-		}
-
-		return $api_query_args;
+		return Helper::apply_instant_search_query_options_to_api_args( $api_query_args );
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -2227,6 +2227,7 @@ HTML;
 		$price_range               = static::parse_url_price_range();
 		$is_initial_loading        = static::is_initial_loading();
 		$searching_text            = function_exists( '__' ) ? __( 'Searching…', 'jetpack-search-pkg' ) : 'Searching…';
+		$query_options             = static::get_instant_search_query_options();
 
 		return array(
 			// Connection / routing config.
@@ -2296,7 +2297,33 @@ HTML;
 			'aiExtendedLoadingHints'     => static::build_ai_extended_loading_hints(),
 
 			'wcStockStatusLabels'        => static::build_stock_status_labels(),
+
+			// Query customization from `jetpack_instant_search_options` — same
+			// keys Instant Search / Inline Search honor, so Embedded and the
+			// blocks Overlay stay compatible with those filters.
+			'highlightPhraseOnly'        => $query_options['highlightPhraseOnly'],
+			'highlightFilterStopwords'   => $query_options['highlightFilterStopwords'],
+			'highlightFields'            => $query_options['highlightFields'],
+			'additionalBlogIds'          => $query_options['additionalBlogIds'],
+			'adminQueryFilter'           => $query_options['adminQueryFilter'],
+			'customResults'              => $query_options['customResults'],
 		);
+	}
+
+	/**
+	 * Read Instant Search query-customization options for the blocks store.
+	 *
+	 * @return array{
+	 *     highlightPhraseOnly: bool,
+	 *     highlightFilterStopwords: array<int, string>,
+	 *     highlightFields: array<int, string>|null,
+	 *     additionalBlogIds: array<int, int|string>,
+	 *     adminQueryFilter: array<string, mixed>|null,
+	 *     customResults: array<int, array{pattern: string, ids: array<int, int|string>}>,
+	 * }
+	 */
+	public static function get_instant_search_query_options(): array {
+		return Helper::get_instant_search_query_options();
 	}
 
 	/**

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -2313,14 +2313,9 @@ HTML;
 	/**
 	 * Read Instant Search query-customization options for the blocks store.
 	 *
-	 * @return array{
-	 *     highlightPhraseOnly: bool,
-	 *     highlightFilterStopwords: array<int, string>,
-	 *     highlightFields: array<int, string>|null,
-	 *     additionalBlogIds: array<int, int|string>,
-	 *     adminQueryFilter: array<string, mixed>|null,
-	 *     customResults: array<int, array{pattern: string, ids: array<int, int|string>}>,
-	 * }
+	 * @return array Query options with keys:
+	 *               `highlightPhraseOnly`, `highlightFilterStopwords`, `highlightFields`,
+	 *               `additionalBlogIds`, `adminQueryFilter`, and `customResults`.
 	 */
 	public static function get_instant_search_query_options(): array {
 		return Helper::get_instant_search_query_options();

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -2313,6 +2313,8 @@ HTML;
 	/**
 	 * Read Instant Search query-customization options for the blocks store.
 	 *
+	 * @since $$next-version$$
+	 *
 	 * @return array Query options with keys:
 	 *               `highlightPhraseOnly`, `highlightFilterStopwords`, `highlightFields`,
 	 *               `additionalBlogIds`, `adminQueryFilter`, and `customResults`.

--- a/projects/packages/search/src/search-blocks/store/api.js
+++ b/projects/packages/search/src/search-blocks/store/api.js
@@ -507,7 +507,14 @@ export function resolveCustomResults( searchQuery, customResults ) {
 		let pattern = rule.pattern;
 		if ( pattern.startsWith( 'regex:' ) ) {
 			pattern = '^' + pattern.replace( 'regex:', '' ) + '$';
-			if ( query.match( pattern ) ) {
+			let matches;
+			try {
+				matches = query.match( pattern );
+			} catch {
+				// Invalid regex is skipped, not fatal — matches the PHP helper.
+				continue;
+			}
+			if ( matches ) {
 				return rule.ids;
 			}
 		} else if ( query === pattern ) {

--- a/projects/packages/search/src/search-blocks/store/api.js
+++ b/projects/packages/search/src/search-blocks/store/api.js
@@ -488,24 +488,60 @@ export function buildStaticPostTypeClauses( staticPostTypes ) {
 }
 
 /**
+ * Resolve `custom_results` post IDs for the current query.
+ * Mirrors Instant Search's exact / `regex:` pattern matching.
+ *
+ * @param {string} searchQuery   - Current search query.
+ * @param {Array}  customResults - `{ pattern, ids }[]` from Instant Search options.
+ * @return {Array|null} Matching post IDs, or null when none apply.
+ */
+export function resolveCustomResults( searchQuery, customResults ) {
+	if ( ! Array.isArray( customResults ) || customResults.length === 0 ) {
+		return null;
+	}
+	const query = searchQuery || '';
+	for ( const rule of customResults ) {
+		if ( ! rule || typeof rule.pattern !== 'string' || ! Array.isArray( rule.ids ) ) {
+			continue;
+		}
+		let pattern = rule.pattern;
+		if ( pattern.startsWith( 'regex:' ) ) {
+			pattern = '^' + pattern.replace( 'regex:', '' ) + '$';
+			if ( query.match( pattern ) ) {
+				return rule.ids;
+			}
+		} else if ( query === pattern ) {
+			return rule.ids;
+		}
+	}
+	return null;
+}
+
+/**
  * Build the full search API URL. Mirrors the 3-path routing in
  * `src/instant-search/lib/api.js`.
  *
- * @param {object}      opts                          - Options.
- * @param {number}      opts.siteId                   - Site ID.
- * @param {string}      opts.searchQuery              - Query string.
- * @param {string}      opts.sortOrder                - Sort key (Woo adds rating_desc/price_*).
- * @param {string|null} opts.pageHandle               - Pagination cursor.
- * @param {boolean}     opts.isPrivateSite            - Private site flag.
- * @param {boolean}     opts.isWpcom                  - WPCOM flag.
- * @param {string}      opts.apiRoot                  - WP REST API root.
- * @param {object}      [opts.activeFilters]          - { [filterKey]: string[] }.
- * @param {object}      [opts.filterConfigs]          - { [filterKey]: FilterConfig }.
- * @param {string}      [opts.homeUrl]                - Required for private WPcom sites.
- * @param {object|null} [opts.priceRange]             - `{ min, max }` against `wc.price`.
- * @param {object|null} [opts.staticPostTypes]        - `{include, exclude}` page-level scope from search-results.
- * @param {object}      [opts.staticFilterSelections] - { [filterKey]: string } static-filter values.
- * @param {number}      [opts.size]                   - Results per page, resolved server-side from `search-results`' `resultsPerPage`.
+ * @param {object}               opts                            - Options.
+ * @param {number}               opts.siteId                     - Site ID.
+ * @param {string}               opts.searchQuery                - Query string.
+ * @param {string}               opts.sortOrder                  - Sort key (Woo adds rating_desc/price_*).
+ * @param {string|null}          opts.pageHandle                 - Pagination cursor.
+ * @param {boolean}              opts.isPrivateSite              - Private site flag.
+ * @param {boolean}              opts.isWpcom                    - WPCOM flag.
+ * @param {string}               opts.apiRoot                    - WP REST API root.
+ * @param {object}               [opts.activeFilters]            - { [filterKey]: string[] }.
+ * @param {object}               [opts.filterConfigs]            - { [filterKey]: FilterConfig }.
+ * @param {string}               [opts.homeUrl]                  - Required for private WPcom sites.
+ * @param {object|null}          [opts.priceRange]               - `{ min, max }` against `wc.price`.
+ * @param {object|null}          [opts.staticPostTypes]          - `{include, exclude}` page-level scope from search-results.
+ * @param {object}               [opts.staticFilterSelections]   - { [filterKey]: string } static-filter values.
+ * @param {number}               [opts.size]                     - Results per page, resolved server-side from `search-results`' `resultsPerPage`.
+ * @param {boolean}              [opts.highlightPhraseOnly]      - Forward `highlight_phrase_only` from Instant Search options.
+ * @param {string[]}             [opts.highlightFilterStopwords] - Forward `highlight_filter_stopwords` from Instant Search options.
+ * @param {string[]|null}        [opts.highlightFields]          - Override default `highlight_fields` from Instant Search options.
+ * @param {Array<number|string>} [opts.additionalBlogIds]        - Forward `additional_blog_ids` from Instant Search options.
+ * @param {object|null}          [opts.adminQueryFilter]         - Extra ES clause from Instant Search options.
+ * @param {Array}                [opts.customResults]            - `{ pattern, ids }[]` from Instant Search options.
  * @return {string} Full URL.
  */
 export function buildSearchUrl( {
@@ -523,6 +559,12 @@ export function buildSearchUrl( {
 	staticPostTypes = null,
 	staticFilterSelections = {},
 	size = 10,
+	highlightPhraseOnly = false,
+	highlightFilterStopwords = [],
+	highlightFields = null,
+	additionalBlogIds = [],
+	adminQueryFilter = null,
+	customResults = [],
 } ) {
 	// `qss.encode()` encodes every value, so we pass the raw query. The
 	// overlay double-encodes; v1.3 tolerates it today but breaks on `&`/`+`/non-ASCII.
@@ -530,8 +572,11 @@ export function buildSearchUrl( {
 		query: searchQuery || '',
 		sort: mapSortToApiValue( sortOrder ),
 		size,
-		fields: SEARCH_FIELDS,
-		highlight_fields: HIGHLIGHT_FIELDS,
+		fields: [ ...SEARCH_FIELDS ],
+		highlight_fields:
+			Array.isArray( highlightFields ) && highlightFields.length > 0
+				? highlightFields
+				: HIGHLIGHT_FIELDS,
 	};
 
 	const aggregations = buildAggregations( filterConfigs );
@@ -568,8 +613,33 @@ export function buildSearchUrl( {
 			? { bool: { must: [ ...filter.bool.must, rangeClause ] } }
 			: { bool: { must: [ rangeClause ] } };
 	}
+	if ( adminQueryFilter ) {
+		filter = filter
+			? { bool: { must: [ ...filter.bool.must, adminQueryFilter ] } }
+			: { bool: { must: [ adminQueryFilter ] } };
+	}
 	if ( filter ) {
 		params.filter = filter;
+	}
+
+	if ( highlightPhraseOnly ) {
+		params.highlight_phrase_only = true;
+	}
+
+	if ( Array.isArray( highlightFilterStopwords ) && highlightFilterStopwords.length > 0 ) {
+		params.highlight_filter_stopwords = highlightFilterStopwords;
+	}
+
+	if ( Array.isArray( additionalBlogIds ) && additionalBlogIds.length > 0 ) {
+		params.additional_blog_ids = additionalBlogIds;
+		params.fields = [
+			...new Set( [ ...params.fields, 'author', 'blog_name', 'blog_icon_url', 'blog_id' ] ),
+		];
+	}
+
+	const matchedCustomResults = resolveCustomResults( searchQuery, customResults );
+	if ( matchedCustomResults ) {
+		params.custom_results = matchedCustomResults;
 	}
 
 	if ( pageHandle ) {

--- a/projects/packages/search/src/search-blocks/store/index.js
+++ b/projects/packages/search/src/search-blocks/store/index.js
@@ -492,6 +492,14 @@ function* fetchResults( pageHandle ) {
 		// so a same-keyed default in the `store()` state object would be applied
 		// *after* and clobber the seeded value back down every time.
 		size: state.resultsPerPage ?? 10,
+		// Instant Search options seeded by Search_Blocks — no client defaults
+		// so a missing seed stays unset rather than overriding PHP.
+		highlightPhraseOnly: state.highlightPhraseOnly ?? false,
+		highlightFilterStopwords: state.highlightFilterStopwords ?? [],
+		highlightFields: state.highlightFields ?? null,
+		additionalBlogIds: state.additionalBlogIds ?? [],
+		adminQueryFilter: state.adminQueryFilter ?? null,
+		customResults: state.customResults ?? [],
 	} );
 	const response = yield fetch( url, {
 		headers: state.isPrivateSite ? { 'X-WP-Nonce': state.nonce } : {},

--- a/projects/packages/search/tests/js/search-blocks/api.test.js
+++ b/projects/packages/search/tests/js/search-blocks/api.test.js
@@ -1283,6 +1283,17 @@ describe( 'buildSearchUrl: Instant Search query options', () => {
 		expect( decodeURIComponent( url ) ).toContain( 'highlight_fields[1]=content' );
 	} );
 
+	it( 'falls back to default highlight fields when highlightFields is empty', () => {
+		const url = buildSearchUrl( { ...baseOpts, highlightFields: [] } );
+		expect( decodeURIComponent( url ) ).toContain( 'highlight_fields[0]=title' );
+		expect( decodeURIComponent( url ) ).toContain( 'highlight_fields[1]=content' );
+	} );
+
+	it( 'omits highlight_filter_stopwords when not an array', () => {
+		const url = buildSearchUrl( { ...baseOpts, highlightFilterStopwords: 'the' } );
+		expect( url ).not.toContain( 'highlight_filter_stopwords' );
+	} );
+
 	it( 'includes additional_blog_ids and multisite fields when additionalBlogIds is set', () => {
 		const url = buildSearchUrl( {
 			...baseOpts,
@@ -1294,6 +1305,11 @@ describe( 'buildSearchUrl: Instant Search query options', () => {
 		expect( decoded ).toContain( 'fields' );
 		expect( decoded ).toContain( 'blog_name' );
 		expect( decoded ).toContain( 'blog_id' );
+	} );
+
+	it( 'omits additional_blog_ids when not an array', () => {
+		const url = buildSearchUrl( { ...baseOpts, additionalBlogIds: 123 } );
+		expect( url ).not.toContain( 'additional_blog_ids' );
 	} );
 } );
 
@@ -1310,5 +1326,28 @@ describe( 'resolveCustomResults', () => {
 				{ pattern: 'hello', ids: [ 2 ] },
 			] )
 		).toEqual( [ 1 ] );
+	} );
+
+	it( 'skips invalid rules and treats a falsy query as empty string', () => {
+		expect(
+			resolveCustomResults( null, [
+				null,
+				{ pattern: 123, ids: [ 1 ] },
+				{ pattern: 'hello', ids: 'not-array' },
+				{ pattern: '', ids: [ 5 ] },
+			] )
+		).toEqual( [ 5 ] );
+	} );
+
+	it( 'returns null when regex rules do not match', () => {
+		expect(
+			resolveCustomResults( 'nope', [ { pattern: 'regex:^hello.*', ids: [ 9 ] } ] )
+		).toBeNull();
+	} );
+
+	it( 'matches regex: patterns', () => {
+		expect(
+			resolveCustomResults( 'hello world', [ { pattern: 'regex:hello.*', ids: [ 99 ] } ] )
+		).toEqual( [ 99 ] );
 	} );
 } );

--- a/projects/packages/search/tests/js/search-blocks/api.test.js
+++ b/projects/packages/search/tests/js/search-blocks/api.test.js
@@ -8,6 +8,7 @@ import {
 	buildStaticFilterClauses,
 	buildStaticPostTypeClauses,
 	formatDateBucketLabel,
+	resolveCustomResults,
 	resolveFilterFields,
 } from '../../../src/search-blocks/store/api';
 
@@ -1181,5 +1182,133 @@ describe( 'buildSearchUrl: static filter selections', () => {
 		const decoded = decodeURIComponent( url );
 		expect( decoded ).toContain( 'filter[bool][must][0][term][category.slug]=news' );
 		expect( decoded ).toContain( 'filter[bool][must][1][term][section]=guides' );
+	} );
+} );
+
+describe( 'buildSearchUrl: Instant Search query options', () => {
+	const baseOpts = {
+		siteId: 1,
+		searchQuery: 'the search',
+		sortOrder: 'relevance',
+		pageHandle: null,
+		isPrivateSite: false,
+		isWpcom: false,
+		apiRoot: '',
+	};
+
+	it( 'includes highlight_phrase_only when highlightPhraseOnly is true', () => {
+		const url = buildSearchUrl( { ...baseOpts, highlightPhraseOnly: true } );
+		expect( url ).toContain( 'highlight_phrase_only=true' );
+	} );
+
+	it( 'omits highlight_phrase_only when highlightPhraseOnly is false', () => {
+		const url = buildSearchUrl( { ...baseOpts, highlightPhraseOnly: false } );
+		expect( url ).not.toContain( 'highlight_phrase_only' );
+	} );
+
+	it( 'includes highlight_filter_stopwords when set', () => {
+		const url = buildSearchUrl( {
+			...baseOpts,
+			highlightFilterStopwords: [ 'the', 'a' ],
+		} );
+		expect( decodeURIComponent( url ) ).toContain( 'highlight_filter_stopwords[0]=the' );
+		expect( decodeURIComponent( url ) ).toContain( 'highlight_filter_stopwords[1]=a' );
+	} );
+
+	it( 'omits highlight_filter_stopwords when empty', () => {
+		const url = buildSearchUrl( { ...baseOpts, highlightFilterStopwords: [] } );
+		expect( url ).not.toContain( 'highlight_filter_stopwords' );
+	} );
+
+	it( 'folds adminQueryFilter into bool.must', () => {
+		const url = buildSearchUrl( {
+			...baseOpts,
+			adminQueryFilter: { term: { post_type: 'post' } },
+		} );
+		expect( decodeURIComponent( url ) ).toContain( 'filter[bool][must][0][term][post_type]=post' );
+	} );
+
+	it( 'combines adminQueryFilter with active filters under one bool.must', () => {
+		const url = buildSearchUrl( {
+			...baseOpts,
+			activeFilters: { category: [ 'news' ] },
+			filterConfigs: { category: { filterType: 'taxonomy', taxonomy: 'category' } },
+			adminQueryFilter: { term: { post_type: 'post' } },
+		} );
+		const decoded = decodeURIComponent( url );
+		expect( decoded ).toContain( 'filter[bool][must][0][term][category.slug]=news' );
+		expect( decoded ).toContain( 'filter[bool][must][1][term][post_type]=post' );
+	} );
+
+	it( 'includes custom_results when query exactly matches a pattern', () => {
+		const url = buildSearchUrl( {
+			...baseOpts,
+			searchQuery: 'hello',
+			customResults: [ { pattern: 'hello', ids: [ 11, 22 ] } ],
+		} );
+		expect( decodeURIComponent( url ) ).toContain( 'custom_results[0]=11' );
+		expect( decodeURIComponent( url ) ).toContain( 'custom_results[1]=22' );
+	} );
+
+	it( 'includes custom_results when query matches a regex: pattern', () => {
+		const url = buildSearchUrl( {
+			...baseOpts,
+			searchQuery: 'hello world',
+			customResults: [ { pattern: 'regex:hello.*', ids: [ 99 ] } ],
+		} );
+		expect( decodeURIComponent( url ) ).toContain( 'custom_results[0]=99' );
+	} );
+
+	it( 'omits custom_results when no pattern matches', () => {
+		const url = buildSearchUrl( {
+			...baseOpts,
+			searchQuery: 'nope',
+			customResults: [ { pattern: 'hello', ids: [ 11 ] } ],
+		} );
+		expect( url ).not.toContain( 'custom_results' );
+	} );
+
+	it( 'uses highlightFields when set', () => {
+		const url = buildSearchUrl( {
+			...baseOpts,
+			highlightFields: [ 'title', 'comments' ],
+		} );
+		expect( decodeURIComponent( url ) ).toContain( 'highlight_fields[0]=title' );
+		expect( decodeURIComponent( url ) ).toContain( 'highlight_fields[1]=comments' );
+	} );
+
+	it( 'falls back to default highlight fields when highlightFields is null', () => {
+		const url = buildSearchUrl( { ...baseOpts, highlightFields: null } );
+		expect( decodeURIComponent( url ) ).toContain( 'highlight_fields[0]=title' );
+		expect( decodeURIComponent( url ) ).toContain( 'highlight_fields[1]=content' );
+	} );
+
+	it( 'includes additional_blog_ids and multisite fields when additionalBlogIds is set', () => {
+		const url = buildSearchUrl( {
+			...baseOpts,
+			additionalBlogIds: [ 123, 456 ],
+		} );
+		const decoded = decodeURIComponent( url );
+		expect( decoded ).toContain( 'additional_blog_ids[0]=123' );
+		expect( decoded ).toContain( 'additional_blog_ids[1]=456' );
+		expect( decoded ).toContain( 'fields' );
+		expect( decoded ).toContain( 'blog_name' );
+		expect( decoded ).toContain( 'blog_id' );
+	} );
+} );
+
+describe( 'resolveCustomResults', () => {
+	it( 'returns null for empty rules', () => {
+		expect( resolveCustomResults( 'hello', [] ) ).toBeNull();
+		expect( resolveCustomResults( 'hello', null ) ).toBeNull();
+	} );
+
+	it( 'matches exact patterns before later rules', () => {
+		expect(
+			resolveCustomResults( 'hello', [
+				{ pattern: 'hello', ids: [ 1 ] },
+				{ pattern: 'hello', ids: [ 2 ] },
+			] )
+		).toEqual( [ 1 ] );
 	} );
 } );

--- a/projects/packages/search/tests/js/search-blocks/api.test.js
+++ b/projects/packages/search/tests/js/search-blocks/api.test.js
@@ -1350,4 +1350,13 @@ describe( 'resolveCustomResults', () => {
 			resolveCustomResults( 'hello world', [ { pattern: 'regex:hello.*', ids: [ 99 ] } ] )
 		).toEqual( [ 99 ] );
 	} );
+
+	it( 'skips invalid regex: patterns instead of throwing', () => {
+		expect(
+			resolveCustomResults( 'hello', [
+				{ pattern: 'regex:[invalid', ids: [ 1 ] },
+				{ pattern: 'hello', ids: [ 2 ] },
+			] )
+		).toEqual( [ 2 ] );
+	} );
 } );

--- a/projects/packages/search/tests/php/Helpers_Test.php
+++ b/projects/packages/search/tests/php/Helpers_Test.php
@@ -1902,6 +1902,10 @@ class Helpers_Test extends TestCase {
 		$callback = static function () {
 			return 'not-an-array';
 		};
+		$options  = array(
+			'highlightPhraseOnly' => false,
+			'customResults'       => array(),
+		);
 		add_filter( 'jetpack_instant_search_options', $callback );
 		try {
 			$options = Helper::get_instant_search_query_options();

--- a/projects/packages/search/tests/php/Helpers_Test.php
+++ b/projects/packages/search/tests/php/Helpers_Test.php
@@ -1855,4 +1855,150 @@ class Helpers_Test extends TestCase {
 		$this->assertTrue( $found_pa_size, 'Should have pa_size attribute (was in included_attributes)' );
 		$this->assertFalse( $found_pa_material, 'Should NOT have pa_material attribute (was NOT in included_attributes)' );
 	}
+
+	/**
+	 * Test that parse_instant_search_query_options normalizes empty / invalid option values.
+	 */
+	public function test_parse_instant_search_query_options_edge_cases() {
+		$parsed = Helper::parse_instant_search_query_options(
+			array(
+				'highlightFields'     => array( '', '' ),
+				'customResults'       => array(
+					'not-an-array',
+					array(
+						'pattern' => 'hello',
+						'ids'     => array( 1 ),
+					),
+					array(
+						'pattern' => '',
+						'ids'     => array( 2 ),
+					),
+					array(
+						'pattern' => 'missing-ids',
+						'ids'     => array(),
+					),
+				),
+				'highlightPhraseOnly' => false,
+			)
+		);
+
+		$this->assertNull( $parsed['highlightFields'] );
+		$this->assertSame(
+			array(
+				array(
+					'pattern' => 'hello',
+					'ids'     => array( 1 ),
+				),
+			),
+			$parsed['customResults']
+		);
+		$this->assertFalse( $parsed['highlightPhraseOnly'] );
+	}
+
+	/**
+	 * Test that get_instant_search_query_options ignores a non-array filter return.
+	 */
+	public function test_get_instant_search_query_options_non_array_filter() {
+		$callback = static function () {
+			return 'not-an-array';
+		};
+		add_filter( 'jetpack_instant_search_options', $callback );
+		try {
+			$options = Helper::get_instant_search_query_options();
+		} finally {
+			remove_filter( 'jetpack_instant_search_options', $callback );
+		}
+
+		$this->assertFalse( $options['highlightPhraseOnly'] );
+		$this->assertSame( array(), $options['customResults'] );
+	}
+
+	/**
+	 * Test apply_instant_search_query_options_to_api_args for regex customResults,
+	 * missing fields, and a non-array options filter when options are loaded via generate.
+	 */
+	public function test_apply_instant_search_query_options_to_api_args_edge_cases() {
+		$with_regex = Helper::apply_instant_search_query_options_to_api_args(
+			array(
+				'query' => 'hello world',
+			),
+			array(
+				'customResults'     => array(
+					array(
+						'pattern' => 'regex:hello.*',
+						'ids'     => array( 99 ),
+					),
+				),
+				'additionalBlogIds' => array( 7 ),
+			)
+		);
+		$this->assertSame( array( 99 ), $with_regex['custom_results'] );
+		$this->assertSame( array( 7 ), $with_regex['additional_blog_ids'] );
+		$this->assertSame(
+			Helper::MULTISITE_SEARCH_FIELD_NAMES,
+			$with_regex['fields']
+		);
+
+		$no_match = Helper::apply_instant_search_query_options_to_api_args(
+			array( 'query' => 'nope' ),
+			array(
+				'customResults' => array(
+					array(
+						'pattern' => 'hello',
+						'ids'     => array( 1 ),
+					),
+					array(
+						'pattern' => 'regex:^world$',
+						'ids'     => array( 2 ),
+					),
+				),
+			)
+		);
+		$this->assertArrayNotHasKey( 'custom_results', $no_match );
+
+		$callback = static function () {
+			return 'not-an-array';
+		};
+		add_filter( 'jetpack_instant_search_options', $callback );
+		try {
+			$passthrough = Helper::apply_instant_search_query_options_to_api_args(
+				array( 'query' => 'keep-me' )
+			);
+		} finally {
+			remove_filter( 'jetpack_instant_search_options', $callback );
+		}
+		$this->assertSame( array( 'query' => 'keep-me' ), $passthrough );
+	}
+
+	/**
+	 * Test that resolve_instant_search_custom_results matches exact and regex: patterns.
+	 */
+	public function test_resolve_instant_search_custom_results() {
+		$rules = array(
+			array(
+				'pattern' => 'exact',
+				'ids'     => array( 1 ),
+			),
+			array(
+				'pattern' => 'regex:^hello.*',
+				'ids'     => array( 2, 3 ),
+			),
+		);
+
+		$this->assertNull( Helper::resolve_instant_search_custom_results( 'x', array() ) );
+		$this->assertSame( array( 1 ), Helper::resolve_instant_search_custom_results( 'exact', $rules ) );
+		$this->assertSame( array( 2, 3 ), Helper::resolve_instant_search_custom_results( 'hello there', $rules ) );
+		$this->assertNull( Helper::resolve_instant_search_custom_results( 'nope', $rules ) );
+		$this->assertNull(
+			Helper::resolve_instant_search_custom_results(
+				'hello',
+				array(
+					array(
+						'pattern' => 'regex:[invalid',
+						'ids'     => array( 9 ),
+					),
+				)
+			)
+		);
+	}
 }

--- a/projects/packages/search/tests/php/Helpers_Test.php
+++ b/projects/packages/search/tests/php/Helpers_Test.php
@@ -2004,5 +2004,18 @@ class Helpers_Test extends TestCase {
 				)
 			)
 		);
+		$this->assertSame(
+			array( 4 ),
+			Helper::resolve_instant_search_custom_results(
+				'docs/getting-started',
+				array(
+					array(
+						'pattern' => 'regex:docs/.*',
+						'ids'     => array( 4 ),
+					),
+				)
+			),
+			'Patterns containing the PCRE delimiter should still match.'
+		);
 	}
 }

--- a/projects/packages/search/tests/php/Helpers_Test.php
+++ b/projects/packages/search/tests/php/Helpers_Test.php
@@ -1896,6 +1896,31 @@ class Helpers_Test extends TestCase {
 	}
 
 	/**
+	 * Test that stopwords drop when combined with highlightPhraseOnly — the v1.3 API
+	 * rejects requests carrying both.
+	 */
+	public function test_parse_instant_search_query_options_phrase_only_wins_over_stopwords() {
+		$parsed = Helper::parse_instant_search_query_options(
+			array(
+				'highlightPhraseOnly'      => true,
+				'highlightFilterStopwords' => array( 'the', 'a' ),
+			)
+		);
+
+		$this->assertTrue( $parsed['highlightPhraseOnly'] );
+		$this->assertSame( array(), $parsed['highlightFilterStopwords'] );
+
+		$parsed = Helper::parse_instant_search_query_options(
+			array(
+				'highlightFilterStopwords' => array( 'the', 'a' ),
+			)
+		);
+
+		$this->assertFalse( $parsed['highlightPhraseOnly'] );
+		$this->assertSame( array( 'the', 'a' ), $parsed['highlightFilterStopwords'] );
+	}
+
+	/**
 	 * Test that get_instant_search_query_options ignores a non-array filter return.
 	 */
 	public function test_get_instant_search_query_options_non_array_filter() {

--- a/projects/packages/search/tests/php/Inline_Search_Filters_Test.php
+++ b/projects/packages/search/tests/php/Inline_Search_Filters_Test.php
@@ -498,6 +498,130 @@ class Inline_Search_Filters_Test extends TestCase {
 					'highlight_filter_stopwords' => array( 'the', 'a' ),
 				),
 			),
+			'custom_results'             => array(
+				'wp_query_args'     => array(
+					's'              => 'hello',
+					'posts_per_page' => 5,
+					'post_type'      => 'any',
+				),
+				'is_opt_filter'     => function ( $options ) {
+					$options['customResults'] = array(
+						array(
+							'pattern' => 'hello',
+							'ids'     => array( 11, 22 ),
+						),
+					);
+
+					return $options;
+				},
+				'expected_api_args' => array(
+					'size'             => '5',
+					'from'             => '0',
+					'fields'           => array( 'post_id' ),
+					'query'            => 'hello',
+					'sort'             => 'score_recency',
+					'langs'            => array( 'en_US' ),
+					'filter'           => array(
+						'bool' => array(
+							'must' => array(
+								array(
+									'terms' => array(
+										'post_type' => array(
+											'post',
+											'page',
+											'attachment',
+										),
+									),
+								),
+							),
+						),
+					),
+					'highlight_fields' => array( 'title', 'content', 'comments' ),
+					'highlight'        => array(
+						'fields' => array( 'title', 'content', 'comments' ),
+					),
+					'custom_results'   => array( 11, 22 ),
+				),
+			),
+			'highlight_fields'           => array(
+				'wp_query_args'     => array(
+					's'              => 'hello',
+					'posts_per_page' => 5,
+					'post_type'      => 'any',
+				),
+				'is_opt_filter'     => function ( $options ) {
+					$options['highlightFields'] = array( 'title', 'comments' );
+
+					return $options;
+				},
+				'expected_api_args' => array(
+					'size'             => '5',
+					'from'             => '0',
+					'fields'           => array( 'post_id' ),
+					'query'            => 'hello',
+					'sort'             => 'score_recency',
+					'langs'            => array( 'en_US' ),
+					'filter'           => array(
+						'bool' => array(
+							'must' => array(
+								array(
+									'terms' => array(
+										'post_type' => array(
+											'post',
+											'page',
+											'attachment',
+										),
+									),
+								),
+							),
+						),
+					),
+					'highlight_fields' => array( 'title', 'comments' ),
+					'highlight'        => array(
+						'fields' => array( 'title', 'comments' ),
+					),
+				),
+			),
+			'additional_blog_ids'        => array(
+				'wp_query_args'     => array(
+					's'              => 'hello',
+					'posts_per_page' => 5,
+					'post_type'      => 'any',
+				),
+				'is_opt_filter'     => function ( $options ) {
+					$options['additionalBlogIds'] = array( 123, 456 );
+
+					return $options;
+				},
+				'expected_api_args' => array(
+					'size'                => '5',
+					'from'                => '0',
+					'fields'              => array( 'post_id', 'author', 'blog_name', 'blog_icon_url', 'blog_id' ),
+					'query'               => 'hello',
+					'sort'                => 'score_recency',
+					'langs'               => array( 'en_US' ),
+					'filter'              => array(
+						'bool' => array(
+							'must' => array(
+								array(
+									'terms' => array(
+										'post_type' => array(
+											'post',
+											'page',
+											'attachment',
+										),
+									),
+								),
+							),
+						),
+					),
+					'highlight_fields'    => array( 'title', 'content', 'comments' ),
+					'highlight'           => array(
+						'fields' => array( 'title', 'content', 'comments' ),
+					),
+					'additional_blog_ids' => array( 123, 456 ),
+				),
+			),
 		);
 	}
 

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -3213,6 +3213,14 @@ class Search_Blocks_Test extends TestCase {
 			);
 			return $options;
 		};
+		$options  = array(
+			'highlightPhraseOnly'      => false,
+			'highlightFilterStopwords' => array(),
+			'highlightFields'          => null,
+			'additionalBlogIds'        => array(),
+			'adminQueryFilter'         => null,
+			'customResults'            => array(),
+		);
 		add_filter( 'jetpack_instant_search_options', $callback );
 		try {
 			$options = Search_Blocks::get_instant_search_query_options();
@@ -3260,6 +3268,14 @@ class Search_Blocks_Test extends TestCase {
 			);
 			return $options;
 		};
+		$state    = array(
+			'highlightPhraseOnly'      => false,
+			'highlightFilterStopwords' => array(),
+			'highlightFields'          => null,
+			'additionalBlogIds'        => array(),
+			'adminQueryFilter'         => null,
+			'customResults'            => array(),
+		);
 		add_filter( 'jetpack_instant_search_options', $callback );
 		try {
 			$state = Search_Blocks::build_initial_state();

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -3229,7 +3229,8 @@ class Search_Blocks_Test extends TestCase {
 		}
 
 		$this->assertTrue( $options['highlightPhraseOnly'] );
-		$this->assertSame( array( 'the', 'a' ), $options['highlightFilterStopwords'] );
+		// Stopwords drop when combined with phrase-only — the API rejects both together.
+		$this->assertSame( array(), $options['highlightFilterStopwords'] );
 		$this->assertSame( array( 'title' ), $options['highlightFields'] );
 		$this->assertSame( array( 123, 456 ), $options['additionalBlogIds'] );
 		$this->assertSame(
@@ -3253,7 +3254,7 @@ class Search_Blocks_Test extends TestCase {
 	 */
 	public function test_build_initial_state_seeds_instant_search_query_options() {
 		$callback = static function ( $options ) {
-			$options['highlightPhraseOnly']      = true;
+			// Stopwords only — combining with phrase-only would drop them (API constraint).
 			$options['highlightFilterStopwords'] = array( 'the' );
 			$options['highlightFields']          = array( 'title', 'content' );
 			$options['additionalBlogIds']        = array( 99 );
@@ -3283,7 +3284,7 @@ class Search_Blocks_Test extends TestCase {
 			remove_filter( 'jetpack_instant_search_options', $callback );
 		}
 
-		$this->assertTrue( $state['highlightPhraseOnly'] );
+		$this->assertFalse( $state['highlightPhraseOnly'] );
 		$this->assertSame( array( 'the' ), $state['highlightFilterStopwords'] );
 		$this->assertSame( array( 'title', 'content' ), $state['highlightFields'] );
 		$this->assertSame( array( 99 ), $state['additionalBlogIds'] );

--- a/projects/packages/search/tests/php/Search_Blocks_Test.php
+++ b/projects/packages/search/tests/php/Search_Blocks_Test.php
@@ -3175,6 +3175,118 @@ class Search_Blocks_Test extends TestCase {
 	}
 
 	/**
+	 * Instant Search query-customization options seed into the blocks store
+	 * so Embedded / Overlay Blocks honor the same `jetpack_instant_search_options`
+	 * filter as Instant Search and Inline Search.
+	 */
+	public function test_get_instant_search_query_options_defaults() {
+		$options = Search_Blocks::get_instant_search_query_options();
+		$this->assertFalse( $options['highlightPhraseOnly'] );
+		$this->assertSame( array(), $options['highlightFilterStopwords'] );
+		$this->assertNull( $options['highlightFields'] );
+		$this->assertSame( array(), $options['additionalBlogIds'] );
+		$this->assertNull( $options['adminQueryFilter'] );
+		$this->assertSame( array(), $options['customResults'] );
+	}
+
+	/**
+	 * Highlight + admin filter + customResults keys from the Instant Search
+	 * options filter round-trip into the helper used by the seed.
+	 */
+	public function test_get_instant_search_query_options_reads_filter() {
+		$callback = static function ( $options ) {
+			$options['highlightPhraseOnly']      = true;
+			$options['highlightFilterStopwords'] = array( 'the', 'a', '' );
+			$options['highlightFields']          = array( 'title', '' );
+			$options['additionalBlogIds']        = array( 123, 456 );
+			$options['adminQueryFilter']         = array(
+				'term' => array( 'post_type' => 'post' ),
+			);
+			$options['customResults']            = array(
+				array(
+					'pattern' => 'hello',
+					'ids'     => array( 11, 22 ),
+				),
+				array(
+					'pattern' => 'missing-ids',
+				),
+			);
+			return $options;
+		};
+		add_filter( 'jetpack_instant_search_options', $callback );
+		try {
+			$options = Search_Blocks::get_instant_search_query_options();
+		} finally {
+			remove_filter( 'jetpack_instant_search_options', $callback );
+		}
+
+		$this->assertTrue( $options['highlightPhraseOnly'] );
+		$this->assertSame( array( 'the', 'a' ), $options['highlightFilterStopwords'] );
+		$this->assertSame( array( 'title' ), $options['highlightFields'] );
+		$this->assertSame( array( 123, 456 ), $options['additionalBlogIds'] );
+		$this->assertSame(
+			array( 'term' => array( 'post_type' => 'post' ) ),
+			$options['adminQueryFilter']
+		);
+		$this->assertSame(
+			array(
+				array(
+					'pattern' => 'hello',
+					'ids'     => array( 11, 22 ),
+				),
+			),
+			$options['customResults']
+		);
+	}
+
+	/**
+	 * `build_initial_state()` surfaces the Instant Search query options so
+	 * the Interactivity API store can forward them on every fetch.
+	 */
+	public function test_build_initial_state_seeds_instant_search_query_options() {
+		$callback = static function ( $options ) {
+			$options['highlightPhraseOnly']      = true;
+			$options['highlightFilterStopwords'] = array( 'the' );
+			$options['highlightFields']          = array( 'title', 'content' );
+			$options['additionalBlogIds']        = array( 99 );
+			$options['adminQueryFilter']         = array(
+				'term' => array( 'post_type' => 'page' ),
+			);
+			$options['customResults']            = array(
+				array(
+					'pattern' => 'promo',
+					'ids'     => array( 5 ),
+				),
+			);
+			return $options;
+		};
+		add_filter( 'jetpack_instant_search_options', $callback );
+		try {
+			$state = Search_Blocks::build_initial_state();
+		} finally {
+			remove_filter( 'jetpack_instant_search_options', $callback );
+		}
+
+		$this->assertTrue( $state['highlightPhraseOnly'] );
+		$this->assertSame( array( 'the' ), $state['highlightFilterStopwords'] );
+		$this->assertSame( array( 'title', 'content' ), $state['highlightFields'] );
+		$this->assertSame( array( 99 ), $state['additionalBlogIds'] );
+		$this->assertSame(
+			array( 'term' => array( 'post_type' => 'page' ) ),
+			$state['adminQueryFilter']
+		);
+		$this->assertSame(
+			array(
+				array(
+					'pattern' => 'promo',
+					'ids'     => array( 5 ),
+				),
+			),
+			$state['customResults']
+		);
+	}
+
+	/**
 	 * The resolver routes mapped slugs to their slot and unmapped slugs to
 	 * Themselves. Built-in slugs (covered by their own filter variations)
 	 * Always return verbatim regardless of map content, so a stray entry


### PR DESCRIPTION
Fixes #

## Proposed changes
* Centralize parsing and application of `jetpack_instant_search_options` query parameters in `Helper` so all Instant Search experiences share the same logic.
* Seed `highlightPhraseOnly`, `highlightFilterStopwords`, `highlightFields`, `additionalBlogIds`, `adminQueryFilter`, and `customResults` into the Embedded and Overlay Blocks Interactivity API store, and forward them through `buildSearchUrl()`.
* Extend Theme search (Inline API) to apply the same options via the shared helper, including multisite field handling when `additionalBlogIds` is set.
* Follow-up to #50738, which added `highlightPhraseOnly` and `highlightFilterStopwords` for Overlay and Theme search only.

## Related product discussion/links
* Linear: SEARCH-320

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Add `highlightPhraseOnly` and/or `highlightFilterStopwords` via the `jetpack_instant_search_options` filter on a site using the **Embedded** experience. Confirm search API requests include the corresponding query params and the experience remains Embedded (does not fall back to Overlay). (See also testing instructions from #50738 )
* Repeat for `customResults`, `highlightFields`, and `additionalBlogIds` on Embedded and Overlay Blocks.
* For Theme search (Inline API), verify query params are sent on `?s=` searches when options are set via the filter.
* Run automated tests:
  * `jp test js packages/search`
  * `jp test php packages/search`


Made with [Cursor](https://cursor.com)