### PR TITLE
jetpack-mu-wpcom: Remove Classic block deprecation related stickers and filters

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-classic-block-deprecation-stickers-and-filters
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-classic-block-deprecation-stickers-and-filters
@@ -1,0 +1,4 @@
+Significance: patch
+Type: removed
+
+Remove the Classic block deprecation experiment and the Classic block inserter support sticker, since the deprecation was removed from Gutenberg.

--- a/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
+++ b/projects/packages/jetpack-mu-wpcom/src/class-jetpack-mu-wpcom.php
@@ -99,16 +99,6 @@ class Jetpack_Mu_Wpcom {
 		// Filter to populate JetpackScriptData.site.wpcom.blog_id with the actual WP.com blog ID.
 		add_filter( 'jetpack_admin_js_script_data', array( __CLASS__, 'set_wpcom_blog_id_script_data' ), 10, 1 );
 
-		// Allow sites with the `classic-block-inserter-support` blog sticker to insert the Classic block.
-		if ( wpcom_has_blog_sticker( 'classic-block-inserter-support', get_wpcom_blog_id() ) ) {
-			add_filter( 'wp_classic_block_supports_inserter', '__return_true' );
-		}
-
-		// Enable the `gutenberg-classic-block-deprecation` Gutenberg experiment for all sites, with an opt-out via the `disable-classic-block-deprecation` blog sticker.
-		// Both filters are needed: `default_option_` fires when the option doesn't exist in the DB, `option_` fires when it does.
-		add_filter( 'option_gutenberg-experiments', array( __CLASS__, 'enable_gutenberg_classic_block_deprecation_experiment' ) );
-		add_filter( 'default_option_gutenberg-experiments', array( __CLASS__, 'enable_gutenberg_classic_block_deprecation_experiment' ) );
-
 		// Enable the `gutenberg-react-19` Gutenberg experiment on selected sites.
 		add_filter( 'option_gutenberg-experiments', array( __CLASS__, 'enable_gutenberg_react_19_experiment' ) );
 		add_filter( 'default_option_gutenberg-experiments', array( __CLASS__, 'enable_gutenberg_react_19_experiment' ) );
@@ -849,26 +839,6 @@ class Jetpack_Mu_Wpcom {
 			$data['site']['wpcom']['blog_id'] = $blog_id;
 		}
 		return $data;
-	}
-
-	/**
-	 * Add `gutenberg-classic-block-deprecation` to the list of enabled Gutenberg experiments.
-	 * Skip sites that have the `disable-classic-block-deprecation` sticker enabled.
-	 *
-	 * @param mixed $experiments The current value of the gutenberg-experiments option.
-	 * @return mixed Original option value or the filtered experiments.
-	 */
-	public static function enable_gutenberg_classic_block_deprecation_experiment( $experiments ) {
-		if ( wpcom_has_blog_sticker( 'disable-classic-block-deprecation', get_wpcom_blog_id() ) ) {
-			return $experiments;
-		}
-
-		if ( ! is_array( $experiments ) ) {
-			$experiments = array();
-		}
-
-		$experiments['gutenberg-classic-block-deprecation'] = true;
-		return $experiments;
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

The Classic block deprecation was reverted in Gutenberg, so the code we added for it in `jetpack-mu-wpcom` is no longer needed. This PR removes it.

* Remove the `gutenberg-classic-block-deprecation` experiment filters and the `enable_gutenberg_classic_block_deprecation_experiment()` method. This also removes the `disable-classic-block-deprecation` sticker opt-out.
* Remove the `classic-block-inserter-support` sticker check and the `wp_classic_block_supports_inserter` filter.

## Related product discussion/links

https://github.com/WordPress/gutenberg/pull/79894

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions

* Review code changes.
