### PR TITLE
VideoPress: move the chapters list into a side panel in the chapters editors

### DIFF
--- a/projects/packages/videopress/changelog/update-videopress-chapters-sidebar-layout
+++ b/projects/packages/videopress/changelog/update-videopress-chapters-sidebar-layout
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Chapters editor: move the chapter list into a side panel beside the preview and timeline.

--- a/projects/packages/videopress/routes/video-editor/stage.tsx
+++ b/projects/packages/videopress/routes/video-editor/stage.tsx
@@ -27,6 +27,7 @@ import { redo as redoIcon, undo as undoIcon } from '@wordpress/icons';
 import { Link, useNavigate, useParams } from '@wordpress/route';
 import { Button, Dialog, Stack, Text } from '@wordpress/ui';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import ChaptersPanel from '../../src/client/components/chapters-editor/chapters/chapters-panel';
 import ChaptersTimeline from '../../src/client/components/chapters-editor/chapters/chapters-timeline';
 import ChaptersPreviewPlayer from '../../src/client/components/chapters-editor/preview/preview-player';
 import { usePreviewTransport } from '../../src/client/components/chapters-editor/preview/use-preview-transport';
@@ -536,38 +537,55 @@ function EditorReady( { video }: ReadyProps ): ReactElement {
 				<div className="vp-video-editor vp-chapters-tokens">
 					<div className="vp-video-editor__body">
 						<EditorOperationsPanel />
-						<div className="vp-video-editor__main">
-							<div className="vp-video-editor__canvas">
-								<ChaptersPreviewPlayer
-									ref={ playerRef }
-									video={ video }
-									fallbackPlaybackUrl={ playbackFallbackUrl }
-									onTimeUpdate={ onTimeUpdate }
-									onPlayingChange={ onPlayingChange }
-								/>
+						<div className="vp-video-editor__workspace">
+							<div className="vp-video-editor__main">
+								<div className="vp-video-editor__canvas">
+									<ChaptersPreviewPlayer
+										ref={ playerRef }
+										video={ video }
+										fallbackPlaybackUrl={ playbackFallbackUrl }
+										onTimeUpdate={ onTimeUpdate }
+										onPlayingChange={ onPlayingChange }
+									/>
+								</div>
+								<div
+									className={
+										'vp-video-editor__timeline-section vp-video-editor__timeline' +
+										( chaptersLocked ? ' vp-video-editor__timeline--locked' : '' )
+									}
+									data-testid="chapters-timeline-lock"
+									aria-busy={ chaptersLocked || undefined }
+								>
+									{ /* The timeline owns the document-level shortcuts instance
+									     (space, arrows, Delete, mod+Z); it detaches while the
+									     discard confirm dialog is open. */ }
+									<ChaptersTimeline
+										session={ session }
+										dispatch={ dispatch }
+										currentMs={ currentMs }
+										onSeek={ onSeek }
+										onTogglePlay={ onTogglePlay }
+										playing={ playing }
+										locked={ chaptersLocked }
+										onScrubStart={ onScrubStart }
+										onScrubEnd={ onScrubEnd }
+										shortcutsEnabled={ ! confirmDiscardOpen }
+										readOnly={ chaptersProbe === 'manual' }
+									/>
+								</div>
 							</div>
 							<div
 								className={
-									'vp-video-editor__timeline-section vp-video-editor__timeline' +
-									( chaptersLocked ? ' vp-video-editor__timeline--locked' : '' )
+									'vp-video-editor__panel' +
+									( chaptersLocked ? ' vp-video-editor__panel--locked' : '' )
 								}
-								data-testid="chapters-timeline-lock"
 								aria-busy={ chaptersLocked || undefined }
 							>
-								{ /* The timeline owns the document-level shortcuts instance
-								     (space, arrows, Delete, mod+Z); it detaches while the
-								     discard confirm dialog is open. */ }
-								<ChaptersTimeline
+								<ChaptersPanel
 									session={ session }
 									dispatch={ dispatch }
-									currentMs={ currentMs }
 									onSeek={ onSeek }
-									onTogglePlay={ onTogglePlay }
-									playing={ playing }
 									locked={ chaptersLocked }
-									onScrubStart={ onScrubStart }
-									onScrubEnd={ onScrubEnd }
-									shortcutsEnabled={ ! confirmDiscardOpen }
 									readOnly={ chaptersProbe === 'manual' }
 								/>
 							</div>

--- a/projects/packages/videopress/routes/video-editor/style.scss
+++ b/projects/packages/videopress/routes/video-editor/style.scss
@@ -185,7 +185,7 @@
 // stacked layout every width had before the side panel existed. Keyed off
 // the card's own width (the wp-admin sidebar states and the tools rail make
 // viewport width a poor proxy for it).
-@container ( max-width: 1023px ) {
+@container ( max-inline-size: 1023px ) {
 
 	.vp-video-editor__workspace {
 		flex-direction: column;

--- a/projects/packages/videopress/routes/video-editor/style.scss
+++ b/projects/packages/videopress/routes/video-editor/style.scss
@@ -192,16 +192,16 @@
 	}
 
 	.vp-video-editor__panel {
+		// The page scrolls the stacked layout, so the panel's list stops
+		// scrolling internally (a published knob on the shared panel).
+		--vp-chapters-panel-list-overflow: visible;
+
 		inline-size: auto;
 		border-inline-start: 0;
 		border-block-start: 1px solid var(--vp-gray-200);
 
 		.vp-chapters-panel {
 			position: static;
-		}
-
-		.vp-chapters-panel__list {
-			overflow-y: visible;
 		}
 	}
 }

--- a/projects/packages/videopress/routes/video-editor/style.scss
+++ b/projects/packages/videopress/routes/video-editor/style.scss
@@ -20,12 +20,26 @@
 }
 
 .vp-video-editor__body {
+	// The card is the query container deciding when the chapters panel drops
+	// below the main column, so the arrangement keys off the space the card
+	// actually has (wp-admin sidebar and tools rail already subtracted from
+	// the viewport) rather than the viewport itself.
+	container-type: inline-size;
 	display: flex;
 	align-items: stretch;
 	border: 1px solid var(--vp-gray-300);
 	border-radius: var(--vp-radius-medium);
 	background: #fff;
 	overflow: hidden;
+}
+
+// Everything beside the tools rail: the main column (canvas + timeline) with
+// the chapters panel to its right.
+.vp-video-editor__workspace {
+	flex: 1;
+	min-inline-size: 0;
+	display: flex;
+	align-items: stretch;
 }
 
 // The tools rail: a fixed-width "Edit" section of icon + label items, the
@@ -108,8 +122,31 @@
 	.vp-chapters-preview {
 		inline-size: 100%;
 		margin-inline: auto;
-		max-inline-size: min(640px, calc(var(--vp-chapters-stage-max-height, 612px) * 16 / 9));
+		max-inline-size: min(880px, calc(var(--vp-chapters-stage-max-height, 612px) * 16 / 9));
 	}
+}
+
+// The chapters panel rail: fixed width beside the main column. The panel
+// component is pulled out of flow (absolute against this wrapper) so the
+// row's height is set by the main column alone — a long chapter list
+// scrolls inside the panel instead of stretching the card past the canvas.
+.vp-video-editor__panel {
+	position: relative;
+	flex: none;
+	inline-size: 320px;
+	border-inline-start: 1px solid var(--vp-gray-200);
+
+	.vp-chapters-panel {
+		position: absolute;
+		inset: 0;
+		padding: 16px;
+	}
+}
+
+// Same presentation-only dim as the timeline while a probe or save locks
+// editing; the panel's own controls disable individually.
+.vp-video-editor__panel--locked {
+	opacity: 0.6;
 }
 
 // The timeline docked below the canvas, full width.
@@ -144,6 +181,31 @@
 	background: var(--vp-gray-300, #ddd);
 }
 
+// Narrow card: the chapters panel drops below the main column — the same
+// stacked layout every width had before the side panel existed. Keyed off
+// the card's own width (the wp-admin sidebar states and the tools rail make
+// viewport width a poor proxy for it).
+@container ( max-width: 1023px ) {
+
+	.vp-video-editor__workspace {
+		flex-direction: column;
+	}
+
+	.vp-video-editor__panel {
+		inline-size: auto;
+		border-inline-start: 0;
+		border-block-start: 1px solid var(--vp-gray-200);
+
+		.vp-chapters-panel {
+			position: static;
+		}
+
+		.vp-chapters-panel__list {
+			overflow-y: visible;
+		}
+	}
+}
+
 // Narrow viewports (wp-admin's mobile breakpoint): the rail collapses to
 // icon-only — the tool buttons keep their accessible names via aria-label —
 // leaving the width to the chapters editor, and the widest single-line rows
