### PR TITLE
Agents Manager: Remove the sidebar docking viewport-height gate

### DIFF
--- a/projects/packages/agents-manager/changelog/update-agents-manager-sidebar-docking-height-gate
+++ b/projects/packages/agents-manager/changelog/update-agents-manager-sidebar-docking-height-gate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Sidebar docking: remove the viewport-height gate. The simplified wp-admin layout keeps the admin menu in normal flow, so a tall menu no longer prevents docking.

--- a/projects/packages/agents-manager/src/class-sidebar-open-preservation.php
+++ b/projects/packages/agents-manager/src/class-sidebar-open-preservation.php
@@ -18,13 +18,10 @@ namespace Automattic\Jetpack\Agents_Manager;
  * never left orphaned.
  *
  * The server can know the persisted "open && docked" preference, but not the
- * live viewport — and the docked layout only fits above a width breakpoint and
- * when the admin menu fits vertically. Width is handled in CSS (a static media
- * query). Height cannot be: the threshold is the *measured* #adminmenu height,
- * which varies per page. So a tiny synchronous viewport-height gate is printed on
- * `in_admin_header` (which fires after #adminmenu is in the DOM, before the
- * content paints) to re-evaluate the real dock gate and strip the pre-rendered
- * classes when the chat will actually float — pre-paint, so there is no flash.
+ * live viewport width or the editor's fullscreen mode. So a tiny synchronous
+ * gate script is printed on `in_admin_header` (before the content paints) to
+ * re-evaluate the real dock gates and strip the pre-rendered classes when the
+ * chat will actually float — pre-paint, so there is no flash.
  */
 class Sidebar_Open_Preservation {
 	/**
@@ -68,9 +65,8 @@ class Sidebar_Open_Preservation {
 		// ours, breaking the CSS selector that pre-opens the sidebar.
 		add_filter( 'admin_body_class', array( $this, 'add_preopen_body_classes' ), PHP_INT_MAX );
 
-		// Reconcile the pre-rendered shell against the live viewport before the
-		// page content paints. `in_admin_header` fires after #adminmenu is in the
-		// DOM, so the script can measure it the same way the React app does.
+		// Reconcile the pre-rendered shell against the live dock gates before
+		// the page content paints.
 		add_action( 'in_admin_header', array( $this, 'print_sidebar_docking_gate_script' ) );
 	}
 
@@ -106,7 +102,7 @@ class Sidebar_Open_Preservation {
 	 * inject the docked sidebar body classes, this script reconciles the gates that
 	 * the React hook applies and removes those classes so the chat floats instead.
 	 *
-	 * The script lives in src/js/sidebar-docking-gate.js and is inlined (not
+	 * The script lives in src/js/sidebar-docking-gate.ts and is inlined (not
 	 * referenced via `src`) on purpose: it must run render-blocking before paint,
 	 * and a same- or cross-origin fetch would add latency to that blocking window.
 	 * Reading the bundled file and printing it inline keeps it a real, lintable JS

--- a/projects/packages/agents-manager/src/js/sidebar-docking-gate.ts
+++ b/projects/packages/agents-manager/src/js/sidebar-docking-gate.ts
@@ -63,19 +63,9 @@ function runSidebarDockingGate() {
 		return;
 	}
 
-	const adminMenu = document.getElementById( 'adminmenu' );
-	if ( ! adminMenu ) {
-		return;
-	}
-
-	// The docked layout pins the admin menu to the viewport; if the menu is taller
-	// than the room below the admin bar it would be clipped, so the chat floats instead.
-	const adminBar = document.getElementById( 'wpadminbar' );
-	const adminBarHeight = adminBar ? adminBar.offsetHeight : 32;
-	const tooShort = window.innerHeight < adminMenu.offsetHeight + adminBarHeight + 20;
 	const tooNarrow = window.innerWidth < DESKTOP_MIN_WIDTH;
 
-	if ( tooShort || tooNarrow || ! isFullscreenGateOpen() ) {
+	if ( tooNarrow || ! isFullscreenGateOpen() ) {
 		removeDockedShell();
 	}
 }

--- a/projects/packages/agents-manager/tests/js/sidebar-docking-gate.test.ts
+++ b/projects/packages/agents-manager/tests/js/sidebar-docking-gate.test.ts
@@ -15,33 +15,6 @@ const DOCKED_SIDEBAR_BODY_CLASSES = [
 ];
 
 /**
- * jsdom does not lay elements out, so offsetHeight is always 0. Stub it so the
- * gate's height math has something to measure.
- *
- * @param {HTMLElement} element - Element to stub.
- * @param {number}      value   - Pixel height to report.
- */
-function stubOffsetHeight( element: HTMLElement, value: number ): void {
-	Object.defineProperty( element, 'offsetHeight', {
-		configurable: true,
-		value,
-	} );
-}
-
-/**
- * Set the viewport height the gate reads.
- *
- * @param {number} value - Pixel height for window.innerHeight.
- */
-function setViewportHeight( value: number ): void {
-	Object.defineProperty( window, 'innerHeight', {
-		configurable: true,
-		writable: true,
-		value,
-	} );
-}
-
-/**
  * Set the viewport width the gate reads.
  *
  * @param {number} value - Pixel width for window.innerWidth.
@@ -89,34 +62,8 @@ describe( 'sidebar-docking-gate', () => {
 		jest.resetModules();
 	} );
 
-	it( 'removes the docked classes when the menu does not fit the viewport', async () => {
+	it( 'keeps the docked classes on a desktop viewport', async () => {
 		addDockedClasses();
-
-		const adminMenu = document.createElement( 'div' );
-		adminMenu.id = 'adminmenu';
-		stubOffsetHeight( adminMenu, 800 );
-		document.body.appendChild( adminMenu );
-
-		// 600 < 800 + 32 (default bar) + 20 => too short.
-		setViewportHeight( 600 );
-
-		await runGate();
-
-		DOCKED_SIDEBAR_BODY_CLASSES.forEach( cls => {
-			expect( document.body ).not.toHaveClass( cls );
-		} );
-	} );
-
-	it( 'keeps the docked classes when the menu fits the viewport', async () => {
-		addDockedClasses();
-
-		const adminMenu = document.createElement( 'div' );
-		adminMenu.id = 'adminmenu';
-		stubOffsetHeight( adminMenu, 400 );
-		document.body.appendChild( adminMenu );
-
-		// 1000 >= 400 + 32 + 20 => fits.
-		setViewportHeight( 1000 );
 
 		await runGate();
 
@@ -128,13 +75,7 @@ describe( 'sidebar-docking-gate', () => {
 	it( 'removes the docked classes when the viewport is too narrow', async () => {
 		addDockedClasses();
 
-		const adminMenu = document.createElement( 'div' );
-		adminMenu.id = 'adminmenu';
-		stubOffsetHeight( adminMenu, 400 );
-		document.body.appendChild( adminMenu );
-
-		// Tall enough to fit, but narrower than the 1200px threshold.
-		setViewportHeight( 1000 );
+		// Narrower than the 1200px threshold.
 		setViewportWidth( 1100 );
 
 		await runGate();
@@ -148,14 +89,6 @@ describe( 'sidebar-docking-gate', () => {
 		addDockedClasses();
 		document.body.classList.add( 'post-php' );
 
-		const adminMenu = document.createElement( 'div' );
-		adminMenu.id = 'adminmenu';
-		stubOffsetHeight( adminMenu, 400 );
-		document.body.appendChild( adminMenu );
-
-		// Fits and wide enough; only the fullscreen gate trips.
-		setViewportHeight( 1000 );
-
 		await runGate();
 
 		DOCKED_SIDEBAR_BODY_CLASSES.forEach( cls => {
@@ -167,90 +100,15 @@ describe( 'sidebar-docking-gate', () => {
 		addDockedClasses();
 		document.body.classList.add( 'post-php', 'is-fullscreen-mode' );
 
-		const adminMenu = document.createElement( 'div' );
-		adminMenu.id = 'adminmenu';
-		stubOffsetHeight( adminMenu, 400 );
-		document.body.appendChild( adminMenu );
-
-		setViewportHeight( 1000 );
-
 		await runGate();
 
 		DOCKED_SIDEBAR_BODY_CLASSES.forEach( cls => {
 			expect( document.body ).toHaveClass( cls );
-		} );
-	} );
-
-	it( 'does nothing when the admin menu is absent', async () => {
-		addDockedClasses();
-		setViewportHeight( 100 );
-
-		await runGate();
-
-		// The classes are left untouched because the gate bails out early.
-		DOCKED_SIDEBAR_BODY_CLASSES.forEach( cls => {
-			expect( document.body ).toHaveClass( cls );
-		} );
-	} );
-
-	it( 'falls back to a 32px admin bar height when #wpadminbar is missing', async () => {
-		addDockedClasses();
-
-		const adminMenu = document.createElement( 'div' );
-		adminMenu.id = 'adminmenu';
-		stubOffsetHeight( adminMenu, 700 );
-		document.body.appendChild( adminMenu );
-
-		// Boundary with the 32px fallback: 760 >= 700 + 32 + 20 (752) => fits.
-		setViewportHeight( 760 );
-		await runGate();
-		DOCKED_SIDEBAR_BODY_CLASSES.forEach( cls => {
-			expect( document.body ).toHaveClass( cls );
-		} );
-
-		// One pixel under the fallback threshold => too short.
-		document.body.className = '';
-		addDockedClasses();
-		jest.resetModules();
-		setViewportHeight( 751 );
-		await runGate();
-		DOCKED_SIDEBAR_BODY_CLASSES.forEach( cls => {
-			expect( document.body ).not.toHaveClass( cls );
-		} );
-	} );
-
-	it( 'uses the real admin bar offsetHeight when #wpadminbar is present', async () => {
-		addDockedClasses();
-
-		const adminBar = document.createElement( 'div' );
-		adminBar.id = 'wpadminbar';
-		stubOffsetHeight( adminBar, 100 );
-		document.body.appendChild( adminBar );
-
-		const adminMenu = document.createElement( 'div' );
-		adminMenu.id = 'adminmenu';
-		stubOffsetHeight( adminMenu, 700 );
-		document.body.appendChild( adminMenu );
-
-		// With the taller real bar: 800 < 700 + 100 + 20 (820) => too short,
-		// even though it would have fit with the 32px fallback.
-		setViewportHeight( 800 );
-
-		await runGate();
-
-		DOCKED_SIDEBAR_BODY_CLASSES.forEach( cls => {
-			expect( document.body ).not.toHaveClass( cls );
 		} );
 	} );
 
 	it( 'strips the shell when a fullscreen-gated class is added after the first run', async () => {
 		addDockedClasses();
-
-		const adminMenu = document.createElement( 'div' );
-		adminMenu.id = 'adminmenu';
-		stubOffsetHeight( adminMenu, 400 );
-		document.body.appendChild( adminMenu );
-		setViewportHeight( 1000 );
 
 		await runGate();
 
@@ -271,12 +129,6 @@ describe( 'sidebar-docking-gate', () => {
 	it( 'keeps the shell when a gated class is added while in fullscreen mode', async () => {
 		addDockedClasses();
 
-		const adminMenu = document.createElement( 'div' );
-		adminMenu.id = 'adminmenu';
-		stubOffsetHeight( adminMenu, 400 );
-		document.body.appendChild( adminMenu );
-		setViewportHeight( 1000 );
-
 		await runGate();
 
 		document.body.classList.add( 'post-php', 'is-fullscreen-mode' );
@@ -289,12 +141,6 @@ describe( 'sidebar-docking-gate', () => {
 
 	it( 'stops observing once the chat app mounts', async () => {
 		addDockedClasses();
-
-		const adminMenu = document.createElement( 'div' );
-		adminMenu.id = 'adminmenu';
-		stubOffsetHeight( adminMenu, 400 );
-		document.body.appendChild( adminMenu );
-		setViewportHeight( 1000 );
 
 		await runGate();
 
@@ -315,12 +161,6 @@ describe( 'sidebar-docking-gate', () => {
 
 	it( 'disconnects after one strip and never loops or re-strips', async () => {
 		addDockedClasses();
-
-		const adminMenu = document.createElement( 'div' );
-		adminMenu.id = 'adminmenu';
-		stubOffsetHeight( adminMenu, 400 );
-		document.body.appendChild( adminMenu );
-		setViewportHeight( 1000 );
 
 		await runGate();
 

--- a/projects/packages/agents-manager/tests/php/Sidebar_Open_Preservation_Test.php
+++ b/projects/packages/agents-manager/tests/php/Sidebar_Open_Preservation_Test.php
@@ -225,20 +225,20 @@ class Sidebar_Open_Preservation_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that the constructor registers the early dock-sync script hook.
+	 * Tests that the constructor registers the early docking-gate script hook.
 	 */
-	public function test_constructor_registers_sync_script_hook() {
+	public function test_constructor_registers_docking_gate_script_hook() {
 		$this->assertNotFalse(
 			has_action( 'in_admin_header', array( $this->preservation, 'print_sidebar_docking_gate_script' ) ),
-			'The docking viewport height gate script must be hooked into the admin body.'
+			'The docking gate script must be hooked into the admin body.'
 		);
 	}
 
 	/**
-	 * Tests that the dock-height sync script is printed when the
+	 * Tests that the docking-gate script is printed when the
 	 * docked-open shell is pre-rendered.
 	 */
-	public function test_print_sync_script_outputs_when_pre_rendering() {
+	public function test_print_docking_gate_script_outputs_when_pre_rendering() {
 		$this->enable_preservation();
 		$this->cache_open_state( true );
 
@@ -260,9 +260,9 @@ class Sidebar_Open_Preservation_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
-	 * Tests that the dock-sync script is not printed when nothing is pre-rendered.
+	 * Tests that the docking-gate script is not printed when nothing is pre-rendered.
 	 */
-	public function test_print_sync_script_noop_when_not_pre_rendering() {
+	public function test_print_docking_gate_script_noop_when_not_pre_rendering() {
 		$this->enable_preservation();
 		$this->cache_open_state( false );
 


### PR DESCRIPTION
Part of AI-1089.

## Proposed changes

* Remove the viewport-height check from the Agents Manager pre-paint docking gate. The paired Calypso shrink layout keeps the admin menu in normal flow, so a tall menu no longer prevents docking. The gate now checks only viewport width and the editor fullscreen mode, matching the Calypso hook.
* Update the docblocks and tests to match.

## Related product discussion/links

* AI-1089
* Paired Calypso PR: Automattic/wp-calypso#113160

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This is the backend half of the paired Calypso PR — test them together. Deploy this package to your sandbox (all plugin copies) alongside the Calypso PR's `apps/agents-manager` bundle, then follow the testing instructions in Automattic/wp-calypso#113160 — its "Jetpack docking gate" section covers this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

