### PR TITLE
Inline Search: Insert corrected-query notice as text

### DIFF
--- a/projects/packages/search/changelog/fix-inline-corrected-query-xss
+++ b/projects/packages/search/changelog/fix-inline-corrected-query-xss
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Inline Search: Insert the corrected-query notice as text so search terms are not parsed as HTML.

--- a/projects/packages/search/changelog/fix-search-is-search-block-render
+++ b/projects/packages/search/changelog/fix-search-is-search-block-render
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Search Blocks: Fix `is_search()` being called before the main query runs during block render, which caused a `_doing_it_wrong()` notice.

--- a/projects/packages/search/src/inline-search/class-inline-search-correction.php
+++ b/projects/packages/search/src/inline-search/class-inline-search-correction.php
@@ -37,8 +37,7 @@ class Inline_Search_Correction {
 	 * @since 0.48.0
 	 */
 	public function enqueue_styles() {
-		$corrected_query_html = $this->get_corrected_query_html();
-		if ( empty( $corrected_query_html ) ) {
+		if ( '' === $this->get_corrected_query_message() ) {
 			return;
 		}
 
@@ -49,11 +48,15 @@ class Inline_Search_Correction {
 	/**
 	 * Register and configure the JavaScript for displaying the corrected query notice.
 	 *
+	 * Passes a plain-text message (not HTML). The front-end builds the notice with
+	 * textContent so user-controlled query text is never parsed as HTML.
+	 * Avoids wp_localize_script(), which html_entity_decodes values (core #25280).
+	 *
 	 * @since 0.48.0
 	 */
 	public function register_corrected_query_script() {
-		$corrected_query_html = $this->get_corrected_query_html();
-		if ( empty( $corrected_query_html ) ) {
+		$message = $this->get_corrected_query_message();
+		if ( '' === $message ) {
 			return;
 		}
 
@@ -70,16 +73,17 @@ class Inline_Search_Correction {
 			)
 		);
 
-		wp_localize_script(
+		// Use wp_add_inline_script instead of wp_localize_script, see https://core.trac.wordpress.org/ticket/25280.
+		wp_add_inline_script(
 			$handle,
-			'JetpackSearchCorrectedQuery',
-			array(
-				'html'      => $corrected_query_html,
-				'selectors' => $this->get_title_selectors(),
-				'i18n'      => array(
-					'error' => esc_html__( 'Error displaying search correction', 'jetpack-search-pkg' ),
+			'window.JetpackSearchCorrectedQuery=' . wp_json_encode(
+				array(
+					'message'   => $message,
+					'selectors' => $this->get_title_selectors(),
 				),
-			)
+				JSON_HEX_TAG | JSON_HEX_AMP | JSON_UNESCAPED_SLASHES
+			) . ';',
+			'before'
 		);
 	}
 
@@ -159,11 +163,14 @@ class Inline_Search_Correction {
 	}
 
 	/**
-	 * Generate the HTML for the corrected query notice.
+	 * Generate the plain-text message for the corrected query notice.
 	 *
-	 * @return string The HTML for the corrected query notice or empty string if none.
+	 * Returns text only — never HTML. The front-end must insert this via
+	 * textContent (or equivalent), not insertAdjacentHTML / innerHTML.
+	 *
+	 * @return string The notice message, or empty string if none.
 	 */
-	private function get_corrected_query_html() {
+	public function get_corrected_query_message() {
 		global $wp_query;
 		$original_query = $wp_query->get( 's' );
 		$search_result  = $this->get_search_result();
@@ -172,15 +179,10 @@ class Inline_Search_Correction {
 			return '';
 		}
 
-		$message = sprintf(
-			/* translators: %s: Original search term the user entered */
-			esc_html__( 'No results for "%s"', 'jetpack-search-pkg' ),
-			esc_html( $original_query )
-		);
-
 		return sprintf(
-			'<p class="jetpack-search-corrected-query">%s</p>',
-			$message
+			/* translators: %s: Original search term the user entered */
+			__( 'No results for "%s"', 'jetpack-search-pkg' ),
+			$original_query
 		);
 	}
 

--- a/projects/packages/search/src/inline-search/js/corrected-query.js
+++ b/projects/packages/search/src/inline-search/js/corrected-query.js
@@ -1,17 +1,29 @@
 /**
- * Script to display corrected query notice after search titles.
+ * Display the corrected query notice after a search title.
+ *
+ * Builds the notice with DOM APIs so the original query is never parsed as HTML.
+ * Passing escaped HTML through wp_localize_script() (which html_entity_decodes)
+ * and then insertAdjacentHTML() was a reflected XSS vector.
+ *
+ * @param {object} [config] - Localized config; defaults to window.JetpackSearchCorrectedQuery.
+ * @return {void}
  */
-document.addEventListener( 'DOMContentLoaded', () => {
-	if ( ! window.JetpackSearchCorrectedQuery?.html ) {
+export function displayCorrectedQuery( config = window.JetpackSearchCorrectedQuery ) {
+	if ( ! config?.message || ! Array.isArray( config.selectors ) || ! config.selectors.length ) {
 		return;
 	}
 
-	const { selectors, html } = window.JetpackSearchCorrectedQuery;
-	const titleElement = document.querySelector( selectors.join( ', ' ) );
-
+	const titleElement = document.querySelector( config.selectors.join( ', ' ) );
 	if ( ! titleElement ) {
 		return;
 	}
 
-	titleElement.insertAdjacentHTML( 'afterend', html );
+	const notice = document.createElement( 'p' );
+	notice.className = 'jetpack-search-corrected-query';
+	notice.textContent = config.message;
+	titleElement.insertAdjacentElement( 'afterend', notice );
+}
+
+document.addEventListener( 'DOMContentLoaded', () => {
+	displayCorrectedQuery();
 } );

--- a/projects/packages/search/src/inline-search/js/test/corrected-query.test.js
+++ b/projects/packages/search/src/inline-search/js/test/corrected-query.test.js
@@ -1,0 +1,53 @@
+import { displayCorrectedQuery } from '../corrected-query';
+
+describe( 'displayCorrectedQuery', () => {
+	beforeEach( () => {
+		document.body.innerHTML = '<h1 class="page-title">Search results for: hello</h1>';
+	} );
+
+	afterEach( () => {
+		document.body.innerHTML = '';
+		delete window.JetpackSearchCorrectedQuery;
+	} );
+
+	test( 'inserts a text notice after the title', () => {
+		displayCorrectedQuery( {
+			message: 'No results for "typo"',
+			selectors: [ '.page-title' ],
+		} );
+
+		const notice = document.querySelector( '.jetpack-search-corrected-query' );
+		expect( notice ).not.toBeNull();
+		expect( notice.tagName ).toBe( 'P' );
+		expect( notice ).toHaveTextContent( 'No results for "typo"' );
+		expect( document.querySelector( '.page-title' ).nextElementSibling ).toBe( notice );
+	} );
+
+	test( 'does not parse HTML from a reflected XSS search query', () => {
+		const xssPayload = '<img src=x onerror=alert(1)>';
+		displayCorrectedQuery( {
+			message: `No results for "${ xssPayload }"`,
+			selectors: [ '.page-title' ],
+		} );
+
+		const notice = document.querySelector( '.jetpack-search-corrected-query' );
+		expect( notice ).not.toBeNull();
+		expect( notice.querySelectorAll( 'img' ) ).toHaveLength( 0 );
+		expect( notice.children ).toHaveLength( 0 );
+		expect( notice ).toHaveTextContent( new RegExp( xssPayload ) );
+		expect( notice.innerHTML ).toBe( 'No results for "&lt;img src=x onerror=alert(1)&gt;"' );
+	} );
+
+	test( 'does nothing when message is missing', () => {
+		displayCorrectedQuery( { selectors: [ '.page-title' ] } );
+		expect( document.querySelector( '.jetpack-search-corrected-query' ) ).toBeNull();
+	} );
+
+	test( 'does nothing when no title selector matches', () => {
+		displayCorrectedQuery( {
+			message: 'No results for "typo"',
+			selectors: [ '.missing-title' ],
+		} );
+		expect( document.querySelector( '.jetpack-search-corrected-query' ) ).toBeNull();
+	} );
+} );

--- a/projects/packages/search/src/inline-search/js/test/corrected-query.test.js
+++ b/projects/packages/search/src/inline-search/js/test/corrected-query.test.js
@@ -34,7 +34,7 @@ describe( 'displayCorrectedQuery', () => {
 		expect( notice ).not.toBeNull();
 		expect( notice.querySelectorAll( 'img' ) ).toHaveLength( 0 );
 		expect( notice.children ).toHaveLength( 0 );
-		expect( notice ).toHaveTextContent( new RegExp( xssPayload ) );
+		expect( notice ).toHaveTextContent( xssPayload );
 		expect( notice.innerHTML ).toBe( 'No results for "&lt;img src=x onerror=alert(1)&gt;"' );
 	} );
 

--- a/projects/packages/search/src/search-blocks/class-search-blocks.php
+++ b/projects/packages/search/src/search-blocks/class-search-blocks.php
@@ -631,10 +631,18 @@ class Search_Blocks {
 	 * URL param key the inline search experience uses for the current request.
 	 * On the WP search route `s`; elsewhere `q` (see `NON_SEARCH_QUERY_PARAM`).
 	 *
+	 * Uses direct property access on `$wp_query` rather than the `is_search()`
+	 * global function, because the function calls `_doing_it_wrong()` when
+	 * invoked before the query has finished running (e.g. during block render).
+	 *
 	 * @return string
 	 */
 	public static function get_search_param_name(): string {
-		return function_exists( 'is_search' ) && is_search() ? 's' : self::NON_SEARCH_QUERY_PARAM;
+		global $wp_query;
+		if ( isset( $wp_query ) && ! empty( $wp_query->is_search ) ) {
+			return 's';
+		}
+		return self::NON_SEARCH_QUERY_PARAM;
 	}
 
 	/**

--- a/projects/packages/search/tests/php/Inline_Search_Correction_Test.php
+++ b/projects/packages/search/tests/php/Inline_Search_Correction_Test.php
@@ -1,0 +1,154 @@
+<?php
+/**
+ * Tests for Inline_Search_Correction.
+ *
+ * @package automattic/jetpack-search
+ */
+
+namespace Automattic\Jetpack\Search;
+
+use WorDBless\BaseTestCase;
+
+/**
+ * Inline_Search_Correction test cases.
+ */
+class Inline_Search_Correction_Test extends BaseTestCase {
+	/**
+	 * Correction instance under test.
+	 *
+	 * @var Inline_Search_Correction
+	 */
+	private $correction;
+
+	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->correction = new Inline_Search_Correction();
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		global $wp_query;
+		$wp_query = null;
+
+		// Inline_Search::instance() is a process-wide singleton; clear it so later
+		// tests don't see this fixture's search_result / pre_get_posts hooks.
+		$instance_prop = new \ReflectionProperty( Inline_Search::class, 'instance' );
+		$instance_prop->setAccessible( true );
+		$instance = $instance_prop->getValue();
+		if ( $instance ) {
+			$correction_prop = new \ReflectionProperty( Inline_Search::class, 'correction' );
+			$correction_prop->setAccessible( true );
+			$correction = $correction_prop->getValue( $instance );
+			if ( $correction ) {
+				remove_action( 'pre_get_posts', array( $correction, 'setup_corrected_query_hooks' ) );
+			}
+		}
+		$instance_prop->setValue( null, null );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Seed Inline_Search's cached API response and the main query's `s` var.
+	 *
+	 * @param string $original_query Original search string from ?s=.
+	 * @param array  $search_result  Mock Instant Search API response.
+	 */
+	private function seed_search_state( $original_query, $search_result ) {
+		global $wp_query;
+
+		$wp_query = new \WP_Query();
+		$wp_query->set( 's', $original_query );
+
+		$search     = Inline_Search::instance( 1 );
+		$reflection = new \ReflectionProperty( Classic_Search::class, 'search_result' );
+		$reflection->setAccessible( true );
+		$reflection->setValue( $search, $search_result );
+	}
+
+	/**
+	 * Corrected-query payload used by the notice.
+	 *
+	 * @return array
+	 */
+	private function corrected_result_fixture() {
+		return array(
+			'corrected_query' => 'hello',
+			'results'         => array(
+				array(
+					'fields' => array( 'post_id' => 1 ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Message is plain text and includes the original query literally.
+	 */
+	public function test_get_corrected_query_message_includes_original_query() {
+		$this->seed_search_state( 'typo', $this->corrected_result_fixture() );
+
+		$message = $this->correction->get_corrected_query_message();
+
+		$this->assertSame( 'No results for "typo"', $message );
+	}
+
+	/**
+	 * XSS payload in ?s= must remain literal text in the localized message —
+	 * never HTML-escaped entities that wp_localize_script would decode, and
+	 * never pre-built markup for insertAdjacentHTML.
+	 */
+	public function test_get_corrected_query_message_keeps_xss_payload_as_plain_text() {
+		$xss_payload = '<img src=x onerror=alert(1)>';
+		$this->seed_search_state( $xss_payload, $this->corrected_result_fixture() );
+
+		$message = $this->correction->get_corrected_query_message();
+
+		$this->assertStringContainsString( $xss_payload, $message );
+		$this->assertStringNotContainsString( '&lt;', $message );
+		$this->assertStringNotContainsString( '<p', $message );
+		$this->assertStringNotContainsString( 'jetpack-search-corrected-query', $message );
+	}
+
+	/**
+	 * JSON_HEX_TAG encoding must escape angle brackets for safe script embedding.
+	 */
+	public function test_corrected_query_json_escapes_angle_brackets_for_script_context() {
+		$xss_payload = '<img src=x onerror=alert(1)>';
+		$this->seed_search_state( $xss_payload, $this->corrected_result_fixture() );
+
+		$message = $this->correction->get_corrected_query_message();
+		$json    = wp_json_encode(
+			array( 'message' => $message ),
+			JSON_HEX_TAG | JSON_HEX_AMP | JSON_UNESCAPED_SLASHES
+		);
+
+		$this->assertIsString( $json );
+		$this->assertStringNotContainsString( '<', $json );
+		$this->assertStringContainsString( '\u003C', $json );
+	}
+
+	/**
+	 * No notice when the API did not return a corrected query.
+	 */
+	public function test_get_corrected_query_message_empty_without_correction() {
+		$this->seed_search_state(
+			'hello',
+			array(
+				'corrected_query' => false,
+				'results'         => array(
+					array(
+						'fields' => array( 'post_id' => 1 ),
+					),
+				),
+			)
+		);
+
+		$this->assertSame( '', $this->correction->get_corrected_query_message() );
+	}
+}

--- a/projects/packages/search/tests/php/Inline_Search_Correction_Test.php
+++ b/projects/packages/search/tests/php/Inline_Search_Correction_Test.php
@@ -38,11 +38,17 @@ class Inline_Search_Correction_Test extends BaseTestCase {
 		// Inline_Search::instance() is a process-wide singleton; clear it so later
 		// tests don't see this fixture's search_result / pre_get_posts hooks.
 		$instance_prop = new \ReflectionProperty( Inline_Search::class, 'instance' );
-		$instance_prop->setAccessible( true );
+		// setAccessible() became a no-op in PHP 8.1 and was deprecated in 8.5;
+		// only call it on older versions where it is still required.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$instance_prop->setAccessible( true );
+		}
 		$instance = $instance_prop->getValue();
 		if ( $instance ) {
 			$correction_prop = new \ReflectionProperty( Inline_Search::class, 'correction' );
-			$correction_prop->setAccessible( true );
+			if ( PHP_VERSION_ID < 80100 ) {
+				$correction_prop->setAccessible( true );
+			}
 			$correction = $correction_prop->getValue( $instance );
 			if ( $correction ) {
 				remove_action( 'pre_get_posts', array( $correction, 'setup_corrected_query_hooks' ) );
@@ -67,7 +73,11 @@ class Inline_Search_Correction_Test extends BaseTestCase {
 
 		$search     = Inline_Search::instance( 1 );
 		$reflection = new \ReflectionProperty( Classic_Search::class, 'search_result' );
-		$reflection->setAccessible( true );
+		// setAccessible() became a no-op in PHP 8.1 and was deprecated in 8.5;
+		// only call it on older versions where it is still required.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$reflection->setAccessible( true );
+		}
 		$reflection->setValue( $search, $search_result );
 	}
 


### PR DESCRIPTION
## Proposed changes
* Insert the Inline Search corrected-query (did-you-mean) notice via `textContent` instead of `insertAdjacentHTML`.
* Pass a plain-text message with `wp_add_inline_script` instead of HTML through `wp_localize_script` (avoids `html_entity_decode` undoing escaping — core #25280).
* Add PHP and JS coverage so markup in the search query remains literal text in the notice.

## Related product discussion/links
* Linear: T51OPS-357

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* On a site with Jetpack Search enabled and Instant Search **off** (theme / inline search), run a misspelled query that returns a corrected-query notice.
* Confirm the "No results for ..." notice still appears under the search title and reads correctly for normal queries.
* Confirm a query containing HTML markup (for example angle brackets) shows as plain text in that notice and does not create extra DOM nodes inside it.
* In `projects/packages/search`: `composer phpunit -- --filter=Inline_Search_Correction_Test`
* In `projects/packages/search`: `pnpm test-scripts -- src/inline-search/js/test/corrected-query.test.js`
