### PR TITLE
STATS-345: Show a pricing screen before the site is connected

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6482,6 +6482,8 @@ importers:
         specifier: ^0.0.26
         version: 0.0.26
 
+  projects/plugins/stats: {}
+
   projects/plugins/videopress:
     dependencies:
       '@automattic/jetpack-base-styles':

--- a/projects/packages/stats-admin/changelog/stats-345-odyssey-pricing-screen
+++ b/projects/packages/stats-admin/changelog/stats-345-odyssey-pricing-screen
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Add a pricing screen for sites that are not yet connected to WordPress.com.

--- a/projects/packages/stats-admin/src/class-odyssey-assets.php
+++ b/projects/packages/stats-admin/src/class-odyssey-assets.php
@@ -44,11 +44,17 @@ class Odyssey_Assets {
 	 */
 	public function load_admin_scripts( $asset_handle, $asset_name, $options = array() ) {
 		$default_options = array(
-			'config_data'          => ( new Odyssey_Config_Data() )->get_data(),
+			'config_data'          => null,
 			'config_variable_name' => 'configData',
 			'enqueue_css'          => true,
 		);
 		$options         = wp_parse_args( $options, $default_options );
+
+		// Built only when the caller brings no config of its own. The dashboard payload reads
+		// plan and blog data that a caller running before a connection cannot use.
+		if ( null === $options['config_data'] ) {
+			$options['config_data'] = ( new Odyssey_Config_Data() )->get_data();
+		}
 		if ( file_exists( __DIR__ . "/../dist/{$asset_name}.js" ) ) {
 			// Load local assets for the convinience of development.
 			Assets::register_script(

--- a/projects/packages/stats-admin/src/class-odyssey-config-data.php
+++ b/projects/packages/stats-admin/src/class-odyssey-config-data.php
@@ -10,6 +10,7 @@ namespace Automattic\Jetpack\Stats_Admin;
 use Automattic\Jetpack\Blaze;
 use Automattic\Jetpack\Current_Plan as Jetpack_Plan;
 use Automattic\Jetpack\Modules;
+use Automattic\Jetpack\Status;
 use Automattic\Jetpack\Status\Host;
 use Jetpack_Options;
 
@@ -34,20 +35,21 @@ class Odyssey_Config_Data {
 	}
 
 	/**
-	 * Return the config for the app.
+	 * The config keys that do not depend on a WordPress.com connection.
+	 *
+	 * Shared with the pricing screen, which runs before the site has a blog ID or a token
+	 * and so can supply none of the site and plan data the dashboard adds on top.
+	 *
+	 * @return array
 	 */
-	public function get_data() {
+	protected function get_base_data() {
 		global $wp_version;
 
-		$blog_id = Jetpack_Options::get_option( 'id' );
-		$host    = new Host();
-
-		$can_blaze = class_exists( 'Automattic\Jetpack\Blaze' ) && Blaze::should_initialize()['can_init'];
+		$host = new Host();
 
 		return array(
 			'admin_page_base'                => $this->get_admin_path(),
 			'api_root'                       => esc_url_raw( rest_url() ),
-			'blog_id'                        => Jetpack_Options::get_option( 'id' ),
 			'enable_all_sections'            => false,
 			'env_id'                         => 'production',
 			'google_analytics_key'           => 'UA-10673494-15',
@@ -67,46 +69,91 @@ class Odyssey_Config_Data {
 			// Intended for apps that do not use redux.
 			'gmt_offset'                     => $this->get_gmt_offset(),
 			'odyssey_stats_base_url'         => admin_url( 'admin.php?page=stats' ),
-			'intial_state'                   => array(
-				'currentUser' => array(
-					'id'           => 1000,
-					'user'         => array(
-						'ID'       => 1000,
-						'username' => 'no-user',
-					),
-					'capabilities' => array(
-						"$blog_id" => $this->get_current_user_capabilities(),
-					),
-				),
-				'sites'       => array(
-					'items'    => array(
-						"$blog_id" => array(
-							'ID'           => $blog_id,
-							'URL'          => site_url(),
-							// Atomic and jetpack sites should return true.
-							'jetpack'      => ! $host->is_wpcom_simple(),
-							'visible'      => true,
-							'capabilities' => $this->get_current_user_capabilities(),
-							'products'     => Jetpack_Plan::get_products(),
-							'plan'         => $this->get_plan(),
-							'options'      => array(
-								'wordads'               => ( new Modules() )->is_active( 'wordads' ),
-								'admin_url'             => admin_url(),
-								'gmt_offset'            => $this->get_gmt_offset(),
-								'is_automated_transfer' => $this->is_automated_transfer( $blog_id ),
-								'is_wpcom_atomic'       => $host->is_woa_site(),
-								'is_wpcom_simple'       => $host->is_wpcom_simple(),
-								'is_vip'                => $host->is_vip_site(),
-								'jetpack_version'       => defined( 'JETPACK__VERSION' ) ? JETPACK__VERSION : '',
-								'stats_admin_version'   => Main::VERSION,
-								'software_version'      => $wp_version,
-								'can_blaze'             => $can_blaze,
-							),
+			// The app decides from these whether wp-admin already serves the
+			// `@wordpress/components` base stylesheet, so every screen needs them, including the
+			// ones that carry no site data.
+			'software_version'               => $wp_version,
+			'stats_admin_version'            => Main::VERSION,
+			// Set when the visitor already picked a plan on the pre-connection screen. The
+			// dashboard reads it to avoid asking the same question again once the site connects.
+			'stats_pricing_choice_recorded'  => Pricing_Page::has_recorded_choice(),
+		);
+	}
+
+	/**
+	 * Return the config for the pre-connection pricing screen.
+	 *
+	 * Carries no blog ID and no initial state: neither exists yet. `site_suffix` is what
+	 * WordPress.com needs to identify the site during a siteless checkout.
+	 *
+	 * @return array
+	 */
+	public function get_pricing_data() {
+		return array_merge(
+			$this->get_base_data(),
+			array(
+				'admin_url'   => admin_url(),
+				'site_suffix' => ( new Status() )->get_site_suffix(),
+			)
+		);
+	}
+
+	/**
+	 * Return the config for the app.
+	 */
+	public function get_data() {
+		global $wp_version;
+
+		$blog_id = Jetpack_Options::get_option( 'id' );
+		$host    = new Host();
+
+		$can_blaze = class_exists( 'Automattic\Jetpack\Blaze' ) && Blaze::should_initialize()['can_init'];
+
+		return array_merge(
+			$this->get_base_data(),
+			array(
+				'blog_id'      => $blog_id,
+				'intial_state' => array(
+					'currentUser' => array(
+						'id'           => 1000,
+						'user'         => array(
+							'ID'       => 1000,
+							'username' => 'no-user',
+						),
+						'capabilities' => array(
+							"$blog_id" => $this->get_current_user_capabilities(),
 						),
 					),
-					'features' => array( "$blog_id" => array( 'data' => $this->get_plan_features() ) ),
+					'sites'       => array(
+						'items'    => array(
+							"$blog_id" => array(
+								'ID'           => $blog_id,
+								'URL'          => site_url(),
+								// Atomic and jetpack sites should return true.
+								'jetpack'      => ! $host->is_wpcom_simple(),
+								'visible'      => true,
+								'capabilities' => $this->get_current_user_capabilities(),
+								'products'     => Jetpack_Plan::get_products(),
+								'plan'         => $this->get_plan(),
+								'options'      => array(
+									'wordads'             => ( new Modules() )->is_active( 'wordads' ),
+									'admin_url'           => admin_url(),
+									'gmt_offset'          => $this->get_gmt_offset(),
+									'is_automated_transfer' => $this->is_automated_transfer( $blog_id ),
+									'is_wpcom_atomic'     => $host->is_woa_site(),
+									'is_wpcom_simple'     => $host->is_wpcom_simple(),
+									'is_vip'              => $host->is_vip_site(),
+									'jetpack_version'     => defined( 'JETPACK__VERSION' ) ? JETPACK__VERSION : '',
+									'stats_admin_version' => Main::VERSION,
+									'software_version'    => $wp_version,
+									'can_blaze'           => $can_blaze,
+								),
+							),
+						),
+						'features' => array( "$blog_id" => array( 'data' => $this->get_plan_features() ) ),
+					),
 				),
-			),
+			)
 		);
 	}
 

--- a/projects/packages/stats-admin/src/class-pricing-page.php
+++ b/projects/packages/stats-admin/src/class-pricing-page.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * The Stats pricing screen shown before a site is connected to WordPress.com.
+ *
+ * @package automattic/jetpack-stats-admin
+ */
+
+namespace Automattic\Jetpack\Stats_Admin;
+
+/**
+ * Registers and renders the pre-connection Stats pricing screen.
+ *
+ * The screen runs the Odyssey `pricing` bundle rather than the dashboard bundle. A site
+ * with no connection has no blog ID and no WordPress.com token, so the dashboard cannot
+ * boot; the pricing screen asks the visitor to choose a plan, and the connection follows
+ * from that choice.
+ */
+class Pricing_Page {
+	/**
+	 * Admin page slug.
+	 *
+	 * Deliberately the same slug `Dashboard` uses, so a site keeps one Stats menu entry and
+	 * one bookmarkable URL whichever of the two screens it qualifies for.
+	 */
+	const PAGE_SLUG = 'stats';
+
+	/**
+	 * My Jetpack's admin page slug.
+	 *
+	 * Landing on this page with no connection makes My Jetpack redirect to its own
+	 * onboarding step, which is where the free plan sends the visitor.
+	 */
+	const MY_JETPACK_PAGE_SLUG = 'my-jetpack';
+
+	/**
+	 * Script handle for the Odyssey pricing bundle.
+	 */
+	const ASSET_HANDLE = 'jp-stats-pricing';
+
+	/**
+	 * DOM id the Odyssey pricing app mounts on.
+	 */
+	const MOUNT_ID = 'jp-stats-pricing';
+
+	/**
+	 * Records that a visitor chose a plan on this screen.
+	 *
+	 * Read once the site connects, to keep the connected dashboard from opening with its own
+	 * pricing grid and asking the same question a second time. A site connected by any other
+	 * route never sets this, so it still gets that grid.
+	 */
+	const CHOICE_OPTION = 'jetpack_stats_pricing_choice_recorded';
+
+	/**
+	 * Whether the class has been initialized.
+	 *
+	 * @var boolean
+	 */
+	private static $initialized = false;
+
+	/**
+	 * Init the pricing screen.
+	 */
+	public static function init() {
+		if ( self::$initialized ) {
+			return;
+		}
+
+		self::$initialized = true;
+		( new self() )->init_hooks();
+	}
+
+	/**
+	 * Initialize the hooks.
+	 */
+	public function init_hooks() {
+		// The Jetpack plugin uses 998 and `Admin_Menu` uses 1000, matching `Dashboard`.
+		add_action( 'admin_menu', array( $this, 'add_wp_admin_menu' ), 999 );
+		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ) );
+	}
+
+	/**
+	 * Add a "Stats" top-level admin menu.
+	 *
+	 * @return void
+	 */
+	public function add_wp_admin_menu() {
+		$page_suffix = add_menu_page(
+			__( 'Stats', 'jetpack-stats-admin' ),
+			_x( 'Stats', 'product name shown in menu', 'jetpack-stats-admin' ),
+			'view_stats',
+			self::PAGE_SLUG,
+			array( $this, 'render' ),
+			'dashicons-chart-bar',
+			2
+		);
+
+		if ( $page_suffix ) {
+			add_action( 'load-' . $page_suffix, array( $this, 'admin_init' ) );
+		}
+	}
+
+	/**
+	 * Render the mount point for the Odyssey pricing app.
+	 *
+	 * The `jp-stats-pricing` class is required, not decorative: Odyssey scopes every one of its
+	 * stylesheets to the set of known mount markers so its generic class names cannot collide
+	 * with wp-admin's own chrome. See `apps/odyssey-stats/webpack-css-scope.js` in wp-calypso.
+	 */
+	public function render() {
+		printf( '<div id="%s" class="jp-stats-pricing"></div>', esc_attr( self::MOUNT_ID ) );
+	}
+
+	/**
+	 * Initialize the admin resources.
+	 */
+	public function admin_init() {
+		add_action( 'admin_enqueue_scripts', array( $this, 'load_admin_scripts' ) );
+	}
+
+	/**
+	 * Load the admin scripts.
+	 */
+	public function load_admin_scripts() {
+		( new Odyssey_Assets() )->load_admin_scripts(
+			self::ASSET_HANDLE,
+			'pricing.min',
+			array(
+				'config_variable_name' => 'jetpackStatsOdysseyPricingConfigData',
+				'config_data'          => $this->get_config_data(),
+			)
+		);
+	}
+
+	/**
+	 * Register the route the screen uses to record a plan choice.
+	 *
+	 * Answered by the site itself rather than proxied to WordPress.com: the choice is made
+	 * before the site has a blog ID, so there is nothing to key it against there yet.
+	 */
+	public function register_rest_routes() {
+		register_rest_route(
+			'jetpack/v4',
+			'/stats-app/pricing-choice',
+			array(
+				'methods'             => \WP_REST_Server::CREATABLE,
+				'callback'            => array( $this, 'record_choice' ),
+				'permission_callback' => array( $this, 'can_record_choice' ),
+			)
+		);
+	}
+
+	/**
+	 * Whether the current user may record a plan choice.
+	 *
+	 * The same capabilities that let them reach the screen in the first place.
+	 *
+	 * @return bool
+	 */
+	public function can_record_choice() {
+		return current_user_can( 'manage_options' ) || current_user_can( 'view_stats' );
+	}
+
+	/**
+	 * Record that a plan choice was made.
+	 *
+	 * @return \WP_REST_Response
+	 */
+	public function record_choice() {
+		self::mark_choice_recorded();
+
+		return rest_ensure_response( array( 'recorded' => true ) );
+	}
+
+	/**
+	 * Remember that this site has already been asked to choose a plan.
+	 */
+	public static function mark_choice_recorded() {
+		// Autoloaded: the connected dashboard reads it on every Stats page load.
+		update_option( self::CHOICE_OPTION, true, true );
+	}
+
+	/**
+	 * Whether this site has already been asked to choose a plan.
+	 *
+	 * @return bool
+	 */
+	public static function has_recorded_choice() {
+		return (bool) get_option( self::CHOICE_OPTION, false );
+	}
+
+	/**
+	 * Config data for the pricing app.
+	 *
+	 * @return array
+	 */
+	protected function get_config_data() {
+		return array_merge(
+			( new Odyssey_Config_Data() )->get_pricing_data(),
+			array(
+				'connect_url' => admin_url( 'admin.php?page=' . self::MY_JETPACK_PAGE_SLUG ),
+				'stats_url'   => admin_url( 'admin.php?page=' . self::PAGE_SLUG ),
+			)
+		);
+	}
+}

--- a/projects/packages/stats-admin/tests/php/Pricing_Page_Test.php
+++ b/projects/packages/stats-admin/tests/php/Pricing_Page_Test.php
@@ -1,0 +1,176 @@
+<?php
+namespace Automattic\Jetpack\Stats_Admin;
+
+use Automattic\Jetpack\Stats_Admin\TestCase as Stats_TestCase;
+use ReflectionMethod;
+
+/**
+ * Unit tests for the pre-connection pricing screen.
+ *
+ * @package automattic/jetpack-stats-admin
+ */
+class Pricing_Page_Test extends Stats_TestCase {
+	/**
+	 * Odyssey scopes all of its CSS to a fixed set of mount markers, so a class outside that
+	 * set leaves the screen unstyled.
+	 */
+	public function test_render_mounts_under_the_odyssey_scope() {
+		$this->expectOutputRegex( '/<div id="jp-stats-pricing" class="jp-stats-pricing">/i' );
+		( new Pricing_Page() )->render();
+	}
+
+	/**
+	 * The screen shares the dashboard's menu slug, so a bookmark and the plugin action link
+	 * stay valid once the site connects and the dashboard takes the slug over.
+	 */
+	public function test_menu_registers_under_the_dashboard_slug() {
+		$GLOBALS['menu'] = array();
+		$this->become_admin();
+
+		( new Pricing_Page() )->add_wp_admin_menu();
+
+		$this->assertContains( Pricing_Page::PAGE_SLUG, array_column( $GLOBALS['menu'], 2 ) );
+	}
+
+	/**
+	 * The route is registered from `init_hooks()`, which only runs on a site with no
+	 * connection — the one state where the screen has to record anything.
+	 */
+	public function test_choice_route_is_registered() {
+		( new Pricing_Page() )->init_hooks();
+
+		// Registering anywhere but on this action is what WordPress warns about, so drive the
+		// hook rather than the method: that covers the wiring as well as the route itself.
+		do_action( 'rest_api_init' );
+
+		$this->assertArrayHasKey(
+			'/jetpack/v4/stats-app/pricing-choice',
+			rest_get_server()->get_routes()
+		);
+	}
+
+	/**
+	 * WordPress.com identifies the site by its suffix during a siteless checkout, and the free
+	 * plan needs somewhere to send the visitor. Neither can be recovered later in JavaScript.
+	 */
+	public function test_config_data_carries_what_the_calls_to_action_need() {
+		$config = $this->get_config_data();
+
+		$this->assertNotEmpty( $config['site_suffix'] );
+		$this->assertStringContainsString( 'page=my-jetpack', $config['connect_url'] );
+		$this->assertStringContainsString( 'page=stats', $config['stats_url'] );
+	}
+
+	/**
+	 * The screen runs before the site has a blog ID, so shipping the key at all would hand the
+	 * app a value it must not trust.
+	 */
+	public function test_config_data_omits_connection_only_keys() {
+		$config = $this->get_config_data();
+
+		$this->assertArrayNotHasKey( 'blog_id', $config );
+		$this->assertArrayNotHasKey( 'intial_state', $config );
+	}
+
+	/**
+	 * A site that has never been offered the choice must still get the dashboard's own pricing
+	 * grid once it connects, so the flag has to start unset.
+	 */
+	public function test_no_choice_is_recorded_by_default() {
+		$this->assertFalse( Pricing_Page::has_recorded_choice() );
+	}
+
+	/**
+	 * The whole point of the flag: a visitor who answered here is not asked again after the
+	 * site connects.
+	 */
+	public function test_recording_a_choice_persists() {
+		Pricing_Page::mark_choice_recorded();
+
+		$this->assertTrue( Pricing_Page::has_recorded_choice() );
+	}
+
+	/**
+	 * The dashboard reads the flag from its config payload, so a recorded choice has to reach
+	 * it there rather than only living in the database.
+	 */
+	public function test_config_data_reports_a_recorded_choice() {
+		$this->assertFalse( ( new Odyssey_Config_Data() )->get_pricing_data()['stats_pricing_choice_recorded'] );
+
+		Pricing_Page::mark_choice_recorded();
+
+		$this->assertTrue( ( new Odyssey_Config_Data() )->get_pricing_data()['stats_pricing_choice_recorded'] );
+	}
+
+	/**
+	 * Recording a choice writes an option, so it cannot be open to any visitor.
+	 */
+	public function test_recording_is_denied_to_a_logged_out_visitor() {
+		wp_set_current_user( 0 );
+
+		$this->assertFalse( ( new Pricing_Page() )->can_record_choice() );
+	}
+
+	/**
+	 * The counterpart: whoever can reach the screen must be able to answer it, or the choice
+	 * is silently dropped for every real user and the grid returns after connecting.
+	 */
+	public function test_recording_is_allowed_for_an_administrator() {
+		$this->become_admin();
+
+		$this->assertTrue( ( new Pricing_Page() )->can_record_choice() );
+	}
+
+	/**
+	 * A visitor who cannot manage the site has no business changing its onboarding state.
+	 */
+	public function test_recording_is_denied_to_a_subscriber() {
+		$subscriber = wp_insert_user(
+			array(
+				'user_login' => 'pricing_subscriber',
+				'user_pass'  => 'password',
+				'role'       => 'subscriber',
+			)
+		);
+		wp_set_current_user( $subscriber );
+
+		$this->assertFalse( ( new Pricing_Page() )->can_record_choice() );
+	}
+
+	/**
+	 * Sign in as an administrator.
+	 *
+	 * `add_menu_page()` and the permission callback both check capabilities, so the tests that
+	 * exercise them need a real user rather than the default logged-out state.
+	 *
+	 * @return int The user id.
+	 */
+	private function become_admin() {
+		$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'pricing_admin',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $admin_id );
+
+		return $admin_id;
+	}
+
+	/**
+	 * Read the screen's protected config builder.
+	 *
+	 * @return array
+	 */
+	private function get_config_data() {
+		$method = new ReflectionMethod( Pricing_Page::class, 'get_config_data' );
+
+		// @todo Remove this call once we no longer need to support PHP <8.1.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$method->setAccessible( true );
+		}
+
+		return $method->invoke( new Pricing_Page() );
+	}
+}

--- a/projects/plugins/stats/.gitattributes
+++ b/projects/plugins/stats/.gitattributes
@@ -1,0 +1,13 @@
+# Files to include in the mirror repo, but excluded via gitignore
+# Remember to end all directories with `/**` to properly tag every file.
+jetpack_vendor/**                               production-include
+vendor/autoload.php                             production-include
+vendor/autoload_packages.php                    production-include
+vendor/automattic/**                            production-include
+vendor/composer/**                              production-include
+vendor/jetpack-autoloader/**                    production-include
+
+# Files to exclude from the mirror repo, but included in the monorepo.
+# (see also entries in the monorepo root .gitattributes)
+# Remember to end all directories with `/**` to properly tag every file.
+/README.md                                      production-exclude

--- a/projects/plugins/stats/.gitattributes
+++ b/projects/plugins/stats/.gitattributes
@@ -11,3 +11,5 @@ vendor/jetpack-autoloader/**                    production-include
 # (see also entries in the monorepo root .gitattributes)
 # Remember to end all directories with `/**` to properly tag every file.
 /README.md                                      production-exclude
+# WordPress.org rejects shell scripts in a plugin ("Application files are not permitted").
+bin/**                                          production-exclude

--- a/projects/plugins/stats/.gitignore
+++ b/projects/plugins/stats/.gitignore
@@ -1,0 +1,6 @@
+vendor/
+node_modules/
+wordpress/
+.cache/
+build/
+jetpack-stats.zip

--- a/projects/plugins/stats/.phan/config.php
+++ b/projects/plugins/stats/.phan/config.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * This configuration will be read and overlaid on top of the
+ * default configuration. Command-line arguments will be applied
+ * after this file is read.
+ *
+ * @package automattic/jetpack-stats-plugin
+ */
+
+// Require base config.
+require __DIR__ . '/../../../../.phan/config.base.php';
+
+return make_phan_config( dirname( __DIR__ ) );

--- a/projects/plugins/stats/.phpcs.dir.xml
+++ b/projects/plugins/stats/.phpcs.dir.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset>
+
+	<rule ref="WordPress.WP.I18n">
+		<properties>
+			<property name="text_domain" type="array">
+				<element value="jetpack-stats" />
+			</property>
+		</properties>
+	</rule>
+	<rule ref="Jetpack.Functions.I18n">
+		<properties>
+			<property name="text_domain" value="jetpack-stats" />
+		</properties>
+	</rule>
+
+	<rule ref="WordPress.Utils.I18nTextDomainFixer">
+		<properties>
+			<property name="old_text_domain" type="array" />
+			<property name="new_text_domain" value="jetpack-stats" />
+		</properties>
+	</rule>
+
+</ruleset>

--- a/projects/plugins/stats/.w.org-assets/README.md
+++ b/projects/plugins/stats/.w.org-assets/README.md
@@ -1,0 +1,7 @@
+# WordPress.org Assets
+
+This directory is intended to hold assets meant for w.org plugins SVN.
+
+There is no auto-deployment of these assets, so once you make changes, please ping the plugin's team or ask the Monorepo team to deploy them.
+
+The icon, banner and screenshot files are still outstanding. Eder is the design DRI for them (STATS-343, Phase 1).

--- a/projects/plugins/stats/CHANGELOG.md
+++ b/projects/plugins/stats/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/projects/plugins/stats/README.md
+++ b/projects/plugins/stats/README.md
@@ -1,0 +1,32 @@
+# Jetpack Stats
+
+A standalone WordPress plugin that ships the Jetpack Stats experience without the full Jetpack plugin.
+
+This project is a packaging shell. All the behaviour lives in monorepo packages:
+
+- `automattic/jetpack-stats` — the tracking pixel, the `view_stats` capability map, the REST provider.
+- `automattic/jetpack-stats-admin` — the Odyssey dashboard wrapper and the REST proxy to the WordPress.com stats API.
+- `automattic/jetpack-connection` — the WordPress.com connection.
+- `automattic/jetpack-my-jetpack` — the My Jetpack product card.
+
+## Requires a WordPress.com connection
+
+Stats is a WordPress.com client. Collection happens through the `pixel.wp.com/g.gif` pixel and reporting reads back from the WordPress.com REST API. The plugin is inert until a connection completes. This is by design and is not something this plugin changes.
+
+## Coexisting with the Jetpack plugin
+
+While the full Jetpack plugin is active it owns the `stats` admin menu, because it chooses between the legacy Stats screen and the Odyssey dashboard. This plugin registers the dashboard only when the Jetpack plugin is absent. See `Jetpack_Stats_Plugin::initialize_other_packages()`.
+
+## Development
+
+```bash
+jp build plugins/stats
+jp test php plugins/stats
+jp phan plugins/stats
+```
+
+The plugin has no front-end build. The dashboard React app is served from the WordPress.com CDN by the `jetpack-stats-admin` package.
+
+## Release
+
+Automated release is switched off for now. `composer.json` sets `autorelease: false`, `autotagger: false` and `wp-svn-autopublish: false`, and declares no `mirror-repo` or `wp-plugin-slug`. Publishing to the WordPress.org directory is tracked separately in STATS-343 Phase 6.

--- a/projects/plugins/stats/README.md
+++ b/projects/plugins/stats/README.md
@@ -29,4 +29,6 @@ The plugin has no front-end build. The dashboard React app is served from the Wo
 
 ## Release
 
-Automated release is switched off for now. `composer.json` sets `autorelease: false`, `autotagger: false` and `wp-svn-autopublish: false`, and declares no `mirror-repo` or `wp-plugin-slug`. Publishing to the WordPress.org directory is tracked separately in STATS-343 Phase 6.
+The plugin is mirrored to GitHub only. `composer.json` sets `mirror-repo` to `Automattic/jetpack-stats-plugin`, so a trunk build pushes there, and `beta-plugin-slug` to `jetpack-stats`, so builds reach the Jetpack Beta Tester.
+
+Tagging and publishing stay off: `autotagger: false` and `autorelease: false`. There is no `wp-svn-autopublish`, and no `wp-plugin-slug`, because the plugin is not in the WordPress.org directory yet. Publishing there is tracked separately in STATS-343 Phase 6, and it is what turns `beta-plugin-slug` into `wp-plugin-slug`.

--- a/projects/plugins/stats/bin/build-zip.sh
+++ b/projects/plugins/stats/bin/build-zip.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+PLUGIN_SLUG="jetpack-stats"
+PROJECT="plugins/stats"
+
+SCRIPT_DIR="$(
+	cd "$(dirname "${BASH_SOURCE[0]}")"
+	pwd -P
+)"
+PLUGIN_DIR="$(
+	cd "$SCRIPT_DIR/.."
+	pwd -P
+)"
+# projects/plugins/stats -> monorepo root is three levels up.
+MONOREPO_ROOT="$(
+	cd "$PLUGIN_DIR/../../.."
+	pwd -P
+)"
+JETPACK_CLI="$MONOREPO_ROOT/tools/cli/bin/jetpack.js"
+OUTPUT_PATH="$PLUGIN_DIR/${PLUGIN_SLUG}.zip"
+
+usage() {
+	cat <<EOF
+Build an installable Jetpack Stats plugin zip.
+
+The zip is built from the current monorepo working tree: the plugin is compiled
+for production in place and staged with the same file-collection that
+\`jetpack rsync\` uses, so the archive contains exactly the production file set
+(plugin PHP, the bundled package build output, and the production autoloader).
+
+Usage:
+  composer build-zip
+  bin/build-zip.sh [options]
+
+Options:
+  -h, --help               Show this help text.
+
+Requirements:
+  - A monorepo dev environment (run \`pnpm install\` at the repo root first).
+  - Standard rsync. macOS ships openrsync, which cannot sync the package
+    symlinks; install real rsync with \`brew install rsync\`.
+
+Note: this performs a production build (\`composer install --no-dev\`) in your
+working tree. Re-run \`jetpack build $PROJECT\` afterwards to restore dev
+dependencies.
+EOF
+}
+
+log() {
+	printf '%s\n' "$*"
+}
+
+error() {
+	printf 'Error: %s\n' "$*" >&2
+	exit 1
+}
+
+require_command() {
+	if ! command -v "$1" >/dev/null 2>&1; then
+		error "Missing required command: $1"
+	fi
+}
+
+require_rsync() {
+	require_command rsync
+
+	# Apple ships a fork of openrsync that cannot properly sync the package
+	# symlinks; it silently copies nothing. Match the guidance from
+	# tools/cli/commands/rsync.js and fail fast.
+	if [[ "$(uname)" == "Darwin" ]] && rsync --version 2>/dev/null | grep -q openrsync; then
+		error "macOS's built-in rsync (openrsync) cannot sync the package symlinks. Please install standard rsync (e.g. \`brew install rsync\`)."
+	fi
+}
+
+jetpack() {
+	node "$JETPACK_CLI" "$@"
+}
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		-h|--help)
+			usage
+			exit 0
+			;;
+		*)
+			error "Unknown option: $1"
+			;;
+	esac
+done
+
+require_command node
+require_command zip
+require_rsync
+
+[[ -f "$JETPACK_CLI" ]] || error "Jetpack CLI not found at $JETPACK_CLI. Run this from a monorepo checkout."
+
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/${PLUGIN_SLUG}-zip.XXXXXX")"
+PLUGIN_STAGE="$WORK_DIR/$PLUGIN_SLUG"
+
+cleanup() {
+	rm -rf "$WORK_DIR"
+}
+trap cleanup EXIT
+
+log "Building production assets for $PROJECT..."
+# --deps also builds the bundled packages so any build output they produce
+# exists for the symlinks that rsync follows.
+jetpack build "$PROJECT" --production --deps
+
+log "Staging production files via jetpack rsync..."
+mkdir -p "$PLUGIN_STAGE"
+jetpack rsync stats "$PLUGIN_STAGE/" --non-interactive
+
+# rsync can exit 0 while copying nothing (e.g. an unsupported rsync fork or a
+# filter mishap), and `zip` happily archives an empty directory. Verify the
+# stage contains the plugin bootstrap and the production autoloader before zipping.
+[[ -f "$PLUGIN_STAGE/jetpack-stats.php" ]] || error "Staged tree at $PLUGIN_STAGE is missing jetpack-stats.php; refusing to zip an incomplete stage."
+[[ -f "$PLUGIN_STAGE/vendor/autoload_packages.php" ]] || error "Staged tree at $PLUGIN_STAGE is missing vendor/autoload_packages.php; refusing to zip an incomplete stage."
+
+log "Creating zip..."
+mkdir -p "$(dirname "$OUTPUT_PATH")"
+rm -f "$OUTPUT_PATH"
+(
+	cd "$WORK_DIR"
+	zip -qr "$OUTPUT_PATH" "$PLUGIN_SLUG"
+)
+
+log "Zip created: $OUTPUT_PATH"

--- a/projects/plugins/stats/changelog/stats-343-standalone-stats-plugin
+++ b/projects/plugins/stats/changelog/stats-343-standalone-stats-plugin
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Initial scaffold for the standalone Jetpack Stats plugin.

--- a/projects/plugins/stats/changelog/stats-343-standalone-stats-plugin#2
+++ b/projects/plugins/stats/changelog/stats-343-standalone-stats-plugin#2
@@ -1,0 +1,5 @@
+Significance: patch
+Type: changed
+Comment: Update composer.lock.
+
+

--- a/projects/plugins/stats/changelog/stats-345-odyssey-pricing-screen
+++ b/projects/plugins/stats/changelog/stats-345-odyssey-pricing-screen
@@ -1,0 +1,4 @@
+Significance: minor
+Type: added
+
+Show a pricing screen instead of the connection flow when the site is not yet connected.

--- a/projects/plugins/stats/composer.json
+++ b/projects/plugins/stats/composer.json
@@ -1,0 +1,73 @@
+{
+	"name": "automattic/jetpack-stats-plugin",
+	"description": "Simple, yet powerful stats to grow your site.",
+	"type": "wordpress-plugin",
+	"license": "GPL-2.0-or-later",
+	"require": {
+		"automattic/jetpack-assets": "@dev",
+		"automattic/jetpack-autoloader": "@dev",
+		"automattic/jetpack-composer-plugin": "@dev",
+		"automattic/jetpack-config": "@dev",
+		"automattic/jetpack-connection": "@dev",
+		"automattic/jetpack-my-jetpack": "@dev",
+		"automattic/jetpack-stats": "@dev",
+		"automattic/jetpack-stats-admin": "@dev",
+		"automattic/jetpack-status": "@dev",
+		"automattic/jetpack-sync": "@dev"
+	},
+	"require-dev": {
+		"automattic/phpunit-select-config": "@dev",
+		"yoast/phpunit-polyfills": "^4.0.0",
+		"automattic/jetpack-test-environment": "@dev"
+	},
+	"autoload": {
+		"classmap": [
+			"src/"
+		]
+	},
+	"scripts": {
+		"build-zip": [
+			"bash bin/build-zip.sh"
+		],
+		"phpunit": [
+			"phpunit-select-config phpunit.#.xml.dist --colors=always"
+		],
+		"test-php": "@composer phpunit",
+		"test-php-coverage": "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\"",
+		"build-production": "pnpm run build-production",
+		"build-development": "pnpm run build"
+	},
+	"repositories": [
+		{
+			"type": "path",
+			"url": "../../packages/*",
+			"options": {
+				"monorepo": true
+			}
+		}
+	],
+	"minimum-stability": "dev",
+	"prefer-stable": true,
+	"extra": {
+		"autotagger": false,
+		"autorelease": false,
+		"mirror-repo": "Automattic/jetpack-stats-plugin",
+		"release-branch-prefix": "stats",
+		"beta-plugin-slug": "jetpack-stats",
+		"changelogger": {
+			"versioning": "semver"
+		},
+		"version-constants": {
+			"JETPACK_STATS_PLUGIN__VERSION": "jetpack-stats.php"
+		}
+	},
+	"config": {
+		"sort-packages": true,
+		"autoloader-suffix": "29f459d83ca5f0666183989c5a327600_jetpack_statsⓥ0_1_0_alpha",
+		"allow-plugins": {
+			"automattic/jetpack-autoloader": true,
+			"automattic/jetpack-composer-plugin": true,
+			"roots/wordpress-core-installer": true
+		}
+	}
+}

--- a/projects/plugins/stats/composer.lock
+++ b/projects/plugins/stats/composer.lock
@@ -1,0 +1,4047 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "24e060de83ac080e51734a28301f3b66",
+    "packages": [
+        {
+            "name": "automattic/jetpack-a8c-mc-stats",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/a8c-mc-stats",
+                "reference": "48895090b425c307b50fdf77f2c770719e1d3cf4"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-a8c-mc-stats",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-a8c-mc-stats/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Used to record internal usage stats for Automattic. Not visible to site owners.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-admin-ui",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/admin-ui",
+                "reference": "96398da45af93491fdd90cea96331e624b42e39e"
+            },
+            "require": {
+                "automattic/jetpack-redirect": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-logo": "@dev",
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-admin-ui",
+                "textdomain": "jetpack-admin-ui",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-admin-ui/compare/${old}...${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.9.x-dev"
+                },
+                "dependencies": {
+                    "test-only": [
+                        "packages/connection"
+                    ]
+                },
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-admin-menu.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Generic Jetpack wp-admin UI elements",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-agents-manager",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/agents-manager",
+                "reference": "c0f1178356cb6bd2dad22f7175d7a4f0ef53ebb3"
+            },
+            "require": {
+                "automattic/jetpack-assets": "@dev",
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autorelease": true,
+                "autotagger": true,
+                "branch-alias": {
+                    "dev-trunk": "0.9.x-dev"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-agents-manager/compare/v${old}...v${new}"
+                },
+                "mirror-repo": "Automattic/jetpack-agents-manager",
+                "textdomain": "jetpack-agents-manager",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-agents-manager.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-js": [
+                    "pnpm run test"
+                ],
+                "test-js-coverage": [
+                    "pnpm run test-coverage"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Shared AI infrastructure helpers for Automattic plugins",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-assets",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/assets",
+                "reference": "7214a03808294ae652164b2495dc4e8a09c54e89"
+            },
+            "require": {
+                "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "wikimedia/testing-access-wrapper": "^1.0 || ^2.0 || ^3.0 || ^4.0",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-assets",
+                "textdomain": "jetpack-assets",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-assets/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "4.4.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "actions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-js": [
+                    "pnpm run test"
+                ],
+                "test-js-coverage": [
+                    "pnpm run test-coverage"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Asset management utilities for Jetpack ecosystem packages",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-autoloader",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/autoloader",
+                "reference": "afee041b24440e62c6ddb502b3c6716044f8c3ed"
+            },
+            "require": {
+                "composer-plugin-api": "^2.2",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "composer/composer": "^2.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "autotagger": true,
+                "class": "Automattic\\Jetpack\\Autoloader\\CustomAutoloaderPlugin",
+                "mirror-repo": "Automattic/jetpack-autoloader",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-autoloader/compare/v${old}...v${new}"
+                },
+                "version-constants": {
+                    "::VERSION": "src/AutoloadGenerator.php"
+                },
+                "branch-alias": {
+                    "dev-trunk": "5.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/AutoloadGenerator.php"
+                ],
+                "psr-4": {
+                    "Automattic\\Jetpack\\Autoloader\\": "src"
+                }
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"./tests/php/tmp/coverage-report.php\"",
+                    "php ./tests/php/bin/test-coverage.php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Creates a custom autoloader for a plugin or theme.",
+            "keywords": [
+                "autoload",
+                "autoloader",
+                "composer",
+                "jetpack",
+                "plugin",
+                "wordpress"
+            ],
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-blaze",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/blaze",
+                "reference": "7a7c6fc7ef68f3388c0c43dd402c7b31126fa587"
+            },
+            "require": {
+                "automattic/jetpack-admin-ui": "@dev",
+                "automattic/jetpack-assets": "@dev",
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-plans": "@dev",
+                "automattic/jetpack-redirect": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "automattic/jetpack-sync": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-blaze",
+                "changelogger": {
+                    "link-template": "https://github.com/automattic/jetpack-blaze/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.28.x-dev"
+                },
+                "textdomain": "jetpack-blaze",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-dashboard.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "build-production": [
+                    "pnpm run build-production"
+                ],
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Attract high-quality traffic to your site using Blaze.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-boost-core",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/boost-core",
+                "reference": "df08fb330780a8f58a84f370929051a76a93c49e"
+            },
+            "require": {
+                "automattic/jetpack-connection": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-boost-core",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-boost-core/compare/v${old}...v${new}"
+                },
+                "autotagger": true,
+                "branch-alias": {
+                    "dev-trunk": "0.4.x-dev"
+                },
+                "textdomain": "jetpack-boost-core"
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Core functionality for boost and relevant packages to depend on",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-boost-speed-score",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/boost-speed-score",
+                "reference": "5d26f7dade0d8f1ffa8c4130c208795710fa29f7"
+            },
+            "require": {
+                "automattic/jetpack-boost-core": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "mirror-repo": "Automattic/jetpack-boost-speed-score",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-boost-speed-score/compare/v${old}...v${new}"
+                },
+                "autotagger": true,
+                "branch-alias": {
+                    "dev-trunk": "0.4.x-dev"
+                },
+                "textdomain": "jetpack-boost-speed-score",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-speed-score.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\Boost_Speed_Score\\Tests\\": "./tests/php"
+                }
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "A package that handles the API to generate the speed score.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-composer-plugin",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/composer-plugin",
+                "reference": "4c4b86f8b4a330c7033d2f49e33397d044a3d7a0"
+            },
+            "require": {
+                "composer-plugin-api": "^2.2",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "composer/composer": "^2.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "plugin-modifies-install-path": true,
+                "class": "Automattic\\Jetpack\\Composer\\Plugin",
+                "mirror-repo": "Automattic/jetpack-composer-plugin",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-composer-plugin/compare/v${old}...v${new}"
+                },
+                "autotagger": true,
+                "branch-alias": {
+                    "dev-trunk": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "A custom installer plugin for Composer to move Jetpack packages out of `vendor/` so WordPress's translation infrastructure will find their strings.",
+            "keywords": [
+                "composer",
+                "i18n",
+                "jetpack",
+                "plugin"
+            ],
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-config",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/config",
+                "reference": "c57552fadeaa0ee131577eea652128b3686f62cc"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-account-protection": "@dev",
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-import": "@dev",
+                "automattic/jetpack-jitm": "@dev",
+                "automattic/jetpack-post-list": "@dev",
+                "automattic/jetpack-publicize": "@dev",
+                "automattic/jetpack-search": "@dev",
+                "automattic/jetpack-stats": "@dev",
+                "automattic/jetpack-stats-admin": "@dev",
+                "automattic/jetpack-sync": "@dev",
+                "automattic/jetpack-videopress": "@dev",
+                "automattic/jetpack-waf": "@dev",
+                "automattic/jetpack-yoast-promo": "@dev"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-config",
+                "textdomain": "jetpack-config",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-config/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "3.1.x-dev"
+                },
+                "dependencies": {
+                    "test-only": [
+                        "packages/account-protection",
+                        "packages/connection",
+                        "packages/import",
+                        "packages/jitm",
+                        "packages/post-list",
+                        "packages/publicize",
+                        "packages/search",
+                        "packages/stats-admin",
+                        "packages/stats",
+                        "packages/sync",
+                        "packages/videopress",
+                        "packages/waf",
+                        "packages/yoast-promo"
+                    ]
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Jetpack configuration package that initializes other packages and configures Jetpack's functionality. Can be used as a base for all variants of Jetpack package usage.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-connection",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/connection",
+                "reference": "0dbe3a1dcdf89e1ab1f31ae75ef779638300f023"
+            },
+            "require": {
+                "automattic/jetpack-a8c-mc-stats": "@dev",
+                "automattic/jetpack-admin-ui": "@dev",
+                "automattic/jetpack-assets": "@dev",
+                "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-ip": "@dev",
+                "automattic/jetpack-redirect": "@dev",
+                "automattic/jetpack-roles": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-licensing": "@dev",
+                "automattic/jetpack-plans": "@dev",
+                "automattic/jetpack-sync": "@dev",
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/jetpack-wp-abilities": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-connection",
+                "textdomain": "jetpack-connection",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-package-version.php"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "8.8.x-dev"
+                },
+                "dependencies": {
+                    "test-only": [
+                        "packages/licensing",
+                        "packages/plans",
+                        "packages/sync"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "actions.php"
+                ],
+                "classmap": [
+                    "legacy",
+                    "src/",
+                    "src/webhooks",
+                    "src/identity-crisis"
+                ]
+            },
+            "scripts": {
+                "build-production": [
+                    "pnpm run build-production"
+                ],
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Everything needed to connect to the Jetpack infrastructure",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-constants",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/constants",
+                "reference": "a2f68c778c6c47b3e9f7699379fe5efa8ffe2acc"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-constants",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-constants/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "A wrapper for defining constants in a more testable way.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-device-detection",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/device-detection",
+                "reference": "060e4e98b1fb7351b6635c5c8c16a0a2f365ce90"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-device-detection",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-device-detection/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "3.4.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "A way to detect device types based on User-Agent header.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-explat",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/explat",
+                "reference": "99f2996bbbebf82f41575664aa47d5847ec1c5a8"
+            },
+            "require": {
+                "automattic/jetpack-connection": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "branch-alias": {
+                    "dev-trunk": "0.5.x-dev"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-explat/compare/v${old}...v${new}"
+                },
+                "mirror-repo": "Automattic/jetpack-explat",
+                "textdomain": "jetpack-explat",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-explat.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-js": [
+                    "pnpm run test"
+                ],
+                "test-js-coverage": [
+                    "pnpm run test-coverage"
+                ],
+                "test-js-watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run test --watch"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "A package for running A/B tests on the Experimentation Platform (ExPlat) in the plugin.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-ip",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/ip",
+                "reference": "d63dccb293846fdd6ef54fb78848d043815de4bb"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-ip",
+                "changelogger": {
+                    "link-template": "https://github.com/automattic/jetpack-ip/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.5.x-dev"
+                },
+                "textdomain": "jetpack-ip",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-utils.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Utilities for working with IP addresses.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-jitm",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/jitm",
+                "reference": "9060a71b2749d8026a07f334efc6e536114a7ced"
+            },
+            "require": {
+                "automattic/jetpack-a8c-mc-stats": "@dev",
+                "automattic/jetpack-assets": "@dev",
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-device-detection": "@dev",
+                "automattic/jetpack-logo": "@dev",
+                "automattic/jetpack-redirect": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-jitm",
+                "textdomain": "jetpack-jitm",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-jitm.php"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-jitm/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "4.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-production": [
+                    "pnpm run build-production"
+                ],
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Just in time messages for Jetpack",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-licensing",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/licensing",
+                "reference": "ec3d61e7f74cc0cdee6f028c67ff5db7c0dc50b9"
+            },
+            "require": {
+                "automattic/jetpack-connection": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-licensing",
+                "textdomain": "jetpack-licensing",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-licensing/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "3.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Everything needed to manage Jetpack licenses client-side.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-logo",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/logo",
+                "reference": "9772ff10ed4f2e82abda216a2631b547d0a562e9"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-logo",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-logo/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "A logo for Jetpack",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-menu-badges",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/menu-badges",
+                "reference": "f6a211b6b7d5fa6435b088df54d61109fd423a28"
+            },
+            "require": {
+                "automattic/jetpack-assets": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-menu-badges",
+                "textdomain": "jetpack-menu-badges",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-menu-badges/compare/${old}...${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-menu-badges.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Central registry and renderer for Jetpack admin-menu notification-count badges.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-my-jetpack",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/my-jetpack",
+                "reference": "5d4eb48bddb87779e6b1a8a5909b2d8770b7d854"
+            },
+            "require": {
+                "automattic/jetpack-admin-ui": "@dev",
+                "automattic/jetpack-agents-manager": "@dev",
+                "automattic/jetpack-assets": "@dev",
+                "automattic/jetpack-boost-speed-score": "@dev",
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-explat": "@dev",
+                "automattic/jetpack-jitm": "@dev",
+                "automattic/jetpack-licensing": "@dev",
+                "automattic/jetpack-menu-badges": "@dev",
+                "automattic/jetpack-plans": "@dev",
+                "automattic/jetpack-plugins-installer": "@dev",
+                "automattic/jetpack-protect-status": "@dev",
+                "automattic/jetpack-redirect": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "automattic/jetpack-sync": "@dev",
+                "automattic/jetpack-wp-build-polyfills": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-search": "@dev",
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/jetpack-videopress": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-my-jetpack",
+                "textdomain": "jetpack-my-jetpack",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "5.41.x-dev"
+                },
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-initializer.php"
+                },
+                "dependencies": {
+                    "test-only": [
+                        "packages/search",
+                        "packages/videopress"
+                    ]
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/",
+                    "src/products"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-js": [
+                    "pnpm run test"
+                ],
+                "test-js-coverage": [
+                    "pnpm run test-coverage"
+                ],
+                "test-js-watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run test --watch"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "build-production": [
+                    "NODE_ENV=production pnpm run build"
+                ],
+                "watch": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch"
+                ],
+                "watch-hot": [
+                    "Composer\\Config::disableProcessTimeout",
+                    "pnpm run watch:hot"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "WP Admin page with information and configuration shared among all Jetpack stand-alone plugins",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-password-checker",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/password-checker",
+                "reference": "d9e7a7a8db710ebc8d064ae207775df8bd9e6662"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-password-checker",
+                "textdomain": "jetpack-password-checker",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-password-checker/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.4.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Password Checker.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-plans",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/plans",
+                "reference": "d694876b1987293d1f9c0de3ff6ae37d8be95e85"
+            },
+            "require": {
+                "automattic/jetpack-connection": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-status": "@dev",
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-plans",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-plans/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.11.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "build-production": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ],
+                "build-development": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Fetch information about Jetpack Plans from wpcom",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-plugins-installer",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/plugins-installer",
+                "reference": "15f58ebd10de1132242538d0d649774637fa14c3"
+            },
+            "require": {
+                "automattic/jetpack-a8c-mc-stats": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "branch-alias": {
+                    "dev-trunk": "0.5.x-dev"
+                },
+                "mirror-repo": "Automattic/jetpack-plugins-installer",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-plugins-installer/compare/v${old}...v${new}"
+                },
+                "autotagger": true,
+                "textdomain": "jetpack-plugins-installer"
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Handle installation of plugins from WP.org",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-protect-models",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/protect-models",
+                "reference": "d030dc4cdd0116bfb3073f0cb767398d85f48127"
+            },
+            "require": {
+                "automattic/jetpack-redirect": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "branch-alias": {
+                    "dev-trunk": "0.6.x-dev"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-protect-models/compare/v${old}...v${new}"
+                },
+                "mirror-repo": "Automattic/jetpack-protect-models",
+                "textdomain": "jetpack-protect-models",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-protect-models.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-development": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ],
+                "build-production": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ],
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "This package contains the models used in Protect. ",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-protect-status",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/protect-status",
+                "reference": "6b28cbfe429b6998ea50c241085a364c67a82062"
+            },
+            "require": {
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-plans": "@dev",
+                "automattic/jetpack-plugins-installer": "@dev",
+                "automattic/jetpack-protect-models": "@dev",
+                "automattic/jetpack-sync": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "branch-alias": {
+                    "dev-trunk": "0.7.x-dev"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-protect-status/compare/v${old}...v${new}"
+                },
+                "mirror-repo": "Automattic/jetpack-protect-status",
+                "textdomain": "jetpack-protect-status",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-status.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-development": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ],
+                "build-production": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ],
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "This package contains the Protect Status API functionality to retrieve a site's scan status (WordPress, Themes, and Plugins threats).",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-redirect",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/redirect",
+                "reference": "84a8949d203512d279ad65280af8d2af01d4d799"
+            },
+            "require": {
+                "automattic/jetpack-status": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-redirect",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-redirect/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Utilities to build URLs to the jetpack.com/redirect/ service",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-roles",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/roles",
+                "reference": "a9e558a67db231ecf3194a02125a4b3f14a48b94"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-roles",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-roles/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Utilities, related with user roles and capabilities.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-stats",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/stats",
+                "reference": "cabc204d02f8c619d6d22adc12aa323ae42ffb0c"
+            },
+            "require": {
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "automattic/jetpack-wp-abilities": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-stats",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-package-version.php"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-stats/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.20.x-dev"
+                },
+                "textdomain": "jetpack-stats-pkg"
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\Stats\\": "tests/php"
+                }
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Collect valuable traffic stats and insights.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-stats-admin",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/stats-admin",
+                "reference": "787372d8dc4397eeba9f513b9ac50228dee948cc"
+            },
+            "require": {
+                "automattic/jetpack-blaze": "@dev",
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-jitm": "@dev",
+                "automattic/jetpack-plans": "@dev",
+                "automattic/jetpack-stats": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-stats-admin",
+                "branch-alias": {
+                    "dev-trunk": "0.32.x-dev"
+                },
+                "textdomain": "jetpack-stats-admin",
+                "version-constants": {
+                    "::VERSION": "src/class-main.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "build-production": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ],
+                "build-development": [
+                    "echo 'Add your build step to composer.json, please!'"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Stats Dashboard",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-status",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/status",
+                "reference": "f4614222d05fbc8315ef03d8ce7529b2c83fd244"
+            },
+            "require": {
+                "automattic/jetpack-constants": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-ip": "@dev",
+                "automattic/jetpack-plans": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-status",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-status/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "6.2.x-dev"
+                },
+                "dependencies": {
+                    "test-only": [
+                        "packages/connection",
+                        "packages/plans"
+                    ]
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Used to retrieve information about the current status of Jetpack and the site overall.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-sync",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/sync",
+                "reference": "0e6c312d73cf8b2bde57a5656e16e42c1b593217"
+            },
+            "require": {
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-ip": "@dev",
+                "automattic/jetpack-password-checker": "@dev",
+                "automattic/jetpack-roles": "@dev",
+                "automattic/jetpack-status": "@dev",
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-search": "@dev",
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/jetpack-waf": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-sync",
+                "textdomain": "jetpack-sync",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-package-version.php"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-sync/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "4.45.x-dev"
+                },
+                "dependencies": {
+                    "test-only": [
+                        "packages/search",
+                        "packages/waf"
+                    ]
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Everything needed to allow syncing to the WP.com infrastructure.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-wp-abilities",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/wp-abilities",
+                "reference": "97a1a9548ae11e0cd0f0514d81c0701474968828"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "brain/monkey": "^2.6.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-wp-abilities",
+                "changelogger": {
+                    "link-template": "https://github.com/automattic/jetpack-wp-abilities/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.1.x-dev"
+                },
+                "textdomain": "jetpack-wp-abilities",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-registrar.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Shared utilities for registering abilities with the WordPress Abilities API from Jetpack packages and plugins.",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/jetpack-wp-build-polyfills",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/wp-build-polyfills",
+                "reference": "823178fd7fbc1654830b637a7687b939cdb998ee"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/jetpack-test-environment": "@dev",
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "autotagger": true,
+                "mirror-repo": "Automattic/jetpack-wp-build-polyfills",
+                "textdomain": "jetpack-wp-build-polyfills",
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/jetpack-wp-build-polyfills/compare/v${old}...v${new}"
+                },
+                "branch-alias": {
+                    "dev-trunk": "0.3.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "build-production": [
+                    "pnpm run build-production"
+                ],
+                "build-development": [
+                    "pnpm run build"
+                ],
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "test-js": [
+                    "pnpm run build",
+                    "pnpm run test"
+                ],
+                "test-js-coverage": [
+                    "pnpm run build",
+                    "pnpm run test-coverage"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Polyfills for WordPress Core packages not available or incomplete in older WP versions",
+            "transport-options": {
+                "relative": true
+            }
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "automattic/jetpack-test-environment",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/test-environment",
+                "reference": "734d268ff73839769bd167a6d1ccdd87390e9d84"
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "require-dev": {
+                "automattic/phpunit-select-config": "@dev",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "suggest": {
+                "automattic/jetpack-autoloader": "Allow for better interoperability with other plugins that use this package."
+            },
+            "type": "jetpack-library",
+            "extra": {
+                "branch-alias": {
+                    "dev-trunk": "0.2.x-dev"
+                },
+                "textdomain": "jetpack-test-environment",
+                "version-constants": {
+                    "::PACKAGE_VERSION": "src/class-test-environment.php"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "scripts": {
+                "phpunit": [
+                    "phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Shared WordPress test environment for Jetpack monorepo projects",
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "automattic/phpunit-select-config",
+            "version": "dev-trunk",
+            "dist": {
+                "type": "path",
+                "url": "../../packages/phpunit-select-config",
+                "reference": "f34d251d44e96b67a97272b464b69fc9ffb7de76"
+            },
+            "require": {
+                "composer-runtime-api": "^2.2.2",
+                "php": ">=5.4",
+                "phpunit/phpunit": "*"
+            },
+            "require-dev": {
+                "antecedent/patchwork": "^2.2",
+                "yoast/phpunit-polyfills": "^4.0.0"
+            },
+            "bin": [
+                "bin/phpunit-select-config"
+            ],
+            "type": "library",
+            "extra": {
+                "autotagger": true,
+                "branch-alias": {
+                    "dev-trunk": "1.0.x-dev"
+                },
+                "changelogger": {
+                    "link-template": "https://github.com/Automattic/phpunit-select-config/compare/v${old}...v${new}"
+                },
+                "mirror-repo": "Automattic/phpunit-select-config"
+            },
+            "scripts": {
+                "phpunit": [
+                    "./vendor/bin/phpunit-select-config phpunit.#.xml.dist --colors=always"
+                ],
+                "test-php": [
+                    "@composer phpunit"
+                ],
+                "test-php-coverage": [
+                    "php -dpcov.directory=. ./vendor/bin/phpunit-select-config phpunit.#.xml.dist --coverage-php \"$COVERAGE_DIR/php.cov\""
+                ],
+                "post-install-cmd": [
+                    "rm -f vendor/bin/phpunit-select-config && ln -s ../../bin/local-phpunit-select-config vendor/bin/phpunit-select-config"
+                ],
+                "post-update-cmd": [
+                    "rm -f vendor/bin/phpunit-select-config && ln -s ../../bin/local-phpunit-select-config vendor/bin/phpunit-select-config"
+                ]
+            },
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Run PHPUnit, choosing a configuration file by version.",
+            "keywords": [
+                "config",
+                "dev",
+                "phpunit"
+            ],
+            "transport-options": {
+                "relative": true
+            }
+        },
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
+            },
+            "time": "2026-07-04T14:30:18+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "12.5.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "186dab580576598076de6818596d12b61801880e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/186dab580576598076de6818596d12b61801880e",
+                "reference": "186dab580576598076de6818596d12b61801880e",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.3",
+                "phpunit/php-text-template": "^5.0",
+                "sebastian/complexity": "^5.0",
+                "sebastian/environment": "^8.1.2",
+                "sebastian/lines-of-code": "^4.0.1",
+                "sebastian/version": "^6.0",
+                "theseer/tokenizer": "^2.0.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.5.28"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "12.5.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.7"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-01T13:24:19+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "6.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
+                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/6.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-02T14:04:18+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/12b54e689b07a25a9b41e57736dfab6ec9ae5406",
+                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^12.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/6.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:58:58+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/e1367a453f0eda562eedb4f659e13aa900d66c53",
+                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:59:16+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "8.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
+                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "8.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/8.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:59:38+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "12.5.33",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "b98e028a26c5c5ba7e4a54be96ccf35f2914d184"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b98e028a26c5c5ba7e4a54be96ccf35f2914d184",
+                "reference": "b98e028a26c5c5ba7e4a54be96ccf35f2914d184",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.3",
+                "phpunit/php-code-coverage": "^12.5.7",
+                "phpunit/php-file-iterator": "^6.0.1",
+                "phpunit/php-invoker": "^6.0.0",
+                "phpunit/php-text-template": "^5.0.0",
+                "phpunit/php-timer": "^8.0.0",
+                "sebastian/cli-parser": "^4.2.1",
+                "sebastian/comparator": "^7.1.8",
+                "sebastian/diff": "^7.0.0",
+                "sebastian/environment": "^8.1.2",
+                "sebastian/exporter": "^7.0.3",
+                "sebastian/global-state": "^8.0.3",
+                "sebastian/object-enumerator": "^7.0.0",
+                "sebastian/recursion-context": "^7.0.1",
+                "sebastian/type": "^6.0.4",
+                "sebastian/version": "^6.0.0",
+                "staabm/side-effects-detector": "^1.0.5"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "12.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.33"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
+                }
+            ],
+            "time": "2026-07-28T13:58:09+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "4.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "7d05781b13f7dec9043a629a21d086ed74582a15"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/7d05781b13f7dec9043a629a21d086ed74582a15",
+                "reference": "7d05781b13f7dec9043a629a21d086ed74582a15",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.5.25"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/4.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/cli-parser",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-17T05:29:34+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "7.1.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "7c65c1e79836812819705b473a90c12399542485"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/7c65c1e79836812819705b473a90c12399542485",
+                "reference": "7c65c1e79836812819705b473a90c12399542485",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.3",
+                "sebastian/diff": "^7.0",
+                "sebastian/exporter": "^7.0.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.5.25"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.8"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-21T04:45:25+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/bad4316aba5303d0221f43f8cee37eb58d384bbb",
+                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:55:25+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "7.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "7ab1ea946c012266ca32390913653d844ecd085f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7ab1ea946c012266ca32390913653d844ecd085f",
+                "reference": "7ab1ea946c012266ca32390913653d844ecd085f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0",
+                "symfony/process": "^7.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/7.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:55:46+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "8.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "9d32c685773823b1983e256ae4ecd48a10d6e439"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/9d32c685773823b1983e256ae4ecd48a10d6e439",
+                "reference": "9d32c685773823b1983e256ae4ecd48a10d6e439",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.5.26"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "8.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/8.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-25T13:40:20+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "7.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "c5e21b5de653ce0a769fb36f5cdfcb5e7a32cf23"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/c5e21b5de653ce0a769fb36f5cdfcb5e7a32cf23",
+                "reference": "c5e21b5de653ce0a769fb36f5cdfcb5e7a32cf23",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.3",
+                "sebastian/recursion-context": "^7.0.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.5.25"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/7.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-20T04:37:17+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "8.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "b164d3274d6537ab462591c5755f76a8f5b1aae9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b164d3274d6537ab462591c5755f76a8f5b1aae9",
+                "reference": "b164d3274d6537ab462591c5755f76a8f5b1aae9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3",
+                "sebastian/object-reflector": "^5.0",
+                "sebastian/recursion-context": "^7.0.1"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^12.5.28"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "8.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/8.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-06-01T15:10:33+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "d543b8ef219dcd8da262cbb958639a96bedba10e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d543b8ef219dcd8da262cbb958639a96bedba10e",
+                "reference": "d543b8ef219dcd8da262cbb958639a96bedba10e",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.5.25"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/lines-of-code",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-19T16:22:07+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "7.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1effe8e9b8e068e9ae228e542d5d11b5d16db894",
+                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3",
+                "sebastian/object-reflector": "^5.0",
+                "sebastian/recursion-context": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/7.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:57:48+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "4bfa827c969c98be1e527abd576533293c634f6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/4bfa827c969c98be1e527abd576533293c634f6a",
+                "reference": "4bfa827c969c98be1e527abd576533293c634f6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T04:58:17+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "7.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
+                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/7.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-13T04:44:59+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "6.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "82ff822c2edc46724be9f7411d3163021f602773"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/82ff822c2edc46724be9f7411d3163021f602773",
+                "reference": "82ff822c2edc46724be9f7411d3163021f602773",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^12.5.25"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/6.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-05-20T06:45:45+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/3e6ccf7657d4f0a59200564b08cead899313b53c",
+                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/6.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-02-07T05:00:38+00:00"
+        },
+        {
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
+                "reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^8.1"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-12-08T11:19:18+00:00"
+        },
+        {
+            "name": "yoast/phpunit-polyfills",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Yoast/PHPUnit-Polyfills.git",
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Yoast/PHPUnit-Polyfills/zipball/134921bfca9b02d8f374c48381451da1d98402f9",
+                "reference": "134921bfca9b02d8f374c48381451da1d98402f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0 || ^11.0 || ^12.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "yoast/yoastcs": "^3.1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "phpunitpolyfills-autoload.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Team Yoast",
+                    "email": "support@yoast.com",
+                    "homepage": "https://yoast.com"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Yoast/PHPUnit-Polyfills/graphs/contributors"
+                }
+            ],
+            "description": "Set of polyfills for changed PHPUnit functionality to allow for creating PHPUnit cross-version compatible tests",
+            "homepage": "https://github.com/Yoast/PHPUnit-Polyfills",
+            "keywords": [
+                "phpunit",
+                "polyfill",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/Yoast/PHPUnit-Polyfills/issues",
+                "security": "https://github.com/Yoast/PHPUnit-Polyfills/security/policy",
+                "source": "https://github.com/Yoast/PHPUnit-Polyfills"
+            },
+            "time": "2025-02-09T18:58:54+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "dev",
+    "stability-flags": {
+        "automattic/jetpack-assets": 20,
+        "automattic/jetpack-autoloader": 20,
+        "automattic/jetpack-composer-plugin": 20,
+        "automattic/jetpack-config": 20,
+        "automattic/jetpack-connection": 20,
+        "automattic/jetpack-my-jetpack": 20,
+        "automattic/jetpack-stats": 20,
+        "automattic/jetpack-stats-admin": 20,
+        "automattic/jetpack-status": 20,
+        "automattic/jetpack-sync": 20,
+        "automattic/jetpack-test-environment": 20,
+        "automattic/phpunit-select-config": 20
+    },
+    "prefer-stable": true,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
+}

--- a/projects/plugins/stats/composer.lock
+++ b/projects/plugins/stats/composer.lock
@@ -684,7 +684,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/connection",
-                "reference": "0dbe3a1dcdf89e1ab1f31ae75ef779638300f023"
+                "reference": "e5ff8b59b34901f3aef7e0f593b8ccf1fc6246f4"
             },
             "require": {
                 "automattic/jetpack-a8c-mc-stats": "@dev",
@@ -699,7 +699,6 @@
             },
             "require-dev": {
                 "automattic/jetpack-licensing": "@dev",
-                "automattic/jetpack-plans": "@dev",
                 "automattic/jetpack-sync": "@dev",
                 "automattic/jetpack-test-environment": "@dev",
                 "automattic/jetpack-wp-abilities": "@dev",
@@ -722,12 +721,11 @@
                     "link-template": "https://github.com/Automattic/jetpack-connection/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "8.8.x-dev"
+                    "dev-trunk": "8.9.x-dev"
                 },
                 "dependencies": {
                     "test-only": [
                         "packages/licensing",
-                        "packages/plans",
                         "packages/sync"
                     ]
                 }

--- a/projects/plugins/stats/composer.lock
+++ b/projects/plugins/stats/composer.lock
@@ -1248,7 +1248,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/my-jetpack",
-                "reference": "5d4eb48bddb87779e6b1a8a5909b2d8770b7d854"
+                "reference": "60c053ace8f2475c24a75c6e509a0944f4374196"
             },
             "require": {
                 "automattic/jetpack-admin-ui": "@dev",
@@ -1289,7 +1289,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-my-jetpack/compare/${old}...${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "5.41.x-dev"
+                    "dev-trunk": "5.42.x-dev"
                 },
                 "version-constants": {
                     "::PACKAGE_VERSION": "src/class-initializer.php"
@@ -2101,7 +2101,7 @@
             "dist": {
                 "type": "path",
                 "url": "../../packages/wp-build-polyfills",
-                "reference": "823178fd7fbc1654830b637a7687b939cdb998ee"
+                "reference": "70cb1e74eafd173c0b2d3b8b0f25cf5a96421ba2"
             },
             "require": {
                 "php": ">=7.2"
@@ -2120,7 +2120,7 @@
                     "link-template": "https://github.com/Automattic/jetpack-wp-build-polyfills/compare/v${old}...v${new}"
                 },
                 "branch-alias": {
-                    "dev-trunk": "0.3.x-dev"
+                    "dev-trunk": "0.4.x-dev"
                 }
             },
             "autoload": {

--- a/projects/plugins/stats/index.php
+++ b/projects/plugins/stats/index.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * Silence is golden.
+ *
+ * @package automattic/jetpack-stats-plugin
+ */

--- a/projects/plugins/stats/jetpack-stats.php
+++ b/projects/plugins/stats/jetpack-stats.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ *
+ * Plugin Name: Jetpack Stats
+ * Plugin URI: https://jetpack.com/stats/
+ * Description: Simple, yet powerful stats to grow your site.
+ * Version: 0.1.0-alpha
+ * Author: Automattic - Jetpack Stats team
+ * Author URI: https://jetpack.com/
+ * License: GPLv2 or later
+ * Requires at least: 6.9
+ * Requires PHP: 7.2
+ * Text Domain: jetpack-stats
+ *
+ * @package automattic/jetpack-stats-plugin
+ */
+
+namespace Automattic\Jetpack\Stats_Plugin;
+
+use Automattic\Jetpack\Assets;
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit( 0 );
+}
+
+// Constant definitions.
+define( 'JETPACK_STATS_PLUGIN__DIR', plugin_dir_path( __FILE__ ) );
+define( 'JETPACK_STATS_PLUGIN__FILE', __FILE__ );
+define( 'JETPACK_STATS_PLUGIN__FILE_RELATIVE_PATH', plugin_basename( __FILE__ ) );
+define( 'JETPACK_STATS_PLUGIN__SLUG', 'jetpack-stats' );
+define( 'JETPACK_STATS_PLUGIN__VERSION', '0.1.0-alpha' );
+defined( 'JETPACK_CLIENT__AUTH_LOCATION' ) || define( 'JETPACK_CLIENT__AUTH_LOCATION', 'header' );
+
+defined( 'JETPACK__API_BASE' ) || define( 'JETPACK__API_BASE', 'https://jetpack.wordpress.com/jetpack.' );
+defined( 'JETPACK__WPCOM_JSON_API_BASE' ) || define( 'JETPACK__WPCOM_JSON_API_BASE', 'https://public-api.wordpress.com' );
+
+defined( 'JETPACK__SANDBOX_DOMAIN' ) || define( 'JETPACK__SANDBOX_DOMAIN', '' );
+
+/*
+ * These constants can be set in wp-config.php to ensure sites behind proxies will still work.
+ * Setting these constants, though, is *not* the preferred method. It's better to configure
+ * the proxy to send the X-Forwarded-Port header.
+ */
+defined( 'JETPACK_SIGNATURE__HTTP_PORT' ) || define( 'JETPACK_SIGNATURE__HTTP_PORT', 80 );
+defined( 'JETPACK_SIGNATURE__HTTPS_PORT' ) || define( 'JETPACK_SIGNATURE__HTTPS_PORT', 443 );
+
+$jetpack_stats_autoload_packages_path = JETPACK_STATS_PLUGIN__DIR . 'vendor/autoload_packages.php';
+if ( ! is_readable( $jetpack_stats_autoload_packages_path ) ) {
+	if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+		error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			sprintf(
+			/* translators: Placeholder is a link to a support document. */
+				__( 'Your installation of Jetpack Stats is incomplete. If you installed Jetpack Stats from GitHub, please refer to this document to set up your development environment: %1$s', 'jetpack-stats' ),
+				'https://github.com/Automattic/jetpack/blob/trunk/docs/development-environment.md'
+			)
+		);
+	}
+
+	// Add a red bubble notification to My Jetpack if the installation is bad.
+	add_filter(
+		'my_jetpack_red_bubble_notification_slugs',
+		function ( $slugs ) {
+			$slugs['jetpack-stats-plugin-bad-installation'] = array(
+				'data' => array(
+					'plugin' => 'Jetpack Stats',
+				),
+			);
+
+			return $slugs;
+		}
+	);
+
+	/**
+	 * Outputs an admin notice for folks running Jetpack Stats without having run composer install.
+	 *
+	 * @since $$next-version$$
+	 */
+	function jetpack_stats_admin_missing_files() {
+		if ( get_current_screen()->id !== 'plugins' ) {
+			return;
+		}
+
+		$message = sprintf(
+			wp_kses(
+				/* translators: Placeholder is a link to a support document. */
+				__( 'Your installation of Jetpack Stats is incomplete. If you installed Jetpack Stats from GitHub, please refer to <a href="%1$s" target="_blank" rel="noopener noreferrer">this document</a> to set up your development environment. Jetpack Stats must have Composer dependencies installed and built via the build command.', 'jetpack-stats' ),
+				array(
+					'a' => array(
+						'href'   => array(),
+						'target' => array(),
+						'rel'    => array(),
+					),
+				)
+			),
+			'https://github.com/Automattic/jetpack/blob/trunk/docs/development-environment.md#building-your-project'
+		);
+		wp_admin_notice(
+			$message,
+			array(
+				'type'        => 'error',
+				'dismissible' => true,
+			)
+		);
+	}
+
+	add_action( 'admin_notices', __NAMESPACE__ . '\jetpack_stats_admin_missing_files' );
+	return;
+}
+
+/**
+ * Setup autoloading
+ */
+require_once $jetpack_stats_autoload_packages_path;
+
+/**
+ * Load jetpack packages i18n map.
+ *
+ * The map is only generated when `.extra.wp-plugin-slug` is set in composer.json, which
+ * happens once this plugin is published to the WordPress.org directory. Until then the
+ * file is absent, and `alias_textdomains_from_file()` would fatal on a bare `require`.
+ */
+$jetpack_stats_i18n_map_path = JETPACK_STATS_PLUGIN__DIR . 'jetpack_vendor/i18n-map.php';
+if ( is_readable( $jetpack_stats_i18n_map_path ) && method_exists( Assets::class, 'alias_textdomains_from_file' ) ) {
+	Assets::alias_textdomains_from_file( $jetpack_stats_i18n_map_path );
+}
+
+Jetpack_Stats_Plugin::bootstrap();

--- a/projects/plugins/stats/package.json
+++ b/projects/plugins/stats/package.json
@@ -1,0 +1,22 @@
+{
+	"private": true,
+	"description": "Simple, yet powerful stats to grow your site.",
+	"homepage": "https://jetpack.com/stats/",
+	"bugs": {
+		"url": "https://github.com/Automattic/jetpack/labels/[Plugin] Stats"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/Automattic/jetpack.git",
+		"directory": "projects/plugins/stats"
+	},
+	"license": "GPL-2.0-or-later",
+	"author": "Automattic",
+	"scripts": {
+		"build": "echo Success.",
+		"build-js": "echo  Success.",
+		"build-production": "echo  Success.",
+		"build-production-js": "echo  Success.",
+		"clean": "true"
+	}
+}

--- a/projects/plugins/stats/phpunit.11.xml.dist
+++ b/projects/plugins/stats/phpunit.11.xml.dist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+	bootstrap="tests/php/bootstrap.php"
+	cacheDirectory=".phpunit.cache"
+	colors="true"
+	executionOrder="depends"
+	beStrictAboutOutputDuringTests="true"
+	displayDetailsOnPhpunitDeprecations="true"
+	displayDetailsOnTestsThatTriggerDeprecations="true"
+	displayDetailsOnTestsThatTriggerErrors="true"
+	displayDetailsOnTestsThatTriggerNotices="true"
+	displayDetailsOnTestsThatTriggerWarnings="true"
+	failOnDeprecation="true"
+	failOnEmptyTestSuite="false"
+	failOnPhpunitDeprecation="true"
+	failOnNotice="true"
+	failOnRisky="true"
+	failOnWarning="true"
+>
+	<testsuites>
+		<testsuite name="main">
+			<directory suffix="Test.php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+
+	<source>
+		<include>
+			<!-- Better to only include "src" than to add "." and then exclude "tests", "vendor", and so on, as PHPUnit still scans the excluded directories. -->
+			<!-- Add additional lines for any files or directories outside of src/ that need coverage. -->
+			<directory suffix=".php">src</directory>
+			<file>jetpack-stats.php</file>
+		</include>
+	</source>
+	<coverage ignoreDeprecatedCodeUnits="true">
+	</coverage>
+</phpunit>

--- a/projects/plugins/stats/phpunit.11.xml.dist
+++ b/projects/plugins/stats/phpunit.11.xml.dist
@@ -29,7 +29,6 @@
 			<!-- Better to only include "src" than to add "." and then exclude "tests", "vendor", and so on, as PHPUnit still scans the excluded directories. -->
 			<!-- Add additional lines for any files or directories outside of src/ that need coverage. -->
 			<directory suffix=".php">src</directory>
-			<file>jetpack-stats.php</file>
 		</include>
 	</source>
 	<coverage ignoreDeprecatedCodeUnits="true">

--- a/projects/plugins/stats/phpunit.12.xml.dist
+++ b/projects/plugins/stats/phpunit.12.xml.dist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+	bootstrap="tests/php/bootstrap.php"
+	cacheDirectory=".phpunit.cache"
+	colors="true"
+	executionOrder="depends"
+	beStrictAboutOutputDuringTests="true"
+	displayDetailsOnPhpunitDeprecations="true"
+	displayDetailsOnTestsThatTriggerDeprecations="true"
+	displayDetailsOnTestsThatTriggerErrors="true"
+	displayDetailsOnTestsThatTriggerNotices="true"
+	displayDetailsOnTestsThatTriggerWarnings="true"
+	failOnDeprecation="true"
+	failOnEmptyTestSuite="false"
+	failOnPhpunitDeprecation="true"
+	failOnNotice="true"
+	failOnRisky="true"
+	failOnWarning="true"
+>
+	<testsuites>
+		<testsuite name="main">
+			<directory suffix="Test.php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+
+	<source>
+		<include>
+			<!-- Better to only include "src" than to add "." and then exclude "tests", "vendor", and so on, as PHPUnit still scans the excluded directories. -->
+			<!-- Add additional lines for any files or directories outside of src/ that need coverage. -->
+			<directory suffix=".php">src</directory>
+			<file>jetpack-stats.php</file>
+		</include>
+	</source>
+	<coverage ignoreDeprecatedCodeUnits="true">
+	</coverage>
+</phpunit>

--- a/projects/plugins/stats/phpunit.12.xml.dist
+++ b/projects/plugins/stats/phpunit.12.xml.dist
@@ -29,7 +29,6 @@
 			<!-- Better to only include "src" than to add "." and then exclude "tests", "vendor", and so on, as PHPUnit still scans the excluded directories. -->
 			<!-- Add additional lines for any files or directories outside of src/ that need coverage. -->
 			<directory suffix=".php">src</directory>
-			<file>jetpack-stats.php</file>
 		</include>
 	</source>
 	<coverage ignoreDeprecatedCodeUnits="true">

--- a/projects/plugins/stats/phpunit.8.xml.dist
+++ b/projects/plugins/stats/phpunit.8.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+	bootstrap="tests/php/bootstrap.php"
+	cacheResultFile=".phpunit.cache/test-results"
+	colors="true"
+	executionOrder="depends"
+	beStrictAboutOutputDuringTests="true"
+	failOnRisky="true"
+	failOnWarning="true"
+>
+	<testsuites>
+		<testsuite name="main">
+			<directory suffix="Test.php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/projects/plugins/stats/phpunit.9.xml.dist
+++ b/projects/plugins/stats/phpunit.9.xml.dist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.6/phpunit.xsd"
+	bootstrap="tests/php/bootstrap.php"
+	cacheResultFile=".phpunit.cache/test-results"
+	colors="true"
+	executionOrder="depends"
+	beStrictAboutOutputDuringTests="true"
+	failOnRisky="true"
+	failOnWarning="true"
+>
+	<testsuites>
+		<testsuite name="main">
+			<directory suffix="Test.php">tests/php</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/projects/plugins/stats/readme.txt
+++ b/projects/plugins/stats/readme.txt
@@ -1,0 +1,86 @@
+=== Jetpack Stats ===
+Contributors: automattic
+Tags: stats, analytics, site stats, traffic, visitors
+Requires at least: 6.9
+Requires PHP: 7.2
+Tested up to: 7.0
+Stable tag: 0.1.0-alpha
+License: GPLv2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+
+Simple, yet powerful stats to grow your site.
+
+== Description ==
+
+With Jetpack Stats, you don't need to be a data scientist to see how your site is performing.
+
+**Tried and true visitor stats to help you understand your audience**
+
+Explore real-time data on visitors, likes, and comments. Get detailed insights on the referrers that bring traffic to your site. Discover what countries your visitors are coming from. Measure link clicks, video plays, and file downloads within your site.
+
+**See what's working with content performance metrics**
+
+Discover your top performing posts & pages. See who is creating the most popular content on your team with our author metrics. Easily keep track of your content creation habits & trends over the years. View weekly and yearly trends with 7-day Highlights and Year in Review. Understand where your visitors are coming from with UTM tracking.
+
+**Engage with your subscribers and view your social reach**
+
+See your WordPress & Email subscribers, and follow them back to build your community. Connect Jetpack Social to popular social networks and see your total follower counts. See what popular social networks your content is being shared to the most.
+
+**Third-party integrations to keep you growing**
+
+Promote content to millions of WordPress and Tumblr users directly from Stats using Blaze. Easily see orders, refunds, shipping, and other product trends as a WooCommerce customer. Monitor ads displayed & keep track of earnings when using Jetpack Ads.
+
+**Keeping personal data secure**
+
+Jetpack Stats gives you a powerful WordPress analytics tool that respects your visitors' privacy, allowing you to gain valuable insights while maintaining GDPR compliance.
+
+== External services ==
+
+This plugin relies on WordPress.com, a service operated by Automattic. The plugin does not work without it.
+
+* **What the service does:** it records page views and returns the reports shown in the Stats dashboard.
+* **What data is sent:** the page viewed, the referring URL, the visitor IP address, the user agent, and your site ID. Data is sent on every front-end page view, and whenever the Stats dashboard loads a report.
+* **Where it is sent:** `https://pixel.wp.com/g.gif` for collection, and `https://public-api.wordpress.com` for reporting.
+
+This plugin requires a connection to a WordPress.com account. Until that connection is complete, no data is collected and no reports are available.
+
+Service terms: [Terms of Service](https://wordpress.com/tos/)
+Service privacy policy: [Privacy Policy](https://automattic.com/privacy/)
+
+== Installation ==
+
+1. Install the plugin through the WordPress plugins screen, or upload the plugin files to your `/wp-content/plugins/` directory.
+2. Activate the plugin through the Plugins screen in WordPress.
+3. Connect your site to a WordPress.com account when the plugin asks you to. Stats cannot collect data before this step is complete.
+4. Go to the Stats tab.
+
+== Frequently Asked Questions ==
+
+= How do I configure Jetpack Stats? =
+
+Simply install the plugin and go to the Stats tab. It's that simple. If you need more help, check out [this support article](https://jetpack.com/support/jetpack-stats/).
+
+= Does Jetpack Stats integrate with Google Analytics? =
+
+Yes! You can use both on your WordPress installation. The benefit of using Jetpack Stats is that you can see a snapshot of your blog's activity directly from your dashboard. If you want to use another analytics service to give you additional in-depth information, you can certainly do so.
+
+= With Stats, can I view visitors by country? =
+
+Yes! Jetpack Stats will show you a heatmap of exactly where in the world your site has been receiving its visitors from.
+
+= Does Stats honor DNT requests? =
+
+Do Not Track (DNT) is a feature in web browsers and websites that asks advertisers and other web software providers not to track individuals' browsing habits. As a site owner, you can configure Jetpack Stats to honor requests from visitors who have DNT enabled, and prevent tracking of their activity (i.e., post and page views) with an easy-to-add snippet.
+
+= Through Stats, can I see who viewed individual posts? =
+
+No. Any piece of data explicitly identifying a specific user (IP address, WordPress.com ID, WordPress.com username, etc.) is not visible to the site owner when using Jetpack Stats, so you won't be able to see which specific users or accounts viewed a particular post.
+
+= Can I download my site stats? =
+
+You can click the title of each feature on your stats page, and scroll to the bottom of that feature to download your stats. Simply click on the "Download data as CSV" link, and download the file to your computer.
+
+== Changelog ==
+
+= 0.1.0-alpha =
+* Initial release.

--- a/projects/plugins/stats/readme.txt
+++ b/projects/plugins/stats/readme.txt
@@ -8,11 +8,13 @@ Stable tag: 0.1.0-alpha
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-Simple, yet powerful stats to grow your site.
+Simple, yet powerful stats to grow your site. See your traffic, referrers, and top content at a glance — no data science required.
 
 == Description ==
 
-With Jetpack Stats, you don't need to be a data scientist to see how your site is performing.
+With Jetpack Stats, you don't need to be a data scientist to see how your site is performing. Get a clear, privacy-friendly picture of your traffic right inside your WordPress dashboard.
+
+Jetpack Stats is a standalone plugin — you can run it on its own, without installing the full Jetpack plugin.
 
 **Tried and true visitor stats to help you understand your audience**
 
@@ -34,24 +36,21 @@ Promote content to millions of WordPress and Tumblr users directly from Stats us
 
 Jetpack Stats gives you a powerful WordPress analytics tool that respects your visitors' privacy, allowing you to gain valuable insights while maintaining GDPR compliance.
 
-== External services ==
-
-This plugin relies on WordPress.com, a service operated by Automattic. The plugin does not work without it.
-
-* **What the service does:** it records page views and returns the reports shown in the Stats dashboard.
-* **What data is sent:** the page viewed, the referring URL, the visitor IP address, the user agent, and your site ID. Data is sent on every front-end page view, and whenever the Stats dashboard loads a report.
-* **Where it is sent:** `https://pixel.wp.com/g.gif` for collection, and `https://public-api.wordpress.com` for reporting.
-
-This plugin requires a connection to a WordPress.com account. Until that connection is complete, no data is collected and no reports are available.
-
-Service terms: [Terms of Service](https://wordpress.com/tos/)
-Service privacy policy: [Privacy Policy](https://automattic.com/privacy/)
-
 == Installation ==
 
-1. Install the plugin through the WordPress plugins screen, or upload the plugin files to your `/wp-content/plugins/` directory.
-2. Activate the plugin through the Plugins screen in WordPress.
-3. Connect your site to a WordPress.com account when the plugin asks you to. Stats cannot collect data before this step is complete.
+= Automated installation =
+
+1. Go to the Plugins screen in your WordPress admin and click "Add New".
+2. Search for "Jetpack Stats" and click "Install Now".
+3. Activate the plugin through the Plugins screen.
+4. Connect your site to a WordPress.com account when the plugin asks you to. Stats cannot collect data before this step is complete.
+5. Go to the Stats tab.
+
+= Manual installation =
+
+1. Upload the plugin files to the `/wp-content/plugins/jetpack-stats` directory, or install the .zip file through the Plugins screen in your WordPress admin.
+2. Activate the plugin through the Plugins screen.
+3. Connect your site to a WordPress.com account when the plugin asks you to.
 4. Go to the Stats tab.
 
 == Frequently Asked Questions ==
@@ -59,6 +58,10 @@ Service privacy policy: [Privacy Policy](https://automattic.com/privacy/)
 = How do I configure Jetpack Stats? =
 
 Simply install the plugin and go to the Stats tab. It's that simple. If you need more help, check out [this support article](https://jetpack.com/support/jetpack-stats/).
+
+= Do I need the full Jetpack plugin to use Jetpack Stats? =
+
+No. Jetpack Stats is a standalone plugin and works on its own. If you already run the full Jetpack plugin, Stats works there too — you don't need both, and running both will not create duplicate menus.
 
 = Does Jetpack Stats integrate with Google Analytics? =
 
@@ -80,7 +83,54 @@ No. Any piece of data explicitly identifying a specific user (IP address, WordPr
 
 You can click the title of each feature on your stats page, and scroll to the bottom of that feature to download your stats. Simply click on the "Download data as CSV" link, and download the file to your computer.
 
+== Screenshots ==
+
+1. The Stats dashboard — traffic at a glance with visitors, views, and trends.
+2. Top posts & pages, and the referrers driving your traffic.
+3. A world heatmap showing where your visitors come from.
+4. 7-day Highlights and Year in Review trends.
+
+== External services ==
+
+This plugin relies on WordPress.com, a service operated by Automattic, to record visits and generate the reports shown in the Stats dashboard. The plugin does not work without it.
+
+It connects to the following external services:
+
+**WordPress.com view-tracking pixel (`https://pixel.wp.com/g.gif`)**
+
+* What it does: records a page view each time a visitor loads a page on your site.
+* Data sent: the page viewed, the referring URL, the visitor's IP address, the user agent, and your site ID.
+* When: on every front-end page view.
+
+**WordPress.com measurement script (`https://stats.wp.com/e-{year}.js`)**
+
+* What it does: loads the small JavaScript file that sends the view-tracking request above from the visitor's browser.
+* Data sent: no data is sent when the file is downloaded; it is a static script served from Automattic's CDN.
+* When: on every front-end page view.
+
+**WordPress.com reporting API (`https://public-api.wordpress.com`)**
+
+* What it does: returns the aggregated statistics displayed in your Stats dashboard.
+* Data sent: your site ID and the report parameters (date ranges, metric requested). Requires an authenticated WordPress.com connection.
+* When: whenever you open the Stats dashboard or load a report.
+
+**WordPress.com dashboard assets (`https://widgets.wp.com/odyssey-stats/`)**
+
+* What it does: serves the JavaScript, styles, and icons that render the Stats dashboard interface in your WordPress admin.
+* Data sent: no personal data; these are static front-end assets served from Automattic's CDN.
+* When: whenever you open the Stats dashboard.
+
+This plugin requires a connection to a WordPress.com account. Until that connection is complete, no data is collected and no reports are available.
+
+Service terms: [Terms of Service](https://wordpress.com/tos/)
+Service privacy policy: [Privacy Policy](https://automattic.com/privacy/)
+
 == Changelog ==
 
 = 0.1.0-alpha =
 * Initial release.
+
+== Upgrade Notice ==
+
+= 0.1.0-alpha =
+Initial release — install Jetpack Stats to see simple, privacy-friendly traffic insights right inside your WordPress dashboard.

--- a/projects/plugins/stats/src/class-jetpack-stats-plugin.php
+++ b/projects/plugins/stats/src/class-jetpack-stats-plugin.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * Bootstrap class for the Jetpack Stats plugin.
+ *
+ * @package automattic/jetpack-stats-plugin
+ */
+
+namespace Automattic\Jetpack\Stats_Plugin;
+
+use Automattic\Jetpack\Config;
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Connection\Rest_Authentication as Connection_Rest_Authentication;
+use Automattic\Jetpack\Modules;
+use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
+use Automattic\Jetpack\Paths;
+use Automattic\Jetpack\Stats_Admin\Dashboard as Stats_Dashboard;
+
+/**
+ * Class to bootstrap the Jetpack Stats plugin.
+ */
+class Jetpack_Stats_Plugin {
+	/**
+	 * The admin page slug registered by the Stats dashboard.
+	 *
+	 * Owned by `Automattic\Jetpack\Stats_Admin\Dashboard`, which registers a top-level
+	 * menu with this slug. Kept here so the plugin can link to the page.
+	 */
+	const ADMIN_PAGE_SLUG = 'stats';
+
+	/**
+	 * My Jetpack's admin page slug.
+	 *
+	 * Landing on this page with no connection makes My Jetpack redirect to its own
+	 * onboarding step. See `My_Jetpack\Initializer::get_onboarding_redirect_args()`.
+	 */
+	const MY_JETPACK_PAGE_SLUG = 'my-jetpack';
+
+	/**
+	 * Register hooks to initialize the plugin.
+	 */
+	public static function bootstrap() {
+		add_action( 'plugins_loaded', array( self::class, 'configure_packages' ), 1 );
+		add_action( 'plugins_loaded', array( self::class, 'initialize_other_packages' ) );
+		add_action( 'activated_plugin', array( self::class, 'handle_plugin_activation' ) );
+		add_action( 'jetpack_site_registered', array( self::class, 'activate_stats_module' ) );
+		add_filter( 'plugin_action_links_' . JETPACK_STATS_PLUGIN__FILE_RELATIVE_PATH, array( self::class, 'plugin_page_add_links' ) );
+		add_filter( 'jetpack_get_available_standalone_modules', array( self::class, 'filter_available_modules_add_stats' ) );
+
+		/**
+		 * The Jetpack plugin owns the Stats admin menu while it is active, and it chooses
+		 * between the legacy Stats screen and the Odyssey dashboard. Once it is deactivated
+		 * that choice falls to this plugin, so re-activate the module and take over the menu.
+		 */
+		add_action( 'deactivate_jetpack/jetpack.php', array( self::class, 'activate_stats_module' ) );
+	}
+
+	/**
+	 * Configure packages controlled by the `Config` class.
+	 *
+	 * Note: the function only configures the packages, but doesn't initialize them.
+	 * The actual initialization is done on 'plugins_loaded' priority 2, which is the
+	 * reason the function is hooked on priority 1.
+	 */
+	public static function configure_packages() {
+		$config = new Config();
+		// Connection package.
+		$config->ensure(
+			'connection',
+			array(
+				'slug'     => JETPACK_STATS_PLUGIN__SLUG,
+				'name'     => 'Jetpack Stats',
+				'url_info' => 'https://jetpack.com/stats/',
+			)
+		);
+		// Sync package.
+		$config->ensure( 'sync' );
+		// Identity crisis package.
+		$config->ensure( 'identity_crisis' );
+		// Stats package: the tracking pixel, the `view_stats` capability map and the REST provider.
+		$config->ensure( 'stats' );
+		// Stats Admin package: the REST proxy to the WPCOM stats API used by the dashboard.
+		$config->ensure( 'stats_admin' );
+	}
+
+	/**
+	 * Initialize packages not controlled by the `Config` class.
+	 */
+	public static function initialize_other_packages() {
+		// Set up the REST authentication hooks.
+		Connection_Rest_Authentication::init();
+		// Initialize My Jetpack.
+		My_Jetpack_Initializer::init();
+
+		/**
+		 * `Config::ensure( 'stats_admin' )` starts the package but does not register the
+		 * dashboard page — the Jetpack plugin does that itself in `modules/stats.php`.
+		 * Register it here only when the Jetpack plugin is absent, so the two never
+		 * register the same `stats` menu slug.
+		 */
+		if ( self::is_jetpack_plugin_active() ) {
+			return;
+		}
+
+		// Every figure in the dashboard is read back from the WordPress.com API, which
+		// needs a connection token.
+		if ( ( new Connection_Manager() )->is_connected() ) {
+			Stats_Dashboard::init();
+		} else {
+			add_action( 'admin_menu', array( self::class, 'register_disconnected_menu' ), 999 );
+		}
+	}
+
+	/**
+	 * Register a Stats menu that routes to the connection flow.
+	 *
+	 * Runs at priority 999 to match `Stats_Admin\Dashboard`, which places itself between
+	 * the Jetpack plugin (998) and Admin_Menu (1000).
+	 */
+	public static function register_disconnected_menu() {
+		$page_suffix = add_menu_page(
+			__( 'Stats', 'jetpack-stats' ),
+			_x( 'Stats', 'product name shown in menu', 'jetpack-stats' ),
+			'view_stats',
+			self::ADMIN_PAGE_SLUG,
+			'__return_null',
+			'dashicons-chart-bar',
+			2
+		);
+
+		if ( $page_suffix ) {
+			add_action( 'load-' . $page_suffix, array( self::class, 'redirect_to_connection_flow' ) );
+		}
+	}
+
+	/**
+	 * Send the current request to My Jetpack, which redirects on to its onboarding step.
+	 *
+	 * @return never
+	 */
+	public static function redirect_to_connection_flow() {
+		wp_safe_redirect( admin_url( 'admin.php?page=' . self::MY_JETPACK_PAGE_SLUG ) );
+		exit( 0 );
+	}
+
+	/**
+	 * Whether the full Jetpack plugin is running alongside this one.
+	 *
+	 * @return bool
+	 */
+	public static function is_jetpack_plugin_active() {
+		return class_exists( 'Jetpack' );
+	}
+
+	/**
+	 * Add a Stats link to the plugin actions.
+	 *
+	 * @param array $links the array of links.
+	 * @return array
+	 */
+	public static function plugin_page_add_links( $links ) {
+		$stats_link = '<a href="' . esc_url( admin_url( 'admin.php?page=' . self::ADMIN_PAGE_SLUG ) ) . '">' . esc_html__( 'Stats', 'jetpack-stats' ) . '</a>';
+		array_unshift( $links, $stats_link );
+
+		return $links;
+	}
+
+	/**
+	 * Redirect to the Stats dashboard when the plugin is activated.
+	 *
+	 * @param string $plugin Path to the plugin file relative to the plugins directory.
+	 */
+	public static function handle_plugin_activation( $plugin ) {
+		// On a connected site the module can be switched on right away. On a site with no
+		// connection this is a no-op.
+		self::activate_stats_module();
+
+		if (
+			JETPACK_STATS_PLUGIN__FILE_RELATIVE_PATH === $plugin &&
+			( new Paths() )->is_current_request_activating_plugin_from_plugins_screen( JETPACK_STATS_PLUGIN__FILE_RELATIVE_PATH )
+		) {
+			wp_safe_redirect( esc_url( admin_url( 'admin.php?page=' . self::get_post_activation_page() ) ) );
+			exit( 0 );
+		}
+	}
+
+	/**
+	 * Which admin page a fresh activation should land on.
+	 *
+	 * An unconnected site has nothing to show in the dashboard, so it starts in My Jetpack
+	 * onboarding instead. A connected site goes straight to Stats.
+	 *
+	 * @return string The admin page slug.
+	 */
+	public static function get_post_activation_page() {
+		return ( new Connection_Manager() )->is_connected()
+			? self::ADMIN_PAGE_SLUG
+			: self::MY_JETPACK_PAGE_SLUG;
+	}
+
+	/**
+	 * Activate the Stats module on a connected site.
+	 */
+	public static function activate_stats_module() {
+		if ( ! ( new Connection_Manager() )->is_connected() ) {
+			return;
+		}
+
+		( new Modules() )->activate( 'stats', false, false );
+	}
+
+	/**
+	 * Add the Stats module to the list of modules available without the Jetpack plugin.
+	 *
+	 * @param array $modules The available modules.
+	 * @return array
+	 */
+	public static function filter_available_modules_add_stats( $modules ) {
+		return array_merge( array( 'stats' ), $modules );
+	}
+}

--- a/projects/plugins/stats/src/class-jetpack-stats-plugin.php
+++ b/projects/plugins/stats/src/class-jetpack-stats-plugin.php
@@ -170,14 +170,17 @@ class Jetpack_Stats_Plugin {
 	 * @param string $plugin Path to the plugin file relative to the plugins directory.
 	 */
 	public static function handle_plugin_activation( $plugin ) {
+		// `activated_plugin` fires for every plugin, so ignore everything but this one.
+		// Otherwise activating an unrelated plugin turns Stats back on after a user disabled it.
+		if ( JETPACK_STATS_PLUGIN__FILE_RELATIVE_PATH !== $plugin ) {
+			return;
+		}
+
 		// On a connected site the module can be switched on right away. On a site with no
 		// connection this is a no-op.
 		self::activate_stats_module();
 
-		if (
-			JETPACK_STATS_PLUGIN__FILE_RELATIVE_PATH === $plugin &&
-			( new Paths() )->is_current_request_activating_plugin_from_plugins_screen( JETPACK_STATS_PLUGIN__FILE_RELATIVE_PATH )
-		) {
+		if ( ( new Paths() )->is_current_request_activating_plugin_from_plugins_screen( JETPACK_STATS_PLUGIN__FILE_RELATIVE_PATH ) ) {
 			wp_safe_redirect( esc_url( admin_url( 'admin.php?page=' . self::get_post_activation_page() ) ) );
 			exit( 0 );
 		}
@@ -199,13 +202,16 @@ class Jetpack_Stats_Plugin {
 
 	/**
 	 * Activate the Stats module on a connected site.
+	 *
+	 * @return bool True when the module is active after the call, false when the site has no
+	 *              connection or the module could not be activated.
 	 */
 	public static function activate_stats_module() {
 		if ( ! ( new Connection_Manager() )->is_connected() ) {
-			return;
+			return false;
 		}
 
-		( new Modules() )->activate( 'stats', false, false );
+		return (bool) ( new Modules() )->activate( 'stats', false, false );
 	}
 
 	/**

--- a/projects/plugins/stats/src/class-jetpack-stats-plugin.php
+++ b/projects/plugins/stats/src/class-jetpack-stats-plugin.php
@@ -14,6 +14,7 @@ use Automattic\Jetpack\Modules;
 use Automattic\Jetpack\My_Jetpack\Initializer as My_Jetpack_Initializer;
 use Automattic\Jetpack\Paths;
 use Automattic\Jetpack\Stats_Admin\Dashboard as Stats_Dashboard;
+use Automattic\Jetpack\Stats_Admin\Pricing_Page as Stats_Pricing_Page;
 
 /**
  * Class to bootstrap the Jetpack Stats plugin.
@@ -26,14 +27,6 @@ class Jetpack_Stats_Plugin {
 	 * menu with this slug. Kept here so the plugin can link to the page.
 	 */
 	const ADMIN_PAGE_SLUG = 'stats';
-
-	/**
-	 * My Jetpack's admin page slug.
-	 *
-	 * Landing on this page with no connection makes My Jetpack redirect to its own
-	 * onboarding step. See `My_Jetpack\Initializer::get_onboarding_redirect_args()`.
-	 */
-	const MY_JETPACK_PAGE_SLUG = 'my-jetpack';
 
 	/**
 	 * Register hooks to initialize the plugin.
@@ -102,44 +95,13 @@ class Jetpack_Stats_Plugin {
 		}
 
 		// Every figure in the dashboard is read back from the WordPress.com API, which
-		// needs a connection token.
+		// needs a connection token. Until the site has one, the same menu slug shows the
+		// pricing screen instead, and the plan the visitor picks starts the connection.
 		if ( ( new Connection_Manager() )->is_connected() ) {
 			Stats_Dashboard::init();
 		} else {
-			add_action( 'admin_menu', array( self::class, 'register_disconnected_menu' ), 999 );
+			Stats_Pricing_Page::init();
 		}
-	}
-
-	/**
-	 * Register a Stats menu that routes to the connection flow.
-	 *
-	 * Runs at priority 999 to match `Stats_Admin\Dashboard`, which places itself between
-	 * the Jetpack plugin (998) and Admin_Menu (1000).
-	 */
-	public static function register_disconnected_menu() {
-		$page_suffix = add_menu_page(
-			__( 'Stats', 'jetpack-stats' ),
-			_x( 'Stats', 'product name shown in menu', 'jetpack-stats' ),
-			'view_stats',
-			self::ADMIN_PAGE_SLUG,
-			'__return_null',
-			'dashicons-chart-bar',
-			2
-		);
-
-		if ( $page_suffix ) {
-			add_action( 'load-' . $page_suffix, array( self::class, 'redirect_to_connection_flow' ) );
-		}
-	}
-
-	/**
-	 * Send the current request to My Jetpack, which redirects on to its onboarding step.
-	 *
-	 * @return never
-	 */
-	public static function redirect_to_connection_flow() {
-		wp_safe_redirect( admin_url( 'admin.php?page=' . self::MY_JETPACK_PAGE_SLUG ) );
-		exit( 0 );
 	}
 
 	/**
@@ -189,15 +151,14 @@ class Jetpack_Stats_Plugin {
 	/**
 	 * Which admin page a fresh activation should land on.
 	 *
-	 * An unconnected site has nothing to show in the dashboard, so it starts in My Jetpack
-	 * onboarding instead. A connected site goes straight to Stats.
+	 * Always Stats. A connected site gets the dashboard, and a site with no connection gets
+	 * the pricing screen under the same slug, so both states land on a page that speaks to
+	 * what the visitor just installed.
 	 *
 	 * @return string The admin page slug.
 	 */
 	public static function get_post_activation_page() {
-		return ( new Connection_Manager() )->is_connected()
-			? self::ADMIN_PAGE_SLUG
-			: self::MY_JETPACK_PAGE_SLUG;
+		return self::ADMIN_PAGE_SLUG;
 	}
 
 	/**

--- a/projects/plugins/stats/tests/.phpcs.dir.xml
+++ b/projects/plugins/stats/tests/.phpcs.dir.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0"?>
+<ruleset>
+	<rule ref="Jetpack-Tests" />
+</ruleset>

--- a/projects/plugins/stats/tests/php/Jetpack_Stats_Plugin_Test.php
+++ b/projects/plugins/stats/tests/php/Jetpack_Stats_Plugin_Test.php
@@ -17,6 +17,37 @@ use WorDBless\BaseTestCase;
 class Jetpack_Stats_Plugin_Test extends BaseTestCase {
 
 	/**
+	 * `Connection_Manager::is_connected()` caches its answer in a static, which survives
+	 * the per-test database reset. Clear it so a faked connection cannot leak.
+	 */
+	public function tear_down() {
+		( new Connection_Manager() )->reset_connection_status();
+	}
+
+	/**
+	 * Give `Connection_Manager::is_connected()` the blog ID and token it looks for.
+	 */
+	private function fake_connection() {
+		Jetpack_Options::update_option( 'id', 1234 );
+		Jetpack_Options::update_option( 'blog_token', 'test.token' );
+		( new Connection_Manager() )->reset_connection_status();
+	}
+
+	/**
+	 * Record every module that reaches `Modules::activate()`.
+	 *
+	 * @param array $activated Collected module slugs, by reference.
+	 */
+	private function record_module_activations( array &$activated ) {
+		add_action(
+			'jetpack_pre_activate_module',
+			function ( $module ) use ( &$activated ) {
+				$activated[] = $module;
+			}
+		);
+	}
+
+	/**
 	 * The plugin file registers its hooks on load, in `bootstrap()`. Requiring the
 	 * file happens once in the test bootstrap, so the hooks are already in place.
 	 */
@@ -82,6 +113,42 @@ class Jetpack_Stats_Plugin_Test extends BaseTestCase {
 	public function test_activation_lands_on_onboarding_when_not_connected() {
 		$this->assertFalse( ( new Connection_Manager() )->is_connected(), 'Test environment is expected to be unconnected.' );
 		$this->assertSame( 'my-jetpack', Jetpack_Stats_Plugin::get_post_activation_page() );
+	}
+
+	/**
+	 * `activated_plugin` fires for every plugin. Acting on all of them would switch Stats
+	 * back on whenever any other plugin is activated, undoing a deliberate opt-out.
+	 */
+	public function test_activating_another_plugin_leaves_the_stats_module_alone() {
+		$this->fake_connection();
+		$activated = array();
+		$this->record_module_activations( $activated );
+
+		Jetpack_Stats_Plugin::handle_plugin_activation( 'some-other-plugin/some-other-plugin.php' );
+
+		$this->assertSame( array(), $activated );
+	}
+
+	/**
+	 * The counterpart: activating this plugin does switch the module on.
+	 */
+	public function test_activating_this_plugin_activates_the_stats_module() {
+		$this->fake_connection();
+		$activated = array();
+		$this->record_module_activations( $activated );
+
+		Jetpack_Stats_Plugin::handle_plugin_activation( JETPACK_STATS_PLUGIN__FILE_RELATIVE_PATH );
+
+		$this->assertSame( array( 'stats' ), $activated );
+	}
+
+	/**
+	 * A site with no connection has no token to report stats with, so the module stays off
+	 * and the caller is told so rather than the result being discarded.
+	 */
+	public function test_module_activation_reports_failure_without_a_connection() {
+		$this->assertFalse( ( new Connection_Manager() )->is_connected(), 'Test environment is expected to be unconnected.' );
+		$this->assertFalse( Jetpack_Stats_Plugin::activate_stats_module() );
 	}
 
 	/**

--- a/projects/plugins/stats/tests/php/Jetpack_Stats_Plugin_Test.php
+++ b/projects/plugins/stats/tests/php/Jetpack_Stats_Plugin_Test.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Bootstrap wiring tests for the Jetpack Stats plugin.
+ *
+ * @package automattic/jetpack-stats-plugin
+ */
+
+use Automattic\Jetpack\Connection\Manager as Connection_Manager;
+use Automattic\Jetpack\Stats\Main as Stats_Main;
+use Automattic\Jetpack\Stats\Options as Stats_Options;
+use Automattic\Jetpack\Stats_Plugin\Jetpack_Stats_Plugin;
+use WorDBless\BaseTestCase;
+
+/**
+ * Test that the plugin shell registers everything the Stats packages expect.
+ */
+class Jetpack_Stats_Plugin_Test extends BaseTestCase {
+
+	/**
+	 * The plugin file registers its hooks on load, in `bootstrap()`. Requiring the
+	 * file happens once in the test bootstrap, so the hooks are already in place.
+	 */
+	public function test_bootstrap_registers_package_configuration() {
+		$this->assertSame(
+			1,
+			has_action( 'plugins_loaded', array( Jetpack_Stats_Plugin::class, 'configure_packages' ) )
+		);
+		$this->assertSame(
+			10,
+			has_action( 'plugins_loaded', array( Jetpack_Stats_Plugin::class, 'initialize_other_packages' ) )
+		);
+	}
+
+	/**
+	 * The Stats module must switch back on when the Jetpack plugin goes away, otherwise
+	 * a site that used the module toggle in Jetpack is left with Stats silently off.
+	 */
+	public function test_bootstrap_reactivates_stats_when_jetpack_is_deactivated() {
+		$this->assertSame(
+			10,
+			has_action( 'deactivate_jetpack/jetpack.php', array( Jetpack_Stats_Plugin::class, 'activate_stats_module' ) )
+		);
+		$this->assertSame(
+			10,
+			has_action( 'jetpack_site_registered', array( Jetpack_Stats_Plugin::class, 'activate_stats_module' ) )
+		);
+	}
+
+	/**
+	 * My Jetpack builds its product list from this filter. Without `stats` in it the
+	 * plugin has no product card.
+	 */
+	public function test_stats_is_offered_as_a_standalone_module() {
+		$this->assertSame(
+			array( 'stats', 'search' ),
+			Jetpack_Stats_Plugin::filter_available_modules_add_stats( array( 'search' ) )
+		);
+	}
+
+	/**
+	 * The action link is prepended, not replacing what the plugins screen already added.
+	 */
+	public function test_plugin_action_links_are_prepended() {
+		$links = Jetpack_Stats_Plugin::plugin_page_add_links( array( '<a href="#">Deactivate</a>' ) );
+
+		$this->assertCount( 2, $links );
+		$this->assertStringContainsString( 'Deactivate', $links[1] );
+	}
+
+	/**
+	 * The dashboard registration is skipped while the Jetpack plugin is active, because
+	 * Jetpack registers the same `stats` menu slug itself.
+	 */
+	public function test_jetpack_plugin_detection() {
+		$this->assertSame( class_exists( 'Jetpack' ), Jetpack_Stats_Plugin::is_jetpack_plugin_active() );
+	}
+
+	/**
+	 * An unconnected site has no token, so every stats-app route answers 500. Activation
+	 * must land on My Jetpack onboarding rather than a dashboard full of failed requests.
+	 */
+	public function test_activation_lands_on_onboarding_when_not_connected() {
+		$this->assertFalse( ( new Connection_Manager() )->is_connected(), 'Test environment is expected to be unconnected.' );
+		$this->assertSame( 'my-jetpack', Jetpack_Stats_Plugin::get_post_activation_page() );
+	}
+
+	/**
+	 * On an unconnected site the Stats menu is still registered, but it is the stand-in
+	 * that redirects to the connection flow, not the Odyssey dashboard.
+	 */
+	public function test_disconnected_site_registers_the_stand_in_menu() {
+		Jetpack_Stats_Plugin::initialize_other_packages();
+
+		$this->assertSame(
+			999,
+			has_action( 'admin_menu', array( Jetpack_Stats_Plugin::class, 'register_disconnected_menu' ) )
+		);
+	}
+
+	/**
+	 * The stand-in menu keeps the `stats` slug so the plugin action link and any bookmark
+	 * stay valid across a connection.
+	 */
+	public function test_stand_in_menu_uses_the_dashboard_slug() {
+		$GLOBALS['menu'] = array();
+
+		// `add_menu_page()` checks `view_stats`, which `Stats\Main` maps to `read` for any
+		// role listed in the Stats `roles` option.
+		Stats_Main::init();
+		Stats_Options::set_option( 'roles', array( 'administrator' ) );
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'stats_admin',
+				'user_pass'  => 'password',
+				'role'       => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+
+		Jetpack_Stats_Plugin::register_disconnected_menu();
+
+		$this->assertContains( 'stats', array_column( $GLOBALS['menu'], 2 ) );
+	}
+
+	/**
+	 * The Odyssey dashboard and the block editor both read stats through the
+	 * `jetpack/v4/stats-app` proxy, which `Stats_Admin\REST_Controller` registers. Walk the
+	 * real path — `configure_packages()` then the `Config` initializer — so the assertion
+	 * covers the plugin's own wiring and not just the presence of the package.
+	 */
+	public function test_stats_app_rest_proxy_is_registered() {
+		global $wp_rest_server;
+		$wp_rest_server = new \WP_REST_Server();
+
+		Jetpack_Stats_Plugin::configure_packages();
+		do_action( 'plugins_loaded' );
+		do_action( 'rest_api_init' );
+
+		$routes = array_keys( $wp_rest_server->get_routes() );
+
+		// Most routes interpolate the connected blog ID into the path rather than matching it,
+		// so assert on the namespace as a whole plus the two routes that carry no blog ID.
+		$this->assertNotEmpty( preg_grep( '#^/jetpack/v4/stats-app/#', $routes ) );
+		$this->assertContains( '/jetpack/v4/stats-app', $routes );
+		$this->assertContains( '/jetpack/v4/stats-app/stats/notices', $routes );
+
+		// Odyssey reads `is_commercial` from this route to decide what to paywall, and the
+		// Subscribers and Store tabs from the same response.
+		$this->assertContains( '/jetpack/v4/site', $routes );
+	}
+}

--- a/projects/plugins/stats/tests/php/Jetpack_Stats_Plugin_Test.php
+++ b/projects/plugins/stats/tests/php/Jetpack_Stats_Plugin_Test.php
@@ -92,7 +92,13 @@ class Jetpack_Stats_Plugin_Test extends BaseTestCase {
 	 */
 	private function reset_dashboard_initialization() {
 		$initialized = new ReflectionProperty( Stats_Dashboard::class, 'initialized' );
-		$initialized->setAccessible( true );
+
+		// Reflection cannot write a private property before PHP 8.1 without this, and the
+		// method is deprecated from PHP 8.5. The plugin supports 7.2, so both ends apply.
+		if ( PHP_VERSION_ID < 80100 ) {
+			$initialized->setAccessible( true );
+		}
+
 		$initialized->setValue( null, false );
 	}
 

--- a/projects/plugins/stats/tests/php/Jetpack_Stats_Plugin_Test.php
+++ b/projects/plugins/stats/tests/php/Jetpack_Stats_Plugin_Test.php
@@ -9,6 +9,7 @@ use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Stats\Main as Stats_Main;
 use Automattic\Jetpack\Stats\Options as Stats_Options;
 use Automattic\Jetpack\Stats_Admin\Dashboard as Stats_Dashboard;
+use Automattic\Jetpack\Stats_Admin\Pricing_Page as Stats_Pricing_Page;
 use Automattic\Jetpack\Stats_Plugin\Jetpack_Stats_Plugin;
 use WorDBless\BaseTestCase;
 
@@ -64,19 +65,21 @@ class Jetpack_Stats_Plugin_Test extends BaseTestCase {
 	}
 
 	/**
-	 * Whether the Odyssey dashboard has claimed the admin menu.
+	 * Whether the given Stats screen has claimed the admin menu.
 	 *
-	 * `Stats_Admin\Dashboard` hooks an instance method, so `has_action()` cannot match it
-	 * against a class name.
+	 * Both screens hook an instance method, so `has_action()` cannot match them against a
+	 * class name.
+	 *
+	 * @param string $screen_class Fully qualified class name of the screen.
 	 */
-	private function dashboard_menu_is_registered() {
+	private function menu_is_registered_by( $screen_class ) {
 		if ( ! isset( $GLOBALS['wp_filter']['admin_menu'] ) ) {
 			return false;
 		}
 
 		foreach ( $GLOBALS['wp_filter']['admin_menu']->callbacks as $callbacks ) {
 			foreach ( $callbacks as $callback ) {
-				if ( is_array( $callback['function'] ) && $callback['function'][0] instanceof Stats_Dashboard ) {
+				if ( is_array( $callback['function'] ) && $callback['function'][0] instanceof $screen_class ) {
 					return true;
 				}
 			}
@@ -86,12 +89,14 @@ class Jetpack_Stats_Plugin_Test extends BaseTestCase {
 	}
 
 	/**
-	 * `Stats_Admin\Dashboard` records its initialization in a static that survives the
-	 * per-test hook restore, and it registers the menu only on the first call. Clear it so a
-	 * test that expects the dashboard to register controls its own precondition.
+	 * Both Stats screens record their initialization in a static that survives the per-test
+	 * hook restore, and each registers its menu only on the first call. Clear it so a test
+	 * that expects a screen to register controls its own precondition.
+	 *
+	 * @param string $screen_class Fully qualified class name of the screen.
 	 */
-	private function reset_dashboard_initialization() {
-		$initialized = new ReflectionProperty( Stats_Dashboard::class, 'initialized' );
+	private function reset_screen_initialization( $screen_class ) {
+		$initialized = new ReflectionProperty( $screen_class, 'initialized' );
 
 		// Reflection cannot write a private property before PHP 8.1 without this, and the
 		// method is deprecated from PHP 8.5. The plugin supports 7.2, so both ends apply.
@@ -176,19 +181,18 @@ class Jetpack_Stats_Plugin_Test extends BaseTestCase {
 	}
 
 	/**
-	 * An unconnected site has no token, so every stats-app route answers 500. Activation
-	 * must land on My Jetpack onboarding rather than a dashboard full of failed requests.
+	 * An unconnected site has no token, so it cannot show figures. It still lands on Stats,
+	 * where the pricing screen holds the same slug and asks the visitor to pick a plan.
 	 */
-	public function test_activation_lands_on_onboarding_when_not_connected() {
+	public function test_activation_lands_on_stats_when_not_connected() {
 		$this->assertFalse( ( new Connection_Manager() )->is_connected(), 'Test environment is expected to be unconnected.' );
-		$this->assertSame( 'my-jetpack', Jetpack_Stats_Plugin::get_post_activation_page() );
+		$this->assertSame( 'stats', Jetpack_Stats_Plugin::get_post_activation_page() );
 	}
 
 	/**
-	 * The counterpart: a connected site has figures to show, so activation opens the
-	 * dashboard rather than sending the user through onboarding again.
+	 * The counterpart: a connected site lands on the same page and gets the dashboard.
 	 */
-	public function test_activation_lands_on_the_dashboard_when_connected() {
+	public function test_activation_lands_on_stats_when_connected() {
 		$this->fake_connection();
 
 		$this->assertSame( 'stats', Jetpack_Stats_Plugin::get_post_activation_page() );
@@ -231,23 +235,23 @@ class Jetpack_Stats_Plugin_Test extends BaseTestCase {
 	}
 
 	/**
-	 * On an unconnected site the Stats menu is still registered, but it is the stand-in
-	 * that redirects to the connection flow, not the Odyssey dashboard.
+	 * On an unconnected site the Stats menu is still registered, but it is the pricing
+	 * screen that claims it, not the Odyssey dashboard.
 	 */
-	public function test_disconnected_site_registers_the_stand_in_menu() {
+	public function test_disconnected_site_registers_the_pricing_screen() {
+		$this->reset_screen_initialization( Stats_Pricing_Page::class );
+
 		Jetpack_Stats_Plugin::initialize_other_packages();
 
-		$this->assertSame(
-			999,
-			has_action( 'admin_menu', array( Jetpack_Stats_Plugin::class, 'register_disconnected_menu' ) )
-		);
+		$this->assertTrue( $this->menu_is_registered_by( Stats_Pricing_Page::class ) );
+		$this->assertFalse( $this->menu_is_registered_by( Stats_Dashboard::class ) );
 	}
 
 	/**
-	 * The stand-in menu keeps the `stats` slug so the plugin action link and any bookmark
+	 * The pricing screen keeps the `stats` slug so the plugin action link and any bookmark
 	 * stay valid across a connection.
 	 */
-	public function test_stand_in_menu_uses_the_dashboard_slug() {
+	public function test_pricing_screen_uses_the_dashboard_slug() {
 		$GLOBALS['menu'] = array();
 
 		// `add_menu_page()` checks `view_stats`, which `Stats\Main` maps to `read` for any
@@ -263,25 +267,24 @@ class Jetpack_Stats_Plugin_Test extends BaseTestCase {
 		);
 		wp_set_current_user( $user_id );
 
-		Jetpack_Stats_Plugin::register_disconnected_menu();
+		( new Stats_Pricing_Page() )->add_wp_admin_menu();
 
 		$this->assertContains( 'stats', array_column( $GLOBALS['menu'], 2 ) );
 	}
 
 	/**
-	 * The connected counterpart of the two tests above. Both menus claim the `stats` slug, so
-	 * the dashboard must take it and the stand-in must stay out of the way.
+	 * The connected counterpart of the two tests above. Both screens claim the `stats` slug,
+	 * so the dashboard must take it and the pricing screen must stay out of the way.
 	 */
 	public function test_connected_site_initializes_the_dashboard() {
 		$this->fake_connection();
-		$this->reset_dashboard_initialization();
+		$this->reset_screen_initialization( Stats_Dashboard::class );
+		$this->reset_screen_initialization( Stats_Pricing_Page::class );
 
 		Jetpack_Stats_Plugin::initialize_other_packages();
 
-		$this->assertTrue( $this->dashboard_menu_is_registered() );
-		$this->assertFalse(
-			has_action( 'admin_menu', array( Jetpack_Stats_Plugin::class, 'register_disconnected_menu' ) )
-		);
+		$this->assertTrue( $this->menu_is_registered_by( Stats_Dashboard::class ) );
+		$this->assertFalse( $this->menu_is_registered_by( Stats_Pricing_Page::class ) );
 	}
 
 	/**

--- a/projects/plugins/stats/tests/php/Jetpack_Stats_Plugin_Test.php
+++ b/projects/plugins/stats/tests/php/Jetpack_Stats_Plugin_Test.php
@@ -8,6 +8,7 @@
 use Automattic\Jetpack\Connection\Manager as Connection_Manager;
 use Automattic\Jetpack\Stats\Main as Stats_Main;
 use Automattic\Jetpack\Stats\Options as Stats_Options;
+use Automattic\Jetpack\Stats_Admin\Dashboard as Stats_Dashboard;
 use Automattic\Jetpack\Stats_Plugin\Jetpack_Stats_Plugin;
 use WorDBless\BaseTestCase;
 
@@ -48,18 +49,80 @@ class Jetpack_Stats_Plugin_Test extends BaseTestCase {
 	}
 
 	/**
-	 * The plugin file registers its hooks on load, in `bootstrap()`. Requiring the
-	 * file happens once in the test bootstrap, so the hooks are already in place.
+	 * The complete set of hooks `bootstrap()` registers, as `hook, method, priority`.
 	 */
-	public function test_bootstrap_registers_package_configuration() {
-		$this->assertSame(
-			1,
-			has_action( 'plugins_loaded', array( Jetpack_Stats_Plugin::class, 'configure_packages' ) )
+	private function bootstrap_hooks() {
+		return array(
+			array( 'plugins_loaded', 'configure_packages', 1 ),
+			array( 'plugins_loaded', 'initialize_other_packages', 10 ),
+			array( 'activated_plugin', 'handle_plugin_activation', 10 ),
+			array( 'jetpack_site_registered', 'activate_stats_module', 10 ),
+			array( 'deactivate_jetpack/jetpack.php', 'activate_stats_module', 10 ),
+			array( 'plugin_action_links_' . JETPACK_STATS_PLUGIN__FILE_RELATIVE_PATH, 'plugin_page_add_links', 10 ),
+			array( 'jetpack_get_available_standalone_modules', 'filter_available_modules_add_stats', 10 ),
 		);
-		$this->assertSame(
-			10,
-			has_action( 'plugins_loaded', array( Jetpack_Stats_Plugin::class, 'initialize_other_packages' ) )
-		);
+	}
+
+	/**
+	 * Whether the Odyssey dashboard has claimed the admin menu.
+	 *
+	 * `Stats_Admin\Dashboard` hooks an instance method, so `has_action()` cannot match it
+	 * against a class name.
+	 */
+	private function dashboard_menu_is_registered() {
+		if ( ! isset( $GLOBALS['wp_filter']['admin_menu'] ) ) {
+			return false;
+		}
+
+		foreach ( $GLOBALS['wp_filter']['admin_menu']->callbacks as $callbacks ) {
+			foreach ( $callbacks as $callback ) {
+				if ( is_array( $callback['function'] ) && $callback['function'][0] instanceof Stats_Dashboard ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * `Stats_Admin\Dashboard` records its initialization in a static that survives the
+	 * per-test hook restore, and it registers the menu only on the first call. Clear it so a
+	 * test that expects the dashboard to register controls its own precondition.
+	 */
+	private function reset_dashboard_initialization() {
+		$initialized = new ReflectionProperty( Stats_Dashboard::class, 'initialized' );
+		$initialized->setAccessible( true );
+		$initialized->setValue( null, false );
+	}
+
+	/**
+	 * `bootstrap()` is the plugin's whole wiring surface, so a hook dropped from it is a
+	 * feature silently switched off. Clear the hooks the test bootstrap already registered
+	 * before calling it, otherwise the assertions pass on that earlier state and the test
+	 * says nothing about `bootstrap()` itself.
+	 *
+	 * WordPress stores actions as filters, so `has_filter()` and `remove_filter()` cover both.
+	 */
+	public function test_bootstrap_registers_every_hook() {
+		foreach ( $this->bootstrap_hooks() as list( $hook, $method, $priority ) ) {
+			remove_filter( $hook, array( Jetpack_Stats_Plugin::class, $method ), $priority );
+
+			$this->assertFalse(
+				has_filter( $hook, array( Jetpack_Stats_Plugin::class, $method ) ),
+				"$hook still holds $method before bootstrap() runs."
+			);
+		}
+
+		Jetpack_Stats_Plugin::bootstrap();
+
+		foreach ( $this->bootstrap_hooks() as list( $hook, $method, $priority ) ) {
+			$this->assertSame(
+				$priority,
+				has_filter( $hook, array( Jetpack_Stats_Plugin::class, $method ) ),
+				"bootstrap() did not register $method on $hook."
+			);
+		}
 	}
 
 	/**
@@ -113,6 +176,16 @@ class Jetpack_Stats_Plugin_Test extends BaseTestCase {
 	public function test_activation_lands_on_onboarding_when_not_connected() {
 		$this->assertFalse( ( new Connection_Manager() )->is_connected(), 'Test environment is expected to be unconnected.' );
 		$this->assertSame( 'my-jetpack', Jetpack_Stats_Plugin::get_post_activation_page() );
+	}
+
+	/**
+	 * The counterpart: a connected site has figures to show, so activation opens the
+	 * dashboard rather than sending the user through onboarding again.
+	 */
+	public function test_activation_lands_on_the_dashboard_when_connected() {
+		$this->fake_connection();
+
+		$this->assertSame( 'stats', Jetpack_Stats_Plugin::get_post_activation_page() );
 	}
 
 	/**
@@ -187,6 +260,22 @@ class Jetpack_Stats_Plugin_Test extends BaseTestCase {
 		Jetpack_Stats_Plugin::register_disconnected_menu();
 
 		$this->assertContains( 'stats', array_column( $GLOBALS['menu'], 2 ) );
+	}
+
+	/**
+	 * The connected counterpart of the two tests above. Both menus claim the `stats` slug, so
+	 * the dashboard must take it and the stand-in must stay out of the way.
+	 */
+	public function test_connected_site_initializes_the_dashboard() {
+		$this->fake_connection();
+		$this->reset_dashboard_initialization();
+
+		Jetpack_Stats_Plugin::initialize_other_packages();
+
+		$this->assertTrue( $this->dashboard_menu_is_registered() );
+		$this->assertFalse(
+			has_action( 'admin_menu', array( Jetpack_Stats_Plugin::class, 'register_disconnected_menu' ) )
+		);
 	}
 
 	/**

--- a/projects/plugins/stats/tests/php/bootstrap.php
+++ b/projects/plugins/stats/tests/php/bootstrap.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * Bootstrap.
+ *
+ * @package automattic/jetpack-stats-plugin
+ */
+
+/**
+ * Include the composer autoloader.
+ */
+require_once __DIR__ . '/../../vendor/autoload.php';
+
+\Automattic\Jetpack\Test_Environment::init();
+require_once __DIR__ . '/../../jetpack-stats.php';


### PR DESCRIPTION
Fixes STATS-345

Based on #51060 — review that one first, and merge it before this.

## Proposed changes
* Activating the standalone Stats plugin on a site with no WordPress.com connection now lands on a plan choice instead of My Jetpack onboarding. The Stats menu registers before the connection exists and renders the Odyssey `pricing` bundle there.
* The screen is Odyssey, not PHP: the plan comparison and the views-tier slider are the same components the connected dashboard uses, so the copy and layout live in one place. That side is Automattic/wp-calypso#113476, which **must ship first** — this plugin loads `pricing.min.js` from the CDN and renders an empty page without it.
* Whichever plan the visitor picks is recorded in a site option and exposed through the Odyssey config, so the dashboard's own pricing grid does not ask the same question again once the site connects. A site connected by any other route never sets it and still sees that grid.
* `Odyssey_Assets` no longer builds the full dashboard config when the caller supplies its own, and the connection-independent config keys moved into a shared base so a screen with no site data can reuse them.

## Related product discussion/links
* STATS-345
* Depends on STATS-343 (#51060)
* Companion PR, ships the screen itself: Automattic/wp-calypso#113476

## Does this pull request change what data or activity we track or use?
No new tracking. The screen reuses the existing `stats_pricing_grid_*` Tracks events already fired by the shared pricing grid. It does store one new site option recording that a plan was chosen, which never leaves the site.

## Testing instructions

You need a site with **no** Jetpack connection, and the Odyssey side has to be live first: this plugin ships no `dist`, so without Automattic/wp-calypso#113476 synced to your sandbox the Stats page renders empty rather than erroring. That PR has the sync steps.

**Install via Jetpack Beta**

Use the Jetpack Beta plugin and pick this branch, `stats-345-odyssey-unconnected-pricing`, for **Jetpack Stats**. Nothing else to configure: the beta build ships real package versions, so the autoloader resolves them normally and no `JETPACK_AUTOLOAD_DEV` constant is needed.

Note the beta build is of this branch, so it already contains #51060's plugin — that is the intent here.

<details>
<summary>Building the zip locally instead</summary>

```
jetpack build plugins/stats --production --deps
projects/plugins/stats/bin/build-zip.sh
```

Two differences from the beta route. The script stages via `jetpack rsync`, which only picks up files git knows about — `git add` anything new first, or the class silently goes missing and the plugin fatals. And the packages are versioned `dev-trunk`, so the site needs `define( 'JETPACK_AUTOLOAD_DEV', true );` in `wp-config.php`; without it the autoloader prefers a released copy from any other active Jetpack plugin and `Pricing_Page` never loads.
</details>

**Set up the site**

1. Spin up a fresh Jurassic Ninja site, or reset an existing one so it has no Jetpack connection and no leftover `jetpack_*` options.
2. Deactivate the Jetpack plugin if it is active — the standalone plugin stands down while `Jetpack` exists, so the Stats menu would stay with Jetpack.

**Check the flow**

1. Go to **Stats**. You should get the plan comparison, with prices, rather than a redirect to My Jetpack.
2. Click **Start for free** → lands on My Jetpack onboarding.
3. Back on **Stats**, click **Get Paid Stats** → the views slider, then **Get Stats to grow my site** → a siteless checkout URL on WordPress.com carrying `connect_after_checkout=true`, `from_site_slug` and the chosen tier as `:-q-<views>`.
4. **I will do it later** goes to the connection flow too — before connecting, declining the paid plan means taking the free one.
5. Connect the site, then reload **Stats**: you should get the dashboard, *not* the pricing grid, because step 2/3/4 recorded the choice.
6. To confirm the opposite case, clear `jetpack_stats_pricing_choice_recorded` on a freshly connected site — the dashboard's pricing grid should appear as usual.

Screenshots of the two screens to follow.
