### PR TITLE
Help Center: Configure interaction bot slugs

### DIFF
--- a/projects/packages/help-center/CHANGELOG.md
+++ b/projects/packages/help-center/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-07-30
+### Added
+- Help Center: Allow consumers to configure interaction bot slugs.
+
 ## [0.2.0] - 2026-07-27
 ### Added
 - Allow consumers to load the logged-out Help Center bundle and proxy logged-out requests anonymously.
@@ -14,4 +18,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow consumers to provide the WordPress.com authentication state and request client used by the Help Center.
 - Initial version, extracted from Jetpack MU WPCOM to its own package for external consumption.
 
+[0.3.0]: https://github.com/Automattic/jetpack-help-center/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Automattic/jetpack-help-center/compare/v0.1.0...v0.2.0

--- a/projects/packages/help-center/changelog/help-center-bot-slugs
+++ b/projects/packages/help-center/changelog/help-center-bot-slugs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Help Center: Allow consumers to configure interaction bot slugs.

--- a/projects/packages/help-center/changelog/help-center-bot-slugs
+++ b/projects/packages/help-center/changelog/help-center-bot-slugs
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Help Center: Allow consumers to configure interaction bot slugs.

--- a/projects/packages/help-center/composer.json
+++ b/projects/packages/help-center/composer.json
@@ -45,7 +45,7 @@
 		"autorelease": true,
 		"autotagger": true,
 		"branch-alias": {
-			"dev-trunk": "0.2.x-dev"
+			"dev-trunk": "0.3.x-dev"
 		},
 		"changelogger": {
 			"link-template": "https://github.com/Automattic/jetpack-help-center/compare/v${old}...v${new}"

--- a/projects/packages/help-center/src/class-help-center.php
+++ b/projects/packages/help-center/src/class-help-center.php
@@ -18,7 +18,7 @@ class Help_Center {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.2.0';
+	const PACKAGE_VERSION = '0.3.0';
 
 	/**
 	 * Class instance.

--- a/projects/packages/help-center/src/class-help-center.php
+++ b/projects/packages/help-center/src/class-help-center.php
@@ -35,6 +35,20 @@ class Help_Center {
 	private $wpcom_request_client;
 
 	/**
+	 * Bot slug for new interactions.
+	 *
+	 * @var string|null
+	 */
+	private $new_interactions_bot_slug;
+
+	/**
+	 * Bot slug for new logged-out interactions.
+	 *
+	 * @var string|null
+	 */
+	private $new_logged_out_interactions_bot_slug;
+
+	/**
 	 * Whether the current site is a support site.
 	 *
 	 * @var bool
@@ -58,10 +72,14 @@ class Help_Center {
 	/**
 	 * Help_Center constructor.
 	 *
-	 * @param Wpcom_Request_Client|null $wpcom_request_client WP.com request client.
+	 * @param Wpcom_Request_Client|null $wpcom_request_client                 WP.com request client.
+	 * @param string|null               $new_interactions_bot_slug            Bot slug for new interactions.
+	 * @param string|null               $new_logged_out_interactions_bot_slug Bot slug for new logged-out interactions.
 	 */
-	public function __construct( ?Wpcom_Request_Client $wpcom_request_client = null ) {
-		$this->wpcom_request_client = $wpcom_request_client ?? new Jetpack_Wpcom_Request_Client();
+	public function __construct( ?Wpcom_Request_Client $wpcom_request_client = null, ?string $new_interactions_bot_slug = null, ?string $new_logged_out_interactions_bot_slug = null ) {
+		$this->wpcom_request_client                 = $wpcom_request_client ?? new Jetpack_Wpcom_Request_Client();
+		$this->new_interactions_bot_slug            = $new_interactions_bot_slug;
+		$this->new_logged_out_interactions_bot_slug = $new_logged_out_interactions_bot_slug;
 
 		if ( function_exists( 'wpcom_get_site_purchases' ) ) {
 			$this->purchases = wp_list_filter( wpcom_get_site_purchases(), array( 'product_type' => 'bundle' ) );
@@ -177,10 +195,12 @@ class Help_Center {
 	/**
 	 * Creates instance.
 	 *
-	 * @param Wpcom_Request_Client|null $wpcom_request_client WP.com request client.
+	 * @param Wpcom_Request_Client|null $wpcom_request_client                 WP.com request client.
+	 * @param string|null               $new_interactions_bot_slug            Bot slug for new interactions.
+	 * @param string|null               $new_logged_out_interactions_bot_slug Bot slug for new logged-out interactions.
 	 * @return self|null
 	 */
-	public static function init( ?Wpcom_Request_Client $wpcom_request_client = null ) {
+	public static function init( ?Wpcom_Request_Client $wpcom_request_client = null, ?string $new_interactions_bot_slug = null, ?string $new_logged_out_interactions_bot_slug = null ) {
 		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 
 		if ( str_contains( $request_uri, 'wp-content/plugins/gutenberg-core' ) || str_contains( $request_uri, 'preview=true' ) ) {
@@ -208,7 +228,7 @@ class Help_Center {
 				}
 			}
 
-			self::$instance = new self( $wpcom_request_client );
+			self::$instance = new self( $wpcom_request_client, $new_interactions_bot_slug, $new_logged_out_interactions_bot_slug );
 		}
 
 		return self::$instance;
@@ -493,6 +513,14 @@ class Help_Center {
 			'site'             => $this->get_current_site(),
 			'locale'           => self::determine_iso_639_locale(),
 		);
+
+		if ( null !== $this->new_interactions_bot_slug ) {
+			$data['newInteractionsBotSlug'] = $this->new_interactions_bot_slug;
+		}
+
+		if ( null !== $this->new_logged_out_interactions_bot_slug ) {
+			$data['newLoggedOutInteractionsBotSlug'] = $this->new_logged_out_interactions_bot_slug;
+		}
 
 		return array_replace( $data, $overrides );
 	}

--- a/projects/packages/help-center/tests/php/Help_Center_Data_Test.php
+++ b/projects/packages/help-center/tests/php/Help_Center_Data_Test.php
@@ -142,6 +142,30 @@ class Help_Center_Data_Test extends \WorDBless\BaseTestCase {
 		$this->assertInstanceOf( Help_Center::class, Help_Center::get_instance() );
 	}
 
+	public function test_init_includes_configured_bot_slugs_in_payload() {
+		$help_center = Help_Center::init( null, 'new-interactions-bot', 'new-logged-out-interactions-bot' );
+		$data        = $help_center->get_help_center_data();
+
+		$this->assertSame( 'new-interactions-bot', $data['newInteractionsBotSlug'] );
+		$this->assertSame( 'new-logged-out-interactions-bot', $data['newLoggedOutInteractionsBotSlug'] );
+	}
+
+	public function test_init_omits_unset_bot_slugs_from_payload() {
+		$help_center = Help_Center::init();
+		$data        = $help_center->get_help_center_data();
+
+		$this->assertArrayNotHasKey( 'newInteractionsBotSlug', $data );
+		$this->assertArrayNotHasKey( 'newLoggedOutInteractionsBotSlug', $data );
+	}
+
+	public function test_init_omits_unset_logged_out_bot_slug_from_payload() {
+		$help_center = Help_Center::init( null, 'new-interactions-bot' );
+		$data        = $help_center->get_help_center_data();
+
+		$this->assertSame( 'new-interactions-bot', $data['newInteractionsBotSlug'] );
+		$this->assertArrayNotHasKey( 'newLoggedOutInteractionsBotSlug', $data );
+	}
+
 	public function test_consumer_can_load_logged_out_bundle_on_frontend() {
 		wp_set_current_user( 0 );
 		set_transient(

--- a/projects/plugins/mu-wpcom-plugin/changelog/alshakero-help-center-bot-slugs
+++ b/projects/plugins/mu-wpcom-plugin/changelog/alshakero-help-center-bot-slugs
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -1044,7 +1044,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/help-center",
-                "reference": "48d4a0c0e828efd684bf626fbfd0428d6a235bb7"
+                "reference": "eb8b07424bccf9eebd947f841b3bf607fd5b36c6"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1065,7 +1065,7 @@
                 "autorelease": true,
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.2.x-dev"
+                    "dev-trunk": "0.3.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-help-center/compare/v${old}...v${new}"

--- a/projects/plugins/wpcomsh/changelog/alshakero-help-center-bot-slugs
+++ b/projects/plugins/wpcomsh/changelog/alshakero-help-center-bot-slugs
@@ -1,0 +1,3 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -1160,7 +1160,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/help-center",
-                "reference": "d0694e7d9bd86f99017e4e9f42348d2bb83480e6"
+                "reference": "017c4230a4a324dcd0daab94d5e171dda6898441"
             },
             "require": {
                 "automattic/jetpack-connection": "@dev",
@@ -1181,7 +1181,7 @@
                 "autorelease": true,
                 "autotagger": true,
                 "branch-alias": {
-                    "dev-trunk": "0.2.x-dev"
+                    "dev-trunk": "0.3.x-dev"
                 },
                 "changelogger": {
                     "link-template": "https://github.com/Automattic/jetpack-help-center/compare/v${old}...v${new}"


### PR DESCRIPTION
Fixes #

## Proposed changes

* Allow Help Center consumers to configure the new-interactions and logged-out-interactions bot slugs when initializing the package.
* Include the corresponding `newInteractionsBotSlug` and `newLoggedOutInteractionsBotSlug` fields in `helpCenterData` only when configured.
* Prepare the Help Center package for the v0.3.0 release, including the finalized changelog and consumer dependency metadata.

## Related product discussion/links

* N/A

## Does this pull request change what data or activity we track or use?

* No.

## Testing instructions

* Run `php vendor/bin/phpunit -c phpunit.12.xml.dist` from `projects/packages/help-center`.
* Confirm the suite passes (20 tests, 90 assertions).
* Run `tools/project-version.sh -c 0.3.0 packages/help-center` from the repository root.
