### PR TITLE
Premium Analytics: align back-link labels and trim the Popular post helper

### DIFF
--- a/projects/packages/premium-analytics/changelog/wooa7s-1888-copy
+++ b/projects/packages/premium-analytics/changelog/wooa7s-1888-copy
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Widget copy: Use sentence case for the drill-down back links, and shorten the Popular post description to one sentence.

--- a/projects/packages/premium-analytics/widgets/clicks/render.tsx
+++ b/projects/packages/premium-analytics/widgets/clicks/render.tsx
@@ -274,7 +274,7 @@ function ClicksInner( { max }: ClicksInnerProps ) {
 
 	const backLink = isDrillDown ? (
 		<WidgetBackLink
-			label={ __( 'All Clicks', 'jetpack-premium-analytics-pkg' ) }
+			label={ __( 'All clicks', 'jetpack-premium-analytics-pkg' ) }
 			ariaLabel={ __( 'View all clicks', 'jetpack-premium-analytics-pkg' ) }
 			onClick={ clearSelectedClick }
 		/>

--- a/projects/packages/premium-analytics/widgets/locations/render.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/render.tsx
@@ -307,7 +307,7 @@ function LocationsInner( { max, geoGranularity }: LocationsInnerProps ) {
 
 	const backLink = renderSelectedCountry ? (
 		<WidgetBackLink
-			label={ __( 'All Locations', 'jetpack-premium-analytics-pkg' ) }
+			label={ __( 'All locations', 'jetpack-premium-analytics-pkg' ) }
 			ariaLabel={ __( 'View all locations', 'jetpack-premium-analytics-pkg' ) }
 			onClick={ clearSelectedCountry }
 			className={ styles.backLink }

--- a/projects/packages/premium-analytics/widgets/popular-post/widget.json
+++ b/projects/packages/premium-analytics/widgets/popular-post/widget.json
@@ -3,7 +3,7 @@
 	"title": "Popular post",
 	"description": "Your most-viewed post for the selected date range, with its all-time stats.",
 	"help": {
-		"content": "The post with the most views in the dashboard's date range, with its publish date and engagement. The date range selects which post is shown; views, likes, and comments are all-time totals, because the Stats API reports them per post rather than per period."
+		"content": "Your most viewed post in the selected date range, with its all-time views, likes, and comments."
 	},
 	"category": "stats",
 	"presentation": "framed"

--- a/projects/packages/premium-analytics/widgets/top-posts/render.tsx
+++ b/projects/packages/premium-analytics/widgets/top-posts/render.tsx
@@ -468,7 +468,7 @@ function ArchivesReport( { max }: { max: number } ) {
 				resolved = false;
 				break;
 			}
-			label = previousStep ?? __( 'All Archives', 'jetpack-premium-analytics-pkg' );
+			label = previousStep ?? __( 'All archives', 'jetpack-premium-analytics-pkg' );
 			list = parent.children;
 			previousStep = step;
 		}
@@ -505,7 +505,7 @@ function ArchivesReport( { max }: { max: number } ) {
 	const backLink =
 		activeRows === rows ? null : (
 			<WidgetBackLink
-				label={ backLabel ?? __( 'All Archives', 'jetpack-premium-analytics-pkg' ) }
+				label={ backLabel ?? __( 'All archives', 'jetpack-premium-analytics-pkg' ) }
 				ariaLabel={ __( 'Back to the previous archive list', 'jetpack-premium-analytics-pkg' ) }
 				onClick={ handleBack }
 			/>

--- a/projects/packages/premium-analytics/widgets/utm-insights/render.tsx
+++ b/projects/packages/premium-analytics/widgets/utm-insights/render.tsx
@@ -174,7 +174,7 @@ function UtmInsightsInner( { utmDimension, max, showReportLink }: UtmInsightsInn
 
 	const backLink = isDrillDown ? (
 		<WidgetBackLink
-			label={ __( 'All UTM Insights', 'jetpack-premium-analytics-pkg' ) }
+			label={ __( 'All UTM insights', 'jetpack-premium-analytics-pkg' ) }
 			ariaLabel={ __( 'View all UTM insights', 'jetpack-premium-analytics-pkg' ) }
 			onClick={ clearSelectedUtm }
 			className={ styles.backLink }


### PR DESCRIPTION


## Proposed changes

- Standardize drill-down back links to sentence case for consistency: `All clicks`, `All locations`, `All UTM insights`, and `All archives`.
- Shorten the **Popular post** help text while keeping the important all-time context.
- This is a copy-only change with no functional impact.

## Related product discussion/links

- WOOA7S-1888

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Open the Premium Analytics dashboard.
- Drill into **Top locations**, **Top links clicked**, **Top UTM**, and the **Archives** view of **Top pages**.
- Confirm their back links read `All locations`, `All clicks`, `All UTM insights`, and `All archives`.
- Hover the info icon on **Popular post** and confirm the help text is: “Your most viewed post in the selected date range, with its all-time views, likes, and comments.”
