### PR TITLE
Newsletter: remove the misleading "Joined" field from the subscriber profile

### DIFF
--- a/projects/packages/newsletter/_inc/subscribers/components/detail/subscriber-detail-content.tsx
+++ b/projects/packages/newsletter/_inc/subscribers/components/detail/subscriber-detail-content.tsx
@@ -291,10 +291,6 @@ export default function SubscriberDetailContent( { open }: Props ): JSX.Element 
 			<DetailSection title={ __( 'Subscriber information', 'jetpack-newsletter' ) }>
 				<Stack direction="column" gap="md">
 					<DetailRow
-						label={ __( 'Joined', 'jetpack-newsletter' ) }
-						value={ formatDate( stats?.blog_registration_date ) }
-					/>
-					<DetailRow
 						label={ __( 'Email', 'jetpack-newsletter' ) }
 						value={ subscriber.email_address }
 					/>

--- a/projects/packages/newsletter/_inc/subscribers/data/types.ts
+++ b/projects/packages/newsletter/_inc/subscribers/data/types.ts
@@ -168,5 +168,4 @@ export type SubscriberStats = {
 	emails_sent: number;
 	unique_opens: number;
 	unique_clicks: number;
-	blog_registration_date?: string;
 };

--- a/projects/packages/newsletter/changelog/nl-811-remove-joined-field
+++ b/projects/packages/newsletter/changelog/nl-811-remove-joined-field
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Subscribers: remove the misleading "Joined" field from the subscriber profile, which showed the site's creation date rather than a per-subscriber date.

--- a/projects/packages/newsletter/changelog/nl-811-remove-joined-field
+++ b/projects/packages/newsletter/changelog/nl-811-remove-joined-field
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Subscribers: remove the misleading "Joined" field from the subscriber profile, which showed the site's creation date rather than a per-subscriber date.
+Subscribers: Remove the misleading "Joined" field from the subscriber profile, which showed the site's creation date rather than a per-subscriber date.


### PR DESCRIPTION
Fixes NL-811

## Proposed changes
* Remove the "Joined" row from the **Subscriber information** section of the subscriber profile. It was bound to `blog_registration_date`, which the wpcom `individual-subscriber-stats` endpoint populates from `get_blog_details()->registered` — a per-*blog* value that takes no subscriber argument. As a result every subscriber on a site showed the exact same date (the site's creation date) under a label that reads as "when this person subscribed".
* The genuine per-subscriber date is already displayed as **"Date subscribed"** in the *Newsletter subscription details* section, so the row is dropped rather than relabelled — a "Site created" row adds nothing for a site owner who already knows when they created their site.
* Drop the now-unused `blog_registration_date` field from the `SubscriberStats` type. Nothing else in the monorepo consumed it. The Jetpack proxy endpoint (`class-wpcom-rest-api-v2-endpoint-subscribers-list.php`) passes the wpcom response through without enumerating fields, so it needs no change; removing the field from the wpcom endpoint itself is a separate, optional follow-up.

## Related product discussion/links
* https://linear.app/a8c/issue/NL-811/subscriber-profile-remove-the-misleading-joined-field-it-shows-the

## Does this pull request change what data or activity we track or use?
No. This removes the display of an already-fetched field; no new data is collected or tracked.

## Testing instructions

* Set up a site with the Newsletter subscribers UI available, with at least two subscribers who subscribed on different dates.
* Go to the Subscribers screen and open a subscriber's profile.
* Confirm the **Subscriber information** section no longer shows a "Joined" row. It should start with "Email", followed by "Country", "Site", etc.
* Confirm the **Newsletter subscription details** section still shows **"Date subscribed"** with that subscriber's own subscription date.
* Open a second subscriber's profile and confirm "Date subscribed" differs between the two (before this change, "Joined" was identical on both — the site's creation date).
* Confirm the stat tiles at the top (Emails sent, Open rate, Click rate) still render correctly, since they come from the same `individual-subscriber-stats` request.
