### PR TITLE
AI Assistant: Use content-neutral suggestion copy

### DIFF
--- a/projects/js-packages/ai-client/changelog/fix-forno-441-neutral-suggestion-copy
+++ b/projects/js-packages/ai-client/changelog/fix-forno-441-neutral-suggestion-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+AI Assistant: Use content-neutral wording for title and featured image copy.

--- a/projects/js-packages/ai-client/src/components/ai-image/featured-image.tsx
+++ b/projects/js-packages/ai-client/src/components/ai-image/featured-image.tsx
@@ -377,7 +377,7 @@ export default function FeaturedImage( {
 				placement === PLACEMENT_DOCUMENT_SETTINGS ) && (
 				<>
 					<p className="jetpack-ai-assistant__help-text">
-						{ __( 'Based on your post content.', 'jetpack-ai-client' ) }
+						{ __( 'Based on your content.', 'jetpack-ai-client' ) }
 					</p>
 					<Button
 						onClick={ handleModalOpen }

--- a/projects/js-packages/ai-client/src/constants.ts
+++ b/projects/js-packages/ai-client/src/constants.ts
@@ -111,7 +111,7 @@ export const MAKE_SHORTER_LABEL = __( 'Make shorter', 'jetpack-ai-client' );
 export const MAKE_LONGER_LABEL = __( 'Expand', 'jetpack-ai-client' );
 export const TURN_LIST_INTO_TABLE_LABEL = __( 'Turn list into a table', 'jetpack-ai-client' );
 export const WRITE_POST_FROM_LIST_LABEL = __( 'Write a post from this list', 'jetpack-ai-client' );
-export const GENERATE_TITLE_LABEL = __( 'Generate a post title', 'jetpack-ai-client' );
+export const GENERATE_TITLE_LABEL = __( 'Generate a title', 'jetpack-ai-client' );
 export const SUMMARY_BASED_ON_TITLE_LABEL = __( 'Summary based on title', 'jetpack-ai-client' );
 export const CONTINUE_LABEL = __( 'Continue writing', 'jetpack-ai-client' );
 

--- a/projects/plugins/jetpack/changelog/fix-forno-441-title-context
+++ b/projects/plugins/jetpack/changelog/fix-forno-441-title-context
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Assistant: Use content-neutral wording for title optimization and SEO metadata.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/seo-enhancer/seo-enhancer.tsx
@@ -109,7 +109,7 @@ export function SeoEnhancer( {
 							label={ __( 'Auto-generate metadata', 'jetpack' ) }
 							__nextHasNoMarginBottom={ true }
 							help={ __(
-								'When enabled, missing metadata will be automatically generated when you publish a post.',
+								'When enabled, missing metadata will be automatically generated when you publish your content.',
 								'jetpack'
 							) }
 						/>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/index.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/index.tsx
@@ -79,15 +79,12 @@ export default function TitleOptimization( {
 	busy: boolean;
 	disabled: boolean;
 } ) {
-	const currentModalTitle = __( 'Optimize post title', 'jetpack' );
+	const currentModalTitle = __( 'Optimize title', 'jetpack' );
 	const SEOModalTitle = __( 'Improve title for SEO', 'jetpack' );
 	const modalTitle = isKeywordsFeatureAvailable ? SEOModalTitle : currentModalTitle;
 
-	const currentSidebarDescription = __( 'Based on your post content.', 'jetpack' );
-	const SEOSidebarDescription = __(
-		'Based on your post content and SEO best practices.',
-		'jetpack'
-	);
+	const currentSidebarDescription = __( 'Based on your content.', 'jetpack' );
+	const SEOSidebarDescription = __( 'Based on your content and SEO best practices.', 'jetpack' );
 	const sidebarDescription = isKeywordsFeatureAvailable
 		? SEOSidebarDescription
 		: currentSidebarDescription;
@@ -252,7 +249,7 @@ export default function TitleOptimization( {
 									height: '50px',
 								} }
 							/>
-							{ __( 'Reading your post and generating suggestions…', 'jetpack' ) }
+							{ __( 'Reading your content and generating suggestions…', 'jetpack' ) }
 						</div>
 					) : (
 						<>

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/test/index.test.tsx
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/components/title-optimization/test/index.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TitleOptimization from '..';
+
+jest.mock( '@automattic/jetpack-ai-client', () => ( {
+	AiAssistantModal: ( { children, title }: { children: React.ReactNode; title: string } ) => (
+		<section>
+			<h1>{ title }</h1>
+			{ children }
+		</section>
+	),
+	ERROR_NETWORK: 'network',
+	ERROR_QUOTA_EXCEEDED: 'quota',
+	ERROR_SERVICE_UNAVAILABLE: 'service-unavailable',
+	ERROR_UNCLEAR_PROMPT: 'unclear-prompt',
+	QuotaExceededMessage: () => null,
+	useAiSuggestions: () => ( {
+		request: jest.fn(),
+		stopSuggestion: jest.fn(),
+	} ),
+	usePostContent: () => ( {
+		getPostContent: jest.fn(),
+		isEditedPostEmpty: () => false,
+	} ),
+} ) );
+
+jest.mock( '@automattic/jetpack-shared-extension-utils', () => ( {
+	useAnalytics: () => ( {
+		tracks: {
+			recordEvent: jest.fn(),
+		},
+	} ),
+	useAutosaveAndRedirect: () => ( {
+		autosave: jest.fn(),
+	} ),
+} ) );
+
+jest.mock( '@wordpress/components', () => ( {
+	Button: ( { children, onClick }: { children: React.ReactNode; onClick?: () => void } ) => (
+		<button onClick={ onClick }>{ children }</button>
+	),
+	Notice: ( { children }: { children: React.ReactNode } ) => <div>{ children }</div>,
+	Spinner: () => <span>Loading</span>,
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( {
+		editPost: jest.fn(),
+		increaseAiAssistantRequestsCount: jest.fn(),
+	} ),
+} ) );
+
+jest.mock( '../../../../../blocks/ai-assistant/lib/utils/get-feature-availability', () => ( {
+	getFeatureAvailability: () => false,
+} ) );
+
+jest.mock( '../style.scss', () => ( {} ) );
+
+describe( 'TitleOptimization', () => {
+	it( 'uses content-neutral wording', async () => {
+		const user = userEvent.setup();
+		render( <TitleOptimization placement="sidebar" busy={ false } disabled={ false } /> );
+
+		expect( screen.getByText( 'Based on your content.' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'heading', { name: 'Optimize title' } ) ).not.toBeInTheDocument();
+
+		await user.click( screen.getByRole( 'button', { name: 'Generate title options' } ) );
+
+		expect( screen.getByRole( 'heading', { name: 'Optimize title' } ) ).toBeInTheDocument();
+		expect(
+			screen.getByText( 'Reading your content and generating suggestions…' )
+		).toBeInTheDocument();
+	} );
+} );


### PR DESCRIPTION

## Proposed changes

* Use content-neutral wording in the title optimization sidebar, modal, and loading state.
* Use the same neutral wording for Featured Image help text, SEO metadata auto-generation, and the shared whole-content “Generate a title” action.
* Remove the title optimization component’s dependency on the current editor post type.
* Keep explicitly post-generating actions such as “Write a post from this list” unchanged.
* Add focused coverage for the title optimization sidebar-to-modal flow.

Several Jetpack AI suggestions assumed the current content was a post, so page editors displayed copy such as “Optimize post title,” “Based on your post content,” and “when you publish a post.” Neutral copy is accurate for posts, pages, and other supported editor contexts without adding post-type branching to each suggestion.

The audit also covered feedback, spelling and grammar, proofreading/Write Brief, rewrite, summarize, tone, translation, SEO title and description, and image alt-text suggestions. Those surfaces were already content-neutral and do not need code changes.

## Related product discussion/links



## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Automated checks completed:

* `cd projects/plugins/jetpack && node_modules/.bin/jest --config=tests/jest.config.extensions.js --runInBand extensions/plugins/ai-assistant-plugin/components/title-optimization/test/index.test.tsx`
  * Result: 1 test passed and the intended suite was explicitly collected.
* `cd projects/plugins/jetpack && node_modules/.bin/tsgo --noEmit`
* `cd projects/js-packages/ai-client && node_modules/.bin/tsgo --noEmit`
* Targeted ESLint and Prettier checks for all changed TypeScript files.
* `git diff --check origin/trunk...HEAD`
* A scoped source audit confirmed there is no remaining post/page-specific suggestion copy in the Jetpack AI assistant, SEO enhancer, or shared AI client surfaces. Explicitly post-generating prompts remain unchanged.
* Required Claude review completed with no blocking findings.

Manual testing:

1. Open a page in the block editor and open the Jetpack AI title optimization panel.
2. Confirm the description says “Based on your content.”
3. Click **Generate title options** and confirm the modal says “Optimize title” and the loading state says “Reading your content and generating suggestions…”.
4. With the title optimization keywords feature enabled, confirm the description says “Based on your content and SEO best practices.” and the modal retains “Improve title for SEO”.
5. Open Featured Image generation and confirm its help text says “Based on your content.”
6. Open the SEO enhancer and confirm the auto-generation help says missing metadata is generated “when you publish your content.”
7. Spot-check feedback, spelling and grammar, proofreading/Write Brief, rewrite, summarize, tone, translation, and image alt-text suggestions; confirm they do not refer to a post or page.
8. Open the AI Assistant block’s whole-content actions and confirm the title action says “Generate a title”.
9. Repeat the relevant checks in a post editor and confirm the neutral copy still reads naturally.
