### PR TITLE
Premium Analytics: fix the breadcrumb overflow behind the display:contents trail

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-stats-breadcrumbs-overflow
+++ b/projects/packages/premium-analytics/changelog/fix-stats-breadcrumbs-overflow
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats breadcrumbs: Fix a long unbroken crumb widening the page into horizontal scrolling instead of truncating.

--- a/projects/packages/premium-analytics/packages/ui/src/stats-breadcrumbs/stats-breadcrumbs.module.scss
+++ b/projects/packages/premium-analytics/packages/ui/src/stats-breadcrumbs/stats-breadcrumbs.module.scss
@@ -8,3 +8,23 @@
 .trail li {
 	margin-block-end: 0;
 }
+
+/* A long unbroken crumb refuses to shrink: admin-ui's Page header renders the
+ * breadcrumbs slot inside a flex chain whose items keep the flexbox default
+ * `min-inline-size: auto`, so the crumb's nowrap min-content propagates and
+ * drags the whole page into horizontal scrolling before the crumb's own
+ * ellipsis (admin-ui's `.current`) can engage. The `.trail` wrapper is
+ * `display: contents`, so a `min-inline-size` on it has no box to act on —
+ * the constraint must land on the wrapper's DOM parent (the header's inner
+ * Stack, which has no stable class, hence the structural `:has()`) and on the
+ * `nav`, the actual flex item in the box tree. Owned here so every page using
+ * StatsBreadcrumbs gets the fix; the slot is set to be reworked upstream under
+ * https://github.com/WordPress/gutenberg/issues/77039 and
+ * https://github.com/WordPress/gutenberg/issues/77628. */
+:has(> .trail) {
+	min-inline-size: 0;
+}
+
+.trail nav {
+	min-inline-size: 0;
+}

--- a/projects/packages/premium-analytics/packages/ui/src/stats-breadcrumbs/stats-breadcrumbs.module.scss
+++ b/projects/packages/premium-analytics/packages/ui/src/stats-breadcrumbs/stats-breadcrumbs.module.scss
@@ -18,8 +18,9 @@
  * the constraint must land on the wrapper's DOM parent (the header's inner
  * Stack, which has no stable class, hence the structural `:has()`) and on the
  * `nav`, the actual flex item in the box tree. Owned here so every page using
- * StatsBreadcrumbs gets the fix; the slot is set to be reworked upstream under
- * https://github.com/WordPress/gutenberg/issues/77039 and
+ * StatsBreadcrumbs gets the fix. Tracked upstream as
+ * https://github.com/WordPress/gutenberg/issues/81297; the slot is set to be
+ * reworked under https://github.com/WordPress/gutenberg/issues/77039 and
  * https://github.com/WordPress/gutenberg/issues/77628. */
 :has(> .trail) {
 	min-inline-size: 0;

--- a/projects/packages/premium-analytics/routes/video-detail/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/video-detail/stage.module.scss
@@ -2,25 +2,6 @@
 	min-block-size: 0;
 }
 
-// A long unbroken video title in the breadcrumb refuses to shrink: admin-ui's
-// Page header renders the breadcrumbs slot inside a flex chain (inner header
-// Stack → the Breadcrumbs `nav`) whose items keep the flexbox default
-// `min-inline-size: auto`, so the crumb's nowrap min-content propagates and
-// drags the whole page into horizontal scrolling before the crumb's own
-// ellipsis can engage. No dedicated upstream issue exists for this exact
-// propagation; the slot is set to be reworked under the Breadcrumb component
-// extraction (https://github.com/WordPress/gutenberg/issues/77039) and the
-// admin-ui 2.0 proposal (https://github.com/WordPress/gutenberg/issues/77628).
-// Let both links shrink until then; the `nav`'s parent has no stable class,
-// hence the structural `:has()`.
-.page :has(> nav[aria-label]) {
-	min-inline-size: 0;
-}
-
-.page nav[aria-label] {
-	min-inline-size: 0;
-}
-
 .scrollArea {
 	flex: 1 1 auto;
 	min-block-size: 0;


### PR DESCRIPTION
## Proposed changes

Fix a long unbroken breadcrumb crumb widening the whole page into horizontal scrolling instead of truncating, on every page that renders `StatsBreadcrumbs` (dashboard, post detail, video detail).

**Root cause.** admin-ui's Page header renders the breadcrumbs slot inside a flex chain whose items keep the flexbox default `min-inline-size: auto`, so a nowrap crumb's min-content propagates up and drags the page into horizontal scrolling before the crumb's own ellipsis (admin-ui's `.current`) can engage. #50970 worked around this at the route level with `.page :has(> nav[aria-label]) { min-inline-size: 0 }` — but #51022 wrapped the `nav` in `StatsBreadcrumbs`' `div.trail`, which is `display: contents`: the `:has(> nav)` selector now matches that box-less wrapper, where `min-inline-size` has nothing to act on, and the header's inner Stack (the element that actually needs the constraint) is no longer matched. The regression affects every consumer of the component.

**Fix.** Own the constraint in the component's stylesheet, where the wrapper's shape is known: `:has(> .trail)` lands `min-inline-size: 0` on the trail's DOM parent (the header's inner Stack, which has no stable class), and the `nav` — the actual flex item in the box tree under `display: contents` — gets the same. The superseded route-level rules are removed: video detail's in this PR (per review), post detail's in #50971. Tracked upstream as WordPress/gutenberg#81297 with a fix submitted in WordPress/gutenberg#81301; the slot is also set to be reworked under WordPress/gutenberg#77039 / WordPress/gutenberg#77628.

## Related product discussion/links

* Regressed in #51022; the original workaround shipped in #50970.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Build `packages/premium-analytics` + `plugins/premium-analytics`.
2. Open a post or video detail page for a post with a long unbroken title (e.g. `VID_20260731_aaaaaaaa….mp4`).
3. Narrow the browser window.
   * **Before:** the breadcrumb crumb refuses to shrink and the page scrolls horizontally.
   * **After:** the crumb truncates with an ellipsis and the page keeps its width.
4. Check the dashboard and a report page briefly — breadcrumbs render unchanged at normal widths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

