### PR TITLE
Premium Analytics: fix empty edit-mode dashboard after a detail-page entry

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-premium-analytics-dashboard-entity-guard
+++ b/projects/packages/premium-analytics/changelog/fix-premium-analytics-dashboard-entity-guard
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: Fix the dashboard opening as an empty edit-mode canvas when a post or video detail page was loaded first.

--- a/projects/packages/premium-analytics/routes/dashboard-entities.test.ts
+++ b/projects/packages/premium-analytics/routes/dashboard-entities.test.ts
@@ -1,0 +1,79 @@
+import { ensureDashboardEntities } from './dashboard-entities';
+
+const mockGetEntityConfig = jest.fn();
+const mockAddEntities = jest.fn();
+jest.mock( '@wordpress/data', () => ( {
+	select: () => ( { getEntityConfig: mockGetEntityConfig } ),
+	dispatch: () => ( { addEntities: mockAddEntities } ),
+} ) );
+
+jest.mock( '@wordpress/core-data', () => ( { store: {} } ) );
+
+/**
+ * The names registered by the single `addEntities` call, if any.
+ *
+ * @return The registered entity names.
+ */
+function registeredNames(): string[] {
+	return mockAddEntities.mock.calls.flatMap( ( [ entities ] ) =>
+		( entities as { name: string }[] ).map( entity => entity.name )
+	);
+}
+
+describe( 'ensureDashboardEntities', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
+	} );
+
+	it( 'registers every requested entity on a fresh store', () => {
+		mockGetEntityConfig.mockReturnValue( undefined );
+
+		ensureDashboardEntities( [ 'widgetModule', 'dashboardSection' ] );
+
+		expect( mockAddEntities ).toHaveBeenCalledTimes( 1 );
+		expect( registeredNames() ).toEqual( [ 'widgetModule', 'dashboardSection' ] );
+	} );
+
+	it( 'registers dashboardSection even when a detail route already registered widgetModule', () => {
+		// Regression: entering via a detail page registers only `widgetModule`;
+		// a later dashboard beforeLoad must still register `dashboardSection`
+		// instead of treating the store as fully seeded.
+		mockGetEntityConfig.mockImplementation( ( _kind: string, name: string ) =>
+			name === 'widgetModule' ? {} : undefined
+		);
+
+		ensureDashboardEntities( [ 'widgetModule', 'dashboardSection' ] );
+
+		expect( registeredNames() ).toEqual( [ 'dashboardSection' ] );
+	} );
+
+	it( 'does nothing when every requested entity is registered', () => {
+		mockGetEntityConfig.mockReturnValue( {} );
+
+		ensureDashboardEntities( [ 'widgetModule' ] );
+
+		expect( mockAddEntities ).not.toHaveBeenCalled();
+	} );
+
+	it( 'builds the entity configs the stage hooks expect', () => {
+		mockGetEntityConfig.mockReturnValue( undefined );
+
+		ensureDashboardEntities( [ 'widgetModule', 'dashboardSection' ] );
+
+		const [ widgetModule, dashboardSection ] = mockAddEntities.mock.calls[ 0 ][ 0 ];
+		expect( widgetModule ).toMatchObject( {
+			kind: 'root',
+			key: 'name',
+			baseURL: '/wpcom/v2/widget-modules',
+			plural: 'widgetModules',
+			supportsPagination: false,
+		} );
+		expect( dashboardSection ).toMatchObject( {
+			kind: 'root',
+			key: 'slug',
+			baseURL: '/wpcom/v2/dashboards/jetpack-premium-analytics_dashboard/sections',
+			plural: 'dashboardSections',
+			supportsPagination: false,
+		} );
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/dashboard-entities.test.ts
+++ b/projects/packages/premium-analytics/routes/dashboard-entities.test.ts
@@ -25,32 +25,31 @@ describe( 'ensureDashboardEntities', () => {
 		jest.clearAllMocks();
 	} );
 
-	it( 'registers every requested entity on a fresh store', () => {
+	it( 'registers the complete entity set on a fresh store', () => {
 		mockGetEntityConfig.mockReturnValue( undefined );
 
-		ensureDashboardEntities( [ 'widgetModule', 'dashboardSection' ] );
+		ensureDashboardEntities();
 
 		expect( mockAddEntities ).toHaveBeenCalledTimes( 1 );
 		expect( registeredNames() ).toEqual( [ 'widgetModule', 'dashboardSection' ] );
 	} );
 
-	it( 'registers dashboardSection even when a detail route already registered widgetModule', () => {
-		// Regression: entering via a detail page registers only `widgetModule`;
-		// a later dashboard beforeLoad must still register `dashboardSection`
-		// instead of treating the store as fully seeded.
+	it( 'registers dashboardSection even when widgetModule is already registered', () => {
+		// Regression: an older detail-route guard registered only `widgetModule`,
+		// and the dashboard treated its presence as "the store is fully seeded".
 		mockGetEntityConfig.mockImplementation( ( _kind: string, name: string ) =>
 			name === 'widgetModule' ? {} : undefined
 		);
 
-		ensureDashboardEntities( [ 'widgetModule', 'dashboardSection' ] );
+		ensureDashboardEntities();
 
 		expect( registeredNames() ).toEqual( [ 'dashboardSection' ] );
 	} );
 
-	it( 'does nothing when every requested entity is registered', () => {
+	it( 'does nothing when every entity is registered', () => {
 		mockGetEntityConfig.mockReturnValue( {} );
 
-		ensureDashboardEntities( [ 'widgetModule' ] );
+		ensureDashboardEntities();
 
 		expect( mockAddEntities ).not.toHaveBeenCalled();
 	} );
@@ -58,7 +57,7 @@ describe( 'ensureDashboardEntities', () => {
 	it( 'builds the entity configs the stage hooks expect', () => {
 		mockGetEntityConfig.mockReturnValue( undefined );
 
-		ensureDashboardEntities( [ 'widgetModule', 'dashboardSection' ] );
+		ensureDashboardEntities();
 
 		const [ widgetModule, dashboardSection ] = mockAddEntities.mock.calls[ 0 ][ 0 ];
 		expect( widgetModule ).toMatchObject( {

--- a/projects/packages/premium-analytics/routes/dashboard-entities.ts
+++ b/projects/packages/premium-analytics/routes/dashboard-entities.ts
@@ -12,7 +12,9 @@ import { DASHBOARD_NAME, DASHBOARD_REST_NAMESPACE } from './dashboard/hooks/cons
 /**
  * The core-data entities the analytics routes read dashboard metadata from.
  */
-export type DashboardEntityName = 'widgetModule' | 'dashboardSection';
+const DASHBOARD_ENTITY_NAMES = [ 'widgetModule', 'dashboardSection' ] as const;
+
+type DashboardEntityName = ( typeof DASHBOARD_ENTITY_NAMES )[ number ];
 
 /**
  * Build the core-data configuration for one dashboard entity.
@@ -48,24 +50,25 @@ function buildEntityConfig( name: DashboardEntityName ): object {
 }
 
 /**
- * Register the given dashboard core-data entities, skipping any already
- * registered.
+ * Register the dashboard core-data entities, skipping any already registered.
  *
  * Routes call this from `beforeLoad`, which re-runs on every navigation and
- * preload, so each entity is guarded individually. The guard must stay
- * per-entity: the detail routes register only `widgetModule`, so a dashboard
- * `beforeLoad` that treats "widgetModule exists" as "everything exists" never
- * registers `dashboardSection` when a detail page loaded first, and the
- * dashboard then resolves zero sections and force-opens an empty edit-mode
- * canvas.
- *
- * @param names - The entities the calling route needs.
+ * preload, so each entity is guarded individually. The helper owns the
+ * complete entity set on purpose: registration is config-only (no request is
+ * made until something reads the entity), so registering an entity a route
+ * never reads costs nothing, while letting callers pick a subset restores the
+ * route-level invariant that caused the original regression — a detail route
+ * registering `widgetModule` alone made the dashboard's guard treat the store
+ * as fully seeded, `dashboardSection` was never registered, and the dashboard
+ * resolved zero sections and force-opened an empty edit-mode canvas.
  */
-export function ensureDashboardEntities( names: readonly DashboardEntityName[] ): void {
+export function ensureDashboardEntities(): void {
 	const coreSelect = select( coreStore ) as unknown as {
 		getEntityConfig: ( kind: string, name: string ) => unknown;
 	};
-	const missing = names.filter( name => ! coreSelect.getEntityConfig( 'root', name ) );
+	const missing = DASHBOARD_ENTITY_NAMES.filter(
+		name => ! coreSelect.getEntityConfig( 'root', name )
+	);
 	if ( missing.length === 0 ) {
 		return;
 	}

--- a/projects/packages/premium-analytics/routes/dashboard-entities.ts
+++ b/projects/packages/premium-analytics/routes/dashboard-entities.ts
@@ -1,0 +1,77 @@
+/**
+ * External dependencies
+ */
+import { store as coreStore } from '@wordpress/core-data';
+import { dispatch, select } from '@wordpress/data';
+import { __ } from '@wordpress/i18n';
+/**
+ * Internal dependencies
+ */
+import { DASHBOARD_NAME, DASHBOARD_REST_NAMESPACE } from './dashboard/hooks/constants';
+
+/**
+ * The core-data entities the analytics routes read dashboard metadata from.
+ */
+export type DashboardEntityName = 'widgetModule' | 'dashboardSection';
+
+/**
+ * Build the core-data configuration for one dashboard entity.
+ *
+ * Built at call time (not module scope) so `__()` reads translations after
+ * the locale data has loaded.
+ *
+ * @param name - The entity to configure.
+ * @return The entity configuration for `addEntities`.
+ */
+function buildEntityConfig( name: DashboardEntityName ): object {
+	if ( name === 'widgetModule' ) {
+		return {
+			name: 'widgetModule',
+			kind: 'root',
+			key: 'name',
+			baseURL: `/${ DASHBOARD_REST_NAMESPACE }/widget-modules`,
+			plural: 'widgetModules',
+			label: __( 'Widget modules', 'jetpack-premium-analytics-pkg' ),
+			supportsPagination: false,
+		};
+	}
+
+	return {
+		name: 'dashboardSection',
+		kind: 'root',
+		key: 'slug',
+		baseURL: `/${ DASHBOARD_REST_NAMESPACE }/dashboards/${ DASHBOARD_NAME }/sections`,
+		plural: 'dashboardSections',
+		label: __( 'Dashboard sections', 'jetpack-premium-analytics-pkg' ),
+		supportsPagination: false,
+	};
+}
+
+/**
+ * Register the given dashboard core-data entities, skipping any already
+ * registered.
+ *
+ * Routes call this from `beforeLoad`, which re-runs on every navigation and
+ * preload, so each entity is guarded individually. The guard must stay
+ * per-entity: the detail routes register only `widgetModule`, so a dashboard
+ * `beforeLoad` that treats "widgetModule exists" as "everything exists" never
+ * registers `dashboardSection` when a detail page loaded first, and the
+ * dashboard then resolves zero sections and force-opens an empty edit-mode
+ * canvas.
+ *
+ * @param names - The entities the calling route needs.
+ */
+export function ensureDashboardEntities( names: readonly DashboardEntityName[] ): void {
+	const coreSelect = select( coreStore ) as unknown as {
+		getEntityConfig: ( kind: string, name: string ) => unknown;
+	};
+	const missing = names.filter( name => ! coreSelect.getEntityConfig( 'root', name ) );
+	if ( missing.length === 0 ) {
+		return;
+	}
+
+	const coreDispatch = dispatch( coreStore ) as unknown as {
+		addEntities: ( entities: object[] ) => void;
+	};
+	coreDispatch.addEntities( missing.map( buildEntityConfig ) );
+}

--- a/projects/packages/premium-analytics/routes/dashboard/route.test.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/route.test.ts
@@ -1,0 +1,110 @@
+import { needsReportDateParamsSeed } from '@jetpack-premium-analytics/data';
+import {
+	isPremiumAnalyticsInitialSyncFinished,
+	isPremiumAnalyticsSiteConnected,
+} from '../site-readiness';
+import { route } from './route';
+
+jest.mock( '@jetpack-premium-analytics/data', () => ( {
+	ensureCoreSettingsReady: jest.fn( () => Promise.resolve() ),
+	needsReportDateParamsSeed: jest.fn( () => false ),
+	normalizeReportParams: jest.fn( ( search: Record< string, string | undefined > ) => ( {
+		from: '2026-06-01T00:00:00',
+		to: '2026-06-16T23:59:59',
+		...search,
+	} ) ),
+} ) );
+
+jest.mock( '../site-readiness', () => ( {
+	isPremiumAnalyticsSiteConnected: jest.fn( () => true ),
+	isPremiumAnalyticsInitialSyncFinished: jest.fn( () => true ),
+} ) );
+
+jest.mock( '@wordpress/route', () => ( {
+	redirect: jest.fn( ( options: object ) => ( { isRedirect: true, ...options } ) ),
+} ) );
+
+const mockGetEntityConfig = jest.fn();
+const mockAddEntities = jest.fn();
+jest.mock( '@wordpress/data', () => ( {
+	select: () => ( { getEntityConfig: mockGetEntityConfig } ),
+	dispatch: () => ( { addEntities: mockAddEntities } ),
+} ) );
+
+jest.mock( '@wordpress/core-data', () => ( { store: {} } ) );
+
+// A search that needs no seeding: the seed check is mocked false.
+const settledSearch = {
+	from: '2026-06-01T00:00:00',
+	to: '2026-06-16T23:59:59',
+	interval: 'day',
+};
+
+const beforeLoad = ( search?: object ) =>
+	route.beforeLoad( { search } as Parameters< typeof route.beforeLoad >[ 0 ] );
+
+/**
+ * The names registered across all `addEntities` calls.
+ *
+ * @return The registered entity names.
+ */
+function registeredNames(): string[] {
+	return mockAddEntities.mock.calls.flatMap( ( [ entities ] ) =>
+		( entities as { name: string }[] ).map( entity => entity.name )
+	);
+}
+
+describe( 'dashboard route.beforeLoad', () => {
+	afterEach( () => {
+		jest.clearAllMocks();
+		mockGetEntityConfig.mockReset();
+	} );
+
+	it( 'redirects to /connect when the site is not connected', async () => {
+		( isPremiumAnalyticsSiteConnected as jest.Mock ).mockReturnValueOnce( false );
+
+		await expect( beforeLoad( settledSearch ) ).rejects.toMatchObject( { to: '/connect' } );
+	} );
+
+	it( 'redirects to /syncing before the initial sync finishes', async () => {
+		( isPremiumAnalyticsInitialSyncFinished as jest.Mock ).mockReturnValueOnce( false );
+
+		await expect( beforeLoad( settledSearch ) ).rejects.toMatchObject( { to: '/syncing' } );
+	} );
+
+	it( 're-seeds the date params when they are missing', async () => {
+		( needsReportDateParamsSeed as jest.Mock ).mockReturnValueOnce( true );
+
+		await expect( beforeLoad( {} ) ).rejects.toMatchObject( { to: '/', replace: true } );
+	} );
+
+	it( 'registers both dashboard entities on a fresh store', async () => {
+		mockGetEntityConfig.mockReturnValue( undefined );
+
+		await beforeLoad( settledSearch );
+
+		expect( registeredNames() ).toEqual( [ 'widgetModule', 'dashboardSection' ] );
+	} );
+
+	it( 'registers dashboardSection even when a detail-page entry already registered widgetModule', async () => {
+		// Regression for the empty edit-mode dashboard: reloading on a detail
+		// page registered `widgetModule` alone, and the dashboard's old guard
+		// then skipped `dashboardSection` entirely, so the stage resolved zero
+		// sections and force-opened an empty edit-mode canvas.
+		mockGetEntityConfig.mockImplementation( ( _kind: string, name: string ) =>
+			name === 'widgetModule' ? {} : undefined
+		);
+
+		await beforeLoad( settledSearch );
+
+		expect( registeredNames() ).toEqual( [ 'dashboardSection' ] );
+	} );
+
+	it( 'does not re-register entities that already exist', async () => {
+		mockGetEntityConfig.mockReturnValue( {} );
+
+		await beforeLoad( settledSearch );
+
+		expect( mockAddEntities ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/packages/premium-analytics/routes/dashboard/route.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/route.ts
@@ -106,6 +106,6 @@ export const route = {
 			} );
 		}
 
-		ensureDashboardEntities( [ 'widgetModule', 'dashboardSection' ] );
+		ensureDashboardEntities();
 	},
 };

--- a/projects/packages/premium-analytics/routes/dashboard/route.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/route.ts
@@ -6,18 +6,15 @@ import {
 	needsReportDateParamsSeed,
 	normalizeReportParams,
 } from '@jetpack-premium-analytics/data';
-import { store as coreStore } from '@wordpress/core-data';
-import { dispatch, select } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
 import { redirect } from '@wordpress/route';
 /**
  * Internal dependencies
  */
+import { ensureDashboardEntities } from '../dashboard-entities';
 import {
 	isPremiumAnalyticsInitialSyncFinished,
 	isPremiumAnalyticsSiteConnected,
 } from '../site-readiness';
-import { DASHBOARD_NAME, DASHBOARD_REST_NAMESPACE } from './hooks/constants';
 
 type DashboardSearch = Record< string, string | undefined >;
 
@@ -44,7 +41,10 @@ type DashboardSearch = Record< string, string | undefined >;
  * (see `src/widget-modules.php`), independent of core's `wp/v2` endpoint.
  * The route is registered under `wpcom/v2` so WPCOM can expose it through the
  * site-scoped public-api path for Simple sites.
- * Guarded for idempotency: beforeLoad re-runs on every navigation and preload.
+ * Registration is idempotent per entity (see `ensureDashboardEntities`):
+ * beforeLoad re-runs on every navigation and preload, and a detail route may
+ * already have registered `widgetModule` alone before the user reaches the
+ * dashboard.
  *
  * That registration is one-time bootstrap setup that could move to the page's
  * `init` module (`packages/init`) now that `@wordpress/build` supports it —
@@ -106,35 +106,6 @@ export const route = {
 			} );
 		}
 
-		const coreSelect = select( coreStore ) as unknown as {
-			getEntityConfig: ( kind: string, name: string ) => unknown;
-		};
-		if ( coreSelect.getEntityConfig( 'root', 'widgetModule' ) ) {
-			return;
-		}
-
-		const coreDispatch = dispatch( coreStore ) as unknown as {
-			addEntities: ( entities: object[] ) => void;
-		};
-		coreDispatch.addEntities( [
-			{
-				name: 'widgetModule',
-				kind: 'root',
-				key: 'name',
-				baseURL: `/${ DASHBOARD_REST_NAMESPACE }/widget-modules`,
-				plural: 'widgetModules',
-				label: __( 'Widget modules', 'jetpack-premium-analytics-pkg' ),
-				supportsPagination: false,
-			},
-			{
-				name: 'dashboardSection',
-				kind: 'root',
-				key: 'slug',
-				baseURL: `/${ DASHBOARD_REST_NAMESPACE }/dashboards/${ DASHBOARD_NAME }/sections`,
-				plural: 'dashboardSections',
-				label: __( 'Dashboard sections', 'jetpack-premium-analytics-pkg' ),
-				supportsPagination: false,
-			},
-		] );
+		ensureDashboardEntities( [ 'widgetModule', 'dashboardSection' ] );
 	},
 };

--- a/projects/packages/premium-analytics/routes/post-detail/route.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/route.ts
@@ -114,6 +114,6 @@ export const route = {
 			} );
 		}
 
-		ensureDashboardEntities( [ 'widgetModule' ] );
+		ensureDashboardEntities();
 	},
 };

--- a/projects/packages/premium-analytics/routes/post-detail/route.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/route.ts
@@ -6,14 +6,11 @@ import {
 	needsReportDateParamsSeed,
 	normalizeReportParams,
 } from '@jetpack-premium-analytics/data';
-import { store as coreStore } from '@wordpress/core-data';
-import { dispatch, select } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
 import { redirect } from '@wordpress/route';
 /**
  * Internal dependencies
  */
-import { DASHBOARD_REST_NAMESPACE } from '../dashboard/hooks/constants';
+import { ensureDashboardEntities } from '../dashboard-entities';
 import {
 	isPremiumAnalyticsInitialSyncFinished,
 	isPremiumAnalyticsSiteConnected,
@@ -117,26 +114,6 @@ export const route = {
 			} );
 		}
 
-		const coreSelect = select( coreStore ) as unknown as {
-			getEntityConfig: ( kind: string, name: string ) => unknown;
-		};
-		if ( coreSelect.getEntityConfig( 'root', 'widgetModule' ) ) {
-			return;
-		}
-
-		const coreDispatch = dispatch( coreStore ) as unknown as {
-			addEntities: ( entities: object[] ) => void;
-		};
-		coreDispatch.addEntities( [
-			{
-				name: 'widgetModule',
-				kind: 'root',
-				key: 'name',
-				baseURL: `/${ DASHBOARD_REST_NAMESPACE }/widget-modules`,
-				plural: 'widgetModules',
-				label: __( 'Widget modules', 'jetpack-premium-analytics-pkg' ),
-				supportsPagination: false,
-			},
-		] );
+		ensureDashboardEntities( [ 'widgetModule' ] );
 	},
 };

--- a/projects/packages/premium-analytics/routes/video-detail/route.ts
+++ b/projects/packages/premium-analytics/routes/video-detail/route.ts
@@ -90,6 +90,6 @@ export const route = {
 			} );
 		}
 
-		ensureDashboardEntities( [ 'widgetModule' ] );
+		ensureDashboardEntities();
 	},
 };

--- a/projects/packages/premium-analytics/routes/video-detail/route.ts
+++ b/projects/packages/premium-analytics/routes/video-detail/route.ts
@@ -6,14 +6,11 @@ import {
 	needsReportDateParamsSeed,
 	normalizeReportParams,
 } from '@jetpack-premium-analytics/data';
-import { store as coreStore } from '@wordpress/core-data';
-import { dispatch, select } from '@wordpress/data';
-import { __ } from '@wordpress/i18n';
 import { redirect } from '@wordpress/route';
 /**
  * Internal dependencies
  */
-import { DASHBOARD_REST_NAMESPACE } from '../dashboard/hooks/constants';
+import { ensureDashboardEntities } from '../dashboard-entities';
 import {
 	isPremiumAnalyticsInitialSyncFinished,
 	isPremiumAnalyticsSiteConnected,
@@ -93,26 +90,6 @@ export const route = {
 			} );
 		}
 
-		const coreSelect = select( coreStore ) as unknown as {
-			getEntityConfig: ( kind: string, name: string ) => unknown;
-		};
-		if ( coreSelect.getEntityConfig( 'root', 'widgetModule' ) ) {
-			return;
-		}
-
-		const coreDispatch = dispatch( coreStore ) as unknown as {
-			addEntities: ( entities: object[] ) => void;
-		};
-		coreDispatch.addEntities( [
-			{
-				name: 'widgetModule',
-				kind: 'root',
-				key: 'name',
-				baseURL: `/${ DASHBOARD_REST_NAMESPACE }/widget-modules`,
-				plural: 'widgetModules',
-				label: __( 'Widget modules', 'jetpack-premium-analytics-pkg' ),
-				supportsPagination: false,
-			},
-		] );
+		ensureDashboardEntities( [ 'widgetModule' ] );
 	},
 };


