### PR TITLE
Premium Analytics: remove duplicate padding in the chart-tab widgets

### DIFF
--- a/projects/packages/premium-analytics/changelog/fix-pa-chart-widget-double-padding
+++ b/projects/packages/premium-analytics/changelog/fix-pa-chart-widget-double-padding
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Premium Analytics: remove the duplicate padding around the chart-tab widgets.

--- a/projects/packages/premium-analytics/widgets/subscribers-chart/style.module.css
+++ b/projects/packages/premium-analytics/widgets/subscribers-chart/style.module.css
@@ -3,7 +3,6 @@
 	display: flex;
 	flex-direction: column;
 	height: 100%;
-	padding: var(--wpds-dimension-padding-lg);
 	overflow: hidden;
 }
 

--- a/projects/packages/premium-analytics/widgets/traffic-chart/style.module.css
+++ b/projects/packages/premium-analytics/widgets/traffic-chart/style.module.css
@@ -3,6 +3,5 @@
 	display: flex;
 	flex-direction: column;
 	height: 100%;
-	padding: var(--wpds-dimension-padding-lg);
 	overflow: hidden;
 }

--- a/projects/packages/premium-analytics/widgets/wordads-chart-tabs/style.module.css
+++ b/projects/packages/premium-analytics/widgets/wordads-chart-tabs/style.module.css
@@ -3,6 +3,5 @@
 	display: flex;
 	flex-direction: column;
 	height: 100%;
-	padding: var(--wpds-dimension-padding-lg);
 	overflow: hidden;
 }


### PR DESCRIPTION
## Proposed changes

- Drop the `padding: var(--wpds-dimension-padding-lg)` from the `.root` of the three chart-tab widgets (`subscribers-chart`, `traffic-chart`, `wordads-chart-tabs`), so their content is inset once by the host frame instead of twice.

The widget chrome already pads every widget body (`0 16px 16px`), so these three were adding a second 16px on top of it — putting their content 32px from the card edge while every other widget sits at 16px. In a column that misalignment is visible: on the Subscribers section, "Subscribers summary" starts its content at x=201+16 while "Latest subscribers" directly below it starts at x=201.

These were the only three widgets in `widgets/` whose `.root` declared its own padding; the rest already rely on the host padding alone. The other `.root` declarations (`container-type`, flex, `height: 100%`, `overflow`) are still needed and stay.


## Related product discussion/links

-

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

- Go to **Stats v2 → Subscribers**.
- Compare the left edge of the "Subscribers summary" metric card with the rows in "Latest subscribers" directly below it — they should line up. On trunk the summary widget is indented 16px further.
- Do the same on the **Traffic** tab with "Traffic summary" vs. "Top pages", and on the **Store** tab / WordAds screen for the WordAds chart-tabs widget.
- Check the widget at a few sizes (resize the browser, and resize the widget in edit mode) to confirm the metric tabs, the tabs→dropdown collapse, and the chart still have room.
