### PR TITLE
VideoPress: load the RTL dashboard shell stylesheet that the build actually emits

### DIFF
--- a/projects/packages/videopress/changelog/fix-videopress-rtl-dashboard-shell
+++ b/projects/packages/videopress/changelog/fix-videopress-rtl-dashboard-shell
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: fix the blank Library page on right-to-left locales caused by a missing RTL stylesheet.

--- a/projects/packages/videopress/src/class-admin-ui.php
+++ b/projects/packages/videopress/src/class-admin-ui.php
@@ -372,15 +372,23 @@ class Admin_UI {
 			// footer) regardless of whether it uses DashboardLayout. Without this,
 			// non-tabbed routes (e.g. Video details) would only get the layout
 			// after a sibling route's chunk happened to inject the same CSS.
-			$shell_css = dirname( __DIR__ ) . '/build/dashboard-shell/index.css';
-			if ( file_exists( $shell_css ) ) {
+			// Pick the flipped build ourselves on RTL locales rather than leaning on
+			// `wp_style_add_data( …, 'rtl', 'replace' )`: core resolves that by
+			// rewriting `index.css` to `index-rtl.css` (hyphenated) *and* dropping
+			// the LTR tag, but webpack emits the flipped file as `index.rtl.css`
+			// (dotted, the same convention `Assets::register_script()`'s `css_path`
+			// follows). The hyphenated file never exists, so RTL sites used to load
+			// no shell stylesheet at all — the layout flex chain never formed and
+			// the dashboard rendered as a blank page.
+			$shell_dir  = dirname( __DIR__ ) . '/build/dashboard-shell/';
+			$shell_file = is_rtl() && file_exists( $shell_dir . 'index.rtl.css' ) ? 'index.rtl.css' : 'index.css';
+			if ( file_exists( $shell_dir . $shell_file ) ) {
 				wp_register_style(
 					'jetpack-videopress-dashboard-shell',
-					plugins_url( 'build/dashboard-shell/index.css', __DIR__ ),
+					plugins_url( 'build/dashboard-shell/' . $shell_file, __DIR__ ),
 					array(),
-					(string) filemtime( $shell_css )
+					(string) filemtime( $shell_dir . $shell_file )
 				);
-				wp_style_add_data( 'jetpack-videopress-dashboard-shell', 'rtl', 'replace' );
 				wp_enqueue_style( 'jetpack-videopress-dashboard-shell' );
 			}
 


### PR DESCRIPTION
Fixes VIDP-349

## Proposed changes

The modernized VideoPress dashboard registers its page-level shell stylesheet and flags it for RTL with `wp_style_add_data( 'jetpack-videopress-dashboard-shell', 'rtl', 'replace' )`.

Core resolves `'replace'` by rewriting the href from `index.css` to `index-rtl.css` (hyphenated) **and** swapping out the LTR `<link>` entirely — see `WP_Styles::do_item()`. But webpack emits the flipped build as `build/dashboard-shell/index.rtl.css` (dotted), which is the convention `Assets::register_script()`'s `css_path` option already follows across the monorepo. The hyphenated file never exists, so on RTL locales the dashboard loaded **no** shell stylesheet at all — the `jetpack-admin-page-layout` flex chain never formed, `.jp-admin-page__page`'s `height: 100%` collapsed against auto-height ancestors, and the Library page rendered blank.

This drops the `wp_style_add_data()` call and resolves the flipped file in PHP instead: on `is_rtl()`, enqueue `index.rtl.css` when it exists, otherwise fall back to `index.css`. Same approach `Assets::register_script()` uses for its CSS companion, so the two stay consistent.

Worth noting the RTL build is a genuine flip, not just a duplicate — the layout mixin uses physical `left`/`right` offsets to position `#wpbody-content` against the admin sidebar, and rtlcss turns `left: 160px` into `right: 160px`. So this restores correct positioning too, not only a missing file.

The other `'rtl' => 'replace'` call sites in the monorepo (`grunion.css`, `grunion-editor-ui`) build through a Sass pipeline that does emit hyphenated `-rtl.css` files, so they're unaffected.

## Related product discussion/links

* VIDP-349
* 11530097-zen

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. On a site with the Jetpack plugin (or standalone Jetpack VideoPress) active and connected, go to **Settings → General** and set **Site Language** to an RTL locale — Arabic (`العربية`) is what the report used.
2. Go to **Jetpack → VideoPress → Library**.
3. **Before this change:** the page renders blank — no video list, no chrome. DevTools → Network shows `.../build/dashboard-shell/index-rtl.css` returning **404**.
4. **After this change:** the Library renders normally, mirrored for RTL. The Network tab shows `.../build/dashboard-shell/index.rtl.css` returning **200**, and there is no `index-rtl.css` request.
5. Switch the site language back to an LTR locale (e.g. English) and reload the Library — it should still load `index.css` and look exactly as it did before, with the fixed header, internally scrolling middle, and pinned footer intact.
6. Click through the other dashboard routes (Overview, Settings, a video's detail page) in both directions to confirm the shell layout applies everywhere.
