### PR TITLE
Agents Manager: let providers request the full UI

### DIFF
--- a/projects/packages/agents-manager/changelog/show-ask-ai-for-full-admin-variants
+++ b/projects/packages/agents-manager/changelog/show-ask-ai-for-full-admin-variants
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Allow integrations to request the Agents Manager shell without enabling the unified Help Center experience.
+Allow integrations to request the full Agents Manager shell without taking over the Help Center.

--- a/projects/packages/agents-manager/changelog/show-ask-ai-for-full-admin-variants
+++ b/projects/packages/agents-manager/changelog/show-ask-ai-for-full-admin-variants
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Show the Ask AI button in the wp-admin bar whenever the full Agents Manager app is loaded.

--- a/projects/packages/agents-manager/changelog/show-ask-ai-for-full-admin-variants
+++ b/projects/packages/agents-manager/changelog/show-ask-ai-for-full-admin-variants
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Show the Ask AI button in the wp-admin bar whenever the full Agents Manager app is loaded.
+Allow integrations to request the Agents Manager shell without enabling the unified Help Center experience.

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -420,7 +420,7 @@ class Agents_Manager {
 			return null;
 		}
 
-		// Apply wp-admin exclusions (WooCommerce, customizer, preview contexts).
+		// Apply wp-admin exclusions (customizer, asset, and preview contexts).
 		if ( ! self::passes_admin_checks() ) {
 			return null;
 		}

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -247,9 +247,9 @@ class Agents_Manager {
 			wp_dequeue_style( 'help-center-style' );
 		}
 
-		// For non-Gutenberg, non-CIAB environments, add to the admin bar. The fullscreen Gutenberg
-		// editor has no admin bar, so JS handles UI insertion — except under the omnibar, which is
-		// handled below. CIAB hides the admin bar and uses its own Site Hub.
+		// For non-Gutenberg, non-CIAB environments, add to the admin bar. Gutenberg uses JS when
+		// no admin bar is visible and the server-side branch below when one is available. CIAB
+		// hides the admin bar and uses its own Site Hub.
 		$is_ciab = $this->is_ciab_environment();
 		if ( ! $is_gutenberg && ! $is_ciab ) {
 			// Disconnected variants are Help-only. Full variants take over Help
@@ -276,8 +276,8 @@ class Agents_Manager {
 			}
 		}
 
