### PR TITLE
AI sidebar tests: drive master-off through the ai module

### DIFF
--- a/projects/plugins/jetpack/changelog/fix-ai-sidebar-master-off-tests
+++ b/projects/plugins/jetpack/changelog/fix-ai-sidebar-master-off-tests
@@ -1,0 +1,5 @@
+Significance: patch
+Type: other
+Comment: Test-only change; drive the AI sidebar master-off tests through the ai module now that it is the master off Simple.
+
+

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -627,13 +627,14 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		add_filter( 'jetpack_ai_sidebar_enabled', array( \Jetpack_AI_Settings::class, 'apply_master_gates' ), 11 );
 
 		// Master off + features on: hidden (existing rule, no regression).
-		update_option( \Jetpack_AI_Settings::MASTER_OPTION, 0 );
+		// Off-Simple the master is the `ai` module; turn it off there.
+		$this->deactivate_ai_module_for_test();
 		update_option( 'jetpack_ai_writing_assistant_enabled', 1 );
 		update_option( 'ai_seo_enhancer_enabled', 1 );
 		$master_off_features_on = $this->gate_open();
 
 		// Master on + both features off: hidden (the new rule).
-		update_option( \Jetpack_AI_Settings::MASTER_OPTION, 1 );
+		$this->activate_ai_module_for_test();
 		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
 		update_option( 'ai_seo_enhancer_enabled', 0 );
 		$master_on_features_off = $this->gate_open();
@@ -642,7 +643,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 		update_option( 'jetpack_ai_writing_assistant_enabled', 1 );
 		$master_on_writing_on = $this->gate_open();
 
-		delete_option( \Jetpack_AI_Settings::MASTER_OPTION );
 		delete_option( 'jetpack_ai_writing_assistant_enabled' );
 		delete_option( 'ai_seo_enhancer_enabled' );
 
@@ -658,12 +658,11 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * points.
 	 */
 	public function test_init_does_nothing_when_master_off_despite_late_filter() {
-		update_option( \Jetpack_AI_Settings::MASTER_OPTION, 0 );
+		// Off-Simple the master is the `ai` module; turn it off there.
+		$this->deactivate_ai_module_for_test();
 		add_filter( 'jetpack_ai_sidebar_enabled', '__return_true', 999 );
 
 		Jetpack_AI_Sidebar::init();
-
-		delete_option( \Jetpack_AI_Settings::MASTER_OPTION );
 
 		$this->assertFalse(
 			has_filter( 'agents_manager_agent_providers', array( Jetpack_AI_Sidebar::class, 'register_provider' ) ),


### PR DESCRIPTION
## Proposed changes

* Fix the two `Jetpack_AI_Sidebar_Test` failures on trunk: `test_preview_master_gate_composes_with_feature_toggles` and `test_init_does_nothing_when_master_off_despite_late_filter` drove master-off by writing the `jetpack_ai_enabled` option, which stopped being the master off Simple when the ai module landed (#50718). They now use the existing `activate/deactivate_ai_module_for_test()` trait helpers, like the rest of the file.
* #50778 and #50718 were each green against the trunk they were written on; the collision only appears with both merged. Test-only change.

## Related product discussion/links

* Trunk failure: https://github.com/Automattic/jetpack/actions/runs/31347077573/job/93330894030

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* `jp docker phpunit jetpack -- --filter=Jetpack_AI_Sidebar_Test` — all tests pass, including the two above.
