### PR TITLE
Premium Analytics: match the Insights board default widgets to the prototype layout

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1786-default-insights-widgets
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1786-default-insights-widgets
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Insights: Reorder and resize the default widgets so each row fills the grid, and show the Highlights metrics by default.
+Insights: Reorder and resize the default widgets so each row fills the grid, add Popular post next to Latest post, and show the Highlights metrics by default.

--- a/projects/packages/premium-analytics/changelog/wooa7s-1786-default-insights-widgets
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1786-default-insights-widgets
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Insights: Reorder and resize the default widgets so each row fills the grid, add Popular post next to Latest post, and show the Highlights metrics by default.
+Insights: Reorder and resize the default widgets so each row fills the grid, and add Popular post, Total views, and Total visitors to the defaults.

--- a/projects/packages/premium-analytics/changelog/wooa7s-1786-default-insights-widgets
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1786-default-insights-widgets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Insights: Reorder and resize the default widgets so each row fills the grid, and show the Highlights metrics by default.

--- a/projects/packages/premium-analytics/src/dashboard-layout.php
+++ b/projects/packages/premium-analytics/src/dashboard-layout.php
@@ -300,9 +300,10 @@ function get_dashboard_default_section_layouts() {
 		DASHBOARD_INSIGHTS_SECTION_ID    => array(
 			// Mirrors the legacy Calypso Stats Insights page (WOOA7S-1616).
 			// Emails is not an Insights module (it lives on the Subscribers
-			// tab). Two modules from the design are not ported yet — Most
-			// popular post (part of WOOA7S-1510) and the site-wide views
-			// heatmap; the rows below close over the gaps they leave.
+			// tab). Two modules from the design have no widget yet — the
+			// site-wide views heatmap (WOOA7S-1787) and the Total views /
+			// Total visitors cards (WOOA7S-1847); the rows below close over
+			// the gaps they leave.
 			// Row 1: highlights + posting-activity heatmap. Highlights renders
 			// an empty prompt without an explicit metric list.
 			get_dashboard_default_widget_instance(
@@ -322,33 +323,40 @@ function get_dashboard_default_section_layouts() {
 				2,
 				2
 			),
-			// Row 2: all-time totals, as a single-height banner.
-			get_dashboard_default_widget_instance(
-				'default-all-time-stats-widget-instance',
-				'jpa/all-time-stats',
-				2,
-				4,
-				1
-			),
-			// Row 3: latest post + the two most-popular cards.
+			// Row 2: the two post spotlights.
 			get_dashboard_default_widget_instance(
 				'default-latest-post-widget-instance',
 				'jpa/latest-post',
+				2,
+				2,
+				2
+			),
+			get_dashboard_default_widget_instance(
+				'default-popular-post-widget-instance',
+				'jpa/popular-post',
 				3,
+				2,
+				2
+			),
+			// Row 3: all-time totals + the two most-popular cards.
+			get_dashboard_default_widget_instance(
+				'default-all-time-stats-widget-instance',
+				'jpa/all-time-stats',
+				4,
 				2,
 				2
 			),
 			get_dashboard_default_widget_instance(
 				'default-most-popular-time-widget-instance',
 				'jpa/most-popular-time',
-				4,
+				5,
 				1,
 				2
 			),
 			get_dashboard_default_widget_instance(
 				'default-most-popular-day-widget-instance',
 				'jpa/most-popular-day',
-				5,
+				6,
 				1,
 				2
 			),
@@ -356,7 +364,7 @@ function get_dashboard_default_section_layouts() {
 			get_dashboard_default_widget_instance(
 				'default-most-commented-posts-widget-instance',
 				'jpa/most-commented-posts',
-				6,
+				7,
 				1,
 				2,
 				array(
@@ -366,7 +374,7 @@ function get_dashboard_default_section_layouts() {
 			get_dashboard_default_widget_instance(
 				'default-most-commented-authors-widget-instance',
 				'jpa/most-commented-authors',
-				7,
+				8,
 				1,
 				2,
 				array(
@@ -376,7 +384,7 @@ function get_dashboard_default_section_layouts() {
 			get_dashboard_default_widget_instance(
 				'default-shares-widget-instance',
 				'jpa/shares',
-				8,
+				9,
 				1,
 				2,
 				array(
@@ -386,7 +394,7 @@ function get_dashboard_default_section_layouts() {
 			get_dashboard_default_widget_instance(
 				'default-tags-widget-instance',
 				'jpa/tags',
-				9,
+				10,
 				1,
 				2,
 				array(

--- a/projects/packages/premium-analytics/src/dashboard-layout.php
+++ b/projects/packages/premium-analytics/src/dashboard-layout.php
@@ -298,32 +298,35 @@ function get_dashboard_default_section_layouts() {
 			),
 		),
 		DASHBOARD_INSIGHTS_SECTION_ID    => array(
-			// Mirrors the legacy Calypso Stats Insights page (WOOA7S-1616).
-			// Emails is not an Insights module (it lives on the Subscribers
-			// tab). Two modules from the design have no widget yet — the
-			// site-wide views heatmap (WOOA7S-1787) and the Total views /
-			// Total visitors cards (WOOA7S-1847); the rows below close over
-			// the gaps they leave.
-			// Row 1: highlights + posting-activity heatmap. Highlights renders
-			// an empty prompt without an explicit metric list.
+			// Mirrors the legacy Calypso Stats Insights page (WOOA7S-1616) and
+			// follows the design's row structure. Emails is not an Insights
+			// module (it lives on the Subscribers tab). Two modules have no
+			// widget yet, so their rows are absent rather than substituted:
+			// the site-wide views heatmap (WOOA7S-1787) and the Total views /
+			// Total visitors cards (WOOA7S-1847, stood in for by All-time
+			// stats). Widgets on the single-height rows below still crop their
+			// content until WOOA7S-1846 lands.
+			// Row 1: highlights banner. Renders an empty prompt without an
+			// explicit metric list.
 			get_dashboard_default_widget_instance(
 				'default-annual-highlights-widget-instance',
 				'jpa/annual-highlights',
 				0,
-				2,
-				2,
+				4,
+				1,
 				array(
 					'metrics' => array( 'posts', 'words', 'likes', 'comments' ),
 				)
 			),
+			// Row 2: posting-activity heatmap.
 			get_dashboard_default_widget_instance(
 				'default-posting-activity-widget-instance',
 				'jpa/posting-activity',
 				1,
-				2,
-				2
+				4,
+				1
 			),
-			// Row 2: the two post spotlights.
+			// Row 3: the two post spotlights.
 			get_dashboard_default_widget_instance(
 				'default-latest-post-widget-instance',
 				'jpa/latest-post',
@@ -338,29 +341,29 @@ function get_dashboard_default_section_layouts() {
 				2,
 				2
 			),
-			// Row 3: all-time totals + the two most-popular cards.
+			// Row 4: all-time totals + the two most-popular cards.
 			get_dashboard_default_widget_instance(
 				'default-all-time-stats-widget-instance',
 				'jpa/all-time-stats',
 				4,
 				2,
-				2
+				1
 			),
 			get_dashboard_default_widget_instance(
 				'default-most-popular-time-widget-instance',
 				'jpa/most-popular-time',
 				5,
 				1,
-				2
+				1
 			),
 			get_dashboard_default_widget_instance(
 				'default-most-popular-day-widget-instance',
 				'jpa/most-popular-day',
 				6,
 				1,
-				2
+				1
 			),
-			// Row 4: the comment leaderboards, shares, and tags.
+			// Row 5: the comment leaderboards, shares, and tags.
 			get_dashboard_default_widget_instance(
 				'default-most-commented-posts-widget-instance',
 				'jpa/most-commented-posts',

--- a/projects/packages/premium-analytics/src/dashboard-layout.php
+++ b/projects/packages/premium-analytics/src/dashboard-layout.php
@@ -300,68 +300,63 @@ function get_dashboard_default_section_layouts() {
 		DASHBOARD_INSIGHTS_SECTION_ID    => array(
 			// Mirrors the legacy Calypso Stats Insights page (WOOA7S-1616).
 			// Emails is not an Insights module (it lives on the Subscribers
-			// tab). Two canonical modules are not ported yet — All-time total
-			// views (WOOA7S-1512) and Most popular post (part of WOOA7S-1510).
-			// Row 1: annual highlights + all-time stats.
+			// tab). Two modules from the design are not ported yet — Most
+			// popular post (part of WOOA7S-1510) and the site-wide views
+			// heatmap; the rows below close over the gaps they leave.
+			// Row 1: highlights + posting-activity heatmap. Highlights renders
+			// an empty prompt without an explicit metric list.
 			get_dashboard_default_widget_instance(
 				'default-annual-highlights-widget-instance',
 				'jpa/annual-highlights',
 				0,
 				2,
+				2,
+				array(
+					'metrics' => array( 'posts', 'words', 'likes', 'comments' ),
+				)
+			),
+			get_dashboard_default_widget_instance(
+				'default-posting-activity-widget-instance',
+				'jpa/posting-activity',
+				1,
+				2,
 				2
 			),
+			// Row 2: all-time totals, as a single-height banner.
 			get_dashboard_default_widget_instance(
 				'default-all-time-stats-widget-instance',
 				'jpa/all-time-stats',
-				1,
 				2,
-				2
+				4,
+				1
 			),
-			// Row 2: latest post + the two most-popular cards + tags.
+			// Row 3: latest post + the two most-popular cards.
 			get_dashboard_default_widget_instance(
 				'default-latest-post-widget-instance',
 				'jpa/latest-post',
+				3,
 				2,
-				1,
 				2
 			),
 			get_dashboard_default_widget_instance(
 				'default-most-popular-time-widget-instance',
 				'jpa/most-popular-time',
-				3,
+				4,
 				1,
 				2
 			),
 			get_dashboard_default_widget_instance(
 				'default-most-popular-day-widget-instance',
 				'jpa/most-popular-day',
-				4,
-				1,
-				2
-			),
-			get_dashboard_default_widget_instance(
-				'default-tags-widget-instance',
-				'jpa/tags',
 				5,
 				1,
-				2,
-				array(
-					'max' => 10,
-				)
-			),
-			// Row 3: posting-activity heatmap + the two comment leaderboards.
-			get_dashboard_default_widget_instance(
-				'default-posting-activity-widget-instance',
-				'jpa/posting-activity',
-				6,
-				2,
 				2
 			),
-			// Posts before authors, matching the design's Insights bottom row.
+			// Row 4: the comment leaderboards, shares, and tags.
 			get_dashboard_default_widget_instance(
 				'default-most-commented-posts-widget-instance',
 				'jpa/most-commented-posts',
-				7,
+				6,
 				1,
 				2,
 				array(
@@ -371,6 +366,16 @@ function get_dashboard_default_section_layouts() {
 			get_dashboard_default_widget_instance(
 				'default-most-commented-authors-widget-instance',
 				'jpa/most-commented-authors',
+				7,
+				1,
+				2,
+				array(
+					'max' => 10,
+				)
+			),
+			get_dashboard_default_widget_instance(
+				'default-shares-widget-instance',
+				'jpa/shares',
 				8,
 				1,
 				2,
@@ -378,10 +383,9 @@ function get_dashboard_default_section_layouts() {
 					'max' => 10,
 				)
 			),
-			// Row 4: shares, joined by the two unported modules noted above.
 			get_dashboard_default_widget_instance(
-				'default-shares-widget-instance',
-				'jpa/shares',
+				'default-tags-widget-instance',
+				'jpa/tags',
 				9,
 				1,
 				2,

--- a/projects/packages/premium-analytics/src/dashboard-layout.php
+++ b/projects/packages/premium-analytics/src/dashboard-layout.php
@@ -298,25 +298,16 @@ function get_dashboard_default_section_layouts() {
 			),
 		),
 		DASHBOARD_INSIGHTS_SECTION_ID    => array(
-			// Mirrors the legacy Calypso Stats Insights page (WOOA7S-1616) and
-			// follows the design's row structure. Emails is not an Insights
-			// module (it lives on the Subscribers tab). Two modules have no
-			// widget yet, so their rows are absent rather than substituted:
-			// the site-wide views heatmap (WOOA7S-1787) and the Total views /
-			// Total visitors cards (WOOA7S-1847, stood in for by All-time
-			// stats). Widgets on the single-height rows below still crop their
-			// content until WOOA7S-1846 lands.
-			// Row 1: highlights banner. Renders an empty prompt without an
-			// explicit metric list.
+			// Follows the prototype's rows (WOOA7S-1786). Emails lives on the
+			// Subscribers tab, and the site-wide views heatmap has no widget
+			// yet (WOOA7S-1787), so that row is absent.
+			// Row 1: highlights banner.
 			get_dashboard_default_widget_instance(
 				'default-annual-highlights-widget-instance',
 				'jpa/annual-highlights',
 				0,
 				4,
-				1,
-				array(
-					'metrics' => array( 'posts', 'words', 'likes', 'comments' ),
-				)
+				1
 			),
 			// Row 2: posting-activity heatmap.
 			get_dashboard_default_widget_instance(
@@ -341,25 +332,33 @@ function get_dashboard_default_section_layouts() {
 				2,
 				2
 			),
-			// Row 4: all-time totals + the two most-popular cards.
+			// Row 4: the period totals + the two most-popular cards. The
+			// most-popular cards still crop at this height (WOOA7S-1846).
 			get_dashboard_default_widget_instance(
-				'default-all-time-stats-widget-instance',
-				'jpa/all-time-stats',
+				'default-total-views-widget-instance',
+				'jpa/total-views',
 				4,
-				2,
+				1,
+				1
+			),
+			get_dashboard_default_widget_instance(
+				'default-total-visitors-widget-instance',
+				'jpa/total-visitors',
+				5,
+				1,
 				1
 			),
 			get_dashboard_default_widget_instance(
 				'default-most-popular-time-widget-instance',
 				'jpa/most-popular-time',
-				5,
+				6,
 				1,
 				1
 			),
 			get_dashboard_default_widget_instance(
 				'default-most-popular-day-widget-instance',
 				'jpa/most-popular-day',
-				6,
+				7,
 				1,
 				1
 			),
@@ -367,7 +366,7 @@ function get_dashboard_default_section_layouts() {
 			get_dashboard_default_widget_instance(
 				'default-most-commented-posts-widget-instance',
 				'jpa/most-commented-posts',
-				7,
+				8,
 				1,
 				2,
 				array(
@@ -377,7 +376,7 @@ function get_dashboard_default_section_layouts() {
 			get_dashboard_default_widget_instance(
 				'default-most-commented-authors-widget-instance',
 				'jpa/most-commented-authors',
-				8,
+				9,
 				1,
 				2,
 				array(
@@ -387,7 +386,7 @@ function get_dashboard_default_section_layouts() {
 			get_dashboard_default_widget_instance(
 				'default-shares-widget-instance',
 				'jpa/shares',
-				9,
+				10,
 				1,
 				2,
 				array(
@@ -397,7 +396,7 @@ function get_dashboard_default_section_layouts() {
 			get_dashboard_default_widget_instance(
 				'default-tags-widget-instance',
 				'jpa/tags',
-				10,
+				11,
 				1,
 				2,
 				array(

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
@@ -281,15 +281,15 @@ class Dashboard_Layout_Test extends BaseTestCase {
 		$layout_by_uuid = array_column( $layout, null, 'uuid' );
 		$layout_types   = array_column( $layout, 'type' );
 
-		// uuid => [ type, width, height, order ]; widths fill the four-column grid.
+		// uuid => [ type, width, height, order ]; each row fills the four-column grid.
 		$expected = array(
-			'default-annual-highlights-widget-instance'    => array( 'jpa/annual-highlights', 2, 2, 0 ),
-			'default-posting-activity-widget-instance'     => array( 'jpa/posting-activity', 2, 2, 1 ),
+			'default-annual-highlights-widget-instance'    => array( 'jpa/annual-highlights', 4, 1, 0 ),
+			'default-posting-activity-widget-instance'     => array( 'jpa/posting-activity', 4, 1, 1 ),
 			'default-latest-post-widget-instance'          => array( 'jpa/latest-post', 2, 2, 2 ),
 			'default-popular-post-widget-instance'         => array( 'jpa/popular-post', 2, 2, 3 ),
-			'default-all-time-stats-widget-instance'       => array( 'jpa/all-time-stats', 2, 2, 4 ),
-			'default-most-popular-time-widget-instance'    => array( 'jpa/most-popular-time', 1, 2, 5 ),
-			'default-most-popular-day-widget-instance'     => array( 'jpa/most-popular-day', 1, 2, 6 ),
+			'default-all-time-stats-widget-instance'       => array( 'jpa/all-time-stats', 2, 1, 4 ),
+			'default-most-popular-time-widget-instance'    => array( 'jpa/most-popular-time', 1, 1, 5 ),
+			'default-most-popular-day-widget-instance'     => array( 'jpa/most-popular-day', 1, 1, 6 ),
 			'default-most-commented-posts-widget-instance' => array( 'jpa/most-commented-posts', 1, 2, 7 ),
 			'default-most-commented-authors-widget-instance' => array( 'jpa/most-commented-authors', 1, 2, 8 ),
 			'default-shares-widget-instance'               => array( 'jpa/shares', 1, 2, 9 ),

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
@@ -287,13 +287,14 @@ class Dashboard_Layout_Test extends BaseTestCase {
 			'default-posting-activity-widget-instance'     => array( 'jpa/posting-activity', 4, 1, 1 ),
 			'default-latest-post-widget-instance'          => array( 'jpa/latest-post', 2, 2, 2 ),
 			'default-popular-post-widget-instance'         => array( 'jpa/popular-post', 2, 2, 3 ),
-			'default-all-time-stats-widget-instance'       => array( 'jpa/all-time-stats', 2, 1, 4 ),
-			'default-most-popular-time-widget-instance'    => array( 'jpa/most-popular-time', 1, 1, 5 ),
-			'default-most-popular-day-widget-instance'     => array( 'jpa/most-popular-day', 1, 1, 6 ),
-			'default-most-commented-posts-widget-instance' => array( 'jpa/most-commented-posts', 1, 2, 7 ),
-			'default-most-commented-authors-widget-instance' => array( 'jpa/most-commented-authors', 1, 2, 8 ),
-			'default-shares-widget-instance'               => array( 'jpa/shares', 1, 2, 9 ),
-			'default-tags-widget-instance'                 => array( 'jpa/tags', 1, 2, 10 ),
+			'default-total-views-widget-instance'          => array( 'jpa/total-views', 1, 1, 4 ),
+			'default-total-visitors-widget-instance'       => array( 'jpa/total-visitors', 1, 1, 5 ),
+			'default-most-popular-time-widget-instance'    => array( 'jpa/most-popular-time', 1, 1, 6 ),
+			'default-most-popular-day-widget-instance'     => array( 'jpa/most-popular-day', 1, 1, 7 ),
+			'default-most-commented-posts-widget-instance' => array( 'jpa/most-commented-posts', 1, 2, 8 ),
+			'default-most-commented-authors-widget-instance' => array( 'jpa/most-commented-authors', 1, 2, 9 ),
+			'default-shares-widget-instance'               => array( 'jpa/shares', 1, 2, 10 ),
+			'default-tags-widget-instance'                 => array( 'jpa/tags', 1, 2, 11 ),
 		);
 
 		$this->assertSame( array_keys( $expected ), array_column( $layout, 'uuid' ) );
@@ -319,13 +320,13 @@ class Dashboard_Layout_Test extends BaseTestCase {
 		$this->assertNotContains( 'jpa/stats-emails', $layout_types );
 		// The Comments module ships as two focused widgets, not one toggled widget.
 		$this->assertNotContains( 'jpa/comments', $layout_types );
+		// Total views and Total visitors carry the totals row instead.
+		$this->assertNotContains( 'jpa/all-time-stats', $layout_types );
 
-		// Highlights renders an empty prompt without an explicit metric list.
-		$this->assertSame(
-			array(
-				'metrics' => array( 'posts', 'words', 'likes', 'comments' ),
-			),
-			$layout_by_uuid['default-annual-highlights-widget-instance']['attributes']
+		// Highlights falls back to the widget's own default metric list.
+		$this->assertArrayNotHasKey(
+			'attributes',
+			$layout_by_uuid['default-annual-highlights-widget-instance']
 		);
 
 		$this->assertSame(

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
@@ -285,14 +285,15 @@ class Dashboard_Layout_Test extends BaseTestCase {
 		$expected = array(
 			'default-annual-highlights-widget-instance'    => array( 'jpa/annual-highlights', 2, 2, 0 ),
 			'default-posting-activity-widget-instance'     => array( 'jpa/posting-activity', 2, 2, 1 ),
-			'default-all-time-stats-widget-instance'       => array( 'jpa/all-time-stats', 4, 1, 2 ),
-			'default-latest-post-widget-instance'          => array( 'jpa/latest-post', 2, 2, 3 ),
-			'default-most-popular-time-widget-instance'    => array( 'jpa/most-popular-time', 1, 2, 4 ),
-			'default-most-popular-day-widget-instance'     => array( 'jpa/most-popular-day', 1, 2, 5 ),
-			'default-most-commented-posts-widget-instance' => array( 'jpa/most-commented-posts', 1, 2, 6 ),
-			'default-most-commented-authors-widget-instance' => array( 'jpa/most-commented-authors', 1, 2, 7 ),
-			'default-shares-widget-instance'               => array( 'jpa/shares', 1, 2, 8 ),
-			'default-tags-widget-instance'                 => array( 'jpa/tags', 1, 2, 9 ),
+			'default-latest-post-widget-instance'          => array( 'jpa/latest-post', 2, 2, 2 ),
+			'default-popular-post-widget-instance'         => array( 'jpa/popular-post', 2, 2, 3 ),
+			'default-all-time-stats-widget-instance'       => array( 'jpa/all-time-stats', 2, 2, 4 ),
+			'default-most-popular-time-widget-instance'    => array( 'jpa/most-popular-time', 1, 2, 5 ),
+			'default-most-popular-day-widget-instance'     => array( 'jpa/most-popular-day', 1, 2, 6 ),
+			'default-most-commented-posts-widget-instance' => array( 'jpa/most-commented-posts', 1, 2, 7 ),
+			'default-most-commented-authors-widget-instance' => array( 'jpa/most-commented-authors', 1, 2, 8 ),
+			'default-shares-widget-instance'               => array( 'jpa/shares', 1, 2, 9 ),
+			'default-tags-widget-instance'                 => array( 'jpa/tags', 1, 2, 10 ),
 		);
 
 		$this->assertSame( array_keys( $expected ), array_column( $layout, 'uuid' ) );

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
@@ -281,49 +281,52 @@ class Dashboard_Layout_Test extends BaseTestCase {
 		$layout_by_uuid = array_column( $layout, null, 'uuid' );
 		$layout_types   = array_column( $layout, 'type' );
 
-		$this->assertContains( 'jpa/annual-highlights', $layout_types );
-		$this->assertContains( 'jpa/all-time-stats', $layout_types );
-		$this->assertContains( 'jpa/latest-post', $layout_types );
-		$this->assertContains( 'jpa/posting-activity', $layout_types );
+		// uuid => [ type, width, height, order ]; widths fill the four-column grid.
+		$expected = array(
+			'default-annual-highlights-widget-instance'    => array( 'jpa/annual-highlights', 2, 2, 0 ),
+			'default-posting-activity-widget-instance'     => array( 'jpa/posting-activity', 2, 2, 1 ),
+			'default-all-time-stats-widget-instance'       => array( 'jpa/all-time-stats', 4, 1, 2 ),
+			'default-latest-post-widget-instance'          => array( 'jpa/latest-post', 2, 2, 3 ),
+			'default-most-popular-time-widget-instance'    => array( 'jpa/most-popular-time', 1, 2, 4 ),
+			'default-most-popular-day-widget-instance'     => array( 'jpa/most-popular-day', 1, 2, 5 ),
+			'default-most-commented-posts-widget-instance' => array( 'jpa/most-commented-posts', 1, 2, 6 ),
+			'default-most-commented-authors-widget-instance' => array( 'jpa/most-commented-authors', 1, 2, 7 ),
+			'default-shares-widget-instance'               => array( 'jpa/shares', 1, 2, 8 ),
+			'default-tags-widget-instance'                 => array( 'jpa/tags', 1, 2, 9 ),
+		);
+
+		$this->assertSame( array_keys( $expected ), array_column( $layout, 'uuid' ) );
+
+		foreach ( $expected as $uuid => $instance ) {
+			list( $type, $width, $height, $order ) = $instance;
+
+			$this->assertSame( $type, $layout_by_uuid[ $uuid ]['type'], $uuid );
+			$this->assertSame(
+				array(
+					'width'  => $width,
+					'height' => $height,
+					'order'  => $order,
+				),
+				$layout_by_uuid[ $uuid ]['placement'],
+				$uuid
+			);
+		}
+
 		$this->assertNotContains( 'jpa/authors', $layout_types );
 		$this->assertNotContains( 'jpa/videopress', $layout_types );
 		// Emails is not an Insights module — it lives on the Subscribers tab.
 		$this->assertNotContains( 'jpa/stats-emails', $layout_types );
 		// The Comments module ships as two focused widgets, not one toggled widget.
-		$this->assertContains( 'jpa/most-commented-authors', $layout_types );
-		$this->assertContains( 'jpa/most-commented-posts', $layout_types );
 		$this->assertNotContains( 'jpa/comments', $layout_types );
-		$this->assertContains( 'jpa/shares', $layout_types );
+
+		// Highlights renders an empty prompt without an explicit metric list.
 		$this->assertSame(
 			array(
-				'uuid'       => 'default-most-commented-posts-widget-instance',
-				'type'       => 'jpa/most-commented-posts',
-				'attributes' => array(
-					'max' => 10,
-				),
-				'placement'  => array(
-					'width'  => 1,
-					'height' => 2,
-					'order'  => 7,
-				),
+				'metrics' => array( 'posts', 'words', 'likes', 'comments' ),
 			),
-			$layout_by_uuid['default-most-commented-posts-widget-instance']
+			$layout_by_uuid['default-annual-highlights-widget-instance']['attributes']
 		);
-		$this->assertSame(
-			array(
-				'uuid'       => 'default-shares-widget-instance',
-				'type'       => 'jpa/shares',
-				'attributes' => array(
-					'max' => 10,
-				),
-				'placement'  => array(
-					'width'  => 1,
-					'height' => 2,
-					'order'  => 9,
-				),
-			),
-			$layout_by_uuid['default-shares-widget-instance']
-		);
+
 		$this->assertSame(
 			get_dashboard_default_layout_for( DASHBOARD_INSIGHTS_SECTION_ID ),
 			get_dashboard_default_layout_for( 'analytics/insights' )


### PR DESCRIPTION
Part of WOOA7S-1786

## Proposed changes

Update the default Insights board to match the prototype's row order and sizing:

* Highlights and Posting activity are each full width.
* Latest post is paired with the newly added Popular post.
* Total views and Total visitors replace the temporary All-time stats widget and share a row with Most popular time and Most popular day.
* The four leaderboard widgets fill the final row.

`Highlights` now uses its built-in default metrics from #51052. The layout test also verifies the complete widget order and placement instead of two selected widgets.

Existing customized boards are unchanged; the new defaults apply only to untouched boards and resets.

### Known gaps, tracked elsewhere

* **WOOA7S-1846** — Most popular time and Most popular day can still crop at single-row height.
* **WOOA7S-1855** — The Traffic views activity is omitted because its widget does not exist yet.

## Related product discussion/links

* WOOA7S-1786

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Check out this branch and build `packages/premium-analytics`, or use a site already running it.
* As a user who has never customized the Insights tab, open **Stats v2 -> Insights**.
* The rows should be: Highlights full width, Posting activity full width, Latest post + Popular post, Total views / Total visitors / Most popular time / Most popular day, then Most commented posts / Most commented authors / Top social media shares / Top tags & categories. Every row fills the four-column grid.
* Highlights should show Posts, Words, Likes, and Comments without any saved attributes.
* All-time stats should no longer be on the board by default, but should still be available from the widget picker.
* If you have customized the tab before, use the tab's Reset action first — a stored layout takes precedence over the default.

Or

Compare layout with https://sweetly-steep.jurassic.ninja/wp-admin/admin.php?page=analytics-dashboard#insights


<img width="2442" height="1242" alt="Screenshot 2026-08-07 at 11 12 52 AM" src="https://github.com/user-attachments/assets/6cd4f1ad-ead5-4360-a57e-4f95099d1339" />
