### PR TITLE
jest: exclude nested storybook support files from coverage

### DIFF
--- a/tools/js-tools/jest/config.coverage.js
+++ b/tools/js-tools/jest/config.coverage.js
@@ -19,7 +19,8 @@ module.exports = {
 		'!<rootDir>/**/?(*.)+(spec|test).[jt]s?(x)',
 		'!<rootDir>/**/test/*.[jt]s?(x)',
 
-		// Exclude storybook stories too.
-		'!<rootDir>/**/stories/*.[jt]s?(x)',
+		// Exclude storybook stories too, including support files nested under
+		// a stories dir (mocks, fixtures, decorators).
+		'!<rootDir>/**/stories/**/*.[jt]s?(x)',
 	],
 };


### PR DESCRIPTION
Split out of #50970 per its CODEOWNERS routing, so the monorepo change can be reviewed on its own.

## Proposed changes:

* Widen the shared jest coverage config's storybook exclusion from `stories/*.[jt]s?(x)` to `stories/**/*.[jt]s?(x)`.

The config already intends to exclude storybook files from coverage, but the current glob only matches files sitting directly in a `stories/` directory. Support files nested under it — mocks, fixtures, decorators — still land in the coverage report as permanently-uncovered lines and trip the PR coverage requirement. First hit in practice by #50970, whose `stories/mocks/register-report-mocks.ts` (433 lines of storybook mock data) was flagged as needing unit-test coverage.

## Other information:

- [ ] Have you written new tests for your changes, if applicable?
- [x] Have you checked whether your change updates the changelog? (Changes under `tools/` need no changelog entry.)

## Jetpack product discussion

None — tooling only.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions:

* On #50970's branch (which carries storybook mocks nested under `stories/mocks/`), run a package coverage pass, e.g. `cd projects/packages/premium-analytics && COVERAGE_DIR=/tmp/cov pnpm test-coverage`.
* `stories/mocks/*` files no longer appear in `coverage-final.json`; files directly in `stories/` remain excluded as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
