### PR TITLE
AI: Attach blog_id to MCP settings Tracks events

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -27,6 +27,9 @@ import McpWrite from './mcp/write';
 
 const { blogId, activityLogUrl, apiRoot, apiNonce } = window?.jetpackAiSettings ?? {};
 
+// Matches the `source` value convention used by the MCP upsell events.
+const SETTINGS_SOURCE = 'jetpack-ai-mcp-settings';
+
 const MCP_SUB_VIEWS = [ 'read', 'write', 'setup' ];
 
 // Read at call time, not module scope, so the flag reflects the injected page data.
@@ -143,7 +146,11 @@ export default function App() {
 	useEffect( () => {
 		if ( ! isLoading && hasMcpAccess && isMcpContext && ! mcpViewedRecorded.current ) {
 			mcpViewedRecorded.current = true;
-			analytics.tracks.recordEvent( 'jetpack_mcp_settings_viewed' );
+			// blog_id is attached automatically by the analytics library from
+			// window.jpTracksContext, which the page sets via an inline script.
+			analytics.tracks.recordEvent( 'jetpack_mcp_settings_viewed', {
+				source: SETTINGS_SOURCE,
+			} );
 		}
 	}, [ isLoading, hasMcpAccess, isMcpContext ] );
 

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
@@ -147,6 +147,22 @@ class Jetpack_AI_Page extends Jetpack_Admin_Page {
 			'before'
 		);
 
+		/*
+		 * `@automattic/jetpack-analytics` reads `window.jpTracksContext.blog_id` at
+		 * event-fire time and attaches it to every Tracks event fired from this page.
+		 * Without it, JS-fired events from self-hosted sites carry no blog_id — the
+		 * Tracks pixel cannot resolve the site — so the events cannot be joined to
+		 * plan or site data. Mirrors Connection\Initial_State::render().
+		 */
+		wp_add_inline_script(
+			'jetpack-ai-admin',
+			sprintf(
+				'window.jpTracksContext = window.jpTracksContext || {}; window.jpTracksContext.blog_id = %s;',
+				absint( $blog_id )
+			),
+			'before'
+		);
+
 		wp_enqueue_style(
 			'jetpack-ai-admin',
 			plugins_url( '_inc/build/jetpack-ai-admin.css', JETPACK__PLUGIN_FILE ),

--- a/projects/plugins/jetpack/changelog/aiint-574-jetpack-mcp-settings-events-fire-in-a-site-context-without
+++ b/projects/plugins/jetpack/changelog/aiint-574-jetpack-mcp-settings-events-fire-in-a-site-context-without
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI: Attach the site ID to MCP settings Tracks events, and add a source property to the settings view event.


### PR DESCRIPTION
Fixes [AIINT-574](https://linear.app/a8c/issue/AIINT-574/jetpack-mcp-settings-events-fire-in-a-site-context-without-blog-id-and)

## Proposed changes

* AI admin page (`wp-admin/admin.php?page=jetpack-ai`): set `window.jpTracksContext.blog_id` via an inline script alongside `jetpackAiSettings`, so `@automattic/jetpack-analytics` attaches the site's WordPress.com blog ID to every Tracks event fired from the page (mechanism introduced in #48096, mirroring `Connection\Initial_State::render()`). This fixes all five `jetpack_mcp_*` events firing without `blog_id` on self-hosted sites.
* `jetpack_mcp_settings_viewed`: add a `source` property (`jetpack-ai-mcp-settings`), matching the sibling `jetpack_mcp_upsell_viewed` event. The event previously fired with no properties at all.

### Root cause

The events fire from JavaScript on a standalone React admin page that never rendered the connection initial state, so `window.jpTracksContext` was never set and the analytics library had no `blog_id` to attach. On Simple/Atomic the Tracks pixel can resolve the blog from the request context; on self-hosted Jetpack sites — the population this page is built for — it cannot.

## Related product discussion/links

* https://linear.app/a8c/issue/AIINT-574/jetpack-mcp-settings-events-fire-in-a-site-context-without-blog-id-and
* Platform-wide `blog_id` mechanism this relies on: #48096

## Does this pull request change what data or activity we track or use?

Yes — property-level changes to existing events; no new events are introduced:

* The five existing `jetpack_mcp_*` events (`jetpack_mcp_settings_viewed`, `jetpack_mcp_enabled_toggled`, `jetpack_mcp_upsell_viewed`, `jetpack_mcp_upsell_cta_click`, `jetpack_mcp_allowlist_updated`) now include `blog_id`, which Tracks standards require on every site-scoped event.
* `jetpack_mcp_settings_viewed` additionally gains a `source` property (it previously fired with an empty payload).

## Testing instructions

Prerequisites: a Jetpack-connected self-hosted site (e.g. Jurassic Ninja) running this branch, with browser devtools open. Watching `window._tkq` in the console (or the Tracks Vigilante extension) shows the events as they fire.

1. On a site **without** MCP access, go to `wp-admin/admin.php?page=jetpack-ai`.
2. Confirm `window.jpTracksContext.blog_id` in the console returns the site's WordPress.com blog ID.
3. Observe `jetpack_mcp_upsell_viewed` fire with both `source` and `blog_id`. Click "Upgrade plan" and observe `jetpack_mcp_upsell_cta_click` with the same properties.
4. On a site **with** MCP access, open the same page. Observe `jetpack_mcp_settings_viewed` fire with `source: "jetpack-ai-mcp-settings"` and `blog_id`.
5. Toggle "Enable MCP access" and observe `jetpack_mcp_enabled_toggled` with `enabled` and `blog_id`.
6. In the Read/Write sub-views, toggle a tool and observe `jetpack_mcp_allowlist_updated` with its usual properties plus `blog_id`.

Post-deploy verification (queries in the Linear issue): `blog_id` coverage should be at or above 95% for every `jetpack_mcp_%` event, and `jetpack_mcp_settings_viewed` should return rows in a property scan.
