### PR TITLE
Newsletter: fix site name with apostrophe showing up incorrectly in Sender Settings

### DIFF
--- a/projects/packages/assets/changelog/fix-script-data-site-title-html-entities
+++ b/projects/packages/assets/changelog/fix-script-data-site-title-html-entities
@@ -1,4 +1,4 @@
 Significance: patch
-Type: bugfix
+Type: fixed
 
 Script Data: decode HTML entities in the shared site title so consumers (e.g. the Newsletter Sender Settings panel) don't show literal entities like `&#039;` for site names containing an apostrophe or other special characters.

--- a/projects/packages/assets/changelog/fix-script-data-site-title-html-entities
+++ b/projects/packages/assets/changelog/fix-script-data-site-title-html-entities
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Script Data: decode HTML entities in the shared site title so consumers (e.g. the Newsletter Sender Settings panel) don't show literal entities like `&#039;` for site names containing an apostrophe or other special characters.

--- a/projects/packages/assets/src/class-script-data.php
+++ b/projects/packages/assets/src/class-script-data.php
@@ -192,7 +192,7 @@ class Script_Data {
 	 * @return string
 	 */
 	protected static function get_site_title() {
-		$title = get_bloginfo( 'name' );
+		$title = wp_specialchars_decode( get_bloginfo( 'name' ), ENT_QUOTES );
 
 		return $title ? $title : esc_url_raw( ( get_site_url() ) );
 	}

--- a/projects/packages/assets/tests/php/ScriptDataTest.php
+++ b/projects/packages/assets/tests/php/ScriptDataTest.php
@@ -295,4 +295,34 @@ class ScriptDataTest extends TestCase {
 		$this->assertStringNotContainsString( 'should_not_be_used', $data );
 		$this->assertSame( 'before', $position );
 	}
+
+	public function test_admin_script_data_decodes_html_entities_in_site_title() {
+		// Simulate a site title stored with encoded HTML entities, e.g. an apostrophe.
+		Functions\when( 'get_bloginfo' )->alias(
+			function () {
+				return 'Gabriel&#039;s Blog';
+			}
+		);
+
+		Functions\when( 'is_admin' )->justReturn( true );
+		Functions\when( 'wp_is_serving_rest_request' )->justReturn( false );
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( 'did_action' )->justReturn( false );
+
+		// Let the filter pass the real $data through unmodified, so the built 'site.title' is observable.
+		Monkey\Filters\expectApplied( 'jetpack_admin_js_script_data' )->once();
+
+		$add_inline_args = array( null, '', null );
+		Functions\when( 'wp_add_inline_script' )->alias(
+			function ( $handle, $data, $position ) use ( &$add_inline_args ) {
+				$add_inline_args = array( $handle, $data, $position );
+			}
+		);
+
+		Script_Data::render_script_data();
+
+		list( , $data, ) = $add_inline_args;
+		$this->assertStringContainsString( '"title":"Gabriel\'s Blog"', $data );
+		$this->assertStringNotContainsString( '&#039;', $data );
+	}
 }

--- a/projects/packages/assets/tests/php/ScriptDataTest.php
+++ b/projects/packages/assets/tests/php/ScriptDataTest.php
@@ -42,6 +42,11 @@ class ScriptDataTest extends TestCase {
 				return 'Test Blog';
 			}
 		);
+		Functions\when( 'wp_specialchars_decode' )->alias(
+			function ( $string, $flags = ENT_QUOTES ) {
+				return htmlspecialchars_decode( $string, $flags );
+			}
+		);
 		Functions\when( 'get_site_url' )->alias(
 			function () {
 				return 'http://example.com/';


### PR DESCRIPTION
Closes NL-677

Before
<img width="1562" height="640" alt="CleanShot 2026-08-03 at 10 45 03@2x" src="https://github.com/user-attachments/assets/54067a36-4768-44af-9438-ee94ea9b347a" />

After
<img width="1564" height="640" alt="CleanShot 2026-08-03 at 10 46 53@2x" src="https://github.com/user-attachments/assets/68c1d966-4b3b-4194-97b0-367daed987e1" />


## Proposed changes

* `Script_Data::get_site_title()` now decodes HTML entities in the site title before exposing it as `window.JetpackScriptData.site.title`.
* `get_bloginfo( 'name' )` can return the title already HTML-entity-encoded — WordPress.com stores `blogname` with entities for special characters (e.g. an apostrophe becomes `&#039;`). Since `window.JetpackScriptData.site.title` is placed directly into things like the Newsletter Sender Settings panel's input placeholder (a DOM attribute, not an HTML-rendering context), the entity was never decoded and showed up literally instead of the real character.
* This matches the pattern already used elsewhere in this repo for the same reason — `wpcom-dashboard-widgets.php` and `class-verbum-comments.php` both decode `get_bloginfo( 'name' )` before use, as does WordPress core itself in several places (`pluggable.php`, `user.php`, `functions.php`).
* `window.JetpackScriptData.site.title` is shared/global, so this fixes every consumer, not just Sender Settings. Notably, the actual sent newsletter email already shows the site name correctly (a different, already-decoded code path) — this bug was specific to the Sender Settings preview/placeholder in the admin UI.

## Related product discussion/links

* Linear: NL-677 — "Site name with apostrophe shows up incorrectly in Sender Settings".

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On a site whose title contains an apostrophe or other special character (WordPress.com stores this already entity-encoded, e.g. `Gabriel&#039;s Blog` — confirm with `wp option get blogname`), go to **Jetpack → Newsletter** settings (`wp-admin/admin.php?page=jetpack-newsletter`).
2. Look at the **Sender settings** card's "Sender name" field (leave it empty so the placeholder shows) and the "Preview" line just below it.
3. **Before this fix:** both show the literal entity, e.g. `Gabriel&#039;s Blog`.
4. **After this fix:** both show the real character, e.g. `Gabriel's Blog`.
5. You can also confirm the underlying value directly without the UI: `wp eval 'echo (new ReflectionMethod("Automattic\\Jetpack\\Assets\\Script_Data", "get_site_title"))->invoke(null);'` — should print the decoded title. (Or on a sandbox where `wp eval` is disabled, compare `get_bloginfo('name')` vs `wp_specialchars_decode(get_bloginfo('name'), ENT_QUOTES)` via `wp shell`.)
