### PR TITLE
Codesniffer: Ignore the php_codesniffer 3.13.5 advisory blocking static analysis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -112,6 +112,13 @@
 		"sort-packages": true,
 		"allow-plugins": {
 			"dealerdirect/phpcodesniffer-composer-installer": true
+		},
+		"policy": {
+			"advisories": {
+				"ignore-id": [
+					"PKSA-rdkp-vv9z-mjkg"
+				]
+			}
 		}
 	},
 	"require": {

--- a/composer.lock
+++ b/composer.lock
@@ -63,7 +63,7 @@
             "dist": {
                 "type": "path",
                 "url": "projects/packages/codesniffer",
-                "reference": "0f1e6c789c704afeb9533643e1f41b52ec687a27"
+                "reference": "d9cddf2f8607377d801588c63c7d1951dd37d087"
             },
             "require": {
                 "automattic/vipwpcs": "^3.0",

--- a/projects/packages/codesniffer/changelog/fix-phpcs-advisory-block
+++ b/projects/packages/codesniffer/changelog/fix-phpcs-advisory-block
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Ignore CVE-2026-67434 advisory for php_codesniffer 3.13.5, which mediawiki-codesniffer 51 pins exactly.
+
+

--- a/projects/packages/codesniffer/composer.json
+++ b/projects/packages/codesniffer/composer.json
@@ -77,7 +77,8 @@
 		"policy": {
 			"advisories": {
 				"ignore-id": [
-					"GHSA-3pwp-g2mj-5p3v"
+					"GHSA-3pwp-g2mj-5p3v",
+					"PKSA-rdkp-vv9z-mjkg"
 				]
 			}
 		}


### PR DESCRIPTION
See p1786003254963629-slack-C01U2KGS2PQ

## Proposed changes

* Ignore advisory `PKSA-rdkp-vv9z-mjkg` (CVE-2026-67434) in [projects/packages/codesniffer/composer.json](https://github.com/Automattic/jetpack/blob/trunk/projects/packages/codesniffer/composer.json) so dependency resolution stops failing.
* Composer started blocking `squizlabs/php_codesniffer` 3.13.5 on 2026-08-05, and `mediawiki/mediawiki-codesniffer` 51 pins that version exactly, so `composer update` in `packages/codesniffer` aborts and the Static analysis job fails on every PR.
* `mediawiki-codesniffer` 52 pins the patched 3.13.6, but it requires PHP >= 8.3 while this package declares >= 8.2, and at the monorepo root Composer would then prefer upstream 3.13.6 over `Automattic/PHP_CodeSniffer` 3.13.5, dropping the per-directory-config patches behind `jetpack-filter-perdir-file`.
* Follow-up to remove this ignore: tag 3.13.6 (and 4.0.2) in `Automattic/PHP_CodeSniffer`, then bump to `mediawiki-codesniffer ^52.0` and `php >=8.3`.

## Related product discussion/links

* Upstream fix: https://github.com/PHPCSStandards/PHP_CodeSniffer/releases/tag/3.13.6

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Confirm the Static analysis check passes on this PR.
* Run `composer update --dry-run` in `projects/packages/codesniffer`. It should resolve and report the advisory as ignored instead of erroring.
* Run `jp phan packages/codesniffer` and confirm it completes.