### PR TITLE
Forms: add site ID and Jetpack version to the email open Tracks event

### DIFF
--- a/projects/packages/forms/changelog/forms-742-email-open-tracks-props
+++ b/projects/packages/forms/changelog/forms-742-email-open-tracks-props
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Add the site ID and Jetpack version to the response email open tracking event.

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -7,6 +7,7 @@
 
 namespace Automattic\Jetpack\Forms\ContactForm;
 
+use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Forms\Dashboard\Dashboard as Forms_Dashboard;
 use Automattic\Jetpack\Forms\Jetpack_Forms;
 use Jetpack_Tracks_Event;
@@ -614,13 +615,21 @@ class Feedback_Email_Renderer {
 
 		// The hash is just used to anonymize the admin email and have a unique identifier for the event.
 		// The secret key used could have been a random string, but it's better to use the version number to make it easier to track.
-		$event = new Jetpack_Tracks_Event(
-			(object) array(
-				'_en' => 'jetpack_forms_email_open',
-				'_ui' => hash_hmac( 'md5', get_option( 'admin_email' ), JETPACK__VERSION ),
-				'_ut' => 'anon',
-			)
+		$event_props = array(
+			'_en'             => 'jetpack_forms_email_open',
+			'_ui'             => hash_hmac( 'md5', get_option( 'admin_email' ), JETPACK__VERSION ),
+			'_ut'             => 'anon',
+			'jetpack_version' => JETPACK__VERSION,
 		);
+
+		// Only send the site ID when the site is connected. Sending an empty value would have Tracks
+		// record `blogid` as a string, which makes the property unusable for analysis.
+		$blog_id = Manager::get_site_id( true );
+		if ( $blog_id ) {
+			$event_props['blogid'] = $blog_id;
+		}
+
+		$event = new Jetpack_Tracks_Event( (object) $event_props );
 
 		$tracking_pixel = '<img src="' . $event->build_pixel_url() . '" alt="" width="1" height="1" />';
 


### PR DESCRIPTION
Fixes FORMS-742

## Proposed changes

The `jetpack_forms_email_open` Tracks pixel embedded in form response notification emails was firing with no site context and no event properties at all — just an anonymous user id and the event name. That makes the event impossible to segment: you can count opens globally, but you can't tell which site an open came from, or which Jetpack version produced the email.

* Send `blogid` (the connected site's WP.com blog ID) so opens land in a site context. `blogid` is the reserved Tracks field, so this populates the standard blog dimension rather than a custom property.
* Send `jetpack_version`, matching the property name every other Jetpack Tracks event uses (`Automattic\Jetpack\Connection\Tracking::record_user_event`), so version-over-version comparisons work without a special case.
* Only attach `blogid` when the site is actually connected. `Manager::get_site_id( true )` returns `null` on a disconnected site, and passing that through `http_build_query()` would emit a bare `blogid=`, which Tracks records as an empty string and permanently types the field as a string.

The user identity is unchanged: the pixel still reports `_ut => 'anon'` with an HMAC of the admin email. Note that the HMAC key is `JETPACK__VERSION`, so the anon id rotates on every Jetpack release and can't be followed over time — worth a separate look, but out of scope here.

## Related product discussion/links

* FORMS-742

## Does this pull request change what data or activity we track or use?

Yes — this adds two properties to an existing Tracks event that already fires today.

* `blogid`: the WP.com blog ID of the connected site that sent the notification email. Only sent when the site is Jetpack-connected. This is the same site identifier already attached to every other Jetpack Tracks event.
* `jetpack_version`: the Jetpack version string that rendered the email. Not user data.

No new personal data is collected, and no new event is introduced. The pixel's user identity is unchanged (still anonymous). Tracks recording remains gated on ToS agreement / `tk_opt-out` via `Jetpack_Tracks_Client`.

## Testing instructions

This needs a **Jetpack-connected** site — `blogid` is intentionally omitted when disconnected.

1. On a connected site, publish a post or page containing a Jetpack Form. Make sure the form has an email notification recipient set.
2. Submit the form from the front end.
3. Open the notification email that arrives, and view its raw HTML source (in Gmail: "Show original"; or read it out of your mail log).
4. Find the 1×1 tracking pixel near the end of the body — a `https://pixel.wp.com/t.gif?...` URL.
5. Confirm the query string now contains:
   * `blogid=<your site's blog ID>` — should match `wp jetpack options get id` (or the `blog_id` shown in My Jetpack).
   * `jetpack_version=<version>` — e.g. `15.4-a.8`.
   * plus the pre-existing `_en=jetpack_forms_email_open`, `_ui=<hash>`, `_ut=anon`.

Disconnected check:

6. Disconnect Jetpack, submit the form again, and confirm the pixel URL has **no** `blogid` parameter at all (rather than an empty `blogid=`). `jetpack_version` should still be present.

### Verified on a live site

Jurassic Ninja site with this branch synced and Jetpack connected (`blog_id` 256599751):
https://frequent-sheep.jurassic.ninja/?auto_login — it already has a **FORMS-742 Test Form**
page, and an mu-plugin that logs outgoing `wp_mail()` payloads to `/tmp/jn-mail.log`.

A real front-end submission produced a feedback entry, and the resulting notification email
body contained:

```
https://pixel.wp.com/t.gif?_en=jetpack_forms_email_open&_ui=f410ce7b89db37963eaa4b16093b3df2&_ut=anon&jetpack_version=16.1-beta&blogid=256599751&browser_type=php-agent&_aua=tracks-client-v0.3&_ts=1786035794438
```

`blogid` matches `wp jetpack options get id` (256599751).

Simulating a disconnected site (`Manager::get_site_id( true )` returning `null`) produces a
pixel with no `blogid` parameter at all — not an empty one:

```
https://pixel.wp.com/t.gif?_en=jetpack_forms_email_open&_ui=f410ce7b89db37963eaa4b16093b3df2&_ut=anon&jetpack_version=16.1-beta&browser_type=php-agent&_aua=tracks-client-v0.3&_ts=1786035723848
```

`jetpack phan packages/forms` is clean. `jetpack test php packages/forms` has one failure,
`Form_Webhooks_Test::test_send_webhooks_blocks_localhost_hostname`, which reproduces
identically on unmodified trunk and is unrelated to this change.
