### PR TITLE
Premium Analytics: align metric chart tabs with the prototype

### DIFF
--- a/projects/packages/premium-analytics/changelog/change-wooa7s-1898-metric-tabs
+++ b/projects/packages/premium-analytics/changelog/change-wooa7s-1898-metric-tabs
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Metric tabs: Spread the cards across the full chart width and tint the selected one with the brand colour, and render a lone metric as a static headline rather than a card.

--- a/projects/packages/premium-analytics/changelog/change-wooa7s-1898-metric-tabs
+++ b/projects/packages/premium-analytics/changelog/change-wooa7s-1898-metric-tabs
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Metric tabs: Spread cards evenly across the chart, wrap them before their contents overlap, tint the selected one with the brand colour, and render a lone metric as a static headline.
+Metric tabs: Spread cards evenly across the chart, wrap them before their contents overlap, match the prototype's card fill, spacing and headline value size, and render a lone metric as a static headline.

--- a/projects/packages/premium-analytics/changelog/change-wooa7s-1898-metric-tabs
+++ b/projects/packages/premium-analytics/changelog/change-wooa7s-1898-metric-tabs
@@ -1,4 +1,4 @@
 Significance: patch
 Type: changed
 
-Metric tabs: Spread the cards across the full chart width and tint the selected one with the brand colour, and render a lone metric as a static headline rather than a card.
+Metric tabs: Spread cards evenly across the chart, wrap them before their contents overlap, tint the selected one with the brand colour, and render a lone metric as a static headline.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/__tests__/metric-tabs-chart.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/__tests__/metric-tabs-chart.test.tsx
@@ -77,6 +77,24 @@ describe( 'MetricTabsChart', () => {
 		expect( screen.queryByTestId( 'bar-chart' ) ).not.toBeInTheDocument();
 	} );
 
