### PR TITLE
Premium Analytics: align post detail card titles and the clicks Locations card with the design mocks

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-post-detail-mock-alignment
+++ b/projects/packages/premium-analytics/changelog/update-post-detail-mock-alignment
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Post detail: align card titles with the design mocks (Locations, Platforms, Clients, UTM) and drop the map from the Email clicks Locations card.
+Post detail: align cards with the design mocks — plain Locations/Platforms/Clients/UTM titles, per-card icons, a three-column highlights row, and no map on the Email clicks Locations card.

--- a/projects/packages/premium-analytics/changelog/update-post-detail-mock-alignment
+++ b/projects/packages/premium-analytics/changelog/update-post-detail-mock-alignment
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Post detail: align card titles with the design mocks (Locations, Platforms, Clients, UTM) and drop the map from the Email clicks Locations card.

--- a/projects/packages/premium-analytics/routes/post-detail/config/index.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/index.ts
@@ -10,4 +10,4 @@ export {
 
 export { POST_DETAIL_TAB_LAYOUTS } from './tab-layouts';
 
-export { EMAIL_WIDGET_TYPE_ALIASES } from './email-widget-variants';
+export { POST_DETAIL_WIDGET_TYPE_ALIASES } from './widget-variants';

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.test.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.test.ts
@@ -31,7 +31,7 @@ describe( 'post detail tab layouts', () => {
 			},
 			{
 				uuid: 'post-utm',
-				type: 'jpa/utm-insights',
+				type: 'jpa/utm-insights--utm',
 				attributes: { utmDimension: 'utm_source,utm_medium', max: 10, showReportLink: false },
 				placement: { width: 1, height: 2, order: 6 },
 			},
@@ -73,7 +73,7 @@ describe( 'post detail tab layouts', () => {
 		] );
 	} );
 
