### PR TITLE
Jetpack MU WPcom: migrate legacy guidelines to Knowledge on Atomic sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/migrate-knowledge
+++ b/projects/packages/jetpack-mu-wpcom/changelog/migrate-knowledge
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Knowledge: Migrate legacy guideline storage on Atomic sites.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -75,6 +75,7 @@ class Jetpack_Mu_Wpcom {
 		// These features run only on atomic sites.
 		if ( defined( 'IS_ATOMIC' ) && IS_ATOMIC ) {
 			add_action( 'plugins_loaded', array( __CLASS__, 'load_custom_css' ) );
+			add_action( 'plugins_loaded', array( __CLASS__, 'load_knowledge_migration' ) );
 			add_action( 'init', array( __CLASS__, 'schedule_translation_updates' ) );
 		}
 
@@ -135,6 +136,13 @@ class Jetpack_Mu_Wpcom {
 		if ( ! wp_next_scheduled( 'wpcomsh_translation_update' ) ) {
 			wp_schedule_event( time(), 'twicedaily', 'wpcomsh_translation_update' );
 		}
+	}
+
+	/**
+	 * Load the temporary legacy guideline compatibility and Knowledge migration feature.
+	 */
+	public static function load_knowledge_migration() {
+		require_once __DIR__ . '/features/knowledge-migration/knowledge-migration.php';
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/src/features/knowledge-migration/class-knowledge-migration.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/knowledge-migration/class-knowledge-migration.php
@@ -548,10 +548,19 @@ class Knowledge_Migration {
 	/**
 	 * Find an active Knowledge post by exact slug.
 	 *
+	 * Drafts and pending posts are allowed to have an empty slug, and WP_Query
+	 * drops the `name` condition when it is empty. Querying with an empty slug
+	 * would therefore return an unrelated Knowledge post and make the caller
+	 * retire a source that was never migrated.
+	 *
 	 * @param string $slug Post slug.
 	 * @return \WP_Post|null
 	 */
 	private static function find_knowledge_post( string $slug ): ?\WP_Post {
+		if ( '' === $slug ) {
+			return null;
+		}
+
 		$posts = get_posts(
 			array(
 				'name'           => $slug,

--- a/projects/packages/jetpack-mu-wpcom/src/features/knowledge-migration/class-knowledge-migration.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/knowledge-migration/class-knowledge-migration.php
@@ -1,0 +1,686 @@
+<?php
+/**
+ * Local migration from legacy guideline storage to Knowledge.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+/**
+ * Register legacy storage and migrate its active records locally.
+ */
+class Knowledge_Migration {
+	/**
+	 * Increment to deliberately run another migration pass on Atomic sites.
+	 */
+	public const MIGRATION_VERSION = 1;
+
+	/**
+	 * Public constants used by operational checks and tests.
+	 */
+	public const OPTION_NAME = 'jetpack_mu_wpcom_knowledge_migration';
+	public const CRON_HOOK   = 'jetpack_mu_wpcom_knowledge_migration';
+
+	/**
+	 * Internal migration constants.
+	 */
+	private const LOCK_TRANSIENT  = 'jetpack_mu_wpcom_knowledge_migration_lock';
+	private const LOCK_TTL        = 15 * MINUTE_IN_SECONDS;
+	private const RETRY_DELAY     = DAY_IN_SECONDS;
+	private const ACTIVE_STATUSES = array( 'publish', 'private', 'draft', 'pending', 'future' );
+
+	/**
+	 * Whether hooks have already been registered.
+	 *
+	 * @var bool
+	 */
+	private static $initialized = false;
+
+	/**
+	 * Register feature hooks.
+	 */
+	public static function init(): void {
+		if ( self::$initialized ) {
+			return;
+		}
+
+		self::$initialized = true;
+
+		add_action( 'init', array( __CLASS__, 'register_legacy_storage' ), 9 );
+		add_action( 'init', array( __CLASS__, 'register_migration_setting' ), 9 );
+		add_action( 'init', array( __CLASS__, 'maybe_schedule_migration' ), 100 );
+		add_action( self::CRON_HOOK, array( __CLASS__, 'run_migration' ) );
+	}
+
+	/**
+	 * Register legacy post types and taxonomy independently of migration state.
+	 */
+	public static function register_legacy_storage(): void {
+		if ( ! post_type_exists( 'wp_guideline' ) ) {
+			register_post_type(
+				'wp_guideline', // phpcs:ignore WordPress.NamingConventions.ValidPostTypeSlug.ReservedPrefix -- Historical Gutenberg post type being migrated.
+				array(
+					'label'                 => __( 'Guidelines', 'jetpack-mu-wpcom' ),
+					'public'                => false,
+					'publicly_queryable'    => false,
+					'show_ui'               => false,
+					'show_in_menu'          => false,
+					'show_in_rest'          => true,
+					'rest_base'             => 'guidelines',
+					'rest_controller_class' => Legacy_Guideline_REST_Controller::class,
+					'supports'              => array( 'title', 'editor', 'excerpt', 'author', 'custom-fields', 'revisions' ),
+					'has_archive'           => false,
+					'rewrite'               => false,
+					'query_var'             => false,
+					'can_export'            => true,
+				)
+			);
+		}
+
+		if ( ! taxonomy_exists( 'wp_guideline_type' ) ) {
+			register_taxonomy(
+				'wp_guideline_type',
+				'wp_guideline',
+				array(
+					'label'              => __( 'Guideline Types', 'jetpack-mu-wpcom' ),
+					'public'             => false,
+					'publicly_queryable' => false,
+					'hierarchical'       => true,
+					'show_ui'            => false,
+					'show_in_rest'       => true,
+					'rest_base'          => 'wp_guideline_type',
+					'show_in_nav_menus'  => false,
+					'rewrite'            => false,
+					'query_var'          => false,
+				)
+			);
+		}
+
+		if ( ! post_type_exists( 'wp_content_guideline' ) ) {
+			register_post_type(
+				'wp_content_guideline', // phpcs:ignore WordPress.NamingConventions.ValidPostTypeSlug.ReservedPrefix -- Historical Gutenberg post type being migrated.
+				array(
+					'label'                 => __( 'Content Guidelines', 'jetpack-mu-wpcom' ),
+					'public'                => false,
+					'publicly_queryable'    => false,
+					'show_ui'               => false,
+					'show_in_menu'          => false,
+					'show_in_rest'          => true,
+					'rest_base'             => 'content-guidelines',
+					'rest_controller_class' => Legacy_Guideline_REST_Controller::class,
+					'supports'              => array( 'title', 'author', 'custom-fields' ),
+					'has_archive'           => false,
+					'rewrite'               => false,
+					'query_var'             => false,
+				)
+			);
+		}
+	}
+
+	/**
+	 * Register the writable migration state in the standard settings REST API.
+	 */
+	public static function register_migration_setting(): void {
+		register_setting(
+			'general',
+			self::OPTION_NAME,
+			array(
+				'type'              => 'object',
+				'description'       => __( 'State of the legacy guideline to Knowledge migration.', 'jetpack-mu-wpcom' ),
+				'default'           => self::default_state(),
+				'sanitize_callback' => array( __CLASS__, 'sanitize_state' ),
+				'show_in_rest'      => array(
+					'schema' => array(
+						'type'                 => 'object',
+						'additionalProperties' => false,
+						'properties'           => array(
+							'version'      => array(
+								'type'    => 'integer',
+								'default' => 0,
+							),
+							'status'       => array(
+								'type'    => 'string',
+								'enum'    => array( 'not_started', 'scheduled', 'started', 'complete', 'error' ),
+								'default' => 'not_started',
+							),
+							'started_at'   => array(
+								'type'    => 'integer',
+								'default' => 0,
+							),
+							'completed_at' => array(
+								'type'    => 'integer',
+								'default' => 0,
+							),
+							'last_error'   => array(
+								'type'    => 'string',
+								'default' => '',
+							),
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Sanitize migration state written locally or through REST.
+	 *
+	 * @param mixed $state Candidate state.
+	 * @return array<string, int|string>
+	 */
+	public static function sanitize_state( $state ): array {
+		$state          = is_array( $state ) ? $state : array();
+		$valid_statuses = array( 'not_started', 'scheduled', 'started', 'complete', 'error' );
+		$status         = isset( $state['status'] ) ? sanitize_key( (string) $state['status'] ) : 'not_started';
+
+		if ( ! in_array( $status, $valid_statuses, true ) ) {
+			$status = 'not_started';
+		}
+
+		return array(
+			'version'      => isset( $state['version'] ) ? max( 0, (int) $state['version'] ) : 0,
+			'status'       => $status,
+			'started_at'   => isset( $state['started_at'] ) ? max( 0, (int) $state['started_at'] ) : 0,
+			'completed_at' => isset( $state['completed_at'] ) ? max( 0, (int) $state['completed_at'] ) : 0,
+			'last_error'   => isset( $state['last_error'] ) ? sanitize_text_field( (string) $state['last_error'] ) : '',
+		);
+	}
+
+	/**
+	 * Schedule a single migration pass when this version has not completed.
+	 */
+	public static function maybe_schedule_migration(): void {
+		$state = self::get_state();
+		if ( self::is_complete( $state ) || wp_next_scheduled( self::CRON_HOOK ) ) {
+			return;
+		}
+
+		$scheduled = wp_schedule_single_event(
+			time() + wp_rand( MINUTE_IN_SECONDS, DAY_IN_SECONDS ),
+			self::CRON_HOOK,
+			array(),
+			true
+		);
+
+		if ( is_wp_error( $scheduled ) ) {
+			self::update_state( 'error', $scheduled->get_error_message() );
+			return;
+		}
+
+		self::update_state( 'scheduled' );
+	}
+
+	/**
+	 * Run the local migration from WP-Cron.
+	 */
+	public static function run_migration(): void {
+		if ( self::is_complete( self::get_state() ) ) {
+			return;
+		}
+
+		if ( get_transient( self::LOCK_TRANSIENT ) ) {
+			self::schedule_retry();
+			return;
+		}
+
+		set_transient( self::LOCK_TRANSIENT, 1, self::LOCK_TTL );
+		self::update_state( 'started' );
+
+		try {
+			$result = self::migrate();
+			if ( is_wp_error( $result ) ) {
+				self::update_state( 'error', $result->get_error_message() );
+				self::schedule_retry();
+				return;
+			}
+
+			self::update_state( 'complete' );
+		} finally {
+			delete_transient( self::LOCK_TRANSIENT );
+		}
+	}
+
+	/**
+	 * Migrate all active local legacy records.
+	 *
+	 * @return true|\WP_Error
+	 */
+	private static function migrate() {
+		if ( ! post_type_exists( 'wp_guideline' ) || ! taxonomy_exists( 'wp_guideline_type' ) || ! post_type_exists( 'wp_content_guideline' ) ) {
+			return new \WP_Error( 'legacy_storage_unavailable', 'Legacy guideline storage is not registered.' );
+		}
+
+		if ( ! post_type_exists( 'wp_knowledge' ) || ! taxonomy_exists( 'wp_knowledge_type' ) ) {
+			return new \WP_Error( 'knowledge_storage_unavailable', 'Knowledge storage is not registered.' );
+		}
+
+		$legacy_posts  = self::get_active_posts( 'wp_guideline' );
+		$content_posts = self::get_active_posts( 'wp_content_guideline' );
+
+		foreach ( $legacy_posts as $source ) {
+			$term_slugs = wp_get_object_terms( $source->ID, 'wp_guideline_type', array( 'fields' => 'slugs' ) );
+			if ( is_wp_error( $term_slugs ) ) {
+				return $term_slugs;
+			}
+
+			if ( in_array( 'content', $term_slugs, true ) ) {
+				$content_posts[] = $source;
+				continue;
+			}
+
+			$migrated = self::migrate_ordinary_post( $source );
+			if ( is_wp_error( $migrated ) ) {
+				return $migrated;
+			}
+		}
+
+		foreach ( self::build_content_items( $content_posts ) as $item ) {
+			$migrated = self::migrate_content_item( $item );
+			if ( is_wp_error( $migrated ) ) {
+				return $migrated;
+			}
+		}
+
+		foreach ( $content_posts as $source ) {
+			if ( ! wp_trash_post( $source->ID ) instanceof \WP_Post ) {
+				return new \WP_Error( 'legacy_source_not_trashed', sprintf( 'Failed to trash legacy content guideline %d.', $source->ID ) );
+			}
+		}
+
+		if ( self::has_active_legacy_posts() ) {
+			return new \WP_Error( 'legacy_sources_remain', 'Active legacy guideline records remain after migration.' );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Migrate an ordinary guideline in place.
+	 *
+	 * @param \WP_Post $source Legacy post.
+	 * @return true|\WP_Error
+	 */
+	private static function migrate_ordinary_post( \WP_Post $source ) {
+		if ( self::find_knowledge_post( $source->post_name ) ) {
+			return wp_trash_post( $source->ID ) instanceof \WP_Post
+				? true
+				: new \WP_Error( 'legacy_source_not_trashed', sprintf( 'Failed to trash superseded legacy guideline %d.', $source->ID ) );
+		}
+
+		$terms = wp_get_object_terms( $source->ID, 'wp_guideline_type' );
+		if ( is_wp_error( $terms ) ) {
+			return $terms;
+		}
+		if ( ! is_array( $terms ) ) {
+			return new \WP_Error( 'legacy_terms_invalid', sprintf( 'Legacy guideline %d returned an invalid term result.', $source->ID ) );
+		}
+
+		$term_slugs = array();
+		foreach ( $terms as $term ) {
+			$ensured = self::ensure_knowledge_term( $term );
+			if ( is_wp_error( $ensured ) ) {
+				return $ensured;
+			}
+			$term_slugs[] = $term->slug;
+		}
+
+		$updated = wp_update_post(
+			array(
+				'ID'        => $source->ID,
+				'post_type' => 'wp_knowledge',
+			),
+			true
+		);
+		if ( is_wp_error( $updated ) ) {
+			return $updated;
+		}
+
+		$set_terms = wp_set_object_terms( $source->ID, $term_slugs, 'wp_knowledge_type' );
+		if ( is_wp_error( $set_terms ) ) {
+			return self::rollback_ordinary_post( $source->ID, $term_slugs, $set_terms );
+		}
+
+		$clear_terms = wp_set_object_terms( $source->ID, array(), 'wp_guideline_type' );
+		if ( is_wp_error( $clear_terms ) ) {
+			return self::rollback_ordinary_post( $source->ID, $term_slugs, $clear_terms );
+		}
+
+		$converted = get_post( $source->ID );
+		if ( ! $converted instanceof \WP_Post || 'wp_knowledge' !== $converted->post_type ) {
+			return self::rollback_ordinary_post(
+				$source->ID,
+				$term_slugs,
+				new \WP_Error( 'post_type_conversion_failed', 'Post type conversion did not persist.' )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Restore an ordinary legacy row after a partial conversion.
+	 *
+	 * @param int       $post_id    Post ID.
+	 * @param string[]  $term_slugs Legacy term slugs.
+	 * @param \WP_Error $error      Original error.
+	 * @return \WP_Error
+	 */
+	private static function rollback_ordinary_post( int $post_id, array $term_slugs, \WP_Error $error ): \WP_Error {
+		$rollback_errors = array();
+		$updated         = wp_update_post(
+			array(
+				'ID'        => $post_id,
+				'post_type' => 'wp_guideline',
+			),
+			true
+		);
+		if ( is_wp_error( $updated ) ) {
+			$rollback_errors[] = $updated->get_error_message();
+		}
+
+		$restored = wp_set_object_terms( $post_id, $term_slugs, 'wp_guideline_type' );
+		if ( is_wp_error( $restored ) ) {
+			$rollback_errors[] = $restored->get_error_message();
+		}
+
+		$cleared = wp_set_object_terms( $post_id, array(), 'wp_knowledge_type' );
+		if ( is_wp_error( $cleared ) ) {
+			$rollback_errors[] = $cleared->get_error_message();
+		}
+
+		$message = $error->get_error_message();
+		if ( ! empty( $rollback_errors ) ) {
+			$message .= ' Rollback also failed: ' . implode( '; ', $rollback_errors );
+		}
+
+		return new \WP_Error( $error->get_error_code(), $message );
+	}
+
+	/**
+	 * Create a scoped Knowledge row from legacy content-guideline metadata.
+	 *
+	 * @param array{slug:string,title:string,content:string,author:int} $item Content item.
+	 * @return true|\WP_Error
+	 */
+	private static function migrate_content_item( array $item ) {
+		if ( self::find_knowledge_post( $item['slug'] ) ) {
+			return true;
+		}
+
+		$post_id = wp_insert_post(
+			wp_slash(
+				array(
+					'post_type'    => 'wp_knowledge',
+					'post_status'  => 'publish',
+					'post_author'  => $item['author'],
+					'post_title'   => $item['title'],
+					'post_name'    => $item['slug'],
+					'post_content' => $item['content'],
+				)
+			),
+			true
+		);
+		if ( is_wp_error( $post_id ) ) {
+			return $post_id;
+		}
+
+		$term = term_exists( 'guideline', 'wp_knowledge_type' );
+		if ( ! $term ) {
+			$term = wp_insert_term( 'Guideline', 'wp_knowledge_type', array( 'slug' => 'guideline' ) );
+		}
+		if ( is_wp_error( $term ) ) {
+			wp_delete_post( $post_id, true );
+			return $term;
+		}
+
+		$set_terms = wp_set_object_terms( $post_id, 'guideline', 'wp_knowledge_type' );
+		if ( is_wp_error( $set_terms ) ) {
+			wp_delete_post( $post_id, true );
+			return $set_terms;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Expand content singleton metadata into scoped Knowledge items.
+	 *
+	 * Transitional wp_guideline content posts take precedence over the older
+	 * wp_content_guideline singleton when both contain the same scope.
+	 *
+	 * @param \WP_Post[] $posts Legacy content posts.
+	 * @return array<int, array{slug:string,title:string,content:string,author:int}>
+	 */
+	private static function build_content_items( array $posts ): array {
+		usort(
+			$posts,
+			static function ( \WP_Post $left, \WP_Post $right ): int {
+				if ( $left->post_type !== $right->post_type ) {
+					return 'wp_guideline' === $left->post_type ? -1 : 1;
+				}
+
+				return $right->ID <=> $left->ID;
+			}
+		);
+
+		$items = array();
+		foreach ( $posts as $post ) {
+			$prefix       = 'wp_guideline' === $post->post_type ? '_guideline_' : '_content_guideline_';
+			$block_prefix = $prefix . 'block_';
+			$meta         = get_post_meta( $post->ID );
+
+			foreach ( array( 'site', 'copy', 'images', 'additional' ) as $scope ) {
+				$key     = $prefix . $scope;
+				$content = isset( $meta[ $key ][0] ) ? self::decode_content_meta_value( $meta[ $key ][0] ) : '';
+				$slug    = 'guideline-' . $scope;
+				if ( '' !== trim( $content ) && ! isset( $items[ $slug ] ) ) {
+					$items[ $slug ] = array(
+						'slug'    => $slug,
+						'title'   => ucfirst( $scope ),
+						'content' => $content,
+						'author'  => (int) $post->post_author,
+					);
+				}
+			}
+
+			foreach ( $meta as $key => $values ) {
+				if ( ! str_starts_with( (string) $key, $block_prefix ) ) {
+					continue;
+				}
+
+				$content = isset( $values[0] ) ? self::decode_content_meta_value( $values[0] ) : '';
+				$block   = substr( (string) $key, strlen( $block_prefix ) );
+				$slug    = 'guideline-block-' . $block;
+				if ( '' !== trim( $content ) && '' !== $block && ! isset( $items[ $slug ] ) ) {
+					$items[ $slug ] = array(
+						'slug'    => $slug,
+						'title'   => str_replace( '_', '/', $block ),
+						'content' => $content,
+						'author'  => (int) $post->post_author,
+					);
+				}
+			}
+		}
+
+		return array_values( $items );
+	}
+
+	/**
+	 * Decode only the serialized-string wrapper WordPress may add to string meta.
+	 *
+	 * @param mixed $value Raw metadata value.
+	 * @return string
+	 */
+	private static function decode_content_meta_value( $value ): string {
+		if ( ! is_string( $value ) ) {
+			return '';
+		}
+
+		$trimmed = trim( $value );
+		if ( ! str_starts_with( $trimmed, 's:' ) || ! is_serialized( $trimmed ) ) {
+			return $value;
+		}
+
+		$decoded = unserialize( $trimmed, array( 'allowed_classes' => false ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.serialize_unserialize -- Only validated serialized strings are decoded and classes are disabled.
+		return is_string( $decoded ) ? $decoded : $value;
+	}
+
+	/**
+	 * Return active posts for one legacy type.
+	 *
+	 * @param string $post_type Post type.
+	 * @return \WP_Post[]
+	 */
+	private static function get_active_posts( string $post_type ): array {
+		return get_posts(
+			array(
+				'post_type'        => $post_type,
+				'post_status'      => self::ACTIVE_STATUSES,
+				'posts_per_page'   => -1,
+				'orderby'          => 'ID',
+				'order'            => 'ASC',
+				'suppress_filters' => false,
+			)
+		);
+	}
+
+	/**
+	 * Find an active Knowledge post by exact slug.
+	 *
+	 * @param string $slug Post slug.
+	 * @return \WP_Post|null
+	 */
+	private static function find_knowledge_post( string $slug ): ?\WP_Post {
+		$posts = get_posts(
+			array(
+				'name'           => $slug,
+				'post_type'      => 'wp_knowledge',
+				'post_status'    => self::ACTIVE_STATUSES,
+				'posts_per_page' => 1,
+			)
+		);
+
+		return ! empty( $posts ) ? $posts[0] : null;
+	}
+
+	/**
+	 * Ensure a legacy type term exists in the Knowledge taxonomy.
+	 *
+	 * @param \WP_Term $source Legacy term.
+	 * @return true|\WP_Error
+	 */
+	private static function ensure_knowledge_term( \WP_Term $source ) {
+		if ( term_exists( $source->slug, 'wp_knowledge_type' ) ) {
+			return true;
+		}
+
+		$created = wp_insert_term(
+			$source->name,
+			'wp_knowledge_type',
+			array(
+				'slug'        => $source->slug,
+				'description' => $source->description,
+			)
+		);
+
+		return is_wp_error( $created ) ? $created : true;
+	}
+
+	/**
+	 * Whether active legacy records remain.
+	 */
+	private static function has_active_legacy_posts(): bool {
+		foreach ( array( 'wp_guideline', 'wp_content_guideline' ) as $post_type ) {
+			$posts = get_posts(
+				array(
+					'post_type'      => $post_type,
+					'post_status'    => self::ACTIVE_STATUSES,
+					'posts_per_page' => 1,
+					'fields'         => 'ids',
+				)
+			);
+			if ( ! empty( $posts ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Read and normalize the migration state option.
+	 *
+	 * @return array<string, int|string>
+	 */
+	private static function get_state(): array {
+		return self::sanitize_state( get_option( self::OPTION_NAME, self::default_state() ) );
+	}
+
+	/**
+	 * Return the initial migration state.
+	 *
+	 * @return array<string, int|string>
+	 */
+	private static function default_state(): array {
+		return array(
+			'version'      => 0,
+			'status'       => 'not_started',
+			'started_at'   => 0,
+			'completed_at' => 0,
+			'last_error'   => '',
+		);
+	}
+
+	/**
+	 * Whether the current migration version is complete.
+	 *
+	 * @param array<string, int|string> $state Migration state.
+	 */
+	private static function is_complete( array $state ): bool {
+		return 'complete' === $state['status'] && (int) $state['version'] >= self::MIGRATION_VERSION;
+	}
+
+	/**
+	 * Persist a migration state transition.
+	 *
+	 * @param string $status Migration status.
+	 * @param string $error  Optional error message.
+	 */
+	private static function update_state( string $status, string $error = '' ): void {
+		$previous = self::get_state();
+		$now      = time();
+		$state    = array(
+			'version'      => self::MIGRATION_VERSION,
+			'status'       => $status,
+			'started_at'   => (int) $previous['started_at'],
+			'completed_at' => 0,
+			'last_error'   => $error,
+		);
+
+		if ( 'scheduled' === $status && (int) $previous['version'] !== self::MIGRATION_VERSION ) {
+			$state['started_at'] = 0;
+		}
+
+		if ( 'started' === $status ) {
+			$state['started_at'] = $now;
+		}
+
+		if ( 'complete' === $status ) {
+			$state['completed_at'] = $now;
+		}
+
+		update_option( self::OPTION_NAME, $state, true );
+	}
+
+	/**
+	 * Schedule a retry after a failed or overlapping run.
+	 */
+	private static function schedule_retry(): void {
+		if ( wp_next_scheduled( self::CRON_HOOK ) ) {
+			return;
+		}
+
+		wp_schedule_single_event( time() + self::RETRY_DELAY, self::CRON_HOOK );
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/knowledge-migration/class-legacy-guideline-rest-controller.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/knowledge-migration/class-legacy-guideline-rest-controller.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * REST controller for temporary legacy guideline post types.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+/**
+ * Restrict legacy guideline REST access to site administrators.
+ */
+class Legacy_Guideline_REST_Controller extends \WP_REST_Posts_Controller {
+	/**
+	 * Check whether the current user can inspect legacy guidelines.
+	 *
+	 * @return true|\WP_Error
+	 */
+	private function check_access() {
+		if ( current_user_can( 'manage_options' ) ) {
+			return true;
+		}
+
+		return new \WP_Error(
+			'rest_cannot_read_legacy_guidelines',
+			__( 'Sorry, you are not allowed to view legacy guidelines.', 'jetpack-mu-wpcom' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
+	}
+
+	/**
+	 * Check collection read access.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return true|\WP_Error
+	 */
+	public function get_items_permissions_check( $request ) {
+		$access = $this->check_access();
+		return is_wp_error( $access ) ? $access : parent::get_items_permissions_check( $request );
+	}
+
+	/**
+	 * Check single-item read access.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return true|\WP_Error
+	 */
+	public function get_item_permissions_check( $request ) {
+		$access = $this->check_access();
+		return is_wp_error( $access ) ? $access : parent::get_item_permissions_check( $request );
+	}
+
+	/**
+	 * Check create access.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return true|\WP_Error
+	 */
+	public function create_item_permissions_check( $request ) {
+		$access = $this->check_access();
+		return is_wp_error( $access ) ? $access : parent::create_item_permissions_check( $request );
+	}
+
+	/**
+	 * Check update access.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return true|\WP_Error
+	 */
+	public function update_item_permissions_check( $request ) {
+		$access = $this->check_access();
+		return is_wp_error( $access ) ? $access : parent::update_item_permissions_check( $request );
+	}
+
+	/**
+	 * Check delete access.
+	 *
+	 * @param \WP_REST_Request $request Request object.
+	 * @return true|\WP_Error
+	 */
+	public function delete_item_permissions_check( $request ) {
+		$access = $this->check_access();
+		return is_wp_error( $access ) ? $access : parent::delete_item_permissions_check( $request );
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/knowledge-migration/knowledge-migration.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/knowledge-migration/knowledge-migration.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Bootstrap the legacy guideline compatibility and Knowledge migration feature.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+namespace Automattic\Jetpack\Jetpack_Mu_Wpcom;
+
+require_once __DIR__ . '/class-legacy-guideline-rest-controller.php';
+require_once __DIR__ . '/class-knowledge-migration.php';
+
+Knowledge_Migration::init();

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/knowledge-migration/Knowledge_Migration_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/knowledge-migration/Knowledge_Migration_Test.php
@@ -1,0 +1,667 @@
+<?php
+/**
+ * Tests for the legacy guideline to Knowledge migration.
+ *
+ * @package automattic/jetpack-mu-wpcom
+ */
+
+use Automattic\Jetpack\Jetpack_Mu_Wpcom;
+use Automattic\Jetpack\Jetpack_Mu_Wpcom\Knowledge_Migration;
+
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/knowledge-migration/class-legacy-guideline-rest-controller.php';
+require_once Jetpack_Mu_Wpcom::PKG_DIR . 'src/features/knowledge-migration/class-knowledge-migration.php';
+
+/**
+ * Test the local Knowledge migration lifecycle.
+ */
+class Knowledge_Migration_Test extends \WorDBless\BaseTestCase {
+	/**
+	 * Migration state observed while a Knowledge post was being saved.
+	 *
+	 * @var array<string, int|string>|null
+	 */
+	private $state_during_save;
+
+	/**
+	 * Post IDs visible to the WorDBless WP_Query shim.
+	 *
+	 * @var int[]
+	 */
+	private $post_ids = array();
+
+	/**
+	 * Term slugs assigned to tracked posts, keyed by post ID and taxonomy.
+	 *
+	 * @var array<int, array<string, string[]>>
+	 */
+	private $object_terms = array();
+
+	/**
+	 * Post metadata visible to the WorDBless metadata shim.
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	private $post_meta = array();
+
+	/**
+	 * Prepare isolated storage registrations and state.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->unregister_storage();
+		delete_option( Knowledge_Migration::OPTION_NAME );
+		delete_transient( 'jetpack_mu_wpcom_knowledge_migration_lock' );
+		wp_clear_scheduled_hook( Knowledge_Migration::CRON_HOOK );
+		wp_set_current_user( 0 );
+		$this->state_during_save = null;
+		$this->post_ids          = array();
+		$this->object_terms      = array();
+		$this->post_meta         = array();
+		add_action( 'wp_after_insert_post', array( $this, 'track_post' ), 10, 1 );
+		add_action( 'added_post_meta', array( $this, 'track_post_meta' ), 10, 4 );
+		add_action( 'updated_post_meta', array( $this, 'track_post_meta' ), 10, 4 );
+		add_filter( 'posts_pre_query', array( $this, 'filter_posts_query' ), 10, 2 );
+		add_filter( 'get_object_terms', array( $this, 'filter_object_terms' ), 999, 4 );
+		add_filter( 'wp_get_object_terms', array( $this, 'filter_wp_get_object_terms' ), 999, 4 );
+		add_filter( 'get_post_metadata', array( $this, 'filter_post_metadata' ), 10, 5 );
+
+		Knowledge_Migration::register_legacy_storage();
+		$this->register_knowledge_storage();
+
+		if ( ! isset( get_registered_settings()[ Knowledge_Migration::OPTION_NAME ] ) ) {
+			Knowledge_Migration::register_migration_setting();
+		}
+	}
+
+	/**
+	 * Remove global registrations and scheduled work.
+	 */
+	public function tear_down() {
+		remove_action( 'save_post_wp_knowledge', array( $this, 'capture_migration_state' ) );
+		remove_action( 'wp_after_insert_post', array( $this, 'track_post' ), 10 );
+		remove_action( 'added_post_meta', array( $this, 'track_post_meta' ), 10 );
+		remove_action( 'updated_post_meta', array( $this, 'track_post_meta' ), 10 );
+		remove_filter( 'posts_pre_query', array( $this, 'filter_posts_query' ), 10 );
+		remove_filter( 'get_object_terms', array( $this, 'filter_object_terms' ), 999 );
+		remove_filter( 'wp_get_object_terms', array( $this, 'filter_wp_get_object_terms' ), 999 );
+		remove_filter( 'get_post_metadata', array( $this, 'filter_post_metadata' ), 10 );
+		delete_option( Knowledge_Migration::OPTION_NAME );
+		delete_transient( 'jetpack_mu_wpcom_knowledge_migration_lock' );
+		wp_clear_scheduled_hook( Knowledge_Migration::CRON_HOOK );
+		wp_set_current_user( 0 );
+		$this->unregister_storage();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Legacy storage stays registered after migration completion.
+	 */
+	public function test_legacy_storage_registration_is_independent_of_migration_state() {
+		update_option( Knowledge_Migration::OPTION_NAME, $this->state( 'complete' ) );
+		$this->unregister_legacy_storage();
+
+		Knowledge_Migration::register_legacy_storage();
+
+		$guideline = get_post_type_object( 'wp_guideline' );
+		$content   = get_post_type_object( 'wp_content_guideline' );
+		$taxonomy  = get_taxonomy( 'wp_guideline_type' );
+
+		$this->assertNotNull( $guideline );
+		$this->assertTrue( $guideline->show_in_rest );
+		$this->assertSame( 'guidelines', $guideline->rest_base );
+		$this->assertNotNull( $content );
+		$this->assertTrue( $content->show_in_rest );
+		$this->assertSame( 'content-guidelines', $content->rest_base );
+		$this->assertNotNull( $taxonomy );
+		$this->assertTrue( $taxonomy->show_in_rest );
+		$this->assertSame( 'wp_guideline_type', $taxonomy->rest_base );
+	}
+
+	/**
+	 * Legacy post contents require administrator authentication over REST.
+	 */
+	public function test_legacy_rest_collection_requires_an_administrator() {
+		$post_id = wp_insert_post(
+			array(
+				'post_type'    => 'wp_guideline',
+				'post_status'  => 'publish',
+				'post_title'   => 'Private legacy guideline',
+				'post_content' => 'Private content',
+			)
+		);
+		$this->assertIsInt( $post_id );
+
+		do_action( 'rest_api_init' );
+		$request = new WP_REST_Request( 'GET', '/wp/v2/guidelines' );
+		$request->set_param( 'context', 'edit' );
+		$anonymous = rest_do_request( $request );
+		$this->assertSame( 401, $anonymous->get_status() );
+
+		wp_set_current_user( $this->create_administrator() );
+		$authorized = rest_do_request( $request );
+		$this->assertSame( 200, $authorized->get_status() );
+		$this->assertNotEmpty( $authorized->get_data() );
+		$this->assertSame( $post_id, $authorized->get_data()[0]['id'] );
+	}
+
+	/**
+	 * Migration state is readable and writable through core REST settings.
+	 */
+	public function test_migration_state_is_writable_through_rest_settings() {
+		do_action( 'rest_api_init' );
+		wp_set_current_user( $this->create_administrator() );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/settings' );
+		$request->set_body_params(
+			array(
+				Knowledge_Migration::OPTION_NAME => array(
+					'version'      => 4,
+					'status'       => 'started',
+					'started_at'   => 123,
+					'completed_at' => 0,
+					'last_error'   => '',
+				),
+			)
+		);
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( 4, $response->get_data()[ Knowledge_Migration::OPTION_NAME ]['version'] );
+		$this->assertSame( 'started', get_option( Knowledge_Migration::OPTION_NAME )['status'] );
+	}
+
+	/**
+	 * An incomplete version schedules exactly one randomized cron event.
+	 */
+	public function test_incomplete_migration_schedules_only_one_event() {
+		Knowledge_Migration::maybe_schedule_migration();
+
+		$first = wp_next_scheduled( Knowledge_Migration::CRON_HOOK );
+		$this->assertIsInt( $first );
+		$this->assertSame( 'scheduled', get_option( Knowledge_Migration::OPTION_NAME )['status'] );
+		$this->assertSame( Knowledge_Migration::MIGRATION_VERSION, get_option( Knowledge_Migration::OPTION_NAME )['version'] );
+
+		Knowledge_Migration::maybe_schedule_migration();
+		$this->assertSame( $first, wp_next_scheduled( Knowledge_Migration::CRON_HOOK ) );
+	}
+
+	/**
+	 * A completed current version does not schedule another pass.
+	 */
+	public function test_completed_migration_does_not_schedule_event() {
+		update_option( Knowledge_Migration::OPTION_NAME, $this->state( 'complete' ) );
+
+		Knowledge_Migration::maybe_schedule_migration();
+
+		$this->assertFalse( wp_next_scheduled( Knowledge_Migration::CRON_HOOK ) );
+	}
+
+	/**
+	 * Sites without legacy records are marked as checked and complete.
+	 */
+	public function test_empty_site_is_marked_complete() {
+		Knowledge_Migration::run_migration();
+
+		$state = get_option( Knowledge_Migration::OPTION_NAME );
+		$this->assertSame( 'complete', $state['status'] );
+		$this->assertSame( Knowledge_Migration::MIGRATION_VERSION, $state['version'] );
+		$this->assertGreaterThan( 0, $state['started_at'] );
+		$this->assertGreaterThan( 0, $state['completed_at'] );
+		$this->assertSame( '', $state['last_error'] );
+	}
+
+	/**
+	 * Ordinary guidelines retain their ID and receive equivalent Knowledge terms.
+	 */
+	public function test_ordinary_guideline_is_converted_in_place() {
+		$term = wp_insert_term( 'Instruction', 'wp_guideline_type', array( 'slug' => 'instruction' ) );
+		$this->assertIsArray( $term );
+		$post_id   = wp_insert_post(
+			array(
+				'post_type'    => 'wp_guideline',
+				'post_status'  => 'private',
+				'post_name'    => 'legacy-instruction',
+				'post_title'   => 'Legacy instruction',
+				'post_content' => 'Keep this content.',
+			)
+		);
+		$set_terms = wp_set_object_terms( $post_id, 'instruction', 'wp_guideline_type' );
+		$this->assertFalse( is_wp_error( $set_terms ) );
+		$this->object_terms[ $post_id ]['wp_guideline_type'] = array( 'instruction' );
+		add_action( 'save_post_wp_knowledge', array( $this, 'capture_migration_state' ) );
+		$this->assertSame( 'private', get_post_status( $post_id ) );
+
+		Knowledge_Migration::run_migration();
+
+		$state = get_option( Knowledge_Migration::OPTION_NAME );
+		$this->assertSame( 'complete', $state['status'], $state['last_error'] );
+		$converted = get_post( $post_id );
+		$this->assertSame( 'wp_knowledge', $converted->post_type );
+		$this->assertSame( 'Keep this content.', $converted->post_content );
+		$this->assertNotFalse( term_exists( 'instruction', 'wp_knowledge_type' ) );
+		$this->assertSame( 'started', $this->state_during_save['status'] ?? null );
+		$this->assertSame( 'complete', get_option( Knowledge_Migration::OPTION_NAME )['status'] );
+	}
+
+	/**
+	 * An existing Knowledge slug wins and the superseded legacy row is retired.
+	 */
+	public function test_existing_knowledge_slug_retires_legacy_guideline() {
+		$destination_id = wp_insert_post(
+			array(
+				'post_type'    => 'wp_knowledge',
+				'post_status'  => 'publish',
+				'post_name'    => 'same-slug',
+				'post_content' => 'Current content.',
+			)
+		);
+		$source_id      = wp_insert_post(
+			array(
+				'post_type'    => 'wp_guideline',
+				'post_status'  => 'publish',
+				'post_name'    => 'same-slug',
+				'post_content' => 'Legacy content.',
+			)
+		);
+
+		Knowledge_Migration::run_migration();
+
+		$state = get_option( Knowledge_Migration::OPTION_NAME );
+		$this->assertSame( 'complete', $state['status'], $state['last_error'] );
+		$this->assertSame( 'trash', get_post_status( $source_id ) );
+		$this->assertSame( 'Current content.', get_post( $destination_id )->post_content );
+		$this->assertCount( 1, $this->get_knowledge_posts() );
+	}
+
+	/**
+	 * Content singleton formats expand into scoped rows before sources are retired.
+	 */
+	public function test_content_guidelines_expand_with_transitional_format_precedence() {
+		$old_id = wp_insert_post(
+			array(
+				'post_type'   => 'wp_content_guideline',
+				'post_status' => 'publish',
+				'post_author' => 12,
+			)
+		);
+		update_post_meta( $old_id, '_content_guideline_site', 'Old site guidance.' );
+		update_post_meta( $old_id, '_content_guideline_block_core_paragraph', 'Paragraph guidance.' );
+
+		$content_term = wp_insert_term( 'Content', 'wp_guideline_type', array( 'slug' => 'content' ) );
+		$this->assertIsArray( $content_term );
+		$new_id    = wp_insert_post(
+			array(
+				'post_type'   => 'wp_guideline',
+				'post_status' => 'private',
+				'post_author' => 34,
+				'post_title'  => 'Transitional content guidelines',
+			)
+		);
+		$set_terms = wp_set_object_terms( $new_id, 'content', 'wp_guideline_type' );
+		$this->assertFalse( is_wp_error( $set_terms ) );
+		$this->object_terms[ $new_id ]['wp_guideline_type'] = array( 'content' );
+		update_post_meta( $new_id, '_guideline_site', 'New site guidance.' );
+		$this->assertSame( array( 'content' ), wp_get_object_terms( $new_id, 'wp_guideline_type', array( 'fields' => 'slugs' ) ) );
+
+		Knowledge_Migration::run_migration();
+
+		$state = get_option( Knowledge_Migration::OPTION_NAME );
+		$this->assertSame( 'complete', $state['status'], $state['last_error'] );
+		$site  = $this->find_knowledge_post( 'guideline-site' );
+		$block = $this->find_knowledge_post( 'guideline-block-core_paragraph' );
+		$this->assertNotNull( $site );
+		$this->assertSame( 'New site guidance.', $site->post_content );
+		$this->assertSame( 34, (int) $site->post_author );
+		$this->assertNotNull( $block );
+		$this->assertSame( 'Paragraph guidance.', $block->post_content );
+		$this->assertSame( 'core/paragraph', $block->post_title );
+		$this->assertNotFalse( term_exists( 'guideline', 'wp_knowledge_type' ) );
+		$this->assertSame( 'trash', get_post_status( $old_id ) );
+		$this->assertSame( 'trash', get_post_status( $new_id ) );
+
+		$count = count( $this->get_knowledge_posts() );
+		update_option( Knowledge_Migration::OPTION_NAME, $this->state( 'not_started', 0 ) );
+		Knowledge_Migration::run_migration();
+		$this->assertCount( $count, $this->get_knowledge_posts() );
+	}
+
+	/**
+	 * A missing destination leaves an observable error and schedules a retry.
+	 */
+	public function test_missing_knowledge_storage_records_error_and_retry() {
+		unregister_post_type( 'wp_knowledge' );
+		unregister_taxonomy( 'wp_knowledge_type' );
+
+		Knowledge_Migration::run_migration();
+
+		$state = get_option( Knowledge_Migration::OPTION_NAME );
+		$this->assertSame( 'error', $state['status'] );
+		$this->assertStringContainsString( 'Knowledge storage is not registered', $state['last_error'] );
+		$this->assertIsInt( wp_next_scheduled( Knowledge_Migration::CRON_HOOK ) );
+	}
+
+	/**
+	 * Capture the migration state from inside a Knowledge save callback.
+	 */
+	public function capture_migration_state(): void {
+		$this->state_during_save = get_option( Knowledge_Migration::OPTION_NAME );
+	}
+
+	/**
+	 * Track posts created by both the test and the migrator.
+	 *
+	 * @param int $post_id Inserted post ID.
+	 */
+	public function track_post( int $post_id ): void {
+		if ( ! in_array( $post_id, $this->post_ids, true ) ) {
+			$this->post_ids[] = $post_id;
+		}
+	}
+
+	/**
+	 * Supply post queries from tracked objects because WorDBless does not run WP_Query.
+	 *
+	 * @param WP_Post[]|int[]|null $posts Existing short-circuit value.
+	 * @param WP_Query             $query Query object.
+	 * @return WP_Post[]|int[]|null
+	 */
+	public function filter_posts_query( $posts, WP_Query $query ) {
+		$post_types  = (array) $query->get( 'post_type' );
+		$known_types = array( 'wp_guideline', 'wp_content_guideline', 'wp_knowledge' );
+		if ( empty( array_intersect( $post_types, $known_types ) ) ) {
+			return $posts;
+		}
+
+		$statuses = (array) $query->get( 'post_status' );
+		if ( empty( $statuses ) ) {
+			$statuses = array( 'publish' );
+		}
+		$name    = (string) $query->get( 'name' );
+		$matches = array();
+		foreach ( $this->post_ids as $post_id ) {
+			$post = get_post( $post_id );
+			if ( ! $post instanceof WP_Post || ! in_array( $post->post_type, $post_types, true ) ) {
+				continue;
+			}
+			if ( ! in_array( 'any', $statuses, true ) && ! in_array( $post->post_status, $statuses, true ) ) {
+				continue;
+			}
+			if ( '' !== $name && $post->post_name !== $name ) {
+				continue;
+			}
+
+			$matches[] = $post;
+		}
+
+		usort(
+			$matches,
+			static function ( WP_Post $left, WP_Post $right ): int {
+				return $left->ID <=> $right->ID;
+			}
+		);
+
+		$limit = (int) $query->get( 'posts_per_page' );
+		if ( $limit > 0 ) {
+			$matches = array_slice( $matches, 0, $limit );
+		}
+
+		$query->found_posts   = count( $matches );
+		$query->max_num_pages = 1;
+		if ( 'ids' === $query->get( 'fields' ) ) {
+			return array_map(
+				static function ( WP_Post $post ): int {
+					return $post->ID;
+				},
+				$matches
+			);
+		}
+
+		return $matches;
+	}
+
+	/**
+	 * Supply object terms from tracked assignments.
+	 *
+	 * @param mixed    $terms       Terms returned by WorDBless.
+	 * @param int[]    $object_ids  Object IDs.
+	 * @param string[] $taxonomies  Taxonomies.
+	 * @param array    $args        Query arguments.
+	 * @return mixed
+	 */
+	public function filter_object_terms( $terms, array $object_ids, array $taxonomies, array $args ) {
+		$slugs = array();
+		foreach ( $object_ids as $object_id ) {
+			foreach ( $taxonomies as $taxonomy ) {
+				$slugs = array_merge( $slugs, $this->object_terms[ $object_id ][ $taxonomy ] ?? array() );
+			}
+		}
+
+		if ( 'slugs' === ( $args['fields'] ?? 'all' ) ) {
+			return $slugs;
+		}
+
+		$objects = array();
+		foreach ( $object_ids as $object_id ) {
+			foreach ( $taxonomies as $taxonomy ) {
+				foreach ( $this->object_terms[ $object_id ][ $taxonomy ] ?? array() as $slug ) {
+					$term = get_term_by( 'slug', $slug, $taxonomy );
+					if ( ! $term instanceof WP_Term ) {
+						$term_id = abs( crc32( $taxonomy . ':' . $slug ) );
+						$term    = new WP_Term(
+							(object) array(
+								'term_id'          => $term_id,
+								'name'             => ucfirst( $slug ),
+								'slug'             => $slug,
+								'term_group'       => 0,
+								'term_taxonomy_id' => $term_id,
+								'taxonomy'         => $taxonomy,
+								'description'      => '',
+								'parent'           => 0,
+								'count'            => 1,
+								'filter'           => 'raw',
+							)
+						);
+					}
+					$objects[] = $term;
+				}
+			}
+		}
+
+		switch ( $args['fields'] ?? 'all' ) {
+			case 'ids':
+			case 'tt_ids':
+				return array_map(
+					static function ( WP_Term $term ): int {
+						return $term->term_id;
+					},
+					$objects
+				);
+			case 'names':
+				return array_map(
+					static function ( WP_Term $term ): string {
+						return $term->name;
+					},
+					$objects
+				);
+			default:
+				return $objects;
+		}
+	}
+
+	/**
+	 * Restore tracked slugs after WorDBless applies its final taxonomy shim.
+	 *
+	 * @param mixed  $terms       Terms returned by WorDBless.
+	 * @param string $object_ids  Comma-separated object IDs.
+	 * @param string $taxonomies  SQL-formatted taxonomy names.
+	 * @param array  $args        Query arguments.
+	 * @return mixed
+	 */
+	public function filter_wp_get_object_terms( $terms, string $object_ids, string $taxonomies, array $args ) {
+		if ( 'slugs' !== ( $args['fields'] ?? 'all' ) ) {
+			return $terms;
+		}
+
+		$slugs = array();
+		foreach ( array_map( 'intval', explode( ',', $object_ids ) ) as $object_id ) {
+			foreach ( $this->object_terms[ $object_id ] ?? array() as $assigned_slugs ) {
+				$slugs = array_merge( $slugs, $assigned_slugs );
+			}
+		}
+
+		return ! empty( $slugs ) ? $slugs : $terms;
+	}
+
+	/**
+	 * Track added and updated post metadata.
+	 *
+	 * @param int    $meta_id    Metadata ID.
+	 * @param int    $object_id  Post ID.
+	 * @param string $meta_key   Metadata key.
+	 * @param mixed  $meta_value Metadata value.
+	 */
+	public function track_post_meta( int $meta_id, int $object_id, string $meta_key, $meta_value ): void {
+		unset( $meta_id );
+		$this->post_meta[ $object_id ][ $meta_key ] = $meta_value;
+	}
+
+	/**
+	 * Supply tracked metadata because WorDBless does not populate meta queries.
+	 *
+	 * @param mixed  $value     Existing short-circuit value.
+	 * @param int    $object_id Post ID.
+	 * @param string $meta_key  Metadata key.
+	 * @param bool   $single    Whether one value was requested.
+	 * @param string $meta_type Metadata type.
+	 * @return mixed
+	 */
+	public function filter_post_metadata( $value, int $object_id, string $meta_key, bool $single, string $meta_type ) {
+		if ( 'post' !== $meta_type || ! isset( $this->post_meta[ $object_id ] ) ) {
+			return $value;
+		}
+
+		if ( '' === $meta_key ) {
+			return array_map(
+				static function ( $meta_value ): array {
+					return array( $meta_value );
+				},
+				$this->post_meta[ $object_id ]
+			);
+		}
+
+		if ( ! array_key_exists( $meta_key, $this->post_meta[ $object_id ] ) ) {
+			return $single ? '' : array();
+		}
+
+		return $single
+			? $this->post_meta[ $object_id ][ $meta_key ]
+			: array( $this->post_meta[ $object_id ][ $meta_key ] );
+	}
+
+	/**
+	 * Register a minimal destination matching Gutenberg's public storage shape.
+	 */
+	private function register_knowledge_storage(): void {
+		register_post_type(
+			'wp_knowledge', // phpcs:ignore WordPress.NamingConventions.ValidPostTypeSlug.ReservedPrefix -- Mirrors the Gutenberg destination post type.
+			array(
+				'public'   => false,
+				'supports' => array( 'title', 'editor', 'author' ),
+			)
+		);
+		register_taxonomy( 'wp_knowledge_type', 'wp_knowledge', array( 'public' => false ) );
+	}
+
+	/**
+	 * Create an administrator and return its ID.
+	 */
+	private function create_administrator(): int {
+		return wp_insert_user(
+			array(
+				'user_login' => 'knowledge_migration_admin_' . wp_rand(),
+				'user_pass'  => 'password',
+				'user_email' => 'knowledge-migration-' . wp_rand() . '@example.com',
+				'role'       => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Build a state option for a test.
+	 *
+	 * @param string $status  State status.
+	 * @param int    $version State version.
+	 * @return array<string, int|string>
+	 */
+	private function state( string $status, int $version = Knowledge_Migration::MIGRATION_VERSION ): array {
+		return array(
+			'version'      => $version,
+			'status'       => $status,
+			'started_at'   => 100,
+			'completed_at' => 'complete' === $status ? 200 : 0,
+			'last_error'   => '',
+		);
+	}
+
+	/**
+	 * Return all active Knowledge rows.
+	 *
+	 * @return WP_Post[]
+	 */
+	private function get_knowledge_posts(): array {
+		return get_posts(
+			array(
+				'post_type'      => 'wp_knowledge',
+				'post_status'    => array( 'publish', 'private', 'draft', 'pending', 'future' ),
+				'posts_per_page' => -1,
+			)
+		);
+	}
+
+	/**
+	 * Find an active Knowledge row by slug.
+	 *
+	 * @param string $slug Post slug.
+	 */
+	private function find_knowledge_post( string $slug ): ?WP_Post {
+		$posts = get_posts(
+			array(
+				'post_type'      => 'wp_knowledge',
+				'post_status'    => array( 'publish', 'private', 'draft', 'pending', 'future' ),
+				'name'           => $slug,
+				'posts_per_page' => 1,
+			)
+		);
+
+		return ! empty( $posts ) ? $posts[0] : null;
+	}
+
+	/**
+	 * Unregister all post types and taxonomies used by the feature tests.
+	 */
+	private function unregister_storage(): void {
+		$this->unregister_legacy_storage();
+		if ( post_type_exists( 'wp_knowledge' ) ) {
+			unregister_post_type( 'wp_knowledge' );
+		}
+		if ( taxonomy_exists( 'wp_knowledge_type' ) ) {
+			unregister_taxonomy( 'wp_knowledge_type' );
+		}
+	}
+
+	/**
+	 * Unregister only the compatibility storage.
+	 */
+	private function unregister_legacy_storage(): void {
+		foreach ( array( 'wp_guideline', 'wp_content_guideline' ) as $post_type ) {
+			if ( post_type_exists( $post_type ) ) {
+				unregister_post_type( $post_type );
+			}
+		}
+		if ( taxonomy_exists( 'wp_guideline_type' ) ) {
+			unregister_taxonomy( 'wp_guideline_type' );
+		}
+	}
+}

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/knowledge-migration/Knowledge_Migration_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/knowledge-migration/Knowledge_Migration_Test.php
@@ -44,6 +44,17 @@ class Knowledge_Migration_Test extends \WorDBless\BaseTestCase {
 	private $post_meta = array();
 
 	/**
+	 * Term slugs assigned during the test, keyed by post ID and taxonomy.
+	 *
+	 * WorDBless does not back term lookups — `wp_insert_term()` succeeds but
+	 * `term_exists()` and `get_term_by()` return null — so assignments are
+	 * recorded from the `set_object_terms` action instead.
+	 *
+	 * @var array<int, array<string, string[]>>
+	 */
+	private $assigned_terms = array();
+
+	/**
 	 * Prepare isolated storage registrations and state.
 	 */
 	public function set_up() {
@@ -58,6 +69,8 @@ class Knowledge_Migration_Test extends \WorDBless\BaseTestCase {
 		$this->post_ids          = array();
 		$this->object_terms      = array();
 		$this->post_meta         = array();
+		$this->assigned_terms    = array();
+		add_action( 'set_object_terms', array( $this, 'track_object_terms' ), 10, 4 );
 		add_action( 'wp_after_insert_post', array( $this, 'track_post' ), 10, 1 );
 		add_action( 'added_post_meta', array( $this, 'track_post_meta' ), 10, 4 );
 		add_action( 'updated_post_meta', array( $this, 'track_post_meta' ), 10, 4 );
@@ -79,6 +92,7 @@ class Knowledge_Migration_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function tear_down() {
 		remove_action( 'save_post_wp_knowledge', array( $this, 'capture_migration_state' ) );
+		remove_action( 'set_object_terms', array( $this, 'track_object_terms' ), 10 );
 		remove_action( 'wp_after_insert_post', array( $this, 'track_post' ), 10 );
 		remove_action( 'added_post_meta', array( $this, 'track_post_meta' ), 10 );
 		remove_action( 'updated_post_meta', array( $this, 'track_post_meta' ), 10 );
@@ -252,7 +266,7 @@ class Knowledge_Migration_Test extends \WorDBless\BaseTestCase {
 		$converted = get_post( $post_id );
 		$this->assertSame( 'wp_knowledge', $converted->post_type );
 		$this->assertSame( 'Keep this content.', $converted->post_content );
-		$this->assertNotFalse( term_exists( 'instruction', 'wp_knowledge_type' ) );
+		$this->assertSame( array( 'instruction' ), $this->assigned_terms( $post_id, 'wp_knowledge_type' ) );
 		$this->assertSame( 'started', $this->state_during_save['status'] ?? null );
 		$this->assertSame( 'complete', get_option( Knowledge_Migration::OPTION_NAME )['status'] );
 	}
@@ -285,6 +299,76 @@ class Knowledge_Migration_Test extends \WorDBless\BaseTestCase {
 		$this->assertSame( 'trash', get_post_status( $source_id ) );
 		$this->assertSame( 'Current content.', get_post( $destination_id )->post_content );
 		$this->assertCount( 1, $this->get_knowledge_posts() );
+	}
+
+	/**
+	 * A guideline with no slug is converted instead of being treated as superseded.
+	 *
+	 * Drafts and pending posts are allowed to have an empty slug, and an empty
+	 * slug must not match an unrelated Knowledge post.
+	 */
+	public function test_guideline_without_slug_is_converted_not_retired() {
+		$unrelated_id = wp_insert_post(
+			array(
+				'post_type'    => 'wp_knowledge',
+				'post_status'  => 'publish',
+				'post_name'    => 'unrelated-knowledge',
+				'post_content' => 'Unrelated content.',
+			)
+		);
+		$draft_id     = wp_insert_post(
+			array(
+				'post_type'    => 'wp_guideline',
+				'post_status'  => 'draft',
+				'post_title'   => 'Unfinished guideline',
+				'post_content' => 'Keep this draft.',
+			)
+		);
+		$this->assertSame( '', get_post( $draft_id )->post_name );
+
+		Knowledge_Migration::run_migration();
+
+		$state = get_option( Knowledge_Migration::OPTION_NAME );
+		$this->assertSame( 'complete', $state['status'], $state['last_error'] );
+		$converted = get_post( $draft_id );
+		$this->assertSame( 'wp_knowledge', $converted->post_type );
+		$this->assertSame( 'draft', $converted->post_status );
+		$this->assertSame( 'Keep this draft.', $converted->post_content );
+		$this->assertSame( 'Unrelated content.', get_post( $unrelated_id )->post_content );
+	}
+
+	/**
+	 * Every slugless guideline is converted, not only the first one.
+	 *
+	 * Once the first one becomes a Knowledge post it must not be mistaken for
+	 * the destination of the ones that follow.
+	 */
+	public function test_all_guidelines_without_slugs_are_converted() {
+		$draft_id   = wp_insert_post(
+			array(
+				'post_type'    => 'wp_guideline',
+				'post_status'  => 'draft',
+				'post_title'   => 'First guideline',
+				'post_content' => 'First content.',
+			)
+		);
+		$pending_id = wp_insert_post(
+			array(
+				'post_type'    => 'wp_guideline',
+				'post_status'  => 'pending',
+				'post_title'   => 'Second guideline',
+				'post_content' => 'Second content.',
+			)
+		);
+
+		Knowledge_Migration::run_migration();
+
+		$state = get_option( Knowledge_Migration::OPTION_NAME );
+		$this->assertSame( 'complete', $state['status'], $state['last_error'] );
+		$this->assertSame( 'wp_knowledge', get_post( $draft_id )->post_type );
+		$this->assertSame( 'wp_knowledge', get_post( $pending_id )->post_type );
+		$this->assertSame( 'Second content.', get_post( $pending_id )->post_content );
+		$this->assertCount( 2, $this->get_knowledge_posts() );
 	}
 
 	/**
@@ -329,7 +413,8 @@ class Knowledge_Migration_Test extends \WorDBless\BaseTestCase {
 		$this->assertNotNull( $block );
 		$this->assertSame( 'Paragraph guidance.', $block->post_content );
 		$this->assertSame( 'core/paragraph', $block->post_title );
-		$this->assertNotFalse( term_exists( 'guideline', 'wp_knowledge_type' ) );
+		$this->assertSame( array( 'guideline' ), $this->assigned_terms( $site->ID, 'wp_knowledge_type' ) );
+		$this->assertSame( array( 'guideline' ), $this->assigned_terms( $block->ID, 'wp_knowledge_type' ) );
 		$this->assertSame( 'trash', get_post_status( $old_id ) );
 		$this->assertSame( 'trash', get_post_status( $new_id ) );
 
@@ -359,6 +444,30 @@ class Knowledge_Migration_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function capture_migration_state(): void {
 		$this->state_during_save = get_option( Knowledge_Migration::OPTION_NAME );
+	}
+
+	/**
+	 * Record the term slugs assigned to a post.
+	 *
+	 * @param int    $object_id Object ID.
+	 * @param mixed  $terms     Terms passed to wp_set_object_terms().
+	 * @param int[]  $tt_ids    Term taxonomy IDs.
+	 * @param string $taxonomy  Taxonomy name.
+	 */
+	public function track_object_terms( int $object_id, $terms, $tt_ids, string $taxonomy ): void {
+		unset( $tt_ids );
+		$this->assigned_terms[ $object_id ][ $taxonomy ] = array_values( (array) $terms );
+	}
+
+	/**
+	 * Return the term slugs a post was tagged with in one taxonomy.
+	 *
+	 * @param int    $post_id  Post ID.
+	 * @param string $taxonomy Taxonomy name.
+	 * @return string[]
+	 */
+	private function assigned_terms( int $post_id, string $taxonomy ): array {
+		return $this->assigned_terms[ $post_id ][ $taxonomy ] ?? array();
 	}
 
 	/**

--- a/projects/packages/jetpack-mu-wpcom/tests/php/features/knowledge-migration/Knowledge_Migration_Test.php
+++ b/projects/packages/jetpack-mu-wpcom/tests/php/features/knowledge-migration/Knowledge_Migration_Test.php
@@ -96,6 +96,18 @@ class Knowledge_Migration_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * The package loader initializes the feature hooks.
+	 */
+	public function test_feature_loader_bootstraps_migration_hooks() {
+		Jetpack_Mu_Wpcom::load_knowledge_migration();
+
+		$this->assertSame( 9, has_action( 'init', array( Knowledge_Migration::class, 'register_legacy_storage' ) ) );
+		$this->assertSame( 9, has_action( 'init', array( Knowledge_Migration::class, 'register_migration_setting' ) ) );
+		$this->assertSame( 100, has_action( 'init', array( Knowledge_Migration::class, 'maybe_schedule_migration' ) ) );
+		$this->assertSame( 10, has_action( Knowledge_Migration::CRON_HOOK, array( Knowledge_Migration::class, 'run_migration' ) ) );
+	}
+
+	/**
 	 * Legacy storage stays registered after migration completion.
 	 */
 	public function test_legacy_storage_registration_is_independent_of_migration_state() {
@@ -464,7 +476,9 @@ class Knowledge_Migration_Test extends \WorDBless\BaseTestCase {
 							)
 						);
 					}
-					$objects[] = $term;
+					$term            = clone $term;
+					$term->object_id = $object_id;
+					$objects[]       = $term;
 				}
 			}
 		}


### PR DESCRIPTION
## Proposed changes

This adds a temporary compatibility and migration feature to the Jetpack MU WPcom package for Atomic sites.

- Keep the legacy `wp_guideline`, `wp_guideline_type`, and `wp_content_guideline` storage registered independently of migration state so administrators can inspect it through the standard WordPress REST API.
- Expose a writable, versioned migration status through `/wp/v2/settings`. The status records when a migration is scheduled, started, completed, or failed.
- Schedule a randomized one-time WP-Cron migration. A short-lived transient prevents overlapping runs, and failed runs are retried later.
- Migrate ordinary guideline posts in place to `wp_knowledge`, preserving their post IDs, content, authors, status, and equivalent taxonomy terms.
- Expand legacy content-guideline metadata into scoped Knowledge posts. Transitional `wp_guideline` content takes precedence when both legacy formats provide the same scope.
- Treat an existing active Knowledge post with the same slug as the destination and retire the superseded legacy source.
- Leave legacy storage registration active after migration so completion can be checked separately from the migration job.

The migration runs locally on the site and does not depend on a Jetpack connection or a custom migration REST endpoint.

## Related product discussion/links

None included; the implementation and test coverage in this PR are self-contained.

## Does this pull request change what data or activity we track or use?

No. This PR does not add analytics or activity tracking.

## Testing instructions

Run the focused migration tests:

```sh
cd projects/packages/jetpack-mu-wpcom
php -d opcache.enable_cli=0 -d opcache.restrict_api= vendor/bin/phpunit -c phpunit.11.xml.dist --filter Knowledge_Migration_Test
```

The focused tests verify:

- legacy REST registration remains available after migration completion;
- legacy REST collections require administrator access;
- migration status can be written through `/wp/v2/settings`;
- scheduling is versioned and does not create duplicate events;
- empty sites complete successfully;
- ordinary guidelines migrate in place;
- slug collisions retain the existing Knowledge post and retire the legacy source;
- content-guideline formats expand with the expected precedence and remain idempotent;
- failures remain observable and schedule a retry.

Run the complete package test suite:

```sh
cd projects/packages/jetpack-mu-wpcom
php -d opcache.enable_cli=0 -d opcache.restrict_api= vendor/bin/phpunit -c phpunit.11.xml.dist
```

Also run the package's PHPCS and Phan checks.