### PR TITLE
Forms: fix form editor showing no block selected while the inserter is open

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-editor-no-block-selected
+++ b/projects/packages/forms/changelog/fix-forms-editor-no-block-selected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Form editor: keep the form block selected so the form settings sidebar stays reachable.

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -47,6 +47,7 @@ import {
 } from './utils/category-utils';
 import { getAllowedBlocks } from './utils/get-allowed-blocks';
 import { shouldAutoOpenInserter } from './utils/inserter-utils';
+import { shouldRunSelectionEnforcement } from './utils/selection-utils';
 import type { WPPlugin } from '@wordpress/plugins';
 
 type PluginSettings = Omit< WPPlugin, 'name' >;
@@ -567,7 +568,12 @@ const setupFormEditorSubscription = () => {
 			// 6. React to selection changes
 			const { getSelectedBlockClientId } = select( 'core/block-editor' );
 			const currentSelectedBlockId = getSelectedBlockClientId();
-			if ( currentSelectedBlockId !== state.lastSelectedBlockId ) {
+			if (
+				shouldRunSelectionEnforcement( {
+					selectedBlockId: currentSelectedBlockId,
+					lastSelectedBlockId: state.lastSelectedBlockId,
+				} )
+			) {
 				state.lastSelectedBlockId = currentSelectedBlockId;
 				enforceBlockSelection();
 			}

--- a/projects/packages/forms/src/form-editor/index.tsx
+++ b/projects/packages/forms/src/form-editor/index.tsx
@@ -47,7 +47,7 @@ import {
 } from './utils/category-utils';
 import { getAllowedBlocks } from './utils/get-allowed-blocks';
 import { shouldAutoOpenInserter } from './utils/inserter-utils';
-import { shouldRunSelectionEnforcement } from './utils/selection-utils';
+import { shouldRunSelectionEnforcement, shouldSelectFormBlock } from './utils/selection-utils';
 import type { WPPlugin } from '@wordpress/plugins';
 
 type PluginSettings = Omit< WPPlugin, 'name' >;
@@ -233,19 +233,12 @@ const enforceBlockSelection = () => {
 	}
 	const { getSelectedBlockClientId, hasMultiSelection } = select( 'core/block-editor' );
 
-	if ( hasMultiSelection() ) {
-		return;
-	}
-
-	// Don't force-select when the inserter is open — selecting a block
-	// can close the inserter or change its context.
-	const { isInserterOpened } = select( 'core/editor' );
-	if ( isInserterOpened() ) {
-		return;
-	}
-
-	const selectedBlockId = getSelectedBlockClientId();
-	if ( ! selectedBlockId ) {
+	if (
+		shouldSelectFormBlock( {
+			selectedBlockId: getSelectedBlockClientId(),
+			hasMultiSelection: hasMultiSelection(),
+		} )
+	) {
 		const { selectBlock } = dispatch( 'core/block-editor' ) as {
 			selectBlock: ( clientId: string ) => void;
 		};

--- a/projects/packages/forms/src/form-editor/utils/selection-utils.ts
+++ b/projects/packages/forms/src/form-editor/utils/selection-utils.ts
@@ -17,9 +17,10 @@ export interface SelectionEnforcementContext {
  * Determines whether a selection-enforcement pass should run on this tick.
  *
  * A changed selection always needs a pass. An empty selection needs one on every
- * tick, because enforcement can bail out (inserter open, multi-selection) on the
- * tick that first observes it — treating an already-empty selection as "no change"
- * would leave the form permanently deselected once the blocking condition cleared.
+ * tick, because enforcement can bail out on the tick that first observes it —
+ * either because the form block has not been located yet (editor still settling)
+ * or because a multi-selection is active. Treating an already-empty selection as
+ * "no change" would leave the form permanently deselected once that cleared.
  *
  * @param context - Current and previously observed selection
  * @return Whether enforcement should run

--- a/projects/packages/forms/src/form-editor/utils/selection-utils.ts
+++ b/projects/packages/forms/src/form-editor/utils/selection-utils.ts
@@ -1,0 +1,33 @@
+/**
+ * Selection utility functions
+ *
+ * Pure functions for determining form editor selection behavior with no side effects.
+ *
+ * @package
+ */
+
+export interface SelectionEnforcementContext {
+	/** The block currently selected in the editor, if any. */
+	selectedBlockId: string | null | undefined;
+	/** The selection observed on the previous subscribe tick. */
+	lastSelectedBlockId: string | null | undefined;
+}
+
+/**
+ * Determines whether a selection-enforcement pass should run on this tick.
+ *
+ * A changed selection always needs a pass. An empty selection needs one on every
+ * tick, because enforcement can bail out (inserter open, multi-selection) on the
+ * tick that first observes it — treating an already-empty selection as "no change"
+ * would leave the form permanently deselected once the blocking condition cleared.
+ *
+ * @param context - Current and previously observed selection
+ * @return Whether enforcement should run
+ */
+export function shouldRunSelectionEnforcement( context: SelectionEnforcementContext ): boolean {
+	if ( ! context.selectedBlockId ) {
+		return true;
+	}
+
+	return context.selectedBlockId !== context.lastSelectedBlockId;
+}

--- a/projects/packages/forms/src/form-editor/utils/selection-utils.ts
+++ b/projects/packages/forms/src/form-editor/utils/selection-utils.ts
@@ -31,3 +31,32 @@ export function shouldRunSelectionEnforcement( context: SelectionEnforcementCont
 
 	return context.selectedBlockId !== context.lastSelectedBlockId;
 }
+
+export interface FormBlockSelectionContext {
+	/** The block currently selected in the editor, if any. */
+	selectedBlockId: string | null | undefined;
+	/** Whether the editor currently holds a multi-block selection. */
+	hasMultiSelection: boolean;
+}
+
+/**
+ * Determines whether the form block should be force-selected right now.
+ *
+ * Deliberately independent of whether the inserter is open. Selecting a block
+ * neither closes the inserter nor changes where it inserts, and the inserter is
+ * open by default in the form editor — so skipping enforcement while it is open
+ * leaves the form deselected and its settings unreachable for the common case.
+ *
+ * A multi-selection is still respected: getSelectedBlockClientId() is null while
+ * one is active, and force-selecting would discard the user's range.
+ *
+ * @param context - Current selection state
+ * @return Whether the form block should be selected
+ */
+export function shouldSelectFormBlock( context: FormBlockSelectionContext ): boolean {
+	if ( context.hasMultiSelection ) {
+		return false;
+	}
+
+	return ! context.selectedBlockId;
+}

--- a/projects/packages/forms/tests/js/form-editor/utils/selection-utils.test.js
+++ b/projects/packages/forms/tests/js/form-editor/utils/selection-utils.test.js
@@ -5,7 +5,10 @@
  * should run a selection-enforcement pass on the current subscribe tick.
  */
 
-import { shouldRunSelectionEnforcement } from '../../../../src/form-editor/utils/selection-utils';
+import {
+	shouldRunSelectionEnforcement,
+	shouldSelectFormBlock,
+} from '../../../../src/form-editor/utils/selection-utils';
 
 describe( 'selection-utils', () => {
 	describe( 'shouldRunSelectionEnforcement', () => {
@@ -54,6 +57,46 @@ describe( 'selection-utils', () => {
 				shouldRunSelectionEnforcement( {
 					selectedBlockId: undefined,
 					lastSelectedBlockId: null,
+				} )
+			).toBe( true );
+		} );
+	} );
+
+	describe( 'shouldSelectFormBlock', () => {
+		test( 'returns true when no block is selected', () => {
+			expect(
+				shouldSelectFormBlock( {
+					selectedBlockId: null,
+					hasMultiSelection: false,
+				} )
+			).toBe( true );
+		} );
+
+		test( 'returns false when a block is already selected', () => {
+			expect(
+				shouldSelectFormBlock( {
+					selectedBlockId: 'block-1',
+					hasMultiSelection: false,
+				} )
+			).toBe( false );
+		} );
+
+		// getSelectedBlockClientId() is null during a multi-selection, so without this
+		// guard the form block would be force-selected and the user's range destroyed.
+		test( 'returns false during a multi-selection', () => {
+			expect(
+				shouldSelectFormBlock( {
+					selectedBlockId: null,
+					hasMultiSelection: true,
+				} )
+			).toBe( false );
+		} );
+
+		test( 'returns true when the selection is undefined', () => {
+			expect(
+				shouldSelectFormBlock( {
+					selectedBlockId: undefined,
+					hasMultiSelection: false,
 				} )
 			).toBe( true );
 		} );

--- a/projects/packages/forms/tests/js/form-editor/utils/selection-utils.test.js
+++ b/projects/packages/forms/tests/js/form-editor/utils/selection-utils.test.js
@@ -1,8 +1,9 @@
 /**
  * Tests for selection-utils
  *
- * These tests verify the pure function that decides whether the form editor
- * should run a selection-enforcement pass on the current subscribe tick.
+ * These tests verify the pure functions that decide whether the form editor
+ * should run a selection-enforcement pass on the current subscribe tick, and
+ * whether that pass should force-select the form block.
  */
 
 import {

--- a/projects/packages/forms/tests/js/form-editor/utils/selection-utils.test.js
+++ b/projects/packages/forms/tests/js/form-editor/utils/selection-utils.test.js
@@ -39,10 +39,11 @@ describe( 'selection-utils', () => {
 			).toBe( true );
 		} );
 
-		// Regression: enforcement can bail out (inserter open, multi-selection) on the
-		// tick that first observes the empty selection. If an already-empty selection
-		// were treated as "no change", the form block would never be re-selected once
-		// the blocking condition cleared, leaving the form settings unreachable.
+		// Regression: enforcement can bail out on the tick that first observes the empty
+		// selection — the form block may not be located yet, or a multi-selection may be
+		// active. If an already-empty selection were treated as "no change", the form
+		// block would never be re-selected once that cleared, leaving the settings
+		// unreachable.
 		test( 'returns true when the selection is still empty from a previous tick', () => {
 			expect(
 				shouldRunSelectionEnforcement( {

--- a/projects/packages/forms/tests/js/form-editor/utils/selection-utils.test.js
+++ b/projects/packages/forms/tests/js/form-editor/utils/selection-utils.test.js
@@ -1,0 +1,61 @@
+/**
+ * Tests for selection-utils
+ *
+ * These tests verify the pure function that decides whether the form editor
+ * should run a selection-enforcement pass on the current subscribe tick.
+ */
+
+import { shouldRunSelectionEnforcement } from '../../../../src/form-editor/utils/selection-utils';
+
+describe( 'selection-utils', () => {
+	describe( 'shouldRunSelectionEnforcement', () => {
+		test( 'returns true when a different block became selected', () => {
+			expect(
+				shouldRunSelectionEnforcement( {
+					selectedBlockId: 'block-2',
+					lastSelectedBlockId: 'block-1',
+				} )
+			).toBe( true );
+		} );
+
+		test( 'returns false when the same block is still selected', () => {
+			expect(
+				shouldRunSelectionEnforcement( {
+					selectedBlockId: 'block-1',
+					lastSelectedBlockId: 'block-1',
+				} )
+			).toBe( false );
+		} );
+
+		test( 'returns true when the selection was just cleared', () => {
+			expect(
+				shouldRunSelectionEnforcement( {
+					selectedBlockId: null,
+					lastSelectedBlockId: 'block-1',
+				} )
+			).toBe( true );
+		} );
+
+		// Regression: enforcement can bail out (inserter open, multi-selection) on the
+		// tick that first observes the empty selection. If an already-empty selection
+		// were treated as "no change", the form block would never be re-selected once
+		// the blocking condition cleared, leaving the form settings unreachable.
+		test( 'returns true when the selection is still empty from a previous tick', () => {
+			expect(
+				shouldRunSelectionEnforcement( {
+					selectedBlockId: null,
+					lastSelectedBlockId: null,
+				} )
+			).toBe( true );
+		} );
+
+		test( 'returns true on the first tick, when nothing has been observed yet', () => {
+			expect(
+				shouldRunSelectionEnforcement( {
+					selectedBlockId: undefined,
+					lastSelectedBlockId: null,
+				} )
+			).toBe( true );
+		} );
+	} );
+} );


### PR DESCRIPTION
## Proposed changes

* Fix the standalone form editor (`jetpack_form`) ending up with **no block selected**, which makes the form's settings unreachable — the Block tab just says "No block selected".

Two things combined to cause this, both in `src/form-editor/index.tsx`:

**1. `enforceBlockSelection()` skipped its work whenever the inserter was open.**

```js
// Don't force-select when the inserter is open — selecting a block
// can close the inserter or change its context.
if ( isInserterOpened() ) {
    return;
}
```

That premise doesn't hold. Verified in a live editor: `selectBlock()` does not close the inserter, and it does not change where the inserter inserts (a block added from the open inserter still lands inside the form, root block count unchanged). Since the inserter *auto-opens on load* in the form editor, this guard was disabled exactly when it mattered most — deselecting while the inserter was open left the form deselected and its settings unreachable, which is the state users actually hit.

The guard is removed. The multi-selection guard is kept and is now explicit — `getSelectedBlockClientId()` is null during a multi-selection, so force-selecting would discard the user's range.

**2. The caller latched the observed selection before enforcement could act.**

```js
if ( currentSelectedBlockId !== state.lastSelectedBlockId ) {
    state.lastSelectedBlockId = currentSelectedBlockId;   // latched to null…
    enforceBlockSelection();                              // …which then bailed out
}
```

A `null` selection arriving during any bail-out was consumed by the latch and never retried — on later ticks `null === state.lastSelectedBlockId`, so enforcement never ran again. Enforcement now runs on every tick while the selection is empty, so it retries until it can act. It self-terminates as soon as it succeeds, since the selection is then non-null.

Both decisions are extracted into pure helpers in `utils/selection-utils.ts` (`shouldRunSelectionEnforcement`, `shouldSelectFormBlock`) with unit tests, matching the existing `inserter-utils` / `block-nesting-logic` pattern.

The inserter guard was introduced in #47413, together with the auto-open-inserter behaviour.

### Intentional behaviour change

**You can no longer end up with nothing selected in the form editor.** Any empty selection is immediately reclaimed by the form block (an active multi-selection is still respected). This is the module's stated purpose — its header comment reads *"Keeps the form block selected"* — but previously it did not hold while the inserter was open, so this is a real change from current behaviour and is worth reviewing as a deliberate choice.

Checked and found not to be a problem: because `selectBlock()` places the caret in the block, this could in theory steal focus from the post title. It does not — the title is itself a block, and focus stays in it while the form block holds block-selection, so the title remains editable.

### Known limitation

The new tests cover both pure helpers, but the bug this PR fixes lived in the *wiring* inside `enforceBlockSelection` — a guard sitting between the store reads and the helper. Re-introducing such a guard would break the feature with the whole suite still green. Locking that down needs an integration-level test with a mocked `@wordpress/data`, which is heavier than this package's current test conventions; the intent is documented in the `shouldSelectFormBlock` docblock instead. Flagging it explicitly rather than leaving it implicit.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Open **Jetpack → Forms** and edit (or create) a form. The block inserter opens automatically on load — leave it open.
* Click the empty canvas whitespace to the left or right of the form block.
* **Before this change:** nothing is selected, the Block tab reads "No block selected", and there is no way back to the form's settings short of the List View. It stays that way even after closing the inserter.
* **After this change:** the form block stays selected, and its settings remain reachable.
* Confirm the inserter is **not** closed by this — it should stay open the whole time.
* Confirm inserting a field from the open inserter still lands **inside** the form, not as a sibling.
* Select two or more field blocks (click one, shift-click another) and confirm the multi-selection is preserved rather than being collapsed back to the form block.
* Confirm the form title is still editable — click it and type.
