### PR TITLE
Forms: default the Button block to a submit element inside a Form

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-button-default-element
+++ b/projects/packages/forms/changelog/fix-forms-button-default-element
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Ensure the submit button inside a Form renders as a button element so forms saved without an explicit element can still be submitted.

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -817,7 +817,15 @@ class Contact_Form_Block {
 		// A Button block that doesn't specify an element renders as an `a`, which can
 		// never submit the form. Default it to `button` for as long as this form is
 		// rendering; gutenblock_render_form() drops the filter again once it is done.
-		add_filter( 'jetpack_button_default_element', array( __CLASS__, 'submit_button_element' ) );
+		//
+		// Only attach it when we know that method will run: either we render a synced
+		// form ourselves just below, or rendering proceeds normally and it runs as the
+		// block's render callback. If another pre_render_block callback has already
+		// short-circuited this block, neither happens and the filter would stay attached
+		// for the rest of the request.
+		if ( isset( $parsed_block['attrs']['ref'] ) || null === $pre_render ) {
+			add_filter( 'jetpack_button_default_element', array( __CLASS__, 'submit_button_element' ) );
+		}
 
 		// For ref (synced) forms, render here via pre_render_block to short-circuit
 		// render_block(). This prevents wp_render_layout_support_flag from adding

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -814,6 +814,11 @@ class Contact_Form_Block {
 		// Count and store form steps
 		self::$form_step_count = self::count_form_steps_in_block( $parsed_block );
 
+		// A Button block that doesn't specify an element renders as an `a`, which can
+		// never submit the form. Default it to `button` for as long as this form is
+		// rendering; gutenblock_render_form() drops the filter again once it is done.
+		add_filter( 'jetpack_button_default_element', array( __CLASS__, 'submit_button_element' ) );
+
 		// For ref (synced) forms, render here via pre_render_block to short-circuit
 		// render_block(). This prevents wp_render_layout_support_flag from adding
 		// layout classes to the outer ref block's container div. The synced form's
@@ -899,6 +904,17 @@ class Contact_Form_Block {
 	}
 
 	/**
+	 * The element a Button block inside a form falls back to when it doesn't set one.
+	 *
+	 * Filters `jetpack_button_default_element` for the duration of a form's render.
+	 *
+	 * @return string
+	 */
+	public static function submit_button_element() {
+		return 'button';
+	}
+
+	/**
 	 * Render the gutenblock form.
 	 *
 	 * @param array  $atts - the block attributes.
@@ -907,6 +923,24 @@ class Contact_Form_Block {
 	 * @return string
 	 */
 	public static function gutenblock_render_form( $atts, $content ) {
+		$form = self::render_form( $atts, $content );
+
+		// The form and its buttons are rendered by now, so stop defaulting Button blocks
+		// to `button` — any further button on the page is not a submit button.
+		remove_filter( 'jetpack_button_default_element', array( __CLASS__, 'submit_button_element' ) );
+
+		return $form;
+	}
+
+	/**
+	 * Render the gutenblock form markup.
+	 *
+	 * @param array  $atts - the block attributes.
+	 * @param string $content - html content.
+	 *
+	 * @return string
+	 */
+	private static function render_form( $atts, $content ) {
 		// We should not render block if the module is disabled on a site using the Jetpack plugin.
 		// Exception: allow rendering in preview mode so form previews work.
 		if ( class_exists( 'Jetpack' ) && ! ( new Modules() )->is_active( 'contact-form' ) && ! Form_Preview::is_preview_mode() ) {

--- a/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
+++ b/projects/packages/forms/src/blocks/contact-form/class-contact-form-block.php
@@ -814,16 +814,10 @@ class Contact_Form_Block {
 		// Count and store form steps
 		self::$form_step_count = self::count_form_steps_in_block( $parsed_block );
 
-		// A Button block that doesn't specify an element renders as an `a`, which can
-		// never submit the form. Default it to `button` for as long as this form is
-		// rendering; gutenblock_render_form() drops the filter again once it is done.
-		//
-		// Only attach it when we know that method will run: either we render a synced
-		// form ourselves just below, or rendering proceeds normally and it runs as the
-		// block's render callback. If another pre_render_block callback has already
-		// short-circuited this block, neither happens and the filter would stay attached
-		// for the rest of the request.
 		if ( isset( $parsed_block['attrs']['ref'] ) || null === $pre_render ) {
+			// This happends only important for lagacy reasons and when code is programatically generated.
+			// Since it can include the previous jetpack button.
+			// Which by default renders as a link instead of a button resulting in the form not submitting.
 			add_filter( 'jetpack_button_default_element', array( __CLASS__, 'submit_button_element' ) );
 		}
 

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -41,6 +41,77 @@ class Contact_Form_Block_Test extends BaseTestCase {
 	}
 
 	/**
+	 * The value a Button block inside a form falls back to.
+	 */
+	public function test_submit_button_element_is_a_submit_button() {
+		$this->assertSame( 'button', Contact_Form_Block::submit_button_element() );
+	}
+
+	/**
+	 * Rendering a form makes element-less Button blocks default to `button`, so the
+	 * form can actually be submitted.
+	 */
+	public function test_pre_render_contact_form_defaults_buttons_to_submit() {
+		$this->assertSame(
+			'a',
+			apply_filters( 'jetpack_button_default_element', 'a' ),
+			'The Button block default should be untouched before a form renders.'
+		);
+
+		Contact_Form_Block::pre_render_contact_form(
+			null,
+			array(
+				'blockName'   => 'jetpack/contact-form',
+				'attrs'       => array(),
+				'innerBlocks' => array(),
+			)
+		);
+
+		$this->assertSame( 'button', apply_filters( 'jetpack_button_default_element', 'a' ) );
+
+		remove_filter( 'jetpack_button_default_element', array( Contact_Form_Block::class, 'submit_button_element' ) );
+	}
+
+	/**
+	 * The default only applies while the form renders — a Button elsewhere on the page
+	 * is not a submit button and must keep the block's own `a` fallback.
+	 */
+	public function test_gutenblock_render_form_restores_the_button_default() {
+		Contact_Form_Block::pre_render_contact_form(
+			null,
+			array(
+				'blockName'   => 'jetpack/contact-form',
+				'attrs'       => array(),
+				'innerBlocks' => array(),
+			)
+		);
+		$this->assertSame( 'button', apply_filters( 'jetpack_button_default_element', 'a' ) );
+
+		Contact_Form_Block::gutenblock_render_form( array(), '' );
+
+		$this->assertSame( 'a', apply_filters( 'jetpack_button_default_element', 'a' ) );
+		$this->assertFalse(
+			has_filter( 'jetpack_button_default_element', array( Contact_Form_Block::class, 'submit_button_element' ) )
+		);
+	}
+
+	/**
+	 * Blocks other than the form leave the Button default alone.
+	 */
+	public function test_pre_render_contact_form_ignores_other_blocks() {
+		Contact_Form_Block::pre_render_contact_form(
+			null,
+			array(
+				'blockName'   => 'core/group',
+				'attrs'       => array(),
+				'innerBlocks' => array(),
+			)
+		);
+
+		$this->assertSame( 'a', apply_filters( 'jetpack_button_default_element', 'a' ) );
+	}
+
+	/**
 	 * Test that we're registering inner block types via ::register_child_blocks.
 	 *
 	 * @dataProvider data_provider_test_register_child_blocks

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Block_Test.php
@@ -96,6 +96,46 @@ class Contact_Form_Block_Test extends BaseTestCase {
 	}
 
 	/**
+	 * When another pre_render_block callback has already short-circuited the form, our
+	 * render callback never runs to remove the filter — so it must not be attached at
+	 * all, or every later Button block in the request would turn into a submit button.
+	 */
+	public function test_pre_render_contact_form_leaves_the_default_alone_when_short_circuited() {
+		Contact_Form_Block::pre_render_contact_form(
+			'<div>rendered by someone else</div>',
+			array(
+				'blockName'   => 'jetpack/contact-form',
+				'attrs'       => array(),
+				'innerBlocks' => array(),
+			)
+		);
+
+		$this->assertSame( 'a', apply_filters( 'jetpack_button_default_element', 'a' ) );
+		$this->assertFalse(
+			has_filter( 'jetpack_button_default_element', array( Contact_Form_Block::class, 'submit_button_element' ) )
+		);
+	}
+
+	/**
+	 * The synced (`ref`) path renders through gutenblock_render_form() itself, so it is
+	 * safe to attach the filter there even when something else short-circuited the
+	 * block — it is removed again by the time we return.
+	 */
+	public function test_pre_render_contact_form_synced_form_does_not_leak_the_filter() {
+		Contact_Form_Block::pre_render_contact_form(
+			'<div>rendered by someone else</div>',
+			array(
+				'blockName'   => 'jetpack/contact-form',
+				'attrs'       => array( 'ref' => 123 ),
+				'innerBlocks' => array(),
+			)
+		);
+
+		// gutenblock_render_form() ran as part of the ref path and removed the filter.
+		$this->assertSame( 'a', apply_filters( 'jetpack_button_default_element', 'a' ) );
+	}
+
+	/**
 	 * Blocks other than the form leave the Button default alone.
 	 */
 	public function test_pre_render_contact_form_ignores_other_blocks() {

--- a/projects/plugins/jetpack/changelog/fix-forms-button-default-element
+++ b/projects/plugins/jetpack/changelog/fix-forms-button-default-element
@@ -1,4 +1,4 @@
 Significance: patch
 Type: other
 
-Button block: add a filter for the default HTML element the block falls back to when it does not specify one.
+Button block: Add a filter for the default HTML element the block falls back to when it does not specify one.

--- a/projects/plugins/jetpack/changelog/fix-forms-button-default-element
+++ b/projects/plugins/jetpack/changelog/fix-forms-button-default-element
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Button block: add a filter for the default HTML element the block falls back to when it does not specify one.

--- a/projects/plugins/jetpack/extensions/blocks/button/button.php
+++ b/projects/plugins/jetpack/extensions/blocks/button/button.php
@@ -414,6 +414,23 @@ function get_attribute( $attributes, $attribute_name ) {
 		'saveInPostContent' => false,
 	);
 
+	if ( 'element' === $attribute_name ) {
+		/**
+		 * Filter the HTML element the Button block falls back to when the block itself
+		 * does not specify one.
+		 *
+		 * Jetpack Forms uses this to default its submit button to `button` while a form
+		 * renders, since an `a` inside a form can never submit it.
+		 *
+		 * Values outside 'a', 'button' and 'input' are ignored by the render callback.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param string $element The default element. One of 'a', 'button', or 'input'.
+		 */
+		return apply_filters( 'jetpack_button_default_element', $default_attributes['element'] );
+	}
+
 	if ( isset( $default_attributes[ $attribute_name ] ) ) {
 		return $default_attributes[ $attribute_name ];
 	}


### PR DESCRIPTION
Fixes FORMS-741

## Proposed changes

A Jetpack Button block that has no `element` attribute falls back to rendering an `<a>` (see `get_attribute()` in `projects/plugins/jetpack/extensions/blocks/button/button.php`). Inside a Form that produces a submit control that looks right but is actually an anchor:

```html
<a class="wp-block-button__link" href="#" target="_blank" role="button" rel="noopener noreferrer">Submit</a>
```

Clicking it opens a blank tab and the form is never submitted. The Form block's inner-block template does set `element: "button"`, so this only bites forms whose saved markup predates that or lost the attribute along the way.

* **Button block:** make that fallback filterable via a new `jetpack_button_default_element` filter, instead of hardcoding `'a'`. Nothing changes on its own — the default is still `a`, and the render callback's existing allowlist still ignores anything outside `a`/`button`/`input`.
* **Forms:** hook that filter to return `button` for the duration of a form's render — added in `pre_render_contact_form()` (before the inner blocks render) and removed in `gutenblock_render_form()` (once they have). A Button that sets `element` explicitly is untouched either way, since the filter only supplies the fallback.

Scoping to the form's render span means it covers a button nested in a Group or any other wrapper inside the form, and stops applying the moment the form is done — a Calendly, Eventbrite, Payment Button or Subscribe block elsewhere on the page still renders its anchor.

`gutenblock_render_form()` has several early returns, so its body moved to a private `render_form()` and the public method became a thin wrapper that removes the filter. The public signature is unchanged.

Two deliberate non-changes:

* This is render-time only. The editor is visually unchanged (the block's `edit.jsx` draws a `RichText` regardless of `element`) and saved post content is not rewritten — PHP simply supplies the fallback on every render, so no posts are dirtied on load.
* `saveInPostContent` mode still always renders an `<a>`. That is intentional and documented in the Button block's README (stricter WordPress.com sanitization rules), and the render callback returns early before the fallback is consulted.

The filter is only attached when `gutenblock_render_form()` is guaranteed to run and remove it again — either the synced-form (`ref`) path, which calls it directly, or a normal render where it runs as the block's render callback. If another `pre_render_block` callback has already short-circuited the block, the filter is never attached, so it cannot leak into later Button blocks in the same request.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

You need a Form whose Button block has **no** `element` attribute — this is the legacy shape, and the editor will not produce it for you.

* Create a post, switch to the code editor (⌥⌘M / Ctrl+Shift+Alt+M), and paste this — it puts a plain Button before and after the form so you can check the scoping at the same time:

```
<!-- wp:jetpack/button {"text":"Before form button"} /-->
<!-- wp:jetpack/contact-form -->
<!-- wp:jetpack/field-name {"required":true,"label":"Name"} /-->
<!-- wp:jetpack/button {"text":"Submit"} /-->
<!-- /wp:jetpack/contact-form -->
<!-- wp:jetpack/button {"text":"After form button"} /-->
```

* Publish and view the post on the front end, then view source.
* **Before this change:** all three render as `<a class="wp-block-button__link" href="#" target="_blank" role="button">`. Fill in the Name field and click Submit — a blank tab opens, nothing is submitted, and no new entry appears under Feedback / Form Responses.
* **After this change:**
  * "Before form button" → still `<a ... href="#">`
  * "Submit" → `<button class="wp-block-button__link" type="submit">`
  * "After form button" → still `<a ... href="#">`
* Fill in Name and click Submit — the form submits and a new response is recorded.
* Check nothing else regressed:
  * Wrap the submit button in a Group block inside the Form — it should still render as `<button type="submit">`.
  * A Button with an explicit element inside the Form, e.g. `<!-- wp:jetpack/button {"element":"a","text":"Link"} /-->`, must still render as an `<a>`.
  * A Calendly, Eventbrite, Payment Button or Subscribe block should still render its anchor as before.
* Run the unit tests: `jp test php packages/forms`

Verified live on a Jurassic Ninja site: the three buttons render as anchor / button / anchor exactly as above, and a real form submission created a response (0 → 1).

