### PR TITLE
wp-build: restore PHP 7.2 page compatibility

### DIFF
--- a/.pnpm-patches/@wordpress__build.patch
+++ b/.pnpm-patches/@wordpress__build.patch
@@ -30,3 +30,6 @@ index 96c4627..48fcf28 100644
  			};
  			if ( document.readyState === "loading" ) {
  				document.addEventListener( "DOMContentLoaded", run );
+@@ -182 +201 @@
+-		JS;
++JS;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 pnpmfileChecksum: sha256-ZW2BoUDYyI5nkZ8o3EkCzocg7Bspf+AzfFGBEEoeEK8=
 
 patchedDependencies:
-  '@wordpress/build': 5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945
+  '@wordpress/build': 151ae1c0c3786b862724512e48d8cfcb4b34faf4cac98e352a450abd4741e022
   react-autosize-textarea: 5c09e1dee59caaaba3871f9d722f93e56b41169db486b059597e8f8c788aa464
   uuid@<11: 87a713b75995ed86c0ecd0cadfd1b9f85092ca16fdff7132ff98b62fc3cf2db0
 
@@ -1898,7 +1898,7 @@ importers:
         version: 6.51.0
       '@wordpress/build':
         specifier: 0.20.0
-        version: 0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
+        version: 0.20.0(patch_hash=151ae1c0c3786b862724512e48d8cfcb4b34faf4cac98e352a450abd4741e022)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
       '@wordpress/theme':
         specifier: 1.1.0
         version: 1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2128,7 +2128,7 @@ importers:
         version: 6.51.0
       '@wordpress/build':
         specifier: 0.20.0
-        version: 0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
+        version: 0.20.0(patch_hash=151ae1c0c3786b862724512e48d8cfcb4b34faf4cac98e352a450abd4741e022)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
       autoprefixer:
         specifier: 10.4.20
         version: 10.4.20(postcss@8.5.23)
@@ -2765,7 +2765,7 @@ importers:
         version: 6.51.0
       '@wordpress/build':
         specifier: 0.20.0
-        version: 0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
+        version: 0.20.0(patch_hash=151ae1c0c3786b862724512e48d8cfcb4b34faf4cac98e352a450abd4741e022)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
       '@wordpress/date':
         specifier: 5.51.0
         version: 5.51.0
@@ -3089,7 +3089,7 @@ importers:
         version: 6.51.0
       '@wordpress/build':
         specifier: 0.20.0
-        version: 0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.52.0)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
+        version: 0.20.0(patch_hash=151ae1c0c3786b862724512e48d8cfcb4b34faf4cac98e352a450abd4741e022)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.52.0)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
       autoprefixer:
         specifier: 10.4.20
         version: 10.4.20(postcss@8.5.23)
@@ -3527,7 +3527,7 @@ importers:
         version: 6.51.0
       '@wordpress/build':
         specifier: 0.20.0
-        version: 0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
+        version: 0.20.0(patch_hash=151ae1c0c3786b862724512e48d8cfcb4b34faf4cac98e352a450abd4741e022)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
       autoprefixer:
         specifier: 10.4.20
         version: 10.4.20(postcss@8.5.23)
@@ -3883,7 +3883,7 @@ importers:
         version: 6.51.0
       '@wordpress/build':
         specifier: 0.20.0
-        version: 0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
+        version: 0.20.0(patch_hash=151ae1c0c3786b862724512e48d8cfcb4b34faf4cac98e352a450abd4741e022)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
       '@wordpress/theme':
         specifier: 1.1.0
         version: 1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -4097,7 +4097,7 @@ importers:
         version: 11.0.0
       '@wordpress/build':
         specifier: 0.20.0
-        version: 0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.52.0)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
+        version: 0.20.0(patch_hash=151ae1c0c3786b862724512e48d8cfcb4b34faf4cac98e352a450abd4741e022)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.52.0)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
       browserslist:
         specifier: 4.28.4
         version: 4.28.4
