### PR TITLE
Forms: open responses on the standalone single response page

### DIFF
--- a/projects/packages/forms/changelog/fix-forms-view-action
+++ b/projects/packages/forms/changelog/fix-forms-view-action
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Responses: open a response on its own page from the list's View action and from response notification emails, and keep the user on that page when a response is marked as spam or trashed.
+Responses: open a response on its own page from the list's View action and from both response notification email buttons, and keep the user on that page when a response is marked as spam or trashed.

--- a/projects/packages/forms/changelog/fix-forms-view-action
+++ b/projects/packages/forms/changelog/fix-forms-view-action
@@ -1,4 +1,4 @@
 Significance: minor
 Type: changed
 
-Responses: open a response on its own page from the list's View action and from both response notification email buttons, and keep the user on that page when a response is marked as spam or trashed.
+Responses: Open a response on its own page from the list's View action and from both response notification email buttons, and keep the user on that page when a response is marked as spam or trashed.

--- a/projects/packages/forms/changelog/fix-forms-view-action
+++ b/projects/packages/forms/changelog/fix-forms-view-action
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Responses: open a response on its own page from the list's View action and from response notification emails, and keep the user on that page when a response is marked as spam or trashed.

--- a/projects/packages/forms/routes/response/page-actions.tsx
+++ b/projects/packages/forms/routes/response/page-actions.tsx
@@ -13,6 +13,7 @@ import * as React from 'react';
  * Internal dependencies
  */
 import { getActions } from '../responses/actions.tsx';
