### PR TITLE
Connection: standardize error structure with explicit transport and direction

### DIFF
--- a/projects/packages/connection/changelog/update-connection-standardize-error-structure
+++ b/projects/packages/connection/changelog/update-connection-standardize-error-structure
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Error Handler: Standardize the stored connection error structure, record whether errors come from incoming or outgoing requests, and label errors with the actual transport (XML-RPC or REST) of the failed request.

--- a/projects/packages/connection/changelog/update-connection-standardize-error-structure
+++ b/projects/packages/connection/changelog/update-connection-standardize-error-structure
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Error Handler: Standardize the stored connection error structure, record whether errors come from incoming or outgoing requests, and label errors with the actual transport (XML-RPC or REST) of the failed request.
+Error Handler: Standardize the stored connection error structure, record whether errors come from incoming or outgoing requests, and label errors with the actual transport (XML-RPC or REST) of the failed request. Local connection-state errors are now stored with error type 'local_state' instead of 'connection'.

--- a/projects/packages/connection/changelog/update-connection-standardize-error-structure
+++ b/projects/packages/connection/changelog/update-connection-standardize-error-structure
@@ -1,6 +1,4 @@
 Significance: minor
 Type: changed
 
-Error Handler: Standardize the stored connection error structure, record whether errors come from incoming or outgoing requests, and label errors with the actual transport (XML-RPC or REST) of the failed request. Local connection-state errors are now stored with error type 'local_state' instead of 'connection'.
-
-Error Handler: Signature verification errors that previously carried no error data (e.g. `invalid_secret`, `invalid_token` from Jetpack_Signature) are now normalized and stored. Sites with a corrupt stored token may start seeing connection error notices that were previously dropped. Signature errors that were stored untyped are now labeled with their transport, so a successful API request clears them.
+Error Handler: Standardize the stored connection error structure with explicit error type and direction fields, store local connection-state errors as 'local_state' instead of 'connection', and store previously dropped signature verification errors, which can now surface connection error notices.

--- a/projects/packages/connection/changelog/update-connection-standardize-error-structure
+++ b/projects/packages/connection/changelog/update-connection-standardize-error-structure
@@ -2,3 +2,5 @@ Significance: minor
 Type: changed
 
 Error Handler: Standardize the stored connection error structure, record whether errors come from incoming or outgoing requests, and label errors with the actual transport (XML-RPC or REST) of the failed request. Local connection-state errors are now stored with error type 'local_state' instead of 'connection'.
+
+Error Handler: Signature verification errors that previously carried no error data (e.g. `invalid_secret`, `invalid_token` from Jetpack_Signature) are now normalized and stored. Sites with a corrupt stored token may start seeing connection error notices that were previously dropped. Signature errors that were stored untyped are now labeled with their transport, so a successful API request clears them.

--- a/projects/packages/connection/docs/error-handling.md
+++ b/projects/packages/connection/docs/error-handling.md
@@ -1,16 +1,108 @@
 # Error Handling
 
-Whenever WordPress.com makes a request that fails to authenticate, the Connection package will store the error in the database and display a generic error message to the user.
+The Connection package detects, stores, and surfaces connection (authentication/signature) errors. `Automattic\Jetpack\Connection\Error_Handler` is the central class: it captures errors for requests in both directions, keeps them in the database, and drives the admin notices and dashboard messages that prompt users to fix a broken connection.
 
-If you want to enable and customize this message, here is what you have to do.
+This document describes how errors are captured, classified, stored, displayed, and cleared, and how plugins can customize the experience.
 
