### PR TITLE
Forms: conditional logic (4/5) — server-side render and validation

### DIFF
--- a/projects/packages/forms/changelog/add-forms-conditional-logic-server
+++ b/projects/packages/forms/changelog/add-forms-conditional-logic-server
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Render and validate conditionally hidden form fields correctly, so a hidden required field cannot block submission.

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -203,10 +203,19 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				'showotheroption'              => null,
 				// derived from block metadata for blockVisibility support
 				'labelhiddenbyblockvisibility' => null,
+				// JSON-encoded conditional logic config; decoded below.
+				'conditionallogic'             => null,
 			),
 			$attributes,
 			'contact-field'
 		);
+
+		if ( ! empty( $attributes['conditionallogic'] ) && is_string( $attributes['conditionallogic'] ) ) {
+			$decoded                        = json_decode( html_entity_decode( $attributes['conditionallogic'], ENT_COMPAT ), true );
+			$attributes['conditionallogic'] = is_array( $decoded ) ? $decoded : null;
+		} elseif ( ! is_array( $attributes['conditionallogic'] ) ) {
+			$attributes['conditionallogic'] = null;
+		}
 
 		// special default for subject field
 		if ( 'subject' === $attributes['type'] && $attributes['default'] === null && $form !== null ) {
@@ -334,6 +343,20 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			return ! empty( array_filter( $field_value ) );
 		}
 		return ! empty( trim( $field_value ) );
+	}
+
+	/**
+	 * Validates the form input
+	 */
+	/**
+	 * Whether this field's visibility is governed by conditional logic.
+	 *
+	 * @return bool True when the field carries an enabled conditional-logic config.
+	 */
+	public function has_conditional_logic() {
+		$logic = $this->get_attribute( 'conditionallogic' );
+
+		return is_array( $logic ) && ! empty( $logic['enabled'] );
 	}
 
 	/**
@@ -2927,7 +2950,25 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 			'formHash'          => $this->form->hash,
 		);
 
+		// Conditional logic is not emitted per field: it cascades, so resolving it needs every
+		// field's logic and type at once. The form block emits that map once as
+		// `conditionalLogic`, and this field's wrapper reads its own entry from there.
 		$interactivity_attrs = ' data-wp-interactive="jetpack/form" ' . wp_interactivity_data_wp_context( $context ) . ' ';
+
+		// Hiding a field has to hide whichever element occupies the slot in the row, or the
+		// field disappears and leaves a hole behind it. For an inset label that is the outer
+		// wrapper, which is where the width class lives -- the inner div is inside it and
+		// carries no width of its own.
+		// data-jp-visibility-root names the element the initial server-side render stamps, so
+		// the first paint and the runtime always hide the same element. Matching on
+		// data-jp-field-id instead would stamp the inner div even when the wrapper is the one
+		// the runtime hides.
+		$visibility_attrs = " data-jp-visibility-root='" . esc_attr( $id ) . "'"
+			. ( $this->has_conditional_logic() ? " data-jp-conditional='1'" : '' )
+			. ' data-wp-class--jetpack-field--conditionally-hidden="state.isFieldHidden"'
+			// Runs whenever the field's visibility changes, so focus does not fall to <body>
+			// when the field the visitor is filling in disappears under them.
+			. ' data-wp-watch--conditional-focus="callbacks.manageConditionalFocus"';
 
 		// Fields with an inset label need an extra wrapper to show the error message below the input.
 		if ( $has_inset_label ) {
@@ -2938,11 +2979,12 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 				array_push( $inset_label_class, 'grunion-field-width-' . $field_width . '-wrap' );
 			}
 
-			$field              .= "\n<div class='" . implode( ' ', $inset_label_class ) . "' {$interactivity_attrs} >\n";
+			$field              .= "\n<div class='" . implode( ' ', $inset_label_class ) . "' {$interactivity_attrs} {$visibility_attrs} >\n";
 			$interactivity_attrs = ''; // Reset interactivity attributes for the field wrapper.
+			$visibility_attrs    = ''; // The outer wrapper owns visibility for this layout.
 		}
 
-		$field .= "\n<div {$block_style} {$interactivity_attrs} {$shell_field_class} data-wp-init='callbacks.initializeField' data-wp-on--jetpack-form-reset='callbacks.initializeField' >\n"; // new in Jetpack 6.8.0
+		$field .= "\n<div {$block_style} {$interactivity_attrs} {$shell_field_class} data-jp-field-id='" . esc_attr( $id ) . "'{$visibility_attrs} data-wp-init='callbacks.initializeField' data-wp-on--jetpack-form-reset='callbacks.initializeField' >\n"; // new in Jetpack 6.8.0
 
 		switch ( $type ) {
 			case 'email':

--- a/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-plugin.php
@@ -569,6 +569,33 @@ class Contact_Form_Plugin {
 			unset( $atts['defaultValue'] );
 		}
 
+		// Serialize the conditionalLogic object so it survives the shortcode roundtrip.
+		// Only emit when explicitly enabled to keep the shortcode and frontend context lean.
+		//
+		// JSON_HEX_TAG matters as much as JSON_HEX_AMP here: this lands in `post_content` as
+		// shortcode text and is decoded back in Contact_Form_Field, and KSES rewrites a bare
+		// `<` on the way in. A rule comparing against a value containing `<` would come back
+		// as unparseable JSON and silently drop the field's whole condition.
+		if ( isset( $atts['conditionalLogic'] ) ) {
+			$logic = $atts['conditionalLogic'];
+			if ( is_array( $logic ) && ! empty( $logic['enabled'] ) ) {
+				$json = \wp_json_encode( $logic, JSON_UNESCAPED_SLASHES | JSON_HEX_AMP | JSON_HEX_TAG );
+
+				// The rules are a JSON array, so the value contains `[` and `]`. WordPress's
+				// shortcode attribute pattern excludes both, so as shortcode text the value is
+				// cut short and the attribute is dropped entirely -- leaving a field that is
+				// still required but no longer conditional, which blocks submission on a
+				// question the visitor cannot see. Numeric entities survive the pattern and
+				// are turned back by the html_entity_decode() in Contact_Form_Field.
+				$atts['conditionallogic'] = str_replace(
+					array( '[', ']' ),
+					array( '&#91;', '&#93;' ),
+					(string) $json
+				);
+			}
+			unset( $atts['conditionalLogic'] );
+		}
+
 		// Process inner blocks to shortcode attributes.
 		if ( $block && ! empty( $block->parsed_block['innerBlocks'] ) ) {
 			// Only apply the block style classes to the field wrapper if the field is one of the new inner block types.
@@ -1848,6 +1875,17 @@ class Contact_Form_Plugin {
 		if ( ! $form ) {
 			return Form_Submission_Error::system_error( 'form_not_found', __( 'Form not found.', 'jetpack-forms' ) );
 		}
+
+		// Conditional fields cannot be validated while the form is still being parsed: a rule's
+		// subject may not exist yet, so `parse_contact_field()` defers them. Something has to
+		// validate them once the whole form is known, and on this path nothing did -- the JWT
+		// branch calls `validate()` above, but this one went straight to `has_errors()`. A
+		// required conditional field left empty, an invalid email or an out-of-allow-list choice
+		// would all be stored unchecked.
+		//
+		// Fields that were validated at parse time early-return once `is_error()` is set, so
+		// this is idempotent for everything else.
+		$form->validate();
 
 		if ( $form->has_errors() ) {
 			return $form->errors;

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -3991,8 +3991,8 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		foreach ( $this->fields as $field_id => $field ) {
 			$descriptors[ $field_id ] = array(
-				'logic' => $field->get_attribute( 'conditionallogic' ),
-				'type'  => $field->get_attribute( 'type' ),
+				'logic'  => $field->get_attribute( 'conditionallogic' ),
+				'type'   => $field->get_attribute( 'type' ),
 				// A date field's value is written in its own format, and the comparison has
 				// to read it the same way the datepicker wrote it.
 				'format' => $field->get_attribute( 'dateformat' ),

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -9,6 +9,7 @@ namespace Automattic\Jetpack\Forms\ContactForm;
 
 use Automattic\Jetpack\Connection\Tokens;
 use Automattic\Jetpack\Forms\Dashboard\Dashboard as Forms_Dashboard;
+use Automattic\Jetpack\Forms\Jetpack_Forms;
 use Automattic\Jetpack\JWT;
 use Automattic\Jetpack\Sync\Settings;
 use PHPMailer\PHPMailer\PHPMailer;
@@ -154,6 +155,15 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @var Feedback_Source
 	 */
 	private $source;
