### PR TITLE
Stats: proxy the email overview endpoint

### DIFF
--- a/projects/packages/stats-admin/changelog/add-email-overview-proxy
+++ b/projects/packages/stats-admin/changelog/add-email-overview-proxy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Stats: Proxy the email overview stats endpoint.

--- a/projects/packages/stats-admin/src/class-rest-controller.php
+++ b/projects/packages/stats-admin/src/class-rest-controller.php
@@ -863,6 +863,7 @@ class REST_Controller {
 	 */
 	public function get_email_stats_list( $req ) {
 		switch ( $req->get_param( 'resource' ) ) {
+			case 'overview':
 			case 'summary':
 				return WPCOM_Client::request_as_blog_cached(
 					sprintf(

--- a/projects/packages/stats-admin/tests/php/REST_Controller_Test.php
+++ b/projects/packages/stats-admin/tests/php/REST_Controller_Test.php
@@ -194,6 +194,36 @@ class REST_Controller_Test extends Stats_TestCase {
 	}
 
 	/**
+	 * Test that the email stats `overview` resource is proxied rather than refused.
+	 *
+	 * The route list above only asserts a route is not a 404, and this one always
+	 * matched: `resource` is a dynamic path segment, so before `overview` was an
+	 * allowed value the request still reached the controller and came back 403
+	 * from the `default` branch. Asserting 200 is what distinguishes proxying the
+	 * resource from forbidding it.
+	 */
+	public function test_email_stats_overview_resource_is_proxied() {
+		wp_set_current_user( $this->admin_id );
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/stats-app/sites/999/stats/emails/overview' );
+		$request->set_header( 'content-type', 'application/json' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * Test that an unknown email stats resource is still refused.
+	 */
+	public function test_email_stats_unknown_resource_is_forbidden() {
+		wp_set_current_user( $this->admin_id );
+		$request = new WP_REST_Request( 'GET', '/jetpack/v4/stats-app/sites/999/stats/emails/not-a-resource' );
+		$request->set_header( 'content-type', 'application/json' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 403, $response->get_status() );
+	}
+
+	/**
 	 * Test '/jetpack/v4/stats-app/stats/notices' failed
 	 */
 	public function test_stats_notices_illegal_params() {

--- a/projects/packages/stats-admin/tests/php/REST_Controller_Test.php
+++ b/projects/packages/stats-admin/tests/php/REST_Controller_Test.php
@@ -36,6 +36,7 @@ class REST_Controller_Test extends Stats_TestCase {
 		'/jetpack/v4/stats-app/sites/999/stats/comments',
 		'/jetpack/v4/stats-app/sites/999/stats/comment-followers',
 		'/jetpack/v4/stats-app/sites/999/stats/subscribers',
+		'/jetpack/v4/stats-app/sites/999/stats/emails/overview',
 		'/jetpack/v4/stats-app/sites/999/stats/post/1',
 		'/jetpack/v4/stats-app/sites/999/stats/video/1',
 		'/jetpack/v4/stats-app/sites/999/site-has-never-published-post',


### PR DESCRIPTION
## Proposed changes
Proxy the `overview` resource on the email stats endpoint, alongside the existing `summary` resource. Both use the same cached proxy implementation, so this is a one-line fall through.

This is the first of a series of PRs splitting up #50680 (a proof of concept, not for merge). It stands alone and has no dependency on the rest of that work.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Run the package tests: `jp test php packages/stats-admin` — the new `/jetpack/v4/stats-app/sites/<id>/stats/emails/overview` route is covered by the existing proxied-route assertions.
* On a site with Stats, confirm a request to that route returns email overview data rather than a 404.