### PR TITLE
Premium Analytics: remove the Metrics selector from the chart-tab widgets

### DIFF
--- a/projects/packages/premium-analytics/changelog/remove-traffic-chart-metrics-selector
+++ b/projects/packages/premium-analytics/changelog/remove-traffic-chart-metrics-selector
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Chart widgets: Remove the Metrics selector from Traffic summary, Subscribers summary, WordAds, and Store performance — the metric tabs already choose what the chart plots.

--- a/projects/packages/premium-analytics/widgets/store-performance/metrics.ts
+++ b/projects/packages/premium-analytics/widgets/store-performance/metrics.ts
@@ -96,9 +96,3 @@ export const STORE_PERFORMANCE_METRICS: StorePerformanceMetric[] = [
 		metricKey: 'customers',
 	},
 ];
-
-/**
- * Default selection for new widget instances: every metric enabled.
- */
-export const DEFAULT_STORE_PERFORMANCE_METRICS: StorePerformanceMetricId[] =
-	STORE_PERFORMANCE_METRICS.map( metric => metric.id );

--- a/projects/packages/premium-analytics/widgets/store-performance/metrics.ts
+++ b/projects/packages/premium-analytics/widgets/store-performance/metrics.ts
@@ -8,8 +8,7 @@ import { __ } from '@wordpress/i18n';
 import type { MetricKey } from '@jetpack-premium-analytics/widgets-toolkit';
 
 /**
- * Identifier persisted in the widget's `metrics` attribute for each
- * selectable store metric.
+ * Identifier of one store metric tab.
  */
 export type StorePerformanceMetricId =
 	| 'net-sales'

--- a/projects/packages/premium-analytics/widgets/store-performance/render.tsx
+++ b/projects/packages/premium-analytics/widgets/store-performance/render.tsx
@@ -18,14 +18,8 @@ import {
 	type TimeSeriesData,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { __ } from '@wordpress/i18n';
-import { store } from '@wordpress/icons';
 import { useCallback, useMemo } from 'react';
-import {
-	DEFAULT_STORE_PERFORMANCE_METRICS,
-	STORE_PERFORMANCE_METRICS,
-	type StorePerformanceMetric,
-	type StorePerformanceMetricId,
-} from './metrics';
+import { STORE_PERFORMANCE_METRICS, type StorePerformanceMetric } from './metrics';
 import styles from './styles.module.scss';
 import type { StorePerformanceAttributes } from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
@@ -36,9 +30,8 @@ const DEFAULT_DATA_FORMAT = {
 	options: { useMultipliers: true, decimals: 0 },
 };
 
-// Report params (date range + comparison) arrive from the host via WidgetRoot;
-// the widget's own `metrics` attribute selects which store metrics render as
-// tabs. Load failures surface through `<WidgetState>` in the widget body.
+// Report params (date range + comparison) arrive from the host via WidgetRoot.
+// Load failures surface through `<WidgetState>` in the widget body.
 type StorePerformanceRenderAttributes = StorePerformanceAttributes &
 	Partial< ReportParamsFieldAttributes >;
 
@@ -184,72 +177,30 @@ function buildSeriesForMetric( metric: StorePerformanceMetric, dataSources: Data
 	} );
 }
 
