### PR TITLE
Premium Analytics: tighten the widget grid gap to 16px

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1828-widget-grid-gap
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1828-widget-grid-gap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Dashboard: tighten the widget grid gap to 16px.

--- a/projects/packages/premium-analytics/changelog/wooa7s-1828-widget-grid-gap
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1828-widget-grid-gap
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Dashboard: tighten the widget grid gap to 16px.
+Widgets: tighten the grid gap between cards to 16px.

--- a/projects/packages/premium-analytics/routes/dashboard/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.module.scss
@@ -22,9 +22,8 @@
 }
 
 .widgets {
-	// Tile gap for the @wordpress/grid surfaces (grid, masonry, edit overlay).
-	// `--wp-grid-gap` is the documented override hook; the package default is
-	// 24px and Analytics is designed on a 16px spacing system.
+	// Inherited by the @wordpress/grid surfaces (grid, masonry, edit overlay),
+	// which otherwise fall back to the wider `--wpds-dimension-gap-xl`.
 	--wp-grid-gap: var(--wpds-dimension-gap-lg);
 }
 

--- a/projects/packages/premium-analytics/routes/dashboard/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.module.scss
@@ -21,6 +21,13 @@
 	padding-inline: var(--wpds-dimension-padding-2xl);
 }
 
+.widgets {
+	// Tile gap for the @wordpress/grid surfaces (grid, masonry, edit overlay).
+	// `--wp-grid-gap` is the documented override hook; the package default is
+	// 24px and Analytics is designed on a 16px spacing system.
+	--wp-grid-gap: var(--wpds-dimension-gap-lg);
+}
+
 .sectionHeader {
 	// Separates the header row from the widget grid below. The inline gutter
 	// comes from the panel, which already pads to match the tabs.

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -117,7 +117,7 @@ function Dashboard(): JSX.Element {
 								{ activeSection === section.slug ? (
 									<>
 										<WidgetDashboard.NoWidgetsState />
-										<WidgetDashboard.Widgets />
+										<WidgetDashboard.Widgets className={ styles.widgets } />
 									</>
 								) : null }
 							</SectionTabPanel>

--- a/projects/packages/premium-analytics/routes/post-detail/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.module.scss
@@ -21,9 +21,8 @@
 }
 
 .widgets {
-	// Tile gap for the @wordpress/grid surfaces (grid, masonry, edit overlay).
-	// `--wp-grid-gap` is the documented override hook; the package default is
-	// 24px and Analytics is designed on a 16px spacing system.
+	// Inherited by the @wordpress/grid surfaces (grid, masonry, edit overlay),
+	// which otherwise fall back to the wider `--wpds-dimension-gap-xl`.
 	--wp-grid-gap: var(--wpds-dimension-gap-lg);
 }
 

--- a/projects/packages/premium-analytics/routes/post-detail/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.module.scss
@@ -20,6 +20,13 @@
 	padding-inline: var(--wpds-dimension-padding-2xl);
 }
 
+.widgets {
+	// Tile gap for the @wordpress/grid surfaces (grid, masonry, edit overlay).
+	// `--wp-grid-gap` is the documented override hook; the package default is
+	// 24px and Analytics is designed on a 16px spacing system.
+	--wp-grid-gap: var(--wpds-dimension-gap-lg);
+}
+
 .dateFilters {
 	// Sits directly below the tab bar, outside the scroll container, so it
 	// stays fixed exactly like the dashboard's filters. The tab list already

--- a/projects/packages/premium-analytics/routes/post-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/post-detail/stage.tsx
@@ -166,7 +166,9 @@ function PostDetail(): JSX.Element {
 							</div>
 							{ tabs.map( tab => (
 								<SectionTabPanel key={ tab.id } value={ tab.id } className={ styles.content }>
-									{ activeTab === tab.id ? <WidgetDashboard.Widgets /> : null }
+									{ activeTab === tab.id ? (
+										<WidgetDashboard.Widgets className={ styles.widgets } />
+									) : null }
 								</SectionTabPanel>
 							) ) }
 						</div>

--- a/projects/packages/premium-analytics/routes/video-detail/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/video-detail/stage.module.scss
@@ -15,6 +15,13 @@
 	padding-inline: var(--wpds-dimension-padding-2xl);
 }
 
+.widgets {
+	// Tile gap for the @wordpress/grid surfaces (grid, masonry, edit overlay).
+	// `--wp-grid-gap` is the documented override hook; the package default is
+	// 24px and Analytics is designed on a 16px spacing system.
+	--wp-grid-gap: var(--wpds-dimension-gap-lg);
+}
+
 .header {
 	// Summary row above the widget grid. Inline padding matches the widget grid;
 	// the 40px block spacing is the design's breathing room around the header.

--- a/projects/packages/premium-analytics/routes/video-detail/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/video-detail/stage.module.scss
@@ -16,9 +16,8 @@
 }
 
 .widgets {
-	// Tile gap for the @wordpress/grid surfaces (grid, masonry, edit overlay).
-	// `--wp-grid-gap` is the documented override hook; the package default is
-	// 24px and Analytics is designed on a 16px spacing system.
+	// Inherited by the @wordpress/grid surfaces (grid, masonry, edit overlay),
+	// which otherwise fall back to the wider `--wpds-dimension-gap-xl`.
 	--wp-grid-gap: var(--wpds-dimension-gap-lg);
 }
 

--- a/projects/packages/premium-analytics/routes/video-detail/stage.tsx
+++ b/projects/packages/premium-analytics/routes/video-detail/stage.tsx
@@ -136,7 +136,7 @@ function VideoDetail(): JSX.Element {
 					) : null }
 					{ canRenderWidgets ? (
 						<div className={ styles.content }>
-							<WidgetDashboard.Widgets />
+							<WidgetDashboard.Widgets className={ styles.widgets } />
 						</div>
 					) : null }
 				</div>

