### PR TITLE
Agents Manager: skip the sidebar pre-render when the user connection is gone

### DIFF
--- a/projects/packages/agents-manager/changelog/fix-agents-manager-open-state-pre-render-disconnected
+++ b/projects/packages/agents-manager/changelog/fix-agents-manager-open-state-pre-render-disconnected
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Agents Manager: skip the sidebar pre-render when the user has no WordPress.com connection, so a stale cached open state no longer flashes a shell the app never mounts into after disconnecting.

--- a/projects/packages/agents-manager/src/class-open-state-store.php
+++ b/projects/packages/agents-manager/src/class-open-state-store.php
@@ -8,6 +8,7 @@
 namespace Automattic\Jetpack\Agents_Manager;
 
 use Automattic\Jetpack\Connection\Client;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Status\Host;
 
 /**
@@ -132,6 +133,14 @@ class Open_State_Store {
 				'agents_manager_open'   => (bool) ( $calypso_prefs['agents_manager_open'] ?? false ),
 				'agents_manager_docked' => (bool) ( $calypso_prefs['agents_manager_docked'] ?? false ),
 			);
+		}
+
+		// The cached state is only as good as the connection that produced it.
+		// Without a user connection the frontend cannot fetch or refresh state
+		// (the app never mounts), so a pre-render from a stale transient would
+		// flash a shell nothing ever takes down.
+		if ( ! ( new Connection_Manager() )->is_user_connected( $user_id ) ) {
+			return null;
 		}
 
 		$cached = get_transient( self::cache_key( $user_id ) );

--- a/projects/packages/agents-manager/tests/php/Open_State_Store_Test.php
+++ b/projects/packages/agents-manager/tests/php/Open_State_Store_Test.php
@@ -69,6 +69,16 @@ class Open_State_Store_Test extends \WorDBless\BaseTestCase {
 	}
 
 	/**
+	 * Mock a user connection by seeding the connection tokens.
+	 *
+	 * @param int $user_id User ID.
+	 */
+	private function connect_user( int $user_id ) {
+		\Jetpack_Options::update_option( 'user_tokens', array( $user_id => 'test.token.' . $user_id ) );
+		\Jetpack_Options::update_option( 'id', 12345 );
+	}
+
+	/**
 	 * Tests that get_cached() returns null when no user is logged in.
 	 */
 	public function test_get_cached_returns_null_without_user() {
@@ -81,6 +91,25 @@ class Open_State_Store_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_get_cached_returns_null_when_uncached() {
 		wp_set_current_user( $this->user_id );
+		$this->connect_user( $this->user_id );
+		$this->assertNull( Open_State_Store::get_cached() );
+	}
+
+	/**
+	 * Tests that get_cached() ignores the transient when the user has no
+	 * WordPress.com connection (e.g. after a disconnect), so the pre-render
+	 * cannot inject a shell the app will never mount into.
+	 */
+	public function test_get_cached_returns_null_when_user_not_connected() {
+		wp_set_current_user( $this->user_id );
+
+		$this->cache(
+			array(
+				'agents_manager_open'   => true,
+				'agents_manager_docked' => true,
+			)
+		);
+
 		$this->assertNull( Open_State_Store::get_cached() );
 	}
 
@@ -89,6 +118,7 @@ class Open_State_Store_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_cache_round_trip_stores_open_and_docked_only() {
 		wp_set_current_user( $this->user_id );
+		$this->connect_user( $this->user_id );
 
 		$this->cache(
 			array(
@@ -116,6 +146,7 @@ class Open_State_Store_Test extends \WorDBless\BaseTestCase {
 	 */
 	public function test_cache_coerces_booleans() {
 		wp_set_current_user( $this->user_id );
+		$this->connect_user( $this->user_id );
 
 		$this->cache(
 			array(
@@ -147,6 +178,7 @@ class Open_State_Store_Test extends \WorDBless\BaseTestCase {
 		);
 
 		wp_set_current_user( $this->user_id );
+		$this->connect_user( $this->user_id );
 		$this->assertNull( Open_State_Store::get_cached() );
 	}
 

--- a/projects/packages/agents-manager/tests/php/Sidebar_Open_Preservation_Test.php
+++ b/projects/packages/agents-manager/tests/php/Sidebar_Open_Preservation_Test.php
@@ -67,6 +67,10 @@ class Sidebar_Open_Preservation_Test extends \WorDBless\BaseTestCase {
 			)
 		);
 		wp_set_current_user( $this->user_id );
+
+		// The pre-render only runs for connected users now, so seed the tokens.
+		\Jetpack_Options::update_option( 'user_tokens', array( $this->user_id => 'test.token.' . $this->user_id ) );
+		\Jetpack_Options::update_option( 'id', 12345 );
 	}
 
 	/**


### PR DESCRIPTION
## Proposed changes

On sites whose Jetpack connection is gone, the Agents Manager sidebar shell flashes on every wp-admin page load and then disappears.

**Why it happens:** the server-side pre-render (`Sidebar_Open_Preservation`) reads the persisted open state through `Open_State_Store::get_cached()`, a per-user transient with a week-long TTL. After a disconnect the transient still says `open + docked`, so PHP keeps injecting the docked sidebar body classes optimistically. But the frontend can no longer refresh that state — the `open-state?_locale=user` request fails with `missing_token` — and the app never mounts, so nothing ever takes the shell down. The pre-paint docking gate (`sidebar-docking-gate.ts`) doesn't help: it only handles fullscreen/viewport conditions, not "the app will never mount."

**The fix:** gate the cached read on the user connection. `get_cached()` now returns `null` on the remote (WoA / self-hosted) path when `Connection_Manager::is_user_connected()` is false, and `null` already means "skip the pre-render."

Tests: new coverage that a seeded transient is ignored while disconnected; existing remote-path fixtures now seed connection tokens.

## Related product discussion/links

* Found while manual-testing the WooCommerce AI pre-connection flow (WOOAI-789 territory; see woocommerce/woocommerce-ai#433 and Automattic/wp-calypso#113030 for the adjacent pre-connection shell work).

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

You need a WoA or self-hosted site where the assistant sidebar was open/docked **before** disconnecting, so the transient is primed.

First build the package in your Jetpack checkout so the compiled assets (e.g. the sidebar docking gate script) are present:

```bash
cd projects/packages/agents-manager
pnpm install
composer install
composer build-development
```

Then, to run this package's code in a plugin that consumes it (e.g. WooCommerce AI), point Composer at your local Jetpack checkout:

```diff
 	"repositories": [
+		{
+			"type": "path",
+			"url": "../jetpack/projects/packages/agents-manager",
+			"options": {
+				"symlink": false
+			}
+		},
 		{
```

```diff
-		"automattic/jetpack-agents-manager": "^0.9.1"
+		"automattic/jetpack-agents-manager": "@dev"
```

Then `composer update automattic/jetpack-agents-manager` and confirm `composer show automattic/jetpack-agents-manager` reports `dist: [path] ../jetpack/projects/packages/agents-manager`.

1. With the site connected, open the assistant and leave it docked open. Reload wp-admin — the sidebar shell should pre-render as before (no regression).
2. Disconnect the site from WordPress.com (or unlink the current user).
3. **Before this PR:** every wp-admin page load briefly flashes the docked sidebar shell before it vanishes; DevTools shows `open-state?_locale=user` failing with `{"code":"missing_token"}`.
4. **With this PR:** no shell is injected at all — no flash. The `missing_token` request may still appear (frontend probe); that's expected and unrelated to the pre-render.
5. Reconnect and confirm the docked pre-render comes back once state is refreshed.

Unit tests:

```bash
cd projects/packages/agents-manager
composer install
composer phpunit
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
