### PR TITLE
Site Health: Make the WordPress.com connection test readable and actionable

### DIFF
--- a/projects/packages/connection/changelog/site-health-blocked-request-copy
+++ b/projects/packages/connection/changelog/site-health-blocked-request-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Site Health: Clarify the guidance shown when a firewall blocks WordPress.com requests, and link to the Jetpack IP allowlist guide.

--- a/projects/packages/connection/changelog/site-health-blocked-request-copy
+++ b/projects/packages/connection/changelog/site-health-blocked-request-copy
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Site Health: Clarify the guidance shown when a firewall blocks WordPress.com requests, and link to the Jetpack IP allowlist guide.
+Site Health: Clarify the descriptions shown by the connection tests, link to the Jetpack IP allowlist guide when a firewall blocks WordPress.com requests, and explain why a test was skipped.

--- a/projects/packages/connection/changelog/site-health-wpcom-connection-test-label
+++ b/projects/packages/connection/changelog/site-health-wpcom-connection-test-label
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Site Health: Improve the label shown for the WordPress.com connection test.
+Site Health: Give every connection test a readable heading instead of one derived from its internal name.

--- a/projects/packages/connection/changelog/site-health-wpcom-connection-test-label
+++ b/projects/packages/connection/changelog/site-health-wpcom-connection-test-label
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Site Health: Improve the label shown for the WordPress.com connection test.