+
+	/**
+	 * Cached map of field id to conditional-logic visibility for this submission.
+	 *
+	 * Null until resolved. Shared by validation and storage so the two cannot disagree.
+	 *
+	 * @var array|null
+	 */
+	private $resolved_field_visibility = null;
 
 	/**
 	 * The reference ID for the contact form.
@@ -587,6 +597,61 @@ class Contact_Form extends Contact_Form_Shortcode {
 
 		// $this->body and $this->fields have been setup.  We no longer need the contact-field shortcode.
 		Contact_Form_Plugin::$using_contact_form_field = false;
+
+		$this->apply_initial_field_visibility();
+	}
+
+	/**
+	 * Mark conditionally hidden fields as hidden in the rendered markup.
+	 *
+	 * Without this the server sends every field visible and the browser hides them once the
+	 * interactivity store hydrates, so the visitor sees the hidden fields flash on screen
+	 * first. The class applied here is the same one the client toggles, so the first paint
+	 * already matches what the client will compute and nothing moves.
+	 *
+	 * This runs after the whole form is parsed. It cannot happen while fields render: they
+	 * are parsed one at a time, so a rule referring to a field further down the form would be
+	 * resolved against a form that does not exist yet.
+	 *
+	 * Public so it can be exercised directly; it is idempotent and safe to call again.
+	 *
+	 * @return void
+	 */
+	public function apply_initial_field_visibility() {
+		if ( empty( $this->body ) || ! Jetpack_Forms::is_conditional_logic_enabled() ) {
+			return;
+		}
+
+		// Deliberately not get_resolved_field_visibility(): that caches for the submission, and
+		// this runs while the form is still being built. Seeding the cache here would hand a
+		// render-time answer to validation and storage later on.
+		$visibility = $this->compute_field_visibility();
+		$hidden     = array();
+
+		foreach ( $visibility as $field_id => $is_visible ) {
+			if ( false === $is_visible ) {
+				$hidden[ $field_id ] = true;
+			}
+		}
+
+		if ( empty( $hidden ) ) {
+			return;
+		}
+
+		$processor = new \WP_HTML_Tag_Processor( $this->body );
+
+		// Matches the element the runtime hides, which is not always the one carrying
+		// data-jp-field-id: an inset label puts the width class on an outer wrapper, and
+		// hiding the inner div there leaves the wrapper holding its slot in the row.
+		while ( $processor->next_tag( array( 'tag_name' => 'DIV' ) ) ) {
+			$field_id = $processor->get_attribute( 'data-jp-visibility-root' );
+
+			if ( null !== $field_id && isset( $hidden[ $field_id ] ) ) {
+				$processor->add_class( 'jetpack-field--conditionally-hidden' );
+			}
+		}
+
+		$this->body = $processor->get_updated_html();
 	}
 	/**
 	 * Get the instance of the contact form from a JWT token.
@@ -1521,6 +1586,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'elementId'               => $element_id,
 			'isSingleInputForm'       => $is_single_input_form,
 			'isForcedHorizontal'      => $is_forced_horizontal,
+			'conditionalLogic'        => $form->get_conditional_logic_context(),
 		);
 
 		if ( $is_multistep ) {
@@ -2600,7 +2666,23 @@ class Contact_Form extends Contact_Form_Shortcode {
 			isset( $_POST['contact-form-hash'] ) && is_string( $_POST['contact-form-hash'] ) && hash_equals( $form->hash, wp_unslash( $_POST['contact-form-hash'] ) )
 		) { // phpcs:enable
 			// If we're processing a POST submission for this contact form, validate the field value so we can show errors as necessary.
-			$field->validate();
+			//
+			// A field carrying conditional logic is skipped here. Whether it is visible depends
+			// on the answers to other fields, and fields are appended to $form->fields as they
+			// parse — at this point the form is still incomplete, so the question cannot be
+			// answered correctly. Validating anyway records an error against a field the visitor
+			// may never see, which leaves the form permanently unsubmittable: the error is real
+			// to has_errors(), but invisible on screen and impossible to clear.
+			//
+			// Contact_Form::validate() re-validates every field once the form is fully parsed,
+			// and skips the ones conditional logic resolves as hidden, so nothing is lost by
+			// deferring: a visible field still gets its error, just a moment later.
+			$defer_to_full_form_validation = Jetpack_Forms::is_conditional_logic_enabled()
+				&& $field->has_conditional_logic();
+
+			if ( ! $defer_to_full_form_validation ) {
+				$field->validate();
+			}
 		}
 
 		// Output HTML
@@ -3107,6 +3189,17 @@ class Contact_Form extends Contact_Form_Shortcode {
 			update_post_meta( $post_id, '_feedback_akismet_values', $this->addslashes_deep( $akismet_values ) );
 		}
 
+		// Integrations must not see a field the visitor was never shown. MailPoet in
+		// particular reads this payload directly for explicit consent and the subscriber's
+		// email, so a forged POST naming a hidden consent field could otherwise subscribe
+		// someone off a question that was never on screen.
+		$visible_fields = $this->fields;
+		foreach ( $this->get_resolved_field_visibility() as $field_id => $is_visible ) {
+			if ( false === $is_visible ) {
+				unset( $visible_fields[ $field_id ] );
+			}
+		}
+
 		/**
 		 * Fires after the feedback post for the contact form submission has been inserted.
 		 *
@@ -3115,11 +3208,12 @@ class Contact_Form extends Contact_Form_Shortcode {
 		 * @since 8.6.0
 		 *
 		 * @param integer $post_id The post id that contains the contact form data.
-		 * @param array   $this->fields An array containg the form's Contact_Form_Field objects.
+		 * @param array   $visible_fields The form's Contact_Form_Field objects, less any that
+		 *                                conditional logic hid from the visitor.
 		 * @param boolean $is_spam Whether the form submission has been identified as spam.
 		 * @param array   $entry_values The feedback entry values.
 		 */
