### PR TITLE
JN skill: document WP-CLI access and two beta-testing gotchas

### DIFF
--- a/.agents/skills/jetpack-test-jurassic-ninja.md
+++ b/.agents/skills/jetpack-test-jurassic-ninja.md
@@ -1,13 +1,11 @@
 ---
 name: jetpack-test-jurassic-ninja
 description: >
-  Rsync a Jetpack monorepo plugin to a Jurassic Ninja test site for live testing.
-  Creates a new JN site on demand when the user has none or asks for a fresh one.
-  Use when the user wants to push/deploy/sync/test code on a Jurassic Ninja site,
-  mentions "jurassic ninja", "JN site", "test live", "rsync to JN", "create a JN site",
-  "spin up a new JN site", or says "/jetpack-test-jurassic-ninja". Handles site
-  discovery, provisioning, Jetpack connection, password retrieval, and the jetpack
-  rsync command automatically with no user interaction needed.
+  Work with a Jurassic Ninja test site: rsync a monorepo plugin to one, spin up a fresh
+  site, or run WP-CLI on one. Use when the user mentions "jurassic ninja" or "JN site",
+  wants to push/deploy/sync/test code live, asks for a new site, or needs to know what a
+  site is actually running — which plugin or package version loaded, options, logs, or
+  reproducing a conflict there.
 ---
 
 # Jetpack Test on Jurassic Ninja
@@ -15,7 +13,8 @@ description: >
 Push a plugin from the Jetpack monorepo to a Jurassic Ninja ephemeral site. Fully
 automated — no user interaction required after pre-flight checks pass. Can also
 provision a brand-new JN site and connect Jetpack to it when the user asks for a
-fresh environment or has no existing sites.
+fresh environment or has no existing sites, and run WP-CLI on a site to inspect or
+change what it's actually running.
 
 ## Step 0: Classify the request (do this first)
 
@@ -25,7 +24,7 @@ Decide up front which shape the task is — it controls which checks and credent
 - **`provision-only`** — the user only wants a site created/connected/inspected (phrases like "create a new JN site", "spin up a JN site", "connect Jetpack on a new site", "give me a fresh JN site to test in the browser"). No rsync, no SFTP, no password needed.
 - **`mixed`** — default when ambiguous, or when the user says things like "spin up a new site and push my branch to it". Treat as `rsync` because SFTP is required.
 
-The flow below is gated on this classification: checks that exist only to support rsync are skipped for `provision-only`. **Never fetch or display site passwords** unless the flow is `rsync` *and* SSH key auth has failed.
+The flow below is gated on this classification: checks that exist only to support rsync are skipped for `provision-only`. **Never fetch or display site passwords** unless the flow needs shell or SFTP access *and* SSH key auth has failed.
 
 ## Pre-flight Checks
 
@@ -70,7 +69,7 @@ If it fails, tell the user:
 
 ### Check 5: Pick or create a Jurassic Ninja site
 
-Call `list-sites` **without** `include_passwords` unless the flow is `rsync` and you already know SSH key auth is unavailable. Omitting it keeps credentials out of the agent transcript for flows that never need them.
+Call `list-sites` **without** `include_passwords` unless the flow needs shell or SFTP and you already know SSH key auth is unavailable. Omitting it keeps credentials out of the agent transcript for flows that never need them.
 
 ```
 execute-tool: jurassic-ninja / list-sites (include_config: false)
@@ -110,9 +109,9 @@ execute-tool: jurassic-ninja / connect-jetpack (domain: <site domain>)
 
 This remotely links the site to Jetpack using the creator's WP.com account. Idempotent — returns `already_connected` when already linked and `connected` on first success. Skip if the user explicitly said "don't connect Jetpack".
 
-### Check 6: SSH access to Jurassic Ninja *(rsync only)*
+### Check 6: SSH access to Jurassic Ninja *(when using rsync or WP-CLI)*
 
-Skip this entire check for `provision-only` flows — we aren't using SFTP.
+Skip this entire check when neither SFTP nor shell is needed.
 
 Test whether the user has SSH key-based access configured for the JN SFTP host:
 
@@ -126,16 +125,30 @@ Where `{domain}` is the domain of the target site (e.g. `foo.jurassic.ninja`).
 
 **If the command fails:** SSH key auth isn't configured. Tell the user:
 
-> SSH key authentication to `ssh.atomicsites.net` is not configured. If you are an Automattician, you can fix this by adding the following to your `~/.ssh/config`:
+> SSH key authentication to `ssh.atomicsites.net` is not configured. If you are an Automattician, you can fix this by adding the following near the **top** of your `~/.ssh/config`, above any broad `Host *` stanza (SSH is first-match-wins, so a general block earlier in the file can shadow these settings):
 >
 > ```
