### PR TITLE
Premium Analytics: match the Traffic board default widgets to the prototype

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1786-default-traffic-widgets
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1786-default-traffic-widgets
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Traffic: Reorder and resize the default widgets so each row fills the grid, and drop Plan usage from the defaults.
+Traffic: Reorder and resize the default widgets so each row fills the grid, rename Summary to Traffic summary, and drop Plan usage from the defaults.

--- a/projects/packages/premium-analytics/changelog/wooa7s-1786-default-traffic-widgets
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1786-default-traffic-widgets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Traffic: Reorder and resize the default widgets so each row fills the grid, and drop Plan usage from the defaults.

--- a/projects/packages/premium-analytics/src/dashboard-layout.php
+++ b/projects/packages/premium-analytics/src/dashboard-layout.php
@@ -168,28 +168,30 @@ function get_dashboard_default_widget_instance(
 function get_dashboard_default_section_layouts() {
 	return array(
 		DASHBOARD_TRAFFIC_SECTION_ID     => array(
-			// Row 1: traffic chart + most-viewed posts.
+			// Rows fill the four-column grid. Plan usage is intentionally not a
+			// default; it stays available from the widget picker.
+			// Row 1: traffic chart.
 			get_dashboard_default_widget_instance(
 				'default-traffic-chart-widget-instance',
 				'jpa/traffic-chart',
 				0,
-				3,
+				4,
 				2,
 				array(
 					'granularity' => 'auto',
 				)
 			),
+			// Row 2: most-viewed posts + referrers + devices.
 			get_dashboard_default_widget_instance(
 				'default-stats-top-posts-widget-instance',
 				'jpa/stats-top-posts',
 				1,
-				1,
+				2,
 				2,
 				array(
 					'max' => 10,
 				)
 			),
-			// Row 2: referrers + locations map + devices.
 			get_dashboard_default_widget_instance(
 				'default-referrers-widget-instance',
 				'jpa/referrers',
@@ -201,26 +203,26 @@ function get_dashboard_default_section_layouts() {
 				)
 			),
 			get_dashboard_default_widget_instance(
-				'default-locations-widget-instance',
-				'jpa/locations',
-				3,
-				2,
-				2,
-				array(
-					'max' => 10,
-				)
-			),
-			get_dashboard_default_widget_instance(
 				'default-devices-widget-instance',
 				'jpa/devices',
-				4,
+				3,
 				1,
 				2,
 				array(
 					'max' => 5,
 				)
 			),
-			// Row 3: top platforms + VideoPress + authors + UTM insights.
+			// Row 3: locations map + top platforms.
+			get_dashboard_default_widget_instance(
+				'default-locations-widget-instance',
+				'jpa/locations',
+				4,
+				3,
+				2,
+				array(
+					'max' => 10,
+				)
+			),
 			get_dashboard_default_widget_instance(
 				'default-top-platforms-widget-instance',
 				'jpa/top-platforms',
@@ -231,6 +233,7 @@ function get_dashboard_default_section_layouts() {
 					'max' => 10,
 				)
 			),
+			// Row 4: VideoPress + clicks + authors.
 			get_dashboard_default_widget_instance(
 				'default-videopress-widget-instance',
 				'jpa/videopress',
@@ -242,35 +245,35 @@ function get_dashboard_default_section_layouts() {
 				)
 			),
 			get_dashboard_default_widget_instance(
-				'default-authors-widget-instance',
-				'jpa/authors',
+				'default-clicks-widget-instance',
+				'jpa/clicks',
 				7,
 				1,
+				2,
+				array(
+					'max' => 10,
+				)
+			),
+			get_dashboard_default_widget_instance(
+				'default-authors-widget-instance',
+				'jpa/authors',
+				8,
+				2,
 				2,
 				array(
 					'max' => 7,
 				)
 			),
+			// Row 5: UTM insights + search terms + file downloads (Simple only).
 			get_dashboard_default_widget_instance(
 				'default-utm-insights-widget-instance',
 				'jpa/utm-insights',
-				8,
-				1,
+				9,
+				2,
 				2,
 				array(
 					'utmDimension' => 'utm_source,utm_medium',
 					'max'          => 10,
-				)
-			),
-			// Row 4: clicks + search terms + file downloads + plan usage.
-			get_dashboard_default_widget_instance(
-				'default-clicks-widget-instance',
-				'jpa/clicks',
-				9,
-				1,
-				2,
-				array(
-					'max' => 10,
 				)
 			),
 			get_dashboard_default_widget_instance(
@@ -292,13 +295,6 @@ function get_dashboard_default_section_layouts() {
 				array(
 					'max' => 10,
 				)
-			),
-			get_dashboard_default_widget_instance(
-				'default-plan-usage-widget-instance',
-				'jpa/plan-usage',
-				12,
-				1,
-				2
 			),
 		),
 		DASHBOARD_INSIGHTS_SECTION_ID    => array(

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
@@ -223,58 +223,54 @@ class Dashboard_Layout_Test extends BaseTestCase {
 	 * The traffic tab receives its bundled traffic widgets.
 	 */
 	public function test_seed_default_dashboard_layout_adds_traffic_widgets() {
-		$layout              = seed_default_dashboard_layout( array(), DASHBOARD_TRAFFIC_SECTION_ID );
-		$layout_by_uuid      = array_column( $layout, null, 'uuid' );
-		$layout_types        = array_column( $layout, 'type' );
-		$utm_widget_uuid     = 'default-utm-insights-widget-instance';
-		$top_posts_uuid      = 'default-stats-top-posts-widget-instance';
-		$traffic_chart_uuid  = 'default-traffic-chart-widget-instance';
-		$file_downloads_uuid = 'default-file-downloads-widget-instance';
+		$layout          = seed_default_dashboard_layout( array(), DASHBOARD_TRAFFIC_SECTION_ID );
+		$layout_by_uuid  = array_column( $layout, null, 'uuid' );
+		$layout_types    = array_column( $layout, 'type' );
+		$utm_widget_uuid = 'default-utm-insights-widget-instance';
 
-		$this->assertContains( 'jpa/traffic-chart', $layout_types );
-		$this->assertContains( 'jpa/stats-top-posts', $layout_types );
-		$this->assertContains( 'jpa/referrers', $layout_types );
-		$this->assertContains( 'jpa/authors', $layout_types );
-		$this->assertContains( 'jpa/videopress', $layout_types );
-		$this->assertContains( 'jpa/plan-usage', $layout_types );
-		$this->assertArrayHasKey( 'default-locations-widget-instance', $layout_by_uuid );
-		$this->assertArrayHasKey( $utm_widget_uuid, $layout_by_uuid );
-		$this->assertArrayHasKey( $file_downloads_uuid, $layout_by_uuid );
+		// uuid => [ type, width, order ]; widths fill the four-column grid.
+		$expected = array(
+			'default-traffic-chart-widget-instance'   => array( 'jpa/traffic-chart', 4, 0 ),
+			'default-stats-top-posts-widget-instance' => array( 'jpa/stats-top-posts', 2, 1 ),
+			'default-referrers-widget-instance'       => array( 'jpa/referrers', 1, 2 ),
+			'default-devices-widget-instance'         => array( 'jpa/devices', 1, 3 ),
+			'default-locations-widget-instance'       => array( 'jpa/locations', 3, 4 ),
+			'default-top-platforms-widget-instance'   => array( 'jpa/top-platforms', 1, 5 ),
+			'default-videopress-widget-instance'      => array( 'jpa/videopress', 1, 6 ),
+			'default-clicks-widget-instance'          => array( 'jpa/clicks', 1, 7 ),
+			'default-authors-widget-instance'         => array( 'jpa/authors', 2, 8 ),
+			'default-utm-insights-widget-instance'    => array( 'jpa/utm-insights', 2, 9 ),
+			'default-search-terms-widget-instance'    => array( 'jpa/search-terms', 1, 10 ),
+			'default-file-downloads-widget-instance'  => array( 'jpa/file-downloads', 1, 11 ),
+		);
+
+		$this->assertSame( array_keys( $expected ), array_column( $layout, 'uuid' ) );
+
+		foreach ( $expected as $uuid => $instance ) {
+			list( $type, $width, $order ) = $instance;
+
+			$this->assertSame( $type, $layout_by_uuid[ $uuid ]['type'], $uuid );
+			$this->assertSame(
+				array(
+					'width'  => $width,
+					'height' => 2,
+					'order'  => $order,
+				),
+				$layout_by_uuid[ $uuid ]['placement'],
+				$uuid
+			);
+		}
+
+		// Plan usage is intentionally not a default.
+		$this->assertNotContains( 'jpa/plan-usage', $layout_types );
 
 		$this->assertSame(
 			array(
-				'uuid'       => $utm_widget_uuid,
-				'type'       => 'jpa/utm-insights',
-				'attributes' => array(
-					'utmDimension' => 'utm_source,utm_medium',
-					'max'          => 10,
-				),
-				'placement'  => array(
-					'width'  => 1,
-					'height' => 2,
-					'order'  => 8,
-				),
+				'utmDimension' => 'utm_source,utm_medium',
+				'max'          => 10,
 			),
-			$layout_by_uuid[ $utm_widget_uuid ]
+			$layout_by_uuid[ $utm_widget_uuid ]['attributes']
 		);
-
-		$this->assertSame(
-			array(
-				'uuid'       => $top_posts_uuid,
-				'type'       => 'jpa/stats-top-posts',
-				'attributes' => array(
-					'max' => 10,
-				),
-				'placement'  => array(
-					'width'  => 1,
-					'height' => 2,
-					'order'  => 1,
-				),
-			),
-			$layout_by_uuid[ $top_posts_uuid ]
-		);
-
-		$this->assertSame( 'jpa/traffic-chart', $layout_by_uuid[ $traffic_chart_uuid ]['type'] );
 	}
 
 	/**

--- a/projects/packages/premium-analytics/widgets/traffic-chart/widget.json
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/widget.json
@@ -1,6 +1,6 @@
 {
 	"name": "jpa/traffic-chart",
-	"title": "Summary",
+	"title": "Traffic summary",
 	"description": "Compare views, visitors, likes, and comments over the selected period, with the previous period overlaid for comparison.",
 	"help": {
 		"content": "A summary of your site's views, visitors, likes, and comments."


### PR DESCRIPTION
Part of WOOA7S-1786

## Proposed changes

Update the `Traffic` board's default layout to match the design prototype.

* Reorder and resize the Traffic defaults so every row fills the four-column grid.
* Drop Plan usage from the defaults. It stays registered and can still be added from the widget picker.
* Rename the traffic chart widget from "Summary" to "Traffic summary".
* Pin the full Traffic order and placements in `Dashboard_Layout_Test`, instead of two hand-picked widgets.

Anyone who has already customized Traffic keeps their stored layout; only untouched tabs and resets pick this up. On non-Simple sites the last row stops short because `jpa/file-downloads` is Simple-only.

## Related product discussion/links

* WOOA7S-1786

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On a site with the Premium Analytics dashboard, go to **Stats v2** and make sure you have never customized the Traffic tab. If you have, open the `⋮ menu` and reset the layout.
2. Confirm the Traffic board renders in this order, with each row filling the width (match https://sweetly-steep.jurassic.ninja/wp-admin/admin.php?page=analytics-dashboard):
   - Traffic summary (full width)
   - Top pages (half) · Top referrers · Devices
   - Top locations (three quarters) · Top platforms
   - Top videos · Top links clicked · Popular authors (half)
   - Top UTM (half) · Top searched terms
3. Confirm the first widget's header reads **Traffic summary**, not "Summary".
4. Confirm **Plan usage** is not on the board, and that it is still offered under Customize → add widget.
5. On a self-hosted Jetpack site, confirm **Top downloaded** is absent (it is WordPress.com Simple only) and the last row ends after Top searched terms.
6. Customize the Traffic tab, reload, and confirm your saved layout still wins over the new default.


https://github.com/user-attachments/assets/3402d41c-f246-4f56-aaf2-e7c1232f5627

