### PR TITLE
Charts: stop pre-bundling @wordpress/ui so IconButton works in Script Module consumers

### DIFF
--- a/projects/js-packages/charts/AGENTS.md
+++ b/projects/js-packages/charts/AGENTS.md
@@ -40,14 +40,29 @@ The package is migrating to WordPress UI and Theme as its defaults. When adding 
   (My Jetpack and friends) resolve source through the `jetpack:src` export
   condition instead. A change that only affects `dist/` can therefore break
   four packages this one does not import.
-- **Do not add packages to `deps.alwaysBundle` in `tsdown.config.ts`.**
-  Pre-bundling a dependency with `react` external forces Rolldown to emit a
-  dynamic-`require` shim for any transitive CommonJS module, and that shim
-  throws during module evaluation in Script Module consumers — taking down
-  every widget on the page, not just the feature that pulled it in. Leave
-  dependencies external and let each consumer's bundler resolve them.
-  `tools/assert-no-dynamic-require.ts` fails the build if a shim reaches the
-  ESM output; never suppress it.
+- **Never `deps.alwaysBundle` a package that transitively requires an external.**
+  Pre-bundling is safe only for dependencies that require nothing themselves —
+  `fast-deep-equal` qualifies, which is why `tsdown.config.ts` still lists it.
+  Pre-bundle anything that reaches a CommonJS module requiring an external
+  (`react`, above all) and Rolldown emits a dynamic-`require` shim, because it
+  cannot rewrite a runtime `require` into a static ESM import. That shim throws
+  during module evaluation in Script Module consumers, taking down every widget
+  on the page rather than just the feature that pulled it in.
+  `tools/assert-no-dynamic-require.ts` fails the build when such a shim reaches
+  the ESM output; never suppress it.
+- **`@wordpress/ui` is external in `dist`, and no build check can prove that is
+  safe.** Correctness depends on `@wordpress/build` *bundling* `@wordpress/ui`
+  rather than externalising it to `window.wp.ui`. It used to externalise it,
+  which is what CHARTS-163 worked around by pre-bundling; it now bundles any
+  `@wordpress/*` package that declares neither `wpScriptModuleExports` nor
+  `wpScript`, and `@wordpress/ui` declares `wpScript: false`. If a future
+  version reverts, `dist/index.js` keeps its clean `import … from
+  "@wordpress/ui"`, the guard passes, the build passes, and every Script Module
+  consumer breaks at runtime on `wp.ui` being undefined — the same blast radius
+  as CHARTS-237, with no build-time signal. Verified against `@wordpress/build`
+  0.18.0 (publicize, podcast, videopress) and 0.19.1-next (premium-analytics).
+  Check a major bump by loading a charts screen in wp-admin, not by trusting a
+  green build.
 
 ## Documentation Workflow
 

--- a/projects/js-packages/charts/AGENTS.md
+++ b/projects/js-packages/charts/AGENTS.md
@@ -33,6 +33,21 @@ The package is migrating to WordPress UI and Theme as its defaults. When adding 
   `--wpds-*` mappings). Charts reference `--a8c-charts-*` roles with the mapped
   `var(--wpds-*, <spec-fallback>)` as the inline fallback; there is no runtime
   emission yet (that is CHARTS-203).
+- **Two consumption paths — this changes what a charts change can break.**
+  `@wordpress/build` apps (premium-analytics, publicize, podcast, videopress)
+  consume the Rolldown output in `dist/` and load it as a **WordPress Script
+  Module** — native browser ESM, where `require` does not exist. Webpack apps
+  (My Jetpack and friends) resolve source through the `jetpack:src` export
+  condition instead. A change that only affects `dist/` can therefore break
+  four packages this one does not import.
+- **Do not add packages to `deps.alwaysBundle` in `tsdown.config.ts`.**
+  Pre-bundling a dependency with `react` external forces Rolldown to emit a
+  dynamic-`require` shim for any transitive CommonJS module, and that shim
+  throws during module evaluation in Script Module consumers — taking down
+  every widget on the page, not just the feature that pulled it in. Leave
+  dependencies external and let each consumer's bundler resolve them.
+  `tools/assert-no-dynamic-require.ts` fails the build if a shim reaches the
+  ESM output; never suppress it.
 
 ## Documentation Workflow
 

