### PR TITLE
Premium Analytics: add a Popular days widget

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1851-popular-days
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1851-popular-days
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Insights: add a Popular days widget showing the busiest day of the week and how views are distributed across the week.

--- a/projects/packages/premium-analytics/packages/formatters/src/date/__fixtures__/wp-date-settings.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/__fixtures__/wp-date-settings.ts
@@ -40,6 +40,8 @@ const ES_MONTHS = [
 	'diciembre',
 ];
 
+const ES_WEEKDAYS = [ 'domingo', 'lunes', 'martes', 'miércoles', 'jueves', 'viernes', 'sábado' ];
+
 /**
  * Build a settings object for a locale.
  *
@@ -52,12 +54,15 @@ const ES_MONTHS = [
  * @param dateFormat - The site's `date_format` option, in PHP tokens.
  * @param months     - Translated month names, January first. Defaults to the
  *                   package's English names.
+ * @param weekdays   - Translated weekday names, Sunday first. Defaults to the
+ *                   package's English names.
  * @return Settings ready for `setSettings`.
  */
 export const settingsFor = (
 	locale: string,
 	dateFormat: string,
-	months: string[] = DEFAULT_MONTHS
+	months: string[] = DEFAULT_MONTHS,
+	weekdays: string[] = DEFAULTS.l10n.weekdays as string[]
 ): DateSettings => ( {
 	...DEFAULTS,
 	l10n: {
@@ -65,6 +70,8 @@ export const settingsFor = (
 		locale,
 		months,
 		monthsShort: months.map( month => month.slice( 0, 3 ) ),
+		weekdays,
+		weekdaysShort: weekdays.map( weekday => weekday.slice( 0, 3 ) ),
 	},
 	formats: { ...DEFAULTS.formats, date: dateFormat },
 	timezone: { offset: 0, offsetFormatted: '0', string: 'UTC', abbr: 'UTC' },
@@ -77,7 +84,12 @@ export const EN_US_SETTINGS = settingsFor( 'en_US_test', 'F j, Y' );
  * A Spanish site. Its `date_format` puts the day first and spells "de" with
  * escaped literals (`\d\e`), which double as the day and timezone tokens.
  */
-export const ES_ES_SETTINGS = settingsFor( 'es_ES_test', 'j \\d\\e F \\d\\e Y', ES_MONTHS );
+export const ES_ES_SETTINGS = settingsFor(
+	'es_ES_test',
+	'j \\d\\e F \\d\\e Y',
+	ES_MONTHS,
+	ES_WEEKDAYS
+);
 
 /**
  * Build a UTC date, matching the fixtures' timezone so no day shift is in play.

--- a/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-date.test.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/__tests__/format-date.test.ts
@@ -6,7 +6,7 @@ import { setSettings } from '@wordpress/date';
  * Internal dependencies
  */
 import { EN_US_SETTINGS, ES_ES_SETTINGS, settingsFor } from '../__fixtures__/wp-date-settings';
-import { formatDate } from '../format-date';
+import { formatDate, formatWeekday } from '../format-date';
 
 // Midnight UTC, matching the fixtures' timezone, so no day shift is in play.
 const JUNE_21 = new Date( '2025-06-21T00:00:00+00:00' );
@@ -61,6 +61,10 @@ describe( 'formatDate', () => {
 
 		it( 'keeps "iso" untranslated so it stays machine-readable', () => {
 			expect( formatDate( JUNE_21, 'iso' ) ).toBe( '2025-06-21' );
+		} );
+
+		it( 'formats a weekday in the site locale', () => {
+			expect( formatWeekday( 6 ) ).toBe( 'sábado' );
 		} );
 	} );
 

--- a/projects/packages/premium-analytics/packages/formatters/src/date/format-date.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/format-date.ts
@@ -88,3 +88,15 @@ function formatFor( name: DateFormatName ): string {
  */
 export const formatDate = ( date: DateInput, name: DateFormatName = 'medium' ): string =>
 	dateI18n( formatFor( name ), date );
+
+/**
+ * Return a full weekday name in the site's locale.
+ *
+ * @param weekday - Sunday-based weekday index (`0` = Sunday).
+ * @return The localized full weekday name.
+ */
+export const formatWeekday = ( weekday: number ): string => {
+	const weekdays = getSettings().l10n.weekdays as string[];
+
+	return weekdays[ weekday ] ?? '';
+};

--- a/projects/packages/premium-analytics/packages/formatters/src/date/index.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/date/index.ts
@@ -1,4 +1,4 @@
-export { formatDate, type DateFormatName } from './format-date';
+export { formatDate, formatWeekday, type DateFormatName } from './format-date';
 export { formatDateRange, formatDateRangeCompact } from './format-date-range';
 export { formatDateRangeLong } from './format-date-range-long';
 export {

--- a/projects/packages/premium-analytics/packages/formatters/src/index.ts
+++ b/projects/packages/premium-analytics/packages/formatters/src/index.ts
@@ -1,5 +1,6 @@
 export {
 	formatDate,
+	formatWeekday,
 	formatDateRange,
 	formatDateRangeCompact,
 	formatDateRangeLong,

--- a/projects/packages/premium-analytics/src/dashboard-layout.php
+++ b/projects/packages/premium-analytics/src/dashboard-layout.php
@@ -332,8 +332,13 @@ function get_dashboard_default_section_layouts() {
 				2,
 				2
 			),
-			// Row 4: the period totals + the two most-popular cards. The
-			// most-popular cards still crop at this height (WOOA7S-1846).
+			// Row 4: the period totals, the weekday distribution, and the
+			// all-time best day. `jpa/most-popular-time` sat here until
+			// `jpa/popular-days` replaced its "best day" half with one that
+			// follows the date picker; its "best hour" half returns as its own
+			// widget in WOOA7S-1897. `jpa/most-popular-day` answers a different
+			// question — the single best date ever — so it stays.
+			// The most-popular-day card still crops at this height (WOOA7S-1846).
 			get_dashboard_default_widget_instance(
 				'default-total-views-widget-instance',
 				'jpa/total-views',
@@ -349,8 +354,8 @@ function get_dashboard_default_section_layouts() {
 				1
 			),
 			get_dashboard_default_widget_instance(
-				'default-most-popular-time-widget-instance',
-				'jpa/most-popular-time',
+				'default-popular-days-widget-instance',
+				'jpa/popular-days',
 				6,
 				1,
 				1

--- a/projects/packages/premium-analytics/src/dashboard-layout.php
+++ b/projects/packages/premium-analytics/src/dashboard-layout.php
@@ -333,12 +333,8 @@ function get_dashboard_default_section_layouts() {
 				2
 			),
 			// Row 4: the period totals, the weekday distribution, and the
-			// all-time best day. `jpa/most-popular-time` sat here until
-			// `jpa/popular-days` replaced its "best day" half with one that
-			// follows the date picker; its "best hour" half returns as its own
-			// widget in WOOA7S-1897. `jpa/most-popular-day` answers a different
-			// question — the single best date ever — so it stays.
-			// The most-popular-day card still crops at this height (WOOA7S-1846).
+			// all-time best day. The most-popular-day card still crops at this
+			// height (WOOA7S-1846).
 			get_dashboard_default_widget_instance(
 				'default-total-views-widget-instance',
 				'jpa/total-views',

--- a/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Dashboard_Layout_Test.php
@@ -289,7 +289,7 @@ class Dashboard_Layout_Test extends BaseTestCase {
 			'default-popular-post-widget-instance'         => array( 'jpa/popular-post', 2, 2, 3 ),
 			'default-total-views-widget-instance'          => array( 'jpa/total-views', 1, 1, 4 ),
 			'default-total-visitors-widget-instance'       => array( 'jpa/total-visitors', 1, 1, 5 ),
-			'default-most-popular-time-widget-instance'    => array( 'jpa/most-popular-time', 1, 1, 6 ),
+			'default-popular-days-widget-instance'         => array( 'jpa/popular-days', 1, 1, 6 ),
 			'default-most-popular-day-widget-instance'     => array( 'jpa/most-popular-day', 1, 1, 7 ),
 			'default-most-commented-posts-widget-instance' => array( 'jpa/most-commented-posts', 1, 2, 8 ),
 			'default-most-commented-authors-widget-instance' => array( 'jpa/most-commented-authors', 1, 2, 9 ),

--- a/projects/packages/premium-analytics/widgets/popular-days/__tests__/bucket-views-by-weekday.test.ts
+++ b/projects/packages/premium-analytics/widgets/popular-days/__tests__/bucket-views-by-weekday.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Internal dependencies
+ */
+import { bucketViewsByWeekday, pickPeakWeekday } from '../bucket-views-by-weekday';
+
+// 2026-07-06 is a Monday, so a run starting here maps weekday index 0 → Monday.
+function dailyRow( date: string, views: number ) {
+	return {
+		period: date,
+		time_interval: date,
+		date_start: `${ date }T00:00:00+00:00`,
+		date_end: `${ date }T23:59:59+00:00`,
+		label: date,
+		value: views,
+		views,
+	};
+}
+
+describe( 'bucketViewsByWeekday', () => {
+	it( 'always returns seven buckets, Monday first', () => {
+		const buckets = bucketViewsByWeekday( [] );
+
+		expect( buckets ).toHaveLength( 7 );
+		expect( buckets.map( bucket => bucket.weekday ) ).toEqual( [ 0, 1, 2, 3, 4, 5, 6 ] );
+		expect( buckets.every( bucket => bucket.occurrences === 0 ) ).toBe( true );
+	} );
+
+	it( 'assigns each date to its weekday', () => {
+		const buckets = bucketViewsByWeekday( [
+			dailyRow( '2026-07-06', 10 ), // Monday
+			dailyRow( '2026-07-09', 40 ), // Thursday
+			dailyRow( '2026-07-12', 5 ), // Sunday
+		] );
+
+		expect( buckets[ 0 ] ).toMatchObject( { total: 10, occurrences: 1, average: 10 } );
+		expect( buckets[ 3 ] ).toMatchObject( { total: 40, occurrences: 1, average: 40 } );
+		expect( buckets[ 6 ] ).toMatchObject( { total: 5, occurrences: 1, average: 5 } );
+	} );
+
+	it( 'averages over how many times each weekday actually occurred', () => {
+		// Three Mondays, one Tuesday. Monday's total is larger, its average is not.
+		const buckets = bucketViewsByWeekday( [
+			dailyRow( '2026-07-06', 10 ),
+			dailyRow( '2026-07-07', 25 ),
+			dailyRow( '2026-07-13', 10 ),
+			dailyRow( '2026-07-20', 10 ),
+		] );
+
+		expect( buckets[ 0 ] ).toMatchObject( { total: 30, occurrences: 3, average: 10 } );
+		expect( buckets[ 1 ] ).toMatchObject( { total: 25, occurrences: 1, average: 25 } );
+	} );
+
+	it( 'reads the calendar date, not a UTC instant', () => {
+		// `date_start` carries a nominal +00:00 that is a bucket label, not a real
+		// instant. Parsing it as UTC would shift the day west of Greenwich and move
+		// this row onto Sunday.
+		const buckets = bucketViewsByWeekday( [ dailyRow( '2026-07-06', 10 ) ] );
+
+		expect( buckets[ 0 ].occurrences ).toBe( 1 );
+		expect( buckets[ 6 ].occurrences ).toBe( 0 );
+	} );
+
+	it( 'counts a zero-view day as an occurrence', () => {
+		// Otherwise a weekday that reliably draws nothing would average as if it had
+		// never happened, and could outrank a weekday with real traffic.
+		const buckets = bucketViewsByWeekday( [
+			dailyRow( '2026-07-06', 0 ),
+			dailyRow( '2026-07-13', 10 ),
+		] );
+
+		expect( buckets[ 0 ] ).toMatchObject( { total: 10, occurrences: 2, average: 5 } );
+	} );
+
+	it( 'falls back to the row value when no views field is present', () => {
+		const buckets = bucketViewsByWeekday( [
+			{ time_interval: '2026-07-06', date_start: '2026-07-06T00:00:00+00:00', value: 12 },
+		] );
+
+		expect( buckets[ 0 ] ).toMatchObject( { total: 12, occurrences: 1 } );
+	} );
+
+	it( 'ignores rows with an unparseable date', () => {
+		const buckets = bucketViewsByWeekday( [
+			dailyRow( '2026-07-06', 10 ),
+			{ time_interval: 'not-a-date', value: 999 },
+		] );
+
+		expect( buckets.reduce( ( sum, bucket ) => sum + bucket.total, 0 ) ).toBe( 10 );
+	} );
+
+	it( 'labels buckets with localized weekday names', () => {
+		const buckets = bucketViewsByWeekday( [] );
+
+		expect( buckets[ 0 ].label ).toBe( 'Monday' );
+		expect( buckets[ 6 ].label ).toBe( 'Sunday' );
+	} );
+} );
+
+describe( 'pickPeakWeekday', () => {
+	it( 'picks the highest average, not the highest total', () => {
+		// This is the whole point of averaging: a range that is not a whole number
+		// of weeks samples some weekdays more often than others, and the extra
+		// sample alone must not decide the winner.
+		const buckets = bucketViewsByWeekday( [
+			dailyRow( '2026-07-06', 10 ),
+			dailyRow( '2026-07-13', 10 ),
+			dailyRow( '2026-07-20', 10 ), // Monday total 30, average 10
+			dailyRow( '2026-07-07', 25 ), // Tuesday total 25, average 25
+		] );
+
+		expect( pickPeakWeekday( buckets ) ).toMatchObject( { weekday: 1, average: 25 } );
+	} );
+
+	it( 'ignores weekdays the range never covered', () => {
+		const buckets = bucketViewsByWeekday( [ dailyRow( '2026-07-06', 0 ) ] );
+
+		// Monday occurred and drew nothing; the other six never occurred at all.
+		expect( pickPeakWeekday( buckets ) ).toMatchObject( { weekday: 0, occurrences: 1 } );
+	} );
+
+	it( 'returns undefined when the range covers no days', () => {
+		expect( pickPeakWeekday( bucketViewsByWeekday( [] ) ) ).toBeUndefined();
+	} );
+
+	it( 'breaks ties toward the earlier weekday', () => {
+		const buckets = bucketViewsByWeekday( [
+			dailyRow( '2026-07-08', 10 ), // Wednesday
+			dailyRow( '2026-07-09', 10 ), // Thursday
+		] );
+
+		expect( pickPeakWeekday( buckets ) ).toMatchObject( { weekday: 2 } );
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/popular-days/__tests__/popular-days.test.tsx
+++ b/projects/packages/premium-analytics/widgets/popular-days/__tests__/popular-days.test.tsx
@@ -106,6 +106,27 @@ describe( 'PopularDaysWidget', () => {
 		expect( screen.getByTitle( '166,900' ) ).toBeInTheDocument();
 	} );
 
+	it( 'reads the exact figure to assistive tech, not the abbreviation', () => {
+		mockUseStatsVisits.mockReturnValue(
+			visitsResult( { summary: { views: 166900 }, data: [ dailyRow( '2026-07-06', 166900 ) ] } )
+		);
+
+		renderWidget();
+
+		// `title` is not reliably announced, so the abbreviation must be hidden and the
+		// exact figure exposed in its place.
+		expect( screen.getByText( '166.9K views' ) ).toHaveAttribute( 'aria-hidden', 'true' );
+		expect( screen.getByText( '166,900 views' ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not double up when the figure needs no abbreviating', () => {
+		mockUseStatsVisits.mockReturnValue( visitsResult( REPORT ) );
+
+		renderWidget();
+
+		expect( screen.getAllByText( '25 views' ) ).toHaveLength( 1 );
+	} );
+
 	it( 'keeps daily buckets on a coarse dashboard interval, so weekdays stay separable', () => {
 		mockUseStatsVisits.mockReturnValue( visitsResult( REPORT ) );
 

--- a/projects/packages/premium-analytics/widgets/popular-days/__tests__/popular-days.test.tsx
+++ b/projects/packages/premium-analytics/widgets/popular-days/__tests__/popular-days.test.tsx
@@ -1,0 +1,184 @@
+/**
+ * External dependencies
+ */
+import { useStatsVisits } from '@jetpack-premium-analytics/data';
+import { render, screen } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import PopularDaysRender from '../render';
+import type { ReportParams } from '@jetpack-premium-analytics/data';
+
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
+
+// Keep visx out of jsdom and make the series the widget passes assertable.
+jest.mock( '@jetpack-premium-analytics/externals', () => ( {
+	...jest.requireActual( '@jetpack-premium-analytics/externals' ),
+	Sparkline: ( { data }: { data: number[] } ) => (
+		<div data-testid="sparkline" data-points={ data.join( ',' ) } />
+	),
+} ) );
+
+// Spread the real module: `WidgetRoot` and the toolkit helpers import from it too.
+jest.mock( '@jetpack-premium-analytics/data', () => ( {
+	...jest.requireActual( '@jetpack-premium-analytics/data' ),
+	useStatsVisits: jest.fn(),
+} ) );
+
+const mockUseStatsVisits = jest.mocked( useStatsVisits );
+
+const REPORT_PARAMS = {
+	from: '2026-07-06',
+	to: '2026-07-26',
+	interval: 'day',
+	comp: '1',
+	compare_from: '2026-06-15',
+	compare_to: '2026-07-05',
+	compare_preset: 'previous_period',
+} as unknown as ReportParams;
+
+function dailyRow( date: string, views: number ) {
+	return { date_start: `${ date }T00:00:00+00:00`, time_interval: date, views, visitors: 1 };
+}
+
+// Three Mondays at 10 views each and one Tuesday at 25. Monday has the larger
+// total, Tuesday the larger average — the case the averaging exists for.
+const REPORT = {
+	summary: { views: 55 },
+	data: [
+		dailyRow( '2026-07-06', 10 ),
+		dailyRow( '2026-07-07', 25 ),
+		dailyRow( '2026-07-13', 10 ),
+		dailyRow( '2026-07-20', 10 ),
+	],
+};
+
+function visitsResult( primaryData: unknown, overrides: Record< string, unknown > = {} ) {
+	return {
+		primary: { data: primaryData },
+		comparison: { data: undefined },
+		hasComparison: false,
+		isLoading: false,
+		isFetching: false,
+		hasData: !! primaryData,
+		isError: false,
+		error: null,
+		refetch: jest.fn(),
+		...overrides,
+	} as unknown as ReturnType< typeof useStatsVisits >;
+}
+
+function renderWidget( reportParams: ReportParams = REPORT_PARAMS ) {
+	return render( <PopularDaysRender attributes={ { reportParams } } /> );
+}
+
+describe( 'PopularDaysWidget', () => {
+	beforeEach( () => {
+		mockUseStatsVisits.mockReset();
+	} );
+
+	it( 'headlines the weekday with the highest average, not the highest total', () => {
+		mockUseStatsVisits.mockReturnValue( visitsResult( REPORT ) );
+
+		renderWidget();
+
+		expect( screen.getByText( 'Tuesday' ) ).toBeInTheDocument();
+		expect( screen.queryByText( 'Monday' ) ).not.toBeInTheDocument();
+		expect( screen.getByText( '25 views' ) ).toBeInTheDocument();
+	} );
+
+	it( 'plots seven Monday-first averages, so the chart agrees with the headline', () => {
+		mockUseStatsVisits.mockReturnValue( visitsResult( REPORT ) );
+
+		renderWidget();
+
+		expect( screen.getByTestId( 'sparkline' ) ).toHaveAttribute( 'data-points', '10,25,0,0,0,0,0' );
+	} );
+
+	it( 'abbreviates a large average but keeps the exact figure available', () => {
+		mockUseStatsVisits.mockReturnValue(
+			visitsResult( { summary: { views: 166900 }, data: [ dailyRow( '2026-07-06', 166900 ) ] } )
+		);
+
+		renderWidget();
+
+		expect( screen.getByText( '166.9K views' ) ).toBeInTheDocument();
+		expect( screen.getByTitle( '166,900' ) ).toBeInTheDocument();
+	} );
+
+	it( 'keeps daily buckets on a coarse dashboard interval, so weekdays stay separable', () => {
+		mockUseStatsVisits.mockReturnValue( visitsResult( REPORT ) );
+
+		renderWidget( { ...REPORT_PARAMS, interval: 'month' } as ReportParams );
+
+		expect( mockUseStatsVisits.mock.calls[ 0 ][ 0 ] ).toMatchObject( { period: 'day' } );
+	} );
+
+	it( 'requests both traffic fields, without comparison, so it shares the totals query', () => {
+		mockUseStatsVisits.mockReturnValue( visitsResult( REPORT ) );
+
+		renderWidget();
+
+		const params = mockUseStatsVisits.mock.calls[ 0 ][ 0 ];
+		expect( params ).toMatchObject( { stat_fields: 'views,visitors', period: 'day' } );
+		expect( params ).not.toHaveProperty( 'comp' );
+		expect( params ).not.toHaveProperty( 'compare_from' );
+		expect( params ).not.toHaveProperty( 'compare_to' );
+		expect( params ).not.toHaveProperty( 'compare_preset' );
+	} );
+
+	it( 'renders the empty state when the range has no buckets', () => {
+		mockUseStatsVisits.mockReturnValue( visitsResult( { summary: { views: 0 }, data: [] } ) );
+
+		renderWidget();
+
+		expect( screen.getByText( 'No views in this period.' ) ).toBeInTheDocument();
+		expect( screen.queryByTestId( 'sparkline' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'still headlines a weekday when every day in range drew zero views', () => {
+		mockUseStatsVisits.mockReturnValue(
+			visitsResult( { summary: { views: 0 }, data: [ dailyRow( '2026-07-06', 0 ) ] } )
+		);
+
+		renderWidget();
+
+		expect( screen.getByText( 'Monday' ) ).toBeInTheDocument();
+		expect( screen.getByText( '0 views' ) ).toBeInTheDocument();
+	} );
+
+	it( 'routes a permission-gated 403 through describeError: neutral copy, no retry', () => {
+		mockUseStatsVisits.mockReturnValue(
+			visitsResult( undefined, { isError: true, error: { error: 'unauthorized', status: 403 } } )
+		);
+
+		renderWidget();
+
+		expect( screen.getByText( "You don't have access to this data." ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Retry' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'offers a retry for a failure that can heal', () => {
+		mockUseStatsVisits.mockReturnValue(
+			visitsResult( undefined, { isError: true, error: { error: 'no_connection', status: 403 } } )
+		);
+
+		renderWidget();
+
+		expect(
+			screen.getByText( "We couldn't load your popular days. Please try again in a moment." )
+		).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Retry' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'keeps the rendered peak when a refetch fails, instead of showing the error', () => {
+		mockUseStatsVisits.mockReturnValue(
+			visitsResult( REPORT, { isError: true, error: { error: 'no_connection', status: 403 } } )
+		);
+
+		renderWidget();
+
+		expect( screen.getByText( 'Tuesday' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'button', { name: 'Retry' } ) ).not.toBeInTheDocument();
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/popular-days/bucket-views-by-weekday.ts
+++ b/projects/packages/premium-analytics/widgets/popular-days/bucket-views-by-weekday.ts
@@ -1,0 +1,113 @@
+/**
+ * External dependencies
+ */
+import { getDatePart } from '@jetpack-premium-analytics/datetime';
+import { format, getDay, isValid, parse } from 'date-fns';
+
+export type PopularDayBucket = {
+	/** 0 = Monday … 6 = Sunday, matching the package's `weekStartsOn: 1` convention. */
+	weekday: number;
+	/** Localized full weekday name, e.g. "Monday". */
+	label: string;
+	total: number;
+	/** How many times this weekday fell inside the selected range. */
+	occurrences: number;
+	/** `total / occurrences`, or 0 for a weekday the range never covered. */
+	average: number;
+};
+
+const DATE_PART_FORMAT = 'yyyy-MM-dd';
+
+// date-fns only reads this when the parsed string omits a field; every field we
+// parse is present, so it never contributes to the result.
+const referenceDate = new Date( 2001, 0, 1 );
+
+// 2026-01-05 is a Monday. Stepping forward from it gives the seven weekday names
+// in this widget's Monday-first order without depending on today's date.
+const WEEKDAY_NAME_ANCHOR = new Date( 2026, 0, 5, 12 );
+
+function weekdayLabel( weekday: number ) {
+	const date = new Date( WEEKDAY_NAME_ANCHOR );
+	date.setDate( date.getDate() + weekday );
+
+	return format( date, 'EEEE' );
+}
+
+/**
+ * Read a row's calendar date as wall-clock, never as an instant.
+ *
+ * `date_start` carries a nominal `+00:00` that labels a calendar bucket rather
+ * than marking a real UTC time (see `getDateFnsIntervalFields` in the stats
+ * time-series normalizer). Handing it to `new Date()` would resolve it against
+ * the viewer's timezone and slide the row onto the previous weekday for anyone
+ * west of Greenwich.
+ */
+function readRowDate( row: Record< string, unknown > ) {
+	const datePart = getDatePart( row.date_start ?? row.time_interval ?? row.period );
+
+	if ( ! datePart ) {
+		return undefined;
+	}
+
+	const parsed = parse( datePart, DATE_PART_FORMAT, referenceDate );
+
+	return isValid( parsed ) && format( parsed, DATE_PART_FORMAT ) === datePart ? parsed : undefined;
+}
+
+function readRowViews( row: Record< string, unknown > ) {
+	const views = row.views ?? row.value;
+
+	return typeof views === 'number' ? views : Number( views ?? 0 ) || 0;
+}
+
+/**
+ * Fold a daily `stats/visits` series into one bucket per day of the week.
+ *
+ * Always returns seven buckets so the chart keeps a stable shape, including for
+ * weekdays the range never covered — those carry `occurrences: 0` and are
+ * excluded from the peak by `pickPeakWeekday`.
+ */
+export function bucketViewsByWeekday( rows: Record< string, unknown >[] ): PopularDayBucket[] {
+	const totals = Array.from( { length: 7 }, () => ( { total: 0, occurrences: 0 } ) );
+
+	rows.forEach( row => {
+		const date = readRowDate( row );
+
+		if ( ! date ) {
+			return;
+		}
+
+		// date-fns counts from Sunday; shift to the Monday-first order used here.
+		const weekday = ( getDay( date ) + 6 ) % 7;
+
+		totals[ weekday ].total += readRowViews( row );
+		// Counted even when the day drew no views: a weekday that reliably draws
+		// nothing must average as a real zero, not drop out of the comparison.
+		totals[ weekday ].occurrences += 1;
+	} );
+
+	return totals.map( ( { total, occurrences }, weekday ) => ( {
+		weekday,
+		label: weekdayLabel( weekday ),
+		total,
+		occurrences,
+		average: occurrences ? total / occurrences : 0,
+	} ) );
+}
+
+/**
+ * The busiest weekday by mean views per occurrence.
+ *
+ * Averaging rather than summing is load-bearing: a user-selected range rarely
+ * spans a whole number of weeks, so some weekdays are sampled more often than
+ * others — over 30 days, two weekdays occur five times and five occur four. A
+ * total would let that extra sample alone decide the winner.
+ */
+export function pickPeakWeekday( buckets: PopularDayBucket[] ): PopularDayBucket | undefined {
+	return buckets
+		.filter( bucket => bucket.occurrences > 0 )
+		.reduce< PopularDayBucket | undefined >(
+			( peak, bucket ) => ( ! peak || bucket.average > peak.average ? bucket : peak ),
+			undefined
+		);
+}

--- a/projects/packages/premium-analytics/widgets/popular-days/bucket-views-by-weekday.ts
+++ b/projects/packages/premium-analytics/widgets/popular-days/bucket-views-by-weekday.ts
@@ -7,23 +7,19 @@ import { format, getDay, isValid, parse } from 'date-fns';
 export type PopularDayBucket = {
 	/** 0 = Monday … 6 = Sunday, matching the package's `weekStartsOn: 1` convention. */
 	weekday: number;
-	/** Localized full weekday name, e.g. "Monday". */
 	label: string;
 	total: number;
 	/** How many times this weekday fell inside the selected range. */
 	occurrences: number;
-	/** `total / occurrences`, or 0 for a weekday the range never covered. */
 	average: number;
 };
 
 const DATE_PART_FORMAT = 'yyyy-MM-dd';
 
-// date-fns only reads this when the parsed string omits a field; every field we
-// parse is present, so it never contributes to the result.
+// Only consulted for fields the parsed string omits, and ours omits none.
 const referenceDate = new Date( 2001, 0, 1 );
 
-// 2026-01-05 is a Monday. Stepping forward from it gives the seven weekday names
-// in this widget's Monday-first order without depending on today's date.
+// A Monday, so stepping forward yields the names in Monday-first order.
 const WEEKDAY_NAME_ANCHOR = new Date( 2026, 0, 5, 12 );
 
 function weekdayLabel( weekday: number ) {
@@ -33,15 +29,9 @@ function weekdayLabel( weekday: number ) {
 	return format( date, 'EEEE' );
 }
 
-/**
- * Read a row's calendar date as wall-clock, never as an instant.
- *
- * `date_start` carries a nominal `+00:00` that labels a calendar bucket rather
- * than marking a real UTC time (see `getDateFnsIntervalFields` in the stats
- * time-series normalizer). Handing it to `new Date()` would resolve it against
- * the viewer's timezone and slide the row onto the previous weekday for anyone
- * west of Greenwich.
- */
+// The `+00:00` on `date_start` labels a calendar bucket rather than marking a
+// real UTC time, so `new Date()` would resolve it against the viewer's timezone
+// and slide the row onto the previous weekday west of Greenwich.
 function readRowDate( row: Record< string, unknown > ) {
 	const datePart = getDatePart( row.date_start ?? row.time_interval ?? row.period );
 
@@ -63,9 +53,8 @@ function readRowViews( row: Record< string, unknown > ) {
 /**
  * Fold a daily `stats/visits` series into one bucket per day of the week.
  *
- * Always returns seven buckets so the chart keeps a stable shape, including for
- * weekdays the range never covered — those carry `occurrences: 0` and are
- * excluded from the peak by `pickPeakWeekday`.
+ * Always seven buckets, so the chart keeps a stable shape; weekdays the range
+ * never covered carry `occurrences: 0` and are skipped by `pickPeakWeekday`.
  */
 export function bucketViewsByWeekday( rows: Record< string, unknown >[] ): PopularDayBucket[] {
 	const totals = Array.from( { length: 7 }, () => ( { total: 0, occurrences: 0 } ) );
@@ -81,8 +70,8 @@ export function bucketViewsByWeekday( rows: Record< string, unknown >[] ): Popul
 		const weekday = ( getDay( date ) + 6 ) % 7;
 
 		totals[ weekday ].total += readRowViews( row );
-		// Counted even when the day drew no views: a weekday that reliably draws
-		// nothing must average as a real zero, not drop out of the comparison.
+		// Counted even at zero views, so a reliably quiet weekday averages as a
+		// real zero instead of dropping out of the comparison.
 		totals[ weekday ].occurrences += 1;
 	} );
 
@@ -98,10 +87,9 @@ export function bucketViewsByWeekday( rows: Record< string, unknown >[] ): Popul
 /**
  * The busiest weekday by mean views per occurrence.
  *
- * Averaging rather than summing is load-bearing: a user-selected range rarely
- * spans a whole number of weeks, so some weekdays are sampled more often than
- * others — over 30 days, two weekdays occur five times and five occur four. A
- * total would let that extra sample alone decide the winner.
+ * Mean, not total: a selected range rarely spans a whole number of weeks — over
+ * 30 days two weekdays occur five times and five occur four — so a total would
+ * let that extra occurrence alone decide the winner.
  */
 export function pickPeakWeekday( buckets: PopularDayBucket[] ): PopularDayBucket | undefined {
 	return buckets

--- a/projects/packages/premium-analytics/widgets/popular-days/bucket-views-by-weekday.ts
+++ b/projects/packages/premium-analytics/widgets/popular-days/bucket-views-by-weekday.ts
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { getDatePart } from '@jetpack-premium-analytics/datetime';
+import { formatWeekday } from '@jetpack-premium-analytics/formatters';
 import { format, getDay, isValid, parse } from 'date-fns';
 
 export type PopularDayBucket = {
@@ -19,14 +20,9 @@ const DATE_PART_FORMAT = 'yyyy-MM-dd';
 // Only consulted for fields the parsed string omits, and ours omits none.
 const referenceDate = new Date( 2001, 0, 1 );
 
-// A Monday, so stepping forward yields the names in Monday-first order.
-const WEEKDAY_NAME_ANCHOR = new Date( 2026, 0, 5, 12 );
-
 function weekdayLabel( weekday: number ) {
-	const date = new Date( WEEKDAY_NAME_ANCHOR );
-	date.setDate( date.getDate() + weekday );
-
-	return format( date, 'EEEE' );
+	// WordPress's locale table is Sunday-first; the widget's buckets are Monday-first.
+	return formatWeekday( ( weekday + 1 ) % 7 );
 }
 
 // The `+00:00` on `date_start` labels a calendar bucket rather than marking a

--- a/projects/packages/premium-analytics/widgets/popular-days/package.json
+++ b/projects/packages/premium-analytics/widgets/popular-days/package.json
@@ -1,0 +1,21 @@
+{
+	"name": "@automattic/jetpack-premium-analytics-widget-popular-days",
+	"version": "0.1.0-alpha",
+	"private": true,
+	"type": "module",
+	"dependencies": {
+		"@jetpack-premium-analytics/data": "link:../../packages/data",
+		"@jetpack-premium-analytics/datetime": "link:../../packages/datetime",
+		"@jetpack-premium-analytics/externals": "link:../../packages/externals",
+		"@jetpack-premium-analytics/formatters": "link:../../packages/formatters",
+		"@jetpack-premium-analytics/icons": "link:../../packages/icons",
+		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
+		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/widget-primitives": "0.4.0",
+		"date-fns": "4.1.0",
+		"react": "18.3.1"
+	},
+	"devDependencies": {
+		"@wordpress/api-fetch": "7.51.0"
+	}
+}

--- a/projects/packages/premium-analytics/widgets/popular-days/package.json
+++ b/projects/packages/premium-analytics/widgets/popular-days/package.json
@@ -11,6 +11,7 @@
 		"@jetpack-premium-analytics/icons": "link:../../packages/icons",
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/i18n": "^6.9.0",
+		"@wordpress/icons": "^15.0.0",
 		"@wordpress/widget-primitives": "0.4.0",
 		"date-fns": "4.1.0",
 		"react": "18.3.1"

--- a/projects/packages/premium-analytics/widgets/popular-days/render.tsx
+++ b/projects/packages/premium-analytics/widgets/popular-days/render.tsx
@@ -1,0 +1,117 @@
+/**
+ * External dependencies
+ */
+import { Text } from '@jetpack-premium-analytics/externals';
+import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
+import { calendar } from '@jetpack-premium-analytics/icons';
+import {
+	describeError,
+	Sparkline,
+	WidgetRoot,
+	WidgetState,
+	type ReportParamsFieldAttributes,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { __, sprintf } from '@wordpress/i18n';
+import { useMemo } from 'react';
+/**
+ * Internal dependencies
+ */
+import styles from './style.module.css';
+import { usePopularDays } from './use-popular-days';
+import type { PopularDaysAttributes } from './widget';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps } from 'react';
+
+// Report params are usually URL-driven (WidgetRoot's fallback), but the host and
+// Storybook may also pass them via `attributes`.
+type PopularDaysRenderAttributes = PopularDaysAttributes & Partial< ReportParamsFieldAttributes >;
+
+type PopularDaysWidgetProps = WidgetRenderProps< PopularDaysRenderAttributes > & {
+	setError?: ComponentProps< typeof WidgetRoot >[ 'setError' ];
+};
+
+// `decimals: 0` would round 166,900 to "167K"; the prototype's secondary figure
+// keeps the digit ("166.9k").
+const ABBREVIATED_VIEWS_OPTIONS = { useMultipliers: true, decimals: 1 };
+const PLAIN_VIEWS_OPTIONS = { decimals: 0 };
+
+/**
+ * The busiest weekday over an area chart of the whole week's distribution.
+ */
+function PopularDaysReport() {
+	const { buckets, peak, isLoading, isFetching, isError, error, refetch } = usePopularDays();
+
+	// Averages, matching the headline — plotting totals here would contradict it
+	// on any range that samples some weekdays more often than others.
+	const points = useMemo( () => buckets.map( bucket => bucket.average ), [ buckets ] );
+
+	// `placeholderData` keeps the prior response on a transient refetch failure,
+	// so the error only surfaces when there is nothing left to show. `error` is
+	// gated on the same predicate so the two cannot disagree.
+	const showError = isError && ! peak;
+
+	const views = peak?.average ?? 0;
+	const exactViews = formatMetricValue( views, 'number', PLAIN_VIEWS_OPTIONS );
+	const formattedViews = formatMetricValue(
+		views,
+		'number',
+		views >= 1000 ? ABBREVIATED_VIEWS_OPTIONS : PLAIN_VIEWS_OPTIONS
+	);
+
+	return (
+		<div className={ styles.root }>
+			<WidgetState
+				isLoading={ isLoading }
+				isFetching={ isFetching }
+				isError={ showError }
+				isEmpty={ ! peak }
+				error={
+					showError
+						? describeError( error, {
+								retryDescription: __(
+									"We couldn't load your popular days. Please try again in a moment.",
+									'jetpack-premium-analytics-pkg'
+								),
+								onRetry: refetch,
+						  } )
+						: null
+				}
+				empty={ {
+					icon: calendar,
+					description: __( 'No views in this period.', 'jetpack-premium-analytics-pkg' ),
+				} }
+			>
+				<div className={ styles.body }>
+					<div className={ styles.headline }>
+						{ /* Not `MetricValue`: it pins a 20px line-height at any font size, which
+						    clips 32px glyphs. `heading-2xl` pairs 32px with 40px. */ }
+						<Text variant="heading-2xl">{ peak?.label }</Text>
+						<Text variant="body-md" className={ styles.views } title={ exactViews }>
+							{ sprintf(
+								/* translators: %s is a number of views, e.g. "166.9k". */
+								__( '%s views', 'jetpack-premium-analytics-pkg' ),
+								formattedViews
+							) }
+						</Text>
+					</div>
+					<div className={ styles.chart }>
+						{ /* `withResponsive` caps width at 1200px by default, stranding space on a
+						    wider card. */ }
+						<Sparkline data={ points } maxWidth={ Infinity } />
+					</div>
+				</div>
+			</WidgetState>
+		</div>
+	);
+}
+
+/**
+ * WidgetRoot provides the query client, chart theme, and resolved report params.
+ */
+export default function PopularDaysRender( { attributes = {}, setError }: PopularDaysWidgetProps ) {
+	return (
+		<WidgetRoot attributes={ attributes } setError={ setError }>
+			<PopularDaysReport />
+		</WidgetRoot>
+	);
+}

--- a/projects/packages/premium-analytics/widgets/popular-days/render.tsx
+++ b/projects/packages/premium-analytics/widgets/popular-days/render.tsx
@@ -35,14 +35,11 @@ type PopularDaysWidgetProps = WidgetRenderProps< PopularDaysRenderAttributes > &
 const ABBREVIATED_VIEWS_OPTIONS = { useMultipliers: true, decimals: 1 };
 const PLAIN_VIEWS_OPTIONS = { decimals: 0 };
 
-/**
- * The busiest weekday over an area chart of the whole week's distribution.
- */
 function PopularDaysReport() {
 	const { buckets, peak, isLoading, isFetching, isError, error, refetch } = usePopularDays();
 
-	// Averages, matching the headline — plotting totals here would contradict it
-	// on any range that samples some weekdays more often than others.
+	// Averages, matching the headline; totals would contradict it on any range
+	// that samples some weekdays more often than others.
 	const points = useMemo( () => buckets.map( bucket => bucket.average ), [ buckets ] );
 
 	// `placeholderData` keeps the prior response on a transient refetch failure,

--- a/projects/packages/premium-analytics/widgets/popular-days/render.tsx
+++ b/projects/packages/premium-analytics/widgets/popular-days/render.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Text } from '@jetpack-premium-analytics/externals';
+import { Text, VisuallyHidden } from '@jetpack-premium-analytics/externals';
 import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
 import { calendar } from '@jetpack-premium-analytics/icons';
 import {
@@ -55,6 +55,11 @@ function PopularDaysReport() {
 		views >= 1000 ? ABBREVIATED_VIEWS_OPTIONS : PLAIN_VIEWS_OPTIONS
 	);
 
+	/* translators: %s is a number of views, e.g. "166.9k". */
+	const viewsTemplate = __( '%s views', 'jetpack-premium-analytics-pkg' );
+	const viewsLabel = sprintf( viewsTemplate, formattedViews );
+	const exactViewsLabel = sprintf( viewsTemplate, exactViews );
+
 	return (
 		<div className={ styles.root }>
 			<WidgetState
@@ -84,10 +89,15 @@ function PopularDaysReport() {
 						    clips 32px glyphs. `heading-2xl` pairs 32px with 40px. */ }
 						<Text variant="heading-2xl">{ peak?.label }</Text>
 						<Text variant="body-md" className={ styles.views } title={ exactViews }>
-							{ sprintf(
-								/* translators: %s is a number of views, e.g. "166.9k". */
-								__( '%s views', 'jetpack-premium-analytics-pkg' ),
-								formattedViews
+							{ viewsLabel === exactViewsLabel ? (
+								viewsLabel
+							) : (
+								<>
+									{ /* `title` is not reliably announced, so the abbreviation is hidden
+									    from assistive tech and the exact figure read in its place. */ }
+									<span aria-hidden="true">{ viewsLabel }</span>
+									<VisuallyHidden>{ exactViewsLabel }</VisuallyHidden>
+								</>
 							) }
 						</Text>
 					</div>

--- a/projects/packages/premium-analytics/widgets/popular-days/stories/popular-days-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/popular-days/stories/popular-days-widget.stories.tsx
@@ -1,0 +1,173 @@
+/**
+ * External dependencies
+ */
+import { getDefaultQueryParams, type PresetType } from '@jetpack-premium-analytics/data';
+/**
+ * Internal dependencies
+ */
+import {
+	registerReportMocks,
+	setReportMockState,
+} from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
+import {
+	DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	WidgetDashboardWithWidget as WidgetDashboardWithWidgetStory,
+	widgetDashboardWithWidgetArgTypes,
+	type WidgetDashboardWithWidgetControls,
+} from '../../stories/widget-dashboard-with-widget';
+import { createStoryWidgetType } from '../../stories/create-story-widget-type';
+import { withWidgetCanvas } from '../../stories/with-widget-canvas';
+import PopularDaysRender from '../render';
+import widgetDefinition from '../widget';
+import widgetManifest from '../widget.json';
+import type { Meta, StoryObj } from '@storybook/react';
+import type { WidgetRenderProps } from '@wordpress/widget-primitives';
+import type { ComponentProps, ComponentType } from 'react';
+
+registerReportMocks();
+
+const POPULAR_DAYS_RENDER_MODULE = 'storybook/popular-days';
+
+const storyWidgetType = createStoryWidgetType( widgetManifest, widgetDefinition );
+
+/**
+ * Renders the data-connected widget.
+ *
+ * @return The rendered widget.
+ */
+function renderPopularDays() {
+	return <PopularDaysRender attributes={ { reportParams: getDefaultQueryParams( false ) } } />;
+}
+
+/**
+ * Renders the widget on its own date preset.
+ *
+ * A distinct preset means a distinct query-cache entry, so a forced state cannot
+ * be served from another story's cached response.
+ *
+ * @param preset - The date-range preset to render on.
+ * @return The rendered widget.
+ */
+function renderPopularDaysOnPreset( preset: PresetType ) {
+	return (
+		<PopularDaysRender attributes={ { reportParams: getDefaultQueryParams( false, preset ) } } />
+	);
+}
+
+const meta = {
+	title: 'Packages/Premium Analytics/Widgets/PopularDays',
+	component: PopularDaysRender,
+	tags: [ 'autodocs' ],
+	parameters: {
+		docs: {
+			description: {
+				component:
+					'The "Popular days" card: the busiest day of the week for the selected range, as the weekday name and its mean views, over an area chart of the whole week\'s distribution. Both figures are means per occurrence of that weekday, not totals — a user-selected range rarely spans a whole number of weeks, so totals would let a weekday win on having occurred one extra time. Data comes from `stats/visits` at daily granularity, folded into seven buckets client-side; `stats/insights` also reports weekday views but over a window fixed at ten weeks, so it cannot follow the date picker. There is no WithComparison story — the widget strips comparison from its request and renders no delta, so it would be identical to Default.',
+			},
+		},
+	},
+} satisfies Meta< ComponentProps< typeof PopularDaysRender > >;
+
+export default meta;
+
+type Story = StoryObj< Record< never, never > >;
+
+/**
+ * Default state — the peak weekday over the week's distribution.
+ */
+export const Default: Story = {
+	render: renderPopularDays,
+	decorators: [ withWidgetCanvas ],
+};
+
+/**
+ * First load: the fetch is in flight, so the widget shows its loading state. The
+ * mock is forced to never resolve for the duration of this story.
+ */
+export const Loading: Story = {
+	render: () => renderPopularDaysOnPreset( 'last-90-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'stats/visits', 'loading' );
+		return () => setReportMockState( 'stats/visits', null );
+	},
+};
+
+/**
+ * The fetch failed with a permission-gated 403: neutral copy and no Retry
+ * action, since retrying cannot clear a permission gate.
+ */
+export const Error: Story = {
+	render: () => renderPopularDaysOnPreset( 'last-7-days' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'stats/visits', 'error' );
+		return () => setReportMockState( 'stats/visits', null );
+	},
+};
+
+/**
+ * The fetch failed in a way that can heal — the proxy's `no_connection` 403: the
+ * retryable copy with a Retry action, which re-runs the query (still mocked as
+ * failing while this story is active).
+ */
+export const ErrorRetryable: Story = {
+	render: () => renderPopularDaysOnPreset( 'last-12-months' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'stats/visits', 'error-retryable' );
+		return () => setReportMockState( 'stats/visits', null );
+	},
+};
+
+/**
+ * Resolved with no buckets: the widget shows its empty state.
+ */
+export const Empty: Story = {
+	// A calendar year, not a rolling window: `last-365-days` and `last-12-months`
+	// resolve to the same dates most years, which would share ErrorRetryable's
+	// query key and serve this story's cached empty result there instead.
+	render: () => renderPopularDaysOnPreset( 'last-year' ),
+	tags: [ '!autodocs' ],
+	decorators: [ withWidgetCanvas ],
+	beforeEach: () => {
+		setReportMockState( 'stats/visits', 'empty' );
+		return () => setReportMockState( 'stats/visits', null );
+	},
+};
+
+/**
+ * Renders the data-connected widget through the shared dashboard harness, so it
+ * appears exactly as it does in product (framed card, sizing, edit mode).
+ *
+ * Comparison params are passed even though the widget strips them, so the story
+ * covers the widget against crashing or inventing deltas when the host supplies
+ * comparison dates.
+ *
+ * @param {WidgetDashboardWithWidgetControls} dashboardArgs - The dashboard story controls.
+ * @return The widget mounted inside the real `WidgetDashboard`.
+ */
+function PopularDaysDashboardStory( dashboardArgs: WidgetDashboardWithWidgetControls ) {
+	return (
+		<WidgetDashboardWithWidgetStory
+			{ ...dashboardArgs }
+			widgetType={ storyWidgetType }
+			renderModule={ POPULAR_DAYS_RENDER_MODULE }
+			renderComponent={ PopularDaysRender as ComponentType< WidgetRenderProps< unknown > > }
+			attributes={ { reportParams: getDefaultQueryParams( true ) } }
+		/>
+	);
+}
+
+export const WidgetDashboardWithWidget: StoryObj< WidgetDashboardWithWidgetControls > = {
+	render: args => <PopularDaysDashboardStory { ...args } />,
+	args: {
+		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
+	},
+	argTypes: {
+		...widgetDashboardWithWidgetArgTypes,
+	},
+};

--- a/projects/packages/premium-analytics/widgets/popular-days/style.module.css
+++ b/projects/packages/premium-analytics/widgets/popular-days/style.module.css
@@ -1,0 +1,38 @@
+.root {
+	position: relative;
+	display: flex;
+	flex-direction: column;
+	block-size: 100%;
+	min-block-size: 0;
+}
+
+.body {
+	display: flex;
+	flex-direction: column;
+	block-size: 100%;
+	min-block-size: 0;
+	gap: var(--wpds-dimension-gap-sm);
+}
+
+/* The weekday and its view count sit on one line in the prototype, with the
+   count riding the weekday's baseline. `baseline` alignment keeps that true as
+   the two font sizes change. */
+.headline {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: baseline;
+	gap: var(--wpds-dimension-gap-sm);
+}
+
+.views {
+	color: var(--wpds-color-foreground-content-neutral-weak);
+}
+
+/* `Sparkline` is the responsive variant, so it fills this box: let the box take
+   whatever the headline leaves, rather than pinning it to a fixed band that
+   strands empty space as the card grows. `min-block-size: 0` is what lets a
+   flex child shrink below its content size. */
+.chart {
+	flex: 1 1 auto;
+	min-block-size: 0;
+}

--- a/projects/packages/premium-analytics/widgets/popular-days/use-popular-days.ts
+++ b/projects/packages/premium-analytics/widgets/popular-days/use-popular-days.ts
@@ -38,10 +38,7 @@ export function usePopularDays() {
 	const { primary, isLoading, isFetching, isError, error, refetch } = useStatsVisits( params );
 	const report = primary.data as StatsVisitsResponse | undefined;
 
-	const buckets = useMemo(
-		() => bucketViewsByWeekday( ( report?.data ?? [] ) as Record< string, unknown >[] ),
-		[ report ]
-	);
+	const buckets = useMemo( () => bucketViewsByWeekday( report?.data ?? [] ), [ report ] );
 
 	return {
 		buckets,

--- a/projects/packages/premium-analytics/widgets/popular-days/use-popular-days.ts
+++ b/projects/packages/premium-analytics/widgets/popular-days/use-popular-days.ts
@@ -1,0 +1,57 @@
+/**
+ * External dependencies
+ */
+import { useStatsVisits } from '@jetpack-premium-analytics/data';
+import {
+	useWidgetRootContext,
+	withoutComparison,
+} from '@jetpack-premium-analytics/widgets-toolkit';
+import { useMemo } from 'react';
+/**
+ * Internal dependencies
+ */
+import { bucketViewsByWeekday, pickPeakWeekday } from './bucket-views-by-weekday';
+import type { StatsVisitsParams, StatsVisitsResponse } from '@jetpack-premium-analytics/data';
+
+// Pinned rather than taken from the dashboard interval: weekday buckets can only
+// be rebuilt from daily rows, and a weekly or monthly bucket would silently
+// collapse the very distribution this widget draws.
+const PERIOD = 'day';
+
+// Matches the request `total-views` and `total-visitors` make, so all three
+// widgets share one cache entry instead of issuing near-identical requests.
+const STAT_FIELDS = 'views,visitors';
+
+/**
+ * Views folded into one bucket per day of the week, for the dashboard's range.
+ *
+ * `stats/insights` also reports a weekday breakdown, but over a window fixed at
+ * ten weeks and with no date parameters at all, so it cannot follow the date
+ * picker. `stats/visits` has no such cap and reports site-local dates.
+ */
+export function usePopularDays() {
+	const { reportParams } = useWidgetRootContext();
+
+	const params = useMemo< StatsVisitsParams >(
+		() => withoutComparison( { ...reportParams, stat_fields: STAT_FIELDS, period: PERIOD } ),
+		[ reportParams ]
+	);
+
+	const { primary, isLoading, isFetching, isError, error, refetch } = useStatsVisits( params );
+	const report = primary.data as StatsVisitsResponse | undefined;
+
+	const buckets = useMemo(
+		() => bucketViewsByWeekday( ( report?.data ?? [] ) as Record< string, unknown >[] ),
+		[ report ]
+	);
+
+	return {
+		buckets,
+		peak: useMemo( () => pickPeakWeekday( buckets ), [ buckets ] ),
+		isLoading,
+		isFetching,
+		isError,
+		error,
+		refetch,
+	};
+}

--- a/projects/packages/premium-analytics/widgets/popular-days/use-popular-days.ts
+++ b/projects/packages/premium-analytics/widgets/popular-days/use-popular-days.ts
@@ -13,21 +13,19 @@ import { useMemo } from 'react';
 import { bucketViewsByWeekday, pickPeakWeekday } from './bucket-views-by-weekday';
 import type { StatsVisitsParams, StatsVisitsResponse } from '@jetpack-premium-analytics/data';
 
-// Pinned rather than taken from the dashboard interval: weekday buckets can only
-// be rebuilt from daily rows, and a weekly or monthly bucket would silently
-// collapse the very distribution this widget draws.
+// Pinned, not taken from the dashboard interval: a weekly or monthly bucket
+// collapses the very distribution this widget draws.
 const PERIOD = 'day';
 
-// Matches the request `total-views` and `total-visitors` make, so all three
-// widgets share one cache entry instead of issuing near-identical requests.
+// Matches what `total-views` and `total-visitors` request, so all three share
+// one cache entry instead of issuing near-identical requests.
 const STAT_FIELDS = 'views,visitors';
 
 /**
  * Views folded into one bucket per day of the week, for the dashboard's range.
  *
- * `stats/insights` also reports a weekday breakdown, but over a window fixed at
- * ten weeks and with no date parameters at all, so it cannot follow the date
- * picker. `stats/visits` has no such cap and reports site-local dates.
+ * Not `stats/insights`, which reports the same breakdown over a window fixed at
+ * ten weeks and takes no date parameters, so it cannot follow the date picker.
  */
 export function usePopularDays() {
 	const { reportParams } = useWidgetRootContext();

--- a/projects/packages/premium-analytics/widgets/popular-days/widget.json
+++ b/projects/packages/premium-analytics/widgets/popular-days/widget.json
@@ -3,7 +3,13 @@
 	"title": "Popular days",
 	"description": "The day of the week that draws the most views, with the distribution across the week.",
 	"help": {
-		"content": "The days of the week when your site received the most views on average."
+		"content": "The days of the week when your site received the most views on average.",
+		"links": [
+			{
+				"label": "Learn more",
+				"href": "https://wordpress.com/support/stats/#popular-hours"
+			}
+		]
 	},
 	"category": "stats",
 	"presentation": "framed"

--- a/projects/packages/premium-analytics/widgets/popular-days/widget.json
+++ b/projects/packages/premium-analytics/widgets/popular-days/widget.json
@@ -1,0 +1,10 @@
+{
+	"name": "jpa/popular-days",
+	"title": "Popular days",
+	"description": "The day of the week that draws the most views, with the distribution across the week.",
+	"help": {
+		"content": "The days of the week when your site received the most views on average."
+	},
+	"category": "stats",
+	"presentation": "framed"
+}

--- a/projects/packages/premium-analytics/widgets/popular-days/widget.ts
+++ b/projects/packages/premium-analytics/widgets/popular-days/widget.ts
@@ -1,0 +1,20 @@
+/**
+ * Internal dependencies
+ */
+import { calendar } from '@jetpack-premium-analytics/icons';
+
+/**
+ * Configurable attributes for the Popular days widget. There are none: the
+ * metric is fixed and the date range comes from the dashboard picker.
+ */
+export type PopularDaysAttributes = Record< never, never >;
+
+/**
+ * Widget type definition.
+ *
+ * Shows the busiest day of the week for the selected range, as the weekday name,
+ * its mean views, and an area chart of the whole week's distribution.
+ */
+export default {
+	icon: calendar,
+};

--- a/projects/packages/premium-analytics/widgets/popular-days/widget.ts
+++ b/projects/packages/premium-analytics/widgets/popular-days/widget.ts
@@ -1,7 +1,7 @@
 /**
- * Internal dependencies
+ * External dependencies
  */
-import { calendar } from '@jetpack-premium-analytics/icons';
+import { calendar } from '@wordpress/icons';
 
 /**
  * Configurable attributes for the Popular days widget. There are none: the


### PR DESCRIPTION
Fixes WOOA7S-1851

## Proposed changes

- Add a **Popular days** widget to the Insights tab: the busiest day of the week, its view count, and an area chart of the whole week's distribution.
- Follows the dashboard date picker. Data comes from `stats/visits` at daily granularity, folded into seven weekday buckets in the frontend.
- Figures are the **mean views per occurrence of that weekday**, not the sum. A user-selected range rarely spans a whole number of weeks — over 30 days, two weekdays occur five times and five occur four — so a total would let a weekday win on having occurred one extra time.
- **Put it on the default Insights layout in place of `Most popular time`.** That widget's "best day" half asks the same question and is fixed to a ten-week window; its "best hour" half comes back as its own widget in WOOA7S-1897. Nothing is deleted — `Most popular time` stays in the registry and can still be added by hand.

Two notes for reviewers:

- **Why not `stats/insights`?** It already reports a weekday breakdown, but over a window hard-coded to ten weeks and with no date parameters at all, so it cannot follow the date picker. `stats/visits` has no row cap and reports site-local dates.
- **`Most popular day` stays.** Despite the name it answers a different question — the single best calendar date ever recorded — and comes from a different endpoint.


## Related product discussion/links

- WOOA7S-1851
- WOOA7S-1897 — Popular hours, split out of this issue. Blocked on a 60-day cap on hourly data that does not affect this widget.
- WOOA7S-1899 — a Storybook preset collision found while testing this, present in six other widgets.

## Does this pull request change what data or activity we track or use?

No. It reads an endpoint the dashboard already calls.

## Testing instructions

### Storybook

```
cd projects/js-packages/storybook && pnpm run storybook:dev
```

Open **Packages / Premium Analytics / Widgets / PopularDays**.

- **Default** — a weekday, a view count, and the distribution chart.
- **WidgetDashboardWithWidget** — the widget in the real dashboard frame. Comparison params are passed on purpose; the widget strips them, so there should be no delta anywhere.
- **Loading / Error / ErrorRetryable / Empty** — forced states. `Error` is a permission-gated 403 and offers no Retry; `ErrorRetryable` is the proxy's `no_connection` 403 and does.
- Switch between all of them in any order — every state should stay correct. (Story order used to matter; see WOOA7S-1899.)


https://github.com/user-attachments/assets/9863bad7-be61-438f-a1b9-e5642da688aa

### Stats v2 dashboard


1.  Open **Stats v2 → Insights**.
2. **Popular days** should be on the dashboard by default, where **Most popular time** used to be. **Most popular day** ("August 18 / 2020") should still be there — it is a different metric and was left alone.
3. Check the headline weekday and view count look plausible against **Jetpack → Stats → Traffic** for the same range.
4. Change the date range in the picker. The widget should update — this is the main thing to verify, since the widget it replaced could not.
5. Set the picker's **Group by** to Week or Month. The widget should be unaffected: it always requests daily buckets, because weekday buckets cannot be rebuilt from weekly ones.


https://github.com/user-attachments/assets/16a4dac5-0ba5-4f48-9229-fbcd46169f38

