### PR TITLE
Charts: accept an explicit tickResolution hint on the time axis

### DIFF
--- a/projects/js-packages/charts/changelog/echo-charts-tick-resolution-hint
+++ b/projects/js-packages/charts/changelog/echo-charts-tick-resolution-hint
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Time axis: accept a tickResolution hint on the x-axis options so callers that know the data's bucket size can set tick formats directly instead of relying on inference.

--- a/projects/js-packages/charts/src/charts/area-chart/area-chart.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/area-chart.tsx
@@ -202,7 +202,8 @@ const AreaChartInternal = forwardRef< SingleChartRef, AreaChartProps >(
 		}, [ dataSorted, stacked, stackOffset, legendInteractive, rescaleYOnVisibility ] );
 
 		const chartOptions = useMemo( () => {
-			const formatter = options?.axis?.x?.tickFormat || getFormatter( dataSorted );
+			const { tickResolution, ...xAxisOptions } = options?.axis?.x ?? {};
+			const formatter = xAxisOptions.tickFormat || getFormatter( dataSorted, tickResolution );
 
 			return {
 				axis: {
@@ -211,7 +212,7 @@ const AreaChartInternal = forwardRef< SingleChartRef, AreaChartProps >(
 						numTicks: guessOptimalNumTicks( dataSorted, width, formatter ),
 						tickFormat: formatter,
 						display: true,
-						...options?.axis?.x,
+						...xAxisOptions,
 					},
 					y: {
 						orientation: 'left' as const,

--- a/projects/js-packages/charts/src/charts/area-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/area-chart/stories/index.stories.tsx
@@ -556,3 +556,45 @@ MismatchedXDomains.parameters = {
 		},
 	},
 };
+
+// A single hourly bucket: with no spacing to measure, inference falls back to
+// date ticks, so only the declared `tickResolution` yields an hour tick.
+const loneHourlyBucket: SeriesData[] = [
+	{
+		label: 'Views',
+		data: [ { date: new Date( 2026, 7, 2, 13 ), value: 42 } ],
+		options: {},
+	},
+];
+
+export const TimeAxisTickResolution: StoryObj< StoryArgs > = {
+	render: () => (
+		<div style={ { display: 'grid', gap: '2rem', gridTemplateColumns: 'repeat(2, 1fr)' } }>
+			<div>
+				<h3>Lone hourly bucket, resolution inferred → date tick</h3>
+				<AreaChart width={ 460 } height={ 220 } data={ loneHourlyBucket } />
+			</div>
+			<div>
+				<h3>Same point, tickResolution: &apos;hour&apos; → hour tick</h3>
+				<AreaChart
+					width={ 460 }
+					height={ 220 }
+					data={ loneHourlyBucket }
+					options={ { axis: { x: { tickResolution: 'hour' } } } }
+				/>
+			</div>
+		</div>
+	),
+	args: {
+		containerWidth: '1020px',
+		containerHeight: '320px',
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"When the caller already knows the data's bucket resolution, `options.axis.x.tickResolution` declares it and the automatic formatter uses it instead of inferring the resolution from point spacing. An explicit `tickFormat` takes precedence over the hint.",
+			},
+		},
+	},
+};

--- a/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/line-chart.tsx
@@ -287,7 +287,8 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 		} );
 
 		const chartOptions = useMemo( () => {
-			const formatter = options?.axis?.x?.tickFormat || getFormatter( dataSorted );
+			const { tickResolution, ...xAxisOptions } = options?.axis?.x ?? {};
+			const formatter = xAxisOptions.tickFormat || getFormatter( dataSorted, tickResolution );
 
 			return {
 				axis: {
@@ -296,7 +297,7 @@ const LineChartInternal = forwardRef< SingleChartRef, LineChartProps >(
 						numTicks: guessOptimalNumTicks( dataSorted, width, formatter ),
 						tickFormat: formatter,
 						display: true,
-						...options?.axis?.x,
+						...xAxisOptions,
 					},
 					y: {
 						orientation: 'left' as const,

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.api.mdx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.api.mdx
@@ -170,6 +170,11 @@ type ChartOptions = {
 			orientation?: 'top' | 'bottom';
 			numTicks?: number;
 			tickFormat?: (value: any) => string;
+			// Declared bucket resolution of the data; the automatic tick
+			// formatter uses it instead of inferring from point spacing.
+			// The time span still constrains the choice; ignored when
+			// tickFormat is set.
+			tickResolution?: 'hour' | 'day' | 'week' | 'month' | 'year';
 		};
 		y?: {
 			orientation?: 'left' | 'right';

--- a/projects/js-packages/charts/src/charts/line-chart/stories/index.stories.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/stories/index.stories.tsx
@@ -593,6 +593,86 @@ export const TimeAxisTickFormats: StoryObj< StoryArgs > = {
 	},
 };
 
+// Single-bucket series: the shape where point-spacing inference can't recover
+// the resolution — there is no spacing to measure — so only the declared
+// `tickResolution` can pick the right tick format.
+const loneHourlyBucket: SeriesData[] = [
+	{
+		label: 'Views',
+		data: [ { date: new Date( 2026, 7, 2, 13 ), value: 42 } ],
+		options: {},
+	},
+];
+
+const loneYearlyBucket: SeriesData[] = [
+	{
+		label: 'Views',
+		data: [ { date: new Date( 2026, 5, 1 ), value: 640 } ],
+		options: {},
+	},
+];
+
+export const TimeAxisTickResolution: StoryObj< StoryArgs > = {
+	render: () => (
+		<div style={ { display: 'grid', gap: '2rem', gridTemplateColumns: 'repeat(2, 1fr)' } }>
+			<div>
+				<h3>Lone hourly bucket, resolution inferred → date tick</h3>
+				<LineChart
+					width={ 460 }
+					height={ 220 }
+					data={ loneHourlyBucket }
+					withGradientFill={ false }
+					withLegendGlyph={ false }
+				/>
+			</div>
+			<div>
+				<h3>Same point, tickResolution: &apos;hour&apos; → hour tick</h3>
+				<LineChart
+					width={ 460 }
+					height={ 220 }
+					data={ loneHourlyBucket }
+					options={ { axis: { x: { tickResolution: 'hour' } } } }
+					withGradientFill={ false }
+					withLegendGlyph={ false }
+				/>
+			</div>
+			<div>
+				<h3>Lone yearly bucket, resolution inferred → date tick</h3>
+				<LineChart
+					width={ 460 }
+					height={ 220 }
+					data={ loneYearlyBucket }
+					withGradientFill={ false }
+					withLegendGlyph={ false }
+				/>
+			</div>
+			<div>
+				<h3>Same point, tickResolution: &apos;year&apos; → year tick</h3>
+				<LineChart
+					width={ 460 }
+					height={ 220 }
+					data={ loneYearlyBucket }
+					options={ { axis: { x: { tickResolution: 'year' } } } }
+					withGradientFill={ false }
+					withLegendGlyph={ false }
+				/>
+			</div>
+		</div>
+	),
+	args: {
+		containerWidth: '1020px',
+		containerHeight: '700px',
+	},
+	parameters: {
+		docs: {
+			description: {
+				story:
+					"When the caller already knows the data's bucket resolution — e.g. from a granularity selector — `options.axis.x.tickResolution` declares it and the automatic formatter derives tick formats from it directly, instead of inferring the resolution from point spacing. Inference needs at least two points, so a single-bucket series always falls back to date ticks; the declared resolution picks the right format. The overall time span still constrains the choice, and an explicit `tickFormat` takes precedence over the hint.",
+			},
+		},
+	},
+};
+
 export const DateStringFormats: StoryObj< StoryArgs > = Template.bind( {} );
 DateStringFormats.args = {
 	...lineChartStoryArgs,

--- a/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
+++ b/projects/js-packages/charts/src/charts/line-chart/test/line-chart.test.tsx
@@ -436,6 +436,26 @@ describe( 'LineChart', () => {
 			expect( ticks.length ).toBeGreaterThan( 1 );
 		} );
 
+		test( 'renders hour ticks when tickResolution declares the buckets sub-daily.', () => {
+			renderWithTheme( {
+				width: 800,
+				options: { axis: { x: { tickResolution: 'hour' } } },
+				data: [
+					{
+						label: 'Series A',
+						// A day apart: spacing inference would read this as daily buckets.
+						data: [
+							{ date: new Date( '2024-01-01T00:00:00' ), value: 10 },
+							{ date: new Date( '2024-01-02T00:00:00' ), value: 20 },
+						],
+					},
+				],
+			} );
+
+			const ticks = screen.getAllByText( /\d+\s(AM|PM)/ );
+			expect( ticks.length ).toBeGreaterThan( 1 );
+		} );
+
 		test( 'renders ticks in short date format.', () => {
 			renderWithTheme( {
 				width: 800,

--- a/projects/js-packages/charts/src/charts/private/test/time-axis.test.ts
+++ b/projects/js-packages/charts/src/charts/private/test/time-axis.test.ts
@@ -123,4 +123,40 @@ describe( 'getFormatter', () => {
 
 		expect( yearly( new Date( '2023-01-01T00:00:00' ).getTime() ) ).toBe( '2023' );
 	} );
+
+	describe( 'with an explicit tickResolution', () => {
+		it( 'uses hour ticks for two hourly points a day apart, where spacing would read as daily', () => {
+			const formatter = getFormatter(
+				toSeries( [ new Date( '2026-08-01T00:00:00' ), new Date( '2026-08-02T00:00:00' ) ] ),
+				'hour'
+			);
+
+			expect( formatter( new Date( '2026-08-01T13:00:00' ).getTime() ) ).toMatch( /1\sPM/ );
+		} );
+
+		it( 'uses date ticks for a lone daily point, where spacing is unknowable', () => {
+			const formatter = getFormatter( toSeries( [ new Date( '2026-08-02T00:00:00' ) ] ), 'day' );
+
+			expect( formatter( new Date( '2026-08-02T00:00:00' ).getTime() ) ).toMatch( /Aug 2/ );
+		} );
+
+		it( 'uses month ticks for monthly buckets regardless of their measured gaps', () => {
+			const formatter = getFormatter(
+				toSeries( [ new Date( '2026-02-01T00:00:00' ), new Date( '2026-03-01T00:00:00' ) ] ),
+				'month'
+			);
+
+			expect( formatter( new Date( '2026-03-01T00:00:00' ).getTime() ) ).toBe( 'Mar' );
+		} );
+
+		it( 'uses date ticks for weekly buckets', () => {
+			const weeklyDates = Array.from(
+				{ length: 8 },
+				( _, i ) => new Date( Date.UTC( 2026, 0, 5 + i * 7 ) )
+			);
+			const formatter = getFormatter( toSeries( weeklyDates ), 'week' );
+
+			expect( formatter( new Date( '2026-01-12T00:00:00' ).getTime() ) ).toMatch( /Jan 12/ );
+		} );
+	} );
 } );

--- a/projects/js-packages/charts/src/charts/private/test/time-axis.test.ts
+++ b/projects/js-packages/charts/src/charts/private/test/time-axis.test.ts
@@ -159,17 +159,6 @@ describe( 'getFormatter', () => {
 			expect( formatter( new Date( '2026-01-12T00:00:00' ).getTime() ) ).toMatch( /Jan 12/ );
 		} );
 
-		it( 'uses month ticks (with the year at January) for quarterly buckets', () => {
-			const quarterlyDates = Array.from(
-				{ length: 4 },
-				( _, i ) => new Date( Date.UTC( 2026, i * 3, 1 ) )
-			);
-			const formatter = getFormatter( toSeries( quarterlyDates ), 'quarter' );
-
-			expect( formatter( new Date( '2026-04-01T00:00:00' ).getTime() ) ).toBe( 'Apr' );
-			expect( formatter( new Date( '2026-01-01T00:00:00' ).getTime() ) ).toBe( '2026' );
-		} );
-
 		it( 'uses year ticks for a pair of yearly buckets', () => {
 			const formatter = getFormatter(
 				toSeries( [ new Date( '2025-01-01T00:00:00' ), new Date( '2026-01-01T00:00:00' ) ] ),

--- a/projects/js-packages/charts/src/charts/private/test/time-axis.test.ts
+++ b/projects/js-packages/charts/src/charts/private/test/time-axis.test.ts
@@ -158,5 +158,26 @@ describe( 'getFormatter', () => {
 
 			expect( formatter( new Date( '2026-01-12T00:00:00' ).getTime() ) ).toMatch( /Jan 12/ );
 		} );
+
+		it( 'uses month ticks (with the year at January) for quarterly buckets', () => {
+			const quarterlyDates = Array.from(
+				{ length: 4 },
+				( _, i ) => new Date( Date.UTC( 2026, i * 3, 1 ) )
+			);
+			const formatter = getFormatter( toSeries( quarterlyDates ), 'quarter' );
+
+			expect( formatter( new Date( '2026-04-01T00:00:00' ).getTime() ) ).toBe( 'Apr' );
+			expect( formatter( new Date( '2026-01-01T00:00:00' ).getTime() ) ).toBe( '2026' );
+		} );
+
+		it( 'uses year ticks for a pair of yearly buckets', () => {
+			const formatter = getFormatter(
+				toSeries( [ new Date( '2025-01-01T00:00:00' ), new Date( '2026-01-01T00:00:00' ) ] ),
+				'year'
+			);
+
+			expect( formatter( new Date( '2025-01-01T00:00:00' ).getTime() ) ).toBe( '2025' );
+			expect( formatter( new Date( '2026-01-01T00:00:00' ).getTime() ) ).toBe( '2026' );
+		} );
 	} );
 } );

--- a/projects/js-packages/charts/src/charts/private/test/time-axis.test.ts
+++ b/projects/js-packages/charts/src/charts/private/test/time-axis.test.ts
@@ -168,5 +168,15 @@ describe( 'getFormatter', () => {
 			expect( formatter( new Date( '2025-01-01T00:00:00' ).getTime() ) ).toBe( '2025' );
 			expect( formatter( new Date( '2026-01-01T00:00:00' ).getTime() ) ).toBe( '2026' );
 		} );
+
+		it( 'uses year ticks for yearly buckets that do not start in January', () => {
+			const formatter = getFormatter(
+				toSeries( [ new Date( '2025-06-01T00:00:00' ), new Date( '2026-06-01T00:00:00' ) ] ),
+				'year'
+			);
+
+			expect( formatter( new Date( '2025-06-01T00:00:00' ).getTime() ) ).toBe( '2025' );
+			expect( formatter( new Date( '2026-06-01T00:00:00' ).getTime() ) ).toBe( '2026' );
+		} );
 	} );
 } );

--- a/projects/js-packages/charts/src/charts/private/time-axis.ts
+++ b/projects/js-packages/charts/src/charts/private/time-axis.ts
@@ -2,6 +2,7 @@ import { curveCatmullRom, curveLinear, curveMonotoneX } from '@visx/curve';
 import { scaleTime } from '@visx/scale';
 import { differenceInHours, differenceInYears } from 'date-fns';
 import type { useChartDataTransform } from '../../hooks';
+import type { TickResolution } from '../../types';
 import type { CurveType } from '../line-chart/types';
 
 // Approximate min pixel width for an x-axis tick label.
@@ -84,16 +85,31 @@ const getPointSpacingInHours = ( sortedData: ReturnType< typeof useChartDataTran
 	);
 };
 
+// Nominal point spacing for a caller-declared bucket resolution. A month maps
+// to the shortest month so month-or-coarser regimes engage (see getFormatter).
+const SPACING_BY_RESOLUTION: Record< TickResolution, number > = {
+	hour: 1,
+	day: 24,
+	week: 24 * 7,
+	month: 28 * 24,
+};
+
 // Pick the most informative tick formatter for the data's resolution and time
 // span: hours within a day, hours with day boundaries for sub-daily data
 // spanning up to a week, calendar dates for daily-or-finer buckets within a
 // year, months (with the year at January) for month-or-coarser buckets,
-// otherwise just years.
-export const getFormatter = ( sortedData: ReturnType< typeof useChartDataTransform > ) => {
+// otherwise just years. The resolution comes from `tickResolution` when the
+// caller knows it, and is inferred from point spacing otherwise.
+export const getFormatter = (
+	sortedData: ReturnType< typeof useChartDataTransform >,
+	tickResolution?: TickResolution
+) => {
 	const minX = Math.min( ...sortedData.map( datom => datom.data.at( 0 )?.date ) );
 	const maxX = Math.max( ...sortedData.map( datom => datom.data.at( -1 )?.date ) );
 
-	const spacingInHours = getPointSpacingInHours( sortedData );
+	const spacingInHours = tickResolution
+		? SPACING_BY_RESOLUTION[ tickResolution ]
+		: getPointSpacingInHours( sortedData );
 	// 23, not 24: a daily gap shrinks to 23 wall-clock hours across a
 	// spring-forward DST transition.
 	const isSubDaily = spacingInHours < 23;

--- a/projects/js-packages/charts/src/charts/private/time-axis.ts
+++ b/projects/js-packages/charts/src/charts/private/time-axis.ts
@@ -85,13 +85,16 @@ const getPointSpacingInHours = ( sortedData: ReturnType< typeof useChartDataTran
 	);
 };
 
-// Nominal point spacing for a caller-declared bucket resolution. A month maps
-// to the shortest month so month-or-coarser regimes engage (see getFormatter).
+// Nominal point spacing for a caller-declared bucket resolution. Month and
+// coarser map to their shortest calendar length so the month-or-coarser
+// regimes engage (see getFormatter).
 const SPACING_BY_RESOLUTION: Record< TickResolution, number > = {
 	hour: 1,
 	day: 24,
 	week: 24 * 7,
 	month: 28 * 24,
+	quarter: 90 * 24,
+	year: 365 * 24,
 };
 
 // Pick the most informative tick formatter for the data's resolution and time

--- a/projects/js-packages/charts/src/charts/private/time-axis.ts
+++ b/projects/js-packages/charts/src/charts/private/time-axis.ts
@@ -85,15 +85,15 @@ const getPointSpacingInHours = ( sortedData: ReturnType< typeof useChartDataTran
 	);
 };
 
-// Nominal point spacing for a caller-declared bucket resolution. Month and
-// coarser map to their shortest calendar length so the month-or-coarser
-// regimes engage (see getFormatter).
-const SPACING_BY_RESOLUTION: Record< TickResolution, number > = {
+// Nominal point spacing for a caller-declared bucket resolution. A month maps
+// to the shortest month so the month-or-coarser regime engages (see
+// getFormatter). Year is absent: it short-circuits to year ticks before the
+// spacing regimes run.
+const SPACING_BY_RESOLUTION: Record< Exclude< TickResolution, 'year' >, number > = {
 	hour: 1,
 	day: 24,
 	week: 24 * 7,
 	month: 28 * 24,
-	year: 365 * 24,
 };
 
 // Pick the most informative tick formatter for the data's resolution and time
@@ -106,6 +106,13 @@ export const getFormatter = (
 	sortedData: ReturnType< typeof useChartDataTransform >,
 	tickResolution?: TickResolution
 ) => {
+	// The month regime only prints the year at January boundaries, so yearly
+	// buckets starting mid-year would render as month names; year ticks are
+	// correct for yearly buckets at any span.
+	if ( tickResolution === 'year' ) {
+		return formatYearTick;
+	}
+
 	const minX = Math.min( ...sortedData.map( datom => datom.data.at( 0 )?.date ) );
 	const maxX = Math.max( ...sortedData.map( datom => datom.data.at( -1 )?.date ) );
 

--- a/projects/js-packages/charts/src/charts/private/time-axis.ts
+++ b/projects/js-packages/charts/src/charts/private/time-axis.ts
@@ -93,7 +93,6 @@ const SPACING_BY_RESOLUTION: Record< TickResolution, number > = {
 	day: 24,
 	week: 24 * 7,
 	month: 28 * 24,
-	quarter: 90 * 24,
 	year: 365 * 24,
 };
 

--- a/projects/js-packages/charts/src/index.ts
+++ b/projects/js-packages/charts/src/index.ts
@@ -51,6 +51,7 @@ export type {
 	ChartTheme,
 	CompleteChartTheme,
 	AxisOptions,
+	TickResolution,
 	ScaleOptions,
 	LegendItemStyles,
 	LegendLabelStyles,

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -462,6 +462,12 @@ export type CompleteChartTheme = Required< ChartTheme > & {
 		Pick< NonNullable< ChartTheme[ 'heatmapChart' ] >, 'primaryColor' >;
 };
 
+/**
+ * Bucket resolution of time-series data, as known by the caller (e.g. a
+ * granularity selector), for consumers that don't need to infer it.
+ */
+export type TickResolution = 'hour' | 'day' | 'week' | 'month';
+
 export type AxisOptions = {
 	orientation?: OrientationType;
 	numTicks?: number;
@@ -475,6 +481,13 @@ export type AxisOptions = {
 	labelClassName?: string;
 	tickClassName?: string;
 	tickFormat?: TickFormatter< ScaleInput< AxisScale > >;
+	/**
+	 * Bucket resolution of the data on a time x-axis. When set, the automatic
+	 * tick formatter derives tick formats from it directly instead of
+	 * inferring the resolution from point spacing. Ignored when `tickFormat`
+	 * is set.
+	 */
+	tickResolution?: TickResolution;
 	/**
 	 * Whether to display this axis. Defaults to true.
 	 */

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -466,7 +466,7 @@ export type CompleteChartTheme = Required< ChartTheme > & {
  * Bucket resolution of time-series data, as known by the caller (e.g. a
  * granularity selector), for consumers that don't need to infer it.
  */
-export type TickResolution = 'hour' | 'day' | 'week' | 'month';
+export type TickResolution = 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year';
 
 export type AxisOptions = {
 	orientation?: OrientationType;

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -466,7 +466,7 @@ export type CompleteChartTheme = Required< ChartTheme > & {
  * Bucket resolution of time-series data, as known by the caller (e.g. a
  * granularity selector), for consumers that don't need to infer it.
  */
-export type TickResolution = 'hour' | 'day' | 'week' | 'month' | 'quarter' | 'year';
+export type TickResolution = 'hour' | 'day' | 'week' | 'month' | 'year';
 
 export type AxisOptions = {
 	orientation?: OrientationType;

--- a/projects/js-packages/charts/src/types.ts
+++ b/projects/js-packages/charts/src/types.ts
@@ -484,8 +484,10 @@ export type AxisOptions = {
 	/**
 	 * Bucket resolution of the data on a time x-axis. When set, the automatic
 	 * tick formatter derives tick formats from it directly instead of
-	 * inferring the resolution from point spacing. Ignored when `tickFormat`
-	 * is set.
+	 * inferring the resolution from point spacing. The overall time span still
+	 * constrains the choice — e.g. hourly buckets spanning more than a week
+	 * get date ticks, since hour ticks would be unreadable at that span.
+	 * Ignored when `tickFormat` is set.
 	 */
 	tickResolution?: TickResolution;
 	/**


### PR DESCRIPTION
## Why
The time axis picks tick formats by inferring the data's bucket resolution from point spacing. Consumers with a granularity selector — like the Premium Analytics Traffic widget's Group-by dropdown — already know the resolution exactly, and the inference heuristic keeps producing edge cases for them (two daily points spanning exactly 24 hours, DST-shortened gaps, single-point series). This mirrors how Jetpack Stats in Calypso avoids the whole problem: the selected period flows down to the chart, nothing is guessed.

## Proposed changes
* Add an optional `tickResolution: 'hour' | 'day' | 'week' | 'month' | 'year'` to the x-axis options on LineChart and AreaChart — the same union as the Stats API's `period`, so consumers like #50917 can pass their period straight through
* When set, the automatic tick formatter derives its regime from the declared resolution (mapped onto the nominal point spacing the selection logic already keys on) instead of measuring gaps between points
* Inference remains the fallback for callers without a granularity concept, and an explicit `tickFormat` still takes precedence over both
* Export the `TickResolution` type so consumers can narrow their own interval unions to it

## Related product discussion/links
* Follow-up to #51010 and #51013; motivated by https://github.com/Automattic/jetpack/pull/50917 (https://linear.app/a8c/issue/WOOA7S-1834/add-hourly-stats-to-the-traffic-chart), which will pass the Traffic widget's Group-by selection through this hint

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

* Run the unit tests: `cd projects/js-packages/charts && pnpm run test time-axis`
* The new `with an explicit tickResolution` describe block covers the hint overriding inference (hourly hint on day-apart points, lone points, monthly buckets, weekly buckets, yearly buckets)
* In Storybook (`pnpm run storybook`), see the new **TimeAxisTickResolution** stories under Line Chart and Area Chart

## Screenshots

The new `TimeAxisTickResolution` stories, inferred vs declared resolution on single-bucket series — the shape where spacing inference has nothing to measure:

**LineChart** — lone hourly bucket with `tickResolution: 'hour'`, lone yearly bucket with `'year'`:

<img width="800" alt="LineChart TimeAxisTickResolution story" src="https://github.com/user-attachments/assets/8d76b9bb-1192-44ed-8c32-f2c408b8ac32" />

**AreaChart** — lone hourly bucket with `tickResolution: 'hour'`:

<img width="800" alt="AreaChart TimeAxisTickResolution story" src="https://github.com/user-attachments/assets/97be1592-64e8-4658-83f2-f5f25db612ef" />
