### PR TITLE
VideoPress: fix the age gate in the block editor

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-editor-age-gate
+++ b/projects/packages/videopress/changelog/fix-videopress-editor-age-gate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix the age gate in the editor: the birth date can now be submitted, and lowering a video's rating removes the gate.

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/index.tsx
@@ -14,7 +14,22 @@ import useVideoPlayer, { getIframeWindowFromRef } from '../../../../hooks/use-vi
  * Types
  */
 import type { PlayerProps } from './types';
-import type { ReactElement } from 'react';
+import type { ComponentProps, ComponentType, ReactElement } from 'react';
+
+/*
+ * `allowForms` adds `allow-forms` to the sandbox iframe, which the player needs
+ * so the birth date form of the age gate can be submitted. It was added to
+ * SandBox in WordPress/gutenberg#76471 and is not part of the
+ * `@wordpress/components` version this package builds against yet, so the
+ * component is widened locally to accept it. Versions without the prop ignore
+ * it, leaving the age gate as blocked as it is today.
+ *
+ * Pass `allowForms` directly to `SandBox` and delete this once the bundled
+ * `@wordpress/components` includes the prop.
+ */
+const SandBoxWithForms = SandBox as ComponentType<
+	ComponentProps< typeof SandBox > & { allowForms?: boolean }
+>;
 
 // Global scripts array to be run in the Sandbox context.
 const sandboxScripts = [];