+	it( 'renders a single metric as a static headline', () => {
+		render( <MetricTabsChart metrics={ [ METRIC ] } dataFormat={ DATA_FORMAT } /> );
+
+		expect( screen.getByText( 'Views' ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'tablist' ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'tab' ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders multiple metrics as tabs', () => {
+		const visitors = { ...METRIC, key: 'visitors', label: 'Visitors' };
+
+		render( <MetricTabsChart metrics={ [ METRIC, visitors ] } dataFormat={ DATA_FORMAT } /> );
+
+		expect( screen.getByRole( 'tablist' ) ).toBeInTheDocument();
+		expect( screen.getAllByRole( 'tab' ) ).toHaveLength( 2 );
+	} );
+
 	it( 'draws a bar chart when chartType is bar', () => {
 		render( <MetricTabsChart metrics={ [ METRIC ] } dataFormat={ DATA_FORMAT } chartType="bar" /> );
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/__tests__/metric-tabs-chart.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/__tests__/metric-tabs-chart.test.tsx
@@ -78,9 +78,13 @@ describe( 'MetricTabsChart', () => {
 	} );
 
 	it( 'renders a single metric as a static headline', () => {
-		render( <MetricTabsChart metrics={ [ METRIC ] } dataFormat={ DATA_FORMAT } /> );
+		const describedMetric = { ...METRIC, description: 'Total views for the selected period.' };
+
+		render( <MetricTabsChart metrics={ [ describedMetric ] } dataFormat={ DATA_FORMAT } /> );
 
 		expect( screen.getByText( 'Views' ) ).toBeInTheDocument();
+		expect( screen.getByText( describedMetric.description ) ).toBeInTheDocument();
+		expect( screen.queryByTitle( describedMetric.description ) ).not.toBeInTheDocument();
 		expect( screen.queryByRole( 'tablist' ) ).not.toBeInTheDocument();
 		expect( screen.queryByRole( 'tab' ) ).not.toBeInTheDocument();
 		expect( screen.queryByRole( 'button' ) ).not.toBeInTheDocument();

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.module.scss
@@ -25,13 +25,13 @@
 	gap: var(--wpds-dimension-gap-md);
 }
 
-/* The metric tab list: a row of equal-width cards (not a text tab bar), taking
- * the header width the controls leave. `overflow: visible` overrides the
- * toolkit tablist's horizontal scroll — the narrow case collapses to the
- * dropdown instead. */
+/* Equal-width cards fill the room left by the controls. The minimum keeps an
+ * xl value + delta readable; when every card cannot fit, grid restores the
+ * wrapping protection that flex-basis: 0 would otherwise remove. */
 .tabs {
-	display: flex;
+	display: grid;
 	flex: 1 1 auto;
+	grid-template-columns: repeat(auto-fit, minmax(min(100%, 180px), 1fr));
 	gap: var(--wpds-dimension-gap-sm);
 	min-width: 0;
 	overflow: visible;
@@ -69,13 +69,10 @@
 	text-align: start;
 }
 
-/* `flex-basis: 0` (over the tablist's `1 0 auto`) makes every card the same
- * width whatever its label, and keeps the row from overflowing — below
- * `MIN_TAB_WIDTH` per metric the component swaps in the dropdown instead. */
 .tab {
-	flex: 1 1 0;
 	height: auto;
 	min-width: 0;
+	overflow: hidden;
 	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-md);
 	border-radius: var(--wpds-border-radius-md);
 }
@@ -102,12 +99,12 @@
 	cursor: default;
 }
 
-.singleMetric .tab:hover,
-.singleMetric .tab[aria-selected="true"] {
+/* A static headline has no selected or hover state. */
+.singleMetric .tab:hover {
 	background-color: transparent;
 }
 
-/* Each tab's content: label stacked over the value + delta, left-aligned.
+/* Each tab's content: label stacked over the value + delta, start-aligned.
  * Growing to fill is what keeps it against the card's leading edge — the
  * tablist centres a tab's children, which shows as soon as a card is wider
  * than its text. */
@@ -118,11 +115,22 @@
 	gap: var(--wpds-dimension-gap-xs);
 	align-items: flex-start;
 	min-width: 0;
-	text-align: left;
+	text-align: start;
 }
 
 .tabLabel {
+	display: block;
+	max-width: 100%;
+	overflow: hidden;
 	color: var(--wpds-color-foreground-content-neutral-weak);
+	text-overflow: ellipsis;
+}
+
+/* Prefer moving the delta below the value over painting into the next card. */
+.metricComparison {
+	flex-wrap: wrap;
+	max-width: 100%;
+	min-width: 0;
 }
 
 /* Anchors the absolutely positioned loading overlay; fills the room left

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.module.scss
@@ -25,12 +25,13 @@
 	gap: var(--wpds-dimension-gap-md);
 }
 
-/* The metric tab list: a row of cards that wrap (not a text tab bar).
- * `overflow: visible` overrides the toolkit tablist's horizontal scroll —
- * the narrow case collapses to the dropdown instead. */
+/* The metric tab list: a row of equal-width cards (not a text tab bar), taking
+ * the header width the controls leave. `overflow: visible` overrides the
+ * toolkit tablist's horizontal scroll — the narrow case collapses to the
+ * dropdown instead. */
 .tabs {
 	display: flex;
-	flex-wrap: wrap;
+	flex: 1 1 auto;
 	gap: var(--wpds-dimension-gap-sm);
 	min-width: 0;
 	overflow: visible;
@@ -68,8 +69,13 @@
 	text-align: start;
 }
 
+/* `flex-basis: 0` (over the tablist's `1 0 auto`) makes every card the same
+ * width whatever its label, and keeps the row from overflowing — below
+ * `MIN_TAB_WIDTH` per metric the component swaps in the dropdown instead. */
 .tab {
+	flex: 1 1 0;
 	height: auto;
+	min-width: 0;
 	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-md);
 	border-radius: var(--wpds-border-radius-md);
 }
@@ -85,20 +91,33 @@
 	display: none;
 }
 
-.tab:hover {
-	background-color: var(--wpds-color-background-interactive-neutral-weak);
-}
-
+.tab:hover,
 .tab[aria-selected="true"] {
-	background-color: var(--wpds-color-background-interactive-neutral-weak-active);
+	background-color: var(--wpds-color-background-interactive-brand-weak-active);
 }
 
-/* Each tab's content: label stacked over the value + delta, left-aligned. */
+/* A lone metric has nothing to switch to: it reads as the widget's headline
+ * figure rather than a control, so it drops the card fill and the pointer. */
+.singleMetric .tab {
+	cursor: default;
+}
+
+.singleMetric .tab:hover,
+.singleMetric .tab[aria-selected="true"] {
+	background-color: transparent;
+}
+
+/* Each tab's content: label stacked over the value + delta, left-aligned.
+ * Growing to fill is what keeps it against the card's leading edge — the
+ * tablist centres a tab's children, which shows as soon as a card is wider
+ * than its text. */
 .tabContent {
 	display: flex;
+	flex: 1 1 auto;
 	flex-direction: column;
 	gap: var(--wpds-dimension-gap-xs);
 	align-items: flex-start;
+	min-width: 0;
 	text-align: left;
 }
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.module.scss
@@ -25,8 +25,8 @@
 	gap: var(--wpds-dimension-gap-md);
 }
 
