### PR TITLE
AI Assistant: scroll the Form block's prompt into view instead of over the form

### DIFF
--- a/projects/plugins/jetpack/changelog/dsgcom-549-scroll-to-reveal-ai-prompt
+++ b/projects/plugins/jetpack/changelog/dsgcom-549-scroll-to-reveal-ai-prompt
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI Assistant: Scroll the Form block's AI prompt into view when it opens, so it no longer sits over the form.

--- a/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/text-blocks/with-ai-text-extension.tsx
+++ b/projects/plugins/jetpack/extensions/blocks/ai-assistant/extensions/text-blocks/with-ai-text-extension.tsx
@@ -9,9 +9,9 @@ import {
 	useAiFeature,
 } from '@automattic/jetpack-ai-client';
 import { useAnalytics } from '@automattic/jetpack-shared-extension-utils';
-import { BlockControls, useBlockProps } from '@wordpress/block-editor';
+import { BlockControls, store as blockEditorStore, useBlockProps } from '@wordpress/block-editor';
 import { createHigherOrderComponent } from '@wordpress/compose';
-import { useDispatch, useSelect } from '@wordpress/data';
+import { useDispatch, useRegistry, useSelect } from '@wordpress/data';
 import { useCallback, useEffect, useState, useRef, useMemo } from '@wordpress/element';
 import { addFilter, doAction } from '@wordpress/hooks';
 import clsx from 'clsx';
@@ -71,6 +71,8 @@ type RequestOptions = {
 
 type CoreEditorDispatch = { undo: () => Promise< void > };
 type CoreEditorSelect = { getCurrentPostId: () => number };
+// Not part of the block editor store's published types, though it is a real selector.
+type BlockInsertionSelect = { wasBlockJustInserted: ( clientId: string ) => boolean };
 
 // HOC to populate the block's edit component with the AI Assistant control input and toolbar button.
 const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
@@ -112,6 +114,8 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 		const { id, className } = useBlockProps( {
 			className: clsx( { [ blockName?.replace?.( '/', '-' ) ]: true } ),
 		} );
+
+		const registry = useRegistry();
 
 		// Jetpack AI Assistant feature functions.
 		const { increaseRequestsCount, dequeueAsyncRequest, requireUpgrade } = useAiFeature();
@@ -446,6 +450,65 @@ const blockEditWithAiComponents = createHigherOrderComponent( BlockEdit => {
 				focusInput();
 			}
 		}, [ showAiControl, focusInput, isSelectionEnabled ] );
+
+		// Scroll a newly inserted block into view along with the AI control below it. The control is
+		// sticky to the bottom of the viewport, so on a tall block it sits over the block's last
+		// content, and focusing it does not help — a pinned element already counts as visible.
+		//
+		// Mount only: wasBlockJustInserted() stays true until the next insertion.
+		useEffect( () => {
+			const control = controlRef.current;
+
+			// Blocks that pad their own bottom already leave room. Skip unselected ones too: a pattern
+			// marks every block it inserts as just inserted, including forms buried inside one.
+			if ( adjustPosition || ! control || ! isSelected ) {
+				return;
+			}
+
+			const blockEditor = registry.select( blockEditorStore );
+			const { wasBlockJustInserted } = blockEditor as unknown as BlockInsertionSelect;
+
+			// An empty form renders a variation picker, whose options start at the top.
+			if ( ! wasBlockJustInserted( clientId ) || blockEditor.getBlockCount( clientId ) === 0 ) {
+				return;
+			}
+
+			const block = control.ownerDocument.getElementById( id );
+			const view = control.ownerDocument.defaultView;
+
+			if ( ! block || ! view ) {
+				return;
+			}
+
+			// scrollIntoView( 'end' ) scrolls even when nothing is covered, so look for an overlap.
+			const controlRect = control.getBoundingClientRect();
+
+			if ( block.getBoundingClientRect().bottom <= controlRect.top ) {
+				return;
+			}
+
+			// A stuck element reports where it is held, not where it belongs, so scrolling to it does
+			// nothing. Unstick it and the browser places it against the block, spaced by their margin.
+			const scrollControlIntoPlace = () => {
+				const { bottom } = view.getComputedStyle( control );
+				const originalPosition = control.style.position;
+				const originalScrollMarginBottom = control.style.scrollMarginBottom;
+
+				control.style.position = 'static';
+				control.style.scrollMarginBottom = bottom;
+				control.scrollIntoView( { block: 'end' } );
+				control.style.position = originalPosition;
+				control.style.scrollMarginBottom = originalScrollMarginBottom;
+			};
+
+			// Once now, so that the editor's own scroll on selection finds the block already in view and
+			// leaves it where we put it. Once more next frame, by when the control has grown into its
+			// message and request count — without which sticky lifts the taller control back over the
+			// block, taking the gap with it.
+			scrollControlIntoPlace();
+			view.requestAnimationFrame( scrollControlIntoPlace );
+			// eslint-disable-next-line react-hooks/exhaustive-deps -- Runs on mount only.
+		}, [] );
 
 		// Adjusts the input position in the editor by increasing the block's bottom-padding
 		// and setting the control's margin-top, "wrapping" the input with the block.


