### PR TITLE
Premium Analytics: Preserve complete VideoPress CSV metrics

### DIFF
--- a/projects/packages/premium-analytics/changelog/audit-report-csv-parity
+++ b/projects/packages/premium-analytics/changelog/audit-report-csv-parity
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+CSV exports: Preserve complete VideoPress metrics.

--- a/projects/packages/premium-analytics/routes/reports/videos/page.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/videos/page.test.tsx
@@ -144,9 +144,12 @@ describe( 'VideosReportPage', () => {
 
 		const { columns } = reportCsvActionMock.mock.calls[ 0 ][ 0 ];
 		expect( columns.map( column => column.getValue( rows[ 0 ] ) ) ).toEqual( [
+			441,
 			'Demo',
 			13,
 			22,
+			0.04,
+			64.5,
 			'https://example.com/video/441',
 		] );
 		expect( reportCsvActionMock.mock.calls[ 0 ][ 0 ] ).toEqual(

--- a/projects/packages/premium-analytics/routes/reports/videos/page.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/videos/page.test.tsx
@@ -143,6 +143,15 @@ describe( 'VideosReportPage', () => {
 		);
 
 		const { columns } = reportCsvActionMock.mock.calls[ 0 ][ 0 ];
+		expect( columns.map( column => column.label ) ).toEqual( [
+			'Video ID',
+			'Video',
+			'Plays',
+			'Impressions',
+			'Watch time (hours)',
+			'Retention rate (%)',
+			'URL',
+		] );
 		expect( columns.map( column => column.getValue( rows[ 0 ] ) ) ).toEqual( [
 			441,
 			'Demo',

--- a/projects/packages/premium-analytics/routes/reports/videos/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/videos/page.tsx
@@ -101,11 +101,11 @@ function VideosReport(): JSX.Element {
 				getValue: row => row.impressions,
 			},
 			{
-				label: __( 'Watch time', 'jetpack-premium-analytics-pkg' ),
+				label: __( 'Watch time (hours)', 'jetpack-premium-analytics-pkg' ),
 				getValue: row => row.watch_time,
 			},
 			{
-				label: __( 'Retention rate', 'jetpack-premium-analytics-pkg' ),
+				label: __( 'Retention rate (%)', 'jetpack-premium-analytics-pkg' ),
 				getValue: row => row.retention_rate,
 			},
 			{ label: __( 'URL', 'jetpack-premium-analytics-pkg' ), getValue: row => row.link ?? '' },

--- a/projects/packages/premium-analytics/routes/reports/videos/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/videos/page.tsx
@@ -85,6 +85,10 @@ function VideosReport(): JSX.Element {
 	const csvColumns = useMemo< CsvColumn< StatsVideoPlaysItem >[] >(
 		() => [
 			{
+				label: __( 'Video ID', 'jetpack-premium-analytics-pkg' ),
+				getValue: row => row.id ?? '',
+			},
+			{
 				label: __( 'Video', 'jetpack-premium-analytics-pkg' ),
 				getValue: row =>
 					typeof row.label === 'string' && row.label
@@ -95,6 +99,14 @@ function VideosReport(): JSX.Element {
 			{
 				label: __( 'Impressions', 'jetpack-premium-analytics-pkg' ),
 				getValue: row => row.impressions,
+			},
+			{
+				label: __( 'Watch time', 'jetpack-premium-analytics-pkg' ),
+				getValue: row => row.watch_time,
+			},
+			{
+				label: __( 'Retention rate', 'jetpack-premium-analytics-pkg' ),
+				getValue: row => row.retention_rate,
 			},
 			{ label: __( 'URL', 'jetpack-premium-analytics-pkg' ), getValue: row => row.link ?? '' },
 		],


### PR DESCRIPTION
Second part of and closes WOOA7S-1838.

## Proposed changes

* Preserve the complete VideoPress metrics already returned by the Videos report in CSV exports: video ID, plays, impressions, watch time, retention rate, and URL.
* Add regression coverage for the exported Videos row schema.
* Record the user-facing fix in the Premium Analytics changelog.

The wider ddevtest and source audit found no other confirmed unintended mismatches beyond the UTM work in #50914. Premium Analytics headers, clearer filenames, helpful URL/group/type metadata, comparison columns, and exports without a Jetpack Stats counterpart are intentional differences.

## Related product discussion/links

* WOOA7S-1838
* #50914

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Use a site with Premium Analytics and VideoPress plays in the selected date range.
* Open the **Videos** report and download its CSV.
* Verify the file contains **Video ID**, **Video**, **Plays**, **Impressions**, **Watch time**, **Retention rate**, and **URL**.
* Verify the exported values match the corresponding Videos rows and current Jetpack Stats data.
