### PR TITLE
Central Forms Management: stop excluding e2e test sites

### DIFF
--- a/projects/packages/jetpack-mu-wpcom/changelog/remove-forms-cfm-e2e-test-blog-gate
+++ b/projects/packages/jetpack-mu-wpcom/changelog/remove-forms-cfm-e2e-test-blog-gate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Central Forms Management: stop excluding e2e test sites.

--- a/projects/packages/jetpack-mu-wpcom/src/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php
+++ b/projects/packages/jetpack-mu-wpcom/src/features/wpcom-contact-form-flags/wpcom-contact-form-flags.php
@@ -31,7 +31,7 @@ function wpcom_forms_has_blog_sticker( $sticker, $blog_id ) {
 /**
  * Check if Central Forms Management is enabled for a given blog.
  *
- * Enabled for all WordPress.com sites except e2e test sites.
+ * Enabled for all WordPress.com sites, except those that opt out by sticker.
  *
  * @param int|null $blog_id Blog ID. Defaults to the current WP.com blog ID.
  * @return bool
@@ -39,11 +39,6 @@ function wpcom_forms_has_blog_sticker( $sticker, $blog_id ) {
 function wpcom_is_central_forms_management_enabled( $blog_id = null ) {
 	if ( null === $blog_id ) {
 		$blog_id = function_exists( 'get_wpcom_blog_id' ) ? get_wpcom_blog_id() : get_current_blog_id();
-	}
-
-	// Exclude e2e test sites — their tests aren't ready for CFM yet.
-	if ( wpcom_forms_has_blog_sticker( 'a8c-e2e-test-blog', $blog_id ) ) {
-		return false;
 	}
 
 	// Allow disabling CFM for individual sites via blog sticker.
@@ -58,8 +53,8 @@ function wpcom_is_central_forms_management_enabled( $blog_id = null ) {
  * Disable Central Forms Management for excluded WordPress.com sites.
  *
  * CFM is now enabled by default in the Forms package. This function
- * explicitly disables it for sites that should be excluded (e2e test
- * sites, sites with the disable-central-forms-management sticker).
+ * explicitly disables it for sites that carry the
+ * disable-central-forms-management sticker.
  *
  * Called immediately on file load since this file is required during
  * plugins_loaded (priority 10) inside load_wpcom_sites_features().


### PR DESCRIPTION
Part of #50712 (step 3b).

## Proposed changes

* Remove the `a8c-e2e-test-blog` check from `wpcom_is_central_forms_management_enabled()`. WordPress.com e2e test sites now get Central Forms Management like every other site.
* Update the two docblocks that described the exclusion.

The sticker itself is **not** touched. `a8c-e2e-test-blog` predates Forms by years, is auto-applied to every e2e-created site, and has many unrelated consumers. Only the CFM check goes away. Sites can still opt out through the `disable-central-forms-management` sticker, which this PR leaves in place as the per-site rescue hatch.

### Why now

The exclusion was added in #47801 because the Calypso feedback inbox spec only knew the legacy dashboard. That spec now handles both.

### Blocked on

**Do not merge before Automattic/wp-calypso#113202.** That PR teaches the spec to find response folders on both dashboards. Landing this first moves every e2e site to CFM while the deployed spec still uses the legacy folder lookup, which breaks both the Simple and the Atomic e2e builds.

## Related product discussion/links

* FORMS-733

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

This change has no test surface inside the monorepo — the behaviour it controls only exists on WordPress.com. Verification is by inspection plus the e2e suite after deploy.

**By inspection:**

* Read `wpcom_is_central_forms_management_enabled()`. It should return `false` only for sites carrying `disable-central-forms-management`.
* Confirm `wpcom_forms_has_blog_sticker()` is still used, and still handles the Simple and Atomic paths.

**After deploy**, the Forms e2e spec should exercise the CFM dashboard on both infrastructures.

For testing against one of the test sites, sandbox the site URL and patch your sandbox with this PR:

```
bin/jetpack-downloader test jetpack-mu-wpcom-plugin remove/forms-cfm-e2e-test-blog-gate
```

Then, from wp-calypso repo, run:

```
CALYPSO_BASE_URL=https://wordpress.com yarn workspace wp-e2e-tests playwright test specs/published-content/forms__submissions.spec.ts --project=chrome
```

```
CALYPSO_BASE_URL=https://wordpress.com TEST_ON_ATOMIC=true yarn workspace wp-e2e-tests playwright test  specs/published-content/forms__submissions.spec.ts --project=chrome
```

Both runs should reach the Central Forms Management dashboard rather than the legacy hash-routed SPA. The served bundle tells them apart: CFM loads `build/pages/*` and `build/routes/*`, legacy loads `dist/dashboard/*`.

### Note on Atomic

Atomic reads this sticker through `Atomic_Persistent_Data`, and that sync is per-site — it is written when a sticker is added while the sticker is in `atomic_site_stickers()`, and re-pushed on transfer, clone or reset. So Atomic sites can disagree with each other even when both carry the sticker. After this change none of that matters for Forms, because nothing reads the persisted value any more.