### PR DESCRIPTION
## Proposed changes

Premium Analytics: fix the dashboard opening as an empty edit-mode canvas when a post or video detail page was loaded first.

**Root cause.** Entering the SPA on a detail page (reload on `/post/$postId` or `/video/$videoId`) runs only that route's `beforeLoad`, which registers just the `widgetModule` core-data entity. The dashboard route's `beforeLoad` used "`widgetModule` config exists" as its idempotency guard for registering *both* `widgetModule` and `dashboardSection` — so when the user then navigates to the dashboard (e.g. via the breadcrumb), the guard short-circuits and `dashboardSection` is never registered. `useDashboardSections()` resolves zero sections, the layout stays empty, and `WidgetDashboard` treats an empty layout as "no widgets" and force-opens edit mode over a blank canvas (see the comment in `routes/dashboard/stage.tsx`).

**Fix.** Extract a shared `ensureDashboardEntities()` helper (`routes/dashboard-entities.ts`) that guards each entity individually and registers only the missing ones, and adopt it in the dashboard, post-detail, and video-detail routes. Unit tests cover the regression path (detail route registered `widgetModule` first → dashboard still registers `dashboardSection`).

## Related product discussion/links

* Found while testing #50970 (the video detail composition PR); the bug predates it — the same round trip through the existing post detail page reproduces it on trunk.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Build the package and open the Premium Analytics dashboard to confirm the normal state (sections and widgets render).
2. Navigate to a post detail page (or video detail page), then **reload the browser** on that page — this makes the detail route the SPA's entry point.
3. Click the breadcrumb back to the dashboard.
   * **Before:** the dashboard renders an empty canvas in edit mode ("Add widget / Cancel / Done") with no section tabs and no widgets, and no console errors.
   * **After:** the dashboard renders its sections and widgets normally.
4. `pnpm run test` in `projects/packages/premium-analytics` — the new `routes/dashboard-entities.test.ts` covers the regression.

### Recording

#### Before
https://github.com/user-attachments/assets/bf9970a4-3462-45a8-b161-82399f4a86b1

#### After
https://github.com/user-attachments/assets/755370cd-bf8e-4d86-9355-8678fe1fedf7

🤖 Generated with [Claude Code](https://claude.com/claude-code)
