### PR TITLE
Forms: keep the rating field's default rendering under the Outlined and Animated styles

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-rating-animated-style
+++ b/projects/packages/forms/changelog/fix-forms-rating-animated-style
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Rating field: keep the default left-aligned, borderless rendering under the Outlined and Animated form styles.

--- a/projects/packages/forms/src/blocks/label/edit.jsx
+++ b/projects/packages/forms/src/blocks/label/edit.jsx
@@ -28,8 +28,10 @@ const OPTIONS_FIELDS = [ 'jetpack/field-radio', 'jetpack/field-checkbox-multiple
 
 // Field blocks whose input is not a single text-like box, so an inset
 // (notched/animated) label would overlap the control rather than sit in it.
-// Keep in sync with Contact_Form_Field::TYPES_WITHOUT_INSET_LABEL.
-const FIELDS_WITHOUT_INSET_LABEL = [ 'jetpack/field-slider' ];
+// The slider's front-end counterpart is Contact_Form_Field::TYPES_WITHOUT_INSET_LABEL.
+// The rating field needs no entry there: it renders its label as a legend via
+// render_legend_as_label() and never reaches render_label().
+const FIELDS_WITHOUT_INSET_LABEL = [ 'jetpack/field-slider', 'jetpack/field-rating' ];
 
 // Stable reference for "no input block found", so useSelect's shallow comparison
 // does not see a new object on every store change.
@@ -117,9 +119,10 @@ const LabelEdit = ( { clientId, attributes, name, setAttributes, context } ) => 
 
 	const { inputBlock, parentName } = useFieldContext( clientId );
 
-	// The slider is not a text-like input: it has no empty state to rest in and its
-	// range input is nested inside a wrapper, so an inset (notched/animated) label
-	// would sit on top of the track instead of animating. Keep the default label.
+	// Neither field is a text-like input: the slider has no empty state to rest in
+	// and its range input is nested inside a wrapper, and the rating field is a group
+	// of radio inputs. An inset (notched/animated) label would sit on top of the
+	// control instead of animating, so keep the default label.
 	// 'below' renders the label outside the field, so it still applies.
 	const hasInsetLabel = ! FIELDS_WITHOUT_INSET_LABEL.includes( parentName );
 

--- a/projects/packages/forms/src/blocks/label/test/edit.test.js
+++ b/projects/packages/forms/src/blocks/label/test/edit.test.js
@@ -98,23 +98,28 @@ describe( 'LabelEdit inset label classes', () => {
 		expect( getLabelClassName( formClassName ) ).toContain( expectedClass );
 	} );
 
-	test.each( [ [ 'is-style-outlined' ], [ 'is-style-animated' ] ] )(
-		'the slider field gets no inset label under %s',
-		formClassName => {
-			setParentField( 'jetpack/field-slider', 'jetpack/input-range' );
+	describe.each( [
+		[ 'slider', 'jetpack/field-slider', 'jetpack/input-range' ],
+		[ 'rating', 'jetpack/field-rating', 'jetpack/input-rating' ],
+	] )( 'the %s field', ( fieldLabel, fieldName, inputName ) => {
+		test.each( [ [ 'is-style-outlined' ], [ 'is-style-animated' ] ] )(
+			'gets no inset label under %s',
+			formClassName => {
+				setParentField( fieldName, inputName );
 
-			const className = getLabelClassName( formClassName );
+				const className = getLabelClassName( formClassName );
 
-			expect( className ).not.toContain( 'notched-label__label' );
-			expect( className ).not.toContain( 'animated-label__label' );
-			expect( className ).toContain( 'jetpack-field-label' );
-		}
-	);
+				expect( className ).not.toContain( 'notched-label__label' );
+				expect( className ).not.toContain( 'animated-label__label' );
+				expect( className ).toContain( 'jetpack-field-label' );
+			}
+		);
 
-	test( 'the slider field still gets the below label, which renders outside the field', () => {
-		setParentField( 'jetpack/field-slider', 'jetpack/input-range' );
+		test( 'still gets the below label, which renders outside the field', () => {
+			setParentField( fieldName, inputName );
 
-		expect( getLabelClassName( 'is-style-below' ) ).toContain( 'below-label__label' );
+			expect( getLabelClassName( 'is-style-below' ) ).toContain( 'below-label__label' );
+		} );
 	} );
 
 	test( 'the default form style adds no style-specific class', () => {

--- a/projects/packages/forms/src/contact-form/css/grunion.scss
+++ b/projects/packages/forms/src/contact-form/css/grunion.scss
@@ -894,7 +894,8 @@
 		.grunion-field-select-wrap,
 		.grunion-field-file-wrap,
 		.grunion-field-phone-wrap,
-		.grunion-field-slider-wrap
+		.grunion-field-slider-wrap,
+		.grunion-field-rating-wrap
 	) {
 		position: relative;
 		display: flex;
@@ -1254,7 +1255,7 @@ on production builds, the attributes are being reordered, causing side-effects
 }
 
 /* fields with multiple options */
-.wp-block-jetpack-contact-form:not(.is-style-outlined) .jetpack-field-multiple__fieldset {
+.wp-block-jetpack-contact-form .jetpack-field-multiple__fieldset {
 	padding: 8px 0 0 0;
 	border: 0;
 	margin: 0;

--- a/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Contact_Form_Test.php
@@ -1772,6 +1772,63 @@ class Contact_Form_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Renders a rating field, optionally under a given form style.
+	 *
+	 * @param string $form_class_name The contact form's className attribute, e.g. 'is-style-outlined'.
+	 *
+	 * @return string The field html string.
+	 */
+	private function render_rating_field( $form_class_name = '' ) {
+		return $this->render_field(
+			array(
+				'label'               => 'Rate your experience',
+				'type'                => 'rating',
+				'fieldwrapperclasses' => 'wp-block-jetpack-field-rating',
+				'id'                  => 'ratingID',
+				'max'                 => 5,
+			),
+			$form_class_name ? array( 'className' => $form_class_name ) : array()
+		);
+	}
+
+	/**
+	 * The rating field is a group of radio inputs with no single text-like box, so it
+	 * must keep its plain legend label under the inset styles rather than have the
+	 * label positioned over the icons.
+	 *
+	 * Unlike the slider, it reaches this via render_legend_as_label() and never calls
+	 * render_label(), so it needs no entry in TYPES_WITHOUT_INSET_LABEL. This test
+	 * guards that assumption.
+	 *
+	 * @dataProvider inset_label_form_style_provider
+	 *
+	 * @param string $form_class_name The contact form's className attribute.
+	 */
+	#[DataProvider( 'inset_label_form_style_provider' )]
+	public function test_rating_field_does_not_render_an_inset_label( $form_class_name ) {
+		$html = $this->render_rating_field( $form_class_name );
+
+		$this->assertStringNotContainsString( 'notched-label__label', $html );
+		$this->assertStringNotContainsString( 'animated-label__label', $html );
+	}
+
+	/**
+	 * The rating field's label must survive under the inset styles, rendered as the
+	 * fieldset's legend.
+	 *
+	 * @dataProvider inset_label_form_style_provider
+	 *
+	 * @param string $form_class_name The contact form's className attribute.
+	 */
+	#[DataProvider( 'inset_label_form_style_provider' )]
+	public function test_rating_field_still_renders_its_label( $form_class_name ) {
+		$html = $this->render_rating_field( $form_class_name );
+
+		$this->assertStringContainsString( 'Rate your experience', $html );
+		$this->assertStringContainsString( '<legend', $html );
+	}
+
+	/**
 	 * Renders a Contact_Form_Field.
 	 *
 	 * @param array $attributes An associative array of shortcode attributes.


### PR DESCRIPTION
Fixes #

## Proposed changes

The Rating field was laid out as if it were a text-like input by the Outlined and Animated form styles, so it rendered right-aligned and wrapped in a stray border. It now keeps its Default rendering whatever style the form uses — the same approach already taken for checkbox, radio, consent and file fields. The only intended difference between styles is the label's font weight, which the existing rules already handle.

Three independent causes:

* **The wrapper was flexed.** `.grunion-field-rating-wrap` was not in the exclusion list for the `display: flex; flex-direction: row-reverse` rule shared by the Outlined and Animated styles, so the field's single fieldset became a flex item, shrank to its content width and was pushed to the right edge of the form.
* **The fieldset kept the browser's default chrome.** The reset that zeroes a `<fieldset>`'s border, padding and margin was scoped `:not(.is-style-outlined)`, so under Outlined the Rating field inherited the UA default `border: 2px groove` plus fieldset padding and margin. This is what produced both the unwanted border and the indent.
* **The editor label got an inset class it could never use.** `label/edit.jsx` applies `animated-label__label` / `notched-label__label` purely from the form style, with no field-type check, so the Rating field's label was absolutely positioned on top of its icons under the Animated style. (Note for reviewers: the existing `useSiblingBlock()` helper can't be used to detect this — it only ever looks for `jetpack/input`, `jetpack/options` or `jetpack/phone-input`, so it returns `undefined` for the Rating field's `jetpack/input-rating`.)

Changes:

* `label/edit.jsx` — add `jetpack/field-rating` to the `FIELDS_WITHOUT_INSET_LABEL` list introduced by #51124.
* `grunion.scss` — add `.grunion-field-rating-wrap` to the `row-reverse` exclusion list, and drop the `:not(.is-style-outlined)` qualifier from the `jetpack-field-multiple__fieldset` reset.
* Tests — extend #51124's `label/edit.test.js` cases to cover the rating field alongside the slider, and add PHP coverage asserting the rating field renders its legend and no inset label under both styles.

**Rebased on trunk after #51124 merged.** That PR introduced `FIELDS_WITHOUT_INSET_LABEL` and a `useFieldContext()` hook that return the parent block name — the same structures this PR had been carrying separately — so the editor half is now a one-line addition to its list rather than a parallel mechanism. The rating field deliberately gets **no** entry in `Contact_Form_Field::TYPES_WITHOUT_INSET_LABEL`: unlike the slider it renders its label through `render_legend_as_label()` and never reaches `render_label()`, so an entry there would never execute. The comment on the JS list says so, and the new PHP test guards the assumption.

On dropping the `:not()`: that qualifier was never doing what it looked like it was doing. `jetpack-field-multiple__fieldset` is emitted in exactly three places, and for radio (`class-contact-form-field.php:1444`) and checkbox-multiple (`:1937`) it is in the **`else`** branch of `if ( $is_outlined_style )` — under Outlined those two emit `grunion-radio-options` / `grunion-checkbox-multiple-options` instead and get their box from `grunion.scss:192`. So the only element carrying that class under Outlined is the Rating fieldset at `:3085`, and the unqualified selector matches the identical set. Verified live under all four styles; see the regression check below.

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Create a page with a **Form** block and add a **Rating** field to it. Add a second one and set its variation to **Hearts** so both icon styles are covered.
* Keep a **Name** and a **Textarea** field in the form — they are the control: they must keep their floating/notched inset labels throughout.
* In the block inspector, set the form's style to **Animated**.
* Confirm in the editor that both rating labels sit above their icons rather than on top of them.
* Publish the page and confirm on the front end that both rating fields are left-aligned with the rest of the form and have no border around them.
* Repeat with the **Outlined** style. The field should again be left-aligned and borderless; its label will use the lighter Outlined label weight, which is expected and matches the Default style's behaviour.
* Switch the form back to the **Default** style and confirm nothing changed there.
* **Regression check for the `:not()` removal:** on a form containing a **Radio** field and a **Checkbox multiple** field, confirm under **Outlined** that both still render inside their bordered box with the legend notched into the top border, and that nothing changes for them under Animated or Default.

### Before / After — front end

| Style | Before | After |
|---|---|---|
| Animated | ![before](https://raw.githubusercontent.com/Automattic/jetpack/8670c595ec4f00f2570fe0c512e9f4c146ffd41c/before-frontend-animated.png) | ![after](https://raw.githubusercontent.com/Automattic/jetpack/8670c595ec4f00f2570fe0c512e9f4c146ffd41c/after-frontend-animated.png) |
| Outlined | ![before](https://raw.githubusercontent.com/Automattic/jetpack/8670c595ec4f00f2570fe0c512e9f4c146ffd41c/before-frontend-outlined.png) | ![after](https://raw.githubusercontent.com/Automattic/jetpack/8670c595ec4f00f2570fe0c512e9f4c146ffd41c/after-frontend-outlined.png) |
| Default (no change expected) | ![before](https://raw.githubusercontent.com/Automattic/jetpack/8670c595ec4f00f2570fe0c512e9f4c146ffd41c/before-frontend-default.png) | ![after](https://raw.githubusercontent.com/Automattic/jetpack/8670c595ec4f00f2570fe0c512e9f4c146ffd41c/after-frontend-default.png) |

### Before / After — editor

The editor regression only affected the Animated style. Under Outlined the label was given the `notched-label__label` class too, but that class is inert without a `.notched-label` ancestor, which the Rating field never gets — so the Outlined editor view was already correct and is unchanged here. It is included below for completeness.

| Style | Before | After |
|---|---|---|
| Animated | ![before](https://raw.githubusercontent.com/Automattic/jetpack/8670c595ec4f00f2570fe0c512e9f4c146ffd41c/before-editor-animated.png) | ![after](https://raw.githubusercontent.com/Automattic/jetpack/8670c595ec4f00f2570fe0c512e9f4c146ffd41c/after-editor-animated.png) |
| Outlined (no change expected) | ![before](https://raw.githubusercontent.com/Automattic/jetpack/8670c595ec4f00f2570fe0c512e9f4c146ffd41c/before-editor-outlined.png) | ![after](https://raw.githubusercontent.com/Automattic/jetpack/8670c595ec4f00f2570fe0c512e9f4c146ffd41c/after-editor-outlined.png) |

### Regression check — radio and checkbox-multiple alongside rating

Taken after the `:not()` removal, on a form containing all three field types.

| Outlined | Animated |
|---|---|
| ![outlined](https://raw.githubusercontent.com/Automattic/jetpack/40c1acfee18cb1513d29e4e0213286f41baeed96/check-opts-outlined.png) | ![animated](https://raw.githubusercontent.com/Automattic/jetpack/40c1acfee18cb1513d29e4e0213286f41baeed96/check-opts-animated.png) |

### A note on the Below style

`FIELDS_WITHOUT_INSET_LABEL` gates the Outlined and Animated inset labels only; the Below style renders the label outside the field and still applies, matching the slider's behaviour from #51124. The Below style was also checked on a real form: the editor and the front end both render the Rating label above the icons, so there is no editor/front-end split to close there. Screenshot: [editor under Below](https://raw.githubusercontent.com/Automattic/jetpack/40c1acfee18cb1513d29e4e0213286f41baeed96/check-below-editor.png).
