### PR TITLE
Premium Analytics: align the post activity heatmap's current week and tooltip with the design

### DIFF
--- a/projects/packages/premium-analytics/changelog/update-pa-heatmap-clip-trailing-days
+++ b/projects/packages/premium-analytics/changelog/update-pa-heatmap-clip-trailing-days
@@ -1,4 +1,4 @@
 Significance: patch
 Type: fixed
 
-Stats: draw the post activity heatmap's current week only through today, matching the design's ragged edge.
+Stats: align the post activity heatmap with the design: draw the current week only through today, and lead the cell tooltip with the view count.

--- a/projects/packages/premium-analytics/changelog/update-pa-heatmap-clip-trailing-days
+++ b/projects/packages/premium-analytics/changelog/update-pa-heatmap-clip-trailing-days
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fixed
+
+Stats: draw the post activity heatmap's current week only through today, matching the design's ragged edge.

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/render.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/render.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * External dependencies
+ */
+import { render, screen } from '@testing-library/react';
+/**
+ * Internal dependencies
+ */
+import PostTrafficActivityRender from '../render';
+import usePostTrafficActivity from '../use-post-traffic-activity';
+import type { ReportParams } from '@jetpack-premium-analytics/data';
+import type { ReactNode } from 'react';
+
+jest.mock( '@wordpress/route', () => jest.requireActual( '../../test-utils' ).mockWordPressRoute );
+
+jest.mock( '../use-post-traffic-activity' );
+
+type TooltipData = { value: number | null; cellLabel?: string; row: number; column: number };
+
+// Keep visx out of jsdom while exercising the widget's tooltip renderer with
+// one cell of each kind: a pre-range filler blank, an in-range blank, and
+// singular/plural counted cells.
+jest.mock( '@jetpack-premium-analytics/externals', () => {
+	const actual = jest.requireActual( '@jetpack-premium-analytics/externals' );
+
+	return {
+		...actual,
+		HeatmapChartUnresponsive: ( {
+			renderTooltip,
+		}: {
+			renderTooltip?: ( data: TooltipData ) => ReactNode;
+		} ) => (
+			<>
+				<div data-testid="tooltip-filler-blank">
+					{ renderTooltip?.( {
+						value: null,
+						cellLabel: 'Mon, Jul 6, 2026',
+						row: 0,
+						column: 0,
+					} ) }
+				</div>
+				<div data-testid="tooltip-in-range-blank">
+					{ renderTooltip?.( {
+						value: null,
+						cellLabel: 'Mon, Jul 13, 2026',
+						row: 0,
+						column: 1,
+					} ) }
+				</div>
+				<div data-testid="tooltip-singular">
+					{ renderTooltip?.( { value: 1, cellLabel: 'Tue, Jul 14, 2026', row: 1, column: 1 } ) }
+				</div>
+				<div data-testid="tooltip-plural">
+					{ renderTooltip?.( {
+						value: 1234,
+						cellLabel: 'Wed, Jul 15, 2026',
+						row: 2,
+						column: 1,
+					} ) }
+				</div>
+			</>
+		),
+	};
+} );
+
+const mockUsePostTrafficActivity = jest.mocked( usePostTrafficActivity );
+
+// Two Monday-aligned weeks: the first is entirely pre-range filler, the second
+// is the selected range. `column * 7 + row` maps a cell back to this series.
+function twoWeeksOfDays() {
+	const days = [];
+	for ( let i = 0; i < 14; i++ ) {
+		const day = new Date( Date.UTC( 2026, 6, 6 + i ) );
+		days.push( { dateString: day.toISOString().slice( 0, 10 ), value: null } );
+	}
+	days[ 8 ].value = 1;
+	days[ 9 ].value = 1234;
+	return days;
+}
+
+const REPORT_PARAMS = {
+	post_id: 779,
+	from: '2026-07-13T00:00:00.000+08:00',
+	to: '2026-07-19T23:59:59.999+08:00',
+} as unknown as ReportParams;
+
+describe( 'PostTrafficActivity tooltip', () => {
+	beforeEach( () => {
+		mockUsePostTrafficActivity.mockReset();
+		mockUsePostTrafficActivity.mockReturnValue( {
+			days: twoWeeksOfDays(),
+			isPaged: false,
+			canShowOlder: false,
+			canShowNewer: false,
+			showOlder: jest.fn(),
+			showNewer: jest.fn(),
+			isLoading: false,
+			isFetching: false,
+			isError: false,
+			hasData: true,
+			refetch: jest.fn(),
+		} );
+	} );
+
+	it( 'labels blanks by what the blank means, and leads counted cells with the count', () => {
+		render( <PostTrafficActivityRender attributes={ { reportParams: REPORT_PARAMS } } /> );
+
+		// Pre-range filler is masked, not measured — no claim about its views.
+		expect( screen.getByTestId( 'tooltip-filler-blank' ) ).toHaveTextContent( 'No data' );
+		// An in-range day with no recorded views really had none.
+		expect( screen.getByTestId( 'tooltip-in-range-blank' ) ).toHaveTextContent( 'No views' );
+
+		expect( screen.getByTestId( 'tooltip-singular' ) ).toHaveTextContent( '1 view' );
+		expect( screen.getByTestId( 'tooltip-plural' ) ).toHaveTextContent( '1,234 views' );
+
+		// The date stays in the tooltip, below the count.
+		expect( screen.getByTestId( 'tooltip-filler-blank' ) ).toHaveTextContent( 'Mon, Jul 6, 2026' );
+	} );
+} );

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/__tests__/use-post-traffic-activity.test.tsx
@@ -52,24 +52,24 @@ describe( 'usePostTrafficActivity', () => {
 
 		const { days } = result.current;
 
-		// The 4-day range pads backward to the grid span (168 days), with the
-		// page snapped to week boundaries (Monday 2026-01-19 → Sunday
-		// 2026-07-05) so it lays out exactly 24 columns.
-		expect( days ).toHaveLength( 168 );
+		// The 4-day range pads backward with the page snapped to week
+		// boundaries (Monday 2026-01-19), but stops at the range end: the
+		// week-completion days past it (2026-07-05) emit no points, so the
+		// chart's ragged-edge option hides their cells.
+		expect( days ).toHaveLength( 167 );
 		expect( days[ 0 ].dateString ).toBe( '2026-01-19' );
 
-		// Values render only inside the selected range; the in-range gap and
-		// the trailing week-completion day are blank.
-		expect( days.slice( -5 ) ).toEqual( [
+		// Values render only inside the selected range; the in-range gap is
+		// blank, and the series ends on the range's last day.
+		expect( days.slice( -4 ) ).toEqual( [
 			{ dateString: '2026-07-01', value: 2 },
 			{ dateString: '2026-07-02', value: null },
 			{ dateString: '2026-07-03', value: 5 },
 			{ dateString: '2026-07-04', value: null },
-			{ dateString: '2026-07-05', value: null },
 		] );
 
 		// Filler days stay blank even where the history has views (2026-06-30).
-		expect( days.slice( 0, -5 ).every( day => day.value === null ) ).toBe( true );
+		expect( days.slice( 0, -4 ).every( day => day.value === null ) ).toBe( true );
 
 		// One page covers the range, so no pager.
 		expect( result.current.isPaged ).toBe( false );
@@ -92,13 +92,14 @@ describe( 'usePostTrafficActivity', () => {
 
 		await waitFor( () => expect( result.current.hasData ).toBe( true ) );
 
-		// Newest page first: ends at the end of the range's last week
-		// (Sunday 2026-07-05), no newer page.
+		// Newest page first: the page window ends at the end of the range's
+		// last week (Sunday 2026-07-05) but the series stops at the range end,
+		// so the trailing cells hide. No newer page.
 		expect( result.current.isPaged ).toBe( true );
 		expect( result.current.canShowNewer ).toBe( false );
 		expect( result.current.canShowOlder ).toBe( true );
-		expect( result.current.days ).toHaveLength( 168 );
-		expect( result.current.days.at( -1 )?.dateString ).toBe( '2026-07-05' );
+		expect( result.current.days ).toHaveLength( 167 );
+		expect( result.current.days.at( -1 )?.dateString ).toBe( '2026-07-04' );
 
 		act( () => result.current.showOlder() );
 

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/package.json
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/package.json
@@ -6,6 +6,7 @@
 	"dependencies": {
 		"@jetpack-premium-analytics/data": "link:../../packages/data",
 		"@jetpack-premium-analytics/externals": "link:../../packages/externals",
+		"@jetpack-premium-analytics/formatters": "link:../../packages/formatters",
 		"@jetpack-premium-analytics/icons": "link:../../packages/icons",
 		"@jetpack-premium-analytics/widgets-toolkit": "link:../../packages/widgets-toolkit",
 		"@wordpress/compose": "8.4.0",

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/render.tsx
@@ -2,6 +2,7 @@
  * External dependencies
  */
 import { toPostId } from '@jetpack-premium-analytics/data';
+import { formatMetricValue } from '@jetpack-premium-analytics/formatters';
 import { reports } from '@jetpack-premium-analytics/icons';
 import {
 	HeatmapChartUnresponsive,
@@ -13,7 +14,7 @@ import {
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { useResizeObserver } from '@wordpress/compose';
 import { useMemo, useState } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { Button, Stack } from '@jetpack-premium-analytics/externals';
 /**
@@ -39,6 +40,27 @@ const CELL_GAP = 4;
 const LABEL_GUTTER = 48;
 const MIN_PAGE_WEEKS = 4;
 const DEFAULT_PAGE_WEEKS = 16;
+
+// Show the exact count before the date instead of the chart's default
+// ordering, mirroring the Insights daily-views heatmap. "No views" rather
+// than a literal 0: the filler cells before the range start share the blank
+// rendering, and a "0 views" claim would be wrong for them.
+function renderCellTooltip( { value, cellLabel }: { value: number | null; cellLabel?: string } ) {
+	return (
+		<>
+			<strong>
+				{ value === null
+					? __( 'No views', 'jetpack-premium-analytics-pkg' )
+					: sprintf(
+							/* translators: %s: number of views, e.g. "2,033". */
+							_n( '%s view', '%s views', value, 'jetpack-premium-analytics-pkg' ),
+							formatMetricValue( value, 'number', { decimals: 0 } )
+					  ) }
+			</strong>
+			<div>{ cellLabel }</div>
+		</>
+	);
+}
 
 /**
  * Whole week columns that fit the measured card width.
@@ -165,6 +187,7 @@ function PostTrafficActivityInner() {
 							// sized to the card, so tracks never need to shrink below it.
 							maxCellWidth={ 64 }
 							maxCellHeight={ 42 }
+							renderTooltip={ renderCellTooltip }
 							className={ styles.heatmap }
 						/>
 					</div>

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/render.tsx
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/render.tsx
@@ -9,11 +9,12 @@ import {
 	WidgetRoot,
 	WidgetState,
 	buildCalendarHeatmapData,
+	toDay,
 	useWidgetRootContext,
 	type ReportParamsFieldAttributes,
 } from '@jetpack-premium-analytics/widgets-toolkit';
 import { useResizeObserver } from '@wordpress/compose';
-import { useMemo, useState } from '@wordpress/element';
+import { useCallback, useMemo, useState } from '@wordpress/element';
 import { __, _n, sprintf } from '@wordpress/i18n';
 import { chevronLeft, chevronRight } from '@wordpress/icons';
 import { Button, Stack } from '@jetpack-premium-analytics/externals';
@@ -40,27 +41,6 @@ const CELL_GAP = 4;
 const LABEL_GUTTER = 48;
 const MIN_PAGE_WEEKS = 4;
 const DEFAULT_PAGE_WEEKS = 16;
-
-// Show the exact count before the date instead of the chart's default
-// ordering, mirroring the Insights daily-views heatmap. "No views" rather
-// than a literal 0: the filler cells before the range start share the blank
-// rendering, and a "0 views" claim would be wrong for them.
-function renderCellTooltip( { value, cellLabel }: { value: number | null; cellLabel?: string } ) {
-	return (
-		<>
-			<strong>
-				{ value === null
-					? __( 'No views', 'jetpack-premium-analytics-pkg' )
-					: sprintf(
-							/* translators: %s: number of views, e.g. "2,033". */
-							_n( '%s view', '%s views', value, 'jetpack-premium-analytics-pkg' ),
-							formatMetricValue( value, 'number', { decimals: 0 } )
-					  ) }
-			</strong>
-			<div>{ cellLabel }</div>
-		</>
-	);
-}
 
 /**
  * Whole week columns that fit the measured card width.
@@ -115,6 +95,55 @@ function PostTrafficActivityInner() {
 	const { data: heatmapData, rowLabels } = useMemo(
 		() => buildCalendarHeatmapData( days ),
 		[ days ]
+	);
+
+	const from = toDay( reportParams.from );
+	const to = toDay( reportParams.to );
+
+	// Show the exact count before the date instead of the chart's default
+	// ordering, mirroring the Insights daily-views heatmap. Blank cells split
+	// by what the blank means: inside the range a day with no recorded views
+	// really had none ("No views"), while the filler days padding the grid
+	// before the range start are masked, not measured — claiming "No views"
+	// there could be false, so they say "No data". Cells map back to `days`
+	// by grid position: the page start is always week-aligned, so
+	// `column * 7 + row` indexes the flat series.
+	const renderCellTooltip = useCallback(
+		( {
+			value,
+			cellLabel,
+			row,
+			column,
+		}: {
+			value: number | null;
+			cellLabel?: string;
+			row: number;
+			column: number;
+		} ) => {
+			let label;
+			if ( value !== null ) {
+				label = sprintf(
+					/* translators: %s: number of views, e.g. "2,033". */
+					_n( '%s view', '%s views', value, 'jetpack-premium-analytics-pkg' ),
+					formatMetricValue( value, 'number', { decimals: 0 } )
+				);
+			} else {
+				const day = days[ column * 7 + row ];
+				const inRange =
+					!! day && !! from && !! to && day.dateString >= from && day.dateString <= to;
+				label = inRange
+					? __( 'No views', 'jetpack-premium-analytics-pkg' )
+					: __( 'No data', 'jetpack-premium-analytics-pkg' );
+			}
+
+			return (
+				<>
+					<strong>{ label }</strong>
+					<div>{ cellLabel }</div>
+				</>
+			);
+		},
+		[ days, from, to ]
 	);
 
 	return (

--- a/projects/packages/premium-analytics/widgets/post-traffic-activity/use-post-traffic-activity.ts
+++ b/projects/packages/premium-analytics/widgets/post-traffic-activity/use-post-traffic-activity.ts
@@ -44,10 +44,12 @@ export interface PostTrafficActivityState {
  * `range end − (pageSpanDays − 1)` with blank filler weeks, and a longer
  * range is paged — the newest page shows first and the header arrows step
  * through the range one page at a time, the oldest page padding backward the
- * same way. Every calendar day of the page gets a point so the heatmap grid
- * stays complete, but days without traffic — and filler days outside the
- * selected range — carry `null`: the design renders them as blank cells
- * rather than zero labels. A `postId` of 0 disables the request.
+ * same way. Every calendar day of the page through the range end gets a
+ * point: days without traffic — and leading filler days before the range —
+ * carry `null` (blank cells per the design, not zero labels), while the days
+ * completing the newest week past the range end emit no point at all, so the
+ * chart's ragged-edge option hides their cells and the current week only
+ * draws through today. A `postId` of 0 disables the request.
  */
 export default function usePostTrafficActivity(
 	postId: number,
@@ -100,13 +102,20 @@ export default function usePostTrafficActivity(
 			pageEnd = clampedEnd < newestPageEnd ? clampedEnd : newestPageEnd;
 		}
 
-		const points = eachDayOfInterval( { start: pageStart, end: pageEnd } ).map( date => {
+		// No points past the range end: the chart's ragged-edge option then
+		// hides the trailing cells of the newest week (future days, on a
+		// rolling preset), per the design. `pageEnd` itself stays week-aligned
+		// so the column count still matches the width measurement.
+		const rangeEnd = parseISO( to );
+		const pointsEnd = rangeEnd < pageEnd ? rangeEnd : pageEnd;
+
+		const points = eachDayOfInterval( { start: pageStart, end: pointsEnd } ).map( date => {
 			const dateString = format( date, 'yyyy-MM-dd' );
 			const inRange = dateString >= from && dateString <= to;
 			const views = inRange ? viewsByDay.get( dateString ) : undefined;
 
-			// Blank (null) for no-traffic and filler days, per the design —
-			// not a `0` label.
+			// Blank (null) for no-traffic and leading filler days, per the
+			// design — not a `0` label.
 			return { dateString, value: views ? views : null };
 		} );
 


### PR DESCRIPTION
Part of WOOA7S-1905 (items 1 and 3).

## Proposed changes

* **Stop emitting heatmap data points past the range end** in `usePostTrafficActivity`. The chart's built-in ragged-edge option (`hideOutOfRangeDays`, on by default in `buildCalendarHeatmapData`) hides the cells of days the series doesn't cover — but only if the series actually stops at the range end. Emitting `value: null` points for the future days of the current week made them part of the series span, so they painted as blank grey cells instead: today being Tue Aug 11, the newest column showed grey cells through Sun Aug 16, reading as covered-but-empty future days. The design prototype's newest column stops at today with a ragged edge.
* The week-aligned page window (`pageEnd`) is untouched: the newest column still exists as a full-week column, so the column count keeps matching the width measurement, and older pages are unaffected (`min(rangeEnd, pageEnd)` is a no-op there).
* **Lead the cell tooltip with the view count.** The design's tooltip shows the value first in bold with the date second; the chart default leads with the date and renders empty cells as "No data". A widget-level `renderTooltip` now renders "%s views" (via `formatMetricValue`) first and the date second, mirroring the value-first convention the Insights daily-views heatmap establishes in #51139 — with one refinement: blank cells split by what the blank means. In-range days with no recorded views say "No views" (true: the endpoint omits zero-view days), while the pre-range filler cells are masked rather than measured, so they say "No data" instead of claiming an unverified zero. Neither uses the design's literal `0`.

## Related product discussion/links

* WOOA7S-1905 tracks these plus the remaining heatmap fit issue (grid clipping at the card's top/bottom edges); that part ships separately.
* The backward padding before the range start intentionally stays as blank grey cells, matching the design's fill-the-card intent.

## Does this pull request change what data or activity we track or use?

No.

## Testing instructions

* Build `packages/premium-analytics` + `plugins/premium-analytics` and open a post detail page (Stats v2 → a post → Traffic activity card).
* With any rolling preset (e.g. Last 30 days), the newest column draws cells only through today — the remaining days of the week are empty slots, not grey cells (compare the design prototype, where the current week's column stops at today).

|Before|After|
|-|-|
|<img width="1286" height="442" alt="截圖 2026-08-12 凌晨12 08 40" src="https://github.com/user-attachments/assets/fdaefe0f-61e1-46d4-a96f-6fec3cd0ce79" />|<img width="1285" height="445" alt="截圖 2026-08-12 凌晨12 03 34" src="https://github.com/user-attachments/assets/4b176178-8d3f-48cb-9c9a-d8bff17db9ef" />|

* Hover a cell with data: the tooltip leads with "<n> views" in bold, date below. Hover an in-range blank cell (a day with no recorded views): "No views". Hover a grey filler cell before the range start: "No data" — those days are masked, not measured, so the tooltip makes no claim about them.

|Before|After|
|-|-|
|<img width="352" height="238" alt="截圖 2026-08-12 上午10 54 33" src="https://github.com/user-attachments/assets/7576aa0f-238d-4d4c-a7e6-4eb5e24822c8" />|<img width="337" height="206" alt="截圖 2026-08-12 上午10 51 47" src="https://github.com/user-attachments/assets/b84e5b48-1639-42b5-924f-15964512d5bc" />|

|Before|After|
|-|-|
|<img width="239" height="150" alt="截圖 2026-08-12 凌晨12 08 43" src="https://github.com/user-attachments/assets/549ad328-2f82-4644-8a54-d9196256c11b" />|<img width="220" height="146" alt="截圖 2026-08-12 凌晨12 04 01" src="https://github.com/user-attachments/assets/3588e0d4-c2a3-40ff-94c0-684e7939b1cd" />|

* Days before the range start keep their grey filler cells (unchanged).
* Select Last 12 months and page with the header arrows: older pages render exactly as before.


