### PR TITLE
Forms: keep the slider field's default label under Outlined and Animated styles

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-slider-animated-style
+++ b/projects/packages/forms/changelog/fix-forms-slider-animated-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: fix the slider field label overlapping the track when the form uses the Outlined or Animated style.

--- a/projects/packages/forms/changelog/fix-forms-slider-animated-style
+++ b/projects/packages/forms/changelog/fix-forms-slider-animated-style
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Forms: fix the slider field label overlapping the track when the form uses the Outlined or Animated style.
+Slider field: keep the default label when the form uses the Outlined or Animated style, so the label no longer overlaps the slider track.

--- a/projects/packages/forms/src/blocks/label/edit.jsx
+++ b/projects/packages/forms/src/blocks/label/edit.jsx
@@ -26,20 +26,35 @@ const getLabelOrFallback = ( label, placeholder ) => {
 
 const OPTIONS_FIELDS = [ 'jetpack/field-radio', 'jetpack/field-checkbox-multiple' ];
 
-function useSiblingBlock( clientId ) {
-	const inputBlock = useSelect(
+// Field blocks whose input is not a single text-like box, so an inset
+// (notched/animated) label would overlap the control rather than sit in it.
+// Keep in sync with Contact_Form_Field::TYPES_WITHOUT_INSET_LABEL.
+const FIELDS_WITHOUT_INSET_LABEL = [ 'jetpack/field-slider' ];
+
+// Stable reference for "no input block found", so useSelect's shallow comparison
+// does not see a new object on every store change.
+const NO_INPUT_BLOCK = {};
+
+/**
+ * Resolves the field block this label belongs to, and its sibling input block.
+ *
+ * @param {string} clientId - The label block's client ID.
+ * @return {{inputBlock: Object|undefined, parentName: string|undefined}} The sibling input block and the parent field block name.
+ */
+function useFieldContext( clientId ) {
+	return useSelect(
 		select => {
 			const { getBlock, getBlockRootClientId } = select( blockEditorStore );
 
 			// Get the parent block's clientId.
 			const parentClientId = getBlockRootClientId( clientId );
 			if ( ! parentClientId ) {
-				return {};
+				return { inputBlock: NO_INPUT_BLOCK, parentName: undefined };
 			}
 			// Get the parent block
 			const parentBlock = getBlock( parentClientId );
 			if ( ! parentBlock ) {
-				return {};
+				return { inputBlock: NO_INPUT_BLOCK, parentName: undefined };
 			}
 
 			let siblingBlockType = OPTIONS_FIELDS.includes( parentBlock.name )
@@ -51,26 +66,10 @@ function useSiblingBlock( clientId ) {
 				siblingBlockType = 'jetpack/phone-input';
 			}
 
-			return parentBlock.innerBlocks.find( block => block.name === siblingBlockType );
-		},
-		[ clientId ]
-	);
-
-	return inputBlock;
-}
-
-/**
- * Returns the name of the field block this label belongs to.
- *
- * @param {string} clientId - The label block's client ID.
- * @return {string|undefined} The parent field block name, if any.
- */
-function useParentFieldName( clientId ) {
-	return useSelect(
-		select => {
-			const { getBlockName, getBlockRootClientId } = select( blockEditorStore );
-			const parentClientId = getBlockRootClientId( clientId );
-			return parentClientId ? getBlockName( parentClientId ) : undefined;
+			return {
+				inputBlock: parentBlock.innerBlocks.find( block => block.name === siblingBlockType ),
+				parentName: parentBlock.name,
+			};
 		},
 		[ clientId ]
 	);
@@ -116,12 +115,13 @@ const LabelEdit = ( { clientId, attributes, name, setAttributes, context } ) => 
 		: undefined;
 	const formStyle = getBlockStyle( formClassName );
 
-	const inputBlock = useSiblingBlock( clientId );
+	const { inputBlock, parentName } = useFieldContext( clientId );
 
 	// The slider is not a text-like input: it has no empty state to rest in and its
 	// range input is nested inside a wrapper, so an inset (notched/animated) label
 	// would sit on top of the track instead of animating. Keep the default label.
-	const hasInsetLabel = useParentFieldName( clientId ) !== 'jetpack/field-slider';
+	// 'below' renders the label outside the field, so it still applies.
+	const hasInsetLabel = ! FIELDS_WITHOUT_INSET_LABEL.includes( parentName );
 
 	const className = clsx( 'jetpack-field-label', {
 		'notched-label__label': hasInsetLabel && formStyle === FORM_STYLE.OUTLINED,
@@ -160,7 +160,7 @@ const LabelEdit = ( { clientId, attributes, name, setAttributes, context } ) => 
 	return (
 		<WithNotchedWrapper
 			formStyle={ formStyle }
-			forcePlainStyle={ ! inputBlock }
+			forcePlainStyle={ ! inputBlock || ! hasInsetLabel }
 			styles={ variationProps?.style }
 			cssVars={ variationProps?.cssVars }
 			className={ variationProps?.className }

--- a/projects/packages/forms/src/blocks/label/edit.jsx
+++ b/projects/packages/forms/src/blocks/label/edit.jsx
@@ -59,6 +59,23 @@ function useSiblingBlock( clientId ) {
 	return inputBlock;
 }
 
+/**
+ * Returns the name of the field block this label belongs to.
+ *
+ * @param {string} clientId - The label block's client ID.
+ * @return {string|undefined} The parent field block name, if any.
+ */
+function useParentFieldName( clientId ) {
+	return useSelect(
+		select => {
+			const { getBlockName, getBlockRootClientId } = select( blockEditorStore );
+			const parentClientId = getBlockRootClientId( clientId );
+			return parentClientId ? getBlockName( parentClientId ) : undefined;
+		},
+		[ clientId ]
+	);
+}
+
 const WithNotchedWrapper = ( {
 	formStyle,
 	styles,
@@ -98,13 +115,19 @@ const LabelEdit = ( { clientId, attributes, name, setAttributes, context } ) => 
 		? `(${ DATE_FORMATS.find( f => f.value === dateFormat )?.label })`
 		: undefined;
 	const formStyle = getBlockStyle( formClassName );
-	const className = clsx( 'jetpack-field-label', {
-		'notched-label__label': formStyle === FORM_STYLE.OUTLINED,
-		'animated-label__label': formStyle === FORM_STYLE.ANIMATED,
-		'below-label__label': formStyle === FORM_STYLE.BELOW,
-	} );
 
 	const inputBlock = useSiblingBlock( clientId );
+
+	// The slider is not a text-like input: it has no empty state to rest in and its
+	// range input is nested inside a wrapper, so an inset (notched/animated) label
+	// would sit on top of the track instead of animating. Keep the default label.
+	const hasInsetLabel = useParentFieldName( clientId ) !== 'jetpack/field-slider';
+
+	const className = clsx( 'jetpack-field-label', {
+		'notched-label__label': hasInsetLabel && formStyle === FORM_STYLE.OUTLINED,
+		'animated-label__label': hasInsetLabel && formStyle === FORM_STYLE.ANIMATED,
+		'below-label__label': formStyle === FORM_STYLE.BELOW,
+	} );
 
 	const variationProps = useVariationStyleProperties( {
 		clientId,

--- a/projects/packages/forms/src/blocks/label/test/edit.test.js
+++ b/projects/packages/forms/src/blocks/label/test/edit.test.js
@@ -1,0 +1,125 @@
+import { describe, expect, jest, test, beforeEach } from '@jest/globals';
+
+// Captures what the component passes to useBlockProps / WithNotchedWrapper.
+let blockPropsArg;
+
+// The fake block-editor store the mocked useSelect runs mapSelect against.
+let fakeBlocks;
+
+const LABEL_CLIENT_ID = 'label-client-id';
+const FIELD_CLIENT_ID = 'field-client-id';
+
+await jest.unstable_mockModule( '@wordpress/block-editor', () => ( {
+	RichText: jest.fn( () => null ),
+	store: 'core/block-editor',
+	useBlockProps: jest.fn( args => {
+		blockPropsArg = args;
+		return args;
+	} ),
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/data', () => ( {
+	// Run the real mapSelect against a fake `select` so the hooks under test
+	// (useFieldContext in particular) actually execute.
+	useSelect: jest.fn( mapSelect =>
+		mapSelect( () => ( {
+			getBlockRootClientId: clientId => ( clientId === LABEL_CLIENT_ID ? FIELD_CLIENT_ID : null ),
+			getBlock: clientId => fakeBlocks[ clientId ],
+			getSettings: () => ( { isPreviewMode: false } ),
+		} ) )
+	),
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/element', () => ( {
+	useCallback: jest.fn( fn => fn ),
+} ) );
+
+await jest.unstable_mockModule( '@wordpress/i18n', () => ( {
+	__: jest.fn( str => str ),
+} ) );
+
+await jest.unstable_mockModule( '../../shared/hooks/use-synced-attributes.jsx', () => ( {
+	useSyncedAttributes: jest.fn(),
+} ) );
+
+await jest.unstable_mockModule( '../../shared/hooks/use-variation-style-properties.js', () => ( {
+	default: jest.fn( () => ( {} ) ),
+} ) );
+
+const LabelEdit = ( await import( '../edit.jsx' ) ).default;
+
+/**
+ * Builds the parent field block returned by the fake store.
+ *
+ * @param {string} fieldName - The parent field block name.
+ * @param {string} inputName - The inner input block name.
+ */
+const setParentField = ( fieldName, inputName ) => {
+	fakeBlocks = {
+		[ FIELD_CLIENT_ID ]: {
+			name: fieldName,
+			innerBlocks: [ { name: inputName, attributes: {} } ],
+		},
+	};
+};
+
+/**
+ * Invokes the label block and returns the className it computed.
+ *
+ * @param {string} formClassName - The parent form's className attribute.
+ * @return {string} The className passed to useBlockProps.
+ */
+const getLabelClassName = formClassName => {
+	blockPropsArg = undefined;
+	LabelEdit( {
+		clientId: LABEL_CLIENT_ID,
+		name: 'jetpack/label',
+		attributes: { label: 'How happy are you?', placeholder: '', requiredText: '' },
+		setAttributes: jest.fn(),
+		context: {
+			'jetpack/form-class-name': formClassName,
+			'jetpack/field-required': false,
+			'jetpack/field-date-format': undefined,
+			'jetpack/field-share-attributes': false,
+		},
+	} );
+	return blockPropsArg.className;
+};
+
+describe( 'LabelEdit inset label classes', () => {
+	beforeEach( () => {
+		setParentField( 'jetpack/field-name', 'jetpack/input' );
+	} );
+
+	test.each( [
+		[ 'is-style-outlined', 'notched-label__label' ],
+		[ 'is-style-animated', 'animated-label__label' ],
+	] )( 'a text field gets its inset label under %s', ( formClassName, expectedClass ) => {
+		expect( getLabelClassName( formClassName ) ).toContain( expectedClass );
+	} );
+
+	test.each( [ [ 'is-style-outlined' ], [ 'is-style-animated' ] ] )(
+		'the slider field gets no inset label under %s',
+		formClassName => {
+			setParentField( 'jetpack/field-slider', 'jetpack/input-range' );
+
+			const className = getLabelClassName( formClassName );
+
+			expect( className ).not.toContain( 'notched-label__label' );
+			expect( className ).not.toContain( 'animated-label__label' );
+			expect( className ).toContain( 'jetpack-field-label' );
+		}
+	);
+
+	test( 'the slider field still gets the below label, which renders outside the field', () => {
+		setParentField( 'jetpack/field-slider', 'jetpack/input-range' );
+
+		expect( getLabelClassName( 'is-style-below' ) ).toContain( 'below-label__label' );
+	} );
+
+	test( 'the default form style adds no style-specific class', () => {
+		const className = getLabelClassName( 'is-style-default' );
+
+		expect( className ).toBe( 'jetpack-field-label' );
+	} );
+} );

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -833,7 +833,9 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$form_style = $this->get_form_style();
 
 		if ( ! empty( $form_style ) && $form_style !== 'default' ) {
-			if ( ! in_array( $type, array( 'checkbox', 'checkbox-multiple', 'radio', 'consent', 'file' ), true ) ) {
+			// These field types have no single text-like input for an inset label to sit
+			// in, so they keep the default label rendering whatever the form style is.
+			if ( ! in_array( $type, array( 'checkbox', 'checkbox-multiple', 'radio', 'consent', 'file', 'slider' ), true ) ) {
 				switch ( $form_style ) {
 					case 'outlined':
 						return $this->render_outline_label( $id, $label, $required, $required_field_text, $required_indicator );
@@ -3131,7 +3133,10 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$min_text_label = $extra_attrs['minLabel'] ?? '';
 		$max_text_label = $extra_attrs['maxLabel'] ?? '';
 
-		$field = $this->render_label( 'slider', $id, $label, $required, $required_field_text, array(), false, $required_indicator );
+		// $always_render must be true: 'slider' is excluded from inset labels in
+		// render_label(), so without it the label would be dropped entirely when the
+		// form uses the Outlined or Animated style.
+		$field = $this->render_label( 'slider', $id, $label, $required, $required_field_text, array(), true, $required_indicator );
 
 		ob_start();
 		?>

--- a/projects/packages/forms/src/contact-form/class-contact-form-field.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form-field.php
@@ -30,6 +30,32 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	public $shortcode_name = 'contact-field';
 
 	/**
+	 * Field types that never render a style-specific label.
+	 *
+	 * These have no single labellable input — they are groups of inputs, or a
+	 * control with its own labelling — so every non-default form style falls back
+	 * to the plain default label.
+	 *
+	 * @var string[]
+	 */
+	const TYPES_WITHOUT_STYLED_LABEL = array( 'checkbox', 'checkbox-multiple', 'radio', 'consent', 'file' );
+
+	/**
+	 * Field types that never render an *inset* (Outlined / Animated) label.
+	 *
+	 * Their input is not a single text-like box for a label to sit inside, so an
+	 * inset label would overlap the control. Styles that render the label outside
+	 * the field, such as 'below', still apply — unlike TYPES_WITHOUT_STYLED_LABEL,
+	 * this only opts out of the inset styles.
+	 *
+	 * Keep in sync with the editor (`blocks/label/edit.jsx`) and the wrapper
+	 * exclusion list in `contact-form/css/grunion.scss`.
+	 *
+	 * @var string[]
+	 */
+	const TYPES_WITHOUT_INSET_LABEL = array( 'slider' );
+
+	/**
 	 * The parent form.
 	 *
 	 * @var Contact_Form
@@ -833,14 +859,18 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$form_style = $this->get_form_style();
 
 		if ( ! empty( $form_style ) && $form_style !== 'default' ) {
-			// These field types have no single text-like input for an inset label to sit
-			// in, so they keep the default label rendering whatever the form style is.
-			if ( ! in_array( $type, array( 'checkbox', 'checkbox-multiple', 'radio', 'consent', 'file', 'slider' ), true ) ) {
+			if ( ! in_array( $type, self::TYPES_WITHOUT_STYLED_LABEL, true ) ) {
 				switch ( $form_style ) {
 					case 'outlined':
-						return $this->render_outline_label( $id, $label, $required, $required_field_text, $required_indicator );
+						if ( $this->type_has_inset_label( $type ) ) {
+							return $this->render_outline_label( $id, $label, $required, $required_field_text, $required_indicator );
+						}
+						break;
 					case 'animated':
-						return $this->render_animated_label( $id, $label, $required, $required_field_text, $required_indicator );
+						if ( $this->type_has_inset_label( $type ) ) {
+							return $this->render_animated_label( $id, $label, $required, $required_field_text, $required_indicator );
+						}
+						break;
 					case 'below':
 						return $this->render_below_label( $id, $label, $required, $required_field_text, $required_indicator );
 				}
@@ -2950,7 +2980,13 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 	}
 
 	/**
-	 * Checks if the field has an inset label, i.e., a label displayed inside the field instead of above.
+	 * Checks if the form style renders labels inside the field rather than above it.
+	 *
+	 * This is a property of the *style* alone: it stays true for a field type that
+	 * opts out of the inset label itself, because it also governs the extra
+	 * `.contact-form__inset-label-wrap` wrapper, which those fields still need (it
+	 * carries the field width). Use type_has_inset_label() to decide whether a given
+	 * field actually renders an inset label.
 	 *
 	 * @return boolean
 	 */
@@ -2958,6 +2994,19 @@ class Contact_Form_Field extends Contact_Form_Shortcode {
 		$form_style = $this->get_form_style();
 
 		return in_array( $form_style, array( 'outlined', 'animated' ), true );
+	}
+
+	/**
+	 * Checks whether a field type renders an inset label under the current form style.
+	 *
+	 * @param string $type The field type.
+	 *
+	 * @return boolean
+	 */
+	private function type_has_inset_label( $type ) {
+		return $this->has_inset_label()
+			&& ! in_array( $type, self::TYPES_WITHOUT_STYLED_LABEL, true )
+			&& ! in_array( $type, self::TYPES_WITHOUT_INSET_LABEL, true );
 	}
 
 	/**

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -893,7 +893,8 @@
 		.grunion-field-radio-wrap,
 		.grunion-field-select-wrap,
 		.grunion-field-file-wrap,
-		.grunion-field-phone-wrap
+		.grunion-field-phone-wrap,
+		.grunion-field-slider-wrap
 	) {
 		position: relative;
 		display: flex;

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -1705,6 +1705,8 @@ class Contact_Form_Test extends BaseTestCase {
 	 * keep the plain default label under the inset styles rather than have the label
 	 * positioned over the slider track.
 	 *
+	 * @dataProvider inset_label_form_style_provider
+	 *
 	 * @param string $form_class_name The contact form's className attribute.
 	 */
 	#[DataProvider( 'inset_label_form_style_provider' )]
@@ -1719,6 +1721,8 @@ class Contact_Form_Test extends BaseTestCase {
 	 * Excluding a type from the inset label makes render_label() fall through to its
 	 * `! $always_render` early return, so the slider must pass $always_render = true
 	 * or its label disappears entirely under the inset styles.
+	 *
+	 * @dataProvider inset_label_form_style_provider
 	 *
 	 * @param string $form_class_name The contact form's className attribute.
 	 */
@@ -1744,6 +1748,8 @@ class Contact_Form_Test extends BaseTestCase {
 	/**
 	 * The exclusion must be scoped to the slider: ordinary text-like fields still get
 	 * their inset label under the same form styles.
+	 *
+	 * @dataProvider inset_label_form_style_provider
 	 *
 	 * @param string $form_class_name The contact form's className attribute.
 	 */

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -1668,6 +1668,104 @@ class Contact_Form_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Renders a slider field, optionally under a given form style.
+	 *
+	 * @param string $form_class_name The contact form's className attribute, e.g. 'is-style-outlined'.
+	 *
+	 * @return string The field html string.
+	 */
+	private function render_slider_field( $form_class_name = '' ) {
+		return $this->render_field(
+			array(
+				'label'               => 'How happy are you?',
+				'type'                => 'slider',
+				'fieldwrapperclasses' => 'wp-block-jetpack-field-slider',
+				'id'                  => 'sliderID',
+				'min'                 => 0,
+				'max'                 => 100,
+			),
+			$form_class_name ? array( 'className' => $form_class_name ) : array()
+		);
+	}
+
+	/**
+	 * Form styles that render an inset (in-field) label.
+	 *
+	 * @return array
+	 */
+	public static function inset_label_form_style_provider() {
+		return array(
+			'outlined' => array( 'is-style-outlined' ),
+			'animated' => array( 'is-style-animated' ),
+		);
+	}
+
+	/**
+	 * The slider has no single text-like input for a label to sit inside, so it must
+	 * keep the plain default label under the inset styles rather than have the label
+	 * positioned over the slider track.
+	 *
+	 * @param string $form_class_name The contact form's className attribute.
+	 */
+	#[DataProvider( 'inset_label_form_style_provider' )]
+	public function test_slider_field_does_not_render_an_inset_label( $form_class_name ) {
+		$html = $this->render_slider_field( $form_class_name );
+
+		$this->assertStringNotContainsString( 'notched-label__label', $html );
+		$this->assertStringNotContainsString( 'animated-label__label', $html );
+	}
+
+	/**
+	 * Excluding a type from the inset label makes render_label() fall through to its
+	 * `! $always_render` early return, so the slider must pass $always_render = true
+	 * or its label disappears entirely under the inset styles.
+	 *
+	 * @param string $form_class_name The contact form's className attribute.
+	 */
+	#[DataProvider( 'inset_label_form_style_provider' )]
+	public function test_slider_field_still_renders_its_label( $form_class_name ) {
+		$html = $this->render_slider_field( $form_class_name );
+
+		$this->assertStringContainsString( 'How happy are you?', $html );
+		$this->assertStringContainsString( '<label', $html );
+	}
+
+	/**
+	 * The 'below' style renders the label outside the field, so it is unaffected by
+	 * the inset-label exclusion and must still apply to sliders.
+	 */
+	public function test_slider_field_still_uses_the_below_label() {
+		$html = $this->render_slider_field( 'is-style-below' );
+
+		$this->assertStringContainsString( 'below-label__label', $html );
+		$this->assertStringContainsString( 'How happy are you?', $html );
+	}
+
+	/**
+	 * The exclusion must be scoped to the slider: ordinary text-like fields still get
+	 * their inset label under the same form styles.
+	 *
+	 * @param string $form_class_name The contact form's className attribute.
+	 */
+	#[DataProvider( 'inset_label_form_style_provider' )]
+	public function test_text_field_still_renders_an_inset_label( $form_class_name ) {
+		$html = $this->render_field(
+			array(
+				'label' => 'Name',
+				'type'  => 'text',
+				'id'    => 'nameID',
+			),
+			array( 'className' => $form_class_name )
+		);
+
+		$expected_class = $form_class_name === 'is-style-outlined'
+			? 'notched-label__label'
+			: 'animated-label__label';
+
+		$this->assertStringContainsString( $expected_class, $html );
+	}
+
+	/**
 	 * Renders a Contact_Form_Field.
 	 *
 	 * @param array $attributes An associative array of shortcode attributes.


### PR DESCRIPTION
Fixes #

## Proposed changes

The Slider field was being treated as a text-like input by the inset-label system, so applying the **Outlined** or **Animated** form style broke its layout in both the editor and the front end. The label was laid over the slider track, and the field's rows were laid out side-by-side and reversed.

Sliders now keep the Default field rendering under those two styles — the same approach already taken for checkbox, radio, consent and file fields.

Two independent causes:

* **The label got an inset class it could never use.** `render_label()` excluded `checkbox`, `checkbox-multiple`, `radio`, `consent` and `file` from inset labels, but not `slider`, so the slider received an absolutely-positioned `animated-label__label` / `notched-label__label` on top of its track. The editor did the same, applying those classes purely from the form style with no field-type check. The float-up CSS could never fire for a slider anyway: those selectors use the sibling combinator `~ .grunion-field`, but the slider's range input is nested two levels deep inside `.jetpack-field-slider__input-container`.
* **The wrapper was flexed.** `.grunion-field-slider-wrap` was not in the exclusion list for the `display: flex; flex-direction: row-reverse` rule shared by the Outlined and Animated styles, so the slider's input row and its min/max text-label row were laid out horizontally and reversed.

### Changes

**`class-contact-form-field.php`** — two separate rules, rather than one conflated list:

* `TYPES_WITHOUT_STYLED_LABEL` (checkbox, checkbox-multiple, radio, consent, file) — no style-specific label under *any* form style. Existing behaviour, now a named constant.
* `TYPES_WITHOUT_INSET_LABEL` (`slider`) — opts out of the *inset* styles only. Styles that render the label outside the field, such as `below`, still apply.
* New `type_has_inset_label( $type )` combines style and type, and is checked inside the `outlined` and `animated` cases so `below` and unknown `is-style-*` values keep their existing paths.
* `render_slider_field()` passes `$always_render = true`. This is required: an excluded type otherwise falls through to `return ''` and the label disappears entirely under both styles. `file` sets it for the same reason.
* `has_inset_label()` stays style-only by design — it also governs the `.contact-form__inset-label-wrap` wrapper, which carries field width, so narrowing it would be a regression. The docblock now says so explicitly.

**`label/edit.jsx`**

* `useSiblingBlock` is now `useFieldContext`, returning `{ inputBlock, parentName }`, so the parent field name comes from the existing subscription rather than a second one.
* `FIELDS_WITHOUT_INSET_LABEL` mirrors the PHP constant; the inset classes are skipped for `jetpack/field-slider`, and `below-label__label` is left alone so the two renderers agree.
* `forcePlainStyle={ ! inputBlock || ! hasInsetLabel }` — previously the slider escaped the Outlined notch wrapper only because `useSiblingBlock` happened not to find its `jetpack/input-range` child. This makes the invariant explicit, so the next excluded field type whose input *is* a `jetpack/input` doesn't get a notch box painted over it.

**`grunion.scss`** — `.grunion-field-slider-wrap` added to the `row-reverse` exclusion list.

### Tests

* PHP (`Contact_Form_Test`): slider renders no inset label under Outlined/Animated; slider still renders its label at all (pins `$always_render`); slider still uses `below-label__label` under `is-style-below`; a text field still gets its inset label, so the exclusion can't quietly widen.
* JS (`src/blocks/label/test/edit.test.js`): the same matrix for the editor.

Each test was mutation-checked against the specific regression it targets — reverting `$always_render`, restoring the old broad `in_array`, and forcing `hasInsetLabel = true` each fail the expected tests.

The label is not bold under the Outlined style, since it now inherits that style's lighter label weight. That is intentional and consistent with how the field renders in the Default style.

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Create a page with a **Form** block and add a **Slider** field to it.
* In the block inspector, set the form's style to **Animated**.
* Confirm in the editor that the slider label sits above the value bubble and track, exactly as it does under the **Default** style — it should not overlap the track or be clipped.
* Repeat with the **Outlined** style. The label should again sit above the field (it will use the lighter Outlined label weight).
* Publish the page and confirm the same on the front end for both styles.
* Confirm no regression for the other fields: with the form still set to Animated or Outlined, the Name, Email and Textarea fields must still show their floating/notched inset labels.

### Before / After — front end

| Style | Before | After |
|---|---|---|
| Animated | ![before](https://raw.githubusercontent.com/Automattic/jetpack/5bdc91767da7ca11d06c7e70ab141a3d0e23358d/before-frontend-animated.png) | ![after](https://raw.githubusercontent.com/Automattic/jetpack/5bdc91767da7ca11d06c7e70ab141a3d0e23358d/after-frontend-animated.png) |
| Outlined | ![before](https://raw.githubusercontent.com/Automattic/jetpack/5bdc91767da7ca11d06c7e70ab141a3d0e23358d/before-frontend-outlined.png) | ![after](https://raw.githubusercontent.com/Automattic/jetpack/5bdc91767da7ca11d06c7e70ab141a3d0e23358d/after-frontend-outlined.png) |

### Before / After — editor

| Style | Before | After |
|---|---|---|
| Animated | ![before](https://raw.githubusercontent.com/Automattic/jetpack/5bdc91767da7ca11d06c7e70ab141a3d0e23358d/before-editor-animated.png) | ![after](https://raw.githubusercontent.com/Automattic/jetpack/5bdc91767da7ca11d06c7e70ab141a3d0e23358d/after-editor-animated.png) |
| Outlined | ![before](https://raw.githubusercontent.com/Automattic/jetpack/5bdc91767da7ca11d06c7e70ab141a3d0e23358d/before-editor-outlined.png) | ![after](https://raw.githubusercontent.com/Automattic/jetpack/5bdc91767da7ca11d06c7e70ab141a3d0e23358d/after-editor-outlined.png) |
