### PR TITLE
Help Center: Forward logged-out chat sessions

### DIFF
--- a/projects/packages/help-center/CHANGELOG.md
+++ b/projects/packages/help-center/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2026-07-31
+### Fixed
+- Help Center: Forward anonymous chat session data to WordPress.com.
+
 ## [0.3.0] - 2026-07-30
 ### Added
 - Help Center: Allow consumers to configure interaction bot slugs.
@@ -18,5 +22,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow consumers to provide the WordPress.com authentication state and request client used by the Help Center.
 - Initial version, extracted from Jetpack MU WPCOM to its own package for external consumption.
 
+[0.3.1]: https://github.com/Automattic/jetpack-help-center/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Automattic/jetpack-help-center/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Automattic/jetpack-help-center/compare/v0.1.0...v0.2.0

--- a/projects/packages/help-center/src/class-help-center.php
+++ b/projects/packages/help-center/src/class-help-center.php
@@ -18,7 +18,7 @@ class Help_Center {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.3.0';
+	const PACKAGE_VERSION = '0.3.1';
 
 	/**
 	 * Class instance.

--- a/projects/packages/help-center/src/class-wp-rest-help-center-odie.php
+++ b/projects/packages/help-center/src/class-wp-rest-help-center-odie.php
@@ -207,6 +207,17 @@ class WP_REST_Help_Center_Odie extends WP_REST_Help_Center_Controller {
 	public function send_chat_message( \WP_REST_Request $request ) {
 		$bot_name_slug = $request->get_param( 'bot_id' );
 		$chat_id       = $request->get_param( 'chat_id' );
+		$request_body  = array(
+			'message' => $request->get_param( 'message' ),
+			'context' => $request->get_param( 'context' ) ?? array(),
+		);
+
+		foreach ( array( 'version', 'session_id', 'external_chat_provider', 'external_chat_id' ) as $optional_param ) {
+			$value = $request->get_param( $optional_param );
+			if ( null !== $value ) {
+				$request_body[ $optional_param ] = $value;
+			}
+		}
 
 		// Forward the request body to the support chat endpoint.
 		$body = $this->wpcom_request_client->request(
@@ -216,11 +227,7 @@ class WP_REST_Help_Center_Odie extends WP_REST_Help_Center_Controller {
 				'method'  => 'POST',
 				'timeout' => 60,
 			),
-			array(
-				'message' => $request->get_param( 'message' ),
-				'context' => $request->get_param( 'context' ) ?? array(),
-				'version' => $request->get_param( 'version' ),
-			)
+			$request_body
 		);
 
 		if ( is_wp_error( $body ) ) {
@@ -249,6 +256,8 @@ class WP_REST_Help_Center_Odie extends WP_REST_Help_Center_Controller {
 				'page_number'      => $page_number,
 				'items_per_page'   => $items_per_page,
 				'include_feedback' => $include_feedback,
+				'version'          => $request->get_param( 'version' ),
+				'session_id'       => $request->get_param( 'session_id' ),
 			)
 		);
 

--- a/projects/packages/help-center/tests/php/Logged_Out_Request_Test.php
+++ b/projects/packages/help-center/tests/php/Logged_Out_Request_Test.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\Jetpack\Help_Center\Jetpack_Wpcom_Request_Client;
+use Automattic\Jetpack\Help_Center\WP_REST_Help_Center_Odie;
 use Automattic\Jetpack\Help_Center\WP_REST_Help_Center_Search;
 use Automattic\Jetpack\Help_Center\Wpcom_Request_Client;
 
@@ -119,5 +120,107 @@ class Logged_Out_Request_Test extends \WorDBless\BaseTestCase {
 		$response_data = $response->get_data();
 		$this->assertCount( 1, $response_data->results );
 		$this->assertSame( 'Payments', $response_data->results[0]->title );
+	}
+
+	public function test_odie_proxy_forwards_logged_out_chat_session() {
+		$wpcom_request_client = $this->create_capturing_request_client();
+		$request              = new \WP_REST_Request( 'POST', '/help-center/odie/chat/test-bot/123' );
+		$request->set_param( 'bot_id', 'test-bot' );
+		$request->set_param( 'chat_id', 123 );
+		$request->set_param( 'message', 'hi' );
+		$request->set_param( 'context', array( 'screen' => 'storefront' ) );
+		$request->set_param( 'version', '3.0.1' );
+		$request->set_param( 'session_id', 'anonymous-session' );
+		$request->set_param( 'external_chat_provider', 'zendesk' );
+		$request->set_param( 'external_chat_id', 'external-chat' );
+
+		$controller = new WP_REST_Help_Center_Odie( $wpcom_request_client );
+		$controller->send_chat_message( $request );
+
+		$this->assertSame(
+			array(
+				'message'                => 'hi',
+				'context'                => array( 'screen' => 'storefront' ),
+				'version'                => '3.0.1',
+				'session_id'             => 'anonymous-session',
+				'external_chat_provider' => 'zendesk',
+				'external_chat_id'       => 'external-chat',
+			),
+			$wpcom_request_client->requests[0]['body']
+		);
+	}
+
+	public function test_odie_proxy_omits_unset_optional_chat_fields() {
+		$wpcom_request_client = $this->create_capturing_request_client();
+		$request              = new \WP_REST_Request( 'POST', '/help-center/odie/chat/test-bot' );
+		$request->set_param( 'bot_id', 'test-bot' );
+		$request->set_param( 'message', 'hi' );
+
+		$controller = new WP_REST_Help_Center_Odie( $wpcom_request_client );
+		$controller->send_chat_message( $request );
+
+		$this->assertSame(
+			array(
+				'message' => 'hi',
+				'context' => array(),
+			),
+			$wpcom_request_client->requests[0]['body']
+		);
+	}
+
+	public function test_odie_proxy_forwards_logged_out_session_when_getting_chat() {
+		$wpcom_request_client = $this->create_capturing_request_client();
+		$request              = new \WP_REST_Request( 'GET', '/help-center/odie/chat/test-bot/123' );
+		$request->set_param( 'bot_id', 'test-bot' );
+		$request->set_param( 'chat_id', 123 );
+		$request->set_param( 'page_number', 1 );
+		$request->set_param( 'items_per_page', 30 );
+		$request->set_param( 'include_feedback', true );
+		$request->set_param( 'version', '3.0.1' );
+		$request->set_param( 'session_id', 'anonymous-session' );
+
+		$controller = new WP_REST_Help_Center_Odie( $wpcom_request_client );
+		$controller->get_chat( $request );
+
+		$this->assertSame(
+			'/odie/chat/test-bot/123?page_number=1&items_per_page=30&include_feedback=1&version=3.0.1&session_id=anonymous-session',
+			$wpcom_request_client->requests[0]['path']
+		);
+	}
+
+	private function create_capturing_request_client(): Wpcom_Request_Client {
+		return new class() implements Wpcom_Request_Client {
+			/**
+			 * Captured requests.
+			 *
+			 * @var array
+			 */
+			public $requests = array();
+
+			public function is_user_connected() {
+				return false;
+			}
+
+			public function request(
+				$path,
+				$version = '2',
+				$args = array(),
+				$body = null,
+				$base_api_path = 'wpcom'
+			) {
+				$this->requests[] = compact( 'path', 'version', 'args', 'body', 'base_api_path' );
+
+				return array(
+					'headers'  => array(),
+					'body'     => '{"messages":[]}',
+					'response' => array(
+						'code'    => 200,
+						'message' => 'OK',
+					),
+					'cookies'  => array(),
+					'filename' => null,
+				);
+			}
+		};
 	}
 }

