### PR TITLE
Forms: prevent a fatal when logging webhook responses with non-dictionary headers

### DIFF
--- a/projects/packages/forms/changelog/forms-690-webhook-response-headers
+++ b/projects/packages/forms/changelog/forms-690-webhook-response-headers
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Forms: prevent a fatal error when logging webhook responses with unexpected header types.

--- a/projects/packages/forms/src/service/class-form-webhooks.php
+++ b/projects/packages/forms/src/service/class-form-webhooks.php
@@ -141,7 +141,7 @@ class Form_Webhooks {
 		$response_data = array(
 			'timestamp' => gmdate( 'Y-m-d H:i:s', time() ),
 			'http_code' => $response_code,
-			'headers'   => wp_remote_retrieve_headers( $response )->getAll(),
+			'headers'   => $this->normalize_response_headers( wp_remote_retrieve_headers( $response ) ),
 			'body'      => $response_data ?? $response_body, // If the response is not JSON, return the body as is.
 		);
 
@@ -150,6 +150,24 @@ class Form_Webhooks {
 		// Track success (2xx) or failure based on HTTP response code
 		$status = ( $response_code >= 200 && $response_code < 300 ) ? 'success' : 'failed';
 		$this->track_webhook_request( $status );
+	}
+
+	/**
+	 * Normalize the headers of a webhook response into a plain array.
+	 *
+	 * The value returned by wp_remote_retrieve_headers() is usually a case-insensitive dictionary,
+	 * but it is a plain array when the response has no headers, and other shapes are possible when
+	 * a pre_http_request or http_response filter supplies the response.
+	 *
+	 * @param mixed $headers The value returned by wp_remote_retrieve_headers().
+	 * @return array The headers as a plain array, empty when they cannot be read.
+	 */
+	private function normalize_response_headers( $headers ) {
+		if ( is_object( $headers ) && method_exists( $headers, 'getAll' ) ) {
+			$headers = $headers->getAll();
+		}
+
+		return is_array( $headers ) ? $headers : array();
 	}
 
 	/**

--- a/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
+++ b/projects/packages/forms/tests/php/service/Form_Webhooks_Test.php
@@ -484,6 +484,91 @@ class Form_Webhooks_Test extends BaseTestCase {
 	}
 
 	/**
+	 * Test webhook logs the response headers when they come back as a case-insensitive dictionary.
+	 */
+	public function test_send_webhooks_logs_dictionary_headers() {
+		$response_data = $this->run_webhook_with_response(
+			array(
+				'response' => array( 'code' => 200 ),
+				'body'     => '{"success":true}',
+				'headers'  => new CaseInsensitiveDictionary( array( 'Content-Type' => 'application/json' ) ),
+			)
+		);
+
+		$this->assertIsArray( $response_data['headers'] );
+		$this->assertEquals( 'application/json', $response_data['headers']['content-type'] );
+	}
+
+	/**
+	 * Test webhook logs the response headers when they come back as a plain array.
+	 *
+	 * A pre_http_request filter, a mocked transport, or another plugin filtering the response can
+	 * hand back plain array headers instead of a case-insensitive dictionary.
+	 */
+	public function test_send_webhooks_logs_plain_array_headers() {
+		$response_data = $this->run_webhook_with_response(
+			array(
+				'response' => array( 'code' => 200 ),
+				'body'     => '{"success":true}',
+				'headers'  => array( 'content-type' => 'application/json' ),
+			)
+		);
+
+		$this->assertIsArray( $response_data['headers'] );
+		$this->assertEquals( 'application/json', $response_data['headers']['content-type'] );
+	}
+
+	/**
+	 * Test webhook logs an empty header list when the response has no headers at all.
+	 */
+	public function test_send_webhooks_logs_missing_headers() {
+		$response_data = $this->run_webhook_with_response(
+			array(
+				'response' => array( 'code' => 200 ),
+				'body'     => '{"success":true}',
+			)
+		);
+
+		$this->assertIsArray( $response_data['headers'] );
+		$this->assertSame( array(), $response_data['headers'] );
+	}
+
+	/**
+	 * Test webhook logs an empty header list when the headers are an unexpected type.
+	 */
+	public function test_send_webhooks_logs_unexpected_header_type() {
+		$response_data = $this->run_webhook_with_response(
+			array(
+				'response' => array( 'code' => 200 ),
+				'body'     => '{"success":true}',
+				'headers'  => 'content-type: application/json',
+			)
+		);
+
+		$this->assertIsArray( $response_data['headers'] );
+		$this->assertSame( array(), $response_data['headers'] );
+	}
+
+	/**
+	 * Test webhook logs an empty header list when the headers are an object without getAll().
+	 */
+	public function test_send_webhooks_logs_header_object_without_get_all() {
+		$headers               = new \stdClass();
+		$headers->content_type = 'application/json';
+
+		$response_data = $this->run_webhook_with_response(
+			array(
+				'response' => array( 'code' => 200 ),
+				'body'     => '{"success":true}',
+				'headers'  => $headers,
+			)
+		);
+
+		$this->assertIsArray( $response_data['headers'] );
+		$this->assertSame( array(), $response_data['headers'] );
+	}
+
+	/**
 	 * Test webhook logs error to post meta.
 	 */
 	public function test_send_webhooks_logs_error() {
@@ -1850,6 +1935,49 @@ class Form_Webhooks_Test extends BaseTestCase {
 		$webhooks->send_webhooks( $post_id, $fields, false, array() );
 
 		$this->assertTrue( $http_request_made, 'HTTP request should be made for valid public HTTPS URLs' );
+	}
+
+	/**
+	 * Helper method to run a webhook against a canned HTTP response and return the logged response meta.
+	 *
+	 * @param array $http_response The response a pre_http_request filter should short-circuit with.
+	 * @return array The decoded _jetpack_forms_webhook_response meta.
+	 */
+	private function run_webhook_with_response( $http_response ) {
+		$form   = $this->create_mock_form(
+			array(
+				'webhooks' => array(
+					array(
+						'webhook_id' => 'test-webhook',
+						'url'        => 'https://example.com/webhook',
+						'format'     => 'json',
+						'method'     => 'POST',
+						'enabled'    => true,
+					),
+				),
+			)
+		);
+		$fields = array( $this->create_mock_field( $form, 'test-field', 'test value' ) );
+
+		$post_id = $this->create_feedback_post( $form, $fields );
+
+		add_filter(
+			'pre_http_request',
+			function () use ( $http_response ) {
+				return $http_response;
+			}
+		);
+
+		$webhooks = Form_Webhooks::init();
+		$webhooks->send_webhooks( $post_id, $fields, false, array() );
+
+		$response_meta = get_post_meta( $post_id, '_jetpack_forms_webhook_response', true );
+		$this->assertNotEmpty( $response_meta, 'The webhook response should be logged to post meta' );
+
+		$response_data = json_decode( $response_meta, true );
+		$this->assertIsArray( $response_data, 'The logged webhook response should decode to an array' );
+
+		return $response_data;
 	}
 
 	/**


### PR DESCRIPTION
Fixes FORMS-690

## Proposed changes
* `Form_Webhooks::log_response_to_post_meta()` called `->getAll()` straight on the return value of `wp_remote_retrieve_headers()`. That is a `WpOrg\Requests\Utility\CaseInsensitiveDictionary` for a normal HTTP response, but it is a plain array whenever the response has no `headers` key, and other shapes are possible whenever something other than the real transport supplies the response — a `pre_http_request` short-circuit, a mocked or stubbed transport, or another plugin filtering `http_response`. Calling `getAll()` on those values is a fatal: `Call to a member function getAll() on array`.
* This code runs on form submission for every form with a webhook configured, so the fatal took down the submission request itself. The response is already known-good at that point (the `is_wp_error()` branch returned earlier), so this is purely defensive typing.
* The headers are now normalized before use: any object exposing `getAll()` is unwrapped, a plain array is used as-is, and anything else falls back to an empty array. The stored meta shape is unchanged — `headers` is still an array inside `_jetpack_forms_webhook_response`, so the normal path serializes exactly as before.
* Added PHPUnit coverage for each header shape: dictionary, plain array, missing, a scalar, and an object without `getAll()`.

## Related product discussion/links
* FORMS-690

## Does this pull request change what data or activity we track or use?
No. The `_jetpack_forms_webhook_response` post meta is written exactly as before for well-formed responses; only malformed header values change, and those now record an empty header list instead of fataling.

## Testing instructions

Automated coverage:

* `jp test php packages/forms` — 950 tests pass. Reverting just the normalization in `class-form-webhooks.php` makes the four new tests error with `Call to a member function getAll() on array` / `on string` / `Call to undefined method stdClass::getAll()`, which is the reported fatal.
* `jp phan packages/forms` — 0 issues.

Manual check on a site with Jetpack Forms:

1. Add a Form block to a page and configure a webhook on it (Form block → Settings → Webhooks) pointing at any HTTPS endpoint, e.g. a https://webhook.site/ URL. Make sure the webhook is enabled.
2. Drop this snippet into a mu-plugin to simulate a response whose headers are not a `CaseInsensitiveDictionary`. It short-circuits the request the same way a mocked transport or a caching/HTTP plugin would, and deliberately omits the `headers` key:

   ```php
   add_filter(
       'pre_http_request',
       function ( $preempt, $args, $url ) {
           if ( false === strpos( $url, 'webhook.site' ) ) {
               return $preempt;
           }
           return array(
               'response' => array(
                   'code'    => 200,
                   'message' => 'OK',
               ),
               'body'     => '{"success":true}',
               // No 'headers' key at all — wp_remote_retrieve_headers() returns a plain array.
           );
       },
       10,
       3
   );
   ```

   To cover the other shape, swap the comment for `'headers' => array( 'content-type' => 'application/json' ),` — a plain array rather than a dictionary.
3. Submit the form on the front end.
4. Before this change: the submission request dies with `Call to a member function getAll() on array` (check the PHP error log; the visitor sees a failed submission).
5. After this change: the submission completes normally and the response is logged. Confirm the meta with WP-CLI, where `<id>` is the new feedback post:

   ```
   wp post list --post_type=feedback --format=ids
   wp post meta get <id> _jetpack_forms_webhook_response
   ```

   The value should be JSON containing `"headers":[]` for the missing-headers case, or `"headers":{"content-type":"application\/json"}` for the plain-array case, alongside `timestamp`, `http_code`, and `body`.
6. Remove the snippet and submit once more against the real endpoint to confirm the normal path is unchanged — `headers` should contain the endpoint's real response headers.
