### PR TITLE
AI: Add is_a11n and is_test audience properties to MCP Tracks events

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/main.jsx
@@ -15,12 +15,12 @@ import { Spinner } from '@wordpress/components';
 import { useCallback, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Badge, Notice, Stack, Tabs } from '@wordpress/ui';
-import analytics from 'lib/analytics';
 import AiFeatures from './features/index';
 import { useFeatureSettings } from './features/use-feature-settings';
 import McpHub from './mcp/index';
 import McpRead from './mcp/read';
 import McpSetup from './mcp/setup';
+import { recordMcpTracksEvent } from './mcp/tracks';
 import McpUpsell from './mcp/upsell';
 import { useMcpSettings } from './mcp/use-mcp-settings';
 import McpWrite from './mcp/write';
@@ -148,7 +148,7 @@ export default function App() {
 			mcpViewedRecorded.current = true;
 			// blog_id is attached automatically by the analytics library from
 			// window.jpTracksContext, which the page sets via an inline script.
-			analytics.tracks.recordEvent( 'jetpack_mcp_settings_viewed', {
+			recordMcpTracksEvent( 'jetpack_mcp_settings_viewed', {
 				ref: SETTINGS_REF,
 			} );
 		}

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/index.jsx
@@ -24,8 +24,8 @@ import {
 	list,
 } from '@wordpress/icons';
 import { Badge, Button, Stack } from '@wordpress/ui';
-import analytics from 'lib/analytics';
 import { isWriteTool } from './categories';
+import { recordMcpTracksEvent } from './tracks';
 import {
 	getAccountMcpAbilities,
 	getSiteContextToolIds,
@@ -209,7 +209,7 @@ export default function McpHub( {
 
 	const handleMcpToggle = useCallback(
 		enabled => {
-			analytics.tracks.recordEvent( 'jetpack_mcp_enabled_toggled', { enabled } );
+			recordMcpTracksEvent( 'jetpack_mcp_enabled_toggled', { enabled } );
 			const abilities = {};
 			if ( enabled ) {
 				// Enable all tools (read + write) by default, matching the backend's

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/read.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/read.jsx
@@ -17,10 +17,10 @@ import { Fragment, useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { chevronDown, chevronUp } from '@wordpress/icons';
 import { Stack } from '@wordpress/ui';
-import analytics from 'lib/analytics';
 import { isWriteTool } from './categories';
 import { getOverridesToMatch } from './group-intents';
 import { groupToolsByGroup, groupToolsBySubCategory } from './groups';
+import { recordMcpTracksEvent } from './tracks';
 import {
 	getAccountMcpAbilities,
 	getGroupDescriptors,
@@ -174,7 +174,7 @@ export default function McpRead( { mcpAbilities, blogId, savingToolIds, onUpdate
 
 	const handleToolChange = useCallback(
 		( toolId, enabled ) => {
-			analytics.tracks.recordEvent( 'jetpack_mcp_allowlist_updated', {
+			recordMcpTracksEvent( 'jetpack_mcp_allowlist_updated', {
 				ability_name: toolId,
 				enabled,
 				view: 'read',
@@ -200,7 +200,7 @@ export default function McpRead( { mcpAbilities, blogId, savingToolIds, onUpdate
 			if ( ! overrides ) {
 				return;
 			}
-			analytics.tracks.recordEvent( 'jetpack_mcp_allowlist_updated', {
+			recordMcpTracksEvent( 'jetpack_mcp_allowlist_updated', {
 				enabled,
 				view: 'read',
 				scope: 'page',
@@ -223,7 +223,7 @@ export default function McpRead( { mcpAbilities, blogId, savingToolIds, onUpdate
 			if ( ! overrides ) {
 				return;
 			}
-			analytics.tracks.recordEvent( 'jetpack_mcp_allowlist_updated', {
+			recordMcpTracksEvent( 'jetpack_mcp_allowlist_updated', {
 				enabled,
 				view: 'read',
 				scope: 'group',

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/test/allowlist-updated.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/test/allowlist-updated.jsx
@@ -62,11 +62,19 @@ describe( 'jetpack_mcp_allowlist_updated', () => {
 			await userEvent.click( screen.getByRole( 'button', { name: 'Show operations' } ) );
 			await userEvent.click( screen.getByRole( 'checkbox', { name: 'List posts' } ) );
 
-			// toEqual pins the whole property bag: ability_name present, no tool_id.
+			// toEqual pins the whole property bag: ability_name present, no tool_id,
+			// plus the AI-product-standard audience properties (AIINT-586). This
+			// suite injects no jetpackAiSettings, so both default to 'false'.
 			expect( allowlistUpdatedCalls() ).toEqual( [
 				[
 					'jetpack_mcp_allowlist_updated',
-					{ ability_name: 'wpcom-mcp/posts-list', enabled: true, view },
+					{
+						is_a11n: 'false',
+						is_test: 'false',
+						ability_name: 'wpcom-mcp/posts-list',
+						enabled: true,
+						view,
+					},
 				],
 			] );
 			expect( onUpdate ).toHaveBeenCalledWith( {

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/tracks.js
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/tracks.js
@@ -1,0 +1,40 @@
+/**
+ * Tracks wrapper for the jetpack_mcp_* events.
+ *
+ * Merges the AI-product-standard audience properties into every MCP event so
+ * events added later inherit them, matching TracksPropsHelper::audience_props()
+ * in wpcom (AIINT-586) and useMcpTracksAudienceProps() in wp-calypso:
+ *
+ * - is_a11n is identity, not access — the user is an Automattician, regardless
+ * of the MCP allowlist.
+ * - is_test is environment only — an internal testing environment (localhost,
+ * sandbox, proxied request), regardless of who made the request.
+ *
+ * Both are computed server-side by Jetpack_AI_Page and ride the
+ * jetpackAiSettings global, and both are sent as the strings 'true'/'false'
+ * per the AIINT-576 encoding cutover.
+ *
+ * ai_session_id is deliberately absent: these events fire from browser UI with
+ * no agent session in scope, so the property would be 'none' on every row.
+ */
+
+import analytics from 'lib/analytics';
+
+/**
+ * Record a jetpack_mcp_* Tracks event with the audience properties merged in.
+ *
+ * Reads jetpackAiSettings at call time, not module scope, so tests and late
+ * injections see current values.
+ *
+ * @param {string} eventName       - Tracks event name (jetpack_mcp_*).
+ * @param {object} eventProperties - Event-specific properties.
+ */
+export function recordMcpTracksEvent( eventName, eventProperties = {} ) {
+	const { isA11n = false, isTest = false } = window?.jetpackAiSettings ?? {};
+
+	analytics.tracks.recordEvent( eventName, {
+		is_a11n: isA11n ? 'true' : 'false',
+		is_test: isTest ? 'true' : 'false',
+		...eventProperties,
+	} );
+}

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/upsell.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/upsell.jsx
@@ -15,7 +15,7 @@
 import { Button } from '@wordpress/components';
 import { __ } from '@wordpress/i18n';
 import { useCallback, useEffect } from 'react';
-import analytics from 'lib/analytics';
+import { recordMcpTracksEvent } from './tracks';
 import illustrationUrl from './upsell-illustration.svg';
 import './style.scss';
 
@@ -34,13 +34,13 @@ export default function McpUpsell() {
 	// lifecycle is the right place to record the impression — no extra
 	// gating needed here.
 	useEffect( () => {
-		analytics.tracks.recordEvent( 'jetpack_mcp_upsell_viewed', {
+		recordMcpTracksEvent( 'jetpack_mcp_upsell_viewed', {
 			ref: UPSELL_REF,
 		} );
 	}, [] );
 
 	const onClickUpgrade = useCallback( () => {
-		analytics.tracks.recordEvent( 'jetpack_mcp_upsell_cta_click', {
+		recordMcpTracksEvent( 'jetpack_mcp_upsell_cta_click', {
 			ref: UPSELL_REF,
 		} );
 	}, [] );

--- a/projects/plugins/jetpack/_inc/client/ai/mcp/write.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/mcp/write.jsx
@@ -17,10 +17,10 @@ import { Fragment, useCallback, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { chevronDown, chevronUp } from '@wordpress/icons';
 import { Stack } from '@wordpress/ui';
-import analytics from 'lib/analytics';
 import { isWriteTool } from './categories';
 import { getOverridesToMatch } from './group-intents';
 import { groupToolsByGroup, groupToolsBySubCategory } from './groups';
+import { recordMcpTracksEvent } from './tracks';
 import {
 	getAccountMcpAbilities,
 	getGroupDescriptors,
@@ -174,7 +174,7 @@ export default function McpWrite( { mcpAbilities, blogId, savingToolIds, onUpdat
 
 	const handleToolChange = useCallback(
 		( toolId, enabled ) => {
-			analytics.tracks.recordEvent( 'jetpack_mcp_allowlist_updated', {
+			recordMcpTracksEvent( 'jetpack_mcp_allowlist_updated', {
 				ability_name: toolId,
 				enabled,
 				view: 'write',
@@ -200,7 +200,7 @@ export default function McpWrite( { mcpAbilities, blogId, savingToolIds, onUpdat
 			if ( ! overrides ) {
 				return;
 			}
-			analytics.tracks.recordEvent( 'jetpack_mcp_allowlist_updated', {
+			recordMcpTracksEvent( 'jetpack_mcp_allowlist_updated', {
 				enabled,
 				view: 'write',
 				scope: 'page',
@@ -223,7 +223,7 @@ export default function McpWrite( { mcpAbilities, blogId, savingToolIds, onUpdat
 			if ( ! overrides ) {
 				return;
 			}
-			analytics.tracks.recordEvent( 'jetpack_mcp_allowlist_updated', {
+			recordMcpTracksEvent( 'jetpack_mcp_allowlist_updated', {
 				enabled,
 				view: 'write',
 				scope: 'group',

--- a/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/test/main.jsx
@@ -229,11 +229,17 @@ describe( 'AI admin page (main.jsx)', () => {
 
 		await waitFor( () => expect( mcpViewCount() ).toBe( 1 ) );
 
-		// Pin the event's property contract: `ref` follows the AI Tracks standard.
+		// Pin the event's property contract: `ref` follows the AI Tracks standard,
+		// and the audience properties default to 'false' when the page injects no
+		// isA11n/isTest values (AIINT-586).
 		const settingsViewedCall = analytics.tracks.recordEvent.mock.calls.find(
 			call => call[ 0 ] === 'jetpack_mcp_settings_viewed'
 		);
-		expect( settingsViewedCall[ 1 ] ).toEqual( { ref: 'jetpack-ai-mcp-settings' } );
+		expect( settingsViewedCall[ 1 ] ).toEqual( {
+			is_a11n: 'false',
+			is_test: 'false',
+			ref: 'jetpack-ai-mcp-settings',
+		} );
 
 		// The useRef latch: leaving and re-entering the MCP context on the same
 		// mounted instance does not re-fire the view event.
@@ -315,5 +321,25 @@ describe( 'AI admin page (main.jsx)', () => {
 			screen.findByRole( 'checkbox', { name: /Writing Assistant/ } )
 		).resolves.toBeInTheDocument();
 		expect( mcpViewCount() ).toBe( 0 );
+	} );
+
+	test( 'MCP audience properties: follow the injected isA11n/isTest page data as strings', async () => {
+		// The audience properties are computed server-side and ride the
+		// jetpackAiSettings global; the event must send the strings
+		// 'true'/'false', not booleans (AIINT-576 encoding).
+		window.jetpackAiSettings = { showFeaturesView: true, isA11n: true, isTest: true };
+		mockApiFetch( {
+			mcpGet: { has_mcp_access: true, mcp_abilities: { account: { some_tool: {} }, sites: [] } },
+		} );
+
+		window.location.hash = '#/mcp';
+		render( <App /> );
+
+		await waitFor( () => expect( mcpViewCount() ).toBe( 1 ) );
+
+		const settingsViewedCall = analytics.tracks.recordEvent.mock.calls.find(
+			call => call[ 0 ] === 'jetpack_mcp_settings_viewed'
+		);
+		expect( settingsViewedCall[ 1 ] ).toMatchObject( { is_a11n: 'true', is_test: 'true' } );
 	} );
 } );

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-jetpack-ai-page.php
@@ -141,6 +141,11 @@ class Jetpack_AI_Page extends Jetpack_Admin_Page {
 					// Pre-release gate: only internal testing environments see
 					// the Features view. Remove when the view goes public.
 					'showFeaturesView' => jetpack_is_internal_testing_environment(),
+					// Tracks audience properties for the jetpack_mcp_* events, per the
+					// Tracks standards for AI product events (AIINT-586). The client
+					// sends them as the strings 'true'/'false' (AIINT-576).
+					'isA11n'           => self::is_current_user_automattician(),
+					'isTest'           => jetpack_is_internal_testing_environment(),
 				),
 				JSON_UNESCAPED_SLASHES | JSON_HEX_TAG | JSON_HEX_AMP
 			) . ';',
@@ -169,6 +174,33 @@ class Jetpack_AI_Page extends Jetpack_Admin_Page {
 			array( 'wp-components' ),
 			$script_version
 		);
+	}
+
+	/**
+	 * Whether the current user is an Automattician.
+	 *
+	 * Identity check for the Tracks `is_a11n` audience property — it answers
+	 * "who is this", not "may they use the tool", so it deliberately does not
+	 * consult the MCP allowlist: allowlisted external testers are not a11ns.
+	 *
+	 * On wpcom Simple/Atomic the platform's is_automattician() is authoritative.
+	 * Self-hosted Jetpack has no platform check; there the Tracks identity of a
+	 * connected user is their WordPress.com account, so the connected account's
+	 * email domain is the identity signal.
+	 *
+	 * @return bool
+	 */
+	private static function is_current_user_automattician() {
+		if ( function_exists( 'is_automattician' ) ) {
+			return (bool) is_automattician( get_current_user_id() );
+		}
+
+		$user_data = ( new Connection_Manager() )->get_connected_user_data();
+		$email     = is_array( $user_data ) && ! empty( $user_data['email'] )
+			? strtolower( (string) $user_data['email'] )
+			: '';
+
+		return '' !== $email && '@automattic.com' === substr( $email, -15 );
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/aiint-586-jetpack-mcp-tracks-audience-properties
+++ b/projects/plugins/jetpack/changelog/aiint-586-jetpack-mcp-tracks-audience-properties
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+AI: Add the is_a11n and is_test audience properties to the MCP settings Tracks events.

--- a/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
+++ b/projects/plugins/jetpack/tests/php/general/Jetpack_AI_Page_Test.php
@@ -74,4 +74,30 @@ class Jetpack_AI_Page_Test extends \WP_UnitTestCase {
 
 		$this->assertTrue( $settings['showFeaturesView'] );
 	}
+
+	/**
+	 * The Tracks audience properties ride the same payload (AIINT-586): isTest
+	 * is the environment flag, isA11n the identity flag. The test environment
+	 * defines no is_automattician() and connects no user, so isA11n is false.
+	 */
+	public function test_tracks_audience_properties_default_to_false() {
+		$settings = $this->get_injected_settings();
+
+		$this->assertArrayHasKey( 'isA11n', $settings );
+		$this->assertArrayHasKey( 'isTest', $settings );
+		$this->assertFalse( $settings['isA11n'] );
+		$this->assertFalse( $settings['isTest'] );
+	}
+
+	/**
+	 * A proxied request is a test environment regardless of who made it, so
+	 * isTest follows jetpack_is_internal_testing_environment().
+	 */
+	public function test_tracks_is_test_follows_internal_testing_environment() {
+		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+
+		$settings = $this->get_injected_settings();
+
+		$this->assertTrue( $settings['isTest'] );
+	}
 }


### PR DESCRIPTION
Part of [AIINT-586](https://linear.app/a8c/issue/AIINT-586/mcp-tracks-events-are-missing-the-ai-product-standard-properties-in)

## Proposed changes

The five `jetpack_mcp_*` events fired from the Jetpack AI admin page (`wp-admin/admin.php?page=jetpack-ai`) carried none of the audience properties the *Tracks Standards for AI Product Events* ask for. Without `is_a11n`/`is_test` there is no way to separate dogfooding and sandbox traffic from real usage — and once the MCP Automattician gate lifts, nothing in the historical data would mark today's rows as internal.

* `Jetpack_AI_Page` now computes both values server-side and exposes them on the `jetpackAiSettings` global as `isA11n` / `isTest`:
  * **`isA11n` is identity, not access** — `is_automattician()` where the platform provides it (Simple/Atomic); on self-hosted, the connected WordPress.com account's email domain (the identity Tracks attributes the event to anyway). Allowlisted external testers who may use MCP are `false`.
  * **`isTest` is environment only** — `jetpack_is_internal_testing_environment()` (localhost, Jurassic sandbox, proxied request, Atomic test client IDs). Deliberately disjoint from `isA11n` so dogfooding and sandbox traffic can be sliced separately.
* New `recordMcpTracksEvent()` wrapper (`_inc/client/ai/mcp/tracks.js`) merges the two into every MCP event as the strings `'true'`/`'false'` per the AIINT-576 encoding cutover, so events added later inherit them — same chokepoint approach as the wpcom half (`TracksPropsHelper::audience_props()`, wpcom#233247) and the Calypso half (`useMcpTracksAudienceProps()`, Automattic/wp-calypso#a752d37798a).
* `ai_session_id` is deliberately **not** added: these are browser-UI events with no agent session in scope, so the property would be `none` on every row. AIINT-586 is the record of why; MCP tool-call telemetry is tracked separately in AIINT-417.

Note the deploy shape: Jetpack ships on the plugin release cycle, so this is a rollout window (16.1) rather than the clean cut wpcom and Calypso get.

## Related product discussion/links

* [AIINT-586](https://linear.app/a8c/issue/AIINT-586/mcp-tracks-events-are-missing-the-ai-product-standard-properties-in) — parent issue, including the definition decisions this matches
* wpcom server-side half: wpcom#233247 (AIINT-581)
* Calypso half: Automattic/wp-calypso#a752d37798a
* Registry entries: Automattic/tracks-events-registration#289

## Does this pull request change what data or activity we track or use?

Yes — property-level changes to existing events; no new events are introduced:

* The five existing `jetpack_mcp_*` events (`jetpack_mcp_settings_viewed`, `jetpack_mcp_enabled_toggled`, `jetpack_mcp_upsell_viewed`, `jetpack_mcp_upsell_cta_click`, `jetpack_mcp_allowlist_updated`) now include `is_a11n` (whether the user the event is attributed to is an Automattician) and `is_test` (whether the event came from an internal testing environment), both as the strings `'true'`/`'false'`.
* Both values are derivable from data Tracks rows already carry (the event's user identity and the request environment); this makes them explicit and queryable, which is the point of the AI product event standard — separating internal dogfooding/test traffic from real usage.

## Testing instructions

Prerequisites: a Jetpack-connected site running this branch, with browser devtools open. Watching `window._tkq` in the console (or the Tracks Vigilante extension) shows the events as they fire.

1. Go to `wp-admin/admin.php?page=jetpack-ai` and confirm `window.jetpackAiSettings.isA11n` and `window.jetpackAiSettings.isTest` are set (booleans).
2. On a site **without** MCP access, observe `jetpack_mcp_upsell_viewed` fire with `is_a11n` and `is_test` alongside `ref`; click "Upgrade plan" and observe `jetpack_mcp_upsell_cta_click` with the same.
3. On a site **with** MCP access, observe `jetpack_mcp_settings_viewed` fire with both properties plus `ref`.
4. Toggle "Enable MCP access" and observe `jetpack_mcp_enabled_toggled` with `enabled` plus both properties.
5. In the Read/Write sub-views, toggle a tool and observe `jetpack_mcp_allowlist_updated` with its usual properties plus both audience properties.
6. Values are the strings `'true'`/`'false'`, never booleans. On a Jurassic Ninja site (an internal testing environment) `is_test` is `'true'`; on a production self-hosted site it is `'false'`. `is_a11n` is `'true'` when the connected WordPress.com account is an Automattician.

Automated: `pnpm jetpack test js plugins/jetpack` covers the event payloads; `jp docker phpunit jetpack -- --filter=Jetpack_AI_Page_Test` covers the injected page data.
