### PR TITLE
Premium Analytics: improve axis label legibility and add Devices chart tooltips

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1893-stats-v2-a11y-chart-labels-devices
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1893-stats-v2-a11y-chart-labels-devices
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Darken and enlarge chart axis labels, and show a tooltip when hovering a Devices chart segment.

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/use-chart-theme.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/use-chart-theme.ts
@@ -38,8 +38,11 @@ export function useChartTheme(): WooChartTheme {
 			tickLength: 4,
 			gridColor: '',
 			gridColorDark: '',
-			// visx's buildChartTheme defaults svgLabelSmall to fontSize 11 and nothing else sets it,
-			// so this override is load-bearing rather than a restatement of a browser default.
+			// Both overrides are load-bearing. `fill` restates the charts default, which cannot
+			// resolve until CHARTS-203 emits --a8c-charts-color-label: the default nests its
+			// var() fallbacks and resolveCssVariable() parses only one level. `fontSize` has to
+			// stay a plain number, since resolveFontSize() rejects var(); without it visx falls
+			// back to 11 and the chart margin and pie label measurements go with it.
 			svgLabelSmall: {
 				fill: 'var(--wpds-color-foreground-content-neutral)',
 				fontSize: 12,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/use-chart-theme.ts
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/hooks/use-chart-theme.ts
@@ -38,8 +38,11 @@ export function useChartTheme(): WooChartTheme {
 			tickLength: 4,
 			gridColor: '',
 			gridColorDark: '',
+			// visx's buildChartTheme defaults svgLabelSmall to fontSize 11 and nothing else sets it,
+			// so this override is load-bearing rather than a restatement of a browser default.
 			svgLabelSmall: {
-				fill: 'var(--wpds-color-foreground-content-neutral-weak)',
+				fill: 'var(--wpds-color-foreground-content-neutral)',
+				fontSize: 12,
 			},
 			xTickLineStyles: { stroke: '' },
 			xAxisLineStyles: {

--- a/projects/packages/premium-analytics/widgets/devices/render.tsx
+++ b/projects/packages/premium-analytics/widgets/devices/render.tsx
@@ -108,6 +108,7 @@ function DevicesInner( { max }: DevicesInnerProps ) {
 							styles={ segmentStyles }
 							showLegend={ false }
 							showMetric={ false }
+							withTooltips
 							dataFormat={ PERCENTAGE_DATA_FORMAT }
 						/>
 						<Legend items={ styledLegendData } withComparison={ hasComparison } />


### PR DESCRIPTION
Fixes WOOA7S-1893

## Proposed changes

- Darken chart axis labels from `--wpds-color-foreground-content-neutral-weak` (`#707070`) to `--wpds-color-foreground-content-neutral` (`#1e1e1e`), and set `svgLabelSmall.fontSize` to 12.
- Show a tooltip when hovering a segment of the Devices chart.

Both come from Stats v2 beta feedback. The axis labels were reported as "light gray on white", but `#707070` on `#fff` is 4.95:1 and passes AA — the actual cause is that `svgLabelSmall` carried visx's `buildChartTheme` defaults for everything except `fill`, including `fontSize: 11` and `fontWeight: 200`, and WCAG measures neither size nor stroke weight. Weight is deliberately left at 200 for now; if the report recurs, that is the first thing to revisit. Separately, Devices was the only one of seven pie/donut widgets not passing `withTooltips`, leaving its segments distinguishable by colour alone with no hover affordance.

## Related product discussion/links

- WOOA7S-1893

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Axis labels affect every chart with axes; the Devices change affects one widget.

**Devices tooltip**

- Run Storybook and open **Packages / Premium Analytics / Widgets / Devices → Default**.
- Hover a segment of the half-donut. A tooltip should appear naming the segment and its share, e.g. "Desktop 57.8%".
- Before this change, hovering did nothing.
- Note the tooltip is portalled and can extend past the widget card edge. That is pre-existing behaviour shared with the other pie/donut widgets, not introduced here.

**Axis labels**

- Open any widget that renders a chart with axes and compare against trunk.
- Axis tick text should be `#1e1e1e` at 12px, previously `#707070` at 11px.
- To assert it rather than eyeball it, the colour is written by visx as an SVG presentation attribute rather than a CSS rule, so check the computed value:

```js
getComputedStyle(document.querySelector("svg .visx-axis-tick text")).fill; // rgb(30, 30, 30)
getComputedStyle(document.querySelector("svg .visx-axis-tick text")).fontSize; // 12px
```

