### PR TITLE
Premium Analytics: Align widget icons with the design reference

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1852-align-widget-icons
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1852-align-widget-icons
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Widgets: Update dashboard widget icons to match the design reference.

--- a/projects/packages/premium-analytics/widgets/annual-highlights/widget.ts
+++ b/projects/packages/premium-analytics/widgets/annual-highlights/widget.ts
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { calendar } from '@wordpress/icons';
+import { pin } from '@wordpress/icons';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
 /**
@@ -40,7 +40,7 @@ export const DEFAULT_HIGHLIGHT_METRICS: AnnualHighlightMetric[] = [
  * metric enabled.
  */
 export default {
-	icon: calendar,
+	icon: pin,
 	attributes: [
 		{
 			id: 'metrics',

--- a/projects/packages/premium-analytics/widgets/devices/widget.ts
+++ b/projects/packages/premium-analytics/widgets/devices/widget.ts
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { desktop } from '@wordpress/icons';
+import { mobile } from '@wordpress/icons';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
 /**
@@ -23,7 +23,7 @@ export type DevicesAttributes = {
  * reportParams (the shared dashboard date picker).
  */
 export default {
-	icon: desktop,
+	icon: mobile,
 	attributes: [
 		{
 			id: 'max',

--- a/projects/packages/premium-analytics/widgets/latest-post/widget.ts
+++ b/projects/packages/premium-analytics/widgets/latest-post/widget.ts
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { postList } from '@wordpress/icons';
+import { post } from '@wordpress/icons';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
 /**
@@ -21,7 +21,7 @@ export type LatestPostAttributes = Record< never, never >;
  * period.
  */
 export default {
-	icon: postList,
+	icon: post,
 	attributes: [] as WidgetAttributeField< LatestPostAttributes >[],
 	example: {
 		attributes: {},

--- a/projects/packages/premium-analytics/widgets/most-commented-authors/widget.ts
+++ b/projects/packages/premium-analytics/widgets/most-commented-authors/widget.ts
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { commentAuthorAvatar } from '@wordpress/icons';
+import { postAuthor } from '@wordpress/icons';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
 export type MostCommentedAuthorsAttributes = {
@@ -24,7 +24,7 @@ export type MostCommentedAuthorsAttributes = {
  * period, so the widget ignores the dashboard date range.
  */
 export default {
-	icon: commentAuthorAvatar,
+	icon: postAuthor,
 	attributes: [
 		{
 			id: 'max',

--- a/projects/packages/premium-analytics/widgets/most-commented-posts/widget.ts
+++ b/projects/packages/premium-analytics/widgets/most-commented-posts/widget.ts
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { commentContent } from '@wordpress/icons';
+import { comment } from '@wordpress/icons';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
 export type MostCommentedPostsAttributes = {
@@ -24,7 +24,7 @@ export type MostCommentedPostsAttributes = {
  * period, so the widget ignores the dashboard date range.
  */
 export default {
-	icon: commentContent,
+	icon: comment,
 	attributes: [
 		{
 			id: 'max',

--- a/projects/packages/premium-analytics/widgets/posting-activity/widget.ts
+++ b/projects/packages/premium-analytics/widgets/posting-activity/widget.ts
@@ -1,7 +1,7 @@
 /**
  * WordPress dependencies
  */
-import { calendar } from '@wordpress/icons';
+import { verse } from '@wordpress/icons';
 
 /**
  * The Posting activity widget has no configurable settings: it always renders
@@ -18,5 +18,5 @@ export type PostingActivityAttributes = Record< never, never >;
  * `stats/streak` endpoint has no comparison period, so no delta is shown.
  */
 export default {
-	icon: calendar,
+	icon: verse,
 };

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/widget.ts
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/widget.ts
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { trendingUp } from '@wordpress/icons';
+import { people } from '@wordpress/icons';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
 /**
@@ -65,7 +65,7 @@ export const DEFAULT_SUBSCRIBERS_CHART_METRICS: SubscribersChartMetricId[] =
  * as the defaults applied to new instances.
  */
 export default {
-	icon: trendingUp,
+	icon: people,
 	attributes: [
 		{
 			id: 'granularity',

--- a/projects/packages/premium-analytics/widgets/tags/widget.ts
+++ b/projects/packages/premium-analytics/widgets/tags/widget.ts
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { tag } from '@wordpress/icons';
+import { category } from '@wordpress/icons';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
 export type TagsAttributes = {
@@ -23,7 +23,7 @@ export type TagsAttributes = {
  * archive URL and drill down to their individual members instead.
  */
 export default {
-	icon: tag,
+	icon: category,
 	attributes: [
 		{
 			id: 'max',

--- a/projects/packages/premium-analytics/widgets/top-platforms/widget.ts
+++ b/projects/packages/premium-analytics/widgets/top-platforms/widget.ts
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { chartBar } from '@wordpress/icons';
+import { desktop } from '@wordpress/icons';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
 /**
@@ -29,7 +29,7 @@ export type TopPlatformsAttributes = {
  * so the widget host renders its control.
  */
 export default {
-	icon: chartBar,
+	icon: desktop,
 	attributes: [
 		{
 			id: 'max',

--- a/projects/packages/premium-analytics/widgets/top-posts/widget.ts
+++ b/projects/packages/premium-analytics/widgets/top-posts/widget.ts
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { postList } from '@wordpress/icons';
+import { page } from '@wordpress/icons';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
 /**
@@ -42,7 +42,7 @@ export type TopPostsAttributes = {
  * rows, Posts & pages view. The date range comes from the dashboard picker.
  */
 export default {
-	icon: postList,
+	icon: page,
 	attributes: [
 		{
 			id: 'max',

--- a/projects/packages/premium-analytics/widgets/traffic-chart/widget.ts
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/widget.ts
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { chartBar } from '@wordpress/icons';
+import { trendingUp } from '@wordpress/icons';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
 /**
@@ -68,7 +68,7 @@ export const DEFAULT_TRAFFIC_CHART_METRICS: TrafficChartMetricId[] = TRAFFIC_CHA
  * `example.attributes` doubles as the defaults applied to new instances.
  */
 export default {
-	icon: chartBar,
+	icon: trendingUp,
 	attributes: [
 		{
 			id: 'granularity',

--- a/projects/packages/premium-analytics/widgets/utm-insights/widget.ts
+++ b/projects/packages/premium-analytics/widgets/utm-insights/widget.ts
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { trendingUp } from '@wordpress/icons';
+import { megaphone } from '@wordpress/icons';
 import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
 /**
@@ -36,7 +36,7 @@ export type UtmInsightsAttributes = {
  * shared dashboard date picker).
  */
 export default {
-	icon: trendingUp,
+	icon: megaphone,
 	attributes: [
 		{
 			id: 'utmDimension',


### PR DESCRIPTION
Fixes WOOA7S-1852

## Proposed changes

Several Stats widgets use generic or mismatched header icons, making the dashboard less consistent with the approved design and harder to scan.

This PR aligns the widget header icons with the prototype across the Traffic, Insights, and Subscribers boards:

| Board | Widget | New icon |
| --- | --- | --- |
| Traffic | Traffic summary | Trending up |
| Traffic | Top pages | Page |
| Traffic | Devices | Mobile |
| Traffic | Top platforms | Desktop |
| Traffic | Top UTM | Megaphone |
| Insights | Highlights | Pin |
| Insights | Posting activity | Verse |
| Insights | Latest post | Post |
| Insights | Top tags & categories | Category |
| Insights | Most commented posts | Comment |
| Insights | Most commented authors | Post author |
| Subscribers | Subscribers summary | People |

Only widget header icons change. Widget data, layout, empty states, and in-body icons remain unchanged. The Store board is out of scope because it has no counterpart in the prototype.

## Related product discussion/links

- WOOA7S-1852

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Open the Stats dashboard at `?page=jetpack-premium-analytics-wp-admin`.
2. On the Traffic board, confirm the header icons match the following:
   - Traffic summary: trending-up arrow
   - Top pages: page
   - Devices: mobile phone
   - Top platforms: desktop monitor
   - Top UTM: megaphone
3. On the Insights board, confirm the header icons match the following:
   - Highlights: pin
   - Posting activity: verse/quill
   - Latest post: post
   - Top tags & categories: category/folder
   - Most commented posts: comment bubble
   - Most commented authors: post author
4. On the `Subscribers` board, confirm Subscribers summary uses the people icon.
5. Confirm widget content, empty states, and the Store board are unchanged.

Or just open the dashboard and comparre with https://sweetly-steep.jurassic.ninja/

PA:
<img width="2446" height="1307" alt="Screenshot 2026-08-06 at 5 18 05 PM" src="https://github.com/user-attachments/assets/deb0c764-b8c7-4f6f-904e-fbdae03e2d03" />
<img width="2444" height="1243" alt="Screenshot 2026-08-06 at 5 19 14 PM" src="https://github.com/user-attachments/assets/56a5bcb9-b1d5-43fc-9c81-e925883e854f" />

Prototype:
<img width="2440" height="1242" alt="Screenshot 2026-08-06 at 5 18 12 PM" src="https://github.com/user-attachments/assets/663c767b-7264-46d5-b7d3-d701abaa35f1" />

<img width="2448" height="1246" alt="Screenshot 2026-08-06 at 5 19 20 PM" src="https://github.com/user-attachments/assets/f86d05f8-4e54-4788-86d5-26609898484d" />

