### PR TITLE
Premium Analytics: report a missing widget manifest as a partial build

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1850-build-missing-signal
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1850-build-missing-signal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Report a missing widget manifest as a partial build, so a half-deployed dashboard is no longer silent.

--- a/projects/packages/premium-analytics/src/class-analytics.php
+++ b/projects/packages/premium-analytics/src/class-analytics.php
@@ -362,6 +362,27 @@ class Analytics {
 	}
 
 	/**
+	 * Absolute path to the generated widget manifest.
+	 *
+	 * On the class rather than beside its readers in widget-modules.php: two copies
+	 * of this package can load in one request, and only classes go through the
+	 * autoloader's version dedupe. See load_dashboard_components().
+	 *
+	 * @return string
+	 */
+	public static function widget_manifest_path() {
+		/**
+		 * Filters the path to the generated widget manifest.
+		 *
+		 * @param string $path Absolute path to the generated widget manifest.
+		 */
+		return apply_filters(
+			'jetpack_premium_analytics_widgets_manifest_path',
+			__DIR__ . '/../build/widgets.php'
+		);
+	}
+
+	/**
 	 * Register the admin-only render path: polyfills, menu, and page hooks.
 	 *
 	 * @return void
@@ -441,17 +462,14 @@ class Analytics {
 	 * @return void
 	 */
 	public static function register_admin_menu() {
-		// Keep this dependency explicit in case the dashboard load order changes.
-		if ( ! function_exists( __NAMESPACE__ . '\\widgets_manifest_path' ) ) {
-			require_once __DIR__ . '/widget-modules.php';
-		}
-
 		$can_render          = function_exists( 'jpa_jetpack_premium_analytics_wp_admin_render_page' );
-		$has_widget_manifest = file_exists( widgets_manifest_path() );
+		$has_widget_manifest = file_exists( self::widget_manifest_path() );
 
 		$missing = array();
 		if ( ! $can_render ) {
-			$missing[] = 'build/pages.php (the dashboard page render callback)';
+			// Named by symbol, not by file: build/pages.php is only a loader, and the
+			// callback can also go missing to a renamed page slug or an absent build entry.
+			$missing[] = 'the jpa_jetpack_premium_analytics_wp_admin_render_page() callback, generated under build/pages/';
 		}
 		if ( ! $has_widget_manifest ) {
 			$missing[] = 'build/widgets.php (the widget manifest)';
@@ -462,6 +480,8 @@ class Analytics {
 			// the first admin request instead of waiting for someone to open the dashboard.
 			_doing_it_wrong(
 				__METHOD__,
+				// esc_html() only to satisfy WordPress.Security.EscapeOutput, which treats
+				// this argument as output; every entry is a literal from just above.
 				'The Premium Analytics build output is incomplete: ' . esc_html( implode( ', ', $missing ) ) . '. The package build did not run, or ran only partially, for this deploy.',
 				''
 			);

--- a/projects/packages/premium-analytics/src/class-analytics.php
+++ b/projects/packages/premium-analytics/src/class-analytics.php
@@ -435,22 +435,44 @@ class Analytics {
 	 * comes from the generated build; when that is missing we say so rather
 	 * than render an empty page, since the two look identical from the outside.
 	 *
+	 * build/build.php guards each sub-require separately, so its parts go missing
+	 * independently. Only pages.php decides whether the page renders, but both it
+	 * and widgets.php are reported: a deploy dropping only the manifest is silent
+	 * everywhere else, leaving every widget reading "Widget is no longer
+	 * available" (WOOA7S-1850).
+	 *
 	 * @return void
 	 */
 	public static function register_admin_menu() {
-		$has_build = function_exists( 'jpa_jetpack_premium_analytics_wp_admin_render_page' );
+		// Never fires today: load_dashboard_surface() loads this file first. Kept because
+		// no test can catch that ordering breaking — test files load widget-modules.php at
+		// file scope, so a reorder stays green in CI and fatals in wp-admin.
+		if ( ! function_exists( __NAMESPACE__ . '\\widgets_manifest_path' ) ) {
+			require_once __DIR__ . '/widget-modules.php';
+		}
 
-		if ( ! $has_build ) {
+		$can_render          = function_exists( 'jpa_jetpack_premium_analytics_wp_admin_render_page' );
+		$has_widget_manifest = file_exists( widgets_manifest_path() );
+
+		$missing = array();
+		if ( ! $can_render ) {
+			$missing[] = 'build/pages.php (the dashboard page render callback)';
+		}
+		if ( ! $has_widget_manifest ) {
+			$missing[] = 'build/widgets.php (the widget manifest)';
+		}
+
+		if ( $missing ) {
 			// Surfaced here rather than only on the page itself, so a partial deploy shows up on
 			// the first admin request instead of waiting for someone to open the dashboard.
 			_doing_it_wrong(
 				__METHOD__,
-				'The Premium Analytics build output is missing, so the dashboard cannot render. The package build did not run for this deploy.',
+				'The Premium Analytics build output is incomplete: ' . esc_html( implode( ', ', $missing ) ) . '. The package build did not run, or ran only partially, for this deploy.',
 				''
 			);
 		}
 
-		$render_callback = $has_build
+		$render_callback = $can_render
 			? 'jpa_jetpack_premium_analytics_wp_admin_render_page'
 			: array( __CLASS__, 'render_missing_build_notice' );
 

--- a/projects/packages/premium-analytics/src/class-analytics.php
+++ b/projects/packages/premium-analytics/src/class-analytics.php
@@ -435,18 +435,13 @@ class Analytics {
 	 * comes from the generated build; when that is missing we say so rather
 	 * than render an empty page, since the two look identical from the outside.
 	 *
-	 * build/build.php guards each sub-require separately, so its parts go missing
-	 * independently. Only pages.php decides whether the page renders, but both it
-	 * and widgets.php are reported: a deploy dropping only the manifest is silent
-	 * everywhere else, leaving every widget reading "Widget is no longer
-	 * available" (WOOA7S-1850).
+	 * Report missing page and widget build artifacts independently because the
+	 * build loader includes each one conditionally.
 	 *
 	 * @return void
 	 */
 	public static function register_admin_menu() {
-		// Never fires today: load_dashboard_surface() loads this file first. Kept because
-		// no test can catch that ordering breaking — test files load widget-modules.php at
-		// file scope, so a reorder stays green in CI and fatals in wp-admin.
+		// Keep this dependency explicit in case the dashboard load order changes.
 		if ( ! function_exists( __NAMESPACE__ . '\\widgets_manifest_path' ) ) {
 			require_once __DIR__ . '/widget-modules.php';
 		}

--- a/projects/packages/premium-analytics/src/widget-modules.php
+++ b/projects/packages/premium-analytics/src/widget-modules.php
@@ -32,6 +32,27 @@ function register_widget_modules_rest_route() {
 }
 
 /**
+ * Absolute path to the generated widget manifest.
+ *
+ * One definition, so the require in ensure_widget_registry_ready() and the
+ * missing-build check in Analytics::register_admin_menu() cannot drift.
+ *
+ * @return string
+ */
+function widgets_manifest_path() {
+	/**
+	 * Filters the path to the generated widget manifest.
+	 *
+	 * @param string $path Absolute path to the manifest register_widget_types()
+	 *                     reads. Absent without a JS build.
+	 */
+	return apply_filters(
+		'jetpack_premium_analytics_widgets_manifest_path',
+		__DIR__ . '/../build/widgets.php'
+	);
+}
+
+/**
  * Load and hydrate the widget type registry, once.
  *
  * Deferred to here (the registry's only two readers) instead of running
@@ -53,21 +74,13 @@ function ensure_widget_registry_ready() {
 	require_once __DIR__ . '/widget-types.php';
 	require_once __DIR__ . '/widget-availability.php';
 
-	/**
-	 * Filters the path to the generated widget manifest.
-	 *
+	/*
 	 * Load-bearing since WOOA7S-1804: the build is otherwise admin-only, so on a
 	 * REST request this require is the only thing that puts the manifest in
 	 * reach. Drop it and every dashboard widget renders "Widget is no longer
 	 * available" (the #49961 bug).
-	 *
-	 * @param string $path Absolute path to the manifest register_widget_types()
-	 *                     reads. Absent without a JS build.
 	 */
-	$widgets_manifest = apply_filters(
-		'jetpack_premium_analytics_widgets_manifest_path',
-		__DIR__ . '/../build/widgets.php'
-	);
+	$widgets_manifest = widgets_manifest_path();
 	if ( file_exists( $widgets_manifest ) ) {
 		require_once $widgets_manifest;
 	}

--- a/projects/packages/premium-analytics/src/widget-modules.php
+++ b/projects/packages/premium-analytics/src/widget-modules.php
@@ -32,23 +32,6 @@ function register_widget_modules_rest_route() {
 }
 
 /**
- * Get the absolute path to the generated widget manifest.
- *
- * @return string
- */
-function widgets_manifest_path() {
-	/**
-	 * Filters the path to the generated widget manifest.
-	 *
-	 * @param string $path Absolute path to the generated widget manifest.
-	 */
-	return apply_filters(
-		'jetpack_premium_analytics_widgets_manifest_path',
-		__DIR__ . '/../build/widgets.php'
-	);
-}
-
-/**
  * Load and hydrate the widget type registry, once.
  *
  * Deferred to here (the registry's only two readers) instead of running
@@ -70,8 +53,10 @@ function ensure_widget_registry_ready() {
 	require_once __DIR__ . '/widget-types.php';
 	require_once __DIR__ . '/widget-availability.php';
 
-	// REST requests do not load the admin build, so load the manifest explicitly.
-	$widgets_manifest = widgets_manifest_path();
+	// REST does not load the admin build, so this require is the manifest's only route
+	// in (WOOA7S-1804). Drop it and every widget renders "Widget is no longer
+	// available" — the #49961 bug.
+	$widgets_manifest = Analytics::widget_manifest_path();
 	if ( file_exists( $widgets_manifest ) ) {
 		require_once $widgets_manifest;
 	}

--- a/projects/packages/premium-analytics/src/widget-modules.php
+++ b/projects/packages/premium-analytics/src/widget-modules.php
@@ -32,10 +32,7 @@ function register_widget_modules_rest_route() {
 }
 
 /**
- * Absolute path to the generated widget manifest.
- *
- * One definition, so the require in ensure_widget_registry_ready() and the
- * missing-build check in Analytics::register_admin_menu() cannot drift.
+ * Get the absolute path to the generated widget manifest.
  *
  * @return string
  */
@@ -43,8 +40,7 @@ function widgets_manifest_path() {
 	/**
 	 * Filters the path to the generated widget manifest.
 	 *
-	 * @param string $path Absolute path to the manifest register_widget_types()
-	 *                     reads. Absent without a JS build.
+	 * @param string $path Absolute path to the generated widget manifest.
 	 */
 	return apply_filters(
 		'jetpack_premium_analytics_widgets_manifest_path',
@@ -74,12 +70,7 @@ function ensure_widget_registry_ready() {
 	require_once __DIR__ . '/widget-types.php';
 	require_once __DIR__ . '/widget-availability.php';
 
-	/*
-	 * Load-bearing since WOOA7S-1804: the build is otherwise admin-only, so on a
-	 * REST request this require is the only thing that puts the manifest in
-	 * reach. Drop it and every dashboard widget renders "Widget is no longer
-	 * available" (the #49961 bug).
-	 */
+	// REST requests do not load the admin build, so load the manifest explicitly.
 	$widgets_manifest = widgets_manifest_path();
 	if ( file_exists( $widgets_manifest ) ) {
 		require_once $widgets_manifest;

--- a/projects/packages/premium-analytics/tests/php/Analytics_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Analytics_Test.php
@@ -25,11 +25,9 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \Automattic\Jetpack\PremiumAnalytics\Analytics
  * @covers ::Automattic\Jetpack\PremiumAnalytics\ensure_widget_registry_ready
- * @covers ::Automattic\Jetpack\PremiumAnalytics\widgets_manifest_path
  */
 #[CoversClass( Analytics::class )]
 #[CoversFunction( 'Automattic\\Jetpack\\PremiumAnalytics\\ensure_widget_registry_ready' )]
-#[CoversFunction( 'Automattic\\Jetpack\\PremiumAnalytics\\widgets_manifest_path' )]
 class Analytics_Test extends TestCase {
 
 	const MENU_SLUG     = 'jetpack-premium-analytics-wp-admin';
@@ -664,6 +662,38 @@ class Analytics_Test extends TestCase {
 			array( Analytics::class . '::register_admin_menu' ),
 			$this->doing_it_wrong
 		);
+		$this->assertStringContainsString(
+			'jpa_jetpack_premium_analytics_wp_admin_render_page',
+			$this->doing_it_wrong_messages[0] ?? '',
+			'The diagnostic must name the artifact that is actually missing.'
+		);
+		$this->assertStringNotContainsString(
+			'build/widgets.php',
+			$this->doing_it_wrong_messages[0] ?? '',
+			'The manifest is staged here; naming it would send the reader to the wrong file.'
+		);
+	}
+
+	/**
+	 * A build that never ran names both artifacts in one diagnostic.
+	 *
+	 * Pins the whole sentence once, so the per-artifact tests can stay on substrings.
+	 */
+	public function test_register_admin_menu_lists_both_missing_artifacts() {
+		$this->register_admin_menu_without_build( 'use_absent_widget_manifest' );
+
+		$this->assertSame(
+			array( Analytics::class . '::register_admin_menu' ),
+			$this->doing_it_wrong,
+			'Both artifacts are reported in one diagnostic, not one per artifact.'
+		);
+		$this->assertSame(
+			'The Premium Analytics build output is incomplete: '
+				. 'the jpa_jetpack_premium_analytics_wp_admin_render_page() callback, generated under build/pages/, '
+				. 'build/widgets.php (the widget manifest). '
+				. 'The package build did not run, or ran only partially, for this deploy.',
+			$this->doing_it_wrong_messages[0] ?? ''
+		);
 	}
 
 	/**
@@ -765,14 +795,29 @@ class Analytics_Test extends TestCase {
 			'The diagnostic must name the artifact that is actually missing.'
 		);
 		$this->assertStringNotContainsString(
-			'build/pages.php',
+			'jpa_jetpack_premium_analytics_wp_admin_render_page',
 			$this->doing_it_wrong_messages[0] ?? '',
-			'build/pages.php is present here; naming it would send the reader to the wrong file.'
+			'The page renders here; naming its callback would send the reader to the wrong artifact.'
 		);
 		$this->assertNotFalse(
 			has_action( self::MENU_HOOKNAME, 'jpa_jetpack_premium_analytics_wp_admin_render_page' ),
 			'Only the manifest is missing, so the page still renders through the generated callback.'
 		);
+	}
+
+	/**
+	 * The unfiltered manifest path points at the generated build output.
+	 *
+	 * Every other test stages this path through the filter, so nothing else would
+	 * notice the default breaking - and on REST a wrong path empties the widget
+	 * registry with no error at all (the #49961 bug).
+	 */
+	public function test_widget_manifest_path_defaults_to_the_generated_manifest() {
+		// Collapse the ".." the default is built from rather than realpath()ing it:
+		// build/ does not exist in a checkout that has not run the JS build.
+		$path = preg_replace( '#/[^/]+/\.\./#', '/', Analytics::widget_manifest_path() );
+
+		$this->assertSame( dirname( __DIR__, 2 ) . '/build/widgets.php', $path );
 	}
 
 	/**
@@ -789,19 +834,24 @@ class Analytics_Test extends TestCase {
 	 * add_menu_page() only wires the render callback for a user who can reach the
 	 * page, hence the capability grant.
 	 *
+	 * @param string $manifest_filter Method on this class supplying the manifest path.
 	 * @return array|null The registered menu entry.
 	 */
-	private function register_admin_menu_without_build() {
+	private function register_admin_menu_without_build( $manifest_filter = 'use_fixture_widget_manifest' ) {
 		$GLOBALS['menu'] = array();
 
 		// Hooked by boot_shared_services() in production; add_menu_page() resolves the
 		// dashboard capability, and an unmapped one would skip the page's render hook.
 		Capabilities::register();
 
+		// Stage the manifest: unfiltered, the diagnostic would name a different set of
+		// artifacts depending on whether this checkout has run the JS build.
+		add_filter( 'jetpack_premium_analytics_widgets_manifest_path', array( $this, $manifest_filter ) );
 		add_filter( 'user_has_cap', array( $this, 'grant_manage_options' ) );
 		$this->capture_doing_it_wrong();
 		Analytics::register_admin_menu();
 		remove_filter( 'user_has_cap', array( $this, 'grant_manage_options' ) );
+		remove_filter( 'jetpack_premium_analytics_widgets_manifest_path', array( $this, $manifest_filter ) );
 
 		foreach ( $GLOBALS['menu'] as $item ) {
 			if ( self::MENU_SLUG === ( $item[2] ?? null ) ) {
@@ -813,7 +863,10 @@ class Analytics_Test extends TestCase {
 	}
 
 	/**
-	 * Capture _doing_it_wrong() calls without triggering a PHP warning.
+	 * Capture _doing_it_wrong() calls without tripping the suite's failOnWarning gate.
+	 *
+	 * Records each triggering function name and its message, and suppresses the
+	 * underlying PHP warning, so a test can assert the diagnostic fired.
 	 */
 	private function capture_doing_it_wrong() {
 		$this->doing_it_wrong          = array();

--- a/projects/packages/premium-analytics/tests/php/Analytics_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Analytics_Test.php
@@ -25,9 +25,11 @@ use PHPUnit\Framework\TestCase;
  *
  * @covers \Automattic\Jetpack\PremiumAnalytics\Analytics
  * @covers ::Automattic\Jetpack\PremiumAnalytics\ensure_widget_registry_ready
+ * @covers ::Automattic\Jetpack\PremiumAnalytics\widgets_manifest_path
  */
 #[CoversClass( Analytics::class )]
 #[CoversFunction( 'Automattic\\Jetpack\\PremiumAnalytics\\ensure_widget_registry_ready' )]
+#[CoversFunction( 'Automattic\\Jetpack\\PremiumAnalytics\\widgets_manifest_path' )]
 class Analytics_Test extends TestCase {
 
 	const MENU_SLUG     = 'jetpack-premium-analytics-wp-admin';
@@ -39,6 +41,13 @@ class Analytics_Test extends TestCase {
 	 * @var string[]
 	 */
 	private $doing_it_wrong = array();
+
+	/**
+	 * _doing_it_wrong() messages captured during a test, in the same order.
+	 *
+	 * @var string[]
+	 */
+	private $doing_it_wrong_messages = array();
 
 	/**
 	 * Fail loudly if the fixture build leaked in from an earlier test.
@@ -357,6 +366,15 @@ class Analytics_Test extends TestCase {
 	 */
 	public function use_fixture_widget_manifest() {
 		return __DIR__ . '/fixtures/build-entry/widgets.php';
+	}
+
+	/**
+	 * Point the manifest at a path no build ever writes, for the half-deployed case.
+	 *
+	 * @return string
+	 */
+	public function use_absent_widget_manifest() {
+		return __DIR__ . '/fixtures/build-entry/no-such-widgets.php';
 	}
 
 	/**
@@ -685,6 +703,9 @@ class Analytics_Test extends TestCase {
 	 * from the page slug at build time, so a rename on either side swaps the
 	 * dashboard for the missing-build notice with nothing else to notice it.
 	 *
+	 * Both artifacts need fixtures: build/ is gitignored and test-php runs no build,
+	 * so a default manifest path would report a missing one here.
+	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 */
@@ -699,13 +720,61 @@ class Analytics_Test extends TestCase {
 		$GLOBALS['menu'] = array();
 		Capabilities::register();
 		add_filter( 'user_has_cap', array( $this, 'grant_manage_options' ) );
+		add_filter( 'jetpack_premium_analytics_widgets_manifest_path', array( $this, 'use_fixture_widget_manifest' ) );
 		$this->capture_doing_it_wrong();
 		Analytics::register_admin_menu();
+		remove_filter( 'jetpack_premium_analytics_widgets_manifest_path', array( $this, 'use_fixture_widget_manifest' ) );
 		remove_filter( 'user_has_cap', array( $this, 'grant_manage_options' ) );
 
 		$this->assertSame( array(), $this->doing_it_wrong, 'A present build must not report a missing one.' );
 		$this->assertNotFalse(
 			has_action( self::MENU_HOOKNAME, 'jpa_jetpack_premium_analytics_wp_admin_render_page' )
+		);
+	}
+
+	/**
+	 * A deploy can drop build/widgets.php and keep build/pages.php. Nothing else
+	 * reports that state, so the diagnostic has to key on the manifest rather than
+	 * on the render callback that is still there.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_register_admin_menu_reports_a_missing_widget_manifest() {
+		$this->use_fixture_build();
+		set_current_screen( self::MENU_HOOKNAME );
+
+		Analytics::init();
+
+		$GLOBALS['menu'] = array();
+		Capabilities::register();
+		add_filter( 'user_has_cap', array( $this, 'grant_manage_options' ) );
+		add_filter( 'jetpack_premium_analytics_widgets_manifest_path', array( $this, 'use_absent_widget_manifest' ) );
+		$this->capture_doing_it_wrong();
+		Analytics::register_admin_menu();
+		remove_filter( 'jetpack_premium_analytics_widgets_manifest_path', array( $this, 'use_absent_widget_manifest' ) );
+		remove_filter( 'user_has_cap', array( $this, 'grant_manage_options' ) );
+
+		$this->assertSame(
+			array( Analytics::class . '::register_admin_menu' ),
+			$this->doing_it_wrong,
+			'A missing widget manifest must be reported even though the page renders.'
+		);
+		$this->assertStringContainsString(
+			'build/widgets.php',
+			$this->doing_it_wrong_messages[0] ?? '',
+			'The diagnostic must name the artifact that is actually missing.'
+		);
+		$this->assertStringNotContainsString(
+			'build/pages.php',
+			$this->doing_it_wrong_messages[0] ?? '',
+			'build/pages.php is present here; naming it would send the reader to the wrong file.'
+		);
+		$this->assertNotFalse(
+			has_action( self::MENU_HOOKNAME, 'jpa_jetpack_premium_analytics_wp_admin_render_page' ),
+			'Only the manifest is missing, so the page still renders through the generated callback.'
 		);
 	}
 
@@ -749,17 +818,21 @@ class Analytics_Test extends TestCase {
 	/**
 	 * Capture _doing_it_wrong() calls without tripping the suite's failOnWarning gate.
 	 *
-	 * Records each triggering function name in $this->doing_it_wrong and suppresses the
-	 * underlying PHP warning, so a test can assert the diagnostic fired.
+	 * Records each call's function name and message, and suppresses the underlying PHP
+	 * warning, so a test can assert both that the diagnostic fired and what it named.
 	 */
 	private function capture_doing_it_wrong() {
-		$this->doing_it_wrong = array();
+		$this->doing_it_wrong          = array();
+		$this->doing_it_wrong_messages = array();
 		add_filter( 'doing_it_wrong_trigger_error', '__return_false' );
 		add_action(
 			'doing_it_wrong_run',
-			function ( $function_name ) {
-				$this->doing_it_wrong[] = $function_name;
-			}
+			function ( $function_name, $message ) {
+				$this->doing_it_wrong[]          = $function_name;
+				$this->doing_it_wrong_messages[] = $message;
+			},
+			10,
+			2
 		);
 	}
 

--- a/projects/packages/premium-analytics/tests/php/Analytics_Test.php
+++ b/projects/packages/premium-analytics/tests/php/Analytics_Test.php
@@ -369,7 +369,7 @@ class Analytics_Test extends TestCase {
 	}
 
 	/**
-	 * Point the manifest at a path no build ever writes, for the half-deployed case.
+	 * Point the manifest at a missing file.
 	 *
 	 * @return string
 	 */
@@ -703,8 +703,7 @@ class Analytics_Test extends TestCase {
 	 * from the page slug at build time, so a rename on either side swaps the
 	 * dashboard for the missing-build notice with nothing else to notice it.
 	 *
-	 * Both artifacts need fixtures: build/ is gitignored and test-php runs no build,
-	 * so a default manifest path would report a missing one here.
+	 * Use fixtures because the test suite does not generate build artifacts.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
@@ -733,9 +732,7 @@ class Analytics_Test extends TestCase {
 	}
 
 	/**
-	 * A deploy can drop build/widgets.php and keep build/pages.php. Nothing else
-	 * reports that state, so the diagnostic has to key on the manifest rather than
-	 * on the render callback that is still there.
+	 * A missing widget manifest is reported even when the page can render.
 	 *
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
@@ -816,10 +813,7 @@ class Analytics_Test extends TestCase {
 	}
 
 	/**
-	 * Capture _doing_it_wrong() calls without tripping the suite's failOnWarning gate.
-	 *
-	 * Records each call's function name and message, and suppresses the underlying PHP
-	 * warning, so a test can assert both that the diagnostic fired and what it named.
+	 * Capture _doing_it_wrong() calls without triggering a PHP warning.
 	 */
 	private function capture_doing_it_wrong() {
 		$this->doing_it_wrong          = array();

--- a/projects/packages/premium-analytics/tests/php/fixtures/build-entry/widgets.php
+++ b/projects/packages/premium-analytics/tests/php/fixtures/build-entry/widgets.php
@@ -2,7 +2,7 @@
 /**
  * Test fixture: stand-in for the generated widget manifest.
  *
- * Reached only through widgets_manifest_path(), so a test can prove
+ * Reached only through Analytics::widget_manifest_path(), so a test can prove
  * ensure_widget_registry_ready() still requires the manifest: drop that require
  * and this file never loads, the registry stays empty, and the REST test fails.
  * Delegates the declaration so there is one stub accessor, not two.


### PR DESCRIPTION
## Proposed changes

When `build/widgets.php` is missing from a partial build, the existing diagnostic does not fire because it only checks `build/pages.php`. The dashboard still loads, but every widget appears unavailable without explaining why.

This PR:

- Reports a missing widget manifest through `_doing_it_wrong()` and identifies the missing file.
- Centralizes the widget manifest path.
- Adds coverage for partial builds.

There is no user-facing behavior change. The diagnostic only appears when `WP_DEBUG` is enabled, and the existing dashboard and REST behavior remain unchanged.

## Related product discussion/links

- WOOA7S-1850
- Follows WOOA7S-1804 (#50890), which left the `require_once` in `ensure_widget_registry_ready()` as REST's only route to the manifest.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This is a developer-facing diagnostic, so testing it means faking a partial build.

The `build/` directory to edit depends on where you are testing. In a monorepo checkout it is `projects/packages/premium-analytics/build/`. On a Jurassic Ninja or Atomic site the package is vendored into the plugin, so it is `wp-content/plugins/jetpack/jetpack_vendor/automattic/jetpack-premium-analytics/build/` — editing the monorepo path there does nothing.

1. `jetpack build packages/premium-analytics`, then set `WP_DEBUG` and `WP_DEBUG_LOG` in `wp-config.php` (both are already on for JN sites).
2. Move `build/widgets.php` aside — leave the rest of `build/` alone.
3. Load any wp-admin page. On trunk: nothing is logged. With this PR, `debug.log` gets:
   > The Premium Analytics build output is incomplete: build/widgets.php (the widget manifest). …
4. Confirm the dashboard still opens and renders (only the widgets are dead), and that the message does _not_ name `build/pages.php`.
5. Restore the file, reload, confirm nothing is logged.
6. Other direction: move `build/pages.php` aside instead. The message should name it, and the page should fall back to the "assets missing" notice.

Verified on a Jurassic Ninja site across all four states: on trunk the missing manifest logged nothing at all, and with the patch each of the three broken states named the artifact that was actually missing while a complete build stayed quiet.

`jetpack test php packages/premium-analytics` (426 tests) and `jetpack phan packages/premium-analytics` both pass.
