### PR TITLE
Akismet: restore the WordPress contextual Help tab on Akismet admin pages

### DIFF
--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-akismet-admin-chrome.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-akismet-admin-chrome.php
@@ -216,22 +216,10 @@ class Akismet_Admin_Chrome {
 			body[class*="_page_akismet-key-config"] #wpfooter {
 				display: none;
 			}
-			/* Do NOT hide `#screen-meta-links` (core's Screen Options / Help toggles):
-				Akismet registers real contextual-help tabs on this screen
-				(`Akismet_Admin::admin_help()`), so hiding the container takes its Help
-				button away on every Akismet page whenever Jetpack is active. The
-				`jetpack-admin-page-layout` mixin can hide it because none of Jetpack's
-				own React pages register help tabs or screen options; that reasoning does
-				not carry over to a page owned by another plugin.
-
-				`#screen-meta-links` and `#screen-meta` (the panel it opens) are children
-				of `#wpbody-content`, which the rules below flip to a fixed flex column —
-				that makes core's `float: right` a no-op, leaving the toggles as a
-				left-aligned full-width row and the panel free to be squeezed. The two
-				rules below put both back where core puts them, and deliberately go no
-				further: this stylesheet is transitional scaffolding until Akismet renders
-				the Jetpack header itself, so it should touch Akismet's and core's markup
-				as lightly as possible. */
+			/* Don't hide `#screen-meta-links`: Akismet registers real help tabs here, so
+				hiding it removes its Help button. `#wpbody-content` is a flex column
+				below, which makes core's `float: right` a no-op — restore the toggle's
+				position and keep it and the panel from being squeezed. */
 			body[class*="_page_akismet-key-config"] #screen-meta,
 			body[class*="_page_akismet-key-config"] #screen-meta-links {
 				flex-shrink: 0;

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-akismet-admin-chrome.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-akismet-admin-chrome.php
@@ -216,24 +216,22 @@ class Akismet_Admin_Chrome {
 			body[class*="_page_akismet-key-config"] #wpfooter {
 				display: none;
 			}
-			/* `#screen-meta-links` (the Screen Options / Help toggles) and `#screen-meta`
-				(the panel they open) are children of `#wpbody-content`, which the rules
-				below flip to a fixed flex column. That drops core's `float: right` on the
-				toggles — turning them into a full-width row — and core's own margins then
-				reserve blank space above the Jetpack header.
+			/* Do NOT hide `#screen-meta-links` (core's Screen Options / Help toggles):
+				Akismet registers real contextual-help tabs on this screen
+				(`Akismet_Admin::admin_help()`), so hiding the container takes its Help
+				button away on every Akismet page whenever Jetpack is active. The
+				`jetpack-admin-page-layout` mixin can hide it because none of Jetpack's
+				own React pages register help tabs or screen options; that reasoning does
+				not carry over to a page owned by another plugin.
 
-				Do NOT hide them: Akismet registers real contextual-help tabs on this
-				screen (`Akismet_Admin::admin_help()`), and hiding the container takes the
-				Help button away from every Akismet page whenever Jetpack is active. The
-				`jetpack-admin-page-layout` mixin can hide it because none of Jetpack's own
-				React pages register help tabs or screen options; that reasoning does not
-				carry over to a page owned by another plugin.
-
-				Instead, neutralise the margins and restore the right-aligned tab look
-				inside the flex column. When a screen genuinely has neither help tabs nor
-				screen options, core omits `#screen-meta-links` altogether and leaves
-				`#screen-meta` at `display: none` until its toggle is clicked, so nothing
-				reserves space in that case either. */
+				`#screen-meta-links` and `#screen-meta` (the panel it opens) are children
+				of `#wpbody-content`, which the rules below flip to a fixed flex column —
+				that makes core's `float: right` a no-op, leaving the toggles as a
+				left-aligned full-width row and the panel free to be squeezed. The two
+				rules below put both back where core puts them, and deliberately go no
+				further: this stylesheet is transitional scaffolding until Akismet renders
+				the Jetpack header itself, so it should touch Akismet's and core's markup
+				as lightly as possible. */
 			body[class*="_page_akismet-key-config"] #screen-meta,
 			body[class*="_page_akismet-key-config"] #screen-meta-links {
 				flex-shrink: 0;
@@ -243,15 +241,6 @@ class Akismet_Admin_Chrome {
 				justify-content: flex-end;
 				margin: 0;
 				padding-inline-end: 20px;
-			}
-			/* Keep core's -1px bottom margin so the open panel and the toggle button
-				below it share a border seam, but drop the horizontal margins the flex
-				column no longer needs. The column is viewport-height, so cap the panel
-				and let it scroll rather than squeezing the pinned footer off-screen. */
-			body[class*="_page_akismet-key-config"] #screen-meta {
-				margin: 0 0 -1px;
-				max-height: 60vh;
-				overflow: auto;
 			}
 			body[class*="_page_akismet-key-config"] #wpbody-content {
 				box-sizing: border-box;

--- a/projects/plugins/jetpack/_inc/lib/admin-pages/class-akismet-admin-chrome.php
+++ b/projects/plugins/jetpack/_inc/lib/admin-pages/class-akismet-admin-chrome.php
@@ -216,18 +216,42 @@ class Akismet_Admin_Chrome {
 			body[class*="_page_akismet-key-config"] #wpfooter {
 				display: none;
 			}
