### PR TITLE
SEO: move toasts top-right and chip the title-structure preview parts

### DIFF
--- a/projects/packages/seo/_inc/admin-page-layout.scss
+++ b/projects/packages/seo/_inc/admin-page-layout.scss
@@ -116,3 +116,51 @@ body.toplevel_page_jetpack-seo {
 .jetpack-seo-page-content--flush {
 	padding: 0;
 }
+
+// Toasts: move the boot layer's snackbars to the top-right, matching the
+// rest of Jetpack.
+
+// Two systems place Jetpack toasts and they disagree. `@wordpress/boot` renders
+// one `<SnackbarNotices className="boot-notices__snackbar">` per wp-build page
+// and pins it bottom-center; `<GlobalNotices>` in
+// @automattic/jetpack-components pins top-right, which is what Newsletter,
+// My Jetpack and VideoPress show.
+// This page is wp-build, so it inherited the odd one out.
+
+// We restyle boot's list rather than rendering our own. Rendering a second
+// `SnackbarList` is what #49470 removed: the store is shared, so both lists
+// subscribe and every toast appears twice.
+
+// The values below intentionally mirror `global-notices/styles.module.scss` so
+// the two stay identical — small screens keep the full-width bottom strip
+// (nothing is pinned over the content on a narrow viewport), and the top offset
+// steps down at 782px where the wp-admin bar shrinks.
+
+// Specificity: boot injects its rule as a runtime `<style>` in `<head>` with
+// `.boot-layout .boot-notices__snackbar` (0,2,0). Load order between that and
+// our bundled CSS isn't guaranteed, so this leads with `body` to win outright
+// rather than relying on coming later.
+body .boot-layout .boot-notices__snackbar {
+	inset-block-start: auto;
+	inset-block-end: 0;
+	inset-inline: 0;
+
+	@media (min-width: 600px) {
+		inset-block-start: 4rem;
+		inset-block-end: auto;
+		inset-inline-start: auto;
+		inset-inline-end: 1rem;
+		inline-size: auto;
+
+		// Boot centers each snackbar in a full-width container (`margin-inline:
+		// auto`). The container is no longer full width, so that would now center
+		// them against the right edge instead of aligning them to it.
+		.components-snackbar {
+			margin-inline: 0;
+		}
+	}
+
+	@media (min-width: 782px) {
+		inset-block-start: 3rem;
+	}
+}

--- a/projects/packages/seo/_inc/admin-page-layout.scss
+++ b/projects/packages/seo/_inc/admin-page-layout.scss
@@ -136,31 +136,41 @@ body.toplevel_page_jetpack-seo {
 // (nothing is pinned over the content on a narrow viewport), and the top offset
 // steps down at 782px where the wp-admin bar shrinks.
 
-// Specificity: boot injects its rule as a runtime `<style>` in `<head>` with
-// `.boot-layout .boot-notices__snackbar` (0,2,0). Load order between that and
-// our bundled CSS isn't guaranteed, so this leads with `body` to win outright
-// rather than relying on coming later.
-body .boot-layout .boot-notices__snackbar {
-	inset-block-start: auto;
-	inset-block-end: 0;
-	inset-inline: 0;
+// Scoped to the SEO page's body class, like the layout rules at the top of this
+// file. Every other rule here is namespaced by a `jetpack-seo-*` class, but
+// this
+// one targets a class we don't own — so without the scope it would move
+// the snackbars on any other wp-build screen this stylesheet ever loaded on.
 
-	@media (min-width: 600px) {
-		inset-block-start: 4rem;
-		inset-block-end: auto;
-		inset-inline-start: auto;
-		inset-inline-end: 1rem;
-		inline-size: auto;
+// It also settles specificity. Boot injects its rule as a runtime `<style>` in
+// `<head>` at `.boot-layout .boot-notices__snackbar` (0,2,0); the body class
+// puts this at (0,3,1), so it wins outright rather than depending on load
+// order.
+body.jetpack_page_jetpack-seo,
+body.toplevel_page_jetpack-seo {
 
-		// Boot centers each snackbar in a full-width container (`margin-inline:
-		// auto`). The container is no longer full width, so that would now center
-		// them against the right edge instead of aligning them to it.
-		.components-snackbar {
-			margin-inline: 0;
+	.boot-layout .boot-notices__snackbar {
+		inset-block-start: auto;
+		inset-block-end: 0;
+		inset-inline: 0;
+
+		@media (min-width: 600px) {
+			inset-block-start: 4rem;
+			inset-block-end: auto;
+			inset-inline-start: auto;
+			inset-inline-end: 1rem;
+			inline-size: auto;
+
+			// Boot centers each snackbar in a full-width container
+			// (`margin-inline: auto`). The container is no longer full width, so
+			// that would now center them against the right edge, not align to it.
+			.components-snackbar {
+				margin-inline: 0;
+			}
 		}
-	}
 
-	@media (min-width: 782px) {
-		inset-block-start: 3rem;
+		@media (min-width: 782px) {
+			inset-block-start: 3rem;
+		}
 	}
 }

--- a/projects/packages/seo/_inc/admin-page-layout.scss
+++ b/projects/packages/seo/_inc/admin-page-layout.scss
@@ -136,16 +136,14 @@ body.toplevel_page_jetpack-seo {
 // (nothing is pinned over the content on a narrow viewport), and the top offset
 // steps down at 782px where the wp-admin bar shrinks.
 
-// Scoped to the SEO page's body class, like the layout rules at the top of this
-// file. Every other rule here is namespaced by a `jetpack-seo-*` class, but
-// this
-// one targets a class we don't own — so without the scope it would move
-// the snackbars on any other wp-build screen this stylesheet ever loaded on.
+// Scoped to the SEO page's body class, like the layout rules at the top of
+// this file. Every other rule here is namespaced by a `jetpack-seo-*` class,
+// but this one targets a class we don't own — so without the scope it would
+// move the snackbars on any other wp-build screen this stylesheet loaded on.
 
-// It also settles specificity. Boot injects its rule as a runtime `<style>` in
-// `<head>` at `.boot-layout .boot-notices__snackbar` (0,2,0); the body class
-// puts this at (0,3,1), so it wins outright rather than depending on load
-// order.
+// It also settles specificity. Boot injects its rule at runtime as
+// `.boot-layout .boot-notices__snackbar` (0,2,0); the body class puts this at
+// (0,3,1), so it wins outright rather than depending on load order.
 body.jetpack_page_jetpack-seo,
 body.toplevel_page_jetpack-seo {
 

--- a/projects/packages/seo/_inc/data/test/title-format-tokens.test.ts
+++ b/projects/packages/seo/_inc/data/test/title-format-tokens.test.ts
@@ -6,7 +6,9 @@ import {
 	PAGE_TYPE_SUGGESTIONS,
 	PAGE_TYPE_TOKENS,
 	buildDefaultPreview,
+	buildDefaultPreviewParts,
 	buildPreview,
+	buildPreviewParts,
 	fromDisplay,
 	stringToTokens,
 	toDisplay,
@@ -271,5 +273,63 @@ describe( 'stringToTokens', () => {
 			{ type: 'token', value: 'site_name' },
 		];
 		expect( stringToTokens( tokensToString( tokens ), PAGE_TYPE_TOKENS.posts ) ).toEqual( tokens );
+	} );
+} );
+
+describe( 'preview parts', () => {
+	it( 'labels resolved values and typed separators differently', () => {
+		expect(
+			buildPreviewParts(
+				[
+					{ type: 'token', value: 'site_name' },
+					{ type: 'string', value: ' | ' },
+					{ type: 'token', value: 'tagline' },
+				],
+				{ site_name: 'Acme Co', tagline: 'We make things' }
+			)
+		).toEqual( [
+			{ kind: 'value', text: 'Acme Co' },
+			{ kind: 'literal', text: ' | ' },
+			{ kind: 'value', text: 'We make things' },
+		] );
+	} );
+
+	it( 'keeps an empty value as a part, so its separators still show', () => {
+		// The real title concatenates straight through, leaving the separator
+		// dangling. Dropping the part here would make the preview tidier than the
+		// output — the exact dishonesty this preview exists to avoid.
+		expect(
+			buildPreviewParts(
+				[
+					{ type: 'token', value: 'site_name' },
+					{ type: 'string', value: ' - ' },
+					{ type: 'token', value: 'tagline' },
+				],
+				{ site_name: 'Acme Co', tagline: '' }
+			)
+		).toEqual( [
+			{ kind: 'value', text: 'Acme Co' },
+			{ kind: 'literal', text: ' - ' },
+			{ kind: 'value', text: '' },
+		] );
+	} );
+
+	it( 'puts default-title separators between values only', () => {
+		// A site with no tagline keeps just its name, and must not trail a separator
+		// core would never emit.
+		expect(
+			buildDefaultPreviewParts( 'front_page', '-', { site_name: 'Acme Co', tagline: '' } )
+		).toEqual( [ { kind: 'value', text: 'Acme Co' } ] );
+
+		expect(
+			buildDefaultPreviewParts( 'front_page', '-', {
+				site_name: 'Acme Co',
+				tagline: 'We make things',
+			} )
+		).toEqual( [
+			{ kind: 'value', text: 'Acme Co' },
+			{ kind: 'literal', text: ' - ' },
+			{ kind: 'value', text: 'We make things' },
+		] );
 	} );
 } );

--- a/projects/packages/seo/_inc/data/title-format-tokens.ts
+++ b/projects/packages/seo/_inc/data/title-format-tokens.ts
@@ -151,18 +151,62 @@ export const fromDisplay = ( display: string, allowedTokenIds?: string[] ): Titl
 export const buildPreview = (
 	tokens: TitleFormatToken[],
 	overrides: Partial< Record< string, string > > = {}
-): string =>
-	tokens
-		.map( token => {
-			if ( token.type === 'string' ) {
-				return token.value;
-			}
-			if ( token.value in overrides ) {
-				return overrides[ token.value ] ?? '';
-			}
-			return TOKEN_PREVIEW_SAMPLES[ token.value ] || token.value;
-		} )
-		.join( '' );
+): string => partsToString( buildPreviewParts( tokens, overrides ) );
+
+/**
+ * One piece of a rendered preview.
+ *
+ * `value` is what a placeholder resolved to — the part of the title that came
+ * from the site. `literal` is text the format carries verbatim, which is to say
+ * the separators the admin typed between placeholders.
+ *
+ * The split exists so the preview can *show* that structure (values as chips,
+ * separators as the plain text they are) without changing what it claims: the
+ * concatenation of every part is byte-for-byte the title that gets emitted.
+ */
+export type PreviewPart = {
+	kind: 'value' | 'literal';
+	text: string;
+};
+
+/**
+ * Concatenate preview parts back into the title they represent.
+ *
+ * @param parts - The ordered preview parts.
+ * @return The title the parts spell out.
+ */
+const partsToString = ( parts: PreviewPart[] ): string => parts.map( part => part.text ).join( '' );
+
+/**
+ * Render an ordered token list into preview parts. Same resolution rules as
+ * {@link buildPreview} — which is implemented on top of this, so the string and
+ * the rendered form can never disagree.
+ *
+ * A placeholder that resolves to nothing is kept as an empty `value` part rather
+ * than dropped, so callers can reproduce the dangling separators the real title
+ * would have. Rendering can skip empty parts; the string form must not.
+ *
+ * @param tokens    - The ordered token list.
+ * @param overrides - Real values keyed by token id. A key that is present but empty
+ *                  renders as empty; a key that is absent falls back to sample text.
+ * @return The ordered preview parts.
+ */
+export const buildPreviewParts = (
+	tokens: TitleFormatToken[],
+	overrides: Partial< Record< string, string > > = {}
+): PreviewPart[] =>
+	tokens.map( token => {
+		if ( token.type === 'string' ) {
+			return { kind: 'literal' as const, text: token.value };
+		}
+		if ( token.value in overrides ) {
+			return { kind: 'value' as const, text: overrides[ token.value ] ?? '' };
+		}
+		return {
+			kind: 'value' as const,
+			text: TOKEN_PREVIEW_SAMPLES[ token.value ] || token.value,
+		};
+	} );
 
 // The token pair WordPress joins to build each page type's default title, in
 // order. A page type with no stored format keeps that default —
@@ -203,23 +247,51 @@ export const buildDefaultPreview = (
 	pageTypeId: string,
 	separator: string,
 	overrides: Partial< Record< string, string > > = {}
-): string => {
-	const parts = DEFAULT_TITLE_PARTS[ pageTypeId ];
-	if ( ! parts ) {
-		return '';
+): string => partsToString( buildDefaultPreviewParts( pageTypeId, separator, overrides ) );
+
+/**
+ * The default-title preview as parts, so a defaulted row renders with the same
+ * treatment as a customized one. {@link buildDefaultPreview} is implemented on
+ * top of this.
+ *
+ * The separator lands as a `literal` part between the values — which is exactly
+ * what it is here: core joins the parts with it, and the admin never typed it.
+ *
+ * @param pageTypeId - The page type (`posts`, `pages`, …).
+ * @param separator  - The site's document-title separator.
+ * @param overrides  - Real values keyed by token id, as for `buildPreviewParts`.
+ * @return The ordered preview parts, empty for an unknown page type.
+ */
+export const buildDefaultPreviewParts = (
+	pageTypeId: string,
+	separator: string,
+	overrides: Partial< Record< string, string > > = {}
+): PreviewPart[] => {
+	const tokens = DEFAULT_TITLE_PARTS[ pageTypeId ];
+	if ( ! tokens ) {
+		return [];
 	}
-	return (
-		parts
-			// Unlike `buildPreview`, a supplied-but-empty override means the part is
-			// genuinely absent, not unknown — so it is dropped rather than replaced with
-			// sample text. This preview claims to be the title WordPress produces, and a
-			// site with no tagline really does get just its name; showing "Your tagline"
-			// there would promise something the site doesn't have. Core does the same,
-			// running `array_filter()` over the parts before joining. Sample text still
-			// stands in for tokens with no override at all, such as the post title.
-			.map( token => ( token in overrides ? overrides[ token ] : TOKEN_PREVIEW_SAMPLES[ token ] ) )
-			.filter( Boolean )
-			.join( ` ${ separator } ` )
+
+	const values = tokens
+		// Unlike `buildPreviewParts`, a supplied-but-empty override means the part is
+		// genuinely absent, not unknown — so it is dropped rather than replaced with
+		// sample text. This preview claims to be the title WordPress produces, and a
+		// site with no tagline really does get just its name; showing "Your tagline"
+		// there would promise something the site doesn't have. Core does the same,
+		// running `array_filter()` over the parts before joining. Sample text still
+		// stands in for tokens with no override at all, such as the post title.
+		.map( token => ( token in overrides ? overrides[ token ] : TOKEN_PREVIEW_SAMPLES[ token ] ) )
+		.filter( Boolean ) as string[];
+
+	// Separators go *between* values only, so a single surviving part (a site with
+	// no tagline, say) doesn't render a trailing separator core wouldn't emit.
+	return values.flatMap( ( text, index ) =>
+		index === 0
+			? [ { kind: 'value' as const, text } ]
+			: [
+					{ kind: 'literal' as const, text: ` ${ separator } ` },
+					{ kind: 'value' as const, text },
+			  ]
 	);
 };
 

--- a/projects/packages/seo/_inc/screens/settings/test/title-structure-field.test.tsx
+++ b/projects/packages/seo/_inc/screens/settings/test/title-structure-field.test.tsx
@@ -15,6 +15,20 @@ jest.unstable_mockModule( '../../../data/get-site', () => ( {
 	default: () => site,
 } ) );
 
+// Real class names for the preview parts. Without this jest resolves every key to
+// `undefined`, and an assertion that a span "has" that class passes vacuously —
+// which is exactly the bug this test exists to catch (see #50619).
+jest.unstable_mockModule( '../title-structure-field.module.scss', () => ( {
+	default: {
+		previewValue: 'preview-value',
+		previewSeparator: 'preview-separator',
+		row: 'row',
+		muted: 'muted',
+		preview: 'preview',
+		save: 'save',
+	},
+} ) );
+
 const { default: TitleStructureField } = await import( '../title-structure-field' );
 
 const SITE: SiteData = {
@@ -52,6 +66,23 @@ const expand = () =>
 	// eslint-disable-next-line testing-library/prefer-user-event -- single click; fireEvent avoids the user-event devDep (lockfile churn).
 	fireEvent.click( screen.getByRole( 'button', { name: /Title structure/ } ) );
 
+/**
+ * The rendered preview for every page-type row, as plain strings.
+ *
+ * Previews render as chips and separators rather than one text node, so no
+ * `getByText` can match a whole title. Reading each row's `textContent` back is
+ * the stronger assertion anyway: it proves the parts *concatenate* to exactly
+ * the title that would be emitted, which is the whole promise of the preview.
+ * The "Preview:" label is stripped; surrounding whitespace is left alone so the
+ * separator spacing stays assertable.
+ *
+ * @return One string per rendered row.
+ */
+const previews = (): string[] =>
+	screen
+		.getAllByText( 'Preview:' )
+		.map( label => ( label.parentElement?.textContent ?? '' ).replace( /^Preview:/, '' ) );
+
 describe( 'TitleStructureField', () => {
 	beforeEach( () => {
 		site = SITE;
@@ -82,8 +113,8 @@ describe( 'TitleStructureField', () => {
 			// Core pairs the page-specific title with the site title everywhere but
 			// the front page, where it pairs the site title with the tagline. Each
 			// preview is unique, so no per-row scoping is needed.
-			expect( screen.getByText( /Hello World - Acme Co/ ) ).toBeInTheDocument();
-			expect( screen.getByText( /Acme Co - We make things/ ) ).toBeInTheDocument();
+			expect( previews() ).toContainEqual( expect.stringMatching( /Hello World - Acme Co/ ) );
+			expect( previews() ).toContainEqual( expect.stringMatching( /Acme Co - We make things/ ) );
 		} );
 
 		it( 'marks an untouched field as using the default', () => {
@@ -95,6 +126,49 @@ describe( 'TitleStructureField', () => {
 			);
 		} );
 
+		// The preview is split into elements so the title's structure is legible:
+		// values chipped, separators left as plain text. What matters is that the
+		// split is faithful — concatenating the pieces has to give the exact title,
+		// with the admin's own spacing intact.
+		it( 'splits the preview into values and separators without altering the title', () => {
+			renderField( {
+				posts: [
+					{ type: 'token', value: 'post_title' },
+					{ type: 'string', value: ' | ' },
+					{ type: 'token', value: 'site_name' },
+				],
+			} );
+			expand();
+
+			// Every page type renders a row, so pick the one under test by its content
+			// rather than by position — the row order is not this test's subject.
+			const row = screen
+				.getAllByText( 'Preview:' )
+				// eslint-disable-next-line testing-library/no-node-access -- asserting the DOM split is this test's subject; no TL query exposes sibling structure.
+				.map( label => label.parentElement! )
+				.find( node => node.textContent?.includes( 'Hello World' ) )!;
+			// eslint-disable-next-line testing-library/no-node-access -- see above.
+			const parts = Array.from( row.querySelectorAll( 'span' ) ).map( node => node.textContent );
+
+			// Three pieces, in order, with the separator kept as its own part and its
+			// surrounding spaces intact in the DOM. (The `white-space: pre` that stops
+			// the browser collapsing those spaces on screen is a stylesheet concern —
+			// jsdom applies no CSS, so it can't be asserted here.)
+			expect( parts ).toEqual( [ 'Hello World', ' | ', 'Acme Co' ] );
+			expect( parts.join( '' ) ).toBe( 'Hello World | Acme Co' );
+
+			// And the two kinds are distinguishable, which the text alone doesn't show:
+			// values are chipped, the separator is not. Without this, rendering every
+			// part identically would still satisfy the assertions above.
+			// eslint-disable-next-line testing-library/no-node-access -- see above.
+			const spans = Array.from( row.querySelectorAll( 'span' ) );
+			expect( spans.map( node => node.className ) ).toEqual( [
+				'preview-value',
+				'preview-separator',
+				'preview-value',
+			] );
+		} );
+
 		it( 'previews a stored format from its tokens', () => {
 			renderField( {
 				posts: [
@@ -104,7 +178,7 @@ describe( 'TitleStructureField', () => {
 				],
 			} );
 			expand();
-			expect( screen.getByText( /Hello World \| Acme Co/ ) ).toBeInTheDocument();
+			expect( previews() ).toContainEqual( expect.stringMatching( /Hello World \| Acme Co/ ) );
 		} );
 	} );
 
@@ -120,7 +194,7 @@ describe( 'TitleStructureField', () => {
 			expand();
 			// The front page pairs site title + tagline; with no tagline core drops
 			// that part rather than leaving a dangling separator.
-			expect( screen.getByText( /^\s*Acme Co\s*$/ ) ).toBeInTheDocument();
+			expect( previews() ).toContainEqual( expect.stringMatching( /^\s*Acme Co\s*$/ ) );
 			expect( screen.queryByText( /Your tagline/ ) ).not.toBeInTheDocument();
 		} );
 
@@ -133,7 +207,7 @@ describe( 'TitleStructureField', () => {
 				],
 			} );
 			expand();
-			expect( screen.getByText( /^\s*Acme Co -\s*$/ ) ).toBeInTheDocument();
+			expect( previews() ).toContainEqual( expect.stringMatching( /^\s*Acme Co -\s*$/ ) );
 			expect( screen.queryByText( /Your tagline/ ) ).not.toBeInTheDocument();
 		} );
 
@@ -154,6 +228,6 @@ describe( 'TitleStructureField', () => {
 		site = null;
 		renderField();
 		expand();
-		expect( screen.getByText( /Hello World - Your site/ ) ).toBeInTheDocument();
+		expect( previews() ).toContainEqual( expect.stringMatching( /Hello World - Your site/ ) );
 	} );
 } );

--- a/projects/packages/seo/_inc/screens/settings/title-structure-field.module.scss
+++ b/projects/packages/seo/_inc/screens/settings/title-structure-field.module.scss
@@ -22,6 +22,40 @@
 	overflow-wrap: anywhere;
 }
 
+// A resolved part of the title — what a placeholder evaluated to. Chipped so
+// the structure of the title reads at a glance; without it the preview is a
+// run of words and you have to work out where the site name ends and the
+// tagline begins.
+
+// Deliberately quieter than the insert buttons above it: those are controls,
+// this is a readout, and matching them would invite clicking. No border for
+// the same reason — the tint alone separates it from the card.
+.previewValue {
+	// `inline`, not `inline-block`, so a long title still wraps mid-chip rather
+	// than pushing an unbreakable box past the column and forcing a scrollbar.
+	// Box decorations then clone onto each line so both halves keep the tint.
+	display: inline;
+	padding-block: 1px;
+	padding-inline: var(--wpds-dimension-gap-xs);
+	border-radius: var(--wpds-border-radius-sm);
+	background: var(--wpds-color-background-surface-neutral-weak);
+	box-decoration-break: clone;
+	-webkit-box-decoration-break: clone;
+}
+
+// The separator between parts: literal text the admin typed, or for a
+// defaulted row the site's own document-title separator. Muted because it is
+// punctuation rather than content.
+
+// `white-space: pre` is load-bearing, not cosmetic. Separators routinely carry
+// leading and trailing spaces (" | "), which HTML would collapse against the
+// chips — so the preview would show tighter spacing than the emitted title
+// actually has. Preserving it keeps the preview honest about its own spacing.
+.previewSeparator {
+	white-space: pre;
+	color: var(--wpds-color-foreground-content-neutral-weak);
+}
+
 .save {
 	flex-shrink: 0;
 	// Keep Save at the right edge even when there's no preview yet.

--- a/projects/packages/seo/_inc/screens/settings/title-structure-field.tsx
+++ b/projects/packages/seo/_inc/screens/settings/title-structure-field.tsx
@@ -15,8 +15,8 @@ import {
 	PAGE_TYPE_SUGGESTIONS,
 	PAGE_TYPE_TOKENS,
 	TOKEN_LABELS,
-	buildDefaultPreview,
-	buildPreview,
+	buildDefaultPreviewParts,
+	buildPreviewParts,
 	stringToTokens,
 	tokensToString,
 } from '../../data/title-format-tokens';
@@ -86,12 +86,18 @@ const TitleStructureRow: FC< RowProps > = ( {
 	const allowed = PAGE_TYPE_TOKENS[ pageTypeId ];
 	// An untouched page type still has a title — WordPress composes it — so preview
 	// that instead of leaving the row blank under the module's "Complete" status.
-	const preview = useMemo(
+	const previewParts = useMemo(
 		() =>
 			tokens.length > 0
-				? buildPreview( tokens, previewOverrides )
-				: buildDefaultPreview( pageTypeId, titleSeparator, previewOverrides ),
+				? buildPreviewParts( tokens, previewOverrides )
+				: buildDefaultPreviewParts( pageTypeId, titleSeparator, previewOverrides ),
 		[ tokens, previewOverrides, pageTypeId, titleSeparator ]
+	);
+	// The parts concatenated — the literal title this format produces. Only used to
+	// decide whether there is anything to show; the row renders the parts.
+	const preview = useMemo(
+		() => previewParts.map( part => part.text ).join( '' ),
+		[ previewParts ]
 	);
 
 	const setFromString = useCallback(
@@ -159,7 +165,30 @@ const TitleStructureRow: FC< RowProps > = ( {
 				     result is the honest one, and hiding it would undo the point. */ }
 				{ ( tokens.length > 0 || preview ) && (
 					<Text variant="body-md" className={ styles.preview }>
-						<strong>{ previewLabel }:</strong> { preview }
+						<strong>{ previewLabel }:</strong>{ ' ' }
+						{ /* Values render as chips and separators as the plain text they are, so
+						     the shape of the title is legible at a glance — a run of words is
+						     hard to read as "site name, then a divider, then a tagline".
+						     Concatenating what's rendered still gives the exact emitted title:
+						     nothing is inserted between the parts, and the separators keep the
+						     admin's own spacing (see `.previewSeparator`). Empty values are
+						     skipped so a placeholder that resolves to nothing leaves no stray
+						     chip — the separators around it still show, which is what the real
+						     title does. */ }
+						{ previewParts.map( ( part, index ) =>
+							part.text === '' ? null : (
+								<span
+									// Parts are positional and can repeat ("Acme | Acme"), so the
+									// index is the only stable identity available here.
+									key={ index }
+									className={
+										part.kind === 'value' ? styles.previewValue : styles.previewSeparator
+									}
+								>
+									{ part.text }
+								</span>
+							)
+						) }
 					</Text>
 				) }
 				<Button className={ styles.save } onClick={ onSave } disabled={ disabled || ! canSave }>

--- a/projects/packages/seo/changelog/add-seo-toast-placement-and-title-preview-pills
+++ b/projects/packages/seo/changelog/add-seo-toast-placement-and-title-preview-pills
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-SEO: show save toasts in the top-right, matching the rest of Jetpack, and render the title-structure preview with its parts as chips so the shape of the title is legible.
+Show save toasts in the top-right, matching the rest of Jetpack, and render the title-structure preview with its parts as chips so the shape of the title is legible.

--- a/projects/packages/seo/changelog/add-seo-toast-placement-and-title-preview-pills
+++ b/projects/packages/seo/changelog/add-seo-toast-placement-and-title-preview-pills
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+SEO: show save toasts in the top-right, matching the rest of Jetpack, and render the title-structure preview with its parts as chips so the shape of the title is legible.


### PR DESCRIPTION
Fixes JETPACK-1822, JETPACK-1819

Two small polish items from Devin Walker's Jetpack SEO V1 review. Unrelated to each other, but both a few lines and both on the SEO dashboard, so they share a PR. Behind `rsm_jetpack_seo`.

## Proposed changes

* **Toasts now appear top-right, matching the rest of Jetpack** (JETPACK-1822). Two systems place Jetpack toasts and they disagree: `@wordpress/boot` renders one `<SnackbarNotices className="boot-notices__snackbar">` on every wp-build page and pins it **bottom-centre**, while `<GlobalNotices>` from `@automattic/jetpack-components` pins **top-right** — which is what Newsletter, My Jetpack and VideoPress show. The SEO page is wp-build, so it was the odd one out. This restyles boot's list to match, mirroring the values in `global-notices/styles.module.scss` so the two can't drift: full-width bottom strip below 600px, top-right above it, with the top offset stepping down at 782px where the admin bar shrinks.
* **The title-structure preview now shows its parts as chips** (JETPACK-1819). Values render as chips and separators as the plain text they are, so the shape of a title is legible instead of a run of words. `buildPreviewParts()` / `buildDefaultPreviewParts()` return the structured parts; the existing string builders are re-implemented on top of them, so the rendered form and the string can't disagree.

### Two things worth a reviewer's attention

**Why boot's list is restyled rather than replaced.** Rendering our own `<SnackbarList>` is exactly what #49470 removed: the notices store is shared, so both lists subscribe and every toast appears twice (and ours floated over the tab nav). The override leads with `body` for specificity — boot injects its rule as a runtime `<style>` in `<head>`, so load order against our bundled CSS isn't guaranteed and matching on specificity is more reliable than assuming we come later.

**No pipe is injected into the preview, deliberately.** The issue asks for "a pipe with spacing between elements", but the preview mirrors the emitted title exactly — separators are literal text the admin typed, and `Jetpack_SEO_Titles::get_custom_title()` concatenates the format straight through. Inserting a separator would show a title the site doesn't actually produce. Chipping the parts gets the readability win honestly, and separators keep the admin's own spacing (`white-space: pre`, so the browser doesn't collapse `" | "` against the chips and understate the real spacing). Untouched page types already preview using the site's real document-title separator, which is where the spacing in the original request was presumably coming from.

## Related product discussion/links

* https://linear.app/a8c/issue/JETPACK-1822/standardize-toast-notification-placement
* https://linear.app/a8c/issue/JETPACK-1819/polish-title-preview-styling-pipe-spacing-pill-style-tags

## Does this pull request change what data or activity we track or use?

No. Presentation only — no new settings, no stored values, no events.

## Testing instructions

Both changes are behind `rsm_jetpack_seo`, on **Jetpack → SEO**.

**Toast placement (JETPACK-1822)**

* Go to **Jetpack → SEO → Settings**, change any setting and hit Save.
* The "Saving…" → "Settings saved." toast should appear in the **top-right**, below the admin bar — not bottom-centre.
* Compare against **Jetpack → Newsletter** (or My Jetpack): the placement should now match.
* Narrow the window below 600px and save again — the toast should become a full-width strip pinned to the bottom, which is what `GlobalNotices` does on small screens too.
* Confirm only **one** toast appears. A second snackbar list would mean the boot layer and a package-level list are both rendering (the bug #49470 fixed).

**Title preview (JETPACK-1819)**

* On **Settings → Title structure**, expand the module.
* Each row's Preview should render the resolved values as chips with the separators as plain text between them.
* Type a format with a tight separator, e.g. `[Post title]|[Site name]` — the preview should show no spaces around the pipe, because the emitted title has none.
* Now use `[Post title] | [Site name]` — the spaces should be preserved and visible.
* An untouched page type should still preview the default title, using the site's own separator.
* On a site with no tagline, the front page's default preview should show just the site name (core drops the empty part), while a *custom* format keeps its dangling separator (Jetpack concatenates straight through).

**What I tested:** verified on a Jurassic Ninja site with the Beta build of this PR — toast placement confirmed top-right on desktop and as a full-width bottom strip under 600px, only one toast rendering, and the title preview showing chipped parts with the typed separator spacing preserved.

Locally: 274 JS tests pass (up from 270 — 4 added), plus typecheck, ESLint, Prettier and Stylelint. The new tests are mutation-verified — rendering every part with the same class, trimming the separator text, and emitting a separator before the first value each fail the suite.

**Where to focus a review.** The toast fix restyles `@wordpress/boot`'s own `boot-notices__snackbar` class, so it is coupled to a class name outside this repo. If boot renames it or changes its layout approach, the override silently stops applying and toasts revert to bottom-centre — and no test can catch that, since jsdom applies no CSS. That coupling is deliberate (rendering our own list is what #49470 removed, because both lists subscribe to the same store and every toast doubles), but it is the part most worth a second opinion.

**Not covered:** a preview long enough to wrap across lines wasn't exercised visually. The chips are `display: inline` with `padding-block`, which doesn't grow the line box — but the arithmetic rules out a collision: `body-md` is 13px on a 20px line height, so each line carries 3.5px of half-leading and the chip's 1px extension sits well inside it.

## Screenshots

<!-- Before -->

<!-- After -->


