### PR TITLE
Subscribers: deep links into Add Subscribers tabs

### DIFF
--- a/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.scss
+++ b/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.scss
@@ -1,14 +1,3 @@
-// `Tabs.Tab` sizes its box to its label, so the focus ring lands hard against
-// the word with nothing between the two. A little inline padding gives the ring
-// room to breathe; the tabs keep their own spacing from the list's gap, so the
-// row reads the same.
-.jetpack-newsletter__add-subscribers-tabs {
-
-	[role="tab"] {
-		padding-inline: var(--wpds-dimension-padding-xs);
-	}
-}
-
 // CSV upload drop area for the Add Subscribers modal. Replaces the bare file
 // input with a clickable box (click to open the picker) and lets core's
 // `<DropZone>` own the drag-and-drop — the same primitive the modernized

--- a/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.scss
+++ b/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.scss
@@ -1,3 +1,14 @@
+// `Tabs.Tab` sizes its box to its label, so the focus ring lands hard against
+// the word with nothing between the two. A little inline padding gives the ring
+// room to breathe; the tabs keep their own spacing from the list's gap, so the
+// row reads the same.
+.jetpack-newsletter__add-subscribers-tabs {
+
+	[role="tab"] {
+		padding-inline: var(--wpds-dimension-padding-xs);
+	}
+}
+
 // CSV upload drop area for the Add Subscribers modal. Replaces the bare file
 // input with a clickable box (click to open the picker) and lets core's
 // `<DropZone>` own the drag-and-drop — the same primitive the modernized

--- a/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
@@ -20,6 +20,12 @@ import type { ImportJob } from '../../data/types';
 type Props = {
 	isOpen: boolean;
 	onClose: () => void;
+	/**
+	 * Which tab to open on. Defaults to Manual. Read once, when the modal
+	 * mounts — callers that need a specific tab on every open (rather than only
+	 * the first) should mount the modal while it is open.
+	 */
+	initialTab?: AddSubscribersTab;
 };
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -61,7 +67,7 @@ function isAcceptedCsvFile( file: File ): boolean {
 	return ACCEPTED_CSV_EXTENSIONS.includes( extension );
 }
 
-type TabValue = 'manual' | 'upload' | 'substack';
+export type AddSubscribersTab = 'manual' | 'upload' | 'substack';
 
 /**
  * Consent + large-import notice shown under both the manual and CSV entry forms, mirroring the copy
@@ -613,14 +619,19 @@ function SubstackTab(): JSX.Element {
  * dashboard yet because its `/me/sites` lookup needs an oauth token the Jetpack-as-user proxy
  * can't supply server-side. Tracked in #48365 — Phase 5b deferred.)
  *
- * @param props         - Component props.
- * @param props.isOpen  - Whether the modal is open.
- * @param props.onClose - Close handler.
+ * @param props            - Component props.
+ * @param props.isOpen     - Whether the modal is open.
+ * @param props.onClose    - Close handler.
+ * @param props.initialTab - Tab to open on; defaults to Manual.
  * @return Modal element or null when closed.
  */
