### PR TITLE
wpcomsh: mirror the declared site purchase shape

### DIFF
--- a/projects/plugins/wpcomsh/.phan/baseline.php
+++ b/projects/plugins/wpcomsh/.phan/baseline.php
@@ -43,11 +43,13 @@ return [
         'tests/FrontendNoticesTest.php' => ['PhanUndeclaredStaticMethod'],
         'tests/PlanNoticesTest.php' => ['PhanDeprecatedProperty', 'PhanPluginUseReturnValueInternalKnown', 'PhanUndeclaredStaticMethod'],
         'tests/WpcomFeaturesTest.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredStaticMethod'],
+        'tests/WpcomSitePurchaseTest.php' => ['PhanUndeclaredStaticMethod'],
         'tests/WpcomshPremiumAnalyticsTest.php' => ['PhanUndeclaredStaticMethod'],
         'tests/feature-manager/FeatureHookTest.php' => ['PhanUndeclaredStaticMethod'],
         'tests/imports/SQLGeneratorTest.php' => ['PhanTypeObjectUnsetDeclaredProperty'],
         'widgets/class-widget-top-clicks.php' => ['PhanDeprecatedFunction'],
         'wpcom-features/class-wpcom-features.php' => ['PhanPluginMixedKeyNoKey'],
+        'wpcom-features/class-wpcom-site-purchase.php' => ['PhanUndeclaredStaticMethod'],
         'wpcom-features/functions-wpcom-features.php' => ['PhanTypeMismatchArgument', 'PhanUndeclaredMethod'],
     ],
     // 'directory_suppressions' => ['src/directory_name' => ['PhanIssueName1', 'PhanIssueName2']] can be manually added if needed.

--- a/projects/plugins/wpcomsh/changelog/add-dotcom-16619-site-purchase-shape
+++ b/projects/plugins/wpcomsh/changelog/add-dotcom-16619-site-purchase-shape
@@ -1,0 +1,4 @@
+Significance: minor
+Type: changed
+
+Return site purchases in a declared shape, with billing-derived auto-renew state behind accessors.

--- a/projects/plugins/wpcomsh/phpunit.11.xml.dist
+++ b/projects/plugins/wpcomsh/phpunit.11.xml.dist
@@ -26,6 +26,7 @@
 			<exclude>tests/FunctionsTest.php</exclude>
 			<exclude>tests/PlanNoticesTest.php</exclude>
 			<exclude>tests/WpcomFeaturesTest.php</exclude>
+			<exclude>tests/WpcomSitePurchaseTest.php</exclude>
 			<exclude>tests/WpcomshPremiumAnalyticsTest.php</exclude>
 		</testsuite>
 		<testsuite name="other">
@@ -34,6 +35,7 @@
 			<file>tests/FunctionsTest.php</file>
 			<file>tests/PlanNoticesTest.php</file>
 			<file>tests/WpcomFeaturesTest.php</file>
+			<file>tests/WpcomSitePurchaseTest.php</file>
 			<file>tests/WpcomshPremiumAnalyticsTest.php</file>
 		</testsuite>
 	</testsuites>

--- a/projects/plugins/wpcomsh/phpunit.9.xml.dist
+++ b/projects/plugins/wpcomsh/phpunit.9.xml.dist
@@ -17,6 +17,7 @@
 			<exclude>tests/FunctionsTest.php</exclude>
 			<exclude>tests/PlanNoticesTest.php</exclude>
 			<exclude>tests/WpcomFeaturesTest.php</exclude>
+			<exclude>tests/WpcomSitePurchaseTest.php</exclude>
 			<exclude>tests/WpcomshPremiumAnalyticsTest.php</exclude>
 		</testsuite>
 		<testsuite name="other">
@@ -25,6 +26,7 @@
 			<file>tests/FunctionsTest.php</file>
 			<file>tests/PlanNoticesTest.php</file>
 			<file>tests/WpcomFeaturesTest.php</file>
