### PR TITLE
Connection Health: Surface blocked WP.com requests as a Connection error

### DIFF
--- a/projects/packages/connection/changelog/update-jp-connect-blocked-xmlrpc-visibility
+++ b/projects/packages/connection/changelog/update-jp-connect-blocked-xmlrpc-visibility
@@ -1,4 +1,4 @@
 Significance: minor
 Type: added
 
-Connection Health: surface the blocked-request connection failure (host blocking WordPress.com requests) as a verified connection error with an admin notice, and re-check the connection daily on the heartbeat cron.
+Connection Health: Surface the blocked-request connection failure (host blocking WordPress.com requests) as a verified connection error with an admin notice, and re-check the connection daily on the heartbeat cron.

--- a/projects/packages/connection/changelog/update-jp-connect-blocked-xmlrpc-visibility
+++ b/projects/packages/connection/changelog/update-jp-connect-blocked-xmlrpc-visibility
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Connection Health: surface the blocked-request connection failure (host blocking WordPress.com requests) as a verified connection error with an admin notice, and re-check the connection daily on the heartbeat cron.

--- a/projects/packages/connection/docs/connection-health-tests.md
+++ b/projects/packages/connection/docs/connection-health-tests.md
@@ -37,7 +37,7 @@ Extends `Connection_Health_Test_Base` with all the connection-specific tests. It
 | `test__outbound_https` | Outbound HTTPS requests work |
 | `test__identity_crisis` | No URL mismatch with WordPress.com |
 | `test__connection_token_health` | Connection tokens are valid |
-| `test__wpcom_connection_test` | WordPress.com can reach the site |
+| `test__wpcom_connection_test` | WordPress.com can reach the site. Also keeps the `xmlrpc_request_blocked` connection error in sync: a blocked result reports it, a passing result clears it (see [error handling](error-handling.md)) |
 | `test__server_port_value` | Server port is standard |
 | `test__xml_parser_available` | PHP XML extension is available |
 
@@ -48,10 +48,12 @@ Integrates the health tests into WordPress Site Health. It:
 - Registers each `direct` test as a Site Health direct test (runs on page load).
 - Registers an async test suite entry (`jetpack-connection-health`) with a corresponding AJAX handler.
 - Defers to the legacy Jetpack debugger when an old Jetpack version is active (detected via `has_filter( 'site_status_tests', 'jetpack_debugger_site_status_tests' )`).
+- Runs `test__wpcom_connection_test` once a day via `do_daily_connection_check()` on the `jetpack_heartbeat` cron action, so the `xmlrpc_request_blocked` connection error stays fresh while the condition persists and clears within a day of it being resolved. The hook is deliberately the cron-only `jetpack_heartbeat` action, not `jetpack_heartbeat_stats_array`, which also fires in synchronous request contexts (XML-RPC, REST, WP-CLI) where a remote test would be slow and an amplification vector.
 
 ## When tests run
 
 - **Site Health page** (`/wp-admin/site-health.php`): Direct tests run synchronously on page load. The async test suite runs via an AJAX request after the page loads.
+- **Cron**: Core's weekly `wp_site_health_scheduled_check` event runs all direct tests (this feeds the dashboard "Site Health Status" widget counts). The daily `jetpack_v2_heartbeat` event runs `test__wpcom_connection_test` only, via `Site_Health::do_daily_connection_check()`.
 - **WP-CLI**: Tests can be run programmatically via `$tests = new Connection_Health_Tests(); $tests->output_results_for_cli();`.
 - **REST API / other consumers**: Instantiate `Connection_Health_Tests` and call `run_test()`, `pass()`, or `output_fails_as_wp_error()` as needed.
 
