### PR TITLE
Premium Analytics: fit the metric tile in a height-1 widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1846-metric-tile-short-cells
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1846-metric-tile-short-cells
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Metric tiles: fit the value inside the tile at the minimum widget height.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tile/metric-tile-grid.module.scss
@@ -2,6 +2,8 @@ $metric-tile-grid-wide-min-inline-size: 640px;
 // Height at which a wide cell has room for a balanced two-row grid instead of a
 // single row of tiles. Tunable — below this, wide cells stay one row.
 $metric-tile-grid-grid-min-block-size: 360px;
+// Between a height-1 widget body (~110px) and a height-2 one (~300px).
+$metric-tile-grid-short-max-block-size: 140px;
 $metric-tile-grid-row-value-font-size-max: 40px;
 // The design spec pins highlight-tile values at 32px.
 $metric-tile-grid-tile-value-font-size: 32px;
@@ -138,6 +140,20 @@ $metric-tile-grid-large-row-min-block-size: calc(var(--wpds-typography-line-heig
 	.tile .value,
 	.tile .placeholder {
 		font-size: $metric-tile-grid-tile-value-font-size;
+	}
+}
+
+/* Wide but height-1 short: keep the columns — stacked rows are taller past one
+ * tile — and tighten the tile so the value still fits. */
+@container (min-width: #{$metric-tile-grid-wide-min-inline-size}) and (max-height: #{$metric-tile-grid-short-max-block-size}) {
+
+	.tile {
+		padding-block: var(--wpds-dimension-padding-sm);
+	}
+
+	.tile .value,
+	.tile .placeholder {
+		line-height: 1;
 	}
 }
 


### PR DESCRIPTION
## Proposed changes

- Reduce vertical padding and value line height for wide `MetricTileGrid` tiles in one-row cells so they fit within 200px widgets.
- Keep the existing spacing for cells two or more rows tall.

This is the toolkit portion of WOOA7S-1846. The Annual Highlights UI adjustments will follow separately.

## Related product discussion/links

- WOOA7S-1846

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Run Storybook: `cd projects/js-packages/storybook && pnpm run storybook:dev`.
- Open **Packages/Premium Analytics/Widgets/AllTimeStats → WidgetDashboardWithWidget**.
- Set `rowHeight` to `200`, `widgetWidth` to `4`, and `widgetHeight` to `1`. Confirm all four tiles and their values fit within their borders.
- Set `widgetHeight` to `2` and confirm the tiles retain their roomier spacing.
- Set `rowHeight` to `400` and confirm the two-column layout is unchanged.
