### PR TITLE
Connection: Report signing failures with correct codes and attribution

### DIFF
--- a/projects/packages/connection/changelog/update-connection-error-intake-fixes
+++ b/projects/packages/connection/changelog/update-connection-error-intake-fixes
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Report connection errors that happen while signing an outgoing request, record the specific reason the token could not be loaded, and store the request body hash with them.

--- a/projects/packages/connection/src/class-client.php
+++ b/projects/packages/connection/src/class-client.php
@@ -144,8 +144,8 @@ class Client {
 		}
 		if ( ! $token ) {
 			// `get_access_token()` explains itself for every case but one: it returns a bare
-			// `false` when the tokens are locked, so we report a generic code here.
-			return new WP_Error( 'missing_token' );
+			// `false` when the tokens are locked. That lock is one-shot and self-healing.
+			return new WP_Error( 'tokens_locked' );
 		}
 
 		$method = strtoupper( $args['method'] );

--- a/projects/packages/connection/src/class-client.php
+++ b/projects/packages/connection/src/class-client.php
@@ -39,15 +39,8 @@ class Client {
 			$args['url'] = apply_filters( 'jetpack_remote_request_url', $args['url'] );
 		}
 
-		$result = self::build_signed_request( $args, $body );
-		if ( is_wp_error( $result ) ) {
-			return $result;
-		}
-
-		$response = self::_wp_remote_request( $result['url'], $result['request'] );
-
-		// Feed the response into the outgoing-request error flow of Error_Handler: any known
-		// connection error in it is stored and surfaced to the user. See the Error_Handler
+		// Feed failures into the outgoing-request error flow of Error_Handler: any known
+		// connection error is stored and surfaced to the user. See the Error_Handler
 		// class docblock for the full picture of both error-handling flows.
 		// Outgoing XML-RPC calls (Jetpack_IXR_Client) are funneled through this method too;
 		// tell the transports apart by the endpoint the request targets.