@@ -203,8 +205,8 @@ return self::connection_failing_test(
 The framework and individual tests are covered by PHPUnit tests in `tests/php/`:
 
 - **`Connection_Health_Test_Base_Test.php`** — Tests the base framework: test registration, execution, result helpers, output methods, encryption, filters, and the subclass extension pattern.
-- **`Connection_Health_Tests_Test.php`** — Tests individual health test methods: verifies skipped/pass/fail paths for each built-in test using partial mocks for helper methods.
-- **`Site_Health_Test.php`** — Tests Site Health integration: registration, legacy Jetpack detection, direct test callback invocation, and AJAX action registration.
+- **`Connection_Health_Tests_Test.php`** — Tests individual health test methods: verifies skipped/pass/fail paths for each built-in test using partial mocks for helper methods, including the reporting/clearing of the `xmlrpc_request_blocked` connection error by the WP.com connection test.
+- **`Site_Health_Test.php`** — Tests Site Health integration: registration, legacy Jetpack detection, direct test callback invocation, AJAX action registration, and the daily heartbeat check wiring.
 
 Run the tests from the package directory:
 

--- a/projects/packages/connection/docs/error-handling.md
+++ b/projects/packages/connection/docs/error-handling.md
@@ -25,7 +25,10 @@ Note: XML-RPC faults arrive as HTTP 200 responses with an XML body, so they are 
 
 ### Connection-state errors
 
-Some errors describe broken local state rather than a failed request — for example `invalid_connection_owner`, reported by `Manager::get_connection_owner()` when the connection owner cannot be resolved (missing owner token, or the owner's WP user was deleted). These are stored with `error_type` set to `local_state` and are reported with `report_error()` skipping the WordPress.com round-trip: the evidence is the site's own database, so there is nothing for WordPress.com to confirm.
+Some errors describe a broken connection state that a successful outgoing request cannot disprove, rather than an individual failed request. These are stored with `error_type` set to `local_state` and are reported with `report_error()` skipping the WordPress.com round-trip, because the error is self-evidencing:
+
+* `invalid_connection_owner` — reported by `Manager::get_connection_owner()` when the connection owner cannot be resolved (missing owner token, or the owner's WP user was deleted). The evidence is the site's own database.
+* `xmlrpc_request_blocked` — reported by the connection health tests (`Connection_Health_Tests::evaluate_wpcom_connection_result()`) when WordPress.com reports that its request to the site was rejected (firewall, WAF, or server rule blocking `xmlrpc.php`). The evidence is WordPress.com's response to a signed request this site initiated. This error is invisible to both request flows above — the failing incoming requests never arrive, and outgoing requests keep succeeding — which is exactly why the health test reports it explicitly.
 
 ## Error classification
 
@@ -33,7 +36,7 @@ Each stored error carries two orthogonal classification fields:
 
 | Field | Values | Meaning |
 |---|---|---|
-| `error_type` | `xmlrpc`, `rest`, `local_state`, `''` | The transport of the failed request; `local_state` marks connection-state errors that involve no request (stored as `connection` by package versions ≤ 8.8); `''` appears on entries stored by older package versions. |
+| `error_type` | `xmlrpc`, `rest`, `local_state`, `''` | The transport of the failed request; `local_state` marks connection-state errors that a successful outgoing request cannot disprove (stored as `connection` by package versions ≤ 8.8); `''` appears on entries stored by older package versions. |
 | `error_direction` | `incoming`, `outgoing`, `''` | Whether the failed request was made to the site or by the site; `''` appears on legacy entries and `local_state`-type errors, which have no direction — the error factory discards any direction passed for them. |
 
 ## Supported error codes
@@ -43,7 +46,7 @@ Only a fixed list of error codes is handled: the `Error_Handler::$known_errors` 
 * **Incoming request token problems** — the token in the incoming request is malformed or references an unknown user (e.g. `malformed_token`, `unknown_user`).
 * **Locally stored token problems** — the token stored on this site is missing or corrupt (e.g. `no_user_tokens`, `token_malformed`, `no_valid_blog_token`).
 * **Signature problems** — signing or signature verification failed, either for an incoming request or reported by WordPress.com for an outgoing one (e.g. `invalid_token`, `signature_mismatch`, `invalid_nonce`).
-* **Connection state problems** — local connection state is broken (`invalid_connection_owner`).
+* **Connection state problems** — the connection state is broken in a way requests can't disprove (`invalid_connection_owner`, `xmlrpc_request_blocked`).
 
 If WordPress.com starts returning a new error code, it will be invisible to this system until the code is added to the allowlist. When debugging missing errors, check the response body against this list first (see [Debugging](#debugging)).
 
@@ -98,9 +101,11 @@ Storage limits and hygiene:
 
 Verified, displayable errors are surfaced on admin pages through `handle_verified_errors()`: a generic admin notice, and an entry in the React dashboard's initial state. Only a subset of error codes is user-displayable (see `get_displayable_errors()`), and each displayable error is classified by audience — `site` (blog token), `owner` (the connection owner's token), or `user` (another user's token) — so consumers can render viewer-appropriate copy.
 
+Most displayable errors share a default presentation: generic "please reconnect" copy with a reconnect CTA. Error codes that need to deviate — different copy, a suppressed CTA, or a default admin notice — are declared in the `get_error_display_config()` table inside `Error_Handler`, so adding a special code is one entry rather than new branches in the display paths. Copy is always resolved at display time (never stored with the error), so messages follow the viewer's locale and stay current across package updates. Currently `xmlrpc_request_blocked` is the only entry: reconnecting would be rejected by the same firewall rule that broke the connection, so its message names the real cause, suppresses the reconnect CTA, and directs the user to Site Health.
+
 ### Enabling the error message
 
-By default, no admin notice text is shown. To enable it, use the `jetpack_connection_error_notice_message` filter. The second argument is an array with the details of all the errors (if more than one).
+By default, no admin notice text is shown — except for error codes whose [display config](#displaying-errors) opts into a default message (currently `xmlrpc_request_blocked`, which would otherwise be invisible outside Site Health). To enable text for other errors, or to override a default, use the `jetpack_connection_error_notice_message` filter. The second argument is an array with the details of all the errors (if more than one).
 
 This basic example shows how to display a simple error message no matter the specific error type:
 
@@ -185,7 +190,9 @@ Check [the class file](../src/class-error-handler.php) for further documentation
 
 ## When errors are cleared
 
-Stored errors are deleted automatically when the connection is restored or torn down — on site registration, reconnection, disconnection, token deletion, user unlink, and user-token update. Additionally, a successful API request (`jetpack_get_site_data_success`) clears all `xmlrpc` and `rest` type errors via `delete_all_api_errors()`; `local_state`-type errors are deliberately kept there, because a successful API round-trip refutes token/signature problems but says nothing about local state such as a missing connection owner.
+Stored errors are deleted automatically when the connection is restored or torn down — on site registration, reconnection, disconnection, token deletion, user unlink, and user-token update. Additionally, a successful API request (`jetpack_get_site_data_success`) clears all `xmlrpc` and `rest` type errors via `delete_all_api_errors()`; `local_state`-type errors are deliberately kept there, because a successful API round-trip refutes token/signature problems but says nothing about state such as a missing connection owner or WordPress.com being blocked from reaching the site.
+
+`local_state` errors are instead cleared by whatever detects their condition. For `xmlrpc_request_blocked`, a passing WP.com connection test deletes the error via `delete_error_by_code()`; the test runs on Site Health page loads, Core's weekly Site Health cron, and a daily check on the `jetpack_heartbeat` cron (see the [connection health tests doc](connection-health-tests.md)), so the error both stays fresh while the blockage persists and clears within a day of the host resolving it. As a safety net, all errors expire 24 hours after they were last stored.
 
 ## Debugging
 

--- a/projects/packages/connection/docs/error-handling.md
+++ b/projects/packages/connection/docs/error-handling.md
@@ -101,7 +101,12 @@ Storage limits and hygiene:
 
 Verified, displayable errors are surfaced on admin pages through `handle_verified_errors()`: a generic admin notice, and an entry in the React dashboard's initial state. Only a subset of error codes is user-displayable (see `get_displayable_errors()`), and each displayable error is classified by audience — `site` (blog token), `owner` (the connection owner's token), or `user` (another user's token) — so consumers can render viewer-appropriate copy.
 
-Most displayable errors share a default presentation: generic "please reconnect" copy with a reconnect CTA. Error codes that need to deviate — different copy, a suppressed CTA, or a default admin notice — are declared in the `get_error_display_config()` table inside `Error_Handler`, so adding a special code is one entry rather than new branches in the display paths. Copy is always resolved at display time (never stored with the error), so messages follow the viewer's locale and stay current across package updates. Currently `xmlrpc_request_blocked` is the only entry: reconnecting would be rejected by the same firewall rule that broke the connection, so its message names the real cause, suppresses the reconnect CTA, and directs the user to Site Health.
+Most displayable errors share a default presentation: generic "please reconnect" copy with a reconnect CTA. Deviations split by their nature:
+
+* **The action** is declared by the *reporter* at creation time, stored in `error_data['action']` (e.g. `'none'` to suppress the reconnect CTA — readers treat a missing action as `'reconnect'`). It's a stable, locale-independent machine token, so storing it is safe, and this matches how consumer-injected errors already carry their actions (see `build_action_error_data()`).
+* **Display-time state** — custom copy, a default admin notice, or an action link on that notice — is declared in the `get_error_display_config()` table inside `Error_Handler`. Copy cannot be stored with the error: it must resolve in each viewer's locale (errors are often reported from cron, where there is no viewer) and follow current code rather than what was stored up to a day ago.
+
+Currently `xmlrpc_request_blocked` is the only special code: reconnecting would be rejected by the same firewall rule that broke the connection, so its reporter stores `action => 'none'`, and its (deliberately brief) display message names the real cause and points at Site Health — the source of truth with the detailed diagnosis — which the admin notice also links to.
 
 ### Enabling the error message
 

--- a/projects/packages/connection/src/class-error-handler.php
+++ b/projects/packages/connection/src/class-error-handler.php
@@ -342,21 +342,14 @@ class Error_Handler {
 					$message = __( "Your connection with WordPress.com seems to be broken. If you're experiencing issues, please try reconnecting.", 'jetpack-connection' );
 					$action  = null;
 
-					// The site itself is rejecting WordPress.com's requests (firewall, WAF,
-					// security plugin, or server rule). The token could be perfectly valid,
-					// so a reconnect would be rejected the same way — surface the real cause
-					// and point at Site Health, which re-runs the check on page load.
-					if ( 'xmlrpc_request_blocked' === $error_code ) {
-						$site_http_status = isset( $error['error_data']['site_http_status'] ) ? (int) $error['error_data']['site_http_status'] : 0;
-
-						$message = $site_http_status
-							? sprintf(
-								/* translators: %d is the HTTP status code (e.g. 403) the site returned to WordPress.com. */
-								__( 'WordPress.com is unable to communicate with your site: requests are being blocked (HTTP %d), usually by a firewall, security plugin, or server rule. Reconnecting will not fix this. Ask your host to allow requests from WordPress.com to your site\'s xmlrpc.php file, then confirm the fix on your site\'s Site Health page.', 'jetpack-connection' ),
-								$site_http_status
-							)
-							: __( 'WordPress.com is unable to communicate with your site: requests are being blocked, usually by a firewall, security plugin, or server rule. Reconnecting will not fix this. Ask your host to allow requests from WordPress.com to your site\'s xmlrpc.php file, then confirm the fix on your site\'s Site Health page.', 'jetpack-connection' );
-						$action = 'none';
+					$display_config = $this->get_error_display_config( $error_code );
+					if ( $display_config ) {
+						if ( isset( $display_config['message_callback'] ) ) {
+							$message = call_user_func( $display_config['message_callback'], $error );
+						}
+						if ( isset( $display_config['action'] ) ) {
+							$action = $display_config['action'];
+						}
 					}
 
 					// A secondary admin looking at the connection owner's token error, on a
@@ -437,6 +430,69 @@ class Error_Handler {
 		}
 
 		return $displayable_errors;
+	}
+
+	/**
+	 * Returns the display configuration for error codes that deviate from the default
+	 * presentation (generic "please reconnect" copy with a reconnect CTA).
+	 *
+	 * Copy is resolved at display time rather than stored with the error, so messages
+	 * follow the viewer's locale and stay current across package updates. Adding a new
+	 * special error code means adding one entry here — no branching in the display or
+	 * notice paths.
+	 *
+	 * Recognized keys, all optional:
+	 * - `message_callback` (callable): receives the stored error array, returns the
+	 *   displayable message. Omit to keep the generic reconnect copy.
+	 * - `action` (string): value for `error_data['action']`, e.g. 'none' to suppress
+	 *   the reconnect CTA. Omit to keep the default reconnect behavior.
+	 * - `default_admin_notice` (bool): when true, generic_admin_notice_error() shows
+	 *   this error's message even when no consumer supplies one via the
+	 *   `jetpack_connection_error_notice_message` filter (which still overrides).
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $error_code The error code.
+	 * @return array|null Display configuration, or null for the default presentation.
+	 */
+	private function get_error_display_config( $error_code ) {
+		$config = array(
+			// The site itself is rejecting WordPress.com's requests (firewall, WAF,
+			// security plugin, or server rule). The token could be perfectly valid, so
+			// a reconnect would be rejected the same way: suppress the reconnect CTA
+			// and surface the real cause. Ships a default admin notice because this
+			// error is invisible to every other detection path — WP.com's requests
+			// never reach the site.
+			'xmlrpc_request_blocked' => array(
+				'message_callback'     => array( $this, 'get_blocked_request_message' ),
+				'action'               => 'none',
+				'default_admin_notice' => true,
+			),
+		);
+
+		return $config[ $error_code ] ?? null;
+	}
+
+	/**
+	 * Builds the displayable message for the blocked-request error.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array $error The stored error array.
+	 * @return string The message.
+	 */
+	private function get_blocked_request_message( $error ) {
+		$site_http_status = isset( $error['error_data']['site_http_status'] ) ? (int) $error['error_data']['site_http_status'] : 0;
+
+		if ( $site_http_status ) {
+			return sprintf(
+				/* translators: %d is the HTTP status code (e.g. 403) the site returned to WordPress.com. */
+				__( 'WordPress.com is unable to communicate with your site: requests are being blocked (HTTP %d), usually by a firewall, security plugin, or server rule. Reconnecting will not fix this. Ask your host to allow requests from WordPress.com to your site\'s xmlrpc.php file, then confirm the fix on your site\'s Site Health page.', 'jetpack-connection' ),
+				$site_http_status
+			);
+		}
+
+		return __( 'WordPress.com is unable to communicate with your site: requests are being blocked, usually by a firewall, security plugin, or server rule. Reconnecting will not fix this. Ask your host to allow requests from WordPress.com to your site\'s xmlrpc.php file, then confirm the fix on your site\'s Site Health page.', 'jetpack-connection' );
 	}
 
 	/**
@@ -1368,15 +1424,19 @@ class Error_Handler {
 		$displayable_errors = $this->get_displayable_errors();
 
 		// Most errors default to no admin notice — consumers opt in via the filter
-		// below, and the React dashboard is the primary surface. The blocked-request
-		// error is the exception: it is invisible to the dashboard's own error
-		// detection paths (WP.com cannot reach the site), so it ships with a
-		// default message and does not depend on a consumer supplying one.
+		// below, and the React dashboard is the primary surface. Error codes whose
+		// display config sets `default_admin_notice` provide their own message and
+		// do not depend on a consumer supplying one.
 		$default_message = '';
-		if ( isset( $displayable_errors['xmlrpc_request_blocked'] ) ) {
-			$first_blocked_error = reset( $displayable_errors['xmlrpc_request_blocked'] );
-			if ( is_array( $first_blocked_error ) && ! empty( $first_blocked_error['error_message'] ) ) {
-				$default_message = $first_blocked_error['error_message'];
+		foreach ( $displayable_errors as $error_code => $user_errors ) {
+			$display_config = $this->get_error_display_config( $error_code );
+			if ( empty( $display_config['default_admin_notice'] ) ) {
+				continue;
+			}
+			$first_error = reset( $user_errors );
+			if ( is_array( $first_error ) && ! empty( $first_error['error_message'] ) ) {
+				$default_message = $first_error['error_message'];
+				break;
 			}
 		}
 
@@ -1405,7 +1465,7 @@ class Error_Handler {
 		 *
 		 * @param array $errors The array of errors. See Automattic\Jetpack\Connection\Error_Handler for details on the array structure.
 		 */
-		do_action( 'jetpack_connection_error_notice', $this->get_displayable_errors() );
+		do_action( 'jetpack_connection_error_notice', $displayable_errors );
 
 		if ( empty( $message ) ) {
 			return;

--- a/projects/packages/connection/src/class-error-handler.php
+++ b/projects/packages/connection/src/class-error-handler.php
@@ -38,9 +38,10 @@ namespace Automattic\Jetpack\Connection;
  * Stored errors carry two orthogonal classification fields:
  *
  * - `error_type` — the transport/source of the failed request: 'xmlrpc', 'rest',
- *   'local_state' (local connection-state errors involving no request at all, e.g.
- *   `invalid_connection_owner`; stored as 'connection' by package versions <= 8.8),
- *   or '' for entries stored by older package versions.
+ *   'local_state' (connection-state errors that a successful outgoing request cannot
+ *   disprove — e.g. `invalid_connection_owner`, or WP.com being blocked from reaching
+ *   this site; stored as 'connection' by package versions <= 8.8), or '' for entries
+ *   stored by older package versions.
  * - `error_direction` — 'incoming', 'outgoing', or '' (legacy entries and
  *   'local_state'-type errors, which have no direction).
  *
@@ -203,8 +204,9 @@ class Error_Handler {
 		'invalid_body_hash',         // The body hash doesn't match the request body.
 		'invalid_nonce',             // The request nonce could not be added (likely a reuse/replay).
 		'signature_mismatch',        // Computed signature differs: wrong secret, or URL/body drift (domain change, proxy).
-		// Connection state problems (Manager::get_connection_owner).
+		// Connection state problems (Manager::get_connection_owner, Connection_Health_Tests).
 		'invalid_connection_owner',  // The connection owner cannot be resolved: token missing or WP user deleted.
+		'xmlrpc_request_blocked',    // WP.com reached the site but the request was rejected (firewall, WAF, or server rule).
 	);
 
 	/**
@@ -315,6 +317,7 @@ class Error_Handler {
 				'signature_mismatch',
 				'no_token_for_user',
 				'invalid_connection_owner',
+				'xmlrpc_request_blocked',
 			);
 
 			$owner_id        = (int) \Jetpack_Options::get_option( 'master_user' );
@@ -338,6 +341,23 @@ class Error_Handler {
 
 					$message = __( "Your connection with WordPress.com seems to be broken. If you're experiencing issues, please try reconnecting.", 'jetpack-connection' );
 					$action  = null;
+
+					// The site itself is rejecting WordPress.com's requests (firewall, WAF,
+					// security plugin, or server rule). The token could be perfectly valid,
+					// so a reconnect would be rejected the same way — surface the real cause
+					// and point at Site Health, which re-runs the check on page load.
+					if ( 'xmlrpc_request_blocked' === $error_code ) {
+						$site_http_status = isset( $error['error_data']['site_http_status'] ) ? (int) $error['error_data']['site_http_status'] : 0;
+
+						$message = $site_http_status
+							? sprintf(
+								/* translators: %d is the HTTP status code (e.g. 403) the site returned to WordPress.com. */
+								__( 'WordPress.com is unable to communicate with your site: requests are being blocked (HTTP %d), usually by a firewall, security plugin, or server rule. Reconnecting will not fix this. Ask your host to allow requests from WordPress.com to your site\'s xmlrpc.php file, then confirm the fix on your site\'s Site Health page.', 'jetpack-connection' ),
+								$site_http_status
+							)
+							: __( 'WordPress.com is unable to communicate with your site: requests are being blocked, usually by a firewall, security plugin, or server rule. Reconnecting will not fix this. Ask your host to allow requests from WordPress.com to your site\'s xmlrpc.php file, then confirm the fix on your site\'s Site Health page.', 'jetpack-connection' );
+						$action = 'none';
+					}
 
 					// A secondary admin looking at the connection owner's token error, on a
 					// site where ownership is locked (a consumer declared it non-transferable).
@@ -925,6 +945,12 @@ class Error_Handler {
 			$error_data['has_user_token'] = (bool) $data['has_user_token'];
 		}
 
+		// For xmlrpc_request_blocked, the HTTP status the site returned to WP.com
+		// (e.g. 403). Keep it so display code can include it in the message.
+		if ( isset( $data['site_http_status'] ) ) {
+			$error_data['site_http_status'] = (int) $data['site_http_status'];
+		}
+
 		return $this->build_error_array(
 			$error->get_error_code(),
 			$error->get_error_message(),
@@ -1185,6 +1211,50 @@ class Error_Handler {
 	}
 
 	/**
+	 * Deletes all stored and verified errors for a single error code.
+	 *
+	 * Used by self-healing flows that can positively confirm one specific error
+	 * condition is gone (e.g. a passing connection test clearing
+	 * `xmlrpc_request_blocked`) without touching unrelated errors.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param string $error_code The error code to delete.
+	 * @return bool True if any stored or verified error was deleted.
+	 */
+	public function delete_error_by_code( $error_code ) {
+		$deleted = false;
+
+		$stored_errors = $this->get_stored_errors();
+		if ( isset( $stored_errors[ $error_code ] ) ) {
+			unset( $stored_errors[ $error_code ] );
+			$deleted = true;
+			if ( count( $stored_errors ) ) {
+				update_option( self::STORED_ERRORS_OPTION, $stored_errors );
+			} else {
+				delete_option( self::STORED_ERRORS_OPTION );
+			}
+		}
+
+		$verified_errors = $this->get_verified_errors();
+		if ( isset( $verified_errors[ $error_code ] ) ) {
+			unset( $verified_errors[ $error_code ] );
+			$deleted = true;
+			if ( count( $verified_errors ) ) {
+				update_option( self::STORED_VERIFIED_ERRORS_OPTION, $verified_errors );
+			} else {
+				delete_option( self::STORED_VERIFIED_ERRORS_OPTION );
+			}
+		}
+
+		if ( $deleted ) {
+			$this->invalidate_displayable_errors_cache();
+		}
+
+		return $deleted;
+	}
+
+	/**
 	 * Gets an error based on the nonce
 	 *
 	 * Receives a nonce and finds the related error.
@@ -1295,19 +1365,36 @@ class Error_Handler {
 			return;
 		}
 
+		$displayable_errors = $this->get_displayable_errors();
+
+		// Most errors default to no admin notice — consumers opt in via the filter
+		// below, and the React dashboard is the primary surface. The blocked-request
+		// error is the exception: it is invisible to the dashboard's own error
+		// detection paths (WP.com cannot reach the site), so it ships with a
+		// default message and does not depend on a consumer supplying one.
+		$default_message = '';
+		if ( isset( $displayable_errors['xmlrpc_request_blocked'] ) ) {
+			$first_blocked_error = reset( $displayable_errors['xmlrpc_request_blocked'] );
+			if ( is_array( $first_blocked_error ) && ! empty( $first_blocked_error['error_message'] ) ) {
+				$default_message = $first_blocked_error['error_message'];
+			}
+		}
+
 		/**
 		 * Filters the message to be displayed in the admin notices area when there's a connection error.
 		 *
-		 * By default  we don't display any errors.
+		 * By default we don't display any errors, except for the blocked-request error
+		 * (`xmlrpc_request_blocked`), which provides its own default message.
 		 *
 		 * Return an empty value to disable the message.
 		 *
 		 * @since 8.9.0
+		 * @since $$next-version$$ The default message is no longer always empty.
 		 *
 		 * @param string $message The error message.
 		 * @param array  $errors The array of errors. See Automattic\Jetpack\Connection\Error_Handler for details on the array structure.
 		 */
-		$message = apply_filters( 'jetpack_connection_error_notice_message', '', $this->get_displayable_errors() );
+		$message = apply_filters( 'jetpack_connection_error_notice_message', $default_message, $displayable_errors );
 
 		/**
 		 * Fires inside the admin_notices hook just before displaying the error message for a broken connection.

--- a/projects/packages/connection/src/class-error-handler.php
+++ b/projects/packages/connection/src/class-error-handler.php
@@ -343,13 +343,8 @@ class Error_Handler {
 					$action  = null;
 
 					$display_config = $this->get_error_display_config( $error_code );
-					if ( $display_config ) {
-						if ( isset( $display_config['message_callback'] ) ) {
-							$message = call_user_func( $display_config['message_callback'], $error );
-						}
-						if ( isset( $display_config['action'] ) ) {
-							$action = $display_config['action'];
-						}
+					if ( $display_config && isset( $display_config['message_callback'] ) ) {
+						$message = call_user_func( $display_config['message_callback'], $error );
 					}
 
 					// A secondary admin looking at the connection owner's token error, on a
@@ -441,14 +436,22 @@ class Error_Handler {
 	 * special error code means adding one entry here — no branching in the display or
 	 * notice paths.
 	 *
+	 * Everything here is display-time state that cannot be stored with the error:
+	 * copy must resolve in each viewer's locale and follow current code, and the
+	 * notice flags describe how this package renders, not the error itself. The
+	 * error's *action* is deliberately NOT configured here — reporters declare it
+	 * at creation time in `error_data['action']` (see `wp_error_to_array()`), since
+	 * it is a stable machine token.
+	 *
 	 * Recognized keys, all optional:
 	 * - `message_callback` (callable): receives the stored error array, returns the
 	 *   displayable message. Omit to keep the generic reconnect copy.
-	 * - `action` (string): value for `error_data['action']`, e.g. 'none' to suppress
-	 *   the reconnect CTA. Omit to keep the default reconnect behavior.
 	 * - `default_admin_notice` (bool): when true, generic_admin_notice_error() shows
 	 *   this error's message even when no consumer supplies one via the
 	 *   `jetpack_connection_error_notice_message` filter (which still overrides).
+	 * - `notice_link` (array): presentational `label` and `url` for a link appended to
+	 *   the default admin notice only. Only used when the notice shows this error's
+	 *   default message (a filtered message keeps full control of the copy).
 	 *
 	 * @since $$next-version$$
 	 *
@@ -462,11 +465,15 @@ class Error_Handler {
 			// a reconnect would be rejected the same way: suppress the reconnect CTA
 			// and surface the real cause. Ships a default admin notice because this
 			// error is invisible to every other detection path — WP.com's requests
-			// never reach the site.
+			// never reach the site. The message stays brief on purpose: Site Health
+			// is the source of truth with the detailed diagnosis and resolution steps.
 			'xmlrpc_request_blocked' => array(
 				'message_callback'     => array( $this, 'get_blocked_request_message' ),
-				'action'               => 'none',
 				'default_admin_notice' => true,
+				'notice_link'          => array(
+					'label' => __( 'Visit Site Health', 'jetpack-connection' ),
+					'url'   => admin_url( 'site-health.php' ),
+				),
 			),
 		);
 
@@ -476,23 +483,17 @@ class Error_Handler {
 	/**
 	 * Builds the displayable message for the blocked-request error.
 	 *
+	 * Deliberately brief: Site Health holds the detailed diagnosis (including the
+	 * HTTP status the site returned) and the resolution steps, so the message only
+	 * names the condition and points there.
+	 *
 	 * @since $$next-version$$
 	 *
-	 * @param array $error The stored error array.
+	 * @param array $error The stored error array (unused; part of the message_callback contract).
 	 * @return string The message.
 	 */
-	private function get_blocked_request_message( $error ) {
-		$site_http_status = isset( $error['error_data']['site_http_status'] ) ? (int) $error['error_data']['site_http_status'] : 0;
-
-		if ( $site_http_status ) {
-			return sprintf(
-				/* translators: %d is the HTTP status code (e.g. 403) the site returned to WordPress.com. */
-				__( 'WordPress.com is unable to communicate with your site: requests are being blocked (HTTP %d), usually by a firewall, security plugin, or server rule. Reconnecting will not fix this. Ask your host to allow requests from WordPress.com to your site\'s xmlrpc.php file, then confirm the fix on your site\'s Site Health page.', 'jetpack-connection' ),
-				$site_http_status
-			);
-		}
-
-		return __( 'WordPress.com is unable to communicate with your site: requests are being blocked, usually by a firewall, security plugin, or server rule. Reconnecting will not fix this. Ask your host to allow requests from WordPress.com to your site\'s xmlrpc.php file, then confirm the fix on your site\'s Site Health page.', 'jetpack-connection' );
+	private function get_blocked_request_message( $error ) { // phpcs:ignore VariableAnalysis.CodeAnalysis.VariableAnalysis.UnusedVariable
+		return __( 'WordPress.com requests to your site are being blocked, usually by a firewall or security rule. See Site Health for details and next steps.', 'jetpack-connection' );
 	}
 
 	/**
@@ -1007,6 +1008,13 @@ class Error_Handler {
 			$error_data['site_http_status'] = (int) $data['site_http_status'];
 		}
 
+		// The display action declared by the reporter at creation time, e.g. 'none'
+		// to suppress the reconnect CTA. Only our own reporters set this (it is never
+		// derived from request data); readers treat a missing action as 'reconnect'.
+		if ( isset( $data['action'] ) && is_string( $data['action'] ) ) {
+			$error_data['action'] = $data['action'];
+		}
+
 		return $this->build_error_array(
 			$error->get_error_code(),
 			$error->get_error_message(),
@@ -1281,6 +1289,11 @@ class Error_Handler {
 	public function delete_error_by_code( $error_code ) {
 		$deleted = false;
 
+		// Reopen the reporting gate for this code: deletion means the condition was
+		// positively confirmed cleared, so a recurrence must be reportable immediately
+		// rather than suppressed for up to an hour.
+		delete_transient( self::ERROR_REPORTING_GATE . $error_code );
+
 		$stored_errors = $this->get_stored_errors();
 		if ( isset( $stored_errors[ $error_code ] ) ) {
 			unset( $stored_errors[ $error_code ] );
@@ -1428,14 +1441,21 @@ class Error_Handler {
 		// display config sets `default_admin_notice` provide their own message and
 		// do not depend on a consumer supplying one.
 		$default_message = '';
+		$notice_link     = null;
 		foreach ( $displayable_errors as $error_code => $user_errors ) {
 			$display_config = $this->get_error_display_config( $error_code );
 			if ( empty( $display_config['default_admin_notice'] ) ) {
 				continue;
 			}
+			// On selected hosting platforms the displayable errors pass through a
+			// consumer filter, so the shape is not guaranteed.
+			if ( ! is_array( $user_errors ) ) {
+				continue;
+			}
 			$first_error = reset( $user_errors );
 			if ( is_array( $first_error ) && ! empty( $first_error['error_message'] ) ) {
 				$default_message = $first_error['error_message'];
+				$notice_link     = $display_config['notice_link'] ?? null;
 				break;
 			}
 		}
@@ -1471,8 +1491,20 @@ class Error_Handler {
 			return;
 		}
 
+		$notice_content = esc_html( $message );
+
+		// Append the link only when the notice is showing the unmodified default
+		// message — a filtered message keeps full control of the copy.
+		if ( $notice_link && $message === $default_message && ! empty( $notice_link['url'] ) && ! empty( $notice_link['label'] ) ) {
+			$notice_content .= sprintf(
+				' <a href="%1$s">%2$s</a>',
+				esc_url( $notice_link['url'] ),
+				esc_html( $notice_link['label'] )
+			);
+		}
+
 		wp_admin_notice(
-			esc_html( $message ),
+			$notice_content,
 			array(
 				'type'               => 'error',
 				'dismissible'        => true,

--- a/projects/packages/connection/src/class-site-health.php
+++ b/projects/packages/connection/src/class-site-health.php
@@ -39,6 +39,32 @@ class Site_Health {
 		self::$initialized = true;
 
 		add_action( 'admin_init', array( __CLASS__, 'maybe_register_site_health' ), 1 );
+
+		// Deliberately hooked to the cron-only `jetpack_heartbeat` action (end of
+		// Heartbeat::cron_exec()) and not `jetpack_heartbeat_stats_array`, which
+		// also fires in synchronous request contexts (XML-RPC, REST, WP-CLI) where
+		// a remote test would be slow and an amplification vector.
+		add_action( 'jetpack_heartbeat', array( __CLASS__, 'do_daily_connection_check' ) );
+	}
+
+	/**
+	 * Runs the WP.com connection test once a day on the heartbeat cron.
+	 *
+	 * The test result itself is discarded: the point is the test's side effects,
+	 * which keep the Error_Handler state for failures that WP.com cannot report
+	 * through a request of its own (e.g. the site blocking WP.com requests) fresh —
+	 * reported while the condition persists, cleared once it resolves. Without this,
+	 * the error would only update on Site Health page visits and Core's weekly
+	 * Site Health cron, and would expire (ERROR_LIFE_TIME) while still unresolved.
+	 *
+	 * @since $$next-version$$
+	 */
+	public static function do_daily_connection_check() {
+		if ( ! ( new Manager() )->is_connected() ) {
+			return;
+		}
+
+		( new Connection_Health_Tests() )->run_test( 'test__wpcom_connection_test' );
 	}
 
 	/**

--- a/projects/packages/connection/src/health/class-connection-health-tests.php
+++ b/projects/packages/connection/src/health/class-connection-health-tests.php
@@ -483,9 +483,9 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 	 * of the test: Site Health page loads, Core's weekly Site Health cron, and the
 	 * daily connection check on the heartbeat cron.
 	 *
-	 * @param string     $name        The test name.
-	 * @param object     $result      The JSON-decoded response body.
-	 * @param int|string $status_code The HTTP status code of the WP.com response.
+	 * @param string      $name        The test name.
+	 * @param object|null $result      The JSON-decoded response body; null when the body was not valid JSON.
+	 * @param int|string  $status_code The HTTP status code of the WP.com response.
 	 *
 	 * @return array Test results.
 	 */
@@ -526,10 +526,16 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 			return $this->blocked_request_failing_test( $name, $site_http_status );
 		}
 
-		// WP.com answered with a definitive, non-blocked failure: its test ran and
-		// did not report the request as blocked, so a lingering blocked error is
-		// stale — and its "don't reconnect" advice would be wrong for this failure.
-		Error_Handler::get_instance()->delete_error_by_code( 'xmlrpc_request_blocked' );
+		// An explicit `connected` property (falsy here, past the pass branch) proves
+		// WP.com actually ran its test and did not report a blockage — a definitive
+		// non-blocked failure, so a lingering blocked error is stale and its
+		// suppressed-reconnect presentation would be wrong for this failure.
+		// Malformed bodies and service-error envelopes (no `connected` property) are
+		// inconclusive: preserve any existing blocked error, as with timeouts and
+		// 404s. A wrongly preserved error is bounded by ERROR_LIFE_TIME anyway.
+		if ( is_object( $result ) && property_exists( $result, 'connected' ) ) {
+			Error_Handler::get_instance()->delete_error_by_code( 'xmlrpc_request_blocked' );
+		}
 
 		$message = isset( $result->message ) && '' !== $result->message
 			? $result->message

--- a/projects/packages/connection/src/health/class-connection-health-tests.php
+++ b/projects/packages/connection/src/health/class-connection-health-tests.php
@@ -514,6 +514,9 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 					array(
 						'user_id'          => 0,
 						'site_http_status' => $site_http_status,
+						// Reconnecting would be rejected by the same rule that blocks WP.com,
+						// so the error carries its remedy: no reconnect CTA on any surface.
+						'action'           => 'none',
 					)
 				),
 				false,
@@ -522,6 +525,11 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 
 			return $this->blocked_request_failing_test( $name, $site_http_status );
 		}
+
+		// WP.com answered with a definitive, non-blocked failure: its test ran and
+		// did not report the request as blocked, so a lingering blocked error is
+		// stale — and its "don't reconnect" advice would be wrong for this failure.
+		Error_Handler::get_instance()->delete_error_by_code( 'xmlrpc_request_blocked' );
 
 		$message = isset( $result->message ) && '' !== $result->message
 			? $result->message

--- a/projects/packages/connection/src/health/class-connection-health-tests.php
+++ b/projects/packages/connection/src/health/class-connection-health-tests.php
@@ -476,6 +476,13 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 	 * Split out from test__wpcom_connection_test() so the decision logic can be
 	 * exercised without performing a signed remote request.
 	 *
+	 * Besides producing the Site Health result, this also keeps the Error_Handler
+	 * state for `xmlrpc_request_blocked` in sync: a blocked result reports the
+	 * error (making it visible on Error_Handler surfaces such as admin notices and
+	 * the dashboard), and a connected result clears it. Runs from every entry point
+	 * of the test: Site Health page loads, Core's weekly Site Health cron, and the
+	 * daily connection check on the heartbeat cron.
+	 *
 	 * @param string     $name        The test name.
 	 * @param object     $result      The JSON-decoded response body.
 	 * @param int|string $status_code The HTTP status code of the WP.com response.
@@ -484,6 +491,7 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 	 */
 	public function evaluate_wpcom_connection_result( $name, $result, $status_code ) {
 		if ( ! empty( $result->connected ) ) {
+			Error_Handler::get_instance()->delete_error_by_code( 'xmlrpc_request_blocked' );
 			return self::passing_test( array( 'name' => $name ) );
 		}
 
@@ -491,10 +499,28 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 		// plugin, or server rule). The connection token could be valid, but reconnecting would
 		// be rejected the same way - surface the real cause and don't offer a reconnect.
 		if ( isset( $result->error_code ) && 'xmlrpc_request_blocked' === $result->error_code ) {
-			return $this->blocked_request_failing_test(
-				$name,
-				(int) ( $result->site_http_status ?? 0 )
+			$site_http_status = (int) ( $result->site_http_status ?? 0 );
+
+			// Skipping the WP.com verification round-trip is safe here: the error was
+			// derived from a response WP.com sent to a request this site initiated and
+			// signed, so it is self-evidencing (same trust model as the outgoing flow).
+			Error_Handler::get_instance()->report_error(
+				Error_Handler::build_connection_wp_error(
+					'xmlrpc_request_blocked',
+					'WordPress.com requests to the site are blocked',
+					array( 'token' => '' ),
+					Error_Handler::ERROR_TYPE_LOCAL_STATE,
+					'', // The blocked state describes the site's environment, not one request, so it has no direction.
+					array(
+						'user_id'          => 0,
+						'site_http_status' => $site_http_status,
+					)
+				),
+				false,
+				true
 			);
+
+			return $this->blocked_request_failing_test( $name, $site_http_status );
 		}
 
 		$message = isset( $result->message ) && '' !== $result->message

--- a/projects/packages/connection/src/health/class-connection-health-tests.php
+++ b/projects/packages/connection/src/health/class-connection-health-tests.php
@@ -491,7 +491,7 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 	 */
 	public function evaluate_wpcom_connection_result( $name, $result, $status_code ) {
 		if ( ! empty( $result->connected ) ) {
-			Error_Handler::get_instance()->delete_error_by_code( 'xmlrpc_request_blocked' );
+			$this->clear_blocked_request_error();
 			return self::passing_test( array( 'name' => $name ) );
 		}
 
@@ -504,24 +504,30 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 			// Skipping the WP.com verification round-trip is safe here: the error was
 			// derived from a response WP.com sent to a request this site initiated and
 			// signed, so it is self-evidencing (same trust model as the outgoing flow).
-			Error_Handler::get_instance()->report_error(
-				Error_Handler::build_connection_wp_error(
-					'xmlrpc_request_blocked',
-					'WordPress.com requests to the site are blocked',
-					array( 'token' => '' ),
-					Error_Handler::ERROR_TYPE_LOCAL_STATE,
-					'', // The blocked state describes the site's environment, not one request, so it has no direction.
-					array(
-						'user_id'          => 0,
-						'site_http_status' => $site_http_status,
-						// Reconnecting would be rejected by the same rule that blocks WP.com,
-						// so the error carries its remedy: no reconnect CTA on any surface.
-						'action'           => 'none',
-					)
-				),
-				false,
-				true
-			);
+			// The method_exists guard and the 'local_state' literal (which matches
+			// Error_Handler::ERROR_TYPE_LOCAL_STATE) protect mid-plugin-update requests,
+			// where a stale Error_Handler predating the factory and the constant can
+			// already be loaded: reporting is best-effort and must never fatal.
+			if ( method_exists( Error_Handler::class, 'build_connection_wp_error' ) ) {
+				Error_Handler::get_instance()->report_error(
+					Error_Handler::build_connection_wp_error(
+						'xmlrpc_request_blocked',
+						'WordPress.com requests to the site are blocked',
+						array( 'token' => '' ),
+						'local_state', // Error_Handler::ERROR_TYPE_LOCAL_STATE.
+						'', // The blocked state describes the site's environment, not one request, so it has no direction.
+						array(
+							'user_id'          => 0,
+							'site_http_status' => $site_http_status,
+							// Reconnecting would be rejected by the same rule that blocks WP.com,
+							// so the error carries its remedy: no reconnect CTA on any surface.
+							'action'           => 'none',
+						)
+					),
+					false,
+					true
+				);
+			}
 
 			return $this->blocked_request_failing_test( $name, $site_http_status );
 		}
@@ -534,7 +540,7 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 		// inconclusive: preserve any existing blocked error, as with timeouts and
 		// 404s. A wrongly preserved error is bounded by ERROR_LIFE_TIME anyway.
 		if ( is_object( $result ) && property_exists( $result, 'connected' ) ) {
-			Error_Handler::get_instance()->delete_error_by_code( 'xmlrpc_request_blocked' );
+			$this->clear_blocked_request_error();
 		}
 
 		$message = isset( $result->message ) && '' !== $result->message
@@ -548,6 +554,21 @@ class Connection_Health_Tests extends Connection_Health_Test_Base {
 		);
 
 		return self::connection_failing_test( $name, $message );
+	}
+
+	/**
+	 * Clears a stored `xmlrpc_request_blocked` error, when the loaded Error_Handler supports it.
+	 *
+	 * During a plugin update, a stale Error_Handler predating `delete_error_by_code()` can
+	 * already be in memory while this file is the new version on disk. State sync is
+	 * best-effort and must never fatal such a request, so it is skipped in that window.
+	 *
+	 * @since $$next-version$$
+	 */
+	private function clear_blocked_request_error() {
+		if ( method_exists( Error_Handler::class, 'delete_error_by_code' ) ) {
+			Error_Handler::get_instance()->delete_error_by_code( 'xmlrpc_request_blocked' );
+		}
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/Connection_Health_Tests_Test.php
+++ b/projects/packages/connection/tests/php/Connection_Health_Tests_Test.php
@@ -54,7 +54,11 @@ class Connection_Health_Tests_Test extends TestCase {
 		remove_all_filters( 'jetpack_debugger_run_self_test' );
 		remove_all_filters( 'jetpack_connection_reconnect_url' );
 		remove_all_filters( 'jetpack_connection_support_url' );
+		remove_all_filters( 'jetpack_connection_bypass_error_reporting_gate' );
 		remove_all_actions( 'jetpack_connection_tests_loaded' );
+		// Also invalidates the Error_Handler singleton's displayable-errors cache,
+		// which would otherwise leak into tests run later in the same process.
+		Error_Handler::get_instance()->delete_all_errors();
 	}
 
 	/**
@@ -585,6 +589,55 @@ class Connection_Health_Tests_Test extends TestCase {
 		// The action points to support, not the reconnect URL.
 		$this->assertSame( 'https://example.com/support', $result['action'] );
 		$this->assertNotSame( 'https://example.com/reconnect', $result['action'] );
+	}
+
+	/**
+	 * Test a blocked result reports a verified local_state error to the Error_Handler.
+	 */
+	public function test_wpcom_connection_test_blocked_reports_connection_error() {
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+
+		$this->evaluate_response(
+			array(
+				'connected'        => false,
+				'message'          => 'XML-RPC request was blocked.',
+				'error_code'       => 'xmlrpc_request_blocked',
+				'site_http_status' => 403,
+			)
+		);
+
+		$verified_errors = Error_Handler::get_instance()->get_verified_errors();
+
+		$this->assertArrayHasKey( 'xmlrpc_request_blocked', $verified_errors );
+
+		// Attributed to the site (blog token), not a user.
+		$this->assertArrayHasKey( '0', $verified_errors['xmlrpc_request_blocked'] );
+
+		$error = $verified_errors['xmlrpc_request_blocked']['0'];
+		$this->assertSame( Error_Handler::ERROR_TYPE_LOCAL_STATE, $error['error_type'] );
+		$this->assertSame( '', $error['error_direction'] );
+		$this->assertSame( 403, $error['error_data']['site_http_status'] );
+	}
+
+	/**
+	 * Test a connected result clears a previously reported blocked error.
+	 */
+	public function test_wpcom_connection_test_pass_clears_blocked_error() {
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+
+		$this->evaluate_response(
+			array(
+				'connected'        => false,
+				'error_code'       => 'xmlrpc_request_blocked',
+				'site_http_status' => 403,
+			)
+		);
+		$this->assertArrayHasKey( 'xmlrpc_request_blocked', Error_Handler::get_instance()->get_verified_errors() );
+
+		$this->evaluate_response( array( 'connected' => true ) );
+
+		$this->assertArrayNotHasKey( 'xmlrpc_request_blocked', Error_Handler::get_instance()->get_verified_errors() );
+		$this->assertArrayNotHasKey( 'xmlrpc_request_blocked', Error_Handler::get_instance()->get_stored_errors() );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/Connection_Health_Tests_Test.php
+++ b/projects/packages/connection/tests/php/Connection_Health_Tests_Test.php
@@ -617,6 +617,8 @@ class Connection_Health_Tests_Test extends TestCase {
 		$this->assertSame( Error_Handler::ERROR_TYPE_LOCAL_STATE, $error['error_type'] );
 		$this->assertSame( '', $error['error_direction'] );
 		$this->assertSame( 403, $error['error_data']['site_http_status'] );
+		// The reporter declares the remedy with the error: no reconnect CTA.
+		$this->assertSame( 'none', $error['error_data']['action'] );
 	}
 
 	/**
@@ -638,6 +640,34 @@ class Connection_Health_Tests_Test extends TestCase {
 
 		$this->assertArrayNotHasKey( 'xmlrpc_request_blocked', Error_Handler::get_instance()->get_verified_errors() );
 		$this->assertArrayNotHasKey( 'xmlrpc_request_blocked', Error_Handler::get_instance()->get_stored_errors() );
+	}
+
+	/**
+	 * Test a definitive non-blocked failure clears a previously reported blocked error.
+	 *
+	 * WP.com ran its test and reported something other than a blockage, so a
+	 * lingering blocked error (with its "don't reconnect" advice) is stale.
+	 */
+	public function test_wpcom_connection_test_other_failure_clears_blocked_error() {
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+
+		$this->evaluate_response(
+			array(
+				'connected'        => false,
+				'error_code'       => 'xmlrpc_request_blocked',
+				'site_http_status' => 403,
+			)
+		);
+		$this->assertArrayHasKey( 'xmlrpc_request_blocked', Error_Handler::get_instance()->get_verified_errors() );
+
+		$this->evaluate_response(
+			array(
+				'connected' => false,
+				'message'   => 'Invalid token.',
+			)
+		);
+
+		$this->assertArrayNotHasKey( 'xmlrpc_request_blocked', Error_Handler::get_instance()->get_verified_errors() );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/Connection_Health_Tests_Test.php
+++ b/projects/packages/connection/tests/php/Connection_Health_Tests_Test.php
@@ -671,6 +671,53 @@ class Connection_Health_Tests_Test extends TestCase {
 	}
 
 	/**
+	 * Test a service-error envelope (no `connected` property) preserves the blocked error.
+	 *
+	 * A WP.com 5xx envelope proves nothing about the site's blockage — the
+	 * test-connection logic may never have run — so the error must survive.
+	 */
+	public function test_wpcom_connection_test_error_envelope_preserves_blocked_error() {
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+
+		$this->evaluate_response(
+			array(
+				'connected'        => false,
+				'error_code'       => 'xmlrpc_request_blocked',
+				'site_http_status' => 403,
+			)
+		);
+		$this->assertArrayHasKey( 'xmlrpc_request_blocked', Error_Handler::get_instance()->get_verified_errors() );
+
+		$this->evaluate_response( array( 'error' => 'internal_server_error' ), 500 );
+
+		$this->assertArrayHasKey( 'xmlrpc_request_blocked', Error_Handler::get_instance()->get_verified_errors() );
+	}
+
+	/**
+	 * Test a malformed (non-JSON) response body preserves the blocked error.
+	 *
+	 * A non-JSON body (e.g. a proxy error page) decodes to null — inconclusive,
+	 * so the error must survive.
+	 */
+	public function test_wpcom_connection_test_malformed_body_preserves_blocked_error() {
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+
+		$this->evaluate_response(
+			array(
+				'connected'        => false,
+				'error_code'       => 'xmlrpc_request_blocked',
+				'site_http_status' => 403,
+			)
+		);
+		$this->assertArrayHasKey( 'xmlrpc_request_blocked', Error_Handler::get_instance()->get_verified_errors() );
+
+		$result = $this->tests->evaluate_wpcom_connection_result( 'test__wpcom_connection_test', null, 200 );
+
+		$this->assertFalse( $result['pass'] );
+		$this->assertArrayHasKey( 'xmlrpc_request_blocked', Error_Handler::get_instance()->get_verified_errors() );
+	}
+
+	/**
 	 * Test the blocked-request result omits the HTTP status when it is unknown.
 	 */
 	public function test_wpcom_connection_test_blocked_without_status_code() {

--- a/projects/packages/connection/tests/php/Error_Handler_Test.php
+++ b/projects/packages/connection/tests/php/Error_Handler_Test.php
@@ -1472,6 +1472,7 @@ class Error_Handler_Test extends BaseTestCase {
 			array(
 				'user_id'          => 0,
 				'site_http_status' => $site_http_status,
+				'action'           => 'none',
 			)
 		);
 	}
@@ -1513,10 +1514,9 @@ class Error_Handler_Test extends BaseTestCase {
 
 		$error = $displayable_errors['xmlrpc_request_blocked']['0'];
 
-		// The message names the real cause with the HTTP status, warns that
-		// reconnecting won't help, and points at Site Health for re-verification.
-		$this->assertStringContainsString( '403', $error['error_message'] );
-		$this->assertStringContainsString( 'Reconnecting will not fix this', $error['error_message'] );
+		// The message is deliberately brief — Site Health carries the detailed
+		// diagnosis — but names the condition and points there.
+		$this->assertStringContainsString( 'blocked', $error['error_message'] );
 		$this->assertStringContainsString( 'Site Health', $error['error_message'] );
 
 		// No reconnect CTA.
@@ -1527,18 +1527,126 @@ class Error_Handler_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Test the blocked-request message omits the HTTP status when it is unknown.
+	 * Test the admin notice appends a Site Health link to the default blocked-request message.
 	 */
-	public function test_displayable_errors_blocked_request_without_status() {
+	public function test_generic_admin_notice_appends_site_health_link() {
 		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
 
-		$this->error_handler->report_error( $this->get_blocked_request_error( 0 ), false, true );
+		$this->error_handler->report_error( $this->get_blocked_request_error( 403 ), false, true );
 
-		$displayable_errors = $this->error_handler->get_displayable_errors();
-		$error              = $displayable_errors['xmlrpc_request_blocked']['0'];
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'admin_link_test',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+		wp_get_current_user()->add_cap( 'jetpack_connect' );
 
-		$this->assertStringNotContainsString( 'HTTP', $error['error_message'] );
-		$this->assertStringContainsString( 'blocked', $error['error_message'] );
+		ob_start();
+		$this->error_handler->generic_admin_notice_error();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'site-health.php', $output );
+		$this->assertStringContainsString( 'Visit Site Health', $output );
+	}
+
+	/**
+	 * Test the admin notice omits the action link when a filter overrides the message.
+	 */
+	public function test_generic_admin_notice_no_link_when_message_filtered() {
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+
+		$this->error_handler->report_error( $this->get_blocked_request_error( 403 ), false, true );
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'admin_filtered_test',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+		wp_get_current_user()->add_cap( 'jetpack_connect' );
+
+		add_filter(
+			'jetpack_connection_error_notice_message',
+			static function () {
+				return 'Custom consumer message.';
+			}
+		);
+
+		ob_start();
+		$this->error_handler->generic_admin_notice_error();
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'Custom consumer message.', $output );
+		$this->assertStringNotContainsString( 'site-health.php', $output );
+	}
+
+	/**
+	 * Test delete_error_by_code reopens the reporting gate so a recurrence is reportable immediately.
+	 */
+	public function test_delete_error_by_code_clears_reporting_gate() {
+		// No gate bypass here on purpose: the gate is the subject of the test.
+		$this->error_handler->report_error( $this->get_blocked_request_error( 403 ), false, true );
+		$this->assertArrayHasKey( 'xmlrpc_request_blocked', $this->error_handler->get_verified_errors() );
+
+		$this->error_handler->delete_error_by_code( 'xmlrpc_request_blocked' );
+		$this->assertArrayNotHasKey( 'xmlrpc_request_blocked', $this->error_handler->get_verified_errors() );
+
+		// With the gate still closed this second report would be suppressed.
+		$this->error_handler->report_error( $this->get_blocked_request_error( 403 ), false, true );
+		$this->assertArrayHasKey( 'xmlrpc_request_blocked', $this->error_handler->get_verified_errors() );
+	}
+
+	/**
+	 * Test the admin notice survives a consumer filter injecting a non-array under an error code.
+	 */
+	public function test_generic_admin_notice_survives_non_array_user_errors() {
+		// Platform-gated consumers (WoA/VIP/Newspack) can reshape the displayable
+		// errors; simulate one injecting a malformed entry.
+		$handler = new class() extends Error_Handler {
+			/**
+			 * Public constructor bypassing the singleton's hook registration.
+			 */
+			public function __construct() {
+			}
+
+			/**
+			 * Pretend we are on a platform where error filtering is allowed.
+			 *
+			 * @return bool
+			 */
+			protected function should_allow_error_filtering() {
+				return true;
+			}
+		};
+
+		add_filter(
+			'jetpack_connection_get_verified_errors',
+			static function () {
+				return array( 'xmlrpc_request_blocked' => 'not-an-array' );
+			}
+		);
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'admin_malformed_test',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+		wp_get_current_user()->add_cap( 'jetpack_connect' );
+
+		ob_start();
+		$handler->generic_admin_notice_error();
+		$output = ob_get_clean();
+
+		// No fatal, and no default message could be derived from the malformed entry.
+		$this->assertSame( '', $output );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/Error_Handler_Test.php
+++ b/projects/packages/connection/tests/php/Error_Handler_Test.php
@@ -1457,6 +1457,157 @@ class Error_Handler_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Builds the blocked-request error the connection health tests report.
+	 *
+	 * @param int $site_http_status The HTTP status the site returned to WP.com.
+	 * @return \WP_Error
+	 */
+	private function get_blocked_request_error( $site_http_status = 403 ) {
+		return Error_Handler::build_connection_wp_error(
+			'xmlrpc_request_blocked',
+			'WordPress.com requests to the site are blocked',
+			array( 'token' => '' ),
+			Error_Handler::ERROR_TYPE_LOCAL_STATE,
+			'',
+			array(
+				'user_id'          => 0,
+				'site_http_status' => $site_http_status,
+			)
+		);
+	}
+
+	/**
+	 * Test delete_error_by_code removes one code and leaves others intact.
+	 */
+	public function test_delete_error_by_code() {
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+
+		$this->error_handler->report_error( $this->get_sample_error( 'invalid_token', 1 ), false, true );
+		$this->error_handler->report_error( $this->get_sample_error( 'unknown_token', 2 ), false, true );
+
+		$this->assertArrayHasKey( 'invalid_token', $this->error_handler->get_verified_errors() );
+		$this->assertArrayHasKey( 'unknown_token', $this->error_handler->get_verified_errors() );
+
+		$this->assertTrue( $this->error_handler->delete_error_by_code( 'invalid_token' ) );
+
+		$this->assertArrayNotHasKey( 'invalid_token', $this->error_handler->get_stored_errors() );
+		$this->assertArrayNotHasKey( 'invalid_token', $this->error_handler->get_verified_errors() );
+		$this->assertArrayHasKey( 'unknown_token', $this->error_handler->get_stored_errors() );
+		$this->assertArrayHasKey( 'unknown_token', $this->error_handler->get_verified_errors() );
+
+		// Deleting a code with no errors reports nothing was deleted.
+		$this->assertFalse( $this->error_handler->delete_error_by_code( 'invalid_token' ) );
+	}
+
+	/**
+	 * Test the blocked-request error is displayable with its own message and no reconnect CTA.
+	 */
+	public function test_displayable_errors_blocked_request() {
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+
+		$this->error_handler->report_error( $this->get_blocked_request_error( 403 ), false, true );
+
+		$displayable_errors = $this->error_handler->get_displayable_errors();
+
+		$this->assertArrayHasKey( 'xmlrpc_request_blocked', $displayable_errors );
+
+		$error = $displayable_errors['xmlrpc_request_blocked']['0'];
+
+		// The message names the real cause with the HTTP status, warns that
+		// reconnecting won't help, and points at Site Health for re-verification.
+		$this->assertStringContainsString( '403', $error['error_message'] );
+		$this->assertStringContainsString( 'Reconnecting will not fix this', $error['error_message'] );
+		$this->assertStringContainsString( 'Site Health', $error['error_message'] );
+
+		// No reconnect CTA.
+		$this->assertSame( 'none', $error['error_data']['action'] );
+
+		// Site-wide audience: the blog, not a specific user, is affected.
+		$this->assertSame( 'site', $error['audience'] );
+	}
+
+	/**
+	 * Test the blocked-request message omits the HTTP status when it is unknown.
+	 */
+	public function test_displayable_errors_blocked_request_without_status() {
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+
+		$this->error_handler->report_error( $this->get_blocked_request_error( 0 ), false, true );
+
+		$displayable_errors = $this->error_handler->get_displayable_errors();
+		$error              = $displayable_errors['xmlrpc_request_blocked']['0'];
+
+		$this->assertStringNotContainsString( 'HTTP', $error['error_message'] );
+		$this->assertStringContainsString( 'blocked', $error['error_message'] );
+	}
+
+	/**
+	 * Test the admin notice provides a default message for the blocked-request error.
+	 */
+	public function test_generic_admin_notice_default_message_for_blocked_request() {
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+
+		$this->error_handler->report_error( $this->get_blocked_request_error( 403 ), false, true );
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'admin_blocked_test',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+		wp_get_current_user()->add_cap( 'jetpack_connect' );
+
+		$received_default = null;
+		add_filter(
+			'jetpack_connection_error_notice_message',
+			static function ( $message ) use ( &$received_default ) {
+				$received_default = $message;
+				return ''; // Suppress the actual notice output.
+			}
+		);
+
+		$this->error_handler->generic_admin_notice_error();
+
+		$this->assertIsString( $received_default );
+		$this->assertStringContainsString( 'blocked', $received_default );
+		$this->assertStringContainsString( 'Site Health', $received_default );
+	}
+
+	/**
+	 * Test the admin notice default message stays empty for other error codes.
+	 */
+	public function test_generic_admin_notice_no_default_message_for_other_errors() {
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+
+		$this->error_handler->report_error( $this->get_sample_error( 'invalid_token', 1 ), false, true );
+
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'admin_default_test',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+		wp_get_current_user()->add_cap( 'jetpack_connect' );
+
+		$received_default = null;
+		add_filter(
+			'jetpack_connection_error_notice_message',
+			static function ( $message ) use ( &$received_default ) {
+				$received_default = $message;
+				return '';
+			}
+		);
+
+		$this->error_handler->generic_admin_notice_error();
+
+		$this->assertSame( '', $received_default );
+	}
+
+	/**
 	 * Test caching functionality of get_displayable_errors method
 	 */
 	public function test_get_displayable_errors_caching() {

--- a/projects/packages/connection/tests/php/Site_Health_Test.php
+++ b/projects/packages/connection/tests/php/Site_Health_Test.php
@@ -7,8 +7,10 @@
 
 namespace Automattic\Jetpack\Connection;
 
+use Automattic\Jetpack\Constants;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
+use WorDBless\Options as WorDBless_Options;
 
 /**
  * Tests for the Site_Health class.
@@ -38,6 +40,10 @@ class Site_Health_Test extends TestCase {
 		remove_all_actions( 'admin_init' );
 		remove_all_actions( 'wp_ajax_health-check-jetpack-connection-health' );
 		remove_all_actions( 'jetpack_heartbeat' );
+		remove_all_filters( 'jetpack_connection_bypass_error_reporting_gate' );
+		Error_Handler::get_instance()->delete_all_errors();
+		WorDBless_Options::init()->clear_options();
+		Constants::clear_constants();
 		( new Manager() )->reset_connection_status();
 	}
 
@@ -158,6 +164,63 @@ class Site_Health_Test extends TestCase {
 		Site_Health::do_daily_connection_check();
 
 		$this->assertFalse( $http_request_attempted );
+	}
+
+	/**
+	 * Test that on a connected site the daily check runs the WP.com connection test,
+	 * clearing a previously reported blocked error when WP.com reports the site connected.
+	 */
+	public function test_do_daily_connection_check_runs_test_and_clears_blocked_error() {
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+		\Jetpack_Options::update_option( 'blog_token', 'blog.token' );
+		\Jetpack_Options::update_option( 'id', 12345 );
+
+		// Seed a previously reported blocked error.
+		add_filter( 'jetpack_connection_bypass_error_reporting_gate', '__return_true' );
+		Error_Handler::get_instance()->report_error(
+			Error_Handler::build_connection_wp_error(
+				'xmlrpc_request_blocked',
+				'WordPress.com requests to the site are blocked',
+				array( 'token' => '' ),
+				Error_Handler::ERROR_TYPE_LOCAL_STATE,
+				'',
+				array(
+					'user_id'          => 0,
+					'site_http_status' => 403,
+				)
+			),
+			false,
+			true
+		);
+		$this->assertArrayHasKey( 'xmlrpc_request_blocked', Error_Handler::get_instance()->get_verified_errors() );
+
+		$test_connection_requested = false;
+		add_filter(
+			'pre_http_request',
+			static function ( $preempt, $parsed_args, $url ) use ( &$test_connection_requested ) {
+				if ( false !== strpos( $url, '/test-connection' ) ) {
+					$test_connection_requested = true;
+					return array(
+						'headers'  => array(),
+						'response' => array(
+							'code'    => 200,
+							'message' => 'OK',
+						),
+						'body'     => wp_json_encode( array( 'connected' => true ), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ),
+						'cookies'  => array(),
+						'filename' => null,
+					);
+				}
+				return $preempt;
+			},
+			10,
+			3
+		);
+
+		Site_Health::do_daily_connection_check();
+
+		$this->assertTrue( $test_connection_requested );
+		$this->assertArrayNotHasKey( 'xmlrpc_request_blocked', Error_Handler::get_instance()->get_verified_errors() );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/Site_Health_Test.php
+++ b/projects/packages/connection/tests/php/Site_Health_Test.php
@@ -37,6 +37,8 @@ class Site_Health_Test extends TestCase {
 		remove_all_filters( 'pre_http_request' );
 		remove_all_actions( 'admin_init' );
 		remove_all_actions( 'wp_ajax_health-check-jetpack-connection-health' );
+		remove_all_actions( 'jetpack_heartbeat' );
+		( new Manager() )->reset_connection_status();
 	}
 
 	/**
@@ -127,6 +129,35 @@ class Site_Health_Test extends TestCase {
 		$this->assertNotFalse(
 			has_action( 'wp_ajax_health-check-jetpack-connection-health', array( Site_Health::class, 'ajax_local_testing_suite' ) )
 		);
+	}
+
+	/**
+	 * Test that init registers the daily connection check on the heartbeat cron.
+	 */
+	public function test_init_registers_daily_connection_check() {
+		Site_Health::init();
+
+		$this->assertNotFalse(
+			has_action( 'jetpack_heartbeat', array( Site_Health::class, 'do_daily_connection_check' ) )
+		);
+	}
+
+	/**
+	 * Test that the daily connection check makes no requests when the site is not connected.
+	 */
+	public function test_do_daily_connection_check_requires_connection() {
+		$http_request_attempted = false;
+		add_filter(
+			'pre_http_request',
+			static function () use ( &$http_request_attempted ) {
+				$http_request_attempted = true;
+				return new \WP_Error( 'unexpected_request', 'No request should be made.' );
+			}
+		);
+
+		Site_Health::do_daily_connection_check();
+
+		$this->assertFalse( $http_request_attempted );
 	}
 
 	/**


### PR DESCRIPTION
Fixes CONNECT-402

## Proposed changes

When a host blocks WordPress.com requests to a site (firewall, WAF, or server rule rejecting `xmlrpc.php`), the connection is broken in a way the Connection Error Handler cannot detect: the failing requests never arrive, so no error flows are triggered. Until now the only place this surfaced was Tools → Site Health, and only if the user happened to visit it.

This PR makes the blocked state visible through the existing Error_Handler surfaces:

* **Report the blocked state as a verified connection error.** `evaluate_wpcom_connection_result()` now reports `xmlrpc_request_blocked` as an `ERROR_TYPE_LOCAL_STATE` error with the WP.com verification round-trip skipped — mirroring the `invalid_connection_owner` precedent. Skipping verification is safe because the `test-connection` response answers a signed request this site initiated. `local_state` is the right error type because `delete_all_api_errors()` deliberately preserves it: outgoing API success doesn't disprove wpcom→site being blocked.
* **The error carries its remedy.** The reporter declares `action => 'none'` at creation time, stored in `error_data['action']` (newly whitelisted in `wp_error_to_array()`) — matching how consumer-injected errors already carry their actions via `build_action_error_data()`. Readers keep treating a missing action as `'reconnect'`, so no reconnect CTA is shown for this error on any surface.
* **Clear the error whenever the test is conclusive.** A `connected` result deletes the error via a new `Error_Handler::delete_error_by_code()` helper — and so does any *definitive non-blocked* failure, since WP.com ran its test without reporting a blockage (a lingering "blocked" state would be stale and its suppressed-reconnect presentation wrong for the new failure). Inconclusive responses — malformed bodies, service-error envelopes without a `connected` property — preserve the error, like timeouts and 404s do, with staleness bounded by the 24h expiry. Deletion also reopens the hourly reporting gate for the code, so a recurrence is reportable immediately.
* **Brief messaging that defers to Site Health.** The displayable message is deliberately short — it names the cause ("requests are being blocked, usually by a firewall or security rule") and points at Site Health, which remains the source of truth with the detailed diagnosis (including the HTTP status) and resolution steps.
* **Default admin-notice message with a Site Health link.** Nothing in the monorepo supplies `jetpack_connection_error_notice_message`, so the generic admin notice was effectively dormant. The blocked error now ships a scoped default message plus an appended "Visit Site Health" link (other error codes keep the empty default; a filtered message keeps full control of the copy and suppresses the link).
* **Declarative display config for what can't be stored.** Display-time state — the message callback (copy must resolve in each viewer's locale; the cron reporter has no viewer), the default-notice flag, and the notice link — is declared in a single `get_error_display_config()` table rather than branching in the display and notice paths. A future special error code is one entry, not new `if`s.
* **Daily re-check on the heartbeat cron.** `Site_Health::do_daily_connection_check()` runs `test__wpcom_connection_test` on the `jetpack_heartbeat` action — cron-only, once a day. This keeps the error fresh while the condition persists (it would otherwise expire after `ERROR_LIFE_TIME` = 24h with only the weekly core Site Health cron re-running the test) and clears it within ~a day of the host fixing the issue. The hook is deliberately not on `jetpack_heartbeat_stats_array`, which also fires in synchronous request contexts (XML-RPC, REST, WP-CLI) where a remote test would be slow and an amplification vector.
* **Package docs updated** (`docs/error-handling.md`, `docs/connection-health-tests.md`) to cover the new error, the creation-time/display-time split, the clearing lifecycle, and the daily check.

Known accepted limitation: with `ERROR_LIFE_TIME` at exactly 24h and a ~24h re-check cadence, the notice can briefly disappear if WP-cron drifts past the 24h mark; it reappears at the next heartbeat run and never shows a false positive.

Follow-ups (not in this PR): removing the vestigial async Site Health suite registration, and an optional `connection-errors` heartbeat stat for fleet observability.

## Related product discussion/links

* CONNECT-402 (implementation plan in the issue description)
* Builds on the `xmlrpc_request_blocked` detection added in #50870 (CONNECT-379)

## Does this pull request change what data or activity we track or use?

No. The error is stored locally in the existing connection-error options. Because verification is skipped, nothing new is sent to WordPress.com but the existing connection test now runs daily.

## Testing instructions

Setup: a Jetpack-connected site (e.g. Jurassic Ninja) with this branch's `packages/connection` build.

**Simulate the blocked state** by adding the following in `.htaccess`

```
# END WordPress

<Files xmlrpc.php>
	Require all denied
</Files>
```

1. Visit Tools → Site Health. The "WordPress.com Connection Test" check fails with the blocked-request message and a support link (no reconnect CTA)
2. Verify the error was reported: `wp option get jetpack_connection_xmlrpc_verified_errors` should contain `xmlrpc_request_blocked` with `error_type: local_state`, `site_http_status: 403`, and `action: none`.
3. Visit any wp-admin page other than the Jetpack dashboard (e.g. Plugins). An error notice appears — "WordPress.com requests to your site are being blocked, usually by a firewall or security rule. See Site Health for details and next steps." — followed by a "Visit Site Health" link and no reconnect suggestion.
4. Visit the Jetpack dashboard (Jetpack → Dashboard). The connection error banner shows the same message without a "Restore connection" action.
5. Test the daily re-check: reset the heartbeat gate with `wp eval 'Jetpack_Options::update_option( "last_heartbeat", 0 );'`, then run `wp cron event run jetpack_v2_heartbeat`. The verified error's timestamp refreshes.
6. Remove the htaccess block and visit Site Health again. The check passes, and `jetpack_connection_xmlrpc_verified_errors` no longer contains `xmlrpc_request_blocked`; the admin notice and dashboard banner are gone.
7. Confirm no reconnect regression: with the `.htaccess` block removed and a token error simulated instead, the existing reconnect-oriented error flows behave as before.
8. On WoA sites, this error should be hidden, similar to all Connection Errors -- see [Protected_Owner_Error_Handler](https://github.com/Automattic/jetpack/blob/9ea5918eb92a8ddcac9b4084775eedbc9f70be66/projects/plugins/wpcomsh/connection/class-protected-owner-error-handler.php#L129)
