### PR TITLE
WOOA7S-1697: Premium Analytics: address the Locations report review feedback

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-wooa7s-1697-locations-csv-export
+++ b/projects/packages/premium-analytics/changelog/fix-wooa7s-1697-locations-csv-export
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Locations report: add CSV export.

--- a/projects/packages/premium-analytics/changelog/fix-wooa7s-1697-locations-report-review-feedback
+++ b/projects/packages/premium-analytics/changelog/fix-wooa7s-1697-locations-report-review-feedback
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Locations report: show period-over-period changes and use the shared number format.

--- a/projects/packages/premium-analytics/changelog/fix-wooa7s-1697-locations-report-review-feedback
+++ b/projects/packages/premium-analytics/changelog/fix-wooa7s-1697-locations-report-review-feedback
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Locations report: show period-over-period changes and use the shared number format.
+Locations report: correct the view counts to match the other reports, show period-over-period changes, and use the shared number format.

--- a/projects/packages/premium-analytics/routes/reports/count-fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/count-fields.test.tsx
@@ -11,6 +11,7 @@ import { getCommentFollowersFields } from './comment-followers/config/fields';
 import { getCommentsFields } from './comments/config/fields';
 import { getDownloadsFields } from './downloads/config/fields';
 import { getEmailsFields } from './emails/config/fields';
+import { getLocationFields } from './locations/config/fields';
 import { getArchivesFields, getPostsFields } from './posts/config/fields';
 import { getReferrerFields } from './referrers/config/fields';
 import { getSearchTermsFields } from './search-terms/config/fields';
