### PR TITLE
JETPACK-2126: Cache the site record and stop redundant option writes

### DIFF
--- a/projects/packages/connection/changelog/jetpack-2126-site-data-perf-follow-up
+++ b/projects/packages/connection/changelog/jetpack-2126-site-data-perf-follow-up
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Cache the WordPress.com site record briefly so the site endpoint does not make a request per read.

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -1068,7 +1068,10 @@ class Manager {
 
 		$result = ( $sandboxed || $signed ) ? false : get_transient( $transient_key );
 
-		if ( false === $result ) {
+		// Only the array shape stored below can be served. A `pre_transient_*` filter or a damaged
+		// object cache entry can hand back anything, and a non-array would throw on
+		// `$result['body']` for every request until the entry expired, so it reads as a miss.
+		if ( ! is_array( $result ) ) {
 			$result = $this->fetch_connected_site_data( $site_id, $sandbox_secret );
 
 			// A signed read that failed must not replace a still-usable cached record with the failure.

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -1004,6 +1004,25 @@ class Manager {
 	}
 
 	/**
+	 * Drop the cached WordPress.com site record.
+	 *
+	 * A caller that fetched the record by another route holds something newer than the cache can,
+	 * and `jetpack_site_data_fetched` fires on a cached read too. Without this, a cached copy
+	 * would keep announcing the older record and undo what the caller just stored.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return void
+	 */
+	public static function delete_cached_site_data() {
+		$site_id = \Jetpack_Options::get_option( 'id' );
+
+		if ( $site_id ) {
+			delete_transient( self::SITE_DATA_TRANSIENT_PREFIX . $site_id );
+		}
+	}
+
+	/**
 	 * Fetch the site's own record from the WordPress.com `/sites/%d` endpoint.
 	 *
 	 * The result is cached briefly. Every plugin that bundles this package serves this route, and
@@ -2124,7 +2143,7 @@ class Manager {
 		delete_transient( $transient_key );
 
 		// Delete the cached site record, which a later connection must not serve.
-		delete_transient( self::SITE_DATA_TRANSIENT_PREFIX . (int) \Jetpack_Options::get_option( 'id' ) );
+		self::delete_cached_site_data();
 
 		// Delete all XML-RPC errors.
 		Error_Handler::get_instance()->delete_all_errors();

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -1007,8 +1007,8 @@ class Manager {
 	 * Drop the cached WordPress.com site record.
 	 *
 	 * A caller that fetched the record by another route holds something newer than the cache can,
-	 * and `jetpack_site_data_fetched` fires on a cached read too. Without this, a cached copy
-	 * would keep announcing the older record and undo what the caller just stored.
+	 * and `jetpack_site_data_fetched` fires on a cached read too. The cached copy has to go, or it
+	 * keeps announcing the older record and undoes what that caller stored.
 	 *
 	 * @since $$next-version$$
 	 *
@@ -1042,7 +1042,9 @@ class Manager {
 
 		$sandbox_secret = null;
 
-		if ( isset( $_COOKIE['store_sandbox'] ) ) {
+		// An array cookie (`store_sandbox[]=`) sanitizes down to an empty string, which must not
+		// count as a sandbox secret: it opts the request out of the cache with no sandbox to reach.
+		if ( isset( $_COOKIE['store_sandbox'] ) && is_string( $_COOKIE['store_sandbox'] ) ) {
 			// Keep only RFC 6265 cookie-octets so the value cannot break out of the Cookie header.
 			$sandbox_secret = preg_replace( '/[^\x21-\x7E]|[";,\\\\]/', '', filter_var( wp_unslash( $_COOKIE['store_sandbox'] ) ) );
 		}
@@ -1070,7 +1072,7 @@ class Manager {
 		}
 
 		/**
-		 * Fires after the site record was served from WordPress.com.
+		 * Fires after the site record was served, whether it was fetched or read from the cache.
 		 *
 		 * Consumers that cache anything derived from the record, such as the current plan,
 		 * can refresh it here.

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -30,6 +30,16 @@ use WP_User;
  */
 class Manager {
 	/**
+	 * Prefix of the transient holding the cached WordPress.com site record. The blog ID is
+	 * appended so a reconnect to a different site cannot read the previous site's record.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @var string
+	 */
+	const SITE_DATA_TRANSIENT_PREFIX = 'jetpack_site_data_';
+
+	/**
 	 * A copy of the raw POST data for signature verification purposes.
 	 *
 	 * @var string
@@ -996,6 +1006,10 @@ class Manager {
 	/**
 	 * Fetch the site's own record from the WordPress.com `/sites/%d` endpoint.
 	 *
+	 * The result is cached briefly. Every plugin that bundles this package serves this route, and
+	 * the Jetpack dashboard requests it on mount, so an uncached read means a blocking round trip
+	 * per render.
+	 *
 	 * @since 8.10.0
 	 *
 	 * @return object|WP_Error The decoded site record, or an error describing the failure.
@@ -1007,10 +1021,66 @@ class Manager {
 			return new WP_Error( 'site_id_missing', '', array( 'api_error_code' => 'site_id_missing' ) );
 		}
 
+		// A sandboxed request must neither read the shared cache nor seed it with sandbox data.
+		$sandboxed     = isset( $_COOKIE ) && isset( $_COOKIE['store_sandbox'] );
+		$transient_key = self::SITE_DATA_TRANSIENT_PREFIX . $site_id;
+		$result        = $sandboxed ? false : get_transient( $transient_key );
+
+		if ( false === $result ) {
+			$result = $this->fetch_connected_site_data( $site_id, $sandboxed );
+
+			if ( ! $sandboxed ) {
+				// Failures expire sooner so an outage recovers without waiting out a full success window.
+				set_transient(
+					$transient_key,
+					$result,
+					isset( $result['error'] ) ? 2 * MINUTE_IN_SECONDS : 5 * MINUTE_IN_SECONDS
+				);
+			}
+		}
+
+		if ( isset( $result['error'] ) ) {
+			return new WP_Error( 'site_data_fetch_failed', '', $result['error'] );
+		}
+
+		/**
+		 * Fires after the site record was served from WordPress.com.
+		 *
+		 * Consumers that cache anything derived from the record, such as the current plan,
+		 * can refresh it here.
+		 *
+		 * This fires on a cached read too, so a consumer stays in step with every request that
+		 * serves the record rather than only the ones that reached WordPress.com.
+		 *
+		 * The record is passed as an array rather than the object this method returns, so that a
+		 * listener cannot mutate the instance that becomes the REST response.
+		 *
+		 * @since $$next-version$$
+		 *
+		 * @param array $record The decoded site record from the WordPress.com `/sites/%d` endpoint.
+		 */
+		do_action( 'jetpack_site_data_fetched', json_decode( $result['body'], true ) );
+
+		return json_decode( $result['body'] );
+	}
+
+	/**
+	 * Request the site record from WordPress.com.
+	 *
+	 * Returns a cacheable array rather than the decoded record so that both outcomes survive a
+	 * round trip through a transient.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param int  $site_id   The WordPress.com blog ID.
+	 * @param bool $sandboxed Whether to forward the store sandbox cookie.
+	 * @return array Either `array( 'body' => string )` or `array( 'error' => array )`.
+	 */
+	private function fetch_connected_site_data( $site_id, $sandboxed ) {
 		$args = array( 'headers' => array() );
 
 		// Allow use a store sandbox. Internal ref: PCYsg-IA-p2.
-		if ( isset( $_COOKIE ) && isset( $_COOKIE['store_sandbox'] ) ) {
+		if ( $sandboxed ) {
 			// Keep only RFC 6265 cookie-octets so the value cannot break out of the Cookie header.
 			$secret                    = preg_replace( '/[^\x21-\x7E]|[";,\\\\]/', '', filter_var( wp_unslash( $_COOKIE['store_sandbox'] ) ) );
 			$args['headers']['Cookie'] = "store_sandbox=$secret;";
@@ -1032,36 +1102,19 @@ class Manager {
 				$error_info['api_error_code'] = is_string( $data->error ) ? wp_strip_all_tags( $data->error ) : null;
 			}
 
-			return new WP_Error( 'site_data_fetch_failed', '', $error_info );
+			return array( 'error' => $error_info );
 		}
 
 		if ( ! is_object( $data ) ) {
-			return new WP_Error(
-				'site_data_fetch_failed',
-				'',
-				array(
+			return array(
+				'error' => array(
 					'api_error_code' => 'invalid_body',
 					'api_http_code'  => 200,
-				)
+				),
 			);
 		}
 
-		/**
-		 * Fires after the site record was fetched from WordPress.com.
-		 *
-		 * Consumers that cache anything derived from the record, such as the current plan,
-		 * can refresh it here.
-		 *
-		 * The record is passed as an array rather than the object this method returns, so that a
-		 * listener cannot mutate the instance that becomes the REST response.
-		 *
-		 * @since 8.10.0
-		 *
-		 * @param array $record The decoded site record from the WordPress.com `/sites/%d` endpoint.
-		 */
-		do_action( 'jetpack_site_data_fetched', json_decode( $body, true ) );
-
-		return $data;
+		return array( 'body' => $body );
 	}
 
 	/**
@@ -2064,6 +2117,9 @@ class Manager {
 		// Delete cached connected user data.
 		$transient_key = 'jetpack_connected_user_data_' . get_current_user_id();
 		delete_transient( $transient_key );
+
+		// Delete the cached site record, which a later connection must not serve.
+		delete_transient( self::SITE_DATA_TRANSIENT_PREFIX . (int) \Jetpack_Options::get_option( 'id' ) );
 
 		// Delete all XML-RPC errors.
 		Error_Handler::get_instance()->delete_all_errors();

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -1021,13 +1021,20 @@ class Manager {
 			return new WP_Error( 'site_id_missing', '', array( 'api_error_code' => 'site_id_missing' ) );
 		}
 
+		$sandbox_secret = null;
+
+		if ( isset( $_COOKIE['store_sandbox'] ) ) {
+			// Keep only RFC 6265 cookie-octets so the value cannot break out of the Cookie header.
+			$sandbox_secret = preg_replace( '/[^\x21-\x7E]|[";,\\\\]/', '', filter_var( wp_unslash( $_COOKIE['store_sandbox'] ) ) );
+		}
+
 		// A sandboxed request must neither read the shared cache nor seed it with sandbox data.
-		$sandboxed     = isset( $_COOKIE ) && isset( $_COOKIE['store_sandbox'] );
+		$sandboxed     = null !== $sandbox_secret;
 		$transient_key = self::SITE_DATA_TRANSIENT_PREFIX . $site_id;
 		$result        = $sandboxed ? false : get_transient( $transient_key );
 
 		if ( false === $result ) {
-			$result = $this->fetch_connected_site_data( $site_id, $sandboxed );
+			$result = $this->fetch_connected_site_data( $site_id, $sandbox_secret );
 
 			if ( ! $sandboxed ) {
 				// Failures expire sooner so an outage recovers without waiting out a full success window.
@@ -1072,18 +1079,16 @@ class Manager {
 	 *
 	 * @since $$next-version$$
 	 *
-	 * @param int  $site_id   The WordPress.com blog ID.
-	 * @param bool $sandboxed Whether to forward the store sandbox cookie.
+	 * @param int         $site_id        The WordPress.com blog ID.
+	 * @param string|null $sandbox_secret Sanitized store sandbox cookie value, or null when not sandboxed.
 	 * @return array Either `array( 'body' => string )` or `array( 'error' => array )`.
 	 */
-	private function fetch_connected_site_data( $site_id, $sandboxed ) {
+	private function fetch_connected_site_data( $site_id, $sandbox_secret ) {
 		$args = array( 'headers' => array() );
 
 		// Allow use a store sandbox. Internal ref: PCYsg-IA-p2.
-		if ( $sandboxed ) {
-			// Keep only RFC 6265 cookie-octets so the value cannot break out of the Cookie header.
-			$secret                    = preg_replace( '/[^\x21-\x7E]|[";,\\\\]/', '', filter_var( wp_unslash( $_COOKIE['store_sandbox'] ) ) );
-			$args['headers']['Cookie'] = "store_sandbox=$secret;";
+		if ( null !== $sandbox_secret ) {
+			$args['headers']['Cookie'] = "store_sandbox=$sandbox_secret;";
 		}
 
 		$response = Client::wpcom_json_api_request_as_blog( sprintf( '/sites/%d', $site_id ) . '?force=wpcom', '1.1', $args );

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -1042,11 +1042,17 @@ class Manager {
 
 		$sandbox_secret = null;
 
-		// An array cookie (`store_sandbox[]=`) sanitizes down to an empty string, which must not
-		// count as a sandbox secret: it opts the request out of the cache with no sandbox to reach.
+		// An array cookie (`store_sandbox[]=`) carries no secret to send, and `filter_var()` turns
+		// it into `false`.
 		if ( isset( $_COOKIE['store_sandbox'] ) && is_string( $_COOKIE['store_sandbox'] ) ) {
 			// Keep only RFC 6265 cookie-octets so the value cannot break out of the Cookie header.
 			$sandbox_secret = preg_replace( '/[^\x21-\x7E]|[";,\\\\]/', '', filter_var( wp_unslash( $_COOKIE['store_sandbox'] ) ) );
+
+			// An empty cookie, or one the sanitizer strips to nothing, is not a sandbox secret.
+			// Counting it as one opts the request out of the cache with no sandbox to reach.
+			if ( '' === $sandbox_secret ) {
+				$sandbox_secret = null;
+			}
 		}
 
 		// A sandboxed request must neither read the shared cache nor seed it with sandbox data.

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -1052,12 +1052,21 @@ class Manager {
 		// A sandboxed request must neither read the shared cache nor seed it with sandbox data.
 		$sandboxed     = null !== $sandbox_secret;
 		$transient_key = self::SITE_DATA_TRANSIENT_PREFIX . $site_id;
-		$result        = $sandboxed ? false : get_transient( $transient_key );
+
+		// WordPress.com itself requests this route right after a purchase, for the side effect of
+		// the `jetpack_site_data_fetched` consumers storing the new plan. Those requests arrive
+		// signed with a connection token, which no browser request carries. A cached read would
+		// hand that refresh the pre-purchase record and turn it into a no-op, so a signed request
+		// always reads from WordPress.com and replaces the cache with the record it fetched.
+		$signed = Rest_Authentication::is_signed_with_blog_token() || Rest_Authentication::is_signed_with_user_token();
+
+		$result = ( $sandboxed || $signed ) ? false : get_transient( $transient_key );
 
 		if ( false === $result ) {
 			$result = $this->fetch_connected_site_data( $site_id, $sandbox_secret );
 
-			if ( ! $sandboxed ) {
+			// A signed read that failed must not replace a still-usable cached record with the failure.
+			if ( ! $sandboxed && ! ( $signed && isset( $result['error'] ) ) ) {
 				// Failures expire sooner so an outage recovers without waiting out a full success window.
 				set_transient(
 					$transient_key,

--- a/projects/packages/connection/tests/php/Site_Data_Endpoint_Test.php
+++ b/projects/packages/connection/tests/php/Site_Data_Endpoint_Test.php
@@ -331,8 +331,10 @@ class Site_Data_Endpoint_Test extends BaseTestCase {
 
 		$requests = $this->count_http_requests(
 			function () {
-				$this->manager->get_connected_site_data();
-				$this->manager->get_connected_site_data();
+				$first  = $this->manager->get_connected_site_data();
+				$second = $this->manager->get_connected_site_data();
+
+				$this->assertEquals( $first, $second );
 			}
 		);
 
@@ -354,11 +356,12 @@ class Site_Data_Endpoint_Test extends BaseTestCase {
 			}
 		);
 
-		$this->manager->get_connected_site_data();
-		$this->manager->get_connected_site_data();
+		$fresh  = $this->manager->get_connected_site_data();
+		$cached = $this->manager->get_connected_site_data();
 
+		$this->assertEquals( $fresh, $cached );
 		$this->assertCount( 2, $payloads );
-		$this->assertSame( $payloads[0], $payloads[1] );
+		$this->assertSame( reset( $payloads ), end( $payloads ) );
 	}
 
 	/**
@@ -369,13 +372,15 @@ class Site_Data_Endpoint_Test extends BaseTestCase {
 
 		$requests = $this->count_http_requests(
 			function () {
-				$this->manager->get_connected_site_data();
-				$this->manager->get_connected_site_data();
+				$first  = $this->manager->get_connected_site_data();
+				$second = $this->manager->get_connected_site_data();
+
+				$this->assertInstanceOf( 'WP_Error', $first );
+				$this->assertInstanceOf( 'WP_Error', $second );
 			}
 		);
 
 		$this->assertSame( 1, $requests );
-		$this->assertInstanceOf( 'WP_Error', $this->manager->get_connected_site_data() );
 	}
 
 	/**
@@ -388,8 +393,10 @@ class Site_Data_Endpoint_Test extends BaseTestCase {
 
 		$requests = $this->count_http_requests(
 			function () {
-				$this->manager->get_connected_site_data();
-				$this->manager->get_connected_site_data();
+				$first  = $this->manager->get_connected_site_data();
+				$second = $this->manager->get_connected_site_data();
+
+				$this->assertEquals( $first, $second );
 			}
 		);
 

--- a/projects/packages/connection/tests/php/Site_Data_Endpoint_Test.php
+++ b/projects/packages/connection/tests/php/Site_Data_Endpoint_Test.php
@@ -76,6 +76,8 @@ class Site_Data_Endpoint_Test extends BaseTestCase {
 		$wp_rest_server = null;
 		$this->server   = null;
 
+		unset( $_COOKIE['store_sandbox'] );
+
 		StatusCache::clear();
 		Constants::clear_constants();
 
@@ -212,6 +214,9 @@ class Site_Data_Endpoint_Test extends BaseTestCase {
 		Jetpack_Options::update_option( 'id', 1234 );
 		$this->manager->reset_connection_status();
 
+		// Each test starts uncached, otherwise the first fetch would answer every later one.
+		delete_transient( Manager::SITE_DATA_TRANSIENT_PREFIX . 1234 );
+
 		// Signing needs an absolute URL, so the API base has to resolve.
 		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
 		Constants::set_constant( 'JETPACK__API_VERSION', 1 );
@@ -292,6 +297,104 @@ class Site_Data_Endpoint_Test extends BaseTestCase {
 		$this->assertSame( 'site_data_fetch_failed', $result->get_error_code() );
 		$this->assertSame( 'invalid_body', $result->get_error_data()['api_error_code'] );
 		$this->assertFalse( $fired, 'The action must not fire without a usable record.' );
+	}
+
+	/**
+	 * Count the outgoing HTTP requests made while the callback runs.
+	 *
+	 * @param callable $callback Code under test.
+	 * @return int
+	 */
+	private function count_http_requests( callable $callback ) {
+		$requests = 0;
+
+		$counter = function ( $pre ) use ( &$requests ) {
+			++$requests;
+
+			return $pre;
+		};
+
+		add_filter( 'pre_http_request', $counter, 1 );
+		$callback();
+		remove_filter( 'pre_http_request', $counter, 1 );
+
+		return $requests;
+	}
+
+	/**
+	 * The record is cached, so a second read inside the window is served without another round
+	 * trip. Every plugin bundling this package serves the route, so an uncached read is a
+	 * blocking request per render.
+	 */
+	public function test_the_site_record_is_served_from_cache() {
+		$this->fake_http_response( 200, '{"ID":1234,"name":"Test site"}' );
+
+		$requests = $this->count_http_requests(
+			function () {
+				$this->manager->get_connected_site_data();
+				$this->manager->get_connected_site_data();
+			}
+		);
+
+		$this->assertSame( 1, $requests );
+	}
+
+	/**
+	 * A cached read still announces the record, so a consumer deriving its own state stays in
+	 * step with every request that serves it.
+	 */
+	public function test_a_cached_read_still_fires_the_site_data_action() {
+		$this->fake_http_response( 200, '{"ID":1234,"name":"Test site"}' );
+
+		$payloads = array();
+		add_action(
+			'jetpack_site_data_fetched',
+			function ( $payload ) use ( &$payloads ) {
+				$payloads[] = $payload;
+			}
+		);
+
+		$this->manager->get_connected_site_data();
+		$this->manager->get_connected_site_data();
+
+		$this->assertCount( 2, $payloads );
+		$this->assertSame( $payloads[0], $payloads[1] );
+	}
+
+	/**
+	 * A failure is cached as well, so an outage does not put a blocking request on every load.
+	 */
+	public function test_a_failed_fetch_is_also_cached() {
+		$this->fake_http_response( 500, '{"error":"unavailable"}' );
+
+		$requests = $this->count_http_requests(
+			function () {
+				$this->manager->get_connected_site_data();
+				$this->manager->get_connected_site_data();
+			}
+		);
+
+		$this->assertSame( 1, $requests );
+		$this->assertInstanceOf( 'WP_Error', $this->manager->get_connected_site_data() );
+	}
+
+	/**
+	 * A sandboxed request must not read the shared cache or seed it, otherwise sandbox data would
+	 * leak into ordinary requests.
+	 */
+	public function test_a_sandboxed_request_bypasses_the_cache() {
+		$this->fake_http_response( 200, '{"ID":1234,"name":"Test site"}' );
+		$_COOKIE['store_sandbox'] = 'sandbox.example.com';
+
+		$requests = $this->count_http_requests(
+			function () {
+				$this->manager->get_connected_site_data();
+				$this->manager->get_connected_site_data();
+			}
+		);
+
+		$this->assertSame( 2, $requests );
+		$this->assertFalse( get_transient( Manager::SITE_DATA_TRANSIENT_PREFIX . 1234 ) );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/Site_Data_Endpoint_Test.php
+++ b/projects/packages/connection/tests/php/Site_Data_Endpoint_Test.php
@@ -365,6 +365,27 @@ class Site_Data_Endpoint_Test extends BaseTestCase {
 	}
 
 	/**
+	 * A caller that reached WordPress.com by another route holds something newer than the cache
+	 * can. Dropping the cache has to send the next read back to WordPress.com, otherwise the
+	 * older record keeps being announced and undoes what that caller stored.
+	 */
+	public function test_dropping_the_cache_sends_the_next_read_to_wpcom() {
+		$this->fake_http_response( 200, '{"ID":1234,"name":"Test site"}' );
+
+		$requests = $this->count_http_requests(
+			function () {
+				$this->manager->get_connected_site_data();
+
+				Manager::delete_cached_site_data();
+
+				$this->manager->get_connected_site_data();
+			}
+		);
+
+		$this->assertSame( 2, $requests );
+	}
+
+	/**
 	 * A failure is cached as well, so an outage does not put a blocking request on every load.
 	 */
 	public function test_a_failed_fetch_is_also_cached() {

--- a/projects/packages/connection/tests/php/Site_Data_Endpoint_Test.php
+++ b/projects/packages/connection/tests/php/Site_Data_Endpoint_Test.php
@@ -46,6 +46,13 @@ class Site_Data_Endpoint_Test extends BaseTestCase {
 	private $rest_connector;
 
 	/**
+	 * Whether the test simulated a request signed by WordPress.com, so tear_down knows to undo it.
+	 *
+	 * @var bool
+	 */
+	private $signed_request_simulated = false;
+
+	/**
 	 * Set up the REST server and register the package routes.
 	 */
 	public function set_up() {
@@ -78,10 +85,69 @@ class Site_Data_Endpoint_Test extends BaseTestCase {
 
 		unset( $_COOKIE['store_sandbox'] );
 
+		if ( $this->signed_request_simulated ) {
+			unset( $_GET['_for'], $_GET['token'], $_GET['signature'], $_SERVER['REQUEST_METHOD'] );
+			self::clear_auth_singleton();
+			$this->signed_request_simulated = false;
+		}
+
 		StatusCache::clear();
 		Constants::clear_constants();
 
 		wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Delete any cached Rest_Authentication singleton.
+	 */
+	private static function clear_auth_singleton() {
+		$instance_property = ( new \ReflectionClass( Rest_Authentication::class ) )->getProperty( 'instance' );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$instance_property->setAccessible( true );
+		}
+		$instance_property->setValue( null, false );
+	}
+
+	/**
+	 * Make the current request read as signed with a user connection token, the way the
+	 * WordPress.com post-purchase plan refresh arrives.
+	 *
+	 * Drives the real `Rest_Authentication::wp_rest_authenticate()` with a mocked signature
+	 * verifier, because a real signature would consume a single-use nonce.
+	 */
+	private function sign_request_as_wpcom() {
+		$this->signed_request_simulated = true;
+
+		self::clear_auth_singleton();
+		$authentication = Rest_Authentication::init();
+
+		$verifier = $this->getMockBuilder( Manager::class )
+			->onlyMethods( array( 'verify_xml_rpc_signature' ) )
+			->getMock();
+		$verifier->expects( $this->once() )->method( 'verify_xml_rpc_signature' )->willReturn(
+			array(
+				'type'      => 'user',
+				'token_key' => 'asdasd',
+				'user_id'   => 1,
+			)
+		);
+
+		$manager_property = ( new \ReflectionClass( Rest_Authentication::class ) )->getProperty( 'connection_manager' );
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$manager_property->setAccessible( true );
+		}
+		$manager_property->setValue( $authentication, $verifier );
+
+		$_GET['_for']              = 'jetpack';
+		$_GET['token']             = 'asdasd:1:1';
+		$_GET['signature']         = 'signature';
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+
+		$authentication->wp_rest_authenticate( false );
+
+		$this->assertTrue( Rest_Authentication::is_signed_with_user_token() );
 	}
 
 	/**
@@ -445,6 +511,62 @@ class Site_Data_Endpoint_Test extends BaseTestCase {
 
 		$this->assertSame( 1, $requests );
 		$this->assertNotFalse( get_transient( Manager::SITE_DATA_TRANSIENT_PREFIX . 1234 ) );
+	}
+
+	/**
+	 * WordPress.com requests this route right after a purchase so the site stores the new plan.
+	 * That request arrives signed with a connection token. Serving it from the cache would hand
+	 * it the pre-purchase record and turn the refresh into a no-op, so a signed request reads
+	 * from WordPress.com and replaces the cache with the record it fetched.
+	 */
+	public function test_a_signed_request_reads_fresh_and_replaces_the_cache() {
+		$this->fake_http_response( 200, '{"ID":1234,"name":"After purchase"}' );
+
+		// A browser read moments earlier left the pre-purchase record in the cache.
+		set_transient(
+			Manager::SITE_DATA_TRANSIENT_PREFIX . 1234,
+			array( 'body' => '{"ID":1234,"name":"Before purchase"}' ),
+			5 * MINUTE_IN_SECONDS
+		);
+
+		$this->sign_request_as_wpcom();
+
+		$record   = null;
+		$requests = $this->count_http_requests(
+			function () use ( &$record ) {
+				$record = $this->manager->get_connected_site_data();
+			}
+		);
+
+		$this->assertSame( 1, $requests );
+		$this->assertSame( 'After purchase', $record->name );
+
+		$cached = get_transient( Manager::SITE_DATA_TRANSIENT_PREFIX . 1234 );
+		$this->assertSame( '{"ID":1234,"name":"After purchase"}', $cached['body'] );
+	}
+
+	/**
+	 * A signed read that fails must not replace a still-usable cached record with the failure,
+	 * or a hiccup during the WordPress.com refresh would put an error in front of every browser
+	 * read for the failure window.
+	 */
+	public function test_a_failed_signed_read_keeps_the_cached_record() {
+		$this->fake_http_response( 500, '{"error":"unavailable"}' );
+
+		set_transient(
+			Manager::SITE_DATA_TRANSIENT_PREFIX . 1234,
+			array( 'body' => '{"ID":1234,"name":"Before purchase"}' ),
+			5 * MINUTE_IN_SECONDS
+		);
+
+		$this->sign_request_as_wpcom();
+
+		$result = $this->manager->get_connected_site_data();
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+
+		$cached = get_transient( Manager::SITE_DATA_TRANSIENT_PREFIX . 1234 );
+		$this->assertSame( '{"ID":1234,"name":"Before purchase"}', $cached['body'] );
 	}
 
 	/**

--- a/projects/packages/connection/tests/php/Site_Data_Endpoint_Test.php
+++ b/projects/packages/connection/tests/php/Site_Data_Endpoint_Test.php
@@ -436,8 +436,10 @@ class Site_Data_Endpoint_Test extends BaseTestCase {
 
 		$requests = $this->count_http_requests(
 			function () {
-				$this->manager->get_connected_site_data();
-				$this->manager->get_connected_site_data();
+				$first  = $this->manager->get_connected_site_data();
+				$second = $this->manager->get_connected_site_data();
+
+				$this->assertEquals( $first, $second );
 			}
 		);
 

--- a/projects/packages/connection/tests/php/Site_Data_Endpoint_Test.php
+++ b/projects/packages/connection/tests/php/Site_Data_Endpoint_Test.php
@@ -514,6 +514,41 @@ class Site_Data_Endpoint_Test extends BaseTestCase {
 	}
 
 	/**
+	 * A `store_sandbox` cookie sent with no value sanitizes down to an empty string. Counting that
+	 * as a sandbox secret opts the request out of the cache and puts a `store_sandbox=;` header on
+	 * a request that has no sandbox to reach, so an empty cookie has to read as no cookie at all.
+	 */
+	public function test_an_empty_sandbox_cookie_is_not_a_sandboxed_request() {
+		$this->fake_http_response( 200, '{"ID":1234,"name":"Test site"}' );
+		$_COOKIE['store_sandbox'] = '';
+
+		$headers = null;
+		add_filter(
+			'pre_http_request',
+			function ( $pre, $args ) use ( &$headers ) {
+				$headers = $args['headers'];
+
+				return $pre;
+			},
+			1,
+			2
+		);
+
+		$requests = $this->count_http_requests(
+			function () {
+				$first  = $this->manager->get_connected_site_data();
+				$second = $this->manager->get_connected_site_data();
+
+				$this->assertEquals( $first, $second );
+			}
+		);
+
+		$this->assertSame( 1, $requests );
+		$this->assertNotFalse( get_transient( Manager::SITE_DATA_TRANSIENT_PREFIX . 1234 ) );
+		$this->assertArrayNotHasKey( 'cookie', array_change_key_case( (array) $headers ) );
+	}
+
+	/**
 	 * WordPress.com requests this route right after a purchase so the site stores the new plan.
 	 * That request arrives signed with a connection token. Serving it from the cache would hand
 	 * it the pre-purchase record and turn the refresh into a no-op, so a signed request reads

--- a/projects/packages/connection/tests/php/Site_Data_Endpoint_Test.php
+++ b/projects/packages/connection/tests/php/Site_Data_Endpoint_Test.php
@@ -531,15 +531,13 @@ class Site_Data_Endpoint_Test extends BaseTestCase {
 
 		$this->sign_request_as_wpcom();
 
-		$record   = null;
 		$requests = $this->count_http_requests(
-			function () use ( &$record ) {
-				$record = $this->manager->get_connected_site_data();
+			function () {
+				$this->assertSame( 'After purchase', $this->manager->get_connected_site_data()->name );
 			}
 		);
 
 		$this->assertSame( 1, $requests );
-		$this->assertSame( 'After purchase', $record->name );
 
 		$cached = get_transient( Manager::SITE_DATA_TRANSIENT_PREFIX . 1234 );
 		$this->assertSame( '{"ID":1234,"name":"After purchase"}', $cached['body'] );

--- a/projects/packages/connection/tests/php/Site_Data_Endpoint_Test.php
+++ b/projects/packages/connection/tests/php/Site_Data_Endpoint_Test.php
@@ -426,6 +426,26 @@ class Site_Data_Endpoint_Test extends BaseTestCase {
 	}
 
 	/**
+	 * `store_sandbox[]=` arrives as an array, which sanitizes down to an empty string. Treating
+	 * that as a sandbox secret would let any reader of the route opt their own requests out of
+	 * the cache, so it has to read as no cookie at all.
+	 */
+	public function test_an_array_sandbox_cookie_is_not_a_sandboxed_request() {
+		$this->fake_http_response( 200, '{"ID":1234,"name":"Test site"}' );
+		$_COOKIE['store_sandbox'] = array( 'sandbox.example.com' );
+
+		$requests = $this->count_http_requests(
+			function () {
+				$this->manager->get_connected_site_data();
+				$this->manager->get_connected_site_data();
+			}
+		);
+
+		$this->assertSame( 1, $requests );
+		$this->assertNotFalse( get_transient( Manager::SITE_DATA_TRANSIENT_PREFIX . 1234 ) );
+	}
+
+	/**
 	 * A failed fetch must not fire the action, otherwise consumers would cache an error body.
 	 */
 	public function test_failed_fetch_does_not_fire_the_site_data_action() {

--- a/projects/packages/connection/tests/php/Site_Data_Endpoint_Test.php
+++ b/projects/packages/connection/tests/php/Site_Data_Endpoint_Test.php
@@ -549,6 +549,24 @@ class Site_Data_Endpoint_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Only the array shape this method stores can be served. A `pre_transient_*` filter or a
+	 * damaged object cache entry can hand back anything, and reading a body off a non-array would
+	 * throw for every request until the entry expired. An unusable entry has to fail open.
+	 */
+	public function test_an_unusable_cache_entry_is_refetched() {
+		$this->fake_http_response( 200, '{"ID":1234,"name":"Test site"}' );
+		set_transient( Manager::SITE_DATA_TRANSIENT_PREFIX . 1234, 'not-an-array', 5 * MINUTE_IN_SECONDS );
+
+		$record = $this->manager->get_connected_site_data();
+
+		$this->assertSame( 'Test site', $record->name );
+		$this->assertSame(
+			array( 'body' => '{"ID":1234,"name":"Test site"}' ),
+			get_transient( Manager::SITE_DATA_TRANSIENT_PREFIX . 1234 )
+		);
+	}
+
+	/**
 	 * WordPress.com requests this route right after a purchase so the site stores the new plan.
 	 * That request arrives signed with a connection token. Serving it from the cache would hand
 	 * it the pre-purchase record and turn the refresh into a no-op, so a signed request reads

--- a/projects/packages/plans/changelog/jetpack-2126-site-data-perf-follow-up
+++ b/projects/packages/plans/changelog/jetpack-2126-site-data-perf-follow-up
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stop deleting and rewriting the plan and product options when the stored value is unchanged.

--- a/projects/packages/plans/src/class-current-plan.php
+++ b/projects/packages/plans/src/class-current-plan.php
@@ -226,13 +226,20 @@ class Current_Plan {
 	private static function store_data_in_option( $option, $data ) {
 		$result = update_option( $option, $data, true );
 
-		// If something goes wrong with the update, so delete the current option and then update it.
-		if ( ! $result ) {
-			delete_option( $option );
-			$result = update_option( $option, $data, true );
+		if ( $result ) {
+			return true;
 		}
 
-		return $result;
+		// update_option() also reports false when the stored value already matches, which is not a
+		// failure. Without this the option is deleted and rewritten on every unchanged fetch.
+		if ( get_option( $option ) === $data ) {
+			return true;
+		}
+
+		// If something goes wrong with the update, so delete the current option and then update it.
+		delete_option( $option );
+
+		return update_option( $option, $data, true );
 	}
 
 	/**

--- a/projects/packages/plans/src/class-current-plan.php
+++ b/projects/packages/plans/src/class-current-plan.php
@@ -267,7 +267,16 @@ class Current_Plan {
 			'1.1'
 		);
 
-		return self::update_from_sites_response( $response );
+		$updated = self::update_from_sites_response( $response );
+
+		// The shared site record cache can still hold a record older than this response, and a
+		// cached read stores the plan again. Dropping it keeps that older record from reverting
+		// what this fetch just stored.
+		if ( ! is_wp_error( $response ) ) {
+			Manager::delete_cached_site_data();
+		}
+
+		return $updated;
 	}
 
 	/**

--- a/projects/packages/plans/src/class-current-plan.php
+++ b/projects/packages/plans/src/class-current-plan.php
@@ -231,12 +231,13 @@ class Current_Plan {
 		}
 
 		// update_option() also reports false when the stored value already matches, which is not a
-		// failure. Without this the option is deleted and rewritten on every unchanged fetch.
+		// failure. Both options are autoloaded, so reading it as one rewrites them on every
+		// unchanged fetch and drops the alloptions cache with it.
 		if ( get_option( $option ) === $data ) {
 			return true;
 		}
 
-		// If something goes wrong with the update, so delete the current option and then update it.
+		// If the update genuinely failed, delete the option and write it again.
 		delete_option( $option );
 
 		return update_option( $option, $data, true );

--- a/projects/packages/plans/tests/php/Jetpack_Plan_Test.php
+++ b/projects/packages/plans/tests/php/Jetpack_Plan_Test.php
@@ -5,6 +5,7 @@
 
 namespace Automattic\Jetpack;
 
+use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Current_Plan as Jetpack_Plan;
 use Jetpack_Options;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -17,11 +18,60 @@ use WP_Error;
 class Jetpack_Plan_Test extends TestCase {
 
 	/**
+	 * Blog ID the connection state and the cached site record are keyed on.
+	 */
+	const TEST_BLOG_ID = 1234;
+
+	/**
 	 * Setting up the test.
 	 */
 	public function setUp(): void {
 		parent::setUp();
 		delete_option( 'jetpack_active_plan' );
+	}
+
+	/**
+	 * Returning the environment to its initial state. This class does not roll the database back
+	 * between tests, so connection state a test writes would otherwise reach the next one.
+	 */
+	public function tearDown(): void {
+		Jetpack_Options::delete_option( array( 'id', 'blog_token' ) );
+		delete_transient( Manager::SITE_DATA_TRANSIENT_PREFIX . self::TEST_BLOG_ID );
+		Constants::clear_constants();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * A refresh reads WordPress.com directly, so the shared site record cache can still hold an
+	 * older record. A cached read stores the plan again, so leaving that copy in place would
+	 * revert the plan this fetch just stored — the case a plan purchase hits.
+	 */
+	public function test_a_refresh_drops_the_cached_site_record() {
+		Jetpack_Options::update_option( 'blog_token', 'asdasd.123123' );
+		Jetpack_Options::update_option( 'id', self::TEST_BLOG_ID );
+		( new Manager() )->reset_connection_status();
+
+		// Signing needs an absolute URL, so the API base has to resolve.
+		Constants::set_constant( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+		Constants::set_constant( 'JETPACK__API_VERSION', 1 );
+
+		$transient_key = Manager::SITE_DATA_TRANSIENT_PREFIX . self::TEST_BLOG_ID;
+		set_transient( $transient_key, array( 'body' => wp_json_encode( array( 'plan' => self::get_free_plan() ), JSON_UNESCAPED_SLASHES ) ) );
+
+		$serve_personal_plan = function () {
+			return array(
+				'response' => array( 'code' => 200 ),
+				'body'     => wp_json_encode( array( 'plan' => self::get_personal_plan() ), JSON_UNESCAPED_SLASHES ),
+			);
+		};
+
+		add_filter( 'pre_http_request', $serve_personal_plan );
+		$updated = Jetpack_Plan::refresh_from_wpcom();
+		remove_filter( 'pre_http_request', $serve_personal_plan );
+
+		$this->assertTrue( $updated );
+		$this->assertFalse( get_transient( $transient_key ), 'A stale record would overwrite the plan this refresh stored.' );
 	}
 
 	public function test_update_from_sites_response_failure_to_update() {

--- a/projects/packages/plans/tests/php/Jetpack_Plan_Test.php
+++ b/projects/packages/plans/tests/php/Jetpack_Plan_Test.php
@@ -37,6 +37,32 @@ class Jetpack_Plan_Test extends TestCase {
 	}
 
 	/**
+	 * A record that matches what is already stored must not touch the options. `update_option()`
+	 * reports false for an unchanged value, which previously read as a failure and triggered a
+	 * delete plus a rewrite of an autoloaded option on every fetch.
+	 */
+	public function test_an_unchanged_record_does_not_rewrite_the_options() {
+		$record = array(
+			'plan'     => array( 'product_slug' => 'jetpack_personal' ),
+			'products' => array( array( 'product_slug' => 'jetpack_backup_t1_yearly' ) ),
+		);
+
+		Jetpack_Plan::update_from_site_record( $record );
+
+		$deleted = array();
+		add_action(
+			'delete_option',
+			function ( $option ) use ( &$deleted ) {
+				$deleted[] = $option;
+			}
+		);
+
+		Jetpack_Plan::update_from_site_record( $record );
+
+		$this->assertSame( array(), $deleted );
+	}
+
+	/**
 	 * @dataProvider get_update_from_sites_response_data
 	 */
 	#[DataProvider( 'get_update_from_sites_response_data' )]

--- a/projects/plugins/jetpack/changelog/jetpack-2126-site-data-perf-follow-up
+++ b/projects/plugins/jetpack/changelog/jetpack-2126-site-data-perf-follow-up
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Connection: Cache the WordPress.com site record briefly so the Jetpack dashboard does not make a request per view.


### PR DESCRIPTION
Follow-up to #51057, for the two performance items raised in review there and deliberately scoped out of that PR.

## Proposed changes
* `Current_Plan::store_data_in_option()` read `update_option()`'s return value as a success flag. `update_option()` also returns `false` when the stored value already matches, so an unchanged value took the failure path and did a `delete_option()` plus a rewrite. Both options are autoloaded, so each pointless write also dropped the `alloptions` cache that every request depends on. This happened on every `/jetpack/v4/site` hit. The plan option was shielded by the equality check in `update_from_site_record()`, so in practice it hit the products option, which has none.
* `Manager::get_connected_site_data()` now caches the WordPress.com site record in a transient — five minutes for a success, two for a failure, so an outage recovers without waiting out a full success window. Every plugin bundling the Connection package serves this route and the Jetpack dashboard requests it on mount, so an uncached read was a blocking round trip per render.

Four details worth knowing while reviewing:

* `jetpack_site_data_fetched` still fires on a cached read, not only when the request reached WordPress.com. A consumer that derives its own state stays in step with every request that serves the record. This is cheap now that an unchanged record no longer writes options.
* Because of that, `Current_Plan::refresh_from_wpcom()` drops the cached record after a successful fetch. It reads `/sites/%d` directly, so the cache can still hold an older record, and a cached read would store the plan again and revert what the refresh just wrote. This is the path a plan purchase takes, through `?plan_upgraded=1` in the editor.
* A request signed with a connection token skips the cache read and replaces the cache with the record it fetches. WordPress.com requests this route right after a purchase, for the side effect of the site storing the new plan (Automattic/wp-calypso#33794), and a cached read would hand that refresh the pre-purchase record and turn it into a no-op. A failed signed read does not overwrite a still-usable cached record.
* A request carrying a `store_sandbox` cookie neither reads the cache nor seeds it. The entry is dropped on disconnect and on any fresh refresh. The blog ID is part of the key, so a reconnect to a different site cannot read the previous record.

## Related product discussion/links
* JETPACK-2126
* Requested in the review of #51057
* P2 discussion on the cache duration and invalidation: p1HpG7-yvW-p2

## Does this pull request change what data or activity we track or use?

No. Same request and same response. It is made less often.

## Testing instructions

Both changes are about how often we write and request, so the checks are about counting, not about output. The response body should not change at all.

**Caching**

* Open Jetpack → Dashboard on a connected site. Confirm the plan shows correctly.
* Reload within five minutes. Confirm only the first load makes an outbound request to `/sites/<blog_id>`. Query Monitor's HTTP panel, or a `pre_http_request` log, will show this.
* Wait out the five minutes, reload, and confirm a fresh request goes out.
* Confirm `/wp-json/jetpack/v4/site` returns the same payload as before on both the fresh and the cached read.

**Option writes**

* With a query log running, hit `/wp-json/jetpack/v4/site` twice while the plan and products are unchanged.
* Before this change the second hit produced a `DELETE` and an `INSERT` on `jetpack_site_products`. It should now produce neither.

**Invalidation**

* Disconnect the site and reconnect it. Confirm the record is fetched again rather than served from the previous connection.
* With a `store_sandbox` cookie set, confirm every request still reaches the sandbox rather than a cached response.
* Buy a plan or product on WordPress.com checkout while the cache is warm (dashboard loaded within the last five minutes). Confirm `jetpack_active_plan` holds the new plan right after checkout, without waiting out the window: the post-purchase request from WordPress.com arrives signed and must go past the cache. The signed-request tests in `Site_Data_Endpoint_Test` cover the same path without a purchase.
* Load Jetpack → Dashboard to seed the cache, then change the plan on WordPress.com and open the editor with `?plan_upgraded=1`. Confirm `jetpack_active_plan` holds the new plan, and still holds it after another `/wp-json/jetpack/v4/site` request inside the five-minute window.