-(Check [#16194](https://github.com/Automattic/jetpack/pull/16194) for more information on how errors are catched and validated.)
+## How errors are captured
 
-## Enabling the error message
+### Incoming requests (WordPress.com → site)
 
-If you want to enable the error message, you can use the `jetpack_connection_error_notice_message` filter. The second argument is an array with the details of all the errors (if more than one).
+When WordPress.com makes a signed request to the site and signature verification fails in `Manager::verify_xml_rpc_signature()`, the resulting error is reported to `Error_Handler::report_error()`. This covers both transports: XML-RPC requests, and signed REST requests, which `REST_Authentication` funnels into the same verification path.
 
-This basic example show how to display a simple error message no matter the specific error type:
+Because anyone can send an unauthenticated request that fails verification, an incoming error cannot be trusted at face value. It goes through a verification round-trip:
+
+1. The error is stored in the database as **unverified**.
+2. The error details are encrypted and sent to WordPress.com.
+3. WordPress.com checks that the token in the error actually belongs to this site and, if so, calls back the site's `jetpack/v4/verify_xmlrpc_error` REST endpoint with the error's nonce.
+4. The site moves the matching error to the **verified** list. Only verified errors are eligible for display and error-recovery workflows.
+
+### Outgoing requests (site → WordPress.com)
+
+Every signed request made through `Client::remote_request()` has its response checked by `Error_Handler::check_api_response_for_errors()`. When a non-200 response carries a known error code — in either the legacy v1 JSON-API envelope (`{"error": ...}`) or the WP-API v2 envelope (`{"code": ...}`) — the error is stored directly as **verified**. No WordPress.com round-trip is needed: the error arrived in a response to a request this site itself initiated and signed, so the failed response is its own evidence.
+
+Note: XML-RPC faults arrive as HTTP 200 responses with an XML body, so they are invisible to this check. Only errors surfaced at the HTTP level with a JSON error envelope are captured — one of the reasons outgoing calls are being migrated from XML-RPC to REST.
+
+### Connection-state errors
+
+Some errors describe broken local state rather than a failed request — for example `invalid_connection_owner`, reported by `Manager::get_connection_owner()` when the connection owner cannot be resolved (missing owner token, or the owner's WP user was deleted). These are reported with `report_error()` and skip the WordPress.com round-trip, since the evidence is local.
+
+## Error classification
+
+Each stored error carries two orthogonal classification fields:
+
+| Field | Values | Meaning |
+|---|---|---|
+| `error_type` | `xmlrpc`, `rest`, `connection`, `''` | The transport of the failed request; `connection` marks local connection-state errors that involve no request; `''` appears on entries stored by older package versions. |
+| `error_direction` | `incoming`, `outgoing`, `''` | Whether the failed request was made to the site or by the site; `''` appears on legacy entries and `connection`-type errors, which have no direction. |
+
+## Supported error codes
+
+Only a fixed list of error codes is handled: the `Error_Handler::$known_errors` allowlist, defined in [`src/class-error-handler.php`](../src/class-error-handler.php). Any error reported with a code outside this list is silently discarded — no log, no storage. The known codes fall into four groups, and each individual code is documented inline where the list is defined:
+
+* **Incoming request token problems** — the token in the incoming request is malformed or references an unknown user (e.g. `malformed_token`, `unknown_user`).
+* **Locally stored token problems** — the token stored on this site is missing or corrupt (e.g. `no_user_tokens`, `token_malformed`, `no_valid_blog_token`).
+* **Signature problems** — signing or signature verification failed, either for an incoming request or reported by WordPress.com for an outgoing one (e.g. `invalid_token`, `signature_mismatch`, `invalid_nonce`).
+* **Connection state problems** — local connection state is broken (`invalid_connection_owner`).
+
+If WordPress.com starts returning a new error code, it will be invisible to this system until the code is added to the allowlist. When debugging missing errors, check the response body against this list first (see [Debugging](#debugging)).
+
+## The standard error structure
+
+All reporters build their `WP_Error` objects through the `Error_Handler::build_connection_wp_error()` / `build_connection_error_data()` factory, which defines the standard data shape: a `signature_details` array that always contains a `token` key (empty string when the error is not tied to a specific token), plus validated `error_type` and `error_direction` values. Errors that don't follow this shape are silently discarded by the storage layer, so use the factory rather than assembling the data by hand.
+
+If you are reporting an error yourself, note the security contract of `report_error()`'s `$skip_wpcom_verification` parameter: verified errors trigger user-facing workflows, so only skip the WordPress.com round-trip when the error is self-evidencing (an outgoing response, or local connection state) — never for an error derived from an incoming request.
+
+## Storage
+
+Errors are stored in two options:
+
+* `jetpack_connection_xmlrpc_errors` — unverified errors.
+* `jetpack_connection_xmlrpc_verified_errors` — verified errors.
+
+Both names contain "xmlrpc" because they predate REST support; they are intentionally kept as-is to avoid a data migration, and store errors of every type and direction.
+
+Within each option, errors are keyed by error code, then by user ID:
+
+```
+[
+  'invalid_token' => [
+    '123' => [
+      'error_code'      => 'invalid_token',
+      'user_id'         => '123',
+      'error_message'   => 'The token is invalid',
+      'error_data'      => [ ... signature details ... ],
+      'timestamp'       => 1234567890,
+      'nonce'           => 'abc123def',
+      'error_type'      => 'xmlrpc',
+      'error_direction' => 'incoming',
+    ],
+  ],
+]
+```
+
+The user ID identifies the credential that failed:
+
+* `0` — the blog token.
+* A positive integer — that user's token.
+* `'invalid'` — the token could not be attributed to anyone (empty, truncated, or garbled). Unattributable errors are skipped by the display pipeline, since no viewer can act on them.
+
+Storage limits and hygiene:
+
+* At most 5 user IDs are kept per error code; the oldest is evicted when a sixth arrives.
+* Errors expire 24 hours after being stored (checked on read).
+* A reporting gate only processes each error code once per hour, protecting both the site and WordPress.com from error storms. The `jetpack_connection_bypass_error_reporting_gate` filter can disable the gate (useful in tests).
+* Only [supported error codes](#supported-error-codes) are stored — anything else is silently discarded.
+
+## Displaying errors
+
+Verified, displayable errors are surfaced on admin pages through `handle_verified_errors()`: a generic admin notice, and an entry in the React dashboard's initial state. Only a subset of error codes is user-displayable (see `get_displayable_errors()`), and each displayable error is classified by audience — `site` (blog token), `owner` (the connection owner's token), or `user` (another user's token) — so consumers can render viewer-appropriate copy.
+
+### Enabling the error message
+
+By default, no admin notice text is shown. To enable it, use the `jetpack_connection_error_notice_message` filter. The second argument is an array with the details of all the errors (if more than one).
+
+This basic example shows how to display a simple error message no matter the specific error type:
 
 ```PHP
 
@@ -47,7 +139,7 @@ function my_function( $message, $errors ) {
 
 ```
 
-## Further customizing error notices
+### Further customizing error notices
 
 If you want to completely change the admin notice, you can ignore the default message and hook into an action that will let you do whatever you want.
 
@@ -79,6 +171,8 @@ function my_function( $errors ) {
 
 ```
 
+On selected hosting platforms (WoA, VIP, Newspack), the displayable errors themselves can additionally be filtered via `jetpack_connection_get_verified_errors`.
+
 ## Getting the errors yourself
 
 If you want to access the errors stored in the database, you can use:
@@ -88,3 +182,11 @@ If you want to access the errors stored in the database, you can use:
 ```
 
 Check [the class file](../src/class-error-handler.php) for further documentation on the structure of the stored errors.
+
+## When errors are cleared
+
+Stored errors are deleted automatically when the connection is restored or torn down — on site registration, reconnection, disconnection, token deletion, user unlink, and user-token update. Additionally, a successful API request (`jetpack_get_site_data_success`) clears all `xmlrpc` and `rest` type errors via `delete_all_api_errors()`; `connection`-type errors are deliberately kept there, because a successful API round-trip refutes token/signature problems but says nothing about local state such as a missing connection owner.
+
+## Debugging
+
+The [Jetpack Debug Tools](https://github.com/Automattic/jetpack/tree/trunk/projects/plugins/debug-helper) plugin's **Broken Token** module is the main tool for exercising this system on a test site: it can corrupt the blog or user token, generate sample errors of any type and direction, and display the raw contents of the stored and verified error options.

--- a/projects/packages/connection/docs/error-handling.md
+++ b/projects/packages/connection/docs/error-handling.md
@@ -25,7 +25,7 @@ Note: XML-RPC faults arrive as HTTP 200 responses with an XML body, so they are 
 
 ### Connection-state errors
 
-Some errors describe broken local state rather than a failed request — for example `invalid_connection_owner`, reported by `Manager::get_connection_owner()` when the connection owner cannot be resolved (missing owner token, or the owner's WP user was deleted). These are reported with `report_error()` and skip the WordPress.com round-trip, since the evidence is local.
+Some errors describe broken local state rather than a failed request — for example `invalid_connection_owner`, reported by `Manager::get_connection_owner()` when the connection owner cannot be resolved (missing owner token, or the owner's WP user was deleted). These are stored with `error_type` set to `local_state` and are reported with `report_error()` skipping the WordPress.com round-trip: the evidence is the site's own database, so there is nothing for WordPress.com to confirm.
 
 ## Error classification
 
@@ -33,8 +33,8 @@ Each stored error carries two orthogonal classification fields:
 
 | Field | Values | Meaning |
 |---|---|---|
-| `error_type` | `xmlrpc`, `rest`, `connection`, `''` | The transport of the failed request; `connection` marks local connection-state errors that involve no request; `''` appears on entries stored by older package versions. |
-| `error_direction` | `incoming`, `outgoing`, `''` | Whether the failed request was made to the site or by the site; `''` appears on legacy entries and `connection`-type errors, which have no direction. |
+| `error_type` | `xmlrpc`, `rest`, `local_state`, `''` | The transport of the failed request; `local_state` marks connection-state errors that involve no request (stored as `connection` by package versions ≤ 8.8); `''` appears on entries stored by older package versions. |
+| `error_direction` | `incoming`, `outgoing`, `''` | Whether the failed request was made to the site or by the site; `''` appears on legacy entries and `local_state`-type errors, which have no direction — the error factory discards any direction passed for them. |
 
 ## Supported error codes
 
@@ -185,7 +185,7 @@ Check [the class file](../src/class-error-handler.php) for further documentation
 
 ## When errors are cleared
 
-Stored errors are deleted automatically when the connection is restored or torn down — on site registration, reconnection, disconnection, token deletion, user unlink, and user-token update. Additionally, a successful API request (`jetpack_get_site_data_success`) clears all `xmlrpc` and `rest` type errors via `delete_all_api_errors()`; `connection`-type errors are deliberately kept there, because a successful API round-trip refutes token/signature problems but says nothing about local state such as a missing connection owner.
+Stored errors are deleted automatically when the connection is restored or torn down — on site registration, reconnection, disconnection, token deletion, user unlink, and user-token update. Additionally, a successful API request (`jetpack_get_site_data_success`) clears all `xmlrpc` and `rest` type errors via `delete_all_api_errors()`; `local_state`-type errors are deliberately kept there, because a successful API round-trip refutes token/signature problems but says nothing about local state such as a missing connection owner.
 
 ## Debugging
 

--- a/projects/packages/connection/docs/error-handling.md
+++ b/projects/packages/connection/docs/error-handling.md
@@ -189,4 +189,4 @@ Stored errors are deleted automatically when the connection is restored or torn 
 
 ## Debugging
 
-The [Jetpack Debug Tools](https://github.com/Automattic/jetpack/tree/trunk/projects/plugins/debug-helper) plugin's **Broken Token** module is the main tool for exercising this system on a test site: it can corrupt the blog or user token, generate sample errors of any type and direction, and display the raw contents of the stored and verified error options.
+The [Jetpack Debug Tools](https://github.com/Automattic/jetpack/tree/trunk/projects/plugins/debug-helper) plugin's **Broken Token** module is the main tool for exercising this system on a test site: it can corrupt the blog or user token, generate sample errors of any type and direction, and display the raw contents of the stored and verified error options. The easiest way to install it is via the [Jetpack Beta Tester](https://jetpack.com/download-jetpack-beta/) plugin — activate the Bleeding Edge version of Jetpack Debug Tools from its plugin list; alternatively, build it from the monorepo and upload it manually.

--- a/projects/packages/connection/src/class-client.php
+++ b/projects/packages/connection/src/class-client.php
@@ -46,12 +46,22 @@ class Client {
 
 		$response = self::_wp_remote_request( $result['url'], $result['request'] );
 
+		// Feed the response into the outgoing-request error flow of Error_Handler: any known
+		// connection error in it is stored and surfaced to the user. See the Error_Handler
+		// class docblock for the full picture of both error-handling flows.
+		// Outgoing XML-RPC calls (Jetpack_IXR_Client) are funneled through this method too;
+		// tell the transports apart by the endpoint the request targets.
+		$request_path = (string) wp_parse_url( empty( $args['url'] ) ? '' : $args['url'], PHP_URL_PATH );
+		$error_type   = '/xmlrpc.php' === substr( $request_path, -strlen( '/xmlrpc.php' ) )
+			? Error_Handler::ERROR_TYPE_XMLRPC
+			: Error_Handler::ERROR_TYPE_REST;
+
 		Error_Handler::get_instance()->check_api_response_for_errors(
 			$response,
 			$result['auth'],
 			empty( $args['url'] ) ? '' : $args['url'],
 			empty( $args['method'] ) ? 'POST' : $args['method'],
-			'rest'
+			$error_type
 		);
 
 		/**

--- a/projects/packages/connection/src/class-error-handler.php
+++ b/projects/packages/connection/src/class-error-handler.php
@@ -810,11 +810,13 @@ class Error_Handler {
 	 * - `signature_details` is guaranteed to contain a `token` key (empty string when
 	 *   the error is not tied to a specific token), which `wp_error_to_array()` requires.
 	 *   The token is also what WP.com checks when verifying incoming-flow errors, so its
-	 *   key and position in the payload must not change.
+	 *   key must not be renamed.
 	 * - `error_type` and `error_direction` are validated against the class constants and
 	 *   stored as '' when the given value is not recognized. For 'local_state' errors the
 	 *   direction is always forced to '' — they describe the site's own database, not a
 	 *   request, so a direction would be meaningless and is ignored if passed.
+	 * - `$extra` cannot override the reserved keys: `signature_details`, `error_type`,
+	 *   and `error_direction` always win the merge.
 	 *
 	 * @since $$next-version$$
 	 *
@@ -1352,7 +1354,7 @@ class Error_Handler {
 	 * @param array           $auth_data Auth data, allowed keys: `token`, `timestamp`, `nonce`, `body-hash`.
 	 * @param string          $url Request URL.
 	 * @param string          $method Request method.
-	 * @param string          $error_type The transport of the outgoing request: 'xmlrpc' or 'rest'.
+	 * @param string          $error_type The transport of the outgoing request: `ERROR_TYPE_XMLRPC` or `ERROR_TYPE_REST`.
 	 *
 	 * @return void
 	 */

--- a/projects/packages/connection/src/class-error-handler.php
+++ b/projects/packages/connection/src/class-error-handler.php
@@ -8,11 +8,16 @@
 namespace Automattic\Jetpack\Connection;
 
 /**
- * The Jetpack Connection Errors that handles errors
+ * The Jetpack Connection error handler.
  *
- * This class handles the following workflow for incoming XML-RPC and REST API requests:
+ * This class stores and surfaces connection (authentication/signature) errors for requests
+ * in both directions: incoming (WP.com to this site) and outgoing (this site to WP.com).
  *
- * 1. An incoming XML-RPC or REST API request with an invalid signature triggers an error
+ * Flow 1 — incoming request errors. Entry point: `report_error()`.
+ *
+ * 1. An incoming XML-RPC or REST API request with an invalid signature triggers an error in
+ *    `Manager::verify_xml_rpc_signature()`, which reports it here. (Signed incoming REST
+ *    requests are funneled into the same verification path by `REST_Authentication`.)
  * 2. Applies a gate to only process each error code once an hour to avoid overflow
  * 3. It stores the error on the database, but we don't know yet if this is a valid error, because
  *    we can't confirm it came from WP.com.
@@ -21,8 +26,27 @@ namespace Automattic\Jetpack\Connection;
  * 6. This endpoint adds this error to the Verified errors in the database
  * 7. Triggers a workflow depending on the error (display user an error message, do some self healing, etc.)
  *
- * Note: This class only handles authentication/signature errors from incoming requests to this site.
- * Outgoing request signing issues (when this site makes requests to WP.com) are not handled here.
+ * Flow 2 — outgoing request errors. Entry point: `check_api_response_for_errors()`.
+ *
+ * 1. Every signed request made through `Client::remote_request()` has its response checked
+ *    by `check_api_response_for_errors()`.
+ * 2. When the response carries a known error code, the error is stored and immediately
+ *    marked verified (the same hourly gate applies). The WP.com verification round-trip of
+ *    flow 1 is skipped because the error arrived in a response to a request this site
+ *    itself initiated and signed — the failed response is its own evidence.
+ *
+ * Stored errors carry two orthogonal classification fields:
+ *
+ * - `error_type` — the transport/source of the failed request: 'xmlrpc', 'rest',
+ *   'connection' (local connection-state errors involving no request at all, e.g.
+ *   `invalid_connection_owner`), or '' for entries stored by older package versions.
+ * - `error_direction` — 'incoming', 'outgoing', or '' (legacy entries and
+ *   'connection'-type errors, which have no direction).
+ *
+ * Note on naming: both option names below contain "xmlrpc" because they predate REST
+ * support. They are intentionally kept as-is to avoid a data migration and breaking
+ * consumers that read the options directly — despite the names, they store errors of
+ * every type and direction.
  *
  * Errors are stored in the database as options in the following format:
  *
@@ -51,7 +75,8 @@ namespace Automattic\Jetpack\Connection;
  *       'error_data' => ['action' => 'reconnect'],
  *       'timestamp' => 1234567890,
  *       'nonce' => 'abc123def',
- *       'error_type' => 'xmlrpc'
+ *       'error_type' => 'xmlrpc',
+ *       'error_direction' => 'incoming'
  *     ]
  *   ]
  * ]
@@ -86,6 +111,52 @@ class Error_Handler {
 	 * @var string
 	 */
 	const ERROR_REPORTING_GATE = 'jetpack_connection_error_reporting_gate_';
+
+	/**
+	 * `error_type` value for errors from XML-RPC requests.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var string
+	 */
+	const ERROR_TYPE_XMLRPC = 'xmlrpc';
+
+	/**
+	 * `error_type` value for errors from REST requests.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var string
+	 */
+	const ERROR_TYPE_REST = 'rest';
+
+	/**
+	 * `error_type` value for local connection-state errors that involve no request,
+	 * e.g. `invalid_connection_owner`.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var string
+	 */
+	const ERROR_TYPE_CONNECTION = 'connection';
+
+	/**
+	 * `error_direction` value for errors triggered by incoming requests (WP.com to this site).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var string
+	 */
+	const DIRECTION_INCOMING = 'incoming';
+
+	/**
+	 * `error_direction` value for errors triggered by outgoing requests (this site to WP.com).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var string
+	 */
+	const DIRECTION_OUTGOING = 'outgoing';
 
 	/**
 	 * Time in seconds a test should live in the database before being discarded
@@ -513,9 +584,22 @@ class Error_Handler {
 	/**
 	 * Keep track of a connection error that was encountered
 	 *
+	 * This is the entry point of the incoming-request error flow (flow 1 in the class
+	 * docblock) when called with `$skip_wpcom_verification = false` (the default).
+	 *
+	 * Only error codes present in `$known_errors` are handled; anything else is
+	 * silently discarded. The `WP_Error` must carry the data shape produced by
+	 * `build_connection_error_data()`, or it is discarded as well.
+	 *
 	 * @param \WP_Error $error  The error object.
 	 * @param boolean   $force  Force the report, even if should_report_error is false.
-	 * @param boolean   $skip_wpcom_verification Set to 'true' to verify the error locally and skip the WP.com verification.
+	 * @param boolean   $skip_wpcom_verification Set to 'true' to verify the error locally and skip the WP.com
+	 *                  verification round-trip. Only do this when the error is self-evidencing — e.g. it came
+	 *                  from a response WP.com sent to a request this site initiated (the outgoing flow), or
+	 *                  from local connection state. Skipping verification for an incoming request error would
+	 *                  let any unauthenticated requester plant a verified error and trigger its workflows
+	 *                  (admin notices, self-healing), so leave it 'false' for anything derived from an
+	 *                  incoming request.
 	 *
 	 * @return void
 	 * @since 1.14.2
@@ -667,12 +751,15 @@ class Error_Handler {
 	 * by both internal error handling and external plugins/customizations.
 	 *
 	 * @since 1.14.2
+	 * @since $$next-version$$ Added the `$error_direction` parameter and output field.
 	 *
-	 * @param string $error_code    The error code identifier.
-	 * @param string $error_message The human-readable error message.
-	 * @param array  $error_data    Additional error data (optional).
-	 * @param string $user_id       The user ID associated with the error (optional).
-	 * @param string $error_type    The type of error (optional).
+	 * @param string $error_code      The error code identifier.
+	 * @param string $error_message   The human-readable error message.
+	 * @param array  $error_data      Additional error data (optional).
+	 * @param string $user_id         The user ID associated with the error (optional).
+	 * @param string $error_type      The type of error (optional). One of the `ERROR_TYPE_*` constants or ''.
+	 * @param string $error_direction The direction of the request that triggered the error (optional).
+	 *                                One of the `DIRECTION_*` constants or ''.
 	 * @return array|false The standardized error array or false on failure.
 	 *                     Example successful return:
 	 *                     [
@@ -682,10 +769,11 @@ class Error_Handler {
 	 *                       'error_data' => ['action' => 'reconnect'],
 	 *                       'timestamp' => 1234567890,
 	 *                       'nonce' => 'abc123def',
-	 *                       'error_type' => 'xmlrpc'
+	 *                       'error_type' => 'xmlrpc',
+	 *                       'error_direction' => 'incoming'
 	 *                     ]
 	 */
-	public function build_error_array( string $error_code, string $error_message, array $error_data = array(), $user_id = '0', string $error_type = '' ) {
+	public function build_error_array( string $error_code, string $error_message, array $error_data = array(), $user_id = '0', string $error_type = '', string $error_direction = '' ) {
 		// Validate required parameters
 		if ( empty( $error_code ) || empty( $error_message ) ) {
 			return false;
@@ -697,18 +785,90 @@ class Error_Handler {
 		}
 
 		return array(
-			'error_code'    => $error_code,
-			'user_id'       => $user_id,
-			'error_message' => $error_message,
-			'error_data'    => $error_data,
-			'timestamp'     => time(),
-			'nonce'         => wp_generate_password( 10, false ),
-			'error_type'    => $error_type,
+			'error_code'      => $error_code,
+			'user_id'         => $user_id,
+			'error_message'   => $error_message,
+			'error_data'      => $error_data,
+			'timestamp'       => time(),
+			'nonce'           => wp_generate_password( 10, false ),
+			'error_type'      => $error_type,
+			'error_direction' => $error_direction,
+		);
+	}
+
+	/**
+	 * Builds the standardized `WP_Error` data payload for a connection error.
+	 *
+	 * This is the single place the error-data contract consumed by `wp_error_to_array()`
+	 * is defined. Use it (or `build_connection_wp_error()`) instead of assembling the
+	 * data array by hand, so every reporter produces the same shape:
+	 *
+	 * - `signature_details` is guaranteed to contain a `token` key (empty string when
+	 *   the error is not tied to a specific token), which `wp_error_to_array()` requires.
+	 *   The token is also what WP.com checks when verifying incoming-flow errors, so its
+	 *   key and position in the payload must not change.
+	 * - `error_type` and `error_direction` are validated against the class constants and
+	 *   stored as '' when the given value is not recognized.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array  $signature_details Details of the signed request that failed: `token`,
+	 *                                  and typically `timestamp`, `nonce`, `body_hash`,
+	 *                                  `method`, `url`.
+	 * @param string $error_type        One of the `ERROR_TYPE_*` constants.
+	 * @param string $error_direction   One of the `DIRECTION_*` constants, or '' for
+	 *                                  errors with no direction ('connection' type).
+	 * @param array  $extra             Optional additional data, e.g. a `user_id` fallback for
+	 *                                  errors whose token cannot be attributed to a user, or
+	 *                                  `has_user_token` for `invalid_connection_owner`.
+	 * @return array The error data array to pass as the third argument of `WP_Error`.
+	 */
+	public static function build_connection_error_data( array $signature_details, string $error_type, string $error_direction, array $extra = array() ) {
+		$valid_types      = array( self::ERROR_TYPE_XMLRPC, self::ERROR_TYPE_REST, self::ERROR_TYPE_CONNECTION );
+		$valid_directions = array( self::DIRECTION_INCOMING, self::DIRECTION_OUTGOING );
+
+		return array_merge(
+			$extra,
+			array(
+				'signature_details' => array_merge( array( 'token' => '' ), $signature_details ),
+				'error_type'        => in_array( $error_type, $valid_types, true ) ? $error_type : '',
+				'error_direction'   => in_array( $error_direction, $valid_directions, true ) ? $error_direction : '',
+			)
+		);
+	}
+
+	/**
+	 * Builds a `WP_Error` carrying the standardized connection error data.
+	 *
+	 * Convenience wrapper around `build_connection_error_data()` — see it for the
+	 * data contract. All connection error reporters should create their `WP_Error`
+	 * objects through this factory.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $error_code        The error code, ideally one of `$known_errors`.
+	 * @param string $error_message     The human-readable error message.
+	 * @param array  $signature_details Details of the signed request that failed. See `build_connection_error_data()`.
+	 * @param string $error_type        One of the `ERROR_TYPE_*` constants.
+	 * @param string $error_direction   One of the `DIRECTION_*` constants, or '' for errors with no direction.
+	 * @param array  $extra             Optional additional data. See `build_connection_error_data()`.
+	 * @return \WP_Error
+	 */
+	public static function build_connection_wp_error( string $error_code, string $error_message, array $signature_details, string $error_type, string $error_direction, array $extra = array() ) {
+		return new \WP_Error(
+			$error_code,
+			$error_message,
+			self::build_connection_error_data( $signature_details, $error_type, $error_direction, $extra )
 		);
 	}
 
 	/**
 	 * Converts a WP_Error object in the array representation we store in the database
+	 *
+	 * The `WP_Error` data must follow the contract defined by `build_connection_error_data()`:
+	 * a `signature_details` array containing at least a `token` key is required, and this
+	 * method returns false without storing anything when it is absent. `error_type` and
+	 * `error_direction` are read from the data and stored as '' when missing.
 	 *
 	 * The user attribution comes from the token in `signature_details`, which identifies
 	 * the exact credential that failed. An explicit `user_id` in the error data is only
@@ -754,7 +914,8 @@ class Error_Handler {
 			$error->get_error_message(),
 			$error_data,
 			$user_id,
-			empty( $data['error_type'] ) ? '' : $data['error_type']
+			empty( $data['error_type'] ) ? '' : $data['error_type'],
+			empty( $data['error_direction'] ) ? '' : $data['error_direction']
 		);
 	}
 
@@ -925,6 +1086,10 @@ class Error_Handler {
 	/**
 	 * Delete all stored and verified API errors from the database, leave the non-API errors intact.
 	 *
+	 * Only 'xmlrpc' and 'rest' type errors are deleted. 'connection' type errors are
+	 * deliberately kept: they describe local connection state (e.g. a missing owner token),
+	 * which a successful API request does not disprove.
+	 *
 	 * @since 1.54.0
 	 *
 	 * @return void
@@ -933,7 +1098,7 @@ class Error_Handler {
 		$type_filter = function ( $errors ) {
 			if ( is_array( $errors ) ) {
 				foreach ( $errors as $key => $error ) {
-					if ( ! empty( $error['error_type'] ) && in_array( $error['error_type'], array( 'xmlrpc', 'rest' ), true ) ) {
+					if ( ! empty( $error['error_type'] ) && in_array( $error['error_type'], array( self::ERROR_TYPE_XMLRPC, self::ERROR_TYPE_REST ), true ) ) {
 						unset( $errors[ $key ] );
 					}
 				}
@@ -1155,14 +1320,25 @@ class Error_Handler {
 	}
 
 	/**
-	 * Check REST API response for errors, and report them to WP.com if needed.
+	 * Check an outgoing signed request's response for errors, and store them if needed.
+	 *
+	 * This is the entry point of the outgoing-request error flow (flow 2 in the class
+	 * docblock). `Client::remote_request()` calls it after every outgoing signed request.
+	 * Errors captured here are stored directly as verified — the WP.com verification
+	 * round-trip used for incoming errors is unnecessary, because the error arrived in a
+	 * response to a request this site itself initiated and signed.
+	 *
+	 * Note: XML-RPC faults arrive as HTTP 200 responses with an XML body, so they are
+	 * invisible to this method — only errors surfaced at the HTTP level with a JSON error
+	 * envelope are captured. This is one of the reasons outgoing calls are being migrated
+	 * from XML-RPC to REST.
 	 *
 	 * @see wp_remote_request() For more information on the $http_response array format.
 	 * @param array|\WP_Error $http_response The response or WP_Error on failure.
 	 * @param array           $auth_data Auth data, allowed keys: `token`, `timestamp`, `nonce`, `body-hash`.
 	 * @param string          $url Request URL.
 	 * @param string          $method Request method.
-	 * @param string          $error_type The source of an error: 'xmlrpc' or 'rest'.
+	 * @param string          $error_type The transport of the outgoing request: 'xmlrpc' or 'rest'.
 	 *
 	 * @return void
 	 */
@@ -1187,20 +1363,19 @@ class Error_Handler {
 			return;
 		}
 
-		$error = new \WP_Error(
-			$error_code,
+		$error = self::build_connection_wp_error(
+			(string) $error_code,
 			empty( $body['message'] ) ? '' : $body['message'],
 			array(
-				'signature_details' => array(
-					'token'     => empty( $auth_data['token'] ) ? '' : $auth_data['token'],
-					'timestamp' => empty( $auth_data['timestamp'] ) ? '' : $auth_data['timestamp'],
-					'nonce'     => empty( $auth_data['nonce'] ) ? '' : $auth_data['nonce'],
-					'body_hash' => empty( $auth_data['body_hash'] ) ? '' : $auth_data['body_hash'],
-					'method'    => $method,
-					'url'       => $url,
-				),
-				'error_type'        => in_array( $error_type, array( 'xmlrpc', 'rest' ), true ) ? $error_type : '',
-			)
+				'token'     => empty( $auth_data['token'] ) ? '' : $auth_data['token'],
+				'timestamp' => empty( $auth_data['timestamp'] ) ? '' : $auth_data['timestamp'],
+				'nonce'     => empty( $auth_data['nonce'] ) ? '' : $auth_data['nonce'],
+				'body_hash' => empty( $auth_data['body_hash'] ) ? '' : $auth_data['body_hash'],
+				'method'    => $method,
+				'url'       => $url,
+			),
+			$error_type,
+			self::DIRECTION_OUTGOING
 		);
 
 		$this->report_error( $error, false, true );

--- a/projects/packages/connection/src/class-error-handler.php
+++ b/projects/packages/connection/src/class-error-handler.php
@@ -38,10 +38,11 @@ namespace Automattic\Jetpack\Connection;
  * Stored errors carry two orthogonal classification fields:
  *
  * - `error_type` — the transport/source of the failed request: 'xmlrpc', 'rest',
- *   'connection' (local connection-state errors involving no request at all, e.g.
- *   `invalid_connection_owner`), or '' for entries stored by older package versions.
+ *   'local_state' (local connection-state errors involving no request at all, e.g.
+ *   `invalid_connection_owner`; stored as 'connection' by package versions <= 8.8),
+ *   or '' for entries stored by older package versions.
  * - `error_direction` — 'incoming', 'outgoing', or '' (legacy entries and
- *   'connection'-type errors, which have no direction).
+ *   'local_state'-type errors, which have no direction).
  *
  * Note on naming: both option names below contain "xmlrpc" because they predate REST
  * support. They are intentionally kept as-is to avoid a data migration and breaking
@@ -132,13 +133,16 @@ class Error_Handler {
 
 	/**
 	 * `error_type` value for local connection-state errors that involve no request,
-	 * e.g. `invalid_connection_owner`.
+	 * e.g. `invalid_connection_owner`. The evidence for these errors is the site's own
+	 * database, which is also why they carry no `error_direction`.
+	 *
+	 * Note: package versions <= 8.8 stored these errors with the type 'connection'.
 	 *
 	 * @since $$next-version$$
 	 *
 	 * @var string
 	 */
-	const ERROR_TYPE_CONNECTION = 'connection';
+	const ERROR_TYPE_LOCAL_STATE = 'local_state';
 
 	/**
 	 * `error_direction` value for errors triggered by incoming requests (WP.com to this site).
@@ -808,7 +812,9 @@ class Error_Handler {
 	 *   The token is also what WP.com checks when verifying incoming-flow errors, so its
 	 *   key and position in the payload must not change.
 	 * - `error_type` and `error_direction` are validated against the class constants and
-	 *   stored as '' when the given value is not recognized.
+	 *   stored as '' when the given value is not recognized. For 'local_state' errors the
+	 *   direction is always forced to '' — they describe the site's own database, not a
+	 *   request, so a direction would be meaningless and is ignored if passed.
 	 *
 	 * @since $$next-version$$
 	 *
@@ -816,23 +822,31 @@ class Error_Handler {
 	 *                                  and typically `timestamp`, `nonce`, `body_hash`,
 	 *                                  `method`, `url`.
 	 * @param string $error_type        One of the `ERROR_TYPE_*` constants.
-	 * @param string $error_direction   One of the `DIRECTION_*` constants, or '' for
-	 *                                  errors with no direction ('connection' type).
+	 * @param string $error_direction   One of the `DIRECTION_*` constants. Ignored for
+	 *                                  'local_state' errors, which have no direction.
 	 * @param array  $extra             Optional additional data, e.g. a `user_id` fallback for
 	 *                                  errors whose token cannot be attributed to a user, or
 	 *                                  `has_user_token` for `invalid_connection_owner`.
 	 * @return array The error data array to pass as the third argument of `WP_Error`.
 	 */
 	public static function build_connection_error_data( array $signature_details, string $error_type, string $error_direction, array $extra = array() ) {
-		$valid_types      = array( self::ERROR_TYPE_XMLRPC, self::ERROR_TYPE_REST, self::ERROR_TYPE_CONNECTION );
+		$valid_types      = array( self::ERROR_TYPE_XMLRPC, self::ERROR_TYPE_REST, self::ERROR_TYPE_LOCAL_STATE );
 		$valid_directions = array( self::DIRECTION_INCOMING, self::DIRECTION_OUTGOING );
+
+		$error_type = in_array( $error_type, $valid_types, true ) ? $error_type : '';
+
+		if ( self::ERROR_TYPE_LOCAL_STATE === $error_type ) {
+			$error_direction = '';
+		} else {
+			$error_direction = in_array( $error_direction, $valid_directions, true ) ? $error_direction : '';
+		}
 
 		return array_merge(
 			$extra,
 			array(
 				'signature_details' => array_merge( array( 'token' => '' ), $signature_details ),
-				'error_type'        => in_array( $error_type, $valid_types, true ) ? $error_type : '',
-				'error_direction'   => in_array( $error_direction, $valid_directions, true ) ? $error_direction : '',
+				'error_type'        => $error_type,
+				'error_direction'   => $error_direction,
 			)
 		);
 	}
@@ -1086,7 +1100,7 @@ class Error_Handler {
 	/**
 	 * Delete all stored and verified API errors from the database, leave the non-API errors intact.
 	 *
-	 * Only 'xmlrpc' and 'rest' type errors are deleted. 'connection' type errors are
+	 * Only 'xmlrpc' and 'rest' type errors are deleted. 'local_state' type errors are
 	 * deliberately kept: they describe local connection state (e.g. a missing owner token),
 	 * which a successful API request does not disprove.
 	 *

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -652,6 +652,18 @@ class Manager {
 		// XML-RPC label rather than guessing at a transport.
 		$is_rest = ! $is_xmlrpc && ( function_exists( 'wp_is_rest_endpoint' ) ? wp_is_rest_endpoint() : ( defined( 'REST_REQUEST' ) && REST_REQUEST ) );
 
+		// Signature verification can run before REST dispatch is set up: REST_Authentication
+		// hooks `determine_current_user`, which any plugin can trigger early (e.g. by calling
+		// wp_get_current_user() on plugins_loaded), before the REST_REQUEST constant exists.
+		// In that window, recognize REST requests by their URL: the REST prefix in the path,
+		// or the rest_route query argument used by sites without pretty permalinks.
+		if ( ! $is_xmlrpc && ! $is_rest ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Only used to classify the request transport.
+			$has_rest_route_arg = isset( $_GET['rest_route'] );
+			$request_path       = (string) wp_parse_url( isset( $_SERVER['REQUEST_URI'] ) ? wp_unslash( $_SERVER['REQUEST_URI'] ) : '', PHP_URL_PATH ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Parsed for path comparison only.
+			$is_rest            = $has_rest_route_arg || false !== strpos( $request_path, '/' . rest_get_url_prefix() . '/' );
+		}
+
 		return $is_rest ? Error_Handler::ERROR_TYPE_REST : Error_Handler::ERROR_TYPE_XMLRPC;
 	}
 

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -981,8 +981,8 @@ class Manager {
 					'invalid_connection_owner',
 					'Invalid connection owner',
 					array( 'token' => '' ),
-					Error_Handler::ERROR_TYPE_CONNECTION,
-					'', // Connection-state errors describe local state, not a request, so they have no direction.
+					Error_Handler::ERROR_TYPE_LOCAL_STATE,
+					'', // Local-state errors describe the site's database, not a request, so they have no direction.
 					array(
 						'user_id'        => $user_id,
 						'has_user_token' => (bool) $user_token,

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -477,7 +477,12 @@ class Manager {
 			'signature' => isset( $_GET['signature'] ) ? wp_unslash( $_GET['signature'] ) : '',
 		);
 
-		$error_type = 'xmlrpc';
+		// Transport of the incoming request being verified. This signature-verification path
+		// serves both XML-RPC requests and signed REST requests (REST_Authentication funnels
+		// REST authentication into verify_xml_rpc_signature()), so the stored error type is
+		// derived from the actual request context rather than hardcoded.
+		$error_type      = $this->get_current_request_transport();
+		$error_direction = Error_Handler::DIRECTION_INCOMING;
 
 		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 		@list( $token_key, $version, $user_id ) = explode( ':', wp_unslash( $_GET['token'] ) );
@@ -490,7 +495,7 @@ class Manager {
 				|| empty( $version )
 				|| (string) $jetpack_api_version !== $version
 		) {
-			return new \WP_Error( 'malformed_token', 'Malformed token in request', compact( 'signature_details', 'error_type' ) );
+			return new \WP_Error( 'malformed_token', 'Malformed token in request', Error_Handler::build_connection_error_data( $signature_details, $error_type, $error_direction ) );
 		}
 
 		if ( '0' === $user_id ) {
@@ -502,7 +507,7 @@ class Manager {
 				return new \WP_Error(
 					'malformed_user_id',
 					'Malformed user_id in request',
-					compact( 'signature_details', 'error_type' )
+					Error_Handler::build_connection_error_data( $signature_details, $error_type, $error_direction )
 				);
 			}
 			$user_id = (int) $user_id;
@@ -512,20 +517,20 @@ class Manager {
 				return new \WP_Error(
 					'unknown_user',
 					sprintf( 'User %d does not exist', $user_id ),
-					compact( 'signature_details', 'error_type' )
+					Error_Handler::build_connection_error_data( $signature_details, $error_type, $error_direction )
 				);
 			}
 		}
 
 		$token = $this->get_tokens()->get_access_token( $user_id, $token_key, false );
 		if ( is_wp_error( $token ) ) {
-			$token->add_data( compact( 'signature_details', 'error_type' ) );
+			$token->add_data( Error_Handler::build_connection_error_data( $signature_details, $error_type, $error_direction ) );
 			return $token;
 		} elseif ( ! $token ) {
 			return new \WP_Error(
 				'unknown_token',
 				sprintf( 'Token %s:%s:%d does not exist', $token_key, $version, $user_id ),
-				compact( 'signature_details', 'error_type' )
+				Error_Handler::build_connection_error_data( $signature_details, $error_type, $error_direction )
 			);
 		}
 
@@ -567,9 +572,17 @@ class Manager {
 			return new \WP_Error(
 				'could_not_sign',
 				'Unknown signature error',
-				compact( 'signature_details', 'error_type' )
+				Error_Handler::build_connection_error_data( $signature_details, $error_type, $error_direction )
 			);
 		} elseif ( is_wp_error( $signature ) ) {
+			// Jetpack_Signature errors carry their own signature_details (or, for some codes,
+			// no data at all) but never a type or direction; normalize them into the standard
+			// error data shape so Error_Handler can attribute and store them.
+			$signature_error_data = $signature->get_error_data();
+			if ( isset( $signature_error_data['signature_details'] ) && is_array( $signature_error_data['signature_details'] ) ) {
+				$signature_details = array_merge( $signature_details, $signature_error_data['signature_details'] );
+			}
+			$signature->add_data( Error_Handler::build_connection_error_data( $signature_details, $error_type, $error_direction ) );
 			return $signature;
 		}
 
@@ -583,7 +596,7 @@ class Manager {
 			return new \WP_Error(
 				'invalid_nonce',
 				'Could not add nonce',
-				compact( 'signature_details', 'error_type' )
+				Error_Handler::build_connection_error_data( $signature_details, $error_type, $error_direction )
 			);
 		}
 
@@ -597,7 +610,7 @@ class Manager {
 			return new \WP_Error(
 				'signature_mismatch',
 				'Signature mismatch',
-				compact( 'signature_details', 'error_type' )
+				Error_Handler::build_connection_error_data( $signature_details, $error_type, $error_direction )
 			);
 		}
 
@@ -620,6 +633,31 @@ class Manager {
 			$token,
 			$this->raw_post_data
 		);
+	}
+
+	/**
+	 * Determines the transport of the incoming request currently being verified.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return string Error_Handler::ERROR_TYPE_XMLRPC or Error_Handler::ERROR_TYPE_REST.
+	 */
+	private function get_current_request_transport() {
+		if ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) {
+			return Error_Handler::ERROR_TYPE_XMLRPC;
+		}
+
+		$is_rest = function_exists( 'wp_is_rest_endpoint' )
+			? wp_is_rest_endpoint()
+			: ( defined( 'REST_REQUEST' ) && REST_REQUEST );
+
+		if ( $is_rest ) {
+			return Error_Handler::ERROR_TYPE_REST;
+		}
+
+		// Signed requests can also arrive outside the XML-RPC and REST endpoints (e.g. the
+		// alternate XML-RPC endpoint). Keep the historic label for those.
+		return Error_Handler::ERROR_TYPE_XMLRPC;
 	}
 
 	/**
@@ -939,16 +977,15 @@ class Manager {
 
 		if ( $connection_owner === false ) {
 			Error_Handler::get_instance()->report_error(
-				new WP_Error(
+				Error_Handler::build_connection_wp_error(
 					'invalid_connection_owner',
 					'Invalid connection owner',
+					array( 'token' => '' ),
+					Error_Handler::ERROR_TYPE_CONNECTION,
+					'', // Connection-state errors describe local state, not a request, so they have no direction.
 					array(
-						'user_id'           => $user_id,
-						'has_user_token'    => (bool) $user_token,
-						'error_type'        => 'connection',
-						'signature_details' => array(
-							'token' => '',
-						),
+						'user_id'        => $user_id,
+						'has_user_token' => (bool) $user_token,
 					)
 				),
 				false,

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -643,21 +643,16 @@ class Manager {
 	 * @return string Error_Handler::ERROR_TYPE_XMLRPC or Error_Handler::ERROR_TYPE_REST.
 	 */
 	private function get_current_request_transport() {
-		if ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) {
-			return Error_Handler::ERROR_TYPE_XMLRPC;
-		}
+		$is_xmlrpc = defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST;
 
-		$is_rest = function_exists( 'wp_is_rest_endpoint' )
-			? wp_is_rest_endpoint()
-			: ( defined( 'REST_REQUEST' ) && REST_REQUEST );
+		// XMLRPC_REQUEST covers both /xmlrpc.php and the alternate XML-RPC endpoint, which
+		// defines the constant itself (see setup_xmlrpc_handlers). Outside those, signed REST
+		// requests are detected via the REST dispatch state. Anything else (e.g. signed
+		// requests verified on the 'authenticate' filter for regular URLs) keeps the historic
+		// XML-RPC label rather than guessing at a transport.
+		$is_rest = ! $is_xmlrpc && ( function_exists( 'wp_is_rest_endpoint' ) ? wp_is_rest_endpoint() : ( defined( 'REST_REQUEST' ) && REST_REQUEST ) );
 
-		if ( $is_rest ) {
-			return Error_Handler::ERROR_TYPE_REST;
-		}
-
-		// Signed requests can also arrive outside the XML-RPC and REST endpoints (e.g. the
-		// alternate XML-RPC endpoint). Keep the historic label for those.
-		return Error_Handler::ERROR_TYPE_XMLRPC;
+		return $is_rest ? Error_Handler::ERROR_TYPE_REST : Error_Handler::ERROR_TYPE_XMLRPC;
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/Error_Handler_Test.php
+++ b/projects/packages/connection/tests/php/Error_Handler_Test.php
@@ -61,8 +61,10 @@ class Error_Handler_Test extends BaseTestCase {
 	 *
 	 * @param string $error_code The error code you want the error to have.
 	 * @param string $user_id The user id you want the token to have.
-	 * @param string $error_type The error type: 'xmlrpc' or 'rest'.
-	 * @param string $error_direction The error direction: 'incoming' or 'outgoing'.
+	 * @param string $error_type The error type: one of the Error_Handler::ERROR_TYPE_* constants
+	 *                           ('xmlrpc', 'rest', or 'local_state').
+	 * @param string $error_direction The error direction: 'incoming' or 'outgoing'. Ignored for
+	 *                                'local_state' errors, which the factory stores without a direction.
 	 *
 	 * @return \WP_Error
 	 */

--- a/projects/packages/connection/tests/php/Error_Handler_Test.php
+++ b/projects/packages/connection/tests/php/Error_Handler_Test.php
@@ -121,7 +121,7 @@ class Error_Handler_Test extends BaseTestCase {
 
 		$error  = $this->get_sample_error( 'invalid_token', 1, 'xmlrpc' );
 		$error2 = $this->get_sample_error( 'unknown_user', 1, 'rest' );
-		$error3 = $this->get_sample_error( 'invalid_connection_owner', 'invalid', 'connection' );
+		$error3 = $this->get_sample_error( 'invalid_connection_owner', 'invalid', Error_Handler::ERROR_TYPE_LOCAL_STATE );
 
 		$this->error_handler->report_error( $error );
 		$this->error_handler->report_error( $error2 );
@@ -466,7 +466,7 @@ class Error_Handler_Test extends BaseTestCase {
 
 		$error  = $this->get_sample_error( 'invalid_token', 1, 'xmlrpc' );
 		$error2 = $this->get_sample_error( 'unknown_user', 1, 'rest' );
-		$error3 = $this->get_sample_error( 'invalid_connection_owner', 'invalid', 'connection' );
+		$error3 = $this->get_sample_error( 'invalid_connection_owner', 'invalid', Error_Handler::ERROR_TYPE_LOCAL_STATE );
 
 		$this->error_handler->report_error( $error );
 		$this->error_handler->report_error( $error2 );
@@ -547,7 +547,7 @@ class Error_Handler_Test extends BaseTestCase {
 			array(
 				'user_id'           => 42,
 				'has_user_token'    => false,
-				'error_type'        => 'connection',
+				'error_type'        => Error_Handler::ERROR_TYPE_LOCAL_STATE,
 				'signature_details' => array( 'token' => '' ),
 			)
 		);
@@ -1205,6 +1205,21 @@ class Error_Handler_Test extends BaseTestCase {
 		$this->assertSame( '', $result['error_type'], 'An unrecognized error_type must be stored as an empty string, and extra data must not override it.' );
 		$this->assertSame( '', $result['error_direction'], 'An unrecognized error_direction must be stored as an empty string, and extra data must not override it.' );
 		$this->assertSame( 'abc:1:2', $result['signature_details']['token'] );
+	}
+
+	/**
+	 * Test that local-state errors never carry a direction, even if a caller passes one:
+	 * they describe the site's own database, not a request.
+	 */
+	public function test_build_connection_error_data_forces_empty_direction_for_local_state() {
+		$result = Error_Handler::build_connection_error_data(
+			array( 'token' => '' ),
+			Error_Handler::ERROR_TYPE_LOCAL_STATE,
+			Error_Handler::DIRECTION_INCOMING
+		);
+
+		$this->assertSame( 'local_state', $result['error_type'] );
+		$this->assertSame( '', $result['error_direction'], 'A direction passed for a local_state error must be discarded.' );
 	}
 
 	/**
@@ -2098,16 +2113,15 @@ class Error_Handler_Test extends BaseTestCase {
 		// Report the error exactly the way Manager::get_connection_owner() does:
 		// empty token, explicit user_id in the error data, locally verified.
 		$this->error_handler->report_error(
-			new \WP_Error(
+			Error_Handler::build_connection_wp_error(
 				'invalid_connection_owner',
 				'Invalid connection owner',
+				array( 'token' => '' ),
+				Error_Handler::ERROR_TYPE_LOCAL_STATE,
+				'',
 				array(
-					'user_id'           => $owner_id,
-					'has_user_token'    => false,
-					'error_type'        => 'connection',
-					'signature_details' => array(
-						'token' => '',
-					),
+					'user_id'        => $owner_id,
+					'has_user_token' => false,
 				)
 			),
 			false,
@@ -2190,7 +2204,7 @@ class Error_Handler_Test extends BaseTestCase {
 			'error_data'    => array( 'token' => '' ),
 			'timestamp'     => time(),
 			'nonce'         => 'nonce_invalid_owner',
-			'error_type'    => 'connection',
+			'error_type'    => 'connection', // The legacy type value stored by package versions <= 8.8, deliberately kept.
 		);
 		update_option( Error_Handler::STORED_VERIFIED_ERRORS_OPTION, array( 'invalid_connection_owner' => array( 'invalid' => $error ) ) );
 

--- a/projects/packages/connection/tests/php/Error_Handler_Test.php
+++ b/projects/packages/connection/tests/php/Error_Handler_Test.php
@@ -62,10 +62,11 @@ class Error_Handler_Test extends BaseTestCase {
 	 * @param string $error_code The error code you want the error to have.
 	 * @param string $user_id The user id you want the token to have.
 	 * @param string $error_type The error type: 'xmlrpc' or 'rest'.
+	 * @param string $error_direction The error direction: 'incoming' or 'outgoing'.
 	 *
 	 * @return \WP_Error
 	 */
-	public function get_sample_error( $error_code, $user_id, $error_type = 'xmlrpc' ) {
+	public function get_sample_error( $error_code, $user_id, $error_type = 'xmlrpc', $error_direction = 'incoming' ) {
 
 		$signature_details = array(
 			'token'     => 'dhj938djh938d:1:' . $user_id,
@@ -77,10 +78,12 @@ class Error_Handler_Test extends BaseTestCase {
 			'signature' => 'sdf234fe',
 		);
 
-		return new \WP_Error(
+		return Error_Handler::build_connection_wp_error(
 			$error_code,
 			'An error was triggered',
-			compact( 'signature_details', 'error_type' )
+			$signature_details,
+			$error_type,
+			$error_direction
 		);
 	}
 
@@ -104,6 +107,7 @@ class Error_Handler_Test extends BaseTestCase {
 		$error_data = $stored_errors['invalid_token']['1'];
 		$this->assertEquals( 'invalid_token', $error_data['error_code'] );
 		$this->assertEquals( 'xmlrpc', $error_data['error_type'] );
+		$this->assertEquals( 'incoming', $error_data['error_direction'] );
 		$this->assertArrayHasKey( 'nonce', $error_data );
 		$this->assertArrayHasKey( 'timestamp', $error_data );
 	}
@@ -297,7 +301,13 @@ class Error_Handler_Test extends BaseTestCase {
 		$encrypted = $this->error_handler->encrypt_data_to_wpcom( $stored_errors['unknown_user']['3'] );
 
 		$this->assertIsString( $encrypted );
-		$this->assertEquals( 500, strlen( $encrypted ) );
+
+		// The sealed box is the JSON payload plus a constant sodium overhead. Deriving the
+		// expected length keeps this from breaking every time a field is added to the payload.
+		$decoded = base64_decode( $encrypted, true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+		$this->assertNotFalse( $decoded );
+		$expected_length = strlen( (string) wp_json_encode( $stored_errors['unknown_user']['3'], JSON_UNESCAPED_SLASHES ) ) + SODIUM_CRYPTO_BOX_SEALBYTES;
+		$this->assertSame( $expected_length, strlen( $decoded ) );
 	}
 
 	/**
@@ -360,6 +370,7 @@ class Error_Handler_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 'error_code', $stored_errors['unknown_token']['0'] );
 		$this->assertArrayHasKey( 'error_type', $stored_errors['unknown_token']['0'] );
 		$this->assertEquals( 'rest', $stored_errors['unknown_token']['0']['error_type'] );
+		$this->assertEquals( 'outgoing', $stored_errors['unknown_token']['0']['error_direction'] );
 
 		$this->assertCount( 1, $verified_errors );
 		$this->assertArrayHasKey( 'unknown_token', $verified_errors );
@@ -367,6 +378,7 @@ class Error_Handler_Test extends BaseTestCase {
 		$this->assertArrayHasKey( 0, $verified_errors['unknown_token'] );
 		$this->assertArrayHasKey( 'error_code', $verified_errors['unknown_token']['0'] );
 		$this->assertEquals( 'rest', $verified_errors['unknown_token']['0']['error_type'] );
+		$this->assertEquals( 'outgoing', $verified_errors['unknown_token']['0']['error_direction'] );
 	}
 
 	/**
@@ -1152,6 +1164,122 @@ class Error_Handler_Test extends BaseTestCase {
 		$this->assertEquals( $error_code, $result['error_code'] );
 		$this->assertEquals( $error_message, $result['error_message'] );
 		$this->assertSame( '0', $result['user_id'] );
+		$this->assertSame( '', $result['error_type'] );
+		$this->assertSame( '', $result['error_direction'] );
+	}
+
+	/**
+	 * Test that build_connection_error_data produces the standardized data shape.
+	 */
+	public function test_build_connection_error_data() {
+		$result = Error_Handler::build_connection_error_data(
+			array( 'timestamp' => 123 ),
+			Error_Handler::ERROR_TYPE_REST,
+			Error_Handler::DIRECTION_OUTGOING,
+			array( 'user_id' => 42 )
+		);
+
+		// A token key is always guaranteed, even when the caller did not provide one.
+		$this->assertSame( '', $result['signature_details']['token'] );
+		$this->assertSame( 123, $result['signature_details']['timestamp'] );
+		$this->assertSame( 'rest', $result['error_type'] );
+		$this->assertSame( 'outgoing', $result['error_direction'] );
+		$this->assertSame( 42, $result['user_id'] );
+	}
+
+	/**
+	 * Test that build_connection_error_data replaces unrecognized type/direction values
+	 * with an empty string, and that extra data cannot override the reserved keys.
+	 */
+	public function test_build_connection_error_data_validates_values() {
+		$result = Error_Handler::build_connection_error_data(
+			array( 'token' => 'abc:1:2' ),
+			'carrier-pigeon',
+			'sideways',
+			array(
+				'error_type'      => 'rest',
+				'error_direction' => 'incoming',
+			)
+		);
+
+		$this->assertSame( '', $result['error_type'], 'An unrecognized error_type must be stored as an empty string, and extra data must not override it.' );
+		$this->assertSame( '', $result['error_direction'], 'An unrecognized error_direction must be stored as an empty string, and extra data must not override it.' );
+		$this->assertSame( 'abc:1:2', $result['signature_details']['token'] );
+	}
+
+	/**
+	 * Test that a WP_Error built by build_connection_wp_error round-trips through
+	 * wp_error_to_array with its type and direction intact.
+	 */
+	public function test_build_connection_wp_error_round_trip() {
+		$error = Error_Handler::build_connection_wp_error(
+			'invalid_token',
+			'The token is invalid',
+			array( 'token' => 'dhj938djh938d:1:7' ),
+			Error_Handler::ERROR_TYPE_XMLRPC,
+			Error_Handler::DIRECTION_INCOMING
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $error );
+
+		$result = $this->error_handler->wp_error_to_array( $error );
+
+		$this->assertSame( 'invalid_token', $result['error_code'] );
+		$this->assertSame( '7', $result['user_id'] );
+		$this->assertSame( 'xmlrpc', $result['error_type'] );
+		$this->assertSame( 'incoming', $result['error_direction'] );
+	}
+
+	/**
+	 * Test that errors reported the pre-error_direction way (no direction in the WP_Error
+	 * data) are still stored, with an empty error_direction.
+	 */
+	public function test_report_error_without_direction_is_stored_with_empty_direction() {
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+
+		$error = new \WP_Error(
+			'invalid_token',
+			'An error was triggered',
+			array(
+				'signature_details' => array( 'token' => 'dhj938djh938d:1:1' ),
+				'error_type'        => 'xmlrpc',
+			)
+		);
+
+		$this->error_handler->report_error( $error );
+
+		$stored_errors = $this->error_handler->get_stored_errors();
+
+		$this->assertArrayHasKey( 'invalid_token', $stored_errors );
+		$this->assertSame( 'xmlrpc', $stored_errors['invalid_token']['1']['error_type'] );
+		$this->assertSame( '', $stored_errors['invalid_token']['1']['error_direction'] );
+	}
+
+	/**
+	 * Test that stored entries written by older package versions (no error_direction key
+	 * at all) are still read and deleted correctly.
+	 */
+	public function test_legacy_stored_errors_without_direction_key() {
+		$legacy_error = array(
+			'error_code'    => 'invalid_token',
+			'user_id'       => '1',
+			'error_message' => 'Legacy error',
+			'error_data'    => array(),
+			'timestamp'     => time(),
+			'nonce'         => 'legacy_nonce',
+			'error_type'    => 'xmlrpc',
+		);
+
+		update_option( Error_Handler::STORED_ERRORS_OPTION, array( 'invalid_token' => array( '1' => $legacy_error ) ) );
+		update_option( Error_Handler::STORED_VERIFIED_ERRORS_OPTION, array( 'invalid_token' => array( '1' => $legacy_error ) ) );
+
+		$this->assertArrayHasKey( 'invalid_token', $this->error_handler->get_stored_errors() );
+		$this->assertArrayHasKey( 'invalid_token', $this->error_handler->get_displayable_errors() );
+
+		$this->error_handler->delete_all_api_errors();
+
+		$this->assertEmpty( $this->error_handler->get_stored_errors() );
+		$this->assertEmpty( $this->error_handler->get_verified_errors() );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/ManagerIntegrationTest.php
+++ b/projects/packages/connection/tests/php/ManagerIntegrationTest.php
@@ -901,6 +901,11 @@ class ManagerIntegrationTest extends \WorDBless\BaseTestCase {
 	 * `invalid_signature` WP_Error carrying its own signature_details but no type/direction.
 	 */
 	public function test_verify_xml_rpc_signature_normalizes_signature_errors() {
+		// Snapshot the superglobals: the test environment pre-populates some $_SERVER keys
+		// (e.g. HTTP_HOST) that later tests rely on, so they must be restored, not unset.
+		$original_server = $_SERVER;
+		$original_get    = $_GET;
+
 		Constants::set_constant( 'JETPACK__API_VERSION', 1 );
 		\Jetpack_Options::update_option( 'blog_token', 'blogkey.blogsecret' );
 		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
@@ -918,8 +923,8 @@ class ManagerIntegrationTest extends \WorDBless\BaseTestCase {
 		$stored_errors = Error_Handler::get_instance()->get_stored_errors();
 
 		// Clean up before asserting, so a failed assertion cannot leak state into other tests.
-		unset( $_GET['token'], $_GET['signature'], $_GET['timestamp'], $_GET['nonce'] );
-		unset( $_SERVER['REQUEST_METHOD'], $_SERVER['HTTP_HOST'], $_SERVER['REQUEST_URI'] );
+		$_SERVER = $original_server;
+		$_GET    = $original_get;
 		remove_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
 		Error_Handler::get_instance()->delete_all_errors();
 		\Jetpack_Options::delete_option( 'blog_token' );

--- a/projects/packages/connection/tests/php/ManagerIntegrationTest.php
+++ b/projects/packages/connection/tests/php/ManagerIntegrationTest.php
@@ -942,6 +942,49 @@ class ManagerIntegrationTest extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Test that a `Jetpack_Signature` error carrying NO error data at all is normalized and
+	 * stored. A blog token with an empty secret chunk passes token retrieval but makes
+	 * `Jetpack_Signature::sign_request()` return `invalid_secret` with no data — before the
+	 * normalization, such errors were silently unstorable by `wp_error_to_array()`.
+	 */
+	public function test_verify_xml_rpc_signature_stores_dataless_signature_errors() {
+		$original_server = $_SERVER;
+		$original_get    = $_GET;
+
+		Constants::set_constant( 'JETPACK__API_VERSION', 1 );
+		\Jetpack_Options::update_option( 'blog_token', 'blogkey.' );
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+
+		$_GET['token']     = 'blogkey:1:0';
+		$_GET['signature'] = 'irrelevant';
+		$_GET['timestamp'] = (string) time();
+		$_GET['nonce']     = 'testnonce2';
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$_SERVER['HTTP_HOST']      = 'example.org';
+		$_SERVER['REQUEST_URI']    = '/';
+
+		$result        = $this->manager->verify_xml_rpc_signature();
+		$stored_errors = Error_Handler::get_instance()->get_stored_errors();
+
+		// Clean up before asserting, so a failed assertion cannot leak state into other tests.
+		$_SERVER = $original_server;
+		$_GET    = $original_get;
+		remove_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+		Error_Handler::get_instance()->delete_all_errors();
+		\Jetpack_Options::delete_option( 'blog_token' );
+
+		$this->assertFalse( $result );
+		$this->assertArrayHasKey( 'invalid_secret', $stored_errors );
+		$error = $stored_errors['invalid_secret']['0'];
+		$this->assertSame( Error_Handler::ERROR_TYPE_XMLRPC, $error['error_type'] );
+		$this->assertSame( Error_Handler::DIRECTION_INCOMING, $error['error_direction'] );
+		// With no signature_details of its own, the error is attributed via the
+		// Manager-built details from the request superglobals.
+		$this->assertSame( 'blogkey:1:0', $error['error_data']['token'] );
+	}
+
+	/**
 	 * Data provider for test_remote_request_labels_outgoing_errors.
 	 *
 	 * @return array

--- a/projects/packages/connection/tests/php/ManagerIntegrationTest.php
+++ b/projects/packages/connection/tests/php/ManagerIntegrationTest.php
@@ -823,6 +823,96 @@ class ManagerIntegrationTest extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Test that the transport of the incoming request being verified defaults to XML-RPC
+	 * and is detected as REST for REST endpoint requests.
+	 */
+	public function test_get_current_request_transport() {
+		$reflection = new \ReflectionClass( $this->manager );
+		$method     = $reflection->getMethod( 'get_current_request_transport' );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		$default_transport = $method->invoke( $this->manager );
+
+		// Simulate a REST API request. In a real REST request the REST_REQUEST constant
+		// is set instead; the filter is the only way to toggle the state in-process.
+		add_filter( 'wp_is_rest_endpoint', '__return_true' );
+		$rest_transport = $method->invoke( $this->manager );
+		remove_filter( 'wp_is_rest_endpoint', '__return_true' );
+
+		$this->assertSame( Error_Handler::ERROR_TYPE_XMLRPC, $default_transport );
+		$this->assertSame( Error_Handler::ERROR_TYPE_REST, $rest_transport );
+	}
+
+	/**
+	 * Test that errors from outgoing requests through `Client::remote_request()` are stored
+	 * with the transport derived from the target endpoint and the 'outgoing' direction.
+	 *
+	 * @dataProvider outgoing_request_transport_provider
+	 *
+	 * @param string $url                The request URL.
+	 * @param string $expected_type      The expected stored error_type.
+	 */
+	#[DataProvider( 'outgoing_request_transport_provider' )]
+	public function test_remote_request_labels_outgoing_errors( $url, $expected_type ) {
+		$this->set_up_connected_user();
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+
+		$error_response = function () {
+			return array(
+				'body'     => '{"error":"unknown_token","message":"It looks like your Jetpack connection is broken."}',
+				'response' => array(
+					'code'    => 403,
+					'message' => 'Forbidden',
+				),
+				'headers'  => array(),
+			);
+		};
+		add_filter( 'pre_http_request', $error_response );
+
+		Client::remote_request(
+			array(
+				'url'     => $url,
+				'method'  => 'POST',
+				'user_id' => 0,
+			),
+			'request-body'
+		);
+
+		$verified_errors = Error_Handler::get_instance()->get_verified_errors();
+
+		// Clean up before asserting, so a failed assertion cannot leak state into other tests.
+		remove_filter( 'pre_http_request', $error_response );
+		remove_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+		Error_Handler::get_instance()->delete_all_errors();
+
+		$this->assertArrayHasKey( 'unknown_token', $verified_errors );
+		$error = reset( $verified_errors['unknown_token'] );
+		$this->assertSame( $expected_type, $error['error_type'] );
+		$this->assertSame( Error_Handler::DIRECTION_OUTGOING, $error['error_direction'] );
+	}
+
+	/**
+	 * Data provider for test_remote_request_labels_outgoing_errors.
+	 *
+	 * @return array
+	 */
+	public static function outgoing_request_transport_provider() {
+		return array(
+			'xmlrpc endpoint' => array(
+				'https://jetpack.wordpress.com/xmlrpc.php',
+				Error_Handler::ERROR_TYPE_XMLRPC,
+			),
+			'rest endpoint'   => array(
+				'https://public-api.wordpress.com/wpcom/v2/sites/1234/jetpack-wpcom-user-data',
+				Error_Handler::ERROR_TYPE_REST,
+			),
+		);
+	}
+
+	/**
 	 * Set up a connected blog and user so a signed request can be built as $user_id.
 	 *
 	 * @param int $user_id The local user id to connect.

--- a/projects/packages/connection/tests/php/ManagerIntegrationTest.php
+++ b/projects/packages/connection/tests/php/ManagerIntegrationTest.php
@@ -836,14 +836,30 @@ class ManagerIntegrationTest extends \WorDBless\BaseTestCase {
 
 		$default_transport = $method->invoke( $this->manager );
 
-		// Simulate a REST API request. In a real REST request the REST_REQUEST constant
-		// is set instead; the filter is the only way to toggle the state in-process.
+		// Simulate a dispatched REST API request. In a real REST request the REST_REQUEST
+		// constant is set instead; the filter is the only way to toggle the state in-process.
 		add_filter( 'wp_is_rest_endpoint', '__return_true' );
 		$rest_transport = $method->invoke( $this->manager );
 		remove_filter( 'wp_is_rest_endpoint', '__return_true' );
 
+		// Before REST dispatch (e.g. signature verification triggered by an early
+		// determine_current_user call), REST requests are recognized by their URL.
+		$original_server        = $_SERVER;
+		$original_get           = $_GET;
+		$_SERVER['REQUEST_URI'] = '/wp-json/jetpack/v4/connection/status?token=abc';
+		$early_rest_transport   = $method->invoke( $this->manager );
+
+		$_SERVER['REQUEST_URI']          = '/index.php';
+		$_GET['rest_route']              = '/jetpack/v4/connection/status';
+		$plain_permalinks_rest_transport = $method->invoke( $this->manager );
+
+		$_SERVER = $original_server;
+		$_GET    = $original_get;
+
 		$this->assertSame( Error_Handler::ERROR_TYPE_XMLRPC, $default_transport );
 		$this->assertSame( Error_Handler::ERROR_TYPE_REST, $rest_transport );
+		$this->assertSame( Error_Handler::ERROR_TYPE_REST, $early_rest_transport, 'A REST-prefixed request path must be labeled rest even before REST dispatch state exists.' );
+		$this->assertSame( Error_Handler::ERROR_TYPE_REST, $plain_permalinks_rest_transport, 'A rest_route query argument must be labeled rest even before REST dispatch state exists.' );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/ManagerIntegrationTest.php
+++ b/projects/packages/connection/tests/php/ManagerIntegrationTest.php
@@ -895,6 +895,48 @@ class ManagerIntegrationTest extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Test that a `Jetpack_Signature` error surfaced during incoming signature verification
+	 * is normalized into the standard error data shape and stored with the incoming
+	 * direction. Uses a stale timestamp, which makes `sign_current_request()` return an
+	 * `invalid_signature` WP_Error carrying its own signature_details but no type/direction.
+	 */
+	public function test_verify_xml_rpc_signature_normalizes_signature_errors() {
+		Constants::set_constant( 'JETPACK__API_VERSION', 1 );
+		\Jetpack_Options::update_option( 'blog_token', 'blogkey.blogsecret' );
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+
+		$_GET['token']     = 'blogkey:1:0';
+		$_GET['signature'] = 'irrelevant';
+		$_GET['timestamp'] = (string) ( time() - DAY_IN_SECONDS );
+		$_GET['nonce']     = 'testnonce1';
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$_SERVER['HTTP_HOST']      = 'example.org';
+		$_SERVER['REQUEST_URI']    = '/';
+
+		$result        = $this->manager->verify_xml_rpc_signature();
+		$stored_errors = Error_Handler::get_instance()->get_stored_errors();
+
+		// Clean up before asserting, so a failed assertion cannot leak state into other tests.
+		unset( $_GET['token'], $_GET['signature'], $_GET['timestamp'], $_GET['nonce'] );
+		unset( $_SERVER['REQUEST_METHOD'], $_SERVER['HTTP_HOST'], $_SERVER['REQUEST_URI'] );
+		remove_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+		Error_Handler::get_instance()->delete_all_errors();
+		\Jetpack_Options::delete_option( 'blog_token' );
+
+		$this->assertFalse( $result );
+		$this->assertArrayHasKey( 'invalid_signature', $stored_errors );
+		$error = $stored_errors['invalid_signature']['0'];
+		$this->assertSame( Error_Handler::ERROR_TYPE_XMLRPC, $error['error_type'] );
+		$this->assertSame( Error_Handler::DIRECTION_INCOMING, $error['error_direction'] );
+		$this->assertSame( 'blogkey:1:0', $error['error_data']['token'] );
+		// The URL normalized by Jetpack_Signature (scheme://host:port form, port empty for
+		// defaults) must win the merge, proving the signature error's own signature_details
+		// were preserved over the Manager-built ones.
+		$this->assertSame( 'http://example.org:/', $error['error_data']['url'] );
+	}
+
+	/**
 	 * Data provider for test_remote_request_labels_outgoing_errors.
 	 *
 	 * @return array

--- a/projects/plugins/debug-helper/changelog/update-connection-standardize-error-structure
+++ b/projects/plugins/debug-helper/changelog/update-connection-standardize-error-structure
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Broken Token: Use the connection error factory when generating sample connection errors.

--- a/projects/plugins/debug-helper/modules/inc/class-broken-token-connection-errors.php
+++ b/projects/plugins/debug-helper/modules/inc/class-broken-token-connection-errors.php
@@ -288,8 +288,10 @@ class Broken_Token_Connection_Errors {
 	 *
 	 * @param string $error_code The error code you want the error to have.
 	 * @param string $user_id The user id you want the token to have.
-	 * @param string $error_type The error type: 'xmlrpc' or 'rest'.
-	 * @param string $error_direction The error direction: 'incoming' or 'outgoing'.
+	 * @param string $error_type The error type: one of the Error_Handler::ERROR_TYPE_* constants
+	 *                           ('xmlrpc', 'rest', or 'local_state').
+	 * @param string $error_direction The error direction: 'incoming' or 'outgoing'. Ignored for
+	 *                                'local_state' errors, which the factory stores without a direction.
 	 *
 	 * @return \WP_Error
 	 */

--- a/projects/plugins/debug-helper/modules/inc/class-broken-token-connection-errors.php
+++ b/projects/plugins/debug-helper/modules/inc/class-broken-token-connection-errors.php
@@ -289,10 +289,11 @@ class Broken_Token_Connection_Errors {
 	 * @param string $error_code The error code you want the error to have.
 	 * @param string $user_id The user id you want the token to have.
 	 * @param string $error_type The error type: 'xmlrpc' or 'rest'.
+	 * @param string $error_direction The error direction: 'incoming' or 'outgoing'.
 	 *
 	 * @return \WP_Error
 	 */
-	public function get_sample_error( $error_code, $user_id, $error_type = 'xmlrpc' ) {
+	public function get_sample_error( $error_code, $user_id, $error_type = 'xmlrpc', $error_direction = 'incoming' ) {
 		$signature_details = array(
 			'token'     => 'dhj938djh938d:1:' . $user_id,
 			'timestamp' => time(),
@@ -303,10 +304,12 @@ class Broken_Token_Connection_Errors {
 			'signature' => 'sdf234fe',
 		);
 
-		return new \WP_Error(
+		return Error_Handler::build_connection_wp_error(
 			$error_code,
 			'An error was triggered',
-			compact( 'signature_details', 'error_type' )
+			$signature_details,
+			$error_type,
+			$error_direction
 		);
 	}
 

--- a/projects/plugins/debug-helper/modules/inc/class-broken-token-connection-errors.php
+++ b/projects/plugins/debug-helper/modules/inc/class-broken-token-connection-errors.php
@@ -306,12 +306,18 @@ class Broken_Token_Connection_Errors {
 			'signature' => 'sdf234fe',
 		);
 
-		return Error_Handler::build_connection_wp_error(
+		// Build the error data array by hand rather than through
+		// Error_Handler::build_connection_wp_error(): this plugin runs against whatever
+		// connection package the site ships, and the factory may not exist there yet.
+		// Older packages simply ignore the error_direction key.
+		return new \WP_Error(
 			$error_code,
 			'An error was triggered',
-			$signature_details,
-			$error_type,
-			$error_direction
+			array(
+				'signature_details' => $signature_details,
+				'error_type'        => $error_type,
+				'error_direction'   => $error_direction,
+			)
 		);
 	}
 


### PR DESCRIPTION
Closes CONNECT-379

## Proposed changes

This is the `Error_Handler` refactoring discussed in CONNECT-379: a standard error structure, and a clear separation between XML-RPC and REST requests and between incoming and outgoing requests. All three parts ship together so the documentation never describes a half-migrated state.

**1. Standard error structure**

* New `ERROR_TYPE_XMLRPC` / `ERROR_TYPE_REST` / `ERROR_TYPE_LOCAL_STATE` and `DIRECTION_INCOMING` / `DIRECTION_OUTGOING` constants on `Error_Handler`.
* New `error_direction` field on stored errors (`'incoming'`, `'outgoing'`, or `''` for legacy entries and local-state errors, which involve no request). Purely additive: legacy stored entries (which expire within 24h anyway) and the WPCOM `jetpack-report-error` payload remain compatible — the WPCOM handler validates `error_code`/`error_data.token`/`user_id`/`nonce` structurally and ignores unknown fields (verified against the wpcom endpoint code).
* New `Error_Handler::build_connection_error_data()` / `build_connection_wp_error()` static factory defining the `WP_Error` data contract in one place (guaranteed `signature_details.token` key, validated type/direction). All reporters now use it instead of hand-rolling `compact()` arrays: the 8 error sites in `Manager::internal_verify_xml_rpc_signature()`, `Manager::get_connection_owner()`, `Error_Handler::check_api_response_for_errors()`, and the Broken Token debug-helper module.
* The factory enforces the no-direction contract for local-state errors: any `error_direction` passed with `ERROR_TYPE_LOCAL_STATE` is discarded and stored as `''` — these errors describe the site's own database, not a request, so a direction would be inconsistent data.
* **⚠️ Behavior change — previously-invisible signature errors can now reach the user as an admin notice.** `Jetpack_Signature` errors returned from `internal_verify_xml_rpc_signature()` are now normalized into the standard shape. Previously they carried no `error_type`, and some codes (`invalid_scheme`, `invalid_secret`, `invalid_token` from signing) carried no `signature_details` at all — making them silently unstorable by `wp_error_to_array()` despite being in `known_errors`. With this PR those errors are stored and sent to WPCOM for verification, and codes on the displayable list (e.g. `invalid_token`) can now surface the generic connection admin notice and React dashboard error where previously nothing appeared. This fixes a latent bug — broken-token states users could never see — but it is user-visible and should be kept in mind when triaging new connection-notice reports after release.

**2. Correct type + direction labeling**

* **Incoming**: `internal_verify_xml_rpc_signature()` derives the real transport instead of hardcoding `'xmlrpc'` — `XMLRPC_REQUEST` → `xmlrpc`, `wp_is_rest_endpoint()` → `rest` (signed REST requests are funneled into this path by `REST_Authentication` and were previously mislabeled), fallback `xmlrpc`. Direction is always `incoming`.
* **Outgoing**: `Client::remote_request()` labels the transport by the endpoint the request targets — `/xmlrpc.php` (i.e. `Jetpack_IXR_Client` traffic, previously mislabeled `'rest'`) vs everything else. `check_api_response_for_errors()` stamps `DIRECTION_OUTGOING`.
* **Local connection-state errors** (`invalid_connection_owner`) are now stored with `error_type: 'local_state'` instead of the old `'connection'`, which was near-meaningless in a class where every error concerns the connection — the type answers "what is the evidence for this error?" (a failed request over a transport vs the site's own database). Nothing in the monorepo consumes the old stored value (`delete_all_api_errors()` spares every non-`xmlrpc`/`rest` type by default, and these errors are never sent to WPCOM), and legacy `'connection'` entries expire within 24h of upgrading, so no migration or reading shim is needed.
* WPCOM side is unaffected: the `jetpack-report-error` verification handler does not branch on `error_type` (matches by token + nonce only), and site-side consumers (`delete_all_api_errors()`, displayable-error filtering) already accept both values.

**3. Documentation**

* `Error_Handler` class docblock now describes both flows (incoming with WPCOM verification round-trip, outgoing self-verified), all valid `error_type`/`error_direction` values (including the legacy `'connection'` value stored by versions ≤ 8.8), and why the legacy `xmlrpc` option names are kept.
* `check_api_response_for_errors()` documented as the outgoing-flow entry point, including why XML-RPC faults (HTTP 200 + XML body) remain invisible to it.
* `report_error()` documents the security rationale of `$skip_wpcom_verification` (verified errors trigger workflows, so only self-evidencing errors may skip the round-trip).
* `wp_error_to_array()` documents the required data shape; cross-reference added in `Client::remote_request()`.
* `docs/error-handling.md` rewritten as a self-contained reference: both capture flows, the type/direction classification, the supported error codes (`$known_errors`) allowlist with a link to its definition, the standard error structure and factory, storage details (legacy option names, `user_id` semantics, 5-per-code limit, 24h expiry, hourly gate), display customization (examples kept), clearing behavior, and debugging with the Broken Token module. The stale links to old PRs are gone.

This closes out all remaining checklist items on CONNECT-379.

## Related product discussion/links

* Linear: CONNECT-379
* Previous step (merged): #50870

## Does this pull request change what data or activity we track or use?

Errors reported to WPCOM via the existing `jetpack-report-error` endpoint now include an `error_direction` field alongside the existing `error_type`. No new data categories — it classifies the same failed-request metadata already being sent.

## Testing instructions

**Automated**:

* `cd projects/packages/connection && composer phpunit` — full suite passes (828 tests); new coverage includes the factory contract (validation, local-state direction forcing), all four type/direction combinations end-to-end through `Client::remote_request()`, incoming transport detection, legacy entries without `error_direction` (and with the legacy `'connection'` type), and `delete_all_api_errors()`.
* `jp phan packages/connection` and `jp phan plugins/debug-helper` — clean.

**Manual**:

Before testing, disable the hourly reporting gate — `should_report_error()` otherwise processes each error code only once per hour, so repeated test attempts would be silently dropped. Add this to a mu-plugin (or via Code Snippets plugin) on the test site:                                                               
                                                                                                                                                      
``` 
add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );                                                                           
```

1. On a Jurassic Ninja or Docker site with this branch, install the Jetpack Debug Tools plugin and use **Broken Token → Connection Errors** to generate sample errors — stored errors (shown on that page) now carry `error_direction`.
2. Break the blog token (Broken Token module), then load any wp-admin page so an outgoing signed request fails: the stored verified error should have `error_type` matching the transport (`rest` for API calls, `xmlrpc` for IXR calls) and `error_direction: outgoing`.
3. With a broken token, have WPCOM hit the site (e.g. use the debugger): incoming failures land as unverified errors with `error_direction: incoming`, and as `error_type: rest` when they arrive via the REST authenticator.
4. Set the `master_user` option to a user ID with no token (or delete the owner's WP user), then load the Jetpack dashboard: the stored `invalid_connection_owner` error should have `error_type: local_state` and an empty `error_direction`.
5. **Previously-dropped signature errors** (the ⚠️ behavior change above): empty the blog token's secret chunk while keeping its key, so incoming signature verification fails inside `Jetpack_Signature` with a data-less error. The blog token lives inside the `jetpack_private_options` array and has the form `key.secret`:

   ```
   wp option pluck jetpack_private_options blog_token
   # → e.g. abcd1234.efgh5678 — copy the part BEFORE the dot, then:
   wp option patch update jetpack_private_options blog_token 'abcd1234.'
   ```

   (Note the trailing dot — the key must stay intact so the incoming request still matches the stored token.) Then have WPCOM hit the site as in step 3: an `invalid_secret` error should appear in the stored errors (Broken Token → Connection Errors) with `error_type: xmlrpc` / `error_direction: incoming` — on trunk this error is silently dropped and nothing is stored. Once an error with a displayable code (e.g. `invalid_token`) is verified, the generic connection admin notice appears on wp-admin pages where previously nothing did.
6. [WoA dev blog](https://github.com/Automattic/jetpack/pull/50992#issuecomment-5165055286): WoA sites are special since the source of truth for JP tokens is in Persistent Data, therefore breaking the token with the broken token tool is not possible. You can test with the following two scenarios tho:
- (With Broken Token) Randomize the primary user ID -> Will produce a `invalid_connection_owner ` error with  `error_type: local_state` and empty `error_direction`
- Clear the user token on **WPCOM** -> Visit JP Debugger -> Will produce an `unknown_token` error with `error_type:rest` and `error_direction: outgoing`

**Documentation**:

1. Proof read the updated documentation and confirm it's clean and helpful
