### PR TITLE
Build debug code frames only when debug output is enabled (faster text-domain stamping)

### DIFF
--- a/projects/js-packages/babel-plugin-replace-textdomain/changelog/fix-textdomain-code-frame-perf
+++ b/projects/js-packages/babel-plugin-replace-textdomain/changelog/fix-textdomain-code-frame-perf
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Build debug code frames only when debug output is enabled, which makes stamping text domains onto large bundles dramatically faster.

--- a/projects/js-packages/babel-plugin-replace-textdomain/src/index.js
+++ b/projects/js-packages/babel-plugin-replace-textdomain/src/index.js
@@ -15,8 +15,8 @@ const defaultI18nModule = '@wordpress/i18n';
  * Log a code frame only when debug output is enabled, as generating one scans
  * the source file.
  *
- * @param {object} path    Babel path to point the code frame at.
- * @param {string} message Message to log.
+ * @param {object} path    - Babel path to point the code frame at.
+ * @param {string} message - Message to log.
  */
 function debugCodeFrame( path, message ) {
 	if ( debug.enabled ) {

--- a/projects/js-packages/babel-plugin-replace-textdomain/src/index.js
+++ b/projects/js-packages/babel-plugin-replace-textdomain/src/index.js
@@ -11,6 +11,26 @@ const defaultFunctions = Object.freeze( {
 
 const defaultI18nModule = '@wordpress/i18n';
 
+/**
+ * Emit a debug message describing a node, with a code frame pointing at it.
+ *
+ * `buildCodeFrameError()` renders an excerpt of the surrounding source, which
+ * means walking the whole file. Passing it straight to `debug()` looks free
+ * when debug output is off, but JavaScript evaluates call arguments eagerly, so
+ * the frame is built for every matched call either way. On the large bundles
+ * this plugin runs over during a build that dominated the whole transform —
+ * building frames cost ~35s on a 2.4MB bundle, against ~0.5s to parse and
+ * regenerate it. Build the frame only when something will read it.
+ *
+ * @param {object} path    - Babel path to point the code frame at.
+ * @param {string} message - Message to log.
+ */
+function debugCodeFrame( path, message ) {
+	if ( debug.enabled ) {
+		debug( path.buildCodeFrameError( message, Error ).message );
+	}
+}
+
 module.exports = ( babel, opts ) => {
 	const { types: t } = babel;
 	const seenDomains = {};
@@ -69,10 +89,7 @@ module.exports = ( babel, opts ) => {
 
 				// If the domain argument is not set, maybe inject one.
 				if ( ! path.node.arguments[ idx ] ) {
-					debug(
-						path.buildCodeFrameError( `Domain argument (index ${ idx + 1 }) is missing`, Error )
-							.message
-					);
+					debugCodeFrame( path, `Domain argument (index ${ idx + 1 }) is missing` );
 					const newdomain = replacementDomain( '' );
 					if ( typeof newdomain === 'string' ) {
 						for ( let i = path.node.arguments.length; i < idx; i++ ) {
@@ -92,11 +109,9 @@ module.exports = ( babel, opts ) => {
 				} else if ( t.isTemplateLiteral( argnode ) && argnode.expressions.length === 0 ) {
 					olddomain = argnode.quasis[ 0 ].value.cooked;
 				} else {
-					debug(
-						argpath.buildCodeFrameError(
-							`Domain argument should be a StringLiteral, not ${ argnode.type }`,
-							Error
-						).message
+					debugCodeFrame(
+						argpath,
+						`Domain argument should be a StringLiteral, not ${ argnode.type }`
 					);
 					return;
 				}
@@ -107,12 +122,7 @@ module.exports = ( babel, opts ) => {
 					argpath.replaceWith( t.stringLiteral( newdomain ) );
 				} else if ( ! seenDomains[ olddomain ] ) {
 					seenDomains[ olddomain ] = true;
-					debug(
-						argpath.buildCodeFrameError(
-							`No mapping for textdomain ${ olddomain } (first instance)`,
-							Error
-						).message
-					);
+					debugCodeFrame( argpath, `No mapping for textdomain ${ olddomain } (first instance)` );
 				}
 			},
 		},

--- a/projects/js-packages/babel-plugin-replace-textdomain/src/index.js
+++ b/projects/js-packages/babel-plugin-replace-textdomain/src/index.js
@@ -12,18 +12,11 @@ const defaultFunctions = Object.freeze( {
 const defaultI18nModule = '@wordpress/i18n';
 
 /**
- * Emit a debug message describing a node, with a code frame pointing at it.
+ * Log a code frame only when debug output is enabled, as generating one scans
+ * the source file.
  *
- * `buildCodeFrameError()` renders an excerpt of the surrounding source, which
- * means walking the whole file. Passing it straight to `debug()` looks free
- * when debug output is off, but JavaScript evaluates call arguments eagerly, so
- * the frame is built for every matched call either way. On the large bundles
- * this plugin runs over during a build that dominated the whole transform —
- * building frames cost ~35s on a 2.4MB bundle, against ~0.5s to parse and
- * regenerate it. Build the frame only when something will read it.
- *
- * @param {object} path    - Babel path to point the code frame at.
- * @param {string} message - Message to log.
+ * @param {object} path    Babel path to point the code frame at.
+ * @param {string} message Message to log.
  */
 function debugCodeFrame( path, message ) {
 	if ( debug.enabled ) {

--- a/projects/js-packages/babel-plugin-replace-textdomain/tests/code-frame.test.js
+++ b/projects/js-packages/babel-plugin-replace-textdomain/tests/code-frame.test.js
@@ -1,0 +1,139 @@
+/**
+ * Code frames are only worth building when something will read them.
+ *
+ * `buildCodeFrameError()` renders an excerpt of the surrounding source, so its
+ * cost scales with the size of the file. Passing it directly as a `debug()`
+ * argument looks free when debug output is off, but arguments are evaluated
+ * eagerly, so the frame gets built for every matched call regardless. Over the
+ * bundles this plugin runs on during a build that dominated the transform, so
+ * these tests pin the behaviour: no debug output, no code frames.
+ */
+
+const mockOrigDebug = jest.requireActual( 'debug' );
+const mockDebug = jest.fn();
+// Only stand in for this plugin's own namespace — Babel itself logs through
+// `debug`, and capturing every namespace would count its messages too.
+jest.mock( 'debug', () => {
+	return name => {
+		if ( name.startsWith( '@automattic/babel-plugin-replace-textdomain' ) ) {
+			return mockDebug;
+		}
+		return mockOrigDebug( name );
+	};
+} );
+
+const { transformSync } = require( '@babel/core' );
+const plugin = require( '../src/index.js' );
+
+const babelOptions = { babelrc: false, configFile: false, filename: __filename };
+
+/**
+ * `NodePath.prototype`, read off a live path rather than imported, so these
+ * tests do not need `@babel/traverse` as a dependency of their own.
+ */
+const nodePathProto = ( () => {
+	let proto;
+	transformSync( ';', {
+		...babelOptions,
+		plugins: [
+			() => ( {
+				visitor: {
+					Program( path ) {
+						proto = Object.getPrototypeOf( path );
+					},
+				},
+			} ),
+		],
+	} );
+	return proto;
+} )();
+
+/**
+ * Build a source file with `count` gettext calls that are missing their domain
+ * argument — the shape esbuild leaves behind, and the branch that used to build
+ * a code frame every time.
+ *
+ * @param {number} count - Number of call sites to emit.
+ * @return {string} Source code.
+ */
+function sourceWithMissingDomains( count ) {
+	return Array.from( { length: count }, ( _, i ) => `__( 'string ${ i }' );` ).join( '\n' );
+}
+
+const stamp = ( code, pluginOptions = { textdomain: 'new-domain' } ) =>
+	transformSync( code, { ...babelOptions, plugins: [ [ plugin, pluginOptions ] ] } ).code;
+
+let spy;
+
+beforeEach( () => {
+	mockDebug.mockClear();
+	mockDebug.enabled = false;
+	spy = jest.spyOn( nodePathProto, 'buildCodeFrameError' );
+} );
+
+afterEach( () => {
+	spy.mockRestore();
+} );
+
+describe( 'code frame construction', () => {
+	it( 'builds no code frames when debug output is disabled', () => {
+		const code = stamp( sourceWithMissingDomains( 25 ) );
+
+		expect( spy ).not.toHaveBeenCalled();
+		expect( mockDebug ).not.toHaveBeenCalled();
+		// The stamp itself still happened. Babel quotes the inserted literal
+		// itself, so match either quote style.
+		expect( code.match( /["']new-domain["']/g ) ).toHaveLength( 25 );
+	} );
+
+	it( 'builds code frames when debug output is enabled', () => {
+		mockDebug.enabled = true;
+
+		stamp( sourceWithMissingDomains( 25 ) );
+
+		expect( spy ).toHaveBeenCalledTimes( 25 );
+		expect( mockDebug ).toHaveBeenCalledTimes( 25 );
+	} );
+
+	it( 'does no code frame work per call site as the file grows', () => {
+		stamp( sourceWithMissingDomains( 1 ) );
+		const afterOne = spy.mock.calls.length;
+
+		stamp( sourceWithMissingDomains( 500 ) );
+		const afterMany = spy.mock.calls.length;
+
+		// Guards the complexity, not just the count: the old code built one
+		// frame per call site, so this grew with the size of the bundle.
+		expect( afterOne ).toBe( 0 );
+		expect( afterMany ).toBe( 0 );
+	} );
+
+	it( 'produces identical output whether or not debug output is enabled', () => {
+		const source = sourceWithMissingDomains( 10 );
+
+		mockDebug.enabled = false;
+		const quiet = stamp( source );
+
+		mockDebug.enabled = true;
+		const verbose = stamp( source );
+
+		expect( quiet ).toBe( verbose );
+	} );
+
+	it( 'skips the frame for an unmapped domain when debug output is disabled', () => {
+		// `textdomain` as an object leaves unlisted domains alone, which is the
+		// other branch that logs through a code frame.
+		const code = stamp( `__( 'foo', 'unmapped' );`, { textdomain: { other: 'x' } } );
+
+		expect( spy ).not.toHaveBeenCalled();
+		expect( code ).toContain( "'unmapped'" );
+	} );
+
+	it( 'skips the frame for a non-literal domain when debug output is disabled', () => {
+		const code = stamp( `__( 'foo', someVariable );` );
+
+		expect( spy ).not.toHaveBeenCalled();
+		// A dynamic domain is left untouched.
+		expect( code ).toContain( 'someVariable' );
+	} );
+} );

--- a/projects/js-packages/babel-plugin-replace-textdomain/tests/plugin.test.js
+++ b/projects/js-packages/babel-plugin-replace-textdomain/tests/plugin.test.js
@@ -1,5 +1,8 @@
 const mockOrigDebug = jest.requireActual( 'debug' );
 const mockDebug = jest.fn();
+// The plugin only builds a code frame when the debug instance is enabled, so
+// these tests have to present an enabled one to exercise the messages below.
+mockDebug.enabled = true;
 jest.mock( 'debug', () => {
 	return name => {
 		if ( name.startsWith( '@automattic/babel-plugin-replace-textdomain' ) ) {


### PR DESCRIPTION
## Proposed changes

Stamping translation text domains onto built JavaScript is the single most expensive step in a **production** build of `packages/premium-analytics` — more expensive than all of esbuild put together. In the unmodified CI control it takes **11m54s** of a 16m29s build; with this change, **2m44s**, taking the whole package build to 8m29s.

(Development builds are barely affected — see "What you will *not* see" below before measuring.)

* Build Babel's "code frame" debug output only when debug output is actually switched on.
* Add tests pinning that behaviour, including one that guards the underlying complexity.

### In plain terms

When something looks unusual during text-domain stamping, the tool wants to log a helpful message showing the offending line, like a compiler error:

```
  12 | __( 'Hello world' );
     | ^ Domain argument (index 2) is missing
```

To produce that little excerpt, Babel has to scan the **entire file** to work out where line 12 is and what surrounds it.

The code asked for the excerpt like this:

```js
debug( path.buildCodeFrameError( 'Domain argument (index 2) is missing' ).message );
```

`debug(...)` does nothing unless you have debug logging switched on. But JavaScript always evaluates the *arguments* before calling a function — so the excerpt was built every single time, then handed to a function that immediately discarded it.

An analogy: printing and binding a 300-page report, walking it to the shredder, and repeating that 249 times — because the person you meant to give it to isn't in the building.

For one real bundle:

* the file is **2.4 MB**
* it has **249** translation calls
* each one triggered a full scan of all 2.4 MB
* roughly **600 MB** of scanning, to build messages nobody reads

The fix checks whether anyone is listening first:

```js
if ( debug.enabled ) {
    debug( path.buildCodeFrameError( 'Domain argument (index 2) is missing' ).message );
}
```

Debug output is unchanged when you switch it on (`DEBUG='@automattic/babel-plugin-replace-textdomain'`, or `DEBUG='*'`). The built files are **byte-for-byte identical** either way — this is purely wasted work being removed.

### Why it got bad now, and why it wasn't a problem before

This eager call has been in the plugin since #22077 (Dec 2021), where it was genuinely harmless: the plugin ran over hand-written source files, which are small and whose translation calls already *have* a text domain — so the expensive branch almost never ran.

#50762 added the `stamp-textdomains` step, which runs this same plugin over the bundles `@wordpress/build` (esbuild) emits. Two things changed at once:

1. **The files got huge** — bundles are megabytes, because they inline their dependencies.
2. **The expensive branch became the normal case** — `@wordpress/build` strips the text domain from gettext calls, which is the entire reason `stamp-textdomains` exists. "Domain argument is missing" is no longer an edge case; it is every call.

So this is not a regression in #50762. It is a long-dormant inefficiency that #50762's new (and correct) usage turned into the dominant cost of a production build.

## Measurements

Two end-to-end measurements of the real `stamp-textdomains` step, both on `packages/premium-analytics` production builds. They differ, and the gap is informative, so both are given.

**Author's local measurement, timing the step on its own** (342 bundles, nothing else running; results are machine-specific):

| | Time |
| --- | ---: |
| trunk | 221.1s |
| this branch | **10.6s** |
| | **20.9x** |

**Independent local reproduction** on the exact PR commit (350 stamped files, same unstamped production output for both implementations):

| | Time |
| --- | ---: |
| before | 21.38s |
| this branch | **11.29s** |
| | **1.9x** |

The independent run also confirmed that all 562 generated files were byte-for-byte identical between implementations. The wide difference between local ratios shows that the absolute local speedup depends heavily on the machine and workload.

**In CI, in situ** — the same step inside `Build all projects`, where other projects are building concurrently and competing for the runner's cores:

| | Before | After | Saved |
| --- | ---: | ---: | ---: |
| `stamp-textdomains` step | 714s | **164s** | 550s (**4.35x**) |
| Whole `packages/premium-analytics` build | 16m29s | **8m29s** | ~8m00s |

Runs: [unmodified control](https://github.com/Automattic/jetpack/actions/runs/31008591090) · [after](https://github.com/Automattic/jetpack/actions/runs/31084155746)

The CI ratio is the one worth planning against: a build agent is busy with other projects, so the saved CPU partly goes to whatever else is running rather than straight to wall time. Take **~4x on the step and ~8 minutes off this package** as the observed CI figure.

Note the *job* totals on those two runs are **not** comparable — the build matrix differs by which projects each PR touches (140 projects vs 122). The per-project comparison is more useful, but is not perfectly controlled either: the control stamped 342 files while the later run stamped 350. Treat the CI figures as strong directional evidence rather than a laboratory benchmark.

### Isolating the transform

On the author's machine, the Babel transform alone across all 342 built bundles, current plugin vs patched, with byte-identical output for every file, measured 211.8s → 6.2s (34x). An independent check of the current 2.48 MB dashboard bundle measured 1.52s → a median 0.53s (2.9x), while instrumenting `buildCodeFrameError()` calls from 234 → 0. These results confirm the mechanism while also showing that the transform ratio is machine-specific.

Once the transform stops dominating, the rest of `stamp-textdomains` becomes the cost — writing files, re-hashing each sibling `.asset.php`, regenerating source maps, and the separate manifest pass. That residual is the obvious next lever (parallelising the file loop) if this step needs to get faster still. Out of scope here.

Worst individual bundles, transform only:

| Bundle | Size | Before | After |
| --- | ---: | ---: | ---: |
| `routes/post-detail/content.js` | 2.4 MB | 36.4s | 0.54s |
| `routes/dashboard/content.js` | 2.4 MB | 34.9s | 0.48s |
| `modules/externals/index.js` | 2.8 MB | 34.0s | 0.65s |

Two controls confirm the diagnosis rather than merely correlating with it:

* Parsing **and** regenerating that same 2.4 MB bundle with no plugin at all takes **0.58s** — so Babel is not the problem, the frame-building is.
* `routes/reports/content.js` improves only 2.4x, because its translation calls already carry a domain, so the expensive branch rarely fires — exactly what the explanation predicts.

### What you will *not* see

**A development build barely changes.** `jetpack build packages/premium-analytics --deps` runs the development build, which does not emit the ~171 minified bundles or run `strip-unminified-prod`, so there is far less to stamp — @manzoorwanijk measured 95s → 81s that way. All the figures above are production builds (`build-production`), which is what CI runs and what ships. If you are checking this change by eye, use the production commands in the testing instructions below, or you will conclude it does almost nothing.

The same plugin runs for every package that stamps text domains — `forms`, `activity-log`, `newsletter`, `publicize`, `videopress`, `seo`, `scan`, `jetpack-mu-wpcom` and others — so the saving should be broad, but I have not measured those individually.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

### 1. Unit tests

```
jetpack test js js-packages/babel-plugin-replace-textdomain
```

All 43 tests and 51 existing snapshots pass. The snapshots being **unchanged** is itself the evidence that debug output and transform output are unaffected.

`tests/code-frame.test.js` covers:

* no code frames are built when debug output is disabled — while the text domain is still correctly stamped;
* code frames **are** still built, and messages still logged, when debug output is enabled;
* code-frame work does not grow with the number of call sites (the complexity guard — this is the one that would have caught the original problem);
* output is identical whether debug is on or off;
* the two rarer logging branches (unmapped domain, non-literal domain) are also covered.

To confirm the tests are not vacuous, revert the `if ( debug.enabled )` guard in `src/index.js` and re-run: 4 of the 6 new tests fail.

### 2. Timing a real build

**Use a production build.** A development build will show almost no difference, for the reason given above.

The package's normal `build` script chains four steps, and the one this PR changes is the third:

```
clean → build:wp-build → build:stamp-textdomains → build:boot-asset
```

So run the first two **as two separate commands**. `build:wp-build` only bundles — it does not stamp, and on its own will print no stamping output at all. That is deliberate: it leaves the bundles unstamped so the stamp step can then be timed by itself, instead of being buried inside one combined number.
Run this command on both trunk and this branch:
```bash
time jetpack build packages/premium-analytics --deps --production
```
Test the textdomains stamp specifically:
```bash
cd projects/packages/premium-analytics

# 1. Build the bundles. This does NOT stamp — no stamping output is expected here.
rm -rf build
NODE_ENV=production pnpm run build:wp-build

# 2. Now stamp them, and time just this. THIS is the step the PR changes.

time pnpm run build:stamp-textdomains
```

Step 2 should end with a line like:

```
stamp-textdomains: stamped "jetpack-premium-analytics-pkg" onto 342 file(s) in …; 102 string-bearing bundle(s) listed in the i18n manifest
pnpm run build:stamp-textdomains  15.90s user 0.87s system 158% cpu 10.554 total
```

Run both steps on `trunk` and again on this branch, comparing only the step 2 timing. The exact local ratio is machine-dependent: the author's measurement was 221.1s → 10.6s, while an independent reproduction was 21.38s → 11.29s. Inside the measured CI job the improvement was around 4x.

Re-run step 1 before each step 2: stamping is idempotent, so timing it a second time on already-stamped output measures the cheap no-op path and will look fast on both branches.

For the in-situ figure, compare the `stamp-textdomains` line in the CI `Build all projects` log between the unmodified control and this branch; that is where 714s → 164s above comes from.

### 3. Confirming debug output still works

```bash
DEBUG='@automattic/babel-plugin-replace-textdomain' pnpm run build:stamp-textdomains
```

The "Domain argument (index 2) is missing" messages, with code frames, should appear exactly as before. Note that this deliberately restores the slow path — building those frames is the expensive work, and you have asked for them. (`DEBUG=1`, which Jetpack tooling uses elsewhere, does not match this namespace and leaves the fast path in place.)