-function StorePerformanceContent( {
-	metricIds = DEFAULT_STORE_PERFORMANCE_METRICS,
-}: {
-	metricIds?: StorePerformanceMetricId[];
-} ) {
+function StorePerformanceContent() {
 	const { reportParams } = useWidgetRootContext();
 
-	// Resolve selected ids against the canonical definitions so the tab order
-	// stays stable regardless of the order the ids were toggled in.
-	const enabledMetrics = useMemo( () => {
-		const selected = new Set( metricIds );
-		return STORE_PERFORMANCE_METRICS.filter( metric => selected.has( metric.id ) );
-	}, [ metricIds ] );
-	const metricTypes = useMemo(
-		() => new Set( enabledMetrics.map( metric => metric.metricType ) ),
-		[ enabledMetrics ]
-	);
-
-	const generalReport = useReportOrders( reportParams, {
-		enabled: metricTypes.has( 'general' ),
-	} );
+	const generalReport = useReportOrders( reportParams );
 	const { primary, comparison } = generalReport;
 
-	const bookingsReport = useReportOrders(
-		{
-			...reportParams,
-			filters: [ BOOKINGS_FILTER ],
-		},
-		{
-			enabled: metricTypes.has( 'booking' ),
-		}
-	);
+	const bookingsReport = useReportOrders( {
+		...reportParams,
+		filters: [ BOOKINGS_FILTER ],
+	} );
 	const { primary: bookingsPrimary, comparison: bookingsComparison } = bookingsReport;
 
-	const visitorsReport = useReportVisitors( reportParams, {
-		enabled: metricTypes.has( 'visitors' ),
-	} );
+	const visitorsReport = useReportVisitors( reportParams );
 	const { primary: visitorsPrimary, comparison: visitorsComparison } = visitorsReport;
 
-	const conversionReport = useReportConversionRate( reportParams, {
-		enabled: metricTypes.has( 'conversion' ),
-	} );
+	const conversionReport = useReportConversionRate( reportParams );
 	const { primary: conversionPrimary, comparison: conversionComparison } = conversionReport;
 
-	const customersReport = useReportCustomersByDate( reportParams, {
-		enabled: metricTypes.has( 'customers' ),
-	} );
+	const customersReport = useReportCustomersByDate( reportParams );
 	const { primary: customersPrimary, comparison: customersComparison } = customersReport;
 
 	const activeReports = useMemo(
-		() =>
-			[
-				metricTypes.has( 'general' ) ? generalReport : null,
-				metricTypes.has( 'booking' ) ? bookingsReport : null,
-				metricTypes.has( 'visitors' ) ? visitorsReport : null,
-				metricTypes.has( 'conversion' ) ? conversionReport : null,
-				metricTypes.has( 'customers' ) ? customersReport : null,
-			].filter( report => report !== null ),
-		[
-			metricTypes,
-			generalReport,
-			bookingsReport,
-			visitorsReport,
-			conversionReport,
-			customersReport,
-		]
+		() => [ generalReport, bookingsReport, visitorsReport, conversionReport, customersReport ],
+		[ generalReport, bookingsReport, visitorsReport, conversionReport, customersReport ]
 	);
 	// Gate the error per report — each metric tab has its own report, so a failed
 	// one must surface an error rather than render as an empty chart beside the
@@ -264,7 +215,7 @@ function StorePerformanceContent( {
 
 	const enrichedMetrics = useMemo(
 		() =>
-			enabledMetrics.map( metric => {
+			STORE_PERFORMANCE_METRICS.map( metric => {
 				type Summary = Record< string, string | number >;
 				const getMetricSummaries = (): [ Summary, Summary ] => {
 					if ( metric.metricType === 'booking' ) {
@@ -304,7 +255,6 @@ function StorePerformanceContent( {
 				};
 			} ),
 		[
-			enabledMetrics,
 			bookingsPrimary.data,
 			bookingsComparison.data,
 			visitorsPrimary.data,
@@ -340,8 +290,8 @@ function StorePerformanceContent( {
 		]
 	);
 
-	// One tab per enabled metric; MetricTabsChart owns selection and the
-	// responsive tabs↔dropdown and chart↔sparkline switches.
+	// One tab per metric; MetricTabsChart owns selection and the responsive
+	// tabs↔dropdown and chart↔sparkline switches.
 	const metricTabs: MetricTab[] = useMemo(
 		() =>
 			enrichedMetrics.map( metric => {
@@ -368,20 +318,15 @@ function StorePerformanceContent( {
 			<WidgetState
 				isLoading={ isInitialLoading }
 				isError={ isError }
-				isEmpty={ ! metricTabs.length }
+				// The tabs are fixed, so there is always something to render: the only
+				// empty state this widget ever had was "no metric selected".
+				isEmpty={ false }
 				error={ {
 					description: __(
 						"We couldn't load store performance data. Please try again in a moment.",
 						'jetpack-premium-analytics-pkg'
 					),
 					actions: [ { label: __( 'Retry', 'jetpack-premium-analytics-pkg' ), onClick: refetch } ],
-				} }
-				empty={ {
-					icon: store,
-					description: __(
-						'No metric selected. Please select a metric from the metrics list.',
-						'jetpack-premium-analytics-pkg'
-					),
 				} }
 				// First load keeps the widget's chart-shaped skeleton (the metric tabs
 				// over the chart's own loading overlay) instead of the default overlay.
@@ -408,13 +353,13 @@ function StorePerformanceContent( {
 }
 
 /**
- * Ported from the upstream analytics-at-a-glance widget: the metrics selected by
- * the `metrics` attribute, over a comparison line chart.
+ * Ported from the upstream analytics-at-a-glance widget: every store metric as a
+ * selectable tab, over a comparison line chart.
  */
 export default function StorePerformanceRender( { attributes = {} }: StorePerformanceRenderProps ) {
 	return (
 		<WidgetRoot attributes={ attributes } options={ { from: '/' } }>
-			<StorePerformanceContent metricIds={ attributes.metrics } />
+			<StorePerformanceContent />
 		</WidgetRoot>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/store-performance/render.tsx
+++ b/projects/packages/premium-analytics/widgets/store-performance/render.tsx
@@ -198,7 +198,7 @@ function StorePerformanceContent() {
 	const customersReport = useReportCustomersByDate( reportParams );
 	const { primary: customersPrimary, comparison: customersComparison } = customersReport;
 
-	const activeReports = useMemo(
+	const reports = useMemo(
 		() => [ generalReport, bookingsReport, visitorsReport, conversionReport, customersReport ],
 		[ generalReport, bookingsReport, visitorsReport, conversionReport, customersReport ]
 	);
@@ -206,11 +206,11 @@ function StorePerformanceContent() {
 	// one must surface an error rather than render as an empty chart beside the
 	// others. Placeholder data keeps a report's rows on a transient refetch failure,
 	// so a report with data is not errored.
-	const isError = activeReports.some( report => report.isError && ! report.hasData );
-	// Retry re-runs every active metric report, not only the failed one.
+	const isError = reports.some( report => report.isError && ! report.hasData );
+	// Retry re-runs every metric report, not only the failed one.
 	const refetch = useCallback(
-		() => Promise.all( activeReports.map( report => report.refetch() ) ),
-		[ activeReports ]
+		() => Promise.all( reports.map( report => report.refetch() ) ),
+		[ reports ]
 	);
 
 	const enrichedMetrics = useMemo(
@@ -310,8 +310,8 @@ function StorePerformanceContent() {
 		[ enrichedMetrics, dataSources ]
 	);
 
-	const isInitialLoading = activeReports.some( report => report.isLoading && ! report.hasData );
-	const isFetching = activeReports.some( report => report.isFetching );
+	const isInitialLoading = reports.some( report => report.isLoading && ! report.hasData );
+	const isFetching = reports.some( report => report.isFetching );
 
 	return (
 		<div className={ styles.widgetRoot }>

--- a/projects/packages/premium-analytics/widgets/store-performance/stories/store-performance-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/store-performance/stories/store-performance-widget.stories.tsx
@@ -13,7 +13,6 @@ import {
 } from '../../stories/widget-dashboard-with-widget';
 import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
-import { DEFAULT_STORE_PERFORMANCE_METRICS, type StorePerformanceMetricId } from '../metrics';
 import StorePerformanceRender from '../render';
 import widgetDefinition from '../widget';
 import widgetManifest from '../widget.json';
@@ -29,10 +28,8 @@ const PRESET_OPTIONS = SELECTABLE_PRESETS;
 // Static Storybook builds need this source import before ComparativeLineChart reads LineChart.Legend.
 const ensureLineChartComposition = () => LineChart.Legend;
 
-// Carry the widget's metadata, including the metric-visibility attribute schema
-// so the dashboard story's settings drawer renders the real checkboxes.
-// Presentation is left unset in widget.json, so the host frames the widget and
-// renders its identity (title + icon).
+// Carry the widget's metadata. Presentation is left unset in widget.json, so the
+// host frames the widget and renders its identity (title + icon).
 const storyWidgetType = createStoryWidgetType( widgetManifest, widgetDefinition );
 
 type StorePerformanceRenderProps = ComponentProps< typeof StorePerformanceRender >;
@@ -40,16 +37,7 @@ type StorePerformanceRenderProps = ComponentProps< typeof StorePerformanceRender
 interface StorePerformanceStoryControls {
 	withComparison: boolean;
 	preset: SelectablePresetId;
-	metrics: StorePerformanceMetricId[];
 }
-
-const METRIC_ARG_TYPES = {
-	metrics: {
-		control: 'check',
-		options: DEFAULT_STORE_PERFORMANCE_METRICS,
-		description: 'Store metrics to show as selectable tabs in the widget body.',
-	},
-} as const;
 
 type StorePerformanceStoryProps = StorePerformanceRenderProps & StorePerformanceStoryControls;
 
@@ -60,11 +48,9 @@ interface StorePerformanceDashboardStoryProps
 function getStorePerformanceAttributes( {
 	withComparison = false,
 	preset = DEFAULT_PRESET,
-	metrics = DEFAULT_STORE_PERFORMANCE_METRICS,
 }: Partial< StorePerformanceStoryControls > ): StorePerformanceRenderProps[ 'attributes' ] {
 	return {
 		reportParams: getDefaultQueryParams( withComparison, preset ),
-		metrics,
 	};
 }
 
@@ -86,54 +72,40 @@ function getDefaultQueryParamsSource( {
 	return `getDefaultQueryParams( ${ hasComparison ? 'true' : 'false' }, '${ storyPreset }' )`;
 }
 
-function getMetricsSource(
-	metrics: StorePerformanceMetricId[] = DEFAULT_STORE_PERFORMANCE_METRICS
-) {
-	return `[ ${ metrics.map( metric => `'${ metric }'` ).join( ', ' ) } ]`;
-}
-
 function getStorePerformanceSource( args: Partial< StorePerformanceStoryControls > ) {
 	return `import { getDefaultQueryParams } from '@jetpack-premium-analytics/data';
 
 <StorePerformanceRender
 \tattributes={ {
 \t\treportParams: ${ getDefaultQueryParamsSource( args ) },
-\t\tmetrics: ${ getMetricsSource( args.metrics ) },
 \t} }
 />`;
 }
 
-function renderStorePerformance( {
-	withComparison,
-	preset,
-	metrics,
-}: StorePerformanceStoryControls ) {
+function renderStorePerformance( { withComparison, preset }: StorePerformanceStoryControls ) {
 	ensureLineChartComposition();
 
 	return (
 		<StorePerformanceRender
-			attributes={ getStorePerformanceAttributes( { withComparison, preset, metrics } ) }
+			attributes={ getStorePerformanceAttributes( { withComparison, preset } ) }
 		/>
 	);
 }
 
 // Distinct preset → own query-cache entry; see forceStatsMockState.
-function renderStorePerformanceOnPreset(
-	preset: SelectablePresetId,
-	metrics: StorePerformanceMetricId[] = DEFAULT_STORE_PERFORMANCE_METRICS
-) {
+function renderStorePerformanceOnPreset( preset: SelectablePresetId ) {
 	ensureLineChartComposition();
 
 	return (
 		<StorePerformanceRender
-			attributes={ getStorePerformanceAttributes( { withComparison: false, preset, metrics } ) }
+			attributes={ getStorePerformanceAttributes( { withComparison: false, preset } ) }
 		/>
 	);
 }
 
-// Every report endpoint behind the widget's default metrics (net sales/orders,
-// bookings, visitors, conversion rate, customers). State stories force all of
-// them so no metric report resolves with data.
+// Every report endpoint behind the widget's metrics (net sales/orders, bookings,
+// visitors, conversion rate, customers). State stories force all of them so no
+// metric report resolves with data.
 const STORE_PERFORMANCE_ENDPOINTS = [
 	'orders/by-date',
 	'orders-by-product-type/by-date',
@@ -149,7 +121,6 @@ function setAllReportMockStates( state: 'loading' | 'error' | null ) {
 function StorePerformanceDashboardStory( {
 	withComparison,
 	preset,
-	metrics,
 	...dashboardStoryArgs
 }: StorePerformanceDashboardStoryProps ) {
 	ensureLineChartComposition();
@@ -160,7 +131,7 @@ function StorePerformanceDashboardStory( {
 			widgetType={ storyWidgetType }
 			renderModule={ STORE_PERFORMANCE_RENDER_MODULE }
 			renderComponent={ StorePerformanceRender as ComponentType< WidgetRenderProps< unknown > > }
-			attributes={ getStorePerformanceAttributes( { withComparison, preset, metrics } ) }
+			attributes={ getStorePerformanceAttributes( { withComparison, preset } ) }
 		/>
 	);
 }
@@ -179,13 +150,12 @@ const meta = {
 			control: 'boolean',
 			description: 'Include previous-period comparison report params.',
 		},
-		...METRIC_ARG_TYPES,
 	},
 	parameters: {
 		docs: {
 			description: {
 				component:
-					"Dashboard widget that displays key store performance metrics at a glance. Which metrics render as tabs is controlled by the `metrics` attribute (`relevance: 'high'`), exposed inline in the widget header and in the settings drawer.",
+					'Dashboard widget that displays key store performance metrics at a glance as selectable tabs — net sales, orders, bookings, visitors, conversion rate, and customers — over a comparison line chart.',
 			},
 		},
 	},
@@ -204,7 +174,6 @@ export const Default: Story = {
 	args: {
 		preset: DEFAULT_PRESET,
 		withComparison: false,
-		metrics: DEFAULT_STORE_PERFORMANCE_METRICS,
 	},
 	decorators: [ withWidgetCanvas ],
 	parameters: {
@@ -227,7 +196,6 @@ export const WithComparison: Story = {
 	args: {
 		preset: DEFAULT_PRESET,
 		withComparison: true,
-		metrics: DEFAULT_STORE_PERFORMANCE_METRICS,
 	},
 	decorators: [ withWidgetCanvas ],
 	parameters: {
@@ -273,16 +241,6 @@ export const Error: Story = {
 };
 
 /**
- * No metrics selected: the widget has no tabs to show, so it renders its empty
- * state before fetching reports.
- */
-export const Empty: Story = {
-	render: () => renderStorePerformanceOnPreset( 'last-365-days', [] ),
-	tags: [ '!autodocs' ],
-	decorators: [ withWidgetCanvas ],
-};
-
-/**
  * Renders the widget through the shared dashboard harness.
  */
 export const WidgetDashboardWithWidget: DashboardStory = {
@@ -291,7 +249,6 @@ export const WidgetDashboardWithWidget: DashboardStory = {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 		preset: DEFAULT_PRESET,
 		withComparison: true,
-		metrics: DEFAULT_STORE_PERFORMANCE_METRICS,
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
@@ -304,7 +261,6 @@ export const WidgetDashboardWithWidget: DashboardStory = {
 			control: 'boolean',
 			description: 'Include previous-period comparison report params.',
 		},
-		...METRIC_ARG_TYPES,
 	},
 	parameters: {
 		docs: {
@@ -317,7 +273,6 @@ export const WidgetDashboardWithWidget: DashboardStory = {
 \trenderComponent={ StorePerformanceRender }
 \tattributes={ {
 \t\treportParams: getDefaultQueryParams( true ),
-\t\tmetrics: ${ getMetricsSource() },
 \t} }
 />`,
 			},

--- a/projects/packages/premium-analytics/widgets/store-performance/widget.ts
+++ b/projects/packages/premium-analytics/widgets/store-performance/widget.ts
@@ -1,32 +1,14 @@
 /**
  * WordPress dependencies
  */
-import { __ } from '@wordpress/i18n';
 import { store } from '@wordpress/icons';
-import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 
 /**
- * Internal dependencies
+ * The widget has no user-configurable attributes. Report params still reach it
+ * through WidgetRoot: the dashboard date range, or `attributes.reportParams`
+ * when a host injects them (e.g. Storybook and dashboard previews).
  */
-import { ArrayCheckboxField } from '@jetpack-premium-analytics/fields';
-import {
-	DEFAULT_STORE_PERFORMANCE_METRICS,
-	STORE_PERFORMANCE_METRICS,
-	type StorePerformanceMetricId,
-} from './metrics';
-
-/**
- * Configurable attributes for the Store performance widget. Report params
- * still reach it through WidgetRoot: the dashboard date range, or
- * `attributes.reportParams` when a host injects them (e.g. Storybook and
- * dashboard previews).
- */
-export type StorePerformanceAttributes = {
-	/**
-	 * Store metrics to show as selectable tabs in the widget body.
-	 */
-	metrics?: StorePerformanceMetricId[];
-};
+export type StorePerformanceAttributes = Record< never, never >;
 
 /**
  * Widget type definition.
@@ -34,28 +16,8 @@ export type StorePerformanceAttributes = {
  * Ported from `woocommerce-analytics/at-a-glance` in
  * woocommerce/woocommerce-analytics (next-woocommerce-analytics).
  *
- * The `metrics` attribute (`relevance: 'high'`) selects which store metrics
- * render as tabs; `example.attributes` doubles as the defaults applied to new
- * instances: every metric enabled.
+ * Which metric is plotted is the chart's own tab selection, not an attribute.
  */
 export default {
 	icon: store,
-	attributes: [
-		{
-			id: 'metrics',
-			label: __( 'Metrics', 'jetpack-premium-analytics-pkg' ),
-			type: 'array',
-			relevance: 'high',
-			Edit: ArrayCheckboxField,
-			elements: STORE_PERFORMANCE_METRICS.map( metric => ( {
-				value: metric.id,
-				label: metric.label,
-			} ) ),
-		},
-	] as WidgetAttributeField< StorePerformanceAttributes >[],
-	example: {
-		attributes: {
-			metrics: DEFAULT_STORE_PERFORMANCE_METRICS,
-		},
-	},
 };

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/render.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/render.tsx
@@ -6,14 +6,12 @@ import {
 	WidgetRoot,
 	WidgetState,
 	useWidgetRootContext,
-	ChartEmptyState,
 	defaultPeriodForInterval,
 	type MetricTab,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { customer } from '@jetpack-premium-analytics/icons';
 import { useMemo } from '@wordpress/element';
-import { trendingUp } from '@wordpress/icons';
 import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
@@ -25,7 +23,6 @@ import useSubscribersChart, {
 	type SubscribersPeriod,
 } from './use-subscribers-chart';
 import {
-	DEFAULT_SUBSCRIBERS_CHART_METRICS,
 	SUBSCRIBERS_CHART_METRICS,
 	type SubscribersChartAttributes,
 	type SubscribersChartGranularity,
@@ -70,8 +67,8 @@ function latest(
 }
 
 /**
- * Pulls each metric's value off a chart point. Ids and labels are shared with
- * the settings checkboxes via `SUBSCRIBERS_CHART_METRICS` in `widget.ts`.
+ * Pulls each metric's value off a chart point. Ids and labels come from
+ * `SUBSCRIBERS_CHART_METRICS` in `widget.ts`.
  */
 const METRIC_ACCESSORS: Record<
 	SubscribersChartMetricId,
@@ -82,32 +79,27 @@ const METRIC_ACCESSORS: Record<
 };
 
 /**
- * Build the metric tabs from the fetched state: the selected metrics, in
- * canonical order, with Paid subscribers only when the site has any. Each tab
- * carries its headline total + the previous-window total for the delta, and
- * the per-period points for the chart.
+ * Build the metric tabs from the fetched state, in canonical order, with Paid
+ * subscribers only when the site has any. Each tab carries its headline total +
+ * the previous-window total for the delta, and the per-period points for the
+ * chart.
  */
-function buildMetrics(
-	state: SubscribersChartState,
-	metricIds: SubscribersChartMetricId[]
-): MetricTab[] {
-	const selected = new Set( metricIds );
-
-	return SUBSCRIBERS_CHART_METRICS.filter(
-		( { id } ) => selected.has( id ) && ( id !== 'paid' || state.hasPaid )
-	).map( ( { id, label } ) => {
-		const accessor = METRIC_ACCESSORS[ id ];
-		return {
-			key: id,
-			label,
-			value: latest( state.current, accessor ),
-			previousValue: state.previous.length ? latest( state.previous, accessor ) : undefined,
-			current: state.current.map( point => ( { date: point.date, value: accessor( point ) } ) ),
-			previous: state.previous.length
-				? state.previous.map( point => ( { date: point.date, value: accessor( point ) } ) )
-				: undefined,
-		};
-	} );
+function buildMetrics( state: SubscribersChartState ): MetricTab[] {
+	return SUBSCRIBERS_CHART_METRICS.filter( ( { id } ) => id !== 'paid' || state.hasPaid ).map(
+		( { id, label } ) => {
+			const accessor = METRIC_ACCESSORS[ id ];
+			return {
+				key: id,
+				label,
+				value: latest( state.current, accessor ),
+				previousValue: state.previous.length ? latest( state.previous, accessor ) : undefined,
+				current: state.current.map( point => ( { date: point.date, value: accessor( point ) } ) ),
+				previous: state.previous.length
+					? state.previous.map( point => ( { date: point.date, value: accessor( point ) } ) )
+					: undefined,
+			};
+		}
+	);
 }
 
 type SubscribersChartInnerProps = {
@@ -116,25 +108,17 @@ type SubscribersChartInnerProps = {
 	 */
 	granularity: SubscribersChartGranularity;
 	/**
-	 * Selected metric tab ids; defaults to every metric.
-	 */
-	metrics?: SubscribersChartMetricId[];
-	/**
 	 * How to draw the selected metric. `MetricTabsChart` owns the default.
 	 */
 	chartType?: SubscribersChartType;
 };
 
 /**
- * The "Group by" control is the `granularity` attribute, the tab selection is the
- * `metrics` attribute, and the "Chart type" control is the `chartType` attribute
- * (all `relevance: 'high'`), rendered by the widget host.
+ * The "Group by" control is the `granularity` attribute and the "Chart type"
+ * control is the `chartType` attribute (both `relevance: 'high'`), rendered by
+ * the widget host. Which metric is plotted is the chart's own tab selection.
  */
-function SubscribersChartInner( {
-	granularity,
-	metrics: metricIds = DEFAULT_SUBSCRIBERS_CHART_METRICS,
-	chartType,
-}: SubscribersChartInnerProps ) {
+function SubscribersChartInner( { granularity, chartType }: SubscribersChartInnerProps ) {
 	const { reportParams } = useWidgetRootContext();
 	// `auto` means "follow the dashboard range"; an explicit value sticks
 	// across range changes. This keeps a wide range from staying stuck on
@@ -146,40 +130,8 @@ function SubscribersChartInner( {
 			: granularity;
 
 	const state = useSubscribersChart( reportParams, period );
-	const metricTabs = useMemo( () => buildMetrics( state, metricIds ), [ state, metricIds ] );
+	const metricTabs = useMemo( () => buildMetrics( state ), [ state ] );
 	const groupLabel = __( 'Subscriber metric', 'jetpack-premium-analytics-pkg' );
-
-	// An empty selection is a configuration state, not a data state: it stands
-	// whatever the fetch is doing.
-	if ( ! metricIds.length ) {
-		return (
-			<ChartEmptyState
-				icon={ trendingUp }
-				text={ __(
-					'No metric selected. Please select a metric from the metrics list.',
-					'jetpack-premium-analytics-pkg'
-				) }
-			/>
-		);
-	}
-
-	// Metrics are selected but every tab was filtered out — today that means
-	// Paid subscribers is the sole selection on a site with no paid subscribers
-	// in the window. Wait out the first fetch before claiming so, and let a
-	// failed fetch fall through to `WidgetState`'s error rather than reporting
-	// the absence of paid subscribers we never managed to load.
-	if ( ! metricTabs.length && ! state.isError ) {
-		if ( state.isLoading ) {
-			return null;
-		}
-
-		return (
-			<ChartEmptyState
-				icon={ trendingUp }
-				text={ __( 'No paid subscribers in this date range.', 'jetpack-premium-analytics-pkg' ) }
-			/>
-		);
-	}
 
 	return (
 		<div className={ styles.root }>
@@ -241,11 +193,7 @@ export default function SubscribersChart( {
 
 	return (
 		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
-			<SubscribersChartInner
-				granularity={ granularity }
-				metrics={ attributes.metrics }
-				chartType={ attributes.chartType }
-			/>
+			<SubscribersChartInner granularity={ granularity } chartType={ attributes.chartType } />
 		</WidgetRoot>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/stories/subscribers-chart-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/stories/subscribers-chart-widget.stories.tsx
@@ -18,11 +18,7 @@ import {
 	setReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import SubscribersChartRender from '../render';
-import widgetDefinition, {
-	DEFAULT_SUBSCRIBERS_CHART_METRICS,
-	type SubscribersChartMetricId,
-	type SubscribersChartType,
-} from '../widget';
+import widgetDefinition, { type SubscribersChartType } from '../widget';
 import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
@@ -32,42 +28,29 @@ registerReportMocks();
 
 const SUBSCRIBERS_CHART_RENDER_MODULE = 'storybook/subscribers-chart';
 
-// Carry the widget's metadata, including the metric-visibility attribute schema
-// so the dashboard story's settings drawer renders the real controls.
+// Carry the widget's metadata, including the attribute schema so the dashboard
+// story's settings drawer renders the real controls.
 const storyWidgetType = createStoryWidgetType( widgetManifest, widgetDefinition );
 
 interface SubscribersChartStoryControls {
 	withComparison: boolean;
-	metrics: SubscribersChartMetricId[];
 	chartType: SubscribersChartType;
 }
 
-const METRIC_ARG_TYPES = {
-	metrics: {
-		control: 'check',
-		options: DEFAULT_SUBSCRIBERS_CHART_METRICS,
-	},
+const CHART_TYPE_ARG_TYPES = {
 	chartType: {
 		control: 'inline-radio',
 		options: [ 'line', 'bar' ] satisfies SubscribersChartType[],
 	},
 } as const;
 
-const ALL_METRICS_ARGS = {
-	metrics: DEFAULT_SUBSCRIBERS_CHART_METRICS,
-	chartType: 'line',
-} as const;
+const DEFAULT_CHART_ARGS = { chartType: 'line' } as const;
 
-function renderSubscribersChart( {
-	withComparison,
-	metrics,
-	chartType,
-}: SubscribersChartStoryControls ) {
+function renderSubscribersChart( { withComparison, chartType }: SubscribersChartStoryControls ) {
 	return (
 		<SubscribersChartRender
 			attributes={ {
 				reportParams: getDefaultQueryParams( withComparison ),
-				metrics,
 				chartType,
 			} }
 		/>
@@ -89,13 +72,13 @@ const meta = {
 	tags: [ 'autodocs' ],
 	argTypes: {
 		withComparison: { control: 'boolean' },
-		...METRIC_ARG_TYPES,
+		...CHART_TYPE_ARG_TYPES,
 	},
 	parameters: {
 		docs: {
 			description: {
 				component:
-					'Subscriber growth over time. The date range and previous-period comparison follow the dashboard picker; the "Group by" control is the `granularity` attribute and the tab selection is the `metrics` attribute (both `relevance: \'high\'`), exposed by the widget host. When comparison is on, the previous period is overlaid as a same-colour dashed line and the headline shows the period-over-period delta. The Paid subscribers tab renders only when the site has paid subscribers, even while selected. Data comes from `useStatsSubscribersReport`; in Storybook it is served by `registerReportMocks`.',
+					'Subscriber growth over time. The date range and previous-period comparison follow the dashboard picker; the "Group by" control is the `granularity` attribute and the "Chart type" control is the `chartType` attribute (both `relevance: \'high\'`), exposed by the widget host; which metric is plotted is the chart\'s own tab selection. When comparison is on, the previous period is overlaid as a same-colour dashed line and the headline shows the period-over-period delta. The Paid subscribers tab renders only when the site has paid subscribers. Data comes from `useStatsSubscribersReport`; in Storybook it is served by `registerReportMocks`.',
 			},
 		},
 	},
@@ -110,7 +93,7 @@ type Story = StoryObj< SubscribersChartStoryControls >;
  */
 export const Default: Story = {
 	render: renderSubscribersChart,
-	args: { withComparison: false, ...ALL_METRICS_ARGS },
+	args: { withComparison: false, ...DEFAULT_CHART_ARGS },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -120,7 +103,7 @@ export const Default: Story = {
  */
 export const WithComparison: Story = {
 	render: renderSubscribersChart,
-	args: { withComparison: true, ...ALL_METRICS_ARGS },
+	args: { withComparison: true, ...DEFAULT_CHART_ARGS },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -129,7 +112,7 @@ export const WithComparison: Story = {
  */
 export const BarChart: Story = {
 	render: renderSubscribersChart,
-	args: { withComparison: false, ...ALL_METRICS_ARGS, chartType: 'bar' },
+	args: { withComparison: false, chartType: 'bar' },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -139,7 +122,7 @@ export const BarChart: Story = {
  */
 export const BarChartWithComparison: Story = {
 	render: renderSubscribersChart,
-	args: { withComparison: true, ...ALL_METRICS_ARGS, chartType: 'bar' },
+	args: { withComparison: true, chartType: 'bar' },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -193,7 +176,6 @@ interface SubscribersChartDashboardStoryProps
 
 function SubscribersChartDashboardStory( {
 	withComparison,
-	metrics,
 	chartType,
 	...dashboardArgs
 }: SubscribersChartDashboardStoryProps ) {
@@ -205,7 +187,6 @@ function SubscribersChartDashboardStory( {
 			renderComponent={ SubscribersChartRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ {
 				reportParams: getDefaultQueryParams( withComparison ),
-				metrics,
 				chartType,
 			} }
 		/>
@@ -220,11 +201,11 @@ export const WidgetDashboardWithWidget: StoryObj< SubscribersChartDashboardStory
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 		withComparison: true,
-		...ALL_METRICS_ARGS,
+		...DEFAULT_CHART_ARGS,
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
 		withComparison: { control: 'boolean' },
-		...METRIC_ARG_TYPES,
+		...CHART_TYPE_ARG_TYPES,
 	},
 };

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/widget.ts
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/widget.ts
@@ -37,9 +37,9 @@ export const SUBSCRIBERS_CHART_TYPES = [
 export type SubscribersChartType = ( typeof SUBSCRIBERS_CHART_TYPES )[ number ][ 'id' ];
 
 /**
- * The metric tabs the chart can show, in display order: the persisted id and
- * label of each metric. The Paid subscribers tab only renders when the site
- * has paid subscribers.
+ * The metric tabs the chart shows, in display order: the id and label of each
+ * metric. The Paid subscribers tab only renders when the site has paid
+ * subscribers.
  */
 export const SUBSCRIBERS_CHART_METRICS = [
 	{ id: 'subscribers', label: __( 'Subscribers', 'jetpack-premium-analytics-pkg' ) },

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/widget.ts
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/widget.ts
@@ -8,7 +8,7 @@ import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 /**
  * Internal dependencies
  */
-import { ArrayCheckboxField, SelectField } from '@jetpack-premium-analytics/fields';
+import { SelectField } from '@jetpack-premium-analytics/fields';
 import type { MetricTabsChartType } from '@jetpack-premium-analytics/widgets-toolkit';
 
 /**
@@ -38,9 +38,8 @@ export type SubscribersChartType = ( typeof SUBSCRIBERS_CHART_TYPES )[ number ][
 
 /**
  * The metric tabs the chart can show, in display order: the persisted id and
- * label of each metric. Single source for the settings checkboxes and the
- * chart tabs so the two cannot drift apart. The Paid subscribers tab only
- * renders when the site has paid subscribers, even while selected.
+ * label of each metric. The Paid subscribers tab only renders when the site
+ * has paid subscribers.
  */
 export const SUBSCRIBERS_CHART_METRICS = [
 	{ id: 'subscribers', label: __( 'Subscribers', 'jetpack-premium-analytics-pkg' ) },
@@ -48,7 +47,7 @@ export const SUBSCRIBERS_CHART_METRICS = [
 ] as const satisfies readonly { id: string; label: string }[];
 
 /**
- * Identifier persisted in the widget's `metrics` attribute for one metric tab.
+ * Identifier of one metric tab.
  */
 export type SubscribersChartMetricId = ( typeof SUBSCRIBERS_CHART_METRICS )[ number ][ 'id' ];
 
@@ -59,20 +58,12 @@ export type SubscribersChartMetricId = ( typeof SUBSCRIBERS_CHART_METRICS )[ num
  * dashboard previews).
  *
  * @property granularity - Bucket size within the dashboard range. Defaults to `auto`.
- * @property metrics     - Metric tabs to show in the chart. Defaults to every metric.
  * @property chartType   - How to draw the selected metric. Defaults to `line`.
  */
 export type SubscribersChartAttributes = {
 	granularity?: SubscribersChartGranularity;
-	metrics?: SubscribersChartMetricId[];
 	chartType?: SubscribersChartType;
 };
-
-/**
- * Default selection for new widget instances: every metric enabled.
- */
-export const DEFAULT_SUBSCRIBERS_CHART_METRICS: SubscribersChartMetricId[] =
-	SUBSCRIBERS_CHART_METRICS.map( metric => metric.id );
 
 /**
  * Widget type definition.
@@ -81,9 +72,9 @@ export const DEFAULT_SUBSCRIBERS_CHART_METRICS: SubscribersChartMetricId[] =
  * wp-calypso. The date range and previous-period comparison follow the
  * dashboard picker; the legacy interval segmented control is the
  * `granularity` attribute (`relevance: 'high'`), so the widget host renders
- * its control. It only chooses the bucket size within that range. The
- * `metrics` attribute selects which tabs render; `example.attributes` doubles
- * as the defaults applied to new instances.
+ * its control. It only chooses the bucket size within that range. Which metric
+ * is plotted is the chart's own tab selection, not an attribute;
+ * `example.attributes` doubles as the defaults applied to new instances.
  */
 export default {
 	icon: people,
@@ -114,17 +105,6 @@ export default {
 			relevance: 'high',
 		},
 		{
-			id: 'metrics',
-			label: __( 'Metrics', 'jetpack-premium-analytics-pkg' ),
-			type: 'array',
-			relevance: 'high',
-			Edit: ArrayCheckboxField,
-			elements: SUBSCRIBERS_CHART_METRICS.map( metric => ( {
-				value: metric.id,
-				label: metric.label,
-			} ) ),
-		},
-		{
 			id: 'chartType',
 			label: __( 'Chart type', 'jetpack-premium-analytics-pkg' ),
 			type: 'text',
@@ -139,7 +119,6 @@ export default {
 	example: {
 		attributes: {
 			granularity: 'auto',
-			metrics: DEFAULT_SUBSCRIBERS_CHART_METRICS,
 			chartType: 'line',
 		},
 	},

--- a/projects/packages/premium-analytics/widgets/traffic-chart/__tests__/use-traffic-chart.test.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/__tests__/use-traffic-chart.test.tsx
@@ -189,17 +189,4 @@ describe( 'useTrafficChart', () => {
 			expect( metric.previousValue ).toBeUndefined();
 		}
 	} );
-
-	it( 'yields only the selected metrics, in canonical order', async () => {
-		// Ids passed out of canonical order to prove the order comes from the
-		// definitions, not the selection.
-		const { result } = renderHook(
-			() => useTrafficChart( RANGE, 'month', [ 'comments', 'views' ] ),
-			{ wrapper }
-		);
-
-		await waitFor( () => expect( result.current.isFetching ).toBe( false ) );
-
-		expect( result.current.metrics.map( metric => metric.key ) ).toEqual( [ 'views', 'comments' ] );
-	} );
 } );

--- a/projects/packages/premium-analytics/widgets/traffic-chart/render.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/render.tsx
@@ -16,12 +16,7 @@ import { __ } from '@wordpress/i18n';
  */
 import styles from './style.module.css';
 import useTrafficChart, { type TrafficPeriod } from './use-traffic-chart';
-import type {
-	TrafficChartAttributes,
-	TrafficChartGranularity,
-	TrafficChartMetricId,
-	TrafficChartType,
-} from './widget';
+import type { TrafficChartAttributes, TrafficChartGranularity, TrafficChartType } from './widget';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
 import type { ComponentProps } from 'react';
 
@@ -47,21 +42,17 @@ type TrafficChartInnerProps = {
 	 */
 	granularity: TrafficChartGranularity;
 	/**
-	 * Selected metric tab ids; defaults to every metric.
-	 */
-	metrics?: TrafficChartMetricId[];
-	/**
 	 * How to draw the selected metric. `MetricTabsChart` owns the default.
 	 */
 	chartType?: TrafficChartType;
 };
 
 /**
- * The "Group by" control is the `granularity` attribute, the tab selection is the
- * `metrics` attribute, and the "Chart type" control is the `chartType` attribute
- * (all `relevance: 'high'`), rendered by the widget host.
+ * The "Group by" control is the `granularity` attribute and the "Chart type"
+ * control is the `chartType` attribute (both `relevance: 'high'`), rendered by
+ * the widget host. Which metric is plotted is the chart's own tab selection.
  */
-function TrafficChartInner( { granularity, metrics, chartType }: TrafficChartInnerProps ) {
+function TrafficChartInner( { granularity, chartType }: TrafficChartInnerProps ) {
 	const { reportParams } = useWidgetRootContext();
 	// `auto` means "follow the dashboard range"; an explicit value sticks
 	// across range changes, so a wide range doesn't stay stuck on `day`
@@ -78,19 +69,8 @@ function TrafficChartInner( { granularity, metrics, chartType }: TrafficChartInn
 		isFetching,
 		isError,
 		refetch,
-	} = useTrafficChart( reportParams, period, metrics );
+	} = useTrafficChart( reportParams, period );
 	const groupLabel = __( 'Traffic metric', 'jetpack-premium-analytics-pkg' );
-
-	if ( ! metricTabs.length ) {
-		return (
-			<div className={ styles.emptyState }>
-				{ __(
-					'No metric selected. Please select a metric from the metrics list.',
-					'jetpack-premium-analytics-pkg'
-				) }
-			</div>
-		);
-	}
 
 	return (
 		<div className={ styles.root }>
@@ -146,11 +126,7 @@ export default function TrafficChart( { attributes = {}, setError }: TrafficChar
 
 	return (
 		<WidgetRoot attributes={ attributes } setError={ setError } options={ { from: '/' } }>
-			<TrafficChartInner
-				granularity={ granularity }
-				metrics={ attributes.metrics }
-				chartType={ attributes.chartType }
-			/>
+			<TrafficChartInner granularity={ granularity } chartType={ attributes.chartType } />
 		</WidgetRoot>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/traffic-chart/stories/traffic-chart-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/stories/traffic-chart-widget.stories.tsx
@@ -15,11 +15,7 @@ import {
 	setReportMockState,
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import TrafficChartRender from '../render';
-import widgetDefinition, {
-	DEFAULT_TRAFFIC_CHART_METRICS,
-	type TrafficChartMetricId,
-	type TrafficChartType,
-} from '../widget';
+import widgetDefinition, { type TrafficChartType } from '../widget';
 import widgetManifest from '../widget.json';
 import type { Meta, StoryObj } from '@storybook/react';
 import type { WidgetRenderProps } from '@wordpress/widget-primitives';
@@ -29,38 +25,29 @@ registerReportMocks();
 
 const TRAFFIC_CHART_RENDER_MODULE = 'storybook/traffic-chart';
 
-// Carry the widget's metadata, including the metric-visibility attribute schema
-// so the dashboard story's settings drawer renders the real controls.
+// Carry the widget's metadata, including the attribute schema so the dashboard
+// story's settings drawer renders the real controls.
 const storyWidgetType = createStoryWidgetType( widgetManifest, widgetDefinition );
 
 interface TrafficChartStoryControls {
 	withComparison: boolean;
-	metrics: TrafficChartMetricId[];
 	chartType: TrafficChartType;
 }
 
-const METRIC_ARG_TYPES = {
-	metrics: {
-		control: 'check',
-		options: DEFAULT_TRAFFIC_CHART_METRICS,
-	},
+const CHART_TYPE_ARG_TYPES = {
 	chartType: {
 		control: 'inline-radio',
 		options: [ 'line', 'bar' ] satisfies TrafficChartType[],
 	},
 } as const;
 
-const ALL_METRICS_ARGS = {
-	metrics: DEFAULT_TRAFFIC_CHART_METRICS,
-	chartType: 'line',
-} as const;
+const DEFAULT_CHART_ARGS = { chartType: 'line' } as const;
 
-function renderTrafficChart( { withComparison, metrics, chartType }: TrafficChartStoryControls ) {
+function renderTrafficChart( { withComparison, chartType }: TrafficChartStoryControls ) {
 	return (
 		<TrafficChartRender
 			attributes={ {
 				reportParams: getDefaultQueryParams( withComparison ),
-				metrics,
 				chartType,
 			} }
 		/>
@@ -80,13 +67,13 @@ const meta = {
 	tags: [ 'autodocs' ],
 	argTypes: {
 		withComparison: { control: 'boolean' },
-		...METRIC_ARG_TYPES,
+		...CHART_TYPE_ARG_TYPES,
 	},
 	parameters: {
 		docs: {
 			description: {
 				component:
-					'Traffic over the selected period as selectable metric tabs — Views, Visitors, Likes, and Comments — over a comparative chart. The date range and comparison come from the dashboard controls; the "Group by" control is the `granularity` attribute, the tab selection is the `metrics` attribute, and the "Chart type" control is the `chartType` attribute (all `relevance: \'high\'`), exposed by the widget host. When comparison is on, each tab shows its period-over-period delta and the previous period is overlaid — as a same-colour dashed line for `line`, or as the translucent shadow bar behind each bar for `bar`. Views/visitors and likes/comments are fetched as two parallel requests (mirroring Calypso) to keep latency down; a pair\'s request is skipped while neither of its metrics is selected. Data comes from the `useStatsVisits` hook; in Storybook it is served by `registerReportMocks`.',
+					'Traffic over the selected period as selectable metric tabs — Views, Visitors, Likes, and Comments — over a comparative chart. The date range and comparison come from the dashboard controls; the "Group by" control is the `granularity` attribute and the "Chart type" control is the `chartType` attribute (both `relevance: \'high\'`), exposed by the widget host; which metric is plotted is the chart\'s own tab selection. When comparison is on, each tab shows its period-over-period delta and the previous period is overlaid — as a same-colour dashed line for `line`, or as the translucent shadow bar behind each bar for `bar`. Views/visitors and likes/comments are fetched as two parallel requests (mirroring Calypso) to keep latency down. Data comes from the `useStatsVisits` hook; in Storybook it is served by `registerReportMocks`.',
 			},
 		},
 	},
@@ -101,7 +88,7 @@ type Story = StoryObj< TrafficChartStoryControls >;
  */
 export const Default: Story = {
 	render: renderTrafficChart,
-	args: { withComparison: false, ...ALL_METRICS_ARGS },
+	args: { withComparison: false, ...DEFAULT_CHART_ARGS },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -110,7 +97,7 @@ export const Default: Story = {
  */
 export const WithComparison: Story = {
 	render: renderTrafficChart,
-	args: { withComparison: true, ...ALL_METRICS_ARGS },
+	args: { withComparison: true, ...DEFAULT_CHART_ARGS },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -119,7 +106,7 @@ export const WithComparison: Story = {
  */
 export const BarChart: Story = {
 	render: renderTrafficChart,
-	args: { withComparison: false, ...ALL_METRICS_ARGS, chartType: 'bar' },
+	args: { withComparison: false, ...DEFAULT_CHART_ARGS, chartType: 'bar' },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -129,7 +116,7 @@ export const BarChart: Story = {
  */
 export const BarChartWithComparison: Story = {
 	render: renderTrafficChart,
-	args: { withComparison: true, ...ALL_METRICS_ARGS, chartType: 'bar' },
+	args: { withComparison: true, ...DEFAULT_CHART_ARGS, chartType: 'bar' },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -184,7 +171,6 @@ interface TrafficChartDashboardStoryProps
 
 function TrafficChartDashboardStory( {
 	withComparison,
-	metrics,
 	chartType,
 	...dashboardArgs
 }: TrafficChartDashboardStoryProps ) {
@@ -196,7 +182,6 @@ function TrafficChartDashboardStory( {
 			renderComponent={ TrafficChartRender as ComponentType< WidgetRenderProps< unknown > > }
 			attributes={ {
 				reportParams: getDefaultQueryParams( withComparison ),
-				metrics,
 				chartType,
 			} }
 		/>
@@ -211,11 +196,11 @@ export const WidgetDashboardWithWidget: StoryObj< TrafficChartDashboardStoryProp
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 		withComparison: true,
-		...ALL_METRICS_ARGS,
+		...DEFAULT_CHART_ARGS,
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
 		withComparison: { control: 'boolean' },
-		...METRIC_ARG_TYPES,
+		...CHART_TYPE_ARG_TYPES,
 	},
 };

--- a/projects/packages/premium-analytics/widgets/traffic-chart/style.module.css
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/style.module.css
@@ -6,11 +6,3 @@
 	padding: var(--wpds-dimension-padding-lg);
 	overflow: hidden;
 }
-
-.emptyState {
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	min-height: 250px;
-	color: var(--wpds-color-foreground-content-neutral-weak);
-}

--- a/projects/packages/premium-analytics/widgets/traffic-chart/use-traffic-chart.ts
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/use-traffic-chart.ts
@@ -13,11 +13,7 @@ import { useCallback, useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import {
-	DEFAULT_TRAFFIC_CHART_METRICS,
-	TRAFFIC_CHART_METRICS,
-	type TrafficChartMetricId,
-} from './widget';
+import { TRAFFIC_CHART_METRICS } from './widget';
 import { buildMetricTab, type MetricTab } from '@jetpack-premium-analytics/widgets-toolkit';
 
 /**
@@ -54,18 +50,12 @@ function toVisitsParams(
  * visitors ride one request, likes and comments a second — split (rather than a
  * single four-field request) because the visits endpoint's latency grows with
  * the number of requested fields, so two smaller requests resolve faster in
- * parallel. Mirrors how Calypso's chart tabs fetch each pair. A pair's request
- * is skipped entirely while neither of its fields is selected.
+ * parallel. Mirrors how Calypso's chart tabs fetch each pair.
  */
 export default function useTrafficChart(
 	reportParams: ReportParams,
-	period: TrafficPeriod,
-	metricIds: TrafficChartMetricId[] = DEFAULT_TRAFFIC_CHART_METRICS
+	period: TrafficPeriod
 ): TrafficChartState {
-	const selected = useMemo( () => new Set( metricIds ), [ metricIds ] );
-	const needsViewsVisitors = selected.has( 'views' ) || selected.has( 'visitors' );
-	const needsLikesComments = selected.has( 'likes' ) || selected.has( 'comments' );
-
 	// Memoize each request's params (as sibling Stats widgets do) so the query key
 	// is stable across renders.
 	const viewsVisitorsParams = useMemo(
@@ -77,8 +67,8 @@ export default function useTrafficChart(
 		[ reportParams, period ]
 	);
 
-	const viewsVisitors = useStatsVisits( viewsVisitorsParams, { enabled: needsViewsVisitors } );
-	const likesComments = useStatsVisits( likesCommentsParams, { enabled: needsLikesComments } );
+	const viewsVisitors = useStatsVisits( viewsVisitorsParams );
+	const likesComments = useStatsVisits( likesCommentsParams );
 
 	const vvPrimary = viewsVisitors.primary.data as StatsVisitsResponse | undefined;
 	const vvComparison = viewsVisitors.comparison.data as StatsVisitsResponse | undefined;
@@ -87,11 +77,10 @@ export default function useTrafficChart(
 	const lcComparison = likesComments.comparison.data as StatsVisitsResponse | undefined;
 	const lcHasComparison = likesComments.hasComparison;
 
-	// One tab per selected metric, in canonical definition order regardless of
-	// the order the ids were toggled in.
+	// One tab per metric, in canonical definition order.
 	const metrics = useMemo(
 		() =>
-			TRAFFIC_CHART_METRICS.filter( metric => selected.has( metric.id ) ).map( metric => {
+			TRAFFIC_CHART_METRICS.map( metric => {
 				const isViewsVisitors = metric.id === 'views' || metric.id === 'visitors';
 				return buildMetricTab( {
 					primary: isViewsVisitors ? vvPrimary : lcPrimary,
@@ -101,7 +90,7 @@ export default function useTrafficChart(
 					label: metric.label,
 				} );
 			} ),
-		[ selected, vvPrimary, vvComparison, vvHasComparison, lcPrimary, lcComparison, lcHasComparison ]
+		[ vvPrimary, vvComparison, vvHasComparison, lcPrimary, lcComparison, lcHasComparison ]
 	);
 
 	// Depend on the underlying refetch callbacks (each a stable `useReport`

--- a/projects/packages/premium-analytics/widgets/traffic-chart/widget.ts
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/widget.ts
@@ -8,7 +8,7 @@ import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 /**
  * Internal dependencies
  */
-import { ArrayCheckboxField, SelectField } from '@jetpack-premium-analytics/fields';
+import { SelectField } from '@jetpack-premium-analytics/fields';
 import type { MetricTabsChartType } from '@jetpack-premium-analytics/widgets-toolkit';
 
 /**
@@ -37,10 +37,9 @@ export const TRAFFIC_CHART_TYPES = [
 export type TrafficChartType = ( typeof TRAFFIC_CHART_TYPES )[ number ][ 'id' ];
 
 /**
- * The metric tabs the chart can show, in display order: the persisted id and
+ * The metric tabs the chart shows, in display order: the persisted id and
  * label of each metric. The id doubles as the visits `stat_fields` field the
- * tab reads. Single source for the settings checkboxes and the chart tabs so
- * the two cannot drift apart.
+ * tab reads.
  */
 export const TRAFFIC_CHART_METRICS = [
 	{ id: 'views', label: __( 'Views', 'jetpack-premium-analytics-pkg' ) },
@@ -50,7 +49,7 @@ export const TRAFFIC_CHART_METRICS = [
 ] as const satisfies readonly { id: string; label: string }[];
 
 /**
- * Identifier persisted in the widget's `metrics` attribute for one metric tab.
+ * Identifier of one metric tab.
  */
 export type TrafficChartMetricId = ( typeof TRAFFIC_CHART_METRICS )[ number ][ 'id' ];
 
@@ -61,21 +60,12 @@ export type TrafficChartMetricId = ( typeof TRAFFIC_CHART_METRICS )[ number ][ '
  * dashboard previews).
  *
  * @property granularity - Bucket size within the dashboard range. Defaults to `auto`.
- * @property metrics     - Metric tabs to show in the chart. Defaults to every metric.
  * @property chartType   - How to draw the selected metric. Defaults to `line`.
  */
 export type TrafficChartAttributes = {
 	granularity?: TrafficChartGranularity;
-	metrics?: TrafficChartMetricId[];
 	chartType?: TrafficChartType;
 };
-
-/**
- * Default selection for new widget instances: every metric enabled.
- */
-export const DEFAULT_TRAFFIC_CHART_METRICS: TrafficChartMetricId[] = TRAFFIC_CHART_METRICS.map(
-	metric => metric.id
-);
 
 /**
  * Widget type definition.
@@ -85,8 +75,8 @@ export const DEFAULT_TRAFFIC_CHART_METRICS: TrafficChartMetricId[] = TRAFFIC_CHA
  * and Comments as selectable metric tabs over a comparative chart. The date
  * range and comparison state come from the dashboard via `reportParams`; the
  * `granularity` attribute (`relevance: 'high'`) chooses the bucket size within
- * that range, the `metrics` attribute selects which tabs render, and
- * `chartType` switches between lines and bars.
+ * that range, and `chartType` switches between lines and bars. Which metric is
+ * plotted is the chart's own tab selection, not an attribute.
  * `example.attributes` doubles as the defaults applied to new instances.
  */
 export default {
@@ -118,17 +108,6 @@ export default {
 			relevance: 'high',
 		},
 		{
-			id: 'metrics',
-			label: __( 'Metrics', 'jetpack-premium-analytics-pkg' ),
-			type: 'array',
-			relevance: 'high',
-			Edit: ArrayCheckboxField,
-			elements: TRAFFIC_CHART_METRICS.map( metric => ( {
-				value: metric.id,
-				label: metric.label,
-			} ) ),
-		},
-		{
 			id: 'chartType',
 			label: __( 'Chart type', 'jetpack-premium-analytics-pkg' ),
 			type: 'text',
@@ -143,7 +122,6 @@ export default {
 	example: {
 		attributes: {
 			granularity: 'auto',
-			metrics: DEFAULT_TRAFFIC_CHART_METRICS,
 			chartType: 'line',
 		},
 	},

--- a/projects/packages/premium-analytics/widgets/traffic-chart/widget.ts
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/widget.ts
@@ -37,9 +37,8 @@ export const TRAFFIC_CHART_TYPES = [
 export type TrafficChartType = ( typeof TRAFFIC_CHART_TYPES )[ number ][ 'id' ];
 
 /**
- * The metric tabs the chart shows, in display order: the persisted id and
- * label of each metric. The id doubles as the visits `stat_fields` field the
- * tab reads.
+ * The metric tabs the chart shows, in display order: the id and label of each
+ * metric. The id doubles as the visits `stat_fields` field the tab reads.
  */
 export const TRAFFIC_CHART_METRICS = [
 	{ id: 'views', label: __( 'Views', 'jetpack-premium-analytics-pkg' ) },
@@ -47,11 +46,6 @@ export const TRAFFIC_CHART_METRICS = [
 	{ id: 'likes', label: __( 'Likes', 'jetpack-premium-analytics-pkg' ) },
 	{ id: 'comments', label: __( 'Comments', 'jetpack-premium-analytics-pkg' ) },
 ] as const satisfies readonly { id: string; label: string }[];
-
-/**
- * Identifier of one metric tab.
- */
-export type TrafficChartMetricId = ( typeof TRAFFIC_CHART_METRICS )[ number ][ 'id' ];
 
 /**
  * Configurable attributes for the Traffic chart widget. Report params still

--- a/projects/packages/premium-analytics/widgets/wordads-chart-tabs/__tests__/wordads-chart-tabs.test.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-chart-tabs/__tests__/wordads-chart-tabs.test.tsx
@@ -81,42 +81,6 @@ describe( 'useWordAdsChart', () => {
 		expect( result.current.isEmpty ).toBe( false );
 	} );
 
-	it( 'shows only the selected metrics, in canonical order', async () => {
-		const reportParams: ReportParams = {
-			from: '2026-05-01',
-			to: '2026-06-30',
-			interval: 'month',
-		};
-
-		// Pass the ids out of canonical order to prove the tab order is resolved
-		// against the definitions, not the selection order.
-		const { result } = renderHook(
-			() => useWordAdsChart( reportParams, 'month', [ 'revenue', 'impressions' ] ),
-			{ wrapper }
-		);
-
-		await waitFor( () => expect( result.current.isFetching ).toBe( false ) );
-
-		expect( result.current.metrics.map( metric => metric.key ) ).toEqual( [
-			'impressions',
-			'revenue',
-		] );
-	} );
-
-	it( 'yields no metric tabs when the selection is empty', async () => {
-		const reportParams: ReportParams = {
-			from: '2026-05-01',
-			to: '2026-06-30',
-			interval: 'month',
-		};
-
-		const { result } = renderHook( () => useWordAdsChart( reportParams, 'month', [] ), {
-			wrapper,
-		} );
-
-		expect( result.current.metrics ).toHaveLength( 0 );
-	} );
-
 	it( 'requests the wordads/stats endpoint honouring the range and granularity', async () => {
 		const reportParams: ReportParams = {
 			from: '2026-05-01',

--- a/projects/packages/premium-analytics/widgets/wordads-chart-tabs/metrics.ts
+++ b/projects/packages/premium-analytics/widgets/wordads-chart-tabs/metrics.ts
@@ -7,8 +7,7 @@ import { __ } from '@wordpress/i18n';
  */
 import type { DataFormat } from '@jetpack-premium-analytics/widgets-toolkit';
 
-// Persisted in the `metrics` attribute; each id doubles as the WordAds response
-// field the tab reads.
+// Each id doubles as the WordAds response field the tab reads.
 export type WordAdsChartMetricId = 'impressions' | 'cpm' | 'revenue';
 
 export type WordAdsChartMetric = {
@@ -23,7 +22,7 @@ const CURRENCY_FORMAT: DataFormat = {
 	options: { decimals: 2 },
 };
 
-// Single source for the settings checkboxes and the rendered tabs, in tab order.
+// Canonical metric definitions, in tab order.
 export const WORDADS_CHART_METRICS: WordAdsChartMetric[] = [
 	{ id: 'impressions', label: __( 'Ads Served', 'jetpack-premium-analytics-pkg' ) },
 	{
@@ -37,8 +36,3 @@ export const WORDADS_CHART_METRICS: WordAdsChartMetric[] = [
 		dataFormat: CURRENCY_FORMAT,
 	},
 ];
-
-// Default for new widget instances: every metric enabled.
-export const DEFAULT_WORDADS_CHART_METRICS: WordAdsChartMetricId[] = WORDADS_CHART_METRICS.map(
-	metric => metric.id
-);

--- a/projects/packages/premium-analytics/widgets/wordads-chart-tabs/render.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-chart-tabs/render.tsx
@@ -14,7 +14,6 @@ import { __ } from '@wordpress/i18n';
 /**
  * Internal dependencies
  */
-import { type WordAdsChartMetricId } from './metrics';
 import styles from './style.module.css';
 import useWordAdsChart, { type WordAdsPeriod } from './use-wordads-chart';
 import type { WordAdsChartTabsAttributes, WordAdsChartTabsGranularity } from './widget';
@@ -43,18 +42,14 @@ type WordAdsChartTabsInnerProps = {
 	 * Selected granularity; `auto` follows the dashboard range.
 	 */
 	granularity: WordAdsChartTabsGranularity;
-	/**
-	 * WordAds metrics to show as tabs; `undefined` shows all.
-	 */
-	metricIds?: WordAdsChartMetricId[];
 };
 
 /**
- * The "Group by" control is the `granularity` attribute and the tab set is the
- * `metrics` attribute (both `relevance: 'high'`), rendered by the widget host;
- * granularity only chooses the bucket size within the dashboard range.
+ * The "Group by" control is the `granularity` attribute (`relevance: 'high'`),
+ * rendered by the widget host; it only chooses the bucket size within the
+ * dashboard range. Which metric is plotted is the chart's own tab selection.
  */
-function WordAdsChartTabsInner( { granularity, metricIds }: WordAdsChartTabsInnerProps ) {
+function WordAdsChartTabsInner( { granularity }: WordAdsChartTabsInnerProps ) {
 	const { reportParams } = useWidgetRootContext();
 	// `auto` means "follow the dashboard range"; an explicit value sticks
 	// across range changes, so a wide range doesn't stay stuck on `day`
@@ -67,20 +62,16 @@ function WordAdsChartTabsInner( { granularity, metricIds }: WordAdsChartTabsInne
 
 	const { metrics, isLoading, isFetching, isError, isEmpty, refetch } = useWordAdsChart(
 		reportParams,
-		period,
-		metricIds
+		period
 	);
-
-	// No metric selected: skip the data-driven states and show a distinct empty state.
-	const noMetricSelected = metrics.length === 0;
 
 	return (
 		<div className={ styles.root }>
 			<WidgetState
-				isLoading={ noMetricSelected ? false : isLoading }
-				isFetching={ noMetricSelected ? false : isFetching }
-				isError={ noMetricSelected ? false : isError }
-				isEmpty={ noMetricSelected || isEmpty }
+				isLoading={ isLoading }
+				isFetching={ isFetching }
+				isError={ isError }
+				isEmpty={ isEmpty }
 				error={ {
 					description: __(
 						"We couldn't load WordAds data. Please try again in a moment.",
@@ -90,9 +81,7 @@ function WordAdsChartTabsInner( { granularity, metricIds }: WordAdsChartTabsInne
 				} }
 				empty={ {
 					icon: megaphone,
-					description: noMetricSelected
-						? __( 'Select at least one metric to display.', 'jetpack-premium-analytics-pkg' )
-						: __( 'No WordAds data in this period.', 'jetpack-premium-analytics-pkg' ),
+					description: __( 'No WordAds data in this period.', 'jetpack-premium-analytics-pkg' ),
 				} }
 			>
 				<MetricTabsChart
@@ -110,7 +99,7 @@ export default function WordAdsChartTabs( { attributes = {} }: WordAdsChartTabsW
 
 	return (
 		<WidgetRoot attributes={ attributes } options={ { from: '/' } }>
-			<WordAdsChartTabsInner granularity={ granularity } metricIds={ attributes.metrics } />
+			<WordAdsChartTabsInner granularity={ granularity } />
 		</WidgetRoot>
 	);
 }

--- a/projects/packages/premium-analytics/widgets/wordads-chart-tabs/stories/wordads-chart-tabs-widget.stories.tsx
+++ b/projects/packages/premium-analytics/widgets/wordads-chart-tabs/stories/wordads-chart-tabs-widget.stories.tsx
@@ -14,7 +14,6 @@ import {
 } from '../../../packages/widgets-toolkit/src/stories/mocks/register-report-mocks';
 import { createStoryWidgetType } from '../../stories/create-story-widget-type';
 import { withWidgetCanvas } from '../../stories/with-widget-canvas';
-import { DEFAULT_WORDADS_CHART_METRICS, type WordAdsChartMetricId } from '../metrics';
 import WordAdsChartTabsRender from '../render';
 import widgetDefinition from '../widget';
 import widgetManifest from '../widget.json';
@@ -28,27 +27,12 @@ const WORDADS_CHART_TABS_RENDER_MODULE = 'storybook/wordads-chart-tabs';
 
 interface WordAdsChartTabsStoryControls {
 	withComparison: boolean;
-	/**
-	 * WordAds metrics to show as selectable tabs.
-	 */
-	metrics: WordAdsChartMetricId[];
 }
 
-const METRIC_ARG_TYPES = {
-	metrics: {
-		control: 'check',
-		options: DEFAULT_WORDADS_CHART_METRICS,
-	},
-} as const;
-
-const ALL_METRICS_ARGS = {
-	metrics: DEFAULT_WORDADS_CHART_METRICS,
-} as const;
-
-function renderWordAdsChartTabs( { withComparison, metrics }: WordAdsChartTabsStoryControls ) {
+function renderWordAdsChartTabs( { withComparison }: WordAdsChartTabsStoryControls ) {
 	return (
 		<WordAdsChartTabsRender
-			attributes={ { reportParams: getDefaultQueryParams( withComparison ), metrics } }
+			attributes={ { reportParams: getDefaultQueryParams( withComparison ) } }
 		/>
 	);
 }
@@ -68,13 +52,12 @@ const meta = {
 	tags: [ 'autodocs' ],
 	argTypes: {
 		withComparison: { control: 'boolean' },
-		...METRIC_ARG_TYPES,
 	},
 	parameters: {
 		docs: {
 			description: {
 				component:
-					"WordAds performance over the selected period as selectable metric tabs — Ads Served, Average CPM, and Revenue, matching the Calypso WordAds page's tabs — over a comparative line chart. Ads Served is a count; CPM and revenue are currency (WordAds pays USD). The date range and comparison come from the dashboard controls; the \"Group by\" control is the `granularity` attribute and the visible tabs are the `metrics` attribute (both `relevance: 'high'`), exposed by the widget host. WordAds stats are computed nightly, so a range ending today is clamped to end at yesterday. When comparison is on the previous period is overlaid as a same-colour dashed line and each tab shows its period-over-period delta. Data comes from the `useStatsWordAdsStats` hook (the `wordads` proxy prefix); in Storybook it is served by `registerReportMocks`. Requires WordAds to be active on the site for live data.",
+					"WordAds performance over the selected period as selectable metric tabs — Ads Served, Average CPM, and Revenue, matching the Calypso WordAds page's tabs — over a comparative line chart. Ads Served is a count; CPM and revenue are currency (WordAds pays USD). The date range and comparison come from the dashboard controls; the \"Group by\" control is the `granularity` attribute (`relevance: 'high'`), exposed by the widget host; which metric is plotted is the chart's own tab selection. WordAds stats are computed nightly, so a range ending today is clamped to end at yesterday. When comparison is on the previous period is overlaid as a same-colour dashed line and each tab shows its period-over-period delta. Data comes from the `useStatsWordAdsStats` hook (the `wordads` proxy prefix); in Storybook it is served by `registerReportMocks`. Requires WordAds to be active on the site for live data.",
 			},
 		},
 	},
@@ -89,7 +72,7 @@ type Story = StoryObj< WordAdsChartTabsStoryControls >;
  */
 export const Default: Story = {
 	render: renderWordAdsChartTabs,
-	args: { withComparison: false, ...ALL_METRICS_ARGS },
+	args: { withComparison: false },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -98,7 +81,7 @@ export const Default: Story = {
  */
 export const WithComparison: Story = {
 	render: renderWordAdsChartTabs,
-	args: { withComparison: true, ...ALL_METRICS_ARGS },
+	args: { withComparison: true },
 	decorators: [ withWidgetCanvas ],
 };
 
@@ -151,7 +134,6 @@ interface WordAdsChartTabsDashboardStoryProps
 
 function WordAdsChartTabsDashboardStory( {
 	withComparison,
-	metrics,
 	...dashboardArgs
 }: WordAdsChartTabsDashboardStoryProps ) {
 	return (
@@ -160,7 +142,7 @@ function WordAdsChartTabsDashboardStory( {
 			widgetType={ createStoryWidgetType( widgetManifest, widgetDefinition ) }
 			renderModule={ WORDADS_CHART_TABS_RENDER_MODULE }
 			renderComponent={ WordAdsChartTabsRender as ComponentType< WidgetRenderProps< unknown > > }
-			attributes={ { reportParams: getDefaultQueryParams( withComparison ), metrics } }
+			attributes={ { reportParams: getDefaultQueryParams( withComparison ) } }
 		/>
 	);
 }
@@ -173,11 +155,9 @@ export const WidgetDashboardWithWidget: StoryObj< WordAdsChartTabsDashboardStory
 	args: {
 		...DEFAULT_WIDGET_DASHBOARD_STORY_ARGS,
 		withComparison: true,
-		...ALL_METRICS_ARGS,
 	},
 	argTypes: {
 		...widgetDashboardWithWidgetArgTypes,
 		withComparison: { control: 'boolean' },
-		...METRIC_ARG_TYPES,
 	},
 };

--- a/projects/packages/premium-analytics/widgets/wordads-chart-tabs/use-wordads-chart.ts
+++ b/projects/packages/premium-analytics/widgets/wordads-chart-tabs/use-wordads-chart.ts
@@ -13,11 +13,7 @@ import { useMemo } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import {
-	DEFAULT_WORDADS_CHART_METRICS,
-	WORDADS_CHART_METRICS,
-	type WordAdsChartMetricId,
-} from './metrics';
+import { WORDADS_CHART_METRICS } from './metrics';
 import { buildMetricTab, type MetricTab } from '@jetpack-premium-analytics/widgets-toolkit';
 
 /**
@@ -54,17 +50,15 @@ function toWordAdsParams( reportParams: ReportParams, period: WordAdsPeriod ): S
 
 /**
  * Fetch the WordAds time series for the dashboard's report params and expose one
- * metric tab per selected WordAds field — Ads Served (impressions), Average CPM,
- * and Revenue, matching the Calypso WordAds page's tab labels and order. Ads
- * Served is a count; CPM and revenue are currency. The endpoint returns all
- * three fields in a single request, so — unlike the traffic chart's split
- * requests — one `useStatsWordAdsStats` call drives every tab; the `metricIds`
- * selection only picks which of those tabs render.
+ * metric tab per WordAds field — Ads Served (impressions), Average CPM, and
+ * Revenue, matching the Calypso WordAds page's tab labels and order. Ads Served
+ * is a count; CPM and revenue are currency. The endpoint returns all three
+ * fields in a single request, so — unlike the traffic chart's split requests —
+ * one `useStatsWordAdsStats` call drives every tab.
  */
 export default function useWordAdsChart(
 	reportParams: ReportParams,
-	period: WordAdsPeriod,
-	metricIds: WordAdsChartMetricId[] = DEFAULT_WORDADS_CHART_METRICS
+	period: WordAdsPeriod
 ): WordAdsChartState {
 	// Memoize the request params so the query key is stable across renders.
 	const params = useMemo( () => toWordAdsParams( reportParams, period ), [ reportParams, period ] );
@@ -88,16 +82,9 @@ export default function useWordAdsChart(
 		[ primaryData, rawComparisonData ]
 	);
 
-	// Resolve selected ids against the canonical definitions so the tab order
-	// stays stable regardless of the order the ids were toggled in.
-	const enabledMetrics = useMemo( () => {
-		const selected = new Set( metricIds );
-		return WORDADS_CHART_METRICS.filter( metric => selected.has( metric.id ) );
-	}, [ metricIds ] );
-
 	const metrics = useMemo(
 		() =>
-			enabledMetrics.map( metric =>
+			WORDADS_CHART_METRICS.map( metric =>
 				buildMetricTab( {
 					primary: primaryData,
 					comparison: comparisonData,
@@ -107,7 +94,7 @@ export default function useWordAdsChart(
 					dataFormat: metric.dataFormat,
 				} )
 			),
-		[ enabledMetrics, primaryData, comparisonData, hasComparison ]
+		[ primaryData, comparisonData, hasComparison ]
 	);
 
 	return {

--- a/projects/packages/premium-analytics/widgets/wordads-chart-tabs/widget.ts
+++ b/projects/packages/premium-analytics/widgets/wordads-chart-tabs/widget.ts
@@ -8,13 +8,7 @@ import type { WidgetAttributeField } from '@wordpress/widget-primitives';
 /**
  * Internal dependencies
  */
-import { ArrayCheckboxField, SelectField } from '@jetpack-premium-analytics/fields';
-import {
-	DEFAULT_WORDADS_CHART_METRICS,
-	WORDADS_CHART_METRICS,
-	type WordAdsChartMetricId,
-} from './metrics';
-
+import { SelectField } from '@jetpack-premium-analytics/fields';
 /**
  * Granularity the chart can be grouped by. `auto` follows the dashboard date
  * range (a wide range buckets by month, a narrow one by day); an explicit
@@ -29,11 +23,9 @@ export type WordAdsChartTabsGranularity = 'auto' | 'day' | 'week' | 'month' | 'y
  * dashboard previews).
  *
  * @property granularity - Bucket size within the dashboard range. Defaults to `auto`.
- * @property metrics     - WordAds metrics to show as selectable tabs. Defaults to all.
  */
 export type WordAdsChartTabsAttributes = {
 	granularity?: WordAdsChartTabsGranularity;
-	metrics?: WordAdsChartMetricId[];
 };
 
 /**
@@ -45,10 +37,9 @@ export type WordAdsChartTabsAttributes = {
  * labels and order — over a comparative line chart. The date range and
  * comparison state come from the dashboard via `reportParams`; the
  * `granularity` attribute (`relevance: 'high'`) chooses the bucket size within
- * that range, and the `metrics` attribute (`relevance: 'high'`) selects which
- * metrics render as tabs (`example.attributes` doubles as the defaults applied
- * to new instances: every metric enabled). Requires WordAds to be active on the
- * site.
+ * that range (`example.attributes` doubles as the defaults applied to new
+ * instances). Which metric is plotted is the chart's own tab selection.
+ * Requires WordAds to be active on the site.
  */
 export default {
 	icon: chartBar,
@@ -82,22 +73,10 @@ export default {
 			],
 			relevance: 'high',
 		},
-		{
-			id: 'metrics',
-			label: __( 'Metrics', 'jetpack-premium-analytics-pkg' ),
-			type: 'array',
-			relevance: 'high',
-			Edit: ArrayCheckboxField,
-			elements: WORDADS_CHART_METRICS.map( metric => ( {
-				value: metric.id,
-				label: metric.label,
-			} ) ),
-		},
 	] as WidgetAttributeField< WordAdsChartTabsAttributes >[],
 	example: {
 		attributes: {
 			granularity: 'auto',
-			metrics: DEFAULT_WORDADS_CHART_METRICS,
 		},
 	},
 };

--- a/projects/packages/premium-analytics/widgets/wordads-chart-tabs/widget.ts
+++ b/projects/packages/premium-analytics/widgets/wordads-chart-tabs/widget.ts
@@ -9,6 +9,7 @@ import type { WidgetAttributeField } from '@wordpress/widget-primitives';
  * Internal dependencies
  */
 import { SelectField } from '@jetpack-premium-analytics/fields';
+
 /**
  * Granularity the chart can be grouped by. `auto` follows the dashboard date
  * range (a wide range buckets by month, a narrow one by day); an explicit


### PR DESCRIPTION
## Proposed changes

- Remove the "Metrics" multi-select from the four widgets built on `MetricTabsChart`: Traffic summary, Subscribers summary, WordAds, and Store performance. The metric tabs already choose what the chart plots, so a second control labelled "Metrics" read as the graph selector while it only toggled which tabs exist — and de-selecting everything hid the chart entirely.
- Drop the empty states that only a zero-metric selection could reach, including the "Select at least one metric to display." one reported as firing when everything was already selected.
- Requests that were skipped for an unselected metric now always run. No change in practice: the default all-metrics state already ran them all.
- Store performance had no other attribute, so it becomes a zero-attribute widget.

The tile-based widgets (Site overview, Highlights, All-time stats) keep their `metrics` dropdown — there it is the only control deciding what renders, so it competes with nothing.

## Related product discussion/links

- WOOA7S-1891

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- In Storybook, open the `WidgetDashboardWithWidget` story for TrafficChart, SubscribersChart, WordAdsChartTabs, and StorePerformance.
- Confirm no "Metrics" dropdown in the widget header. Traffic summary and Subscribers summary keep "Group by" and "Chart type"; WordAds keeps "Group by"; Store performance has no attribute controls.
- Confirm the metric tabs still switch what the chart plots, and still collapse into the single-select at narrow widths.
- On the dashboard, open a widget's settings drawer and confirm "Metrics" is gone while the other settings still apply.
