### PR TITLE
wpcomsh: mirror the WPCOM $with_billing_data purchases change

### DIFF
--- a/projects/plugins/wpcomsh/changelog/add-expiry-purchase-billing-data
+++ b/projects/plugins/wpcomsh/changelog/add-expiry-purchase-billing-data
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Add an opt-in `$with_billing_data` argument to `wpcom_get_site_purchases()`, mirroring the WPCOM copy of this file.
+Add an opt-in `$with_billing_data` argument to `wpcom_get_site_purchases()`, which overlays billing-derived auto-renew and expiry state onto each purchase. No effect on Atomic sites, which serve the purchase data synced to them.

--- a/projects/plugins/wpcomsh/changelog/add-expiry-purchase-billing-data
+++ b/projects/plugins/wpcomsh/changelog/add-expiry-purchase-billing-data
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add an opt-in `$with_billing_data` argument to `wpcom_get_site_purchases()`, mirroring the WPCOM copy of this file.

--- a/projects/plugins/wpcomsh/changelog/add-expiry-purchase-billing-data
+++ b/projects/plugins/wpcomsh/changelog/add-expiry-purchase-billing-data
@@ -1,4 +1,4 @@
 Significance: patch
 Type: added
 
-Add an opt-in `$with_billing_data` argument to `wpcom_get_site_purchases()`, which overlays billing-derived auto-renew and expiry state onto each purchase. No effect on Atomic sites, which serve the purchase data synced to them.
+Add an opt-in `$with_billing_data` argument to `wpcom_get_site_purchases()`, which reports whether each purchase will really be renewed rather than only whether its auto-renew flag is set. No effect on Atomic sites, which serve the purchase data synced to them.

--- a/projects/plugins/wpcomsh/tests/WpcomFeaturesTest.php
+++ b/projects/plugins/wpcomsh/tests/WpcomFeaturesTest.php
@@ -37,4 +37,22 @@ class WpcomFeaturesTest extends WP_UnitTestCase {
 		// Cleanup.
 		Atomic_Persistent_Data::delete( 'WPCOM_PURCHASES' );
 	}
+
+	/**
+	 * The billing-data overlay is a Simple-site concern, so asking for it here
+	 * has to be harmless: Atomic sites serve whatever was synced to them either
+	 * way.
+	 */
+	public function test_billing_data_argument_is_inert_on_atomic() {
+		$purchase = array( 'product_slug' => 'business-bundle' );
+		Atomic_Persistent_Data::set( 'WPCOM_PURCHASES', wp_json_encode( array( $purchase ), JSON_UNESCAPED_SLASHES ) );
+
+		$this->assertEquals(
+			wpcom_get_site_purchases(),
+			wpcom_get_site_purchases( 0, true )
+		);
+
+		// Cleanup.
+		Atomic_Persistent_Data::delete( 'WPCOM_PURCHASES' );
+	}
 }