-			/* `#screen-meta-links` (the Screen Options / Help tabs container) is always
-				emitted by core's admin header even when empty, and core gives it
-				`margin: 0 10px 20px 0`. On wp.com Simple sites its contents are hidden
-				but the element — and its 20px bottom margin — remain, reserving a blank
-				slot at the very top of the page above the Jetpack header. The
-				`jetpack-admin-page-layout` mixin hides it for the same reason; do it here
-				too. Left UNSCOPED (not under `_page_akismet-key-config`) on purpose: the
-				inline stylesheet is only ever printed on Akismet admin views, and Simple
-				renders its stats UI under a different slug (`dashboard_page_akismet-stats`),
-				so an unscoped rule covers every page this chrome appears on. */
-			#screen-meta-links {
-				display: none;
+			/* `#screen-meta-links` (the Screen Options / Help toggles) and `#screen-meta`
+				(the panel they open) are children of `#wpbody-content`, which the rules
+				below flip to a fixed flex column. That drops core's `float: right` on the
+				toggles — turning them into a full-width row — and core's own margins then
+				reserve blank space above the Jetpack header.
+
+				Do NOT hide them: Akismet registers real contextual-help tabs on this
+				screen (`Akismet_Admin::admin_help()`), and hiding the container takes the
+				Help button away from every Akismet page whenever Jetpack is active. The
+				`jetpack-admin-page-layout` mixin can hide it because none of Jetpack's own
+				React pages register help tabs or screen options; that reasoning does not
+				carry over to a page owned by another plugin.
+
+				Instead, neutralise the margins and restore the right-aligned tab look
+				inside the flex column. When a screen genuinely has neither help tabs nor
+				screen options, core omits `#screen-meta-links` altogether and leaves
+				`#screen-meta` at `display: none` until its toggle is clicked, so nothing
+				reserves space in that case either. */
+			body[class*="_page_akismet-key-config"] #screen-meta,
+			body[class*="_page_akismet-key-config"] #screen-meta-links {
+				flex-shrink: 0;
+			}
+			body[class*="_page_akismet-key-config"] #screen-meta-links {
+				display: flex;
+				justify-content: flex-end;
+				margin: 0;
+				padding-inline-end: 20px;
+			}
+			/* Keep core's -1px bottom margin so the open panel and the toggle button
+				below it share a border seam, but drop the horizontal margins the flex
+				column no longer needs. The column is viewport-height, so cap the panel
+				and let it scroll rather than squeezing the pinned footer off-screen. */
+			body[class*="_page_akismet-key-config"] #screen-meta {
+				margin: 0 0 -1px;
+				max-height: 60vh;
+				overflow: auto;
 			}
 			body[class*="_page_akismet-key-config"] #wpbody-content {
 				box-sizing: border-box;

--- a/projects/plugins/jetpack/changelog/fix-akismet-contextual-help
+++ b/projects/plugins/jetpack/changelog/fix-akismet-contextual-help
@@ -1,0 +1,4 @@
+Significance: patch
+Type: bugfix
+
+Akismet: Restore the WordPress contextual Help tab on Akismet admin pages.


### PR DESCRIPTION
Fixes #

## Proposed changes

Jetpack hides WordPress' contextual **Help** tab on Akismet's admin pages. Regression from #49658.

The Akismet admin chrome printed an unscoped `#screen-meta-links { display: none; }`. That's core's container for the *Screen Options* and *Help* buttons, and Akismet registers real help tabs on this screen (`Akismet_Admin::admin_help()`), so its Help button disappeared.

The rule was copied from the `jetpack-admin-page-layout` mixin, where it's fine — none of Jetpack's own React pages register help tabs. That doesn't hold for a page owned by another plugin.

It can't just be deleted, though: the chrome flips `#wpbody-content` to a fixed flex column, making core's `float: right` a no-op. So this replaces the hide with the two smallest rules that put things back where core has them:

* `flex-shrink: 0` on `#screen-meta` / `#screen-meta-links`, so neither gets squeezed.
* `#screen-meta-links` as a right-aligned flex row with `margin: 0`.

Deliberately nothing more — this stylesheet is scaffolding until Akismet renders the Jetpack header via React itself, so it should stay as light as possible.

### Why the new rules are scoped to `_page_akismet-key-config`

The old rule was left unscoped so it would also cover the stats page, which Simple renders under `dashboard_page_akismet-stats`. That isn't needed:

* On Simple, the stats page is registered as an `index.php` submenu with no `admin_help` hook, so it has no help tabs, and it has no Calypso menu mapping, so the masterbar view switcher isn't added either. Core's `render_screen_meta()` returns early when a screen has neither help tabs nor screen options, so `#screen-meta-links` is never emitted there — the unscoped rule was hiding an element that doesn't exist.
* The contained-layout rules were always scoped to `_page_akismet-key-config`, so the stats page never had the layout problem the hide was solving.

Gating the hide to Simple was also considered and rejected: Simple registers `Akismet_Admin::admin_help()` on the key-config page just like self-hosted does, so gating would keep the bug on Simple while protecting a stats page that has nothing to hide.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Requires Akismet installed and activated alongside Jetpack.

1. Go to **Jetpack → Akismet Anti-spam** (`admin.php?page=akismet-key-config`). On `trunk` there's no **Help** button; on this branch it appears top-right, above the Jetpack header.
2. Click it — the help panel opens with Akismet's tabs. Click again to close.
3. Confirm the Jetpack header, scrolling content and pinned footer are unchanged, with no blank gap above the header.

Please also check: menu expanded and folded; narrow viewport (< 782px); an RTL locale; Akismet's setup view; and, on a WordPress.com Simple site, both the key-config page and the Akismet Stats page under Dashboard.

One known trade-off: on a very short viewport an open help panel may crowd the pinned footer. Worth a follow-up rather than more CSS here.
