### PR TITLE
Likes: recover widgets stuck on "Loading…" via a readiness handshake

### DIFF
--- a/projects/plugins/jetpack/changelog/debug-likes-loading-issue
+++ b/projects/plugins/jetpack/changelog/debug-likes-loading-issue
@@ -1,4 +1,4 @@
 Significance: patch
 Type: bugfix
 
-Likes: fix Like buttons sometimes getting stuck on "Loading…" and never appearing.
+Likes: Fix Like buttons sometimes getting stuck on "Loading…" and never appearing.

--- a/projects/plugins/jetpack/changelog/debug-likes-loading-issue
+++ b/projects/plugins/jetpack/changelog/debug-likes-loading-issue
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Likes: fix Like buttons sometimes getting stuck on "Loading…" and never appearing.

--- a/projects/plugins/jetpack/modules/likes/queuehandler.js
+++ b/projects/plugins/jetpack/modules/likes/queuehandler.js
@@ -334,6 +334,12 @@ function JetpackLikesWidgetQueueHandler() {
 	var wrapperID;
 
 	if ( ! jetpackLikesMasterReady ) {
+		// The master iframe emits `masterReady` a single time, when it finishes loading. On
+		// script-heavy pages it can finish loading — and emit — before this script attaches its
+		// message listener above, so that one event is missed and the queue never starts. Ping the
+		// master iframe while we wait so it re-emits `masterReady` once both it and our listener
+		// are ready.
+		JetpackLikesPostMessage( { event: 'queryMasterReady' }, window.frames[ 'likes-master' ] );
 		setTimeout( JetpackLikesWidgetQueueHandler, 500 );
 		return;
 	}

--- a/projects/plugins/jetpack/modules/likes/test/queuehandler.test.js
+++ b/projects/plugins/jetpack/modules/likes/test/queuehandler.test.js
@@ -1,0 +1,76 @@
+/**
+ * Tests for the Likes queue handler <-> master iframe readiness handshake.
+ *
+ * @jest-environment jsdom
+ */
+
+describe( 'Likes queue handler master iframe handshake', () => {
+	let masterWindow;
+
+	// Collect only the `queryMasterReady` pings the queue handler posts to the master iframe.
+	const queryReadyPings = () =>
+		masterWindow.postMessage.mock.calls.filter( ( [ raw ] ) => {
+			try {
+				return JSON.parse( raw ).data.event === 'queryMasterReady';
+			} catch {
+				return false;
+			}
+		} );
+
+	const sendMasterReady = () =>
+		window.dispatchEvent(
+			new MessageEvent( 'message', {
+				data: JSON.stringify( {
+					type: 'likesMessage',
+					data: { event: 'masterReady' },
+				} ),
+				origin: 'https://widgets.wp.com',
+			} )
+		);
+
+	beforeEach( () => {
+		jest.useFakeTimers();
+		jest.resetModules();
+
+		document.body.innerHTML = '';
+
+		// The queue handler talks to the master iframe via window.frames['likes-master'].
+		const iframe = document.createElement( 'iframe' );
+		iframe.id = 'likes-master';
+		iframe.name = 'likes-master';
+		document.body.appendChild( iframe );
+
+		masterWindow = window.frames[ 'likes-master' ];
+		jest.spyOn( masterWindow, 'postMessage' ).mockImplementation( () => {} );
+	} );
+
+	afterEach( () => {
+		jest.runOnlyPendingTimers();
+		jest.useRealTimers();
+	} );
+
+	it( 'pings the master iframe with queryMasterReady while it waits for readiness', () => {
+		// Loading the script runs the queue handler once; the master hasn't reported ready yet.
+		require( '../queuehandler' );
+
+		expect( queryReadyPings().length ).toBeGreaterThanOrEqual( 1 );
+
+		// The poll keeps pinging on each tick, so a missed masterReady eventually gets answered.
+		const before = queryReadyPings().length;
+		jest.advanceTimersByTime( 500 );
+		expect( queryReadyPings().length ).toBeGreaterThan( before );
+	} );
+
+	it( 'stops pinging once the master iframe reports it is ready', async () => {
+		require( '../queuehandler' );
+
+		sendMasterReady();
+		// masterReady is handled after the internal document-ready promise resolves.
+		await Promise.resolve();
+
+		masterWindow.postMessage.mockClear();
+		jest.advanceTimersByTime( 2000 );
+
+		expect( queryReadyPings() ).toHaveLength( 0 );
+	} );
+} );

--- a/projects/plugins/jetpack/modules/likes/test/queuehandler.test.js
+++ b/projects/plugins/jetpack/modules/likes/test/queuehandler.test.js
@@ -1,17 +1,29 @@
 /**
  * Tests for the Likes queue handler <-> master iframe readiness handshake.
- *
- * @jest-environment jsdom
  */
 
 describe( 'Likes queue handler master iframe handshake', () => {
 	let masterWindow;
+	// Listeners the queue handler attaches to window on each require(). jest.resetModules() clears
+	// the module cache but leaves these attached, so we track and detach them between tests to stop
+	// a stale masterReady handler from firing against the current test's DOM.
+	let trackedWindowListeners;
 
 	// Collect only the `queryMasterReady` pings the queue handler posts to the master iframe.
 	const queryReadyPings = () =>
 		masterWindow.postMessage.mock.calls.filter( ( [ raw ] ) => {
 			try {
 				return JSON.parse( raw ).data.event === 'queryMasterReady';
+			} catch {
+				return false;
+			}
+		} );
+
+	// Collect the `initialBatch` requests the queue handler posts once it starts processing widgets.
+	const initialBatches = () =>
+		masterWindow.postMessage.mock.calls.filter( ( [ raw ] ) => {
+			try {
+				return JSON.parse( raw ).data.event === 'initialBatch';
 			} catch {
 				return false;
 			}
@@ -28,11 +40,52 @@ describe( 'Likes queue handler master iframe handshake', () => {
 			} )
 		);
 
+	// Simulate a master iframe that answers a `queryMasterReady` ping by (re-)emitting `masterReady`.
+	// This is the crux of the fix: a real master that missed nothing stays silent forever, so the
+	// queue only recovers because the ping prompts this reply. If the ping is removed, this master
+	// never speaks and the readiness-dependent assertions below fail.
+	const answerPingsWithMasterReady = () =>
+		masterWindow.postMessage.mockImplementation( raw => {
+			let event;
+			try {
+				event = JSON.parse( raw ).data.event;
+			} catch {
+				return;
+			}
+			if ( event === 'queryMasterReady' ) {
+				sendMasterReady();
+			}
+		} );
+
+	// Add an unloaded post-like widget so the queue has something to process once the master is ready.
+	const addUnloadedPostWidget = () => {
+		const widget = document.createElement( 'div' );
+		widget.id = 'like-post-wrapper-12345-678-abc123';
+		widget.className = 'jetpack-likes-widget-unloaded';
+		widget.dataset.src = 'https://widgets.wp.com/likes/#blog_id=12345&post_id=678';
+		widget.dataset.name = 'like-post-frame-12345-678-abc123';
+		widget.dataset.title = 'Like or Reblog';
+
+		const placeholder = document.createElement( 'div' );
+		placeholder.className = 'likes-widget-placeholder post-likes-widget-placeholder';
+		widget.appendChild( placeholder );
+
+		document.body.appendChild( widget );
+	};
+
 	beforeEach( () => {
 		jest.useFakeTimers();
 		jest.resetModules();
 
 		document.body.innerHTML = '';
+
+		// Record every window listener the queue handler adds so afterEach can detach them.
+		trackedWindowListeners = [];
+		const addEventListener = window.addEventListener.bind( window );
+		jest.spyOn( window, 'addEventListener' ).mockImplementation( ( type, listener, options ) => {
+			trackedWindowListeners.push( { type, listener, options } );
+			addEventListener( type, listener, options );
+		} );
 
 		// The queue handler talks to the master iframe via window.frames['likes-master'].
 		const iframe = document.createElement( 'iframe' );
@@ -47,6 +100,11 @@ describe( 'Likes queue handler master iframe handshake', () => {
 	afterEach( () => {
 		jest.runOnlyPendingTimers();
 		jest.useRealTimers();
+
+		trackedWindowListeners.forEach( ( { type, listener, options } ) =>
+			window.removeEventListener( type, listener, options )
+		);
+		jest.restoreAllMocks();
 	} );
 
 	it( 'pings the master iframe with queryMasterReady while it waits for readiness', () => {
@@ -64,13 +122,29 @@ describe( 'Likes queue handler master iframe handshake', () => {
 	it( 'stops pinging once the master iframe reports it is ready', async () => {
 		require( '../queuehandler' );
 
+		// It pings while it waits for readiness...
+		expect( queryReadyPings().length ).toBeGreaterThanOrEqual( 1 );
+
 		sendMasterReady();
 		// masterReady is handled after the internal document-ready promise resolves.
 		await Promise.resolve();
 
-		masterWindow.postMessage.mockClear();
+		// ...and stops pinging once the master is ready, even as the poll keeps ticking.
+		const pingsWhenReady = queryReadyPings().length;
 		jest.advanceTimersByTime( 2000 );
+		expect( queryReadyPings() ).toHaveLength( pingsWhenReady );
+	} );
 
-		expect( queryReadyPings() ).toHaveLength( 0 );
+	it( 'recovers a missed masterReady: the ping prompts the master to re-emit, and the queue starts', async () => {
+		addUnloadedPostWidget();
+		answerPingsWithMasterReady();
+
+		// Loading the script pings the master, which (only because of the ping) answers with
+		// masterReady; that reply is handled after the internal document-ready promise resolves.
+		require( '../queuehandler' );
+		await Promise.resolve();
+
+		// Recovery worked: the queue picked up the waiting widget and requested its data.
+		expect( initialBatches().length ).toBeGreaterThanOrEqual( 1 );
 	} );
 } );


### PR DESCRIPTION
Fixes #51036

## Proposed changes

Likes widgets can hang forever on the "Loading…" placeholder: the wrapper keeps `jetpack-likes-widget-unloaded`, and no widget iframe is ever created.

Here's what's happening. The master iframe (`widgets.wp.com/likes/master.html`) sends `masterReady` exactly once, on its `window` load event. The queue handler attaches its `message` listener as the script runs. On script-heavy pages, the iframe can finish loading (and send `masterReady`) before that listener exists, so the event is lost, `jetpackLikesMasterReady` never flips to `true`, and the queue poll spins silently forever. The previous queue handler had a fallback that hid this; the rewrite dropped it, and a change in `master.html` load timing made it show up.

* `modules/likes/queuehandler.js`: while it's waiting for readiness, ping the master iframe with a new `queryMasterReady` message on each poll tick. The master replies by sending `masterReady` again, so whichever side wins the race, the widget recovers within one poll interval (~500ms).
* Add a jsdom regression test for the ping-while-waiting behavior, and for the pinging stopping once the master reports ready.

> [!NOTE]
> One thing to flag: this PR isn't self-sufficient. The ping only helps once the master (`widgets.wp.com`) knows how to answer `queryMasterReady`. That companion change ships from the wpcom side and needs to deploy first. Jetpack on its own leaves already-stuck widgets stuck, so there's no regression, but there's no fix either until wpcom is out. The ping is a no-op against a master that doesn't recognize it, so it's safe either way.
> 232989-ghe-Automattic/wpcom

Of note: `queuehandler.js` is the source; the shipped file is `_inc/build/likes/queuehandler.min.js`, regenerated by the build. The test lives under `modules/likes/test/`, which is `production-exclude`d, so it won't ship in the released plugin.

## Related product discussion/links

* Reported in #51036.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This is a timing-dependent race, so it shows up most reliably on a script-heavy post page (player embeds, interactivity view modules) on a site with Likes enabled.

* Deploy the wpcom companion change first, so the master can answer `queryMasterReady`.
* Open a post with a Like block/widget that previously hung on "Loading…".
* Confirm the widget resolves and the Like button appears within ~0.5s, and that an `iframe.jetpack-likes-widget` is created (the wrapper loses `jetpack-likes-widget-unloaded`).
* Check that a normal, lighter page still loads Likes as before.
* Run the regression test: from `projects/plugins/jetpack`, `pnpm jest --config=tests/jest.config.client.js modules/likes/test/queuehandler.test.js`.