### PR TITLE
Tiled Gallery: fix saved column widths desyncing from the rendered layout

### DIFF
--- a/projects/plugins/jetpack/changelog/jetpack-1990-carousel-duplicate-data-attributes
+++ b/projects/plugins/jetpack/changelog/jetpack-1990-carousel-duplicate-data-attributes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Carousel: stop adding a duplicate set of image data attributes to galleries.

--- a/projects/plugins/jetpack/changelog/jetpack-1990-tiled-gallery-columnwidths-desync
+++ b/projects/plugins/jetpack/changelog/jetpack-1990-tiled-gallery-columnwidths-desync
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Tiled Gallery: fix rows rendering at partial width after an alignment change, and correct the srcset on published galleries.

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/edit.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/edit.jsx
@@ -10,6 +10,7 @@ import metadata from './block.json';
 import { ALLOWED_MEDIA_TYPES, LAYOUT_STYLES } from './constants';
 import { TiledGalleryBlockControls, TiledGalleryInspectorControls } from './controls';
 import Layout from './layout';
+import { hasSameColumnShape } from './layout/utils';
 
 const DEFAULT_COLUMNS_COUNT = 3;
 
@@ -137,7 +138,16 @@ const TiledGalleryEdit = ( {
 	};
 
 	const onResize = value => {
-		if ( changed ) {
+		// Recomputed widths are normally only persisted once the user has edited the
+		// images, so that merely opening a post never marks it as modified. Widths
+		// that no longer match the layout are the exception. The row and column shape
+		// is recomputed from the images and the alignment on every render, so
+		// changing either — changing the alignment in particular, which edits no
+		// image — leaves the saved widths describing a layout the block no longer
+		// draws. Saving those spreads one row's widths over a differently shaped row,
+		// which is what published galleries render as rows only 57% of the content
+		// width. See JETPACK-1990.
+		if ( changed || ! hasSameColumnShape( value, columnWidths ) ) {
 			setAttributes( { columnWidths: value } );
 		}
 	};

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/index.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/mosaic/index.jsx
@@ -146,6 +146,14 @@ export default class Mosaic extends Component {
 			// Lay out against a stable width rather than the (possibly content-sized)
 			// observed width, so the result is deterministic across browsers/reloads.
 			const width = this.getLayoutWidth();
+			// A gallery that is not laid out yet, or that sits inside a hidden
+			// container, measures 0px. Percentages derived from that are meaningless
+			// — a single column row divides zero by zero and produces NaN — and the
+			// widths this pass reports are persisted, so wait for a real measurement
+			// rather than saving nonsense. See JETPACK-1990.
+			if ( width <= 0 ) {
+				return;
+			}
 			// Ignore sub-pixel width changes. When the block is a content-sized flex
 			// item (inside a Row/Stack), our own layout writes can feed back into the
 			// observed width; bailing here stops that feedback loop.

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/utils.js
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/layout/utils.js
@@ -1,3 +1,24 @@
 export function layoutSupportsColumns( layout ) {
 	return [ 'columns', 'circle', 'square' ].includes( layout );
 }
+
+/**
+ * Whether two `columnWidths` values describe the same grid of rows and columns.
+ *
+ * `columnWidths` is applied by position — `columnWidths[ rowIndex ][ colIndex ]` —
+ * against a row/column shape that is recomputed from the images on every render.
+ * Comparing shapes is how a saved value is recognised as belonging to a layout the
+ * block no longer renders. See JETPACK-1990.
+ *
+ * @param {Array<Array>} a - A columnWidths value.
+ * @param {Array<Array>} b - The columnWidths value to compare it against.
+ * @return {boolean} True when both have the same number of rows and the same number of columns in each row.
+ */
+export function hasSameColumnShape( a, b ) {
+	return (
+		Array.isArray( a ) &&
+		Array.isArray( b ) &&
+		a.length === b.length &&
+		a.every( ( row, rowIndex ) => row?.length === b[ rowIndex ]?.length )
+	);
+}

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/test/column-widths.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/test/column-widths.jsx
@@ -1,0 +1,175 @@
+import { render } from '@testing-library/react';
+import Edit from '../edit';
+
+// The mosaic watches its own size to decide when to lay out again. jsdom performs
+// no layout so the observer would never fire anyway, and the pass these tests
+// exercise is the one the component runs itself on mount. Stubbing the observer
+// keeps its global refresh machinery out of the test environment.
+jest.mock(
+	'resize-observer-polyfill',
+	() =>
+		class ResizeObserverStub {
+			observe() {}
+			unobserve() {}
+			disconnect() {}
+		}
+);
+
+/**
+ * Five portrait images.
+ *
+ * The mosaic algorithm lays this set out as a single row of five columns when the
+ * block is wide or full aligned, and as two rows (three columns, then two) at any
+ * other alignment. The saved `columnWidths` shape therefore differs between the
+ * two alignments, which is what makes the set useful here. See JETPACK-1990.
+ */
+const images = Array.from( { length: 5 }, ( _, i ) => ( {
+	alt: `Gallery Image ${ i + 1 }`,
+	height: 2048,
+	id: `${ i + 1 }`,
+	// A localhost URL stops photonizedImgProps from rewriting the src.
+	url: `http://localhost:4759/wp-content/uploads/2021/03/tree${ i + 1 }.jpeg`,
+	width: 1365,
+} ) );
+
+/** Widths the block saves for the two-row layout it uses when not wide aligned. */
+const narrowColumnWidths = [
+	[ '33.33333', '33.33333', '33.33333' ],
+	[ '50.00000', '50.00000' ],
+];
+
+/** Widths the block saves for the one-row layout it uses when wide aligned. */
+const wideColumnWidths = [ [ '20.00000', '20.00000', '20.00000', '20.00000', '20.00000' ] ];
+
+const GALLERY_WIDTH = 600;
+
+let clientWidthSpy;
+let animationFrameSpy;
+
+beforeEach( () => {
+	// jsdom performs no layout, so the mosaic would otherwise measure a 0px wide
+	// gallery. Give elements a width so a real layout pass runs.
+	clientWidthSpy = jest
+		.spyOn( window.Element.prototype, 'clientWidth', 'get' )
+		.mockReturnValue( GALLERY_WIDTH );
+	// The mosaic defers its layout pass to an animation frame. Running it inline
+	// means rendering the block is enough to observe what it writes back.
+	animationFrameSpy = jest
+		.spyOn( window, 'requestAnimationFrame' )
+		.mockImplementation( callback => {
+			callback();
+			return 0;
+		} );
+} );
+
+afterEach( () => {
+	clientWidthSpy.mockRestore();
+	animationFrameSpy.mockRestore();
+} );
+
+/**
+ * Render the block and return the setAttributes it was given.
+ *
+ * The mosaic lays itself out on mount, so by the time this returns the block has
+ * already written back whatever it intends to.
+ *
+ * @param {object} attributes - Block attributes to render the block with.
+ * @return {Function} The setAttributes mock the block was rendered with.
+ */
+function layOutGallery( attributes ) {
+	const setAttributes = jest.fn();
+	render( <Edit attributes={ attributes } setAttributes={ setAttributes } isSelected={ false } /> );
+	return setAttributes;
+}
+
+/**
+ * Column count of each row in a columnWidths value.
+ *
+ * @param {Array<Array>} columnWidths - A columnWidths attribute value.
+ * @return {Array<number>|undefined} Number of columns in each row.
+ */
+function shapeOf( columnWidths ) {
+	return columnWidths?.map( row => row.length );
+}
+
+/**
+ * Percentage each row of a columnWidths value adds up to, rounded to two decimals.
+ *
+ * @param {Array<Array>} columnWidths - A columnWidths attribute value.
+ * @return {Array<number>|undefined} Total percentage of each row.
+ */
+function rowTotalsOf( columnWidths ) {
+	return columnWidths?.map(
+		row =>
+			Math.round( row.reduce( ( total, width ) => total + parseFloat( width ), 0 ) * 100 ) / 100
+	);
+}
+
+/**
+ * The columnWidths value the block last wrote back, or undefined if it wrote none.
+ *
+ * @param {Function} setAttributes - The setAttributes mock the block was rendered with.
+ * @return {Array<Array>|undefined} The columnWidths that were written, if any.
+ */
+function writtenColumnWidths( setAttributes ) {
+	const call = setAttributes.mock.calls.filter( ( [ attrs ] ) => 'columnWidths' in attrs ).pop();
+	return call?.[ 0 ].columnWidths;
+}
+
+describe( 'columnWidths staleness', () => {
+	it( 'rewrites saved columnWidths that no longer match the rendered layout', () => {
+		// Widths computed for the not-wide layout, now rendered wide aligned. The
+		// block used to keep the stale value because no image had changed, which
+		// baked a two-row set of widths into a one-row layout on the next save:
+		// the row took the first three widths, summing to 100% across five columns,
+		// and the last two columns got no flex-basis at all.
+		const setAttributes = layOutGallery( {
+			align: 'wide',
+			columnWidths: narrowColumnWidths,
+			images,
+		} );
+
+		expect( shapeOf( writtenColumnWidths( setAttributes ) ) ).toEqual( [ 5 ] );
+	} );
+
+	it( 'writes columnWidths whose every row fills the gallery', () => {
+		// The layout algorithm normalises each row to 100%, so a row adding up to
+		// anything else can only be widths belonging to a differently shaped row.
+		// That is what shipped to readers as a 57% wide row. See JETPACK-1990.
+		const setAttributes = layOutGallery( {
+			align: 'wide',
+			columnWidths: narrowColumnWidths,
+			images,
+		} );
+
+		expect( rowTotalsOf( writtenColumnWidths( setAttributes ) ) ).toEqual( [ 100 ] );
+	} );
+
+	it( 'writes nothing when the gallery has no width to lay out against', () => {
+		// A gallery that has not been laid out yet, or that sits inside a hidden
+		// container, measures 0px. A single column row reserves no gutter, so the
+		// row is 0px wide too and turning its column into a percentage of the row
+		// divides zero by zero. The resulting "NaN" must never reach saved content.
+		clientWidthSpy.mockReturnValue( 0 );
+
+		const setAttributes = layOutGallery( {
+			align: 'wide',
+			columnWidths: narrowColumnWidths,
+			images: images.slice( 0, 1 ),
+		} );
+
+		expect( writtenColumnWidths( setAttributes ) ).toBeUndefined();
+	} );
+
+	it( 'leaves saved columnWidths alone when they still match the rendered layout', () => {
+		// Opening a post must not mark it as modified. Nothing changed here, so the
+		// block has no reason to write anything back.
+		const setAttributes = layOutGallery( {
+			align: 'wide',
+			columnWidths: wideColumnWidths,
+			images,
+		} );
+
+		expect( writtenColumnWidths( setAttributes ) ).toBeUndefined();
+	} );
+} );

--- a/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
+++ b/projects/plugins/jetpack/extensions/blocks/tiled-gallery/tiled-gallery.php
@@ -103,6 +103,18 @@ class Tiled_Gallery {
 						continue;
 					}
 
+					// data-width and data-height describe the original upload, but the
+					// candidates below are built on the src, which is usually a smaller
+					// intermediate size. Photon never upscales, so sizing the srcset from
+					// the original would advertise widths that resolve to a narrower image
+					// than the browser was told to expect, and the tile renders soft on a
+					// high density screen. Cap both to what the source file can produce.
+					$source_dimensions = self::get_source_file_dimensions( $orig_src );
+					if ( null !== $source_dimensions ) {
+						$orig_width  = min( $orig_width, $source_dimensions[0] );
+						$orig_height = min( $orig_height, $source_dimensions[1] );
+					}
+
 					$srcset_parts = array();
 					if ( $is_squareish_layout ) {
 						$min_width = min( self::IMG_SRCSET_WIDTH_MIN, $orig_width, $orig_height );
@@ -175,6 +187,25 @@ class Tiled_Gallery {
 	}
 
 	/**
+	 * Dimensions of the file an image URL points at, when it names a WordPress intermediate size.
+	 *
+	 * WordPress appends -WIDTHxHEIGHT to the file name of every size it generates, so
+	 * a URL ending that way tells us how large the file behind it actually is. Returns
+	 * null for anything else, including the original upload, whose size is unknowable
+	 * from the URL alone.
+	 *
+	 * @param string $url Image URL, with any query string already removed.
+	 * @return array|null Array of width and height, or null if the URL names no size.
+	 */
+	private static function get_source_file_dimensions( $url ) {
+		if ( ! preg_match( '/-(\d+)x(\d+)\.[a-zA-Z0-9]+$/', $url, $dimensions ) ) {
+			return null;
+		}
+
+		return array( absint( $dimensions[1] ), absint( $dimensions[2] ) );
+	}
+
+	/**
 	 * Adds tabindex, role and aria-label markup for images that should be interactive (front-end only).
 	 *
 	 * @param integer $image_index Integer The current image index.
@@ -194,7 +225,9 @@ class Tiled_Gallery {
 				$image_index,
 				$number_images
 			);
-			$img_element = '<img role="button" tabindex="0" aria-label="' . esc_attr( $aria_label_content ) . '"';
+			// The trailing space matters: render() appends the srcset directly onto
+			// this string, and without it the two run together as aria-label="…"srcset="…".
+			$img_element = '<img role="button" tabindex="0" aria-label="' . esc_attr( $aria_label_content ) . '" ';
 		} else {
 			$img_element = '<img ';
 		}

--- a/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
+++ b/projects/plugins/jetpack/modules/carousel/jetpack-carousel.php
@@ -828,6 +828,14 @@ class Jetpack_Carousel {
 		}
 		$selected_images = array();
 		foreach ( $matches[0] as $image_html ) {
+			// This image already carries the attributes this method adds, so adding
+			// them again would emit every one of them twice. Tiled Gallery output
+			// reaches this filter twice: once as 'jetpack_tiled_galleries_block_content'
+			// from inside the block's render callback, and again as 'the_content' when
+			// single image galleries are enabled. See JETPACK-1990.
+			if ( str_contains( $image_html, 'data-attachment-id=' ) ) {
+				continue;
+			}
 			if (
 				preg_match( '/(wp-image-|data-id=)\"?([0-9]+)\"?/i', $image_html, $class_id )
 				&& ! str_contains( $image_html, 'wp-block-jetpack-slideshow_image' )

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Tiled_Gallery_Block_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Tiled_Gallery_Block_Test.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Tiled Gallery Block tests
+ *
+ * @package automattic/jetpack
+ */
+
+require_once JETPACK__PLUGIN_DIR . 'extensions/blocks/tiled-gallery/tiled-gallery.php';
+
+use Automattic\Jetpack\Extensions\Tiled_Gallery;
+use PHPUnit\Framework\Attributes\CoversMethod;
+
+/**
+ * Tiled Gallery Block tests.
+ *
+ * The block saves its markup from JavaScript; these tests cover the server side
+ * pass that rewrites the saved <img> tags on the front end.
+ *
+ * @covers Automattic\Jetpack\Extensions\Tiled_Gallery::render
+ */
+#[CoversMethod( Automattic\Jetpack\Extensions\Tiled_Gallery::class, 'render' )]
+class Tiled_Gallery_Block_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	const UPLOADS = 'http://example.org/wp-content/uploads/2026/07/';
+
+	/**
+	 * Saved markup for a single image gallery.
+	 *
+	 * @param string $file   File name the img src points at.
+	 * @param int    $width  Value of the img's data-width, the width of the original upload.
+	 * @param int    $height Value of the img's data-height, the height of the original upload.
+	 * @return string The gallery markup as the block's save function writes it.
+	 */
+	private function gallery_markup( $file, $width, $height ) {
+		return '<div class="wp-block-jetpack-tiled-gallery is-style-rectangular">'
+			. '<div class="tiled-gallery__gallery">'
+			. '<div class="tiled-gallery__row">'
+			. '<div class="tiled-gallery__col" style="flex-basis:100%">'
+			. '<figure class="tiled-gallery__item">'
+			. '<img alt="" data-height="' . $height . '" data-id="1"'
+			. ' data-url="' . self::UPLOADS . $file . '" data-width="' . $width . '"'
+			. ' src="' . self::UPLOADS . $file . '"/>'
+			. '</figure></div></div></div></div>';
+	}
+
+	/**
+	 * Widths advertised by the first srcset in a chunk of markup.
+	 *
+	 * @param string $markup Rendered block markup.
+	 * @return array Width descriptors found in the srcset, as integers.
+	 */
+	private function srcset_widths( $markup ) {
+		if ( ! preg_match( '/srcset="([^"]*)"/', $markup, $srcset ) ) {
+			return array();
+		}
+
+		$widths = array();
+		foreach ( explode( ',', html_entity_decode( $srcset[1] ) ) as $candidate ) {
+			if ( preg_match( '/\s(\d+)w$/', trim( $candidate ), $width ) ) {
+				$widths[] = (int) $width[1];
+			}
+		}
+		return $widths;
+	}
+
+	/**
+	 * Pretend the Carousel module is active, which is what makes the block add the
+	 * role, tabindex and aria-label attributes that open an image full screen.
+	 */
+	private function activate_carousel() {
+		add_filter(
+			'jetpack_active_modules',
+			function ( $modules ) {
+				$modules[] = 'carousel';
+				return $modules;
+			}
+		);
+	}
+
+	/**
+	 * The srcset must not be glued to the attribute before it.
+	 *
+	 * With Carousel active the block prefixes the img with an aria-label and then
+	 * appends the srcset, and the two ran together as aria-label="…"srcset="…".
+	 * See JETPACK-1990.
+	 */
+	public function test_render_separates_srcset_from_the_preceding_attribute() {
+		$this->activate_carousel();
+
+		$rendered = Tiled_Gallery::render(
+			array( 'className' => 'is-style-rectangular' ),
+			$this->gallery_markup( 'photo.jpg', 2048, 1365 )
+		);
+
+		$this->assertStringContainsString( 'aria-label=', $rendered );
+		$this->assertStringNotContainsString( '"srcset=', $rendered );
+	}
+
+	/**
+	 * The srcset must not advertise widths the file it points at cannot produce.
+	 *
+	 * The candidates are sized from the original upload's data-width, but they are
+	 * built on the img's src, which is usually an intermediate size. Photon never
+	 * upscales, so a candidate wider than that file serves a narrower image than
+	 * the browser was told to expect. See JETPACK-1990.
+	 */
+	public function test_render_caps_srcset_widths_at_the_width_of_the_source_file() {
+		$rendered = Tiled_Gallery::render(
+			array( 'className' => 'is-style-rectangular' ),
+			$this->gallery_markup( 'photo-1024x683.jpg', 2048, 1365 )
+		);
+
+		$widths = $this->srcset_widths( $rendered );
+
+		$this->assertNotEmpty( $widths );
+		$this->assertLessThanOrEqual( 1024, max( $widths ) );
+	}
+
+	/**
+	 * An src with no intermediate size suffix still gets the full range of candidates.
+	 */
+	public function test_render_sizes_srcset_from_the_original_when_src_has_no_size_suffix() {
+		$rendered = Tiled_Gallery::render(
+			array( 'className' => 'is-style-rectangular' ),
+			$this->gallery_markup( 'photo.jpg', 2048, 1365 )
+		);
+
+		$this->assertSame( 2000, max( $this->srcset_widths( $rendered ) ) );
+	}
+}

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/Tiled_Gallery_Block_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/Tiled_Gallery_Block_Test.php
@@ -55,13 +55,12 @@ class Tiled_Gallery_Block_Test extends WP_UnitTestCase {
 			return array();
 		}
 
-		$widths = array();
-		foreach ( explode( ',', html_entity_decode( $srcset[1] ) ) as $candidate ) {
-			if ( preg_match( '/\s(\d+)w$/', trim( $candidate ), $width ) ) {
-				$widths[] = (int) $width[1];
-			}
-		}
-		return $widths;
+		// Match the width descriptors directly rather than splitting on the comma
+		// separator: the candidate URLs are escaped, and a squareish layout puts a
+		// comma inside them via the resize argument. URLs never contain a space,
+		// so a space followed by digits and a "w" is unambiguously a descriptor.
+		preg_match_all( '/\s(\d+)w/', $srcset[1], $widths );
+		return array_map( 'intval', $widths[1] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/modules/carousel/Jetpack_Carousel_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/carousel/Jetpack_Carousel_Test.php
@@ -161,6 +161,27 @@ class Jetpack_Carousel_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Adding the data attributes twice must not add them twice.
+	 *
+	 * Tiled Gallery output passes through this filter once as
+	 * 'jetpack_tiled_galleries_block_content', from inside the block's render
+	 * callback, and again as 'the_content' when single image galleries are enabled.
+	 * Both hooks see the same markup, so without a guard every carousel data-*
+	 * attribute is emitted twice. See JETPACK-1990.
+	 */
+	public function test_add_data_img_tags_and_enqueue_assets_is_idempotent() {
+		$attachment = $this->create_image_attachment_with_exif();
+		$content    = '<div class="tiled-gallery__item"><img alt="" data-id="' . $attachment->ID
+			. '" data-height="100" data-width="100" src="https://example.com/jetpack-icon.jpg" /></div>';
+
+		$once  = $this->instance->add_data_img_tags_and_enqueue_assets( $content );
+		$twice = $this->instance->add_data_img_tags_and_enqueue_assets( $once );
+
+		$this->assertSame( 1, substr_count( $once, 'data-attachment-id=' ) );
+		$this->assertSame( $once, $twice );
+	}
+
+	/**
 	 * When the EXIF display option is enabled (the default), add_data_to_images()
 	 * should include the data-image-meta attribute.
 	 */


### PR DESCRIPTION
Fixes JETPACK-1990

## Proposed changes

* **Tiled Gallery: keep saved `columnWidths` in sync with the rendered layout.** The row/column shape is recomputed from the image ratios and the alignment on every render, but `columnWidths` is a stored attribute applied by position (`columnWidths[ rowIndex ][ colIndex ]`). `onResize` only persisted a recomputed value once the user had edited the images, so changing the alignment — which edits no image — left the saved widths describing a layout the block no longer draws. Saving then spread one row's widths over a differently shaped row and the published post rendered rows at a fraction of the content width. Widths are now persisted whenever their shape stops matching, which also repairs already-broken posts when they are reopened, while a consistent gallery is still left untouched so opening a post does not mark it as modified.
* **Tiled Gallery: skip the layout pass at 0px.** Percentages derived from an unmeasured gallery are meaningless — a single-column row divides zero by zero and yields `"NaN"` — and those widths are now persisted, so the pass waits for a real measurement.
* **Tiled Gallery: cap srcset candidates at the source file's width.** Candidates were sized from `data-width` (the original upload) but built on the img's `src`, which is usually a smaller intermediate size. Photon never upscales, so a candidate wider than that file served a narrower image than advertised and tiles rendered soft on high-density screens.
* **Tiled Gallery: separate the srcset from the attribute before it.** With Carousel active the interactive markup ran into the appended srcset, producing `aria-label="…"srcset="…"`.
* **Carousel: stop adding a duplicate set of image data attributes.** Tiled Gallery output passes through `add_data_img_tags_and_enqueue_assets` twice — once as `jetpack_tiled_galleries_block_content` from inside the block's render callback, again as `the_content` when single-image galleries are enabled. The method had no guard against images already carrying its attributes, so every carousel `data-*` attribute was emitted twice. Measured at **8,840 bytes, 5.7% of the response**, on all 10 images of a test gallery. Browsers keep the first occurrence, so it is invisible in DevTools and only shows in the raw markup.

`isWide` has been an input to the shape function since deprecation v1, so the desync is a latent design flaw rather than a recent regression. The fix is editor-side only — no change to `save()` output, so no new block deprecation is needed.

## Related product discussion/links

* JETPACK-1990
* Same family as JETPACK-1726 (resize loop in Row/Stack) and JETPACK-1900 (width collapse on a non-iframed canvas), but this one corrupts published output.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The corruption is **save-time only** — the editor canvas re-measures and always looks correct, so the bug is only visible on the published page. That is why it went unnoticed.

**Reproducing the bug (on `trunk`)**

* Create a post with a Tiled Gallery whose layout differs between alignments. Roughly 9–10 images with mixed portrait/landscape ratios works; the packing algorithm must produce a different number of columns in at least one row for wide vs. centre.
* Set the alignment, then **save**, then **reload the editor**. The reload matters — it resets the internal `changed` flag, which is what the old code gated on.
* Now change the alignment (e.g. wide → centre) and save again. Do not touch any image.
* View the published post. At least one row renders short of the content width, or a column renders with no `flex-basis` at all.
* Inspect the saved markup: the `flex-basis` values in the affected row no longer add up to 100%.

**Verifying the fix (this branch)**

* Open the broken post. The block detects the mismatch and repairs the widths on load, so the post is immediately marked as modified. Save, then reload the published page — every row now fills the width.
* Repeat the alignment change above. Widths now follow every time; cycling wide → centre → wide → full keeps every row at 100%.
* Open a gallery that was already consistent and confirm the post is **not** marked as modified — opening a post must not dirty it.

**srcset and Carousel attributes**

* Enable the Carousel module and view a post with a Tiled Gallery.
* View source (not DevTools — the parser hides both problems). Each carousel `data-*` attribute should appear once per image, and `aria-label="…" srcset="…"` should have a space between them.
* No srcset candidate should advertise a width larger than the size in the `src` file name (e.g. an `…-1024x683.jpg` src should stop at `1024w`, even though `data-width` says `1880`).

**Automated tests**

```
cd projects/plugins/jetpack
TZ=UTC pnpm exec jest --config=tests/jest.config.extensions.js tiled-gallery
jp docker phpunit jetpack -- --filter='Tiled_Gallery_Block_Test|Jetpack_Carousel_Test'
```

## Before / after

Captured on a local `jp docker` site at 1440×900.

**Published post** — the last row renders at 66% of the content width before the fix, full width after:

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/jetpack-1990-tiled-gallery-columnwidths-desync/before-published.jpg) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/jetpack-1990-tiled-gallery-columnwidths-desync/after-published.jpg) |

**Editor** — deliberately identical. `layout/index.jsx` passes `columnWidths` only when `isSave`, so the canvas re-measures and renders correctly no matter what is stored. This pair is included to show why the corruption reaches readers without the author noticing:

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/jetpack-1990-tiled-gallery-columnwidths-desync/before-editor.jpg) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/jetpack-1990-tiled-gallery-columnwidths-desync/after-editor.jpg) |
