### PR TITLE
Newsletter: register the subscriptions extension first

### DIFF
--- a/projects/plugins/jetpack/changelog/newsletter-panel-registration-order
+++ b/projects/plugins/jetpack/changelog/newsletter-panel-registration-order
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Newsletter: Show the Newsletter panels above other Jetpack panels in the editor.

--- a/projects/plugins/jetpack/extensions/index.json
+++ b/projects/plugins/jetpack/extensions/index.json
@@ -1,5 +1,6 @@
 {
 	"production": [
+		"subscriptions",
 		"ai-assistant",
 		"ai-chat",
 		"ai-assistant-plugin",
@@ -42,7 +43,6 @@
 		"slideshow",
 		"story",
 		"subscriber-login",
-		"subscriptions",
 		"tiled-gallery",
 		"tock",
 		"videopress",


### PR DESCRIPTION
Fixes #

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* Move `subscriptions` to the top of the `production` list in `extensions/index.json`, so the Access and Newsletter panels render first among Jetpack's editor panels.
* Panel order follows plugin registration order, which follows this array. The underlying SlotFill API has no priority or weighting mechanism.
* This does not change our position against other plugins — Blaze ships as a separate script — nor against core's panels, which always render first.
* Caveat: nothing in the file signals that order is meaningful, so a future reorder could undo this silently, with no test to catch it.
* Split out of #51053, which covers the panel's expanded state and is independent of ordering.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Use a site with Jetpack connected to WordPress.com and the Newsletter (`subscriptions`) module active, plus the AI assistant available so there is another Jetpack panel to compare against.
* Go to Posts &rarr; Add New and write a post.
* Click **Publish** to open the pre-publish sidebar. Before this change the order is `Visibility` &rarr; `Publish` &rarr; `Improve with AI` &rarr; `Access` &rarr; `Newsletter`. After it, `Access` and `Newsletter` appear above `Improve with AI`.
* Complete the publish and check the post-publish sidebar: Jetpack's panels should now lead with Newsletter, though still below any panel from a plugin that loads earlier.
* Confirm the document sidebar (Jetpack icon in the toolbar) still renders every panel, in the same new order.
* Confirm no blocks are missing from the inserter, since this file also drives which extensions are bundled.
