### PR TITLE
Premium Analytics: add end-of-page spacing to the dashboard

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-premium-analytics-dashboard-end-spacing
+++ b/projects/packages/premium-analytics/changelog/fix-premium-analytics-dashboard-end-spacing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Dashboard: add spacing below the widget grid so the last row no longer sits flush against the end of the page.

--- a/projects/packages/premium-analytics/routes/dashboard/stage.module.scss
+++ b/projects/packages/premium-analytics/routes/dashboard/stage.module.scss
@@ -50,14 +50,17 @@
 }
 
 .content {
+	// Grows to fill a short section, but never shrinks below the widget grid:
+	// `min-block-size: 0` here would let the panel end above its own content, so
+	// the scroll container's end landed on the last widget and the padding below
+	// never rendered.
 	flex: 1 1 auto;
-	min-block-size: 0;
 
 	// Reserve paint space for the widget host's outer focus outline.
 	padding-block-start: calc(var(--wpds-border-width-focus) + 2px);
+	padding-block-end: var(--wpds-dimension-padding-3xl);
 	// Match the horizontal padding of the page header and the section tabs so the
 	// widget grid lines up with them instead of sitting flush to the edge.
-	padding-block-end: 24px;
 	padding-inline: var(--wpds-dimension-padding-2xl);
 }
 


### PR DESCRIPTION
## Proposed changes

- Add spacing below the dashboard's widget grid, so the last row no longer sits flush against the bottom of the page.

`.content` already declared `padding-block-end`, but `min-block-size: 0` let the panel end above its own content, so the grid overflowed past it and the padding never landed at the end of the scroll area. Dropping it lets the panel grow with the grid; it still fills a short section.

## Related product discussion/links

- Reported in an internal Slack thread.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Go to **Stats v2** (`/wp-admin/admin.php?page=jetpack-premium-analytics-wp-admin`) on a site with enough widgets that the Traffic section scrolls.
- Scroll to the bottom — the last row should have space below it instead of ending flush against the edge.
- Switch to a short section (e.g. Subscribers) and confirm the panel still fills the page.
- Enter **Customize**, scroll to the bottom again, and confirm the same spacing. **Cancel** to leave without saving.

<img width="1565" height="1318" alt="Screenshot 2026-08-11 at 11 38 40 AM" src="https://github.com/user-attachments/assets/85df0315-37a2-4f9b-8906-c55da42bfa52" />

https://github.com/user-attachments/assets/ae4a38eb-938f-4f7f-8b77-d15a14a262d4
