### PR TITLE
Connection: prevent fatal when mixed package versions load mid-update

### DIFF
--- a/projects/packages/connection/changelog/fix-connection-mid-update-error-handler-fatal
+++ b/projects/packages/connection/changelog/fix-connection-mid-update-error-handler-fatal
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Error Handler: Prevent a fatal error when a request runs during a plugin update and an older version of the Error_Handler class is already loaded.

--- a/projects/packages/connection/src/class-client.php
+++ b/projects/packages/connection/src/class-client.php
@@ -51,10 +51,12 @@ class Client {
 		// class docblock for the full picture of both error-handling flows.
 		// Outgoing XML-RPC calls (Jetpack_IXR_Client) are funneled through this method too;
 		// tell the transports apart by the endpoint the request targets.
+		// The literals match Error_Handler::ERROR_TYPE_XMLRPC / ERROR_TYPE_REST. The constants
+		// themselves must not be referenced from this class: during a plugin update, a stale
+		// Error_Handler that predates them can already be loaded, and resolving them against
+		// it would fatal the request.
 		$request_path = (string) wp_parse_url( empty( $args['url'] ) ? '' : $args['url'], PHP_URL_PATH );
-		$error_type   = '/xmlrpc.php' === substr( $request_path, -strlen( '/xmlrpc.php' ) )
-			? Error_Handler::ERROR_TYPE_XMLRPC
-			: Error_Handler::ERROR_TYPE_REST;
+		$error_type   = '/xmlrpc.php' === substr( $request_path, -strlen( '/xmlrpc.php' ) ) ? 'xmlrpc' : 'rest';
 
 		Error_Handler::get_instance()->check_api_response_for_errors(
 			$response,

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -482,7 +482,7 @@ class Manager {
 		// REST authentication into verify_xml_rpc_signature()), so the stored error type is
 		// derived from the actual request context rather than hardcoded.
 		$error_type      = $this->get_current_request_transport();
-		$error_direction = Error_Handler::DIRECTION_INCOMING;
+		$error_direction = 'incoming'; // Matches Error_Handler::DIRECTION_INCOMING — see build_connection_error_data() for why the constant is not referenced.
 
 		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 		@list( $token_key, $version, $user_id ) = explode( ':', wp_unslash( $_GET['token'] ) );
@@ -495,7 +495,7 @@ class Manager {
 				|| empty( $version )
 				|| (string) $jetpack_api_version !== $version
 		) {
-			return new \WP_Error( 'malformed_token', 'Malformed token in request', Error_Handler::build_connection_error_data( $signature_details, $error_type, $error_direction ) );
+			return new \WP_Error( 'malformed_token', 'Malformed token in request', $this->build_connection_error_data( $signature_details, $error_type, $error_direction ) );
 		}
 
 		if ( '0' === $user_id ) {
@@ -507,7 +507,7 @@ class Manager {
 				return new \WP_Error(
 					'malformed_user_id',
 					'Malformed user_id in request',
-					Error_Handler::build_connection_error_data( $signature_details, $error_type, $error_direction )
+					$this->build_connection_error_data( $signature_details, $error_type, $error_direction )
 				);
 			}
 			$user_id = (int) $user_id;
@@ -517,20 +517,20 @@ class Manager {
 				return new \WP_Error(
 					'unknown_user',
 					sprintf( 'User %d does not exist', $user_id ),
-					Error_Handler::build_connection_error_data( $signature_details, $error_type, $error_direction )
+					$this->build_connection_error_data( $signature_details, $error_type, $error_direction )
 				);
 			}
 		}
 
 		$token = $this->get_tokens()->get_access_token( $user_id, $token_key, false );
 		if ( is_wp_error( $token ) ) {
-			$token->add_data( Error_Handler::build_connection_error_data( $signature_details, $error_type, $error_direction ) );
+			$token->add_data( $this->build_connection_error_data( $signature_details, $error_type, $error_direction ) );
 			return $token;
 		} elseif ( ! $token ) {
 			return new \WP_Error(
 				'unknown_token',
 				sprintf( 'Token %s:%s:%d does not exist', $token_key, $version, $user_id ),
-				Error_Handler::build_connection_error_data( $signature_details, $error_type, $error_direction )
+				$this->build_connection_error_data( $signature_details, $error_type, $error_direction )
 			);
 		}
 
@@ -572,7 +572,7 @@ class Manager {
 			return new \WP_Error(
 				'could_not_sign',
 				'Unknown signature error',
-				Error_Handler::build_connection_error_data( $signature_details, $error_type, $error_direction )
+				$this->build_connection_error_data( $signature_details, $error_type, $error_direction )
 			);
 		} elseif ( is_wp_error( $signature ) ) {
 			// Jetpack_Signature errors carry their own signature_details (or, for some codes,
@@ -582,7 +582,7 @@ class Manager {
 			if ( isset( $signature_error_data['signature_details'] ) && is_array( $signature_error_data['signature_details'] ) ) {
 				$signature_details = array_merge( $signature_details, $signature_error_data['signature_details'] );
 			}
-			$signature->add_data( Error_Handler::build_connection_error_data( $signature_details, $error_type, $error_direction ) );
+			$signature->add_data( $this->build_connection_error_data( $signature_details, $error_type, $error_direction ) );
 			return $signature;
 		}
 
@@ -596,7 +596,7 @@ class Manager {
 			return new \WP_Error(
 				'invalid_nonce',
 				'Could not add nonce',
-				Error_Handler::build_connection_error_data( $signature_details, $error_type, $error_direction )
+				$this->build_connection_error_data( $signature_details, $error_type, $error_direction )
 			);
 		}
 
@@ -610,7 +610,7 @@ class Manager {
 			return new \WP_Error(
 				'signature_mismatch',
 				'Signature mismatch',
-				Error_Handler::build_connection_error_data( $signature_details, $error_type, $error_direction )
+				$this->build_connection_error_data( $signature_details, $error_type, $error_direction )
 			);
 		}
 
@@ -664,7 +664,33 @@ class Manager {
 			$is_rest            = $has_rest_route_arg || false !== strpos( $request_path, '/' . rest_get_url_prefix() . '/' );
 		}
 
-		return $is_rest ? Error_Handler::ERROR_TYPE_REST : Error_Handler::ERROR_TYPE_XMLRPC;
+		// The literals match Error_Handler::ERROR_TYPE_REST / ERROR_TYPE_XMLRPC — see
+		// build_connection_error_data() for why the constants are not referenced.
+		return $is_rest ? 'rest' : 'xmlrpc';
+	}
+
+	/**
+	 * Builds the standardized connection error data attached to signature-verification errors.
+	 *
+	 * Wraps `Error_Handler::build_connection_error_data()`, falling back to the legacy
+	 * error-data shape when the loaded Error_Handler predates that method: during a plugin
+	 * update, an older version of the class can already be in memory while this file is the
+	 * new one, and a mid-update request must never fatal. For the same reason, code in this
+	 * class must not reference Error_Handler constants introduced along with that method
+	 * ('xmlrpc', 'rest', 'local_state', 'incoming', 'outgoing') — use the literal values.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @param array  $signature_details Details of the request signature being verified.
+	 * @param string $error_type        The transport of the request: 'xmlrpc' or 'rest'.
+	 * @param string $error_direction   The direction of the request: 'incoming' or 'outgoing'.
+	 * @return array Error data for `WP_Error`.
+	 */
+	private function build_connection_error_data( $signature_details, $error_type, $error_direction ) {
+		if ( ! method_exists( Error_Handler::class, 'build_connection_error_data' ) ) {
+			return compact( 'signature_details', 'error_type' );
+		}
+		return Error_Handler::build_connection_error_data( $signature_details, $error_type, $error_direction );
 	}
 
 	/**
@@ -1053,13 +1079,15 @@ class Manager {
 			$connection_owner = get_userdata( $user_token->external_user_id );
 		}
 
-		if ( $connection_owner === false ) {
+		// Reporting is best-effort and must never fatal a request running mid-plugin-update:
+		// skip it when the already-loaded Error_Handler is a stale version predating the factory.
+		if ( $connection_owner === false && method_exists( Error_Handler::class, 'build_connection_wp_error' ) ) {
 			Error_Handler::get_instance()->report_error(
 				Error_Handler::build_connection_wp_error(
 					'invalid_connection_owner',
 					'Invalid connection owner',
 					array( 'token' => '' ),
-					Error_Handler::ERROR_TYPE_LOCAL_STATE,
+					'local_state', // Error_Handler::ERROR_TYPE_LOCAL_STATE.
 					'', // Local-state errors describe the site's database, not a request, so they have no direction.
 					array(
 						'user_id'        => $user_id,


### PR DESCRIPTION
## Proposed changes

Sites auto-updating to the release containing #50992 report fatals from wp-cron sync requests running while the upgrader swaps the plugin files:

> Uncaught Error: Undefined constant Automattic\Jetpack\Connection\Error_Handler::ERROR_TYPE_REST in .../jetpack-connection/src/class-client.php:57

Root cause: a mixed-version window during the update. `Error_Handler` is bootstrapped early in the request, so the **old** class (predating the `ERROR_TYPE_*` constants) is already in memory; `Client` is autoloaded later in the same request and picks up the **new** file from disk, which resolves `Error_Handler::ERROR_TYPE_REST` against the stale class and fatals. The error clears once the update completes, but any site updating from a pre-#50992 release to a newer one can still hit it — including updates to the release this PR ships in.

This PR makes all cross-class references to `Error_Handler` symbols introduced in #50992 safe against a stale loaded `Error_Handler`:

* `Client::remote_request()` (the reported fatal): derive the transport as the `'xmlrpc'` / `'rest'` literals instead of the `ERROR_TYPE_*` constants, as the code did before #50992.
* `Manager` had the same unreported hazard on the incoming-request path:
  * `DIRECTION_INCOMING` and the `get_current_request_transport()` return values become literals.
  * The nine `Error_Handler::build_connection_error_data()` calls in `internal_verify_xml_rpc_signature()` now go through a private wrapper that falls back to the legacy `compact( 'signature_details', 'error_type' )` error-data shape when the loaded `Error_Handler` predates the factory — so an old class keeps receiving data in the shape it understands.
  * The `get_connection_owner()` invalid-owner reporting is skipped via `method_exists()` when `build_connection_wp_error()` isn't available; reporting is best-effort and must never fatal the request.

Not touched: `Error_Handler::get_instance()` and `report_error()` references are safe (both exist with compatible signatures in older package versions), and the debug-helper module already builds its error data by hand for this exact reason.

## Related product discussion/links

* p1786436104146629-slack-CDLH4C1UZ

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

Regression check (normal operation is unchanged):

* On a connected site running this branch, use the Jetpack Debug Helper → Broken Token module to trigger connection errors and confirm they are still stored and surfaced as admin notices.
* Run a sync pass (`wp cron event run jetpack_sync_cron`) and confirm no errors.
* `jp test php packages/connection` and `jp phan packages/connection` pass.

Mixed-version repro (the actual bug):

The fatal needs the *mixed* state — old `Error_Handler` already in memory while the new `Client`/`Manager` files load from disk — so cleanly swapping whole plugin versions (manually or with a rollback plugin) won't trigger it. An mu-plugin that preloads the stale class recreates the state deterministically: PHP keeps the first class definition it sees, so the autoloader skips the new file, exactly as in a real mid-update request.

1. Build and install the Jetpack plugin from this branch on a test site.
2. Grab `class-error-handler.php` from any release that predates #50992, e.g.:
   ```
   cd wp-content
   wget https://downloads.wordpress.org/plugin/jetpack.16.0.zip
   unzip -j jetpack.16.0.zip 'jetpack/jetpack_vendor/automattic/jetpack-connection/src/class-error-handler.php'
   ```
3. Preload it from an mu-plugin:
   ```
   echo '<?php require_once WP_CONTENT_DIR . "/class-error-handler.php";' > mu-plugins/stale-error-handler.php
   ```
4. Trigger an outgoing request (`wp cron event run jetpack_sync_cron`) and browse wp-admin.
   * On trunk, this fatals with `Undefined constant ... ERROR_TYPE_REST`.
   * On this branch, requests complete; error reporting silently degrades to the legacy behavior.
5. Delete the mu-plugin (and the copied file) and confirm error reporting works fully again, e.g. via the Broken Token module.