### PR TITLE
Premium Analytics: Exclude source map files from the mirror repo

### DIFF
--- a/projects/packages/premium-analytics/.gitattributes
+++ b/projects/packages/premium-analytics/.gitattributes
@@ -5,6 +5,7 @@
 # Files to exclude from the mirror repo, but included in the monorepo.
 # (see also entries in the monorepo root .gitattributes)
 # Remember to end all directories with `/**` to properly tag every file.
+/build/**/*.map   production-exclude
 routes/**         production-exclude
 packages/**       production-exclude
 shims/**          production-exclude

--- a/projects/packages/premium-analytics/changelog/exclude-source-maps-from-mirror
+++ b/projects/packages/premium-analytics/changelog/exclude-source-maps-from-mirror
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Exclude source map files from the distributed package.


### PR DESCRIPTION
## Proposed changes

* Exclude `build/**/*.map` files from the `Automattic/jetpack-premium-analytics` mirror repo via `production-exclude` in the package's `.gitattributes`.
* The production build currently ships 9 `.min.js.map` files to the mirror. They contribute significantly to the byte size of wpcom PRs that update the package, and follow the same exclusion pattern already used by the connection package and several plugins.
* Source maps remain available in local development builds; only the mirror/distribution output changes.

## Related product discussion/links

*

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Run `jp build packages/premium-analytics --production` (or wait for the mirror build on this PR).
* Verify the generated mirror artifact contains no `.map` files under `build/`, while `.min.js` files are still present.
