### PR TITLE
VideoPress: update admin dashboard subtitle copy

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-dashboard-subtitle-copy
+++ b/projects/packages/videopress/changelog/update-videopress-dashboard-subtitle-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Dashboard: Update the admin page subtitle copy.

--- a/projects/packages/videopress/src/dashboard/components/connection-gate/connect-screen.tsx
+++ b/projects/packages/videopress/src/dashboard/components/connection-gate/connect-screen.tsx
@@ -27,7 +27,7 @@ export default function ConnectScreen( { onConnect, isConnecting }: Props ) {
 		<AdminPage
 			title={ 'VideoPress' /* product name; not translated */ }
 			subTitle={ __(
-				'Host, manage, customize, and track your videos—all in one place.',
+				'Host, manage, customize, and track your videos — all in one place.',
 				'jetpack-videopress-pkg'
 			) }
 		>

--- a/projects/packages/videopress/src/dashboard/components/connection-gate/connect-screen.tsx
+++ b/projects/packages/videopress/src/dashboard/components/connection-gate/connect-screen.tsx
@@ -26,7 +26,10 @@ export default function ConnectScreen( { onConnect, isConnecting }: Props ) {
 	return (
 		<AdminPage
 			title={ 'VideoPress' /* product name; not translated */ }
-			subTitle={ __( 'Professional quality, ad-free video hosting.', 'jetpack-videopress-pkg' ) }
+			subTitle={ __(
+				'Host, manage, customize, and track your videos—all in one place.',
+				'jetpack-videopress-pkg'
+			) }
 		>
 			<Stack direction="column" gap="md" className="vp-connection-gate">
 				<Text variant="heading-2xl">

--- a/projects/packages/videopress/src/dashboard/components/connection-gate/pricing-upsell.tsx
+++ b/projects/packages/videopress/src/dashboard/components/connection-gate/pricing-upsell.tsx
@@ -62,7 +62,10 @@ export default function PricingUpsell() {
 	return (
 		<AdminPage
 			title={ 'VideoPress' /* product name; not translated */ }
-			subTitle={ __( 'Professional quality, ad-free video hosting.', 'jetpack-videopress-pkg' ) }
+			subTitle={ __(
+				'Host, manage, customize, and track your videos—all in one place.',
+				'jetpack-videopress-pkg'
+			) }
 		>
 			<div className="vp-connection-gate__upsell">
 				<PricingTable title={ title } items={ pricingItems }>

--- a/projects/packages/videopress/src/dashboard/components/connection-gate/pricing-upsell.tsx
+++ b/projects/packages/videopress/src/dashboard/components/connection-gate/pricing-upsell.tsx
@@ -63,7 +63,7 @@ export default function PricingUpsell() {
 		<AdminPage
 			title={ 'VideoPress' /* product name; not translated */ }
 			subTitle={ __(
-				'Host, manage, customize, and track your videos—all in one place.',
+				'Host, manage, customize, and track your videos — all in one place.',
 				'jetpack-videopress-pkg'
 			) }
 		>

--- a/projects/packages/videopress/src/dashboard/components/dashboard-layout/index.tsx
+++ b/projects/packages/videopress/src/dashboard/components/dashboard-layout/index.tsx
@@ -52,7 +52,7 @@ export default function DashboardLayout( { activeTab, children, actions, hideFoo
 		<AdminPage
 			title={ 'VideoPress' /* product name; not translated */ }
 			subTitle={ __(
-				'Host, manage, customize, and track your videos—all in one place.',
+				'Host, manage, customize, and track your videos — all in one place.',
 				'jetpack-videopress-pkg'
 			) }
 			actions={ actions }

--- a/projects/packages/videopress/src/dashboard/components/dashboard-layout/index.tsx
+++ b/projects/packages/videopress/src/dashboard/components/dashboard-layout/index.tsx
@@ -51,7 +51,10 @@ export default function DashboardLayout( { activeTab, children, actions, hideFoo
 	return (
 		<AdminPage
 			title={ 'VideoPress' /* product name; not translated */ }
-			subTitle={ __( 'Professional quality, ad-free video hosting.', 'jetpack-videopress-pkg' ) }
+			subTitle={ __(
+				'Host, manage, customize, and track your videos—all in one place.',
+				'jetpack-videopress-pkg'
+			) }
 			actions={ actions }
 			showFooter={ ! hideFooter }
 		>


### PR DESCRIPTION
Fixes #

## Proposed changes

* Update the VideoPress admin page header subtitle from "Professional quality, ad-free video hosting." to "Host, manage, customize, and track your videos — all in one place."
* The subtitle is rendered in three places that share the same `AdminPage` header chrome, all updated for consistency: the connected dashboard layout, the pre-connection connect screen, and the pre-connection pricing upsell.

## Related product discussion/links

* JETPACK-1890

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build the package: `jetpack build packages/videopress --deps`
* On a Jetpack-connected test site, go to wp-admin → Jetpack → VideoPress.
* Confirm the page header subtitle under the "VideoPress" title reads "Host, manage, customize, and track your videos — all in one place."
* Optional: on a disconnected site, visit the same page and confirm the connect screen (and pricing upsell, when pricing data is available) shows the same updated subtitle in its header.
