### PR TITLE
[not for merge] Benchmark: wp-build esbuild concurrency limit (patched onto 0.20.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,7 +119,7 @@ jobs:
       # below this runner's core count (4), so the cap from
       # https://github.com/WordPress/gutenberg/pull/79889 actually constrains
       # something. At its default the cap equals the core count and is a no-op.
-      WP_BUILD_CONCURRENCY: 2
+      WP_BUILD_CONCURRENCY: 1
     # TEMPORARY, benchmark only: raised from 40. Halving concurrency is expected
     # to make this slower, and a timeout would waste the run.
     timeout-minutes: 90

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,7 +115,14 @@ jobs:
       CHANGED: ${{ fromJson( needs.prepare.outputs.build_matrix ).all.changed }}
       # Hard-code a specific directory to avoid paths in vendor/composer/installed.json changing every build.
       BUILD_BASE: /tmp/jetpack-build
-    timeout-minutes: 40  # 2026-08-04: PRs that rebuild every project take ~26 minutes.
+      # TEMPORARY, benchmark only: force the wp-build esbuild concurrency limit
+      # below this runner's core count (4), so the cap from
+      # https://github.com/WordPress/gutenberg/pull/79889 actually constrains
+      # something. At its default the cap equals the core count and is a no-op.
+      WP_BUILD_CONCURRENCY: 2
+    # TEMPORARY, benchmark only: raised from 40. Halving concurrency is expected
+    # to make this slower, and a timeout would waste the run.
+    timeout-minutes: 90
 
     steps: &build_steps
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.pnpm-patches/@wordpress__build.patch
+++ b/.pnpm-patches/@wordpress__build.patch
@@ -1,8 +1,479 @@
+diff --git a/lib/build-concurrency.mjs b/lib/build-concurrency.mjs
+new file mode 100644
+index 0000000..f793eca
+--- /dev/null
++++ b/lib/build-concurrency.mjs
+@@ -0,0 +1,118 @@
++/**
++ * External dependencies
++ */
++import os from 'node:os';
++import esbuild from 'esbuild';
++
++const MIN_DEFAULT_BUILD_CONCURRENCY = 2;
++const MAX_DEFAULT_BUILD_CONCURRENCY = 16;
++
++/**
++ * @typedef {Object} QueuedBuild
++ * @property {() => Promise<unknown> | unknown} task    Task to run.
++ * @property {(value: unknown) => void}         resolve Promise resolver.
++ * @property {(reason?: unknown) => void}       reject  Promise rejecter.
++ */
++
++let buildConcurrency = MIN_DEFAULT_BUILD_CONCURRENCY;
++let activeBuilds = 0;
++/** @type {QueuedBuild[]} */
++const queuedBuilds = [];
++
++/**
++ * Get the default number of concurrent esbuild builds.
++ *
++ * @param {number} availableParallelism Available parallelism to use.
++ * @return {number} Default build concurrency.
++ */
++export function getDefaultBuildConcurrency(
++	availableParallelism = os.availableParallelism()
++) {
++	return Math.max(
++		MIN_DEFAULT_BUILD_CONCURRENCY,
++		Math.min( MAX_DEFAULT_BUILD_CONCURRENCY, availableParallelism )
++	);
++}
++
++/**
++ * Parse a concurrency override.
++ *
++ * @param {string|undefined} value Concurrency override value.
++ * @return {number|undefined} Parsed concurrency, or undefined when unset.
++ */
++export function parseBuildConcurrency( value ) {
++	if ( value === undefined ) {
++		return undefined;
++	}
++
++	if ( ! /^\d+$/.test( value ) || Number( value ) === 0 ) {
++		console.warn(
++			`Invalid build concurrency value: ${ JSON.stringify(
++				value
++			) }. Expected a positive integer; falling back to the default.`
++		);
++		return undefined;
++	}
++
++	return Number( value );
++}
++
++/**
++ * Set the maximum number of concurrent esbuild builds.
++ *
++ * @param {number} concurrency Build concurrency.
++ */
++export function setBuildConcurrency( concurrency ) {
++	buildConcurrency = concurrency;
++	runNextBuilds();
++}
++
++/**
++ * Runs an esbuild build while respecting the global wp-build concurrency limit.
++ *
++ * @param {import('esbuild').BuildOptions} buildOptions Esbuild build options.
++ * @return {Promise<import('esbuild').BuildResult>} Esbuild build result.
++ */
++export function buildWithConcurrency( buildOptions ) {
++	return enqueueBuild( () => esbuild.build( buildOptions ) );
++}
++
++/**
++ * Runs an arbitrary async task while respecting the build concurrency limit.
++ *
++ * @template T
++ * @param {() => Promise<T> | T} task Task to run.
++ * @return {Promise<T>} Task result.
++ */
++export function enqueueBuild( task ) {
++	return new Promise( ( resolve, reject ) => {
++		queuedBuilds.push( {
++			task,
++			resolve: ( value ) =>
++				resolve( /** @type {T | PromiseLike<T>} */ ( value ) ),
++			reject,
++		} );
++		runNextBuilds();
++	} );
++}
++
++/**
++ * Starts queued build tasks while capacity is available.
++ */
++function runNextBuilds() {
++	while ( activeBuilds < buildConcurrency && queuedBuilds.length > 0 ) {
++		const queuedBuild = queuedBuilds.shift();
++		if ( ! queuedBuild ) {
++			return;
++		}
++		const { task, resolve, reject } = queuedBuild;
++		activeBuilds++;
++		Promise.resolve()
++			.then( task )
++			.then( resolve, reject )
++			.finally( () => {
++				activeBuilds--;
++				runNextBuilds();
++			} );
++	}
++}
+diff --git a/lib/build.mjs b/lib/build.mjs
+index 83abe1a..8644114 100755
+--- a/lib/build.mjs
++++ b/lib/build.mjs
+@@ -8,7 +8,6 @@ import path from 'path';
+ import { createHash } from 'node:crypto';
+ import { createRequire as createNodeRequire } from 'node:module';
+ import { parseArgs } from 'node:util';
+-import esbuild from 'esbuild';
+ import glob from 'fast-glob';
+ import chokidar from 'chokidar';
+ import browserslistToEsbuild from 'browserslist-to-esbuild';
+@@ -73,6 +72,12 @@ import {
+ 	buildWorkers,
+ 	generateWorkerCode,
+ } from './worker-build.mjs';
++import {
++	buildWithConcurrency,
++	getDefaultBuildConcurrency,
++	parseBuildConcurrency,
++	setBuildConcurrency,
++} from './build-concurrency.mjs';
+ 
+ const ROOT_DIR = process.cwd();
+ const PACKAGES_DIR = path.join( ROOT_DIR, 'packages' );
+@@ -637,7 +642,7 @@ async function bundlePackage( packageName, options = {} ) {
+ 		];
+ 
+ 		builds.push(
+-			esbuild.build( {
++			buildWithConcurrency( {
+ 				...baseConfig,
+ 				outfile: path.join( outputDir, 'index.min.js' ),
+ 				minify: true,
+@@ -652,7 +657,7 @@ async function bundlePackage( packageName, options = {} ) {
+ 					),
+ 				],
+ 			} ),
+-			esbuild.build( {
++			buildWithConcurrency( {
+ 				...baseConfig,
+ 				outfile: path.join( outputDir, 'index.js' ),
+ 				minify: false,
+@@ -707,7 +712,7 @@ async function bundlePackage( packageName, options = {} ) {
+ 				);
+ 
+ 			builds.push(
+-				esbuild.build( {
++				buildWithConcurrency( {
+ 					entryPoints: [ entryPoint ],
+ 					outfile: path.join(
+ 						rootBuildModuleDir,
+@@ -738,7 +743,7 @@ async function bundlePackage( packageName, options = {} ) {
+ 
+ 			if ( ! isWasmWorker ) {
+ 				builds.push(
+-					esbuild.build( {
++					buildWithConcurrency( {
+ 						entryPoints: [ entryPoint ],
+ 						outfile: path.join(
+ 							rootBuildModuleDir,
+@@ -1458,7 +1463,7 @@ async function transpilePackage( packageName ) {
+ 
+ 	if ( packageJson.main ) {
+ 		builds.push(
+-			esbuild.build( {
++			buildWithConcurrency( {
+ 				entryPoints: srcFiles,
+ 				outdir: buildDir,
+ 				outbase: srcDir,
+@@ -1492,7 +1497,7 @@ async function transpilePackage( packageName ) {
+ 
+ 	if ( packageJson.module ) {
+ 		builds.push(
+-			esbuild.build( {
++			buildWithConcurrency( {
+ 				entryPoints: srcFiles,
+ 				outdir: buildModuleDir,
+ 				outbase: srcDir,
+@@ -1600,7 +1605,7 @@ async function compileStyles( packageName ) {
+ 
+ 			await mkdir( outputDir, { recursive: true } );
+ 
+-			await esbuild.build( {
++			await buildWithConcurrency( {
+ 				entryPoints: [ styleEntryPath ],
+ 				outdir: outputDir,
+ 				bundle: true,
+@@ -1732,7 +1737,7 @@ async function buildRoute( routeName ) {
+ 		if ( routeEntryPoints.length > 0 ) {
+ 			// Build both minified and non-minified versions in parallel
+ 			await Promise.all( [
+-				esbuild.build( {
++				buildWithConcurrency( {
+ 					entryPoints: routeEntryPoints,
+ 					outfile: path.join( outputDir, 'route.min.js' ),
+ 					bundle: true,
+@@ -1750,7 +1755,7 @@ async function buildRoute( routeName ) {
+ 						),
+ 					],
+ 				} ),
+-				esbuild.build( {
++				buildWithConcurrency( {
+ 					entryPoints: routeEntryPoints,
+ 					outfile: path.join( outputDir, 'route.js' ),
+ 					bundle: true,
+@@ -1783,7 +1788,7 @@ async function buildRoute( routeName ) {
+ 
+ 		// Build both minified and non-minified versions in parallel
+ 		await Promise.all( [
+-			esbuild.build( {
++			buildWithConcurrency( {
+ 				entryPoints: [ tempEntryPath ],
+ 				outfile: path.join( outputDir, 'content.min.js' ),
+ 				bundle: true,
+@@ -1801,7 +1806,7 @@ async function buildRoute( routeName ) {
+ 					),
+ 				],
+ 			} ),
+-			esbuild.build( {
++			buildWithConcurrency( {
+ 				entryPoints: [ tempEntryPath ],
+ 				outfile: path.join( outputDir, 'content.js' ),
+ 				bundle: true,
+@@ -1895,7 +1900,7 @@ async function buildWidget( widgetName ) {
+ 		if ( renderEntryPoints.length > 0 ) {
+ 			// Build both minified and non-minified versions in parallel
+ 			await Promise.all( [
+-				esbuild.build( {
++				buildWithConcurrency( {
+ 					entryPoints: renderEntryPoints,
+ 					outfile: path.join( outputDir, 'render.min.js' ),
+ 					bundle: true,
+@@ -1913,7 +1918,7 @@ async function buildWidget( widgetName ) {
+ 						),
+ 					],
+ 				} ),
+-				esbuild.build( {
++				buildWithConcurrency( {
+ 					entryPoints: renderEntryPoints,
+ 					outfile: path.join( outputDir, 'render.js' ),
+ 					bundle: true,
+@@ -1945,7 +1950,7 @@ async function buildWidget( widgetName ) {
+ 		if ( widgetEntryPoints.length > 0 ) {
+ 			// Build both minified and non-minified versions in parallel
+ 			await Promise.all( [
+-				esbuild.build( {
++				buildWithConcurrency( {
+ 					entryPoints: widgetEntryPoints,
+ 					outfile: path.join( outputDir, 'widget.min.js' ),
+ 					bundle: true,
+@@ -1963,7 +1968,7 @@ async function buildWidget( widgetName ) {
+ 						),
+ 					],
+ 				} ),
+-				esbuild.build( {
++				buildWithConcurrency( {
+ 					entryPoints: widgetEntryPoints,
+ 					outfile: path.join( outputDir, 'widget.js' ),
+ 					bundle: true,
+@@ -2784,11 +2789,20 @@ async function main() {
+ 						? "includes_url( 'build/' )"
+ 						: 'plugin_dir_url( __FILE__ )',
+ 			},
++			concurrency: {
++				type: 'string',
++				default: process.env.WP_BUILD_CONCURRENCY,
++			},
+ 		},
+ 		strict: false,
+ 	} );
+ 
+ 	const baseUrlExpression = values[ 'base-url' ];
++	const buildConcurrency =
++		parseBuildConcurrency( values.concurrency ) ??
++		getDefaultBuildConcurrency();
++	setBuildConcurrency( buildConcurrency );
++	console.log( `⚙️ Using build concurrency: ${ buildConcurrency }\n` );
+ 
+ 	await buildAll( baseUrlExpression );
+ 
+diff --git a/lib/test/build-concurrency.js b/lib/test/build-concurrency.js
+new file mode 100644
+index 0000000..48cee76
+--- /dev/null
++++ b/lib/test/build-concurrency.js
+@@ -0,0 +1,107 @@
++jest.mock( 'esbuild', () => ( {
++	build: jest.fn(),
++} ) );
++
++/**
++ * Internal dependencies
++ */
++import {
++	enqueueBuild,
++	getDefaultBuildConcurrency,
++	parseBuildConcurrency,
++	setBuildConcurrency,
++} from '../build-concurrency.mjs';
++
++const flushPromises = () =>
++	new Promise( ( resolve ) => {
++		setTimeout( resolve, 0 );
++	} );
++
++describe( 'getDefaultBuildConcurrency()', () => {
++	it( 'uses the available parallelism clamped to the default range', () => {
++		expect( getDefaultBuildConcurrency( 1 ) ).toBe( 2 );
++		expect( getDefaultBuildConcurrency( 2 ) ).toBe( 2 );
++		expect( getDefaultBuildConcurrency( 4 ) ).toBe( 4 );
++		expect( getDefaultBuildConcurrency( 12 ) ).toBe( 12 );
++		expect( getDefaultBuildConcurrency( 16 ) ).toBe( 16 );
++		expect( getDefaultBuildConcurrency( 32 ) ).toBe( 16 );
++		expect( getDefaultBuildConcurrency( 64 ) ).toBe( 16 );
++	} );
++} );
++
++describe( 'parseBuildConcurrency()', () => {
++	it( 'returns undefined when no value is configured', () => {
++		expect( parseBuildConcurrency( undefined ) ).toBe( undefined );
++	} );
++
++	it( 'accepts positive integers', () => {
++		expect( parseBuildConcurrency( '1' ) ).toBe( 1 );
++		expect( parseBuildConcurrency( '01' ) ).toBe( 1 );
++		expect( parseBuildConcurrency( '12' ) ).toBe( 12 );
++	} );
++
++	it( 'warns and returns undefined for invalid values', () => {
++		const warnSpy = jest.spyOn( console, 'warn' ).mockImplementation();
++
++		try {
++			for ( const value of [ '', '0', '-1', '1.5', 'abc' ] ) {
++				expect( parseBuildConcurrency( value ) ).toBe( undefined );
++				expect( warnSpy ).toHaveBeenLastCalledWith(
++					'Invalid build concurrency value: ' +
++						JSON.stringify( value ) +
++						'. Expected a positive integer; falling back to the default.'
++				);
++			}
++
++			expect( warnSpy ).toHaveBeenCalledTimes( 5 );
++		} finally {
++			warnSpy.mockRestore();
++		}
++	} );
++} );
++
++describe( 'enqueueBuild()', () => {
++	afterEach( () => {
++		setBuildConcurrency( getDefaultBuildConcurrency( 12 ) );
++	} );
++
++	it( 'runs no more than the configured number of tasks at once', async () => {
++		setBuildConcurrency( 2 );
++
++		const startedTasks = [];
++		const taskResolvers = [];
++		const tasks = [ 0, 1, 2, 3 ].map( ( index ) =>
++			enqueueBuild(
++				() =>
++					new Promise( ( resolve ) => {
++						startedTasks.push( index );
++						taskResolvers[ index ] = resolve;
++					} )
++			)
++		);
++
++		await flushPromises();
++
++		expect( startedTasks ).toEqual( [ 0, 1 ] );
++
++		taskResolvers[ 0 ]( 'first' );
++		await flushPromises();
++
++		expect( startedTasks ).toEqual( [ 0, 1, 2 ] );
++
++		taskResolvers[ 1 ]( 'second' );
++		await flushPromises();
++
++		expect( startedTasks ).toEqual( [ 0, 1, 2, 3 ] );
++
++		taskResolvers[ 2 ]( 'third' );
++		taskResolvers[ 3 ]( 'fourth' );
++
++		await expect( Promise.all( tasks ) ).resolves.toEqual( [
++			'first',
++			'second',
++			'third',
++			'fourth',
++		] );
++	} );
++} );
+diff --git a/lib/worker-build.mjs b/lib/worker-build.mjs
+index 087f0c5..3665bf9 100644
+--- a/lib/worker-build.mjs
++++ b/lib/worker-build.mjs
+@@ -12,7 +12,11 @@
+  */
+ import { readFile, writeFile, access } from 'fs/promises';
+ import path from 'path';
+-import esbuild from 'esbuild';
++
++/**
++ * Internal dependencies
++ */
++import { buildWithConcurrency } from './build-concurrency.mjs';
+ 
+ /**
+  * Creates an esbuild plugin that redirects module loads based on filename patterns.
+@@ -173,7 +177,7 @@ export async function buildWorkers(
+ 		// Build ESM worker for build-module (primary for browser use).
+ 		if ( packageJson.module ) {
+ 			workerBuilds.push(
+-				esbuild.build( {
++				buildWithConcurrency( {
+ 					entryPoints: [ workerEntryPoint ],
+ 					outfile: path.join(
+ 						buildModuleDir,
+@@ -215,7 +219,7 @@ export async function buildWorkers(
+ 		// unused or misleading CJS artifacts.
+ 		if ( packageJson.main ) {
+ 			workerBuilds.push(
+-				esbuild.build( {
++				buildWithConcurrency( {
+ 					entryPoints: [ workerEntryPoint ],
+ 					outfile: path.join( buildDir, `${ workerOutputName }.cjs` ),
+ 					bundle: true,
+@@ -322,7 +326,7 @@ export const workerCode = ${ JSON.stringify( workerContent ) };
+ 
+ 	if ( packageJson.module ) {
+ 		retranspileBuilds.push(
+-			esbuild.build( {
++			buildWithConcurrency( {
+ 				entryPoints: [ workerCodeSrcFile ],
+ 				outdir: buildModuleDir,
+ 				outbase: srcDir,
+@@ -345,7 +349,7 @@ export const workerCode = ${ JSON.stringify( workerContent ) };
+ 
+ 	if ( packageJson.main ) {
+ 		retranspileBuilds.push(
+-			esbuild.build( {
++			buildWithConcurrency( {
+ 				entryPoints: [ workerCodeSrcFile ],
+ 				outdir: buildDir,
+ 				outbase: srcDir,
 diff --git a/templates/page-wp-admin.php.template b/templates/page-wp-admin.php.template
-index 96c4627..48fcf28 100644
+index 5bceb04..61a6e65 100644
 --- a/templates/page-wp-admin.php.template
 +++ b/templates/page-wp-admin.php.template
-@@ -171,7 +171,26 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_enqueue_scripts( $hook_suf
+@@ -172,7 +172,26 @@ function {{PREFIX}}_{{PAGE_SLUG_UNDERSCORE}}_wp_admin_enqueue_scripts( $hook_suf
  		( mountId, routes, initModules ) => {
  			const run = async () => {
  				const mod = await import( "@wordpress/boot" );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 pnpmfileChecksum: sha256-ZW2BoUDYyI5nkZ8o3EkCzocg7Bspf+AzfFGBEEoeEK8=
 
 patchedDependencies:
-  '@wordpress/build': 5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945
+  '@wordpress/build': a4dc697d3e87d99b11d4c5886d40e2752b9081c33108ce900bf0fa6fc05c4d8f
   react-autosize-textarea: 5c09e1dee59caaaba3871f9d722f93e56b41169db486b059597e8f8c788aa464
   uuid@<11: 87a713b75995ed86c0ecd0cadfd1b9f85092ca16fdff7132ff98b62fc3cf2db0
 
@@ -1898,7 +1898,7 @@ importers:
         version: 6.51.0
       '@wordpress/build':
         specifier: 0.20.0
-        version: 0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
+        version: 0.20.0(patch_hash=a4dc697d3e87d99b11d4c5886d40e2752b9081c33108ce900bf0fa6fc05c4d8f)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
       '@wordpress/theme':
         specifier: 1.1.0
         version: 1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2128,7 +2128,7 @@ importers:
         version: 6.51.0
       '@wordpress/build':
         specifier: 0.20.0
-        version: 0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
+        version: 0.20.0(patch_hash=a4dc697d3e87d99b11d4c5886d40e2752b9081c33108ce900bf0fa6fc05c4d8f)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
       autoprefixer:
         specifier: 10.4.20
         version: 10.4.20(postcss@8.5.23)
@@ -2765,7 +2765,7 @@ importers:
         version: 6.51.0
       '@wordpress/build':
         specifier: 0.20.0
-        version: 0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
+        version: 0.20.0(patch_hash=a4dc697d3e87d99b11d4c5886d40e2752b9081c33108ce900bf0fa6fc05c4d8f)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
       '@wordpress/date':
         specifier: 5.51.0
         version: 5.51.0
@@ -3089,7 +3089,7 @@ importers:
         version: 6.51.0
       '@wordpress/build':
         specifier: 0.20.0
-        version: 0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.52.0)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
+        version: 0.20.0(patch_hash=a4dc697d3e87d99b11d4c5886d40e2752b9081c33108ce900bf0fa6fc05c4d8f)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.52.0)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
       autoprefixer:
         specifier: 10.4.20
         version: 10.4.20(postcss@8.5.23)
@@ -3527,7 +3527,7 @@ importers:
         version: 6.51.0
       '@wordpress/build':
         specifier: 0.20.0
-        version: 0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
+        version: 0.20.0(patch_hash=a4dc697d3e87d99b11d4c5886d40e2752b9081c33108ce900bf0fa6fc05c4d8f)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
       autoprefixer:
         specifier: 10.4.20
         version: 10.4.20(postcss@8.5.23)
@@ -3883,7 +3883,7 @@ importers:
         version: 6.51.0
       '@wordpress/build':
         specifier: 0.20.0
-        version: 0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
+        version: 0.20.0(patch_hash=a4dc697d3e87d99b11d4c5886d40e2752b9081c33108ce900bf0fa6fc05c4d8f)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
       '@wordpress/theme':
         specifier: 1.1.0
         version: 1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -4097,7 +4097,7 @@ importers:
         version: 11.0.0
       '@wordpress/build':
         specifier: 0.20.0
-        version: 0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.52.0)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
+        version: 0.20.0(patch_hash=a4dc697d3e87d99b11d4c5886d40e2752b9081c33108ce900bf0fa6fc05c4d8f)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.52.0)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
       browserslist:
         specifier: 4.28.4
         version: 4.28.4
@@ -4282,7 +4282,7 @@ importers:
         version: 6.51.0
       '@wordpress/build':
         specifier: 0.20.0
-        version: 0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
+        version: 0.20.0(patch_hash=a4dc697d3e87d99b11d4c5886d40e2752b9081c33108ce900bf0fa6fc05c4d8f)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
       autoprefixer:
         specifier: 10.4.20
         version: 10.4.20(postcss@8.5.23)
@@ -4524,7 +4524,7 @@ importers:
         version: 6.51.0
       '@wordpress/build':
         specifier: 0.20.0
-        version: 0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
+        version: 0.20.0(patch_hash=a4dc697d3e87d99b11d4c5886d40e2752b9081c33108ce900bf0fa6fc05c4d8f)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
       browserslist:
         specifier: ^4.24.0
         version: 4.28.4
@@ -4844,7 +4844,7 @@ importers:
         version: 6.51.0
       '@wordpress/build':
         specifier: 0.20.0
-        version: 0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
+        version: 0.20.0(patch_hash=a4dc697d3e87d99b11d4c5886d40e2752b9081c33108ce900bf0fa6fc05c4d8f)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
       '@wordpress/theme':
         specifier: 1.1.0
         version: 1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -5062,7 +5062,7 @@ importers:
         version: 6.51.0
       '@wordpress/build':
         specifier: 0.20.0
-        version: 0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
+        version: 0.20.0(patch_hash=a4dc697d3e87d99b11d4c5886d40e2752b9081c33108ce900bf0fa6fc05c4d8f)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
       autoprefixer:
         specifier: 10.4.20
         version: 10.4.20(postcss@8.5.23)
@@ -5138,7 +5138,7 @@ importers:
         version: 6.51.0
       '@wordpress/build':
         specifier: 0.20.0
-        version: 0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.52.0)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
+        version: 0.20.0(patch_hash=a4dc697d3e87d99b11d4c5886d40e2752b9081c33108ce900bf0fa6fc05c4d8f)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.52.0)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
       '@wordpress/compose':
         specifier: 8.4.0
         version: 8.4.0(@types/react@18.3.28)(react@18.3.1)
@@ -25360,7 +25360,7 @@ snapshots:
 
   '@wordpress/browserslist-config@6.51.0': {}
 
-  '@wordpress/build@0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.52.0)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)':
+  '@wordpress/build@0.20.0(patch_hash=a4dc697d3e87d99b11d4c5886d40e2752b9081c33108ce900bf0fa6fc05c4d8f)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.52.0)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)':
     dependencies:
       '@emotion/babel-plugin': 11.13.5
       '@wordpress/style-runtime': 0.8.0
@@ -25388,7 +25388,7 @@ snapshots:
       - browserslist
       - supports-color
 
-  '@wordpress/build@0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.52.0)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)':
+  '@wordpress/build@0.20.0(patch_hash=a4dc697d3e87d99b11d4c5886d40e2752b9081c33108ce900bf0fa6fc05c4d8f)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.52.0)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)':
     dependencies:
       '@emotion/babel-plugin': 11.13.5
       '@wordpress/style-runtime': 0.8.0
@@ -25416,7 +25416,7 @@ snapshots:
       - browserslist
       - supports-color
 
-  '@wordpress/build@0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)':
+  '@wordpress/build@0.20.0(patch_hash=a4dc697d3e87d99b11d4c5886d40e2752b9081c33108ce900bf0fa6fc05c4d8f)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)':
     dependencies:
       '@emotion/babel-plugin': 11.13.5
       '@wordpress/style-runtime': 0.8.0
@@ -25443,7 +25443,7 @@ snapshots:
       - browserslist
       - supports-color
 
-  '@wordpress/build@0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)':
+  '@wordpress/build@0.20.0(patch_hash=a4dc697d3e87d99b11d4c5886d40e2752b9081c33108ce900bf0fa6fc05c4d8f)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)':
     dependencies:
       '@emotion/babel-plugin': 11.13.5
       '@wordpress/style-runtime': 0.8.0
@@ -25470,7 +25470,7 @@ snapshots:
       - browserslist
       - supports-color
 
-  '@wordpress/build@0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.52.0)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)':
+  '@wordpress/build@0.20.0(patch_hash=a4dc697d3e87d99b11d4c5886d40e2752b9081c33108ce900bf0fa6fc05c4d8f)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.52.0)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)':
     dependencies:
       '@emotion/babel-plugin': 11.13.5
       '@wordpress/style-runtime': 0.8.0
@@ -25498,7 +25498,7 @@ snapshots:
       - browserslist
       - supports-color
 
-  '@wordpress/build@0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)':
+  '@wordpress/build@0.20.0(patch_hash=a4dc697d3e87d99b11d4c5886d40e2752b9081c33108ce900bf0fa6fc05c4d8f)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)':
     dependencies:
       '@emotion/babel-plugin': 11.13.5
       '@wordpress/style-runtime': 0.8.0
@@ -25524,7 +25524,7 @@ snapshots:
       - browserslist
       - supports-color
 
-  '@wordpress/build@0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)':
+  '@wordpress/build@0.20.0(patch_hash=a4dc697d3e87d99b11d4c5886d40e2752b9081c33108ce900bf0fa6fc05c4d8f)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)':
     dependencies:
       '@emotion/babel-plugin': 11.13.5
       '@wordpress/style-runtime': 0.8.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -101,4 +101,8 @@ patchedDependencies:
   # the option, so init modules never run there. The patch runs them in the
   # inline bootstrap instead. Remove once the template runs init modules itself
   # upstream (or Jetpack's WP floor ships a boot with initModules support).
+  #
+  # TEMPORARY: this patch has also been extended with the esbuild concurrency
+  # limit from https://github.com/WordPress/gutenberg/pull/79889, so its effect
+  # on our CI build times can be measured. Revert that part before merging.
   "@wordpress/build": .pnpm-patches/@wordpress__build.patch


### PR DESCRIPTION
**Do not merge.** This is a throwaway measurement PR, opened at @manzoorwanijk's suggestion on WordPress/gutenberg#79889 so we can see what the `wp-build` esbuild concurrency limit does to Jetpack's CI build times.

Pair it with the control PR, #51064, which is the same base commit with an unmodified dependency tree.

## Proposed changes

* Extend `.pnpm-patches/@wordpress__build.patch` with the concurrency change from WordPress/gutenberg#79889, on top of the published `@wordpress/build@0.20.0` we already use. The upstream diff applies to 0.20.0 with only line offsets — no conflicts.

That is the whole change. The lockfile churn is just `patch_hash` propagating through every dependency path that involves `@wordpress/build`.

### Why not the `github:` override that was suggested

The suggested recipe — `blockExoticSubdeps: false` plus `overrides` pointing at the branch — does not survive a cold pnpm cache, which is what CI always has. I tried it first (see this PR's history) and it failed every job.

`github:…&path:packages/wp-build` does not fetch just that subdirectory. pnpm fetches the whole Gutenberg repo, **prepares** it, and then takes the subpath. Preparing runs `npm install` across the entire Gutenberg monorepo, which runs `@wordpress/icons`'s build, which shells out to `git clean -Xfq` and dies with `fatal: not a git repository` — the extracted tarball isn't a git checkout:

```
[ERR_PNPM_PREPARE_PACKAGE] Failed to prepare git-hosted package fetched from
"https://codeload.github.com/WordPress/gutenberg/tar.gz/a42acef…":
gutenberg@23.7.0-rc.1 npm-install: `npm install` Exit status 1
```

There is no way out of that: adding `gutenberg: true` to `allowBuilds` runs the failing `npm install`, and omitting it (or setting `false`) hard-fails with `ERR_PNPM_GIT_DEP_PREPARE_NOT_ALLOWED` regardless of `strictDepBuilds`. It only appears to work on a machine that already has the prepared package cached, which is why it looked fine locally at first.

Patching sidesteps all of it, and has a second advantage: the Gutenberg branch is based on `@wordpress/build` 0.19.0 while Jetpack is on 0.20.0, so an override would have folded two releases of unrelated changes into the measurement. Patching 0.20.0 keeps the comparison to the concurrency change alone.

## Related product discussion/links

* WordPress/gutenberg#79889 — Limit wp-build esbuild concurrency
* WordPress/gutenberg#79888 — the underlying issue

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Locally verified before pushing:

* `pnpm install` completes cleanly.
* The installed `@wordpress/build@0.20.0` has `lib/build-concurrency.mjs`, 16 `buildWithConcurrency` call sites in `lib/build.mjs`, and still carries Jetpack's original wp-admin template fix — both halves of the patch apply.
* `pnpm run build:wp-build` prints `⚙️ Using build concurrency: 12` (12 = this machine's CPU count).
* `pnpm jetpack build packages/scan --deps` succeeds end to end.

What to look at here: the **Build** job timings on this PR versus #51064.

One caveat before reading the numbers. The branch's current default is `clamp(availableParallelism(), 2, 16)`, not the "half of `availableParallelism()`, clamped 2–8" the upstream PR description mentions. On a runner with ≤16 cores the default cap therefore equals the core count and constrains almost nothing, so the default-configuration runs may look near-identical. To see the knob actually bite, a run with `WP_BUILD_CONCURRENCY` set explicitly (e.g. `4`) is needed.
