### PR TITLE
Update CODEOWNERS for performance and Premium Analytics

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,14 +51,14 @@
 
 # Tools owned by specific teams
 
-/tools/performance @Automattic/Zap
+/tools/performance @LiamSarsfield @anomiex
 
 # Actions
 
 /projects/github-actions/repo-gardening/ @jeherve
 
 # Packages
-/projects/packages/premium-analytics @Automattic/red @Automattic/ventures
+/projects/packages/premium-analytics @chihsuan @kangzj
 /projects/packages/search/src/wpes @Automattic/prometheus
 /projects/packages/connection/src @Automattic/jetpack-connection
 /projects/packages/connection/legacy @Automattic/jetpack-connection
@@ -70,7 +70,7 @@
 
 # Plugins
 
-/projects/plugins/premium-analytics @Automattic/red @Automattic/ventures
+/projects/plugins/premium-analytics @chihsuan @kangzj
 
 # Functionality that is important to our partners
 /projects/plugins/jetpack/class.jetpack-cli.php @Automattic/jetpack-infinity

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,14 +51,14 @@
 
 # Tools owned by specific teams
 
-/tools/performance @LiamSarsfield @anomiex
+/tools/performance @Automattic/jetpack-performance 
 
 # Actions
 
 /projects/github-actions/repo-gardening/ @jeherve
 
 # Packages
-/projects/packages/premium-analytics @chihsuan @kangzj
+/projects/packages/premium-analytics @Automattic/jetpack-stats 
 /projects/packages/search/src/wpes @Automattic/prometheus
 /projects/packages/connection/src @Automattic/jetpack-connection
 /projects/packages/connection/legacy @Automattic/jetpack-connection
@@ -70,7 +70,7 @@
 
 # Plugins
 
-/projects/plugins/premium-analytics @chihsuan @kangzj
+/projects/plugins/premium-analytics @Automattic/jetpack-stats 
 
 # Functionality that is important to our partners
 /projects/plugins/jetpack/class.jetpack-cli.php @Automattic/jetpack-infinity


### PR DESCRIPTION
Fixes #

## Proposed changes

* Replace `@Automattic/Zap` with `@Automattic/jetpack-performance` for `/tools/performance`.
* Replace `@Automattic/red` and `@Automattic/ventures` with `@Automattic/jetpack-stats` for both Premium Analytics projects:
  * `/projects/packages/premium-analytics`
  * `/projects/plugins/premium-analytics`
* Keep the existing path patterns unchanged because they already cover the intended subtrees and override broader monorepo ownership rules.

This moves the affected paths away from disbanded Matticspace-aligned teams and onto feature-specific GitHub teams whose membership can be maintained without changing CODEOWNERS rules.

## Related product discussion/links

* Jetpack team-disband audit.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Confirm `/tools/performance` is owned by `@Automattic/jetpack-performance`.
* Confirm both Premium Analytics paths are owned by `@Automattic/jetpack-stats`.
* Confirm the previous `@Automattic/Zap`, `@Automattic/red`, and `@Automattic/ventures` assignments are absent from those rules.
* Confirm GitHub reports no CODEOWNERS errors for this branch.

*\*left by Biff (AI agent) on behalf of Darren*
