### PR TITLE
Content Guidelines AI: stop the banner painting over the sticky page header

### DIFF
--- a/projects/plugins/jetpack/_inc/content-guidelines-ai/style.scss
+++ b/projects/plugins/jetpack/_inc/content-guidelines-ai/style.scss
@@ -16,8 +16,12 @@ $cg-diff-removed: #f8d7da;
 }
 
 // Empty state banner.
+// isolation keeps the z-indexes inside the banner from competing with the
+// route's sticky page header (also z-index: 1, earlier in the DOM) — without
+// it the banner text paints over the header when scrolled underneath.
 .jetpack-content-guidelines-ai__banner {
 	position: relative;
+	isolation: isolate;
 	background: #003010;
 	border-radius: 8px;
 	padding: 32px;
@@ -33,6 +37,11 @@ $cg-diff-removed: #f8d7da;
 .jetpack-content-guidelines-ai__banner-content {
 	position: relative;
 	z-index: 1;
+	// Forces the text onto its own compositor layer. Without this, Chromium
+	// lets the glyphs escape the wp-admin scroll container's rounded clip and
+	// draw over the sticky header / admin bar when the banner straddles the
+	// scrollport's top edge.
+	transform: translateZ(0);
 	display: flex;
 	flex-direction: column;
 	max-width: 520px;

--- a/projects/plugins/jetpack/changelog/fix-content-guidelines-ai-banner-sticky-header-overlap
+++ b/projects/plugins/jetpack/changelog/fix-content-guidelines-ai-banner-sticky-header-overlap
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Content Guidelines AI: Keep the empty-state banner from painting over the sticky page header while scrolling.


### PR DESCRIPTION
Fixes #

## Proposed changes

When the Guidelines page is scrolled, the empty-state banner's text was showing on top of the sticky "Guidelines" header instead of sliding underneath it.

* Add `isolation: isolate` to the banner. Its inner elements use `z-index: 1`, which tied with the sticky header's `z-index: 1` and won by DOM order — isolating the banner keeps those z-indexes contained so the header always paints on top.
* Add `transform: translateZ(0)` to the banner content. Without it, Chromium lets the text escape wp-admin's rounded scroll clip and draw over the header when the banner sits right at the top edge of the scroll area.



### Before
<img width="1471" height="909" alt="Screenshot 2026-08-10 at 12 28 10 PM" src="https://github.com/user-attachments/assets/6a64bd1f-65b4-4b45-b9a2-12e79cb1e94c" />


### After
<img width="1465" height="911" alt="Screenshot 2026-08-10 at 12 29 10 PM" src="https://github.com/user-attachments/assets/fa03274f-3207-4444-aabb-1f5137acd30c" />


## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a WordPress.com site with Jetpack AI, go to Settings → Guidelines (`options-general.php?page=guidelines-wp-admin`) and make sure the "Generate your guidelines in seconds" banner is showing.
* Scroll down so the banner passes under the sticky "Guidelines" header.
* Before: the banner heading showed through the header. After: the banner stays underneath it at every scroll position.
