### PR TITLE
phpcs-filter: Fix PHP coverage token conflict

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -195,7 +195,7 @@
             "dist": {
                 "type": "path",
                 "url": "projects/packages/phpcs-filter",
-                "reference": "72cdb43773a1ccc86f44e57ff87ef8e5aa787a03"
+                "reference": "abd2135645d94bd39f5b2f8a5b54f15d63efc9df"
             },
             "require": {
                 "automattic/ignorefile": "@dev",
@@ -225,7 +225,7 @@
                     "@composer phpunit"
                 ],
                 "test-php-coverage": [
-                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                    "php -dpcov.directory=. -dauto_prepend_file=tests/php/coverage-bootstrap.php ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
                 ]
             },
             "license": [

--- a/projects/packages/phpcs-filter/changelog/fix-php-coverage-token-conflict
+++ b/projects/packages/phpcs-filter/changelog/fix-php-coverage-token-conflict
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix PHP coverage compatibility with PHP_CodeSniffer.

--- a/projects/packages/phpcs-filter/composer.json
+++ b/projects/packages/phpcs-filter/composer.json
@@ -31,7 +31,7 @@
 			"phpunit-select-config phpunit.#.xml.dist --colors=always"
 		],
 		"test-php": "@composer phpunit",
-		"test-php-coverage": "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+		"test-php-coverage": "php -dpcov.directory=. -dauto_prepend_file=tests/php/coverage-bootstrap.php ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
 	},
 	"repositories": [
 		{

--- a/projects/packages/phpcs-filter/tests/php/coverage-bootstrap.php
+++ b/projects/packages/phpcs-filter/tests/php/coverage-bootstrap.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Bootstrap PHP-Parser's compatibility tokens before PHP_CodeSniffer is loaded.
+ *
+ * @package    automattic/jetpack-phpcs-filter
+ * @subpackage Tests
+ */
+
+$compatibility_tokens = __DIR__ . '/../../vendor/nikic/php-parser/lib/PhpParser/compatibility_tokens.php';
+
+if ( file_exists( $compatibility_tokens ) ) {
+	// PHPCS emulates future tokens with string values, while PHP-Parser requires integer token IDs.
+	// Load PHP-Parser's definitions first to prevent that conflict during coverage initialization.
+	require_once $compatibility_tokens;
+}

--- a/projects/packages/phpcs-filter/tests/php/coverage-bootstrap.php
+++ b/projects/packages/phpcs-filter/tests/php/coverage-bootstrap.php
@@ -6,10 +6,12 @@
  * @subpackage Tests
  */
 
-$compatibility_tokens = __DIR__ . '/../../vendor/nikic/php-parser/lib/PhpParser/compatibility_tokens.php';
+( static function () {
+	$compatibility_tokens = __DIR__ . '/../../vendor/nikic/php-parser/lib/PhpParser/compatibility_tokens.php';
 
-if ( file_exists( $compatibility_tokens ) ) {
-	// PHPCS emulates future tokens with string values, while PHP-Parser requires integer token IDs.
-	// Load PHP-Parser's definitions first to prevent that conflict during coverage initialization.
-	require_once $compatibility_tokens;
-}
+	if ( is_file( $compatibility_tokens ) ) {
+		// PHPCS emulates future tokens with string values, while PHP-Parser requires integer token IDs.
+		// Load PHP-Parser's definitions first to prevent that conflict during coverage initialization.
+		require_once $compatibility_tokens;
+	}
+} )();


### PR DESCRIPTION
Fixes #51110

## Proposed changes

PHP coverage for `phpcs-filter` currently fatals on PHP 8.4. PHPCS defines future token constants such as `T_VOID_CAST` as strings, while PHP-Parser's coverage analysis requires integer token IDs.

This change prepends a coverage-only bootstrap that lets PHP-Parser define those compatibility tokens first. Normal tests, PHPCS usage, and production autoloading are unchanged.

I tested and ruled out a few smaller-looking alternatives:

* Pin PHP-Parser below 5.8: 5.7 contains the same guard and reproduces the fatal. Pinning below 5.7 forces PHPUnit/coverage downgrades and did not reliably produce a coverage artifact.
* Add a package `composer.lock`: package lockfiles are intentionally ignored in this monorepo, and changing that policy would have wider consequences.
* Move coverage to PHP 8.5: it avoids this specific token because PHP 8.5 defines it natively, but changes the runtime for all coverage jobs and only masks the underlying load-order conflict.
* Wait for upstream: the PHPCS/PHP-Parser incompatibility has been known for some time without an agreed upstream resolution.

The main risk is relying on PHP-Parser's internal compatibility-token file path. If that path changes, coverage will fail again rather than affecting production. The bootstrap is limited to this package's coverage command, conditionally no-ops when the file is absent, and leaves normal runtime behavior alone, so I think that risk is acceptable for restoring CI now.

## Related product discussion/links

* #51110

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Run `jp test php-coverage packages/phpcs-filter --verbose` on PHP 8.4. Confirm all 15 tests and 88 assertions pass, a PHP coverage artifact is generated, and the merged HTML report completes.
2. Run `jp test php packages/phpcs-filter --verbose` and confirm all tests pass without loading the coverage bootstrap.
3. Run `jp phan packages/phpcs-filter` and confirm it reports zero issues.

I also verified the new bootstrap parses on the supported PHP boundaries, 7.2 and 8.5, and passes the repository's PHP coding standards.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scope is limited to the package’s coverage command and a conditional require of a dev dependency path; no production or normal test runtime behavior changes.
> 
> **Overview**
> **Restores `phpcs-filter` PHP coverage on PHP 8.4** by fixing a fatal caused when PHP_CodeSniffer defines future token constants as strings while PHP-Parser’s coverage path expects integer token IDs.
> 
> The `test-php-coverage` Composer script now runs PHPUnit with `-dauto_prepend_file=tests/php/coverage-bootstrap.php`. That bootstrap loads PHP-Parser’s `compatibility_tokens.php` before PHPCS is pulled in, so token definitions don’t clash during coverage initialization. Regular `test-php`, PHPCS, and production autoloading are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2832c2d23623589592c4bd8801dd58cf74610991. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->