### PR TITLE
Add CODEOWNERS entry for the Boost plugin

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -71,6 +71,7 @@
 # Plugins
 
 /projects/plugins/premium-analytics @Automattic/jetpack-stats 
+/projects/plugins/boost @Automattic/jetpack-boost
 
 # Functionality that is important to our partners
 /projects/plugins/jetpack/class.jetpack-cli.php @Automattic/jetpack-infinity


### PR DESCRIPTION
## Proposed changes

* Assign `/projects/plugins/boost` to `@Automattic/jetpack-boost`, the new feature-area GitHub team, in the `# Plugins` section of CODEOWNERS.

Boost previously had no CODEOWNERS entry, and its former owning teams (Heart of Gold, Vulcan) no longer exist or no longer own it. This follows the same pattern as #51099 (Jetpack Performance / Jetpack Stats): feature-specific GitHub teams whose membership can be maintained without changing CODEOWNERS rules.

## Related product discussion/links

* Jetpack team-disband audit.
* #51099

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Confirm `/projects/plugins/boost` is owned by `@Automattic/jetpack-boost`.
* Confirm GitHub reports no CODEOWNERS errors for this branch.