-	it( 'composes Email clicks as a trend chart beside Platforms and Clients, over the mapped Locations and links rows', () => {
+	it( 'composes Email clicks as a trend chart beside Platforms and Clients, over the Locations and links rows', () => {
 		expect( POST_DETAIL_TAB_LAYOUTS[ 'email-clicks' ] ).toMatchObject( [
 			{
 				uuid: 'email-clicks-highlights',
@@ -102,7 +102,7 @@ describe( 'post detail tab layouts', () => {
 			{
 				uuid: 'email-clicks-countries',
 				type: 'jpa/email-breakdown--location-clicks',
-				attributes: { view: 'countries', metric: 'clicks', max: 7, showMap: true },
+				attributes: { view: 'countries', metric: 'clicks', max: 7 },
 				placement: { width: 2, height: 2, order: 5 },
 			},
 			{

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.test.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.test.ts
@@ -102,7 +102,7 @@ describe( 'post detail tab layouts', () => {
 			{
 				uuid: 'email-clicks-countries',
 				type: 'jpa/email-breakdown--location-clicks',
-				attributes: { view: 'countries', metric: 'clicks', max: 7 },
+				attributes: { view: 'countries', metric: 'clicks', max: 8 },
 				placement: { width: 2, height: 2, order: 5 },
 			},
 			{

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.test.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.test.ts
@@ -2,12 +2,12 @@ import { WIDGET_DASHBOARD_COLUMN_COUNT } from '@wordpress/widget-dashboard';
 import { POST_DETAIL_TAB_LAYOUTS } from './tab-layouts';
 
 describe( 'post detail tab layouts', () => {
-	it( 'composes Post traffic as a full-width highlights row, a Post views chart beside the interaction cards, then Traffic activity beside UTM', () => {
+	it( 'composes Post traffic as a three-column highlights row, a Post views chart beside the interaction cards, then Traffic activity beside UTM', () => {
 		expect( POST_DETAIL_TAB_LAYOUTS[ 'post-traffic' ] ).toEqual( [
 			{
 				uuid: 'post-detail-highlights',
 				type: 'jpa/post-detail-highlights',
-				placement: { width: WIDGET_DASHBOARD_COLUMN_COUNT, height: 1, order: 1 },
+				placement: { width: 3, height: 1, order: 1 },
 			},
 			{
 				uuid: 'post-views',

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
@@ -13,8 +13,10 @@ export const POST_DETAIL_TAB_LAYOUTS: Record< PostDetailTabId, DashboardWidget[]
 	'post-traffic': [
 		{
 			uuid: 'post-detail-highlights',
+			// Three quarter-width tiles with the last column left empty, per the
+			// design mocks — unlike the email highlights rows, which span all four.
 			type: 'jpa/post-detail-highlights',
-			placement: { width: WIDGET_DASHBOARD_COLUMN_COUNT, height: 1, order: 1 },
+			placement: { width: 3, height: 1, order: 1 },
 		},
 		{
 			uuid: 'post-views',

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
@@ -111,7 +111,7 @@ export const POST_DETAIL_TAB_LAYOUTS: Record< PostDetailTabId, DashboardWidget[]
 			uuid: 'email-clicks-countries',
 			// Plain leaderboard per the design mocks — no map beside it.
 			type: 'jpa/email-breakdown--location-clicks',
-			attributes: { view: 'countries', metric: 'clicks', max: 7 },
+			attributes: { view: 'countries', metric: 'clicks', max: 8 },
 			placement: { width: 2, height: 2, order: 5 },
 		},
 		{

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
@@ -38,7 +38,9 @@ export const POST_DETAIL_TAB_LAYOUTS: Record< PostDetailTabId, DashboardWidget[]
 		},
 		{
 			uuid: 'post-utm',
-			type: 'jpa/utm-insights',
+			// The alias carries the mock's "UTM" card title; the registry's
+			// global "UTM Insights" title is owned by the copy spreadsheet work.
+			type: 'jpa/utm-insights--utm',
 			// Detail-page widgets carry no "See report" action per the design
 			// mocks — the post detail page is itself the terminal page, and the
 			// site-wide UTM report would silently drop this post's scope.
@@ -105,8 +107,9 @@ export const POST_DETAIL_TAB_LAYOUTS: Record< PostDetailTabId, DashboardWidget[]
 		},
 		{
 			uuid: 'email-clicks-countries',
+			// Plain leaderboard per the design mocks — no map beside it.
 			type: 'jpa/email-breakdown--location-clicks',
-			attributes: { view: 'countries', metric: 'clicks', max: 7, showMap: true },
+			attributes: { view: 'countries', metric: 'clicks', max: 7 },
 			placement: { width: 2, height: 2, order: 5 },
 		},
 		{

--- a/projects/packages/premium-analytics/routes/post-detail/config/widget-variants.test.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/widget-variants.test.ts
@@ -1,0 +1,35 @@
+/**
+ * Internal dependencies
+ */
+import { POST_DETAIL_WIDGET_TYPE_ALIASES } from './widget-variants';
+
+describe( 'post detail widget type aliases', () => {
+	it( 'titles every variant with its design-mock card title', () => {
+		const titles = Object.fromEntries(
+			POST_DETAIL_WIDGET_TYPE_ALIASES.flatMap( ( { variants } ) =>
+				variants.map( variant => [ variant.name, variant.getTitle() ] )
+			)
+		);
+
+		expect( titles ).toEqual( {
+			'jpa/email-time-series--total-opens': 'Total opens',
+			'jpa/email-time-series--total-clicks': 'Total clicks',
+			'jpa/email-breakdown--location-opens': 'Locations',
+			'jpa/email-breakdown--platforms-opens': 'Platforms',
+			'jpa/email-breakdown--clients-opens': 'Clients',
+			'jpa/email-breakdown--location-clicks': 'Locations',
+			'jpa/email-breakdown--platforms-clicks': 'Platforms',
+			'jpa/email-breakdown--clients-clicks': 'Clients',
+			'jpa/email-breakdown--top-links': 'Top links',
+			'jpa/utm-insights--utm': 'UTM',
+		} );
+	} );
+
+	it( 'keeps every variant name unique so the host resolves each independently', () => {
+		const names = POST_DETAIL_WIDGET_TYPE_ALIASES.flatMap( ( { variants } ) =>
+			variants.map( variant => variant.name )
+		);
+
+		expect( new Set( names ).size ).toBe( names.length );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/post-detail/config/widget-variants.test.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/widget-variants.test.ts
@@ -1,4 +1,8 @@
 /**
+ * External dependencies
+ */
+import { link, mapMarker, megaphone, desktop, seen } from '@wordpress/icons';
+/**
  * Internal dependencies
  */
 import { POST_DETAIL_WIDGET_TYPE_ALIASES } from './widget-variants';
@@ -22,6 +26,27 @@ describe( 'post detail widget type aliases', () => {
 			'jpa/email-breakdown--clients-clicks': 'Clients',
 			'jpa/email-breakdown--top-links': 'Top links',
 			'jpa/utm-insights--utm': 'UTM',
+		} );
+	} );
+
+	it( 'gives every variant its design-mock icon, inheriting the base icon when unset', () => {
+		const icons = Object.fromEntries(
+			POST_DETAIL_WIDGET_TYPE_ALIASES.flatMap( ( { variants } ) =>
+				variants.map( variant => [ variant.name, variant.icon ] )
+			)
+		);
+
+		expect( icons ).toEqual( {
+			'jpa/email-time-series--total-opens': seen,
+			'jpa/email-time-series--total-clicks': link,
+			'jpa/email-breakdown--location-opens': mapMarker,
+			'jpa/email-breakdown--platforms-opens': desktop,
+			'jpa/email-breakdown--clients-opens': undefined,
+			'jpa/email-breakdown--location-clicks': mapMarker,
+			'jpa/email-breakdown--platforms-clicks': desktop,
+			'jpa/email-breakdown--clients-clicks': undefined,
+			'jpa/email-breakdown--top-links': link,
+			'jpa/utm-insights--utm': megaphone,
 		} );
 	} );
 

--- a/projects/packages/premium-analytics/routes/post-detail/config/widget-variants.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/widget-variants.ts
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 
 /**
- * Page-local aliases of registered widget types for the fixed email
+ * Page-local aliases of registered widget types for the fixed post-detail
  * compositions. The widget host titles a card by its widget *type*, so one
  * type rendered several times would repeat one generic title; each alias
  * reuses the resolved base type's render module under a design title instead.
@@ -15,7 +15,7 @@ import { __ } from '@wordpress/i18n';
  * Labels are lazy getters so translations resolve after the i18n locale data
  * has loaded, mirroring the tab definitions.
  */
-export const EMAIL_WIDGET_TYPE_ALIASES: ReadonlyArray< {
+export const POST_DETAIL_WIDGET_TYPE_ALIASES: ReadonlyArray< {
 	baseType: `jpa/${ string }`;
 	variants: ReadonlyArray< {
 		name: `jpa/${ string }`;
@@ -40,31 +40,40 @@ export const EMAIL_WIDGET_TYPE_ALIASES: ReadonlyArray< {
 		variants: [
 			{
 				name: 'jpa/email-breakdown--location-opens',
-				getTitle: () => __( 'Location opens', 'jetpack-premium-analytics-pkg' ),
+				getTitle: () => __( 'Locations', 'jetpack-premium-analytics-pkg' ),
 			},
 			{
 				name: 'jpa/email-breakdown--platforms-opens',
-				getTitle: () => __( 'Platforms opens', 'jetpack-premium-analytics-pkg' ),
+				getTitle: () => __( 'Platforms', 'jetpack-premium-analytics-pkg' ),
 			},
 			{
 				name: 'jpa/email-breakdown--clients-opens',
-				getTitle: () => __( 'Clients opens', 'jetpack-premium-analytics-pkg' ),
+				getTitle: () => __( 'Clients', 'jetpack-premium-analytics-pkg' ),
 			},
 			{
 				name: 'jpa/email-breakdown--location-clicks',
-				getTitle: () => __( 'Location clicks', 'jetpack-premium-analytics-pkg' ),
+				getTitle: () => __( 'Locations', 'jetpack-premium-analytics-pkg' ),
 			},
 			{
 				name: 'jpa/email-breakdown--platforms-clicks',
-				getTitle: () => __( 'Platforms clicks', 'jetpack-premium-analytics-pkg' ),
+				getTitle: () => __( 'Platforms', 'jetpack-premium-analytics-pkg' ),
 			},
 			{
 				name: 'jpa/email-breakdown--clients-clicks',
-				getTitle: () => __( 'Clients clicks', 'jetpack-premium-analytics-pkg' ),
+				getTitle: () => __( 'Clients', 'jetpack-premium-analytics-pkg' ),
 			},
 			{
 				name: 'jpa/email-breakdown--top-links',
 				getTitle: () => __( 'Top links', 'jetpack-premium-analytics-pkg' ),
+			},
+		],
+	},
+	{
+		baseType: 'jpa/utm-insights',
+		variants: [
+			{
+				name: 'jpa/utm-insights--utm',
+				getTitle: () => __( 'UTM', 'jetpack-premium-analytics-pkg' ),
 			},
 		],
 	},

--- a/projects/packages/premium-analytics/routes/post-detail/config/widget-variants.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/widget-variants.ts
@@ -2,24 +2,31 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { link, mapMarker, megaphone, desktop, seen } from '@wordpress/icons';
+/**
+ * Internal dependencies
+ */
+import type { WidgetIcon } from '@wordpress/widget-primitives';
 
 /**
  * Page-local aliases of registered widget types for the fixed post-detail
  * compositions. The widget host titles a card by its widget *type*, so one
  * type rendered several times would repeat one generic title; each alias
- * reuses the resolved base type's render module under a design title instead.
- * The aliases exist only in this page's `widgetTypes` — the post detail page
- * is a fixed composition with no widget gallery, so they can never be picked
- * elsewhere.
+ * reuses the resolved base type's render module under a design title (and,
+ * where the mocks call for one, its own icon) instead. The aliases exist only
+ * in this page's `widgetTypes` — the post detail page is a fixed composition
+ * with no widget gallery, so they can never be picked elsewhere.
  *
  * Labels are lazy getters so translations resolve after the i18n locale data
- * has loaded, mirroring the tab definitions.
+ * has loaded, mirroring the tab definitions. Icons are static module refs;
+ * variants without one inherit the base type's icon.
  */
 export const POST_DETAIL_WIDGET_TYPE_ALIASES: ReadonlyArray< {
 	baseType: `jpa/${ string }`;
 	variants: ReadonlyArray< {
 		name: `jpa/${ string }`;
 		getTitle: () => string;
+		icon?: WidgetIcon;
 	} >;
 } > = [
 	{
@@ -28,10 +35,12 @@ export const POST_DETAIL_WIDGET_TYPE_ALIASES: ReadonlyArray< {
 			{
 				name: 'jpa/email-time-series--total-opens',
 				getTitle: () => __( 'Total opens', 'jetpack-premium-analytics-pkg' ),
+				icon: seen,
 			},
 			{
 				name: 'jpa/email-time-series--total-clicks',
 				getTitle: () => __( 'Total clicks', 'jetpack-premium-analytics-pkg' ),
+				icon: link,
 			},
 		],
 	},
@@ -41,10 +50,12 @@ export const POST_DETAIL_WIDGET_TYPE_ALIASES: ReadonlyArray< {
 			{
 				name: 'jpa/email-breakdown--location-opens',
 				getTitle: () => __( 'Locations', 'jetpack-premium-analytics-pkg' ),
+				icon: mapMarker,
 			},
 			{
 				name: 'jpa/email-breakdown--platforms-opens',
 				getTitle: () => __( 'Platforms', 'jetpack-premium-analytics-pkg' ),
+				icon: desktop,
 			},
 			{
 				name: 'jpa/email-breakdown--clients-opens',
@@ -53,10 +64,12 @@ export const POST_DETAIL_WIDGET_TYPE_ALIASES: ReadonlyArray< {
 			{
 				name: 'jpa/email-breakdown--location-clicks',
 				getTitle: () => __( 'Locations', 'jetpack-premium-analytics-pkg' ),
+				icon: mapMarker,
 			},
 			{
 				name: 'jpa/email-breakdown--platforms-clicks',
 				getTitle: () => __( 'Platforms', 'jetpack-premium-analytics-pkg' ),
+				icon: desktop,
 			},
 			{
 				name: 'jpa/email-breakdown--clients-clicks',
@@ -65,6 +78,7 @@ export const POST_DETAIL_WIDGET_TYPE_ALIASES: ReadonlyArray< {
 			{
 				name: 'jpa/email-breakdown--top-links',
 				getTitle: () => __( 'Top links', 'jetpack-premium-analytics-pkg' ),
+				icon: link,
 			},
 		],
 	},
@@ -74,6 +88,7 @@ export const POST_DETAIL_WIDGET_TYPE_ALIASES: ReadonlyArray< {
 			{
 				name: 'jpa/utm-insights--utm',
 				getTitle: () => __( 'UTM', 'jetpack-premium-analytics-pkg' ),
+				icon: megaphone,
 			},
 		],
 	},

--- a/projects/packages/premium-analytics/routes/post-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.tsx
@@ -83,6 +83,7 @@ function PostDetail(): JSX.Element {
 						...base,
 						name: variant.name,
 						title: variant.getTitle(),
+						...( variant.icon ? { icon: variant.icon } : {} ),
 				  } ) )
 				: [];
 		} );

--- a/projects/packages/premium-analytics/routes/post-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.tsx
@@ -11,7 +11,7 @@ import { Button } from '@wordpress/ui';
 import { DEFAULT_GRID, ROW_HEIGHT_PRESETS, WidgetDashboard } from '@wordpress/widget-dashboard';
 import { useWidgetTypes, type WidgetModuleRecord } from '@wordpress/widget-primitives';
 import { PostDetailTabs, PostSummaryCard } from './components';
-import { EMAIL_WIDGET_TYPE_ALIASES } from './config';
+import { POST_DETAIL_WIDGET_TYPE_ALIASES } from './config';
 import { usePostDetailTabs, usePostSummary } from './hooks';
 import { route } from './package.json';
 import styles from './stage.module.scss';
@@ -69,13 +69,13 @@ function PostDetail(): JSX.Element {
 
 	const [ widgetTypes, isResolvingWidgetTypes ] = useWidgetTypes( widgetModules );
 
-	// The fixed email compositions reuse registered widget types under
-	// page-local aliases so each card carries its design title — the host
-	// titles a card by its widget *type*. Each alias clones the resolved base
-	// type (render module and all) under a variant name and title; see
-	// `config/email-widget-variants`.
+	// The fixed compositions reuse registered widget types under page-local
+	// aliases so each card carries its design title — the host titles a card
+	// by its widget *type*. Each alias clones the resolved base type (render
+	// module and all) under a variant name and title; see
+	// `config/widget-variants`.
 	const pageWidgetTypes = useMemo( () => {
-		const aliases = EMAIL_WIDGET_TYPE_ALIASES.flatMap( ( { baseType, variants } ) => {
+		const aliases = POST_DETAIL_WIDGET_TYPE_ALIASES.flatMap( ( { baseType, variants } ) => {
 			const base = widgetTypes.find( widgetType => widgetType.name === baseType );
 
 			return base

--- a/projects/packages/premium-analytics/widgets/email-breakdown/stories/email-breakdown-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/email-breakdown/stories/email-breakdown-widget.stories.tsx
@@ -137,7 +137,9 @@ export const Default: Story = {
 };
 
 /**
- * The wide Location clicks card used by the fixed Email clicks composition.
+ * The optional map beside the countries leaderboard. No fixed composition
+ * enables it anymore (the Email clicks Locations card is a plain leaderboard
+ * per the design mocks); the story keeps the capability covered.
  */
 export const LocationClicksWithMap: Story = {
 	render: renderEmailBreakdown,

--- a/projects/packages/premium-analytics/widgets/email-top-row/render.tsx
+++ b/projects/packages/premium-analytics/widgets/email-top-row/render.tsx
@@ -17,7 +17,7 @@ import {
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { useCallback, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { chartBar, envelope, link, people, percent, seen, send } from '@wordpress/icons';
+import { envelope, link, people, percent, seen, send } from '@wordpress/icons';
 import { Icon, Stack } from '@wordpress/ui';
 /**
  * Internal dependencies
@@ -129,7 +129,7 @@ const EMAIL_METRICS: readonly EmailMetricSpec[] = [
 	},
 	{
 		key: 'clicks_rate',
-		icon: chartBar,
+		icon: percent,
 		label: () => __( 'Click rate', 'jetpack-premium-analytics-pkg' ),
 		kind: 'rate',
 		views: [ 'clicks' ],

--- a/projects/packages/premium-analytics/widgets/post-detail-highlights/widget.ts
+++ b/projects/packages/premium-analytics/widgets/post-detail-highlights/widget.ts
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { starEmpty } from '@wordpress/icons';
+import { chartBar } from '@wordpress/icons';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
 /**
@@ -25,7 +25,7 @@ export type PostDetailHighlightsAttributes = Record< never, never >;
  * summary header, not repeated here.
  */
 export default {
-	icon: starEmpty,
+	icon: chartBar,
 	attributes: [] as WidgetAttributeField< PostDetailHighlightsAttributes >[],
 	example: {
 		attributes: {},

--- a/projects/packages/premium-analytics/widgets/post-views/widget.ts
+++ b/projects/packages/premium-analytics/widgets/post-views/widget.ts
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { chartBar } from '@wordpress/icons';
+import { seen } from '@wordpress/icons';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
 /**
@@ -36,7 +36,7 @@ export type PostViewsAttributes = {
  * `granularity` attribute (`relevance: 'high'`) chooses the bucket size.
  */
 export default {
-	icon: chartBar,
+	icon: seen,
 	attributes: [
 		{
 			id: 'granularity',


### PR DESCRIPTION
Part of WOOA7S-1785

## Why

The post detail page's cards should read like the design mocks so beta interviewees see the intended UI: the email breakdown cards were titled "Location opens" / "Platforms clicks" etc. where the mocks title them plainly Locations / Platforms / Clients, the UTM card said "UTM Insights" instead of "UTM", and the Email clicks Locations card rendered a geo map the mocks don't have.

## Proposed changes

* Retitle the six email-breakdown page aliases to the mock titles — `Locations`, `Platforms`, `Clients` (identical on both email tabs).
* Add a `jpa/utm-insights--utm` page alias titled `UTM` and use it in the Post traffic composition — page-local, so the registry's global "UTM Insights" title (owned by the WOOA7S-1782 copy-spreadsheet work) is untouched.
* Drop `showMap` from the Email clicks Locations card — plain leaderboard per the mocks.
* Rename `config/email-widget-variants.ts` → `config/widget-variants.ts` (`EMAIL_WIDGET_TYPE_ALIASES` → `POST_DETAIL_WIDGET_TYPE_ALIASES`) now that the aliases are no longer email-only.

## Related product discussion/links

* WOOA7S-1785, WOOA7S-1782 (global widget titles), design mocks in the Beta-testing milestone discussion

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Verified on a local docker env against a post with newsletter sends (`admin.php?page=jetpack-premium-analytics-wp-admin&p=%2Fpost%2F<id>`):

* Post traffic tab renders: Post highlights / Post views / Latest likes / Latest comments / Traffic activity / **UTM** (previously "UTM Insights").
* Email opens tab renders: Email highlights / Total opens / **Locations** / **Platforms** / **Clients** (previously "Location opens" / "Platforms opens" / "Clients opens").
* Email clicks tab renders: Email highlights / Total clicks / Platforms / Clients / **Locations** (plain leaderboard, no map) / Top links.
* `pnpm run test` in `projects/packages/premium-analytics` — 1450 tests pass (layout snapshot test updated); `pnpm run typecheck` clean.

Out of scope, left on the Linear card: the video detail composition follow-ups and the registry-level widget titles (WOOA7S-1782).
