### PR TITLE
Plugins: distinguish already-active/inactive from real failures in the modify endpoint

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-activation-failure-message
+++ b/projects/plugins/jetpack/changelog/fix-activation-failure-message
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Plugins: Return a meaningful message when plugin activation fails.

--- a/projects/plugins/jetpack/changelog/fix-missing-plugin-file-warning
+++ b/projects/plugins/jetpack/changelog/fix-missing-plugin-file-warning
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Plugins: Avoid a PHP warning when an active plugin's files are no longer on disk.

--- a/projects/plugins/jetpack/changelog/fix-plugin-already-in-state-error-codes
+++ b/projects/plugins/jetpack/changelog/fix-plugin-already-in-state-error-codes
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Plugins: Return distinct error codes when a plugin is already active or inactive.
+Plugins: Add a reason to activation and deactivation errors when the plugin is already in the requested state.

--- a/projects/plugins/jetpack/changelog/fix-plugin-already-in-state-error-codes
+++ b/projects/plugins/jetpack/changelog/fix-plugin-already-in-state-error-codes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Plugins: Return distinct error codes when a plugin is already active or inactive.

--- a/projects/plugins/jetpack/class.jetpack-client-server.php
+++ b/projects/plugins/jetpack/class.jetpack-client-server.php
@@ -88,6 +88,12 @@ class Jetpack_Client_Server {
 			// If the plugin is not in the usual place, try looking through all active plugins.
 			$active_plugins = Jetpack::get_active_plugins();
 			foreach ( $active_plugins as $plugin ) {
+				// `active_plugins` can name a plugin whose files are no longer on
+				// disk, and reading headers from a missing file raises a warning.
+				if ( ! is_readable( WP_PLUGIN_DIR . '/' . $plugin ) ) {
+					continue;
+				}
+
 				$data = get_plugin_data( WP_PLUGIN_DIR . '/' . $plugin );
 				if ( $data['Name'] === $probable_title ) {
 					deactivate_plugins( $plugin );

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -303,7 +303,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 			}
 
 			if ( ! $success ) {
-				$this->log[ $plugin ]['error'] = $result->get_error_messages;
+				$this->log[ $plugin ]['error'] = __( 'There was an error activating your plugin', 'jetpack' );
 				$has_errors                    = true;
 				continue;
 			}

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -316,8 +316,11 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 				return new WP_Error( 'unauthorized_error', $this->log[ $plugin ]['error'], 403 );
 			}
 
-			$error_code = $plugin_already_active ? 'plugin_already_active' : 'activation_error';
-			return new WP_Error( $error_code, $this->log[ $plugin ]['error'] );
+			$error = new WP_Error( 'activation_error', $this->log[ $plugin ]['error'] );
+			if ( $plugin_already_active ) {
+				$error->add_data( array( 'reason' => 'already_active' ), 'additional_data' );
+			}
+			return $error;
 		}
 	}
 
@@ -383,8 +386,11 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 				return new WP_Error( 'unauthorized_error', $error, 403 );
 			}
 
-			$error_code = $plugin_already_inactive ? 'plugin_already_inactive' : 'deactivation_error';
-			return new WP_Error( $error_code, $error );
+			$error = new WP_Error( 'deactivation_error', $error );
+			if ( $plugin_already_inactive ) {
+				$error->add_data( array( 'reason' => 'already_inactive' ), 'additional_data' );
+			}
+			return $error;
 		}
 	}
 

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-endpoint.php
@@ -265,7 +265,8 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 	 * @return null|WP_Error null if the activation was successful.
 	 */
 	protected function activate() {
-		$permission_error = false;
+		$permission_error      = false;
+		$plugin_already_active = false;
 		foreach ( $this->plugins as $plugin ) {
 
 			if ( ! $this->current_user_can( 'activate_plugin', $plugin ) ) {
@@ -278,6 +279,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 			if ( ( ! $this->network_wide && Jetpack::is_plugin_active( $plugin ) ) || is_plugin_active_for_network( $plugin ) ) {
 				$this->log[ $plugin ]['error'] = __( 'The Plugin is already active.', 'jetpack' );
 				$has_errors                    = true;
+				$plugin_already_active         = true;
 				continue;
 			}
 
@@ -314,7 +316,8 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 				return new WP_Error( 'unauthorized_error', $this->log[ $plugin ]['error'], 403 );
 			}
 
-			return new WP_Error( 'activation_error', $this->log[ $plugin ]['error'] );
+			$error_code = $plugin_already_active ? 'plugin_already_active' : 'activation_error';
+			return new WP_Error( $error_code, $this->log[ $plugin ]['error'] );
 		}
 	}
 