--- a/projects/js-packages/charts/changelog/charts-247-externalize-wordpress-ui
+++ b/projects/js-packages/charts/changelog/charts-247-externalize-wordpress-ui
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Zoom: Restore the accessible tooltip on the reset control, and stop bundling `@wordpress/ui` into the package output so each consumer's bundler resolves it.

--- a/projects/js-packages/charts/changelog/charts-247-externalize-wordpress-ui
+++ b/projects/js-packages/charts/changelog/charts-247-externalize-wordpress-ui
@@ -1,4 +1,4 @@
-Significance: minor
+Significance: major
 Type: changed
 
-Zoom: Restore the accessible tooltip on the reset control, and stop bundling `@wordpress/ui` into the package output so each consumer's bundler resolves it.
+Zoom: Restore the accessible tooltip on the reset control. `@wordpress/ui` is no longer bundled into the package output, so each consumer's bundler now resolves it. It remains a dependency and resolves from node_modules by default, but a bundler that externalizes `@wordpress/*` to `window.wp.*` must bundle `@wordpress/ui` instead — `window.wp.ui` does not exist.

--- a/projects/js-packages/charts/src/charts/area-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/area-chart/stories/index.docs.mdx
@@ -95,7 +95,7 @@ Zoom behaviour:
 - Only the X axis rescales; the Y axis is unaffected.
 - A selection rectangle follows the pointer while dragging.
 - Drags shorter than 6px are ignored, so a click never zooms.
-- While zoomed, a "Reset zoom" button appears in the top-right to restore the full domain. It is reachable with Tab and activates with Enter or Space.
+- While zoomed, a "Reset zoom" button appears in the top-right to restore the full domain. It is reachable with Tab and activates with Enter or Space. A "Reset zoom" tooltip shows on hover and on keyboard focus, and Escape dismisses it.
 - Areas are clipped to the plot area whenever `zoomable` is set, keeping the zoom-out animation within the axes.
 - `zoomable` chains with your own `onPointerDown`/`onPointerMove`/`onPointerUp` handlers rather than replacing them.
 

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.docs.mdx
@@ -527,7 +527,7 @@ Zoom behaviour:
 - Only the X axis rescales; the Y axis is unaffected.
 - A selection rectangle follows the pointer while dragging.
 - Drags shorter than 6px are ignored, so a click never zooms.
-- While zoomed, a "Reset zoom" button appears in the top-right to restore the full domain.
+- While zoomed, a "Reset zoom" button appears in the top-right to restore the full domain. It is reachable with Tab and activates with Enter or Space. A "Reset zoom" tooltip shows on hover and on keyboard focus, and Escape dismisses it.
 - Series are clipped to the plot area while zoomed, so lines never overflow the axes.
 - `zoomable` chains with your own `onPointerDown`/`onPointerMove`/`onPointerUp` handlers rather than replacing them.
 

--- a/projects/js-packages/charts/src/charts/private/x-zoom/test/x-zoom.test.tsx
+++ b/projects/js-packages/charts/src/charts/private/x-zoom/test/x-zoom.test.tsx
@@ -1,4 +1,4 @@
-import { act, render, renderHook, screen } from '@testing-library/react';
+import { act, render, renderHook, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useRef } from 'react';
 import { useXZoom, ZoomResetButton } from '../index';
