### PR TITLE
Build: raise the timeout for full-monorepo builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,7 @@ jobs:
       CHANGED: ${{ fromJson( needs.prepare.outputs.build_matrix ).all.changed }}
       # Hard-code a specific directory to avoid paths in vendor/composer/installed.json changing every build.
       BUILD_BASE: /tmp/jetpack-build
-    timeout-minutes: 25  # 2026-04-07: Successful runs seem to take ~15 minutes.
+    timeout-minutes: 40  # 2026-08-04: PRs that rebuild every project take ~26 minutes.
 
     steps: &build_steps
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7


### PR DESCRIPTION
## Proposed changes

Raise `timeout-minutes` on the `build_all` job in `.github/workflows/build.yml` from 25 to 40. The comment next to it said successful runs take about 15 minutes; that was written in April and is no longer true.

Most PRs rebuild only what they touch and never get near the limit. A PR that modifies `pnpm-lock.yaml` or a root `package.json` marks every project as changed, so `build_all` rebuilds all 140 of them, and those runs now finish with seconds to spare, when they finish at all. Measured on #50509 on 2026-08-04:

| Run | Result | Duration | Margin to the 25 min cap |
| --- | --- | --- | --- |
| [30910793192](https://github.com/Automattic/jetpack/actions/runs/30910793192) | cancelled | 25m18s | hit the cap |
| [30919473627](https://github.com/Automattic/jetpack/actions/runs/30919473627) | success | 26m42s | ran under a temporary 40 min cap, would have been cancelled at 25 |
| [30923362248](https://github.com/Automattic/jetpack/actions/runs/30923362248) | success | 24m39s | 21s |
| [30927805943](https://github.com/Automattic/jetpack/actions/runs/30927805943) | success | 23m56s | 64s |

The last successful run spent 73 seconds on setup, 20m30s building and 2m03s creating the archive. The build itself has room; the archive is what pushes the job over the edge, and a 21 second margin is no margin at all: a slower runner or a slightly larger archive cancels the job.

A cancelled build costs more than a re-run. On a PR it also takes down the two TeamCity checks, which report "Build failed" seconds later, so one cause produces three red checks. On trunk it means `Push to mirror repos` never runs, so no mirror repo advances for that commit and everything that releases from the mirrors sits on the previous state until a later build succeeds.

`build_wpcom` and `build_nonwpcom` carry the same value and the same stale comment, but they run on smaller matrices and show no sign of pressure, so they stay as they are.

### Follow-up

The critical path is `premium-analytics`: 16m06s of the 20m30s build, with the next project at 11m53s. Its 76 widgets and 6 routes fan out into roughly 164 esbuild jobs with no global cap. WordPress/gutenberg#79889 adds that cap upstream and is awaiting review; once it ships, this timeout gets real headroom back. Until then the pressure grows rather than eases: Premium Analytics went from 51 to 76 widgets in a month, and the 2m15s that #50964 saved by routing shared libraries through one externals module was a one-off gain, not a change in slope.

## Related product discussion/links

* WordPress/gutenberg#79889

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Nothing to test on a site. Confirm the diff touches only the `build_all` timeout in `.github/workflows/build.yml`, and that CI here is green; this PR runs a partial build, so it never exercises the new value. The value earns its keep on any PR that rebuilds everything, such as a dependency bump touching `pnpm-lock.yaml`: under the old cap, anything above roughly 24 minutes gets cancelled.
