### PR TITLE
Premium Analytics: load widget translation catalogs only for the widgets on screen, and free stalled download slots

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-jetpack-2095-i18n-catalog-scope-and-slot-leak
+++ b/projects/packages/premium-analytics/changelog/fix-jetpack-2095-i18n-catalog-scope-and-slot-leak
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Keep widget translation catalog downloads off the dashboard's initial render, loading the widgets on screen first and the rest of the registry once the page is idle.

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -53,9 +53,11 @@ function Dashboard(): JSX.Element {
 
 	// Only the widgets this section renders need their metadata resolved at
 	// boot; the complete registry is what the widget picker lists, so it can
-	// wait for edit mode. See `useWidgetTypesWithI18n`.
+	// wait for edit mode. `null` until the sections resolve — the layout is
+	// empty until then, and this hook runs on those renders too, below the
+	// spinner returned further down. See `useWidgetTypesWithI18n`.
 	const [ widgetTypes, isResolvingWidgetTypes ] = useWidgetTypesWithI18n( widgetModules, {
-		visibleNames: layout.map( widget => widget.type ),
+		visibleNames: hasResolvedSections ? layout.map( widget => widget.type ) : null,
 		includeAll: editMode,
 	} );
 

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -49,9 +49,15 @@ function Dashboard(): JSX.Element {
 		[]
 	);
 
-	const [ widgetTypes, isResolvingWidgetTypes ] = useWidgetTypesWithI18n( widgetModules );
-
 	const [ editMode, setEditMode ] = useState( false );
+
+	// Only the widgets this section renders need their metadata resolved at
+	// boot; the complete registry is what the widget picker lists, so it can
+	// wait for edit mode. See `useWidgetTypesWithI18n`.
+	const [ widgetTypes, isResolvingWidgetTypes ] = useWidgetTypesWithI18n( widgetModules, {
+		visibleNames: layout.map( widget => widget.type ),
+		includeAll: editMode,
+	} );
 
 	/*
 	 * Date-range state lives in the URL search params. The shared controller

--- a/projects/packages/premium-analytics/routes/widget-module-i18n.ts
+++ b/projects/packages/premium-analytics/routes/widget-module-i18n.ts
@@ -264,5 +264,13 @@ export function useWidgetTypesWithI18n(
 		gatedRecords = readyRecords === scopedRecords ? scopedRecords : null;
 	}
 
-	return useWidgetTypes( gatedRecords );
+	const [ types, resolving ] = useWidgetTypes( gatedRecords );
+	// The gate closes during render — a render-phase `setNeededNames` widens the
+	// scope, which yields a new `scopedRecords` array the same pass — but
+	// `useWidgetTypes` only raises its own flag from an effect, one commit
+	// later. That commit in between reports the previous section's types as
+	// resolved, and the host renders every widget it cannot find in them as
+	// "Missing widget" rather than as loading. A closed gate is itself the
+	// answer: records are being withheld, so resolution has not finished.
+	return [ types, resolving || gatedRecords === null ] as const;
 }

--- a/projects/packages/premium-analytics/routes/widget-module-i18n.ts
+++ b/projects/packages/premium-analytics/routes/widget-module-i18n.ts
@@ -49,6 +49,41 @@ const TEXT_DOMAIN = 'jetpack-premium-analytics-pkg';
 const METADATA_CATALOG_TIMEOUT_MS = 15000;
 
 /**
+ * How long the registry warm-up will wait for an idle moment before running
+ * anyway. Long enough for the dashboard's own data requests to get away first,
+ * short enough that the registry is warm well before anyone opens the widget
+ * picker.
+ */
+const REGISTRY_WARM_TIMEOUT_MS = 5000;
+
+/**
+ * Delay used to approximate an idle moment where `requestIdleCallback` is
+ * unavailable (Safari before 16.4, jsdom).
+ */
+const REGISTRY_WARM_FALLBACK_MS = 2000;
+
+/**
+ * Run a callback once the page goes idle.
+ *
+ * @param callback - Work to run.
+ * @return Cancels the scheduled callback.
+ */
+function onIdle( callback: () => void ): () => void {
+	const scheduler = globalThis as typeof globalThis & {
+		requestIdleCallback?: ( cb: () => void, options?: { timeout: number } ) => number;
+		cancelIdleCallback?: ( handle: number ) => void;
+	};
+	if ( typeof scheduler.requestIdleCallback === 'function' ) {
+		const handle = scheduler.requestIdleCallback( callback, {
+			timeout: REGISTRY_WARM_TIMEOUT_MS,
+		} );
+		return () => scheduler.cancelIdleCallback?.( handle );
+	}
+	const handle = setTimeout( callback, REGISTRY_WARM_FALLBACK_MS );
+	return () => clearTimeout( handle );
+}
+
+/**
  * Widget script-module ids as registered by `build/widgets.php`:
  * `jetpack-premium-analytics/widgets/{widget-dir-name}/render` and
  * `…/widget`. The corresponding bundles land at
@@ -160,6 +195,12 @@ export interface UseWidgetTypesWithI18nOptions {
  * `useWidgetTypes` keeps its previous types while re-resolving, and the host
  * consults `isResolving` only for widgets whose type it cannot find.
  *
+ * Scoping defers those requests rather than dropping them: once the widgets on
+ * screen have resolved, the rest of the registry's catalogs are downloaded on
+ * the next idle callback. The widget picker renders the registry it is given
+ * with no loading state of its own, so it must never be the thing waiting on a
+ * download — but nothing it lists needs to be on the boot critical path.
+ *
  * Once `@wordpress/widget-primitives` resolves widget metadata lazily per
  * rendered widget (JETPACK-2095), this scoping and the gate can both go.
  *
@@ -253,6 +294,36 @@ export function useWidgetTypesWithI18n(
 			cancelled = true;
 		};
 	}, [ scopedRecords ] );
+
+	// The widget picker lists the complete registry and has no loading state of
+	// its own — it renders whatever types the dashboard hands it, with a count
+	// to match — so a registry still widening when edit mode opens briefly
+	// shows a silently incomplete gallery. Warming the rest of the catalogs
+	// once the page is idle keeps them off the boot critical path while leaving
+	// `includeAll` a microtask of already-downloaded catalogs: the loader keys
+	// its downloads by bundle path, so the gated preload adopts the promise
+	// this one started rather than re-requesting.
+	useEffect( () => {
+		if ( ! isScoped || resolveAll || ! records || records.length === 0 ) {
+			return;
+		}
+		// Nothing was scoped away, so there is nothing left to warm.
+		if ( scopedRecords === records ) {
+			return;
+		}
+		// Wait for the widgets on screen to finish. Warming earlier would queue
+		// the whole registry into the same concurrency-limited download queue
+		// they are draining, putting the visible grid behind the invisible
+		// registry — the inversion this scoping exists to prevent.
+		if ( readyRecords !== scopedRecords ) {
+			return;
+		}
+		return onIdle( () => {
+			// Failures already fall back to English inside the preload; nothing
+			// here waits on the result, so a rejection has nowhere to go.
+			preloadWidgetModuleCatalogs( records ).catch( () => undefined );
+		} );
+	}, [ isScoped, resolveAll, records, scopedRecords, readyRecords ] );
 
 	// Gate by identity: only the exact records array whose preload finished is
 	// handed over, so a records update closes the gate until its own preload

--- a/projects/packages/premium-analytics/routes/widget-module-i18n.ts
+++ b/projects/packages/premium-analytics/routes/widget-module-i18n.ts
@@ -20,7 +20,7 @@
  * External dependencies
  */
 import { loadBundleI18nCatalog } from '@automattic/jetpack-wp-build-polyfills/src/js/load-i18n-catalogs';
-import { useEffect, useState } from '@wordpress/element';
+import { useEffect, useMemo, useState } from '@wordpress/element';
 import { useWidgetTypes } from '@wordpress/widget-primitives';
 import type {
 	ResolveWidgetModule,
@@ -116,28 +116,129 @@ export function preloadWidgetModuleCatalogs( records: WidgetModuleRecord[] ): Pr
 }
 
 /**
- * `useWidgetTypes`, gated on the records' translation catalogs.
+ * Options narrowing which records `useWidgetTypesWithI18n` resolves.
+ */
+export interface UseWidgetTypesWithI18nOptions {
+	/**
+	 * Widget type names the active layout renders. Only these records are
+	 * resolved — and only their catalogs downloaded — until `includeAll` turns
+	 * on. Three states, because "the layout is empty" and "the layout has not
+	 * loaded yet" must not be treated alike:
+	 *
+	 * - `undefined` — the caller does no scoping; resolve every record.
+	 * - `null` — the caller scopes, but its layout has not resolved yet.
+	 * - `string[]` — the names on screen; `[]` means genuinely nothing.
+	 *
+	 * The `null` state matters because hooks cannot be skipped: a caller that
+	 * renders a spinner until its layout arrives still calls this hook on those
+	 * renders, and treating that as an empty layout would preload the whole
+	 * registry before the layout could ever narrow it.
+	 */
+	visibleNames?: string[] | null;
+	/**
+	 * Resolve every record regardless of `visibleNames`. Latches: once true,
+	 * the registry stays complete for the life of the page.
+	 */
+	includeAll?: boolean;
+}
+
+/**
+ * `useWidgetTypes`, gated on the records' translation catalogs and scoped to
+ * the widgets on screen.
  *
  * `useWidgetTypes` imports every record's `widget.js` metadata module, which
  * evaluates `__()` at module scope — so the records are handed over only once
  * their catalogs are installed. Until then the hook reports resolving, same
  * as while the records themselves are still loading.
  *
+ * Because that import is eager and has no resolver seam, handing over the full
+ * record set puts one catalog request per registered widget on the boot
+ * critical path. `options.visibleNames` narrows the set to the widgets the
+ * active layout renders; `options.includeAll` widens it back out when the
+ * complete registry is needed, which in practice means when the widget picker
+ * mounts in edit mode. Widening cannot disturb what is already on screen:
+ * `useWidgetTypes` keeps its previous types while re-resolving, and the host
+ * consults `isResolving` only for widgets whose type it cannot find.
+ *
+ * Once `@wordpress/widget-primitives` resolves widget metadata lazily per
+ * rendered widget (JETPACK-2095), this scoping and the gate can both go.
+ *
  * @param records - Host-supplied records, or `null`/`undefined` while loading.
+ * @param options - Scoping options; omit to resolve every record.
  * @return The resolved widget types and whether resolution is still in progress.
  */
 export function useWidgetTypesWithI18n(
-	records: WidgetModuleRecord[] | null | undefined
+	records: WidgetModuleRecord[] | null | undefined,
+	options: UseWidgetTypesWithI18nOptions = {}
 ): readonly [ WidgetType[], boolean ] {
+	const { visibleNames, includeAll = false } = options;
+
+	const isScoped = visibleNames !== undefined;
+	const layoutKnown = Array.isArray( visibleNames );
+	// Keyed on the names themselves rather than the array, so a caller that
+	// builds `visibleNames` inline on every render does not restart resolution.
+	const visibleKey = layoutKnown ? [ ...visibleNames ].sort().join( '\n' ) : null;
+
+	const [ neededNames, setNeededNames ] = useState< ReadonlySet< string > >(
+		() => new Set< string >()
+	);
+	const [ seenVisibleKey, setSeenVisibleKey ] = useState< string | null >( null );
+	const [ resolveAll, setResolveAll ] = useState( includeAll );
+
+	// Adjusted during render, not in an effect: an effect would leave the first
+	// render scoped to an empty set, which falls back to every record below and
+	// would start the very preload this scoping exists to avoid. React discards
+	// the render that schedules these and re-runs immediately, so no effect of
+	// this component runs against the stale values.
+	if ( visibleKey !== null && visibleKey !== seenVisibleKey ) {
+		setSeenVisibleKey( visibleKey );
+		setNeededNames( current => {
+			const names = visibleKey === '' ? [] : visibleKey.split( '\n' );
+			if ( names.every( name => current.has( name ) ) ) {
+				return current;
+			}
+			// Grows only: a section the user has already visited must not drop
+			// back to a loading state when they return to it.
+			return new Set( [ ...current, ...names ] );
+		} );
+	}
+	if ( includeAll && ! resolveAll ) {
+		setResolveAll( true );
+	}
+
+	const scopedRecords = useMemo( () => {
+		if ( ! records || records.length === 0 || resolveAll || ! isScoped ) {
+			return records;
+		}
+		if ( ! layoutKnown ) {
+			// Resolve nothing until the caller's layout arrives. Falling through
+			// to the empty-scope branch below would preload the whole registry
+			// on the renders before the layout could ever narrow it — which is
+			// every load, since hooks run even while the caller renders a
+			// spinner.
+			return null;
+		}
+		const subset = records.filter( record => neededNames.has( record.name ) );
+		// A settled but empty layout means nothing is on screen to protect —
+		// and the dashboard force-opens edit mode in that state, where the full
+		// registry is needed anyway. Handing over an empty array instead would
+		// report "resolved, no types" and render every layout widget as missing
+		// rather than loading.
+		return subset.length > 0 ? subset : records;
+		// No `visibleKey` dependency: the names live in `neededNames`, whose
+		// identity changes exactly when the set grew. A layout that only loses
+		// names leaves the scope alone, which is the cumulative behaviour.
+	}, [ records, resolveAll, isScoped, layoutKnown, neededNames ] );
+
 	const [ readyRecords, setReadyRecords ] = useState< WidgetModuleRecord[] | null >( null );
 
 	useEffect( () => {
-		if ( ! records || records.length === 0 ) {
+		if ( ! scopedRecords || scopedRecords.length === 0 ) {
 			// Nothing to preload; these records pass straight through below.
 			return;
 		}
 		let cancelled = false;
-		preloadWidgetModuleCatalogs( records )
+		preloadWidgetModuleCatalogs( scopedRecords )
 			// Defensive: every failure path inside the preload already falls
 			// back to English on its own, so this should not fire. If one ever
 			// escapes, open the gate anyway — an untranslated grid beats one
@@ -145,22 +246,22 @@ export function useWidgetTypesWithI18n(
 			.catch( () => undefined )
 			.then( () => {
 				if ( ! cancelled ) {
-					setReadyRecords( records );
+					setReadyRecords( scopedRecords );
 				}
 			} );
 		return () => {
 			cancelled = true;
 		};
-	}, [ records ] );
+	}, [ scopedRecords ] );
 
 	// Gate by identity: only the exact records array whose preload finished is
 	// handed over, so a records update closes the gate until its own preload
 	// completes — and loading/empty records need no state round-trip at all.
 	let gatedRecords: WidgetModuleRecord[] | null;
-	if ( ! records || records.length === 0 ) {
-		gatedRecords = records ?? null;
+	if ( ! scopedRecords || scopedRecords.length === 0 ) {
+		gatedRecords = scopedRecords ?? null;
 	} else {
-		gatedRecords = readyRecords === records ? records : null;
+		gatedRecords = readyRecords === scopedRecords ? scopedRecords : null;
 	}
 
 	return useWidgetTypes( gatedRecords );

--- a/projects/packages/premium-analytics/routes/widget-module-i18n.ts
+++ b/projects/packages/premium-analytics/routes/widget-module-i18n.ts
@@ -63,6 +63,18 @@ const REGISTRY_WARM_TIMEOUT_MS = 5000;
 const REGISTRY_WARM_FALLBACK_MS = 2000;
 
 /**
+ * How many catalog downloads the background registry warm-up keeps in flight.
+ *
+ * Deliberately below the loader's six-slot concurrency cap. The queue is shared
+ * and FIFO, so anything the warm-up has queued delays a download requested
+ * after it — including a widget's own `render.js` catalog, which blocks that
+ * widget's import and carries a bound that counts its queue wait. Holding at
+ * most this many slots leaves the rest free, so such a download starts
+ * immediately rather than waiting out the registry.
+ */
+const WARM_BATCH_SIZE = 3;
+
+/**
  * Run a callback once the page goes idle.
  *
  * @param callback - Work to run.
@@ -132,22 +144,67 @@ export function resolveWidgetModuleWithI18n(
 }
 
 /**
+ * Metadata (`widget.js`) bundle paths for a set of widget records, skipping
+ * records with no widget module and ids that are not widget modules.
+ *
+ * @param records - Widget module records from the `/widget-modules` REST route.
+ * @return The package-relative bundle paths, in record order.
+ */
+function metadataBundlePaths( records: WidgetModuleRecord[] ): string[] {
+	return records
+		.map( record =>
+			record.widget_module ? widgetModuleBundlePath( record.widget_module ) : null
+		)
+		.filter( ( bundlePath ): bundlePath is string => bundlePath !== null );
+}
+
+/**
  * Install the metadata (`widget.js`) catalogs for a set of widget records.
+ *
+ * Requests everything at once: every caller of this has someone waiting on it —
+ * the registry gate, or the widget picker behind `includeAll` — so it takes the
+ * download queue at full width. Background work goes through
+ * `warmWidgetModuleCatalogs` instead.
  *
  * @param records - Widget module records from the `/widget-modules` REST route.
  * @return Resolves once every catalog is installed (or has fallen back to English).
  */
 export function preloadWidgetModuleCatalogs( records: WidgetModuleRecord[] ): Promise< void > {
 	return Promise.all(
-		records.map( record => {
-			const bundlePath = record.widget_module
-				? widgetModuleBundlePath( record.widget_module )
-				: null;
-			return bundlePath
-				? loadBundleI18nCatalog( TEXT_DOMAIN, bundlePath, METADATA_CATALOG_TIMEOUT_MS )
-				: Promise.resolve();
-		} )
+		metadataBundlePaths( records ).map( bundlePath =>
+			loadBundleI18nCatalog( TEXT_DOMAIN, bundlePath, METADATA_CATALOG_TIMEOUT_MS )
+		)
 	).then( () => undefined );
+}
+
+/**
+ * Install the metadata catalogs for a set of widget records as background work,
+ * keeping at most `WARM_BATCH_SIZE` downloads in flight.
+ *
+ * Nothing awaits this, so it must not cost anything that is awaited. The
+ * loader's queue is shared and FIFO: submitting the whole registry at once
+ * would leave a widget's own `render.js` catalog — requested when the widget
+ * mounts, with a caller blocked on it — queued behind dozens of downloads
+ * nobody is waiting for, tripping its own bound and rendering the widget in
+ * English. Batching below the queue's width keeps free slots, so those
+ * downloads start immediately instead of queueing.
+ *
+ * @param records - Widget module records from the `/widget-modules` REST route.
+ * @return Resolves once every catalog is installed (or has fallen back to English).
+ */
+export async function warmWidgetModuleCatalogs( records: WidgetModuleRecord[] ): Promise< void > {
+	const bundlePaths = metadataBundlePaths( records );
+	for ( let index = 0; index < bundlePaths.length; index += WARM_BATCH_SIZE ) {
+		// Sequential on purpose — the whole point is to not have the next batch
+		// sitting in the queue while this one drains.
+		await Promise.all(
+			bundlePaths
+				.slice( index, index + WARM_BATCH_SIZE )
+				.map( bundlePath =>
+					loadBundleI18nCatalog( TEXT_DOMAIN, bundlePath, METADATA_CATALOG_TIMEOUT_MS )
+				)
+		);
+	}
 }
 
 /**
@@ -197,9 +254,11 @@ export interface UseWidgetTypesWithI18nOptions {
  *
  * Scoping defers those requests rather than dropping them: once the widgets on
  * screen have resolved, the rest of the registry's catalogs are downloaded on
- * the next idle callback. The widget picker renders the registry it is given
- * with no loading state of its own, so it must never be the thing waiting on a
- * download — but nothing it lists needs to be on the boot critical path.
+ * the next idle callback, a few at a time so the shared download queue keeps
+ * free slots for anything a caller is actually blocked on. The widget picker
+ * renders the registry it is given with no loading state of its own, so it must
+ * never be the thing waiting on a download — but nothing it lists needs to be
+ * on the boot critical path.
  *
  * Once `@wordpress/widget-primitives` resolves widget metadata lazily per
  * rendered widget (JETPACK-2095), this scoping and the gate can both go.
@@ -322,7 +381,7 @@ export function useWidgetTypesWithI18n(
 		return onIdle( () => {
 			// Failures already fall back to English inside the preload; nothing
 			// here waits on the result, so a rejection has nowhere to go.
-			preloadWidgetModuleCatalogs( records ).catch( () => undefined );
+			warmWidgetModuleCatalogs( records ).catch( () => undefined );
 		} );
 	}, [ isScoped, resolveAll, records, scopedRecords, readyRecords ] );
 

--- a/projects/packages/premium-analytics/routes/widget-module-i18n.ts
+++ b/projects/packages/premium-analytics/routes/widget-module-i18n.ts
@@ -259,13 +259,14 @@ export function useWidgetTypesWithI18n(
 			// spinner.
 			return null;
 		}
-		const subset = records.filter( record => neededNames.has( record.name ) );
-		// A settled but empty layout means nothing is on screen to protect —
-		// and the dashboard force-opens edit mode in that state, where the full
-		// registry is needed anyway. Handing over an empty array instead would
-		// report "resolved, no types" and render every layout widget as missing
-		// rather than loading.
-		return subset.length > 0 ? subset : records;
+		// An empty scope resolves nothing, which is what `[]` means. Falling
+		// back to the full record set here — on the theory that an empty
+		// dashboard force-opens edit mode and needs the registry anyway — made
+		// the scoping collapse whenever a layout was empty for a single render,
+		// putting every catalog back on the boot critical path
+		// non-deterministically. `includeAll` already covers the genuinely
+		// empty dashboard, one render later and without the boot cost.
+		return records.filter( record => neededNames.has( record.name ) );
 		// No `visibleKey` dependency: the names live in `neededNames`, whose
 		// identity changes exactly when the set grew. A layout that only loses
 		// names leaves the scope alone, which is the cumulative behaviour.

--- a/projects/packages/premium-analytics/tests/js/widget-module-i18n.test.tsx
+++ b/projects/packages/premium-analytics/tests/js/widget-module-i18n.test.tsx
@@ -469,6 +469,95 @@ describe( 'useWidgetTypesWithI18n', () => {
 	} );
 
 	describe( 'registry warm-up', () => {
+		// Enough records that a batched warm-up is distinguishable from an
+		// all-at-once one.
+		const MANY_RECORDS = Array.from( { length: 7 }, ( _, index ) => ( {
+			name: `jpa/w${ index }`,
+			widget_module: `jetpack-premium-analytics/widgets/w${ index }/widget`,
+			render_module: `jetpack-premium-analytics/widgets/w${ index }/render`,
+		} ) ) as WidgetModuleRecord[];
+
+		/**
+		 * Let pending promise chains and timers run.
+		 *
+		 * @return Resolves on the next macrotask.
+		 */
+		function flush(): Promise< void > {
+			return new Promise( resolve => {
+				setTimeout( resolve, 0 );
+			} );
+		}
+
+		/**
+		 * Make catalog loads hang, recording how many are in flight at once.
+		 *
+		 * @return The in-flight tracker and a release for the pending loads.
+		 */
+		function trackInFlight() {
+			let inFlight = 0;
+			const tracker = { max: 0 };
+			let pending: Array< () => void > = [];
+			loadCatalogMock.mockImplementation(
+				() =>
+					new Promise< void >( resolve => {
+						inFlight++;
+						tracker.max = Math.max( tracker.max, inFlight );
+						pending.push( () => {
+							inFlight--;
+							resolve();
+						} );
+					} )
+			);
+			return {
+				tracker,
+				releaseAll: () => {
+					const settling = pending;
+					pending = [];
+					settling.forEach( release => release() );
+				},
+			};
+		}
+
+		it( 'never holds more than half the download slots while warming', async () => {
+			// The loader's queue is shared and FIFO, so a warm-up that submits
+			// the whole registry at once leaves a widget's own render catalog —
+			// which blocks that widget's import — queued behind downloads
+			// nobody is waiting for, past its own bound. Staying under the
+			// six-slot cap keeps slots free for it.
+			renderHook( () => useWidgetTypesWithI18n( MANY_RECORDS, { visibleNames: [ 'jpa/w0' ] } ) );
+			await waitFor( () => expect( idleCallbacks ).toHaveLength( 1 ) );
+
+			const { tracker, releaseAll } = trackInFlight();
+			const before = requestedBundles().length;
+			runIdleCallbacks();
+
+			for ( let pass = 0; pass < 10 && requestedBundles().length - before < 7; pass++ ) {
+				await flush();
+				releaseAll();
+			}
+			await flush();
+
+			expect( tracker.max ).toBeLessThanOrEqual( 3 );
+			expect( requestedBundles().length - before ).toBe( 7 );
+		} );
+
+		it( 'does not batch the gated preload, which has the picker waiting on it', async () => {
+			const { rerender } = renderHook(
+				( { includeAll }: { includeAll: boolean } ) =>
+					useWidgetTypesWithI18n( MANY_RECORDS, { visibleNames: [ 'jpa/w0' ], includeAll } ),
+				{ initialProps: { includeAll: false } }
+			);
+			await waitFor( () => expect( idleCallbacks ).toHaveLength( 1 ) );
+
+			const { tracker } = trackInFlight();
+			rerender( { includeAll: true } );
+			await flush();
+
+			// Someone is blocked on this one, so it takes the queue at full
+			// width rather than trickling.
+			expect( tracker.max ).toBe( 7 );
+		} );
+
 		it( 'warms the rest of the registry once the widgets on screen have resolved', async () => {
 			renderHook( () => useWidgetTypesWithI18n( SCOPED_RECORDS, { visibleNames: [ 'jpa/b' ] } ) );
 			await waitFor( () => expect( lastRecordsArg() ).not.toBeNull() );

--- a/projects/packages/premium-analytics/tests/js/widget-module-i18n.test.tsx
+++ b/projects/packages/premium-analytics/tests/js/widget-module-i18n.test.tsx
@@ -416,14 +416,42 @@ describe( 'useWidgetTypesWithI18n', () => {
 		expect( requestedBundles() ).toEqual( [ 'build/widgets/b/widget.js' ] );
 	} );
 
-	it( 'falls back to every record when nothing is on screen', async () => {
-		// An empty layout means there is nothing to protect, and the dashboard
-		// force-opens edit mode in that state. Handing over an empty array
-		// instead would report "resolved, no types" and render any layout
-		// widget as missing rather than loading.
-		renderHook( () => useWidgetTypesWithI18n( SCOPED_RECORDS, { visibleNames: [] } ) );
+	it( 'resolves nothing when nothing is on screen, leaving the registry to includeAll', async () => {
+		// A genuinely empty dashboard force-opens edit mode, which turns
+		// `includeAll` on and takes the full registry a render later. Falling
+		// back to every record here instead would put that registry on the boot
+		// critical path for anyone whose layout is empty for even one render.
+		const { rerender } = renderHook(
+			( { includeAll }: { includeAll: boolean } ) =>
+				useWidgetTypesWithI18n( SCOPED_RECORDS, { visibleNames: [], includeAll } ),
+			{ initialProps: { includeAll: false } }
+		);
 
+		await waitFor( () => expect( lastRecordsArg() ).toEqual( [] ) );
+		expect( loadCatalogMock ).not.toHaveBeenCalled();
+
+		rerender( { includeAll: true } );
 		await waitFor( () => expect( lastRecordsArg() ).toBe( SCOPED_RECORDS ) );
+	} );
+
+	it( 'does not preload the whole registry over a layout that is briefly empty', async () => {
+		// The scoping is only worth anything if it holds on every load. A
+		// layout that arrives a render late used to collapse the scope to the
+		// full record set, which is both the boot cost this exists to avoid and
+		// enough queue traffic to push later per-widget catalogs past their own
+		// timeout.
+		const { rerender } = renderHook(
+			( { names }: { names: string[] } ) =>
+				useWidgetTypesWithI18n( SCOPED_RECORDS, { visibleNames: names } ),
+			{ initialProps: { names: [] as string[] } }
+		);
+
+		expect( loadCatalogMock ).not.toHaveBeenCalled();
+
+		rerender( { names: [ 'jpa/b' ] } );
+
+		await waitFor( () => expect( lastRecordsArg() ).toEqual( [ SCOPED_RECORDS[ 1 ] ] ) );
+		expect( requestedBundles() ).toEqual( [ 'build/widgets/b/widget.js' ] );
 	} );
 
 	it( 'keeps the gate closed until the scoped catalogs are installed', async () => {

--- a/projects/packages/premium-analytics/tests/js/widget-module-i18n.test.tsx
+++ b/projects/packages/premium-analytics/tests/js/widget-module-i18n.test.tsx
@@ -37,11 +37,44 @@ function useWidgetTypesSyncStandIn( records: WidgetModuleRecord[] | null | undef
 	return [ [], ! records ];
 }
 
+/**
+ * Idle callbacks the registry warm-up has scheduled, in order. jsdom has no
+ * `requestIdleCallback`, so without this stub the warm-up would fall back to a
+ * real timer and fire after the test that scheduled it had ended.
+ */
+let idleCallbacks: Array< () => void > = [];
+
+const realRequestIdleCallback = globalThis.requestIdleCallback;
+const realCancelIdleCallback = globalThis.cancelIdleCallback;
+
+/**
+ * Run every idle callback scheduled so far.
+ */
+function runIdleCallbacks(): void {
+	const pending = idleCallbacks;
+	idleCallbacks = [];
+	pending.forEach( callback => callback() );
+}
+
 beforeEach( () => {
 	loadCatalogMock.mockClear();
 	loadCatalogMock.mockImplementation( () => Promise.resolve() );
 	useWidgetTypesMock.mockClear();
 	useWidgetTypesMock.mockImplementation( useWidgetTypesSyncStandIn );
+
+	idleCallbacks = [];
+	globalThis.requestIdleCallback = ( ( callback: () => void ) => {
+		idleCallbacks.push( callback );
+		return idleCallbacks.length;
+	} ) as typeof globalThis.requestIdleCallback;
+	globalThis.cancelIdleCallback = ( ( handle: number ) => {
+		idleCallbacks[ handle - 1 ] = () => {};
+	} ) as typeof globalThis.cancelIdleCallback;
+} );
+
+afterEach( () => {
+	globalThis.requestIdleCallback = realRequestIdleCallback;
+	globalThis.cancelIdleCallback = realCancelIdleCallback;
 } );
 
 describe( 'widgetModuleBundlePath', () => {
@@ -405,6 +438,72 @@ describe( 'useWidgetTypesWithI18n', () => {
 
 		releaseCatalogs();
 		await waitFor( () => expect( lastRecordsArg() ).toEqual( [ SCOPED_RECORDS[ 1 ] ] ) );
+	} );
+
+	describe( 'registry warm-up', () => {
+		it( 'warms the rest of the registry once the widgets on screen have resolved', async () => {
+			renderHook( () => useWidgetTypesWithI18n( SCOPED_RECORDS, { visibleNames: [ 'jpa/b' ] } ) );
+			await waitFor( () => expect( lastRecordsArg() ).not.toBeNull() );
+
+			// Boot pays for the widget on screen and nothing else.
+			expect( requestedBundles() ).toEqual( [ 'build/widgets/b/widget.js' ] );
+
+			// The widget picker lists the complete registry with no loading
+			// state of its own, so the catalogs it needs are downloaded before
+			// edit mode can ask for them — just not on the boot critical path.
+			runIdleCallbacks();
+
+			expect( new Set( requestedBundles() ) ).toEqual(
+				new Set( [
+					'build/widgets/a/widget.js',
+					'build/widgets/b/widget.js',
+					'build/widgets/c/widget.js',
+				] )
+			);
+		} );
+
+		it( 'schedules no warm-up until the widgets on screen have resolved', async () => {
+			const releaseCatalogs = holdCatalogs();
+
+			renderHook( () => useWidgetTypesWithI18n( SCOPED_RECORDS, { visibleNames: [ 'jpa/b' ] } ) );
+			await waitFor( () =>
+				expect( requestedBundles() ).toEqual( [ 'build/widgets/b/widget.js' ] )
+			);
+
+			// Warming early would queue the whole registry into the same
+			// concurrency-limited queue the visible widget is draining.
+			expect( idleCallbacks ).toEqual( [] );
+
+			releaseCatalogs();
+			await waitFor( () => expect( idleCallbacks ).toHaveLength( 1 ) );
+		} );
+
+		it( 'schedules no warm-up for a caller that does not scope', async () => {
+			renderHook( () => useWidgetTypesWithI18n( RECORDS ) );
+
+			await waitFor( () => expect( lastRecordsArg() ).toBe( RECORDS ) );
+			// Nothing was held back, so there is nothing left to warm.
+			expect( idleCallbacks ).toEqual( [] );
+		} );
+
+		it( 'cancels a pending warm-up when includeAll takes over', async () => {
+			const { rerender } = renderHook(
+				( { includeAll }: { includeAll: boolean } ) =>
+					useWidgetTypesWithI18n( SCOPED_RECORDS, { visibleNames: [ 'jpa/b' ], includeAll } ),
+				{ initialProps: { includeAll: false } }
+			);
+			await waitFor( () => expect( idleCallbacks ).toHaveLength( 1 ) );
+
+			rerender( { includeAll: true } );
+			await waitFor( () => expect( lastRecordsArg() ).toBe( SCOPED_RECORDS ) );
+			runIdleCallbacks();
+
+			// `includeAll` preloads the full registry itself; the warm-up must
+			// not fire a second, redundant pass behind it.
+			expect(
+				loadCatalogMock.mock.calls.filter( call => call[ 1 ] === 'build/widgets/a/widget.js' )
+			).toHaveLength( 1 );
+		} );
 	} );
 
 	describe( 'with useWidgetTypes timed the way upstream times it', () => {

--- a/projects/packages/premium-analytics/tests/js/widget-module-i18n.test.tsx
+++ b/projects/packages/premium-analytics/tests/js/widget-module-i18n.test.tsx
@@ -1,5 +1,6 @@
 import { loadBundleI18nCatalog } from '@automattic/jetpack-wp-build-polyfills/src/js/load-i18n-catalogs';
 import { renderHook, waitFor } from '@testing-library/react';
+import { useEffect, useState } from '@wordpress/element';
 import { useWidgetTypes } from '@wordpress/widget-primitives';
 import {
 	preloadWidgetModuleCatalogs,
@@ -16,24 +17,31 @@ jest.mock( '@automattic/jetpack-wp-build-polyfills/src/js/load-i18n-catalogs', (
 } ) );
 
 jest.mock( '@wordpress/widget-primitives', () => ( {
-	// Synchronous stand-in for the real hook, which resolves its metadata
-	// imports asynchronously and so reports `isResolving` on first render no
-	// matter what it was handed. Resolving immediately for any non-null
-	// argument leaves the gate as the only thing that can keep the hook
-	// resolving, which is what these tests are here to check.
-	useWidgetTypes: jest.fn( ( records: WidgetModuleRecord[] | null | undefined ) => [
-		[],
-		! records,
-	] ),
+	useWidgetTypes: jest.fn(),
 } ) );
 
 const loadCatalogMock = loadBundleI18nCatalog as jest.Mock;
 const useWidgetTypesMock = useWidgetTypes as jest.Mock;
 
+/**
+ * Synchronous stand-in for the real hook, which resolves its metadata imports
+ * asynchronously and so reports `isResolving` on first render no matter what
+ * it was handed. Resolving immediately for any non-null argument leaves the
+ * gate as the only thing that can keep the hook resolving, which is what most
+ * of these tests are here to check.
+ *
+ * @param records - The records handed to the hook.
+ * @return The resolved types and whether resolution is in progress.
+ */
+function useWidgetTypesSyncStandIn( records: WidgetModuleRecord[] | null | undefined ) {
+	return [ [], ! records ];
+}
+
 beforeEach( () => {
 	loadCatalogMock.mockClear();
 	loadCatalogMock.mockImplementation( () => Promise.resolve() );
 	useWidgetTypesMock.mockClear();
+	useWidgetTypesMock.mockImplementation( useWidgetTypesSyncStandIn );
 } );
 
 describe( 'widgetModuleBundlePath', () => {
@@ -397,5 +405,99 @@ describe( 'useWidgetTypesWithI18n', () => {
 
 		releaseCatalogs();
 		await waitFor( () => expect( lastRecordsArg() ).toEqual( [ SCOPED_RECORDS[ 1 ] ] ) );
+	} );
+
+	describe( 'with useWidgetTypes timed the way upstream times it', () => {
+		/**
+		 * A stand-in that flips its flags from an effect, exactly as the real
+		 * `useWidgetTypes` does. The synchronous stand-in above cannot see the
+		 * frame these tests cover: upstream keeps reporting the *previous*
+		 * records as resolved for one commit after the gate closes, because the
+		 * gate closes during render and the flag only moves an effect later.
+		 *
+		 * @param records - The records handed to the hook.
+		 * @return The resolved types and whether resolution is in progress.
+		 */
+		function useWidgetTypesLikeUpstream( records: WidgetModuleRecord[] | null | undefined ) {
+			const [ types, setTypes ] = useState< Array< { name: string } > >( [] );
+			const [ resolving, setResolving ] = useState( true );
+			useEffect( () => {
+				if ( ! records ) {
+					setResolving( true );
+					return;
+				}
+				let cancelled = false;
+				setResolving( true );
+				Promise.resolve().then( () => {
+					if ( ! cancelled ) {
+						setTypes( records.map( record => ( { name: record.name } ) ) );
+						setResolving( false );
+					}
+				} );
+				return () => {
+					cancelled = true;
+				};
+			}, [ records ] );
+			return [ types, resolving ];
+		}
+
+		/**
+		 * Render the hook, recording every committed `[ type names, resolving ]`
+		 * frame.
+		 *
+		 * @param names - The initial `visibleNames`.
+		 * @return The recorded frames and a rerender that changes `visibleNames`.
+		 */
+		function renderRecordingFrames( names: string[] ) {
+			useWidgetTypesMock.mockImplementation( useWidgetTypesLikeUpstream );
+			const frames: Array< [ string[], boolean ] > = [];
+			const { rerender } = renderHook(
+				( props: { names: string[] } ) => {
+					const value = useWidgetTypesWithI18n( SCOPED_RECORDS, {
+						visibleNames: props.names,
+					} );
+					// No dependency array, so this records every commit — and
+					// only commits: a render React discards over a render-phase
+					// state update never runs its effects.
+					useEffect( () => {
+						frames.push( [ value[ 0 ].map( type => type.name ), value[ 1 ] ] );
+					} );
+					return value;
+				},
+				{ initialProps: { names } }
+			);
+			return { frames, rerender };
+		}
+
+		it( 'never reports resolved with a stale type set while a section switch resolves', async () => {
+			const { frames, rerender } = renderRecordingFrames( [ 'jpa/a' ] );
+			await waitFor( () => expect( frames.at( -1 ) ).toEqual( [ [ 'jpa/a' ], false ] ) );
+
+			frames.length = 0;
+			rerender( { names: [ 'jpa/b' ] } );
+			await waitFor( () => expect( frames.at( -1 ) ).toEqual( [ [ 'jpa/a', 'jpa/b' ], false ] ) );
+
+			// The gate closes during the render that widens the scope, but
+			// `useWidgetTypes` only raises its own flag an effect later. A
+			// committed frame that claims "resolved" while the incoming
+			// section's type is still missing is the frame the dashboard
+			// renders as a "Missing widget" placeholder.
+			expect(
+				frames.filter( ( [ typeNames, resolving ] ) => {
+					return ! resolving && ! typeNames.includes( 'jpa/b' );
+				} )
+			).toEqual( [] );
+		} );
+
+		it( 'never reports resolved before the first scoped preload finishes', async () => {
+			const { frames } = renderRecordingFrames( [ 'jpa/b' ] );
+			await waitFor( () => expect( frames.at( -1 ) ).toEqual( [ [ 'jpa/b' ], false ] ) );
+
+			expect(
+				frames.filter( ( [ typeNames, resolving ] ) => {
+					return ! resolving && ! typeNames.includes( 'jpa/b' );
+				} )
+			).toEqual( [] );
+		} );
 	} );
 } );

--- a/projects/packages/premium-analytics/tests/js/widget-module-i18n.test.tsx
+++ b/projects/packages/premium-analytics/tests/js/widget-module-i18n.test.tsx
@@ -149,6 +149,33 @@ describe( 'useWidgetTypesWithI18n', () => {
 		},
 	] as WidgetModuleRecord[];
 
+	const SCOPED_RECORDS = [
+		{
+			name: 'jpa/a',
+			widget_module: 'jetpack-premium-analytics/widgets/a/widget',
+			render_module: 'jetpack-premium-analytics/widgets/a/render',
+		},
+		{
+			name: 'jpa/b',
+			widget_module: 'jetpack-premium-analytics/widgets/b/widget',
+			render_module: 'jetpack-premium-analytics/widgets/b/render',
+		},
+		{
+			name: 'jpa/c',
+			widget_module: 'jetpack-premium-analytics/widgets/c/widget',
+			render_module: 'jetpack-premium-analytics/widgets/c/render',
+		},
+	] as WidgetModuleRecord[];
+
+	/**
+	 * Bundle paths passed to the catalog loader so far.
+	 *
+	 * @return The requested bundle paths.
+	 */
+	function requestedBundles(): string[] {
+		return loadCatalogMock.mock.calls.map( ( call: unknown[] ) => call[ 1 ] as string );
+	}
+
 	/**
 	 * The records argument of the most recent `useWidgetTypes` call — what the
 	 * gate has actually handed downstream on the latest render.
@@ -248,5 +275,127 @@ describe( 'useWidgetTypesWithI18n', () => {
 		expect( lastRecordsArg() ).toBe( emptyRecords );
 		expect( result.current ).toEqual( [ [], false ] );
 		expect( loadCatalogMock ).not.toHaveBeenCalled();
+	} );
+
+	it( 'loads catalogs only for the widgets the layout renders', async () => {
+		const { result } = renderHook( () =>
+			useWidgetTypesWithI18n( SCOPED_RECORDS, { visibleNames: [ 'jpa/b' ] } )
+		);
+
+		await waitFor( () => expect( result.current[ 1 ] ).toBe( false ) );
+
+		// A registered-but-not-laid-out widget's metadata catalog is what this
+		// change exists to stop requesting at boot.
+		expect( requestedBundles() ).toEqual( [ 'build/widgets/b/widget.js' ] );
+	} );
+
+	it( 'hands useWidgetTypes only the scoped subset', async () => {
+		renderHook( () => useWidgetTypesWithI18n( SCOPED_RECORDS, { visibleNames: [ 'jpa/b' ] } ) );
+
+		await waitFor( () => expect( lastRecordsArg() ).not.toBeNull() );
+		expect( lastRecordsArg() ).toEqual( [ SCOPED_RECORDS[ 1 ] ] );
+	} );
+
+	it( 'keeps the scoped array stable across renders with an equal visibleNames array', async () => {
+		const { rerender } = renderHook(
+			( { names }: { names: string[] } ) =>
+				useWidgetTypesWithI18n( SCOPED_RECORDS, { visibleNames: names } ),
+			{ initialProps: { names: [ 'jpa/b' ] } }
+		);
+		await waitFor( () => expect( lastRecordsArg() ).not.toBeNull() );
+		const firstScoped = lastRecordsArg();
+
+		// A caller building `visibleNames` inline re-creates the array every
+		// render; that must not restart resolution.
+		rerender( { names: [ 'jpa/b' ] } );
+
+		expect( lastRecordsArg() ).toBe( firstScoped );
+		expect( requestedBundles() ).toEqual( [ 'build/widgets/b/widget.js' ] );
+	} );
+
+	it( 'unions newly visible widgets rather than replacing the scope', async () => {
+		const { rerender } = renderHook(
+			( { names }: { names: string[] } ) =>
+				useWidgetTypesWithI18n( SCOPED_RECORDS, { visibleNames: names } ),
+			{ initialProps: { names: [ 'jpa/a' ] } }
+		);
+		await waitFor( () => expect( lastRecordsArg() ).not.toBeNull() );
+
+		// Switching sections must not drop the previous section's widgets back
+		// into a loading state when the user returns to it.
+		rerender( { names: [ 'jpa/c' ] } );
+
+		await waitFor( () =>
+			expect( lastRecordsArg() ).toEqual( [ SCOPED_RECORDS[ 0 ], SCOPED_RECORDS[ 2 ] ] )
+		);
+		// The second preload re-requests `a` alongside `c`; the real loader
+		// dedupes that, the mock records both. Assert on the distinct set — the
+		// point is that `b` is still never requested.
+		expect( new Set( requestedBundles() ) ).toEqual(
+			new Set( [ 'build/widgets/a/widget.js', 'build/widgets/c/widget.js' ] )
+		);
+	} );
+
+	it( 'expands to every record once includeAll turns on, and stays expanded', async () => {
+		const { rerender } = renderHook(
+			( { includeAll }: { includeAll: boolean } ) =>
+				useWidgetTypesWithI18n( SCOPED_RECORDS, { visibleNames: [ 'jpa/b' ], includeAll } ),
+			{ initialProps: { includeAll: false } }
+		);
+		await waitFor( () => expect( lastRecordsArg() ).not.toBeNull() );
+
+		// WidgetPicker lists the complete registry, so edit mode needs it all.
+		rerender( { includeAll: true } );
+		await waitFor( () => expect( lastRecordsArg() ).toBe( SCOPED_RECORDS ) );
+
+		// Latched: leaving edit mode must not shrink the registry and drop
+		// types the picker has already listed.
+		rerender( { includeAll: false } );
+		expect( lastRecordsArg() ).toBe( SCOPED_RECORDS );
+	} );
+
+	it( 'preloads nothing while the caller has not resolved its layout', async () => {
+		// Hooks cannot be skipped, so a caller that renders a spinner until its
+		// layout arrives still calls this hook meanwhile. Treating that as an
+		// empty layout would fall through to the every-record branch below and
+		// preload the whole registry before the layout could narrow it — which
+		// is what shipped and made the scoping a no-op on every real load.
+		const { rerender } = renderHook(
+			( { names }: { names: string[] | null } ) =>
+				useWidgetTypesWithI18n( SCOPED_RECORDS, { visibleNames: names } ),
+			{ initialProps: { names: null as string[] | null } }
+		);
+
+		expect( lastRecordsArg() ).toBeNull();
+		expect( loadCatalogMock ).not.toHaveBeenCalled();
+
+		rerender( { names: [ 'jpa/b' ] } );
+
+		await waitFor( () => expect( lastRecordsArg() ).toEqual( [ SCOPED_RECORDS[ 1 ] ] ) );
+		expect( requestedBundles() ).toEqual( [ 'build/widgets/b/widget.js' ] );
+	} );
+
+	it( 'falls back to every record when nothing is on screen', async () => {
+		// An empty layout means there is nothing to protect, and the dashboard
+		// force-opens edit mode in that state. Handing over an empty array
+		// instead would report "resolved, no types" and render any layout
+		// widget as missing rather than loading.
+		renderHook( () => useWidgetTypesWithI18n( SCOPED_RECORDS, { visibleNames: [] } ) );
+
+		await waitFor( () => expect( lastRecordsArg() ).toBe( SCOPED_RECORDS ) );
+	} );
+
+	it( 'keeps the gate closed until the scoped catalogs are installed', async () => {
+		const releaseCatalogs = holdCatalogs();
+
+		const { result } = renderHook( () =>
+			useWidgetTypesWithI18n( SCOPED_RECORDS, { visibleNames: [ 'jpa/b' ] } )
+		);
+
+		expect( lastRecordsArg() ).toBeNull();
+		expect( result.current[ 1 ] ).toBe( true );
+
+		releaseCatalogs();
+		await waitFor( () => expect( lastRecordsArg() ).toEqual( [ SCOPED_RECORDS[ 1 ] ] ) );
 	} );
 } );

--- a/projects/packages/wp-build-polyfills/changelog/fix-jetpack-2095-i18n-catalog-scope-and-slot-leak
+++ b/projects/packages/wp-build-polyfills/changelog/fix-jetpack-2095-i18n-catalog-scope-and-slot-leak
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Free a stalled translation-catalog download's concurrency slot so queued downloads still run.

--- a/projects/packages/wp-build-polyfills/src/js/load-i18n-catalogs.ts
+++ b/projects/packages/wp-build-polyfills/src/js/load-i18n-catalogs.ts
@@ -64,6 +64,19 @@ const CATALOG_TIMEOUT_MS = 5000;
 const MAX_CONCURRENT_DOWNLOADS = 6;
 
 /**
+ * How long a download may hold its concurrency slot before the slot is
+ * returned to the pool. `downloadI18n()` awaits a bare `fetch` with no timeout
+ * and takes no `AbortSignal`, so a stalled origin never settles it and the
+ * callers' own bounds unblock only themselves — without this, six stalled
+ * downloads wedge the queue for the rest of the page. Set well above both
+ * caller bounds (5s, and 15s for the metadata preload) so a merely slow origin
+ * never trips it: this bound exists for deadlock-immunity, not responsiveness.
+ * The orphaned request keeps running, so in-flight downloads can transiently
+ * exceed the cap — which only happens once the origin has stopped answering.
+ */
+const SLOT_TIMEOUT_MS = 30000;
+
+/**
  * Bundles whose catalogs are left to on-demand loading: the widget tree, one
  * directory below the build root (`build/widgets/…`). Anchored rather than a
  * bare `/widgets/` substring so a route or module that happens to be *named*
@@ -166,19 +179,48 @@ function sharedState(): SharedCatalogState {
 }
 
 /**
- * Run a download task once a concurrency slot is free.
+ * Run a download task once a concurrency slot is free, releasing the slot when
+ * the task settles or when it has held the slot past `SLOT_TIMEOUT_MS`.
  *
  * @param state - The shared catalog state.
+ * @param path  - Package-relative bundle path, for the watchdog's diagnostic.
  * @param task  - The task to run.
  * @return Resolves/rejects with the task once it has run.
  */
-function throttled( state: SharedCatalogState, task: () => Promise< void > ): Promise< void > {
+function throttled(
+	state: SharedCatalogState,
+	path: string,
+	task: () => Promise< void >
+): Promise< void > {
 	return new Promise( resolve => {
 		const run = () => {
 			state.active++;
-			// `finally` frees the slot on both outcomes; `resolve()` adopts the
-			// task's promise, so a rejection still reaches the caller.
-			resolve( task().finally( () => releaseSlot( state ) ) );
+			let released = false;
+			// Whichever of the two paths fires first frees the slot; the guard
+			// keeps the other from decrementing `active` a second time, which
+			// would let later bursts run over the concurrency cap.
+			const release = () => {
+				if ( released ) {
+					return;
+				}
+				released = true;
+				clearTimeout( watchdog );
+				releaseSlot( state );
+			};
+			const watchdog = setTimeout( () => {
+				warn(
+					`Catalog download for ${ path } has held a slot for ${ SLOT_TIMEOUT_MS }ms; releasing it so queued downloads can proceed.`
+				);
+				release();
+			}, SLOT_TIMEOUT_MS );
+			// Browsers return an opaque handle and stop timers at teardown, but
+			// this module is imported directly under `node --test`, where a
+			// pending timer keeps the process alive — a stalled download would
+			// hold a test run open for the whole timeout. Harmless where absent.
+			( watchdog as unknown as { unref?: () => void } ).unref?.();
+			// `resolve()` adopts the task's promise, so a rejection still
+			// reaches the caller.
+			resolve( task().finally( release ) );
 		};
 		if ( state.active < MAX_CONCURRENT_DOWNLOADS ) {
 			run();
@@ -223,7 +265,7 @@ function downloadOnce(
 	const key = `${ domain }|${ path }`;
 	let download = state.downloads.get( key );
 	if ( ! download ) {
-		download = throttled( state, () => loader.downloadI18n( path, domain, 'plugin' ) ).catch(
+		download = throttled( state, path, () => loader.downloadI18n( path, domain, 'plugin' ) ).catch(
 			( error: unknown ) => {
 				const message = errorMessage( error );
 				if ( ! isMissingCatalog( message ) ) {

--- a/projects/packages/wp-build-polyfills/tests/js/load-i18n-catalogs.test.js
+++ b/projects/packages/wp-build-polyfills/tests/js/load-i18n-catalogs.test.js
@@ -5,7 +5,7 @@
  */
 
 const assert = require( 'node:assert/strict' );
-const { describe, it, beforeEach, afterEach } = require( 'node:test' );
+const { describe, it, beforeEach, afterEach, mock } = require( 'node:test' );
 
 const HELPER = '../../src/js/load-i18n-catalogs.ts';
 
@@ -459,5 +459,84 @@ describe( 'loadBundleI18nCatalog', () => {
 
 		assert.equal( warnings.length, 1 );
 		assert.match( warnings[ 0 ], /still pending after 25ms/ );
+	} );
+} );
+
+describe( 'download slot watchdog', () => {
+	/**
+	 * Let every already-queued microtask and immediate run. `setImmediate` is
+	 * deliberately not among the mocked timer APIs, so it still flushes while
+	 * `setTimeout` is under test control.
+	 *
+	 * @return {Promise} Resolves on the next immediate.
+	 */
+	function flush() {
+		return new Promise( resolve => setImmediate( resolve ) );
+	}
+
+	/**
+	 * The catalog state the helper parks on `window`.
+	 *
+	 * @return {object} The shared state.
+	 */
+	function parkedState() {
+		return globalThis.window.__jetpackWpBuildI18nCatalogs;
+	}
+
+	it( "frees a stalled download's slot so queued downloads still run", async () => {
+		mock.timers.enable( { apis: [ 'setTimeout' ] } );
+		try {
+			// Never settles: the stalled-origin case the watchdog exists for.
+			const calls = installLoader( () => new Promise( () => {} ) );
+			installFetch( {
+				bundles: Array.from( { length: 7 }, ( _, i ) => `build/routes/r${ i }/content.js` ),
+			} );
+			const { loadI18nCatalogs } = await import( HELPER );
+
+			loadI18nCatalogs( 'jetpack-test', MODULE_URL );
+			await flush();
+
+			assert.equal( calls.length, 6, 'the queue starts at the concurrency cap' );
+
+			// Past the slot timeout: the six stalled downloads give their slots
+			// back and the seventh starts.
+			mock.timers.tick( 30000 );
+			await flush();
+
+			assert.equal( calls.length, 7, 'the queued download runs once a slot is freed' );
+			assert.ok(
+				warnings.some( message => message.includes( 'build/routes/r0/content.js' ) ),
+				'the watchdog names the download that held its slot'
+			);
+		} finally {
+			mock.timers.reset();
+		}
+	} );
+
+	it( 'releases each slot exactly once when downloads settle normally', async () => {
+		mock.timers.enable( { apis: [ 'setTimeout' ] } );
+		try {
+			installLoader( () => Promise.resolve() );
+			installFetch( {
+				bundles: Array.from( { length: 12 }, ( _, i ) => `build/routes/r${ i }/content.js` ),
+			} );
+			const { loadI18nCatalogs } = await import( HELPER );
+
+			const boot = loadI18nCatalogs( 'jetpack-test', MODULE_URL );
+			await flush();
+			await boot;
+
+			// Every watchdog now fires against an already-released slot. A
+			// second release would drive `active` negative and let the next
+			// burst exceed the concurrency cap.
+			mock.timers.tick( 30000 );
+			await flush();
+
+			assert.equal( parkedState().active, 0, 'no slot is released twice' );
+			assert.equal( parkedState().queue.length, 0, 'nothing is left queued' );
+			assert.deepEqual( warnings, [], 'a normal download trips no warning' );
+		} finally {
+			mock.timers.reset();
+		}
 	} );
 } );

--- a/projects/packages/wp-build-polyfills/tests/js/load-i18n-catalogs.test.js
+++ b/projects/packages/wp-build-polyfills/tests/js/load-i18n-catalogs.test.js
@@ -513,7 +513,7 @@ describe( 'download slot watchdog', () => {
 		}
 	} );
 
-	it( 'releases each slot exactly once when downloads settle normally', async () => {
+	it( 'cancels the watchdog when a download settles normally', async () => {
 		mock.timers.enable( { apis: [ 'setTimeout' ] } );
 		try {
 			installLoader( () => Promise.resolve() );
@@ -526,15 +526,49 @@ describe( 'download slot watchdog', () => {
 			await flush();
 			await boot;
 
-			// Every watchdog now fires against an already-released slot. A
-			// second release would drive `active` negative and let the next
-			// burst exceed the concurrency cap.
+			// `clearTimeout` is mocked alongside `setTimeout`, so this tick
+			// proves the watchdogs were cancelled rather than merely silent:
+			// an uncancelled one would warn about a download that finished.
 			mock.timers.tick( 30000 );
 			await flush();
 
-			assert.equal( parkedState().active, 0, 'no slot is released twice' );
+			assert.equal( parkedState().active, 0, 'every slot is handed back' );
 			assert.equal( parkedState().queue.length, 0, 'nothing is left queued' );
 			assert.deepEqual( warnings, [], 'a normal download trips no warning' );
+		} finally {
+			mock.timers.reset();
+		}
+	} );
+
+	it( 'ignores a stalled download that settles after its watchdog freed the slot', async () => {
+		mock.timers.enable( { apis: [ 'setTimeout' ] } );
+		try {
+			const resolvers = [];
+			const calls = installLoader( () => new Promise( resolve => resolvers.push( resolve ) ) );
+			installFetch( {
+				bundles: Array.from( { length: 7 }, ( _, i ) => `build/routes/r${ i }/content.js` ),
+			} );
+			const { loadI18nCatalogs } = await import( HELPER );
+
+			loadI18nCatalogs( 'jetpack-test', MODULE_URL );
+			await flush();
+			assert.equal( calls.length, 6, 'the queue starts at the concurrency cap' );
+
+			// The six watchdogs fire and hand their slots back; the seventh
+			// download takes one of them.
+			mock.timers.tick( 30000 );
+			await flush();
+			assert.equal( calls.length, 7, 'the queued download runs once a slot is freed' );
+			assert.equal( parkedState().active, 1, 'only the seventh download still holds a slot' );
+
+			// The stalled origin finally answers. Each of those six downloads
+			// now runs its `finally` against a slot the watchdog already
+			// released — releasing a second time would drive `active` negative
+			// and let the next burst run over the concurrency cap.
+			resolvers.slice( 0, 6 ).forEach( resolve => resolve() );
+			await flush();
+
+			assert.equal( parkedState().active, 1, 'a late settle does not release the slot twice' );
 		} finally {
 			mock.timers.reset();
 		}


### PR DESCRIPTION
Fixes # N/A (JETPACK-2095, follow-up to #50904 — both items raised by @LiamSarsfield in that review)

## Proposed changes

Two independent items that were deliberately left out of #50904 because the clean fixes lived outside it.

* **`premium-analytics`: keep widget metadata resolution off the initial render.** Upstream `useWidgetTypes()` imports every record's `widget.js` metadata module eagerly, with no resolver seam, and those modules evaluate `__()` at module scope — so #50904 had to gate the whole registry on preloading every record's catalog. That put one catalog request per registered widget on the boot critical path (~41 of them by the ticket's estimate) and added a grid delay that did not exist before. `useWidgetTypesWithI18n()` now hands `useWidgetTypes()` only the records the active section's layout renders, then downloads the rest of the registry's catalogs on the next idle callback once those widgets have resolved. Edit mode still widens the registry explicitly, but by then it is adopting downloads that already happened.
* **`wp-build-polyfills`: a stalled download no longer holds its concurrency slot forever.** `throttled()` released a slot only from `task().finally()`, and `downloadI18n()` awaits a bare `fetch` with no timeout and no `AbortSignal`. The callers' `Promise.race` bounds unblock only the caller; the request keeps its slot. With `MAX_CONCURRENT_DOWNLOADS = 6`, six genuinely stalled downloads deadlocked the queue for the rest of the page. Each slot now carries a watchdog that returns it after 30s and lets the orphaned request finish in the background.

### Notes for reviewers

**This defers the registry's catalogs; it does not drop them.** An earlier revision of this PR downloaded only the visible widgets' catalogs and widened the registry when edit mode opened. `WidgetPicker` hardcodes `isLoading={ false }` and takes `totalItems` from whatever types the dashboard hands it, so it has no way to render "still loading" — during the widening it just showed a short gallery with a matching count (@CGastrell measured 12 of 44, for 3.26s). The same burst is what tripped the 5s per-widget catalog bound and produced a `[jetpack-i18n]` warning. The idle warm-up closes both: `includeAll` now adopts promises already in the loader's download map (keyed by bundle path), so widening resolves in a microtask and queues nothing. The saving is therefore on the critical path, not in total bytes; after the page settles the registry is as complete as it was in #50904.

**The warm-up waits for the widgets on screen, and stays under the queue's width.** Scheduling it any earlier would queue the whole registry into the same six-slot download queue the visible widgets are draining, putting the grid behind the registry — the inversion the scoping exists to prevent. For the same reason it warms three catalogs at a time rather than all at once: the queue is FIFO and each catalog's bound counts its queue wait, so a background batch that fills all six slots pushes a widget's own `render.js` catalog — which blocks that widget's import — past its bound, and the widget renders in English. Holding at most half the slots means anything with a caller blocked on it starts immediately. Nothing awaits the warm-up, so trading its wall-clock for that costs nothing.

The gated preload deliberately does *not* batch: the registry gate and the widget picker are both waiting on it, so it takes the queue at full width.

That is also why this PR does not move where the bound starts. Measuring only the fetch would make the `still pending` message literally true, but the bound's other job is capping how long a widget's import can block — start it at dequeue and that cap becomes `queue wait + 5s`, unbounded by queue depth, which is the stalled-origin-wedges-first-render shape this whole area exists to avoid. Keeping background work out of the way fixes the same conflation from the other end, and leaves the cap intact.

**`visibleNames` is tri-state, and that is load-bearing.** `undefined` means "no scoping", `null` means "the caller's layout has not resolved yet", `[]` means "genuinely nothing on screen". The middle state is not decoration: hooks cannot be skipped, so `stage.tsx` calls this hook on the renders where it returns a spinner, and on those renders `layout` is empty. An earlier revision treated that as an empty layout and fell back to the full record set — which made the scoping a no-op on every real page load while every unit test still passed, because tests hand the hook a settled layout. There is a regression test named for exactly this.

**Why the resolving flag is derived rather than passed through — and why that is a guard, not a bug fix.** Scoping closes the gate *during render* — the render-phase `setNeededNames` widens the scope and the new `scopedRecords` array lands the same pass — but `useWidgetTypes()` only raises `isResolvingWidgetTypes` from an effect, one commit later. A section switch therefore commits one frame holding the previous section's types while reporting resolved, which is the tuple `widget-chrome.tsx` turns into "Missing widget" for any widget it cannot find.

Nothing renders it today, and @CGastrell was right to push back on the original wording here. `WidgetDashboard` keeps its own `stagingLayout` in `useState`, synced from the `layout` prop by an effect, and renders *that* — so the incoming section's tiles mount one commit after the layout changes, by which time the flag has already flipped. Two unrelated one-commit lags cancel out; he measured 158 aria-attribute ops across a section switch with `"Missing widget"` set zero times.

The flag is still derived — `resolving || gatedRecords === null` — because the cancellation is accidental. It rests on an internal `useState` + `useEffect` sync in an upstream package, and the invariant this hook owes its caller is "withholding records means resolution is not finished", independent of who happens to be mounted. The suite could not see the bad tuple at all originally: its `useWidgetTypes` stand-in reported resolving synchronously during render, the exact timing that hides it. There is now a second stand-in timed the way upstream times it, asserting on every committed frame.

**An empty layout no longer collapses the scope.** `scopedRecords` used to fall back to the full record set whenever the scoped subset came out empty, on the theory that an empty dashboard force-opens edit mode and needs the registry anyway. That makes the scoping collapse if a layout is empty for even one render, putting every catalog back on the boot critical path. `[]` already means "nothing on screen" in this option's contract, so it now resolves nothing; `includeAll` covers the genuinely empty dashboard one render later at no boot cost. Note this closes only one route from a transiently empty layout to a full preload — the other runs through `WidgetDashboard` force-opening edit mode, which latches `includeAll`, and shows up as the dashboard opening in Customize mode.

**Why not `AbortSignal` in `jetpack-assets`.** Adding it to `downloadI18n()` would also cancel the wasted bytes, but it cannot replace the watchdog — the autoloader can hand the page an older `jetpack-assets` copy that ignores the signal, so `throttled()` needs its own guarantee regardless. That makes abort purely additive, at the cost of a second package and a version-skew story, so it is left out.

**Known limitation.** The queue state is parked on `window` and shared with any other copy of the module on the page, including copies built before the watchdog existed. A stalled task started by such a copy still holds its slot. Nothing in this package can fix that.

**Still open upstream.** The clean fix for the first item is lazy per-widget metadata resolution in `@wordpress/widget-primitives`; that is the path to ~16 requests, and the only thing that turns this deferral into a real reduction. This change reduces the cost of waiting for it and is written to fold away when it lands. `WidgetPicker`'s missing loading state is worth reporting upstream separately.

## Related product discussion/links

* JETPACK-2095
* Follow-up to #50904 (originally WOOA7S-1822)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Measured on a local site through a tunnel, `pt_BR`, one full dashboard load each. Counts are of unique translation-catalog downloads; note that the browser's resource-timing buffer fills before the catalogs are requested, so the DevTools Network panel undercounts — read `window.__jetpackWpBuildI18nCatalogs.downloads` instead.

| Metric | #50904 | This PR |
|---|---|---|
| Catalog downloads before the grid renders | 56 | **39** (−30%) |
| — route/script/module | 16 | 16 |
| — widget metadata (`widget.js`) | 28 | **11** |
| — widget render (`render.js`) | 12 | 12 |
| Catalog downloads once the page has gone idle | 56 | 56 |

The first four rows were measured on the revision that had no idle warm-up; the warm-up starts only after the visible widgets have resolved, so it does not move them. The last row is the point of the change: the same catalogs are fetched, after the grid is on screen instead of before it.

1. On a Jetpack site with Premium Analytics, set the site or user language to any non-`en_US` locale, e.g. Português do Brasil.
2. Open `wp-admin/admin.php?page=jetpack-premium-analytics-wp-admin`. The widgets on the Traffic tab should render with translated titles, with no longer a wait than trunk.
3. In the console, run:
   ```js
   const k = [ ...window.__jetpackWpBuildI18nCatalogs.downloads.keys() ];
   ( { total: k.length, metadata: k.filter( x => x.endsWith( '/widget.js' ) ).length } )
   ```
   By the time you can type this the idle warm-up has run, so expect the full registry (~56 total, ~28 metadata) — the same coverage as #50904. What changed is *when*: see step 4.
4. Reload with the Network panel open, filtered to the catalog requests, and watch the waterfall. The route/module catalogs and the visible widgets' catalogs come first and the grid renders; the rest of the registry follows in a later batch, after first paint.
5. Switch to the Insights tab: new **render** bundles download for the newly rendered widgets, but no new metadata catalogs — the warm-up already covered them. No widget shows "Missing widget" at any point during the switch; this is the check for the stale-frame fix.
6. Switch back to Traffic: no new downloads, and no widget drops back to a loading state.
7. Click **Customize**, then **Add widget** as fast as you can — inside ~100ms, before edit mode has settled. Assert the count rather than eyeballing the grid: the gallery must show the full registry on its first frame, not a short list that grows. On the revision before the idle warm-up this window was measured at 3.26s, showing 12 of 44.
8. Console should show no `[jetpack-i18n]` warnings, in particular no `still pending after 5000ms` for a `render.js` catalog. That warning is queue arithmetic, not a network fault: the 6-slot download queue serves everything, and a per-widget catalog carries a 5s bound that includes its wait, so a burst of ~48 catalogs ahead of it pushes the tail past the bound. Two things now keep that from happening — the widening at *Customize* has nothing left to queue, and the warm-up itself never takes more than three of the six slots. Try to provoke it: switch sections repeatedly during the first few seconds after load, which is when the warm-up is draining and new widgets are requesting their own render catalogs. Catalog requests returning 404 is expected on a test site; no language packs exist for these bundles yet, and the UI falls back to English.
9. On `en_US`, no catalog requests should fire at all.

Automated tests:

```
jp test js packages/premium-analytics
jp test js packages/wp-build-polyfills
```

The slot watchdog is covered by three `node:test` tests. One asserts a queued download starts after six stalled downloads give up their slots. One asserts a normally-settling download's watchdog is cancelled rather than merely silent — `clearTimeout` is mocked alongside `setTimeout`, so ticking past the timeout proves cancellation. The third covers the `released` guard itself: a stalled download whose watchdog frees its slot and which *then* settles, running `finally` against a slot already back in the pool. Without the guard that drives `active` to -5 and lets the next burst exceed the concurrency cap; the first two tests pass with the guard deleted, this one does not.
