### PR TITLE
STATS-343: Recognize the standalone Jetpack Stats plugin in My Jetpack

### DIFF
--- a/projects/packages/my-jetpack/changelog/stats-343-my-jetpack-stats-hybrid
+++ b/projects/packages/my-jetpack/changelog/stats-343-my-jetpack-stats-hybrid
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Stats: recognize the standalone Jetpack Stats plugin as a product install target.

--- a/projects/packages/my-jetpack/changelog/stats-343-my-jetpack-stats-hybrid
+++ b/projects/packages/my-jetpack/changelog/stats-343-my-jetpack-stats-hybrid
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Stats: recognize the standalone Jetpack Stats plugin as a product install target.
+Stats: Recognize the standalone Jetpack Stats plugin as a product install target.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -59,6 +59,7 @@ class Initializer {
 		'jetpack-social',
 		'jetpack-videopress',
 		'jetpack-search',
+		'jetpack-stats',
 	);
 
 	private const MY_JETPACK_SITE_INFO_TRANSIENT_KEY = 'my-jetpack-site-info';
@@ -527,7 +528,7 @@ class Initializer {
 	public static function get_my_jetpack_flags() {
 		$flags = array(
 			'videoPressStats'          => Jetpack_Constants::is_true( 'JETPACK_MY_JETPACK_VIDEOPRESS_STATS_ENABLED' ),
-			'showFullJetpackStatsCard' => class_exists( 'Jetpack' ),
+			'showFullJetpackStatsCard' => class_exists( 'Jetpack' ) || Products\Stats::is_standalone_plugin_active(),
 			// Only says which destination `manage_url` is: the legacy Stats page
 			// caches its report and wants a `force_refresh` hint the dashboard does not.
 			'premiumAnalyticsEnabled'  => Products\Stats::is_premium_analytics_enabled(),

--- a/projects/packages/my-jetpack/src/products/class-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-stats.php
@@ -7,9 +7,9 @@
 
 namespace Automattic\Jetpack\My_Jetpack\Products;
 
+use Automattic\Jetpack\My_Jetpack\Hybrid_Product;
 use Automattic\Jetpack\My_Jetpack\Initializer;
-use Automattic\Jetpack\My_Jetpack\Module_Product;
-use Automattic\Jetpack\My_jetpack\Products;
+use Automattic\Jetpack\My_Jetpack\Products;
 use Automattic\Jetpack\My_Jetpack\Wpcom_Products;
 use Automattic\Jetpack\Status\Host;
 use Jetpack_Options;
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Class responsible for handling the Jetpack Stats product
  */
-class Stats extends Module_Product {
+class Stats extends Hybrid_Product {
 	/**
 	 * The product slug
 	 *
@@ -48,14 +48,18 @@ class Stats extends Module_Product {
 	 *
 	 * @var string|null
 	 */
-	public static $plugin_slug = self::JETPACK_PLUGIN_SLUG;
+	public static $plugin_slug = 'jetpack-stats';
 
 	/**
 	 * The Plugin file associated with stats
 	 *
-	 * @var string|null
+	 * @var string|array|null
 	 */
-	public static $plugin_filename = self::JETPACK_PLUGIN_FILENAME;
+	public static $plugin_filename = array(
+		'jetpack-stats/jetpack-stats.php',
+		'stats/jetpack-stats.php',
+		'jetpack-stats-dev/jetpack-stats.php',
+	);
 
 	/**
 	 * Stats only requires site connection, not user connection
@@ -63,13 +67,6 @@ class Stats extends Module_Product {
 	 * @var bool
 	 */
 	public static $requires_user_connection = false;
-
-	/**
-	 * Stats does not have a standalone plugin (yet?)
-	 *
-	 * @var bool
-	 */
-	public static $has_standalone_plugin = false;
 
 	/**
 	 * Whether this product has a free offering

--- a/projects/packages/my-jetpack/src/products/class-stats.php
+++ b/projects/packages/my-jetpack/src/products/class-stats.php
@@ -53,7 +53,7 @@ class Stats extends Hybrid_Product {
 	/**
 	 * The Plugin file associated with stats
 	 *
-	 * @var string|array|null
+	 * @var string[]
 	 */
 	public static $plugin_filename = array(
 		'jetpack-stats/jetpack-stats.php',
@@ -191,6 +191,12 @@ class Stats extends Hybrid_Product {
 			// If the site has never been connected before, show the "Learn more" CTA,
 			// that points to the add Stats product interstitial.
 			$status = Products::STATUS_NEEDS_FIRST_SITE_CONNECTION;
+		}
+		if ( Products::STATUS_NEEDS_PLAN === $status ) {
+			// Recognizing the standalone plugin makes the base class ask an unowned site to
+			// buy a plan while that plugin is inactive, but Stats is free from the Jetpack
+			// plugin, so the card keeps offering activation.
+			$status = Products::STATUS_NEEDS_ACTIVATION;
 		}
 		return $status;
 	}

--- a/projects/packages/my-jetpack/tests/php/Hybrid_Product_Deactivate_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Hybrid_Product_Deactivate_Test.php
@@ -73,6 +73,7 @@ class Hybrid_Product_Deactivate_Test extends TestCase {
 					'search'     => '1.0',
 					'protect'    => '1.0',
 					'publicize'  => '1.0',
+					'stats'      => '1.0',
 				),
 			)
 		);

--- a/projects/packages/my-jetpack/tests/php/Plan_Matrix_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Plan_Matrix_Test.php
@@ -82,6 +82,7 @@ class Plan_Matrix_Test extends TestCase {
 		'jetpack-protect'    => 'protect-mock-plugin.txt',
 		'jetpack-search'     => 'search-mock-plugin.txt',
 		'jetpack-social'     => 'social-mock-plugin.txt',
+		'jetpack-stats'      => 'stats-mock-plugin.txt',
 		'jetpack-videopress' => 'videopress-mock-plugin.txt',
 	);
 
@@ -206,8 +207,8 @@ class Plan_Matrix_Test extends TestCase {
 			'direct/on'            => Products::STATUS_ACTIVE,
 		),
 		'stats'         => array(
-			'none/plugin_absent'   => Products::STATUS_MODULE_DISABLED,
-			'none/off'             => Products::STATUS_MODULE_DISABLED,
+			'none/plugin_absent'   => Products::STATUS_NEEDS_ACTIVATION,
+			'none/off'             => Products::STATUS_NEEDS_ACTIVATION,
 			'none/on'              => Products::STATUS_CAN_UPGRADE,
 			'bundle/plugin_absent' => Products::STATUS_MODULE_DISABLED,
 			'bundle/off'           => Products::STATUS_MODULE_DISABLED,

--- a/projects/packages/my-jetpack/tests/php/Stats_Product_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Stats_Product_Test.php
@@ -22,6 +22,11 @@ use WorDBless\Users as WorDBless_Users;
 class Stats_Product_Test extends TestCase {
 
 	/**
+	 * The first filename Stats declares for its standalone plugin.
+	 */
+	private const STANDALONE_PLUGIN_FILE = 'jetpack-stats/jetpack-stats.php';
+
+	/**
 	 * The current user id.
 	 *
 	 * @var int
@@ -70,6 +75,8 @@ class Stats_Product_Test extends TestCase {
 	public function tearDown(): void {
 		// @phan-suppress-next-line PhanUndeclaredStaticProperty -- It's declared on the mock from ./assets/jetpack-mock-plugin.txt
 		\Jetpack::$mock_premium_analytics_enabled = false;
+
+		$this->uninstall_standalone_plugin();
 
 		WorDBless_Options::init()->clear_options();
 		WorDBless_Users::init()->clear_all_users();
@@ -131,5 +138,40 @@ class Stats_Product_Test extends TestCase {
 		$this->set_premium_analytics_enabled( true );
 
 		$this->assertNull( Stats::get_purchase_url() );
+	}
+
+	public function test_standalone_plugin_is_not_active_when_only_the_jetpack_plugin_is() {
+		$this->assertFalse( Stats::is_standalone_plugin_active() );
+	}
+
+	public function test_standalone_plugin_is_active_once_installed_and_activated() {
+		$this->install_standalone_plugin();
+		activate_plugin( self::STANDALONE_PLUGIN_FILE );
+
+		$this->assertTrue( Stats::is_standalone_plugin_active() );
+	}
+
+	/**
+	 * Copy the standalone Stats mock plugin into place.
+	 */
+	private function install_standalone_plugin() {
+		$target = WP_PLUGIN_DIR . '/' . self::STANDALONE_PLUGIN_FILE;
+		if ( ! file_exists( dirname( $target ) ) ) {
+			mkdir( dirname( $target ), 0777, true );
+		}
+		copy( __DIR__ . '/assets/stats-mock-plugin.txt', $target );
+		wp_cache_delete( 'plugins', 'plugins' );
+	}
+
+	/**
+	 * Remove the standalone Stats mock plugin, so it cannot answer another test class's
+	 * "standalone plugin absent" case.
+	 */
+	private function uninstall_standalone_plugin() {
+		$target = WP_PLUGIN_DIR . '/' . self::STANDALONE_PLUGIN_FILE;
+		if ( file_exists( $target ) ) {
+			unlink( $target );
+		}
+		wp_cache_delete( 'plugins', 'plugins' );
 	}
 }

--- a/projects/packages/my-jetpack/tests/php/assets/stats-mock-plugin.txt
+++ b/projects/packages/my-jetpack/tests/php/assets/stats-mock-plugin.txt
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Jetpack Stats Plugin
+ *
+ * Plugin Name:       Stats
+ * Description:       Jetpack Stats mock
+ * Author:            Automattic
+ * Author URI:        https://automattic.com
+ * License:           GPL-2.0+
+ * License URI:       http://www.gnu.org/licenses/gpl-2.0.txt
+ */


### PR DESCRIPTION
Fixes STATS-343

## Proposed changes
* Split out of #51060 after review feedback from @chihsuan. That pull request added the standalone plugin and has merged; this one carries the My Jetpack integration.
* Switches the My Jetpack Stats product from `Module_Product` to `Hybrid_Product`, so the card can detect a standalone Jetpack Stats install and does not treat the Jetpack plugin as the only source of Stats.
* Adds `jetpack-stats` to `JETPACK_PLUGIN_SLUGS`, as @chihsuan suggested. Both consumers want it: `get_installed_jetpack_plugins()` and the "is this a new user" check. All three install paths in `$plugin_filename` reduce to the `jetpack-stats` basename, which is what that list matches on.
* `showFullJetpackStatsCard` is now also true when the standalone plugin is active. Without it, a standalone site sees the reduced Stats card.

## Do not merge until the plugin is on WordPress.org

Two side effects remain while `jetpack-stats` is unpublished. Both were found by @chihsuan on #51060 and both are real:

1. **The install path 404s.** `Product::do_activation()` calls `Plugins_Installer::install_plugin( 'jetpack-stats' )`, which requests `jetpack-stats.latest-stable.zip`. That returns 404 today. `Hybrid_Product::do_product_specific_activation()` catches the resulting `no_package` error and installs the Jetpack plugin instead, so it does recover, but a user who asks for Stats gets the whole Jetpack plugin, and every attempt records `fail-jetpack-stats` in `A8c_Mc_Stats`.
2. **The status flow changes.** With `$has_standalone_plugin = true`, an unconnected site with no plan resolves to `STATUS_NEEDS_PLAN` instead of `STATUS_NEEDS_FIRST_SITE_CONNECTION`. The site is unconnected, so `Jetpack_Options::get_option( 'id' )` is empty and the purchase URL carries blog ID `0`.

Neither is fixable inside `Stats`. Both paths call `self::is_plugin_installed()` and `self::is_plugin_active()` rather than the `static::` forms, so `Hybrid_Product`'s overrides, which also count the Jetpack plugin, do not apply. That is deliberate: the comment above the `$has_standalone_plugin` branch in `Product::get_status()` ([class-product.php](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/my-jetpack/src/products/class-product.php)) says the check is about the standalone plugin specifically. So a site that already runs the Jetpack plugin still takes both paths.

Publishing the plugin to WordPress.org resolves the first and makes the second correct rather than misleading. That work is STATS-343 Phase 6. Doing it sooner would mean overriding `get_status()` and the install path in `Stats`, which is temporary code we would delete at Phase 6, so deferring looks better.

## Related product discussion/links
* STATS-343
* Follows #51060, which added the standalone plugin and has merged

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

The behaviour only differs when the standalone plugin is present, so test both shapes.

**With the Jetpack plugin active and no standalone plugin:**

* Open My Jetpack. Confirm that the Stats card looks and behaves exactly as it does on trunk.
* Turn the Stats module off, then on, from the card. Confirm that both still work.

**With the standalone Jetpack Stats plugin active and the Jetpack plugin inactive:**

* Build the standalone plugin from this branch with `jp build plugins/stats`, activate it, and deactivate the Jetpack plugin.
* Open My Jetpack. Confirm that the Stats card reports Stats as active, and that it shows the full view chart rather than the reduced card.

**On an unconnected site:**

* Confirm the Stats card sends you to the connection flow, and that any purchase link contains a real blog ID. A URL with blog ID `0` means issue 2 above is still present.
