### PR TITLE
SEO: trim each schema override before its fallback

### DIFF
--- a/projects/packages/seo/_inc/screens/settings/schema-card.tsx
+++ b/projects/packages/seo/_inc/screens/settings/schema-card.tsx
@@ -69,9 +69,15 @@ function SchemaCard( { initialSettings, onSave }: Props ) {
 	// duplicate rows. Otherwise the header could read "Complete" off a row that
 	// server sanitization is about to discard — while Save sits disabled on the
 	// very validation error that makes it uncounted.
+	//
+	// Each override is trimmed *before* the fallback, mirroring the backend, where
+	// `Schema_Settings::text()` trims and the node then falls back to site identity.
+	// Trimming the result instead would let a whitespace-only override win the `||`
+	// and collapse to empty, dropping the module out of Complete over a value the
+	// server will discard in favour of the Site Title that was counting before.
 	const configuredFields = [
-		( organization.name || defaults.name ).trim(),
-		( organization.description || defaults.description ).trim(),
+		organization.name.trim() || defaults.name.trim(),
+		organization.description.trim() || defaults.description.trim(),
 		cleanProfileUrls( organization.sameAs ).length > 0,
 	];
 	const configuredCount = configuredFields.filter( Boolean ).length;

--- a/projects/packages/seo/_inc/screens/settings/test/schema-card.test.tsx
+++ b/projects/packages/seo/_inc/screens/settings/test/schema-card.test.tsx
@@ -182,6 +182,17 @@ describe( 'SchemaCard', () => {
 		expect( screen.getByRole( 'button', { name: /Schema/ } ) ).toHaveTextContent( 'Not started' );
 	} );
 
+	it( 'falls back to the site defaults when the override is only whitespace', () => {
+		// The backend trims the override and then falls back to site identity, so a
+		// stray space must not drop the module below what the Site Title already earns.
+		mockForm = makeForm( {
+			organization: { name: '   ', description: ' ', sameAs: [], email: '' },
+		} );
+		renderCard();
+
+		expect( screen.getByRole( 'button', { name: /Schema/ } ) ).toHaveTextContent( 'In progress' );
+	} );
+
 	it( 'counts an explicit value, not just its default', () => {
 		// The rule is "has a value OR its smart default". Every other status test
 		// leaves the overrides empty and varies only the defaults, so without this

--- a/projects/packages/seo/changelog/fix-seo-schema-status-trim-override
+++ b/projects/packages/seo/changelog/fix-seo-schema-status-trim-override
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Keep the Schema module's completion status accurate when a name or description field contains only spaces.


### PR DESCRIPTION
Fixes JETPACK-2079

Follow-up to #50918 — this fix reached the branch about a minute after that PR merged, so it missed the boat. Two lines plus a test.

## Proposed changes

The Schema module's completion status read:

```js
( organization.name || defaults.name ).trim()
```

A whitespace-only override wins the `||` and then collapses to empty, so typing a stray space into **Name** or **Description** drops the module out of "Complete" — even though the server trims that value away and falls back to the Site Title, which was counting a moment earlier. `Schema_Settings::text()` is `trim( wp_strip_all_tags( … ) )`, so the stored value is empty and the *default* is what actually gets emitted.

Trimming each override **before** the fallback mirrors the backend, so the status matches what would be stored:

```js
organization.name.trim() || defaults.name.trim()
```

That's the same rule the profile-link and empty-row checks in that module already follow — this brings the third and fourth counted values in line.

Impact is small: the wrong reading only lasts until the value is saved and re-seeded from the server. But the fields now share one rule instead of two.

## Related product discussion/links

* [JETPACK-2079](https://linear.app/a8c/issue/JETPACK-2079/seo-combine-the-site-level-schema-controls-into-one-schema-module) — the issue #50918 landed under
* #50918 — the PR this follows up
* Found by Copilot's review on #50918, where it was **suppressed as low confidence**. Verified against `Schema_Settings::text()` before acting on it.

## Does this pull request change what data or activity we track or use?

No. No PHP, no stored options, no requests, no change to emitted schema. It only changes which of three values the header counts as configured.

## Testing instructions

Requires the `rsm_jetpack_seo` feature flag (a filter — `add_filter( 'rsm_jetpack_seo', '__return_true' );` in an mu-plugin).

* Go to **Jetpack → SEO → Settings** on a site that has a **Site Title** and **Tagline** set, and no social profile links. The collapsed **Schema** header reads **In progress**.
* Expand it and type a single space into **Name**.
* **Before this fix:** the header drops to **Not started**. **After:** it stays **In progress**, because the Site Title still applies.
* Same with a space in **Description**.
* Regression check: clearing both the Site Title and Tagline in **Settings → General** with empty overrides still reads **Not started**, and adding a social profile link still reaches **Complete**.
