### PR TITLE
Modules: modernize the modules page and improve Offline Mode

### DIFF
--- a/projects/plugins/jetpack/_inc/jetpack-modules.js
+++ b/projects/plugins/jetpack/_inc/jetpack-modules.js
@@ -38,7 +38,19 @@
 
 	$the_filters.on( 'click', '.button-group .button', { modules: modules }, function ( event ) {
 		event.preventDefault();
-		$( this ).addClass( 'active' ).siblings( '.active' ).removeClass( 'active' );
+		var $button = $( this );
+
+		// The "View" filter is split across two visual groups (State and Purpose)
+		// but still represents a single, mutually-exclusive selection. Clearing the
+		// active state across every `.filter-active` group keeps only one filter
+		// active at a time. Other groups (e.g. Sort) stay self-contained.
+		if ( $button.closest( '.button-group' ).hasClass( 'filter-active' ) ) {
+			$( '.button-group.filter-active .button.active' ).removeClass( 'active' );
+			$button.addClass( 'active' );
+		} else {
+			$button.addClass( 'active' ).siblings( '.active' ).removeClass( 'active' );
+		}
+
 		modules.trigger( 'change' );
 	} );
 

--- a/projects/plugins/jetpack/_inc/jetpack-modules.js
+++ b/projects/plugins/jetpack/_inc/jetpack-modules.js
@@ -1,7 +1,7 @@
 ( function ( window, $, items, models, views, i18n, modalinfo, nonces ) {
 	'use strict';
 
-	var modules, list_table, handle_module_tag_click, $the_filters, $the_search, $bulk_button;
+	var modules, list_table, handle_facet_click, $the_filters, $the_search, $bulk_button;
 
 	$the_filters = $( '.navbar-form' );
 	$the_search = $( '#srch-term-search-input' );
@@ -20,47 +20,53 @@
 	// Kick off an initial redraw.
 	modules.trigger( 'change' );
 
-	// Handle the filtering of modules.
-	handle_module_tag_click = function ( event ) {
-		$( '.subsubsub' ).find( 'li.current' ).removeClass( 'current' );
-
-		// Switch the item in the subsubsub list that's flagged as current.
-		$( '.subsubsub' )
-			.find( 'a[data-title="' + $( this ).data( 'title' ) + '"]' )
-			.closest( 'li' )
-			.addClass( 'current' );
-
+	// Handle the filtering of modules. The tag list (".subsubsub") and the
+	// "Purpose" list (".purpose-filter") are independent single-select facets
+	// that share this behaviour and combine with one another.
+	handle_facet_click = function ( event ) {
 		event.preventDefault();
+
+		var $link = $( this );
+
+		// Ignore facets greyed out because they have no matches under the current filters.
+		if ( $link.closest( 'li' ).hasClass( 'is-empty' ) ) {
+			return;
+		}
+
+		// Move the "current" selection within this facet list only.
+		var $list = $link.closest( '.subsubsub, .purpose-filter' );
+		$list.find( 'li.current' ).removeClass( 'current' );
+		$link.closest( 'li' ).addClass( 'current' );
+
 		modules.trigger( 'change' );
 	};
 
-	$( '.subsubsub a' ).on( 'click', { modules: modules }, handle_module_tag_click );
+	$( '.subsubsub a, .purpose-filter a' ).on( 'click', handle_facet_click );
 
 	$the_filters.on( 'click', '.button-group .button', { modules: modules }, function ( event ) {
 		event.preventDefault();
-		var $button = $( this );
 
-		// The "View" filter is split across two visual groups (State and Purpose)
-		// but still represents a single, mutually-exclusive selection. Clearing the
-		// active state across every `.filter-active` group keeps only one filter
-		// active at a time. Other groups (e.g. Sort) stay self-contained.
-		if ( $button.closest( '.button-group' ).hasClass( 'filter-active' ) ) {
-			$( '.button-group.filter-active .button.active' ).removeClass( 'active' );
-			$button.addClass( 'active' );
-		} else {
-			$button.addClass( 'active' ).siblings( '.active' ).removeClass( 'active' );
-		}
+		// Each button group is an independent, single-select facet: activating a
+		// button clears only its siblings. State and Purpose are separate groups,
+		// so their selections combine rather than replacing one another.
+		$( this ).addClass( 'active' ).siblings( '.active' ).removeClass( 'active' );
 
 		modules.trigger( 'change' );
 	} );
 
-	$the_search.on( 'keyup search', function ( e ) {
-		// Don't trigger change on tab, since it's only used for accessibility
-		// anyway, and will remove all checked boxes
-		if ( e.code !== 'Tab' ) {
-			modules.trigger( 'change' );
-		}
-	} );
+	$the_search.on(
+		'keyup search',
+		// Debounce so we re-render (and history.replaceState) once the user
+		// pauses typing rather than on every keystroke. This keeps the ~50-row
+		// rebuild off the critical path and avoids Safari's replaceState rate limit.
+		window._.debounce( function ( e ) {
+			// Don't trigger change on tab, since it's only used for accessibility
+			// anyway, and will remove all checked boxes
+			if ( e.code !== 'Tab' ) {
+				modules.trigger( 'change' );
+			}
+		}, 200 )
+	);
 
 	$the_search.prop( 'placeholder', i18n.search_placeholder );
 

--- a/projects/plugins/jetpack/_inc/jetpack-modules.models.js
+++ b/projects/plugins/jetpack/_inc/jetpack-modules.models.js
@@ -16,8 +16,16 @@ window.jetpackModules.models = ( function ( window, $, Backbone ) {
 			var subsubsub = $( '.subsubsub .current a' ),
 				items = Object.values( this.get( 'raw' ) ),
 				m_filter = $( '.button-group.filter-active .active' ),
+				m_availability = $( '.button-group.availability-filter .active' ),
 				m_sort = $( '.button-group.sort .active' ),
 				m_search = $( '#srch-term-search-input' ).val().toLowerCase();
+
+			// Offline-mode top-level filter: when "Hide unavailable" is selected,
+			// drop every module that isn't available offline, regardless of the
+			// other filters below it.
+			if ( 'hide-unavailable' === m_availability.data( 'availability' ) ) {
+				items = items.filter( item => item.available );
+			}
 
 			// If a module filter has been selected, filter it!
 			if ( ! subsubsub.closest( 'li' ).hasClass( 'all' ) ) {
@@ -56,9 +64,21 @@ window.jetpackModules.models = ( function ( window, $, Backbone ) {
 				);
 			}
 
-			// Sort unavailable modules to the end if the user is running in local mode.
-			// JS sort is supposed to be stable since 2019, and is in browsers we care about, so this is safe.
-			items.sort( ( a, b ) => b.available - a.available );
+			// Group by product group (primary), then push unavailable modules to
+			// the end of their group. Any user-selected sort above is preserved
+			// within a group because Array.prototype.sort is stable in the
+			// browsers we support.
+			var groupOrder = { growth: 0, performance: 1, security: 2, other: 3 };
+			items.sort( function ( a, b ) {
+				var ga = groupOrder[ a.product_group ] !== undefined ? groupOrder[ a.product_group ] : 99;
+				var gb = groupOrder[ b.product_group ] !== undefined ? groupOrder[ b.product_group ] : 99;
+
+				if ( ga !== gb ) {
+					return ga - gb;
+				}
+
+				return ( b.available ? 1 : 0 ) - ( a.available ? 1 : 0 );
+			} );
 
 			// Now shove it back in.
 			this.set( 'items', items );

--- a/projects/plugins/jetpack/_inc/jetpack-modules.models.js
+++ b/projects/plugins/jetpack/_inc/jetpack-modules.models.js
@@ -9,15 +9,24 @@ window.jetpackModules.models = ( function ( window, $, Backbone ) {
 		visibles: {},
 
 		/**
-		 * Updates modules.items dataset to be a reflection of both the current
-		 * modules.raw data, as well as any filters or sorting that may be in effect.
+		 * Applies the active availability, tag, state/purpose and search filters
+		 * to the raw module set and returns the matching items (unsorted).
+		 *
+		 * @param {Object}  [options]               Filtering options.
+		 * @param {boolean} [options.ignoreTag]     When true, skip the "Show" tag
+		 *                                          facet so counts can be computed independently of the current tag
+		 *                                          selection (faceted counting).
+		 * @param {boolean} [options.ignorePurpose] When true, skip the "Purpose"
+		 *                                          facet so its own faceted counts can be computed.
+		 * @return {Array} Filtered module items.
 		 */
-		filter_and_sort: function () {
+		apply_filters: function ( options ) {
+			options = options || {};
+
 			var subsubsub = $( '.subsubsub .current a' ),
+				purpose = $( '.purpose-filter .current a' ),
 				items = Object.values( this.get( 'raw' ) ),
-				m_filter = $( '.button-group.filter-active .active' ),
 				m_availability = $( '.button-group.availability-filter .active' ),
-				m_sort = $( '.button-group.sort .active' ),
 				m_search = $( '#srch-term-search-input' ).val().toLowerCase();
 
 			// Offline-mode top-level filter: when "Hide unavailable" is selected,
@@ -27,16 +36,29 @@ window.jetpackModules.models = ( function ( window, $, Backbone ) {
 				items = items.filter( item => item.available );
 			}
 
-			// If a module filter has been selected, filter it!
-			if ( ! subsubsub.closest( 'li' ).hasClass( 'all' ) ) {
+			// Tag facet ("Show"). Skipped when computing that facet's own counts.
+			if ( ! options.ignoreTag && ! subsubsub.closest( 'li' ).hasClass( 'all' ) ) {
 				items = items.filter( item => item.module_tags.includes( subsubsub.data( 'title' ) ) );
 			}
 
-			if ( m_filter.data( 'filter-by' ) ) {
-				items = items.filter(
-					item => item[ m_filter.data( 'filter-by' ) ] === m_filter.data( 'filter-value' )
-				);
+			// Purpose facet. Skipped when computing that facet's own counts.
+			if (
+				! options.ignorePurpose &&
+				purpose.length &&
+				! purpose.closest( 'li' ).hasClass( 'all' )
+			) {
+				items = items.filter( item => item.product_group === purpose.data( 'group' ) );
 			}
+
+			// State facet (segmented buttons). "All" carries no data-filter-by.
+			$( '.button-group.module-filter .active' ).each( function () {
+				var by = $( this ).data( 'filter-by' ),
+					value = $( this ).data( 'filter-value' );
+
+				if ( by ) {
+					items = items.filter( item => item[ by ] === value );
+				}
+			} );
 
 			if ( m_search.length ) {
 				items = items.filter( function ( item ) {
@@ -54,15 +76,61 @@ window.jetpackModules.models = ( function ( window, $, Backbone ) {
 				} );
 			}
 
-			if ( m_sort.data( 'sort-by' ) ) {
-				const key = m_sort.data( 'sort-by' );
-				const cmpret = 'reverse' === m_sort.data( 'sort-order' ) ? -1 : 1;
+			return items;
+		},
 
-				items.sort( ( a, b ) =>
-					// eslint-disable-next-line no-nested-ternary
-					a[ key ] > b[ key ] ? cmpret : a[ key ] < b[ key ] ? -cmpret : 0
-				);
-			}
+		/**
+		 * Computes, for the "Show" tag list, how many modules match every active
+		 * filter except the tag facet itself. This powers faceted counts that
+		 * stay meaningful as the user narrows the other filters.
+		 *
+		 * @return {Object} Map of translated tag title to count, plus an
+		 *   `__all__` key holding the total across all tags.
+		 */
+		tag_counts: function () {
+			var base = this.apply_filters( { ignoreTag: true } ),
+				counts = { __all__: base.length };
+
+			base.forEach( function ( item ) {
+				( item.module_tags || [] ).forEach( function ( tag ) {
+					counts[ tag ] = ( counts[ tag ] || 0 ) + 1;
+				} );
+			} );
+
+			return counts;
+		},
+
+		/**
+		 * Computes, for the "Purpose" list, how many modules fall in each product
+		 * group under every active filter except the Purpose facet itself. Mirrors
+		 * tag_counts() so the two facet lists behave identically.
+		 *
+		 * @return {Object} Map of product-group slug to count, plus an `__all__`
+		 *   key holding the total across all groups.
+		 */
+		purpose_counts: function () {
+			var base = this.apply_filters( { ignorePurpose: true } ),
+				counts = { __all__: base.length };
+
+			base.forEach( function ( item ) {
+				if ( item.product_group ) {
+					counts[ item.product_group ] = ( counts[ item.product_group ] || 0 ) + 1;
+				}
+			} );
+
+			return counts;
+		},
+
+		/**
+		 * Updates modules.items dataset to be a reflection of both the current
+		 * modules.raw data, as well as any filters or sorting that may be in effect.
+		 */
+		filter_and_sort: function () {
+			var items = this.apply_filters();
+
+			// Default alphabetical order by name. The product-group sort below is
+			// stable, so this ordering is preserved within each group.
+			items.sort( ( a, b ) => a.name.localeCompare( b.name ) );
 
 			// Group by product group (primary), then push unavailable modules to
 			// the end of their group. Any user-selected sort above is preserved

--- a/projects/plugins/jetpack/_inc/jetpack-modules.views.js
+++ b/projects/plugins/jetpack/_inc/jetpack-modules.views.js
@@ -20,11 +20,18 @@ window.jetpackModules.views = ( function ( window, $, Backbone, wp ) {
 			var url = window.location.href.split( '?' )[ 0 ] + '?page=jetpack_modules',
 				m_tag = $( '.subsubsub .current' ),
 				m_filter = $( '.button-group.filter-active .active' ),
+				m_availability = $( '.button-group.availability-filter .active' ),
 				m_sort = $( '.button-group.sort .active' ),
 				m_search = $( '#srch-term-search-input' ).val();
 
 			if ( m_search.length ) {
 				url += '&s=' + encodeURIComponent( m_search );
+			}
+
+			// "Hide unavailable" is the default in Offline Mode, so only the opt-out
+			// ("All") needs to be persisted in the URL.
+			if ( 'all' === m_availability.data( 'availability' ) ) {
+				url += '&offline_available=all';
 			}
 
 			if ( ! m_tag.hasClass( 'all' ) ) {

--- a/projects/plugins/jetpack/_inc/jetpack-modules.views.js
+++ b/projects/plugins/jetpack/_inc/jetpack-modules.views.js
@@ -19,9 +19,8 @@ window.jetpackModules.views = ( function ( window, $, Backbone, wp ) {
 
 			var url = window.location.href.split( '?' )[ 0 ] + '?page=jetpack_modules',
 				m_tag = $( '.subsubsub .current' ),
-				m_filter = $( '.button-group.filter-active .active' ),
+				m_purpose = $( '.purpose-filter .current' ),
 				m_availability = $( '.button-group.availability-filter .active' ),
-				m_sort = $( '.button-group.sort .active' ),
 				m_search = $( '#srch-term-search-input' ).val();
 
 			if ( m_search.length ) {
@@ -38,24 +37,60 @@ window.jetpackModules.views = ( function ( window, $, Backbone, wp ) {
 				url += '&module_tag=' + encodeURIComponent( m_tag.find( 'a' ).data( 'title' ) );
 			}
 
-			if ( m_filter.data( 'filter-by' ) ) {
-				url +=
-					'&' +
-					encodeURIComponent( m_filter.data( 'filter-by' ) ) +
-					'=' +
-					encodeURIComponent( m_filter.data( 'filter-value' ) );
+			if ( m_purpose.length && ! m_purpose.hasClass( 'all' ) ) {
+				url += '&product_group=' + encodeURIComponent( m_purpose.find( 'a' ).data( 'group' ) );
 			}
 
-			if ( 'name' !== m_sort.data( 'sort-by' ) ) {
-				url += '&sort_by=' + encodeURIComponent( m_sort.data( 'sort-by' ) );
-			}
+			// State facet (segmented buttons). "All" carries no data-filter-by.
+			$( '.button-group.module-filter .active' ).each( function () {
+				var by = $( this ).data( 'filter-by' ),
+					value = $( this ).data( 'filter-value' );
+
+				if ( by ) {
+					url += '&' + encodeURIComponent( by ) + '=' + encodeURIComponent( value );
+				}
+			} );
 
 			window.history.replaceState( {}, '', url );
+		},
+
+		/**
+		 * Writes faceted counts into a facet list (the tag list or the Purpose
+		 * list), and greys out entries that have no matches under the current
+		 * filters. The "All" entry always shows the total and is never disabled.
+		 *
+		 * @param {string} selector Facet list selector (e.g. '.subsubsub').
+		 * @param {Object} counts   Map of key to count, plus `__all__`.
+		 * @param {string} dataKey  data-* attribute on each link holding its key.
+		 */
+		updateFacetCounts: function ( selector, counts, dataKey ) {
+			$( selector + ' > li' ).each( function () {
+				var $li = $( this ),
+					isAll = $li.hasClass( 'all' ),
+					key = $li.children( 'a' ).data( dataKey ),
+					n = isAll ? counts.__all__ : counts[ key ] || 0;
+
+				$li.find( '.count' ).text( '(' + n + ')' );
+
+				if ( ! isAll ) {
+					$li.toggleClass( 'is-empty', 0 === n );
+				}
+			} );
+		},
+
+		/**
+		 * Refreshes both facet lists ("Show" tags and "Purpose") so their counts
+		 * reflect the currently-active filters.
+		 */
+		updateCounts: function () {
+			this.updateFacetCounts( '.subsubsub', this.model.tag_counts(), 'title' );
+			this.updateFacetCounts( '.purpose-filter', this.model.purpose_counts(), 'group' );
 		},
 
 		render: function () {
 			this.model.filter_and_sort();
 			this.$el.html( this.template( this.model.attributes ) );
+			this.updateCounts();
 			this.updateUrl();
 			return this;
 		},

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-admin-page.php
@@ -277,8 +277,9 @@ abstract class Jetpack_Admin_Page {
 						<h2 class="jp-masthead__title">
 							<?php
 							// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- View logic only.
-							$page          = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : '';
-							$current_label = '';
+							$page            = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : '';
+							$is_offline_mode = ( new Status() )->is_offline_mode();
+							$current_label   = '';
 							if ( 'jetpack_modules' === $page ) {
 								$current_label = __( 'Modules', 'jetpack' );
 							} elseif ( 'jetpack_about' === $page ) {
@@ -290,6 +291,10 @@ abstract class Jetpack_Admin_Page {
 							<?php if ( $current_label ) : ?>
 								<a class="jp-masthead__title-link" href="<?php echo esc_url( admin_url( 'admin.php?page=my-jetpack#/overview' ) ); ?>">Jetpack</a><?php // "Jetpack" is a product name, do not translate. ?>
 								<span class="jp-masthead__title-separator" aria-hidden="true">/</span>
+								<?php if ( $is_offline_mode ) : ?>
+									<span class="jp-masthead__title-offline"><?php esc_html_e( 'Offline Mode', 'jetpack' ); ?></span>
+									<span class="jp-masthead__title-separator" aria-hidden="true">/</span>
+								<?php endif; ?>
 								<span class="jp-masthead__title-current"><?php echo esc_html( $current_label ); ?></span>
 							<?php else : ?>
 								Jetpack<?php // "Jetpack" is a product name, do not translate. ?>

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -1,6 +1,9 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 
+use Automattic\Jetpack\Admin_UI\Admin_Menu;
 use Automattic\Jetpack\Assets;
+use Automattic\Jetpack\Redirect;
+use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Tracking;
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -34,6 +37,24 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 	 * Adds the Settings sub menu.
 	 */
 	public function get_page_hook() {
+		/*
+		 * In Offline Mode the cloud dashboard and My Jetpack don't initialize, so
+		 * surface the Modules page as a visible, first-position item under the
+		 * Jetpack top-level menu. This makes the top-level "Jetpack" menu land on
+		 * Modules (instead of the first cloud page, e.g. AI) while leaving the
+		 * "Settings" item free to point at the real settings dashboard.
+		 */
+		if ( ( new Status() )->is_offline_mode() ) {
+			return Admin_Menu::add_menu(
+				__( 'Jetpack Settings', 'jetpack' ),
+				__( 'Modules', 'jetpack' ),
+				'jetpack_manage_modules',
+				'jetpack_modules',
+				array( $this, 'render' ),
+				1
+			);
+		}
+
 		return add_submenu_page(
 			'',
 			__( 'Jetpack Settings', 'jetpack' ),
@@ -50,6 +71,15 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 	 */
 	public function page_render() {
 		$list_table = new Jetpack_Modules_List_Table();
+
+		// Currently selected product group filter (used to highlight the active View button).
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is view logic.
+		$current_group = isset( $_GET['product_group'] ) ? sanitize_text_field( wp_unslash( $_GET['product_group'] ) ) : '';
+
+		$is_offline_mode = ( new Status() )->is_offline_mode();
+		// Currently selected offline-availability filter (only meaningful in Offline Mode).
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is view logic.
+		$current_availability = isset( $_GET['offline_available'] ) ? sanitize_text_field( wp_unslash( $_GET['offline_available'] ) ) : '';
 
 		// We have static.html so let's continue trying to fetch the others.
 		$noscript_notice = @file_get_contents( JETPACK__PLUGIN_DIR . '_inc/build/static-noscript-notice.html' ); //phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents, Not fetching a remote file.
@@ -84,39 +114,60 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 		?>
 
 		<div class="jetpack-module-list">
+			<?php if ( $is_offline_mode ) : ?>
+				<div class="wrap">
+					<div class="jetpack-offline-notice">
+						<p class="jetpack-offline-notice__title"><?php esc_html_e( "You're working in Offline Mode", 'jetpack' ); ?></p>
+						<p class="jetpack-offline-notice__text">
+							<?php esc_html_e( 'Jetpack is running in Offline Mode, so features that need a connection to WordPress.com are paused for now — this is completely normal for local and development sites. Go ahead and activate or configure any of the modules below that work offline.', 'jetpack' ); ?>
+							<a href="<?php echo esc_url( Redirect::get_url( 'jetpack-support-development-mode' ) ); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e( 'Learn more about Offline Mode.', 'jetpack' ); ?></a>
+						</p>
+					</div>
+				</div>
+			<?php endif; ?>
 			<div class="wrap">
-				<div class="manage-left jp-static-block">
-					<table class="table table-bordered fixed-top jetpack-modules">
-						<thead>
-							<tr>
-								<th class="check-column"><input type="checkbox" class="checkall"></th>
-								<th colspan="2">
-									<?php $list_table->unprotected_display_tablenav( 'top' ); ?>
-									<span class="filter-search">
-										<button type="button" class="button">Filter</button>
-									</span>
-								</th>
-							</tr>
-						</thead>
-					</table>
-					<form class="jetpack-modules-list-table-form" onsubmit="return false;">
-						<table class="<?php echo esc_attr( implode( ' ', $list_table->get_table_classes() ) ); ?>">
-							<tbody id="the-list">
-							<?php $list_table->display_rows_or_placeholder(); ?>
-							</tbody>
-						</table>
-					</form>
+				<div class="manage-left">
+					<div class="jetpack-modules-card">
+						<div class="jetpack-modules-card__bulk">
+							<label class="jetpack-modules-card__checkall">
+								<input type="checkbox" class="checkall" />
+								<span><?php esc_html_e( 'Select all', 'jetpack' ); ?></span>
+							</label>
+							<?php $list_table->unprotected_display_tablenav( 'top' ); ?>
+							<span class="filter-search">
+								<button type="button" class="button"><?php esc_html_e( 'Filter', 'jetpack' ); ?></button>
+							</span>
+						</div>
+						<form class="jetpack-modules-list-table-form" onsubmit="return false;">
+							<table class="<?php echo esc_attr( implode( ' ', $list_table->get_table_classes() ) ); ?> jetpack-modules">
+								<tbody id="the-list">
+								<?php $list_table->display_rows_or_placeholder(); ?>
+								</tbody>
+							</table>
+						</form>
+					</div>
 				</div>
 				<div class="manage-right">
 					<div class="bumper">
 						<form class="navbar-form" role="search">
 							<input type="hidden" name="page" value="jetpack_modules" />
-							<?php $list_table->search_box( __( 'Search', 'jetpack' ), 'srch-term' ); ?>
-							<p><?php esc_html_e( 'View', 'jetpack' ); ?></p>
+							<?php $list_table->search_box( __( 'Search modules…', 'jetpack' ), 'srch-term' ); ?>
+							<?php if ( $is_offline_mode ) : ?>
+								<p><?php esc_html_e( 'Available in offline mode', 'jetpack' ); ?></p>
+								<span class="dops-button-group button-group availability-filter">
+									<button type="button" class="dops-button is-compact button
+									<?php echo 'all' === $current_availability ? 'active' : ''; ?>
+										" data-availability="all"><?php esc_html_e( 'All', 'jetpack' ); ?></button>
+									<button type="button" class="dops-button button
+									<?php echo 'all' === $current_availability ? '' : 'active'; ?>
+									" data-availability="hide-unavailable"><?php esc_html_e( 'Hide unavailable', 'jetpack' ); ?></button>
+								</span>
+							<?php endif; ?>
+							<p><?php esc_html_e( 'State', 'jetpack' ); ?></p>
 							<span class="dops-button-group button-group filter-active">
 								<button type="button" class="dops-button is-compact button
 								<?php // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is view logic.
-								if ( empty( $_GET['activated'] ) ) {
+								if ( empty( $_GET['activated'] ) && '' === $current_group ) {
 									echo 'active';
 								}
 								?>
@@ -136,6 +187,19 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 								}
 								?>
 								" data-filter-by="activated" data-filter-value="false"><?php esc_html_e( 'Inactive', 'jetpack' ); ?></button>
+							</span>
+							<p><?php esc_html_e( 'Purpose', 'jetpack' ); ?></p>
+							<span class="dops-button-group button-group filter-active">
+								<?php
+								foreach ( Jetpack_Modules_List_Table::PRODUCT_GROUP_ORDER as $group_slug ) {
+									printf(
+										'<button type="button" class="dops-button button %1$s" data-filter-by="product_group" data-filter-value="%2$s">%3$s</button>',
+										esc_attr( $group_slug === $current_group ? 'active' : '' ),
+										esc_attr( $group_slug ),
+										esc_html( Jetpack_Modules_List_Table::get_product_group_name( $group_slug ) )
+									);
+								}
+								?>
 							</span>
 							<p><?php esc_html_e( 'Sort by', 'jetpack' ); ?></p>
 							<span class="dops-button-group button-group sort">
@@ -167,7 +231,7 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 					</div>
 				</div>
 			</div>
-		</div><!-- /.content -->
+		</div><!-- /.jetpack-module-list -->
 		<?php
 
 		$tracking = new Tracking();

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-settings-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class.jetpack-settings-page.php
@@ -164,10 +164,10 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 								</span>
 							<?php endif; ?>
 							<p><?php esc_html_e( 'State', 'jetpack' ); ?></p>
-							<span class="dops-button-group button-group filter-active">
+							<span class="dops-button-group button-group module-filter filter-state">
 								<button type="button" class="dops-button is-compact button
 								<?php // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is view logic.
-								if ( empty( $_GET['activated'] ) && '' === $current_group ) {
+								if ( empty( $_GET['activated'] ) ) {
 									echo 'active';
 								}
 								?>
@@ -189,43 +189,20 @@ class Jetpack_Settings_Page extends Jetpack_Admin_Page {
 								" data-filter-by="activated" data-filter-value="false"><?php esc_html_e( 'Inactive', 'jetpack' ); ?></button>
 							</span>
 							<p><?php esc_html_e( 'Purpose', 'jetpack' ); ?></p>
-							<span class="dops-button-group button-group filter-active">
+							<ul class="purpose-filter">
+								<li class="all<?php echo '' === $current_group ? ' current' : ''; ?>"><a href="#" data-group=""><?php esc_html_e( 'All', 'jetpack' ); ?></a> <span class="count"></span></li>
 								<?php
 								foreach ( Jetpack_Modules_List_Table::PRODUCT_GROUP_ORDER as $group_slug ) {
 									printf(
-										'<button type="button" class="dops-button button %1$s" data-filter-by="product_group" data-filter-value="%2$s">%3$s</button>',
-										esc_attr( $group_slug === $current_group ? 'active' : '' ),
+										'<li class="%1$s%2$s"><a href="#" data-group="%1$s">%3$s</a> <span class="count"></span></li>',
 										esc_attr( $group_slug ),
+										$group_slug === $current_group ? ' current' : '',
 										esc_html( Jetpack_Modules_List_Table::get_product_group_name( $group_slug ) )
 									);
 								}
 								?>
-							</span>
-							<p><?php esc_html_e( 'Sort by', 'jetpack' ); ?></p>
-							<span class="dops-button-group button-group sort">
-								<button type="button" class="dops-button button
-								<?php // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is view logic.
-								if ( empty( $_GET['sort_by'] ) ) {
-									echo 'active';
-								}
-								?>
-								" data-sort-by="name"><?php esc_html_e( 'Alphabetical', 'jetpack' ); ?></button>
-								<button type="button" class="dops-button button
-								<?php // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is view logic.
-								if ( ! empty( $_GET['sort_by'] ) && 'introduced' === $_GET['sort_by'] ) {
-									echo 'active';
-								}
-								?>
-								" data-sort-by="introduced" data-sort-order="reverse"><?php esc_html_e( 'Newest', 'jetpack' ); ?></button>
-								<button type="button" class="dops-button button
-								<?php // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This is view logic.
-								if ( ! empty( $_GET['sort_by'] ) && 'sort' === $_GET['sort_by'] ) {
-									echo 'active';
-								}
-								?>
-								" data-sort-by="sort"><?php esc_html_e( 'Popular', 'jetpack' ); ?></button>
-							</span>
-							<p><?php esc_html_e( 'Show', 'jetpack' ); ?></p>
+							</ul>
+							<p><?php esc_html_e( 'Tags', 'jetpack' ); ?></p>
 							<?php $list_table->views(); ?>
 						</form>
 					</div>

--- a/projects/plugins/jetpack/changelog/hide-legacy-vaultpress-module
+++ b/projects/plugins/jetpack/changelog/hide-legacy-vaultpress-module
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Modules: Hide the legacy VaultPress module row from the modules page, as it is permanently unavailable and superseded by the VaultPress Backup product.

--- a/projects/plugins/jetpack/changelog/modules-page-offline-mode
+++ b/projects/plugins/jetpack/changelog/modules-page-offline-mode
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Modules: In Offline Mode, surface the Modules page as the first Jetpack menu item so it loads by default, add an Offline Mode breadcrumb and explanatory notice, and add an "Available in offline mode" filter.

--- a/projects/plugins/jetpack/changelog/refine-modules-page-search
+++ b/projects/plugins/jetpack/changelog/refine-modules-page-search
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Modules: Debounce the modules page search so results update smoothly while typing.

--- a/projects/plugins/jetpack/changelog/update-modules-page-core-ui
+++ b/projects/plugins/jetpack/changelog/update-modules-page-core-ui
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Modules: Refresh the modules page with a modern, core-UI look.

--- a/projects/plugins/jetpack/changelog/update-modules-page-dynamic-tag-counts
+++ b/projects/plugins/jetpack/changelog/update-modules-page-dynamic-tag-counts
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Modules: Update the tag filter counts on the modules page to reflect the currently-applied filters, and grey out tags with no matching modules.

--- a/projects/plugins/jetpack/class.jetpack-admin.php
+++ b/projects/plugins/jetpack/class.jetpack-admin.php
@@ -455,7 +455,7 @@ class Jetpack_Admin {
 		 */
 		if ( ( new Status() )->is_offline_mode() ) {
 			if ( $module['requires_connection'] || $module['requires_user_connection'] ) {
-				return __( 'Offline mode', 'jetpack' );
+				return __( 'Unavailable in Offline mode', 'jetpack' );
 			}
 		}
 

--- a/projects/plugins/jetpack/class.jetpack-modules-list-table.php
+++ b/projects/plugins/jetpack/class.jetpack-modules-list-table.php
@@ -20,6 +20,103 @@ if ( ! class_exists( 'WP_List_Table' ) ) {
  */
 class Jetpack_Modules_List_Table extends WP_List_Table {
 
+	/**
+	 * Order in which product groups are displayed on the page.
+	 *
+	 * @var string[]
+	 */
+	const PRODUCT_GROUP_ORDER = array( 'growth', 'performance', 'security', 'other' );
+
+	/**
+	 * Map of module slug to product group.
+	 *
+	 * Modeled on the Offline Mode dashboard grouping so the modules page reads
+	 * as a set of focused product areas. Any module not listed falls back to
+	 * the "other" group.
+	 *
+	 * @return array<string, string> Module slug => product group slug.
+	 */
+	public static function get_module_product_groups_map() {
+		return array(
+			// Grow your audience.
+			'blaze'                 => 'growth',
+			'comment-likes'         => 'growth',
+			'comments'              => 'growth',
+			'contact-form'          => 'growth',
+			'gravatar-hovercards'   => 'growth',
+			'likes'                 => 'growth',
+			'publicize'             => 'growth',
+			'related-posts'         => 'growth',
+			'sharedaddy'            => 'growth',
+			'simple-payments'       => 'growth',
+			'stats'                 => 'growth',
+			'subscriptions'         => 'growth',
+			'woocommerce-analytics' => 'growth',
+			'wordads'               => 'growth',
+			'wpcom-reader'          => 'growth',
+
+			// Speed up your site.
+			'carousel'              => 'performance',
+			'google-fonts'          => 'performance',
+			'infinite-scroll'       => 'performance',
+			'photon'                => 'performance',
+			'photon-cdn'            => 'performance',
+			'search'                => 'performance',
+			'tiled-gallery'         => 'performance',
+			'videopress'            => 'performance',
+
+			// Protect your site.
+			'account-protection'    => 'security',
+			'monitor'               => 'security',
+			'notes'                 => 'security',
+			'protect'               => 'security',
+			'sso'                   => 'security',
+			'vaultpress'            => 'security',
+			'waf'                   => 'security',
+		);
+	}
+
+	/**
+	 * Get the product group slug for a given module.
+	 *
+	 * @param string $slug Module slug.
+	 * @return string Product group slug.
+	 */
+	public static function get_module_product_group( $slug ) {
+		$map = self::get_module_product_groups_map();
+
+		return isset( $map[ $slug ] ) ? $map[ $slug ] : 'other';
+	}
+
+	/**
+	 * Get the translated display name for a product group.
+	 *
+	 * @param string $group Product group slug.
+	 * @return string Translated group name.
+	 */
+	public static function get_product_group_name( $group ) {
+		switch ( $group ) {
+			case 'growth':
+				return __( 'Grow your audience', 'jetpack' );
+			case 'performance':
+				return __( 'Speed up your site', 'jetpack' );
+			case 'security':
+				return __( 'Protect your site', 'jetpack' );
+			default:
+				return __( 'Other features', 'jetpack' );
+		}
+	}
+
+	/**
+	 * Whether a module is flagged as recommended.
+	 *
+	 * @param array $module Module data (with raw, untranslated module tags).
+	 * @return bool
+	 */
+	public static function is_module_recommended( $module ) {
+		return ! empty( $module['module_tags'] ) && in_array( 'Recommended', (array) $module['module_tags'], true );
+	}
+
 	/** Constructor. */
 	public function __construct() {
 		parent::__construct();
@@ -84,11 +181,21 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 			true
 		);
 
+		$modules_for_js = (array) Jetpack::get_translated_modules( $this->all_items );
+		foreach ( array_keys( $modules_for_js ) as $slug ) {
+			$group = self::get_module_product_group( $slug );
+
+			$modules_for_js[ $slug ]['product_group']      = $group;
+			$modules_for_js[ $slug ]['product_group_name'] = self::get_product_group_name( $group );
+			// Detect recommendation from the raw (untranslated) module tags.
+			$modules_for_js[ $slug ]['recommended'] = isset( $this->all_items[ $slug ] ) && self::is_module_recommended( $this->all_items[ $slug ] );
+		}
+
 		wp_localize_script(
 			'jetpack-modules-list-table',
 			'jetpackModulesData',
 			array(
-				'modules'   => Jetpack::get_translated_modules( $this->all_items ),
+				'modules'   => $modules_for_js,
 				'i18n'      => array(
 					'search_placeholder' => __( 'Search modules…', 'jetpack' ),
 				),
@@ -117,28 +224,50 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 	public function js_templates() {
 		?>
 		<script type="text/html" id="tmpl-Jetpack_Modules_List_Table_Template">
-			<# var i = 0;
+			<# var i = 0; var currentGroup = null;
 			if ( data.items.length ) {
 			_.each( data.items, function( item, key, list ) {
-				if ( item === undefined ) return; #>
-				<tr class="jetpack-module <# if ( ++i % 2 ) { #> alternate<# } #><# if ( item.activated ) { #> active<# } #><# if ( ! item.available ) { #> unavailable<# } #>" id="{{{ item.module }}}">
+				if ( item === undefined ) return;
+				if ( item.product_group !== currentGroup ) {
+					currentGroup = item.product_group; #>
+					<tr class="jetpack-module-group-header" data-group="{{ item.product_group }}">
+						<td colspan="2"><h2 class="jetpack-module-group-header__title">{{ item.product_group_name }}</h2></td>
+					</tr>
+				<# } #>
+				<tr class="jetpack-module<# if ( ++i % 2 ) { #> alternate<# } #><# if ( item.activated ) { #> active<# } #><# if ( ! item.available ) { #> unavailable<# } #>" id="{{{ item.module }}}">
 					<th scope="row" class="check-column">
-						<input type="checkbox" name="modules[]" value="{{{ item.module }}}" {{{ item.disabled }}} />
+						<# if ( item.available ) { #><input type="checkbox" name="modules[]" value="{{{ item.module }}}" {{{ item.disabled }}} /><# } #>
 					</th>
-					<td class='name column-name'>
-						<p class='info'><a href="{{{item.learn_more_button}}}" target="blank" style="text-decoration: none;">{{{ item.name }}}</a></p>
-						<div class="row-actions">
-						<# if ( item.configurable ) { #>
-							<span class='configure'>{{{ item.configurable }}}</span>
-						<# } #>
-						<# if ( item.activated && 'vaultpress' !== item.module && item.available ) { #>
-							<span class='delete'><a class="dops-button is-compact" href="<?php echo esc_url( admin_url( 'admin.php' ) ); ?>?page=jetpack&#038;action=deactivate&#038;module={{{ item.module }}}&#038;_wpnonce={{{ item.deactivate_nonce }}}"><?php esc_html_e( 'Deactivate', 'jetpack' ); ?></a></span>
-						<# } else if ( item.available ) { #>
-							<span class='activate'><a class="dops-button is-compact" href="<?php echo esc_url( admin_url( 'admin.php' ) ); ?>?page=jetpack&#038;action=activate&#038;module={{{ item.module }}}&#038;_wpnonce={{{ item.activate_nonce }}}"><?php esc_html_e( 'Activate', 'jetpack' ); ?></a></span>
-						<# } #>
-						<# if ( ! item.available ) { #>
-							<p class='unavailable_reason'>{{{ item.unavailable_reason }}}</p>
-						<# } #>
+					<td class="name column-name">
+						<div class="jetpack-module__body">
+							<div class="jetpack-module__info">
+								<span class="jetpack-module__name">{{{ item.name }}}</span>
+								<# if ( item.description ) { #><span class="jetpack-module__description">{{ item.description }}</span><# } #>
+							</div>
+							<div class="jetpack-module__meta">
+								<span class="jetpack-module__badges">
+									<# if ( item.recommended && item.available ) { #><span class="jetpack-module__badge is-recommended"><?php esc_html_e( 'Recommended', 'jetpack' ); ?></span><# } #>
+									<# if ( item.available ) { #>
+										<# if ( item.activated ) { #><span class="jetpack-module__badge is-active"><?php esc_html_e( 'Active', 'jetpack' ); ?></span><# } else { #><span class="jetpack-module__badge is-inactive"><?php esc_html_e( 'Inactive', 'jetpack' ); ?></span><# } #>
+									<# } #>
+								</span>
+								<div class="row-actions">
+									<# if ( item.configurable ) { #>
+										<span class="configure">{{{ item.configurable }}}</span>
+									<# } #>
+									<# if ( item.available ) { #>
+										<# if ( item.activated && 'vaultpress' !== item.module ) { #>
+											<a class="jetpack-module__toggle is-active" role="switch" aria-checked="true" href="<?php echo esc_url( admin_url( 'admin.php' ) ); ?>?page=jetpack&#038;action=deactivate&#038;module={{{ item.module }}}&#038;_wpnonce={{{ item.deactivate_nonce }}}"><span class="jetpack-module__toggle-track"><span class="jetpack-module__toggle-thumb"></span></span><span class="screen-reader-text"><?php esc_html_e( 'Deactivate', 'jetpack' ); ?></span></a>
+										<# } else if ( item.activated ) { #>
+											<span class="jetpack-module__toggle is-active is-disabled" role="switch" aria-checked="true" aria-disabled="true"><span class="jetpack-module__toggle-track"><span class="jetpack-module__toggle-thumb"></span></span></span>
+										<# } else { #>
+											<a class="jetpack-module__toggle" role="switch" aria-checked="false" href="<?php echo esc_url( admin_url( 'admin.php' ) ); ?>?page=jetpack&#038;action=activate&#038;module={{{ item.module }}}&#038;_wpnonce={{{ item.activate_nonce }}}"><span class="jetpack-module__toggle-track"><span class="jetpack-module__toggle-thumb"></span></span><span class="screen-reader-text"><?php esc_html_e( 'Activate', 'jetpack' ); ?></span></a>
+										<# } #>
+									<# } else { #>
+										<span class="jetpack-module__unavailable">{{{ item.unavailable_reason }}}</span>
+									<# } #>
+								</div>
+							</div>
 						</div>
 					</td>
 				</tr>
@@ -288,6 +417,51 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 	}
 
 	/**
+	 * Print the module rows grouped by product group.
+	 *
+	 * Overrides WP_List_Table::display_rows() so the server-rendered (no-JS)
+	 * output matches the grouped, card-style layout produced by the Backbone
+	 * template.
+	 */
+	public function display_rows() {
+		$buckets = array();
+		foreach ( self::PRODUCT_GROUP_ORDER as $group ) {
+			$buckets[ $group ] = array();
+		}
+
+		foreach ( $this->items as $item ) {
+			$group = self::get_module_product_group( $item['module'] );
+			if ( ! isset( $buckets[ $group ] ) ) {
+				$group = 'other';
+			}
+			$buckets[ $group ][] = $item;
+		}
+
+		foreach ( $buckets as $group => $items ) {
+			if ( empty( $items ) ) {
+				continue;
+			}
+			$this->group_header_row( $group );
+			foreach ( $items as $item ) {
+				$this->single_row( $item );
+			}
+		}
+	}
+
+	/**
+	 * Print a product group header row.
+	 *
+	 * @param string $group Product group slug.
+	 */
+	protected function group_header_row( $group ) {
+		printf(
+			'<tr class="jetpack-module-group-header" data-group="%1$s"><td colspan="2"><h2 class="jetpack-module-group-header__title">%2$s</h2></td></tr>',
+			esc_attr( $group ),
+			esc_html( self::get_product_group_name( $group ) )
+		);
+	}
+
+	/**
 	 * Print a single row of the table.
 	 *
 	 * @param object|array $item Item.
@@ -296,17 +470,124 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 		static $i  = 0;
 		$row_class = ( ( ++$i ) % 2 ) ? ' alternate' : '';
 
+		$available = Jetpack_Admin::is_module_available( $item );
+
 		if ( ! empty( $item['activated'] ) ) {
 			$row_class .= ' active';
 		}
-
-		if ( ! Jetpack_Admin::is_module_available( $item ) ) {
+		if ( ! $available ) {
 			$row_class .= ' unavailable';
 		}
 
 		echo '<tr class="jetpack-module' . esc_attr( $row_class ) . '" id="' . esc_attr( $item['module'] ) . '">';
-		$this->single_row_columns( $item );
+
+		echo '<th scope="row" class="check-column">';
+		if ( $available ) {
+			printf( '<input type="checkbox" name="modules[]" value="%s" />', esc_attr( $item['module'] ) );
+		}
+		echo '</th>';
+
+		echo '<td class="name column-name">';
+		echo '<div class="jetpack-module__body">';
+
+		echo '<div class="jetpack-module__info">';
+		echo '<span class="jetpack-module__name">' . wp_kses_post( wptexturize( $item['name'] ) ) . '</span>';
+		if ( ! empty( $item['description'] ) ) {
+			echo '<span class="jetpack-module__description">' . esc_html( wp_strip_all_tags( $item['description'] ) ) . '</span>';
+		}
+		echo '</div>';
+
+		echo '<div class="jetpack-module__meta">';
+		echo '<span class="jetpack-module__badges">';
+		if ( $available && self::is_module_recommended( $item ) ) {
+			echo '<span class="jetpack-module__badge is-recommended">' . esc_html__( 'Recommended', 'jetpack' ) . '</span>';
+		}
+		if ( $available ) {
+			if ( ! empty( $item['activated'] ) ) {
+				echo '<span class="jetpack-module__badge is-active">' . esc_html__( 'Active', 'jetpack' ) . '</span>';
+			} else {
+				echo '<span class="jetpack-module__badge is-inactive">' . esc_html__( 'Inactive', 'jetpack' ) . '</span>';
+			}
+		}
+		echo '</span>';
+
+		echo '<div class="row-actions">';
+		if ( ! empty( $item['configurable'] ) ) {
+			echo '<span class="configure">' . wp_kses_post( $item['configurable'] ) . '</span>';
+		}
+		if ( $available ) {
+			echo $this->get_module_toggle_html( $item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Escaped in helper.
+		} elseif ( ! empty( $item['unavailable_reason'] ) ) {
+			echo '<span class="jetpack-module__unavailable">' . wp_kses_post( $item['unavailable_reason'] ) . '</span>';
+		}
+		echo '</div>';
+
+		echo '</div>';
+
+		echo '</div>';
+		echo '</td>';
 		echo '</tr>';
+	}
+
+	/**
+	 * Build the activate/deactivate toggle control markup for a module row.
+	 *
+	 * @param object|array $item Module data.
+	 * @return string HTML.
+	 */
+	protected function get_module_toggle_html( $item ) {
+		$is_active = ! empty( $item['activated'] );
+
+		// VaultPress cannot be deactivated from here; render a disabled active toggle.
+		if ( $is_active && 'vaultpress' === $item['module'] ) {
+			return '<span class="jetpack-module__toggle is-active is-disabled" role="switch" aria-checked="true" aria-disabled="true"><span class="jetpack-module__toggle-track"><span class="jetpack-module__toggle-thumb"></span></span></span>';
+		}
+
+		if ( $is_active ) {
+			$url   = wp_nonce_url(
+				Jetpack::admin_url(
+					array(
+						'page'   => 'jetpack',
+						'action' => 'deactivate',
+						'module' => $item['module'],
+					)
+				),
+				'jetpack_deactivate-' . $item['module']
+			);
+			$label = sprintf(
+				/* translators: %s: Jetpack module name. */
+				__( 'Deactivate %s', 'jetpack' ),
+				$item['name']
+			);
+			$class = 'jetpack-module__toggle is-active';
+			$aria  = 'true';
+		} else {
+			$url   = wp_nonce_url(
+				Jetpack::admin_url(
+					array(
+						'page'   => 'jetpack',
+						'action' => 'activate',
+						'module' => $item['module'],
+					)
+				),
+				'jetpack_activate-' . $item['module']
+			);
+			$label = sprintf(
+				/* translators: %s: Jetpack module name. */
+				__( 'Activate %s', 'jetpack' ),
+				$item['name']
+			);
+			$class = 'jetpack-module__toggle';
+			$aria  = 'false';
+		}
+
+		return sprintf(
+			'<a class="%1$s" role="switch" aria-checked="%2$s" href="%3$s"><span class="jetpack-module__toggle-track"><span class="jetpack-module__toggle-thumb"></span></span><span class="screen-reader-text">%4$s</span></a>',
+			esc_attr( $class ),
+			esc_attr( $aria ),
+			esc_url( $url ),
+			esc_html( $label )
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/class.jetpack-modules-list-table.php
+++ b/projects/plugins/jetpack/class.jetpack-modules-list-table.php
@@ -85,7 +85,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 	public static function get_module_product_group( $slug ) {
 		$map = self::get_module_product_groups_map();
 
-		return isset( $map[ $slug ] ) ? $map[ $slug ] : 'other';
+		return $map[ $slug ] ?? 'other';
 	}
 
 	/**
@@ -520,11 +520,8 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 		} elseif ( ! empty( $item['unavailable_reason'] ) ) {
 			echo '<span class="jetpack-module__unavailable">' . wp_kses_post( $item['unavailable_reason'] ) . '</span>';
 		}
-		echo '</div>';
-
-		echo '</div>';
-
-		echo '</div>';
+		// Close .row-actions, .jetpack-module__meta, and .jetpack-module__body.
+		echo '</div></div></div>';
 		echo '</td>';
 		echo '</tr>';
 	}

--- a/projects/plugins/jetpack/class.jetpack-modules-list-table.php
+++ b/projects/plugins/jetpack/class.jetpack-modules-list-table.php
@@ -241,7 +241,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 					<td class="name column-name">
 						<div class="jetpack-module__body">
 							<div class="jetpack-module__info">
-								<span class="jetpack-module__name">{{{ item.name }}}</span>
+								<# if ( item.learn_more_button ) { #><a class="jetpack-module__name" href="{{{ item.learn_more_button }}}" target="_blank" rel="noopener noreferrer">{{{ item.name }}}</a><# } else { #><span class="jetpack-module__name">{{{ item.name }}}</span><# } #>
 								<# if ( item.description ) { #><span class="jetpack-module__description">{{ item.description }}</span><# } #>
 							</div>
 							<div class="jetpack-module__meta">
@@ -491,7 +491,15 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 		echo '<div class="jetpack-module__body">';
 
 		echo '<div class="jetpack-module__info">';
-		echo '<span class="jetpack-module__name">' . wp_kses_post( wptexturize( $item['name'] ) ) . '</span>';
+		if ( ! empty( $item['learn_more_button'] ) ) {
+			printf(
+				'<a class="jetpack-module__name" href="%1$s" target="_blank" rel="noopener noreferrer">%2$s</a>',
+				esc_url( $item['learn_more_button'] ),
+				wp_kses_post( wptexturize( $item['name'] ) )
+			);
+		} else {
+			echo '<span class="jetpack-module__name">' . wp_kses_post( wptexturize( $item['name'] ) ) . '</span>';
+		}
 		if ( ! empty( $item['description'] ) ) {
 			echo '<span class="jetpack-module__description">' . esc_html( wp_strip_all_tags( $item['description'] ) ) . '</span>';
 		}

--- a/projects/plugins/jetpack/class.jetpack-modules-list-table.php
+++ b/projects/plugins/jetpack/class.jetpack-modules-list-table.php
@@ -117,11 +117,34 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 		return ! empty( $module['module_tags'] ) && in_array( 'Recommended', (array) $module['module_tags'], true );
 	}
 
+	/**
+	 * Remove the legacy `vaultpress` module from the modules screen.
+	 *
+	 * The `vaultpress` module is a leftover stub for the original standalone
+	 * VaultPress plugin. It is hard-coded as never activatable (see
+	 * Jetpack_Admin::is_module_available()) and is unrelated to the modern
+	 * VaultPress Backup product, which is delivered through My Jetpack and the
+	 * standalone Jetpack VaultPress Backup plugin rather than a Jetpack module.
+	 * Showing a permanently-unavailable row that merely reuses the modern
+	 * product's name is misleading, so we drop it from this screen only. Other
+	 * surfaces (REST, the React dashboard, standalone plugins) are unaffected.
+	 *
+	 * @param array $modules Array of Jetpack modules keyed by slug.
+	 * @return array Modules without the legacy `vaultpress` entry.
+	 */
+	public static function hide_legacy_vaultpress_module( $modules ) {
+		unset( $modules['vaultpress'] );
+		return $modules;
+	}
+
 	/** Constructor. */
 	public function __construct() {
 		parent::__construct();
 
 		Jetpack::init();
+
+		// Scope this to the modules screen so REST/React/standalone surfaces keep the legacy slug.
+		add_filter( 'jetpack_modules_list_table_items', array( __CLASS__, 'hide_legacy_vaultpress_module' ) );
 
 		if ( $this->compat_fields && is_array( $this->compat_fields ) ) {
 			array_push( $this->compat_fields, 'all_items' );
@@ -241,7 +264,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 					<td class="name column-name">
 						<div class="jetpack-module__body">
 							<div class="jetpack-module__info">
-								<# if ( item.learn_more_button ) { #><a class="jetpack-module__name" href="{{{ item.learn_more_button }}}" target="_blank" rel="noopener noreferrer">{{{ item.name }}}</a><# } else { #><span class="jetpack-module__name">{{{ item.name }}}</span><# } #>
+								<# if ( item.learn_more_button ) { #><a class="jetpack-module__name" href="{{{ item.learn_more_button }}}" target="_blank" rel="noopener noreferrer">{{ item.name }}</a><# } else { #><span class="jetpack-module__name">{{ item.name }}</span><# } #>
 								<# if ( item.description ) { #><span class="jetpack-module__description">{{ item.description }}</span><# } #>
 							</div>
 							<div class="jetpack-module__meta">
@@ -256,15 +279,13 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 										<span class="configure">{{{ item.configurable }}}</span>
 									<# } #>
 									<# if ( item.available ) { #>
-										<# if ( item.activated && 'vaultpress' !== item.module ) { #>
+										<# if ( item.activated ) { #>
 											<a class="jetpack-module__toggle is-active" role="switch" aria-checked="true" href="<?php echo esc_url( admin_url( 'admin.php' ) ); ?>?page=jetpack&#038;action=deactivate&#038;module={{{ item.module }}}&#038;_wpnonce={{{ item.deactivate_nonce }}}"><span class="jetpack-module__toggle-track"><span class="jetpack-module__toggle-thumb"></span></span><span class="screen-reader-text"><?php esc_html_e( 'Deactivate', 'jetpack' ); ?></span></a>
-										<# } else if ( item.activated ) { #>
-											<span class="jetpack-module__toggle is-active is-disabled" role="switch" aria-checked="true" aria-disabled="true"><span class="jetpack-module__toggle-track"><span class="jetpack-module__toggle-thumb"></span></span></span>
 										<# } else { #>
 											<a class="jetpack-module__toggle" role="switch" aria-checked="false" href="<?php echo esc_url( admin_url( 'admin.php' ) ); ?>?page=jetpack&#038;action=activate&#038;module={{{ item.module }}}&#038;_wpnonce={{{ item.activate_nonce }}}"><span class="jetpack-module__toggle-track"><span class="jetpack-module__toggle-thumb"></span></span><span class="screen-reader-text"><?php esc_html_e( 'Activate', 'jetpack' ); ?></span></a>
 										<# } #>
 									<# } else { #>
-										<span class="jetpack-module__unavailable">{{{ item.unavailable_reason }}}</span>
+										<span class="jetpack-module__unavailable">{{ item.unavailable_reason }}</span>
 									<# } #>
 								</div>
 							</div>
@@ -430,10 +451,7 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 		}
 
 		foreach ( $this->items as $item ) {
-			$group = self::get_module_product_group( $item['module'] );
-			if ( ! isset( $buckets[ $group ] ) ) {
-				$group = 'other';
-			}
+			$group               = self::get_module_product_group( $item['module'] );
 			$buckets[ $group ][] = $item;
 		}
 
@@ -543,11 +561,6 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 	protected function get_module_toggle_html( $item ) {
 		$is_active = ! empty( $item['activated'] );
 
-		// VaultPress cannot be deactivated from here; render a disabled active toggle.
-		if ( $is_active && 'vaultpress' === $item['module'] ) {
-			return '<span class="jetpack-module__toggle is-active is-disabled" role="switch" aria-checked="true" aria-disabled="true"><span class="jetpack-module__toggle-track"><span class="jetpack-module__toggle-thumb"></span></span></span>';
-		}
-
 		if ( $is_active ) {
 			$url   = wp_nonce_url(
 				Jetpack::admin_url(
@@ -602,137 +615,6 @@ class Jetpack_Modules_List_Table extends WP_List_Table {
 	 */
 	public function get_table_classes() {
 		return array( 'table', 'table-bordered', 'wp-list-table', 'widefat', 'fixed' );
-	}
-
-	/**
-	 * Column checkbox.
-	 *
-	 * @param object|array $item Item.
-	 * @return string HTML.
-	 */
-	public function column_cb( $item ) {
-		if ( ! Jetpack_Admin::is_module_available( $item ) ) {
-			return '';
-		}
-
-		return sprintf( '<input type="checkbox" name="modules[]" value="%s" />', $item['module'] );
-	}
-
-	/**
-	 * Column icon.
-	 *
-	 * @return string HTML.
-	 */
-	public function column_icon() {
-		$badge_text = '';
-		$free_text  = '';
-		ob_start();
-		?>
-		<a href="#TB_inline?width=600&height=550&inlineId=more-info-module-settings-modal" class="thickbox">
-			<div class="module-image">
-				<p><span class="module-image-badge"><?php echo esc_html( $badge_text ); ?></span><span class="module-image-free" style="display: none"><?php echo esc_html( $free_text ); ?></span></p>
-			</div>
-		</a>
-		<?php
-		return ob_get_clean();
-	}
-
-	/**
-	 * Column name.
-	 *
-	 * @param object|array $item Item.
-	 * @return string HTML.
-	 */
-	public function column_name( $item ) {
-		$actions = array(
-			'info' => sprintf( '<a href="%s" target="blank">%s</a>', esc_url( $item['learn_more_button'] ), esc_html__( 'Feature Info', 'jetpack' ) ),
-		);
-
-		if ( ! empty( $item['configurable'] ) ) {
-			$actions['configure'] = $item['configurable'];
-		}
-
-		if ( empty( $item['activated'] ) && Jetpack_Admin::is_module_available( $item ) ) {
-			$url                 = wp_nonce_url(
-				Jetpack::admin_url(
-					array(
-						'page'   => 'jetpack',
-						'action' => 'activate',
-						'module' => $item['module'],
-					)
-				),
-				'jetpack_activate-' . $item['module']
-			);
-			$actions['activate'] = sprintf( '<a href="%s">%s</a>', esc_url( $url ), esc_html__( 'Activate', 'jetpack' ) );
-		} elseif ( ! empty( $item['activated'] ) ) {
-			$url               = wp_nonce_url(
-				Jetpack::admin_url(
-					array(
-						'page'   => 'jetpack',
-						'action' => 'deactivate',
-						'module' => $item['module'],
-					)
-				),
-				'jetpack_deactivate-' . $item['module']
-			);
-			$actions['delete'] = sprintf( '<a href="%s">%s</a>', esc_url( $url ), esc_html__( 'Deactivate', 'jetpack' ) );
-		}
-
-		return $this->row_actions( $actions ) . wptexturize( $item['name'] );
-	}
-
-	/**
-	 * Column description.
-	 *
-	 * @param object|array $item Item.
-	 * @return string HTML.
-	 */
-	public function column_description( $item ) {
-		ob_start();
-		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
-		/** This action is documented in class.jetpack-admin.php */
-		echo apply_filters( 'jetpack_short_module_description', $item['description'], $item['module'] );
-		/** This action is documented in class.jetpack-admin.php */
-		do_action( 'jetpack_learn_more_button_' . $item['module'] );
-		echo '<div id="more-info-' . $item['module'] . '" class="more-info">';
-		/** This action is documented in class.jetpack-admin.php */
-		do_action( 'jetpack_module_more_info_' . $item['module'] );
-		echo '</div>';
-		// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped
-		return ob_get_clean();
-	}
-
-	/**
-	 * Return module tags HTML.
-	 *
-	 * @param object|array $item Item.
-	 * @return string HTML.
-	 */
-	public function column_module_tags( $item ) {
-		$module_tags = array();
-		foreach ( array_map( 'jetpack_get_module_i18n_tag', $item['module_tags'] ) as $module_tag ) {
-			$module_tags[] = sprintf( '<a href="%3$s" data-title="%2$s">%1$s</a>', esc_html( $module_tag ), esc_attr( $module_tag ), esc_url( add_query_arg( 'module_tag', rawurlencode( $module_tag ) ) ) );
-		}
-		return implode( ', ', $module_tags );
-	}
-
-	/**
-	 * Column default value.
-	 *
-	 * @param object|array $item Item.
-	 * @param string       $column_name Column name.
-	 * @return string
-	 */
-	public function column_default( $item, $column_name ) {
-		switch ( $column_name ) {
-			case 'icon':
-			case 'name':
-			case 'description':
-				return '';
-			default:
-				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
-				return print_r( $item, true );
-		}
 	}
 
 	/**

--- a/projects/plugins/jetpack/images/gradient.svg
+++ b/projects/plugins/jetpack/images/gradient.svg
@@ -1,0 +1,17 @@
+<svg width="380" height="183" viewBox="0 0 380 183" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g opacity="0.75" filter="url(#filter0_f_5953_11924)">
+<path d="M360 -60C360 7.93102 304.931 63 237 63C169.069 63 114 7.93102 114 -60C114 -127.931 169.069 -183 237 -183C304.931 -183 360 -127.931 360 -60Z" fill="url(#paint0_linear_5953_11924)"/>
+</g>
+<defs>
+<filter id="filter0_f_5953_11924" x="-6" y="-303" width="486" height="486" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feBlend mode="normal" in="SourceGraphic" in2="BackgroundImageFix" result="shape"/>
+<feGaussianBlur stdDeviation="60" result="effect1_foregroundBlur_5953_11924"/>
+</filter>
+<linearGradient id="paint0_linear_5953_11924" x1="360" y1="-60" x2="114" y2="-60" gradientUnits="userSpaceOnUse">
+<stop stop-color="#48FF50"/>
+<stop offset="0.471846" stop-color="#108642"/>
+<stop offset="1" stop-color="#2E38FA"/>
+</linearGradient>
+</defs>
+</svg>

--- a/projects/plugins/jetpack/scss/templates/_settings.scss
+++ b/projects/plugins/jetpack/scss/templates/_settings.scss
@@ -525,6 +525,13 @@ tr.jetpack-module.unavailable {
 	font-size: $jp-font-ui;
 	font-weight: 600;
 	color: $jp-text;
+
+	// Rendered as a link to the module's support page when one is available.
+	&:hover,
+	&:focus {
+		color: $jp-primary;
+		text-decoration: underline;
+	}
 }
 
 .jetpack-module__description {

--- a/projects/plugins/jetpack/scss/templates/_settings.scss
+++ b/projects/plugins/jetpack/scss/templates/_settings.scss
@@ -6,6 +6,20 @@
 @use "../atoms/colors/colors";
 @use "../atoms/typography/functions" as typography-functions;
 
+// Design tokens aligned with the React-based Jetpack admin pages (Newsletter,
+// VideoPress, Activity Log). These mirror the WordPress Design System (WPDS)
+// tokens those pages consume, with hex fallbacks for when the token stylesheet
+// isn't enqueued on this legacy page. See @automattic/jetpack-base-styles.
+$jp-surface: #fff;
+$jp-border: var(--wpds-color-stroke-surface-neutral-weak, #e0e0e0);
+$jp-text: var(--wpds-color-foreground-content-neutral, #1e1e1e);
+$jp-text-muted: var(--wpds-color-foreground-content-neutral-weak, #50575e);
+$jp-primary: #3858e9;
+$jp-primary-hover: #2145c7;
+// Primary UI/body text size on the WPDS admin pages (Activity Log, etc.) is
+// 13px, not the 16px `$font-body` this legacy page used.
+$jp-font-ui: var(--wpds-typography-font-size-md, 13px);
+
 .page-content.configure {
 	margin-top: 0;
 }
@@ -50,437 +64,435 @@
 	padding-top: 94px;
 }
 
-.filter-search {
-	display: none;
-	margin-top: 15px;
-	float: left;
-
-	@media (max-width: 782px) {
-		display: block;
-	}
-
-	@media (max-width: 530px) {
-		display: none;
-	}
-
-	.button {
-		background: colors.$white;
-		border: 1.5px solid calypso-colors.$black;
-		border-radius: 4px;
-		font-size: typography.$font-body;
-		line-height: 24px;
-		letter-spacing: -0.01em;
-		color: calypso-colors.$black;
-	}
-}
-
-// Bulk select table header area.
-.fixed-top {
-	box-sizing: border-box;
-	border-bottom: 1px solid calypso-colors.$gray-5;
-
-	/* Auto layout */
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-	padding: 16px;
-	gap: 16px;
-
-	.tablenav.top {
-		display: flex;
-		padding: 0;
-		margin: 0 0 0 10px;
-		height: auto;
-	}
-
-	select#bulk-action-selector-top {
-		width: 180px;
-		height: 40px;
-		border: 1px solid #dcdcde;
-		border-radius: 4px;
-		padding: 8px 16px;
-		margin-right: 8px;
-		line-height: normal;
-		color: calypso-colors.$black;
-		font-size: typography.$font-body-small;
-		letter-spacing: -0.02em;
-	}
-
-	.alignleft.actions.bulkactions {
-		display: flex;
-		align-items: center;
-
-		.button {
-			display: flex;
-			flex-direction: row;
-			justify-content: center;
-			align-items: center;
-			padding: 6px 24px;
-			height: 40px;
-			background: colors.$white;
-			border: 1.5px solid calypso-colors.$black;
-			border-radius: 4px;
-
-			// Button label.
-			font-size: typography.$font-body;
-			line-height: 24px;
-			letter-spacing: -0.01em;
-			color: calypso-colors.$black;
-		}
-
-		.button:hover {
-			//border: 1.5px solid $black;
-		}
-	}
-}
-
-#jp-plugin-container .table-bordered {
-	border-collapse: collapse;
-
-	.check-column {
-
-		input[type="checkbox"] {
-			width: 20px;
-			height: 20px;
-			border-radius: 2px;
-			margin-left: 0;
-
-			&::before {
-				margin: -2px;
-				color: calypso-colors.$black;
-				width: 21px;
-				height: 21px;
-			}
-		}
-	}
-
-	.info {
-		letter-spacing: -0.02em;
-	}
-
-	.row-actions {
-
-		a.dops-button.is-compact {
-			color: calypso-colors.$black;
-			line-height: 20px;
-			font-size: typography.$font-body-extra-small;
-			font-weight: 600;
-			background: colors.$white;
-			border: 1.5px solid calypso-colors.$black;
-			border-radius: 4px;
-			box-shadow: none;
-			text-decoration: none;
-			padding: 3px 8px;
-		}
-
-		.delete a.dops-button.is-compact {
-			color: calypso-colors.$red-50;
-			border: 1px solid calypso-colors.$gray-5;
-		}
-
-		.configure a {
-			color: calypso-colors.$black;
-			font-size: typography.$font-body-extra-small;
-			line-height: 20px;
-			font-weight: 600;
-			text-decoration: none;
-
-			&:hover {
-				text-decoration: underline;
-			}
-		}
-	}
-}
-
+// Shared admin wrapper spacing (masthead notices / footer areas).
 .wrap {
 	margin: 0;
-	padding: 0 1.5em 1em;
+	padding-block: 0 1em;
+	padding-inline: 1.5em;
 	overflow: hidden;
+}
 
-	//h2 {
-	//	font-size: 24px;
-	//	font-weight: 400;
-	//}
+// ==========================================================================
+// Modules page (admin.php?page=jetpack_modules)
+// Two-column layout (module list + filter sidebar) restyled to match the
+// Offline Mode dashboard: product-group sections rendered as toggle rows
+// inside a card, with status/recommended badges. Uses CSS logical properties
+// so the layout is RTL-aware by default.
+// ==========================================================================
+
+.jetpack-module-list {
+	// 24px canvas inset top and bottom, matching the React admin pages.
+	padding-block: 24px;
+
+	.wrap {
+		display: flex;
+		gap: 24px;
+		overflow: visible;
+	}
+
 	.manage-left {
-		float: left;
+		flex: 1 1 auto;
+		min-width: 0;
 		margin: 0;
 		padding: 0;
-		width: 63%;
-
-		table {
-			width: 100%;
-		}
-
-		th {
-			font-weight: 400;
-		}
-
-		@media (max-width: 782px) {
-			width: 100%;
-		}
 	}
 
 	.manage-right {
-		margin-top: 24px;
+		flex: 0 0 260px;
+		inline-size: 260px;
+		margin: 0;
 		padding: 0;
-		float: right;
-		width: 35%;
-		z-index: 1;
+	}
+}
 
-		p {
-			font-size: typography.$font-body-small;
+// --------------------------------------------------------------------------
+// Offline Mode notice panel
+// --------------------------------------------------------------------------
+// Friendly informational callout, mirroring jp-activity-log__upsell-callout:
+// a neutral bordered card rather than an error/warning-style notice.
+.jetpack-offline-notice {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	width: 100%;
+	margin-block: 0 24px;
+	margin-inline: 0;
+	padding: 24px;
+	// Decorative blurred gradient blob anchored to the top-inline-end corner,
+	// matching the plan-picker/pricing sections (Search, VideoPress). Layered
+	// over the neutral surface and clipped by the card's rounded corners.
+	background-color: $jp-surface;
+	background-image: url(../images/gradient.svg);
+	background-repeat: no-repeat;
+	background-position: right top;
+	background-size: 380px auto;
+	border: 1px solid $jp-border;
+	border-radius: 8px;
+}
+
+.jetpack-offline-notice__title {
+	margin: 0;
+	font-size: typography.$font-title-small;
+	line-height: 1.3;
+	font-weight: 500;
+	color: $jp-text;
+}
+
+.jetpack-offline-notice__text {
+	margin: 0;
+	font-size: $jp-font-ui;
+	line-height: 1.5;
+	color: $jp-text-muted;
+
+	a {
+		color: $jp-primary;
+		text-decoration: underline;
+	}
+}
+
+// --------------------------------------------------------------------------
+// Filter sidebar (.manage-right)
+// --------------------------------------------------------------------------
+.jetpack-module-list .manage-right {
+
+	.bumper {
+		margin: 0;
+	}
+
+	p {
+		font-size: $jp-font-ui;
+		line-height: 24px;
+		letter-spacing: -0.02em;
+		font-weight: 700;
+		color: $jp-text;
+		margin-block: 16px 4px;
+		margin-inline: 0;
+	}
+
+	// Search box. Nudge down so it vertically aligns with the list card's
+	// bulk-actions bar (12px padding + 36px controls) in the main column.
+	p.search-box {
+		width: 100%;
+		margin-block: 10px 0;
+		margin-inline: 0;
+		float: none;
+		display: block;
+		position: static;
+
+		input[type="search"] {
+			box-sizing: border-box;
+			border: 1px solid $jp-border;
+			border-radius: 4px;
+			padding-block: 8px;
+			padding-inline: 40px 16px;
 			line-height: 24px;
-			letter-spacing: -0.02em;
-			font-weight: 700;
-			color: calypso-colors.$gray-80;
-			margin: 16px 0 4px 0;
+			font-size: $jp-font-ui;
+			color: $jp-text;
+			font-weight: 400;
+			height: 40px;
+			width: 100%;
+			margin: 0;
+			background-image: url(../images/icon-search.svg);
+			background-repeat: no-repeat;
+			background-position: 12px center;
+			float: none;
+
+			&::placeholder {
+				color: calypso-colors.$gray-30;
+			}
 		}
 
+		input[type="submit"] {
+			display: none;
+		}
+	}
+
+	// Module tag filters (subsubsub) as a vertical list.
+	.subsubsub {
+		margin: 0;
+		padding: 0;
+
+		li {
+			display: block;
+			margin-block: 0 4px;
+			margin-inline: 0;
+			font-size: $jp-font-ui;
+
+			a {
+				display: inline-block;
+				padding-block: 2px;
+				padding-inline: 6px;
+				border-radius: 4px;
+				color: $jp-text;
+				text-decoration: none;
+				line-height: 24px;
+				letter-spacing: -0.02em;
+
+				&:hover {
+					background: calypso-colors.$gray-0;
+				}
+			}
+
+			.count {
+				color: $jp-text-muted;
+			}
+
+			&.current a {
+				background: $jp-primary;
+
+				&,
+				.count {
+					color: colors.$white;
+					font-weight: 700;
+				}
+			}
+		}
+	}
+
+	// Mobile: slide the sidebar in as an overlay panel.
+	@media (max-width: 782px) {
+		position: fixed;
+		inset-block: 0;
+		inset-inline-end: 0;
+		margin-block: 0;
+		min-inline-size: 300px;
+		display: none;
+		background: colors.$white;
+		box-shadow: 0 1px 20px 5px rgba(0, 0, 0, 0.1);
+		z-index: 13;
+
 		.bumper {
-			margin-left: 48px;
+			margin: 13px;
+		}
+
+		.navbar-form {
+			margin-block: 16px 0;
+			margin-inline: 0;
+			padding: 0;
 		}
 
 		&.show {
 			display: block;
 			overflow-y: auto;
 			overflow-x: hidden;
-			position: absolute;
-			z-index: 100000; // sits on top of wp-admin bar
+			z-index: 100000; // above the wp-admin bar
+		}
+	}
+}
+
+// Mobile-only toggle that reveals the filter sidebar.
+.filter-search {
+	display: none;
+
+	@media (max-width: 782px) {
+		display: inline-flex;
+	}
+
+	.button {
+		background: colors.$white;
+		border: 1px solid $jp-border;
+		border-radius: 4px;
+		font-size: $jp-font-ui;
+		color: $jp-text;
+		height: 36px;
+	}
+}
+
+// Segmented filter / sort chips.
+.jetpack-module-list .button-group {
+	display: inline-flex;
+	flex-wrap: wrap;
+
+	.button {
+		box-shadow: none;
+		padding-inline: 16px;
+		min-inline-size: 72px;
+		border: 1px solid $jp-border;
+		color: $jp-text;
+		height: 36px;
+		font-size: 13px;
+		line-height: 18px;
+		font-weight: 400;
+		background: colors.$white;
+
+		&:hover {
+			background: calypso-colors.$gray-0;
 		}
 
-		.search-bar {
-			margin-bottom: 18px;
-			max-width: 300px;
+		&:focus {
+			border-color: $jp-primary;
+		}
+	}
+
+	button.dops-button.button.active {
+		background: $jp-primary;
+		border-color: $jp-primary;
+		color: colors.$white;
+		font-weight: 600;
+
+		&:hover {
+			background: $jp-primary-hover;
+			border-color: $jp-primary-hover;
 		}
 
-		p.search-box {
-			width: 100%;
-			height: auto;
-			margin: 16px 0 0 0;
-			float: none;
-			display: block;
-			position: static;
+		&:focus {
+			border-color: colors.$white;
+			box-shadow: 0 0 0 1px $jp-primary;
+		}
+	}
+}
 
-			input[type="search"] {
-				border: 1px solid calypso-colors.$gray-5;
+// --------------------------------------------------------------------------
+// Card + bulk actions
+// --------------------------------------------------------------------------
+.jetpack-modules-card {
+	background: colors.$white;
+	border: 1px solid $jp-border;
+	border-radius: 8px;
+	overflow: hidden;
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.jetpack-modules-card__bulk {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 16px;
+	padding-block: 12px;
+	padding-inline: 16px;
+	background: calypso-colors.$gray-0;
+	border-block-end: 1px solid $jp-border;
+
+	.jetpack-modules-card__checkall {
+		display: inline-flex;
+		align-items: center;
+		gap: 8px;
+		font-size: $jp-font-ui;
+		color: $jp-text;
+		white-space: nowrap;
+
+		input[type="checkbox"] {
+			margin: 0;
+		}
+	}
+
+	.tablenav.top {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		float: none;
+		height: auto;
+		margin: 0;
+		padding: 0;
+
+		.tablenav-pages,
+		.displaying-num,
+		br.clear {
+			display: none;
+		}
+
+		.alignleft.actions.bulkactions {
+			display: flex;
+			align-items: center;
+			gap: 8px;
+
+			select {
+				min-inline-size: 140px;
+				height: 36px;
+				border: 1px solid $jp-border;
 				border-radius: 4px;
-				padding: 8px 16px 8px 40px;
-				line-height: 24px;
-				font-size: typography.$font-body;
-				letter-spacing: -0.02em;
-				color: calypso-colors.$black;
-				font-weight: 400;
-				height: 40px;
-				width: 100%;
-				background-image: url(../images/icon-search.svg);
-				background-repeat: no-repeat;
-				background-position: 8px center;
-				float: none;
-
-				&::placeholder {
-					color: calypso-colors.$gray-30;
-				}
-
-				@media (max-width: 782px) {
-					max-width: 90%;
-				}
-			}
-
-			input[type="submit"] {
-				display: none;
-			}
-		}
-
-		.button-group {
-
-			@media (max-width: 782px) {
-				white-space: normal;
+				padding-block: 0;
+				// Leave room for the native dropdown arrow so the label doesn't overlap it.
+				padding-inline: 12px 28px;
+				font-size: $jp-font-ui;
+				color: $jp-text;
 			}
 
 			.button {
-				box-shadow: none;
-				padding-left: 24px;
-				padding-right: 24px;
-				min-width: 90px;
-				border: 1px solid calypso-colors.$gray-5;
-				color: calypso-colors.$black;
-				height: 40px;
-				font-size: 13px;
-				line-height: 18px;
-				font-weight: 400;
+				height: 36px;
+				border: 1px solid $jp-border;
+				border-radius: 4px;
 				background: colors.$white;
-
-				&:hover {
-					background: calypso-colors.$gray-0;
-				}
-
-				&:focus {
-					border-color: calypso-colors.$black;
-				}
-			}
-
-			button.dops-button.button.active {
-				background: calypso-colors.$black;
-				color: colors.$white;
-				font-weight: 600;
-
-				&:hover {
-					background: calypso-colors.$gray-80;
-				}
-
-				&:focus {
-					border-color: colors.$white;
-					box-shadow: 0 0 0 1px calypso-colors.$black;
-				}
+				color: $jp-text;
+				box-shadow: none;
 			}
 		}
-
-		.subsubsub {
-			margin: 0;
-			padding: 0;
-
-			li {
-				display: block;
-				text-align: left;
-				margin: 0 0 4px 0;
-				font-size: 14px;
-
-				a {
-					padding: 0;
-					color: calypso-colors.$black;
-					text-decoration: underline;
-					font-size: typography.$font-body-small;
-					line-height: 24px;
-					letter-spacing: -0.02em;
-
-					&:hover {
-						text-decoration-thickness: 3px;
-					}
-				}
-
-				&.current {
-					border-radius: 4px;
-					background: calypso-colors.$black;
-					padding: 2px 6px;
-
-					a,
-					.count {
-						color: colors.$white;
-						text-decoration: none;
-						font-weight: 700;
-					}
-				}
-			}
-		}
-
-		@media (max-width: 782px) {
-			background: #fff;
-			bottom: 0;
-			display: none;
-			min-width: 300px;
-			position: fixed;
-			right: 0;
-			top: 0;
-			z-index: 13;
-			box-shadow: 0 1px 20px 5px rgba(0, 0, 0, 0.1);
-
-			.bumper {
-				margin: 13px;
-			}
-
-			.navbar-form {
-				margin: 16px 0 0 0;
-				padding: 0;
-			}
-		} // < 782
 	}
 }
 
-@media (max-width: 782px) {
-
-	// Fix to override particular wp-list-table changes in core - July 2015
-	.wp-list-table tr:not(.inline-edit-row):not(.no-items) td:not(.column-primary):not(.check-column) {
-		padding: 11px 10px;
-		display: block;
-	}
-
-	.manage-right.show .subsubsub li {
-		padding: 5px;
-	}
-
-} // < 782
-
-@media (max-width: 650px) {
-
-	.table-bordered.jetpack-modules tr.jetpack-module.deprecated td .row-actions {
-		float: none;
-		padding-left: 18px;
-	}
+.jetpack-modules-card table.jetpack-modules {
+	width: 100%;
+	margin: 0;
+	border: 0;
+	border-collapse: collapse;
+	background: transparent;
+	box-shadow: none;
 }
 
-@media (max-width: 430px) {
-
-	// Hide activate / config links on really small screens.
-	// Users can still utilize these actions by tapping on the title of the module.
-	.table-bordered.jetpack-modules tr.jetpack-module td .row-actions {
-		display: none;
-	}
-
-	.table-bordered.jetpack-modules tr.jetpack-module.deprecated td .row-actions {
-		display: block;
-	}
-} // < 430
-
-// Modules page hacks
 .jetpack-modules-list-table-form .widefat td {
 	width: 100%;
 }
 
-.jetpack-module-list {
+// --------------------------------------------------------------------------
+// Group headers
+// --------------------------------------------------------------------------
+tr.jetpack-module-group-header {
+	display: block;
 
-	.widefat {
-		border: none;
+	td {
+		display: block;
+		padding-block: 20px 8px;
+		padding-inline: 16px;
+		border: 0;
+		background: transparent;
 	}
 
-	.wrap {
-		display: flex;
-		overflow: visible;
-
-		.manage-left {
-			flex-grow: 1;
-			width: auto;
-		}
-
-		.manage-right {
-			flex-grow: 0;
-		}
+	// The very first group header sits flush with the top of the card.
+	&:first-child td {
+		padding-block-start: 16px;
 	}
 }
 
+.jetpack-module-group-header__title {
+	margin: 0;
+	font-size: 12px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+	color: $jp-text-muted;
+}
+
+// --------------------------------------------------------------------------
+// Module rows
+// --------------------------------------------------------------------------
 tr.jetpack-module {
 	box-sizing: border-box;
 	display: flex;
 	flex-direction: row;
-	align-items: center;
-	padding: 16px;
+	align-items: flex-start;
 	gap: 16px;
 	width: 100%;
-	height: 60px;
+	padding: 16px;
 	background: colors.$white;
-	border-bottom: 1px solid calypso-colors.$gray-5;
+	border-block-start: 1px solid $jp-border;
 
-	@media (max-width: 782px) {
-		padding: 4px 10px;
-		height: auto;
-	}
-
-	&:last-of-type {
-		border-bottom: 0;
+	// No divider directly under a group header.
+	.jetpack-module-group-header + & {
+		border-block-start: 0;
 	}
 
 	th.check-column {
-		padding-top: 0;
+		flex: 0 0 auto;
 		width: auto;
+		padding: 0;
+		margin-block-start: 2px;
+	}
+
+	.column-name {
+		flex: 1 1 auto;
+		min-width: 0;
+		padding: 0;
+		color: $jp-text;
 	}
 
 	a,
@@ -493,32 +505,194 @@ tr.jetpack-module.unavailable {
 	background: #f9f9f6;
 }
 
-tr.jetpack-module.active {
-	background: #f9f9f6;
+.jetpack-module__body {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: 16px;
+	width: 100%;
+}
 
-	.column-name .info {
-		font-weight: 700;
+.jetpack-module__info {
+	display: flex;
+	flex-direction: column;
+	gap: 2px;
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+.jetpack-module__name {
+	font-size: $jp-font-ui;
+	font-weight: 600;
+	color: $jp-text;
+}
+
+.jetpack-module__description {
+	font-size: $jp-font-ui;
+	line-height: 1.5;
+	color: $jp-text-muted;
+}
+
+.jetpack-module__meta {
+	display: flex;
+	align-items: center;
+	gap: 16px;
+	flex: 0 0 auto;
+	margin-inline-start: auto;
+}
+
+.jetpack-module__badges {
+	display: flex;
+	align-items: center;
+	gap: 8px;
+}
+
+.jetpack-module__badge {
+	display: inline-flex;
+	align-items: center;
+	padding-block: 2px;
+	padding-inline: 8px;
+	border-radius: 2px;
+	font-size: 12px;
+	font-weight: 500;
+	line-height: 1.5;
+	white-space: nowrap;
+
+	&.is-active {
+		background: #edfaef;
+		color: #00450c;
 	}
 
+	&.is-inactive {
+		background: calypso-colors.$gray-0;
+		color: $jp-text-muted;
+	}
 
+	&.is-recommended {
+		background: #f0f4ff;
+		color: #1d35b4;
+	}
 }
 
-tr.jetpack-module .column-name {
-	color: calypso-colors.$gray-80;
-	float: left;
-	align-items: center;
+.jetpack-module .row-actions {
 	display: flex;
-	padding: 0;
+	align-items: center;
+	gap: 12px;
+	position: static;
+	margin: 0;
+	left: auto;
+
+	// Row actions are always visible on this page (not on hover).
+	opacity: 1;
+
+	.configure a {
+		color: $jp-text;
+		font-size: typography.$font-body-extra-small;
+		line-height: 20px;
+		font-weight: 600;
+		text-decoration: none;
+
+		&:hover {
+			text-decoration: underline;
+		}
+	}
 }
 
-tr.jetpack-module .row-actions {
+.jetpack-module__unavailable {
+	max-inline-size: 220px;
+	font-size: typography.$font-body-extra-small;
+	line-height: 1.4;
+	color: $jp-text-muted;
+}
+
+// --------------------------------------------------------------------------
+// Toggle switch (styled link that activates / deactivates the module)
+// --------------------------------------------------------------------------
+.jetpack-module__toggle {
+	display: inline-flex;
 	align-items: center;
-	display: flex;
+	text-decoration: none;
+	cursor: pointer;
+	border-radius: 10px;
+
+	&:focus {
+		outline: none;
+	}
+}
+
+.jetpack-module__toggle-track {
 	position: relative;
-	margin-left: auto;
-	left: 0;
+	display: inline-block;
+	inline-size: 36px;
+	block-size: 20px;
+	background: #dcdcde;
+	border-radius: 10px;
+	transition: background 0.15s ease-in-out;
+}
 
-	span.configure {
-		margin-right: 16px;
+.jetpack-module__toggle-thumb {
+	position: absolute;
+	inset-block-start: 2px;
+	inset-inline-start: 2px;
+	inline-size: 16px;
+	block-size: 16px;
+	border-radius: 50%;
+	background: colors.$white;
+	box-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+	transition: inset-inline-start 0.15s ease-in-out;
+}
+
+.jetpack-module__toggle.is-active {
+
+	.jetpack-module__toggle-track {
+		background: $jp-primary;
+	}
+
+	.jetpack-module__toggle-thumb {
+		inset-inline-start: 18px;
+	}
+}
+
+.jetpack-module__toggle.is-disabled {
+	cursor: default;
+	opacity: 0.6;
+}
+
+.jetpack-module__toggle:focus-visible .jetpack-module__toggle-track {
+	box-shadow: 0 0 0 2px colors.$white, 0 0 0 4px $jp-primary;
+}
+
+// --------------------------------------------------------------------------
+// Checkboxes
+// --------------------------------------------------------------------------
+.jetpack-module-list .check-column input[type="checkbox"] {
+	width: 20px;
+	height: 20px;
+	border-radius: 2px;
+	margin-inline-start: 0;
+
+	&::before {
+		margin: -2px;
+		color: $jp-text;
+		width: 21px;
+		height: 21px;
+	}
+}
+
+// --------------------------------------------------------------------------
+// Responsive
+// --------------------------------------------------------------------------
+@media (max-width: 782px) {
+
+	.jetpack-module__body {
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 12px;
+	}
+
+	.jetpack-module__meta {
+		margin-inline-start: 0;
+		width: 100%;
+		justify-content: space-between;
 	}
 }

--- a/projects/plugins/jetpack/scss/templates/_settings.scss
+++ b/projects/plugins/jetpack/scss/templates/_settings.scss
@@ -140,7 +140,7 @@ $jp-font-ui: var(--wpds-typography-font-size-md, 13px);
 
 .jetpack-offline-notice__text {
 	margin: 0;
-	font-size: $jp-font-ui;
+	font-size: typography.$font-body-small;
 	line-height: 1.5;
 	color: $jp-text-muted;
 
@@ -173,7 +173,7 @@ $jp-font-ui: var(--wpds-typography-font-size-md, 13px);
 	// bulk-actions bar (12px padding + 36px controls) in the main column.
 	p.search-box {
 		width: 100%;
-		margin-block: 10px 0;
+		margin-block: 0;
 		margin-inline: 0;
 		float: none;
 		display: block;
@@ -207,8 +207,10 @@ $jp-font-ui: var(--wpds-typography-font-size-md, 13px);
 		}
 	}
 
-	// Module tag filters (subsubsub) as a vertical list.
-	.subsubsub {
+	// Module tag filters (subsubsub) and the "Purpose" facet share the same
+	// vertical text-link list styling.
+	.subsubsub,
+	.purpose-filter {
 		margin: 0;
 		padding: 0;
 
@@ -244,6 +246,17 @@ $jp-font-ui: var(--wpds-typography-font-size-md, 13px);
 				.count {
 					color: colors.$white;
 					font-weight: 700;
+				}
+			}
+
+			// Tags with no matches under the current filters: greyed out and
+			// non-interactive, but kept in place so the list doesn't reflow.
+			&.is-empty {
+				opacity: 0.4;
+
+				a {
+					pointer-events: none;
+					cursor: default;
 				}
 			}
 		}

--- a/projects/plugins/jetpack/tests/php/Get_Modules_Test.php
+++ b/projects/plugins/jetpack/tests/php/Get_Modules_Test.php
@@ -213,7 +213,7 @@ class Get_Modules_Test extends WP_UnitTestCase {
 
 		StatusCache::clear();
 		add_filter( 'jetpack_offline_mode', '__return_true' );
-		$this->assertSame( 'Offline mode', Jetpack_Admin::get_module_unavailable_reason( $dummy_module ) );
+		$this->assertSame( 'Unavailable in Offline mode', Jetpack_Admin::get_module_unavailable_reason( $dummy_module ) );
 		remove_filter( 'jetpack_offline_mode', '__return_true' );
 		StatusCache::clear();
 


### PR DESCRIPTION
Closes JETPACK-2068

## Proposed changes

Modernizes the legacy Jetpack Modules page (`admin.php?page=jetpack_modules`) and improves how it behaves in Offline Mode. No React was introduced — the existing PHP/Backbone page was restyled and extended.

**UI refresh**
* Restyle the two-column layout (module list + filter sidebar) to a core-UI look aligned with the React admin pages (Newsletter, VideoPress, Activity Log): grouped product-area sections rendered as toggle rows inside a card, with Active/Inactive/Recommended badges.
* Group modules by product area ("Grow your audience", "Speed up your site", "Protect your site", "Other features") on both the Backbone re-render and the server-rendered (no-JS) output.
* Split the View filter into two labeled groups: **State** (All / Active / Inactive) and **Purpose** (product areas).
* Align typography, colors, and borders with WPDS design tokens (13px UI text, neutral borders, blue primary), with hex fallbacks for when the token stylesheet isn't enqueued.

**Offline Mode**
* Surface the Modules page as the first item under the Jetpack top-level menu in Offline Mode, so clicking "Jetpack" lands on Modules (instead of the first cloud page, e.g. AI). The "Settings" item continues to point at the settings dashboard.
* Add a "Jetpack / Offline Mode / Modules" breadcrumb in the masthead.
* Add a friendly, informational Offline Mode notice (styled like the plan-picker callouts, with the shared gradient asset) explaining what to expect.
* Add an "Available in offline mode" top-level filter (All / Hide unavailable) that hides connection-dependent modules regardless of the other filters. It defaults to "Hide unavailable" in Offline Mode.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Connected site (UI refresh):
* Go to **Jetpack → Settings** (`admin.php?page=jetpack_modules`).
* Confirm modules render grouped into product-area cards with toggles and Active/Inactive/Recommended badges.
* Use the sidebar: search, the **State** (All/Active/Inactive) and **Purpose** (product area) filters, sort options, and module-tag list. Confirm only one State/Purpose filter is active at a time and the list updates accordingly.
* Toggle a module on/off and confirm it activates/deactivates and the filter state is preserved after reload.

Offline Mode:
* Put the site in Offline Mode (e.g. `define( 'JETPACK_DEV_DEBUG', true );` or a local `.test`/`.local` domain).
* Click the top-level **Jetpack** menu item and confirm it lands on the **Modules** page (not AI).
* Confirm the masthead shows **Jetpack / Offline Mode / Modules** and a friendly Offline Mode notice appears above the list.
* Confirm the **Available in offline mode** filter is present and defaults to **Hide unavailable** (connection-dependent modules hidden); switch to **All** and confirm they reappear (greyed out / unavailable).
* Confirm the **Settings** menu item still opens the settings dashboard.
