### PR TITLE
Connection: Handle mixed Manager package versions

### DIFF
--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.8.2] - 2026-07-31
+### Fixed
+- Connection: Prevent mixed package versions from causing a fatal error in the admin initial state.
+
 ## [8.8.1] - 2026-07-31
 ### Added
 - Connection: Expose the connection-error audience (site/owner/user) to the Jetpack dashboard so error notices can be tailored to the viewer.
@@ -1970,6 +1974,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[8.8.2]: https://github.com/Automattic/jetpack-connection/compare/v8.8.1...v8.8.2
 [8.8.1]: https://github.com/Automattic/jetpack-connection/compare/v8.8.0...v8.8.1
 [8.8.0]: https://github.com/Automattic/jetpack-connection/compare/v8.7.10...v8.8.0
 [8.7.10]: https://github.com/Automattic/jetpack-connection/compare/v8.7.9...v8.7.10

--- a/projects/packages/connection/src/class-initial-state.php
+++ b/projects/packages/connection/src/class-initial-state.php
@@ -15,6 +15,28 @@ use Automattic\Jetpack\Status;
 class Initial_State {
 
 	/**
+	 * Check whether connection ownership can be transferred.
+	 *
+	 * Older versions of Manager may already be loaded by another plugin before the
+	 * latest Connection package is registered. Ownership was always transferable
+	 * before this API was introduced, so preserve that behavior in mixed-version
+	 * requests.
+	 *
+	 * @since 8.8.2
+	 *
+	 * @param object $manager Connection manager instance.
+	 * @return bool
+	 */
+	private static function is_ownership_transferable( $manager ) {
+		$callback = array( $manager, 'is_ownership_transferable' );
+		if ( ! is_callable( $callback ) ) {
+			return true;
+		}
+
+		return (bool) call_user_func( $callback );
+	}
+
+	/**
 	 * Get the initial state data.
 	 *
 	 * @return array
@@ -58,7 +80,7 @@ class Initial_State {
 			'connectionErrors'        => Error_Handler::get_instance()->get_displayable_errors(),
 			'isOfflineMode'           => $status->is_offline_mode(),
 			'calypsoEnv'              => ( new Status\Host() )->get_calypso_env(),
-			'isOwnershipTransferable' => ( new Manager() )->is_ownership_transferable(),
+			'isOwnershipTransferable' => self::is_ownership_transferable( new Manager() ),
 			'connectionOwner'         => $connection_owner,
 		);
 	}

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '8.8.1';
+	const PACKAGE_VERSION = '8.8.2';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/connection/tests/php/Initial_State_Test.php
+++ b/projects/packages/connection/tests/php/Initial_State_Test.php
@@ -13,6 +13,21 @@ use PHPUnit\Framework\TestCase;
 class Initial_State_Test extends TestCase {
 
 	/**
+	 * Invoke the private ownership-transferability compatibility helper.
+	 *
+	 * @param object $manager Connection manager instance.
+	 * @return bool
+	 */
+	private static function is_ownership_transferable( $manager ) {
+		$method = new \ReflectionMethod( Initial_State::class, 'is_ownership_transferable' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		return $method->invoke( null, $manager );
+	}
+
+	/**
 	 * Cleans up the test environment after each test.
 	 */
 	protected function tearDown(): void {
@@ -109,6 +124,31 @@ class Initial_State_Test extends TestCase {
 		unset( $_GET['calypso_env'] );
 
 		$this->assertEquals( $expected_value, $actual_value );
+	}
+
+	/**
+	 * Older Manager versions loaded by another plugin predate ownership locking.
+	 */
+	public function test_ownership_is_transferable_with_legacy_manager() {
+		$this->assertTrue( self::is_ownership_transferable( new class() {} ) );
+	}
+
+	/**
+	 * The compatibility guard must preserve the value returned by current managers.
+	 */
+	public function test_ownership_transferability_uses_manager_value() {
+		$manager = new class() {
+			/**
+			 * Report that ownership is locked.
+			 *
+			 * @return bool
+			 */
+			public function is_ownership_transferable() {
+				return false;
+			}
+		};
+
+		$this->assertFalse( self::is_ownership_transferable( $manager ) );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- avoid a fatal error when `Initial_State` is loaded from a current Connection package while an older plugin has already loaded `Manager`
- preserve the pre-8.8 behavior by treating ownership as transferable when the loaded manager predates `is_ownership_transferable()`
- add focused compatibility coverage and prepare Connection 8.8.2

## Root cause

Jetpack package classes share namespaces across plugins. The version-aware autoloader selects the newest registered package, but it cannot replace a class that another plugin loaded before that package registered.

This can leave a request with `Initial_State` from Connection 8.8.1 and `Manager` from an older release. `Initial_State` then calls `Manager::is_ownership_transferable()`, which was introduced in 8.8.0, and the request fatals.

The fallback is `true` because ownership was always transferable before the locking API existed.

## Testing

- Connection PHPUnit suite: 821 tests, 1796 assertions
- focused `Initial_State_Test`: 6 tests, 12 assertions
- PHPCS and PHP compatibility checks on the changed source and test files
- Jetpack pre-commit syntax, PHPCS, compatibility, and changelog checks
- WooCommerce.com Docker verification with Connection 6.19.2 `Manager` explicitly preloaded before Connection 8.8.1 `Initial_State`; initial-state rendering completed and returned `isOwnershipTransferable: true`
