### PR TITLE
Build: raise the build_wpcom timeout for trunk builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,7 +193,7 @@ jobs:
       CHANGED: ${{ fromJson( needs.prepare.outputs.build_matrix ).wpcom.changed }}
       # Hard-code a specific directory to avoid paths in vendor/composer/installed.json changing every build.
       BUILD_BASE: /tmp/jetpack-build
-    timeout-minutes: 25  # 2026-04-07: Successful runs seem to take ~15 minutes.
+    timeout-minutes: 40  # 2026-08-05: Trunk pushes build the full wpcom half, which now takes over 25 minutes.
     steps: *build_steps
 
   build_nonwpcom:


### PR DESCRIPTION
## Proposed changes

Raise `timeout-minutes` on the `build_wpcom` job in `.github/workflows/build.yml` from 25 to 40, and refresh the stale comment next to it. Same change and same reason as #51029, which covered `build_all` but deliberately left the split jobs alone for lack of evidence. The evidence arrived a few hours after it merged.

Every trunk push builds the whole monorepo split into `build_wpcom` and `build_nonwpcom` (see the comment in the `prepare` job). Since #50509 landed, the wpcom half takes more than 25 minutes, so the job is cancelled at its cap on every trunk push: run [30993937046](https://github.com/Automattic/jetpack/actions/runs/30993937046) died at 25m21s, and the follow-up run for the next trunk commit did the same. While that holds, `Push wpcom plugins to mirror repos` and `Push to mirror repos` never run and every mirror repo stays frozen at the last pre-#50509 state, which blocks the wpcomsh rolling releases and everything else that deploys from the mirrors.

`build_nonwpcom` finished in 14m53s on the same run, so its 25-minute value keeps a healthy margin and stays as is.

The mirror pipeline self-heals once this merges: trunk builds cover the full tree, so the first green run pushes all mirrors up to date.

## Related product discussion/links

* #51029
* WordPress/gutenberg#79889 (the upstream esbuild concurrency cap that gives the real headroom back)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Nothing to test on a site. Confirm the diff touches only the `build_wpcom` timeout in `.github/workflows/build.yml`. The value proves itself on the first trunk push after merge: `Build wpcom projects` should complete in roughly 26 to 30 minutes and the two mirror-push jobs should run.
