### PR TITLE
Premium Analytics: compile shared third-party libraries into their own module

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3944,6 +3944,9 @@ importers:
       '@jetpack-premium-analytics/datetime':
         specifier: link:packages/datetime
         version: link:packages/datetime
+      '@jetpack-premium-analytics/externals':
+        specifier: link:packages/externals
+        version: link:packages/externals
       '@jetpack-premium-analytics/fields':
         specifier: link:packages/fields
         version: link:packages/fields

--- a/projects/packages/premium-analytics/AGENTS.md
+++ b/projects/packages/premium-analytics/AGENTS.md
@@ -32,6 +32,7 @@ src/REST/class-api-proxy-controller.php # the WPCOM data proxy (PREFIX_CONFIG)
 src/REST/class-notices-controller.php   # /notices route
 src/Sync/                               # interim woocommerce_analytics sync (WOOA7S-1550)
 packages/data/src/api/                  # frontend fetch helpers (apiFetch)
+packages/externals/                     # passthrough module for shared third-party libraries
 routes/                                 # lazy-loaded SPA pages; build/ is generated
 ```
 
@@ -169,6 +170,10 @@ See Automattic/jetpack#50266 for the PR that established this contract.
 - Don't edit dashboard React in Calypso — it lives here now.
 - Internal package names use `@jetpack-premium-analytics/*` aliases throughout the package —
   never `@automattic/jetpack-premium-analytics-*`.
+- Never import `@automattic/charts`, `@wordpress/ui`, or `@wordpress/dataviews` directly from a
+  package that compiles to a script module — go through `@jetpack-premium-analytics/externals`.
+  A direct import compiles the whole library into that module again; see
+  `packages/externals/README.md`.
 - All source code comments must be in English.
 
 ## Widgets
@@ -508,7 +513,8 @@ give it a story for each; both mocks are 403s, so neither waits out the query's 
 - Importing `@automattic/charts` directly from a widget — chart components must come through
   `@jetpack-premium-analytics/widgets-toolkit` (a shared script module). A direct import
   bundles the entire charting stack into that widget's render bundle; add a re-export to the
-  toolkit's "Charts passthrough" section instead.
+  toolkit's "Charts passthrough" section instead. The toolkit in turn takes charts from
+  `@jetpack-premium-analytics/externals`, so a passthrough export costs nothing.
 - Porting a Stats widget and forgetting to add its endpoint to `routeStatsReport()` in
   `register-report-mocks.ts` — stories will render an error state instead of mock data because
   the middleware only intercepts Woo analytics paths by default.

--- a/projects/packages/premium-analytics/changelog/wooa7s-1836-split-toolkit-externals
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1836-split-toolkit-externals
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Compile shared third-party libraries into a dedicated externals script module so they are no longer duplicated across widget bundles.

--- a/projects/packages/premium-analytics/eslint.config.mjs
+++ b/projects/packages/premium-analytics/eslint.config.mjs
@@ -124,6 +124,41 @@ export default defineConfig(
 		},
 	},
 	{
+		// The toolkit is a shared script module, so a direct import of one of
+		// these libraries compiles it *into* the toolkit instead of resolving
+		// to the externals module — which is what made an unrelated one-line
+		// change rewrite megabytes of build output (WOOA7S-1836).
+		//
+		// Scoped to the toolkit because that is the only module migrated so
+		// far; `packages/ui`, `widgets/`, and `routes/` still import these
+		// directly and are the follow-ups tracked in the PR description.
+		// `packages/externals` is deliberately not covered: it *is* the
+		// passthrough, so it has to import them directly.
+		files: [
+			'packages/widgets-toolkit/**',
+			'projects/packages/premium-analytics/packages/widgets-toolkit/**',
+		],
+		rules: {
+			'no-restricted-imports': [
+				'error',
+				{
+					patterns: [
+						{
+							// Matches the libraries and their subpath entries
+							// (e.g. `@automattic/charts/visx/legend`) but not
+							// stylesheet side-effect imports: those are plain
+							// CSS, not the library, so they carry none of the
+							// bundling cost.
+							regex: '^(@automattic/charts|@wordpress/ui|@wordpress/dataviews)(/(?!.*\\.css$).*)?$',
+							message:
+								'Import these from @jetpack-premium-analytics/externals instead: it compiles them once into a shared script module rather than into every module that imports them. Missing an export? Add it to packages/externals/src/index.ts.',
+						},
+					],
+				},
+			],
+		},
+	},
+	{
 		// Widgets must reach chart components through the widgets-toolkit
 		// shared script module: a direct `@automattic/charts` import gets
 		// silently inlined into that widget's render bundle, dragging the

--- a/projects/packages/premium-analytics/package.json
+++ b/projects/packages/premium-analytics/package.json
@@ -46,6 +46,7 @@
 		"@date-fns/tz": "1.4.1",
 		"@jetpack-premium-analytics/data": "link:packages/data",
 		"@jetpack-premium-analytics/datetime": "link:packages/datetime",
+		"@jetpack-premium-analytics/externals": "link:packages/externals",
 		"@jetpack-premium-analytics/fields": "link:packages/fields",
 		"@jetpack-premium-analytics/formatters": "link:packages/formatters",
 		"@jetpack-premium-analytics/icons": "link:packages/icons",

--- a/projects/packages/premium-analytics/packages/externals/README.md
+++ b/projects/packages/premium-analytics/packages/externals/README.md
@@ -1,0 +1,35 @@
+# `@jetpack-premium-analytics/externals`
+
+A passthrough script module for the heavy third-party libraries the dashboard shares:
+`@automattic/charts`, `@wordpress/ui`, and `@wordpress/dataviews`.
+
+## Why this exists
+
+Every package under `packages/` that declares `wpScriptModuleExports` is compiled into its own
+script module, and wp-build externalises imports between those modules. Anything a module imports
+from npm, however, is bundled *into* that module — so a library used by both `ui` and
+`widgets-toolkit` was compiled into both.
+
+That is a build-output problem, not a runtime one. Premium Analytics is vendored into both
+`plugins/jetpack` and `jetpack-mu-wpcom`, so each module's `index.min.js` and `index.min.js.map`
+ship twice. Because minified bundles are single-line, a one-character source change rewrites the
+whole file, and the sun/moon deploy sees the full artifact as a diff. With ~950 KB of npm code
+compiled into `widgets-toolkit`, an unrelated tweak to a helper produced megabytes of churn and
+tripped the wpcom PR size limit (WOOA7S-1836).
+
+Concentrating those libraries here means they are compiled once, into a module whose contents only
+change when the libraries themselves are upgraded. Feature work no longer rewrites them.
+
+## Rules
+
+- **Re-export only.** No components, hooks, helpers, or types of our own — a change here
+  invalidates the artifact for everyone, which is exactly what this package exists to avoid.
+- **Import from here, never from the library directly.** `import { LineChart } from
+  '@automattic/charts'` inside another module bundles charts into that module again and silently
+  undoes the split.
+- **Adding an export is cheap; adding a library is not.** A new library only belongs here if more
+  than one module needs it, or if it is large enough that re-emitting it per module hurts.
+
+Libraries WordPress already registers as script modules or globals (`@wordpress/components`,
+`@wordpress/data`, `@wordpress/i18n`, `react`, …) are externalised by wp-build on their own and
+must **not** be routed through here.

--- a/projects/packages/premium-analytics/packages/externals/README.md
+++ b/projects/packages/premium-analytics/packages/externals/README.md
@@ -26,7 +26,10 @@ change when the libraries themselves are upgraded. Feature work no longer rewrit
   invalidates the artifact for everyone, which is exactly what this package exists to avoid.
 - **Import from here, never from the library directly.** `import { LineChart } from
   '@automattic/charts'` inside another module bundles charts into that module again and silently
-  undoes the split.
+  undoes the split. ESLint enforces this for `packages/widgets-toolkit` (`no-restricted-imports`
+  in `eslint.config.mjs`); stylesheet imports are exempt, since plain CSS carries none of the
+  bundling cost. The rule is scoped to the toolkit because that is the only module migrated so
+  far — widen it as `packages/ui`, `widgets/`, and `routes/` follow.
 - **Adding an export is cheap; adding a library is not.** A new library only belongs here if more
   than one module needs it, or if it is large enough that re-emitting it per module hurts.
 

--- a/projects/packages/premium-analytics/packages/externals/package.json
+++ b/projects/packages/premium-analytics/packages/externals/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@jetpack-premium-analytics/externals",
+	"name": "@automattic/jetpack-premium-analytics-externals",
 	"version": "0.1.0",
 	"private": true,
 	"type": "module",

--- a/projects/packages/premium-analytics/packages/externals/package.json
+++ b/projects/packages/premium-analytics/packages/externals/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "@jetpack-premium-analytics/externals",
+	"version": "0.1.0",
+	"private": true,
+	"type": "module",
+	"main": "src/index.ts",
+	"module": "build-module/index.mjs",
+	"wpScriptModuleExports": "./build-module/index.mjs",
+	"types": "src/index.ts",
+	"sideEffects": [
+		"*.css",
+		"*.scss",
+		"src/index.ts"
+	],
+	"dependencies": {
+		"@automattic/charts": "workspace:*",
+		"@wordpress/dataviews": "17.1.0",
+		"@wordpress/ui": "0.17.0",
+		"react": "18.3.1"
+	}
+}

--- a/projects/packages/premium-analytics/packages/externals/src/index.ts
+++ b/projects/packages/premium-analytics/packages/externals/src/index.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared third-party passthrough module.
+ *
+ * Everything here is re-exported verbatim from an external library. Nothing in
+ * this package may contain Premium Analytics logic — see README.md for why.
+ */
+
+/**
+ * External dependencies
+ */
+import '@automattic/charts/style.css';
+
+/**
+ * Charts
+ */
+export {
+	BarChart,
+	ConversionFunnelChart,
+	GeoChart,
+	GlobalChartsProvider,
+	HeatmapChart,
+	HeatmapChartUnresponsive,
+	LeaderboardChartUnresponsive,
+	Legend,
+	LineChart,
+	PieChartUnresponsive,
+	PieSemiCircleChart,
+	buildCalendarHeatmapData,
+	lightenHexColor,
+	normalizeColorToHex,
+	useGlobalChartsContext,
+	type BaseLegendItem,
+	type ChartTheme,
+	type DataPointDate,
+	type DataPointPercentage,
+	type GeoChartError,
+	type GeoData,
+	type GoogleDataTableColumn,
+	type GoogleDataTableRow,
+	type LineStyles,
+	type SeriesData,
+} from '@automattic/charts';
+
+export { LineShape, RectShape } from '@automattic/charts/visx/legend';
+
+/**
+ * WordPress design system
+ */
+export {
+	Button,
+	EmptyState,
+	Icon,
+	Link,
+	SelectControl,
+	Stack,
+	Tabs,
+	Text,
+	VisuallyHidden,
+} from '@wordpress/ui';
+
+/**
+ * DataViews
+ */
+export {
+	DataViews,
+	filterSortAndPaginate,
+	type Action,
+	type DataFormControlProps,
+	type Field,
+	type SupportedLayouts,
+	type View,
+} from '@wordpress/dataviews';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/package.json
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/package.json
@@ -11,10 +11,10 @@
 		"*.scss"
 	],
 	"dependencies": {
-		"@automattic/charts": "workspace:*",
 		"@automattic/jetpack-script-data": "workspace:*",
 		"@jetpack-premium-analytics/data": "workspace:*",
 		"@jetpack-premium-analytics/datetime": "workspace:*",
+		"@jetpack-premium-analytics/externals": "workspace:*",
 		"@jetpack-premium-analytics/formatters": "workspace:*",
 		"@jetpack-premium-analytics/icons": "workspace:*",
 		"@jetpack-premium-analytics/routing": "workspace:*",
@@ -24,12 +24,10 @@
 		"@wordpress/components": "37.0.0",
 		"@wordpress/compose": "8.4.0",
 		"@wordpress/data": "10.51.0",
-		"@wordpress/dataviews": "17.1.0",
 		"@wordpress/i18n": "^6.9.0",
 		"@wordpress/icons": "^15.0.0",
 		"@wordpress/route": "0.17.0",
 		"@wordpress/theme": "0.17.0",
-		"@wordpress/ui": "0.17.0",
 		"clsx": "2.1.1",
 		"date-fns": "4.1.0",
 		"react": "18.3.1"
@@ -37,6 +35,7 @@
 	"devDependencies": {
 		"@storybook/react": "10.4.6",
 		"@testing-library/react": "16.3.2",
+		"@wordpress/dataviews": "17.1.0",
 		"@wordpress/date": "5.51.0"
 	}
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-bar/bar-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-bar/bar-chart.tsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import { BarChart as BarChartBase } from '@automattic/charts';
-import { Icon } from '@wordpress/ui';
+import { BarChart as BarChartBase, Icon } from '@jetpack-premium-analytics/externals';
 import clsx from 'clsx';
 import { useCallback, useMemo, useId } from 'react';
 /**

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-bar/stories/bar-chart.stories.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-bar/stories/bar-chart.stories.tsx
@@ -1,6 +1,6 @@
 import { withChartTheme } from '../../../stories/with-chart-theme';
 import { BarChart, type BarChartStyle } from '../bar-chart';
-import type { SeriesData } from '@automattic/charts';
+import type { SeriesData } from '@jetpack-premium-analytics/externals';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta< typeof BarChart > = {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-line/comparative-line-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-line/comparative-line-chart.tsx
@@ -1,14 +1,13 @@
 /**
  * External dependencies
  */
-import { LineChart } from '@automattic/charts';
+import { LineChart, Stack } from '@jetpack-premium-analytics/externals';
 import {
 	formatDate,
 	formatMetricValue,
 	type DateFormatName,
 } from '@jetpack-premium-analytics/formatters';
 import { useResizeObserver } from '@wordpress/compose';
-import { Stack } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useCallback, useMemo, useState } from 'react';
 import { type ComponentProps } from 'react';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-line/types.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-comparative-line/types.ts
