### PR TITLE
Jetpack AI: one gate for the SEO Enhancer

### DIFF
--- a/projects/packages/seo/changelog/add-ai-seo-enhancer-gate
+++ b/projects/packages/seo/changelog/add-ai-seo-enhancer-gate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add a shared gate for the AI SEO Enhancer's availability, so the surfaces that offer it can stop each deriving their own answer.

--- a/projects/packages/seo/src/class-ai-seo-enhancer.php
+++ b/projects/packages/seo/src/class-ai-seo-enhancer.php
@@ -1,19 +1,7 @@
 <?php
 /**
- * The AI SEO Enhancer's availability gate — the editor feature that
- * auto-generates SEO titles, meta descriptions and image alt text.
- *
- * Several surfaces each carried their own copy of this predicate and drifted
- * apart. The AI feature settings endpoint delegates here. Everything else still
- * resolves the enhancer itself for now: the SEO dashboard's AI tab, the AI
- * Assistant block's extension registration, the legacy settings endpoint, and
- * the AI sidebar's SEO suggestions, which asks a deliberately different
- * question (see below).
- *
- * This package owns the `ai_seo_enhancer_enabled` option and already depends on
- * jetpack-plans and jetpack-status, so the predicate lives here and the plugin
- * calls in. The dependency runs one way: this class must never reference a
- * plugin class such as Jetpack_AI_Settings.
+ * The AI SEO Enhancer's availability gate. This package owns the
+ * `ai_seo_enhancer_enabled` option, so the shared predicate lives here.
  *
  * @package automattic/jetpack-seo-package
  */
