### PR TITLE
My Jetpack: restore the Activity Log menu item for standalone plugins

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-activity-log-menu-standalone-plugins
+++ b/projects/packages/my-jetpack/changelog/fix-activity-log-menu-standalone-plugins
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Restore the Jetpack > Activity Log menu item for standalone plugins, which lost it when the native Activity Log page took over the entry in the Jetpack plugin.

--- a/projects/packages/my-jetpack/src/class-initializer.php
+++ b/projects/packages/my-jetpack/src/class-initializer.php
@@ -24,6 +24,7 @@ use Automattic\Jetpack\Menu_Badges\Menu_Badges;
 use Automattic\Jetpack\Menu_Badges\Notification_Counts;
 use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Plugins_Installer;
+use Automattic\Jetpack\Redirect;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host as Status_Host;
 use Automattic\Jetpack\Sync\Functions as Sync_Functions;
@@ -112,6 +113,8 @@ class Initializer {
 		// Add "Jetpack Manage" menu item.
 		Jetpack_Manage::init();
 
+		add_action( 'admin_menu', array( __CLASS__, 'add_activity_log_menu_item' ) );
+
 		/**
 		 * Fires after the My Jetpack package is initialized
 		 *
@@ -168,6 +171,54 @@ class Initializer {
 			-1
 		);
 		add_action( 'load-' . $page_suffix, array( __CLASS__, 'admin_init' ) );
+	}
+
+	/**
+	 * Add an "Activity Log" menu item pointing at Cloud.
+	 *
+	 * Only for plugins that ship My Jetpack without the native Activity Log
+	 * page. The `automattic/jetpack-activity-log` package, which only the
+	 * Jetpack plugin bundles, renders that page in wp-admin and owns the menu
+	 * item wherever it is present, so we stand down for it. Presence of the
+	 * package is the signal, not whether it registered an item: when it is
+	 * there but chooses not to render, a redirect out to Cloud is not the
+	 * fallback we want.
+	 *
+	 * @return void|null|string The resulting page's hook_suffix.
+	 */
+	public static function add_activity_log_menu_item() {
+		// Checked here, on `admin_menu`, so the autoloader has already resolved
+		// the newest copy of the package across every active Jetpack plugin.
+		if ( class_exists( 'Automattic\Jetpack\Activity_Log\Jetpack_Activity_Log' ) ) {
+			return;
+		}
+
+		// Only proceed if the user is connected to WordPress.com.
+		if ( ! ( new Connection_Manager() )->is_user_connected() ) {
+			return;
+		}
+
+		// Do not display the menu on Multisite.
+		if ( is_multisite() ) {
+			return;
+		}
+
+		$args = array();
+
+		$blog_id = Connection_Manager::get_site_id( true );
+		if ( $blog_id ) {
+			$args = array( 'site' => $blog_id );
+		}
+
+		return Admin_Menu::add_menu(
+			/** "Activity Log" is a product name, do not translate. */
+			'Activity Log',
+			'Activity Log <span aria-hidden="true">↗</span>',
+			'manage_options',
+			esc_url( Redirect::get_url( 'cloud-activity-log-wp-menu', $args ) ),
+			null,
+			14
+		);
 	}
 
 	/**

--- a/projects/packages/my-jetpack/tests/php/Initializer_Test.php
+++ b/projects/packages/my-jetpack/tests/php/Initializer_Test.php
@@ -8,8 +8,10 @@
 namespace Automattic\Jetpack\My_Jetpack;
 
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Connection\Tokens;
 use Automattic\Jetpack\Constants;
 use Automattic\Jetpack\Status\Cache as StatusCache;
+use Jetpack_Options;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\PreserveGlobalState;
 use PHPUnit\Framework\Attributes\RunInSeparateProcess;
@@ -250,5 +252,72 @@ class Initializer_Test extends BaseTestCase {
 		$this->assertFalse( Initializer::get_my_jetpack_flags()['showAiModuleToggle'] );
 
 		unset( $GLOBALS['jetpack_mock_internal_testing_environment'] );
+	}
+
+	/**
+	 * Mock a site and user connection to WordPress.com, which the Activity Log
+	 * menu item requires, and make that user current.
+	 *
+	 * @return int The connected user's id.
+	 */
+	private function mock_connected_admin() {
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'activity_log_admin',
+				'user_pass'  => 'dummy_pass',
+				'role'       => 'administrator',
+			)
+		);
+
+		( new Tokens() )->update_blog_token( 'test.test.1' );
+		( new Tokens() )->update_user_token( $user_id, 'test.test.' . $user_id, true );
+		Jetpack_Options::update_option( 'id', 123 );
+		wp_set_current_user( $user_id );
+
+		return $user_id;
+	}
+
+	/**
+	 * The Activity Log menu item is not added when the user is not connected to
+	 * WordPress.com.
+	 */
+	public function test_activity_log_menu_item_requires_a_connection() {
+		$this->assertNull( Initializer::add_activity_log_menu_item() );
+	}
+
+	/**
+	 * The Activity Log menu item is registered for connected admins on plugins
+	 * that do not bundle the native Activity Log page.
+	 *
+	 * Note the item is only queued here: `Admin_Menu` passes the
+	 * `manage_options` requirement to `add_submenu_page()` later, on
+	 * `admin_menu`, so a return value means registered, not visible.
+	 */
+	public function test_activity_log_menu_item_is_added_when_connected() {
+		$this->mock_connected_admin();
+
+		$this->assertStringStartsWith( 'jetpack_page_', (string) Initializer::add_activity_log_menu_item() );
+	}
+
+	/**
+	 * The Activity Log menu item stands down when the native Activity Log page
+	 * is available, so sites running the Jetpack plugin alongside a standalone
+	 * plugin do not get two entries.
+	 *
+	 * Runs isolated: the stub class cannot be undefined once declared.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_activity_log_menu_item_defers_to_the_native_page() {
+		// Same conditions as the test above, which registers the item. The guard
+		// only asks whether the class exists, so any user-defined class stands in
+		// for the real one.
+		$this->mock_connected_admin();
+		class_alias( Initializer::class, 'Automattic\Jetpack\Activity_Log\Jetpack_Activity_Log' );
+
+		$this->assertNull( Initializer::add_activity_log_menu_item() );
 	}
 }


### PR DESCRIPTION
Fixes #

## Proposed changes
<!--- Explain what functional changes your PR includes -->
* 

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions
<!-- If you were reviewing this PR, how would you like the instructions to be presented? -->
<!-- Please include detailed testing steps, explaining how to test your change. -->
<!-- Bear in mind that context you are working on is not obvious for everyone.  -->
<!-- Adding relevant configuration steps will help reviewers to get to your PR as quickly as possible. -->
<!-- "Before"/"After" screenshots can be helpful when the change is visual. -->

* Go to '..'
*
