### PR TITLE
Premium Analytics: defer Cookie Consent initialization

### DIFF
--- a/projects/plugins/premium-analytics/.phan/config.php
+++ b/projects/plugins/premium-analytics/.phan/config.php
@@ -10,4 +10,14 @@
 // Require base config.
 require __DIR__ . '/../../../../.phan/config.base.php';
 
-return make_phan_config( dirname( __DIR__ ) );
+return make_phan_config(
+	dirname( __DIR__ ),
+	array(
+		'exclude_file_list' => array(
+			// Standalone test doubles intentionally redefine package classes and a WordPress function.
+			'tests/php/fixtures/class-analytics.php',
+			'tests/php/fixtures/class-cookie-consent.php',
+			'tests/php/fixtures/functions-wordpress.php',
+		),
+	)
+);

--- a/projects/plugins/premium-analytics/changelog/fix-cookie-consent-translation-timing
+++ b/projects/plugins/premium-analytics/changelog/fix-cookie-consent-translation-timing
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Prevent an early translation-loading warning when Premium Analytics initializes.

--- a/projects/plugins/premium-analytics/src/class-jetpack-premium-analytics.php
+++ b/projects/plugins/premium-analytics/src/class-jetpack-premium-analytics.php
@@ -29,6 +29,17 @@ class Jetpack_Premium_Analytics {
 		// mean translating it on plugins_loaded, too early for the textdomain to be loaded.
 		Analytics::init();
 
+		// Priority 0 leaves time for Cookie Consent to register its own default-priority
+		// init callbacks when the development config filter enables the package.
+		add_action( 'init', array( __CLASS__, 'init_cookie_consent' ), 0 );
+	}
+
+	/**
+	 * Initialize Cookie Consent once WordPress translations can load safely.
+	 *
+	 * @return void
+	 */
+	public static function init_cookie_consent() {
 		// Ships disabled: the banner is planned for a later release. The package stays wired up
 		// so the `jetpack_cookie_consent_config` filter can switch it back on for development.
 		Cookie_Consent::init( array( 'enabled' => false ) );

--- a/projects/plugins/premium-analytics/tests/php/AnalyticsInitTest.php
+++ b/projects/plugins/premium-analytics/tests/php/AnalyticsInitTest.php
@@ -6,6 +6,8 @@
  */
 
 use Automattic\Jetpack\PremiumAnalytics\Analytics;
+use PHPUnit\Framework\Attributes\PreserveGlobalState;
+use PHPUnit\Framework\Attributes\RunInSeparateProcess;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -18,5 +20,41 @@ class AnalyticsInitTest extends TestCase {
 	 */
 	public function test_analytics_class_exists() {
 		$this->assertTrue( class_exists( Analytics::class ) );
+	}
+
+	/**
+	 * Cookie Consent resolves translated defaults, so its initialization must wait for init.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	#[RunInSeparateProcess]
+	#[PreserveGlobalState( false )]
+	public function test_cookie_consent_initialization_is_deferred_until_init() {
+		if ( ! defined( 'ABSPATH' ) ) {
+			define( 'ABSPATH', __DIR__ );
+		}
+
+		$GLOBALS['jpa_test_analytics_init_calls']        = 0;
+		$GLOBALS['jpa_test_cookie_consent_init_configs'] = array();
+
+		require_once __DIR__ . '/fixtures/class-analytics.php';
+		require_once __DIR__ . '/fixtures/class-cookie-consent.php';
+		require_once __DIR__ . '/fixtures/functions-wordpress.php';
+		require_once __DIR__ . '/../../src/class-jetpack-premium-analytics.php';
+
+		new Jetpack_Premium_Analytics();
+
+		$this->assertSame( 1, $GLOBALS['jpa_test_analytics_init_calls'] );
+		$this->assertSame( array(), $GLOBALS['jpa_test_cookie_consent_init_configs'] );
+		$this->assertSame(
+			array( Jetpack_Premium_Analytics::class, 'init_cookie_consent' ),
+			$GLOBALS['jpa_test_actions']['init'][0]['callback'] ?? null
+		);
+		$this->assertSame( 0, $GLOBALS['jpa_test_actions']['init'][0]['priority'] ?? null );
+
+		call_user_func( $GLOBALS['jpa_test_actions']['init'][0]['callback'] );
+
+		$this->assertSame( array( array( 'enabled' => false ) ), $GLOBALS['jpa_test_cookie_consent_init_configs'] );
 	}
 }

--- a/projects/plugins/premium-analytics/tests/php/fixtures/class-analytics.php
+++ b/projects/plugins/premium-analytics/tests/php/fixtures/class-analytics.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Analytics initializer test double.
+ *
+ * @package automattic/jetpack-premium-analytics-plugin
+ */
+
+namespace Automattic\Jetpack\PremiumAnalytics;
+
+/**
+ * Records calls to the package initializer.
+ */
+class Analytics {
+	/**
+	 * Record an initialization call.
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		++$GLOBALS['jpa_test_analytics_init_calls'];
+	}
+}

--- a/projects/plugins/premium-analytics/tests/php/fixtures/class-cookie-consent.php
+++ b/projects/plugins/premium-analytics/tests/php/fixtures/class-cookie-consent.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Cookie Consent initializer test double.
+ *
+ * @package automattic/jetpack-premium-analytics-plugin
+ */
+
+namespace Automattic\Jetpack\CookieConsent;
+
+/**
+ * Records calls to the Cookie Consent initializer.
+ */
+class Cookie_Consent {
+	/**
+	 * Record an initialization call.
+	 *
+	 * @param array $config Cookie Consent configuration.
+	 * @return void
+	 */
+	public static function init( array $config = array() ) {
+		$GLOBALS['jpa_test_cookie_consent_init_configs'][] = $config;
+	}
+}

--- a/projects/plugins/premium-analytics/tests/php/fixtures/functions-wordpress.php
+++ b/projects/plugins/premium-analytics/tests/php/fixtures/functions-wordpress.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * WordPress function test doubles for the plugin wrapper test.
+ *
+ * @package automattic/jetpack-premium-analytics-plugin
+ */
+
+/**
+ * Record an action registration without booting WordPress.
+ *
+ * @param string   $hook_name     Hook name.
+ * @param callable $callback      Hook callback.
+ * @param int      $priority      Hook priority.
+ * @param int      $accepted_args Number of accepted arguments.
+ * @return true
+ */
+function add_action( $hook_name, $callback, $priority = 10, $accepted_args = 1 ) {
+	$GLOBALS['jpa_test_actions'][ $hook_name ][] = array(
+		'callback'      => $callback,
+		'priority'      => $priority,
+		'accepted_args' => $accepted_args,
+	);
+
+	return true;
+}


### PR DESCRIPTION
Fixes WOOA7S-1933

## Proposed changes

* Defer Cookie Consent initialization until `init` priority 0 so translated configuration defaults are not resolved during plugin loading.
* Preserve the existing Premium Analytics bootstrap timing and Cookie Consent development override behavior.
* Add regression coverage for the hook timing and disabled configuration.

<img width="1210" height="190" alt="image" src="https://github.com/user-attachments/assets/d5fec82e-fb2a-4152-8cf1-f89410541592" />

## Related product discussion/links

* None.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* On WordPress 6.7 or later, enable `WP_DEBUG` and activate Premium Analytics.
* Load the WordPress admin and confirm no `_load_textdomain_just_in_time` notice appears for the `jetpack-premium-analytics` text domain.
* Confirm the Premium Analytics admin page remains available.
