### PR TITLE
WOOA7S-1832: Show the origin report in detail-page breadcrumbs

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1832-detail-breadcrumb
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1832-detail-breadcrumb
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Detail pages: Show the report the visitor came from in the breadcrumb.

--- a/projects/packages/premium-analytics/packages/routing/src/index.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/index.ts
@@ -9,7 +9,17 @@ export {
 	REPORT_DATE_PARAM_KEYS,
 	pickReportDateParams,
 	buildDashboardLink,
+	buildReportLink,
 } from './search/report-params';
+export {
+	REPORT_ORIGIN_PARAM_KEYS,
+	createReportOriginSearch,
+	createDetailLinkSearch,
+	readReportOriginSearch,
+	pickReportOriginParams,
+	type DetailLinkSearchUpdater,
+	type ReportOrigin,
+} from './search/report-origin';
 export {
 	useStagedSearch,
 	useReportDateFilters,

--- a/projects/packages/premium-analytics/packages/routing/src/search/report-origin/index.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/search/report-origin/index.ts
@@ -1,0 +1,9 @@
+export {
+	REPORT_ORIGIN_PARAM_KEYS,
+	createReportOriginSearch,
+	createDetailLinkSearch,
+	readReportOriginSearch,
+	pickReportOriginParams,
+	type DetailLinkSearchUpdater,
+	type ReportOrigin,
+} from './report-origin';

--- a/projects/packages/premium-analytics/packages/routing/src/search/report-origin/report-origin.test.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/search/report-origin/report-origin.test.ts
@@ -1,0 +1,58 @@
+import {
+	createDetailLinkSearch,
+	createReportOriginSearch,
+	pickReportOriginParams,
+	readReportOriginSearch,
+} from './report-origin';
+
+describe( 'report origin search params', () => {
+	it( 'round-trips a report and section', () => {
+		expect( readReportOriginSearch( createReportOriginSearch( 'comments', 'posts' ) ) ).toEqual( {
+			report: 'comments',
+			section: 'posts',
+		} );
+	} );
+
+	it( 'omits an empty section', () => {
+		expect( createReportOriginSearch( 'videos' ) ).toEqual( { ref: 'videos' } );
+		expect( readReportOriginSearch( createReportOriginSearch( 'videos' ) ) ).toEqual( {
+			report: 'videos',
+		} );
+	} );
+
+	it.each( [
+		[ 'no search', undefined ],
+		[ 'no ref', { from: '2026-06-01' } ],
+		[ 'an empty ref', { ref: '' } ],
+		[ 'a non-string ref', { ref: 42 } ],
+	] )( 'reads no origin from %s', ( _label, search ) => {
+		expect( readReportOriginSearch( search as Record< string, unknown > ) ).toBeUndefined();
+	} );
+
+	it( 'picks only the origin params that are set', () => {
+		expect(
+			pickReportOriginParams( {
+				from: '2026-06-01',
+				ref: 'posts',
+				ref_section: 'archives',
+				post_id: '42',
+			} )
+		).toEqual( { ref: 'posts', ref_section: 'archives' } );
+
+		expect( pickReportOriginParams( { from: '2026-06-01' } ) ).toEqual( {} );
+		expect( pickReportOriginParams( undefined ) ).toEqual( {} );
+	} );
+
+	it( 'builds a detail link updater from the report window, the origin, and the destination params', () => {
+		const updateSearch = createDetailLinkSearch( {
+			report: 'emails',
+			extraParams: { section: 'email-opens' },
+		} );
+
+		expect( updateSearch( { from: '2026-06-01', post_id: '42', section: 'archives' } ) ).toEqual( {
+			from: '2026-06-01',
+			ref: 'emails',
+			section: 'email-opens',
+		} );
+	} );
+} );

--- a/projects/packages/premium-analytics/packages/routing/src/search/report-origin/report-origin.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/search/report-origin/report-origin.ts
@@ -1,0 +1,124 @@
+import { pickReportDateParams } from '../report-params';
+
+export type ReportOrigin = {
+	report: string;
+	section?: string;
+};
+
+/**
+ * Search params that name the report a detail page was opened from.
+ *
+ * The origin travels in the URL rather than in history state. Every navigation
+ * carries the search params forward on its own, so a date change or a tab
+ * switch on the detail page cannot drop the breadcrumb. A route that allowlists
+ * its params must pass these through with `pickReportOriginParams()`.
+ */
+export const REPORT_ORIGIN_PARAM_KEYS = [ 'ref', 'ref_section' ] as const;
+
+/**
+ * Build the search params that carry a report origin to a detail page.
+ *
+ * @param report  - The report the detail link belongs to.
+ * @param section - The active report section, when the report has tabs.
+ * @return Search params to merge into the detail link.
+ */
+export function createReportOriginSearch(
+	report: string,
+	section?: string
+): Record< string, string > {
+	return {
+		ref: report,
+		...( section ? { ref_section: section } : {} ),
+	};
+}
+
+/**
+ * Builds the next search params of a detail link from the current ones.
+ *
+ * The router types a link's `search` prop against the destination route's own
+ * param shape and does not model this updater form, so a call site that passes
+ * the updater to a router `Link` casts it — the same cast those links already
+ * apply to `params`. Components that accept an updater of this type, such as
+ * `PostTitleLink`, take it without a cast.
+ */
+export type DetailLinkSearchUpdater = (
+	current: Record< string, unknown >
+) => Record< string, unknown >;
+
+/**
+ * Build the `search` prop for a report table's detail link.
+ *
+ * Every report table links a row to a detail page the same way: carry the
+ * shared report window forward, then name the report the visitor came from so
+ * the detail page can render the origin breadcrumb.
+ *
+ * @param options               - Link options.
+ * @param options.report        - The report the detail link belongs to.
+ * @param options.originSection - The active report section, when the report has tabs.
+ * @param options.extraParams   - Params the destination owns, such as the detail page's section.
+ * @return The `search` updater for the detail link.
+ */
+export function createDetailLinkSearch( {
+	report,
+	originSection,
+	extraParams,
+}: {
+	report: string;
+	originSection?: string;
+	extraParams?: Record< string, string >;
+} ): DetailLinkSearchUpdater {
+	return current => ( {
+		...pickReportDateParams( current ),
+		...createReportOriginSearch( report, originSection ),
+		...( extraParams ?? {} ),
+	} );
+}
+
+/**
+ * Read a report origin from the current route search params.
+ *
+ * The values are untrusted: anyone can type them into the URL. The caller
+ * resolves them against the report registry before linking to them.
+ *
+ * @param search - The current route search params.
+ * @return The report origin, when one is present.
+ */
+export function readReportOriginSearch(
+	search: Record< string, unknown > | undefined
+): ReportOrigin | undefined {
+	const report = search?.ref;
+	if ( typeof report !== 'string' || ! report ) {
+		return undefined;
+	}
+
+	const section = search?.ref_section;
+
+	return {
+		report,
+		...( typeof section === 'string' && section ? { section } : {} ),
+	};
+}
+
+/**
+ * Pick the report-origin params out of a search object.
+ *
+ * Detail routes allowlist the params they own when they seed the URL, so the
+ * origin needs to be re-added explicitly to survive that redirect.
+ *
+ * @param search - The current route search params.
+ * @return Only the report-origin params that are set.
+ */
+export function pickReportOriginParams(
+	search: Record< string, unknown > | undefined
+): Record< string, string > {
+	const picked: Record< string, string > = {};
+
+	for ( const key of REPORT_ORIGIN_PARAM_KEYS ) {
+		const value = search?.[ key ];
+		if ( typeof value === 'string' && value ) {
+			picked[ key ] = value;
+		}
+	}
+
+	return picked;
+}

--- a/projects/packages/premium-analytics/packages/routing/src/search/report-params/index.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/search/report-params/index.ts
@@ -1,1 +1,6 @@
-export { REPORT_DATE_PARAM_KEYS, pickReportDateParams, buildDashboardLink } from './report-params';
+export {
+	REPORT_DATE_PARAM_KEYS,
+	pickReportDateParams,
+	buildDashboardLink,
+	buildReportLink,
+} from './report-params';

--- a/projects/packages/premium-analytics/packages/routing/src/search/report-params/report-params.test.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/search/report-params/report-params.test.ts
@@ -1,4 +1,32 @@
-import { buildDashboardLink, pickReportDateParams } from './report-params';
+import { buildDashboardLink, buildReportLink, pickReportDateParams } from './report-params';
+
+/**
+ * Read a link's querystring the way the router reads it, so a test asserts the
+ * values the destination route receives rather than their raw encoding.
+ *
+ * @param url - The parsed link.
+ * @return The search params, parsed.
+ */
+function parseSearch( url: URL ): Record< string, unknown > {
+	const parsed: Record< string, unknown > = {};
+
+	for ( const [ key, value ] of url.searchParams ) {
+		try {
+			parsed[ key ] = JSON.parse( value );
+		} catch {
+			parsed[ key ] = value;
+		}
+	}
+
+	return parsed;
+}
+
+function expectLink( link: string, pathname: string, search: Record< string, unknown > ) {
+	const url = new URL( link, 'https://example.com' );
+
+	expect( url.pathname ).toBe( pathname );
+	expect( parseSearch( url ) ).toEqual( search );
+}
 
 describe( 'pickReportDateParams', () => {
 	it( 'keeps only the shared report-window params that are set', () => {
@@ -60,13 +88,80 @@ describe( 'buildDashboardLink', () => {
 	} );
 
 	it( 'drops page-scoped params, carrying only the report window', () => {
-		expect(
+		expect.assertions( 2 );
+		expectLink(
 			buildDashboardLink( {
 				from: '2026-01-01',
 				period: 'week',
 				post_id: '42',
 				section: 'archives',
-			} )
-		).toBe( '/?from=2026-01-01' );
+			} ),
+			'/',
+			{ from: '2026-01-01' }
+		);
+	} );
+} );
+
+describe( 'buildReportLink', () => {
+	it( 'serializes the shared report window into the querystring', () => {
+		expect.assertions( 2 );
+		expectLink(
+			buildReportLink( 'videos', {
+				from: '2026-01-01',
+				to: '2026-01-31',
+				compare_from: '2025-12-01',
+				comp: '1',
+			} ),
+			'/reports/videos',
+			{
+				from: '2026-01-01',
+				to: '2026-01-31',
+				compare_from: '2025-12-01',
+				comp: '1',
+			}
+		);
+	} );
+
+	it( 'quotes a numeric string so it survives the router round trip', () => {
+		expect.assertions( 3 );
+
+		const link = buildReportLink( 'videos', { comp: '1' } );
+
+		expect( link ).toBe( '/reports/videos?comp=%221%22' );
+		expectLink( link, '/reports/videos', { comp: '1' } );
+	} );
+
+	it( 'leaves a value that is not valid JSON unquoted', () => {
+		expect( buildReportLink( 'videos', { from: '2026-01-01' } ) ).toBe(
+			'/reports/videos?from=2026-01-01'
+		);
+	} );
+
+	it( 'appends the referring report section when supplied', () => {
+		expect.assertions( 2 );
+		expectLink(
+			buildReportLink(
+				'comments',
+				{ from: '2026-01-01', to: '2026-01-31', ref_section: 'ignored' },
+				'posts'
+			),
+			'/reports/comments',
+			{ from: '2026-01-01', to: '2026-01-31', section: 'posts' }
+		);
+	} );
+
+	it( 'drops detail-page params, carrying only the report window', () => {
+		expect.assertions( 2 );
+		expectLink(
+			buildReportLink( 'emails', {
+				from: '2026-01-01',
+				post_id: '42',
+				section: 'email-opens',
+				ref: 'emails',
+				ref_section: 'posts',
+			} ),
+			'/reports/emails',
+			{ from: '2026-01-01' }
+		);
 	} );
 } );

--- a/projects/packages/premium-analytics/packages/routing/src/search/report-params/report-params.ts
+++ b/projects/packages/premium-analytics/packages/routing/src/search/report-params/report-params.ts
@@ -69,6 +69,26 @@ function stringifySearchValue( value: unknown ): string {
 }
 
 /**
+ * Add the shared report-window querystring and any page-specific params to a path.
+ *
+ * @param path        - The path to link to.
+ * @param search      - The current route search params.
+ * @param extraParams - Optional destination-specific query params.
+ * @return The path with its serialized querystring.
+ */
+function buildReportWindowLink(
+	path: string,
+	search: Record< string, unknown > | undefined,
+	extraParams: Record< string, string > = {}
+): string {
+	const params = { ...pickReportDateParams( search ), ...extraParams };
+	const query = new URLSearchParams(
+		Object.entries( params ).map( ( [ key, value ] ) => [ key, stringifySearchValue( value ) ] )
+	).toString();
+	return query ? `${ path }?${ query }` : path;
+}
+
+/**
  * Build the `to` link back to the dashboard, preserving the shared report window.
  *
  * Serializes the date range and comparison (via `pickReportDateParams`) into a
@@ -79,9 +99,25 @@ function stringifySearchValue( value: unknown ): string {
  * @return A dashboard `to` path (e.g. `/?from=…&to=…`), or `/` when none are set.
  */
 export function buildDashboardLink( search: Record< string, unknown > | undefined ): string {
-	const params = pickReportDateParams( search );
-	const query = new URLSearchParams(
-		Object.entries( params ).map( ( [ key, value ] ) => [ key, stringifySearchValue( value ) ] )
-	).toString();
-	return query ? `/?${ query }` : '/';
+	return buildReportWindowLink( '/', search );
+}
+
+/**
+ * Build the `to` link to a report, preserving the shared report window.
+ *
+ * @param reportId - The report registry id.
+ * @param search   - The current route search params.
+ * @param section  - The referring report's validated section.
+ * @return A report `to` path with the shared report-window querystring.
+ */
+export function buildReportLink(
+	reportId: string,
+	search: Record< string, unknown > | undefined,
+	section?: string
+): string {
+	return buildReportWindowLink(
+		`/reports/${ reportId }`,
+		search,
+		section ? { section } : undefined
+	);
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/index.ts
@@ -54,6 +54,7 @@ export { WidgetBackLink, type WidgetBackLinkProps } from './widget-back-link';
 export { WidgetFooter, type WidgetFooterProps } from './widget-footer';
 export { ReportLink, type ReportLinkProps } from './report-link';
 export { PostTitleLink, POST_URL_SEARCH_PARAM, type PostTitleLinkProps } from './post-title-link';
+export { PostDetailLink, type PostDetailLinkProps } from './post-detail-link';
 export {
 	LeaderboardPostLabel,
 	type LeaderboardPostLabelProps,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/post-detail-link/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/post-detail-link/index.ts
@@ -1,0 +1,1 @@
+export { PostDetailLink, type PostDetailLinkProps } from './post-detail-link';

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/post-detail-link/post-detail-link.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/post-detail-link/post-detail-link.tsx
@@ -1,0 +1,87 @@
+/**
+ * External dependencies
+ */
+import { createDetailLinkSearch } from '@jetpack-premium-analytics/routing';
+import { Link } from '@wordpress/route';
+import type { ReactNode } from 'react';
+
+export type PostDetailLinkProps = {
+	/**
+	 * Post or page ID of the row the link belongs to.
+	 */
+	postId: number | string;
+
+	/**
+	 * The report the link is rendered from. It names the origin the detail
+	 * page's breadcrumb links back to.
+	 */
+	report: string;
+
+	/**
+	 * The report's active section, when the report has tabs.
+	 */
+	originSection?: string;
+
+	/**
+	 * Params the detail page owns, such as the tab it opens on.
+	 */
+	extraParams?: Record< string, string >;
+
+	/**
+	 * Optional class for the anchor.
+	 */
+	className?: string;
+
+	/**
+	 * Optional native title attribute, for the full text on hover.
+	 */
+	title?: string;
+
+	/**
+	 * The link's visible content.
+	 */
+	children: ReactNode;
+};
+
+/**
+ * Link a report row to the post detail page, carrying the report window and the
+ * origin the detail breadcrumb links back to.
+ *
+ * Every report table builds this link the same way, and the router types both
+ * `params` and `search` against a route tree it cannot resolve here, so each
+ * prop needs a cast. This component holds the shape and both casts once, so a
+ * report's field config stays free of them.
+ *
+ * @param props               - Component props.
+ * @param props.postId        - Post or page ID.
+ * @param props.report        - The report the link is rendered from.
+ * @param props.originSection - The report's active section.
+ * @param props.extraParams   - Params the detail page owns.
+ * @param props.className     - Optional class for the anchor.
+ * @param props.title         - Optional native title attribute.
+ * @param props.children      - The link's visible content.
+ * @return The detail page link.
+ */
+export function PostDetailLink( {
+	postId,
+	report,
+	originSection,
+	extraParams,
+	className,
+	title,
+	children,
+}: PostDetailLinkProps ): JSX.Element {
+	return (
+		<Link
+			to="/post/$postId"
+			params={ { postId: String( postId ) } as unknown as never }
+			search={
+				createDetailLinkSearch( { report, originSection, extraParams } ) as unknown as never
+			}
+			className={ className }
+			title={ title }
+		>
+			{ children }
+		</Link>
+	);
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/video-title-link/video-title-link.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/video-title-link/video-title-link.tsx
@@ -8,7 +8,9 @@ export type VideoTitleLinkProps = {
 	id?: number | string;
 	label: string;
 	link?: string | null;
-	search?: Record< string, unknown >;
+	search?:
+		| Record< string, unknown >
+		| ( ( current: Record< string, unknown > ) => Record< string, unknown > );
 	classNames?: {
 		internal?: string;
 		external?: string;
@@ -25,7 +27,8 @@ export type VideoTitleLinkProps = {
  * @param props.id         - Video attachment ID.
  * @param props.label      - Visible video title.
  * @param props.link       - External fallback URL.
- * @param props.search     - Search parameters for the detail route.
+ * @param props.search     - Search parameters for the detail route, either as an
+ *                         object or as an updater that receives the current search.
  * @param props.classNames - Optional classes for each rendering branch.
  * @param props.title      - Optional native title attribute.
  * @return The linked or plain video title.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/index.ts
@@ -57,6 +57,8 @@ export {
 	PostTitleLink,
 	POST_URL_SEARCH_PARAM,
 	type PostTitleLinkProps,
+	PostDetailLink,
+	type PostDetailLinkProps,
 	LeaderboardPostLabel,
 	type LeaderboardPostLabelProps,
 	type LeaderboardPostLabelVariant,

--- a/projects/packages/premium-analytics/routes/post-detail/route.test.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/route.test.ts
@@ -1,0 +1,98 @@
+import { ensureCoreSettingsReady } from '@jetpack-premium-analytics/data';
+import { select } from '@wordpress/data';
+import { redirect } from '@wordpress/route';
+import { route } from './route';
+
+jest.mock( '@jetpack-premium-analytics/data', () => ( {
+	...jest.requireActual( '@jetpack-premium-analytics/data' ),
+	ensureCoreSettingsReady: jest.fn(),
+} ) );
+
+jest.mock( '@wordpress/core-data', () => ( { store: {} } ) );
+jest.mock( '@wordpress/data', () => ( {
+	dispatch: jest.fn(),
+	select: jest.fn(),
+} ) );
+jest.mock( '@wordpress/route', () => ( {
+	redirect: jest.fn( options => options ),
+} ) );
+jest.mock( '../site-readiness', () => ( {
+	isPremiumAnalyticsInitialSyncFinished: () => true,
+	isPremiumAnalyticsSiteConnected: () => true,
+} ) );
+jest.mock( './config', () => ( {
+	resolveTabId: ( section: string ) => section,
+} ) );
+
+const mockEnsureCoreSettingsReady = ensureCoreSettingsReady as jest.MockedFunction<
+	typeof ensureCoreSettingsReady
+>;
+const mockSelect = select as jest.MockedFunction< typeof select >;
+const mockRedirect = redirect as jest.MockedFunction< typeof redirect >;
+
+const seededSearch = {
+	from: '2026-06-01',
+	to: '2026-06-16',
+	interval: 'day',
+	post_id: '42',
+};
+
+describe( 'post detail route report origin', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockEnsureCoreSettingsReady.mockResolvedValue( undefined );
+		mockSelect.mockReturnValue( {
+			getEntityConfig: () => ( {} ),
+			getEntityRecord: () => undefined,
+		} as never );
+	} );
+
+	it( 'carries the report origin through the seeding redirect', async () => {
+		await expect(
+			route.beforeLoad( {
+				params: { postId: '42' },
+				search: {
+					...seededSearch,
+					post_id: undefined,
+					ref: 'comments',
+					ref_section: 'posts',
+				},
+			} )
+		).rejects.toMatchObject( {
+			to: '/post/$postId',
+			replace: true,
+			search: {
+				from: '2026-06-01',
+				to: '2026-06-16',
+				interval: 'day',
+				post_id: '42',
+				ref: 'comments',
+				ref_section: 'posts',
+			},
+		} );
+
+		expect( mockRedirect ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'does not redirect when a seeded search already carries the origin', async () => {
+		await expect(
+			route.beforeLoad( {
+				params: { postId: '42' },
+				search: { ...seededSearch, ref: 'comments', ref_section: 'posts' },
+			} )
+		).resolves.toBeUndefined();
+
+		expect( mockRedirect ).not.toHaveBeenCalled();
+	} );
+
+	it( 'does not redirect when the shareable search is fully seeded and clean', async () => {
+		await expect(
+			route.beforeLoad( {
+				params: { postId: '42' },
+				search: seededSearch,
+			} )
+		).resolves.toBeUndefined();
+
+		expect( mockRedirect ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/post-detail/route.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/route.ts
@@ -6,6 +6,7 @@ import {
 	needsReportDateParamsSeed,
 	normalizeReportParams,
 } from '@jetpack-premium-analytics/data';
+import { pickReportOriginParams } from '@jetpack-premium-analytics/routing';
 import { redirect } from '@wordpress/route';
 /**
  * Internal dependencies
@@ -92,10 +93,13 @@ export const route = {
 			// known report-window params, and the path-derived `post_id` is the
 			// single source of scope. This contains any foreign params a link
 			// carried in (e.g. a dashboard `section`) instead of persisting them.
+			// The report origin is part of that allowlist, so the breadcrumb keeps
+			// its link back to the referring report across this seed.
 			const seeded: Record< string, unknown > = {
 				...normalizeReportParams(
 					currentSearch as Parameters< typeof normalizeReportParams >[ 0 ]
 				),
+				...pickReportOriginParams( currentSearch ),
 				...( resolvedSection ? { section: resolvedSection } : {} ),
 				post_id: postId,
 			};

--- a/projects/packages/premium-analytics/routes/post-detail/stage.test.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.test.tsx
@@ -3,12 +3,17 @@ import { usePostSummary } from './hooks';
 import { stage } from './stage';
 import type { ReactNode } from 'react';
 
+let mockSearch: Record< string, unknown > = {};
+
 jest.mock( '@jetpack-premium-analytics/data', () => ( {
 	AnalyticsQueryClientProvider: ( { children }: { children: ReactNode } ) => <>{ children }</>,
 	GlobalErrorProvider: ( { children }: { children: ReactNode } ) => <>{ children }</>,
 } ) );
 
 jest.mock( '@jetpack-premium-analytics/routing', () => ( {
+	// Spread the real module so the report registry's tab configs, which call
+	// `defineReportTabs`, still resolve now that the registry is not mocked.
+	...jest.requireActual( '@jetpack-premium-analytics/routing' ),
 	useDashboardLink: () => '/?from=2026-06-01&to=2026-06-16',
 	useReportDateFilters: () => ( {} ),
 } ) );
@@ -101,7 +106,11 @@ jest.mock( '@wordpress/admin-ui', () => ( {
 
 jest.mock( '@wordpress/route', () => ( {
 	useParams: () => ( { postId: '41' } ),
+	useSearch: () => mockSearch,
 } ) );
+
+// The report registry is deliberately not mocked so the breadcrumb exercises
+// the real report-origin validation.
 
 jest.mock( './components', () => ( {
 	PostDetailTabs: ( { children }: { children: ReactNode } ) => <div>{ children }</div>,
@@ -137,9 +146,21 @@ function mockSummary( overrides: Record< string, unknown > = {} ) {
 	} );
 }
 
+/**
+ * Read the breadcrumb labels rendered by the page, in order.
+ *
+ * @return The visible breadcrumb labels.
+ */
+function getBreadcrumbLabels(): ( string | null )[] {
+	const breadcrumbs = within( screen.getByRole( 'navigation', { name: 'Breadcrumbs' } ) );
+
+	return breadcrumbs.getAllByRole( 'listitem' ).map( crumb => crumb.textContent );
+}
+
 describe( 'post detail stage', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		mockSearch = { from: '2026-06-01', to: '2026-06-16', post_id: '41' };
 	} );
 
 	it( 'puts a View post action in the page header, opening the live post in a new tab', () => {
@@ -181,21 +202,21 @@ describe( 'post detail stage', () => {
 		expect( screen.queryByRole( 'link', { name: /^View (post|page)$/ } ) ).not.toBeInTheDocument();
 	} );
 
-	it( 'renders the breadcrumb trail with the resolved title', () => {
+	it( 'keeps the two-crumb trail when no report origin is present', () => {
 		mockSummary();
 
 		render( stage() );
 
-		const breadcrumbs = within( screen.getByRole( 'navigation', { name: 'Breadcrumbs' } ) );
-		const crumbs = breadcrumbs.getAllByRole( 'listitem' );
-		expect( crumbs.map( crumb => crumb.textContent ) ).toEqual( [ 'Stats', 'Hello world' ] );
-		expect( within( crumbs[ 0 ] ).getByRole( 'link', { name: 'Stats' } ) ).toHaveAttribute(
-			'href',
-			'/?from=2026-06-01&to=2026-06-16'
-		);
-		expect(
-			within( crumbs[ 1 ] ).getByRole( 'heading', { level: 1, name: 'Hello world' } )
-		).toBeInTheDocument();
+		expect( getBreadcrumbLabels() ).toEqual( [ 'Stats', 'Hello world' ] );
+	} );
+
+	it( 'adds the referring report between Stats and the resolved title', () => {
+		mockSummary();
+		mockSearch = { ...mockSearch, ref: 'posts' };
+
+		render( stage() );
+
+		expect( getBreadcrumbLabels() ).toEqual( [ 'Stats', 'Posts & Pages', 'Hello world' ] );
 	} );
 
 	it.each( [ { title: undefined, isLoading: true }, { title: '' } ] )(

--- a/projects/packages/premium-analytics/routes/post-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.tsx
@@ -16,6 +16,7 @@ import { __ } from '@wordpress/i18n';
 import { useParams } from '@wordpress/route';
 import { DEFAULT_GRID, ROW_HEIGHT_PRESETS, WidgetDashboard } from '@wordpress/widget-dashboard';
 import { type WidgetModuleRecord } from '@wordpress/widget-primitives';
+import { useDetailBreadcrumbs } from '../use-detail-breadcrumbs';
 import { resolveWidgetModuleWithI18n, useWidgetTypesWithI18n } from '../widget-module-i18n';
 import { PostDetailTabs, PostSummaryCard } from './components';
 import { POST_DETAIL_WIDGET_TYPE_ALIASES } from './config';
@@ -102,6 +103,8 @@ function PostDetail(): JSX.Element {
 	// params, staged and committed by the shared date-filter controller.
 	const dateFilters = useReportDateFilters( ROUTE_FROM );
 
+	const breadcrumbs = useDetailBreadcrumbs( summary.title );
+
 	return (
 		<GlobalErrorProvider>
 			<WidgetDashboard
@@ -114,9 +117,7 @@ function PostDetail(): JSX.Element {
 			>
 				<Page
 					visual={ <StatsPageIcon /> }
-					breadcrumbs={
-						<StatsBreadcrumbs items={ summary.title ? [ { label: summary.title } ] : [] } />
-					}
+					breadcrumbs={ <StatsBreadcrumbs items={ breadcrumbs } /> }
 					actions={
 						publicUrl ? (
 							<Button

--- a/projects/packages/premium-analytics/routes/reports/authors/config/fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/authors/config/fields.test.tsx
@@ -5,9 +5,9 @@ import { render, screen } from '@testing-library/react';
 /**
  * Internal dependencies
  */
+import { getMockRouteLinkUrl, setMockRouteSearch } from '../../../../tests/js/route-test-utils';
 import { getAuthorsFields } from './fields';
 import type { AuthorRow } from './aggregate';
-import type { ReactNode } from 'react';
 
 const author: AuthorRow = {
 	id: 'id:42',
@@ -29,17 +29,18 @@ const post: AuthorRow = {
 
 // Field tests do not mount the dynamic report router, so render its Link as
 // the internal anchor produced for the post detail route.
-jest.mock( '@wordpress/route', () => ( {
-	Link: ( {
-		to,
-		params,
-		children,
-	}: {
-		to: string;
-		params: Record< string, string >;
-		children: ReactNode;
-	} ) => <a href={ to.replace( '$postId', params.postId ) }>{ children }</a>,
-} ) );
+jest.mock( '@wordpress/route', () => {
+	const { mockWordPressRoute } = jest.requireActual( '../../../../tests/js/route-test-utils' );
+
+	return mockWordPressRoute;
+} );
+
+setMockRouteSearch( {
+	from: '2026-06-01',
+	to: '2026-06-16',
+	interval: 'day',
+	foreign: 'drop-me',
+} );
 
 /**
  * Mount an Authors table field's render component.
@@ -87,7 +88,14 @@ describe( 'authors fields', () => {
 		renderField( 'author', post );
 
 		const link = screen.getByRole( 'link', { name: /Analytical Engine/ } );
-		expect( link ).toHaveAttribute( 'href', '/post/1' );
+		const url = getMockRouteLinkUrl( link );
+		expect( url.pathname ).toBe( '/post/1' );
+		expect( Object.fromEntries( url.searchParams ) ).toEqual( {
+			from: '2026-06-01',
+			to: '2026-06-16',
+			interval: 'day',
+			ref: 'authors',
+		} );
 		expect( link ).not.toHaveAttribute( 'target' );
 		// eslint-disable-next-line testing-library/no-node-access -- the removed external-link icon has no accessible role or text.
 		expect( link.querySelector( 'svg' ) ).not.toBeInTheDocument();

--- a/projects/packages/premium-analytics/routes/reports/authors/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/authors/config/fields.tsx
@@ -3,9 +3,8 @@
  */
 import { Stack } from '@jetpack-premium-analytics/externals';
 import { DrilldownLeafCell } from '@jetpack-premium-analytics/ui';
-import { MetricWithComparison } from '@jetpack-premium-analytics/widgets-toolkit';
+import { MetricWithComparison, PostDetailLink } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __, sprintf } from '@wordpress/i18n';
-import { Link } from '@wordpress/route';
 /**
  * Internal dependencies
  */
@@ -65,9 +64,9 @@ export function getAuthorsFields( withComparison = false ): Field< AuthorRow >[]
 						<DrilldownLeafCell groupLabel={ getAuthorName( item.parentName ?? '' ) }>
 							<span>
 								{ item.postId ? (
-									<Link to="/post/$postId" params={ { postId: item.postId } as unknown as never }>
+									<PostDetailLink postId={ item.postId } report="authors">
 										{ item.label }
-									</Link>
+									</PostDetailLink>
 								) : (
 									item.label
 								) }

--- a/projects/packages/premium-analytics/routes/reports/comment-followers/config/fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/comment-followers/config/fields.test.tsx
@@ -6,23 +6,24 @@ import { render, screen } from '@testing-library/react';
 /**
  * Internal dependencies
  */
+import { getMockRouteLinkUrl, setMockRouteSearch } from '../../../../tests/js/route-test-utils';
 import { getCommentFollowersFields } from './fields';
-import type { ReactNode } from 'react';
 
 // The router is built dynamically at runtime, so a field-level test has no
 // router to mount. Render `Link` as the anchor it becomes, keeping `to`/`params`
 // assertable.
-jest.mock( '@wordpress/route', () => ( {
-	Link: ( {
-		to,
-		params,
-		children,
-	}: {
-		to: string;
-		params: Record< string, string >;
-		children: ReactNode;
-	} ) => <a href={ to.replace( /\$(\w+)/g, ( _match, key ) => params[ key ] ) }>{ children }</a>,
-} ) );
+jest.mock( '@wordpress/route', () => {
+	const { mockWordPressRoute } = jest.requireActual( '../../../../tests/js/route-test-utils' );
+
+	return mockWordPressRoute;
+} );
+
+setMockRouteSearch( {
+	from: '2026-06-01',
+	to: '2026-06-16',
+	interval: 'day',
+	foreign: 'drop-me',
+} );
 
 /**
  * Mount the post field's render component for a table row.
@@ -55,7 +56,14 @@ describe( 'comment followers fields', () => {
 		} );
 
 		const link = screen.getByRole( 'link', { name: 'Hello world' } );
-		expect( link ).toHaveAttribute( 'href', '/post/42' );
+		const url = getMockRouteLinkUrl( link );
+		expect( url.pathname ).toBe( '/post/42' );
+		expect( Object.fromEntries( url.searchParams ) ).toEqual( {
+			from: '2026-06-01',
+			to: '2026-06-16',
+			interval: 'day',
+			ref: 'comment-followers',
+		} );
 		// Navigation stays in the app, so the row must not open a new tab.
 		expect( link ).not.toHaveAttribute( 'target' );
 	} );

--- a/projects/packages/premium-analytics/routes/reports/comment-followers/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/comment-followers/config/fields.tsx
@@ -5,9 +5,9 @@ import { type StatsCommentFollowersItem } from '@jetpack-premium-analytics/data'
 import { type Field } from '@jetpack-premium-analytics/externals';
 import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
 import { safeHttpUrl } from '@jetpack-premium-analytics/ui';
+import { PostDetailLink } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';
 import { Icon, external } from '@wordpress/icons';
-import { Link } from '@wordpress/route';
 /**
  * Internal dependencies
  */
@@ -35,9 +35,9 @@ export function getCommentFollowersFields(): Field< StatsCommentFollowersItem >[
 				// the ID for some entries) keep the external link as the fallback.
 				if ( item.id ) {
 					return (
-						<Link to="/post/$postId" params={ { postId: String( item.id ) } as unknown as never }>
+						<PostDetailLink postId={ item.id } report="comment-followers">
 							{ item.label }
-						</Link>
+						</PostDetailLink>
 					);
 				}
 

--- a/projects/packages/premium-analytics/routes/reports/comment-followers/page.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/comment-followers/page.test.tsx
@@ -15,6 +15,7 @@ jest.mock( './config', () => ( {
 } ) );
 
 jest.mock( '@jetpack-premium-analytics/routing', () => ( {
+	...jest.requireActual( '@jetpack-premium-analytics/routing' ),
 	useDashboardLink: () => '/',
 } ) );
 

--- a/projects/packages/premium-analytics/routes/reports/comments/config/fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/comments/config/fields.test.tsx
@@ -5,6 +5,7 @@ import { render, screen } from '@testing-library/react';
 /**
  * Internal dependencies
  */
+import { getMockRouteLinkUrl, setMockRouteSearch } from '../../../../tests/js/route-test-utils';
 import { getCommentsFields } from './fields';
 import type { CommentReportRow } from './use-report-records';
 import type { ReactNode } from 'react';
@@ -12,22 +13,19 @@ import type { ReactNode } from 'react';
 // The router is built dynamically at runtime, so a field-level test has no
 // router to mount. Render `Link` as the anchor it becomes, keeping `to`/`params`
 // assertable.
-jest.mock( '@wordpress/route', () => ( {
-	Link: ( {
-		to,
-		params,
-		children,
-		...props
-	}: {
-		to: string;
-		params: Record< string, string >;
-		children: ReactNode;
-	} ) => (
-		<a href={ to.replace( /\$(\w+)/g, ( _match, key ) => params[ key ] ) } { ...props }>
-			{ children }
-		</a>
-	),
-} ) );
+jest.mock( '@wordpress/route', () => {
+	const { mockWordPressRoute } = jest.requireActual( '../../../../tests/js/route-test-utils' );
+
+	return mockWordPressRoute;
+} );
+
+setMockRouteSearch( {
+	from: '2026-06-01',
+	to: '2026-06-16',
+	interval: 'day',
+	section: 'posts',
+	foreign: 'drop-me',
+} );
 
 // The fields import `Link` from the externals passthrough, so the stub has to
 // replace it there; the Proxy leaves the rest of the barrel intact for any
@@ -76,7 +74,7 @@ jest.mock(
  * @return The Testing Library render result.
  */
 function renderLabelField( item: CommentReportRow ) {
-	const field = getCommentsFields().find( candidate => candidate.id === 'label' );
+	const field = getCommentsFields( 'posts' ).find( candidate => candidate.id === 'label' );
 	// eslint-disable-next-line testing-library/render-result-naming-convention -- `render` is the DataViews field render component.
 	const LabelField = field?.render;
 
@@ -98,7 +96,15 @@ describe( 'comments fields', () => {
 		} );
 
 		const link = screen.getByRole( 'link', { name: 'Hello world' } );
-		expect( link ).toHaveAttribute( 'href', '/post/42' );
+		const url = getMockRouteLinkUrl( link );
+		expect( url.pathname ).toBe( '/post/42' );
+		expect( Object.fromEntries( url.searchParams ) ).toEqual( {
+			from: '2026-06-01',
+			to: '2026-06-16',
+			interval: 'day',
+			ref: 'comments',
+			ref_section: 'posts',
+		} );
 		expect( link ).not.toHaveAttribute( 'target' );
 	} );
 

--- a/projects/packages/premium-analytics/routes/reports/comments/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/comments/config/fields.tsx
@@ -3,23 +3,31 @@
  */
 import { Link as UiLink } from '@jetpack-premium-analytics/externals';
 import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
+import { PostDetailLink } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';
-import { Link as RouteLink } from '@wordpress/route';
 /**
  * Internal dependencies
  */
 import styles from './fields.module.css';
+import type { CommentsReportTabId } from './tabs';
 import type { CommentReportRow } from './use-report-records';
 import type { Field } from '@jetpack-premium-analytics/externals';
 
 /**
  * Render the label cell for a Comments report row.
  *
- * @param root0     - Component props.
- * @param root0.row - The Comments report row.
+ * @param root0               - Component props.
+ * @param root0.row           - The Comments report row.
+ * @param root0.originSection - The active Comments report tab.
  * @return The label cell.
  */
-function CommentLabel( { row }: { row: CommentReportRow } ) {
+function CommentLabel( {
+	row,
+	originSection,
+}: {
+	row: CommentReportRow;
+	originSection: CommentsReportTabId;
+} ) {
 	let content = (
 		<span title={ row.label } className={ styles.text }>
 			{ row.label }
@@ -28,14 +36,15 @@ function CommentLabel( { row }: { row: CommentReportRow } ) {
 
 	if ( row.postId ) {
 		content = (
-			<RouteLink
-				to="/post/$postId"
-				params={ { postId: row.postId } as unknown as never }
+			<PostDetailLink
+				postId={ row.postId }
+				report="comments"
+				originSection={ originSection }
 				title={ row.label }
 				className={ styles.text }
 			>
 				{ row.label }
-			</RouteLink>
+			</PostDetailLink>
 		);
 	} else if ( row.link ) {
 		content = (
@@ -62,9 +71,12 @@ function CommentLabel( { row }: { row: CommentReportRow } ) {
 /**
  * DataViews field config for the Comments records table.
  *
+ * @param originSection - The active Comments report tab.
  * @return The field config.
  */
-export function getCommentsFields(): Field< CommentReportRow >[] {
+export function getCommentsFields(
+	originSection: CommentsReportTabId
+): Field< CommentReportRow >[] {
 	return [
 		{
 			id: 'label',
@@ -72,7 +84,7 @@ export function getCommentsFields(): Field< CommentReportRow >[] {
 			enableGlobalSearch: true,
 			enableHiding: false,
 			getValue: ( { item } ) => item.label,
-			render: ( { item } ) => <CommentLabel row={ item } />,
+			render: ( { item } ) => <CommentLabel row={ item } originSection={ originSection } />,
 		},
 		{
 			id: 'comments',

--- a/projects/packages/premium-analytics/routes/reports/comments/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/comments/page.tsx
@@ -62,7 +62,7 @@ function CommentsReport(): JSX.Element {
 	const tabs = useMemo( () => getCommentsReportTabs(), [] );
 	const [ activeTab, setActiveTab ] = useSectionTab( ROUTE_FROM, resolveTabId );
 	const records = useCommentsReportRecords( activeTab );
-	const fields = useMemo( () => getCommentsFields(), [] );
+	const fields = useMemo( () => getCommentsFields( activeTab ), [ activeTab ] );
 	const csvColumns = useMemo< CsvColumn< CommentReportRow >[] >(
 		() => [
 			{ label: __( 'Name', 'jetpack-premium-analytics-pkg' ), getValue: row => row.label },

--- a/projects/packages/premium-analytics/routes/reports/count-fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/count-fields.test.tsx
@@ -49,14 +49,14 @@ describe( 'report table count fields', () => {
 			throw new Error( 'Browser-locale formatting should not be used' );
 		} );
 
-		renderCountField( getPostsFields(), 'views', { views: 12345 } as never );
+		renderCountField( getPostsFields( false, 'posts-pages' ), 'views', { views: 12345 } as never );
 		renderCountField( getArchivesFields(), 'views', { views: 12345 } as never );
 		renderCountField( getCommentFollowersFields(), 'subscribers', { followers: 12345 } as never );
 		renderCountField( getVideosFields(), 'plays', { plays: 12345 } as never );
 		renderCountField( getVideosFields(), 'impressions', { impressions: 12345 } as never );
 		renderCountField( getDownloadsFields(), 'downloads', { downloads: 12345 } as never );
 		renderCountField( getClicksFields(), 'clicks', { clicks: 12345 } as never );
-		renderCountField( getCommentsFields(), 'comments', { value: 12345 } as never );
+		renderCountField( getCommentsFields( 'authors' ), 'comments', { value: 12345 } as never );
 		renderCountField( getTagsFields(), 'views', { value: 12345 } as never );
 		renderCountField( getReferrerFields(), 'views', { views: 12345 } as never );
 		renderCountField( getSearchTermsFields(), 'views', { views: 12345 } as never );

--- a/projects/packages/premium-analytics/routes/reports/emails/config/fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/emails/config/fields.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import { createElement } from 'react';
+import { getMockRouteLinkUrl, setMockRouteSearch } from '../../../../tests/js/route-test-utils';
+import { getEmailsFields } from './fields';
+import type { StatsEmailSummaryItem } from '@jetpack-premium-analytics/data';
+
+jest.mock( '@wordpress/route', () => {
+	const { mockWordPressRoute } = jest.requireActual( '../../../../tests/js/route-test-utils' );
+
+	return mockWordPressRoute;
+} );
+
+setMockRouteSearch( {
+	from: '2026-06-01',
+	to: '2026-06-16',
+	interval: 'day',
+	foreign: 'drop-me',
+} );
+
+const email: StatsEmailSummaryItem = {
+	id: 91,
+	label: 'Weekly update',
+	value: 120,
+	date: '2026-07-10',
+	opens: 120,
+	clicks: 14,
+	opens_rate: 38.1,
+	clicks_rate: 3.81,
+	unique_opens: 98,
+	unique_clicks: 11,
+	total_sends: 250,
+	children: null,
+};
+
+describe( 'emails fields', () => {
+	it( 'links an email to its detail tab with the date window and report origin', () => {
+		const field = getEmailsFields().find( candidate => candidate.id === 'label' );
+
+		if ( ! field || ! field.render ) {
+			throw new Error( 'Emails title field render callback is unavailable' );
+		}
+
+		render( createElement( field.render, { item: email, field: field as never } ) );
+
+		const link = screen.getByRole( 'link', { name: 'Weekly update' } );
+		const url = getMockRouteLinkUrl( link );
+		expect( url.pathname ).toBe( '/post/91' );
+		expect( Object.fromEntries( url.searchParams ) ).toEqual( {
+			from: '2026-06-01',
+			to: '2026-06-16',
+			interval: 'day',
+			ref: 'emails',
+			section: 'email-opens',
+		} );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/reports/emails/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/emails/config/fields.tsx
@@ -3,8 +3,8 @@
  */
 import { parseSiteDateTime } from '@jetpack-premium-analytics/datetime';
 import { formatDate, formatMetricValue } from '@jetpack-premium-analytics/formatters';
+import { PostDetailLink } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';
-import { Link } from '@wordpress/route';
 /**
  * Internal dependencies
  */
@@ -91,20 +91,15 @@ function EmailTitle( { item }: { item: StatsEmailSummaryItem } ) {
 	}
 
 	return (
-		<Link
-			to="/post/$postId"
-			params={ { postId: String( item.id ) } as unknown as never }
-			search={
-				( ( current: Record< string, unknown > ) => ( {
-					...current,
-					section: 'email-opens',
-				} ) ) as unknown as never
-			}
+		<PostDetailLink
+			postId={ item.id }
+			report="emails"
+			extraParams={ { section: 'email-opens' } }
 			title={ title }
 			className={ styles.title }
 		>
 			{ title }
-		</Link>
+		</PostDetailLink>
 	);
 }
 

--- a/projects/packages/premium-analytics/routes/reports/emails/page.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/emails/page.test.tsx
@@ -17,6 +17,7 @@ jest.mock( './config', () => ( {
 } ) );
 
 jest.mock( '@jetpack-premium-analytics/routing', () => ( {
+	...jest.requireActual( '@jetpack-premium-analytics/routing' ),
 	useDashboardLink: () => '/',
 } ) );
 

--- a/projects/packages/premium-analytics/routes/reports/posts/config/fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/posts/config/fields.test.tsx
@@ -6,6 +6,7 @@ import { render, screen } from '@testing-library/react';
 /**
  * Internal dependencies
  */
+import { setMockRouteSearch } from '../../../../tests/js/route-test-utils';
 import {
 	buildArchiveCsvRows,
 	buildArchiveRows,
@@ -13,7 +14,6 @@ import {
 	getPostsFields,
 	type ArchiveRow,
 } from './fields';
-import type { ReactNode } from 'react';
 
 jest.mock( '@jetpack-premium-analytics/data', () => ( {
 	useSiteHomeUrl: jest.fn(),
@@ -21,32 +21,15 @@ jest.mock( '@jetpack-premium-analytics/data', () => ( {
 
 // The router is built dynamically at runtime, so a field-level test has no
 // router to mount. Render `Link` as the anchor it becomes, keeping `to`,
-// `params`, and `search` assertable, matching the other report field tests.
-jest.mock( '@wordpress/route', () => ( {
-	Link: ( {
-		to,
-		params,
-		search,
-		children,
-	}: {
-		to: string;
-		params: Record< string, string >;
-		search?: Record< string, unknown >;
-		children: ReactNode;
-	} ) => {
-		const path = to.replace( /\$(\w+)/g, ( _match, key ) => params[ key ] );
-		const query = new URLSearchParams();
-		Object.entries( search ?? {} ).forEach( ( [ key, value ] ) => {
-			if ( value !== undefined && value !== null ) {
-				query.set( key, String( value ) );
-			}
-		} );
-		const queryString = query.toString();
+// `params`, and `search` assertable, matching the other report field
+// tests.
+jest.mock( '@wordpress/route', () => {
+	const { mockWordPressRoute } = jest.requireActual( '../../../../tests/js/route-test-utils' );
 
-		return <a href={ queryString ? `${ path }?${ queryString }` : path }>{ children }</a>;
-	},
-	useSearch: () => ( { from: '2026-03-01', to: '2026-03-10', interval: 'day' } ),
-} ) );
+	return mockWordPressRoute;
+} );
+
+setMockRouteSearch( { from: '2026-03-01', to: '2026-03-10', interval: 'day' } );
 
 const mockUseSiteHomeUrl = useSiteHomeUrl as jest.MockedFunction< typeof useSiteHomeUrl >;
 
@@ -65,7 +48,9 @@ const homepage: StatsTopPostsComparisonItem = {
  * @return The Testing Library render result.
  */
 function renderTitleField( item: StatsTopPostsComparisonItem ) {
-	const field = getPostsFields().find( candidate => candidate.id === 'title' );
+	const field = getPostsFields( false, 'posts-pages' ).find(
+		candidate => candidate.id === 'title'
+	);
 	// eslint-disable-next-line testing-library/render-result-naming-convention -- `render` here is the DataViews field render component, not RTL's render result.
 	const TitleField = field?.render;
 
@@ -102,7 +87,9 @@ function renderArchiveTitleField( item: ArchiveRow ) {
  * @return The Testing Library render result.
  */
 function renderPostViewsField( item: StatsTopPostsComparisonItem, withComparison = false ) {
-	const field = getPostsFields( withComparison ).find( candidate => candidate.id === 'views' );
+	const field = getPostsFields( withComparison, 'posts-pages' ).find(
+		candidate => candidate.id === 'views'
+	);
 	// eslint-disable-next-line testing-library/render-result-naming-convention -- `render` here is the DataViews field render component, not RTL's render result.
 	const ViewsField = field?.render;
 
@@ -195,6 +182,10 @@ describe( 'posts title field', () => {
 		expect( search.get( 'post_url' ) ).toBe( 'https://example.com/hello-world/' );
 		// A row with a detail page carries no link out to the live post.
 		expect( link ).not.toHaveAttribute( 'target' );
+		// The referring report travels in the URL so the detail breadcrumb can
+		// link back to the tab the visitor came from.
+		expect( search.get( 'ref' ) ).toBe( 'posts' );
+		expect( search.get( 'ref_section' ) ).toBe( 'posts-pages' );
 	} );
 
 	// Guards against a malformed row linking to `/post/undefined`.

--- a/projects/packages/premium-analytics/routes/reports/posts/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/posts/config/fields.tsx
@@ -8,12 +8,13 @@ import {
 	type StatsTopPostsComparisonItem,
 } from '@jetpack-premium-analytics/data';
 import { Link as UiLink } from '@jetpack-premium-analytics/externals';
-import { pickReportDateParams } from '@jetpack-premium-analytics/routing';
+import { createReportOriginSearch, pickReportDateParams } from '@jetpack-premium-analytics/routing';
 import { safeHttpUrl } from '@jetpack-premium-analytics/ui';
 import { MetricWithComparison, PostTitleLink } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';
 import { useSearch } from '@wordpress/route';
 import { useMemo } from 'react';
+import type { ReportPostsTabId } from './tabs';
 import type { Field } from '@jetpack-premium-analytics/externals';
 
 const VIEWS_DATA_FORMAT = {
@@ -31,13 +32,26 @@ const VIEWS_DATA_FORMAT = {
  * resolved from core settings. They never take the detail page: the homepage
  * is not a single post.
  *
- * @param props      - Component props.
- * @param props.item - The posts report row.
+ * @param props               - Component props.
+ * @param props.item          - The posts report row.
+ * @param props.originSection - The active Posts & Pages report tab.
  * @return The linked or plain post title.
  */
-function PostTitle( { item }: { item: StatsTopPostsComparisonItem } ) {
+function PostTitle( {
+	item,
+	originSection,
+}: {
+	item: StatsTopPostsComparisonItem;
+	originSection: ReportPostsTabId;
+} ) {
 	const search = useSearch( { strict: false } ) as Record< string, unknown > | undefined;
-	const detailSearch = useMemo( () => pickReportDateParams( search ), [ search ] );
+	const detailSearch = useMemo(
+		() => ( {
+			...pickReportDateParams( search ),
+			...createReportOriginSearch( 'posts', originSection ),
+		} ),
+		[ search, originSection ]
+	);
 	const homeUrl = useSiteHomeUrl();
 
 	const isHomepage = item.type === 'homepage';
@@ -61,9 +75,13 @@ function PostTitle( { item }: { item: StatsTopPostsComparisonItem } ) {
  * other routes.
  *
  * @param withComparison - Whether to render available period-over-period deltas.
+ * @param originSection  - The active Posts & Pages report tab.
  * @return The field config.
  */
-export function getPostsFields( withComparison = false ): Field< StatsTopPostsComparisonItem >[] {
+export function getPostsFields(
+	withComparison: boolean,
+	originSection: ReportPostsTabId
+): Field< StatsTopPostsComparisonItem >[] {
 	return [
 		{
 			id: 'title',
@@ -71,7 +89,7 @@ export function getPostsFields( withComparison = false ): Field< StatsTopPostsCo
 			enableGlobalSearch: true,
 			enableHiding: false,
 			getValue: ( { item } ) => String( item.label ?? '' ),
-			render: ( { item } ) => <PostTitle item={ item } />,
+			render: ( { item } ) => <PostTitle item={ item } originSection={ originSection } />,
 		},
 		{
 			id: 'views',

--- a/projects/packages/premium-analytics/routes/reports/posts/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/posts/page.tsx
@@ -120,8 +120,8 @@ function PostsReport(): JSX.Element {
 	const retry = useReportRetry( records.refetch );
 
 	const postsFields = useMemo(
-		() => getPostsFields( records.posts.hasComparison ),
-		[ records.posts.hasComparison ]
+		() => getPostsFields( records.posts.hasComparison, activeTab ),
+		[ activeTab, records.posts.hasComparison ]
 	);
 	const archivesFields = useMemo(
 		() => getArchivesFields( records.archives.hasComparison ),

--- a/projects/packages/premium-analytics/routes/reports/registry.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/registry.test.ts
@@ -23,6 +23,15 @@ describe( 'getReportDefinition', () => {
 		expect( getReportDefinition( undefined ) ).toBeUndefined();
 	} );
 
+	// The id comes from the URL, so an inherited object property must not read
+	// as a report.
+	it.each( [ 'constructor', 'toString', 'hasOwnProperty' ] )(
+		'returns undefined for the inherited %s property',
+		id => {
+			expect( getReportDefinition( id ) ).toBeUndefined();
+		}
+	);
+
 	it( 'returns the downloads report on Simple sites', () => {
 		expect( getReportDefinition( 'downloads' )?.id ).toBe( 'downloads' );
 	} );

--- a/projects/packages/premium-analytics/routes/reports/registry.ts
+++ b/projects/packages/premium-analytics/routes/reports/registry.ts
@@ -180,15 +180,43 @@ export const REPORTS: Record< string, ReportDefinition > = {
 /**
  * Look up a report definition by its id.
  *
+ * The id comes from the URL, so the lookup is an own-property check: a plain
+ * index would resolve an inherited name such as `constructor` to a function and
+ * hand back something that is not a report definition.
+ *
  * @param id - The `$report` path segment (may be missing on a malformed URL).
  * @return The matching definition, or `undefined` when the id is missing or unknown.
  */
 export function getReportDefinition( id: string | undefined ): ReportDefinition | undefined {
-	const definition = id ? REPORTS[ id ] : undefined;
+	const definition = id && Object.hasOwn( REPORTS, id ) ? REPORTS[ id ] : undefined;
 
 	if ( definition?.isAvailable && ! definition.isAvailable() ) {
 		return undefined;
 	}
 
 	return definition;
+}
+
+/**
+ * Resolve the report origin behind a detail breadcrumb.
+ *
+ * A section is kept only when the referring report defines a section resolver
+ * and the value round-trips through it, so a section belonging to a different
+ * report — or one that report can no longer render — is never linked.
+ *
+ * @param origin - The report origin read from the current search params.
+ * @return The referring report definition and its validated section, when valid.
+ */
+export function resolveReportOrigin( origin: { report: string; section?: string } | undefined ): {
+	definition?: ReportDefinition;
+	section?: string;
+} {
+	const definition = getReportDefinition( origin?.report );
+	const rawSection = origin?.section;
+	const section =
+		rawSection && definition?.resolveSection?.( rawSection ) === rawSection
+			? rawSection
+			: undefined;
+
+	return { definition, section };
 }

--- a/projects/packages/premium-analytics/routes/reports/utm/config/fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/utm/config/fields.test.tsx
@@ -1,22 +1,24 @@
 import { render, screen } from '@testing-library/react';
+import { getMockRouteLinkUrl, setMockRouteSearch } from '../../../../tests/js/route-test-utils';
 import { getUtmFields } from './fields';
 import type { UtmReportRow } from './aggregate';
-import type { ReactNode } from 'react';
 
 // The router is built dynamically at runtime, so a field-level test has no
 // router to mount. Render `Link` as the anchor it becomes, keeping `to`/`params`
 // assertable.
-jest.mock( '@wordpress/route', () => ( {
-	Link: ( {
-		to,
-		params,
-		children,
-	}: {
-		to: string;
-		params: Record< string, string >;
-		children: ReactNode;
-	} ) => <a href={ to.replace( /\$(\w+)/g, ( _match, key ) => params[ key ] ) }>{ children }</a>,
-} ) );
+jest.mock( '@wordpress/route', () => {
+	const { mockWordPressRoute } = jest.requireActual( '../../../../tests/js/route-test-utils' );
+
+	return mockWordPressRoute;
+} );
+
+setMockRouteSearch( {
+	from: '2026-06-01',
+	to: '2026-06-16',
+	interval: 'day',
+	section: 'campaign',
+	foreign: 'drop-me',
+} );
 
 const row: UtmReportRow = {
 	id: 'post-41',
@@ -59,7 +61,15 @@ describe( 'UTM report fields', () => {
 		render( <UtmField item={ row } field={ field as never } /> );
 
 		const link = screen.getByRole( 'link', { name: row.label } );
-		expect( link ).toHaveAttribute( 'href', '/post/41' );
+		const url = getMockRouteLinkUrl( link );
+		expect( url.pathname ).toBe( '/post/41' );
+		expect( Object.fromEntries( url.searchParams ) ).toEqual( {
+			from: '2026-06-01',
+			to: '2026-06-16',
+			interval: 'day',
+			ref: 'utm',
+			ref_section: 'source-medium',
+		} );
 		expect( link ).not.toHaveAttribute( 'target' );
 		// eslint-disable-next-line testing-library/no-node-access -- An external-link icon would be an SVG inside the anchor.
 		expect( link.querySelector( 'svg' ) ).not.toBeInTheDocument();

--- a/projects/packages/premium-analytics/routes/reports/utm/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/utm/config/fields.tsx
@@ -2,9 +2,8 @@
  * External dependencies
  */
 import { DrilldownLeafCell } from '@jetpack-premium-analytics/ui';
-import { MetricWithComparison } from '@jetpack-premium-analytics/widgets-toolkit';
+import { MetricWithComparison, PostDetailLink } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';
-import { Link } from '@wordpress/route';
 /**
  * Internal dependencies
  */
@@ -39,12 +38,9 @@ export function getUtmFields( activeTab: UtmReportTabId ): Field< UtmReportRow >
 				return (
 					<DrilldownLeafCell groupLabel={ item.groupLabel }>
 						{ item.postId ? (
-							<Link
-								to="/post/$postId"
-								params={ { postId: String( item.postId ) } as unknown as never }
-							>
+							<PostDetailLink postId={ item.postId } report="utm" originSection={ activeTab }>
 								{ item.label }
-							</Link>
+							</PostDetailLink>
 						) : (
 							item.label
 						) }

--- a/projects/packages/premium-analytics/routes/reports/videos/config/fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/videos/config/fields.test.tsx
@@ -1,35 +1,23 @@
 import { render, screen } from '@testing-library/react';
+import { getMockRouteLinkUrl, setMockRouteSearch } from '../../../../tests/js/route-test-utils';
 import { getVideosFields } from './fields';
 import type { StatsVideoPlaysComparisonItem } from '@jetpack-premium-analytics/data';
-import type { ReactNode } from 'react';
 
 // The router is built dynamically at runtime, so a field-level test has no
 // router to mount. Render `Link` as the anchor it becomes, keeping `to`/
 // `params`/`search` assertable, matching the other report field tests.
-jest.mock( '@wordpress/route', () => ( {
-	Link: ( {
-		to,
-		params,
-		search,
-		children,
-	}: {
-		to: string;
-		params: Record< string, string >;
-		search?: Record< string, string >;
-		children: ReactNode;
-	} ) => {
-		const path = to.replace( /\$(\w+)/g, ( _match, key ) => params[ key ] );
-		const query = new URLSearchParams( search ?? {} ).toString();
+jest.mock( '@wordpress/route', () => {
+	const { mockWordPressRoute } = jest.requireActual( '../../../../tests/js/route-test-utils' );
 
-		return <a href={ query ? `${ path }?${ query }` : path }>{ children }</a>;
-	},
-	useSearch: () => ( {
-		from: '2026-06-01',
-		to: '2026-06-16',
-		// A page-owned param the detail link must not carry along.
-		chart_period: 'week',
-	} ),
-} ) );
+	return mockWordPressRoute;
+} );
+
+setMockRouteSearch( {
+	from: '2026-06-01',
+	to: '2026-06-16',
+	interval: 'day',
+	chart_period: 'week',
+} );
 
 const video: StatsVideoPlaysComparisonItem = {
 	id: 12,
@@ -91,7 +79,14 @@ describe( 'videos fields', () => {
 		const link = screen.getByRole( 'link', { name: 'Launch video' } );
 		// Only the shared report-window params travel; page-owned params
 		// (`chart_period`) stay behind.
-		expect( link ).toHaveAttribute( 'href', '/video/12?from=2026-06-01&to=2026-06-16' );
+		const url = getMockRouteLinkUrl( link );
+		expect( url.pathname ).toBe( '/video/12' );
+		expect( Object.fromEntries( url.searchParams ) ).toEqual( {
+			from: '2026-06-01',
+			to: '2026-06-16',
+			interval: 'day',
+			ref: 'videos',
+		} );
 		expect( link ).not.toHaveAttribute( 'target' );
 	} );
 

--- a/projects/packages/premium-analytics/routes/reports/videos/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/videos/config/fields.tsx
@@ -1,11 +1,9 @@
 /**
  * External dependencies
  */
-import { pickReportDateParams } from '@jetpack-premium-analytics/routing';
+import { createReportOriginSearch, pickReportDateParams } from '@jetpack-premium-analytics/routing';
 import { MetricWithComparison, VideoTitleLink } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';
-import { useSearch } from '@wordpress/route';
-import { useMemo } from 'react';
 import type { StatsVideoPlaysComparisonItem } from '@jetpack-premium-analytics/data';
 import type { Field } from '@jetpack-premium-analytics/externals';
 
@@ -27,6 +25,19 @@ function getVideoTitle( video: StatsVideoPlaysComparisonItem ) {
 }
 
 /**
+ * Build the page-scoped search state for a video detail link.
+ *
+ * @param current - The current report search parameters.
+ * @return The detail page search parameters.
+ */
+function getVideoDetailSearch( current: Record< string, unknown > ) {
+	return {
+		...pickReportDateParams( current ),
+		...createReportOriginSearch( 'videos' ),
+	};
+}
+
+/**
  * Render a video row's title. Rows with an attachment ID link to the internal
  * video detail page, carrying the report's current date window so the detail
  * page and its "Stats" breadcrumb keep the range being inspected; the public
@@ -37,12 +48,15 @@ function getVideoTitle( video: StatsVideoPlaysComparisonItem ) {
  * @return The linked or plain video title.
  */
 function VideoTitle( { item }: { item: StatsVideoPlaysComparisonItem } ) {
-	const search = useSearch( { strict: false } ) as Record< string, unknown > | undefined;
-	const detailSearch = useMemo( () => pickReportDateParams( search ), [ search ] );
 	const title = getVideoTitle( item );
 
 	return (
-		<VideoTitleLink id={ item.id } label={ title } link={ item.link } search={ detailSearch } />
+		<VideoTitleLink
+			id={ item.id }
+			label={ title }
+			link={ item.link }
+			search={ getVideoDetailSearch }
+		/>
 	);
 }
 

--- a/projects/packages/premium-analytics/routes/use-detail-breadcrumbs.test.ts
+++ b/projects/packages/premium-analytics/routes/use-detail-breadcrumbs.test.ts
@@ -1,0 +1,98 @@
+import { renderHook } from '@testing-library/react';
+import { useSearch } from '@wordpress/route';
+import { createReportOriginSearch } from '@jetpack-premium-analytics/routing';
+import { useDetailBreadcrumbs } from './use-detail-breadcrumbs';
+
+jest.mock( '@wordpress/route', () => ( {
+	useSearch: jest.fn(),
+} ) );
+
+const mockUseSearch = useSearch as jest.MockedFunction< typeof useSearch >;
+
+const REPORT_WINDOW = { from: '2026-06-01', to: '2026-06-16' };
+
+/**
+ * Point the mocked router at a search object, optionally carrying an origin.
+ *
+ * @param report  - The referring report id.
+ * @param section - The referring report's section.
+ */
+function mockSearch( report?: string, section?: string ) {
+	mockUseSearch.mockReturnValue( {
+		...REPORT_WINDOW,
+		post_id: '42',
+		...( report ? createReportOriginSearch( report, section ) : {} ),
+	} as never );
+}
+
+/**
+ * Assert the destination and search params for a report breadcrumb.
+ *
+ * @param link    - Breadcrumb destination.
+ * @param report  - Expected report id.
+ * @param section - Expected report section.
+ */
+function expectReportLink( link: string | undefined, report: string, section?: string ) {
+	const url = new URL( link ?? '', 'https://example.com' );
+
+	expect( url.pathname ).toBe( `/reports/${ report }` );
+	expect( Object.fromEntries( url.searchParams ) ).toEqual( {
+		...REPORT_WINDOW,
+		...( section ? { section } : {} ),
+	} );
+}
+
+const validOrigins = [
+	[ 'posts', 'Posts & Pages', 'archives' ],
+	[ 'videos', 'Videos', undefined ],
+	[ 'emails', 'Emails', undefined ],
+	[ 'comments', 'Comments', 'posts' ],
+	[ 'authors', 'Top authors', undefined ],
+	[ 'comment-followers', 'Comments Subscribers', undefined ],
+	[ 'utm', 'UTM', 'campaign' ],
+] as const;
+
+describe( 'useDetailBreadcrumbs', () => {
+	it.each( validOrigins )(
+		'adds the %s report before the detail title',
+		( report, label, section ) => {
+			mockSearch( report, section );
+
+			const { result } = renderHook( () => useDetailBreadcrumbs( 'Detail title' ) );
+
+			expect( result.current.map( item => item.label ) ).toEqual( [ label, 'Detail title' ] );
+			expectReportLink( result.current[ 0 ].to, report, section );
+			expect( result.current[ 1 ].to ).toBeUndefined();
+		}
+	);
+
+	it.each( [
+		[ 'an unknown section', 'comments', 'bogus' ],
+		[ 'a section unsupported by its report', 'videos', 'posts' ],
+	] )( 'omits %s from the report link', ( _case, report, section ) => {
+		expect.assertions( 2 );
+		mockSearch( report, section );
+
+		const { result } = renderHook( () => useDetailBreadcrumbs( 'Detail title' ) );
+
+		expectReportLink( result.current[ 0 ].to, report );
+	} );
+
+	it( 'returns only the title crumb when no origin is present', () => {
+		mockSearch();
+
+		const { result } = renderHook( () => useDetailBreadcrumbs( 'Detail title' ) );
+
+		expect( result.current ).toEqual( [ { label: 'Detail title' } ] );
+	} );
+
+	// The origin is untrusted: it is a plain query param anyone can edit, so an
+	// inherited object property must not read as a report either.
+	it.each( [ 'bogus', 'constructor', 'toString' ] )( 'ignores the %s report id', report => {
+		mockSearch( report );
+
+		const { result } = renderHook( () => useDetailBreadcrumbs( 'Detail title' ) );
+
+		expect( result.current ).toEqual( [ { label: 'Detail title' } ] );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/use-detail-breadcrumbs.ts
+++ b/projects/packages/premium-analytics/routes/use-detail-breadcrumbs.ts
@@ -1,0 +1,40 @@
+/**
+ * External dependencies
+ */
+import { useSearch } from '@wordpress/route';
+import { buildReportLink, readReportOriginSearch } from '@jetpack-premium-analytics/routing';
+/**
+ * Internal dependencies
+ */
+import { resolveReportOrigin } from './reports/registry';
+
+type BreadcrumbItem = { label: string; to?: string };
+
+/**
+ * Build the breadcrumbs a post or video detail page adds after the Stats root.
+ *
+ * `StatsBreadcrumbs` renders the root crumb and its dashboard link, so this
+ * hook returns only the crumbs that follow it.
+ *
+ * @param title - The resolved detail-page title.
+ * @return Breadcrumb data for the current detail page.
+ */
+export function useDetailBreadcrumbs( title?: string ): BreadcrumbItem[] {
+	const search = useSearch( { strict: false } ) as Record< string, unknown > | undefined;
+	const origin = readReportOriginSearch( search );
+	const { definition, section: originSection } = resolveReportOrigin( origin );
+	const items: BreadcrumbItem[] = [];
+
+	if ( definition ) {
+		items.push( {
+			label: definition.getTitle(),
+			to: buildReportLink( definition.id, search, originSection ),
+		} );
+	}
+
+	if ( title ) {
+		items.push( { label: title } );
+	}
+
+	return items;
+}

--- a/projects/packages/premium-analytics/routes/video-detail/route.test.ts
+++ b/projects/packages/premium-analytics/routes/video-detail/route.test.ts
@@ -142,3 +142,32 @@ describe( 'video detail route.beforeLoad', () => {
 		expect( mockAddEntities ).toHaveBeenCalledTimes( 1 );
 	} );
 } );
+
+describe( 'video detail route report origin', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
+		mockGetEntityConfig.mockReturnValue( {} );
+	} );
+
+	it( 'carries the report origin through the seeding redirect', async () => {
+		await expect(
+			beforeLoad(
+				{ videoId: '42' },
+				{ ...settledSearch, post_id: '7', ref: 'utm', ref_section: 'campaign' }
+			)
+		).rejects.toMatchObject( {
+			to: '/video/$videoId',
+			search: expect.objectContaining( {
+				post_id: '42',
+				ref: 'utm',
+				ref_section: 'campaign',
+			} ),
+		} );
+	} );
+
+	it( 'does not redirect when a settled search already carries the origin', async () => {
+		await expect(
+			beforeLoad( { videoId: '42' }, { ...settledSearch, ref: 'utm', ref_section: 'campaign' } )
+		).resolves.toBeUndefined();
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/video-detail/route.ts
+++ b/projects/packages/premium-analytics/routes/video-detail/route.ts
@@ -6,6 +6,7 @@ import {
 	needsReportDateParamsSeed,
 	normalizeReportParams,
 } from '@jetpack-premium-analytics/data';
+import { pickReportOriginParams } from '@jetpack-premium-analytics/routing';
 import { redirect } from '@wordpress/route';
 /**
  * Internal dependencies
@@ -69,10 +70,13 @@ export const route = {
 				// Proceed with the default seed below.
 			}
 
+			// The report origin joins the allowlist below so the breadcrumb keeps
+			// its link back to the referring report across this seed.
 			const seeded: Record< string, unknown > = {
 				...normalizeReportParams(
 					currentSearch as Parameters< typeof normalizeReportParams >[ 0 ]
 				),
+				...pickReportOriginParams( currentSearch ),
 				post_id: videoId,
 			};
 

--- a/projects/packages/premium-analytics/routes/video-detail/stage.test.tsx
+++ b/projects/packages/premium-analytics/routes/video-detail/stage.test.tsx
@@ -3,16 +3,19 @@ import { useVideoSummary } from './hooks';
 import { stage } from './stage';
 import type { ReactNode } from 'react';
 
+let mockSearch: Record< string, unknown > = {};
+
 jest.mock( '@jetpack-premium-analytics/data', () => ( {
 	AnalyticsQueryClientProvider: ( { children }: { children: ReactNode } ) => <>{ children }</>,
 	GlobalErrorProvider: ( { children }: { children: ReactNode } ) => <>{ children }</>,
 } ) );
 
 jest.mock( '@jetpack-premium-analytics/routing', () => ( {
-	pickReportDateParams: ( search: Record< string, unknown > ) => ( {
-		from: search.from,
-		to: search.to,
-	} ),
+	// Spread the real module so the report registry's tab configs, which call
+	// `defineReportTabs`, still resolve now that the registry is not mocked.
+	// `buildReportLink` and `pickReportDateParams` stay real too, so the link
+	// assertions below exercise the code that builds the href in product.
+	...jest.requireActual( '@jetpack-premium-analytics/routing' ),
 	useDashboardLink: () => '/?from=2026-06-01&to=2026-06-16',
 	useReportDateFilters: () => ( {
 		appliedRange: { from: new Date( 2026, 5, 1 ), to: new Date( 2026, 5, 16 ) },
@@ -61,6 +64,9 @@ jest.mock( '@wordpress/widget-primitives', () => ( {
 	useWidgetTypes: () => [ [], false ],
 } ) );
 
+// The report registry is deliberately not mocked so the breadcrumb exercises
+// the real report-origin validation.
+
 jest.mock( '@wordpress/admin-ui', () => ( {
 	Breadcrumbs: ( { items }: { items: Array< { label: string; to?: string } > } ) => (
 		<nav aria-label="Breadcrumbs">
@@ -88,35 +94,15 @@ jest.mock( '@wordpress/admin-ui', () => ( {
 	),
 } ) );
 
-jest.mock( '@wordpress/route', () => ( {
-	Link: ( {
-		to,
-		params,
-		search,
-		children,
-	}: {
-		to: string;
-		params?: Record< string, unknown >;
-		search?: Record< string, unknown >;
-		children: ReactNode;
-	} ) => {
-		const path = Object.entries( params ?? {} ).reduce(
-			( acc, [ key, value ] ) => acc.replace( `$${ key }`, String( value ) ),
-			to
-		);
-		const query = new URLSearchParams(
-			Object.entries( search ?? {} ).map( ( [ key, value ] ) => [ key, String( value ) ] )
-		).toString();
+jest.mock( '@wordpress/route', () => {
+	const { mockWordPressRoute } = jest.requireActual( '../../tests/js/route-test-utils' );
 
-		return <a href={ query ? `${ path }?${ query }` : path }>{ children }</a>;
-	},
-	useParams: () => ( { videoId: '42' } ),
-	useSearch: () => ( {
-		from: '2026-06-01',
-		to: '2026-06-16',
-		section: 'embeds',
-	} ),
-} ) );
+	return {
+		Link: mockWordPressRoute.Link,
+		useParams: () => ( { videoId: '42' } ),
+		useSearch: () => mockSearch,
+	};
+} );
 
 jest.mock( './hooks', () => ( {
 	useVideoSummary: jest.fn(),
@@ -145,6 +131,11 @@ function mockSummary( overrides: Record< string, unknown > = {} ) {
 describe( 'video detail stage', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
+		mockSearch = {
+			from: '2026-06-01',
+			to: '2026-06-16',
+			section: 'embeds',
+		};
 	} );
 
 	it( 'shows a not-found state with a date-preserving link back to Videos', () => {
@@ -263,12 +254,29 @@ describe( 'video detail stage', () => {
 		render( stage() );
 
 		const breadcrumbs = within( screen.getByRole( 'navigation', { name: 'Breadcrumbs' } ) );
-		expect( breadcrumbs.getByText( 'Stats' ) ).toBeInTheDocument();
-		expect( breadcrumbs.getByText( 'Launch recap' ) ).toBeInTheDocument();
+		expect( breadcrumbs.getAllByRole( 'listitem' ) ).toHaveLength( 2 );
+		expect( breadcrumbs.getAllByRole( 'listitem' ).map( crumb => crumb.textContent ) ).toEqual( [
+			'Stats',
+			'Launch recap',
+		] );
 		expect(
 			breadcrumbs.getByRole( 'heading', { level: 1, name: 'Launch recap' } )
 		).toBeInTheDocument();
 		expect( screen.getByText( 'Video widgets' ) ).toBeInTheDocument();
+	} );
+
+	it( 'adds the referring report between Stats and the resolved title', () => {
+		mockSearch = { ...mockSearch, ref: 'videos' };
+		mockSummary( { title: 'Launch recap' } );
+
+		render( stage() );
+
+		const breadcrumbs = within( screen.getByRole( 'navigation', { name: 'Breadcrumbs' } ) );
+		expect( breadcrumbs.getAllByRole( 'listitem' ).map( crumb => crumb.textContent ) ).toEqual( [
+			'Stats',
+			'Videos',
+			'Launch recap',
+		] );
 	} );
 
 	it( 'states the applied report range as the performance window in the summary', () => {

--- a/projects/packages/premium-analytics/routes/video-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/video-detail/stage.tsx
@@ -15,6 +15,7 @@ import { type WidgetModuleRecord } from '@wordpress/widget-primitives';
 /**
  * Internal dependencies
  */
+import { useDetailBreadcrumbs } from '../use-detail-breadcrumbs';
 import { resolveWidgetModuleWithI18n, useWidgetTypesWithI18n } from '../widget-module-i18n';
 import { VideoSummaryCard } from './components';
 import { VIDEO_DETAIL_LAYOUT } from './config';
@@ -78,6 +79,7 @@ function VideoDetail(): JSX.Element {
 			? undefined
 			: summary.title?.trim() || __( 'Untitled video', 'jetpack-premium-analytics-pkg' );
 	const resolvedSummary = { ...summary, title };
+	const breadcrumbs = useDetailBreadcrumbs( title );
 	const canRenderWidgets = ! summary.isLoading && ! summary.isError && ! summary.isNotFound;
 	let summaryContent: JSX.Element | null;
 
@@ -127,7 +129,7 @@ function VideoDetail(): JSX.Element {
 		>
 			<Page
 				visual={ <StatsPageIcon /> }
-				breadcrumbs={ <StatsBreadcrumbs items={ title ? [ { label: title } ] : [] } /> }
+				breadcrumbs={ <StatsBreadcrumbs items={ breadcrumbs } /> }
 				className={ styles.page }
 			>
 				<div className={ styles.scrollArea }>

--- a/projects/packages/premium-analytics/tests/js/route-test-utils.tsx
+++ b/projects/packages/premium-analytics/tests/js/route-test-utils.tsx
@@ -1,0 +1,72 @@
+import type { AnchorHTMLAttributes, ReactNode } from 'react';
+
+type RouteSearch =
+	| Record< string, unknown >
+	| ( ( current: Record< string, unknown > ) => Record< string, unknown > );
+
+type MockRouteLinkProps = {
+	to: string;
+	params?: Record< string, unknown >;
+	search?: RouteSearch;
+	children: ReactNode;
+} & Omit< AnchorHTMLAttributes< HTMLAnchorElement >, 'href' >;
+
+let currentSearch: Record< string, unknown > = {};
+
+/**
+ * Set the search params supplied to route-link updater functions.
+ *
+ * @param search - Current route search params.
+ */
+export function setMockRouteSearch( search: Record< string, unknown > = {} ): void {
+	currentSearch = search;
+}
+
+/**
+ * Render a WordPress route link as an anchor for component tests.
+ *
+ * @param root0          - Link props.
+ * @param root0.to       - Destination route pattern.
+ * @param root0.params   - Route path params.
+ * @param root0.search   - Search params or updater.
+ * @param root0.children - Link contents.
+ * @return The rendered anchor.
+ */
+function MockRouteLink( { to, params, search, children, ...props }: MockRouteLinkProps ) {
+	const path = Object.entries( params ?? {} ).reduce(
+		( currentPath, [ key, value ] ) => currentPath.replace( `$${ key }`, String( value ) ),
+		to
+	);
+	const resolvedSearch = typeof search === 'function' ? search( currentSearch ) : search ?? {};
+	const query = new URLSearchParams();
+
+	Object.entries( resolvedSearch ).forEach( ( [ key, value ] ) => {
+		if ( value !== undefined && value !== null ) {
+			query.set( key, String( value ) );
+		}
+	} );
+
+	const queryString = query.toString();
+
+	return (
+		<a href={ queryString ? `${ path }?${ queryString }` : path } { ...props }>
+			{ children }
+		</a>
+	);
+}
+
+/** Shared Jest replacement for the WordPress route module. */
+export const mockWordPressRoute = {
+	Link: MockRouteLink,
+	useSearch: () => currentSearch,
+};
+
+/**
+ * Parse a link rendered by `mockWordPressRoute`.
+ *
+ * @param link - Rendered link element.
+ * @return The parsed link URL.
+ */
+export function getMockRouteLinkUrl( link: HTMLElement ): URL {
+	return new URL( link.getAttribute( 'href' ) ?? '', 'https://example.com' );
+}

--- a/projects/packages/premium-analytics/widgets/test-utils.tsx
+++ b/projects/packages/premium-analytics/widgets/test-utils.tsx
@@ -3,40 +3,9 @@
  */
 import { queryClient } from '@jetpack-premium-analytics/data';
 import { QueryClientProvider } from '@tanstack/react-query';
-import type { AnchorHTMLAttributes, ReactNode } from 'react';
+import type { ReactNode } from 'react';
 
-type MockRouteLinkProps = {
-	to: string;
-	params?: Record< string, unknown >;
-	search?: Record< string, unknown >;
-	children: ReactNode;
-} & Omit< AnchorHTMLAttributes< HTMLAnchorElement >, 'href' >;
-
-function MockRouteLink( { to, params, search, children, ...props }: MockRouteLinkProps ) {
-	const path = Object.entries( params ?? {} ).reduce(
-		( currentPath, [ key, value ] ) => currentPath.replace( `$${ key }`, String( value ) ),
-		to
-	);
-	const query = new URLSearchParams();
-	Object.entries( search ?? {} ).forEach( ( [ key, value ] ) => {
-		if ( value !== undefined && value !== null ) {
-			query.set( key, String( value ) );
-		}
-	} );
-	const queryString = query.toString();
-
-	return (
-		<a href={ queryString ? `${ path }?${ queryString }` : path } { ...props }>
-			{ children }
-		</a>
-	);
-}
-
-/** Shared Jest replacement for the WordPress route module. */
-export const mockWordPressRoute = {
-	Link: MockRouteLink,
-	useSearch: () => ( {} ),
-};
+export { mockWordPressRoute } from '../tests/js/route-test-utils';
 
 /** Shared renderHook wrapper using the application's query client. */
 export function queryClientWrapper( { children }: { children: ReactNode } ) {


### PR DESCRIPTION
Fixes WOOA7S-1832

## Proposed changes
* A detail page showed only a "Stats" crumb. A visitor who opened a post or video from a report lost the report they came from, and the breadcrumb offered no way back to it. This adds a middle crumb that links to that report.
* A report table's detail link adds `ref` (and `ref_section` for a report with tabs) to the detail URL. The breadcrumb reads those params and links back to the report, preserving the date range and applicable report tab.
* The crumb label always comes from the report registry, never from the URL. An unknown or unavailable report id shows no crumb, and a section is dropped unless it round-trips through that report's own section resolver.
* Both detail routes allowlist the params they seed, so they explicitly preserve the origin through that redirect.
* Seven reports that expose detail-page links now pass their origin: Posts & Pages, Videos, Top authors, Comments, Comments Subscribers, Emails, and UTM. Posts & Pages links return to the Posts & Pages tab; Comments and UTM preserve their active report tab.

An earlier version of this branch kept the origin in browser history state instead. That is why the params carry a `ref` prefix rather than a report-specific name. History state was dropped because the router clears it on any navigation that omits it, so every navigating call site had to opt back in by hand and one miss silently removed the crumb. On detail pages, existing date-range and tab navigation merges changes into the current URL search, so the origin persists without separate history-state plumbing.

The tradeoff is that the origin is now visible in the URL. Someone who opens a copied link sees the extra crumb even though they never visited the report. The crumb still points to a report they can open, so this is cosmetic.

## Related product discussion/links
* WOOA7S-1832

## Does this pull request change what data or activity we track or use?
No. No analytics event is recorded. The origin is not forwarded to report APIs or persisted by the application.

## Testing instructions

* Go to **Jetpack → Analytics** and open the **Posts & Pages** report.
* Set a date range that is not the default, for example the last 30 days.
* Click a post title to open the post detail page.
* Check the breadcrumb. It must read **Stats › Posts & Pages › <post title>**.
* Click the **Posts & Pages** crumb. The report must open again on the same date range. The URL must carry no `ref` param.
* Go back to the detail page. Change the date range, then switch a detail-page tab. The middle crumb must remain after each change.
* Reload the detail page. The middle crumb must remain.
* Repeat the flow from the **Videos** report. The breadcrumb must read **Stats › Videos › <video title>**.
* Repeat the flow from **Top authors**, **Comments**, **Comments Subscribers**, and **UTM**. For grouped reports, click a nested post row that links to the detail page.
* From a non-default tab in **Comments** and **UTM**, open a nested post and confirm the middle crumb returns to the same report tab.
* From **Emails**, click an email and confirm the detail page opens on the **Email opens** tab with **Emails** as the middle crumb.
* Open the dashboard, then open a post detail page from a dashboard widget. The breadcrumb must show only **Stats › <post title>**.
* Edit the URL and set `ref` to a value that is not a report, for example `?ref=bogus`. The breadcrumb must fall back to two crumbs.
* Set `ref_section` to a section the report does not own, for example `?ref=videos&ref_section=posts`. The crumb must link to the report without a section.
