### PR TITLE
Stats: cast post IDs to integers when building the post views query

### DIFF
--- a/projects/packages/stats-admin/changelog/fix-stats-post-id-integer-casting
+++ b/projects/packages/stats-admin/changelog/fix-stats-post-id-integer-casting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Cast the quick-edit post ID to an integer before requesting its view counts.

--- a/projects/packages/stats-admin/src/class-admin-post-list-column.php
+++ b/projects/packages/stats-admin/src/class-admin-post-list-column.php
@@ -235,7 +235,7 @@ class Admin_Post_List_Column {
 		if ( $wp_query->posts ) {
 			$post_ids = wp_list_pluck( $wp_query->posts, 'ID' );
 		} elseif ( wp_doing_ajax() && ! empty( $_POST['action'] ) && 'inline-save' === $_POST['action'] && ! empty( $_POST['post_ID'] ) && check_ajax_referer( 'inlineeditnonce', '_inline_edit' ) ) {
-			$post_ids = array( sanitize_text_field( wp_unslash( $_POST['post_ID'] ) ) );
+			$post_ids = array( absint( wp_unslash( $_POST['post_ID'] ) ) );
 		} else {
 			return array();
 		}

--- a/projects/packages/stats/changelog/fix-stats-post-id-integer-casting
+++ b/projects/packages/stats/changelog/fix-stats-post-id-integer-casting
@@ -1,0 +1,4 @@
+Significance: patch
+Type: security
+
+Ensure post IDs are cast to integers before they are used in the post views query on Simple sites.

--- a/projects/packages/stats/src/class-wpcom-stats.php
+++ b/projects/packages/stats/src/class-wpcom-stats.php
@@ -338,8 +338,8 @@ class WPCOM_Stats {
 	 */
 	public function get_total_post_views( $args = array() ) {
 		if ( $this->is_wpcom_simple ) {
-			$post_ids         = isset( $args['post_ids'] ) ? explode( ',', $args['post_ids'] ) : array();
-			$escaped_post_ids = implode( ',', array_map( 'esc_sql', $post_ids ) );
+			$post_ids         = isset( $args['post_ids'] ) ? array_map( 'absint', explode( ',', $args['post_ids'] ) ) : array();
+			$escaped_post_ids = implode( ',', $post_ids );
 
 			$number_of_days = isset( $args['num'] ) ? absint( $args['num'] ) : 1;
 			// It's the same function used in WPCOM simple.

--- a/projects/packages/stats/tests/php/WPCOM_Stats_Test.php
+++ b/projects/packages/stats/tests/php/WPCOM_Stats_Test.php
@@ -580,6 +580,35 @@ class WPCOM_Stats_Test extends StatsBaseTestCase {
 	}
 
 	/**
+	 * Test that get_total_post_views casts post IDs to integers before they reach the query on Simple sites.
+	 *
+	 * @return void
+	 */
+	public function test_get_total_post_views_casts_post_ids_to_integers_on_simple_sites() {
+		$reflection = new \ReflectionClass( $this->wpcom_stats );
+		$property   = $reflection->getProperty( 'is_wpcom_simple' );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( $this->wpcom_stats, true );
+
+		// A non-integer post_ids value must be reduced to integers before it reaches the query.
+		$this->wpcom_stats->expects( $this->once() )
+					->method( 'fetch_stats_on_wpcom_simple' )
+					->with( '2025-03-07', 1, '1,2' )
+					->willReturn( array( '-' => array() ) );
+
+		$args = array(
+			'post_ids' => '1abc,2def',
+			'end'      => '2025-03-07',
+			'num'      => 1,
+		);
+
+		$this->wpcom_stats->get_total_post_views( $args );
+	}
+
+	/**
 	 * Test get_visits.
 	 */
 	public function test_get_visits() {


### PR DESCRIPTION
## Proposed changes

* Cast post IDs to integers with `absint()` before they are used in the post views query — in both the `jetpack-stats` query builder and the `jetpack-stats-admin` quick-edit handler.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run `jp test php packages/stats` and `jp test php packages/stats-admin` — all tests pass.
