### PR TITLE
Jetpack AI: WordPress Agent capabilities card updates

### DIFF
--- a/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/index.jsx
@@ -1,6 +1,7 @@
 /**
  * AI Features view — per-feature toggles for Jetpack AI, grouped by area
- * (Content, Media, SEO, Search) per the AI-Settings design.
+ * (Content, Media, SEO, Search) inside a single "Agent capabilities" card
+ * per the AI-Settings design.
  *
  * Each feature has its own on/off switch, backed by the feature-settings
  * endpoint. A disabled feature must genuinely stop loading (its assets are
@@ -9,7 +10,7 @@
 
 import { getRedirectUrl } from '@automattic/jetpack-components';
 import { ToggleControl } from '@wordpress/components';
-import { useCallback } from '@wordpress/element';
+import { Fragment, useCallback } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { Badge, Card, Link, Notice, Popover, Stack, Text, VisuallyHidden } from '@wordpress/ui';
 import analytics from 'lib/analytics';
@@ -310,46 +311,72 @@ export default function AiFeatures( { settings, savingKeys, onUpdate } ) {
 					</Notice.Description>
 				</Notice.Root>
 			) }
-			{ sections.map( section => (
-				<Card.Root key={ section.key }>
-					<Card.Content>
-						<Stack direction="column" gap="md">
-							<div className="jetpack-ai-features__section-header">
-								<Text as="h3" weight="600">
-									{ section.title }
-								</Text>
-								{ isConnected &&
-									section.features.some( f => features[ f.key ]?.requires_upgrade ) && (
-										<Popover.Root>
-											{ /* A popover rather than a tooltip: click opens it, touch
-											     works, and screen readers announce the remedy copy —
-											     the shape agreed with design on the PR. The trigger's
-											     accessible name is its visible badge text. */ }
-											<Popover.Trigger
-												openOnHover
-												delay={ 200 }
-												closeDelay={ 200 }
-												className="jetpack-ai-features__upgrade-badge"
-											>
-												<Badge intent="informational">
-													{ __( 'Requires upgrade', 'jetpack' ) }
-												</Badge>
-											</Popover.Trigger>
-											<Popover.Popup>
-												<Popover.Arrow />
-												<VisuallyHidden render={ <Popover.Title /> }>
-													{ __( 'Requires upgrade', 'jetpack' ) }
-												</VisuallyHidden>
-												<Popover.Description>{ upgradeBadgeTooltip }</Popover.Description>
-											</Popover.Popup>
-										</Popover.Root>
-									) }
-							</div>
-							{ section.features.map( feature => renderRow( feature ) ) }
+			{ sections.length > 0 && (
+				<Card.Root className="jetpack-ai-features__card">
+					{ /* Single Card.Content, no Card.Header: the FullBleed dividers —
+					     including the one under the header — must stay direct children
+					     of Card.Content per the component's contract. */ }
+					<Card.Content className="jetpack-ai-features__card-content">
+						<Stack direction="column" gap="sm">
+							<Card.Title render={ <h2 /> }>{ __( 'Agent capabilities', 'jetpack' ) }</Card.Title>
+							<Text variant="body-sm" className="jetpack-ai-features__card-subtitle">
+								{ __(
+									'Choose what your WordPress Agent can help with across your site.',
+									'jetpack'
+								) }
+							</Text>
 						</Stack>
+						{ sections.map( section => {
+							const titleId = `jetpack-ai-features-${ section.key }-title`;
+							return (
+								<Fragment key={ section.key }>
+									<Card.FullBleed render={ <hr /> } className="jetpack-ai-features__divider" />
+									{ /* Labelled by its heading so each group is a named region —
+									     screen readers can jump between them inside the merged card. */ }
+									<Stack
+										direction="column"
+										gap="2xl"
+										render={ <section aria-labelledby={ titleId } /> }
+									>
+										<div className="jetpack-ai-features__section-header">
+											<Text variant="heading-lg" render={ <h3 id={ titleId } /> }>
+												{ section.title }
+											</Text>
+											{ isConnected &&
+												section.features.some( f => features[ f.key ]?.requires_upgrade ) && (
+													<Popover.Root>
+														{ /* A popover rather than a tooltip: click opens it, touch
+													     works, and screen readers announce the remedy copy —
+													     the shape agreed with design on the PR. The trigger's
+													     accessible name is its visible badge text. */ }
+														<Popover.Trigger
+															openOnHover
+															delay={ 200 }
+															closeDelay={ 200 }
+															className="jetpack-ai-features__upgrade-badge"
+														>
+															<Badge intent="informational">
+																{ __( 'Requires upgrade', 'jetpack' ) }
+															</Badge>
+														</Popover.Trigger>
+														<Popover.Popup>
+															<Popover.Arrow />
+															<VisuallyHidden render={ <Popover.Title /> }>
+																{ __( 'Requires upgrade', 'jetpack' ) }
+															</VisuallyHidden>
+															<Popover.Description>{ upgradeBadgeTooltip }</Popover.Description>
+														</Popover.Popup>
+													</Popover.Root>
+												) }
+										</div>
+										{ section.features.map( feature => renderRow( feature ) ) }
+									</Stack>
+								</Fragment>
+							);
+						} ) }
 					</Card.Content>
 				</Card.Root>
-			) ) }
+			) }
 		</Stack>
 	);
 }

