### PR TITLE
AI: Rename MCP settings Tracks properties to the AI events standard

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -27,8 +27,8 @@ import McpWrite from './mcp/write';
 
 const { blogId, activityLogUrl, apiRoot, apiNonce } = window?.jetpackAiSettings ?? {};
 
-// Matches the `source` value convention used by the MCP upsell events.
-const SETTINGS_SOURCE = 'jetpack-ai-mcp-settings';
+// Matches the `ref` value convention used by the MCP upsell events.
+const SETTINGS_REF = 'jetpack-ai-mcp-settings';
 
 const MCP_SUB_VIEWS = [ 'read', 'write', 'setup' ];
 
@@ -149,7 +149,7 @@ export default function App() {
 			// blog_id is attached automatically by the analytics library from
 			// window.jpTracksContext, which the page sets via an inline script.
 			analytics.tracks.recordEvent( 'jetpack_mcp_settings_viewed', {
-				source: SETTINGS_SOURCE,
+				ref: SETTINGS_REF,
 			} );
 		}
 	}, [ isLoading, hasMcpAccess, isMcpContext ] );

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/read.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/read.jsx
@@ -175,7 +175,7 @@ export default function McpRead( { mcpAbilities, blogId, savingToolIds, onUpdate
 	const handleToolChange = useCallback(
 		( toolId, enabled ) => {
 			analytics.tracks.recordEvent( 'jetpack_mcp_allowlist_updated', {
-				tool_id: toolId,
+				ability_name: toolId,
 				enabled,
 				view: 'read',
 			} );

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/test/allowlist-updated.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/test/allowlist-updated.jsx
@@ -1,0 +1,77 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import analytics from 'lib/analytics';
+import McpRead from '../read';
+import McpWrite from '../write';
+
+// read.jsx/write.jsx import the webpack-aliased 'lib/analytics', which doesn't
+// resolve under jest — provide it virtually. (jest.mock is hoisted above the
+// imports.)
+jest.mock( 'lib/analytics', () => ( { tracks: { recordEvent: jest.fn() } } ), { virtual: true } );
+
+const BLOG_ID = 123;
+
+/**
+ * Build a minimal mcp_abilities response holding a single tool.
+ *
+ * @param {object}  options          - Options.
+ * @param {boolean} options.readonly - Whether the tool is read-only (read view) or write.
+ * @param {boolean} options.enabled  - Initial enabled state.
+ * @return {object} mcp_abilities object.
+ */
+const abilitiesWithTool = ( { readonly, enabled = false } ) => ( {
+	account: {
+		'wpcom-mcp/posts-list': {
+			title: 'List posts',
+			description: 'List your posts.',
+			enabled,
+			readonly,
+			category: 'posts',
+		},
+	},
+	sites: [],
+} );
+
+const allowlistUpdatedCalls = () =>
+	analytics.tracks.recordEvent.mock.calls.filter(
+		call => call[ 0 ] === 'jetpack_mcp_allowlist_updated'
+	);
+
+beforeEach( () => {
+	analytics.tracks.recordEvent.mockClear();
+} );
+
+describe( 'jetpack_mcp_allowlist_updated', () => {
+	test.each( [
+		{ view: 'read', Component: McpRead, readonly: true },
+		{ view: 'write', Component: McpWrite, readonly: false },
+	] )(
+		'per-tool toggle reports ability_name (not tool_id) on the $view view',
+		async ( { view, Component, readonly } ) => {
+			const onUpdate = jest.fn();
+			render(
+				<Component
+					mcpAbilities={ abilitiesWithTool( { readonly } ) }
+					blogId={ BLOG_ID }
+					savingToolIds={ new Set() }
+					onUpdate={ onUpdate }
+				/>
+			);
+
+			// Individual tool toggles sit behind the group's "Show operations" chevron.
+			await userEvent.click( screen.getByRole( 'button', { name: 'Show operations' } ) );
+			await userEvent.click( screen.getByRole( 'checkbox', { name: 'List posts' } ) );
+
+			// toEqual pins the whole property bag: ability_name present, no tool_id.
+			expect( allowlistUpdatedCalls() ).toEqual( [
+				[
+					'jetpack_mcp_allowlist_updated',
+					{ ability_name: 'wpcom-mcp/posts-list', enabled: true, view },
+				],
+			] );
+			expect( onUpdate ).toHaveBeenCalledWith( {
+				sites: [ { blog_id: BLOG_ID, abilities: { 'wpcom-mcp/posts-list': true } } ],
+			} );
+		}
+	);
+} );

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/upsell.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/upsell.jsx
@@ -19,7 +19,7 @@ import analytics from 'lib/analytics';
 import illustrationUrl from './upsell-illustration.svg';
 import './style.scss';
 
-const UPSELL_SOURCE = 'jetpack-ai-mcp-upsell';
+const UPSELL_REF = 'jetpack-ai-mcp-upsell';
 
 const { upgradeUrl } = window?.jetpackAiSettings ?? {};
 
@@ -35,13 +35,13 @@ export default function McpUpsell() {
 	// gating needed here.
 	useEffect( () => {
 		analytics.tracks.recordEvent( 'jetpack_mcp_upsell_viewed', {
-			source: UPSELL_SOURCE,
+			ref: UPSELL_REF,
 		} );
 	}, [] );
 
 	const onClickUpgrade = useCallback( () => {
 		analytics.tracks.recordEvent( 'jetpack_mcp_upsell_cta_click', {
-			source: UPSELL_SOURCE,
+			ref: UPSELL_REF,
 		} );
 	}, [] );
 

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/write.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/write.jsx
@@ -175,7 +175,7 @@ export default function McpWrite( { mcpAbilities, blogId, savingToolIds, onUpdat
 	const handleToolChange = useCallback(
 		( toolId, enabled ) => {
 			analytics.tracks.recordEvent( 'jetpack_mcp_allowlist_updated', {
-				tool_id: toolId,
+				ability_name: toolId,
 				enabled,
 				view: 'write',
 			} );

--- a/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
@@ -229,6 +229,12 @@ describe( 'AI admin page (main.jsx)', () => {
 
 		await waitFor( () => expect( mcpViewCount() ).toBe( 1 ) );
 
+		// Pin the event's property contract: `ref` follows the AI Tracks standard.
+		const settingsViewedCall = analytics.tracks.recordEvent.mock.calls.find(
+			call => call[ 0 ] === 'jetpack_mcp_settings_viewed'
+		);
+		expect( settingsViewedCall[ 1 ] ).toEqual( { ref: 'jetpack-ai-mcp-settings' } );
+
 		// The useRef latch: leaving and re-entering the MCP context on the same
 		// mounted instance does not re-fire the view event.
 		act( () => {

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-mcp-tracks-ref-ability-name
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-mcp-tracks-ref-ability-name
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Rename Tracks properties on the Jetpack AI MCP settings events: source is now ref, and tool_id is now ability_name, matching the AI product events standard.

--- a/projects/plugins/jetpack/tests/jest.config.gui.js
+++ b/projects/plugins/jetpack/tests/jest.config.gui.js
@@ -10,6 +10,7 @@ module.exports = {
 		'<rootDir>/_inc/client/test/main.js',
 		'<rootDir>/_inc/client/**/test/component.js',
 		'<rootDir>/_inc/client/ai/features/test/component.jsx',
+		'<rootDir>/_inc/client/ai/mcp/test/allowlist-updated.jsx',
 		'<rootDir>/_inc/client/ai/test/main.jsx',
 		'<rootDir>/_inc/client/sharing/test/component.jsx',
 		'<rootDir>/_inc/client/at-a-glance/stats/test/chart-bar-range.js',


### PR DESCRIPTION
## Proposed changes

* Rename Tracks properties on the Jetpack AI MCP settings events to match the Tracks Standards for AI Product Events (Field Guide):
  * `source` → `ref` on `jetpack_mcp_upsell_viewed`, `jetpack_mcp_upsell_cta_click`, and `jetpack_mcp_settings_viewed`
  * `tool_id` → `ability_name` on `jetpack_mcp_allowlist_updated`
* Pin the renamed properties in tests: extend the `jetpack_mcp_settings_viewed` tracking assertion, and add render-level coverage for `jetpack_mcp_allowlist_updated` on the read and write views.

**This is a one-time, breaking property rename on live events.** Events fired before the deploy carry the old property names; events fired after carry the new ones. The break is dated: wpcom Simple deploys from trunk shortly after merge, and self-hosted sites get the change with Jetpack 16.1 — the exact deploy date will be noted on this PR once merged. Same shape as the `enabled` encoding cutover in [AIINT-576](https://linear.app/a8c/issue/AIINT-576).

Decision: Shannon Smith's call on [AIINT-574](https://linear.app/a8c/issue/AIINT-574#comment-06cb0026-96d1-43ef-b5c3-761a8acce585) — as we move toward a unified platform there will be data collisions across products, and the earlier the rename lands, the less data is split.

## Related product discussion/links

* [AIINT-574](https://linear.app/a8c/issue/AIINT-574/jetpack-mcp-settings-events-fire-in-a-site-context-without-blog-id-and) — original audit; its registration notes name `ref` and `ability_name` as the standard property names
* #51096 — attached `blog_id` to these events and added the payload this PR renames

## Does this pull request change what data or activity we track or use?

No new data is collected and no events are added or removed. Four existing events keep firing with the same values; only two property *keys* are renamed (`source` → `ref`, `tool_id` → `ability_name`).

## Testing instructions

* `cd projects/plugins/jetpack && NODE_PATH=tests:_inc/client pnpm jest --config=tests/jest.config.gui.js _inc/client/ai` — all 71 tests pass, including the new assertions pinning `ref` on `jetpack_mcp_settings_viewed` and `ability_name` on `jetpack_mcp_allowlist_updated` (read and write views).
* Manual smoke test (optional): on a connected site, open `wp-admin/admin.php?page=jetpack-ai` → MCP Settings, toggle a tool, and confirm `jetpack_mcp_allowlist_updated` fires with `ability_name` (Tracks Vigilante or the event monitor). On a site without MCP access, the upsell card fires `jetpack_mcp_upsell_viewed` with `ref: jetpack-ai-mcp-upsell`.
