### PR TITLE
Update Renovate reviewer teams

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -97,8 +97,7 @@
 			matchPackageNames: [ 'docker/**' ],
 		},
 
-		// QualityOps decided they want all these pinned to digests.
-		// They were going to have Dependabot create PRs automatically, but as we use Renovate, do it here instead.
+		// Pin GitHub Actions to digests.
 		// We'll leave major updates ungrouped though, as those likely need more individualized attention.
 		{
 			extends: [ 'helpers:pinGitHubActionDigests' ],
@@ -151,11 +150,12 @@
 			separateMajorMinor: false,
 			// Teams that can help test the update
 			additionalReviewers: [
-				'team:triforce', // Monorepo overall, Publicize, My Jetpack
+				'team:jetpack-social', // Social
+				'team:jetpack-my-jetpack', // My Jetpack
 				'team:loop', // Newsletter dashboard & subscriber management
-				'team:zap', // Forms, much of the recent componentry work.
-				'team:red', // Premium Analytics
-				'team:ventures', // Premium Analytics
+				'team:jetpack-newsletter', // Newsletter dashboard & subscriber management
+				'team:jetpack-forms', // Forms and related component work
+				'team:jetpack-stats', // Premium Analytics
 			],
 		},
 
@@ -172,7 +172,7 @@
 				'uuid',
 				'@testing-library/preact',
 			],
-			additionalReviewers: [ 'team:red' ],
+			additionalReviewers: [ 'team:jetpack-search' ],
 			addLabels: [ '[Feature] Search', 'Instant Search' ],
 		},
 	],


### PR DESCRIPTION
Fixes #

## Proposed changes

* Route Renovate review requests to the Jetpack product teams responsible for the affected features.
* Keep both Jetpack Newsletter and Loop as reviewers for bundled WordPress dependency updates.
* Keep QualityOps as an additional reviewer for GitHub Actions updates alongside the global Jetpack Monorepo reviewer.
* Keep the dependency groupings and update behavior unchanged; this only changes reviewer routing.

PR #50868 also changes the bundled WordPress package rule and may require this branch to be rebased after it lands.

## Related product discussion/links

* None.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Confirm every `team:*` reviewer in `.github/renovate.json5` resolves to a GitHub team with access to `Automattic/jetpack`.
* Run `pnpm lint-file .github/renovate.json5`.
* Run `pnpm exec prettier --check .github/renovate.json5`.
* Confirm the next relevant Renovate pull requests request the applicable product teams, while Newsletter updates continue to request both Jetpack Newsletter and Loop.

*\*left by Biff (AI agent) on behalf of Darren*
