### PR TITLE
Random Redirect: restore module to the Jetpack plugin

### DIFF
--- a/projects/plugins/jetpack/changelog/add-restore-random-redirect-module
+++ b/projects/plugins/jetpack/changelog/add-restore-random-redirect-module
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Random Redirect: Restore module previously removed in Jetpack 13.6.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -122,6 +122,9 @@ class Jetpack {
 		'latex'               => array(
 			array( 'wp-latex/wp-latex.php', 'WP LaTeX' ),
 		),
+		'random-redirect'     => array(
+			array( 'random-redirect/random-redirect.php', 'Random Redirect' ),
+		),
 		'sharedaddy'          => array(
 			array( 'sharedaddy/sharedaddy.php', 'Sharedaddy' ),
 			array( 'jetpack-sharing/sharedaddy.php', 'Jetpack Sharing' ),
@@ -210,6 +213,9 @@ class Jetpack {
 			'Wordfence Security'                => 'wordfence/wordfence.php',
 			'All In One WP Security & Firewall' => 'all-in-one-wp-security-and-firewall/wp-security.php',
 			'iThemes Security'                  => 'better-wp-security/better-wp-security.php',
+		),
+		'random-redirect'    => array(
+			'Random Redirect 2' => 'random-redirect-2/random-redirect.php',
 		),
 		'related-posts'      => array(
 			'YARPP'                       => 'yet-another-related-posts-plugin/yarpp.php',

--- a/projects/plugins/jetpack/modules/module-extras.php
+++ b/projects/plugins/jetpack/modules/module-extras.php
@@ -23,6 +23,7 @@ $tools = array(
 	// Theme Tools.
 	'theme-tools.php',
 	'theme-tools/social-links.php',
+	'theme-tools/random-redirect.php',
 	'theme-tools/featured-content.php',
 	'theme-tools/responsive-videos.php',
 	'theme-tools/site-logo.php',

--- a/projects/plugins/jetpack/modules/theme-tools/random-redirect.php
+++ b/projects/plugins/jetpack/modules/theme-tools/random-redirect.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Plugin Name: Random Redirect
+ * Plugin URI: https://wordpress.org/extend/plugins/random-redirect/
+ * Description: Allows you to create a link to yourblog.example.com/?random which will redirect someone to a random post on your blog, in a StumbleUpon-like fashion.
+ * Version: 1.2-wpcom
+ * Author: Matt Mullenweg
+ * Author URI: https://ma.tt/
+ * Text Domain: jetpack
+ *
+ * @package automattic/jetpack
+ */
+
+// phpcs:disable WordPress.Security.NonceVerification -- No changes to the site here, it just redirects.
+
+/**
+ * Redirects to a random post on the site.
+ */
+function jetpack_matt_random_redirect() {
+	// Verify that the Random Redirect plugin this code is from is not active
+	// See https://plugins.trac.wordpress.org/ticket/1898
+	if ( ! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		if ( is_plugin_active( 'random-redirect/random-redirect.php' ) ) {
+			return;
+		}
+	}
+
+	// Acceptable URL formats: /[...]/?random=[post type], /?random, /&random, /&random=1
+	if ( ! isset( $_GET['random'] ) && ! ( isset( $_SERVER['REQUEST_URI'] ) && in_array( strtolower( $_SERVER['REQUEST_URI'] ), array( '/&random', '/&random=1' ), true ) ) ) {
+		return;
+	}
+
+	// Ignore POST requests.
+	if ( ! empty( $_POST ) ) {
+		return;
+	}
+
+	// Persistent AppEngine abuse.  ORDER BY RAND is expensive.
+	if ( isset( $_SERVER['HTTP_USER_AGENT'] ) && strstr( filter_var( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ), 'AppEngine-Google' ) ) {
+		wp_die( 'Please <a href="https://en.support.wordpress.com/contact/" rel="noopener noreferrer" target="_blank">contact support</a>' );
+	}
+
+	$where      = array(
+		"post_password = ''",
+		"post_status = 'publish'",
+	);
+	$where_args = array();
+
+	// Set default post type.
+	$post_type = get_post_type();
+
+	// Change the post type if the parameter is set.
+	if ( isset( $_GET['random_post_type'] ) && post_type_exists( sanitize_key( $_GET['random_post_type'] ) ) ) {
+		$post_type = sanitize_key( $_GET['random_post_type'] );
+	}
+
+	// Don't show a random page if 'page' isn't specified as the post type specifically.
+	if ( 'page' === $post_type && is_front_page() && ! isset( $_GET['random_post_type'] ) ) {
+		$post_type = 'post';
+	}
+
+	$where[]      = 'p.post_type = %s';
+	$where_args[] = $post_type;
+
+	// Set author name if we're on an author archive.
+	if ( is_author() ) {
+		$where[]      = 'post_author = %s';
+		$where_args[] = get_the_author_meta( 'ID' );
+	}
+
+	// Set default category type
+	if ( is_category() ) {
+		$category = get_the_category();
+		if ( isset( $category ) && ! empty( $category ) ) {
+			$random_cat_id = $category[0]->term_id;
+		}
+	}
+
+	// Set the category ID if the parameter is set.
+	if ( isset( $_GET['random_cat_id'] ) ) {
+		$random_cat_id = (int) $_GET['random_cat_id'];
+	}
+
+	global $wpdb;
+
+	$where = implode( ' AND ', $where );
+	if ( isset( $random_cat_id ) ) {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
+		$random_id = $wpdb->get_var( $wpdb->prepare( "SELECT DISTINCT ID FROM $wpdb->posts AS p INNER JOIN $wpdb->term_relationships AS tr ON (p.ID = tr.object_id AND tr.term_taxonomy_id = %s) INNER JOIN  $wpdb->term_taxonomy AS tt ON(tr.term_taxonomy_id = tt.term_taxonomy_id AND taxonomy = 'category') WHERE $where ORDER BY RAND() LIMIT 1", $random_cat_id, ...$where_args ) );
+	} else {
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		$random_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->posts AS p WHERE $where ORDER BY RAND() LIMIT 1", ...$where_args ) );
+	}
+
+	// @phan-suppress-next-line PhanTypeMismatchArgument
+	$permalink = get_permalink( $random_id );
+	wp_safe_redirect( $permalink );
+	exit( 0 );
+}
+
+add_action( 'template_redirect', 'jetpack_matt_random_redirect' );

--- a/projects/plugins/jetpack/modules/theme-tools/random-redirect.php
+++ b/projects/plugins/jetpack/modules/theme-tools/random-redirect.php
@@ -17,6 +17,17 @@
  * Redirects to a random post on the site.
  */
 function jetpack_matt_random_redirect() {
+	/**
+	 * Allows disabling the random redirect feature.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param bool $enabled Whether the random redirect feature is enabled. Default true.
+	 */
+	if ( ! apply_filters( 'jetpack_random_redirect_enabled', true ) ) {
+		return;
+	}
+
 	// Verify that the Random Redirect plugin this code is from is not active
 	// See https://plugins.trac.wordpress.org/ticket/1898
 	if ( ! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {

--- a/projects/plugins/jetpack/modules/theme-tools/random-redirect.php
+++ b/projects/plugins/jetpack/modules/theme-tools/random-redirect.php
@@ -85,12 +85,29 @@ function jetpack_matt_random_redirect() {
 	global $wpdb;
 
 	$where = implode( ' AND ', $where );
+
+	// Pick a post via COUNT plus a random OFFSET rather than ORDER BY RAND(), which randomizes and sorts every candidate row on each request.
 	if ( isset( $random_cat_id ) ) {
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber
-		$random_id = $wpdb->get_var( $wpdb->prepare( "SELECT DISTINCT ID FROM $wpdb->posts AS p INNER JOIN $wpdb->term_relationships AS tr ON (p.ID = tr.object_id AND tr.term_taxonomy_id = %s) INNER JOIN  $wpdb->term_taxonomy AS tt ON(tr.term_taxonomy_id = tt.term_taxonomy_id AND taxonomy = 'category') WHERE $where ORDER BY RAND() LIMIT 1", $random_cat_id, ...$where_args ) );
+		$from_where = "FROM $wpdb->posts AS p INNER JOIN $wpdb->term_relationships AS tr ON (p.ID = tr.object_id AND tr.term_taxonomy_id = %s) INNER JOIN  $wpdb->term_taxonomy AS tt ON(tr.term_taxonomy_id = tt.term_taxonomy_id AND taxonomy = 'category') WHERE $where";
+		$query_args = array_merge( array( $random_cat_id ), $where_args );
 	} else {
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
-		$random_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM $wpdb->posts AS p WHERE $where ORDER BY RAND() LIMIT 1", ...$where_args ) );
+		$from_where = "FROM $wpdb->posts AS p WHERE $where";
+		$query_args = $where_args;
+	}
+
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+	$post_count = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT( DISTINCT p.ID ) $from_where", ...$query_args ) );
+
+	if ( $post_count < 1 ) {
+		return;
+	}
+
+	$query_args[] = wp_rand( 0, $post_count - 1 );
+	// phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+	$random_id = $wpdb->get_var( $wpdb->prepare( "SELECT DISTINCT p.ID $from_where ORDER BY p.ID LIMIT 1 OFFSET %d", ...$query_args ) );
+
+	if ( ! $random_id ) {
+		return;
 	}
 
 	// @phan-suppress-next-line PhanTypeMismatchArgument

--- a/projects/plugins/jetpack/phpunit.11.xml.dist
+++ b/projects/plugins/jetpack/phpunit.11.xml.dist
@@ -42,6 +42,9 @@
 		<testsuite name="infinite-scroll">
 			<directory suffix="Test.php">tests/php/modules/infinite-scroll</directory>
 		</testsuite>
+		<testsuite name="theme-tools">
+			<directory suffix="Test.php">tests/php/modules/theme-tools</directory>
+		</testsuite>
 		<testsuite name="comment-likes">
 			<directory suffix="Test.php">tests/php/modules/comment-likes</directory>
 		</testsuite>

--- a/projects/plugins/jetpack/phpunit.9.xml.dist
+++ b/projects/plugins/jetpack/phpunit.9.xml.dist
@@ -33,6 +33,9 @@
 		<testsuite name="infinite-scroll">
 			<directory suffix="Test.php">tests/php/modules/infinite-scroll</directory>
 		</testsuite>
+		<testsuite name="theme-tools">
+			<directory suffix="Test.php">tests/php/modules/theme-tools</directory>
+		</testsuite>
 		<testsuite name="comment-likes">
 			<directory suffix="Test.php">tests/php/modules/comment-likes</directory>
 		</testsuite>

--- a/projects/plugins/jetpack/tests/php/modules/theme-tools/Random_Redirect_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/theme-tools/Random_Redirect_Test.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Tests for the Random Redirect module.
+ *
+ * @package automattic/jetpack
+ * @since $$next-version$$
+ */
+
+/** Include the random-redirect.php module. */
+require_once __DIR__ . '/../../../../modules/theme-tools/random-redirect.php';
+
+/**
+ * Test class for the Random Redirect module.
+ *
+ * @since $$next-version$$
+ */
+class Random_Redirect_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+		add_filter( 'wp_redirect', array( $this, 'intercept_redirect' ) );
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		remove_filter( 'wp_redirect', array( $this, 'intercept_redirect' ) );
+		unset( $_GET['random'], $_GET['random_post_type'], $_GET['random_cat_id'] );
+		parent::tear_down();
+	}
+
+	/**
+	 * Throws the redirect location so tests can observe it before the module calls exit.
+	 *
+	 * @param string $location Redirect target.
+	 * @throws Exception Always, carrying the redirect location.
+	 */
+	public function intercept_redirect( $location ) {
+		throw new Exception( $location );
+	}
+
+	/**
+	 * Runs the redirect handler and returns the attempted redirect location, or null if none happened.
+	 *
+	 * @return string|null
+	 */
+	protected function get_redirect_location() {
+		try {
+			jetpack_matt_random_redirect();
+		} catch ( Exception $e ) {
+			return $e->getMessage();
+		}
+		return null;
+	}
+
+	/**
+	 * A request without the random parameter must not redirect.
+	 */
+	public function test_no_random_param_does_not_redirect() {
+		self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		$this->assertNull( $this->get_redirect_location() );
+	}
+
+	/**
+	 * Redirects to the permalink of a published post.
+	 */
+	public function test_redirects_to_published_post() {
+		$post_ids                 = self::factory()->post->create_many( 3, array( 'post_status' => 'publish' ) );
+		$_GET['random']           = '1';
+		$_GET['random_post_type'] = 'post';
+
+		$this->assertContains( $this->get_redirect_location(), array_map( 'get_permalink', $post_ids ) );
+	}
+
+	/**
+	 * Password-protected posts are never a redirect target.
+	 */
+	public function test_excludes_password_protected_posts() {
+		$public_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		self::factory()->post->create_many( 2, array( 'post_password' => 'secret' ) );
+		$_GET['random']           = '1';
+		$_GET['random_post_type'] = 'post';
+
+		$this->assertSame( get_permalink( $public_id ), $this->get_redirect_location() );
+	}
+
+	/**
+	 * The random_post_type parameter switches the post type.
+	 */
+	public function test_random_post_type_parameter() {
+		self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$page_id                  = self::factory()->post->create( array( 'post_type' => 'page' ) );
+		$_GET['random']           = '1';
+		$_GET['random_post_type'] = 'page';
+
+		$this->assertSame( get_permalink( $page_id ), $this->get_redirect_location() );
+	}
+
+	/**
+	 * The random_cat_id parameter restricts the pick to that category.
+	 */
+	public function test_random_cat_id_parameter() {
+		$cat_id    = self::factory()->category->create();
+		$in_cat_id = self::factory()->post->create( array( 'post_category' => array( $cat_id ) ) );
+		self::factory()->post->create_many( 3, array( 'post_status' => 'publish' ) );
+		$_GET['random']           = '1';
+		$_GET['random_post_type'] = 'post';
+		$_GET['random_cat_id']    = (string) $cat_id;
+
+		$this->assertSame( get_permalink( $in_cat_id ), $this->get_redirect_location() );
+	}
+
+	/**
+	 * No matching posts means no redirect.
+	 */
+	public function test_no_matching_posts_does_not_redirect() {
+		self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$_GET['random']           = '1';
+		$_GET['random_post_type'] = 'post';
+		$_GET['random_cat_id']    = '99999';
+
+		$this->assertNull( $this->get_redirect_location() );
+	}
+
+	/**
+	 * The jetpack_random_redirect_enabled filter disables the feature.
+	 */
+	public function test_disabled_via_filter() {
+		self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$_GET['random']           = '1';
+		$_GET['random_post_type'] = 'post';
+		add_filter( 'jetpack_random_redirect_enabled', '__return_false' );
+
+		$this->assertNull( $this->get_redirect_location() );
+
+		remove_filter( 'jetpack_random_redirect_enabled', '__return_false' );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/modules/theme-tools/Random_Redirect_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/theme-tools/Random_Redirect_Test.php
@@ -38,6 +38,7 @@ class Random_Redirect_Test extends WP_UnitTestCase {
 	 * Throws the redirect location so tests can observe it before the module calls exit.
 	 *
 	 * @param string $location Redirect target.
+	 * @return never
 	 * @throws Exception Always, carrying the redirect location.
 	 */
 	public function intercept_redirect( $location ) {


### PR DESCRIPTION
## Proposed changes

Restore the Random Redirect module that was removed from the Jetpack plugin in #38310, bringing back support for `yoursite.example/?random` redirects to a random published post.

While restoring it, the post-selection query was updated to use a COUNT plus random OFFSET lookup instead of `ORDER BY RAND()`, which is expensive and uncached on large sites.

Note: this 'module' can't be turned off on its own. If that is needed then we need to turn this into a proper Jetpack module. Alternatively, the `jetpack_random_redirect_enabled` filter can be used to turn this off, but it's undocumented at this point.

## Related product discussion/links

* JETPACK-2577 for more context about why this feature was re-introduced into Jetpack, and what could still be done as a follow-up.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Apply this PR to a Jetpack site with several published posts, some in a category.
* Visit `yoursite.example/?random` — repeat visits should redirect to varying published posts.
* Visit `?random&random_post_type=page` — redirects to a random page.
* Visit `?random&random_cat_id=<category term ID>` — redirects stay within that category.
* Visit `?random&random_cat_id=99999` (nonexistent) — page loads normally, no redirect.
* Password-protected posts should never be a redirect target.
* To disable the feature entirely, add `add_filter( 'jetpack_random_redirect_enabled', '__return_false' );` and confirm `?random` no longer redirects.

