### PR TITLE
Forms: add background image support to the Form and Step blocks

### DIFF
--- a/projects/packages/forms/changelog/add-forms-background-image
+++ b/projects/packages/forms/changelog/add-forms-background-image
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Form: add background image support to the Form and Step blocks.
+Form: Add background image support to the Form and Step blocks.

--- a/projects/packages/forms/changelog/add-forms-background-image
+++ b/projects/packages/forms/changelog/add-forms-background-image
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Form: add background image support to the Form and Step blocks.

--- a/projects/packages/forms/changelog/add-forms-background-image
+++ b/projects/packages/forms/changelog/add-forms-background-image
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Form: Add background image support to the Form and Step blocks.
+Contact Form: Add background image support to the Form and Step blocks.

--- a/projects/packages/forms/changelog/fix-forms-step-padding-overflow
+++ b/projects/packages/forms/changelog/fix-forms-step-padding-overflow
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Form: keep a step's padding inside its width so its content no longer overflows the step.
+Form: Keep a step's padding inside its width so its content no longer overflows the step.

--- a/projects/packages/forms/changelog/fix-forms-step-padding-overflow
+++ b/projects/packages/forms/changelog/fix-forms-step-padding-overflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Form: keep a step's padding inside its width so its content no longer overflows the step.

--- a/projects/packages/forms/changelog/fix-forms-step-padding-overflow
+++ b/projects/packages/forms/changelog/fix-forms-step-padding-overflow
@@ -1,4 +1,4 @@
-Significance: patch
+Significance: minor
 Type: fixed
 
-Form: Keep a step's padding inside its width so its content no longer overflows the step.
+Multistep forms: Keep a step's padding inside its width. Published forms whose steps have padding will change appearance: the step now matches the width of the form, with its fields inset by the padding, instead of overflowing past the form's right edge.

--- a/projects/packages/forms/src/blocks/contact-form/block.json
+++ b/projects/packages/forms/src/blocks/contact-form/block.json
@@ -14,6 +14,13 @@
 			"link": true,
 			"gradients": true
 		},
