### PR TITLE
My Jetpack: fix PHP 8.5 array_key_exists() deprecation for products without a plugin filename

### DIFF
--- a/projects/packages/my-jetpack/changelog/fix-my-jetpack-array-key-exists-null-php85
+++ b/projects/packages/my-jetpack/changelog/fix-my-jetpack-array-key-exists-null-php85
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Fix a PHP 8.5 deprecation notice raised for products that do not ship a standalone plugin.

--- a/projects/packages/my-jetpack/src/products/class-product.php
+++ b/projects/packages/my-jetpack/src/products/class-product.php
@@ -201,7 +201,8 @@ abstract class Product {
 		if ( ! is_array( $filename ) ) {
 			$filename = array( $filename );
 		}
-		foreach ( $filename as $name ) {
+		// Products without a standalone plugin don't declare a filename, so drop the empty values.
+		foreach ( array_filter( $filename ) as $name ) {
 			$installed = array_key_exists( $name, $all_plugins );
 			if ( $installed ) {
 				return $name;


### PR DESCRIPTION
## Proposed changes
* Fix a PHP 8.5 deprecation notice emitted on every My Jetpack page load:
  `Deprecated: Using null as the key parameter for array_key_exists() is deprecated, use an empty string instead in .../my-jetpack/src/products/class-product.php on line 205`
* `Product::get_installed_plugin_filename()` now skips empty filenames before calling `array_key_exists()`.

<img width="1506" height="435" alt="Screenshot 2026-08-11 at 15 52 43" src="https://github.com/user-attachments/assets/d0fab431-7c3d-4b21-80dc-4c05c8f86ee7" />

### Where the null comes from
`Extras` is the only product that resolves to a null plugin filename. It extends `Product` directly and neither declares `$plugin_filename` nor overrides `get_plugin_filename()`, so it inherits the base class default of `null`. Every other product gets a real value via `Module_Product`, `Hybrid_Product`, or its own declaration.

The null then flows through `Product::get_info()` → `is_plugin_active()` → `get_installed_plugin_filename()`, which wraps it in `array( null )` and passes it to `array_key_exists()`. Since `get_info()` runs for every product when the My Jetpack page is built, the notice fires on each page load.

PHP 8.5 is only responsible for surfacing this. It deprecated `null` as the `$key` argument to `array_key_exists()`; earlier versions silently cast it to `""`. The null itself is long-standing and unchanged.

### Why guard in the base class
`Extras` legitimately has no plugin of its own — it activates Jetpack — so giving it a filename would be wrong. Guarding the loop in `Product` also covers any future product in the same position. `array_filter()` only drops the null here; no real plugin filename is a falsy string.

## Related product discussion/links
* 

## Does this pull request change what data or activity we track or use?
No.

## Testing instructions

Requires a site running **PHP 8.5** with `WP_DEBUG` and `WP_DEBUG_DISPLAY` (or `WP_DEBUG_LOG`) enabled.

**Before the fix (reproduce on `trunk`):**
1. Install and connect Jetpack on a PHP 8.5 site.
2. Go to **Jetpack → My Jetpack** (`/wp-admin/admin.php?page=my-jetpack`).
3. Observe the deprecation notice in the page output or in `wp-content/debug.log`:
   `Deprecated: Using null as the key parameter for array_key_exists() is deprecated, use an empty string instead in .../jetpack-my-jetpack/src/products/class-product.php on line 205`

**After the fix (this branch):**
1. Reload **Jetpack → My Jetpack**.
2. Confirm the deprecation notice is gone.
3. Confirm the page renders normally and all product cards show the correct state.

**Regression check (any supported PHP version):**
1. Go to **Jetpack → My Jetpack** and confirm every product card shows the correct status — in particular that products backed by a standalone plugin (Backup, Boost, Protect, Search, Social, VideoPress, CRM, Akismet/Anti-Spam) still correctly report whether their plugin is installed and active.
2. Activate and deactivate one of those standalone plugins and confirm My Jetpack reflects the change.
3. Go to **Plugins** and confirm the "My Jetpack" action link still appears on the Jetpack plugin row and on standalone product plugin rows.