@@ -175,14 +237,6 @@
 
 	.vp-video-editor__timeline-section {
 		padding-inline: 16px;
-	}
-
-	// Page-scoped override of the shared timeline toolbar: its single line
-	// (transport, add-at-playhead, now-indicator, zoom) is wider than a phone
-	// viewport; wrapping keeps every control reachable without side-scroll.
-	.vp-chapters-timeline__toolbar {
-		flex-wrap: wrap;
-		row-gap: 8px;
 	}
 
 	.vp-video-editor__header-actions {

--- a/projects/packages/videopress/src/client/components/chapter-manager-modal/index.tsx
+++ b/projects/packages/videopress/src/client/components/chapter-manager-modal/index.tsx
@@ -16,6 +16,7 @@ import { probeManualTrack } from '../../utils/video-chapters/probe-manual-track'
 import { syncChapters } from '../../utils/video-chapters/sync-chapters';
 import ConfirmationOverlay from '../caption-manager-modal/confirmation-overlay';
 import { useCaptionSnackbars } from '../caption-manager-modal/use-caption-snackbars';
+import ChaptersPanel from '../chapters-editor/chapters/chapters-panel';
 import ChaptersTimeline from '../chapters-editor/chapters/chapters-timeline';
 import ChaptersPreviewPlayer from '../chapters-editor/preview/preview-player';
 import { usePreviewTransport } from '../chapters-editor/preview/use-preview-transport';
@@ -419,7 +420,7 @@ export default function ChapterManagerModal( {
 	const videoTitle = title || __( 'VideoPress video', 'jetpack-videopress-pkg' );
 	const modalHeaderTitle = sprintf(
 		/* translators: %s: video title. */
-		__( 'Manage chapters for %s', 'jetpack-videopress-pkg' ),
+		__( 'Chapters · %s', 'jetpack-videopress-pkg' ),
 		videoTitle
 	);
 
@@ -437,56 +438,66 @@ export default function ChapterManagerModal( {
 			isDismissible={ false }
 			shouldCloseOnClickOutside={ false }
 			headerActions={
-				<Button
-					size="small"
-					icon={ close }
-					label={ __( 'Close', 'jetpack-videopress-pkg' ) }
-					onClick={ handleRequestClose }
-				/>
+				/*
+				 * All the session actions live in the modal header, one row with
+				 * the title. The header sits OUTSIDE the body's keyboard wrapper
+				 * and the confirmation overlay (which covers only the children
+				 * container), so the same keydown handler is attached here — a
+				 * vetoed Escape must not fall through to the Modal's
+				 * animate-then-close handling — and every state-changing action
+				 * is disabled while the discard confirmation is up. Close stays
+				 * live: it routes through the same confirmation flow.
+				 */
+				// eslint-disable-next-line jsx-a11y/no-static-element-interactions -- Intercepts Escape before the Modal's animate-then-close handling and maps the editor shortcuts, same as the body wrapper below.
+				<div className="videopress-chapter-manager__header-actions" onKeyDown={ handleBodyKeyDown }>
+					<Button
+						size="small"
+						icon={ undoIcon }
+						label={ __( 'Undo', 'jetpack-videopress-pkg' ) }
+						disabled={
+							chaptersLocked || confirmation !== null || ! canUndo( history, chaptersEditsEqual )
+						}
+						accessibleWhenDisabled
+						onClick={ () => dispatch( { type: 'UNDO' } ) }
+					/>
+					<Button
+						size="small"
+						icon={ redoIcon }
+						label={ __( 'Redo', 'jetpack-videopress-pkg' ) }
+						disabled={ chaptersLocked || confirmation !== null || ! canRedo( history ) }
+						accessibleWhenDisabled
+						onClick={ () => dispatch( { type: 'REDO' } ) }
+					/>
+					<span className="videopress-chapter-manager__header-divider" aria-hidden="true" />
+					<Button
+						variant="secondary"
+						size="compact"
+						onClick={ requestDiscard }
+						disabled={ chaptersLocked || confirmation !== null || ! effectiveDirty }
+					>
+						{ __( 'Discard changes', 'jetpack-videopress-pkg' ) }
+					</Button>
+					<Button
+						variant="primary"
+						size="compact"
+						onClick={ () => void doSave() }
+						isBusy={ metaSavePending }
+						disabled={ chaptersLocked || confirmation !== null || ! effectiveDirty }
+					>
+						{ __( 'Save', 'jetpack-videopress-pkg' ) }
+					</Button>
+					<span className="videopress-chapter-manager__header-divider" aria-hidden="true" />
+					<Button
+						size="small"
+						icon={ close }
+						label={ __( 'Close', 'jetpack-videopress-pkg' ) }
+						onClick={ handleRequestClose }
+					/>
+				</div>
 			}
 		>
 			{ /* eslint-disable-next-line jsx-a11y/no-static-element-interactions -- Intercepts Escape before the Modal's animate-then-close handling and maps the editor shortcuts. */ }
 			<div className="videopress-chapter-manager__body" onKeyDown={ handleBodyKeyDown }>
-				<div className="videopress-chapter-manager__action-bar">
-					<h3 className="videopress-chapter-manager__action-bar-title">
-						{ __( 'Chapters', 'jetpack-videopress-pkg' ) }
-					</h3>
-					<div className="videopress-chapter-manager__action-buttons">
-						<Button
-							size="small"
-							icon={ undoIcon }
-							label={ __( 'Undo', 'jetpack-videopress-pkg' ) }
-							disabled={ chaptersLocked || ! canUndo( history, chaptersEditsEqual ) }
-							accessibleWhenDisabled
-							onClick={ () => dispatch( { type: 'UNDO' } ) }
-						/>
-						<Button
-							size="small"
-							icon={ redoIcon }
-							label={ __( 'Redo', 'jetpack-videopress-pkg' ) }
-							disabled={ chaptersLocked || ! canRedo( history ) }
-							accessibleWhenDisabled
-							onClick={ () => dispatch( { type: 'REDO' } ) }
-						/>
-						<span className="videopress-chapter-manager__action-divider" aria-hidden="true" />
-						<Button
-							variant="secondary"
-							onClick={ requestDiscard }
-							disabled={ chaptersLocked || ! effectiveDirty }
-						>
-							{ __( 'Discard changes', 'jetpack-videopress-pkg' ) }
-						</Button>
-						<Button
-							variant="primary"
-							onClick={ () => void doSave() }
-							isBusy={ metaSavePending }
-							disabled={ chaptersLocked || ! effectiveDirty }
-						>
-							{ __( 'Save', 'jetpack-videopress-pkg' ) }
-						</Button>
-					</div>
-				</div>
-
 				<div
 					className="videopress-chapter-manager__workspace vp-chapters-tokens"
 					ref={ workspaceRef }
@@ -507,53 +518,70 @@ export default function ChapterManagerModal( {
 						</p>
 					) }
 					{ itemState === 'ready' && (
-						<>
-							{ /*
-							 * The same minimal player as the dashboard's Editor tab:
-							 * a bare <video> stage on the H.264 rendition derived
-							 * from the on-open item fetch (private videos are signed
-							 * with a playback JWT inside the player). It is the
-							 * playhead source for the timeline below and stays
-							 * mounted at every viewport width. The item's original
-							 * upload URL is deliberately not offered as a fallback —
-							 * without a ready rendition the player explains that the
-							 * video has no playable source yet.
-							 */ }
-							<ChaptersPreviewPlayer
-								ref={ playerRef }
-								video={ {
-									guid,
-									isPrivate,
-									durationSeconds: ( itemDurationMs ?? 0 ) / 1000,
-									playbackUrl,
-									sourceUrl: undefined,
-								} }
-								onTimeUpdate={ onTimeUpdate }
-								onPlayingChange={ onPlayingChange }
-							/>
+						<div className="videopress-chapter-manager__panes">
+							<div className="videopress-chapter-manager__pane-main">
+								{ /*
+								 * The same minimal player as the dashboard's Editor tab:
+								 * a bare <video> stage on the H.264 rendition derived
+								 * from the on-open item fetch (private videos are signed
+								 * with a playback JWT inside the player). It is the
+								 * playhead source for the timeline below and stays
+								 * mounted at every viewport width. The item's original
+								 * upload URL is deliberately not offered as a fallback —
+								 * without a ready rendition the player explains that the
+								 * video has no playable source yet.
+								 */ }
+								<ChaptersPreviewPlayer
+									ref={ playerRef }
+									video={ {
+										guid,
+										isPrivate,
+										durationSeconds: ( itemDurationMs ?? 0 ) / 1000,
+										playbackUrl,
+										sourceUrl: undefined,
+									} }
+									onTimeUpdate={ onTimeUpdate }
+									onPlayingChange={ onPlayingChange }
+								/>
+								<div
+									className={
+										'videopress-chapter-manager__editor' +
+										( chaptersLocked ? ' videopress-chapter-manager__editor--locked' : '' )
+									}
+									aria-busy={ chaptersLocked || undefined }
+								>
+									<ChaptersTimeline
+										session={ session }
+										dispatch={ dispatch }
+										currentMs={ currentMs }
+										onSeek={ onSeek }
+										onTogglePlay={ onTogglePlay }
+										playing={ playing }
+										locked={ chaptersLocked }
+										onScrubStart={ onScrubStart }
+										onScrubEnd={ onScrubEnd }
+										// The body's onKeyDown above maps the same keys instead.
+										shortcutsEnabled={ false }
+										readOnly={ readOnly }
+									/>
+								</div>
+							</div>
 							<div
 								className={
-									'videopress-chapter-manager__editor' +
-									( chaptersLocked ? ' videopress-chapter-manager__editor--locked' : '' )
+									'videopress-chapter-manager__panel' +
+									( chaptersLocked ? ' videopress-chapter-manager__panel--locked' : '' )
 								}
 								aria-busy={ chaptersLocked || undefined }
 							>
-								<ChaptersTimeline
+								<ChaptersPanel
 									session={ session }
 									dispatch={ dispatch }
-									currentMs={ currentMs }
 									onSeek={ onSeek }
-									onTogglePlay={ onTogglePlay }
-									playing={ playing }
 									locked={ chaptersLocked }
-									onScrubStart={ onScrubStart }
-									onScrubEnd={ onScrubEnd }
-									// The body's onKeyDown above maps the same keys instead.
-									shortcutsEnabled={ false }
 									readOnly={ readOnly }
 								/>
 							</div>
-						</>
+						</div>
 					) }
 				</div>
 

--- a/projects/packages/videopress/src/client/components/chapter-manager-modal/index.tsx
+++ b/projects/packages/videopress/src/client/components/chapter-manager-modal/index.tsx
@@ -2,8 +2,14 @@
  * External dependencies
  */
 import { Button, Modal, SnackbarList } from '@wordpress/components';
-import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
-import { __, _x } from '@wordpress/i18n';
+import {
+	createInterpolateElement,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from '@wordpress/element';
+import { __, _x, sprintf } from '@wordpress/i18n';
 import { close, redo as redoIcon, undo as undoIcon } from '@wordpress/icons';
 /**
  * Internal dependencies
@@ -426,17 +432,20 @@ export default function ChapterManagerModal( {
 	const videoTitle = title || __( 'VideoPress video', 'jetpack-videopress-pkg' );
 	/*
 	 * Two-tone header: "Chapters" carries the heading weight, the video name
-	 * hangs off it in a muted color. Modal's `title` prop is typed as a
+	 * hangs off it in a muted color. One msgid so translators can reorder
+	 * the parts or swap the separator. Modal's `title` prop is typed as a
 	 * string but is rendered as the h1's children, so a node works at
 	 * runtime — and aria-labelledby reads the heading's text content, which
 	 * still announces as "Chapters · {title}".
 	 */
-	const modalHeaderTitle = (
-		<>
-			{ __( 'Chapters', 'jetpack-videopress-pkg' ) }
-			<span className="videopress-chapter-manager__title-video">{ ` · ${ videoTitle }` }</span>
-		</>
-	 ) as unknown as string;
+	const modalHeaderTitle = createInterpolateElement(
+		sprintf(
+			/* translators: %s: video title, rendered muted after the "Chapters" label. */
+			__( 'Chapters<sep> · %s</sep>', 'jetpack-videopress-pkg' ),
+			videoTitle
+		),
+		{ sep: <span className="videopress-chapter-manager__title-video" /> }
+	) as unknown as string;
 
 	return isOpen ? (
 		<Modal
@@ -484,12 +493,16 @@ export default function ChapterManagerModal( {
 						className="videopress-chapter-manager__header-divider videopress-chapter-manager__header-divider--session"
 						aria-hidden="true"
 					/>
+					{ /* accessibleWhenDisabled keeps these focusable while disabled,
+					     so completing a save (which disables Save) cannot dump
+					     keyboard focus onto <body> inside the focus-trapped modal. */ }
 					<Button
 						className="videopress-chapter-manager__header-discard"
 						variant="secondary"
 						size="compact"
 						onClick={ requestDiscard }
 						disabled={ actionsFrozen || ! effectiveDirty }
+						accessibleWhenDisabled
 					>
 						{ __( 'Discard changes', 'jetpack-videopress-pkg' ) }
 					</Button>
@@ -499,6 +512,7 @@ export default function ChapterManagerModal( {
 						onClick={ () => void doSave() }
 						isBusy={ metaSavePending }
 						disabled={ actionsFrozen || ! effectiveDirty }
+						accessibleWhenDisabled
 					>
 						{ __( 'Save', 'jetpack-videopress-pkg' ) }
 					</Button>

--- a/projects/packages/videopress/src/client/components/chapter-manager-modal/index.tsx
+++ b/projects/packages/videopress/src/client/components/chapter-manager-modal/index.tsx
@@ -417,6 +417,12 @@ export default function ChapterManagerModal( {
 		[ confirmation, dispatch, handleRequestClose, onTogglePlay, readOnly, session.selectedId ]
 	);
 
+	// The header's state-changing actions freeze while the editor is locked
+	// or the discard confirmation is up (the overlay covers only the modal
+	// body, not the header). Close stays live: it routes through the same
+	// confirmation flow.
+	const actionsFrozen = chaptersLocked || confirmation !== null;
+
 	const videoTitle = title || __( 'VideoPress video', 'jetpack-videopress-pkg' );
 	/*
 	 * Two-tone header: "Chapters" carries the heading weight, the video name
@@ -462,9 +468,7 @@ export default function ChapterManagerModal( {
 						size="small"
 						icon={ undoIcon }
 						label={ __( 'Undo', 'jetpack-videopress-pkg' ) }
-						disabled={
-							chaptersLocked || confirmation !== null || ! canUndo( history, chaptersEditsEqual )
-						}
+						disabled={ actionsFrozen || ! canUndo( history, chaptersEditsEqual ) }
 						accessibleWhenDisabled
 						onClick={ () => dispatch( { type: 'UNDO' } ) }
 					/>
@@ -472,16 +476,20 @@ export default function ChapterManagerModal( {
 						size="small"
 						icon={ redoIcon }
 						label={ __( 'Redo', 'jetpack-videopress-pkg' ) }
-						disabled={ chaptersLocked || confirmation !== null || ! canRedo( history ) }
+						disabled={ actionsFrozen || ! canRedo( history ) }
 						accessibleWhenDisabled
 						onClick={ () => dispatch( { type: 'REDO' } ) }
 					/>
-					<span className="videopress-chapter-manager__header-divider" aria-hidden="true" />
+					<span
+						className="videopress-chapter-manager__header-divider videopress-chapter-manager__header-divider--session"
+						aria-hidden="true"
+					/>
 					<Button
+						className="videopress-chapter-manager__header-discard"
 						variant="secondary"
 						size="compact"
 						onClick={ requestDiscard }
-						disabled={ chaptersLocked || confirmation !== null || ! effectiveDirty }
+						disabled={ actionsFrozen || ! effectiveDirty }
 					>
 						{ __( 'Discard changes', 'jetpack-videopress-pkg' ) }
 					</Button>
@@ -490,7 +498,7 @@ export default function ChapterManagerModal( {
 						size="compact"
 						onClick={ () => void doSave() }
 						isBusy={ metaSavePending }
-						disabled={ chaptersLocked || confirmation !== null || ! effectiveDirty }
+						disabled={ actionsFrozen || ! effectiveDirty }
 					>
 						{ __( 'Save', 'jetpack-videopress-pkg' ) }
 					</Button>

--- a/projects/packages/videopress/src/client/components/chapter-manager-modal/index.tsx
+++ b/projects/packages/videopress/src/client/components/chapter-manager-modal/index.tsx
@@ -3,7 +3,7 @@
  */
 import { Button, Modal, SnackbarList } from '@wordpress/components';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
-import { __, _x, sprintf } from '@wordpress/i18n';
+import { __, _x } from '@wordpress/i18n';
 import { close, redo as redoIcon, undo as undoIcon } from '@wordpress/icons';
 /**
  * Internal dependencies
@@ -418,11 +418,19 @@ export default function ChapterManagerModal( {
 	);
 
 	const videoTitle = title || __( 'VideoPress video', 'jetpack-videopress-pkg' );
-	const modalHeaderTitle = sprintf(
-		/* translators: %s: video title. */
-		__( 'Chapters · %s', 'jetpack-videopress-pkg' ),
-		videoTitle
-	);
+	/*
+	 * Two-tone header: "Chapters" carries the heading weight, the video name
+	 * hangs off it in a muted color. Modal's `title` prop is typed as a
+	 * string but is rendered as the h1's children, so a node works at
+	 * runtime — and aria-labelledby reads the heading's text content, which
+	 * still announces as "Chapters · {title}".
+	 */
+	const modalHeaderTitle = (
+		<>
+			{ __( 'Chapters', 'jetpack-videopress-pkg' ) }
+			<span className="videopress-chapter-manager__title-video">{ ` · ${ videoTitle }` }</span>
+		</>
+	 ) as unknown as string;
 
 	return isOpen ? (
 		<Modal

--- a/projects/packages/videopress/src/client/components/chapter-manager-modal/style.scss
+++ b/projects/packages/videopress/src/client/components/chapter-manager-modal/style.scss
@@ -83,13 +83,18 @@
 // width decides when the panes stack, so the arrangement keys off the
 // modal's real size rather than the viewport.
 .videopress-chapter-manager__workspace {
+	// Single source for the workspace padding: the panel pulls itself through
+	// it (below) to run its divider the full body height, and that trick
+	// breaks silently if the two values ever drift apart.
+	--vp-cm-workspace-pad: 18px;
+
 	container-type: inline-size;
 	display: flex;
 	flex-direction: column;
 	gap: 16px;
 	flex: 1;
 	min-block-size: 0;
-	padding: 18px;
+	padding: var(--vp-cm-workspace-pad);
 	background: #fff;
 	overflow-y: auto;
 }
@@ -135,8 +140,8 @@
 	// Pull the pane through the workspace's block padding so its divider
 	// runs the full modal body, header hairline to bottom edge; the padding
 	// puts the content back where the workspace would have had it.
-	margin-block: -18px;
-	padding-block: 18px;
+	margin-block: calc(var(--vp-cm-workspace-pad) * -1);
+	padding-block: var(--vp-cm-workspace-pad);
 
 	.vp-chapters-panel {
 		flex: 1;
@@ -174,16 +179,16 @@
 	}
 
 	.videopress-chapter-manager__panel {
+		// The workspace scrolls the whole stack, so the panel's list stops
+		// scrolling internally (a published knob on the shared panel).
+		--vp-chapters-panel-list-overflow: visible;
+
 		inline-size: auto;
 		border-inline-start: 0;
 		padding-inline-start: 0;
 		margin-block: 0;
 		border-block-start: 1px solid #dcdcde;
 		padding-block: 16px 0;
-
-		.vp-chapters-panel__list {
-			overflow-y: visible;
-		}
 	}
 
 	// The stacked column needs the old tighter player cap so the timeline
@@ -227,8 +232,8 @@
 	// The header can't fit the full action set beside the title on a phone;
 	// keep the essentials (undo/redo/Save/close). Discarding stays reachable
 	// through undo and the close-time confirmation.
-	.videopress-chapter-manager__header-actions > .components-button.is-secondary,
-	.videopress-chapter-manager__header-actions > .videopress-chapter-manager__header-divider:first-of-type {
+	.videopress-chapter-manager__header-discard,
+	.videopress-chapter-manager__header-divider--session {
 		display: none;
 	}
 

--- a/projects/packages/videopress/src/client/components/chapter-manager-modal/style.scss
+++ b/projects/packages/videopress/src/client/components/chapter-manager-modal/style.scss
@@ -37,6 +37,7 @@
 
 	.components-modal__header {
 		padding: 12px 18px;
+		border-block-end: 1px solid #dcdcde;
 	}
 
 	// The header now carries the full action set beside the title, so the
@@ -50,6 +51,12 @@
 		white-space: nowrap;
 		text-overflow: ellipsis;
 	}
+}
+
+// The video name inside the two-tone header title.
+.videopress-chapter-manager__title-video {
+	color: #757575;
+	font-weight: 400;
 }
 
 /* The Escape-intercepting wrapper must not affect the modal's layout. */
@@ -125,6 +132,11 @@
 	flex-direction: column;
 	border-inline-start: 1px solid #dcdcde;
 	padding-inline-start: 18px;
+	// Pull the pane through the workspace's block padding so its divider
+	// runs the full modal body, header hairline to bottom edge; the padding
+	// puts the content back where the workspace would have had it.
+	margin-block: -18px;
+	padding-block: 18px;
 
 	.vp-chapters-panel {
 		flex: 1;
@@ -165,8 +177,9 @@
 		inline-size: auto;
 		border-inline-start: 0;
 		padding-inline-start: 0;
+		margin-block: 0;
 		border-block-start: 1px solid #dcdcde;
-		padding-block-start: 16px;
+		padding-block: 16px 0;
 
 		.vp-chapters-panel__list {
 			overflow-y: visible;

--- a/projects/packages/videopress/src/client/components/chapter-manager-modal/style.scss
+++ b/projects/packages/videopress/src/client/components/chapter-manager-modal/style.scss
@@ -38,6 +38,18 @@
 	.components-modal__header {
 		padding: 12px 18px;
 	}
+
+	// The header now carries the full action set beside the title, so the
+	// title must truncate instead of pushing the buttons out of the frame.
+	.components-modal__header-heading-container {
+		min-inline-size: 0;
+	}
+
+	.components-modal__header-heading {
+		overflow: hidden;
+		white-space: nowrap;
+		text-overflow: ellipsis;
+	}
 }
 
 /* The Escape-intercepting wrapper must not affect the modal's layout. */
@@ -45,39 +57,26 @@
 	display: contents;
 }
 
-.videopress-chapter-manager__action-bar {
+// The session actions in the modal header: undo/redo | discard/save | close.
+.videopress-chapter-manager__header-actions {
 	display: flex;
 	align-items: center;
-	justify-content: space-between;
-	gap: 12px;
-	padding: 10px 18px;
-	border-block-end: 1px solid #dcdcde;
-	background: #fff;
-}
-
-.videopress-chapter-manager__action-bar-title {
-	margin: 0;
-	font-size: 14px;
-	line-height: 1.4;
-}
-
-.videopress-chapter-manager__action-buttons {
-	display: flex;
-	align-items: center;
-	flex-wrap: wrap;
-	justify-content: flex-end;
 	gap: 8px;
+	flex: none;
 }
 
-.videopress-chapter-manager__action-divider {
+.videopress-chapter-manager__header-divider {
 	inline-size: 1px;
-	align-self: stretch;
+	block-size: 24px;
 	background: #dcdcde;
 }
 
-// The single scroll container: the preview player stacked over the timeline
-// editor (and the rows list the timeline renders below its strip).
+// The workspace: the two-pane editing surface (preview + timeline on the
+// left, the chapters panel on the right) — and the container whose own
+// width decides when the panes stack, so the arrangement keys off the
+// modal's real size rather than the viewport.
 .videopress-chapter-manager__workspace {
+	container-type: inline-size;
 	display: flex;
 	flex-direction: column;
 	gap: 16px;
@@ -88,16 +87,49 @@
 	overflow-y: auto;
 }
 
-// The shared chapters preview player fills the Editor tab's canvas in its
-// dashboard home; here it is a full-width row above the timeline. The player
-// is the playhead source, not the star: cap the stage height (its own
-// viewport-derived clamp assumes a full admin page) so the timeline and rows
-// stay above the fold. The stage centers itself and derives its width from
-// the capped height and the 16:9 ratio.
+// The player is the pane's star now that the rows sit beside it instead of
+// below: let it take most of the modal height, keeping a viewport-derived
+// cap so short windows still fit the timeline underneath.
 .videopress-chapter-manager__workspace .vp-chapters-preview {
-	--vp-chapters-stage-max-height: min(300px, 34vh);
+	--vp-chapters-stage-max-height: min(540px, 52vh);
 
 	flex: none;
+}
+
+.videopress-chapter-manager__panes {
+	display: flex;
+	align-items: stretch;
+	gap: 18px;
+	flex: 1;
+	min-block-size: 0;
+}
+
+.videopress-chapter-manager__pane-main {
+	flex: 1;
+	min-inline-size: 0;
+	min-block-size: 0;
+	display: flex;
+	flex-direction: column;
+	gap: 16px;
+	overflow-y: auto;
+}
+
+// The chapters panel pane: fixed rail width, its own scrolling list (the
+// shared panel component scrolls its list region when its height is bound,
+// which the stretched pane provides).
+.videopress-chapter-manager__panel {
+	flex: none;
+	inline-size: 320px;
+	min-block-size: 0;
+	display: flex;
+	flex-direction: column;
+	border-inline-start: 1px solid #dcdcde;
+	padding-inline-start: 18px;
+
+	.vp-chapters-panel {
+		flex: 1;
+		min-block-size: 0;
+	}
 }
 
 .videopress-chapter-manager__editor {
@@ -106,11 +138,46 @@
 	min-block-size: 0;
 }
 
-// Locked chrome while the probe or a save is in flight: dim the editor. The
-// timeline shell blocks its own scroller's pointer events and the store
-// drops edit dispatches, so this is presentation only.
-.videopress-chapter-manager__editor--locked {
+// Locked chrome while the probe or a save is in flight: dim the editor and
+// the panel. The timeline shell blocks its own scroller's pointer events,
+// the panel's controls disable individually, and the store drops edit
+// dispatches, so this is presentation only.
+.videopress-chapter-manager__editor--locked,
+.videopress-chapter-manager__panel--locked {
 	opacity: 0.6;
+}
+
+// Narrow modal: the panes stack back into the single column (player,
+// timeline, rows) — the same layout every viewport had before the side
+// panel existed — and the workspace becomes the one scroll surface again.
+@container (max-width: 919px) {
+
+	.videopress-chapter-manager__panes {
+		flex-direction: column;
+	}
+
+	.videopress-chapter-manager__pane-main {
+		flex: none;
+		overflow-y: visible;
+	}
+
+	.videopress-chapter-manager__panel {
+		inline-size: auto;
+		border-inline-start: 0;
+		padding-inline-start: 0;
+		border-block-start: 1px solid #dcdcde;
+		padding-block-start: 16px;
+
+		.vp-chapters-panel__list {
+			overflow-y: visible;
+		}
+	}
+
+	// The stacked column needs the old tighter player cap so the timeline
+	// and rows stay reachable without a scroll expedition.
+	.videopress-chapter-manager__workspace .vp-chapters-preview {
+		--vp-chapters-stage-max-height: min(300px, 34vh);
+	}
 }
 
 .videopress-chapter-manager__status {
@@ -144,13 +211,11 @@
 		height: calc(100vh - 40px);
 	}
 
-	.videopress-chapter-manager__action-bar {
-		align-items: flex-start;
-	}
-
-	// The modal title already names the editor, so the in-body heading is
-	// redundant on mobile — hide it to reclaim horizontal space.
-	.videopress-chapter-manager__action-bar-title {
+	// The header can't fit the full action set beside the title on a phone;
+	// keep the essentials (undo/redo/Save/close). Discarding stays reachable
+	// through undo and the close-time confirmation.
+	.videopress-chapter-manager__header-actions > .components-button.is-secondary,
+	.videopress-chapter-manager__header-actions > .videopress-chapter-manager__header-divider:first-of-type {
 		display: none;
 	}
 

--- a/projects/packages/videopress/src/client/components/chapter-manager-modal/style.scss
+++ b/projects/packages/videopress/src/client/components/chapter-manager-modal/style.scss
@@ -86,7 +86,7 @@
 	// Single source for the workspace padding: the panel pulls itself through
 	// it (below) to run its divider the full body height, and that trick
 	// breaks silently if the two values ever drift apart.
-	--vp-cm-workspace-pad: 18px;
+	--vp-chapter-manager-workspace-pad: 18px;
 
 	container-type: inline-size;
 	display: flex;
@@ -94,7 +94,7 @@
 	gap: 16px;
 	flex: 1;
 	min-block-size: 0;
-	padding: var(--vp-cm-workspace-pad);
+	padding: var(--vp-chapter-manager-workspace-pad);
 	background: #fff;
 	overflow-y: auto;
 }
@@ -140,8 +140,8 @@
 	// Pull the pane through the workspace's block padding so its divider
 	// runs the full modal body, header hairline to bottom edge; the padding
 	// puts the content back where the workspace would have had it.
-	margin-block: calc(var(--vp-cm-workspace-pad) * -1);
-	padding-block: var(--vp-cm-workspace-pad);
+	margin-block: calc(var(--vp-chapter-manager-workspace-pad) * -1);
+	padding-block: var(--vp-chapter-manager-workspace-pad);
 
 	.vp-chapters-panel {
 		flex: 1;
@@ -167,7 +167,7 @@
 // Narrow modal: the panes stack back into the single column (player,
 // timeline, rows) — the same layout every viewport had before the side
 // panel existed — and the workspace becomes the one scroll surface again.
-@container (max-width: 919px) {
+@container ( max-inline-size: 919px ) {
 
 	.videopress-chapter-manager__panes {
 		flex-direction: column;

--- a/projects/packages/videopress/src/client/components/chapter-manager-modal/test/index.test.tsx
+++ b/projects/packages/videopress/src/client/components/chapter-manager-modal/test/index.test.tsx
@@ -84,12 +84,6 @@ jest.mock( '../../chapters-editor/preview/preview-player', () => {
 } );
 
 /*
- * The timeline is exercised by its own test file; here a stub surfaces the
- * gating props (locked/readOnly/shortcutsEnabled/duration) and offers plain
- * buttons that dispatch into the real store, so lock and dirt semantics are
- * tested against the real reducer.
- */
-/*
  * The panel is exercised alongside the timeline in the chapters-editor test
  * file; here a stub surfaces the gating props. It must NOT render real rows:
  * their "Remove chapter N" buttons would collide with the fake timeline's
@@ -107,6 +101,12 @@ jest.mock( '../../chapters-editor/chapters/chapters-panel', () => ( {
 	),
 } ) );
 
+/*
+ * The timeline is exercised by its own test file; here a stub surfaces the
+ * gating props (locked/readOnly/shortcutsEnabled/duration) and offers plain
+ * buttons that dispatch into the real store, so lock and dirt semantics are
+ * tested against the real reducer.
+ */
 jest.mock( '../../chapters-editor/chapters/chapters-timeline', () => ( {
 	__esModule: true,
 	default: ( { session, dispatch, locked, readOnly, shortcutsEnabled } ) => (

--- a/projects/packages/videopress/src/client/components/chapter-manager-modal/test/index.test.tsx
+++ b/projects/packages/videopress/src/client/components/chapter-manager-modal/test/index.test.tsx
@@ -25,8 +25,12 @@ jest.mock( '@wordpress/components', () => ( {
 				{ children ?? label }
 			</button>
 		) ),
+	// `title` is a React node in this modal (the two-tone heading), so the
+	// mock renders it as heading content the way the real Modal's h1 does,
+	// rather than stringifying it into an aria-label.
 	Modal: ( { children, title, headerActions } ) => (
-		<div role="dialog" aria-label={ title }>
+		<div role="dialog">
+			<h1>{ title }</h1>
 			{ headerActions }
 			{ children }
 		</div>
@@ -85,6 +89,24 @@ jest.mock( '../../chapters-editor/preview/preview-player', () => {
  * buttons that dispatch into the real store, so lock and dirt semantics are
  * tested against the real reducer.
  */
+/*
+ * The panel is exercised alongside the timeline in the chapters-editor test
+ * file; here a stub surfaces the gating props. It must NOT render real rows:
+ * their "Remove chapter N" buttons would collide with the fake timeline's
+ * same-named stand-ins below.
+ */
+jest.mock( '../../chapters-editor/chapters/chapters-panel', () => ( {
+	__esModule: true,
+	default: ( { session, locked, readOnly } ) => (
+		<div
+			data-testid="chapters-panel"
+			data-locked={ String( Boolean( locked ) ) }
+			data-readonly={ String( Boolean( readOnly ) ) }
+			data-count={ String( session.chapters.length ) }
+		/>
+	),
+} ) );
+
 jest.mock( '../../chapters-editor/chapters/chapters-timeline', () => ( {
 	__esModule: true,
 	default: ( { session, dispatch, locked, readOnly, shortcutsEnabled } ) => (
@@ -170,9 +192,9 @@ describe( 'ChapterManagerModal', () => {
 	it( 'fetches the item once on open, feeding the timeline, the preview, and the probe', async () => {
 		const timeline = await openReady();
 
-		expect(
-			screen.getByRole( 'dialog', { name: 'Manage chapters for Test video' } )
-		).toBeInTheDocument();
+		expect( screen.getByRole( 'dialog' ) ).toBeInTheDocument();
+		// Two-tone heading: "Chapters" + the muted video name read as one line.
+		expect( screen.getByRole( 'heading' ) ).toHaveTextContent( 'Chapters · Test video' );
 		expect( fetchVideoItem ).toHaveBeenCalledTimes( 1 );
 		expect( fetchVideoItem ).toHaveBeenCalledWith( { guid: 'abc123', isPrivate: false } );
 		// The probe reuses the fetched item instead of fetching it again.
@@ -184,6 +206,11 @@ describe( 'ChapterManagerModal', () => {
 		expect( timeline ).toHaveAttribute( 'data-readonly', 'false' );
 		// Document-level shortcuts stay off; the modal body maps the keys itself.
 		expect( timeline ).toHaveAttribute( 'data-shortcuts', 'false' );
+		// The side panel shares the timeline's gating and sees the same session.
+		const panel = screen.getByTestId( 'chapters-panel' );
+		expect( panel ).toHaveAttribute( 'data-locked', 'false' );
+		expect( panel ).toHaveAttribute( 'data-readonly', 'false' );
+		expect( panel ).toHaveAttribute( 'data-count', '3' );
 		// The shared player receives the item-derived video: the best H.264
 		// rendition, the duration in seconds, and no original-upload fallback.
 		expect( mockPlayerProps.video ).toEqual( {
@@ -228,6 +255,7 @@ describe( 'ChapterManagerModal', () => {
 
 		const timeline = await openReady();
 		expect( timeline ).toHaveAttribute( 'data-readonly', 'true' );
+		expect( screen.getByTestId( 'chapters-panel' ) ).toHaveAttribute( 'data-readonly', 'true' );
 
 		// Defense-in-depth: even a dispatch that slips past the (hidden) edit
 		// affordances must not arm Save against a manually-managed description.

--- a/projects/packages/videopress/src/client/components/chapter-manager-modal/test/index.test.tsx
+++ b/projects/packages/videopress/src/client/components/chapter-manager-modal/test/index.test.tsx
@@ -435,6 +435,14 @@ describe( 'ChapterManagerModal', () => {
 		const confirmation = screen.getByRole( 'alertdialog' );
 		expect( confirmation ).toHaveTextContent( 'Discard unsaved chapter changes?' );
 
+		// The header actions sit OUTSIDE the overlay's coverage; while the
+		// confirmation is up they must be frozen, or a click could mutate the
+		// session the dialog is asking about.
+		expect( screen.getByRole( 'button', { name: 'Undo' } ) ).toBeDisabled();
+		expect( screen.getByRole( 'button', { name: 'Redo' } ) ).toBeDisabled();
+		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();
+		expect( screen.getByRole( 'button', { name: 'Discard changes' } ) ).toBeDisabled();
+
 		await user.click( screen.getByRole( 'button', { name: 'Discard' } ) );
 		expect( defaultProps.onClose ).toHaveBeenCalledTimes( 1 );
 	} );

--- a/projects/packages/videopress/src/client/components/chapters-editor/chapters/chapter-rows.tsx
+++ b/projects/packages/videopress/src/client/components/chapters-editor/chapters/chapter-rows.tsx
@@ -1,8 +1,9 @@
 /**
- * The rows list below the Chapters tool strip: one row per chapter with the
- * mono index, the title input, the start-time seek button, the computed
- * duration, and the remove button. This list is the accessible editing
- * surface for everything the strip's segments and markers do with pointers.
+ * The chapters rows list (rendered inside ChaptersPanel): one row per
+ * chapter with the title input, the start-time seek button (a lock icon
+ * marks the first chapter's pinned 0:00 start), and the remove button. This
+ * list is the accessible editing surface for everything the strip's
+ * segments and markers do with pointers.
  *
  * Title edits are held in LOCAL draft state and committed on blur/Enter —
  * the same pattern as the Details-tab chapters editor: a half-typed title
@@ -22,7 +23,7 @@
  */
 import { Button } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
-import { Icon, trash } from '@wordpress/icons';
+import { Icon, lockSmall, trash } from '@wordpress/icons';
 import { useEffect, useState } from 'react';
 import { formatTimecode } from '../state/time-utils';
 import type {
@@ -53,10 +54,8 @@ type RowsProps = {
 type RowProps = {
 	/** The chapter this row edits. */
 	chapter: ChapterEntry;
-	/** Row position (0-based; rendered as the 1-based mono index). */
+	/** Row position (0-based; the first row's start is pinned to 0:00). */
 	index: number;
-	/** Start of the next chapter (the video end for the last row), in ms. */
-	endMs: number;
 	/** Whether this row's chapter is selected. */
 	selected: boolean;
 	/** Whether removal is possible (false at one chapter: the trash is inert). */
@@ -77,7 +76,6 @@ type RowProps = {
  * @param props           - Component props.
  * @param props.chapter   - The chapter this row edits.
  * @param props.index     - Row position (0-based).
- * @param props.endMs     - Start of the next chapter (or the video end), in ms.
  * @param props.selected  - Whether this row's chapter is selected.
  * @param props.canRemove - Whether removal is possible.
  * @param props.locked    - Whether a processing job or save locks editing.
@@ -89,7 +87,6 @@ type RowProps = {
 function ChapterRow( {
 	chapter,
 	index,
-	endMs,
 	selected,
 	canRemove,
 	locked,
@@ -141,9 +138,6 @@ function ChapterRow( {
 			onPointerDown={ select }
 			onFocusCapture={ select }
 		>
-			<span className="vp-chapters__row-index" aria-hidden="true">
-				{ String( index + 1 ).padStart( 2, '0' ) }
-			</span>
 			<input
 				className="vp-chapters__row-title"
 				type="text"
@@ -174,6 +168,18 @@ function ChapterRow( {
 					}
 				} }
 			/>
+			{ /* The first chapter's start is pinned to 0:00 by the reducer; the
+			     lock says so in place, instead of a sentence of footer prose. */ }
+			{ index === 0 ? (
+				<span
+					className="vp-chapters__row-lock"
+					role="img"
+					aria-label={ __( 'The first chapter always starts at 0:00.', 'jetpack-videopress-pkg' ) }
+					title={ __( 'The first chapter always starts at 0:00.', 'jetpack-videopress-pkg' ) }
+				>
+					<Icon icon={ lockSmall } size={ 16 } />
+				</span>
+			) : null }
 			<button
 				type="button"
 				className="vp-chapters__row-time"
@@ -187,9 +193,6 @@ function ChapterRow( {
 			>
 				{ formatTimecode( chapter.startMs ) }
 			</button>
-			<span className="vp-chapters__row-duration">
-				{ formatTimecode( endMs - chapter.startMs ) }
-			</span>
 			<Button
 				className="vp-chapters__row-remove"
 				size="small"
@@ -234,7 +237,7 @@ export default function ChapterRows( {
 	locked = false,
 	rowIssues,
 }: RowsProps ): ReactElement {
-	const { chapters, durationMs, selectedId } = session;
+	const { chapters, selectedId } = session;
 
 	return (
 		<div className="vp-chapters__rows" data-testid="chapters-rows">
@@ -243,7 +246,6 @@ export default function ChapterRows( {
 					key={ chapter.id }
 					chapter={ chapter }
 					index={ index }
-					endMs={ index === chapters.length - 1 ? durationMs : chapters[ index + 1 ].startMs }
 					selected={ chapter.id === selectedId }
 					canRemove={ chapters.length > 1 }
 					locked={ locked }

--- a/projects/packages/videopress/src/client/components/chapters-editor/chapters/chapter-rows.tsx
+++ b/projects/packages/videopress/src/client/components/chapters-editor/chapters/chapter-rows.tsx
@@ -1,7 +1,7 @@
 /**
  * The chapters rows list (rendered inside ChaptersPanel): one row per
- * chapter with the title input, the start-time seek button (a lock icon
- * marks the first chapter's pinned 0:00 start), and the remove button. This
+ * chapter with the title input (borderless until focused, so resting rows
+ * read as text), the start-time seek button, and the remove button. This
  * list is the accessible editing surface for everything the strip's
  * segments and markers do with pointers.
  *
@@ -23,7 +23,7 @@
  */
 import { Button } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
-import { Icon, lockSmall, trash } from '@wordpress/icons';
+import { Icon, trash } from '@wordpress/icons';
 import { useEffect, useState } from 'react';
 import { formatTimecode } from '../state/time-utils';
 import type {
@@ -168,18 +168,6 @@ function ChapterRow( {
 					}
 				} }
 			/>
-			{ /* The first chapter's start is pinned to 0:00 by the reducer; the
-			     lock says so in place, instead of a sentence of footer prose. */ }
-			{ index === 0 ? (
-				<span
-					className="vp-chapters__row-lock"
-					role="img"
-					aria-label={ __( 'The first chapter always starts at 0:00.', 'jetpack-videopress-pkg' ) }
-					title={ __( 'The first chapter always starts at 0:00.', 'jetpack-videopress-pkg' ) }
-				>
-					<Icon icon={ lockSmall } size={ 16 } />
-				</span>
-			) : null }
 			<button
 				type="button"
 				className="vp-chapters__row-time"

--- a/projects/packages/videopress/src/client/components/chapters-editor/chapters/chapters-panel.tsx
+++ b/projects/packages/videopress/src/client/components/chapters-editor/chapters/chapters-panel.tsx
@@ -19,7 +19,7 @@
  * whose list region scrolls when the host bounds its height.
  */
 import { _n, sprintf, __ } from '@wordpress/i18n';
-import { useCallback, useMemo } from 'react';
+import { memo, useCallback, useMemo } from 'react';
 import { validateRows } from '../../../utils/video-chapters/description';
 import { chaptersToRows } from '../state/chapters-session';
 import { clampToDuration } from '../timeline/timeline-shell';
@@ -56,7 +56,7 @@ export type ChaptersPanelProps = {
  * @param props.readOnly - Whether a manual VTT locks editing.
  * @return The panel element.
  */
-export default function ChaptersPanel( {
+function ChaptersPanel( {
 	session,
 	dispatch,
 	onSeek,
@@ -94,7 +94,9 @@ export default function ChaptersPanel( {
 		return {
 			rowIssues: perRow,
 			generalIssues: issues.filter( issue => issue.rowIndex === undefined ),
-			untitledCount: session.chapters.filter( chapter => chapter.title.trim() === '' ).length,
+			// Counted from the validator's own verdicts so the rollup can never
+			// disagree with the per-row flags about what "untitled" means.
+			untitledCount: issues.filter( issue => issue.code === 'missing-title' ).length,
 		};
 	}, [ session ] );
 
@@ -155,3 +157,12 @@ export default function ChaptersPanel( {
 		</div>
 	);
 }
+
+/*
+ * Memoized: while the preview plays, the rAF-driven playhead re-renders the
+ * hosts every animation frame. The panel deliberately takes no playhead
+ * prop, and every prop it does take is stable during playback (the session
+ * changes only on edits; dispatch and onSeek are []-dep callbacks in the
+ * hosts) — memo is what turns that decoupling into skipped work.
+ */
+export default memo( ChaptersPanel );

--- a/projects/packages/videopress/src/client/components/chapters-editor/chapters/chapters-panel.tsx
+++ b/projects/packages/videopress/src/client/components/chapters-editor/chapters/chapters-panel.tsx
@@ -1,0 +1,157 @@
+/**
+ * The chapters panel: the list pane that sits beside the preview player and
+ * timeline in both hosts (the block editor's chapter manager modal and the
+ * dashboard's Editor tab) — the "Chapters" header with the live count, the
+ * publish-rule summary, and the editable rows list. When a manually uploaded
+ * chapters VTT governs the video (`readOnly`) the rows are replaced by an
+ * explanatory notice, mirroring what the timeline strip does with its edit
+ * affordances.
+ *
+ * Publish-rule validation lives HERE, not in the timeline: the rows are
+ * where rule violations get fixed, so the messages sit beside them.
+ * Row-scoped issues land on the offending row; issues with no row to sit on
+ * (no chapters, too few) plus the untitled-chapters rollup go under the
+ * header, where they read as the panel's to-do list. It is a pure read of
+ * the session — nothing here gates saving, which stays a host decision.
+ *
+ * Hosts own the panel's placement and sizing (side pane vs. stacked below
+ * the timeline on narrow surfaces); the panel only promises a column layout
+ * whose list region scrolls when the host bounds its height.
+ */
+import { _n, sprintf, __ } from '@wordpress/i18n';
+import { useCallback, useMemo } from 'react';
+import { validateRows } from '../../../utils/video-chapters/description';
+import { chaptersToRows } from '../state/chapters-session';
+import { clampToDuration } from '../timeline/timeline-shell';
+import ChapterRows from './chapter-rows';
+import './style.scss';
+import type { ChaptersSession, ChaptersSessionAction } from '../state/chapters-session';
+import type { HistoryAction } from '../state/history';
+import type { ReactElement } from 'react';
+
+export type ChaptersPanelProps = {
+	/** The chapters session. */
+	session: ChaptersSession;
+	/** Dispatch into the history-wrapped chapters reducer. */
+	dispatch: ( action: HistoryAction< ChaptersSessionAction > ) => void;
+	/** Seek the preview player to a master-timeline ms (clamped here). */
+	onSeek: ( ms: number ) => void;
+	/** True while a processing job or an in-flight save locks editing. */
+	locked?: boolean;
+	/**
+	 * True when a manually uploaded chapters VTT governs this video: the rows
+	 * list is replaced by a notice.
+	 */
+	readOnly?: boolean;
+};
+
+/**
+ * The chapters panel.
+ *
+ * @param props          - Component props.
+ * @param props.session  - The chapters session.
+ * @param props.dispatch - Dispatch into the history-wrapped reducer.
+ * @param props.onSeek   - Seek the preview player.
+ * @param props.locked   - Whether a processing job or save locks editing.
+ * @param props.readOnly - Whether a manual VTT locks editing.
+ * @return The panel element.
+ */
+export default function ChaptersPanel( {
+	session,
+	dispatch,
+	onSeek,
+	locked = false,
+	readOnly = false,
+}: ChaptersPanelProps ): ReactElement {
+	const durationMs = session.durationMs;
+
+	// Live publish-rule check. Row-scoped issues are keyed by ROW POSITION —
+	// the same order `chaptersToRows` and the rows list walk — so they index
+	// straight into the rows array; the rest have no row to sit on and go
+	// under the header, next to the untitled-chapters rollup.
+	//
+	// The duration is passed UNROUNDED, matching what both hosts hand
+	// `validateRows` at save time: rounding here would let a chapter sitting
+	// on the rounded-up second (reachable through LOAD, which reflects the
+	// description as-is) read as fine in the editor and then warn on save,
+	// with no row flagged to explain it.
+	const { rowIssues, generalIssues, untitledCount } = useMemo( () => {
+		// A lone chapter is the "nothing authored yet" state: a description
+		// with no chapter lines loads as one seeded chapter at 0:00, and
+		// greeting that with rule messages scolds the user before they have
+		// done anything. Stay quiet until there is a set to judge; the
+		// save-time message still tells the truth if they save one anyway.
+		if ( session.chapters.length < 2 ) {
+			return { rowIssues: [], generalIssues: [], untitledCount: 0 };
+		}
+		const { issues } = validateRows( chaptersToRows( session ), session.durationMs / 1000 );
+		const perRow: ( string | undefined )[] = [];
+		for ( const issue of issues ) {
+			if ( issue.rowIndex !== undefined && perRow[ issue.rowIndex ] === undefined ) {
+				perRow[ issue.rowIndex ] = issue.message;
+			}
+		}
+		return {
+			rowIssues: perRow,
+			generalIssues: issues.filter( issue => issue.rowIndex === undefined ),
+			untitledCount: session.chapters.filter( chapter => chapter.title.trim() === '' ).length,
+		};
+	}, [ session ] );
+
+	const seekClamped = useCallback(
+		( ms: number ) => onSeek( clampToDuration( ms, durationMs ) ),
+		[ onSeek, durationMs ]
+	);
+
+	return (
+		<div className="vp-chapters-panel" data-testid="chapters-panel">
+			<div className="vp-chapters-panel__header">
+				<h3 className="vp-chapters-panel__title">{ __( 'Chapters', 'jetpack-videopress-pkg' ) }</h3>
+				<span className="vp-chapters-panel__count" data-testid="chapters-count">
+					{ session.chapters.length }
+				</span>
+			</div>
+			{ ! readOnly && ( untitledCount > 0 || generalIssues.length > 0 ) ? (
+				<div className="vp-chapters-panel__issues" role="status" data-testid="chapters-validation">
+					{ untitledCount > 0 ? (
+						<p className="vp-chapters__validation-message">
+							{ sprintf(
+								/* translators: %d: number of chapters with an empty title. */
+								_n(
+									'%d chapter still needs a title.',
+									'%d chapters still need a title.',
+									untitledCount,
+									'jetpack-videopress-pkg'
+								),
+								untitledCount
+							) }
+						</p>
+					) : null }
+					{ generalIssues.map( issue => (
+						<p key={ issue.code } className="vp-chapters__validation-message">
+							{ issue.message }
+						</p>
+					) ) }
+				</div>
+			) : null }
+			{ readOnly ? (
+				<p className="vp-chapters__manual-notice" role="status">
+					{ __(
+						'Chapters for this video are managed by an uploaded VTT file, so they can’t be edited here.',
+						'jetpack-videopress-pkg'
+					) }
+				</p>
+			) : (
+				<div className="vp-chapters-panel__list">
+					<ChapterRows
+						session={ session }
+						dispatch={ dispatch }
+						onSeek={ seekClamped }
+						locked={ locked }
+						rowIssues={ rowIssues }
+					/>
+				</div>
+			) }
+		</div>
+	);
+}

--- a/projects/packages/videopress/src/client/components/chapters-editor/chapters/chapters-panel.tsx
+++ b/projects/packages/videopress/src/client/components/chapters-editor/chapters/chapters-panel.tsx
@@ -108,34 +108,45 @@ function ChaptersPanel( {
 	return (
 		<div className="vp-chapters-panel" data-testid="chapters-panel">
 			<div className="vp-chapters-panel__header">
-				<h3 className="vp-chapters-panel__title">{ __( 'Chapters', 'jetpack-videopress-pkg' ) }</h3>
+				{ /* h2: the modal's title is the h1, and the dashboard route has no
+				     page heading above this — either way the panel heading is the
+				     next level down. */ }
+				<h2 className="vp-chapters-panel__title">{ __( 'Chapters', 'jetpack-videopress-pkg' ) }</h2>
 				<span className="vp-chapters-panel__count" data-testid="chapters-count">
-					{ session.chapters.length }
+					<span aria-hidden="true">{ session.chapters.length }</span>
+					<span className="screen-reader-text">
+						{ sprintf(
+							/* translators: %d: number of chapters in the list. */
+							_n( '%d chapter', '%d chapters', session.chapters.length, 'jetpack-videopress-pkg' ),
+							session.chapters.length
+						) }
+					</span>
 				</span>
 			</div>
-			{ ! readOnly && ( untitledCount > 0 || generalIssues.length > 0 ) ? (
-				<div className="vp-chapters-panel__issues" role="status" data-testid="chapters-validation">
-					{ untitledCount > 0 ? (
-						<p className="vp-chapters__validation-message">
-							{ sprintf(
-								/* translators: %d: number of chapters with an empty title. */
-								_n(
-									'%d chapter still needs a title.',
-									'%d chapters still need a title.',
-									untitledCount,
-									'jetpack-videopress-pkg'
-								),
-								untitledCount
-							) }
-						</p>
-					) : null }
-					{ generalIssues.map( issue => (
+			{ /* The live region stays mounted even while empty: a status region
+			     inserted already-populated is not reliably announced. */ }
+			<div className="vp-chapters-panel__issues" role="status" data-testid="chapters-validation">
+				{ ! readOnly && untitledCount > 0 ? (
+					<p className="vp-chapters__validation-message">
+						{ sprintf(
+							/* translators: %d: number of chapters with an empty title. */
+							_n(
+								'%d chapter still needs a title.',
+								'%d chapters still need a title.',
+								untitledCount,
+								'jetpack-videopress-pkg'
+							),
+							untitledCount
+						) }
+					</p>
+				) : null }
+				{ ! readOnly &&
+					generalIssues.map( issue => (
 						<p key={ issue.code } className="vp-chapters__validation-message">
 							{ issue.message }
 						</p>
 					) ) }
-				</div>
-			) : null }
+			</div>
 			{ readOnly ? (
 				<p className="vp-chapters__manual-notice" role="status">
 					{ __(

--- a/projects/packages/videopress/src/client/components/chapters-editor/chapters/chapters-timeline.tsx
+++ b/projects/packages/videopress/src/client/components/chapters-editor/chapters/chapters-timeline.tsx
@@ -186,12 +186,17 @@ export default function ChaptersTimeline( {
 								 * live in the sibling ChaptersPanel — coordinated only
 								 * through the session — so the selected row is found in
 								 * the DOM once React has flushed the add (next frame).
+								 * The query is scoped to the editor's token wrapper
+								 * (both hosts wrap the strip + panel pair in it) so a
+								 * second mounted editor could never receive the focus.
 								 * Selecting the text lets typing replace the default
 								 * "Chapter N" title directly.
 								 */
-								const doc = event.currentTarget.ownerDocument;
+								const scope =
+									event.currentTarget.closest( '.vp-chapters-tokens' ) ??
+									event.currentTarget.ownerDocument;
 								requestAnimationFrame( () => {
-									const input = doc.querySelector< HTMLInputElement >(
+									const input = scope.querySelector< HTMLInputElement >(
 										'.vp-chapters__row--selected input.vp-chapters__row-title'
 									);
 									input?.focus();

--- a/projects/packages/videopress/src/client/components/chapters-editor/chapters/chapters-timeline.tsx
+++ b/projects/packages/videopress/src/client/components/chapters-editor/chapters/chapters-timeline.tsx
@@ -177,7 +177,27 @@ export default function ChaptersTimeline( {
 							size="compact"
 							variant="secondary"
 							disabled={ readOnly || locked || ! canAddChapterAt( session, currentMs ) }
-							onClick={ () => dispatch( { type: 'ADD_AT', atMs: currentMs } ) }
+							onClick={ event => {
+								dispatch( { type: 'ADD_AT', atMs: currentMs } );
+								/*
+								 * Hand focus to the new chapter's title input so naming
+								 * follows adding without a pointer trip to the panel.
+								 * ADD_AT selects the chapter it creates, and the rows
+								 * live in the sibling ChaptersPanel — coordinated only
+								 * through the session — so the selected row is found in
+								 * the DOM once React has flushed the add (next frame).
+								 * Selecting the text lets typing replace the default
+								 * "Chapter N" title directly.
+								 */
+								const doc = event.currentTarget.ownerDocument;
+								requestAnimationFrame( () => {
+									const input = doc.querySelector< HTMLInputElement >(
+										'.vp-chapters__row--selected input.vp-chapters__row-title'
+									);
+									input?.focus();
+									input?.select();
+								} );
+							} }
 							accessibleWhenDisabled
 						>
 							{ __( 'Add chapter at playhead', 'jetpack-videopress-pkg' ) }

--- a/projects/packages/videopress/src/client/components/chapters-editor/chapters/chapters-timeline.tsx
+++ b/projects/packages/videopress/src/client/components/chapters-editor/chapters/chapters-timeline.tsx
@@ -1,35 +1,32 @@
 /**
  * The chapters editor timeline: the shared {@link TimelineShell} (toolbar
  * slot, scaled scrub surface, gridlines, playhead) composed with the
- * chapter-segments track, the draggable chapter-start markers, and the rows
- * list below the strip.
+ * chapter-segments track and the draggable chapter-start markers. The
+ * editable rows list lives in the sibling ChaptersPanel, which hosts place
+ * beside this strip (or stacked below it on narrow surfaces).
  *
- * This module owns everything chapters-specific: the toolbar's
- * "Add chapter at playhead" wiring (inert per the reducer's ADD_AT no-op
- * predicate), the "Now: {chapter}" indicator, and the document-level
- * shortcuts instance that attaches while THIS tool is mounted (space,
- * arrows, Home/End to the video bounds, Delete removes the selected chapter
- * — the reducer floors removal at one). The zoom ladder is the
- * duration-scaled filmstrip-less ladder ({@link getFilmstripZoomLadder})
+ * This module owns everything chapters-specific about the STRIP: the
+ * toolbar's "Add chapter at playhead" wiring (inert per the reducer's
+ * ADD_AT no-op predicate), the "Now: {chapter}" indicator, and the
+ * document-level shortcuts instance that attaches while THIS tool is
+ * mounted (space, arrows, Home/End to the video bounds, Delete removes the
+ * selected chapter — the reducer floors removal at one). The zoom ladder is
+ * the duration-scaled filmstrip-less ladder ({@link getFilmstripZoomLadder})
  * even though this strip draws no tiles, so the zoom stops stay on the
  * filmstrip grammar's meaningful densities.
  *
  * `readOnly` (a manually uploaded chapters VTT exists) keeps the strip as a
  * visualization — segments render, the playhead scrubs — but removes every
- * edit affordance: no markers, the add button is disabled, and the rows list
- * is replaced by a notice.
+ * edit affordance: no markers and the add button is disabled (the panel
+ * carries the explanatory notice).
  *
- * The publish rules live in `validateRows` and are what decides whether the
- * player gets a chapters track at all, so this module reads them live and
- * shows them where the problem is: row-scoped issues on the offending row,
- * the rest next to the footer help line. It is a pure read of the session —
+ * The publish-rule messages moved to the panel with the rows they qualify;
  * nothing here gates saving, which stays a host decision.
  */
 import { Button } from '@wordpress/components';
 import { sprintf, __ } from '@wordpress/i18n';
-import { useCallback, useMemo } from 'react';
-import { validateRows } from '../../../utils/video-chapters/description';
-import { canAddChapterAt, chaptersToRows } from '../state/chapters-session';
+import { useCallback } from 'react';
+import { canAddChapterAt } from '../state/chapters-session';
 import TimeRuler from '../timeline/time-ruler';
 import TimelineShell, { clampToDuration } from '../timeline/timeline-shell';
 import TimelineTransport from '../timeline/transport';
@@ -37,7 +34,6 @@ import { useKeyboardShortcuts } from '../timeline/use-keyboard-shortcuts';
 import ZoomControl from '../timeline/zoom-control';
 import { getFilmstripZoomLadder } from '../timeline/zoom-ladder';
 import ChapterMarker from './chapter-marker';
-import ChapterRows from './chapter-rows';
 import ChapterTrack from './chapter-track';
 import './style.scss';
 import type { ChaptersSession, ChaptersSessionAction } from '../state/chapters-session';
@@ -135,39 +131,6 @@ export default function ChaptersTimeline( {
 }: ChaptersTimelineProps ): ReactElement {
 	const durationMs = session.durationMs;
 
-	// Live publish-rule check. Row-scoped issues are keyed by ROW POSITION —
-	// the same order `chaptersToRows` and the rows list walk — so they index
-	// straight into the rows array; the rest (no chapters, too few) have no
-	// row to sit on and go by the footer help line.
-	//
-	// The duration is passed UNROUNDED, matching what both hosts hand
-	// `validateRows` at save time: rounding here would let a chapter sitting
-	// on the rounded-up second (reachable through LOAD, which reflects the
-	// description as-is) read as fine in the editor and then warn on save,
-	// with no row flagged to explain it.
-	const { rowIssues, generalIssues } = useMemo( () => {
-		// A lone chapter is the "nothing authored yet" state: a description
-		// with no chapter lines loads as one seeded chapter at 0:00, and
-		// greeting that with "at least three chapters are required" scolds
-		// the user before they have done anything. Stay quiet until there is
-		// a set to judge; the save-time message still tells the truth if they
-		// save one anyway.
-		if ( session.chapters.length < 2 ) {
-			return { rowIssues: [], generalIssues: [] };
-		}
-		const { issues } = validateRows( chaptersToRows( session ), session.durationMs / 1000 );
-		const perRow: ( string | undefined )[] = [];
-		for ( const issue of issues ) {
-			if ( issue.rowIndex !== undefined && perRow[ issue.rowIndex ] === undefined ) {
-				perRow[ issue.rowIndex ] = issue.message;
-			}
-		}
-		return {
-			rowIssues: perRow,
-			generalIssues: issues.filter( issue => issue.rowIndex === undefined ),
-		};
-	}, [ session ] );
-
 	const seekClamped = useCallback(
 		( ms: number ) => onSeek( clampToDuration( ms, durationMs ) ),
 		[ onSeek, durationMs ]
@@ -264,34 +227,9 @@ export default function ChaptersTimeline( {
 					)
 				}
 			/>
-			{ readOnly ? (
-				<p className="vp-chapters__manual-notice" role="status">
-					{ __(
-						'Chapters for this video are managed by an uploaded VTT file, so they can’t be edited here.',
-						'jetpack-videopress-pkg'
-					) }
-				</p>
-			) : (
-				<ChapterRows
-					session={ session }
-					dispatch={ dispatch }
-					onSeek={ seekClamped }
-					locked={ locked }
-					rowIssues={ rowIssues }
-				/>
-			) }
-			{ ! readOnly && generalIssues.length > 0 ? (
-				<div className="vp-chapters__validation" role="status" data-testid="chapters-validation">
-					{ generalIssues.map( issue => (
-						<p key={ issue.code } className="vp-chapters__validation-message">
-							{ issue.message }
-						</p>
-					) ) }
-				</div>
-			) : null }
 			<p className="vp-chapters__help">
 				{ __(
-					'Chapters appear in the player timeline and help viewers jump to a section. The first chapter always starts at 0:00:00.0.',
+					'Chapters appear in the player timeline and help viewers jump to a section.',
 					'jetpack-videopress-pkg'
 				) }
 			</p>

--- a/projects/packages/videopress/src/client/components/chapters-editor/chapters/chapters-timeline.tsx
+++ b/projects/packages/videopress/src/client/components/chapters-editor/chapters/chapters-timeline.tsx
@@ -192,7 +192,10 @@ export default function ChaptersTimeline( {
 								 * Selecting the text lets typing replace the default
 								 * "Chapter N" title directly.
 								 */
-								const scope =
+								// ParentNode: the interface Element and Document share — a
+								// plain union of the two leaves querySelector's generic
+								// signatures un-unifiable (TS2347).
+								const scope: ParentNode =
 									event.currentTarget.closest( '.vp-chapters-tokens' ) ??
 									event.currentTarget.ownerDocument;
 								requestAnimationFrame( () => {

--- a/projects/packages/videopress/src/client/components/chapters-editor/chapters/chapters-timeline.tsx
+++ b/projects/packages/videopress/src/client/components/chapters-editor/chapters/chapters-timeline.tsx
@@ -229,7 +229,7 @@ export default function ChaptersTimeline( {
 			/>
 			<p className="vp-chapters__help">
 				{ __(
-					'Chapters appear in the player timeline and help viewers jump to a section.',
+					'Chapters appear in the player timeline and help viewers jump to a section. The first chapter always starts at 0:00:00.0.',
 					'jetpack-videopress-pkg'
 				) }
 			</p>

--- a/projects/packages/videopress/src/client/components/chapters-editor/chapters/style.scss
+++ b/projects/packages/videopress/src/client/components/chapters-editor/chapters/style.scss
@@ -139,19 +139,20 @@ $vp-chapters-warning: var(--vp-warning, #b26200);
 // Row-scoped publish-rule message, on its own line under the controls.
 .vp-chapters__row-issue {
 	flex: 0 0 100%;
-	padding-inline-start: 32px; // Clears the mono index column + its gap.
 	font-size: 12px;
 	color: $vp-chapters-warning;
 }
 
-.vp-chapters__row-index {
+// The pinned-start lock on the first row, between the title and its 0:00.
+.vp-chapters__row-lock {
 	flex: none;
-	width: 24px;
-	text-align: right;
-	font-family: var(--vp-font-mono, Menlo, Consolas, monaco, monospace);
-	font-size: 12px;
+	display: inline-flex;
+	align-items: center;
 	color: var(--vp-gray-700, #757575);
-	font-variant-numeric: tabular-nums;
+
+	svg {
+		fill: currentColor;
+	}
 }
 
 // Beat wp-admin forms.css's `input[type="text"]` on padding/border, the same
@@ -200,16 +201,6 @@ input[type="text"].vp-chapters__row-title {
 	}
 }
 
-.vp-chapters__row-duration {
-	flex: none;
-	// Wide enough for a full `H:MM:SS.t` timecode at this mono size.
-	width: 68px;
-	font-size: 12px;
-	color: var(--vp-gray-700, #757575);
-	font-variant-numeric: tabular-nums;
-	white-space: nowrap;
-}
-
 .vp-chapters__row-remove.components-button {
 	flex: none;
 	width: 28px;
@@ -239,14 +230,6 @@ input[type="text"].vp-chapters__row-title {
 	text-overflow: ellipsis;
 }
 
-// Publish-rule issues that belong to no single row (no chapters, too few),
-// parked next to the footer help line they qualify.
-.vp-chapters__validation {
-	display: flex;
-	flex-direction: column;
-	gap: 4px;
-}
-
 .vp-chapters__validation-message {
 	margin: 0;
 	font-size: 12px;
@@ -257,4 +240,50 @@ input[type="text"].vp-chapters__row-title {
 	margin: 0;
 	font-size: 12px;
 	color: var(--vp-gray-700, #757575);
+}
+
+// The chapters panel: header (title + live count), the publish-rule summary,
+// and the rows list. Hosts own its placement and outer sizing; when they
+// bound its height (the side-pane arrangement) the list region is what
+// scrolls, so the header stays put.
+.vp-chapters-panel {
+	display: flex;
+	flex-direction: column;
+	gap: 12px;
+	min-block-size: 0;
+}
+
+.vp-chapters-panel__header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+}
+
+// Reads as a section label, like the tools rail's "Edit" heading.
+.vp-chapters-panel__title {
+	margin: 0;
+	color: var(--vp-gray-700, #757575);
+	font-size: 11px;
+	font-weight: 600;
+	text-transform: uppercase;
+	letter-spacing: 0.2px;
+}
+
+.vp-chapters-panel__count {
+	font-size: 12px;
+	color: var(--vp-gray-700, #757575);
+	font-variant-numeric: tabular-nums;
+}
+
+.vp-chapters-panel__issues {
+	display: flex;
+	flex-direction: column;
+	gap: 4px;
+}
+
+.vp-chapters-panel__list {
+	flex: 1;
+	min-block-size: 0;
+	overflow-y: auto;
 }

--- a/projects/packages/videopress/src/client/components/chapters-editor/chapters/style.scss
+++ b/projects/packages/videopress/src/client/components/chapters-editor/chapters/style.scss
@@ -303,5 +303,8 @@ input[type="text"].vp-chapters__row-title {
 .vp-chapters-panel__list {
 	flex: 1;
 	min-block-size: 0;
-	overflow-y: auto;
+	// Published host knob: stacked layouts (where the page or workspace is
+	// the scroll surface) set `visible` on the panel root instead of
+	// reaching into this internal class.
+	overflow-y: var(--vp-chapters-panel-list-overflow, auto);
 }

--- a/projects/packages/videopress/src/client/components/chapters-editor/chapters/style.scss
+++ b/projects/packages/videopress/src/client/components/chapters-editor/chapters/style.scss
@@ -172,6 +172,12 @@ input[type="text"].vp-chapters__row-title {
 		border-color: var(--vp-gray-300, #ddd);
 	}
 
+	// A resting row reads as text, so an overflowing title truncates like
+	// text; while editing the input scrolls with the caret as usual.
+	&:not(:focus) {
+		text-overflow: ellipsis;
+	}
+
 	&:focus {
 		background: #fff;
 		border-color: $vp-chapters-accent;

--- a/projects/packages/videopress/src/client/components/chapters-editor/chapters/style.scss
+++ b/projects/packages/videopress/src/client/components/chapters-editor/chapters/style.scss
@@ -178,6 +178,13 @@ input[type="text"].vp-chapters__row-title {
 		text-overflow: ellipsis;
 	}
 
+	// Forced-colors mode preserves the alpha channel, so the transparent
+	// resting border would leave the field with no boundary at all there —
+	// exactly the users the mode serves. Give it a system-colored one.
+	@media ( forced-colors: active ) {
+		border-color: buttonborder;
+	}
+
 	&:focus {
 		background: #fff;
 		border-color: $vp-chapters-accent;
@@ -264,10 +271,11 @@ input[type="text"].vp-chapters__row-title {
 // and the rows list. Hosts own its placement and outer sizing; when they
 // bound its height (the side-pane arrangement) the list region is what
 // scrolls, so the header stays put.
+// Spacing via margins, not a column gap: the issues live region below stays
+// mounted while empty, and a flex gap would hand the empty box its own slot.
 .vp-chapters-panel {
 	display: flex;
 	flex-direction: column;
-	gap: 12px;
 	min-block-size: 0;
 }
 
@@ -276,6 +284,7 @@ input[type="text"].vp-chapters__row-title {
 	align-items: center;
 	justify-content: space-between;
 	gap: 8px;
+	margin-block-end: 12px;
 }
 
 // Reads as a section label, like the tools rail's "Edit" heading.
@@ -298,6 +307,10 @@ input[type="text"].vp-chapters__row-title {
 	display: flex;
 	flex-direction: column;
 	gap: 4px;
+
+	&:not(:empty) {
+		margin-block-end: 12px;
+	}
 }
 
 .vp-chapters-panel__list {

--- a/projects/packages/videopress/src/client/components/chapters-editor/chapters/style.scss
+++ b/projects/packages/videopress/src/client/components/chapters-editor/chapters/style.scss
@@ -109,75 +109,80 @@ $vp-chapters-warning: var(--vp-warning, #b26200);
 	gap: 4px;
 }
 
+// Boxless rows: at rest a row is just text on the panel background. State
+// lives in the background tint and a slim accent bar on the row's start
+// edge (a permanent transparent border keeps the layout stable when it
+// colors in).
 .vp-chapters__row {
 	display: flex;
 	align-items: center;
-	// The validation message wraps onto its own line inside the row box, so
-	// a flagged row keeps its ring around both.
+	// The validation message wraps onto its own line inside the row, so a
+	// flagged row keeps its tint and bar around both.
 	flex-wrap: wrap;
 	gap: 8px;
-	padding: 6px 8px;
-	border-radius: var(--vp-radius-small, 2px);
-	box-shadow: inset 0 0 0 1px var(--vp-gray-200, #e0e0e0);
+	padding: 4px 8px;
+	border-inline-start: 3px solid transparent;
+	border-start-end-radius: var(--vp-radius-small, 2px);
+	border-end-end-radius: var(--vp-radius-small, 2px);
+
+	&:hover {
+		background: var(--vp-gray-100, #f0f0f0);
+	}
 
 	// Accent-derived tint, with the literal as the parse-time fallback —
 	// same reasoning as the selected segment above.
-	&--selected {
+	&--selected,
+	&--selected:hover {
 		background: rgba(56, 88, 233, 0.06);
 		background: color-mix(in srgb, #{$vp-chapters-accent} 6%, transparent);
-		box-shadow: inset 0 0 0 1px $vp-chapters-accent;
+		border-inline-start-color: $vp-chapters-accent;
 	}
 
-	// A publish-rule violation outranks selection for the ring; the tint still
+	// A publish-rule violation outranks selection for the bar; the tint still
 	// says which row is selected.
 	&--invalid,
 	&--invalid.vp-chapters__row--selected {
-		box-shadow: inset 0 0 0 1px $vp-chapters-warning;
+		border-inline-start-color: $vp-chapters-warning;
 	}
 }
 
 // Row-scoped publish-rule message, on its own line under the controls.
 .vp-chapters__row-issue {
 	flex: 0 0 100%;
+	padding-inline-start: 9px; // Aligns with the borderless title input's text.
 	font-size: 12px;
 	color: $vp-chapters-warning;
 }
 
-// The pinned-start lock on the first row, between the title and its 0:00.
-.vp-chapters__row-lock {
-	flex: none;
-	display: inline-flex;
-	align-items: center;
-	color: var(--vp-gray-700, #757575);
-
-	svg {
-		fill: currentColor;
-	}
-}
-
 // Beat wp-admin forms.css's `input[type="text"]` on padding/border, the same
-// specificity fight as the toolbar timecode box.
+// specificity fight as the toolbar timecode box. The input is seamless at
+// rest — a resting row reads as text — and only grows its box back on focus.
 input[type="text"].vp-chapters__row-title {
 	flex: 1;
 	min-width: 0;
 	height: 32px;
 	padding: 0 8px;
-	border: 1px solid var(--vp-gray-600, #949494);
+	border: 1px solid transparent;
 	border-radius: var(--vp-radius-small, 2px);
-	background: #fff;
+	background: transparent;
 	font-size: 13px;
 	color: var(--vp-gray-900, #1e1e1e);
 
+	&:hover:not(:focus, :disabled) {
+		border-color: var(--vp-gray-300, #ddd);
+	}
+
 	&:focus {
+		background: #fff;
 		border-color: $vp-chapters-accent;
 		box-shadow: 0 0 0 1px $vp-chapters-accent;
 		outline: none;
 	}
 
-	// The explicit white background above would otherwise hide the UA's
-	// disabled treatment while a job or save holds the editor locked.
+	// Keep the seamless look while a job or save holds the editor locked;
+	// the host dims the whole panel, so gray text is enough here.
 	&:disabled {
-		background: var(--vp-gray-100, #f0f0f0);
+		background: transparent;
 		color: var(--vp-gray-700, #757575);
 	}
 }
@@ -223,6 +228,13 @@ input[type="text"].vp-chapters__row-title {
 }
 
 .vp-chapters__now {
+	// Zero flex basis: in the wrapping toolbar, line breaks are decided from
+	// items' BASE sizes (shrink only applies within a line), so a content-
+	// sized basis would let a long title wrap the cluster. Basis 0 never
+	// forces a wrap; grow takes the line's free space and min-inline-size: 0
+	// defeats the content-size floor so the title truncates instead.
+	flex: 1 1 0;
+	min-inline-size: 0;
 	font-size: 12px;
 	color: var(--vp-gray-700, #757575);
 	white-space: nowrap;

--- a/projects/packages/videopress/src/client/components/chapters-editor/chapters/test/chapters-timeline.test.tsx
+++ b/projects/packages/videopress/src/client/components/chapters-editor/chapters/test/chapters-timeline.test.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable testing-library/prefer-user-event -- Drag gestures need raw pointer events carrying clientX/pointerId (userEvent has no pointer-capture drag primitive), and the shortcuts under test listen for raw keydowns on document. */
-import { act, fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useReducer } from 'react';
 import {
@@ -8,6 +8,7 @@ import {
 	createChaptersSession,
 } from '../../state/chapters-session';
 import { canUndo, createHistory, withHistory } from '../../state/history';
+import ChaptersPanel from '../chapters-panel';
 import ChaptersTimeline from '../chapters-timeline';
 import type { ChapterRow } from '../../../../utils/video-chapters/description';
 import type { ChaptersSession, ChaptersSessionAction } from '../../state/chapters-session';
@@ -57,9 +58,10 @@ type HarnessProps = Partial< ChaptersTimelineProps > & {
 };
 
 /**
- * The timeline under a REAL history-wrapped store, so gestures, coalescing,
- * and undo semantics are exercised end to end. An extra harness button
- * dispatches UNDO and a probe span reports canUndo.
+ * The timeline AND the chapters panel over one REAL history-wrapped store —
+ * the same composition both hosts render — so gestures, coalescing, undo
+ * semantics, and the strip ↔ rows interplay are exercised end to end. An
+ * extra harness button dispatches UNDO and a probe span reports canUndo.
  *
  * @param props            - Timeline prop overrides plus the initial rows/duration.
  * @param props.rows       - Rows LOADed into the store at mount.
@@ -76,16 +78,26 @@ function Harness( { rows, durationMs = 60000, ...overrides }: HarnessProps ): Re
 			} )
 		)
 	);
+	// The gating props and the seek callback are shared between the strip and
+	// the panel, exactly as the hosts wire them.
+	const { onSeek = () => {}, locked, readOnly } = overrides;
 	return (
 		<>
 			<ChaptersTimeline
 				session={ history.present }
 				dispatch={ dispatch }
 				currentMs={ 0 }
-				onSeek={ () => {} }
 				onTogglePlay={ () => {} }
 				playing={ false }
 				{ ...overrides }
+				onSeek={ onSeek }
+			/>
+			<ChaptersPanel
+				session={ history.present }
+				dispatch={ dispatch }
+				onSeek={ onSeek }
+				locked={ locked }
+				readOnly={ readOnly }
 			/>
 			<button data-testid="harness-undo" onClick={ () => dispatch( { type: 'UNDO' } ) }>
 				harness undo
@@ -115,7 +127,7 @@ const markers = () => screen.queryAllByTestId( /^chapters-marker-/ );
 const addButton = () => screen.getByRole( 'button', { name: 'Add chapter at playhead' } );
 const isAriaDisabled = ( el: HTMLElement ) => el.getAttribute( 'aria-disabled' ) === 'true';
 
-describe( 'ChaptersTimeline', () => {
+describe( 'Chapters editor (timeline strip + panel)', () => {
 	describe( 'strip', () => {
 		it( 'renders segments spanning start → next start, the last running to the video end', () => {
 			renderChapters();
@@ -313,6 +325,23 @@ describe( 'ChaptersTimeline', () => {
 			// Whole-second rounding: 5400 → 5000.
 			expect( markers()[ 0 ] ).toHaveAttribute( 'aria-valuenow', '5000' );
 		} );
+
+		it( 'hands focus to the new chapter’s title input with the default title selected', async () => {
+			const user = userEvent.setup();
+			renderChapters( { currentMs: 5400 } );
+
+			await user.click( addButton() );
+
+			// The hand-off is a frame behind the add (the rows live in the
+			// sibling panel and render on the next flush).
+			const input = ( await screen.findByLabelText( 'Chapter 2 title' ) ) as HTMLInputElement;
+			await waitFor( () => expect( input ).toHaveFocus() );
+			// The default title is selected so typing replaces it directly.
+			expect( input.value ).toBe( 'Chapter 2' );
+			expect( input.value.slice( input.selectionStart ?? 0, input.selectionEnd ?? 0 ) ).toBe(
+				'Chapter 2'
+			);
+		} );
 	} );
 
 	describe( 'rows list', () => {
@@ -366,33 +395,26 @@ describe( 'ChaptersTimeline', () => {
 			expect( screen.getByTestId( 'harness-can-undo' ) ).toHaveTextContent( 'false' );
 		} );
 
-		it( 'formats the row duration as a timecode rather than raw seconds', () => {
-			// Real media durations are fractional, and the last row runs to the
-			// video end — so this row used to read "4437.055s".
-			renderChapters( { rows: [ { startAtSeconds: 0, title: 'Only' } ], durationMs: 4437055 } );
-
-			const row = screen.getAllByTestId( /^chapters-row-chapter/ )[ 0 ];
-			expect( row ).toHaveTextContent( '1:13:57.0' );
-			expect( row ).not.toHaveTextContent( '4437.055s' );
-		} );
-
-		it( 'shows index, start time, and duration per row and seeks from the time button', async () => {
+		it( 'shows the start time per row and seeks from the time button', async () => {
 			const onSeek = jest.fn();
 			const user = userEvent.setup();
 			renderChapters( { onSeek } );
 
-			const rows = screen.getAllByTestId( /^chapters-row-chapter/ );
-			expect( rows[ 0 ] ).toHaveTextContent( '01' );
-			expect( rows[ 2 ] ).toHaveTextContent( '03' );
-			// Durations: next start − start; the last runs to the video end.
-			expect( rows[ 0 ] ).toHaveTextContent( '0:00:10.0' );
-			expect( rows[ 1 ] ).toHaveTextContent( '0:00:20.0' );
-			expect( rows[ 2 ] ).toHaveTextContent( '0:00:30.0' );
-
 			const timeButtons = screen.getAllByTestId( /^chapters-row-time-/ );
+			expect( timeButtons[ 0 ] ).toHaveTextContent( '0:00:00.0' );
+			expect( timeButtons[ 1 ] ).toHaveTextContent( '0:00:10.0' );
 			expect( timeButtons[ 2 ] ).toHaveTextContent( '0:00:30.0' );
 			await user.click( timeButtons[ 2 ] );
 			expect( onSeek ).toHaveBeenCalledWith( 30000 );
+		} );
+
+		it( 'shows the live chapter count in the panel header', async () => {
+			const user = userEvent.setup();
+			renderChapters( { currentMs: 5000 } );
+			expect( screen.getByTestId( 'chapters-count' ) ).toHaveTextContent( '3' );
+
+			await user.click( addButton() );
+			expect( screen.getByTestId( 'chapters-count' ) ).toHaveTextContent( '4' );
 		} );
 
 		it( 're-pins the new first chapter to 0 when the first is removed', async () => {
@@ -556,7 +578,7 @@ describe( 'ChaptersTimeline', () => {
 			);
 		} );
 
-		it( 'reports issues with no row of their own next to the footer help line', () => {
+		it( 'reports issues with no row of their own under the panel header', () => {
 			renderChapters( {
 				rows: [
 					{ startAtSeconds: 0, title: 'Intro' },
@@ -568,6 +590,26 @@ describe( 'ChaptersTimeline', () => {
 				'At least three chapters are required.'
 			);
 			expect( screen.queryAllByTestId( /^chapters-row-issue-/ ) ).toHaveLength( 0 );
+		} );
+
+		it( 'rolls up untitled chapters under the header while the row carries its own message', () => {
+			renderChapters( {
+				rows: [
+					{ startAtSeconds: 0, title: 'Intro' },
+					{ startAtSeconds: 20, title: '' },
+					{ startAtSeconds: 40, title: 'End' },
+				],
+			} );
+
+			expect( screen.getByTestId( 'chapters-validation' ) ).toHaveTextContent(
+				'1 chapter still needs a title.'
+			);
+			const issues = screen.getAllByTestId( /^chapters-row-issue-/ );
+			expect( issues ).toHaveLength( 1 );
+			expect( issues[ 0 ] ).toHaveTextContent( 'Every chapter needs a title.' );
+			expect( screen.getAllByTestId( /^chapters-row-chapter/ )[ 1 ] ).toContainElement(
+				issues[ 0 ]
+			);
 		} );
 
 		// A description with no chapter lines loads as one seeded chapter, so

--- a/projects/packages/videopress/src/client/components/chapters-editor/chapters/test/chapters-timeline.test.tsx
+++ b/projects/packages/videopress/src/client/components/chapters-editor/chapters/test/chapters-timeline.test.tsx
@@ -57,6 +57,8 @@ type HarnessProps = Partial< ChaptersTimelineProps > & {
 	durationMs?: number;
 };
 
+const noopSeek = () => {};
+
 /**
  * The timeline AND the chapters panel over one REAL history-wrapped store —
  * the same composition both hosts render — so gestures, coalescing, undo
@@ -79,10 +81,15 @@ function Harness( { rows, durationMs = 60000, ...overrides }: HarnessProps ): Re
 		)
 	);
 	// The gating props and the seek callback are shared between the strip and
-	// the panel, exactly as the hosts wire them.
-	const { onSeek = () => {}, locked, readOnly } = overrides;
+	// the panel, exactly as the hosts wire them. The default onSeek is a
+	// stable module-level noop so the memoized panel's props are
+	// identity-stable except the session — the update assertions below then
+	// genuinely prove memo re-renders on session change.
+	const { onSeek = noopSeek, locked, readOnly } = overrides;
 	return (
-		<>
+		// The tokens wrapper mirrors both hosts and is what the add-button's
+		// scoped focus query resolves against.
+		<div className="vp-chapters-tokens">
 			<ChaptersTimeline
 				session={ history.present }
 				dispatch={ dispatch }
@@ -105,7 +112,7 @@ function Harness( { rows, durationMs = 60000, ...overrides }: HarnessProps ): Re
 			<span data-testid="harness-can-undo">
 				{ String( canUndo( history, chaptersEditsEqual ) ) }
 			</span>
-		</>
+		</div>
 	);
 }
 
@@ -529,7 +536,7 @@ describe( 'Chapters editor (timeline strip + panel)', () => {
 		it( 'shows nothing while the chapter set is valid', () => {
 			renderChapters();
 			expect( screen.queryAllByTestId( /^chapters-row-issue-/ ) ).toHaveLength( 0 );
-			expect( screen.queryByTestId( 'chapters-validation' ) ).not.toBeInTheDocument();
+			expect( screen.getByTestId( 'chapters-validation' ) ).toBeEmptyDOMElement();
 		} );
 
 		it( 'flags the offending row and describes its title input with the message', () => {
@@ -554,7 +561,7 @@ describe( 'Chapters editor (timeline strip + panel)', () => {
 				issues[ 0 ].id
 			);
 			// Nothing row-less to report here.
-			expect( screen.queryByTestId( 'chapters-validation' ) ).not.toBeInTheDocument();
+			expect( screen.getByTestId( 'chapters-validation' ) ).toBeEmptyDOMElement();
 		} );
 
 		it( 'checks the duration on the same basis the hosts use at save time', () => {
@@ -612,13 +619,28 @@ describe( 'Chapters editor (timeline strip + panel)', () => {
 			);
 		} );
 
+		it( 'pluralizes the untitled rollup and flags every offending row', () => {
+			renderChapters( {
+				rows: [
+					{ startAtSeconds: 0, title: 'Intro' },
+					{ startAtSeconds: 20, title: '' },
+					{ startAtSeconds: 40, title: '' },
+				],
+			} );
+
+			expect( screen.getByTestId( 'chapters-validation' ) ).toHaveTextContent(
+				'2 chapters still need a title.'
+			);
+			expect( screen.getAllByTestId( /^chapters-row-issue-/ ) ).toHaveLength( 2 );
+		} );
+
 		// A description with no chapter lines loads as one seeded chapter, so
 		// validating it would scold the user on arrival for a set they have
 		// not written yet.
 		it( 'stays quiet until there is more than one chapter to judge', () => {
 			renderChapters( { rows: [ { startAtSeconds: 0, title: 'Only' } ] } );
 
-			expect( screen.queryByTestId( 'chapters-validation' ) ).not.toBeInTheDocument();
+			expect( screen.getByTestId( 'chapters-validation' ) ).toBeEmptyDOMElement();
 			expect( screen.queryAllByTestId( /^chapters-row-issue-/ ) ).toHaveLength( 0 );
 		} );
 
@@ -630,7 +652,7 @@ describe( 'Chapters editor (timeline strip + panel)', () => {
 					{ startAtSeconds: 30, title: 'Second' },
 				],
 			} );
-			expect( screen.queryByTestId( 'chapters-validation' ) ).not.toBeInTheDocument();
+			expect( screen.getByTestId( 'chapters-validation' ) ).toBeEmptyDOMElement();
 		} );
 	} );
 
@@ -643,9 +665,11 @@ describe( 'Chapters editor (timeline strip + panel)', () => {
 			expect( markers() ).toHaveLength( 0 );
 			expect( screen.queryByTestId( 'chapters-rows' ) ).not.toBeInTheDocument();
 			expect( isAriaDisabled( addButton() ) ).toBe( true );
-			expect( screen.getByRole( 'status' ) ).toHaveTextContent(
-				'Chapters for this video are managed by an uploaded VTT file, so they can’t be edited here.'
-			);
+			expect(
+				screen.getByText(
+					'Chapters for this video are managed by an uploaded VTT file, so they can’t be edited here.'
+				)
+			).toBeInTheDocument();
 		} );
 
 		it( 'drops the Delete shortcut', () => {

--- a/projects/packages/videopress/src/client/components/chapters-editor/preview/preview-player.scss
+++ b/projects/packages/videopress/src/client/components/chapters-editor/preview/preview-player.scss
@@ -16,6 +16,11 @@
 
 .vp-chapters-preview__stage {
 	position: relative;
+	// Full width up to the caps below: the cross-axis auto margins opt the
+	// stage out of flex stretching, so without an explicit width it would
+	// shrink-to-fit the <video>'s intrinsic size — 300×150 until metadata
+	// arrives, i.e. a postage stamp while the rendition loads.
+	width: 100%;
 	aspect-ratio: 16 / 9;
 	background: #000;
 	border-radius: 2px;

--- a/projects/packages/videopress/src/client/components/chapters-editor/preview/preview-player.scss
+++ b/projects/packages/videopress/src/client/components/chapters-editor/preview/preview-player.scss
@@ -20,7 +20,7 @@
 	// stage out of flex stretching, so without an explicit width it would
 	// shrink-to-fit the <video>'s intrinsic size — 300×150 until metadata
 	// arrives, i.e. a postage stamp while the rendition loads.
-	width: 100%;
+	inline-size: 100%;
 	aspect-ratio: 16 / 9;
 	background: #000;
 	border-radius: 2px;
@@ -36,7 +36,7 @@
 }
 
 .vp-chapters-preview__video {
-	width: 100%;
+	inline-size: 100%;
 	height: 100%;
 	object-fit: contain;
 }

--- a/projects/packages/videopress/src/client/components/chapters-editor/timeline/style.scss
+++ b/projects/packages/videopress/src/client/components/chapters-editor/timeline/style.scss
@@ -18,7 +18,13 @@ $vp-timeline-accent: var(--vp-accent, var(--wp-admin-theme-color, #3858e9));
 .vp-chapters-timeline__toolbar {
 	display: flex;
 	align-items: center;
+	// The side-panel arrangement narrows the strip's column, so the toolbar
+	// wraps wherever its single line no longer fits instead of forcing a
+	// horizontal scroll; the zoom cluster's margin-inline-start: auto keeps
+	// it right-aligned on whichever line it lands.
+	flex-wrap: wrap;
 	gap: 12px;
+	row-gap: 8px;
 	min-height: 36px;
 }
 


### PR DESCRIPTION
Fixes # N/A

## Proposed changes

Design iteration on the flagged chapters editor (both surfaces: the block editor's chapter manager modal and the dashboard's Editor tab), adopting the side-panel arrangement from Adam's design exploration:

* Move the chapter rows out of `ChaptersTimeline` into a new shared `ChaptersPanel`: a "Chapters" header with a live count, the publish-rule summary (including a "%d chapters still need a title." rollup), and the rows list — rendered beside the preview player and timeline instead of stacked below them, so list length no longer competes with the player for vertical space.
* Collapse back to the stacked layout via a container query on the editor's own width (not the viewport): the modal stacks below ~920px of workspace width, the Editor tab below 1024px of card width. Narrow surfaces keep the exact pre-panel layout.
* Restyle the rows boxless: hover wash, selection tint plus a start-edge accent bar (warning-colored when a row is flagged), title inputs borderless until focused so resting rows read as text, and overflowing titles ellipsize at rest. The ordinal and duration columns are removed.
* "Add chapter at playhead" hands focus to the new chapter's title input with the default "Chapter N" title selected, so typing replaces it directly.
* Modal chrome: the in-body action bar folds into the Modal header (undo/redo │ Discard changes │ Save │ close beside a two-tone "Chapters · {video title}" heading), a hairline separates the header, the panel divider runs the full body height, and the preview's height clamp relaxes from 300px to `min(540px, 52vh)` now that the rows sit beside it.
* The preview stage keeps its full width while a rendition loads instead of collapsing to the `<video>` element's 300×150 intrinsic size.
* A long "Now: {chapter}" title truncates on the timeline toolbar instead of wrapping it.

Everything stays behind the existing `jetpack_videopress_chapters_editor` filter (default off). No PHP changes.

| Editor tab (wide) | Editor tab (stacked card) | Editor tab (mobile) |
| --- | --- | --- |
| ![tab wide](https://github.com/Automattic/jetpack/raw/6a3174b6b18debfeec1512fba43baa63e37c4a51/tab-1680.png) | ![tab stacked](https://github.com/Automattic/jetpack/raw/6a3174b6b18debfeec1512fba43baa63e37c4a51/tab-1080.png) | ![tab mobile](https://github.com/Automattic/jetpack/raw/6a3174b6b18debfeec1512fba43baa63e37c4a51/tab-420.png) |

| Modal (wide) | Modal (narrow, stacked) |
| --- | --- |
| ![modal wide](https://github.com/Automattic/jetpack/raw/6a3174b6b18debfeec1512fba43baa63e37c4a51/modal-1680.png) | ![modal narrow](https://github.com/Automattic/jetpack/raw/6a3174b6b18debfeec1512fba43baa63e37c4a51/modal-900.png) |

| Validation rollup + flagged row | Resting-title ellipsis |
| --- | --- |
| ![validation](https://github.com/Automattic/jetpack/raw/6a3174b6b18debfeec1512fba43baa63e37c4a51/tab-invalid-1680.png) | ![ellipsis](https://github.com/Automattic/jetpack/raw/6a3174b6b18debfeec1512fba43baa63e37c4a51/panel-ellipsis.png) |

## Related product discussion/links

* p1HpG7-ymL-p2

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Enable the flag, e.g. via a mu-plugin or Code Snippets: `add_filter( 'jetpack_videopress_chapters_editor', '__return_true' );`
* You need a VideoPress video; seeding its description with chapter lines (`0:00 Intro` etc., three or more) gives you something to look at.

**Editor tab**

* Go to Jetpack → VideoPress → open a video → Editor tab.
* At a wide window: the chapter list sits in a right panel (header, count, rows); the player and timeline keep the main column. The panel divider runs the full card height.
* Narrow the window below ~1050px: the panel drops below the timeline (the pre-panel stacked layout). At ≤782px the tools rail collapses to icons.
* Click **Add chapter at playhead** (move the playhead first — it's disabled on a taken second): focus lands in the new row's title input with "Chapter N" selected; type to replace, Enter to commit.
* Clear a chapter's title and blur: the row gets a warning start-edge bar plus message, and the panel header shows "1 chapter still needs a title."
* Type a long title and select another row: the resting title truncates with an ellipsis.
* Undo/redo, Discard changes, and Save in the page header all behave as before the refactor (state, history, and the save flow are untouched).

**Block editor modal**

* Edit a post with a VideoPress block → select the block → "Manage chapters" in the block toolbar.
* Header reads "Chapters · {video title}" with undo/redo │ Discard changes │ Save │ ✕ in the header row; a hairline separates it from the body.
* Same two-pane layout and behaviors as the tab; shrink the window below ~960px and the panes stack with the workspace as the single scroll surface.
* Escape with unsaved changes still raises the in-modal discard confirmation; while it's up, the header's undo/redo/Discard/Save are disabled.