### PR TITLE
Forms: conditional logic (2/5) — the resolver, in JS and PHP

### DIFF
--- a/projects/packages/forms/changelog/add-forms-conditional-logic-resolver
+++ b/projects/packages/forms/changelog/add-forms-conditional-logic-resolver
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add the resolver that decides which form fields conditional logic hides. No user-facing change on its own.

--- a/projects/packages/forms/src/blocks/shared/conditional-logic/util/evaluate.ts
+++ b/projects/packages/forms/src/blocks/shared/conditional-logic/util/evaluate.ts
@@ -1,0 +1,460 @@
+/*
+ * Conditional-logic evaluation for Jetpack form fields.
+ *
+ * Mirrors the PHP implementation in src/contact-form/class-conditional-logic.php and MUST
+ * stay in sync with it: the browser decides what to show, PHP decides what to validate and
+ * store, and a disagreement between them either drops a real answer or leaks a hidden one.
+ * Conditional_Logic_Parity_Test guards the operator vocabulary.
+ */
+
+import { OPERATORS, getTypeKeyForFieldType, operatorNeedsValue } from './field-types';
+import type { Operator, TypeKey } from './field-types';
+
+export type Rule = {
+	field: string;
+	operator: Operator | string;
+	value?: unknown;
+};
+
+export type ConditionalLogic = {
+	enabled?: boolean;
+	action?: 'show' | 'hide';
+	logicalOperator?: 'any' | 'all';
+	controls?: {
+		fieldValue?: { rules?: Rule[] };
+	};
+};
+
+export type FormValues = Record< string, unknown >;
+
+export type FieldDescriptor = {
+	logic: ConditionalLogic | null;
+	/**
+	 * The field's shortcode `type`, e.g. `checkbox-multiple` — not a TypeKey.
+	 *
+	 * Deliberately the same vocabulary the PHP evaluator takes, so the two mirrors accept
+	 * identical inputs and a fix can be ported between them without translating arguments.
+	 */
+	type: string;
+	/**
+	 * A date field's `dateformat`, e.g. `dd/mm/yy`.
+	 *
+	 * The field writes its value in this format, so the comparison has to read it the same
+	 * way. Absent for every other field type.
+	 */
+	format?: string;
+};
+
+/**
+ * Reduce a submitted value to a comparable string, for the type keys that compare textually.
+ *
+ * @param value - The submitted value.
+ * @return Comparable string; empty for values with no sensible text form.
+ */
+const toComparableString = ( value: unknown ): string => {
+	if ( value === null || value === undefined ) {
+		return '';
+	}
+	if ( typeof value === 'boolean' ) {
+		return value ? '1' : '';
+	}
+	if ( Array.isArray( value ) ) {
+		return value.map( toComparableString ).join( ',' );
+	}
+	if ( typeof value === 'object' ) {
+		return '';
+	}
+	return String( value );
+};
+
+/**
+ * Whether a submitted value counts as unanswered.
+ *
+ * @param value - The submitted value.
+ * @return True when the field has no answer.
+ */
+const isEmptyValue = ( value: unknown ): boolean => {
+	if ( value === null || value === undefined ) {
+		return true;
+	}
+	if ( typeof value === 'string' ) {
+		return '' === value.trim();
+	}
+	if ( typeof value === 'boolean' ) {
+		return ! value;
+	}
+	if ( Array.isArray( value ) ) {
+		return value.every( isEmptyValue );
+	}
+	if ( typeof value === 'object' ) {
+		return Object.values( value as Record< string, unknown > ).every( isEmptyValue );
+	}
+	return false;
+};
+
+/**
+ * Normalize a multi-select value into a list of selected option strings.
+ *
+ * Membership comparison exists so `contains "Blue"` does not match an option named
+ * "Blueberry", and so an option containing a comma cannot corrupt the comparison.
+ *
+ * @param value - The submitted value.
+ * @return Selected options, trimmed, with blanks removed.
+ */
+const toSelectionList = ( value: unknown ): string[] => {
+	const raw = Array.isArray( value ) ? value : [ value ];
+	const list: string[] = [];
+	raw.forEach( item => {
+		const text = toComparableString( item ).trim();
+		if ( '' !== text ) {
+			list.push( text );
+		}
+	} );
+	return list;
+};
+
+/**
+ * Parse both sides of a numeric comparison.
+ *
+ * @param actual   - The submitted value.
+ * @param expected - The value configured on the rule.
+ * @return Both sides as numbers, or null when either side is not numeric.
+ */
+const toNumericPair = ( actual: unknown, expected: unknown ): [ number, number ] | null => {
+	const left = toComparableString( actual ).trim();
+	const right = toComparableString( expected ).trim();
+	if ( '' === left || '' === right ) {
+		return null;
+	}
+	const leftNumber = Number( left );
+	const rightNumber = Number( right );
+	if ( ! Number.isFinite( leftNumber ) || ! Number.isFinite( rightNumber ) ) {
+		return null;
+	}
+	return [ leftNumber, rightNumber ];
+};
+
+/**
+ * Parse both sides of a date or time comparison into comparable numbers.
+ *
+ * Times are compared as minutes since midnight so a bare `HH:MM` needs no date context.
+ *
+ * @param actual   - The submitted value.
+ * @param expected - The value configured on the rule.
+ * @param typeKey  - Either `date` or `time`.
+ * @return Both sides as numbers, or null when either side cannot be parsed.
+ */
+/**
+ * Parse a date into a comparable YYYYMMDD integer.
+ *
+ * Deliberately not Date.parse(). It reads a bare `YYYY-MM-DD` as UTC but `mm/dd/yy` as local
+ * time, so PHP's site-local reading and this one disagreed by the visitor's UTC offset: `is`
+ * was false here while `after` was true on the server. A `dd/mm/yy` field was worse -- neither
+ * engine could read `31/12/2026`, so a show-rule hid its field permanently and the answer was
+ * dropped at storage.
+ *
+ * The field's own format decides how to read the value, the same way the datepicker wrote it.
+ * A rule's value always arrives as ISO, since the rule builder uses a native date input.
+ *
+ * @param text   - Date text.
+ * @param format - Field date format: `mm/dd/yy`, `dd/mm/yy` or `yy-mm-dd`.
+ * @return YYYYMMDD, or null when the text does not match.
+ */
+const parseDate = ( text: string, format: string ): number | null => {
+	const toInt = ( year: number, month: number, day: number ): number | null =>
+		month < 1 || month > 12 || day < 1 || day > 31 ? null : year * 10000 + month * 100 + day;
+
+	// ISO first: the rule side is always ISO, and it is the default field format.
+	const iso = text.match( /^(\d{4})-(\d{1,2})-(\d{1,2})$/ );
+	if ( iso ) {
+		return toInt( Number( iso[ 1 ] ), Number( iso[ 2 ] ), Number( iso[ 3 ] ) );
+	}
+
+	const parts = text.match( /^(\d{1,4})[/.-](\d{1,2})[/.-](\d{1,4})$/ );
+	if ( ! parts ) {
+		return null;
+	}
+
+	const [ , a, b, c ] = parts.map( Number ) as unknown as number[];
+
+	// jQuery UI tokens, as used by the field: `yy` is the four-digit year.
+	switch ( format ) {
+		case 'dd/mm/yy':
+			return toInt( c, b, a );
+		case 'mm/dd/yy':
+			return toInt( c, a, b );
+		default:
+			return toInt( a, b, c );
+	}
+};
+
+const toTemporalPair = (
+	actual: unknown,
+	expected: unknown,
+	typeKey: TypeKey,
+	format = ''
+): [ number, number ] | null => {
+	const parse = ( value: unknown, valueFormat: string ): number | null => {
+		const text = toComparableString( value ).trim();
+		if ( '' === text ) {
+			return null;
+		}
+		if ( 'time' === typeKey ) {
+			const match = text.match( /^(\d{1,2}):(\d{2})/ );
+			if ( ! match ) {
+				return null;
+			}
+			return Number( match[ 1 ] ) * 60 + Number( match[ 2 ] );
+		}
+		return parseDate( text, valueFormat );
+	};
+
+	// The submitted value is written in the field's format; a rule's value is always ISO.
+	const left = parse( actual, format );
+	const right = parse( expected, '' );
+	if ( left === null || right === null ) {
+		return null;
+	}
+	return [ left, right ];
+};
+
+/**
+ * Evaluate a single rule against the current values.
+ *
+ * @param rule    - The rule to evaluate.
+ * @param typeKey - Comparison behavior of the rule's subject field.
+ * @param actual  - The subject field's current value.
+ * @param format  - The subject field's date format, when it has one.
+ * @return True or false, or null when the rule cannot be evaluated and must be ignored.
+ */
+const evaluateRuleValue = (
+	rule: Rule,
+	typeKey: TypeKey,
+	actual: unknown,
+	format = ''
+): boolean | null => {
+	const operator = rule.operator;
+	const expected = operatorNeedsValue( operator ) ? rule.value ?? '' : '';
+
+	switch ( operator ) {
+		case OPERATORS.IS_EMPTY:
+			return isEmptyValue( actual );
+		case OPERATORS.IS_NOT_EMPTY:
+			return ! isEmptyValue( actual );
+		case OPERATORS.IS_CHECKED:
+			return ! isEmptyValue( actual );
+		case OPERATORS.IS_NOT_CHECKED:
+			return isEmptyValue( actual );
+		default:
+			break;
+	}
+
+	if ( 'multichoice' === typeKey ) {
+		const selection = toSelectionList( actual );
+		const target = toComparableString( expected ).trim();
+		switch ( operator ) {
+			case OPERATORS.CONTAINS:
+				return selection.includes( target );
+			case OPERATORS.DOES_NOT_CONTAIN:
+				return ! selection.includes( target );
+			default:
+				return null;
+		}
+	}
+
+	if ( 'number' === typeKey ) {
+		const pair = toNumericPair( actual, expected );
+		if ( pair === null ) {
+			return false;
+		}
+		const [ left, right ] = pair;
+		switch ( operator ) {
+			case OPERATORS.EQUALS:
+				return left === right;
+			case OPERATORS.NOT_EQUALS:
+				return left !== right;
+			case OPERATORS.GREATER_THAN:
+				return left > right;
+			case OPERATORS.LESS_THAN:
+				return left < right;
+			case OPERATORS.GTE:
+				return left >= right;
+			case OPERATORS.LTE:
+				return left <= right;
+			default:
+				return null;
+		}
+	}
+
+	if ( 'date' === typeKey || 'time' === typeKey ) {
+		const pair = toTemporalPair( actual, expected, typeKey, format );
+		if ( pair === null ) {
+			return false;
+		}
+		const [ left, right ] = pair;
+		switch ( operator ) {
+			case OPERATORS.IS:
+				return left === right;
+			case OPERATORS.IS_NOT:
+				return left !== right;
+			case OPERATORS.BEFORE:
+				return left < right;
+			case OPERATORS.AFTER:
+				return left > right;
+			default:
+				return null;
+		}
+	}
+
+	// string, choice, hidden and file all compare textually.
+	const left = toComparableString( actual );
+	const right = toComparableString( expected );
+	switch ( operator ) {
+		case OPERATORS.IS:
+			return left === right;
+		case OPERATORS.IS_NOT:
+			return left !== right;
+		case OPERATORS.CONTAINS:
+			return '' !== right && left.includes( right );
+		case OPERATORS.DOES_NOT_CONTAIN:
+			return '' === right || ! left.includes( right );
+		default:
+			return null;
+	}
+};
+
+/**
+ * Evaluate a field's conditional logic.
+ *
+ * A rule whose subject field is absent from `fieldTypes` is ignored rather than compared
+ * against an empty value, so deleting an unrelated block cannot silently hide a field.
+ * When every rule is ignored the field stays visible.
+ *
+ * @param logic        - The field's conditional-logic config.
+ * @param fieldTypes   - Map of field id to shortcode field type, for every field in the form.
+ * @param values       - Map of field id to current value.
+ * @param fieldFormats - Map of field id to date format, for date fields.
+ * @return True when the field should be visible.
+ */
+export const evaluateLogic = (
+	logic: ConditionalLogic | null | undefined,
+	fieldTypes: Record< string, string >,
+	values: FormValues,
+	fieldFormats: Record< string, string > = {}
+): boolean => {
+	if ( ! logic || ! logic.enabled ) {
+		return true;
+	}
+
+	const rules = logic.controls?.fieldValue?.rules;
+	if ( ! Array.isArray( rules ) || 0 === rules.length ) {
+		return true;
+	}
+
+	const outcomes: boolean[] = [];
+	rules.forEach( rule => {
+		if ( ! rule || ! rule.field || ! rule.operator ) {
+			return;
+		}
+		if ( ! ( rule.field in fieldTypes ) ) {
+			return; // Subject field no longer exists — ignore this rule.
+		}
+		const typeKey = getTypeKeyForFieldType( fieldTypes[ rule.field ] );
+		// A date field's value is written in its own format, so the comparison needs it.
+		const outcome = evaluateRuleValue(
+			rule,
+			typeKey,
+			values[ rule.field ],
+			fieldFormats[ rule.field ] ?? ''
+		);
+		if ( outcome !== null ) {
+			outcomes.push( outcome );
+		}
+	} );
+
+	if ( 0 === outcomes.length ) {
+		return true;
+	}
+
+	const matched =
+		'all' === logic.logicalOperator ? outcomes.every( Boolean ) : outcomes.some( Boolean );
+
+	return 'hide' === logic.action ? ! matched : matched;
+};
+
+/**
+ * Resolve visibility for every field in a form at once.
+ *
+ * Runs to a fixed point so a hidden field's value reads as empty for everyone else: if the
+ * question was never asked, its answer must not satisfy another field's condition. On
+ * ambiguity — circular rules, or passes exhausted — the field is left visible, because a
+ * stray value in a response is recoverable and a silently discarded answer is not.
+ *
+ * @param fields - Map of field id to its logic and comparison behavior.
+ * @param values - Map of field id to submitted value.
+ * @return Map of field id to visibility.
+ */
+export const resolveVisibility = (
+	fields: Record< string, FieldDescriptor >,
+	values: FormValues
+): Record< string, boolean > => {
+	const ids = Object.keys( fields );
+	const visible: Record< string, boolean > = {};
+	ids.forEach( id => {
+		visible[ id ] = true;
+	} );
+
+	const withLogic = ids.filter( id => fields[ id ]?.logic?.enabled );
+	if ( 0 === withLogic.length ) {
+		return visible;
+	}
+
+	const fieldTypes: Record< string, string > = {};
+	const fieldFormats: Record< string, string > = {};
+	ids.forEach( id => {
+		fieldTypes[ id ] = fields[ id ].type;
+		if ( fields[ id ].format ) {
+			fieldFormats[ id ] = fields[ id ].format as string;
+		}
+	} );
+
+	// One pass per conditional field, plus one to confirm nothing moved. Not clamped to a
+	// constant: that made an acyclic chain deeper than the clamp read as circular and fail
+	// open. The field count is what guarantees convergence, and it cannot exceed the form.
+	const maxPasses = withLogic.length + 1;
+
+	// Fields that change after the opening pass are reacting to another field's change, which
+	// is the signature of an oscillation. Collected across every pass, because a participant in
+	// a cycle need not be the one that happened to flip on the final pass.
+	const unstable = new Set< string >();
+
+	for ( let pass = 0; pass < maxPasses; pass++ ) {
+		const effective: FormValues = {};
+		ids.forEach( id => {
+			effective[ id ] = visible[ id ] ? values[ id ] : '';
+		} );
+
+		let changedCount = 0;
+		withLogic.forEach( id => {
+			const next = evaluateLogic( fields[ id ].logic, fieldTypes, effective, fieldFormats );
+			if ( next !== visible[ id ] ) {
+				visible[ id ] = next;
+				changedCount++;
+				if ( pass > 0 ) {
+					unstable.add( id );
+				}
+			}
+		} );
+
+		if ( 0 === changedCount ) {
+			return visible; // Fixed point.
+		}
+	}
+
+	// Passes exhausted, so the rules are circular. Fail open for everything caught in the cycle.
+	unstable.forEach( id => {
+		visible[ id ] = true;
+	} );
+
+	return visible;
+};

