### PR TITLE
Subscribers: restore newsletter category selection on subscriber import

### DIFF
--- a/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
@@ -187,8 +187,9 @@ function CategoriesField( {
 				<FormTokenField
 					__next40pxDefaultSize
 					__nextHasNoMarginBottom
-					__experimentalExpandOnFocus
+					__experimentalShowHowTo={ false }
 					label={ __( 'Categories', 'jetpack-newsletter' ) }
+					placeholder={ __( 'Type to add categories', 'jetpack-newsletter' ) }
 					value={ selectedNames }
 					suggestions={ Array.from( idByName.keys() ) }
 					onChange={ handleTokensChange }

--- a/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/modals/add-subscribers-modal.tsx
@@ -1,4 +1,4 @@
-import { DropZone, TextareaControl } from '@wordpress/components';
+import { DropZone, FormTokenField, TextareaControl, ToggleControl } from '@wordpress/components';
 import {
 	createInterpolateElement,
 	useCallback,
@@ -6,11 +6,13 @@ import {
 	useRef,
 	useState,
 } from '@wordpress/element';
+import { decodeEntities } from '@wordpress/html-entities';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { check, cloudUpload, Icon } from '@wordpress/icons';
 import { Button, Dialog, Notice, Stack, Tabs, Text } from '@wordpress/ui';
 import { useAddSubscribersMutation } from '../../data/use-add-subscribers-mutation';
 import { isJobInProgress, isJobStale, useImportJobs } from '../../data/use-import-jobs';
+import { useNewsletterCategories } from '../../data/use-newsletter-categories';
 import { useResetImportMutation } from '../../data/use-reset-import-mutation';
 import { extractEmailsFromCsv } from '../../lib/csv-parse';
 import { recordTracksEvent } from '../../lib/tracks';
@@ -89,6 +91,110 @@ function ImportConsentNotice(): JSX.Element {
 					'jetpack-newsletter'
 				) }
 			</Text>
+		</Stack>
+	);
+}
+
+type CategoriesFieldProps = {
+	// Currently selected category ids, owned by the parent tab so they can be sent on submit.
+	selectedIds: number[];
+	// Called with the next set of selected ids as the user toggles the section or edits tokens.
+	onChange: ( ids: number[] ) => void;
+	// Whether editing is blocked (an import is already running).
+	disabled: boolean;
+};
+
+/**
+ * Optional "add these subscribers to specific categories" picker, mirroring Calypso's
+ * `CategoriesSection` on the Add Subscribers flow. Renders nothing unless the site has Newsletter
+ * categories enabled and at least one exists — the same gate Calypso uses — so it stays invisible
+ * on sites that don't use categories. A toggle reveals a token field of the site's categories;
+ * selected ids are lifted to the parent tab, which sends them with the import.
+ *
+ * WordPress stores term names HTML-encoded (`Tips &amp; Tricks`), so names are decoded for display
+ * and mapped back to ids on change. Two categories sharing a decoded name is not something WP.com
+ * prevents, but it's rare enough that a name-keyed lookup is the same tradeoff Calypso makes.
+ *
+ * @param props             - Component props.
+ * @param props.selectedIds - Selected category ids.
+ * @param props.onChange    - Selection change handler.
+ * @param props.disabled    - Whether editing is blocked.
+ * @return Picker element, or null when categories aren't available.
+ */
+function CategoriesField( {
+	selectedIds,
+	onChange,
+	disabled,
+}: CategoriesFieldProps ): JSX.Element | null {
+	const { data } = useNewsletterCategories();
+	const [ isEnabled, setIsEnabled ] = useState( false );
+
+	const categories = useMemo( () => data?.newsletter_categories ?? [], [ data ] );
+
+	// Name <-> id maps, keyed on the decoded name the token field shows the user.
+	const { nameById, idByName } = useMemo( () => {
+		const byId = new Map< number, string >();
+		const byName = new Map< string, number >();
+		for ( const category of categories ) {
+			const name = decodeEntities( category.name );
+			byId.set( category.id, name );
+			byName.set( name, category.id );
+		}
+		return { nameById: byId, idByName: byName };
+	}, [ categories ] );
+
+	const handleToggle = useCallback(
+		( next: boolean ) => {
+			setIsEnabled( next );
+			// Clear any prior selection when the section is switched off so a hidden picker never
+			// smuggles categories into the import.
+			if ( ! next ) {
+				onChange( [] );
+			}
+		},
+		[ onChange ]
+	);
+
+	const handleTokensChange = useCallback(
+		( tokens: ( string | { value: string } )[] ) => {
+			const ids = tokens
+				.map( token => idByName.get( typeof token === 'string' ? token : token.value ) )
+				.filter( ( id ): id is number => typeof id === 'number' );
+			onChange( ids );
+		},
+		[ idByName, onChange ]
+	);
+
+	// Only offer the picker when the feature is on and there's at least one category to pick.
+	if ( ! data?.enabled || categories.length === 0 ) {
+		return null;
+	}
+
+	const selectedNames = selectedIds
+		.map( id => nameById.get( id ) )
+		.filter( ( name ): name is string => typeof name === 'string' );
+
+	return (
+		<Stack direction="column" gap="sm">
+			<ToggleControl
+				__nextHasNoMarginBottom
+				label={ __( 'Add these subscribers to specific categories', 'jetpack-newsletter' ) }
+				checked={ isEnabled }
+				onChange={ handleToggle }
+				disabled={ disabled }
+			/>
+			{ isEnabled ? (
+				<FormTokenField
+					__next40pxDefaultSize
+					__nextHasNoMarginBottom
+					__experimentalExpandOnFocus
+					label={ __( 'Categories', 'jetpack-newsletter' ) }
+					value={ selectedNames }
+					suggestions={ Array.from( idByName.keys() ) }
+					onChange={ handleTokensChange }
+					disabled={ disabled }
+				/>
+			) : null }
 		</Stack>
 	);
 }
