### PR TITLE
Podcast: reframe enable/disable copy as setup and publishing

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-setup-copy
+++ b/projects/packages/podcast/changelog/fix-podcast-setup-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Clarify that the dashboard sets up podcasting rather than enabling it a second time.

--- a/projects/packages/podcast/src/dashboard/settings/index.tsx
+++ b/projects/packages/podcast/src/dashboard/settings/index.tsx
@@ -401,7 +401,7 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 			<Card>
 				<CardHeader>
 					<h2 className="podcast__section-heading">
-						{ __( 'Disable podcasting', 'jetpack-podcast' ) }
+						{ __( 'Stop publishing your podcast', 'jetpack-podcast' ) }
 					</h2>
 				</CardHeader>
 				<CardBody>
@@ -413,7 +413,7 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 							) }
 						</Text>
 						<Button variant="secondary" isDestructive onClick={ openConfirmDisable }>
-							{ __( 'Disable', 'jetpack-podcast' ) }
+							{ __( 'Stop publishing', 'jetpack-podcast' ) }
 						</Button>
 					</VStack>
 				</CardBody>
@@ -421,13 +421,13 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 
 			{ confirmDisable && (
 				<Modal
-					title={ __( 'Disable podcasting?', 'jetpack-podcast' ) }
+					title={ __( 'Stop publishing your podcast?', 'jetpack-podcast' ) }
 					onRequestClose={ closeConfirmDisable }
 				>
 					<VStack spacing={ 4 }>
 						<p>
 							{ __(
-								'Your podcast feed will stop being generated. Existing episodes stay in the assigned category and you can turn podcasting back on at any time.',
+								'Your podcast feed will stop being generated. Existing episodes stay in the assigned category and you can start publishing again at any time.',
 								'jetpack-podcast'
 							) }
 						</p>
@@ -436,7 +436,7 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 								{ __( 'Cancel', 'jetpack-podcast' ) }
 							</Button>
 							<Button variant="primary" isDestructive onClick={ onDisablePodcasting }>
-								{ __( 'Disable podcasting', 'jetpack-podcast' ) }
+								{ __( 'Stop publishing', 'jetpack-podcast' ) }
 							</Button>
 						</HStack>
 					</VStack>

--- a/projects/packages/podcast/src/dashboard/welcome/index.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/index.tsx
@@ -202,7 +202,7 @@ const Welcome = ( { onEnable, hasAccess }: WelcomeProps ) => {
 					) }
 					<HStack justify="flex-start" expanded={ false }>
 						<Button variant="primary" onClick={ onEnable }>
-							{ __( 'Enable podcasting', 'jetpack-podcast' ) }
+							{ __( 'Set up podcasting', 'jetpack-podcast' ) }
 						</Button>
 					</HStack>
 				</VStack>


### PR DESCRIPTION
## Proposed changes

Podcast is already active in the modules list, but the dashboard greeted people with "Enable podcasting" — so it read as a second, redundant enable. It never enabled anything: the button opens a modal already titled *"Set up your podcast"*, and the enable/disable pair just writes `podcasting_category_id`.

Copy only, no behavior change:

* Welcome hero: "Enable podcasting" → **"Set up podcasting"**
* Settings: the mirrored "Disable podcasting" card → **"Stop publishing your podcast"** (button, modal title, and confirm button follow suit), which matches the description already under it.

Not addressed here: whether the module toggle and feature setup should be separate at all — tracked separately.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site with the Podcast module active but no podcast category set, go to **Jetpack → Podcast**.
* Hero button should read **"Set up podcasting"** and still open the "Set up your podcast" modal. Pick a category and confirm setup lands you on **Settings**.
* Bottom of **Settings**: card should read **"Stop publishing your podcast"** / **"Stop publishing"**. Confirm the modal wording, then confirm the action still clears the category, returns you to the welcome screen, and keeps your show details.
* **My Jetpack → Products → Growth → Podcast** toggle is untouched.