-> Host ssh.atomicsites.net
->     HostName ssh.atomicsites.net
+> Host ssh.atomicsites.net sftp.wp.com
 >     Include ~/.ssh/a8c-key.config
 >     ProxyJump proxy.automattic.com
 > ```
 >
+> This is a one-time setup that covers every JN site you create from now on — the key
+> authenticates you to a shared gateway, not to any individual site, so it keeps working
+> as sites come and go.
+>
 > For now, I'll use the site password instead.
+
+Both hostnames are listed because JN's `ssh_command` hands out `sftp.wp.com` while the rsync
+step uses `ssh.atomicsites.net` — same gateway, two names. No `HostName` line is needed; it
+defaults to whichever name was used. Verify with:
+
+```bash
+ssh -o BatchMode=yes {domain}@ssh.atomicsites.net "cd /srv/htdocs && wp option get blogname"
+```
+
+`BatchMode=yes` makes it fail rather than silently fall back to a password prompt, so the
+result is an unambiguous yes/no on key auth.
 
 Then set `SSH_OK=false` and **only now** fetch the site password:
 
@@ -143,7 +156,79 @@ Then set `SSH_OK=false` and **only now** fetch the site password:
 execute-tool: jurassic-ninja / list-sites (domain: <site domain>, include_passwords: true)
 ```
 