@@ -296,6 +402,7 @@ type AddTabProps = {
  */
 function ManualTab( { mutation, importInProgress, onClose }: AddTabProps ): JSX.Element {
 	const [ value, setValue ] = useState( '' );
+	const [ categoryIds, setCategoryIds ] = useState< number[] >( [] );
 
 	// Submit button reflects the *live* value so the user never has to wait to submit — typing one
 	// valid email enables the CTA right away.
@@ -325,14 +432,18 @@ function ManualTab( { mutation, importInProgress, onClose }: AddTabProps ): JSX.
 		if ( valid.length === 0 ) {
 			return;
 		}
-		mutation.mutate( valid, {
-			onSuccess: () => {
-				setValue( '' );
-				setBlurredValue( '' );
-				onClose();
-			},
-		} );
-	}, [ mutation, onClose, valid ] );
+		mutation.mutate(
+			{ emails: valid, categories: categoryIds },
+			{
+				onSuccess: () => {
+					setValue( '' );
+					setBlurredValue( '' );
+					setCategoryIds( [] );
+					onClose();
+				},
+			}
+		);
+	}, [ categoryIds, mutation, onClose, valid ] );
 
 	return (
 		<Stack direction="column" gap="md">
@@ -348,6 +459,11 @@ function ManualTab( { mutation, importInProgress, onClose }: AddTabProps ): JSX.
 				onBlur={ handleBlur }
 				rows={ 6 }
 				placeholder="reader@example.com&#10;another@example.com"
+			/>
+			<CategoriesField
+				selectedIds={ categoryIds }
+				onChange={ setCategoryIds }
+				disabled={ importInProgress }
 			/>
 			<ImportConsentNotice />
 			<InvalidEntriesNotice invalid={ invalid } />
@@ -468,6 +584,7 @@ function UploadTab( { mutation, importInProgress, onClose }: AddTabProps ): JSX.
 	const [ fileName, setFileName ] = useState< string | null >( null );
 	const [ emails, setEmails ] = useState< string[] >( [] );
 	const [ readError, setReadError ] = useState< string | null >( null );
+	const [ categoryIds, setCategoryIds ] = useState< number[] >( [] );
 
 	const handleFile = useCallback( ( file: File ) => {
 		// Drag-and-drop can deliver any file type, so enforce the same allow-list the picker
@@ -502,17 +619,21 @@ function UploadTab( { mutation, importInProgress, onClose }: AddTabProps ): JSX.
 		if ( emails.length === 0 ) {
 			return;
 		}
-		mutation.mutate( emails, {
-			onSuccess: () => {
-				setEmails( [] );
-				setFileName( null );
-				if ( fileInputRef.current ) {
-					fileInputRef.current.value = '';
-				}
-				onClose();
-			},
-		} );
-	}, [ mutation, onClose, emails ] );
+		mutation.mutate(
+			{ emails, categories: categoryIds },
+			{
+				onSuccess: () => {
+					setEmails( [] );
+					setFileName( null );
+					setCategoryIds( [] );
+					if ( fileInputRef.current ) {
+						fileInputRef.current.value = '';
+					}
+					onClose();
+				},
+			}
+		);
+	}, [ categoryIds, mutation, onClose, emails ] );
 
 	return (
 		<Stack direction="column" gap="md">
@@ -539,6 +660,11 @@ function UploadTab( { mutation, importInProgress, onClose }: AddTabProps ): JSX.
 				disabled={ mutation.isPending }
 				onFile={ handleFile }
 				inputRef={ fileInputRef }
+			/>
+			<CategoriesField
+				selectedIds={ categoryIds }
+				onChange={ setCategoryIds }
+				disabled={ importInProgress }
 			/>
 			<ImportConsentNotice />
 			{ readError ? (

--- a/projects/packages/newsletter/_inc/subscribers/components/subscribers-body.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/subscribers-body.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { useNavigate, useSearch } from '@wordpress/route';
 import { useImportCompletionRefresh } from '../data/use-import-completion-refresh';
+import { useNewsletterCategories } from '../data/use-newsletter-categories';
 import { installDataViewsFooterI18n } from '../lib/dataviews-i18n';
 import { getBlogId } from '../lib/site';
 import { isOpenSubscriberRemoved, toFiniteNumber } from '../lib/subscriber-helpers';
@@ -57,6 +58,12 @@ export default function SubscribersBody( {
 	// this always-mounted shell doesn't poll the WP.com import endpoint on the Settings tab, for
 	// connection-gated users, or on Settings-only sites.
 	useImportCompletionRefresh( importRefreshEnabled );
+
+	// Warm the newsletter-categories cache while the list loads, so the Add Subscribers category
+	// picker renders immediately when the modal opens instead of popping in after its own round
+	// trip. Gated to the same import-capable audience as the completion poll so it never fetches on
+	// the Settings tab or for connection-gated users. Shares the query key the modal reads.
+	useNewsletterCategories( { enabled: importRefreshEnabled } );
 
 	const [ isAddOpen, setAddOpen ] = useState( false );
 	const openAdd = useCallback( () => setAddOpen( true ), [] );

--- a/projects/packages/newsletter/_inc/subscribers/data/api.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/api.ts
@@ -3,6 +3,7 @@ import { addQueryArgs } from '@wordpress/url';
 import type {
 	AddSubscribersResponse,
 	ImportJob,
+	NewsletterCategoriesData,
 	RemoveSubscriberPayload,
 	RemoveSubscriberResponse,
 	SubscribedNewsletterCategories,
@@ -73,14 +74,39 @@ export function removeSubscriber(
  * an async job — no invitation email is sent; WP.com emails a "Subscriber import completed"
  * summary when the job finishes.
  *
- * @param emails - Email addresses to import.
+ * @param emails     - Email addresses to import.
+ * @param categories - Newsletter category ids to opt the imported subscribers into. Omitted from
+ *                   the payload when empty, matching Calypso's behavior when the picker is off.
  * @return WP.com response carrying the import job id.
  */
-export function addSubscribers( emails: string[] ): Promise< AddSubscribersResponse > {
+export function addSubscribers(
+	emails: string[],
+	categories: number[] = []
+): Promise< AddSubscribersResponse > {
+	const data: { emails: string[]; categories?: number[] } = { emails };
+	if ( categories.length > 0 ) {
+		data.categories = categories;
+	}
+
 	return apiFetch< AddSubscribersResponse >( {
 		path: '/wpcom/v2/subscribers/add',
 		method: 'POST',
-		data: { emails },
+		data,
+	} );
+}
+
+/**
+ * Fetch the site's newsletter categories and whether the feature is enabled, via the Jetpack proxy
+ * (`GET /wpcom/v2/newsletter-categories`). Unlike {@link fetchSubscribedNewsletterCategories} this
+ * is not scoped to a subscriber, so it's usable from the import flow where no subscriber exists
+ * yet. Mirrors Calypso's `useNewsletterCategories`.
+ *
+ * @return Site categories plus the `enabled` feature flag.
+ */
+export function fetchNewsletterCategories(): Promise< NewsletterCategoriesData > {
+	return apiFetch< NewsletterCategoriesData >( {
+		path: '/wpcom/v2/newsletter-categories',
+		method: 'GET',
 	} );
 }
 

--- a/projects/packages/newsletter/_inc/subscribers/data/types.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/types.ts
@@ -164,6 +164,23 @@ export type SubscribedNewsletterCategories = {
 	newsletter_categories: NewsletterCategory[];
 };
 
+// Site-level newsletter categories (the `/wpcom/v2/newsletter-categories` list), independent of
+// any one subscriber. Same shape as the per-subscriber response minus the `subscribed`
+// discriminator — used to gate and populate the "add to specific categories" import picker.
+export type NewsletterCategoriesData = {
+	// Whether the site has Newsletter categories turned on. Sourced from the site option, so it
+	// tracks the Newsletter settings toggle. When false the import picker is hidden entirely.
+	enabled: boolean;
+	newsletter_categories: NewsletterCategory[];
+};
+
+// Payload for the add-subscribers import. `categories` carries the ids selected in the import
+// picker; omitted/empty when the user doesn't assign any, matching Calypso's `importCsvSubscribers`.
+export type AddSubscribersPayload = {
+	emails: string[];
+	categories?: number[];
+};
+
 export type SubscriberStats = {
 	emails_sent: number;
 	unique_opens: number;

--- a/projects/packages/newsletter/_inc/subscribers/data/use-add-subscribers-mutation.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/use-add-subscribers-mutation.ts
@@ -4,12 +4,13 @@ import { _n, sprintf } from '@wordpress/i18n';
 import { store as noticesStore } from '@wordpress/notices';
 import { addSubscribers } from './api';
 import { IMPORT_IN_PROGRESS_NOTICE_ID } from './use-import-jobs';
-import type { AddSubscribersResponse } from './types';
+import type { AddSubscribersPayload, AddSubscribersResponse } from './types';
 
 /**
- * Add-subscribers mutation. POSTs `emails` to the proxy, which starts an async WP.com import
- * job, then invalidates the subscribers list cache. Fast imports show up on the refetch; larger
- * ones land once WP.com finishes the job and sends its "Subscriber import completed" email.
+ * Add-subscribers mutation. POSTs `emails` (and any selected newsletter category ids) to the
+ * proxy, which starts an async WP.com import job, then invalidates the subscribers list cache.
+ * Fast imports show up on the refetch; larger ones land once WP.com finishes the job and sends its
+ * "Subscriber import completed" email.
  *
  * The "Importing…" snackbar is created under {@link IMPORT_IN_PROGRESS_NOTICE_ID} so
  * `useImportCompletionRefresh` can resolve it into a success / failure notice when the job ends.
@@ -20,9 +21,9 @@ export function useAddSubscribersMutation() {
 	const queryClient = useQueryClient();
 	const { createSuccessNotice, createErrorNotice } = useDispatch( noticesStore );
 
-	return useMutation< AddSubscribersResponse, Error, string[] >( {
-		mutationFn: ( emails: string[] ) => addSubscribers( emails ),
-		onSuccess: ( _response, emails ) => {
+	return useMutation< AddSubscribersResponse, Error, AddSubscribersPayload >( {
+		mutationFn: ( { emails, categories } ) => addSubscribers( emails, categories ),
+		onSuccess: ( _response, { emails } ) => {
 			queryClient.invalidateQueries( { queryKey: [ 'subscribers' ] } );
 
 			createSuccessNotice(

--- a/projects/packages/newsletter/_inc/subscribers/data/use-newsletter-categories.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/use-newsletter-categories.ts
@@ -17,12 +17,21 @@ const NO_CATEGORIES: NewsletterCategoriesData = {
  * `useNewsletterCategories`). On error it resolves to a disabled, empty result so the picker simply
  * stays hidden rather than surfacing an error in the import flow.
  *
+ * The dashboard shell warms this query on mount (gated to import-capable visitors) so the picker is
+ * already cached — and renders instantly — by the time the modal opens, instead of the user
+ * watching it pop in after a round trip. The 5-minute `staleTime` keeps that prefetch fresh across
+ * the shared cache key.
+ *
+ * @param options         - Query options.
+ * @param options.enabled - Whether to run the query. Defaults to true; the shell passes its
+ *                        import-capable gate so it doesn't fetch off the Subscribers surface.
  * @return React-Query result for the site's newsletter categories.
  */
-export function useNewsletterCategories() {
+export function useNewsletterCategories( { enabled = true }: { enabled?: boolean } = {} ) {
 	return useQuery< NewsletterCategoriesData, Error >( {
 		queryKey: [ 'newsletter-categories' ],
 		queryFn: () => fetchNewsletterCategories().catch( () => NO_CATEGORIES ),
 		staleTime: STALE_TIME,
+		enabled,
 	} );
 }

--- a/projects/packages/newsletter/_inc/subscribers/data/use-newsletter-categories.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/use-newsletter-categories.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchNewsletterCategories } from './api';
+import type { NewsletterCategoriesData } from './types';
+
+// Site-level newsletter categories are shared across the dashboard and change rarely, so keep the
+// result fresh for a while to avoid refetching every time the Add Subscribers modal opens.
+const STALE_TIME = 5 * 60 * 1000;
+
+const NO_CATEGORIES: NewsletterCategoriesData = {
+	enabled: false,
+	newsletter_categories: [],
+};
+
+/**
+ * Fetch the site's newsletter categories and whether the feature is enabled. Used by the Add
+ * Subscribers import picker to decide whether to offer category assignment (mirrors Calypso's
+ * `useNewsletterCategories`). On error it resolves to a disabled, empty result so the picker simply
+ * stays hidden rather than surfacing an error in the import flow.
+ *
+ * @return React-Query result for the site's newsletter categories.
+ */
+export function useNewsletterCategories() {
+	return useQuery< NewsletterCategoriesData, Error >( {
+		queryKey: [ 'newsletter-categories' ],
+		queryFn: () => fetchNewsletterCategories().catch( () => NO_CATEGORIES ),
+		staleTime: STALE_TIME,
+	} );
+}

--- a/projects/packages/newsletter/_inc/subscribers/data/use-newsletter-categories.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/use-newsletter-categories.ts
@@ -2,9 +2,12 @@ import { useQuery } from '@tanstack/react-query';
 import { fetchNewsletterCategories } from './api';
 import type { NewsletterCategoriesData } from './types';
 
-// Site-level newsletter categories are shared across the dashboard and change rarely, so keep the
-// result fresh for a while to avoid refetching every time the Add Subscribers modal opens.
-const STALE_TIME = 5 * 60 * 1000;
+// Treat the cached result as immediately stale so every consumer mount refetches. The Add
+// Subscribers modal remounts on open, so this picks up a categories feature toggle flipped on the
+// Settings tab — which lives on a separate surface that never invalidates this key — the next time
+// the picker opens, without a full page reload. The prefetched cache still paints the picker
+// instantly; the refetch just reconciles it in the background (stale-while-revalidate).
+const STALE_TIME = 0;
 
 const NO_CATEGORIES: NewsletterCategoriesData = {
 	enabled: false,
@@ -19,8 +22,9 @@ const NO_CATEGORIES: NewsletterCategoriesData = {
  *
  * The dashboard shell warms this query on mount (gated to import-capable visitors) so the picker is
  * already cached — and renders instantly — by the time the modal opens, instead of the user
- * watching it pop in after a round trip. The 5-minute `staleTime` keeps that prefetch fresh across
- * the shared cache key.
+ * watching it pop in after a round trip. Opening the modal remounts this hook and refetches in the
+ * background, so a categories feature toggle flipped on the Settings tab is reflected without a full
+ * page reload while the cached value keeps the picker from popping in.
  *
  * @param options         - Query options.
  * @param options.enabled - Whether to run the query. Defaults to true; the shell passes its

--- a/projects/packages/newsletter/changelog/nl-806-csv-import-categories
+++ b/projects/packages/newsletter/changelog/nl-806-csv-import-categories
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Subscribers: Restore the option to assign imported subscribers to specific newsletter categories on CSV upload and manual add.

--- a/projects/packages/newsletter/tests/subscribers-api.test.ts
+++ b/projects/packages/newsletter/tests/subscribers-api.test.ts
@@ -1,5 +1,9 @@
 import apiFetch from '@wordpress/api-fetch';
-import { fetchSubscribedNewsletterCategories } from '../_inc/subscribers/data/api';
+import {
+	addSubscribers,
+	fetchNewsletterCategories,
+	fetchSubscribedNewsletterCategories,
+} from '../_inc/subscribers/data/api';
 
 jest.mock( '@wordpress/api-fetch' );
 
@@ -12,6 +16,15 @@ const mockApiFetch = apiFetch as unknown as jest.Mock;
  */
 function requestedPath(): string {
 	return mockApiFetch.mock.calls[ 0 ][ 0 ].path;
+}
+
+/**
+ * The full request options passed to `apiFetch` on the first call.
+ *
+ * @return Request options (path, method, data).
+ */
+function requestedOptions(): { path: string; method: string; data?: Record< string, unknown > } {
+	return mockApiFetch.mock.calls[ 0 ][ 0 ];
 }
 
 describe( 'fetchSubscribedNewsletterCategories', () => {
@@ -47,5 +60,53 @@ describe( 'fetchSubscribedNewsletterCategories', () => {
 		await fetchSubscribedNewsletterCategories( { user_id: 229907063 } );
 
 		expect( mockApiFetch.mock.calls[ 0 ][ 0 ].method ).toBe( 'GET' );
+	} );
+} );
+
+describe( 'fetchNewsletterCategories', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockApiFetch.mockResolvedValue( { enabled: true, newsletter_categories: [] } );
+	} );
+
+	it( 'GETs the site-level, subscriber-agnostic categories endpoint', async () => {
+		// This is the gate the import picker reads — it must NOT hit the per-subscriber
+		// `/subscriptions/{id}` route, which can't be resolved without a subscriber.
+		await fetchNewsletterCategories();
+
+		expect( requestedOptions().path ).toBe( '/wpcom/v2/newsletter-categories' );
+		expect( requestedOptions().method ).toBe( 'GET' );
+	} );
+} );
+
+describe( 'addSubscribers', () => {
+	beforeEach( () => {
+		jest.clearAllMocks();
+		mockApiFetch.mockResolvedValue( { upload_id: 1 } );
+	} );
+
+	it( 'POSTs emails to the add endpoint', async () => {
+		await addSubscribers( [ 'reader@example.com' ] );
+
+		expect( requestedOptions().path ).toBe( '/wpcom/v2/subscribers/add' );
+		expect( requestedOptions().method ).toBe( 'POST' );
+		expect( requestedOptions().data ).toEqual( { emails: [ 'reader@example.com' ] } );
+	} );
+
+	it( 'includes selected category ids in the payload', async () => {
+		await addSubscribers( [ 'reader@example.com' ], [ 7, 12 ] );
+
+		expect( requestedOptions().data ).toEqual( {
+			emails: [ 'reader@example.com' ],
+			categories: [ 7, 12 ],
+		} );
+	} );
+
+	it( 'omits the categories key entirely when none are selected', async () => {
+		// A plain import must send the exact payload it always did — no empty `categories` array —
+		// so existing behavior is untouched on sites that don't use categories.
+		await addSubscribers( [ 'reader@example.com' ], [] );
+
+		expect( requestedOptions().data ).not.toHaveProperty( 'categories' );
 	} );
 } );

--- a/projects/packages/newsletter/tests/use-add-subscribers-mutation.test.tsx
+++ b/projects/packages/newsletter/tests/use-add-subscribers-mutation.test.tsx
@@ -1,0 +1,89 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useAddSubscribersMutation } from '../_inc/subscribers/data/use-add-subscribers-mutation';
+
+const mockCreateSuccessNotice = jest.fn();
+const mockCreateErrorNotice = jest.fn();
+const mockAddSubscribers = jest.fn();
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( {
+		createSuccessNotice: mockCreateSuccessNotice,
+		createErrorNotice: mockCreateErrorNotice,
+	} ),
+} ) );
+
+jest.mock( '@wordpress/notices', () => ( {
+	store: 'core/notices',
+} ) );
+
+jest.mock( '../_inc/subscribers/data/api', () => ( {
+	addSubscribers: ( ...args: unknown[] ) => mockAddSubscribers( ...args ),
+} ) );
+
+const renderMutation = () => {
+	const queryClient = new QueryClient( {
+		defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+	} );
+	const wrapper = ( { children }: { children: React.ReactNode } ) => (
+		<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+	);
+	const invalidateSpy = jest.spyOn( queryClient, 'invalidateQueries' );
+	const { result } = renderHook( () => useAddSubscribersMutation(), { wrapper } );
+	return { result, invalidateSpy };
+};
+
+beforeEach( () => {
+	mockCreateSuccessNotice.mockReset();
+	mockCreateErrorNotice.mockReset();
+	mockAddSubscribers.mockReset();
+} );
+
+describe( 'useAddSubscribersMutation', () => {
+	it( 'forwards selected category ids alongside the emails', async () => {
+		mockAddSubscribers.mockResolvedValue( { upload_id: 99 } );
+
+		const { result, invalidateSpy } = renderMutation();
+		await act( async () => {
+			await result.current.mutateAsync( {
+				emails: [ 'one@example.com', 'two@example.com' ],
+				categories: [ 3, 8 ],
+			} );
+		} );
+
+		expect( mockAddSubscribers ).toHaveBeenCalledWith(
+			[ 'one@example.com', 'two@example.com' ],
+			[ 3, 8 ]
+		);
+		expect( invalidateSpy ).toHaveBeenCalledWith( { queryKey: [ 'subscribers' ] } );
+		// The snackbar counts emails, not categories.
+		await waitFor( () => expect( mockCreateSuccessNotice ).toHaveBeenCalledTimes( 1 ) );
+		expect( mockCreateSuccessNotice.mock.calls[ 0 ][ 0 ] ).toContain( '2' );
+	} );
+
+	it( 'passes undefined categories through untouched for a plain import', async () => {
+		mockAddSubscribers.mockResolvedValue( { upload_id: 100 } );
+
+		const { result } = renderMutation();
+		await act( async () => {
+			await result.current.mutateAsync( { emails: [ 'reader@example.com' ] } );
+		} );
+
+		expect( mockAddSubscribers ).toHaveBeenCalledWith( [ 'reader@example.com' ], undefined );
+	} );
+
+	it( 'surfaces an error notice when the import fails', async () => {
+		mockAddSubscribers.mockRejectedValue( new Error( 'Import limit reached.' ) );
+
+		const { result } = renderMutation();
+		await act( async () => {
+			await result.current
+				.mutateAsync( { emails: [ 'reader@example.com' ], categories: [] } )
+				.catch( () => undefined );
+		} );
+
+		await waitFor( () => expect( mockCreateErrorNotice ).toHaveBeenCalledTimes( 1 ) );
+		expect( mockCreateErrorNotice.mock.calls[ 0 ][ 0 ] ).toBe( 'Import limit reached.' );
+		expect( mockCreateSuccessNotice ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/packages/newsletter/tests/use-newsletter-categories.test.tsx
+++ b/projects/packages/newsletter/tests/use-newsletter-categories.test.tsx
@@ -1,0 +1,60 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import { useNewsletterCategories } from '../_inc/subscribers/data/use-newsletter-categories';
+import type { NewsletterCategoriesData } from '../_inc/subscribers/data/types';
+import type { ReactNode } from 'react';
+
+const mockFetch = jest.fn();
+
+jest.mock( '../_inc/subscribers/data/api', () => ( {
+	fetchNewsletterCategories: ( ...args: unknown[] ) => mockFetch( ...args ),
+} ) );
+
+const ENABLED: NewsletterCategoriesData = {
+	enabled: true,
+	newsletter_categories: [ { id: 7, name: 'News' } ],
+};
+const DISABLED: NewsletterCategoriesData = { enabled: false, newsletter_categories: [] };
+
+/**
+ * A wrapper backed by a single shared QueryClient, so unmounting and remounting the hook models
+ * the Add Subscribers modal closing and reopening against the same cache.
+ *
+ * @return Wrapper component plus the shared client.
+ */
+function makeWrapper() {
+	const queryClient = new QueryClient( {
+		defaultOptions: { queries: { retry: false } },
+	} );
+	const wrapper = ( { children }: { children: ReactNode } ) => (
+		<QueryClientProvider client={ queryClient }>{ children }</QueryClientProvider>
+	);
+	return { wrapper, queryClient };
+}
+
+beforeEach( () => {
+	mockFetch.mockReset();
+} );
+
+describe( 'useNewsletterCategories', () => {
+	it( 'refetches on remount so a settings-tab feature toggle is reflected the next time the modal opens', async () => {
+		// The feature toggle lives on a separate surface that never invalidates this query, so the
+		// picker can only pick up the change by refetching when the modal reopens (a fresh mount).
+		const { wrapper } = makeWrapper();
+
+		mockFetch.mockResolvedValueOnce( ENABLED );
+		const { result: firstResult, unmount } = renderHook( () => useNewsletterCategories(), {
+			wrapper,
+		} );
+		await waitFor( () => expect( firstResult.current.data?.enabled ).toBe( true ) );
+
+		// User closes the modal, then disables newsletter categories on the Settings tab.
+		unmount();
+		mockFetch.mockResolvedValueOnce( DISABLED );
+
+		// Reopening the modal must surface the now-disabled feature, not the cached enabled state.
+		const { result: secondResult } = renderHook( () => useNewsletterCategories(), { wrapper } );
+		await waitFor( () => expect( secondResult.current.data?.enabled ).toBe( false ) );
+		expect( mockFetch ).toHaveBeenCalledTimes( 2 );
+	} );
+} );

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-subscribers-list.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-subscribers-list.php
@@ -59,13 +59,18 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List extends WP_REST_Controller {
 					'callback'            => array( $this, 'add_subscribers' ),
 					'permission_callback' => array( $this, 'permission_check' ),
 					'args'                => array(
-						'emails' => array(
+						'emails'     => array(
 							'type'              => 'array',
 							'items'             => array( 'type' => 'string' ),
 							'required'          => true,
 							'validate_callback' => function ( $value ) {
 								return is_array( $value ) && count( $value ) > 0;
 							},
+						),
+						'categories' => array(
+							'type'    => 'array',
+							'items'   => array( 'type' => 'integer' ),
+							'default' => array(),
 						),
 					),
 				),
@@ -547,6 +552,10 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List extends WP_REST_Controller {
 	 * subscribers (no invitation email); WP.com processes the job in the background and emails the
 	 * importing user a "Subscriber import completed" summary when it finishes.
 	 *
+	 * When the caller passes `categories` (newsletter category ids selected in the Add Subscribers
+	 * picker), they're forwarded so the imported subscribers are opted into those categories — the
+	 * same `categories` payload Calypso's `importCsvSubscribers` sends to this endpoint.
+	 *
 	 * @param WP_REST_Request $request Request.
 	 * @return WP_REST_Response|WP_Error
 	 */
@@ -575,6 +584,24 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List extends WP_REST_Controller {
 			);
 		}
 
+		// Coerce category ids to positive integers and drop anything else — a category id is always
+		// a term id, so a zero or non-numeric value is noise we shouldn't forward to WP.com.
+		$categories = array_values(
+			array_filter(
+				array_map( 'absint', (array) $request->get_param( 'categories' ) )
+			)
+		);
+
+		$body = array(
+			'emails'     => $emails,
+			'parse_only' => false,
+		);
+		// Only include `categories` when the user actually selected some, so a plain import keeps
+		// the exact payload it sent before this feature existed.
+		if ( ! empty( $categories ) ) {
+			$body['categories'] = $categories;
+		}
+
 		// JSON body, not the form encoding Calypso submits: WP.com's Jetpack signature verifier
 		// canonicalizes `application/x-www-form-urlencoded` bodies differently from the Jetpack
 		// client (it re-encodes the parsed array as JSON before hashing), so a form-encoded POST
@@ -589,13 +616,7 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List extends WP_REST_Controller {
 				'method'  => 'POST',
 				'headers' => array( 'Content-Type' => 'application/json' ),
 			),
-			wp_json_encode(
-				array(
-					'emails'     => $emails,
-					'parse_only' => false,
-				),
-				JSON_UNESCAPED_SLASHES
-			),
+			wp_json_encode( $body, JSON_UNESCAPED_SLASHES ),
 			'wpcom'
 		);
 

--- a/projects/plugins/jetpack/changelog/nl-806-csv-import-categories
+++ b/projects/plugins/jetpack/changelog/nl-806-csv-import-categories
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Subscribers: Restore the option to assign imported subscribers to specific newsletter categories on CSV upload and manual add.

--- a/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Subscribers_List_Test.php
+++ b/projects/plugins/jetpack/tests/php/core-api/wpcom-endpoints/WPCOM_REST_API_V2_Endpoint_Subscribers_List_Test.php
@@ -247,6 +247,90 @@ class WPCOM_REST_API_V2_Endpoint_Subscribers_List_Test extends Jetpack_REST_Test
 	}
 
 	/**
+	 * When the caller selects newsletter categories, their ids are forwarded (as positive ints) in
+	 * the import payload — the same `categories` field Calypso sends — so imported subscribers are
+	 * opted into those categories. Non-integer / zero ids are dropped.
+	 */
+	public function test_add_forwards_selected_categories() {
+		$captured_body = '';
+		$filter        = function ( $preempt, $parsed_args ) use ( &$captured_body ) {
+			$captured_body = $parsed_args['body'] ?? null;
+
+			return array(
+				'headers'  => array(),
+				'body'     => wp_json_encode( array( 'upload_id' => 7 ), JSON_UNESCAPED_SLASHES ),
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+				'filename' => null,
+			);
+		};
+		add_filter( 'pre_http_request', $filter, 10, 3 );
+
+		$request = new WP_REST_Request( Requests::POST, '/wpcom/v2/subscribers/add' );
+		$request->set_header( 'content_type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'emails'     => array( 'reader@example.com' ),
+					'categories' => array( 12, 0, 34 ),
+				),
+				JSON_UNESCAPED_SLASHES
+			)
+		);
+
+		$response = $this->server->dispatch( $request );
+
+		remove_filter( 'pre_http_request', $filter, 10 );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$sent = (array) json_decode( (string) $captured_body, true );
+		$this->assertSame( array( 12, 34 ), $sent['categories'] );
+		$this->assertSame( array( 'reader@example.com' ), $sent['emails'] );
+	}
+
+	/**
+	 * A plain import (no categories selected) sends the exact payload it always did — no
+	 * `categories` key at all — so behavior on sites that don't use categories is untouched.
+	 */
+	public function test_add_omits_categories_key_when_none_selected() {
+		$captured_body = '';
+		$filter        = function ( $preempt, $parsed_args ) use ( &$captured_body ) {
+			$captured_body = $parsed_args['body'] ?? null;
+
+			return array(
+				'headers'  => array(),
+				'body'     => wp_json_encode( array( 'upload_id' => 8 ), JSON_UNESCAPED_SLASHES ),
+				'response' => array(
+					'code'    => 200,
+					'message' => 'OK',
+				),
+				'cookies'  => array(),
+				'filename' => null,
+			);
+		};
+		add_filter( 'pre_http_request', $filter, 10, 3 );
+
+		$request = new WP_REST_Request( Requests::POST, '/wpcom/v2/subscribers/add' );
+		$request->set_header( 'content_type', 'application/json' );
+		$request->set_body(
+			wp_json_encode( array( 'emails' => array( 'reader@example.com' ) ), JSON_UNESCAPED_SLASHES )
+		);
+
+		$response = $this->server->dispatch( $request );
+
+		remove_filter( 'pre_http_request', $filter, 10 );
+
+		$this->assertSame( 200, $response->get_status() );
+
+		$sent = (array) json_decode( (string) $captured_body, true );
+		$this->assertArrayNotHasKey( 'categories', $sent );
+	}
+
+	/**
 	 * The import endpoint can report a failure inside a 2xx response (e.g. a subscriber limit);
 	 * any body without an `upload_id` maps to a WP_Error carrying the upstream message.
 	 */


### PR DESCRIPTION
Fixes NL-806

## Proposed changes

The modernized wp-admin Subscribers dashboard's **Add Subscribers** modal imported emails only — it dropped the "Add these subscribers to specific categories" picker that Calypso's Add Subscribers flow offered. This restores category assignment on import.

* Add a gated `CategoriesField` (a `ToggleControl` that reveals a `FormTokenField`) to both the **Upload CSV** and **Manual** add tabs, mirroring Calypso's `CategoriesSection`. It renders only when the site has newsletter categories enabled and at least one category exists.
* The gate reads the site-level `/wpcom/v2/newsletter-categories` endpoint (`{ enabled, newsletter_categories }`), not the per-subscriber `/newsletter-categories/subscriptions/{id}` route — the latter can't be resolved during import because no subscriber exists yet.
* Selected category ids are threaded through `useAddSubscribersMutation` → `addSubscribers()` → the `/wpcom/v2/subscribers/add` PHP proxy, which now forwards them (sanitized to positive ints) in the JSON body it sends to `/sites/{id}/subscribers/import`. That's the same `categories` payload Calypso's `importCsvSubscribers` sends, and the WP.com import backend already understands it — so no WP.com-side change is required.

Manual add | Upload CSV
---- | ----
<img width="587" height="673" alt="Screenshot 2026-08-04 at 3 35 25 PM" src="https://github.com/user-attachments/assets/113a95f2-ecf2-4058-b7b8-9077a20d909c" /> | <img width="596" height="657" alt="Screenshot 2026-08-04 at 3 35 33 PM" src="https://github.com/user-attachments/assets/b466d6e2-906d-4df5-b5f4-c0524874f238" />

## Related product discussion/links

* NL-806

## Does this pull request change what data or activity we track or use?

No. It forwards user-selected newsletter category ids that already exist on the site to the same import endpoint Calypso uses.

## Testing instructions

1. On the site, go to **Jetpack → Newsletter → Settings**, enable Newsletter categories, and create at least 2 categories.
2. Go to **Jetpack → Newsletter → Subscribers** (wp-admin) → **Add subscribers**.
3. On the **Manual** tab: confirm an **"Add these subscribers to specific categories"** toggle appears below the email field. Toggle it on, pick one or more categories, enter a test email, and submit.
4. On the **Upload CSV** tab: confirm the same toggle appears below the dropzone. Upload a CSV, pick categories, and submit.
5. Verify the imported subscribers are opted into the selected categories (open a subscriber's detail view → "Receives emails for", or check the category subscription counts).
6. On a site **without** newsletter categories enabled (or with none created): confirm the toggle does **not** appear on either tab, and a plain import still works.

### Automated tests

* JS (`jp test js packages/newsletter`): 167 pass, incl. new coverage for `addSubscribers` payload (with/without categories), `fetchNewsletterCategories` targeting the site-level route, and the mutation threading category ids through.
* PHP (`jp docker phpunit jetpack -- --filter=WPCOM_REST_API_V2_Endpoint_Subscribers_List_Test`): 22 pass, incl. new tests that categories are forwarded (and sanitized) to the import endpoint, and that the `categories` key is omitted entirely for a plain import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