--- a/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
+++ b/projects/plugins/jetpack/_inc/client/ai/features/test/component.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import analytics from 'lib/analytics';
 import AiFeatures from '../index';
@@ -33,6 +33,78 @@ describe( 'AiFeatures rendering', () => {
 		expect( toggle ).toBeChecked();
 		expect( toggle ).toBeEnabled();
 		expect( screen.getByText( 'Try it out in the editor' ) ).toBeInTheDocument();
+	} );
+
+	test( 'renders one Agent capabilities card with title and subtitle', () => {
+		renderFeatures();
+
+		expect(
+			screen.getByRole( 'heading', { level: 2, name: 'Agent capabilities' } )
+		).toBeInTheDocument();
+		expect(
+			screen.getByText( 'Choose what your WordPress Agent can help with across your site.' )
+		).toBeInTheDocument();
+	} );
+
+	// One divider per visible section — the first doubles as the header rule
+	// per the Figma — and the group headers are real h3s, one level below the
+	// card's h2 (the page title "AI" is the h1 above both).
+	test.each( [
+		[ 'one section', { writing_assistant: { enabled: true } }, [ 'Content' ] ],
+		[ 'two sections', null, [ 'Content', 'Search' ] ],
+		[
+			'three sections',
+			{
+				writing_assistant: { enabled: true },
+				image_editor: { enabled: true },
+				ai_search: { enabled: false, requires_upgrade: true },
+			},
+			[ 'Content', 'Media', 'Search' ],
+		],
+	] )( '%s: one divider per section, h3 group headers in order', ( _label, features, titles ) => {
+		renderFeatures( features ? { features } : {} );
+
+		expect( screen.getAllByRole( 'separator' ) ).toHaveLength( titles.length );
+		const headings = screen.getAllByRole( 'heading', { level: 3 } );
+		expect( headings.map( heading => heading.textContent ) ).toEqual( titles );
+	} );
+
+	test( 'no reported features: no empty card shell', () => {
+		// Everything else healthy — the empty payload alone must suppress the card.
+		renderFeatures( { features: {} } );
+
+		expect(
+			screen.queryByRole( 'heading', { name: 'Agent capabilities' } )
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByText( 'Choose what your WordPress Agent can help with across your site.' )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'the page notices survive the card disappearing', () => {
+		renderFeatures( { master_enabled: false, features: {} } );
+
+		// The notices live outside the card and must not go down with it.
+		expect( screen.getByText( 'Jetpack AI is turned off for this site.' ) ).toBeInTheDocument();
+		expect(
+			screen.queryByRole( 'heading', { name: 'Agent capabilities' } )
+		).not.toBeInTheDocument();
+	} );
+
+	test( 'the upgrade badge sits inside the Search group', () => {
+		renderFeatures();
+
+		// Each group is a region named by its h3, so the badge's placement is
+		// part of the accessibility tree, not just visual layout.
+		const searchGroup = screen.getByRole( 'region', { name: 'Search' } );
+		expect(
+			within( searchGroup ).getByRole( 'button', { name: 'Requires upgrade' } )
+		).toBeInTheDocument();
+		expect(
+			within( screen.getByRole( 'region', { name: 'Content' } ) ).queryByRole( 'button', {
+				name: 'Requires upgrade',
+			} )
+		).not.toBeInTheDocument();
 	} );
 
 	test( 'requires_upgrade: badge shown, toggle disabled but visible, Learn more kept', () => {

--- a/projects/plugins/jetpack/_inc/client/ai/style.scss
+++ b/projects/plugins/jetpack/_inc/client/ai/style.scss
@@ -94,8 +94,45 @@ body.jetpack_page_jetpack-ai {
 	margin-inline-start: 40px;
 }
 
+// The Agent capabilities card, values read off the Figma (AI-Settings
+// node 6021-4152): 20px card padding with 24px above the title. The
+// Card.FullBleed dividers inherit the same padding var for their
+// edge-to-edge negative margins, so they stay in sync.
+.jetpack-ai-features__card {
+	--wp-ui-card-padding: var(--wpds-dimension-padding-xl, 20px);
+}
+
+.jetpack-ai-features__card-content {
+	padding-block-start: var(--wpds-dimension-padding-2xl, 24px);
+}
+
+// Figma: Body SM in foreground/content/neutral-weak.
+.jetpack-ai-features__card-subtitle {
+	color: var(--wpds-color-foreground-content-neutral-weak, #707070);
+}
+
+// Section divider inside the Agent capabilities card. Card.FullBleed already
+// pulls the hr edge-to-edge past the card padding (margin-inline); this only
+// draws the rule and sets the vertical rhythm.
+.jetpack-ai-features__divider {
+	border: 0;
+	// Fallbacks match the token values — the theme token sheet is not loaded
+	// on this page, and two undefined vars would invalidate the whole
+	// shorthand (no rule drawn at all).
+	border-block-start:
+		var(--wpds-border-width-xs, 1px) solid
+		var(--wpds-color-stroke-surface-neutral, #dbdbdb);
+	// Figma rhythm: 20px after a section's rows, 16px before the next header;
+	// the first divider sits 16px under the card subtitle instead.
+	margin-block: var(--wpds-dimension-padding-xl, 20px) var(--wpds-dimension-padding-lg, 16px);
+
+	&:first-of-type {
+		margin-block-start: var(--wpds-dimension-padding-lg, 16px);
+	}
+}
+
 // Section header: title left, optional "Requires upgrade" badge right,
-// matching the Search card in the design.
+// matching the Search group in the design.
 .jetpack-ai-features__section-header {
 	display: flex;
 	align-items: center;

--- a/projects/plugins/jetpack/changelog/update-jetpack-ai-agent-capabilities-card
+++ b/projects/plugins/jetpack/changelog/update-jetpack-ai-agent-capabilities-card
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+AI Features: group the feature toggles into a single Agent capabilities card.


### PR DESCRIPTION
Fixes FORNO-467

## Proposed changes

This PR updates the WordPress Agent tab to group its four per-section cards  (Content / Media / SEO / Search) into a single "Agent capabilities" card, per the AI-Settings design (Figma node 6021-4152)
No behavior changes to the toggles, gating, notices, or `visibleSections()` filtering; no new tracked events;

### Before / after on the same WoA site (entitled plan, full card:

| | Before (trunk) | After (this PR) |
|---|---|---|
| **AI on** | ![before, AI on](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-agent-capabilities-card/before-ai-on.jpg) | ![after, AI on](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-agent-capabilities-card/after-ai-on.jpg) |
| **AI off** | ![before, AI off](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-agent-capabilities-card/before-ai-off.jpg) | ![after, AI off](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-agent-capabilities-card/after-ai-off.jpg) |

<details><summary>Free plan (Jurassic Ninja): SEO hidden, badge on Search</summary>

![free plan, badge on Search](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-agent-capabilities-card/after-agent-capabilities.jpg)

</details>

## Related product discussion/links

- One Hub for Jetpack AI – i4: p1HpG7-ym2-p2#comment-78357

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On a Jetpack-connected test site running this branch, go to **Jetpack → AI** (`wp-admin/admin.php?page=jetpack-ai`), WordPress Agent tab
* Check: groups should render only for features the endpoint reports as available - SEO needs the `seo-tools` module active and a plan with `ai-seo-enhancer`; on a free site the Search group header keeps its "Requires upgrade" badge.
* Go to My Jetpack -> Products (`wp-admin/admin.php?page=my-jetpack#/products`): turn the AI module off
* Go back to WordPress Agent tab: the notice renders above the card, toggles grey out keeping their saved values, links hide, layout intact (bottom row above).
* Headings/regions: the card title is an `h2`, group headers are `h3`s (page title "AI" is the only `h1`); each group is a named region for screen readers.
* Jest: `cd projects/plugins/jetpack && pnpm run test-gui` — the view's tests live in `_inc/client/ai/features/test/component.jsx`.

🤖 AI Assisted