--- a/projects/packages/forms/src/blocks/shared/conditional-logic/util/evaluate.ts
+++ b/projects/packages/forms/src/blocks/shared/conditional-logic/util/evaluate.ts
@@ -14,16 +14,29 @@ export type Rule = {
 	field: string;
 	operator: Operator | string;
 	value?: unknown;
+	/** Defaults to the field-value type when absent. */
+	type?: string;
+};
+
+export type RuleGroup = {
+	/** How this group's own rules combine. */
+	logicalOperator?: 'any' | 'all';
+	rules?: Rule[];
 };
 
 export type ConditionalLogic = {
 	enabled?: boolean;
 	action?: 'show' | 'hide';
+	/** How the groups combine with each other. */
 	logicalOperator?: 'any' | 'all';
-	controls?: {
-		fieldValue?: { rules?: Rule[] };
-	};
+	groups?: RuleGroup[];
 };
+
+/**
+ * The rule type this release understands. Rules of any other type are ignored, so a form
+ * saved by a newer editor degrades to its remaining conditions rather than breaking.
+ */
+const RULE_TYPE_FIELD_VALUE = 'fieldValue';
 
 export type FormValues = Record< string, unknown >;
 
@@ -346,38 +359,60 @@ export const evaluateLogic = (
 		return true;
 	}
 
