### PR TITLE
Charts: gate hour ticks on sub-daily bucket resolution

### DIFF
--- a/projects/js-packages/charts/changelog/echo-charts-daily-pair-hour-ticks
+++ b/projects/js-packages/charts/changelog/echo-charts-daily-pair-hour-ticks
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Time axis: show date ticks rather than hour ticks for a daily-bucket pair spanning exactly one day.

--- a/projects/js-packages/charts/src/charts/private/test/time-axis.test.ts
+++ b/projects/js-packages/charts/src/charts/private/test/time-axis.test.ts
@@ -44,6 +44,14 @@ describe( 'getFormatter', () => {
 		expect( formatter( new Date( '2026-08-05T13:00:00' ).getTime() ) ).toMatch( /1\sPM/ );
 	} );
 
+	it( 'keeps date ticks for a two-point daily series spanning exactly a day', () => {
+		const formatter = getFormatter(
+			toSeries( dailyDates( new Date( '2026-08-01T00:00:00' ), 2 ) )
+		);
+
+		expect( formatter( new Date( '2026-08-02T00:00:00' ).getTime() ) ).toMatch( /Aug 2/ );
+	} );
+
 	it( 'keeps date ticks for daily data over the same multi-day span', () => {
 		const formatter = getFormatter(
 			toSeries( dailyDates( new Date( '2026-08-01T00:00:00' ), 3 ) )

--- a/projects/js-packages/charts/src/charts/private/time-axis.ts
+++ b/projects/js-packages/charts/src/charts/private/time-axis.ts
@@ -93,15 +93,17 @@ export const getFormatter = ( sortedData: ReturnType< typeof useChartDataTransfo
 	const minX = Math.min( ...sortedData.map( datom => datom.data.at( 0 )?.date ) );
 	const maxX = Math.max( ...sortedData.map( datom => datom.data.at( -1 )?.date ) );
 
-	const diffInHours = Math.abs( differenceInHours( maxX, minX ) );
-	if ( diffInHours <= 24 ) {
-		return formatHourTick;
-	}
-
 	const spacingInHours = getPointSpacingInHours( sortedData );
 	// 23, not 24: a daily gap shrinks to 23 wall-clock hours across a
 	// spring-forward DST transition.
-	if ( diffInHours <= 24 * 7 && spacingInHours < 23 ) {
+	const isSubDaily = spacingInHours < 23;
+
+	const diffInHours = Math.abs( differenceInHours( maxX, minX ) );
+	if ( diffInHours <= 24 && isSubDaily ) {
+		return formatHourTick;
+	}
+
+	if ( diffInHours <= 24 * 7 && isSubDaily ) {
 		return formatDateOrHourTick;
 	}
 


### PR DESCRIPTION
## Why
Selecting "By days" on a two-day range in the Premium Analytics Traffic widget rendered the x-axis as "12 AM … 12 AM" hour ticks instead of "Aug 1 / Aug 2" dates, making the axis read as a single day of hourly data when it actually shows two daily buckets.

## Proposed changes
* A two-point daily series spans exactly 24 hours, which satisfied the time axis's span-only hour-tick branch; both hour-tick regimes now also require the data's bucket spacing to be sub-daily
* A side effect worth noting: series where resolution is unknowable (single points) within a day now render date ticks rather than hour ticks, consistent with how the other regimes already treat unknown resolution

## Related product discussion/links
* Follow-up to #51010; surfaced while testing https://github.com/Automattic/jetpack/pull/50917 (https://linear.app/a8c/issue/WOOA7S-1834/add-hourly-stats-to-the-traffic-chart)

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Run the unit tests: `cd projects/js-packages/charts && pnpm run test time-axis`
* Or in Storybook: render a LineChart with exactly two daily points (e.g. Aug 1 and Aug 2) — the x-axis should show "Aug 1 / Aug 2" date ticks, not "12 AM"
