### PR TITLE
Charts: pick time-axis ticks by bucket resolution as well as span

### DIFF
--- a/projects/js-packages/charts/changelog/echo-wooa7s-1834-hourly-traffic-chart
+++ b/projects/js-packages/charts/changelog/echo-wooa7s-1834-hourly-traffic-chart
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Time axis: show hour ticks (with the date at midnight boundaries) for sub-daily series spanning up to a week.
+Time axis: pick tick formats by bucket resolution as well as span — hour ticks (with the date at midnight boundaries) for sub-daily series spanning up to a week, and month ticks (with the year at January) instead of full dates for month-or-coarser buckets.

--- a/projects/js-packages/charts/changelog/echo-wooa7s-1834-hourly-traffic-chart
+++ b/projects/js-packages/charts/changelog/echo-wooa7s-1834-hourly-traffic-chart
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Time axis: show hour ticks (with the date at midnight boundaries) for sub-daily series spanning up to a week.

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.stories.tsx
@@ -505,6 +505,94 @@ BrokenLine.parameters = {
 	},
 };
 
+// Wall-clock dates in the browser frame — the library's parsing convention —
+// so the ticks read the same in any viewer timezone.
+const hourlySeries = ( label: string, startDay: number, hours: number ): SeriesData => ( {
+	label,
+	data: Array.from( { length: hours }, ( _, i ) => ( {
+		date: new Date( 2026, 7, startDay, i ),
+		value: Math.round( 60 + 40 * Math.sin( ( i % 24 ) / 3.5 ) ),
+	} ) ),
+	options: {},
+} );
+
+export const TimeAxisTickFormats: StoryObj< StoryArgs > = {
+	render: () => (
+		<div style={ { display: 'grid', gap: '2rem', gridTemplateColumns: 'repeat(2, 1fr)' } }>
+			<div>
+				<h3>Hourly buckets, single day → hour ticks</h3>
+				<LineChart
+					width={ 460 }
+					height={ 220 }
+					data={ [ hourlySeries( 'Views', 2, 24 ) ] }
+					withGradientFill={ false }
+					withLegendGlyph={ false }
+				/>
+			</div>
+			<div>
+				<h3>Hourly buckets, two days → hour ticks, date at midnight</h3>
+				<LineChart
+					width={ 460 }
+					height={ 220 }
+					data={ [ hourlySeries( 'Views', 2, 48 ) ] }
+					withGradientFill={ false }
+					withLegendGlyph={ false }
+				/>
+			</div>
+			<div>
+				<h3>Daily buckets → date ticks</h3>
+				<LineChart
+					width={ 460 }
+					height={ 220 }
+					data={ [
+						{
+							label: 'Views',
+							data: Array.from( { length: 30 }, ( _, i ) => ( {
+								date: new Date( 2026, 6, 1 + i ),
+								value: Math.round( 60 + 40 * Math.sin( i / 4 ) ),
+							} ) ),
+							options: {},
+						},
+					] }
+					withGradientFill={ false }
+					withLegendGlyph={ false }
+				/>
+			</div>
+			<div>
+				<h3>Monthly buckets → month ticks, year at January</h3>
+				<LineChart
+					width={ 460 }
+					height={ 220 }
+					data={ [
+						{
+							label: 'Views',
+							data: Array.from( { length: 13 }, ( _, i ) => ( {
+								date: new Date( 2025, 7 + i, 1 ),
+								value: Math.round( 60 + 40 * Math.sin( i / 2 ) ),
+							} ) ),
+							options: {},
+						},
+					] }
+					withGradientFill={ false }
+					withLegendGlyph={ false }
+				/>
+			</div>
+		</div>
+	),
+	args: {
+		containerWidth: '1020px',
+		containerHeight: '700px',
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"The time axis picks its tick format from the data's bucket resolution as well as its span: hour ticks within a day; hour ticks with the date at midnight boundaries for sub-daily data spanning up to a week; date ticks for daily and weekly buckets within a year; month ticks (with the year at January) for month-or-coarser buckets; year ticks beyond that.",
+			},
+		},
+	},
+};
+
 export const DateStringFormats: StoryObj< StoryArgs > = Template.bind( {} );
 DateStringFormats.args = {
 	...lineChartStoryArgs,

--- a/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
@@ -442,6 +442,27 @@ describe( 'LineChart', () => {
 				data: [
 					{
 						label: 'Series A',
+						// Weekly resolution: fine enough to keep full dates on the ticks.
+						data: Array.from( { length: 16 }, ( _, i ) => ( {
+							date: new Date( Date.UTC( 2024, 0, 1 + i * 7 ) ),
+							value: 10 + i,
+						} ) ),
+					},
+				],
+			} );
+
+			const ticks = screen.getAllByText(
+				/^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d+$/
+			);
+			expect( ticks.length ).toBeGreaterThan( 1 );
+		} );
+
+		test( 'renders month ticks for month-or-coarser buckets within a year.', () => {
+			renderWithTheme( {
+				width: 800,
+				data: [
+					{
+						label: 'Series A',
 						data: [
 							{ date: new Date( '2024-01-01' ), value: 10 },
 							{ date: new Date( '2024-04-01' ), value: 20 },
@@ -453,9 +474,7 @@ describe( 'LineChart', () => {
 				],
 			} );
 
-			const ticks = screen.getAllByText(
-				/^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d+$/
-			);
+			const ticks = screen.getAllByText( /^(Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)$/ );
 			expect( ticks.length ).toBeGreaterThan( 1 );
 		} );
 
@@ -502,7 +521,8 @@ describe( 'LineChart', () => {
 				],
 			} );
 
-			const ticks = screen.getAllByText( /(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct) \d+/ );
+			// Roughly monthly buckets render month ticks under the resolution-aware formatter.
+			const ticks = screen.getAllByText( /^(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct)$/ );
 			expect( ticks.length ).toBeLessThan( 6 ); // Not much space
 		} );
 

--- a/projects/js-packages/charts/src/charts/private/test/time-axis.test.ts
+++ b/projects/js-packages/charts/src/charts/private/test/time-axis.test.ts
@@ -1,0 +1,76 @@
+import { getFormatter } from '../time-axis';
+import type { useChartDataTransform } from '../../../hooks';
+
+type SortedData = ReturnType< typeof useChartDataTransform >;
+
+const toSeries = ( dates: Date[] ): SortedData =>
+	[
+		{
+			label: 'series',
+			data: dates.map( date => ( { date, value: 1 } ) ),
+		},
+	] as unknown as SortedData;
+
+const hourlyDates = ( start: Date, hours: number ): Date[] =>
+	Array.from( { length: hours }, ( _, i ) => new Date( start.getTime() + i * 60 * 60 * 1000 ) );
+
+const dailyDates = ( start: Date, days: number ): Date[] =>
+	Array.from( { length: days }, ( _, i ) => new Date( start.getTime() + i * 24 * 60 * 60 * 1000 ) );
+
+// TZ is pinned to UTC by the test script, so local formatting is deterministic.
+describe( 'getFormatter', () => {
+	it( 'uses hour ticks within a single day', () => {
+		const formatter = getFormatter(
+			toSeries( hourlyDates( new Date( '2026-08-02T00:00:00' ), 24 ) )
+		);
+
+		expect( formatter( new Date( '2026-08-02T13:00:00' ).getTime() ) ).toMatch( /1\sPM/ );
+	} );
+
+	it( 'uses hour ticks with dates at midnight for sub-daily data spanning multiple days', () => {
+		const formatter = getFormatter(
+			toSeries( hourlyDates( new Date( '2026-08-02T00:00:00' ), 48 ) )
+		);
+
+		expect( formatter( new Date( '2026-08-03T00:00:00' ).getTime() ) ).toMatch( /Aug 3/ );
+		expect( formatter( new Date( '2026-08-02T13:00:00' ).getTime() ) ).toMatch( /1\sPM/ );
+	} );
+
+	it( 'keeps date ticks for daily data over the same multi-day span', () => {
+		const formatter = getFormatter(
+			toSeries( dailyDates( new Date( '2026-08-01T00:00:00' ), 3 ) )
+		);
+
+		expect( formatter( new Date( '2026-08-02T00:00:00' ).getTime() ) ).toMatch( /Aug 2/ );
+		expect( formatter( new Date( '2026-08-02T13:00:00' ).getTime() ) ).not.toMatch( /PM/ );
+	} );
+
+	it( 'uses month ticks with the year at January for monthly buckets', () => {
+		const monthlyDates = Array.from(
+			{ length: 13 },
+			( _, i ) => new Date( Date.UTC( 2025, 7 + i, 1 ) )
+		);
+		const formatter = getFormatter( toSeries( monthlyDates ) );
+
+		expect( formatter( new Date( '2025-09-01T00:00:00' ).getTime() ) ).toBe( 'Sep' );
+		expect( formatter( new Date( '2026-01-01T00:00:00' ).getTime() ) ).toBe( '2026' );
+	} );
+
+	it( 'keeps date ticks for weekly buckets within a year', () => {
+		const weeklyDates = Array.from(
+			{ length: 20 },
+			( _, i ) => new Date( Date.UTC( 2026, 0, 5 + i * 7 ) )
+		);
+		const formatter = getFormatter( toSeries( weeklyDates ) );
+
+		expect( formatter( new Date( '2026-03-02T00:00:00' ).getTime() ) ).toMatch( /Mar 2/ );
+	} );
+
+	it( 'uses year ticks beyond a year', () => {
+		const yearly = getFormatter(
+			toSeries( [ new Date( '2020-01-01T00:00:00' ), new Date( '2026-01-01T00:00:00' ) ] )
+		);
+
+		expect( yearly( new Date( '2023-01-01T00:00:00' ).getTime() ) ).toBe( '2023' );
+	} );
+} );

--- a/projects/js-packages/charts/src/charts/private/test/time-axis.test.ts
+++ b/projects/js-packages/charts/src/charts/private/test/time-axis.test.ts
@@ -36,6 +36,14 @@ describe( 'getFormatter', () => {
 		expect( formatter( new Date( '2026-08-02T13:00:00' ).getTime() ) ).toMatch( /1\sPM/ );
 	} );
 
+	it( 'keeps hour ticks up to a full week of sub-daily data', () => {
+		const formatter = getFormatter(
+			toSeries( hourlyDates( new Date( '2026-08-02T00:00:00' ), 24 * 7 + 1 ) )
+		);
+
+		expect( formatter( new Date( '2026-08-05T13:00:00' ).getTime() ) ).toMatch( /1\sPM/ );
+	} );
+
 	it( 'keeps date ticks for daily data over the same multi-day span', () => {
 		const formatter = getFormatter(
 			toSeries( dailyDates( new Date( '2026-08-01T00:00:00' ), 3 ) )
@@ -43,6 +51,40 @@ describe( 'getFormatter', () => {
 
 		expect( formatter( new Date( '2026-08-02T00:00:00' ).getTime() ) ).toMatch( /Aug 2/ );
 		expect( formatter( new Date( '2026-08-02T13:00:00' ).getTime() ) ).not.toMatch( /PM/ );
+	} );
+
+	it( 'keeps date ticks for daily buckets across a spring-forward transition', () => {
+		// A 23-hour first gap, as a daily series straddling spring-forward
+		// produces, must not demote the series to the sub-daily regime.
+		const start = new Date( '2026-03-08T00:00:00' );
+		const dstDates = [ 0, 23, 47, 71 ].map(
+			offsetHours => new Date( start.getTime() + offsetHours * 60 * 60 * 1000 )
+		);
+		const formatter = getFormatter( toSeries( dstDates ) );
+
+		expect( formatter( dstDates[ 2 ].getTime() ) ).not.toMatch( /AM|PM/ );
+		expect( formatter( dstDates[ 2 ].getTime() ) ).toMatch( /Mar/ );
+	} );
+
+	it( 'keeps date ticks when no series has two points', () => {
+		const formatter = getFormatter( [
+			...toSeries( [ new Date( '2026-03-01T00:00:00' ) ] ),
+			...toSeries( [ new Date( '2026-03-04T00:00:00' ) ] ),
+		] );
+
+		expect( formatter( new Date( '2026-03-02T00:00:00' ).getTime() ) ).toMatch( /Mar 2/ );
+	} );
+
+	it( 'uses month ticks for buckets exactly a shortest-month apart', () => {
+		const formatter = getFormatter(
+			toSeries( [
+				new Date( '2026-02-01T00:00:00' ),
+				new Date( '2026-03-01T00:00:00' ),
+				new Date( '2026-04-01T00:00:00' ),
+			] )
+		);
+
+		expect( formatter( new Date( '2026-03-01T00:00:00' ).getTime() ) ).toBe( 'Mar' );
 	} );
 
 	it( 'uses month ticks with the year at January for monthly buckets', () => {

--- a/projects/js-packages/charts/src/charts/private/time-axis.ts
+++ b/projects/js-packages/charts/src/charts/private/time-axis.ts
@@ -47,8 +47,41 @@ const formatHourTick = ( timestamp: number ) => {
 	return date.toLocaleTimeString( undefined, { hour: 'numeric', hour12: true } );
 };
 
-// Pick the most informative tick formatter for the data's time span: hours
-// within a day, calendar dates within a year, otherwise just years.
+// Hour ticks with the date at midnight boundaries, so multi-day spans of
+// sub-daily data keep their days identifiable.
+const formatDateOrHourTick = ( timestamp: number ) => {
+	const date = new Date( timestamp );
+	return date.getHours() === 0 && date.getMinutes() === 0
+		? formatDateTick( timestamp )
+		: formatHourTick( timestamp );
+};
+
+// Month ticks with the year at January boundaries, for month-or-coarser
+// buckets where a full "Sep 1" date would misread as a daily point.
+const formatMonthOrYearTick = ( timestamp: number ) => {
+	const date = new Date( timestamp );
+	return date.getMonth() === 0
+		? formatYearTick( timestamp )
+		: date.toLocaleDateString( undefined, { month: 'short' } );
+};
+
+// Interval between the first two points of the densest series, in hours.
+// Infinity when no series has two points.
+const getPointSpacingInHours = ( sortedData: ReturnType< typeof useChartDataTransform > ) => {
+	return sortedData.reduce( ( spacing, datom ) => {
+		const [ first, second ] = datom.data;
+		if ( first?.date === undefined || second?.date === undefined ) {
+			return spacing;
+		}
+		return Math.min( spacing, Math.abs( differenceInHours( second.date, first.date ) ) );
+	}, Number.POSITIVE_INFINITY );
+};
+
+// Pick the most informative tick formatter for the data's resolution and time
+// span: hours within a day, hours with day boundaries for sub-daily data
+// spanning up to a week, calendar dates for daily-or-finer buckets within a
+// year, months (with the year at January) for month-or-coarser buckets,
+// otherwise just years.
 export const getFormatter = ( sortedData: ReturnType< typeof useChartDataTransform > ) => {
 	const minX = Math.min( ...sortedData.map( datom => datom.data.at( 0 )?.date ) );
 	const maxX = Math.max( ...sortedData.map( datom => datom.data.at( -1 )?.date ) );
@@ -58,9 +91,15 @@ export const getFormatter = ( sortedData: ReturnType< typeof useChartDataTransfo
 		return formatHourTick;
 	}
 
+	const spacingInHours = getPointSpacingInHours( sortedData );
+	if ( diffInHours <= 24 * 7 && spacingInHours < 24 ) {
+		return formatDateOrHourTick;
+	}
+
 	const diffInYears = Math.abs( differenceInYears( maxX, minX ) );
 	if ( diffInYears <= 1 ) {
-		return formatDateTick;
+		// 28 days: the shortest month, so monthly buckets qualify but weekly don't.
+		return spacingInHours >= 28 * 24 ? formatMonthOrYearTick : formatDateTick;
 	}
 
 	return formatYearTick;

--- a/projects/js-packages/charts/src/charts/private/time-axis.ts
+++ b/projects/js-packages/charts/src/charts/private/time-axis.ts
@@ -65,16 +65,23 @@ const formatMonthOrYearTick = ( timestamp: number ) => {
 		: date.toLocaleDateString( undefined, { month: 'short' } );
 };
 
-// Interval between the first two points of the densest series, in hours.
+// Smallest interval between consecutive points across all series, in hours.
 // Infinity when no series has two points.
 const getPointSpacingInHours = ( sortedData: ReturnType< typeof useChartDataTransform > ) => {
-	return sortedData.reduce( ( spacing, datom ) => {
-		const [ first, second ] = datom.data;
-		if ( first?.date === undefined || second?.date === undefined ) {
-			return spacing;
-		}
-		return Math.min( spacing, Math.abs( differenceInHours( second.date, first.date ) ) );
-	}, Number.POSITIVE_INFINITY );
+	return sortedData.reduce(
+		( spacing, datom ) =>
+			datom.data.reduce( ( seriesSpacing, point, index ) => {
+				const previous = datom.data[ index - 1 ];
+				if ( previous?.date === undefined || point?.date === undefined ) {
+					return seriesSpacing;
+				}
+				return Math.min(
+					seriesSpacing,
+					Math.abs( differenceInHours( point.date, previous.date ) )
+				);
+			}, spacing ),
+		Number.POSITIVE_INFINITY
+	);
 };
 
 // Pick the most informative tick formatter for the data's resolution and time
@@ -92,14 +99,20 @@ export const getFormatter = ( sortedData: ReturnType< typeof useChartDataTransfo
 	}
 
 	const spacingInHours = getPointSpacingInHours( sortedData );
-	if ( diffInHours <= 24 * 7 && spacingInHours < 24 ) {
+	// 23, not 24: a daily gap shrinks to 23 wall-clock hours across a
+	// spring-forward DST transition.
+	if ( diffInHours <= 24 * 7 && spacingInHours < 23 ) {
 		return formatDateOrHourTick;
 	}
 
 	const diffInYears = Math.abs( differenceInYears( maxX, minX ) );
 	if ( diffInYears <= 1 ) {
-		// 28 days: the shortest month, so monthly buckets qualify but weekly don't.
-		return spacingInHours >= 28 * 24 ? formatMonthOrYearTick : formatDateTick;
+		// 28 days: the shortest month, so monthly buckets qualify but weekly
+		// don't. The finiteness check keeps all-single-point series — whose
+		// resolution is unknowable — on date ticks.
+		return Number.isFinite( spacingInHours ) && spacingInHours >= 28 * 24
+			? formatMonthOrYearTick
+			: formatDateTick;
 	}
 
 	return formatYearTick;


### PR DESCRIPTION
## Why
When a chart shows hourly or monthly buckets, its date axis currently mislabels them: a two-day hourly series renders a couple of bare date ticks that hide the hours entirely, and a year of monthly buckets renders "Sep 1"-style full dates that read as daily data points. Viewers can't tell what time span a point actually covers.

## Proposed changes
* Teach the time axis's auto tick formatter to consider the data's bucket resolution (the spacing between points of the densest series) in addition to its overall span
* Sub-daily series spanning up to a week get hour ticks, with the date shown at midnight boundaries so days stay identifiable
* Month-or-coarser buckets within a year get month ticks, with the year shown at January boundaries
* Daily and weekly buckets keep the existing short-date ticks, and multi-year spans keep year ticks

## Related product discussion/links
* Extracted from https://github.com/Automattic/jetpack/pull/50917 so the chart-library change can land and be reviewed on its own; needed there for the Traffic widget's hourly Group-by option (https://linear.app/a8c/issue/WOOA7S-1834/add-hourly-stats-to-the-traffic-chart)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Run the unit tests: `cd projects/js-packages/charts && pnpm run test time-axis line-chart`
* Or visually in Storybook: open **JS Packages/Charts Library/Charts/Line Chart → Time Axis Tick Formats** — a grid of the four tick regimes (added in this PR)


## Screenshots

The new `TimeAxisTickFormats` story, showing each bucket resolution picking its tick format:

![Time axis tick formats story: hour ticks for a single day, hour ticks with dates at midnight for two days of hourly data, date ticks for daily buckets, month ticks with the year at January for monthly buckets](https://github.com/user-attachments/assets/2236006b-2741-4088-86c9-1da519425f49)
