### PR TITLE
SEO: normalize the text hierarchy across the Settings modules [JETPACK-2097]

### DIFF
--- a/projects/packages/seo/README.md
+++ b/projects/packages/seo/README.md
@@ -18,6 +18,40 @@ Built as a [`@wordpress/build`](https://www.npmjs.com/package/@wordpress/build) 
 - **Data:** the Overview, Settings, and GEO routes are backed by read-only REST routes `GET /jetpack/v4/seo/{overview,settings,ai}` (`Dashboard_Data::register_rest_reads()`, `manage_options`-gated), whose responses are **preloaded** into the page server-side via `rest_preload_api_request()` (`Admin_Page::inject_script_data()`, on the `jetpack_admin_js_script_data` filter — wp-build pages load as ES modules, so `wp_localize_script` can't bootstrap them and the script-data layer is the supported channel). On a normal load each route reads its slice from the preload synchronously through `@automattic/jetpack-script-data` (`_inc/data/get-preloaded.ts`) — instant, no request. When a slice is missing or stale (e.g. a mismatched bundle after an update), the route's stage fetches it from its REST route instead of dead-ending: `_inc/data/use-ensure-tab-data.ts` shows a loading skeleton, retries silently, and surfaces a recoverable "Try again" state only on genuine failure. `google_verify` and `site` stay synchronous on `window.JetpackScriptData.seo`. The Content route fetches posts and pages live from **core `/wp/v2/posts` and `/wp/v2/pages`** (no custom endpoint), with SEO meta returned via registered `show_in_rest` post meta; the inspector writes through the same core post endpoint. Most Settings writes reuse `/jetpack/v4/settings` (and core `/wp/v2/settings` for `blog_public`); nested site-level schema settings use the package-owned `GET/POST /jetpack/v4/seo/schema-settings` route so each schema section can be preserved across partial updates.
 - **Plan gating (WordPress.com):** on WordPress.com sites below Premium (lacking the `advanced-seo` entitlement after the March 2026 rebundling) the dashboard reduces to a free subset and surfaces an upsell. The gate is `Host::is_wpcom_platform() && ! Current_Plan::supports( 'advanced-seo' )` (`Initializer::is_gated()`): `advanced-seo` is in the free plan's supports list, so `supports()` returns true on self-hosted (**never gated**) and hijacks to `wpcom_site_has_feature()` on WordPress.com, false below Premium. It's surfaced to the client as the `seo.gating` script-data slice (`is_gated`, `upsell_url`), read via `_inc/data/is-gated.ts`, which **defaults to ungated** when the slice is absent so a stale snapshot never hides a paid feature. When gated: the Content and GEO tabs are removed and their route stages redirect to Overview; Overview and Settings drop their paid cards/sections and pin the upsell banner; and — importantly for anyone debugging a missing `/llms.txt` or absent AI-crawler robots.txt rules — `init()` skips `Llms_Txt::init()` and `Ai_Crawlers::init()`, so those services stop emitting, not just their UI. Gating is evaluated live per request (no cached option), so an upgrade restores everything on the next load and a downgrade takes effect immediately.
 
+## UI conventions
+
+### Text hierarchy
+
+`@wordpress/ui`'s `Text` variants are easy to pick wrong, because **the heading and body ramps don't share a scale** — `heading-sm` is *smaller* than `body-md`. Resolved from the WPDS tokens (`@wordpress/theme`):
+
+| Variant | Size | Weight | Transform | Use it for |
+| -- | -- | -- | -- | -- |
+| `heading-lg` | 15px | medium | — | card title |
+| `heading-md` | 13px | medium | — | sub-heading inside a module |
+| `heading-sm` | **11px** | medium | **UPPERCASE** | field label |
+| `body-md` | 13px | regular | — | body copy |
+| `body-sm` | 12px | regular | — | field explainer |
+
+"Small heading" is a **field label**, not a small sub-heading. Reach for `heading-md` when you want a sub-heading.
+
+The rule for prose, which the modules drifted away from once already:
+
+- **`body-md`** — a module's or section's own prose. Things the reader is meant to read.
+- **`body-sm` + `.muted`** — explainer text *attached to a field*: hints under an input, help under a group label. Not general copy.
+- **`body-md` + `.muted`** — the third case, and deliberately narrow: chrome inside the SERP and social preview mockups (`social-previews-card`, `serp-preview`). Those imitate how Google and Facebook render a link, so their type follows *someone else's* design, not ours. Don't extend this case to real UI.
+
+Field labels should be uppercase across the board. Where a `TextControl` renders the label, that's automatic; where a label is drawn by hand, use `heading-sm` so it matches (same size and casing — the control label is weight 600 against `heading-sm`'s medium, so they read alike without being pixel-identical).
+
+### Element rendering
+
+`Text` renders a `<span>` by default, which is rarely what you want:
+
+- Prose → `render={ <p /> }`.
+- A real sub-heading → `render={ <h3 /> }`. Card headers are `h2` (the page `<h1>` is in `Admin_Page`), so a module's own sub-headings are `h3`. Without this a screen-reader user navigating by heading finds the card title and nothing beneath it.
+- A hand-drawn field label heading a *group* of controls rather than one input → keep it a `span`, but give the wrapper `role="group"` and `aria-labelledby` pointing at it (see `google-verification-field`), or it announces as a label attached to nothing.
+
+Rendering as `<p>` or a heading is safe: `Text` always applies both of `@wordpress/ui`'s global-CSS defenses, and every variant defines `--_gcd-heading-*` alongside `--_gcd-p-*`, so the element change doesn't alter the type.
+
 ## Development
 
 ```bash

--- a/projects/packages/seo/_inc/screens/settings/google-verification-field.tsx
+++ b/projects/packages/seo/_inc/screens/settings/google-verification-field.tsx
@@ -16,6 +16,11 @@ interface Props {
 	disabled?: boolean;
 }
 
+// Names the auto-verify group for assistive tech. Static, matching the
+// `jetpack-seo-settings-*` ids used elsewhere in this folder — there's only ever
+// one Google field on the tab, so it can't collide.
+const GROUP_LABEL_ID = 'jetpack-seo-settings-google-verification-label';
+
 // Matches the wording of the other services' hints in `verification-card`: both
 // a whole pasted meta tag and a bare code are accepted on save.
 const manualHelp = __(
@@ -83,16 +88,20 @@ const GoogleVerificationField: FC< Props > = ( { value, onChange, onCommit, disa
 		);
 	}
 
+	// Named as a group: unlike the other four services, this branch is a name over
+	// several controls (verify, manual entry, and the revealed code field), so it needs
+	// to attach to them for a screen reader. The `Text` inside is styled as a field
+	// label, which on its own would say "label" without saying what it labels.
 	return (
-		<Stack direction="column" gap="md">
+		<Stack direction="column" gap="md" role="group" aria-labelledby={ GROUP_LABEL_ID }>
 			<Stack direction="row" justify="space-between" align="center" gap="sm">
-				{ /* `heading-sm` is the field-label treatment (11px uppercase), matching
-				     the `TextControl` labels the other four services render — and
-				     matching this same field's own manual-entry branch above, which is a
-				     `TextControl` and so was already uppercase. It previously used
-				     `heading-md`, so "Google" changed typography depending on whether the
-				     site was Jetpack-connected. */ }
-				<Text variant="heading-sm" render={ <span /> }>
+				{ /* `heading-sm` is the field-label treatment — 11px uppercase, the same
+				     size and casing as the `TextControl` labels the other four services
+				     render, and as this field's own manual-entry branch above (also a
+				     `TextControl`). Not pixel-identical: `heading-sm` is weight 499 against
+				     the control label's 600. It previously used `heading-md`, so "Google"
+				     changed typography depending on whether the site was Jetpack-connected. */ }
+				<Text variant="heading-sm" render={ <span /> } id={ GROUP_LABEL_ID }>
 					{ __( 'Google', 'jetpack-seo' ) }
 				</Text>
 				{ state === 'verified' && (

--- a/projects/packages/seo/_inc/screens/settings/google-verification-field.tsx
+++ b/projects/packages/seo/_inc/screens/settings/google-verification-field.tsx
@@ -86,7 +86,13 @@ const GoogleVerificationField: FC< Props > = ( { value, onChange, onCommit, disa
 	return (
 		<Stack direction="column" gap="md">
 			<Stack direction="row" justify="space-between" align="center" gap="sm">
-				<Text variant="heading-md" render={ <strong /> }>
+				{ /* `heading-sm` is the field-label treatment (11px uppercase), matching
+				     the `TextControl` labels the other four services render — and
+				     matching this same field's own manual-entry branch above, which is a
+				     `TextControl` and so was already uppercase. It previously used
+				     `heading-md`, so "Google" changed typography depending on whether the
+				     site was Jetpack-connected. */ }
+				<Text variant="heading-sm" render={ <span /> }>
 					{ __( 'Google', 'jetpack-seo' ) }
 				</Text>
 				{ state === 'verified' && (

--- a/projects/packages/seo/_inc/screens/settings/schema-card.tsx
+++ b/projects/packages/seo/_inc/screens/settings/schema-card.tsx
@@ -110,7 +110,7 @@ function SchemaCard( { initialSettings, onSave }: Props ) {
 			</CollapsibleCard.Header>
 			<CollapsibleCard.Content>
 				<Stack direction="column" gap="lg">
-					<Text variant="body-sm" className={ styles.muted } render={ <p /> }>
+					<Text variant="body-md" render={ <p /> }>
 						{ __(
 							'Structured data that tells search engines and AI assistants what your site is and who runs it. Add the details below and Jetpack adds the right markup automatically.',
 							'jetpack-seo'

--- a/projects/packages/seo/_inc/screens/settings/schema-settings/author-profile-section.tsx
+++ b/projects/packages/seo/_inc/screens/settings/schema-settings/author-profile-section.tsx
@@ -39,7 +39,7 @@ const AuthorProfileSection: FC< Props > = ( { form } ) => {
 
 	return (
 		<Stack direction="column" gap="lg">
-			<Text variant="body-sm" className={ styles.muted }>
+			<Text variant="body-md" render={ <p /> }>
 				{ __(
 					'Adds Person schema to your articles and author archive. Name, bio, and website also update your WordPress profile.',
 					'jetpack-seo'

--- a/projects/packages/seo/_inc/screens/settings/schema-settings/organization-section.tsx
+++ b/projects/packages/seo/_inc/screens/settings/schema-settings/organization-section.tsx
@@ -4,7 +4,6 @@ import { TextControl, TextareaControl } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { Stack, Text } from '@wordpress/ui';
 import ProfileUrlList from './profile-url-list';
-import styles from './style.module.scss';
 import type { SchemaSettingsForm } from '../../../data/use-schema-settings';
 import type { FC } from 'react';
 
@@ -28,7 +27,7 @@ const OrganizationSection: FC< Props > = ( { form } ) => {
 
 	return (
 		<Stack direction="column" gap="lg">
-			<Text variant="body-sm" className={ styles.muted } render={ <p /> }>
+			<Text variant="body-md" render={ <p /> }>
 				{ __(
 					'About the organization behind this site. Your Site Logo or Site Icon is used as the logo.',
 					'jetpack-seo'

--- a/projects/packages/seo/_inc/screens/settings/style.module.scss
+++ b/projects/packages/seo/_inc/screens/settings/style.module.scss
@@ -19,13 +19,6 @@
 	margin-inline-start: 40px;
 }
 
-// Secondary copy. Paired with `variant="body-sm"`, this is the established
-// treatment for explanatory text across the tab (schema sections, social
-// previews, title structure).
-.muted {
-	color: var(--wpds-color-foreground-content-neutral-weak);
-}
-
 // Live character count in the front-page description footer, paired with that
 // section's Save button (the same footer shape the title-structure rows use).
 // Tabular figures so the width doesn't jitter while typing.

--- a/projects/packages/seo/_inc/screens/settings/test/google-verification-field.test.tsx
+++ b/projects/packages/seo/_inc/screens/settings/test/google-verification-field.test.tsx
@@ -27,6 +27,17 @@ describe( 'GoogleVerificationField', () => {
 		mockUseGoogleVerify.mockReturnValue( googleVerifyDefaults );
 	} );
 
+	it( 'names its controls as a group', () => {
+		renderField();
+
+		// "Google" is styled as a field label (`heading-sm`, 11px uppercase) to match the
+		// other four services, but here it heads several controls rather than labelling
+		// one input. Without the group it would read as a label attached to nothing.
+		const group = screen.getByRole( 'group', { name: 'Google' } );
+		expect( group ).toBeInTheDocument();
+		expect( screen.getByText( 'Google' ).className ).toMatch( /heading-sm/ );
+	} );
+
 	it( 'shows the manual field, but not the manual button, when a value exists', () => {
 		renderField( 'google-code' );
 

--- a/projects/packages/seo/_inc/screens/settings/test/settings-screen.test.tsx
+++ b/projects/packages/seo/_inc/screens/settings/test/settings-screen.test.tsx
@@ -274,5 +274,8 @@ describe( 'Settings module text hierarchy', () => {
 		const description = screen.getByText( /Confirm you own this site/ );
 		expect( description.className ).toMatch( /body-md/ );
 		expect( description.className ).not.toMatch( /body-sm/ );
+		// `body-md` is also `Text`'s default, so the class alone would still pass if the
+		// `variant` prop were deleted outright. The `<p>` pins that it's a real paragraph.
+		expect( description.tagName ).toBe( 'P' );
 	} );
 } );

--- a/projects/packages/seo/_inc/screens/settings/test/settings-screen.test.tsx
+++ b/projects/packages/seo/_inc/screens/settings/test/settings-screen.test.tsx
@@ -260,3 +260,19 @@ describe( 'Advanced module — WordPress.com Simple', () => {
 		expect( screen.queryByText( 'advanced' ) ).not.toBeInTheDocument();
 	} );
 } );
+
+describe( 'Settings module text hierarchy', () => {
+	// One rule: the small muted treatment (`body-sm`) is for explainer text attached
+	// to a field. A module's own prose is body copy (`body-md`). Pinned because the
+	// failure is silent — muted text still renders, it's just harder to read, which
+	// is how five modules drifted into it one copy-paste at a time.
+	it( 'renders a module description as body copy, not explainer text', () => {
+		// Site verification is the one module this suite leaves unmocked, so it's the
+		// one whose description actually renders here.
+		render( <SettingsScreen form={ buildForm() } /> );
+
+		const description = screen.getByText( /Confirm you own this site/ );
+		expect( description.className ).toMatch( /body-md/ );
+		expect( description.className ).not.toMatch( /body-sm/ );
+	} );
+} );

--- a/projects/packages/seo/_inc/screens/settings/title-structure-field.tsx
+++ b/projects/packages/seo/_inc/screens/settings/title-structure-field.tsx
@@ -236,7 +236,7 @@ const TitleStructureField: FC< Props > = ( {
 			</CollapsibleCard.Header>
 			<CollapsibleCard.Content>
 				<Stack direction="column" gap="lg">
-					<Text variant="body-sm" className={ styles.muted } render={ <p /> }>
+					<Text variant="body-md" render={ <p /> }>
 						{ moduleDescription }
 					</Text>
 					{ PAGE_TYPES.map( pt => (

--- a/projects/packages/seo/_inc/screens/settings/verification-card.tsx
+++ b/projects/packages/seo/_inc/screens/settings/verification-card.tsx
@@ -8,7 +8,6 @@ import CardTitleIcon from '../../components/card-title-icon';
 import StatusIndicator from '../../components/status-indicator';
 import { VERIFICATION_SERVICES } from '../../data/verification-services';
 import GoogleVerificationField from './google-verification-field';
-import styles from './style.module.scss';
 import type { SettingStatus } from '../../components/status-indicator';
 import type { SettingsResponse, VerificationKey } from '../../data/settings-types';
 import type { FC } from 'react';
@@ -97,9 +96,9 @@ const VerificationCard: FC< Props > = ( {
 			</CollapsibleCard.Header>
 			<CollapsibleCard.Content>
 				<Stack direction="column" gap="lg">
-					{ /* `body-sm` + muted matches every other explanatory paragraph on this
-					     tab (schema sections, social previews, title structure). */ }
-					<Text variant="body-sm" className={ styles.muted } render={ <p /> }>
+					{ /* Body copy: this is the module's own prose, not a hint attached to a
+					     field. The muted `body-sm` treatment is reserved for the latter. */ }
+					<Text variant="body-md" render={ <p /> }>
 						{ description }
 					</Text>
 					{ /* Google gets the keyring auto-verify flow; the rest are simple code fields. */ }

--- a/projects/packages/seo/changelog/update-seo-settings-text-hierarchy
+++ b/projects/packages/seo/changelog/update-seo-settings-text-hierarchy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Settings: use consistent text styles across modules, so descriptions read as body copy and every field label is styled the same.

--- a/projects/packages/seo/changelog/update-seo-settings-text-hierarchy
+++ b/projects/packages/seo/changelog/update-seo-settings-text-hierarchy
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Settings: use consistent text styles across modules, so descriptions read as body copy and every field label is styled the same.
+Settings: Make text styles consistent across modules, so descriptions are easier to read and every field label looks the same.


### PR DESCRIPTION
Fixes JETPACK-2097

Off trunk, rebased after #50947 merged. The two overlapped in one place — both appended a `describe` block to the end of `settings-screen.test.tsx` — resolved by keeping both; they test unrelated things.

## Proposed changes

The Settings tab had drifted into using the small muted text treatment for almost everything, which made modules hard to read. `body-sm` + muted is the most-used variant in the package — **20 uses against 13 of `body-md`** — and it spread by copy-paste. A comment in `verification-card.tsx` even documented it as the convention, which was an accurate description of the code rather than a decision anyone made.

**One rule now: the small muted treatment is for explainer text attached to a field. A module's own prose is body copy.**

* **Five module and section descriptions** move from `body-sm` + muted to `body-md`: Schema, Site verification, Title structure, Organization, Author profile.
* **The Google verification label** rendered *two different ways depending on connection state* — a `TextControl` label (11px uppercase) when the site is disconnected or the status check is `unavailable`, and `heading-md` (13px bold, sentence case) when connected. It now uses `heading-sm`, the field-label treatment, so it matches both the other four services and its own manual-entry branch.
* Two `styles` imports are dropped, having lost their only consumer — and with them, the `.muted` rule in `screens/settings/style.module.scss`, which no longer had one. Its comment described `body-sm` + muted as "the established treatment for explanatory text across the tab", i.e. the very convention this PR replaces. The `.muted` rules in the schema-settings, title-structure, social-previews and content stylesheets are all still in use and stay.

**One thing the restyle made necessary.** Giving "Google" the field-label treatment is right against the five-service column it sits in — but in the Jetpack-connected branch it heads a *set* of controls (Verify, "Enter a code manually", and the revealed code field, which has its own label), not a single input. Styled as a label and attached to nothing, it read as a label for the next thing a screen reader happened to find. Its `Stack` now carries `role="group"` and is named by it.

**Deliberately left alone:** field explainers, validation errors, the character counter, and the SERP / social preview mockups. The previews are a facsimile of how Google and Facebook render a link — their type is copying someone else's design on purpose, not following ours.

### The trap, since the names invite it

Resolved from the WPDS tokens, the heading and body ramps **don't share a scale**:

| Variant | Size | Weight | Transform | Role |
| -- | -- | -- | -- | -- |
| `heading-lg` | 15px | emphasis | — | card title |
| `heading-md` | 13px | emphasis | — | **sub-heading** |
| `heading-sm` | **11px** | emphasis | **UPPERCASE** | **field label** |
| `body-md` | 13px | default | — | **body copy** |
| `body-sm` | 12px | default | — | **field explainer** |

So `heading-sm` is *smaller* than `body-md`. "Small heading" is a field label, not a sub-heading. The naming trap goes one level deeper than it looks: `heading-sm` resolves to the **`xs`** size token, not `sm`.

One caveat on the Google label, since the comment in the code used to overstate it: `heading-sm` and a `TextControl` label agree on size (11px), casing and line-height, but not weight — the control label is a hard-coded 600, `heading-sm` uses the WPDS emphasis token. They read as the same treatment; they are not pixel-identical.

## Related product discussion/links

* [JETPACK-2097](https://linear.app/a8c/issue/JETPACK-2097/seo-normalize-the-text-hierarchy-across-the-settings-modules) — this issue
* [JETPACK-2096](https://linear.app/a8c/issue/JETPACK-2096/seo-move-the-turn-off-control-into-an-advanced-module-in-settings) / #50947 — where the problem was noticed
* No cross-package convention to conform to: Newsletter uses `heading-sm` with `render={ <h3 /> }` for genuine section headings, Forms only uses `body-md`. This sets a rule for SEO rather than matching an existing one.

## Does this pull request change what data or activity we track or use?

No. Typography only — no PHP, no logic, no requests, no strings changed.

## Testing instructions

Requires the `rsm_jetpack_seo` feature flag (`add_filter( 'rsm_jetpack_seo', '__return_true' );` in an mu-plugin).

Typography only — no logic, no strings, no PHP, and nothing that needs verifying module by module. The unit tests pin the two things that could regress silently (a description falling back to explainer text, and the Google label reverting). If you want to eyeball it, three things are worth the look:

* **Jetpack → SEO → Settings** — module descriptions read as normal body text rather than small grey text.
* **Site verification** on a Jetpack-connected site — "GOOGLE" is now uppercase, matching BING, PINTEREST, YANDEX and FACEBOOK below it. It's the only change that alters an element rather than just its size, and its controls should now announce to a screen reader as a group named "Google" instead of a label attached to nothing.
* **Search & social previews** should look exactly as before — those mockups imitate Google's and Facebook's type on purpose and are deliberately excluded from the rule.


