### PR TITLE
Help Center: Support empty asset dependencies

### DIFF
--- a/projects/packages/help-center/CHANGELOG.md
+++ b/projects/packages/help-center/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2026-08-03
+### Fixed
+- Help Center: Support empty asset dependency lists.
+
 ## [0.3.1] - 2026-07-31
 ### Fixed
 - Help Center: Forward anonymous chat session data to WordPress.com.
@@ -22,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow consumers to provide the WordPress.com authentication state and request client used by the Help Center.
 - Initial version, extracted from Jetpack MU WPCOM to its own package for external consumption.
 
+[0.3.2]: https://github.com/Automattic/jetpack-help-center/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/Automattic/jetpack-help-center/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Automattic/jetpack-help-center/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Automattic/jetpack-help-center/compare/v0.1.0...v0.2.0

--- a/projects/packages/help-center/src/class-help-center.php
+++ b/projects/packages/help-center/src/class-help-center.php
@@ -18,7 +18,7 @@ class Help_Center {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.3.1';
+	const PACKAGE_VERSION = '0.3.2';
 
 	/**
 	 * Class instance.
@@ -678,7 +678,7 @@ class Help_Center {
 	private static function get_assets_json( $filepath ) {
 		$accessible_directly = file_exists( ABSPATH . '/' . $filepath );
 		if ( $accessible_directly ) {
-			return json_decode( file_get_contents( ABSPATH . $filepath ), true );
+			return json_decode( file_get_contents( ABSPATH . '/' . $filepath ), true );
 		}
 		$request = wp_remote_get( 'https://' . $filepath );
 		if ( is_wp_error( $request ) ) {
@@ -700,9 +700,9 @@ class Help_Center {
 		$cache_key  = 'help-center-asset-' . $variant . '.asset.json';
 		$asset_file = get_transient( $cache_key );
 
-		if ( ! $asset_file ) {
+		if ( false === $asset_file ) {
 			$asset_file = self::get_assets_json( 'widgets.wp.com/help-center/help-center-' . $variant . '.asset.json' );
-			if ( ! $asset_file ) {
+			if ( null === $asset_file ) {
 				return;
 			}
 			set_transient( $cache_key, $asset_file, HOUR_IN_SECONDS );
@@ -782,9 +782,9 @@ class Help_Center {
 		$cache_key  = 'help-center-asset-' . $variant . '.asset.json';
 		$asset_file = get_transient( $cache_key );
 
-		if ( ! $asset_file ) {
+		if ( false === $asset_file ) {
 			$asset_file = self::get_assets_json( 'widgets.wp.com/help-center/help-center-' . $variant . '.asset.json' );
-			if ( ! $asset_file ) {
+			if ( null === $asset_file ) {
 				return;
 			}
 			set_transient( $cache_key, $asset_file, HOUR_IN_SECONDS );


### PR DESCRIPTION
Fixes #

## Proposed changes

* Treat only a missing cache entry as a cache miss, allowing an asset manifest with an empty dependency list to be cached and used.
* Return early only when loading the manifest fails.
* Correct the local asset manifest path.
* Prepare `automattic/jetpack-help-center` 0.3.2 in the same PR.

## Related product discussion/links

* N/A

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run `CI=1 jp test php packages/help-center`.