--- a/projects/packages/premium-analytics/widgets/hello-world/stories/dashboard-sections-grid.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/hello-world/stories/dashboard-sections-grid.stories.tsx
@@ -155,7 +155,7 @@ function DashboardSectionsGridStory() {
 								editMode
 							>
 								<WidgetDashboard.NoWidgetsState />
-								<WidgetDashboard.Widgets />
+								<WidgetDashboard.Widgets className={ styles.widgets } />
 							</WidgetDashboard>
 						) : null }
 					</Tabs.Panel>

--- a/projects/packages/premium-analytics/widgets/stories/widget-dashboard-with-widget.tsx
+++ b/projects/packages/premium-analytics/widgets/stories/widget-dashboard-with-widget.tsx
@@ -1,7 +1,14 @@
 import { GlobalErrorProvider } from '@jetpack-premium-analytics/data';
 import { Page } from '@wordpress/admin-ui';
 import { WidgetDashboard, type DashboardWidget } from '@wordpress/widget-dashboard';
-import { useEffect, useMemo, useState, type ComponentType, type ReactNode } from 'react';
+import {
+	useEffect,
+	useMemo,
+	useState,
+	type CSSProperties,
+	type ComponentType,
+	type ReactNode,
+} from 'react';
 import type { ArgTypes } from '@storybook/react';
 import type {
 	ResolveWidgetModule,
@@ -14,7 +21,10 @@ import type {
 import { StoryRouterProvider } from './with-story-router';
 
 const DASHBOARD_ROW_HEIGHT = 300;
-const DASHBOARD_GRID_GAP = 24;
+// Mirrors the route stages' `--wp-grid-gap` override, so edit-mode track guides and the
+// four-column canvas width below match production. Keep the two forms in sync.
+const DASHBOARD_GRID_GAP_TOKEN = 'var(--wpds-dimension-gap-lg)';
+const DASHBOARD_GRID_GAP = 16;
 const DASHBOARD_ONE_COLUMN_WIDTH = 381;
 const DASHBOARD_PAGE_INLINE_PADDING = 48;
 
@@ -213,13 +223,16 @@ export function WidgetDashboardWithWidget( {
 						} }
 					>
 						<div
-							style={ {
-								display: 'flex',
-								flex: '1 1 auto',
-								flexDirection: 'column',
-								inlineSize: dashboardWidth,
-								minBlockSize: 0,
-							} }
+							style={
+								{
+									display: 'flex',
+									flex: '1 1 auto',
+									flexDirection: 'column',
+									inlineSize: dashboardWidth,
+									minBlockSize: 0,
+									'--wp-grid-gap': DASHBOARD_GRID_GAP_TOKEN,
+								} as CSSProperties
+							}
 						>
 							<WidgetDashboard
 								layout={ layout }


### PR DESCRIPTION
Fixes # WOOA7S-1828

## Proposed changes

* Set the widget grid tile gap to 16px on the dashboard, post-detail, and video-detail stages, via `@wordpress/grid`'s documented `--wp-grid-gap` hook. https://developer.wordpress.org/block-editor/reference-guides/packages/packages-grid/#theming-with-css-variables
* Apply the same gap in Storybook, to both the dashboard sections-grid story and the shared `widget-dashboard-with-widget` harness that every widget story mounts through. The harness also had the gap hardcoded at 24 in the arithmetic for its four-column canvas width.

One custom property covers the 2D grid, masonry lanes, and the edit-mode overlay, and the grid reads the computed `column-gap` from the DOM, so drag/resize snapping follows automatically. The Storybook harness is the one place that still keeps a numeric copy, because its canvas width is computed in JS.

Grid gap only — the padding half of WOOA7S-1828 needs an upstream change, since `@wordpress/ui`'s `Card` hardcodes `--wp-ui-card-padding` with no hook a consumer can reach. Tracked separately.

## Related product discussion/links

* WOOA7S-1828

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Go to **Analytics** in wp-admin (`admin.php?page=jetpack-premium-analytics-wp-admin`).
* Confirm the space between widget tiles is 16px, not 24px. Card padding is unchanged here, so only the space *between* cards should look tighter.
* `gap` is a shorthand, so rows tighten too and a two-row tile loses 8px of body height. Check a dense widget — a full leaderboard, say — hasn't newly picked up a scrollbar.
* Click **Customize**, then drag and resize a widget. Tiles should snap cleanly to the track guides with no drift or overlap. **Cancel** when done.
* Repeat on a post detail page and a video detail page — they mount the same grid.
* In Storybook, open any widget's **WidgetDashboardWithWidget** story and turn on edit mode. The track guides should match what the dashboard shows.

<img width="1071" height="629" alt="Screenshot 2026-07-31 at 3 13 39 PM" src="https://github.com/user-attachments/assets/9cbd63c9-ce80-4d7b-aded-f71dfc55e0ba" />



