### PR TITLE
Premium Analytics: rename the comment widgets to "Top commented ..."

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-wooa7s-1830-top-commented-titles
+++ b/projects/packages/premium-analytics/changelog/update-wooa7s-1830-top-commented-titles
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Rename the "Most commented posts" and "Most commented authors" widgets to "Top commented posts" and "Top commented authors".

--- a/projects/packages/premium-analytics/packages/data/src/processing/stats/comments.ts
+++ b/projects/packages/premium-analytics/packages/data/src/processing/stats/comments.ts
@@ -159,7 +159,7 @@ export type StatsCommentsGroup = 'authors' | 'posts';
 
 /**
  * A flat Comments report row, shared by every consumer of the report: the
- * "Most commented authors" and "Most commented posts" widgets and the Comments
+ * "Top commented authors" and "Top commented posts" widgets and the Comments
  * report page.
  *
  * `link` is the value the report carries: a locally built, root-relative

--- a/projects/packages/premium-analytics/widgets/most-commented-authors/render.tsx
+++ b/projects/packages/premium-analytics/widgets/most-commented-authors/render.tsx
@@ -42,7 +42,7 @@ interface MostCommentedAuthorsInnerProps {
 }
 
 /**
- * Most commented authors inner component. The comment counts come from the
+ * Top commented authors inner component. The comment counts come from the
  * all-time `stats/comments` report, so there is no date range or comparison
  * period to read from context.
  *
@@ -116,7 +116,7 @@ function MostCommentedAuthorsInner( { max }: MostCommentedAuthorsInnerProps ) {
 }
 
 /**
- * Most commented authors widget: the people who comment the most on the site,
+ * Top commented authors widget: the people who comment the most on the site,
  * ranked by comment count. Each row links to the comment management screen
  * filtered to that author when the report reports an email for them.
  *
@@ -125,7 +125,7 @@ function MostCommentedAuthorsInner( { max }: MostCommentedAuthorsInnerProps ) {
  * `useStatsCommentsRows`, so showing both costs a single request.
  *
  * @param {MostCommentedAuthorsWidgetProps} props - The widget render props.
- * @return The rendered Most commented authors widget.
+ * @return The rendered Top commented authors widget.
  */
 export default function MostCommentedAuthors( {
 	attributes = {},

--- a/projects/packages/premium-analytics/widgets/most-commented-authors/stories/most-commented-authors-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/most-commented-authors/stories/most-commented-authors-widget.stories.tsx
@@ -35,7 +35,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'The "Most commented authors" widget. Ranks the people who comment most on the site by comment count, linking each guest commenter to the comment management screen filtered to them. One half of the Jetpack Stats Comments module; "Most commented posts" covers the other.',
+					'The "Top commented authors" widget. Ranks the people who comment most on the site by comment count, linking each guest commenter to the comment management screen filtered to them. One half of the Jetpack Stats Comments module; "Top commented posts" covers the other.',
 			},
 		},
 	},

