### PR TITLE
Newsletter: allow a chosen recipient for test emails

### DIFF
--- a/projects/plugins/jetpack/.phan/config.php
+++ b/projects/plugins/jetpack/.phan/config.php
@@ -19,6 +19,7 @@ $config = make_phan_config(
 			'tests/php/_inc/lib/mocks/simplepie.php',
 			// Mocks of wpcom classes and functions.
 			'tests/php/lib/class-wpcom-features.php',
+			'tests/php/lib/class-email-verification.php',
 			'tests/php/lib/mock-functions.php',
 			// Temporary duplicated defintions of classes.
 			'_inc/lib/class.color.php',

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-send-email-preview.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-send-email-preview.php
@@ -51,9 +51,13 @@ class WPCOM_REST_API_V2_Endpoint_Send_Email_Preview extends WP_REST_Controller {
 			) : array( $this, 'proxy_request_to_wpcom_as_user' ),
 			'permission_callback' => array( $this, 'permissions_check' ),
 			'args'                => array(
-				'id' => array(
+				'id'    => array(
 					'description' => __( 'Unique identifier for the post.', 'jetpack' ),
 					'type'        => 'integer',
+				),
+				'email' => array(
+					'description' => __( 'Optional recipient address. Defaults to the current user. A different address is only accepted from users who may add subscribers, and is subject to the same abuse checks.', 'jetpack' ),
+					'type'        => 'string',
 				),
 			),
 		);
@@ -122,9 +126,44 @@ class WPCOM_REST_API_V2_Endpoint_Send_Email_Preview extends WP_REST_Controller {
 		}
 
 		$current_user = wp_get_current_user();
-		$email        = $current_user->user_email;
+		$self_email   = $current_user->user_email;
+		$email        = $self_email;
 
-		// Try to create a new subscriber with the user's email
+		// Resolve the recipient. The address defaults to the caller's own verified
+		// email; a caller-supplied address is only honored after it clears the same
+		// gates as adding that person as a subscriber. Self-sends keep their
+		// historical behavior and skip the guard entirely.
+		$requested = $request->get_param( 'email' );
+		if ( is_string( $requested ) && '' !== trim( $requested ) ) {
+			$requested = sanitize_email( $requested );
+
+			if ( ! is_email( $requested ) ) {
+				return new WP_Error( 'invalid_email', __( 'Please enter a valid email address.', 'jetpack' ), array( 'status' => 400 ) );
+			}
+
+			if ( 0 !== strcasecmp( $requested, $self_email ) ) {
+				$guard = ABSPATH . 'wp-content/mu-plugins/email-subscriptions/email-preview-guard.php';
+				if ( ! class_exists( 'Email_Preview_Guard' ) && file_exists( $guard ) ) {
+					require_once $guard;
+				}
+
+				if ( ! class_exists( 'Email_Preview_Guard' ) ) {
+					return new WP_Error( 'send_email_preview_guard_unavailable', __( 'Test emails to another address are temporarily unavailable.', 'jetpack' ), array( 'status' => 503 ) );
+				}
+
+				// Email_Preview_Guard ships from wpcom and reaches the Phan stubs via the
+				// separate stub-regeneration job, so it is not yet declared at analysis time.
+				// @phan-suppress-next-line PhanUndeclaredClassMethod
+				$guarded = Email_Preview_Guard::check( $requested, get_current_blog_id() );
+				if ( is_wp_error( $guarded ) ) {
+					return $guarded;
+				}
+
+				$email = $requested;
+			}
+		}
+
+		// Try to create a new subscriber with the resolved email
 		$subscriber = Blog_Subscriber::create( $email );
 		if ( ! $subscriber ) {
 			return new WP_Error( 'unverified', __( 'Could not create subscriber.', 'jetpack' ), array( 'status' => rest_authorization_required_code() ) );

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-send-email-preview.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-send-email-preview.php
@@ -161,7 +161,7 @@ class WPCOM_REST_API_V2_Endpoint_Send_Email_Preview extends WP_REST_Controller {
 				// Email_Preview_Guard ships from wpcom and reaches the Phan stubs via the
 				// separate stub-regeneration job, so it is not yet declared at analysis time.
 				// @phan-suppress-next-line PhanUndeclaredClassMethod
-				$guarded = Email_Preview_Guard::check( $requested, get_current_blog_id() );
+				$guarded = Email_Preview_Guard::check( $requested );
 				if ( is_wp_error( $guarded ) ) {
 					return $guarded;
 				}

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-send-email-preview.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-send-email-preview.php
@@ -133,6 +133,11 @@ class WPCOM_REST_API_V2_Endpoint_Send_Email_Preview extends WP_REST_Controller {
 		// email; a caller-supplied address is only honored after it clears the same
 		// gates as adding that person as a subscriber. Self-sends keep their
 		// historical behavior and skip the guard entirely.
+		//
+		// The self-send fast path relies on the caller's own address matching
+		// $current_user->user_email. That holds because this callback only runs on
+		// wpcom (is_wpcom_simple(); Atomic/Jetpack requests are proxied to run as the
+		// wpcom user) — revisit this comparison if it ever runs in another context.
 		$requested = $request->get_param( 'email' );
 		if ( is_string( $requested ) && '' !== trim( $requested ) ) {
 			$requested = sanitize_email( $requested );
@@ -141,7 +146,9 @@ class WPCOM_REST_API_V2_Endpoint_Send_Email_Preview extends WP_REST_Controller {
 				return new WP_Error( 'invalid_email', __( 'Please enter a valid email address.', 'jetpack' ), array( 'status' => 400 ) );
 			}
 
-			if ( 0 !== strcasecmp( $requested, $self_email ) ) {
+			// Normalize both sides: comparing a sanitized address against the raw
+			// stored email could route a genuine self-send through the guard.
+			if ( 0 !== strcasecmp( $requested, sanitize_email( $self_email ) ) ) {
 				$guard = ABSPATH . 'wp-content/mu-plugins/email-subscriptions/email-preview-guard.php';
 				if ( ! class_exists( 'Email_Preview_Guard' ) && file_exists( $guard ) ) {
 					require_once $guard;

--- a/projects/plugins/jetpack/changelog/add-send-email-preview-recipient-field
+++ b/projects/plugins/jetpack/changelog/add-send-email-preview-recipient-field
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+Newsletter: Allow sending the test email to a chosen address, gated by the same abuse checks used when adding a subscriber.

--- a/projects/plugins/jetpack/class.jetpack-gutenberg.php
+++ b/projects/plugins/jetpack/class.jetpack-gutenberg.php
@@ -875,6 +875,13 @@ class Jetpack_Gutenberg {
 				'is_coming_soon'                => $status->is_coming_soon(),
 				'is_offline_mode'               => $status->is_offline_mode(),
 				'is_newsletter_feature_enabled' => class_exists( '\Jetpack_Memberships' ),
+				// Whether the current user may send a newsletter test email to an
+				// address other than their own. The wpcom guard enforces this on send
+				// (also checking add_users and site stickers); this flag only controls
+				// whether the editor's recipient field is editable. Approximated with
+				// manage_options so editors, who can only test-send to themselves,
+				// aren't shown an editable field that would always be rejected.
+				'can_send_test_email_to_others' => current_user_can( 'manage_options' ),
 				// this is the equivalent of JP initial state siteData.showMyJetpack (class-jetpack-redux-state-helper)
 				// used to determine if we can link to My Jetpack from the block editor
 				'is_my_jetpack_available'       => My_Jetpack_Initializer::should_initialize(),

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.jsx
@@ -46,6 +46,18 @@ import { SendIcon } from './icons';
 const MISSING_CONNECTION_ERROR_CODE = 'rest_cannot_send_email_preview';
 
 /**
+ * Lightweight client-side email format check, used to give instant feedback and
+ * skip the draft save + network round-trip on obviously malformed input. The
+ * server performs the authoritative validation.
+ *
+ * @param {string} email - Address to check.
+ * @return {boolean} Whether the address looks like a valid email.
+ */
+function isValidEmail( email ) {
+	return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test( email );
+}
+
+/**
  * Actionable notice shown when a preview request fails because the user's
  * WordPress.com account isn't connected. Links to the connection flow so the
  * user can resolve it without leaving the editor guessing.
@@ -79,6 +91,13 @@ export function NewsletterTestEmailModal( { isOpen, onClose } ) {
 	const { __unstableSaveForPreview } = useDispatch( editorStore );
 	const { tracks } = useAnalytics();
 
+	// Whether the user may send to an address other than their own. The server
+	// enforces this regardless; locking the field here just spares users who
+	// can't use it from an error they can't act on. Defaults to editable when the
+	// flag is absent so a permitted user is never blocked by a stale initial state.
+	const canEditRecipient =
+		window?.Jetpack_Editor_Initial_State?.jetpack?.can_send_test_email_to_others ?? true;
+
 	// The connection state is known client-side, so surface the requirement (and
 	// disable sending) as soon as the modal opens rather than after a failed send.
 	const { isUserConnected } = useConnection();
@@ -87,6 +106,19 @@ export function NewsletterTestEmailModal( { isOpen, onClose } ) {
 		shouldPromptForConnection || error?.code === MISSING_CONNECTION_ERROR_CODE;
 
 	const sendTestEmail = async () => {
+		const email = recipientEmail?.trim() ?? '';
+
+		// Validate client-side first for instant feedback, skipping the draft save
+		// and the network round-trip on malformed input. An empty address is
+		// allowed: the server falls back to the current user.
+		if ( email && ! isValidEmail( email ) ) {
+			setError( {
+				code: 'invalid_email',
+				message: __( 'Please enter a valid email address.', 'jetpack' ),
+			} );
+			return;
+		}
+
 		tracks.recordEvent( 'jetpack_newsletter_test_email_send', { post_id: postId } );
 		setError( null );
 		setIsEmailSending( true );
@@ -95,7 +127,7 @@ export function NewsletterTestEmailModal( { isOpen, onClose } ) {
 		apiFetch( {
 			path: '/wpcom/v2/send-email-preview/',
 			method: 'POST',
-			data: { id: postId, email: recipientEmail?.trim() },
+			data: { id: postId, email },
 		} )
 			.then( () => {
 				setIsEmailSending( false );
@@ -105,9 +137,17 @@ export function NewsletterTestEmailModal( { isOpen, onClose } ) {
 				setIsEmailSending( false );
 				setError( {
 					code: e?.code,
-					message:
-						e?.message ||
-						__( 'Whoops, we have encountered an error. Please try again later.', 'jetpack' ),
+					// A structured WP_Error carries a code and a user-facing message.
+					// A rejection without a code (e.g. a non-JSON response from an
+					// upstream rate limiter) gets a friendly generic fallback rather
+					// than a raw parser message.
+					message: e?.code
+						? e.message ||
+						  __( 'Whoops, we have encountered an error. Please try again later.', 'jetpack' )
+						: __(
+								'Something went wrong sending the test email. Please try again in a little while.',
+								'jetpack'
+						  ),
 				} );
 			} );
 	};
@@ -136,17 +176,22 @@ export function NewsletterTestEmailModal( { isOpen, onClose } ) {
 				) : (
 					<>
 						<p>
-							{ __(
-								'Send a test email to see exactly what your subscribers receive in their inboxes. It defaults to your address, but you can send it to any address you could add as a subscriber.',
-								'jetpack'
-							) }
+							{ canEditRecipient
+								? __(
+										'Send a test email to see exactly what your subscribers receive in their inboxes. It defaults to your address, but you can send it to any address you could add as a subscriber.',
+										'jetpack'
+								  )
+								: __(
+										'Send a test email to your address so you can see exactly what your subscribers receive in their inboxes.',
+										'jetpack'
+								  ) }
 						</p>
 						<Grid alignment="bottom" columns={ 2 } gap={ 2 } templateColumns="2fr auto;">
 							<InputControl
 								type="email"
 								value={ recipientEmail }
 								onChange={ value => setRecipientEmail( value ?? '' ) }
-								disabled={ isEmailSending }
+								disabled={ isEmailSending || ! canEditRecipient }
 								label={ __( 'Recipient email address', 'jetpack' ) }
 								hideLabelFromVision
 								__next40pxDefaultSize={ true }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.jsx
@@ -183,7 +183,8 @@ export function NewsletterTestEmailModal( { isOpen, onClose } ) {
 								  )
 								: __(
 										'Send a test email to your address so you can see exactly what your subscribers receive in their inboxes.',
-										'jetpack'
+										'jetpack',
+										/* dummy arg to avoid bad minification */ 0
 								  ) }
 						</p>
 						<Grid alignment="bottom" columns={ 2 } gap={ 2 } templateColumns="2fr auto;">

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.jsx
@@ -46,6 +46,19 @@ import { SendIcon } from './icons';
 const MISSING_CONNECTION_ERROR_CODE = 'rest_cannot_send_email_preview';
 
 /**
+ * apiFetch surfaces transport and parse failures under codes that aren't
+ * user-actionable. The most common in the wild is an Atomic edge rate-limit:
+ * the web-server layer returns a `text/html` 429 page before WordPress runs, so
+ * there's no JSON envelope and apiFetch collapses the whole response to
+ * `invalid_json` with the 429 status dropped. Showing that raw parser message to
+ * the user is meaningless — surface the friendly generic fallback instead.
+ *
+ * The heavier `parse: false` pattern that recovers the exact HTTP status lives
+ * in projects/packages/podcast/src/admin-pages/create-ai-podcast/index.js.
+ */
+const NON_ACTIONABLE_ERROR_CODES = [ 'invalid_json', 'unknown_error' ];
+
+/**
  * Lightweight client-side email format check, used to give instant feedback and
  * skip the draft save + network round-trip on obviously malformed input. The
  * server performs the authoritative validation.
@@ -135,15 +148,17 @@ export function NewsletterTestEmailModal( { isOpen, onClose } ) {
 			} )
 			.catch( e => {
 				setIsEmailSending( false );
+				// A structured WP_Error carries a code and a user-facing message we
+				// can show verbatim. A rejection without an actionable code — no code
+				// at all, or a transport/parse code like `invalid_json` from an
+				// upstream rate limiter (see NON_ACTIONABLE_ERROR_CODES) — gets a
+				// friendly generic fallback rather than a raw parser message.
+				const hasActionableMessage =
+					e?.code && ! NON_ACTIONABLE_ERROR_CODES.includes( e.code ) && e.message;
 				setError( {
 					code: e?.code,
-					// A structured WP_Error carries a code and a user-facing message.
-					// A rejection without a code (e.g. a non-JSON response from an
-					// upstream rate limiter) gets a friendly generic fallback rather
-					// than a raw parser message.
-					message: e?.code
-						? e.message ||
-						  __( 'Whoops, we have encountered an error. Please try again later.', 'jetpack' )
+					message: hasActionableMessage
+						? e.message
 						: __(
 								'Something went wrong sending the test email. Please try again in a little while.',
 								'jetpack'

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.jsx
@@ -72,6 +72,9 @@ export function NewsletterTestEmailModal( { isOpen, onClose } ) {
 	const [ isEmailSent, setIsEmailSent ] = useState( false );
 	const [ isEmailSending, setIsEmailSending ] = useState( false );
 	const [ error, setError ] = useState( null );
+	const [ recipientEmail, setRecipientEmail ] = useState(
+		() => window?.Jetpack_Editor_Initial_State?.tracksUserData?.email ?? ''
+	);
 	const postId = useSelect( select => select( 'core/editor' ).getCurrentPostId() );
 	const { __unstableSaveForPreview } = useDispatch( editorStore );
 	const { tracks } = useAnalytics();
@@ -92,7 +95,7 @@ export function NewsletterTestEmailModal( { isOpen, onClose } ) {
 		apiFetch( {
 			path: '/wpcom/v2/send-email-preview/',
 			method: 'POST',
-			data: { id: postId },
+			data: { id: postId, email: recipientEmail?.trim() },
 		} )
 			.then( () => {
 				setIsEmailSending( false );
@@ -134,14 +137,18 @@ export function NewsletterTestEmailModal( { isOpen, onClose } ) {
 					<>
 						<p>
 							{ __(
-								'This will send you an email, allowing you to see exactly what your subscribers receive in their inboxes.',
+								'Send a test email to see exactly what your subscribers receive in their inboxes. It defaults to your address, but you can send it to any address you could add as a subscriber.',
 								'jetpack'
 							) }
 						</p>
 						<Grid alignment="bottom" columns={ 2 } gap={ 2 } templateColumns="2fr auto;">
 							<InputControl
-								value={ window?.Jetpack_Editor_Initial_State?.tracksUserData?.email }
-								disabled
+								type="email"
+								value={ recipientEmail }
+								onChange={ value => setRecipientEmail( value ?? '' ) }
+								disabled={ isEmailSending }
+								label={ __( 'Recipient email address', 'jetpack' ) }
+								hideLabelFromVision
 								__next40pxDefaultSize={ true }
 							/>
 							<Button

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/test/email-preview.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/test/email-preview.jsx
@@ -255,4 +255,43 @@ describe( 'Test email recipient', () => {
 			screen.findByText( /not allowed to send a test email/ )
 		).resolves.toBeInTheDocument();
 	} );
+
+	it( 'rejects a malformed address client-side without calling the API', async () => {
+		const user = userEvent.setup();
+		apiFetch.mockResolvedValue( undefined );
+
+		render( <NewsletterTestEmailModal isOpen onClose={ jest.fn() } /> );
+
+		const field = screen.getByRole( 'textbox' );
+		await user.clear( field );
+		await user.type( field, 'not-an-email' );
+		await user.click( screen.getByRole( 'button', { name: /Send/ } ) );
+
+		await expect(
+			screen.findByText( /please enter a valid email address/i )
+		).resolves.toBeInTheDocument();
+		expect( apiFetch ).not.toHaveBeenCalled();
+	} );
+
+	it( 'shows a friendly fallback when the response has no error code', async () => {
+		const user = userEvent.setup();
+		apiFetch.mockRejectedValue( { message: 'The response is not a valid JSON response.' } );
+
+		render( <NewsletterTestEmailModal isOpen onClose={ jest.fn() } /> );
+
+		await user.click( screen.getByRole( 'button', { name: /Send/ } ) );
+
+		await expect(
+			screen.findByText( /please try again in a little while/i )
+		).resolves.toBeInTheDocument();
+		expect( screen.queryByText( /not a valid JSON response/i ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'locks the recipient field for users who cannot send to others', () => {
+		window.Jetpack_Editor_Initial_State.jetpack = { can_send_test_email_to_others: false };
+
+		render( <NewsletterTestEmailModal isOpen onClose={ jest.fn() } /> );
+
+		expect( screen.getByRole( 'textbox' ) ).toBeDisabled();
+	} );
 } );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/test/email-preview.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/test/email-preview.jsx
@@ -133,3 +133,61 @@ describe( 'Email preview connection errors', () => {
 		).not.toBeInTheDocument();
 	} );
 } );
+
+describe( 'Test email recipient', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockIsUserConnected = true;
+		useSelect.mockImplementation( () => 123 );
+		useDispatch.mockReturnValue( {
+			__unstableSaveForPreview: jest.fn().mockResolvedValue( undefined ),
+		} );
+		window.Jetpack_Editor_Initial_State = { tracksUserData: { email: 'author@example.com' } };
+	} );
+
+	afterEach( () => {
+		delete window.Jetpack_Editor_Initial_State;
+	} );
+
+	it( 'prefills the recipient field with the current user email', () => {
+		render( <NewsletterTestEmailModal isOpen onClose={ jest.fn() } /> );
+
+		expect( screen.getByRole( 'textbox' ) ).toHaveValue( 'author@example.com' );
+	} );
+
+	it( 'sends to an edited recipient address', async () => {
+		const user = userEvent.setup();
+		apiFetch.mockResolvedValue( undefined );
+
+		render( <NewsletterTestEmailModal isOpen onClose={ jest.fn() } /> );
+
+		const field = screen.getByRole( 'textbox' );
+		await user.clear( field );
+		await user.type( field, 'friend@example.com' );
+		await user.click( screen.getByRole( 'button', { name: /Send/ } ) );
+
+		expect( apiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: '/wpcom/v2/send-email-preview/',
+				method: 'POST',
+				data: { id: 123, email: 'friend@example.com' },
+			} )
+		);
+	} );
+
+	it( 'surfaces the guard message when a non-self recipient is rejected', async () => {
+		const user = userEvent.setup();
+		apiFetch.mockRejectedValue( {
+			code: 'send_email_preview_forbidden_recipient',
+			message: 'You are not allowed to send a test email to another address on this site.',
+		} );
+
+		render( <NewsletterTestEmailModal isOpen onClose={ jest.fn() } /> );
+
+		await user.click( screen.getByRole( 'button', { name: /Send/ } ) );
+
+		await expect(
+			screen.findByText( /not allowed to send a test email/ )
+		).resolves.toBeInTheDocument();
+	} );
+} );

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/test/email-preview.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/test/email-preview.jsx
@@ -186,9 +186,7 @@ describe( 'Test email recipient', () => {
 		expect( apiFetch ).toHaveBeenCalledWith(
 			expect.objectContaining( { data: { id: 123, email: 'author@example.com' } } )
 		);
-		await expect(
-			screen.findByText( 'Email sent successfully' )
-		).resolves.toBeInTheDocument();
+		await expect( screen.findByText( 'Email sent successfully' ) ).resolves.toBeInTheDocument();
 	} );
 
 	it( 'trims surrounding whitespace from the recipient before sending', async () => {
@@ -239,7 +237,7 @@ describe( 'Test email recipient', () => {
 
 		// Let the in-flight request settle so the final state update is flushed.
 		resolveSend();
-		await screen.findByText( 'Email sent successfully' );
+		await expect( screen.findByText( 'Email sent successfully' ) ).resolves.toBeInTheDocument();
 	} );
 
 	it( 'surfaces the guard message when a non-self recipient is rejected', async () => {

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/test/email-preview.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/test/email-preview.jsx
@@ -287,6 +287,26 @@ describe( 'Test email recipient', () => {
 		expect( screen.queryByText( /not a valid JSON response/i ) ).not.toBeInTheDocument();
 	} );
 
+	// The Atomic edge rate limiter returns a text/html 429 before WordPress runs,
+	// which apiFetch collapses to a non-actionable `invalid_json` code (the 429
+	// status is dropped). The raw parser message must not reach the user.
+	it( 'shows a friendly fallback for a non-actionable invalid_json rejection', async () => {
+		const user = userEvent.setup();
+		apiFetch.mockRejectedValue( {
+			code: 'invalid_json',
+			message: 'The response is not a valid JSON response.',
+		} );
+
+		render( <NewsletterTestEmailModal isOpen onClose={ jest.fn() } /> );
+
+		await user.click( screen.getByRole( 'button', { name: /Send/ } ) );
+
+		await expect(
+			screen.findByText( /please try again in a little while/i )
+		).resolves.toBeInTheDocument();
+		expect( screen.queryByText( /not a valid JSON response/i ) ).not.toBeInTheDocument();
+	} );
+
 	it( 'locks the recipient field for users who cannot send to others', () => {
 		window.Jetpack_Editor_Initial_State.jetpack = { can_send_test_email_to_others: false };
 

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/test/email-preview.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/test/email-preview.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import apiFetch from '@wordpress/api-fetch';
 import { useSelect, useDispatch } from '@wordpress/data';
@@ -173,6 +173,73 @@ describe( 'Test email recipient', () => {
 				data: { id: 123, email: 'friend@example.com' },
 			} )
 		);
+	} );
+
+	it( 'sends to the prefilled address unchanged and confirms success', async () => {
+		const user = userEvent.setup();
+		apiFetch.mockResolvedValue( undefined );
+
+		render( <NewsletterTestEmailModal isOpen onClose={ jest.fn() } /> );
+
+		await user.click( screen.getByRole( 'button', { name: /Send/ } ) );
+
+		expect( apiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( { data: { id: 123, email: 'author@example.com' } } )
+		);
+		await expect(
+			screen.findByText( 'Email sent successfully' )
+		).resolves.toBeInTheDocument();
+	} );
+
+	it( 'trims surrounding whitespace from the recipient before sending', async () => {
+		const user = userEvent.setup();
+		apiFetch.mockResolvedValue( undefined );
+
+		render( <NewsletterTestEmailModal isOpen onClose={ jest.fn() } /> );
+
+		const field = screen.getByRole( 'textbox' );
+		await user.clear( field );
+		await user.type( field, '  spaced@example.com  ' );
+		await user.click( screen.getByRole( 'button', { name: /Send/ } ) );
+
+		expect( apiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( { data: { id: 123, email: 'spaced@example.com' } } )
+		);
+	} );
+
+	it( 'sends an empty recipient when the field is cleared, letting the server fall back to self', async () => {
+		const user = userEvent.setup();
+		apiFetch.mockResolvedValue( undefined );
+
+		render( <NewsletterTestEmailModal isOpen onClose={ jest.fn() } /> );
+
+		await user.clear( screen.getByRole( 'textbox' ) );
+		await user.click( screen.getByRole( 'button', { name: /Send/ } ) );
+
+		expect( apiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( { data: { id: 123, email: '' } } )
+		);
+	} );
+
+	it( 'disables the recipient field while a send is in flight', async () => {
+		const user = userEvent.setup();
+		let resolveSend;
+		apiFetch.mockReturnValue(
+			new Promise( resolve => {
+				resolveSend = resolve;
+			} )
+		);
+
+		render( <NewsletterTestEmailModal isOpen onClose={ jest.fn() } /> );
+
+		const field = screen.getByRole( 'textbox' );
+		await user.click( screen.getByRole( 'button', { name: /Send/ } ) );
+
+		await waitFor( () => expect( field ).toBeDisabled() );
+
+		// Let the in-flight request settle so the final state update is flushed.
+		resolveSend();
+		await screen.findByText( 'Email sent successfully' );
 	} );
 
 	it( 'surfaces the guard message when a non-self recipient is rejected', async () => {

--- a/projects/plugins/jetpack/tests/php/bootstrap.php
+++ b/projects/plugins/jetpack/tests/php/bootstrap.php
@@ -257,6 +257,9 @@ require __DIR__ . '/attachment_testcase.php';
 // Load WPCOM-shared helper functions.
 require __DIR__ . '/lib/class-wpcom-features.php';
 
+// Mock of the wpcom-only Email_Verification class, needed by endpoints that call it.
+require __DIR__ . '/lib/class-email-verification.php';
+
 function in_running_uninstall_group() {
 	global  $argv;
 	return is_array( $argv ) && in_array( '--group=uninstall', $argv, true );

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Send_Email_Preview_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Send_Email_Preview_Test.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Tests for WPCOM_REST_API_V2_Endpoint_Send_Email_Preview.
+ * To run this test by itself use the following command:
+ * jetpack docker phpunit jetpack -- --filter=WPCOM_REST_API_V2_Endpoint_Send_Email_Preview_Test
+ *
+ * @phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
+ */
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use WpOrg\Requests\Requests;
+
+require_once dirname( __DIR__, 2 ) . '/lib/Jetpack_REST_TestCase.php';
+
+if ( ! class_exists( 'Email_Verification' ) ) {
+	class Email_Verification {
+		/**
+		 * Stand-in for the wpcom-only Email_Verification class so the endpoint body
+		 * can be exercised in the Jetpack test environment, where the real class
+		 * (a wpcom mu-plugin) is not loaded. Treats the caller as verified.
+		 *
+		 * @param int|false $user_id     Unused.
+		 * @param string    $legacy_type Unused.
+		 * @return bool
+		 */
+		public static function is_email_unverified( $user_id = false, $legacy_type = 'NEWKEY' ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			return false;
+		}
+	}
+}
+
+/**
+ * Class WPCOM_REST_API_V2_Endpoint_Send_Email_Preview_Test
+ *
+ * Only the recipient-resolution branches that return before the wpcom-only
+ * subscriber/mailer classes are reached can run here; the successful-send path
+ * requires the wpcom runtime and is exercised end-to-end on wpcom.
+ *
+ * @covers \WPCOM_REST_API_V2_Endpoint_Send_Email_Preview
+ */
+#[CoversClass( WPCOM_REST_API_V2_Endpoint_Send_Email_Preview::class )]
+class WPCOM_REST_API_V2_Endpoint_Send_Email_Preview_Test extends Jetpack_REST_TestCase {
+
+	/**
+	 * Editor user whose own email is the default recipient.
+	 *
+	 * @var int
+	 */
+	private static $user_id_editor = 0;
+
+	/**
+	 * Post to preview.
+	 *
+	 * @var int
+	 */
+	private static $post_id = 0;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		static::$user_id_editor = self::factory()->user->create(
+			array(
+				'role'       => 'editor',
+				'user_email' => 'author@example.com',
+			)
+		);
+
+		wp_set_current_user( static::$user_id_editor );
+
+		static::$post_id = self::factory()->post->create(
+			array(
+				'post_status' => 'published',
+				'post_author' => (string) static::$user_id_editor,
+			)
+		);
+	}
+
+	/**
+	 * Invoke the handler directly. Dispatching via the server would hit the proxy
+	 * callback, since the test environment is not is_wpcom_simple().
+	 *
+	 * @param array $params Request params.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	private function send( array $params ) {
+		$request = new WP_REST_Request( Requests::POST, '/wpcom/v2/send-email-preview' );
+		foreach ( $params as $key => $value ) {
+			$request->set_param( $key, $value );
+		}
+
+		$endpoint = new WPCOM_REST_API_V2_Endpoint_Send_Email_Preview();
+
+		return $endpoint->send_email_preview( $request );
+	}
+
+	/**
+	 * The optional email argument is registered on the route.
+	 */
+	public function test_email_arg_is_registered() {
+		$routes = $this->server->get_routes();
+
+		$this->assertArrayHasKey( '/wpcom/v2/send-email-preview', $routes );
+
+		$args = $routes['/wpcom/v2/send-email-preview'][0]['args'];
+		$this->assertArrayHasKey( 'email', $args );
+		$this->assertSame( 'string', $args['email']['type'] );
+	}
+
+	/**
+	 * A malformed recipient address is rejected with a 400 before any send.
+	 */
+	public function test_invalid_recipient_is_rejected() {
+		$result = $this->send(
+			array(
+				'id'    => static::$post_id,
+				'email' => 'not-an-email',
+			)
+		);
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertSame( 'invalid_email', $result->get_error_code() );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * A different (non-self) recipient is refused when the wpcom guard is not
+	 * available, rather than sending unguarded.
+	 */
+	public function test_non_self_recipient_without_guard_is_unavailable() {
+		$result = $this->send(
+			array(
+				'id'    => static::$post_id,
+				'email' => 'someone-else@example.com',
+			)
+		);
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertSame( 'send_email_preview_guard_unavailable', $result->get_error_code() );
+		$this->assertSame( 503, $result->get_error_data()['status'] );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Send_Email_Preview_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Send_Email_Preview_Test.php
@@ -4,30 +4,14 @@
  * To run this test by itself use the following command:
  * jetpack docker phpunit jetpack -- --filter=WPCOM_REST_API_V2_Endpoint_Send_Email_Preview_Test
  *
- * @phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
+ * The wpcom-only Email_Verification class the endpoint calls is mocked from the
+ * test bootstrap (tests/php/lib/class-email-verification.php).
  */
 
 use PHPUnit\Framework\Attributes\CoversClass;
 use WpOrg\Requests\Requests;
 
 require_once dirname( __DIR__, 2 ) . '/lib/Jetpack_REST_TestCase.php';
-
-if ( ! class_exists( 'Email_Verification' ) ) {
-	class Email_Verification {
-		/**
-		 * Stand-in for the wpcom-only Email_Verification class so the endpoint body
-		 * can be exercised in the Jetpack test environment, where the real class
-		 * (a wpcom mu-plugin) is not loaded. Treats the caller as verified.
-		 *
-		 * @param int|false $user_id     Unused.
-		 * @param string    $legacy_type Unused.
-		 * @return bool
-		 */
-		public static function is_email_unverified( $user_id = false, $legacy_type = 'NEWKEY' ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
-			return false;
-		}
-	}
-}
 
 /**
  * Class WPCOM_REST_API_V2_Endpoint_Send_Email_Preview_Test

--- a/projects/plugins/jetpack/tests/php/lib/class-email-verification.php
+++ b/projects/plugins/jetpack/tests/php/lib/class-email-verification.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Mock of the wpcom-only Email_Verification class.
+ *
+ * The real class is a wpcom mu-plugin, absent in the Jetpack test environment,
+ * so endpoints that call it (e.g. send-email-preview) would fatal without this.
+ * Excluded from Phan analysis in .phan/config.php — Phan has its own stub for
+ * the class and would otherwise report a redefinition.
+ *
+ * @package automattic/jetpack
+ */
+
+if ( ! class_exists( 'Email_Verification' ) ) {
+	/**
+	 * Minimal stand-in that treats the current user as verified.
+	 */
+	class Email_Verification {
+		/**
+		 * Whether the email is unverified. Always false in tests.
+		 *
+		 * @param int|false $user_id     Unused.
+		 * @param string    $legacy_type Unused.
+		 * @return bool
+		 */
+		public static function is_email_unverified( $user_id = false, $legacy_type = 'NEWKEY' ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed, VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+			return false;
+		}
+	}
+}


### PR DESCRIPTION
## Proposed changes
* Make the "Send a test email" recipient field editable instead of a preselected, locked address **for users who can manage subscribers only**.
* A caller-supplied address is only honored after it clears the same abuse gates as adding that person as a subscriber (capability, blog-level blocks, Bkismet, flood, rate limit); self-sends are unchanged. Invalid addresses return 400; guard rejections surface as 403/429 (503 if the guard is unavailable) and the modal shows the message inline.
* The recipient guard lives in wpcom and must deploy before this ships.

<img width="584" height="312" alt="Screenshot 2026-08-03 at 2 16 33 PM" src="https://github.com/user-attachments/assets/693a47a0-25ac-47d5-84cd-c04c2cd3c1a0" />


## Related product discussion/links
* NL-769

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Apply this change to the platform you're testing and to wpcom, where the endpoint lives.
* Open a post in the editor, open the Newsletter/Subscriptions "Send a test email" modal.
* Leave the field as your own address and Send — behaves as before.
* Change it to a different address and Send — the request includes the new address; delivery/gating is enforced on wpcom.
* Enter a malformed or invalid address and Send — an inline error appears.
