### PR TITLE
Boost: batch per-module status option reads into one query

### DIFF
--- a/projects/plugins/boost/app/lib/class-status.php
+++ b/projects/plugins/boost/app/lib/class-status.php
@@ -29,16 +29,30 @@ class Status implements Entry_Can_Get, Entry_Can_Set {
 	 */
 	protected $option_name;
 
+	/**
+	 * Prefix for the per-module status options.
+	 */
+	const OPTION_PREFIX = 'jetpack_boost_status_';
+
 	public function __construct( $slug ) {
 		$this->slug        = $slug;
-		$module_slug       = str_replace( '_', '-', $this->slug );
-		$this->option_name = 'jetpack_boost_status_' . $module_slug;
+		$this->option_name = self::get_option_name( $this->slug );
 
 		$this->status_sync_map = array(
 			Cloud_CSS::get_slug() => array(
 				Critical_CSS::get_slug(),
 			),
 		);
+	}
+
+	/**
+	 * Build the status option name for a given module slug.
+	 *
+	 * @param string $slug Module slug.
+	 * @return string The wp_options option name storing the module's status.
+	 */
+	public static function get_option_name( $slug ) {
+		return self::OPTION_PREFIX . str_replace( '_', '-', $slug );
 	}
 
 	public function get( $_fallback = false ) {

--- a/projects/plugins/boost/app/modules/class-module.php
+++ b/projects/plugins/boost/app/modules/class-module.php
@@ -62,6 +62,15 @@ class Module {
 	}
 
 	/**
+	 * Name of the wp_options option that stores this module's status.
+	 *
+	 * @return string
+	 */
+	public function get_status_option_name() {
+		return Status::get_option_name( $this->get_slug() );
+	}
+
+	/**
 	 * If the module has any submodules, this method will return an array of Module instances for each submodule.
 	 */
 	public function get_submodules() {

--- a/projects/plugins/boost/app/modules/class-modules-setup.php
+++ b/projects/plugins/boost/app/modules/class-modules-setup.php
@@ -32,6 +32,30 @@ class Modules_Setup implements Has_Setup, Has_Data_Sync {
 	public function __construct() {
 		$this->available_modules    = $this->get_available_modules();
 		$this->available_submodules = $this->get_available_submodules();
+		$this->prime_status_option_caches();
+	}
+
+	/**
+	 * Warm the object cache for every module status option in a single query.
+	 *
+	 * Each module's status is read individually via get_option() when its enabled
+	 * state is checked. On a site with no persistent object cache, a module whose
+	 * status option has never been stored is re-queried on every request. Priming
+	 * the caches here collapses those into one query without creating any rows.
+	 */
+	private function prime_status_option_caches() {
+		if ( ! function_exists( 'wp_prime_option_caches' ) ) {
+			return;
+		}
+
+		$option_names = array();
+		foreach ( $this->get_available_modules_and_submodules() as $module ) {
+			$option_names[] = $module->get_status_option_name();
+		}
+
+		if ( ! empty( $option_names ) ) {
+			wp_prime_option_caches( $option_names );
+		}
 	}
 
 	public function get_available_modules() {

--- a/projects/plugins/boost/changelog/boost-607-batch-module-status-reads
+++ b/projects/plugins/boost/changelog/boost-607-batch-module-status-reads
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Modules: Batch the per-module status option reads into a single query to avoid redundant per-request database queries on sites without a persistent object cache.

--- a/projects/plugins/boost/tests/php/modules/Module_Test.php
+++ b/projects/plugins/boost/tests/php/modules/Module_Test.php
@@ -10,6 +10,7 @@ use Automattic\Jetpack_Boost\Modules\Optimizations\Minify\Minify_CSS;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Minify\Minify_JS;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Cache_Preload;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Page_Cache;
+use Automattic\Jetpack_Boost\Lib\Status;
 use Automattic\Jetpack_Boost\Tests\Base_TestCase;
 
 class Module_Test extends Base_TestCase {
@@ -66,5 +67,31 @@ class Module_Test extends Base_TestCase {
 
 		$this->assertArrayHasKey( Minify_JS::get_slug(), $submodule->get_active_parent_modules() );
 		$this->assertArrayHasKey( Minify_CSS::get_slug(), $submodule->get_active_parent_modules() );
+	}
+
+	public function test_status_option_name_replaces_underscores_with_hyphens() {
+		// Slugs use underscores; the stored option name uses hyphens.
+		$this->assertSame( 'jetpack_boost_status_minify-js', Status::get_option_name( 'minify_js' ) );
+		$this->assertSame( 'jetpack_boost_status_page-cache', Status::get_option_name( 'page_cache' ) );
+	}
+
+	public function test_module_exposes_its_status_option_name() {
+		$module = new Module(
+			new class() implements Feature {
+				public static function get_slug() {
+					return 'my_module';
+				}
+
+				public static function is_available() {
+					return true;
+				}
+
+				public function setup() {
+					// no-op
+				}
+			}
+		);
+
+		$this->assertSame( 'jetpack_boost_status_my-module', $module->get_status_option_name() );
 	}
 }

--- a/projects/plugins/boost/tests/php/modules/Module_Test.php
+++ b/projects/plugins/boost/tests/php/modules/Module_Test.php
@@ -4,13 +4,13 @@ namespace Automattic\Jetpack_Boost\Tests\Modules;
 
 use Automattic\Jetpack_Boost\Contracts\Feature;
 use Automattic\Jetpack_Boost\Contracts\Is_Always_On;
+use Automattic\Jetpack_Boost\Lib\Status;
 use Automattic\Jetpack_Boost\Modules\Module;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Minify\Minify_Common;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Minify\Minify_CSS;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Minify\Minify_JS;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Cache_Preload;
 use Automattic\Jetpack_Boost\Modules\Optimizations\Page_Cache\Page_Cache;
-use Automattic\Jetpack_Boost\Lib\Status;
 use Automattic\Jetpack_Boost\Tests\Base_TestCase;
 
 class Module_Test extends Base_TestCase {


### PR DESCRIPTION
Fixes BOOST-607

## Proposed changes

* Prime all `jetpack_boost_status_<module>` options in a single combined query when `Modules_Setup` is constructed, before any per-module status read.
* Add a static `Status::get_option_name( $slug )` helper (extracted from the constructor) and a `Module::get_status_option_name()` accessor, so the full set of status option names can be collected without reaching into each module's private `Status` instance.
* Unit tests for the option-name derivation (including the underscore → hyphen transform).

## Why are these changes being made

`Modules_Setup` checks each module's enabled state via `Module::is_enabled()` → `Status::get()` → `get_option( 'jetpack_boost_status_<slug>', false )`, once per module, in several per-request loops (`get_status()`, `get_ready_active_optimization_modules()`, `init_modules()`, …). The first such loop issues one `SELECT` per module.

On a site **without a persistent object cache**, a module whose status option has never been stored (i.e. never toggled) isn't in `alloptions` and isn't remembered in `notoptions` across requests, so it's re-queried on **every** request — roughly one `SELECT` per available module/submodule.

`wp_prime_option_caches()` (WP core ≥ 6.4; Boost requires ≥ 6.9) loads all the names in a single `IN (…)` query and records the misses in `notoptions`, so the subsequent individual `get_option()` calls are served from cache. It **primes** rather than **seeds** — no rows are written, so absent options stay absent and no module state is synthesized. Repeat instantiations are cheap: `wp_prime_option_caches()` skips names already cached (or in `notoptions`/`alloptions`).


## Does this pull request change what data or activity we track or use?

No. This only changes when/how existing options are read into cache; it writes nothing and syncs nothing.

## Testing instructions

Use a site with **no persistent object cache** (on jurassic.ninja, create it with "Drop-in Cache Plugins" unchecked; with Jetpack Boost active and **no** Boost modules toggled (fresh install) so the status rows don't exist.

Add the following snippet in Code Snippets or create an mu-plugin.

    <?php
    add_filter( 'query', function ( $q ) {
        if ( stripos( $q, 'option_value' ) !== false && strpos( $q, 'jetpack_boost_status_' ) !== false ) {
            @file_put_contents( WP_CONTENT_DIR . '/boost-status.log',
                gmdate( 'c' ) . ' ' . trim( preg_replace( '/\s+/', ' ', $q ) ) . "\n", FILE_APPEND | LOCK_EX );
        }
        return $q;
    }, 0 );

Load the front end logged out with a unique query string each time (so the edge cache doesn't serve a cached page), e.g. `?cachebust=1`, `?cachebust=2`. Then `cat wp-content/boost-status.log`.

* **Before:** several individual `SELECT … 'jetpack_boost_status_<module>'` queries per request (one per available module/submodule).
* **After:** those individual reads are gone and there is one IN (…)` query instead. Behaviour is unchanged, the same modules are enabled/disabled.

**Unit tests:** `projects/plugins/boost` — `Module_Test` (`test_status_option_name_replaces_underscores_with_hyphens`, `test_module_exposes_its_status_option_name`).