--- a/projects/packages/premium-analytics/widgets/most-commented-authors/widget.json
+++ b/projects/packages/premium-analytics/widgets/most-commented-authors/widget.json
@@ -1,6 +1,6 @@
 {
 	"name": "jpa/most-commented-authors",
-	"title": "Most commented authors",
+	"title": "Top commented authors",
 	"description": "The people who comment the most on your site.",
 	"help": {
 		"content": "Your most active commenters, ranked by the number of comments they have left.",

--- a/projects/packages/premium-analytics/widgets/most-commented-authors/widget.ts
+++ b/projects/packages/premium-analytics/widgets/most-commented-authors/widget.ts
@@ -13,7 +13,7 @@ export type MostCommentedAuthorsAttributes = {
 };
 
 /**
- * Widget type definition for the Most commented authors widget.
+ * Widget type definition for the Top commented authors widget.
  *
  * One half of the Jetpack Stats "Comments" module: the site's most active
  * commenters, ranked by comment count. The other half ships as

--- a/projects/packages/premium-analytics/widgets/most-commented-posts/render.tsx
+++ b/projects/packages/premium-analytics/widgets/most-commented-posts/render.tsx
@@ -42,7 +42,7 @@ interface MostCommentedPostsInnerProps {
 }
 
 /**
- * Most commented posts inner component. The comment counts come from the
+ * Top commented posts inner component. The comment counts come from the
  * all-time `stats/comments` report, so there is no date range or comparison
  * period to read from context.
  *
@@ -109,7 +109,7 @@ function MostCommentedPostsInner( { max }: MostCommentedPostsInnerProps ) {
 }
 
 /**
- * Most commented posts widget: the posts and pages that receive the most
+ * Top commented posts widget: the posts and pages that receive the most
  * comments, ranked by comment count. Each row opens the post detail page, and
  * falls back to the published post when the report carries no post ID.
  *
@@ -118,7 +118,7 @@ function MostCommentedPostsInner( { max }: MostCommentedPostsInnerProps ) {
  * `useStatsCommentsRows`, so showing both costs a single request.
  *
  * @param {MostCommentedPostsWidgetProps} props - The widget render props.
- * @return The rendered Most commented posts widget.
+ * @return The rendered Top commented posts widget.
  */
 export default function MostCommentedPosts( { attributes = {} }: MostCommentedPostsWidgetProps ) {
 	return (

--- a/projects/packages/premium-analytics/widgets/most-commented-posts/stories/most-commented-posts-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/most-commented-posts/stories/most-commented-posts-widget.stories.tsx
@@ -35,7 +35,7 @@ const meta = {
 		docs: {
 			description: {
 				component:
-					'The "Most commented posts" widget. Ranks the posts and pages that receive the most comments, linking each row to the published post. One half of the Jetpack Stats Comments module; "Most commented authors" covers the other.',
+					'The "Top commented posts" widget. Ranks the posts and pages that receive the most comments, linking each row to the published post. One half of the Jetpack Stats Comments module; "Top commented authors" covers the other.',
 			},
 		},
 	},

--- a/projects/packages/premium-analytics/widgets/most-commented-posts/widget.json
+++ b/projects/packages/premium-analytics/widgets/most-commented-posts/widget.json
@@ -1,6 +1,6 @@
 {
 	"name": "jpa/most-commented-posts",
-	"title": "Most commented posts",
+	"title": "Top commented posts",
 	"description": "The posts and pages that receive the most comments.",
 	"help": {
 		"content": "Your posts and pages, ranked by the number of comments they have received.",

--- a/projects/packages/premium-analytics/widgets/most-commented-posts/widget.ts
+++ b/projects/packages/premium-analytics/widgets/most-commented-posts/widget.ts
@@ -13,7 +13,7 @@ export type MostCommentedPostsAttributes = {
 };
 
 /**
- * Widget type definition for the Most commented posts widget.
+ * Widget type definition for the Top commented posts widget.
  *
  * One half of the Jetpack Stats "Comments" module: the posts and pages that
  * receive the most comments. The other half ships as


### PR DESCRIPTION
## Proposed changes

Part of WOOA7S-1830 (align widget titles and helper text with the copy spreadsheet).

* Rename the **Most commented posts** widget to **Top commented posts**, and **Most commented authors** to **Top commented authors**.
* Update the doc comments and Storybook descriptions that quote those titles so nothing refers to the old copy.

The spreadsheet uses `Top …` as its consistent prefix across the other eleven ranked widgets — Top pages, Top referrers, Top locations, Top UTM, Top links clicked, Top searched terms, Top videos, Top downloaded, Top platforms, Top tags & categories, Top social media shares. These two shipped as "Most commented …" in #50929 and were the only ranked widgets breaking that pattern.

Only the display titles change. The registered widget names (`jpa/most-commented-posts`, `jpa/most-commented-authors`) and the folder slugs stay as they are — those keys are what stored dashboard layouts reference, so renaming them would drop the widgets from any layout saved since #50929 landed. The helper text is unchanged; the spreadsheet still lists it as TBD.

### Not included: the traffic chart title

The spreadsheet also lists the traffic chart as **Summary**, while trunk has **Traffic summary** after #51023 renamed it to match the prototype. We're keeping `Traffic summary`: it parallels the sibling `Subscribers summary` (which the sheet itself prefixes), and a bare "Summary" is ambiguous in a picker with 70+ widgets. The spreadsheet row is the one that needs updating, tracked on WOOA7S-1830.

## Related product discussion/links

* WOOA7S-1830
* Follows #50929 (which introduced the two widgets)

## Does this pull request change what data or activity we track or use?

No. Display strings only.

## Testing instructions

1. Build and activate Premium Analytics on a test site, then open **Jetpack Stats → Insights**.
2. Confirm the two comment widgets are now titled **Top commented posts** and **Top commented authors**. Their data and helper tooltips should be unchanged.
3. Open the widget picker (`+ Add widget`) and confirm both appear under their new titles.
4. If you already had a customized Insights layout from before this change, confirm both widgets are still present — the rename must not drop them, because the underlying widget names are untouched.
