### PR TITLE
Connection: Prepare 8.8.1 release

### DIFF
--- a/projects/js-packages/babel-plugin-replace-textdomain/CHANGELOG.md
+++ b/projects/js-packages/babel-plugin-replace-textdomain/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-07-31
+### Added
+- Add a `requireI18nSource` option to skip gettext-shaped calls whose callee provably comes from a module other than the i18n one — needed when the plugin runs over whole bundles rather than hand-written source.
+
 ## [1.1.6] - 2026-06-22
 ### Changed
 - Update package dependencies. [#49757]
@@ -277,6 +281,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release.
 - Replace missing domains too.
 
+[1.2.0]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.1.6...v1.2.0
 [1.1.6]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.1.5...v1.1.6
 [1.1.5]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.1.4...v1.1.5
 [1.1.4]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.1.3...v1.1.4

--- a/projects/js-packages/babel-plugin-replace-textdomain/changelog/add-wp-build-dashboards-js-i18n
+++ b/projects/js-packages/babel-plugin-replace-textdomain/changelog/add-wp-build-dashboards-js-i18n
@@ -1,4 +1,0 @@
-Significance: minor
-Type: added
-
-Add a `requireI18nSource` option to skip gettext-shaped calls whose callee provably comes from a module other than the i18n one — needed when the plugin runs over whole bundles rather than hand-written source.

--- a/projects/js-packages/babel-plugin-replace-textdomain/package.json
+++ b/projects/js-packages/babel-plugin-replace-textdomain/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/babel-plugin-replace-textdomain",
-	"version": "1.1.6",
+	"version": "1.2.0",
 	"description": "A Babel plugin to replace the textdomain in gettext-style function calls.",
 	"keywords": [
 		"babel",

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## [2.2.1] - 2026-07-31
+### Changed
+- Connection UI: Make the disconnect survey a real radio group, drop the decorative arrow the options no longer need, and build the option cards on the shared Card component.
+
 ## [2.2.0] - 2026-07-27
 ### Added
 - Add a `./state/store-id` subpath export so `CONNECTION_STORE_ID` can be imported without pulling the package barrel. [#50714]
@@ -1440,6 +1444,7 @@
 - `Main` and `ConnectUser` components added.
 - `JetpackRestApiClient` API client added.
 
+[2.2.1]: https://github.com/Automattic/jetpack-connection-js/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/Automattic/jetpack-connection-js/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/Automattic/jetpack-connection-js/compare/v2.0.2...v2.1.0
 [2.0.2]: https://github.com/Automattic/jetpack-connection-js/compare/v2.0.1...v2.0.2

--- a/projects/js-packages/connection/changelog/update-connection-js-package-ui-pt6
+++ b/projects/js-packages/connection/changelog/update-connection-js-package-ui-pt6
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Connection UI: Make the disconnect survey a real radio group, drop the decorative arrow the options no longer need, and build the option cards on the shared Card component.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "2.2.0",
+	"version": "2.2.1",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/js-packages/jetpack-shared-stores/CHANGELOG.md
+++ b/projects/js-packages/jetpack-shared-stores/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2026-07-31
+### Changed
+- Update dependencies.
+
 ## [0.2.2] - 2026-07-27
 ### Changed
 - Update dependencies.
@@ -48,6 +52,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update package dependencies. [#49757]
 
+[0.2.3]: https://github.com/Automattic/jetpack-shared-stores/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/Automattic/jetpack-shared-stores/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/Automattic/jetpack-shared-stores/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/Automattic/jetpack-shared-stores/compare/v0.1.5...v0.2.0

--- a/projects/js-packages/jetpack-shared-stores/package.json
+++ b/projects/js-packages/jetpack-shared-stores/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-stores",
-	"version": "0.2.2",
+	"version": "0.2.3",
 	"description": "Shared WordPress data stores used by the Jetpack block editor extensions, externalized into a single bundle to avoid duplicate store registration.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/jetpack-shared-stores/#readme",
 	"bugs": {

--- a/projects/js-packages/webpack-config/CHANGELOG.md
+++ b/projects/js-packages/webpack-config/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 4.1.1 - 2026-07-31
+### Changed
+- Update dependencies.
+
 ## 4.1.0 - 2026-07-27
 ### Added
 - Add `PnpmDeterministicChunkIds` plugin. [#50758]

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "4.1.0",
+	"version": "4.1.1",
 	"private": true,
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",

--- a/projects/packages/admin-ui/CHANGELOG.md
+++ b/projects/packages/admin-ui/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.14] - 2026-07-31
+### Changed
+- Update dependencies.
+
 ## [0.9.13] - 2026-07-27
 ### Changed
 - Update package dependencies. [#50751]
@@ -331,6 +335,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixing menu visibility issues.
 
+[0.9.14]: https://github.com/Automattic/jetpack-admin-ui/compare/0.9.13...0.9.14
 [0.9.13]: https://github.com/Automattic/jetpack-admin-ui/compare/0.9.12...0.9.13
 [0.9.12]: https://github.com/Automattic/jetpack-admin-ui/compare/0.9.11...0.9.12
 [0.9.11]: https://github.com/Automattic/jetpack-admin-ui/compare/0.9.10...0.9.11

--- a/projects/packages/admin-ui/package.json
+++ b/projects/packages/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-admin-ui",
-	"version": "0.9.13",
+	"version": "0.9.14",
 	"private": true,
 	"description": "Generic Jetpack wp-admin UI elements",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/admin-ui/#readme",

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -17,7 +17,7 @@ use Jetpack_Tracks_Client;
  */
 class Admin_Menu {
 
-	const PACKAGE_VERSION = '0.9.13';
+	const PACKAGE_VERSION = '0.9.14';
 
 	/**
 	 * Slug used for the upgrade menu item and redirect URL.

--- a/projects/packages/assets/CHANGELOG.md
+++ b/projects/packages/assets/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.4.9] - 2026-07-31
+### Fixed
+- Don't honor a textdomain self-alias: aliasing a domain to itself made the gettext filter recurse infinitely on any untranslated string in that domain. The package's path is still recorded, since JavaScript translation files are located by it whether or not the domain is aliased.
+
 ## [4.4.8] - 2026-07-27
 ### Changed
 - Update package dependencies. [#50751]
@@ -908,6 +912,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Statically access asset tools
 
+[4.4.9]: https://github.com/Automattic/jetpack-assets/compare/v4.4.8...v4.4.9
 [4.4.8]: https://github.com/Automattic/jetpack-assets/compare/v4.4.7...v4.4.8
 [4.4.7]: https://github.com/Automattic/jetpack-assets/compare/v4.4.6...v4.4.7
 [4.4.6]: https://github.com/Automattic/jetpack-assets/compare/v4.4.5...v4.4.6

--- a/projects/packages/assets/changelog/fix-i18n-self-alias-recursion
+++ b/projects/packages/assets/changelog/fix-i18n-self-alias-recursion
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Don't honor a textdomain self-alias: aliasing a domain to itself made the gettext filter recurse infinitely on any untranslated string in that domain. The package's path is still recorded, since JavaScript translation files are located by it whether or not the domain is aliased.

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.8.1] - 2026-07-31
+### Added
+- Connection: Expose the connection-error audience (site/owner/user) to the Jetpack dashboard so error notices can be tailored to the viewer.
+
+### Changed
+- Connection: Fetch connected user data from WordPress.com over REST instead of XML-RPC.
+
+### Fixed
+- Connection: cache wpcom.getUser XML-RPC failures briefly in get_connected_user_data().
+
 ## [8.8.0] - 2026-07-27
 ### Added
 - Show non-owner admins who needs to reconnect instead of a reconnect button when connection ownership is locked. [#50662]
@@ -1960,6 +1970,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[8.8.1]: https://github.com/Automattic/jetpack-connection/compare/v8.8.0...v8.8.1
 [8.8.0]: https://github.com/Automattic/jetpack-connection/compare/v8.7.10...v8.8.0
 [8.7.10]: https://github.com/Automattic/jetpack-connection/compare/v8.7.9...v8.7.10
 [8.7.9]: https://github.com/Automattic/jetpack-connection/compare/v8.7.8...v8.7.9

--- a/projects/packages/connection/changelog/add-connection-error-audience
+++ b/projects/packages/connection/changelog/add-connection-error-audience
@@ -1,4 +1,0 @@
-Significance: patch
-Type: added
-
-Connection: Expose the connection-error audience (site/owner/user) to the Jetpack dashboard so error notices can be tailored to the viewer.

--- a/projects/packages/connection/changelog/connect-379-user-data-rest
+++ b/projects/packages/connection/changelog/connect-379-user-data-rest
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Connection: Fetch connected user data from WordPress.com over REST instead of XML-RPC.

--- a/projects/packages/connection/changelog/fix-connection-cache-connected-user-data-errors
+++ b/projects/packages/connection/changelog/fix-connection-cache-connected-user-data-errors
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Connection: cache wpcom.getUser XML-RPC failures briefly in get_connected_user_data().

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -855,7 +855,7 @@ class Manager {
 	 * Client::remote_request() (rather than the legacy `wpcom.getUser` XML-RPC method)
 	 * ensures any connection errors are captured by the Error_Handler.
 	 *
-	 * @since $$next-version$$ Fetch the data over REST instead of the `wpcom.getUser` XML-RPC method.
+	 * @since 8.8.1 Fetch the data over REST instead of the `wpcom.getUser` XML-RPC method.
 	 *
 	 * @param int|null $user_id the user identifier.
 	 * @return bool|array An array with the WPCOM user data on success, false otherwise.

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '8.8.0';
+	const PACKAGE_VERSION = '8.8.1';
 
 	const PACKAGE_SLUG = 'connection';
 


### PR DESCRIPTION
## Proposed changes

* Prepare the stable `automattic/jetpack-connection` 8.8.1 release.
* Release the pending PHP and JavaScript dependency updates required for stable mirror dependencies.

## Related product discussion/links

* N/A.

## Does this pull request change what data or activity we track or use?

* No.

## Testing instructions

* Run `tools/project-version.sh -c 8.8.1 packages/connection`.
* Run `CI=true pnpm jetpack test php packages/connection`.
  * Expected: 819 tests and 1,794 assertions pass (one PHPUnit notice and three skipped tests).