--- a/projects/packages/connection/src/class-site-health.php
+++ b/projects/packages/connection/src/class-site-health.php
@@ -90,6 +90,67 @@ class Site_Health {
 	}
 
 	/**
+	 * Human-readable headings for the built-in connection tests.
+	 *
+	 * Used when a test result carries no label of its own, so Site Health does not
+	 * derive a title from the method name (e.g. "Wpcom Connection Test").
+	 *
+	 * A heading here has to read sensibly for a pass, a fail, and a skip alike, so
+	 * these name what was tested rather than stating an outcome. Results that want
+	 * to state an outcome set their own label, which takes precedence.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return array Map of test name => label.
+	 */
+	private static function get_default_test_labels() {
+		return array(
+			'test__blog_token_if_exists'           => __( 'Site token', 'jetpack-connection' ),
+			'test__check_if_connected'             => __( 'WordPress.com connection', 'jetpack-connection' ),
+			'test__master_user_exists_on_site'     => __( 'Connection owner', 'jetpack-connection' ),
+			'test__master_user_can_manage_options' => __( 'Connection owner permissions', 'jetpack-connection' ),
+			'test__outbound_http'                  => __( 'Outbound HTTP requests', 'jetpack-connection' ),
+			'test__outbound_https'                 => __( 'Outbound HTTPS requests', 'jetpack-connection' ),
+			'test__identity_crisis'                => __( 'Site address', 'jetpack-connection' ),
+			'test__connection_token_health'        => __( 'Connection tokens', 'jetpack-connection' ),
+			'test__wpcom_connection_test'          => __( 'Requests from WordPress.com', 'jetpack-connection' ),
+			// Only registered when the jetpack_debugger_run_self_test filter returns true.
+			'test__wpcom_self_test'                => __( 'Site XML-RPC endpoint', 'jetpack-connection' ),
+			'test__server_port_value'              => __( 'Server port', 'jetpack-connection' ),
+			'test__xml_parser_available'           => __( 'PHP XML support', 'jetpack-connection' ),
+		);
+	}
+
+	/**
+	 * Get the heading for a test whose result carries no label of its own.
+	 *
+	 * Falls back to deriving a title from the method name, which is the last resort
+	 * for tests other plugins register through the jetpack_connection_tests_loaded
+	 * action and which therefore cannot appear in the map.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $test_name Test name, e.g. "test__blog_token_if_exists".
+	 *
+	 * @return string The heading to display.
+	 */
+	private static function get_default_test_label( $test_name ) {
+		$labels = self::get_default_test_labels();
+
+		if ( isset( $labels[ $test_name ] ) ) {
+			return $labels[ $test_name ];
+		}
+
+		return ucwords(
+			str_replace(
+				'_',
+				' ',
+				str_replace( 'test__', '', $test_name )
+			)
+		);
+	}
+
+	/**
 	 * Create a closure for a Site Health direct test.
 	 *
 	 * @since 8.5.0
@@ -100,21 +161,15 @@ class Site_Health {
 	 * @return callable The Site Health test callback.
 	 */
 	private static function make_site_health_callback( $test, $cxn_tests ) {
-		return function () use ( $test, $cxn_tests ) {
+		$default_label = self::get_default_test_label( $test['name'] );
+
+		return function () use ( $test, $cxn_tests, $default_label ) {
 			$results = $cxn_tests->run_test( $test['name'] );
 			if ( is_wp_error( $results ) ) {
 				return;
 			}
 
-			$label = $results['label'] ?
-				$results['label'] :
-				ucwords(
-					str_replace(
-						'_',
-						' ',
-						str_replace( 'test__', '', $test['name'] )
-					)
-				);
+			$label = $results['label'] ? $results['label'] : $default_label;
 
 			if ( $results['long_description'] ) {
 				$description = $results['long_description'];

--- a/projects/packages/connection/src/class-site-health.php
+++ b/projects/packages/connection/src/class-site-health.php
@@ -105,19 +105,19 @@ class Site_Health {
 	 */
 	private static function get_default_test_labels() {
 		return array(
-			'test__blog_token_if_exists'           => __( 'Site token', 'jetpack-connection' ),
-			'test__check_if_connected'             => __( 'WordPress.com connection', 'jetpack-connection' ),
-			'test__master_user_exists_on_site'     => __( 'Connection owner', 'jetpack-connection' ),
-			'test__master_user_can_manage_options' => __( 'Connection owner permissions', 'jetpack-connection' ),
-			'test__outbound_http'                  => __( 'Outbound HTTP requests', 'jetpack-connection' ),
-			'test__outbound_https'                 => __( 'Outbound HTTPS requests', 'jetpack-connection' ),
-			'test__identity_crisis'                => __( 'Site address', 'jetpack-connection' ),
-			'test__connection_token_health'        => __( 'Connection tokens', 'jetpack-connection' ),
+			'test__blog_token_if_exists'           => __( 'Blog Token', 'jetpack-connection' ),
+			'test__check_if_connected'             => __( 'WordPress.com Connection', 'jetpack-connection' ),
+			'test__master_user_exists_on_site'     => __( 'Connection Owner', 'jetpack-connection' ),
+			'test__master_user_can_manage_options' => __( 'Connection Owner Permissions', 'jetpack-connection' ),
+			'test__outbound_http'                  => __( 'Outbound HTTP Requests', 'jetpack-connection' ),
+			'test__outbound_https'                 => __( 'Outbound HTTPS Requests', 'jetpack-connection' ),
+			'test__identity_crisis'                => __( 'Site Address', 'jetpack-connection' ),
+			'test__connection_token_health'        => __( 'Connection Tokens', 'jetpack-connection' ),
 			'test__wpcom_connection_test'          => __( 'Requests from WordPress.com', 'jetpack-connection' ),
 			// Only registered when the jetpack_debugger_run_self_test filter returns true.
-			'test__wpcom_self_test'                => __( 'Site XML-RPC endpoint', 'jetpack-connection' ),
-			'test__server_port_value'              => __( 'Server port', 'jetpack-connection' ),
-			'test__xml_parser_available'           => __( 'PHP XML support', 'jetpack-connection' ),
+			'test__wpcom_self_test'                => __( 'Site XML-RPC Endpoint', 'jetpack-connection' ),
+			'test__server_port_value'              => __( 'Server Port', 'jetpack-connection' ),
+			'test__xml_parser_available'           => __( 'PHP XML Support', 'jetpack-connection' ),
 		);
 	}
 

--- a/projects/packages/connection/src/health/class-connection-health-test-base.php
+++ b/projects/packages/connection/src/health/class-connection-health-test-base.php
@@ -421,6 +421,18 @@ class Connection_Health_Test_Base {
 	}
 
 	/**
+	 * Returns the translated text describing what a healthy connection provides.
+	 *
+	 * Shared by the passing and failing connection descriptions so the two cannot
+	 * drift apart.
+	 *
+	 * @return string
+	 */
+	protected static function helper_get_healthy_connection_text() {
+		return __( 'A healthy Jetpack Connection allows connected plugins (such as Jetpack and WooCommerce) to provide features like Stats, Site Security, and Payments to your site.', 'jetpack-connection' );
+	}
+
+	/**
 	 * Gets translated reconnect long description.
 	 *
 	 * @param string $connection_error  The connection specific error.
@@ -432,7 +444,7 @@ class Connection_Health_Test_Base {
 		return sprintf(
 			'<p>%1$s</p>' .
 			'<p><span class="dashicons fail"><span class="screen-reader-text">%2$s</span></span> %3$s</p><p><strong>%4$s</strong></p>',
-			__( 'A healthy Jetpack Connection allows connected plugins (such as Jetpack and WooCommerce) to provide features like Stats, Site Security, and Payments.', 'jetpack-connection' ),
+			self::helper_get_healthy_connection_text(),
 			/* translators: screen reader text indicating a test failed */
 			__( 'Error', 'jetpack-connection' ),
 			$connection_error,

--- a/projects/packages/connection/src/health/class-connection-health-tests.php
+++ b/projects/packages/connection/src/health/class-connection-health-tests.php
@@ -111,7 +111,7 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 					'long_description' => sprintf(
 						'<p>%1$s</p>' .
 						'<p><span class="dashicons pass"><span class="screen-reader-text">%2$s</span></span> %3$s</p>',
-						__( 'A healthy Jetpack Connection allows connected plugins (such as Jetpack and WooCommerce) to provide features like Stats, Site Security, and Payments.', 'jetpack-connection' ),
+						__( 'A healthy Jetpack Connection allows connected plugins (such as Jetpack and WooCommerce) to provide Jetpack features to your site.', 'jetpack-connection' ),
 						/* translators: Screen reader text indicating a test has passed */
 						__( 'Passed', 'jetpack-connection' ),
 						__( 'Your site is connected to WordPress.com.', 'jetpack-connection' )

--- a/projects/packages/connection/src/health/class-connection-health-tests.php
+++ b/projects/packages/connection/src/health/class-connection-health-tests.php
@@ -440,12 +440,22 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 	private function run_wpcom_connection_test() {
 		$name = 'test__wpcom_connection_test';
 
-		$status = new Status();
-		if ( ! ( new Manager() )->is_connected() || $status->is_offline_mode() || $status->in_safe_mode() || ! $this->pass ) {
+		$status      = new Status();
+		$skip_reason = '';
+
+		if ( $status->is_offline_mode() ) {
+			$skip_reason = __( 'Your site is in Offline Mode, so this test was skipped.', 'jetpack-connection' );
+		} elseif ( $status->in_safe_mode() ) {
+			$skip_reason = __( 'Your site is in Safe Mode, so this test was skipped.', 'jetpack-connection' );
+		} elseif ( ! ( new Manager() )->is_connected() || ! $this->pass ) {
+			$skip_reason = __( 'Your site is not communicating with WordPress.com, so this test was skipped.', 'jetpack-connection' );
+		}
+
+		if ( $skip_reason ) {
 			return self::skipped_test(
 				array(
 					'name'              => $name,
-					'short_description' => __( 'Your site is not communicating with WordPress.com, so this test was skipped.', 'jetpack-connection' ),
+					'short_description' => $skip_reason,
 				)
 			);
 		}

--- a/projects/packages/connection/src/health/class-connection-health-tests.php
+++ b/projects/packages/connection/src/health/class-connection-health-tests.php
@@ -582,7 +582,7 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 
 		$recommendation = sprintf(
 			/* translators: %1$s opens a link to Jetpack's IP allowlist documentation, %2$s closes it (it also carries hidden text noting the link opens in a new tab). Place them around the phrase that should be linked. */
-			__( 'Jetpack uses your site\'s xmlrpc.php file to securely communicate with WordPress.com. Ask your host or security provider to %1$sallowlist Jetpack\'s IPs%2$s — reconnecting will not resolve this. If you need further help, contact Jetpack support.', 'jetpack-connection' ),
+			__( 'Jetpack Connection uses your site\'s xmlrpc.php file to securely communicate with WordPress.com. Ask your host or security provider to %1$sallowlist Jetpack Connection IPs%2$s — reconnecting will not resolve this. If you need further help, contact Jetpack support.', 'jetpack-connection' ),
 			'<a href="' . esc_url( Redirect::get_url( 'https://jetpack.com/support/how-to-add-jetpack-ips-allowlist/' ) ) . '" target="_blank" rel="noopener noreferrer">',
 			sprintf(
 				/* translators: accessibility text */

--- a/projects/packages/connection/src/health/class-connection-health-tests.php
+++ b/projects/packages/connection/src/health/class-connection-health-tests.php
@@ -450,8 +450,10 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 			$skip_reason = __( 'Your site is in Offline Mode, so this test was skipped.', 'jetpack-connection' );
 		} elseif ( $status->in_safe_mode() ) {
 			$skip_reason = __( 'Your site is in Safe Mode, so this test was skipped.', 'jetpack-connection' );
-		} elseif ( ! ( new Manager() )->is_connected() || ! $this->pass ) {
+		} elseif ( ! ( new Manager() )->is_connected() ) {
 			$skip_reason = __( 'Your site is not communicating with WordPress.com, so this test was skipped.', 'jetpack-connection' );
+		} elseif ( ! $this->pass ) {
+			$skip_reason = __( 'A previous connection health test failed, so this test was skipped.', 'jetpack-connection' );
 		}
 
 		if ( $skip_reason ) {

--- a/projects/packages/connection/src/health/class-connection-health-tests.php
+++ b/projects/packages/connection/src/health/class-connection-health-tests.php
@@ -111,7 +111,7 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 					'long_description' => sprintf(
 						'<p>%1$s</p>' .
 						'<p><span class="dashicons pass"><span class="screen-reader-text">%2$s</span></span> %3$s</p>',
-						__( 'A healthy Jetpack Connection allows connected plugins (such as Jetpack and WooCommerce) to provide Jetpack features to your site.', 'jetpack-connection' ),
+						self::helper_get_healthy_connection_text(),
 						/* translators: Screen reader text indicating a test has passed */
 						__( 'Passed', 'jetpack-connection' ),
 						__( 'Your site is connected to WordPress.com.', 'jetpack-connection' )
@@ -477,7 +477,11 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 			return self::failing_test(
 				array(
 					'name'              => $name,
-					'short_description' => __( 'Connection test failed (empty response body)', 'jetpack-connection' ) . wp_remote_retrieve_response_code( $response ),
+					'short_description' => sprintf(
+						/* translators: %s is the HTTP status code returned by WordPress.com. */
+						__( 'Connection test failed: WordPress.com returned an empty response (status code: %s).', 'jetpack-connection' ),
+						wp_remote_retrieve_response_code( $response )
+					),
 					'action_label'      => $this->helper_get_support_text(),
 					'action'            => $this->helper_get_support_url(),
 				)
@@ -552,12 +556,21 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 		$connection_error = $site_http_status
 			? sprintf(
 				/* translators: %d is the HTTP status code (e.g. 403) the site returned. */
-				__( 'WordPress.com reached your site but the request was blocked (HTTP %d). This is usually caused by a firewall, security plugin, or server rule rejecting requests from WordPress.com.', 'jetpack-connection' ),
+				__( 'WordPress.com reached your site but the request was blocked (HTTP %d). This is usually caused by a security plugin, firewall, or server rule rejecting requests from WordPress.com.', 'jetpack-connection' ),
 				$site_http_status
 			)
-			: __( 'WordPress.com reached your site but the request was blocked. This is usually caused by a firewall, security plugin, or server rule rejecting requests from WordPress.com.', 'jetpack-connection' );
+			: __( 'WordPress.com reached your site but the request was blocked. This is usually caused by a security plugin, firewall, or server rule rejecting requests from WordPress.com.', 'jetpack-connection' );
 
-		$recommendation = __( 'Ask your host or security provider to allow requests from WordPress.com to your site\'s xmlrpc.php file. Reconnecting will not resolve this. If you need further help, contact Jetpack support.', 'jetpack-connection' );
+		$recommendation = sprintf(
+			/* translators: %1$s is the opening tag of a link to Jetpack's IP allowlist documentation, %2$s is the closing tag. */
+			__( 'Jetpack uses your site\'s xmlrpc.php file to securely communicate with WordPress.com. Ask your host or security provider to %1$sallowlist Jetpack\'s IPs%2$s — reconnecting will not resolve this. If you need further help, contact Jetpack support.', 'jetpack-connection' ),
+			'<a href="' . esc_url( Redirect::get_url( 'https://jetpack.com/support/how-to-add-jetpack-ips-allowlist/' ) ) . '" target="_blank" rel="noopener noreferrer">',
+			sprintf(
+				/* translators: accessibility text */
+				'<span class="screen-reader-text"> %s</span></a>',
+				esc_html__( '(opens in a new tab)', 'jetpack-connection' )
+			)
+		);
 
 		return self::failing_test(
 			array(

--- a/projects/packages/connection/src/health/class-connection-health-tests.php
+++ b/projects/packages/connection/src/health/class-connection-health-tests.php
@@ -435,9 +435,12 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 	 * a single place that guarantees a Site Health label. The method name must not
 	 * contain "test__" or the constructor would register it as a separate test.
 	 *
+	 * Protected rather than private so tests can stub the outcome and assert how the
+	 * caller labels it.
+	 *
 	 * @return array
 	 */
-	private function run_wpcom_connection_test() {
+	protected function run_wpcom_connection_test() {
 		$name = 'test__wpcom_connection_test';
 
 		$status      = new Status();
@@ -513,7 +516,7 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 	/**
 	 * Turns a decoded WP.com test-connection response into a test result.
 	 *
-	 * Split out from test__wpcom_connection_test() so the decision logic can be
+	 * Split out from run_wpcom_connection_test() so the decision logic can be
 	 * exercised without performing a signed remote request.
 	 *
 	 * @param string     $name        The test name.
@@ -563,16 +566,20 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 	 * @return array Test results.
 	 */
 	protected function blocked_request_failing_test( $name, $site_http_status = 0 ) {
-		$connection_error = $site_http_status
+		// Only the first sentence varies with the status code. Keeping the explanation
+		// in its own string means it is written, translated, and edited once.
+		$blocked = $site_http_status
 			? sprintf(
 				/* translators: %d is the HTTP status code (e.g. 403) the site returned. */
-				__( 'WordPress.com reached your site but the request was blocked (HTTP %d). This is usually caused by a security plugin, firewall, or server rule rejecting requests from WordPress.com.', 'jetpack-connection' ),
+				__( 'WordPress.com reached your site but the request was blocked (HTTP %d).', 'jetpack-connection' ),
 				$site_http_status
 			)
-			: __( 'WordPress.com reached your site but the request was blocked. This is usually caused by a security plugin, firewall, or server rule rejecting requests from WordPress.com.', 'jetpack-connection' );
+			: __( 'WordPress.com reached your site but the request was blocked.', 'jetpack-connection' );
+
+		$connection_error = $blocked . ' ' . __( 'This is usually caused by a security plugin, firewall, or server rule rejecting requests from WordPress.com.', 'jetpack-connection' );
 
 		$recommendation = sprintf(
-			/* translators: %1$s is the opening tag of a link to Jetpack's IP allowlist documentation, %2$s is the closing tag. */
+			/* translators: %1$s opens a link to Jetpack's IP allowlist documentation, %2$s closes it (it also carries hidden text noting the link opens in a new tab). Place them around the phrase that should be linked. */
 			__( 'Jetpack uses your site\'s xmlrpc.php file to securely communicate with WordPress.com. Ask your host or security provider to %1$sallowlist Jetpack\'s IPs%2$s — reconnecting will not resolve this. If you need further help, contact Jetpack support.', 'jetpack-connection' ),
 			'<a href="' . esc_url( Redirect::get_url( 'https://jetpack.com/support/how-to-add-jetpack-ips-allowlist/' ) ) . '" target="_blank" rel="noopener noreferrer">',
 			sprintf(

--- a/projects/packages/connection/src/health/class-connection-health-tests.php
+++ b/projects/packages/connection/src/health/class-connection-health-tests.php
@@ -417,30 +417,6 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 	 * @return array
 	 */
 	protected function test__wpcom_connection_test() {
-		$result = $this->run_wpcom_connection_test();
-
-		// Without a label, Site Health falls back to a machine-generated title
-		// ("Wpcom Connection Test"). Individual outcomes may set a more specific one.
-		if ( ! $result['label'] ) {
-			$result['label'] = __( 'WordPress.com Connection Test', 'jetpack-connection' );
-		}
-
-		return $result;
-	}
-
-	/**
-	 * Performs the WP.com test-connection request and builds the result.
-	 *
-	 * Split out from test__wpcom_connection_test() so every exit point passes through
-	 * a single place that guarantees a Site Health label. The method name must not
-	 * contain "test__" or the constructor would register it as a separate test.
-	 *
-	 * Protected rather than private so tests can stub the outcome and assert how the
-	 * caller labels it.
-	 *
-	 * @return array
-	 */
-	protected function run_wpcom_connection_test() {
 		$name = 'test__wpcom_connection_test';
 
 		$status      = new Status();
@@ -518,7 +494,7 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 	/**
 	 * Turns a decoded WP.com test-connection response into a test result.
 	 *
-	 * Split out from run_wpcom_connection_test() so the decision logic can be
+	 * Split out from test__wpcom_connection_test() so the decision logic can be
 	 * exercised without performing a signed remote request.
 	 *
 	 * @param string     $name        The test name.

--- a/projects/packages/connection/src/health/class-connection-health-tests.php
+++ b/projects/packages/connection/src/health/class-connection-health-tests.php
@@ -417,11 +417,37 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 	 * @return array
 	 */
 	protected function test__wpcom_connection_test() {
+		$result = $this->run_wpcom_connection_test();
+
+		// Without a label, Site Health falls back to a machine-generated title
+		// ("Wpcom Connection Test"). Individual outcomes may set a more specific one.
+		if ( ! $result['label'] ) {
+			$result['label'] = __( 'WordPress.com Connection Test', 'jetpack-connection' );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Performs the WP.com test-connection request and builds the result.
+	 *
+	 * Split out from test__wpcom_connection_test() so every exit point passes through
+	 * a single place that guarantees a Site Health label. The method name must not
+	 * contain "test__" or the constructor would register it as a separate test.
+	 *
+	 * @return array
+	 */
+	private function run_wpcom_connection_test() {
 		$name = 'test__wpcom_connection_test';
 
 		$status = new Status();
 		if ( ! ( new Manager() )->is_connected() || $status->is_offline_mode() || $status->in_safe_mode() || ! $this->pass ) {
-			return self::skipped_test( array( 'name' => $name ) );
+			return self::skipped_test(
+				array(
+					'name'              => $name,
+					'short_description' => __( 'Your site is not communicating with WordPress.com, so this test was skipped.', 'jetpack-connection' ),
+				)
+			);
 		}
 
 		add_filter( 'http_request_timeout', array( static::class, 'increase_timeout' ) );
@@ -536,6 +562,7 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 		return self::failing_test(
 			array(
 				'name'              => $name,
+				'label'             => __( 'Your site is blocking requests from WordPress.com', 'jetpack-connection' ),
 				'short_description' => $connection_error,
 				'long_description'  => self::helper_get_reconnect_long_description( $connection_error, $recommendation ),
 				'action_label'      => $this->helper_get_support_text(),

--- a/projects/packages/connection/tests/php/Connection_Health_Tests_Test.php
+++ b/projects/packages/connection/tests/php/Connection_Health_Tests_Test.php
@@ -51,6 +51,7 @@ class Connection_Health_Tests_Test extends TestCase {
 		unset( $_SERVER['SERVER_PORT'], $_SERVER['HTTP_X_FORWARDED_PORT'], $_SERVER['HTTPS'] );
 		remove_all_filters( 'pre_http_request' );
 		remove_all_filters( 'jetpack_offline_mode' );
+		remove_all_filters( 'jetpack_is_in_safe_mode' );
 		remove_all_filters( 'jetpack_debugger_run_self_test' );
 		remove_all_filters( 'jetpack_connection_reconnect_url' );
 		remove_all_filters( 'jetpack_connection_support_url' );
@@ -530,6 +531,67 @@ class Connection_Health_Tests_Test extends TestCase {
 	public function test_wpcom_connection_test_skipped_when_not_connected() {
 		$result = $this->tests->run_test( 'test__wpcom_connection_test' );
 		$this->assertEquals( 'skipped', $result['pass'] );
+	}
+
+	/**
+	 * Force the two deliberate-state checks off so a skip can only come from the
+	 * connection itself.
+	 *
+	 * Both are checked before the connection, and Status caches each result, so a test
+	 * that does not pin them can pass through a branch it did not mean to exercise.
+	 */
+	private function disable_offline_and_safe_mode() {
+		add_filter( 'jetpack_offline_mode', '__return_false' );
+		add_filter( 'jetpack_is_in_safe_mode', '__return_false' );
+	}
+
+	/**
+	 * Test the skip explains that the site is not talking to WordPress.com, rather
+	 * than blaming a deliberate state such as offline mode.
+	 */
+	public function test_wpcom_connection_test_skip_reports_missing_connection() {
+		$this->disable_offline_and_safe_mode();
+
+		$result = $this->tests->run_test( 'test__wpcom_connection_test' );
+
+		$this->assertEquals( 'skipped', $result['pass'] );
+		$this->assertSame(
+			'Your site is not communicating with WordPress.com, so this test was skipped.',
+			$result['short_description']
+		);
+	}
+
+	/**
+	 * Test the skip names offline mode, which is a deliberate state rather than a
+	 * communication failure.
+	 */
+	public function test_wpcom_connection_test_skip_reports_offline_mode() {
+		add_filter( 'jetpack_offline_mode', '__return_true' );
+
+		$result = $this->tests->run_test( 'test__wpcom_connection_test' );
+
+		$this->assertEquals( 'skipped', $result['pass'] );
+		$this->assertSame(
+			'Your site is in Offline Mode, so this test was skipped.',
+			$result['short_description']
+		);
+	}
+
+	/**
+	 * Test the skip names safe mode. Offline mode is checked first, so it has to be
+	 * ruled out for this branch to be reached.
+	 */
+	public function test_wpcom_connection_test_skip_reports_safe_mode() {
+		add_filter( 'jetpack_offline_mode', '__return_false' );
+		add_filter( 'jetpack_is_in_safe_mode', '__return_true' );
+
+		$result = $this->tests->run_test( 'test__wpcom_connection_test' );
+
+		$this->assertEquals( 'skipped', $result['pass'] );
+		$this->assertSame(
+			'Your site is in Safe Mode, so this test was skipped.',
+			$result['short_description']
+		);
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/Connection_Health_Tests_Test.php
+++ b/projects/packages/connection/tests/php/Connection_Health_Tests_Test.php
@@ -595,55 +595,6 @@ class Connection_Health_Tests_Test extends TestCase {
 	}
 
 	/**
-	 * Test that an outcome with no label of its own is given the readable fallback,
-	 * rather than leaving Site Health to derive "Wpcom Connection Test" from the
-	 * method name.
-	 */
-	public function test_wpcom_connection_test_applies_fallback_label() {
-		$mock = $this->create_mock_with_helpers(
-			array(
-				'run_wpcom_connection_test' => Connection_Health_Tests::passing_test(
-					array( 'name' => 'test__wpcom_connection_test' )
-				),
-			)
-		);
-
-		$result = $mock->run_test( 'test__wpcom_connection_test' );
-
-		$this->assertSame( 'WordPress.com Connection Test', $result['label'] );
-	}
-
-	/**
-	 * Test that an outcome which sets its own label keeps it, so the fallback never
-	 * overwrites a more specific heading.
-	 */
-	public function test_wpcom_connection_test_keeps_outcome_label() {
-		$mock = $this->create_mock_with_helpers(
-			array(
-				'run_wpcom_connection_test' => Connection_Health_Tests::failing_test(
-					array(
-						'name'  => 'test__wpcom_connection_test',
-						'label' => 'A more specific heading',
-					)
-				),
-			)
-		);
-
-		$result = $mock->run_test( 'test__wpcom_connection_test' );
-
-		$this->assertSame( 'A more specific heading', $result['label'] );
-	}
-
-	/**
-	 * Test that the real skipped outcome also receives the fallback label.
-	 */
-	public function test_wpcom_connection_test_skip_is_labelled() {
-		$result = $this->tests->run_test( 'test__wpcom_connection_test' );
-
-		$this->assertSame( 'WordPress.com Connection Test', $result['label'] );
-	}
-
-	/**
 	 * Evaluate a decoded WP.com test-connection response via the protected helper.
 	 *
 	 * Avoids performing a signed remote request, which can't be mocked in a unit test.

--- a/projects/packages/connection/tests/php/Connection_Health_Tests_Test.php
+++ b/projects/packages/connection/tests/php/Connection_Health_Tests_Test.php
@@ -533,6 +533,55 @@ class Connection_Health_Tests_Test extends TestCase {
 	}
 
 	/**
+	 * Test that an outcome with no label of its own is given the readable fallback,
+	 * rather than leaving Site Health to derive "Wpcom Connection Test" from the
+	 * method name.
+	 */
+	public function test_wpcom_connection_test_applies_fallback_label() {
+		$mock = $this->create_mock_with_helpers(
+			array(
+				'run_wpcom_connection_test' => Connection_Health_Tests::passing_test(
+					array( 'name' => 'test__wpcom_connection_test' )
+				),
+			)
+		);
+
+		$result = $mock->run_test( 'test__wpcom_connection_test' );
+
+		$this->assertSame( 'WordPress.com Connection Test', $result['label'] );
+	}
+
+	/**
+	 * Test that an outcome which sets its own label keeps it, so the fallback never
+	 * overwrites a more specific heading.
+	 */
+	public function test_wpcom_connection_test_keeps_outcome_label() {
+		$mock = $this->create_mock_with_helpers(
+			array(
+				'run_wpcom_connection_test' => Connection_Health_Tests::failing_test(
+					array(
+						'name'  => 'test__wpcom_connection_test',
+						'label' => 'A more specific heading',
+					)
+				),
+			)
+		);
+
+		$result = $mock->run_test( 'test__wpcom_connection_test' );
+
+		$this->assertSame( 'A more specific heading', $result['label'] );
+	}
+
+	/**
+	 * Test that the real skipped outcome also receives the fallback label.
+	 */
+	public function test_wpcom_connection_test_skip_is_labelled() {
+		$result = $this->tests->run_test( 'test__wpcom_connection_test' );
+
+		$this->assertSame( 'WordPress.com Connection Test', $result['label'] );
+	}
+
+	/**
 	 * Evaluate a decoded WP.com test-connection response via the protected helper.
 	 *
 	 * Avoids performing a signed remote request, which can't be mocked in a unit test.
@@ -601,6 +650,28 @@ class Connection_Health_Tests_Test extends TestCase {
 
 		$this->assertFalse( $result['pass'] );
 		$this->assertStringContainsString( 'blocked', $result['short_description'] );
+		$this->assertStringNotContainsString( 'HTTP', $result['short_description'] );
+		// The explanation is shared with the status-code variant, so it must still be present.
+		$this->assertStringContainsString( 'security plugin, firewall, or server rule', $result['short_description'] );
+	}
+
+	/**
+	 * Test the blocked-request result carries its own heading rather than relying on
+	 * the generic fallback.
+	 */
+	public function test_wpcom_connection_test_blocked_has_specific_label() {
+		$result = $this->evaluate_response(
+			array(
+				'connected'        => false,
+				'error_code'       => 'xmlrpc_request_blocked',
+				'site_http_status' => 403,
+			)
+		);
+
+		$this->assertSame( 'Your site is blocking requests from WordPress.com', $result['label'] );
+		// Both variants share one explanation sentence.
+		$this->assertStringContainsString( '(HTTP 403).', $result['short_description'] );
+		$this->assertStringContainsString( 'security plugin, firewall, or server rule', $result['short_description'] );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/Connection_Health_Tests_Test.php
+++ b/projects/packages/connection/tests/php/Connection_Health_Tests_Test.php
@@ -530,7 +530,7 @@ class Connection_Health_Tests_Test extends TestCase {
 	 */
 	public function test_wpcom_connection_test_skipped_when_not_connected() {
 		$result = $this->tests->run_test( 'test__wpcom_connection_test' );
-		$this->assertEquals( 'skipped', $result['pass'] );
+		$this->assertSame( 'skipped', $result['pass'] );
 	}
 
 	/**
@@ -554,7 +554,7 @@ class Connection_Health_Tests_Test extends TestCase {
 
 		$result = $this->tests->run_test( 'test__wpcom_connection_test' );
 
-		$this->assertEquals( 'skipped', $result['pass'] );
+		$this->assertSame( 'skipped', $result['pass'] );
 		$this->assertSame(
 			'Your site is not communicating with WordPress.com, so this test was skipped.',
 			$result['short_description']
@@ -570,7 +570,7 @@ class Connection_Health_Tests_Test extends TestCase {
 
 		$result = $this->tests->run_test( 'test__wpcom_connection_test' );
 
-		$this->assertEquals( 'skipped', $result['pass'] );
+		$this->assertSame( 'skipped', $result['pass'] );
 		$this->assertSame(
 			'Your site is in Offline Mode, so this test was skipped.',
 			$result['short_description']
@@ -587,7 +587,7 @@ class Connection_Health_Tests_Test extends TestCase {
 
 		$result = $this->tests->run_test( 'test__wpcom_connection_test' );
 
-		$this->assertEquals( 'skipped', $result['pass'] );
+		$this->assertSame( 'skipped', $result['pass'] );
 		$this->assertSame(
 			'Your site is in Safe Mode, so this test was skipped.',
 			$result['short_description']

--- a/projects/packages/connection/tests/php/Site_Health_Test.php
+++ b/projects/packages/connection/tests/php/Site_Health_Test.php
@@ -275,7 +275,7 @@ class Site_Health_Test extends TestCase {
 
 		$output = $tests['test__blog_token_if_exists']['test']();
 
-		$this->assertSame( 'Site token', $output['label'] );
+		$this->assertSame( 'Blog Token', $output['label'] );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/Site_Health_Test.php
+++ b/projects/packages/connection/tests/php/Site_Health_Test.php
@@ -35,8 +35,47 @@ class Site_Health_Test extends TestCase {
 
 		remove_all_filters( 'site_status_tests' );
 		remove_all_filters( 'pre_http_request' );
+		remove_all_filters( 'jetpack_debugger_run_self_test' );
 		remove_all_actions( 'admin_init' );
+		remove_all_actions( 'jetpack_connection_tests_loaded' );
 		remove_all_actions( 'wp_ajax_health-check-jetpack-connection-health' );
+	}
+
+	/**
+	 * Register the connection tests and return the direct test callbacks.
+	 *
+	 * @return array Map of test name => Site Health callback.
+	 */
+	private function register_direct_tests() {
+		$result = Site_Health::register_site_health_tests(
+			array(
+				'direct' => array(),
+				'async'  => array(),
+			)
+		);
+
+		return $result['direct'];
+	}
+
+	/**
+	 * Register an extra test through the action other plugins use, so the suite
+	 * contains a test that cannot appear in the default label map.
+	 *
+	 * @param string $name   Test name.
+	 * @param array  $result Result the test should return.
+	 */
+	private function register_third_party_test( $name, array $result ) {
+		add_action(
+			'jetpack_connection_tests_loaded',
+			function ( $tests ) use ( $name, $result ) {
+				$tests->add_test(
+					function () use ( $result ) {
+						return $result;
+					},
+					$name
+				);
+			}
+		);
 	}
 
 	/**
@@ -209,5 +248,102 @@ class Site_Health_Test extends TestCase {
 		$this->assertIsArray( $output );
 		// Skipped tests still return 'good' status (they aren't failures).
 		$this->assertEquals( 'good', $output['status'] );
+	}
+
+	/**
+	 * Test that a result carrying no label of its own gets the readable heading from
+	 * the default map, rather than one derived from the method name.
+	 *
+	 * This is the case that prompted the map: the skipped result sets no label, and
+	 * the heading used to read "Wpcom Connection Test".
+	 */
+	public function test_direct_callback_applies_default_label() {
+		$tests = $this->register_direct_tests();
+
+		// Skips when not connected, and the skipped result sets no label.
+		$output = $tests['test__wpcom_connection_test']['test']();
+
+		$this->assertSame( 'Requests from WordPress.com', $output['label'] );
+	}
+
+	/**
+	 * Test that the default map is applied to every test, not just the one it was
+	 * introduced for.
+	 */
+	public function test_direct_callback_applies_default_label_to_other_tests() {
+		$tests = $this->register_direct_tests();
+
+		$output = $tests['test__blog_token_if_exists']['test']();
+
+		$this->assertSame( 'Site token', $output['label'] );
+	}
+
+	/**
+	 * Test that a result which sets its own label keeps it, so the default never
+	 * overwrites a more specific heading.
+	 */
+	public function test_direct_callback_keeps_label_set_by_the_result() {
+		$this->register_third_party_test(
+			'test__labelled_example',
+			Connection_Health_Tests::failing_test(
+				array(
+					'name'  => 'test__labelled_example',
+					'label' => 'A more specific heading',
+				)
+			)
+		);
+
+		$tests = $this->register_direct_tests();
+
+		$output = $tests['test__labelled_example']['test']();
+
+		$this->assertSame( 'A more specific heading', $output['label'] );
+	}
+
+	/**
+	 * Test that a test registered by another plugin, which cannot appear in the
+	 * default map, still falls back to a heading derived from its name.
+	 */
+	public function test_direct_callback_derives_label_for_third_party_test() {
+		$this->register_third_party_test(
+			'test__some_other_plugin_check',
+			Connection_Health_Tests::passing_test( array( 'name' => 'test__some_other_plugin_check' ) )
+		);
+
+		$tests = $this->register_direct_tests();
+
+		$output = $tests['test__some_other_plugin_check']['test']();
+
+		$this->assertSame( 'Some Other Plugin Check', $output['label'] );
+	}
+
+	/**
+	 * Test that the default label map covers every built-in test, in both directions.
+	 *
+	 * Without this, renaming a test method degrades its heading back to the derived
+	 * form silently, and removing one leaves a dead entry behind.
+	 */
+	public function test_default_label_map_matches_the_built_in_tests() {
+		// Registers test__wpcom_self_test, which is otherwise left out of the suite.
+		add_filter( 'jetpack_debugger_run_self_test', '__return_true' );
+
+		$method = new \ReflectionMethod( Site_Health::class, 'get_default_test_labels' );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+		$labels = $method->invoke( null );
+
+		$registered = array_keys( ( new Connection_Health_Tests() )->list_tests( 'direct' ) );
+
+		sort( $registered );
+		$mapped = array_keys( $labels );
+		sort( $mapped );
+
+		$this->assertSame(
+			$registered,
+			$mapped,
+			'Site_Health::get_default_test_labels() must list exactly the built-in connection tests.'
+		);
 	}
 }


### PR DESCRIPTION

https://linear.app/a8c/issue/CONNECT-401/jetpack-improve-wpcom-connection-test-language-in-site-health

## Proposed changes

On a site where a firewall or security plugin blocks WordPress.com's requests, Site Health reported a critical issue titled **"Wpcom Connection Test"** — a machine-generated heading derived from the PHP method name — and told the user to reconnect, which cannot fix a firewall block. This reworks the headings and copy for the Jetpack Connection health tests.

* Give every connection test a readable heading. Only two of the twelve tests set a label of their own, so Site Health derived the rest from method names: "Wpcom Connection Test", "Blog Token If Exists", "Master User Can Manage Options", "Server Port Value", "Xml Parser Available" and friends. `Site_Health` now maps each built-in test to a heading in one place. Tests other plugins register through `jetpack_connection_tests_loaded` still fall back to the derived form, since they cannot appear in the map.
* Label the firewall/WAF failure "Your site is blocking requests from WordPress.com", so the critical issue names its own cause.
* Rewrite the blocked-request guidance to explain that Jetpack Connection uses `xmlrpc.php` to talk to WordPress.com, and link "allowlist Jetpack Connection IPs" to the support guide. Routed through `Redirect::get_url()`, consistent with the other support links in the suite.
* Attribute skipped tests to the right cause. Offline mode and safe mode now say so, instead of all four skip conditions reporting "Your site is not communicating with WordPress.com". Previously the not-connected skip had no description at all, so Site Health rendered its "This test successfully passed!" default on a disconnected site.
* Share one "A healthy Jetpack Connection allows…" sentence between the passing and failing descriptions via `helper_get_healthy_connection_text()`, instead of two copies that had already drifted apart.
* Fix the empty-response message, which concatenated the HTTP status onto a translated string and rendered as "…(empty response body)200". It now uses a placeholder, matching how the sibling failure message reports its status code.
* Split the blocked-request message so the explanation sentence shared by the with- and without-status-code variants is written once. Rendered text unchanged.

No behavioural change to what the tests detect — the set of conditions that trigger a pass, failure, or skip is identical. Only headings, descriptions, and the recommended action text change.

A heading in the map has to read sensibly for a pass, a fail, and a skip alike, so it names what was tested rather than stating an outcome. Results that want to state an outcome — the blocked-request failure, "Your site is connected to WordPress.com" — set their own label, which takes precedence.

| Test | Heading |
| --- | --- |
| `test__blog_token_if_exists` | Blog Token |
| `test__check_if_connected` | WordPress.com Connection |
| `test__master_user_exists_on_site` | Connection Owner |
| `test__master_user_can_manage_options` | Connection Owner Permissions |
| `test__outbound_http` | Outbound HTTP Requests |
| `test__outbound_https` | Outbound HTTPS Requests |
| `test__identity_crisis` | Site Address |
| `test__connection_token_health` | Connection Tokens |
| `test__wpcom_connection_test` | Requests from WordPress.com |
| `test__wpcom_self_test` | Site XML-RPC Endpoint |
| `test__server_port_value` | Server Port |
| `test__xml_parser_available` | PHP XML Support |

`test__wpcom_self_test` only registers when the `jetpack_debugger_run_self_test` filter returns true. A test asserts the map and the registered suite match exactly in both directions, so renaming or removing a test fails the build rather than silently degrading its heading.

## Before / After

Captured at **Tools → Site Health** at 1440×900, comparing `trunk` against this branch with nothing else changed between the two shots.

### Every connection test heading

`trunk` derives ten of the twelve headings from PHP method names. This branch maps each one to a readable heading. ("Sync Health" comes from the Sync package, not this map, and already read correctly.)

| Before (`trunk`) | After (this branch) |
| --- | --- |
| [![Passed tests on trunk, showing headings derived from method names](https://github.com/Automattic/jetpack/raw/screenshots/fix/site-health-wpcom-connection-test-label/before-site-health.png)](https://github.com/Automattic/jetpack/raw/screenshots/fix/site-health-wpcom-connection-test-label/before-site-health.png) | [![The same list on this branch, with readable headings](https://github.com/Automattic/jetpack/raw/screenshots/fix/site-health-wpcom-connection-test-label/after-site-health.png)](https://github.com/Automattic/jetpack/raw/screenshots/fix/site-health-wpcom-connection-test-label/after-site-health.png) |

### The blocked-request critical issue

Using the `blocked_403` scenario from the test-connection mocker in the testing instructions below. The heading changes from "Wpcom Connection Test" to "Your site is blocking requests from WordPress.com", and the recommendation now explains `xmlrpc.php` and links "allowlist Jetpack Connection IPs" instead of telling the user to reconnect.

| Before (`trunk`) | After (this branch) |
| --- | --- |
| [![Critical issue titled Wpcom Connection Test, recommending the user allow requests to xmlrpc.php](https://github.com/Automattic/jetpack/raw/screenshots/fix/site-health-wpcom-connection-test-label/before-blocked-request.png)](https://github.com/Automattic/jetpack/raw/screenshots/fix/site-health-wpcom-connection-test-label/before-blocked-request.png) | [![Critical issue titled Your site is blocking requests from WordPress.com, with the allowlist link](https://github.com/Automattic/jetpack/raw/screenshots/fix/site-health-wpcom-connection-test-label/after-blocked-request.png)](https://github.com/Automattic/jetpack/raw/screenshots/fix/site-health-wpcom-connection-test-label/after-blocked-request.png) |

### Skipped tests get a reason

On a site in Offline Mode the connection test is skipped. On `trunk` the skip carries no description, so Site Health falls back to rendering "This test successfully passed!" for a test that never ran.

| Before (`trunk`) | After (this branch) |
| --- | --- |
| [![Wpcom Connection Test expanded, reading This test successfully passed!](https://github.com/Automattic/jetpack/raw/screenshots/fix/site-health-wpcom-connection-test-label/before-skip-reasons.png)](https://github.com/Automattic/jetpack/raw/screenshots/fix/site-health-wpcom-connection-test-label/before-skip-reasons.png) | [![Requests from WordPress.com expanded, reading Your site is in Offline Mode, so this test was skipped.](https://github.com/Automattic/jetpack/raw/screenshots/fix/site-health-wpcom-connection-test-label/after-skip-reasons.png)](https://github.com/Automattic/jetpack/raw/screenshots/fix/site-health-wpcom-connection-test-label/after-skip-reasons.png) |

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

All of this surfaces at **Tools → Site Health** on a Jetpack-connected site.

### Headings (no setup)

Open Site Health on a connected site and expand **Passed tests**.

* No Jetpack Connection row reads like a method name. Specifically, none of "Blog Token If Exists", "Master User Can Manage Options", "Outbound Http", "Identity Crisis", "Connection Token Health", "Server Port Value", "Xml Parser Available", or "Wpcom Connection Test" appears anywhere.
* The rows match the heading table above.
* To check the derived fallback still works for third-party tests, register one from a mu-plugin and confirm it gets a title-cased heading rather than an error:

```php
add_action(
	'jetpack_connection_tests_loaded',
	function ( $tests ) {
		$tests->add_test(
			function () {
				return \Automattic\Jetpack\Connection\Connection_Health_Tests::passing_test(
					array( 'name' => 'test__my_plugin_check' )
				);
			},
			'test__my_plugin_check'
		);
	}
);
```

  This should appear as **"My Plugin Check"**.

### The straightforward case (no setup)

Block `xmlrpc.php` at the server or with a security plugin, then reload Site Health.

* A **critical issue** appears titled **"Your site is blocking requests from WordPress.com"** — not "Wpcom Connection Test".
* The description reads: *"WordPress.com reached your site but the request was blocked (HTTP 403). This is usually caused by a security plugin, firewall, or server rule rejecting requests from WordPress.com."*
* The recommendation reads: *"Jetpack Connection uses your site's xmlrpc.php file to securely communicate with WordPress.com. Ask your host or security provider to **allowlist Jetpack Connection IPs** — reconnecting will not resolve this. If you need further help, contact Jetpack support."*
* **"allowlist Jetpack Connection IPs"** is a link, opens in a new tab, and lands on the Jetpack IP allowlist support page.
* The action button is **"Please contact Jetpack support."** There is deliberately **no "Reconnect now"** button, because reconnecting cannot clear a firewall block.

### Healthy connection

Unblock `xmlrpc.php` and reload.

* Under **Passed tests**, "Your site is connected to WordPress.com" reads *"A healthy Jetpack Connection allows connected plugins (such as Jetpack and WooCommerce) to provide features like Stats, Site Security, and Payments to your site."* Note this row keeps its own outcome label rather than taking "WordPress.com Connection" from the map.
* Any failing connection test shows that **same sentence, word for word**.

### Skipped states

* `wp jetpack disconnect blog` → Passed tests: **"Requests from WordPress.com"** — *"Your site is not communicating with WordPress.com, so this test was skipped."* (before this PR: "Wpcom Connection Test" / "This test successfully passed!")
* `define( 'JETPACK_DEV_DEBUG', true );` → *"Your site is in Offline Mode, so this test was skipped."*
* Safe mode → *"Your site is in Safe Mode, so this test was skipped."*

### The remaining outcomes

These depend on what WordPress.com returns, so intercept the request. Drop this in `tools/docker/mu-plugins/jp-connection-mock.php` (that directory is bind-mounted into the container, and its `.gitignore` keeps the file out of `git status`), set the constant, and reload Site Health.

<details>
<summary>Mock mu-plugin</summary>

```php
<?php
/**
 * Plugin Name: Jetpack test-connection mocker (TEMPORARY - delete after testing)
 */
define( 'JP_CONNECTION_MOCK', 'blocked_no_code' );

add_filter(
	'pre_http_request',
	function ( $preempt, $args, $url ) {
		if ( ! str_contains( $url, '/test-connection' ) ) {
			return $preempt;
		}

		$respond = function ( $body, $code = 200 ) {
			return array(
				'headers'  => array(),
				'body'     => $body,
				'response' => array( 'code' => $code, 'message' => '' ),
				'cookies'  => array(),
				'filename' => '',
			);
		};

		switch ( JP_CONNECTION_MOCK ) {
			case 'timeout':
				return new WP_Error( 'http_request_failed', 'cURL error 28: Operation timed out' );
			case 'wp_error':
				return new WP_Error( 'http_request_failed', 'cURL error 6: Could not resolve host' );
			case 'empty_body':
				return $respond( '', 502 );
			case 'api_404':
				return $respond( '{"error":"not_found"}', 404 );
			case 'blocked_no_code':
				return $respond( '{"connected":false,"error_code":"xmlrpc_request_blocked"}' );
			case 'generic_fail':
				return $respond( '{"connected":false,"message":"The Jetpack site token is invalid."}' );
			case 'no_message':
				return $respond( '{"connected":false}', 500 );
			case 'pass':
				return $respond( '{"connected":true}' );
		}

		return $preempt;
	},
	10,
	3
);
```

</details>

| `JP_CONNECTION_MOCK` | Expected |
| --- | --- |
| `pass` | Passed tests — "Requests from WordPress.com" / "Test passed!" |
| `timeout` | Passed tests — the "test timed out … please relaunch tests" message |
| `api_404` | Passed tests — "The WordPress.com API returned a 404 error." |
| `blocked_no_code` | Critical — same as the firewall case above, but **without** the "(HTTP 403)" clause. The explanation sentence must still be present. |
| `wp_error` | Critical — "Connection test failed (#http_request_failed: …)" **with** a "Reconnect now" button |
| `generic_fail` | Critical — WP.com's message + "(status code: 200)", with "Reconnect now" |
| `no_message` | Critical — "Connection test failed. (status code: 500)" |
| `empty_body` | Critical — "Connection test failed: WordPress.com returned an empty response (status code: 502)." Before this PR it read "…(empty response body)502". |

Checks spanning several rows:

* No heading anywhere reads **"Wpcom Connection Test"**. Every row that does not state its own outcome reads **"Requests from WordPress.com"**.
* `wp_error` / `generic_fail` / `no_message` offer **"Reconnect now"**; the blocked cases and `empty_body` offer the support link instead.
* `blocked_no_code` and the real 403 differ **only** by the "(HTTP 403)" clause.

Delete the mu-plugin when finished — while it is present the real connection test never runs.

### Other surfaces

The blocked-request recommendation now contains a link, so confirm the markup does not leak into text-only output. These read `short_description`, which carries no HTML:

* `wp jetpack status` — the blocked message prints as plain text with no `<a>` tags
* `GET /jetpack/v4/connection/test`
* The **Jetpack → Debug** page

Headings are applied by `Site_Health`, so these surfaces are unaffected by the map — they never read `label`.

### Automated

```bash
jp test php packages/connection
```

828 tests pass locally. The label behaviour is covered in `Site_Health_Test`, through the real Site Health callback rather than mocks:

* `test_direct_callback_applies_default_label` — a skipped result with no label of its own gets "Requests from WordPress.com"
* `test_direct_callback_applies_default_label_to_other_tests` — the map applies across the suite, not just the one test
* `test_direct_callback_keeps_label_set_by_the_result` — a result's own label wins over the map
* `test_direct_callback_derives_label_for_third_party_test` — a test registered through `jetpack_connection_tests_loaded` still falls back to the derived heading
* `test_default_label_map_matches_the_built_in_tests` — the map and the registered suite match exactly, in both directions

`Connection_Health_Tests_Test` keeps `test_wpcom_connection_test_blocked_has_specific_label` and the three skip-reason cases, which exercise the real decision paths.

