### PR TITLE
Playlist & Tabs blocks: add "Learn more" support links to descriptions

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/add-playlist-tabs-block-description-links
+++ b/projects/packages/jetpack-mu-wpcom/changelog/add-playlist-tabs-block-description-links
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add a "Learn more" support link to the Playlist and Tabs block descriptions.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/src/block-links-map.ts
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-block-description-links/src/block-links-map.ts
@@ -191,6 +191,14 @@ const blockInfoMapping: { [ key: string ]: { link: string; postId: number } } = 
 		link: 'https://wordpress.com/support/wordpress-editor/blocks/terms-query-block/',
 		postId: 423600,
 	},
+	'core/playlist': {
+		link: 'https://wordpress.com/support/wordpress-editor/blocks/playlist-block/',
+		postId: 445741,
+	},
+	'core/tabs': {
+		link: 'https://wordpress.com/support/wordpress-editor/blocks/tabs-block/',
+		postId: 445742,
+	},
 	'syntaxhighlighter/code': {
 		link: 'https://wordpress.com/support/wordpress-editor/blocks/syntax-highlighter-code-block/',
 		postId: 4743,


### PR DESCRIPTION
## Proposed changes

* Add the Playlist and Tabs blocks to the block description links map, so both show a "Learn more" link to their WordPress.com support doc in the block inspector.
* The links open in the Help Center and load localized versions where available, same as every other block in the map. Child blocks (playlist tracks, tabs) inherit the parent's link automatically.

## Related product discussion/links

* DOTCOM-18094, DOTCOM-18093

## Does this pull request change what data or activity we track or use?

No. The existing `jetpack_mu_wpcom_block_description_support_link_click` event already fires for every block in this map; these two blocks just become additional values of its existing `block` property.

## Testing instructions

* On a WordPress.com Simple or Atomic site, open the post or site editor.
* Insert a Playlist block, open the block inspector (settings sidebar), and confirm a "Learn more" link appears below the block description.
* Click it and confirm the Playlist block support doc opens inside the Help Center rather than a new tab.
* Repeat with the Tabs block.
* Switch your account/interface language to a locale with translated docs (e.g. Spanish) and confirm the localized article loads.
* Confirm the "Learn more" link only shows in the block inspector — searching for "Playlist" or "Tabs" in the block inserter should still show the plain description with no link.