+import getResponseQuery from './query.ts';
 import repairResponseRecord from './repair-record.ts';
 /**
  * Types
@@ -91,7 +92,8 @@ export default function SingleResponseActions( {
 				repairResponseRecord(
 					registry.dispatch( coreStore ).receiveEntityRecords,
 					response,
-					nextStatus
+					nextStatus,
+					getResponseQuery( response.id )
 				);
 			}
 		},

--- a/projects/packages/forms/routes/response/page-actions.tsx
+++ b/projects/packages/forms/routes/response/page-actions.tsx
@@ -4,7 +4,7 @@
 import { DropdownMenu } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useRegistry } from '@wordpress/data';
-import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
 import { useNavigate } from '@wordpress/route';
@@ -39,18 +39,22 @@ type Control = {
  * stays put, each accepted change is followed by a store repair (see
  * `changeStatus`) and the menu is disabled while a change is in flight.
  *
- * @param props           - Component props.
- * @param props.response  - The response being viewed.
- * @param props.isBlocked - Whether another mutation on this response is in flight
- *                        (e.g. the spam confirmation dialog saving).
+ * @param props              - Component props.
+ * @param props.response     - The response being viewed.
+ * @param props.isBlocked    - Whether another mutation on this response is in flight
+ *                           (e.g. the spam confirmation dialog saving).
+ * @param props.onBusyChange - Reports this menu's own in-flight state upwards, so the
+ *                           page can gate navigation on it too.
  * @return The actions dropdown.
  */
 export default function SingleResponseActions( {
 	response,
 	isBlocked = false,
+	onBusyChange,
 }: {
 	response: FormResponse;
 	isBlocked?: boolean;
+	onBusyChange?: ( isBusy: boolean ) => void;
 } ): React.JSX.Element {
 	const registry = useRegistry() as unknown as Registry;
 	const navigate = useNavigate();
@@ -65,6 +69,12 @@ export default function SingleResponseActions( {
 	// synchronously; the state only drives the disabled/busy toggle.
 	const isRunningRef = useRef( false );
 	const [ isPending, setIsPending ] = useState( false );
+
+	// The page owns the combined in-flight signal; report ours so navigation is
+	// gated while a menu action runs, not just while the dialog saves.
+	useEffect( () => {
+		onBusyChange?.( isPending );
+	}, [ isPending, onBusyChange ] );
 
 	const runAction = useCallback(
 		async ( action: Action ) => {

--- a/projects/packages/forms/routes/response/page-actions.tsx
+++ b/projects/packages/forms/routes/response/page-actions.tsx
@@ -4,7 +4,7 @@
 import { DropdownMenu } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useRegistry } from '@wordpress/data';
-import { useCallback, useMemo } from '@wordpress/element';
+import { useCallback, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
 import { useNavigate } from '@wordpress/route';
@@ -39,7 +39,9 @@ type Control = {
  *
  * Status changes (spam / not spam / trash / restore) keep the user on this page —
  * the header badge reflects the new status instead. Only a permanent delete
- * navigates away, since there is no longer a response to show.
+ * navigates away, since there is no longer a response to show. Because the user
+ * stays put, each accepted change is followed by a store repair (see `runAction`)
+ * and the menu is disabled while a change is in flight.
  *
  * @param props          - Component props.
  * @param props.response - The response being viewed.
@@ -56,34 +58,82 @@ export default function SingleResponseActions( {
 	const actions = useMemo( () => getActions( { navigate } ), [ navigate ] );
 	const currentView = VIEW_BY_STATUS[ response.status ] || 'inbox';
 
+	// One response, one action at a time. Every status change used to navigate away
+	// immediately, which guarded this for free; keeping the user here means a second
+	// click (double-clicked Trash, or Trash then Restore) would otherwise fire against
+	// a stale `response.status`, duplicating requests and double-applying the
+	// optimistic count deltas in `processStatusChange`.
+	const [ isPending, setIsPending ] = useState( false );
+
 	const runAction = useCallback(
 		async ( action: Action, nextStatus?: FormResponse[ 'status' ] ) => {
-			await action.callback?.( [ response ], { registry } );
-
-			// Trashing goes through `deleteEntityRecord`, which removes the record
-			// from core-data entirely — this page would then render its "not found"
-			// state. Put it back (carrying the new status) so the user keeps looking
-			// at the response they just actioned. The responses list does the same
-			// after trashing, to keep its Undo working.
-			if ( nextStatus === 'trash' ) {
-				registry
-					.dispatch( coreStore )
-					.receiveEntityRecords(
-						'postType',
-						'feedback',
-						[ { ...response, status: 'trash' } ],
-						undefined,
-						true
-					);
+			if ( isPending ) {
+				return;
 			}
+
+			setIsPending( true );
+
+			let result;
+			try {
+				result = await action.callback?.( [ response ], { registry } );
+			} finally {
+				setIsPending( false );
+			}
+
+			// Only repair the store for a change the server actually accepted —
+			// otherwise a failed request would leave the canonical record (and so the
+			// header badge and this menu) advertising a status the response never got.
+			if ( ! nextStatus || ! result || result.numberOfErrors > 0 ) {
+				return;
+			}
+
+			// Re-receive the pre-action record carrying the new status. This repairs
+			// two things at once:
+			//
+			// - Trash goes through `deleteEntityRecord`, which drops the record from
+			//   core-data entirely, so this page would fall through to "not found".
+			// - The save-based changes (spam / not spam / restore) PUT without
+			//   `fields_format`, and the endpoint defaults that to `label-value`
+			//   (class-contact-form-endpoint.php). The response to that PUT is
+			//   received into the store, replacing the collection-shaped `fields` this
+			//   page renders from — so the body would visibly flatten into plain rows.
+			//   `response` here is still the pre-action, collection-shaped record.
+			//
+			// Same repair as PR #49827, which fixed a query-less *fetch* clobbering the
+			// collection record; these actions reopen the same door via the save.
+			registry
+				.dispatch( coreStore )
+				.receiveEntityRecords(
+					'postType',
+					'feedback',
+					[ { ...response, status: nextStatus } ],
+					undefined,
+					true
+				);
 		},
-		[ response, registry ]
+		[ isPending, response, registry ]
 	);
 
 	const deleteResponse = useCallback( async () => {
-		await actions.deleteAction.callback?.( [ response ], { registry } );
-		navigate( { to: `/responses/${ currentView }` } );
-	}, [ actions.deleteAction, response, registry, navigate, currentView ] );
+		if ( isPending ) {
+			return;
+		}
+
+		setIsPending( true );
+
+		let result;
+		try {
+			result = await actions.deleteAction.callback?.( [ response ], { registry } );
+		} finally {
+			setIsPending( false );
+		}
+
+		// `deleteAction` surfaces failures as a notice rather than throwing, so only
+		// leave the page once the response is actually gone.
+		if ( result && result.numberOfErrors === 0 ) {
+			navigate( { to: `/responses/${ currentView }` } );
+		}
+	}, [ isPending, actions.deleteAction, response, registry, navigate, currentView ] );
 
 	// Grouped controls — nested arrays render as separate menu groups, and the
 	// `controls` API closes the dropdown automatically when an item is selected.
@@ -154,6 +204,7 @@ export default function SingleResponseActions( {
 			icon={ moreVertical }
 			label={ __( 'Actions', 'jetpack-forms' ) }
 			controls={ controls }
+			toggleProps={ { disabled: isPending, isBusy: isPending } }
 		/>
 	);
 }

--- a/projects/packages/forms/routes/response/page-actions.tsx
+++ b/projects/packages/forms/routes/response/page-actions.tsx
@@ -13,6 +13,7 @@ import * as React from 'react';
  * Internal dependencies
  */
 import { getActions } from '../responses/actions.tsx';
+import repairResponseRecord from './repair-record.ts';
 /**
  * Types
  */
@@ -87,29 +88,11 @@ export default function SingleResponseActions( {
 				return;
 			}
 
-			// Re-receive the pre-action record carrying the new status. This repairs
-			// two things at once:
-			//
-			// - Trash goes through `deleteEntityRecord`, which drops the record from
-			//   core-data entirely, so this page would fall through to "not found".
-			// - The save-based changes (spam / not spam / restore) PUT without
-			//   `fields_format`, and the endpoint defaults that to `label-value`
-			//   (class-contact-form-endpoint.php). The response to that PUT is
-			//   received into the store, replacing the collection-shaped `fields` this
-			//   page renders from — so the body would visibly flatten into plain rows.
-			//   `response` here is still the pre-action, collection-shaped record.
-			//
-			// Same repair as PR #49827, which fixed a query-less *fetch* clobbering the
-			// collection record; these actions reopen the same door via the save.
-			registry
-				.dispatch( coreStore )
-				.receiveEntityRecords(
-					'postType',
-					'feedback',
-					[ { ...response, status: nextStatus } ],
-					undefined,
-					true
-				);
+			repairResponseRecord(
+				registry.dispatch( coreStore ).receiveEntityRecords,
+				response,
+				nextStatus
+			);
 		},
 		[ isPending, response, registry ]
 	);

--- a/projects/packages/forms/routes/response/page-actions.tsx
+++ b/projects/packages/forms/routes/response/page-actions.tsx
@@ -4,7 +4,7 @@
 import { DropdownMenu } from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useRegistry } from '@wordpress/data';
-import { useCallback, useMemo, useState } from '@wordpress/element';
+import { useCallback, useMemo, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { moreVertical } from '@wordpress/icons';
 import { useNavigate } from '@wordpress/route';
@@ -17,14 +17,8 @@ import repairResponseRecord from './repair-record.ts';
 /**
  * Types
  */
-import type { Action, Registry } from '../../src/dashboard/inbox/stage/types.tsx';
+import type { Action, ReportingAction, Registry } from '../../src/dashboard/inbox/stage/types.tsx';
 import type { FormResponse } from '../../src/types/index.ts';
-
-const VIEW_BY_STATUS: Record< FormResponse[ 'status' ], string > = {
-	publish: 'inbox',
-	spam: 'spam',
-	trash: 'trash',
-};
 
 type Control = {
 	title: string;
@@ -41,8 +35,8 @@ type Control = {
  * Status changes (spam / not spam / trash / restore) keep the user on this page —
  * the header badge reflects the new status instead. Only a permanent delete
  * navigates away, since there is no longer a response to show. Because the user
- * stays put, each accepted change is followed by a store repair (see `runAction`)
- * and the menu is disabled while a change is in flight.
+ * stays put, each accepted change is followed by a store repair (see
+ * `changeStatus`) and the menu is disabled while a change is in flight.
  *
  * @param props          - Component props.
  * @param props.response - The response being viewed.
@@ -57,71 +51,66 @@ export default function SingleResponseActions( {
 	const navigate = useNavigate();
 
 	const actions = useMemo( () => getActions( { navigate } ), [ navigate ] );
-	const currentView = VIEW_BY_STATUS[ response.status ] || 'inbox';
 
 	// One response, one action at a time. Every status change used to navigate away
 	// immediately, which guarded this for free; keeping the user here means a second
 	// click (double-clicked Trash, or Trash then Restore) would otherwise fire against
 	// a stale `response.status`, duplicating requests and double-applying the
-	// optimistic count deltas in `processStatusChange`.
+	// optimistic count deltas in `processStatusChange`. The ref blocks re-entry
+	// synchronously; the state only drives the disabled/busy toggle.
+	const isRunningRef = useRef( false );
 	const [ isPending, setIsPending ] = useState( false );
 
 	const runAction = useCallback(
-		async ( action: Action, nextStatus?: FormResponse[ 'status' ] ) => {
-			if ( isPending ) {
-				return;
+		async ( action: Action ) => {
+			if ( isRunningRef.current ) {
+				return undefined;
 			}
 
+			isRunningRef.current = true;
 			setIsPending( true );
 
-			let result;
 			try {
-				result = await action.callback?.( [ response ], { registry } );
+				return await action.callback?.( [ response ], { registry } );
 			} finally {
+				isRunningRef.current = false;
 				setIsPending( false );
 			}
-
-			// Only repair the store for a change the server actually accepted —
-			// otherwise a failed request would leave the canonical record (and so the
-			// header badge and this menu) advertising a status the response never got.
-			if ( ! nextStatus || ! result || result.numberOfErrors > 0 ) {
-				return;
-			}
-
-			repairResponseRecord(
-				registry.dispatch( coreStore ).receiveEntityRecords,
-				response,
-				nextStatus
-			);
 		},
-		[ isPending, response, registry ]
+		[ response, registry ]
+	);
+
+	// Only act on a change the server accepted — otherwise a failed request would
+	// leave the canonical record (and so the header badge and this menu) advertising
+	// a status the response never got.
+	const changeStatus = useCallback(
+		async ( action: ReportingAction, nextStatus: FormResponse[ 'status' ] ) => {
+			const result = await runAction( action );
+
+			if ( result && result.numberOfErrors === 0 ) {
+				repairResponseRecord(
+					registry.dispatch( coreStore ).receiveEntityRecords,
+					response,
+					nextStatus
+				);
+			}
+		},
+		[ runAction, registry, response ]
 	);
 
 	const deleteResponse = useCallback( async () => {
-		if ( isPending ) {
-			return;
-		}
-
-		setIsPending( true );
-
-		let result;
-		try {
-			result = await actions.deleteAction.callback?.( [ response ], { registry } );
-		} finally {
-			setIsPending( false );
-		}
+		const result = await runAction( actions.deleteAction );
 
 		// `deleteAction` surfaces failures as a notice rather than throwing, so only
-		// leave the page once the response is actually gone.
+		// leave the page once the response is actually gone. Delete is offered only
+		// on a trashed response, so that is where we return to.
 		if ( result && result.numberOfErrors === 0 ) {
-			navigate( { to: `/responses/${ currentView }` } );
+			navigate( { to: '/responses/trash' } );
 		}
-	}, [ isPending, actions.deleteAction, response, registry, navigate, currentView ] );
+	}, [ runAction, actions.deleteAction, navigate ] );
 
-	// Grouped controls — nested arrays render as separate menu groups, and the
-	// `controls` API closes the dropdown automatically when an item is selected.
-	// Handlers are inlined since they're only used here and all invalidate
-	// together with `runAction` whenever the response changes.
+	// Nested arrays render as separate menu groups. Handlers are inlined since they
+	// are only used here.
 	const controls = useMemo< Control[][] >( () => {
 		const toggleRead: Control = {
 			title: response.is_unread
@@ -136,18 +125,18 @@ export default function SingleResponseActions( {
 			statusControls = [
 				{
 					title: __( 'Not spam', 'jetpack-forms' ),
-					onClick: () => runAction( actions.markAsNotSpamAction, 'publish' ),
+					onClick: () => changeStatus( actions.markAsNotSpamAction, 'publish' ),
 				},
 				{
 					title: __( 'Trash', 'jetpack-forms' ),
-					onClick: () => runAction( actions.moveToTrashAction, 'trash' ),
+					onClick: () => changeStatus( actions.moveToTrashAction, 'trash' ),
 				},
 			];
 		} else if ( response.status === 'trash' ) {
 			statusControls = [
 				{
 					title: __( 'Restore', 'jetpack-forms' ),
-					onClick: () => runAction( actions.restoreAction, 'publish' ),
+					onClick: () => changeStatus( actions.restoreAction, 'publish' ),
 				},
 				{
 					title: __( 'Delete permanently', 'jetpack-forms' ),
@@ -159,11 +148,11 @@ export default function SingleResponseActions( {
 			statusControls = [
 				{
 					title: __( 'Mark as spam', 'jetpack-forms' ),
-					onClick: () => runAction( actions.markAsSpamAction, 'spam' ),
+					onClick: () => changeStatus( actions.markAsSpamAction, 'spam' ),
 				},
 				{
 					title: __( 'Trash', 'jetpack-forms' ),
-					onClick: () => runAction( actions.moveToTrashAction, 'trash' ),
+					onClick: () => changeStatus( actions.moveToTrashAction, 'trash' ),
 				},
 			];
 		}
@@ -180,7 +169,7 @@ export default function SingleResponseActions( {
 		}
 
 		return groups;
-	}, [ response, runAction, deleteResponse, actions, registry ] );
+	}, [ response, runAction, changeStatus, deleteResponse, actions, registry ] );
 
 	return (
 		<DropdownMenu

--- a/projects/packages/forms/routes/response/page-actions.tsx
+++ b/projects/packages/forms/routes/response/page-actions.tsx
@@ -2,6 +2,7 @@
  * WordPress dependencies
  */
 import { DropdownMenu } from '@wordpress/components';
+import { store as coreStore } from '@wordpress/core-data';
 import { useRegistry } from '@wordpress/data';
 import { useCallback, useMemo } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -34,9 +35,11 @@ type Control = {
  * Top-bar actions for the standalone single response page.
  *
  * All actions live in a single three-dot dropdown (the `controls` API closes the
- * menu automatically on selection). Reuses the responses route action callbacks;
- * status-changing actions navigate back to the relevant responses list
- * afterwards, since the response leaves the current view.
+ * menu automatically on selection). Reuses the responses route action callbacks.
+ *
+ * Status changes (spam / not spam / trash / restore) keep the user on this page —
+ * the header badge reflects the new status instead. Only a permanent delete
+ * navigates away, since there is no longer a response to show.
  *
  * @param props          - Component props.
  * @param props.response - The response being viewed.
@@ -50,18 +53,37 @@ export default function SingleResponseActions( {
 	const registry = useRegistry() as unknown as Registry;
 	const navigate = useNavigate();
 
-	const actions = useMemo( () => getActions( { navigate, searchParams: {} } ), [ navigate ] );
+	const actions = useMemo( () => getActions( { navigate } ), [ navigate ] );
 	const currentView = VIEW_BY_STATUS[ response.status ] || 'inbox';
 
 	const runAction = useCallback(
-		async ( action: Action, navigateAway: boolean ) => {
+		async ( action: Action, nextStatus?: FormResponse[ 'status' ] ) => {
 			await action.callback?.( [ response ], { registry } );
-			if ( navigateAway ) {
-				navigate( { to: `/responses/${ currentView }` } );
+
+			// Trashing goes through `deleteEntityRecord`, which removes the record
+			// from core-data entirely — this page would then render its "not found"
+			// state. Put it back (carrying the new status) so the user keeps looking
+			// at the response they just actioned. The responses list does the same
+			// after trashing, to keep its Undo working.
+			if ( nextStatus === 'trash' ) {
+				registry
+					.dispatch( coreStore )
+					.receiveEntityRecords(
+						'postType',
+						'feedback',
+						[ { ...response, status: 'trash' } ],
+						undefined,
+						true
+					);
 			}
 		},
-		[ response, registry, navigate, currentView ]
+		[ response, registry ]
 	);
+
+	const deleteResponse = useCallback( async () => {
+		await actions.deleteAction.callback?.( [ response ], { registry } );
+		navigate( { to: `/responses/${ currentView }` } );
+	}, [ actions.deleteAction, response, registry, navigate, currentView ] );
 
 	// Grouped controls — nested arrays render as separate menu groups, and the
 	// `controls` API closes the dropdown automatically when an item is selected.
@@ -73,10 +95,7 @@ export default function SingleResponseActions( {
 				? __( 'Mark as read', 'jetpack-forms' )
 				: __( 'Mark as unread', 'jetpack-forms' ),
 			onClick: () =>
-				runAction(
-					response.is_unread ? actions.markAsReadAction : actions.markAsUnreadAction,
-					false
-				),
+				runAction( response.is_unread ? actions.markAsReadAction : actions.markAsUnreadAction ),
 		};
 
 		let statusControls: Control[];
@@ -84,22 +103,22 @@ export default function SingleResponseActions( {
 			statusControls = [
 				{
 					title: __( 'Not spam', 'jetpack-forms' ),
-					onClick: () => runAction( actions.markAsNotSpamAction, true ),
+					onClick: () => runAction( actions.markAsNotSpamAction, 'publish' ),
 				},
 				{
 					title: __( 'Trash', 'jetpack-forms' ),
-					onClick: () => runAction( actions.moveToTrashAction, true ),
+					onClick: () => runAction( actions.moveToTrashAction, 'trash' ),
 				},
 			];
 		} else if ( response.status === 'trash' ) {
 			statusControls = [
 				{
 					title: __( 'Restore', 'jetpack-forms' ),
-					onClick: () => runAction( actions.restoreAction, true ),
+					onClick: () => runAction( actions.restoreAction, 'publish' ),
 				},
 				{
 					title: __( 'Delete permanently', 'jetpack-forms' ),
-					onClick: () => runAction( actions.deleteAction, true ),
+					onClick: deleteResponse,
 					isDestructive: true,
 				},
 			];
@@ -107,11 +126,11 @@ export default function SingleResponseActions( {
 			statusControls = [
 				{
 					title: __( 'Mark as spam', 'jetpack-forms' ),
-					onClick: () => runAction( actions.markAsSpamAction, true ),
+					onClick: () => runAction( actions.markAsSpamAction, 'spam' ),
 				},
 				{
 					title: __( 'Trash', 'jetpack-forms' ),
-					onClick: () => runAction( actions.moveToTrashAction, true ),
+					onClick: () => runAction( actions.moveToTrashAction, 'trash' ),
 				},
 			];
 		}
@@ -128,7 +147,7 @@ export default function SingleResponseActions( {
 		}
 
 		return groups;
-	}, [ response, runAction, actions, registry ] );
+	}, [ response, runAction, deleteResponse, actions, registry ] );
 
 	return (
 		<DropdownMenu

--- a/projects/packages/forms/routes/response/page-actions.tsx
+++ b/projects/packages/forms/routes/response/page-actions.tsx
@@ -39,14 +39,18 @@ type Control = {
  * stays put, each accepted change is followed by a store repair (see
  * `changeStatus`) and the menu is disabled while a change is in flight.
  *
- * @param props          - Component props.
- * @param props.response - The response being viewed.
+ * @param props           - Component props.
+ * @param props.response  - The response being viewed.
+ * @param props.isBlocked - Whether another mutation on this response is in flight
+ *                        (e.g. the spam confirmation dialog saving).
  * @return The actions dropdown.
  */
 export default function SingleResponseActions( {
 	response,
+	isBlocked = false,
 }: {
 	response: FormResponse;
+	isBlocked?: boolean;
 } ): React.JSX.Element {
 	const registry = useRegistry() as unknown as Registry;
 	const navigate = useNavigate();
@@ -178,7 +182,7 @@ export default function SingleResponseActions( {
 			icon={ moreVertical }
 			label={ __( 'Actions', 'jetpack-forms' ) }
 			controls={ controls }
-			toggleProps={ { disabled: isPending, isBusy: isPending } }
+			toggleProps={ { disabled: isPending || isBlocked, isBusy: isPending } }
 		/>
 	);
 }

--- a/projects/packages/forms/routes/response/query.ts
+++ b/projects/packages/forms/routes/response/query.ts
@@ -1,0 +1,25 @@
+/**
+ * Query used to load a single response for the standalone response page.
+ *
+ * Deliberately a *collection* query (`include`) rather than a single-record fetch
+ * with a query attached. `getEntityRecord( kind, name, id, query )` makes core-data
+ * receive one object under a query key, and its `receiveQueries` reducer skips
+ * non-array payloads — leaving a `queries` entry with no `itemIds`. Every later
+ * trash dispatches `REMOVE_ITEMS`, which runs `queryItems.itemIds.filter()` across
+ * all entries and throws on that one. The rejection is read as a failed request, so
+ * a trash that actually succeeded gets rolled back. A collection query stores real
+ * `itemIds`, so the reducer has something to filter.
+ *
+ * `status` is listed explicitly because the collection endpoint defaults to
+ * `publish`, and this page has to render spam and trashed responses too.
+ *
+ * @param id - The response ID.
+ * @return The query.
+ */
+export default function getResponseQuery( id: number ) {
+	return {
+		include: [ id ],
+		status: [ 'publish', 'draft', 'spam', 'trash' ],
+		fields_format: 'collection',
+	};
+}

--- a/projects/packages/forms/routes/response/repair-record.ts
+++ b/projects/packages/forms/routes/response/repair-record.ts
@@ -38,13 +38,13 @@ export default function repairResponseRecord(
 	receiveEntityRecords: DispatchActions[ 'receiveEntityRecords' ],
 	response: FormResponse,
 	nextStatus: FormResponse[ 'status' ],
-	query: object
+	query: Record< string, unknown >
 ): void {
 	receiveEntityRecords(
 		'postType',
 		'feedback',
 		[ { ...response, status: nextStatus } ],
-		query as never,
+		query,
 		true
 	);
 }

--- a/projects/packages/forms/routes/response/repair-record.ts
+++ b/projects/packages/forms/routes/response/repair-record.ts
@@ -25,20 +25,26 @@ import type { FormResponse } from '../../src/types/index.ts';
  * Pass the *pre-action* record, which still holds the rich collection-shaped
  * fields, and only once the server has accepted the change.
  *
+ * The page's collection query is passed through so the record is restored to that
+ * query's `itemIds` as well as to the item map — trashing dispatches `REMOVE_ITEMS`,
+ * which strips the id from both.
+ *
  * @param receiveEntityRecords - core-data's `receiveEntityRecords` dispatcher.
  * @param response             - The response as it was before the action ran.
  * @param nextStatus           - The status the server just accepted.
+ * @param query                - The query the page reads the response through.
  */
 export default function repairResponseRecord(
 	receiveEntityRecords: DispatchActions[ 'receiveEntityRecords' ],
 	response: FormResponse,
-	nextStatus: FormResponse[ 'status' ]
+	nextStatus: FormResponse[ 'status' ],
+	query: object
 ): void {
 	receiveEntityRecords(
 		'postType',
 		'feedback',
 		[ { ...response, status: nextStatus } ],
-		undefined,
+		query as never,
 		true
 	);
 }

--- a/projects/packages/forms/routes/response/repair-record.ts
+++ b/projects/packages/forms/routes/response/repair-record.ts
@@ -22,13 +22,8 @@ import type { FormResponse } from '../../src/types/index.ts';
  * collection-shaped `fields` this page renders from, so the body would visibly
  * flatten into plain rows.
  *
- * Callers must pass the *pre-action* record, which still holds the rich
- * collection-shaped fields, and must only call this once the server has accepted
- * the change — otherwise the canonical record would advertise a status the
- * response never got.
- *
- * Same repair as PR #49827, which fixed a query-less *fetch* clobbering the
- * collection record; these actions reopen the same door via the save.
+ * Pass the *pre-action* record, which still holds the rich collection-shaped
+ * fields, and only once the server has accepted the change.
  *
  * @param receiveEntityRecords - core-data's `receiveEntityRecords` dispatcher.
  * @param response             - The response as it was before the action ran.

--- a/projects/packages/forms/routes/response/repair-record.ts
+++ b/projects/packages/forms/routes/response/repair-record.ts
@@ -1,0 +1,49 @@
+/**
+ * Types
+ */
+import type { DispatchActions } from '../../src/dashboard/inbox/stage/types.tsx';
+import type { FormResponse } from '../../src/types/index.ts';
+
+/**
+ * Re-receive a response record carrying the status it was just given.
+ *
+ * Needed by every status change made from the standalone single response page,
+ * because that page keeps the user in place instead of navigating away. It
+ * repairs two different ways the store would otherwise misrepresent the response
+ * the user is still looking at.
+ *
+ * Trash goes through `deleteEntityRecord`, whose `REMOVE_ITEMS` reducer drops the
+ * record from core-data entirely, leaving the page on its "not found" state.
+ *
+ * The save-based changes (spam / not spam / restore, including the one behind the
+ * email's "Mark as spam" confirmation) PUT without `fields_format`, and the
+ * endpoint defaults that to `label-value` (see `class-contact-form-endpoint.php`).
+ * core-data receives that response into the store, replacing the
+ * collection-shaped `fields` this page renders from, so the body would visibly
+ * flatten into plain rows.
+ *
+ * Callers must pass the *pre-action* record, which still holds the rich
+ * collection-shaped fields, and must only call this once the server has accepted
+ * the change — otherwise the canonical record would advertise a status the
+ * response never got.
+ *
+ * Same repair as PR #49827, which fixed a query-less *fetch* clobbering the
+ * collection record; these actions reopen the same door via the save.
+ *
+ * @param receiveEntityRecords - core-data's `receiveEntityRecords` dispatcher.
+ * @param response             - The response as it was before the action ran.
+ * @param nextStatus           - The status the server just accepted.
+ */
+export default function repairResponseRecord(
+	receiveEntityRecords: DispatchActions[ 'receiveEntityRecords' ],
+	response: FormResponse,
+	nextStatus: FormResponse[ 'status' ]
+): void {
+	receiveEntityRecords(
+		'postType',
+		'feedback',
+		[ { ...response, status: nextStatus } ],
+		undefined,
+		true
+	);
+}

--- a/projects/packages/forms/routes/response/route.tsx
+++ b/projects/packages/forms/routes/response/route.tsx
@@ -2,13 +2,17 @@
  * WordPress dependencies
  */
 import { resolveSelect } from '@wordpress/data';
+/**
+ * Internal dependencies
+ */
+import getResponseQuery from './query.ts';
 
 export const route = {
 	/**
 	 * Preloads the single feedback response before the route renders.
 	 *
-	 * Fetches with `fields_format: 'collection'` so the field renderers receive
-	 * the same shape they get from the responses list loader.
+	 * Uses the same collection query the stage reads through, so the preload
+	 * populates the exact cache entry the page then selects from.
 	 *
 	 * @param props                   - Loader props.
 	 * @param props.params            - Route params.
@@ -19,9 +23,11 @@ export const route = {
 
 		if ( Number.isFinite( id ) && id > 0 ) {
 			try {
-				await resolveSelect( 'core' ).getEntityRecord( 'postType', 'feedback', id, {
-					fields_format: 'collection',
-				} );
+				await resolveSelect( 'core' ).getEntityRecords(
+					'postType',
+					'feedback',
+					getResponseQuery( id )
+				);
 			} catch {
 				// Swallow fetch errors (e.g. 404 for a missing response) so the stage
 				// can render its own "not found" state instead of the router error boundary.

--- a/projects/packages/forms/routes/response/stage.tsx
+++ b/projects/packages/forms/routes/response/stage.tsx
@@ -174,6 +174,11 @@ function Stage(): React.JSX.Element {
 		},
 	} );
 
+	// The dialog's save and the menu's actions are separate mutation paths on one
+	// response; this is the single in-flight signal both are gated on, so they can't
+	// run against each other.
+	const isMutating = isConfirmDialogOpen || isSaving;
+
 	const { hasPrevious, hasNext, goPrevious, goNext } = useResponsePageNavigation( id );
 
 	// Arrow keys move between responses, matching the inbox inspector. Ignore the
@@ -186,7 +191,9 @@ function Stage(): React.JSX.Element {
 			if ( event.defaultPrevented || event.metaKey || event.ctrlKey || event.altKey ) {
 				return;
 			}
-			if ( previewFile ) {
+			// Navigating away while the spam confirmation is open would leave the
+			// dialog describing one response and confirming against another.
+			if ( previewFile || isConfirmDialogOpen || isSaving ) {
 				return;
 			}
 			const target = event.target as HTMLElement | null;
@@ -210,7 +217,7 @@ function Stage(): React.JSX.Element {
 
 		window.addEventListener( 'keydown', handleKeyDown );
 		return () => window.removeEventListener( 'keydown', handleKeyDown );
-	}, [ goPrevious, goNext, hasPrevious, hasNext, previewFile ] );
+	}, [ goPrevious, goNext, hasPrevious, hasNext, previewFile, isConfirmDialogOpen, isSaving ] );
 
 	// Mark the response as read when it is viewed, keeping the admin-menu unread
 	// counter in sync. The shared hook latches on a ref, which also survives the
@@ -282,13 +289,13 @@ function Stage(): React.JSX.Element {
 					className="jp-forms__single-response-actions"
 				>
 					<ResponseNavigation
-						hasNext={ hasNext }
-						hasPrevious={ hasPrevious }
+						hasNext={ hasNext && ! isMutating }
+						hasPrevious={ hasPrevious && ! isMutating }
 						onNext={ goNext }
 						onPrevious={ goPrevious }
 						onClose={ null }
 					/>
-					<SingleResponseActions response={ response } />
+					<SingleResponseActions response={ response } isBlocked={ isMutating } />
 				</Stack>
 			}
 			showFooter={ false }

--- a/projects/packages/forms/routes/response/stage.tsx
+++ b/projects/packages/forms/routes/response/stage.tsx
@@ -14,7 +14,7 @@ import { useCallback, useEffect, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { useParams } from '@wordpress/route';
-import { Stack } from '@wordpress/ui';
+import { Badge, Stack } from '@wordpress/ui';
 import * as React from 'react';
 /**
  * Internal dependencies
@@ -47,10 +47,33 @@ const RESPONSE_QUERY = { fields_format: 'collection' };
 type PreviewFileItem = FileItem | { url: string; name: string };
 
 /**
+ * Header badge for a response that is no longer in the inbox.
+ *
+ * Inbox responses (`publish`) get no badge — the absence of one is the normal
+ * state. Spam and trash are surfaced so that actioning a response from this page
+ * (which keeps the user here) still shows where it landed.
+ *
+ * @param props        - Component props.
+ * @param props.status - The response status.
+ * @return The badge, or null for inbox responses.
+ */
+function ResponseStatusBadge( { status }: { status: FormResponse[ 'status' ] } ) {
+	if ( status === 'spam' ) {
+		return <Badge intent="high">{ __( 'Spam', 'jetpack-forms' ) }</Badge>;
+	}
+
+	if ( status === 'trash' ) {
+		return <Badge intent="draft">{ __( 'Trash', 'jetpack-forms' ) }</Badge>;
+	}
+
+	return null;
+}
+
+/**
  * Standalone single response page (wp-build route).
  *
  * Renders one feedback response (meta + fields) as a full page at
- * `/response/$responseId`. Not linked from anywhere yet.
+ * `/response/$responseId`. Reached from the responses list's "View" row action.
  *
  * @return The single response page.
  */
@@ -225,6 +248,7 @@ function Stage(): React.JSX.Element {
 			breadcrumbs={
 				<SingleResponseBreadcrumbs response={ response } formTitle={ formName || formTitle } />
 			}
+			badges={ <ResponseStatusBadge status={ response.status } /> }
 			subTitle={ subTitle }
 			ariaLabel={ displayName }
 			actions={

--- a/projects/packages/forms/routes/response/stage.tsx
+++ b/projects/packages/forms/routes/response/stage.tsx
@@ -13,7 +13,7 @@ import {
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
-import { useCallback, useEffect, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
 import { useNavigate, useParams, useSearch } from '@wordpress/route';
@@ -32,6 +32,7 @@ import { useMarkAsSpam } from '../../src/dashboard/hooks/use-mark-as-spam.ts';
 import FormsPage from '../../src/dashboard/wp-build/components/page';
 import SingleResponseBreadcrumbs from './breadcrumbs.tsx';
 import SingleResponseActions from './page-actions.tsx';
+import getResponseQuery from './query.ts';
 import repairResponseRecord from './repair-record.ts';
 import useResponsePageNavigation from './use-navigation.ts';
 // Shared wp-build dashboard chrome (page layout + breadcrumb link styling). The
@@ -45,10 +46,6 @@ import './style.scss';
  */
 import type { DispatchActions, SelectActions } from '../../src/dashboard/inbox/stage/types.tsx';
 import type { FileItem, FormResponse } from '../../src/types/index.ts';
-
-// Stable query reference so the value passed to `isResolving` matches the one
-// used by `getEntityRecord` (and the route loader).
-const RESPONSE_QUERY = { fields_format: 'collection' };
 
 type PreviewFileItem = FileItem | { url: string; name: string };
 
@@ -94,6 +91,8 @@ function Stage(): React.JSX.Element {
 	const [ previewFile, setPreviewFile ] = useState< PreviewFileItem | null >( null );
 	const [ isImageLoading, setIsImageLoading ] = useState( true );
 
+	const responseQuery = useMemo( () => getResponseQuery( id ), [ id ] );
+
 	const { response, isLoading } = useSelect(
 		select => {
 			if ( ! isValidId ) {
@@ -101,12 +100,15 @@ function Stage(): React.JSX.Element {
 			}
 
 			const core = select( coreStore );
-			// Read the collection-format record directly and overlay any pending
-			// edits (e.g. the optimistic "mark as read"). We avoid
-			// `getEditedEntityRecord`, which resolves the canonical (query-less)
-			// record and refetches feedback without `fields_format=collection`,
-			// overwriting the shared record and stripping the rich field rendering.
-			const rawRecord = core.getEntityRecord( 'postType', 'feedback', id, RESPONSE_QUERY );
+			// Read the collection-format record and overlay any pending edits (e.g.
+			// the optimistic "mark as read"). We avoid `getEditedEntityRecord`, which
+			// resolves the canonical (query-less) record and refetches feedback
+			// without `fields_format=collection`, overwriting the shared record and
+			// stripping the rich field rendering.
+			const records = core.getEntityRecords( 'postType', 'feedback', responseQuery ) as
+				| FormResponse[]
+				| null;
+			const rawRecord = records?.[ 0 ];
 			const edits = (
 				core as unknown as {
 					getEntityRecordEdits: ( k: string, n: string, i: number ) => object | undefined;
@@ -115,15 +117,14 @@ function Stage(): React.JSX.Element {
 
 			return {
 				response: rawRecord ? ( { ...rawRecord, ...edits } as unknown as FormResponse ) : null,
-				isLoading: ( core as unknown as SelectActions ).isResolving( 'getEntityRecord', [
+				isLoading: ( core as unknown as SelectActions ).isResolving( 'getEntityRecords', [
 					'postType',
 					'feedback',
-					id,
-					RESPONSE_QUERY,
+					responseQuery,
 				] ),
 			};
 		},
-		[ id, isValidId ]
+		[ id, isValidId, responseQuery ]
 	);
 
 	// For managed forms, resolve the actual jetpack_form post title so the
@@ -167,7 +168,7 @@ function Stage(): React.JSX.Element {
 			// Unlike the list inspector, this page stays put, so the badge and menu
 			// flip in place rather than the user being taken to the spam view.
 			if ( response ) {
-				repairResponseRecord( receiveEntityRecords, response, 'spam' );
+				repairResponseRecord( receiveEntityRecords, response, 'spam', responseQuery );
 			}
 			clearMarkAsSpamParam();
 		},

--- a/projects/packages/forms/routes/response/stage.tsx
+++ b/projects/packages/forms/routes/response/stage.tsx
@@ -6,14 +6,18 @@ import JetpackLogo from '@automattic/jetpack-components/jetpack-logo';
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
-import { Modal, Spinner } from '@wordpress/components';
+import {
+	Modal,
+	Spinner,
+	__experimentalConfirmDialog as ConfirmDialog, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useEffect, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
 import { __ } from '@wordpress/i18n';
-import { useParams } from '@wordpress/route';
+import { useNavigate, useParams, useSearch } from '@wordpress/route';
 import { Badge, Stack } from '@wordpress/ui';
 import * as React from 'react';
 /**
@@ -24,9 +28,11 @@ import ResponseFieldsIterator from '../../src/dashboard/components/inspector/res
 import ResponseMeta from '../../src/dashboard/components/inspector/response-meta';
 import ResponseNavigation from '../../src/dashboard/components/inspector/response-navigation/index.tsx';
 import { getDisplayName } from '../../src/dashboard/components/inspector/utils.ts';
+import { useMarkAsSpam } from '../../src/dashboard/hooks/use-mark-as-spam.ts';
 import FormsPage from '../../src/dashboard/wp-build/components/page';
 import SingleResponseBreadcrumbs from './breadcrumbs.tsx';
 import SingleResponseActions from './page-actions.tsx';
+import repairResponseRecord from './repair-record.ts';
 import useResponsePageNavigation from './use-navigation.ts';
 // Shared wp-build dashboard chrome (page layout + breadcrumb link styling). The
 // other dashboard routes load this; the single-response route needs it too so
@@ -79,10 +85,14 @@ function ResponseStatusBadge( { status }: { status: FormResponse[ 'status' ] } )
  */
 function Stage(): React.JSX.Element {
 	const params = useParams( { from: '/response/$responseId' } );
+	const searchParams = useSearch( { from: '/response/$responseId' } );
+	const navigate = useNavigate();
 	const id = Number( params.responseId );
 	const isValidId = Number.isFinite( id ) && id > 0;
 
-	const { editEntityRecord } = useDispatch( coreStore ) as unknown as DispatchActions;
+	const { editEntityRecord, receiveEntityRecords } = useDispatch(
+		coreStore
+	) as unknown as DispatchActions;
 	const [ markedReadId, setMarkedReadId ] = useState< number | null >( null );
 	const [ previewFile, setPreviewFile ] = useState< PreviewFileItem | null >( null );
 	const [ isImageLoading, setIsImageLoading ] = useState( true );
@@ -135,6 +145,37 @@ function Stage(): React.JSX.Element {
 		},
 		[ response?.form_id ]
 	);
+
+	// The email's "Mark as spam" button lands here with `?mark_as_spam=1`, which
+	// opens a confirmation dialog — the destructive step is never taken on the
+	// strength of a click in an email client alone. Same hook the responses list
+	// inspector uses, so the copy and behaviour stay in one place.
+	const clearMarkAsSpamParam = useCallback( () => {
+		navigate( {
+			search: { ...searchParams, mark_as_spam: undefined },
+			replace: true,
+		} );
+	}, [ navigate, searchParams ] );
+
+	const {
+		isConfirmDialogOpen,
+		onConfirmMarkAsSpam,
+		onCancelMarkAsSpam,
+		markAsSpamConfirmationMessage,
+		isSaving,
+	} = useMarkAsSpam( response, {
+		checkParameter: () => ( searchParams as { mark_as_spam?: number } )?.mark_as_spam === 1,
+		removeParameter: clearMarkAsSpamParam,
+		switchToSpam: () => {
+			// Unlike the list inspector, this page keeps the user on the response they
+			// just actioned, so the badge and menu flip in place. The hook saves
+			// without `fields_format`, so repair the record or the body flattens.
+			if ( response ) {
+				repairResponseRecord( receiveEntityRecords, response, 'spam' );
+			}
+			clearMarkAsSpamParam();
+		},
+	} );
 
 	const { hasPrevious, hasNext, goPrevious, goNext } = useResponsePageNavigation( id );
 
@@ -288,6 +329,15 @@ function Stage(): React.JSX.Element {
 					/>
 				</Modal>
 			) }
+
+			<ConfirmDialog
+				isOpen={ isConfirmDialogOpen }
+				onConfirm={ onConfirmMarkAsSpam }
+				onCancel={ onCancelMarkAsSpam }
+				isBusy={ isSaving }
+			>
+				{ markAsSpamConfirmationMessage }
+			</ConfirmDialog>
 		</FormsPage>
 	);
 }

--- a/projects/packages/forms/routes/response/stage.tsx
+++ b/projects/packages/forms/routes/response/stage.tsx
@@ -15,7 +15,7 @@ import { useDispatch, useSelect } from '@wordpress/data';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
 import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { decodeEntities } from '@wordpress/html-entities';
-import { __ } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { useNavigate, useParams, useSearch } from '@wordpress/route';
 import { Badge, Stack } from '@wordpress/ui';
 import * as React from 'react';
@@ -62,11 +62,11 @@ type PreviewFileItem = FileItem | { url: string; name: string };
  */
 function ResponseStatusBadge( { status }: { status: FormResponse[ 'status' ] } ) {
 	if ( status === 'spam' ) {
-		return <Badge intent="high">{ __( 'Spam', 'jetpack-forms' ) }</Badge>;
+		return <Badge intent="high">{ _x( 'Spam', 'response status', 'jetpack-forms' ) }</Badge>;
 	}
 
 	if ( status === 'trash' ) {
-		return <Badge intent="draft">{ __( 'Trash', 'jetpack-forms' ) }</Badge>;
+		return <Badge intent="draft">{ _x( 'Trash', 'response status', 'jetpack-forms' ) }</Badge>;
 	}
 
 	return null;
@@ -175,9 +175,11 @@ function Stage(): React.JSX.Element {
 	} );
 
 	// The dialog's save and the menu's actions are separate mutation paths on one
-	// response; this is the single in-flight signal both are gated on, so they can't
-	// run against each other.
-	const isMutating = isConfirmDialogOpen || isSaving;
+	// response. Both report into this single signal — the dialog directly, the menu
+	// through `onBusyChange` — so neither can run against the other and neither can
+	// be navigated away from mid-flight.
+	const [ isMenuBusy, setIsMenuBusy ] = useState( false );
+	const isMutating = isConfirmDialogOpen || isSaving || isMenuBusy;
 
 	const { hasPrevious, hasNext, goPrevious, goNext } = useResponsePageNavigation( id );
 
@@ -250,7 +252,12 @@ function Stage(): React.JSX.Element {
 		</FormsPage>
 	);
 
-	if ( isValidId && isLoading ) {
+	// Only show the spinner when there is nothing to show. Every status change
+	// invalidates `getEntityRecords` resolutions (see `invalidateCacheAndNavigate`),
+	// which re-resolves this page's own query — without the `! response` guard the
+	// response would be replaced by a full-page spinner on each action, which is
+	// exactly what staying on the page is meant to avoid.
+	if ( isValidId && isLoading && ! response ) {
 		return renderMessagePage(
 			isValidId ? `#${ id }` : __( 'Response', 'jetpack-forms' ),
 			__( 'Response', 'jetpack-forms' ),
@@ -295,7 +302,11 @@ function Stage(): React.JSX.Element {
 						onPrevious={ goPrevious }
 						onClose={ null }
 					/>
-					<SingleResponseActions response={ response } isBlocked={ isMutating } />
+					<SingleResponseActions
+						response={ response }
+						isBlocked={ isConfirmDialogOpen || isSaving }
+						onBusyChange={ setIsMenuBusy }
+					/>
 				</Stack>
 			}
 			showFooter={ false }

--- a/projects/packages/forms/routes/response/stage.tsx
+++ b/projects/packages/forms/routes/response/stage.tsx
@@ -5,7 +5,6 @@ import JetpackLogo from '@automattic/jetpack-components/jetpack-logo';
 /**
  * WordPress dependencies
  */
-import apiFetch from '@wordpress/api-fetch';
 import {
 	Modal,
 	Spinner,
@@ -28,6 +27,7 @@ import ResponseFieldsIterator from '../../src/dashboard/components/inspector/res
 import ResponseMeta from '../../src/dashboard/components/inspector/response-meta';
 import ResponseNavigation from '../../src/dashboard/components/inspector/response-navigation/index.tsx';
 import { getDisplayName } from '../../src/dashboard/components/inspector/utils.ts';
+import useMarkAsReadOnView from '../../src/dashboard/hooks/use-mark-as-read-on-view.ts';
 import { useMarkAsSpam } from '../../src/dashboard/hooks/use-mark-as-spam.ts';
 import FormsPage from '../../src/dashboard/wp-build/components/page';
 import SingleResponseBreadcrumbs from './breadcrumbs.tsx';
@@ -90,10 +90,7 @@ function Stage(): React.JSX.Element {
 	const id = Number( params.responseId );
 	const isValidId = Number.isFinite( id ) && id > 0;
 
-	const { editEntityRecord, receiveEntityRecords } = useDispatch(
-		coreStore
-	) as unknown as DispatchActions;
-	const [ markedReadId, setMarkedReadId ] = useState< number | null >( null );
+	const { receiveEntityRecords } = useDispatch( coreStore ) as unknown as DispatchActions;
 	const [ previewFile, setPreviewFile ] = useState< PreviewFileItem | null >( null );
 	const [ isImageLoading, setIsImageLoading ] = useState( true );
 
@@ -167,9 +164,8 @@ function Stage(): React.JSX.Element {
 		checkParameter: () => ( searchParams as { mark_as_spam?: number } )?.mark_as_spam === 1,
 		removeParameter: clearMarkAsSpamParam,
 		switchToSpam: () => {
-			// Unlike the list inspector, this page keeps the user on the response they
-			// just actioned, so the badge and menu flip in place. The hook saves
-			// without `fields_format`, so repair the record or the body flattens.
+			// Unlike the list inspector, this page stays put, so the badge and menu
+			// flip in place rather than the user being taken to the spam view.
 			if ( response ) {
 				repairResponseRecord( receiveEntityRecords, response, 'spam' );
 			}
@@ -215,26 +211,10 @@ function Stage(): React.JSX.Element {
 		return () => window.removeEventListener( 'keydown', handleKeyDown );
 	}, [ goPrevious, goNext, hasPrevious, hasNext, previewFile ] );
 
-	// Mark the response as read when it is viewed.
-	useEffect( () => {
-		if ( ! response || ! response.id || ! response.is_unread ) {
-			return;
-		}
-		if ( markedReadId === response.id ) {
-			return;
-		}
-
-		setMarkedReadId( response.id );
-		editEntityRecord( 'postType', 'feedback', response.id, { is_unread: false } );
-
-		apiFetch( {
-			path: `/wp/v2/feedback/${ response.id }/read`,
-			method: 'POST',
-			data: { is_unread: false },
-		} ).catch( () => {
-			editEntityRecord( 'postType', 'feedback', response.id, { is_unread: true } );
-		} );
-	}, [ response, editEntityRecord, markedReadId ] );
+	// Mark the response as read when it is viewed, keeping the admin-menu unread
+	// counter in sync. The shared hook latches on a ref, which also survives the
+	// "Mark as unread" menu item on this page re-running the effect.
+	useMarkAsReadOnView( response );
 
 	const handleFilePreview = useCallback(
 		( file: PreviewFileItem ) => () => {

--- a/projects/packages/forms/routes/responses/actions.tsx
+++ b/projects/packages/forms/routes/responses/actions.tsx
@@ -27,6 +27,7 @@ import type {
 	Action,
 } from '../../src/dashboard/inbox/stage/types.tsx';
 import type { FormResponse } from '../../src/types/index.ts';
+import type { UseNavigateResult } from '@wordpress/route';
 /**
  * Helper function to extract count-relevant query params from the current query.
  *
@@ -284,8 +285,12 @@ export const BULK_ACTIONS = {
 	markAsNotSpam: 'mark_as_not_spam',
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type NavigateFunction = ( options: any ) => void;
+// The router's own navigate type, rather than `( options: any ) => void`. Note what
+// this does and does not buy: it checks the options shape (a misspelled `to` fails),
+// but not path *values* — the route tree isn't registered as a type in this build, so
+// `to` widens to `string` and a typo'd path still compiles. Same limitation the
+// `search` cast in `routes/response/breadcrumbs.tsx` works around.
+type NavigateFunction = UseNavigateResult< string >;
 
 type ActionWithDestructive = Action & {
 	isDestructive?: boolean;
@@ -491,6 +496,8 @@ export function getActions( { navigate }: GetActionsParams ): GetActionsReturn {
 						BULK_ACTIONS.markAsSpam
 					);
 				}
+
+				return { itemsUpdated: itemsUpdated.length, numberOfErrors };
 			} finally {
 				if ( waitForRecordsPromise ) {
 					await waitForRecordsPromise;
@@ -623,6 +630,8 @@ export function getActions( { navigate }: GetActionsParams ): GetActionsReturn {
 						BULK_ACTIONS.markAsNotSpam
 					);
 				}
+
+				return { itemsUpdated: itemsUpdated.length, numberOfErrors };
 			} finally {
 				if ( waitForRecordsPromise ) {
 					await waitForRecordsPromise;
@@ -742,7 +751,7 @@ export function getActions( { navigate }: GetActionsParams ): GetActionsReturn {
 						removeNotice( 'restore-action' );
 					}
 
-					return;
+					return { itemsUpdated: itemsUpdated.length, numberOfErrors };
 				}
 
 				// There is at least one failure.
@@ -750,6 +759,8 @@ export function getActions( { navigate }: GetActionsParams ): GetActionsReturn {
 
 				removeNotice( 'restore-action' );
 				createErrorNotice( errorMessage, { type: 'snackbar' } );
+
+				return { itemsUpdated: itemsUpdated.length, numberOfErrors };
 			} finally {
 				if ( waitForRecordsPromise ) {
 					await waitForRecordsPromise;
@@ -882,7 +893,7 @@ export function getActions( { navigate }: GetActionsParams ): GetActionsReturn {
 						removeNotice( 'move-to-trash-action' );
 					}
 
-					return;
+					return { itemsUpdated: itemsUpdated.length, numberOfErrors };
 				}
 
 				// There is at least one failure.
@@ -890,6 +901,8 @@ export function getActions( { navigate }: GetActionsParams ): GetActionsReturn {
 
 				removeNotice( 'move-to-trash-action' );
 				createErrorNotice( errorMessage, { type: 'snackbar' } );
+
+				return { itemsUpdated: itemsUpdated.length, numberOfErrors };
 			} finally {
 				if ( waitForRecordsPromise ) {
 					await waitForRecordsPromise;
@@ -980,13 +993,15 @@ export function getActions( { navigate }: GetActionsParams ): GetActionsReturn {
 				const hashString = hashParams.toString();
 				window.location.hash = hashString ? `${ hashBase }?${ hashString }` : hashBase;
 
-				return;
+				return { itemsUpdated: itemsUpdated.length, numberOfErrors: 0 };
 			}
 			// There is at least one failure.
 			const numberOfErrors = promises.filter( ( { status } ) => status === 'rejected' ).length;
 			const errorMessage = getGenericErrorMessage( numberOfErrors );
 
 			createErrorNotice( errorMessage, { type: 'snackbar' } );
+
+			return { itemsUpdated: itemsUpdated.length, numberOfErrors };
 		},
 	};
 

--- a/projects/packages/forms/routes/responses/actions.tsx
+++ b/projects/packages/forms/routes/responses/actions.tsx
@@ -293,22 +293,10 @@ export const BULK_ACTIONS = {
 // `search` cast in `routes/response/breadcrumbs.tsx` works around.
 type NavigateFunction = UseNavigateResult< string >;
 
-// Element type for the row-actions array, which mixes reporting and plain actions.
-type ActionWithDestructive = Action & {
-	isDestructive?: boolean;
-};
-
-type ReportingActionWithDestructive = ReportingAction & {
-	isDestructive?: boolean;
-};
-
 type GetActionsParams = {
 	navigate: NavigateFunction;
 };
 
-// The status-changing actions are typed as `ReportingAction`: callers gate on their
-// result, so every terminal path has to return one. `view` / `editForm` /
-// `markAsRead` / `markAsUnread` stay on the looser `Action` — nothing reads them.
 type GetActionsReturn = {
 	viewAction: Action;
 	editFormAction: Action;
@@ -316,7 +304,7 @@ type GetActionsReturn = {
 	markAsNotSpamAction: ReportingAction;
 	restoreAction: ReportingAction;
 	moveToTrashAction: ReportingAction;
-	deleteAction: ReportingActionWithDestructive;
+	deleteAction: ReportingAction;
 	markAsReadAction: Action;
 	markAsUnreadAction: Action;
 };
@@ -924,7 +912,7 @@ export function getActions( { navigate }: GetActionsParams ): GetActionsReturn {
 		},
 	};
 
-	const deleteAction: ReportingActionWithDestructive = {
+	const deleteAction: ReportingAction = {
 		id: 'delete',
 		isPrimary: true,
 		icon: <Icon icon={ trash } />,
@@ -956,6 +944,9 @@ export function getActions( { navigate }: GetActionsParams ): GetActionsReturn {
 			);
 
 			const itemsUpdated = promises.filter( ( { status } ) => status === 'fulfilled' );
+			// Every settled promise is either fulfilled or rejected, so the failures are
+			// the remainder — no need to filter the list a second time.
+			const numberOfErrors = promises.length - itemsUpdated.length;
 
 			// If there is at least one successful update, invalidate the cache for filters.
 			if ( itemsUpdated.length ) {
@@ -963,7 +954,7 @@ export function getActions( { navigate }: GetActionsParams ): GetActionsReturn {
 				invalidateCacheAndNavigate( registry, getCurrentQuery(), queryParams, 'trash' );
 			}
 
-			if ( itemsUpdated.length === items.length ) {
+			if ( numberOfErrors === 0 ) {
 				// Every request was successful.
 				const successMessage =
 					items.length === 1
@@ -1001,14 +992,10 @@ export function getActions( { navigate }: GetActionsParams ): GetActionsReturn {
 
 				const hashString = hashParams.toString();
 				window.location.hash = hashString ? `${ hashBase }?${ hashString }` : hashBase;
-
-				return { itemsUpdated: itemsUpdated.length, numberOfErrors: 0 };
+			} else {
+				// There is at least one failure.
+				createErrorNotice( getGenericErrorMessage( numberOfErrors ), { type: 'snackbar' } );
 			}
-			// There is at least one failure.
-			const numberOfErrors = promises.filter( ( { status } ) => status === 'rejected' ).length;
-			const errorMessage = getGenericErrorMessage( numberOfErrors );
-
-			createErrorNotice( errorMessage, { type: 'snackbar' } );
 
 			return { itemsUpdated: itemsUpdated.length, numberOfErrors };
 		},
@@ -1268,9 +1255,9 @@ export function getActions( { navigate }: GetActionsParams ): GetActionsReturn {
  * Get actions configuration for form responses DataViews.
  *
  * @param {GetRowActionsParams} params - Parameters for generating actions.
- * @return {ActionWithDestructive[]} Array of action configurations.
+ * @return {Action[]} Array of action configurations.
  */
-export function getRowActions( { navigate, view }: GetRowActionsParams ): ActionWithDestructive[] {
+export function getRowActions( { navigate, view }: GetRowActionsParams ): Action[] {
 	const {
 		viewAction,
 		editFormAction,

--- a/projects/packages/forms/routes/responses/actions.tsx
+++ b/projects/packages/forms/routes/responses/actions.tsx
@@ -287,17 +287,12 @@ export const BULK_ACTIONS = {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type NavigateFunction = ( options: any ) => void;
 
-type SearchParams = {
-	[ key: string ]: string | string[] | undefined;
-};
-
 type ActionWithDestructive = Action & {
 	isDestructive?: boolean;
 };
 
 type GetActionsParams = {
 	navigate: NavigateFunction;
-	searchParams: SearchParams;
 };
 
 type GetActionsReturn = {
@@ -322,7 +317,7 @@ type GetRowActionsParams = GetActionsParams & {
  * @param {GetActionsParams} params - Parameters for generating actions.
  * @return {GetActionsReturn} Object containing the actions.
  */
-export function getActions( { navigate, searchParams }: GetActionsParams ): GetActionsReturn {
+export function getActions( { navigate }: GetActionsParams ): GetActionsReturn {
 	const viewAction: Action = {
 		id: 'view-response',
 		isPrimary: true,
@@ -334,13 +329,14 @@ export function getActions( { navigate, searchParams }: GetActionsParams ): GetA
 				multiple: items.length > 1,
 			} );
 
-			const ids = items.map( item => item.id.toString() );
-			navigate( {
-				search: {
-					...searchParams,
-					responseIds: ids,
-				},
-			} );
+			const [ item ] = items;
+
+			if ( ! item ) {
+				return;
+			}
+
+			// Open the standalone single response page rather than the inspector panel.
+			navigate( { to: `/response/${ item.id }` } );
 		},
 	};
 
@@ -1250,11 +1246,7 @@ export function getActions( { navigate, searchParams }: GetActionsParams ): GetA
  * @param {GetRowActionsParams} params - Parameters for generating actions.
  * @return {ActionWithDestructive[]} Array of action configurations.
  */
-export function getRowActions( {
-	navigate,
-	searchParams,
-	view,
-}: GetRowActionsParams ): ActionWithDestructive[] {
+export function getRowActions( { navigate, view }: GetRowActionsParams ): ActionWithDestructive[] {
 	const {
 		viewAction,
 		editFormAction,
@@ -1265,10 +1257,7 @@ export function getRowActions( {
 		deleteAction,
 		markAsReadAction,
 		markAsUnreadAction,
-	} = getActions( {
-		navigate,
-		searchParams,
-	} );
+	} = getActions( { navigate } );
 
 	switch ( view ) {
 		case 'trash':

--- a/projects/packages/forms/routes/responses/actions.tsx
+++ b/projects/packages/forms/routes/responses/actions.tsx
@@ -25,6 +25,7 @@ import type {
 	QueryParams,
 	Registry,
 	Action,
+	ReportingAction,
 } from '../../src/dashboard/inbox/stage/types.tsx';
 import type { FormResponse } from '../../src/types/index.ts';
 import type { UseNavigateResult } from '@wordpress/route';
@@ -292,7 +293,12 @@ export const BULK_ACTIONS = {
 // `search` cast in `routes/response/breadcrumbs.tsx` works around.
 type NavigateFunction = UseNavigateResult< string >;
 
+// Element type for the row-actions array, which mixes reporting and plain actions.
 type ActionWithDestructive = Action & {
+	isDestructive?: boolean;
+};
+
+type ReportingActionWithDestructive = ReportingAction & {
 	isDestructive?: boolean;
 };
 
@@ -300,14 +306,17 @@ type GetActionsParams = {
 	navigate: NavigateFunction;
 };
 
+// The status-changing actions are typed as `ReportingAction`: callers gate on their
+// result, so every terminal path has to return one. `view` / `editForm` /
+// `markAsRead` / `markAsUnread` stay on the looser `Action` — nothing reads them.
 type GetActionsReturn = {
 	viewAction: Action;
 	editFormAction: Action;
-	markAsSpamAction: Action;
-	markAsNotSpamAction: Action;
-	restoreAction: Action;
-	moveToTrashAction: Action;
-	deleteAction: ActionWithDestructive;
+	markAsSpamAction: ReportingAction;
+	markAsNotSpamAction: ReportingAction;
+	restoreAction: ReportingAction;
+	moveToTrashAction: ReportingAction;
+	deleteAction: ReportingActionWithDestructive;
 	markAsReadAction: Action;
 	markAsUnreadAction: Action;
 };
@@ -368,7 +377,7 @@ export function getActions( { navigate }: GetActionsParams ): GetActionsReturn {
 		},
 	};
 
-	const markAsSpamAction: Action = {
+	const markAsSpamAction: ReportingAction = {
 		id: 'mark-as-spam',
 		isPrimary: true,
 		icon: <Icon icon={ spam } />,
@@ -510,7 +519,7 @@ export function getActions( { navigate }: GetActionsParams ): GetActionsReturn {
 		},
 	};
 
-	const markAsNotSpamAction: Action = {
+	const markAsNotSpamAction: ReportingAction = {
 		id: 'mark-as-not-spam',
 		isPrimary: true,
 		icon: <Icon icon={ notSpam } />,
@@ -644,7 +653,7 @@ export function getActions( { navigate }: GetActionsParams ): GetActionsReturn {
 		},
 	};
 
-	const restoreAction: Action = {
+	const restoreAction: ReportingAction = {
 		id: 'restore',
 		isPrimary: true,
 		icon: <Icon icon={ backup } />,
@@ -773,7 +782,7 @@ export function getActions( { navigate }: GetActionsParams ): GetActionsReturn {
 		},
 	};
 
-	const moveToTrashAction: Action = {
+	const moveToTrashAction: ReportingAction = {
 		id: 'move-to-trash',
 		isPrimary: true,
 		icon: <Icon icon={ trash } />,
@@ -915,7 +924,7 @@ export function getActions( { navigate }: GetActionsParams ): GetActionsReturn {
 		},
 	};
 
-	const deleteAction: ActionWithDestructive = {
+	const deleteAction: ReportingActionWithDestructive = {
 		id: 'delete',
 		isPrimary: true,
 		icon: <Icon icon={ trash } />,

--- a/projects/packages/forms/routes/responses/response/actions.tsx
+++ b/projects/packages/forms/routes/responses/response/actions.tsx
@@ -5,7 +5,7 @@ import { Button } from '@wordpress/components';
 import { useRegistry } from '@wordpress/data';
 import { useCallback, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
-import { useSearch, useNavigate } from '@wordpress/route';
+import { useNavigate } from '@wordpress/route';
 import { Stack } from '@wordpress/ui';
 import * as React from 'react';
 /**
@@ -34,7 +34,6 @@ export function ResponseActions( {
 	response: FormResponse;
 	onActionComplete: ( item: FormResponse ) => void;
 } ) {
-	const searchParams = useSearch( { from: '/responses/$view' } );
 	const navigate = useNavigate();
 
 	const {
@@ -45,14 +44,7 @@ export function ResponseActions( {
 		deleteAction,
 		markAsReadAction,
 		markAsUnreadAction,
-	} = useMemo(
-		() =>
-			getActions( {
-				navigate,
-				searchParams,
-			} ),
-		[ navigate, searchParams ]
-	);
+	} = useMemo( () => getActions( { navigate } ), [ navigate ] );
 
 	const [ isMarkingAsSpam, setIsMarkingAsSpam ] = useState( false );
 	const [ isMarkingAsNotSpam, setIsMarkingAsNotSpam ] = useState( false );

--- a/projects/packages/forms/routes/responses/stage.tsx
+++ b/projects/packages/forms/routes/responses/stage.tsx
@@ -632,10 +632,9 @@ function StageInner() {
 		() =>
 			getRowActions( {
 				navigate,
-				searchParams,
 				view: statusView,
 			} ),
-		[ navigate, searchParams, statusView ]
+		[ navigate, statusView ]
 	);
 
 	const paginationInfo = useMemo(

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -3128,6 +3128,7 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'comment_author'       => $comment_author,
 			'comment_author_email' => $comment_author_email,
 			'comment_author_ip'    => $comment_author_ip,
+			'is_spam'              => $is_spam,
 			'is_test'              => $is_test_submission,
 			'feedback_status'      => $feedback_status,
 		);

--- a/projects/packages/forms/src/contact-form/class-contact-form.php
+++ b/projects/packages/forms/src/contact-form/class-contact-form.php
@@ -3128,7 +3128,6 @@ class Contact_Form extends Contact_Form_Shortcode {
 			'comment_author'       => $comment_author,
 			'comment_author_email' => $comment_author_email,
 			'comment_author_ip'    => $comment_author_ip,
-			'is_spam'              => $is_spam,
 			'is_test'              => $is_test_submission,
 			'feedback_status'      => $feedback_status,
 		);

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -92,7 +92,10 @@ class Feedback_Email_Renderer {
 	 *   'comment_author'       => string  Author name.
 	 *   'comment_author_email' => string  Author email.
 	 *   'comment_author_ip'    => string  Author IP address.
-	 *   'is_spam'              => bool    Whether submission is spam.
+	 *   'is_spam'              => bool    Whether submission is spam. Still passed by the
+	 *                                    caller, but no longer read: both email buttons
+	 *                                    now open the single response page, which shows
+	 *                                    the response whatever its status.
 	 *   'feedback_status'      => string  Post status of the feedback.
 	 *
 	 * @return array{title: string, message: string} The email title and rendered HTML message.
@@ -103,7 +106,6 @@ class Feedback_Email_Renderer {
 		$comment_author       = $context_data['comment_author'];
 		$comment_author_email = $context_data['comment_author_email'];
 		$comment_author_ip    = $context_data['comment_author_ip'];
-		$is_spam              = $context_data['is_spam'];
 		$is_test              = ! empty( $context_data['is_test'] );
 		$feedback_status      = $context_data['feedback_status'];
 
@@ -161,10 +163,9 @@ class Feedback_Email_Renderer {
 			esc_url( $url )
 		);
 
-		// Get the status of the feedback.
-		$status = $is_spam ? 'spam' : 'inbox';
-
-		// Build the dashboard URL with the status and the feedback's post id if we have a post id.
+		// Build the dashboard URL for the feedback's post id if we have one. The
+		// single response page shows the response whatever its status, so the
+		// destination no longer depends on whether this submission was spam.
 		$dashboard_url           = '';
 		$mark_as_spam_url        = '';
 		$footer_mark_as_spam_url = '';
@@ -181,18 +182,15 @@ class Feedback_Email_Renderer {
 		$show_email_actions = apply_filters( 'jetpack_forms_email_show_actions', true );
 
 		if ( $feedback_status !== 'jp-temp-feedback' && $show_email_actions ) {
-			// "View in dashboard" opens the response on its own page.
+			// Both buttons open the response on its own page. "Mark as spam" adds a
+			// parameter that opens a confirmation dialog there, so the destructive
+			// step is never taken on the strength of an email click alone.
 			$dashboard_url = Forms_Dashboard::get_single_response_admin_url( $post_id );
 			// Test responses don't get a Mark-as-spam link in the email — marking
 			// a test entry as spam from email is confusing and the form owner can
 			// always do it from the dashboard if they want.
 			if ( ! $is_test ) {
-				// Mark-as-spam still points at the responses list: its confirmation
-				// dialog lives in the list's response inspector, not on the
-				// standalone response page.
-				$mark_as_spam_url        = self::add_mark_as_spam_to_url(
-					Forms_Dashboard::get_forms_admin_url( $status, $post_id )
-				);
+				$mark_as_spam_url        = self::add_mark_as_spam_to_url( $dashboard_url );
 				$footer_mark_as_spam_url = sprintf(
 					'<a href="%1$s">%2$s</a>',
 					esc_url( $mark_as_spam_url ),

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -189,9 +189,14 @@ class Feedback_Email_Renderer {
 			// Test responses don't get a Mark-as-spam link in the email — marking
 			// a test entry as spam from email is confusing and the form owner can
 			// always do it from the dashboard if they want. Neither do submissions
-			// already flagged as spam (sites can mail those via $send_even_if_spam):
-			// the button would land on a page with nothing to confirm.
-			if ( ! $is_test && ! $is_spam ) {
+			// that already sit outside the inbox: sites can mail spam via
+			// `grunion_still_email_spam`, and a disallowed-list hit is emailed with
+			// `$feedback_status = 'trash'` while `$is_spam` stays false. The single
+			// response page has nothing to confirm for either, so the button would
+			// land somewhere that silently does nothing.
+			$is_already_filed = $is_spam || in_array( $feedback_status, array( 'spam', 'trash' ), true );
+
+			if ( ! $is_test && ! $is_already_filed ) {
 				$mark_as_spam_url        = self::add_mark_as_spam_to_url( $dashboard_url );
 				$footer_mark_as_spam_url = sprintf(
 					'<a href="%1$s">%2$s</a>',
@@ -233,9 +238,10 @@ class Feedback_Email_Renderer {
 		// Use fully table-based layout for maximum email client compatibility - no display:inline-block.
 		$actions = '';
 		if ( $dashboard_url ) {
-			if ( $is_test ) {
-				// For test submissions, only show the "View in dashboard" button
-				// centered — we deliberately drop the Mark-as-spam shortcut.
+			if ( ! $mark_as_spam_url ) {
+				// Only "View in dashboard", centered. Keyed on the URL rather than on
+				// why it is missing, so every suppression path renders one button
+				// instead of an empty `href`.
 				$actions = sprintf(
 					'<table role="presentation" border="0" cellpadding="0" cellspacing="0" class="button-table" align="center" style="border-collapse: collapse; mso-table-lspace: 0pt; mso-table-rspace: 0pt; margin: 0 auto;">
 						<tr>

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -92,10 +92,6 @@ class Feedback_Email_Renderer {
 	 *   'comment_author'       => string  Author name.
 	 *   'comment_author_email' => string  Author email.
 	 *   'comment_author_ip'    => string  Author IP address.
-	 *   'is_spam'              => bool    Whether submission is spam. Still passed by the
-	 *                                    caller, but no longer read: both email buttons
-	 *                                    now open the single response page, which shows
-	 *                                    the response whatever its status.
 	 *   'feedback_status'      => string  Post status of the feedback.
 	 *
 	 * @return array{title: string, message: string} The email title and rendered HTML message.

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -92,6 +92,9 @@ class Feedback_Email_Renderer {
 	 *   'comment_author'       => string  Author name.
 	 *   'comment_author_email' => string  Author email.
 	 *   'comment_author_ip'    => string  Author IP address.
+	 *   'is_spam'              => bool    Whether submission is spam. Suppresses the
+	 *                                    Mark-as-spam button, which would otherwise
+	 *                                    link to a page with nothing to confirm.
 	 *   'feedback_status'      => string  Post status of the feedback.
 	 *
 	 * @return array{title: string, message: string} The email title and rendered HTML message.
@@ -102,6 +105,7 @@ class Feedback_Email_Renderer {
 		$comment_author       = $context_data['comment_author'];
 		$comment_author_email = $context_data['comment_author_email'];
 		$comment_author_ip    = $context_data['comment_author_ip'];
+		$is_spam              = ! empty( $context_data['is_spam'] );
 		$is_test              = ! empty( $context_data['is_test'] );
 		$feedback_status      = $context_data['feedback_status'];
 
@@ -184,8 +188,10 @@ class Feedback_Email_Renderer {
 			$dashboard_url = Forms_Dashboard::get_single_response_admin_url( $post_id );
 			// Test responses don't get a Mark-as-spam link in the email — marking
 			// a test entry as spam from email is confusing and the form owner can
-			// always do it from the dashboard if they want.
-			if ( ! $is_test ) {
+			// always do it from the dashboard if they want. Neither do submissions
+			// already flagged as spam (sites can mail those via $send_even_if_spam):
+			// the button would land on a page with nothing to confirm.
+			if ( ! $is_test && ! $is_spam ) {
 				$mark_as_spam_url        = self::add_mark_as_spam_to_url( $dashboard_url );
 				$footer_mark_as_spam_url = sprintf(
 					'<a href="%1$s">%2$s</a>',

--- a/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
+++ b/projects/packages/forms/src/contact-form/class-feedback-email-renderer.php
@@ -181,12 +181,18 @@ class Feedback_Email_Renderer {
 		$show_email_actions = apply_filters( 'jetpack_forms_email_show_actions', true );
 
 		if ( $feedback_status !== 'jp-temp-feedback' && $show_email_actions ) {
-			$dashboard_url = Forms_Dashboard::get_forms_admin_url( $status, $post_id );
+			// "View in dashboard" opens the response on its own page.
+			$dashboard_url = Forms_Dashboard::get_single_response_admin_url( $post_id );
 			// Test responses don't get a Mark-as-spam link in the email — marking
 			// a test entry as spam from email is confusing and the form owner can
 			// always do it from the dashboard if they want.
 			if ( ! $is_test ) {
-				$mark_as_spam_url        = self::add_mark_as_spam_to_url( $dashboard_url );
+				// Mark-as-spam still points at the responses list: its confirmation
+				// dialog lives in the list's response inspector, not on the
+				// standalone response page.
+				$mark_as_spam_url        = self::add_mark_as_spam_to_url(
+					Forms_Dashboard::get_forms_admin_url( $status, $post_id )
+				);
 				$footer_mark_as_spam_url = sprintf(
 					'<a href="%1$s">%2$s</a>',
 					esc_url( $mark_as_spam_url ),

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -184,7 +184,7 @@ class Dashboard {
 					if ( ! empty( $m[3] ) && strpos( $m[3], 'mark_as_spam' ) !== false ) {
 						$has_mark_as_spam = true;
 					}
-				} elseif ( preg_match( '#^/response/(\d+)#', $p, $m ) ) {
+				} elseif ( preg_match( '#^/response/(\d+)$#', $p, $m ) ) {
 					// Standalone single response page (wp-build only) — the legacy
 					// dashboard shows the response in the inbox list instead.
 					$post_id = absint( $m[1] );

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -184,10 +184,16 @@ class Dashboard {
 					if ( ! empty( $m[3] ) && strpos( $m[3], 'mark_as_spam' ) !== false ) {
 						$has_mark_as_spam = true;
 					}
-				} elseif ( preg_match( '#^/response/(\d+)$#', $p, $m ) ) {
+				} elseif ( preg_match( '#^/response/(\d+)(?:\?(.*))?$#', $p, $m ) ) {
 					// Standalone single response page (wp-build only) — the legacy
-					// dashboard shows the response in the inbox list instead.
+					// dashboard shows the response in the inbox list instead. The path
+					// is matched whole so trailing junk isn't read as a response ID,
+					// but it may legitimately carry the email's mark_as_spam trigger.
 					$post_id = absint( $m[1] );
+
+					if ( ! empty( $m[2] ) && strpos( $m[2], 'mark_as_spam' ) !== false ) {
+						$has_mark_as_spam = true;
+					}
 				} elseif ( preg_match( '#^/forms#', $p ) ) {
 					$tab = 'forms';
 				}

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -599,18 +599,10 @@ class Dashboard {
 	public static function get_single_response_admin_url( $post_id = null ) {
 		$post_id = ! empty( $post_id ) ? absint( $post_id ) : null;
 
-		/** This filter is documented in class-dashboard.php::init */
-		$is_wp_build_enabled = apply_filters( 'jetpack_forms_alpha', true );
-
-		if ( ! $post_id || ! $is_wp_build_enabled ) {
-			return self::get_forms_admin_url( 'inbox', $post_id );
-		}
-
-		$url  = admin_url( 'admin.php' ) . '?page=' . self::FORMS_WPBUILD_ADMIN_SLUG;
-		$url .= '&p=' . rawurlencode( '/response/' . $post_id );
-
-		/** This filter is documented in class-dashboard.php::get_forms_admin_url */
-		return apply_filters( 'jetpack_forms_admin_url', $url, 'response', $post_id );
+		// `get_forms_admin_url()` owns the URL scheme for both dashboards. The
+		// 'response' tab resolves to the standalone page on wp-build, and falls
+		// through to the responses list on legacy, which has no such route.
+		return self::get_forms_admin_url( $post_id ? 'response' : 'inbox', $post_id );
 	}
 
 	/**
@@ -623,6 +615,12 @@ class Dashboard {
 	private static function get_forms_admin_path_wp_build( $tab, $post_id ) {
 		$post_id      = ! empty( $post_id ) ? absint( $post_id ) : null;
 		$response_ids = ! empty( $post_id ) ? '?responseIds=["' . $post_id . '"]' : '';
+
+		// The standalone single response page, which addresses the response by path
+		// rather than selecting it in a list.
+		if ( $tab === 'response' && ! empty( $post_id ) ) {
+			return '/response/' . $post_id;
+		}
 
 		$path_map = array(
 			'inbox'           => '/responses/inbox',

--- a/projects/packages/forms/src/dashboard/class-dashboard.php
+++ b/projects/packages/forms/src/dashboard/class-dashboard.php
@@ -184,6 +184,10 @@ class Dashboard {
 					if ( ! empty( $m[3] ) && strpos( $m[3], 'mark_as_spam' ) !== false ) {
 						$has_mark_as_spam = true;
 					}
+				} elseif ( preg_match( '#^/response/(\d+)#', $p, $m ) ) {
+					// Standalone single response page (wp-build only) — the legacy
+					// dashboard shows the response in the inbox list instead.
+					$post_id = absint( $m[1] );
 				} elseif ( preg_match( '#^/forms#', $p ) ) {
 					$tab = 'forms';
 				}
@@ -571,6 +575,36 @@ class Dashboard {
 		 * @return string The filtered Forms admin page URL.
 		 */
 		return apply_filters( 'jetpack_forms_admin_url', $url, $tab, $post_id );
+	}
+
+	/**
+	 * Returns the URL of the standalone single response page for a given response.
+	 *
+	 * The standalone page is a wp-build route (`/response/<id>`). The legacy
+	 * dashboard has no equivalent, so it falls back to the responses list with the
+	 * response selected — as does a missing/empty post ID.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int|null $post_id Post ID of the response to open.
+	 *
+	 * @return string
+	 */
+	public static function get_single_response_admin_url( $post_id = null ) {
+		$post_id = ! empty( $post_id ) ? absint( $post_id ) : null;
+
+		/** This filter is documented in class-dashboard.php::init */
+		$is_wp_build_enabled = apply_filters( 'jetpack_forms_alpha', true );
+
+		if ( ! $post_id || ! $is_wp_build_enabled ) {
+			return self::get_forms_admin_url( 'inbox', $post_id );
+		}
+
+		$url  = admin_url( 'admin.php' ) . '?page=' . self::FORMS_WPBUILD_ADMIN_SLUG;
+		$url .= '&p=' . rawurlencode( '/response/' . $post_id );
+
+		/** This filter is documented in class-dashboard.php::get_forms_admin_url */
+		return apply_filters( 'jetpack_forms_admin_url', $url, 'response', $post_id );
 	}
 
 	/**

--- a/projects/packages/forms/src/dashboard/hooks/test/use-mark-as-spam.test.js
+++ b/projects/packages/forms/src/dashboard/hooks/test/use-mark-as-spam.test.js
@@ -1,0 +1,102 @@
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import { act, renderHook, waitFor } from '@testing-library/react';
+
+const saveEntityRecord = jest.fn();
+const invalidateCounts = jest.fn();
+
+await jest.unstable_mockModule( '@wordpress/data', () => ( {
+	useDispatch: store => ( store === 'core-store' ? { saveEntityRecord } : { invalidateCounts } ),
+} ) );
+await jest.unstable_mockModule( '@wordpress/core-data', () => ( { store: 'core-store' } ) );
+await jest.unstable_mockModule( '../../store/index.js', () => ( { store: 'dashboard-store' } ) );
+
+const { useMarkAsSpam } = await import( '../use-mark-as-spam.ts' );
+
+const inboxResponse = { id: 7, status: 'publish' };
+
+const setup = ( response, options = {} ) => {
+	const switchToSpam = jest.fn();
+	const removeParameter = jest.fn();
+	const checkParameter = jest.fn( () => options.hasParam ?? false );
+
+	const { result, rerender } = renderHook( ( props = response ) =>
+		useMarkAsSpam( props, { checkParameter, removeParameter, switchToSpam } )
+	);
+
+	return { result, rerender, switchToSpam, removeParameter, checkParameter };
+};
+
+describe( 'useMarkAsSpam', () => {
+	beforeEach( () => {
+		saveEntityRecord.mockReset();
+		invalidateCounts.mockReset();
+		invalidateCounts.mockResolvedValue( undefined );
+	} );
+
+	it( 'reports the change only when the save succeeds', async () => {
+		saveEntityRecord.mockResolvedValue( { id: 7, status: 'spam' } );
+		const { result, switchToSpam } = setup( inboxResponse );
+
+		await act( async () => {
+			await result.current.onConfirmMarkAsSpam();
+		} );
+
+		expect( switchToSpam ).toHaveBeenCalledWith( 7 );
+	} );
+
+	it( 'does not report the change when the save fails', async () => {
+		// The regression this guards: core-data resolves `undefined` on a failed save
+		// unless `throwOnError` is passed, so without it the hook would report success
+		// and callers would repair the store for a change the server refused.
+		saveEntityRecord.mockRejectedValue( new Error( 'nope' ) );
+		const { result, switchToSpam } = setup( inboxResponse );
+
+		await act( async () => {
+			await result.current.onConfirmMarkAsSpam();
+		} );
+
+		expect( switchToSpam ).not.toHaveBeenCalled();
+		expect( result.current.isSaving ).toBe( false );
+	} );
+
+	it( 'asks core-data to throw so failures are observable', async () => {
+		saveEntityRecord.mockResolvedValue( { id: 7 } );
+		const { result } = setup( inboxResponse );
+
+		await act( async () => {
+			await result.current.onConfirmMarkAsSpam();
+		} );
+
+		expect( saveEntityRecord ).toHaveBeenCalledWith(
+			'postType',
+			'feedback',
+			{ id: 7, status: 'spam' },
+			{ throwOnError: true }
+		);
+	} );
+
+	it( 'opens the dialog when the email trigger is present', async () => {
+		const { result } = setup( inboxResponse, { hasParam: true } );
+
+		await waitFor( () => expect( result.current.isConfirmDialogOpen ).toBe( true ) );
+	} );
+
+	it( 'arriving with the trigger does not mutate anything on its own', async () => {
+		const { result } = setup( inboxResponse, { hasParam: true } );
+
+		await waitFor( () => expect( result.current.isConfirmDialogOpen ).toBe( true ) );
+		expect( saveEntityRecord ).not.toHaveBeenCalled();
+	} );
+
+	it.each( [ 'spam', 'trash' ] )(
+		'consumes the trigger instead of leaving it armed for a %s response',
+		async status => {
+			// Left armed, the trigger re-fires the dialog unprompted as soon as a later
+			// Not spam / Restore moves the response back to the inbox.
+			const { result, removeParameter } = setup( { id: 7, status }, { hasParam: true } );
+
+			await waitFor( () => expect( removeParameter ).toHaveBeenCalled() );
+			expect( result.current.isConfirmDialogOpen ).toBe( false );
+		}
+	);
+} );

--- a/projects/packages/forms/src/dashboard/hooks/use-mark-as-spam.ts
+++ b/projects/packages/forms/src/dashboard/hooks/use-mark-as-spam.ts
@@ -3,7 +3,7 @@
  */
 import { store as coreStore } from '@wordpress/core-data';
 import { useDispatch } from '@wordpress/data';
-import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
+import { useCallback, useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { store as dashboardStore } from '../store/index.js';
 /**
@@ -51,10 +51,18 @@ export const useMarkAsSpam = ( response: FormResponse | null, options: UseMarkAs
 		try {
 			setIsSaving( true );
 
-			await saveEntityRecord( 'postType', 'feedback', {
-				id: response.id,
-				status: 'spam',
-			} );
+			// `throwOnError` matters: without it core-data resolves `undefined` on a
+			// failed save instead of rejecting, so the `catch` below never runs and
+			// callers act on a change the server refused.
+			await saveEntityRecord(
+				'postType',
+				'feedback',
+				{
+					id: response.id,
+					status: 'spam',
+				},
+				{ throwOnError: true }
+			);
 
 			await invalidateCounts();
 
@@ -76,12 +84,27 @@ export const useMarkAsSpam = ( response: FormResponse | null, options: UseMarkAs
 		removeParameter();
 	}, [ removeParameter ] );
 
-	// Email links have a query param that triggers the confirmation dialog.
+	// Email links carry a query param that triggers the confirmation dialog. The
+	// trigger is consumed exactly once: a response that is already spam or trashed
+	// has nothing to confirm, so the param is cleared rather than left armed. On a
+	// screen that keeps the user in place, an armed param would re-fire the dialog
+	// unprompted as soon as a later action moved the response back to the inbox.
+	const hasConsumedSpamParameter = useRef( false );
+
 	useEffect( () => {
-		if ( hasSpamParameter && response && ! [ 'spam', 'trash' ].includes( response.status ) ) {
-			setIsConfirmDialogOpen( true );
+		if ( ! hasSpamParameter || ! response || hasConsumedSpamParameter.current ) {
+			return;
 		}
-	}, [ response?.status, hasSpamParameter, response ] );
+
+		hasConsumedSpamParameter.current = true;
+
+		if ( [ 'spam', 'trash' ].includes( response.status ) ) {
+			removeParameter();
+			return;
+		}
+
+		setIsConfirmDialogOpen( true );
+	}, [ response?.status, hasSpamParameter, response, removeParameter ] );
 
 	return {
 		isConfirmDialogOpen,

--- a/projects/packages/forms/src/dashboard/inbox/stage/test/view-action.test.js
+++ b/projects/packages/forms/src/dashboard/inbox/stage/test/view-action.test.js
@@ -1,0 +1,36 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+// The headline behaviour of the standalone response page: the responses list's
+// "View" row action opens `/response/<id>` instead of selecting the response in
+// the list via the `responseIds` search param. Located here rather than beside the
+// route because `routes/*/package.json` has no `"type": "module"`, which makes
+// `.js` under those directories CJS and unable to import the route's TS modules.
+const { getActions } = await import( '../../../../../routes/responses/actions.tsx' );
+
+describe( 'viewAction', () => {
+	it( 'opens the response on its own page', async () => {
+		const navigate = jest.fn();
+
+		await getActions( { navigate } ).viewAction.callback( [ { id: 7 } ], {} );
+
+		expect( navigate ).toHaveBeenCalledWith( { to: '/response/7' } );
+	} );
+
+	it( 'does not fall back to selecting the response in the list', async () => {
+		const navigate = jest.fn();
+
+		await getActions( { navigate } ).viewAction.callback( [ { id: 7 } ], {} );
+
+		// Guards the regression back to the pre-PR behaviour, which navigated by
+		// setting `search: { responseIds: [ '7' ] }` on the list route.
+		expect( navigate.mock.calls[ 0 ][ 0 ] ).not.toHaveProperty( 'search' );
+	} );
+
+	it( 'does nothing when handed no items', async () => {
+		const navigate = jest.fn();
+
+		await getActions( { navigate } ).viewAction.callback( [], {} );
+
+		expect( navigate ).not.toHaveBeenCalled();
+	} );
+} );

--- a/projects/packages/forms/src/dashboard/inbox/stage/types.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/stage/types.tsx
@@ -120,6 +120,22 @@ export type Registry = {
 	resolveSelect: ( store: StoreDescriptor ) => ResolveSelectActions;
 };
 
+/**
+ * Outcome of an action, so callers can tell a successful run from a failed one.
+ *
+ * The status-changing actions already track this internally to decide which
+ * optimistic updates to roll back; reporting it lets callers that keep the user
+ * in place (e.g. the standalone single response page) avoid acting on a change
+ * the server rejected. Callers that don't care — such as the responses list,
+ * which relies on the notices and optimistic updates — can ignore it.
+ */
+export type ActionResult = {
+	/** Number of items the server confirmed. */
+	itemsUpdated: number;
+	/** Number of items whose request failed. */
+	numberOfErrors: number;
+};
+
 export type Action = {
 	id: string;
 	isPrimary: boolean;
@@ -132,5 +148,5 @@ export type Action = {
 		items: FormResponse[],
 		{ registry }: { registry: Registry },
 		options?: { isUndo?: boolean; targetStatus?: 'publish' | 'spam' | 'trash' }
-	) => Promise< void >;
+	) => Promise< ActionResult | void >;
 };

--- a/projects/packages/forms/src/dashboard/inbox/stage/types.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/stage/types.tsx
@@ -61,7 +61,9 @@ export type DispatchActions = {
 		kind: string,
 		name: string,
 		records: FormResponse[],
-		query?: QueryParams,
+		// Collection queries carry keys beyond the dashboard's own filters (e.g.
+		// `include`, `fields_format`), so this is wider than `QueryParams`.
+		query?: QueryParams | Record< string, unknown >,
 		invalidateCache?: boolean
 	) => void;
 	invalidateResolution: ( selector: string, args: unknown[] ) => void;
@@ -155,12 +157,20 @@ export type Action = {
 };
 
 /**
- * An action whose callback must report its outcome on every terminal path.
+ * An action whose callback is expected to report its outcome on every terminal path.
  *
  * Callers that keep the user in place gate on the result, so a success path that
- * forgot to return one would read as "did nothing" — this makes that a compile
- * error. `markAsRead` / `markAsUnread` keep the looser `Action`: nothing inspects
- * their result.
+ * forgot to return one reads as "did nothing" — the repair is skipped and the badge
+ * goes stale.
+ *
+ * This documents intent more than it enforces it. The shared tsconfig sets
+ * `strict: false`, so with `strictNullChecks` off a callback that returns a result
+ * on some paths and falls through on another still satisfies this type; only a
+ * callback whose every path is void is rejected. Enabling `strictNullChecks` +
+ * `noImplicitReturns` for this package would close the gap.
+ *
+ * `markAsRead` / `markAsUnread` keep the looser `Action`: nothing inspects their
+ * result.
  */
 export type ReportingAction = Omit< Action, 'callback' > & {
 	callback: ActionCallback< ActionResult >;

--- a/projects/packages/forms/src/dashboard/inbox/stage/types.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/stage/types.tsx
@@ -150,22 +150,17 @@ export type Action = {
 	modalHeader?: string;
 	isEligible?: ( item: FormResponse ) => boolean;
 	supportsBulk?: boolean;
+	isDestructive?: boolean;
 	callback?: ActionCallback;
 };
 
 /**
  * An action whose callback must report its outcome on every terminal path.
  *
- * Callers that keep the user in place decide what to do next from the returned
- * result — the single response page only repairs the store, or navigates away
- * after a delete, once the server has confirmed the change. Under the looser
- * `ActionResult | void` type, an action that grew a success path with a bare
- * `return` would silently be read as "did nothing", quietly reinstating the
- * field-flattening bug with no type error and no failing test. Requiring the
- * result here turns that into a compile error instead.
- *
- * `markAsRead` / `markAsUnread` deliberately keep the looser `Action` type: no
- * caller inspects their result, and they have bare returns today.
+ * Callers that keep the user in place gate on the result, so a success path that
+ * forgot to return one would read as "did nothing" — this makes that a compile
+ * error. `markAsRead` / `markAsUnread` keep the looser `Action`: nothing inspects
+ * their result.
  */
 export type ReportingAction = Omit< Action, 'callback' > & {
 	callback: ActionCallback< ActionResult >;

--- a/projects/packages/forms/src/dashboard/inbox/stage/types.tsx
+++ b/projects/packages/forms/src/dashboard/inbox/stage/types.tsx
@@ -136,6 +136,12 @@ export type ActionResult = {
 	numberOfErrors: number;
 };
 
+export type ActionCallback< Result extends ActionResult | void = ActionResult | void > = (
+	items: FormResponse[],
+	{ registry }: { registry: Registry },
+	options?: { isUndo?: boolean; targetStatus?: 'publish' | 'spam' | 'trash' }
+) => Promise< Result >;
+
 export type Action = {
 	id: string;
 	isPrimary: boolean;
@@ -144,9 +150,23 @@ export type Action = {
 	modalHeader?: string;
 	isEligible?: ( item: FormResponse ) => boolean;
 	supportsBulk?: boolean;
-	callback?: (
-		items: FormResponse[],
-		{ registry }: { registry: Registry },
-		options?: { isUndo?: boolean; targetStatus?: 'publish' | 'spam' | 'trash' }
-	) => Promise< ActionResult | void >;
+	callback?: ActionCallback;
+};
+
+/**
+ * An action whose callback must report its outcome on every terminal path.
+ *
+ * Callers that keep the user in place decide what to do next from the returned
+ * result — the single response page only repairs the store, or navigates away
+ * after a delete, once the server has confirmed the change. Under the looser
+ * `ActionResult | void` type, an action that grew a success path with a bare
+ * `return` would silently be read as "did nothing", quietly reinstating the
+ * field-flattening bug with no type error and no failing test. Requiring the
+ * result here turns that into a compile error instead.
+ *
+ * `markAsRead` / `markAsUnread` deliberately keep the looser `Action` type: no
+ * caller inspects their result, and they have bare returns today.
+ */
+export type ReportingAction = Omit< Action, 'callback' > & {
+	callback: ActionCallback< ActionResult >;
 };

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Email_Renderer_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Email_Renderer_Test.php
@@ -721,10 +721,14 @@ class Feedback_Email_Renderer_Test extends BaseTestCase {
 
 		remove_filter( 'jetpack_forms_alpha', '__return_true' );
 
-		// "View in dashboard" points at the standalone single response page.
-		$this->assertStringContainsString(
-			esc_url( Dashboard::get_single_response_admin_url( $post_id ) ),
-			$result['message']
+		// "View in dashboard" points at the standalone single response page — and
+		// must NOT carry the trigger. Matched to the closing quote, because the view
+		// URL is a strict prefix of the spam one: a plain "contains" assertion would
+		// pass even if both buttons were armed.
+		$this->assertMatchesRegularExpression(
+			'#href="' . preg_quote( esc_url( Dashboard::get_single_response_admin_url( $post_id ) ), '#' ) . '"#',
+			$result['message'],
+			'View in dashboard must link to the single response page without the mark_as_spam trigger.'
 		);
 
 		// "Mark as spam" points at the same page and carries the trigger. Asserted by
@@ -742,6 +746,55 @@ class Feedback_Email_Renderer_Test extends BaseTestCase {
 			'#href="[^"]*p=%2Fresponses%2Finbox[^"]*mark_as_spam#',
 			$result['message'],
 			'Mark as spam should no longer route through the responses list.'
+		);
+	}
+
+	/**
+	 * A submission already flagged as spam gets no Mark-as-spam button.
+	 *
+	 * Sites can mail spam submissions via `$send_even_if_spam`. The button would
+	 * link to a page that deliberately shows no confirmation for an
+	 * already-spam response, leaving the trigger armed in the URL.
+	 */
+	public function test_build_email_content_omits_mark_as_spam_for_spam_submission() {
+		add_filter( 'jetpack_forms_alpha', '__return_true' );
+
+		$post_id = Utility::create_legacy_feedback(
+			array(
+				'Name'  => 'Test User',
+				'Email' => 'test@example.com',
+			),
+			'Test message',
+			'Test User'
+		);
+
+		$form     = new Contact_Form( array(), '' );
+		$response = Feedback::get( $post_id );
+
+		$context_data = array(
+			'time'                 => current_time( 'mysql' ),
+			'url'                  => 'https://example.com',
+			'comment_author'       => 'Test User',
+			'comment_author_email' => 'test@example.com',
+			'comment_author_ip'    => '127.0.0.1',
+			'is_spam'              => true,
+			'feedback_status'      => 'publish',
+		);
+
+		$result = Feedback_Email_Renderer::build_email_content( $post_id, $form, $response, $context_data );
+
+		remove_filter( 'jetpack_forms_alpha', '__return_true' );
+
+		$this->assertStringNotContainsString(
+			'mark_as_spam',
+			$result['message'],
+			'A spam submission must not be emailed a Mark as spam link.'
+		);
+
+		// The View in dashboard button is still offered.
+		$this->assertStringContainsString(
+			esc_url( Dashboard::get_single_response_admin_url( $post_id ) ),
+			$result['message']
 		);
 	}
 

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Email_Renderer_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Email_Renderer_Test.php
@@ -684,15 +684,15 @@ class Feedback_Email_Renderer_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The two email action buttons must not point at the same place.
+	 * Both email action buttons open the standalone single response page.
 	 *
-	 * "View in dashboard" opens the standalone single response page, while
-	 * "Mark as spam" has to stay on the responses list: the confirmation dialog it
-	 * relies on lives in the list's response inspector, not on the single response
-	 * page. Consolidating the two into one helper looks like a tidy-up and would
-	 * silently drop that confirmation step, so pin the difference here.
+	 * "Mark as spam" differs only by the `mark_as_spam` trigger, which opens a
+	 * confirmation dialog on that page — the destructive step is never taken on the
+	 * strength of an email click alone. Dropping that parameter would look like a
+	 * harmless de-duplication of two now-identical URLs while actually removing the
+	 * confirmation, so pin it here.
 	 */
-	public function test_build_email_content_action_urls_are_distinct() {
+	public function test_build_email_content_action_urls_target_single_response_page() {
 		add_filter( 'jetpack_forms_alpha', '__return_true' );
 
 		$post_id = Utility::create_legacy_feedback(
@@ -727,26 +727,21 @@ class Feedback_Email_Renderer_Test extends BaseTestCase {
 			$result['message']
 		);
 
-		// "Mark as spam" stays on the responses list and keeps its trigger param.
-		// Asserted by shape rather than by rebuilding `add_mark_as_spam_to_url()`,
-		// which embeds the flag inside the encoded `p` path for wp-build URLs.
+		// "Mark as spam" points at the same page and carries the trigger. Asserted by
+		// shape rather than by rebuilding `add_mark_as_spam_to_url()`, which embeds
+		// the flag inside the encoded `p` path for wp-build URLs.
 		$this->assertMatchesRegularExpression(
-			'#href="[^"]*p=%2Fresponses%2Finbox[^"]*mark_as_spam[^"]*"#',
+			'#href="[^"]*p=%2Fresponse%2F' . $post_id . '[^"]*mark_as_spam[^"]*"#',
 			$result['message'],
-			'Mark as spam must stay on the responses list, where its confirmation dialog lives.'
+			'Mark as spam must open the single response page with its confirmation trigger.'
 		);
 
-		// And it must never be pointed at the standalone page, which has no dialog.
+		// It must never lose the trigger and become a plain "view" link — that would
+		// mark the response as spam with no confirmation, or not at all.
 		$this->assertDoesNotMatchRegularExpression(
-			'#href="[^"]*p=%2Fresponse%2F\d+[^"]*mark_as_spam#',
+			'#href="[^"]*p=%2Fresponses%2Finbox[^"]*mark_as_spam#',
 			$result['message'],
-			'Pointing Mark as spam at the single response page would drop the confirmation step.'
-		);
-
-		$this->assertNotEquals(
-			Dashboard::get_single_response_admin_url( $post_id ),
-			Dashboard::get_forms_admin_url( 'inbox', $post_id ),
-			'The single response page and the responses list must remain distinct URLs.'
+			'Mark as spam should no longer route through the responses list.'
 		);
 	}
 

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Email_Renderer_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Email_Renderer_Test.php
@@ -9,6 +9,7 @@
 
 namespace Automattic\Jetpack\Forms\ContactForm;
 
+use Automattic\Jetpack\Forms\Dashboard\Dashboard;
 use PHPUnit\Framework\Attributes\CoversClass;
 use WorDBless\BaseTestCase;
 
@@ -680,6 +681,73 @@ class Feedback_Email_Renderer_Test extends BaseTestCase {
 		remove_all_filters( 'jetpack_forms_response_email_title' );
 
 		$this->assertStringContainsString( '<h1 class="email-header">Custom Email Title</h1>', $result['message'] );
+	}
+
+	/**
+	 * The two email action buttons must not point at the same place.
+	 *
+	 * "View in dashboard" opens the standalone single response page, while
+	 * "Mark as spam" has to stay on the responses list: the confirmation dialog it
+	 * relies on lives in the list's response inspector, not on the single response
+	 * page. Consolidating the two into one helper looks like a tidy-up and would
+	 * silently drop that confirmation step, so pin the difference here.
+	 */
+	public function test_build_email_content_action_urls_are_distinct() {
+		add_filter( 'jetpack_forms_alpha', '__return_true' );
+
+		$post_id = Utility::create_legacy_feedback(
+			array(
+				'Name'  => 'Test User',
+				'Email' => 'test@example.com',
+			),
+			'Test message',
+			'Test User'
+		);
+
+		$form     = new Contact_Form( array(), '' );
+		$response = Feedback::get( $post_id );
+
+		$context_data = array(
+			'time'                 => current_time( 'mysql' ),
+			'url'                  => 'https://example.com',
+			'comment_author'       => 'Test User',
+			'comment_author_email' => 'test@example.com',
+			'comment_author_ip'    => '127.0.0.1',
+			'is_spam'              => false,
+			'feedback_status'      => 'publish',
+		);
+
+		$result = Feedback_Email_Renderer::build_email_content( $post_id, $form, $response, $context_data );
+
+		remove_filter( 'jetpack_forms_alpha', '__return_true' );
+
+		// "View in dashboard" points at the standalone single response page.
+		$this->assertStringContainsString(
+			esc_url( Dashboard::get_single_response_admin_url( $post_id ) ),
+			$result['message']
+		);
+
+		// "Mark as spam" stays on the responses list and keeps its trigger param.
+		// Asserted by shape rather than by rebuilding `add_mark_as_spam_to_url()`,
+		// which embeds the flag inside the encoded `p` path for wp-build URLs.
+		$this->assertMatchesRegularExpression(
+			'#href="[^"]*p=%2Fresponses%2Finbox[^"]*mark_as_spam[^"]*"#',
+			$result['message'],
+			'Mark as spam must stay on the responses list, where its confirmation dialog lives.'
+		);
+
+		// And it must never be pointed at the standalone page, which has no dialog.
+		$this->assertDoesNotMatchRegularExpression(
+			'#href="[^"]*p=%2Fresponse%2F\d+[^"]*mark_as_spam#',
+			$result['message'],
+			'Pointing Mark as spam at the single response page would drop the confirmation step.'
+		);
+
+		$this->assertNotEquals(
+			Dashboard::get_single_response_admin_url( $post_id ),
+			Dashboard::get_forms_admin_url( 'inbox', $post_id ),
+			'The single response page and the responses list must remain distinct URLs.'
+		);
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/contact-form/Feedback_Email_Renderer_Test.php
+++ b/projects/packages/forms/tests/php/contact-form/Feedback_Email_Renderer_Test.php
@@ -791,7 +791,64 @@ class Feedback_Email_Renderer_Test extends BaseTestCase {
 			'A spam submission must not be emailed a Mark as spam link.'
 		);
 
+		// Asserting the URL token is absent is not enough: suppressing the URL while
+		// still rendering the button emits `<a href="">Mark as spam</a>`, which the
+		// token assertion happily passes. Pin the button and the empty href too.
+		$this->assertStringNotContainsString(
+			'href=""',
+			$result['message'],
+			'Suppressing the Mark as spam URL must suppress its button, not leave an empty href.'
+		);
+		$this->assertDoesNotMatchRegularExpression(
+			'#<a[^>]*class="[^"]*action-button[^"]*"[^>]*>\s*' . preg_quote( __( 'Mark as spam', 'jetpack-forms' ), '#' ) . '\s*</a>#',
+			$result['message'],
+			'The Mark as spam button must not render for a submission that is already filed.'
+		);
+
 		// The View in dashboard button is still offered.
+		$this->assertStringContainsString(
+			esc_url( Dashboard::get_single_response_admin_url( $post_id ) ),
+			$result['message']
+		);
+	}
+
+	/**
+	 * A disallowed-list hit is emailed with `trash` status and no Mark-as-spam button.
+	 *
+	 * `$is_spam` stays false for these, so keying the suppression on that flag alone
+	 * would leave the button pointing at a page with nothing to confirm.
+	 */
+	public function test_build_email_content_omits_mark_as_spam_for_trashed_submission() {
+		add_filter( 'jetpack_forms_alpha', '__return_true' );
+
+		$post_id = Utility::create_legacy_feedback(
+			array(
+				'Name'  => 'Test User',
+				'Email' => 'test@example.com',
+			),
+			'Test message',
+			'Test User'
+		);
+
+		$form     = new Contact_Form( array(), '' );
+		$response = Feedback::get( $post_id );
+
+		$context_data = array(
+			'time'                 => current_time( 'mysql' ),
+			'url'                  => 'https://example.com',
+			'comment_author'       => 'Test User',
+			'comment_author_email' => 'test@example.com',
+			'comment_author_ip'    => '127.0.0.1',
+			'is_spam'              => false,
+			'feedback_status'      => 'trash',
+		);
+
+		$result = Feedback_Email_Renderer::build_email_content( $post_id, $form, $response, $context_data );
+
+		remove_filter( 'jetpack_forms_alpha', '__return_true' );
+
+		$this->assertStringNotContainsString( 'mark_as_spam', $result['message'] );
+		$this->assertStringNotContainsString( 'href=""', $result['message'] );
 		$this->assertStringContainsString(
 			esc_url( Dashboard::get_single_response_admin_url( $post_id ) ),
 			$result['message']

--- a/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
+++ b/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
@@ -159,7 +159,9 @@ class Dashboard_Test extends BaseTestCase {
 	private function capture_cross_variant_redirect() {
 		$redirect = null;
 
-		$capture = function ( $location ) use ( &$redirect ) {
+		// Declared in the docblock rather than as a native `never` return type: this
+		// package supports PHP 7.2 and `never` is 8.1+.
+		$capture = /** @return never */ function ( $location ) use ( &$redirect ) {
 			$redirect = $location;
 			throw new \RuntimeException( 'redirected' );
 		};

--- a/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
+++ b/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
@@ -119,6 +119,35 @@ class Dashboard_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test get_single_response_admin_url points at the standalone response page (wp-build mode).
+	 */
+	public function test_get_single_response_admin_url_wp_build() {
+		add_filter( 'jetpack_forms_alpha', '__return_true' );
+
+		$expected = get_admin_url() . 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '&p=' . rawurlencode( '/response/123' );
+		$this->assertEquals( $expected, Dashboard::get_single_response_admin_url( 123 ) );
+
+		// Without a post ID there is no single response to open — fall back to the list.
+		$expected = get_admin_url() . 'admin.php?page=' . Dashboard::FORMS_WPBUILD_ADMIN_SLUG . '&p=' . rawurlencode( '/responses/inbox' );
+		$this->assertEquals( $expected, Dashboard::get_single_response_admin_url() );
+
+		remove_filter( 'jetpack_forms_alpha', '__return_true' );
+	}
+
+	/**
+	 * Test get_single_response_admin_url falls back to the responses list on the legacy dashboard,
+	 * which has no standalone single response route.
+	 */
+	public function test_get_single_response_admin_url_legacy() {
+		add_filter( 'jetpack_forms_alpha', '__return_false' );
+
+		$expected = get_admin_url() . 'admin.php?page=jetpack-forms-admin#/responses?status=inbox&r=123';
+		$this->assertEquals( $expected, Dashboard::get_single_response_admin_url( 123 ) );
+
+		remove_filter( 'jetpack_forms_alpha', '__return_false' );
+	}
+
+	/**
 	 * Test get_forms_admin_url without tab for wp-build dashboard
 	 */
 	public function test_get_forms_admin_url_wp_build_without_tab() {

--- a/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
+++ b/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
@@ -205,6 +205,28 @@ class Dashboard_Test extends BaseTestCase {
 	}
 
 	/**
+	 * The email's Mark as spam trigger survives the cross-variant redirect.
+	 *
+	 * Losing it here would silently turn the email's Mark as spam button into a
+	 * plain "view" link on the legacy dashboard.
+	 */
+	public function test_redirect_cross_variant_keeps_mark_as_spam_on_single_response_path() {
+		add_filter( 'jetpack_forms_alpha', '__return_false' );
+
+		$_GET['page'] = Dashboard::FORMS_WPBUILD_ADMIN_SLUG;
+		$_GET['p']    = '/response/123?mark_as_spam=1';
+
+		$redirect = $this->capture_cross_variant_redirect();
+
+		remove_filter( 'jetpack_forms_alpha', '__return_false' );
+
+		$this->assertEquals(
+			get_admin_url() . 'admin.php?page=jetpack-forms-admin#/responses?status=inbox&r=123&mark_as_spam',
+			$redirect
+		);
+	}
+
+	/**
 	 * The single response path is matched whole — trailing junk is not a response ID.
 	 */
 	public function test_redirect_cross_variant_ignores_malformed_single_response_path() {

--- a/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
+++ b/projects/packages/forms/tests/php/dashboard/Dashboard_Test.php
@@ -148,6 +148,81 @@ class Dashboard_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Capture where redirect_dashboard_url_cross_variant() sends the request.
+	 *
+	 * The method ends in `wp_safe_redirect()` + `exit`, so the redirect is
+	 * intercepted at the `wp_redirect` filter and aborted with an exception before
+	 * either headers or the exit are reached.
+	 *
+	 * @return string|null The redirect target, or null if no redirect happened.
+	 */
+	private function capture_cross_variant_redirect() {
+		$redirect = null;
+
+		$capture = function ( $location ) use ( &$redirect ) {
+			$redirect = $location;
+			throw new \RuntimeException( 'redirected' );
+		};
+
+		add_filter( 'wp_redirect', $capture );
+
+		try {
+			Dashboard::redirect_dashboard_url_cross_variant();
+		} catch ( \RuntimeException $e ) { // phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedCatch
+			// Expected — stands in for the `exit` after the redirect.
+		} finally {
+			remove_filter( 'wp_redirect', $capture );
+		}
+
+		return $redirect;
+	}
+
+	/**
+	 * A wp-build single response link must survive jetpack_forms_alpha being turned off.
+	 *
+	 * This is the branch nobody exercises by hand: it only runs against links already
+	 * sitting in people's inboxes after the flag is flipped.
+	 */
+	public function test_redirect_cross_variant_maps_single_response_path_to_legacy() {
+		add_filter( 'jetpack_forms_alpha', '__return_false' );
+
+		$_GET['page'] = Dashboard::FORMS_WPBUILD_ADMIN_SLUG;
+		$_GET['p']    = '/response/123';
+
+		$redirect = $this->capture_cross_variant_redirect();
+
+		remove_filter( 'jetpack_forms_alpha', '__return_false' );
+
+		// The legacy dashboard has no single response route, so the response is
+		// opened in the inbox list instead — and the `/response/` pattern must not be
+		// shadowed by the `/responses/(inbox|spam|trash)` one above it.
+		$this->assertEquals(
+			get_admin_url() . 'admin.php?page=jetpack-forms-admin#/responses?status=inbox&r=123',
+			$redirect
+		);
+	}
+
+	/**
+	 * The single response path is matched whole — trailing junk is not a response ID.
+	 */
+	public function test_redirect_cross_variant_ignores_malformed_single_response_path() {
+		add_filter( 'jetpack_forms_alpha', '__return_false' );
+
+		$_GET['page'] = Dashboard::FORMS_WPBUILD_ADMIN_SLUG;
+		$_GET['p']    = '/response/123junk';
+
+		$redirect = $this->capture_cross_variant_redirect();
+
+		remove_filter( 'jetpack_forms_alpha', '__return_false' );
+
+		// Falls through to the plain inbox with no response selected.
+		$this->assertEquals(
+			get_admin_url() . 'admin.php?page=jetpack-forms-admin#/responses?status=inbox',
+			$redirect
+		);
+	}
+
+	/**
 	 * Test get_forms_admin_url without tab for wp-build dashboard
 	 */
 	public function test_get_forms_admin_url_wp_build_without_tab() {


### PR DESCRIPTION
## Proposed changes

The standalone single response page (`/response/$responseId`, added in #49827) shipped unlinked — its own docblock said *"Not linked from anywhere yet."* This wires it up and makes it behave like a real destination rather than a dead end.

* **The responses list "View" action** opens the response on its own page instead of setting `responseIds` to open the inspector side panel. Clicking a row is unchanged — that still opens the inspector.
* **Both response notification email buttons** now open that same page. "View in dashboard" goes to `/response/<id>`; "Mark as spam" goes to the same URL plus `?mark_as_spam=1`, which opens a confirmation dialog there, so the destructive step is never taken on the strength of an email click alone. New `Dashboard::get_single_response_admin_url()` builds these, falling back to the responses list when there's no post ID or when `jetpack_forms_alpha` is off (the legacy dashboard has no such route). `redirect_dashboard_url_cross_variant()` learned to parse `/response/<id>`, including its `mark_as_spam` trigger, so links sent while wp-build was enabled still resolve — trigger intact — if the flag is later turned off.
* **Status actions keep the user on the page.** Marking a response as spam, not spam, trashed or restored no longer bounces back to the list; a status badge in the header updates instead (no badge for inbox — "Spam" and "Trash" only). Permanent delete still navigates away, since there's no response left to show.

### Notes for reviewers

**Staying on the page is what makes the store's inaccuracies visible**, and two of them needed fixing:

* Trash goes through `deleteEntityRecord`, whose `REMOVE_ITEMS` reducer drops the record from core-data entirely — the page would otherwise fall through to its "not found" state.
* Spam / not spam / restore (including the one behind the email's confirmation dialog) save via `saveEntityRecord` with no `fields_format`. The endpoint defaults that to `label-value` (`class-contact-form-endpoint.php`), core-data receives the PUT response into the store, and `conservativeMapItem` lets the incoming `fields` replace the collection-shaped ones this page renders from — so the body would visibly flatten into plain rows. Same class of bug #49827 already fixed once from the fetch side.

Both are repaired by re-receiving the pre-action record with its new status, shared via `routes/response/repair-record.ts`. The repair only runs once the server has accepted the change, which is why `Action` callbacks now report an `ActionResult { itemsUpdated, numberOfErrors }` — the four status actions and delete are typed `ReportingAction` so a future callback that forgets to return on a success path is a compile error rather than a silent regression. `markAsRead` / `markAsUnread` keep the looser type; nothing inspects their result.

Because every status change used to navigate away, nothing guarded against a second action landing while the first was in flight. The dropdown is now disabled while one is pending.

`searchParams` was only ever read by the view action, so it was dropped from `getActions()` / `getRowActions()` and their three call sites rather than left as a dead parameter.

## Related product discussion/links

* Follow-up to #49827.

## Does this pull request change what data or activity we track or use?

No. The existing `jetpack_forms_inbox_action_click` Tracks event still fires for `view-response` with the same properties.

## Testing instructions

Requires a Jetpack-connected site with at least one form response in the inbox.

**The list**

* Go to **Jetpack → Forms** and click **View** on a response row → the full single response page opens, not the right-hand inspector. Clicking elsewhere on the row should still open the inspector.

**Staying in place**

* On the single response page, open the **⋮** menu and choose **Mark as spam** → you stay on the page, a "Spam" badge appears in the header, and the menu switches to Not spam / Trash.
* Check the response body still renders its fields richly rather than collapsing into plain `label: value` rows. This is the regression the store repair exists for, so it's the most valuable thing to eyeball.
* Choose **Trash** → you stay on the page, the badge changes to "Trash", the menu becomes Restore / Delete permanently, and the response still renders (not "This response could not be found").
* **Restore** or **Not spam** → the badge disappears; inbox responses show no badge.
* Double-click **Trash** → the menu toggle should go busy/disabled so the second click can't land.
* **Delete permanently** → navigates back to the responses list.

**Email**

* Submit a form so a notification email is sent.
* Click **View in dashboard** → lands on the single response page, no dialog.
* Click **Mark as spam** → lands on the same page with a confirmation dialog. Cancel leaves the response untouched and drops the parameter from the URL; confirming marks it spam and keeps you on the page, with the fields still richly rendered.

**Legacy fallback (optional)**

* Add `add_filter( 'jetpack_forms_alpha', '__return_false' );` and click both email buttons → each should still reach the response in the legacy dashboard, with Mark as spam keeping its trigger.