@@ -344,7 +347,8 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 	 * @return null|WP_Error null if the deactivation was successful
 	 */
 	protected function deactivate() {
-		$permission_error = false;
+		$permission_error        = false;
+		$plugin_already_inactive = false;
 		foreach ( $this->plugins as $plugin ) {
 			if ( ! $this->current_user_can( 'deactivate_plugin', $plugin ) ) {
 				$error                         = __( 'Sorry, you are not allowed to deactivate this plugin.', 'jetpack' );
@@ -356,6 +360,7 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 			if ( ! Jetpack::is_plugin_active( $plugin ) ) {
 				$error                         = __( 'The Plugin is already deactivated.', 'jetpack' );
 				$this->log[ $plugin ]['error'] = $error;
+				$plugin_already_inactive       = true;
 				continue;
 			}
 
@@ -378,7 +383,8 @@ class Jetpack_JSON_API_Plugins_Modify_Endpoint extends Jetpack_JSON_API_Plugins_
 				return new WP_Error( 'unauthorized_error', $error, 403 );
 			}
 
-			return new WP_Error( 'deactivation_error', $error );
+			$error_code = $plugin_already_inactive ? 'plugin_already_inactive' : 'deactivation_error';
+			return new WP_Error( $error_code, $error );
 		}
 	}
 

--- a/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-v1-2-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/jetpack/class.jetpack-json-api-plugins-modify-v1-2-endpoint.php
@@ -160,7 +160,7 @@ class Jetpack_JSON_API_Plugins_Modify_v1_2_Endpoint extends Jetpack_JSON_API_Plu
 			}
 
 			if ( ! $success ) {
-				$this->log[ $plugin ]['error'] = $result->get_error_messages;
+				$this->log[ $plugin ]['error'] = __( 'There was an error activating your plugin', 'jetpack' );
 
 				$has_errors = true;
 				continue;

--- a/projects/plugins/jetpack/tests/php/json-api/Jetpack_Json_Api_Plugins_Endpoints_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/Jetpack_Json_Api_Plugins_Endpoints_Test.php
@@ -277,6 +277,66 @@ class Jetpack_Json_Api_Plugins_Endpoints_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Verify activating an active plugin returns a distinct error code.
+	 */
+	public function test_activate_returns_plugin_already_active_error_code() {
+		wp_set_current_user( self::$super_admin_user_id );
+		$this->install_the_plugin();
+		activate_plugin( 'the/the.php' );
+
+		$result = $this->invoke_plugin_modify_action( 'activate', 'the/the.php' );
+
+		deactivate_plugins( 'the/the.php' );
+		$this->remove_the_plugin();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'plugin_already_active', $result->get_error_code() );
+		$this->assertSame( __( 'The Plugin is already active.', 'jetpack' ), $result->get_error_message() );
+		$this->assertNull( $result->get_error_data() );
+	}
+
+	/**
+	 * Verify deactivating an inactive plugin returns a distinct error code.
+	 */
+	public function test_deactivate_returns_plugin_already_inactive_error_code() {
+		wp_set_current_user( self::$super_admin_user_id );
+		$this->install_the_plugin();
+
+		$result = $this->invoke_plugin_modify_action( 'deactivate', 'the/the.php' );
+
+		$this->remove_the_plugin();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'plugin_already_inactive', $result->get_error_code() );
+		$this->assertSame( __( 'The Plugin is already deactivated.', 'jetpack' ), $result->get_error_message() );
+		$this->assertNull( $result->get_error_data() );
+	}
+
+	/**
+	 * Verify a failed deactivation keeps the existing error code.
+	 */
+	public function test_deactivate_keeps_deactivation_error_code_for_failure() {
+		wp_set_current_user( self::$super_admin_user_id );
+		$this->install_the_plugin();
+		activate_plugin( 'the/the.php' );
+		$prevent_deactivation = function ( $_new_value, $old_value ) {
+			return $old_value;
+		};
+		add_filter( 'pre_update_option_active_plugins', $prevent_deactivation, 10, 2 );
+
+		$result = $this->invoke_plugin_modify_action( 'deactivate', 'the/the.php' );
+
+		remove_filter( 'pre_update_option_active_plugins', $prevent_deactivation, 10 );
+		deactivate_plugins( 'the/the.php' );
+		$this->remove_the_plugin();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'deactivation_error', $result->get_error_code() );
+		$this->assertSame( __( 'There was an error deactivating your plugin', 'jetpack' ), $result->get_error_message() );
+		$this->assertNull( $result->get_error_data() );
+	}
+
+	/**
 	 * @author tonykova
 	 * @group external-http
 	 */
