### PR TITLE
Premium Analytics: match widget footer actions to the dashboard design

### DIFF
--- a/projects/packages/premium-analytics/changelog/premium-analytics-widget-footer-actions
+++ b/projects/packages/premium-analytics/changelog/premium-analytics-widget-footer-actions
@@ -1,0 +1,4 @@
+Significance: patch
+Type: changed
+
+Widgets: restyle the footer actions to match the dashboard design — a "View all" link and an icon-only CSV download.

--- a/projects/packages/premium-analytics/packages/externals/src/index.ts
+++ b/projects/packages/premium-analytics/packages/externals/src/index.ts
@@ -69,6 +69,7 @@ export {
 	Field as FormField,
 	Fieldset,
 	Icon,
+	IconButton,
 	Input,
 	Link,
 	SelectControl,

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/download-csv/__tests__/csv-download-button.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/download-csv/__tests__/csv-download-button.test.tsx
@@ -36,18 +36,30 @@ describe( 'CsvDownloadButton', () => {
 		jest.clearAllMocks();
 	} );
 
-	it( 'supports a solid page action without an icon', () => {
+	it( 'renders the widget footer action as an icon named by its label', () => {
+		render( <CsvDownloadButton onDownload={ jest.fn() } /> );
+
+		const button = screen.getByRole( 'button', { name: 'Download CSV' } );
+		expect( button ).toHaveTextContent( '' );
+		// The decorative SVG is intentionally hidden from the accessibility tree.
+		// eslint-disable-next-line testing-library/no-node-access
+		expect( button.querySelector( 'svg' ) ).not.toBeNull();
+	} );
+
+	it( 'supports a solid page action with a visible label and no icon', () => {
 		render(
 			<CsvDownloadButton
 				onDownload={ jest.fn() }
 				label="Download"
 				variant="solid"
 				showIcon={ false }
+				showLabel
 			/>
 		);
 
 		const button = screen.getByRole( 'button', { name: 'Download' } );
 		expect( button ).toHaveClass( /is-solid/ );
+		expect( button ).toHaveTextContent( 'Download' );
 		// The decorative SVG is intentionally hidden from the accessibility tree.
 		// eslint-disable-next-line testing-library/no-node-access
 		expect( button.querySelector( 'svg' ) ).toBeNull();

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/download-csv/csv-download-button.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/download-csv/csv-download-button.tsx
@@ -1,7 +1,7 @@
 /**
  * External dependencies
  */
-import { Button } from '@jetpack-premium-analytics/externals';
+import { Button, IconButton } from '@jetpack-premium-analytics/externals';
 import { useRegistry } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import { download } from '@wordpress/icons';
@@ -16,7 +16,8 @@ export type CsvDownloadButtonProps = {
 	onDownload: () => Promise< unknown > | void;
 
 	/**
-	 * Visible label. Defaults to "Download CSV".
+	 * Label for the action. Defaults to "Download CSV". Without `showLabel` it
+	 * becomes the icon button's tooltip and accessible name.
 	 */
 	label?: string;
 
@@ -28,9 +29,16 @@ export type CsvDownloadButtonProps = {
 	variant?: ComponentProps< typeof Button >[ 'variant' ];
 
 	/**
-	 * Whether to show the download icon. Defaults to true.
+	 * Whether to show the download icon alongside a visible label. Ignored
+	 * without `showLabel`, where the icon is the whole button.
 	 */
 	showIcon?: boolean;
+
+	/**
+	 * Whether to render the label as text. Defaults to false, the icon-only
+	 * widget footer action; page-level actions opt into a labelled button.
+	 */
+	showLabel?: boolean;
 };
 
 function getErrorMessage( error: unknown ): string {
@@ -61,6 +69,7 @@ export function CsvDownloadButton( {
 	className,
 	variant = 'minimal',
 	showIcon = true,
+	showLabel = false,
 }: CsvDownloadButtonProps ) {
 	const [ isBusy, setIsBusy ] = useState( false );
 	const registry = useRegistry();
@@ -84,15 +93,21 @@ export function CsvDownloadButton( {
 		}
 	};
 
+	const buttonProps = {
+		variant,
+		tone: 'neutral',
+		size: 'compact',
+		onClick,
+		loading: isBusy,
+		className: clsx( styles.downloadCsv, className ),
+	} as const;
+
+	if ( ! showLabel ) {
+		return <IconButton { ...buttonProps } icon={ download } label={ label } />;
+	}
+
 	return (
-		<Button
-			variant={ variant }
-			tone="neutral"
-			size="compact"
-			onClick={ onClick }
-			loading={ isBusy }
-			className={ clsx( styles.downloadCsv, className ) }
-		>
+		<Button { ...buttonProps }>
 			{ showIcon ? <Button.Icon icon={ download } /> : null }
 			<span className={ styles.label }>{ label }</span>
 		</Button>

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-link/__tests__/report-link.test.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-link/__tests__/report-link.test.tsx
@@ -66,7 +66,7 @@ describe( 'ReportLink', () => {
 	it( 'links to the report with shared date params and no page-owned params', () => {
 		render( <ReportLink report="posts" /> );
 
-		const link = screen.getByRole( 'link', { name: 'See report' } );
+		const link = screen.getByRole( 'link', { name: 'View all' } );
 		const href = link.getAttribute( 'href' ) ?? '';
 		const search = new URL( href, 'https://example.com' ).searchParams;
 
@@ -82,6 +82,14 @@ describe( 'ReportLink', () => {
 		expect( search.get( 'date_type' ) ).toBe( 'created' );
 		expect( search.has( 'period' ) ).toBe( false );
 		expect( search.has( 'section' ) ).toBe( false );
+	} );
+
+	it( 'renders through the design system link so it inherits the brand tone', () => {
+		render( <ReportLink report="posts" className="custom-link" /> );
+
+		const link = screen.getByRole( 'link', { name: 'View all' } );
+		expect( link ).toHaveClass( /is-brand/ );
+		expect( link ).toHaveClass( 'custom-link' );
 	} );
 
 	it( 'appends a section and renders custom visible and accessible labels', () => {

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-link/report-link.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-link/report-link.module.scss
@@ -1,0 +1,23 @@
+// A standalone footer action rather than a link inside running text, so it
+// drops the design system's default underline and only shows one on hover.
+.reportLink {
+	font-size: var(--wpds-typography-font-size-md);
+	line-height: var(--wpds-typography-line-height-sm);
+	text-decoration: none;
+}
+
+.reportLink:hover {
+	text-decoration: underline;
+}
+
+// Widgets clip their own overflow and the footer sits flush against that edge,
+// so the design system's outset ring is cut off on the inline-start side. Draw
+// it inset instead. The block padding gives the ring room around the text
+// without moving the link, which has to stay aligned with the widget body.
+.reportLink:focus-visible {
+	border-radius: var(--wpds-border-radius-sm);
+	padding-block: var(--wpds-dimension-padding-xs);
+	margin-block: calc(-1 * var(--wpds-dimension-padding-xs));
+	outline: var(--wpds-border-width-focus) solid var(--wpds-color-stroke-focus);
+	outline-offset: calc(-1 * var(--wpds-border-width-focus));
+}

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-link/report-link.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-link/report-link.tsx
@@ -1,14 +1,17 @@
 /**
  * External dependencies
  */
+import { Link } from '@jetpack-premium-analytics/externals';
 import { pickReportDateParams } from '@jetpack-premium-analytics/routing';
 import { __ } from '@wordpress/i18n';
 import { Link as RouteLink } from '@wordpress/route';
+import clsx from 'clsx';
 import { useMemo } from 'react';
 /**
  * Internal dependencies
  */
 import { useWidgetRootContext } from '../widget-root';
+import styles from './report-link.module.scss';
 
 export type ReportLinkProps = {
 	/**
@@ -22,12 +25,12 @@ export type ReportLinkProps = {
 	section?: string;
 
 	/**
-	 * Visible link label. Defaults to "See report".
+	 * Visible link label. Defaults to "View all".
 	 */
 	label?: string;
 
 	/**
-	 * Optional accessible label to disambiguate identical "See report" links on one page.
+	 * Optional accessible label to disambiguate identical "View all" links on one page.
 	 */
 	ariaLabel?: string;
 
@@ -56,14 +59,18 @@ export function ReportLink( { report, section, label, ariaLabel, className }: Re
 	);
 
 	return (
-		<RouteLink
-			to="/reports/$report"
-			params={ { report } as unknown as never }
-			search={ search as unknown as never }
-			className={ className }
+		<Link
+			render={
+				<RouteLink
+					to="/reports/$report"
+					params={ { report } as unknown as never }
+					search={ search as unknown as never }
+				/>
+			}
+			className={ clsx( styles.reportLink, className ) }
 			aria-label={ ariaLabel }
 		>
-			{ label ?? __( 'See report', 'jetpack-premium-analytics-pkg' ) }
-		</RouteLink>
+			{ label ?? __( 'View all', 'jetpack-premium-analytics-pkg' ) }
+		</Link>
 	);
 }

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-csv-action.tsx
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/report-page/report-csv-action.tsx
@@ -27,6 +27,7 @@ export function ReportCsvAction< Row >( props: ReportCsvActionProps< Row > ) {
 			label={ __( 'Download', 'jetpack-premium-analytics-pkg' ) }
 			variant="solid"
 			showIcon={ false }
+			showLabel
 			{ ...props }
 		/>
 	);

--- a/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-footer/widget-footer.module.scss
+++ b/projects/packages/premium-analytics/packages/widgets-toolkit/src/components/widget-footer/widget-footer.module.scss
@@ -7,7 +7,7 @@
 	border-block-start:
 		var(--wpds-border-width-xs) solid
 		var(--wpds-color-stroke-surface-neutral-weak);
-	padding-block-start: var(--wpds-dimension-padding-md);
+	padding-block-start: var(--wpds-dimension-padding-lg);
 }
 
 .footer:empty {

--- a/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
+++ b/projects/packages/premium-analytics/routes/post-detail/config/tab-layouts.ts
@@ -43,7 +43,7 @@ export const POST_DETAIL_TAB_LAYOUTS: Record< PostDetailTabId, DashboardWidget[]
 			// The alias carries the mock's "UTM" card title; the registry's
 			// global "UTM Insights" title is owned by the copy spreadsheet work.
 			type: 'jpa/utm-insights--utm',
-			// Detail-page widgets carry no "See report" action per the design
+			// Detail-page widgets carry no "View all" action per the design
 			// mocks — the post detail page is itself the terminal page, and the
 			// site-wide UTM report would silently drop this post's scope.
 			attributes: { utmDimension: 'utm_source,utm_medium', max: 10, showReportLink: false },

--- a/projects/packages/premium-analytics/widgets/authors/__tests__/authors.test.tsx
+++ b/projects/packages/premium-analytics/widgets/authors/__tests__/authors.test.tsx
@@ -86,7 +86,7 @@ describe( 'AuthorsWidget', () => {
 	it( 'links to the Authors report', () => {
 		renderInDashboard( <AuthorsWidget attributes={ { max: 7 } } /> );
 
-		expect( screen.getByRole( 'link', { name: 'See report' } ) ).toHaveAttribute(
+		expect( screen.getByRole( 'link', { name: 'View all' } ) ).toHaveAttribute(
 			'href',
 			expect.stringContaining( '/reports/authors' )
 		);

--- a/projects/packages/premium-analytics/widgets/clicks/__tests__/clicks.test.tsx
+++ b/projects/packages/premium-analytics/widgets/clicks/__tests__/clicks.test.tsx
@@ -92,7 +92,7 @@ describe( 'ClicksWidget', () => {
 	it( 'links to the Clicks report', () => {
 		render( <ClicksWidget attributes={ { max: 10 } } /> );
 
-		expect( screen.getByRole( 'link', { name: 'See report' } ) ).toHaveAttribute(
+		expect( screen.getByRole( 'link', { name: 'View all' } ) ).toHaveAttribute(
 			'href',
 			expect.stringContaining( '/reports/clicks' )
 		);

--- a/projects/packages/premium-analytics/widgets/file-downloads/__tests__/file-downloads.test.tsx
+++ b/projects/packages/premium-analytics/widgets/file-downloads/__tests__/file-downloads.test.tsx
@@ -25,7 +25,7 @@ describe( 'FileDownloadsWidget', () => {
 	it( 'links to the Downloads report', () => {
 		render( <FileDownloadsWidget attributes={ { max: 10 } } /> );
 
-		expect( screen.getByRole( 'link', { name: 'See report' } ) ).toHaveAttribute(
+		expect( screen.getByRole( 'link', { name: 'View all' } ) ).toHaveAttribute(
 			'href',
 			expect.stringContaining( '/reports/downloads' )
 		);

--- a/projects/packages/premium-analytics/widgets/locations/__tests__/locations.test.tsx
+++ b/projects/packages/premium-analytics/widgets/locations/__tests__/locations.test.tsx
@@ -56,7 +56,7 @@ describe( 'LocationsWidget', () => {
 	it( 'links to the Locations report', () => {
 		render( <LocationsWidget attributes={ {} } /> );
 
-		expect( screen.getByRole( 'link', { name: 'See report' } ) ).toHaveAttribute(
+		expect( screen.getByRole( 'link', { name: 'View all' } ) ).toHaveAttribute(
 			'href',
 			expect.stringContaining( '/reports/locations' )
 		);

--- a/projects/packages/premium-analytics/widgets/referrers/__tests__/referrers.test.tsx
+++ b/projects/packages/premium-analytics/widgets/referrers/__tests__/referrers.test.tsx
@@ -252,7 +252,7 @@ describe( 'ReferrersWidget', () => {
 			/>
 		);
 
-		const link = screen.getByRole( 'link', { name: 'See report' } );
+		const link = screen.getByRole( 'link', { name: 'View all' } );
 		expect( link ).toHaveAttribute( 'href', expect.stringContaining( '/reports/referrers' ) );
 	} );
 } );

--- a/projects/packages/premium-analytics/widgets/search-terms/__tests__/search-terms.test.tsx
+++ b/projects/packages/premium-analytics/widgets/search-terms/__tests__/search-terms.test.tsx
@@ -30,7 +30,7 @@ describe( 'SearchTermsWidget', () => {
 	it( 'links to the Search Terms report', () => {
 		render( <SearchTermsWidget attributes={ {} } /> );
 
-		expect( screen.getByRole( 'link', { name: 'See report' } ) ).toHaveAttribute(
+		expect( screen.getByRole( 'link', { name: 'View all' } ) ).toHaveAttribute(
 			'href',
 			expect.stringContaining( '/reports/search-terms' )
 		);

--- a/projects/packages/premium-analytics/widgets/top-posts/__tests__/top-posts.test.tsx
+++ b/projects/packages/premium-analytics/widgets/top-posts/__tests__/top-posts.test.tsx
@@ -143,7 +143,7 @@ describe( 'TopPostsWidget', () => {
 	it( 'links to the Posts & Pages report', () => {
 		render( <TopPostsWidget attributes={ { max: 10 } } /> );
 
-		expect( screen.getByRole( 'link', { name: 'See report' } ) ).toHaveAttribute(
+		expect( screen.getByRole( 'link', { name: 'View all' } ) ).toHaveAttribute(
 			'href',
 			expect.stringContaining( '/reports/posts' )
 		);
@@ -273,7 +273,7 @@ describe( 'TopPostsWidget', () => {
 			within( toolbar ).queryByRole( 'button', { name: /Download CSV/ } )
 		).not.toBeInTheDocument();
 		const downloadButton = screen.getByRole( 'button', { name: /Download CSV/ } );
-		const reportLink = screen.getByRole( 'link', { name: 'See report' } );
+		const reportLink = screen.getByRole( 'link', { name: 'View all' } );
 		// The shared parent is the footer layout contract under test.
 		// eslint-disable-next-line testing-library/no-node-access
 		expect( downloadButton.parentElement ).toBe( reportLink.parentElement );

--- a/projects/packages/premium-analytics/widgets/utm-insights/__tests__/utm-insights.test.tsx
+++ b/projects/packages/premium-analytics/widgets/utm-insights/__tests__/utm-insights.test.tsx
@@ -33,11 +33,11 @@ describe( 'UtmInsightsWidget', () => {
 	it( 'links to the UTM report', () => {
 		render( <UtmInsightsWidget attributes={ {} } /> );
 
-		expect( screen.getByRole( 'link', { name: 'See report' } ) ).toHaveAttribute(
+		expect( screen.getByRole( 'link', { name: 'View all' } ) ).toHaveAttribute(
 			'href',
 			expect.stringContaining( '/reports/utm' )
 		);
-		expect( screen.getByRole( 'link', { name: 'See report' } ) ).toHaveAttribute(
+		expect( screen.getByRole( 'link', { name: 'View all' } ) ).toHaveAttribute(
 			'href',
 			expect.stringContaining( 'section=source-medium' )
 		);
@@ -48,7 +48,7 @@ describe( 'UtmInsightsWidget', () => {
 			<UtmInsightsWidget attributes={ { utmDimension: 'utm_campaign,utm_source,utm_medium' } } />
 		);
 
-		expect( screen.getByRole( 'link', { name: 'See report' } ) ).toHaveAttribute(
+		expect( screen.getByRole( 'link', { name: 'View all' } ) ).toHaveAttribute(
 			'href',
 			expect.stringContaining( 'section=campaign-source-medium' )
 		);
@@ -57,7 +57,7 @@ describe( 'UtmInsightsWidget', () => {
 	it( 'hides the report link when the host composition opts out', () => {
 		render( <UtmInsightsWidget attributes={ { showReportLink: false } } /> );
 
-		expect( screen.queryByRole( 'link', { name: 'See report' } ) ).not.toBeInTheDocument();
+		expect( screen.queryByRole( 'link', { name: 'View all' } ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'links a drilled-in post to its detail page and carries the report window', async () => {

--- a/projects/packages/premium-analytics/widgets/utm-insights/render.tsx
+++ b/projects/packages/premium-analytics/widgets/utm-insights/render.tsx
@@ -58,7 +58,7 @@ type UtmInsightsInnerProps = {
 	 */
 	max: number;
 	/**
-	 * Whether to render the "See report" footer link.
+	 * Whether to render the "View all" footer link.
 	 */
 	showReportLink: boolean;
 };

--- a/projects/packages/premium-analytics/widgets/utm-insights/widget.ts
+++ b/projects/packages/premium-analytics/widgets/utm-insights/widget.ts
@@ -16,7 +16,7 @@ import { SelectField } from '@jetpack-premium-analytics/fields';
  *
  * @property utmDimension   - UTM dimension to break down by. Defaults to 'utm_source,utm_medium'.
  * @property max            - Maximum rows to display (0 = all). Defaults to 10.
- * @property showReportLink - Whether to render the "See report" footer link. Defaults to true.
+ * @property showReportLink - Whether to render the "View all" footer link. Defaults to true.
  *                          Host compositions on terminal pages (post detail) set this to false;
  *                          it is not a user-facing control.
  */

--- a/projects/packages/premium-analytics/widgets/videopress/__tests__/videopress.test.tsx
+++ b/projects/packages/premium-analytics/widgets/videopress/__tests__/videopress.test.tsx
@@ -146,7 +146,7 @@ describe( 'VideoPressWidget', () => {
 			<VideoPressWidget attributes={ { reportParams: { from: '2026-03-01', to: '2026-03-10' } } } />
 		);
 
-		expect( screen.getByRole( 'link', { name: 'See report' } ) ).toHaveAttribute(
+		expect( screen.getByRole( 'link', { name: 'View all' } ) ).toHaveAttribute(
 			'href',
 			expect.stringContaining( '/reports/videos' )
 		);


### PR DESCRIPTION
## Proposed changes

Update Premium Analytics widget footer actions to match the dashboard design:

- Style the report link with the design system and rename it to "View all".
- Show CSV downloads as an icon-only button in widgets while keeping the labeled button on report pages.
- Align footer spacing and focus styles with the other widget controls.

This fixes the report link using default browser styles and makes the footer actions consistent across widgets.

Widgets clip overflow at the card edge, which also clips the design system's outset focus ring. This PR uses the existing inset-ring workaround; moving the widget's overflow boundary is out of scope.

## Related product discussion/links

- p1786390298530899-slack-C06FSDTSN82

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

1. Run `pnpm run storybook` from `projects/packages/premium-analytics`.
2. Open **Packages / Premium Analytics / Widgets / TopPosts → Widget Dashboard With Widget**.
3. Confirm the footer shows a styled "View all" link and a download icon with a tooltip and accessible name.
4. Confirm keyboard focus is visible and not clipped.
5. Open a report page with an export, such as **Stats / Pages**, and confirm its Download button still includes a label.

<img width="1033" height="833" alt="Screenshot 2026-08-11 at 5 16 44 PM" src="https://github.com/user-attachments/assets/8821d807-d382-4d5d-a8f0-85dcaefb0502"/>
