### PR TITLE
Site Logo: show the Site Editor / Customizer link even when no logo is set

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/edi-646-site-logo-edit-link-empty-state
+++ b/projects/packages/jetpack-mu-wpcom/changelog/edi-646-site-logo-edit-link-empty-state
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Site Logo: Show the Site Editor or Customizer link in WP Admin General Settings even when no logo is set.

--- a/projects/packages/jetpack-mu-wpcom/changelog/edi-646-site-logo-fiverr-cta-callout
+++ b/projects/packages/jetpack-mu-wpcom/changelog/edi-646-site-logo-fiverr-cta-callout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Site Logo: Restyle the Fiverr logo maker prompt in WP Admin General Settings as an inline callout.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
@@ -156,13 +156,17 @@ function wpcom_fiverr_cta() {
 				<?php wpcom_fiverr_cta_button(); ?>
 			</div>
 		<?php else : ?>
-			<p><b><?php esc_html_e( 'Make an incredible logo in minutes', 'jetpack-mu-wpcom' ); ?></b></p>
-			<p><?php esc_html_e( 'Pre-designed by top talent. Just add your touch.', 'jetpack-mu-wpcom' ); ?></p>
+			<div class="wpcom-fiverr-cta-copy">
+				<p><b><?php esc_html_e( 'Make an incredible logo in minutes', 'jetpack-mu-wpcom' ); ?></b></p>
+				<p><?php esc_html_e( 'Pre-designed by top talent. Just add your touch.', 'jetpack-mu-wpcom' ); ?></p>
+			</div>
 			<?php wpcom_fiverr_cta_button(); ?>
 		<?php endif; ?>
-		<?php wpcom_site_logo_edit_description(); ?>
 	</div>
 	<?php
+	// Sits outside the Fiverr CTA: it describes the Site Logo setting itself,
+	// not the upsell.
+	wpcom_site_logo_edit_description();
 }
 
 /**

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
@@ -61,6 +61,43 @@ function wpcom_site_logo_edit_link() {
 }
 
 /**
+ * The description pointing at where the site logo can be set.
+ *
+ * Rendered whether or not a logo exists, so the empty state still offers a way
+ * to upload one. That is the case where someone is most likely looking for it.
+ * The wording says "set" so it reads correctly for both adding and replacing.
+ */
+function wpcom_site_logo_edit_description() {
+	$logo_edit_link = wpcom_site_logo_edit_link();
+
+	// Only promise an edit path when a known destination exists.
+	if ( ! $logo_edit_link['url'] ) {
+		return;
+	}
+	?>
+	<p class="description wpcom-site-logo-description">
+		<?php
+		if ( $logo_edit_link['is_block'] ) {
+			printf(
+				/* translators: %1$s: opening link tag to the Site Editor, %2$s: closing link tag. */
+				esc_html__( 'Displays in your site\'s layout via the Site Logo block. %1$sYou can set your site logo in the site editor%2$s.', 'jetpack-mu-wpcom' ),
+				'<a href="' . esc_url( $logo_edit_link['url'] ) . '">',
+				'</a>'
+			);
+		} else {
+			printf(
+				/* translators: %1$s: opening link tag to the Customizer, %2$s: closing link tag. */
+				esc_html__( '%1$sYou can set your site logo in the Customizer%2$s.', 'jetpack-mu-wpcom' ),
+				'<a href="' . esc_url( $logo_edit_link['url'] ) . '">',
+				'</a>'
+			);
+		}
+		?>
+	</p>
+	<?php
+}
+
+/**
  * The Fiverr logo-maker CTA button's DOM.
  */
 function wpcom_fiverr_cta_button() {
@@ -118,38 +155,12 @@ function wpcom_fiverr_cta() {
 				</div>
 				<?php wpcom_fiverr_cta_button(); ?>
 			</div>
-			<?php
-			$logo_edit_link = wpcom_site_logo_edit_link();
-			// Only promise an edit path when a known destination exists.
-			if ( $logo_edit_link['url'] ) :
-				?>
-				<p class="description">
-					<?php
-					if ( $logo_edit_link['is_block'] ) {
-						printf(
-							/* translators: %1$s: opening link tag to the Site Editor, %2$s: closing link tag. */
-							esc_html__( 'Displays in your site\'s layout via the Site Logo block. %1$sYou can change your site logo in the site editor%2$s.', 'jetpack-mu-wpcom' ),
-							'<a href="' . esc_url( $logo_edit_link['url'] ) . '">',
-							'</a>'
-						);
-					} else {
-						printf(
-							/* translators: %1$s: opening link tag to the Customizer, %2$s: closing link tag. */
-							esc_html__( '%1$sYou can change your site logo in the Customizer%2$s.', 'jetpack-mu-wpcom' ),
-							'<a href="' . esc_url( $logo_edit_link['url'] ) . '">',
-							'</a>'
-						);
-					}
-					?>
-				</p>
-				<?php
-			endif;
-			?>
 		<?php else : ?>
 			<p><b><?php esc_html_e( 'Make an incredible logo in minutes', 'jetpack-mu-wpcom' ); ?></b></p>
 			<p><?php esc_html_e( 'Pre-designed by top talent. Just add your touch.', 'jetpack-mu-wpcom' ); ?></p>
 			<?php wpcom_fiverr_cta_button(); ?>
 		<?php endif; ?>
+		<?php wpcom_site_logo_edit_description(); ?>
 	</div>
 	<?php
 }

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
@@ -98,15 +98,26 @@ function wpcom_site_logo_edit_description() {
 }
 
 /**
+ * The Fiverr logo mark.
+ *
+ * Decorative in every current use, since the adjacent text always names Fiverr.
+ */
+function wpcom_fiverr_logo() {
+	?>
+	<svg class="wpcom-fiverr-cta-logo" width="20" height="20" viewBox="0 0 500 500" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+		<circle cx="250" cy="250" r="177" fill="white"/>
+		<path d="M500 250C500 111.93 388.07 0 250 0C111.93 0 0 111.93 0 250C0 388.07 111.93 500 250 500C388.07 500 500 388.07 500 250ZM360.42 382.5H294.77V237.2H231.94V382.5H165.9V237.2H128.45V183.45H165.9V167.13C165.9 124.54 198.12 95.48 246.05 95.48H294.78V149.22H256.93C241.62 149.22 231.95 157.58 231.95 171.12V183.45H360.43V382.5H360.42Z" fill="#1DBF73"/>
+	</svg>
+	<?php
+}
+
+/**
  * The Fiverr logo-maker CTA button's DOM.
  */
 function wpcom_fiverr_cta_button() {
 	?>
 	<button class="wpcom-fiverr-cta-button button" type="button">
-		<svg width="20" height="20" viewBox="0 0 500 500" fill="none" xmlns="http://www.w3.org/2000/svg">
-			<circle cx="250" cy="250" r="177" fill="white"/>
-			<path d="M500 250C500 111.93 388.07 0 250 0C111.93 0 0 111.93 0 250C0 388.07 111.93 500 250 500C388.07 500 500 388.07 500 250ZM360.42 382.5H294.77V237.2H231.94V382.5H165.9V237.2H128.45V183.45H165.9V167.13C165.9 124.54 198.12 95.48 246.05 95.48H294.78V149.22H256.93C241.62 149.22 231.95 157.58 231.95 171.12V183.45H360.43V382.5H360.42Z" fill="#1DBF73"/>
-		</svg>
+		<?php wpcom_fiverr_logo(); ?>
 		<?php esc_html_e( 'Try Fiverr Logo Maker', 'jetpack-mu-wpcom' ); ?>
 	</button>
 	<?php
@@ -156,11 +167,22 @@ function wpcom_fiverr_cta() {
 				<?php wpcom_fiverr_cta_button(); ?>
 			</div>
 		<?php else : ?>
-			<div class="wpcom-fiverr-cta-description">
-				<p><b><?php esc_html_e( 'Make an incredible logo in minutes', 'jetpack-mu-wpcom' ); ?></b></p>
-				<p><?php esc_html_e( 'Pre-designed by top talent. Just add your touch.', 'jetpack-mu-wpcom' ); ?></p>
+			<div class="wpcom-fiverr-cta-box">
+				<?php wpcom_fiverr_logo(); ?>
+				<div class="wpcom-fiverr-cta-description">
+					<p>
+						<?php
+						printf(
+							/* translators: %1$s: opening link tag to the Fiverr logo maker, %2$s: closing link tag. */
+							esc_html__( 'No logo yet? Make one in minutes with %1$sFiverr Logo Maker%2$s.', 'jetpack-mu-wpcom' ),
+							'<a class="wpcom-fiverr-cta-link" href="' . esc_url( 'https://wp.me/logo-maker/?utm_campaign=general_settings' ) . '" target="_blank" rel="noopener noreferrer">',
+							'</a>'
+						);
+						?>
+					</p>
+					<p><?php esc_html_e( 'Pre-designed by top talent. Just add your touch.', 'jetpack-mu-wpcom' ); ?></p>
+				</div>
 			</div>
-			<?php wpcom_fiverr_cta_button(); ?>
 		<?php endif; ?>
 	</div>
 	<?php

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.php
@@ -156,7 +156,7 @@ function wpcom_fiverr_cta() {
 				<?php wpcom_fiverr_cta_button(); ?>
 			</div>
 		<?php else : ?>
-			<div class="wpcom-fiverr-cta-copy">
+			<div class="wpcom-fiverr-cta-description">
 				<p><b><?php esc_html_e( 'Make an incredible logo in minutes', 'jetpack-mu-wpcom' ); ?></b></p>
 				<p><?php esc_html_e( 'Pre-designed by top talent. Just add your touch.', 'jetpack-mu-wpcom' ); ?></p>
 			</div>

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
@@ -49,7 +49,9 @@
 		}
 	}
 
-	.wpcom-site-logo + .description {
+	.wpcom-site-logo-description {
+		// Sits on its own line below the preview or the CTA button, clear of the
+		// tighter spacing core gives paragraphs inside a form table cell.
 		margin-top: 8px;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
@@ -49,10 +49,37 @@
 		}
 	}
 
+	.wpcom-fiverr-cta-box {
+		display: flex;
+		align-items: flex-start;
+		gap: 10px;
+		max-inline-size: 30em;
+		padding: 12px;
+		border: 1px solid #dcdcde;
+		border-radius: 4px;
+		background-color: #fff;
+
+		.wpcom-fiverr-cta-logo {
+			// Keep the mark circular at any text length, and align it with the
+			// first line rather than the middle of the block.
+			flex-shrink: 0;
+			margin-block-start: 2px;
+		}
+
+		p {
+			margin: 0;
+		}
+
+		p + p {
+			margin-block-start: 4px;
+			color: #646970;
+		}
+	}
+
 	.wpcom-site-logo-description {
 		// Sits on its own line below the CTA, clear of the tighter spacing core
 		// gives paragraphs inside a form table cell.
-		margin-top: 8px;
+		margin-block-start: 8px;
 	}
 
 	.button.wpcom-add-custom-address-button {

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
@@ -52,12 +52,15 @@
 	.wpcom-fiverr-cta-box {
 		display: flex;
 		align-items: flex-start;
-		gap: 10px;
-		max-inline-size: 30em;
+		gap: 8px;
+		// Shrink to the width of the copy rather than filling the settings
+		// cell, while still giving way on narrow screens.
+		inline-size: fit-content;
+		max-inline-size: 100%;
 		padding: 12px;
-		border: 1px solid #dcdcde;
-		border-radius: 4px;
-		background-color: #fff;
+		border: 1px solid #ccc;
+		border-radius: 2px;
+		background-color: #fafafa;
 
 		.wpcom-fiverr-cta-logo {
 			// Keep the mark circular at any text length, and align it with the

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.scss
@@ -50,8 +50,8 @@
 	}
 
 	.wpcom-site-logo-description {
-		// Sits on its own line below the preview or the CTA button, clear of the
-		// tighter spacing core gives paragraphs inside a form table cell.
+		// Sits on its own line below the CTA, clear of the tighter spacing core
+		// gives paragraphs inside a form table cell.
 		margin-top: 8px;
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-options-general/options-general.ts
@@ -16,7 +16,9 @@ const _wpcomBuildFiverrCta = ( fragment: DocumentFragment ) => {
  * Set up the Fiverr CTA.
  */
 function wpcomInitializeFiverrCta() {
-	const fiverCta = document.querySelector( '.wpcom-fiverr-cta-button' );
+	// A button when a logo is set, an inline link in the empty state; only one
+	// of the two is ever rendered.
+	const fiverCta = document.querySelector( '.wpcom-fiverr-cta-button, .wpcom-fiverr-cta-link' );
 	if ( fiverCta ) {
 		fiverCta.addEventListener( 'click', e => {
 			e.preventDefault();


### PR DESCRIPTION
## Proposed changes

* In WP Admin > Settings > General, the Site Logo row only offered a link to set a logo once one already existed. The empty state showed nothing but the Fiverr upsell, leaving no path to upload a logo — exactly the case where someone is most likely trying to add one.
* The Site Editor (block themes) / Customizer (classic themes) link now renders in both states, below the Fiverr CTA. The wording moved from "change" to "set" so one string reads correctly whether or not a logo is present.
* Restyled the empty state as a bordered callout carrying the Fiverr mark, with the logo maker as an inline link rather than a button. The CTA is now an anchor with a real `href`, so it still works if the tracking script fails to load.
* The Site Editor / Customizer link is still omitted when there is no reliable destination: classic themes supporting neither `custom-logo` nor `site-logo`, and block themes on versions without the Site Editor's Identity screen.

## Related product discussion/links

* EDI-646
* Follow-up to the earlier PR that added the logo preview and edit link (EDI-639).

## Does this pull request change what data or activity we track or use?

No. The existing `wpcom_admin_site_icon_fiverr_logo_maker_cta_click` event still fires from the CTA in both states.

## Testing instructions

On a WordPress.com / Atomic site (or anywhere `jetpack-mu-wpcom` is active), go to **Settings > General** and find the **Site Logo** row.

**Block theme, no logo set** (the bug):
* Confirm a bordered callout showing the Fiverr mark, "No logo yet? Make one in minutes with Fiverr Logo Maker." and "Pre-designed by top talent. Just add your touch."
* Below the callout: "Displays in your site's layout via the Site Logo block. You can set your site logo in the site editor.", linking to the Site Editor's Identity screen. Before this change, no link appeared here at all.
* Click "Fiverr Logo Maker" and confirm it opens the logo maker in a new tab and still records the CTA click event.

**Block theme, logo set:**
* Set a logo and return. The logo preview should appear next to the "Try Fiverr Logo Maker" button, with the same description below.

**Classic theme** (e.g. Twenty Twenty-One):
* With and without a logo set, the description should read "You can set your site logo in the Customizer." and open the Customizer focused on the logo control.

**Link suppression:**
* On a classic theme that declares neither `custom-logo` nor `site-logo` support, confirm no Site Editor / Customizer link is rendered and the callout is otherwise unchanged.