-		// When Gutenberg's "admin bar in editor" (omnibar) experiment is active, add the entry
-		// points to that editor admin bar. CIAB is excluded — it has its own Site Hub UI.
+		// When the block editor exposes the WordPress admin bar, add the entry points there.
+		// CIAB is excluded — it has its own Site Hub UI.
 		// Mirroring wp-admin: the Help "?" dropdown shows only in the full unified experience;
 		// the Ask AI button shows whenever Agents Manager is enabled in this editor.
 		if ( ! $is_ciab && ! $use_disconnected && self::is_admin_bar_in_editor() ) {

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -263,8 +263,8 @@ class Agents_Manager {
 				add_action( 'admin_bar_menu', array( $this, 'add_menu_panel' ), 100 );
 			}
 
-			// Standalone AI chat button, shown only in the unified experience.
-			if ( ! $use_disconnected && self::is_unified_experience() ) {
+			// Standalone AI chat button, shown whenever the full Agents Manager app is loaded.
+			if ( ! $use_disconnected ) {
 				add_action( 'admin_bar_menu', array( $this, 'add_ai_chat_button' ), 100 );
 			}
 		}

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -263,8 +263,8 @@ class Agents_Manager {
 				add_action( 'admin_bar_menu', array( $this, 'add_menu_panel' ), 100 );
 			}
 
-			// Standalone AI chat button, shown whenever the full Agents Manager app is loaded.
-			if ( ! $use_disconnected ) {
+			// Standalone AI chat button, shown whenever the full Agents Manager app is enabled.
+			if ( ! $use_disconnected && self::is_enabled() ) {
 				add_action( 'admin_bar_menu', array( $this, 'add_ai_chat_button' ), 100 );
 			}
 		}
@@ -272,7 +272,7 @@ class Agents_Manager {
 		// When Gutenberg's "admin bar in editor" (omnibar) experiment is active, add the entry
 		// points to that editor admin bar. CIAB is excluded — it has its own Site Hub UI.
 		// Mirroring wp-admin: the Help "?" dropdown shows only in the full unified experience;
-		// the Ask AI button shows whenever a full Agents Manager variant is active.
+		// the Ask AI button shows whenever Agents Manager is enabled in this editor.
 		if ( ! $is_ciab && ! $use_disconnected && self::is_admin_bar_in_editor() ) {
 			// Help "?" node + dropdown panel first, matching the wp-admin admin bar order.
 			if ( self::is_unified_experience() ) {
@@ -286,7 +286,9 @@ class Agents_Manager {
 				add_action( 'admin_bar_menu', array( $this, 'add_menu_panel' ), 100 );
 			}
 
-			add_action( 'admin_bar_menu', array( $this, 'add_ai_chat_button' ), 100 );
+			if ( self::is_enabled() ) {
+				add_action( 'admin_bar_menu', array( $this, 'add_ai_chat_button' ), 100 );
+			}
 		}
 
 		/**
@@ -459,6 +461,8 @@ class Agents_Manager {
 	 * @return bool
 	 */
 	public static function is_enabled() {
+		$enabled = false;
+
 		// CIAB: Agents Manager is the default AI experience — enabled unless explicitly
 		// disabled via filter (e.g. for debugging or gradual rollout).
 		if ( self::is_ciab_environment() ) {
@@ -467,37 +471,39 @@ class Agents_Manager {
 			 *
 			 * @param bool $enabled Whether Agents Manager should load. Default true.
 			 */
-			return apply_filters( 'agents_manager_enabled_in_ciab', true );
+			$enabled = (bool) apply_filters( 'agents_manager_enabled_in_ciab', true );
+		} elseif ( self::is_unified_experience() ) {
+			// Full unified experience: Agents Manager with support guides, Help Center takeover, etc.
+			$enabled = true;
+		} elseif ( self::is_block_editor() && apply_filters( 'agents_manager_enabled_in_block_editor', false ) ) {
+			// Block editor only: Agents Manager replaces Big Sky's native UI. Hooked by Big Sky.
+			$enabled = true;
 		}
 
-		// Full unified experience: Agents Manager with support guides, Help Center takeover, etc.
-		if ( self::is_unified_experience() ) {
-			return true;
-		}
+		/**
+		 * Filters whether an integration requests the Agents Manager shell on this request.
+		 *
+		 * Providers should preserve an existing true value so multiple integrations can
+		 * request the shared shell independently.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param bool $should_load Whether another integration already requested the shell.
+		 */
+		$should_load = (bool) apply_filters( 'agents_manager_should_load', false );
 
-		// Block editor only: Agents Manager replaces Big Sky's native UI. Hooked by Big Sky.
-		if ( self::is_block_editor() && apply_filters( 'agents_manager_enabled_in_block_editor', false ) ) {
-			return true;
-		}
-
-		return false;
+		return $enabled || $should_load;
 	}
 
 	/**
 	 * Returns true if the current wp-admin context passes all exclusion checks.
 	 *
-	 * Excludes WooCommerce Admin home, customizer preview, Gutenberg asset requests,
-	 * and preview query param contexts.
+	 * Excludes customizer previews, Gutenberg asset requests, and preview query
+	 * param contexts.
 	 *
 	 * @return bool
 	 */
 	private static function passes_admin_checks() {
-		// Don't load on WooCommerce Admin home page to avoid UI conflicts.
-		global $current_screen;
-		if ( $current_screen && $current_screen->id === 'woocommerce_page_wc-admin' ) {
-			return false;
-		}
-
 		// Don't load in customizer preview iframe.
 		if ( is_customize_preview() ) {
 			return false;

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -272,7 +272,7 @@ class Agents_Manager {
 		// When Gutenberg's "admin bar in editor" (omnibar) experiment is active, add the entry
 		// points to that editor admin bar. CIAB is excluded — it has its own Site Hub UI.
 		// Mirroring wp-admin: the Help "?" dropdown shows only in the full unified experience;
-		// the Ask AI button shows whenever Agents Manager is enabled in this editor.
+		// the Ask AI button shows whenever a full Agents Manager variant is active.
 		if ( ! $is_ciab && ! $use_disconnected && self::is_admin_bar_in_editor() ) {
 			// Help "?" node + dropdown panel first, matching the wp-admin admin bar order.
 			if ( self::is_unified_experience() ) {
@@ -286,10 +286,7 @@ class Agents_Manager {
 				add_action( 'admin_bar_menu', array( $this, 'add_menu_panel' ), 100 );
 			}
 
-			// Ask AI button — shown whenever Agents Manager is enabled in this editor context.
-			if ( self::is_enabled() ) {
-				add_action( 'admin_bar_menu', array( $this, 'add_ai_chat_button' ), 100 );
-			}
+			add_action( 'admin_bar_menu', array( $this, 'add_ai_chat_button' ), 100 );
 		}
 
 		/**

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -103,7 +103,6 @@ class Agents_Manager {
 			);
 		} else {
 			$menu_args['meta'] = array(
-				'html'   => '<div id="agents-manager-masterbar"></div>',
 				'class'  => 'menupop',
 				'target' => '_blank',
 				'rel'    => 'noopener noreferrer',
@@ -210,6 +209,9 @@ class Agents_Manager {
 				'title'  => '<span title="' . esc_attr__( 'Ask AI', 'jetpack-agents-manager' ) . '"><svg class="ab-icon" role="img" aria-label="' . esc_attr__( 'Ask AI', 'jetpack-agents-manager' ) . '" width="24" height="24" viewBox="-45 -45 490 490" xmlns="http://www.w3.org/2000/svg">
 								<path fill="currentColor" d="M391.528 188.061L309.455 159.75C276.997 148.597 251.403 123.003 240.25 90.5451L211.939 8.47185C208.079 -2.82395 191.921 -2.82395 188.061 8.47185L159.75 90.5451C148.597 123.003 123.003 148.597 90.5451 159.75L8.47185 188.061C-2.82395 191.921 -2.82395 208.079 8.47185 211.939L90.5451 240.25C123.003 251.403 148.597 276.997 159.75 309.455L188.061 391.528C191.921 402.824 208.079 402.824 211.939 391.528L240.25 309.455C251.403 276.997 276.997 251.403 309.455 240.25L391.528 211.939C402.824 208.079 402.824 191.921 391.528 188.061ZM295.728 206.077L254.692 220.232C238.391 225.809 225.666 238.677 220.089 254.835L205.934 295.871C203.932 301.591 195.925 301.591 193.923 295.871L179.768 254.835C174.191 238.534 161.323 225.809 145.165 220.232L104.129 206.077C98.4093 204.075 98.4093 196.068 104.129 194.066L145.165 179.911C161.466 174.334 174.191 161.466 179.768 145.308L193.923 104.272C195.925 98.5523 203.932 98.5523 205.934 104.272L220.089 145.308C225.666 161.609 238.534 174.334 254.692 179.911L295.728 194.066C301.448 196.068 301.448 204.075 295.728 206.077Z" />
 							</svg></span>',
+				'meta'   => array(
+					'html' => '<div id="agents-manager-masterbar"></div>',
+				),
 			)
 		);
 	}
@@ -231,15 +233,16 @@ class Agents_Manager {
 		if ( null === $variant ) {
 			return;
 		}
-		$use_disconnected = str_contains( $variant, 'disconnected' );
-		$is_gutenberg     = $this->is_block_editor();
+		$use_disconnected       = str_contains( $variant, 'disconnected' );
+		$is_gutenberg           = $this->is_block_editor();
+		$use_unified_experience = self::is_unified_experience();
 
 		// In Gutenberg, dequeue Help Center so we don't end up with two buttons — but only
 		// in the full unified experience, where Agents Manager takes over the Help Center.
 		// In block-editor-only mode (e.g. ?flags=unified-big-sky) Agents Manager replaces
 		// Big Sky's native UI and Help Center should remain available.
 		// Agents Manager fires at priority 101, after Help Center at 100, so HC is already enqueued.
-		if ( $is_gutenberg && self::is_unified_experience() ) {
+		if ( $is_gutenberg && $use_unified_experience ) {
 			wp_dequeue_script( 'help-center' );
 			wp_dequeue_style( 'help-center-style' );
 		}
@@ -249,17 +252,21 @@ class Agents_Manager {
 		// handled below. CIAB hides the admin bar and uses its own Site Hub.
 		$is_ciab = $this->is_ciab_environment();
 		if ( ! $is_gutenberg && ! $is_ciab ) {
-			add_action(
-				'admin_bar_menu',
-				function ( $wp_admin_bar ) use ( $use_disconnected ) {
-					$this->add_help_menu( $wp_admin_bar, $use_disconnected );
-				},
-				// Add the agents manager icon to the admin bar after the help center is added, so we can remove it.
-				100
-			);
+			// Disconnected variants are Help-only. Full variants take over Help
+			// only when the unified experience is active.
+			if ( $use_disconnected || $use_unified_experience ) {
+				add_action(
+					'admin_bar_menu',
+					function ( $wp_admin_bar ) use ( $use_disconnected ) {
+						$this->add_help_menu( $wp_admin_bar, $use_disconnected );
+					},
+					// Add the agents manager icon after Help Center so it can replace that node.
+					100
+				);
+			}
 
-			// Initialize the agents manager menu panel (only for full variants, not disconnected)
-			if ( ! $use_disconnected ) {
+			// Initialize the Help menu panel only for the full unified experience.
+			if ( ! $use_disconnected && $use_unified_experience ) {
 				add_action( 'admin_bar_menu', array( $this, 'add_menu_panel' ), 100 );
 			}
 
@@ -275,7 +282,7 @@ class Agents_Manager {
 		// the Ask AI button shows whenever Agents Manager is enabled in this editor.
 		if ( ! $is_ciab && ! $use_disconnected && self::is_admin_bar_in_editor() ) {
 			// Help "?" node + dropdown panel first, matching the wp-admin admin bar order.
-			if ( self::is_unified_experience() ) {
+			if ( $use_unified_experience ) {
 				add_action(
 					'admin_bar_menu',
 					function ( $wp_admin_bar ) {
@@ -301,8 +308,6 @@ class Agents_Manager {
 		 * @param array $providers Array of provider script module IDs.
 		 */
 		$agent_providers = apply_filters( 'agents_manager_agent_providers', array() );
-
-		$use_unified_experience = self::is_unified_experience();
 
 		/**
 		 * Filter the default agent ID for the Agents Manager.

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -961,28 +961,16 @@ class Agents_Manager {
 	}
 
 	/**
-	 * Returns true when Gutenberg's "admin bar in editor" (omnibar) experiment is active.
+	 * Returns true when the WordPress admin bar is available in the block editor.
 	 *
-	 * Mirrors Gutenberg core's gate in `lib/experimental/omnibar/load.php`, and returns false when
-	 * `gutenberg_is_experiment_enabled()` is unavailable. Gutenberg 23.5 renamed the experiment
-	 * slug from `gutenberg-admin-bar-in-editor` to `gutenberg-omnibar`; both are checked since
-	 * pre-rename builds are still deployed (e.g. wpcom's bundled gutenberg-core).
+	 * The frontend uses the visible admin bar as its signal to move editor entry points out of the
+	 * Gutenberg toolbar. Use WordPress's matching server-side signal so a classic editor admin bar
+	 * receives those entry points too, not only Gutenberg's experimental omnibar.
 	 *
 	 * @return bool
 	 */
 	private static function is_admin_bar_in_editor() {
-		if (
-			! self::is_block_editor()
-			|| ! is_admin_bar_showing()
-			|| ! function_exists( 'gutenberg_is_experiment_enabled' )
-		) {
-			return false;
-		}
-
-		// @phan-suppress-next-line PhanUndeclaredFunction -- Guarded by function_exists() above.
-		return \gutenberg_is_experiment_enabled( 'gutenberg-omnibar' )
-			// @phan-suppress-next-line PhanUndeclaredFunction -- Guarded by function_exists() above.
-			|| \gutenberg_is_experiment_enabled( 'gutenberg-admin-bar-in-editor' );
+		return self::is_block_editor() && is_admin_bar_showing();
 	}
 
 	/**

--- a/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
+++ b/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
@@ -633,10 +633,10 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that the standalone AI chat button is not added to the admin bar when
-	 * the unified experience is disabled.
+	 * Tests that the standalone AI chat button is added for a full wp-admin variant
+	 * even when the unified experience is disabled.
 	 */
-	public function test_ai_chat_button_not_registered_without_unified_experience() {
+	public function test_ai_chat_button_registered_for_full_variant_without_unified_experience() {
 		// Same admin context as the enabled case, so only the unified flag differs.
 		require_once ABSPATH . 'wp-admin/includes/screen.php';
 		set_current_screen( 'dashboard' );
@@ -644,6 +644,34 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		// Disable the unified experience (priority 20 runs after the class's own filter).
 		add_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
+		$variant_filter = static function () {
+			return 'wp-admin';
+		};
+		add_filter( 'agents_manager_variant', $variant_filter );
+
+		$this->agents_manager->enqueue_scripts();
+
+		$this->assertNotFalse(
+			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_ai_chat_button' ) )
+		);
+
+		remove_filter( 'agents_manager_variant', $variant_filter );
+		remove_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
+	}
+
+	/**
+	 * Tests that the standalone AI chat button is not added for a disconnected
+	 * Help-only variant.
+	 */
+	public function test_ai_chat_button_not_registered_for_disconnected_variant() {
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		set_current_screen( 'dashboard' );
+		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
+
+		$variant_filter = static function () {
+			return 'wp-admin-disconnected';
+		};
+		add_filter( 'agents_manager_variant', $variant_filter );
 
 		$this->agents_manager->enqueue_scripts();
 
@@ -651,7 +679,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_ai_chat_button' ) )
 		);
 
-		remove_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
+		remove_filter( 'agents_manager_variant', $variant_filter );
 	}
 
 	/**

--- a/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
+++ b/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
@@ -706,7 +706,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Puts the current request into a block-editor screen so the editor omnibar branch is reachable.
+	 * Puts the current request into a block-editor screen so the editor admin-bar branch is reachable.
 	 *
 	 * @param bool $enable Whether to enable Agents Manager in the block editor (block-editor-only,
 	 *                     no unified experience). Pass false to exercise the not-enabled path.
@@ -730,14 +730,13 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that the Ask AI button is added to the editor admin bar when the omnibar experiment is
-	 * active and Agents Manager is enabled — independent of dev mode (here, a non-proxied request).
+	 * Tests that the Ask AI button is added when the editor admin bar is showing and Agents Manager
+	 * is enabled — independent of dev mode (here, a non-proxied request).
 	 */
-	public function test_ai_chat_button_registered_in_editor_omnibar() {
+	public function test_ai_chat_button_registered_in_editor_admin_bar() {
 		$this->set_up_block_editor_request();
 
 		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
-		Functions\when( 'gutenberg_is_experiment_enabled' )->justReturn( true );
 
 		$this->agents_manager->enqueue_scripts();
 
@@ -752,11 +751,10 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	 * Tests that an integration-requested Gutenberg shell adds Ask AI to the editor
 	 * admin bar without taking over the Help Center.
 	 */
-	public function test_ai_chat_button_registered_in_editor_omnibar_for_requested_shell() {
+	public function test_ai_chat_button_registered_in_editor_admin_bar_for_requested_shell() {
 		$this->set_up_block_editor_request( false );
 
 		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
-		Functions\when( 'gutenberg_is_experiment_enabled' )->justReturn( true );
 
 		add_filter( 'agents_manager_should_load', '__return_true' );
 
@@ -770,60 +768,32 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that the omnibar experiment is recognized when only the renamed slug
-	 * (`gutenberg-omnibar`, Gutenberg 23.5+) is enabled.
+	 * Tests that a classic editor admin bar receives Ask AI without the Gutenberg
+	 * omnibar experiment.
 	 */
-	public function test_ai_chat_button_registered_in_editor_omnibar_with_renamed_slug() {
-		$this->set_up_block_editor_request();
-
-		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
-		Functions\when( 'gutenberg_is_experiment_enabled' )->alias(
-			function ( $experiment ) {
-				return 'gutenberg-omnibar' === $experiment;
-			}
-		);
-
-		$this->agents_manager->enqueue_scripts();
-
-		$this->assertNotFalse(
-			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_ai_chat_button' ) )
-		);
-
-		remove_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
-	}
-
-	/**
-	 * Tests that the omnibar experiment is recognized when only the pre-rename slug
-	 * (`gutenberg-admin-bar-in-editor`, Gutenberg ≤ 23.4) is enabled.
-	 */
-	public function test_ai_chat_button_registered_in_editor_omnibar_with_legacy_slug() {
-		$this->set_up_block_editor_request();
-
-		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
-		Functions\when( 'gutenberg_is_experiment_enabled' )->alias(
-			function ( $experiment ) {
-				return 'gutenberg-admin-bar-in-editor' === $experiment;
-			}
-		);
-
-		$this->agents_manager->enqueue_scripts();
-
-		$this->assertNotFalse(
-			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_ai_chat_button' ) )
-		);
-
-		remove_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
-	}
-
-	/**
-	 * Tests that the Ask AI button is not added to the editor admin bar when the omnibar
-	 * experiment is inactive, even though Agents Manager is enabled.
-	 */
-	public function test_ai_chat_button_not_registered_in_editor_without_omnibar() {
+	public function test_ai_chat_button_registered_in_classic_editor_admin_bar() {
 		$this->set_up_block_editor_request();
 
 		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
 		Functions\when( 'gutenberg_is_experiment_enabled' )->justReturn( false );
+
+		$this->agents_manager->enqueue_scripts();
+
+		$this->assertNotFalse(
+			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_ai_chat_button' ) )
+		);
+
+		remove_filter( 'agents_manager_enabled_in_block_editor', '__return_true' );
+	}
+
+	/**
+	 * Tests that the Ask AI button is not added to the editor admin bar when the admin
+	 * bar is hidden, even though Agents Manager is enabled.
+	 */
+	public function test_ai_chat_button_not_registered_in_editor_without_admin_bar() {
+		$this->set_up_block_editor_request();
+
+		Functions\when( 'is_admin_bar_showing' )->justReturn( false );
 
 		$this->agents_manager->enqueue_scripts();
 

--- a/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
+++ b/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
@@ -775,7 +775,6 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		$this->set_up_block_editor_request();
 
 		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
-		Functions\when( 'gutenberg_is_experiment_enabled' )->justReturn( false );
 
 		$this->agents_manager->enqueue_scripts();
 
@@ -806,13 +805,12 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 	/**
 	 * Tests that the Ask AI button is not added to the editor admin bar when Agents Manager is
-	 * not enabled, even while the omnibar experiment is active.
+	 * not enabled, even while the admin bar is showing.
 	 */
 	public function test_ai_chat_button_not_registered_in_editor_when_not_enabled() {
 		$this->set_up_block_editor_request( false );
 
 		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
-		Functions\when( 'gutenberg_is_experiment_enabled' )->justReturn( true );
 
 		$this->agents_manager->enqueue_scripts();
 
@@ -822,14 +820,13 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that the Help "?" dropdown (its menu panel) is added to the editor admin bar when the
-	 * omnibar experiment is active in the unified experience.
+	 * Tests that the Help "?" dropdown (its menu panel) is added to the editor admin bar in the
+	 * unified experience.
 	 */
-	public function test_help_menu_registered_in_editor_omnibar_when_unified() {
+	public function test_help_menu_registered_in_editor_admin_bar_when_unified() {
 		$this->set_up_block_editor_request();
 
 		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
-		Functions\when( 'gutenberg_is_experiment_enabled' )->justReturn( true );
 		Functions\when( 'wpcom_is_proxied_request' )->justReturn( true );
 		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
 
@@ -844,14 +841,13 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that the Help "?" dropdown is not added to the editor admin bar when the omnibar
-	 * experiment is active but the unified experience is disabled (Ask AI only).
+	 * Tests that the Help "?" dropdown is not added to the editor admin bar when the unified
+	 * experience is disabled (Ask AI only).
 	 */
-	public function test_help_menu_not_registered_in_editor_omnibar_without_unified() {
+	public function test_help_menu_not_registered_in_editor_admin_bar_without_unified() {
 		$this->set_up_block_editor_request();
 
 		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
-		Functions\when( 'gutenberg_is_experiment_enabled' )->justReturn( true );
 		Functions\when( 'wpcom_is_proxied_request' )->justReturn( true );
 
 		$this->agents_manager->enqueue_scripts();

--- a/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
+++ b/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
@@ -633,10 +633,10 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that the standalone AI chat button is added for a full wp-admin variant
-	 * even when the unified experience is disabled.
+	 * Tests that the standalone AI chat button is added when an integration requests
+	 * Agents Manager without enabling the unified experience.
 	 */
-	public function test_ai_chat_button_registered_for_full_variant_without_unified_experience() {
+	public function test_ai_chat_button_registered_for_requested_shell_without_unified_experience() {
 		// Same admin context as the enabled case, so only the unified flag differs.
 		require_once ABSPATH . 'wp-admin/includes/screen.php';
 		set_current_screen( 'dashboard' );
@@ -644,10 +644,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 
 		// Disable the unified experience (priority 20 runs after the class's own filter).
 		add_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
-		$variant_filter = static function () {
-			return 'wp-admin';
-		};
-		add_filter( 'agents_manager_variant', $variant_filter );
+		add_filter( 'agents_manager_should_load', '__return_true' );
 
 		$this->agents_manager->enqueue_scripts();
 
@@ -655,7 +652,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_ai_chat_button' ) )
 		);
 
-		remove_filter( 'agents_manager_variant', $variant_filter );
+		remove_filter( 'agents_manager_should_load', '__return_true' );
 		remove_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
 	}
 
@@ -726,19 +723,16 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that a host-filtered full Gutenberg variant adds Ask AI to the editor
-	 * admin bar without requiring another Agents Manager enablement filter.
+	 * Tests that an integration-requested Gutenberg shell adds Ask AI to the editor
+	 * admin bar without taking over the Help Center.
 	 */
-	public function test_ai_chat_button_registered_in_editor_omnibar_for_filtered_full_variant() {
+	public function test_ai_chat_button_registered_in_editor_omnibar_for_requested_shell() {
 		$this->set_up_block_editor_request( false );
 
 		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
 		Functions\when( 'gutenberg_is_experiment_enabled' )->justReturn( true );
 
-		$variant_filter = static function () {
-			return 'gutenberg';
-		};
-		add_filter( 'agents_manager_variant', $variant_filter );
+		add_filter( 'agents_manager_should_load', '__return_true' );
 
 		$this->agents_manager->enqueue_scripts();
 
@@ -746,7 +740,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_ai_chat_button' ) )
 		);
 
-		remove_filter( 'agents_manager_variant', $variant_filter );
+		remove_filter( 'agents_manager_should_load', '__return_true' );
 	}
 
 	/**
@@ -2462,6 +2456,19 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Tests that is_enabled returns true when an integration requests the shell.
+	 */
+	public function test_is_enabled_returns_true_when_shell_is_requested() {
+		add_filter( 'agents_manager_should_load', '__return_true' );
+
+		$result = Agents_Manager::is_enabled();
+
+		remove_filter( 'agents_manager_should_load', '__return_true' );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
 	 * Tests that is_enabled returns true when in block editor and agents_manager_enabled_in_block_editor filter is true.
 	 */
 	public function test_is_enabled_returns_true_in_block_editor_when_block_editor_filter_enabled() {
@@ -2600,23 +2607,20 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that should_enqueue_script returns false on WooCommerce Admin home page.
-	 * This verifies the WooCommerce Admin exclusion to avoid UI conflicts,
-	 * matching the same exclusion in Help_Center::enqueue_wp_admin_scripts().
+	 * Tests that an integration can load Agents Manager on WooCommerce Admin.
 	 */
-	public function test_should_enqueue_script_returns_false_on_woocommerce_admin_home() {
+	public function test_should_enqueue_script_returns_true_on_woocommerce_admin_when_requested() {
 		// Set admin context first.
 		require_once ABSPATH . 'wp-admin/includes/screen.php';
 		set_current_screen( 'woocommerce_page_wc-admin' );
 
-		// Enable unified experience so that Agents Manager is active and the WooCommerce exclusion is exercised.
-		add_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		add_filter( 'agents_manager_should_load', '__return_true' );
 
 		$result = $this->call_should_enqueue_script();
 
-		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+		remove_filter( 'agents_manager_should_load', '__return_true' );
 
-		$this->assertFalse( $result, 'should_enqueue_script should return false on WooCommerce Admin home page' );
+		$this->assertTrue( $result, 'Agents Manager should load on WooCommerce Admin when requested.' );
 	}
 
 	/**

--- a/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
+++ b/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
@@ -651,9 +651,35 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		$this->assertNotFalse(
 			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_ai_chat_button' ) )
 		);
+		$this->assertFalse(
+			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_menu_panel' ) ),
+			'Requesting the shell must not take over the Help Center.'
+		);
 
 		remove_filter( 'agents_manager_should_load', '__return_true' );
 		remove_filter( 'agents_manager_use_unified_experience', '__return_false', 20 );
+	}
+
+	/**
+	 * Tests that the full UI mount target belongs to Ask AI rather than Help.
+	 */
+	public function test_ai_chat_button_owns_full_ui_mount_target() {
+		global $wp_admin_bar;
+
+		require_once ABSPATH . 'wp-includes/class-wp-admin-bar.php';
+		$wp_admin_bar = new \WP_Admin_Bar();
+		$wp_admin_bar->initialize();
+
+		$this->agents_manager->add_help_menu( $wp_admin_bar, false );
+		$this->agents_manager->add_ai_chat_button( $wp_admin_bar );
+
+		$help_node = $wp_admin_bar->get_node( 'agents-manager' );
+		$ai_node   = $wp_admin_bar->get_node( 'agents-manager-ai-chat' );
+
+		$this->assertNotNull( $help_node );
+		$this->assertNotNull( $ai_node );
+		$this->assertStringNotContainsString( 'agents-manager-masterbar', $help_node->meta['html'] ?? '' );
+		$this->assertStringContainsString( 'agents-manager-masterbar', $ai_node->meta['html'] ?? '' );
 	}
 
 	/**

--- a/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
+++ b/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
@@ -726,6 +726,30 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Tests that a host-filtered full Gutenberg variant adds Ask AI to the editor
+	 * admin bar without requiring another Agents Manager enablement filter.
+	 */
+	public function test_ai_chat_button_registered_in_editor_omnibar_for_filtered_full_variant() {
+		$this->set_up_block_editor_request( false );
+
+		Functions\when( 'is_admin_bar_showing' )->justReturn( true );
+		Functions\when( 'gutenberg_is_experiment_enabled' )->justReturn( true );
+
+		$variant_filter = static function () {
+			return 'gutenberg';
+		};
+		add_filter( 'agents_manager_variant', $variant_filter );
+
+		$this->agents_manager->enqueue_scripts();
+
+		$this->assertNotFalse(
+			has_action( 'admin_bar_menu', array( $this->agents_manager, 'add_ai_chat_button' ) )
+		);
+
+		remove_filter( 'agents_manager_variant', $variant_filter );
+	}
+
+	/**
 	 * Tests that the omnibar experiment is recognized when only the renamed slug
 	 * (`gutenberg-omnibar`, Gutenberg 23.5+) is enabled.
 	 */


### PR DESCRIPTION
Relates to WOOAI-822
P2: pgdYcB-1qo-p2

## Why

Agents Manager currently uses `agents_manager_use_unified_experience` for two different decisions:

1. whether the shared Agents Manager shell should load; and
2. whether Agents Manager should take over the Help Center.

That forces provider plugins to enable the unified Help experience just to get a usable chat shell and entry point. It also leaves no generic way for a provider to say “I need Agents Manager on this request” while allowing the package to choose the normal `wp-admin` or `gutenberg` variant.

## Proposed changes

* Add the additive `agents_manager_should_load` filter. Integrations can request the shared shell without changing unified Help behavior or selecting a variant.
* Let the package continue selecting its default full variant by surface: `wp-admin` on ordinary admin pages and `gutenberg` in the block editor.
* Remove the legacy WooCommerce Admin exclusion so a provider request also works on `/wp-admin/admin.php?page=wc-admin`.
* Show Ask AI whenever the full app is enabled, while keeping disconnected Help-only variants unchanged.
* Keep `agents_manager_use_unified_experience` responsible only for the Help menu and Help panel integration.
* Attach the full UI mount target to Ask AI rather than Help. A requested full shell therefore mounts the normal UI instead of falling back to the headless integration.
* Align the PHP and frontend editor gates: when the block editor has a visible WordPress admin bar, PHP adds Ask AI there; otherwise the Gutenberg bundle supplies its toolbar entry point.

## Related product discussion/links

* Woo integration: https://github.com/woocommerce/woocommerce-ai/pull/376
* Plugin-information iframe exclusion: https://github.com/Automattic/jetpack/pull/50921

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Run:

   ```bash
   composer --working-dir=projects/packages/agents-manager test-php
   ```

2. In a wp-admin consumer, request the shell without enabling unified experience:

   ```php
   add_filter(
       'agents_manager_should_load',
       static function ( $requested ) {
           return $requested || is_admin();
       }
   );
   ```

3. Open `/wp-admin/` and confirm:
   * Ask AI appears in the admin bar and opens the full chat UI;
   * Agents Manager does not replace the Help menu;
   * there is no separate floating launcher.
4. Open `/wp-admin/post-new.php` and confirm the `gutenberg` variant loads with exactly one Ask AI entry point.
5. Open `/wp-admin/admin.php?page=wc-admin` and confirm the `wp-admin` variant and full chat UI load.
6. Remove the request filter and confirm these surfaces return to the host's existing enablement behavior.
7. Select `wp-admin-disconnected` and confirm the disconnected Help-only experience does not add Ask AI.

## Proofs

All captures use the same self-hosted development environment. “Before” uses the released package, which does not understand the provider shell request; “after” uses this branch with unified experience still disabled.

### Ordinary wp-admin: full UI entry point no longer depends on unified Help

| Before | After |
|---|---|
| ![Before: Help owns the package mount and chat falls back to a floating launcher](https://gist.githubusercontent.com/aaronfc/83dec71a086f4d30d96c4d6c734f9934/raw/648e3c98a3055d56695a36cdc2a0dd22c3997303/dashboard-desktop-before-requested-shell.png) | ![After: Ask AI appears in the admin bar while Help is left unchanged](https://gist.githubusercontent.com/aaronfc/83dec71a086f4d30d96c4d6c734f9934/raw/648e3c98a3055d56695a36cdc2a0dd22c3997303/dashboard-desktop-after-requested-shell.png) |

The after state has one full UI mount target under Ask AI, no headless mount, and one chat input after opening Ask AI.

### Block editor: requested shell uses the Gutenberg surface

| Before | After |
|---|---|
| ![Before: no Agents Manager entry point in the editor admin bar](https://gist.githubusercontent.com/aaronfc/530ba1f9ff893326f71e46ad32d92354/raw/adabef480dc4eff211d029979da79c774fdc813b/post-editor-desktop-before-requested-shell.png) | ![After: one Ask AI sparkle in the editor admin bar](https://gist.githubusercontent.com/aaronfc/530ba1f9ff893326f71e46ad32d92354/raw/adabef480dc4eff211d029979da79c774fdc813b/post-editor-desktop-after-requested-shell.png) |

Browser inspection confirmed the after state loads `agents-manager-gutenberg.min.js`, has one visible Ask AI entry point, and has no floating launcher.

### WooCommerce Admin: legacy exclusion removed

| Before | After |
|---|---|
| ![Before: WooCommerce Admin has no Agents Manager shell or entry point](https://gist.githubusercontent.com/aaronfc/83dec71a086f4d30d96c4d6c734f9934/raw/648e3c98a3055d56695a36cdc2a0dd22c3997303/wc-admin-desktop-before-provider-request.png) | ![After: WooCommerce Admin shows Ask AI and the standard full chat UI](https://gist.githubusercontent.com/aaronfc/83dec71a086f4d30d96c4d6c734f9934/raw/648e3c98a3055d56695a36cdc2a0dd22c3997303/wc-admin-desktop-after-provider-request.png) |

The same behavior was verified at the 390×844 mobile viewport:

| Before | After |
|---|---|
| ![Before on mobile: no Agents Manager entry point](https://gist.githubusercontent.com/aaronfc/83dec71a086f4d30d96c4d6c734f9934/raw/648e3c98a3055d56695a36cdc2a0dd22c3997303/wc-admin-mobile-before-provider-request.png) | ![After on mobile: the requested full chat UI is available](https://gist.githubusercontent.com/aaronfc/83dec71a086f4d30d96c4d6c734f9934/raw/648e3c98a3055d56695a36cdc2a0dd22c3997303/wc-admin-mobile-after-provider-request.png) |

### Automated verification

* Package PHPUnit suite: 145 tests, 228 assertions passed.
* PHPCS passed for the changed implementation and test files.
* `git diff --check` passed.