### PR TITLE
Premium Analytics: guard the two package entry points against a duplicate copy on disk

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-premium-analytics-function-redeclare
+++ b/projects/packages/premium-analytics/changelog/fix-premium-analytics-function-redeclare
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Guard the dashboard component includes so a second copy of the package on disk cannot fatal on redeclared functions.

--- a/projects/packages/premium-analytics/src/class-analytics.php
+++ b/projects/packages/premium-analytics/src/class-analytics.php
@@ -174,17 +174,39 @@ class Analytics {
 	 * @return void
 	 */
 	private static function load_dashboard_components() {
+		/*
+		 * Every include below is guarded on a symbol the target file declares.
+		 *
+		 * Two copies of this package can be loaded in one request — WPCOM Simple ships
+		 * one under jetpack-plugin and another under jetpack-mu-wpcom-plugin. The
+		 * autoloader dedupes classes by version, but these files declare functions and
+		 * constants at file scope, so they are absent from the classmap entirely and
+		 * reach us through `require_once`, which dedupes by path and not by symbol.
+		 * Once a class from one copy and a class from the other both run their
+		 * includes, PHP fatals on the redeclared functions. The guards make the second
+		 * copy's include a no-op, which also keeps the files' file-scope side effects
+		 * (add_filter() calls, registry bootstrapping) from running twice.
+		 */
+
 		// Widget modules for the client's dynamic import() map.
-		require_once __DIR__ . '/widget-modules.php';
+		if ( ! function_exists( __NAMESPACE__ . '\\register_widget_modules_rest_route' ) ) {
+			require_once __DIR__ . '/widget-modules.php';
+		}
 
 		// Default layout's first-load preference injection.
-		require_once __DIR__ . '/dashboard-layout.php';
+		if ( ! function_exists( __NAMESPACE__ . '\\register_dashboard_default_layout_route' ) ) {
+			require_once __DIR__ . '/dashboard-layout.php';
+		}
 
 		// Dashboard sections and their default layout seeding.
-		require_once __DIR__ . '/dashboard-sections.php';
+		if ( ! function_exists( __NAMESPACE__ . '\\register_dashboard_section' ) ) {
+			require_once __DIR__ . '/dashboard-sections.php';
+		}
 
 		// Default-on CSV export settings and server-side disable filter.
-		require_once __DIR__ . '/csv-exports.php';
+		if ( ! function_exists( __NAMESPACE__ . '\\configure_csv_exports' ) ) {
+			require_once __DIR__ . '/csv-exports.php';
+		}
 		configure_csv_exports();
 	}
 

--- a/projects/packages/premium-analytics/src/class-dashboard-support-routes.php
+++ b/projects/packages/premium-analytics/src/class-dashboard-support-routes.php
@@ -46,9 +46,18 @@ class Dashboard_Support_Routes {
 	 * @return void
 	 */
 	public static function boot_routes() {
-		require_once __DIR__ . '/widget-modules.php';
-		require_once __DIR__ . '/dashboard-layout.php';
-		require_once __DIR__ . '/dashboard-sections.php';
+		// Guarded on a symbol from each file: two copies of this package can be loaded
+		// in one request, and these file-scope functions are outside the autoloader's
+		// dedupe. See Analytics::load_dashboard_components() for the full rationale.
+		if ( ! function_exists( __NAMESPACE__ . '\\register_widget_modules_rest_route' ) ) {
+			require_once __DIR__ . '/widget-modules.php';
+		}
+		if ( ! function_exists( __NAMESPACE__ . '\\register_dashboard_default_layout_route' ) ) {
+			require_once __DIR__ . '/dashboard-layout.php';
+		}
+		if ( ! function_exists( __NAMESPACE__ . '\\register_dashboard_section' ) ) {
+			require_once __DIR__ . '/dashboard-sections.php';
+		}
 
 		register_widget_modules_rest_route();
 		register_dashboard_default_layout_route();


### PR DESCRIPTION
Fixes #

## Proposed changes

Hotfix for a fatal seen on WordPress.com Simple:

```
PHP Fatal error:  Cannot redeclare function Automattic\Jetpack\PremiumAnalytics\register_widget_modules_rest_route()
(previously declared in .../mu-plugins/jetpack-plugin/moon/jetpack_vendor/automattic/jetpack-premium-analytics/src/widget-modules.php:22)
in .../mu-plugins/jetpack-mu-wpcom-plugin/moon/jetpack_vendor/automattic/jetpack-premium-analytics/src/widget-modules.php on line 22
```

**Why it happens.** Two copies of this package are on disk on Simple — Jetpack requires it (`projects/plugins/jetpack/composer.json`) and so does `jetpack-mu-wpcom` (`projects/packages/jetpack-mu-wpcom/composer.json`), and both ship as mu-plugins. The package's `composer.json` declares `"classmap": ["src/"]`, so the function/constant-only files (`widget-modules.php`, `dashboard-layout.php`, `dashboard-sections.php`, `csv-exports.php`, …) produce **no classmap entries at all** and are therefore invisible to the Jetpack autoloader's version selection. They are pulled in with `require_once __DIR__ . '/…'`, which deduplicates by absolute path, not by symbol.

So the moment two classes resolve to different copies, both files get included and PHP fatals. Concretely, matching the two paths in the report:

1. `Analytics::init_wpcom_simple()` → `load_dashboard_components()` requires the **jetpack-plugin** copy's `widget-modules.php` — first declaration.
2. WPCOM's `rest-api-plugins/jetpack-endpoints/premium-analytics-dashboard.php` `require_once`s `class-dashboard-support-routes.php` from the **jetpack-mu-wpcom-plugin** copy by absolute path (the contract documented in the package's `AGENTS.md`), bypassing the autoloader. Its `boot_routes()` runs on `rest_api_init` and requires that copy's `widget-modules.php` — fatal.

An autoloader reset mid-request (mu-plugins record themselves as "activating", which changes the plugin list and triggers `reset_autoloader()`), version skew between the two moon builds, or a class present in only one copy will split the two copies the same way.

Worth noting for anyone reaching for a smaller fix: the existing `self::$initialized` check in `init_wpcom_simple()` does **not** help, and neither would a stronger flag there. Only one `Analytics` class exists per process — the autoloader picks one copy — so that guard already works and already runs `load_dashboard_components()` exactly once from one `__DIR__`. The duplicate arrives through `Dashboard_Support_Routes`, which never passes through `Analytics` at all.

**What this PR does.** There are exactly two doors into these files from outside — `Analytics::load_dashboard_components()` and `Dashboard_Support_Routes::boot_routes()` — so it guards those seven includes on a symbol the target file declares, making the second copy's include a no-op. Nested file→file requires are deliberately left alone: once execution is inside one copy's file, that file's own requires stay within the same copy. Beyond the fatal, this also prevents the files' file-scope side effects — the `add_filter()` registrations in `widget-modules.php` / `dashboard-layout.php` and `bootstrap_dashboard_sections()` — from running a second time, and it silences the `Constant … already defined` warnings the constant files would otherwise emit. Same precedent as `packages/device-detection/src/functions.php`.

This is deliberately a hotfix. The durable fix is to move these functions and constants into classes so the autoloader's version selection deduplicates them (or move the files into composer's `files` autoload, which the Jetpack autoloader's filemap dedupes by identifier — at the cost of the lazy loading `boot_routes()` was written to get). Happy to follow up with that separately.

Known gap left in place: `Analytics::load_build()` requires the generated `build/build.php`, whose sub-files declare global `jpa_*` functions. It is only reachable from the single live `Analytics` class, so it cannot split across copies today, and the generated files are not hand-editable — flagging it rather than papering over it.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Automated checks:

* `jp test php packages/premium-analytics` — 370 tests, 1022 assertions, green.
  * Note: running this with a local JS build present (`projects/packages/premium-analytics/build/`) fails on `Cannot redeclare jpa_get_registered_widget_modules()` from `build/widgets.php` vs the test fixture. That failure **reproduces on trunk** and is unrelated to this change; CI runs without a build directory.
* `jp phan packages/premium-analytics` — 0 issues.
* phpcs clean via the pre-commit hook.

Reproducing the fatal and the fix directly (no WordPress needed) — put two copies of `src/` on disk and drive the two real entry points against different copies, which is exactly the production sequence:

```php
// copy A, via reflection on the private method
Analytics::load_dashboard_components();          // from $copyA
// copy B, as WPCOM loads it
require_once $copyB . '/class-dashboard-support-routes.php';
Dashboard_Support_Routes::boot_routes();
```

* On trunk this fatals with the reported message, byte for byte, including `widget-modules.php on line 22`.
* On this branch both entry points complete and all four routes register (`wpcom/v2/widget-modules`, `.../default-layout`, `.../sections`, `.../sections/…/default-layout`).
* Verified in the reverse order too (support routes first, then `Analytics`), since the two can boot in either order depending on the request.

On a Simple site with the `jetpack-premium-analytics` sticker enabled: load the dashboard and hit the support routes, and confirm the fatal is gone from the PHP error log and the dashboard renders its widgets and sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B33bWGwdTPwoFk8WwoD2Kz