-export default function AddSubscribersModal( { isOpen, onClose }: Props ): JSX.Element | null {
+export default function AddSubscribersModal( {
+	isOpen,
+	onClose,
+	initialTab = 'manual',
+}: Props ): JSX.Element | null {
 	const mutation = useAddSubscribersMutation();
-	const [ tab, setTab ] = useState< TabValue >( 'manual' );
+	const [ tab, setTab ] = useState< AddSubscribersTab >( initialTab );
 	const importJobsQuery = useImportJobs( isOpen );
 
 	const handleOpenChange = useCallback(
@@ -633,7 +644,7 @@ export default function AddSubscribersModal( { isOpen, onClose }: Props ): JSX.E
 	);
 
 	const handleTabChange = useCallback( ( next: string ) => {
-		setTab( next as TabValue );
+		setTab( next as AddSubscribersTab );
 		// Calypso fires `calypso_subscribers_add_question` per import-method tile click, with a
 		// `method` prop. We mirror it on every tab switch so reviewers can read tab-engagement
 		// stats the same way.
@@ -662,7 +673,7 @@ export default function AddSubscribersModal( { isOpen, onClose }: Props ): JSX.E
 							onValueChange={ handleTabChange }
 							render={ <Stack direction="column" gap="lg" /> }
 						>
-							<Tabs.List variant="minimal">
+							<Tabs.List variant="minimal" className="jetpack-newsletter__add-subscribers-tabs">
 								<Tabs.Tab value="manual">{ __( 'Manual', 'jetpack-newsletter' ) }</Tabs.Tab>
 								<Tabs.Tab value="upload">{ __( 'Upload CSV', 'jetpack-newsletter' ) }</Tabs.Tab>
 								<Tabs.Tab value="substack">{ __( 'Substack', 'jetpack-newsletter' ) }</Tabs.Tab>

--- a/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
@@ -673,7 +673,7 @@ export default function AddSubscribersModal( {
 							onValueChange={ handleTabChange }
 							render={ <Stack direction="column" gap="lg" /> }
 						>
-							<Tabs.List variant="minimal" className="jetpack-newsletter__add-subscribers-tabs">
+							<Tabs.List variant="minimal">
 								<Tabs.Tab value="manual">{ __( 'Manual', 'jetpack-newsletter' ) }</Tabs.Tab>
 								<Tabs.Tab value="upload">{ __( 'Upload CSV', 'jetpack-newsletter' ) }</Tabs.Tab>
 								<Tabs.Tab value="substack">{ __( 'Substack', 'jetpack-newsletter' ) }</Tabs.Tab>

--- a/projects/packages/newsletter/_inc/subscribers/components/subscribers-body.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/subscribers-body.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { useNavigate, useSearch } from '@wordpress/route';
 import { useImportCompletionRefresh } from '../data/use-import-completion-refresh';
+import { readAddSubscribersHash } from '../lib/add-subscribers-link';
 import { installDataViewsFooterI18n } from '../lib/dataviews-i18n';
 import { getBlogId } from '../lib/site';
 import { isOpenSubscriberRemoved, toFiniteNumber } from '../lib/subscriber-helpers';
@@ -11,8 +12,6 @@ import type { Subscriber } from '../data/types';
 import type { ReactNode } from 'react';
 
 installDataViewsFooterI18n();
-
-const ADD_SUBSCRIBERS_HASH = '#add-subscribers';
 
 type SubscribersSearch = Record< string, unknown > & {
 	subscriber?: string | number;
@@ -58,19 +57,25 @@ export default function SubscribersBody( {
 	// connection-gated users, or on Settings-only sites.
 	useImportCompletionRefresh( importRefreshEnabled );
 
-	const [ isAddOpen, setAddOpen ] = useState( false );
+	// Read the deep link during the first render, not in an effect: the modal
+	// latches its tab when it mounts, and this shell mounts it right away (it
+	// stays mounted, closed, for the life of the page). Setting the tab
+	// afterwards would land on Manual whatever the link asked for.
+	const [ addLink ] = useState( () => readAddSubscribersHash( window.location.hash ) );
+	const [ isAddOpen, setAddOpen ] = useState( addLink.open );
 	const openAdd = useCallback( () => setAddOpen( true ), [] );
 	const closeAdd = useCallback( () => setAddOpen( false ), [] );
 
+	// Strip the hash once it has been honored, so a reload — or a bookmark of
+	// this URL — doesn't reopen the modal.
 	useEffect( () => {
-		if ( window.location.hash !== ADD_SUBSCRIBERS_HASH ) {
+		if ( ! addLink.open ) {
 			return;
 		}
-		setAddOpen( true );
 		const url = new URL( window.location.href );
 		url.hash = '';
 		window.history.replaceState( window.history.state, '', url.toString() );
-	}, [] );
+	}, [ addLink.open ] );
 
 	const navigate = useNavigate();
 	const search = useSearch( {
@@ -124,7 +129,7 @@ export default function SubscribersBody( {
 				onViewSubscriber={ handleViewSubscriber }
 				onSubscribersRemoved={ handleSubscribersRemoved }
 			/>
-			<AddSubscribersModal isOpen={ isAddOpen } onClose={ closeAdd } />
+			<AddSubscribersModal isOpen={ isAddOpen } onClose={ closeAdd } initialTab={ addLink.tab } />
 		</>
 	);
 

--- a/projects/packages/newsletter/_inc/subscribers/lib/add-subscribers-link.ts
+++ b/projects/packages/newsletter/_inc/subscribers/lib/add-subscribers-link.ts
@@ -1,0 +1,60 @@
+import { getAdminUrl } from '@automattic/jetpack-script-data';
+import type { AddSubscribersTab } from '../components/modals/add-subscribers-modal';
+
+const NEWSLETTER_PAGE = 'admin.php?page=jetpack-newsletter';
+const HASH_NAME = 'add-subscribers';
+
+const TABS: AddSubscribersTab[] = [ 'manual', 'upload', 'substack' ];
+const DEFAULT_TAB: AddSubscribersTab = 'manual';
+
+/**
+ * Link to the Subscribers page with the Add Subscribers modal open.
+ *
+ * Deep-linking rather than rendering the modal in place is deliberate on
+ * surfaces outside the Subscribers page: it keeps that page's whole import
+ * stack — react-query, the Dialog/Tabs primitives, csv parsing — out of their
+ * bundles (wp-build ships each route as one IIFE, so a `React.lazy` boundary
+ * would not have split it out), and it shows people where subscriber management
+ * lives for the next time they need it.
+ *
+ * A hash rather than a search param because the Newsletter page is an SPA whose
+ * router packs its own path and search into a single `p` param; the hash rides
+ * alongside untouched, and {@link readAddSubscribersHash} clears it after use.
+ *
+ * @param tab - Which tab to open on. Defaults to Manual.
+ * @return Absolute admin URL.
+ */
+export function getAddSubscribersUrl( tab: AddSubscribersTab = DEFAULT_TAB ): string {
+	return getAdminUrl( `${ NEWSLETTER_PAGE }#${ HASH_NAME }=${ tab }` );
+}
+
+/**
+ * Read an Add Subscribers deep link off a URL hash.
+ *
+ * Accepts the bare `#add-subscribers` as well as `#add-subscribers=<tab>`, so
+ * links written before tabs were addressable keep working.
+ *
+ * @param hash - `window.location.hash`, including the leading `#`.
+ * @return Whether the modal should open, and on which tab.
+ */
+export function readAddSubscribersHash( hash: string ): {
+	open: boolean;
+	tab: AddSubscribersTab;
+} {
+	// Capture any non-empty value rather than a restricted character class, so
+	// that validation against TABS is the single thing deciding the tab. A
+	// narrower pattern would make `=no-such-tab` fail to match at all — not
+	// opening the modal — while `=nope` matched and fell back to Manual.
+	const match = hash.match( new RegExp( `^#${ HASH_NAME }(?:=(.+))?$` ) );
+
+	if ( ! match ) {
+		return { open: false, tab: DEFAULT_TAB };
+	}
+
+	const requested = match[ 1 ] as AddSubscribersTab | undefined;
+
+	return {
+		open: true,
+		tab: requested && TABS.includes( requested ) ? requested : DEFAULT_TAB,
+	};
+}

--- a/projects/packages/newsletter/changelog/add-subscribers-deep-links
+++ b/projects/packages/newsletter/changelog/add-subscribers-deep-links
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Subscribers: Add deep links that open the Add Subscribers modal on a requested tab.

--- a/projects/packages/newsletter/tests/add-subscribers-link.test.ts
+++ b/projects/packages/newsletter/tests/add-subscribers-link.test.ts
@@ -1,0 +1,56 @@
+// The Add Subscribers deep link is a two-ended contract: `getAddSubscribersUrl()`
+// writes it, `SubscribersBody` reads it back. Both ends live in
+// `add-subscribers-link.ts`, so the round trip is what matters here — plus the
+// bare `#add-subscribers` form, which predates tabs being addressable and has
+// to keep working.
+
+jest.mock( '@automattic/jetpack-script-data', () => ( {
+	getAdminUrl: ( path: string ) => `https://example.com/wp-admin/${ path }`,
+} ) );
+
+import {
+	getAddSubscribersUrl,
+	readAddSubscribersHash,
+} from '../_inc/subscribers/lib/add-subscribers-link';
+
+describe( 'Add Subscribers deep link', () => {
+	it.each( [ 'manual', 'upload', 'substack' ] as const )( 'round-trips the %s tab', tab => {
+		const hash = new URL( getAddSubscribersUrl( tab ) ).hash;
+
+		expect( readAddSubscribersHash( hash ) ).toEqual( { open: true, tab } );
+	} );
+
+	it( 'points at the Newsletter admin page', () => {
+		expect( getAddSubscribersUrl( 'upload' ) ).toBe(
+			'https://example.com/wp-admin/admin.php?page=jetpack-newsletter#add-subscribers=upload'
+		);
+	} );
+
+	it( 'defaults to the manual tab', () => {
+		expect( getAddSubscribersUrl() ).toContain( '#add-subscribers=manual' );
+	} );
+
+	it( 'still honors the bare hash written before tabs were addressable', () => {
+		expect( readAddSubscribersHash( '#add-subscribers' ) ).toEqual( {
+			open: true,
+			tab: 'manual',
+		} );
+	} );
+
+	it.each( [ 'nope', 'no-such-tab', 'Upload', 'upload%20csv' ] )(
+		'falls back to the manual tab when the hash names %p, which is not a tab',
+		requested => {
+			expect( readAddSubscribersHash( `#add-subscribers=${ requested }` ) ).toEqual( {
+				open: true,
+				tab: 'manual',
+			} );
+		}
+	);
+
+	it.each( [ '', '#', '#subscribers', '#add-subscribers-modal', '#add-subscribers=' ] )(
+		'does not open for %p',
+		hash => {
+			expect( readAddSubscribersHash( hash ).open ).toBe( false );
+		}
+	);
+} );

--- a/projects/packages/newsletter/tests/subscribers-body-deep-link.test.tsx
+++ b/projects/packages/newsletter/tests/subscribers-body-deep-link.test.tsx
@@ -1,0 +1,105 @@
+// The Add Subscribers deep link only works if `SubscribersBody` acts on what
+// `readAddSubscribersHash()` returns: opens the modal, opens it on the requested
+// tab, and clears the hash afterwards. `add-subscribers-link.test.ts` covers the
+// URL round trip, but every one of those assertions still passes if this wiring
+// is deleted — so the wiring needs its own coverage.
+
+const mockModal = jest.fn();
+
+jest.mock( '@wordpress/route', () => ( {
+	useNavigate: () => jest.fn(),
+	useSearch: () => ( {} ),
+} ) );
+
+jest.mock( '../_inc/subscribers/data/use-import-completion-refresh', () => ( {
+	useImportCompletionRefresh: () => {},
+} ) );
+
+jest.mock( '../_inc/subscribers/lib/dataviews-i18n', () => ( {
+	installDataViewsFooterI18n: () => {},
+} ) );
+
+jest.mock( '../_inc/subscribers/lib/site', () => ( {
+	getBlogId: () => 123,
+} ) );
+
+// Stand-in that records the props it was handed, so the assertions can read
+// `initialTab` without depending on the modal's markup.
+jest.mock( '../_inc/subscribers/components/modals/add-subscribers-modal', () => ( {
+	__esModule: true,
+	default: ( props: Record< string, unknown > ) => {
+		mockModal( props );
+		return null;
+	},
+} ) );
+
+jest.mock( '../_inc/subscribers/components/header-actions', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
+jest.mock( '../_inc/subscribers/components/subscribers-data-views', () => ( {
+	__esModule: true,
+	default: () => null,
+} ) );
+
+// Imports must come after the jest.mock factories above.
+import { render } from '@testing-library/react';
+import SubscribersBody from '../_inc/subscribers/components/subscribers-body';
+
+/**
+ * Render the shell with a given URL hash in place.
+ *
+ * @param hash - The hash to load with, including the leading `#`.
+ */
+function renderWithHash( hash: string ) {
+	window.history.replaceState( {}, '', `/wp-admin/admin.php?page=jetpack-newsletter${ hash }` );
+
+	render(
+		<SubscribersBody importRefreshEnabled={ false }>{ ( { body } ) => body }</SubscribersBody>
+	);
+}
+
+/**
+ * The props the modal was last rendered with.
+ *
+ * @return The recorded props.
+ */
+function lastModalProps(): Record< string, unknown > {
+	return mockModal.mock.calls[ mockModal.mock.calls.length - 1 ][ 0 ];
+}
+
+describe( 'Add Subscribers deep link wiring', () => {
+	beforeEach( () => {
+		mockModal.mockClear();
+	} );
+
+	it( 'opens the modal on the tab the hash asked for', () => {
+		renderWithHash( '#add-subscribers=upload' );
+
+		expect( lastModalProps() ).toEqual(
+			expect.objectContaining( { isOpen: true, initialTab: 'upload' } )
+		);
+	} );
+
+	it( 'opens on Manual for the bare hash', () => {
+		renderWithHash( '#add-subscribers' );
+
+		expect( lastModalProps() ).toEqual(
+			expect.objectContaining( { isOpen: true, initialTab: 'manual' } )
+		);
+	} );
+
+	it( 'clears the hash once it has been honored, so a reload does not reopen it', () => {
+		renderWithHash( '#add-subscribers=upload' );
+
+		expect( window.location.hash ).toBe( '' );
+	} );
+
+	it( 'stays closed without the hash, and leaves an unrelated hash alone', () => {
+		renderWithHash( '#something-else' );
+
+		expect( lastModalProps() ).toEqual( expect.objectContaining( { isOpen: false } ) );
+		expect( window.location.hash ).toBe( '#something-else' );
+	} );
+} );


### PR DESCRIPTION
## Proposed changes
* Add Subscribers can now be deep-linked to a specific tab. A `#add-subscribers=<tab>` hash on the Newsletter page opens the modal on that tab (Manual, Upload CSV, or Substack); the bare `#add-subscribers` form used before tabs were addressable still works and opens on Manual.
* The hash is read during the first render rather than in an effect — the modal latches its tab on mount, and the Subscribers shell keeps it mounted-but-closed for the life of the page, so setting the tab afterwards would always land on Manual.
* The hash is stripped once honoured, so a reload or a bookmark of that URL doesn't reopen the modal.

`getAddSubscribersUrl()` is exported here but has no caller yet — the surfaces that link to it arrive in a later PR. Shipping the link builder alongside the reader keeps the two ends of the contract, and their round-trip test, together.

This is one of a series of PRs splitting up #50680 (a proof of concept, not for merge). It stands alone and is not gated behind any feature flag.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Go to Jetpack → Newsletter → Subscribers.
* Visit `.../admin.php?page=jetpack-newsletter#add-subscribers=upload` — the Add Subscribers modal should open on **Upload CSV**, and the hash should disappear from the address bar.
* Repeat with `=manual` and `=substack`.
* Visit the bare `.../admin.php?page=jetpack-newsletter#add-subscribers` — should open on **Manual**.
* Visit `#add-subscribers=nope` — should open on **Manual** rather than erroring.
* Reload after the modal opens — it should stay closed.
* `jp test js packages/newsletter` covers the URL round trip.