-/* Equal-width cards fill the room left by the controls. The minimum keeps an
- * xl value + delta readable; when every card cannot fit, grid restores the
+/* Equal-width cards fill the room left by the controls. The minimum keeps a
+ * 2xl value + delta readable; when every card cannot fit, grid restores the
  * wrapping protection that flex-basis: 0 would otherwise remove. */
 .tabs {
 	display: grid;
@@ -54,7 +54,7 @@
  * rule sits in a low-priority @layer, so this unlayered override wins. */
 .metricSelect [class*="trigger-wrapper"] {
 	height: auto;
-	padding-block: var(--wpds-dimension-padding-sm);
+	padding-block: var(--wpds-dimension-padding-md);
 }
 
 /* Draw the focus ring inside the card; the default outset ring gets clipped
@@ -73,8 +73,8 @@
 	height: auto;
 	min-width: 0;
 	overflow: hidden;
-	padding: var(--wpds-dimension-padding-sm) var(--wpds-dimension-padding-md);
-	border-radius: var(--wpds-border-radius-md);
+	padding: var(--wpds-dimension-padding-md);
+	border-radius: var(--wpds-border-radius-lg);
 }
 
 /* Hide the selection underline; the card fill shows selection instead. Older
@@ -90,7 +90,7 @@
 
 .tab:hover,
 .tab[aria-selected="true"] {
-	background-color: var(--wpds-color-background-interactive-brand-weak-active);
+	background-color: var(--wpds-color-background-surface-brand);
 }
 
 /* A lone metric has nothing to switch to: it reads as the widget's headline
@@ -112,7 +112,7 @@
 	display: flex;
 	flex: 1 1 auto;
 	flex-direction: column;
-	gap: var(--wpds-dimension-gap-xs);
+	gap: var(--wpds-dimension-gap-sm);
 	align-items: flex-start;
 	min-width: 0;
 	text-align: start;
@@ -122,7 +122,6 @@
 	display: block;
 	max-width: 100%;
 	overflow: hidden;
-	color: var(--wpds-color-foreground-content-neutral-weak);
 	text-overflow: ellipsis;
 }
 

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { SelectControl, Tabs, Text } from '@jetpack-premium-analytics/externals';
+import { SelectControl, Tabs, Text, VisuallyHidden } from '@jetpack-premium-analytics/externals';
 import { formatDateRange } from '@jetpack-premium-analytics/formatters';
 import { useResizeObserver } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
@@ -266,16 +266,20 @@ export function MetricTabsChart( {
 			<div className={ styles.root }>
 				<div className={ styles.header }>
 					<div className={ clsx( styles.tabs, styles.singleMetric ) }>
-						<div className={ styles.tab } title={ activeMetric.description }>
+						<div className={ styles.tab }>
 							<span className={ styles.tabContent }>
 								<Text className={ styles.tabLabel }>{ activeMetric.label }</Text>
 								<MetricWithComparison
+									className={ styles.metricComparison }
 									value={ activeMetric.value }
 									previousValue={ activeMetric.previousValue }
 									dataFormat={ activeMetric.dataFormat ?? dataFormat }
 									direction="row"
 									align="flex-end"
 								/>
+								{ activeMetric.description && (
+									<VisuallyHidden>{ activeMetric.description }</VisuallyHidden>
+								) }
 							</span>
 						</div>
 					</div>
@@ -344,6 +348,7 @@ export function MetricTabsChart( {
 									<span className={ styles.tabContent }>
 										<Text className={ styles.tabLabel }>{ activeMetric.label }</Text>
 										<MetricWithComparison
+											className={ styles.metricComparison }
 											value={ activeMetric.value }
 											previousValue={ activeMetric.previousValue }
 											dataFormat={ activeMetric.dataFormat ?? dataFormat }
@@ -390,6 +395,7 @@ export function MetricTabsChart( {
 							<span className={ styles.tabContent }>
 								<Text className={ styles.tabLabel }>{ metric.label }</Text>
 								<MetricWithComparison
+									className={ styles.metricComparison }
 									value={ metric.value }
 									previousValue={ metric.previousValue }
 									dataFormat={ metric.dataFormat ?? dataFormat }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
@@ -5,6 +5,7 @@ import { SelectControl, Tabs, Text } from '@jetpack-premium-analytics/externals'
 import { formatDateRange } from '@jetpack-premium-analytics/formatters';
 import { useResizeObserver } from '@wordpress/compose';
 import { __ } from '@wordpress/i18n';
+import clsx from 'clsx';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 /**
  * Internal dependencies
@@ -346,7 +347,11 @@ export function MetricTabsChart( {
 			className={ styles.root }
 		>
 			<div className={ styles.header }>
-				<Tabs.List variant="minimal" className={ styles.tabs } aria-label={ groupLabel }>
+				<Tabs.List
+					variant="minimal"
+					className={ clsx( styles.tabs, metrics.length === 1 && styles.singleMetric ) }
+					aria-label={ groupLabel }
+				>
 					{ metrics.map( metric => (
 						<Tabs.Tab
 							key={ metric.key }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
@@ -261,6 +261,38 @@ export function MetricTabsChart( {
 		[ metrics ]
 	);
 
+	if ( metrics.length === 1 && activeMetric ) {
+		return (
+			<div className={ styles.root }>
+				<div className={ styles.header }>
+					<div className={ clsx( styles.tabs, styles.singleMetric ) }>
+						<div className={ styles.tab } title={ activeMetric.description }>
+							<span className={ styles.tabContent }>
+								<Text className={ styles.tabLabel }>{ activeMetric.label }</Text>
+								<MetricWithComparison
+									value={ activeMetric.value }
+									previousValue={ activeMetric.previousValue }
+									dataFormat={ activeMetric.dataFormat ?? dataFormat }
+									direction="row"
+									align="flex-end"
+								/>
+							</span>
+						</div>
+					</div>
+					{ controls }
+				</div>
+				<div className={ styles.chart }>
+					<MetricChart
+						metric={ activeMetric }
+						dataFormat={ dataFormat }
+						loading={ loading }
+						chartType={ chartType }
+					/>
+				</div>
+			</div>
+		);
+	}
+
 	if ( useDropdown ) {
 		// `value` must be a reference into `metricItems` for the select to match it.
 		const activeItem =
@@ -347,11 +379,7 @@ export function MetricTabsChart( {
 			className={ styles.root }
 		>
 			<div className={ styles.header }>
-				<Tabs.List
-					variant="minimal"
-					className={ clsx( styles.tabs, metrics.length === 1 && styles.singleMetric ) }
-					aria-label={ groupLabel }
-				>
+				<Tabs.List variant="minimal" className={ styles.tabs } aria-label={ groupLabel }>
 					{ metrics.map( metric => (
 						<Tabs.Tab
 							key={ metric.key }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/metric-tabs-chart.tsx
@@ -274,6 +274,7 @@ export function MetricTabsChart( {
 									value={ activeMetric.value }
 									previousValue={ activeMetric.previousValue }
 									dataFormat={ activeMetric.dataFormat ?? dataFormat }
+									fontSize="2xl"
 									direction="row"
 									align="flex-end"
 								/>
@@ -399,6 +400,7 @@ export function MetricTabsChart( {
 									value={ metric.value }
 									previousValue={ metric.previousValue }
 									dataFormat={ metric.dataFormat ?? dataFormat }
+									fontSize="2xl"
 									direction="row"
 									align="flex-end"
 								/>

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/stories/metric-tabs-chart.stories.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/metric-tabs-chart/stories/metric-tabs-chart.stories.tsx
@@ -90,6 +90,8 @@ export const Default: Story = {
 
 /**
  * A single metric with no previous period — just the current line, no delta.
+ * With nothing to switch to, the card drops its fill and pointer and reads as
+ * the widget's headline figure.
  */
 export const SingleMetric: Story = {
 	args: {


### PR DESCRIPTION
## Proposed changes

Aligns the summary charts' metric cards with the prototype.

- Spread the cards evenly across the widget width instead of shrink-wrapping to their labels.
- Tint the hovered/selected card with the brand colour instead of neutral grey.
- Render a lone metric as a static headline — no fill, no pointer — since there is nothing to switch to.

## Related product discussion/links

- WOOA7S-1898

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Storybook — `Packages/Premium Analytics/Widgets Toolkit/Components/MetricTabsChart`:

- `Default`: cards are equal width and span the frame; the selected one is tinted blue, and hover shows the same tint.
- `SingleMetric`: no fill, no pointer cursor, and hovering does nothing.


https://github.com/user-attachments/assets/8a5c5628-eb48-498d-b487-d7774007b1cf


Stats v2 dashboard — **Traffic** tab:

- **Traffic summary**: Views / Visitors / Likes / Comments should be equal width across the widget, selected card tinted blue.
- Open the widget's **Metrics** dropdown and leave only one metric selected — the remaining card should lose its fill and pointer cursor.
- Drag the tile down to one column: below ~120px per metric the cards still collapse into the dropdown, unchanged.

Stats v2 dashboard — **Subscribers** tab:

- **Subscribers summary** has a single metric on a site with no paid subscribers, so it should show the same static treatment.

https://github.com/user-attachments/assets/d55c566d-4240-4639-85d0-5685e29d9b8b

