### PR TITLE
Newsletter: Remove duplicate text from newsletter settings

### DIFF
--- a/projects/packages/newsletter/changelog/remove-duplicate-text-from-subscribe-modal-heading-card
+++ b/projects/packages/newsletter/changelog/remove-duplicate-text-from-subscribe-modal-heading-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Subscribe modal heading: remove the duplicated "Button only" note from the card description.

--- a/projects/packages/newsletter/src/settings/sections/subscribe-modal-section.tsx
+++ b/projects/packages/newsletter/src/settings/sections/subscribe-modal-section.tsx
@@ -125,7 +125,7 @@ export function SubscribeModalSection( {
 				<p>
 					<Text>
 						{ __(
-							'Shown at the top of the subscribe popup that appears when a visitor clicks a Subscribe block. Only applies to blocks using the "Button only" style.',
+							'Shown at the top of the subscribe popup that appears when a visitor clicks a Subscribe block.',
 							'jetpack-newsletter'
 						) }
 					</Text>


### PR DESCRIPTION
Closes: https://linear.app/a8c/issue/NL-784

## Proposed changes

In Newsetter Settings, a “Subscribe modal heading” card is displaying the same text in the field description and help text. We removed the duplication.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

No.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Checkout this PR on sandbox.
* Sandbox the site you want to test.
* Go to Jetpack > Newsletter > Settings > Subscribe modal heading
* Verify the text duplication is fixed now.
