### PR TITLE
Boost: let the host decide whether static cache URLs can be used

### DIFF
--- a/projects/plugins/boost/app/admin/class-config.php
+++ b/projects/plugins/boost/app/admin/class-config.php
@@ -97,9 +97,9 @@ class Config {
 	 * Retrieves the hosting provider.
 	 * We're only interested in 'atomic' or 'woa' for now.
 	 *
-	 * A new value here also changes CSS and JS delivery:
-	 * jetpack_boost_minify_use_static_cache_urls() reads anything but 'other' as a host that
-	 * answers wp-content 404s itself, and opts it out of static cache URLs for good.
+	 * A new value here also changes CSS and JS delivery — see
+	 * jetpack_boost_minify_use_static_cache_urls(), which reads anything but 'other' as a host
+	 * that answers wp-content 404s itself.
 	 *
 	 * @since 3.10.0
 	 *

--- a/projects/plugins/boost/app/admin/class-config.php
+++ b/projects/plugins/boost/app/admin/class-config.php
@@ -97,6 +97,10 @@ class Config {
 	 * Retrieves the hosting provider.
 	 * We're only interested in 'atomic' or 'woa' for now.
 	 *
+	 * A new value here also changes CSS and JS delivery:
+	 * jetpack_boost_minify_host_handles_wp_content_404s() reads anything but 'other' as a host that
+	 * answers wp-content 404s itself, and opts it out of static cache URLs for good.
+	 *
 	 * @since 3.10.0
 	 *
 	 * @return string The hosting provider.

--- a/projects/plugins/boost/app/admin/class-config.php
+++ b/projects/plugins/boost/app/admin/class-config.php
@@ -97,7 +97,7 @@ class Config {
 	 * Retrieves the hosting provider.
 	 * We're only interested in 'atomic' or 'woa' for now.
 	 *
-	 * A new value here also changes CSS and JS delivery — see
+	 * A new value here also changes CSS and JS delivery. See
 	 * jetpack_boost_minify_use_static_cache_urls(), which reads anything but 'other' as a host
 	 * that answers wp-content 404s itself.
 	 *

--- a/projects/plugins/boost/app/admin/class-config.php
+++ b/projects/plugins/boost/app/admin/class-config.php
@@ -98,7 +98,7 @@ class Config {
 	 * We're only interested in 'atomic' or 'woa' for now.
 	 *
 	 * A new value here also changes CSS and JS delivery:
-	 * jetpack_boost_minify_host_handles_wp_content_404s() reads anything but 'other' as a host that
+	 * jetpack_boost_minify_use_static_cache_urls() reads anything but 'other' as a host that
 	 * answers wp-content 404s itself, and opts it out of static cache URLs for good.
 	 *
 	 * @since 3.10.0

--- a/projects/plugins/boost/app/admin/class-config.php
+++ b/projects/plugins/boost/app/admin/class-config.php
@@ -99,7 +99,7 @@ class Config {
 	 *
 	 * A new value here also changes CSS and JS delivery. See
 	 * jetpack_boost_minify_use_static_cache_urls(), which reads anything but 'other' as a host
-	 * that answers wp-content 404s itself.
+	 * that may answer wp-content 404s itself.
 	 *
 	 * @since 3.10.0
 	 *

--- a/projects/plugins/boost/app/lib/minify/class-concatenate-css.php
+++ b/projects/plugins/boost/app/lib/minify/class-concatenate-css.php
@@ -202,7 +202,7 @@ class Concatenate_CSS extends WP_Styles {
 					foreach ( $css_groups as $css_group ) {
 						$file_name = jetpack_boost_page_optimize_generate_concat_path( $css_group, $this->dependency_path_mapping );
 
-						if ( get_site_option( 'jetpack_boost_static_minification' ) ) {
+						if ( jetpack_boost_minify_use_static_cache_urls() ) {
 							$href = jetpack_boost_get_minify_url( $file_name . '.min.css' );
 						} else {
 							$href = $siteurl . jetpack_boost_get_static_prefix() . '??' . $file_name;

--- a/projects/plugins/boost/app/lib/minify/class-concatenate-js.php
+++ b/projects/plugins/boost/app/lib/minify/class-concatenate-js.php
@@ -278,7 +278,7 @@ class Concatenate_JS extends WP_Scripts {
 				if ( isset( $js_array['paths'] ) && count( $js_array['paths'] ) > 1 ) {
 					$file_name = jetpack_boost_page_optimize_generate_concat_path( $js_array['paths'], $this->dependency_path_mapping );
 
-					if ( get_site_option( 'jetpack_boost_static_minification' ) ) {
+					if ( jetpack_boost_minify_use_static_cache_urls() ) {
 						$href = jetpack_boost_get_minify_url( $file_name . '.min.js' );
 					} else {
 						$href = $siteurl . jetpack_boost_get_static_prefix() . '??' . $file_name;

--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -1,5 +1,6 @@
 <?php
 
+use Automattic\Jetpack_Boost\Admin\Config as Boost_Admin_Config;
 use Automattic\Jetpack_Boost\Lib\Minify\Cleanup_Stored_Paths;
 use Automattic\Jetpack_Boost\Lib\Minify\Config;
 use Automattic\Jetpack_Boost\Lib\Minify\Dependency_Path_Mapping;
@@ -491,6 +492,46 @@ function jetpack_boost_get_static_prefix() {
 	}
 
 	return trailingslashit( $prefix );
+}
+
+/**
+ * Whether the host routes requests for missing wp-content files through WordPress.
+ *
+ * Static cache URLs depend on that: the first request 404s, and Boost builds the file while it
+ * answers the 404. Whether a missing .css or .js reaches WordPress is a per-site platform setting on
+ * Atomic and WP Cloud, and Boost cannot read it, so it does not use static cache URLs there.
+ *
+ * The name describes the condition, not the feature, to keep it apart from
+ * Minify\Config::can_use_static_cache(), which asks whether the cache directory is writable.
+ *
+ * Admin\Config::get_hosting_provider() returns 'other' for any host it does not name, so a host it
+ * does not recognize keeps the static cache. A new named value there opts that provider out for
+ * good.
+ *
+ * @since $$next-version$$
+ *
+ * @return bool True if WordPress sees wp-content 404s, false if the web server answers them.
+ */
+function jetpack_boost_minify_host_handles_wp_content_404s() {
+	return 'other' === Boost_Admin_Config::get_hosting_provider();
+}
+
+/**
+ * Whether concatenated files should be linked from the static cache directory.
+ *
+ * The 404 tester's verdict describes the host, but jetpack_boost_static_minification travels with
+ * the database: a migrated site arrives with its previous host's `1`. Ask the host first.
+ *
+ * @since $$next-version$$
+ *
+ * @return bool True if static cache URLs should be used, false to fall back to /_jb_static/.
+ */
+function jetpack_boost_minify_use_static_cache_urls() {
+	if ( ! jetpack_boost_minify_host_handles_wp_content_404s() ) {
+		return false;
+	}
+
+	return (bool) get_site_option( 'jetpack_boost_static_minification' );
 }
 
 function jetpack_boost_get_minify_url( $file_name = '' ) {

--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -523,7 +523,8 @@ function jetpack_boost_minify_use_static_cache_urls() {
 	 *
 	 * Returning true on a host Boost excludes only works if that host routes missing wp-content
 	 * file requests through WordPress; otherwise every bundle URL 404s at the web server. It also
-	 * overrides the 404 tester's verdict, and the tester does not run on excluded hosts. Evaluated
+	 * overrides the 404 tester's verdict, and Boost does not schedule the tester on excluded hosts
+	 * (a cron event inherited from a previous host can still fire until the next release). Evaluated
 	 * per concat group, so return a stable value for the whole render.
 	 *
 	 * @since $$next-version$$

--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -500,16 +500,15 @@ function jetpack_boost_get_static_prefix() {
  * Static cache URLs work only where WordPress sees the 404 for a missing wp-content file: the
  * first request 404s, and Boost builds the file while answering it. Whether such a 404 reaches
  * WordPress is a per-site platform setting on Atomic and WP Cloud that Boost cannot read, so those
- * hosts always get the /_jb_static/ fallback. Everywhere else the 404 tester's verdict decides —
- * but jetpack_boost_static_minification travels with the database, and a migrated site arrives
- * with its previous host's `1`, so the host is asked first.
+ * hosts get the /_jb_static/ fallback unless the filter below says otherwise. Everywhere else the
+ * 404 tester's verdict decides — but jetpack_boost_static_minification travels with the database,
+ * and a migrated site arrives with its previous host's `1`, so the host is asked first.
  *
  * Admin\Config::get_hosting_provider() returns 'other' for any host it does not name, so a host it
- * does not recognize keeps the static cache. A new named value there opts that provider out for
- * good.
+ * does not recognize keeps the static cache. A new named value there opts that provider out.
  *
- * Distinct from Minify\Config::can_use_static_cache(), which asks whether the cache directory is
- * writable.
+ * Distinct from Minify\Config::can_use_static_cache(), which ensures the cache directory exists
+ * and is writable.
  *
  * @since $$next-version$$
  *
@@ -523,7 +522,9 @@ function jetpack_boost_minify_use_static_cache_urls() {
 	 * Filter whether concatenated CSS and JS are linked from the static cache directory.
 	 *
 	 * Returning true on a host Boost excludes only works if that host routes missing wp-content
-	 * file requests through WordPress; otherwise every bundle URL 404s at the web server.
+	 * file requests through WordPress; otherwise every bundle URL 404s at the web server. It also
+	 * overrides the 404 tester's verdict, and the tester does not run on excluded hosts. Evaluated
+	 * per concat group, so return a stable value for the whole render.
 	 *
 	 * @since $$next-version$$
 	 *

--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -495,43 +495,41 @@ function jetpack_boost_get_static_prefix() {
 }
 
 /**
- * Whether the host routes requests for missing wp-content files through WordPress.
+ * Whether concatenated files should be linked from the static cache directory.
  *
- * Static cache URLs depend on that: the first request 404s, and Boost builds the file while it
- * answers the 404. Whether a missing .css or .js reaches WordPress is a per-site platform setting on
- * Atomic and WP Cloud, and Boost cannot read it, so it does not use static cache URLs there.
- *
- * The name describes the condition, not the feature, to keep it apart from
- * Minify\Config::can_use_static_cache(), which asks whether the cache directory is writable.
+ * Static cache URLs work only where WordPress sees the 404 for a missing wp-content file: the
+ * first request 404s, and Boost builds the file while answering it. Whether such a 404 reaches
+ * WordPress is a per-site platform setting on Atomic and WP Cloud that Boost cannot read, so those
+ * hosts always get the /_jb_static/ fallback. Everywhere else the 404 tester's verdict decides —
+ * but jetpack_boost_static_minification travels with the database, and a migrated site arrives
+ * with its previous host's `1`, so the host is asked first.
  *
  * Admin\Config::get_hosting_provider() returns 'other' for any host it does not name, so a host it
  * does not recognize keeps the static cache. A new named value there opts that provider out for
  * good.
  *
- * @since $$next-version$$
- *
- * @return bool True if WordPress sees wp-content 404s, false if the web server answers them.
- */
-function jetpack_boost_minify_host_handles_wp_content_404s() {
-	return 'other' === Boost_Admin_Config::get_hosting_provider();
-}
-
-/**
- * Whether concatenated files should be linked from the static cache directory.
- *
- * The 404 tester's verdict describes the host, but jetpack_boost_static_minification travels with
- * the database: a migrated site arrives with its previous host's `1`. Ask the host first.
+ * Distinct from Minify\Config::can_use_static_cache(), which asks whether the cache directory is
+ * writable.
  *
  * @since $$next-version$$
  *
  * @return bool True if static cache URLs should be used, false to fall back to /_jb_static/.
  */
 function jetpack_boost_minify_use_static_cache_urls() {
-	if ( ! jetpack_boost_minify_host_handles_wp_content_404s() ) {
-		return false;
-	}
+	$use_static_cache_urls = 'other' === Boost_Admin_Config::get_hosting_provider()
+		&& get_site_option( 'jetpack_boost_static_minification' );
 
-	return (bool) get_site_option( 'jetpack_boost_static_minification' );
+	/**
+	 * Filter whether concatenated CSS and JS are linked from the static cache directory.
+	 *
+	 * Returning true on a host Boost excludes only works if that host routes missing wp-content
+	 * file requests through WordPress; otherwise every bundle URL 404s at the web server.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param bool $use_static_cache_urls Whether static cache URLs will be used.
+	 */
+	return (bool) apply_filters( 'jetpack_boost_minify_use_static_cache_urls', $use_static_cache_urls );
 }
 
 function jetpack_boost_get_minify_url( $file_name = '' ) {

--- a/projects/plugins/boost/app/lib/minify/functions-helpers.php
+++ b/projects/plugins/boost/app/lib/minify/functions-helpers.php
@@ -498,17 +498,18 @@ function jetpack_boost_get_static_prefix() {
  * Whether concatenated files should be linked from the static cache directory.
  *
  * Static cache URLs work only where WordPress sees the 404 for a missing wp-content file: the
- * first request 404s, and Boost builds the file while answering it. Whether such a 404 reaches
- * WordPress is a per-site platform setting on Atomic and WP Cloud that Boost cannot read, so those
- * hosts get the /_jb_static/ fallback unless the filter below says otherwise. Everywhere else the
- * 404 tester's verdict decides — but jetpack_boost_static_minification travels with the database,
- * and a migrated site arrives with its previous host's `1`, so the host is asked first.
+ * first request 404s, and Boost builds the file while answering it. On Atomic and WP Cloud, a
+ * per-site platform setting that Boost cannot read decides whether such a 404 reaches WordPress.
+ * Those hosts get the /_jb_static/ fallback unless the filter below says otherwise. Everywhere
+ * else the 404 tester's verdict decides. But jetpack_boost_static_minification travels with the
+ * database, and a migrated site arrives with its previous host's `1`, so this helper asks the
+ * host first.
  *
  * Admin\Config::get_hosting_provider() returns 'other' for any host it does not name, so a host it
  * does not recognize keeps the static cache. A new named value there opts that provider out.
  *
- * Distinct from Minify\Config::can_use_static_cache(), which ensures the cache directory exists
- * and is writable.
+ * This is distinct from Minify\Config::can_use_static_cache(), which ensures the cache directory
+ * exists and is writable.
  *
  * @since $$next-version$$
  *
@@ -521,11 +522,11 @@ function jetpack_boost_minify_use_static_cache_urls() {
 	/**
 	 * Filter whether concatenated CSS and JS are linked from the static cache directory.
 	 *
-	 * Returning true on a host Boost excludes only works if that host routes missing wp-content
-	 * file requests through WordPress; otherwise every bundle URL 404s at the web server. It also
+	 * Return true on an excluded host only if that host routes missing wp-content file requests
+	 * through WordPress; otherwise every bundle URL 404s at the web server. A true value also
 	 * overrides the 404 tester's verdict, and Boost does not schedule the tester on excluded hosts
-	 * (a cron event inherited from a previous host can still fire until the next release). Evaluated
-	 * per concat group, so return a stable value for the whole render.
+	 * (a cron event inherited from a previous host can still fire until the next release). Boost
+	 * evaluates this filter once per concat group, so return one stable value for the whole render.
 	 *
 	 * @since $$next-version$$
 	 *

--- a/projects/plugins/boost/changelog/add-static-cache-urls-filter
+++ b/projects/plugins/boost/changelog/add-static-cache-urls-filter
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Concatenate JS/CSS: Add a jetpack_boost_minify_use_static_cache_urls filter to override whether bundles are linked from the static cache.

--- a/projects/plugins/boost/changelog/add-static-cache-urls-filter
+++ b/projects/plugins/boost/changelog/add-static-cache-urls-filter
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Concatenate JS/CSS: Add a jetpack_boost_minify_use_static_cache_urls filter to override whether bundles are linked from the static cache.
+Concatenate JS/CSS: Add a `jetpack_boost_minify_use_static_cache_urls` filter to override whether bundles are linked from the static cache.

--- a/projects/plugins/boost/changelog/fix-boost-608-static-minification-after-migration
+++ b/projects/plugins/boost/changelog/fix-boost-608-static-minification-after-migration
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Concatenate JS/CSS: Fix broken CSS and JS delivery on pages rendered after a site is migrated onto WP Cloud or WordPress.com. Pages already served from a platform edge cache keep the old URLs until that cache is purged or expires.
+Concatenate JS/CSS: Fix broken CSS and JS delivery on pages rendered after a site is migrated onto WP Cloud or WordPress.com. Pages already served from a cache (Boost's page cache or a platform edge cache) keep the old URLs until the cache is purged or expires.

--- a/projects/plugins/boost/changelog/fix-boost-608-static-minification-after-migration
+++ b/projects/plugins/boost/changelog/fix-boost-608-static-minification-after-migration
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Concatenate JS/CSS: Fix broken CSS and JS delivery on pages rendered after a site is migrated onto WP Cloud. Pages already served from a platform edge cache keep the old URLs until that cache is purged, which Boost cannot do for you.

--- a/projects/plugins/boost/changelog/fix-boost-608-static-minification-after-migration
+++ b/projects/plugins/boost/changelog/fix-boost-608-static-minification-after-migration
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Concatenate JS/CSS: Fix broken CSS and JS delivery on pages rendered after a site is migrated onto WP Cloud. Pages already served from a platform edge cache keep the old URLs until that cache is purged, which Boost cannot do for you.
+Concatenate JS/CSS: Fix broken CSS and JS delivery on pages rendered after a site is migrated onto WP Cloud or WordPress.com. Pages already served from a platform edge cache keep the old URLs until that cache is purged or expires.

--- a/projects/plugins/boost/changelog/fix-boost-608-static-minification-after-migration
+++ b/projects/plugins/boost/changelog/fix-boost-608-static-minification-after-migration
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Concatenate JS/CSS: Fix broken CSS and JS delivery on pages rendered after a site is migrated onto WP Cloud or WordPress.com. Pages already served from a cache (Boost's page cache or a platform edge cache) keep the old URLs until the cache is purged or expires.
+Concatenate JS/CSS: Fix broken CSS and JS delivery on pages rendered after a site is migrated onto WP Cloud or WordPress.com. Pages already served from a cache keep the old URLs until the cache is purged or expires.

--- a/projects/plugins/boost/phpunit.11.xml.dist
+++ b/projects/plugins/boost/phpunit.11.xml.dist
@@ -25,12 +25,14 @@
 			<exclude>tests/php/lib/critical-css/Critical_CSS_Storage_Test.php</exclude>
 			<exclude>tests/php/modules/optimizations/critical-css/CSS_Proxy_Test.php</exclude>
 			<exclude>tests/php/Jetpack_Boost_Test.php</exclude>
+			<exclude>tests/php/lib/minify/Concatenate_Static_Cache_Urls_Test.php</exclude>
 			<exclude>tests/php/modules/optimizations/lcp/LCP_Optimize_Bg_Image_Test.php</exclude>
 			<exclude>tests/php/modules/optimizations/lcp/LCP_Optimize_Img_Tag_Test.php</exclude>
 			<exclude>tests/php/abilities/Boost_Abilities_Test.php</exclude>
 		</testsuite>
 		<testsuite name="with-wordpress">
 			<file>tests/php/Jetpack_Boost_Test.php</file>
+			<file>tests/php/lib/minify/Concatenate_Static_Cache_Urls_Test.php</file>
 			<file>tests/php/lib/critical-css/Display_Critical_CSS_Test.php</file>
 			<file>tests/php/lib/critical-css/Critical_CSS_Storage_Test.php</file>
 			<file>tests/php/modules/optimizations/critical-css/CSS_Proxy_Test.php</file>

--- a/projects/plugins/boost/phpunit.9.xml.dist
+++ b/projects/plugins/boost/phpunit.9.xml.dist
@@ -16,12 +16,14 @@
 			<exclude>tests/php/lib/critical-css/Critical_CSS_Storage_Test.php</exclude>
 			<exclude>tests/php/modules/optimizations/critical-css/CSS_Proxy_Test.php</exclude>
 			<exclude>tests/php/Jetpack_Boost_Test.php</exclude>
+			<exclude>tests/php/lib/minify/Concatenate_Static_Cache_Urls_Test.php</exclude>
 			<exclude>tests/php/modules/optimizations/lcp/LCP_Optimize_Bg_Image_Test.php</exclude>
 			<exclude>tests/php/modules/optimizations/lcp/LCP_Optimize_Img_Tag_Test.php</exclude>
 			<exclude>tests/php/abilities/Boost_Abilities_Test.php</exclude>
 		</testsuite>
 		<testsuite name="with-wordpress">
 			<file>tests/php/Jetpack_Boost_Test.php</file>
+			<file>tests/php/lib/minify/Concatenate_Static_Cache_Urls_Test.php</file>
 			<file>tests/php/lib/critical-css/Display_Critical_CSS_Test.php</file>
 			<file>tests/php/lib/critical-css/Critical_CSS_Storage_Test.php</file>
 			<file>tests/php/modules/optimizations/critical-css/CSS_Proxy_Test.php</file>

--- a/projects/plugins/boost/tests/php/lib/minify/Concatenate_Static_Cache_Urls_Test.php
+++ b/projects/plugins/boost/tests/php/lib/minify/Concatenate_Static_Cache_Urls_Test.php
@@ -37,13 +37,6 @@ class Concatenate_Static_Cache_Urls_Test extends BaseTestCase {
 	private $asset_dir;
 
 	/**
-	 * The page_optimize_site_url filter callback, kept so tear_down can remove it.
-	 *
-	 * @var callable
-	 */
-	private $site_url_filter;
-
-	/**
 	 * Absolute paths of the fixture files written by set_up(), so tear_down removes those and
 	 * nothing else.
 	 *
@@ -60,8 +53,9 @@ class Concatenate_Static_Cache_Urls_Test extends BaseTestCase {
 		Status_Cache::clear();
 
 		// The assets must live under wp-content. Dependency_Path_Mapping resolves enqueued URLs back
-		// to paths relative to it, and skips anything it cannot resolve.
-		$this->asset_dir = WP_CONTENT_DIR . '/boost-concat-test';
+		// to paths relative to it, and skips anything it cannot resolve. The pid suffix keeps
+		// concurrent test processes from clobbering each other's fixtures.
+		$this->asset_dir = WP_CONTENT_DIR . '/boost-concat-test-' . getmypid();
 		if ( ! is_dir( $this->asset_dir ) ) {
 			mkdir( $this->asset_dir, 0755, true );
 		}
@@ -77,20 +71,9 @@ class Concatenate_Static_Cache_Urls_Test extends BaseTestCase {
 			file_put_contents( $path, $contents );
 			$this->asset_files[] = $path;
 		}
-
-		// Both classes derive the site URL from the base_url WordPress hands them, which points at
-		// wp-includes here. Pin it, or nothing resolves as internal and every asset is skipped.
-		$this->site_url_filter = function () {
-			return site_url();
-		};
-		add_filter( 'page_optimize_site_url', $this->site_url_filter );
 	}
 
 	public function tear_down() {
-		if ( $this->site_url_filter ) {
-			remove_filter( 'page_optimize_site_url', $this->site_url_filter );
-		}
-
 		// Remove exactly the files set_up() wrote, then the directory if that emptied it. Tracking
 		// paths rather than ownership means a part-way run cannot leave the fixture behind.
 		foreach ( $this->asset_files as $file ) {
@@ -118,10 +101,24 @@ class Concatenate_Static_Cache_Urls_Test extends BaseTestCase {
 		Status_Cache::clear();
 	}
 
+	/**
+	 * Put the site on WordPress.com Atomic: the WP Cloud constants plus wpcomsh, so
+	 * get_hosting_provider() returns 'woa' rather than 'atomic'.
+	 */
+	private function pretend_to_be_on_wpcom_atomic() {
+		$this->pretend_to_be_on_wp_cloud();
+		Constants::set_constant( 'WPCOMSH__PLUGIN_FILE', 'wpcomsh.php' );
+		Status_Cache::clear();
+	}
+
+	private function asset_url( $name ) {
+		return '/wp-content/' . basename( $this->asset_dir ) . '/' . $name;
+	}
+
 	private function render_styles() {
 		$styles = new Concatenate_CSS( new WP_Styles() );
-		$styles->add( 'boost-test-a', '/wp-content/boost-concat-test/a.css', array(), null );
-		$styles->add( 'boost-test-b', '/wp-content/boost-concat-test/b.css', array(), null );
+		$styles->add( 'boost-test-a', $this->asset_url( 'a.css' ), array(), null );
+		$styles->add( 'boost-test-b', $this->asset_url( 'b.css' ), array(), null );
 		$styles->enqueue( array( 'boost-test-a', 'boost-test-b' ) );
 
 		// finally, so a throw inside do_items() surfaces as that failure rather than as a leaked
@@ -138,8 +135,8 @@ class Concatenate_Static_Cache_Urls_Test extends BaseTestCase {
 
 	private function render_scripts() {
 		$scripts = new Concatenate_JS( new WP_Scripts() );
-		$scripts->add( 'boost-test-a', '/wp-content/boost-concat-test/a.js', array(), null );
-		$scripts->add( 'boost-test-b', '/wp-content/boost-concat-test/b.js', array(), null );
+		$scripts->add( 'boost-test-a', $this->asset_url( 'a.js' ), array(), null );
+		$scripts->add( 'boost-test-b', $this->asset_url( 'b.js' ), array(), null );
 		$scripts->enqueue( array( 'boost-test-a', 'boost-test-b' ) );
 
 		ob_start();
@@ -168,6 +165,30 @@ class Concatenate_Static_Cache_Urls_Test extends BaseTestCase {
 	public function test_js_falls_back_when_a_stale_verdict_arrives_on_wp_cloud() {
 		update_site_option( 'jetpack_boost_static_minification', 1 );
 		$this->pretend_to_be_on_wp_cloud();
+
+		$output = $this->render_scripts();
+
+		$this->assertStringContainsString( '/_jb_static/??', $output );
+		$this->assertStringNotContainsString( '/boost-cache/static/', $output );
+	}
+
+	/**
+	 * WordPress.com Atomic classifies as 'woa', not 'atomic'. These pin the guard to "anything but
+	 * 'other'": narrowing it to one named provider must fail here, not on WordPress.com.
+	 */
+	public function test_css_falls_back_when_a_stale_verdict_arrives_on_wpcom_atomic() {
+		update_site_option( 'jetpack_boost_static_minification', 1 );
+		$this->pretend_to_be_on_wpcom_atomic();
+
+		$output = $this->render_styles();
+
+		$this->assertStringContainsString( '/_jb_static/??', $output );
+		$this->assertStringNotContainsString( '/boost-cache/static/', $output );
+	}
+
+	public function test_js_falls_back_when_a_stale_verdict_arrives_on_wpcom_atomic() {
+		update_site_option( 'jetpack_boost_static_minification', 1 );
+		$this->pretend_to_be_on_wpcom_atomic();
 
 		$output = $this->render_scripts();
 

--- a/projects/plugins/boost/tests/php/lib/minify/Concatenate_Static_Cache_Urls_Test.php
+++ b/projects/plugins/boost/tests/php/lib/minify/Concatenate_Static_Cache_Urls_Test.php
@@ -4,6 +4,7 @@ namespace Automattic\Jetpack_Boost\Tests\Lib\Minify;
 
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Status\Cache as Status_Cache;
+use Automattic\Jetpack_Boost\Admin\Config as Boost_Admin_Config;
 use Automattic\Jetpack_Boost\Lib\Minify\Concatenate_CSS;
 use Automattic\Jetpack_Boost\Lib\Minify\Concatenate_JS;
 use WorDBless\BaseTestCase;
@@ -99,6 +100,11 @@ class Concatenate_Static_Cache_Urls_Test extends BaseTestCase {
 		Constants::set_constant( 'ATOMIC_SITE_ID', 1 );
 		Constants::set_constant( 'ATOMIC_CLIENT_ID', 1 );
 		Status_Cache::clear();
+
+		// Pin the classification, so a fixture that stops taking effect fails here instead of
+		// letting the tests pass for the wrong reason.
+		$this->assertSame( 'atomic', Boost_Admin_Config::get_hosting_provider() );
+		Status_Cache::clear();
 	}
 
 	/**
@@ -108,6 +114,9 @@ class Concatenate_Static_Cache_Urls_Test extends BaseTestCase {
 	private function pretend_to_be_on_wpcom_atomic() {
 		$this->pretend_to_be_on_wp_cloud();
 		Constants::set_constant( 'WPCOMSH__PLUGIN_FILE', 'wpcomsh.php' );
+		Status_Cache::clear();
+
+		$this->assertSame( 'woa', Boost_Admin_Config::get_hosting_provider() );
 		Status_Cache::clear();
 	}
 
@@ -130,7 +139,7 @@ class Concatenate_Static_Cache_Urls_Test extends BaseTestCase {
 			$output = ob_get_clean();
 		}
 
-		return $output;
+		return (string) $output;
 	}
 
 	private function render_scripts() {
@@ -146,7 +155,17 @@ class Concatenate_Static_Cache_Urls_Test extends BaseTestCase {
 			$output = ob_get_clean();
 		}
 
-		return $output;
+		return (string) $output;
+	}
+
+	private function assert_fallback_urls( string $output ) {
+		$this->assertStringContainsString( '/_jb_static/??', $output );
+		$this->assertStringNotContainsString( '/boost-cache/static/', $output );
+	}
+
+	private function assert_static_cache_urls( string $output ) {
+		$this->assertStringContainsString( '/boost-cache/static/', $output );
+		$this->assertStringNotContainsString( '/_jb_static/??', $output );
 	}
 
 	/**
@@ -158,8 +177,7 @@ class Concatenate_Static_Cache_Urls_Test extends BaseTestCase {
 
 		$output = $this->render_styles();
 
-		$this->assertStringContainsString( '/_jb_static/??', $output );
-		$this->assertStringNotContainsString( '/boost-cache/static/', $output );
+		$this->assert_fallback_urls( $output );
 	}
 
 	public function test_js_falls_back_when_a_stale_verdict_arrives_on_wp_cloud() {
@@ -168,8 +186,7 @@ class Concatenate_Static_Cache_Urls_Test extends BaseTestCase {
 
 		$output = $this->render_scripts();
 
-		$this->assertStringContainsString( '/_jb_static/??', $output );
-		$this->assertStringNotContainsString( '/boost-cache/static/', $output );
+		$this->assert_fallback_urls( $output );
 	}
 
 	/**
@@ -182,8 +199,7 @@ class Concatenate_Static_Cache_Urls_Test extends BaseTestCase {
 
 		$output = $this->render_styles();
 
-		$this->assertStringContainsString( '/_jb_static/??', $output );
-		$this->assertStringNotContainsString( '/boost-cache/static/', $output );
+		$this->assert_fallback_urls( $output );
 	}
 
 	public function test_js_falls_back_when_a_stale_verdict_arrives_on_wpcom_atomic() {
@@ -192,8 +208,7 @@ class Concatenate_Static_Cache_Urls_Test extends BaseTestCase {
 
 		$output = $this->render_scripts();
 
-		$this->assertStringContainsString( '/_jb_static/??', $output );
-		$this->assertStringNotContainsString( '/boost-cache/static/', $output );
+		$this->assert_fallback_urls( $output );
 	}
 
 	/**
@@ -205,9 +220,8 @@ class Concatenate_Static_Cache_Urls_Test extends BaseTestCase {
 
 		$output = $this->render_styles();
 
-		$this->assertStringContainsString( '/boost-cache/static/', $output );
+		$this->assert_static_cache_urls( $output );
 		$this->assertStringContainsString( '.min.css', $output );
-		$this->assertStringNotContainsString( '/_jb_static/??', $output );
 	}
 
 	public function test_js_uses_static_cache_urls_on_a_supported_host() {
@@ -215,9 +229,8 @@ class Concatenate_Static_Cache_Urls_Test extends BaseTestCase {
 
 		$output = $this->render_scripts();
 
-		$this->assertStringContainsString( '/boost-cache/static/', $output );
+		$this->assert_static_cache_urls( $output );
 		$this->assertStringContainsString( '.min.js', $output );
-		$this->assertStringNotContainsString( '/_jb_static/??', $output );
 	}
 
 	public function test_css_falls_back_on_a_supported_host_when_the_tester_failed() {
@@ -225,8 +238,7 @@ class Concatenate_Static_Cache_Urls_Test extends BaseTestCase {
 
 		$output = $this->render_styles();
 
-		$this->assertStringContainsString( '/_jb_static/??', $output );
-		$this->assertStringNotContainsString( '/boost-cache/static/', $output );
+		$this->assert_fallback_urls( $output );
 	}
 
 	public function test_js_falls_back_on_a_supported_host_when_the_tester_failed() {
@@ -234,7 +246,39 @@ class Concatenate_Static_Cache_Urls_Test extends BaseTestCase {
 
 		$output = $this->render_scripts();
 
-		$this->assertStringContainsString( '/_jb_static/??', $output );
-		$this->assertStringNotContainsString( '/boost-cache/static/', $output );
+		$this->assert_fallback_urls( $output );
+	}
+
+	/**
+	 * The filter is the PR's escape hatch for hosts the guard excludes wrongly. These pin it in
+	 * both directions; without them, deleting the apply_filters() call keeps the suite green.
+	 */
+	public function test_filter_can_force_static_cache_urls_on_wp_cloud() {
+		update_site_option( 'jetpack_boost_static_minification', 1 );
+		$this->pretend_to_be_on_wp_cloud();
+
+		add_filter( 'jetpack_boost_minify_use_static_cache_urls', '__return_true' );
+		$output = '';
+		try {
+			$output = $this->render_styles();
+		} finally {
+			remove_filter( 'jetpack_boost_minify_use_static_cache_urls', '__return_true' );
+		}
+
+		$this->assert_static_cache_urls( $output );
+	}
+
+	public function test_filter_can_force_the_fallback_on_a_supported_host() {
+		update_site_option( 'jetpack_boost_static_minification', 1 );
+
+		add_filter( 'jetpack_boost_minify_use_static_cache_urls', '__return_false' );
+		$output = '';
+		try {
+			$output = $this->render_scripts();
+		} finally {
+			remove_filter( 'jetpack_boost_minify_use_static_cache_urls', '__return_false' );
+		}
+
+		$this->assert_fallback_urls( $output );
 	}
 }

--- a/projects/plugins/boost/tests/php/lib/minify/Concatenate_Static_Cache_Urls_Test.php
+++ b/projects/plugins/boost/tests/php/lib/minify/Concatenate_Static_Cache_Urls_Test.php
@@ -24,9 +24,9 @@ if ( ! function_exists( 'jetpack_boost_ds_get' ) ) {
 }
 
 /**
- * BOOST-608: the URL these two classes emit is the user-visible contract. The helper tests next door
- * all pass while do_items() reads the migrated option directly, which is the bug. Assert on the
- * emitted tag, not on the helper.
+ * BOOST-608: the URL these two classes emit is the user-visible contract. The helper tests in this
+ * directory stay green even when do_items() reads the migrated option directly, which is the bug.
+ * So these tests assert on the emitted tag, not on the helper.
  */
 class Concatenate_Static_Cache_Urls_Test extends BaseTestCase {
 
@@ -55,7 +55,7 @@ class Concatenate_Static_Cache_Urls_Test extends BaseTestCase {
 
 		// The assets must live under wp-content. Dependency_Path_Mapping resolves enqueued URLs back
 		// to paths relative to it, and skips anything it cannot resolve. The pid suffix keeps
-		// concurrent test processes from clobbering each other's fixtures.
+		// concurrent test processes from overwriting each other's fixtures.
 		$this->asset_dir = WP_CONTENT_DIR . '/boost-concat-test-' . getmypid();
 		if ( ! is_dir( $this->asset_dir ) ) {
 			mkdir( $this->asset_dir, 0755, true );
@@ -130,8 +130,8 @@ class Concatenate_Static_Cache_Urls_Test extends BaseTestCase {
 		$styles->add( 'boost-test-b', $this->asset_url( 'b.css' ), array(), null );
 		$styles->enqueue( array( 'boost-test-a', 'boost-test-b' ) );
 
-		// finally, so a throw inside do_items() surfaces as that failure rather than as a leaked
-		// buffer tripping beStrictAboutOutputDuringTests.
+		// The finally block makes a throw inside do_items() surface as that failure, not as a
+		// leaked buffer that trips beStrictAboutOutputDuringTests.
 		ob_start();
 		try {
 			$styles->do_items();
@@ -190,8 +190,8 @@ class Concatenate_Static_Cache_Urls_Test extends BaseTestCase {
 	}
 
 	/**
-	 * WordPress.com Atomic classifies as 'woa', not 'atomic'. These pin the guard to "anything but
-	 * 'other'": narrowing it to one named provider must fail here, not on WordPress.com.
+	 * WordPress.com Atomic classifies as 'woa', not 'atomic'. These tests pin the guard to "anything
+	 * but 'other'": narrowing it to one named provider must fail here, not on WordPress.com.
 	 */
 	public function test_css_falls_back_when_a_stale_verdict_arrives_on_wpcom_atomic() {
 		update_site_option( 'jetpack_boost_static_minification', 1 );
@@ -250,7 +250,7 @@ class Concatenate_Static_Cache_Urls_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The filter is the PR's escape hatch for hosts the guard excludes wrongly. These pin it in
+	 * The filter is the escape hatch for hosts the guard excludes wrongly. These tests pin it in
 	 * both directions; without them, deleting the apply_filters() call keeps the suite green.
 	 */
 	public function test_filter_can_force_static_cache_urls_on_wp_cloud() {

--- a/projects/plugins/boost/tests/php/lib/minify/Concatenate_Static_Cache_Urls_Test.php
+++ b/projects/plugins/boost/tests/php/lib/minify/Concatenate_Static_Cache_Urls_Test.php
@@ -1,0 +1,219 @@
+<?php
+
+namespace Automattic\Jetpack_Boost\Tests\Lib\Minify;
+
+use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Status\Cache as Status_Cache;
+use Automattic\Jetpack_Boost\Lib\Minify\Concatenate_CSS;
+use Automattic\Jetpack_Boost\Lib\Minify\Concatenate_JS;
+use WorDBless\BaseTestCase;
+use WP_Scripts;
+use WP_Styles;
+
+if ( ! defined( 'JETPACK_BOOST_DIR_PATH' ) ) {
+	define( 'JETPACK_BOOST_DIR_PATH', dirname( __DIR__, 4 ) );
+}
+require_once JETPACK_BOOST_DIR_PATH . '/app/lib/minify/loader.php';
+
+// The exclude lists both classes read call jetpack_boost_ds_get(), which lives outside the minify
+// library. Without this the file passes only when another test booted the plugin first. Guarded,
+// because that is what the configured suite does and these registrations are not idempotent.
+if ( ! function_exists( 'jetpack_boost_ds_get' ) ) {
+	require_once JETPACK_BOOST_DIR_PATH . '/wp-js-data-sync.php';
+}
+
+/**
+ * BOOST-608: the URL these two classes emit is the user-visible contract. The helper tests next door
+ * all pass while do_items() reads the migrated option directly, which is the bug. Assert on the
+ * emitted tag, not on the helper.
+ */
+class Concatenate_Static_Cache_Urls_Test extends BaseTestCase {
+
+	/**
+	 * Directory holding the throwaway assets registered by these tests.
+	 *
+	 * @var string
+	 */
+	private $asset_dir;
+
+	/**
+	 * The page_optimize_site_url filter callback, kept so tear_down can remove it.
+	 *
+	 * @var callable
+	 */
+	private $site_url_filter;
+
+	/**
+	 * Absolute paths of the fixture files written by set_up(), so tear_down removes those and
+	 * nothing else.
+	 *
+	 * @var string[]
+	 */
+	private $asset_files = array();
+
+	public function set_up() {
+		parent::set_up();
+
+		// A leaked constant or a memoised host verdict decides which URL these render, so start from
+		// a known host rather than only tidying up afterwards.
+		Constants::clear_constants();
+		Status_Cache::clear();
+
+		// The assets must live under wp-content. Dependency_Path_Mapping resolves enqueued URLs back
+		// to paths relative to it, and skips anything it cannot resolve.
+		$this->asset_dir = WP_CONTENT_DIR . '/boost-concat-test';
+		if ( ! is_dir( $this->asset_dir ) ) {
+			mkdir( $this->asset_dir, 0755, true );
+		}
+
+		$this->asset_files = array();
+		foreach ( array(
+			'a.css' => '.a{color:red}',
+			'b.css' => '.b{color:blue}',
+			'a.js'  => 'var a = 1;',
+			'b.js'  => 'var b = 2;',
+		) as $name => $contents ) {
+			$path = $this->asset_dir . '/' . $name;
+			file_put_contents( $path, $contents );
+			$this->asset_files[] = $path;
+		}
+
+		// Both classes derive the site URL from the base_url WordPress hands them, which points at
+		// wp-includes here. Pin it, or nothing resolves as internal and every asset is skipped.
+		$this->site_url_filter = function () {
+			return site_url();
+		};
+		add_filter( 'page_optimize_site_url', $this->site_url_filter );
+	}
+
+	public function tear_down() {
+		if ( $this->site_url_filter ) {
+			remove_filter( 'page_optimize_site_url', $this->site_url_filter );
+		}
+
+		// Remove exactly the files set_up() wrote, then the directory if that emptied it. Tracking
+		// paths rather than ownership means a part-way run cannot leave the fixture behind.
+		foreach ( $this->asset_files as $file ) {
+			if ( file_exists( $file ) ) {
+				unlink( $file );
+			}
+		}
+		if ( is_dir( $this->asset_dir ) ) {
+			@rmdir( $this->asset_dir ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- best effort; a non-empty directory holds something this test did not create.
+		}
+
+		Constants::clear_constants();
+		Status_Cache::clear();
+		delete_site_option( 'jetpack_boost_static_minification' );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Put the site on WP Cloud, where the web server may answer wp-content 404s itself.
+	 */
+	private function pretend_to_be_on_wp_cloud() {
+		Constants::set_constant( 'ATOMIC_SITE_ID', 1 );
+		Constants::set_constant( 'ATOMIC_CLIENT_ID', 1 );
+		Status_Cache::clear();
+	}
+
+	private function render_styles() {
+		$styles = new Concatenate_CSS( new WP_Styles() );
+		$styles->add( 'boost-test-a', '/wp-content/boost-concat-test/a.css', array(), null );
+		$styles->add( 'boost-test-b', '/wp-content/boost-concat-test/b.css', array(), null );
+		$styles->enqueue( array( 'boost-test-a', 'boost-test-b' ) );
+
+		// finally, so a throw inside do_items() surfaces as that failure rather than as a leaked
+		// buffer tripping beStrictAboutOutputDuringTests.
+		ob_start();
+		try {
+			$styles->do_items();
+		} finally {
+			$output = ob_get_clean();
+		}
+
+		return $output;
+	}
+
+	private function render_scripts() {
+		$scripts = new Concatenate_JS( new WP_Scripts() );
+		$scripts->add( 'boost-test-a', '/wp-content/boost-concat-test/a.js', array(), null );
+		$scripts->add( 'boost-test-b', '/wp-content/boost-concat-test/b.js', array(), null );
+		$scripts->enqueue( array( 'boost-test-a', 'boost-test-b' ) );
+
+		ob_start();
+		try {
+			$scripts->do_items();
+		} finally {
+			$output = ob_get_clean();
+		}
+
+		return $output;
+	}
+
+	/**
+	 * The migrated database says the 404 tester passed, but it passed on the previous host.
+	 */
+	public function test_css_falls_back_when_a_stale_verdict_arrives_on_wp_cloud() {
+		update_site_option( 'jetpack_boost_static_minification', 1 );
+		$this->pretend_to_be_on_wp_cloud();
+
+		$output = $this->render_styles();
+
+		$this->assertStringContainsString( '/_jb_static/??', $output );
+		$this->assertStringNotContainsString( '/boost-cache/static/', $output );
+	}
+
+	public function test_js_falls_back_when_a_stale_verdict_arrives_on_wp_cloud() {
+		update_site_option( 'jetpack_boost_static_minification', 1 );
+		$this->pretend_to_be_on_wp_cloud();
+
+		$output = $this->render_scripts();
+
+		$this->assertStringContainsString( '/_jb_static/??', $output );
+		$this->assertStringNotContainsString( '/boost-cache/static/', $output );
+	}
+
+	/**
+	 * Hosts that can serve the static cache keep doing so. The guard only moves a site onto the
+	 * fallback, never the other way.
+	 */
+	public function test_css_uses_static_cache_urls_on_a_supported_host() {
+		update_site_option( 'jetpack_boost_static_minification', 1 );
+
+		$output = $this->render_styles();
+
+		$this->assertStringContainsString( '/boost-cache/static/', $output );
+		$this->assertStringContainsString( '.min.css', $output );
+		$this->assertStringNotContainsString( '/_jb_static/??', $output );
+	}
+
+	public function test_js_uses_static_cache_urls_on_a_supported_host() {
+		update_site_option( 'jetpack_boost_static_minification', 1 );
+
+		$output = $this->render_scripts();
+
+		$this->assertStringContainsString( '/boost-cache/static/', $output );
+		$this->assertStringContainsString( '.min.js', $output );
+		$this->assertStringNotContainsString( '/_jb_static/??', $output );
+	}
+
+	public function test_css_falls_back_on_a_supported_host_when_the_tester_failed() {
+		update_site_option( 'jetpack_boost_static_minification', 0 );
+
+		$output = $this->render_styles();
+
+		$this->assertStringContainsString( '/_jb_static/??', $output );
+		$this->assertStringNotContainsString( '/boost-cache/static/', $output );
+	}
+
+	public function test_js_falls_back_on_a_supported_host_when_the_tester_failed() {
+		update_site_option( 'jetpack_boost_static_minification', 0 );
+
+		$output = $this->render_scripts();
+
+		$this->assertStringContainsString( '/_jb_static/??', $output );
+		$this->assertStringNotContainsString( '/boost-cache/static/', $output );
+	}
+}


### PR DESCRIPTION
Fixes BOOST-608

## Proposed changes

Concatenate JS/CSS links bundles in one of two ways: static files under `wp-content/boost-cache/static/`, or the `/_jb_static/??` fallback that PHP serves. Static delivery works only if WordPress receives the 404 for a missing `wp-content` file and builds the bundle while it answers. The 404 tester stores that result in the `jetpack_boost_static_minification` option, and the option travels with the database. A site migrated onto Atomic or WP Cloud can arrive with a stale `1`. Every bundle URL then 404s at the web server, and pages render without CSS or JS.

The fix: the concatenators now call `jetpack_boost_minify_use_static_cache_urls()`. On Atomic and WP Cloud it returns false, so those sites use the fallback, which works on every host. Other hosts keep the stored result. The `jetpack_boost_minify_use_static_cache_urls` filter overrides the decision.

This trade is deliberate. Some WP Cloud sites do route those 404s to WordPress, and they lose static delivery. The fallback serves the same bytes through PHP, so the cost is performance, not an outage. Boost cannot read the platform setting that separates the two groups, and the wrong guess in the other direction breaks sites.

### Known limitations

* Pages already cached (Boost page cache, edge caches) keep the old URLs until purge or expiry.
* A custom `JETPACK_BOOST_STATIC_PREFIX` without a trailing slash hits a router mismatch that predates this PR. The default prefix is unaffected. Follow-up work.

## Related product discussion/links

* [BOOST-608](https://linear.app/a8c/issue/BOOST-608/jp-boost-concatenation-is-broken-after-migrating-a-site-to-wp-cloud)
* Origin thread in `#reprint`: p1785266572764519-slack-C0AB91NNQBG. The workaround was to clear the option by hand.
* Prior art: #41056, #42225, #42249, #42624.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Run `jp test php plugins/boost`. `Concatenate_Static_Cache_Urls_Test` covers both hosts, both option values, and the filter.

To test by hand, make Boost see WP Cloud with a mu-plugin:

```php
define( 'ATOMIC_SITE_ID', 1 );
define( 'ATOMIC_CLIENT_ID', 1 );
```

1. Enable **Concatenate JS** and **Concatenate CSS**.
2. Run `wp option update jetpack_boost_static_minification 1`.
3. View the page source. Bundle URLs must use `/_jb_static/??…`, not `/wp-content/boost-cache/static/`.
4. Confirm those URLs return the CSS and JS with a 200.
5. Remove the constants. The option decides again: `1` gives static URLs, `0` gives the fallback.