--- a/projects/packages/help-center/tests/php/Logged_Out_Request_Test.php
+++ b/projects/packages/help-center/tests/php/Logged_Out_Request_Test.php
@@ -10,6 +10,8 @@ use Automattic\Jetpack\Help_Center\WP_REST_Help_Center_Odie;
 use Automattic\Jetpack\Help_Center\WP_REST_Help_Center_Search;
 use Automattic\Jetpack\Help_Center\Wpcom_Request_Client;
 
+require_once __DIR__ . '/class-logged-out-capturing-request-client.php';
+
 /**
  * Class Logged_Out_Request_Test
  */
@@ -188,39 +190,7 @@ class Logged_Out_Request_Test extends \WorDBless\BaseTestCase {
 		);
 	}
 
-	private function create_capturing_request_client(): Wpcom_Request_Client {
-		return new class() implements Wpcom_Request_Client {
-			/**
-			 * Captured requests.
-			 *
-			 * @var array
-			 */
-			public $requests = array();
-
-			public function is_user_connected() {
-				return false;
-			}
-
-			public function request(
-				$path,
-				$version = '2',
-				$args = array(),
-				$body = null,
-				$base_api_path = 'wpcom'
-			) {
-				$this->requests[] = compact( 'path', 'version', 'args', 'body', 'base_api_path' );
-
-				return array(
-					'headers'  => array(),
-					'body'     => '{"messages":[]}',
-					'response' => array(
-						'code'    => 200,
-						'message' => 'OK',
-					),
-					'cookies'  => array(),
-					'filename' => null,
-				);
-			}
-		};
+	private function create_capturing_request_client(): Logged_Out_Capturing_Request_Client {
+		return new Logged_Out_Capturing_Request_Client();
 	}
 }

--- a/projects/packages/help-center/tests/php/class-logged-out-capturing-request-client.php
+++ b/projects/packages/help-center/tests/php/class-logged-out-capturing-request-client.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * Test request client that captures proxied requests.
+ *
+ * @package automattic/jetpack-help-center
+ */
+
+use Automattic\Jetpack\Help_Center\Wpcom_Request_Client;
+
+/**
+ * Request client that captures proxied requests for assertions.
+ */
+class Logged_Out_Capturing_Request_Client implements Wpcom_Request_Client {
+	/**
+	 * Captured requests.
+	 *
+	 * @var array
+	 */
+	public $requests = array();
+
+	public function is_user_connected() {
+		return false;
+	}
+
+	public function request(
+		$path,
+		$version = '2',
+		$args = array(),
+		$body = null,
+		$base_api_path = 'wpcom'
+	) {
+		$this->requests[] = compact( 'path', 'version', 'args', 'body', 'base_api_path' );
+
+		return array(
+			'headers'  => array(),
+			'body'     => '{"messages":[]}',
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+			'cookies'  => array(),
+			'filename' => null,
+		);
+	}
+}


### PR DESCRIPTION
## Proposed changes

- Forward the anonymous ODIE `session_id` when retrieving and continuing a Help Center chat.
- Preserve optional chat fields such as `version`, `external_chat_provider`, and `external_chat_id` without adding unset fields to the proxied request.
- Add regression coverage for logged-out chat reads and writes.
- Prepare `automattic/jetpack-help-center` 0.3.1 in the same PR.

## Related product discussion/links

N/A

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

This is tested in 26079-gh-Automattic/woocommerce.com