### PR TITLE
Atomic Mail: Add site endpoint field for outgoing email blocks

### DIFF
--- a/projects/plugins/jetpack/changelog/add-atomic-email-block-site-field
+++ b/projects/plugins/jetpack/changelog/add-atomic-email-block-site-field
@@ -1,0 +1,4 @@
+Significance: minor
+Type: enhancement
+
+REST API: Add atomic_email_block field to the site endpoint response.

--- a/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
+++ b/projects/plugins/jetpack/json-endpoints/class.wpcom-json-api-get-site-endpoint.php
@@ -101,6 +101,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'garden_is_provisioned'       => '(bool) If the Garden site is provisioned.',
 		'is_wpcom_flex'               => '(bool) If the site is a Flex site',
 		'big_sky_enabled'             => '(bool) Whether the Big Sky AI assistant is enabled for this site.',
+		'atomic_email_block'          => '(object) State of the block on the site\'s outgoing email, with `status` (`blocked` while a block is active, `at_risk` once it has expired), `reason` and `expires_on` keys, or null when the site has no block history. WordPress.com platform only.',
 		'hosting_provider_guess'      => '(string) Guess of the hosting provider. WordPress.com platform only; only returned when explicitly requested via the fields parameter.',
 		'environment_type'            => '(string) The WP_ENVIRONMENT_TYPE of the site as synced by Jetpack. WordPress.com platform only; only returned when explicitly requested via the fields parameter.',
 	);
@@ -270,6 +271,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 		'garden_is_provisioned',
 		'is_wpcom_flex',
 		'big_sky_enabled',
+		'atomic_email_block',
 	);
 
 	/**
@@ -677,6 +679,9 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 				break;
 			case 'big_sky_enabled':
 				$response[ $key ] = $this->site->is_big_sky_enabled();
+				break;
+			case 'atomic_email_block':
+				$response[ $key ] = $this->site->get_atomic_email_block();
 				break;
 			case 'hosting_provider_guess':
 				// WordPress.com platform decoration, computed only when explicitly requested
@@ -1096,6 +1101,7 @@ class WPCOM_JSON_API_GET_Site_Endpoint extends WPCOM_JSON_API_Endpoint {
 			unset( $response->plan );
 			unset( $response->products );
 			unset( $response->zendesk_site_meta );
+			unset( $response->atomic_email_block );
 		}
 
 		// render additional options.

--- a/projects/plugins/jetpack/sal/class.json-api-site-base.php
+++ b/projects/plugins/jetpack/sal/class.json-api-site-base.php
@@ -1818,6 +1818,16 @@ abstract class SAL_Site {
 	}
 
 	/**
+	 * Get the state of any block on the site's outgoing email.
+	 *
+	 * @return array|null `status` (`blocked` or `at_risk`), `reason` and `expires_on`,
+	 *                    or null if the site has never been blocked.
+	 */
+	public function get_atomic_email_block() {
+		return null;
+	}
+
+	/**
 	 * Get Jetpack recovery mode status.
 	 *
 	 * @return array|null


### PR DESCRIPTION
Fixes #

## Proposed changes

* When we stop a site from sending email, the owner is never told. Their contact forms and notifications just quietly stop arriving.
* This adds `atomic_email_block` to the site API response so the dashboard can show a notice. It says whether email is stopped now, was stopped before, or never has been, along with the reason and when it lifts.
* It carries the reason rather than a yes/no because the fix depends on the cause: a domain misconfiguration needs different advice from sending too much unwanted mail.
* This is only half the change. The field returns nothing until the lookup lands in wpcom, so it is safe to merge on its own.

## Related product discussion/links

* Related to DOTDEV-294

## Does this pull request change what data or activity we track or use?

No new tracking. This exposes information we already record about a site to that site's own owner, through an existing API. It is only readable by people who can already administer the site.

## Testing instructions

On its own this change cannot show a real result yet, since the piece that does the lookup is not in this repository. What is worth checking here is that adding the field breaks nothing.

* Request a site from the API and ask for the new field, e.g. `/rest/v1.1/sites/<site>?fields=ID,atomic_email_block`.
* You should get the site back with `atomic_email_block` set to nothing. No errors, no warnings.
* Try the same against a self-hosted Jetpack site. It should behave identically, rather than failing. This is the case the change is most careful about, since those sites have no way of answering the question.
* Request a site without a `fields` parameter. `atomic_email_block` is part of the default response, so it should be present and set to nothing, alongside every field that was there before.
* Request a site as someone who cannot administer it. The field should be absent entirely, not just empty.