@@ -147,17 +147,35 @@ const preventDefaultKeydown = ( event: ReactKeyboardEvent< HTMLDivElement > ) =>
 	event.preventDefault();
 
 describe( 'ZoomResetButton', () => {
-	test( 'renders a labelled button with a hover tooltip', () => {
+	test( 'renders a labelled button without a native title tooltip', () => {
 		const noop = jest.fn();
 		render( <ZoomResetButton onClick={ noop } /> );
 		const button = screen.getByTestId( 'chart-zoom-reset' );
 		expect( button.tagName ).toBe( 'BUTTON' );
 		expect( button ).toHaveClass( 'x-zoom__reset' );
 		expect( button ).toHaveAccessibleName( 'Reset zoom' );
-		// WPDS `IconButton` would supply a tooltip of its own, but it pulls in a
-		// CommonJS dependency that breaks Script Module consumers (see
-		// ZoomResetButton). `title` restores the hover hint on plain `Button`.
-		expect( button ).toHaveAttribute( 'title', 'Reset zoom' );
+		// IconButton renders a real tooltip, so the `title` fallback is gone —
+		// `title` is invisible to keyboard users and cannot be dismissed.
+		expect( button ).not.toHaveAttribute( 'title' );
+	} );
+
+	test( 'shows a tooltip on keyboard focus', async () => {
+		const noop = jest.fn();
+		render( <ZoomResetButton onClick={ noop } /> );
+		await userEvent.tab();
+		expect( screen.getByTestId( 'chart-zoom-reset' ) ).toHaveFocus();
+		// The button's only text is the tooltip's — its own label is an
+		// `aria-label` attribute, so this cannot match the trigger.
+		await expect( screen.findByText( 'Reset zoom' ) ).resolves.toBeVisible();
+	} );
+
+	test( 'dismisses the tooltip on Escape', async () => {
+		const noop = jest.fn();
+		render( <ZoomResetButton onClick={ noop } /> );
+		await userEvent.tab();
+		await expect( screen.findByText( 'Reset zoom' ) ).resolves.toBeVisible();
+		await userEvent.keyboard( '{Escape}' );
+		await waitFor( () => expect( screen.queryByText( 'Reset zoom' ) ).not.toBeInTheDocument() );
 	} );
 
 	test( 'fires onClick when activated', async () => {

--- a/projects/js-packages/charts/src/charts/private/x-zoom/test/x-zoom.test.tsx
+++ b/projects/js-packages/charts/src/charts/private/x-zoom/test/x-zoom.test.tsx
@@ -1,6 +1,6 @@
 import { act, render, renderHook, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { useRef } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { useXZoom, ZoomResetButton } from '../index';
 import type { SingleChartRef } from '../../single-chart-context';
 import type { EventHandlerParams } from '@visx/xychart';
@@ -183,6 +183,33 @@ describe( 'ZoomResetButton', () => {
 		render( <ZoomResetButton onClick={ onClick } /> );
 		await userEvent.click( screen.getByTestId( 'chart-zoom-reset' ) );
 		expect( onClick ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	test( 'leaves no orphaned tooltip when activation unmounts the button', async () => {
+		// Resetting the zoom unmounts this control while its tooltip is open.
+		// The tooltip renders in a portal outside the container, so a missed
+		// cleanup would strand it on the page rather than remove it with the
+		// button.
+		/**
+		 * Mirrors the host charts: the reset control exists only while zoomed.
+		 *
+		 * @return JSX element or null.
+		 */
+		function Host() {
+			const [ zoomed, setZoomed ] = useState( true );
+			const unzoom = useCallback( () => setZoomed( false ), [] );
+			return zoomed ? <ZoomResetButton onClick={ unzoom } /> : null;
+		}
+		render( <Host /> );
+		await userEvent.tab();
+		await expect( screen.findByText( 'Reset zoom' ) ).resolves.toBeVisible();
+
+		await userEvent.keyboard( '{Enter}' );
+
+		await waitFor( () =>
+			expect( screen.queryByTestId( 'chart-zoom-reset' ) ).not.toBeInTheDocument()
+		);
+		expect( document.body ).not.toHaveTextContent( 'Reset zoom' );
 	} );
 
 	test( 'keyboard activation survives the chart wrapper keydown handler', async () => {

--- a/projects/js-packages/charts/src/charts/private/x-zoom/x-zoom.module.scss
+++ b/projects/js-packages/charts/src/charts/private/x-zoom/x-zoom.module.scss
@@ -11,12 +11,12 @@
 		pointer-events: none;
 	}
 
-	// Overlay placement only — border, hover/focus, sizing and icon-only
-	// geometry all come from the WPDS IconButton. The elevation shadow is
-	// deliberately kept for separation from chart content (CHARTS-237
-	// design call, carrying over CHARTS-200's tokenization). `@wordpress/theme`
-	// 1.0.0 dropped the `--wpds-elevation-*` group, so this role carries the
-	// former token's spec value directly rather than nesting a `--wpds-*` var.
+	// The elevation shadow is deliberately kept for separation
+	// from chart content (CHARTS-237 design call, carrying
+	// over CHARTS-200's tokenization). `@wordpress/theme` 1.0.0
+	// dropped the `--wpds-elevation-*` group, so this role carries
+	// the former token's spec value directly rather than nesting
+	// a `--wpds-*` var.
 	&__reset {
 		position: absolute;
 		top: var(--wpds-dimension-gap-sm, 8px);

--- a/projects/js-packages/charts/src/charts/private/x-zoom/x-zoom.module.scss
+++ b/projects/js-packages/charts/src/charts/private/x-zoom/x-zoom.module.scss
@@ -11,8 +11,8 @@
 		pointer-events: none;
 	}
 
-	// Overlay placement and icon-only geometry — the visual treatment (border,
-	// hover/focus, sizing) comes from the WPDS Button. The elevation shadow is
+	// Overlay placement only — border, hover/focus, sizing and icon-only
+	// geometry all come from the WPDS IconButton. The elevation shadow is
 	// deliberately kept for separation from chart content (CHARTS-237
 	// design call, carrying over CHARTS-200's tokenization). `@wordpress/theme`
 	// 1.0.0 dropped the `--wpds-elevation-*` group, so this role carries the
@@ -23,16 +23,6 @@
 		right: var(--wpds-dimension-gap-sm, 8px);
 		z-index: 2;
 		box-shadow: var(--a8c-charts-elevation-xs, 0 1px 1px 0 #00000008, 0 1px 2px 0 #00000005, 0 3px 3px 0 #00000005, 0 4px 4px 0 #00000003);
-
-		// `Button` is sized for a text label. These are the same three custom
-		// properties @wordpress/ui's own IconButton composition sets to make a
-		// square icon-only control; we set them directly because IconButton
-		// itself cannot be used here — it renders a Base UI tooltip, whose
-		// CommonJS `use-sync-external-store` dependency makes Rolldown emit a
-		// dynamic `require()` that throws in Script Module consumers.
-		--wp-ui-button-aspect-ratio: 1;
-		--wp-ui-button-padding-inline: 0;
-		--wp-ui-button-min-width: unset;
 
 		// WPDS outline-neutral is transparent-bodied at rest; give this
 		// floating control an opaque body so chart content doesn't show

--- a/projects/js-packages/charts/src/charts/private/x-zoom/x-zoom.tsx
+++ b/projects/js-packages/charts/src/charts/private/x-zoom/x-zoom.tsx
@@ -1,6 +1,6 @@
 import { DataContext } from '@visx/xychart';
 import { __ } from '@wordpress/i18n';
-import { Button } from '@wordpress/ui';
+import { IconButton } from '@wordpress/ui';
 import { useCallback, useContext, useMemo, useState } from 'react';
 import styles from './x-zoom.module.scss';
 import type { SingleChartRef } from '../single-chart-context';
@@ -172,14 +172,8 @@ export function ZoomClip( {
 
 /**
  * Visible icon-only reset control rendered as an HTML overlay on top of the
- * chart container, using the WPDS `Button`. The host should wrap its SVG in a
- * `position: relative` container so the button anchors correctly.
- *
- * `IconButton` would be the natural fit, but it renders a Base UI tooltip whose
- * CommonJS `use-sync-external-store` dependency makes Rolldown emit a dynamic
- * `require()` into `dist`, which throws on evaluation in WordPress Script
- * Module consumers. `Button` gives the same treatment without that dependency;
- * the tooltip is replaced by `aria-label` + `title`.
+ * chart container, using the WPDS `IconButton`. The host should wrap its SVG in
+ * a `position: relative` container so the button anchors correctly.
  *
  * @param props         - Props.
  * @param props.onClick - Click handler. Typically the `reset` from `useXZoom`.
@@ -194,44 +188,39 @@ export function ZoomResetButton( { onClick }: { onClick: () => void } ) {
 			event.stopPropagation();
 		}
 	}, [] );
-	const label = __( 'Reset zoom', 'jetpack-charts' );
 	return (
-		<Button
+		<IconButton
 			className={ styles[ 'x-zoom__reset' ] }
 			onKeyDown={ stopActivationKeys }
-			aria-label={ label }
-			title={ label }
+			label={ __( 'Reset zoom', 'jetpack-charts' ) }
 			variant="outline"
 			tone="neutral"
 			size="small"
 			onClick={ onClick }
 			data-testid="chart-zoom-reset"
-		>
-			<Button.Icon
-				icon={
-					<svg
-						viewBox="0 0 24 24"
-						fill="none"
-						stroke="currentColor"
-						strokeWidth="2"
-						strokeLinecap="round"
-						strokeLinejoin="round"
-						aria-hidden="true"
-						focusable="false"
-					>
-						{ /*
-							Icons render edge-to-edge at 24px, so inset the glyph the
-							way @wordpress/icons glyphs do (drawn within roughly 4-20
-							of the viewBox, ~1.5px effective stroke).
-						*/ }
-						<g transform="translate(2.4 2.4) scale(0.8)">
-							<circle cx="10" cy="10" r="6" />
-							<line x1="15" y1="15" x2="20" y2="20" />
-							<line x1="7" y1="10" x2="13" y2="10" />
-						</g>
-					</svg>
-				}
-			/>
-		</Button>
+			icon={
+				<svg
+					viewBox="0 0 24 24"
+					fill="none"
+					stroke="currentColor"
+					strokeWidth="2"
+					strokeLinecap="round"
+					strokeLinejoin="round"
+					aria-hidden="true"
+					focusable="false"
+				>
+					{ /*
+						Icons render edge-to-edge at 24px, so inset the glyph the
+						way @wordpress/icons glyphs do (drawn within roughly 4-20
+						of the viewBox, ~1.5px effective stroke).
+					*/ }
+					<g transform="translate(2.4 2.4) scale(0.8)">
+						<circle cx="10" cy="10" r="6" />
+						<line x1="15" y1="15" x2="20" y2="20" />
+						<line x1="7" y1="10" x2="13" y2="10" />
+					</g>
+				</svg>
+			}
+		/>
 	);
 }

--- a/projects/js-packages/charts/tsdown.config.ts
+++ b/projects/js-packages/charts/tsdown.config.ts
@@ -45,7 +45,7 @@ export default defineConfig( {
 		'.png': 'asset',
 	},
 	deps: {
-		alwaysBundle: [ '@wordpress/ui', /^fast-deep-equal/ ],
+		alwaysBundle: [ /^fast-deep-equal/ ],
 	},
 	css: {
 		fileName: 'index.css',


### PR DESCRIPTION
Fixes CHARTS-247

## Why

PR #50721 converted the chart zoom-reset control to `@wordpress/ui`'s `IconButton`. That broke every wp-admin screen consuming `charts/dist` as a WordPress Script Module — Premium Analytics, Social, VideoPress, Podcasts — and was live for 5 hours before being reverted. The fix that shipped in #50796 swapped `IconButton` for `Button` + a `title` attribute.

That was a stopgap, and review feedback was clear it should not be the end state, on two counts.

**It was solving the problem in the wrong place.** Charts is the only package in the monorepo that pre-bundles `@wordpress/ui`. Everywhere else — including `publicize`, one of the four packages this incident broke — imports `IconButton` and `Tooltip` directly and builds fine under both webpack and `@wordpress/build`.

**`title` is not an equivalent substitute for a tooltip.** It is never shown to keyboard users, it cannot be dismissed (failing [WCAG 2.2 SC 1.4.13](https://www.w3.org/WAI/WCAG22/Understanding/content-on-hover-or-focus.html)), and pairing it with `aria-label` causes double announcements in some screen readers. An icon-only button with no visible or tooltip label is a "mystery meat" button — which is the exact problem `IconButton` exists to solve.

### Root cause

`tsdown.config.ts` inlined `@wordpress/ui` via `deps.alwaysBundle`. With `react` external, Rolldown cannot rewrite a transitive CommonJS `require("react")` (`IconButton` → tooltip → `@base-ui/react` → `use-sync-external-store/shim`) into a static ESM import, so it emitted a shim that throws. `@wordpress/build` then re-bundled that shim opaquely, so its `vendor-external:react` plugin never saw the `require` to rewrite, and it threw during evaluation of the shared `widgets-toolkit` module — failing every widget at once.

**The reason `alwaysBundle` existed no longer holds.** It was added in #47004 (Feb 2026) because `@wordpress/build` externalised all `@wordpress/*` to `window.wp.*`, and `window.wp.ui` does not exist. `@wordpress/build` now externalises only packages declaring `wpScriptModuleExports`; `@wordpress/ui` ships `wpScript: false` and none, so wp-build bundles it itself. Verified on both lines in use here — `0.18.0` (publicize, podcast, videopress) and `0.19.1-next` (premium-analytics).

Note the consequence, which is recorded in the package's `AGENTS.md`: because `@wordpress/ui` is now external in `dist`, `assert-no-dynamic-require` can no longer detect this class of bug — `dist` is clean by construction. If a future `@wordpress/build` reverts to externalising all `@wordpress/*`, every build stays green and consumers break at runtime instead. A major bump should be checked by loading a charts screen in wp-admin.

## Proposed changes

* Remove `@wordpress/ui` from `deps.alwaysBundle` in the charts `tsdown.config.ts`, so each consumer's bundler resolves it. It stays in `dependencies`, so npm consumers still get it transitively; webpack consumers are unaffected either way because they resolve charts through the `jetpack:src` export condition.
* Restore `ZoomResetButton` to `IconButton` with a real `label`, removing the `title` + `aria-label` pair.
* Delete the three `--wp-ui-button-*` custom properties from `x-zoom.module.scss`. They were a verbatim copy of `IconButton`'s own composition layer, added only because `IconButton` could not be used.
* Replace the `title` unit assertion with coverage for tooltip-on-focus and Escape-dismissal.
* Document the `dist` vs `jetpack:src` consumption split in the package's `AGENTS.md`, and record that `alwaysBundle` must not be used.

`tools/assert-no-dynamic-require.ts` (added in #50796) is unchanged and still guards every build.

### Result

| | Before | After |
|---|---|---|
| `dist/index.js` | 433,019 B | **350,627 B** |
| `dist/index.css` | 22,198 B | 22,198 B (unchanged) |
| `@wordpress/ui` in output | inlined | external import |
| Dynamic-require shim | 0 | 0 |

### Screenshots

Line Chart → Zoomable story. Captured with Playwright against a real browser.

**No reset control until you zoom** — full domain, Feb–Dec.

<img width="1100" height="700" alt="zoom-reset-01-before-zoom" src="https://github.com/user-attachments/assets/3116a2aa-7aab-4049-af86-e17bfc14d6da" />

**After dragging to zoom** — the domain narrows to Apr 7–Jul 21 and the square reset control appears top-right, opaque so the gridlines don't show through.

<img width="1100" height="700" alt="zoom-reset-02-zoomed-button-visible" src="https://github.com/user-attachments/assets/eb7f18ab-e6cb-4896-b04a-744c18e8486f" />

**Tooltip on hover.**

<img width="1100" height="700" alt="zoom-reset-03-tooltip-on-hover" src="https://github.com/user-attachments/assets/81c0652f-4069-4fcd-80f3-a23d9e80b930" />

**Tooltip on keyboard focus** — the behaviour `title` could never provide, and the reason for this change. Note the focus ring alongside the tooltip. Escape dismisses it while focus stays put.

<img width="1100" height="700" alt="zoom-reset-04-tooltip-on-keyboard-focus" src="https://github.com/user-attachments/assets/c55148be-15a1-4344-b7b2-b85f7f455de6" />

## Related product discussion/links

* CHARTS-247, following CHARTS-237
* Reverted incident: #50721 → #50795 (revert) → #50796 (stopgap this replaces)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

**Storybook — the accessibility behaviour**

* Run Storybook and open **JS Packages/Charts Library/Charts/Line Chart → Zoomable**.
* Drag horizontally across the plot to zoom. The reset button appears top-right.
* Confirm it is **square**, and opaque (chart gridlines must not show through it).
* **Hover** it — a "Reset zoom" tooltip appears.
* **Tab** to it — the tooltip appears on keyboard focus. This is the behaviour `title` could never provide.
* Press **Escape** — the tooltip dismisses and focus stays on the button (WCAG 2.2 SC 1.4.13).
* Press **Enter** — the zoom resets and the button disappears.

**The build guard**

* `pnpm run build:prod` in `projects/js-packages/charts`. It must succeed — `assert-no-dynamic-require` fails the build if any dynamic-`require` shim reaches the ESM output.
* `grep -o 'from *"@wordpress/ui"' dist/index.js` should now match; it did not before.

**Script Module consumers — the regression this prevents**

Build and load each of these in wp-admin, confirming widgets render rather than showing "This widget encountered an error" or "Dynamic require of react is not supported":

* `pnpm jetpack build packages/premium-analytics` — Premium Analytics dashboard
* `pnpm jetpack build packages/publicize` — Jetpack Social
* `pnpm jetpack build packages/podcast` — Podcasts
* `pnpm jetpack build packages/videopress` — VideoPress
* `pnpm jetpack build packages/my-jetpack` — webpack control; should be unaffected

To check the artefacts directly, the meaningful test is what `__require` is *called with*, not whether the string `Dynamic require of` appears — esbuild always emits that helper text, including on trunk:

```
grep -rho '__require([^)]*)' projects/packages/*/build --include='*.js' | sort -u
```

Expected: only `__require("jetpackConfig")` and `__require("@wordpress/boot")`, both pre-existing. Any `__require("react")` means the regression is back.

### Verification already performed

* Storybook, real browser via Playwright: **12/12** checks pass, covering every step above.
* All five consumer packages built; no `__require("react")` in any output; charts code confirmed present (`a8ccharts-` classes) so this is not a tree-shaken false pass.
* Unit tests: 53 suites / 1054 tests. The two new tooltip tests were mutation-checked — removing the focus step or the Escape step makes them fail, so they are not vacuous.

### Note for whoever releases this

`woocommerce-analytics` consumes the published npm `dist` and was the original driver for #47004. Please confirm its `@wordpress/build` version externalises `@wordpress/ui` the same way 0.18.0 does before this goes out. That could not be checked from this repo.


