### PR TITLE
ESLint: Drop v10 fixups for eslint-plugin-jest-dom

### DIFF
--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -312,7 +312,6 @@ function fixPeerDeps( pkg ) {
 		'eslint-plugin-jsx-a11y', // https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/1075
 		'eslint-plugin-react', // https://github.com/jsx-eslint/eslint-plugin-react/issues/3977
 		'@babel/eslint-parser', // https://github.com/babel/babel/issues/17951
-		'eslint-plugin-jest-dom', // https://github.com/testing-library/eslint-plugin-jest-dom/issues/418
 	] );
 	if ( eslintOldPkgs.has( pkg.name ) ) {
 		for ( const p of [ 'eslint' ] ) {

--- a/.pnpmfile.cjs
+++ b/.pnpmfile.cjs
@@ -347,7 +347,6 @@ function fixPeerDeps( pkg ) {
 		'eslint-plugin-jsx-a11y', // https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/issues/1075
 		'eslint-plugin-react', // https://github.com/jsx-eslint/eslint-plugin-react/issues/3977
 		'@babel/eslint-parser', // https://github.com/babel/babel/issues/17951
-		'eslint-plugin-jest-dom', // https://github.com/testing-library/eslint-plugin-jest-dom/issues/418
 	] );
 	if ( eslintOldPkgs.has( pkg.name ) ) {
 		for ( const p of [ 'eslint' ] ) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
-pnpmfileChecksum: sha256-ZW2BoUDYyI5nkZ8o3EkCzocg7Bspf+AzfFGBEEoeEK8=
+pnpmfileChecksum: sha256-LT+E4Lff3bPPxejSSqYmnqPP+5a7UzazrKPK8+691o8=
 
 patchedDependencies:
   '@wordpress/build': 151ae1c0c3786b862724512e48d8cfcb4b34faf4cac98e352a450abd4741e022
@@ -6816,8 +6816,8 @@ importers:
         specifier: 29.15.4
         version: 29.15.4(eslint@10.6.0)(jest@30.4.2)(typescript@6.0.3)
       eslint-plugin-jest-dom:
-        specifier: 5.5.0
-        version: 5.5.0(@testing-library/dom@10.4.1)(eslint@10.6.0)
+        specifier: 5.10.1
+        version: 5.10.1(@testing-library/dom@10.4.1)(eslint@10.6.0)
       eslint-plugin-jsdoc:
         specifier: 63.0.12
         version: 63.0.12(eslint@10.6.0)
@@ -13622,12 +13622,12 @@ packages:
       '@typescript-eslint/parser':
         optional: true
 
-  eslint-plugin-jest-dom@5.5.0:
-    resolution: {integrity: sha512-CRlXfchTr7EgC3tDI7MGHY6QjdJU5Vv2RPaeeGtkXUHnKZf04kgzMPIJUXt4qKCvYWVVIEo9ut9Oq1vgXAykEA==}
+  eslint-plugin-jest-dom@5.10.1:
+    resolution: {integrity: sha512-IIJdzbACbhJUJyMAqpA9E9gxp1Gv29TeQ3DtL+pepwP8Oq2WiqjOB2HbnEIs23h0ewdKIZRDI56yLro2eUO+DA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0, npm: '>=6', yarn: '>=1'}
     peerDependencies:
       '@testing-library/dom': ^8.0.0 || ^9.0.0 || ^10.0.0
-      eslint: ^6.8.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10
+      eslint: ^6.8.0 || ^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0
     peerDependenciesMeta:
       '@testing-library/dom':
         optional: true
@@ -35679,9 +35679,8 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jest-dom@5.5.0(@testing-library/dom@10.4.1)(eslint@10.6.0):
+  eslint-plugin-jest-dom@5.10.1(@testing-library/dom@10.4.1)(eslint@10.6.0):
     dependencies:
-      '@babel/runtime': 7.29.7
       eslint: 10.6.0
       requireindex: 1.2.0
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,7 +4,7 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
-pnpmfileChecksum: sha256-4/zyKUib0nJ4Kn6ND/Ag1Su76ZAfyUYg8GRhBKJvK1s=
+pnpmfileChecksum: sha256-3Wde9tns2EWIOHz3+26yEp9tswozfsO/HhMfkRq9GL4=
 
 patchedDependencies:
   '@wordpress/build': 6f3fbefb10df6ce84b2e3c307e3894b697d87a888315abc805b6ff67bf7de635

--- a/tools/js-tools/eslintrc/jest.mjs
+++ b/tools/js-tools/eslintrc/jest.mjs
@@ -1,14 +1,8 @@
-import { fixupPluginRules } from '@eslint/compat';
 import eslintPluginJest from 'eslint-plugin-jest';
 import eslintPluginJestDom from 'eslint-plugin-jest-dom';
 import eslintPluginTestingLibrary from 'eslint-plugin-testing-library';
 import globals from 'globals';
 import { defineConfig, javascriptFiles } from './base.mjs';
-
-// https://github.com/testing-library/eslint-plugin-jest-dom/issues/418
-eslintPluginJestDom.configs[ 'flat/recommended' ].plugins[ 'jest-dom' ] = fixupPluginRules(
-	eslintPluginJestDom.configs[ 'flat/recommended' ].plugins[ 'jest-dom' ]
-);
 
 export default defineConfig(
 	{

--- a/tools/js-tools/package.json
+++ b/tools/js-tools/package.json
@@ -41,7 +41,7 @@
 		"eslint-plugin-es-x": "9.7.0",
 		"eslint-plugin-import": "2.32.0",
 		"eslint-plugin-jest": "29.15.4",
-		"eslint-plugin-jest-dom": "5.5.0",
+		"eslint-plugin-jest-dom": "5.10.1",
 		"eslint-plugin-jsdoc": "63.0.12",
 		"eslint-plugin-jsx-a11y": "6.10.2",
 		"eslint-plugin-lodash": "8.0.0",


### PR DESCRIPTION
## Proposed changes

When we upgraded to ESLint v10, `eslint-plugin-jest-dom` didn't support it yet, so we added two workarounds. The plugin now supports ESLint v10 natively (since [v5.6.0](https://github.com/testing-library/eslint-plugin-jest-dom/releases/tag/v5.6.0), see [testing-library/eslint-plugin-jest-dom#418](https://github.com/testing-library/eslint-plugin-jest-dom/issues/418)), so this PR:

* <s>Upgrades `eslint-plugin-jest-dom` from 5.5.0 to 5.10.1.</s>
* Removes the `fixupPluginRules()` wrapper in `tools/js-tools/eslintrc/jest.mjs`.
* Removes the ESLint peer-dependency widening for the plugin in `.pnpmfile.cjs`.

## Related product discussion/links

* https://github.com/testing-library/eslint-plugin-jest-dom/issues/418

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run `pnpm eslint` on a Jest test file, e.g. `pnpm eslint projects/packages/my-jetpack/_inc/components/connection-status-card/test/component.tsx`, and verify the config loads and lints without errors.
