### PR TITLE
Admin Bar: expose the command palette node

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-bar.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-bar.php
@@ -99,6 +99,13 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Bar extends WP_REST_Controller {
 		set_current_screen( 'dashboard' );
 
 		add_filter( 'show_admin_bar', '__return_true', 999 );
+
+		// Core only adds the command palette node when its assets are enqueued,
+		// which normally happens on admin_enqueue_scripts.
+		if ( function_exists( 'wp_enqueue_command_palette_assets' ) ) {
+			wp_enqueue_command_palette_assets();
+		}
+
 		_wp_admin_bar_init();
 
 		ob_start();

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-bar.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-admin-bar.php
@@ -33,7 +33,7 @@ class WPCOM_REST_API_V2_Endpoint_Admin_Bar extends WP_REST_Controller {
 	 *
 	 * @var string[]
 	 */
-	const ALLOWED_TOP_LEVEL_NODES = array( 'wp-logo', 'site-name', 'updates', 'comments', 'new-content', 'my-account' );
+	const ALLOWED_TOP_LEVEL_NODES = array( 'wp-logo', 'site-name', 'updates', 'command-palette', 'comments', 'new-content', 'my-account' );
 
 	/**
 	 * WPCOM_REST_API_V2_Endpoint_Admin_Bar constructor.

--- a/projects/plugins/jetpack/changelog/add-admin-bar-command-palette-node
+++ b/projects/plugins/jetpack/changelog/add-admin-bar-command-palette-node
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Admin Bar: Expose the command palette node through the admin bar endpoint.


### PR DESCRIPTION
## Proposed changes

* Allow the `command-palette` admin bar node through the `wpcom/v2/admin-bar` endpoint, so clients can see whether a site offers the command palette.
* Enqueue the command palette assets before the admin bar is built, so core actually registers that node.

WordPress core adds a top-level command palette button to the admin bar, but only on admin screens and only when the command palette script is enqueued. The endpoint filters the admin bar down to an allowlist, so the node was dropped — and the enqueue happens on `admin_enqueue_scripts`, a hook no REST request fires, so the node was never registered in the first place. Both had to change for it to reach a client.

Calypso's new omnibar needs it: without the node, the palette button there has to be hardcoded, which means guessing whether the site actually has a palette to open. With the node exposed, the omnibar can render the button only when the site really offers one, the same way it already handles Updates and Comments.

Two things a reviewer may want to know about the node's shape:

* Its title carries the keyboard shortcut markup (`⌘K` / `Ctrl+K`), which is what a client would parse for the label.
* Its `meta` carries an `onclick` handler and an inline script tag, passed through verbatim like every other node's meta. Clients should ignore both and open the palette themselves.

The command palette button is new in core and not in a released version yet, so on today's sites the response is unchanged. The enqueue call is guarded on the function existing.

```json
{
    "id": "command-palette",
    "title": "<span class=\"ab-icon\" aria-hidden=\"true\"><\/span><span class=\"ab-label\"><kbd>\u2318K<\/kbd><span class=\"screen-reader-text\"> Open command palette<\/span><\/span>",
    "parent": false,
    "href": "#",
    "group": false,
    "meta": {
        "class": "hide-if-no-js",
        "onclick": "wp.data.dispatch( \"core\/commands\" ).open(); return false;",
        "html": "<script>\n( \t( applePattern, appleOSLabel ) => {\n\t\tif ( ! ( new RegExp( applePattern, 'i' ) ).test( navigator.userAgent ) ) {\n\t\t\treturn;\n\t\t}\n\t\tconst kbd = document.querySelector( '#wp-admin-bar-command-palette .ab-label kbd' );\n\t\tif ( kbd ) {\n\t\t\tkbd.textContent = appleOSLabel;\n\t\t}\n\t} )( \"Macintosh|Mac OS X|Mac_PowerPC\", \"\\u2318K\" );\n\/\/# sourceURL=wp_admin_bar_command_palette_menu\n<\/script>\n"
    }
},
```

## Related product discussion/links

* https://github.com/Automattic/wp-calypso/pull/113256

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a site running a WordPress version that has the core command palette button, request `/wp-json/wpcom/v2/admin-bar/` as an admin.
* Confirm a node with the ID `command-palette` is present, alongside the existing `updates`, `comments`, `new-content` and `my-account` nodes, and that it carries the shortcut markup in its title.
* On an older WordPress, confirm the response is unchanged and nothing errors — neither the enqueue function nor the node exists there.

## Considerations

The endpoint calls the core enqueue function directly rather than firing `admin_enqueue_scripts`. Firing the hook would be the more faithful simulation of an admin screen, but it would also run every plugin's enqueue callbacks on a REST request for no benefit. The direct call is limited to what the node's condition actually checks; the enqueued assets are never rendered.
