### PR TITLE
Premium Analytics: give each dashboard section its own heading and description

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1853-section-copy
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1853-section-copy
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Dashboard: Give each section its own heading and description.

--- a/projects/packages/premium-analytics/routes/dashboard/config/index.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/index.ts
@@ -1,4 +1,9 @@
-export { resolveSectionId, type DashboardSection, type DashboardSectionId } from './sections';
+export {
+	resolveSectionHeading,
+	resolveSectionId,
+	type DashboardSection,
+	type DashboardSectionId,
+} from './sections';
 
 export {
 	DATE_FILTER_RANGE,

--- a/projects/packages/premium-analytics/routes/dashboard/config/sections.test.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/sections.test.ts
@@ -1,10 +1,12 @@
-import { resolveSectionId, type DashboardSection } from './sections';
+import { resolveSectionHeading, resolveSectionId, type DashboardSection } from './sections';
 
 const SECTIONS: DashboardSection[] = [
 	{
 		id: 'analytics/traffic',
 		slug: 'traffic',
 		label: 'Traffic',
+		title: 'Site traffic',
+		description: 'Views, visitors, and where they came from.',
 		order: 10,
 		date_filter: 'range',
 		default_layout: [],
@@ -13,6 +15,8 @@ const SECTIONS: DashboardSection[] = [
 		id: 'analytics/insights',
 		slug: 'insights',
 		label: 'Insights',
+		title: 'Activity insights',
+		description: 'Longer-term patterns in your content and audience.',
 		order: 20,
 		date_filter: 'year',
 		default_layout: [],
@@ -23,10 +27,33 @@ const SECTIONS: DashboardSection[] = [
 		id: 'analytics/subscribers',
 		slug: 'subscribers',
 		label: 'Subscribers',
+		title: 'Subscribers stats',
+		description: 'How your subscriber list is growing, and how your emails land.',
 		order: 30,
 		default_layout: [],
 	},
 ];
+
+// Registers no copy of its own, the way Store does.
+const STORE: DashboardSection = {
+	id: 'woocommerce/store',
+	slug: 'store',
+	label: 'Store',
+	title: null,
+	description: null,
+	order: 40,
+	date_filter: 'range',
+	default_layout: [],
+};
+
+// A payload from a build predating the copy fields: the keys are absent, not null.
+const LEGACY: DashboardSection = {
+	id: 'analytics/traffic',
+	slug: 'traffic',
+	label: 'Traffic',
+	order: 10,
+	default_layout: [],
+};
 
 describe( 'resolveSectionId', () => {
 	it( 'keeps a slug matching an available section', () => {
@@ -44,5 +71,19 @@ describe( 'resolveSectionId', () => {
 
 	it( 'returns an empty slug when no sections are available yet', () => {
 		expect( resolveSectionId( 'traffic', [] ) ).toBe( '' );
+	} );
+} );
+
+describe( 'resolveSectionHeading', () => {
+	it( 'prefers the registered heading over the tab label', () => {
+		expect( resolveSectionHeading( SECTIONS[ 0 ] ) ).toBe( 'Site traffic' );
+	} );
+
+	it( 'falls back to the label when the heading is null', () => {
+		expect( resolveSectionHeading( STORE ) ).toBe( 'Store' );
+	} );
+
+	it( 'falls back to the label when the field is absent', () => {
+		expect( resolveSectionHeading( LEGACY ) ).toBe( 'Traffic' );
 	} );
 } );

--- a/projects/packages/premium-analytics/routes/dashboard/config/sections.test.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/sections.test.ts
@@ -34,13 +34,13 @@ const SECTIONS: DashboardSection[] = [
 	},
 ];
 
-// Registers no copy of its own, the way Store does.
+// Registers no heading of its own, the way Store does.
 const STORE: DashboardSection = {
 	id: 'woocommerce/store',
 	slug: 'store',
 	label: 'Store',
 	title: null,
-	description: null,
+	description: 'Sales, orders, and what your customers are buying.',
 	order: 40,
 	date_filter: 'range',
 	default_layout: [],

--- a/projects/packages/premium-analytics/routes/dashboard/config/sections.test.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/sections.test.ts
@@ -86,4 +86,11 @@ describe( 'resolveSectionHeading', () => {
 	it( 'falls back to the label when the field is absent', () => {
 		expect( resolveSectionHeading( LEGACY ) ).toBe( 'Traffic' );
 	} );
+
+	it( 'falls back to the label when the heading is an empty string', () => {
+		// The registry normalises `''` to null before it ever reaches here; this
+		// pins the client's own guard, since an empty heading would render an
+		// `<h2>` with no accessible name.
+		expect( resolveSectionHeading( { ...STORE, title: '' } ) ).toBe( 'Store' );
+	} );
 } );

--- a/projects/packages/premium-analytics/routes/dashboard/config/sections.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/sections.ts
@@ -10,7 +10,7 @@ import type { DashboardWidget } from '@wordpress/widget-dashboard';
 /**
  * A dashboard section, served by `GET /dashboards/{name}/sections` and read
  * through the `dashboardSection` core-data entity. The server-side registry is
- * the source of truth for which sections exist, their order, and labels.
+ * the source of truth for which sections exist, their order, and their copy.
  */
 export type DashboardSection = {
 	/**
@@ -82,7 +82,9 @@ export type DashboardSectionId = string;
  * @return The heading text.
  */
 export function resolveSectionHeading( section: DashboardSection ): string {
-	return section.title ?? section.label;
+	// `||` rather than `??`: an empty string is a registrant meaning "none", and
+	// heading the section with it would render an `<h2>` with no accessible name.
+	return section.title || section.label;
 }
 
 /**

--- a/projects/packages/premium-analytics/routes/dashboard/config/sections.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/sections.ts
@@ -31,18 +31,17 @@ export type DashboardSection = {
 	label: string;
 
 	/**
-	 * Translated section heading, deliberately distinct from the tab label: the
-	 * tab reads `Traffic` where the heading reads `Site traffic`.
-	 *
-	 * Absent or `null` when the section registers no heading of its own — read it
-	 * as `title ?? label`. Optional for the same reason as `date_filter` below:
-	 * a Simple site can be served a payload built before the field existed.
+	 * Translated section heading, deliberately not the tab label: the `Traffic`
+	 * tab heads its section `Site traffic`. Read it through
+	 * `resolveSectionHeading`. Optional for the same reason as `date_filter`
+	 * below.
 	 */
 	title?: string | null;
 
 	/**
-	 * Translated section description, shown as the page subtitle while this
-	 * section is active. Absent or `null` when the section registers none.
+	 * Translated section description, rendered as the page subtitle while this
+	 * section is active. Missing or `null` renders no subtitle — there is no
+	 * default copy behind it.
 	 */
 	description?: string | null;
 
@@ -58,9 +57,8 @@ export type DashboardSection = {
 	 *
 	 * Optional because the field can genuinely be absent: WPCOM's public-api
 	 * registers this route from its own checkout, so a Simple site can be served
-	 * a sections payload built before the field existed. Read it through
-	 * `resolveDateFilterSurface`, which treats a missing value as the
-	 * date-range surface.
+	 * a sections payload built before the field existed. A missing value means
+	 * the date-range surface.
 	 */
 	date_filter?: DateFilterSurface;
 
@@ -75,6 +73,17 @@ export type DashboardSection = {
  * Server-driven, so an open string.
  */
 export type DashboardSectionId = string;
+
+/**
+ * The heading a section shows above its widgets. Sections that register no
+ * heading of their own — Store today — head the section with their tab label.
+ *
+ * @param section - The section to head.
+ * @return The heading text.
+ */
+export function resolveSectionHeading( section: DashboardSection ): string {
+	return section.title ?? section.label;
+}
 
 /**
  * Narrow a candidate slug to an available section, falling back to the first

--- a/projects/packages/premium-analytics/routes/dashboard/config/sections.ts
+++ b/projects/packages/premium-analytics/routes/dashboard/config/sections.ts
@@ -26,9 +26,25 @@ export type DashboardSection = {
 	slug: string;
 
 	/**
-	 * Translated display label.
+	 * Translated display label. Names the section's tab.
 	 */
 	label: string;
+
+	/**
+	 * Translated section heading, deliberately distinct from the tab label: the
+	 * tab reads `Traffic` where the heading reads `Site traffic`.
+	 *
+	 * Absent or `null` when the section registers no heading of its own — read it
+	 * as `title ?? label`. Optional for the same reason as `date_filter` below:
+	 * a Simple site can be served a payload built before the field existed.
+	 */
+	title?: string | null;
+
+	/**
+	 * Translated section description, shown as the page subtitle while this
+	 * section is active. Absent or `null` when the section registers none.
+	 */
+	description?: string | null;
 
 	/**
 	 * Sort order (ascending).

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -79,15 +79,24 @@ function Dashboard(): JSX.Element {
 	 */
 	const dateFilters = useReportDateFilters( '/' );
 
+	const activeSectionRecord = sections.find( section => section.slug === activeSection );
+
 	/*
 	 * Which date filter the active section's header shows. Also reconciles the
 	 * preset in the URL with that filter's surface, so a section switch never
 	 * leaves the visible control unable to represent the selection.
 	 */
-	const dateFilterSurface = useSectionDateFilter(
-		sections.find( section => section.slug === activeSection ),
-		dateFilters
-	);
+	const dateFilterSurface = useSectionDateFilter( activeSectionRecord, dateFilters );
+
+	/*
+	 * The page description belongs to the active section, so it swaps with the tab.
+	 * WPCOM's public-api registers the sections route from its own checkout and can
+	 * serve a payload built before the field existed, so fall back to the copy the
+	 * page carried when it was not yet per-section.
+	 */
+	const pageSubtitle =
+		activeSectionRecord?.description ??
+		__( 'Track your site performance and visitor insights.', 'jetpack-premium-analytics-pkg' );
 
 	/*
 	 * The subtitle states what the widgets are currently showing, so it follows
@@ -179,10 +188,7 @@ function Dashboard(): JSX.Element {
 				<Page
 					visual={ <StatsPageIcon /> }
 					breadcrumbs={ <StatsBreadcrumbs isRoot /> }
-					subTitle={ __(
-						'Track your site performance and visitor insights.',
-						'jetpack-premium-analytics-pkg'
-					) }
+					subTitle={ pageSubtitle }
 					actions={ <WidgetDashboard.Actions /> }
 					className={ styles.dashboard }
 				>
@@ -198,7 +204,10 @@ function Dashboard(): JSX.Element {
 								className={ styles.content }
 							>
 								<div ref={ setContainerElement } className={ styles.sectionHeader }>
-									<SectionHeader title={ section.label } subtitle={ sectionSubtitle }>
+									<SectionHeader
+										title={ section.title ?? section.label }
+										subtitle={ sectionSubtitle }
+									>
 										{ dateControls }
 									</SectionHeader>
 								</div>

--- a/projects/packages/premium-analytics/routes/dashboard/stage.tsx
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.tsx
@@ -15,12 +15,11 @@ import { Spinner } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useSelect } from '@wordpress/data';
 import { useCallback, useMemo, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
 import { WidgetDashboard } from '@wordpress/widget-dashboard';
 import { type WidgetModuleRecord } from '@wordpress/widget-primitives';
 import { resolveWidgetModuleWithI18n, useWidgetTypesWithI18n } from '../widget-module-i18n';
 import { DashboardSections } from './components';
-import { DATE_FILTER_YEAR } from './config';
+import { DATE_FILTER_YEAR, resolveSectionHeading } from './config';
 import {
 	useActiveSection,
 	useDashboardGridSettings,
@@ -87,16 +86,6 @@ function Dashboard(): JSX.Element {
 	 * leaves the visible control unable to represent the selection.
 	 */
 	const dateFilterSurface = useSectionDateFilter( activeSectionRecord, dateFilters );
-
-	/*
-	 * The page description belongs to the active section, so it swaps with the tab.
-	 * WPCOM's public-api registers the sections route from its own checkout and can
-	 * serve a payload built before the field existed, so fall back to the copy the
-	 * page carried when it was not yet per-section.
-	 */
-	const pageSubtitle =
-		activeSectionRecord?.description ??
-		__( 'Track your site performance and visitor insights.', 'jetpack-premium-analytics-pkg' );
 
 	/*
 	 * The subtitle states what the widgets are currently showing, so it follows
@@ -188,7 +177,7 @@ function Dashboard(): JSX.Element {
 				<Page
 					visual={ <StatsPageIcon /> }
 					breadcrumbs={ <StatsBreadcrumbs isRoot /> }
-					subTitle={ pageSubtitle }
+					subTitle={ activeSectionRecord?.description }
 					actions={ <WidgetDashboard.Actions /> }
 					className={ styles.dashboard }
 				>
@@ -205,7 +194,7 @@ function Dashboard(): JSX.Element {
 							>
 								<div ref={ setContainerElement } className={ styles.sectionHeader }>
 									<SectionHeader
-										title={ section.title ?? section.label }
+										title={ resolveSectionHeading( section ) }
 										subtitle={ sectionSubtitle }
 									>
 										{ dateControls }

--- a/projects/packages/premium-analytics/src/class-dashboard-section.php
+++ b/projects/packages/premium-analytics/src/class-dashboard-section.php
@@ -72,6 +72,23 @@ final class Dashboard_Section {
 	public $label;
 
 	/**
+	 * Section heading, deliberately distinct from the tab label: the tab reads
+	 * `Traffic` where the heading reads `Site traffic`. Null falls back to the label.
+	 *
+	 * @since $$next-version$$
+	 * @var string|null
+	 */
+	public $title = null;
+
+	/**
+	 * Section description, shown as the page subtitle while this section is active.
+	 *
+	 * @since $$next-version$$
+	 * @var string|null
+	 */
+	public $description = null;
+
+	/**
 	 * Sort order.
 	 *
 	 * @var int
@@ -164,6 +181,8 @@ final class Dashboard_Section {
 			'id'             => $this->id,
 			'slug'           => $this->slug,
 			'label'          => $this->label,
+			'title'          => $this->title,
+			'description'    => $this->description,
 			'order'          => (int) $this->order,
 			'date_filter'    => $this->date_filter,
 			'default_layout' => $this->get_default_layout(),
@@ -183,6 +202,14 @@ final class Dashboard_Section {
 
 		if ( isset( $args['label'] ) ) {
 			$this->label = (string) $args['label'];
+		}
+
+		if ( isset( $args['title'] ) ) {
+			$this->title = (string) $args['title'];
+		}
+
+		if ( isset( $args['description'] ) ) {
+			$this->description = (string) $args['description'];
 		}
 
 		if ( isset( $args['order'] ) ) {

--- a/projects/packages/premium-analytics/src/class-dashboard-section.php
+++ b/projects/packages/premium-analytics/src/class-dashboard-section.php
@@ -65,7 +65,7 @@ final class Dashboard_Section {
 	public $slug;
 
 	/**
-	 * Display label.
+	 * Display label, naming the section's tab.
 	 *
 	 * @var string
 	 */

--- a/projects/packages/premium-analytics/src/class-dashboard-section.php
+++ b/projects/packages/premium-analytics/src/class-dashboard-section.php
@@ -204,12 +204,16 @@ final class Dashboard_Section {
 			$this->label = (string) $args['label'];
 		}
 
+		// An empty string is a registrant saying "none", not a heading: kept as-is it
+		// would defeat the label fallback and render an `<h2>` with no accessible name.
 		if ( isset( $args['title'] ) ) {
-			$this->title = (string) $args['title'];
+			$title       = (string) $args['title'];
+			$this->title = '' === $title ? null : $title;
 		}
 
 		if ( isset( $args['description'] ) ) {
-			$this->description = (string) $args['description'];
+			$description       = (string) $args['description'];
+			$this->description = '' === $description ? null : $description;
 		}
 
 		if ( isset( $args['order'] ) ) {

--- a/projects/packages/premium-analytics/src/dashboard-sections.php
+++ b/projects/packages/premium-analytics/src/dashboard-sections.php
@@ -128,8 +128,8 @@ function register_default_dashboard_sections() {
 				return get_dashboard_default_layout_for( 'analytics/subscribers' );
 			},
 		),
-		// Store carries no title or description: the design prototype has no Store
-		// tab, so it falls back to the label until copy exists for it.
+		// Store registers no copy of its own: its heading falls back to the label,
+		// and it shows no page description, until copy exists for it.
 		'woocommerce/store'     => array(
 			'label'          => __( 'Store', 'jetpack-premium-analytics-pkg' ),
 			'order'          => 40,

--- a/projects/packages/premium-analytics/src/dashboard-sections.php
+++ b/projects/packages/premium-analytics/src/dashboard-sections.php
@@ -128,10 +128,10 @@ function register_default_dashboard_sections() {
 				return get_dashboard_default_layout_for( 'analytics/subscribers' );
 			},
 		),
-		// Store registers no copy of its own: its heading falls back to the label,
-		// and it shows no page description, until copy exists for it.
+		// Store registers no heading of its own, so it falls back to the label.
 		'woocommerce/store'     => array(
 			'label'          => __( 'Store', 'jetpack-premium-analytics-pkg' ),
+			'description'    => __( 'Sales, orders, and what your customers are buying.', 'jetpack-premium-analytics-pkg' ),
 			'order'          => 40,
 			'is_available'   => __NAMESPACE__ . '\\is_woocommerce_dashboard_section_available_to_current_user',
 			'default_layout' => __NAMESPACE__ . '\\get_woocommerce_dashboard_section_default_layout',

--- a/projects/packages/premium-analytics/src/dashboard-sections.php
+++ b/projects/packages/premium-analytics/src/dashboard-sections.php
@@ -100,6 +100,8 @@ function register_default_dashboard_sections() {
 	$sections = array(
 		'analytics/traffic'     => array(
 			'label'          => __( 'Traffic', 'jetpack-premium-analytics-pkg' ),
+			'title'          => __( 'Site traffic', 'jetpack-premium-analytics-pkg' ),
+			'description'    => __( 'Views, visitors, and where they came from.', 'jetpack-premium-analytics-pkg' ),
 			'order'          => 10,
 			'default_layout' => static function () {
 				return get_dashboard_default_layout_for( 'analytics/traffic' );
@@ -107,6 +109,8 @@ function register_default_dashboard_sections() {
 		),
 		'analytics/insights'    => array(
 			'label'          => __( 'Insights', 'jetpack-premium-analytics-pkg' ),
+			'title'          => __( 'Activity insights', 'jetpack-premium-analytics-pkg' ),
+			'description'    => __( 'Longer-term patterns in your content and audience.', 'jetpack-premium-analytics-pkg' ),
 			'order'          => 20,
 			// Insights reads whole history, so it offers all time and single
 			// years instead of the rolling date-range picker.
@@ -117,11 +121,15 @@ function register_default_dashboard_sections() {
 		),
 		'analytics/subscribers' => array(
 			'label'          => __( 'Subscribers', 'jetpack-premium-analytics-pkg' ),
+			'title'          => __( 'Subscribers stats', 'jetpack-premium-analytics-pkg' ),
+			'description'    => __( 'How your subscriber list is growing, and how your emails land.', 'jetpack-premium-analytics-pkg' ),
 			'order'          => 30,
 			'default_layout' => static function () {
 				return get_dashboard_default_layout_for( 'analytics/subscribers' );
 			},
 		),
+		// Store carries no title or description: the design prototype has no Store
+		// tab, so it falls back to the label until copy exists for it.
 		'woocommerce/store'     => array(
 			'label'          => __( 'Store', 'jetpack-premium-analytics-pkg' ),
 			'order'          => 40,
@@ -216,8 +224,18 @@ function get_dashboard_section_schema() {
 				'readonly'    => true,
 			),
 			'label'          => array(
-				'description' => __( 'Translated display label.', 'jetpack-premium-analytics-pkg' ),
+				'description' => __( 'Translated display label, naming the section tab.', 'jetpack-premium-analytics-pkg' ),
 				'type'        => 'string',
+				'readonly'    => true,
+			),
+			'title'          => array(
+				'description' => __( 'Translated section heading, distinct from the tab label. Null falls back to the label.', 'jetpack-premium-analytics-pkg' ),
+				'type'        => array( 'string', 'null' ),
+				'readonly'    => true,
+			),
+			'description'    => array(
+				'description' => __( 'Translated section description, shown as the page subtitle while the section is active.', 'jetpack-premium-analytics-pkg' ),
+				'type'        => array( 'string', 'null' ),
 				'readonly'    => true,
 			),
 			'order'          => array(

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
@@ -163,6 +163,24 @@ class Dashboard_Section_Test extends BaseTestCase {
 	}
 
 	/**
+	 * An empty string registers as "no copy" rather than an empty heading.
+	 */
+	public function test_section_normalises_empty_title_and_description_to_null() {
+		$section = new Dashboard_Section(
+			'example_dashboard',
+			'example/traffic',
+			array(
+				'label'       => 'Traffic',
+				'title'       => '',
+				'description' => '',
+			)
+		);
+
+		$this->assertNull( $section->title );
+		$this->assertNull( $section->description );
+	}
+
+	/**
 	 * A section can opt into the year date filter.
 	 */
 	public function test_section_accepts_the_year_date_filter() {

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
@@ -281,7 +281,7 @@ class Dashboard_Section_Test extends BaseTestCase {
 
 		$descriptions = array_column( $sections, 'description', 'slug' );
 		$this->assertSame( 'Views, visitors, and where they came from.', $descriptions['traffic'] );
-		$this->assertNull( $descriptions['store'] );
+		$this->assertSame( 'Sales, orders, and what your customers are buying.', $descriptions['store'] );
 	}
 
 	/**

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Section_Test.php
@@ -123,6 +123,46 @@ class Dashboard_Section_Test extends BaseTestCase {
 	}
 
 	/**
+	 * A section carries a heading and description distinct from its tab label.
+	 */
+	public function test_section_accepts_title_and_description() {
+		$registry = new Dashboard_Section_Registry();
+
+		$section = $registry->register(
+			'example_dashboard',
+			'example/traffic',
+			array(
+				'label'       => 'Traffic',
+				'title'       => 'Site traffic',
+				'description' => 'Views, visitors, and where they came from.',
+			)
+		);
+
+		$this->assertInstanceOf( Dashboard_Section::class, $section );
+		$this->assertSame( 'Traffic', $section->label );
+		$this->assertSame( 'Site traffic', $section->title );
+		$this->assertSame( 'Views, visitors, and where they came from.', $section->description );
+
+		$data = $section->to_array();
+		$this->assertSame( 'Site traffic', $data['title'] );
+		$this->assertSame( 'Views, visitors, and where they came from.', $data['description'] );
+	}
+
+	/**
+	 * Both fields stay null when unregistered, so the dashboard can fall back to the label.
+	 */
+	public function test_section_title_and_description_default_to_null() {
+		$section = new Dashboard_Section( 'example_dashboard', 'example/traffic', array( 'label' => 'Traffic' ) );
+
+		$this->assertNull( $section->title );
+		$this->assertNull( $section->description );
+
+		$data = $section->to_array();
+		$this->assertNull( $data['title'] );
+		$this->assertNull( $data['description'] );
+	}
+
+	/**
 	 * A section can opt into the year date filter.
 	 */
 	public function test_section_accepts_the_year_date_filter() {
@@ -194,13 +234,46 @@ class Dashboard_Section_Test extends BaseTestCase {
 	}
 
 	/**
+	 * The analytics sections carry their own heading; Store still falls back to its label.
+	 */
+	public function test_built_in_sections_declare_their_headings() {
+		// Store needs both gates: the filter stands in for WooCommerce being active,
+		// and the admin user satisfies the capability check added in #50889.
+		$this->set_admin_user();
+		add_filter( WOOCOMMERCE_DASHBOARD_SECTION_AVAILABLE_FILTER, '__return_true' );
+
+		register_default_dashboard_sections();
+
+		$sections = array_map(
+			static function ( Dashboard_Section $section ) {
+				return $section->to_array();
+			},
+			get_available_dashboard_sections( DASHBOARD_NAME )
+		);
+
+		$this->assertSame(
+			array(
+				'traffic'     => 'Site traffic',
+				'insights'    => 'Activity insights',
+				'subscribers' => 'Subscribers stats',
+				'store'       => null,
+			),
+			array_column( $sections, 'title', 'slug' )
+		);
+
+		$descriptions = array_column( $sections, 'description', 'slug' );
+		$this->assertSame( 'Views, visitors, and where they came from.', $descriptions['traffic'] );
+		$this->assertNull( $descriptions['store'] );
+	}
+
+	/**
 	 * The sections schema documents the date-filter surfaces and their default.
 	 */
 	public function test_sections_schema_documents_the_date_filter() {
 		$schema = get_dashboard_section_schema();
 
 		$this->assertSame(
-			array( 'id', 'slug', 'label', 'order', 'date_filter', 'default_layout' ),
+			array( 'id', 'slug', 'label', 'title', 'description', 'order', 'date_filter', 'default_layout' ),
 			array_keys( $schema['properties'] )
 		);
 		$this->assertSame(
@@ -368,6 +441,8 @@ class Dashboard_Section_Test extends BaseTestCase {
 					'id'             => 'analytics/traffic',
 					'slug'           => 'traffic',
 					'label'          => 'Traffic',
+					'title'          => null,
+					'description'    => null,
 					'order'          => 10,
 					'date_filter'    => 'range',
 					'default_layout' => array(),
@@ -484,6 +559,8 @@ class Dashboard_Section_Test extends BaseTestCase {
 					'id'          => 'analytics/traffic',
 					'slug'        => 'traffic',
 					'label'       => 'Traffic',
+					'title'       => 'Site traffic',
+					'description' => 'Views, visitors, and where they came from.',
 					'order'       => 10,
 					'date_filter' => 'range',
 				),
@@ -491,6 +568,8 @@ class Dashboard_Section_Test extends BaseTestCase {
 					'id'          => 'analytics/insights',
 					'slug'        => 'insights',
 					'label'       => 'Insights',
+					'title'       => 'Activity insights',
+					'description' => 'Longer-term patterns in your content and audience.',
 					'order'       => 20,
 					'date_filter' => 'year',
 				),
@@ -498,6 +577,8 @@ class Dashboard_Section_Test extends BaseTestCase {
 					'id'          => 'analytics/subscribers',
 					'slug'        => 'subscribers',
 					'label'       => 'Subscribers',
+					'title'       => 'Subscribers stats',
+					'description' => 'How your subscriber list is growing, and how your emails land.',
 					'order'       => 30,
 					'date_filter' => 'range',
 				),
@@ -691,6 +772,8 @@ class Dashboard_Section_Test extends BaseTestCase {
 					'id'             => 'example/first',
 					'slug'           => 'first',
 					'label'          => 'First',
+					'title'          => null,
+					'description'    => null,
 					'order'          => 10,
 					'date_filter'    => 'range',
 					'default_layout' => array(),
@@ -699,6 +782,8 @@ class Dashboard_Section_Test extends BaseTestCase {
 					'id'             => 'example/later',
 					'slug'           => 'later',
 					'label'          => 'Later',
+					'title'          => null,
+					'description'    => null,
 					'order'          => 20,
 					'date_filter'    => 'range',
 					'default_layout' => array(),
@@ -774,6 +859,8 @@ class Dashboard_Section_Test extends BaseTestCase {
 					'id'             => 'analytics/traffic',
 					'slug'           => 'traffic',
 					'label'          => 'Traffic',
+					'title'          => null,
+					'description'    => null,
 					'order'          => 10,
 					'date_filter'    => 'range',
 					'default_layout' => array(

--- a/projects/packages/premium-analytics/widgets/hello-world/stories/dashboard-sections-grid.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/hello-world/stories/dashboard-sections-grid.stories.tsx
@@ -93,8 +93,7 @@ const resolveWidgetModule: ResolveWidgetModule = moduleId =>
 		: Promise.reject( new Error( `Unknown story widget module: ${ moduleId }` ) );
 
 // In product the section list is server-driven (the dashboardSection entity);
-// the story pins a static list mirroring that response shape. Store registers
-// no description, the way it does in product.
+// the story pins a static list mirroring that response shape.
 const storySections = [
 	{
 		id: 'analytics/traffic',
@@ -120,7 +119,14 @@ const storySections = [
 		order: 30,
 		default_layout: [],
 	},
-	{ id: 'woocommerce/store', slug: 'store', label: 'Store', order: 40, default_layout: [] },
+	{
+		id: 'woocommerce/store',
+		slug: 'store',
+		label: 'Store',
+		description: 'Sales, orders, and what your customers are buying.',
+		order: 40,
+		default_layout: [],
+	},
 ];
 
 /**

--- a/projects/packages/premium-analytics/widgets/hello-world/stories/dashboard-sections-grid.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/hello-world/stories/dashboard-sections-grid.stories.tsx
@@ -1,4 +1,5 @@
 import { useState } from '@wordpress/element';
+import { Page } from '@wordpress/admin-ui';
 import { Tabs } from '@jetpack-premium-analytics/externals';
 import { WidgetDashboard, type DashboardWidget } from '@wordpress/widget-dashboard';
 import { DashboardSections } from '../../../routes/dashboard/components';
@@ -135,30 +136,13 @@ function DashboardSectionsGridStory() {
 	const activeSectionRecord = sections.find( section => section.slug === activeSection );
 
 	return (
-		<section
+		// The page title comes from the breadcrumbs in product; the story passes it
+		// directly so it needs no router.
+		<Page
+			title="Stats"
+			subTitle={ activeSectionRecord?.description }
 			className={ styles.dashboard }
-			style={ {
-				blockSize: '100%',
-				boxSizing: 'border-box',
-				display: 'flex',
-				flexDirection: 'column',
-				padding: '24px',
-			} }
 		>
-			<header
-				style={ {
-					flex: '0 0 auto',
-					marginBlockEnd: '24px',
-				} }
-			>
-				<h1 style={ { fontSize: '32px', lineHeight: 1.2, margin: 0 } }>Stats</h1>
-				{ activeSectionRecord?.description ? (
-					<p style={ { color: '#50575e', margin: '8px 0 0' } }>
-						{ activeSectionRecord.description }
-					</p>
-				) : null }
-			</header>
-
 			<DashboardSections
 				sections={ sections }
 				value={ activeSection }
@@ -181,7 +165,7 @@ function DashboardSectionsGridStory() {
 					</Tabs.Panel>
 				) ) }
 			</DashboardSections>
-		</section>
+		</Page>
 	);
 }
 

--- a/projects/packages/premium-analytics/widgets/hello-world/stories/dashboard-sections-grid.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/hello-world/stories/dashboard-sections-grid.stories.tsx
@@ -92,14 +92,30 @@ const resolveWidgetModule: ResolveWidgetModule = moduleId =>
 		: Promise.reject( new Error( `Unknown story widget module: ${ moduleId }` ) );
 
 // In product the section list is server-driven (the dashboardSection entity);
-// the story pins a static list mirroring that response shape.
+// the story pins a static list mirroring that response shape. Store registers
+// no description, the way it does in product.
 const storySections = [
-	{ id: 'analytics/traffic', slug: 'traffic', label: 'Traffic', order: 10, default_layout: [] },
-	{ id: 'analytics/insights', slug: 'insights', label: 'Insights', order: 20, default_layout: [] },
+	{
+		id: 'analytics/traffic',
+		slug: 'traffic',
+		label: 'Traffic',
+		description: 'Views, visitors, and where they came from.',
+		order: 10,
+		default_layout: [],
+	},
+	{
+		id: 'analytics/insights',
+		slug: 'insights',
+		label: 'Insights',
+		description: 'Longer-term patterns in your content and audience.',
+		order: 20,
+		default_layout: [],
+	},
 	{
 		id: 'analytics/subscribers',
 		slug: 'subscribers',
 		label: 'Subscribers',
+		description: 'How your subscriber list is growing, and how your emails land.',
 		order: 30,
 		default_layout: [],
 	},
@@ -115,6 +131,8 @@ function DashboardSectionsGridStory() {
 	const sections = storySections;
 	const [ activeSection, setActiveSection ] = useState( sections[ 0 ].slug );
 	const [ layout, setLayout ] = useState< DashboardWidget[] >( initialLayout );
+
+	const activeSectionRecord = sections.find( section => section.slug === activeSection );
 
 	return (
 		<section
@@ -133,10 +151,12 @@ function DashboardSectionsGridStory() {
 					marginBlockEnd: '24px',
 				} }
 			>
-				<h1 style={ { fontSize: '32px', lineHeight: 1.2, margin: 0 } }>Analytics</h1>
-				<p style={ { color: '#50575e', margin: '8px 0 0' } }>
-					Track your site performance and visitor insights.
-				</p>
+				<h1 style={ { fontSize: '32px', lineHeight: 1.2, margin: 0 } }>Stats</h1>
+				{ activeSectionRecord?.description ? (
+					<p style={ { color: '#50575e', margin: '8px 0 0' } }>
+						{ activeSectionRecord.description }
+					</p>
+				) : null }
 			</header>
 
 			<DashboardSections


### PR DESCRIPTION
Fixes WOOA7S-1853

## Proposed changes

Every dashboard tab showed the same page description, and each section's heading was its tab label verbatim. The design gives each section its own copy at two levels: a description in the page header that swaps with the active tab, and a heading distinct from the tab label.

- Add optional `title` and `description` to the dashboard section registration args, exposed through `Dashboard_Section::to_array()` and the sections schema. Optional because WPCOM's public-api registers this route from its own checkout, so a Simple site can be served a payload built before the fields existed — the same constraint #50930 hit with `date_filter`.
- Register the copy for Traffic, Insights and Subscribers. Store registers none, so it keeps its label as a heading and shows no page description.
- Read the active section's `title` as the section heading through `resolveSectionHeading`, falling back to the label. Its `description` becomes the page subtitle; a section with none renders no subtitle, with no default copy behind it.

The date-configuration subtitle under each heading is untouched (WOOA7S-1824).

| Tab         | Page description                                               | Section heading   |
| ----------- | -------------------------------------------------------------- | ----------------- |
| Traffic     | Views, visitors, and where they came from.                     | Site traffic      |
| Insights    | Longer-term patterns in your content and audience.             | Activity insights |
| Subscribers | How your subscriber list is growing, and how your emails land. | Subscribers stats |

## Related product discussion/links

- WOOA7S-1853
- WOOA7S-1793 — the section header umbrella this sits under
- WOOA7S-1824 — shipped the date-configuration subtitle this deliberately leaves alone

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Connect a site with the Premium Analytics plugin active and open **Stats v2** in wp-admin.
- On the **Traffic** tab, confirm the line under the "Stats" page heading reads "Views, visitors, and where they came from." and the section heading below the tab bar reads **Site traffic**.
- Switch to **Insights**: the page description becomes "Longer-term patterns in your content and audience." and the heading becomes **Activity insights**.
- Switch to **Subscribers**: "How your subscriber list is growing, and how your emails land." and **Subscribers stats**.
- Confirm the smaller line under each heading still describes the date range/comparison and is unchanged by this PR (Insights keeps its year range, the others the rolling range).
- With WooCommerce active, confirm the **Store** tab heads its section "Store" (falling back to its tab label) and shows no page description at all.

Verified on a Jurassic Ninja site across all four tabs, WooCommerce included; no console errors.

|                 | Before                                                                                                                 | After                                                                                                                 |
| --------------- | ---------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
| **Traffic**     | <img alt="before-traffic" src="https://github.com/user-attachments/assets/79af5916-d3f7-4736-b06a-cea44ba9e447" />     | <img alt="after-traffic" src="https://github.com/user-attachments/assets/31e85438-8e65-4386-90ed-ef44748de2d9" />     |
| **Insights**    | <img alt="before-insights" src="https://github.com/user-attachments/assets/49c87a58-2920-4522-84cf-fc0e355eeaa9" />    | <img alt="after-insights" src="https://github.com/user-attachments/assets/7ff02357-3768-4735-acf3-7625cc5cd616" />    |
| **Subscribers** | <img alt="before-subscribers" src="https://github.com/user-attachments/assets/86a65d0c-cc46-41a8-85b0-ead6636aa8ad" /> | <img alt="after-subscribers" src="https://github.com/user-attachments/assets/09880592-57d6-4fbb-9eb3-4ec02bc14346" /> |