@@ -352,6 +412,34 @@ class Jetpack_Json_Api_Plugins_Endpoints_Test extends WP_UnitTestCase {
 
 	public function filesystem_method_direct() {
 		return 'direct';
+	}
+
+	/**
+	 * Invoke a plugin modification action for a non-bulk request.
+	 *
+	 * @param string $action The action method to invoke.
+	 * @param string $plugin The plugin file.
+	 * @return mixed
+	 */
+	private function invoke_plugin_modify_action( $action, $plugin ) {
+		$endpoint = new Jetpack_JSON_API_Plugins_Modify_Endpoint( array() );
+		$class    = new ReflectionClass( 'Jetpack_JSON_API_Plugins_Modify_Endpoint' );
+
+		$plugins_property = $class->getProperty( 'plugins' );
+		$bulk_property    = $class->getProperty( 'bulk' );
+		$action_method    = $class->getMethod( $action );
+
+		// @todo Remove these calls once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$plugins_property->setAccessible( true );
+			$bulk_property->setAccessible( true );
+			$action_method->setAccessible( true );
+		}
+
+		$plugins_property->setValue( $endpoint, array( $plugin ) );
+		$bulk_property->setValue( $endpoint, false );
+
+		return $action_method->invoke( $endpoint );
 	}
 
 	public function rmdir( $dir ) {

--- a/projects/plugins/jetpack/tests/php/json-api/Jetpack_Json_Api_Plugins_Endpoints_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/Jetpack_Json_Api_Plugins_Endpoints_Test.php
@@ -358,6 +358,7 @@ class Jetpack_Json_Api_Plugins_Endpoints_Test extends WP_UnitTestCase {
 
 		$this->assertWPError( $result );
 		$this->assertSame( 'activation_error', $result->get_error_code() );
+		$this->assertSame( __( 'There was an error activating your plugin', 'jetpack' ), $result->get_error_message() );
 		$this->assertEmpty( $result->get_error_data( 'additional_data' ) );
 	}
 

--- a/projects/plugins/jetpack/tests/php/json-api/Jetpack_Json_Api_Plugins_Endpoints_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/Jetpack_Json_Api_Plugins_Endpoints_Test.php
@@ -282,11 +282,11 @@ class Jetpack_Json_Api_Plugins_Endpoints_Test extends WP_UnitTestCase {
 	public function test_activate_keeps_error_code_and_adds_already_active_reason() {
 		wp_set_current_user( self::$super_admin_user_id );
 		$this->install_the_plugin();
-		activate_plugin( 'the/the.php' );
+		$active_filter = $this->pretend_plugin_is_active( 'the/the.php' );
 
 		$result = $this->invoke_plugin_modify_action( 'activate', 'the/the.php' );
 
-		deactivate_plugins( 'the/the.php' );
+		remove_filter( 'option_active_plugins', $active_filter );
 		$this->remove_the_plugin();
 
 		$this->assertWPError( $result );
@@ -320,7 +320,7 @@ class Jetpack_Json_Api_Plugins_Endpoints_Test extends WP_UnitTestCase {
 	public function test_deactivate_keeps_deactivation_error_code_for_failure() {
 		wp_set_current_user( self::$super_admin_user_id );
 		$this->install_the_plugin();
-		activate_plugin( 'the/the.php' );
+		$active_filter        = $this->pretend_plugin_is_active( 'the/the.php' );
 		$prevent_deactivation = function ( $_new_value, $old_value ) {
 			return $old_value;
 		};
@@ -329,7 +329,7 @@ class Jetpack_Json_Api_Plugins_Endpoints_Test extends WP_UnitTestCase {
 		$result = $this->invoke_plugin_modify_action( 'deactivate', 'the/the.php' );
 
 		remove_filter( 'pre_update_option_active_plugins', $prevent_deactivation, 10 );
-		deactivate_plugins( 'the/the.php' );
+		remove_filter( 'option_active_plugins', $active_filter );
 		$this->remove_the_plugin();
 
 		$this->assertWPError( $result );
@@ -353,7 +353,6 @@ class Jetpack_Json_Api_Plugins_Endpoints_Test extends WP_UnitTestCase {
 		$result = $this->invoke_plugin_modify_action( 'activate', 'the/the.php' );
 
 		remove_filter( 'pre_update_option_active_plugins', $prevent_activation, 10 );
-		deactivate_plugins( 'the/the.php' );
 		$this->remove_the_plugin();
 
 		$this->assertWPError( $result );
@@ -438,6 +437,27 @@ class Jetpack_Json_Api_Plugins_Endpoints_Test extends WP_UnitTestCase {
 
 	public function filesystem_method_direct() {
 		return 'direct';
+	}
+
+	/**
+	 * Report a plugin as active without writing the `active_plugins` option.
+	 *
+	 * Anything hooked to `pre_update_option_active_plugins` sees every write to
+	 * that option, and wpcomsh appends its always-active plugins to the value.
+	 * Those plugins are not installed in the test environment, so a real
+	 * activation leaves the option pointing at files that don't exist, and any
+	 * later test that reads plugin headers for the active plugins warns.
+	 *
+	 * @param string $plugin The plugin file to report as active.
+	 * @return callable The filter callback, for `remove_filter()`.
+	 */
+	private function pretend_plugin_is_active( $plugin ) {
+		$callback = function () use ( $plugin ) {
+			return array( $plugin );
+		};
+		add_filter( 'option_active_plugins', $callback );
+
+		return $callback;
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/json-api/Jetpack_Json_Api_Plugins_Endpoints_Test.php
+++ b/projects/plugins/jetpack/tests/php/json-api/Jetpack_Json_Api_Plugins_Endpoints_Test.php
@@ -277,9 +277,9 @@ class Jetpack_Json_Api_Plugins_Endpoints_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Verify activating an active plugin returns a distinct error code.
+	 * Verify activating an active plugin adds a reason to the existing error.
 	 */
-	public function test_activate_returns_plugin_already_active_error_code() {
+	public function test_activate_keeps_error_code_and_adds_already_active_reason() {
 		wp_set_current_user( self::$super_admin_user_id );
 		$this->install_the_plugin();
 		activate_plugin( 'the/the.php' );
@@ -290,15 +290,16 @@ class Jetpack_Json_Api_Plugins_Endpoints_Test extends WP_UnitTestCase {
 		$this->remove_the_plugin();
 
 		$this->assertWPError( $result );
-		$this->assertSame( 'plugin_already_active', $result->get_error_code() );
+		$this->assertSame( 'activation_error', $result->get_error_code() );
 		$this->assertSame( __( 'The Plugin is already active.', 'jetpack' ), $result->get_error_message() );
-		$this->assertNull( $result->get_error_data() );
+		$this->assertSame( array( 'reason' => 'already_active' ), $result->get_error_data( 'additional_data' ) );
+		$this->assertSame( 400, WPCOM_JSON_API::serializable_error( $result )['status_code'] );
 	}
 
 	/**
-	 * Verify deactivating an inactive plugin returns a distinct error code.
+	 * Verify deactivating an inactive plugin adds a reason to the existing error.
 	 */
-	public function test_deactivate_returns_plugin_already_inactive_error_code() {
+	public function test_deactivate_keeps_error_code_and_adds_already_inactive_reason() {
 		wp_set_current_user( self::$super_admin_user_id );
 		$this->install_the_plugin();
 
@@ -307,9 +308,10 @@ class Jetpack_Json_Api_Plugins_Endpoints_Test extends WP_UnitTestCase {
 		$this->remove_the_plugin();
 
 		$this->assertWPError( $result );
-		$this->assertSame( 'plugin_already_inactive', $result->get_error_code() );
+		$this->assertSame( 'deactivation_error', $result->get_error_code() );
 		$this->assertSame( __( 'The Plugin is already deactivated.', 'jetpack' ), $result->get_error_message() );
-		$this->assertNull( $result->get_error_data() );
+		$this->assertSame( array( 'reason' => 'already_inactive' ), $result->get_error_data( 'additional_data' ) );
+		$this->assertSame( 400, WPCOM_JSON_API::serializable_error( $result )['status_code'] );
 	}
 
 	/**
@@ -334,6 +336,29 @@ class Jetpack_Json_Api_Plugins_Endpoints_Test extends WP_UnitTestCase {
 		$this->assertSame( 'deactivation_error', $result->get_error_code() );
 		$this->assertSame( __( 'There was an error deactivating your plugin', 'jetpack' ), $result->get_error_message() );
 		$this->assertNull( $result->get_error_data() );
+		$this->assertEmpty( $result->get_error_data( 'additional_data' ) );
+	}
+
+	/**
+	 * Verify a failed activation keeps the existing error code.
+	 */
+	public function test_activate_keeps_activation_error_code_for_failure() {
+		wp_set_current_user( self::$super_admin_user_id );
+		$this->install_the_plugin();
+		$prevent_activation = function ( $_new_value, $old_value ) {
+			return $old_value;
+		};
+		add_filter( 'pre_update_option_active_plugins', $prevent_activation, 10, 2 );
+
+		$result = $this->invoke_plugin_modify_action( 'activate', 'the/the.php' );
+
+		remove_filter( 'pre_update_option_active_plugins', $prevent_activation, 10 );
+		deactivate_plugins( 'the/the.php' );
+		$this->remove_the_plugin();
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'activation_error', $result->get_error_code() );
+		$this->assertEmpty( $result->get_error_data( 'additional_data' ) );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

* `activate()` and `deactivate()` in `Jetpack_JSON_API_Plugins_Modify_Endpoint` now attach `array( 'reason' => 'already_active' )` / `array( 'reason' => 'already_inactive' )` to the returned `WP_Error` when the plugin is already in the requested state. The error code, message, and HTTP status are unchanged.
* Fixes a separate bug in the activation-failure branch of both the v1.1 endpoint and the v1.2 override, which returned an empty error message.
* Adds PHPUnit coverage for the already-in-state cases and for genuine activation and deactivation failures.

### Why

`activation_error` and `deactivation_error` are generic codes. The endpoint wraps every failure in them, so they cover both a benign "the plugin is already in that state" no-op and a real failure. API clients cannot tell the two apart, and matching on the message is not viable because those strings are translated.

The result is that at least one client treats *every* `activation_error` as "already active" and shows the user a false "An error occurred while activating" notice on a plugin that is in fact active, while also miscounting its activation stats.

Attaching a reason via `WP_Error::add_data( ..., 'additional_data' )` gives clients a reliable signal. `Jetpack_JSON_API::serializable_error()` already surfaces that as `data` in the response, so no serialization changes are needed.

**This is deliberately backward compatible.** An earlier revision of this branch returned new error codes (`plugin_already_active` / `plugin_already_inactive`) instead. That was rejected in review: it would break every existing consumer matching the current codes, and it would produce divergent behavior across Jetpack versions during rollout and rollback. Carrying the signal in `data` leaves the existing contract untouched — old clients see an identical response, and new clients opt in by reading `data.reason`.

### The activation-failure message bug

Both endpoints did this in their activation failure branch:

```php
$this->log[ $plugin ]['error'] = $result->get_error_messages;
```

`activate_plugin()` returns `null` on success and `WP_Error` on failure, and the `WP_Error` case is already handled by the `is_wp_error()` check above, so `$result` is always `null` by the time that line runs. Reading a property on `null` emits a warning and yields `null`, so a genuine activation failure returned `activation_error` with an empty message.

Worth noting this is *not* a missing `()`. Adding one would call a method on `null` and fatal in the plugin activation path. The fix assigns a message, mirroring what the deactivation branch a few lines below has always done.

## Related product discussion/links

* Client-side counterpart: Automattic/wp-calypso#113242 — regression tests documenting the consumer bug this unblocks. Once this PR ships, that side can branch on `data.reason` and drop its `test.failing()` markers.
* Internal tracking: DOTMKT-41, DOTCOM-18116

## Does this pull request change what data or activity we track or use?

No. This adds a field to an existing error response and corrects an error message. No new data is collected, stored, or transmitted.

## Testing instructions

Run the endpoint tests:

```
jp docker up -d
jp docker phpunit jetpack -- --filter=Jetpack_Json_Api_Plugins_Endpoints_Test
```

All four tests should pass. They cover:

* activating an already-active plugin — code stays `activation_error`, `data.reason` is `already_active`, status stays 400
* deactivating an already-inactive plugin — code stays `deactivation_error`, `data.reason` is `already_inactive`, status stays 400
* a genuine activation failure — code stays `activation_error`, no `reason` attached, and the message is now populated rather than empty
* a genuine deactivation failure — code stays `deactivation_error`, no `reason` attached

To verify by hand against a site, call the plugin activation endpoint twice for the same plugin. The second call returns `activation_error` as before, now with `"data": { "reason": "already_active" }` in the response body.
