### PR TITLE
Random Redirect: query categories by term ID

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-random-redirect-category-term-id
+++ b/projects/plugins/jetpack/changelog/fix-random-redirect-category-term-id
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Random Redirect: Correctly filter posts when category term and taxonomy IDs differ.

--- a/projects/plugins/jetpack/modules/theme-tools/random-redirect.php
+++ b/projects/plugins/jetpack/modules/theme-tools/random-redirect.php
@@ -106,7 +106,7 @@ if ( ! function_exists( 'jetpack_matt_random_redirect' ) ) {
 
 		// Pick a post via COUNT plus a random OFFSET rather than ORDER BY RAND(), which randomizes and sorts every candidate row on each request.
 		if ( isset( $random_cat_id ) ) {
-			$from_where = "FROM $wpdb->posts AS p INNER JOIN $wpdb->term_relationships AS tr ON (p.ID = tr.object_id AND tr.term_taxonomy_id = %s) INNER JOIN  $wpdb->term_taxonomy AS tt ON(tr.term_taxonomy_id = tt.term_taxonomy_id AND taxonomy = 'category') WHERE $where";
+			$from_where = "FROM $wpdb->posts AS p INNER JOIN $wpdb->term_relationships AS tr ON (p.ID = tr.object_id) INNER JOIN $wpdb->term_taxonomy AS tt ON (tr.term_taxonomy_id = tt.term_taxonomy_id AND tt.term_id = %s AND tt.taxonomy = 'category') WHERE $where";
 			$query_args = array_merge( array( $random_cat_id ), $where_args );
 		} else {
 			$from_where = "FROM $wpdb->posts AS p WHERE $where";

--- a/projects/plugins/jetpack/tests/php/modules/theme-tools/Random_Redirect_Test.php
+++ b/projects/plugins/jetpack/tests/php/modules/theme-tools/Random_Redirect_Test.php
@@ -194,6 +194,38 @@ class Random_Redirect_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The random_cat_id parameter is a term ID, not a term taxonomy ID.
+	 */
+	public function test_random_cat_id_when_term_and_taxonomy_ids_differ() {
+		global $wpdb;
+
+		$dummy_term_id = self::factory()->term->create( array( 'taxonomy' => 'post_tag' ) );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Deliberately create distinct term and term-taxonomy IDs.
+		$inserted = $wpdb->insert(
+			$wpdb->term_taxonomy,
+			array(
+				'term_id'     => $dummy_term_id,
+				'taxonomy'    => 'random_redirect_test',
+				'description' => '',
+				'parent'      => 0,
+				'count'       => 0,
+			)
+		);
+		$this->assertSame( 1, $inserted );
+
+		$category = wp_insert_term( 'Random Redirect Category', 'category' );
+		$this->assertNotWPError( $category );
+		$this->assertNotSame( (int) $category['term_id'], (int) $category['term_taxonomy_id'] );
+
+		$in_cat_id                = self::factory()->post->create( array( 'post_category' => array( $category['term_id'] ) ) );
+		$_GET['random']           = '1';
+		$_GET['random_post_type'] = 'post';
+		$_GET['random_cat_id']    = (string) $category['term_id'];
+
+		$this->assertSame( get_permalink( $in_cat_id ), $this->get_redirect_location() );
+	}
+
+	/**
 	 * No matching posts means no redirect.
 	 */
 	public function test_no_matching_posts_does_not_redirect() {


### PR DESCRIPTION
## Proposed changes

* Treat `random_cat_id` as a category term ID when building the Random Redirect query.
* Join the term relationship to its taxonomy row first, then filter by `tt.term_id` and the `category` taxonomy.
* Add a regression test where the term ID and term-taxonomy ID intentionally differ.

The previous query compared `random_cat_id` directly with `term_relationships.term_taxonomy_id`. That only worked accidentally when the two IDs had the same numeric value.

This PR is stacked on #51041, which is stacked on #51037. It can be retargeted after those predecessors merge.

## Related product discussion/links

* #51037
* #51041

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Start and install the Jetpack Docker environment if needed:

   ```sh
   jp docker up -d
   jp docker install
   ```

2. Run the Random Redirect tests:

   ```sh
   jp docker phpunit jetpack -- --filter=Random_Redirect_Test
   ```

3. Confirm all 13 tests and 17 assertions pass, including `test_random_cat_id_when_term_and_taxonomy_ids_differ`.

The new regression test was verified red/green:

* Against the parent code, it fails because no redirect occurs when the category term ID differs from its term-taxonomy ID.
* With this change, the requested category resolves correctly and the complete class passes.
