### PR TITLE
Newsletter categories: deep-link the subscribe-block help text to the categories section

### DIFF
--- a/projects/packages/newsletter/changelog/update-newsletter-subscribe-block-deeplink
+++ b/projects/packages/newsletter/changelog/update-newsletter-subscribe-block-deeplink
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Newsletter categories: deep-link the subscribe block help text to the "Subscribe to specific categories" section.

--- a/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/newsletter-categories-section.tsx
@@ -185,11 +185,13 @@ export function NewsletterCategoriesSection( {
 	const savingText = __( 'Saving…', 'jetpack-newsletter' );
 	const saveText = __( 'Save', 'jetpack-newsletter' );
 
-	// Build subscribe block documentation URL and component
+	// Build subscribe block documentation URL and component. Deep-link to the
+	// "Subscribe to specific categories" section, since that's what this copy is
+	// about (the redirect service appends the fragment via its `anchor` param).
 	const isWpcom = isWpcomPlatformSite();
 	const subscribeBlockUrl = isWpcom
-		? 'https://wordpress.com/support/wordpress-editor/blocks/subscribe-block/'
-		: `https://jetpack.com/redirect/?source=jetpack-support-subscribe-block&site=${
+		? 'https://wordpress.com/support/wordpress-editor/blocks/subscribe-block/#subscribe-to-specific-categories'
+		: `https://jetpack.com/redirect/?source=jetpack-support-subscribe-block&anchor=subscribe-to-specific-categories&site=${
 				getSiteData()?.wpcom?.blog_id || ''
 		  }`;
 


### PR DESCRIPTION
## Proposed changes

* Deep-link the "subscribe block" link in the Newsletter categories help text to the **Subscribe to specific categories** section of the support article, instead of the whole page — that's what the surrounding copy is about.
* Follow-up to NL-785 (categories inline create), which shipped in #50878.

<img width="672" height="399" alt="Screenshot 2026-07-30 at 3 43 36 PM" src="https://github.com/user-attachments/assets/7b1218bb-8908-4ec0-ac21-e2ad6ce06225" />



## Related product discussion/links

* NL-785

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site with the Newsletter (Subscriptions) module active, go to **Jetpack → Newsletter → Settings**.
* In the categories intro copy, click the **subscribe block** link.
* Confirm it lands on the "Subscribe to specific categories" heading of the support article (not the top of the page) — on both WordPress.com (`…/subscribe-block/#subscribe-to-specific-categories`) and self-hosted (`jetpack.com/redirect/…&anchor=subscribe-to-specific-categories` → `…/subscription-form-block/#subscribe-to-specific-categories`).