+		"background": {
+			"backgroundImage": true,
+			"backgroundSize": true,
+			"__experimentalDefaultControls": {
+				"backgroundImage": true
+			}
+		},
 		"html": false,
 		"spacing": {
 			"padding": true,

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -45,6 +45,18 @@ class Contact_Form_Block {
 				'render_email_callback' => array( __CLASS__, 'render_email' ),
 				'render_callback'       => array( __CLASS__, 'gutenblock_render_form' ),
 				'supports'              => array(
+					/*
+					 * Background image styles are applied server-side by core's
+					 * `wp_render_background_support()` render_block filter, so the support has to
+					 * be declared here as well as in block.json for the front end to pick it up.
+					 */
+					'background'           => array(
+						'backgroundImage'               => true,
+						'backgroundSize'                => true,
+						'__experimentalDefaultControls' => array(
+							'backgroundImage' => true,
+						),
+					),
 					'layout'               => array(
 						'default'                => array(
 							'type'              => 'flex',
@@ -662,6 +674,17 @@ class Contact_Form_Block {
 			'jetpack/form-step',
 			array(
 				'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_form_step' ),
+				// Mirrors the supports declared in the block's index.js, so that core can apply the
+				// background image styles to the rendered step on the front end.
+				'supports'        => array(
+					'background' => array(
+						'backgroundImage'               => true,
+						'backgroundSize'                => true,
+						'__experimentalDefaultControls' => array(
+							'backgroundImage' => true,
+						),
+					),
+				),
 			)
 		);
 

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -45,12 +45,6 @@ class Contact_Form_Block {
 				'render_email_callback' => array( __CLASS__, 'render_email' ),
 				'render_callback'       => array( __CLASS__, 'gutenblock_render_form' ),
 				'supports'              => array(
-
-					/*
-					 * Declared here as well as in block.json because the front end styles come from
-					 * PHP. Serialization is skipped because core targets the first tag of the
-					 * rendered output — see self::apply_background_support().
-					 */
 					'background'           => array(
 						'backgroundImage'                 => true,
 						'backgroundSize'                  => true,
@@ -676,9 +670,6 @@ class Contact_Form_Block {
 			'jetpack/form-step',
 			array(
 				'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_form_step' ),
-				// Mirrors the supports declared in the block's index.js, so the front end gets the
-				// background image too. Serialization is skipped because core targets the first tag
-				// of the rendered output — see Contact_Form_Block::apply_background_support().
 				'supports'        => array(
 					'background' => array(
 						'backgroundImage'                 => true,
@@ -987,34 +978,20 @@ class Contact_Form_Block {
 		if ( isset( $atts['ref'] ) ) {
 			$ref_id = absint( $atts['ref'] );
 			if ( $ref_id > 0 ) {
-				// A synced form has no markup of its own, so the outer wrapper of the rendered
-				// form is the only element the ref block's background can go on.
 				return self::apply_background_support( Contact_Form::render_synced_form( $ref_id ), $atts );
 			} else {
 				return ''; // Invalid ref ID.
 			}
 		}
 
-		// The block's own div opens $content, and is what carries the color, padding and radius
-		// supports, so the background image belongs there rather than on Contact_Form::parse()'s
-		// outer container.
 		return Contact_Form::parse( $atts, self::apply_background_support( do_blocks( $content ), $atts ) );
 	}
 
 	/**
 	 * Apply a block's background image styles to the first tag of the given HTML.
 	 *
-	 * Core's `wp_render_background_support()` puts these styles on the first tag of a block's
-	 * rendered output. For both form blocks that tag is a wrapper added at render time — the
-	 * interactivity wrapper for a step, the container div for a form — and not the block's own
-	 * element, which is where the color, padding and border radius supports end up. Leaving the
-	 * two apart means an opaque background color paints over the image on the front end while
-	 * the editor shows both on one element. Serialization is therefore skipped in the block
-	 * registration and the styles are applied here instead, against the same element that
-	 * carries the rest of the block's styles.
-	 *
-	 * @param string $html       Rendered HTML whose first tag should carry the background.
-	 * @param array  $atts       Block attributes.
+	 * @param string $html Rendered HTML whose first tag should carry the background.
+	 * @param array  $atts Block attributes.
 	 *
 	 * @return string The HTML, with background styles applied when the block has an image.
 	 */
@@ -1025,7 +1002,6 @@ class Contact_Form_Block {
 			return $html;
 		}
 
-		// Mirrors the defaults in core's wp_render_background_support().
 		$background_styles = array(
 			'backgroundImage'      => $background['backgroundImage'],
 			'backgroundSize'       => $background['backgroundSize'] ?? 'cover',

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -45,15 +45,17 @@ class Contact_Form_Block {
 				'render_email_callback' => array( __CLASS__, 'render_email' ),
 				'render_callback'       => array( __CLASS__, 'gutenblock_render_form' ),
 				'supports'              => array(
+
 					/*
-					 * Background image styles are applied server-side by core's
-					 * `wp_render_background_support()` render_block filter, so the support has to
-					 * be declared here as well as in block.json for the front end to pick it up.
+					 * Declared here as well as in block.json because the front end styles come from
+					 * PHP. Serialization is skipped because core targets the first tag of the
+					 * rendered output — see self::apply_background_support().
 					 */
 					'background'           => array(
-						'backgroundImage'               => true,
-						'backgroundSize'                => true,
-						'__experimentalDefaultControls' => array(
+						'backgroundImage'                 => true,
+						'backgroundSize'                  => true,
+						'__experimentalSkipSerialization' => true,
+						'__experimentalDefaultControls'   => array(
 							'backgroundImage' => true,
 						),
 					),
@@ -674,13 +676,15 @@ class Contact_Form_Block {
 			'jetpack/form-step',
 			array(
 				'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_form_step' ),
-				// Mirrors the supports declared in the block's index.js, so that core can apply the
-				// background image styles to the rendered step on the front end.
+				// Mirrors the supports declared in the block's index.js, so the front end gets the
+				// background image too. Serialization is skipped because core targets the first tag
+				// of the rendered output — see Contact_Form_Block::apply_background_support().
 				'supports'        => array(
 					'background' => array(
-						'backgroundImage'               => true,
-						'backgroundSize'                => true,
-						'__experimentalDefaultControls' => array(
+						'backgroundImage'                 => true,
+						'backgroundSize'                  => true,
+						'__experimentalSkipSerialization' => true,
+						'__experimentalDefaultControls'   => array(
 							'backgroundImage' => true,
 						),
 					),
@@ -983,13 +987,81 @@ class Contact_Form_Block {
 		if ( isset( $atts['ref'] ) ) {
 			$ref_id = absint( $atts['ref'] );
 			if ( $ref_id > 0 ) {
-				return Contact_Form::render_synced_form( $ref_id );
+				// A synced form has no markup of its own, so the outer wrapper of the rendered
+				// form is the only element the ref block's background can go on.
+				return self::apply_background_support( Contact_Form::render_synced_form( $ref_id ), $atts );
 			} else {
 				return ''; // Invalid ref ID.
 			}
 		}
 
-		return Contact_Form::parse( $atts, do_blocks( $content ) );
+		// The block's own div opens $content, and is what carries the color, padding and radius
+		// supports, so the background image belongs there rather than on Contact_Form::parse()'s
+		// outer container.
+		return Contact_Form::parse( $atts, self::apply_background_support( do_blocks( $content ), $atts ) );
+	}
+
+	/**
+	 * Apply a block's background image styles to the first tag of the given HTML.
+	 *
+	 * Core's `wp_render_background_support()` puts these styles on the first tag of a block's
+	 * rendered output. For both form blocks that tag is a wrapper added at render time — the
+	 * interactivity wrapper for a step, the container div for a form — and not the block's own
+	 * element, which is where the color, padding and border radius supports end up. Leaving the
+	 * two apart means an opaque background color paints over the image on the front end while
+	 * the editor shows both on one element. Serialization is therefore skipped in the block
+	 * registration and the styles are applied here instead, against the same element that
+	 * carries the rest of the block's styles.
+	 *
+	 * @param string $html       Rendered HTML whose first tag should carry the background.
+	 * @param array  $atts       Block attributes.
+	 *
+	 * @return string The HTML, with background styles applied when the block has an image.
+	 */
+	public static function apply_background_support( $html, $atts ) {
+		$background = $atts['style']['background'] ?? null;
+
+		if ( ! is_array( $background ) || empty( $background['backgroundImage'] ) ) {
+			return $html;
+		}
+
+		// Mirrors the defaults in core's wp_render_background_support().
+		$background_styles = array(
+			'backgroundImage'      => $background['backgroundImage'],
+			'backgroundSize'       => $background['backgroundSize'] ?? 'cover',
+			'backgroundPosition'   => $background['backgroundPosition'] ?? null,
+			'backgroundRepeat'     => $background['backgroundRepeat'] ?? null,
+			'backgroundAttachment' => $background['backgroundAttachment'] ?? null,
+		);
+
+		if ( 'contain' === $background_styles['backgroundSize'] && ! $background_styles['backgroundPosition'] ) {
+			$background_styles['backgroundPosition'] = '50% 50%';
+		}
+
+		$styles = wp_style_engine_get_styles( array( 'background' => $background_styles ) );
+
+		if ( empty( $styles['css'] ) ) {
+			return $html;
+		}
+
+		$tags = new \WP_HTML_Tag_Processor( $html );
+
+		if ( ! $tags->next_tag() ) {
+			return $html;
+		}
+
+		$existing_style = $tags->get_attribute( 'style' );
+
+		if ( is_string( $existing_style ) && '' !== $existing_style ) {
+			$separator = str_ends_with( $existing_style, ';' ) ? '' : ';';
+			$tags->set_attribute( 'style', $existing_style . $separator . $styles['css'] );
+		} else {
+			$tags->set_attribute( 'style', $styles['css'] );
+		}
+
+		$tags->add_class( 'has-background' );
+
+		return $tags->get_updated_html();
 	}
 
 	/**

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -24,6 +24,20 @@ use Jetpack;
  */
 class Contact_Form_Block {
 	/**
+	 * Class on the Form block's own element, the one carrying its style supports.
+	 *
+	 * @var string
+	 */
+	const FORM_BLOCK_CLASS = 'wp-block-jetpack-contact-form';
+
+	/**
+	 * Class on the Step block's own element, the one carrying its style supports.
+	 *
+	 * @var string
+	 */
+	const STEP_BLOCK_CLASS = 'wp-block-jetpack-form-step';
+
+	/**
 	 * Register the Contact Form block.
 	 * We are core block dependent only on whether the jetpack contact form plugin
 	 * is active or not. This is allowing us to make it more discoverable
@@ -45,6 +59,12 @@ class Contact_Form_Block {
 				'render_email_callback' => array( __CLASS__, 'render_email' ),
 				'render_callback'       => array( __CLASS__, 'gutenblock_render_form' ),
 				'supports'              => array(
+
+					/*
+					 * Deliberately not mirrored in block.json: serialization is skipped here so
+					 * self::apply_background_support() can put the image on the block's own
+					 * element, and skipping it in JS too would drop the editor preview.
+					 */
 					'background'           => array(
 						'backgroundImage'                 => true,
 						'backgroundSize'                  => true,
@@ -670,6 +690,13 @@ class Contact_Form_Block {
 			'jetpack/form-step',
 			array(
 				'render_callback' => array( Contact_Form_Plugin::class, 'gutenblock_render_form_step' ),
+
+				/*
+				 * Deliberately not mirrored in the block's index.js: serialization is skipped
+				 * here so Contact_Form_Block::apply_background_support() can put the image on
+				 * the block's own element, and skipping it in JS too would drop the editor
+				 * preview.
+				 */
 				'supports'        => array(
 					'background' => array(
 						'backgroundImage'                 => true,
@@ -978,24 +1005,37 @@ class Contact_Form_Block {
 		if ( isset( $atts['ref'] ) ) {
 			$ref_id = absint( $atts['ref'] );
 			if ( $ref_id > 0 ) {
-				return self::apply_background_support( Contact_Form::render_synced_form( $ref_id ), $atts );
+				return self::apply_background_support( Contact_Form::render_synced_form( $ref_id ), $atts, self::FORM_BLOCK_CLASS );
 			} else {
 				return ''; // Invalid ref ID.
 			}
 		}
 
-		return Contact_Form::parse( $atts, self::apply_background_support( do_blocks( $content ), $atts ) );
+		return self::apply_background_support( Contact_Form::parse( $atts, do_blocks( $content ) ), $atts, self::FORM_BLOCK_CLASS );
 	}
 
 	/**
-	 * Apply a block's background image styles to the first tag of the given HTML.
+	 * Apply a block's background image styles to the block's own element.
 	 *
-	 * @param string $html Rendered HTML whose first tag should carry the background.
-	 * @param array  $atts Block attributes.
+	 * Core's `wp_render_background_support()` targets the first tag of the rendered output.
+	 * Both form blocks wrap themselves at render time — the interactivity wrapper for a step,
+	 * the container div and any admin-only notices for a form — so the first tag is not the
+	 * element carrying the block's color, padding and radius, and for a synced form it varies
+	 * with who is viewing. Serialization is skipped in the block registration (PHP only: adding
+	 * it to block.json or index.js would kill the editor preview) and the styles are applied
+	 * here, on the element matching $target_class.
+	 *
+	 * Mirrors core's `wp_render_background_support()`, including its `cover` and `50% 50%`
+	 * defaults. Core 7.1 added gradient handling this does not implement, so `gradient` must
+	 * stay out of the JS supports until it is mirrored here too.
+	 *
+	 * @param string $html         Rendered HTML containing the block's own element.
+	 * @param array  $atts         Block attributes.
+	 * @param string $target_class Class of the element that should carry the background.
 	 *
 	 * @return string The HTML, with background styles applied when the block has an image.
 	 */
-	public static function apply_background_support( $html, $atts ) {
+	public static function apply_background_support( $html, $atts, $target_class ) {
 		$background = $atts['style']['background'] ?? null;
 
 		if ( ! is_array( $background ) || empty( $background['backgroundImage'] ) ) {
@@ -1014,6 +1054,20 @@ class Contact_Form_Block {
 			$background_styles['backgroundPosition'] = '50% 50%';
 		}
 
+		// A step's styles are still ahead of the do_shortcode() pass in Contact_Form::parse(),
+		// so percent-encode the brackets that would otherwise make this URL look like a
+		// shortcode: unencoded they are stripped out of the attribute, taking the background
+		// with them, and the shortcode's side effects run.
+		if ( isset( $background_styles['backgroundImage']['url'] ) && is_string( $background_styles['backgroundImage']['url'] ) ) {
+			$background_styles['backgroundImage']['url'] = strtr(
+				$background_styles['backgroundImage']['url'],
+				array(
+					'[' => '%5B',
+					']' => '%5D',
+				)
+			);
+		}
+
 		$styles = wp_style_engine_get_styles( array( 'background' => $background_styles ) );
 
 		if ( empty( $styles['css'] ) ) {
@@ -1022,7 +1076,7 @@ class Contact_Form_Block {
 
 		$tags = new \WP_HTML_Tag_Processor( $html );
 
-		if ( ! $tags->next_tag() ) {
+		if ( ! $tags->next_tag( array( 'class_name' => $target_class ) ) ) {
 			return $html;
 		}
 

--- a/projects/packages/forms/src/blocks/form-step/edit.jsx
+++ b/projects/packages/forms/src/blocks/form-step/edit.jsx
@@ -166,11 +166,12 @@ export default function Edit( { attributes, setAttributes, clientId, isSelected 
 		renderAppender = InnerBlocks.ButtonBlockAppender;
 	}
 
-	// The inner element mirrors the wrapper's classes, which the form layout CSS relies on to
-	// size the fields. It must not inherit the wrapper's inline styles though: those carry the
-	// block's own background, which would then be painted once per element.
+	// Only the two classes the form layout CSS matches on to size and lay out the fields.
+	// Handing over the whole wrapper props would also copy the block's own styling onto this
+	// element — the inline background image, and the has-background / has-<slug>-background-color
+	// classes for a preset color — which would then paint a second time, on top of the wrapper.
 	const innerBlocksProps = useInnerBlocksProps(
-		{ className: blockProps.className },
+		{ className: 'wp-block-jetpack-form-step jetpack-form-step__container' },
 		{
 			template: getStepTemplate( hasPrevNavigation ),
 			allowedBlocks: ALLOWED_BLOCKS,

--- a/projects/packages/forms/src/blocks/form-step/edit.jsx
+++ b/projects/packages/forms/src/blocks/form-step/edit.jsx
@@ -166,10 +166,6 @@ export default function Edit( { attributes, setAttributes, clientId, isSelected 
 		renderAppender = InnerBlocks.ButtonBlockAppender;
 	}
 
-	// Only the two classes the form layout CSS matches on to size and lay out the fields.
-	// Handing over the whole wrapper props would also copy the block's own styling onto this
-	// element — the inline background image, and the has-background / has-<slug>-background-color
-	// classes for a preset color — which would then paint a second time, on top of the wrapper.
 	const innerBlocksProps = useInnerBlocksProps(
 		{ className: 'wp-block-jetpack-form-step jetpack-form-step__container' },
 		{

--- a/projects/packages/forms/src/blocks/form-step/edit.jsx
+++ b/projects/packages/forms/src/blocks/form-step/edit.jsx
@@ -166,11 +166,17 @@ export default function Edit( { attributes, setAttributes, clientId, isSelected 
 		renderAppender = InnerBlocks.ButtonBlockAppender;
 	}
 
-	const innerBlocksProps = useInnerBlocksProps( blockProps, {
-		template: getStepTemplate( hasPrevNavigation ),
-		allowedBlocks: ALLOWED_BLOCKS,
-		renderAppender,
-	} );
+	// The inner element mirrors the wrapper's classes, which the form layout CSS relies on to
+	// size the fields. It must not inherit the wrapper's inline styles though: those carry the
+	// block's own background, which would then be painted once per element.
+	const innerBlocksProps = useInnerBlocksProps(
+		{ className: blockProps.className },
+		{
+			template: getStepTemplate( hasPrevNavigation ),
+			allowedBlocks: ALLOWED_BLOCKS,
+			renderAppender,
+		}
+	);
 
 	useEffect( () => {
 		if (

--- a/projects/packages/forms/src/blocks/form-step/index.js
+++ b/projects/packages/forms/src/blocks/form-step/index.js
@@ -27,6 +27,13 @@ export const settings = {
 			gradients: true,
 			link: true,
 		},
+		background: {
+			backgroundImage: true,
+			backgroundSize: true,
+			__experimentalDefaultControls: {
+				backgroundImage: true,
+			},
+		},
 		spacing: {
 			padding: true,
 			margin: true,

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -926,8 +926,6 @@ class Contact_Form_Plugin {
 			$processed_content = do_blocks( $content );
 		}
 
-		// The step's own div opens $processed_content and carries its color, padding and radius,
-		// so the background image goes there rather than on the interactivity wrapper below.
 		$processed_content = Contact_Form_Block::apply_background_support( $processed_content, $atts );
 
 		$is_current_step_class = ( self::$step_count === 1 ? 'is-current-step' : '' );

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -925,6 +925,11 @@ class Contact_Form_Plugin {
 		} else {
 			$processed_content = do_blocks( $content );
 		}
+
+		// The step's own div opens $processed_content and carries its color, padding and radius,
+		// so the background image goes there rather than on the interactivity wrapper below.
+		$processed_content = Contact_Form_Block::apply_background_support( $processed_content, $atts );
+
 		$is_current_step_class = ( self::$step_count === 1 ? 'is-current-step' : '' );
 		return '<div data-wp-interactive="jetpack/form" class="jetpack-form-step ' . $is_current_step_class . ' " data-wp-class--is-before-current="state.isBeforeCurrent" data-wp-class--is-after-current="state.isAfterCurrent" data-wp-class--is-current-step="state.isCurrentStep" ' . wp_interactivity_data_wp_context( array( 'step' => self::$step_count ) ) . ' >'
 				. $processed_content

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -898,35 +898,28 @@ class Contact_Form_Plugin {
 		);
 
 		// Process content for marker classes and add interactivity
-		$processed_content = $content;
+		$blocks_content = do_blocks( $content );
+		$tags           = new \WP_HTML_Tag_Processor( $blocks_content );
 
-		// Only process if we have the WP_HTML_Tag_Processor
-		if ( class_exists( 'WP_HTML_Tag_Processor' ) ) {
-			$blocks_content = do_blocks( $content );
-			$tags           = new \WP_HTML_Tag_Processor( $blocks_content );
+		// Move to the first token so the bookmark has a valid span, then set the bookmark.
+		$tags->next_tag();
+		$tags->set_bookmark( 'start' );
 
-			// Move to the first token so the bookmark has a valid span, then set the bookmark.
-			$tags->next_tag();
-			$tags->set_bookmark( 'start' );
-
-			// Process blocks with the "next step" trigger
-			while ( $tags->next_tag( array( 'class_name' => 'trigger-next-step' ) ) ) {
-				// No need to set data-wp-interactive since the parent div already has it
-				$tags->set_attribute( 'data-wp-on--click', 'actions.nextStep' );
-			}
-
-			// Reset and process blocks with the "previous step" trigger
-			$tags->seek( 'start' );
-			while ( $tags->next_tag( array( 'class_name' => 'trigger-previous-step' ) ) ) {
-				$tags->set_attribute( 'data-wp-on--click', 'actions.previousStep' );
-			}
-
-			$processed_content = $tags->get_updated_html();
-		} else {
-			$processed_content = do_blocks( $content );
+		// Process blocks with the "next step" trigger
+		while ( $tags->next_tag( array( 'class_name' => 'trigger-next-step' ) ) ) {
+			// No need to set data-wp-interactive since the parent div already has it
+			$tags->set_attribute( 'data-wp-on--click', 'actions.nextStep' );
 		}
 
-		$processed_content = Contact_Form_Block::apply_background_support( $processed_content, $atts );
+		// Reset and process blocks with the "previous step" trigger
+		$tags->seek( 'start' );
+		while ( $tags->next_tag( array( 'class_name' => 'trigger-previous-step' ) ) ) {
+			$tags->set_attribute( 'data-wp-on--click', 'actions.previousStep' );
+		}
+
+		$processed_content = $tags->get_updated_html();
+
+		$processed_content = Contact_Form_Block::apply_background_support( $processed_content, $atts, Contact_Form_Block::STEP_BLOCK_CLASS );
 
 		$is_current_step_class = ( self::$step_count === 1 ? 'is-current-step' : '' );
 		return '<div data-wp-interactive="jetpack/form" class="jetpack-form-step ' . $is_current_step_class . ' " data-wp-class--is-before-current="state.isBeforeCurrent" data-wp-class--is-after-current="state.isAfterCurrent" data-wp-class--is-current-step="state.isCurrentStep" ' . wp_interactivity_data_wp_context( array( 'step' => self::$step_count ) ) . ' >'

--- a/projects/packages/forms/src/contact-form/css/jetpack-forms-layout.scss
+++ b/projects/packages/forms/src/contact-form/css/jetpack-forms-layout.scss
@@ -67,8 +67,6 @@
 			display: flex;
 			flex-wrap: wrap;
 			width: 100%;
-			// The step's padding has to sit inside its 100% width, otherwise the content
-			// overflows the wrapper the step's own background is painted on.
 			box-sizing: border-box;
 		}
 

--- a/projects/packages/forms/src/contact-form/css/jetpack-forms-layout.scss
+++ b/projects/packages/forms/src/contact-form/css/jetpack-forms-layout.scss
@@ -67,6 +67,9 @@
 			display: flex;
 			flex-wrap: wrap;
 			width: 100%;
+			// The step's padding has to sit inside its 100% width, otherwise the content
+			// overflows the wrapper the step's own background is painted on.
+			box-sizing: border-box;
 		}
 
 		.jetpack-form-steps-wrapper {

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -247,9 +247,6 @@ class Contact_Form_Block_Test extends BaseTestCase {
 					'background' => array(
 						'backgroundImage'                 => true,
 						'backgroundSize'                  => true,
-						// Serialization is skipped so that Contact_Form_Block::apply_background_support()
-						// can put the image on the step's own div rather than core putting it on the
-						// interactivity wrapper, where a background color would paint over it.
 						'__experimentalSkipSerialization' => true,
 						'__experimentalDefaultControls'   => array(
 							'backgroundImage' => true,
@@ -521,8 +518,6 @@ class Contact_Form_Block_Test extends BaseTestCase {
 
 		$supports = $registry->get_registered( 'jetpack/contact-form' )->supports ?? array();
 
-		// The front end styles come from PHP, so the background support has to be declared here
-		// and not only in block.json.
 		$this->assertSame(
 			array(
 				'backgroundImage'                 => true,

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -174,7 +174,7 @@ class Contact_Form_Block_Test extends BaseTestCase {
 	 */
 	public static function data_provider_test_register_child_blocks() {
 		return array(
-			'jetpack/input'   => array(
+			'jetpack/input'     => array(
 				'jetpack/input',
 				array(
 					'__experimentalBorder' => array(
@@ -201,7 +201,7 @@ class Contact_Form_Block_Test extends BaseTestCase {
 					'visibility'           => false,
 				),
 			),
-			'jetpack/label'   => array(
+			'jetpack/label'     => array(
 				'jetpack/label',
 				array(
 					'color'      => array(
@@ -222,7 +222,7 @@ class Contact_Form_Block_Test extends BaseTestCase {
 					'visibility' => true,
 				),
 			),
-			'jetpack/options' => array(
+			'jetpack/options'   => array(
 				'jetpack/options',
 				array(
 					'__experimentalBorder' => array(
@@ -241,7 +241,23 @@ class Contact_Form_Block_Test extends BaseTestCase {
 					'visibility'           => false,
 				),
 			),
-			'jetpack/option'  => array(
+			'jetpack/form-step' => array(
+				'jetpack/form-step',
+				array(
+					'background' => array(
+						'backgroundImage'                 => true,
+						'backgroundSize'                  => true,
+						// Serialization is skipped so that Contact_Form_Block::apply_background_support()
+						// can put the image on the step's own div rather than core putting it on the
+						// interactivity wrapper, where a background color would paint over it.
+						'__experimentalSkipSerialization' => true,
+						'__experimentalDefaultControls'   => array(
+							'backgroundImage' => true,
+						),
+					),
+				),
+			),
+			'jetpack/option'    => array(
 				'jetpack/option',
 				array(
 					'color'      => array(
@@ -502,6 +518,77 @@ class Contact_Form_Block_Test extends BaseTestCase {
 		Contact_Form_Block::register_block();
 
 		$this->assertTrue( $registry->is_registered( 'jetpack/contact-form' ) );
+
+		$supports = $registry->get_registered( 'jetpack/contact-form' )->supports ?? array();
+
+		// The front end styles come from PHP, so the background support has to be declared here
+		// and not only in block.json.
+		$this->assertSame(
+			array(
+				'backgroundImage'                 => true,
+				'backgroundSize'                  => true,
+				'__experimentalSkipSerialization' => true,
+				'__experimentalDefaultControls'   => array(
+					'backgroundImage' => true,
+				),
+			),
+			$supports['background'],
+			'Background support does not match the expected values'
+		);
+	}
+
+	/**
+	 * Test that ::apply_background_support puts the background on the block's own element.
+	 *
+	 * @dataProvider data_provider_test_apply_background_support
+	 */
+	#[DataProvider( 'data_provider_test_apply_background_support' )]
+	public function test_apply_background_support( $atts, $expected_style, $expected_class ) {
+		$html   = '<div class="wp-block-jetpack-form-step"><p>Field</p></div>';
+		$result = Contact_Form_Block::apply_background_support( $html, $atts );
+
+		if ( null === $expected_style ) {
+			$this->assertSame( $html, $result, 'HTML should be returned untouched' );
+			return;
+		}
+
+		$this->assertStringContainsString( $expected_style, $result );
+		$this->assertSame( $expected_class, str_contains( $result, 'has-background' ) );
+	}
+
+	/**
+	 * Data provider for test_apply_background_support.
+	 */
+	public static function data_provider_test_apply_background_support() {
+		$image = array(
+			'backgroundImage' => array(
+				'url'    => 'https://example.com/bg.jpg',
+				'source' => 'file',
+			),
+		);
+
+		return array(
+			'no style attribute'      => array( array(), null, false ),
+			'no background image'     => array(
+				array( 'style' => array( 'background' => array( 'backgroundSize' => 'cover' ) ) ),
+				null,
+				false,
+			),
+			'image defaults to cover' => array(
+				array( 'style' => array( 'background' => $image ) ),
+				'background-size:cover',
+				true,
+			),
+			'contain gets centered'   => array(
+				array(
+					'style' => array(
+						'background' => array_merge( $image, array( 'backgroundSize' => 'contain' ) ),
+					),
+				),
+				'background-position:50% 50%',
+				true,
+			),
+		);
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -540,7 +540,7 @@ class Contact_Form_Block_Test extends BaseTestCase {
 	#[DataProvider( 'data_provider_test_apply_background_support' )]
 	public function test_apply_background_support( $atts, $expected_style, $expected_class ) {
 		$html   = '<div class="wp-block-jetpack-form-step"><p>Field</p></div>';
-		$result = Contact_Form_Block::apply_background_support( $html, $atts );
+		$result = Contact_Form_Block::apply_background_support( $html, $atts, Contact_Form_Block::STEP_BLOCK_CLASS );
 
 		if ( null === $expected_style ) {
 			$this->assertSame( $html, $result, 'HTML should be returned untouched' );
@@ -549,6 +549,131 @@ class Contact_Form_Block_Test extends BaseTestCase {
 
 		$this->assertStringContainsString( $expected_style, $result );
 		$this->assertSame( $expected_class, str_contains( $result, 'has-background' ) );
+	}
+
+	/**
+	 * The background goes on the element matching the target class, not on whatever tag
+	 * happens to come first — a synced form can be preceded by admin-only notices.
+	 */
+	public function test_apply_background_support_skips_tags_before_the_block() {
+		$html = '<div class="jetpack-form-status-notice">Draft</div>'
+			. '<div class="jetpack-contact-form-container">'
+			. '<div class="wp-block-jetpack-contact-form"><p>Field</p></div>'
+			. '</div>';
+
+		$result = Contact_Form_Block::apply_background_support(
+			$html,
+			array( 'style' => array( 'background' => array( 'backgroundImage' => array( 'url' => 'https://example.com/bg.jpg' ) ) ) ),
+			Contact_Form_Block::FORM_BLOCK_CLASS
+		);
+
+		$tags = new \WP_HTML_Tag_Processor( $result );
+
+		$tags->next_tag();
+		$this->assertNull( $tags->get_attribute( 'style' ), 'The notice must not carry the background' );
+
+		$tags->next_tag();
+		$this->assertNull( $tags->get_attribute( 'style' ), 'The container must not carry the background' );
+
+		$tags->next_tag();
+		$this->assertTrue( $tags->has_class( Contact_Form_Block::FORM_BLOCK_CLASS ) );
+		$this->assertStringContainsString( 'background-image', (string) $tags->get_attribute( 'style' ) );
+	}
+
+	/**
+	 * Nothing is painted when the block's own element is absent from the output.
+	 */
+	public function test_apply_background_support_without_the_target_element() {
+		$html = '<div class="jetpack-contact-form-container"><p>No form here</p></div>';
+
+		$this->assertSame(
+			$html,
+			Contact_Form_Block::apply_background_support(
+				$html,
+				array( 'style' => array( 'background' => array( 'backgroundImage' => array( 'url' => 'https://example.com/bg.jpg' ) ) ) ),
+				Contact_Form_Block::FORM_BLOCK_CLASS
+			)
+		);
+	}
+
+	/**
+	 * An existing style attribute is kept, with or without a trailing semicolon.
+	 *
+	 * @dataProvider data_provider_test_apply_background_support_merges_styles
+	 */
+	#[DataProvider( 'data_provider_test_apply_background_support_merges_styles' )]
+	public function test_apply_background_support_merges_existing_styles( $existing, $expected ) {
+		$result = Contact_Form_Block::apply_background_support(
+			'<div class="wp-block-jetpack-form-step" style="' . $existing . '"></div>',
+			array( 'style' => array( 'background' => array( 'backgroundImage' => array( 'url' => 'https://example.com/bg.jpg' ) ) ) ),
+			Contact_Form_Block::STEP_BLOCK_CLASS
+		);
+
+		$tags = new \WP_HTML_Tag_Processor( $result );
+		$tags->next_tag();
+
+		$this->assertSame( $expected, $tags->get_attribute( 'style' ) );
+	}
+
+	/**
+	 * Data provider for test_apply_background_support_merges_existing_styles.
+	 */
+	public static function data_provider_test_apply_background_support_merges_styles() {
+		$background = "background-image:url('https://example.com/bg.jpg');background-size:cover;";
+
+		return array(
+			'trailing semicolon'    => array( 'padding-top:10px;', 'padding-top:10px;' . $background ),
+			'no trailing semicolon' => array( 'padding-top:10px', 'padding-top:10px;' . $background ),
+		);
+	}
+
+	/**
+	 * Position, repeat and attachment are passed through to the style engine.
+	 */
+	public function test_apply_background_support_passes_through_all_properties() {
+		$result = Contact_Form_Block::apply_background_support(
+			'<div class="wp-block-jetpack-form-step"></div>',
+			array(
+				'style' => array(
+					'background' => array(
+						'backgroundImage'      => array( 'url' => 'https://example.com/bg.jpg' ),
+						'backgroundSize'       => '200px',
+						'backgroundPosition'   => '25% 75%',
+						'backgroundRepeat'     => 'no-repeat',
+						'backgroundAttachment' => 'fixed',
+					),
+				),
+			),
+			Contact_Form_Block::STEP_BLOCK_CLASS
+		);
+
+		$this->assertStringContainsString( 'background-size:200px', $result );
+		$this->assertStringContainsString( 'background-position:25% 75%', $result );
+		$this->assertStringContainsString( 'background-repeat:no-repeat', $result );
+		$this->assertStringContainsString( 'background-attachment:fixed', $result );
+	}
+
+	/**
+	 * A URL containing brackets survives the do_shortcode() pass a step's styles still
+	 * sit in front of, instead of being stripped out of the attribute along with the
+	 * background — and without running the shortcode it looks like.
+	 */
+	public function test_apply_background_support_encodes_shortcode_brackets() {
+		$result = Contact_Form_Block::apply_background_support(
+			'<div class="wp-block-jetpack-form-step"></div>',
+			array(
+				'style' => array(
+					'background' => array(
+						'backgroundImage' => array( 'url' => 'https://example.com/a.png[contact-field label=pwn type=text]' ),
+					),
+				),
+			),
+			Contact_Form_Block::STEP_BLOCK_CLASS
+		);
+
+		$this->assertStringNotContainsString( '[', $result );
+		$this->assertStringContainsString( '%5Bcontact-field', $result );
+		$this->assertStringContainsString( 'background-image', do_shortcode( $result ) );
 	}
 
 	/**
@@ -584,6 +709,61 @@ class Contact_Form_Block_Test extends BaseTestCase {
 				true,
 			),
 		);
+	}
+
+	/**
+	 * Integration: the background image must land on the step's own div, not on the
+	 * interactivity wrapper gutenblock_render_form_step() adds around it, and core
+	 * must not apply it a second time.
+	 */
+	public function test_step_background_lands_on_the_blocks_own_div() {
+		Contact_Form_Block::register_block();
+		Contact_Form_Block::register_child_blocks();
+
+		$markup = '<!-- wp:jetpack/form-step {"style":{"background":{"backgroundImage":{"url":"https://example.com/bg.png","source":"file"}}}} -->'
+			. '<div class="wp-block-jetpack-form-step"><!-- wp:jetpack/field-text {"label":"Name"} /--></div>'
+			. '<!-- /wp:jetpack/form-step -->';
+
+		$html = do_blocks( $markup );
+
+		$this->assertSame( 1, substr_count( $html, 'background-image:' ), 'Background should be applied exactly once' );
+
+		$tags = new \WP_HTML_Tag_Processor( $html );
+
+		$this->assertTrue( $tags->next_tag() );
+		$this->assertTrue( $tags->has_class( 'jetpack-form-step' ), 'First tag should be the interactivity wrapper' );
+		$this->assertNull( $tags->get_attribute( 'style' ), 'Interactivity wrapper must not carry the background' );
+
+		$this->assertTrue( $tags->next_tag() );
+		$this->assertTrue( $tags->has_class( Contact_Form_Block::STEP_BLOCK_CLASS ) );
+		$this->assertStringContainsString( 'background-image', (string) $tags->get_attribute( 'style' ) );
+		$this->assertTrue( $tags->has_class( 'has-background' ) );
+	}
+
+	/**
+	 * Integration: the same for the Form block, whose render opens with the container div
+	 * Contact_Form::parse() adds rather than with the block's own element.
+	 */
+	public function test_form_background_lands_on_the_blocks_own_div() {
+		Contact_Form_Block::register_block();
+		Contact_Form_Block::register_child_blocks();
+
+		$markup = '<!-- wp:jetpack/contact-form {"style":{"background":{"backgroundImage":{"url":"https://example.com/bg.png","source":"file"}}}} -->'
+			. '<div class="wp-block-jetpack-contact-form"><!-- wp:jetpack/field-text {"label":"Name"} /--></div>'
+			. '<!-- /wp:jetpack/contact-form -->';
+
+		$html = do_blocks( $markup );
+
+		$this->assertStringContainsString( 'jetpack-contact-form-container', $html, 'The form should have rendered' );
+		$this->assertSame( 1, substr_count( $html, 'background-image:' ), 'Background should be applied exactly once' );
+
+		$tags = new \WP_HTML_Tag_Processor( $html );
+
+		$this->assertTrue( $tags->next_tag( array( 'class_name' => 'jetpack-contact-form-container' ) ) );
+		$this->assertNull( $tags->get_attribute( 'style' ), 'The container must not carry the background' );
+
+		$this->assertTrue( $tags->next_tag( array( 'class_name' => Contact_Form_Block::FORM_BLOCK_CLASS ) ) );
+		$this->assertStringContainsString( 'background-image', (string) $tags->get_attribute( 'style' ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes FORMS-752

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Adds background image support to the Form block and to the Step block, so a form (or an individual step of a multi-step form) can sit on top of an image. This surfaces WordPress core's **Background image** panel in the block inspector's Styles tab, with the usual image / size / position / repeat controls.
* The support is declared both in the blocks' JS registration and in their PHP registration. Both blocks are server rendered, and core applies background image styles through the `wp_render_background_support()` `render_block` filter, which reads the server-registered block type — declaring it only in JS would show the editor panel but render nothing on the front end.
* In the Step block's edit component, the inner blocks element no longer inherits the block wrapper's inline styles. It previously received the whole wrapper prop set, so the block's own styles were applied to two nested elements — invisible for a background colour, but a background image was painted twice.
* Fixes a pre-existing layout bug this exposed: `.wp-block-jetpack-form-step` is sized `width: 100%` on the front end without `box-sizing: border-box`, so a step's padding was added on top of that width and its content overflowed the step. The editor stylesheet already had the border-box rule; the front-end one did not.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Add a **Form** block to a post, and pick the multi-step variation.
* Select the **Step** block, open the **Styles** tab in the block inspector, and set a **Background image**. The image should appear behind the step in the editor, exactly once — no doubled or offset copy.
* Give the step some padding. The fields should stay inside the image, and the step should keep the full width of the form.
* Select the **Form** block itself and set a background image there too — it should render behind the whole form.
* Publish and view the post on the front end. Both background images should render, and the fields should stay inside the padded area rather than overflowing to the right of the image.
* Check a step that has padding but no background image to confirm the `box-sizing` change did not shift anything: its content is now inset by the padding instead of overflowing.

## New UI

Captured on a live Jurassic Ninja site at 1440×900.

**Editor — the new Background image panel on the Step block**

![editor](https://github.com/Automattic/jetpack/raw/screenshots/add/forms-background-image/editor-step-background.png)

**Front end — the same step rendered**

![front end](https://github.com/Automattic/jetpack/raw/screenshots/add/forms-background-image/frontend-step-background.png)

