### PR TITLE
Agents Manager: Address code review follow-ups from #50951

### DIFF
--- a/projects/packages/agents-manager/changelog/update-agents-manager-docking-gate-review-followups
+++ b/projects/packages/agents-manager/changelog/update-agents-manager-docking-gate-review-followups
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Reword an unreleased changelog entry and fix a test assertion message; no user-facing change.
+
+

--- a/projects/packages/agents-manager/changelog/update-agents-manager-sidebar-docking-height-gate
+++ b/projects/packages/agents-manager/changelog/update-agents-manager-sidebar-docking-height-gate
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Sidebar docking: remove the viewport-height gate. The simplified wp-admin layout keeps the admin menu in normal flow, so a tall menu no longer prevents docking.
+Dock the AI sidebar on shorter screens instead of floating it over the page content.

--- a/projects/packages/agents-manager/tests/php/Sidebar_Open_Preservation_Test.php
+++ b/projects/packages/agents-manager/tests/php/Sidebar_Open_Preservation_Test.php
@@ -230,7 +230,7 @@ class Sidebar_Open_Preservation_Test extends \WorDBless\BaseTestCase {
 	public function test_constructor_registers_docking_gate_script_hook() {
 		$this->assertNotFalse(
 			has_action( 'in_admin_header', array( $this->preservation, 'print_sidebar_docking_gate_script' ) ),
-			'The docking gate script must be hooked into the admin body.'
+			'The docking gate script must be hooked into the admin header.'
 		);
 	}
 


### PR DESCRIPTION
Fixes # (N/A — follow-up to #50951)

## Proposed changes

Addresses the code review comments left on #50951 after it merged:

* Reword the docking-gate changelog entry to describe the user-visible effect ("Dock the AI sidebar on shorter screens instead of floating it over the page content.") instead of the implementation details. The entry from #50951 has not shipped yet, so this lands before the next release.
* Fix a test assertion message in `Sidebar_Open_Preservation_Test.php` that said the docking-gate script is hooked into the "admin body" — the hook under test is `in_admin_header`, so the message now says "admin header".

## Related product discussion/links

* Follow-up to #50951 (review comments: https://github.com/Automattic/jetpack/pull/50951#discussion_r3703999777 and https://github.com/Automattic/jetpack/pull/50951#discussion_r3703999845)
* AI-1089

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Docs/wording only — no behavior changes.

* Confirm `projects/packages/agents-manager/changelog/update-agents-manager-sidebar-docking-height-gate` now reads as a user-facing summary.
* Run `jp test php packages/agents-manager` and confirm the suite passes (144 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