@@ -61,11 +62,12 @@ describe( 'report table count fields', () => {
 		renderCountField( getSearchTermsFields(), 'views', { views: 12345 } as never );
 		renderCountField( getUtmFields( 'source-medium' ), 'views', { views: 12345 } as never );
 		renderCountField( getEmailsFields(), 'opens', { opens: 12345 } as never );
+		renderCountField( getLocationFields(), 'views', { views: 12345 } as never );
 		renderCountField( getAnnualInsightsFields(), 'total_posts', {
 			total_posts: 12345,
 		} as never );
 
-		expect( screen.getAllByText( '12,345' ) ).toHaveLength( 14 );
+		expect( screen.getAllByText( '12,345' ) ).toHaveLength( 15 );
 	} );
 
 	it( 'formats Emails rates with the shared formatter', () => {

--- a/projects/packages/premium-analytics/routes/reports/locations/config/aggregate.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/locations/config/aggregate.test.ts
@@ -20,8 +20,6 @@ const items: StatsLocationsComparisonItem[] = [
 ];
 
 describe( 'report locations aggregate', () => {
-	// Region and city names repeat across countries, so the country code has to
-	// stay part of the row identity.
 	it( 'keeps identical names in different countries apart', () => {
 		expect( buildLocationRows( items ) ).toEqual( [
 			{
@@ -43,8 +41,6 @@ describe( 'report locations aggregate', () => {
 		] );
 	} );
 
-	// A location with no match in the previous period must stay undefined, not
-	// collapse to 0, so the table shows no delta rather than a false one.
 	it( 'leaves a missing previous period undefined', () => {
 		expect( buildLocationRows( items )[ 1 ].previousViews ).toBeUndefined();
 	} );

--- a/projects/packages/premium-analytics/routes/reports/locations/config/aggregate.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/locations/config/aggregate.test.ts
@@ -1,56 +1,36 @@
-import { aggregateLocationRows } from './aggregate';
-import type { StatsLocationsItem, StatsNormalizedReport } from '@jetpack-premium-analytics/data';
+import { buildLocationRows } from './aggregate';
+import type { StatsLocationsComparisonItem } from '@jetpack-premium-analytics/data';
 
-const report: StatsNormalizedReport< StatsLocationsItem > = {
-	summary: {},
-	data: [
-		{
-			time_interval: '2026-07-09',
-			date_start: '2026-07-09T00:00:00+00:00',
-			date_end: '2026-07-09T23:59:59+00:00',
-			items: [
-				{
-					label: 'Springfield',
-					views: 8,
-					countryCode: 'US',
-					countryFull: 'United States',
-					children: null,
-				},
-				{
-					label: 'Springfield',
-					views: 3,
-					countryCode: 'CA',
-					countryFull: 'Canada',
-					children: null,
-				},
-			],
-		},
-		{
-			time_interval: '2026-07-10',
-			date_start: '2026-07-10T00:00:00+00:00',
-			date_end: '2026-07-10T23:59:59+00:00',
-			items: [
-				{
-					label: 'Springfield',
-					views: 5,
-					countryCode: 'US',
-					countryFull: 'United States',
-					children: null,
-				},
-			],
-		},
-	],
-};
+const items: StatsLocationsComparisonItem[] = [
+	{
+		label: 'Springfield',
+		views: 13,
+		countryCode: 'US',
+		countryFull: 'United States',
+		children: null,
+		previousViews: 9,
+	},
+	{
+		label: 'Springfield',
+		views: 3,
+		countryCode: 'CA',
+		countryFull: 'Canada',
+		children: null,
+	},
+];
 
 describe( 'report locations aggregate', () => {
-	it( 'aggregates matching locations without merging identical names in different countries', () => {
-		expect( aggregateLocationRows( report ) ).toEqual( [
+	// Region and city names repeat across countries, so the country code has to
+	// stay part of the row identity.
+	it( 'keeps identical names in different countries apart', () => {
+		expect( buildLocationRows( items ) ).toEqual( [
 			{
 				id: 'US:Springfield',
 				label: 'Springfield',
 				countryCode: 'US',
 				countryFull: 'United States',
 				views: 13,
+				previousViews: 9,
 			},
 			{
 				id: 'CA:Springfield',
@@ -58,7 +38,18 @@ describe( 'report locations aggregate', () => {
 				countryCode: 'CA',
 				countryFull: 'Canada',
 				views: 3,
+				previousViews: undefined,
 			},
 		] );
+	} );
+
+	// A location with no match in the previous period must stay undefined, not
+	// collapse to 0, so the table shows no delta rather than a false one.
+	it( 'leaves a missing previous period undefined', () => {
+		expect( buildLocationRows( items )[ 1 ].previousViews ).toBeUndefined();
+	} );
+
+	it( 'returns no rows when the report has not arrived', () => {
+		expect( buildLocationRows( undefined ) ).toEqual( [] );
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/reports/locations/config/aggregate.ts
+++ b/projects/packages/premium-analytics/routes/reports/locations/config/aggregate.ts
@@ -2,51 +2,32 @@
  * External dependencies
  */
 import type { LocationRow } from './fields';
-import type { StatsLocationsItem, StatsNormalizedReport } from '@jetpack-premium-analytics/data';
+import type { StatsLocationsComparisonItem } from '@jetpack-premium-analytics/data';
 
 /**
- * Build a stable identity for a location within its country.
+ * Build the records table's rows from the shared comparison rows.
  *
- * Region and city names are not globally unique, so the country code remains
- * part of the key on every tab.
+ * The request is summarized, so the API returns one row per location for the
+ * whole window and the shared merge helper has already aligned each row with
+ * its previous-period value. Region and city names are not globally unique, so
+ * the country code stays part of the row identity on every tab.
  *
- * @param item - A normalized location item.
- * @return The stable location identity.
+ * @param items - Merged location rows for the active tab.
+ * @return One row per location.
  */
-function getLocationId( item: StatsLocationsItem ): string {
-	return `${ item.countryCode ?? '' }:${ String( item.label ?? '' ) }`;
-}
-
-/**
- * Aggregate location rows across report buckets for the records table.
- *
- * @param report - The bucketed locations report.
- * @return One row per location with views summed across buckets.
- */
-export function aggregateLocationRows(
-	report: StatsNormalizedReport< StatsLocationsItem > | undefined
+export function buildLocationRows(
+	items: StatsLocationsComparisonItem[] | undefined
 ): LocationRow[] {
-	const rowsById = new Map< string, LocationRow >();
+	return ( items ?? [] ).map( item => {
+		const label = String( item.label ?? '' );
 
-	for ( const point of report?.data ?? [] ) {
-		for ( const item of point.items ) {
-			const id = getLocationId( item );
-			const existing = rowsById.get( id );
-
-			if ( existing ) {
-				existing.views += item.views;
-				continue;
-			}
-
-			rowsById.set( id, {
-				id,
-				label: String( item.label ?? '' ),
-				countryCode: item.countryCode,
-				countryFull: item.countryFull ?? item.countryCode ?? '',
-				views: item.views,
-			} );
-		}
-	}
-
-	return [ ...rowsById.values() ];
+		return {
+			id: `${ item.countryCode ?? '' }:${ label }`,
+			label,
+			countryCode: item.countryCode,
+			countryFull: item.countryFull ?? item.countryCode ?? '',
+			views: item.views,
+			previousViews: item.previousViews,
+		};
+	} );
 }

--- a/projects/packages/premium-analytics/routes/reports/locations/config/aggregate.ts
+++ b/projects/packages/premium-analytics/routes/reports/locations/config/aggregate.ts
@@ -7,10 +7,8 @@ import type { StatsLocationsComparisonItem } from '@jetpack-premium-analytics/da
 /**
  * Build the records table's rows from the shared comparison rows.
  *
- * The request is summarized, so the API returns one row per location for the
- * whole window and the shared merge helper has already aligned each row with
- * its previous-period value. Region and city names are not globally unique, so
- * the country code stays part of the row identity on every tab.
+ * Region and city names are not globally unique, so the country code stays part
+ * of the row identity on every tab.
  *
  * @param items - Merged location rows for the active tab.
  * @return One row per location.

--- a/projects/packages/premium-analytics/routes/reports/locations/config/fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/locations/config/fields.test.tsx
@@ -44,16 +44,12 @@ describe( 'locations fields', () => {
 		);
 	} );
 
-	// The shared formatter, not the browser locale, so every report table reads
-	// the same way whatever locale the browser reports.
 	it( 'formats views with the shared formatter', () => {
 		renderField( 'views' );
 
 		expect( screen.getByText( '1,234' ) ).toBeInTheDocument();
 	} );
 
-	// The page only asks for deltas once the comparison period has data, so an
-	// unwanted comparison never reaches the cell.
 	it( 'shows the period-over-period delta only when comparison is on', () => {
 		const { unmount } = renderField( 'views' );
 

--- a/projects/packages/premium-analytics/routes/reports/locations/config/fields.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/locations/config/fields.test.tsx
@@ -7,16 +7,20 @@ const location: LocationRow = {
 	countryCode: 'IN',
 	countryFull: 'India',
 	views: 1234,
+	previousViews: 1000,
 };
 
 /**
  * Render one Locations table field for the fixture row.
  *
- * @param id - The field to render.
+ * @param id             - The field to render.
+ * @param withComparison - Whether the field config renders deltas.
  * @return The Testing Library render result.
  */
-function renderField( id: 'location' | 'views' ) {
-	const field = getLocationFields().find( candidate => candidate.id === id );
+function renderField( id: 'location' | 'views', withComparison = false ) {
+	const field = getLocationFields( undefined, withComparison ).find(
+		candidate => candidate.id === id
+	);
 	// eslint-disable-next-line testing-library/render-result-naming-convention -- This is the DataViews field render component, not RTL's render result.
 	const LocationField = field?.render;
 
@@ -40,10 +44,25 @@ describe( 'locations fields', () => {
 		);
 	} );
 
-	it( 'formats views for display', () => {
+	// The shared formatter, not the browser locale, so every report table reads
+	// the same way whatever locale the browser reports.
+	it( 'formats views with the shared formatter', () => {
 		renderField( 'views' );
 
-		expect( screen.getByText( ( 1234 ).toLocaleString() ) ).toBeInTheDocument();
+		expect( screen.getByText( '1,234' ) ).toBeInTheDocument();
+	} );
+
+	// The page only asks for deltas once the comparison period has data, so an
+	// unwanted comparison never reaches the cell.
+	it( 'shows the period-over-period delta only when comparison is on', () => {
+		const { unmount } = renderField( 'views' );
+
+		expect( screen.queryByText( '+23%' ) ).not.toBeInTheDocument();
+		unmount();
+
+		renderField( 'views', true );
+
+		expect( screen.getByText( '+23%' ) ).toBeInTheDocument();
 	} );
 
 	it( 'omits the country filter when no countries are given', () => {

--- a/projects/packages/premium-analytics/routes/reports/locations/config/fields.tsx
+++ b/projects/packages/premium-analytics/routes/reports/locations/config/fields.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { flagUrl } from '@jetpack-premium-analytics/widgets-toolkit';
+import { flagUrl, MetricWithComparison } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __, sprintf } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -15,7 +15,13 @@ export type LocationRow = {
 	countryCode?: string;
 	countryFull: string;
 	views: number;
+	previousViews?: number;
 };
+
+const VIEWS_DATA_FORMAT = {
+	type: 'number',
+	options: { decimals: 0, useMultipliers: false },
+} as const;
 
 /**
  * One selectable country for the records table's country filter.
@@ -37,10 +43,14 @@ export interface LocationsCountryOption {
  * `views`. The API applies the filter server-side, because it returns at most
  * 256 rows and the regions of a smaller country fall outside that global cut.
  *
- * @param countries - Selectable countries, ordered by views.
+ * @param countries      - Selectable countries, ordered by views.
+ * @param withComparison - Whether to render available period-over-period deltas.
  * @return The field config.
  */
-export function getLocationFields( countries?: LocationsCountryOption[] ): Field< LocationRow >[] {
+export function getLocationFields(
+	countries?: LocationsCountryOption[],
+	withComparison = false
+): Field< LocationRow >[] {
 	const countryField: Field< LocationRow >[] = countries
 		? [
 				{
@@ -90,7 +100,14 @@ export function getLocationFields( countries?: LocationsCountryOption[] ): Field
 			id: 'views',
 			label: __( 'Views', 'jetpack-premium-analytics-pkg' ),
 			getValue: ( { item } ) => item.views,
-			render: ( { item } ) => <>{ item.views.toLocaleString() }</>,
+			render: ( { item } ) => (
+				<MetricWithComparison
+					value={ item.views }
+					previousValue={ withComparison ? item.previousViews : undefined }
+					dataFormat={ VIEWS_DATA_FORMAT }
+					fontSize="md"
+				/>
+			),
 		},
 	];
 }

--- a/projects/packages/premium-analytics/routes/reports/locations/config/index.ts
+++ b/projects/packages/premium-analytics/routes/reports/locations/config/index.ts
@@ -1,4 +1,4 @@
-export { aggregateLocationRows } from './aggregate';
+export { buildLocationRows } from './aggregate';
 export { getLocationFields, type LocationRow, type LocationsCountryOption } from './fields';
 export {
 	getReportLocationsTabs,

--- a/projects/packages/premium-analytics/routes/reports/locations/config/use-report-records.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/locations/config/use-report-records.test.ts
@@ -1,11 +1,7 @@
 import { useStatsLocations } from '@jetpack-premium-analytics/data';
 import { renderHook } from '@testing-library/react';
 import { useLocationsReportRecords } from './use-report-records';
-import type {
-	ReportParams,
-	StatsLocationsItem,
-	StatsNormalizedReport,
-} from '@jetpack-premium-analytics/data';
+import type { ReportParams, StatsLocationsComparisonItem } from '@jetpack-premium-analytics/data';
 
 jest.mock( '@jetpack-premium-analytics/data', () => ( {
 	...jest.requireActual( '@jetpack-premium-analytics/data' ),
@@ -14,39 +10,16 @@ jest.mock( '@jetpack-premium-analytics/data', () => ( {
 
 const mockUseStatsLocations = useStatsLocations as jest.MockedFunction< typeof useStatsLocations >;
 
-const report: StatsNormalizedReport< StatsLocationsItem > = {
-	summary: {},
-	data: [
-		{
-			time_interval: '2026-07-09',
-			date_start: '2026-07-09T00:00:00+00:00',
-			date_end: '2026-07-09T23:59:59+00:00',
-			items: [
-				{
-					label: 'India',
-					views: 7,
-					countryCode: 'IN',
-					countryFull: 'India',
-					children: null,
-				},
-			],
-		},
-		{
-			time_interval: '2026-07-10',
-			date_start: '2026-07-10T00:00:00+00:00',
-			date_end: '2026-07-10T23:59:59+00:00',
-			items: [
-				{
-					label: 'India',
-					views: 6,
-					countryCode: 'IN',
-					countryFull: 'India',
-					children: null,
-				},
-			],
-		},
-	],
-};
+const rows: StatsLocationsComparisonItem[] = [
+	{
+		label: 'India',
+		views: 13,
+		countryCode: 'IN',
+		countryFull: 'India',
+		children: null,
+		previousViews: 9,
+	},
+];
 
 const params: ReportParams = {
 	from: '2026-07-09',
@@ -54,23 +27,44 @@ const params: ReportParams = {
 	interval: 'day',
 };
 
+const REQUEST_PARAMS = {
+	...params,
+	max: 0,
+	summarize: 1,
+	period: 'day',
+};
+
+/**
+ * Build a settled report result for the mocked hook.
+ *
+ * @param overrides - Fields to override for the case under test.
+ * @return The mocked report result.
+ */
+function reportResult( overrides: Record< string, unknown > = {} ) {
+	return {
+		primary: { isLoading: false, isFetching: false, isError: false },
+		comparison: { isLoading: false, isFetching: false, isError: false },
+		comparisonRows: { rows, hasComparison: true },
+		hasComparison: true,
+		refetch: jest.fn(),
+		...overrides,
+	} as unknown as ReturnType< typeof useStatsLocations >;
+}
+
 describe( 'useLocationsReportRecords', () => {
 	beforeEach( () => {
 		mockUseStatsLocations.mockReset();
-		mockUseStatsLocations.mockReturnValue( {
-			primary: { data: report },
-			comparison: { data: undefined },
-			hasComparison: false,
-			isLoading: false,
-		} as ReturnType< typeof useStatsLocations > );
+		mockUseStatsLocations.mockReturnValue( reportResult() );
 	} );
 
-	it( 'keeps every location request day-bucketed', () => {
+	// The API summarizes the window into one row per location, matching the
+	// Locations widget and the other list reports.
+	it( 'summarizes every location request', () => {
 		renderHook( () => useLocationsReportRecords( 'cities', params ) );
 
 		expect(
 			mockUseStatsLocations.mock.calls.every(
-				( [ requestParams ] ) => requestParams.period === 'day'
+				( [ requestParams ] ) => requestParams.summarize === 1 && requestParams.period === 'day'
 			)
 		).toBe( true );
 	} );
@@ -81,10 +75,7 @@ describe( 'useLocationsReportRecords', () => {
 		// No `enabled` gate and no `filter_by_country`: this call backs the
 		// country filter's options as well as the Countries tab.
 		expect( mockUseStatsLocations ).toHaveBeenCalledWith( {
-			...params,
-			max: 0,
-			summarize: 0,
-			period: 'day',
+			...REQUEST_PARAMS,
 			geoMode: 'country',
 		} );
 	} );
@@ -94,10 +85,7 @@ describe( 'useLocationsReportRecords', () => {
 
 		expect( mockUseStatsLocations ).toHaveBeenCalledWith(
 			{
-				...params,
-				max: 0,
-				summarize: 0,
-				period: 'day',
+				...REQUEST_PARAMS,
 				geoMode: 'region',
 				filter_by_country: 'IN',
 			},
@@ -121,26 +109,29 @@ describe( 'useLocationsReportRecords', () => {
 		expect( result.current.countries.options ).toEqual( [ { code: 'IN', label: 'India' } ] );
 	} );
 
-	it( 'sums each location across the range for the table', () => {
+	it( 'carries the previous period through to the table rows', () => {
 		const { result } = renderHook( () => useLocationsReportRecords( 'countries', params ) );
 
 		expect( result.current.table.rows ).toEqual( [
-			{ id: 'IN:India', label: 'India', countryCode: 'IN', countryFull: 'India', views: 13 },
+			{
+				id: 'IN:India',
+				label: 'India',
+				countryCode: 'IN',
+				countryFull: 'India',
+				views: 13,
+				previousViews: 9,
+			},
 		] );
+		expect( result.current.hasComparison ).toBe( true );
 	} );
 
 	it( 'reports the active tab fetch state, not the country options query', () => {
-		mockUseStatsLocations.mockImplementation(
-			( requestParams, options ) =>
-				( {
-					primary: { data: report },
-					comparison: { data: undefined },
-					hasComparison: false,
-					isLoading: false,
-					// Only the enabled per-tab query refetches; the always-on
-					// countries query is already settled.
-					isFetching: options?.enabled === true,
-				} ) as ReturnType< typeof useStatsLocations >
+		mockUseStatsLocations.mockImplementation( ( requestParams, options ) =>
+			reportResult( {
+				// Only the enabled per-tab query refetches; the always-on
+				// countries query is already settled.
+				primary: { isLoading: false, isFetching: options?.enabled === true, isError: false },
+			} )
 		);
 
 		const { result } = renderHook( () => useLocationsReportRecords( 'cities', params ) );
@@ -149,21 +140,31 @@ describe( 'useLocationsReportRecords', () => {
 	} );
 
 	it( 'reports the active tab error and retry, not the country options query', () => {
-		mockUseStatsLocations.mockImplementation(
-			( requestParams, options ) =>
-				( {
-					primary: { data: report },
-					comparison: { data: undefined },
-					hasComparison: false,
-					isLoading: false,
-					// Only the enabled per-tab query fails; the always-on countries
-					// query stays healthy, so the page must not read its state.
-					isError: options?.enabled === true,
-				} ) as ReturnType< typeof useStatsLocations >
+		mockUseStatsLocations.mockImplementation( ( requestParams, options ) =>
+			reportResult( {
+				// Only the enabled per-tab query fails; the always-on countries
+				// query stays healthy, so the page must not read its state.
+				primary: { isLoading: false, isFetching: false, isError: options?.enabled === true },
+			} )
 		);
 
 		const { result } = renderHook( () => useLocationsReportRecords( 'regions', params ) );
 
 		expect( result.current.isError ).toBe( true );
+	} );
+
+	// The comparison period only adds deltas. Losing it must not cost the user
+	// the rows they came for.
+	it( 'keeps the primary rows when only the comparison period fails', () => {
+		mockUseStatsLocations.mockReturnValue(
+			reportResult( {
+				comparison: { isLoading: false, isFetching: false, isError: true },
+			} )
+		);
+
+		const { result } = renderHook( () => useLocationsReportRecords( 'countries', params ) );
+
+		expect( result.current.isError ).toBe( false );
+		expect( result.current.table.rows ).toHaveLength( 1 );
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/reports/locations/config/use-report-records.test.ts
+++ b/projects/packages/premium-analytics/routes/reports/locations/config/use-report-records.test.ts
@@ -42,6 +42,9 @@ const REQUEST_PARAMS = {
  */
 function reportResult( overrides: Record< string, unknown > = {} ) {
 	return {
+		isLoading: false,
+		isFetching: false,
+		isError: false,
 		primary: { isLoading: false, isFetching: false, isError: false },
 		comparison: { isLoading: false, isFetching: false, isError: false },
 		comparisonRows: { rows, hasComparison: true },
@@ -57,8 +60,6 @@ describe( 'useLocationsReportRecords', () => {
 		mockUseStatsLocations.mockReturnValue( reportResult() );
 	} );
 
-	// The API summarizes the window into one row per location, matching the
-	// Locations widget and the other list reports.
 	it( 'summarizes every location request', () => {
 		renderHook( () => useLocationsReportRecords( 'cities', params ) );
 
@@ -130,7 +131,7 @@ describe( 'useLocationsReportRecords', () => {
 			reportResult( {
 				// Only the enabled per-tab query refetches; the always-on
 				// countries query is already settled.
-				primary: { isLoading: false, isFetching: options?.enabled === true, isError: false },
+				isFetching: options?.enabled === true,
 			} )
 		);
 
@@ -153,8 +154,6 @@ describe( 'useLocationsReportRecords', () => {
 		expect( result.current.isError ).toBe( true );
 	} );
 
-	// The comparison period only adds deltas. Losing it must not cost the user
-	// the rows they came for.
 	it( 'keeps the primary rows when only the comparison period fails', () => {
 		mockUseStatsLocations.mockReturnValue(
 			reportResult( {

--- a/projects/packages/premium-analytics/routes/reports/locations/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/locations/config/use-report-records.ts
@@ -2,17 +2,16 @@
  * External dependencies
  */
 import {
+	hasComparisonEnabled,
 	useStatsLocations,
 	type ReportParams,
-	type StatsLocationsItem,
-	type StatsNormalizedReport,
 } from '@jetpack-premium-analytics/data';
 import { useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import { aggregateLocationRows } from './aggregate';
-import type { LocationRow, LocationsCountryOption } from './fields';
+import { buildLocationRows } from './aggregate';
+import type { LocationsCountryOption } from './fields';
 import type { ReportLocationsTabId } from './tabs';
 
 const GEO_MODES = {
@@ -22,23 +21,30 @@ const GEO_MODES = {
 } as const;
 
 /**
- * Fetch and derive map and table records for the active Locations tab.
+ * Fetch and derive the table records for the active Locations tab.
  *
  * @param activeTab     - The active Locations report tab.
  * @param reportParams  - The shared report-window parameters.
  * @param countryFilter - ISO country code to scope regions/cities to, if any.
- * @return Map and table data for the active tab, plus the filter's countries.
+ * @return Table data for the active tab, plus the filter's countries.
  */
 export function useLocationsReportRecords(
 	activeTab: ReportLocationsTabId,
 	reportParams: ReportParams,
 	countryFilter?: string
 ) {
+	/*
+	 * `summarize: 1` asks the API for one row per location across the whole
+	 * window, matching the Locations widget and the other list reports. The
+	 * day-bucketed alternative returns the same list once per day, which the
+	 * shared comparison merge cannot align. `max: 0` keeps the full list so the
+	 * table can search, sort, and page it client-side.
+	 */
 	const recordsParams = useMemo(
 		() => ( {
 			...reportParams,
 			max: 0,
-			summarize: 0,
+			summarize: 1,
 			period: 'day',
 		} ),
 		[ reportParams ]
@@ -69,37 +75,44 @@ export function useLocationsReportRecords(
 
 	const reportsByTab = { countries, regions, cities };
 	const activeReport = reportsByTab[ activeTab ];
-	const primaryReport = activeReport.primary.data as
-		| StatsNormalizedReport< StatsLocationsItem >
-		| undefined;
 
-	const rows = useMemo( () => aggregateLocationRows( primaryReport ), [ primaryReport ] );
-
-	const countriesReport = countries.primary.data as
-		| StatsNormalizedReport< StatsLocationsItem >
-		| undefined;
+	const rows = useMemo(
+		() => buildLocationRows( activeReport.comparisonRows?.rows ),
+		[ activeReport.comparisonRows ]
+	);
 
 	// Options keep the report's own order (views, descending) so the countries
 	// a site actually gets traffic from sit at the top of the list.
 	const countryOptions = useMemo(
 		(): LocationsCountryOption[] =>
-			aggregateLocationRows( countriesReport )
-				.filter( ( row ): row is LocationRow & { countryCode: string } => !! row.countryCode )
+			buildLocationRows( countries.comparisonRows?.rows )
+				.filter( ( row ): row is typeof row & { countryCode: string } => !! row.countryCode )
 				.sort( ( a, b ) => b.views - a.views )
 				.map( row => ( { code: row.countryCode, label: row.countryFull || row.label } ) ),
-		[ countriesReport ]
+		[ countries.comparisonRows ]
 	);
+
+	// The table renders deltas, so it waits for the comparison period too. It
+	// must not fail with it: a comparison-only error still has valid primary
+	// rows to show, just without deltas.
+	const comparisonEnabled = hasComparisonEnabled( reportParams );
+	const isLoading =
+		activeReport.primary.isLoading || ( comparisonEnabled && activeReport.comparison.isLoading );
+	const isFetching =
+		activeReport.primary.isFetching || ( comparisonEnabled && activeReport.comparison.isFetching );
 
 	return {
 		table: {
 			rows,
-			isLoading: activeReport.isLoading,
-			isFetching: activeReport.isFetching,
+			isLoading,
+			isFetching,
+			isError: activeReport.primary.isError,
 		},
+		hasComparison: activeReport.hasComparison,
 		countries: {
 			options: countryOptions,
 		},
-		isError: activeReport.isError,
+		isError: activeReport.primary.isError,
 		refetch: activeReport.refetch,
 	};
 }

--- a/projects/packages/premium-analytics/routes/reports/locations/config/use-report-records.ts
+++ b/projects/packages/premium-analytics/routes/reports/locations/config/use-report-records.ts
@@ -1,11 +1,7 @@
 /**
  * External dependencies
  */
-import {
-	hasComparisonEnabled,
-	useStatsLocations,
-	type ReportParams,
-} from '@jetpack-premium-analytics/data';
+import { useStatsLocations, type ReportParams } from '@jetpack-premium-analytics/data';
 import { useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
@@ -34,11 +30,9 @@ export function useLocationsReportRecords(
 	countryFilter?: string
 ) {
 	/*
-	 * `summarize: 1` asks the API for one row per location across the whole
-	 * window, matching the Locations widget and the other list reports. The
-	 * day-bucketed alternative returns the same list once per day, which the
-	 * shared comparison merge cannot align. `max: 0` keeps the full list so the
-	 * table can search, sort, and page it client-side.
+	 * Without `summarize`, the API returns the whole list once per day, which
+	 * the shared comparison merge cannot align. `max: 0` keeps every row so the
+	 * table can search, sort, and page client-side.
 	 */
 	const recordsParams = useMemo(
 		() => ( {
@@ -92,20 +86,13 @@ export function useLocationsReportRecords(
 		[ countries.comparisonRows ]
 	);
 
-	// The table renders deltas, so it waits for the comparison period too. It
-	// must not fail with it: a comparison-only error still has valid primary
-	// rows to show, just without deltas.
-	const comparisonEnabled = hasComparisonEnabled( reportParams );
-	const isLoading =
-		activeReport.primary.isLoading || ( comparisonEnabled && activeReport.comparison.isLoading );
-	const isFetching =
-		activeReport.primary.isFetching || ( comparisonEnabled && activeReport.comparison.isFetching );
-
 	return {
 		table: {
 			rows,
-			isLoading,
-			isFetching,
+			isLoading: activeReport.isLoading,
+			isFetching: activeReport.isFetching,
+			// Not `activeReport.isError`: that folds in the comparison period,
+			// whose failure costs deltas but must not hide the primary rows.
 			isError: activeReport.primary.isError,
 		},
 		hasComparison: activeReport.hasComparison,

--- a/projects/packages/premium-analytics/routes/reports/locations/page.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/locations/page.test.tsx
@@ -3,9 +3,11 @@
  */
 import { useSectionTab } from '@jetpack-premium-analytics/routing';
 import {
+	ReportCsvAction,
 	ReportErrorState,
 	ReportPageTabs,
 	ReportRecordsTable,
+	useReportCsvExport,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -13,16 +15,21 @@ import { useState } from 'react';
 /**
  * Internal dependencies
  */
-import { useLocationsReportRecords } from './config';
+import { getLocationFields, useLocationsReportRecords } from './config';
 import LocationsReportPage from './page';
 import type { LocationRow, ReportLocationsTabId } from './config';
 import type { View } from '@wordpress/dataviews';
 import type { ReactNode } from 'react';
 
-jest.mock( './config', () => ( {
-	...jest.requireActual( './config' ),
-	useLocationsReportRecords: jest.fn(),
-} ) );
+jest.mock( './config', () => {
+	const actual = jest.requireActual( './config' );
+
+	return {
+		...actual,
+		getLocationFields: jest.fn( actual.getLocationFields ),
+		useLocationsReportRecords: jest.fn(),
+	};
+} );
 
 jest.mock( '@jetpack-premium-analytics/routing', () => ( {
 	...jest.requireActual( '@jetpack-premium-analytics/routing' ),
@@ -49,11 +56,18 @@ jest.mock( '@jetpack-premium-analytics/widgets-toolkit', () => ( {
 			{ children }
 		</>
 	),
-	ReportPageShell: ( { children }: { children: ReactNode } ) => <>{ children }</>,
+	ReportCsvAction: jest.fn( () => <button>Download</button> ),
+	ReportPageShell: ( { actions, children }: { actions?: ReactNode; children: ReactNode } ) => (
+		<>
+			{ actions }
+			{ children }
+		</>
+	),
 	ReportPageTabs: jest.fn( () => null ),
 	// The table's own tests cover how it renders the field config and reports
 	// view changes; here only the props the page hands it matter.
 	ReportRecordsTable: jest.fn( () => <div data-testid="records-table" /> ),
+	useReportCsvExport: jest.fn(),
 	useReportRetry: ( refetch: () => unknown ) => () => {
 		void refetch();
 	},
@@ -76,6 +90,8 @@ const useSectionTabMock = jest.mocked( useSectionTab );
 const reportErrorStateMock = jest.mocked( ReportErrorState );
 const reportPageTabsMock = jest.mocked( ReportPageTabs );
 const reportRecordsTableMock = jest.mocked( ReportRecordsTable );
+const reportCsvActionMock = jest.mocked( ReportCsvAction );
+const useReportCsvExportMock = jest.mocked( useReportCsvExport );
 
 const row: LocationRow = {
 	id: 'AU',
@@ -166,6 +182,46 @@ describe( 'LocationsReportPage', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
 		mockTabState( 'countries' );
+		useReportCsvExportMock.mockReturnValue( {
+			canExport: false,
+			rows: [],
+			filename: 'locations-countries',
+		} );
+	} );
+
+	// Each tab exports a different list, so the filename has to carry the tab.
+	it( 'offers a CSV export of the active tab', () => {
+		mockTabState( 'regions' );
+		const records = mockRecords();
+		useReportCsvExportMock.mockReturnValue( {
+			canExport: true,
+			rows: [ row ],
+			filename: 'locations-regions-2026-06-01_2026-06-30',
+		} );
+
+		render( <LocationsReportPage /> );
+
+		expect( screen.getByRole( 'button', { name: 'Download' } ) ).toBeInTheDocument();
+		expect( useReportCsvExportMock ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				rows: records.table.rows,
+				filenamePrefix: 'locations-regions',
+				status: records.table,
+			} )
+		);
+
+		const { columns, rows: exportRows } = reportCsvActionMock.mock.calls[ 0 ][ 0 ];
+		expect( exportRows.map( item => columns.map( column => column.getValue( item ) ) ) ).toEqual( [
+			[ 'Australia', 15 ],
+		] );
+	} );
+
+	it( 'hides the CSV export until the rows are settled', () => {
+		mockRecords();
+
+		render( <LocationsReportPage /> );
+
+		expect( screen.queryByRole( 'button', { name: 'Download' } ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'hands the active tab rows to the records table', () => {
@@ -246,6 +302,17 @@ describe( 'LocationsReportPage', () => {
 			{ value: 'AU', label: 'Australia' },
 			{ value: 'DE', label: 'Germany' },
 		] );
+	} );
+
+	// The hook knows whether the comparison period returned anything, and the
+	// fields render deltas only when it says so. The fields' own tests cover the
+	// rendering; this covers the hand-off.
+	it.each( [ true, false ] )( 'passes hasComparison=%s to the field config', hasComparison => {
+		mockRecords( { hasComparison } );
+
+		render( <LocationsReportPage /> );
+
+		expect( getLocationFields ).toHaveBeenCalledWith( undefined, hasComparison );
 	} );
 
 	// The country is a filter, not a column.

--- a/projects/packages/premium-analytics/routes/reports/locations/page.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/locations/page.test.tsx
@@ -189,7 +189,6 @@ describe( 'LocationsReportPage', () => {
 		} );
 	} );
 
-	// Each tab exports a different list, so the filename has to carry the tab.
 	it( 'offers a CSV export of the active tab', () => {
 		mockTabState( 'regions' );
 		const records = mockRecords();
@@ -211,9 +210,24 @@ describe( 'LocationsReportPage', () => {
 		);
 
 		const { columns, rows: exportRows } = reportCsvActionMock.mock.calls[ 0 ][ 0 ];
+		expect( columns.map( column => column.label ) ).toEqual( [ 'Location', 'Country', 'Views' ] );
 		expect( exportRows.map( item => columns.map( column => column.getValue( item ) ) ) ).toEqual( [
-			[ 'Australia', 15 ],
+			[ 'Australia', 'Australia', 15 ],
 		] );
+	} );
+
+	it( 'omits the country column from the Countries export', () => {
+		mockRecords();
+		useReportCsvExportMock.mockReturnValue( {
+			canExport: true,
+			rows: [ row ],
+			filename: 'locations-countries-2026-06-01_2026-06-30',
+		} );
+
+		render( <LocationsReportPage /> );
+
+		const { columns } = reportCsvActionMock.mock.calls[ 0 ][ 0 ];
+		expect( columns.map( column => column.label ) ).toEqual( [ 'Location', 'Views' ] );
 	} );
 
 	it( 'hides the CSV export until the rows are settled', () => {
@@ -304,9 +318,6 @@ describe( 'LocationsReportPage', () => {
 		] );
 	} );
 
-	// The hook knows whether the comparison period returned anything, and the
-	// fields render deltas only when it says so. The fields' own tests cover the
-	// rendering; this covers the hand-off.
 	it.each( [ true, false ] )( 'passes hasComparison=%s to the field config', hasComparison => {
 		mockRecords( { hasComparison } );
 

--- a/projects/packages/premium-analytics/routes/reports/locations/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/locations/page.tsx
@@ -9,12 +9,15 @@ import {
 } from '@jetpack-premium-analytics/routing';
 import { DateFiltersPanel } from '@jetpack-premium-analytics/ui';
 import {
+	ReportCsvAction,
 	ReportErrorState,
 	ReportPageLayout,
 	ReportPageShell,
 	ReportPageTabs,
 	ReportRecordsTable,
+	useReportCsvExport,
 	useReportRetry,
+	type CsvColumn,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { Breadcrumbs } from '@wordpress/admin-ui';
 import { useCallback, useMemo, useState } from '@wordpress/element';
@@ -62,6 +65,9 @@ const RECORDS_VIEW = {
 
 const COUNTRY_FILTER_FIELD = 'country';
 
+// Match the table's own default order, so the file reads like the screen.
+const sortLocationCsvRows = ( a: LocationRow, b: LocationRow ) => b.views - a.views;
+
 /**
  * Read the picked country out of a records-table view.
  *
@@ -93,10 +99,30 @@ export default function LocationsReportPage(): JSX.Element {
 	const fields = useMemo(
 		() =>
 			getLocationFields(
-				supportsCountryFilter( activeTab ) ? records.countries.options : undefined
+				supportsCountryFilter( activeTab ) ? records.countries.options : undefined,
+				records.hasComparison
 			),
-		[ activeTab, records.countries.options ]
+		[ activeTab, records.countries.options, records.hasComparison ]
 	);
+	const csvColumns = useMemo< CsvColumn< LocationRow >[] >(
+		() => [
+			{ label: __( 'Location', 'jetpack-premium-analytics-pkg' ), getValue: row => row.label },
+			{ label: __( 'Views', 'jetpack-premium-analytics-pkg' ), getValue: row => row.views },
+		],
+		[]
+	);
+	const {
+		canExport,
+		rows: csvRows,
+		filename: csvFilename,
+	} = useReportCsvExport( {
+		rows: records.table.rows,
+		// The tabs export different lists, so each gets its own filename.
+		filenamePrefix: `locations-${ activeTab }`,
+		range: reportParams,
+		status: records.table,
+		sort: sortLocationCsvRows,
+	} );
 
 	// A country picked on one tab does not carry to the next: the Countries tab
 	// cannot be scoped at all, and a country with regions may have no cities.
@@ -129,6 +155,11 @@ export default function LocationsReportPage(): JSX.Element {
 						{ label: __( 'Locations', 'jetpack-premium-analytics-pkg' ) },
 					] }
 				/>
+			}
+			actions={
+				canExport ? (
+					<ReportCsvAction columns={ csvColumns } rows={ csvRows } filename={ csvFilename } />
+				) : undefined
 			}
 		>
 			<ReportPageLayout

--- a/projects/packages/premium-analytics/routes/reports/locations/page.tsx
+++ b/projects/packages/premium-analytics/routes/reports/locations/page.tsx
@@ -104,12 +104,22 @@ export default function LocationsReportPage(): JSX.Element {
 			),
 		[ activeTab, records.countries.options, records.hasComparison ]
 	);
+	// Region and city names repeat across countries. On screen the flag tells
+	// them apart; a CSV needs its own column.
 	const csvColumns = useMemo< CsvColumn< LocationRow >[] >(
 		() => [
 			{ label: __( 'Location', 'jetpack-premium-analytics-pkg' ), getValue: row => row.label },
+			...( supportsCountryFilter( activeTab )
+				? [
+						{
+							label: __( 'Country', 'jetpack-premium-analytics-pkg' ),
+							getValue: ( row: LocationRow ) => row.countryFull,
+						},
+				  ]
+				: [] ),
 			{ label: __( 'Views', 'jetpack-premium-analytics-pkg' ), getValue: row => row.views },
 		],
-		[]
+		[ activeTab ]
 	);
 	const {
 		canExport,

--- a/projects/packages/premium-analytics/routes/reports/report-csv-exports.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/report-csv-exports.test.tsx
@@ -155,7 +155,7 @@ jest.mock( './locations/config', () => ( {
 	getLocationFields: () => [],
 	getReportLocationsTabs: () => [ { id: 'countries', label: 'Countries' } ],
 	resolveSection: ( value: string | undefined ) => value ?? 'countries',
-	supportsCountryFilter: () => false,
+	supportsCountryFilter: ( tab: string ) => tab !== 'countries',
 	useLocationsReportRecords: jest.fn(),
 } ) );
 
@@ -453,7 +453,6 @@ describe( 'report CSV exports', () => {
 		expectCsvExport( ReferrersReportPage, 'referrers', rows, [ 'Search', '', 10, '' ] );
 	} );
 
-	// The tabs export different lists, so the filename carries the active tab.
 	it( 'configures the Locations export', () => {
 		const rows = [
 			{ id: 'IN:India', label: 'India', countryCode: 'IN', countryFull: 'India', views: 2 },

--- a/projects/packages/premium-analytics/routes/reports/report-csv-exports.test.tsx
+++ b/projects/packages/premium-analytics/routes/reports/report-csv-exports.test.tsx
@@ -23,6 +23,8 @@ import { useDownloadsReportRecords } from './downloads/config';
 import DownloadsReportPage from './downloads/page';
 import { useEmailsReportRecords } from './emails/config';
 import EmailsReportPage from './emails/page';
+import { useLocationsReportRecords } from './locations/config';
+import LocationsReportPage from './locations/page';
 import { useReferrersReportRecords } from './referrers/config';
 import ReferrersReportPage from './referrers/page';
 import { useSearchTermsReportRecords } from './search-terms/config';
@@ -149,6 +151,14 @@ jest.mock( './emails/config', () => ( {
 	useEmailsReportRecords: jest.fn(),
 } ) );
 
+jest.mock( './locations/config', () => ( {
+	getLocationFields: () => [],
+	getReportLocationsTabs: () => [ { id: 'countries', label: 'Countries' } ],
+	resolveSection: ( value: string | undefined ) => value ?? 'countries',
+	supportsCountryFilter: () => false,
+	useLocationsReportRecords: jest.fn(),
+} ) );
+
 jest.mock( './referrers/config', () => ( {
 	getReferrerFields: () => [],
 	useReferrersReportRecords: jest.fn(),
@@ -179,6 +189,7 @@ const useCommentFollowersReportRecordsMock = jest.mocked( useCommentFollowersRep
 const useCommentsReportRecordsMock = jest.mocked( useCommentsReportRecords );
 const useDownloadsReportRecordsMock = jest.mocked( useDownloadsReportRecords );
 const useEmailsReportRecordsMock = jest.mocked( useEmailsReportRecords );
+const useLocationsReportRecordsMock = jest.mocked( useLocationsReportRecords );
 const useReferrersReportRecordsMock = jest.mocked( useReferrersReportRecords );
 const useSearchTermsReportRecordsMock = jest.mocked( useSearchTermsReportRecords );
 const useTagsReportRecordsMock = jest.mocked( useTagsReportRecords );
@@ -440,6 +451,39 @@ describe( 'report CSV exports', () => {
 		} as ReturnType< typeof useReferrersReportRecords > );
 
 		expectCsvExport( ReferrersReportPage, 'referrers', rows, [ 'Search', '', 10, '' ] );
+	} );
+
+	// The tabs export different lists, so the filename carries the active tab.
+	it( 'configures the Locations export', () => {
+		const rows = [
+			{ id: 'IN:India', label: 'India', countryCode: 'IN', countryFull: 'India', views: 2 },
+			{
+				id: 'AU:Australia',
+				label: 'Australia',
+				countryCode: 'AU',
+				countryFull: 'Australia',
+				views: 5,
+			},
+		];
+		useSectionTabMock.mockReturnValue( [ 'countries', jest.fn() ] as unknown as ReturnType<
+			typeof useSectionTab
+		> );
+		useLocationsReportRecordsMock.mockReturnValue( {
+			...reportStatus,
+			hasComparison: false,
+			countries: { options: [] },
+			table: {
+				...reportStatus,
+				rows,
+			},
+		} as unknown as ReturnType< typeof useLocationsReportRecords > );
+
+		expectCsvExport(
+			LocationsReportPage,
+			'locations-countries',
+			[ rows[ 1 ], rows[ 0 ] ],
+			[ 'Australia', 5 ]
+		);
 	} );
 
 	it( 'configures the Search terms export', () => {


### PR DESCRIPTION
Fixes #

Follow-up to #50438, addressing @chihsuan's review feedback.

## Proposed changes

* **Summarize the Locations requests.** They asked for `summarize: 1` to match the Locations widget and the other list reports. The requests were day-bucketed, so the API returned the same list once per day and the page summed it client-side. Worse, the shared comparison merge flattens buckets without summing, so it could never align the two periods.
* **Show the period-over-period change.** `useStatsLocations()` was already fetching both periods, but the page built rows from `primary.data` only — so the table waited on a request it never used. It now renders the comparison through `MetricWithComparison`, like the other report tables.
* **Keep the primary rows when only the comparison fails.** `useReport()` reports `isError` as `primary.isError || comparison.isError`, so a comparison-only failure replaced valid rows with the error state. The page now gates on `primary.isError`.
* **Use the shared number formatter.** The views column called `toLocaleString()`, the browser-locale formatting #50597 moved every other report off. Locations was the last one left, and it was missing from the `count-fields.test.tsx` guard that would have caught it — it is registered there now.
* **Add the CSV export.** Every other report page already offers it. Each tab exports its own list, so the filename carries the active tab (`locations-countries`, `locations-regions`, `locations-cities`).

## Related product discussion/links

* WOOA7S-1697
* Review: https://github.com/Automattic/jetpack/pull/50438#pullrequestreview-4841745613

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Go to **Jetpack → Stats → Locations**.
* Pick a multi-day range, for example **Last 30 days**, and confirm the view counts look right on **Countries**, **Regions**, and **Cities**. They should match what the Locations widget shows on the dashboard.
* Open the network tab and confirm each `stats/country-views` (and region/city) request sends `summarize=1`. Confirm one request per tab, not one per day.
* Set a comparison range with **Compare to**. Each row should show a percentage change next to its view count.
* Turn the comparison off. The percentages should disappear and the counts should stay.
* Confirm the numbers use grouped thousands (`1,234`) whatever your browser locale is.
* Click **Download** in the page header. Confirm the CSV has a `Location` and a `Views` column, is ordered by views descending, and that the filename carries the active tab.
* On **Regions** or **Cities**, pick a country in the filter and confirm the table and the CSV both narrow to it.