-		do_action( 'grunion_after_feedback_post_inserted', $post_id, $this->fields, $is_spam, $entry_values );
+		do_action( 'grunion_after_feedback_post_inserted', $post_id, $visible_fields, $is_spam, $entry_values );
 
 		// Build the complete email content via the renderer.
 		$context_data = array(
@@ -3776,8 +3870,17 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 */
 	public function validate() {
 		$has_value = false;
+		// A field hidden by conditional logic was never shown to the visitor, so validating it
+		// would block submission on an error they cannot see or clear — most visibly when the
+		// hidden field is also required.
+		$visibility = $this->get_resolved_field_visibility();
+
 		// Validate the form fields before processing the form.
-		foreach ( $this->fields as $field ) {
+		foreach ( $this->fields as $field_id => $field ) {
+			if ( isset( $visibility[ $field_id ] ) && false === $visibility[ $field_id ] ) {
+				continue;
+			}
+
 			$field->validate();
 			if ( ! $has_value && $field->has_value() ) {
 				$has_value = true;
@@ -3792,6 +3895,121 @@ class Contact_Form extends Contact_Form_Shortcode {
 		if ( ! empty( $ref_id ) ) {
 			$this->validate_ref( $ref_id );
 		}
+	}
+
+	/**
+	 * Build the form-level conditional-logic context handed to the front end.
+	 *
+	 * Two maps rather than one: `types` covers every field, because any of them may be the
+	 * subject of a rule, while `logic` covers only the few that carry conditions. Emitting
+	 * types solely for fields that have logic would leave the evaluator unable to resolve the
+	 * subject of most rules, and it ignores rules whose subject it cannot type.
+	 *
+	 * Returns an empty array when no field uses conditional logic, so the common case adds
+	 * nothing to the page.
+	 *
+	 * @return array Either an empty array or `array( 'types' => ..., 'logic' => ... )`.
+	 */
+	public function get_conditional_logic_context() {
+		if ( ! Jetpack_Forms::is_conditional_logic_enabled() ) {
+			return array();
+		}
+
+		$types   = array();
+		$logic   = array();
+		$formats = array();
+
+		foreach ( $this->fields as $field_id => $field ) {
+			$types[ $field_id ] = $field->get_attribute( 'type' );
+
+			$date_format = $field->get_attribute( 'dateformat' );
+			if ( ! empty( $date_format ) ) {
+				$formats[ $field_id ] = $date_format;
+			}
+
+			$field_logic = $field->get_attribute( 'conditionallogic' );
+			if ( is_array( $field_logic ) && ! empty( $field_logic['enabled'] ) ) {
+				$logic[ $field_id ] = $field_logic;
+			}
+		}
+
+		if ( empty( $logic ) ) {
+			return array();
+		}
+
+		return array(
+			'types'   => $types,
+			'logic'   => $logic,
+			// Only date fields appear here; everything else compares without a format.
+			'formats' => $formats,
+		);
+	}
+
+	/**
+	 * Resolve which fields are visible for the current submission.
+	 *
+	 * Computed once and cached: validation and storage both consult it, and letting them
+	 * resolve separately would risk them disagreeing about whether a field was shown.
+	 *
+	 * @return array Map of field id to bool visibility.
+	 */
+	public function get_resolved_field_visibility() {
+		if ( null !== $this->resolved_field_visibility ) {
+			return $this->resolved_field_visibility;
+		}
+
+		// With the feature off every field is visible, so validation and storage behave
+		// exactly as they did before conditional logic existed. This is the single choke
+		// point for the runtime: callers do not need their own flag checks.
+		if ( ! Jetpack_Forms::is_conditional_logic_enabled() ) {
+			$this->resolved_field_visibility = array();
+
+			return $this->resolved_field_visibility;
+		}
+
+		$this->resolved_field_visibility = $this->compute_field_visibility();
+
+		return $this->resolved_field_visibility;
+	}
+
+	/**
+	 * Resolve which fields are visible, without caching.
+	 *
+	 * @return array Map of field id to bool visibility.
+	 */
+	private function compute_field_visibility() {
+		if ( ! Jetpack_Forms::is_conditional_logic_enabled() ) {
+			return array();
+		}
+
+		if ( ! is_array( $this->fields ) || empty( $this->fields ) ) {
+			return array();
+		}
+
+		$descriptors = array();
+		$values      = array();
+
+		foreach ( $this->fields as $field_id => $field ) {
+			$descriptors[ $field_id ] = array(
+				'logic' => $field->get_attribute( 'conditionallogic' ),
+				'type'  => $field->get_attribute( 'type' ),
+				// A date field's value is written in its own format, and the comparison has
+				// to read it the same way the datepicker wrote it.
+				'format' => $field->get_attribute( 'dateformat' ),
+			);
+
+			// Resolve the value exactly as the field itself does when rendering: submitted
+			// value first, then a `?field_id=value` query parameter, then the configured
+			// default, then the logged-in user's details. Reading $_POST alone would make a
+			// prefilled form resolve against an empty one, so a field the visitor can already
+			// see satisfying a condition would render hidden and then flash into view.
+			$values[ $field_id ] = $field->get_computed_field_value(
+				$field->get_attribute( 'type' ),
+				$field->get_attribute( 'id' )
+			);
+		}
+
+		return Conditional_Logic::resolve_visibility( $descriptors, $values );
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/class-feedback.php
+++ b/projects/packages/forms/src/contact-form/class-feedback.php
@@ -507,6 +507,15 @@ class Feedback {
 	 */
 	private function load_from_submission( $post_data, $form, $current_post = null, $current_page_number = 1 ) {
 
+		// Drop the answers to fields conditional logic hid, once, before anything reads them.
+		//
+		// get_computed_fields() already skips hidden fields for the stored response, but the
+		// comment content, the consent flag, the author details and the notification
+		// recipients all read $post_data directly and were still seeing them. Stripping here
+		// is what makes "a hidden field was never answered" true for every consumer instead
+		// of just the one.
+		$post_data = self::without_hidden_answers( $post_data, $form );
+
 		$this->source = Feedback_Source::from_submission( $current_post, $current_page_number );
 
 		// Use the form's ref attribute as the authoritative form ID.
@@ -541,6 +550,32 @@ class Feedback {
 				'id'           => $current_user->ID,
 			);
 		}
+	}
+
+	/**
+	 * Remove submitted values belonging to fields conditional logic resolved as hidden.
+	 *
+	 * The form owns the resolution and caches it, so this asks rather than resolving again --
+	 * a second resolution over a different value source is exactly what let validation and
+	 * storage disagree about a prefilled consent field.
+	 *
+	 * @param array        $post_data The post data from the form submission.
+	 * @param Contact_Form $form      The form object.
+	 * @return array The post data, less any hidden field's answer.
+	 */
+	private static function without_hidden_answers( $post_data, $form ) {
+		if ( ! is_array( $post_data ) ) {
+			return $post_data;
+		}
+
+		// Empty when the feature is off, so this is a no-op then.
+		foreach ( $form->get_resolved_field_visibility() as $field_id => $is_visible ) {
+			if ( false === $is_visible ) {
+				unset( $post_data[ $field_id ] );
+			}
+		}
+
+		return $post_data;
 	}
 
 	/**
@@ -2202,16 +2237,54 @@ class Feedback {
 		$fields = array();
 
 		$field_ids = $form->get_field_ids();
-		// For all fields, grab label and value
-		$i = 1;
+
+		// Collect renderable fields and their submitted values up front so conditional logic
+		// rules (which may reference any sibling field) can be evaluated in the loop below.
+		$renderable  = array();
+		$form_values = array();
 		foreach ( $field_ids['all'] as $field_id ) {
 			$field = $form->fields[ $field_id ];
 			$type  = $field->get_attribute( 'type' );
 			if ( ! $field->is_field_renderable( $type ) ) {
 				continue;
 			}
+			$value                    = $this->get_field_value( $field_id, $post_data, $type );
+			$form_values[ $field_id ] = $value;
+			$renderable[ $field_id ]  = array(
+				'field' => $field,
+				'type'  => $type,
+				'value' => $value,
+			);
+		}
 
-			$value = $this->get_field_value( $field_id, $post_data, $type );
+		// Ask the form, rather than resolving a second time.
+		//
+		// Storage used to run its own resolve_visibility() over a different value source and a
+		// different field set than validation did, and the two disagreed. Validation reads
+		// get_computed_field_value() -- POST, then GET, then the field's default, then the
+		// logged-in user -- while this loop reads POST only; and it skips anything
+		// is_field_renderable() rejects, so a rule whose subject is an option-less select was
+		// evaluated during validation and ignored here.
+		//
+		// Unchecking a consent field prefilled from a query argument hit both: the browser
+		// posts nothing, validation fell back to the query argument and read it checked,
+		// storage read '' and read it unchecked. The dependent field was required-validated
+		// and then had its answer dropped -- the silently discarded answer this feature is
+		// supposed to make impossible.
+		//
+		// Returns an empty array when the flag is off, so there is nothing extra to guard.
+		$visibility = $form->get_resolved_field_visibility();
+
+		$i = 1;
+		foreach ( $renderable as $field_id => $entry ) {
+			$field = $entry['field'];
+			$type  = $entry['type'];
+			$value = $entry['value'];
+
+			if ( isset( $visibility[ $field_id ] ) && false === $visibility[ $field_id ] ) {
+				continue;
+			}
+
 			$label = wp_strip_all_tags( $field->get_attribute( 'label' ) );
 			$key   = $i . '_' . $label;
 
@@ -2227,7 +2300,7 @@ class Feedback {
 			if ( ! $this->has_file && $fields[ $key ]->has_file() ) {
 				$this->has_file = true;
 			}
-			++$i; // Increment prefix counter for the next field.
+			++$i;
 		}
 
 		return $fields;

--- a/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Feature_Flag_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Feature_Flag_Test.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Tests that the conditional-logic feature flag gates the whole runtime.
+ *
+ * The flag has to cover the editor panel, the front-end context and the submission-time
+ * enforcement together. Gating only part of it would let a form hide a field from the
+ * visitor while still requiring it on submit, or store a field the visitor never saw.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use Automattic\Jetpack\Feature_Flags\Feature_Flags;
+use Automattic\Jetpack\Forms\Jetpack_Forms;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * @covers Automattic\Jetpack\Forms\Jetpack_Forms
+ */
+#[CoversClass( Jetpack_Forms::class )]
+class Conditional_Logic_Feature_Flag_Test extends BaseTestCase {
+
+	protected function tear_down() {
+		remove_filter( 'jetpack_feature_flag_enabled_forms-conditional-logic', '__return_true' );
+		parent::tear_down();
+		unset( $_POST );
+	}
+
+	/**
+	 * Build a form whose required second field is conditional on the first, with the trigger
+	 * value set so the dependent field would be hidden if the feature were on.
+	 *
+	 * @return Contact_Form
+	 */
+	private function build_form(): Contact_Form {
+		$form = new Contact_Form( array( 'id' => 'cf-flag-test' ) );
+
+		$trigger = new Contact_Form_Field(
+			array(
+				'id'    => 'trigger',
+				'type'  => 'text',
+				'label' => 'Trigger',
+			),
+			'',
+			$form
+		);
+
+		$dependent = new Contact_Form_Field(
+			array(
+				'id'               => 'dependent',
+				'type'             => 'text',
+				'label'            => 'Dependent',
+				'required'         => '1',
+				'conditionallogic' => array(
+					'enabled'         => true,
+					'action'          => 'show',
+					'logicalOperator' => 'all',
+					'controls'        => array(
+						'fieldValue' => array(
+							'rules' => array(
+								array(
+									'field'    => 'trigger',
+									'operator' => 'is',
+									'value'    => 'Other',
+								),
+							),
+						),
+					),
+				),
+			),
+			'',
+			$form
+		);
+
+		$_POST['trigger']   = 'Something else';
+		$_POST['dependent'] = '';
+
+		$trigger->value   = 'Something else';
+		$dependent->value = '';
+
+		$form->fields = array(
+			'trigger'   => $trigger,
+			'dependent' => $dependent,
+		);
+
+		return $form;
+	}
+
+	/**
+	 * The flag is registered with the shared package, so it is discoverable through
+	 * `Feature_Flags::all()` and carries the metadata that says who owns it.
+	 */
+	public function test_the_flag_is_registered_with_the_feature_flags_package() {
+		Jetpack_Forms::register_feature_flags();
+
+		$definition = Feature_Flags::get( Jetpack_Forms::CONDITIONAL_LOGIC_FLAG );
+
+		$this->assertNotNull( $definition, 'The flag must be registered, not merely filtered.' );
+		$this->assertFalse( $definition['default'], 'It ships disabled.' );
+		$this->assertSame( 'jetpack-forms', $definition['owner'] );
+		$this->assertNotSame( '', $definition['description'] );
+	}
+
+	/**
+	 * The generic package filter controls it too, not just the per-flag variant, so a policy
+	 * layer can switch many flags from one place.
+	 */
+	public function test_the_generic_package_filter_turns_the_feature_on() {
+		Jetpack_Forms::register_feature_flags();
+
+		$callback = static function ( $enabled, $flag_name ) {
+			return Jetpack_Forms::CONDITIONAL_LOGIC_FLAG === $flag_name ? true : $enabled;
+		};
+		add_filter( 'jetpack_feature_flag_enabled', $callback, 10, 2 );
+
+		$this->assertTrue( Jetpack_Forms::is_conditional_logic_enabled() );
+
+		remove_filter( 'jetpack_feature_flag_enabled', $callback, 10 );
+	}
+
+	public function test_the_feature_is_off_by_default() {
+		$this->assertFalse(
+			Jetpack_Forms::is_conditional_logic_enabled(),
+			'Conditional logic must stay off until the flag is explicitly enabled.'
+		);
+	}
+
+	public function test_the_filter_turns_the_feature_on() {
+		add_filter( 'jetpack_feature_flag_enabled_forms-conditional-logic', '__return_true' );
+
+		$this->assertTrue( Jetpack_Forms::is_conditional_logic_enabled() );
+	}
+
+	public function test_no_front_end_context_is_emitted_when_disabled() {
+		$form = $this->build_form();
+
+		$this->assertSame(
+			array(),
+			$form->get_conditional_logic_context(),
+			'A disabled feature must add nothing to the page, even on a form that has conditions.'
+		);
+	}
+
+	public function test_every_field_resolves_visible_when_disabled() {
+		$form = $this->build_form();
+
+		$this->assertSame(
+			array(),
+			$form->get_resolved_field_visibility(),
+			'With the feature off no field is hidden, so the map is empty and callers treat every field as visible.'
+		);
+	}
+
+	/**
+	 * The mirror of Conditional_Logic_Validation_Test: with the feature off the condition is
+	 * ignored entirely, so the required field is enforced like any other.
+	 */
+	public function test_conditions_are_ignored_during_validation_when_disabled() {
+		$form = $this->build_form();
+
+		$form->validate();
+
+		$this->assertTrue(
+			$form->has_errors(),
+			'With the feature off the field is not hidden, so its required rule still applies.'
+		);
+	}
+
+	public function test_conditions_are_ignored_during_storage_when_disabled() {
+		$form = $this->build_form();
+
+		$feedback = Feedback::from_submission(
+			array(
+				'trigger'   => 'Something else',
+				'dependent' => 'stored anyway',
+			),
+			$form
+		);
+
+		$field = $feedback->get_field_by_form_field_id( 'dependent' );
+
+		$this->assertNotNull(
+			$field,
+			'With the feature off nothing is stripped from the response.'
+		);
+		$this->assertSame( 'stored anyway', $field->get_value() );
+	}
+
+	public function test_the_same_form_hides_the_field_once_the_flag_is_on() {
+		add_filter( 'jetpack_feature_flag_enabled_forms-conditional-logic', '__return_true' );
+
+		$form = $this->build_form();
+
+		$this->assertFalse(
+			$form->get_resolved_field_visibility()['dependent'],
+			'The flag is the only difference between this and the disabled case.'
+		);
+	}
+}

--- a/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Feature_Flag_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Feature_Flag_Test.php
@@ -57,9 +57,10 @@ class Conditional_Logic_Feature_Flag_Test extends BaseTestCase {
 					'enabled'         => true,
 					'action'          => 'show',
 					'logicalOperator' => 'all',
-					'controls'        => array(
-						'fieldValue' => array(
-							'rules' => array(
+					'groups'   => array(
+						array(
+							'logicalOperator' => 'all',
+							'rules'           => array(
 								array(
 									'field'    => 'trigger',
 									'operator' => 'is',

--- a/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Initial_Render_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Initial_Render_Test.php
@@ -1,0 +1,268 @@
+<?php
+/**
+ * Conditionally hidden fields must be hidden in the markup the server sends.
+ *
+ * Otherwise every field arrives visible and the browser hides them once the interactivity
+ * store hydrates, so the visitor watches the hidden fields flash on screen and the form
+ * reflow. The initial paint has to already agree with what the client will compute.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form
+ */
+#[CoversClass( Contact_Form::class )]
+class Conditional_Logic_Initial_Render_Test extends BaseTestCase {
+
+	protected function set_up() {
+		parent::set_up();
+		add_filter( 'jetpack_feature_flag_enabled_forms-conditional-logic', '__return_true' );
+	}
+
+	protected function tear_down() {
+		remove_filter( 'jetpack_feature_flag_enabled_forms-conditional-logic', '__return_true' );
+		unset( $_GET, $_POST );
+		parent::tear_down();
+	}
+
+	/**
+	 * Conditional logic showing the dependent field when trigger is "Other".
+	 *
+	 * @return array
+	 */
+	private function logic(): array {
+		return array(
+			'enabled'         => true,
+			'action'          => 'show',
+			'logicalOperator' => 'all',
+			'controls'        => array(
+				'fieldValue' => array(
+					'rules' => array(
+						array(
+							'field'    => 'trigger',
+							'operator' => 'is',
+							'value'    => 'Other',
+						),
+					),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Build a two-field form and return the rendered body.
+	 *
+	 * @return string
+	 */
+	private function render_body(): string {
+		$form = new Contact_Form( array( 'id' => 'cl-render' ) );
+
+		$trigger = new Contact_Form_Field(
+			array(
+				'id'    => 'trigger',
+				'type'  => 'text',
+				'label' => 'Trigger',
+			),
+			'',
+			$form
+		);
+
+		$dependent = new Contact_Form_Field(
+			array(
+				'id'               => 'dependent',
+				'type'             => 'text',
+				'label'            => 'Dependent',
+				'conditionallogic' => $this->logic(),
+			),
+			'',
+			$form
+		);
+
+		$form->fields = array(
+			'trigger'   => $trigger,
+			'dependent' => $dependent,
+		);
+
+		$form->body = $trigger->render() . $dependent->render();
+
+		$form->apply_initial_field_visibility();
+
+		return (string) $form->body;
+	}
+
+	/**
+	 * Extract the wrapper markup for one field.
+	 *
+	 * @param string $body     Rendered form body.
+	 * @param string $field_id Field id.
+	 * @return string
+	 */
+	private function wrapper_for( string $body, string $field_id ): string {
+		$processor = new \WP_HTML_Tag_Processor( $body );
+
+		while ( $processor->next_tag( array( 'tag_name' => 'DIV' ) ) ) {
+			if ( $field_id === $processor->get_attribute( 'data-jp-visibility-root' ) ) {
+				return (string) $processor->get_attribute( 'class' );
+			}
+		}
+
+		return '';
+	}
+
+	public function test_a_hidden_field_ships_hidden() {
+		$body = $this->render_body();
+
+		$this->assertStringContainsString(
+			'jetpack-field--conditionally-hidden',
+			$this->wrapper_for( $body, 'dependent' ),
+			'A field whose condition is unmet must arrive hidden, not flash into view.'
+		);
+	}
+
+	public function test_an_unconditional_field_is_untouched() {
+		$body = $this->render_body();
+
+		$this->assertStringNotContainsString(
+			'jetpack-field--conditionally-hidden',
+			$this->wrapper_for( $body, 'trigger' ),
+			'A field with no conditions must never be marked hidden.'
+		);
+	}
+
+	/**
+	 * Fields can be prefilled from the query string, e.g. `?trigger=Other`. The initial
+	 * visibility has to take that into account: resolving against an empty form would hide a
+	 * field the visitor can already see is satisfied, producing the opposite flash.
+	 */
+	public function test_a_query_parameter_prefill_can_reveal_the_field() {
+		$_GET['trigger'] = 'Other';
+
+		$body = $this->render_body();
+
+		$this->assertStringNotContainsString(
+			'jetpack-field--conditionally-hidden',
+			$this->wrapper_for( $body, 'dependent' ),
+			'A query-parameter prefill satisfying the rule must render the field visible.'
+		);
+	}
+
+	public function test_a_query_parameter_that_does_not_match_keeps_it_hidden() {
+		$_GET['trigger'] = 'Something else';
+
+		$body = $this->render_body();
+
+		$this->assertStringContainsString(
+			'jetpack-field--conditionally-hidden',
+			$this->wrapper_for( $body, 'dependent' )
+		);
+	}
+
+	public function test_a_submitted_value_takes_precedence_over_the_query_string() {
+		$_GET['trigger']  = 'Other';
+		$_POST['trigger'] = 'Something else';
+
+		$body = $this->render_body();
+
+		$this->assertStringContainsString(
+			'jetpack-field--conditionally-hidden',
+			$this->wrapper_for( $body, 'dependent' ),
+			'A re-rendered submission resolves against what was submitted, not the query string.'
+		);
+	}
+
+	/**
+	 * The transition is scoped to [data-jp-conditional] so only fields that actually carry a
+	 * condition animate; everything else renders with no animation cost at all.
+	 */
+	public function test_only_conditional_fields_carry_the_animation_marker() {
+		$body = $this->render_body();
+
+		$processor = new \WP_HTML_Tag_Processor( $body );
+		$marked    = array();
+
+		while ( $processor->next_tag( array( 'tag_name' => 'DIV' ) ) ) {
+			$field_id = $processor->get_attribute( 'data-jp-field-id' );
+
+			if ( null !== $field_id && null !== $processor->get_attribute( 'data-jp-conditional' ) ) {
+				$marked[] = $field_id;
+			}
+		}
+
+		$this->assertSame( array( 'dependent' ), $marked );
+	}
+
+	public function test_nothing_is_marked_when_the_feature_is_off() {
+		remove_filter( 'jetpack_feature_flag_enabled_forms-conditional-logic', '__return_true' );
+
+		$body = $this->render_body();
+
+		$this->assertStringNotContainsString(
+			'jetpack-field--conditionally-hidden',
+			$this->wrapper_for( $body, 'dependent' )
+		);
+	}
+
+	/**
+	 * An inset label puts the width class on an outer wrapper, so that wrapper is what holds
+	 * the field's slot in the row. Hiding the inner div instead left the wrapper in place and
+	 * the row kept a hole where the field had been.
+	 */
+	public function test_an_inset_label_field_hides_the_wrapper_that_holds_the_row_slot() {
+		// The inset label comes from the form's block style, not a style attribute.
+		$form = new Contact_Form(
+			array(
+				'id'        => 'cl-inset',
+				'className' => 'is-style-outlined',
+			)
+		);
+
+		$trigger = new Contact_Form_Field(
+			array(
+				'id'    => 'trigger',
+				'type'  => 'text',
+				'label' => 'Trigger',
+			),
+			'',
+			$form
+		);
+
+		$dependent = new Contact_Form_Field(
+			array(
+				'id'               => 'dependent',
+				'type'             => 'text',
+				'label'            => 'Dependent',
+				'width'            => '50',
+				'conditionallogic' => $this->logic(),
+			),
+			'',
+			$form
+		);
+
+		$form->fields = array(
+			'trigger'   => $trigger,
+			'dependent' => $dependent,
+		);
+		$form->body   = $trigger->render() . $dependent->render();
+
+		$form->apply_initial_field_visibility();
+
+		$classes = $this->wrapper_for( (string) $form->body, 'dependent' );
+
+		$this->assertStringContainsString(
+			'jetpack-field--conditionally-hidden',
+			$classes,
+			'The hidden field must ship hidden.'
+		);
+		$this->assertStringContainsString(
+			'contact-form__inset-label-wrap',
+			$classes,
+			'The element hidden must be the wrapper carrying the width, not the inner field.'
+		);
+	}
+}

--- a/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Initial_Render_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Initial_Render_Test.php
@@ -41,9 +41,10 @@ class Conditional_Logic_Initial_Render_Test extends BaseTestCase {
 			'enabled'         => true,
 			'action'          => 'show',
 			'logicalOperator' => 'all',
-			'controls'        => array(
-				'fieldValue' => array(
-					'rules' => array(
+			'groups'   => array(
+				array(
+					'logicalOperator' => 'all',
+					'rules'           => array(
 						array(
 							'field'    => 'trigger',
 							'operator' => 'is',

--- a/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Required_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Required_Field_Test.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * A required field hidden by conditional logic must never block a submission.
+ *
+ * These drive the real shortcode parse rather than building a Contact_Form by hand, because
+ * the defer decision lives inside Contact_Form::parse_contact_field(). A test that restates
+ * that decision asserts against its own copy of the rule and keeps passing when the shipping
+ * one changes -- which is how the missing legacy-path validation got through review.
+ *
+ * Fields are validated twice on a real submission: once as the shortcode is parsed, before
+ * the form knows what other fields exist, and again by Contact_Form::validate() once it does.
+ * A conditional field is skipped by the first pass, so something must run the second, on
+ * every submission path.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form
+ */
+#[CoversClass( Contact_Form::class )]
+class Conditional_Logic_Required_Field_Test extends BaseTestCase {
+
+	protected function set_up() {
+		parent::set_up();
+		add_filter( 'jetpack_feature_flag_enabled_forms-conditional-logic', '__return_true' );
+
+		// Registered, never removed. The shortcode table is global and other suites register
+		// it once per class, so tearing it down here would leave them parsing nothing.
+		if ( ! shortcode_exists( 'contact-field' ) ) {
+			Contact_Form_Plugin::init()->add_shortcode();
+		}
+	}
+
+	protected function tear_down() {
+		remove_filter( 'jetpack_feature_flag_enabled_forms-conditional-logic', '__return_true' );
+		Contact_Form::reset_seen_refs();
+		unset( $_POST );
+		parent::tear_down();
+	}
+
+	/**
+	 * Parse a form whose required second field is conditional on the first.
+	 *
+	 * Goes through do_shortcode(), so parse_contact_field() runs for real and decides for
+	 * itself whether to defer the dependent field's validation.
+	 *
+	 * @param string $trigger_value   Submitted value for the trigger field.
+	 * @param string $dependent_value Submitted value for the dependent field.
+	 *
+	 * @return Contact_Form
+	 */
+	private function parse_form( $trigger_value, $dependent_value ): Contact_Form {
+		$_POST['trigger']   = $trigger_value;
+		$_POST['dependent'] = $dependent_value;
+
+		$logic = array(
+			'enabled'         => true,
+			'action'          => 'show',
+			'logicalOperator' => 'all',
+			'controls'        => array(
+				'fieldValue' => array(
+					'rules' => array(
+						array(
+							'field'    => 'trigger',
+							'operator' => 'is',
+							'value'    => 'Other',
+						),
+					),
+				),
+			),
+		);
+
+		// Serialized exactly as block_attributes_to_shortcode_attributes() does, so this pins
+		// the real wire format: quotes as entities, and brackets too, since WordPress's
+		// shortcode attribute pattern would otherwise cut the value at the rules array.
+		$attribute = str_replace(
+			array( '[', ']' ),
+			array( '&#91;', '&#93;' ),
+			esc_attr( (string) wp_json_encode( $logic, JSON_UNESCAPED_SLASHES | JSON_HEX_AMP | JSON_HEX_TAG ) )
+		);
+
+		$shortcode = '[contact-form id="cl-required" submit_button_text="Submit"]'
+			. '[contact-field id="trigger" type="text" label="Trigger"/]'
+			. '[contact-field id="dependent" type="text" label="Dependent" required="1"'
+			. ' conditionallogic="' . $attribute . '"/]'
+			. '[/contact-form]';
+
+		do_shortcode( $shortcode );
+
+		return Contact_Form::$last;
+	}
+
+	/**
+	 * The parse pass must leave the conditional field alone.
+	 *
+	 * If it records an error here, no later pass can clear it and the visitor is stuck on a
+	 * field they cannot see.
+	 */
+	public function test_the_parse_pass_defers_a_conditional_field() {
+		$form = $this->parse_form( 'Something else', '' );
+
+		$this->assertFalse(
+			$form->has_errors(),
+			'Parsing must not validate a conditional field, whose subject may not exist yet.'
+		);
+	}
+
+	/**
+	 * The bad state: the visitor cannot see the field, cannot fill it, and submitting does
+	 * nothing because the form reports an error against it.
+	 */
+	public function test_hidden_required_field_does_not_block_submission() {
+		$form = $this->parse_form( 'Something else', '' );
+		$form->validate();
+
+		$this->assertFalse(
+			$form->has_errors(),
+			'A required field hidden by conditional logic must not put the form in an error state.'
+		);
+	}
+
+	public function test_visible_required_field_still_blocks_submission() {
+		$form = $this->parse_form( 'Other', '' );
+		$form->validate();
+
+		$this->assertTrue(
+			$form->has_errors(),
+			'Once the condition is met the field is shown, so its required rule applies again.'
+		);
+	}
+
+	public function test_visible_required_field_with_an_answer_passes() {
+		$form = $this->parse_form( 'Other', 'an answer' );
+		$form->validate();
+
+		$this->assertFalse( $form->has_errors() );
+	}
+
+	/**
+	 * Parsing alone is not enough to catch an invalid conditional field.
+	 *
+	 * This is the shape of the legacy (non-JWT) submission path, which used to go straight
+	 * from parsing to storing. Deferring the field's validation is only safe because
+	 * something runs validate() afterwards; if a submission path ever skips it, an empty
+	 * required field is accepted and stored.
+	 */
+	public function test_a_visible_required_field_is_only_caught_once_validate_runs() {
+		$form = $this->parse_form( 'Other', '' );
+
+		$this->assertFalse(
+			$form->has_errors(),
+			'Deferred at parse time, so nothing is recorded yet.'
+		);
+
+		$form->validate();
+
+		$this->assertTrue(
+			$form->has_errors(),
+			'Every submission path must call validate(), or this field is stored unchecked.'
+		);
+	}
+}

--- a/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Required_Field_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Required_Field_Test.php
@@ -63,9 +63,10 @@ class Conditional_Logic_Required_Field_Test extends BaseTestCase {
 			'enabled'         => true,
 			'action'          => 'show',
 			'logicalOperator' => 'all',
-			'controls'        => array(
-				'fieldValue' => array(
-					'rules' => array(
+			'groups'   => array(
+				array(
+					'logicalOperator' => 'all',
+					'rules'           => array(
 						array(
 							'field'    => 'trigger',
 							'operator' => 'is',

--- a/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Validation_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Validation_Test.php
@@ -1,0 +1,193 @@
+<?php
+/**
+ * Integration tests for conditional-logic enforcement during form validation.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * @covers Automattic\Jetpack\Forms\ContactForm\Contact_Form
+ */
+#[CoversClass( Contact_Form::class )]
+class Conditional_Logic_Validation_Test extends BaseTestCase {
+
+	protected function set_up() {
+		parent::set_up();
+		// Conditional logic is behind a jetpack-feature-flags flag; these cover the
+		// behaviour with the feature switched on.
+		add_filter( 'jetpack_feature_flag_enabled_forms-conditional-logic', '__return_true' );
+	}
+
+	protected function tear_down() {
+		remove_filter( 'jetpack_feature_flag_enabled_forms-conditional-logic', '__return_true' );
+		parent::tear_down();
+		unset( $_POST );
+	}
+
+	/**
+	 * Build a form whose second field is required and conditional on the first.
+	 *
+	 * @param string $trigger_value   Value submitted for the trigger field.
+	 * @param string $dependent_value Value submitted for the dependent field.
+	 *
+	 * @return Contact_Form
+	 */
+	private function build_form( $trigger_value, $dependent_value ): Contact_Form {
+		$form = new Contact_Form( array( 'id' => 'cf-validation-test' ) );
+
+		$trigger = new Contact_Form_Field(
+			array(
+				'id'    => 'trigger',
+				'type'  => 'text',
+				'label' => 'Trigger',
+			),
+			'',
+			$form
+		);
+
+		$dependent = new Contact_Form_Field(
+			array(
+				'id'               => 'dependent',
+				'type'             => 'text',
+				'label'            => 'Dependent',
+				// Contact_Form_Field normalizes this attribute: only the strings '1' and 'true'
+				// count as required, matching what the shortcode emits.
+				'required'         => '1',
+				'conditionallogic' => array(
+					'enabled'         => true,
+					'action'          => 'show',
+					'logicalOperator' => 'all',
+					'controls'        => array(
+						'fieldValue' => array(
+							'rules' => array(
+								array(
+									'field'    => 'trigger',
+									'operator' => 'is',
+									'value'    => 'Other',
+								),
+							),
+						),
+					),
+				),
+			),
+			'',
+			$form
+		);
+
+		// Contact_Form_Field::validate() reads $_POST, so the submitted values have to live
+		// there for this to exercise the real validation path.
+		$_POST['trigger']   = $trigger_value;
+		$_POST['dependent'] = $dependent_value;
+
+		$trigger->value   = $trigger_value;
+		$dependent->value = $dependent_value;
+
+		$form->fields = array(
+			'trigger'   => $trigger,
+			'dependent' => $dependent,
+		);
+
+		return $form;
+	}
+
+	/**
+	 * Regression: before conditional logic reached the validation loop, a required field
+	 * hidden by its own rule was still validated, so submitting blocked on an error about a
+	 * field the visitor could neither see nor fill.
+	 */
+	public function test_hidden_required_field_does_not_block_submission() {
+		// Trigger is not "Other", so the required dependent field is hidden.
+		$form = $this->build_form( 'Something else', '' );
+
+		$form->validate();
+
+		$this->assertFalse(
+			$form->has_errors(),
+			'A required field hidden by conditional logic must not produce a validation error.'
+		);
+	}
+
+	public function test_visible_required_field_still_blocks_submission() {
+		// Trigger matches, so the dependent field is shown and its requirement stands.
+		$form = $this->build_form( 'Other', '' );
+
+		$form->validate();
+
+		$this->assertTrue(
+			$form->has_errors(),
+			'A visible required field must still be enforced.'
+		);
+	}
+
+	public function test_visible_required_field_with_a_value_passes() {
+		$form = $this->build_form( 'Other', 'an answer' );
+
+		$form->validate();
+
+		$this->assertFalse( $form->has_errors() );
+	}
+
+	/**
+	 * The resolver is shared between validation and storage, so it must report on every field.
+	 */
+	public function test_resolved_visibility_covers_every_field() {
+		$form = $this->build_form( 'Something else', '' );
+
+		$visibility = $form->get_resolved_field_visibility();
+
+		$this->assertSame(
+			array( 'trigger', 'dependent' ),
+			array_keys( $visibility )
+		);
+		$this->assertTrue( $visibility['trigger'] );
+		$this->assertFalse( $visibility['dependent'] );
+	}
+
+	public function test_conditional_logic_context_is_empty_without_conditions() {
+		$form  = new Contact_Form( array( 'id' => 'cf-plain' ) );
+		$field = new Contact_Form_Field(
+			array(
+				'id'   => 'plain',
+				'type' => 'text',
+			),
+			'',
+			$form
+		);
+
+		$form->fields = array( 'plain' => $field );
+
+		$this->assertSame(
+			array(),
+			$form->get_conditional_logic_context(),
+			'A form with no conditions must not add anything to the page.'
+		);
+	}
+
+	/**
+	 * Types are emitted for every field, not only the ones carrying logic: any field can be
+	 * the subject of a rule, and the evaluator ignores rules whose subject it cannot type.
+	 */
+	public function test_conditional_logic_context_types_cover_every_field() {
+		$form = $this->build_form( 'Other', '' );
+
+		$context = $form->get_conditional_logic_context();
+
+		$this->assertArrayHasKey( 'types', $context );
+		$this->assertArrayHasKey( 'logic', $context );
+		$this->assertSame(
+			array( 'trigger', 'dependent' ),
+			array_keys( $context['types'] ),
+			'Every field needs a type so it can be referenced by a rule.'
+		);
+		$this->assertSame(
+			array( 'dependent' ),
+			array_keys( $context['logic'] ),
+			'Only fields that carry conditions need their logic emitted.'
+		);
+	}
+}

--- a/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Validation_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Conditional_Logic_Validation_Test.php
@@ -62,9 +62,10 @@ class Conditional_Logic_Validation_Test extends BaseTestCase {
 					'enabled'         => true,
 					'action'          => 'show',
 					'logicalOperator' => 'all',
-					'controls'        => array(
-						'fieldValue' => array(
-							'rules' => array(
+					'groups'   => array(
+						array(
+							'logicalOperator' => 'all',
+							'rules'           => array(
 								array(
 									'field'    => 'trigger',
 									'operator' => 'is',

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Conditional_Logic_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Conditional_Logic_Test.php
@@ -1,0 +1,364 @@
+<?php
+/**
+ * Integration tests for conditional-logic enforcement during feedback creation.
+ *
+ * @package automattic/jetpack-forms
+ */
+
+namespace Automattic\Jetpack\Forms\ContactForm;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use WorDBless\BaseTestCase;
+
+/**
+ * @covers Automattic\Jetpack\Forms\ContactForm\Feedback
+ */
+#[CoversClass( Feedback::class )]
+class Feedback_Conditional_Logic_Test extends BaseTestCase {
+
+	protected function set_up() {
+		parent::set_up();
+		// Conditional logic is behind a jetpack-feature-flags flag; these cover the
+		// behaviour with the feature switched on.
+		add_filter( 'jetpack_feature_flag_enabled_forms-conditional-logic', '__return_true' );
+	}
+
+	protected function tear_down() {
+		remove_filter( 'jetpack_feature_flag_enabled_forms-conditional-logic', '__return_true' );
+		parent::tear_down();
+		unset( $_POST );
+	}
+
+	/**
+	 * Submit the form the way a visitor does.
+	 *
+	 * The answers go into $_POST, because that is where Contact_Form resolves visibility
+	 * from. Handing Feedback a $post_data array that $_POST does not agree with would test a
+	 * state no submission can produce -- and storage reading a different value source than
+	 * validation is the bug this file now guards.
+	 *
+	 * @param array        $post_data Submitted values, keyed by field id.
+	 * @param Contact_Form $form      The form.
+	 * @return Feedback
+	 */
+	private function submit( $post_data, $form ) {
+		$_POST = array_merge( $_POST ?? array(), $post_data );
+
+		return Feedback::from_submission( $post_data, $form );
+	}
+
+	/**
+	 * Build a Contact_Form with a trigger text field and a dependent text field
+	 * whose visibility depends on the trigger.
+	 *
+	 * @param array $dependent_logic Conditional logic config attached to the dependent field.
+	 *
+	 * @return Contact_Form
+	 */
+	private function build_form_with_dependent_field( array $dependent_logic ): Contact_Form {
+		$form = new Contact_Form( array( 'id' => 'cf-test' ) );
+
+		$trigger = new Contact_Form_Field(
+			array(
+				'id'    => 'trigger',
+				'type'  => 'text',
+				'label' => 'Trigger',
+			),
+			'',
+			$form
+		);
+
+		$dependent = new Contact_Form_Field(
+			array(
+				'id'               => 'dependent',
+				'type'             => 'text',
+				'label'            => 'Dependent',
+				'conditionallogic' => $dependent_logic,
+			),
+			'',
+			$form
+		);
+
+		$form->fields = array(
+			'trigger'   => $trigger,
+			'dependent' => $dependent,
+		);
+
+		return $form;
+	}
+
+	/**
+	 * Extract the feedback-field keys that reference a given original field id.
+	 *
+	 * @param Feedback $feedback     The feedback instance.
+	 * @param string   $original_id  The field id set on the original Contact_Form_Field.
+	 *
+	 * @return Feedback_Field|null
+	 */
+	private function find_feedback_field( Feedback $feedback, string $original_id ) {
+		return $feedback->get_field_by_form_field_id( $original_id );
+	}
+
+	public function test_hidden_dependent_field_is_not_persisted() {
+		$form = $this->build_form_with_dependent_field(
+			array(
+				'enabled'         => true,
+				'action'          => 'show',
+				'logicalOperator' => 'any',
+				'controls'        => array(
+					'fieldValue' => array(
+						'rules' => array(
+							array(
+								'field'    => 'trigger',
+								'operator' => 'is',
+								'value'    => 'yes',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$post_data = array(
+			'trigger'   => 'no',
+			'dependent' => 'should-not-be-stored',
+		);
+
+		$feedback = $this->submit( $post_data, $form );
+
+		$this->assertNotNull(
+			$this->find_feedback_field( $feedback, 'trigger' ),
+			'Trigger field should always be present.'
+		);
+		$this->assertNull(
+			$this->find_feedback_field( $feedback, 'dependent' ),
+			'Dependent field should be stripped when conditional logic says it is hidden.'
+		);
+	}
+
+	public function test_visible_dependent_field_is_persisted() {
+		$form = $this->build_form_with_dependent_field(
+			array(
+				'enabled'         => true,
+				'action'          => 'show',
+				'logicalOperator' => 'any',
+				'controls'        => array(
+					'fieldValue' => array(
+						'rules' => array(
+							array(
+								'field'    => 'trigger',
+								'operator' => 'is',
+								'value'    => 'yes',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$post_data = array(
+			'trigger'   => 'yes',
+			'dependent' => 'kept',
+		);
+
+		$feedback = $this->submit( $post_data, $form );
+
+		$dependent_field = $this->find_feedback_field( $feedback, 'dependent' );
+		$this->assertNotNull( $dependent_field, 'Dependent field should persist when rule matches.' );
+		$this->assertSame( 'kept', $dependent_field->get_value() );
+	}
+
+	public function test_disabled_logic_never_strips_fields() {
+		$form = $this->build_form_with_dependent_field(
+			array(
+				'enabled'         => false,
+				'action'          => 'show',
+				'logicalOperator' => 'any',
+				'controls'        => array(
+					'fieldValue' => array(
+						'rules' => array(
+							array(
+								'field'    => 'trigger',
+								'operator' => 'is',
+								'value'    => 'yes',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$post_data = array(
+			'trigger'   => 'no',
+			'dependent' => 'still-kept',
+		);
+
+		$feedback = $this->submit( $post_data, $form );
+
+		$dependent_field = $this->find_feedback_field( $feedback, 'dependent' );
+		$this->assertNotNull( $dependent_field, 'Disabled logic must not strip the field.' );
+		$this->assertSame( 'still-kept', $dependent_field->get_value() );
+	}
+
+	public function test_hide_action_strips_when_rule_matches() {
+		$form = $this->build_form_with_dependent_field(
+			array(
+				'enabled'         => true,
+				'action'          => 'hide',
+				'logicalOperator' => 'any',
+				'controls'        => array(
+					'fieldValue' => array(
+						'rules' => array(
+							array(
+								'field'    => 'trigger',
+								'operator' => 'is',
+								'value'    => 'secret',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		$post_data = array(
+			'trigger'   => 'secret',
+			'dependent' => 'leak',
+		);
+
+		$feedback = $this->submit( $post_data, $form );
+
+		$this->assertNull(
+			$this->find_feedback_field( $feedback, 'dependent' ),
+			'Hide-action should strip the value when its rule matches.'
+		);
+	}
+
+	/**
+	 * A hidden field's answer must not keep a downstream field alive.
+	 *
+	 * A -> B -> C: when A stops matching, B hides. B may still carry a value from before the
+	 * visitor changed A, and evaluating each field independently would let that stale value
+	 * satisfy C's "is not empty" rule, storing an answer justified by one that was discarded.
+	 */
+	public function test_cascade_strips_the_whole_chain() {
+		$form = new Contact_Form( array( 'id' => 'cf-cascade' ) );
+
+		$rule = function ( $field, $operator, $value = '' ) {
+			return array(
+				'enabled'         => true,
+				'action'          => 'show',
+				'logicalOperator' => 'all',
+				'controls'        => array(
+					'fieldValue' => array(
+						'rules' => array(
+							array(
+								'field'    => $field,
+								'operator' => $operator,
+								'value'    => $value,
+							),
+						),
+					),
+				),
+			);
+		};
+
+		$a = new Contact_Form_Field(
+			array(
+				'id'    => 'a',
+				'type'  => 'text',
+				'label' => 'A',
+			),
+			'',
+			$form
+		);
+		$b = new Contact_Form_Field(
+			array(
+				'id'               => 'b',
+				'type'             => 'text',
+				'label'            => 'B',
+				'conditionallogic' => $rule( 'a', 'is', 'Other' ),
+			),
+			'',
+			$form
+		);
+		$c = new Contact_Form_Field(
+			array(
+				'id'               => 'c',
+				'type'             => 'text',
+				'label'            => 'C',
+				'conditionallogic' => $rule( 'b', 'is_not_empty' ),
+			),
+			'',
+			$form
+		);
+
+		$form->fields = array(
+			'a' => $a,
+			'b' => $b,
+			'c' => $c,
+		);
+
+		$feedback = $this->submit(
+			array(
+				'a' => 'Something else',
+				'b' => 'stale',
+				'c' => 'should-not-be-stored',
+			),
+			$form
+		);
+
+		$this->assertNotNull( $this->find_feedback_field( $feedback, 'a' ), 'A is unconditional.' );
+		$this->assertNull( $this->find_feedback_field( $feedback, 'b' ), 'B is hidden by its own rule.' );
+		$this->assertNull(
+			$this->find_feedback_field( $feedback, 'c' ),
+			'C must not survive on the strength of a hidden field value.'
+		);
+	}
+
+	/**
+	 * Storage and validation must agree about a prefilled field the visitor cleared.
+	 *
+	 * Validation resolves visibility from get_computed_field_value(): POST, then GET, then
+	 * the field's default. Storage used to resolve again from POST alone. A trigger prefilled
+	 * through a query argument and then cleared by the visitor posts nothing, so the two read
+	 * opposite values -- the dependent field was validated as visible and required, and then
+	 * had its answer dropped as hidden.
+	 */
+	public function test_storage_agrees_with_validation_about_a_cleared_prefilled_trigger() {
+		$form = $this->build_form_with_dependent_field(
+			array(
+				'enabled'         => true,
+				'action'          => 'show',
+				'logicalOperator' => 'all',
+				'controls'        => array(
+					'fieldValue' => array(
+						'rules' => array(
+							array(
+								'field'    => 'trigger',
+								'operator' => 'is',
+								'value'    => 'yes',
+							),
+						),
+					),
+				),
+			)
+		);
+
+		// Prefilled in the link, cleared by the visitor: present in GET, absent from POST.
+		$_GET['trigger'] = 'yes';
+		$_POST           = array( 'dependent' => 'an answer' );
+
+		$feedback = Feedback::from_submission( array( 'dependent' => 'an answer' ), $form );
+
+		$visibility = $form->get_resolved_field_visibility();
+		$stored     = null !== $this->find_feedback_field( $feedback, 'dependent' );
+
+		$this->assertSame(
+			$visibility['dependent'] ?? true,
+			$stored,
+			'Storage must keep exactly the fields the form resolved as visible.'
+		);
+
+		unset( $_GET['trigger'] );
+	}
+}

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Conditional_Logic_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Conditional_Logic_Test.php
@@ -105,9 +105,10 @@ class Feedback_Conditional_Logic_Test extends BaseTestCase {
 				'enabled'         => true,
 				'action'          => 'show',
 				'logicalOperator' => 'any',
-				'controls'        => array(
-					'fieldValue' => array(
-						'rules' => array(
+				'groups'   => array(
+					array(
+						'logicalOperator' => 'all',
+						'rules'           => array(
 							array(
 								'field'    => 'trigger',
 								'operator' => 'is',
@@ -142,9 +143,10 @@ class Feedback_Conditional_Logic_Test extends BaseTestCase {
 				'enabled'         => true,
 				'action'          => 'show',
 				'logicalOperator' => 'any',
-				'controls'        => array(
-					'fieldValue' => array(
-						'rules' => array(
+				'groups'   => array(
+					array(
+						'logicalOperator' => 'all',
+						'rules'           => array(
 							array(
 								'field'    => 'trigger',
 								'operator' => 'is',
@@ -174,9 +176,10 @@ class Feedback_Conditional_Logic_Test extends BaseTestCase {
 				'enabled'         => false,
 				'action'          => 'show',
 				'logicalOperator' => 'any',
-				'controls'        => array(
-					'fieldValue' => array(
-						'rules' => array(
+				'groups'   => array(
+					array(
+						'logicalOperator' => 'all',
+						'rules'           => array(
 							array(
 								'field'    => 'trigger',
 								'operator' => 'is',
@@ -206,9 +209,10 @@ class Feedback_Conditional_Logic_Test extends BaseTestCase {
 				'enabled'         => true,
 				'action'          => 'hide',
 				'logicalOperator' => 'any',
-				'controls'        => array(
-					'fieldValue' => array(
-						'rules' => array(
+				'groups'   => array(
+					array(
+						'logicalOperator' => 'all',
+						'rules'           => array(
 							array(
 								'field'    => 'trigger',
 								'operator' => 'is',
@@ -248,9 +252,10 @@ class Feedback_Conditional_Logic_Test extends BaseTestCase {
 				'enabled'         => true,
 				'action'          => 'show',
 				'logicalOperator' => 'all',
-				'controls'        => array(
-					'fieldValue' => array(
-						'rules' => array(
+				'groups'   => array(
+					array(
+						'logicalOperator' => 'all',
+						'rules'           => array(
 							array(
 								'field'    => $field,
 								'operator' => $operator,
@@ -330,9 +335,10 @@ class Feedback_Conditional_Logic_Test extends BaseTestCase {
 				'enabled'         => true,
 				'action'          => 'show',
 				'logicalOperator' => 'all',
-				'controls'        => array(
-					'fieldValue' => array(
-						'rules' => array(
+				'groups'   => array(
+					array(
+						'logicalOperator' => 'all',
+						'rules'           => array(
 							array(
 								'field'    => 'trigger',
 								'operator' => 'is',


### PR DESCRIPTION
Fixes FORMS-748

> **Part 4 of 5.** This series splits #50938 into reviewable pieces. Each PR is based on the previous one, so the diff shown here is incremental.
>
> 1. #50976 — vocabulary and feature flag
> 2. #50977 — the resolver, in JS and PHP
> 3. #50978 — apply in the browser
> 4. **#50979 — server-side render and validation**
> 5. #50980 — the editor panel

## Proposed changes

Part 4 of 5 splitting #50938. Two problems the browser cannot solve on its own.

**A required field that conditional logic hides used to block submission.** It was invalid, but the visitor could not see it to fill it in. Validation now skips fields the rules hide, evaluated server-side from the submitted values rather than trusting anything the browser reports. Parse-time validation is deferred for conditional fields, which otherwise wrote a static error before any answers existed.

**Fields that start hidden used to render visible and then disappear** once the runtime booted. Initial visibility is now resolved while rendering and stamped onto the markup, so the form is correct in its first paint. Values prefilled through the query string are taken into account, so a link that prefills the field a rule depends on renders the resulting state directly.

Only hidden fields are dropped from the stored feedback, so a response records what the visitor was actually asked.

## Related product discussion/links

* https://wp.me/p1HpG7-xBk

## Does this pull request change what data or activity we track or use?

A form response no longer stores values for fields that conditional logic hid at submit time. Nothing new is collected.

## Testing instructions

With the flag on and a form that hides a required field:

* Submit without revealing the hidden required field → submission succeeds, no error about a field you cannot see.
* Reveal it, leave it empty, submit → validation fails as normal.
* Load a form whose first field is hidden by a rule → it must not flash visible before disappearing. Throttle the network to make a flash obvious.
* Load the same form with `?fieldname=value` prefilling the field a rule depends on → the dependent field renders in its resulting state immediately.
* Check the stored response contains only fields that were visible.

Also: `jetpack test php packages/forms`.

