### PR TITLE
Agents Manager: Expose isDotcomSite in the inline data

### DIFF
--- a/projects/packages/agents-manager/changelog/add-agents-manager-is-dotcom-site
+++ b/projects/packages/agents-manager/changelog/add-agents-manager-is-dotcom-site
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Expose `isDotcomSite` in the `agentsManagerData` inline data so the frontend can gate WordPress.com-only menu items.

--- a/projects/packages/agents-manager/composer.json
+++ b/projects/packages/agents-manager/composer.json
@@ -7,7 +7,8 @@
 		"php": ">=7.2",
 		"automattic/jetpack-assets": "@dev",
 		"automattic/jetpack-connection": "@dev",
-		"automattic/jetpack-constants": "@dev"
+		"automattic/jetpack-constants": "@dev",
+		"automattic/jetpack-status": "@dev"
 	},
 	"require-dev": {
 		"automattic/phpunit-select-config": "@dev",

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -322,6 +322,7 @@ class Agents_Manager {
 			'agentProviders'       => $agent_providers,
 			'useUnifiedExperience' => $use_unified_experience,
 			'isDevMode'            => self::is_dev_mode(),
+			'isDotcomSite'         => ( new \Automattic\Jetpack\Status\Host() )->is_wpcom_platform(),
 			'sectionName'          => apply_filters( 'agents_manager_section_name', $variant ),
 			'currentUser'          => $this->get_current_user_data(),
 			'site'                 => $this->get_current_site(),


### PR DESCRIPTION
Part of AI-1096

## Proposed changes

- Add `isDotcomSite` to the `agentsManagerData` inline data, computed via `Host::is_wpcom_platform()` (Simple or WoA).
- Declare the `automattic/jetpack-status` dependency the file already uses (`Host::is_wpcom_simple()` at the split-screen check relied on it transitively).

## Why

The Agents Manager frontend (wp-calypso#113276) adds an "AI Agent settings" menu item linking to the site's WordPress.com AI tools settings — a page that only exists for WordPress.com-hosted sites. No client-side signal can distinguish Simple/WoA from self-hosted Jetpack (domains don't discriminate: WoA runs on custom domains), so the host answers server-side. Until this ships, the frontend falls back to a `.wordpress.com` site-domain check, which misses WoA.

## Testing instructions

1. On a Simple or WoA site with Agents Manager active, load wp-admin and inspect `window.agentsManagerData` — `isDotcomSite` should be `true`.
2. On a self-hosted Jetpack site, it should be `false`.
3. With the wp-calypso PR applied, the ⋮ chat menu shows "AI Agent settings" only in the first case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)