### PR TITLE
Premium Content: self-heal wpcom_user_id from a verified magic-link token

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-nl-805-wpcom-user-id-self-heal
+++ b/projects/plugins/jetpack/changelog/fix-nl-805-wpcom-user-id-self-heal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Premium Content: self-heal the wpcom_user_id link on a local WordPress account from a freshly-verified magic-link token, so subscription access can be recognized on subsequent visits without another login round trip.

--- a/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
+++ b/projects/plugins/jetpack/extensions/blocks/premium-content/_inc/subscription-service/class-abstract-token-subscription-service.php
@@ -70,10 +70,50 @@ abstract class Abstract_Token_Subscription_Service implements Subscription_Servi
 		$token = $this->token_from_request();
 		if ( null !== $token ) {
 			$this->set_token_cookie( $token );
+			$this->maybe_link_wpcom_user_id( $token );
 			return $token;
 		}
 
 		return $this->token_from_cookie();
+	}
+
+	/**
+	 * Self-heals the local user's wpcom_user_id meta from a freshly-verified magic-link
+	 * token, so future requests can resolve this visitor's subscriptions via the
+	 * authoritative filter (see get_subscriptions_for_logged_in_user() in access-check.php)
+	 * without needing another magic-link round trip once the token/cookie expires.
+	 *
+	 * Safe because the token's user_id was just verified by WordPress.com's own session
+	 * at subscribe.wordpress.com -- never read from anything stored locally. A local
+	 * account's email is not proof of identity by itself (anyone with admin access could
+	 * type in any email when creating a local user), so this additionally requires the
+	 * local account's own email to match the token's blog_subscriber email before linking,
+	 * to avoid mis-linking a local account to whichever WordPress.com session happens to
+	 * be active in the browser (e.g. a shared device) when the two aren't otherwise related.
+	 *
+	 * @param string $token The raw token string from the incoming request.
+	 * @return void
+	 */
+	private function maybe_link_wpcom_user_id( $token ) {
+		if ( ! is_user_logged_in() ) {
+			return;
+		}
+
+		$payload = $this->decode_token( $token );
+		if ( empty( $payload['user_id'] ) || empty( $payload['blog_subscriber'] ) ) {
+			return;
+		}
+
+		$local_user = wp_get_current_user();
+		if ( strcasecmp( $local_user->user_email, $payload['blog_subscriber'] ) !== 0 ) {
+			return;
+		}
+
+		if ( (int) get_user_meta( $local_user->ID, 'wpcom_user_id', true ) === (int) $payload['user_id'] ) {
+			return;
+		}
+
+		update_user_meta( $local_user->ID, 'wpcom_user_id', (int) $payload['user_id'] );
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/blocks/premium-content/Jetpack_Premium_Content_Test.php
@@ -321,6 +321,177 @@ class Jetpack_Premium_Content_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A freshly-verified magic-link token whose blog_subscriber email matches the local
+	 * account's own email should self-heal the wpcom_user_id link (NL-805), so future
+	 * requests can resolve subscriptions via the authoritative filter without another
+	 * magic-link round trip once the token/cookie expires.
+	 *
+	 * @return void
+	 */
+	public function test_get_and_set_token_from_request_links_wpcom_user_id_when_email_matches() {
+		$local_user_id = $this->factory->user->create(
+			array( 'user_email' => 'matching@example.test' )
+		);
+		$wpcom_user_id = 999999;
+
+		wp_set_current_user( $local_user_id );
+		$this->assertSame( '', get_user_meta( $local_user_id, 'wpcom_user_id', true ) );
+
+		$this->set_returned_token(
+			array(
+				'user_id'         => $wpcom_user_id,
+				'blog_subscriber' => 'matching@example.test',
+				'subscriptions'   => array(),
+			)
+		);
+
+		subscription_service()->get_and_set_token_from_request();
+
+		$this->assertSame( $wpcom_user_id, (int) get_user_meta( $local_user_id, 'wpcom_user_id', true ) );
+	}
+
+	/**
+	 * The email match must be case-insensitive -- WordPress itself normalizes emails to
+	 * lowercase in some paths but not all, and email addresses are case-insensitive by
+	 * convention.
+	 *
+	 * @return void
+	 */
+	public function test_get_and_set_token_from_request_links_wpcom_user_id_with_case_insensitive_email_match() {
+		$local_user_id = $this->factory->user->create(
+			array( 'user_email' => 'Matching@Example.Test' )
+		);
+		$wpcom_user_id = 999999;
+
+		wp_set_current_user( $local_user_id );
+		$this->set_returned_token(
+			array(
+				'user_id'         => $wpcom_user_id,
+				'blog_subscriber' => 'matching@example.test',
+				'subscriptions'   => array(),
+			)
+		);
+
+		subscription_service()->get_and_set_token_from_request();
+
+		$this->assertSame( $wpcom_user_id, (int) get_user_meta( $local_user_id, 'wpcom_user_id', true ) );
+	}
+
+	/**
+	 * A local account must never be linked to whichever WordPress.com session happens to
+	 * be active in the browser (e.g. a shared device) when the two aren't otherwise the
+	 * same person -- only a matching email is trusted as confirmation. The local
+	 * account's own stored email is never proof of identity by itself (see NL-787's
+	 * account-impersonation concern), so a mismatch must not link anything.
+	 *
+	 * @return void
+	 */
+	public function test_get_and_set_token_from_request_does_not_link_when_email_mismatch() {
+		$local_user_id = $this->factory->user->create(
+			array( 'user_email' => 'local-account@example.test' )
+		);
+
+		wp_set_current_user( $local_user_id );
+		$this->set_returned_token(
+			array(
+				'user_id'         => 999999,
+				'blog_subscriber' => 'someone-else@example.test',
+				'subscriptions'   => array(),
+			)
+		);
+
+		subscription_service()->get_and_set_token_from_request();
+
+		$this->assertSame( '', get_user_meta( $local_user_id, 'wpcom_user_id', true ) );
+	}
+
+	/**
+	 * An anonymous visitor (e.g. arriving via a ?token= magic link from a newsletter
+	 * email, with no local WordPress session at all) has no local account to link --
+	 * this must not error, and the token must still be returned normally.
+	 *
+	 * @return void
+	 */
+	public function test_get_and_set_token_from_request_does_not_link_when_not_logged_in() {
+		wp_set_current_user( 0 );
+		$this->set_returned_token(
+			array(
+				'user_id'         => 999999,
+				'blog_subscriber' => 'someone@example.test',
+				'subscriptions'   => array(),
+			)
+		);
+
+		$token = subscription_service()->get_and_set_token_from_request();
+
+		$this->assertNotEmpty( $token, 'The token should still be returned even with no local user to link.' );
+	}
+
+	/**
+	 * A stale wpcom_user_id (e.g. left over from a previous WordPress.com account that
+	 * used to own this email) must be corrected to match the freshly-verified token, not
+	 * left alone just because some value was already present.
+	 *
+	 * @return void
+	 */
+	public function test_get_and_set_token_from_request_updates_stale_wpcom_user_id() {
+		$local_user_id = $this->factory->user->create(
+			array( 'user_email' => 'matching@example.test' )
+		);
+		update_user_meta( $local_user_id, 'wpcom_user_id', 111111 );
+
+		wp_set_current_user( $local_user_id );
+		$this->set_returned_token(
+			array(
+				'user_id'         => 999999,
+				'blog_subscriber' => 'matching@example.test',
+				'subscriptions'   => array(),
+			)
+		);
+
+		subscription_service()->get_and_set_token_from_request();
+
+		$this->assertSame( 999999, (int) get_user_meta( $local_user_id, 'wpcom_user_id', true ) );
+	}
+
+	/**
+	 * Once the meta already matches the token, no redundant meta write should happen.
+	 *
+	 * @return void
+	 */
+	public function test_get_and_set_token_from_request_does_not_rewrite_when_already_linked() {
+		$local_user_id = $this->factory->user->create(
+			array( 'user_email' => 'matching@example.test' )
+		);
+		update_user_meta( $local_user_id, 'wpcom_user_id', 999999 );
+
+		wp_set_current_user( $local_user_id );
+		$this->set_returned_token(
+			array(
+				'user_id'         => 999999,
+				'blog_subscriber' => 'matching@example.test',
+				'subscriptions'   => array(),
+			)
+		);
+
+		$update_count = 0;
+		add_action(
+			'updated_user_meta',
+			static function ( $meta_id, $user_id, $meta_key ) use ( &$update_count ) {
+				if ( 'wpcom_user_id' === $meta_key ) {
+					++$update_count;
+				}
+			},
+			10,
+			3
+		);
+
+		subscription_service()->get_and_set_token_from_request();
+
+		$this->assertSame( 0, $update_count, 'No meta write should happen when the value is already correct.' );
+	}
+
+	/**
 	 * Regression guard: a logged-in user without `wpcom_user_id` user_meta (the typical
 	 * Jetpack self-hosted case) must still be granted access via the JWT cookie path.
 	 *


### PR DESCRIPTION
Closes NL-805

## Proposed changes

* When a visitor logs in through the Newsletter magic-link flow (`subscribe.wordpress.com`) and we verify their token, we now also save their real WordPress.com identity (`wpcom_user_id`) on their local WordPress account — the same thing that already happens for accounts connected via full Jetpack SSO, just extended to this second, more common login path.
* We only save it when the local account's email matches the verified email from the token. We never trust the local account's own stored email by itself, since anyone with admin access could type in any email when creating a local account — that would let one browser session get linked to a stranger's WordPress.com identity.
* Why this matters: once that identity is saved, the site can recognize the visitor's real subscriptions on any future visit — even after their login cookie expires or they switch devices — without making them go through the magic-link flow again. Before this fix, accounts that only ever used the magic link (rather than full SSO) never got this saved, so they lost access repeatedly.
* Added test coverage for the new behavior in `Jetpack_Premium_Content_Test.php`.

## Related product discussion/links

* Linear: NL-805 — this specific bug.
* Linear: NL-787 — the broader investigation this was found during (a paid subscriber saw the guest view of Paid Content blocks after logging in, with no way to recover).
* Companion fixes from the same investigation:
  * Automattic/jetpack#50984 — `is_subscriber_logged_in()` treating a bare session as proof of subscription (NL-803).
  * wpcom/pull/231801 — a checkout-time race condition on the wpcom side (NL-804).

## Does this pull request change what data or activity we track or use?

No. `wpcom_user_id` is an existing user_meta key already populated by Jetpack SSO for the same purpose — this only adds a second, safe path to populate it.

## Testing instructions

### Automated

* `Jetpack_Premium_Content_Test.php` has 6 new test cases covering: successful link on email match, case-insensitive match, no-link on email mismatch, no-op for anonymous visitors, correcting a stale existing value, and not rewriting when already correct.

### Manual

1. On a Jetpack-connected site that is **not** WPCOM Simple, create a local WordPress user directly (Users → Add New) using the **same email** as a real WordPress.com account that has an active subscription to this site's Paid Content — do **not** connect via Jetpack SSO.
2. Confirm `wpcom_user_id` user_meta is empty for that user: `wp user meta get <id> wpcom_user_id`.
3. Log in as that local user via `wp-login.php` (username/password).
4. Visit a page with a Paid Content block gated by the plan that account is subscribed to, and click "Log in" (requires Automattic/jetpack#50984, or an ordinary session with no token, to see the link at all) to go through the `subscribe.wordpress.com/memberships/jwt/` magic-link round trip.
5. After returning from that flow, check the meta again: `wp user meta get <id> wpcom_user_id` should now show the real WordPress.com user ID from the token.
6. Repeat steps 1-4 but create the local user with a **different** email than the real WordPress.com account being used to complete the magic link. Confirm the meta remains empty after step 4 — the mismatch must not link anything.
7. **Basic recovery case**: with `wpcom_user_id` now set from step 5, delete the `wp-jp-premium-content-session` cookie (no token in the URL either). Reload the paid content page. Confirm the purchased content is shown — `get_subscriptions_for_logged_in_user()` resolves the correct WordPress.com identity from the meta alone and restores access without another magic-link trip.
