### PR TITLE
Premium Analytics: drop Subscriber highlights from the Subscribers board defaults

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1786-default-subscribers-widgets
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1786-default-subscribers-widgets
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Subscribers: Drop Subscriber highlights from the default widgets so the board opens on the chart.

--- a/projects/packages/premium-analytics/src/dashboard-layout.php
+++ b/projects/packages/premium-analytics/src/dashboard-layout.php
@@ -395,33 +395,24 @@ function get_dashboard_default_section_layouts() {
 			),
 		),
 		DASHBOARD_SUBSCRIBERS_SECTION_ID => array(
-			get_dashboard_default_widget_instance(
-				'default-subscriber-highlights-widget-instance',
-				'jpa/subscriber-highlights',
-				0,
-				4,
-				1,
-				array(
-					'showTotal'  => true,
-					'showPaid'   => true,
-					'showFree'   => true,
-					'showSocial' => true,
-				)
-			),
+			// Subscriber highlights is intentionally not a default: the design
+			// opens on the chart. It stays available from the widget picker.
+			// Row 1: subscribers chart.
 			get_dashboard_default_widget_instance(
 				'default-subscribers-chart-widget-instance',
 				'jpa/subscribers-chart',
-				1,
+				0,
 				4,
 				2,
 				array(
 					'granularity' => 'auto',
 				)
 			),
+			// Row 2: latest subscribers + latest emails sent.
 			get_dashboard_default_widget_instance(
 				'default-subscribers-list-widget-instance',
 				'jpa/subscribers-list',
-				2,
+				1,
 				2,
 				2,
 				array(
@@ -431,7 +422,7 @@ function get_dashboard_default_section_layouts() {
 			get_dashboard_default_widget_instance(
 				'default-subscribers-emails-widget-instance',
 				'jpa/stats-emails',
-				3,
+				2,
 				2,
 				2,
 				array(

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
@@ -342,40 +342,39 @@ class Dashboard_Layout_Test extends BaseTestCase {
 		$layout_by_uuid = array_column( $layout, null, 'uuid' );
 		$layout_types   = array_column( $layout, 'type' );
 
-		$this->assertContains( 'jpa/subscriber-highlights', $layout_types );
-		$this->assertContains( 'jpa/subscribers-chart', $layout_types );
-		$this->assertContains( 'jpa/subscribers-list', $layout_types );
-		$this->assertContains( 'jpa/stats-emails', $layout_types );
-		$this->assertSame(
-			array(
-				'uuid'       => 'default-subscribers-list-widget-instance',
-				'type'       => 'jpa/subscribers-list',
-				'attributes' => array(
-					'max' => 6,
-				),
-				'placement'  => array(
-					'width'  => 2,
-					'height' => 2,
-					'order'  => 2,
-				),
-			),
-			$layout_by_uuid['default-subscribers-list-widget-instance']
+		// uuid => [ type, width, order ]; widths fill the four-column grid.
+		$expected = array(
+			'default-subscribers-chart-widget-instance'  => array( 'jpa/subscribers-chart', 4, 0 ),
+			'default-subscribers-list-widget-instance'   => array( 'jpa/subscribers-list', 2, 1 ),
+			'default-subscribers-emails-widget-instance' => array( 'jpa/stats-emails', 2, 2 ),
 		);
+
+		$this->assertSame( array_keys( $expected ), array_column( $layout, 'uuid' ) );
+
+		foreach ( $expected as $uuid => $instance ) {
+			list( $type, $width, $order ) = $instance;
+
+			$this->assertSame( $type, $layout_by_uuid[ $uuid ]['type'], $uuid );
+			$this->assertSame(
+				array(
+					'width'  => $width,
+					'height' => 2,
+					'order'  => $order,
+				),
+				$layout_by_uuid[ $uuid ]['placement'],
+				$uuid
+			);
+		}
+
+		// Subscriber highlights is intentionally not a default.
+		$this->assertNotContains( 'jpa/subscriber-highlights', $layout_types );
+
 		$this->assertSame(
 			array(
-				'uuid'       => 'default-subscribers-emails-widget-instance',
-				'type'       => 'jpa/stats-emails',
-				'attributes' => array(
-					'max'    => 10,
-					'metric' => 'opens',
-				),
-				'placement'  => array(
-					'width'  => 2,
-					'height' => 2,
-					'order'  => 3,
-				),
+				'max'    => 10,
+				'metric' => 'opens',
 			),
-			$layout_by_uuid['default-subscribers-emails-widget-instance']
+			$layout_by_uuid['default-subscribers-emails-widget-instance']['attributes']
 		);
 		$this->assertSame(
 			get_dashboard_default_layout_for( DASHBOARD_SUBSCRIBERS_SECTION_ID ),


### PR DESCRIPTION
Part of WOOA7S-1786

## Proposed changes

The Subscribers board already matched the design prototype apart from one extra row: the defaults open with a full-width Subscriber highlights strip (Total / Paid / Free / Social) that the prototype doesn't have. The prototype opens straight on the chart.

* Drop Subscriber highlights from the Subscribers defaults. It stays registered and can still be added from the widget picker.
* Pin the full Subscribers order and placements in `Dashboard_Layout_Test`, instead of two hand-picked widgets.

The remaining three widgets are unchanged, and every row still fills the four-column grid: Subscribers summary at full width, then Latest subscribers + Latest emails sent. Anyone who has already customized Subscribers keeps their stored layout; only untouched tabs and resets pick this up.

## Related product discussion/links

* WOOA7S-1786

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Check out this branch and build `packages/premium-analytics`, or use a site already running it.
* As a user who has never customized the Subscribers tab, open **Stats v2 -> Subscribers**.
* The board should start with Subscribers summary at full width, then Latest subscribers and Latest emails sent side by side. There should be no Subscriber highlights row.
* Open the widget picker and confirm Subscriber highlights is still there and can be added back.
* If you have customized the tab before, use the tab's Reset action first — a stored layout takes precedence over the default.

<img width="2401" height="1294" alt="Screenshot 2026-08-05 at 2 01 48 PM" src="https://github.com/user-attachments/assets/783a6de2-71da-483d-8c2c-a23cd5ac47c5" />
