### PR TITLE
Podcast: fix upgrade URL

### DIFF
--- a/projects/packages/podcast/changelog/fix-upgrade-url-podcast
+++ b/projects/packages/podcast/changelog/fix-upgrade-url-podcast
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the plan upgrade buttons linking to a checkout page the site owner cannot access.

--- a/projects/packages/podcast/src/dashboard/locked-preview/index.tsx
+++ b/projects/packages/podcast/src/dashboard/locked-preview/index.tsx
@@ -1,7 +1,6 @@
 // Locked-preview UX for Episodes + Stats on free plans. Renders a blurred,
 // non-language skeleton of the gated content behind a centered upgrade card.
 
-import { getSiteData } from '@automattic/jetpack-script-data';
 import { Button } from '@wordpress/components';
 import { useId } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
@@ -20,7 +19,6 @@ const LockedPreview = ( { variant }: LockedPreviewProps ) => {
 	const planName = getUpgradePlanName();
 	const returnUrl = window.location.href;
 	const checkoutUrl = buildUpgradeCheckoutUrl( {
-		siteSlug: getSiteData()?.suffix ?? '',
 		returnUrl,
 		params: { cancel_to: returnUrl },
 	} );

--- a/projects/packages/podcast/src/dashboard/upgrade.ts
+++ b/projects/packages/podcast/src/dashboard/upgrade.ts
@@ -1,10 +1,10 @@
 // Shared upsell helpers for the podcast dashboard. `getProductCheckoutUrl` is
 // the canonical Calypso checkout-URL builder, so it stays the one place the URL
 // format lives; callers only vary the return target, extra params, and the
-// no-site-slug fallback.
+// no-site fallback.
 
 import { getProductCheckoutUrl } from '@automattic/jetpack-components';
-import { getScriptData } from '@automattic/jetpack-script-data';
+import { getScriptData, getSiteData } from '@automattic/jetpack-script-data';
 
 // Self-hosted upsells Growth, WordPress.com Premium; the server injects the
 // matching slug + plan name (see Admin_Page::inject_podcast_script_data). The
@@ -19,43 +19,70 @@ export const getUpgradePlanName = (): string =>
 
 // Generic, site-agnostic checkout for the injected upgrade product (e.g.
 // `jetpack_growth` on self-hosted, `premium` on wpcom). Used as the fallback
-// when there's no site slug to build a per-site checkout from.
+// when the site can't be identified to build a per-site checkout from.
 export const getUpgradeProductCheckoutUrl = (): string =>
 	`https://wordpress.com/checkout/${ getUpgradeProductSlug() }`;
 
+/**
+ * Identify the site to Calypso for checkout.
+ *
+ * Prefer the WordPress.com blog ID: `site.suffix` is derived from `home_url()`,
+ * which doesn't match the site WordPress.com knows whenever the two disagree
+ * (WordPress in its own directory, mapped domains, multi-URL setups), and
+ * checkout answers "You don't have access to this site". The slug and the
+ * admin host are fallbacks for when no blog ID was injected.
+ *
+ * @return {string} Blog ID, site slug, or admin host; empty when none resolve.
+ */
+export const getUpgradeSiteFragment = (): string => {
+	const site = getSiteData();
+
+	if ( site?.wpcom?.blog_id ) {
+		return String( site.wpcom.blog_id );
+	}
+
+	if ( site?.suffix ) {
+		return site.suffix;
+	}
+
+	try {
+		return new URL( site?.admin_url ?? '' ).host;
+	} catch {
+		return '';
+	}
+};
+
 interface UpgradeCheckoutUrlArgs {
-	/** Calypso site fragment (`site.suffix`); empty falls back to `noSiteSlugUrl`. */
-	siteSlug: string;
 	/** Where checkout returns after purchase (`redirect_to`). */
 	returnUrl: string;
 	/** Extra query params to set on the checkout URL (e.g. `source`, `cancel_to`). */
 	params?: Record< string, string >;
-	/** URL to use when there's no site slug; defaults to the generic product checkout. */
-	noSiteSlugUrl?: string;
+	/** URL to use when the site can't be identified; defaults to the generic product checkout. */
+	noSiteUrl?: string;
 }
 
 /**
  * Build the podcast upsell checkout URL for the injected upgrade product.
  *
- * @param {UpgradeCheckoutUrlArgs} args                 - Checkout URL arguments.
- * @param {string}                 args.siteSlug        - Calypso site fragment; empty falls back to `noSiteSlugUrl`.
- * @param {string}                 args.returnUrl       - Where checkout returns after purchase (`redirect_to`).
- * @param {object}                 [args.params]        - Extra query params to set on the checkout URL.
- * @param {string}                 [args.noSiteSlugUrl] - URL to use when there's no site slug; defaults to the generic product checkout.
+ * @param {UpgradeCheckoutUrlArgs} args             - Checkout URL arguments.
+ * @param {string}                 args.returnUrl   - Where checkout returns after purchase (`redirect_to`).
+ * @param {object}                 [args.params]    - Extra query params to set on the checkout URL.
+ * @param {string}                 [args.noSiteUrl] - URL to use when the site can't be identified; defaults to the generic product checkout.
  * @return {string} The checkout URL for the injected upgrade product.
  */
 export const buildUpgradeCheckoutUrl = ( {
-	siteSlug,
 	returnUrl,
 	params,
-	noSiteSlugUrl = getUpgradeProductCheckoutUrl(),
+	noSiteUrl = getUpgradeProductCheckoutUrl(),
 }: UpgradeCheckoutUrlArgs ): string => {
-	if ( ! siteSlug ) {
-		return noSiteSlugUrl;
+	const siteFragment = getUpgradeSiteFragment();
+
+	if ( ! siteFragment ) {
+		return noSiteUrl;
 	}
 
 	const url = new URL(
-		getProductCheckoutUrl( getUpgradeProductSlug(), siteSlug, returnUrl, true )
+		getProductCheckoutUrl( getUpgradeProductSlug(), siteFragment, returnUrl, true )
 	);
 	if ( params ) {
 		for ( const [ key, value ] of Object.entries( params ) ) {

--- a/projects/packages/podcast/src/dashboard/upgrade.ts
+++ b/projects/packages/podcast/src/dashboard/upgrade.ts
@@ -23,23 +23,10 @@ export const getUpgradePlanName = (): string =>
 export const getUpgradeProductCheckoutUrl = (): string =>
 	`https://wordpress.com/checkout/${ getUpgradeProductSlug() }`;
 
-/**
- * Identify the site to Calypso for checkout.
- *
- * Prefer the WordPress.com blog ID: `site.suffix` is derived from `home_url()`,
- * which doesn't match the site WordPress.com knows whenever the two disagree
- * (WordPress in its own directory, mapped domains, multi-URL setups), and
- * checkout answers "You don't have access to this site". The slug and the
- * admin host are fallbacks for when no blog ID was injected.
- *
- * @return {string} Blog ID, site slug, or admin host; empty when none resolve.
- */
-export const getUpgradeSiteFragment = (): string => {
+// The Calypso slug, with the admin host as a safety net in case `site.suffix`
+// is unexpectedly absent.
+const getSiteSlug = (): string => {
 	const site = getSiteData();
-
-	if ( site?.wpcom?.blog_id ) {
-		return String( site.wpcom.blog_id );
-	}
 
 	if ( site?.suffix ) {
 		return site.suffix;
@@ -50,6 +37,23 @@ export const getUpgradeSiteFragment = (): string => {
 	} catch {
 		return '';
 	}
+};
+
+/**
+ * Identify the site to Calypso for checkout.
+ *
+ * Prefer the WordPress.com blog ID: `site.suffix` is derived from `home_url()`,
+ * which doesn't match the site WordPress.com knows whenever the two disagree
+ * (WordPress in its own directory, mapped domains, multi-URL setups), and
+ * checkout answers "You don't have access to this site". The slug stands in
+ * when no blog ID was injected.
+ *
+ * @return {string} Blog ID or site slug; empty when neither resolves.
+ */
+export const getUpgradeSiteFragment = (): string => {
+	const blogId = getSiteData()?.wpcom?.blog_id;
+
+	return blogId ? String( blogId ) : getSiteSlug();
 };
 
 interface UpgradeCheckoutUrlArgs {
@@ -84,6 +88,15 @@ export const buildUpgradeCheckoutUrl = ( {
 	const url = new URL(
 		getProductCheckoutUrl( getUpgradeProductSlug(), siteFragment, returnUrl, true )
 	);
+
+	// `getProductCheckoutUrl` derives `site` from the path fragment; Boost and
+	// `useProductCheckoutWorkflow` keep the slug there and take the blog ID for
+	// the path alone, so match that shape.
+	const slug = getSiteSlug();
+	if ( slug ) {
+		url.searchParams.set( 'site', slug );
+	}
+
 	if ( params ) {
 		for ( const [ key, value ] of Object.entries( params ) ) {
 			url.searchParams.set( key, value );

--- a/projects/packages/podcast/src/dashboard/upgrade.ts
+++ b/projects/packages/podcast/src/dashboard/upgrade.ts
@@ -23,34 +23,13 @@ export const getUpgradePlanName = (): string =>
 export const getUpgradeProductCheckoutUrl = (): string =>
 	`https://wordpress.com/checkout/${ getUpgradeProductSlug() }`;
 
-// The Calypso slug, with the admin host as a safety net in case `site.suffix`
-// is unexpectedly absent.
-const getSiteSlug = (): string => {
-	const site = getSiteData();
+const getSiteSlug = (): string => getSiteData()?.suffix ?? '';
 
-	if ( site?.suffix ) {
-		return site.suffix;
-	}
-
-	try {
-		return new URL( site?.admin_url ?? '' ).host;
-	} catch {
-		return '';
-	}
-};
-
-/**
- * Identify the site to Calypso for checkout.
- *
- * Prefer the WordPress.com blog ID: `site.suffix` is derived from `home_url()`,
- * which doesn't match the site WordPress.com knows whenever the two disagree
- * (WordPress in its own directory, mapped domains, multi-URL setups), and
- * checkout answers "You don't have access to this site". The slug stands in
- * when no blog ID was injected.
- *
- * @return {string} Blog ID or site slug; empty when neither resolves.
- */
-export const getUpgradeSiteFragment = (): string => {
+// Prefer the blog ID: `site.suffix` is derived from `home_url()`, which isn't
+// the site WordPress.com knows whenever `home` and `siteurl` disagree
+// (WordPress in its own directory, mapped domains, multi-URL setups) — checkout
+// then answers "You don't have access to this site".
+const getUpgradeSiteFragment = (): string => {
 	const blogId = getSiteData()?.wpcom?.blog_id;
 
 	return blogId ? String( blogId ) : getSiteSlug();

--- a/projects/packages/podcast/src/dashboard/upgrade.ts
+++ b/projects/packages/podcast/src/dashboard/upgrade.ts
@@ -1,34 +1,17 @@
-// Shared upsell helpers for the podcast dashboard. `getProductCheckoutUrl` is
-// the canonical Calypso checkout-URL builder, so it stays the one place the URL
-// format lives; callers only vary the return target, extra params, and the
-// no-site fallback.
-
 import { getProductCheckoutUrl } from '@automattic/jetpack-components';
 import { getScriptData, getSiteData } from '@automattic/jetpack-script-data';
 
-// Self-hosted upsells Growth, WordPress.com Premium; the server injects the
-// matching slug + plan name (see Admin_Page::inject_podcast_script_data). The
-// `'premium'` / `'Premium'` fallbacks reproduce today's Premium/WordPress.com
-// behavior for an old bundle running against PHP that doesn't yet inject
-// `upgrade`.
 export const getUpgradeProductSlug = (): string =>
 	getScriptData()?.podcast?.upgrade?.product_slug ?? 'premium';
 
 export const getUpgradePlanName = (): string =>
 	getScriptData()?.podcast?.upgrade?.plan_name ?? 'Premium';
 
-// Generic, site-agnostic checkout for the injected upgrade product (e.g.
-// `jetpack_growth` on self-hosted, `premium` on wpcom). Used as the fallback
-// when the site can't be identified to build a per-site checkout from.
-export const getUpgradeProductCheckoutUrl = (): string =>
+const getUpgradeProductCheckoutUrl = (): string =>
 	`https://wordpress.com/checkout/${ getUpgradeProductSlug() }`;
 
 const getSiteSlug = (): string => getSiteData()?.suffix ?? '';
 
-// Prefer the blog ID: `site.suffix` is derived from `home_url()`, which isn't
-// the site WordPress.com knows whenever `home` and `siteurl` disagree
-// (WordPress in its own directory, mapped domains, multi-URL setups) — checkout
-// then answers "You don't have access to this site".
 const getUpgradeSiteFragment = (): string => {
 	const blogId = getSiteData()?.wpcom?.blog_id;
 
@@ -36,32 +19,26 @@ const getUpgradeSiteFragment = (): string => {
 };
 
 interface UpgradeCheckoutUrlArgs {
-	/** Where checkout returns after purchase (`redirect_to`). */
 	returnUrl: string;
-	/** Extra query params to set on the checkout URL (e.g. `source`, `cancel_to`). */
 	params?: Record< string, string >;
-	/** URL to use when the site can't be identified; defaults to the generic product checkout. */
-	noSiteUrl?: string;
 }
 
 /**
  * Build the podcast upsell checkout URL for the injected upgrade product.
  *
- * @param {UpgradeCheckoutUrlArgs} args             - Checkout URL arguments.
- * @param {string}                 args.returnUrl   - Where checkout returns after purchase (`redirect_to`).
- * @param {object}                 [args.params]    - Extra query params to set on the checkout URL.
- * @param {string}                 [args.noSiteUrl] - URL to use when the site can't be identified; defaults to the generic product checkout.
+ * @param {UpgradeCheckoutUrlArgs} args           - Checkout URL arguments.
+ * @param {string}                 args.returnUrl - Where checkout returns after purchase (`redirect_to`).
+ * @param {object}                 [args.params]  - Extra query params to set on the checkout URL.
  * @return {string} The checkout URL for the injected upgrade product.
  */
 export const buildUpgradeCheckoutUrl = ( {
 	returnUrl,
 	params,
-	noSiteUrl = getUpgradeProductCheckoutUrl(),
 }: UpgradeCheckoutUrlArgs ): string => {
 	const siteFragment = getUpgradeSiteFragment();
 
 	if ( ! siteFragment ) {
-		return noSiteUrl;
+		return getUpgradeProductCheckoutUrl();
 	}
 
 	const url = new URL(

--- a/projects/packages/podcast/src/dashboard/welcome/index.tsx
+++ b/projects/packages/podcast/src/dashboard/welcome/index.tsx
@@ -26,27 +26,13 @@ interface WelcomeProps {
 const CHECKOUT_SOURCE = 'jetpack-podcast-welcome';
 
 const getUpgradeCheckoutUrl = (): string => {
-	const data = getSiteData();
-	const adminUrl = data?.admin_url ?? '';
-
-	// Prefer `site.suffix` since it preserves the full Calypso site fragment
-	// (e.g. `example.com::path` for mapped subdirectory sites). Fall back to
-	// the admin_url host as a safety net in case suffix is unexpectedly absent.
-	let slug = data?.suffix ?? '';
-	if ( ! slug && adminUrl ) {
-		try {
-			slug = new URL( adminUrl ).host;
-		} catch {
-			// Leave slug empty; we'll fall back to the generic plan picker below.
-		}
-	}
-
 	// `tab=settings` bypasses the welcome gate so buyers continue configuring
 	// the podcast instead of re-seeing this pricing card after checkout.
-	const returnTo = adminUrl ? getAdminUrl( 'admin.php?page=jetpack-podcast&tab=settings' ) : '';
+	const returnTo = getSiteData()?.admin_url
+		? getAdminUrl( 'admin.php?page=jetpack-podcast&tab=settings' )
+		: '';
 
 	return buildUpgradeCheckoutUrl( {
-		siteSlug: slug,
 		returnUrl: returnTo,
 		// Calypso threads `source` through its downstream Tracks events.
 		params: { source: CHECKOUT_SOURCE },


### PR DESCRIPTION
## Proposed changes

Podcast's upgrade buttons identified the site with `site.suffix`, which is derived from `home_url()`. On sites where `home` and `siteurl` differ, that slug isn't the site WordPress.com knows and checkout answers "You don't have access to this site."

* Use the WordPress.com blog ID for the checkout path, falling back to the slug. Matches Boost and `useProductCheckoutWorkflow`, which keep the slug on the `site` query param.
* `buildUpgradeCheckoutUrl()` resolves the site itself, so the locked preview and the welcome card share one path.
* Drops the welcome card's `admin_url`-host slug fallback — it only ran when `suffix` was empty (effectively never, since it's `home_url()`-derived) and the blog ID now covers identification.

This is JS only. The PHP that injects `site.wpcom.blog_id` (`Admin_Page::inject_podcast_script_data`, plus `Jetpack_Mu_Wpcom::set_wpcom_blog_id_script_data` on Simple/Atomic) is already on trunk, so there's no deploy ordering to worry about. When `blog_id` is absent or `0` — disconnected self-hosted sites — the URL is byte-identical to today's.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On a connected site without podcast access, go to **Jetpack → Podcast → Stats**.
2. Copy the "Upgrade to Growth" button's link address. The path should now be a numeric blog ID: `wordpress.com/checkout/<blog_id>/jetpack_growth_yearly?...&site=<slug>`.
3. Click it — checkout loads with the site in context rather than the access error.
4. Same check on the welcome/pricing card shown before the podcast is enabled.
5. To confirm the fallback, disconnect the site (or test on a site where `blog_id` isn't injected) — the button should keep using the slug path and behave exactly as it does on trunk.
