### PR TITLE
Social: Preserve hyperlink provenance in previews

### DIFF
--- a/projects/js-packages/social-previews/changelog/social-557-hyperlink-contract
+++ b/projects/js-packages/social-previews/changelog/social-557-hyperlink-contract
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Add a test pinning the PHP hyperlink payload contract; no user-facing change
+
+

--- a/projects/js-packages/social-previews/src/helpers.tsx
+++ b/projects/js-packages/social-previews/src/helpers.tsx
@@ -263,25 +263,34 @@ export function preparePreviewText( text: string, options: PreviewTextOptions ):
 	}
 
 	const componentMap: Record< string, React.ReactElement > = {};
+	const replacements: Array< { start: number; end: number; value: string } > = [];
+	const overlapsReplacement = ( start: number, end: number ) =>
+		replacements.some( replacement => start < replacement.end && replacement.start < end );
 
 	if ( hyperlinkUrls ) {
 		// Convert URLs to hyperlinks.
 		// TODO: Use a better regex here to match the URLs without protocol.
-		const urls = result.match( /(https?:\/\/\S+)/g ) || [];
+		const urls = [ ...result.matchAll( /https?:\/\/\S+/g ) ];
 
 		/**
 		 * BEFORE:
 		 * result = 'Check out this cool site: https://wordpress.org and this one: https://wordpress.com'
 		 */
-		urls.forEach( ( url, index ) => {
+		urls.forEach( ( match, index ) => {
+			const url = match[ 0 ];
+			const start = match.index ?? 0;
+
 			// Add the element to the component map.
 			componentMap[ `Link${ index }` ] = (
 				<a href={ url } rel="noopener noreferrer" target="_blank">
 					{ url }
 				</a>
 			);
-			// Replace the URL with the component placeholder.
-			result = result.replace( url, `<Link${ index } />` );
+			replacements.push( {
+				start,
+				end: start + url.length,
+				value: `<Link${ index } />`,
+			} );
 		} );
 		/**
 		 * AFTER:
@@ -300,7 +309,7 @@ export function preparePreviewText( text: string, options: PreviewTextOptions ):
 		 * For example, we don't want to match the hash in the URL.
 		 * Thus we need to match the whitespace character before the hashtag or the beginning of the string.
 		 */
-		const hashtags = result.matchAll( /(^|\s)#(\w+)/g );
+		const hashtags = [ ...result.matchAll( /(^|\s)#(\w+)/g ) ];
 
 		const hashtagUrl = hashtagUrlMap[ platform ];
 
@@ -309,7 +318,15 @@ export function preparePreviewText( text: string, options: PreviewTextOptions ):
 		 * result = `#breaking text with a #hashtag on the #web
 		 * with a url https://github.com/Automattic/wp-calypso#security that has a hash in it`
 		 */
-		[ ...hashtags ].forEach( ( [ fullMatch, whitespace, hashtag ], index ) => {
+		hashtags.forEach( ( match, index ) => {
+			const [ , whitespace, hashtag ] = match;
+			const start = ( match.index ?? 0 ) + whitespace.length;
+			const end = start + hashtag.length + 1;
+
+			if ( overlapsReplacement( start, end ) ) {
+				return;
+			}
+
 			const url = sprintf( hashtagUrl, hashtag, options.hashtagDomain );
 
 			// Add the element to the component map.
@@ -319,8 +336,7 @@ export function preparePreviewText( text: string, options: PreviewTextOptions ):
 				</a>
 			);
 
-			// Replace the hashtag with the component placeholder.
-			result = result.replace( fullMatch, `${ whitespace }<Hashtag${ index } />` );
+			replacements.push( { start, end, value: `<Hashtag${ index } />` } );
 		} );
 		/**
 		 * AFTER:
@@ -335,13 +351,10 @@ export function preparePreviewText( text: string, options: PreviewTextOptions ):
 		 */
 	}
 
-	// Render editor hyperlinks: wrap each anchor's own occurrence of its text in
-	// a link, resolving all positions before any tags are inserted. Anchors whose
-	// occurrence isn't present (e.g. truncated away) or overlaps another match
-	// are skipped. Runs after the URL/hashtag passes so the inserted tags stay balanced.
+	// Render editor hyperlinks: resolve occurrences against the original plain
+	// message, before URL and hashtag placeholders remove matching text. Anchors
+	// that were truncated away or overlap another link are skipped.
 	if ( hyperlinks?.length ) {
-		const matches: Array< { pos: number; text: string; href: string; index: number } > = [];
-
 		hyperlinks.forEach( ( { text: anchorText, href, occurrence = 0 }, index ) => {
 			if ( ! anchorText ) {
 				return;
@@ -353,25 +366,25 @@ export function preparePreviewText( text: string, options: PreviewTextOptions ):
 				return;
 			}
 
-			const overlaps = matches.some(
-				match => pos < match.pos + match.text.length && match.pos < pos + anchorText.length
-			);
-
-			if ( ! overlaps ) {
-				matches.push( { pos, text: anchorText, href, index } );
+			const end = pos + anchorText.length;
+			if ( overlapsReplacement( pos, end ) ) {
+				return;
 			}
-		} );
 
-		// Insert right-to-left so earlier positions stay valid.
-		matches.sort( ( a, b ) => b.pos - a.pos );
-
-		for ( const { pos, text: anchorText, href, index } of matches ) {
 			const token = `Hyperlink${ index }`;
 			componentMap[ token ] = <a href={ href } rel="noopener noreferrer" target="_blank" />;
+			replacements.push( {
+				start: pos,
+				end,
+				value: `<${ token }>${ anchorText }</${ token }>`,
+			} );
+		} );
+	}
 
-			const wrapped = `<${ token }>${ anchorText }</${ token }>`;
-			result = result.slice( 0, pos ) + wrapped + result.slice( pos + anchorText.length );
-		}
+	// Insert right-to-left so every range remains relative to the plain message.
+	replacements.sort( ( a, b ) => b.start - a.start );
+	for ( const { start, end, value } of replacements ) {
+		result = result.slice( 0, start ) + value + result.slice( end );
 	}
 
 	// Convert newlines to <br> tags.

--- a/projects/js-packages/social-previews/tests/hyperlink-contract.test.tsx
+++ b/projects/js-packages/social-previews/tests/hyperlink-contract.test.tsx
@@ -1,0 +1,57 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { preparePreviewText } from '../src/helpers';
+
+// Payloads captured verbatim from Publicize\Template_Parser::parse_with_hyperlinks()
+// running on the wpcom sandbox at commit cd3ea246b0e.
+const PHP_OUTPUT = {
+	reported_figcaption: {
+		message: 'Today we commemorate Blessed John Soreth. Pray with us.',
+		hyperlinks: [],
+	},
+	literal_plus_content: {
+		message: 'same phrase | same phrase first, then same phrase.',
+		hyperlinks: [ { text: 'same phrase', href: 'https://example.com/real', occurrence: 2 } ],
+	},
+	title_plus_content: {
+		message: 'ha ha\n\nRead the launch post today.',
+		hyperlinks: [ { text: 'launch post', href: 'https://example.com/real', occurrence: 0 } ],
+	},
+	self_overlapping: {
+		message: 'ha ha ha ha ha',
+		hyperlinks: [ { text: 'ha ha', href: 'https://example.com/real', occurrence: 3 } ],
+	},
+};
+
+const markupFor = ( key: keyof typeof PHP_OUTPUT ) => {
+	const { message, hyperlinks } = PHP_OUTPUT[ key ];
+	return renderToStaticMarkup(
+		<>{ preparePreviewText( message, { hyperlinks, platform: 'bluesky' } ) }</>
+	);
+};
+
+describe( 'PHP -> JS hyperlink contract', () => {
+	it( 'renders no link for the reported figcaption case', () => {
+		expect( markupFor( 'reported_figcaption' ) ).not.toContain( '<a' );
+	} );
+
+	it( 'links the content instance, not the literal custom text', () => {
+		// Only the third "same phrase" (the anchor's own) should be wrapped.
+		expect( markupFor( 'literal_plus_content' ) ).toBe(
+			'same phrase | same phrase first, then <a href="https://example.com/real" rel="noopener noreferrer" target="_blank">same phrase</a>.'
+		);
+	} );
+
+	it( 'links across a title segment without drifting', () => {
+		expect( markupFor( 'title_plus_content' ) ).toContain(
+			'Read the <a href="https://example.com/real" rel="noopener noreferrer" target="_blank">launch post</a> today.'
+		);
+	} );
+
+	it( 'agrees with PHP on overlapping occurrence counting', () => {
+		// PHP said occurrence 3 of "ha ha" in "ha ha ha ha ha" (overlapping count).
+		// If JS counted non-overlapping it would land on index 2 -> byte 6.
+		expect( markupFor( 'self_overlapping' ) ).toBe(
+			'ha ha ha <a href="https://example.com/real" rel="noopener noreferrer" target="_blank">ha ha</a>'
+		);
+	} );
+} );

--- a/projects/js-packages/social-previews/tests/hyperlink-contract.test.tsx
+++ b/projects/js-packages/social-previews/tests/hyperlink-contract.test.tsx
@@ -1,8 +1,9 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { preparePreviewText } from '../src/helpers';
 
-// Payloads captured verbatim from Publicize\Template_Parser::parse_with_hyperlinks()
-// running on the wpcom sandbox at commit cd3ea246b0e.
+// Representative payloads from Publicize\Template_Parser::parse_with_hyperlinks().
+// The original cases were captured on the wpcom sandbox at commit cd3ea246b0e;
+// regression cases below follow the same final-message occurrence contract.
 const PHP_OUTPUT = {
 	reported_figcaption: {
 		message: 'Today we commemorate Blessed John Soreth. Pray with us.',
@@ -19,6 +20,10 @@ const PHP_OUTPUT = {
 	self_overlapping: {
 		message: 'ha ha ha ha ha',
 		hyperlinks: [ { text: 'ha ha', href: 'https://example.com/real', occurrence: 3 } ],
+	},
+	tokens_before_content: {
+		message: 'https://example.com/post #post post later post',
+		hyperlinks: [ { text: 'post', href: 'https://example.com/real', occurrence: 2 } ],
 	},
 };
 
@@ -52,6 +57,12 @@ describe( 'PHP -> JS hyperlink contract', () => {
 		// If JS counted non-overlapping it would land on index 2 -> byte 6.
 		expect( markupFor( 'self_overlapping' ) ).toBe(
 			'ha ha ha <a href="https://example.com/real" rel="noopener noreferrer" target="_blank">ha ha</a>'
+		);
+	} );
+
+	it( 'keeps occurrences aligned when URLs and hashtags contain the anchor text', () => {
+		expect( markupFor( 'tokens_before_content' ) ).toBe(
+			'<a href="https://example.com/post" rel="noopener noreferrer" target="_blank">https://example.com/post</a> <a href="https://bsky.app/hashtag/post" rel="noopener noreferrer" target="_blank">#post</a> <a href="https://example.com/real" rel="noopener noreferrer" target="_blank">post</a> later post'
 		);
 	} );
 } );

--- a/projects/packages/publicize/_inc/components/customize-and-preview/preview-section/test/index.test.tsx
+++ b/projects/packages/publicize/_inc/components/customize-and-preview/preview-section/test/index.test.tsx
@@ -51,6 +51,7 @@ const connection: Connection = {
 const previewData: ConnectionPreviewData = {
 	description: 'Description',
 	excerpt: 'Excerpt',
+	hyperlinks: [],
 	image: 'https://example.com/image.jpg',
 	isLoading: false,
 	media: [],

--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
@@ -108,10 +108,10 @@ export function useConnectionPreviewData( connection: Connection ): ConnectionPr
 	).trim();
 	const currentRenderItem = items.find( item => item.connection_id === connection.connection_id );
 
-	const { rendered, isLoadingRendered } = useSelect(
+	const { rendered, renderedHyperlinks, isLoadingRendered } = useSelect(
 		select => {
 			if ( ! templatesEnabled || ! postId ) {
-				return { rendered: null, isLoadingRendered: false };
+				return { rendered: null, renderedHyperlinks: [], isLoadingRendered: false };
 			}
 			// Read from the cache-only selector so this hook does not trigger requests.
 			// Fetches are driven centrally by `useDriveRenderedMessagesFetch`.
@@ -120,6 +120,7 @@ export function useConnectionPreviewData( connection: Connection ): ConnectionPr
 
 			return {
 				rendered: batch?.[ connection.connection_id ]?.rendered_message ?? null,
+				renderedHyperlinks: batch?.[ connection.connection_id ]?.hyperlinks ?? [],
 				isLoadingRendered: social.isLoadingRenderedMessages( postId, items, postIntent ),
 			};
 		},
@@ -138,13 +139,21 @@ export function useConnectionPreviewData( connection: Connection ): ConnectionPr
 	// Last rendered message for this connection, kept across cache-key changes
 	// (e.g. title/excerpt edits) so a pending re-render keeps showing rendered
 	// text instead of flashing the raw template or a skeleton.
-	const lastRenderedRef = useRef< { connectionId: string; message: string } | null >( null );
+	const lastRenderedRef = useRef< {
+		connectionId: string;
+		message: string;
+		hyperlinks: NonNullable< PostPreviewData[ 'hyperlinks' ] >;
+	} | null >( null );
 	if ( templatesEnabled && typeof rendered === 'string' ) {
-		lastRenderedRef.current = { connectionId: connection.connection_id, message: rendered };
+		lastRenderedRef.current = {
+			connectionId: connection.connection_id,
+			message: rendered,
+			hyperlinks: renderedHyperlinks,
+		};
 	}
 	const lastRendered =
 		lastRenderedRef.current?.connectionId === connection.connection_id
-			? lastRenderedRef.current.message
+			? lastRenderedRef.current
 			: null;
 
 	return useMemo( () => {
@@ -155,10 +164,13 @@ export function useConnectionPreviewData( connection: Connection ): ConnectionPr
 		// disabled, or the request failed. While pending, fall back to the last
 		// rendered message, or to the skeleton (`isLoading`) when there is none.
 		let message = baseMessage;
+		let hyperlinks: PostPreviewData[ 'hyperlinks' ] = [];
 		if ( templatesEnabled && typeof rendered === 'string' ) {
 			message = rendered;
+			hyperlinks = renderedHyperlinks;
 		} else if ( lastRendered !== null ) {
-			message = lastRendered;
+			message = lastRendered.message;
+			hyperlinks = lastRendered.hyperlinks;
 		} else if ( isPending ) {
 			message = '';
 		}
@@ -166,6 +178,7 @@ export function useConnectionPreviewData( connection: Connection ): ConnectionPr
 		return {
 			...postData,
 			message,
+			hyperlinks,
 			media,
 			isLoading: isPending && message === '',
 		};
@@ -177,6 +190,7 @@ export function useConnectionPreviewData( connection: Connection ): ConnectionPr
 		media,
 		postData,
 		rendered,
+		renderedHyperlinks,
 		templatesEnabled,
 	] );
 }

--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
@@ -13,11 +13,25 @@ import useSocialMediaMessage from '../use-social-media-message';
 import { useSocialPreviewPostData } from '../use-social-preview-post-data';
 import type { Connection } from '../../social-store/types';
 import type { PostPreviewData } from '../use-social-preview-post-data/types';
+import type { Hyperlink } from '@automattic/social-previews';
 
 export type ConnectionPreviewData = PostPreviewData & {
 	message: string;
+	/**
+	 * Editor hyperlinks that the server resolved for this connection's rendered
+	 * message. Only the renderer knows which anchors survived into the message,
+	 * so these never come from the post body on the client.
+	 */
+	hyperlinks: Hyperlink[];
 	isLoading: boolean;
 };
+
+/**
+ * Shared empty array so the `useSelect` map keeps returning shallow-equal
+ * output when a connection has no hyperlinks — a fresh `[]` would re-render
+ * every preview on each social-store dispatch.
+ */
+const EMPTY_HYPERLINKS: Hyperlink[] = [];
 
 /**
  * Returns the post data needed for the preview of a specific connection.
@@ -111,7 +125,7 @@ export function useConnectionPreviewData( connection: Connection ): ConnectionPr
 	const { rendered, renderedHyperlinks, isLoadingRendered } = useSelect(
 		select => {
 			if ( ! templatesEnabled || ! postId ) {
-				return { rendered: null, renderedHyperlinks: [], isLoadingRendered: false };
+				return { rendered: null, renderedHyperlinks: EMPTY_HYPERLINKS, isLoadingRendered: false };
 			}
 			// Read from the cache-only selector so this hook does not trigger requests.
 			// Fetches are driven centrally by `useDriveRenderedMessagesFetch`.
@@ -120,7 +134,7 @@ export function useConnectionPreviewData( connection: Connection ): ConnectionPr
 
 			return {
 				rendered: batch?.[ connection.connection_id ]?.rendered_message ?? null,
-				renderedHyperlinks: batch?.[ connection.connection_id ]?.hyperlinks ?? [],
+				renderedHyperlinks: batch?.[ connection.connection_id ]?.hyperlinks ?? EMPTY_HYPERLINKS,
 				isLoadingRendered: social.isLoadingRenderedMessages( postId, items, postIntent ),
 			};
 		},
@@ -142,7 +156,7 @@ export function useConnectionPreviewData( connection: Connection ): ConnectionPr
 	const lastRenderedRef = useRef< {
 		connectionId: string;
 		message: string;
-		hyperlinks: NonNullable< PostPreviewData[ 'hyperlinks' ] >;
+		hyperlinks: Hyperlink[];
 	} | null >( null );
 	if ( templatesEnabled && typeof rendered === 'string' ) {
 		lastRenderedRef.current = {
@@ -164,7 +178,7 @@ export function useConnectionPreviewData( connection: Connection ): ConnectionPr
 		// disabled, or the request failed. While pending, fall back to the last
 		// rendered message, or to the skeleton (`isLoading`) when there is none.
 		let message = baseMessage;
-		let hyperlinks: PostPreviewData[ 'hyperlinks' ] = [];
+		let hyperlinks: Hyperlink[] = EMPTY_HYPERLINKS;
 		if ( templatesEnabled && typeof rendered === 'string' ) {
 			message = rendered;
 			hyperlinks = renderedHyperlinks;

--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
@@ -1,4 +1,5 @@
 import { siteHasFeature } from '@automattic/jetpack-script-data';
+import { parseHyperlinks, type Hyperlink } from '@automattic/social-previews';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
 import { useMemo, useRef } from 'react';
@@ -13,14 +14,13 @@ import useSocialMediaMessage from '../use-social-media-message';
 import { useSocialPreviewPostData } from '../use-social-preview-post-data';
 import type { Connection } from '../../social-store/types';
 import type { PostPreviewData } from '../use-social-preview-post-data/types';
-import type { Hyperlink } from '@automattic/social-previews';
 
 export type ConnectionPreviewData = PostPreviewData & {
 	message: string;
 	/**
-	 * Editor hyperlinks that the server resolved for this connection's rendered
-	 * message. Only the renderer knows which anchors survived into the message,
-	 * so these never come from the post body on the client.
+	 * Source-aware editor hyperlinks for this connection's rendered message.
+	 * Paid previews use the server result; legacy Bluesky previews mirror the
+	 * default title + excerpt assembly locally.
 	 */
 	hyperlinks: Hyperlink[];
 	isLoading: boolean;
@@ -32,6 +32,41 @@ export type ConnectionPreviewData = PostPreviewData & {
  * every preview on each social-store dispatch.
  */
 const EMPTY_HYPERLINKS: Hyperlink[] = [];
+
+const WORD_CHARACTER = /[\p{L}\p{M}\p{N}_]/u;
+
+/**
+ * Whether text appears as a standalone phrase, rather than inside a larger word.
+ *
+ * @param message - Text to search.
+ * @param text    - Phrase to find.
+ * @return Whether the phrase has a standalone occurrence.
+ */
+function containsStandaloneText( message: string, text: string ): boolean {
+	const first = text.match( /^./u )?.[ 0 ] ?? '';
+	const last = text.match( /.$/u )?.[ 0 ] ?? '';
+	let offset = 0;
+
+	while ( offset < message.length ) {
+		const index = message.indexOf( text, offset );
+		if ( index < 0 ) {
+			return false;
+		}
+
+		const before = message.slice( 0, index ).match( /.$/u )?.[ 0 ] ?? '';
+		const after = message.slice( index + text.length ).match( /^./u )?.[ 0 ] ?? '';
+		if (
+			( ! WORD_CHARACTER.test( first ) || ! WORD_CHARACTER.test( before ) ) &&
+			( ! WORD_CHARACTER.test( last ) || ! WORD_CHARACTER.test( after ) )
+		) {
+			return true;
+		}
+
+		offset = index + 1;
+	}
+
+	return false;
+}
 
 /**
  * Returns the post data needed for the preview of a specific connection.
@@ -120,6 +155,28 @@ export function useConnectionPreviewData( connection: Connection ): ConnectionPr
 	const baseMessage = (
 		isPerNetworkMode ? connection.message ?? siteMessageTemplate : globalMessage
 	).trim();
+	const legacyHyperlinkSource = useSelect(
+		select => {
+			if ( templatesEnabled || connection.service_name !== 'bluesky' ) {
+				return '';
+			}
+
+			const { getEditedPostAttribute } = select( editorStore );
+			const content = ( getEditedPostAttribute( 'content' ) || '' ).split( '<!--more' )[ 0 ];
+
+			return getEditedPostAttribute( 'excerpt' ) || content;
+		},
+		[ templatesEnabled, connection.service_name ]
+	);
+	const legacyHyperlinks = useMemo(
+		() =>
+			baseMessage || ! legacyHyperlinkSource
+				? EMPTY_HYPERLINKS
+				: parseHyperlinks( legacyHyperlinkSource ).filter(
+						( { text } ) => ! containsStandaloneText( postData.title, text )
+				  ),
+		[ baseMessage, legacyHyperlinkSource, postData.title ]
+	);
 	const currentRenderItem = items.find( item => item.connection_id === connection.connection_id );
 
 	const { rendered, renderedHyperlinks, isLoadingRendered } = useSelect(
@@ -178,7 +235,7 @@ export function useConnectionPreviewData( connection: Connection ): ConnectionPr
 		// disabled, or the request failed. While pending, fall back to the last
 		// rendered message, or to the skeleton (`isLoading`) when there is none.
 		let message = baseMessage;
-		let hyperlinks: Hyperlink[] = EMPTY_HYPERLINKS;
+		let hyperlinks: Hyperlink[] = legacyHyperlinks;
 		if ( templatesEnabled && typeof rendered === 'string' ) {
 			message = rendered;
 			hyperlinks = renderedHyperlinks;
@@ -201,6 +258,7 @@ export function useConnectionPreviewData( connection: Connection ): ConnectionPr
 		isDebouncingRenderedMessage,
 		isLoadingRendered,
 		lastRendered,
+		legacyHyperlinks,
 		media,
 		postData,
 		rendered,

--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/index.ts
@@ -36,6 +36,25 @@ const EMPTY_HYPERLINKS: Hyperlink[] = [];
 const WORD_CHARACTER = /[\p{L}\p{M}\p{N}_]/u;
 
 /**
+ * Count text occurrences, including overlapping matches.
+ *
+ * @param message - Text to search.
+ * @param text    - Phrase to find.
+ * @return Number of occurrences.
+ */
+function countTextOccurrences( message: string, text: string ): number {
+	let count = 0;
+	let offset = 0;
+
+	while ( text && ( offset = message.indexOf( text, offset ) ) >= 0 ) {
+		count++;
+		offset++;
+	}
+
+	return count;
+}
+
+/**
  * Whether text appears as a standalone phrase, rather than inside a larger word.
  *
  * @param message - Text to search.
@@ -172,9 +191,14 @@ export function useConnectionPreviewData( connection: Connection ): ConnectionPr
 		() =>
 			baseMessage || ! legacyHyperlinkSource
 				? EMPTY_HYPERLINKS
-				: parseHyperlinks( legacyHyperlinkSource ).filter(
-						( { text } ) => ! containsStandaloneText( postData.title, text )
-				  ),
+				: parseHyperlinks( legacyHyperlinkSource )
+						.filter( ( { text } ) => ! containsStandaloneText( postData.title, text ) )
+						.map( hyperlink => ( {
+							...hyperlink,
+							occurrence:
+								( hyperlink.occurrence ?? 0 ) +
+								countTextOccurrences( postData.title, hyperlink.text ),
+						} ) ),
 		[ baseMessage, legacyHyperlinkSource, postData.title ]
 	);
 	const currentRenderItem = items.find( item => item.connection_id === connection.connection_id );

--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/test/index.test.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/test/index.test.ts
@@ -120,6 +120,7 @@ const defaultPostData = {
  * @param opts                   - Per-test overrides.
  * @param opts.postId            - Post id returned to the editor-store useSelect.
  * @param opts.messageTemplate   - Saved site message template.
+ * @param opts.legacySource      - Exact fallback body source for feature-off previews.
  * @param opts.rendered          - String returned for the rendered slice, or null to signal "no slice yet".
  * @param opts.hyperlinks        - Source-aware hyperlinks returned with the rendered message.
  * @param opts.isLoadingRendered - Whether the rendered-messages cache slot is currently in-flight.
@@ -128,6 +129,7 @@ function mockSelectCalls(
 	opts: {
 		postId?: number;
 		messageTemplate?: string;
+		legacySource?: string;
 		rendered?: string | null;
 		hyperlinks?: Array< { text: string; href: string; occurrence?: number } >;
 		isLoadingRendered?: boolean;
@@ -136,6 +138,7 @@ function mockSelectCalls(
 	const {
 		postId = 42,
 		messageTemplate = '',
+		legacySource = '',
 		rendered = null,
 		hyperlinks = [],
 		isLoadingRendered = false,
@@ -144,6 +147,7 @@ function mockSelectCalls(
 		.mockReturnValueOnce( postId )
 		.mockReturnValueOnce( 0 )
 		.mockReturnValueOnce( messageTemplate )
+		.mockReturnValueOnce( legacySource )
 		.mockReturnValueOnce( { rendered, renderedHyperlinks: hyperlinks, isLoadingRendered } );
 }
 
@@ -195,6 +199,82 @@ describe( 'useConnectionPreviewData', () => {
 		const { result } = renderHook( () => useConnectionPreviewData( connection ) );
 
 		expect( result.current.message ).toBe( 'Global message' );
+	} );
+
+	it( 'keeps hyperlinks from the legacy default body without paid features', () => {
+		mockSelectCalls( {
+			legacySource: '<p>Read the <a href="https://example.com/real">launch post</a> today.</p>',
+		} );
+		mockUseSocialMediaMessage.mockReturnValue( {
+			message: '',
+			updateMessage: jest.fn(),
+			maxLength: 280,
+		} );
+
+		const { result } = renderHook( () =>
+			useConnectionPreviewData( createMockConnection( { service_name: 'bluesky' } ) )
+		);
+
+		expect( result.current.hyperlinks ).toEqual( [
+			{ text: 'launch post', href: 'https://example.com/real', occurrence: 0 },
+		] );
+	} );
+
+	it( 'does not leak legacy body hyperlinks into a literal custom message', () => {
+		mockSelectCalls( {
+			legacySource: '<p>Later: <a href="https://example.com/unrelated">same phrase</a>.</p>',
+		} );
+
+		const { result } = renderHook( () =>
+			useConnectionPreviewData( createMockConnection( { service_name: 'bluesky' } ) )
+		);
+
+		expect( result.current.message ).toBe( 'Global message' );
+		expect( result.current.hyperlinks ).toEqual( [] );
+	} );
+
+	it( 'does not apply a legacy body hyperlink to matching title text', () => {
+		mockSelectCalls( {
+			legacySource: '<p>Read the <a href="https://example.com/real">launch post</a>.</p>',
+		} );
+		mockUseSocialMediaMessage.mockReturnValue( {
+			message: '',
+			updateMessage: jest.fn(),
+			maxLength: 280,
+		} );
+		mockUseSocialPreviewPostData.mockReturnValue( {
+			...defaultPostData,
+			title: 'launch post',
+		} );
+
+		const { result } = renderHook( () =>
+			useConnectionPreviewData( createMockConnection( { service_name: 'bluesky' } ) )
+		);
+
+		expect( result.current.hyperlinks ).toEqual( [] );
+	} );
+
+	it( 'keeps legacy body hyperlinks that only occur inside a larger title word', () => {
+		mockSelectCalls( {
+			legacySource: '<p>Read the <a href="https://example.com/real">post</a>.</p>',
+		} );
+		mockUseSocialMediaMessage.mockReturnValue( {
+			message: '',
+			updateMessage: jest.fn(),
+			maxLength: 280,
+		} );
+		mockUseSocialPreviewPostData.mockReturnValue( {
+			...defaultPostData,
+			title: 'Composted',
+		} );
+
+		const { result } = renderHook( () =>
+			useConnectionPreviewData( createMockConnection( { service_name: 'bluesky' } ) )
+		);
+
+		expect( result.current.hyperlinks ).toEqual( [
+			{ text: 'post', href: 'https://example.com/real', occurrence: 0 },
+		] );
 	} );
 
 	it( 'should trim the global message', () => {

--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/test/index.test.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/test/index.test.ts
@@ -254,9 +254,9 @@ describe( 'useConnectionPreviewData', () => {
 		expect( result.current.hyperlinks ).toEqual( [] );
 	} );
 
-	it( 'keeps legacy body hyperlinks that only occur inside a larger title word', () => {
+	it( 'keeps legacy body hyperlinks aligned after a larger title word', () => {
 		mockSelectCalls( {
-			legacySource: '<p>Read the <a href="https://example.com/real">post</a>.</p>',
+			legacySource: '<p>First post, then <a href="https://example.com/real">post</a>.</p>',
 		} );
 		mockUseSocialMediaMessage.mockReturnValue( {
 			message: '',
@@ -273,7 +273,7 @@ describe( 'useConnectionPreviewData', () => {
 		);
 
 		expect( result.current.hyperlinks ).toEqual( [
-			{ text: 'post', href: 'https://example.com/real', occurrence: 0 },
+			{ text: 'post', href: 'https://example.com/real', occurrence: 2 },
 		] );
 	} );
 

--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/test/index.test.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/test/index.test.ts
@@ -121,6 +121,7 @@ const defaultPostData = {
  * @param opts.postId            - Post id returned to the editor-store useSelect.
  * @param opts.messageTemplate   - Saved site message template.
  * @param opts.rendered          - String returned for the rendered slice, or null to signal "no slice yet".
+ * @param opts.hyperlinks        - Source-aware hyperlinks returned with the rendered message.
  * @param opts.isLoadingRendered - Whether the rendered-messages cache slot is currently in-flight.
  */
 function mockSelectCalls(
@@ -128,15 +129,22 @@ function mockSelectCalls(
 		postId?: number;
 		messageTemplate?: string;
 		rendered?: string | null;
+		hyperlinks?: Array< { text: string; href: string; occurrence?: number } >;
 		isLoadingRendered?: boolean;
 	} = {}
 ) {
-	const { postId = 42, messageTemplate = '', rendered = null, isLoadingRendered = false } = opts;
+	const {
+		postId = 42,
+		messageTemplate = '',
+		rendered = null,
+		hyperlinks = [],
+		isLoadingRendered = false,
+	} = opts;
 	mockUseSelect
 		.mockReturnValueOnce( postId )
 		.mockReturnValueOnce( 0 )
 		.mockReturnValueOnce( messageTemplate )
-		.mockReturnValueOnce( { rendered, isLoadingRendered } );
+		.mockReturnValueOnce( { rendered, renderedHyperlinks: hyperlinks, isLoadingRendered } );
 }
 
 describe( 'useConnectionPreviewData', () => {
@@ -171,6 +179,7 @@ describe( 'useConnectionPreviewData', () => {
 
 		expect( result.current ).toEqual( {
 			...defaultPostData,
+			hyperlinks: [],
 			isLoading: false,
 			message: 'Global message',
 		} );
@@ -305,6 +314,32 @@ describe( 'useConnectionPreviewData', () => {
 		const { result } = renderHook( () => useConnectionPreviewData( connection ) );
 
 		expect( result.current.message ).toBe( 'Hello World\n\nExcerpt\n\nhttps://example.com/post' );
+	} );
+
+	it( 'uses source-aware hyperlinks returned with the rendered message', () => {
+		const hyperlinks = [ { text: 'same phrase', href: 'https://example.com/real', occurrence: 2 } ];
+		mockSelectCalls( {
+			rendered: 'same phrase | same phrase first, then same phrase',
+			hyperlinks,
+		} );
+		mockSiteHasFeature.mockReturnValue( true );
+
+		const { result } = renderHook( () => useConnectionPreviewData( createMockConnection() ) );
+
+		expect( result.current.hyperlinks ).toEqual( hyperlinks );
+	} );
+
+	it( 'does not apply post hyperlinks to a literal custom message', () => {
+		mockSelectCalls();
+		mockUseSocialPreviewPostData.mockReturnValue( {
+			...defaultPostData,
+			hyperlinks: [ { text: 'same phrase', href: 'https://example.com/unrelated' } ],
+		} );
+
+		const { result } = renderHook( () => useConnectionPreviewData( createMockConnection() ) );
+
+		expect( result.current.message ).toBe( 'Global message' );
+		expect( result.current.hyperlinks ).toEqual( [] );
 	} );
 
 	it( 'falls back to raw message when no rendered slice is available', () => {

--- a/projects/packages/publicize/_inc/hooks/use-connection-preview-data/test/index.test.ts
+++ b/projects/packages/publicize/_inc/hooks/use-connection-preview-data/test/index.test.ts
@@ -329,12 +329,12 @@ describe( 'useConnectionPreviewData', () => {
 		expect( result.current.hyperlinks ).toEqual( hyperlinks );
 	} );
 
-	it( 'does not apply post hyperlinks to a literal custom message', () => {
-		mockSelectCalls();
-		mockUseSocialPreviewPostData.mockReturnValue( {
-			...defaultPostData,
-			hyperlinks: [ { text: 'same phrase', href: 'https://example.com/unrelated' } ],
-		} );
+	it( 'never invents hyperlinks for a literal custom message', () => {
+		// A message with no {content}/{excerpt} output comes back with no
+		// hyperlinks, and the client must not fill them in from the post body —
+		// that whole-post matching is what SOCIAL-557 reported.
+		mockSelectCalls( { rendered: 'Global message', hyperlinks: [] } );
+		mockSiteHasFeature.mockReturnValue( true );
 
 		const { result } = renderHook( () => useConnectionPreviewData( createMockConnection() ) );
 

--- a/projects/packages/publicize/_inc/hooks/use-social-preview-post-data/index.ts
+++ b/projects/packages/publicize/_inc/hooks/use-social-preview-post-data/index.ts
@@ -1,4 +1,3 @@
-import { parseHyperlinks } from '@automattic/social-previews';
 import { Attachment, store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { store as editorStore } from '@wordpress/editor';
@@ -85,20 +84,11 @@ export function useSocialPreviewPostData(): PostPreviewData {
 		);
 	}, [] );
 
-	const content = useSelect( select => select( editorStore ).getEditedPostContent(), [] );
-
-	// Editor hyperlinks are read from the full serialized content (which keeps
-	// the `<a>` tags) rather than the excerpt/content attribute, which is already
-	// HTML-stripped. The DOM parser decodes entities, so the anchor text matches
-	// the decoded body text the previews render.
-	const hyperlinks = useMemo( () => parseHyperlinks( content ), [ content ] );
-
 	return useMemo( () => {
 		return {
 			...linkPreviewData,
 			excerpt,
-			hyperlinks,
 			media,
 		};
-	}, [ hyperlinks, excerpt, linkPreviewData, media ] );
+	}, [ excerpt, linkPreviewData, media ] );
 }

--- a/projects/packages/publicize/_inc/hooks/use-social-preview-post-data/test/index.test.ts
+++ b/projects/packages/publicize/_inc/hooks/use-social-preview-post-data/test/index.test.ts
@@ -118,6 +118,16 @@ describe( 'useSocialPreviewPostData', () => {
 		expect( result.current.excerpt ).toBe( 'Test excerpt' );
 	} );
 
+	it( 'does not infer preview hyperlinks from the whole post', () => {
+		mockGetEditedPostContent.mockReturnValue(
+			'<p><a href="https://example.com/unrelated">Test excerpt</a></p>'
+		);
+
+		const { result } = renderHook( () => useSocialPreviewPostData() );
+
+		expect( result.current.hyperlinks ).toBeUndefined();
+	} );
+
 	it( 'should use content before more tag when no excerpt', () => {
 		mockGetEditedPostAttribute.mockImplementation( ( attr: string ) => {
 			const attributes: Record< string, unknown > = {

--- a/projects/packages/publicize/_inc/hooks/use-social-preview-post-data/test/index.test.ts
+++ b/projects/packages/publicize/_inc/hooks/use-social-preview-post-data/test/index.test.ts
@@ -125,7 +125,9 @@ describe( 'useSocialPreviewPostData', () => {
 
 		const { result } = renderHook( () => useSocialPreviewPostData() );
 
-		expect( result.current.hyperlinks ).toBeUndefined();
+		// Post data carries no hyperlinks at all — only the server knows which
+		// anchors survive into a rendered message (SOCIAL-557).
+		expect( result.current ).not.toHaveProperty( 'hyperlinks' );
 	} );
 
 	it( 'should use content before more tag when no excerpt', () => {

--- a/projects/packages/publicize/_inc/hooks/use-social-preview-post-data/types.ts
+++ b/projects/packages/publicize/_inc/hooks/use-social-preview-post-data/types.ts
@@ -1,9 +1,12 @@
 import { LinkPreviewData } from '../use-link-preview-post-data/types';
-import type { Hyperlink } from '@automattic/social-previews';
 
+/**
+ * No `hyperlinks` here on purpose: which anchors survive into a share message
+ * depends on the rendered template, which only the server knows. They arrive
+ * per-connection on `ConnectionPreviewData` instead.
+ */
 export type PostPreviewData = LinkPreviewData & {
 	excerpt: string;
-	hyperlinks?: Array< Hyperlink >;
 	media: Array< {
 		type: string;
 		url: string;

--- a/projects/packages/publicize/_inc/social-store/resolvers.ts
+++ b/projects/packages/publicize/_inc/social-store/resolvers.ts
@@ -132,6 +132,9 @@ export function getRenderedMessages(
 				if ( typeof record.rendered_message === 'string' ) {
 					slot.rendered_message = record.rendered_message;
 				}
+				if ( Array.isArray( record.hyperlinks ) ) {
+					slot.hyperlinks = record.hyperlinks;
+				}
 				if ( record.error ) {
 					slot.error = record.error;
 				}

--- a/projects/packages/publicize/_inc/social-store/test/resolvers.test.ts
+++ b/projects/packages/publicize/_inc/social-store/test/resolvers.test.ts
@@ -1,6 +1,6 @@
 import { getScriptData, isSimpleSite } from '@automattic/jetpack-script-data';
 import apiFetch from '@wordpress/api-fetch';
-import { getTrafficReferrers } from '../resolvers';
+import { getRenderedMessages, getTrafficReferrers } from '../resolvers';
 import type { TrafficInterval } from '../types';
 
 jest.mock( '@automattic/jetpack-script-data', () => ( {
@@ -111,6 +111,28 @@ describe( 'getTrafficReferrers resolver', () => {
 
 		expect( dispatch ).toHaveBeenCalledWith(
 			expect.objectContaining( { type: 'RECEIVE_TRAFFIC_REFERRERS', interval: 30, days: {} } )
+		);
+	} );
+} );
+
+describe( 'getRenderedMessages resolver', () => {
+	it( 'stores source-aware hyperlinks with the rendered message', async () => {
+		const hyperlinks = [ { text: 'same phrase', href: 'https://example.com/real', occurrence: 1 } ];
+		mockApiFetch.mockResolvedValue( [
+			{ connection_id: 'bluesky-1', rendered_message: 'same phrase', hyperlinks },
+		] );
+		const dispatch = jest.fn();
+		const items = [ { connection_id: 'bluesky-1', message: '{content}' } ];
+
+		await getRenderedMessages( 42, items )( { dispatch } );
+
+		expect( dispatch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				type: 'RECEIVE_RENDERED_MESSAGES',
+				batch: {
+					'bluesky-1': { rendered_message: 'same phrase', hyperlinks },
+				},
+			} )
 		);
 	} );
 } );

--- a/projects/packages/publicize/_inc/social-store/types.ts
+++ b/projects/packages/publicize/_inc/social-store/types.ts
@@ -1,5 +1,6 @@
 import { ConnectionService } from '../types';
 import { AttachedMedia, MediaSourceValue, SHARING_ACTIVITY_TABS } from '../utils';
+import type { Hyperlink } from '@automattic/social-previews';
 
 export type ConnectionStatus = 'ok' | 'broken' | 'must_reauth';
 
@@ -141,6 +142,7 @@ export type RenderCount = { [ Key in 'social-preview' | 'edit-template' ]?: numb
 export type RenderedMessageBatch = {
 	[ ConnectionId: string ]: {
 		rendered_message?: string;
+		hyperlinks?: Hyperlink[];
 		error?: { code: string; message: string };
 	};
 };

--- a/projects/packages/publicize/_inc/utils/render-messages.ts
+++ b/projects/packages/publicize/_inc/utils/render-messages.ts
@@ -1,3 +1,5 @@
+import type { Hyperlink } from '@automattic/social-previews';
+
 /**
  * Render-messages types + cache-key hashing.
  *
@@ -36,6 +38,7 @@ export type RenderPostIntent = {
 export type RenderResult = {
 	connection_id: string;
 	rendered_message?: string;
+	hyperlinks?: Hyperlink[];
 	error?: { code: string; message: string };
 };
 

--- a/projects/packages/publicize/changelog/fix-social-link-provenance
+++ b/projects/packages/publicize/changelog/fix-social-link-provenance
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent unrelated editor hyperlinks from appearing in custom social messages.

--- a/projects/packages/publicize/src/rest-api/class-render-messages-controller.php
+++ b/projects/packages/publicize/src/rest-api/class-render-messages-controller.php
@@ -153,6 +153,20 @@ class Render_Messages_Controller extends Base_Controller {
 					'readonly'    => true,
 					'context'     => array( 'view', 'edit' ),
 				),
+				'hyperlinks'       => array(
+					'description' => __( 'Editor hyperlinks preserved from content or excerpt placeholders.', 'jetpack-publicize-pkg' ),
+					'type'        => 'array',
+					'readonly'    => true,
+					'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'text'       => array( 'type' => 'string' ),
+							'href'       => array( 'type' => 'string' ),
+							'occurrence' => array( 'type' => 'integer' ),
+						),
+					),
+				),
 				'error'            => array(
 					'description' => __( 'Per-item error. Present only when this item failed to render.', 'jetpack-publicize-pkg' ),
 					'type'        => 'object',

--- a/projects/packages/publicize/tests/php/Render_Messages_Controller_Test.php
+++ b/projects/packages/publicize/tests/php/Render_Messages_Controller_Test.php
@@ -232,6 +232,13 @@ class Render_Messages_Controller_Test extends TestCase {
 				array(
 					'connection_id'    => 'conn_a',
 					'rendered_message' => 'A',
+					'hyperlinks'       => array(
+						array(
+							'text'       => 'linked text',
+							'href'       => 'https://example.com/linked',
+							'occurrence' => 1,
+						),
+					),
 				),
 				array(
 					'connection_id'    => 'conn_b',
@@ -307,6 +314,13 @@ class Render_Messages_Controller_Test extends TestCase {
 					array(
 						'connection_id'    => 'conn_a',
 						'rendered_message' => 'A',
+						'hyperlinks'       => array(
+							array(
+								'text'       => 'linked text',
+								'href'       => 'https://example.com/linked',
+								'occurrence' => 1,
+							),
+						),
 					),
 					array(
 						'connection_id'    => 'conn_b',


### PR DESCRIPTION
Fixes SOCIAL-557

## Proposed changes

* Stop extracting preview hyperlinks from the full post, which could link identical text in unrelated custom messages.
* Consume source-aware `{content}`/`{excerpt}` hyperlink metadata returned by the render-messages endpoint.
* Cache each rendered message with its hyperlink metadata so pending previews keep the correct pair.

## Related product discussion/links

* SOCIAL-557

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

wpcom change: 231912-ghe-Automattic/wpcom

* Add linked text to a post, then use the same words in a literal custom social message. Confirm Bluesky and Tumblr previews leave the literal text unlinked.
* Use `{content}` or `{excerpt}` in the message template. Confirm links originating in that output remain clickable, including duplicate phrases and truncated excerpts.
* Run `pnpm --filter @automattic/jetpack-publicize exec jest --runInBand`, `jp test php packages/publicize`, and `jp phan packages/publicize`.

## Screenshots

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/gmjuhasz/investigate-social-links/before-social-preview.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/gmjuhasz/investigate-social-links/after-social-preview.png) |

Before, "Test Phrase XYZ" in the custom message is a live link to the caption's URL. After, it stays plain text.

Links that legitimately come from `{content}`/`{excerpt}` are still preserved — on the default template the same phrase renders with `"hyperlinks":[{"text":"Test Phrase XYZ","href":"…","occurrence":0}]`, because there the text really did originate in the caption.
