### PR TITLE
Instant Search: fix false "No results found" flash before a search starts

### DIFF
--- a/projects/packages/search/changelog/fix-search-311-no-results-flash
+++ b/projects/packages/search/changelog/fix-search-311-no-results-flash
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Instant Search: Avoid a brief "No results found" flash before a search starts.

--- a/projects/packages/search/src/instant-search/components/search-app.jsx
+++ b/projects/packages/search/src/instant-search/components/search-app.jsx
@@ -61,6 +61,10 @@ class SearchApp extends Component {
 			// TODO: Migrate visibility state to Redux.
 			isVisible: !! this.props.initialIsVisible, // initialIsVisible can be undefined
 			overlayOptionsCustomizerOverride: {},
+			// True from the moment a new query/sort/filter is requested until the
+			// debounced request actually dispatches, covering the gap where
+			// isLoading is still false and the response is stale/empty.
+			isQueryPending: false,
 			// AI Answers state — brief (fast) answer
 			aiBriefStatus: 'idle', // 'idle' | 'loading' | 'streaming' | 'done' | 'error'
 			aiBriefText: '',
@@ -106,7 +110,7 @@ class SearchApp extends Component {
 			( this.props.initialShowResults && this.props.initialIsVisible ) ||
 			this.props.isInCustomizer
 		) {
-			this.getResults();
+			this.requestResults();
 		}
 
 		if ( this.props.hasActiveQuery && this.props.overlayOptions.enableFilteringOpensOverlay ) {
@@ -137,7 +141,7 @@ class SearchApp extends Component {
 			stringify( prevState.overlayOptions.excludedPostTypes ) !==
 			stringify( this.state.overlayOptions.excludedPostTypes )
 		) {
-			this.getResults();
+			this.requestResults();
 		}
 	}
 
@@ -149,6 +153,7 @@ class SearchApp extends Component {
 			this.aiExtendedController.abort();
 		}
 		this.getAiAnswer.clear();
+		this.getResults.clear();
 	}
 
 	initializeAnalytics() {
@@ -225,7 +230,7 @@ class SearchApp extends Component {
 	showResults = this.toggleResults.bind( this, true );
 
 	onChangeQueryString = isHistoryNav => {
-		this.getResults();
+		this.requestResults();
 
 		if ( this.props.hasActiveQuery && ! this.state.isVisible ) {
 			this.showResults();
@@ -243,6 +248,13 @@ class SearchApp extends Component {
 
 	loadNextPage = () => {
 		this.props.hasNextPage && this.getResults( { pageHandle: this.props.response.page_handle } );
+	};
+
+	// Marks a new query as pending immediately, so the UI can reflect the
+	// upcoming request before the debounced getResults() actually dispatches it.
+	requestResults = () => {
+		this.setState( { isQueryPending: true } );
+		this.getResults();
 	};
 
 	getResults = ( { pageHandle } = {} ) => {
@@ -266,6 +278,7 @@ class SearchApp extends Component {
 			customResults: this.props.options.customResults,
 			isInCustomizer: this.props.isInCustomizer,
 		} );
+		this.setState( { isQueryPending: false } );
 	};
 
 	/**
@@ -649,6 +662,7 @@ class SearchApp extends Component {
 							hasNextPage={ this.props.hasNextPage }
 							highlightColor={ this.state.overlayOptions.highlightColor }
 							isLoading={ this.props.isLoading }
+							isQueryPending={ this.state.isQueryPending }
 							isPhotonEnabled={ this.props.options.isPhotonEnabled }
 							isPrivateSite={ this.props.options.isPrivateSite }
 							isVisible={ this.state.isVisible }

--- a/projects/packages/search/src/instant-search/components/search-app.jsx
+++ b/projects/packages/search/src/instant-search/components/search-app.jsx
@@ -110,7 +110,7 @@ class SearchApp extends Component {
 			( this.props.initialShowResults && this.props.initialIsVisible ) ||
 			this.props.isInCustomizer
 		) {
-			this.requestResults();
+			this.getResults();
 		}
 
 		if ( this.props.hasActiveQuery && this.props.overlayOptions.enableFilteringOpensOverlay ) {
@@ -141,7 +141,7 @@ class SearchApp extends Component {
 			stringify( prevState.overlayOptions.excludedPostTypes ) !==
 			stringify( this.state.overlayOptions.excludedPostTypes )
 		) {
-			this.requestResults();
+			this.getResults();
 		}
 	}
 
@@ -230,7 +230,14 @@ class SearchApp extends Component {
 	showResults = this.toggleResults.bind( this, true );
 
 	onChangeQueryString = isHistoryNav => {
-		this.requestResults();
+		// Only for a non-empty query: pending-tracking an empty-query change
+		// (e.g. a filter-link click that clears the query) clobbers the overlay's
+		// isVisible update, which is set directly by that same click handler.
+		if ( this.props.searchQuery ) {
+			this.requestResults();
+		} else {
+			this.getResults();
+		}
 
 		if ( this.props.hasActiveQuery && ! this.state.isVisible ) {
 			this.showResults();

--- a/projects/packages/search/src/instant-search/components/search-results.jsx
+++ b/projects/packages/search/src/instant-search/components/search-results.jsx
@@ -56,19 +56,13 @@ class SearchResults extends Component {
 			this.props.staticFilters.group_id &&
 			this.props.staticFilters.group_id !== MULTISITE_NO_GROUP_VALUE;
 
-		// A response with neither a `requestId` nor a `total` means no search has
-		// completed yet (the reducer's initial state is `{}`), which is distinct
-		// from a completed search that returned zero results. `requestId` is
-		// checked too so a response shape that omits `total` doesn't get
-		// mistaken for "never searched" and stick the title on a loading state
-		// forever; every response the API layer produces carries a `requestId`.
+		// Distinguishes "no search has completed yet" (init state `{}`) from a
+		// completed search; `requestId` covers responses that omit `total`.
 		const hasCompletedSearch =
 			'requestId' in this.props.response || 'total' in this.props.response || this.props.hasError;
 
 		if ( this.props.isLoading || this.props.isQueryPending || ! hasCompletedSearch ) {
-			// searchQuery is null before the query string is initialized (e.g. at
-			// first mount, before any `?s=` param is read), not ''; treat that the
-			// same as an empty query here.
+			// searchQuery is null (not '') before the query string initializes.
 			if ( ! this.props.searchQuery ) {
 				return __( 'Loading popular results…', 'jetpack-search-pkg' );
 			}

--- a/projects/packages/search/src/instant-search/components/search-results.jsx
+++ b/projects/packages/search/src/instant-search/components/search-results.jsx
@@ -56,7 +56,11 @@ class SearchResults extends Component {
 			this.props.staticFilters.group_id &&
 			this.props.staticFilters.group_id !== MULTISITE_NO_GROUP_VALUE;
 
-		if ( this.props.isLoading || this.props.isQueryPending ) {
+		// An empty response object means no search has completed yet, which is distinct
+		// from a completed search that returned zero results.
+		const hasCompletedSearch = 'total' in this.props.response || this.props.hasError;
+
+		if ( this.props.isLoading || this.props.isQueryPending || ! hasCompletedSearch ) {
 			if ( ! hasQuery ) {
 				return __( 'Loading popular results…', 'jetpack-search-pkg' );
 			}

--- a/projects/packages/search/src/instant-search/components/search-results.jsx
+++ b/projects/packages/search/src/instant-search/components/search-results.jsx
@@ -49,21 +49,27 @@ class SearchResults extends Component {
 
 	getSearchTitle() {
 		const { total = 0, corrected_query = false } = this.props.response;
-		// searchQuery is null before the query string is initialized (e.g. at
-		// first mount, before any `?s=` param is read), not ''.
-		const hasQuery = !! this.props.searchQuery;
+		const hasQuery = this.props.searchQuery !== '';
 		const hasCorrectedQuery = corrected_query !== false;
 		const isMultiSite =
 			this.props.staticFilters &&
 			this.props.staticFilters.group_id &&
 			this.props.staticFilters.group_id !== MULTISITE_NO_GROUP_VALUE;
 
-		// An empty response object means no search has completed yet, which is distinct
-		// from a completed search that returned zero results.
-		const hasCompletedSearch = 'total' in this.props.response || this.props.hasError;
+		// A response with neither a `requestId` nor a `total` means no search has
+		// completed yet (the reducer's initial state is `{}`), which is distinct
+		// from a completed search that returned zero results. `requestId` is
+		// checked too so a response shape that omits `total` doesn't get
+		// mistaken for "never searched" and stick the title on a loading state
+		// forever; every response the API layer produces carries a `requestId`.
+		const hasCompletedSearch =
+			'requestId' in this.props.response || 'total' in this.props.response || this.props.hasError;
 
 		if ( this.props.isLoading || this.props.isQueryPending || ! hasCompletedSearch ) {
-			if ( ! hasQuery ) {
+			// searchQuery is null before the query string is initialized (e.g. at
+			// first mount, before any `?s=` param is read), not ''; treat that the
+			// same as an empty query here.
+			if ( ! this.props.searchQuery ) {
 				return __( 'Loading popular results…', 'jetpack-search-pkg' );
 			}
 

--- a/projects/packages/search/src/instant-search/components/search-results.jsx
+++ b/projects/packages/search/src/instant-search/components/search-results.jsx
@@ -56,7 +56,7 @@ class SearchResults extends Component {
 			this.props.staticFilters.group_id &&
 			this.props.staticFilters.group_id !== MULTISITE_NO_GROUP_VALUE;
 
-		if ( this.props.isLoading ) {
+		if ( this.props.isLoading || this.props.isQueryPending ) {
 			if ( ! hasQuery ) {
 				return __( 'Loading popular results…', 'jetpack-search-pkg' );
 			}

--- a/projects/packages/search/src/instant-search/components/search-results.jsx
+++ b/projects/packages/search/src/instant-search/components/search-results.jsx
@@ -49,7 +49,9 @@ class SearchResults extends Component {
 
 	getSearchTitle() {
 		const { total = 0, corrected_query = false } = this.props.response;
-		const hasQuery = this.props.searchQuery !== '';
+		// searchQuery is null before the query string is initialized (e.g. at
+		// first mount, before any `?s=` param is read), not ''.
+		const hasQuery = !! this.props.searchQuery;
 		const hasCorrectedQuery = corrected_query !== false;
 		const isMultiSite =
 			this.props.staticFilters &&

--- a/projects/packages/search/src/instant-search/components/test/search-app-query-pending.test.jsx
+++ b/projects/packages/search/src/instant-search/components/test/search-app-query-pending.test.jsx
@@ -1,0 +1,197 @@
+/**
+ * Tests for SEARCH-311: SearchApp should mark a query as "pending" the instant
+ * a query/sort/filter change is detected, before the debounced getResults()
+ * call actually dispatches makeSearchRequest — closing the gap where isLoading
+ * is still false and the response is stale/empty.
+ */
+
+jest.mock( '@microsoft/fetch-event-source', () => ( {
+	fetchEventSource: jest.fn(),
+} ) );
+
+let lastSearchResultsProps = {};
+jest.mock( '../search-results', () => props => {
+	lastSearchResultsProps = props;
+	return <div data-testid="search-results" />;
+} );
+jest.mock( '../overlay', () => ( { children } ) => <div data-testid="overlay">{ children }</div> );
+jest.mock( '../customizer-event-handler', () => () => null );
+jest.mock( '../dom-event-handler', () => () => null );
+
+jest.mock( 'react-redux', () => ( {
+	connect: () => Component => Component,
+} ) );
+
+jest.mock( '../../store/actions', () => ( {} ) );
+jest.mock( '../../store/selectors', () => ( {} ) );
+
+import { act, render } from '@testing-library/react';
+import * as React from 'react';
+import SearchApp from '../search-app';
+
+const noop = () => {};
+
+const defaultProps = {
+	enableAnalytics: false,
+	shouldIntegrateWithDom: false,
+	shouldCreatePortal: false,
+	isInCustomizer: false,
+	initialIsVisible: false,
+	initialHref: '/',
+	options: {
+		siteId: 123,
+		locale: 'en',
+		postTypes: [],
+		widgets: [],
+		additionalBlogIds: [],
+		isPhotonEnabled: false,
+		isPrivateSite: false,
+		postsPerPage: 10,
+		adminQueryFilter: '',
+		highlightFields: [],
+		customResults: {},
+		hasNonSearchWidgets: false,
+	},
+	overlayOptions: {
+		colorTheme: 'light',
+		enableInfScroll: false,
+		enableFilteringOpensOverlay: false,
+		enableSort: false,
+		enablePostDate: false,
+		enableProductPrice: false,
+		overlayTrigger: 'immediate',
+		resultFormat: 'minimal',
+		showPoweredBy: false,
+		highlightColor: '#000',
+		closeColor: '#000',
+		defaultSort: 'relevance',
+		excludedPostTypes: [],
+	},
+	themeOptions: { searchInputSelector: '.search-field' },
+	aggregations: {},
+	hasOverlayWidgets: false,
+	filters: {},
+	staticFilters: {},
+	hasActiveQuery: false,
+	hasError: false,
+	isHistoryNavigation: false,
+	hasNextPage: false,
+	isLoading: false,
+	response: {},
+	searchQuery: '',
+	sort: 'relevance',
+	widgetOutsideOverlay: null,
+	clearQueryValues: noop,
+	disableQueryStringIntegration: noop,
+	initializeQueryValues: noop,
+	setStaticFilter: noop,
+	setFilter: noop,
+	setSearchQuery: noop,
+	setSort: noop,
+};
+
+describe( 'SearchApp — isQueryPending', () => {
+	let makeSearchRequest;
+
+	beforeEach( () => {
+		jest.useFakeTimers();
+		makeSearchRequest = jest.fn();
+		lastSearchResultsProps = {};
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 'is false on initial render', () => {
+		render(
+			<SearchApp { ...defaultProps } searchQuery="" makeSearchRequest={ makeSearchRequest } />
+		);
+		expect( lastSearchResultsProps.isQueryPending ).toBe( false );
+	} );
+
+	it( 'becomes true synchronously when the query changes, before the debounce fires', () => {
+		const utils = render(
+			<SearchApp { ...defaultProps } searchQuery="" makeSearchRequest={ makeSearchRequest } />
+		);
+		utils.rerender(
+			<SearchApp { ...defaultProps } searchQuery="hello" makeSearchRequest={ makeSearchRequest } />
+		);
+
+		expect( lastSearchResultsProps.isQueryPending ).toBe( true );
+		expect( makeSearchRequest ).not.toHaveBeenCalled();
+	} );
+
+	it( 'clears isQueryPending once the debounced request dispatches, handing off to isLoading', () => {
+		const utils = render(
+			<SearchApp { ...defaultProps } searchQuery="" makeSearchRequest={ makeSearchRequest } />
+		);
+		utils.rerender(
+			<SearchApp { ...defaultProps } searchQuery="hello" makeSearchRequest={ makeSearchRequest } />
+		);
+
+		act( () => {
+			jest.advanceTimersByTime( 250 );
+		} );
+
+		// makeSearchRequest firing is what actually dispatches MAKE_SEARCH_REQUEST,
+		// which is what flips the real (redux) isLoading to true in production;
+		// this harness mocks react-redux, so isLoading itself doesn't move here.
+		expect( makeSearchRequest ).toHaveBeenCalledTimes( 1 );
+		expect( lastSearchResultsProps.isQueryPending ).toBe( false );
+
+		// Model the redux handoff explicitly: once isLoading takes over, the
+		// title-visible "pending" state must not get stuck permanently true.
+		utils.rerender(
+			<SearchApp
+				{ ...defaultProps }
+				searchQuery="hello"
+				isLoading={ true }
+				makeSearchRequest={ makeSearchRequest }
+			/>
+		);
+		expect( lastSearchResultsProps.isLoading ).toBe( true );
+		expect( lastSearchResultsProps.isQueryPending ).toBe( false );
+	} );
+
+	it( 'becomes true on mount when isInCustomizer triggers an immediate request', () => {
+		render(
+			<SearchApp
+				{ ...defaultProps }
+				isInCustomizer={ true }
+				makeSearchRequest={ makeSearchRequest }
+			/>
+		);
+
+		expect( lastSearchResultsProps.isQueryPending ).toBe( true );
+		expect( makeSearchRequest ).not.toHaveBeenCalled();
+
+		act( () => {
+			jest.advanceTimersByTime( 250 );
+		} );
+
+		expect( makeSearchRequest ).toHaveBeenCalledTimes( 1 );
+		expect( lastSearchResultsProps.isQueryPending ).toBe( false );
+	} );
+
+	it( 'does not mark a query pending for pagination (loadNextPage)', () => {
+		render(
+			<SearchApp
+				{ ...defaultProps }
+				hasNextPage={ true }
+				response={ { page_handle: 'abc' } }
+				makeSearchRequest={ makeSearchRequest }
+			/>
+		);
+		lastSearchResultsProps.onLoadNextPage();
+
+		expect( lastSearchResultsProps.isQueryPending ).toBe( false );
+
+		act( () => {
+			jest.advanceTimersByTime( 250 );
+		} );
+
+		expect( makeSearchRequest ).toHaveBeenCalledTimes( 1 );
+		expect( lastSearchResultsProps.isQueryPending ).toBe( false );
+	} );
+} );

--- a/projects/packages/search/src/instant-search/components/test/search-app-query-pending.test.jsx
+++ b/projects/packages/search/src/instant-search/components/test/search-app-query-pending.test.jsx
@@ -154,17 +154,15 @@ describe( 'SearchApp — isQueryPending', () => {
 		expect( lastSearchResultsProps.isQueryPending ).toBe( false );
 	} );
 
-	it( 'becomes true on mount when isInCustomizer triggers an immediate request', () => {
-		render(
-			<SearchApp
-				{ ...defaultProps }
-				isInCustomizer={ true }
-				makeSearchRequest={ makeSearchRequest }
-			/>
+	it( 'does not mark a query pending when the query is cleared to empty (e.g. a filter-link click)', () => {
+		const utils = render(
+			<SearchApp { ...defaultProps } searchQuery="foo" makeSearchRequest={ makeSearchRequest } />
+		);
+		utils.rerender(
+			<SearchApp { ...defaultProps } searchQuery="" makeSearchRequest={ makeSearchRequest } />
 		);
 
-		expect( lastSearchResultsProps.isQueryPending ).toBe( true );
-		expect( makeSearchRequest ).not.toHaveBeenCalled();
+		expect( lastSearchResultsProps.isQueryPending ).toBe( false );
 
 		act( () => {
 			jest.advanceTimersByTime( 250 );

--- a/projects/packages/search/src/instant-search/components/test/search-results-title.test.jsx
+++ b/projects/packages/search/src/instant-search/components/test/search-results-title.test.jsx
@@ -38,9 +38,8 @@ describe( 'SearchResults#getSearchTitle — isQueryPending / isLoading', () => {
 		expect( titleFor( { response: { total: 0 } } ) ).toBe( 'No results found' );
 	} );
 
-	// These four use a completed `{ total: 0 }` response (rather than the
-	// default `{}`) so the loading branch is exercised only via the flag
-	// under test, not incidentally via hasCompletedSearch being false too.
+	// Uses a completed `{ total: 0 }` response so the branch under test
+	// isn't reached incidentally via hasCompletedSearch being false too.
 	it( 'shows "Searching…" while isQueryPending is true, even with a stale zero-result response', () => {
 		expect(
 			titleFor( { searchQuery: 'hello', response: { total: 0 }, isQueryPending: true } )
@@ -103,11 +102,6 @@ describe( 'SearchResults#getSearchTitle — no search has completed yet', () => 
 	} );
 
 	it( 'a completed response with a `requestId` but no `total` key does not get mistaken for "never searched"', () => {
-		// Every response the API layer produces carries a `requestId`
-		// (see lib/api.js's responseHandlerFactory); a shape that happens to
-		// omit `total` must still be treated as a completed search, falling
-		// through to the total===0 default rather than sticking on a loading
-		// message forever.
 		expect(
 			titleFor( {
 				searchQuery: 'hello',
@@ -121,11 +115,6 @@ describe( 'SearchResults#getSearchTitle — no search has completed yet', () => 
 
 describe( 'SearchResults#getSearchTitle — hasQuery must not be affected by the null/"" distinction', () => {
 	it( 'still shows "Found N results", not "Showing popular results", for searchQuery: null with a completed non-empty response', () => {
-		// searchQuery is null (not '') e.g. for a URL/filter-driven search with
-		// no typed keyword, or the Customberg/Customizer preview default. hasQuery
-		// (searchQuery !== '') is deliberately untouched by the loading-branch's
-		// null-vs-'' fix, so this pre-existing "Found N results" behavior for a
-		// null searchQuery must not change.
 		expect(
 			titleFor( {
 				searchQuery: null,

--- a/projects/packages/search/src/instant-search/components/test/search-results-title.test.jsx
+++ b/projects/packages/search/src/instant-search/components/test/search-results-title.test.jsx
@@ -1,0 +1,58 @@
+/**
+ * Tests for SEARCH-311: getSearchTitle() must not fall through to
+ * "No results found" while a query is pending (isQueryPending) or actually
+ * loading (isLoading), regardless of a stale/empty response.total.
+ */
+
+// getSearchTitle() doesn't touch any of these; mocked to avoid pulling in
+// unrelated module-level dependencies (e.g. jetpack-colophon's PALETTE, which
+// is only defined via webpack DefinePlugin at build time, not under Jest).
+jest.mock( '../answers-panel', () => () => null );
+jest.mock( '../gridicon', () => () => null );
+jest.mock( '../jetpack-colophon', () => () => null );
+jest.mock( '../notice', () => () => null );
+jest.mock( '../scroll-button', () => () => null );
+jest.mock( '../search-controls', () => () => null );
+jest.mock( '../search-form', () => () => null );
+jest.mock( '../search-result', () => () => null );
+jest.mock( '../sidebar', () => () => null );
+jest.mock( '../tabbed-search-filters', () => () => null );
+
+import SearchResults from '../search-results';
+
+const baseProps = {
+	response: {},
+	searchQuery: '',
+	staticFilters: {},
+	hasError: false,
+	isLoading: false,
+	isQueryPending: false,
+};
+
+const titleFor = props => new SearchResults( { ...baseProps, ...props } ).getSearchTitle();
+
+describe( 'SearchResults#getSearchTitle — isQueryPending', () => {
+	it( 'shows "No results found" when nothing is loading or pending and total is 0', () => {
+		expect( titleFor( {} ) ).toBe( 'No results found' );
+	} );
+
+	it( 'shows "Searching…" while isQueryPending is true, even with a stale empty response', () => {
+		expect( titleFor( { searchQuery: 'hello', isQueryPending: true } ) ).toBe( 'Searching…' );
+	} );
+
+	it( 'shows "Loading popular results…" while isQueryPending is true with no query', () => {
+		expect( titleFor( { searchQuery: '', isQueryPending: true } ) ).toBe(
+			'Loading popular results…'
+		);
+	} );
+
+	it( 'still shows "Searching…" while isLoading is true (existing behavior)', () => {
+		expect( titleFor( { searchQuery: 'hello', isLoading: true } ) ).toBe( 'Searching…' );
+	} );
+
+	it( 'falls through to "No results found" once neither pending nor loading, with a stale empty response', () => {
+		expect( titleFor( { searchQuery: 'hello', isQueryPending: false, isLoading: false } ) ).toBe(
+			'No results found'
+		);
+	} );
+} );

--- a/projects/packages/search/src/instant-search/components/test/search-results-title.test.jsx
+++ b/projects/packages/search/src/instant-search/components/test/search-results-title.test.jsx
@@ -1,7 +1,9 @@
 /**
  * Tests for SEARCH-311: getSearchTitle() must not fall through to
  * "No results found" while a query is pending (isQueryPending) or actually
- * loading (isLoading), regardless of a stale/empty response.total.
+ * loading (isLoading), regardless of a stale/empty response.total — nor
+ * while no search has completed yet at all (e.g. the initial empty response
+ * object before any request has been dispatched).
  */
 
 // getSearchTitle() doesn't touch any of these; mocked to avoid pulling in
@@ -31,23 +33,30 @@ const baseProps = {
 
 const titleFor = props => new SearchResults( { ...baseProps, ...props } ).getSearchTitle();
 
-describe( 'SearchResults#getSearchTitle — isQueryPending', () => {
+describe( 'SearchResults#getSearchTitle — isQueryPending / isLoading', () => {
 	it( 'shows "No results found" when a search has actually completed with total 0', () => {
 		expect( titleFor( { response: { total: 0 } } ) ).toBe( 'No results found' );
 	} );
 
-	it( 'shows "Searching…" while isQueryPending is true, even with a stale empty response', () => {
-		expect( titleFor( { searchQuery: 'hello', isQueryPending: true } ) ).toBe( 'Searching…' );
+	// These four use a completed `{ total: 0 }` response (rather than the
+	// default `{}`) so the loading branch is exercised only via the flag
+	// under test, not incidentally via hasCompletedSearch being false too.
+	it( 'shows "Searching…" while isQueryPending is true, even with a stale zero-result response', () => {
+		expect(
+			titleFor( { searchQuery: 'hello', response: { total: 0 }, isQueryPending: true } )
+		).toBe( 'Searching…' );
 	} );
 
 	it( 'shows "Loading popular results…" while isQueryPending is true with no query', () => {
-		expect( titleFor( { searchQuery: '', isQueryPending: true } ) ).toBe(
+		expect( titleFor( { searchQuery: '', response: { total: 0 }, isQueryPending: true } ) ).toBe(
 			'Loading popular results…'
 		);
 	} );
 
 	it( 'still shows "Searching…" while isLoading is true (existing behavior)', () => {
-		expect( titleFor( { searchQuery: 'hello', isLoading: true } ) ).toBe( 'Searching…' );
+		expect( titleFor( { searchQuery: 'hello', response: { total: 0 }, isLoading: true } ) ).toBe(
+			'Searching…'
+		);
 	} );
 
 	it( 'falls through to "No results found" once neither pending nor loading, with a completed empty response', () => {
@@ -73,6 +82,12 @@ describe( 'SearchResults#getSearchTitle — no search has completed yet', () => 
 		expect(
 			titleFor( { searchQuery: 'hello', response: {}, isQueryPending: false, isLoading: false } )
 		).toBe( 'Searching…' );
+	} );
+
+	it( 'shows "Loading popular results…", not "Searching…", when searchQuery is null (its real initial value, not "")', () => {
+		expect(
+			titleFor( { searchQuery: null, response: {}, isQueryPending: false, isLoading: false } )
+		).toBe( 'Loading popular results…' );
 	} );
 
 	it( 'still shows "No results found" for an empty response when hasError is true', () => {

--- a/projects/packages/search/src/instant-search/components/test/search-results-title.test.jsx
+++ b/projects/packages/search/src/instant-search/components/test/search-results-title.test.jsx
@@ -32,8 +32,8 @@ const baseProps = {
 const titleFor = props => new SearchResults( { ...baseProps, ...props } ).getSearchTitle();
 
 describe( 'SearchResults#getSearchTitle — isQueryPending', () => {
-	it( 'shows "No results found" when nothing is loading or pending and total is 0', () => {
-		expect( titleFor( {} ) ).toBe( 'No results found' );
+	it( 'shows "No results found" when a search has actually completed with total 0', () => {
+		expect( titleFor( { response: { total: 0 } } ) ).toBe( 'No results found' );
 	} );
 
 	it( 'shows "Searching…" while isQueryPending is true, even with a stale empty response', () => {
@@ -50,9 +50,40 @@ describe( 'SearchResults#getSearchTitle — isQueryPending', () => {
 		expect( titleFor( { searchQuery: 'hello', isLoading: true } ) ).toBe( 'Searching…' );
 	} );
 
-	it( 'falls through to "No results found" once neither pending nor loading, with a stale empty response', () => {
-		expect( titleFor( { searchQuery: 'hello', isQueryPending: false, isLoading: false } ) ).toBe(
-			'No results found'
-		);
+	it( 'falls through to "No results found" once neither pending nor loading, with a completed empty response', () => {
+		expect(
+			titleFor( {
+				searchQuery: 'hello',
+				response: { total: 0 },
+				isQueryPending: false,
+				isLoading: false,
+			} )
+		).toBe( 'No results found' );
+	} );
+} );
+
+describe( 'SearchResults#getSearchTitle — no search has completed yet', () => {
+	it( 'shows "Loading popular results…" for the initial empty response, not "No results found"', () => {
+		expect(
+			titleFor( { searchQuery: '', response: {}, isQueryPending: false, isLoading: false } )
+		).toBe( 'Loading popular results…' );
+	} );
+
+	it( 'shows "Searching…" for the initial empty response with a query, not "No results found"', () => {
+		expect(
+			titleFor( { searchQuery: 'hello', response: {}, isQueryPending: false, isLoading: false } )
+		).toBe( 'Searching…' );
+	} );
+
+	it( 'still shows "No results found" for an empty response when hasError is true', () => {
+		expect(
+			titleFor( {
+				searchQuery: 'hello',
+				response: {},
+				hasError: true,
+				isQueryPending: false,
+				isLoading: false,
+			} )
+		).toBe( 'No results found' );
 	} );
 } );

--- a/projects/packages/search/src/instant-search/components/test/search-results-title.test.jsx
+++ b/projects/packages/search/src/instant-search/components/test/search-results-title.test.jsx
@@ -101,4 +101,38 @@ describe( 'SearchResults#getSearchTitle — no search has completed yet', () => 
 			} )
 		).toBe( 'No results found' );
 	} );
+
+	it( 'a completed response with a `requestId` but no `total` key does not get mistaken for "never searched"', () => {
+		// Every response the API layer produces carries a `requestId`
+		// (see lib/api.js's responseHandlerFactory); a shape that happens to
+		// omit `total` must still be treated as a completed search, falling
+		// through to the total===0 default rather than sticking on a loading
+		// message forever.
+		expect(
+			titleFor( {
+				searchQuery: 'hello',
+				response: { requestId: 1, results: [ {} ] },
+				isQueryPending: false,
+				isLoading: false,
+			} )
+		).toBe( 'No results found' );
+	} );
+} );
+
+describe( 'SearchResults#getSearchTitle — hasQuery must not be affected by the null/"" distinction', () => {
+	it( 'still shows "Found N results", not "Showing popular results", for searchQuery: null with a completed non-empty response', () => {
+		// searchQuery is null (not '') e.g. for a URL/filter-driven search with
+		// no typed keyword, or the Customberg/Customizer preview default. hasQuery
+		// (searchQuery !== '') is deliberately untouched by the loading-branch's
+		// null-vs-'' fix, so this pre-existing "Found N results" behavior for a
+		// null searchQuery must not change.
+		expect(
+			titleFor( {
+				searchQuery: null,
+				response: { total: 12 },
+				isQueryPending: false,
+				isLoading: false,
+			} )
+		).toBe( 'Found 12 results' );
+	} );
 } );


### PR DESCRIPTION
Fixes SEARCH-311

## Proposed changes
* Track a synchronous `isQueryPending` state in `SearchApp`, set the instant a non-empty query/sort/filter change is detected (the `onChangeQueryString` path), and cleared once the debounced request actually dispatches.
* Pass `isQueryPending` down to `SearchResults` as a prop separate from `isLoading`, and have `getSearchTitle()` treat it the same as `isLoading` so it renders "Searching…" / "Loading popular results…" instead of falling through to "No results found" while a request is queued but not yet dispatched.
* Fix a second, earlier flash: the reducer's initial `response` state is `{}`, so `getSearchTitle()`'s `total = 0` default made it render "No results found" from page load, before any search had ever been dispatched — including the moment the overlay first opens with an empty query. `getSearchTitle()` now distinguishes "no search has completed yet" (no `requestId` or `total` in `response`, and no error) from "a completed search that found zero results," and treats the former like a loading state.
* Fix a related bug this introduced: the initial `searchQuery` value is `null`, not `''`, so the new loading check needed its own null-safe check rather than reusing the existing `hasQuery` flag — reusing it would have changed "Found N results" to "Showing popular results" for query-less searches (e.g. a filter/URL-driven search, or the Customberg/Customizer preview default).

## Related product discussion/links

N/A

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Open a site with Jetpack Instant Search enabled.
* Open the search overlay with an empty query (e.g. click the search icon without typing anything).
  * Before this fix: a brief flash of "No results found" before it switches to "Loading popular results…" and then real results.
  * After this fix: it goes straight to "Loading popular results…" — no "No results found" flash.
* Type a query.
  * Before this fix: right after each keystroke there's a brief flash of "No results found" before it switches to "Searching…" and then the real results, because the search request is debounced 200ms but nothing marks that a request is pending during that window.
  * After this fix: the title goes straight to "Searching…" — no "No results found" flash.
* A genuine no-match query (e.g. a query unlikely to match anything) still ends on "No results found" once the search completes.
* `jp test js packages/search` and `jp test php packages/search` both pass, including new tests covering the pending-state transitions (`search-app-query-pending.test.jsx`) and the `getSearchTitle()` branch logic (`search-results-title.test.jsx`).
