### PR TITLE
Newsletter: make the post-publish email confirmation more visible

### DIFF
--- a/projects/plugins/jetpack/changelog/newsletter-post-publish-visibility
+++ b/projects/plugins/jetpack/changelog/newsletter-post-publish-visibility
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Newsletter: Make the post-publish email confirmation more visible.

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.jsx
@@ -17,7 +17,6 @@ import {
 import { useLayoutEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { external, Icon } from '@wordpress/icons';
-import { store as noticesStore } from '@wordpress/notices';
 import {
 	accessOptions,
 	META_NAME_FOR_POST_DONT_EMAIL_TO_SUBS,
@@ -27,9 +26,7 @@ import {
 	NewsletterAccessDocumentSettings,
 	NewsletterEmailDocumentSettings,
 } from '../../shared/memberships/settings';
-import SubscribersAffirmation, {
-	getJetpackEmailStatsLink,
-} from '../../shared/memberships/subscribers-affirmation';
+import SubscribersAffirmation from '../../shared/memberships/subscribers-affirmation';
 import {
 	getShowMisconfigurationWarning,
 	MisconfigurationWarning,
@@ -52,8 +49,6 @@ function NewsletterRepublishTracker() {
 		setPublishedWithEmailEnabledInSession: dispatchPublishedWithEmail,
 		setAlreadySentPostModifiedInSession: dispatchModifiedAlreadySent,
 	} = useDispatch( membershipProductsStore );
-	const { createSuccessNotice } = useDispatch( noticesStore );
-	const blogId = window.Jetpack_Editor_Initial_State?.wpcomBlogId;
 
 	const { postId, postMeta, postEmailSentState, status, isSavingPost } = useSelect( select => {
 		const { getCurrentPost, getEditedPostAttribute } = select( editorStore );
@@ -79,19 +74,6 @@ function NewsletterRepublishTracker() {
 				if ( didTransition ) {
 					if ( ! postMeta?.[ META_NAME_FOR_POST_DONT_EMAIL_TO_SUBS ] ) {
 						dispatchPublishedWithEmail( postId );
-						// The post-publish panel is easy to miss, so confirm the send where the
-						// eye already is. The core "Post published." snackbar fires alongside
-						// this one, so the copy covers only the email to avoid repeating it.
-						// Snackbars take at most one action, hence the single link.
-						createSuccessNotice?.( __( 'Emailed to your subscribers.', 'jetpack' ), {
-							type: 'snackbar',
-							actions: [
-								{
-									label: __( 'View delivery details', 'jetpack' ),
-									url: getJetpackEmailStatsLink( blogId, postId ),
-								},
-							],
-						} );
 					}
 				}
 			}
@@ -108,8 +90,6 @@ function NewsletterRepublishTracker() {
 		postMeta,
 		dispatchPublishedWithEmail,
 		dispatchModifiedAlreadySent,
-		createSuccessNotice,
-		blogId,
 	] );
 
 	return null;

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.jsx
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.jsx
@@ -17,6 +17,7 @@ import {
 import { useLayoutEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { external, Icon } from '@wordpress/icons';
+import { store as noticesStore } from '@wordpress/notices';
 import {
 	accessOptions,
 	META_NAME_FOR_POST_DONT_EMAIL_TO_SUBS,
@@ -26,7 +27,9 @@ import {
 	NewsletterAccessDocumentSettings,
 	NewsletterEmailDocumentSettings,
 } from '../../shared/memberships/settings';
-import SubscribersAffirmation from '../../shared/memberships/subscribers-affirmation';
+import SubscribersAffirmation, {
+	getJetpackEmailStatsLink,
+} from '../../shared/memberships/subscribers-affirmation';
 import {
 	getShowMisconfigurationWarning,
 	MisconfigurationWarning,
@@ -49,6 +52,8 @@ function NewsletterRepublishTracker() {
 		setPublishedWithEmailEnabledInSession: dispatchPublishedWithEmail,
 		setAlreadySentPostModifiedInSession: dispatchModifiedAlreadySent,
 	} = useDispatch( membershipProductsStore );
+	const { createSuccessNotice } = useDispatch( noticesStore );
+	const blogId = window.Jetpack_Editor_Initial_State?.wpcomBlogId;
 
 	const { postId, postMeta, postEmailSentState, status, isSavingPost } = useSelect( select => {
 		const { getCurrentPost, getEditedPostAttribute } = select( editorStore );
@@ -74,6 +79,19 @@ function NewsletterRepublishTracker() {
 				if ( didTransition ) {
 					if ( ! postMeta?.[ META_NAME_FOR_POST_DONT_EMAIL_TO_SUBS ] ) {
 						dispatchPublishedWithEmail( postId );
+						// The post-publish panel is easy to miss, so confirm the send where the
+						// eye already is. The core "Post published." snackbar fires alongside
+						// this one, so the copy covers only the email to avoid repeating it.
+						// Snackbars take at most one action, hence the single link.
+						createSuccessNotice?.( __( 'Emailed to your subscribers.', 'jetpack' ), {
+							type: 'snackbar',
+							actions: [
+								{
+									label: __( 'View delivery details', 'jetpack' ),
+									url: getJetpackEmailStatsLink( blogId, postId ),
+								},
+							],
+						} );
 					}
 				}
 			}
@@ -90,6 +108,8 @@ function NewsletterRepublishTracker() {
 		postMeta,
 		dispatchPublishedWithEmail,
 		dispatchModifiedAlreadySent,
+		createSuccessNotice,
+		blogId,
 	] );
 
 	return null;
@@ -214,6 +234,7 @@ function NewsletterPostPublishSettingsPanel( { accessLevel } ) {
 	return (
 		<>
 			<PluginPostPublishPanel
+				initialOpen
 				title={ __( 'Newsletter', 'jetpack' ) }
 				className="jetpack-subscribe-newsletters-panel jetpack-subscribe-post-publish-panel"
 				icon={ <JetpackEditorPanelLogo /> }

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.scss
@@ -37,6 +37,33 @@
 	}
 }
 
+// The post-publish panel renders after the core "is now live" header and the
+// "What's next?" block, so the email confirmation is easy to scroll past. A
+// single highlight pass draws the eye to it, without a global notice's noise.
+.jetpack-subscribe-post-publish-panel {
+	animation: jetpack-subscribe-post-publish-highlight 2s ease-out 1;
+
+	@media (prefers-reduced-motion: reduce) {
+		animation: none;
+	}
+}
+
+@keyframes jetpack-subscribe-post-publish-highlight {
+
+	0% {
+		background-color: transparent;
+	}
+
+	// Jetpack green, kept faint so body copy stays readable.
+	15% {
+		background-color: rgba(6, 158, 8, 0.12);
+	}
+
+	100% {
+		background-color: transparent;
+	}
+}
+
 .paid-newsletters-post-publish-panel {
 
 	&__external_icon {

--- a/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.scss
+++ b/projects/plugins/jetpack/extensions/blocks/subscriptions/panel.scss
@@ -50,17 +50,9 @@
 
 @keyframes jetpack-subscribe-post-publish-highlight {
 
-	0% {
-		background-color: transparent;
-	}
-
 	// Jetpack green, kept faint so body copy stays readable.
 	15% {
 		background-color: rgba(6, 158, 8, 0.12);
-	}
-
-	100% {
-		background-color: transparent;
 	}
 }
 


### PR DESCRIPTION
Fixes NL-798

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Open the Newsletter post-publish panel by default (`initialOpen`). The "Set up a paid newsletter" panel stays collapsed.
* Add a single highlight pass over the panel when it appears, on Jetpack's own class and gated on `prefers-reduced-motion: reduce`.
* No new status UI was needed: the panel already reports whether the email is sending, sent, or was skipped, with a link to delivery details. It was simply never seen, because it started collapsed.
* A snackbar confirming the send was tried and removed — on a live site it stacked under core's own "Post published." notice and read as noise.
* No core changes: `PluginPostPublishPanel` fills always render last inside `.post-publish-panel__postpublish`, and no slot or filter can place content nearer the "is now live" header.
* Known gap, not fixed here: `isPublishedWithoutEmail` never checks `isSendEmailEnabled()`, so a still-queued email 15+ minutes after publish reports "This post was published without sending an email… move the post to draft… and republish." That advice would send it twice. Expanding the panel makes this copy far more visible, so it wants its own fix.

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Use a site with Jetpack connected to WordPress.com and the Newsletter (`subscriptions`) module active. This cannot be tested on a local Docker site: `localhost` forces Jetpack offline mode, and the module declares `Requires Connection: Yes`, so it refuses to activate.
* Go to Posts &rarr; Add New, write a post, leave the Newsletter access at its default and keep "Post and email" enabled.
* Publish, then check the post-publish sidebar:
  * The **Newsletter** panel is expanded and shows the send status ("This post is being emailed to…").
  * The panel briefly highlights as it appears.
  * Only core's own "Post published." notice appears — no second notice from Jetpack.
* Publish a second post with "Post and email" turned off, and confirm the panel reports the post was not emailed.
* Enable "Reduce motion" in your OS accessibility settings, publish again, and confirm the highlight does not animate.
