### PR TITLE
Write: extract testable helpers from view.js into modules with unit tests

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-write-view-js-test-coverage
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-write-view-js-test-coverage
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Write: Extract the image-formatting and pure text helpers out of view.js into standalone modules with unit tests.

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -25,7 +25,7 @@
 		"clean": "rm -rf src/build/ src/build-module/ build/",
 		"e2e-tests": "playwright test --config src/features/verbum-comments/playwright.config.ts",
 		"sync:newspack-blocks": "./bin/sync-newspack-blocks.sh",
-		"test": "node --test --test-reporter spec src/features/write/test/undo-history.test.mjs",
+		"test": "node --test --test-reporter spec src/features/write/test/*.test.mjs",
 		"test-coverage": "c8 --report-dir=\"$COVERAGE_DIR\" --temp-directory=\"$ARTIFACTS_DIR/v8\" pnpm run test",
 		"typecheck": "tsgo --build",
 		"watch": "pnpm run build-production-js && pnpm webpack watch"

--- a/projects/packages/jetpack-mu-wpcom/package.json
+++ b/projects/packages/jetpack-mu-wpcom/package.json
@@ -25,7 +25,7 @@
 		"clean": "rm -rf src/build/ src/build-module/ build/",
 		"e2e-tests": "playwright test --config src/features/verbum-comments/playwright.config.ts",
 		"sync:newspack-blocks": "./bin/sync-newspack-blocks.sh",
