### PR TITLE
Random Redirect: test existing function compatibility

### DIFF
--- a/projects/plugins/jetpack/.phan/config.php
+++ b/projects/plugins/jetpack/.phan/config.php
@@ -19,6 +19,7 @@ $config = make_phan_config(
 			'tests/php/_inc/lib/mocks/simplepie.php',
 			// Standalone compatibility fixtures that intentionally redefine a package class and a WordPress function.
 			'tests/php/fixtures/legacy-status/class-host.php',
+			'tests/php/fixtures/random-redirect-existing-function.php',
 			'tests/php/fixtures/reprint-export-legacy-status-host.php',
 			// Mocks of wpcom classes and functions.
 			'tests/php/lib/class-wpcom-features.php',

--- a/projects/plugins/jetpack/changelog/add-random-redirect-function-conflict-test
+++ b/projects/plugins/jetpack/changelog/add-random-redirect-function-conflict-test
@@ -1,0 +1,3 @@
+Significance: patch
+Type: other
+Comment: Add regression coverage for compatibility with existing Random Redirect implementations.

--- a/projects/plugins/jetpack/tests/php/fixtures/random-redirect-existing-function.php
+++ b/projects/plugins/jetpack/tests/php/fixtures/random-redirect-existing-function.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * Loads Random Redirect after another component has declared its global function.
+ *
+ * @package automattic/jetpack
+ */
+
+$registered_actions = array();
+
+/**
+ * Minimal WordPress action stub used to observe hook registration.
+ *
+ * @param string   $hook_name Hook name.
+ * @param callable $callback  Hook callback.
+ * @return true
+ */
+function add_action( $hook_name, $callback ) {
+	global $registered_actions;
+	$registered_actions[] = array( $hook_name, $callback );
+	return true;
+}
+
+/**
+ * Simulates the legacy implementation loaded by a theme or plugin before Jetpack.
+ *
+ * @return string Fixture marker.
+ */
+function jetpack_matt_random_redirect() {
+	return 'existing implementation';
+}
+
+add_action( 'template_redirect', 'jetpack_matt_random_redirect' );
+
+$plugin_dir = dirname( __DIR__, 3 );
+require $plugin_dir . '/modules/theme-tools/random-redirect.php';
+
+if ( 'existing implementation' !== jetpack_matt_random_redirect() ) {
+	throw new RuntimeException( 'Jetpack did not preserve the existing Random Redirect implementation.' );
+}
+
+$expected_actions = array(
+	array( 'template_redirect', 'jetpack_matt_random_redirect' ),
+);
+if ( $expected_actions !== $registered_actions ) {
+	throw new RuntimeException( 'Jetpack unexpectedly changed the existing Random Redirect hook.' );
+}
+
+echo "OK\n";

--- a/projects/plugins/jetpack/tests/php/fixtures/random-redirect-existing-function.php
+++ b/projects/plugins/jetpack/tests/php/fixtures/random-redirect-existing-function.php
@@ -33,6 +33,7 @@ add_action( 'template_redirect', 'jetpack_matt_random_redirect' );
 
 $plugin_dir = dirname( __DIR__, 3 );
 require $plugin_dir . '/modules/theme-tools/random-redirect.php';
+require $plugin_dir . '/modules/theme-tools/random-redirect.php';
 
 if ( 'existing implementation' !== jetpack_matt_random_redirect() ) {
 	throw new RuntimeException( 'Jetpack did not preserve the existing Random Redirect implementation.' );

--- a/projects/plugins/jetpack/tests/php/modules/theme-tools/Random_Redirect_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/theme-tools/Random_Redirect_Test.php
@@ -131,7 +131,11 @@ class Random_Redirect_Test extends WP_UnitTestCase {
 	public function test_excludes_unpublished_posts() {
 		$public_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
 		foreach ( array( 'draft', 'future', 'pending', 'private', 'trash' ) as $post_status ) {
-			self::factory()->post->create( array( 'post_status' => $post_status ) );
+			$post_data = array( 'post_status' => $post_status );
+			if ( 'future' === $post_status ) {
+				$post_data['post_date'] = '2037-01-01 00:00:00';
+			}
+			self::factory()->post->create( $post_data );
 		}
 		$_GET['random']           = '1';
 		$_GET['random_post_type'] = 'post';

--- a/projects/plugins/jetpack/tests/php/modules/theme-tools/Random_Redirect_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/theme-tools/Random_Redirect_Test.php
@@ -53,6 +53,7 @@ class Random_Redirect_Test extends WP_UnitTestCase {
 	public function tear_down() {
 		remove_filter( 'wp_redirect', array( $this, 'intercept_redirect' ) );
 		unset( $_GET['random'], $_GET['random_post_type'], $_GET['random_cat_id'] );
+		unset( $_POST['random_redirect_test'] );
 		parent::tear_down();
 	}
 
@@ -97,6 +98,55 @@ class Random_Redirect_Test extends WP_UnitTestCase {
 		$post_ids                 = self::factory()->post->create_many( 3, array( 'post_status' => 'publish' ) );
 		$_GET['random']           = '1';
 		$_GET['random_post_type'] = 'post';
+
+		$this->assertContains( $this->get_redirect_location(), array_map( 'get_permalink', $post_ids ) );
+	}
+
+	/**
+	 * A bare random request uses the post type from the main query.
+	 */
+	public function test_bare_random_request_uses_contextual_post_type() {
+		$post_ids        = self::factory()->post->create_many( 3, array( 'post_status' => 'publish' ) );
+		$_GET['random']  = '1';
+		$GLOBALS['post'] = get_post( $post_ids[0] );
+
+		$this->assertContains( $this->get_redirect_location(), array_map( 'get_permalink', $post_ids ) );
+	}
+
+	/**
+	 * Non-GET requests must not redirect.
+	 */
+	public function test_post_request_does_not_redirect() {
+		self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		$_GET['random']                = '1';
+		$_GET['random_post_type']      = 'post';
+		$_POST['random_redirect_test'] = '1';
+
+		$this->assertNull( $this->get_redirect_location() );
+	}
+
+	/**
+	 * Only published posts are eligible redirect targets.
+	 */
+	public function test_excludes_unpublished_posts() {
+		$public_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+		foreach ( array( 'draft', 'future', 'pending', 'private', 'trash' ) as $post_status ) {
+			self::factory()->post->create( array( 'post_status' => $post_status ) );
+		}
+		$_GET['random']           = '1';
+		$_GET['random_post_type'] = 'post';
+
+		$this->assertSame( get_permalink( $public_id ), $this->get_redirect_location() );
+	}
+
+	/**
+	 * An invalid post type falls back to the type from the main query.
+	 */
+	public function test_invalid_post_type_uses_contextual_post_type() {
+		$post_ids                 = self::factory()->post->create_many( 3, array( 'post_status' => 'publish' ) );
+		$_GET['random']           = '1';
+		$_GET['random_post_type'] = 'not-a-post-type';
+		$GLOBALS['post']          = get_post( $post_ids[0] );
 
 		$this->assertContains( $this->get_redirect_location(), array_map( 'get_permalink', $post_ids ) );
 	}

--- a/projects/plugins/jetpack/tests/php/modules/theme-tools/Random_Redirect_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/theme-tools/Random_Redirect_Test.php
@@ -18,6 +18,28 @@ class Random_Redirect_Test extends WP_UnitTestCase {
 	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
 
 	/**
+	 * An existing Random Redirect implementation must not make Jetpack fatal.
+	 *
+	 * The fixture runs in a separate process because this test file has already
+	 * loaded Jetpack's implementation and PHP functions cannot be unloaded.
+	 */
+	public function test_loads_with_existing_random_redirect_function() {
+		$script = dirname( __DIR__, 2 ) . '/fixtures/random-redirect-existing-function.php';
+
+		$output    = array();
+		$exit_code = 0;
+		// phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.system_calls_exec -- A separate process is required to preload the legacy function before Jetpack's module.
+		exec( escapeshellarg( PHP_BINARY ) . ' ' . escapeshellarg( $script ) . ' 2>&1', $output, $exit_code );
+
+		$this->assertSame(
+			0,
+			$exit_code,
+			"Compatibility process failed:\n" . implode( "\n", $output )
+		);
+		$this->assertSame( array( 'OK' ), $output );
+	}
+
+	/**
 	 * Set up.
 	 */
 	public function set_up() {


### PR DESCRIPTION
## Proposed changes

* Add regression coverage for the Random Redirect function conflict fixed by #51037.
* Run the compatibility check in a separate PHP process so a theme or plugin implementation can declare and hook `jetpack_matt_random_redirect()` before Jetpack loads its module.
* Require Jetpack's module twice to verify repeated loads remain idempotent: the existing implementation is preserved and the callback is not registered again.
* Expand behavior coverage for bare requests, invalid post-type fallback, POST requests, and unpublished posts.

This PR is stacked on #51037 so its test suite remains green. It can be retargeted to `trunk` after that PR merges.

## Related product discussion/links

* #51037

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Start and install the Jetpack Docker environment if needed:

   ```sh
   jp docker up -d
   jp docker install
   ```

2. Run the Random Redirect tests:

   ```sh
   jp docker phpunit jetpack -- --filter=Random_Redirect_Test
   ```

3. Confirm all 12 tests pass, including `test_loads_with_existing_random_redirect_function`.

Red/green behavior was also verified directly with the standalone fixture:

* On the Jetpack 16.1 beta backport commit (`5d8235ab7c`), the fixture exits with status 255 and the original `Cannot redeclare jetpack_matt_random_redirect()` fatal.
* With #51037 applied, the fixture prints `OK`, and the complete Random Redirect test class passes: 12 tests and 13 assertions.