@@ -57,6 +50,29 @@ class Client {
 		// it would fatal the request.
 		$request_path = (string) wp_parse_url( empty( $args['url'] ) ? '' : $args['url'], PHP_URL_PATH );
 		$error_type   = '/xmlrpc.php' === substr( $request_path, -strlen( '/xmlrpc.php' ) ) ? 'xmlrpc' : 'rest';
+
+		$result = self::build_signed_request( $args, $body );
+		if ( is_wp_error( $result ) ) {
+			// The request was never made, so it has no response to check. Report the signing
+			// failure directly. No token is available yet, so attribute the error to the
+			// connection owner (`true`).
+			$requesting_user_id = empty( $args['user_id'] ) ? 0 : $args['user_id'];
+			if ( true === $requesting_user_id ) {
+				$requesting_user_id = (int) \Jetpack_Options::get_option( 'master_user' );
+			}
+
+			Error_Handler::get_instance()->check_signed_request_for_errors(
+				$result,
+				empty( $args['url'] ) ? '' : $args['url'],
+				empty( $args['method'] ) ? 'POST' : $args['method'],
+				$error_type,
+				(int) $requesting_user_id
+			);
+
+			return $result;
+		}
+
+		$response = self::_wp_remote_request( $result['url'], $result['request'] );
 
 		Error_Handler::get_instance()->check_api_response_for_errors(
 			$response,
@@ -122,8 +138,19 @@ class Client {
 			$args['auth_location'] = 'query_string';
 		}
 
-		$token = ( new Tokens() )->get_access_token( $args['user_id'] );
+		// Return the specific reason the token could not be loaded instead of a bare `false`.
+		// Note the returned `WP_Error` is truthy, so this must not be tested with `! $token`.
+		$token = ( new Tokens() )->get_access_token(
+			$args['user_id'],
+			false, // token_key
+			false  // suppress_errors
+		);
+		if ( is_wp_error( $token ) ) {
+			return $token;
+		}
 		if ( ! $token ) {
+			// `get_access_token()` explains itself for every case but one: it returns a bare
+			// `false` when the tokens are locked, so we report a generic code here.
 			return new WP_Error( 'missing_token' );
 		}
 

--- a/projects/packages/connection/src/class-client.php
+++ b/projects/packages/connection/src/class-client.php
@@ -54,8 +54,7 @@ class Client {
 		$result = self::build_signed_request( $args, $body );
 		if ( is_wp_error( $result ) ) {
 			// The request was never made, so it has no response to check. Report the signing
-			// failure directly. No token is available yet, so attribute the error to the
-			// connection owner (`true`).
+			// failure, attributed to the caller's requested user (defaults to `0`, site-level).
 			$requesting_user_id = empty( $args['user_id'] ) ? 0 : $args['user_id'];
 			if ( true === $requesting_user_id ) {
 				$requesting_user_id = (int) \Jetpack_Options::get_option( 'master_user' );

--- a/projects/packages/connection/src/class-client.php
+++ b/projects/packages/connection/src/class-client.php
@@ -56,12 +56,16 @@ class Client {
 			// The request was never made, so it has no response to check. Report the signing
 			// failure; attribution comes from the error itself — see
 			// `Error_Handler::check_signed_request_for_errors()`.
-			Error_Handler::get_instance()->check_signed_request_for_errors(
-				$result,
-				empty( $args['url'] ) ? '' : $args['url'],
-				empty( $args['method'] ) ? 'POST' : $args['method'],
-				$error_type
-			);
+			// Reporting is best-effort and must never fatal a request running mid-plugin-update:
+			// skip it when the already-loaded Error_Handler is a stale version predating this method.
+			if ( method_exists( Error_Handler::class, 'check_signed_request_for_errors' ) ) {
+				Error_Handler::get_instance()->check_signed_request_for_errors(
+					$result,
+					empty( $args['url'] ) ? '' : $args['url'],
+					empty( $args['method'] ) ? 'POST' : $args['method'],
+					$error_type
+				);
+			}
 
 			return $result;
 		}

--- a/projects/packages/connection/src/class-client.php
+++ b/projects/packages/connection/src/class-client.php
@@ -54,18 +54,13 @@ class Client {
 		$result = self::build_signed_request( $args, $body );
 		if ( is_wp_error( $result ) ) {
 			// The request was never made, so it has no response to check. Report the signing
-			// failure, attributed to the caller's requested user (defaults to `0`, site-level).
-			$requesting_user_id = empty( $args['user_id'] ) ? 0 : $args['user_id'];
-			if ( true === $requesting_user_id ) {
-				$requesting_user_id = (int) \Jetpack_Options::get_option( 'master_user' );
-			}
-
+			// failure; attribution comes from the error itself — see
+			// `Error_Handler::check_signed_request_for_errors()`.
 			Error_Handler::get_instance()->check_signed_request_for_errors(
 				$result,
 				empty( $args['url'] ) ? '' : $args['url'],
 				empty( $args['method'] ) ? 'POST' : $args['method'],
-				$error_type,
-				(int) $requesting_user_id
+				$error_type
 			);
 
 			return $result;

--- a/projects/packages/connection/src/class-error-handler.php
+++ b/projects/packages/connection/src/class-error-handler.php
@@ -1600,7 +1600,8 @@ class Error_Handler {
 	 * Codes reaching this method include `missing_token`, `malformed_token` and
 	 * `invalid_body` (from `Client::build_signed_request()`), plus the signing errors
 	 * returned by `Jetpack_Signature::sign_request()` (e.g. `invalid_scheme`,
-	 * `unknown_scheme_port`).
+	 * `unknown_scheme_port`), plus the token-lookup errors raised by
+	 * `Tokens::get_access_token()` (e.g. `no_user_tokens`, `no_token_for_user`).
 	 *
 	 * This includes token lookup, request validation, and request signing errors.
 	 *
@@ -1610,14 +1611,10 @@ class Error_Handler {
 	 * @param string $url            Request URL.
 	 * @param string $method         Request method.
 	 * @param string $error_type     The transport of the outgoing request: `ERROR_TYPE_XMLRPC` or `ERROR_TYPE_REST`.
-	 * @param int    $user_id        The local user ID the request was signed for, or `0` for the blog token. Used
-	 *                               only as an attribution fallback — see `wp_error_to_array()` — for the errors
-	 *                               raised when no token could be found at all (e.g. `no_user_tokens`,
-	 *                               `token_malformed`), which therefore carry no real token to attribute by.
 	 *
 	 * @return void
 	 */
-	public function check_signed_request_for_errors( $signing_result, $url, $method, $error_type, $user_id = 0 ) {
+	public function check_signed_request_for_errors( $signing_result, $url, $method, $error_type ) {
 		if ( ! is_wp_error( $signing_result ) ) {
 			return;
 		}
@@ -1641,7 +1638,12 @@ class Error_Handler {
 			$signature_details,
 			$error_type,
 			self::DIRECTION_OUTGOING,
-			array( 'user_id' => $user_id )
+			// `Tokens::get_access_token()` attaches `user_id` to the WP_Errors it raises when it
+			// has already resolved one (see its docblock); pass it through as the attribution
+			// fallback consulted by `wp_error_to_array()`. Errors with no token to look up at all
+			// (e.g. `missing_token`, `malformed_token` from `Client` itself) carry no such data,
+			// and fall back to unattributed there.
+			array( 'user_id' => isset( $data['user_id'] ) ? (int) $data['user_id'] : 0 )
 		);
 
 		$this->report_error( $error, false, true );

--- a/projects/packages/connection/src/class-error-handler.php
+++ b/projects/packages/connection/src/class-error-handler.php
@@ -19,21 +19,25 @@ namespace Automattic\Jetpack\Connection;
  *    `Manager::verify_xml_rpc_signature()`, which reports it here. (Signed incoming REST
  *    requests are funneled into the same verification path by `REST_Authentication`.)
  * 2. Applies a gate to only process each error code once an hour to avoid overflow
- * 3. It stores the error on the database, but we don't know yet if this is a valid error, because
+ * 3. It stores the error in the database, but we don't know yet if this is a valid error, because
  *    we can't confirm it came from WP.com.
  * 4. It encrypts the error details and sends it to the wp.com server
  * 5. wp.com checks it and, if valid, sends a new request back to this site using the verify_xml_rpc_error REST endpoint
  * 6. This endpoint adds this error to the Verified errors in the database
  * 7. Triggers a workflow depending on the error (display user an error message, do some self healing, etc.)
  *
- * Flow 2 — outgoing request errors. Entry point: `check_api_response_for_errors()`.
+ * Flow 2 — outgoing request errors. Entry points: `check_api_response_for_errors()` and
+ * `check_signed_request_for_errors()`.
  *
  * 1. Every signed request made through `Client::remote_request()` has its response checked
- *    by `check_api_response_for_errors()`.
- * 2. When the response carries a known error code, the error is stored and immediately
- *    marked verified (the same hourly gate applies). The WP.com verification round-trip of
- *    flow 1 is skipped because the error arrived in a response to a request this site
- *    itself initiated and signed — the failed response is its own evidence.
+ *    by `check_api_response_for_errors()`. A request that could not be signed at all never
+ *    gets a response, so `Client::remote_request()` passes the signing failure to
+ *    `check_signed_request_for_errors()` instead.
+ * 2. When the response (or the signing failure) carries a known error code, the error is
+ *    stored and immediately marked verified (the same hourly gate applies). The WP.com
+ *    verification round-trip of flow 1 is skipped because the error arrived in a response to
+ *    a request this site itself initiated and signed — the failed response is its own
+ *    evidence — or, for signing failures, because the evidence is the site's own state.
  *
  * Stored errors carry two orthogonal classification fields:
  *
@@ -192,10 +196,12 @@ class Error_Handler {
 		'no_valid_user_token',       // The stored user token doesn't match the key the request was signed with.
 		'no_valid_blog_token',       // The stored blog token doesn't match the key the request was signed with.
 		'unknown_token',             // No stored token matches the request token's key.
+		'missing_token',             // No token could be loaded to sign an outgoing request (Client::build_signed_request).
 		// Signature verification problems (Jetpack_Signature), or errors WPCOM returned
 		// for an outbound request (Error_Handler::check_api_response_for_errors).
 		'could_not_sign',            // Signing the request failed for an unknown reason.
 		'invalid_scheme',            // Invalid URL scheme when signing.
+		'unknown_scheme_port',       // The URL scheme has no known port, so the signature cannot be built.
 		'invalid_secret',            // The stored token secret is invalid.
 		'invalid_token',             // No token available when signing; from WPCOM: the token used was rejected.
 		'token_mismatch',            // The request token doesn't match the token we hold.
@@ -1565,12 +1571,80 @@ class Error_Handler {
 				'token'     => empty( $auth_data['token'] ) ? '' : $auth_data['token'],
 				'timestamp' => empty( $auth_data['timestamp'] ) ? '' : $auth_data['timestamp'],
 				'nonce'     => empty( $auth_data['nonce'] ) ? '' : $auth_data['nonce'],
-				'body_hash' => empty( $auth_data['body_hash'] ) ? '' : $auth_data['body_hash'],
+				// `Client::build_signed_request()` builds this key as `body-hash` (it is sent as an
+				// `Authorization` header parameter). The snake_case fallback keeps callers that pass
+				// the stored `signature_details` shape working.
+				'body_hash' => $auth_data['body-hash'] ?? $auth_data['body_hash'] ?? '',
 				'method'    => $method,
 				'url'       => $url,
 			),
 			$error_type,
 			self::DIRECTION_OUTGOING
+		);
+
+		$this->report_error( $error, false, true );
+	}
+
+	/**
+	 * Check the result of signing an outgoing request for errors, and store them if needed.
+	 *
+	 * This is the second entry point of the outgoing-request error flow (flow 2 in the class
+	 * docblock). It handles failures from `Client::build_signed_request()`, which
+	 * occur before a request is sent and therefore have no response to inspect.
+	 *
+	 * Like response errors in flow 2, these are stored as verified without a WP.com
+	 * round-trip because the site's own token and URL state provides the evidence.
+	 * The hourly reporting gate in `report_error()` still applies.
+	 *
+	 * Codes reaching this method include `missing_token`, `malformed_token` and
+	 * `invalid_body` (from `Client::build_signed_request()`), plus the signing errors
+	 * returned by `Jetpack_Signature::sign_request()` (e.g. `invalid_scheme`,
+	 * `unknown_scheme_port`).
+	 *
+	 * This includes token lookup, request validation, and request signing errors.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param mixed  $signing_result The return value of `Client::build_signed_request()`. Ignored unless it is a `WP_Error`.
+	 * @param string $url            Request URL.
+	 * @param string $method         Request method.
+	 * @param string $error_type     The transport of the outgoing request: `ERROR_TYPE_XMLRPC` or `ERROR_TYPE_REST`.
+	 * @param int    $user_id        The local user ID the request was signed for, or `0` for the blog token. Used
+	 *                               only as an attribution fallback — see `wp_error_to_array()` — for the errors
+	 *                               raised when no token could be found at all (e.g. `no_user_tokens`,
+	 *                               `token_malformed`), which therefore carry no real token to attribute by.
+	 *
+	 * @return void
+	 */
+	public function check_signed_request_for_errors( $signing_result, $url, $method, $error_type, $user_id = 0 ) {
+		if ( ! is_wp_error( $signing_result ) ) {
+			return;
+		}
+
+		$data = $signing_result->get_error_data();
+
+		// The signing errors raised by `Jetpack_Signature` already carry the details of the
+		// request they failed to sign; the ones raised by `Client` itself carry nothing.
+		$signature_details = isset( $data['signature_details'] ) && is_array( $data['signature_details'] )
+			? $data['signature_details']
+			: array();
+
+		$signature_details += array(
+			'method' => $method,
+			'url'    => $url,
+		);
+
+		$message = $signing_result->get_error_message();
+
+		$error = self::build_connection_wp_error(
+			(string) $signing_result->get_error_code(),
+			// `build_error_array()` rejects an empty message, and several of these errors are
+			// raised without one.
+			'' === $message ? 'The request could not be signed.' : $message,
+			$signature_details,
+			$error_type,
+			self::DIRECTION_OUTGOING,
+			array( 'user_id' => $user_id )
 		);
 
 		$this->report_error( $error, false, true );

--- a/projects/packages/connection/src/class-error-handler.php
+++ b/projects/packages/connection/src/class-error-handler.php
@@ -305,9 +305,9 @@ class Error_Handler {
 		// (e.g. wpcomsh) can inject errors into an empty set.
 		if ( ! empty( $verified_errors ) ) {
 			// Only process error codes that are meant to be displayed to users.
-			// `no_user_tokens` is deliberately excluded: with an empty user_tokens option the
-			// site already behaves as site-only connected, and the connection UI prompts users
-			// to connect their accounts. The owner flavor is covered by `invalid_connection_owner`.
+			// `no_user_tokens` and `no_token_for_user` are deliberately excluded: both mean the
+			// targeted user simply never connected their WordPress.com account, which is expected.
+			// The owner flavor is covered by `invalid_connection_owner`.
 			$displayable_error_codes = array(
 				'malformed_token',
 				'token_malformed',
@@ -320,7 +320,6 @@ class Error_Handler {
 				'token_mismatch',
 				'invalid_signature',
 				'signature_mismatch',
-				'no_token_for_user',
 				'invalid_connection_owner',
 				'xmlrpc_request_blocked',
 			);
@@ -753,8 +752,13 @@ class Error_Handler {
 
 		$stored_errors = $this->get_stored_errors();
 		$error_array   = $this->wp_error_to_array( $error );
-		$error_code    = $error->get_error_code();
-		$user_id       = $error_array['user_id'];
+
+		if ( ! $error_array ) {
+			return false;
+		}
+
+		$error_code = $error->get_error_code();
+		$user_id    = $error_array['user_id'];
 
 		if ( ! isset( $stored_errors[ $error_code ] ) || ! is_array( $stored_errors[ $error_code ] ) ) {
 			$stored_errors[ $error_code ] = array();

--- a/projects/packages/connection/src/class-error-handler.php
+++ b/projects/packages/connection/src/class-error-handler.php
@@ -196,7 +196,6 @@ class Error_Handler {
 		'no_valid_user_token',       // The stored user token doesn't match the key the request was signed with.
 		'no_valid_blog_token',       // The stored blog token doesn't match the key the request was signed with.
 		'unknown_token',             // No stored token matches the request token's key.
-		'missing_token',             // No token could be loaded to sign an outgoing request (Client::build_signed_request).
 		// Signature verification problems (Jetpack_Signature), or errors WPCOM returned
 		// for an outbound request (Error_Handler::check_api_response_for_errors).
 		'could_not_sign',            // Signing the request failed for an unknown reason.
@@ -1597,11 +1596,13 @@ class Error_Handler {
 	 * round-trip because the site's own token and URL state provides the evidence.
 	 * The hourly reporting gate in `report_error()` still applies.
 	 *
-	 * Codes reaching this method include `missing_token`, `malformed_token` and
-	 * `invalid_body` (from `Client::build_signed_request()`), plus the signing errors
-	 * returned by `Jetpack_Signature::sign_request()` (e.g. `invalid_scheme`,
-	 * `unknown_scheme_port`), plus the token-lookup errors raised by
-	 * `Tokens::get_access_token()` (e.g. `no_user_tokens`, `no_token_for_user`).
+	 * Codes reaching this method include `malformed_token` and `invalid_body` (from
+	 * `Client::build_signed_request()`), plus the signing errors returned by
+	 * `Jetpack_Signature::sign_request()` (e.g. `invalid_scheme`, `unknown_scheme_port`),
+	 * plus the token-lookup errors raised by `Tokens::get_access_token()` (e.g.
+	 * `no_user_tokens`, `no_token_for_user`). `tokens_locked` also reaches here but is not
+	 * in `known_errors`, so `report_error()` silently discards it — see the comment on
+	 * `Client::build_signed_request()`'s `tokens_locked` branch for why.
 	 *
 	 * This includes token lookup, request validation, and request signing errors.
 	 *
@@ -1641,7 +1642,7 @@ class Error_Handler {
 			// `Tokens::get_access_token()` attaches `user_id` to the WP_Errors it raises when it
 			// has already resolved one (see its docblock); pass it through as the attribution
 			// fallback consulted by `wp_error_to_array()`. Errors with no token to look up at all
-			// (e.g. `missing_token`, `malformed_token` from `Client` itself) carry no such data,
+			// (e.g. `tokens_locked`, `malformed_token` from `Client` itself) carry no such data,
 			// and fall back to unattributed there.
 			array( 'user_id' => isset( $data['user_id'] ) ? (int) $data['user_id'] : 0 )
 		);

--- a/projects/packages/connection/src/class-error-handler.php
+++ b/projects/packages/connection/src/class-error-handler.php
@@ -946,7 +946,8 @@ class Error_Handler {
 	 * @since 8.9.0
 	 *
 	 * @param string $error_code        The error code, ideally one of `$known_errors`.
-	 * @param string $error_message     The human-readable error message.
+	 * @param string $error_message     The human-readable error message. `build_error_array()` rejects an
+	 *                                  empty message, so a generic fallback is substituted when this is ''.
 	 * @param array  $signature_details Details of the signed request that failed. See `build_connection_error_data()`.
 	 * @param string $error_type        One of the `ERROR_TYPE_*` constants.
 	 * @param string $error_direction   One of the `DIRECTION_*` constants, or '' for errors with no direction.
@@ -956,7 +957,7 @@ class Error_Handler {
 	public static function build_connection_wp_error( string $error_code, string $error_message, array $signature_details, string $error_type, string $error_direction, array $extra = array() ) {
 		return new \WP_Error(
 			$error_code,
-			$error_message,
+			'' === $error_message ? __( 'An error occurred with the connection.', 'jetpack-connection' ) : $error_message,
 			self::build_connection_error_data( $signature_details, $error_type, $error_direction, $extra )
 		);
 	}
@@ -1634,13 +1635,9 @@ class Error_Handler {
 			'url'    => $url,
 		);
 
-		$message = $signing_result->get_error_message();
-
 		$error = self::build_connection_wp_error(
 			(string) $signing_result->get_error_code(),
-			// `build_error_array()` rejects an empty message, and several of these errors are
-			// raised without one.
-			'' === $message ? 'The request could not be signed.' : $message,
+			$signing_result->get_error_message(),
 			$signature_details,
 			$error_type,
 			self::DIRECTION_OUTGOING,

--- a/projects/packages/connection/src/class-rest-authentication.php
+++ b/projects/packages/connection/src/class-rest-authentication.php
@@ -119,6 +119,9 @@ class Rest_Authentication {
 				return null;
 			}
 
+			// These `rest_invalid_request` errors occur before `verify_xml_rpc_signature()`,
+			// so the request has not been authenticated as WP.com. Do not report them to
+			// Error_Handler: they are malformed unauthenticated requests, not connection errors.
 			if ( ! isset( $_SERVER['REQUEST_METHOD'] ) ) {
 				$this->rest_authentication_status = new WP_Error(
 					'rest_invalid_request',

--- a/projects/packages/connection/src/class-tokens.php
+++ b/projects/packages/connection/src/class-tokens.php
@@ -377,15 +377,16 @@ class Tokens {
 		$user_tokens             = $this->get_user_tokens();
 
 		if ( $user_id ) {
+			$resolved_user_id = true === $user_id ? (int) Jetpack_Options::get_option( 'master_user' ) : (int) $user_id;
+
 			if ( ! $user_tokens ) {
-				$attributed_user_id = true === $user_id ? (int) Jetpack_Options::get_option( 'master_user' ) : (int) $user_id;
-				return $suppress_errors ? false : new WP_Error( 'no_user_tokens', __( 'No user tokens found', 'jetpack-connection' ), array( 'user_id' => $attributed_user_id ) );
+				return $suppress_errors ? false : new WP_Error( 'no_user_tokens', __( 'No user tokens found', 'jetpack-connection' ), array( 'user_id' => $resolved_user_id ) );
 			}
 			if ( true === $user_id ) { // connection owner.
-				$user_id = Jetpack_Options::get_option( 'master_user' );
-				if ( ! $user_id ) {
+				if ( ! $resolved_user_id ) {
 					return $suppress_errors ? false : new WP_Error( 'empty_master_user_option', __( 'No primary user defined', 'jetpack-connection' ) );
 				}
+				$user_id = $resolved_user_id;
 			}
 			if ( ! isset( $user_tokens[ $user_id ] ) || ! $user_tokens[ $user_id ] ) {
 				// translators: %s is the user ID.
@@ -456,7 +457,7 @@ class Tokens {
 		if ( ! $valid_token ) {
 			if ( $user_id ) {
 				// translators: %d is the user ID.
-				return $suppress_errors ? false : new WP_Error( 'no_valid_user_token', sprintf( __( 'Invalid token for user %d', 'jetpack-connection' ), $user_id ) );
+				return $suppress_errors ? false : new WP_Error( 'no_valid_user_token', sprintf( __( 'Invalid token for user %d', 'jetpack-connection' ), $user_id ), array( 'user_id' => (int) $user_id ) );
 			} else {
 				return $suppress_errors ? false : new WP_Error( 'no_valid_blog_token', __( 'Invalid blog token', 'jetpack-connection' ) );
 			}

--- a/projects/packages/connection/src/class-tokens.php
+++ b/projects/packages/connection/src/class-tokens.php
@@ -378,7 +378,8 @@ class Tokens {
 
 		if ( $user_id ) {
 			if ( ! $user_tokens ) {
-				return $suppress_errors ? false : new WP_Error( 'no_user_tokens', __( 'No user tokens found', 'jetpack-connection' ) );
+				$attributed_user_id = true === $user_id ? (int) Jetpack_Options::get_option( 'master_user' ) : (int) $user_id;
+				return $suppress_errors ? false : new WP_Error( 'no_user_tokens', __( 'No user tokens found', 'jetpack-connection' ), array( 'user_id' => $attributed_user_id ) );
 			}
 			if ( true === $user_id ) { // connection owner.
 				$user_id = Jetpack_Options::get_option( 'master_user' );
@@ -388,16 +389,16 @@ class Tokens {
 			}
 			if ( ! isset( $user_tokens[ $user_id ] ) || ! $user_tokens[ $user_id ] ) {
 				// translators: %s is the user ID.
-				return $suppress_errors ? false : new WP_Error( 'no_token_for_user', sprintf( __( 'No token for user %d', 'jetpack-connection' ), $user_id ) );
+				return $suppress_errors ? false : new WP_Error( 'no_token_for_user', sprintf( __( 'No token for user %d', 'jetpack-connection' ), $user_id ), array( 'user_id' => (int) $user_id ) );
 			}
 			$user_token_chunks = explode( '.', $user_tokens[ $user_id ] );
 			if ( empty( $user_token_chunks[1] ) || empty( $user_token_chunks[2] ) ) {
 				// translators: %s is the user ID.
-				return $suppress_errors ? false : new WP_Error( 'token_malformed', sprintf( __( 'Token for user %d is malformed', 'jetpack-connection' ), $user_id ) );
+				return $suppress_errors ? false : new WP_Error( 'token_malformed', sprintf( __( 'Token for user %d is malformed', 'jetpack-connection' ), $user_id ), array( 'user_id' => (int) $user_id ) );
 			}
 			if ( $user_token_chunks[2] !== (string) $user_id ) {
 				// translators: %1$d is the ID of the requested user. %2$d is the user ID found in the token.
-				return $suppress_errors ? false : new WP_Error( 'user_id_mismatch', sprintf( __( 'Requesting user_id %1$d does not match token user_id %2$d', 'jetpack-connection' ), $user_id, $user_token_chunks[2] ) );
+				return $suppress_errors ? false : new WP_Error( 'user_id_mismatch', sprintf( __( 'Requesting user_id %1$d does not match token user_id %2$d', 'jetpack-connection' ), $user_id, $user_token_chunks[2] ), array( 'user_id' => (int) $user_id ) );
 			}
 			$possible_normal_tokens[] = "{$user_token_chunks[0]}.{$user_token_chunks[1]}";
 		} else {

--- a/projects/packages/connection/tests/php/Error_Handler_Test.php
+++ b/projects/packages/connection/tests/php/Error_Handler_Test.php
@@ -461,6 +461,262 @@ class Error_Handler_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test that the body hash of the failed request is stored.
+	 */
+	public function test_check_api_response_for_errors_stores_body_hash() {
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+
+		$this->error_handler->check_api_response_for_errors(
+			array(
+				'response' => array(
+					'code' => 400,
+				),
+				'body'     => '{"error":"invalid_token","message":"The token is invalid."}',
+			),
+			array(
+				'token'     => 'broken:1:0',
+				'timestamp' => 1234567890,
+				'nonce'     => 'asd3d32d',
+				'body-hash' => 'dsf34frf',
+			),
+			'https://localhost/',
+			'POST',
+			'rest'
+		);
+
+		$stored_errors = $this->error_handler->get_stored_errors();
+
+		$this->assertSame( 'dsf34frf', $stored_errors['invalid_token']['0']['error_data']['body_hash'] );
+	}
+
+	/**
+	 * Test that the stored `signature_details` shape (`body_hash`) is still accepted.
+	 */
+	public function test_check_api_response_for_errors_accepts_snake_case_body_hash() {
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+
+		$this->error_handler->check_api_response_for_errors(
+			array(
+				'response' => array(
+					'code' => 400,
+				),
+				'body'     => '{"error":"invalid_token","message":"The token is invalid."}',
+			),
+			array(
+				'token'     => 'broken:1:0',
+				'body_hash' => 'dsf34frf',
+			),
+			'https://localhost/',
+			'POST',
+			'rest'
+		);
+
+		$stored_errors = $this->error_handler->get_stored_errors();
+
+		$this->assertSame( 'dsf34frf', $stored_errors['invalid_token']['0']['error_data']['body_hash'] );
+	}
+
+	/**
+	 * Test that a request that could not be signed is reported.
+	 *
+	 * These failures happen before the request is made, so they never reach
+	 * `check_api_response_for_errors()`.
+	 */
+	public function test_check_signed_request_for_errors_stores_signing_failure() {
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+
+		$this->error_handler->check_signed_request_for_errors(
+			new \WP_Error( 'missing_token' ),
+			'https://jetpack.wordpress.com/jetpack.token/1/',
+			'POST',
+			Error_Handler::ERROR_TYPE_REST
+		);
+
+		$stored_errors   = $this->error_handler->get_stored_errors();
+		$verified_errors = $this->error_handler->get_verified_errors();
+
+		$this->assertArrayHasKey( 'missing_token', $stored_errors );
+
+		// No token was found to attribute the error to a specific user, so it falls back to
+		// the caller's $user_id argument (defaulted to 0, the blog-token/site attribution).
+		$stored = $stored_errors['missing_token']['0'];
+
+		$this->assertSame( 'The request could not be signed.', $stored['error_message'] );
+		$this->assertSame( Error_Handler::ERROR_TYPE_REST, $stored['error_type'] );
+		$this->assertSame( Error_Handler::DIRECTION_OUTGOING, $stored['error_direction'] );
+		$this->assertSame( 'https://jetpack.wordpress.com/jetpack.token/1/', $stored['error_data']['url'] );
+		$this->assertSame( 'POST', $stored['error_data']['method'] );
+		$this->assertSame( '', $stored['error_data']['token'] );
+
+		// The evidence is local, so the error is verified without the WP.com round-trip.
+		$this->assertArrayHasKey( 'missing_token', $verified_errors );
+	}
+
+	/**
+	 * Test that the request details carried by a `Jetpack_Signature` error are preserved.
+	 */
+	public function test_check_signed_request_for_errors_keeps_signature_details() {
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+
+		$this->error_handler->check_signed_request_for_errors(
+			new \WP_Error(
+				'unknown_scheme_port',
+				"The scheme's port is unknown",
+				array(
+					'signature_details' => array(
+						'token'     => 'dhj938djh938d:1:5',
+						'timestamp' => 1234567890,
+						'nonce'     => 'asd3d32d',
+						'body_hash' => 'dsf34frf',
+						'url'       => 'gopher://localhost/',
+					),
+				)
+			),
+			'https://localhost/',
+			'POST',
+			Error_Handler::ERROR_TYPE_XMLRPC
+		);
+
+		$stored_errors = $this->error_handler->get_stored_errors();
+
+		$this->assertArrayHasKey( 'unknown_scheme_port', $stored_errors );
+
+		// The token in the signature details attributes the error to its user.
+		$stored = $stored_errors['unknown_scheme_port']['5'];
+
+		$this->assertSame( "The scheme's port is unknown", $stored['error_message'] );
+		$this->assertSame( Error_Handler::ERROR_TYPE_XMLRPC, $stored['error_type'] );
+		// The details of the request that failed to sign win over the caller's arguments.
+		$this->assertSame( 'gopher://localhost/', $stored['error_data']['url'] );
+		$this->assertSame( 'dsf34frf', $stored['error_data']['body_hash'] );
+		$this->assertSame( 'POST', $stored['error_data']['method'] );
+	}
+
+	/**
+	 * Test that an error with no token to attribute is stored under the caller-supplied
+	 * $user_id, rather than falling back to 'invalid'.
+	 */
+	public function test_check_signed_request_for_errors_attributes_to_the_given_user() {
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+
+		$this->error_handler->check_signed_request_for_errors(
+			new \WP_Error( 'no_user_tokens' ),
+			'https://localhost/',
+			'POST',
+			Error_Handler::ERROR_TYPE_REST,
+			42
+		);
+
+		$stored_errors = $this->error_handler->get_stored_errors();
+
+		$this->assertArrayHasKey( '42', $stored_errors['no_user_tokens'] );
+		$this->assertArrayNotHasKey( 'invalid', $stored_errors['no_user_tokens'] );
+	}
+
+	/**
+	 * Test that a successful signing result is ignored.
+	 */
+	public function test_check_signed_request_for_errors_ignores_success() {
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+
+		$this->error_handler->check_signed_request_for_errors(
+			array(
+				'url'     => 'https://localhost/',
+				'request' => array(),
+				'auth'    => array(),
+			),
+			'https://localhost/',
+			'POST',
+			Error_Handler::ERROR_TYPE_REST
+		);
+
+		$this->assertEmpty( $this->error_handler->get_stored_errors() );
+	}
+
+	/**
+	 * Test that a signing failure with an unknown error code is not stored.
+	 */
+	public function test_check_signed_request_for_errors_ignores_unknown_code() {
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+
+		$this->error_handler->check_signed_request_for_errors(
+			new \WP_Error( 'http_request_failed', 'cURL error 28' ),
+			'https://localhost/',
+			'POST',
+			Error_Handler::ERROR_TYPE_REST
+		);
+
+		$this->assertEmpty( $this->error_handler->get_stored_errors() );
+	}
+
+	/**
+	 * Test that signing failures go through the hourly reporting gate like every other error.
+	 */
+	public function test_check_signed_request_for_errors_respects_the_gate() {
+		// No gate-bypass filter here: this test is about the gate.
+		$this->error_handler->check_signed_request_for_errors(
+			new \WP_Error( 'missing_token' ),
+			'https://localhost/',
+			'POST',
+			Error_Handler::ERROR_TYPE_REST
+		);
+
+		$this->assertArrayHasKey( 'missing_token', $this->error_handler->get_stored_errors() );
+
+		$this->error_handler->delete_all_errors();
+
+		$this->error_handler->check_signed_request_for_errors(
+			new \WP_Error( 'missing_token' ),
+			'https://localhost/',
+			'POST',
+			Error_Handler::ERROR_TYPE_REST
+		);
+
+		$this->assertEmpty( $this->error_handler->get_stored_errors(), 'the gate should suppress a second report within the hour' );
+
+		delete_transient( Error_Handler::ERROR_REPORTING_GATE . 'missing_token' );
+	}
+
+	/**
+	 * Test that only displayable signing errors surface notices.
+	 * `missing_token` and `unknown_scheme_port` should not, even with valid attribution.
+	 */
+	public function test_signing_failures_are_not_displayable() {
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+
+		foreach ( array( 'missing_token', 'unknown_scheme_port' ) as $error_code ) {
+			$this->error_handler->check_signed_request_for_errors(
+				new \WP_Error( $error_code ),
+				'https://localhost/',
+				'POST',
+				Error_Handler::ERROR_TYPE_REST
+			);
+		}
+
+		$this->assertCount( 2, $this->error_handler->get_stored_errors() );
+		$this->assertEmpty( $this->error_handler->get_displayable_errors() );
+	}
+
+	/**
+	 * Test that a displayable signing error is shown once it has valid attribution.
+	 */
+	public function test_displayable_signing_failure_surfaces_a_notice() {
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+
+		$this->error_handler->check_signed_request_for_errors(
+			new \WP_Error( 'malformed_token' ),
+			'https://localhost/',
+			'POST',
+			Error_Handler::ERROR_TYPE_REST
+		);
+
+		$displayable = $this->error_handler->get_displayable_errors();
+
+		$this->assertArrayHasKey( 'malformed_token', $displayable );
+		$this->assertSame( 'site', $displayable['malformed_token']['0']['audience'] );
+	}
+
+	/**
 	 * Test storing errors
 	 */
 	public function test_delete_all_api_errors() {

--- a/projects/packages/connection/tests/php/Error_Handler_Test.php
+++ b/projects/packages/connection/tests/php/Error_Handler_Test.php
@@ -537,11 +537,12 @@ class Error_Handler_Test extends BaseTestCase {
 
 		$this->assertArrayHasKey( 'missing_token', $stored_errors );
 
-		// No token was found to attribute the error to a specific user, so it falls back to
-		// the caller's $user_id argument (defaulted to 0, the blog-token/site attribution).
+		// No token was found to attribute the error to a specific user, and the error carries
+		// no `user_id` of its own (`Client` raises `missing_token` with no data), so it falls
+		// back to 0, the blog-token/site attribution.
 		$stored = $stored_errors['missing_token']['0'];
 
-		$this->assertSame( 'The request could not be signed.', $stored['error_message'] );
+		$this->assertSame( 'An error occurred with the connection.', $stored['error_message'] );
 		$this->assertSame( Error_Handler::ERROR_TYPE_REST, $stored['error_type'] );
 		$this->assertSame( Error_Handler::DIRECTION_OUTGOING, $stored['error_direction'] );
 		$this->assertSame( 'https://jetpack.wordpress.com/jetpack.token/1/', $stored['error_data']['url'] );
@@ -593,18 +594,18 @@ class Error_Handler_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test that an error with no token to attribute is stored under the caller-supplied
-	 * $user_id, rather than falling back to 'invalid'.
+	 * Test that an error with no token to attribute is stored under the user_id carried in
+	 * the error's own data (as `Tokens::get_access_token()` attaches it), rather than
+	 * falling back to 'invalid'.
 	 */
 	public function test_check_signed_request_for_errors_attributes_to_the_given_user() {
 		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
 
 		$this->error_handler->check_signed_request_for_errors(
-			new \WP_Error( 'no_user_tokens' ),
+			new \WP_Error( 'no_user_tokens', '', array( 'user_id' => 42 ) ),
 			'https://localhost/',
 			'POST',
-			Error_Handler::ERROR_TYPE_REST,
-			42
+			Error_Handler::ERROR_TYPE_REST
 		);
 
 		$stored_errors = $this->error_handler->get_stored_errors();

--- a/projects/packages/connection/tests/php/Error_Handler_Test.php
+++ b/projects/packages/connection/tests/php/Error_Handler_Test.php
@@ -54,6 +54,8 @@ class Error_Handler_Test extends BaseTestCase {
 		// Reset viewer/owner state used by the audience-aware display tests.
 		wp_set_current_user( 0 );
 		\Jetpack_Options::delete_option( 'master_user' );
+
+		delete_transient( Error_Handler::ERROR_REPORTING_GATE . 'malformed_token' );
 	}
 
 	/**
@@ -674,8 +676,6 @@ class Error_Handler_Test extends BaseTestCase {
 		);
 
 		$this->assertEmpty( $this->error_handler->get_stored_errors(), 'the gate should suppress a second report within the hour' );
-
-		delete_transient( Error_Handler::ERROR_REPORTING_GATE . 'malformed_token' );
 	}
 
 	/**
@@ -2453,7 +2453,7 @@ class Error_Handler_Test extends BaseTestCase {
 		$verified_errors = array(
 			'invalid_token'       => array( '0' => $make_error( 'invalid_token', 0 ) ),
 			'no_valid_user_token' => array( '7' => $make_error( 'no_valid_user_token', 7 ) ),
-			'no_token_for_user'   => array( '3' => $make_error( 'no_token_for_user', 3 ) ),
+			'token_mismatch'      => array( '3' => $make_error( 'token_mismatch', 3 ) ),
 		);
 		update_option( Error_Handler::STORED_VERIFIED_ERRORS_OPTION, $verified_errors );
 
@@ -2461,7 +2461,7 @@ class Error_Handler_Test extends BaseTestCase {
 
 		$this->assertSame( 'site', $result['invalid_token']['0']['audience'], 'A blog-token error (user 0) is site-wide.' );
 		$this->assertSame( 'owner', $result['no_valid_user_token']['7']['audience'], "The connection owner's token error is owner-scoped." );
-		$this->assertSame( 'user', $result['no_token_for_user']['3']['audience'], "A non-owner user's token error is user-scoped." );
+		$this->assertSame( 'user', $result['token_mismatch']['3']['audience'], "A non-owner user's token error is user-scoped." );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/Error_Handler_Test.php
+++ b/projects/packages/connection/tests/php/Error_Handler_Test.php
@@ -526,7 +526,7 @@ class Error_Handler_Test extends BaseTestCase {
 		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
 
 		$this->error_handler->check_signed_request_for_errors(
-			new \WP_Error( 'missing_token' ),
+			new \WP_Error( 'malformed_token' ),
 			'https://jetpack.wordpress.com/jetpack.token/1/',
 			'POST',
 			Error_Handler::ERROR_TYPE_REST
@@ -535,12 +535,12 @@ class Error_Handler_Test extends BaseTestCase {
 		$stored_errors   = $this->error_handler->get_stored_errors();
 		$verified_errors = $this->error_handler->get_verified_errors();
 
-		$this->assertArrayHasKey( 'missing_token', $stored_errors );
+		$this->assertArrayHasKey( 'malformed_token', $stored_errors );
 
 		// No token was found to attribute the error to a specific user, and the error carries
-		// no `user_id` of its own (`Client` raises `missing_token` with no data), so it falls
+		// no `user_id` of its own (`Client` raises `malformed_token` with no data), so it falls
 		// back to 0, the blog-token/site attribution.
-		$stored = $stored_errors['missing_token']['0'];
+		$stored = $stored_errors['malformed_token']['0'];
 
 		$this->assertSame( 'An error occurred with the connection.', $stored['error_message'] );
 		$this->assertSame( Error_Handler::ERROR_TYPE_REST, $stored['error_type'] );
@@ -550,7 +550,7 @@ class Error_Handler_Test extends BaseTestCase {
 		$this->assertSame( '', $stored['error_data']['token'] );
 
 		// The evidence is local, so the error is verified without the WP.com round-trip.
-		$this->assertArrayHasKey( 'missing_token', $verified_errors );
+		$this->assertArrayHasKey( 'malformed_token', $verified_errors );
 	}
 
 	/**
@@ -656,18 +656,18 @@ class Error_Handler_Test extends BaseTestCase {
 	public function test_check_signed_request_for_errors_respects_the_gate() {
 		// No gate-bypass filter here: this test is about the gate.
 		$this->error_handler->check_signed_request_for_errors(
-			new \WP_Error( 'missing_token' ),
+			new \WP_Error( 'malformed_token' ),
 			'https://localhost/',
 			'POST',
 			Error_Handler::ERROR_TYPE_REST
 		);
 
-		$this->assertArrayHasKey( 'missing_token', $this->error_handler->get_stored_errors() );
+		$this->assertArrayHasKey( 'malformed_token', $this->error_handler->get_stored_errors() );
 
 		$this->error_handler->delete_all_errors();
 
 		$this->error_handler->check_signed_request_for_errors(
-			new \WP_Error( 'missing_token' ),
+			new \WP_Error( 'malformed_token' ),
 			'https://localhost/',
 			'POST',
 			Error_Handler::ERROR_TYPE_REST
@@ -675,17 +675,17 @@ class Error_Handler_Test extends BaseTestCase {
 
 		$this->assertEmpty( $this->error_handler->get_stored_errors(), 'the gate should suppress a second report within the hour' );
 
-		delete_transient( Error_Handler::ERROR_REPORTING_GATE . 'missing_token' );
+		delete_transient( Error_Handler::ERROR_REPORTING_GATE . 'malformed_token' );
 	}
 
 	/**
 	 * Test that only displayable signing errors surface notices.
-	 * `missing_token` and `unknown_scheme_port` should not, even with valid attribution.
+	 * `invalid_body` and `unknown_scheme_port` should not, even with valid attribution.
 	 */
 	public function test_signing_failures_are_not_displayable() {
 		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
 
-		foreach ( array( 'missing_token', 'unknown_scheme_port' ) as $error_code ) {
+		foreach ( array( 'invalid_body', 'unknown_scheme_port' ) as $error_code ) {
 			$this->error_handler->check_signed_request_for_errors(
 				new \WP_Error( $error_code ),
 				'https://localhost/',

--- a/projects/packages/connection/tests/php/Remote_Request_Test.php
+++ b/projects/packages/connection/tests/php/Remote_Request_Test.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Testing of the `Client` methods that build and make outgoing signed requests.
+ *
+ * Note the file name: this class must not sort ahead of the first test class in the suite.
+ * Several classes (ManagerIntegrationTest, ManagerTest, Jetpack_XMLRPC_Server_Test) depend on
+ * being preceded by a class that leaves `Manager`'s memoized connection status invalidatable,
+ * and displacing the first class breaks them.
+ *
+ * @package automattic/jetpack-connection
+ */
+
+namespace Automattic\Jetpack\Connection;
+
+use Automattic\Jetpack\Constants;
+use Jetpack_Options;
+use WorDBless\BaseTestCase;
+
+/**
+ * Testing of the `Client` methods that build and make outgoing signed requests.
+ */
+class Remote_Request_Test extends BaseTestCase {
+
+	/**
+	 * Error_Handler instance.
+	 *
+	 * @var Error_Handler
+	 */
+	private $error_handler;
+
+	/**
+	 * Initialize tests.
+	 */
+	public function set_up() {
+		$this->error_handler = Error_Handler::get_instance();
+
+		// The reporting gate is per error code and lives for an hour; tests assert on the
+		// stored result, not on the gate.
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+	}
+
+	/**
+	 * Clean up after tests.
+	 */
+	public function tear_down() {
+		remove_all_filters( 'jetpack_connection_bypass_error_reporting_gate' );
+
+		// `Client::build_signed_request()` registers this filter on every call and never
+		// removes it; left in place it changes how constants resolve for later tests.
+		remove_all_filters( 'jetpack_constant_default_value' );
+		Constants::clear_constants();
+
+		$this->error_handler->delete_all_errors();
+
+		Jetpack_Options::delete_option( 'blog_token' );
+		Jetpack_Options::delete_option( 'user_tokens' );
+
+		// `Manager::is_connected()` memoizes its result and hook registration.
+		// Reset both so later tests can re-register the hooks and invalidate the cache.
+		$manager_reflection = new \ReflectionClass( Manager::class );
+		foreach ( array(
+			'is_connected'                  => null,
+			'connection_invalidators_added' => false,
+		) as $name => $value ) {
+			$static = $manager_reflection->getProperty( $name );
+			// @todo Remove this call once we no longer need to support PHP <8.1.
+			if ( PHP_VERSION_ID < 80100 ) {
+				$static->setAccessible( true );
+			}
+			$static->setValue( null, $value );
+		}
+
+		// The displayable errors are cached per viewer on the singleton.
+		$reflection = new \ReflectionClass( $this->error_handler );
+		$property   = $reflection->getProperty( 'cached_displayable_errors' );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( $this->error_handler, null );
+	}
+
+	/**
+	 * Test that a request that cannot be signed reports why, rather than a generic code.
+	 *
+	 * `Tokens::get_access_token()` distinguishes eight reasons a token cannot be loaded, and
+	 * `build_signed_request()` asks for them instead of collapsing them into `missing_token`.
+	 */
+	public function test_build_signed_request_returns_the_specific_token_error() {
+		$result = Client::build_signed_request( array( 'url' => 'https://example.org/' ) );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertSame( 'no_possible_tokens', $result->get_error_code() );
+	}
+
+	/**
+	 * Test the same for a user token, which fails on a different branch.
+	 */
+	public function test_build_signed_request_returns_the_specific_user_token_error() {
+		Jetpack_Options::update_option( 'blog_token', 'asdasd.123' );
+
+		$result = Client::build_signed_request(
+			array(
+				'url'     => 'https://example.org/',
+				'user_id' => 12,
+			)
+		);
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertSame( 'no_user_tokens', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that a signing failure is reported to the Error_Handler.
+	 *
+	 * The request is never sent, so it has no response for `check_api_response_for_errors()`
+	 * to inspect; `remote_request()` reports the signing failure itself.
+	 */
+	public function test_remote_request_reports_a_signing_failure() {
+		$result = Client::remote_request( array( 'url' => 'https://example.org/wp-json/' ) );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+
+		$stored_errors = $this->error_handler->get_stored_errors();
+
+		$this->assertArrayHasKey( 'no_possible_tokens', $stored_errors );
+
+		// No token was found, so there's nothing to attribute the error to a specific user
+		// with; it falls back to the request's $user_id (defaulted to 0, i.e. site-level).
+		$stored = $stored_errors['no_possible_tokens']['0'];
+
+		$this->assertSame( Error_Handler::ERROR_TYPE_REST, $stored['error_type'] );
+		$this->assertSame( Error_Handler::DIRECTION_OUTGOING, $stored['error_direction'] );
+		$this->assertSame( 'https://example.org/wp-json/', $stored['error_data']['url'] );
+	}
+
+	/**
+	 * Test that an outgoing XML-RPC request is reported as such.
+	 */
+	public function test_remote_request_reports_a_signing_failure_as_xmlrpc() {
+		$result = Client::remote_request( array( 'url' => 'https://jetpack.wordpress.com/xmlrpc.php' ) );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+
+		$stored_errors = $this->error_handler->get_stored_errors();
+
+		$this->assertArrayHasKey( 'no_possible_tokens', $stored_errors );
+		$this->assertSame( Error_Handler::ERROR_TYPE_XMLRPC, $stored_errors['no_possible_tokens']['0']['error_type'] );
+	}
+
+	/**
+	 * Test that reporting a signing failure surfaces a notice.
+	 *
+	 * `no_possible_tokens` is on the displayable list, and a request with no explicit
+	 * `user_id` is attributed to the site (user ID 0), so it is not skipped by the
+	 * 'invalid'-attribution guard in the display pipeline.
+	 */
+	public function test_a_reported_signing_failure_is_displayed() {
+		Client::remote_request( array( 'url' => 'https://example.org/wp-json/' ) );
+
+		$displayable = $this->error_handler->get_displayable_errors();
+
+		$this->assertArrayHasKey( 'no_possible_tokens', $displayable );
+		$this->assertSame( 'site', $displayable['no_possible_tokens']['0']['audience'] );
+	}
+}

--- a/projects/packages/connection/tests/php/Remote_Request_Test.php
+++ b/projects/packages/connection/tests/php/Remote_Request_Test.php
@@ -135,6 +135,35 @@ class Remote_Request_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test that a signing failure for the connection owner (`user_id => true`) is attributed
+	 * to the resolved master user, not the site.
+	 *
+	 * `Client` no longer resolves the `true` sentinel itself — `Tokens::get_access_token()`
+	 * does, and attaches the resolved id to the `WP_Error` it raises, which
+	 * `check_signed_request_for_errors()` reads back out.
+	 */
+	public function test_remote_request_attributes_a_signing_failure_to_the_connection_owner() {
+		Jetpack_Options::update_option( 'master_user', 12 );
+
+		$result = Client::remote_request(
+			array(
+				'url'     => 'https://example.org/wp-json/',
+				'user_id' => true,
+			)
+		);
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertSame( 'no_user_tokens', $result->get_error_code() );
+
+		$stored_errors = $this->error_handler->get_stored_errors();
+
+		$this->assertArrayHasKey( '12', $stored_errors['no_user_tokens'] );
+		$this->assertArrayNotHasKey( '0', $stored_errors['no_user_tokens'] );
+
+		Jetpack_Options::delete_option( 'master_user' );
+	}
+
+	/**
 	 * Test that an outgoing XML-RPC request is reported as such.
 	 */
 	public function test_remote_request_reports_a_signing_failure_as_xmlrpc() {

--- a/projects/packages/connection/tests/php/Remote_Request_Test.php
+++ b/projects/packages/connection/tests/php/Remote_Request_Test.php
@@ -54,6 +54,7 @@ class Remote_Request_Test extends BaseTestCase {
 
 		Jetpack_Options::delete_option( 'blog_token' );
 		Jetpack_Options::delete_option( 'user_tokens' );
+		Jetpack_Options::delete_option( 'master_user' );
 
 		// `Manager::is_connected()` memoizes its result and hook registration.
 		// Reset both so later tests can re-register the hooks and invalidate the cache.
@@ -159,8 +160,6 @@ class Remote_Request_Test extends BaseTestCase {
 
 		$this->assertArrayHasKey( '12', $stored_errors['no_user_tokens'] );
 		$this->assertArrayNotHasKey( '0', $stored_errors['no_user_tokens'] );
-
-		Jetpack_Options::delete_option( 'master_user' );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/Remote_Request_Test.php
+++ b/projects/packages/connection/tests/php/Remote_Request_Test.php
@@ -84,7 +84,7 @@ class Remote_Request_Test extends BaseTestCase {
 	 * Test that a request that cannot be signed reports why, rather than a generic code.
 	 *
 	 * `Tokens::get_access_token()` distinguishes eight reasons a token cannot be loaded, and
-	 * `build_signed_request()` asks for them instead of collapsing them into `missing_token`.
+	 * `build_signed_request()` asks for them instead of collapsing them into a generic code.
 	 */
 	public function test_build_signed_request_returns_the_specific_token_error() {
 		$result = Client::build_signed_request( array( 'url' => 'https://example.org/' ) );
@@ -161,6 +161,36 @@ class Remote_Request_Test extends BaseTestCase {
 		$this->assertArrayNotHasKey( '0', $stored_errors['no_user_tokens'] );
 
 		Jetpack_Options::delete_option( 'master_user' );
+	}
+
+	/**
+	 * Test that a token lock is deliberately not reported: it is a one-shot transitional
+	 * state, since `Tokens::get_access_token()` wipes all tokens (and the lock itself) the
+	 * moment it trips. The very next signing attempt therefore takes the normal path and
+	 * fails with the already-reported `no_possible_tokens` instead.
+	 */
+	public function test_tokens_locked_is_not_reported_but_self_heals() {
+		Jetpack_Options::update_option( 'blog_token', 'asdasd.123' );
+		// A lock whose site URL doesn't match this site's is treated as active regardless of
+		// expiry (Tokens::is_locked()).
+		Jetpack_Options::update_option(
+			'token_lock',
+			gmdate( 'Y-m-d\TH:i:sP' ) . '|||' . base64_encode( 'https://not-this-site.example' )
+		);
+
+		$result = Client::remote_request( array( 'url' => 'https://example.org/wp-json/' ) );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertSame( 'tokens_locked', $result->get_error_code() );
+		$this->assertEmpty( $this->error_handler->get_stored_errors(), 'tokens_locked is not in known_errors, so report_error() should silently discard it' );
+
+		// The lock (and the token it locked) is now gone; the next attempt takes the normal
+		// path and fails with the standard, reportable code.
+		$result = Client::remote_request( array( 'url' => 'https://example.org/wp-json/' ) );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertSame( 'no_possible_tokens', $result->get_error_code() );
+		$this->assertArrayHasKey( 'no_possible_tokens', $this->error_handler->get_stored_errors() );
 	}
 
 	/**


### PR DESCRIPTION
Related to CONNECT-382

## Proposed changes

This PR focusses on improving connection error reporting by ensuring outgoing request failures are captured and surfaced correctly. Specifically it cover:
*  Reporting connection errors that occur while signing an outgoing request (`Client::build_signed_request()` failures), not just errors in the response. Previously these were silently dropped — `Client::remote_request()` had no request to send, so `check_api_response_for_errors()` never ran. Adds `Error_Handler::check_signed_request_for_errors()` as a second entry point for flow 2 (outgoing-request errors), documented in the class docblock.
* When a signing failure can't be signed because no token could be loaded, report the specific reason (`Tokens::get_access_token()` already distinguishes eight cases — no blog token, no token for this user, malformed stored token, etc.) instead of a flat `missing_token`. Previously `build_signed_request()` called `get_access_token()` with the default `$suppress_errors = true`, so all eight cases collapsed into one generic `WP_Error('missing_token')` at that single call site; it now passes `$suppress_errors = false` and forwards the resulting specific WP_Error. The one case that still returns a bare `false` — the token lock — is now named `tokens_locked` rather than the old catch-all name, and is deliberately excluded from `$known_errors`: the lock wipes all tokens on trip, so the next signing attempt self-heals into the already-reported `no_possible_tokens`.
* Fix the body-hash key read when storing signature details — `Client` builds it as body-hash, but the handler was reading body_hash, so it was always empty. Falls back to body_hash for callers passing the already-stored shape.
* Add `unknown_scheme_port` to `$known_errors` — was reachable but not in the allowlist, so would have been dropped by `report_error()`.
* `build_error_array()` rejects an empty error message, which several signing-failure codes have (e.g. `no_user_tokens`). Moved the empty-message fallback into the shared `build_connection_wp_error()` factory so both `check_signed_request_for_errors()` and `check_api_response_for_errors()` get it — the latter had the same latent bug (a known code with an empty message made `wp_error_to_array()` return `false`, and `store_error()` would then read `user_id` off `false`).
* To attribute token-less errors correctly instead of falling back to 'invalid', `Tokens::get_access_token()` now attaches the resolved `user_id` to the WP_Errors it raises (when it has one). `Error_Handler::check_signed_request_for_errors()` reads that attribution back off the error's own data via `wp_error_to_array()`'s existing fallback — `Client::remote_request()` no longer duplicates the `true → master_user` resolution itself.
* Document (no code change) why `REST_Authentication::wp_rest_authenticate()`'s three pre-verification `rest_invalid_request` rejections (missing/unsupported method, body on non-POST) are deliberately not reported to `Error_Handler` — they fire before `verify_xml_rpc_signature()`, so no caller has been authenticated yet and storing them would put unauthenticated traffic in the connection error store. Comment added so a future audit doesn't re-flag it. 

## Related product discussion/links

* See above Linear issue. 

## Does this pull request change what data or activity we track or use?

No new data is sent to WPcom.

## Testing instructions

Tests should pass. Also:
```
cd projects/packages/connection
./vendor/bin/phpunit -c phpunit.11.xml.dist --filter "Error_Handler_Test|Remote_Request_Test"
```

To verify visually, on a test site with this branch applied (locally or using the Jetpack Beta tester plugin):

* Create a mu-plugin to add the following snippet: 3c320-pb
* You'll also want to add the following to a snippet or mu-plugin to allow multiple reports per code per hour: `add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );`
* Visit each of the test links mentioned in the snippet eg. `/wp-admin/?test_conn_error=no_token_for_user`.  Each dumps the raw `Client::remote_request()` return (should be a `WP_Error` with the specific code, proving the 'token code flattening' fix) and the stored errors from `Error_Handler` (should now be non-empty, proving the 'signing failures invisible' fix — pre-fix this array would stay empty for every case). 
* Then, using the Jetpack Debug helper plugin (can activate bleeding edge using the Jetpack Beta tester plugin), check the connection-errors page — it should show the matching specific code, not `missing_token`, for the first four cases.
* If testing with https://github.com/Automattic/jetpack/pull/51034 applied or merged, note the only error you'll see on the Connection error notice in My Jetpack is for `token_malformed`  as it is the only one in `$displayable_error_codes` (to be refactored later, see CONNECT-403)
* On trunk you will see no stored errors printed on the screen, nothing showing in the Jetpack Debug helper connection errors page, and 'missing_token' for all `Client::remote_request()` return codes.