### PR TITLE
Newsletter: send test email on Enter, and show send errors as an error notice

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-newsletter-test-email-enter-and-error-styling
+++ b/projects/plugins/jetpack/changelog/fix-newsletter-test-email-enter-and-error-styling
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Newsletter: send the test email when pressing Enter, and show send errors as a proper error notice.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/email-preview.jsx
@@ -9,6 +9,7 @@ import {
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	Modal,
+	Notice,
 	__experimentalInputControl as InputControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	Icon,
 	__experimentalToggleGroupControl as ToggleGroupControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
@@ -182,7 +183,15 @@ export function NewsletterTestEmailModal( { isOpen, onClose } ) {
 		>
 			<VStack>
 				{ showConnectionNotice && <MissingConnectionNotice /> }
-				{ error && error.code !== MISSING_CONNECTION_ERROR_CODE && <p>{ error.message } </p> }
+				{ error && error.code !== MISSING_CONNECTION_ERROR_CODE && (
+					<Notice
+						status="error"
+						isDismissible={ false }
+						className="jetpack-newsletter-test-email-modal__error"
+					>
+						{ error.message }
+					</Notice>
+				) }
 				{ isEmailSent ? (
 					<HStack alignment="left" className="jetpack-newsletter-test-email-modal__email-sent">
 						<Icon icon={ check } size={ 28 } />
@@ -202,27 +211,44 @@ export function NewsletterTestEmailModal( { isOpen, onClose } ) {
 										/* dummy arg to avoid bad minification */ 0
 								  ) }
 						</p>
-						<Grid alignment="bottom" columns={ 2 } gap={ 2 } templateColumns="2fr auto;">
-							<InputControl
-								type="email"
-								value={ recipientEmail }
-								onChange={ value => setRecipientEmail( value ?? '' ) }
-								disabled={ isEmailSending || ! canEditRecipient }
-								label={ __( 'Recipient email address', 'jetpack' ) }
-								hideLabelFromVision
-								__next40pxDefaultSize={ true }
-							/>
-							<Button
-								variant="primary"
-								onClick={ sendTestEmail }
-								isBusy={ isEmailSending }
-								disabled={ shouldPromptForConnection }
-								__next40pxDefaultSize={ true }
-							>
-								{ __( 'Send', 'jetpack' ) }
-								<Icon icon={ SendIcon } />
-							</Button>
-						</Grid>
+						<form
+							// noValidate keeps our own isValidEmail check the single,
+							// translated, Notice-styled source of validation. Without it
+							// the type="email" input's native constraint validation would
+							// block submit on malformed input and show a browser bubble
+							// instead of our inline error.
+							noValidate
+							onSubmit={ event => {
+								// The modal renders in a portal outside the editor's own
+								// form, so this submit is self-contained. Prevent the
+								// default navigation and route Enter (and the button's
+								// native submit) through the same send path as a click.
+								event.preventDefault();
+								sendTestEmail();
+							} }
+						>
+							<Grid alignment="bottom" columns={ 2 } gap={ 2 } templateColumns="2fr auto;">
+								<InputControl
+									type="email"
+									value={ recipientEmail }
+									onChange={ value => setRecipientEmail( value ?? '' ) }
+									disabled={ isEmailSending || ! canEditRecipient }
+									label={ __( 'Recipient email address', 'jetpack' ) }
+									hideLabelFromVision
+									__next40pxDefaultSize={ true }
+								/>
+								<Button
+									type="submit"
+									variant="primary"
+									isBusy={ isEmailSending }
+									disabled={ shouldPromptForConnection }
+									__next40pxDefaultSize={ true }
+								>
+									{ __( 'Send', 'jetpack' ) }
+									<Icon icon={ SendIcon } />
+								</Button>
+							</Grid>
+						</form>
 					</>
 				) }
 			</VStack>

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/test/email-preview.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/test/email-preview.jsx
@@ -53,6 +53,11 @@ const MISSING_CONNECTION_ERROR = {
 	data: { status: 403 },
 };
 
+// Error messages render inside a `Notice`, which mirrors its text into
+// @wordpress/a11y's global live region — so the message exists twice in the
+// DOM. Scope message assertions to the visible copy by ignoring that region.
+const IGNORE_LIVE_REGION = { ignore: '.a11y-speak-region' };
+
 describe( 'Email preview connection errors', () => {
 	beforeEach( () => {
 		jest.clearAllMocks();
@@ -105,7 +110,7 @@ describe( 'Email preview connection errors', () => {
 
 		await user.click( screen.getByRole( 'button', { name: /Send/ } ) );
 
-		await expect( screen.findByText( /Boom/ ) ).resolves.toBeInTheDocument();
+		await expect( screen.findByText( /Boom/, IGNORE_LIVE_REGION ) ).resolves.toBeInTheDocument();
 		expect(
 			screen.queryByRole( 'link', { name: 'Connect your account' } )
 		).not.toBeInTheDocument();
@@ -165,6 +170,26 @@ describe( 'Test email recipient', () => {
 		await user.clear( field );
 		await user.type( field, 'friend@example.com' );
 		await user.click( screen.getByRole( 'button', { name: /Send/ } ) );
+
+		expect( apiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: '/wpcom/v2/send-email-preview/',
+				method: 'POST',
+				data: { id: 123, email: 'friend@example.com' },
+			} )
+		);
+	} );
+
+	it( 'sends the test email when pressing Enter in the recipient field', async () => {
+		const user = userEvent.setup();
+		apiFetch.mockResolvedValue( undefined );
+
+		render( <NewsletterTestEmailModal isOpen onClose={ jest.fn() } /> );
+
+		const field = screen.getByRole( 'textbox' );
+		await user.clear( field );
+		// The trailing {Enter} submits the surrounding form rather than clicking Send.
+		await user.type( field, 'friend@example.com{Enter}' );
 
 		expect( apiFetch ).toHaveBeenCalledWith(
 			expect.objectContaining( {
@@ -252,8 +277,22 @@ describe( 'Test email recipient', () => {
 		await user.click( screen.getByRole( 'button', { name: /Send/ } ) );
 
 		await expect(
-			screen.findByText( /not allowed to send a test email/ )
+			screen.findByText( /not allowed to send a test email/, IGNORE_LIVE_REGION )
 		).resolves.toBeInTheDocument();
+	} );
+
+	it( 'renders send errors in an error notice rather than plain text', async () => {
+		const user = userEvent.setup();
+		apiFetch.mockRejectedValue( { code: 'rest_something_else', message: 'Boom' } );
+
+		render( <NewsletterTestEmailModal isOpen onClose={ jest.fn() } /> );
+
+		await user.click( screen.getByRole( 'button', { name: /Send/ } ) );
+
+		// The message must live inside a Notice styled as an error, not a bare <p>.
+		const message = await screen.findByText( /Boom/, IGNORE_LIVE_REGION );
+		// eslint-disable-next-line testing-library/no-node-access
+		expect( message.closest( '.components-notice' ) ).toHaveClass( 'is-error' );
 	} );
 
 	it( 'rejects a malformed address client-side without calling the API', async () => {
@@ -268,7 +307,7 @@ describe( 'Test email recipient', () => {
 		await user.click( screen.getByRole( 'button', { name: /Send/ } ) );
 
 		await expect(
-			screen.findByText( /please enter a valid email address/i )
+			screen.findByText( /please enter a valid email address/i, IGNORE_LIVE_REGION )
 		).resolves.toBeInTheDocument();
 		expect( apiFetch ).not.toHaveBeenCalled();
 	} );
@@ -282,7 +321,7 @@ describe( 'Test email recipient', () => {
 		await user.click( screen.getByRole( 'button', { name: /Send/ } ) );
 
 		await expect(
-			screen.findByText( /please try again in a little while/i )
+			screen.findByText( /please try again in a little while/i, IGNORE_LIVE_REGION )
 		).resolves.toBeInTheDocument();
 		expect( screen.queryByText( /not a valid JSON response/i ) ).not.toBeInTheDocument();
 	} );
@@ -302,7 +341,7 @@ describe( 'Test email recipient', () => {
 		await user.click( screen.getByRole( 'button', { name: /Send/ } ) );
 
 		await expect(
-			screen.findByText( /please try again in a little while/i )
+			screen.findByText( /please try again in a little while/i, IGNORE_LIVE_REGION )
 		).resolves.toBeInTheDocument();
 		expect( screen.queryByText( /not a valid JSON response/i ) ).not.toBeInTheDocument();
 	} );


### PR DESCRIPTION
Follow-up to #50969, which made the "Send a test email" recipient field editable. Two rough edges on that now-editable field.

## Proposed changes
* **Enter now sends.** The recipient field and Send button are wrapped in a `<form>`, and Send is a submit button, so pressing Enter in the field submits the same way a click does. Previously Enter did nothing and you had to click Send.
* `noValidate` on the form keeps our own `isValidEmail` check as the single, translated source of validation, instead of the browser's native `type="email"` bubble (which would otherwise block submit and bypass our inline message).
* **Send errors now look like errors.** Failure messages render in a `<Notice status="error">` instead of a bare `<p>` that was visually indistinguishable from the modal's help text. This matches the `Notice` convention already used across the subscriptions extension (e.g. `panel.jsx`).
* Adds tests for the Enter-to-send path and for errors rendering inside an error `Notice`.

<img width="583" height="314" alt="Screenshot 2026-08-04 at 5 10 59 PM" src="https://github.com/user-attachments/assets/1d0f3c51-9234-4786-8805-0a1854550a93" />

## Related product discussion/links
* NL-769

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
* Apply this change and open a post in the block editor.
* Open the Newsletter "Send a test email" modal (pre-publish panel, or the Jetpack Newsletter sidebar).
* Type a recipient address and press **Enter** (don't click Send) — the test email is sent, same as clicking Send.
* Enter a malformed address and press Enter — an inline **red error notice** appears with "Please enter a valid email address." (not a native browser tooltip).
* Trigger a send failure (e.g. a rejected recipient) — the error surfaces as a red `Notice`, not plain text.
