### PR TITLE
Docs: document the wpcom-only symbol / Phan stub workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -266,6 +266,22 @@ Before introducing new dependencies:
 - **Do NOT modify `$$next-version$$` placeholders** — they are replaced automatically at release time
 - **Reuse monorepo packages** before adding external dependencies — check `projects/packages/` and `projects/js-packages/` first
 - **Git merge conflicts**: after resolving, use `git commit --no-edit --no-verify` — pre-commit hooks can make unintended changes to merge commit files
+- **Do NOT hand-edit generated Phan stubs** — `.phan/stubs/wpcom-stubs.php` (and other generated stub files) are regenerated from the wpcom repo; any manual edit is overwritten. See *Referencing wpcom-only symbols from Jetpack* below.
+
+## Referencing wpcom-only symbols from Jetpack (Phan stubs)
+
+When Jetpack code calls a class or function that ships only from wpcom (not present in this repo), Phan flags `PhanUndeclared{Class,ClassMethod,Function}`. Do NOT just silence it permanently. The correct order is:
+
+1. **Add the symbol to the wpcom stub definitions** — `bin/teamcity-builds/jetpack-stubs/stub-defs.php` in the wpcom repo. This is the source that Jetpack's `.phan/stubs/wpcom-stubs.php` is regenerated from.
+2. **Get the regenerated stubs merged into Jetpack first** — triggering the *Jetpack Staging → Update WPCOM Stubs* job in TeamCity opens a "phan: Update wpcom stubs" PR. Land that before your feature PR.
+3. **Rebase your feature PR** on trunk so it picks up the new stubs.
+4. **Remove the suppression** — the symbol is now declared, so Phan passes without it.
+
+An inline `@phan-suppress-next-line <Rule> -- <reason>` is acceptable ONLY as a temporary bridge until step 2 lands, and MUST carry a `-- <reason>` justification.
+
+**Gotchas:**
+- The "phan: Update wpcom stubs" PR is machine-generated and gets rebased/recreated on every job run — never hand-edit it, your changes will be overwritten.
+- `.phan/stubs/wpcom-stubs.php` is likewise generated (its header says so). Never edit it directly to add a symbol — add it to `stub-defs.php` in wpcom instead.
 
 ## Maintaining This File
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -270,7 +270,7 @@ Before introducing new dependencies:
 
 ## Referencing wpcom-only symbols from Jetpack (Phan stubs)
 
-When Jetpack code calls a class or function that ships only from wpcom (not present in this repo), Phan flags `PhanUndeclared{Class,ClassMethod,Function}`. Do NOT just silence it permanently. The correct order is:
+When Jetpack code calls a class or function that ships only from wpcom (not present in this repo), Phan flags `PhanUndeclared{Class,ClassMethod,Function}`. Do NOT just silence it permanently. See also `docs/monorepo.md` § Static Analysis → *Referencing wpcom-only symbols*. The correct order is:
 
 1. **Add the symbol to the wpcom stub definitions** — `bin/teamcity-builds/jetpack-stubs/stub-defs.php` in the wpcom repo. This is the source that Jetpack's `.phan/stubs/wpcom-stubs.php` is regenerated from.
 2. **Get the regenerated stubs merged into Jetpack first** — triggering the *Jetpack Staging → Update WPCOM Stubs* job in TeamCity opens a "phan: Update wpcom stubs" PR. Land that before your feature PR.

--- a/docs/monorepo.md
+++ b/docs/monorepo.md
@@ -254,6 +254,14 @@ This assumes you have PHP installed via Homebrew, e.g. you've done `brew install
 
 Alternatives, if you can't install the ast extension, include running Phan with the `--allow-polyfill-parser` option (note this may cause false positives and cannot be used to update baseline files) or running Phan inside the [Docker development environment](../tools/docker/README.md).
 
+#### Referencing wpcom-only symbols
+
+Some Jetpack code calls classes or functions that exist only on WordPress.com, not in this repo. Phan flags these as `PhanUndeclared{Class,ClassMethod,Function}`. Rather than suppressing the error permanently, add the symbol to Phan's stub set:
+
+1. Add the class/method (or function) to the wpcom stub definitions at `bin/teamcity-builds/jetpack-stubs/stub-defs.php` in the wpcom repo — this is the source that the monorepo's `.phan/stubs/wpcom-stubs.php` is generated from. Do **not** hand-edit the generated `wpcom-stubs.php`; it will be overwritten.
+2. Trigger the *Jetpack Staging → Update WPCOM Stubs* TeamCity job, which opens a "phan: Update wpcom stubs" PR. Land that PR first, then rebase your feature PR on top so it picks up the new stubs.
+3. Remove any temporary inline `@phan-suppress-next-line <Rule> -- <reason>` you added at the call site as a bridge — once the stub exists, Phan passes without it.
+
 [^1]: In 2024 we evaluated Phan, Psalm, and PHPStan. Psalm was unable to produce a consistent baseline. PHPStan was confused about which constants were defined, and would have needed a bootstrapping file re-defining them all to work. Thus we settled on Phan. Details in pdWQjU-IH-p2.
 
 ### PHP tests


### PR DESCRIPTION
## Proposed changes

Documents the workflow for referencing a wpcom-only class or function from Jetpack, so contributors (and AI agents) resolve `PhanUndeclared{Class,ClassMethod,Function}` correctly instead of silencing it permanently or hand-editing generated files.

* Add a "Referencing wpcom-only symbols from Jetpack (Phan stubs)" section to `AGENTS.md` (loaded into every agent's context in this repo), plus a Common Pitfalls bullet.
* Add a "Referencing wpcom-only symbols" subsection to the Static Analysis section of `docs/monorepo.md` (the human-facing home for the Phan workflow), and cross-link the two.

The workflow captured: add the symbol to the wpcom `stub-defs.php`, land the regenerated "phan: Update wpcom stubs" PR first, rebase, then drop the temporary inline `@phan-suppress` bridge — with warnings against hand-editing the generated `.phan/stubs/wpcom-stubs.php` or the machine-generated stubs PR (both get overwritten).

This came out of review feedback on #50969, where the ordering had to be explained inline.

### On public-repo safety

Every internal reference in these docs is already public in this repo. The wpcom stub-definition path (`bin/teamcity-builds/jetpack-stubs/stub-defs.php`) and the *Jetpack Staging → Update WPCOM Stubs* TeamCity job name are both quoted verbatim in the committed header of `.phan/stubs/wpcom-stubs.php`, so nothing new is exposed. No internal site addresses, build URLs, or user data are included — the TeamCity job is referenced by name only, not by its internal URL.

## Related product discussion/links

* Follow-up to review discussion on #50969.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Documentation only — no code changes, no changelog needed (both files are outside `/projects`).

* Read the new "Referencing wpcom-only symbols" content in `docs/monorepo.md` (§ Static Analysis) and `AGENTS.md`.
* Confirm the steps and cross-links are accurate and render correctly.