@@ -1,7 +1,11 @@
 /**
  * External dependencies
  */
-import { type SeriesData, type DataPointDate, type LineStyles } from '@automattic/charts';
+import {
+	type SeriesData,
+	type DataPointDate,
+	type LineStyles,
+} from '@jetpack-premium-analytics/externals';
 
 /**
  * Types

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-donut/donut-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-donut/donut-chart.tsx
@@ -1,8 +1,11 @@
 /**
  * External dependencies
  */
-import { PieChartUnresponsive as PieChart } from '@automattic/charts';
-import { Icon, Stack } from '@wordpress/ui';
+import {
+	PieChartUnresponsive as PieChart,
+	Icon,
+	Stack,
+} from '@jetpack-premium-analytics/externals';
 import { useMemo } from 'react';
 /**
  * Internal dependencies

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-empty-state/chart-empty-state.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-empty-state/chart-empty-state.tsx
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
+import { EmptyState, Icon } from '@jetpack-premium-analytics/externals';
 import { __ } from '@wordpress/i18n';
 import { cautionFilled } from '@wordpress/icons';
-import { EmptyState, Icon } from '@wordpress/ui';
 /**
  * Internal dependencies
  */

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-chart.tsx
@@ -7,9 +7,10 @@ import {
 	Legend,
 	lightenHexColor,
 	normalizeColorToHex,
-} from '@automattic/charts';
+	Icon,
+	Stack,
+} from '@jetpack-premium-analytics/externals';
 import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
