### PR TITLE
Random Redirect: only declare the redirect function when nothing else has

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-random-redirect-function-conflict
+++ b/projects/plugins/jetpack/changelog/fix-random-redirect-function-conflict
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Random Redirect: avoid a fatal error when a theme or plugin already declares the module's redirect function.

--- a/projects/plugins/jetpack/modules/theme-tools/random-redirect.php
+++ b/projects/plugins/jetpack/modules/theme-tools/random-redirect.php
@@ -13,118 +13,126 @@
 
 // phpcs:disable WordPress.Security.NonceVerification -- No changes to the site here, it just redirects.
 
-/**
- * Redirects to a random post on the site.
+/*
+ * This module was removed from the plugin in 13.6 and restored in 16.1. In the meantime some themes
+ * and plugins started shipping their own copy of the function below, so only declare it when nothing
+ * else has, to avoid a fatal error. The declaration must stay inside this conditional: PHP binds
+ * unconditional top-level function declarations when the file is compiled, before any check could run.
  */
-function jetpack_matt_random_redirect() {
+if ( ! function_exists( 'jetpack_matt_random_redirect' ) ) {
 	/**
-	 * Allows disabling the random redirect feature.
-	 *
-	 * @since 16.1
-	 *
-	 * @param bool $enabled Whether the random redirect feature is enabled. Default true.
+	 * Redirects to a random post on the site.
 	 */
-	if ( ! apply_filters( 'jetpack_random_redirect_enabled', true ) ) {
-		return;
-	}
-
-	// Verify that the Random Redirect plugin this code is from is not active
-	// See https://plugins.trac.wordpress.org/ticket/1898
-	if ( ! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
-		require_once ABSPATH . 'wp-admin/includes/plugin.php';
-		if ( is_plugin_active( 'random-redirect/random-redirect.php' ) ) {
+	function jetpack_matt_random_redirect() {
+		/**
+		 * Allows disabling the random redirect feature.
+		 *
+		 * @since 16.1
+		 *
+		 * @param bool $enabled Whether the random redirect feature is enabled. Default true.
+		 */
+		if ( ! apply_filters( 'jetpack_random_redirect_enabled', true ) ) {
 			return;
 		}
-	}
 
-	// Acceptable URL formats: /[...]/?random=[post type], /?random, /&random, /&random=1
-	if ( ! isset( $_GET['random'] ) && ! ( isset( $_SERVER['REQUEST_URI'] ) && in_array( strtolower( $_SERVER['REQUEST_URI'] ), array( '/&random', '/&random=1' ), true ) ) ) {
-		return;
-	}
-
-	// Ignore POST requests.
-	if ( ! empty( $_POST ) ) {
-		return;
-	}
-
-	// Persistent AppEngine abuse.  ORDER BY RAND is expensive.
-	if ( isset( $_SERVER['HTTP_USER_AGENT'] ) && strstr( filter_var( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ), 'AppEngine-Google' ) ) {
-		wp_die( 'Please <a href="https://en.support.wordpress.com/contact/" rel="noopener noreferrer" target="_blank">contact support</a>' );
-	}
-
-	$where      = array(
-		"post_password = ''",
-		"post_status = 'publish'",
-	);
-	$where_args = array();
-
-	// Set default post type.
-	$post_type = get_post_type();
-
-	// Change the post type if the parameter is set.
-	if ( isset( $_GET['random_post_type'] ) && post_type_exists( sanitize_key( $_GET['random_post_type'] ) ) ) {
-		$post_type = sanitize_key( $_GET['random_post_type'] );
-	}
-
-	// Don't show a random page if 'page' isn't specified as the post type specifically.
-	if ( 'page' === $post_type && is_front_page() && ! isset( $_GET['random_post_type'] ) ) {
-		$post_type = 'post';
-	}
-
-	$where[]      = 'p.post_type = %s';
-	$where_args[] = $post_type;
-
-	// Set author name if we're on an author archive.
-	if ( is_author() ) {
-		$where[]      = 'post_author = %s';
-		$where_args[] = get_the_author_meta( 'ID' );
-	}
-
-	// Set default category type
-	if ( is_category() ) {
-		$category = get_the_category();
-		if ( isset( $category ) && ! empty( $category ) ) {
-			$random_cat_id = $category[0]->term_id;
+		// Verify that the Random Redirect plugin this code is from is not active
+		// See https://plugins.trac.wordpress.org/ticket/1898
+		if ( ! ( defined( 'IS_WPCOM' ) && IS_WPCOM ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+			if ( is_plugin_active( 'random-redirect/random-redirect.php' ) ) {
+				return;
+			}
 		}
+
+		// Acceptable URL formats: /[...]/?random=[post type], /?random, /&random, /&random=1
+		if ( ! isset( $_GET['random'] ) && ! ( isset( $_SERVER['REQUEST_URI'] ) && in_array( strtolower( $_SERVER['REQUEST_URI'] ), array( '/&random', '/&random=1' ), true ) ) ) {
+			return;
+		}
+
+		// Ignore POST requests.
+		if ( ! empty( $_POST ) ) {
+			return;
+		}
+
+		// Persistent AppEngine abuse.  ORDER BY RAND is expensive.
+		if ( isset( $_SERVER['HTTP_USER_AGENT'] ) && strstr( filter_var( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ), 'AppEngine-Google' ) ) {
+			wp_die( 'Please <a href="https://en.support.wordpress.com/contact/" rel="noopener noreferrer" target="_blank">contact support</a>' );
+		}
+
+		$where      = array(
+			"post_password = ''",
+			"post_status = 'publish'",
+		);
+		$where_args = array();
+
+		// Set default post type.
+		$post_type = get_post_type();
+
+		// Change the post type if the parameter is set.
+		if ( isset( $_GET['random_post_type'] ) && post_type_exists( sanitize_key( $_GET['random_post_type'] ) ) ) {
+			$post_type = sanitize_key( $_GET['random_post_type'] );
+		}
+
+		// Don't show a random page if 'page' isn't specified as the post type specifically.
+		if ( 'page' === $post_type && is_front_page() && ! isset( $_GET['random_post_type'] ) ) {
+			$post_type = 'post';
+		}
+
+		$where[]      = 'p.post_type = %s';
+		$where_args[] = $post_type;
+
+		// Set author name if we're on an author archive.
+		if ( is_author() ) {
+			$where[]      = 'post_author = %s';
+			$where_args[] = get_the_author_meta( 'ID' );
+		}
+
+		// Set default category type
+		if ( is_category() ) {
+			$category = get_the_category();
+			if ( isset( $category ) && ! empty( $category ) ) {
+				$random_cat_id = $category[0]->term_id;
+			}
+		}
+
+		// Set the category ID if the parameter is set.
+		if ( isset( $_GET['random_cat_id'] ) ) {
+			$random_cat_id = (int) $_GET['random_cat_id'];
+		}
+
+		global $wpdb;
+
+		$where = implode( ' AND ', $where );
+
+		// Pick a post via COUNT plus a random OFFSET rather than ORDER BY RAND(), which randomizes and sorts every candidate row on each request.
+		if ( isset( $random_cat_id ) ) {
+			$from_where = "FROM $wpdb->posts AS p INNER JOIN $wpdb->term_relationships AS tr ON (p.ID = tr.object_id AND tr.term_taxonomy_id = %s) INNER JOIN  $wpdb->term_taxonomy AS tt ON(tr.term_taxonomy_id = tt.term_taxonomy_id AND taxonomy = 'category') WHERE $where";
+			$query_args = array_merge( array( $random_cat_id ), $where_args );
+		} else {
+			$from_where = "FROM $wpdb->posts AS p WHERE $where";
+			$query_args = $where_args;
+		}
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		$post_count = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT( DISTINCT p.ID ) $from_where", ...$query_args ) );
+
+		if ( $post_count < 1 ) {
+			return;
+		}
+
+		$query_args[] = wp_rand( 0, $post_count - 1 );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
+		$random_id = $wpdb->get_var( $wpdb->prepare( "SELECT DISTINCT p.ID $from_where ORDER BY p.ID LIMIT 1 OFFSET %d", ...$query_args ) );
+
+		if ( ! $random_id ) {
+			return;
+		}
+
+		// @phan-suppress-next-line PhanTypeMismatchArgument
+		$permalink = get_permalink( $random_id );
+		wp_safe_redirect( $permalink );
+		exit( 0 );
 	}
 
-	// Set the category ID if the parameter is set.
-	if ( isset( $_GET['random_cat_id'] ) ) {
-		$random_cat_id = (int) $_GET['random_cat_id'];
-	}
-
-	global $wpdb;
-
-	$where = implode( ' AND ', $where );
-
-	// Pick a post via COUNT plus a random OFFSET rather than ORDER BY RAND(), which randomizes and sorts every candidate row on each request.
-	if ( isset( $random_cat_id ) ) {
-		$from_where = "FROM $wpdb->posts AS p INNER JOIN $wpdb->term_relationships AS tr ON (p.ID = tr.object_id AND tr.term_taxonomy_id = %s) INNER JOIN  $wpdb->term_taxonomy AS tt ON(tr.term_taxonomy_id = tt.term_taxonomy_id AND taxonomy = 'category') WHERE $where";
-		$query_args = array_merge( array( $random_cat_id ), $where_args );
-	} else {
-		$from_where = "FROM $wpdb->posts AS p WHERE $where";
-		$query_args = $where_args;
-	}
-
-	// phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
-	$post_count = (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT( DISTINCT p.ID ) $from_where", ...$query_args ) );
-
-	if ( $post_count < 1 ) {
-		return;
-	}
-
-	$query_args[] = wp_rand( 0, $post_count - 1 );
-	// phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.ReplacementsWrongNumber, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
-	$random_id = $wpdb->get_var( $wpdb->prepare( "SELECT DISTINCT p.ID $from_where ORDER BY p.ID LIMIT 1 OFFSET %d", ...$query_args ) );
-
-	if ( ! $random_id ) {
-		return;
-	}
-
-	// @phan-suppress-next-line PhanTypeMismatchArgument
-	$permalink = get_permalink( $random_id );
-	wp_safe_redirect( $permalink );
-	exit( 0 );
+	add_action( 'template_redirect', 'jetpack_matt_random_redirect' );
 }
-
-add_action( 'template_redirect', 'jetpack_matt_random_redirect' );


### PR DESCRIPTION
## Proposed changes
* Only declare `jetpack_matt_random_redirect()` when nothing else already has, so the Random Redirect module no longer fatals on sites where a theme or plugin ships its own copy of the function.

The module was removed from the plugin in 13.6 (#38310) and restored in 16.1 (#50940). While it was gone, some themes started carrying their own copy. A theme's `functions.php` runs before `after_setup_theme`, where Jetpack loads `module-extras.php`, so the theme declares the function first and the plugin's copy hits `Cannot redeclare jetpack_matt_random_redirect()`. This was reported against 16.1-beta.2 with the `panel` theme active.

The declaration has to sit inside the conditional rather than behind an early `return` — PHP binds unconditional top-level function declarations when the file is compiled, so a runtime check placed before one never gets the chance to run.

Reviewing with whitespace hidden (`?w=1`) shows the real change: 8 added lines. Everything else is the existing function being indented one level.

## Related product discussion/links
p1785868165462669-slack-C01U2KGS2PQ

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

The redeclare only happens when something else declares the function first, so you need to simulate that.

1. On a test site running this branch, confirm Random Redirect still works normally: visit `https://<site>/?random` on the front end. You should be redirected to a random published post.
2. Drop this into `wp-content/mu-plugins/random-redirect-conflict.php` to stand in for a theme that ships its own copy:

   ```php
   <?php
   function jetpack_matt_random_redirect() {
       wp_die( 'conflicting copy ran' );
   }
   add_action( 'template_redirect', 'jetpack_matt_random_redirect' );
   ```

3. Reload any front-end page. On trunk this fatals with `Cannot redeclare jetpack_matt_random_redirect()`. On this branch the site loads normally.
4. Visit `https://<site>/?random` again — you should see `conflicting copy ran`, confirming Jetpack stepped aside and the other copy is the one running.
5. Delete the mu-plugin and confirm `/?random` goes back to redirecting to a random post.

Note that when another copy wins, the `jetpack_random_redirect_enabled` filter added in #50940 no longer applies, since that filter lives in Jetpack's implementation. That is the intended trade-off: not fataling matters more than owning the behaviour on those sites.