-	const rules = logic.controls?.fieldValue?.rules;
-	if ( ! Array.isArray( rules ) || 0 === rules.length ) {
+	const groups = Array.isArray( logic.groups ) ? logic.groups : [];
+	if ( 0 === groups.length ) {
 		return true;
 	}
 
-	const outcomes: boolean[] = [];
-	rules.forEach( rule => {
-		if ( ! rule || ! rule.field || ! rule.operator ) {
-			return;
-		}
-		if ( ! ( rule.field in fieldTypes ) ) {
-			return; // Subject field no longer exists — ignore this rule.
-		}
-		const typeKey = getTypeKeyForFieldType( fieldTypes[ rule.field ] );
-		// A date field's value is written in its own format, so the comparison needs it.
-		const outcome = evaluateRuleValue(
-			rule,
-			typeKey,
-			values[ rule.field ],
-			fieldFormats[ rule.field ] ?? ''
-		);
-		if ( outcome !== null ) {
-			outcomes.push( outcome );
+	// Each group reduces its own rules with its own operator; the groups then reduce with the
+	// top-level one. With a single group -- all the V1 panel writes -- the outer reduction is
+	// a no-op, so this behaves exactly as a flat rule list until a second group exists.
+	const groupOutcomes: boolean[] = [];
+
+	groups.forEach( group => {
+		const rules = Array.isArray( group?.rules ) ? group.rules : [];
+		const outcomes: boolean[] = [];
+
+		rules.forEach( rule => {
+			if ( ! rule || ! rule.field || ! rule.operator ) {
+				return;
+			}
+			if ( rule.type && rule.type !== RULE_TYPE_FIELD_VALUE ) {
+				return; // A condition kind this release does not know — ignore it.
+			}
+			if ( ! ( rule.field in fieldTypes ) ) {
+				return; // Subject field no longer exists — ignore this rule.
+			}
+			const typeKey = getTypeKeyForFieldType( fieldTypes[ rule.field ] );
+			// A date field's value is written in its own format, so the comparison needs it.
+			const outcome = evaluateRuleValue(
+				rule,
+				typeKey,
+				values[ rule.field ],
+				fieldFormats[ rule.field ] ?? ''
+			);
+			if ( outcome !== null ) {
+				outcomes.push( outcome );
+			}
+		} );
+
+		// A group with nothing evaluable is ignored, the same way a single unusable rule is,
+		// so deleting a subject field cannot silently hide the field that referenced it.
+		if ( outcomes.length ) {
+			groupOutcomes.push(
+				'all' === group?.logicalOperator ? outcomes.every( Boolean ) : outcomes.some( Boolean )
+			);
 		}
 	} );
 
-	if ( 0 === outcomes.length ) {
+	if ( 0 === groupOutcomes.length ) {
 		return true;
 	}
 
 	const matched =
-		'all' === logic.logicalOperator ? outcomes.every( Boolean ) : outcomes.some( Boolean );
+		'all' === logic.logicalOperator
+			? groupOutcomes.every( Boolean )
+			: groupOutcomes.some( Boolean );
 
 	return 'hide' === logic.action ? ! matched : matched;
 };

--- a/projects/packages/forms/src/blocks/shared/conditional-logic/util/evaluate.ts
+++ b/projects/packages/forms/src/blocks/shared/conditional-logic/util/evaluate.ts
@@ -133,6 +133,19 @@ const toSelectionList = ( value: unknown ): string[] => {
  * @param expected - The value configured on the rule.
  * @return Both sides as numbers, or null when either side is not numeric.
  */
+/**
+ * The selected value of a rating, dropping the scale it was submitted with.
+ *
+ * @param value - The submitted value, `selected/max` or a bare number.
+ * @return The selected part, for numeric comparison.
+ */
+const toRatingValue = ( value: unknown ): string => {
+	const text = toComparableString( value ).trim();
+	const slash = text.indexOf( '/' );
+
+	return slash === -1 ? text : text.slice( 0, slash );
+};
+
 const toNumericPair = ( actual: unknown, expected: unknown ): [ number, number ] | null => {
 	const left = toComparableString( actual ).trim();
 	const right = toComparableString( expected ).trim();
@@ -275,8 +288,12 @@ const evaluateRuleValue = (
 		}
 	}
 
-	if ( 'number' === typeKey ) {
-		const pair = toNumericPair( actual, expected );
+	if ( 'number' === typeKey || 'rating' === typeKey ) {
+		// A rating submits `selected/max`, e.g. `4/5`. The rule stores the bare number, so
+		// only the submitted side needs unpacking -- without it is_numeric/Number see `4/5`,
+		// every comparison returns false, and a rating rule can never match.
+		const submitted = 'rating' === typeKey ? toRatingValue( actual ) : actual;
+		const pair = toNumericPair( submitted, expected );
 		if ( pair === null ) {
 			return false;
 		}

--- a/projects/packages/forms/src/contact-form/class-conditional-logic.php
+++ b/projects/packages/forms/src/contact-form/class-conditional-logic.php
@@ -1,0 +1,566 @@
+<?php
+/**
+ * Conditional Logic evaluator for Jetpack form fields.
+ *
+ * Mirrors the JS implementation in
+ * src/blocks/shared/conditional-logic/util/evaluate.ts and MUST stay in sync.
+ *
+ * The browser decides what a visitor sees; this class decides what gets validated and
+ * stored. A disagreement between the two either discards a real answer or accepts one for
+ * a field that was never shown, so Conditional_Logic_Parity_Test pins the operator
+ * vocabulary and Conditional_Logic_Test mirrors the JS cases one for one.
+ *
+ * Targets PHP 7.2: no arrow functions, no typed properties, no match expressions.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+/**
+ * Pure evaluator for field conditional-logic rules.
+ */
+class Conditional_Logic {
+
+	const OP_IS               = 'is';
+	const OP_IS_NOT           = 'is_not';
+	const OP_CONTAINS         = 'contains';
+	const OP_DOES_NOT_CONTAIN = 'does_not_contain';
+	const OP_IS_EMPTY         = 'is_empty';
+	const OP_IS_NOT_EMPTY     = 'is_not_empty';
+	const OP_EQUALS           = 'equals';
+	const OP_NOT_EQUALS       = 'not_equals';
+	const OP_GREATER_THAN     = 'greater_than';
+	const OP_LESS_THAN        = 'less_than';
+	const OP_GTE              = 'gte';
+	const OP_LTE              = 'lte';
+	const OP_BEFORE           = 'before';
+	const OP_AFTER            = 'after';
+	const OP_IS_CHECKED       = 'is_checked';
+	const OP_IS_NOT_CHECKED   = 'is_not_checked';
+
+	/**
+	 * Shortcode field type to comparison behavior.
+	 *
+	 * Mirrors TYPE_KEY_BY_FIELD_TYPE in
+	 * src/blocks/shared/conditional-logic/util/field-types.ts. `field-telephone` renders as
+	 * either `telephone` or `phone` depending on its country-selector setting, so both appear.
+	 *
+	 * @var array
+	 */
+	const TYPE_KEY_BY_FIELD_TYPE = array(
+		'text'              => 'string',
+		'name'              => 'string',
+		'email'             => 'string',
+		'url'               => 'string',
+		'textarea'          => 'string',
+		'telephone'         => 'string',
+		'phone'             => 'string',
+		'select'            => 'choice',
+		'radio'             => 'choice',
+		'image-select'      => 'choice',
+		'checkbox-multiple' => 'multichoice',
+		'number'            => 'number',
+		'slider'            => 'number',
+		'rating'            => 'number',
+		'date'              => 'date',
+		'time'              => 'time',
+		'checkbox'          => 'boolean',
+		'consent'           => 'boolean',
+		'hidden'            => 'hidden',
+		'file'              => 'file',
+	);
+
+	/**
+	 * Operators that compare against nothing, so `value` is ignored.
+	 *
+	 * @var array
+	 */
+	const OPERATORS_WITHOUT_VALUE = array(
+		self::OP_IS_EMPTY,
+		self::OP_IS_NOT_EMPTY,
+		self::OP_IS_CHECKED,
+		self::OP_IS_NOT_CHECKED,
+	);
+
+	/**
+	 * Resolve a shortcode field type to its comparison behavior.
+	 *
+	 * @param string $field_type The shortcode `type` attribute.
+	 *
+	 * @return string The type key; unknown types compare textually rather than being dropped.
+	 */
+	public static function type_key_for_field_type( $field_type ): string {
+		if ( ! is_string( $field_type ) || '' === $field_type ) {
+			return 'string';
+		}
+
+		return self::TYPE_KEY_BY_FIELD_TYPE[ $field_type ] ?? 'string';
+	}
+
+	/**
+	 * Evaluate a field's conditional logic.
+	 *
+	 * A rule whose subject field is absent from `$field_types` is ignored rather than
+	 * compared against an empty value, so deleting an unrelated block cannot silently hide a
+	 * field. When every rule is ignored the field stays visible.
+	 *
+	 * @param array|null $logic       The field's conditional-logic config.
+	 * @param array      $field_types   Map of field id to shortcode type, for every form field.
+	 * @param array      $form_values   Map of field id to submitted value.
+	 * @param array      $field_formats Map of field id to date format, for date fields.
+	 *
+	 * @return bool True when the field should be visible.
+	 */
+	public static function evaluate( $logic, array $field_types, array $form_values, array $field_formats = array() ): bool {
+		if ( ! is_array( $logic ) || empty( $logic['enabled'] ) ) {
+			return true;
+		}
+
+		$rules = array();
+		if ( isset( $logic['controls']['fieldValue']['rules'] ) && is_array( $logic['controls']['fieldValue']['rules'] ) ) {
+			$rules = $logic['controls']['fieldValue']['rules'];
+		}
+
+		if ( empty( $rules ) ) {
+			return true;
+		}
+
+		$outcomes = array();
+		foreach ( $rules as $rule ) {
+			if ( ! is_array( $rule ) || empty( $rule['field'] ) || empty( $rule['operator'] ) ) {
+				continue;
+			}
+
+			$field_id = (string) $rule['field'];
+			if ( ! array_key_exists( $field_id, $field_types ) ) {
+				continue; // Subject field no longer exists: ignore this rule.
+			}
+
+			$type_key = self::type_key_for_field_type( $field_types[ $field_id ] );
+			$actual   = array_key_exists( $field_id, $form_values ) ? $form_values[ $field_id ] : '';
+			// A date field's value is written in its own format, so the comparison needs it.
+			$format  = isset( $field_formats[ $field_id ] ) ? (string) $field_formats[ $field_id ] : '';
+			$outcome = self::evaluate_rule_value( $rule, $type_key, $actual, $format );
+
+			if ( null !== $outcome ) {
+				$outcomes[] = $outcome;
+			}
+		}
+
+		if ( empty( $outcomes ) ) {
+			return true;
+		}
+
+		$logical_operator = $logic['logicalOperator'] ?? 'any';
+
+		if ( 'all' === $logical_operator ) {
+			$matched = ! in_array( false, $outcomes, true );
+		} else {
+			$matched = in_array( true, $outcomes, true );
+		}
+
+		$action = $logic['action'] ?? 'show';
+
+		return 'hide' === $action ? ! $matched : $matched;
+	}
+
+	/**
+	 * Resolve visibility for every field in a form at once.
+	 *
+	 * Runs to a fixed point so a hidden field's value reads as empty for everyone else: if the
+	 * question was never asked, its answer must not satisfy another field's condition. On
+	 * ambiguity — circular rules, or passes exhausted — the field is left visible, because a
+	 * stray value in a response is recoverable and a silently discarded answer is not.
+	 *
+	 * @param array $fields      Map of field id to `array( 'logic' => array|null, 'type' => string )`.
+	 * @param array $form_values Map of field id to submitted value.
+	 *
+	 * @return array Map of field id to bool visibility.
+	 */
+	public static function resolve_visibility( array $fields, array $form_values ): array {
+		$visible = array();
+		foreach ( $fields as $field_id => $descriptor ) {
+			$visible[ $field_id ] = true;
+		}
+
+		$with_logic  = array();
+		$field_types   = array();
+		$field_formats = array();
+		foreach ( $fields as $field_id => $descriptor ) {
+			$field_types[ $field_id ] = $descriptor['type'] ?? 'text';
+			if ( isset( $descriptor['format'] ) ) {
+				$field_formats[ $field_id ] = (string) $descriptor['format'];
+			}
+			if ( isset( $descriptor['logic'] ) && is_array( $descriptor['logic'] ) && ! empty( $descriptor['logic']['enabled'] ) ) {
+				$with_logic[] = $field_id;
+			}
+		}
+
+		if ( empty( $with_logic ) ) {
+			return $visible;
+		}
+
+		// An acyclic dependency chain settles at least one more level per pass, so one pass
+		// per conditional field, plus one to confirm nothing moved, always reaches the fixed
+		// point unless the rules are circular.
+		//
+		// This used to be clamped to a constant 25, which made that claim false: a chain
+		// deeper than 24 ran out of passes, was read as circular, and failed open with
+		// fields left visible that should have been hidden. The bound is the field count
+		// because that is what actually guarantees convergence -- and it is self-limiting,
+		// since it can only be as large as the form.
+		$max_passes = count( $with_logic ) + 1;
+
+		// Fields that change after the opening pass are reacting to another field's change,
+		// which is the signature of an oscillation. Collected across every pass, because a
+		// participant in a cycle need not be the one that flipped on the final pass.
+		$unstable = array();
+
+		for ( $pass = 0; $pass < $max_passes; $pass++ ) {
+			$effective = array();
+			foreach ( $fields as $field_id => $descriptor ) {
+				$value                  = array_key_exists( $field_id, $form_values ) ? $form_values[ $field_id ] : '';
+				$effective[ $field_id ] = $visible[ $field_id ] ? $value : '';
+			}
+
+			$changed_count = 0;
+			foreach ( $with_logic as $field_id ) {
+				$next = self::evaluate( $fields[ $field_id ]['logic'], $field_types, $effective, $field_formats );
+				if ( $next !== $visible[ $field_id ] ) {
+					$visible[ $field_id ] = $next;
+					++$changed_count;
+					if ( $pass > 0 ) {
+						$unstable[ $field_id ] = true;
+					}
+				}
+			}
+
+			if ( 0 === $changed_count ) {
+				return $visible; // Fixed point.
+			}
+		}
+
+		// Passes exhausted, so the rules are circular. Fail open for everything in the cycle.
+		foreach ( array_keys( $unstable ) as $field_id ) {
+			$visible[ $field_id ] = true;
+		}
+
+		return $visible;
+	}
+
+	/**
+	 * Evaluate a single rule against a submitted value.
+	 *
+	 * @param array  $rule     The rule.
+	 * @param string $type_key Comparison behavior of the rule's subject field.
+	 * @param mixed  $actual   The subject field's current value.
+	 *
+	 * @return bool|null True or false, or null when the rule must be ignored.
+	 */
+	private static function evaluate_rule_value( array $rule, $type_key, $actual, $format = '' ) {
+		$operator = (string) $rule['operator'];
+		$expected = '';
+		if ( ! in_array( $operator, self::OPERATORS_WITHOUT_VALUE, true ) && isset( $rule['value'] ) ) {
+			$expected = $rule['value'];
+		}
+
+		switch ( $operator ) {
+			case self::OP_IS_EMPTY:
+				return self::is_empty_value( $actual );
+			case self::OP_IS_NOT_EMPTY:
+				return ! self::is_empty_value( $actual );
+			case self::OP_IS_CHECKED:
+				return ! self::is_empty_value( $actual );
+			case self::OP_IS_NOT_CHECKED:
+				return self::is_empty_value( $actual );
+		}
+
+		if ( 'multichoice' === $type_key ) {
+			$selection = self::to_selection_list( $actual );
+			$target    = trim( self::to_comparable_string( $expected ) );
+
+			switch ( $operator ) {
+				case self::OP_CONTAINS:
+					return in_array( $target, $selection, true );
+				case self::OP_DOES_NOT_CONTAIN:
+					return ! in_array( $target, $selection, true );
+			}
+
+			return null;
+		}
+
+		if ( 'number' === $type_key ) {
+			$pair = self::to_numeric_pair( $actual, $expected );
+			if ( null === $pair ) {
+				return false;
+			}
+
+			switch ( $operator ) {
+				case self::OP_EQUALS:
+					return $pair[0] === $pair[1];
+				case self::OP_NOT_EQUALS:
+					return $pair[0] !== $pair[1];
+				case self::OP_GREATER_THAN:
+					return $pair[0] > $pair[1];
+				case self::OP_LESS_THAN:
+					return $pair[0] < $pair[1];
+				case self::OP_GTE:
+					return $pair[0] >= $pair[1];
+				case self::OP_LTE:
+					return $pair[0] <= $pair[1];
+			}
+
+			return null;
+		}
+
+		if ( 'date' === $type_key || 'time' === $type_key ) {
+			$pair = self::to_temporal_pair( $actual, $expected, $type_key, $format );
+			if ( null === $pair ) {
+				return false;
+			}
+
+			switch ( $operator ) {
+				case self::OP_IS:
+					return $pair[0] === $pair[1];
+				case self::OP_IS_NOT:
+					return $pair[0] !== $pair[1];
+				case self::OP_BEFORE:
+					return $pair[0] < $pair[1];
+				case self::OP_AFTER:
+					return $pair[0] > $pair[1];
+			}
+
+			return null;
+		}
+
+		// string, choice, hidden and file all compare textually.
+		$left  = self::to_comparable_string( $actual );
+		$right = self::to_comparable_string( $expected );
+
+		switch ( $operator ) {
+			case self::OP_IS:
+				return $left === $right;
+			case self::OP_IS_NOT:
+				return $left !== $right;
+			case self::OP_CONTAINS:
+				return '' !== $right && false !== strpos( $left, $right );
+			case self::OP_DOES_NOT_CONTAIN:
+				return '' === $right || false === strpos( $left, $right );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Normalize a multi-select value into a list of selected option strings.
+	 *
+	 * Membership comparison exists so `contains "Blue"` does not match an option named
+	 * "Blueberry", and so an option containing a comma cannot corrupt the comparison.
+	 *
+	 * @param mixed $value The submitted value.
+	 *
+	 * @return array Selected options, trimmed, with blanks removed.
+	 */
+	private static function to_selection_list( $value ): array {
+		$raw  = is_array( $value ) ? $value : array( $value );
+		$list = array();
+
+		foreach ( $raw as $item ) {
+			$text = trim( self::to_comparable_string( $item ) );
+			if ( '' !== $text ) {
+				$list[] = $text;
+			}
+		}
+
+		return $list;
+	}
+
+	/**
+	 * Parse both sides of a numeric comparison.
+	 *
+	 * @param mixed $actual   The submitted value.
+	 * @param mixed $expected The value configured on the rule.
+	 *
+	 * @return array|null Both sides as floats, or null when either side is not numeric.
+	 */
+	private static function to_numeric_pair( $actual, $expected ) {
+		$left  = trim( self::to_comparable_string( $actual ) );
+		$right = trim( self::to_comparable_string( $expected ) );
+
+		if ( '' === $left || '' === $right || ! is_numeric( $left ) || ! is_numeric( $right ) ) {
+			return null;
+		}
+
+		return array( (float) $left, (float) $right );
+	}
+
+	/**
+	 * Parse both sides of a date or time comparison into comparable numbers.
+	 *
+	 * Times become minutes since midnight, so a bare `HH:MM` needs no date context.
+	 *
+	 * @param mixed  $actual   The submitted value.
+	 * @param mixed  $expected The value configured on the rule.
+	 * @param string $type_key Either `date` or `time`.
+	 *
+	 * @return array|null Both sides as ints, or null when either side cannot be parsed.
+	 */
+	private static function to_temporal_pair( $actual, $expected, $type_key, $format = '' ) {
+		// The submitted value is written in the field's format; a rule's value is always ISO.
+		$left  = self::parse_temporal( $actual, $type_key, $format );
+		$right = self::parse_temporal( $expected, $type_key, '' );
+
+		if ( null === $left || null === $right ) {
+			return null;
+		}
+
+		return array( $left, $right );
+	}
+
+	/**
+	 * Parse one side of a temporal comparison.
+	 *
+	 * @param mixed  $value    The value to parse.
+	 * @param string $type_key Either `date` or `time`.
+	 *
+	 * @return int|null Comparable integer, or null when unparseable.
+	 */
+	private static function parse_temporal( $value, $type_key, $format = '' ) {
+		$text = trim( self::to_comparable_string( $value ) );
+		if ( '' === $text ) {
+			return null;
+		}
+
+		if ( 'time' === $type_key ) {
+			if ( ! preg_match( '/^(\d{1,2}):(\d{2})/', $text, $matches ) ) {
+				return null;
+			}
+			return ( (int) $matches[1] ) * 60 + (int) $matches[2];
+		}
+
+		return self::parse_date( $text, $format );
+	}
+
+	/**
+	 * Parse a date into a comparable YYYYMMDD integer.
+	 *
+	 * Deliberately not strtotime(). The browser has to reach the same answer, and its
+	 * Date.parse() reads a bare `YYYY-MM-DD` as UTC while reading `mm/dd/yy` as local time --
+	 * so for any visitor away from UTC the two engines disagreed by the offset, and `is` was
+	 * false on one side while `after` was true on the other. A `dd/mm/yy` field was worse:
+	 * neither engine could read `31/12/2026` at all, so a show-rule hid its field permanently
+	 * and the answer was then dropped at storage.
+	 *
+	 * The field's own format decides how to read the value, the same way the datepicker
+	 * writes it. A rule's value always arrives as ISO, since the rule builder uses a native
+	 * date input, so ISO is accepted regardless of the field's format.
+	 *
+	 * @param string $text   Date text.
+	 * @param string $format Field date format: `mm/dd/yy`, `dd/mm/yy` or `yy-mm-dd`.
+	 *
+	 * @return int|null YYYYMMDD, or null when the text does not match.
+	 */
+	private static function parse_date( $text, $format = '' ) {
+		// ISO first: the rule side is always ISO, and it is the default field format.
+		if ( preg_match( '/^(\d{4})-(\d{1,2})-(\d{1,2})$/', $text, $m ) ) {
+			return self::to_date_int( (int) $m[1], (int) $m[2], (int) $m[3] );
+		}
+
+		if ( ! preg_match( '/^(\d{1,4})[\/.-](\d{1,2})[\/.-](\d{1,4})$/', $text, $m ) ) {
+			return null;
+		}
+
+		// jQuery UI tokens, as used by the field: `yy` is the four-digit year.
+		switch ( $format ) {
+			case 'dd/mm/yy':
+				return self::to_date_int( (int) $m[3], (int) $m[2], (int) $m[1] );
+			case 'mm/dd/yy':
+				return self::to_date_int( (int) $m[3], (int) $m[1], (int) $m[2] );
+			default:
+				return self::to_date_int( (int) $m[1], (int) $m[2], (int) $m[3] );
+		}
+	}
+
+	/**
+	 * Combine date parts, rejecting anything out of range.
+	 *
+	 * @param int $year  Four-digit year.
+	 * @param int $month Month.
+	 * @param int $day   Day.
+	 *
+	 * @return int|null YYYYMMDD, or null when the parts cannot be a date.
+	 */
+	private static function to_date_int( $year, $month, $day ) {
+		if ( $month < 1 || $month > 12 || $day < 1 || $day > 31 ) {
+			return null;
+		}
+
+		return $year * 10000 + $month * 100 + $day;
+	}
+
+	/**
+	 * Reduce any submitted value to a comparable string.
+	 *
+	 * @param mixed $value The submitted value.
+	 *
+	 * @return string Comparable string; empty for values with no sensible text form.
+	 */
+	private static function to_comparable_string( $value ): string {
+		if ( null === $value ) {
+			return '';
+		}
+		if ( is_bool( $value ) ) {
+			return $value ? '1' : '';
+		}
+		if ( is_array( $value ) ) {
+			$parts = array();
+			foreach ( $value as $item ) {
+				$parts[] = self::to_comparable_string( $item );
+			}
+			return implode( ',', $parts );
+		}
+		if ( is_object( $value ) ) {
+			return '';
+		}
+
+		return (string) $value;
+	}
+
+	/**
+	 * Whether a submitted value counts as unanswered.
+	 *
+	 * @param mixed $value The submitted value.
+	 *
+	 * @return bool True when the field has no answer.
+	 */
+	private static function is_empty_value( $value ): bool {
+		if ( null === $value ) {
+			return true;
+		}
+		if ( is_string( $value ) ) {
+			return '' === trim( $value );
+		}
+		if ( is_bool( $value ) ) {
+			return ! $value;
+		}
+		if ( is_array( $value ) ) {
+			foreach ( $value as $item ) {
+				if ( ! self::is_empty_value( $item ) ) {
+					return false;
+				}
+			}
+			return true;
+		}
+		if ( is_object( $value ) ) {
+			foreach ( get_object_vars( $value ) as $item ) {
+				if ( ! self::is_empty_value( $item ) ) {
+					return false;
+				}
+			}
+			return true;
+		}
+
+		return false;
+	}
+}

--- a/projects/packages/forms/src/contact-form/class-conditional-logic.php
+++ b/projects/packages/forms/src/contact-form/class-conditional-logic.php
@@ -184,7 +184,7 @@ class Conditional_Logic {
 			$visible[ $field_id ] = true;
 		}
 
-		$with_logic  = array();
+		$with_logic    = array();
 		$field_types   = array();
 		$field_formats = array();
 		foreach ( $fields as $field_id => $descriptor ) {
@@ -255,6 +255,7 @@ class Conditional_Logic {
 	 * @param array  $rule     The rule.
 	 * @param string $type_key Comparison behavior of the rule's subject field.
 	 * @param mixed  $actual   The subject field's current value.
+	 * @param string $format   Subject field's date format: `mm/dd/yy`, `dd/mm/yy` or `yy-mm-dd`.
 	 *
 	 * @return bool|null True or false, or null when the rule must be ignored.
 	 */
@@ -403,6 +404,7 @@ class Conditional_Logic {
 	 * @param mixed  $actual   The submitted value.
 	 * @param mixed  $expected The value configured on the rule.
 	 * @param string $type_key Either `date` or `time`.
+	 * @param string $format   Subject field's date format: `mm/dd/yy`, `dd/mm/yy` or `yy-mm-dd`.
 	 *
 	 * @return array|null Both sides as ints, or null when either side cannot be parsed.
 	 */
@@ -423,6 +425,7 @@ class Conditional_Logic {
 	 *
 	 * @param mixed  $value    The value to parse.
 	 * @param string $type_key Either `date` or `time`.
+	 * @param string $format   Subject field's date format: `mm/dd/yy`, `dd/mm/yy` or `yy-mm-dd`.
 	 *
 	 * @return int|null Comparable integer, or null when unparseable.
 	 */

--- a/projects/packages/forms/src/contact-form/class-conditional-logic.php
+++ b/projects/packages/forms/src/contact-form/class-conditional-logic.php
@@ -71,7 +71,7 @@ class Conditional_Logic {
 		'checkbox-multiple' => 'multichoice',
 		'number'            => 'number',
 		'slider'            => 'number',
-		'rating'            => 'number',
+		'rating'            => 'rating',
 		'date'              => 'date',
 		'time'              => 'time',
 		'checkbox'          => 'boolean',
@@ -324,8 +324,12 @@ class Conditional_Logic {
 			return null;
 		}
 
-		if ( 'number' === $type_key ) {
-			$pair = self::to_numeric_pair( $actual, $expected );
+		if ( 'number' === $type_key || 'rating' === $type_key ) {
+			// A rating submits `selected/max`, e.g. `4/5`. The rule stores the bare number, so
+			// only the submitted side needs unpacking -- without it is_numeric() sees `4/5`,
+			// every comparison returns false, and a rating rule can never match.
+			$submitted = 'rating' === $type_key ? self::to_rating_value( $actual ) : $actual;
+			$pair      = self::to_numeric_pair( $submitted, $expected );
 			if ( null === $pair ) {
 				return false;
 			}
@@ -418,6 +422,20 @@ class Conditional_Logic {
 	 *
 	 * @return array|null Both sides as floats, or null when either side is not numeric.
 	 */
+	/**
+	 * The selected value of a rating, dropping the scale it was submitted with.
+	 *
+	 * @param mixed $value The submitted value, `selected/max` or a bare number.
+	 *
+	 * @return string The selected part, for numeric comparison.
+	 */
+	private static function to_rating_value( $value ) {
+		$text  = trim( self::to_comparable_string( $value ) );
+		$slash = strpos( $text, '/' );
+
+		return false === $slash ? $text : substr( $text, 0, $slash );
+	}
+
 	private static function to_numeric_pair( $actual, $expected ) {
 		$left  = trim( self::to_comparable_string( $actual ) );
 		$right = trim( self::to_comparable_string( $expected ) );

--- a/projects/packages/forms/src/contact-form/class-conditional-logic.php
+++ b/projects/packages/forms/src/contact-form/class-conditional-logic.php
@@ -40,6 +40,15 @@ class Conditional_Logic {
 	const OP_IS_NOT_CHECKED   = 'is_not_checked';
 
 	/**
+	 * The rule type this release understands.
+	 *
+	 * Rules carry their own type so further condition kinds -- query string, user role, date
+	 * and time -- become new rule types inside the existing groups rather than another
+	 * reshape of the stored attribute.
+	 */
+	const RULE_TYPE_FIELD_VALUE = 'fieldValue';
+
+	/**
 	 * Shortcode field type to comparison behavior.
 	 *
 	 * Mirrors TYPE_KEY_BY_FIELD_TYPE in
@@ -117,47 +126,71 @@ class Conditional_Logic {
 			return true;
 		}
 
-		$rules = array();
-		if ( isset( $logic['controls']['fieldValue']['rules'] ) && is_array( $logic['controls']['fieldValue']['rules'] ) ) {
-			$rules = $logic['controls']['fieldValue']['rules'];
-		}
+		$groups = isset( $logic['groups'] ) && is_array( $logic['groups'] ) ? $logic['groups'] : array();
 
-		if ( empty( $rules ) ) {
+		if ( empty( $groups ) ) {
 			return true;
 		}
 
-		$outcomes = array();
-		foreach ( $rules as $rule ) {
-			if ( ! is_array( $rule ) || empty( $rule['field'] ) || empty( $rule['operator'] ) ) {
+		// Each group reduces its own rules with its own operator; the groups then reduce with
+		// the top-level one. With a single group -- all the V1 panel writes -- the outer
+		// reduction is a no-op, so this behaves exactly as a flat rule list until a second
+		// group exists.
+		$group_outcomes = array();
+
+		foreach ( $groups as $group ) {
+			$rules = isset( $group['rules'] ) && is_array( $group['rules'] ) ? $group['rules'] : array();
+
+			$outcomes = array();
+			foreach ( $rules as $rule ) {
+				if ( ! is_array( $rule ) || empty( $rule['field'] ) || empty( $rule['operator'] ) ) {
+					continue;
+				}
+
+				// A condition kind this release does not know: ignore that rule, so a form
+				// saved by a newer editor degrades to its remaining conditions.
+				if ( ! empty( $rule['type'] ) && self::RULE_TYPE_FIELD_VALUE !== $rule['type'] ) {
+					continue;
+				}
+
+				$field_id = (string) $rule['field'];
+				if ( ! array_key_exists( $field_id, $field_types ) ) {
+					continue; // Subject field no longer exists: ignore this rule.
+				}
+
+				$type_key = self::type_key_for_field_type( $field_types[ $field_id ] );
+				$actual   = array_key_exists( $field_id, $form_values ) ? $form_values[ $field_id ] : '';
+				// A date field's value is written in its own format, so the comparison needs it.
+				$format  = isset( $field_formats[ $field_id ] ) ? (string) $field_formats[ $field_id ] : '';
+				$outcome = self::evaluate_rule_value( $rule, $type_key, $actual, $format );
+
+				if ( null !== $outcome ) {
+					$outcomes[] = $outcome;
+				}
+			}
+
+			// A group with nothing evaluable is ignored, the same way a single unusable rule
+			// is, so deleting a subject field cannot silently hide the field referencing it.
+			if ( empty( $outcomes ) ) {
 				continue;
 			}
 
-			$field_id = (string) $rule['field'];
-			if ( ! array_key_exists( $field_id, $field_types ) ) {
-				continue; // Subject field no longer exists: ignore this rule.
-			}
-
-			$type_key = self::type_key_for_field_type( $field_types[ $field_id ] );
-			$actual   = array_key_exists( $field_id, $form_values ) ? $form_values[ $field_id ] : '';
-			// A date field's value is written in its own format, so the comparison needs it.
-			$format  = isset( $field_formats[ $field_id ] ) ? (string) $field_formats[ $field_id ] : '';
-			$outcome = self::evaluate_rule_value( $rule, $type_key, $actual, $format );
-
-			if ( null !== $outcome ) {
-				$outcomes[] = $outcome;
-			}
+			$group_operator   = $group['logicalOperator'] ?? 'any';
+			$group_outcomes[] = 'all' === $group_operator
+				? ! in_array( false, $outcomes, true )
+				: in_array( true, $outcomes, true );
 		}
 
-		if ( empty( $outcomes ) ) {
+		if ( empty( $group_outcomes ) ) {
 			return true;
 		}
 
 		$logical_operator = $logic['logicalOperator'] ?? 'any';
 
 		if ( 'all' === $logical_operator ) {
-			$matched = ! in_array( false, $outcomes, true );
+			$matched = ! in_array( false, $group_outcomes, true );
 		} else {
-			$matched = in_array( true, $outcomes, true );
+			$matched = in_array( true, $group_outcomes, true );
 		}
 
 		$action = $logic['action'] ?? 'show';

--- a/projects/packages/forms/tests/fixtures/conditional-logic-behaviour.json
+++ b/projects/packages/forms/tests/fixtures/conditional-logic-behaviour.json
@@ -1,0 +1,224 @@
+{
+	"_comment": [
+		"Behavioural parity between the JS and PHP conditional-logic evaluators.",
+		"",
+		"The other parity test pins vocabulary: the operator names and the field type table.",
+		"That is worth having, but it is not where the two implementations actually drift --",
+		"both the Date.parse/strtotime disagreement and the consent value-shape bug passed it.",
+		"Drift lives in the comparisons, so this table pins those instead.",
+		"",
+		"Each case builds a one-rule 'show' condition on a single subject field and asserts the",
+		"field's resulting visibility. Consumed by evaluate.test.js and",
+		"Conditional_Logic_Behaviour_Test.php, which must agree case for case.",
+		"",
+		"Fields: type is the shortcode field type, actual is the submitted value, value is the",
+		"rule's operand, format is the field's dateformat where it has one."
+	],
+	"cases": [
+		{
+			"name": "iso date equal to itself",
+			"type": "date",
+			"format": "yy-mm-dd",
+			"operator": "is",
+			"actual": "2026-03-15",
+			"value": "2026-03-15",
+			"visible": true
+		},
+		{
+			"name": "us format compared against the rule's iso value",
+			"why": "Date.parse read the rule value as UTC and the field value as local, so this was false in the browser and true on the server for anyone away from UTC.",
+			"type": "date",
+			"format": "mm/dd/yy",
+			"operator": "is",
+			"actual": "03/15/2026",
+			"value": "2026-03-15",
+			"visible": true
+		},
+		{
+			"name": "us format after",
+			"type": "date",
+			"format": "mm/dd/yy",
+			"operator": "after",
+			"actual": "03/16/2026",
+			"value": "2026-03-15",
+			"visible": true
+		},
+		{
+			"name": "day-first format, day past the twelfth",
+			"why": "31/12/2026 parsed on neither side, so a show rule hid its field permanently.",
+			"type": "date",
+			"format": "dd/mm/yy",
+			"operator": "is",
+			"actual": "31/12/2026",
+			"value": "2026-12-31",
+			"visible": true
+		},
+		{
+			"name": "day-first format is not read as month-first",
+			"why": "05/06/2026 parsed as May 6 under both engines regardless of the field's format.",
+			"type": "date",
+			"format": "dd/mm/yy",
+			"operator": "is",
+			"actual": "05/06/2026",
+			"value": "2026-06-05",
+			"visible": true
+		},
+		{
+			"name": "day-first format before",
+			"type": "date",
+			"format": "dd/mm/yy",
+			"operator": "before",
+			"actual": "01/12/2026",
+			"value": "2026-12-31",
+			"visible": true
+		},
+		{
+			"name": "unparseable date fails the rule",
+			"type": "date",
+			"format": "yy-mm-dd",
+			"operator": "is",
+			"actual": "not a date",
+			"value": "2026-03-15",
+			"visible": false
+		},
+		{
+			"name": "impossible month fails the rule",
+			"type": "date",
+			"format": "mm/dd/yy",
+			"operator": "is",
+			"actual": "13/01/2026",
+			"value": "2026-01-13",
+			"visible": false
+		},
+		{
+			"name": "time equal",
+			"type": "time",
+			"operator": "is",
+			"actual": "09:30",
+			"value": "09:30",
+			"visible": true
+		},
+		{
+			"name": "time after",
+			"type": "time",
+			"operator": "after",
+			"actual": "10:00",
+			"value": "09:30",
+			"visible": true
+		},
+		{
+			"name": "time before is not after",
+			"type": "time",
+			"operator": "after",
+			"actual": "08:00",
+			"value": "09:30",
+			"visible": false
+		},
+		{
+			"name": "number equality ignores trailing zeros",
+			"why": "is_numeric versus Number() is the other place the two engines can disagree.",
+			"type": "number",
+			"operator": "equals",
+			"actual": "10",
+			"value": "10.0",
+			"visible": true
+		},
+		{
+			"name": "number greater than",
+			"type": "number",
+			"operator": "greater_than",
+			"actual": "11",
+			"value": "10",
+			"visible": true
+		},
+		{
+			"name": "number comparison against an empty value fails",
+			"type": "number",
+			"operator": "equals",
+			"actual": "",
+			"value": "0",
+			"visible": false
+		},
+		{
+			"name": "negative number less than",
+			"type": "number",
+			"operator": "less_than",
+			"actual": "-5",
+			"value": "0",
+			"visible": true
+		},
+		{
+			"name": "a checked consent field reads as checked",
+			"type": "consent",
+			"operator": "is_checked",
+			"actual": "1",
+			"value": "",
+			"visible": true
+		},
+		{
+			"name": "an unchecked consent field does not read as checked",
+			"why": "The browser stored the literal 'Yes' on uncheck, so this read true on screen and false on the server.",
+			"type": "consent",
+			"operator": "is_checked",
+			"actual": "",
+			"value": "",
+			"visible": false
+		},
+		{
+			"name": "an unchecked checkbox reads as not checked",
+			"type": "checkbox",
+			"operator": "is_not_checked",
+			"actual": "",
+			"value": "",
+			"visible": true
+		},
+		{
+			"name": "text contains is case sensitive",
+			"type": "text",
+			"operator": "contains",
+			"actual": "Hello World",
+			"value": "World",
+			"visible": true
+		},
+		{
+			"name": "text contains does not match a different case",
+			"type": "text",
+			"operator": "contains",
+			"actual": "Hello World",
+			"value": "world",
+			"visible": false
+		},
+		{
+			"name": "text is empty",
+			"type": "text",
+			"operator": "is_empty",
+			"actual": "",
+			"value": "",
+			"visible": true
+		},
+		{
+			"name": "text is not empty",
+			"type": "text",
+			"operator": "is_not_empty",
+			"actual": "something",
+			"value": "",
+			"visible": true
+		},
+		{
+			"name": "select is",
+			"type": "select",
+			"operator": "is",
+			"actual": "Large",
+			"value": "Large",
+			"visible": true
+		},
+		{
+			"name": "select is not",
+			"type": "select",
+			"operator": "is_not",
+			"actual": "Small",
+			"value": "Large",
+			"visible": true
+		}
+	]
+}

--- a/projects/packages/forms/tests/fixtures/conditional-logic-behaviour.json
+++ b/projects/packages/forms/tests/fixtures/conditional-logic-behaviour.json
@@ -219,6 +219,39 @@
 			"actual": "Small",
 			"value": "Large",
 			"visible": true
+		},
+		{
+			"name": "rating equals its selected value",
+			"why": "A rating submits \"selected/max\", e.g. 4/5, not a bare number.",
+			"type": "rating",
+			"operator": "equals",
+			"actual": "4/5",
+			"value": "4",
+			"visible": true
+		},
+		{
+			"name": "rating greater than",
+			"type": "rating",
+			"operator": "greater_than",
+			"actual": "4/5",
+			"value": "3",
+			"visible": true
+		},
+		{
+			"name": "rating not greater than",
+			"type": "rating",
+			"operator": "greater_than",
+			"actual": "2/5",
+			"value": "3",
+			"visible": false
+		},
+		{
+			"name": "an unrated field is empty",
+			"type": "rating",
+			"operator": "is_empty",
+			"actual": "",
+			"value": "",
+			"visible": true
 		}
 	]
 }

--- a/projects/packages/forms/tests/js/blocks/shared/conditional-logic/evaluate.test.js
+++ b/projects/packages/forms/tests/js/blocks/shared/conditional-logic/evaluate.test.js
@@ -1,0 +1,405 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import {
+	evaluateLogic,
+	resolveVisibility,
+} from '../../../../../src/blocks/shared/conditional-logic/util/evaluate';
+
+const logic = ( rules, extra = {} ) => ( {
+	enabled: true,
+	action: 'show',
+	logicalOperator: 'all',
+	controls: { fieldValue: { rules } },
+	...extra,
+} );
+
+const one = ( operator, value, field = 'a' ) => logic( [ { field, operator, value } ] );
+
+describe( 'evaluateLogic — string operators', () => {
+	const types = { a: 'text' };
+
+	it.each( [
+		[ 'is', 'yes', 'yes', true ],
+		[ 'is', 'yes', 'no', false ],
+		[ 'is_not', 'yes', 'no', true ],
+		[ 'is_not', 'yes', 'yes', false ],
+		[ 'contains', 'blueberry', 'blue', true ],
+		[ 'contains', 'blueberry', 'red', false ],
+		[ 'does_not_contain', 'blueberry', 'red', true ],
+		[ 'does_not_contain', 'blueberry', 'blue', false ],
+	] )( '%s: %p vs %p', ( operator, actual, expected, want ) => {
+		expect( evaluateLogic( one( operator, expected ), types, { a: actual } ) ).toBe( want );
+	} );
+
+	it.each( [
+		[ 'is_empty', '', true ],
+		[ 'is_empty', '   ', true ],
+		[ 'is_empty', 'x', false ],
+		[ 'is_not_empty', 'x', true ],
+		[ 'is_not_empty', '', false ],
+	] )( '%s: %p', ( operator, actual, want ) => {
+		expect( evaluateLogic( one( operator, '' ), types, { a: actual } ) ).toBe( want );
+	} );
+} );
+
+describe( 'evaluateLogic — multiple choice uses membership', () => {
+	const types = { a: 'checkbox-multiple' };
+
+	it( 'does not match a longer option that merely contains the value', () => {
+		expect( evaluateLogic( one( 'contains', 'Blue' ), types, { a: [ 'Blueberry' ] } ) ).toBe(
+			false
+		);
+	} );
+
+	it( 'matches an exact selected option', () => {
+		expect( evaluateLogic( one( 'contains', 'Blue' ), types, { a: [ 'Blue', 'Red' ] } ) ).toBe(
+			true
+		);
+	} );
+
+	it( 'handles does_not_contain', () => {
+		expect( evaluateLogic( one( 'does_not_contain', 'Blue' ), types, { a: [ 'Red' ] } ) ).toBe(
+			true
+		);
+		expect( evaluateLogic( one( 'does_not_contain', 'Blue' ), types, { a: [ 'Blue' ] } ) ).toBe(
+			false
+		);
+	} );
+
+	it( 'is not fooled by a comma inside an option label', () => {
+		expect( evaluateLogic( one( 'contains', 'Yes' ), types, { a: [ 'Yes, please' ] } ) ).toBe(
+			false
+		);
+		expect(
+			evaluateLogic( one( 'contains', 'Yes, please' ), types, { a: [ 'Yes, please' ] } )
+		).toBe( true );
+	} );
+
+	it( 'treats an empty selection as empty', () => {
+		expect( evaluateLogic( one( 'is_empty', '' ), types, { a: [] } ) ).toBe( true );
+		expect( evaluateLogic( one( 'is_not_empty', '' ), types, { a: [ 'Blue' ] } ) ).toBe( true );
+	} );
+
+	it( 'accepts a single string selection', () => {
+		expect( evaluateLogic( one( 'contains', 'Blue' ), types, { a: 'Blue' } ) ).toBe( true );
+	} );
+} );
+
+describe( 'evaluateLogic — choice operators', () => {
+	const types = { a: 'select' };
+
+	it( 'compares the whole selected option', () => {
+		expect( evaluateLogic( one( 'is', 'Blue' ), types, { a: 'Blue' } ) ).toBe( true );
+		expect( evaluateLogic( one( 'is', 'Blue' ), types, { a: 'Blueberry' } ) ).toBe( false );
+		expect( evaluateLogic( one( 'is_not', 'Blue' ), types, { a: 'Red' } ) ).toBe( true );
+	} );
+} );
+
+describe( 'evaluateLogic — numeric operators', () => {
+	const types = { a: 'number' };
+
+	it.each( [
+		[ 'equals', '10.0', '10', true ],
+		[ 'equals', '11', '10', false ],
+		[ 'not_equals', '11', '10', true ],
+		[ 'greater_than', '20', '10', true ],
+		[ 'greater_than', '10', '10', false ],
+		[ 'less_than', '5', '10', true ],
+		[ 'less_than', '10', '10', false ],
+		[ 'gte', '10', '10', true ],
+		[ 'gte', '9', '10', false ],
+		[ 'lte', '10', '10', true ],
+		[ 'lte', '11', '10', false ],
+	] )( '%s: %p vs %p', ( operator, actual, expected, want ) => {
+		expect( evaluateLogic( one( operator, expected ), types, { a: actual } ) ).toBe( want );
+	} );
+
+	it( 'fails the rule when either side is not numeric', () => {
+		expect( evaluateLogic( one( 'greater_than', '10' ), types, { a: 'abc' } ) ).toBe( false );
+		expect( evaluateLogic( one( 'greater_than', 'abc' ), types, { a: '20' } ) ).toBe( false );
+		expect( evaluateLogic( one( 'greater_than', '10' ), types, { a: '' } ) ).toBe( false );
+	} );
+
+	it( 'compares numbers numerically, not as strings', () => {
+		// '9' > '10' lexically, but 9 < 10 numerically.
+		expect( evaluateLogic( one( 'greater_than', '10' ), types, { a: '9' } ) ).toBe( false );
+	} );
+
+	it( 'accepts real numbers as values', () => {
+		expect( evaluateLogic( one( 'greater_than', 10 ), types, { a: 20 } ) ).toBe( true );
+	} );
+} );
+
+describe( 'evaluateLogic — date and time operators', () => {
+	it.each( [
+		[ 'before', '2026-01-01', '2026-06-01', true ],
+		[ 'before', '2026-12-01', '2026-06-01', false ],
+		[ 'after', '2026-12-01', '2026-06-01', true ],
+		[ 'after', '2026-01-01', '2026-06-01', false ],
+		[ 'is', '2026-06-01', '2026-06-01', true ],
+		[ 'is_not', '2026-06-02', '2026-06-01', true ],
+	] )( 'date %s: %p vs %p', ( operator, actual, expected, want ) => {
+		expect( evaluateLogic( one( operator, expected ), { a: 'date' }, { a: actual } ) ).toBe( want );
+	} );
+
+	it.each( [
+		[ 'before', '09:00', '17:00', true ],
+		[ 'after', '18:00', '17:00', true ],
+		[ 'is', '17:00', '17:00', true ],
+	] )( 'time %s: %p vs %p', ( operator, actual, expected, want ) => {
+		expect( evaluateLogic( one( operator, expected ), { a: 'time' }, { a: actual } ) ).toBe( want );
+	} );
+
+	it( 'fails the rule when either side is unparseable', () => {
+		expect( evaluateLogic( one( 'before', '2026-06-01' ), { a: 'date' }, { a: 'nonsense' } ) ).toBe(
+			false
+		);
+		expect( evaluateLogic( one( 'before', 'nonsense' ), { a: 'date' }, { a: '2026-06-01' } ) ).toBe(
+			false
+		);
+	} );
+} );
+
+describe( 'evaluateLogic — boolean operators', () => {
+	const types = { a: 'checkbox' };
+
+	it.each( [
+		[ 'is_checked', true, true ],
+		[ 'is_checked', false, false ],
+		[ 'is_checked', '1', true ],
+		[ 'is_checked', '', false ],
+		[ 'is_not_checked', false, true ],
+		[ 'is_not_checked', true, false ],
+	] )( '%s: %p', ( operator, actual, want ) => {
+		expect( evaluateLogic( logic( [ { field: 'a', operator } ] ), types, { a: actual } ) ).toBe(
+			want
+		);
+	} );
+} );
+
+describe( 'evaluateLogic — combination, action, and ignored rules', () => {
+	const types = { a: 'text', b: 'text' };
+	const twoRules = [
+		{ field: 'a', operator: 'is', value: 'x' },
+		{ field: 'b', operator: 'is', value: 'y' },
+	];
+
+	it( 'honors any versus all', () => {
+		const values = { a: 'x', b: 'nope' };
+		expect( evaluateLogic( logic( twoRules, { logicalOperator: 'any' } ), types, values ) ).toBe(
+			true
+		);
+		expect( evaluateLogic( logic( twoRules, { logicalOperator: 'all' } ), types, values ) ).toBe(
+			false
+		);
+	} );
+
+	it( 'inverts the outcome for the hide action', () => {
+		expect( evaluateLogic( one( 'is', 'x' ), types, { a: 'x' } ) ).toBe( true );
+		expect(
+			evaluateLogic(
+				logic( [ { field: 'a', operator: 'is', value: 'x' } ], { action: 'hide' } ),
+				types,
+				{
+					a: 'x',
+				}
+			)
+		).toBe( false );
+	} );
+
+	it( 'is visible when disabled, ruleless, or missing its control', () => {
+		expect( evaluateLogic( logic( [] ), types, {} ) ).toBe( true );
+		expect(
+			evaluateLogic(
+				logic( [ { field: 'a', operator: 'is', value: 'x' } ], { enabled: false } ),
+				types,
+				{}
+			)
+		).toBe( true );
+		expect(
+			evaluateLogic(
+				{ enabled: true, action: 'show', logicalOperator: 'all', controls: {} },
+				types,
+				{}
+			)
+		).toBe( true );
+		expect( evaluateLogic( null, types, {} ) ).toBe( true );
+	} );
+
+	it( 'ignores a rule whose subject field no longer exists', () => {
+		// A deleted subject must not be compared against empty — that would make is_empty
+		// spuriously true and hide the field because an unrelated block was removed.
+		expect( evaluateLogic( one( 'is_empty', '', 'gone_field' ), types, {} ) ).toBe( true );
+		expect( evaluateLogic( one( 'is', 'x', 'gone_field' ), types, {} ) ).toBe( true );
+	} );
+
+	it( 'ignores only the missing rule and still evaluates the rest', () => {
+		const rules = [
+			{ field: 'gone_field', operator: 'is', value: 'x' },
+			{ field: 'a', operator: 'is', value: 'x' },
+		];
+		expect( evaluateLogic( logic( rules ), types, { a: 'x' } ) ).toBe( true );
+		expect( evaluateLogic( logic( rules ), types, { a: 'nope' } ) ).toBe( false );
+	} );
+
+	it( 'ignores a rule with an unknown operator', () => {
+		expect( evaluateLogic( one( 'not_a_real_operator', 'x' ), types, { a: 'x' } ) ).toBe( true );
+	} );
+} );
+
+describe( 'resolveVisibility — cascade', () => {
+	const chain = () => ( {
+		a: { logic: null, type: 'text' },
+		b: { logic: one( 'is', 'Other' ), type: 'text' },
+		c: { logic: logic( [ { field: 'b', operator: 'is_not_empty' } ] ), type: 'text' },
+	} );
+
+	it( 'treats a hidden field as empty for downstream rules', () => {
+		// A switched away from Other, so B hides. B still holds a stale value, but C must
+		// not stay visible on the strength of an answer the visitor can no longer see.
+		const visible = resolveVisibility( chain(), { a: 'Something else', b: 'xyz', c: '' } );
+		expect( visible.b ).toBe( false );
+		expect( visible.c ).toBe( false );
+	} );
+
+	it( 'keeps the chain visible when the trigger matches', () => {
+		const visible = resolveVisibility( chain(), { a: 'Other', b: 'xyz', c: '' } );
+		expect( visible.a ).toBe( true );
+		expect( visible.b ).toBe( true );
+		expect( visible.c ).toBe( true );
+	} );
+
+	it( 'fails open on a two-field cycle', () => {
+		const fields = {
+			a: { logic: logic( [ { field: 'b', operator: 'is_empty' } ] ), type: 'text' },
+			b: { logic: logic( [ { field: 'a', operator: 'is_not_empty' } ] ), type: 'text' },
+		};
+		const visible = resolveVisibility( fields, { a: 'x', b: 'y' } );
+		expect( visible.a ).toBe( true );
+		expect( visible.b ).toBe( true );
+	} );
+
+	it( 'fails open on self-reference', () => {
+		const fields = {
+			a: { logic: logic( [ { field: 'a', operator: 'is_empty' } ] ), type: 'text' },
+		};
+		expect( resolveVisibility( fields, { a: 'x' } ).a ).toBe( true );
+	} );
+
+	it( 'marks every field visible when none has logic', () => {
+		const fields = {
+			a: { logic: null, type: 'text' },
+			b: { logic: null, type: 'text' },
+		};
+		expect( resolveVisibility( fields, {} ) ).toEqual( { a: true, b: true } );
+	} );
+
+	it( 'resolves a three-deep chain in one call', () => {
+		const fields = {
+			a: { logic: null, type: 'text' },
+			b: { logic: one( 'is', 'go' ), type: 'text' },
+			c: { logic: logic( [ { field: 'b', operator: 'is_not_empty' } ] ), type: 'text' },
+			d: { logic: logic( [ { field: 'c', operator: 'is_not_empty' } ] ), type: 'text' },
+		};
+		const visible = resolveVisibility( fields, { a: 'go', b: 'x', c: 'y', d: '' } );
+		expect( visible ).toEqual( { a: true, b: true, c: true, d: true } );
+
+		const hidden = resolveVisibility( fields, { a: 'stop', b: 'x', c: 'y', d: '' } );
+		expect( hidden.b ).toBe( false );
+		expect( hidden.c ).toBe( false );
+		expect( hidden.d ).toBe( false );
+	} );
+
+	it( 'returns an entry for every field, including those without logic', () => {
+		const visible = resolveVisibility( chain(), { a: 'Other', b: 'x', c: '' } );
+		expect( Object.keys( visible ).sort() ).toEqual( [ 'a', 'b', 'c' ] );
+	} );
+
+	it( 'tolerates an empty field map', () => {
+		expect( resolveVisibility( {}, {} ) ).toEqual( {} );
+	} );
+
+	/**
+	 * The pass budget used to be clamped to a constant, so an acyclic chain deeper than the
+	 * clamp ran out of passes, was read as circular, and failed open -- leaving fields
+	 * visible that every rule said to hide. Mirrors the PHP case of the same name.
+	 */
+	it( 'resolves a chain deeper than the old pass cap', () => {
+		const depth = 30;
+		const fields = { f0: { type: 'text' } };
+		const values = { f0: 'no' };
+
+		for ( let i = 1; i <= depth; i++ ) {
+			fields[ `f${ i }` ] = {
+				type: 'text',
+				logic: {
+					enabled: true,
+					action: 'show',
+					logicalOperator: 'all',
+					controls: {
+						fieldValue: {
+							rules: [ { field: `f${ i - 1 }`, operator: 'is', value: 'yes' } ],
+						},
+					},
+				},
+			};
+			values[ `f${ i }` ] = 'yes';
+		}
+
+		const visible = resolveVisibility( fields, values );
+
+		expect( visible.f0 ).toBe( true );
+		for ( let i = 1; i <= depth; i++ ) {
+			expect( visible[ `f${ i }` ] ).toBe( false );
+		}
+	} );
+} );
+
+/**
+ * Behavioural parity with the PHP evaluator.
+ *
+ * The PHP-side parity test pins the shared vocabulary -- operator names and the field type
+ * table -- but that is not where the two implementations drift: both the Date.parse/strtotime
+ * disagreement and the consent value-shape bug passed it. This reads the same table
+ * Conditional_Logic_Behaviour_Test.php does, so a comparison that behaves differently in the
+ * two languages fails on one side.
+ */
+describe( 'behaviour parity with PHP', () => {
+	const fixture = JSON.parse(
+		readFileSync(
+			path.join( process.cwd(), 'tests/fixtures/conditional-logic-behaviour.json' ),
+			'utf8'
+		)
+	);
+
+	it.each( fixture.cases.map( testCase => [ testCase.name, testCase ] ) )(
+		'%s',
+		( name, testCase ) => {
+			const caseLogic = {
+				enabled: true,
+				action: 'show',
+				logicalOperator: 'all',
+				controls: {
+					fieldValue: {
+						rules: [
+							{
+								field: 'subject',
+								operator: testCase.operator,
+								value: testCase.value,
+							},
+						],
+					},
+				},
+			};
+
+			const visible = evaluateLogic(
+				caseLogic,
+				{ subject: testCase.type },
+				{ subject: testCase.actual },
+				testCase.format ? { subject: testCase.format } : {}
+			);
+
+			expect( visible ).toBe( testCase.visible );
+		}
+	);
+} );

--- a/projects/packages/forms/tests/js/blocks/shared/conditional-logic/evaluate.test.js
+++ b/projects/packages/forms/tests/js/blocks/shared/conditional-logic/evaluate.test.js
@@ -5,13 +5,27 @@ import {
 	resolveVisibility,
 } from '../../../../../src/blocks/shared/conditional-logic/util/evaluate';
 
-const logic = ( rules, extra = {} ) => ( {
-	enabled: true,
-	action: 'show',
-	logicalOperator: 'all',
-	controls: { fieldValue: { rules } },
-	...extra,
-} );
+/**
+ * One group holding every rule, which is what the V1 panel writes.
+ *
+ * `logicalOperator` in `extra` sets that group's operator, since with a single group the
+ * top-level one is inert -- it combines groups with each other.
+ *
+ * @param {Array}  rules - Rules for the group.
+ * @param {object} extra - Top-level overrides; `logicalOperator` applies to the group.
+ * @return {object} A logic object.
+ */
+const logic = ( rules, extra = {} ) => {
+	const { logicalOperator = 'all', ...rest } = extra;
+
+	return {
+		enabled: true,
+		action: 'show',
+		logicalOperator: 'any',
+		groups: [ { logicalOperator, rules } ],
+		...rest,
+	};
+};
 
 const one = ( operator, value, field = 'a' ) => logic( [ { field, operator, value } ] );
 
@@ -336,11 +350,12 @@ describe( 'resolveVisibility — cascade', () => {
 					enabled: true,
 					action: 'show',
 					logicalOperator: 'all',
-					controls: {
-						fieldValue: {
+					groups: [
+						{
+							logicalOperator: 'all',
 							rules: [ { field: `f${ i - 1 }`, operator: 'is', value: 'yes' } ],
 						},
-					},
+					],
 				},
 			};
 			values[ `f${ i }` ] = 'yes';
@@ -379,8 +394,9 @@ describe( 'behaviour parity with PHP', () => {
 				enabled: true,
 				action: 'show',
 				logicalOperator: 'all',
-				controls: {
-					fieldValue: {
+				groups: [
+					{
+						logicalOperator: 'all',
 						rules: [
 							{
 								field: 'subject',
@@ -389,7 +405,7 @@ describe( 'behaviour parity with PHP', () => {
 							},
 						],
 					},
-				},
+				],
 			};
 
 			const visible = evaluateLogic(
@@ -402,4 +418,101 @@ describe( 'behaviour parity with PHP', () => {
 			expect( visible ).toBe( testCase.visible );
 		}
 	);
+} );
+
+/**
+ * The shape stores groups so that "any of these AND all of those" becomes possible without
+ * another migration. The V1 panel writes one group, but the evaluator has to handle several
+ * already -- otherwise the storage change buys nothing and the second group would arrive
+ * alongside an evaluator change anyway. Mirrored in Conditional_Logic_Test.php.
+ */
+describe( 'evaluateLogic — multiple groups', () => {
+	const types = { a: 'text', b: 'text', c: 'text' };
+
+	const twoGroups = ( outer, firstOperator, secondOperator ) => ( {
+		enabled: true,
+		action: 'show',
+		logicalOperator: outer,
+		groups: [
+			{
+				logicalOperator: firstOperator,
+				rules: [
+					{ field: 'a', operator: 'is', value: 'yes' },
+					{ field: 'b', operator: 'is', value: 'yes' },
+				],
+			},
+			{
+				logicalOperator: secondOperator,
+				rules: [ { field: 'c', operator: 'is', value: 'yes' } ],
+			},
+		],
+	} );
+
+	it( 'combines groups with all: both must hold', () => {
+		// First group satisfied by b alone, second group satisfied by c.
+		expect(
+			evaluateLogic( twoGroups( 'all', 'any', 'all' ), types, { a: 'no', b: 'yes', c: 'yes' } )
+		).toBe( true );
+
+		// Second group fails, so the whole condition fails.
+		expect(
+			evaluateLogic( twoGroups( 'all', 'any', 'all' ), types, { a: 'no', b: 'yes', c: 'no' } )
+		).toBe( false );
+	} );
+
+	it( 'combines groups with any: one is enough', () => {
+		// First group needs both and gets one; second group carries it.
+		expect(
+			evaluateLogic( twoGroups( 'any', 'all', 'all' ), types, { a: 'no', b: 'yes', c: 'yes' } )
+		).toBe( true );
+
+		expect(
+			evaluateLogic( twoGroups( 'any', 'all', 'all' ), types, { a: 'no', b: 'yes', c: 'no' } )
+		).toBe( false );
+	} );
+
+	it( 'ignores a group with nothing it can evaluate', () => {
+		// The second group names a field that no longer exists, so it drops out rather than
+		// dragging the field into hiding under an `all`.
+		const visible = evaluateLogic(
+			{
+				enabled: true,
+				action: 'show',
+				logicalOperator: 'all',
+				groups: [
+					{ logicalOperator: 'all', rules: [ { field: 'a', operator: 'is', value: 'yes' } ] },
+					{ logicalOperator: 'all', rules: [ { field: 'gone', operator: 'is', value: 'yes' } ] },
+				],
+			},
+			types,
+			{ a: 'yes' }
+		);
+
+		expect( visible ).toBe( true );
+	} );
+
+	it( 'ignores a rule of a kind it does not know', () => {
+		// A form saved by a newer editor degrades to the conditions this release understands
+		// rather than breaking on the ones it does not.
+		const visible = evaluateLogic(
+			{
+				enabled: true,
+				action: 'show',
+				logicalOperator: 'all',
+				groups: [
+					{
+						logicalOperator: 'all',
+						rules: [
+							{ type: 'fieldValue', field: 'a', operator: 'is', value: 'yes' },
+							{ type: 'queryString', field: 'utm_source', operator: 'is', value: 'ads' },
+						],
+					},
+				],
+			},
+			types,
+			{ a: 'yes' }
+		);
+
+		expect( visible ).toBe( true );
+	} );
 } );

--- a/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Behaviour_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Behaviour_Test.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Behavioural parity with the JavaScript evaluator.
+ *
+ * Conditional_Logic_Parity_Test pins the shared vocabulary -- operator names and the field
+ * type table. That is worth having, but it is not where the two implementations drift: both
+ * the Date.parse/strtotime disagreement and the consent value-shape bug passed it. The
+ * comparisons are where they drift, so this pins those, from a table evaluate.test.js reads
+ * as well. A case that behaves differently in the two languages fails on one side.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * @covers Automattic\Jetpack\Forms\ContactForm\Conditional_Logic
+ */
+#[CoversClass( Conditional_Logic::class )]
+class Conditional_Logic_Behaviour_Test extends BaseTestCase {
+
+	/**
+	 * The shared case table.
+	 *
+	 * @return array<string, array{0: array<string, mixed>}>
+	 */
+	public static function behaviour_cases(): array {
+		$path = __DIR__ . '/../../fixtures/conditional-logic-behaviour.json';
+		$data = json_decode( (string) file_get_contents( $path ), true );
+
+		$cases = array();
+		foreach ( $data['cases'] as $case ) {
+			$cases[ $case['name'] ] = array( $case );
+		}
+
+		return $cases;
+	}
+
+	/**
+	 * @param array<string, mixed> $case One row of the shared table.
+	 */
+	#[\PHPUnit\Framework\Attributes\DataProvider( 'behaviour_cases' )]
+	public function test_matches_the_shared_behaviour_table( array $case ) {
+		$logic = array(
+			'enabled'         => true,
+			'action'          => 'show',
+			'logicalOperator' => 'all',
+			'controls'        => array(
+				'fieldValue' => array(
+					'rules' => array(
+						array(
+							'field'    => 'subject',
+							'operator' => $case['operator'],
+							'value'    => $case['value'],
+						),
+					),
+				),
+			),
+		);
+
+		$formats = isset( $case['format'] ) ? array( 'subject' => $case['format'] ) : array();
+
+		$visible = Conditional_Logic::evaluate(
+			$logic,
+			array( 'subject' => $case['type'] ),
+			array( 'subject' => $case['actual'] ),
+			$formats
+		);
+
+		$this->assertSame(
+			$case['visible'],
+			$visible,
+			$case['why'] ?? 'Behaviour must match the JavaScript evaluator.'
+		);
+	}
+
+	/**
+	 * The table is only worth anything if both sides actually read it.
+	 */
+	public function test_the_shared_table_covers_every_comparison_family() {
+		$data  = json_decode(
+			(string) file_get_contents( __DIR__ . '/../../fixtures/conditional-logic-behaviour.json' ),
+			true
+		);
+		$types = array_unique( array_column( $data['cases'], 'type' ) );
+
+		foreach ( array( 'date', 'time', 'number', 'consent', 'checkbox', 'text', 'select' ) as $type ) {
+			$this->assertContains( $type, $types, "The shared table lost its $type cases." );
+		}
+	}
+}

--- a/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Behaviour_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Behaviour_Test.php
@@ -69,9 +69,10 @@ class Conditional_Logic_Behaviour_Test extends BaseTestCase {
 			'enabled'         => true,
 			'action'          => 'show',
 			'logicalOperator' => 'all',
-			'controls'        => array(
-				'fieldValue' => array(
-					'rules' => array(
+			'groups'   => array(
+				array(
+					'logicalOperator' => 'all',
+					'rules'           => array(
 						array(
 							'field'    => 'subject',
 							'operator' => $case['operator'],

--- a/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Behaviour_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Behaviour_Test.php
@@ -23,16 +23,35 @@ use WorDBless\BaseTestCase;
 class Conditional_Logic_Behaviour_Test extends BaseTestCase {
 
 	/**
+	 * Read the rows of the shared table.
+	 *
+	 * Throws rather than returning an empty list: a fixture that cannot be read would
+	 * otherwise turn every case below into a silent pass, which is the one failure mode a
+	 * shared parity table must not have.
+	 *
+	 * @throws \RuntimeException When the fixture is missing or does not hold a case list.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private static function load_cases(): array {
+		$path = __DIR__ . '/../../fixtures/conditional-logic-behaviour.json';
+		$data = json_decode( (string) file_get_contents( $path ), true );
+
+		if ( ! is_array( $data ) || ! isset( $data['cases'] ) || ! is_array( $data['cases'] ) ) {
+			throw new \RuntimeException( 'conditional-logic-behaviour.json is missing its cases array.' );
+		}
+
+		return $data['cases'];
+	}
+
+	/**
 	 * The shared case table.
 	 *
 	 * @return array<string, array{0: array<string, mixed>}>
 	 */
 	public static function behaviour_cases(): array {
-		$path = __DIR__ . '/../../fixtures/conditional-logic-behaviour.json';
-		$data = json_decode( (string) file_get_contents( $path ), true );
-
 		$cases = array();
-		foreach ( $data['cases'] as $case ) {
+		foreach ( self::load_cases() as $case ) {
 			$cases[ $case['name'] ] = array( $case );
 		}
 
@@ -40,6 +59,8 @@ class Conditional_Logic_Behaviour_Test extends BaseTestCase {
 	}
 
 	/**
+	 * @dataProvider behaviour_cases
+	 *
 	 * @param array<string, mixed> $case One row of the shared table.
 	 */
 	#[\PHPUnit\Framework\Attributes\DataProvider( 'behaviour_cases' )]
@@ -81,11 +102,7 @@ class Conditional_Logic_Behaviour_Test extends BaseTestCase {
 	 * The table is only worth anything if both sides actually read it.
 	 */
 	public function test_the_shared_table_covers_every_comparison_family() {
-		$data  = json_decode(
-			(string) file_get_contents( __DIR__ . '/../../fixtures/conditional-logic-behaviour.json' ),
-			true
-		);
-		$types = array_unique( array_column( $data['cases'], 'type' ) );
+		$types = array_unique( array_column( self::load_cases(), 'type' ) );
 
 		foreach ( array( 'date', 'time', 'number', 'consent', 'checkbox', 'text', 'select' ) as $type ) {
 			$this->assertContains( $type, $types, "The shared table lost its $type cases." );

--- a/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Parity_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Parity_Test.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Guards the contract between the two conditional-logic evaluators.
+ *
+ * Conditional logic is implemented twice: once in TypeScript for the editor and the browser
+ * runtime, once in PHP for validation and storage. They agree only by convention, and a
+ * silent divergence is expensive — a field the visitor never saw gets stored, or an answer
+ * they did give gets dropped. These tests turn that convention into a failing build.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * @covers Automattic\Jetpack\Forms\ContactForm\Conditional_Logic
+ */
+#[CoversClass( Conditional_Logic::class )]
+class Conditional_Logic_Parity_Test extends TestCase {
+
+	/**
+	 * Absolute path to the TypeScript module that owns the shared vocabulary.
+	 *
+	 * @return string
+	 */
+	private function field_types_path(): string {
+		return __DIR__ . '/../../../src/blocks/shared/conditional-logic/util/field-types.ts';
+	}
+
+	/**
+	 * Read the TypeScript source that defines the shared tables.
+	 *
+	 * @return string
+	 */
+	private function field_types_source(): string {
+		$path = $this->field_types_path();
+		$this->assertFileExists( $path, 'field-types.ts moved; update this test to match.' );
+
+		$source = file_get_contents( $path );
+		$this->assertNotEmpty( $source, 'field-types.ts is empty.' );
+
+		return $source;
+	}
+
+	/**
+	 * The PHP operator constants must match the TypeScript OPERATORS values exactly.
+	 *
+	 * Operator strings are persisted in post content, so a rename on one side silently stops
+	 * matching rules saved by the other.
+	 */
+	public function test_php_operator_constants_match_the_typescript_source() {
+		$source = $this->field_types_source();
+
+		$matched = preg_match( '/export const OPERATORS = \{(.*?)\} as const;/s', $source, $block );
+		$this->assertSame( 1, $matched, 'Could not locate the OPERATORS object in field-types.ts.' );
+
+		preg_match_all( "/^\s*[A-Z_]+:\s*'([a-z_]+)',/m", $block[1], $matches );
+		$ts_operators = $matches[1];
+		$this->assertNotEmpty( $ts_operators, 'No operators parsed from field-types.ts.' );
+
+		$php_operators = array();
+		foreach ( ( new ReflectionClass( Conditional_Logic::class ) )->getConstants() as $name => $value ) {
+			if ( 0 === strpos( $name, 'OP_' ) ) {
+				$php_operators[] = $value;
+			}
+		}
+
+		sort( $ts_operators );
+		sort( $php_operators );
+
+		$this->assertSame(
+			$ts_operators,
+			$php_operators,
+			'Operator drift between field-types.ts and Conditional_Logic.'
+		);
+	}
+
+	/**
+	 * Both sides must agree on how a shortcode field type compares.
+	 *
+	 * The editor keys off block names and the runtime keys off shortcode types; this table is
+	 * where the two meet, so it has to be identical in both languages.
+	 */
+	public function test_php_field_type_table_matches_the_typescript_source() {
+		$source = $this->field_types_source();
+
+		$matched = preg_match(
+			'/export const TYPE_KEY_BY_FIELD_TYPE: Record< string, TypeKey > = \{(.*?)\n\};/s',
+			$source,
+			$block
+		);
+		$this->assertSame( 1, $matched, 'Could not locate TYPE_KEY_BY_FIELD_TYPE in field-types.ts.' );
+
+		preg_match_all( "/^\s*'?([a-z-]+)'?:\s*'([a-z]+)',/m", $block[1], $matches, PREG_SET_ORDER );
+		$this->assertNotEmpty( $matches, 'No field type entries parsed from field-types.ts.' );
+
+		$ts_table = array();
+		foreach ( $matches as $entry ) {
+			$ts_table[ $entry[1] ] = $entry[2];
+		}
+
+		$php_table = Conditional_Logic::TYPE_KEY_BY_FIELD_TYPE;
+
+		ksort( $ts_table );
+		ksort( $php_table );
+
+		$this->assertSame(
+			$ts_table,
+			$php_table,
+			'Field type mapping drift between field-types.ts and Conditional_Logic.'
+		);
+	}
+
+}

--- a/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Parity_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Parity_Test.php
@@ -114,5 +114,4 @@ class Conditional_Logic_Parity_Test extends TestCase {
 			'Field type mapping drift between field-types.ts and Conditional_Logic.'
 		);
 	}
-
 }

--- a/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Parity_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Parity_Test.php
@@ -15,6 +15,7 @@ namespace Automattic\Jetpack\Forms\ContactForm;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
+use ReflectionMethod;
 
 /**
  * @covers Automattic\Jetpack\Forms\ContactForm\Conditional_Logic
@@ -113,5 +114,85 @@ class Conditional_Logic_Parity_Test extends TestCase {
 			$php_table,
 			'Field type mapping drift between field-types.ts and Conditional_Logic.'
 		);
+	}
+
+	/**
+	 * Every operator the rule builder offers for a type must be one the PHP evaluator dispatches.
+	 *
+	 * `OPERATORS_BY_TYPE_KEY` in field-types.ts is the list of operators the editor lets you pick
+	 * per field type. `evaluate_rule_value` returns null for any (type key, operator) pair it does
+	 * not handle, and a null outcome is dropped silently: the rule never counts, and the field it
+	 * guards falls unconditionally visible with no notice and no failing test. This walks the
+	 * offered table and asserts each pair evaluates to a real boolean, so adding an operator to the
+	 * UI without wiring its comparison — on either side — turns red instead of shipping a dead rule.
+	 */
+	public function test_every_offered_operator_pair_is_dispatched_by_php() {
+		$source = $this->field_types_source();
+
+		// Resolve the OPERATORS.<NAME> references the table uses back to their string values.
+		$matched = preg_match( '/export const OPERATORS = \{(.*?)\} as const;/s', $source, $block );
+		$this->assertSame( 1, $matched, 'Could not locate the OPERATORS object in field-types.ts.' );
+
+		preg_match_all( "/^\s*([A-Z_]+):\s*'([a-z_]+)',/m", $block[1], $matches, PREG_SET_ORDER );
+		$this->assertNotEmpty( $matches, 'No operators parsed from field-types.ts.' );
+
+		$operator_values = array();
+		foreach ( $matches as $entry ) {
+			$operator_values[ $entry[1] ] = $entry[2];
+		}
+
+		$matched = preg_match(
+			'/OPERATORS_BY_TYPE_KEY: Record< TypeKey, Operator\[\] > = \{(.*?)\n\};/s',
+			$source,
+			$block
+		);
+		$this->assertSame( 1, $matched, 'Could not locate OPERATORS_BY_TYPE_KEY in field-types.ts.' );
+
+		preg_match_all( '/([a-z]+):\s*\[(.*?)\]/s', $block[1], $entries, PREG_SET_ORDER );
+		$this->assertNotEmpty( $entries, 'No type-key operator lists parsed from field-types.ts.' );
+
+		$evaluate = new ReflectionMethod( Conditional_Logic::class, 'evaluate_rule_value' );
+		$evaluate->setAccessible( true );
+
+		$pairs_checked = 0;
+		foreach ( $entries as $entry ) {
+			$type_key = $entry[1];
+
+			preg_match_all( '/OPERATORS\.([A-Z_]+)/', $entry[2], $refs );
+			$this->assertNotEmpty(
+				$refs[1],
+				"No operators parsed for type key '$type_key' in OPERATORS_BY_TYPE_KEY."
+			);
+
+			foreach ( $refs[1] as $name ) {
+				$this->assertArrayHasKey(
+					$name,
+					$operator_values,
+					"OPERATORS_BY_TYPE_KEY references OPERATORS.$name, which OPERATORS does not define."
+				);
+				$operator = $operator_values[ $name ];
+
+				// Generic operands: enough for every branch to reach its comparison, so only a
+				// genuinely unhandled (type key, operator) pair returns null.
+				$outcome = $evaluate->invoke(
+					null,
+					array(
+						'operator' => $operator,
+						'value'    => '1',
+					),
+					$type_key,
+					'1',
+					''
+				);
+
+				$this->assertNotNull(
+					$outcome,
+					"Type '$type_key' offers operator '$operator' but the PHP evaluator does not dispatch it, so the rule is dropped silently."
+				);
+				++$pairs_checked;
+			}
+		}
+
+		$this->assertGreaterThan( 0, $pairs_checked, 'No offered operator pairs were checked.' );
 	}
 }

--- a/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Test.php
@@ -1,0 +1,674 @@
+<?php
+/**
+ * Unit tests for Automattic\Jetpack\Forms\ContactForm\Conditional_Logic.
+ *
+ * Mirrors tests/js/blocks/shared/conditional-logic/evaluate.test.js case for case. The two
+ * evaluators must agree: the browser decides what to show, PHP decides what to validate and
+ * store, and a disagreement either drops a real answer or accepts a hidden one.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers Automattic\Jetpack\Forms\ContactForm\Conditional_Logic
+ */
+#[CoversClass( Conditional_Logic::class )]
+class Conditional_Logic_Test extends TestCase {
+
+	/**
+	 * Build a logic config wrapping the given rules.
+	 *
+	 * @param array $rules     Rule list.
+	 * @param array $overrides Top-level overrides (action, logicalOperator, enabled).
+	 *
+	 * @return array
+	 */
+	private function logic( array $rules, array $overrides = array() ): array {
+		return array_merge(
+			array(
+				'enabled'         => true,
+				'action'          => 'show',
+				'logicalOperator' => 'all',
+				'controls'        => array( 'fieldValue' => array( 'rules' => $rules ) ),
+			),
+			$overrides
+		);
+	}
+
+	/**
+	 * Build a single-rule logic config.
+	 *
+	 * @param string $operator Operator wire string.
+	 * @param mixed  $value    Expected value.
+	 * @param string $field    Subject field id.
+	 *
+	 * @return array
+	 */
+	private function one( $operator, $value = '', $field = 'a' ): array {
+		return $this->logic(
+			array(
+				array(
+					'field'    => $field,
+					'operator' => $operator,
+					'value'    => $value,
+				),
+			)
+		);
+	}
+
+	/**
+	 * Every shortcode field type and its comparison behavior.
+	 *
+	 * @return array
+	 */
+	public static function provide_field_types(): array {
+		return array(
+			array( 'text', 'string' ),
+			array( 'name', 'string' ),
+			array( 'email', 'string' ),
+			array( 'url', 'string' ),
+			array( 'textarea', 'string' ),
+			array( 'telephone', 'string' ),
+			array( 'phone', 'string' ),
+			array( 'select', 'choice' ),
+			array( 'radio', 'choice' ),
+			array( 'image-select', 'choice' ),
+			array( 'checkbox-multiple', 'multichoice' ),
+			array( 'number', 'number' ),
+			array( 'slider', 'number' ),
+			array( 'rating', 'number' ),
+			array( 'date', 'date' ),
+			array( 'time', 'time' ),
+			array( 'checkbox', 'boolean' ),
+			array( 'consent', 'boolean' ),
+			array( 'hidden', 'hidden' ),
+			array( 'file', 'file' ),
+		);
+	}
+
+	/**
+	 * @param string $field_type Shortcode type.
+	 * @param string $expected   Expected type key.
+	 * @dataProvider provide_field_types
+	 */
+	#[DataProvider( 'provide_field_types' )]
+	public function test_type_key_for_field_type( $field_type, $expected ) {
+		$this->assertSame( $expected, Conditional_Logic::type_key_for_field_type( $field_type ) );
+	}
+
+	public function test_unknown_field_type_compares_textually() {
+		$this->assertSame( 'string', Conditional_Logic::type_key_for_field_type( 'not-a-type' ) );
+		$this->assertSame( 'string', Conditional_Logic::type_key_for_field_type( '' ) );
+	}
+
+	/**
+	 * String operator cases.
+	 *
+	 * @return array
+	 */
+	public static function provide_string_operators(): array {
+		return array(
+			array( 'is', 'yes', 'yes', true ),
+			array( 'is', 'yes', 'no', false ),
+			array( 'is_not', 'yes', 'no', true ),
+			array( 'is_not', 'yes', 'yes', false ),
+			array( 'contains', 'blueberry', 'blue', true ),
+			array( 'contains', 'blueberry', 'red', false ),
+			array( 'does_not_contain', 'blueberry', 'red', true ),
+			array( 'does_not_contain', 'blueberry', 'blue', false ),
+		);
+	}
+
+	/**
+	 * @param string $operator Operator.
+	 * @param string $actual   Submitted value.
+	 * @param string $expected Rule value.
+	 * @param bool   $want     Expected visibility.
+	 * @dataProvider provide_string_operators
+	 */
+	#[DataProvider( 'provide_string_operators' )]
+	public function test_string_operators( $operator, $actual, $expected, $want ) {
+		$this->assertSame(
+			$want,
+			Conditional_Logic::evaluate(
+				$this->one( $operator, $expected ),
+				array( 'a' => 'text' ),
+				array( 'a' => $actual )
+			)
+		);
+	}
+
+	public function test_empty_operators() {
+		$types = array( 'a' => 'text' );
+		$this->assertTrue( Conditional_Logic::evaluate( $this->one( 'is_empty' ), $types, array( 'a' => '' ) ) );
+		$this->assertTrue( Conditional_Logic::evaluate( $this->one( 'is_empty' ), $types, array( 'a' => '   ' ) ) );
+		$this->assertFalse( Conditional_Logic::evaluate( $this->one( 'is_empty' ), $types, array( 'a' => 'x' ) ) );
+		$this->assertTrue( Conditional_Logic::evaluate( $this->one( 'is_not_empty' ), $types, array( 'a' => 'x' ) ) );
+		$this->assertFalse( Conditional_Logic::evaluate( $this->one( 'is_not_empty' ), $types, array( 'a' => '' ) ) );
+	}
+
+	public function test_multichoice_uses_membership_not_substring() {
+		$types = array( 'a' => 'checkbox-multiple' );
+
+		// "Blue" must not match an option named "Blueberry".
+		$this->assertFalse(
+			Conditional_Logic::evaluate( $this->one( 'contains', 'Blue' ), $types, array( 'a' => array( 'Blueberry' ) ) )
+		);
+		$this->assertTrue(
+			Conditional_Logic::evaluate( $this->one( 'contains', 'Blue' ), $types, array( 'a' => array( 'Blue', 'Red' ) ) )
+		);
+	}
+
+	public function test_multichoice_does_not_contain() {
+		$types = array( 'a' => 'checkbox-multiple' );
+		$this->assertTrue(
+			Conditional_Logic::evaluate( $this->one( 'does_not_contain', 'Blue' ), $types, array( 'a' => array( 'Red' ) ) )
+		);
+		$this->assertFalse(
+			Conditional_Logic::evaluate( $this->one( 'does_not_contain', 'Blue' ), $types, array( 'a' => array( 'Blue' ) ) )
+		);
+	}
+
+	public function test_multichoice_is_not_confused_by_commas_in_labels() {
+		$types = array( 'a' => 'checkbox-multiple' );
+		$this->assertFalse(
+			Conditional_Logic::evaluate( $this->one( 'contains', 'Yes' ), $types, array( 'a' => array( 'Yes, please' ) ) )
+		);
+		$this->assertTrue(
+			Conditional_Logic::evaluate(
+				$this->one( 'contains', 'Yes, please' ),
+				$types,
+				array( 'a' => array( 'Yes, please' ) )
+			)
+		);
+	}
+
+	public function test_multichoice_accepts_a_single_string_selection() {
+		$this->assertTrue(
+			Conditional_Logic::evaluate(
+				$this->one( 'contains', 'Blue' ),
+				array( 'a' => 'checkbox-multiple' ),
+				array( 'a' => 'Blue' )
+			)
+		);
+	}
+
+	public function test_choice_compares_the_whole_option() {
+		$types = array( 'a' => 'select' );
+		$this->assertTrue( Conditional_Logic::evaluate( $this->one( 'is', 'Blue' ), $types, array( 'a' => 'Blue' ) ) );
+		$this->assertFalse( Conditional_Logic::evaluate( $this->one( 'is', 'Blue' ), $types, array( 'a' => 'Blueberry' ) ) );
+		$this->assertTrue( Conditional_Logic::evaluate( $this->one( 'is_not', 'Blue' ), $types, array( 'a' => 'Red' ) ) );
+	}
+
+	/**
+	 * Numeric operator cases.
+	 *
+	 * @return array
+	 */
+	public static function provide_numeric_operators(): array {
+		return array(
+			array( 'equals', '10.0', '10', true ),
+			array( 'equals', '11', '10', false ),
+			array( 'not_equals', '11', '10', true ),
+			array( 'greater_than', '20', '10', true ),
+			array( 'greater_than', '10', '10', false ),
+			array( 'less_than', '5', '10', true ),
+			array( 'less_than', '10', '10', false ),
+			array( 'gte', '10', '10', true ),
+			array( 'gte', '9', '10', false ),
+			array( 'lte', '10', '10', true ),
+			array( 'lte', '11', '10', false ),
+		);
+	}
+
+	/**
+	 * @param string $operator Operator.
+	 * @param string $actual   Submitted value.
+	 * @param string $expected Rule value.
+	 * @param bool   $want     Expected visibility.
+	 * @dataProvider provide_numeric_operators
+	 */
+	#[DataProvider( 'provide_numeric_operators' )]
+	public function test_numeric_operators( $operator, $actual, $expected, $want ) {
+		$this->assertSame(
+			$want,
+			Conditional_Logic::evaluate(
+				$this->one( $operator, $expected ),
+				array( 'a' => 'number' ),
+				array( 'a' => $actual )
+			)
+		);
+	}
+
+	public function test_numeric_rule_fails_when_either_side_is_not_numeric() {
+		$types = array( 'a' => 'number' );
+		$this->assertFalse( Conditional_Logic::evaluate( $this->one( 'greater_than', '10' ), $types, array( 'a' => 'abc' ) ) );
+		$this->assertFalse( Conditional_Logic::evaluate( $this->one( 'greater_than', 'abc' ), $types, array( 'a' => '20' ) ) );
+		$this->assertFalse( Conditional_Logic::evaluate( $this->one( 'greater_than', '10' ), $types, array( 'a' => '' ) ) );
+	}
+
+	public function test_numbers_compare_numerically_not_lexically() {
+		// '9' > '10' as strings, but 9 < 10 as numbers.
+		$this->assertFalse(
+			Conditional_Logic::evaluate( $this->one( 'greater_than', '10' ), array( 'a' => 'number' ), array( 'a' => '9' ) )
+		);
+	}
+
+	/**
+	 * Date and time operator cases.
+	 *
+	 * @return array
+	 */
+	public static function provide_temporal_operators(): array {
+		return array(
+			array( 'date', 'before', '2026-01-01', '2026-06-01', true ),
+			array( 'date', 'before', '2026-12-01', '2026-06-01', false ),
+			array( 'date', 'after', '2026-12-01', '2026-06-01', true ),
+			array( 'date', 'after', '2026-01-01', '2026-06-01', false ),
+			array( 'date', 'is', '2026-06-01', '2026-06-01', true ),
+			array( 'date', 'is_not', '2026-06-02', '2026-06-01', true ),
+			array( 'time', 'before', '09:00', '17:00', true ),
+			array( 'time', 'after', '18:00', '17:00', true ),
+			array( 'time', 'is', '17:00', '17:00', true ),
+		);
+	}
+
+	/**
+	 * @param string $field_type Shortcode type (date or time).
+	 * @param string $operator   Operator.
+	 * @param string $actual     Submitted value.
+	 * @param string $expected   Rule value.
+	 * @param bool   $want       Expected visibility.
+	 * @dataProvider provide_temporal_operators
+	 */
+	#[DataProvider( 'provide_temporal_operators' )]
+	public function test_temporal_operators( $field_type, $operator, $actual, $expected, $want ) {
+		$this->assertSame(
+			$want,
+			Conditional_Logic::evaluate(
+				$this->one( $operator, $expected ),
+				array( 'a' => $field_type ),
+				array( 'a' => $actual )
+			)
+		);
+	}
+
+	public function test_temporal_rule_fails_when_unparseable() {
+		$this->assertFalse(
+			Conditional_Logic::evaluate( $this->one( 'before', '2026-06-01' ), array( 'a' => 'date' ), array( 'a' => 'nonsense' ) )
+		);
+		$this->assertFalse(
+			Conditional_Logic::evaluate( $this->one( 'before', 'nonsense' ), array( 'a' => 'date' ), array( 'a' => '2026-06-01' ) )
+		);
+	}
+
+	public function test_boolean_operators() {
+		$types = array( 'a' => 'checkbox' );
+		$this->assertTrue( Conditional_Logic::evaluate( $this->one( 'is_checked' ), $types, array( 'a' => true ) ) );
+		$this->assertFalse( Conditional_Logic::evaluate( $this->one( 'is_checked' ), $types, array( 'a' => false ) ) );
+		$this->assertTrue( Conditional_Logic::evaluate( $this->one( 'is_checked' ), $types, array( 'a' => '1' ) ) );
+		$this->assertFalse( Conditional_Logic::evaluate( $this->one( 'is_checked' ), $types, array( 'a' => '' ) ) );
+		$this->assertTrue( Conditional_Logic::evaluate( $this->one( 'is_not_checked' ), $types, array( 'a' => false ) ) );
+		$this->assertFalse( Conditional_Logic::evaluate( $this->one( 'is_not_checked' ), $types, array( 'a' => true ) ) );
+	}
+
+	public function test_any_versus_all() {
+		$types  = array(
+			'a' => 'text',
+			'b' => 'text',
+		);
+		$rules  = array(
+			array(
+				'field'    => 'a',
+				'operator' => 'is',
+				'value'    => 'x',
+			),
+			array(
+				'field'    => 'b',
+				'operator' => 'is',
+				'value'    => 'y',
+			),
+		);
+		$values = array(
+			'a' => 'x',
+			'b' => 'nope',
+		);
+
+		$this->assertTrue(
+			Conditional_Logic::evaluate( $this->logic( $rules, array( 'logicalOperator' => 'any' ) ), $types, $values )
+		);
+		$this->assertFalse(
+			Conditional_Logic::evaluate( $this->logic( $rules, array( 'logicalOperator' => 'all' ) ), $types, $values )
+		);
+	}
+
+	public function test_hide_action_inverts_the_outcome() {
+		$types = array( 'a' => 'text' );
+		$rules = array(
+			array(
+				'field'    => 'a',
+				'operator' => 'is',
+				'value'    => 'x',
+			),
+		);
+		$this->assertTrue( Conditional_Logic::evaluate( $this->logic( $rules ), $types, array( 'a' => 'x' ) ) );
+		$this->assertFalse(
+			Conditional_Logic::evaluate( $this->logic( $rules, array( 'action' => 'hide' ) ), $types, array( 'a' => 'x' ) )
+		);
+	}
+
+	public function test_visible_when_disabled_ruleless_or_missing_control() {
+		$types = array( 'a' => 'text' );
+		$rules = array(
+			array(
+				'field'    => 'a',
+				'operator' => 'is',
+				'value'    => 'x',
+			),
+		);
+
+		$this->assertTrue( Conditional_Logic::evaluate( $this->logic( array() ), $types, array() ) );
+		$this->assertTrue(
+			Conditional_Logic::evaluate( $this->logic( $rules, array( 'enabled' => false ) ), $types, array() )
+		);
+		$this->assertTrue(
+			Conditional_Logic::evaluate(
+				array(
+					'enabled'         => true,
+					'action'          => 'show',
+					'logicalOperator' => 'all',
+					'controls'        => array(),
+				),
+				$types,
+				array()
+			)
+		);
+		$this->assertTrue( Conditional_Logic::evaluate( null, $types, array() ) );
+	}
+
+	public function test_rule_with_missing_subject_field_is_ignored() {
+		// A deleted subject must not be compared against empty: that would make is_empty
+		// spuriously true and hide the field because an unrelated block was removed.
+		$types = array( 'a' => 'text' );
+		$this->assertTrue( Conditional_Logic::evaluate( $this->one( 'is_empty', '', 'gone' ), $types, array() ) );
+		$this->assertTrue( Conditional_Logic::evaluate( $this->one( 'is', 'x', 'gone' ), $types, array() ) );
+	}
+
+	public function test_only_the_missing_rule_is_ignored() {
+		$types = array( 'a' => 'text' );
+		$rules = array(
+			array(
+				'field'    => 'gone',
+				'operator' => 'is',
+				'value'    => 'x',
+			),
+			array(
+				'field'    => 'a',
+				'operator' => 'is',
+				'value'    => 'x',
+			),
+		);
+		$this->assertTrue( Conditional_Logic::evaluate( $this->logic( $rules ), $types, array( 'a' => 'x' ) ) );
+		$this->assertFalse( Conditional_Logic::evaluate( $this->logic( $rules ), $types, array( 'a' => 'nope' ) ) );
+	}
+
+	public function test_unknown_operator_is_ignored() {
+		$this->assertTrue(
+			Conditional_Logic::evaluate(
+				$this->one( 'not_a_real_operator', 'x' ),
+				array( 'a' => 'text' ),
+				array( 'a' => 'x' )
+			)
+		);
+	}
+
+	/**
+	 * Build the A -> B -> C chain used by the cascade tests.
+	 *
+	 * @return array
+	 */
+	private function chain(): array {
+		return array(
+			'a' => array(
+				'logic' => null,
+				'type'  => 'text',
+			),
+			'b' => array(
+				'logic' => $this->one( 'is', 'Other' ),
+				'type'  => 'text',
+			),
+			'c' => array(
+				'logic' => $this->logic(
+					array(
+						array(
+							'field'    => 'b',
+							'operator' => 'is_not_empty',
+						),
+					)
+				),
+				'type'  => 'text',
+			),
+		);
+	}
+
+	public function test_cascade_treats_hidden_field_as_empty() {
+		// A switched away from Other so B hides. B still holds a stale value, but C must not
+		// stay visible on the strength of an answer the visitor can no longer see.
+		$visible = Conditional_Logic::resolve_visibility(
+			$this->chain(),
+			array(
+				'a' => 'Something else',
+				'b' => 'xyz',
+				'c' => '',
+			)
+		);
+
+		$this->assertTrue( $visible['a'] );
+		$this->assertFalse( $visible['b'] );
+		$this->assertFalse( $visible['c'] );
+	}
+
+	public function test_cascade_keeps_the_chain_visible_when_the_trigger_matches() {
+		$visible = Conditional_Logic::resolve_visibility(
+			$this->chain(),
+			array(
+				'a' => 'Other',
+				'b' => 'xyz',
+				'c' => '',
+			)
+		);
+
+		$this->assertTrue( $visible['b'] );
+		$this->assertTrue( $visible['c'] );
+	}
+
+	public function test_cascade_resolves_a_three_deep_chain() {
+		$fields      = $this->chain();
+		$fields['d'] = array(
+			'logic' => $this->logic(
+				array(
+					array(
+						'field'    => 'c',
+						'operator' => 'is_not_empty',
+					),
+				)
+			),
+			'type'  => 'text',
+		);
+
+		$visible = Conditional_Logic::resolve_visibility(
+			$fields,
+			array(
+				'a' => 'Other',
+				'b' => 'x',
+				'c' => 'y',
+				'd' => '',
+			)
+		);
+		$this->assertTrue( $visible['d'] );
+
+		$hidden = Conditional_Logic::resolve_visibility(
+			$fields,
+			array(
+				'a' => 'stop',
+				'b' => 'x',
+				'c' => 'y',
+				'd' => '',
+			)
+		);
+		$this->assertFalse( $hidden['b'] );
+		$this->assertFalse( $hidden['c'] );
+		$this->assertFalse( $hidden['d'] );
+	}
+
+	public function test_two_field_cycle_fails_open() {
+		$fields = array(
+			'a' => array(
+				'logic' => $this->logic(
+					array(
+						array(
+							'field'    => 'b',
+							'operator' => 'is_empty',
+						),
+					)
+				),
+				'type'  => 'text',
+			),
+			'b' => array(
+				'logic' => $this->logic(
+					array(
+						array(
+							'field'    => 'a',
+							'operator' => 'is_not_empty',
+						),
+					)
+				),
+				'type'  => 'text',
+			),
+		);
+
+		$visible = Conditional_Logic::resolve_visibility(
+			$fields,
+			array(
+				'a' => 'x',
+				'b' => 'y',
+			)
+		);
+
+		$this->assertTrue( $visible['a'] );
+		$this->assertTrue( $visible['b'] );
+	}
+
+	public function test_self_reference_fails_open() {
+		$fields = array(
+			'a' => array(
+				'logic' => $this->logic(
+					array(
+						array(
+							'field'    => 'a',
+							'operator' => 'is_empty',
+						),
+					)
+				),
+				'type'  => 'text',
+			),
+		);
+
+		$visible = Conditional_Logic::resolve_visibility( $fields, array( 'a' => 'x' ) );
+
+		$this->assertTrue( $visible['a'] );
+	}
+
+	public function test_every_field_visible_when_none_has_logic() {
+		$fields = array(
+			'a' => array(
+				'logic' => null,
+				'type'  => 'text',
+			),
+			'b' => array(
+				'logic' => null,
+				'type'  => 'text',
+			),
+		);
+
+		$this->assertSame(
+			array(
+				'a' => true,
+				'b' => true,
+			),
+			Conditional_Logic::resolve_visibility( $fields, array() )
+		);
+	}
+
+	public function test_resolve_visibility_returns_an_entry_for_every_field() {
+		$visible = Conditional_Logic::resolve_visibility(
+			$this->chain(),
+			array(
+				'a' => 'Other',
+				'b' => 'x',
+				'c' => '',
+			)
+		);
+		$keys    = array_keys( $visible );
+		sort( $keys );
+		$this->assertSame( array( 'a', 'b', 'c' ), $keys );
+	}
+
+	public function test_resolve_visibility_tolerates_an_empty_field_map() {
+		$this->assertSame( array(), Conditional_Logic::resolve_visibility( array(), array() ) );
+	}
+
+	/**
+	 * A deep chain must still reach its fixed point.
+	 *
+	 * The pass budget used to be clamped to a constant, so an acyclic chain deeper than the
+	 * clamp ran out of passes, was read as circular, and failed open -- leaving fields
+	 * visible that every rule said to hide.
+	 */
+	public function test_a_deep_acyclic_chain_resolves_completely() {
+		$depth       = 30;
+		$descriptors = array( 'f0' => array( 'type' => 'text' ) );
+		$values      = array( 'f0' => 'no' );
+
+		// Each field is shown only when the one before it says 'yes'. f0 says 'no', so every
+		// field downstream of it must resolve hidden.
+		for ( $i = 1; $i <= $depth; $i++ ) {
+			$descriptors[ "f$i" ] = array(
+				'type'  => 'text',
+				'logic' => array(
+					'enabled'         => true,
+					'action'          => 'show',
+					'logicalOperator' => 'all',
+					'controls'        => array(
+						'fieldValue' => array(
+							'rules' => array(
+								array(
+									'field'    => 'f' . ( $i - 1 ),
+									'operator' => 'is',
+									'value'    => 'yes',
+								),
+							),
+						),
+					),
+				),
+			);
+			$values[ "f$i" ] = 'yes';
+		}
+
+		$visible = Conditional_Logic::resolve_visibility( $descriptors, $values );
+
+		$this->assertTrue( $visible['f0'], 'The unconditional field is always visible.' );
+		for ( $i = 1; $i <= $depth; $i++ ) {
+			$this->assertFalse(
+				$visible[ "f$i" ],
+				"Field f$i is downstream of a false condition and must be hidden."
+			);
+		}
+	}
+}

--- a/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Test.php
@@ -93,7 +93,7 @@ class Conditional_Logic_Test extends TestCase {
 			array( 'checkbox-multiple', 'multichoice' ),
 			array( 'number', 'number' ),
 			array( 'slider', 'number' ),
-			array( 'rating', 'number' ),
+			array( 'rating', 'rating' ),
 			array( 'date', 'date' ),
 			array( 'time', 'time' ),
 			array( 'checkbox', 'boolean' ),

--- a/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Test.php
@@ -658,7 +658,7 @@ class Conditional_Logic_Test extends TestCase {
 					),
 				),
 			);
-			$values[ "f$i" ] = 'yes';
+			$values[ "f$i" ]      = 'yes';
 		}
 
 		$visible = Conditional_Logic::resolve_visibility( $descriptors, $values );

--- a/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Test.php
@@ -30,12 +30,23 @@ class Conditional_Logic_Test extends TestCase {
 	 * @return array
 	 */
 	private function logic( array $rules, array $overrides = array() ): array {
+		// One group holding every rule, which is what the V1 panel writes. A logicalOperator
+		// override sets that group's operator, since with a single group the top-level one is
+		// inert -- it combines groups with each other.
+		$group_operator = $overrides['logicalOperator'] ?? 'all';
+		unset( $overrides['logicalOperator'] );
+
 		return array_merge(
 			array(
 				'enabled'         => true,
 				'action'          => 'show',
-				'logicalOperator' => 'all',
-				'controls'        => array( 'fieldValue' => array( 'rules' => $rules ) ),
+				'logicalOperator' => 'any',
+				'groups'          => array(
+					array(
+						'logicalOperator' => $group_operator,
+						'rules'           => $rules,
+					),
+				),
 			),
 			$overrides
 		);
@@ -645,9 +656,10 @@ class Conditional_Logic_Test extends TestCase {
 					'enabled'         => true,
 					'action'          => 'show',
 					'logicalOperator' => 'all',
-					'controls'        => array(
-						'fieldValue' => array(
-							'rules' => array(
+					'groups'   => array(
+						array(
+							'logicalOperator' => 'all',
+							'rules'           => array(
 								array(
 									'field'    => 'f' . ( $i - 1 ),
 									'operator' => 'is',
@@ -670,5 +682,194 @@ class Conditional_Logic_Test extends TestCase {
 				"Field f$i is downstream of a false condition and must be hidden."
 			);
 		}
+	}
+
+	/**
+	 * Build two groups over three fields.
+	 *
+	 * @param string $outer  How the groups combine.
+	 * @param string $first  How the first group's own rules combine.
+	 * @param string $second How the second group's own rules combine.
+	 *
+	 * @return array
+	 */
+	private function two_groups( string $outer, string $first, string $second ): array {
+		return array(
+			'enabled'         => true,
+			'action'          => 'show',
+			'logicalOperator' => $outer,
+			'groups'          => array(
+				array(
+					'logicalOperator' => $first,
+					'rules'           => array(
+						array(
+							'field'    => 'a',
+							'operator' => 'is',
+							'value'    => 'yes',
+						),
+						array(
+							'field'    => 'b',
+							'operator' => 'is',
+							'value'    => 'yes',
+						),
+					),
+				),
+				array(
+					'logicalOperator' => $second,
+					'rules'           => array(
+						array(
+							'field'    => 'c',
+							'operator' => 'is',
+							'value'    => 'yes',
+						),
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * The shape stores groups so that "any of these AND all of those" becomes possible without
+	 * another migration. The V1 panel writes one group, but the evaluator has to handle
+	 * several already. Mirrored in evaluate.test.js.
+	 */
+	public function test_groups_combine_with_all() {
+		$types = array(
+			'a' => 'text',
+			'b' => 'text',
+			'c' => 'text',
+		);
+
+		$this->assertTrue(
+			Conditional_Logic::evaluate(
+				$this->two_groups( 'all', 'any', 'all' ),
+				$types,
+				array(
+					'a' => 'no',
+					'b' => 'yes',
+					'c' => 'yes',
+				)
+			),
+			'First group satisfied by b alone, second by c.'
+		);
+
+		$this->assertFalse(
+			Conditional_Logic::evaluate(
+				$this->two_groups( 'all', 'any', 'all' ),
+				$types,
+				array(
+					'a' => 'no',
+					'b' => 'yes',
+					'c' => 'no',
+				)
+			),
+			'The second group fails, so the whole condition fails.'
+		);
+	}
+
+	public function test_groups_combine_with_any() {
+		$types = array(
+			'a' => 'text',
+			'b' => 'text',
+			'c' => 'text',
+		);
+
+		$this->assertTrue(
+			Conditional_Logic::evaluate(
+				$this->two_groups( 'any', 'all', 'all' ),
+				$types,
+				array(
+					'a' => 'no',
+					'b' => 'yes',
+					'c' => 'yes',
+				)
+			),
+			'The first group needs both and gets one; the second carries it.'
+		);
+
+		$this->assertFalse(
+			Conditional_Logic::evaluate(
+				$this->two_groups( 'any', 'all', 'all' ),
+				$types,
+				array(
+					'a' => 'no',
+					'b' => 'yes',
+					'c' => 'no',
+				)
+			)
+		);
+	}
+
+	/**
+	 * A group naming a field that no longer exists drops out rather than dragging the field
+	 * into hiding under an `all`.
+	 */
+	public function test_a_group_with_nothing_evaluable_is_ignored() {
+		$logic = array(
+			'enabled'         => true,
+			'action'          => 'show',
+			'logicalOperator' => 'all',
+			'groups'          => array(
+				array(
+					'logicalOperator' => 'all',
+					'rules'           => array(
+						array(
+							'field'    => 'a',
+							'operator' => 'is',
+							'value'    => 'yes',
+						),
+					),
+				),
+				array(
+					'logicalOperator' => 'all',
+					'rules'           => array(
+						array(
+							'field'    => 'gone',
+							'operator' => 'is',
+							'value'    => 'yes',
+						),
+					),
+				),
+			),
+		);
+
+		$this->assertTrue(
+			Conditional_Logic::evaluate( $logic, array( 'a' => 'text' ), array( 'a' => 'yes' ) )
+		);
+	}
+
+	/**
+	 * A form saved by a newer editor degrades to the conditions this release understands
+	 * rather than breaking on the ones it does not.
+	 */
+	public function test_a_rule_of_an_unknown_kind_is_ignored() {
+		$logic = array(
+			'enabled'         => true,
+			'action'          => 'show',
+			'logicalOperator' => 'all',
+			'groups'          => array(
+				array(
+					'logicalOperator' => 'all',
+					'rules'           => array(
+						array(
+							'type'     => 'fieldValue',
+							'field'    => 'a',
+							'operator' => 'is',
+							'value'    => 'yes',
+						),
+						array(
+							'type'     => 'queryString',
+							'field'    => 'utm_source',
+							'operator' => 'is',
+							'value'    => 'ads',
+						),
+					),
+				),
+			),
+		);
+
+		$this->assertTrue(
+			Conditional_Logic::evaluate( $logic, array( 'a' => 'text' ), array( 'a' => 'yes' ) )
+		);
 	}
 }


### PR DESCRIPTION
Fixes FORMS-746

> **Part 2 of 5.** This series splits #50938 into reviewable pieces. Each PR is based on the previous one, so the diff shown here is incremental.
>
> 1. #50976 — vocabulary and feature flag
> 2. **#50977 — the resolver, in JS and PHP**
> 3. #50978 — apply in the browser
> 4. #50979 — server-side render and validation
> 5. #50980 — the editor panel

## Proposed changes

Part 2 of 5 splitting #50938. Given a form's rules and its current answers, decide which fields are visible. Pure functions — **nothing calls them yet.**

The same resolution has to happen twice: in the browser as the visitor types, and on the server at submit time, where the browser's answer cannot be trusted. So it is implemented once in each language, and pinned together by a parity test that fails if the two ever disagree about an operator or a comparison.

### Why a fixed point rather than a single pass

A field's visibility can depend on a field that is itself conditional, so one pass can settle A while leaving B stale. The resolver iterates to a fixed point instead.

A cycle has no fixed point, so it **fails open**: every field still changing after the first pass is shown. Hiding a field the visitor has no way to reveal is a dead end; a form showing too much is recoverable in a way that one showing too little is not.

### Review notes

This is the intellectual core of the feature and the part most worth arguing about — particularly the fail-open choice and the operator semantics for empty values.

## Related product discussion/links

* https://wp.me/p1HpG7-xBk

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

No user-visible behaviour. Verification is the test suite:

* `jetpack test js packages/forms` — `evaluate.test.js`
* `jetpack test php packages/forms` — `Conditional_Logic_Test.php` (the resolver) and `Conditional_Logic_Parity_Test.php` (the two implementations agree)

To see the parity test do its job, change an operator in `util/field-types.ts` without changing `class-conditional-logic.php`, and confirm `Conditional_Logic_Parity_Test` fails.