-		"test": "node --test --test-reporter spec src/features/write/test/*.test.mjs",
+		"test": "node --test --test-reporter spec 'src/**/test/*.test.mjs'",
 		"test-coverage": "c8 --report-dir=\"$COVERAGE_DIR\" --temp-directory=\"$ARTIFACTS_DIR/v8\" pnpm run test",
 		"typecheck": "tsgo --build",
 		"watch": "pnpm run build-production-js && pnpm webpack watch"

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/image-format.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/image-format.js
@@ -1,0 +1,84 @@
+/**
+ * Write — image/figure formatting helpers.
+ *
+ * Pure-ish module extracted from view.js so it can be unit-tested without the
+ * Interactivity API store or global DOM listeners. The figure helpers touch
+ * only an element's `classList` / `className`, so tests can drive them with a
+ * lightweight classList mock rather than full jsdom.
+ */
+
+// Image size presets we ship. Wide/full layouts and custom widths stay in the
+// block editor (see RSM-3472).
+export const IMAGE_SIZE_SLUGS = [ 'thumbnail', 'medium', 'large', 'full' ];
+
+// Image alignment values we ship. All three are made explicit on save —
+// every image gets an `align*` class on the figure and an `align`
+// attribute in the block JSON, including center, so themes can rely on
+// the class to position the figure (many don't center unaligned figures
+// by default).
+export const IMAGE_ALIGNS = [ 'left', 'center', 'right' ];
+
+/**
+ * Read the attachment ID embedded in `wp-image-<id>` on an `<img>`.
+ *
+ * @param {HTMLImageElement} img - The image element.
+ * @return {number|null} Numeric attachment ID, or null when the class is absent.
+ */
+export function getMediaIdFromImg( img ) {
+	if ( ! img ) return null;
+	const match = img.className.match( /(?:^|\s)wp-image-(\d+)(?:\s|$)/ );
+	return match ? parseInt( match[ 1 ], 10 ) : null;
+}
+
+/**
+ * Toggle a size class on a figure, replacing any existing one.
+ *
+ * @param {Element} fig  - The figure element.
+ * @param {string}  slug - A size slug or '' (clear).
+ */
+export function setFigureSize( fig, slug ) {
+	IMAGE_SIZE_SLUGS.forEach( s => fig.classList.remove( 'size-' + s ) );
+	if ( slug ) fig.classList.add( 'size-' + slug );
+}
+
+/**
+ * Toggle an alignment class on a figure, replacing any existing one.  Always
+ * adds one of alignleft/aligncenter/alignright so the published view centers
+ * reliably (themes key off these classes; unaligned figures don't center
+ * consistently across themes).
+ *
+ * @param {Element} fig   - The figure element.
+ * @param {string}  align - 'left', 'center', or 'right'.
+ */
+export function setFigureAlignment( fig, align ) {
+	fig.classList.remove( 'alignleft', 'alignright', 'aligncenter' );
+	if ( align === 'left' ) fig.classList.add( 'alignleft' );
+	else if ( align === 'right' ) fig.classList.add( 'alignright' );
+	else fig.classList.add( 'aligncenter' );
+}
+
+/**
+ * Read the current alignment from a figure's class list. Returns 'center'
+ * when no align class is set.
+ *
+ * @param {Element} fig - The figure element.
+ * @return {string} 'left', 'center', or 'right'.
+ */
+export function getFigureAlignment( fig ) {
+	if ( fig.classList.contains( 'alignleft' ) ) return 'left';
+	if ( fig.classList.contains( 'alignright' ) ) return 'right';
+	return 'center';
+}
+
+/**
+ * Pick the smallest reasonable thumbnail URL for the grid. Falls back to the
+ * full-size source_url for images without registered sizes (e.g. uploads that
+ * pre-date a media setting change).
+ *
+ * @param {object} media - Media item from /wp/v2/media.
+ * @return {string} The thumbnail URL to render.
+ */
+export function libraryThumbUrl( media ) {
+	const sizes = media.media_details?.sizes;
+	return sizes?.thumbnail?.source_url || sizes?.medium?.source_url || media.source_url || '';
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/test/image-format.test.mjs
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/test/image-format.test.mjs
@@ -1,0 +1,184 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+	IMAGE_SIZE_SLUGS,
+	IMAGE_ALIGNS,
+	getMediaIdFromImg,
+	setFigureSize,
+	setFigureAlignment,
+	getFigureAlignment,
+	libraryThumbUrl,
+} from '../image-format.js';
+
+/**
+ * Minimal stand-in for a DOM element's classList, backed by a Set. Covers the
+ * add / remove / contains surface the figure helpers touch — no jsdom needed.
+ *
+ * @param {string[]} initial - Classes the element starts with.
+ * @return {object} A fake element with `classList` and a `className` getter.
+ */
+function fakeEl( initial = [] ) {
+	const set = new Set( initial );
+	return {
+		classList: {
+			add: ( ...classes ) => classes.forEach( c => set.add( c ) ),
+			remove: ( ...classes ) => classes.forEach( c => set.delete( c ) ),
+			contains: c => set.has( c ),
+		},
+		get className() {
+			return [ ...set ].join( ' ' );
+		},
+	};
+}
+
+describe( 'IMAGE_SIZE_SLUGS / IMAGE_ALIGNS', () => {
+	it( 'ships the four size presets in order', () => {
+		assert.deepEqual( IMAGE_SIZE_SLUGS, [ 'thumbnail', 'medium', 'large', 'full' ] );
+	} );
+
+	it( 'ships the three alignment values', () => {
+		assert.deepEqual( IMAGE_ALIGNS, [ 'left', 'center', 'right' ] );
+	} );
+} );
+
+describe( 'getMediaIdFromImg', () => {
+	it( 'returns null for a missing image', () => {
+		assert.equal( getMediaIdFromImg( null ), null );
+		assert.equal( getMediaIdFromImg( undefined ), null );
+	} );
+
+	it( 'reads the numeric id from a wp-image-<id> class', () => {
+		assert.equal( getMediaIdFromImg( { className: 'wp-image-42' } ), 42 );
+	} );
+
+	it( 'finds the class among other classes', () => {
+		assert.equal( getMediaIdFromImg( { className: 'foo wp-image-123 bar' } ), 123 );
+		assert.equal( getMediaIdFromImg( { className: 'size-large wp-image-7' } ), 7 );
+	} );
+
+	it( 'returns null when there is no wp-image class', () => {
+		assert.equal( getMediaIdFromImg( { className: 'size-large aligncenter' } ), null );
+		assert.equal( getMediaIdFromImg( { className: '' } ), null );
+	} );
+
+	it( 'does not match a partial or non-numeric wp-image token', () => {
+		// A trailing word char after the digits breaks the (?:\s|$) boundary.
+		assert.equal( getMediaIdFromImg( { className: 'wp-image-12x' } ), null );
+		assert.equal( getMediaIdFromImg( { className: 'my-wp-image-9' } ), null );
+		assert.equal( getMediaIdFromImg( { className: 'wp-image-abc' } ), null );
+	} );
+} );
+
+describe( 'setFigureSize', () => {
+	it( 'adds the requested size class', () => {
+		const fig = fakeEl();
+		setFigureSize( fig, 'large' );
+		assert.equal( fig.classList.contains( 'size-large' ), true );
+	} );
+
+	it( 'replaces any existing size class', () => {
+		const fig = fakeEl( [ 'size-thumbnail' ] );
+		setFigureSize( fig, 'medium' );
+		assert.equal( fig.classList.contains( 'size-thumbnail' ), false );
+		assert.equal( fig.classList.contains( 'size-medium' ), true );
+	} );
+
+	it( 'clears all size classes when slug is empty', () => {
+		const fig = fakeEl( [ 'size-full', 'aligncenter' ] );
+		setFigureSize( fig, '' );
+		IMAGE_SIZE_SLUGS.forEach( s => assert.equal( fig.classList.contains( 'size-' + s ), false ) );
+		// Non-size classes are untouched.
+		assert.equal( fig.classList.contains( 'aligncenter' ), true );
+	} );
+} );
+
+describe( 'setFigureAlignment', () => {
+	it( 'maps left to alignleft', () => {
+		const fig = fakeEl();
+		setFigureAlignment( fig, 'left' );
+		assert.equal( fig.classList.contains( 'alignleft' ), true );
+	} );
+
+	it( 'maps right to alignright', () => {
+		const fig = fakeEl();
+		setFigureAlignment( fig, 'right' );
+		assert.equal( fig.classList.contains( 'alignright' ), true );
+	} );
+
+	it( 'maps center (and any unknown value) to aligncenter', () => {
+		const center = fakeEl();
+		setFigureAlignment( center, 'center' );
+		assert.equal( center.classList.contains( 'aligncenter' ), true );
+
+		const unknown = fakeEl();
+		setFigureAlignment( unknown, 'wide' );
+		assert.equal( unknown.classList.contains( 'aligncenter' ), true );
+	} );
+
+	it( 'replaces any existing alignment class', () => {
+		const fig = fakeEl( [ 'alignleft' ] );
+		setFigureAlignment( fig, 'right' );
+		assert.equal( fig.classList.contains( 'alignleft' ), false );
+		assert.equal( fig.classList.contains( 'alignright' ), true );
+	} );
+} );
+
+describe( 'getFigureAlignment', () => {
+	it( 'reads left and right from the class list', () => {
+		assert.equal( getFigureAlignment( fakeEl( [ 'alignleft' ] ) ), 'left' );
+		assert.equal( getFigureAlignment( fakeEl( [ 'alignright' ] ) ), 'right' );
+	} );
+
+	it( 'defaults to center when no align class is present', () => {
+		assert.equal( getFigureAlignment( fakeEl() ), 'center' );
+		assert.equal( getFigureAlignment( fakeEl( [ 'aligncenter' ] ) ), 'center' );
+		assert.equal( getFigureAlignment( fakeEl( [ 'size-large' ] ) ), 'center' );
+	} );
+
+	it( 'round-trips with setFigureAlignment', () => {
+		for ( const align of IMAGE_ALIGNS ) {
+			const fig = fakeEl();
+			setFigureAlignment( fig, align );
+			assert.equal( getFigureAlignment( fig ), align );
+		}
+	} );
+} );
+
+describe( 'libraryThumbUrl', () => {
+	it( 'prefers the thumbnail size', () => {
+		const media = {
+			source_url: 'https://example.com/full.jpg',
+			media_details: {
+				sizes: {
+					thumbnail: { source_url: 'https://example.com/thumb.jpg' },
+					medium: { source_url: 'https://example.com/medium.jpg' },
+				},
+			},
+		};
+		assert.equal( libraryThumbUrl( media ), 'https://example.com/thumb.jpg' );
+	} );
+
+	it( 'falls back to medium when there is no thumbnail', () => {
+		const media = {
+			source_url: 'https://example.com/full.jpg',
+			media_details: { sizes: { medium: { source_url: 'https://example.com/medium.jpg' } } },
+		};
+		assert.equal( libraryThumbUrl( media ), 'https://example.com/medium.jpg' );
+	} );
+
+	it( 'falls back to source_url when no registered sizes exist', () => {
+		assert.equal(
+			libraryThumbUrl( { source_url: 'https://example.com/full.jpg' } ),
+			'https://example.com/full.jpg'
+		);
+		assert.equal(
+			libraryThumbUrl( { source_url: 'https://example.com/full.jpg', media_details: {} } ),
+			'https://example.com/full.jpg'
+		);
+	} );
+
+	it( 'returns an empty string when nothing is available', () => {
+		assert.equal( libraryThumbUrl( {} ), '' );
+		assert.equal( libraryThumbUrl( { media_details: { sizes: {} } } ), '' );
+	} );
+} );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/test/text-helpers.test.mjs
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/test/text-helpers.test.mjs
@@ -1,0 +1,232 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+	MAX_ERROR_MESSAGE_LENGTH,
+	parsePostId,
+	escapeAttr,
+	rgbToHex,
+	isSafePasteHref,
+	getEmbedUrl,
+	parseMarkdownListShortcut,
+	parseMarkdownQuoteShortcut,
+	describeSaveError,
+} from '../text-helpers.js';
+
+describe( 'parsePostId', () => {
+	it( 'parses a bare numeric string', () => {
+		assert.equal( parsePostId( '123' ), 123 );
+	} );
+
+	it( 'trims surrounding whitespace', () => {
+		assert.equal( parsePostId( '  42  ' ), 42 );
+	} );
+
+	it( 'returns null for non-numeric input', () => {
+		assert.equal( parsePostId( 'abc' ), null );
+		assert.equal( parsePostId( '12abc' ), null );
+		assert.equal( parsePostId( 'https://example.com/?p=7' ), null );
+		assert.equal( parsePostId( '' ), null );
+	} );
+} );
+
+describe( 'escapeAttr', () => {
+	it( 'escapes ampersands and double quotes', () => {
+		assert.equal( escapeAttr( 'a & b' ), 'a &amp; b' );
+		assert.equal( escapeAttr( 'say "hi"' ), 'say &quot;hi&quot;' );
+	} );
+
+	it( 'escapes ampersands before quotes so entities are not double-escaped', () => {
+		assert.equal( escapeAttr( '&"' ), '&amp;&quot;' );
+	} );
+
+	it( 'leaves a plain string unchanged', () => {
+		assert.equal( escapeAttr( 'plain text' ), 'plain text' );
+	} );
+} );
+
+describe( 'rgbToHex', () => {
+	it( 'converts an rgb() string to hex', () => {
+		assert.equal( rgbToHex( 'rgb(214, 54, 56)' ), '#d63638' );
+	} );
+
+	it( 'zero-pads single-digit channels', () => {
+		assert.equal( rgbToHex( 'rgb(0, 0, 0)' ), '#000000' );
+		assert.equal( rgbToHex( 'rgb(1, 2, 3)' ), '#010203' );
+	} );
+
+	it( 'handles white', () => {
+		assert.equal( rgbToHex( 'rgb(255, 255, 255)' ), '#ffffff' );
+	} );
+
+	it( 'returns the input unchanged when not in rgb() format', () => {
+		assert.equal( rgbToHex( '#abcdef' ), '#abcdef' );
+		assert.equal( rgbToHex( 'red' ), 'red' );
+		assert.equal( rgbToHex( 'rgba(0, 0, 0, 0)' ), 'rgba(0, 0, 0, 0)' );
+	} );
+} );
+
+describe( 'isSafePasteHref', () => {
+	it( 'allows http and https', () => {
+		assert.equal( isSafePasteHref( 'https://example.com' ), true );
+		assert.equal( isSafePasteHref( 'http://example.com' ), true );
+	} );
+
+	it( 'allows mailto and tel', () => {
+		assert.equal( isSafePasteHref( 'mailto:hi@example.com' ), true );
+		assert.equal( isSafePasteHref( 'tel:+15551234' ), true );
+	} );
+
+	it( 'allows relative, fragment, and query hrefs', () => {
+		assert.equal( isSafePasteHref( '/about' ), true );
+		assert.equal( isSafePasteHref( '#section' ), true );
+		assert.equal( isSafePasteHref( '?page=2' ), true );
+		assert.equal( isSafePasteHref( './local' ), true );
+		assert.equal( isSafePasteHref( '../up' ), true );
+	} );
+
+	it( 'rejects script-bearing and data schemes', () => {
+		assert.equal( isSafePasteHref( 'javascript:alert(1)' ), false );
+		assert.equal( isSafePasteHref( 'vbscript:msgbox(1)' ), false );
+		assert.equal( isSafePasteHref( 'data:text/html,<script>' ), false );
+	} );
+
+	it( 'is case-insensitive on the scheme', () => {
+		assert.equal( isSafePasteHref( 'HTTPS://example.com' ), true );
+	} );
+
+	it( 'rejects empty or whitespace-only hrefs', () => {
+		assert.equal( isSafePasteHref( '' ), false );
+		assert.equal( isSafePasteHref( '   ' ), false );
+		assert.equal( isSafePasteHref( undefined ), false );
+	} );
+} );
+
+describe( 'getEmbedUrl', () => {
+	it( 'converts a YouTube watch URL', () => {
+		assert.equal(
+			getEmbedUrl( 'https://www.youtube.com/watch?v=dQw4w9WgXcQ' ),
+			'https://www.youtube.com/embed/dQw4w9WgXcQ'
+		);
+	} );
+
+	it( 'converts a youtu.be short URL', () => {
+		assert.equal(
+			getEmbedUrl( 'https://youtu.be/dQw4w9WgXcQ' ),
+			'https://www.youtube.com/embed/dQw4w9WgXcQ'
+		);
+	} );
+
+	it( 'converts an existing YouTube embed URL', () => {
+		assert.equal(
+			getEmbedUrl( 'https://www.youtube.com/embed/dQw4w9WgXcQ' ),
+			'https://www.youtube.com/embed/dQw4w9WgXcQ'
+		);
+	} );
+
+	it( 'converts a Vimeo URL', () => {
+		assert.equal(
+			getEmbedUrl( 'https://vimeo.com/123456789' ),
+			'https://player.vimeo.com/video/123456789'
+		);
+	} );
+
+	it( 'returns null for an unrecognized URL', () => {
+		assert.equal( getEmbedUrl( 'https://example.com/video' ), null );
+		assert.equal( getEmbedUrl( 'not a url' ), null );
+	} );
+} );
+
+describe( 'parseMarkdownListShortcut', () => {
+	it( 'returns ul for -, *, and + markers', () => {
+		assert.equal( parseMarkdownListShortcut( '-' ), 'ul' );
+		assert.equal( parseMarkdownListShortcut( '*' ), 'ul' );
+		assert.equal( parseMarkdownListShortcut( '+' ), 'ul' );
+	} );
+
+	it( 'returns ol for a 1. marker', () => {
+		assert.equal( parseMarkdownListShortcut( '1.' ), 'ol' );
+	} );
+
+	it( 'tolerates trailing whitespace after the marker', () => {
+		assert.equal( parseMarkdownListShortcut( '- ' ), 'ul' );
+		assert.equal( parseMarkdownListShortcut( '1. ' ), 'ol' );
+	} );
+
+	it( 'returns null for anything else', () => {
+		assert.equal( parseMarkdownListShortcut( '- item' ), null );
+		assert.equal( parseMarkdownListShortcut( '2.' ), null );
+		assert.equal( parseMarkdownListShortcut( 'text' ), null );
+		assert.equal( parseMarkdownListShortcut( '' ), null );
+	} );
+} );
+
+describe( 'parseMarkdownQuoteShortcut', () => {
+	it( 'returns true for a lone > marker', () => {
+		assert.equal( parseMarkdownQuoteShortcut( '>' ), true );
+		assert.equal( parseMarkdownQuoteShortcut( '> ' ), true );
+	} );
+
+	it( 'returns false for anything else', () => {
+		assert.equal( parseMarkdownQuoteShortcut( '> quote' ), false );
+		assert.equal( parseMarkdownQuoteShortcut( 'text' ), false );
+		assert.equal( parseMarkdownQuoteShortcut( '' ), false );
+	} );
+} );
+
+describe( 'describeSaveError', () => {
+	it( 'handles a WP REST error shape', () => {
+		const err = {
+			code: 'rest_cannot_edit',
+			message: 'Sorry, you are not allowed to edit this post.',
+			data: { status: 403 },
+		};
+		assert.deepEqual( describeSaveError( err ), {
+			code: 'rest_cannot_edit',
+			status: 403,
+			message: 'Sorry, you are not allowed to edit this post.',
+		} );
+	} );
+
+	it( 'falls back to the error name when there is no string code', () => {
+		const err = { name: 'AbortError', message: 'The operation was aborted.' };
+		const result = describeSaveError( err );
+		assert.equal( result.code, 'AbortError' );
+		assert.equal( result.status, null );
+		assert.equal( result.message, 'The operation was aborted.' );
+	} );
+
+	it( 'ignores a numeric DOMException-style code and uses the name', () => {
+		// A DOMException carries a numeric `.code` (AbortError is 20); the name
+		// must win so telemetry reports 'AbortError', not 20.
+		const err = { code: 20, name: 'AbortError', message: 'aborted' };
+		assert.equal( describeSaveError( err ).code, 'AbortError' );
+	} );
+
+	it( 'reports unknown for a code-less, name-less object', () => {
+		assert.equal( describeSaveError( {} ).code, 'unknown' );
+	} );
+
+	it( 'handles non-object throws', () => {
+		assert.deepEqual( describeSaveError( 'boom' ), {
+			code: 'unknown',
+			status: null,
+			message: 'boom',
+		} );
+		assert.deepEqual( describeSaveError( undefined ), {
+			code: 'unknown',
+			status: null,
+			message: '',
+		} );
+	} );
+
+	it( 'truncates long messages to the cap', () => {
+		const long = 'x'.repeat( MAX_ERROR_MESSAGE_LENGTH + 50 );
+		const result = describeSaveError( { code: 'boom', message: long } );
+		assert.equal( result.message.length, MAX_ERROR_MESSAGE_LENGTH );
+	} );
+
+	it( 'coerces a non-numeric status to null', () => {
+		const err = { code: 'boom', message: 'x', data: { status: 'nope' } };
+		assert.equal( describeSaveError( err ).status, null );
+	} );
+} );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/test/text-helpers.test.mjs
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/test/text-helpers.test.mjs
@@ -90,6 +90,40 @@ describe( 'isSafePasteHref', () => {
 		assert.equal( isSafePasteHref( 'data:text/html,<script>' ), false );
 	} );
 
