### PR TITLE
Premium Analytics: give a time-series summary the same date shape with and without rows

### DIFF
--- a/projects/packages/premium-analytics/changelog/nova-stats-384-summary-bound-shape
+++ b/projects/packages/premium-analytics/changelog/nova-stats-384-summary-bound-shape
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats: report the same date format in a time-series summary whether or not the response contained rows.

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/time-series.test.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/__tests__/time-series.test.ts
@@ -271,6 +271,49 @@ describe( 'Stats time-series normalizer', () => {
 		expect( result.summary ).toEqual( { date_start: '', date_end: '' } );
 	} );
 
+	it( 'restamps an offset-bearing query date as a bucket bound when no rows are returned', () => {
+		const result = sanitizeStatsTimeSeriesResponse(
+			{},
+			{
+				start_date: '2026-06-15T00:00:00-07:00',
+				end_date: '2026-06-16T23:59:59-07:00',
+			}
+		);
+
+		expect( result.data ).toEqual( [] );
+		expect( result.summary ).toEqual( {
+			date_start: '2026-06-15T00:00:00+00:00',
+			date_end: '2026-06-16T23:59:59+00:00',
+		} );
+	} );
+
+	it( 'falls back to the offset-bearing `date` param for date_end when end_date is absent', () => {
+		const result = sanitizeStatsTimeSeriesResponse(
+			{},
+			{ start_date: '2026-06-15T00:00:00-07:00', date: '2026-06-16T23:59:59-07:00' }
+		);
+
+		expect( result.summary ).toEqual( {
+			date_start: '2026-06-15T00:00:00+00:00',
+			date_end: '2026-06-16T23:59:59+00:00',
+		} );
+	} );
+
+	it( 'matches the row shape when rows are present and when they are not', () => {
+		const query = {
+			start_date: '2026-06-15T00:00:00-07:00',
+			end_date: '2026-06-15T23:59:59-07:00',
+		};
+		const withRows = sanitizeStatsTimeSeriesResponse(
+			{ unit: 'day', fields: [ 'period', 'views' ], data: [ [ '2026-06-15', 3 ] ] },
+			query
+		);
+		const withoutRows = sanitizeStatsTimeSeriesResponse( {}, query );
+
+		expect( withoutRows.summary.date_start ).toBe( withRows.summary.date_start );
+		expect( withoutRows.summary.date_end ).toBe( withRows.summary.date_end );
+	} );
+
 	it( 'detects supported time-series payload shapes', () => {
 		expect( isStatsTimeSeriesPayload( visitsFixture ) ).toBe( true );
 		expect( isStatsTimeSeriesPayload( scalarDaysTimeSeriesFixture ) ).toBe( true );

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/time-series.ts
@@ -226,6 +226,17 @@ function getRowIntervalFields( row: StatsRecord, rawPeriod: unknown, unit: strin
 	return getTimeSeriesIntervalFields( rawPeriod, unit );
 }
 
+// Rebuild a summary bound from a query date when no rows came back. Rows stamp
+// `date_start`/`date_end` as full ISO 8601 with a nominal +00:00 (see
+// getStatsIntervalFields), so the query's own site-local offset can't be passed
+// through verbatim: consumers read these as wall-clock bucket labels, and a real
+// offset would be converted a second time. Mirrors getStatsSummaryIntervalFields.
+function toSummaryBound( value: string | undefined, time: string ) {
+	const datePart = getDatePart( value );
+
+	return datePart ? formatDatePartWithTime( datePart, time ) : '';
+}
+
 function getTimeSeriesSummarySidecars( response: StatsRecord ) {
 	return {
 		...normalizeStatsSummary( coerceStatsRecord( response.summary ) ),
@@ -288,8 +299,8 @@ export function sanitizeStatsTimeSeriesResponse(
 		summary: {
 			...getTimeSeriesSummarySidecars( response ),
 			...summary,
-			date_start: firstRow?.date_start ?? query?.start_date ?? '',
-			date_end: lastRow?.date_end ?? query?.end_date ?? query?.date ?? '',
+			date_start: firstRow?.date_start ?? toSummaryBound( query?.start_date, '00:00:00' ),
+			date_end: lastRow?.date_end ?? toSummaryBound( query?.end_date ?? query?.date, '23:59:59' ),
 		},
 		data,
 	};


### PR DESCRIPTION
Part of [WOOA7S-1833](https://linear.app/a8c/issue/WOOA7S-1833/remove-adapter-from-premium-analytics-data-layer). Split out of #50916 — independent of that PR and mergeable on its own.

## Why

A time-series summary reports the range it covers as `summary.date_start` / `date_end`. Today those come out in **two different shapes depending on whether the response had any rows**, which means a widget can render the same field two different ways for the same range.

`sanitizeStatsTimeSeriesResponse()` takes them from the first and last row, falling back to the query's own dates when nothing came back:

```ts
date_start: firstRow?.date_start ?? query?.start_date ?? '',
date_end: lastRow?.date_end ?? query?.end_date ?? query?.date ?? '',
```

Rows always carry full ISO 8601 with a nominal `+00:00` — `getStatsIntervalFields()` builds them with `formatDatePartWithTime()`, and the API's own `row.date_start` has the same shape. The fallback passes the query date through untouched, so it emits a bare `yyyy-MM-dd`.

That matters because consumers treat the two as the same thing. `build-report-metric-series.ts` reads `report.summary.date_start` and falls back to `first?.date_start` for the same field, then hands the result to `localTZDate()` — where a bare day and an offset-tagged instant do not resolve alike. An empty period can therefore label its range a day off from a populated one.

## Proposed changes

* `sanitizeStatsTimeSeriesResponse()` re-stamps the query date as a bucket bound (`00:00:00` / `23:59:59` with the same nominal `+00:00`) instead of passing it through raw, so both branches emit one shape.

The re-stamp deliberately does **not** forward the query's own timezone offset. Row bounds are wall-clock bucket labels rather than real instants — `getHourIntervalFields()` says so explicitly — so a genuine offset here would be converted a second time downstream. This mirrors what `getStatsSummaryIntervalFields()` already does for the summarized path.

## Testing instructions

* `jp test js packages/premium-analytics` — 212 suites / 1498 tests pass.
* The new `time-series.test.ts` case asserts the two branches agree byte for byte: it runs the same query with and without rows and compares `summary.date_start` / `date_end` directly. Revert the source change and it fails.
* No UI change is expected for a populated period, since that path already took the row bounds. The difference shows on an empty period — for example a widget on a date range with no data, whose summary bound previously read `2026-06-15` and now reads `2026-06-15T00:00:00+00:00`, matching what the same widget reports when data is present.