+			<file>tests/WpcomSitePurchaseTest.php</file>
 			<file>tests/WpcomshPremiumAnalyticsTest.php</file>
 		</testsuite>
 	</testsuites>

--- a/projects/plugins/wpcomsh/tests/WpcomSitePurchaseTest.php
+++ b/projects/plugins/wpcomsh/tests/WpcomSitePurchaseTest.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * WPCOM Site Purchase Test file.
+ *
+ * Covers the half of WPCOM_Site_Purchase that actually executes on an Atomic site: the purchases
+ * synced into Atomic Persistent Data, read back through wpcom_get_site_purchases(). The Simple-site
+ * half, and the billing lookup behind the accessors, are covered on the WordPress.com side, where
+ * the billing code-base exists to be asked.
+ *
+ * @package wpcomsh
+ */
+
+/**
+ * Class WpcomSitePurchaseTest.
+ */
+class WpcomSitePurchaseTest extends WP_UnitTestCase {
+	use \Automattic\Jetpack\PHPUnit\WP_UnitTestCase_Fix;
+
+	/**
+	 * Remove the synced payload after each test, so one test's purchases cannot leak into another.
+	 */
+	public function tear_down() {
+		Atomic_Persistent_Data::delete( 'WPCOM_PURCHASES' );
+		parent::tear_down();
+	}
+
+	/**
+	 * The synced payload is served as WPCOM_Site_Purchase, with the billing-derived state it was
+	 * synced with. Billing is never consulted here -- its code-base does not ship to Atomic sites.
+	 */
+	public function test_synced_purchases_are_served_in_the_declared_shape() {
+		$purchase = array(
+			'product_slug'                  => 'business-bundle',
+			'product_id'                    => '1008',
+			'billing_product_slug'          => 'wp-bundle-business',
+			'product_type'                  => 'bundle',
+			'subscribed_date'               => '2026-04-12T18:55:02+00:00',
+			'expiry_date'                   => '2027-04-12T00:00:00+00:00',
+			'subscription_id'               => '42',
+			'ownership_id'                  => '99',
+			'auto_renew'                    => true,
+			'might_still_auto_renew'        => false,
+			'first_auto_renew_attempt_date' => '2027-03-13T00:00:00+00:00',
+		);
+		Atomic_Persistent_Data::set( 'WPCOM_PURCHASES', wp_json_encode( array( $purchase ), JSON_UNESCAPED_SLASHES ) );
+
+		$purchases = wpcom_get_site_purchases();
+		$this->assertCount( 1, $purchases );
+		$this->assertInstanceOf( WPCOM_Site_Purchase::class, $purchases[0] );
+
+		// The payload names the flag `auto_renew`; both names carry it.
+		$this->assertTrue( $purchases[0]->auto_renew );
+		$this->assertTrue( $purchases[0]->user_allows_auto_renew );
+
+		// The flag is set, yet billing had already decided the renewal cannot be attempted.
+		$this->assertFalse( $purchases[0]->might_still_auto_renew() );
+		$this->assertSame( '2027-03-13T00:00:00+00:00', $purchases[0]->first_auto_renew_attempt_date() );
+	}
+
+	/**
+	 * A payload synced before these fields existed cannot be answered here, and says so rather
+	 * than guessing.
+	 */
+	public function test_a_synced_purchase_without_billing_state_reports_unknown() {
+		$purchase = array(
+			'product_slug'    => 'business-bundle',
+			'product_id'      => '1008',
+			'subscription_id' => '42',
+			'auto_renew'      => true,
+		);
+		Atomic_Persistent_Data::set( 'WPCOM_PURCHASES', wp_json_encode( array( $purchase ), JSON_UNESCAPED_SLASHES ) );
+
+		$purchases = wpcom_get_site_purchases();
+		$this->assertNull( $purchases[0]->might_still_auto_renew() );
+		$this->assertNull( $purchases[0]->first_auto_renew_attempt_date() );
+	}
+
+	/**
+	 * Feature checks read this on nearly every request, so a malformed payload must degrade rather
+	 * than take the site down: entries that are not objects are skipped, and fields of the wrong
+	 * shape fall back to their defaults.
+	 */
+	public function test_a_malformed_synced_payload_does_not_fatal() {
+		Atomic_Persistent_Data::set(
+			'WPCOM_PURCHASES',
+			wp_json_encode(
+				array(
+					'not-an-entry',
+					array( 'product_slug' => array( 'not-a-string' ) ),
+					array( 'product_slug' => 'business-bundle' ),
+				),
+				JSON_UNESCAPED_SLASHES
+			)
+		);
+
+		$purchases = wpcom_get_site_purchases();
+
+		// The scalar entry is dropped; the two objects survive, the malformed field defaulting.
+		$this->assertCount( 2, $purchases );
+		$this->assertSame( '', $purchases[0]->product_slug );
+		$this->assertSame( 'business-bundle', $purchases[1]->product_slug );
+	}
+}

