### PR TITLE
Agents Manager: skip plugin information iframes

### DIFF
--- a/projects/packages/agents-manager/changelog/wooai-822-plugin-information-iframe
+++ b/projects/packages/agents-manager/changelog/wooai-822-plugin-information-iframe
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent Agents Manager from loading a second time inside plugin information modals.

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -361,6 +361,10 @@ class Agents_Manager {
 	 * @return string|null The variant name, or null if scripts should not be loaded.
 	 */
 	public static function get_active_variant() {
+		if ( self::is_plugin_information_iframe() ) {
+			return null;
+		}
+
 		/**
 		 * Filter the script variant the Agents Manager loads for this request.
 		 *
@@ -369,6 +373,25 @@ class Agents_Manager {
 		 * @param string|null $variant The resolved variant, or null to not load.
 		 */
 		return apply_filters( 'agents_manager_variant', self::get_variant() );
+	}
+
+	/**
+	 * Whether the current request renders the plugin information iframe.
+	 *
+	 * The parent plugin screen may load Agents Manager, but the iframe must not
+	 * bootstrap a second copy of the app.
+	 *
+	 * @return bool
+	 */
+	private static function is_plugin_information_iframe() {
+		global $current_screen;
+
+		if ( ! $current_screen || 'plugin-install' !== $current_screen->id ) {
+			return false;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is a request context check, not a form submission.
+		return isset( $_GET['tab'] ) && 'plugin-information' === sanitize_text_field( wp_unslash( $_GET['tab'] ) );
 	}
 
 	/**

--- a/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
+++ b/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
@@ -38,6 +38,13 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	private $original_get_preview;
 
 	/**
+	 * Original $_GET['tab'] value to restore after tests.
+	 *
+	 * @var mixed
+	 */
+	private $original_get_tab;
+
+	/**
 	 * Original $_SERVER['REQUEST_URI'] value to restore after tests.
 	 *
 	 * @var mixed
@@ -96,6 +103,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		// Save original superglobal values that tests may modify.
 		$this->original_get_preview = $_GET['preview'] ?? null;
+		$this->original_get_tab     = $_GET['tab'] ?? null;
 		$this->original_request_uri = $_SERVER['REQUEST_URI'] ?? null;
 
 		// Save original $wp_customize global.
@@ -131,6 +139,12 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 			unset( $_GET['preview'] );
 		} else {
 			$_GET['preview'] = $this->original_get_preview;
+		}
+
+		if ( $this->original_get_tab === null ) {
+			unset( $_GET['tab'] );
+		} else {
+			$_GET['tab'] = $this->original_get_tab;
 		}
 
 		if ( $this->original_request_uri === null ) {
@@ -175,6 +189,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		// Clear the status cache and constants.
 		Cache::clear();
 		Constants::clear_constants();
+		remove_all_filters( 'agents_manager_variant' );
 
 		parent::tear_down();
 	}
@@ -1477,6 +1492,42 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	private function set_admin_context() {
 		require_once ABSPATH . 'wp-admin/includes/screen.php';
 		set_current_screen( 'dashboard' );
+	}
+
+	/**
+	 * Tests that the plugin information iframe cannot be enabled by a variant filter.
+	 */
+	public function test_get_active_variant_returns_null_in_plugin_information_iframe() {
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		set_current_screen( 'plugin-install' );
+		$_GET['tab'] = 'plugin-information';
+
+		add_filter(
+			'agents_manager_variant',
+			static function () {
+				return 'wp-admin';
+			}
+		);
+
+		$this->assertNull( Agents_Manager::get_active_variant() );
+	}
+
+	/**
+	 * Tests that a variant filter still controls the parent plugin screen.
+	 */
+	public function test_get_active_variant_allows_parent_plugin_screen() {
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		set_current_screen( 'plugin-install' );
+		unset( $_GET['tab'] );
+
+		add_filter(
+			'agents_manager_variant',
+			static function () {
+				return 'wp-admin';
+			}
+		);
+
+		$this->assertSame( 'wp-admin', Agents_Manager::get_active_variant() );
 	}
 
 	/**


### PR DESCRIPTION
Part of WOOAI-822.

## Why

The plugin-information Thickbox renders a complete wp-admin request inside an iframe. A provider can legitimately request Agents Manager on the parent Plugins page, but the same filters also run in that nested request and bootstrap a second chat inside the modal.

This is intentionally a narrow request-context exclusion rather than a blanket “all modals” or “all iframes” rule:

* a modal is a frontend presentation detail and the parent Agents Manager app should remain loaded;
* other iframe surfaces may intentionally host Agents Manager;
* `plugin-install.php?tab=plugin-information` is the stable server-side identity of the duplicate document we must exclude.

## Proposed changes

* Return no active Agents Manager variant inside the `plugin-information` iframe.
* Apply the exclusion before the `agents_manager_variant` filter so a provider cannot accidentally re-enable that nested document.
* Keep the parent Installed Plugins and Add Plugins screens eligible for normal enablement and provider shell requests.
* Add regression coverage for the hard iframe exclusion and the unaffected parent screen.

## Related product discussion/links

* Woo integration: https://github.com/woocommerce/woocommerce-ai/pull/376
* Generic provider shell request: https://github.com/Automattic/jetpack/pull/50922

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Run:

   ```bash
   jp test php packages/agents-manager
   ```

2. In a consumer that requests Agents Manager on wp-admin, open `/wp-admin/plugins.php`.
3. Open Ask AI in pop-out mode, then open an installed plugin's **View details** modal.
4. Confirm:
   * the parent pop-out remains visible and usable above the backdrop;
   * the plugin details iframe contains no second chat and no Agents Manager script.
5. Close the modal, switch the parent chat to sidebar mode, and open the modal again.
6. Confirm the modal backdrop blocks access to the parent sidebar while the modal is open.
7. Repeat from `/wp-admin/plugin-install.php` using a plugin's **More Details** link.

## Proofs

Captured on the same Installed Plugins page at 1809×1220 with the parent chat in pop-out mode.

| Before: parent and iframe both bootstrap chat | After: only the parent chat remains |
|---|---|
| ![Before: one pop-out chat on the parent Plugins page and a second chat inside the plugin information modal](https://gist.githubusercontent.com/aaronfc/e04e00f97bf1562415bb572a0f41f446/raw/ac75ee41daeee739bb6ccfbfbb7e12886ad8db26/plugin-information-before.png) | ![After: the parent pop-out remains above the backdrop and the plugin information modal contains only plugin details](https://gist.githubusercontent.com/aaronfc/83dec71a086f4d30d96c4d6c734f9934/raw/648e3c98a3055d56695a36cdc2a0dd22c3997303/plugin-information-desktop-after-provider-request.png) |

Browser inspection confirmed:

* the parent document loaded one Agents Manager script and retained one chat input;
* the plugin-information iframe loaded zero Agents Manager scripts and contained zero chat elements;
* no modal dimensions or Thickbox layout were changed by this PR.

Automated verification:

* Targeted PHPUnit regression tests: 2 tests, 2 assertions passed.
* PHPCS passed for the changed PHP implementation and tests.
* `jp phan packages/agents-manager --allow-polyfill-parser` reported zero issues before its `var_representation_polyfill` dependency crashed while parsing the WordPress stubs, so that run was incomplete.