### PR DESCRIPTION
## Proposed changes

* The AI Assistant prompt is pinned to the bottom of the viewport. That is what keeps it reachable while a block grows during generation, and it is also what leaves it sitting over the block until the block's end has been scrolled past. Insert an Appointment Form taller than the viewport and you land at the form's top with the prompt lying across the bottom of it, over the Notes field and the "Book appointment" button.
* Focus does not resolve it, and the reason is worth stating: opening the prompt focuses it, and focus scrolls its target into view — but a pinned element already counts as in view, so there is nothing to scroll to. The pinning suppresses the very scroll that would have settled the prompt below the block. This is also why scrolling down by hand fixes it: once the block's end passes, the prompt reaches its resting place and stops overlapping.
* So a form is scrolled to as it arrives, by scrolling the block with the room the prompt needs reserved beneath it. The form's end and the prompt come into view together, and the prompt settles below the form instead of across it. The question is asked once, as the block appears — the only moment the editor's record of the last block inserted is about this block rather than an earlier one — and only answered where the prompt is genuinely over the form. A short form already clear of it does not move, and blocks that pad their own bottom for the prompt already carry that room and are left alone.

## Related product discussion/links

* DSGCOM-549

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Requires a site with Jetpack AI available.

**On a phone-sized viewport (375px wide — a real device, or your browser's device emulation):**

* Open the post editor and insert an Appointment Form block, or any Form block variation tall enough to exceed the viewport.
* Confirm the editor settles showing the end of the form with the prompt below it, and that nothing is covered. Before this change the prompt sat across the bottom of the form, hiding the Notes field and the "Book appointment" button until dismissed.
* Ask it for a change ("add a phone number field") and confirm generation behaves as it does on trunk.
* Close the prompt and reopen it from the block toolbar. This deliberately does not scroll — reopening on a form already on the page behaves as it does on trunk, and scrolling past the form's end resolves it as it does today.
* Insert a plain Form block instead, so it opens on its variation picker. The editor should stay put and leave the choices where they are. Picking a variation from it does not move anything either, since at the moment that block arrived there was only a picker; picking a *pattern* does, because that replaces the block outright and the new one arrives with its fields already in place. Worth trying sideways too, where the picker is likeliest to outgrow the screen.

**On a desktop viewport:**

* Insert a Form block and confirm the prompt opens below the form as it does today, and that a form short enough to sit clear of the prompt produces no scroll at all.
* Repeat with a form long enough to exceed the window height — the editor should settle on the form's end with the prompt below it, rather than the prompt lying over the form.
* Insert a paragraph, heading, and list block and run a request from each. These are untouched: the new scroll is skipped for blocks that pad their own bottom for the prompt.

**Loading a post that already contains forms:**

* Open a post with one or more Form blocks in it, ideally further down the page, and confirm the editor stays where it opens rather than jumping to a form.

## Scope

This answers for the moment the report describes — the form arriving with the prompt already across it — and leaves the pinning alone otherwise. Opening the prompt on a form already on the page, choosing a variation from a plain form's picker, or scrolling back up through a form mid-request all still put the prompt over the form as they do on trunk, and scrolling past the form's end still resolves it. Choosing a *pattern* from that picker does scroll, since it replaces the block and the replacement arrives with its fields already there — the same position as inserting a variation outright.

An earlier attempt instead took the prompt out of its pinned positioning for the Form block on narrow screens, so it sat in the document below the form and could not overlap at all. It costs considerably more: once the prompt no longer pins itself, everything the pinning did for free has to be rebuilt — following the content while it generates, keeping the Stop button reachable, restoring the prompt after the closing update, revealing it when a request fails. That version is on `dsgcom-549-editor-ai-assistant-prompt-covers-the-appointment-forms` for comparison.
