### PR TITLE
Podcast: disable settings when edited during a save

### DIFF
--- a/projects/packages/podcast/changelog/fix-podcast-settings-saving
+++ b/projects/packages/podcast/changelog/fix-podcast-settings-saving
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Settings: keep edits made while an earlier save is still in flight.
+Settings: lock controls while a save is in progress so quick edits aren't lost.

--- a/projects/packages/podcast/changelog/fix-podcast-settings-saving
+++ b/projects/packages/podcast/changelog/fix-podcast-settings-saving
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Settings: keep edits made while an earlier save is still in flight.

--- a/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
@@ -22,6 +22,11 @@ import type {
 const ENTITY_KIND = 'wpcom/v2';
 const ENTITY_NAME = 'podcast/settings';
 
+// Shared by the in-progress notice and both outcomes: creating a notice
+// replaces any existing one with the same id, so "Saving…" turns into the
+// result in place rather than stacking a second snackbar under it.
+const SAVE_NOTICE_ID = 'jetpack-podcast-save-settings';
+
 if (
 	! dataSelect( coreStore )
 		.getEntitiesConfig( ENTITY_KIND )
@@ -176,7 +181,7 @@ export function useUpdatePodcastSettings(): {
 	isPending: boolean;
 } {
 	const { saveEntityRecord } = useDispatch( coreStore );
-	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
+	const { createInfoNotice, createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 	const isPending = useSelect(
 		select => !! select( coreStore ).isSavingEntityRecord( ENTITY_KIND, ENTITY_NAME, undefined ),
 		[]
@@ -187,6 +192,15 @@ export function useUpdatePodcastSettings(): {
 			updates: PodcastSettingsUpdate,
 			{ silent = false }: { silent?: boolean } = {}
 		): Promise< PodcastSettings > => {
+			if ( ! silent ) {
+				// Not dismissible: it's replaced by the outcome a moment later, so
+				// there's nothing worth dismissing by hand.
+				createInfoNotice( __( 'Saving…', 'jetpack-podcast' ), {
+					id: SAVE_NOTICE_ID,
+					type: 'snackbar',
+					isDismissible: false,
+				} );
+			}
 			try {
 				const record = await saveEntityRecord(
 					ENTITY_KIND,
@@ -198,6 +212,7 @@ export function useUpdatePodcastSettings(): {
 				}
 				if ( ! silent ) {
 					createSuccessNotice( __( 'Settings saved.', 'jetpack-podcast' ), {
+						id: SAVE_NOTICE_ID,
 						type: 'snackbar',
 					} );
 				}
@@ -206,13 +221,13 @@ export function useUpdatePodcastSettings(): {
 				if ( ! silent ) {
 					createErrorNotice(
 						__( 'Could not save your podcast settings. Please try again.', 'jetpack-podcast' ),
-						{ type: 'snackbar' }
+						{ id: SAVE_NOTICE_ID, type: 'snackbar' }
 					);
 				}
 				throw error;
 			}
 		},
-		[ saveEntityRecord, createSuccessNotice, createErrorNotice ]
+		[ saveEntityRecord, createInfoNotice, createSuccessNotice, createErrorNotice ]
 	);
 
 	const mutate = useCallback(

--- a/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
@@ -130,17 +130,6 @@ export const refreshPodcastSettings = (): void => {
 	dataDispatch( coreStore ).invalidateResolution( 'getEntityRecord', [ ENTITY_KIND, ENTITY_NAME ] );
 };
 
-// The entity has no record id, so core-data locks each save under a fresh uuid
-// and never serialises them — concurrent saves land in arbitrary order.
-let saveQueue: Promise< unknown > = Promise.resolve();
-
-const enqueueSave = < T >( run: () => Promise< T > ): Promise< T > => {
-	const result = saveQueue.then( run, run );
-	// Keep the chain alive after a failure; `result` still rejects for the caller.
-	saveQueue = result.catch( () => {} );
-	return result;
-};
-
 interface MutateCallbacks {
 	onSuccess?: ( result: PodcastSettings ) => void;
 	onError?: ( error: unknown ) => void;
@@ -199,8 +188,10 @@ export function useUpdatePodcastSettings(): {
 			{ silent = false }: { silent?: boolean } = {}
 		): Promise< PodcastSettings > => {
 			try {
-				const record = await enqueueSave( () =>
-					saveEntityRecord( ENTITY_KIND, ENTITY_NAME, updates as Record< string, unknown > )
+				const record = await saveEntityRecord(
+					ENTITY_KIND,
+					ENTITY_NAME,
+					updates as Record< string, unknown >
 				);
 				if ( ! record ) {
 					throw new Error( 'save returned no record' );

--- a/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
@@ -130,15 +130,13 @@ export const refreshPodcastSettings = (): void => {
 	dataDispatch( coreStore ).invalidateResolution( 'getEntityRecord', [ ENTITY_KIND, ENTITY_NAME ] );
 };
 
-// This entity has no record id, so core-data locks each save under a fresh uuid
-// instead of serialising them. Two saves started close together would race, and
-// the server applies whichever lands last — so a slower earlier request can undo
-// a newer edit. Chain them here so edits persist in the order they were made.
+// The entity has no record id, so core-data locks each save under a fresh uuid
+// and never serialises them — concurrent saves land in arbitrary order.
 let saveQueue: Promise< unknown > = Promise.resolve();
 
 const enqueueSave = < T >( run: () => Promise< T > ): Promise< T > => {
 	const result = saveQueue.then( run, run );
-	// Swallow rejections on the queue only; `result` keeps them for the caller.
+	// Keep the chain alive after a failure; `result` still rejects for the caller.
 	saveQueue = result.catch( () => {} );
 	return result;
 };

--- a/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
+++ b/projects/packages/podcast/src/dashboard/hooks/use-podcast-settings.ts
@@ -130,6 +130,19 @@ export const refreshPodcastSettings = (): void => {
 	dataDispatch( coreStore ).invalidateResolution( 'getEntityRecord', [ ENTITY_KIND, ENTITY_NAME ] );
 };
 
+// This entity has no record id, so core-data locks each save under a fresh uuid
+// instead of serialising them. Two saves started close together would race, and
+// the server applies whichever lands last — so a slower earlier request can undo
+// a newer edit. Chain them here so edits persist in the order they were made.
+let saveQueue: Promise< unknown > = Promise.resolve();
+
+const enqueueSave = < T >( run: () => Promise< T > ): Promise< T > => {
+	const result = saveQueue.then( run, run );
+	// Swallow rejections on the queue only; `result` keeps them for the caller.
+	saveQueue = result.catch( () => {} );
+	return result;
+};
+
 interface MutateCallbacks {
 	onSuccess?: ( result: PodcastSettings ) => void;
 	onError?: ( error: unknown ) => void;
@@ -188,10 +201,8 @@ export function useUpdatePodcastSettings(): {
 			{ silent = false }: { silent?: boolean } = {}
 		): Promise< PodcastSettings > => {
 			try {
-				const record = await saveEntityRecord(
-					ENTITY_KIND,
-					ENTITY_NAME,
-					updates as Record< string, unknown >
+				const record = await enqueueSave( () =>
+					saveEntityRecord( ENTITY_KIND, ENTITY_NAME, updates as Record< string, unknown > )
 				);
 				if ( ! record ) {
 					throw new Error( 'save returned no record' );

--- a/projects/packages/podcast/src/dashboard/settings/cover-image-control.tsx
+++ b/projects/packages/podcast/src/dashboard/settings/cover-image-control.tsx
@@ -66,7 +66,7 @@ const CoverImageControl = ( {
 
 	const renderTrigger = useCallback(
 		( { open }: { open: () => void } ) => (
-			<Button variant="secondary" onClick={ open } disabled={ disabled }>
+			<Button variant="secondary" onClick={ open } disabled={ disabled } accessibleWhenDisabled>
 				{ triggerLabel }
 			</Button>
 		),
@@ -94,7 +94,13 @@ const CoverImageControl = ( {
 					render={ renderTrigger }
 				/>
 				{ hasImage && (
-					<Button variant="tertiary" isDestructive onClick={ onRemove } disabled={ disabled }>
+					<Button
+						variant="tertiary"
+						isDestructive
+						onClick={ onRemove }
+						disabled={ disabled }
+						accessibleWhenDisabled
+					>
 						{ __( 'Remove', 'jetpack-podcast' ) }
 					</Button>
 				) }

--- a/projects/packages/podcast/src/dashboard/settings/index.tsx
+++ b/projects/packages/podcast/src/dashboard/settings/index.tsx
@@ -99,6 +99,19 @@ const useFieldEditor = (
 	};
 };
 
+// Leaving a text field starts its save on mousedown, and the click that caused
+// it only lands ~100ms later. Locking the instant the save starts would disable
+// the control mid-press and swallow that click, so wait out a press first. Long
+// enough for the click, short enough that a second deliberate edit still meets a
+// locked form — and a save that beats the delay never flashes the tab grey.
+const LOCK_DELAY_MS = 250;
+
+// `disabled` covers the native controls; `aria-disabled` the buttons that stay
+// focusable while locked.
+const isControlDisabled = ( element: HTMLElement ): boolean =>
+	( element as HTMLInputElement ).disabled === true ||
+	element.getAttribute( 'aria-disabled' ) === 'true';
+
 interface SettingsTabProps {
 	onAfterDisable?: () => void;
 }
@@ -118,6 +131,16 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 		}
 	}, [ settings, draft ] );
 
+	const [ isLocked, setIsLocked ] = useState( false );
+	useEffect( () => {
+		if ( ! isSaving ) {
+			setIsLocked( false );
+			return;
+		}
+		const timer = setTimeout( () => setIsLocked( true ), LOCK_DELAY_MS );
+		return () => clearTimeout( timer );
+	}, [ isSaving ] );
+
 	// Disabling a control blurs it, and the browser has already moved focus to
 	// <body> by the time effects run — so record focus on the way in instead.
 	const lastFocused = useRef< HTMLElement | null >( null );
@@ -125,8 +148,18 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 		lastFocused.current = event.target;
 	}, [] );
 
+	// Focus leaving a control that is still enabled is the user's own move —
+	// clicking into blank space, say — and there's nothing to hand back. Only the
+	// lock taking focus away is worth undoing, and that control is already
+	// disabled by the time it fires this.
+	const forgetFocus = useCallback( ( event: FocusEvent< HTMLDivElement > ) => {
+		if ( ! isControlDisabled( event.target ) ) {
+			lastFocused.current = null;
+		}
+	}, [] );
+
 	useEffect( () => {
-		if ( isSaving ) {
+		if ( isLocked ) {
 			return;
 		}
 		const target = lastFocused.current;
@@ -134,11 +167,11 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 		if ( ! target?.isConnected ) {
 			return;
 		}
-		// Only reclaim focus the disable dropped, not focus the user moved on purpose.
+		// Don't pull focus back from wherever the user has since moved it.
 		if ( target.ownerDocument.activeElement === target.ownerDocument.body ) {
 			target.focus();
 		}
-	}, [ isSaving ] );
+	}, [ isLocked ] );
 
 	// Save a partial update, then resync draft from the server-merged record so
 	// `isDirty` and reference checks fall back to false on the saved keys.
@@ -274,7 +307,12 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 	}
 
 	return (
-		<VStack spacing={ 5 } className="podcast__settings" onFocus={ rememberFocus }>
+		<VStack
+			spacing={ 5 }
+			className="podcast__settings"
+			onFocus={ rememberFocus }
+			onBlur={ forgetFocus }
+		>
 			{ issues.length > 0 && (
 				<Notice status="warning" isDismissible={ false }>
 					<strong>{ __( 'Finish setting up your podcast', 'jetpack-podcast' ) }</strong>
@@ -301,7 +339,7 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 						<CategoryPicker
 							selectedId={ draft.podcasting_category_id }
 							onSelect={ handleCategorySelect }
-							disabled={ isSaving }
+							disabled={ isLocked }
 						/>
 					</VStack>
 				</CardBody>
@@ -324,34 +362,34 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 							imageId={ draft.podcasting_image_id }
 							onSelect={ handleCoverSelect }
 							onRemove={ handleCoverRemove }
-							disabled={ isSaving }
+							disabled={ isLocked }
 						/>
 						<TextControl
 							__next40pxDefaultSize
 							__nextHasNoMarginBottom
 							label={ __( 'Title', 'jetpack-podcast' ) }
-							disabled={ isSaving }
+							disabled={ isLocked }
 							{ ...titleField }
 						/>
 						<TextareaControl
 							__nextHasNoMarginBottom
 							label={ __( 'Summary/Description', 'jetpack-podcast' ) }
 							rows={ 4 }
-							disabled={ isSaving }
+							disabled={ isLocked }
 							{ ...summaryField }
 						/>
 						<TextControl
 							__next40pxDefaultSize
 							__nextHasNoMarginBottom
 							label={ __( 'Hosts/Artist/Producer', 'jetpack-podcast' ) }
-							disabled={ isSaving }
+							disabled={ isLocked }
 							{ ...talentNameField }
 						/>
 						<TextControl
 							__next40pxDefaultSize
 							__nextHasNoMarginBottom
 							label={ __( 'Copyright', 'jetpack-podcast' ) }
-							disabled={ isSaving }
+							disabled={ isLocked }
 							{ ...copyrightField }
 						/>
 					</VStack>
@@ -383,7 +421,7 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 									suggestions={ TOPIC_SUGGESTIONS }
 									onChange={ handleTopicsChange }
 									maxLength={ 3 }
-									disabled={ isSaving }
+									disabled={ isLocked }
 								/>
 							</div>
 							<Text variant="muted">
@@ -413,7 +451,7 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 							value={ draft.podcasting_explicit ? 'yes' : 'no' }
 							onChange={ handleExplicitChange }
 							options={ EXPLICIT_OPTIONS }
-							disabled={ isSaving }
+							disabled={ isLocked }
 						/>
 						<TextControl
 							__next40pxDefaultSize
@@ -424,7 +462,7 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 								'Included in your feed so podcast directories can verify ownership. Most require it for submission.',
 								'jetpack-podcast'
 							) }
-							disabled={ isSaving }
+							disabled={ isLocked }
 							{ ...emailField }
 						/>
 					</VStack>
@@ -449,7 +487,7 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 							variant="secondary"
 							isDestructive
 							onClick={ openConfirmDisable }
-							disabled={ isSaving }
+							disabled={ isLocked }
 							accessibleWhenDisabled
 						>
 							{ __( 'Disable', 'jetpack-podcast' ) }

--- a/projects/packages/podcast/src/dashboard/settings/index.tsx
+++ b/projects/packages/podcast/src/dashboard/settings/index.tsx
@@ -16,7 +16,7 @@ import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import CategoryPicker from '../category-picker';
 import { usePodcastSettings, useUpdatePodcastSettings } from '../hooks/use-podcast-settings';
@@ -85,9 +85,19 @@ const useFieldEditor = (
 	onCommit: ( value: string ) => void
 ): { value: string; onChange: ( v: string ) => void; onBlur: () => void } => {
 	const [ local, setLocal ] = useState( stored );
+	// The `stored` value this editor last synced from. Anything the user typed
+	// since then is an unsaved edit that an incoming save response must not eat.
+	const syncedRef = useRef( stored );
 	useEffect( () => {
-		setLocal( stored );
-	}, [ stored ] );
+		if ( stored === syncedRef.current ) {
+			return;
+		}
+		const isDirty = local !== syncedRef.current;
+		syncedRef.current = stored;
+		if ( ! isDirty ) {
+			setLocal( stored );
+		}
+	}, [ stored, local ] );
 	return {
 		value: local,
 		onChange: setLocal,
@@ -98,6 +108,18 @@ const useFieldEditor = (
 		},
 	};
 };
+
+// Show urls/states are patch-shaped in an update but whole maps on the record,
+// so they merge a level deeper than the scalar keys.
+const mergeSettings = (
+	base: PodcastSettings,
+	updates: PodcastSettingsUpdate
+): PodcastSettings => ( {
+	...base,
+	...updates,
+	podcasting_show_urls: { ...base.podcasting_show_urls, ...updates.podcasting_show_urls },
+	podcasting_show_states: { ...base.podcasting_show_states, ...updates.podcasting_show_states },
+} );
 
 interface SettingsTabProps {
 	onAfterDisable?: () => void;
@@ -110,17 +132,43 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 	const [ draft, setDraft ] = useState< PodcastSettings | null >( null );
 	const [ confirmDisable, setConfirmDisable ] = useState( false );
 
+	// Bumped on every commit. A response only owns the draft if no newer edit has
+	// been made since it was sent, otherwise a slow save resurrects a value the
+	// user already changed.
+	const saveSeq = useRef( 0 );
+	// Last server-authoritative record, used to roll back a failed save.
+	const settingsRef = useRef( settings );
+
 	useEffect( () => {
+		settingsRef.current = settings;
 		if ( settings && ! draft ) {
 			setDraft( settings );
 		}
 	}, [ settings, draft ] );
 
-	// Save a partial update, then resync draft from the server-merged record so
-	// `isDirty` and reference checks fall back to false on the saved keys.
+	// Save a partial update, echoing it into the draft first so the next edit
+	// compares against what the user just did rather than the value the in-flight
+	// request hasn't returned yet — that stale comparison was dropping an edit
+	// made while a save was still running.
 	const commit = useCallback(
 		( updates: PodcastSettingsUpdate ) => {
-			saveSettings( updates, { onSuccess: setDraft } );
+			const seq = ++saveSeq.current;
+			const isCurrent = () => seq === saveSeq.current;
+			setDraft( prev => ( prev ? mergeSettings( prev, updates ) : prev ) );
+			saveSettings( updates, {
+				// Resync from the server-merged record so reference checks fall back
+				// to false on the saved keys.
+				onSuccess: record => {
+					if ( isCurrent() ) {
+						setDraft( record );
+					}
+				},
+				onError: () => {
+					if ( isCurrent() && settingsRef.current ) {
+						setDraft( settingsRef.current );
+					}
+				},
+			} );
 		},
 		[ saveSettings ]
 	);

--- a/projects/packages/podcast/src/dashboard/settings/index.tsx
+++ b/projects/packages/podcast/src/dashboard/settings/index.tsx
@@ -16,7 +16,7 @@ import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import CategoryPicker from '../category-picker';
 import { usePodcastSettings, useUpdatePodcastSettings } from '../hooks/use-podcast-settings';
@@ -85,18 +85,9 @@ const useFieldEditor = (
 	onCommit: ( value: string ) => void
 ): { value: string; onChange: ( v: string ) => void; onBlur: () => void } => {
 	const [ local, setLocal ] = useState( stored );
-	// Typing since the last sync is an unsaved edit a save response must not eat.
-	const syncedRef = useRef( stored );
 	useEffect( () => {
-		if ( stored === syncedRef.current ) {
-			return;
-		}
-		const isDirty = local !== syncedRef.current;
-		syncedRef.current = stored;
-		if ( ! isDirty ) {
-			setLocal( stored );
-		}
-	}, [ stored, local ] );
+		setLocal( stored );
+	}, [ stored ] );
 	return {
 		value: local,
 		onChange: setLocal,
@@ -108,60 +99,30 @@ const useFieldEditor = (
 	};
 };
 
-// Show urls/states are patches in an update but whole maps on the record.
-const mergeSettings = (
-	base: PodcastSettings,
-	updates: PodcastSettingsUpdate
-): PodcastSettings => ( {
-	...base,
-	...updates,
-	podcasting_show_urls: { ...base.podcasting_show_urls, ...updates.podcasting_show_urls },
-	podcasting_show_states: { ...base.podcasting_show_states, ...updates.podcasting_show_states },
-} );
-
 interface SettingsTabProps {
 	onAfterDisable?: () => void;
 }
 
 const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 	const { data: settings, isLoading } = usePodcastSettings();
-	const { mutate: saveSettings } = useUpdatePodcastSettings();
+	// Controls lock while a save is in flight: they autosave as you leave each
+	// one, so a second edit landing mid-request would race it and be lost.
+	const { mutate: saveSettings, isPending: isSaving } = useUpdatePodcastSettings();
 
 	const [ draft, setDraft ] = useState< PodcastSettings | null >( null );
 	const [ confirmDisable, setConfirmDisable ] = useState( false );
 
-	// Only the newest save owns the draft; older responses would resurrect values
-	// the user has already changed.
-	const saveSeq = useRef( 0 );
-	// Last server-authoritative record, for rolling back a failed save.
-	const settingsRef = useRef( settings );
-
 	useEffect( () => {
-		settingsRef.current = settings;
 		if ( settings && ! draft ) {
 			setDraft( settings );
 		}
 	}, [ settings, draft ] );
 
-	// Echo the update into the draft first, so the next edit compares against what
-	// the user just did rather than a value the in-flight request hasn't returned.
+	// Save a partial update, then resync draft from the server-merged record so
+	// `isDirty` and reference checks fall back to false on the saved keys.
 	const commit = useCallback(
 		( updates: PodcastSettingsUpdate ) => {
-			const seq = ++saveSeq.current;
-			const isCurrent = () => seq === saveSeq.current;
-			setDraft( prev => ( prev ? mergeSettings( prev, updates ) : prev ) );
-			saveSettings( updates, {
-				onSuccess: record => {
-					if ( isCurrent() ) {
-						setDraft( record );
-					}
-				},
-				onError: () => {
-					if ( isCurrent() && settingsRef.current ) {
-						setDraft( settingsRef.current );
-					}
-				},
-			} );
+			saveSettings( updates, { onSuccess: setDraft } );
 		},
 		[ saveSettings ]
 	);
@@ -318,6 +279,7 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 						<CategoryPicker
 							selectedId={ draft.podcasting_category_id }
 							onSelect={ handleCategorySelect }
+							disabled={ isSaving }
 						/>
 					</VStack>
 				</CardBody>
@@ -340,29 +302,34 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 							imageId={ draft.podcasting_image_id }
 							onSelect={ handleCoverSelect }
 							onRemove={ handleCoverRemove }
+							disabled={ isSaving }
 						/>
 						<TextControl
 							__next40pxDefaultSize
 							__nextHasNoMarginBottom
 							label={ __( 'Title', 'jetpack-podcast' ) }
+							disabled={ isSaving }
 							{ ...titleField }
 						/>
 						<TextareaControl
 							__nextHasNoMarginBottom
 							label={ __( 'Summary/Description', 'jetpack-podcast' ) }
 							rows={ 4 }
+							disabled={ isSaving }
 							{ ...summaryField }
 						/>
 						<TextControl
 							__next40pxDefaultSize
 							__nextHasNoMarginBottom
 							label={ __( 'Hosts/Artist/Producer', 'jetpack-podcast' ) }
+							disabled={ isSaving }
 							{ ...talentNameField }
 						/>
 						<TextControl
 							__next40pxDefaultSize
 							__nextHasNoMarginBottom
 							label={ __( 'Copyright', 'jetpack-podcast' ) }
+							disabled={ isSaving }
 							{ ...copyrightField }
 						/>
 					</VStack>
@@ -394,6 +361,7 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 									suggestions={ TOPIC_SUGGESTIONS }
 									onChange={ handleTopicsChange }
 									maxLength={ 3 }
+									disabled={ isSaving }
 								/>
 							</div>
 							<Text variant="muted">
@@ -423,6 +391,7 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 							value={ draft.podcasting_explicit ? 'yes' : 'no' }
 							onChange={ handleExplicitChange }
 							options={ EXPLICIT_OPTIONS }
+							disabled={ isSaving }
 						/>
 						<TextControl
 							__next40pxDefaultSize
@@ -433,6 +402,7 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 								'Included in your feed so podcast directories can verify ownership. Most require it for submission.',
 								'jetpack-podcast'
 							) }
+							disabled={ isSaving }
 							{ ...emailField }
 						/>
 					</VStack>
@@ -453,7 +423,12 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 								'jetpack-podcast'
 							) }
 						</Text>
-						<Button variant="secondary" isDestructive onClick={ openConfirmDisable }>
+						<Button
+							variant="secondary"
+							isDestructive
+							onClick={ openConfirmDisable }
+							disabled={ isSaving }
+						>
 							{ __( 'Disable', 'jetpack-podcast' ) }
 						</Button>
 					</VStack>

--- a/projects/packages/podcast/src/dashboard/settings/index.tsx
+++ b/projects/packages/podcast/src/dashboard/settings/index.tsx
@@ -85,8 +85,7 @@ const useFieldEditor = (
 	onCommit: ( value: string ) => void
 ): { value: string; onChange: ( v: string ) => void; onBlur: () => void } => {
 	const [ local, setLocal ] = useState( stored );
-	// The `stored` value this editor last synced from. Anything the user typed
-	// since then is an unsaved edit that an incoming save response must not eat.
+	// Typing since the last sync is an unsaved edit a save response must not eat.
 	const syncedRef = useRef( stored );
 	useEffect( () => {
 		if ( stored === syncedRef.current ) {
@@ -109,8 +108,7 @@ const useFieldEditor = (
 	};
 };
 
-// Show urls/states are patch-shaped in an update but whole maps on the record,
-// so they merge a level deeper than the scalar keys.
+// Show urls/states are patches in an update but whole maps on the record.
 const mergeSettings = (
 	base: PodcastSettings,
 	updates: PodcastSettingsUpdate
@@ -132,11 +130,10 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 	const [ draft, setDraft ] = useState< PodcastSettings | null >( null );
 	const [ confirmDisable, setConfirmDisable ] = useState( false );
 
-	// Bumped on every commit. A response only owns the draft if no newer edit has
-	// been made since it was sent, otherwise a slow save resurrects a value the
-	// user already changed.
+	// Only the newest save owns the draft; older responses would resurrect values
+	// the user has already changed.
 	const saveSeq = useRef( 0 );
-	// Last server-authoritative record, used to roll back a failed save.
+	// Last server-authoritative record, for rolling back a failed save.
 	const settingsRef = useRef( settings );
 
 	useEffect( () => {
@@ -146,18 +143,14 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 		}
 	}, [ settings, draft ] );
 
-	// Save a partial update, echoing it into the draft first so the next edit
-	// compares against what the user just did rather than the value the in-flight
-	// request hasn't returned yet — that stale comparison was dropping an edit
-	// made while a save was still running.
+	// Echo the update into the draft first, so the next edit compares against what
+	// the user just did rather than a value the in-flight request hasn't returned.
 	const commit = useCallback(
 		( updates: PodcastSettingsUpdate ) => {
 			const seq = ++saveSeq.current;
 			const isCurrent = () => seq === saveSeq.current;
 			setDraft( prev => ( prev ? mergeSettings( prev, updates ) : prev ) );
 			saveSettings( updates, {
-				// Resync from the server-merged record so reference checks fall back
-				// to false on the saved keys.
 				onSuccess: record => {
 					if ( isCurrent() ) {
 						setDraft( record );

--- a/projects/packages/podcast/src/dashboard/settings/index.tsx
+++ b/projects/packages/podcast/src/dashboard/settings/index.tsx
@@ -16,7 +16,7 @@ import {
 	// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack,
 } from '@wordpress/components';
-import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import CategoryPicker from '../category-picker';
 import { usePodcastSettings, useUpdatePodcastSettings } from '../hooks/use-podcast-settings';
@@ -117,6 +117,28 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 			setDraft( settings );
 		}
 	}, [ settings, draft ] );
+
+	// Disabling a control blurs it, and the browser has already moved focus to
+	// <body> by the time effects run — so record focus on the way in instead.
+	const lastFocused = useRef< HTMLElement | null >( null );
+	const rememberFocus = useCallback( ( event: FocusEvent< HTMLDivElement > ) => {
+		lastFocused.current = event.target;
+	}, [] );
+
+	useEffect( () => {
+		if ( isSaving ) {
+			return;
+		}
+		const target = lastFocused.current;
+		lastFocused.current = null;
+		if ( ! target?.isConnected ) {
+			return;
+		}
+		// Only reclaim focus the disable dropped, not focus the user moved on purpose.
+		if ( target.ownerDocument.activeElement === target.ownerDocument.body ) {
+			target.focus();
+		}
+	}, [ isSaving ] );
 
 	// Save a partial update, then resync draft from the server-merged record so
 	// `isDirty` and reference checks fall back to false on the saved keys.
@@ -252,7 +274,7 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 	}
 
 	return (
-		<VStack spacing={ 5 } className="podcast__settings">
+		<VStack spacing={ 5 } className="podcast__settings" onFocus={ rememberFocus }>
 			{ issues.length > 0 && (
 				<Notice status="warning" isDismissible={ false }>
 					<strong>{ __( 'Finish setting up your podcast', 'jetpack-podcast' ) }</strong>
@@ -428,6 +450,7 @@ const SettingsTab = ( { onAfterDisable }: SettingsTabProps = {} ) => {
 							isDestructive
 							onClick={ openConfirmDisable }
 							disabled={ isSaving }
+							accessibleWhenDisabled
 						>
 							{ __( 'Disable', 'jetpack-podcast' ) }
 						</Button>


### PR DESCRIPTION
## Proposed changes
<!--- Explain what functional changes your PR includes -->
The Podcast settings tab autosaves each control as you finish with it — on blur for the text fields, on change for the pickers. Nothing stopped you editing again while that save was still in flight, and the second edit was silently lost. Reported during Jetpack 16.1 testing as: set a podcast topic, quickly remove it, and the topic comes back and survives a refresh.

The underlying cause was that the blur handler compares the new value against `draft`, which only updates once a save *responds*. Removing the topic while the first save was in flight compared against a stale value, matched, and skipped the save entirely — then the in-flight response overwrote the local state and put the value back.

* Lock every control in the tab while a save is in flight, using the `isPending` flag the settings hook already exposes. `CategoryPicker` and `CoverImageControl` both already accepted a `disabled` prop, so no changes were needed in those components.
* Covers the category picker, cover image, all four show-detail text fields, the topics token field, the explicit-content select, the owner email field, and the Disable button.

Chosen over adding save queueing / last-write-wins reconciliation in the data layer, which fixed the same bug but added considerably more machinery to a settings form. Worth knowing this trades a rare race for a short lock: the form is uninteractive for the duration of each save, so on a slow connection editing several fields in a row will feel stop-start.

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->

Podcasting must be set up on the site (Jetpack → Podcast, pick a post category), then go to **Jetpack → Podcast → Settings**.

The bug is a race, so throttle the network to see it clearly: DevTools → Network → **Slow 3G**, or a custom profile with ~2s latency.

**The reported case**

1. Under *Feed settings*, add a topic in **Podcast topics**.
2. Click outside the field to trigger the save.
3. While the save is in flight, try to remove the topic chip.
4. **Expected:** the controls are greyed out until the save finishes, so the removal can't be made mid-save. Once it completes, remove the chip, click away, and reload — it stays removed.
5. On trunk, step 3 succeeds but is silently discarded: the topic reappears and survives a reload.

**Everything locks together**

1. Throttled, change the **Title** and click away.
2. **Expected:** every control on the tab (category picker, cover image buttons, all text fields, topics, explicit content, owner email, Disable) is greyed out until the save completes, then re-enables.

**No regressions**

* Unthrottled, editing fields one at a time still saves and shows the "Settings saved." snackbar.
* Creating a new category inline from the picker still works.
* Disable podcasting from the bottom card still works.
* Distribution → submitting a show URL in the modal still saves.
