### PR TITLE
Top Posts & Pages: only process as many posts as we request from the Stats API

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-top-posts-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-top-posts-helper.php
@@ -14,9 +14,9 @@ class Jetpack_Top_Posts_Helper {
 	/**
 	 * Returns user's top posts.
 	 *
-	 * @param int    $period       Period of days to draw stats from.
-	 * @param int    $items_count  Optional. Number of items to display.
-	 * @param string $types        Optional. Content types to include.
+	 * @param int|string $period      Period of days to draw stats from, or 'all-time'.
+	 * @param int        $items_count Optional. Number of items to display.
+	 * @param string     $types       Optional. Content types to include.
 	 * @return array
 	 */
 	public static function get_top_posts( $period, $items_count = null, $types = null ) {

--- a/projects/plugins/jetpack/_inc/lib/class-jetpack-top-posts-helper.php
+++ b/projects/plugins/jetpack/_inc/lib/class-jetpack-top-posts-helper.php
@@ -56,15 +56,41 @@ class Jetpack_Top_Posts_Helper {
 			$data = array( 'summary' => array( 'postviews' => array() ) );
 		}
 
-		// Remove posts that have subsequently been deleted.
-		$data['summary']['postviews'] = array_filter(
-			$data['summary']['postviews'],
-			function ( $item ) {
-				return get_post_status( $item['id'] ) === 'publish';
-			}
-		);
+		$acceptable_types = $is_rendering_block ? explode( ',', $types ) : array();
 
-		$posts_retrieved = is_countable( $data['summary']['postviews'] ) ? count( $data['summary']['postviews'] ) : 0;
+		// Remove posts that have subsequently been deleted. The endpoint can return more
+		// entries than the `max` we asked for, so stop there, then keep only further ones
+		// the block can render, so its type filter is never starved.
+		$published  = array();
+		$renderable = 0;
+
+		foreach ( (array) ( $data['summary']['postviews'] ?? array() ) as $item ) {
+			$capped = $is_rendering_block && count( $published ) >= $posts_to_obtain_count;
+
+			if ( $capped && $renderable >= $items_count ) {
+				break;
+			}
+			if ( get_post_status( $item['id'] ) !== 'publish' ) {
+				continue;
+			}
+
+			$can_render = $is_rendering_block
+				&& ! empty( $item['public'] )
+				&& in_array( $item['type'] ?? '', $acceptable_types, true );
+
+			if ( $capped && ! $can_render ) {
+				continue;
+			}
+
+			$published[] = $item;
+
+			if ( $can_render ) {
+				++$renderable;
+			}
+		}
+
+		$data['summary']['postviews'] = $published;
+		$posts_retrieved              = count( $published );
 
 		// Fallback to random posts if user does not have enough top content.
 		if ( $posts_retrieved < $posts_to_obtain_count ) {
@@ -96,6 +122,11 @@ class Jetpack_Top_Posts_Helper {
 		$top_posts = array();
 
 		foreach ( $data['summary']['postviews'] as $post ) {
+			// Non-public entries are discarded, so skip their thumbnail lookups entirely.
+			if ( empty( $post['public'] ) ) {
+				continue;
+			}
+
 			$post_id   = $post['id'];
 			$thumbnail = get_the_post_thumbnail_url( $post_id );
 
@@ -107,44 +138,40 @@ class Jetpack_Top_Posts_Helper {
 				}
 			}
 
-			if ( $post['public'] ) {
-				$top_post = array(
-					'id'        => $post_id,
-					'author'    => get_the_author_meta( 'display_name', get_post_field( 'post_author', $post_id ) ),
-					'context'   => get_the_category( $post_id ) ? get_the_category( $post_id ) : get_the_tags( $post_id ),
-					// Use the local permalink to avoid stale values from the Stats API.
-					'href'      => get_permalink( $post_id ),
-					'date'      => get_the_date( '', $post_id ),
-					'title'     => $post['title'],
-					'type'      => $post['type'],
-					'public'    => $post['public'],
-					'views'     => $post['views'] ?? 0,
-					'thumbnail' => $thumbnail,
-				);
+			$top_post = array(
+				'id'        => $post_id,
+				'author'    => get_the_author_meta( 'display_name', get_post_field( 'post_author', $post_id ) ),
+				'context'   => get_the_category( $post_id ) ? get_the_category( $post_id ) : get_the_tags( $post_id ),
+				// Use the local permalink to avoid stale values from the Stats API.
+				'href'      => get_permalink( $post_id ),
+				'date'      => get_the_date( '', $post_id ),
+				'title'     => $post['title'],
+				'type'      => $post['type'] ?? '',
+				'public'    => $post['public'],
+				'views'     => $post['views'] ?? 0,
+				'thumbnail' => $thumbnail,
+			);
 
-				/**
-				 * Allows modifying the title of each individual post returned by the Top Posts helper.
-				 *
-				 * Applies to both the Top Posts block's front-end output and the REST
-				 * response used by the block editor preview.
-				 *
-				 * @module stats
-				 *
-				 * @since 15.8
-				 *
-				 * @param string $post_title Post title.
-				 * @param array  $top_post   Information about the post.
-				 */
-				$top_post['title'] = apply_filters( 'jetpack_top_posts_item_title', $top_post['title'], $top_post );
+			/**
+			 * Allows modifying the title of each individual post returned by the Top Posts helper.
+			 *
+			 * Applies to both the Top Posts block's front-end output and the REST
+			 * response used by the block editor preview.
+			 *
+			 * @module stats
+			 *
+			 * @since 15.8
+			 *
+			 * @param string $post_title Post title.
+			 * @param array  $top_post   Information about the post.
+			 */
+			$top_post['title'] = apply_filters( 'jetpack_top_posts_item_title', $top_post['title'], $top_post );
 
-				$top_posts[] = $top_post;
-			}
+			$top_posts[] = $top_post;
 		}
 
 		// This applies for rendering the block front-end, but not for editing it.
 		if ( $is_rendering_block ) {
-			$acceptable_types = explode( ',', $types );
-
 			$top_posts = array_filter(
 				$top_posts,
 				function ( $item ) use ( $acceptable_types ) {

--- a/projects/plugins/jetpack/changelog/fix-top-posts-cap-stats-entries
+++ b/projects/plugins/jetpack/changelog/fix-top-posts-cap-stats-entries
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Top Posts & Pages: only process as many posts as were requested from the Stats API, cutting post and metadata lookups when rendering the block without changing which posts it shows.

--- a/projects/plugins/jetpack/changelog/fix-top-posts-cap-stats-entries
+++ b/projects/plugins/jetpack/changelog/fix-top-posts-cap-stats-entries
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Top Posts & Pages: only process as many posts as were requested from the Stats API, cutting post and metadata lookups when rendering the block without changing which posts it shows.
+Top Posts & Pages: Only process as many posts as requested from the Stats API, cutting post and metadata lookups when rendering the block without changing which posts it shows.

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Top_Posts_Helper_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Top_Posts_Helper_Test.php
@@ -181,7 +181,12 @@ class Jetpack_Top_Posts_Helper_Test extends WP_UnitTestCase {
 	 * should not consume the cap.
 	 */
 	public function test_get_top_posts_looks_past_the_cap_for_renderable_entries() {
-		$this->fake_stats_response( array( 'page' => 40, 'post' => 3 ) );
+		$this->fake_stats_response(
+			array(
+				'page' => 40,
+				'post' => 3,
+			)
+		);
 
 		$top_posts = Jetpack_Top_Posts_Helper::get_top_posts( '7', 3, 'post' );
 

--- a/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Top_Posts_Helper_Test.php
+++ b/projects/plugins/jetpack/tests/php/_inc/lib/Jetpack_Top_Posts_Helper_Test.php
@@ -1,0 +1,201 @@
+<?php
+/**
+ * Top Posts Helper unit tests.
+ *
+ * @package automattic/jetpack
+ */
+
+use Automattic\Jetpack\Stats\WPCOM_Stats;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+require_once JETPACK__PLUGIN_DIR . '/_inc/lib/class-jetpack-top-posts-helper.php';
+
+/**
+ * Class for testing the Jetpack_Top_Posts_Helper class.
+ *
+ * @covers \Jetpack_Top_Posts_Helper
+ */
+#[CoversClass( Jetpack_Top_Posts_Helper::class )]
+class Jetpack_Top_Posts_Helper_Test extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Number of posts get_top_posts() asks the Stats API for (its $posts_to_obtain_count).
+	 */
+	const REQUESTED_MAX = 30;
+
+	/**
+	 * Blog ID the stats cache key is built from.
+	 */
+	const BLOG_ID = 1234;
+
+	/**
+	 * Post IDs listed in the faked Stats response.
+	 *
+	 * @var int[]
+	 */
+	private $post_ids = array();
+
+	/**
+	 * Post IDs whose metadata was read during the call.
+	 *
+	 * @var array<int,bool>
+	 */
+	private $meta_reads = array();
+
+	/**
+	 * Number of get_attached_media() calls made during the call.
+	 *
+	 * @var int
+	 */
+	private $attached_media_calls = 0;
+
+	/**
+	 * Publishes posts and primes the Stats cache with a response listing them.
+	 *
+	 * IDs must be real and published; get_top_posts() drops anything else. Priming the
+	 * transient keeps the test offline and matches the block's front-end path.
+	 *
+	 * @param array $spec Entry counts keyed by the stats `type`, in response order,
+	 *                    e.g. array( 'page' => 40, 'post' => 3 ).
+	 */
+	private function fake_stats_response( array $spec ) {
+		Jetpack_Options::update_option( 'id', self::BLOG_ID );
+		update_option( 'site_created_date', '2020-01-01 00:00:00' ); // Read unconditionally by get_top_posts().
+
+		$views     = array_sum( $spec ) * 10;
+		$postviews = array();
+
+		foreach ( $spec as $type => $count ) {
+			foreach ( self::factory()->post->create_many( $count ) as $post_id ) {
+				$this->post_ids[] = $post_id;
+				$postviews[]      = array(
+					'id'     => $post_id,
+					'title'  => 'Top post ' . $post_id,
+					'type'   => $type,
+					'public' => true,
+					'views'  => $views--,
+				);
+			}
+		}
+
+		$args = array(
+			'max'       => self::REQUESTED_MAX,
+			'summarize' => true,
+			'num'       => '7',
+			'period'    => 'day',
+		);
+		$key  = md5(
+			implode(
+				'|',
+				array(
+					sprintf( '/sites/%d/stats/top-posts', self::BLOG_ID ),
+					WPCOM_Stats::STATS_REST_API_VERSION,
+					wp_json_encode( $args, JSON_UNESCAPED_SLASHES ),
+				)
+			)
+		);
+
+		set_transient(
+			WPCOM_Stats::STATS_CACHE_TRANSIENT_PREFIX . $key,
+			array( time() => wp_json_encode( array( 'summary' => array( 'postviews' => $postviews ) ), JSON_UNESCAPED_SLASHES ) ),
+			MINUTE_IN_SECONDS
+		);
+
+		// The key above is rebuilt by hand. If it ever stops matching, the helper falls
+		// back to random posts rather than erroring, so fail loudly instead of silently
+		// testing the fallback. This filter only runs on a cache miss.
+		add_filter(
+			'jetpack_fetch_stats_cache_expiration',
+			function () {
+				$this->fail( 'The primed Stats transient was missed; the cache key is stale.' );
+			}
+		);
+
+		add_filter(
+			'get_post_metadata',
+			function ( $value, $object_id ) {
+				$this->meta_reads[ $object_id ] = true;
+				return $value;
+			},
+			10,
+			2
+		);
+		add_filter(
+			'get_attached_media_args',
+			function ( $args_in ) {
+				++$this->attached_media_calls;
+				return $args_in;
+			}
+		);
+	}
+
+	/**
+	 * How many of the faked posts had their metadata read.
+	 *
+	 * @return int
+	 */
+	private function processed_count() {
+		return count( array_intersect( array_keys( $this->meta_reads ), $this->post_ids ) );
+	}
+
+	/**
+	 * The Stats API can return more posts than the `max` we ask for; get_top_posts() must
+	 * not do per-post work for any of the surplus.
+	 */
+	public function test_get_top_posts_caps_work_at_requested_max() {
+		$this->fake_stats_response( array( 'post' => 100 ) );
+
+		$top_posts = Jetpack_Top_Posts_Helper::get_top_posts( '7', 3, 'post' );
+
+		$this->assertCount( 3, $top_posts );
+		$this->assertSame( self::REQUESTED_MAX, $this->processed_count(), 'Processed the wrong number of posts.' );
+		$this->assertSame( self::REQUESTED_MAX, $this->attached_media_calls, 'Ran the wrong number of attachment queries.' );
+	}
+
+	/**
+	 * Capping the work must not change what the block renders.
+	 */
+	public function test_get_top_posts_returns_most_viewed_in_order() {
+		$this->fake_stats_response( array( 'post' => 100 ) );
+
+		$top_posts = Jetpack_Top_Posts_Helper::get_top_posts( '7', 5, 'post' );
+
+		$this->assertSame( array_slice( $this->post_ids, 0, 5 ), array_column( $top_posts, 'id' ) );
+	}
+
+	/**
+	 * A response smaller than the requested max must be left alone.
+	 */
+	public function test_get_top_posts_processes_short_response_in_full() {
+		$this->fake_stats_response( array( 'post' => 10 ) );
+
+		$top_posts = Jetpack_Top_Posts_Helper::get_top_posts( '7', 3, 'post' );
+
+		$this->assertSame( array_slice( $this->post_ids, 0, 3 ), array_column( $top_posts, 'id' ) );
+		$this->assertSame( 10, $this->processed_count() );
+	}
+
+	/**
+	 * Capping must not starve the block's post type filter: entries it cannot render
+	 * should not consume the cap.
+	 */
+	public function test_get_top_posts_looks_past_the_cap_for_renderable_entries() {
+		$this->fake_stats_response( array( 'page' => 40, 'post' => 3 ) );
+
+		$top_posts = Jetpack_Top_Posts_Helper::get_top_posts( '7', 3, 'post' );
+
+		$this->assertSame( array_slice( $this->post_ids, -3 ), array_column( $top_posts, 'id' ) );
+	}
+
+	/**
+	 * Looking past the cap must not do per-post work for the whole response when the
+	 * type filter can never be satisfied.
+	 */
+	public function test_get_top_posts_bounds_work_when_nothing_is_renderable() {
+		$this->fake_stats_response( array( 'page' => 100 ) );
+
+		$this->assertSame( array(), Jetpack_Top_Posts_Helper::get_top_posts( '7', 3, 'post' ) );
+		$this->assertSame( self::REQUESTED_MAX, $this->processed_count(), 'Did per-post work for the whole response.' );
+	}
+}


### PR DESCRIPTION
Fixes #

## Proposed changes

* `Jetpack_Top_Posts_Helper::get_top_posts()` requests `max => 30` from the Stats API, but the endpoint returns more than that when `summarize` is set. The helper processed every entry and only trimmed to `postsToShow` at the end. Each entry costs a `get_post_status()` lookup, a featured image, an author, a permalink, and an unbounded `get_attached_media()` query when the post has no thumbnail. On a large site, that's hundreds of post objects per uncached view to render a handful of items.
* Collection now stops at `max`. Past that point, it keeps only entries the block can render, so the cap can't leave the post type filter short.
* Non-public entries are skipped before the thumbnail lookups rather than after, since they're discarded either way.
* The editor preview filters by post type client-side, and the REST endpoint isn't told which types are selected, so that path stays uncapped.
* The `get_post_status()` sweep can still walk the whole response, either when fewer than `max` entries are published or while it's still looking for entries the block can render. That's unchanged. Only the per-post work (thumbnail, author, permalink, attachment query) is newly bounded.
* Tests cover the cap, the post type continuation, and the case where no entry is renderable.

## Related product discussion/links

* NPPM-2832

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Run the unit tests: `jetpack docker phpunit jetpack -- --filter Jetpack_Top_Posts_Helper_Test`. All pass.
2. On a site whose Stats API returns more than 30 top posts, add a Top Posts & Pages block set to show 3 items. The same posts render before and after this change.
3. Set the block to a single post type. It still fills, even when the highest-ranked entries are of the other type.
4. Open Query Monitor on that page. The block's per-post lookups no longer scale with the size of the Stats response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
