### PR TITLE
Block Patterns: re-register the core Query Loop patterns on WordPress.com

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-core-query-block-patterns
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-core-query-block-patterns
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Block patterns: Re-register the core Query Loop patterns, which were excluded along with all other core patterns.

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/block-patterns.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/block-patterns.php
@@ -101,29 +101,38 @@ function wpcom_unregister_core_block_patterns() {
 add_action( 'after_setup_theme', 'wpcom_unregister_core_block_patterns' );
 
 /**
- * Re-register the Query Loop patterns bundled in core, which are excluded by
- * wpcom_unregister_core_block_patterns() along with all other core patterns.
+ * Re-register a subset of the Query Loop patterns bundled in core, which are
+ * excluded by wpcom_unregister_core_block_patterns() along with all other core
+ * patterns.
+ *
+ * Only the bundled patterns with a `core/query` root block are restored. They
+ * feed the Query Loop block's pattern picker, and also appear in the inserter
+ * under the "Posts" category. Core's group-wrapped query patterns (Offset,
+ * Large title) are deliberately left out. The list is hardcoded like core's
+ * own rather than discovered from disk, because core retires patterns by
+ * delisting them while keeping the file around (e.g. the deprecated
+ * social-links-shared-background-color pattern).
  */
 function wpcom_register_core_query_block_patterns() {
-	$registry = \WP_Block_Patterns_Registry::get_instance();
-	$files    = glob( ABSPATH . WPINC . '/block-patterns/query-*.php' );
-	if ( ! $files ) {
-		return;
-	}
-	foreach ( $files as $file ) {
-		$name = 'core/' . basename( $file, '.php' );
-		if ( $registry->is_registered( $name ) ) {
+	$query_patterns = array(
+		'query-standard-posts',
+		'query-medium-posts',
+		'query-small-posts',
+		'query-grid-posts',
+	);
+	$registry       = \WP_Block_Patterns_Registry::get_instance();
+	foreach ( $query_patterns as $slug ) {
+		$name = 'core/' . $slug;
+		$file = ABSPATH . WPINC . '/block-patterns/' . $slug . '.php';
+		if ( $registry->is_registered( $name ) || ! file_exists( $file ) ) {
 			continue;
 		}
 		$pattern = require $file;
-		if ( ! is_array( $pattern ) ) {
-			continue;
-		}
-		// Require a `core/query` root block, mirroring the filter in the Query
-		// Loop pattern picker: section-style patterns that merely contain a
-		// query (e.g. wrapped in a group) shouldn't surface elsewhere either.
-		$blocks = parse_blocks( trim( $pattern['content'] ?? '' ) );
-		if ( 'core/query' !== ( $blocks[0]['blockName'] ?? null ) ) {
+		// Cheap safety net for the `core/query` root block invariant: a
+		// group-wrapped pattern would leak into the inserter, since blockTypes
+		// doesn't limit visibility there (the Query Loop picker filters
+		// non-query-root patterns client-side on its own).
+		if ( ! is_array( $pattern ) || ! str_starts_with( trim( $pattern['content'] ?? '' ), '<!-- wp:query ' ) ) {
 			continue;
 		}
 		$pattern['source'] = 'core';

--- a/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/block-patterns.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/block-patterns/block-patterns.php
@@ -99,3 +99,35 @@ function wpcom_unregister_core_block_patterns() {
 }
 
 add_action( 'after_setup_theme', 'wpcom_unregister_core_block_patterns' );
+
+/**
+ * Re-register the Query Loop patterns bundled in core, which are excluded by
+ * wpcom_unregister_core_block_patterns() along with all other core patterns.
+ */
+function wpcom_register_core_query_block_patterns() {
+	$registry = \WP_Block_Patterns_Registry::get_instance();
+	$files    = glob( ABSPATH . WPINC . '/block-patterns/query-*.php' );
+	if ( ! $files ) {
+		return;
+	}
+	foreach ( $files as $file ) {
+		$name = 'core/' . basename( $file, '.php' );
+		if ( $registry->is_registered( $name ) ) {
+			continue;
+		}
+		$pattern = require $file;
+		if ( ! is_array( $pattern ) ) {
+			continue;
+		}
+		// Require a `core/query` root block, mirroring the filter in the Query
+		// Loop pattern picker: section-style patterns that merely contain a
+		// query (e.g. wrapped in a group) shouldn't surface elsewhere either.
+		$blocks = parse_blocks( trim( $pattern['content'] ?? '' ) );
+		if ( 'core/query' !== ( $blocks[0]['blockName'] ?? null ) ) {
+			continue;
+		}
+		$pattern['source'] = 'core';
+		register_block_pattern( $name, $pattern );
+	}
+}
+add_action( 'init', 'wpcom_register_core_query_block_patterns', 11 );

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/Wpcom_Core_Query_Block_Patterns_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/Wpcom_Core_Query_Block_Patterns_Test.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Test class for wpcom_register_core_query_block_patterns().
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+use PHPUnit\Framework\Attributes\After;
+use PHPUnit\Framework\TestCase;
+
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/block-patterns/block-patterns.php';
+
+/**
+ * Class Wpcom_Core_Query_Block_Patterns_Test
+ */
+class Wpcom_Core_Query_Block_Patterns_Test extends TestCase {
+	/**
+	 * Unregister any core query patterns registered during a test.
+	 *
+	 * @after
+	 */
+	#[After]
+	public function unregister_core_query_patterns() {
+		foreach ( $this->get_registered_core_query_pattern_names() as $name ) {
+			unregister_block_pattern( $name );
+		}
+	}
+
+	/**
+	 * Tests that the bundled core Query Loop patterns get registered.
+	 */
+	public function test_registers_bundled_query_patterns() {
+		if ( ! file_exists( ABSPATH . WPINC . '/block-patterns/query-standard-posts.php' ) ) {
+			$this->markTestSkipped( 'This WordPress copy does not bundle the core query patterns.' );
+		}
+
+		wpcom_register_core_query_block_patterns();
+
+		$this->assertContains( 'core/query-standard-posts', $this->get_registered_core_query_pattern_names() );
+	}
+
+	/**
+	 * Tests that every registered core query pattern has a `core/query` root block.
+	 */
+	public function test_registered_patterns_have_query_root_block() {
+		wpcom_register_core_query_block_patterns();
+
+		$registry = WP_Block_Patterns_Registry::get_instance();
+		foreach ( $this->get_registered_core_query_pattern_names() as $name ) {
+			$pattern = $registry->get_registered( $name );
+			$blocks  = parse_blocks( trim( $pattern['content'] ) );
+			$this->assertSame( 'core/query', $blocks[0]['blockName'], "Pattern $name does not have a core/query root block." );
+		}
+	}
+
+	/**
+	 * Tests that bundled patterns merely containing a query inside a wrapper are not registered.
+	 */
+	public function test_skips_group_wrapped_bundled_patterns() {
+		if ( ! file_exists( ABSPATH . WPINC . '/block-patterns/query-offset-posts.php' ) ) {
+			$this->markTestSkipped( 'This WordPress copy does not bundle the group-wrapped Offset query pattern.' );
+		}
+
+		wpcom_register_core_query_block_patterns();
+
+		$this->assertNotContains( 'core/query-offset-posts', $this->get_registered_core_query_pattern_names() );
+	}
+
+	/**
+	 * Tests that an already registered pattern is left untouched.
+	 */
+	public function test_does_not_overwrite_existing_registration() {
+		register_block_pattern(
+			'core/query-standard-posts',
+			array(
+				'title'   => 'Pre-existing',
+				'content' => '<!-- wp:paragraph --><p>Pre-existing</p><!-- /wp:paragraph -->',
+			)
+		);
+
+		wpcom_register_core_query_block_patterns();
+
+		$pattern = WP_Block_Patterns_Registry::get_instance()->get_registered( 'core/query-standard-posts' );
+		$this->assertSame( 'Pre-existing', $pattern['title'] );
+	}
+
+	/**
+	 * Returns the names of all registered `core/query-*` patterns.
+	 *
+	 * @return string[]
+	 */
+	private function get_registered_core_query_pattern_names() {
+		$names = array_column( WP_Block_Patterns_Registry::get_instance()->get_all_registered(), 'name' );
+		return array_values(
+			array_filter(
+				$names,
+				function ( $name ) {
+					return str_starts_with( $name, 'core/query-' );
+				}
+			)
+		);
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/Wpcom_Core_Query_Block_Patterns_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/Wpcom_Core_Query_Block_Patterns_Test.php
@@ -86,6 +86,43 @@ class Wpcom_Core_Query_Block_Patterns_Test extends TestCase {
 	}
 
 	/**
+	 * Guards the hardcoded allowlist against drifting from core.
+	 *
+	 * Derives the expected set from this WordPress copy itself: the `query-*`
+	 * slugs core lists in wp-includes/block-patterns.php, narrowed to the ones
+	 * with a `core/query` root block. Fails when a WordPress update adds,
+	 * renames, delists, or removes a bundled query pattern, so a human can
+	 * update (or deliberately not update) the allowlist.
+	 */
+	public function test_allowlist_stays_in_sync_with_core() {
+		$core_registration_source = file_get_contents( ABSPATH . WPINC . '/block-patterns.php' );
+		preg_match_all( "/'(query-[\w-]+)'/", $core_registration_source, $matches );
+
+		$expected = array();
+		foreach ( array_unique( $matches[1] ) as $slug ) {
+			$file = ABSPATH . WPINC . '/block-patterns/' . $slug . '.php';
+			if ( ! file_exists( $file ) ) {
+				continue;
+			}
+			$pattern = require $file;
+			if ( is_array( $pattern ) && str_starts_with( trim( $pattern['content'] ?? '' ), '<!-- wp:query ' ) ) {
+				$expected[] = 'core/' . $slug;
+			}
+		}
+		sort( $expected );
+
+		wpcom_register_core_query_block_patterns();
+		$registered = $this->get_registered_core_query_pattern_names();
+		sort( $registered );
+
+		$this->assertSame(
+			$expected,
+			$registered,
+			'The query patterns bundled and registered by core changed. Update the allowlist in wpcom_register_core_query_block_patterns(), or exclude the new pattern here if it should not be offered.'
+		);
+	}
+
+	/**
 	 * Returns the names of all registered `core/query-*` patterns.
 	 *
 	 * @return string[]

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/Wpcom_Core_Query_Block_Patterns_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/Wpcom_Core_Query_Block_Patterns_Test.php
@@ -49,7 +49,10 @@ class Wpcom_Core_Query_Block_Patterns_Test extends TestCase {
 		$registry = WP_Block_Patterns_Registry::get_instance();
 		foreach ( $this->get_registered_core_query_pattern_names() as $name ) {
 			$pattern = $registry->get_registered( $name );
-			$blocks  = parse_blocks( trim( $pattern['content'] ) );
+			if ( ! is_array( $pattern ) ) {
+				$this->fail( "Pattern $name is not registered." );
+			}
+			$blocks = parse_blocks( trim( $pattern['content'] ) );
 			$this->assertSame( 'core/query', $blocks[0]['blockName'], "Pattern $name does not have a core/query root block." );
 		}
 	}
@@ -82,6 +85,9 @@ class Wpcom_Core_Query_Block_Patterns_Test extends TestCase {
 		wpcom_register_core_query_block_patterns();
 
 		$pattern = WP_Block_Patterns_Registry::get_instance()->get_registered( 'core/query-standard-posts' );
+		if ( ! is_array( $pattern ) ) {
+			$this->fail( 'Pattern core/query-standard-posts is not registered.' );
+		}
 		$this->assertSame( 'Pre-existing', $pattern['title'] );
 	}
 

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/Wpcom_Core_Query_Block_Patterns_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/block-patterns/Wpcom_Core_Query_Block_Patterns_Test.php
@@ -86,39 +86,17 @@ class Wpcom_Core_Query_Block_Patterns_Test extends TestCase {
 	}
 
 	/**
-	 * Guards the hardcoded allowlist against drifting from core.
-	 *
-	 * Derives the expected set from this WordPress copy itself: the `query-*`
-	 * slugs core lists in wp-includes/block-patterns.php, narrowed to the ones
-	 * with a `core/query` root block. Fails when a WordPress update adds,
-	 * renames, delists, or removes a bundled query pattern, so a human can
-	 * update (or deliberately not update) the allowlist.
+	 * Guards the hardcoded allowlist against drifting from core: if a
+	 * WordPress update renames or removes the bundled query patterns to the
+	 * point that none of the allowlisted files exist anymore, this fails
+	 * instead of the Query Loop pattern picker silently going empty.
 	 */
-	public function test_allowlist_stays_in_sync_with_core() {
-		$core_registration_source = file_get_contents( ABSPATH . WPINC . '/block-patterns.php' );
-		preg_match_all( "/'(query-[\w-]+)'/", $core_registration_source, $matches );
-
-		$expected = array();
-		foreach ( array_unique( $matches[1] ) as $slug ) {
-			$file = ABSPATH . WPINC . '/block-patterns/' . $slug . '.php';
-			if ( ! file_exists( $file ) ) {
-				continue;
-			}
-			$pattern = require $file;
-			if ( is_array( $pattern ) && str_starts_with( trim( $pattern['content'] ?? '' ), '<!-- wp:query ' ) ) {
-				$expected[] = 'core/' . $slug;
-			}
-		}
-		sort( $expected );
-
+	public function test_registers_at_least_one_core_query_pattern() {
 		wpcom_register_core_query_block_patterns();
-		$registered = $this->get_registered_core_query_pattern_names();
-		sort( $registered );
 
-		$this->assertSame(
-			$expected,
-			$registered,
-			'The query patterns bundled and registered by core changed. Update the allowlist in wpcom_register_core_query_block_patterns(), or exclude the new pattern here if it should not be offered.'
+		$this->assertNotEmpty(
+			$this->get_registered_core_query_pattern_names(),
+			'No core query pattern was registered. The bundled patterns likely changed; update the allowlist in wpcom_register_core_query_block_patterns().'
 		);
 	}
 


### PR DESCRIPTION
Related to EDI-562

## Proposed changes

On WordPress.com we blanket-disable core block patterns (`remove_theme_support( 'core-block-patterns' )`) so only the Dotcom pattern library is offered. A side effect is that the Query Loop block's "Choose a pattern" flow has nothing to offer, since it only lists patterns whose root block is `core/query` — and those all come from core.

* Re-register the core-bundled Query Loop patterns (`wp-includes/block-patterns/query-*.php`) on `init`, after the blanket removal.
* Only patterns whose parsed root block is `core/query` are registered, mirroring the Query Loop pattern picker's own filter. Section-style patterns that merely contain a query wrapped in a group (Offset, Large title) are excluded — the picker would hide them anyway, and this keeps them from leaking into other pattern surfaces alongside the Dotcom library.
* Globbing the files rather than hardcoding names keeps the list in sync as core adds/renames patterns (e.g. `query-grouped-posts` was replaced by `query-grid-posts`), and the guards degrade gracefully (register nothing) if core ever moves or removes the files.

## Related product discussion/links

* EDI-562

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a WordPress.com site (Simple or Atomic with jetpack-mu-wpcom), open the post editor.
* Insert a **Query Loop** block and pick **Choose** in the placeholder.
* The core query patterns should appear: Standard, Image at left, Small image and title, Grid (exact set depends on the WP version's bundled `query-*.php` files).
* Confirm no other core patterns (e.g. the social-links pattern, or the group-wrapped Offset / Large title sections) show up in the inserter, and the Dotcom pattern library still loads as before.