--- a/projects/plugins/wpcomsh/wpcom-features/class-wpcom-site-purchase.php
+++ b/projects/plugins/wpcomsh/wpcom-features/class-wpcom-site-purchase.php
@@ -1,0 +1,276 @@
+<?php
+/**
+ * THIS FILE EXISTS VERBATIM IN WPCOM AND WPCOMSH.
+ *
+ * DANGER DANGER DANGER!!!
+ * If you make any changes to this file you must MANUALLY update this file in both WPCOM and WPCOMSH.
+ *
+ * @package WPCOM_Features
+ */
+
+/**
+ * A site purchase, in the one shape both Simple and Atomic sites serve.
+ *
+ * The two platforms answer from different sources — a cached store query on Simple, a payload
+ * synced from billing on Atomic — and used to hand back bare rows whose fields differed between
+ * them. This declares the shape instead, so that consumers can be written once.
+ *
+ * This is the site-side sibling of `Billing_Upgrade`, which returns a much richer object from
+ * the purchases endpoints. `Billing_Upgrade` is billing's own record of a purchase and needs
+ * the billing codebase to build it; `WPCOM_Site_Purchase` is what a site can answer about itself
+ * from data it already holds. It is safe on the feature-check path and can exist on Atomic,
+ * where billing does not ship. Use `Billing_Upgrade` when you need the full purchase record
+ * and billing is available; use `WPCOM_Site_Purchase` when you are on a site asking what it owns.
+ */
+class WPCOM_Site_Purchase {
+	/**
+	 * The blog the purchase belongs to.
+	 *
+	 * @var int
+	 */
+	public int $blog_id;
+
+	/**
+	 * The product's slug.
+	 *
+	 * @var string
+	 */
+	public string $product_slug;
+
+	/**
+	 * The product's ID.
+	 *
+	 * @var string
+	 */
+	public string $product_id;
+
+	/**
+	 * The billing product's slug.
+	 *
+	 * @var string
+	 */
+	public string $billing_product_slug;
+
+	/**
+	 * The product's type.
+	 *
+	 * @var string
+	 */
+	public string $product_type;
+
+	/**
+	 * The ISO 8601 date the purchase was made, carrying an explicit offset rather than
+	 * normalised to UTC.
+	 *
+	 * @var string
+	 */
+	public string $subscribed_date;
+
+	/**
+	 * The ISO 8601 date the purchase expires, on the same terms as `$subscribed_date`.
+	 *
+	 * @var string
+	 */
+	public string $expiry_date;
+
+	/**
+	 * The subscription's ID.
+	 *
+	 * @var string
+	 */
+	public string $subscription_id;
+
+	/**
+	 * Whether the owner has auto-renew switched on.
+	 *
+	 * Both names hold it, populated from whichever one the source provides: Simple sites call it
+	 * `user_allows_auto_renew`, Atomic sites `auto_renew`.
+	 *
+	 * @var bool
+	 */
+	public bool $user_allows_auto_renew;
+
+	/**
+	 * Alias of `$user_allows_auto_renew`.
+	 *
+	 * @var bool
+	 */
+	public bool $auto_renew;
+
+	/**
+	 * Only synced payloads carry an ownership.
+	 *
+	 * @var string|null
+	 */
+	public ?string $ownership_id = null;
+
+	/**
+	 * Billing-derived state, when it arrived with the source.
+	 *
+	 * Private so that it cannot be read without going through the accessors, which know how to
+	 * resolve it when it did not.
+	 *
+	 * @var bool|null
+	 */
+	private ?bool $might_still_auto_renew = null;
+
+	/**
+	 * Sibling of `$might_still_auto_renew`; same reason for being private.
+	 *
+	 * @var string|null
+	 */
+	private ?string $first_auto_renew_attempt_date = null;
+
+	/**
+	 * Builds from a row of the Simple site store query.
+	 *
+	 * Leaves the two billing-derived fields null on purpose, so the accessors resolve them live.
+	 * They track the passage of time, and the rows this is built from are cached for a day, so a
+	 * value stored here would go stale between refreshes. Only the synced payload carries them
+	 * pre-computed, because an Atomic site has no billing code-base to ask.
+	 *
+	 * @param object $row     A row as returned by _wpcom_features_get_simple_site_purchases().
+	 * @param int    $blog_id The blog the row belongs to.
+	 */
+	public static function from_store_row( object $row, int $blog_id ): self {
+		$purchase = new self();
+
+		$purchase->blog_id                = $blog_id;
+		$purchase->product_slug           = (string) $row->product_slug;
+		$purchase->product_id             = (string) $row->product_id;
+		$purchase->billing_product_slug   = (string) $row->billing_product_slug;
+		$purchase->product_type           = (string) $row->product_type;
+		$purchase->subscribed_date        = (string) $row->subscribed_date;
+		$purchase->expiry_date            = (string) $row->expiry_date;
+		$purchase->subscription_id        = (string) $row->subscription_id;
+		$purchase->user_allows_auto_renew = (bool) $row->user_allows_auto_renew;
+		$purchase->auto_renew             = $purchase->user_allows_auto_renew;
+
+		return $purchase;
+	}
+
+	/**
+	 * Builds from an entry of the payload synced to an Atomic site.
+	 *
+	 * Every field is optional: a site holds whatever it was last synced with, which may predate
+	 * any given field.
+	 *
+	 * @param object $entry   One decoded entry of WPCOM_PURCHASES.
+	 * @param int    $blog_id The blog the entry belongs to.
+	 */
+	public static function from_synced_payload( object $entry, int $blog_id ): self {
+		$purchase = new self();
+
+		$purchase->blog_id                = $blog_id;
+		$purchase->product_slug           = self::text( $entry->product_slug ?? null );
+		$purchase->product_id             = self::text( $entry->product_id ?? null );
+		$purchase->billing_product_slug   = self::text( $entry->billing_product_slug ?? null );
+		$purchase->product_type           = self::text( $entry->product_type ?? null );
+		$purchase->subscribed_date        = self::text( $entry->subscribed_date ?? null );
+		$purchase->expiry_date            = self::text( $entry->expiry_date ?? null );
+		$purchase->subscription_id        = self::text( $entry->subscription_id ?? null );
+		$purchase->ownership_id           = is_scalar( $entry->ownership_id ?? null ) ? (string) $entry->ownership_id : null;
+		$purchase->user_allows_auto_renew = (bool) ( $entry->auto_renew ?? false );
+		$purchase->auto_renew             = $purchase->user_allows_auto_renew;
+
+		$purchase->might_still_auto_renew        = is_bool( $entry->might_still_auto_renew ?? null ) ? $entry->might_still_auto_renew : null;
+		$purchase->first_auto_renew_attempt_date = is_string( $entry->first_auto_renew_attempt_date ?? null ) ? $entry->first_auto_renew_attempt_date : null;
+
+		return $purchase;
+	}
+
+	/**
+	 * Coerces a decoded JSON value to a string, defaulting anything that is not a scalar.
+	 *
+	 * Guards from_synced_payload() against a field arriving with the wrong shape -- an object or
+	 * array where a scalar was expected, which JSON can express trivially and an ordinary cast
+	 * cannot survive.
+	 *
+	 * @param mixed $value Decoded JSON value.
+	 */
+	private static function text( $value ): string {
+		return is_scalar( $value ) ? (string) $value : '';
+	}
+
+	/**
+	 * Whether a renewal will really be attempted, rather than merely having been asked for.
+	 *
+	 * The raw auto-renew flag stays true for subscriptions that cannot renew — one with no
+	 * chargeable payment method attached, for instance — so only billing can answer this.
+	 * Null wherever billing cannot be reached.
+	 */
+	public function might_still_auto_renew(): ?bool {
+		return $this->might_still_auto_renew ?? $this->billing_state()?->might_still_auto_renew;
+	}
+
+	/**
+	 * The UTC date of the first scheduled auto-renewal attempt, as an ISO 8601 string.
+	 *
+	 * The date rather than "is it behind us", because a synced copy is only refreshed on
+	 * subscription events and never on the passage of time; comparing this against the reader's
+	 * own clock stays correct in between. Being scheduled is not a promise that an attempt runs,
+	 * nor that it runs at this time of day. Null either because nothing is scheduled -- no
+	 * meaningful expiry to schedule against, e.g. a VIP domain or a one-time product -- or
+	 * because billing could not be reached; a consumer cannot tell the two apart.
+	 */
+	public function first_auto_renew_attempt_date(): ?string {
+		return $this->first_auto_renew_attempt_date ?? $this->billing_state()?->first_auto_renew_attempt_date;
+	}
+
+	/**
+	 * Billing does not necessarily know about every subscription, so this may be null.
+	 */
+	private function billing_state(): ?object {
+		return self::billing_states_for_blog( $this->blog_id )[ $this->subscription_id ] ?? null;
+	}
+
+	/**
+	 * Billing-derived state for a site's subscriptions, keyed by subscription ID.
+	 *
+	 * Only Simple sites can answer. Answering pulls the entire billing stack into a request that
+	 * may never have loaded it. The billing code-base does not ship everywhere this file runs, and
+	 * a single subscription whose product no longer loads throws for the whole site; both cases
+	 * yield an empty map, so every value must be treated as optional.
+	 *
+	 * Memoized per request, so that a site with many purchases costs one lookup rather than one
+	 * per purchase. Deliberately not cached beyond the request: these values track the passage of
+	 * time, while the `site_purchases` cache lives for a day.
+	 *
+	 * @param int $blog_id Blog ID to look up.
+	 *
+	 * @return array Map of subscription ID to an object of derived state. Empty where unavailable.
+	 */
+	private static function billing_states_for_blog( int $blog_id ): array {
+		static $states = array();
+
+		if ( isset( $states[ $blog_id ] ) ) {
+			return $states[ $blog_id ];
+		}
+
+		$states[ $blog_id ] = array();
+
+		// The whole loader rather than just the class file, as get_site_billing_upgrades() also
+		// reaches for store_logger(). Unreadable wherever the billing code-base does not ship.
+		$billing_loader = WP_CONTENT_DIR . '/admin-plugins/wpcom-billing.php';
+		if ( ! is_readable( $billing_loader ) ) {
+			return $states[ $blog_id ];
+		}
+
+		try {
+			require_once $billing_loader;
+
+			// Subscriptions only: skips domain-subscription combining, so every upgrade still
+			// matches one store subscription.
+			foreach ( WPCOM_Store_API::get_site_billing_upgrades( $blog_id, true ) as $upgrade ) {
+				$states[ $blog_id ][ (string) $upgrade->ID ] = (object) array(
+					'might_still_auto_renew'        => $upgrade->might_still_auto_renew,
+					'first_auto_renew_attempt_date' => $upgrade->first_auto_renew_attempt_date,
+				);
+			}
+		} catch ( \Throwable $e ) {
+			$states[ $blog_id ] = array();
+		}
+
+		return $states[ $blog_id ];
+	}
+}

