### PR TITLE
Write: add `wpcom_write_back_destinations` filter

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/write-editor-back-destinations-filter
+++ b/projects/packages/jetpack-mu-wpcom/changelog/write-editor-back-destinations-filter
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Write editor: Add a filter so callers can register vetted back-button destinations.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -77,6 +77,22 @@ function wpcom_write_resolve_back_url( $source ) {
 		'reader' => 'https://wordpress.com/reader',
 	);
 
+	/**
+	 * Filters the Write editor "back" destination map (source token => URL).
+	 *
+	 * Register vetted destinations here rather than passing an arbitrary return
+	 * URL via the query string, which is intentionally not supported
+	 * (open-redirect guard). Destinations are not validated by this filter, and
+	 * need not be same-origin — the built-in Reader entry is not — so register
+	 * only URLs you trust. The resolved URL is escaped with esc_url() before
+	 * output.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $destinations Map of source token to destination URL.
+	 */
+	$destinations = apply_filters( 'wpcom_write_back_destinations', $destinations );
+
 	return $destinations[ $source ] ?? admin_url();
 }
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/write/Write_Test.php
@@ -103,6 +103,60 @@ class Write_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Test that a filtered destination is resolvable.
+	 *
+	 * The filter is the supported way to register a back destination: an
+	 * arbitrary return URL passed through the query string is deliberately not
+	 * honoured, so callers outside this package have no other route in.
+	 */
+	public function test_resolve_back_url_honours_filtered_destination() {
+		$destination = 'https://example.org/wp-admin/admin.php?page=jetpack-newsletter';
+
+		$add_destination = function ( $destinations ) use ( $destination ) {
+			$destinations['newsletter'] = $destination;
+			return $destinations;
+		};
+
+		// Unregistered before the filter is added — this is what makes the
+		// assertion below evidence that the filter did the work.
+		$this->assertSame( admin_url(), wpcom_write_resolve_back_url( 'newsletter' ) );
+
+		add_filter( 'wpcom_write_back_destinations', $add_destination );
+		$filtered = wpcom_write_resolve_back_url( 'newsletter' );
+		remove_filter( 'wpcom_write_back_destinations', $add_destination );
+
+		$this->assertSame( $destination, $filtered );
+
+		// And the map is not mutated for later calls once the filter is gone.
+		$this->assertSame( admin_url(), wpcom_write_resolve_back_url( 'newsletter' ) );
+	}
+
+	/**
+	 * Test that the filter is passed the built-in destinations.
+	 *
+	 * Consumers are expected to add an entry to the map rather than build one,
+	 * so receiving the populated map is the contract they rely on. Note this is
+	 * not a guarantee that built-ins survive: a filter is free to replace the
+	 * array wholesale, and nothing prevents that.
+	 */
+	public function test_resolve_back_url_filter_receives_built_in_destinations() {
+		$received = null;
+
+		$capture = function ( $destinations ) use ( &$received ) {
+			$received = $destinations;
+			return $destinations;
+		};
+
+		add_filter( 'wpcom_write_back_destinations', $capture );
+		wpcom_write_resolve_back_url( 'reader' );
+		remove_filter( 'wpcom_write_back_destinations', $capture );
+
+		$this->assertIsArray( $received );
+		$this->assertArrayHasKey( 'reader', $received );
+		$this->assertSame( 'https://wordpress.com/reader', $received['reader'] );
+	}
+
+	/**
 	 * Test that the back button href reflects the resolved destination, defaulting to the dashboard.
 	 */
 	public function test_template_back_button_defaults_to_dashboard() {


### PR DESCRIPTION
## Proposed changes
Add a `wpcom_write_back_destinations` filter to the Write editor's back-URL resolver, so callers can register vetted destinations for the back button.

Registering through a filter is deliberate: an arbitrary return URL passed via the query string is intentionally not honoured (open-redirect guard), so this is the only supported way for code outside the package to add a destination. The resolved URL is still escaped with `esc_url()` before output.

There is no consumer in this PR — that arrives later, in the Newsletter Mode work. Shipping the extension point first keeps the consumer a pure consumer.

This is one of a series of PRs splitting up #50680 (a proof of concept, not for merge). It stands alone.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Run the package tests: `jp test php packages/jetpack-mu-wpcom`
* Two new cases in `Write_Test.php` cover it: a registered destination resolves through the filter, and a no-op filter leaves the built-in `reader` destination untouched.