### PR TITLE
Forms: make the auto-populated notification recipient visible and overridable

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-688-recipient-auto-populate
+++ b/projects/packages/forms/changelog/fix-forms-688-recipient-auto-populate
@@ -1,0 +1,4 @@
+Significance: minor
+Type: fixed
+
+Form block: show the fallback notification recipient as a placeholder so it is clear when no address is saved.

--- a/projects/packages/forms/src/blocks/contact-form/attributes.ts
+++ b/projects/packages/forms/src/blocks/contact-form/attributes.ts
@@ -9,11 +9,11 @@ export default {
 	},
 	subject: {
 		type: 'string',
-		default: window.jpFormsBlocks?.defaults?.subject || '',
+		default: '',
 	},
 	to: {
 		type: 'string',
-		default: window.jpFormsBlocks?.defaults?.to || '',
+		default: '',
 	},
 	customThankyou: {
 		type: 'string',

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -983,7 +983,9 @@ class Contact_Form_Block {
 			'defaults' => array(
 				'to'                   => $default_recipient['to'],
 				'toSource'             => $default_recipient['source'],
-				'subject'              => Contact_Form::get_default_subject( array() ),
+				// Decoded for display only: get_option( 'blogname' ) stores the site title HTML-encoded,
+				// which would otherwise surface raw entities such as &#039; in the editor's placeholder.
+				'subject'              => wp_specialchars_decode( Contact_Form::get_default_subject( array() ), ENT_QUOTES ),
 				'formsResponsesUrl'    => $form_responses_url,
 				'akismetActiveWithKey' => $akismet_active_with_key,
 				'akismetUrl'           => $akismet_key_url,

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -977,9 +977,12 @@ class Contact_Form_Block {
 		$akismet_active_with_key = Jetpack::is_akismet_active();
 		$akismet_key_url         = admin_url( 'admin.php?page=akismet-key-config' );
 
+		$default_recipient = Contact_Form::get_default_to_with_source( $post );
+
 		$data = array(
 			'defaults' => array(
-				'to'                   => Contact_Form::get_default_to_for_editor( $post ),
+				'to'                   => $default_recipient['to'],
+				'toSource'             => $default_recipient['source'],
 				'subject'              => Contact_Form::get_default_subject( array() ),
 				'formsResponsesUrl'    => $form_responses_url,
 				'akismetActiveWithKey' => $akismet_active_with_key,

--- a/projects/packages/forms/src/blocks/contact-form/components/jetpack-email-connection-settings.jsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/jetpack-email-connection-settings.jsx
@@ -3,6 +3,7 @@ import { useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 import { Notice } from '@wordpress/ui';
 import { validate as emailValidatorValidate } from 'email-validator';
+import { getAutoRecipientHelpText } from '../util/auto-recipient';
 
 const JetpackEmailConnectionSettings = ( {
 	emailAddress = '',
@@ -10,7 +11,9 @@ const JetpackEmailConnectionSettings = ( {
 	emailNotifications = true,
 	instanceId,
 	setAttributes,
-	postAuthorEmail,
+	autoRecipient = '',
+	autoRecipientSource = 'site_admin',
+	autoSubject = '',
 } ) => {
 	const [ emailErrors, setEmailErrors ] = useState( false );
 
@@ -67,9 +70,9 @@ const JetpackEmailConnectionSettings = ( {
 	};
 
 	const onBlurEmailField = e => {
+		// An empty field means "inherit the fallback recipient", so it must stay empty.
 		if ( e.target.value.length === 0 ) {
 			setEmailErrors( false );
-			setAttributes( { to: postAuthorEmail } );
 			return;
 		}
 
@@ -84,6 +87,11 @@ const JetpackEmailConnectionSettings = ( {
 		setEmailErrors( false );
 		setAttributes( { to: email.trim() } );
 	};
+
+	const emailHelpText = `${ getAutoRecipientHelpText( autoRecipientSource ) } ${ __(
+		'You can enter multiple email addresses separated by commas.',
+		'jetpack-forms'
+	) }`;
 
 	return (
 		<>
@@ -100,9 +108,9 @@ const JetpackEmailConnectionSettings = ( {
 							hasEmailErrors() ? 'error' : 'help'
 						}` }
 						label={ __( 'Send email notifications to', 'jetpack-forms' ) }
-						placeholder={ __( 'name@example.com', 'jetpack-forms' ) }
+						placeholder={ autoRecipient || __( 'name@example.com', 'jetpack-forms' ) }
 						onKeyDown={ e => {
-							if ( event.key === 'Enter' ) {
+							if ( e.key === 'Enter' ) {
 								e.preventDefault();
 								e.stopPropagation();
 							}
@@ -110,10 +118,7 @@ const JetpackEmailConnectionSettings = ( {
 						value={ emailAddress }
 						onBlur={ onBlurEmailField }
 						onChange={ onChangeEmailField }
-						help={ __(
-							'You can enter multiple email addresses separated by commas.',
-							'jetpack-forms'
-						) }
+						help={ emailHelpText }
 						__nextHasNoMarginBottom={ true }
 						__next40pxDefaultSize={ true }
 					/>
@@ -131,7 +136,7 @@ const JetpackEmailConnectionSettings = ( {
 					<TextControl
 						label={ __( 'Email subject line', 'jetpack-forms' ) }
 						value={ emailSubject }
-						placeholder={ __( 'Enter a subject', 'jetpack-forms' ) }
+						placeholder={ autoSubject || __( 'Enter a subject', 'jetpack-forms' ) }
 						onChange={ newSubject => setAttributes( { subject: newSubject } ) }
 						__nextHasNoMarginBottom={ true }
 						__next40pxDefaultSize={ true }

--- a/projects/packages/forms/src/blocks/contact-form/components/notifications-settings.jsx
+++ b/projects/packages/forms/src/blocks/contact-form/components/notifications-settings.jsx
@@ -13,7 +13,9 @@ const NotificationsSettings = ( {
 	emailSubject,
 	emailNotifications,
 	instanceId,
-	postAuthorEmail,
+	autoRecipient,
+	autoRecipientSource,
+	autoSubject,
 } ) => {
 	const [ localNotificationRecipients, setLocalNotificationRecipients ] =
 		useState( notificationRecipients );
@@ -62,7 +64,9 @@ const NotificationsSettings = ( {
 				emailSubject={ emailSubject }
 				emailNotifications={ emailNotifications }
 				instanceId={ instanceId }
-				postAuthorEmail={ postAuthorEmail }
+				autoRecipient={ autoRecipient }
+				autoRecipientSource={ autoRecipientSource }
+				autoSubject={ autoSubject }
 				setAttributes={ setAttributes }
 			/>
 			<>

--- a/projects/packages/forms/src/blocks/contact-form/edit.tsx
+++ b/projects/packages/forms/src/blocks/contact-form/edit.tsx
@@ -70,6 +70,7 @@ import { useSyncedFormAutoSave } from './hooks/use-synced-form-auto-save.ts';
 import { useSyncedFormLoader } from './hooks/use-synced-form-loader.ts';
 import { useSyncedForm } from './hooks/use-synced-form.ts';
 import useFormBlockDefaults from './shared/hooks/use-form-block-defaults.js';
+import { getAutoRecipient } from './util/auto-recipient.ts';
 import { getEditorContext } from './util/get-editor-context.ts';
 import { isCollectingResponses } from './util/is-collecting-responses.ts';
 import VariationPicker from './variation-picker.jsx';
@@ -344,6 +345,14 @@ function JetpackContactFormEdit( {
 		},
 		[ clientId, syncedFormBlocks ]
 	);
+
+	const formBlockDefaults = window.jpFormsBlocks?.defaults || {};
+	const autoRecipient = getAutoRecipient( {
+		serverSource: formBlockDefaults.toSource,
+		serverAddress: formBlockDefaults.to,
+		postAuthorEmail,
+		isStandaloneForm: isJetpackFormEditor,
+	} );
 
 	useEffect( () => {
 		if ( submitButton && ! submitButton.attributes.lock ) {
@@ -1263,7 +1272,9 @@ function JetpackContactFormEdit( {
 							emailSubject={ subject }
 							emailNotifications={ emailNotifications }
 							instanceId={ instanceId }
-							postAuthorEmail={ postAuthorEmail }
+							autoRecipient={ autoRecipient.address }
+							autoRecipientSource={ autoRecipient.source }
+							autoSubject={ formBlockDefaults.subject || '' }
 							setAttributes={ setAttributes }
 						/>
 					</PanelBody>

--- a/projects/packages/forms/src/blocks/contact-form/util/auto-recipient.ts
+++ b/projects/packages/forms/src/blocks/contact-form/util/auto-recipient.ts
@@ -1,0 +1,74 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+
+/** Which rule decides where responses go when no recipient is explicitly saved. */
+export type AutoRecipientSource = 'post_author' | 'site_admin' | 'embedding_post_author';
+
+/** A fallback recipient and the rule that produced it. */
+export type AutoRecipient = {
+	address: string;
+	source: AutoRecipientSource;
+};
+
+type AutoRecipientParams = {
+	serverSource?: string;
+	serverAddress?: string;
+	postAuthorEmail?: string;
+	isStandaloneForm?: boolean;
+};
+
+/**
+ * Resolve the recipient a form falls back to when no address is explicitly saved.
+ *
+ * Mirrors what Contact_Form resolves at send time so the editor can explain the fallback rather than displaying it as though it were a stored value.
+ *
+ * @param params                  - Resolution inputs.
+ * @param params.serverSource     - Fallback branch PHP reported for this page load.
+ * @param params.serverAddress    - Address PHP resolved for that branch.
+ * @param params.postAuthorEmail  - Live post author email from the editor store, when known.
+ * @param params.isStandaloneForm - Whether the block is being edited in the standalone form post type.
+ * @return The fallback address and the rule that produced it.
+ */
+export function getAutoRecipient( {
+	serverSource,
+	serverAddress = '',
+	postAuthorEmail = '',
+	isStandaloneForm = false,
+}: AutoRecipientParams ): AutoRecipient {
+	// A standalone form has no single destination to predict: at send time the recipient resolves
+	// against whichever page embeds the form, which this editor cannot know.
+	if ( isStandaloneForm ) {
+		return { address: '', source: 'embedding_post_author' };
+	}
+
+	if ( serverSource === 'post_author' ) {
+		// Prefer the live author so reassigning the post author updates the hint without a reload.
+		// PHP's edit_post and blog-membership checks already gated us into this branch.
+		return { address: postAuthorEmail || serverAddress, source: 'post_author' };
+	}
+
+	return { address: serverAddress, source: 'site_admin' };
+}
+
+/**
+ * Help text explaining which fallback applies while the recipient field is empty.
+ *
+ * @param source - The rule that produced the fallback recipient.
+ * @return Translated sentence for the field's help text.
+ */
+export function getAutoRecipientHelpText( source: AutoRecipientSource ): string {
+	if ( source === 'post_author' ) {
+		return __( 'Leave empty to send responses to the post author.', 'jetpack-forms' );
+	}
+
+	if ( source === 'embedding_post_author' ) {
+		return __(
+			'Leave empty to send responses to the author of the page where this form appears.',
+			'jetpack-forms'
+		);
+	}
+
+	return __( 'Leave empty to send responses to the site admin email.', 'jetpack-forms' );
+}

--- a/projects/packages/forms/src/blocks/contact-form/util/auto-recipient.ts
+++ b/projects/packages/forms/src/blocks/contact-form/util/auto-recipient.ts
@@ -59,16 +59,17 @@ export function getAutoRecipient( {
  * @return Translated sentence for the field's help text.
  */
 export function getAutoRecipientHelpText( source: AutoRecipientSource ): string {
-	if ( source === 'post_author' ) {
-		return __( 'Leave empty to send responses to the post author.', 'jetpack-forms' );
-	}
-
-	if ( source === 'embedding_post_author' ) {
-		return __(
+	// Keyed unconditionally rather than branched. Selecting a translated string inside a branch lets
+	// the minifier collapse the branches into a single __() call whose msgid is a ternary, which the
+	// gettext extractor cannot read — so every __() call here stays unconditional and literal.
+	const helpTexts: Record< AutoRecipientSource, string > = {
+		post_author: __( 'Leave empty to send responses to the post author.', 'jetpack-forms' ),
+		embedding_post_author: __(
 			'Leave empty to send responses to the author of the page where this form appears.',
 			'jetpack-forms'
-		);
-	}
+		),
+		site_admin: __( 'Leave empty to send responses to the site admin email.', 'jetpack-forms' ),
+	};
 
-	return __( 'Leave empty to send responses to the site admin email.', 'jetpack-forms' );
+	return helpTexts[ source ] || helpTexts.site_admin;
 }

--- a/projects/packages/forms/src/blocks/contact-form/util/test/auto-recipient.test.js
+++ b/projects/packages/forms/src/blocks/contact-form/util/test/auto-recipient.test.js
@@ -1,0 +1,67 @@
+import { getAutoRecipient, getAutoRecipientHelpText } from '../auto-recipient';
+
+describe( 'getAutoRecipient', () => {
+	it( 'prefers the live post author email over the page-load value', () => {
+		expect(
+			getAutoRecipient( {
+				serverSource: 'post_author',
+				serverAddress: 'stale@example.com',
+				postAuthorEmail: 'live@example.com',
+			} )
+		).toEqual( { address: 'live@example.com', source: 'post_author' } );
+	} );
+
+	it( 'falls back to the server address when the editor store has no author email', () => {
+		expect(
+			getAutoRecipient( {
+				serverSource: 'post_author',
+				serverAddress: 'author@example.com',
+			} )
+		).toEqual( { address: 'author@example.com', source: 'post_author' } );
+	} );
+
+	it( 'never substitutes the post author in the site admin branch', () => {
+		expect(
+			getAutoRecipient( {
+				serverSource: 'site_admin',
+				serverAddress: 'admin@example.com',
+				postAuthorEmail: 'ignored@example.com',
+			} )
+		).toEqual( { address: 'admin@example.com', source: 'site_admin' } );
+	} );
+
+	it( 'predicts no address for a standalone form', () => {
+		expect(
+			getAutoRecipient( {
+				serverSource: 'post_author',
+				serverAddress: 'form-author@example.com',
+				postAuthorEmail: 'form-author@example.com',
+				isStandaloneForm: true,
+			} )
+		).toEqual( { address: '', source: 'embedding_post_author' } );
+	} );
+
+	it( 'treats an unknown or missing server source as the site admin branch', () => {
+		expect( getAutoRecipient( { serverAddress: 'admin@example.com' } ) ).toEqual( {
+			address: 'admin@example.com',
+			source: 'site_admin',
+		} );
+	} );
+
+	it( 'returns an empty address when nothing is known', () => {
+		expect( getAutoRecipient( {} ) ).toEqual( { address: '', source: 'site_admin' } );
+	} );
+} );
+
+describe( 'getAutoRecipientHelpText', () => {
+	it( 'returns a distinct sentence for each source', () => {
+		const texts = [
+			getAutoRecipientHelpText( 'post_author' ),
+			getAutoRecipientHelpText( 'site_admin' ),
+			getAutoRecipientHelpText( 'embedding_post_author' ),
+		];
+
+		expect( new Set( texts ).size ).toBe( 3 );
+		texts.forEach( text => expect( text ).toMatch( /^Leave empty to send responses to/ ) );
+	} );
+} );

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -1154,6 +1154,53 @@ class Contact_Form extends Contact_Form_Shortcode {
 	}
 
 	/**
+	 * Get the default recipient email address for the editor, together with the rule that produced it.
+	 *
+	 * The editor needs to explain why an address is being suggested, not merely what it is, so the
+	 * resolution branch is returned alongside the address instead of being discarded.
+	 *
+	 * @param mixed|null $post Optional post data (object or array).
+	 *
+	 * @return array{to: string, source: string} The address, and its source: 'post_author' or 'site_admin'.
+	 *
+	 * @since $$next-version$$
+	 */
+	public static function get_default_to_with_source( $post = null ) {
+		$site_admin = array(
+			'to'     => get_option( 'admin_email' ),
+			'source' => 'site_admin',
+		);
+
+		if ( empty( $post ) ) {
+			return $site_admin;
+		}
+
+		$post_author_id = self::get_post_property( $post, 'post_author' );
+		$post_id        = self::get_post_property( $post, 'ID' );
+		$post_author    = get_user( $post_author_id );
+
+		// Check that the user has edit permissions for this blog and has an email address
+		if ( empty( $post_author ) || empty( $post_author->user_email ) ) {
+			return $site_admin;
+		}
+
+		// Check that the user is still a member of the blog.
+		if ( ! is_user_member_of_blog( $post_author_id ) ) {
+			return $site_admin;
+		}
+
+		// Check that the author can still edit the post or page.
+		if ( user_can( $post_author_id, 'edit_post', $post_id ) ) {
+			return array(
+				'to'     => $post_author->user_email,
+				'source' => 'post_author',
+			);
+		}
+
+		return $site_admin;
+	}
+
+	/**
 	 * Get the default recipient email address for the contact form based on post data.
 	 *
 	 * This is used when we load the post or page in the editor, and we don't have the post author ID directly.
@@ -1163,32 +1210,9 @@ class Contact_Form extends Contact_Form_Shortcode {
 	 * @return string The default recipient email address.
 	 */
 	public static function get_default_to_for_editor( $post = null ) {
-		$default_to = get_option( 'admin_email' );
+		$resolved = self::get_default_to_with_source( $post );
 
-		if ( empty( $post ) ) {
-			return $default_to;
-		}
-
-		$post_author_id = self::get_post_property( $post, 'post_author' );
-		$post_id        = self::get_post_property( $post, 'ID' );
-		$post_author    = get_user( $post_author_id );
-
-		// Check that the user has edit permissions for this blog and has an email address
-		if ( empty( $post_author ) || empty( $post_author->user_email ) ) {
-			return $default_to;
-		}
-
-		// Check that the user is still a member of the blog.
-		if ( ! is_user_member_of_blog( $post_author_id ) ) {
-			return $default_to;
-		}
-
-		// Check that the author can still edit the post or page.
-		if ( user_can( $post_author_id, 'edit_post', $post_id ) ) {
-			return $post_author->user_email;
-		}
-
-		return $default_to;
+		return $resolved['to'];
 	}
 
 	/**

--- a/projects/packages/forms/src/types/index.ts
+++ b/projects/packages/forms/src/types/index.ts
@@ -214,6 +214,8 @@ export interface JPFormsBlocksDefaults {
 	subject?: string;
 	/** The default recipient email address for the form. */
 	to?: string;
+	/** Which rule produced the default recipient: 'post_author' or 'site_admin'. */
+	toSource?: string;
 }
 
 /**

--- a/projects/packages/forms/tests/js/blocks/contact-form/components/jetpack-email-connection-settings.test.jsx
+++ b/projects/packages/forms/tests/js/blocks/contact-form/components/jetpack-email-connection-settings.test.jsx
@@ -1,0 +1,111 @@
+/**
+ * External dependencies
+ */
+import { describe, expect, it, jest } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useCallback, useState } from 'react';
+
+const { default: JetpackEmailConnectionSettings } = await import(
+	'../../../../../src/blocks/contact-form/components/jetpack-email-connection-settings.jsx'
+);
+
+/**
+ * Stateful wrapper mirroring how the block editor feeds attributes back into the component.
+ *
+ * @param {object}   props               - Component props.
+ * @param {Function} props.setAttributes - Spy invoked with each attribute change.
+ * @param {string}   props.initialTo     - Starting value for the recipient attribute.
+ * @return {import('react').JSX.Element} The settings component wired to local state.
+ */
+const Harness = ( { setAttributes, initialTo = '', ...props } ) => {
+	const [ attributes, setLocalAttributes ] = useState( { to: initialTo, subject: '' } );
+
+	const handleSetAttributes = useCallback(
+		next => {
+			setLocalAttributes( prev => ( { ...prev, ...next } ) );
+			setAttributes( next );
+		},
+		[ setAttributes ]
+	);
+
+	return (
+		<JetpackEmailConnectionSettings
+			emailNotifications={ true }
+			instanceId="test"
+			autoRecipient="author@example.com"
+			autoRecipientSource="post_author"
+			autoSubject="[Test Blog] Test Post"
+			{ ...props }
+			emailAddress={ attributes.to }
+			emailSubject={ attributes.subject }
+			setAttributes={ handleSetAttributes }
+		/>
+	);
+};
+
+const renderSettings = ( props = {} ) => {
+	const setAttributes = jest.fn();
+	render( <Harness setAttributes={ setAttributes } { ...props } /> );
+	return { setAttributes, field: screen.getByLabelText( 'Send email notifications to' ) };
+};
+
+describe( 'JetpackEmailConnectionSettings', () => {
+	it( 'shows the fallback recipient as a placeholder rather than as a value', () => {
+		const { field } = renderSettings();
+
+		expect( field ).toHaveValue( '' );
+		expect( field ).toHaveAttribute( 'placeholder', 'author@example.com' );
+	} );
+
+	it( 'explains which fallback applies', () => {
+		renderSettings();
+
+		expect(
+			screen.getByText( /Leave empty to send responses to the post author/ )
+		).toBeInTheDocument();
+	} );
+
+	it( 'shows the fallback subject as a placeholder', () => {
+		renderSettings();
+
+		expect( screen.getByLabelText( 'Email subject line' ) ).toHaveAttribute(
+			'placeholder',
+			'[Test Blog] Test Post'
+		);
+	} );
+
+	it( 'saves an address identical to the fallback recipient', async () => {
+		const user = userEvent.setup();
+		const { setAttributes, field } = renderSettings();
+
+		await user.type( field, 'author@example.com' );
+
+		expect( setAttributes ).toHaveBeenLastCalledWith( { to: 'author@example.com' } );
+	} );
+
+	it( 'leaves the recipient empty when the field is cleared', async () => {
+		const user = userEvent.setup();
+		const { setAttributes, field } = renderSettings( { initialTo: 'someone@example.org' } );
+
+		await user.clear( field );
+		await user.tab();
+
+		expect( setAttributes ).toHaveBeenLastCalledWith( { to: '' } );
+		expect( setAttributes ).not.toHaveBeenCalledWith(
+			expect.objectContaining( { to: 'author@example.com' } )
+		);
+	} );
+
+	it( 'falls back to a generic placeholder when no address can be predicted', () => {
+		const { field } = renderSettings( {
+			autoRecipient: '',
+			autoRecipientSource: 'embedding_post_author',
+		} );
+
+		expect( field ).toHaveAttribute( 'placeholder', 'name@example.com' );
+		expect(
+			screen.getByText( /the author of the page where this form appears/ )
+		).toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -2467,6 +2467,75 @@ class Contact_Form_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Tests get_default_to_with_source reports the post author branch.
+	 */
+	public function test_get_default_to_with_source_reports_post_author() {
+		$email     = 'source_author@example.com';
+		$author_id = wp_insert_user(
+			array(
+				'user_email' => $email,
+				'user_login' => 'test_source_author',
+				'user_pass'  => 'password123',
+				'role'       => 'editor',
+			)
+		);
+		$post_id   = wp_insert_post(
+			array(
+				'post_title'  => 'Test Post',
+				'post_status' => 'publish',
+				'post_author' => $author_id,
+			)
+		);
+
+		$result = Contact_Form::get_default_to_with_source( get_post( $post_id ) );
+
+		$this->assertSame( $email, $result['to'] );
+		$this->assertSame( 'post_author', $result['source'] );
+
+		wp_delete_user( $author_id );
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
+	 * Tests get_default_to_with_source falls back to the site admin when there is no post.
+	 */
+	public function test_get_default_to_with_source_reports_site_admin_without_post() {
+		$result = Contact_Form::get_default_to_with_source( null );
+
+		$this->assertSame( get_option( 'admin_email' ), $result['to'] );
+		$this->assertSame( 'site_admin', $result['source'] );
+	}
+
+	/**
+	 * Tests get_default_to_with_source falls back to the site admin when the author cannot edit the post.
+	 */
+	public function test_get_default_to_with_source_reports_site_admin_for_subscriber_author() {
+		$author_id = wp_insert_user(
+			array(
+				'user_email' => 'source_subscriber@example.com',
+				'user_login' => 'test_source_subscriber',
+				'user_pass'  => 'password123',
+				'role'       => 'subscriber',
+			)
+		);
+		$post_id   = wp_insert_post(
+			array(
+				'post_title'  => 'Test Post',
+				'post_status' => 'publish',
+				'post_author' => $author_id,
+			)
+		);
+
+		$result = Contact_Form::get_default_to_with_source( get_post( $post_id ) );
+
+		$this->assertSame( get_option( 'admin_email' ), $result['to'] );
+		$this->assertSame( 'site_admin', $result['source'] );
+
+		wp_delete_user( $author_id );
+		wp_delete_post( $post_id, true );
+	}
+
+	/**
 	 * Tests get_default_to method with valid post author.
 	 */
 	public function test_get_default_to_with_valid_post_author() {


### PR DESCRIPTION
Fixes #

<!-- No GitHub issue; tracked in Linear as FORMS-688 (linked below). -->

## Proposed changes

The Form block's "Send email notifications to" field auto-populates from the post author when no recipient is saved, but gives no indication it is doing so — and the displayed address changes depending on where you open the form. Partners and internal folks repeatedly read this as "submissions are going to the wrong place."

The root cause is that `to` (and `subject`) used a **server-computed value as their Gutenberg attribute default**:

```js
to: { type: 'string', default: window.jpFormsBlocks?.defaults?.to || '' },
```

Gutenberg omits any attribute equal to its default when serializing block markup, so a default holding a real value creates a trap. Verified in the editor before this change:

| Block | `to` in serialized markup? |
|---|---|
| `createBlock( 'jetpack/contact-form', {} )` | no |
| `createBlock( ..., { to: <the address the field displays> } )` | **no** |
| `createBlock( ..., { to: 'someone@example.org' } )` | yes |

So there were two symptoms from one cause: the value looked saved but wasn't, and **explicitly typing the address you see was impossible to save** — meaning you could not pin the recipient to today's post-author address, and if the post author later changed, the recipient silently followed.

This PR:

* Sets the `to` and `subject` attribute defaults to `''`, so "inherited" and "explicitly saved" are distinguishable states. An empty `to` was already a fully working inherit state on the front end — `Contact_Form::__construct` resolves it at send time — so this makes the editor model behavior PHP has always had.
* Moves the resolved address from `value` to `placeholder`, where it reads as a hint.
* Adds `Contact_Form::get_default_to_with_source()`, which returns the recipient **and the rule that produced it**. `get_default_to_for_editor()` becomes a thin wrapper, so its behavior and every existing caller are untouched.
* Uses that source to pick accurate help text per context, because "post author" is only one of five branches:

| Where the form lives | Resolved recipient |
|---|---|
| Post / page content | Post author — only if they still have an email, are still a member of the blog, and can still `edit_post` that post |
| …any of those checks fails | Site admin email |
| A widget | Site admin email (non-numeric source id short-circuits) |
| A block template / template part | Site admin email (same short-circuit) |

* Removes the `onBlur` handler that wrote the post author's address back into the attribute when the field was cleared — clearing now means "inherit" and stays empty.
* Fixes the subject placeholder rendering a raw HTML entity (`[The developer&#039;s corner]`). `get_option( 'blogname' )` stores the title encoded; the delivered mail's `Subject:` header contains a real apostrophe, so the encoded display was actively misleading.
* Fixes `onKeyDown` reading the global `event` instead of the handler's `e` parameter (survived only via legacy `window.event`).

### No mail-routing changes

`get_default_to()`, `get_default_to_for_editor()`'s resolution, and `Contact_Form::__construct` are all untouched. **No existing form's mail changes destination.** Verified end-to-end, not just asserted: a published post with an empty recipient still delivers to the post author (checked in mailpit).

### Known consequence

Forms that never set a recipient have no `to` in their markup, so their field now renders **empty with a placeholder** instead of pre-filled. Routing is identical, but the sidebar looks different to users who never touched it. That is the intended fix — it is precisely the "is this saved or inherited?" ambiguity being reported.

### Deliberately not fixed

In the standalone/synced form editor, the displayed fallback comes from the *form's* author while send time resolves against the *embedding page's* author. This PR describes that accurately ("the author of the page where this form appears") rather than changing it, since changing it would silently redirect live submissions on every site using a synced form without an explicit recipient. Worth its own issue.

## Related product discussion/links

* [FORMS-688](https://linear.app/a8c/issue/FORMS-688/contact-form-notification-recipient-field-silently-auto-populates-from)

## Does this pull request change what data or activity we track or use?

No.

## Real-screen before / after

Captured on a live Jurassic Ninja site at `/wp-admin/post-new.php`, Form block selected, "Form notifications" panel open. The site's admin email was set to `author@example.com` so no real address appears.

| Before | After |
|---|---|
| ![before](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-688-recipient-auto-populate/before-notifications.png) | ![after](https://github.com/Automattic/jetpack/raw/screenshots/fix/forms-688-recipient-auto-populate/after-notifications.png) |

Before, the address sits in the field as a value with no explanation. After, it is a placeholder, with help text naming the rule that produced it.

## Testing instructions

**The regression itself — an override that matches the auto-populated address:**

1. Add a Form block to a new post. Open the sidebar → **Form notifications**.
2. The "Send email notifications to" field is **empty**, with the post author's address shown as a greyed placeholder and help text reading "Leave empty to send responses to the post author."
3. Type that **exact same address** into the field. Save, reload, reopen the panel.
4. It persists. Confirm it reached the markup:
   ```js
   wp.data.select( 'core/block-editor' ).getBlocks()
     .filter( b => b.name === 'jetpack/contact-form' )
     .map( b => b.attributes.to )
   ```
   Expect the typed address. **On trunk this returns `undefined`** — the value silently never saved.

**Clearing returns to the inherited state:**

5. Clear the field and click away. It stays empty and the placeholder returns — it must not re-fill with the author's address.

**Routing is unchanged:**

6. Publish a post containing a form with an **empty** recipient and submit it from the front end.
7. The notification still arrives at the post author's address, exactly as before.

**Context-specific help text:**

8. Open the standalone Form post type editor. The placeholder is the generic `name@example.com` and the help text reads "Leave empty to send responses to the author of the page where this form appears."
9. Add a form to a block template or a widget. The help text names the site admin email instead.

**Existing content still validates:**

10. Open a post that already contained a Form block before this change. It renders with no block-validation warning.
