### PR TITLE
Agents Manager: Expose isWpcomPlatform in the inline data

### DIFF
--- a/projects/packages/agents-manager/changelog/add-agents-manager-is-wpcom-platform
+++ b/projects/packages/agents-manager/changelog/add-agents-manager-is-wpcom-platform
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Expose `isWpcomPlatform` in the `agentsManagerData` inline data so the frontend can gate WordPress.com-only menu items.

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -326,6 +326,7 @@ class Agents_Manager {
 			'agentProviders'       => $agent_providers,
 			'useUnifiedExperience' => $use_unified_experience,
 			'isDevMode'            => self::is_dev_mode(),
+			'isWpcomPlatform'      => ( new \Automattic\Jetpack\Status\Host() )->is_wpcom_platform(),
 			'sectionName'          => apply_filters( 'agents_manager_section_name', $variant ),
 			'currentUser'          => $this->get_current_user_data(),
 			'site'                 => $this->get_current_site(),

--- a/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
+++ b/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
@@ -538,13 +538,15 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	/**
 	 * Tests that enqueue_scripts exposes whether the site runs on the WordPress.com platform.
 	 *
-	 * @param bool $is_wpcom Whether to simulate a Simple site via the IS_WPCOM constant.
+	 * @param string $platform Hosting platform to simulate: 'none', 'simple', or 'woa'.
+	 * @param string $expected Expected JSON-encoded isWpcomPlatform value.
 	 * @dataProvider provide_is_wpcom_platform
 	 */
 	#[DataProvider( 'provide_is_wpcom_platform' )]
-	public function test_enqueue_scripts_exposes_is_wpcom_platform( $is_wpcom ) {
-		if ( $is_wpcom ) {
-			Constants::set_constant( 'IS_WPCOM', true );
+	public function test_enqueue_scripts_exposes_is_wpcom_platform( $platform, $expected ) {
+		Constants::set_constant( 'IS_WPCOM', 'simple' === $platform );
+		if ( 'woa' === $platform ) {
+			Cache::set( 'is_woa_site', true );
 		}
 
 		// Set admin context - scripts only enqueue in admin.
@@ -574,10 +576,7 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 		// Find the inline script containing agentsManagerData.
 		$inline_script = implode( "\n", array_filter( $inline_scripts ) );
 
-		$this->assertStringContainsString(
-			'"isWpcomPlatform":' . ( $is_wpcom ? 'true' : 'false' ),
-			$inline_script
-		);
+		$this->assertStringContainsString( '"isWpcomPlatform":' . $expected, $inline_script );
 
 		// Clean up the filter.
 		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
@@ -586,12 +585,13 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	/**
 	 * Data provider for test_enqueue_scripts_exposes_is_wpcom_platform.
 	 *
-	 * @return array<string, array{0: bool}>
+	 * @return array<string, array{0: string, 1: string}>
 	 */
 	public static function provide_is_wpcom_platform() {
 		return array(
-			'non-wpcom site' => array( false ),
-			'Simple site'    => array( true ),
+			'non-wpcom site' => array( 'none', 'false' ),
+			'Simple site'    => array( 'simple', 'true' ),
+			'WoA site'       => array( 'woa', 'true' ),
 		);
 	}
 

--- a/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
+++ b/projects/packages/agents-manager/tests/php/Agents_Manager_Test.php
@@ -536,6 +536,66 @@ class Agents_Manager_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Tests that enqueue_scripts exposes whether the site runs on the WordPress.com platform.
+	 *
+	 * @param bool $is_wpcom Whether to simulate a Simple site via the IS_WPCOM constant.
+	 * @dataProvider provide_is_wpcom_platform
+	 */
+	#[DataProvider( 'provide_is_wpcom_platform' )]
+	public function test_enqueue_scripts_exposes_is_wpcom_platform( $is_wpcom ) {
+		if ( $is_wpcom ) {
+			Constants::set_constant( 'IS_WPCOM', true );
+		}
+
+		// Set admin context - scripts only enqueue in admin.
+		require_once ABSPATH . 'wp-admin/includes/screen.php';
+		set_current_screen( 'dashboard' );
+
+		// Reset the script registry to ensure test isolation.
+		global $wp_scripts;
+		$wp_scripts = null;
+
+		// Register the agents-manager script so we can attach inline script to it.
+		wp_register_script( 'agents-manager', 'https://example.com/agents-manager.js', array(), '1.0', true );
+
+		// Add a filter to enable unified experience.
+		add_filter(
+			'agents_manager_use_unified_experience',
+			'__return_true',
+			// Use a higher priority to ensure it runs after the class's own filter.
+			20
+		);
+
+		$this->agents_manager->enqueue_scripts();
+
+		// Re-fetch global after wp_register_script initializes it.
+		$inline_scripts = $wp_scripts->registered['agents-manager']->extra['before'] ?? array(); // @phan-suppress-current-line PhanTypeExpectedObjectPropAccessButGotNull
+
+		// Find the inline script containing agentsManagerData.
+		$inline_script = implode( "\n", array_filter( $inline_scripts ) );
+
+		$this->assertStringContainsString(
+			'"isWpcomPlatform":' . ( $is_wpcom ? 'true' : 'false' ),
+			$inline_script
+		);
+
+		// Clean up the filter.
+		remove_filter( 'agents_manager_use_unified_experience', '__return_true', 20 );
+	}
+
+	/**
+	 * Data provider for test_enqueue_scripts_exposes_is_wpcom_platform.
+	 *
+	 * @return array<string, array{0: bool}>
+	 */
+	public static function provide_is_wpcom_platform() {
+		return array(
+			'non-wpcom site' => array( false ),
+			'Simple site'    => array( true ),
+		);
+	}
+
+	/**
 	 * Tests that Help Center is dequeued in the block editor when the unified experience
 	 * (Help Center takeover) is active — Agents Manager becomes the single help affordance.
 	 */


### PR DESCRIPTION
Fixes # N/A

## Proposed changes
* Expose `isWpcomPlatform` in the `agentsManagerData` inline data, computed via `( new \Automattic\Jetpack\Status\Host() )->is_wpcom_platform()`, so the frontend can gate WordPress.com-only menu items (the `AI Agent settings` link points to a settings page that only exists for Simple/WoA sites).
* Add a data-provider test asserting the flag is `false` by default and `true` when `IS_WPCOM` simulates a Simple site.

## Related product discussion/links
* Part of AI-1096

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions
Test together with Calypso PR Automattic/wp-calypso#113276, which consumes this flag — its testing instructions cover the end-to-end behavior (the `AI Agent settings` item in the chat header's More Options menu only shows when this flag is `true`).

To verify the flag itself:

* Sync this branch's `agents-manager` package to a WordPress.com Simple/WoA site (or sandbox), load any wp-admin page with the Agents Manager enabled, and check the inline `agentsManagerData` object in the page source: it should contain `"isWpcomPlatform":true`.
* On a non-WordPress.com site (e.g. Jurassic Ninja), the same object should contain `"isWpcomPlatform":false`.
* `cd projects/packages/agents-manager && composer test-php` — the new `test_enqueue_scripts_exposes_is_wpcom_platform` cases pass.
