### PR TITLE
Forms: conditional logic (1/5) — vocabulary and feature flag

### DIFF
--- a/projects/packages/forms/changelog/add-forms-conditional-logic-foundation
+++ b/projects/packages/forms/changelog/add-forms-conditional-logic-foundation
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add the vocabulary and feature flag for form field conditional logic. No user-facing change on its own.

--- a/projects/packages/forms/composer.json
+++ b/projects/packages/forms/composer.json
@@ -11,6 +11,7 @@
 		"automattic/jetpack-connection": "@dev",
 		"automattic/jetpack-device-detection": "@dev",
 		"automattic/jetpack-external-connections": "@dev",
+		"automattic/jetpack-feature-flags": "@dev",
 		"automattic/jetpack-jwt": "@dev",
 		"automattic/jetpack-logo": "@dev",
 		"automattic/jetpack-menu-badges": "@dev",

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -204,6 +204,10 @@ class Contact_Form_Block {
 		$features['multistep-form'] = Current_Plan::supports( 'multistep-form' );
 		$features['form-webhooks']  = Current_Plan::supports( 'form-webhooks' );
 
+		// Bridges the jetpack-feature-flags registration to the editor, so JS `hasFeatureFlag()`
+		// and PHP `Feature_Flags::is_enabled()` answer from one source under one name.
+		$features[ Jetpack_Forms::CONDITIONAL_LOGIC_FLAG ] = Jetpack_Forms::is_conditional_logic_enabled();
+
 		return self::register_central_form_management_default( $features );
 	}
 

--- a/projects/packages/forms/src/blocks/field-checkbox/index.js
+++ b/projects/packages/forms/src/blocks/field-checkbox/index.js
@@ -11,6 +11,16 @@ export const form_editor = {
 	category: 'choice',
 };
 