-Pull the SFTP password out of the returned config and use it for the rsync step only. Don't print it back to the user.
+Pull the SFTP password out of the returned config and use it for the rsync or shell step. Don't print it back to the user.
+
+## Running commands on the site
+
+To inspect or change site state — which package version actually loaded, options, logs,
+toggling plugins — run WP-CLI over SSH.
+
+**If key auth works**, just run it directly:
+
+```bash
+ssh {domain}@ssh.atomicsites.net "cd /srv/htdocs && wp plugin list"
+```
+
+**If key auth is unavailable**, drive the password prompt with `expect` (the
+`context-a8c:jurassic-ninja-ssh` skill covers this too). Use the non-interactive form —
+passing the command as an argument to `ssh` — rather than sending keystrokes into a login
+shell, because a pty echoes and can mangle long input:
+
+```bash
+expect -c '
+set timeout 120
+log_user 0
+spawn ssh -o StrictHostKeyChecking=no -o PubkeyAuthentication=no -T {domain}@sftp.wp.com {cd /srv/htdocs && wp plugin list}
+expect { -re "assword:" { send "<JN_PASSWORD>\r"; log_user 1 } timeout { puts "TIMEOUT"; exit 1 } }
+expect eof
+'
+```
+
+Notes that save time:
+
+- The shell lands in the home directory. `wp` itself resolves the install from anywhere, but
+  **relative paths do not** — `cd /srv/htdocs` first whenever a command names a file
+  (`wp-content/plugins/...`), or use absolute paths.
+- Both `ssh.atomicsites.net` and `sftp.wp.com` work as hosts.
+- To run a non-trivial PHP snippet, base64-encode it locally, decode it remotely to a temp file,
+  and run `wp eval-file`. This sidesteps every layer of shell/expect quoting.
+- `python3` is not installed on JN hosts. Use `php` for scripted file edits.
+- Prefer a temporary mu-plugin under `wp-content/mu-plugins/` over editing plugin or theme
+  files when you need code to run early in the request. Gate it behind an env var or query
+  param so normal traffic and wp-admin stay unaffected, and delete it when finished.
+- Back up any file you patch (`cp $F $F.bak`), and verify the restore afterwards. When
+  grepping for a pattern containing `$`, quote it so the remote shell doesn't expand it —
+  an unquoted `$host` silently becomes an empty string and a real match reports as zero.
+- Page caching is on. Add a cache-busting query param when verifying that a change took effect.
+
+## Gotchas when testing a Jetpack beta or branch build
+
+**JN can leave two Jetpack plugins active at once.** Provisioning installs `jetpack-production`
+(trunk), and the Jetpack Beta plugin adds a second copy in `jetpack-dev`. Both end up in
+`active_plugins`. Because the Jetpack Autoloader resolves each package to the **highest
+version** across all active plugins, trunk's packages can win and you end up testing trunk code
+while believing you're testing the beta.
+
+Always confirm what is actually active before trusting a result:
+
+```bash
+wp plugin list --fields=name,status,version
+```
+
+If both are active, deactivate the one you are not testing (`wp plugin deactivate
+jetpack-production`) and re-verify. To confirm which copy of a class is really loaded:
+
+```bash
+wp eval 'echo (new ReflectionClass("Automattic\\Jetpack\\Status\\Host"))->getFileName();'
+```
+
+**Autoloader conflicts need forcing to reproduce.** Some third-party plugins bundle older
+Jetpack packages with a plain Composer classmap and no Jetpack Autoloader. Merely activating
+such a plugin usually does *not* reproduce a version conflict, because Jetpack's autoloader
+registers with `prepend=true` and wins the lookup — so "installed it, nothing broke" is a
+vacuous pass. To reproduce, force the older class to load before Jetpack boots (a gated
+mu-plugin that `require_once`s the other plugin's copy). Then confirm the test is sensitive by
+temporarily removing the guard under test and checking that it does fatal.
 
 ## Workflow
 
@@ -151,6 +236,7 @@ Pull the SFTP password out of the returned config and use it for the rsync step 
 
 `rsync` flow: default to `jetpack`; use a different plugin only if the user specifies one.
 `provision-only` flow: skip this step and jump to step 5 — there's nothing to sync.
+Running WP-CLI rather than syncing code: skip to [Running commands on the site](#running-commands-on-the-site).
 
 ### 2. Pick the target site
 


### PR DESCRIPTION
## Proposed changes
* Adds a "Running commands on the site" section — WP-CLI over SSH, with an `expect` recipe for the password path and the details that otherwise waste time: base64 + `wp eval-file` to sidestep quoting, no `python3` on JN hosts, page caching, and that `wp` resolves the install from anywhere but relative paths do not.
* Adds "Gotchas when testing a Jetpack beta or branch build":
  * JN can leave `jetpack-production` and `jetpack-dev` active at the same time. The Jetpack Autoloader resolves each package to the highest version across active plugins, so trunk's packages can serve while you believe you're testing a beta.
  * Activating a plugin that bundles an older Jetpack package usually does **not** reproduce a version conflict — Jetpack's autoloader prepends and wins the lookup. "Installed it, nothing broke" is a vacuous pass; the older class has to be forced to load before Jetpack boots.
* Fixes the `~/.ssh/config` block: covers both gateway hostnames (`ssh.atomicsites.net` and `sftp.wp.com`), drops the redundant `HostName`, notes it must sit above any broad `Host *` stanza, and adds a `BatchMode` verification command.
* Trims the frontmatter description (545 → 373 chars) and drops its what-it-does clause, per the skill-authoring guidance that a description should carry triggering conditions rather than a workflow summary.

Both gotchas came out of testing 16.1-beta.2 today. The first produced a wrong smoke-test result before it was caught.

## Related product discussion/links
*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Documentation only, no testing required.

For reviewer confidence: every command added here was run against a live JN site. One draft claim — that `cd /srv/htdocs` is required or WP-CLI won't find WordPress — was wrong and corrected; `~/htdocs` symlinks to `/srv/htdocs` and Atomic's `wp` wrapper resolves the install from any directory.

An earlier revision of this PR also added behavioural guidance (a shell-first rule, an `inspect` flow, a note that failing key auth still leaves a password path). **It has been dropped.** Subagent testing showed the unmodified skill already produces the right behaviour: given the exact situation the guidance was meant to correct — mid-task, key auth failing with `Permission denied (publickey,password)`, a browser already open with the file editors available — 4/4 agents chose WP-CLI over SSH and 4/4 correctly identified that shell was still reachable. A separate discovery test over the old and new descriptions came out 5/5 identical in both arms. Per the skill-authoring guidance, guidance whose control doesn't fail shouldn't ship, so what remains is only reference material.

@enejb — you wrote this skill in #47935 as a companion to `jetpack rsync`, which is why it covers SFTP transport but not running commands. This adds that without changing any of the existing flow. Happy to move the WP-CLI section into `context-a8c:jurassic-ninja-ssh` and leave a cross-reference here instead, if you'd rather keep this skill focused.