--- a/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
+++ b/projects/plugins/wpcomsh/wpcom-features/functions-wpcom-features.php
@@ -15,6 +15,7 @@
  * Load `WPCOM_Features` class.
  */
 require_once __DIR__ . '/class-wpcom-features.php';
+require_once __DIR__ . '/class-wpcom-site-purchase.php';
 
 /**
  * Internal function to retrieve the current WP.com blog ID depending on the environment.
@@ -140,7 +141,7 @@ function wpcom_site_can_upload_videos( $blog_id = 0 ) {
  *
  * @param int $blog_id Optional. Blog ID. Defaults to current blog.
  *
- * @return array An array of product objects containing product_slug, product_id, subscribed_date, and expiry_date.
+ * @return array An array of WPCOM_Site_Purchase objects.
  */
 function wpcom_get_site_purchases( $blog_id = 0 ) {
 	if ( ! $blog_id ) {
@@ -161,13 +162,23 @@ function wpcom_get_site_purchases( $blog_id = 0 ) {
 			return array();
 		}
 
-		$purchases = (array) json_decode( $persistent_data->WPCOM_PURCHASES ); // phpcs:ignore WordPress.NamingConventions
+		// An entry that is not an object cannot be a purchase. Skipping keeps a payload of the
+		// wrong shape a degraded answer rather than a fatal on a near-universal code path.
+		$entries = array_filter( (array) json_decode( $persistent_data->WPCOM_PURCHASES ), 'is_object' ); // phpcs:ignore WordPress.NamingConventions
+
+		$purchases = array_map(
+			static fn ( $entry ) => WPCOM_Site_Purchase::from_synced_payload( $entry, $blog_id ),
+			array_values( $entries )
+		);
 
 	} else {
 		// Allow overriding the blog ID for feature checks.
 		$blog_id = apply_filters( 'wpcom_site_has_feature_blog_id', $blog_id );
 
-		$purchases = _wpcom_features_get_simple_site_purchases( $blog_id );
+		$purchases = array_map(
+			static fn ( $row ) => WPCOM_Site_Purchase::from_store_row( $row, $blog_id ),
+			_wpcom_features_get_simple_site_purchases( $blog_id )
+		);
 	}
 
 	return $purchases;


### PR DESCRIPTION
Fixes DOTCOM-16619

## Proposed changes

* Mirrors the WordPress.com-side change into wpcomsh: a new `WPCOM_Site_Purchase` class — which carries the billing-state lookup as a private static of its own — and the wiring that makes `wpcom_get_site_purchases()` return instances rather than bare rows.

`wpcom-features/` exists in both this repo and the WordPress.com one and has to be updated in both. `class-wpcom-site-purchase.php` is byte-identical to its counterpart. `functions-wpcom-features.php` is **not** copied wholesale — despite the header, the two copies have genuinely drifted (different `site_purchases` cache TTL, no `wpcom_features_get_simple_site_purchases_force_db()` helper here, different phan annotations, a `function_exists( 'wpcom_is_automattic_p2_site' )` guard), so only the relevant changes were ported by hand: the `require_once`, and the two `array_map()` calls in `wpcom_get_site_purchases()` that construct the class.

**Two notes on static analysis, since neither is obvious from the diff.**

Two wpcomsh baseline entries, both `PhanUndeclaredStaticMethod`, both because a wpcom-side class is only partially stubbed for phan — which is why that same baseline file already carries seven entries for this exact issue type:

* `wpcom-features/class-wpcom-site-purchase.php` — `WPCOM_Store_API` is stubbed in `.phan/stubs/wpcom-stubs.php` with only `get_current_plan()`, so the class's billing lookup looks undeclared.
* `tests/WpcomSitePurchaseTest.php` — `Atomic_Persistent_Data::set()` and `::delete()` likewise, which is why `tests/WpcomFeaturesTest.php` beside it already carries the same entry.

Completing the stub would be the better fix for the first, but that file is generated: the definition lives in the wpcom repo at `bin/teamcity-builds/jetpack-stubs/stub-defs.php`, and picking it up needs a TeamCity regeneration run. Worth doing as a follow-up, at which point that entry can go.

`wpcom_get_site_purchases()` is documented as `@return array An array of WPCOM_Site_Purchase objects` rather than `@return WPCOM_Site_Purchase[]`, and that is deliberate. This file is fed to every other project in the monorepo as a phan stub. A machine-readable type there forces a choice between two kinds of noise: without the class in the stub list phan reports an undeclared class on every purchase property read, and with it phan can prove the `isset()` in `class.wpcom-json-api-site-settings-endpoint.php`'s gifting default is redundant — which it will be once both sides ship, but is not yet, because that file is vendored into WordPress.com on the Jetpack release cadence and can arrive while Simple sites still return only `user_allows_auto_renew`. Either would need suppressing. Naming the class in prose costs the IDE hint and buys a clean run.

Worth revisiting once both sides have shipped and that `isset()` — plus the "create parity between WPCOM and WPCOMSH" assignment in `frontend-notices/gifting-banner/gifting-banner.php` — can be collapsed. At that point the typed return can come back with no suppression.

## Related product discussion/links

* Paired WordPress.com change: 233441-ghe-Automattic/wpcom — the class it mirrors landed separately in 233440-ghe-Automattic/wpcom, already merged.
* DOTCOM-16619

## Does this pull request change what data or activity we track or use?

No new tracking. The purchases payload synced to Atomic sites gains two derived billing fields, `might_still_auto_renew` and `first_auto_renew_attempt_date`, alongside the `auto_renew` flag it already carried.

Worth noting explicitly rather than leaving implicit: `might_still_auto_renew: false` beside `auto_renew: true` reveals that the subscription owner's payment method cannot currently be charged, and it sits in the container's persistent data, readable by anyone with code execution on the site — which on a multi-admin site includes admins who are not the subscription owner. That blob already exposes `ownership_id`, `subscription_id` and expiry to the same audience, so the delta is small, but it is a deliberate accept rather than an oversight.

## Testing instructions

Atomic sites read the purchase payload synced to them, so there is nothing to exercise here until the WordPress.com side is deployed. What this PR is worth checking by reading:

* `wpcom_get_site_purchases()` now returns `WPCOM_Site_Purchase` objects on both platforms. Every consumer in this monorepo reads plain properties, and the declared properties are public precisely so `wp_list_filter()` keeps working — `WP_List_Util::filter()` inspects objects from outside class scope, so the two private billing fields are invisible to it, as intended.
* Both `auto_renew` and `user_allows_auto_renew` are declared and populated identically from whichever one the source provided. That is deliberate: it makes the "create parity between WPCOM and WPCOMSH" assignment in `frontend-notices/gifting-banner/gifting-banner.php` redundant. Deleting it is a follow-up, not this PR.
* `from_synced_payload()` treats the decoded payload as untrusted — every field is shape-checked and non-object entries are skipped. That is defensive rather than a response to a known bad payload, but this data reaches `wpcom_site_has_feature()` on nearly every request, and the typed properties would turn one malformed entry into a site-wide fatal where the previous untyped code merely degraded.
* The accessors return `null` on Atomic until the WordPress.com side starts syncing the two fields, and for payloads synced before then. `null` is a documented outcome, not an error.

`tests/WpcomSitePurchaseTest.php` covers the synced-payload path, which is the half that actually executes on Atomic: the declared shape, the billing state served as synced, a pre-field payload reporting `null` rather than guessing, and a malformed payload degrading instead of fataling.

It is registered in the `other` suite rather than `wpcloud`, next to `WpcomFeaturesTest.php` and for the same reason: it drives `Atomic_Persistent_Data::set()`, which exists in the mocked environment but not on a real WP Cloud test site.

What stays uncovered here is `from_store_row()` and the Simple-site branch of `wpcom_get_site_purchases()`, including the part of the lookup that loads the billing code-base. None of that can execute on an Atomic site — it is the WordPress.com half of a mirrored file — and it is covered by the tests on the WordPress.com side, so there is nothing worth adding on this side for it.
