### PR TITLE
Premium Content: stop treating a bare WordPress session as proof of subscription

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-nl-787-login-button-session-trap
+++ b/projects/plugins/jetpack/changelog/fix-nl-787-login-button-session-trap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Content: stop treating a bare WordPress session as proof of subscription in the Subscriber Login and Premium Content login button blocks, which could hide the only way to recover a subscription token.

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/login-button/login-button.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/login-button/login-button.php
@@ -80,12 +80,21 @@ function get_subscriber_login_url( $redirect ) {
 }
 
 /**
- * Determines whether the current visitor is a logged in user or a subscriber.
+ * Determines whether the current visitor is a confirmed subscriber -- someone who
+ * actually holds a premium-content session token, not merely someone with a
+ * WordPress session on this site.
+ *
+ * A bare WordPress session is not proof of a subscription (see NL-787): the
+ * previous is_user_logged_in() || has_token_from_cookie() check hid this block's
+ * only "Log in" link -- the sole way to mint a fresh token via the
+ * subscribe.wordpress.com magic-link round trip -- for anyone the site owner
+ * simply added as a WP user (or anyone else with an ordinary session and no
+ * token), leaving them with no way to recover.
  *
  * @return bool
  */
 function is_subscriber_logged_in() {
-	return is_user_logged_in() || Abstract_Token_Subscription_Service::has_token_from_cookie();
+	return is_user_logged_in() && Abstract_Token_Subscription_Service::has_token_from_cookie();
 }
 
 /**

--- a/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
+++ b/projects/plugins/jetpack/extensions/blocks/subscriber-login/subscriber-login.php
@@ -113,12 +113,21 @@ function get_subscriber_login_url( $redirect ) {
 }
 
 /**
- * Determines whether the current visitor is a logged in user or a subscriber.
+ * Determines whether the current visitor is a confirmed subscriber -- someone who
+ * actually holds a premium-content session token, not merely someone with a
+ * WordPress session on this site.
+ *
+ * A bare WordPress session is not proof of a subscription (see NL-787): the
+ * previous is_user_logged_in() || has_token_from_cookie() check hid this block's
+ * only "Log in" link -- the sole way to mint a fresh token via the
+ * subscribe.wordpress.com magic-link round trip -- for anyone the site owner
+ * simply added as a WP user (or anyone else with an ordinary session and no
+ * token), leaving them with no way to recover.
  *
  * @return bool
  */
 function is_subscriber_logged_in() {
-	return is_user_logged_in() || Abstract_Token_Subscription_Service::has_token_from_cookie();
+	return is_user_logged_in() && Abstract_Token_Subscription_Service::has_token_from_cookie();
 }
 
 /**


### PR DESCRIPTION
Closes NL-803

## Proposed changes

* `is_subscriber_logged_in()` (duplicated identically in the Premium Content `login-button` block and the standalone `Subscriber Login` block) now requires an actual premium-content session token before treating a visitor as a confirmed subscriber, instead of accepting a bare WordPress session as sufficient proof.

## Related product discussion/links

* Linear: NL-803 — reports this specific bug (session treated as proof of subscription, hiding the "Log in" link).
* Linear: NL-787 — the broader investigation this was found during: a paid subscriber saw the guest view of Paid Content blocks after logging in on Atomic, with no way to recover because this check hid the only path to mint a fresh subscription token.
* Companion fix on the wpcom side, for a related but separate bug in the same investigation (a checkout-time race condition): https://github.a8c.com/Automattic/wpcom/pull/231801

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

### Reproduce the bug (before this fix) / confirm it's gone (after)

1. On a Jetpack-connected site that is **not** WPCOM Simple (an Atomic site, a Jurassic Ninja site, or any self-hosted Jetpack install), create a paid plan/tier (**Jetpack → Newsletter** → add a paid tier, or via `POST /wpcom/v2/memberships/product`).
2. Create a page with a Paid Content block, with the plan from step 1 selected on the block, so it actually gates content (the `logged-out-view` should contain the `login-button` child block) — or a page with a standalone Subscriber Login block, which doesn't need a plan.
3. Create a local WordPress user **without** going through Jetpack SSO — e.g. from **wp-admin → Users → Add New**, or `wp user create testuser test@example.com --role=subscriber`. This reproduces the real-world trigger: a site owner adding a reader directly instead of the reader connecting via SSO.
4. Log in as that user through the normal `wp-login.php` form (username/password) — not through "Log in with WordPress.com".
5. Clear cookies for the site's domain, or confirm in DevTools → Application → Cookies that no `wp-jp-premium-content-session` cookie is present.
6. Visit the page from step 2.
   * **Before this fix:** the block correctly shows the gated view (this user genuinely has no subscription), but no "Log in" link is shown — there is no way to trigger a fresh token.
   * **After this fix:** the "Log in" link is visible, and clicking it goes through the normal `subscribe.wordpress.com/memberships/jwt/` magic-link round trip.

### Confirm no regression for confirmed subscribers

7. As a user who already has a valid `wp-jp-premium-content-session` cookie (e.g. completed a real or sandboxed purchase), visit the same page.
8. Confirm the "Log in" link is still hidden, same as before this fix — a real token should still suppress the link.

### Confirm WPCOM Simple is unaffected either way

9. Repeat steps 1-6 on a WPCOM Simple site instead. Behavior should be unchanged from before this fix in both directions — Simple was never affected by the underlying bug, since the local user ID and WordPress.com user ID are the same value there and no identity gap exists.