+	it( 'resolves the scheme after trimming leading whitespace', () => {
+		// Browsers strip leading control characters before resolving the
+		// scheme, so the check has to trim first rather than anchoring on the
+		// raw value — otherwise a padded-but-safe href reads as unrecognized.
+		assert.equal( isSafePasteHref( '  https://example.com' ), true );
+		assert.equal( isSafePasteHref( '\thttps://example.com' ), true );
+		assert.equal( isSafePasteHref( '\n#section' ), true );
+	} );
+
+	it( 'rejects a script scheme however it is cased or padded', () => {
+		assert.equal( isSafePasteHref( '  javascript:alert(1)' ), false );
+		assert.equal( isSafePasteHref( '\tjavascript:alert(1)' ), false );
+		assert.equal( isSafePasteHref( '\njavascript:alert(1)' ), false );
+		assert.equal( isSafePasteHref( 'JaVaScRiPt:alert(1)' ), false );
+		// The allowlist must match at the start, not anywhere in the string —
+		// an unanchored test would wave this through on the embedded https:.
+		assert.equal( isSafePasteHref( 'javascript:location="https://example.com"' ), false );
+	} );
+
+	it( 'rejects a backslash-prefixed authority', () => {
+		// Browsers normalize the backslashes to slashes, so these must not be
+		// waved through as relative URLs.
+		assert.equal( isSafePasteHref( '\\\\evil.example' ), false );
+		assert.equal( isSafePasteHref( '\\evil.example' ), false );
+	} );
+
+	it( 'treats a protocol-relative href as safe', () => {
+		// `//host` inherits the page's scheme (always https here), so it can't
+		// smuggle script execution. Pinned deliberately: the leading-slash
+		// branch is what allows it, and narrowing that branch would change
+		// this to false.
+		assert.equal( isSafePasteHref( '//example.com/page' ), true );
+	} );
+
 	it( 'is case-insensitive on the scheme', () => {
 		assert.equal( isSafePasteHref( 'HTTPS://example.com' ), true );
 	} );

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/text-helpers.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/text-helpers.js
@@ -1,0 +1,144 @@
+/**
+ * Write — pure text / data helpers.
+ *
+ * Extracted from view.js so they can be unit-tested in isolation. Every export
+ * here is a pure function of its arguments: no DOM, no Interactivity API store,
+ * no module-level side effects.
+ */
+
+// Cap free-text error strings so a pathological message can't bloat the payload.
+export const MAX_ERROR_MESSAGE_LENGTH = 200;
+
+/**
+ * Check whether raw user input is a bare numeric post ID.
+ *
+ * @param {string} input - Raw user input from the post picker URL field.
+ * @return {number|null} Post ID or null if not a bare numeric string.
+ */
+export function parsePostId( input ) {
+	const trimmed = input.trim();
+	if ( /^\d+$/.test( trimmed ) ) return parseInt( trimmed, 10 );
+	return null;
+}
+
+/**
+ * Escape a string for safe interpolation into an HTML attribute value.
+ *
+ * @param {string} str - Raw string value.
+ * @return {string} HTML-attribute-safe string.
+ */
+export function escapeAttr( str ) {
+	return str.replace( /&/g, '&amp;' ).replace( /"/g, '&quot;' );
+}
+
+/**
+ * Convert an rgb() color string to hex (#rrggbb). Returns the input
+ * unchanged if it is not in rgb() format.
+ *
+ * @param {string} rgb - A CSS color value, e.g. "rgb(214, 54, 56)".
+ * @return {string} Hex color string, e.g. "#d63638".
+ */
+export function rgbToHex( rgb ) {
+	const m = rgb.match( /^rgb\(\s*(\d+),\s*(\d+),\s*(\d+)\s*\)$/ );
+	if ( ! m ) return rgb;
+	const hex = i => ( '0' + parseInt( m[ i ], 10 ).toString( 16 ) ).slice( -2 );
+	return '#' + hex( 1 ) + hex( 2 ) + hex( 3 );
+}
+
+/**
+ * Whether `href` is safe to preserve on a pasted link. Allows http(s),
+ * mailto, tel, and same-document/relative URLs; everything else (notably
+ * `javascript:`, `vbscript:`, and `data:`) is rejected so a pasted link
+ * can't smuggle script execution past the sanitizer.
+ *
+ * @param {string} href - The href value to check.
+ * @return {boolean} True when the href is safe to keep.
+ */
+export function isSafePasteHref( href ) {
+	if ( ! href ) return false;
+	const trimmed = href.trim();
+	if ( ! trimmed ) return false;
+	// Relative / same-document / query / fragment URLs have no scheme.
+	if ( /^[#/?]/.test( trimmed ) || trimmed.startsWith( './' ) || trimmed.startsWith( '../' ) ) {
+		return true;
+	}
+	return /^(https?:|mailto:|tel:)/i.test( trimmed );
+}
+
+/**
+ * Convert a YouTube/Vimeo URL to an embeddable URL.
+ *
+ * @param {string} url - The video URL to convert.
+ * @return {string|null} The embeddable URL, or null if not recognized.
+ */
+export function getEmbedUrl( url ) {
+	// YouTube
+	let match = url.match(
+		/(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([a-zA-Z0-9_-]{11})/
+	);
+	if ( match ) return 'https://www.youtube.com/embed/' + match[ 1 ];
+
+	// Vimeo
+	match = url.match( /vimeo\.com\/(\d+)/ );
+	if ( match ) return 'https://player.vimeo.com/video/' + match[ 1 ];
+
+	return null;
+}
+
+/**
+ * Detect a markdown list shortcut in a paragraph's text.
+ *
+ * Returns 'ul' for `-`, `*`, or `+`, 'ol' for `1.`, otherwise null. Captured
+ * before the trigger space is inserted, so the marker should be the only
+ * content — trailing whitespace is allowed to tolerate a stray <br>-only text
+ * node that contentEditable can leave in an otherwise-empty block.
+ *
+ * @param {string} text - The paragraph's text content.
+ * @return {'ul'|'ol'|null} The list tag to create, or null.
+ */
+export function parseMarkdownListShortcut( text ) {
+	if ( /^[-*+]\s*$/.test( text ) ) return 'ul';
+	if ( /^1\.\s*$/.test( text ) ) return 'ol';
+	return null;
+}
+
+/**
+ * Detect a markdown blockquote shortcut in a paragraph's text.
+ *
+ * Returns true for a lone `>` marker. Captured before the trigger space is
+ * inserted, so the marker should be the only content — trailing whitespace is
+ * allowed to tolerate a stray <br>-only text node that contentEditable can
+ * leave in an otherwise-empty block, matching parseMarkdownListShortcut.
+ *
+ * @param {string} text - The paragraph's text content.
+ * @return {boolean} Whether the text is a blockquote shortcut.
+ */
+export function parseMarkdownQuoteShortcut( text ) {
+	return /^>\s*$/.test( text );
+}
+
+/**
+ * Normalize an unknown thrown value into a small, Tracks-friendly descriptor.
+ *
+ * Handles the shapes `wp.apiFetch` actually rejects with: WP REST errors
+ * ( `{ code, message, data: { status } }` ), native/AbortError ( `{ name,
+ * message }` ), and non-object throws as a last resort.
+ *
+ * @param {*} err - The thrown value.
+ * @return {{ code: string, status: (number|null), message: string }} Descriptor.
+ */
+export function describeSaveError( err ) {
+	if ( ! err || typeof err !== 'object' ) {
+		const raw = err === undefined ? '' : String( err );
+		return { code: 'unknown', status: null, message: raw.slice( 0, MAX_ERROR_MESSAGE_LENGTH ) };
+	}
+	// Prefer the specific REST `code` (always a string, e.g. 'rest_cannot_edit');
+	// fall back to `name` ('AbortError', 'TypeError', …). Guard on a string code
+	// because a DOMException carries a numeric `.code` (AbortError is 20), which
+	// would otherwise shadow the 'AbortError' name and break the timeout message
+	// and telemetry error_code.
+	const code = ( typeof err.code === 'string' && err.code ) || err.name || 'unknown';
+	const status = err.data && typeof err.data.status === 'number' ? err.data.status : null;
+	const message = String( err.message || '' ).slice( 0, MAX_ERROR_MESSAGE_LENGTH );
+	return { code: String( code ), status, message };
+}

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/view.js
@@ -9,8 +9,28 @@
 
 // eslint-disable-next-line import/no-unresolved -- Provided by WordPress at runtime via wp_register_script_module.
 import { store, getElement } from '@wordpress/interactivity';
-// eslint-disable-next-line import/no-unresolved -- Provided by WordPress at runtime via wp_register_script_module.
+/* eslint-disable import/no-unresolved -- wpcom-write/* modules are provided by WordPress at runtime via wp_register_script_module. */
+import {
+	IMAGE_SIZE_SLUGS,
+	IMAGE_ALIGNS,
+	getMediaIdFromImg,
+	setFigureSize,
+	setFigureAlignment,
+	getFigureAlignment,
+	libraryThumbUrl,
+} from 'wpcom-write/image-format';
+import {
+	parsePostId,
+	escapeAttr,
+	rgbToHex,
+	isSafePasteHref,
+	getEmbedUrl,
+	parseMarkdownListShortcut,
+	parseMarkdownQuoteShortcut,
+	describeSaveError,
+} from 'wpcom-write/text-helpers';
 import { createUndoHistory } from 'wpcom-write/undo-history';
+/* eslint-enable import/no-unresolved */
 
 // Translated strings passed from PHP via wp_print_inline_script_tag.
 const i18n = window.wpcomWriteStrings || {};
@@ -378,18 +398,6 @@ function formatRelativeDate( dateStr ) {
 	} ).format( new Date( dateStr ) );
 }
 
-/**
- * Check whether raw user input is a bare numeric post ID.
- *
- * @param {string} input - Raw user input from the post picker URL field.
- * @return {number|null} Post ID or null if not a bare numeric string.
- */
-function parsePostId( input ) {
-	const trimmed = input.trim();
-	if ( /^\d+$/.test( trimmed ) ) return parseInt( trimmed, 10 );
-	return null;
-}
-
 // Save/restore the selection so we can insert images after the modal closes.
 let savedRange = null;
 
@@ -669,33 +677,10 @@ function getContent() {
 	return cachedContent;
 }
 
-// Image size presets we ship. Wide/full layouts and custom widths stay in the
-// block editor (see RSM-3472).
-const IMAGE_SIZE_SLUGS = [ 'thumbnail', 'medium', 'large', 'full' ];
-
-// Image alignment values we ship. All three are made explicit on save —
-// every image gets an `align*` class on the figure and an `align`
-// attribute in the block JSON, including center, so themes can rely on
-// the class to position the figure (many don't center unaligned figures
-// by default).
-const IMAGE_ALIGNS = [ 'left', 'center', 'right' ];
-
 // Cache of media library size lookups keyed by attachment ID.  Populated
 // at upload time from the API response, then again lazily when the user
 // changes the size of a figure loaded from a saved post.
 const mediaSizesCache = new Map();
-
-/**
- * Read the attachment ID embedded in `wp-image-<id>` on an `<img>`.
- *
- * @param {HTMLImageElement} img - The image element.
- * @return {number|null} Numeric attachment ID, or null when the class is absent.
- */
-function getMediaIdFromImg( img ) {
-	if ( ! img ) return null;
-	const match = img.className.match( /(?:^|\s)wp-image-(\d+)(?:\s|$)/ );
-	return match ? parseInt( match[ 1 ], 10 ) : null;
-}
 
 /**
  * Get the registered media-library sizes for an attachment, caching the
@@ -760,17 +745,6 @@ function trackMediaSizeSwap( promise ) {
 }
 
 /**
- * Toggle a size class on a figure, replacing any existing one.
- *
- * @param {Element} fig  - The figure element.
- * @param {string}  slug - A size slug or '' (clear).
- */
-function setFigureSize( fig, slug ) {
-	IMAGE_SIZE_SLUGS.forEach( s => fig.classList.remove( 'size-' + s ) );
-	if ( slug ) fig.classList.add( 'size-' + slug );
-}
-
-/**
  * Infer a size slug for a figure by matching the img's current src against
  * the media library's registered sizes. Used when a figure loaded from
  * outside Write (e.g. block-editor default insert) has no `size-X` class
@@ -795,35 +769,6 @@ async function inferSizeFromImgSrc( fig ) {
 		if ( sizes[ slug ]?.source_url === src ) return slug;
 	}
 	return '';
-}
-
-/**
- * Toggle an alignment class on a figure, replacing any existing one.  Always
- * adds one of alignleft/aligncenter/alignright so the published view centers
- * reliably (themes key off these classes; unaligned figures don't center
- * consistently across themes).
- *
- * @param {Element} fig   - The figure element.
- * @param {string}  align - 'left', 'center', or 'right'.
- */
-function setFigureAlignment( fig, align ) {
-	fig.classList.remove( 'alignleft', 'alignright', 'aligncenter' );
-	if ( align === 'left' ) fig.classList.add( 'alignleft' );
-	else if ( align === 'right' ) fig.classList.add( 'alignright' );
-	else fig.classList.add( 'aligncenter' );
-}
-
-/**
- * Read the current alignment from a figure's class list. Returns 'center'
- * when no align class is set.
- *
- * @param {Element} fig - The figure element.
- * @return {string} 'left', 'center', or 'right'.
- */
-function getFigureAlignment( fig ) {
-	if ( fig.classList.contains( 'alignleft' ) ) return 'left';
-	if ( fig.classList.contains( 'alignright' ) ) return 'right';
-	return 'center';
 }
 
 /**
@@ -1044,30 +989,6 @@ function focusModalInput() {
 		);
 		if ( target ) target.focus();
 	} );
-}
-
-/**
- * Escape a string for safe interpolation into an HTML attribute value.
- *
- * @param {string} str - Raw string value.
- * @return {string} HTML-attribute-safe string.
- */
-function escapeAttr( str ) {
-	return str.replace( /&/g, '&amp;' ).replace( /"/g, '&quot;' );
-}
-
-/**
- * Convert an rgb() color string to hex (#rrggbb). Returns the input
- * unchanged if it is not in rgb() format.
- *
- * @param {string} rgb - A CSS color value, e.g. "rgb(214, 54, 56)".
- * @return {string} Hex color string, e.g. "#d63638".
- */
-function rgbToHex( rgb ) {
-	const m = rgb.match( /^rgb\(\s*(\d+),\s*(\d+),\s*(\d+)\s*\)$/ );
-	if ( ! m ) return rgb;
-	const hex = i => ( '0' + parseInt( m[ i ], 10 ).toString( 16 ) ).slice( -2 );
-	return '#' + hex( 1 ) + hex( 2 ) + hex( 3 );
 }
 
 /**
@@ -1313,26 +1234,6 @@ function sanitizePasteNode( el ) {
 		if ( tag === 'A' && attr.name === 'href' && isSafePasteHref( attr.value ) ) continue;
 		el.removeAttribute( attr.name );
 	}
-}
-
-/**
- * Whether `href` is safe to preserve on a pasted link. Allows http(s),
- * mailto, tel, and same-document/relative URLs; everything else (notably
- * `javascript:`, `vbscript:`, and `data:`) is rejected so a pasted link
- * can't smuggle script execution past the sanitizer.
- *
- * @param {string} href - The href value to check.
- * @return {boolean} True when the href is safe to keep.
- */
-function isSafePasteHref( href ) {
-	if ( ! href ) return false;
-	const trimmed = href.trim();
-	if ( ! trimmed ) return false;
-	// Relative / same-document / query / fragment URLs have no scheme.
-	if ( /^[#/?]/.test( trimmed ) || trimmed.startsWith( './' ) || trimmed.startsWith( '../' ) ) {
-		return true;
-	}
-	return /^(https?:|mailto:|tel:)/i.test( trimmed );
 }
 
 /**
@@ -1659,26 +1560,6 @@ function clearSlashText() {
 			parent.innerHTML = '<br>';
 		}
 	}
-}
-
-/**
- * Convert a YouTube/Vimeo URL to an embeddable URL.
- *
- * @param {string} url - The video URL to convert.
- * @return {string|null} The embeddable URL, or null if not recognized.
- */
-function getEmbedUrl( url ) {
-	// YouTube
-	let match = url.match(
-		/(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/embed\/)([a-zA-Z0-9_-]{11})/
-	);
-	if ( match ) return 'https://www.youtube.com/embed/' + match[ 1 ];
-
-	// Vimeo
-	match = url.match( /vimeo\.com\/(\d+)/ );
-	if ( match ) return 'https://player.vimeo.com/video/' + match[ 1 ];
-
-	return null;
 }
 
 /**
@@ -2374,19 +2255,6 @@ let libraryFetchToken = 0;
 const LIBRARY_PER_PAGE = 24;
 
 /**
- * Pick the smallest reasonable thumbnail URL for the grid. Falls back to the
- * full-size source_url for images without registered sizes (e.g. uploads that
- * pre-date a media setting change).
- *
- * @param {object} media - Media item from /wp/v2/media.
- * @return {string} The thumbnail URL to render.
- */
-function libraryThumbUrl( media ) {
-	const sizes = media.media_details?.sizes;
-	return sizes?.thumbnail?.source_url || sizes?.medium?.source_url || media.source_url || '';
-}
-
-/**
  * Render the library strip into #bw-library-grid. Always replaces — the strip
  * holds the most recent items (or current search results) only.  Thumbnails
  * are <button>s; the container has aria-label, so individual items use plain
@@ -2564,23 +2432,6 @@ function insertNewList( listTag ) {
 }
 
 /**
- * Detect a markdown list shortcut in a paragraph's text.
- *
- * Returns 'ul' for `-`, `*`, or `+`, 'ol' for `1.`, otherwise null. Captured
- * before the trigger space is inserted, so the marker should be the only
- * content — trailing whitespace is allowed to tolerate a stray <br>-only text
- * node that contentEditable can leave in an otherwise-empty block.
- *
- * @param {string} text - The paragraph's text content.
- * @return {'ul'|'ol'|null} The list tag to create, or null.
- */
-function parseMarkdownListShortcut( text ) {
-	if ( /^[-*+]\s*$/.test( text ) ) return 'ul';
-	if ( /^1\.\s*$/.test( text ) ) return 'ol';
-	return null;
-}
-
-/**
  * Replace a paragraph with a fresh list containing one empty item, and move the cursor into it.
  *
  * @param {HTMLElement} paragraph - The paragraph to convert.
@@ -2597,21 +2448,6 @@ function applyMarkdownListShortcut( paragraph, listTag ) {
 	state.formatUList = listTag === 'ul';
 	state.formatOList = listTag === 'ol';
 	state.insideList = true;
-}
-
-/**
- * Detect a markdown blockquote shortcut in a paragraph's text.
- *
- * Returns true for a lone `>` marker. Captured before the trigger space is
- * inserted, so the marker should be the only content — trailing whitespace is
- * allowed to tolerate a stray <br>-only text node that contentEditable can
- * leave in an otherwise-empty block, matching parseMarkdownListShortcut.
- *
- * @param {string} text - The paragraph's text content.
- * @return {boolean} Whether the text is a blockquote shortcut.
- */
-function parseMarkdownQuoteShortcut( text ) {
-	return /^>\s*$/.test( text );
 }
 
 /**
@@ -6220,34 +6056,6 @@ const SAVE_STALL_THRESHOLD_MS = 30000;
 // first as the diagnostic, then the abort surfaces as a recoverable
 // `save_failed` with error_code 'AbortError'.
 const SAVE_REQUEST_TIMEOUT_MS = SAVE_STALL_THRESHOLD_MS + 15000;
-// Cap free-text error strings so a pathological message can't bloat the payload.
-const MAX_ERROR_MESSAGE_LENGTH = 200;
-
-/**
- * Normalize an unknown thrown value into a small, Tracks-friendly descriptor.
- *
- * Handles the shapes `wp.apiFetch` actually rejects with: WP REST errors
- * ( `{ code, message, data: { status } }` ), native/AbortError ( `{ name,
- * message }` ), and non-object throws as a last resort.
- *
- * @param {*} err - The thrown value.
- * @return {{ code: string, status: (number|null), message: string }} Descriptor.
- */
-function describeSaveError( err ) {
-	if ( ! err || typeof err !== 'object' ) {
-		const raw = err === undefined ? '' : String( err );
-		return { code: 'unknown', status: null, message: raw.slice( 0, MAX_ERROR_MESSAGE_LENGTH ) };
-	}
-	// Prefer the specific REST `code` (always a string, e.g. 'rest_cannot_edit');
-	// fall back to `name` ('AbortError', 'TypeError', …). Guard on a string code
-	// because a DOMException carries a numeric `.code` (AbortError is 20), which
-	// would otherwise shadow the 'AbortError' name and break the timeout message
-	// and telemetry error_code.
-	const code = ( typeof err.code === 'string' && err.code ) || err.name || 'unknown';
-	const status = err.data && typeof err.data.status === 'number' ? err.data.status : null;
-	const message = String( err.message || '' ).slice( 0, MAX_ERROR_MESSAGE_LENGTH );
-	return { code: String( code ), status, message };
-}
 
 /**
  * Fire the `wpcom_write_editor_save_failed` Tracks event.

--- a/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/write/write.php
@@ -17,7 +17,7 @@ use Automattic\Jetpack\Jetpack_Mu_Wpcom\Common;
 
 if ( ! defined( 'WPCOM_WRITE_VERSION' ) ) {
 	// Use file modification time to bust CDN caches when files change.
-	define( 'WPCOM_WRITE_VERSION', (string) max( filemtime( __DIR__ . '/view.js' ), filemtime( __DIR__ . '/style.css' ), filemtime( __DIR__ . '/undo-history.js' ), filemtime( __DIR__ . '/post-publish-checklist.js' ), filemtime( __DIR__ . '/post-publish-checklist.css' ) ) );
+	define( 'WPCOM_WRITE_VERSION', (string) max( filemtime( __DIR__ . '/view.js' ), filemtime( __DIR__ . '/style.css' ), filemtime( __DIR__ . '/undo-history.js' ), filemtime( __DIR__ . '/image-format.js' ), filemtime( __DIR__ . '/text-helpers.js' ), filemtime( __DIR__ . '/post-publish-checklist.js' ), filemtime( __DIR__ . '/post-publish-checklist.css' ) ) );
 }
 
 // Inline SVG icons used by the top bar and the formatting toolbar.
@@ -152,9 +152,26 @@ add_action(
 			WPCOM_WRITE_VERSION
 		);
 		wp_register_script_module(
+			'wpcom-write/image-format',
+			wpcom_write_asset_url( 'image-format.js' ),
+			array(),
+			WPCOM_WRITE_VERSION
+		);
+		wp_register_script_module(
+			'wpcom-write/text-helpers',
+			wpcom_write_asset_url( 'text-helpers.js' ),
+			array(),
+			WPCOM_WRITE_VERSION
+		);
+		wp_register_script_module(
 			'wpcom-write/view',
 			wpcom_write_asset_url( 'view.js' ),
-			array( '@wordpress/interactivity', 'wpcom-write/undo-history' ),
+			array(
+				'@wordpress/interactivity',
+				'wpcom-write/undo-history',
+				'wpcom-write/image-format',
+				'wpcom-write/text-helpers',
+			),
 			WPCOM_WRITE_VERSION
 		);
 	}


### PR DESCRIPTION
Fixes RSM-4353

## Proposed changes

The Write editor's `view.js` is a raw ES-module Interactivity API entry point sitting at 0% test coverage, so every PR that touches it trips the Jetpack Code Coverage Requirement bot. This peels the pure, testable helpers out of `view.js` into two importable sibling modules and covers them with `node:test`, giving new Write logic a place to land with coverage.

* **New `image-format.js`** — the figure/media formatting cluster: `IMAGE_SIZE_SLUGS`, `IMAGE_ALIGNS`, `getMediaIdFromImg`, `setFigureSize`, `setFigureAlignment`, `getFigureAlignment`, `libraryThumbUrl`.
* **New `text-helpers.js`** — pure string/data helpers: `parsePostId`, `escapeAttr`, `rgbToHex`, `isSafePasteHref`, `getEmbedUrl`, `parseMarkdownListShortcut`, `parseMarkdownQuoteShortcut`, `describeSaveError`.
* `view.js` now imports these via the existing `wpcom-write/*` script-module import map (same mechanism as `undo-history.js`); the function bodies are unchanged, so behavior is identical. Net `view.js` diff is −192 lines.
* `write.php` registers the two new script modules and adds them as dependencies of `wpcom-write/view` (and to the cache-busting version).
* The package `test` script now runs the whole `test/` directory instead of a single file.

Both new modules land at **100% statement / branch / function coverage** (56 new tests). This won't silence the bot on changes to the un-extractable parts of `view.js` (event handlers, the Interactivity store), but it stops the "0% baseline" and gives future pure logic a tested home.

## Related product discussion/links

* RSM-4353

## Does this pull request change what data or activity we track or use?

No. Pure refactor — the extracted functions (including the `describeSaveError` Tracks-descriptor helper) are moved verbatim; no telemetry behavior changes.

This is a behavior-preserving refactor, so the goal of testing is to confirm (a) the extracted modules are correct and (b) `view.js` still loads and behaves identically through the new import map.

### 1. Automated tests

* `jp test js packages/jetpack-mu-wpcom` → **67 pass / 0 fail** (11 existing `undo-history` + 56 new).
* Coverage of the extracted modules:
  ```
  cd projects/packages/jetpack-mu-wpcom
  npx c8 --include='src/features/write/image-format.js' \
         --include='src/features/write/text-helpers.js' \
         node --test 'src/features/write/test/*.test.mjs'
  ```
  → **100%** statements/branches/functions on both `image-format.js` and `text-helpers.js`.

### 2. The editor still loads (the one real risk)

Because `view.js` is served as a raw WP Script Module, a broken import map would stop the whole editor from initializing. Confirm it doesn't:

1. Log in and open **Write**: `wp-admin/admin.php?page=write`.
2. The editor UI renders (title field, content area, formatting toolbar) and there are **no module-load errors** in the browser console.
3. In the console, confirm the import map lists the two new modules:
   ```js
   JSON.parse( document.querySelector('script[type="importmap"]').textContent )
     .imports // → includes "wpcom-write/image-format" and "wpcom-write/text-helpers"
   ```

### 3. Exercise the extracted code paths end-to-end

Each step below runs through a helper that now lives in a new module:

* **Markdown list shortcut** (`parseMarkdownListShortcut`): on an empty line type `-` then a space → converts to a bulleted list. Repeat with `1. ` → numbered list.
* **Markdown quote shortcut** (`parseMarkdownQuoteShortcut`): on an empty line type `>` then a space → converts to a blockquote.
* **Image size + alignment** (`getMediaIdFromImg`, `setFigureSize`, `setFigureAlignment`, `getFigureAlignment`): insert an image from the media library, open its properties, change the **size** and the **alignment** (left/center/right) → the figure updates and the panel reflects the current alignment. The media grid thumbnails rendering exercises `libraryThumbUrl`.
* **Text color** (`rgbToHex`): select some text, apply a text color, then save and reopen (or check the serialized block) → the color persists as a `<mark class="has-inline-color">` with a hex value.
* **Paste sanitization** (`isSafePasteHref`): paste rich content containing a normal `https://` link (kept) — a `javascript:`-scheme link would be stripped.
* **Video embed** (`getEmbedUrl`): use the embed flow with a YouTube or Vimeo URL → it embeds; a non-video URL does not.
* **Post picker** (`parsePostId`): in the internal-link/post-picker field, enter a bare numeric post ID → it resolves to that post.
* **Save/publish + error descriptor** (`describeSaveError`): save a draft and publish a post → both succeed and (on publish) redirect to the permalink. `describeSaveError` only surfaces on the failure path (it feeds the `wpcom_write_editor_save_failed` Tracks event), so no telemetry behavior changes here.
