### PR TITLE
Backport: Agents Manager 0.9.1

### DIFF
--- a/projects/js-packages/babel-plugin-replace-textdomain/CHANGELOG.md
+++ b/projects/js-packages/babel-plugin-replace-textdomain/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] - 2026-08-06
+### Fixed
+- Build debug code frames only when debug output is enabled, which makes stamping text domains onto large bundles dramatically faster. [#51086]
+
 ## [1.2.0] - 2026-07-31
 ### Added
 - Add a `requireI18nSource` option to skip gettext-shaped calls whose callee provably comes from a module other than the i18n one — needed when the plugin runs over whole bundles rather than hand-written source.
@@ -281,6 +285,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Initial release.
 - Replace missing domains too.
 
+[1.2.1]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.2.0...v1.2.1
 [1.2.0]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.1.6...v1.2.0
 [1.1.6]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.1.5...v1.1.6
 [1.1.5]: https://github.com/Automattic/babel-plugin-replace-textdomain/compare/v1.1.4...v1.1.5

--- a/projects/js-packages/babel-plugin-replace-textdomain/changelog/fix-textdomain-code-frame-perf
+++ b/projects/js-packages/babel-plugin-replace-textdomain/changelog/fix-textdomain-code-frame-perf
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Build debug code frames only when debug output is enabled, which makes stamping text domains onto large bundles dramatically faster.

--- a/projects/js-packages/babel-plugin-replace-textdomain/package.json
+++ b/projects/js-packages/babel-plugin-replace-textdomain/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/babel-plugin-replace-textdomain",
-	"version": "1.2.0",
+	"version": "1.2.1",
 	"description": "A Babel plugin to replace the textdomain in gettext-style function calls.",
 	"keywords": [
 		"babel",

--- a/projects/js-packages/components/CHANGELOG.md
+++ b/projects/js-packages/components/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA Components package releases.
 
+## [2.1.1] - 2026-08-06
+### Changed
+- Update package dependencies. [#50509]
+
 ## [2.1.0] - 2026-08-03
 ### Changed
 - Decorative card: Build on the shared Card component, inline the unlink glyph, and hide the card from assistive technology. [#50861]
@@ -1897,6 +1901,7 @@
 ### Changed
 - Update node version requirement to 14.16.1
 
+[2.1.1]: https://github.com/Automattic/jetpack-components/compare/2.1.0...2.1.1
 [2.1.0]: https://github.com/Automattic/jetpack-components/compare/2.0.1...2.1.0
 [2.0.1]: https://github.com/Automattic/jetpack-components/compare/2.0.0...2.0.1
 [2.0.0]: https://github.com/Automattic/jetpack-components/compare/1.12.17...2.0.0

--- a/projects/js-packages/components/package.json
+++ b/projects/js-packages/components/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-components",
-	"version": "2.1.0",
+	"version": "2.1.1",
 	"description": "Jetpack Components Package",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/components/#readme",
 	"bugs": {

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## [2.2.3] - 2026-08-06
 ### Changed
-- Connection UI: Modernise the disconnect-confirm and thank-you step components. [#50864]
+- Modernise the disconnect-confirm and thank-you step components. [#50864]
 - Update package dependencies. [#50509]
 
 ## [2.2.2] - 2026-08-03

--- a/projects/js-packages/connection/CHANGELOG.md
+++ b/projects/js-packages/connection/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ### This is a list detailing changes for the Jetpack RNA Connection Component releases.
 
+## [2.2.3] - 2026-08-06
+### Changed
+- Connection UI: Modernise the disconnect-confirm and thank-you step components. [#50864]
+- Update package dependencies. [#50509]
+
 ## [2.2.2] - 2026-08-03
 ### Changed
 - Update dependencies.
@@ -1448,6 +1453,7 @@
 - `Main` and `ConnectUser` components added.
 - `JetpackRestApiClient` API client added.
 
+[2.2.3]: https://github.com/Automattic/jetpack-connection-js/compare/v2.2.2...v2.2.3
 [2.2.2]: https://github.com/Automattic/jetpack-connection-js/compare/v2.2.1...v2.2.2
 [2.2.1]: https://github.com/Automattic/jetpack-connection-js/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/Automattic/jetpack-connection-js/compare/v2.1.0...v2.2.0

--- a/projects/js-packages/connection/changelog/update-connection-js-package-ui-pt6-steps
+++ b/projects/js-packages/connection/changelog/update-connection-js-package-ui-pt6-steps
@@ -1,4 +1,0 @@
-Significance: patch
-Type: changed
-
-Connection UI: Modernise the disconnect-confirm and thank-you step components.

--- a/projects/js-packages/connection/package.json
+++ b/projects/js-packages/connection/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-connection",
-	"version": "2.2.2",
+	"version": "2.2.3",
 	"description": "Jetpack Connection Component",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/connection/#readme",
 	"bugs": {

--- a/projects/js-packages/idc/CHANGELOG.md
+++ b/projects/js-packages/idc/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### This is a list detailing changes for the Jetpack RNA IDC package releases.
 
+## 1.0.89 - 2026-08-06
+### Changed
+- Update dependencies. [#46035]
+
 ## 1.0.88 - 2026-08-03
 ### Changed
 - Update dependencies. [#46035]

--- a/projects/js-packages/idc/package.json
+++ b/projects/js-packages/idc/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-idc",
-	"version": "1.0.88",
+	"version": "1.0.89",
 	"description": "Jetpack Connection Component",
 	"license": "GPL-2.0-or-later",
 	"author": "Automattic",

--- a/projects/js-packages/jetpack-shared-stores/CHANGELOG.md
+++ b/projects/js-packages/jetpack-shared-stores/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.4] - 2026-08-06
+### Changed
+- Update dependencies.
+
 ## [0.2.3] - 2026-07-31
 ### Changed
 - Update dependencies.
@@ -52,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Update package dependencies. [#49757]
 
+[0.2.4]: https://github.com/Automattic/jetpack-shared-stores/compare/v0.2.3...v0.2.4
 [0.2.3]: https://github.com/Automattic/jetpack-shared-stores/compare/v0.2.2...v0.2.3
 [0.2.2]: https://github.com/Automattic/jetpack-shared-stores/compare/v0.2.1...v0.2.2
 [0.2.1]: https://github.com/Automattic/jetpack-shared-stores/compare/v0.2.0...v0.2.1

--- a/projects/js-packages/jetpack-shared-stores/package.json
+++ b/projects/js-packages/jetpack-shared-stores/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-shared-stores",
-	"version": "0.2.3",
+	"version": "0.2.4",
 	"description": "Shared WordPress data stores used by the Jetpack block editor extensions, externalized into a single bundle to avoid duplicate store registration.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/jetpack-shared-stores/#readme",
 	"bugs": {

--- a/projects/js-packages/webpack-config/CHANGELOG.md
+++ b/projects/js-packages/webpack-config/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 4.1.2 - 2026-08-06
+### Changed
+- Update dependencies.
+
 ## 4.1.1 - 2026-07-31
 ### Changed
 - Update dependencies.

--- a/projects/js-packages/webpack-config/package.json
+++ b/projects/js-packages/webpack-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-webpack-config",
-	"version": "4.1.1",
+	"version": "4.1.2",
 	"private": true,
 	"description": "Library of pieces for webpack config in Jetpack projects.",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/js-packages/webpack-config/#readme",

--- a/projects/packages/admin-ui/CHANGELOG.md
+++ b/projects/packages/admin-ui/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.15] - 2026-08-06
+### Changed
+- Update package dependencies. [#50509]
+
 ## [0.9.14] - 2026-07-31
 ### Changed
 - Update dependencies.
@@ -335,6 +339,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixing menu visibility issues.
 
+[0.9.15]: https://github.com/Automattic/jetpack-admin-ui/compare/0.9.14...0.9.15
 [0.9.14]: https://github.com/Automattic/jetpack-admin-ui/compare/0.9.13...0.9.14
 [0.9.13]: https://github.com/Automattic/jetpack-admin-ui/compare/0.9.12...0.9.13
 [0.9.12]: https://github.com/Automattic/jetpack-admin-ui/compare/0.9.11...0.9.12

--- a/projects/packages/admin-ui/package.json
+++ b/projects/packages/admin-ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-admin-ui",
-	"version": "0.9.14",
+	"version": "0.9.15",
 	"private": true,
 	"description": "Generic Jetpack wp-admin UI elements",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/admin-ui/#readme",

--- a/projects/packages/admin-ui/src/class-admin-menu.php
+++ b/projects/packages/admin-ui/src/class-admin-menu.php
@@ -17,7 +17,7 @@ use Jetpack_Tracks_Client;
  */
 class Admin_Menu {
 
-	const PACKAGE_VERSION = '0.9.14';
+	const PACKAGE_VERSION = '0.9.15';
 
 	/**
 	 * Slug used for the upgrade menu item and redirect URL.

--- a/projects/packages/agents-manager/CHANGELOG.md
+++ b/projects/packages/agents-manager/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.1] - 2026-08-06
+### Fixed
+- Allow integrations to request the full Agents Manager shell without taking over the Help Center. [#50922]
+
 ## [0.9.0] - 2026-08-03
 ### Changed
 - Dock the AI sidebar on shorter screens instead of floating it over the page content. [#50999]
@@ -101,6 +105,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Agents Manager: Allow overriding variant and sectionName through filters [#49283]
 - Initial version, extracted from Jetpack MU WPCOM to its own package for external consumption. [#49202]
 
+[0.9.1]: https://github.com/Automattic/jetpack-agents-manager/compare/v0.9.0...v0.9.1
 [0.9.0]: https://github.com/Automattic/jetpack-agents-manager/compare/v0.8.4...v0.9.0
 [0.8.4]: https://github.com/Automattic/jetpack-agents-manager/compare/v0.8.3...v0.8.4
 [0.8.3]: https://github.com/Automattic/jetpack-agents-manager/compare/v0.8.2...v0.8.3

--- a/projects/packages/agents-manager/changelog/show-ask-ai-for-full-admin-variants
+++ b/projects/packages/agents-manager/changelog/show-ask-ai-for-full-admin-variants
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Allow integrations to request the full Agents Manager shell without taking over the Help Center.

--- a/projects/packages/agents-manager/package.json
+++ b/projects/packages/agents-manager/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@automattic/jetpack-agents-manager",
-	"version": "0.9.0",
+	"version": "0.9.1",
 	"private": true,
 	"description": "Shared AI infrastructure helpers for Automattic plugins",
 	"homepage": "https://github.com/Automattic/jetpack/tree/HEAD/projects/packages/agents-manager/#readme",

--- a/projects/packages/agents-manager/src/class-agents-manager.php
+++ b/projects/packages/agents-manager/src/class-agents-manager.php
@@ -19,7 +19,7 @@ class Agents_Manager {
 	 *
 	 * @var string
 	 */
-	const PACKAGE_VERSION = '0.9.0';
+	const PACKAGE_VERSION = '0.9.1';
 
 	/**
 	 * Help Center URL for disconnected variants.
@@ -491,7 +491,7 @@ class Agents_Manager {
 		 * Providers should preserve an existing true value so multiple integrations can
 		 * request the shared shell independently.
 		 *
-		 * @since $$next-version$$
+		 * @since 0.9.1
 		 *
 		 * @param bool $should_load Whether another integration already requested the shell.
 		 */

--- a/projects/packages/assets/CHANGELOG.md
+++ b/projects/packages/assets/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.4.10] - 2026-08-06
 ### Fixed
-- Script Data: decode HTML entities in the shared site title so consumers (e.g. the Newsletter Sender Settings panel) don't show literal entities like `&#039;` for site names containing an apostrophe or other special characters. [#50991]
+- Script Data: Decode HTML entities in the shared site title to avoid consumers seeing the encoded entities. [#50991]
 
 ## [4.4.9] - 2026-07-31
 ### Fixed

--- a/projects/packages/assets/CHANGELOG.md
+++ b/projects/packages/assets/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.4.10] - 2026-08-06
+### Fixed
+- Script Data: decode HTML entities in the shared site title so consumers (e.g. the Newsletter Sender Settings panel) don't show literal entities like `&#039;` for site names containing an apostrophe or other special characters. [#50991]
+
 ## [4.4.9] - 2026-07-31
 ### Fixed
 - Don't honor a textdomain self-alias: aliasing a domain to itself made the gettext filter recurse infinitely on any untranslated string in that domain. The package's path is still recorded, since JavaScript translation files are located by it whether or not the domain is aliased.
@@ -912,6 +916,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Statically access asset tools
 
+[4.4.10]: https://github.com/Automattic/jetpack-assets/compare/v4.4.9...v4.4.10
 [4.4.9]: https://github.com/Automattic/jetpack-assets/compare/v4.4.8...v4.4.9
 [4.4.8]: https://github.com/Automattic/jetpack-assets/compare/v4.4.7...v4.4.8
 [4.4.7]: https://github.com/Automattic/jetpack-assets/compare/v4.4.6...v4.4.7

--- a/projects/packages/assets/changelog/fix-script-data-site-title-html-entities
+++ b/projects/packages/assets/changelog/fix-script-data-site-title-html-entities
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Script Data: decode HTML entities in the shared site title so consumers (e.g. the Newsletter Sender Settings panel) don't show literal entities like `&#039;` for site names containing an apostrophe or other special characters.

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [8.9.0] - 2026-08-06
 ### Changed
-- Error Handler: Standardize the stored connection error structure with explicit error type and direction fields, store local connection-state errors as 'local_state' instead of 'connection', and store previously dropped signature verification errors, which can now surface connection error notices. [#50992]
+- Error Handler: Standardize the stored connection error structure with explicit error type and direction fields. [#50992]
 
 ## [8.8.2] - 2026-08-03
 ### Changed

--- a/projects/packages/connection/CHANGELOG.md
+++ b/projects/packages/connection/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.9.0] - 2026-08-06
+### Changed
+- Error Handler: Standardize the stored connection error structure with explicit error type and direction fields, store local connection-state errors as 'local_state' instead of 'connection', and store previously dropped signature verification errors, which can now surface connection error notices. [#50992]
+
 ## [8.8.2] - 2026-08-03
 ### Changed
 - Update dependencies. [#50674]
@@ -1974,6 +1978,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Separate the connection library into its own package.
 
+[8.9.0]: https://github.com/Automattic/jetpack-connection/compare/v8.8.2...v8.9.0
 [8.8.2]: https://github.com/Automattic/jetpack-connection/compare/v8.8.1...v8.8.2
 [8.8.1]: https://github.com/Automattic/jetpack-connection/compare/v8.8.0...v8.8.1
 [8.8.0]: https://github.com/Automattic/jetpack-connection/compare/v8.7.10...v8.8.0

--- a/projects/packages/connection/changelog/update-connection-standardize-error-structure
+++ b/projects/packages/connection/changelog/update-connection-standardize-error-structure
@@ -1,4 +1,0 @@
-Significance: minor
-Type: changed
-
-Error Handler: Standardize the stored connection error structure with explicit error type and direction fields, store local connection-state errors as 'local_state' instead of 'connection', and store previously dropped signature verification errors, which can now surface connection error notices.

--- a/projects/packages/connection/composer.json
+++ b/projects/packages/connection/composer.json
@@ -72,7 +72,7 @@
 			"link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
 		},
 		"branch-alias": {
-			"dev-trunk": "8.8.x-dev"
+			"dev-trunk": "8.9.x-dev"
 		},
 		"dependencies": {
 			"test-only": [

--- a/projects/packages/connection/src/class-error-handler.php
+++ b/projects/packages/connection/src/class-error-handler.php
@@ -116,7 +116,7 @@ class Error_Handler {
 	/**
 	 * `error_type` value for errors from XML-RPC requests.
 	 *
-	 * @since $$next-version$$
+	 * @since 8.9.0
 	 *
 	 * @var string
 	 */
@@ -125,7 +125,7 @@ class Error_Handler {
 	/**
 	 * `error_type` value for errors from REST requests.
 	 *
-	 * @since $$next-version$$
+	 * @since 8.9.0
 	 *
 	 * @var string
 	 */
@@ -138,7 +138,7 @@ class Error_Handler {
 	 *
 	 * Note: package versions <= 8.8 stored these errors with the type 'connection'.
 	 *
-	 * @since $$next-version$$
+	 * @since 8.9.0
 	 *
 	 * @var string
 	 */
@@ -147,7 +147,7 @@ class Error_Handler {
 	/**
 	 * `error_direction` value for errors triggered by incoming requests (WP.com to this site).
 	 *
-	 * @since $$next-version$$
+	 * @since 8.9.0
 	 *
 	 * @var string
 	 */
@@ -156,7 +156,7 @@ class Error_Handler {
 	/**
 	 * `error_direction` value for errors triggered by outgoing requests (this site to WP.com).
 	 *
-	 * @since $$next-version$$
+	 * @since 8.9.0
 	 *
 	 * @var string
 	 */
@@ -755,7 +755,7 @@ class Error_Handler {
 	 * by both internal error handling and external plugins/customizations.
 	 *
 	 * @since 1.14.2
-	 * @since $$next-version$$ Added the `$error_direction` parameter and output field.
+	 * @since 8.9.0 Added the `$error_direction` parameter and output field.
 	 *
 	 * @param string $error_code      The error code identifier.
 	 * @param string $error_message   The human-readable error message.
@@ -818,7 +818,7 @@ class Error_Handler {
 	 * - `$extra` cannot override the reserved keys: `signature_details`, `error_type`,
 	 *   and `error_direction` always win the merge.
 	 *
-	 * @since $$next-version$$
+	 * @since 8.9.0
 	 *
 	 * @param array  $signature_details Details of the signed request that failed: `token`,
 	 *                                  and typically `timestamp`, `nonce`, `body_hash`,
@@ -860,7 +860,7 @@ class Error_Handler {
 	 * data contract. All connection error reporters should create their `WP_Error`
 	 * objects through this factory.
 	 *
-	 * @since $$next-version$$
+	 * @since 8.9.0
 	 *
 	 * @param string $error_code        The error code, ideally one of `$known_errors`.
 	 * @param string $error_message     The human-readable error message.

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -638,7 +638,7 @@ class Manager {
 	/**
 	 * Determines the transport of the incoming request currently being verified.
 	 *
-	 * @since $$next-version$$
+	 * @since 8.9.0
 	 *
 	 * @return string Error_Handler::ERROR_TYPE_XMLRPC or Error_Handler::ERROR_TYPE_REST.
 	 */

--- a/projects/packages/connection/src/class-package-version.php
+++ b/projects/packages/connection/src/class-package-version.php
@@ -12,7 +12,7 @@ namespace Automattic\Jetpack\Connection;
  */
 class Package_Version {
 
-	const PACKAGE_VERSION = '8.8.2';
+	const PACKAGE_VERSION = '8.9.0';
 
 	const PACKAGE_SLUG = 'connection';
 

--- a/projects/packages/external-connections/changelog/force-a-release
+++ b/projects/packages/external-connections/changelog/force-a-release
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update dependencies.

--- a/projects/packages/jitm/changelog/force-a-release
+++ b/projects/packages/jitm/changelog/force-a-release
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update dependencies.

--- a/projects/packages/post-list/changelog/force-a-release
+++ b/projects/packages/post-list/changelog/force-a-release
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Update dependencies.

--- a/projects/packages/status/CHANGELOG.md
+++ b/projects/packages/status/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [6.2.1] - 2026-08-06
+### Fixed
+- Offline mode: Avoid a redundant per-request database query on sites without a persistent object cache. [#50961]
+
 ## [6.2.0] - 2026-08-03
 ### Added
 - Add Host::is_pressable() to detect sites hosted on the Pressable platform via the IS_PRESSABLE constant. [#50369]
@@ -556,6 +560,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Packages: Introduce a status package
 
+[6.2.1]: https://github.com/Automattic/jetpack-status/compare/v6.2.0...v6.2.1
 [6.2.0]: https://github.com/Automattic/jetpack-status/compare/v6.1.9...v6.2.0
 [6.1.9]: https://github.com/Automattic/jetpack-status/compare/v6.1.8...v6.1.9
 [6.1.8]: https://github.com/Automattic/jetpack-status/compare/v6.1.7...v6.1.8

--- a/projects/packages/status/changelog/fix-jetpack-1539-option-read-churn
+++ b/projects/packages/status/changelog/fix-jetpack-1539-option-read-churn
@@ -1,4 +1,0 @@
-Significance: patch
-Type: fixed
-
-Offline mode: Avoid a redundant per-request database query on sites without a persistent object cache.

--- a/projects/plugins/agents-manager/changelog/prerelease#6
+++ b/projects/plugins/agents-manager/changelog/prerelease#6
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Update composer.lock.
 
-Update package dependencies.
+

--- a/projects/plugins/agents-manager/composer.lock
+++ b/projects/plugins/agents-manager/composer.lock
@@ -418,7 +418,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
+                "reference": "e5ff8b59b34901f3aef7e0f593b8ccf1fc6246f4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -455,7 +455,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.8.x-dev"
+                    "dev-trunk": "8.9.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/automattic-for-agencies-client/changelog/prerelease#19
+++ b/projects/plugins/automattic-for-agencies-client/changelog/prerelease#19
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Update composer.lock.
 
-Update package dependencies.
+

--- a/projects/plugins/automattic-for-agencies-client/composer.lock
+++ b/projects/plugins/automattic-for-agencies-client/composer.lock
@@ -414,7 +414,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
+                "reference": "e5ff8b59b34901f3aef7e0f593b8ccf1fc6246f4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -451,7 +451,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.8.x-dev"
+                    "dev-trunk": "8.9.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/backup/changelog/prerelease#22
+++ b/projects/plugins/backup/changelog/prerelease#22
@@ -1,4 +1,5 @@
 Significance: patch
 Type: changed
+Comment: Update composer.lock.
 
-Update package dependencies.
+

--- a/projects/plugins/backup/composer.lock
+++ b/projects/plugins/backup/composer.lock
@@ -751,7 +751,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
+                "reference": "e5ff8b59b34901f3aef7e0f593b8ccf1fc6246f4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -788,7 +788,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.8.x-dev"
+                    "dev-trunk": "8.9.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/boost/changelog/prerelease#7
+++ b/projects/plugins/boost/changelog/prerelease#7
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/boost/composer.lock
+++ b/projects/plugins/boost/composer.lock
@@ -608,7 +608,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
+                "reference": "e5ff8b59b34901f3aef7e0f593b8ccf1fc6246f4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -645,7 +645,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.8.x-dev"
+                    "dev-trunk": "8.9.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/classic-theme-helper-plugin/changelog/prerelease#41
+++ b/projects/plugins/classic-theme-helper-plugin/changelog/prerelease#41
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/classic-theme-helper-plugin/composer.lock
+++ b/projects/plugins/classic-theme-helper-plugin/composer.lock
@@ -599,7 +599,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
+                "reference": "e5ff8b59b34901f3aef7e0f593b8ccf1fc6246f4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -636,7 +636,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.8.x-dev"
+                    "dev-trunk": "8.9.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/inspect/changelog/prerelease#11
+++ b/projects/plugins/inspect/changelog/prerelease#11
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/inspect/composer.lock
+++ b/projects/plugins/inspect/composer.lock
@@ -414,7 +414,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
+                "reference": "e5ff8b59b34901f3aef7e0f593b8ccf1fc6246f4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -451,7 +451,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.8.x-dev"
+                    "dev-trunk": "8.9.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/jetpack/changelog/prerelease
+++ b/projects/plugins/jetpack/changelog/prerelease
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/jetpack/composer.lock
+++ b/projects/plugins/jetpack/composer.lock
@@ -1190,7 +1190,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
+                "reference": "e5ff8b59b34901f3aef7e0f593b8ccf1fc6246f4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -1227,7 +1227,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.8.x-dev"
+                    "dev-trunk": "8.9.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/mu-wpcom-plugin/changelog/prerelease#24
+++ b/projects/plugins/mu-wpcom-plugin/changelog/prerelease#24
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/mu-wpcom-plugin/composer.lock
+++ b/projects/plugins/mu-wpcom-plugin/composer.lock
@@ -716,7 +716,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
+                "reference": "e5ff8b59b34901f3aef7e0f593b8ccf1fc6246f4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -753,7 +753,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.8.x-dev"
+                    "dev-trunk": "8.9.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/paypal-payment-buttons/changelog/prerelease#11
+++ b/projects/plugins/paypal-payment-buttons/changelog/prerelease#11
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/paypal-payment-buttons/composer.lock
+++ b/projects/plugins/paypal-payment-buttons/composer.lock
@@ -399,7 +399,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
+                "reference": "e5ff8b59b34901f3aef7e0f593b8ccf1fc6246f4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -436,7 +436,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.8.x-dev"
+                    "dev-trunk": "8.9.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/premium-analytics/changelog/prerelease#11
+++ b/projects/plugins/premium-analytics/changelog/prerelease#11
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/premium-analytics/composer.lock
+++ b/projects/plugins/premium-analytics/composer.lock
@@ -477,7 +477,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
+                "reference": "e5ff8b59b34901f3aef7e0f593b8ccf1fc6246f4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -514,7 +514,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.8.x-dev"
+                    "dev-trunk": "8.9.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/protect/changelog/prerelease#22
+++ b/projects/plugins/protect/changelog/prerelease#22
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/protect/composer.lock
+++ b/projects/plugins/protect/composer.lock
@@ -730,7 +730,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
+                "reference": "e5ff8b59b34901f3aef7e0f593b8ccf1fc6246f4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -767,7 +767,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.8.x-dev"
+                    "dev-trunk": "8.9.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/search/changelog/prerelease#3
+++ b/projects/plugins/search/changelog/prerelease#3
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/search/composer.lock
+++ b/projects/plugins/search/composer.lock
@@ -608,7 +608,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
+                "reference": "e5ff8b59b34901f3aef7e0f593b8ccf1fc6246f4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -645,7 +645,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.8.x-dev"
+                    "dev-trunk": "8.9.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/social/changelog/prerelease#8
+++ b/projects/plugins/social/changelog/prerelease#8
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/social/composer.lock
+++ b/projects/plugins/social/composer.lock
@@ -671,7 +671,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
+                "reference": "e5ff8b59b34901f3aef7e0f593b8ccf1fc6246f4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -708,7 +708,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.8.x-dev"
+                    "dev-trunk": "8.9.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/starter-plugin/changelog/prerelease#22
+++ b/projects/plugins/starter-plugin/changelog/prerelease#22
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/starter-plugin/composer.lock
+++ b/projects/plugins/starter-plugin/composer.lock
@@ -608,7 +608,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
+                "reference": "e5ff8b59b34901f3aef7e0f593b8ccf1fc6246f4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -645,7 +645,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.8.x-dev"
+                    "dev-trunk": "8.9.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/videopress/changelog/prerelease#5
+++ b/projects/plugins/videopress/changelog/prerelease#5
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/videopress/composer.lock
+++ b/projects/plugins/videopress/composer.lock
@@ -608,7 +608,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
+                "reference": "e5ff8b59b34901f3aef7e0f593b8ccf1fc6246f4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -645,7 +645,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.8.x-dev"
+                    "dev-trunk": "8.9.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/wpcloud-sso/changelog/prerelease#35
+++ b/projects/plugins/wpcloud-sso/changelog/prerelease#35
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/wpcloud-sso/composer.lock
+++ b/projects/plugins/wpcloud-sso/composer.lock
@@ -414,7 +414,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "b73cc2a68522658c6693f035e7a8c0d5b6984688"
+                "reference": "e5ff8b59b34901f3aef7e0f593b8ccf1fc6246f4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -451,7 +451,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.8.x-dev"
+                    "dev-trunk": "8.9.x-dev"
                 },
                 "dependencies": {
                     "test-only": [

--- a/projects/plugins/wpcomsh/changelog/prerelease#26
+++ b/projects/plugins/wpcomsh/changelog/prerelease#26
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/wpcomsh/composer.lock
+++ b/projects/plugins/wpcomsh/composer.lock
@@ -832,7 +832,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "f2b33840260110de1b61cfdb42e537e33989a4a7"
+                "reference": "90609009daeb991bdb5fe7e46758456840e5a19a"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -869,7 +869,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.8.x-dev"
+                    "dev-trunk": "8.9.x-dev"
                 },
                 "dependencies": {
                     "test-only": [


### PR DESCRIPTION
## Proposed changes
* Release version 0.9.1 of the `agents-manager` package following the merge of https://github.com/Automattic/jetpack/pull/50922.
* Backport the resulting release changes from `prerelease` to `trunk`.

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* https://github.com/Automattic/jetpack/pull/50922

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->
No.

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Verify that CI passes. No additional functional testing is required for the generated release changes.