@@ -4282,7 +4282,7 @@ importers:
         version: 6.51.0
       '@wordpress/build':
         specifier: 0.20.0
-        version: 0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
+        version: 0.20.0(patch_hash=151ae1c0c3786b862724512e48d8cfcb4b34faf4cac98e352a450abd4741e022)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
       autoprefixer:
         specifier: 10.4.20
         version: 10.4.20(postcss@8.5.23)
@@ -4524,7 +4524,7 @@ importers:
         version: 6.51.0
       '@wordpress/build':
         specifier: 0.20.0
-        version: 0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
+        version: 0.20.0(patch_hash=151ae1c0c3786b862724512e48d8cfcb4b34faf4cac98e352a450abd4741e022)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
       browserslist:
         specifier: ^4.24.0
         version: 4.28.4
@@ -4844,7 +4844,7 @@ importers:
         version: 6.51.0
       '@wordpress/build':
         specifier: 0.20.0
-        version: 0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
+        version: 0.20.0(patch_hash=151ae1c0c3786b862724512e48d8cfcb4b34faf4cac98e352a450abd4741e022)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
       '@wordpress/theme':
         specifier: 1.1.0
         version: 1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -5062,7 +5062,7 @@ importers:
         version: 6.51.0
       '@wordpress/build':
         specifier: 0.20.0
-        version: 0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
+        version: 0.20.0(patch_hash=151ae1c0c3786b862724512e48d8cfcb4b34faf4cac98e352a450abd4741e022)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
       autoprefixer:
         specifier: 10.4.20
         version: 10.4.20(postcss@8.5.23)
@@ -5138,7 +5138,7 @@ importers:
         version: 6.51.0
       '@wordpress/build':
         specifier: 0.20.0
-        version: 0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.52.0)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
+        version: 0.20.0(patch_hash=151ae1c0c3786b862724512e48d8cfcb4b34faf4cac98e352a450abd4741e022)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.52.0)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)
       '@wordpress/compose':
         specifier: 8.4.0
         version: 8.4.0(@types/react@18.3.28)(react@18.3.1)
@@ -25391,7 +25391,7 @@ snapshots:
 
   '@wordpress/browserslist-config@6.51.0': {}
 
-  '@wordpress/build@0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.52.0)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)':
+  '@wordpress/build@0.20.0(patch_hash=151ae1c0c3786b862724512e48d8cfcb4b34faf4cac98e352a450abd4741e022)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@date-fns/tz@1.4.1)(@types/react@18.3.28)(date-fns@4.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.52.0)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)':
     dependencies:
       '@emotion/babel-plugin': 11.13.5
       '@wordpress/style-runtime': 0.8.0
@@ -25419,7 +25419,7 @@ snapshots:
       - browserslist
       - supports-color
 
-  '@wordpress/build@0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.52.0)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)':
+  '@wordpress/build@0.20.0(patch_hash=151ae1c0c3786b862724512e48d8cfcb4b34faf4cac98e352a450abd4741e022)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.52.0)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)':
     dependencies:
       '@emotion/babel-plugin': 11.13.5
       '@wordpress/style-runtime': 0.8.0
@@ -25447,7 +25447,7 @@ snapshots:
       - browserslist
       - supports-color
 
-  '@wordpress/build@0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)':
+  '@wordpress/build@0.20.0(patch_hash=151ae1c0c3786b862724512e48d8cfcb4b34faf4cac98e352a450abd4741e022)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)':
     dependencies:
       '@emotion/babel-plugin': 11.13.5
       '@wordpress/style-runtime': 0.8.0
@@ -25474,7 +25474,7 @@ snapshots:
       - browserslist
       - supports-color
 
-  '@wordpress/build@0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)':
+  '@wordpress/build@0.20.0(patch_hash=151ae1c0c3786b862724512e48d8cfcb4b34faf4cac98e352a450abd4741e022)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)':
     dependencies:
       '@emotion/babel-plugin': 11.13.5
       '@wordpress/style-runtime': 0.8.0
@@ -25501,7 +25501,7 @@ snapshots:
       - browserslist
       - supports-color
 