+/**
+ * Conditional logic: how this field's value is compared.
+ *
+ * Declared per block so the rule builder can offer the right operators and value
+ * input. A block that omits this simply gets no conditional-logic support.
+ */
+export const conditional_logic = {
+	type: 'boolean',
+};
+
 export const settings = {
 	...defaultSettings,
 	title: __( 'Checkbox', 'jetpack-forms' ),
@@ -49,4 +59,5 @@ export default {
 	name,
 	settings,
 	form_editor,
+	conditional_logic,
 };

--- a/projects/packages/forms/src/blocks/field-consent/index.js
+++ b/projects/packages/forms/src/blocks/field-consent/index.js
@@ -11,6 +11,16 @@ export const form_editor = {
 	category: 'advanced',
 };
 
+/**
+ * Conditional logic: how this field's value is compared.
+ *
+ * Declared per block so the rule builder can offer the right operators and value
+ * input. A block that omits this simply gets no conditional-logic support.
+ */
+export const conditional_logic = {
+	type: 'boolean',
+};
+
 export const settings = {
 	...defaultSettings,
 	title: __( 'Terms consent', 'jetpack-forms' ),
@@ -70,4 +80,5 @@ export default {
 	name,
 	settings,
 	form_editor,
+	conditional_logic,
 };

--- a/projects/packages/forms/src/blocks/field-date/index.js
+++ b/projects/packages/forms/src/blocks/field-date/index.js
@@ -11,6 +11,16 @@ export const form_editor = {
 	category: 'advanced',
 };
 
+/**
+ * Conditional logic: how this field's value is compared.
+ *
+ * Declared per block so the rule builder can offer the right operators and value
+ * input. A block that omits this simply gets no conditional-logic support.
+ */
+export const conditional_logic = {
+	type: 'date',
+};
+
 export const settings = {
 	...defaultSettings,
 	title: __( 'Date picker', 'jetpack-forms' ),
@@ -56,4 +66,5 @@ export default {
 	name,
 	settings,
 	form_editor,
+	conditional_logic,
 };

--- a/projects/packages/forms/src/blocks/field-email/index.jsx
+++ b/projects/packages/forms/src/blocks/field-email/index.jsx
@@ -12,6 +12,16 @@ export const form_editor = {
 	category: 'contact-info',
 };
 
+/**
+ * Conditional logic: how this field's value is compared.
+ *
+ * Declared per block so the rule builder can offer the right operators and value
+ * input. A block that omits this simply gets no conditional-logic support.
+ */
+export const conditional_logic = {
+	type: 'string',
+};
+
 export const settings = {
 	...defaultSettings,
 	title: __( 'Email field', 'jetpack-forms' ),
@@ -45,4 +55,5 @@ export default {
 	name,
 	settings,
 	form_editor,
+	conditional_logic,
 };

--- a/projects/packages/forms/src/blocks/field-file/index.jsx
+++ b/projects/packages/forms/src/blocks/field-file/index.jsx
@@ -11,6 +11,16 @@ export const form_editor = {
 	category: 'advanced',
 };
 
+/**
+ * Conditional logic: how this field's value is compared.
+ *
+ * Declared per block so the rule builder can offer the right operators and value
+ * input. A block that omits this simply gets no conditional-logic support.
+ */
+export const conditional_logic = {
+	type: 'file',
+};
+
 export const settings = {
 	...defaultSettings,
 	title: __( 'File upload field', 'jetpack-forms' ),
@@ -45,4 +55,5 @@ export default {
 	name,
 	settings,
 	form_editor,
+	conditional_logic,
 };

--- a/projects/packages/forms/src/blocks/field-hidden/index.js
+++ b/projects/packages/forms/src/blocks/field-hidden/index.js
@@ -10,6 +10,16 @@ export const form_editor = {
 	category: 'advanced',
 };
 
+/**
+ * Conditional logic: how this field's value is compared.
+ *
+ * Declared per block so the rule builder can offer the right operators and value
+ * input. A block that omits this simply gets no conditional-logic support.
+ */
+export const conditional_logic = {
+	type: 'hidden',
+};
+
 export const settings = {
 	...defaultSettings,
 	title: __( 'Hidden field', 'jetpack-forms' ),
@@ -39,4 +49,5 @@ export default {
 	name,
 	settings,
 	form_editor,
+	conditional_logic,
 };

--- a/projects/packages/forms/src/blocks/field-image-select/index.tsx
+++ b/projects/packages/forms/src/blocks/field-image-select/index.tsx
@@ -16,6 +16,20 @@ export const form_editor = {
 	category: 'choice',
 };
 
+/*
+ * Deliberately no `conditional_logic` declaration, so this block gets no panel.
+ *
+ * An image-select field submits a JSON document describing the choice
+ * (`{"perceived":"A","selected":"a","label":"Blue",...}`), not the label the rule builder
+ * offers as a value. All three evaluators would compare that document against `Blue` and
+ * never match, so `is` would be permanently false and `is not` permanently true: a rule
+ * would hide its field forever and the answer would then be dropped at storage.
+ *
+ * Comparing the decoded `label` in every evaluator is the real fix, but that is value-shape
+ * handling in exactly the place where the JS and PHP evaluators already drift. Offering no
+ * rule is better than offering one that cannot fire.
+ */
+
 export const settings = {
 	...defaultSettings,
 	title: __( 'Image Select Field', 'jetpack-forms' ),

--- a/projects/packages/forms/src/blocks/field-multiple-choice/index.js
+++ b/projects/packages/forms/src/blocks/field-multiple-choice/index.js
@@ -11,6 +11,16 @@ export const form_editor = {
 	category: 'choice',
 };
 
+/**
+ * Conditional logic: how this field's value is compared.
+ *
+ * Declared per block so the rule builder can offer the right operators and value
+ * input. A block that omits this simply gets no conditional-logic support.
+ */
+export const conditional_logic = {
+	type: 'multichoice',
+};
+
 export const settings = {
 	...defaultSettings,
 	title: __( 'Multiple choice (checkbox)', 'jetpack-forms' ),
@@ -70,4 +80,5 @@ export default {
 	name,
 	settings,
 	form_editor,
+	conditional_logic,
 };

--- a/projects/packages/forms/src/blocks/field-name/index.js
+++ b/projects/packages/forms/src/blocks/field-name/index.js
@@ -13,6 +13,16 @@ export const form_editor = {
 	category: 'contact-info',
 };
 
+/**
+ * Conditional logic: how this field's value is compared.
+ *
+ * Declared per block so the rule builder can offer the right operators and value
+ * input. A block that omits this simply gets no conditional-logic support.
+ */
+export const conditional_logic = {
+	type: 'string',
+};
+
 const transforms = {
 	...transformsSource,
 	to: transformsSource.to.filter( transform => ! transform.blocks.includes( 'jetpack/' + name ) ),
@@ -57,4 +67,5 @@ export default {
 	name,
 	settings,
 	form_editor,
+	conditional_logic,
 };

--- a/projects/packages/forms/src/blocks/field-number/index.js
+++ b/projects/packages/forms/src/blocks/field-number/index.js
@@ -11,6 +11,16 @@ export const form_editor = {
 	category: 'basic',
 };
 
+/**
+ * Conditional logic: how this field's value is compared.
+ *
+ * Declared per block so the rule builder can offer the right operators and value
+ * input. A block that omits this simply gets no conditional-logic support.
+ */
+export const conditional_logic = {
+	type: 'number',
+};
+
 export const settings = {
 	...defaultSettings,
 	title: __( 'Number input field', 'jetpack-forms' ),
@@ -41,4 +51,5 @@ export default {
 	name,
 	settings,
 	form_editor,
+	conditional_logic,
 };

--- a/projects/packages/forms/src/blocks/field-rating/index.js
+++ b/projects/packages/forms/src/blocks/field-rating/index.js
@@ -11,6 +11,16 @@ export const form_editor = {
 	category: 'advanced',
 };
 
+/**
+ * Conditional logic: how this field's value is compared.
+ *
+ * Declared per block so the rule builder can offer the right operators and value
+ * input. A block that omits this simply gets no conditional-logic support.
+ */
+export const conditional_logic = {
+	type: 'number',
+};
+
 export const settings = {
 	...defaultSettings,
 	title: __( 'Rating field', 'jetpack-forms' ),
@@ -60,4 +70,4 @@ export const settings = {
 	},
 };
 
-export default { name, settings, form_editor };
+export default { name, settings, form_editor, conditional_logic };

--- a/projects/packages/forms/src/blocks/field-rating/index.js
+++ b/projects/packages/forms/src/blocks/field-rating/index.js
@@ -18,7 +18,7 @@ export const form_editor = {
  * input. A block that omits this simply gets no conditional-logic support.
  */
 export const conditional_logic = {
-	type: 'number',
+	type: 'rating',
 };
 
 export const settings = {

--- a/projects/packages/forms/src/blocks/field-select/index.js
+++ b/projects/packages/forms/src/blocks/field-select/index.js
@@ -11,6 +11,16 @@ export const form_editor = {
 	category: 'choice',
 };
 
+/**
+ * Conditional logic: how this field's value is compared.
+ *
+ * Declared per block so the rule builder can offer the right operators and value
+ * input. A block that omits this simply gets no conditional-logic support.
+ */
+export const conditional_logic = {
+	type: 'choice',
+};
+
 export const settings = {
 	...defaultSettings,
 	title: __( 'Dropdown field', 'jetpack-forms' ),
@@ -62,4 +72,5 @@ export default {
 	name,
 	settings,
 	form_editor,
+	conditional_logic,
 };

--- a/projects/packages/forms/src/blocks/field-single-choice/index.js
+++ b/projects/packages/forms/src/blocks/field-single-choice/index.js
@@ -11,6 +11,16 @@ export const form_editor = {
 	category: 'choice',
 };
 
+/**
+ * Conditional logic: how this field's value is compared.
+ *
+ * Declared per block so the rule builder can offer the right operators and value
+ * input. A block that omits this simply gets no conditional-logic support.
+ */
+export const conditional_logic = {
+	type: 'choice',
+};
+
 export const settings = {
 	...defaultSettings,
 	title: __( 'Single choice (radio)', 'jetpack-forms' ),
@@ -68,4 +78,5 @@ export default {
 	name,
 	settings,
 	form_editor,
+	conditional_logic,
 };

--- a/projects/packages/forms/src/blocks/field-slider/index.jsx
+++ b/projects/packages/forms/src/blocks/field-slider/index.jsx
@@ -10,6 +10,16 @@ export const form_editor = {
 	category: 'advanced',
 };
 
+/**
+ * Conditional logic: how this field's value is compared.
+ *
+ * Declared per block so the rule builder can offer the right operators and value
+ * input. A block that omits this simply gets no conditional-logic support.
+ */
+export const conditional_logic = {
+	type: 'number',
+};
+
 export const settings = {
 	...defaultSettings,
 	title: __( 'Slider field', 'jetpack-forms' ),
@@ -85,4 +95,5 @@ export default {
 	name,
 	settings,
 	form_editor,
+	conditional_logic,
 };

--- a/projects/packages/forms/src/blocks/field-telephone/index.jsx
+++ b/projects/packages/forms/src/blocks/field-telephone/index.jsx
@@ -12,6 +12,16 @@ export const form_editor = {
 	category: 'contact-info',
 };
 
+/**
+ * Conditional logic: how this field's value is compared.
+ *
+ * Declared per block so the rule builder can offer the right operators and value
+ * input. A block that omits this simply gets no conditional-logic support.
+ */
+export const conditional_logic = {
+	type: 'string',
+};
+
 export const settings = {
 	...defaultSettings,
 	title: __( 'Phone number field', 'jetpack-forms' ),
@@ -74,4 +84,5 @@ export default {
 	name,
 	settings,
 	form_editor,
+	conditional_logic,
 };

--- a/projects/packages/forms/src/blocks/field-text/index.js
+++ b/projects/packages/forms/src/blocks/field-text/index.js
@@ -11,6 +11,16 @@ export const form_editor = {
 	category: 'basic',
 };
 
+/**
+ * Conditional logic: how this field's value is compared.
+ *
+ * Declared per block so the rule builder can offer the right operators and value
+ * input. A block that omits this simply gets no conditional-logic support.
+ */
+export const conditional_logic = {
+	type: 'string',
+};
+
 export const settings = {
 	...defaultSettings,
 	title: __( 'Text input field', 'jetpack-forms' ),
@@ -41,4 +51,5 @@ export default {
 	name,
 	settings,
 	form_editor,
+	conditional_logic,
 };

--- a/projects/packages/forms/src/blocks/field-textarea/index.js
+++ b/projects/packages/forms/src/blocks/field-textarea/index.js
@@ -11,6 +11,16 @@ export const form_editor = {
 	category: 'basic',
 };
 
+/**
+ * Conditional logic: how this field's value is compared.
+ *
+ * Declared per block so the rule builder can offer the right operators and value
+ * input. A block that omits this simply gets no conditional-logic support.
+ */
+export const conditional_logic = {
+	type: 'string',
+};
+
 export const settings = {
 	...defaultSettings,
 	title: __( 'Multi-line text field', 'jetpack-forms' ),
@@ -46,4 +56,5 @@ export default {
 	name,
 	settings,
 	form_editor,
+	conditional_logic,
 };

--- a/projects/packages/forms/src/blocks/field-time/index.js
+++ b/projects/packages/forms/src/blocks/field-time/index.js
@@ -10,6 +10,16 @@ export const form_editor = {
 	category: 'advanced',
 };
 
+/**
+ * Conditional logic: how this field's value is compared.
+ *
+ * Declared per block so the rule builder can offer the right operators and value
+ * input. A block that omits this simply gets no conditional-logic support.
+ */
+export const conditional_logic = {
+	type: 'time',
+};
+
 export const settings = {
 	...defaultSettings,
 	title: __( 'Time input field', 'jetpack-forms' ),
@@ -39,4 +49,5 @@ export default {
 	name,
 	settings,
 	form_editor,
+	conditional_logic,
 };

--- a/projects/packages/forms/src/blocks/field-url/index.jsx
+++ b/projects/packages/forms/src/blocks/field-url/index.jsx
@@ -12,6 +12,16 @@ export const form_editor = {
 	category: 'contact-info',
 };
 
+/**
+ * Conditional logic: how this field's value is compared.
+ *
+ * Declared per block so the rule builder can offer the right operators and value
+ * input. A block that omits this simply gets no conditional-logic support.
+ */
+export const conditional_logic = {
+	type: 'string',
+};
+
 export const settings = {
 	...defaultSettings,
 	title: __( 'Website field', 'jetpack-forms' ),
@@ -50,4 +60,5 @@ export default {
 	name,
 	settings,
 	form_editor,
+	conditional_logic,
 };

--- a/projects/packages/forms/src/blocks/shared/conditional-logic/util/field-types.ts
+++ b/projects/packages/forms/src/blocks/shared/conditional-logic/util/field-types.ts
@@ -1,0 +1,181 @@
+/*
+ * Kept free of `@wordpress/i18n` on purpose: this module is imported by the front-end
+ * form runtime, which builds as a WordPress script module, and script modules cannot
+ * import that package yet. Translated operator labels live in ./operator-labels.ts,
+ * which only the editor loads.
+ */
+
+/**
+ * Operator wire strings shared with the PHP evaluator.
+ *
+ * This object is the source of truth: `Conditional_Logic`'s `OP_*` constants must
+ * match these values exactly, and `Conditional_Logic_Parity_Test` parses this file
+ * to enforce that. Changing a value here is a breaking change to stored rules.
+ */
+export const OPERATORS = {
+	IS: 'is',
+	IS_NOT: 'is_not',
+	CONTAINS: 'contains',
+	DOES_NOT_CONTAIN: 'does_not_contain',
+	IS_EMPTY: 'is_empty',
+	IS_NOT_EMPTY: 'is_not_empty',
+	EQUALS: 'equals',
+	NOT_EQUALS: 'not_equals',
+	GREATER_THAN: 'greater_than',
+	LESS_THAN: 'less_than',
+	GTE: 'gte',
+	LTE: 'lte',
+	BEFORE: 'before',
+	AFTER: 'after',
+	IS_CHECKED: 'is_checked',
+	IS_NOT_CHECKED: 'is_not_checked',
+} as const;
+
+export type Operator = ( typeof OPERATORS )[ keyof typeof OPERATORS ];
+
+/**
+ * A field's comparison behavior, derived from its block type. Several blocks share a
+ * key: a slider and a rating both compare numerically, a select and a radio group both
+ * compare against a fixed option list.
+ */
+export type TypeKey =
+	| 'string'
+	| 'choice'
+	| 'multichoice'
+	| 'number'
+	| 'date'
+	| 'time'
+	| 'boolean'
+	| 'hidden'
+	| 'file';
+
+export type ValueInputKind = 'text' | 'options' | 'number' | 'date' | 'time' | 'none';
+
+/**
+ * Operators that compare a field against nothing, so the UI renders no value input and
+ * the evaluators ignore `rule.value` entirely.
+ */
+const OPERATORS_WITHOUT_VALUE: Set< string > = new Set( [
+	OPERATORS.IS_EMPTY,
+	OPERATORS.IS_NOT_EMPTY,
+	OPERATORS.IS_CHECKED,
+	OPERATORS.IS_NOT_CHECKED,
+] );
+
+/**
+ * Front-end and submission-side lookup: shortcode `type` to comparison behavior.
+ *
+ * Fields flatten to `[contact-field type="…"]` before rendering, so the browser runtime and
+ * PHP see these strings rather than block names. Mirrored by
+ * `Conditional_Logic::TYPE_KEY_BY_FIELD_TYPE`.
+ *
+ * `field-telephone` emits `telephone` or `phone` depending on its country-selector setting,
+ * so both appear here.
+ */
+export const TYPE_KEY_BY_FIELD_TYPE: Record< string, TypeKey > = {
+	text: 'string',
+	name: 'string',
+	email: 'string',
+	url: 'string',
+	textarea: 'string',
+	telephone: 'string',
+	phone: 'string',
+	select: 'choice',
+	radio: 'choice',
+	'image-select': 'choice',
+	'checkbox-multiple': 'multichoice',
+	number: 'number',
+	slider: 'number',
+	rating: 'number',
+	date: 'date',
+	time: 'time',
+	checkbox: 'boolean',
+	consent: 'boolean',
+	hidden: 'hidden',
+	file: 'file',
+};
+
+const OPERATORS_BY_TYPE_KEY: Record< TypeKey, Operator[] > = {
+	string: [
+		OPERATORS.IS,
+		OPERATORS.IS_NOT,
+		OPERATORS.CONTAINS,
+		OPERATORS.DOES_NOT_CONTAIN,
+		OPERATORS.IS_EMPTY,
+		OPERATORS.IS_NOT_EMPTY,
+	],
+	choice: [ OPERATORS.IS, OPERATORS.IS_NOT, OPERATORS.IS_EMPTY, OPERATORS.IS_NOT_EMPTY ],
+	multichoice: [
+		OPERATORS.CONTAINS,
+		OPERATORS.DOES_NOT_CONTAIN,
+		OPERATORS.IS_EMPTY,
+		OPERATORS.IS_NOT_EMPTY,
+	],
+	number: [
+		OPERATORS.EQUALS,
+		OPERATORS.NOT_EQUALS,
+		OPERATORS.GREATER_THAN,
+		OPERATORS.LESS_THAN,
+		OPERATORS.GTE,
+		OPERATORS.LTE,
+		OPERATORS.IS_EMPTY,
+		OPERATORS.IS_NOT_EMPTY,
+	],
+	date: [ OPERATORS.IS, OPERATORS.IS_NOT, OPERATORS.BEFORE, OPERATORS.AFTER ],
+	time: [ OPERATORS.IS, OPERATORS.IS_NOT, OPERATORS.BEFORE, OPERATORS.AFTER ],
+	boolean: [ OPERATORS.IS_CHECKED, OPERATORS.IS_NOT_CHECKED ],
+	hidden: [ OPERATORS.IS, OPERATORS.IS_NOT, OPERATORS.CONTAINS ],
+	file: [ OPERATORS.IS_EMPTY, OPERATORS.IS_NOT_EMPTY ],
+};
+
+const VALUE_INPUT_BY_TYPE_KEY: Record< TypeKey, ValueInputKind > = {
+	string: 'text',
+	choice: 'options',
+	multichoice: 'options',
+	number: 'number',
+	date: 'date',
+	time: 'time',
+	boolean: 'none',
+	hidden: 'text',
+	file: 'none',
+};
+
+/**
+ * Resolve a shortcode field type to its comparison behavior.
+ *
+ * @param fieldType - The shortcode `type` attribute, e.g. `checkbox-multiple`.
+ * @return The type key; unknown types compare textually rather than being dropped.
+ */
+export const getTypeKeyForFieldType = ( fieldType?: string ): TypeKey => {
+	if ( ! fieldType ) {
+		return 'string';
+	}
+	return TYPE_KEY_BY_FIELD_TYPE[ fieldType ] ?? 'string';
+};
+
+/**
+ * Operators offered for a given comparison behavior.
+ *
+ * @param typeKey - The field's type key.
+ * @return Ordered operator list; empty for an unrecognized key.
+ */
+export const getOperatorsForTypeKey = ( typeKey: TypeKey | string ): Operator[] =>
+	OPERATORS_BY_TYPE_KEY[ typeKey as TypeKey ] ?? [];
+
+/**
+ * Which value control the rule builder should render for a comparison behavior.
+ *
+ * @param typeKey - The field's type key.
+ * @return The value input kind; falls back to a plain text box.
+ */
+export const getValueInputForTypeKey = ( typeKey: TypeKey | string ): ValueInputKind =>
+	VALUE_INPUT_BY_TYPE_KEY[ typeKey as TypeKey ] ?? 'text';
+
+/**
+ * Whether an operator compares against a value the author must supply.
+ *
+ * @param operator - The operator wire string.
+ * @return True when a value input is required.
+ */
+export const operatorNeedsValue = ( operator: Operator | string ): boolean =>
+	! OPERATORS_WITHOUT_VALUE.has( operator );

--- a/projects/packages/forms/src/blocks/shared/conditional-logic/util/field-types.ts
+++ b/projects/packages/forms/src/blocks/shared/conditional-logic/util/field-types.ts
@@ -35,8 +35,9 @@ export type Operator = ( typeof OPERATORS )[ keyof typeof OPERATORS ];
 
 /**
  * A field's comparison behavior, derived from its block type. Several blocks share a
- * key: a slider and a rating both compare numerically, a select and a radio group both
- * compare against a fixed option list.
+ * key: a select and a radio group both compare against a fixed option list. A rating
+ * compares numerically but is not a `number`: it submits `selected/max`, e.g. `4/5`, and
+ * offers its own scale as the values to compare against.
  */
 export type TypeKey =
 	| 'string'
@@ -47,7 +48,8 @@ export type TypeKey =
 	| 'time'
 	| 'boolean'
 	| 'hidden'
-	| 'file';
+	| 'file'
+	| 'rating';
 
 export type ValueInputKind = 'text' | 'options' | 'number' | 'date' | 'time' | 'none';
 
@@ -86,7 +88,7 @@ export const TYPE_KEY_BY_FIELD_TYPE: Record< string, TypeKey > = {
 	'checkbox-multiple': 'multichoice',
 	number: 'number',
 	slider: 'number',
-	rating: 'number',
+	rating: 'rating',
 	date: 'date',
 	time: 'time',
 	checkbox: 'boolean',
@@ -108,6 +110,16 @@ const OPERATORS_BY_TYPE_KEY: Record< TypeKey, Operator[] > = {
 	multichoice: [
 		OPERATORS.CONTAINS,
 		OPERATORS.DOES_NOT_CONTAIN,
+		OPERATORS.IS_EMPTY,
+		OPERATORS.IS_NOT_EMPTY,
+	],
+	rating: [
+		OPERATORS.EQUALS,
+		OPERATORS.NOT_EQUALS,
+		OPERATORS.GREATER_THAN,
+		OPERATORS.LESS_THAN,
+		OPERATORS.GTE,
+		OPERATORS.LTE,
 		OPERATORS.IS_EMPTY,
 		OPERATORS.IS_NOT_EMPTY,
 	],
@@ -133,6 +145,9 @@ const VALUE_INPUT_BY_TYPE_KEY: Record< TypeKey, ValueInputKind > = {
 	choice: 'options',
 	multichoice: 'options',
 	number: 'number',
+	// The field carries its own scale, so the rule builder lists 1..max rather than a free
+	// number box that would accept 6 stars out of 5.
+	rating: 'options',
 	date: 'date',
 	time: 'time',
 	boolean: 'none',

--- a/projects/packages/forms/src/blocks/shared/conditional-logic/util/operator-labels.ts
+++ b/projects/packages/forms/src/blocks/shared/conditional-logic/util/operator-labels.ts
@@ -1,0 +1,42 @@
+/*
+ * Translated operator labels for the conditional-logic rule builder.
+ *
+ * Separate from ./field-types.ts because that module is shared with the front-end form
+ * runtime, which builds as a WordPress script module and cannot import `@wordpress/i18n`.
+ * Only the editor imports this file.
+ */
+
+import { __ } from '@wordpress/i18n';
+import { OPERATORS } from './field-types';
+import type { Operator } from './field-types';
+
+/**
+ * Human-readable label for every operator, keyed by wire string.
+ */
+export const OPERATOR_LABELS: Record< Operator, string > = {
+	[ OPERATORS.IS ]: __( 'is', 'jetpack-forms' ),
+	[ OPERATORS.IS_NOT ]: __( 'is not', 'jetpack-forms' ),
+	[ OPERATORS.CONTAINS ]: __( 'contains', 'jetpack-forms' ),
+	[ OPERATORS.DOES_NOT_CONTAIN ]: __( 'does not contain', 'jetpack-forms' ),
+	[ OPERATORS.IS_EMPTY ]: __( 'is empty', 'jetpack-forms' ),
+	[ OPERATORS.IS_NOT_EMPTY ]: __( 'is not empty', 'jetpack-forms' ),
+	[ OPERATORS.EQUALS ]: __( 'equals', 'jetpack-forms' ),
+	[ OPERATORS.NOT_EQUALS ]: __( 'does not equal', 'jetpack-forms' ),
+	[ OPERATORS.GREATER_THAN ]: __( 'is greater than', 'jetpack-forms' ),
+	[ OPERATORS.LESS_THAN ]: __( 'is less than', 'jetpack-forms' ),
+	[ OPERATORS.GTE ]: __( 'is at least', 'jetpack-forms' ),
+	[ OPERATORS.LTE ]: __( 'is at most', 'jetpack-forms' ),
+	[ OPERATORS.BEFORE ]: __( 'is before', 'jetpack-forms' ),
+	[ OPERATORS.AFTER ]: __( 'is after', 'jetpack-forms' ),
+	[ OPERATORS.IS_CHECKED ]: __( 'is checked', 'jetpack-forms' ),
+	[ OPERATORS.IS_NOT_CHECKED ]: __( 'is not checked', 'jetpack-forms' ),
+};
+
+/**
+ * Label for an operator, falling back to the raw wire string for forward compatibility.
+ *
+ * @param operator - The operator wire string.
+ * @return Translated label.
+ */
+export const getOperatorLabel = ( operator: Operator | string ): string =>
+	OPERATOR_LABELS[ operator as Operator ] ?? operator;

--- a/projects/packages/forms/src/blocks/shared/settings/index.js
+++ b/projects/packages/forms/src/blocks/shared/settings/index.js
@@ -20,6 +20,17 @@ export default {
 			type: 'boolean',
 			default: true,
 		},
+		conditionalLogic: {
+			type: 'object',
+			default: {
+				enabled: false,
+				action: 'show',
+				logicalOperator: 'any',
+				// Keyed by control slug so further condition types (query string, user role,
+				// date and time) become sibling keys rather than a reshape.
+				controls: {},
+			},
+		},
 	},
 	category: 'contact-form',
 	providesContext: {

--- a/projects/packages/forms/src/blocks/shared/settings/index.js
+++ b/projects/packages/forms/src/blocks/shared/settings/index.js
@@ -25,10 +25,13 @@ export default {
 			default: {
 				enabled: false,
 				action: 'show',
+				// Combines the groups with each other; each group combines its own rules.
 				logicalOperator: 'any',
-				// Keyed by control slug so further condition types (query string, user role,
-				// date and time) become sibling keys rather than a reshape.
-				controls: {},
+				// An array, not a map: a map cannot express "any of these AND all of those",
+				// which is where this is heading. The V1 panel writes one group, so showing a
+				// second one later is a panel change rather than a storage change. Rules carry
+				// their own type, so further condition kinds slot into a group instead.
+				groups: [],
 			},
 		},
 	},

--- a/projects/packages/forms/src/class-jetpack-forms.php
+++ b/projects/packages/forms/src/class-jetpack-forms.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Forms;
 
+use Automattic\Jetpack\Feature_Flags\Feature_Flags;
 use Automattic\Jetpack\Forms\ContactForm\Feedback_Source;
 use Automattic\Jetpack\Forms\ContactForm\Util;
 use Automattic\Jetpack\Forms\Dashboard\Dashboard;
@@ -18,9 +19,36 @@ class Jetpack_Forms {
 	const PACKAGE_VERSION = '7.24.0';
 
 	/**
+	 * Name of the feature flag gating field conditional logic.
+	 */
+	const CONDITIONAL_LOGIC_FLAG = 'forms-conditional-logic';
+
+	/**
+	 * Register the package's feature flags.
+	 *
+	 * Registration is unconditional and happens as the package loads, so the full set stays
+	 * discoverable through `Feature_Flags::all()` and nothing can call `is_enabled()` on an
+	 * unregistered flag.
+	 *
+	 * @return void
+	 */
+	public static function register_feature_flags() {
+		Feature_Flags::register(
+			self::CONDITIONAL_LOGIC_FLAG,
+			array(
+				'default'     => false,
+				'description' => 'Show or hide a form field based on the answer to another field.',
+				'owner'       => 'jetpack-forms',
+			)
+		);
+	}
+
+	/**
 	 * Load the contact form module.
 	 */
 	public static function load_contact_form() {
+		self::register_feature_flags();
+
 		Util::init();
 
 		if ( self::is_feedback_dashboard_enabled() ) {
@@ -127,6 +155,22 @@ class Jetpack_Forms {
 		 * @param bool true Whether to enable the Integrations UI. Default true.
 		 */
 		return apply_filters( 'jetpack_forms_is_integrations_enabled', true );
+	}
+
+	/**
+	 * Returns true if field conditional logic is enabled.
+	 *
+	 * One switch for the whole feature: the editor panel, the front-end show/hide, and the
+	 * submission-time enforcement in validation and storage. Gating them together means a
+	 * form can never hide a field from the visitor while still requiring it on submit.
+	 *
+	 * Turning the flag off on a form that already has conditions is safe: the conditions are
+	 * simply ignored, so every field renders, validates and stores as an ordinary field.
+	 *
+	 * @return boolean
+	 */
+	public static function is_conditional_logic_enabled() {
+		return Feature_Flags::is_enabled( self::CONDITIONAL_LOGIC_FLAG );
 	}
 
 	/**

--- a/projects/packages/forms/tests/js/blocks/shared/conditional-logic/block-names.test.js
+++ b/projects/packages/forms/tests/js/blocks/shared/conditional-logic/block-names.test.js
@@ -1,0 +1,105 @@
+import fs from 'fs';
+import path from 'path';
+import { getOperatorsForTypeKey } from '../../../../../src/blocks/shared/conditional-logic/util/field-types';
+
+/**
+ * Every field block declares how its value is compared, beside `form_editor`.
+ *
+ * This reads the block sources rather than restating the block list, for two reasons. A new
+ * field block that forgets the declaration is reported here instead of silently getting no
+ * conditional-logic support. And the registered name is taken from the block itself: two
+ * blocks register under a name that differs from their directory — `field-single-choice` as
+ * `jetpack/field-radio`, `field-multiple-choice` as `jetpack/field-checkbox-multiple` — and a
+ * hand-written table got both wrong, which is how both silently lost their panel once.
+ */
+const BLOCKS_DIR = path.join( process.cwd(), 'src/blocks' );
+
+const readFieldBlocks = () =>
+	fs
+		.readdirSync( BLOCKS_DIR )
+		.filter( entry => entry.startsWith( 'field-' ) )
+		.map( dir => {
+			const indexFile = fs
+				.readdirSync( path.join( BLOCKS_DIR, dir ) )
+				.find( file => /^index\.(js|jsx|ts|tsx)$/.test( file ) );
+
+			if ( ! indexFile ) {
+				return null;
+			}
+
+			const source = fs.readFileSync( path.join( BLOCKS_DIR, dir, indexFile ), 'utf8' );
+			const name = source.match( /^(?:export )?const name = '([^']+)'/m );
+			const type = source.match( /export const conditional_logic = \{\s*type: '([a-z]+)'/m );
+
+			return {
+				dir,
+				blockName: name ? `jetpack/${ name[ 1 ] }` : null,
+				type: type ? type[ 1 ] : null,
+				// Declared but not exported would leave it invisible to the lookup.
+				exported: /export default \{[^}]*conditional_logic/s.test( source ),
+			};
+		} )
+		.filter( Boolean );
+
+// The expected comparison behavior of each field block, keyed by registered block name.
+const EXPECTED_TYPES = {
+	'jetpack/field-text': 'string',
+	'jetpack/field-name': 'string',
+	'jetpack/field-email': 'string',
+	'jetpack/field-url': 'string',
+	'jetpack/field-textarea': 'string',
+	'jetpack/field-telephone': 'string',
+	'jetpack/field-select': 'choice',
+	'jetpack/field-radio': 'choice',
+	'jetpack/field-checkbox-multiple': 'multichoice',
+	'jetpack/field-number': 'number',
+	'jetpack/field-slider': 'number',
+	'jetpack/field-rating': 'number',
+	'jetpack/field-date': 'date',
+	'jetpack/field-time': 'time',
+	'jetpack/field-checkbox': 'boolean',
+	'jetpack/field-consent': 'boolean',
+	'jetpack/field-hidden': 'hidden',
+	'jetpack/field-file': 'file',
+};
+
+describe( 'field block conditional-logic declarations', () => {
+	const blocks = readFieldBlocks();
+
+	it( 'finds every field block in the package', () => {
+		expect( blocks ).toHaveLength( 19 );
+		// One block deliberately opts out, see below.
+		expect( Object.keys( EXPECTED_TYPES ) ).toHaveLength( 18 );
+	} );
+
+	/**
+	 * An image-select field submits a JSON document, not the label the rule builder offers,
+	 * so every evaluator would compare the two and never match: `is` permanently false, `is
+	 * not` permanently true. Offering no rule beats offering one that cannot fire.
+	 */
+	it( 'leaves image-select without conditional-logic support', () => {
+		const imageSelect = blocks.find( block => block.dir === 'field-image-select' );
+
+		expect( imageSelect.type ).toBeNull();
+		expect( imageSelect.exported ).toBe( false );
+	} );
+
+	it( 'registers the block names the table expects', () => {
+		const declaring = blocks.filter( block => block.type !== null );
+
+		expect( declaring.map( block => block.blockName ).sort() ).toEqual(
+			Object.keys( EXPECTED_TYPES ).sort()
+		);
+	} );
+
+	it.each(
+		readFieldBlocks()
+			.filter( block => block.type !== null )
+			.map( block => [ block.dir, block ] )
+	)( '%s declares and exports its comparison behavior', ( dir, block ) => {
+		expect( block.type ).toBe( EXPECTED_TYPES[ block.blockName ] );
+		expect( block.exported ).toBe( true );
+		// The declared type must be one the rule builder can offer operators for.
+		expect( getOperatorsForTypeKey( block.type ).length ).toBeGreaterThan( 0 );
+	} );
+} );

--- a/projects/packages/forms/tests/js/blocks/shared/conditional-logic/block-names.test.js
+++ b/projects/packages/forms/tests/js/blocks/shared/conditional-logic/block-names.test.js
@@ -54,7 +54,7 @@ const EXPECTED_TYPES = {
 	'jetpack/field-checkbox-multiple': 'multichoice',
 	'jetpack/field-number': 'number',
 	'jetpack/field-slider': 'number',
-	'jetpack/field-rating': 'number',
+	'jetpack/field-rating': 'rating',
 	'jetpack/field-date': 'date',
 	'jetpack/field-time': 'time',
 	'jetpack/field-checkbox': 'boolean',

--- a/projects/packages/forms/tests/js/blocks/shared/conditional-logic/field-types.test.js
+++ b/projects/packages/forms/tests/js/blocks/shared/conditional-logic/field-types.test.js
@@ -1,0 +1,78 @@
+import {
+	OPERATORS,
+	getOperatorsForTypeKey,
+	getValueInputForTypeKey,
+	operatorNeedsValue,
+} from '../../../../../src/blocks/shared/conditional-logic/util/field-types';
+
+/**
+ * One row per comparison behavior: [ type key, value input kind ].
+ *
+ * Which block declares which type key is not asserted here — the blocks own that, and
+ * block-names.test.js checks it against their source. This file covers what the type key
+ * itself buys you: the operator set and the value input the rule builder renders.
+ */
+const CASES = [
+	[ 'string', 'text' ],
+	[ 'choice', 'options' ],
+	[ 'multichoice', 'options' ],
+	[ 'number', 'number' ],
+	[ 'date', 'date' ],
+	[ 'time', 'time' ],
+	[ 'boolean', 'none' ],
+	[ 'hidden', 'text' ],
+	[ 'file', 'none' ],
+];
+
+const EXPECTED_OPERATORS = {
+	string: [ 'is', 'is_not', 'contains', 'does_not_contain', 'is_empty', 'is_not_empty' ],
+	choice: [ 'is', 'is_not', 'is_empty', 'is_not_empty' ],
+	multichoice: [ 'contains', 'does_not_contain', 'is_empty', 'is_not_empty' ],
+	number: [
+		'equals',
+		'not_equals',
+		'greater_than',
+		'less_than',
+		'gte',
+		'lte',
+		'is_empty',
+		'is_not_empty',
+	],
+	date: [ 'is', 'is_not', 'before', 'after' ],
+	time: [ 'is', 'is_not', 'before', 'after' ],
+	boolean: [ 'is_checked', 'is_not_checked' ],
+	hidden: [ 'is', 'is_not', 'contains' ],
+	file: [ 'is_empty', 'is_not_empty' ],
+};
+
+describe( 'field-types', () => {
+	it( 'covers every comparison behavior a block can declare', () => {
+		expect( CASES.map( ( [ typeKey ] ) => typeKey ).sort() ).toEqual(
+			Object.keys( EXPECTED_OPERATORS ).sort()
+		);
+	} );
+
+	it.each( CASES )( '%s renders a %s value input', ( typeKey, input ) => {
+		expect( getValueInputForTypeKey( typeKey ) ).toBe( input );
+	} );
+
+	it.each( CASES )( '%s exposes its operator set', typeKey => {
+		expect( getOperatorsForTypeKey( typeKey ) ).toEqual( EXPECTED_OPERATORS[ typeKey ] );
+	} );
+
+	it( 'returns an empty operator list for an unknown type key', () => {
+		expect( getOperatorsForTypeKey( 'nonsense' ) ).toEqual( [] );
+		expect( getValueInputForTypeKey( 'nonsense' ) ).toBe( 'text' );
+	} );
+
+	it( 'knows which operators take no value operand', () => {
+		expect( operatorNeedsValue( OPERATORS.IS ) ).toBe( true );
+		expect( operatorNeedsValue( OPERATORS.CONTAINS ) ).toBe( true );
+		expect( operatorNeedsValue( OPERATORS.GREATER_THAN ) ).toBe( true );
+		expect( operatorNeedsValue( OPERATORS.BEFORE ) ).toBe( true );
+		expect( operatorNeedsValue( OPERATORS.IS_EMPTY ) ).toBe( false );
+		expect( operatorNeedsValue( OPERATORS.IS_NOT_EMPTY ) ).toBe( false );
+		expect( operatorNeedsValue( OPERATORS.IS_CHECKED ) ).toBe( false );
+		expect( operatorNeedsValue( OPERATORS.IS_NOT_CHECKED ) ).toBe( false );
+	} );
+} );

--- a/projects/packages/forms/tests/js/blocks/shared/conditional-logic/field-types.test.js
+++ b/projects/packages/forms/tests/js/blocks/shared/conditional-logic/field-types.test.js
@@ -17,6 +17,7 @@ const CASES = [
 	[ 'choice', 'options' ],
 	[ 'multichoice', 'options' ],
 	[ 'number', 'number' ],
+	[ 'rating', 'options' ],
 	[ 'date', 'date' ],
 	[ 'time', 'time' ],
 	[ 'boolean', 'none' ],
@@ -29,6 +30,17 @@ const EXPECTED_OPERATORS = {
 	choice: [ 'is', 'is_not', 'is_empty', 'is_not_empty' ],
 	multichoice: [ 'contains', 'does_not_contain', 'is_empty', 'is_not_empty' ],
 	number: [
+		'equals',
+		'not_equals',
+		'greater_than',
+		'less_than',
+		'gte',
+		'lte',
+		'is_empty',
+		'is_not_empty',
+	],
+	// Compares like a number, but offers its own scale as the values.
+	rating: [
 		'equals',
 		'not_equals',
 		'greater_than',

--- a/projects/packages/forms/tests/js/blocks/shared/conditional-logic/operator-labels.test.js
+++ b/projects/packages/forms/tests/js/blocks/shared/conditional-logic/operator-labels.test.js
@@ -1,0 +1,30 @@
+import { OPERATORS } from '../../../../../src/blocks/shared/conditional-logic/util/field-types';
+import {
+	OPERATOR_LABELS,
+	getOperatorLabel,
+} from '../../../../../src/blocks/shared/conditional-logic/util/operator-labels';
+
+describe( 'operator labels', () => {
+	it( 'labels every operator', () => {
+		const operators = Object.values( OPERATORS );
+		const labelled = Object.keys( OPERATOR_LABELS );
+		expect( labelled.sort() ).toEqual( [ ...operators ].sort() );
+	} );
+
+	// Some labels legitimately read the same as their wire string ("is", "contains",
+	// "equals"), so only blankness is a defect here.
+	it( 'has no blank labels', () => {
+		Object.values( OPERATOR_LABELS ).forEach( label => {
+			expect( typeof label ).toBe( 'string' );
+			expect( label.trim() ).not.toBe( '' );
+		} );
+	} );
+
+	it( 'falls back to the wire string for an unknown operator', () => {
+		expect( getOperatorLabel( 'not_a_real_operator' ) ).toBe( 'not_a_real_operator' );
+	} );
+
+	it( 'returns the label for a known operator', () => {
+		expect( getOperatorLabel( OPERATORS.GREATER_THAN ) ).toBe( 'is greater than' );
+	} );
+} );

--- a/projects/plugins/jetpack/changelog/add-forms-conditional-logic-foundation
+++ b/projects/plugins/jetpack/changelog/add-forms-conditional-logic-foundation
@@ -1,0 +1,3 @@
+Significance: patch
+Type: other
+Comment: Update composer.lock.

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1636,12 +1636,70 @@
             }
         },
         {
+            "name": "automattic/jetpack-feature-flags",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/feature-flags",
+                "reference": "9747cc6b1ec3ece04c835a901e1513e1442b8996"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-feature-flags",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-feature-flags/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "textdomain": "jetpack-feature-flags",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-feature-flags.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Shared utilities for registering and checking lightweight Jetpack feature flags.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
             "name": "automattic/jetpack-forms",
             "version": "dev-trunk",
             "dist": {
                 "type": "path",
                 "url": "../../packages/forms",
-                "reference": "b277a5ada04615aee2dbe69d1321339ca8065a28"
+                "reference": "7dceb3e1f578bc96043f2b614a8eb495c3b40713"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1650,6 +1708,7 @@
                 "automattic/jetpack-connection": "@dev",
                 "automattic/jetpack-device-detection": "@dev",
                 "automattic/jetpack-external-connections": "@dev",
+                "automattic/jetpack-feature-flags": "@dev",
                 "automattic/jetpack-jwt": "@dev",
                 "automattic/jetpack-logo": "@dev",
                 "automattic/jetpack-menu-badges": "@dev",


### PR DESCRIPTION
Fixes FORMS-745

> **Part 1 of 5.** This series splits #50938 into reviewable pieces. Each PR is based on the previous one, so the diff shown here is incremental.
>
> 1. **#50976 — vocabulary and feature flag**
> 2. #50977 — the resolver, in JS and PHP
> 3. #50978 — apply in the browser
> 4. #50979 — server-side render and validation
> 5. #50980 — the editor panel

## Proposed changes

Part 1 of 5 splitting #50938 into reviewable pieces. This is the foundation: the shared vocabulary the editor and the runtime both speak, plus the flag that gates the whole feature. **Nothing renders or evaluates yet.**

* The comparison behaviours a field can have — `string`, `choice`, `multichoice`, `number`, `date`, `time`, `boolean`, `hidden`, `file` — the operators each one offers, and the value input each operator needs.
* The `conditionalLogic` block attribute. Rules are keyed by control slug so that further condition types (query string, user role, date and time) become sibling keys rather than a reshape.
* A `conditional_logic` declaration on each of the 19 field blocks, beside `form_editor` and **outside** the registered block settings, so there is no chance of colliding with core block metadata.
* The `forms-conditional-logic` flag, registered with the `jetpack-feature-flags` package and bridged into the editor, so PHP and JS answer from one source under one name.

Declaring support per block is what makes the rest of the series safe to land incrementally: a block that omits the declaration simply gets no conditional-logic support.

### Review notes

`block-names.test.js` reads the block sources rather than restating the block list. Two blocks register under a name that differs from their directory — `field-single-choice` as `jetpack/field-radio`, `field-multiple-choice` as `jetpack/field-checkbox-multiple` — and a hand-written table got both wrong, silently dropping the panel for those two.

## Related product discussion/links

* https://wp.me/p1HpG7-xBk

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Nothing is user-visible in this PR — the flag is off and no code path consumes the vocabulary yet. Verification is the test suite:

* `jetpack test js packages/forms` — the operator/type table and the per-block declarations
* `jetpack test php packages/forms`

To confirm the flag is wired, on a site with the package installed:

* `wp eval 'echo Automattic\Jetpack\Forms\Jetpack_Forms::is_conditional_logic_enabled() ? "on" : "off";'` → `off`
* Add `add_filter( 'jetpack_feature_flag_enabled_forms-conditional-logic', '__return_true' );` in a mu-plugin → `on`

