### PR TITLE
Reprint export: guard Host::is_pressable() against older Status packages

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-reprint-export-is-pressable-guard
+++ b/projects/plugins/jetpack/changelog/fix-reprint-export-is-pressable-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Reprint export: Avoid a fatal error when another plugin loads an older version of the Status package.

--- a/projects/plugins/jetpack/src/reprint-export/class-reprint-exporter.php
+++ b/projects/plugins/jetpack/src/reprint-export/class-reprint-exporter.php
@@ -35,6 +35,7 @@
 
 namespace Automattic\Jetpack\Reprint_Export;
 
+use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Status\Host;
 
 /**
@@ -90,8 +91,16 @@ class Reprint_Exporter {
 	 * @return bool
 	 */
 	public static function is_available() {
-		$host      = new Host();
-		$available = $host->is_pressable() || $host->is_atomic_platform();
+		$host = new Host();
+
+		// Host::is_pressable() was added in jetpack-status 6.2.0. Another plugin on the
+		// site can ship an older copy of the package that wins autoloading, in which case
+		// calling the method is fatal, so fall back to the constant it reads.
+		$is_pressable = method_exists( $host, 'is_pressable' )
+			? $host->is_pressable()
+			: Constants::is_true( 'IS_PRESSABLE' );
+
+		$available = $is_pressable || $host->is_atomic_platform();
 
 		/**
 		 * Filters whether Jetpack Reprint export support is available on the


### PR DESCRIPTION
## Proposed changes
* Guard the `Host::is_pressable()` call in `Reprint_Exporter::is_available()` with `method_exists()`, falling back to `Constants::is_true( 'IS_PRESSABLE' )` — the exact expression the method itself returns.

`Host::is_pressable()` is new in `jetpack-status` 6.2.0. `Reprint_Exporter::is_available()` is called from `Jetpack::__construct()`, so on a site where another plugin bundles an older copy of the Status package and wins autoloading, Jetpack fatals during plugin load:

```
PHP Fatal error: Uncaught Error: Call to undefined method
Automattic\Jetpack\Status\Host::is_pressable() in .../class-reprint-exporter.php:94
```

This was hit while rolling out 16.1-beta. The site had a third-party plugin shipping an older Status package.

## Related product discussion/links
p1785846697318679-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
To reproduce the original fatal and confirm the fix:

1. On a test site, install Jetpack from this branch.
2. Simulate the conflict by making an older `Host` win autoloading — e.g. install a plugin that bundles a pre-6.2.0 `jetpack-status` (QuadLayers' Insta Gallery is one), or temporarily remove the `is_pressable()` method from the loaded `Automattic\Jetpack\Status\Host` class.
3. Load any front-end page. On `trunk` this fatals with `Call to undefined method ...Host::is_pressable()`; on this branch the page loads normally.
4. On a Pressable site (or with `define( 'IS_PRESSABLE', true );` in `wp-config.php`), confirm `Automattic\Jetpack\Reprint_Export\Reprint_Exporter::is_available()` still returns `true` and `?reprint-api-jetpack` is still registered.
5. On a plain self-hosted site with neither `IS_PRESSABLE` nor the Atomic constants, confirm it still returns `false`.

## Definition of done
- [ ] Jetpack no longer fatals at plugin load when an older `jetpack-status` copy wins autoloading.
- [ ] Reprint export availability is unchanged on Pressable, Atomic, and plain self-hosted sites.
- [ ] Existing `Reprint_Exporter_Test` cases pass.
- [ ] Cherry-picked onto `branch-16.1` so the beta rollout is unblocked.