--- a/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
@@ -191,9 +191,11 @@ function wpcom_get_site_purchases( $blog_id = 0, $with_billing_data = false ) {
  * subscriptions that cannot actually renew (no chargeable payment method), and
  * they carry none of the derived state that depends on the auto-renew attempt
  * schedule. Both of those change with the passage of time, so neither can live
- * in the `site_purchases` cache; this is computed on each call, on clones — the
- * cached objects themselves must stay untouched or the overlay would leak into
- * callers that did not ask for it.
+ * in the 24-30 hour `site_purchases` cache. The billing lookup is instead
+ * memoised for the current request only, keeping repeat callers within a single
+ * page load to one lookup. Results are handed back as clones, since the cached
+ * objects themselves must stay untouched or the overlay would leak into callers
+ * that did not ask for it.
  *
  * Only ever does anything on Simple sites. Purchases are returned as-is in
  * contexts where the billing code-base is unavailable (see pdqkMK-18D-p2), so
@@ -210,11 +212,14 @@ function _wpcom_features_add_billing_data_to_purchases( $purchases, $blog_id ) {
 	}
 
 	if ( ! class_exists( 'WPCOM_Store_API' ) ) {
-		$store_api = WP_CONTENT_DIR . '/admin-plugins/wpcom-billing/class.wpcom-store-api.php';
-		if ( ! is_readable( $store_api ) ) {
+		// The whole billing loader rather than just the class file, as
+		// get_site_billing_upgrades() also reaches for store_logger(), a plain
+		// function that only the loader pulls in. Same as woa_get_purchases().
+		$billing_loader = WP_CONTENT_DIR . '/admin-plugins/wpcom-billing.php';
+		if ( ! is_readable( $billing_loader ) ) {
 			return $purchases;
 		}
-		require_once $store_api;
+		require_once $billing_loader;
 	}
 
 	static $upgrades_by_blog = array();

--- a/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
@@ -138,11 +138,18 @@ function wpcom_site_can_upload_videos( $blog_id = 0 ) {
  *
  * @throws Error If $blog_id !== current_blog_id on Atomic sites.
  *
- * @param int $blog_id Optional. Blog ID. Defaults to current blog.
+ * @param int  $blog_id           Optional. Blog ID. Defaults to current blog.
+ * @param bool $with_billing_data Optional. Overlay billing-derived state (accurate
+ *                                `user_allows_auto_renew`, `is_past_first_auto_renew_attempt_date`,
+ *                                `is_past_last_auto_renew_attempt_date`, `might_still_auto_renew`,
+ *                                `expiry_status`) onto each purchase. Opt-in because it queries the
+ *                                billing system on every call; the plain cached rows are enough for
+ *                                feature checks. On Atomic sites this is a no-op: the synced payload
+ *                                carries whatever fields it was synced with.
  *
  * @return array An array of product objects containing product_slug, product_id, subscribed_date, and expiry_date.
  */
-function wpcom_get_site_purchases( $blog_id = 0 ) {
+function wpcom_get_site_purchases( $blog_id = 0, $with_billing_data = false ) {
 	if ( ! $blog_id ) {
 		$blog_id = _wpcom_get_current_blog_id();
 	}
@@ -168,9 +175,77 @@ function wpcom_get_site_purchases( $blog_id = 0 ) {
 		$blog_id = apply_filters( 'wpcom_site_has_feature_blog_id', $blog_id );
 
 		$purchases = _wpcom_features_get_simple_site_purchases( $blog_id );
+
+		if ( $with_billing_data ) {
+			$purchases = _wpcom_features_add_billing_data_to_purchases( $purchases, $blog_id );
+		}
 	}
 
 	return $purchases;
+}
+
+/**
+ * Overlay billing-derived state onto purchases from the cached store query.
+ *
+ * The cached rows carry the raw auto-renew flag, which stays true for
+ * subscriptions that cannot actually renew (no chargeable payment method), and
+ * they carry none of the derived state that depends on the auto-renew attempt
+ * schedule. Both of those change with the passage of time, so neither can live
+ * in the `site_purchases` cache; this is computed on each call, on clones — the
+ * cached objects themselves must stay untouched or the overlay would leak into
+ * callers that did not ask for it.
+ *
+ * Only ever does anything on Simple sites. Purchases are returned as-is in
+ * contexts where the billing code-base is unavailable (see pdqkMK-18D-p2), so
+ * callers must treat the extra fields as optional.
+ *
+ * @param array $purchases Purchases as returned by _wpcom_features_get_simple_site_purchases().
+ * @param int   $blog_id   Blog ID the purchases belong to.
+ *
+ * @return array The purchases, enriched when possible.
+ */
+function _wpcom_features_add_billing_data_to_purchases( $purchases, $blog_id ) {
+	if ( empty( $purchases ) || ! class_exists( '\A8C\Billingdaddy\Container' ) ) {
+		return $purchases;
+	}
+
+	if ( ! class_exists( 'WPCOM_Store_API' ) ) {
+		$store_api = WP_CONTENT_DIR . '/admin-plugins/wpcom-billing/class.wpcom-store-api.php';
+		if ( ! is_readable( $store_api ) ) {
+			return $purchases;
+		}
+		require_once $store_api;
+	}
+
+	static $upgrades_by_blog = array();
+	if ( ! isset( $upgrades_by_blog[ $blog_id ] ) ) {
+		$upgrades_by_blog[ $blog_id ] = array();
+		// Subscriptions only: skips domain-subscription combining so that every
+		// upgrade still matches a store subscription row one-to-one.
+		foreach ( WPCOM_Store_API::get_site_billing_upgrades( $blog_id, true ) as $upgrade ) {
+			$upgrades_by_blog[ $blog_id ][ (string) $upgrade->ID ] = $upgrade;
+		}
+	}
+	$upgrades = $upgrades_by_blog[ $blog_id ];
+
+	return array_map(
+		function ( $purchase ) use ( $upgrades ) {
+			$upgrade = $upgrades[ (string) ( $purchase->subscription_id ?? '' ) ] ?? null;
+			if ( ! $upgrade ) {
+				return $purchase;
+			}
+
+			$purchase                                        = clone $purchase;
+			$purchase->user_allows_auto_renew                = $upgrade->is_auto_renew_enabled;
+			$purchase->is_past_first_auto_renew_attempt_date = $upgrade->is_past_first_auto_renew_attempt_date;
+			$purchase->is_past_last_auto_renew_attempt_date  = $upgrade->is_past_last_auto_renew_attempt_date;
+			$purchase->might_still_auto_renew                = $upgrade->might_still_auto_renew;
+			$purchase->expiry_status                         = $upgrade->expiry_status;
+
+			return $purchase;
+		},
+		$purchases
+	);
 }
 
 /**

--- a/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
@@ -147,7 +147,10 @@ function wpcom_site_can_upload_videos( $blog_id = 0 ) {
  *                                feature checks. On Atomic sites this is a no-op: the synced payload
  *                                carries whatever fields it was synced with.
  *
- * @return array An array of product objects containing product_slug, product_id, subscribed_date, and expiry_date.
+ * @return array An array of product objects containing at least product_slug, product_id,
+ *               product_type, subscribed_date, expiry_date and subscription_id. With
+ *               $with_billing_data, and where the billing code-base is available, each also
+ *               carries the derived fields listed above.
  */
 function wpcom_get_site_purchases( $blog_id = 0, $with_billing_data = false ) {
 	if ( ! $blog_id ) {
@@ -222,18 +225,23 @@ function _wpcom_features_add_billing_data_to_purchases( $purchases, $blog_id ) {
 		require_once $billing_loader;
 	}
 
-	static $upgrades_by_blog = array();
-	if ( ! isset( $upgrades_by_blog[ $blog_id ] ) ) {
-		$upgrades_by_blog[ $blog_id ] = array();
+	// Keyed by the subscriptions being asked about, not just the blog, so that
+	// a changed set of subscriptions never reads a memo built for a different
+	// one — including across tests, which share a process.
+	$memo_key = $blog_id . ':' . implode( ',', wp_list_pluck( $purchases, 'subscription_id' ) );
+
+	static $upgrades_by_key = array();
+	if ( ! isset( $upgrades_by_key[ $memo_key ] ) ) {
+		$upgrades_by_key[ $memo_key ] = array();
 		// Subscriptions only: skips domain-subscription combining so that every
 		// upgrade still matches a store subscription row one-to-one.
 		// WPCOM_Store_API only exists on WPCOM, hence the guard above.
 		// @phan-suppress-next-line PhanUndeclaredStaticMethod
 		foreach ( WPCOM_Store_API::get_site_billing_upgrades( $blog_id, true ) as $upgrade ) {
-			$upgrades_by_blog[ $blog_id ][ (string) $upgrade->ID ] = $upgrade;
+			$upgrades_by_key[ $memo_key ][ (string) $upgrade->ID ] = $upgrade;
 		}
 	}
-	$upgrades = $upgrades_by_blog[ $blog_id ];
+	$upgrades = $upgrades_by_key[ $memo_key ];
 
 	return array_map(
 		function ( $purchase ) use ( $upgrades ) {

--- a/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
@@ -222,6 +222,8 @@ function _wpcom_features_add_billing_data_to_purchases( $purchases, $blog_id ) {
 		$upgrades_by_blog[ $blog_id ] = array();
 		// Subscriptions only: skips domain-subscription combining so that every
 		// upgrade still matches a store subscription row one-to-one.
+		// WPCOM_Store_API only exists on WPCOM, hence the guard above.
+		// @phan-suppress-next-line PhanUndeclaredStaticMethod
 		foreach ( WPCOM_Store_API::get_site_billing_upgrades( $blog_id, true ) as $upgrade ) {
 			$upgrades_by_blog[ $blog_id ][ (string) $upgrade->ID ] = $upgrade;
 		}

--- a/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
@@ -140,12 +140,19 @@ function wpcom_site_can_upload_videos( $blog_id = 0 ) {
  *
  * @param int  $blog_id           Optional. Blog ID. Defaults to current blog.
  * @param bool $with_billing_data Optional. Overlay billing-derived state (accurate
- *                                `user_allows_auto_renew`, `is_past_first_auto_renew_attempt_date`,
- *                                `is_past_last_auto_renew_attempt_date`, `might_still_auto_renew`,
- *                                `expiry_status`) onto each purchase. Opt-in because it queries the
+ *                                `user_allows_auto_renew`, plus `might_still_auto_renew`,
+ *                                `is_past_first_auto_renew_attempt_date`,
+ *                                `is_past_last_auto_renew_attempt_date`,
+ *                                `first_auto_renew_attempt_date`, `last_auto_renew_attempt_date`
+ *                                and `expiry_status`) onto each purchase. The same fields the
+ *                                Atomic payload carries, so consumers read one shape on either
+ *                                site type. Opt-in because it queries the
  *                                billing system on every call; the plain cached rows are enough for
- *                                feature checks. On Atomic sites this is a no-op: the synced payload
- *                                carries whatever fields it was synced with.
+ *                                feature checks. The overlay degrades to the plain rows wherever
+ *                                billing cannot answer, so read the derived fields as optional and
+ *                                trust `user_allows_auto_renew` as billing-accurate only on a
+ *                                purchase that carries them. On Atomic sites this is a no-op: the
+ *                                synced payload carries whatever fields it was synced with.
  *
  * @return array An array of product objects containing at least product_slug, product_id,
  *               product_type, subscribed_date, expiry_date and subscription_id. With
@@ -194,15 +201,21 @@ function wpcom_get_site_purchases( $blog_id = 0, $with_billing_data = false ) {
  * subscriptions that cannot actually renew (no chargeable payment method), and
  * they carry none of the derived state that depends on the auto-renew attempt
  * schedule. Both of those change with the passage of time, so neither can live
- * in the 24-30 hour `site_purchases` cache. The billing lookup is instead
- * memoised for the current request only, keeping repeat callers within a single
- * page load to one lookup. Results are handed back as clones, since the cached
- * objects themselves must stay untouched or the overlay would leak into callers
- * that did not ask for it.
+ * in the 24-30 hour `site_purchases` cache: the billing lookup runs on every
+ * call. Results are handed back as clones, since the cached objects themselves
+ * must stay untouched or the overlay would leak into callers that did not ask
+ * for it.
  *
- * Only ever does anything on Simple sites. Purchases are returned as-is in
- * contexts where the billing code-base is unavailable (see pdqkMK-18D-p2), so
- * callers must treat the extra fields as optional.
+ * The two attempt dates come along for parity with the Atomic payload, which
+ * needs them because it is only re-synced on subscription events. Here they are
+ * as fresh as the booleans beside them.
+ *
+ * Only ever does anything on Simple sites. Purchases are returned as-is when
+ * the billing code-base is unavailable (see pdqkMK-18D-p2), when the billing
+ * lookup fails, and for any purchase billing does not know about, so callers
+ * must treat the extra fields as optional. `user_allows_auto_renew` is only
+ * billing-accurate on a purchase that carries them; where they are absent it is
+ * still the raw cached flag this overlay exists to correct.
  *
  * @param array $purchases Purchases as returned by _wpcom_features_get_simple_site_purchases().
  * @param int   $blog_id   Blog ID the purchases belong to.
@@ -210,51 +223,56 @@ function wpcom_get_site_purchases( $blog_id = 0, $with_billing_data = false ) {
  * @return array The purchases, enriched when possible.
  */
 function _wpcom_features_add_billing_data_to_purchases( $purchases, $blog_id ) {
-	if ( empty( $purchases ) || ! class_exists( '\A8C\Billingdaddy\Container' ) ) {
+	if ( empty( $purchases ) ) {
 		return $purchases;
 	}
 
-	if ( ! class_exists( 'WPCOM_Store_API' ) ) {
-		// The whole billing loader rather than just the class file, as
-		// get_site_billing_upgrades() also reaches for store_logger(), a plain
-		// function that only the loader pulls in. Same as woa_get_purchases().
-		$billing_loader = WP_CONTENT_DIR . '/admin-plugins/wpcom-billing.php';
-		if ( ! is_readable( $billing_loader ) ) {
-			return $purchases;
-		}
-		require_once $billing_loader;
+	// The whole billing loader rather than just the class file, as
+	// get_site_billing_upgrades() also reaches for store_logger(), a plain
+	// function that only the loader pulls in. Same as woa_get_purchases().
+	// Unreadable wherever the billing code-base does not ship, which is what
+	// keeps this inert in the WPCOMSH copy of this file.
+	$billing_loader = WP_CONTENT_DIR . '/admin-plugins/wpcom-billing.php';
+	if ( ! is_readable( $billing_loader ) ) {
+		return $purchases;
 	}
+	require_once $billing_loader;
 
-	// Keyed by the subscriptions being asked about, not just the blog, so that
-	// a changed set of subscriptions never reads a memo built for a different
-	// one — including across tests, which share a process.
-	$memo_key = $blog_id . ':' . implode( ',', wp_list_pluck( $purchases, 'subscription_id' ) );
+	$upgrades = array();
 
-	static $upgrades_by_key = array();
-	if ( ! isset( $upgrades_by_key[ $memo_key ] ) ) {
-		$upgrades_by_key[ $memo_key ] = array();
+	try {
 		// Subscriptions only: skips domain-subscription combining so that every
 		// upgrade still matches a store subscription row one-to-one.
 		// WPCOM_Store_API only exists on WPCOM, hence the guard above.
 		// @phan-suppress-next-line PhanUndeclaredStaticMethod
 		foreach ( WPCOM_Store_API::get_site_billing_upgrades( $blog_id, true ) as $upgrade ) {
-			$upgrades_by_key[ $memo_key ][ (string) $upgrade->ID ] = $upgrade;
+			$upgrades[ (string) $upgrade->ID ] = $upgrade;
 		}
+	} catch ( \Throwable $e ) {
+		// A single subscription whose product no longer loads throws for the
+		// whole site. Purchases are the caller's actual errand, so degrade to
+		// the plain rows rather than taking the request down with them.
+		return $purchases;
 	}
-	$upgrades = $upgrades_by_key[ $memo_key ];
 
 	return array_map(
 		function ( $purchase ) use ( $upgrades ) {
+			// Cloned before the match is tested, so that every purchase handed
+			// back is the caller's own copy: the cached rows are shared object
+			// instances for the whole request.
+			$purchase = clone $purchase;
+
 			$upgrade = $upgrades[ (string) ( $purchase->subscription_id ?? '' ) ] ?? null;
 			if ( ! $upgrade ) {
 				return $purchase;
 			}
 
-			$purchase                                        = clone $purchase;
 			$purchase->user_allows_auto_renew                = $upgrade->is_auto_renew_enabled;
+			$purchase->might_still_auto_renew                = $upgrade->might_still_auto_renew;
 			$purchase->is_past_first_auto_renew_attempt_date = $upgrade->is_past_first_auto_renew_attempt_date;
 			$purchase->is_past_last_auto_renew_attempt_date  = $upgrade->is_past_last_auto_renew_attempt_date;
-			$purchase->might_still_auto_renew                = $upgrade->might_still_auto_renew;
+			$purchase->first_auto_renew_attempt_date         = $upgrade->first_auto_renew_attempt_date;
+			$purchase->last_auto_renew_attempt_date          = $upgrade->last_auto_renew_attempt_date;
 			$purchase->expiry_status                         = $upgrade->expiry_status;
 
 			return $purchase;

--- a/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
@@ -139,20 +139,15 @@ function wpcom_site_can_upload_videos( $blog_id = 0 ) {
  * @throws Error If $blog_id !== current_blog_id on Atomic sites.
  *
  * @param int  $blog_id           Optional. Blog ID. Defaults to current blog.
- * @param bool $with_billing_data Optional. Overlay billing-derived state (accurate
- *                                `user_allows_auto_renew`, plus `might_still_auto_renew`,
- *                                `is_past_first_auto_renew_attempt_date`,
- *                                `is_past_last_auto_renew_attempt_date`,
- *                                `first_auto_renew_attempt_date`, `last_auto_renew_attempt_date`
- *                                and `expiry_status`) onto each purchase. The same fields the
- *                                Atomic payload carries, so consumers read one shape on either
- *                                site type. Opt-in because it queries the
- *                                billing system on every call; the plain cached rows are enough for
- *                                feature checks. The overlay degrades to the plain rows wherever
- *                                billing cannot answer, so read the derived fields as optional and
- *                                trust `user_allows_auto_renew` as billing-accurate only on a
- *                                purchase that carries them. On Atomic sites this is a no-op: the
- *                                synced payload carries whatever fields it was synced with.
+ * @param bool $with_billing_data Optional. Overlay `might_still_auto_renew` and
+ *                                `is_past_first_auto_renew_attempt_date` onto each purchase. The
+ *                                same fields the Atomic payload carries, so consumers read one
+ *                                shape on either site type. Opt-in because it queries the billing
+ *                                system on every call; the plain cached rows are enough for feature
+ *                                checks. The overlay degrades to the plain rows wherever billing
+ *                                cannot answer, so read both as optional. On Atomic sites this is a
+ *                                no-op: the synced payload carries whatever fields it was synced
+ *                                with.
  *
  * @return array An array of product objects containing at least product_slug, product_id,
  *               product_type, subscribed_date, expiry_date and subscription_id. With
@@ -198,24 +193,17 @@ function wpcom_get_site_purchases( $blog_id = 0, $with_billing_data = false ) {
  * Overlay billing-derived state onto purchases from the cached store query.
  *
  * The cached rows carry the raw auto-renew flag, which stays true for
- * subscriptions that cannot actually renew (no chargeable payment method), and
- * they carry none of the derived state that depends on the auto-renew attempt
- * schedule. Both of those change with the passage of time, so neither can live
- * in the 24-30 hour `site_purchases` cache: the billing lookup runs on every
- * call. Results are handed back as clones, since the cached objects themselves
- * must stay untouched or the overlay would leak into callers that did not ask
- * for it.
- *
- * The two attempt dates come along for parity with the Atomic payload, which
- * needs them because it is only re-synced on subscription events. Here they are
- * as fresh as the booleans beside them.
+ * subscriptions that cannot actually renew (no chargeable payment method), so
+ * only billing can say whether a renewal will really be attempted. That answer
+ * changes with the passage of time, so it cannot live in the 24-30 hour
+ * `site_purchases` cache: the billing lookup runs on every call. Results are
+ * handed back as clones, since the cached objects themselves must stay
+ * untouched or the overlay would leak into callers that did not ask for it.
  *
  * Only ever does anything on Simple sites. Purchases are returned as-is when
  * the billing code-base is unavailable (see pdqkMK-18D-p2), when the billing
  * lookup fails, and for any purchase billing does not know about, so callers
- * must treat the extra fields as optional. `user_allows_auto_renew` is only
- * billing-accurate on a purchase that carries them; where they are absent it is
- * still the raw cached flag this overlay exists to correct.
+ * must treat both fields as optional.
  *
  * @param array $purchases Purchases as returned by _wpcom_features_get_simple_site_purchases().
  * @param int   $blog_id   Blog ID the purchases belong to.
@@ -267,13 +255,8 @@ function _wpcom_features_add_billing_data_to_purchases( $purchases, $blog_id ) {
 				return $purchase;
 			}
 
-			$purchase->user_allows_auto_renew                = $upgrade->is_auto_renew_enabled;
 			$purchase->might_still_auto_renew                = $upgrade->might_still_auto_renew;
 			$purchase->is_past_first_auto_renew_attempt_date = $upgrade->is_past_first_auto_renew_attempt_date;
-			$purchase->is_past_last_auto_renew_attempt_date  = $upgrade->is_past_last_auto_renew_attempt_date;
-			$purchase->first_auto_renew_attempt_date         = $upgrade->first_auto_renew_attempt_date;
-			$purchase->last_auto_renew_attempt_date          = $upgrade->last_auto_renew_attempt_date;
-			$purchase->expiry_status                         = $upgrade->expiry_status;
 
 			return $purchase;
 		},

--- a/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
@@ -140,14 +140,13 @@ function wpcom_site_can_upload_videos( $blog_id = 0 ) {
  *
  * @param int  $blog_id           Optional. Blog ID. Defaults to current blog.
  * @param bool $with_billing_data Optional. Overlay `might_still_auto_renew` and
- *                                `is_past_first_auto_renew_attempt_date` onto each purchase. The
- *                                same fields the Atomic payload carries, so consumers read one
- *                                shape on either site type. Opt-in because it queries the billing
- *                                system on every call; the plain cached rows are enough for feature
- *                                checks. The overlay degrades to the plain rows wherever billing
- *                                cannot answer, so read both as optional. On Atomic sites this is a
- *                                no-op: the synced payload carries whatever fields it was synced
- *                                with.
+ *                                `first_auto_renew_attempt_date` onto each purchase. The same
+ *                                fields the Atomic payload carries, so consumers read one shape on
+ *                                either site type. Opt-in because it queries the billing system on
+ *                                every call; the plain cached rows are enough for feature checks.
+ *                                The overlay degrades to the plain rows wherever billing cannot
+ *                                answer, so read both as optional. On Atomic sites this is a no-op:
+ *                                the synced payload carries whatever fields it was synced with.
  *
  * @return array An array of product objects containing at least product_slug, product_id,
  *               product_type, subscribed_date, expiry_date and subscription_id. With
@@ -255,8 +254,8 @@ function _wpcom_features_add_billing_data_to_purchases( $purchases, $blog_id ) {
 				return $purchase;
 			}
 
-			$purchase->might_still_auto_renew                = $upgrade->might_still_auto_renew;
-			$purchase->is_past_first_auto_renew_attempt_date = $upgrade->is_past_first_auto_renew_attempt_date;
+			$purchase->might_still_auto_renew        = $upgrade->might_still_auto_renew;
+			$purchase->first_auto_renew_attempt_date = $upgrade->first_auto_renew_attempt_date;
 
 			return $purchase;
 		},


### PR DESCRIPTION
Fixes # — DOTCOM-16619 (Linear)

## Proposed changes

* Mirror into wpcomsh the `wpcom_get_site_purchases()` change made in the WPCOM copy of `wpcom-features/functions-wpcom-features.php`: an opt-in `$with_billing_data` argument, plus the `_wpcom_features_add_billing_data_to_purchases()` helper it delegates to. The overlay adds two fields to each purchase, `might_still_auto_renew` and `first_auto_renew_attempt_date`.

That file carries a `THIS FILE EXISTS VERBATIM IN WPCOM AND WPCOMSH` header requiring both copies to be updated together, so this is the wpcomsh half of wpcom PR D233012.

The overlay only ever runs on the Simple branch of that function, so it is inert on Atomic sites, where `wpcom_get_site_purchases()` returns whatever was synced into Atomic Persistent Data. (The same two fields reach Atomic sites through that synced payload, which the paired WPCOM change adds them to.) It is mirrored anyway to keep the two copies from drifting further apart.

## Related product discussion/links

* Linear: https://linear.app/a8c/issue/DOTCOM-16619
* Paired WPCOM change: D233012
* Consumer of this data: DOTCOM-16615 (wp-admin expiry banner)

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This change is inert on Atomic by design, so the meaningful test is that nothing regresses:

* On an Atomic test site, confirm `wpcom_get_site_purchases()` still returns the site purchases as before, and that features gated on it (plan checks, the expiry banner) behave unchanged.
* Calling `wpcom_get_site_purchases( $blog_id, true )` on Atomic returns the same result as calling it without the second argument. Covered by `WpcomFeaturesTest::test_billing_data_argument_is_inert_on_atomic`.

Reviewer note: the two copies of this file have already drifted independently of this PR — wpcomsh lacks `wpcom_features_get_simple_site_purchases_force_db()`, uses a shorter cache TTL, and carries a few Phan/coverage annotations. I deliberately ported only my change rather than copying the WPCOM file wholesale, to avoid smuggling in unrelated behaviour changes. The added code is byte-identical in both copies apart from one Phan suppression, which the WPCOM copy does not need.
