### PR TITLE
Connection: don't register in offline mode, stop auto-retrying permanent registration errors, honor 429 Retry-After

### DIFF
--- a/projects/js-packages/connection/changelog/add-connection-registration-backoff
+++ b/projects/js-packages/connection/changelog/add-connection-registration-backoff
@@ -1,0 +1,4 @@
+Significance: patch
+Type: added
+
+Add the registration failure reason to the connection status type.

--- a/projects/js-packages/connection/types.ts
+++ b/projects/js-packages/connection/types.ts
@@ -17,6 +17,17 @@ export type ConnectionScriptData = {
 			wpLocalConstant: boolean;
 		};
 		isPublic: boolean;
+		/** Why the last registration attempt failed; null when it did not. */
+		registrationError: {
+			code: string;
+			message: string;
+			/** Whether retrying could ever succeed without the site's environment changing. */
+			isPermanent: boolean;
+			attempts: number;
+			lastAttemptAt: number;
+			/** Unix timestamp of the next automatic attempt; null when there will not be one. */
+			nextRetryAfter: number | null;
+		} | null;
 	};
 	userConnectionData: {
 		currentUser: {

--- a/projects/packages/connection/changelog/add-connection-registration-backoff
+++ b/projects/packages/connection/changelog/add-connection-registration-backoff
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Hold back automatic WordPress.com registration attempts in offline mode, after failures that cannot be resolved by retrying, and until any Retry-After window has elapsed.

--- a/projects/packages/connection/legacy/class-jetpack-xmlrpc-server.php
+++ b/projects/packages/connection/legacy/class-jetpack-xmlrpc-server.php
@@ -333,7 +333,8 @@ class Jetpack_XMLRPC_Server {
 			if ( isset( $request['from'] ) ) {
 				$this->connection->add_register_request_param( 'from', (string) $request['from'] );
 			}
-			$registered = $this->connection->try_registration();
+			// Provisioning is an explicit request, so it is never held back by a previous failure.
+			$registered = $this->connection->try_registration( true, true );
 			if ( is_wp_error( $registered ) ) {
 				return $this->error( $registered, 'remote_register' );
 			} elseif ( ! $registered ) {

--- a/projects/packages/connection/src/class-manager.php
+++ b/projects/packages/connection/src/class-manager.php
@@ -104,6 +104,13 @@ class Manager {
 	private static $connection_invalidators_added = false;
 
 	/**
+	 * The raw HTTP response of the registration request currently being processed.
+	 *
+	 * @var array|WP_Error|null
+	 */
+	private $last_register_response = null;
+
+	/**
 	 * Initialize the object.
 	 * Make sure to call the "Configure" first.
 	 *
@@ -174,6 +181,8 @@ class Manager {
 		add_action( 'profile_update', array( $user_account_status, 'clean_account_mismatch_transients' ), 9, 1 );
 
 		$manager->add_connection_status_invalidation_hooks();
+
+		Registration_Failure::init_hooks();
 
 		// Set up package version hook.
 		add_filter( 'jetpack_package_versions', __NAMESPACE__ . '\Package_Version::send_package_version_to_tracker' );
@@ -1453,6 +1462,34 @@ class Manager {
 	 * @return true|WP_Error The error object.
 	 */
 	public function register( $api_endpoint = 'register' ) {
+		$this->last_register_response = null;
+
+		$result = $this->do_register( $api_endpoint );
+
+		if ( is_wp_error( $result ) ) {
+			Registration_Failure::record(
+				$result,
+				$this->last_register_response,
+				$this->get_plugin() ? $this->get_plugin()->get_slug() : null
+			);
+		} else {
+			Registration_Failure::clear();
+		}
+
+		$this->last_register_response = null;
+
+		return $result;
+	}
+
+	/**
+	 * Perform the registration request and store the resulting connection data.
+	 *
+	 * @see Manager::register()
+	 *
+	 * @param string $api_endpoint An API endpoint to use.
+	 * @return true|WP_Error The error object.
+	 */
+	private function do_register( $api_endpoint ) {
 		// Clean-up leftover tokens just in-case.
 		// This fixes an edge case that was preventing users to register when the blog token was missing but
 		// there were still leftover user tokens present.
@@ -1544,6 +1581,10 @@ class Manager {
 			true
 		);
 
+		// Kept so that ::register() can read response headers such as `Retry-After`
+		// when recording the failure.
+		$this->last_register_response = $response;
+
 		// Make sure the response is valid and does not contain any Jetpack errors.
 		$registration_details = $this->validate_remote_register_response( $response );
 
@@ -1634,11 +1675,43 @@ class Manager {
 	/**
 	 * Attempts Jetpack registration.
 	 *
+	 * Automatic attempts are held back while a previous failure still stands: some
+	 * registration errors describe the site's environment and cannot be resolved by
+	 * trying again, and the rest are retried on a backoff schedule. Pass `$force` for
+	 * attempts a user explicitly asked for - those are never held back.
+	 *
+	 * @since $$next-version$$ Added the `$force` parameter, the offline mode check, and the retry backoff.
+	 *
 	 * @param bool $tos_agree Whether the user agreed to TOS.
+	 * @param bool $force     Whether this attempt was explicitly requested by a user.
 	 *
 	 * @return bool|WP_Error
 	 */
-	public function try_registration( $tos_agree = true ) {
+	public function try_registration( $tos_agree = true, $force = false ) {
+		if ( $force ) {
+			Registration_Failure::clear();
+		}
+
+		if ( ( new Status() )->is_offline_mode() ) {
+			return new WP_Error(
+				'offline_mode',
+				__( 'Site is in offline mode; WordPress.com registration is not attempted.', 'jetpack-connection' )
+			);
+		}
+
+		if ( ! $force ) {
+			$blocking_error = Registration_Failure::get_blocking_error();
+
+			if ( $blocking_error ) {
+				Registration_Failure::record_suppressed_attempt(
+					$blocking_error,
+					$this->get_plugin() ? $this->get_plugin()->get_slug() : null
+				);
+
+				return $blocking_error;
+			}
+		}
+
 		if ( $tos_agree ) {
 			$terms_of_service = new Terms_Of_Service();
 			$terms_of_service->agree();
@@ -1676,6 +1749,21 @@ class Manager {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Get the reason the last registration attempt failed, if it still stands.
+	 *
+	 * Lets consuming plugins tell the user why the site is not connected - for
+	 * example that WordPress.com cannot reach a site on a private address - instead
+	 * of leaving the connection silently unavailable.
+	 *
+	 * @since $$next-version$$
+	 *
+	 * @return array|null Failure details, or null if the last attempt did not fail.
+	 */
+	public function get_registration_failure() {
+		return Registration_Failure::get();
 	}
 
 	/**

--- a/projects/packages/connection/src/class-registration-failure.php
+++ b/projects/packages/connection/src/class-registration-failure.php
@@ -1,0 +1,363 @@
+<?php
+/**
+ * Registration failure state for the Jetpack connection.
+ *
+ * @package automattic/jetpack-connection
+ */
+
+namespace Automattic\Jetpack\Connection;
+
+use Automattic\Jetpack\Tracking;
+use WP_Error;
+
+/**
+ * Remembers why the last registration attempt failed, and decides whether another
+ * attempt is worth making.
+ *
+ * Registration is triggered by unattended code paths (plugin update hooks, admin
+ * page loads), so a site whose environment can never register - for example one
+ * that WordPress.com cannot reach - would otherwise retry forever. This class
+ * records the failure, blocks automatic retries of errors that cannot resolve on
+ * their own, and backs off exponentially on the ones that can.
+ *
+ * @since $$next-version$$
+ */
+class Registration_Failure {
+
+	/**
+	 * Name of the option holding the failure state.
+	 */
+	const OPTION = 'jetpack_register_failure';
+
+	/**
+	 * Name of the transient used to rate-limit the "retry suppressed" Tracks event.
+	 */
+	const SUPPRESSION_TRACKED_TRANSIENT = 'jetpack_register_suppression_tracked';
+
+	/**
+	 * Longest delay between two automatic attempts.
+	 */
+	const MAX_BACKOFF = DAY_IN_SECONDS;
+
+	/**
+	 * Error codes that cannot be resolved by trying again.
+	 *
+	 * These describe the site's environment or a rejected request, so an automatic
+	 * retry would fail identically. They are cleared by an explicit user action, by
+	 * a successful registration, or by the site URL changing.
+	 */
+	const TERMINAL_ERROR_CODES = array(
+		'siteurl_private_ip',
+		'home_private_ip',
+		'site_inaccessible_403',
+		'site_requires_authorization',
+		'request_cancelled',
+	);
+
+	/**
+	 * Error code suffixes marking a malformed request, which is also not retryable.
+	 */
+	const TERMINAL_ERROR_SUFFIXES = array( '_missing', '_malformed' );
+
+	/**
+	 * Delay before each successive automatic attempt, in seconds.
+	 *
+	 * Attempts past the end of the list reuse the last value.
+	 *
+	 * @return int[]
+	 */
+	private static function backoff_schedule() {
+		return array(
+			MINUTE_IN_SECONDS,
+			5 * MINUTE_IN_SECONDS,
+			30 * MINUTE_IN_SECONDS,
+			2 * HOUR_IN_SECONDS,
+			self::MAX_BACKOFF,
+		);
+	}
+
+	/**
+	 * Register the hooks that discard the state when the site's address changes.
+	 *
+	 * @return void
+	 */
+	public static function init_hooks() {
+		add_action( 'update_option_siteurl', array( __CLASS__, 'clear' ) );
+		add_action( 'update_option_home', array( __CLASS__, 'clear' ) );
+	}
+
+	/**
+	 * Get the stored failure state.
+	 *
+	 * @return array|null The state, or null if there is none or it no longer applies.
+	 */
+	public static function get() {
+		$state = get_option( self::OPTION );
+
+		if ( ! is_array( $state ) || empty( $state['error_code'] ) ) {
+			return null;
+		}
+
+		// A site that moved to a different address deserves a fresh attempt: the
+		// previous failure was about the previous address.
+		if ( ! isset( $state['fingerprint'] ) || self::fingerprint() !== $state['fingerprint'] ) {
+			self::clear();
+			return null;
+		}
+
+		return $state;
+	}
+
+	/**
+	 * Get the error to return instead of attempting registration again, if the
+	 * previous failure still stands.
+	 *
+	 * The code and message are copied from the original failure so that callers
+	 * handling specific error codes keep working; the `suppressed` data flag tells
+	 * apart a remembered failure from a fresh one.
+	 *
+	 * @return WP_Error|null Null when an attempt should be made.
+	 */
+	public static function get_blocking_error() {
+		$state = self::get();
+
+		if ( null === $state ) {
+			return null;
+		}
+
+		$next_retry_after = $state['next_retry_after'] ?? null;
+
+		if ( null !== $next_retry_after && time() >= (int) $next_retry_after ) {
+			return null;
+		}
+
+		return new WP_Error(
+			$state['error_code'],
+			$state['error_message'] ?? '',
+			array(
+				'suppressed'       => true,
+				'status'           => $state['http_status'] ?? null,
+				'next_retry_after' => $next_retry_after,
+			)
+		);
+	}
+
+	/**
+	 * Record a failed registration attempt.
+	 *
+	 * @param WP_Error            $error    The error the attempt failed with.
+	 * @param array|WP_Error|null $response The raw HTTP response, when there was one. Used to read the `Retry-After` header.
+	 * @param string|null         $plugin_slug Slug of the plugin that triggered the attempt, for tracking.
+	 *
+	 * @return void
+	 */
+	public static function record( WP_Error $error, $response = null, $plugin_slug = null ) {
+		$previous = self::get();
+		$attempts = null === $previous ? 1 : (int) $previous['attempts'] + 1;
+
+		$error_code  = (string) $error->get_error_code();
+		$http_status = self::extract_http_status( $error, $response );
+		$is_terminal = self::is_terminal( $error_code );
+
+		$state = array(
+			'error_code'       => $error_code,
+			'error_message'    => (string) $error->get_error_message(),
+			'http_status'      => $http_status,
+			'attempts'         => $attempts,
+			'last_attempt_at'  => time(),
+			'next_retry_after' => $is_terminal ? null : time() + self::backoff_delay( $attempts, $response, $http_status ),
+			'terminal'         => $is_terminal,
+			'fingerprint'      => self::fingerprint(),
+		);
+
+		update_option( self::OPTION, $state, false );
+
+		$is_new_terminal_failure = $is_terminal && ( null === $previous || empty( $previous['terminal'] ) );
+
+		if ( $is_new_terminal_failure ) {
+			self::track(
+				'jpc_register_terminal_failure',
+				array(
+					'error_code'  => $error_code,
+					'http_status' => $http_status,
+					'attempts'    => $attempts,
+				),
+				$plugin_slug
+			);
+		}
+	}
+
+	/**
+	 * Record that an attempt was blocked by the stored state.
+	 *
+	 * Rate-limited to once per backoff window so that a site retrying on every admin
+	 * request does not trade a request storm for an event storm.
+	 *
+	 * @param WP_Error    $error       The error returned in place of the attempt.
+	 * @param string|null $plugin_slug Slug of the plugin that triggered the attempt.
+	 *
+	 * @return void
+	 */
+	public static function record_suppressed_attempt( WP_Error $error, $plugin_slug = null ) {
+		if ( get_transient( self::SUPPRESSION_TRACKED_TRANSIENT ) ) {
+			return;
+		}
+
+		$data             = $error->get_error_data();
+		$next_retry_after = is_array( $data ) && isset( $data['next_retry_after'] ) ? (int) $data['next_retry_after'] : 0;
+		$window           = $next_retry_after > time() ? $next_retry_after - time() : self::MAX_BACKOFF;
+
+		set_transient( self::SUPPRESSION_TRACKED_TRANSIENT, 1, min( $window, self::MAX_BACKOFF ) );
+
+		self::track(
+			'jpc_register_retry_suppressed',
+			array(
+				'error_code' => (string) $error->get_error_code(),
+			),
+			$plugin_slug
+		);
+	}
+
+	/**
+	 * Forget the stored failure.
+	 *
+	 * @return void
+	 */
+	public static function clear() {
+		delete_option( self::OPTION );
+		delete_transient( self::SUPPRESSION_TRACKED_TRANSIENT );
+	}
+
+	/**
+	 * Whether an error code can ever be resolved by trying again.
+	 *
+	 * Unrecognized codes are treated as transient, so a new server-side error does
+	 * not silently become permanent.
+	 *
+	 * @param string $error_code The error code.
+	 *
+	 * @return bool
+	 */
+	public static function is_terminal( $error_code ) {
+		if ( in_array( $error_code, self::TERMINAL_ERROR_CODES, true ) ) {
+			return true;
+		}
+
+		foreach ( self::TERMINAL_ERROR_SUFFIXES as $suffix ) {
+			if ( substr( $error_code, -strlen( $suffix ) ) === $suffix ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Work out how long to wait before the next automatic attempt.
+	 *
+	 * @param int                 $attempts    Number of consecutive failures, including this one.
+	 * @param array|WP_Error|null $response    The raw HTTP response, when there was one.
+	 * @param int|null            $http_status The HTTP status code of the response.
+	 *
+	 * @return int Delay in seconds.
+	 */
+	private static function backoff_delay( $attempts, $response, $http_status ) {
+		$schedule = self::backoff_schedule();
+		$index    = min( max( $attempts, 1 ), count( $schedule ) ) - 1;
+		$delay    = $schedule[ $index ];
+
+		// When the server asks us to wait, that is a floor rather than a suggestion:
+		// it reports the window actually in effect, which can be far longer than the
+		// default one.
+		if ( 429 === $http_status ) {
+			$delay = max( $delay, self::retry_after_seconds( $response ) );
+		}
+
+		$delay = min( $delay, self::MAX_BACKOFF );
+
+		// Spread out sites that failed at the same moment.
+		return $delay + wp_rand( 0, (int) ceil( $delay * 0.1 ) );
+	}
+
+	/**
+	 * Read the `Retry-After` response header.
+	 *
+	 * @param array|WP_Error|null $response The raw HTTP response.
+	 *
+	 * @return int Seconds to wait, or 0 if the header is absent or unusable.
+	 */
+	private static function retry_after_seconds( $response ) {
+		if ( ! is_array( $response ) ) {
+			return 0;
+		}
+
+		$retry_after = wp_remote_retrieve_header( $response, 'retry-after' );
+
+		if ( is_array( $retry_after ) ) {
+			$retry_after = reset( $retry_after );
+		}
+
+		if ( ! is_string( $retry_after ) && ! is_numeric( $retry_after ) ) {
+			return 0;
+		}
+
+		$retry_after = trim( (string) $retry_after );
+
+		if ( is_numeric( $retry_after ) ) {
+			return max( 0, (int) $retry_after );
+		}
+
+		// The header may also be an HTTP date.
+		$timestamp = strtotime( $retry_after );
+
+		return $timestamp ? max( 0, $timestamp - time() ) : 0;
+	}
+
+	/**
+	 * Determine the HTTP status the attempt failed with.
+	 *
+	 * @param WP_Error            $error    The error the attempt failed with.
+	 * @param array|WP_Error|null $response The raw HTTP response, when there was one.
+	 *
+	 * @return int|null
+	 */
+	private static function extract_http_status( WP_Error $error, $response ) {
+		if ( is_array( $response ) ) {
+			$code = wp_remote_retrieve_response_code( $response );
+			if ( $code ) {
+				return (int) $code;
+			}
+		}
+
+		// Most registration errors carry the status code as their error data.
+		$data = $error->get_error_data();
+
+		return is_numeric( $data ) ? (int) $data : null;
+	}
+
+	/**
+	 * Fingerprint of the site addresses the stored failure refers to.
+	 *
+	 * @return string
+	 */
+	private static function fingerprint() {
+		return md5( (string) get_option( 'siteurl' ) . '|' . (string) get_option( 'home' ) );
+	}
+
+	/**
+	 * Send a Tracks event.
+	 *
+	 * @param string      $event_type  Event name, without the `jetpack_` prefix.
+	 * @param array       $data        Event properties.
+	 * @param string|null $plugin_slug Slug of the plugin that triggered the attempt.
+	 *
+	 * @return void
+	 */
+	private static function track( $event_type, array $data, $plugin_slug ) {
+		if ( null !== $plugin_slug ) {
+			$data['plugin_slug'] = $plugin_slug;
+		}
+
+		( new Tracking() )->record_user_event( $event_type, $data );
+	}
+}

--- a/projects/packages/connection/src/class-rest-connector.php
+++ b/projects/packages/connection/src/class-rest-connector.php
@@ -506,6 +506,8 @@ class REST_Connector {
 		$status     = new Status();
 		$connection = new Manager();
 
+		$registration_failure = $connection->get_registration_failure();
+
 		$connection_status = array(
 			'isActive'          => $connection->has_connected_owner(), // TODO deprecate this.
 			'isStaging'         => $status->in_safe_mode(), // TODO deprecate this.
@@ -522,6 +524,15 @@ class REST_Connector {
 				'option'          => (bool) get_option( 'jetpack_offline_mode' ),
 			),
 			'isPublic'          => '1' == get_option( 'blog_public' ), // phpcs:ignore Universal.Operators.StrictComparisons.LooseEqual
+			// Why the site could not be registered, so consumers can explain it rather than retry silently.
+			'registrationError' => null === $registration_failure ? null : array(
+				'code'           => $registration_failure['error_code'],
+				'message'        => $registration_failure['error_message'],
+				'isPermanent'    => (bool) $registration_failure['terminal'],
+				'attempts'       => (int) $registration_failure['attempts'],
+				'lastAttemptAt'  => (int) $registration_failure['last_attempt_at'],
+				'nextRetryAfter' => null === $registration_failure['next_retry_after'] ? null : (int) $registration_failure['next_retry_after'],
+			),
 		);
 
 		/**
@@ -851,7 +862,8 @@ class REST_Connector {
 			}
 		}
 
-		$result = $this->connection->try_registration();
+		// A user asked for this, so it is never held back by a previous failure.
+		$result = $this->connection->try_registration( true, true );
 
 		if ( is_wp_error( $result ) ) {
 			return $result;

--- a/projects/packages/connection/src/identity-crisis/class-rest-endpoints.php
+++ b/projects/packages/connection/src/identity-crisis/class-rest-endpoints.php
@@ -241,7 +241,8 @@ class REST_Endpoints {
 		do_action( 'jetpack_idc_disconnect' );
 
 		$connection = new Connection_Manager();
-		$result     = $connection->try_registration( true );
+		// A user asked for this, so it is never held back by a previous failure.
+		$result = $connection->try_registration( true, true );
 
 		// early return if site registration fails.
 		if ( ! $result || is_wp_error( $result ) ) {

--- a/projects/packages/connection/tests/php/Registration_Failure_Test.php
+++ b/projects/packages/connection/tests/php/Registration_Failure_Test.php
@@ -1,0 +1,344 @@
+<?php
+/**
+ * Registration failure state and retry backoff testing.
+ *
+ * @package automattic/jetpack-connection
+ */
+
+namespace Automattic\Jetpack\Connection;
+
+use Automattic\Jetpack\Constants;
+use Automattic\Jetpack\Status\Cache as StatusCache;
+use PHPUnit\Framework\Attributes\CoversClass;
+use WpOrg\Requests\Utility\CaseInsensitiveDictionary;
+
+/**
+ * Registration failure state and retry backoff testing.
+ *
+ * @covers \Automattic\Jetpack\Connection\Registration_Failure
+ */
+#[CoversClass( Registration_Failure::class )]
+class Registration_Failure_Test extends \WorDBless\BaseTestCase {
+
+	/**
+	 * The connection manager.
+	 *
+	 * @var Manager
+	 */
+	private $manager;
+
+	/**
+	 * Number of registration requests the HTTP mock has intercepted.
+	 *
+	 * @var int
+	 */
+	private $register_request_count = 0;
+
+	/**
+	 * The canned response the HTTP mock returns for a registration request.
+	 *
+	 * @var array|\WP_Error
+	 */
+	private $register_response;
+
+	/**
+	 * Set up the test.
+	 */
+	public function set_up() {
+		$this->manager                = new Manager();
+		$this->register_request_count = 0;
+		$this->register_response      = self::success_response();
+
+		Constants::set_constant( 'JETPACK__API_BASE', 'https://jetpack.wordpress.com/jetpack.' );
+
+		// Avoid an extra request to determine the site creation date.
+		set_transient( 'jetpack_assumed_site_creation_date', '2021-01-01 01:01:01' );
+
+		add_filter( 'pre_http_request', array( $this, 'intercept_http_request' ), 10, 3 );
+	}
+
+	/**
+	 * Clean up after the test.
+	 */
+	public function tear_down() {
+		remove_filter( 'pre_http_request', array( $this, 'intercept_http_request' ), 10 );
+		delete_transient( 'jetpack_assumed_site_creation_date' );
+		Registration_Failure::clear();
+		remove_all_filters( 'jetpack_offline_mode' );
+		StatusCache::clear();
+		Constants::clear_constants();
+	}
+
+	/**
+	 * Intercept every outgoing HTTP request so that no test reaches the network.
+	 *
+	 * @param bool|array $response The existing response.
+	 * @param array      $args     The request arguments.
+	 * @param string     $url      The request URL.
+	 *
+	 * @return array|\WP_Error
+	 */
+	public function intercept_http_request( $response, $args, $url ) {
+		if ( str_contains( $url, 'jetpack.register' ) ) {
+			++$this->register_request_count;
+			return $this->register_response;
+		}
+
+		return array(
+			'headers'  => self::headers( array() ),
+			'body'     => '',
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+		);
+	}
+
+	/**
+	 * Test that no registration request is made while the site is in offline mode.
+	 */
+	public function test_offline_mode_prevents_registration_request() {
+		add_filter( 'jetpack_offline_mode', '__return_true' );
+		StatusCache::clear();
+
+		$result = $this->manager->try_registration();
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'offline_mode', $result->get_error_code() );
+		$this->assertSame( 0, $this->register_request_count );
+		$this->assertNull( $this->manager->get_registration_failure() );
+	}
+
+	/**
+	 * Test that an error which cannot resolve on its own stops further attempts.
+	 */
+	public function test_terminal_error_blocks_subsequent_attempts() {
+		$this->register_response = self::error_response( 'siteurl_private_ip', 'The site URL is a private IP address.', 400 );
+
+		$first = $this->manager->try_registration();
+
+		$this->assertInstanceOf( \WP_Error::class, $first );
+		$this->assertSame( 'siteurl_private_ip', $first->get_error_code() );
+		$this->assertSame( 1, $this->register_request_count );
+
+		$state = $this->recorded_failure();
+		$this->assertTrue( $state['terminal'] );
+		$this->assertNull( $state['next_retry_after'] );
+		$this->assertSame( 1, $state['attempts'] );
+
+		$second = $this->manager->try_registration();
+
+		$this->assertInstanceOf( \WP_Error::class, $second );
+		$this->assertSame( 'siteurl_private_ip', $second->get_error_code() );
+		$this->assertSame( 'The site URL is a private IP address.', $second->get_error_message() );
+		$this->assertSame( 1, $this->register_request_count, 'A terminal failure must not be retried automatically.' );
+
+		$data = $second->get_error_data();
+		$this->assertIsArray( $data );
+		$this->assertTrue( $data['suppressed'] );
+	}
+
+	/**
+	 * Test that a temporary error is retried on a lengthening schedule.
+	 */
+	public function test_transient_error_backs_off_and_retries_after_expiry() {
+		$this->register_response = self::error_response( 'connection_refused', 'Connection refused.', 400 );
+
+		$this->manager->try_registration();
+
+		$first_state = $this->recorded_failure();
+		$this->assertFalse( $first_state['terminal'] );
+		$this->assertGreaterThan( time(), $first_state['next_retry_after'] );
+		$this->assertSame( 1, $this->register_request_count );
+
+		// Still within the backoff window: no request, and the stored error comes back.
+		$blocked = $this->manager->try_registration();
+		$this->assertInstanceOf( \WP_Error::class, $blocked );
+		$this->assertSame( 'connection_refused', $blocked->get_error_code() );
+		$this->assertSame( 1, $this->register_request_count );
+
+		self::expire_backoff();
+
+		$this->manager->try_registration();
+
+		$second_state = $this->recorded_failure();
+		$this->assertSame( 2, $this->register_request_count );
+		$this->assertSame( 2, $second_state['attempts'] );
+		$this->assertGreaterThan(
+			$first_state['next_retry_after'] - $first_state['last_attempt_at'],
+			$second_state['next_retry_after'] - $second_state['last_attempt_at'],
+			'Each successive failure should wait longer than the last.'
+		);
+	}
+
+	/**
+	 * Test that a 429 response defers the next attempt by at least the `Retry-After` window.
+	 */
+	public function test_too_many_requests_honors_retry_after_header() {
+		$this->register_response = self::error_response(
+			'too_many_requests',
+			'Too many requests.',
+			429,
+			array( 'Retry-After' => '3600' )
+		);
+
+		$before = time();
+		$this->manager->try_registration();
+
+		$state = $this->recorded_failure();
+
+		$this->assertSame( 429, $state['http_status'] );
+		$this->assertFalse( $state['terminal'] );
+		$this->assertGreaterThanOrEqual( $before + 3600, $state['next_retry_after'] );
+		// The window may be padded with jitter, but not stretched beyond it.
+		$this->assertLessThanOrEqual( time() + 3600 + 360, $state['next_retry_after'] );
+	}
+
+	/**
+	 * Test that a successful registration forgets the previous failure.
+	 */
+	public function test_successful_registration_clears_state() {
+		$this->register_response = self::error_response( 'siteurl_private_ip', 'The site URL is a private IP address.', 400 );
+		$this->manager->try_registration();
+		$this->assertIsArray( $this->manager->get_registration_failure() );
+
+		$this->register_response = self::success_response();
+		$this->assertTrue( $this->manager->try_registration( true, true ) );
+
+		$this->assertNull( $this->manager->get_registration_failure() );
+	}
+
+	/**
+	 * Test that moving the site to a different address gives it a fresh chance.
+	 */
+	public function test_changing_siteurl_clears_state() {
+		Registration_Failure::init_hooks();
+
+		$this->register_response = self::error_response( 'siteurl_private_ip', 'The site URL is a private IP address.', 400 );
+		$this->manager->try_registration();
+		$this->assertIsArray( $this->manager->get_registration_failure() );
+
+		update_option( 'siteurl', 'https://reachable.example.com' );
+
+		$this->assertNull( $this->manager->get_registration_failure() );
+
+		$this->manager->try_registration();
+		$this->assertSame( 2, $this->register_request_count, 'A site that moved should be allowed to try again.' );
+	}
+
+	/**
+	 * Test that an attempt a user asked for is never held back.
+	 */
+	public function test_forced_attempt_bypasses_the_gate() {
+		$this->register_response = self::error_response( 'siteurl_private_ip', 'The site URL is a private IP address.', 400 );
+
+		$this->manager->try_registration();
+		$blocked = $this->manager->try_registration();
+
+		$this->assertInstanceOf( \WP_Error::class, $blocked );
+		$this->assertSame( 1, $this->register_request_count );
+
+		$this->manager->try_registration( true, true );
+
+		$this->assertSame( 2, $this->register_request_count );
+	}
+
+	/**
+	 * Get the recorded failure state, asserting that there is one.
+	 *
+	 * @return array
+	 */
+	private function recorded_failure() {
+		$state = $this->manager->get_registration_failure();
+		$this->assertIsArray( $state );
+
+		return (array) $state;
+	}
+
+	/**
+	 * Test the classification of error codes.
+	 */
+	public function test_is_terminal() {
+		$this->assertTrue( Registration_Failure::is_terminal( 'siteurl_private_ip' ) );
+		$this->assertTrue( Registration_Failure::is_terminal( 'request_cancelled' ) );
+		$this->assertTrue( Registration_Failure::is_terminal( 'secret_1_missing' ) );
+		$this->assertTrue( Registration_Failure::is_terminal( 'siteurl_malformed' ) );
+
+		$this->assertFalse( Registration_Failure::is_terminal( 'site_inaccessible' ) );
+		$this->assertFalse( Registration_Failure::is_terminal( 'wpcom_5??' ) );
+		$this->assertFalse( Registration_Failure::is_terminal( 'too_many_requests' ) );
+		// Codes the client does not know about could be temporary, so they are retried.
+		$this->assertFalse( Registration_Failure::is_terminal( 'some_future_error' ) );
+	}
+
+	/**
+	 * Move the stored backoff window into the past.
+	 *
+	 * @return void
+	 */
+	private static function expire_backoff() {
+		$state                     = get_option( Registration_Failure::OPTION );
+		$state['next_retry_after'] = time() - 1;
+		update_option( Registration_Failure::OPTION, $state, false );
+	}
+
+	/**
+	 * Build a successful registration response.
+	 *
+	 * @return array
+	 */
+	private static function success_response() {
+		return array(
+			'headers'  => self::headers( array( 'content-type' => 'application/json' ) ),
+			'body'     => wp_json_encode(
+				array(
+					'jetpack_id'     => '12345',
+					'jetpack_secret' => 'sample_secret',
+				),
+				JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+			),
+			'response' => array(
+				'code'    => 200,
+				'message' => 'OK',
+			),
+		);
+	}
+
+	/**
+	 * Build a failed registration response.
+	 *
+	 * @param string $error       The error code returned by the server.
+	 * @param string $description The error description returned by the server.
+	 * @param int    $status      The HTTP status code.
+	 * @param array  $headers     Additional response headers.
+	 *
+	 * @return array
+	 */
+	private static function error_response( $error, $description, $status, array $headers = array() ) {
+		return array(
+			'headers'  => self::headers( array_merge( array( 'content-type' => 'application/json' ), $headers ) ),
+			'body'     => wp_json_encode(
+				array(
+					'error'             => $error,
+					'error_description' => $description,
+				),
+				JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+			),
+			'response' => array(
+				'code'    => $status,
+				'message' => 'Error',
+			),
+		);
+	}
+
+	/**
+	 * Build a response headers object.
+	 *
+	 * @param array $headers The headers.
+	 *
+	 * @return CaseInsensitiveDictionary
+	 */
+	private static function headers( array $headers ) {
+		return new CaseInsensitiveDictionary( $headers );
+	}
+}

--- a/projects/plugins/jetpack/_inc/class.jetpack-provision.php
+++ b/projects/plugins/jetpack/_inc/class.jetpack-provision.php
@@ -61,7 +61,8 @@ class Jetpack_Provision {
 			// This code mostly copied from Jetpack::admin_page_load.
 			Jetpack::maybe_set_version_option();
 			Jetpack::connection()->add_register_request_param( 'from', 'jetpack-start' );
-			$registered = Jetpack::connection()->try_registration();
+			// Provisioning is an explicit request, so it is never held back by a previous failure.
+			$registered = Jetpack::connection()->try_registration( true, true );
 			if ( is_wp_error( $registered ) ) {
 				return $registered;
 			} elseif ( ! $registered ) {

--- a/projects/plugins/jetpack/changelog/add-connection-registration-backoff
+++ b/projects/plugins/jetpack/changelog/add-connection-registration-backoff
@@ -1,0 +1,4 @@
+Significance: patch
+Type: other
+
+Connection: Keep explicit connect actions exempt from the new registration retry backoff.

--- a/projects/plugins/jetpack/class.jetpack.php
+++ b/projects/plugins/jetpack/class.jetpack.php
@@ -4258,7 +4258,8 @@ p {
 					if ( $from ) {
 						static::connection()->add_register_request_param( 'from', (string) $from );
 					}
-					$registered = static::connection()->try_registration();
+					// A user asked for this, so it is never held back by a previous failure.
+					$registered = static::connection()->try_registration( true, true );
 					if ( is_wp_error( $registered ) ) {
 						$error = $registered->get_error_code();
 						self::state( 'error', $error );


### PR DESCRIPTION
Closes CONNECT-422

## Proposed changes

Registration used to be something a person did: click Connect, get a result. It is now
also something plugins do unattended, from update hooks and admin page loads. The
connection package never adapted — `Manager::register()` makes one request, returns a
`WP_Error`, and keeps no memory of it. A site whose environment can never register (one
WordPress.com cannot reach, one on a private address) therefore retries on every trigger,
forever, with nothing to show the user for it.

This PR gives the package the retry discipline it was missing. All of it is in
`projects/packages/connection/`, except for passing the new "a user asked for this" flag
at two Jetpack plugin entry points.

* **Skip registration in offline mode.** `try_registration()` now returns an
  `offline_mode` error before making any request. The Status package already classifies
  localhost, `.test`/`.local`, `JETPACK_DEV_DEBUG` and friends, and the package already
  trusts it for disconnect gating — these are exactly the environments that cannot
  register. No state to manage, no request sent.
* **Remember why the last attempt failed.** New `Registration_Failure` class, storing
  `{ error_code, error_message, http_status, attempts, last_attempt_at, next_retry_after,
  terminal }` in a non-autoloaded `jetpack_register_failure` option. Written when
  `register()` fails, deleted when it succeeds.
* **Never auto-retry what cannot resolve on its own.** `siteurl_private_ip`,
  `home_private_ip`, `site_inaccessible_403`, `site_requires_authorization`,
  `request_cancelled`, and any `*_missing` / `*_malformed` parameter error are terminal:
  no further automatic attempt is made until the state is cleared. Everything else,
  including error codes the client does not recognize, backs off 1m → 5m → 30m → 2h →
  capped at 24h, with jitter.
* **Honor `Retry-After` on a 429.** The header value is read from the response and used
  as the floor for the next attempt, rather than an assumed constant —
  `validate_remote_register_response()` discards headers, so `register()` now keeps the
  raw response for the state writer.
* **Never block a person.** `try_registration()` takes a new `$force` argument that clears
  the stored state first. It is passed from the REST `connection/register` endpoint, the
  Identity Crisis "start fresh" endpoint, XML-RPC `remote_register`, the legacy
  `?action=register` admin flow, and CLI provisioning.
* **Escape hatch for a site that moves.** The state carries a fingerprint of `siteurl` and
  `home`; if either changes, it is discarded and the site gets a fresh attempt
  immediately. `update_option_siteurl` / `update_option_home` also clear it eagerly.
* **Surface it instead of looping silently.** New `Manager::get_registration_failure()`
  and a `registrationError` field on the connection status REST response, so a consuming
  plugin can tell the user *"WordPress.com can't reach your site because it's on a private
  address"* rather than leaving the connection quietly unavailable.

The returned `WP_Error` keeps the original code and message, so existing consumer error
handling is unaffected; a `'suppressed' => true` data flag distinguishes a remembered
failure from a fresh one.

**Consuming plugins benefit without changing anything.** They already treat a `WP_Error`
return as "bail", which is exactly what the gate produces. WooCommerce is the notable case:
`TransactAccountManager::do_onboarding()` calls `try_registration()` from the
`woocommerce_updated` hook and handles failure by logging and returning, with no memory —
so on sites where the `woocommerce_version` option does not persist and that hook re-fires
on every admin request, registration is attempted continuously. A dependency bump in
consumers is expected as a follow-up, but is not required for the fix to take effect.

**Flagged, deliberately not changed here:** `try_registration( $tos_agree = true )` agrees
to the Terms of Service by default. That was reasonable when a person was clicking Connect;
now that unattended consumer code calls it, the package agrees on the site owner's behalf
with no interaction. This is a product/legal decision rather than a bug fix, so it is left
alone — flagging it so the owning team can decide.

## Related product discussion/links

* 

## Does this pull request change what data or activity we track or use?

Yes — two new Tracks events, both from the connection package's existing `Tracking` class,
alongside the current `jpc_register_begin`:

* `jpc_register_terminal_failure` — fired once when a failure that cannot be retried is
  first recorded. Properties: `error_code`, `http_status`, `attempts`, `plugin_slug`.
* `jpc_register_retry_suppressed` — fired when an automatic attempt is held back, rate
  limited to once per backoff window so a looping site does not trade a request storm for
  an event storm. Properties: `error_code`, `plugin_slug`.

No new personal data; these carry the same error codes already returned to the client.

## Testing instructions

Automated coverage is in
`projects/packages/connection/tests/php/Registration_Failure_Test.php` (8 tests): offline
mode makes no request, a terminal error blocks the next attempt, a transient error backs
off and retries after expiry, a 429 with `Retry-After: 3600` defers accordingly, success
clears the state, a `siteurl` change clears the state, and a forced attempt bypasses the
gate.

To check by hand on a site that is not connected:

1. Force a permanent failure — the simplest way is a site WordPress.com cannot reach (a
   local or private-network install with offline mode filtered off), or filter
   `pre_http_request` to return a `siteurl_private_ip` error body with a 400 status.
2. Trigger registration from an unattended path (any code calling `try_registration()`;
   loading an admin page on a site with WooCommerce 10.5+ works). Confirm the failure is
   stored: `wp option get jetpack_register_failure`.
3. Trigger it again and confirm **no** outgoing request is made — the same `WP_Error` comes
   back immediately, now with `suppressed` in its data.
4. Click **Connect** in the Jetpack UI. Confirm the attempt goes through: the stored state
   is cleared and a request is sent. A person is never blocked.
5. Change the site URL (`wp option update siteurl ...`) and confirm the stored state is
   gone, so the site gets a fresh chance.
6. Enable offline mode (`define( 'JETPACK_DEV_DEBUG', true );`) and confirm
   `try_registration()` returns `offline_mode` with no request at all.
7. Confirm nothing regressed for a healthy site: connect and disconnect normally.
