### PR TITLE
VideoPress dashboard: wrap dialog bodies in Dialog.Content

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-chapters-modal-dialog-content
+++ b/projects/packages/videopress/changelog/fix-videopress-chapters-modal-dialog-content
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: fix cramped spacing in the Chapters help modal and let long dialog content scroll.

--- a/projects/packages/videopress/src/dashboard/components/video-details/chapters-help-modal.scss
+++ b/projects/packages/videopress/src/dashboard/components/video-details/chapters-help-modal.scss
@@ -1,0 +1,56 @@
+// Body styles for the Chapters help modal.
+
+// The Dialog portals into `<body>`, so wp-admin's global element rules apply
+// to everything inside it — and they win: `@wordpress/ui` ships its styles
+// inside `@layer wp-ui`, and an unlayered declaration always outranks a
+// layered one regardless of specificity. That means `p { margin: 1em 0 }`,
+// `ul li { margin-bottom: 6px }` and `h3 { font-size: 1.3em }` beat anything
+// the design system sets. Rather than fight that per property, the body zeroes
+// the inherited block margins and lets `Stack` gaps own the vertical rhythm.
+
+// Scoped to the dashboard body class (as in `admin-shell.scss`) so these rules
+// stay inside the modernized VideoPress pages.
+
+body.jetpack_page_jetpack-videopress {
+
+	.vp-chapters-help {
+
+		p,
+		ol,
+		li {
+			margin-block: 0;
+		}
+
+		// Sub-headings inside the dialog body. `Dialog.Title` is the `<h2>`,
+		// so these are `<h3>`; the visual treatment stays plain bold body
+		// text rather than wp-admin's larger heading scale.
+		&__heading {
+			font-size: inherit;
+			font-weight: 600;
+			line-height: inherit;
+			margin-block: 0;
+		}
+
+		// Marker indent has to be restated: the margin reset above drops
+		// wp-admin's list offset along with its bottom margins.
+		&__steps {
+			padding-inline-start: 1.5em;
+
+			li + li {
+				margin-block-start: var(--wpds-dimension-gap-sm);
+			}
+		}
+
+		// The sample chapter list is text the user copies into the video
+		// Description, so it reads as a code-style block: monospace keeps the
+		// timestamps aligned, and the fill separates it from the surrounding
+		// prose.
+		&__example {
+			background-color: var(--wpds-color-background-surface-neutral-weak);
+			border-radius: var(--wpds-border-radius-sm);
+			font-family: Menlo, Consolas, monaco, monospace;
+			padding: var(--wpds-dimension-padding-md);
+		}
+	}
+
+}

--- a/projects/packages/videopress/src/dashboard/components/video-details/chapters-help-modal.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/chapters-help-modal.tsx
@@ -1,6 +1,7 @@
 import { __ } from '@wordpress/i18n';
-import { Button, Dialog } from '@wordpress/ui';
+import { Button, Dialog, Stack } from '@wordpress/ui';
 import type { ReactElement } from 'react';
