### PR TITLE
Verbum Comments: prevent duplicate comment submissions

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-duplicate-comment-submissions
+++ b/projects/packages/jetpack-mu-wpcom/changelog/fix-verbum-duplicate-comment-submissions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Verbum Comments: prevent a single comment from being submitted more than once.

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/class-verbum-comments.php
@@ -266,6 +266,7 @@ class Verbum_Comments {
 					'Enter your email address'           => __( 'Enter your email address', 'jetpack-mu-wpcom' ),
 					'Subscribe'                          => __( 'Subscribe', 'jetpack-mu-wpcom' ),
 					'Comment sent successfully'          => __( 'Comment sent successfully', 'jetpack-mu-wpcom' ),
+					'Your comment could not be sent. Please try again.' => __( 'Your comment could not be sent. Please try again.', 'jetpack-mu-wpcom' ),
 					'Save my name, email, and website in this browser for the next time I comment.' => __( 'Save my name, email, and website in this browser for the next time I comment.', 'jetpack-mu-wpcom' ),
 					'hovercardi18n'                      => $hovercard_i18n,
 					'siteId'                             => $this->blog_id,

--- a/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/index.tsx
+++ b/projects/packages/jetpack-mu-wpcom/src/features/verbum-comments/src/index.tsx
@@ -38,7 +38,9 @@ const Verbum = ( { siteId, parentForm }: VerbumAppProps ) => {
 
 	const commentTextarea = useRef< HTMLTextAreaElement >( null );
 	const [ email, setEmail ] = useState( '' );
-	const [ ignoreSubscriptionModal, setIgnoreSubscriptionModal ] = useState( false );
+	// A ref, not a signal: it has to take effect inside the submit handler itself, before
+	// Preact gets a chance to re-render the button as disabled.
+	const isSubmitting = useRef( false );
 	const { login, loginWindowRef, logout } = useSocialLogin();
 
 	useFormMutations( parentForm );
@@ -77,6 +79,23 @@ const Verbum = ( { siteId, parentForm }: VerbumAppProps ) => {
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [ isEmptyComment.value ] );
 
+	useEffect( () => {
+		// The back/forward cache restores this page with the in-flight submission still recorded,
+		// which would leave the form locked for good once the commenter navigates back to it.
+		const handlePageShow = ( event: PageTransitionEvent ) => {
+			if ( event.persisted ) {
+				isSubmitting.current = false;
+				isSavingComment.value = false;
+			}
+		};
+
+		window.addEventListener( 'pageshow', handlePageShow );
+		return () => {
+			window.removeEventListener( 'pageshow', handlePageShow );
+		};
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
+
 	const subscriptionTraySeen = () => {
 		try {
 			return window.localStorage.getItem(
@@ -109,6 +128,15 @@ const Verbum = ( { siteId, parentForm }: VerbumAppProps ) => {
 		}
 	};
 
+	// Only call this when the comment was rejected. Releasing it after a comment was accepted
+	// hands the commenter a live button for something the server already stored.
+	const allowResubmission = ( message: string ) => {
+		setShowMessage( message );
+		setIsErrorMessage( true );
+		isSavingComment.value = false;
+		isSubmitting.current = false;
+	};
+
 	const handleSubscriptionModal = async ( event: Event ) => {
 		event.preventDefault();
 		setShowMessage( '' );
@@ -123,10 +151,18 @@ const Verbum = ( { siteId, parentForm }: VerbumAppProps ) => {
 
 		formData.set( 'verbum_show_subscription_modal', subscribeModalStatus.value ?? '' );
 
-		const response = await fetch( formAction!, {
-			method: 'POST',
-			body: formData,
-		} );
+		let response: Response;
+
+		try {
+			response = await fetch( formAction!, {
+				method: 'POST',
+				body: formData,
+			} );
+		} catch {
+			// The request never completed, so nothing was stored and retrying is safe.
+			allowResubmission( translate( 'Your comment could not be sent. Please try again.' ) );
+			return;
+		}
 
 		if ( response.redirected ) {
 			// If the user is not replying any comment, we scroll to the comment form.
@@ -141,18 +177,13 @@ const Verbum = ( { siteId, parentForm }: VerbumAppProps ) => {
 		const doc = new DOMParser().parseFromString( text, 'text/html' );
 		const errorMessageElement = doc.querySelector( '.wp-die-message p' );
 
-		// Show error message
-		if ( errorMessageElement !== null ) {
-			setShowMessage( errorMessageElement.innerHTML );
-			setIsErrorMessage( true );
-			isSavingComment.value = false;
-		}
-
-		// If no error message and not redirect, we re-submit the form as usual instead of using fetch.
-		setIgnoreSubscriptionModal( true );
-		isSavingComment.value = false;
-		const submitFormFunction = Object.getPrototypeOf( parentForm ).submit;
-		submitFormFunction.call( parentForm );
+		// wp-comments-post.php answered without redirecting, which it only does when it rejected
+		// the comment. Report why and let the commenter decide to try again -- re-posting the form
+		// from here is what turned a single click into several identical comments.
+		allowResubmission(
+			errorMessageElement?.innerHTML ??
+				translate( 'Your comment could not be sent. Please try again.' )
+		);
 	};
 
 	const handleCommentSubmit = async ( event: Event ) => {
@@ -160,6 +191,17 @@ const Verbum = ( { siteId, parentForm }: VerbumAppProps ) => {
 			event.preventDefault();
 			return;
 		}
+
+		// Stop every re-entry path -- repeated clicks, implicit submission from the name and email
+		// fields, another script calling submit() -- before a second request can leave the browser.
+		if ( isSubmitting.current ) {
+			event.preventDefault();
+			event.stopImmediatePropagation();
+			return;
+		}
+
+		isSubmitting.current = true;
+		isSavingComment.value = true;
 
 		window.removeEventListener( 'beforeunload', handleBeforeUnload );
 		if ( userInfo.value?.service === 'guest' ) {
@@ -181,13 +223,8 @@ const Verbum = ( { siteId, parentForm }: VerbumAppProps ) => {
 			setSubscriptionTraySeen();
 		}
 
-		setTimeout( () => ( isSavingComment.value = true ), 0 );
-
-		if ( ! VerbumComments.isJetpackComments ) {
-			if ( VerbumComments.enableSubscriptionModal && ! ignoreSubscriptionModal ) {
-				isSavingComment.value = true;
-				await handleSubscriptionModal( event );
-			}
+		if ( ! VerbumComments.isJetpackComments && VerbumComments.enableSubscriptionModal ) {
+			await handleSubscriptionModal( event );
 		}
 	};
 


### PR DESCRIPTION
## Proposed changes

Readers were getting the same comment posted several times — byte-identical content, seconds apart. Verbum's only protection was the submit button's `disabled` prop, and it leaked in a few ways.

* Guard the comment form's `submit` event with a re-entrancy check that takes effect synchronously inside the handler, so repeat clicks (or implicit submission from the name/email inputs) can't start a second submission while one is in flight. The button's `disabled` prop was previously applied a macrotask late via `setTimeout( …, 0 )`; three clicks in a single task all reached the server.
* Stop re-posting the form once the request has already reached `wp-comments-post.php`. The subscription-modal path called `HTMLFormElement.prototype.submit()` on *any* non-redirect response — and re-enabled the button first — so one click could produce two submissions. The error branch had no `return`, so a rejected comment showed the error inline **and** sent a second POST.
* Report failures instead of hanging: an aborted `fetch` used to leave the button stuck in its busy state with no message and no way to retry.
* Release the guard on a back/forward-cache restore (`pageshow` + `persisted`), so navigating back to a post doesn't leave the comment form permanently locked.

Worth noting for reviewers: WordPress's own duplicate-comment check in `wp_allow_comment()` does not reliably reject these, so the client is currently the only thing standing between a reader and a duplicate.

## Related product discussion/links

* CM-847

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Verbum only runs on WordPress.com Simple, so test on a Simple site with comments open to everyone.

* Open a post as a logged-out reader, fill in name and email, and write a comment.
* Click **Comment** several times in quick succession while the request is still in flight. Exactly one comment should be created — before this change each extra click could add another.
* Confirm the happy path is unchanged: the comment posts and you land back on the post, with the subscribe modal first if it applies to your account.
* Make the server reject a submission (for example clear the required name or email before submitting). You should get the error message inline, the comment text should stay in the box, and the button should become clickable again — with no second POST and no full-page navigation to the raw error page.
* After commenting, hit the browser Back button and confirm the comment form is usable again rather than stuck disabled.