-import { Icon, Stack } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useMemo } from 'react';
 /**

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-label.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-label.tsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
+import { Stack } from '@jetpack-premium-analytics/externals';
 import { __, sprintf } from '@wordpress/i18n';
-import { Stack } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useState } from 'react';
 /**

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-row.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-leaderboard/leaderboard-row.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Link } from '@wordpress/ui';
+import { Link } from '@jetpack-premium-analytics/externals';
 /**
  * Internal dependencies
  */

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-semi-circle/semi-circle-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-semi-circle/semi-circle-chart.tsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import { PieSemiCircleChart } from '@automattic/charts';
-import { Icon, Stack } from '@wordpress/ui';
+import { PieSemiCircleChart, Icon, Stack } from '@jetpack-premium-analytics/externals';
 import { useMemo } from 'react';
 import { RESIZE_DEBOUNCE_MS } from '../../constants';
 import {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-tooltip/chart-tooltip.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-tooltip/chart-tooltip.tsx
@@ -1,8 +1,7 @@
 /**
  * External dependencies
  */
-import { LineShape, RectShape } from '@automattic/charts/visx/legend';
-import { Stack } from '@wordpress/ui';
+import { LineShape, RectShape, Stack } from '@jetpack-premium-analytics/externals';
 /**
  * Internal dependencies
  */

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-tooltip/pie-chart-tooltip.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-tooltip/pie-chart-tooltip.tsx
@@ -1,12 +1,10 @@
 /**
  * External dependencies
  */
-import { RectShape } from '@automattic/charts/visx/legend';
-import { Stack } from '@wordpress/ui';
+import { RectShape, Stack, type DataPointPercentage } from '@jetpack-premium-analytics/externals';
 import styles from './chart-tooltip.module.scss';
 import { TooltipRow } from './tooltip-row';
 import type { DataFormat } from '../../types';
-import type { DataPointPercentage } from '@automattic/charts';
 
 /**
  * Internal dependencies

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-tooltip/tooltip-row.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/chart-tooltip/tooltip-row.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Stack } from '@wordpress/ui';
+import { Stack } from '@jetpack-premium-analytics/externals';
 /**
  * Internal dependencies
  */

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/download-csv/__tests__/csv-download-button.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/download-csv/__tests__/csv-download-button.test.tsx
@@ -12,9 +12,24 @@ const mockDispatch = jest.fn( () => ( {
 	createErrorNotice: mockCreateErrorNotice,
 } ) );
 
-jest.mock( '@wordpress/data', () => ( {
-	useRegistry: () => ( { dispatch: mockDispatch } ),
-} ) );
+// Override `useRegistry` only, falling through to the real module for everything else:
+// the component's import graph now reaches other consumers of `@wordpress/data`
+// (rich-text's store calls `combineReducers` at import time), which a `useRegistry`-only
+// mock breaks. The fall-through has to resolve lazily — calling `requireActual` in the
+// factory body re-enters `@wordpress/data` while it is still initialising.
+jest.mock(
+	'@wordpress/data',
+	() =>
+		new Proxy(
+			{ useRegistry: () => ( { dispatch: mockDispatch } ) },
+			{
+				get: ( overrides, prop ) =>
+					prop in overrides
+						? overrides[ prop as keyof typeof overrides ]
+						: jest.requireActual( '@wordpress/data' )[ prop ],
+			}
+		)
+);
 
 describe( 'CsvDownloadButton', () => {
 	beforeEach( () => {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/download-csv/csv-download-button.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/download-csv/csv-download-button.tsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
+import { Button } from '@jetpack-premium-analytics/externals';
 import { useRegistry } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { download } from '@wordpress/icons';
-import { Button } from '@wordpress/ui';
 import clsx from 'clsx';
 import { useState, type ComponentProps } from 'react';
 /**

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/legend/legend-with-theme.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/legend/legend-with-theme.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { type BaseLegendItem, useGlobalChartsContext } from '@automattic/charts';
+import { type BaseLegendItem, useGlobalChartsContext } from '@jetpack-premium-analytics/externals';
 /**
  * Internal dependencies
  */

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/legend/row/legend-row.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/legend/row/legend-row.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Stack } from '@wordpress/ui';
+import { Stack } from '@jetpack-premium-analytics/externals';
 import styles from '../legend.module.scss';
 import type { ReactNode } from 'react';
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-delta/metric-delta.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-delta/metric-delta.tsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
+import { Stack } from '@jetpack-premium-analytics/externals';
 import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
-import { Stack } from '@wordpress/ui';
 import clsx from 'clsx';
 /**
  * Internal dependencies

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
+import { SelectControl, Tabs, Text } from '@jetpack-premium-analytics/externals';
 import { formatDateRange } from '@jetpack-premium-analytics/formatters';
 import { useResizeObserver } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
-import { SelectControl, Tabs, Text } from '@wordpress/ui';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 /**
  * Internal dependencies

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Icon, Text, VisuallyHidden } from '@wordpress/ui';
+import { Icon, Text, VisuallyHidden } from '@jetpack-premium-analytics/externals';
 import clsx from 'clsx';
 /**
  * Internal dependencies

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-with-comparison/metric-with-comparison.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-with-comparison/metric-with-comparison.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Stack } from '@wordpress/ui';
+import { Stack } from '@jetpack-premium-analytics/externals';
 import { ComponentProps } from 'react';
 /**
  * Internal dependencies

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/post-title-link/post-title-link.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/post-title-link/post-title-link.tsx
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
+import { Link as UiLink } from '@jetpack-premium-analytics/externals';
 import { safeHttpUrl } from '@jetpack-premium-analytics/ui';
 import { Link } from '@wordpress/route';
-import { Link as UiLink } from '@wordpress/ui';
 
 /**
  * Route search param carrying a row's public URL to the post detail page.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-metric/report-metric.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-metric/report-metric.tsx
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-import { useGlobalChartsContext } from '@automattic/charts';
+import { useGlobalChartsContext, Icon } from '@jetpack-premium-analytics/externals';
 import { __ } from '@wordpress/i18n';
 import { chartBar } from '@wordpress/icons';
-import { Icon } from '@wordpress/ui';
 import { useMemo } from 'react';
 /**
  * Internal dependencies

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-error-state.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-error-state.tsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
+import { Button, EmptyState } from '@jetpack-premium-analytics/externals';
 import { __ } from '@wordpress/i18n';
-import { Button, EmptyState } from '@wordpress/ui';
 /**
  * Internal dependencies
  */

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-page-layout.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-page-layout.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Text } from '@wordpress/ui';
+import { Text } from '@jetpack-premium-analytics/externals';
 import clsx from 'clsx';
 /**
  * Internal dependencies

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-performance-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-performance-chart.tsx
@@ -1,10 +1,10 @@
 /**
  * External dependencies
  */
+import { Text } from '@jetpack-premium-analytics/externals';
 import { Button, DropdownMenu, MenuGroup, MenuItem, SelectControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { check, moreVertical } from '@wordpress/icons';
-import { Text } from '@wordpress/ui';
 import { useMemo, useState } from 'react';
 /**
  * Internal dependencies
@@ -24,7 +24,6 @@ import type { ReactNode } from 'react';
 // Charts base styles. Widgets get these through WidgetRoot; report pages
 // render charts without a WidgetRoot, so load them here. Without them the
 // chart's layout constraints are missing and the svg grows without bound.
-import '@automattic/charts/style.css';
 
 const DEFAULT_DATA_FORMAT: DataFormat = {
 	type: 'number',

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-records-table.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-records-table.tsx
@@ -1,14 +1,20 @@
 /**
  * External dependencies
  */
-import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import {
+	DataViews,
+	filterSortAndPaginate,
+	type Action,
+	type Field,
+	type SupportedLayouts,
+	type View,
+} from '@jetpack-premium-analytics/externals';
 import { useMemo, useState } from 'react';
 /**
  * Internal dependencies
  */
 import { ReportPageSection } from './report-page-layout';
 import styles from './report-records-table.module.scss';
-import type { Action, Field, SupportedLayouts, View } from '@wordpress/dataviews';
 import type { ComponentProps, ReactElement, ReactNode } from 'react';
 
 const DEFAULT_PER_PAGE_SIZES = [ 10, 25, 50, 100 ];

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/stories/report-page.stories.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/stories/report-page.stories.tsx
@@ -1,11 +1,10 @@
 /**
  * External dependencies
  */
-import { GlobalChartsProvider } from '@automattic/charts';
+import { GlobalChartsProvider, Text, type Field } from '@jetpack-premium-analytics/externals';
 import '@wordpress/dataviews/build-style/style.css';
 import { Button } from '@wordpress/components';
 import { Icon, external } from '@wordpress/icons';
-import { Text } from '@wordpress/ui';
 import { useState } from 'react';
 /**
  * Internal dependencies
@@ -17,7 +16,6 @@ import { ReportRecordsTable } from '../report-records-table';
 import styles from './report-page.stories.module.scss';
 import type { IntervalType, StatsTimeSeriesReport } from '@jetpack-premium-analytics/data';
 import type { Decorator, Meta, StoryObj } from '@storybook/react';
-import type { Field } from '@wordpress/dataviews';
 import type { ComponentProps, ReactNode } from 'react';
 
 /**

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/subscriber-list/subscriber-list.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/subscriber-list/subscriber-list.tsx
@@ -1,9 +1,9 @@
 /**
  * External dependencies
  */
+import { Link, Stack, Text } from '@jetpack-premium-analytics/externals';
 import { safeHttpUrl } from '@jetpack-premium-analytics/ui';
 import { _n, sprintf } from '@wordpress/i18n';
-import { Link, Stack, Text } from '@wordpress/ui';
 /**
  * Internal dependencies
  */

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-back-link/widget-back-link.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-back-link/widget-back-link.tsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
+import { Button, Icon } from '@jetpack-premium-analytics/externals';
 import { chevronLeft } from '@wordpress/icons';
-import { Button, Icon } from '@wordpress/ui';
 import clsx from 'clsx';
 /**
  * Internal dependencies

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-data-table/widget-data-table.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-data-table/widget-data-table.tsx
@@ -1,14 +1,19 @@
 /**
  * External dependencies
  */
-import { DataViews, filterSortAndPaginate } from '@wordpress/dataviews';
+import {
+	DataViews,
+	filterSortAndPaginate,
+	type Field,
+	type SupportedLayouts,
+	type View,
+} from '@jetpack-premium-analytics/externals';
 import { useMemo, useState } from 'react';
 /**
  * Internal dependencies
  */
 import './style.scss';
 import styles from './style.module.scss';
-import type { Field, SupportedLayouts, View } from '@wordpress/dataviews';
 import type { ReactNode } from 'react';
 
 const DEFAULT_PER_PAGE_SIZES = [ 10, 25, 50, 100 ];

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-loading-overlay/widget-loading-overlay.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-loading-overlay/widget-loading-overlay.tsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
+import { Stack } from '@jetpack-premium-analytics/externals';
 import { Spinner } from '@wordpress/components';
-import { Stack } from '@wordpress/ui';
 /**
  * Internal dependencies
  */

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-root/widget-root.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-root/widget-root.tsx
@@ -1,16 +1,15 @@
 /**
  * External dependencies
  */
-import { GlobalChartsProvider } from '@automattic/charts';
 import {
 	AnalyticsQueryClientProvider,
 	getDefaultPreset,
 	normalizeReportParams,
 } from '@jetpack-premium-analytics/data';
+import { GlobalChartsProvider } from '@jetpack-premium-analytics/externals';
 import { useSearch } from '@wordpress/route';
 import { useMemo, type ReactNode } from 'react';
 import { getStoreInfo } from '../../helpers/store-info';
-import '@automattic/charts/style.css';
 /**
  * Internal dependencies
  */

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/widget-state.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-state/widget-state.tsx
@@ -1,8 +1,8 @@
 /**
  * External dependencies
  */
+import { Button, Icon, Stack } from '@jetpack-premium-analytics/externals';
 import { __ } from '@wordpress/i18n';
-import { Button, Icon, Stack } from '@wordpress/ui';
 /**
  * Internal dependencies
  */

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/wordads-earnings-history/fields.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/wordads-earnings-history/fields.tsx
@@ -8,7 +8,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies
  */
 import type { StatsWordAdsEarningsBreakdown } from '@jetpack-premium-analytics/data';
-import type { Field, View } from '@wordpress/dataviews';
+import type { Field, View } from '@jetpack-premium-analytics/externals';
 
 /** A single WordAds earnings-history row (one period). */
 export type EarningsHistoryRow = {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/fields/date-report-params-field/date-report-params-field.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/fields/date-report-params-field/date-report-params-field.tsx
@@ -12,13 +12,12 @@ import {
 	isPrimaryPreset,
 	type DateRange,
 } from '@jetpack-premium-analytics/datetime';
+import { Stack, type DataFormControlProps } from '@jetpack-premium-analytics/externals';
 import { deriveComparisonRange, encodeDateToSearchParam } from '@jetpack-premium-analytics/routing';
 import { DateFiltersPanel } from '@jetpack-premium-analytics/ui';
-import { Stack } from '@wordpress/ui';
 import { endOfDay } from 'date-fns';
 import { useCallback, useMemo, useState, useEffect } from 'react';
 import { getStoreInfo } from '../../helpers/store-info';
-import type { DataFormControlProps } from '@wordpress/dataviews';
 
 /**
  * Inferred types

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/build-revenue-by-customer-type-data.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/build-revenue-by-customer-type-data.ts
@@ -3,8 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { formatLegendLabels } from './format-legend-labels';
-import type { SeriesData } from '@automattic/charts';
 import type { ReportDataMap, ReportParams } from '@jetpack-premium-analytics/data';
+import type { SeriesData } from '@jetpack-premium-analytics/externals';
 
 /**
  * Internal dependencies

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/build-sales-by-coupon-data.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/build-sales-by-coupon-data.ts
@@ -3,8 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { formatLegendLabels } from './format-legend-labels';
-import type { SeriesData } from '@automattic/charts';
 import type { ReportDataMap, ReportParams } from '@jetpack-premium-analytics/data';
+import type { SeriesData } from '@jetpack-premium-analytics/externals';
 
 /**
  * Internal dependencies

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/build-sales-by-device-data.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/build-sales-by-device-data.ts
@@ -3,8 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { formatLegendLabels } from './format-legend-labels';
-import type { SeriesData } from '@automattic/charts';
 import type { ReportDataMap, ReportParams } from '@jetpack-premium-analytics/data';
+import type { SeriesData } from '@jetpack-premium-analytics/externals';
 
 /**
  * Internal dependencies

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/build-total-returns-data.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/build-total-returns-data.ts
@@ -3,8 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { formatLegendLabels } from './format-legend-labels';
-import type { SeriesData } from '@automattic/charts';
 import type { ReportDataMap, ReportParams } from '@jetpack-premium-analytics/data';
+import type { SeriesData } from '@jetpack-premium-analytics/externals';
 
 /**
  * Internal dependencies

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/build-visitors-by-location-data.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/build-visitors-by-location-data.ts
@@ -9,7 +9,7 @@ import { calculateDelta } from './calculate-delta';
 import { getCombinedPeriodMax } from './get-combined-period-max';
 import { sharePercentage } from './share-percentage';
 import type { LeaderboardChartData } from '../components/chart-leaderboard/leaderboard-chart';
-import type { GeoData } from '@automattic/charts';
+import type { GeoData } from '@jetpack-premium-analytics/externals';
 
 export type Region = 'US' | 'world';
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/chart-empty-state.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/helpers/chart-empty-state.ts
@@ -6,7 +6,7 @@
 /**
  * External dependencies
  */
-import type { DataPointPercentage } from '@automattic/charts';
+import type { DataPointPercentage } from '@jetpack-premium-analytics/externals';
 
 /**
  * Series data shape for bar and line charts (nested array format).

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/use-chart-theme.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/use-chart-theme.ts
@@ -4,7 +4,7 @@
 import { useMemo } from 'react';
 import { WOO_COLORS } from '../constants';
 import { useColorPreference } from './use-color-preference';
-import type { ChartTheme } from '@automattic/charts';
+import type { ChartTheme } from '@jetpack-premium-analytics/externals';
 
 /**
  * Internal dependencies

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/use-series-styles.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/use-series-styles.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useGlobalChartsContext } from '@automattic/charts';
+import { useGlobalChartsContext } from '@jetpack-premium-analytics/externals';
 import { useMemo } from 'react';
 /**
  * Internal dependencies

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -201,7 +201,9 @@ export type { MetricKey, OrderMetricKey, OrderMetrics, OrdersSummary, DataFormat
  *
  * Widgets must import chart components from here, never from
  * `@automattic/charts` directly: the toolkit is a shared script module, so
- * charts is bundled once instead of once per widget.
+ * charts is bundled once instead of once per widget. The toolkit itself takes
+ * charts from `@jetpack-premium-analytics/externals`, which is where the
+ * library is actually compiled in.
  */
 export {
 	GeoChart,
@@ -214,7 +216,7 @@ export {
 	type GeoData,
 	type GoogleDataTableColumn,
 	type GoogleDataTableRow,
-} from '@automattic/charts';
+} from '@jetpack-premium-analytics/externals';
 
 /**
  * UI passthrough

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/with-chart-theme.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/stories/with-chart-theme.tsx
@@ -1,4 +1,4 @@
-import { GlobalChartsProvider } from '@automattic/charts';
+import { GlobalChartsProvider } from '@jetpack-premium-analytics/externals';
 import { useChartTheme } from '../hooks';
 import type { Decorator } from '@storybook/react';
 import type { ReactNode } from 'react';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/bookings-by-attendance/bookings-by-attendance-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/bookings-by-attendance/bookings-by-attendance-widget.tsx
@@ -2,9 +2,9 @@
  * External dependencies
  */
 import { useReportBookings } from '@jetpack-premium-analytics/data';
+import { Stack } from '@jetpack-premium-analytics/externals';
 import { calendar } from '@jetpack-premium-analytics/icons';
 import { __ } from '@wordpress/i18n';
-import { Stack } from '@wordpress/ui';
 import { useMemo } from 'react';
 import { DonutChart, WidgetState } from '../../components';
 /**

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/common/use-bar-styles.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/common/use-bar-styles.ts
@@ -1,10 +1,9 @@
 /**
  * External dependencies
  */
-import { useGlobalChartsContext } from '@automattic/charts';
+import { useGlobalChartsContext, type SeriesData } from '@jetpack-premium-analytics/externals';
 import { useMemo } from 'react';
 import type { BarChartStyle } from '../../components';
-import type { SeriesData } from '@automattic/charts';
 
 /**
  * Internal dependencies

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/common/use-segment-styles.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/common/use-segment-styles.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { useGlobalChartsContext } from '@automattic/charts';
+import { useGlobalChartsContext } from '@jetpack-premium-analytics/externals';
 import { useMemo } from 'react';
 /**
  * Internal dependencies

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/conversion-rate/conversion-rate-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/conversion-rate/conversion-rate-widget.tsx
@@ -1,11 +1,10 @@
 /**
  * External dependencies
  */
-import { ConversionFunnelChart } from '@automattic/charts';
 import { FilterCondition, useReportConversionRate } from '@jetpack-premium-analytics/data';
+import { ConversionFunnelChart, Icon, Stack } from '@jetpack-premium-analytics/externals';
 import { goal } from '@jetpack-premium-analytics/icons';
 import { __ } from '@wordpress/i18n';
-import { Icon, Stack } from '@wordpress/ui';
 import { useMemo } from 'react';
 /**
  * Internal dependencies

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/coupon-use/coupon-use-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/coupon-use/coupon-use-widget.tsx
@@ -2,9 +2,9 @@
  * External dependencies
  */
 import { useReportCouponsByDate } from '@jetpack-premium-analytics/data';
+import { Stack } from '@jetpack-premium-analytics/externals';
 import { coupon } from '@jetpack-premium-analytics/icons';
 import { __ } from '@wordpress/i18n';
-import { Stack } from '@wordpress/ui';
 import { useMemo } from 'react';
 import { DonutChart, WidgetState } from '../../components';
 /**

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/metric-comparison/metric-comparison-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/metric-comparison/metric-comparison-widget.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Stack } from '@wordpress/ui';
+import { Stack } from '@jetpack-premium-analytics/externals';
 /**
  * Internal dependencies
  */

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/new-vs-returning-customer/new-vs-returning-customer-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/new-vs-returning-customer/new-vs-returning-customer-widget.tsx
@@ -2,9 +2,9 @@
  * External dependencies
  */
 import { useReportCustomersByDate } from '@jetpack-premium-analytics/data';
+import { Stack } from '@jetpack-premium-analytics/externals';
 import { customer } from '@jetpack-premium-analytics/icons';
 import { __ } from '@wordpress/i18n';
-import { Stack } from '@wordpress/ui';
 import { useMemo } from 'react';
 import { DonutChart, WidgetState } from '../../components';
 /**

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/orders-fulfillment/orders-fulfillment-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/orders-fulfillment/orders-fulfillment-widget.tsx
@@ -2,9 +2,9 @@
  * External dependencies
  */
 import { useReportOrders } from '@jetpack-premium-analytics/data';
+import { Stack } from '@jetpack-premium-analytics/externals';
 import { reports } from '@jetpack-premium-analytics/icons';
 import { __ } from '@wordpress/i18n';
-import { Stack } from '@wordpress/ui';
 import { useMemo, useCallback } from 'react';
 import { DonutChart, WidgetState } from '../../components';
 /**

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/product-leaderboard/top-performing-product-leaderboard-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/product-leaderboard/top-performing-product-leaderboard-widget.tsx
@@ -6,9 +6,9 @@ import {
 	useProductImages,
 	type FilterCondition,
 } from '@jetpack-premium-analytics/data';
+import { Icon } from '@jetpack-premium-analytics/externals';
 import { productBlouse } from '@jetpack-premium-analytics/icons';
 import { __ } from '@wordpress/i18n';
-import { Icon } from '@wordpress/ui';
 import { useMemo } from 'react';
 import { buildLeaderboardRow, LeaderboardChart } from '../../components/chart-leaderboard';
 import { useWidgetRootContext } from '../../components/widget-root';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sessions-by-device/sessions-by-device-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/sessions-by-device/sessions-by-device-widget.tsx
@@ -2,9 +2,9 @@
  * External dependencies
  */
 import { useReportSessionsByDevice } from '@jetpack-premium-analytics/data';
+import { Stack } from '@jetpack-premium-analytics/externals';
 import { device } from '@jetpack-premium-analytics/icons';
 import { __ } from '@wordpress/i18n';
-import { Stack } from '@wordpress/ui';
 import { useMemo } from 'react';
 import { SemiCircleChart, WidgetState } from '../../components';
 /**

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/visitors-by-location/visitors-by-location-widget.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/widgets/visitors-by-location/visitors-by-location-widget.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { GeoChart } from '@automattic/charts';
+import { GeoChart } from '@jetpack-premium-analytics/externals';
 import { location } from '@jetpack-premium-analytics/icons';
 import {
 	__experimentalToggleGroupControl as ToggleGroupControl,


### PR DESCRIPTION
Fixes WOOA7S-1836

## Proposed changes

Premium Analytics is vendored into both `plugins/jetpack` and `jetpack-mu-wpcom`, so each built script module ships twice. Minified bundles are single-line, so a one-character source change rewrites the whole file and the sun/moon deploy counts the entire artifact as a diff. `widgets-toolkit` carried ~950 KB of npm code, so an unrelated helper tweak produced megabytes of churn and tripped the wpcom PR size limit.

wp-build already externalises imports *between* the package's script modules, but anything imported from npm is compiled *into* the importing module — and the same libraries were being compiled into both `ui` and `widgets-toolkit`.

* Add `@jetpack-premium-analytics/externals`, a re-export-only script module that owns `@automattic/charts`, `@wordpress/ui`, and `@wordpress/dataviews`.
* Route `widgets-toolkit`'s imports through it. No wp-build config change is needed — the new package is discovered from its `wpScriptModuleExports` field like every other module, and shows up in the generated `modules/registry.php` automatically.
* The toolkit's public API is unchanged, so no widget or route needed editing.

### Size impact on `widgets-toolkit` (production build)

| file | trunk | this PR | change |
| --- | ---: | ---: | ---: |
| `index.min.js` | 1,467,917 B | 412,225 B | **−71.9%** |
| `index.min.js.map` | 6,745,546 B | 1,133,889 B | **−83.2%** |
| combined | 7.83 MB | 1.48 MB | **−81.2%** |

Measured by attributing minified bytes through the source map: 67% of the old `widgets-toolkit` bundle was npm vendor code and only ~21% was first-party source. After the split it is 74% first-party.

The extracted code moves into `modules/externals` (1,073,311 B + 5,803,060 B map), which only changes when those libraries are upgraded — not when someone edits a widget helper.

**Trade-off:** total build output grows ~210 KB (+0.9%) from the extra module boundary. Widget and route bundles are byte-identical to trunk (4,802,777 B in both builds), as are the `ui`, `data`, `fields`, `init`, and `site-sync` modules — the entire delta is inside `build/modules`.

### Follow-ups (not in this PR)

* `packages/ui` still imports the same libraries directly, so its 748 KB module contains a duplicate ~500 KB of `@base-ui/react`, `dataviews`, and `@wordpress/ui`. Routing it through `externals` too would dedupe that.
* `.min.js.map` accounts for 6.43 MB of the original 7.83 MB. Dropping maps from the production build would be a bigger single lever than any split, and composes with this change.

## Related product discussion/links

* WOOA7S-1836

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This is a build-output change with no intended behaviour change; the goal is to confirm the dashboard still renders identically.

* Check out this branch and run `jetpack build --deps packages/premium-analytics`, then `jetpack build plugins/premium-analytics` (the second step generates the plugin's `vendor/` + `jetpack_vendor/`).
* Confirm `projects/packages/premium-analytics/build/modules/` now contains an `externals/` directory, and that `build/modules/registry.php` lists `@jetpack-premium-analytics/externals`.
* Confirm `build/modules/widgets-toolkit/index.min.asset.php` lists `@jetpack-premium-analytics/externals` under `module_dependencies` — that is what proves the libraries are externalised rather than inlined.
* Load the Premium Analytics dashboard (`wp-admin/admin.php?page=jetpack-premium-analytics-wp-admin`) and confirm:
  * widgets render (charts, leaderboards, donut/bar/line charts, the geo chart, and the posting-activity heatmap in particular, since those come from `@automattic/charts`);
  * report pages render, including the DataViews-backed tables (`WidgetDataTable` / `ReportRecordsTable`);
  * no new console errors, in particular no "failed to resolve module specifier" or missing-export errors from the new module.
* Toggle `SCRIPT_DEBUG` on and reload, to exercise the unminified module path as well.