+import './chapters-help-modal.scss';
 
 type Props = {
 	isOpen: boolean;
@@ -11,6 +12,12 @@ type Props = {
  * Help modal explaining how to add chapters via the Description field.
  * Triggered from VideoDetailsCard. Same copy as the legacy
  * `learn-how-notice` component, rebuilt on `@wordpress/ui` `Dialog.*`.
+ *
+ * The body lives inside `Dialog.Content`, which owns the popup's padding and
+ * its overflow — `Dialog.Popup` is `overflow: hidden`, so content rendered as
+ * a direct child of the popup clips instead of scrolling once it outgrows the
+ * viewport. Spacing comes from `Stack` gaps rather than element margins; see
+ * `chapters-help-modal.scss` for why margins can't be trusted here.
  *
  * @param props         - Component props.
  * @param props.isOpen  - Whether the dialog is open.
@@ -32,56 +39,66 @@ export default function ChaptersHelpModal( { isOpen, onClose }: Props ): ReactEl
 					<Dialog.Title>{ __( 'Chapters in VideoPress', 'jetpack-videopress-pkg' ) }</Dialog.Title>
 					<Dialog.CloseIcon label={ __( 'Close', 'jetpack-videopress-pkg' ) } />
 				</Dialog.Header>
-				<p>
-					{ __(
-						'Chapters are a great way to split up longer videos and organize them into different sections.',
-						'jetpack-videopress-pkg'
-					) }
-				</p>
-				<p>
-					{ __(
-						'They allow your visitors to see what each section is about and skip to their favorite parts.',
-						'jetpack-videopress-pkg'
-					) }
-				</p>
-				<p>
-					<strong>
-						{ __( 'How to add Chapters to your VideoPress videos', 'jetpack-videopress-pkg' ) }
-					</strong>
-				</p>
-				<ol>
-					<li>
-						{ __(
-							'In the Description, add a list of timestamps and titles.',
-							'jetpack-videopress-pkg'
-						) }
-					</li>
-					<li>
-						{ __(
-							'Make sure that the first timestamp starts with 00:00.',
-							'jetpack-videopress-pkg'
-						) }
-					</li>
-					<li>
-						{ __(
-							'Add at least three chapters entries and as many as you need.',
-							'jetpack-videopress-pkg'
-						) }
-					</li>
-					<li>
-						{ __(
-							'Add your chapters entries in consecutive order, with at least 10-second intervals between each.',
-							'jetpack-videopress-pkg'
-						) }
-					</li>
-				</ol>
-				<p>
-					<strong>{ __( 'Example', 'jetpack-videopress-pkg' ) }</strong>
-				</p>
-				<p>00:00 Intro</p>
-				<p>00:24 Mountains arise</p>
-				<p>02:38 Coming back home</p>
-				<p>03:04 Credits</p>
+				<Dialog.Content className="vp-chapters-help">
+					<Stack direction="column" gap="lg">
+						<Stack direction="column" gap="sm">
+							<p>
+								{ __(
+									'Chapters are a great way to split up longer videos and organize them into different sections.',
+									'jetpack-videopress-pkg'
+								) }
+							</p>
+							<p>
+								{ __(
+									'They allow your visitors to see what each section is about and skip to their favorite parts.',
+									'jetpack-videopress-pkg'
+								) }
+							</p>
+						</Stack>
+						<Stack direction="column" gap="sm">
+							<h3 className="vp-chapters-help__heading">
+								{ __( 'How to add Chapters to your VideoPress videos', 'jetpack-videopress-pkg' ) }
+							</h3>
+							<ol className="vp-chapters-help__steps">
+								<li>
+									{ __(
+										'In the Description, add a list of timestamps and titles.',
+										'jetpack-videopress-pkg'
+									) }
+								</li>
+								<li>
+									{ __(
+										'Make sure that the first timestamp starts with 00:00.',
+										'jetpack-videopress-pkg'
+									) }
+								</li>
+								<li>
+									{ __(
+										'Add at least three chapters entries and as many as you need.',
+										'jetpack-videopress-pkg'
+									) }
+								</li>
+								<li>
+									{ __(
+										'Add your chapters entries in consecutive order, with at least 10-second intervals between each.',
+										'jetpack-videopress-pkg'
+									) }
+								</li>
+							</ol>
+						</Stack>
+						<Stack direction="column" gap="sm">
+							<h3 className="vp-chapters-help__heading">
+								{ __( 'Example', 'jetpack-videopress-pkg' ) }
+							</h3>
+							<Stack direction="column" gap="xs" className="vp-chapters-help__example">
+								<p>00:00 Intro</p>
+								<p>00:24 Mountains arise</p>
+								<p>02:38 Coming back home</p>
+								<p>03:04 Credits</p>
+							</Stack>
+						</Stack>
+					</Stack>
+				</Dialog.Content>
 				<Dialog.Footer>
 					<Dialog.Action render={ <Button /> }>
 						{ __( 'Got it, thanks', 'jetpack-videopress-pkg' ) }

--- a/projects/packages/videopress/src/dashboard/components/video-details/select-frame-dialog.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/select-frame-dialog.tsx
@@ -172,7 +172,9 @@ export default function SelectFrameDialog( {
 					</Dialog.Title>
 					<Dialog.CloseIcon label={ __( 'Close', 'jetpack-videopress-pkg' ) } />
 				</Dialog.Header>
-				{ isOpen && <FrameScrubber src={ src } onChange={ setSelectedMs } /> }
+				<Dialog.Content>
+					{ isOpen && <FrameScrubber src={ src } onChange={ setSelectedMs } /> }
+				</Dialog.Content>
 				<Dialog.Footer>
 					<Dialog.Action render={ <Button variant="outline" /> }>
 						{ __( 'Cancel', 'jetpack-videopress-pkg' ) }

--- a/projects/packages/videopress/src/dashboard/components/video-details/test/chapters-help-modal.test.tsx
+++ b/projects/packages/videopress/src/dashboard/components/video-details/test/chapters-help-modal.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ChaptersHelpModal from '../chapters-help-modal';
+
+/**
+ * Locate the dialog's scroll/padding container.
+ *
+ * `Dialog.Content` tags its element with `data-wp-ui-overlay-scroll-container`
+ * (see `useOverlayScrollStateAttributes` in `@wordpress/ui`). Asserting against
+ * that attribute rather than the hashed CSS module class keeps these tests tied
+ * to the behaviour that matters: the body has to sit inside the dialog's scroll
+ * container, not directly under `Dialog.Popup`, or it renders without padding
+ * and clips instead of scrolling. Testing Library has no query for attributes,
+ * hence the direct lookup.
+ *
+ * @return The dialog body element, or null when no dialog is rendered.
+ */
+function getDialogBody(): HTMLElement | null {
+	return document.querySelector< HTMLElement >( '[data-wp-ui-overlay-scroll-container]' );
+}
+
+describe( 'ChaptersHelpModal', () => {
+	it( 'renders nothing while closed', () => {
+		render( <ChaptersHelpModal isOpen={ false } onClose={ jest.fn() } /> );
+		expect( screen.queryByRole( 'dialog' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders the body inside the dialog content container', () => {
+		render( <ChaptersHelpModal isOpen onClose={ jest.fn() } /> );
+
+		const body = getDialogBody();
+		expect( body ).toContainElement(
+			screen.getByText( /Chapters are a great way to split up longer videos/i )
+		);
+		expect( body ).toContainElement(
+			screen.getByRole( 'heading', {
+				name: /How to add Chapters to your VideoPress videos/i,
+			} )
+		);
+		expect( body ).toContainElement( screen.getByRole( 'list' ) );
+		expect( body ).toContainElement( screen.getByText( '00:24 Mountains arise' ) );
+	} );
+
+	it( 'keeps the header and footer outside the scrolling body', () => {
+		render( <ChaptersHelpModal isOpen onClose={ jest.fn() } /> );
+
+		const body = getDialogBody();
+		expect( body ).not.toContainElement(
+			screen.getByRole( 'heading', { name: 'Chapters in VideoPress' } )
+		);
+		expect( body ).not.toContainElement( screen.getByRole( 'button', { name: 'Got it, thanks' } ) );
+	} );
+
+	it( 'calls onClose when the confirm button is clicked', async () => {
+		const user = userEvent.setup();
+		const onClose = jest.fn();
+		render( <ChaptersHelpModal isOpen onClose={ onClose } /> );
+
+		await user.click( screen.getByRole( 'button', { name: 'Got it, thanks' } ) );
+		expect( onClose ).toHaveBeenCalledTimes( 1 );
+	} );
+} );


### PR DESCRIPTION
Fixes VIDP-340

## Proposed changes
* Wrap the body of both modernized-dashboard dialogs in `Dialog.Content`. Previously the body content was a direct child of `Dialog.Popup`, which skips the element that owns the popup's padding, its scroll container, and the scroll-state attributes driving the header/footer separators. Practical fallout in the Chapters help modal: the copy sat ~24px further out than its own title (`Dialog.Header`/`Dialog.Footer` carry their own inline padding) and ran flush against the popup border, and since `Dialog.Popup` is `overflow: hidden` with a `max-height` of `calc(100dvh - 48px)`, long bodies clipped instead of scrolling. The same omission was in `select-frame-dialog.tsx`, fixed here too — those were the only two `Dialog.Popup` call sites in the package.
* Rebuild the Chapters modal body on `Stack` gaps instead of element margins. The dialog portals into `<body>`, where wp-admin's unlayered `p { margin: 1em 0 }` and `ul li { margin-bottom: 6px }` outrank anything `@wordpress/ui` sets from inside `@layer wp-ui` — an unlayered declaration beats a layered one regardless of specificity — so block margins weren't reliable here. The new stylesheet zeroes them and the spacing comes from `Stack`, giving a consistent 8px/16px rhythm in place of the loose default one.
* Promote the `<p><strong>` pseudo-headings to real `<h3>`s (the dialog title is the `<h2>`), and render the example chapter list as a monospace block — it's text the user copies verbatim into the video Description, so the timestamps now line up.
* Add unit tests covering the structural regression: the body must live inside the dialog's scroll container, while the header and footer must stay outside it. Verified the new tests fail against the pre-fix markup.

## Related product discussion/links
* VIDP-340

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Build and activate the VideoPress package on a site running the modernized dashboard (`jp build packages/videopress`).
* Go to **VideoPress → Library**, open any video to reach the video details page.
* Click **Learn how** in the "Did you know you can now add Chapters to your videos?" notice.
* Confirm the modal body is inset from the popup edges and its left edge lines up with the "Chapters in VideoPress" title — before this change the copy started ~24px further out and the first paragraph touched the right border.
* Confirm the vertical spacing is even: 8px between related lines, 16px between the intro/steps/example blocks, no cavernous gaps between the example timestamps. The example block renders as a monospace, lightly filled panel.
* Shrink the browser window vertically until the modal hits its max height. The body should scroll on its own, with the title and the "Got it, thanks" button staying pinned and a separator line appearing at the scroll edge. Before this change the content clipped with no way to reach it.
* Repeat with an RTL locale to confirm the list indent and block padding flip correctly.
* Regression check on the sibling dialog: from the same page use **Update thumbnail → Select from video**. The scrubber and slider should now sit inside the dialog's padding rather than bleeding to its edges, and the dialog should behave normally otherwise.