-  '@wordpress/build@0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.52.0)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)':
+  '@wordpress/build@0.20.0(patch_hash=151ae1c0c3786b862724512e48d8cfcb4b34faf4cac98e352a450abd4741e022)(@babel/core@7.29.7)(@wordpress/boot@0.19.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/private-apis@1.52.0)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)':
     dependencies:
       '@emotion/babel-plugin': 11.13.5
       '@wordpress/style-runtime': 0.8.0
@@ -25529,7 +25529,7 @@ snapshots:
       - browserslist
       - supports-color
 
-  '@wordpress/build@0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)':
+  '@wordpress/build@0.20.0(patch_hash=151ae1c0c3786b862724512e48d8cfcb4b34faf4cac98e352a450abd4741e022)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(postcss@8.5.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)':
     dependencies:
       '@emotion/babel-plugin': 11.13.5
       '@wordpress/style-runtime': 0.8.0
@@ -25555,7 +25555,7 @@ snapshots:
       - browserslist
       - supports-color
 
-  '@wordpress/build@0.20.0(patch_hash=5101ca7f7d13e7288807e098a40232362baae7ffcb00d08f28e0642c373ae945)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)':
+  '@wordpress/build@0.20.0(patch_hash=151ae1c0c3786b862724512e48d8cfcb4b34faf4cac98e352a450abd4741e022)(@babel/core@7.29.7)(@wordpress/route@0.18.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@wordpress/theme@1.1.0(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(browserslist@4.28.4)':
     dependencies:
       '@emotion/babel-plugin': 11.13.5
       '@wordpress/style-runtime': 0.8.0

--- a/projects/packages/activity-log/changelog/fix-php72-wp-build-page
+++ b/projects/packages/activity-log/changelog/fix-php72-wp-build-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Restore PHP 7.2 compatibility for the Activity Log admin page.

--- a/projects/packages/premium-analytics/changelog/fix-php72-wp-build-page
+++ b/projects/packages/premium-analytics/changelog/fix-php72-wp-build-page
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Restore PHP 7.2 compatibility for the Premium Analytics admin page.


### PR DESCRIPTION
## Proposed changes

* Move the generated admin-page heredoc closing marker to column 1 so PHP 7.2 can parse it.
* Update the pnpm patch hash in the lockfile.
* Add patch changelog entries for Activity Log and Premium Analytics.

The Activity Log exposure was introduced by its wp-build migration in [#50714](https://github.com/Automattic/jetpack/pull/50714) on July 22, 2026. Premium Analytics used the affected generator when the package was introduced in [#48085](https://github.com/Automattic/jetpack/pull/48085) on April 15, 2026, and it entered the Jetpack release artifact in [#50768](https://github.com/Automattic/jetpack/pull/50768) on July 28, 2026.

The fix has one intentional side effect: generated inline JavaScript retains its leading indentation because PHP no longer strips the heredoc indentation. That only adds insignificant whitespace; JavaScript behavior is unchanged. The shared patch affects future pages produced by the same wp-build template.

This PR intentionally targets `trunk`. After review and manual merge, the `wp-build: restore PHP 7.2 page compatibility` commit will be cherry-picked to `jetpack/branch-16.1` before the release. The other affected packages already have pending changelog entries on `trunk`, so this PR does not add duplicate release metadata for them.

## Related product discussion/links

* None.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run `pnpm run build` in `projects/packages/activity-log`.
* Run `pnpm run build` in `projects/packages/premium-analytics`.
* Run `php -l` on each generated `build/pages/*/page-wp-admin.php` file.
* Run `vendor/bin/phpcs --standard=PHPCompatibilityWP --runtime-set testVersion 7.2-` against both generated admin-page PHP files.
* Confirm each generated heredoc closing marker starts at column 1.

Both package builds, PHP syntax checks, PHPCompatibilityWP checks for PHP 7.2, patch application checks for the two installed `@wordpress/build` versions, changelog checks, and whitespace checks pass locally.