@@ -29,31 +17,10 @@ use Automattic\Jetpack\Modules;
 class AI_SEO_Enhancer {
 
 	/**
-	 * Whether the site can offer the enhancer at all, independent of the admin's
-	 * toggle: the `ai_seo_enhancer_enabled` filter (a host's outright veto), the
-	 * `seo-tools` module, `jetpack_disable_seo_tools`, and the plan.
-	 *
-	 * The module is required because the enhancer writes to the SEO title and
-	 * meta description fields that module registers. `Modules::is_active()`
-	 * returns true unconditionally under `IS_WPCOM`, so that term is inert on
-	 * WordPress.com Simple.
-	 *
-	 * `jetpack_disable_seo_tools` is how the seo-tools module cedes a site's SEO
-	 * to a conflicting plugin (Yoast, AIOSEO, Rank Math). Without it a settings
-	 * screen would offer a toggle for suggestions the editor then refuses to
-	 * make. The module registers that filter as it loads, so this only reads
-	 * true once modules are loaded — fine for this class's callers, which run on
-	 * `rest_api_init`.
-	 *
-	 * The plan slug is `ai-seo-enhancer` (Business and up). The AI sidebar's SEO
-	 * suggestions deliberately use a different slug, `advanced-seo` (free tier
-	 * off-WordPress.com), because those suggestions write into the plan-gated SEO
-	 * meta fields and so follow those fields' entitlement rather than the
-	 * enhancer's. The divergence is intentional — do not unify the two slugs.
-	 *
-	 * Deliberately excludes the AI master and host gates: callers own the outer
-	 * gate, as `Jetpack_AI_Settings::is_feature_enabled()` does for its own
-	 * features, and the package cannot reach that plugin class anyway.
+	 * Whether the site can offer the enhancer, independent of the admin's
+	 * toggle. Callers own the outer AI master and host gates. The AI sidebar's
+	 * SEO suggestions intentionally gate on a different plan slug
+	 * (`advanced-seo`) — do not unify the two.
 	 *
 	 * @since $$next-version$$
 	 *

--- a/projects/packages/seo/src/class-ai-seo-enhancer.php
+++ b/projects/packages/seo/src/class-ai-seo-enhancer.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * The AI SEO Enhancer's availability gate — the editor feature that
+ * auto-generates SEO titles, meta descriptions and image alt text.
+ *
+ * The AI feature settings endpoint and the SEO dashboard each carried their own
+ * copy of this predicate and drifted apart. Both now delegate here. Other
+ * surfaces still resolve the enhancer themselves: the AI Assistant block's
+ * extension registration, the legacy settings endpoint, and the AI sidebar's
+ * SEO suggestions, which asks a deliberately different question (see below).
+ *
+ * This package owns the `ai_seo_enhancer_enabled` option and already depends on
+ * jetpack-plans and jetpack-status, so the predicate lives here and the plugin
+ * calls in. The dependency runs one way: this class must never reference a
+ * plugin class such as Jetpack_AI_Settings.
+ *
+ * @package automattic/jetpack-seo-package
+ */
+
+namespace Automattic\Jetpack\SEO;
+
+use Automattic\Jetpack\Current_Plan;
+use Automattic\Jetpack\Modules;
+
+/**
+ * Whether the AI SEO Enhancer is offered, and whether it is switched on.
+ */
+class AI_SEO_Enhancer {
+
+	/**
+	 * The user-facing toggle, round-tripped through `/jetpack/v4/settings`.
+	 * Opt-in: absent means off.
+	 *
+	 * @var string
+	 */
+	const OPTION = 'ai_seo_enhancer_enabled';
+
+	/**
+	 * Whether the site can offer the enhancer at all, independent of the admin's
+	 * toggle: the `ai_seo_enhancer_enabled` filter (a host's outright veto), the
+	 * `seo-tools` module, `jetpack_disable_seo_tools`, and the plan.
+	 *
+	 * The module is required because the enhancer writes to the SEO title and
+	 * meta description fields that module registers. `Modules::is_active()`
+	 * returns true unconditionally under `IS_WPCOM`, so that term is inert on
+	 * WordPress.com Simple.
+	 *
+	 * `jetpack_disable_seo_tools` is how the seo-tools module cedes a site's SEO
+	 * to a conflicting plugin (Yoast, AIOSEO, Rank Math). Without it a settings
+	 * screen would offer a toggle for suggestions the editor then refuses to
+	 * make. The module registers that filter as it loads, so this only reads
+	 * true once modules are loaded — fine for this class's callers, which run on
+	 * `rest_api_init`.
+	 *
+	 * The plan slug is `ai-seo-enhancer` (Business and up). The AI sidebar's SEO
+	 * suggestions deliberately use a different slug, `advanced-seo` (free tier
+	 * off-WordPress.com), because those suggestions write into the plan-gated SEO
+	 * meta fields and so follow those fields' entitlement rather than the
+	 * enhancer's. The divergence is intentional — do not unify the two slugs.
+	 *
+	 * Deliberately excludes the AI master and host gates: callers own the outer
+	 * gate, as `Jetpack_AI_Settings::is_feature_enabled()` does for its own
+	 * features, and the package cannot reach that plugin class anyway.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return bool
+	 */
+	public static function is_available() {
+		/** This filter is documented in projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php */
+		if ( ! apply_filters( 'ai_seo_enhancer_enabled', true ) ) {
+			return false;
+		}
+
+		/** This filter is documented in projects/plugins/jetpack/modules/seo-tools/class-jetpack-seo-utils.php */
+		if ( apply_filters( 'jetpack_disable_seo_tools', false ) ) {
+			return false;
+		}
+
+		return ( new Modules() )->is_active( 'seo-tools' )
+			&& Current_Plan::supports( 'ai-seo-enhancer' );
+	}
+
+	/**
+	 * Whether the admin has switched the enhancer on. The raw stored toggle, with
+	 * no availability folded in, so a UI renders the switch where the admin left
+	 * it even while the feature is unavailable.
+	 *
+	 * Reads exactly what `Jetpack_AI_Settings::is_feature_enabled( 'seo_enhancer' )`
+	 * reads: `seo_enhancer` is not among that class's owned features, so its
+	 * WordPress.com Simple short-circuit does not apply and it falls through to
+	 * this same option and default.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return bool
+	 */
+	public static function is_toggled_on() {
+		return (bool) get_option( self::OPTION, false );
+	}
+}

--- a/projects/packages/seo/src/class-ai-seo-enhancer.php
+++ b/projects/packages/seo/src/class-ai-seo-enhancer.php
@@ -24,17 +24,9 @@ use Automattic\Jetpack\Current_Plan;
 use Automattic\Jetpack\Modules;
 
 /**
- * Whether the AI SEO Enhancer is offered, and whether it is switched on.
+ * Whether the AI SEO Enhancer is offered on this site.
  */
 class AI_SEO_Enhancer {
-
-	/**
-	 * The user-facing toggle, round-tripped through `/jetpack/v4/settings`.
-	 * Opt-in: absent means off.
-	 *
-	 * @var string
-	 */
-	const OPTION = 'ai_seo_enhancer_enabled';
 
 	/**
 	 * Whether the site can offer the enhancer at all, independent of the admin's
@@ -74,23 +66,5 @@ class AI_SEO_Enhancer {
 			&& ! apply_filters( 'jetpack_disable_seo_tools', false )
 			&& ( new Modules() )->is_active( 'seo-tools' )
 			&& Current_Plan::supports( 'ai-seo-enhancer' );
-	}
-
-	/**
-	 * Whether the admin has switched the enhancer on. The raw stored toggle, with
-	 * no availability folded in, so a UI renders the switch where the admin left
-	 * it even while the feature is unavailable.
-	 *
-	 * Reads exactly what `Jetpack_AI_Settings::is_feature_enabled( 'seo_enhancer' )`
-	 * reads: `seo_enhancer` is not among that class's owned features, so its
-	 * WordPress.com Simple short-circuit does not apply and it falls through to
-	 * this same option and default.
-	 *
-	 * @since $$next-version$$
-	 *
-	 * @return bool
-	 */
-	public static function is_toggled_on() {
-		return (bool) get_option( self::OPTION, false );
 	}
 }

--- a/projects/packages/seo/src/class-ai-seo-enhancer.php
+++ b/projects/packages/seo/src/class-ai-seo-enhancer.php
@@ -3,11 +3,12 @@
  * The AI SEO Enhancer's availability gate — the editor feature that
  * auto-generates SEO titles, meta descriptions and image alt text.
  *
- * The AI feature settings endpoint and the SEO dashboard each carried their own
- * copy of this predicate and drifted apart. Both now delegate here. Other
- * surfaces still resolve the enhancer themselves: the AI Assistant block's
- * extension registration, the legacy settings endpoint, and the AI sidebar's
- * SEO suggestions, which asks a deliberately different question (see below).
+ * Several surfaces each carried their own copy of this predicate and drifted
+ * apart. The AI feature settings endpoint delegates here. Everything else still
+ * resolves the enhancer itself for now: the SEO dashboard's AI tab, the AI
+ * Assistant block's extension registration, the legacy settings endpoint, and
+ * the AI sidebar's SEO suggestions, which asks a deliberately different
+ * question (see below).
  *
  * This package owns the `ai_seo_enhancer_enabled` option and already depends on
  * jetpack-plans and jetpack-status, so the predicate lives here and the plugin
@@ -68,16 +69,10 @@ class AI_SEO_Enhancer {
 	 */
 	public static function is_available() {
 		/** This filter is documented in projects/plugins/jetpack/_inc/lib/class.core-rest-api-endpoints.php */
-		if ( ! apply_filters( 'ai_seo_enhancer_enabled', true ) ) {
-			return false;
-		}
-
-		/** This filter is documented in projects/plugins/jetpack/modules/seo-tools/class-jetpack-seo-utils.php */
-		if ( apply_filters( 'jetpack_disable_seo_tools', false ) ) {
-			return false;
-		}
-
-		return ( new Modules() )->is_active( 'seo-tools' )
+		return (bool) apply_filters( 'ai_seo_enhancer_enabled', true )
+			/** This filter is documented in projects/plugins/jetpack/modules/seo-tools/class-jetpack-seo-utils.php */
+			&& ! apply_filters( 'jetpack_disable_seo_tools', false )
+			&& ( new Modules() )->is_active( 'seo-tools' )
 			&& Current_Plan::supports( 'ai-seo-enhancer' );
 	}
 

--- a/projects/packages/seo/src/class-ai-seo-enhancer.php
+++ b/projects/packages/seo/src/class-ai-seo-enhancer.php
@@ -19,8 +19,7 @@ class AI_SEO_Enhancer {
 	/**
 	 * Whether the site can offer the enhancer, independent of the admin's
 	 * toggle. Callers own the outer AI master and host gates. The AI sidebar's
-	 * SEO suggestions intentionally gate on a different plan slug
-	 * (`advanced-seo`) — do not unify the two.
+	 * SEO suggestions intentionally use a different plan slug — do not unify.
 	 *
 	 * @since $$next-version$$
 	 *

--- a/projects/packages/seo/tests/php/AiSeoEnhancerTest.php
+++ b/projects/packages/seo/tests/php/AiSeoEnhancerTest.php
@@ -1,7 +1,6 @@
 <?php
 /**
- * Tests for the AI SEO Enhancer gate: each availability term falsified on its
- * own, and the stored toggle.
+ * Tests for the AI SEO Enhancer gate: each availability term falsified on its own.
  *
  * Not covered here: that the module term is inert on WordPress.com Simple.
  * Exercising it needs the real `IS_WPCOM` constant, which only works in an
@@ -27,7 +26,7 @@ class AiSeoEnhancerTest extends SeoTestCase {
 	 * Reset the option, filters and plan pin every test touches.
 	 */
 	protected function tearDown(): void {
-		delete_option( AI_SEO_Enhancer::OPTION );
+		delete_option( 'ai_seo_enhancer_enabled' );
 		remove_all_filters( 'ai_seo_enhancer_enabled' );
 		remove_all_filters( 'jetpack_active_modules' );
 		remove_all_filters( 'jetpack_disable_seo_tools' );
@@ -35,15 +34,6 @@ class AiSeoEnhancerTest extends SeoTestCase {
 		self::reset_plan();
 
 		parent::tearDown();
-	}
-
-	/**
-	 * The option name is the one the settings endpoints round-trip, so the
-	 * package copy of the gate can never read a different store than the
-	 * plugin's AI feature settings.
-	 */
-	public function test_option_constant_is_the_shared_toggle() {
-		$this->assertSame( 'ai_seo_enhancer_enabled', AI_SEO_Enhancer::OPTION );
 	}
 
 	/**
@@ -104,24 +94,5 @@ class AiSeoEnhancerTest extends SeoTestCase {
 		add_filter( 'jetpack_disable_seo_tools', '__return_true' );
 
 		$this->assertFalse( AI_SEO_Enhancer::is_available() );
-	}
-
-	/**
-	 * The stored toggle is opt-in: absent means off, matching the `false`
-	 * default `Jetpack_AI_Settings::is_feature_enabled( 'seo_enhancer' )` reads.
-	 */
-	public function test_is_toggled_on_defaults_to_false() {
-		delete_option( AI_SEO_Enhancer::OPTION );
-
-		$this->assertFalse( AI_SEO_Enhancer::is_toggled_on() );
-	}
-
-	/**
-	 * A stored `1` reads as on, and as a real bool rather than the raw option.
-	 */
-	public function test_is_toggled_on_reads_the_stored_option() {
-		update_option( AI_SEO_Enhancer::OPTION, 1 );
-
-		$this->assertTrue( AI_SEO_Enhancer::is_toggled_on() );
 	}
 }

--- a/projects/packages/seo/tests/php/AiSeoEnhancerTest.php
+++ b/projects/packages/seo/tests/php/AiSeoEnhancerTest.php
@@ -1,13 +1,8 @@
 <?php
 /**
- * Tests for the AI SEO Enhancer gate: each availability term falsified on its own.
- *
- * Not covered here: that the module term is inert on WordPress.com Simple.
- * Exercising it needs the real `IS_WPCOM` constant, which only works in an
- * isolated process, and this package's SQLite bootstrap emits deprecations
- * there on PHP 8.5 that PHPUnit reports as an error. The user-visible half of
- * that guarantee is covered plugin-side by
- * Jetpack_AI_Sidebar_Test::test_preview_stays_open_on_simple_even_with_every_toggle_off.
+ * Tests for the AI SEO Enhancer gate: each availability term falsified on its
+ * own. The Simple behavior is pinned plugin-side in Jetpack_AI_Sidebar_Test
+ * (IS_WPCOM needs process isolation, broken here under PHP 8.5).
  *
  * @package automattic/jetpack-seo
  */
@@ -37,8 +32,7 @@ class AiSeoEnhancerTest extends SeoTestCase {
 	}
 
 	/**
-	 * Availability ANDs four independent inputs; with all of them satisfied the
-	 * enhancer is available.
+	 * All four terms satisfied: available.
 	 */
 	public function test_is_available_when_all_inputs_true() {
 		self::set_plan( 'jetpack_business' );
@@ -48,8 +42,7 @@ class AiSeoEnhancerTest extends SeoTestCase {
 	}
 
 	/**
-	 * The feature filter vetoes on its own: a host that kills the enhancer
-	 * hides it even with the module and the plan in place.
+	 * The feature filter vetoes on its own.
 	 */
 	public function test_is_not_available_when_filter_off() {
 		self::set_plan( 'jetpack_business' );
@@ -60,9 +53,7 @@ class AiSeoEnhancerTest extends SeoTestCase {
 	}
 
 	/**
-	 * The seo-tools module vetoes on its own: the enhancer writes to the SEO
-	 * title and meta description fields that module owns, so an inactive module
-	 * leaves it nothing to write.
+	 * The seo-tools module vetoes on its own.
 	 */
 	public function test_is_not_available_when_seo_tools_module_inactive() {
 		self::set_plan( 'jetpack_business' );
@@ -72,8 +63,7 @@ class AiSeoEnhancerTest extends SeoTestCase {
 	}
 
 	/**
-	 * The plan vetoes on its own: `ai-seo-enhancer` is a Business-tier feature,
-	 * so a free site is not entitled to it.
+	 * The plan vetoes on its own.
 	 */
 	public function test_is_not_available_when_plan_lacks_feature() {
 		self::set_plan( 'jetpack_free' );
@@ -83,10 +73,7 @@ class AiSeoEnhancerTest extends SeoTestCase {
 	}
 
 	/**
-	 * A conflicting SEO plugin vetoes on its own. The seo-tools module raises
-	 * `jetpack_disable_seo_tools` when Yoast, AIOSEO or Rank Math owns the
-	 * site's SEO; the enhancer's fields are then not Jetpack's to write, so no
-	 * surface should offer the toggle.
+	 * A conflicting SEO plugin (jetpack_disable_seo_tools) vetoes on its own.
 	 */
 	public function test_is_not_available_when_seo_tools_are_disabled_by_filter() {
 		self::set_plan( 'jetpack_business' );

--- a/projects/packages/seo/tests/php/AiSeoEnhancerTest.php
+++ b/projects/packages/seo/tests/php/AiSeoEnhancerTest.php
@@ -1,0 +1,177 @@
+<?php
+/**
+ * Tests for the canonical AI SEO Enhancer gate: the three availability terms,
+ * the stored toggle, and the combination of the two.
+ *
+ * @package automattic/jetpack-seo
+ */
+
+namespace Automattic\Jetpack\SEO;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Depends;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
+
+/**
+ * @covers \Automattic\Jetpack\SEO\AI_SEO_Enhancer
+ */
+#[CoversClass( AI_SEO_Enhancer::class )]
+class AiSeoEnhancerTest extends SeoTestCase {
+
+	/**
+	 * Reset the option, filters and plan pin every test touches.
+	 */
+	protected function tearDown(): void {
+		delete_option( AI_SEO_Enhancer::OPTION );
+		remove_all_filters( 'ai_seo_enhancer_enabled' );
+		remove_all_filters( 'jetpack_active_modules' );
+		remove_all_filters( 'jetpack_disable_seo_tools' );
+
+		self::reset_plan();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * The option name is the one the settings endpoints round-trip, so the
+	 * package copy of the gate can never read a different store than the
+	 * plugin's AI feature settings.
+	 */
+	public function test_option_constant_is_the_shared_toggle() {
+		$this->assertSame( 'ai_seo_enhancer_enabled', AI_SEO_Enhancer::OPTION );
+	}
+
+	/**
+	 * Availability ANDs three independent inputs; with all three satisfied the
+	 * enhancer is available.
+	 */
+	public function test_is_available_when_all_inputs_true() {
+		self::set_plan( 'jetpack_business' );
+		self::set_seo_tools_active( true );
+
+		$this->assertTrue( AI_SEO_Enhancer::is_available() );
+	}
+
+	/**
+	 * The feature filter vetoes on its own: a host that kills the enhancer
+	 * hides it even with the module and the plan in place.
+	 */
+	public function test_is_not_available_when_filter_off() {
+		self::set_plan( 'jetpack_business' );
+		self::set_seo_tools_active( true );
+		add_filter( 'ai_seo_enhancer_enabled', '__return_false' );
+
+		try {
+			$this->assertFalse( AI_SEO_Enhancer::is_available() );
+		} finally {
+			remove_filter( 'ai_seo_enhancer_enabled', '__return_false' );
+		}
+	}
+
+	/**
+	 * The seo-tools module vetoes on its own: the enhancer writes to the SEO
+	 * title and meta description fields that module owns, so an inactive module
+	 * leaves it nothing to write.
+	 */
+	public function test_is_not_available_when_seo_tools_module_inactive() {
+		self::set_plan( 'jetpack_business' );
+		self::set_seo_tools_active( false );
+
+		$this->assertFalse( AI_SEO_Enhancer::is_available() );
+	}
+
+	/**
+	 * The plan vetoes on its own: `ai-seo-enhancer` is a Business-tier feature,
+	 * so a free site is not entitled to it.
+	 */
+	public function test_is_not_available_when_plan_lacks_feature() {
+		self::set_plan( 'jetpack_free' );
+		self::set_seo_tools_active( true );
+
+		$this->assertFalse( AI_SEO_Enhancer::is_available() );
+	}
+
+	/**
+	 * A conflicting SEO plugin vetoes on its own. The seo-tools module raises
+	 * `jetpack_disable_seo_tools` when Yoast, AIOSEO or Rank Math owns the
+	 * site's SEO; the enhancer's fields are then not Jetpack's to write, so no
+	 * surface should offer the toggle.
+	 */
+	public function test_is_not_available_when_seo_tools_are_disabled_by_filter() {
+		self::set_plan( 'jetpack_business' );
+		self::set_seo_tools_active( true );
+		add_filter( 'jetpack_disable_seo_tools', '__return_true' );
+
+		try {
+			$this->assertFalse( AI_SEO_Enhancer::is_available() );
+		} finally {
+			remove_filter( 'jetpack_disable_seo_tools', '__return_true' );
+		}
+	}
+
+	/**
+	 * The stored toggle is opt-in: absent means off, matching the `false`
+	 * default `Jetpack_AI_Settings::is_feature_enabled( 'seo_enhancer' )` reads.
+	 */
+	public function test_is_toggled_on_defaults_to_false() {
+		delete_option( AI_SEO_Enhancer::OPTION );
+
+		$this->assertFalse( AI_SEO_Enhancer::is_toggled_on() );
+	}
+
+	/**
+	 * A stored `1` reads as on, and as a real bool rather than the raw option.
+	 */
+	public function test_is_toggled_on_reads_the_stored_option() {
+		update_option( AI_SEO_Enhancer::OPTION, 1 );
+
+		$this->assertTrue( AI_SEO_Enhancer::is_toggled_on() );
+	}
+
+	/**
+	 * WordPress.com Simple no-regression guarantee: adding the module term must
+	 * not take the enhancer away from Simple sites, which do not run the
+	 * seo-tools module through Jetpack's module machinery at all.
+	 *
+	 * `Modules::is_active()` returns true unconditionally when the real
+	 * `IS_WPCOM` constant is defined, so the module term is inert there. That
+	 * constant can't be defined for a single test in-process (it would leak into
+	 * every later test in the run and turn *every* module on), so this runs in
+	 * an isolated process with the constant genuinely defined — the same read
+	 * path production takes on Simple.
+	 *
+	 * The annotations are kept alongside the attributes on purpose: the
+	 * attributes are what PHPUnit 10+ reads, the annotations are what the
+	 * PHPUnit 8/9 configurations this package still ships read. Losing the
+	 * isolation would silently define `IS_WPCOM` for the rest of the run.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_module_term_is_inert_on_wordpress_com_simple() {
+		define( 'IS_WPCOM', true );
+
+		self::set_plan( 'jetpack_business' );
+		self::set_seo_tools_active( false );
+
+		$this->assertTrue( AI_SEO_Enhancer::is_available() );
+	}
+
+	/**
+	 * Guards the isolation the test above depends on: a dropped
+	 * `#[RunInSeparateProcess]` shows up here as a failure rather than as
+	 * `IS_WPCOM` quietly switching every module on for the rest of the run.
+	 *
+	 * Ordered by `@depends` rather than by declaration order, so the guard still
+	 * runs after its subject if the suite is ever switched to random execution.
+	 *
+	 * @depends test_module_term_is_inert_on_wordpress_com_simple
+	 */
+	#[Depends( 'test_module_term_is_inert_on_wordpress_com_simple' )]
+	public function test_wordpress_com_simple_case_did_not_leak_its_constant() {
+		$this->assertFalse( defined( 'IS_WPCOM' ), 'IS_WPCOM leaked out of the isolated WordPress.com Simple test.' );
+	}
+}

--- a/projects/packages/seo/tests/php/AiSeoEnhancerTest.php
+++ b/projects/packages/seo/tests/php/AiSeoEnhancerTest.php
@@ -1,7 +1,14 @@
 <?php
 /**
- * Tests for the canonical AI SEO Enhancer gate: the three availability terms,
- * the stored toggle, and the combination of the two.
+ * Tests for the AI SEO Enhancer gate: each availability term falsified on its
+ * own, and the stored toggle.
+ *
+ * Not covered here: that the module term is inert on WordPress.com Simple.
+ * Exercising it needs the real `IS_WPCOM` constant, which only works in an
+ * isolated process, and this package's SQLite bootstrap emits deprecations
+ * there on PHP 8.5 that PHPUnit reports as an error. The user-visible half of
+ * that guarantee is covered plugin-side by
+ * Jetpack_AI_Sidebar_Test::test_preview_stays_open_on_simple_even_with_every_toggle_off.
  *
  * @package automattic/jetpack-seo
  */
@@ -40,7 +47,7 @@ class AiSeoEnhancerTest extends SeoTestCase {
 	}
 
 	/**
-	 * Availability ANDs three independent inputs; with all three satisfied the
+	 * Availability ANDs four independent inputs; with all of them satisfied the
 	 * enhancer is available.
 	 */
 	public function test_is_available_when_all_inputs_true() {
@@ -59,11 +66,7 @@ class AiSeoEnhancerTest extends SeoTestCase {
 		self::set_seo_tools_active( true );
 		add_filter( 'ai_seo_enhancer_enabled', '__return_false' );
 
-		try {
-			$this->assertFalse( AI_SEO_Enhancer::is_available() );
-		} finally {
-			remove_filter( 'ai_seo_enhancer_enabled', '__return_false' );
-		}
+		$this->assertFalse( AI_SEO_Enhancer::is_available() );
 	}
 
 	/**
@@ -100,11 +103,7 @@ class AiSeoEnhancerTest extends SeoTestCase {
 		self::set_seo_tools_active( true );
 		add_filter( 'jetpack_disable_seo_tools', '__return_true' );
 
-		try {
-			$this->assertFalse( AI_SEO_Enhancer::is_available() );
-		} finally {
-			remove_filter( 'jetpack_disable_seo_tools', '__return_true' );
-		}
+		$this->assertFalse( AI_SEO_Enhancer::is_available() );
 	}
 
 	/**
@@ -125,16 +124,4 @@ class AiSeoEnhancerTest extends SeoTestCase {
 
 		$this->assertTrue( AI_SEO_Enhancer::is_toggled_on() );
 	}
-
-	/**
-	 * The module term is inert on WordPress.com Simple, because
-	 * `Modules::is_active()` returns true unconditionally when `IS_WPCOM` is
-	 * defined — so adding it cannot take the enhancer away from Simple sites.
-	 *
-	 * Not covered here: exercising it needs the real constant defined, which
-	 * only works in an isolated process, and this package's SQLite bootstrap
-	 * emits deprecations there on PHP 8.5 that PHPUnit reports as an error. The
-	 * user-visible half of the guarantee is covered plugin-side instead, by
-	 * Jetpack_AI_Sidebar_Test::test_preview_stays_open_on_simple_even_with_every_toggle_off.
-	 */
 }

--- a/projects/packages/seo/tests/php/AiSeoEnhancerTest.php
+++ b/projects/packages/seo/tests/php/AiSeoEnhancerTest.php
@@ -9,9 +9,6 @@
 namespace Automattic\Jetpack\SEO;
 
 use PHPUnit\Framework\Attributes\CoversClass;
-use PHPUnit\Framework\Attributes\Depends;
-use PHPUnit\Framework\Attributes\PreserveGlobalState;
-use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 
 /**
  * @covers \Automattic\Jetpack\SEO\AI_SEO_Enhancer
@@ -130,48 +127,14 @@ class AiSeoEnhancerTest extends SeoTestCase {
 	}
 
 	/**
-	 * WordPress.com Simple no-regression guarantee: adding the module term must
-	 * not take the enhancer away from Simple sites, which do not run the
-	 * seo-tools module through Jetpack's module machinery at all.
+	 * The module term is inert on WordPress.com Simple, because
+	 * `Modules::is_active()` returns true unconditionally when `IS_WPCOM` is
+	 * defined — so adding it cannot take the enhancer away from Simple sites.
 	 *
-	 * `Modules::is_active()` returns true unconditionally when the real
-	 * `IS_WPCOM` constant is defined, so the module term is inert there. That
-	 * constant can't be defined for a single test in-process (it would leak into
-	 * every later test in the run and turn *every* module on), so this runs in
-	 * an isolated process with the constant genuinely defined — the same read
-	 * path production takes on Simple.
-	 *
-	 * The annotations are kept alongside the attributes on purpose: the
-	 * attributes are what PHPUnit 10+ reads, the annotations are what the
-	 * PHPUnit 8/9 configurations this package still ships read. Losing the
-	 * isolation would silently define `IS_WPCOM` for the rest of the run.
-	 *
-	 * @runInSeparateProcess
-	 * @preserveGlobalState disabled
+	 * Not covered here: exercising it needs the real constant defined, which
+	 * only works in an isolated process, and this package's SQLite bootstrap
+	 * emits deprecations there on PHP 8.5 that PHPUnit reports as an error. The
+	 * user-visible half of the guarantee is covered plugin-side instead, by
+	 * Jetpack_AI_Sidebar_Test::test_preview_stays_open_on_simple_even_with_every_toggle_off.
 	 */
-	#[RunInSeparateProcess]
-	#[PreserveGlobalState( false )]
-	public function test_module_term_is_inert_on_wordpress_com_simple() {
-		define( 'IS_WPCOM', true );
-
-		self::set_plan( 'jetpack_business' );
-		self::set_seo_tools_active( false );
-
-		$this->assertTrue( AI_SEO_Enhancer::is_available() );
-	}
-
-	/**
-	 * Guards the isolation the test above depends on: a dropped
-	 * `#[RunInSeparateProcess]` shows up here as a failure rather than as
-	 * `IS_WPCOM` quietly switching every module on for the rest of the run.
-	 *
-	 * Ordered by `@depends` rather than by declaration order, so the guard still
-	 * runs after its subject if the suite is ever switched to random execution.
-	 *
-	 * @depends test_module_term_is_inert_on_wordpress_com_simple
-	 */
-	#[Depends( 'test_module_term_is_inert_on_wordpress_com_simple' )]
-	public function test_wordpress_com_simple_case_did_not_leak_its_constant() {
-		$this->assertFalse( defined( 'IS_WPCOM' ), 'IS_WPCOM leaked out of the isolated WordPress.com Simple test.' );
-	}
 }

--- a/projects/packages/seo/tests/php/SeoTestCase.php
+++ b/projects/packages/seo/tests/php/SeoTestCase.php
@@ -19,14 +19,12 @@ use PHPUnit\Framework\TestCase;
 abstract class SeoTestCase extends TestCase {
 
 	/**
-	 * Short-circuit filter for the active plan option, so a test can pin the
-	 * site's plan without writing the option.
+	 * Short-circuit filter for the active plan option.
 	 */
 	const PLAN_FILTER = 'pre_option_' . Current_Plan::PLAN_OPTION;
 
 	/**
-	 * Priority for PLAN_FILTER. Later than the default so the pin wins over a
-	 * dev environment that already short-circuits the same option.
+	 * Priority for PLAN_FILTER; later than default so the test pin wins.
 	 */
 	const PLAN_FILTER_PRIORITY = 20;
 
@@ -63,8 +61,7 @@ abstract class SeoTestCase extends TestCase {
 	}
 
 	/**
-	 * Undo a plan pin set by set_plan(). Only our own priority, so an
-	 * environment's own pin survives.
+	 * Undo a plan pin set by set_plan().
 	 */
 	protected static function reset_plan() {
 		remove_all_filters( self::PLAN_FILTER, self::PLAN_FILTER_PRIORITY );
@@ -72,8 +69,7 @@ abstract class SeoTestCase extends TestCase {
 	}
 
 	/**
-	 * `Current_Plan::get()` memoizes for the request, so a pin set by one test
-	 * would otherwise leak into the next.
+	 * Clear Current_Plan::get()'s request memo so pins don't leak between tests.
 	 */
 	protected static function reset_active_plan_cache() {
 		$property = ( new \ReflectionClass( Current_Plan::class ) )->getProperty( 'active_plan_cache' );
@@ -86,17 +82,8 @@ abstract class SeoTestCase extends TestCase {
 	}
 
 	/**
-	 * Put the site on a given plan.
-	 *
-	 * `Current_Plan::get_class_and_features()` accumulates each tier's features
-	 * as it walks PLAN_DATA, so a tier is the *minimum* plan granting its
-	 * features and every higher tier inherits them.
-	 *
-	 * Filtered rather than written with `update_option()`: a local dev
-	 * environment may already short-circuit `pre_option_jetpack_active_plan`,
-	 * which makes an option write invisible to `Current_Plan::get()`.
-	 * Registering at a later priority overrides any such pin without
-	 * disturbing it.
+	 * Put the site on a given plan, via filter so the pin also wins over an
+	 * environment's own pre_option short-circuit.
 	 *
 	 * @param string $product_slug Plan product slug.
 	 */

--- a/projects/packages/seo/tests/php/SeoTestCase.php
+++ b/projects/packages/seo/tests/php/SeoTestCase.php
@@ -8,6 +8,7 @@
 
 namespace Automattic\Jetpack\SEO;
 
+use Automattic\Jetpack\Current_Plan;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -16,6 +17,18 @@ use PHPUnit\Framework\TestCase;
  * so content created or cached by one test would otherwise leak into the next.
  */
 abstract class SeoTestCase extends TestCase {
+
+	/**
+	 * Short-circuit filter for the active plan option, so a test can pin the
+	 * site's plan without writing the option.
+	 */
+	const PLAN_FILTER = 'pre_option_' . Current_Plan::PLAN_OPTION;
+
+	/**
+	 * Priority for PLAN_FILTER. Later than the default so the pin wins over a
+	 * dev environment that already short-circuits the same option.
+	 */
+	const PLAN_FILTER_PRIORITY = 20;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -47,6 +60,79 @@ abstract class SeoTestCase extends TestCase {
 	 */
 	protected function reset_coverage_cache() {
 		delete_transient( Content_Coverage::TRANSIENT );
+	}
+
+	/**
+	 * Undo a plan pin set by set_plan(). Only our own priority, so an
+	 * environment's own pin survives.
+	 */
+	protected static function reset_plan() {
+		remove_all_filters( self::PLAN_FILTER, self::PLAN_FILTER_PRIORITY );
+		self::reset_active_plan_cache();
+	}
+
+	/**
+	 * `Current_Plan::get()` memoizes for the request, so a pin set by one test
+	 * would otherwise leak into the next.
+	 */
+	protected static function reset_active_plan_cache() {
+		$property = ( new \ReflectionClass( Current_Plan::class ) )->getProperty( 'active_plan_cache' );
+		// @todo Remove once we drop PHP < 8.1 support. `setAccessible()` is
+		// deprecated in 8.5 (a no-op since 8.1), so only call it where it's needed.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$property->setAccessible( true );
+		}
+		$property->setValue( null, null );
+	}
+
+	/**
+	 * Put the site on a given plan.
+	 *
+	 * `Current_Plan::get_class_and_features()` accumulates each tier's features
+	 * as it walks PLAN_DATA, so a tier is the *minimum* plan granting its
+	 * features and every higher tier inherits them.
+	 *
+	 * Filtered rather than written with `update_option()`: a local dev
+	 * environment may already short-circuit `pre_option_jetpack_active_plan`,
+	 * which makes an option write invisible to `Current_Plan::get()`.
+	 * Registering at a later priority overrides any such pin without
+	 * disturbing it.
+	 *
+	 * @param string $product_slug Plan product slug.
+	 */
+	protected static function set_plan( $product_slug ) {
+		remove_all_filters( self::PLAN_FILTER, self::PLAN_FILTER_PRIORITY );
+		add_filter(
+			self::PLAN_FILTER,
+			static function () use ( $product_slug ) {
+				return array( 'product_slug' => $product_slug );
+			},
+			self::PLAN_FILTER_PRIORITY
+		);
+		self::reset_active_plan_cache();
+	}
+
+	/**
+	 * Force the seo-tools module on or off.
+	 *
+	 * Filtering is what `Modules::get_active()` applies last — after it
+	 * intersects the stored option with the available modules — so this
+	 * controls the input regardless of which modules the test context ships.
+	 *
+	 * @param bool $active Whether seo-tools should report active.
+	 */
+	protected static function set_seo_tools_active( $active ) {
+		remove_all_filters( 'jetpack_active_modules' );
+		add_filter(
+			'jetpack_active_modules',
+			static function ( $modules ) use ( $active ) {
+				$modules = array_diff( (array) $modules, array( 'seo-tools' ) );
+				if ( $active ) {
+					$modules[] = 'seo-tools';
+				}
+				return array_values( $modules );
+			}
+		);
 	}
 
 	/**

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai-feature-settings.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai-feature-settings.php
@@ -233,13 +233,8 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings extends WP_REST_Controller 
 
 	/**
 	 * Whether the AI SEO enhancer is available on this site, so the settings
-	 * page can hide its row where the feature can't run.
-	 *
-	 * Defers to the SEO package, which owns the `ai_seo_enhancer_enabled`
-	 * option and is the single place the feature filter, the seo-tools module
-	 * and the `ai-seo-enhancer` plan feature are resolved. The terms are
-	 * unchanged from the copy this method used to carry; keeping one definition
-	 * is what stops this endpoint and the SEO dashboard drifting apart again.
+	 * page can hide its row. Defers to the SEO package's shared gate; the
+	 * terms are unchanged.
 	 *
 	 * @return bool
 	 */

--- a/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai-feature-settings.php
+++ b/projects/plugins/jetpack/_inc/lib/core-api/wpcom-endpoints/class-wpcom-rest-api-v2-endpoint-ai-feature-settings.php
@@ -23,8 +23,8 @@
 
 use Automattic\Jetpack\Connection\Manager;
 use Automattic\Jetpack\Current_Plan;
-use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\Search\Plan as Search_Plan;
+use Automattic\Jetpack\SEO\AI_SEO_Enhancer;
 use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 
@@ -235,22 +235,16 @@ class WPCOM_REST_API_V2_Endpoint_AI_Feature_Settings extends WP_REST_Controller 
 	 * Whether the AI SEO enhancer is available on this site, so the settings
 	 * page can hide its row where the feature can't run.
 	 *
-	 * Mirrors the legacy Traffic page's gate: the feature filter, the
-	 * seo-tools module (always active on WordPress.com Simple, where
-	 * Modules::is_active() short-circuits), and the plan feature.
+	 * Defers to the SEO package, which owns the `ai_seo_enhancer_enabled`
+	 * option and is the single place the feature filter, the seo-tools module
+	 * and the `ai-seo-enhancer` plan feature are resolved. The terms are
+	 * unchanged from the copy this method used to carry; keeping one definition
+	 * is what stops this endpoint and the SEO dashboard drifting apart again.
 	 *
 	 * @return bool
 	 */
 	private function is_seo_enhancer_available() {
-		$filter_on = (bool) apply_filters( 'ai_seo_enhancer_enabled', true );
-
-		$module_active = class_exists( Modules::class )
-			&& ( new Modules() )->is_active( 'seo-tools' );
-
-		$plan_supports = class_exists( Current_Plan::class )
-			&& Current_Plan::supports( 'ai-seo-enhancer' );
-
-		return $filter_on && $module_active && $plan_supports;
+		return AI_SEO_Enhancer::is_available();
 	}
 
 	/**

--- a/projects/plugins/jetpack/changelog/add-ai-seo-enhancer-gate
+++ b/projects/plugins/jetpack/changelog/add-ai-seo-enhancer-gate
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Jetpack AI: Stop showing the AI sidebar when the SEO Enhancer is the only feature switched on and SEO tools are off.

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -391,9 +391,8 @@ class Jetpack_AI_Sidebar {
 
 	/**
 	 * Whether any feature the sidebar surfaces is effectively enabled; with
-	 * nothing to offer the sidebar must not load. Load-order caveat: init()
-	 * runs before modules/seo-tools.php registers jetpack_disable_seo_tools,
-	 * so that one term reads its default here.
+	 * nothing to offer it must not load. Caveat: init() runs before seo-tools
+	 * registers jetpack_disable_seo_tools, so that term reads its default here.
 	 *
 	 * @return bool
 	 */

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -390,29 +390,10 @@ class Jetpack_AI_Sidebar {
 	}
 
 	/**
-	 * Whether any feature the sidebar surfaces is effectively enabled.
-	 *
-	 * The sidebar only hosts writing-assistant and SEO suggestions; when both
-	 * are off it has nothing to offer and must not load. The writing half gets
-	 * its filter inside is_feature_enabled() (owned feature). The SEO half
-	 * delegates to is_seo_suggestions_enabled() — the same predicate that
-	 * decides whether the suggestions are offered — so a switched-on enhancer
-	 * that cannot run no longer holds the sidebar open.
-	 *
-	 * One term of that predicate cannot bite here. init() runs while the modules
-	 * are still loading (blocks is Auto Activate: Yes and pulls in this file via
-	 * Jetpack_Gutenberg::load_block_editor_extensions(); seo-tools is Auto
-	 * Activate: No and is appended to jetpack_active_modules later), so
-	 * modules/seo-tools.php has not yet registered its jetpack_disable_seo_tools
-	 * filter and that check reads its default. A site whose SEO is owned by a
-	 * conflicting plugin therefore still loads the sidebar; the suggestions
-	 * themselves stay off, because the features payload is built later, once the
-	 * filter is registered. The toggle, plan and module terms all resolve from
-	 * options and are unaffected by load order.
-	 *
-	 * The module term does not change WordPress.com Simple: Modules::is_active()
-	 * short-circuits to true there, so the SEO half reduces to the filter,
-	 * toggle and plan checks.
+	 * Whether any feature the sidebar surfaces is effectively enabled; with
+	 * nothing to offer the sidebar must not load. Load-order caveat: init()
+	 * runs before modules/seo-tools.php registers jetpack_disable_seo_tools,
+	 * so that one term reads its default here.
 	 *
 	 * @return bool
 	 */

--- a/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
+++ b/projects/plugins/jetpack/extensions/plugins/ai-assistant-plugin/ai-sidebar/class-jetpack-ai-sidebar.php
@@ -393,17 +393,32 @@ class Jetpack_AI_Sidebar {
 	 * Whether any feature the sidebar surfaces is effectively enabled.
 	 *
 	 * The sidebar only hosts writing-assistant and SEO suggestions; when both
-	 * are off it has nothing to offer and must not load. The SEO half folds in
-	 * the ai_seo_enhancer_enabled kill-switch filter, the same way every other
-	 * SEO enhancer consumer resolves the effective value; the writing half gets
-	 * its filter inside is_feature_enabled() (owned feature).
+	 * are off it has nothing to offer and must not load. The writing half gets
+	 * its filter inside is_feature_enabled() (owned feature). The SEO half
+	 * delegates to is_seo_suggestions_enabled() — the same predicate that
+	 * decides whether the suggestions are offered — so a switched-on enhancer
+	 * that cannot run no longer holds the sidebar open.
+	 *
+	 * One term of that predicate cannot bite here. init() runs while the modules
+	 * are still loading (blocks is Auto Activate: Yes and pulls in this file via
+	 * Jetpack_Gutenberg::load_block_editor_extensions(); seo-tools is Auto
+	 * Activate: No and is appended to jetpack_active_modules later), so
+	 * modules/seo-tools.php has not yet registered its jetpack_disable_seo_tools
+	 * filter and that check reads its default. A site whose SEO is owned by a
+	 * conflicting plugin therefore still loads the sidebar; the suggestions
+	 * themselves stay off, because the features payload is built later, once the
+	 * filter is registered. The toggle, plan and module terms all resolve from
+	 * options and are unaffected by load order.
+	 *
+	 * The module term does not change WordPress.com Simple: Modules::is_active()
+	 * short-circuits to true there, so the SEO half reduces to the filter,
+	 * toggle and plan checks.
 	 *
 	 * @return bool
 	 */
 	private static function has_enabled_sidebar_features(): bool {
 		return \Jetpack_AI_Settings::is_feature_enabled( 'writing_assistant' )
-			|| ( (bool) apply_filters( 'ai_seo_enhancer_enabled', true )
-				&& \Jetpack_AI_Settings::is_feature_enabled( 'seo_enhancer' ) );
+			|| self::is_seo_suggestions_enabled();
 	}
 
 	/**

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -529,16 +529,8 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	// ──────────────────────────────────────────────────
 
 	/**
-	 * The sidebar only surfaces writing-assistant and SEO suggestions, so the
-	 * gate follows the two toggles: it closes only when BOTH are off. Any single
-	 * enabled feature keeps the sidebar available.
-	 *
-	 * The seo-tools module is activated for the whole matrix because SEO alone
-	 * only holds the sidebar open when the suggestions can actually run: the SEO
-	 * half of the gate is the full suggestions predicate (filter, toggle, plan
-	 * and module), not the toggle by itself. The rows where the SEO toggle is
-	 * off are unaffected by the module — their SEO half is false either way.
-	 * The module-inactive counterpart of the writing=0 seo=1 row is covered by
+	 * The gate closes only when BOTH toggles are off. seo-tools stays active;
+	 * the module-inactive case is
 	 * test_preview_disabled_when_seo_enhancer_cannot_run.
 	 */
 	public function test_preview_follows_writing_and_seo_toggle_matrix() {
@@ -570,16 +562,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * WordPress.com Simple is unreachable by the SEO half of the gate, so the
-	 * plan and module terms it now carries cannot close the sidebar there.
-	 * `writing_assistant` is one of the features Jetpack owns, and
-	 * Jetpack_AI_Settings::is_feature_enabled() forces owned features on for
-	 * Simple regardless of their stored option, so the first half of the gate is
-	 * always true there and the SEO half is never reached.
-	 *
-	 * Pinned because the SEO half's terms only ever narrow the gate: without
-	 * this, a future change to the Simple carve-out could silently take the
-	 * sidebar away from every Simple site below Business.
+	 * Simple never reaches the SEO half: writing_assistant is forced on there
+	 * as an owned feature. Pinned so a carve-out change cannot silently close
+	 * the sidebar on Simple sites below Business.
 	 */
 	public function test_preview_stays_open_on_simple_even_with_every_toggle_off() {
 		$this->simulate_wpcom_simple();
@@ -598,12 +583,8 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The SEO half of the load gate is the same predicate that decides whether
-	 * SEO suggestions are offered, so a switched-on SEO enhancer that cannot run
-	 * does not hold the sidebar open. With writing off, the SEO toggle on and
-	 * the seo-tools module inactive — the module registers the SEO meta fields
-	 * the suggestions write to — every sidebar feature is off, so the sidebar
-	 * must not load at all.
+	 * A switched-on enhancer that cannot run (seo-tools inactive) must not
+	 * hold the sidebar open with writing off.
 	 */
 	public function test_preview_disabled_when_seo_enhancer_cannot_run() {
 		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
@@ -618,10 +599,8 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The jetpack_disable_seo_tools filter — which the seo-tools module raises
-	 * when a conflicting SEO plugin (Yoast, AIOSEO, Rank Math, …) owns the
-	 * site's SEO — also closes the gate: the SEO suggestions cannot run, so with
-	 * writing off the sidebar has nothing left to offer.
+	 * A conflicting SEO plugin (jetpack_disable_seo_tools) closes the gate the
+	 * same way.
 	 */
 	public function test_preview_disabled_when_seo_tools_are_disabled_by_filter() {
 		$this->activate_seo_tools_module();
@@ -638,10 +617,8 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The writing half of the gate is untouched by the SEO terms: with the
-	 * writing assistant on, the sidebar stays available however unusable the SEO
-	 * enhancer is — toggle off, module inactive and SEO tools filter-disabled
-	 * all at once.
+	 * Writing on keeps the sidebar available however unusable the SEO
+	 * enhancer is.
 	 */
 	public function test_preview_enabled_when_writing_on_regardless_of_seo() {
 		update_option( 'jetpack_ai_writing_assistant_enabled', 1 );
@@ -827,11 +804,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The toolbar button replaces the legacy AI toolbar, which is a writing
-	 * surface, so it follows the writing assistant toggle — and the generic
-	 * preview-features filter must not be able to force it back on. SEO stays on
-	 * — with the seo-tools module active so its suggestions can actually run and
-	 * keep the sidebar available — and the assertion is about the button alone.
+	 * The toolbar button is a writing surface: it follows the writing toggle
+	 * and the preview-features filter must not force it back on. SEO keeps the
+	 * sidebar available; the assertion is about the button alone.
 	 */
 	public function test_toolbar_button_follows_writing_toggle_despite_filter() {
 		$this->set_block_editor_screen();
@@ -949,11 +924,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * With the writing assistant off, the toolbar button extension is registered
-	 * as unavailable rather than merely reporting a false flag: the editor needs
-	 * the extension torn down for the button to disappear. SEO stays on — with
-	 * the seo-tools module active so its suggestions can actually run and keep
-	 * the sidebar available — and this covers the button alone.
+	 * With writing off the toolbar button extension must register as
+	 * unavailable — the editor needs it torn down to drop the button. SEO
+	 * keeps the sidebar available; this covers the button alone.
 	 */
 	public function test_register_toolbar_button_extension_unavailable_when_writing_is_off() {
 		$this->set_block_editor_screen();
@@ -1173,13 +1146,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Block transformations (Translate, Change Tone, etc.) are writing features:
-	 * with the writing assistant off they stay out of the payload even when the
-	 * generic preview-features filter tries to force them on.
-	 *
-	 * SEO carries the sidebar here, so its suggestions must be able to run —
-	 * hence the seo-tools module — or the sidebar itself would not load and
-	 * there would be no payload to assert on.
+	 * Block transformations are writing features: with writing off they stay
+	 * out of the payload even when the preview-features filter forces them.
+	 * SEO (seo-tools active) carries the sidebar so there is a payload.
 	 */
 	public function test_add_agents_manager_data_block_transformations_follow_writing_toggle_despite_filter() {
 		$this->set_block_editor_screen();
@@ -1204,13 +1173,9 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * AI Editorial Review is writing-gated like its sibling suggestions: with
-	 * the writing assistant off, the generic preview-features filter must not
-	 * be able to force it back into the payload.
-	 *
-	 * SEO carries the sidebar here, so its suggestions must be able to run —
-	 * hence the seo-tools module — or the sidebar itself would not load and
-	 * there would be no payload to assert on.
+	 * AI Editorial Review is writing-gated: with writing off the
+	 * preview-features filter must not force it back into the payload. SEO
+	 * (seo-tools active) carries the sidebar so there is a payload.
 	 */
 	public function test_add_agents_manager_data_editorial_review_follows_writing_toggle_despite_filter() {
 		$this->set_block_editor_screen();

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -532,8 +532,18 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * The sidebar only surfaces writing-assistant and SEO suggestions, so the
 	 * gate follows the two toggles: it closes only when BOTH are off. Any single
 	 * enabled feature keeps the sidebar available.
+	 *
+	 * The seo-tools module is activated for the whole matrix because SEO alone
+	 * only holds the sidebar open when the suggestions can actually run: the SEO
+	 * half of the gate is the full suggestions predicate (filter, toggle, plan
+	 * and module), not the toggle by itself. The rows where the SEO toggle is
+	 * off are unaffected by the module — their SEO half is false either way.
+	 * The module-inactive counterpart of the writing=0 seo=1 row is covered by
+	 * test_preview_disabled_when_seo_enhancer_cannot_run.
 	 */
 	public function test_preview_follows_writing_and_seo_toggle_matrix() {
+		$this->activate_seo_tools_module();
+
 		$combinations = array(
 			// writing, seo, expected gate.
 			array( 1, 1, true ),
@@ -557,6 +567,111 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 				sprintf( 'Gate should be %s with writing=%d seo=%d.', $expected ? 'open' : 'closed', $writing, $seo )
 			);
 		}
+	}
+
+	/**
+	 * WordPress.com Simple is unreachable by the SEO half of the gate, so the
+	 * plan and module terms it now carries cannot close the sidebar there.
+	 * `writing_assistant` is one of the features Jetpack owns, and
+	 * Jetpack_AI_Settings::is_feature_enabled() forces owned features on for
+	 * Simple regardless of their stored option, so the first half of the gate is
+	 * always true there and the SEO half is never reached.
+	 *
+	 * Pinned because the SEO half's terms only ever narrow the gate: without
+	 * this, a future change to the Simple carve-out could silently take the
+	 * sidebar away from every Simple site below Business.
+	 */
+	public function test_preview_stays_open_on_simple_even_with_every_toggle_off() {
+		$this->simulate_wpcom_simple();
+		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
+		update_option( 'ai_seo_enhancer_enabled', 0 );
+
+		$open = $this->gate_open();
+
+		delete_option( 'jetpack_ai_writing_assistant_enabled' );
+		delete_option( 'ai_seo_enhancer_enabled' );
+
+		$this->assertTrue(
+			$open,
+			'WordPress.com Simple forces owned features on, so the sidebar gate must stay open there.'
+		);
+	}
+
+	/**
+	 * The SEO half of the load gate is the same predicate that decides whether
+	 * SEO suggestions are offered, so a switched-on SEO enhancer that cannot run
+	 * does not hold the sidebar open. With writing off, the SEO toggle on and
+	 * the seo-tools module inactive — the module registers the SEO meta fields
+	 * the suggestions write to — every sidebar feature is off, so the sidebar
+	 * must not load at all.
+	 */
+	public function test_preview_disabled_when_seo_enhancer_cannot_run() {
+		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
+		update_option( 'ai_seo_enhancer_enabled', 1 );
+
+		$open = $this->gate_open();
+
+		delete_option( 'jetpack_ai_writing_assistant_enabled' );
+		delete_option( 'ai_seo_enhancer_enabled' );
+
+		$this->assertFalse( $open, 'A switched-on SEO enhancer whose seo-tools module is inactive must not hold the sidebar open.' );
+	}
+
+	/**
+	 * The counterpart of the test above, so the gate is not over-closed: with
+	 * the seo-tools module active the SEO suggestions can run, and the SEO
+	 * enhancer alone keeps the sidebar available with writing off.
+	 */
+	public function test_preview_enabled_when_seo_enhancer_can_run_with_writing_off() {
+		$this->activate_seo_tools_module();
+		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
+		update_option( 'ai_seo_enhancer_enabled', 1 );
+
+		$open = $this->gate_open();
+
+		delete_option( 'jetpack_ai_writing_assistant_enabled' );
+		delete_option( 'ai_seo_enhancer_enabled' );
+
+		$this->assertTrue( $open, 'A usable SEO enhancer should keep the sidebar available even with writing off.' );
+	}
+
+	/**
+	 * The jetpack_disable_seo_tools filter — which the seo-tools module raises
+	 * when a conflicting SEO plugin (Yoast, AIOSEO, Rank Math, …) owns the
+	 * site's SEO — also closes the gate: the SEO suggestions cannot run, so with
+	 * writing off the sidebar has nothing left to offer.
+	 */
+	public function test_preview_disabled_when_seo_tools_are_disabled_by_filter() {
+		$this->activate_seo_tools_module();
+		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
+		update_option( 'ai_seo_enhancer_enabled', 1 );
+		add_filter( 'jetpack_disable_seo_tools', '__return_true' );
+
+		$open = $this->gate_open();
+
+		delete_option( 'jetpack_ai_writing_assistant_enabled' );
+		delete_option( 'ai_seo_enhancer_enabled' );
+
+		$this->assertFalse( $open, 'A site whose SEO is owned by another plugin must not get a sidebar holding only SEO suggestions.' );
+	}
+
+	/**
+	 * The writing half of the gate is untouched by the SEO terms: with the
+	 * writing assistant on, the sidebar stays available however unusable the SEO
+	 * enhancer is — toggle off, module inactive and SEO tools filter-disabled
+	 * all at once.
+	 */
+	public function test_preview_enabled_when_writing_on_regardless_of_seo() {
+		update_option( 'jetpack_ai_writing_assistant_enabled', 1 );
+		update_option( 'ai_seo_enhancer_enabled', 0 );
+		add_filter( 'jetpack_disable_seo_tools', '__return_true' );
+
+		$open = $this->gate_open();
+
+		delete_option( 'jetpack_ai_writing_assistant_enabled' );
+		delete_option( 'ai_seo_enhancer_enabled' );
+
+		$this->assertTrue( $open, 'The writing assistant alone should keep the sidebar available whatever the SEO state.' );
 	}
 
 	/**
@@ -733,11 +848,12 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * The toolbar button replaces the legacy AI toolbar, which is a writing
 	 * surface, so it follows the writing assistant toggle — and the generic
 	 * preview-features filter must not be able to force it back on. SEO stays on
-	 * so the sidebar itself remains available and the assertion is about the
-	 * button alone.
+	 * — with the seo-tools module active so its suggestions can actually run and
+	 * keep the sidebar available — and the assertion is about the button alone.
 	 */
 	public function test_toolbar_button_follows_writing_toggle_despite_filter() {
 		$this->set_block_editor_screen();
+		$this->activate_seo_tools_module();
 		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
 		update_option( 'ai_seo_enhancer_enabled', 1 );
 		add_filter(
@@ -853,13 +969,15 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	/**
 	 * With the writing assistant off, the toolbar button extension is registered
 	 * as unavailable rather than merely reporting a false flag: the editor needs
-	 * the extension torn down for the button to disappear. SEO stays on so the
-	 * sidebar itself is still available and this covers the button alone.
+	 * the extension torn down for the button to disappear. SEO stays on — with
+	 * the seo-tools module active so its suggestions can actually run and keep
+	 * the sidebar available — and this covers the button alone.
 	 */
 	public function test_register_toolbar_button_extension_unavailable_when_writing_is_off() {
 		$this->set_block_editor_screen();
 		$this->make_legacy_block_toolbar_extensions_available();
 		$this->enable_sidebar_extension_availability_checks();
+		$this->activate_seo_tools_module();
 		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
 		update_option( 'ai_seo_enhancer_enabled', 1 );
 
@@ -1076,10 +1194,15 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * Block transformations (Translate, Change Tone, etc.) are writing features:
 	 * with the writing assistant off they stay out of the payload even when the
 	 * generic preview-features filter tries to force them on.
+	 *
+	 * SEO carries the sidebar here, so its suggestions must be able to run —
+	 * hence the seo-tools module — or the sidebar itself would not load and
+	 * there would be no payload to assert on.
 	 */
 	public function test_add_agents_manager_data_block_transformations_follow_writing_toggle_despite_filter() {
 		$this->set_block_editor_screen();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		$this->activate_seo_tools_module();
 		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
 		update_option( 'ai_seo_enhancer_enabled', 1 );
 		add_filter(
@@ -1102,10 +1225,15 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	 * AI Editorial Review is writing-gated like its sibling suggestions: with
 	 * the writing assistant off, the generic preview-features filter must not
 	 * be able to force it back into the payload.
+	 *
+	 * SEO carries the sidebar here, so its suggestions must be able to run —
+	 * hence the seo-tools module — or the sidebar itself would not load and
+	 * there would be no payload to assert on.
 	 */
 	public function test_add_agents_manager_data_editorial_review_follows_writing_toggle_despite_filter() {
 		$this->set_block_editor_screen();
 		$_SERVER['A8C_PROXIED_REQUEST'] = '1';
+		$this->activate_seo_tools_module();
 		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
 		update_option( 'ai_seo_enhancer_enabled', 1 );
 		add_filter(

--- a/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
+++ b/projects/plugins/jetpack/tests/php/extensions/plugins/ai-sidebar/Jetpack_AI_Sidebar_Test.php
@@ -618,24 +618,6 @@ class Jetpack_AI_Sidebar_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The counterpart of the test above, so the gate is not over-closed: with
-	 * the seo-tools module active the SEO suggestions can run, and the SEO
-	 * enhancer alone keeps the sidebar available with writing off.
-	 */
-	public function test_preview_enabled_when_seo_enhancer_can_run_with_writing_off() {
-		$this->activate_seo_tools_module();
-		update_option( 'jetpack_ai_writing_assistant_enabled', 0 );
-		update_option( 'ai_seo_enhancer_enabled', 1 );
-
-		$open = $this->gate_open();
-
-		delete_option( 'jetpack_ai_writing_assistant_enabled' );
-		delete_option( 'ai_seo_enhancer_enabled' );
-
-		$this->assertTrue( $open, 'A usable SEO enhancer should keep the sidebar available even with writing off.' );
-	}
-
-	/**
 	 * The jetpack_disable_seo_tools filter — which the seo-tools module raises
 	 * when a conflicting SEO plugin (Yoast, AIOSEO, Rank Math, …) owns the
 	 * site's SEO — also closes the gate: the SEO suggestions cannot run, so with


### PR DESCRIPTION
Fixes FORNO-468

## Proposed changes

This PR adds the check that makes AI settings and the AI sidebar agree on SEO.

- Writing assistant off, SEO Enhancer on, and the Enhancer unable to run - SEO Tools off, another SEO plugin owning the site's SEO, or a plan without the feature: the AI sidebar doesn't load.
- Writing assistant on: sidebar loads regardless of the SEO side.
- Simple sites are unaffected: the writing assistant is always on there, so the sidebar loads regardless of the SEO side.

One load-order caveat, noted in the code: the gate runs while modules are still loading, before seo-tools registers its `jetpack_disable_seo_tools` filter, so that term reads its default at gate time. A site whose SEO is owned by a conflicting plugin (Yoast, AIOSEO, Rank Math) therefore still loads the sidebar; its SEO suggestions stay off, because the features payload is built later, once the filter is registered. Not a regression — that configuration loaded a featureless sidebar before this PR too.

<details>
<summary>Before / after on a live site</summary>

Captured on a Jurassic Ninja site running this branch. Only one setting changes between each step; the second is the behaviour this PR introduces.

**Writing assistant off, SEO Enhancer on, SEO Tools on** — the sidebar loads, offering only Optimize SEO.

![Sidebar offering only Optimize SEO](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-seo-enhancer-gate/b-seo-only.jpg)

**SEO Tools off** — the Enhancer is still switched on but cannot run, so the sidebar does not load. On trunk this state still loads the sidebar, empty.

![No AI sidebar and no Ask AI icon](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-seo-enhancer-gate/c-gone.jpg)

**Writing assistant back on, SEO Tools still off** — the sidebar returns, carried by the writing half alone.

![Sidebar back with writing suggestions](https://github.com/Automattic/jetpack/raw/screenshots/update/jetpack-ai-seo-enhancer-gate/d-writing-carries.jpg)

</details>

## Related product discussion/links
<!-- If you're an Automattician, include a shortlink to the P2, Slack, and/or Linear discussions here. -->
* 

## Does this pull request change what data or activity we track or use?
<!--- If so, please add the "[Status] Needs Privacy Updates" label and explain what changes there are. -->
<!--- Check existing Jetpack support documents for a preview of the information we need. -->

## Testing instructions

### Setup

An internal testing env (JN, or an Atomic site) with this branch.

- Jetpack connected, with a user connection — the `ai` module requires it, and without it the sidebar never loads. `wp jetpack module activate ai`
- The AI sidebar preview is off by default outside wpcom. Either the site has Big Sky enabled, or add a mu-plugin at `wp-content/mu-plugins/zz-ai-sidebar-preview.php` containing `add_filter( 'jetpack_ai_sidebar_enabled', '__return_true' );`. There is no UI for this.
- A plan with the Enhancer (Business or higher). The AI SEO row only renders when the Enhancer is available, so without it there is no toggle to set. Alternatively skip the plan and set the option directly: `wp option update ai_seo_enhancer_enabled 1`.

Sanity check before starting: open the post editor and confirm the ✦ Ask AI icon is in the toolbar. If it isn't, one of the above is missing and every step below will read as a false negative.

Starting point, which the steps below carry on from:

- Activate SEO Tools: `/wp-admin/admin.php?page=jetpack#/traffic`
- Set SEO Enhancer on, writing assistant on: `/wp-admin/admin.php?page=jetpack-ai`

### Sidebar stays away when the Enhancer can't run

- Set writing assistant off: `/wp-admin/admin.php?page=jetpack-ai`
- Deactivate SEO Tools: `/wp-admin/admin.php?page=jetpack#/traffic`
- Go to the post editor: `/wp-admin/post-new.php`

Expect: no Jetpack AI panel, and no ✦ Ask AI icon in the editor toolbar. On a site where another provider also draws the agent panel, expect Jetpack's contributions to disappear rather than the panel itself.

### Sidebar opens when it can run

- Activate SEO Tools: `/wp-admin/admin.php?page=jetpack#/traffic`
- Go to post editor: `/wp-admin/post-new.php` (or reload)

Expect: sidebar loads, SEO suggestions offered. Writing features stay off, since the writing assistant is still off.

This step works on any plan on JN, but needs Business or higher on a real WordPress.com site. The SEO suggestions gate on `advanced-seo`, which sits in the free tier of the plan classes — but on WordPress.com `Current_Plan::supports()` defers to `wpcom_site_has_feature()`, where it is Business and up.

### Writing assistant carries it on its own

- Set writing assistant on: `/wp-admin/admin.php?page=jetpack-ai`
- Deactivate SEO Tools: `/wp-admin/admin.php?page=jetpack#/traffic`
- Go to post editor: `/wp-admin/post-new.php` (or reload)

Expect: sidebar loads
