### PR TITLE
[not for merge] Benchmark control: unmodified deps on the same base

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -75,6 +75,11 @@ allowBuilds:
   core-js-pure: false
   print-this: false
 
+# TEMPORARY: this comment is the entire diff of this branch. It exists only so
+# that a PR can be opened to serve as the control run for the build-time
+# measurement of https://github.com/WordPress/gutenberg/pull/79889. Dependencies
+# here are byte-for-byte identical to trunk.
+
 # Package compromise avoidance: Block odd protocols in subdeps
 blockExoticSubdeps: true
 


### PR DESCRIPTION
**Do not merge.** This is the control half of a throwaway measurement, opened at @manzoorwanijk's suggestion on WordPress/gutenberg#79889.

The entire diff is a comment in `pnpm-workspace.yaml`. The lockfile is byte-for-byte identical to trunk, so this runs the same CI on the same base commit with an unmodified dependency tree — the baseline for the timings in #51063.

## Proposed changes

* Add a comment to `pnpm-workspace.yaml`, purely so a PR can exist. Nothing else changes.

## Related product discussion/links

* WordPress/gutenberg#79889 — Limit wp-build esbuild concurrency
* WordPress/gutenberg#79888 — the underlying issue

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `pnpm install` completes cleanly and leaves `pnpm-lock.yaml` unchanged from trunk.

What to look at here: the **Build** job timings, compared against #51063.