@@ -276,11 +291,12 @@ export default function Player( {
 				>
 					<>
 						{ ! isRequestingEmbedPreview && (
-							<SandBox
+							<SandBoxWithForms
 								html={ html }
 								scripts={ sandboxScripts }
 								styles={ [ innerContainerStyle ] }
 								allowSameOrigin
+								allowForms
 							/>
 						) }
 

--- a/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/test/index.test.tsx
+++ b/projects/packages/videopress/src/client/block-editor/blocks/video/components/player/test/index.test.tsx
@@ -15,11 +15,21 @@ jest.mock( '@wordpress/components', () => {
 	 * child and switches its contentWindow between a same-origin Window and
 	 * a cross-origin Proxy based on the `allowSameOrigin` prop.
 	 *
+	 * The `sandbox` attribute mirrors how the real component composes its
+	 * permissions, so tests can assert on the flags VideoPress opts into.
+	 *
 	 * @param {object}  props                 - Props forwarded from VideoPress.
 	 * @param {boolean} props.allowSameOrigin - Whether contentWindow should be same-origin.
+	 * @param {boolean} props.allowForms      - Whether the iframe may submit forms.
 	 * @return {ReactElement} A div hosting the simulated sandbox iframe.
 	 */
-	function SandBoxMock( { allowSameOrigin }: { allowSameOrigin?: boolean } ) {
+	function SandBoxMock( {
+		allowSameOrigin,
+		allowForms,
+	}: {
+		allowSameOrigin?: boolean;
+		allowForms?: boolean;
+	} ) {
 		return React.createElement( 'div', {
 			ref: ( host: HTMLDivElement | null ) => {
 				// Direct DOM access is intentional — this mock simulates the real
@@ -30,6 +40,17 @@ jest.mock( '@wordpress/components', () => {
 				}
 				const iframe = host.ownerDocument.createElement( 'iframe' );
 				iframe.className = 'components-sandbox';
+				iframe.setAttribute(
+					'sandbox',
+					[
+						'allow-scripts',
+						allowSameOrigin ? 'allow-same-origin' : null,
+						'allow-presentation',
+						allowForms ? 'allow-forms' : null,
+					]
+						.filter( Boolean )
+						.join( ' ' )
+				);
 
 				if ( allowSameOrigin ) {
 					Object.defineProperty( iframe, 'contentWindow', {
@@ -162,6 +183,18 @@ describe( 'Player', () => {
 
 			expect( securityErrors ).toEqual( [] );
 			expect( screen.getByRole( 'figure' ) ).toBeInTheDocument();
+		} );
+
+		it( 'allows form submission so the age gate birth date can be sent', () => {
+			// Videos whose rating requires an age check render a birth date form
+			// inside the player. Sandboxes block form submission unless
+			// `allow-forms` is set, which left "Continue" doing nothing.
+			const { container } = render( <Player { ...defaultProps } /> );
+
+			// eslint-disable-next-line testing-library/no-container, testing-library/no-node-access -- the sandbox iframe is created imperatively by the SandBox mock.
+			const iframe = container.querySelector( 'iframe.components-sandbox' );
+
+			expect( iframe ).toHaveAttribute( 'sandbox', expect.stringContaining( 'allow-forms' ) );
 		} );
 	} );
 

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-sync-media/index.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-sync-media/index.ts
@@ -77,6 +77,7 @@ const invalidateEmbedResolutionFields = [
 	'is_private',
 	'allow_download',
 	'display_embed',
+	'rating',
 ];
 
 /**

--- a/projects/packages/videopress/src/client/block-editor/hooks/use-sync-media/test/index.test.ts
+++ b/projects/packages/videopress/src/client/block-editor/hooks/use-sync-media/test/index.test.ts
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { renderHook, waitFor } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 /**
  * Internal dependencies
  */
@@ -200,5 +200,55 @@ describe( 'useSyncMedia auto-generated chapter upload', () => {
 		expect( tracksCall[ 0 ].tracks[ 0 ].src ).toBe(
 			'https://videos.files.wordpress.com/guid123/track.vtt'
 		);
+	} );
+} );
+
+describe( 'useSyncMedia embed invalidation', () => {
+	/**
+	 * Render a save transition with an empty description, so the auto-generated
+	 * chapter branch is skipped and the field-based invalidation path runs.
+	 *
+	 * @param {VideoBlockAttributes} attributes - Block attributes to sync.
+	 * @return {object} The renderHook result.
+	 */
+	function renderSaveWithoutChapters( attributes: VideoBlockAttributes ) {
+		const setAttributes = jest.fn() as jest.MockedFunction< VideoBlockSetAttributesProps >;
+
+		mockUseSelect.mockReturnValue( true );
+		const utils = renderHook( () => useSyncMedia( attributes, setAttributes ) );
+
+		mockUseSelect.mockReturnValue( false );
+		utils.rerender();
+
+		return utils;
+	}
+
+	it( 'refreshes the player when the rating changes', async () => {
+		/*
+		 * Raising or lowering the rating adds or removes the age gate, but the
+		 * rating is not part of the embed URL, so without an explicit
+		 * invalidation the cached preview keeps rendering the stale gate.
+		 */
+		renderSaveWithoutChapters( { ...baseAttributes, description: '', rating: 'G' } );
+
+		await waitFor( () =>
+			expect( invalidateResolution ).toHaveBeenCalledWith( 'getEmbedPreview', [
+				'https://videopress.com/v/guid123',
+			] )
+		);
+	} );
+
+	it( 'leaves the player alone for fields the embed does not depend on', async () => {
+		renderSaveWithoutChapters( { ...baseAttributes, description: '', duration: 42 } );
+
+		await waitFor( () => expect( updateMediaHandler ).toHaveBeenCalled() );
+
+		// Settle the very promise the hook hangs its invalidation off, so a
+		// missing call is a real absence and not an assertion that ran early.
+		await act( async () => {
+			await updateMediaHandler.mock.results[ 0 ].value;
+		} );
+
+		expect( invalidateResolution ).not.toHaveBeenCalled();
 	} );
 } );


### PR DESCRIPTION
Fixes #28375

## Proposed changes

This issue was two independent bugs that presented as one. Both are fixed here.

**1. The age gate's "Continue" button did nothing.**

The editor renders the player inside Gutenberg's `SandBox`, and an iframe's `sandbox` flags are inherited by every nested browsing context — including the `videopress.com` player frame that hosts the age gate. Without `allow-forms`, the browser blocked the birth date submission outright:

```
Blocked form submission to '' because the form's frame is sandboxed
and the 'allow-forms' permission is not set.
```

This was unfixable from Jetpack until [WordPress/gutenberg#76471](https://github.com/WordPress/gutenberg/pull/76471) added an `allowForms` prop to `SandBox`. That PR is merged but not yet released, so `SandBoxWithForms` widens the component type locally to accept the prop. Module augmentation is not an option here — `SandBoxProps` is not re-exported from `@wordpress/components`' root and `./sandbox` is not in the package `exports` map. Older versions ignore the unknown prop, so the age gate simply stays as blocked as it is today until the bundled version catches up. The comment on that cast says to delete it and pass `allowForms` directly once it does.

**2. Lowering a video's rating left the age gate on screen.**

`use-sync-media` keeps two parallel field lists: `videoFieldsToUpdate` (pushed to the VideoPress API on save) and `invalidateEmbedResolutionFields` (triggers `invalidateResolution( 'getEmbedPreview', … )`). `rating` was in the first and missing from the second, so the API took the new rating — a page reload showed the correct state — while the cached oEmbed preview kept serving HTML with the gate baked in. That also explains the original report that changing *any other* video attribute cleared it: `title`, `privacy_setting`, `allow_download` and `display_embed` are all on the invalidation list.

Worth noting for reviewers: the comment above that list mentions some fields are "handled indirectly by the VideoPress video URL". That is true for `loop`, `autoplay`, `color` and friends, which `getVideoPressUrl` puts in the query string so a change produces a different URL and misses the cache naturally. `rating` is not one of its args, so it had no implicit invalidation to fall back on — hence the explicit list entry rather than a URL change.

## Related product discussion/links

* [WordPress/gutenberg#76471](https://github.com/WordPress/gutenberg/pull/76471) — the upstream `allowForms` prop this depends on.
* [WordPress/gutenberg#48942](https://github.com/WordPress/gutenberg/issues/48942) — the upstream issue that blocked this since 2023.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

**Fix 1 requires the Gutenberg plugin on `trunk`** (or any build including gutenberg#76471). Without it the prop is silently ignored and the age gate stays blocked — that is the intended graceful degradation, not a regression.

Set up a video whose rating requires an age check:

* Add a VideoPress block to a post, open the block sidebar, and expand **Privacy and rating**.
* Set **Rating** to **R** and save the post. Reload the editor — the player should show "This video may display mature content" with MM / DD / YYYY fields and a **Continue** button.

Verify the form submits:

* Click the block to select it (the block overlay swallows clicks while it is unselected).
* Fill in a birth date over 17 years ago and click **Continue**.
* The gate should clear and the video should become playable. On `trunk` today it does nothing.
* Optional: inspect `iframe.components-sandbox` in the editor canvas. Its `sandbox` attribute should now read `allow-scripts allow-same-origin allow-presentation allow-forms`.

Verify the gate goes away when the rating is lowered:

* With the gate showing, set **Rating** back to **G** and **save the post** — the sync runs on a save transition, not on the dropdown change itself.
* The player should refresh on its own and drop the age gate, with no page reload.
* Before this change, the gate persisted until you changed some other video attribute or reloaded the page.

Automated coverage:

* `jp test js packages/videopress` — 642 tests pass. The new cases are "allows form submission so the age gate birth date can be sent" and, in `use-sync-media`, "refreshes the player when the rating changes" plus a negative control asserting fields the embed does not depend on do not trigger a refresh.
